### PR TITLE
访问系统路由表内容的过程中无需输出权限控制链的具体内容，该具体内容的输出有特定的查询接口，同时原输出的内容也有bug需修复

### DIFF
--- a/systemcontractv2/tool.js
+++ b/systemcontractv2/tool.js
@@ -116,20 +116,6 @@ switch (filename){
         var key=SystemProxy.getRouteNameByIndex(i).toString();
         var route=SystemProxy.getRoute(key);
         console.log(i+" )"+ key+"=>"+route[0].toString()+","+route[1].toString()+","+route[2].toString());
-
-        if( "TransactionFilterChain" == key ){
-            var contract = web3.eth.contract(getAbi("TransactionFilterChain"));
-			      var instance = contract.at(route[0]);
-            var filterlength=instance.getFiltersLength();
-            for( var j=0;j<filterlength;j++){
-                var filter=instance.getFilter(j);
-                contract = web3.eth.contract(getAbi("TransactionFilterBase"));
-                instance = contract.at(filter);
-                var name= instance.name();
-                var version=instance.version();
-                console.log("       "+name+"=>"+version+","+filter);
-            }
-        }
     }
      
      


### PR DESCRIPTION
用户在使用systemcontract目录下的tool语句输出系统路由表中的内容中发现一个函数使用的错误，这个错误的触发需要是启动了权限控制之后，执行查询操作才会导致的。考虑访问系统路由表内容的过程中无需输出权限控制链的具体内容，该具体内容的输出有特定的查询接口，同时原输出的内容也有上述问题需修复，因此直接将该内容删去。