### PR TITLE
fix node.key file error

### DIFF
--- a/libinitializer/SecureInitializer.cpp
+++ b/libinitializer/SecureInitializer.cpp
@@ -118,7 +118,10 @@ void SecureInitializer::initConfig(const boost::property_tree::ptree &pt) {
 	});
 
 	std::string keyHex(privateKeyData.get()); //取出key数据
-
+	if(keyHex.size() != 64u)
+	{
+		throw std::invalid_argument("Private Key file error! Missing bytes!");
+	}
 	_key = KeyPair(Secret(keyHex));
 
 	try {


### PR DESCRIPTION
openssl generate wrong node.key, lost 2 bytes