### PR TITLE
Fix bug before release 1.3.4

### DIFF
--- a/tools/scripts/deploy_systemcontract.sh
+++ b/tools/scripts/deploy_systemcontract.sh
@@ -126,8 +126,8 @@ deploy_systemcontract_using_nodejs() {
     echo "Start depoly system contract"
     rm -f $systemcontract_dir/output/SystemProxy.address
     cd $systemcontract_dir
-    execute_cmd "babel-node deploy_systemcontract.js $config_file" & \
-    (sleep 7 && rm $config_file)
+    execute_cmd "babel-node deploy_systemcontract.js $config_file" #& \
+    #(sleep 7 && rm $config_file)
     wait
     cd -
 }

--- a/tools/scripts/generate_genesis.sh
+++ b/tools/scripts/generate_genesis.sh
@@ -60,14 +60,14 @@ help() {
     echo "    bash $this_script -i xxxxxxxxxxxxx -o ~/mydata/node0 -r 0x3b5b68db7502424007c6e6567fa690c5afd71721 -g"
 exit -1
 }
-goumi_support=0
+guomi_support=0
 while getopts "d:o:i:s:gh" option;do
 	case $option in
 	o) output_dirs=$OPTARG;;
     d) genesis_node_dir=$OPTARG;;
     i) init_miners=$OPTARG;;
     s) god_address=$OPTARG;;
-    g) goumi_support=1;;
+    g) guomi_support=1;;
 	h) help;;
 	esac
 done


### PR DESCRIPTION
1. fix file missing bug when deploying system contract if running babel-node is slow
2. fix variable definition bug of generate_node.sh
3. add information dump flag '-o' of node_info.sh
4. add using info file to generate node flag '-f' in generate_node.sh