### PR TITLE
### V2.0.0 (2018-03-28)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,4 +14,13 @@ eth_getStorageAtCNS         =>    eth_getStorageAt
 eth_getTransactionCountCNS   =>    eth_getTransactionCount
 
 * Fix:
-1. CNS调用合约支持合约重载的接口。
+1. CNS调用合约支持合约重载的接口。  
+
+### V2.0.0 (2018-03-28)  
+* Update
+1. 为查询block的RPC接口增加更多的返回字段。  
+2. FISCO BCOS用户手册更新, a. 在web3lib中需要增加cnpm install的操作  b. config.js文件放入weblib3目录中。  
+
+* Add:
+1. 添加打印监控日志的功能，适配于区块链浏览器的report agent。  
+2. scripts/install_deps.sh 依赖脚本添加Linux Oracle Server的支持。

--- a/doc/manual/README.md
+++ b/doc/manual/README.md
@@ -150,6 +150,8 @@ god账号是区块链的最高权限，在启动区块链前必须配置。
 #### 2.2.1 生成god账号
 
 ```shell
+cd /mydata/FISCO-BCOS/web3lib
+cnpm install #安装nodejs依赖, 在执行nodejs脚本之前, 该命令在该目录需要执行一次, 之后不需要再执行。
 cd /mydata/FISCO-BCOS/tool #代码根目录下的tool文件夹
 cnpm install #安装nodejs包，仅需运行一次，之后若需要再次在tool目录下使用nodejs，不需要重复运行此命令
 node accountManager.js > godInfo.txt
@@ -553,7 +555,10 @@ cd /mydata/FISCO-BCOS/tool
 > 安装依赖环境
 
 ```shell
-cnpm install
+cd /mydata/FISCO-BCOS/web3lib
+cnpm install #安装nodejs依赖, 在执行nodejs脚本之前, 如果已经执行过, 则忽略。
+cd /mydata/FISCO-BCOS/tool
+cnpm install #该命令在该目录执行一次即可, 如果之前已经执行过一次, 则忽略。
 ```
 
 > 设置区块链节点RPC端口

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -144,6 +144,7 @@ Linux)
     elif [ -f "/etc/os-release" ]; then
 
         DISTRO_NAME=$(. /etc/os-release; echo $NAME)
+	echo "Linux distribution: $DISTRO_NAME."
         case $DISTRO_NAME in
 
         Debian*)
@@ -207,6 +208,21 @@ Linux)
 
         CentOS*)
             echo "Installing cpp-ethereum dependencies on CentOS."
+            # Enable EPEL repo that contains leveldb-devel
+            $SUDO yum -y -q install epel-release
+            $SUDO yum -y -q install \
+                make \
+                gcc-c++ \
+                boost-devel \
+                leveldb-devel \
+                curl-devel \
+                libmicrohttpd-devel \
+                gmp-devel \
+                openssl openssl-devel
+            ;;
+	#add Oracle Linux Server dependencies
+	Oracle*)
+            echo "Installing cpp-ethereum dependencies on Oracle Linux Server."
             # Enable EPEL repo that contains leveldb-devel
             $SUDO yum -y -q install epel-release
             $SUDO yum -y -q install \


### PR DESCRIPTION
* Update
1. 为查询block的RPC接口增加更多的返回字段。
2. FISCO BCOS用户手册更新, a. 在web3lib中需要增加cnpm install的操作  b. config.js文件放入weblib3目录中。

* Add:
1. 添加打印监控日志的功能，适配于区块链浏览器的report agent。
2. scripts/install_deps.sh 依赖脚本添加Linux Oracle Server的支持。