### PR TITLE
单线程StateMonitor，maxBlockHeaderGas逻辑调整

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,12 @@
 
 (2018-08-17)
 
+* Update
+1. 优化StateMonitor，调整为单线程执行
+
+* Add
+1. 加上maxBlockHeaderGas的set操作的保护逻辑。当设置小于系统不可用的值时，将不会被设置。
+
 * Fix
 1. 内存泄漏问题
 2. bootstrapnodes.json在磁盘满时被清空的问题

--- a/libdevcore/StateMonitor.h
+++ b/libdevcore/StateMonitor.h
@@ -85,17 +85,10 @@ private:
 
 class StateReporter
 {
-private:
-    static void thread_report(const std::string& state_str)
-    {
-        NormalStatLog()  << "##State Report: " << state_str;
-    }
-
 public:
     static void report(std::string state_str)
     {
-        //开另一个线程来report
-        boost::thread t(thread_report, state_str);
+        NormalStatLog()  << "##State Report: " << state_str;
     }
 };
 

--- a/libdevcore/StateMonitor.h
+++ b/libdevcore/StateMonitor.h
@@ -39,7 +39,7 @@
 #include "easylog.h"
 
 namespace statemonitor
-{
+{ 
 using data_t = double;
 
 class StateContainer
@@ -85,11 +85,17 @@ private:
 
 class StateReporter
 {
+private:
+    static void thread_report(const std::string& state_str)
+    {
+        NormalStatLog()  << "##State Report: " << state_str;
+    }
+
 public:
     static void report(std::string state_str)
     {
-        // std::cout << "##State Report: " << state_str << std::endl;//暂时打印到std::cout
-        NormalStatLog()  << "##State Report: " << state_str;
+        //开另一个线程来report
+        boost::thread t(thread_report, state_str);
     }
 };
 
@@ -107,8 +113,8 @@ public:
 //以时间为周期，上报state
 class StateMonitorByTime : public StateMonitor
 {
-    using sec_t = uint64_t;
 public:
+    using sec_t = uint64_t;
     int code;
     std::string state_name, state_info;
 
@@ -119,14 +125,12 @@ public:
     void recordStart(int code, uint64_t interval, int child_code);
     void recordEnd(int code, std::string& name, std::string& info, int is_success, int child_code);
     void recordOnce(int code, uint64_t interval, data_t value, std::string& name, std::string& info, int is_success);
-
-    
+    void timerToReport(sec_t sec_time);
 private:
     sec_t _interval; 
     bool _is_timer_on;
 
     //按周期（_interval）进行上报
-    void timerToReport();
     void startTimer(sec_t interval);
 };
 
@@ -164,6 +168,8 @@ inline int getChildCodeFromThreadId()
     return pthread_self() & 0xfffff;
 #endif
 }
+
+void enableTimerLoop();
 
 void recordStateByTimeStart(int code, uint64_t interval,
                             int child_code = getChildCodeFromThreadId());

--- a/libethcore/BlockHeader.cpp
+++ b/libethcore/BlockHeader.cpp
@@ -237,7 +237,7 @@ void BlockHeader::verify(Strictness _s, BlockHeader const& _parent, bytesConstRe
 				transactionsTrie.insert(&k.out(), txList[i].data());
 
 				txs.push_back(txList[i].data());
-				LOG(DEBUG) << toHex(k.out()) << toHex(txList[i].data());
+				LOG(TRACE) << toHex(k.out()) << toHex(txList[i].data());
 			}
 			LOG(TRACE) << "trieRootOver" << expectedRoot;
 			LOG(TRACE) << "orderedTrieRoot" << orderedTrieRoot(txs);

--- a/libethcore/BlockHeader.cpp
+++ b/libethcore/BlockHeader.cpp
@@ -42,7 +42,7 @@ BlockHeader::BlockHeader(bytesConstRef _block, BlockDataType _bdt, h256 const& _
 	populate(header);
 }
 
-u256 BlockHeader::maxBlockHeadGas = 2000000000;
+u256 BlockHeader::maxBlockHeadGas = 33000000000;
 u256 BlockHeader::updateHeight = 0;				// 字段升级所在块高
 
 void BlockHeader::clear()
@@ -237,7 +237,7 @@ void BlockHeader::verify(Strictness _s, BlockHeader const& _parent, bytesConstRe
 				transactionsTrie.insert(&k.out(), txList[i].data());
 
 				txs.push_back(txList[i].data());
-				LOG(TRACE) << toHex(k.out()) << toHex(txList[i].data());
+				LOG(DEBUG) << toHex(k.out()) << toHex(txList[i].data());
 			}
 			LOG(TRACE) << "trieRootOver" << expectedRoot;
 			LOG(TRACE) << "orderedTrieRoot" << orderedTrieRoot(txs);

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -95,7 +95,7 @@ Client::Client(
 	{
 		if ( _params.godMinerStart != bc().number() + 1 )
 		{
-			LOG(WARNING) << "Current Height Don't Match Config. Please Check Config！blockchain.number=" << bc().number() << ",godMinerStart=" << _params.godMinerStart;
+			LOG(ERROR) << "Current Height Don't Match Config. Please Check Config！blockchain.number=" << bc().number() << ",godMinerStart=" << _params.godMinerStart;
 			exit(-1);
 		}
 	}
@@ -135,7 +135,7 @@ void Client::updateConfig() {
 	value = "";
 	m_systemcontractapi->getValue("maxBlockHeadGas", value);
 	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
-	u256 min_block_gas = (m_maxBlockTranscations + 100) * TransactionBase::maxGas; //100 we 
+	u256 min_block_gas = (m_maxBlockTranscations + 100) * TransactionBase::maxGas; //100: We assume that each transaction has 100 extra gas to call systemcontract 
 	if ( uvalue < min_block_gas )
 		uvalue = min_block_gas;
 	BlockHeader::maxBlockHeadGas = uvalue;
@@ -509,7 +509,7 @@ ExecutionResult Client::call(Address _dest, bytes const& _data, u256 _gas, u256 
 		Block temp(chainParams().accountStartNonce);
 		temp.setEvmEventLog(bc().chainParams().evmEventLog);
 
-		LOG(INFO) << "Nonce at " << _dest << " pre:" << m_preSeal.transactionsFrom(_dest) << " post:" << m_postSeal.transactionsFrom(_dest);
+		LOG(TRACE) << "Nonce at " << _dest << " pre:" << m_preSeal.transactionsFrom(_dest) << " post:" << m_postSeal.transactionsFrom(_dest);
 		DEV_READ_GUARDED(x_postSeal)
 		temp = m_postSeal;
 		temp.mutableState().addBalance(_from, _value + _gasPrice * _gas);

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -95,7 +95,7 @@ Client::Client(
 	{
 		if ( _params.godMinerStart != bc().number() + 1 )
 		{
-			LOG(ERROR) << "Current Height Don't Match Config. Please Check Config！blockchain.number=" << bc().number() << ",godMinerStart=" << _params.godMinerStart;
+			LOG(WARNING) << "Current Height Don't Match Config. Please Check Config！blockchain.number=" << bc().number() << ",godMinerStart=" << _params.godMinerStart;
 			exit(-1);
 		}
 	}
@@ -126,6 +126,21 @@ void Client::updateConfig() {
 	//Block::c_maxSyncTransactions = static_cast<unsigned>(uvalue);
 
 	value = "";
+	m_systemcontractapi->getValue("maxTranscationGas", value);
+	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
+	if ( uvalue < 30000000 )
+		uvalue = 30000000;
+	TransactionBase::maxGas = uvalue;
+
+	value = "";
+	m_systemcontractapi->getValue("maxBlockHeadGas", value);
+	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
+	u256 min_block_gas = (m_maxBlockTranscations + 100) * TransactionBase::maxGas; //100 we 
+	if ( uvalue < min_block_gas )
+		uvalue = min_block_gas;
+	BlockHeader::maxBlockHeadGas = uvalue;
+
+	value = "";
 	m_systemcontractapi->getValue("intervalBlockTime", value);
 	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
 	if ( uvalue < 1000 )
@@ -133,23 +148,9 @@ void Client::updateConfig() {
 	sealEngine()->setIntervalBlockTime(uvalue);
 
 	value = "";
-	m_systemcontractapi->getValue("maxBlockHeadGas", value);
-	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
-	if ( uvalue < 2000000000 )
-		uvalue = 2000000000;
-	BlockHeader::maxBlockHeadGas = uvalue;
-
-	value = "";
 	m_systemcontractapi->getValue("updateHeight", value);
 	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
 	BlockHeader::updateHeight = uvalue;
-
-	value = "";
-	m_systemcontractapi->getValue("maxTranscationGas", value);
-	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
-	if ( uvalue < 30000000 )
-		uvalue = 30000000;
-	TransactionBase::maxGas = uvalue;
 
 	value = "";
 	m_systemcontractapi->getValue("maxNonceCheckBlock", value);
@@ -508,7 +509,7 @@ ExecutionResult Client::call(Address _dest, bytes const& _data, u256 _gas, u256 
 		Block temp(chainParams().accountStartNonce);
 		temp.setEvmEventLog(bc().chainParams().evmEventLog);
 
-		LOG(TRACE) << "Nonce at " << _dest << " pre:" << m_preSeal.transactionsFrom(_dest) << " post:" << m_postSeal.transactionsFrom(_dest);
+		LOG(INFO) << "Nonce at " << _dest << " pre:" << m_preSeal.transactionsFrom(_dest) << " post:" << m_postSeal.transactionsFrom(_dest);
 		DEV_READ_GUARDED(x_postSeal)
 		temp = m_postSeal;
 		temp.mutableState().addBalance(_from, _value + _gasPrice * _gas);

--- a/libethereum/Client.cpp
+++ b/libethereum/Client.cpp
@@ -135,7 +135,7 @@ void Client::updateConfig() {
 	value = "";
 	m_systemcontractapi->getValue("maxBlockHeadGas", value);
 	uvalue = u256(fromBigEndian<u256>(fromHex(value)));
-	u256 min_block_gas = (m_maxBlockTranscations + 100) * TransactionBase::maxGas; //100: We assume that each transaction has 100 extra gas to call systemcontract 
+	u256 min_block_gas = (m_maxBlockTranscations + 100) * TransactionBase::maxGas; //100: We assume that each block has 100 extra times to call systemcontract 
 	if ( uvalue < min_block_gas )
 		uvalue = min_block_gas;
 	BlockHeader::maxBlockHeadGas = uvalue;


### PR DESCRIPTION
（1）将多线程的StateMonitor改成单线程的，
（2）调整maxBlockHeaderGas的逻辑，当设置小于系统不可用的值时，将不会被设置