### PR TITLE
fix compile warnings related to ut && fix pbft bug related to future block &&  move ttl configuration of consensus from genesis configuration to ini configuration

### DIFF
--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -128,6 +128,6 @@ std::pair<ExecutionResult, TransactionReceipt> BlockVerifier::execute(EnvInfo co
     e.finalize();
 
     return make_pair(res,
-        TransactionReceipt(executiveContext->getState()->rootHash(), startGasUsed + e.gasUsed(),
+        TransactionReceipt(executiveContext->getState()->rootHash(false), startGasUsed + e.gasUsed(),
             e.logs(), e.status(), e.takeOutput().takeBytes(), e.newAddress()));
 }

--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -127,7 +127,7 @@ std::pair<ExecutionResult, TransactionReceipt> BlockVerifier::execute(EnvInfo co
         e.go(onOp);
     e.finalize();
 
-    return make_pair(res,
-        TransactionReceipt(executiveContext->getState()->rootHash(false), startGasUsed + e.gasUsed(),
-            e.logs(), e.status(), e.takeOutput().takeBytes(), e.newAddress()));
+    return make_pair(res, TransactionReceipt(executiveContext->getState()->rootHash(false),
+                              startGasUsed + e.gasUsed(), e.logs(), e.status(),
+                              e.takeOutput().takeBytes(), e.newAddress()));
 }

--- a/libchannelserver/ChannelRPCServer.cpp
+++ b/libchannelserver/ChannelRPCServer.cpp
@@ -221,7 +221,7 @@ void ChannelRPCServer::onDisconnect(
         {
             if (it.second == session)
             {
-                auto c = _sessions.erase(it.first);
+                _sessions.erase(it.first);
                 CHANNEL_LOG(DEBUG) << "sessions removed";
                 break;
             }
@@ -231,7 +231,7 @@ void ChannelRPCServer::onDisconnect(
         {
             if (it.second == session)
             {
-                auto c = _seq2session.erase(it.first);
+                _seq2session.erase(it.first);
                 CHANNEL_LOG(DEBUG) << "seq2session removed";
                 break;
             }

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -933,7 +933,7 @@ bool PBFTEngine::isValidSignReq(SignReq const& req, std::ostringstream& oss) con
     }
     CheckResult result = checkReq(req, oss);
     if (result == CheckResult::FUTURE &&
-        m_reqCache->getSigCacheSize(req.block_hash) == (size_t)(minValidNodes() - 1))
+        m_reqCache->getSigCacheSize(req.block_hash) < (size_t)(minValidNodes() - 1))
     {
         m_reqCache->addSignReq(req);
         PBFTENGINE_LOG(INFO) << LOG_DESC("FutureBlock") << LOG_KV("INFO", oss.str());

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -463,7 +463,7 @@ bool PBFTEngine::isValidPrepare(PrepareReq const& req, std::ostringstream& oss) 
         return false;
     }
 
-    if (isFutureBlock(req))
+    if (isFuturePrepare(req))
     {
         PBFTENGINE_LOG(INFO) << LOG_DESC("FutureBlock") << LOG_KV("EINFO", oss.str());
         m_reqCache->addFuturePrepareCache(req);
@@ -829,7 +829,6 @@ void PBFTEngine::checkAndSave()
                 m_txPool->handleBadBlock(*p_block);
             }
             /// clear caches to in case of repeated commit
-            m_reqCache->clearAllExceptCommitCache();
             m_reqCache->delCache(m_reqCache->prepareCache().block_hash);
         }
         else
@@ -869,7 +868,6 @@ void PBFTEngine::reportBlock(Block const& block)
             m_reqCache->delInvalidViewChange(m_highestBlock);
         }
         resetConfig();
-        m_reqCache->clearAllExceptCommitCache();
         m_reqCache->delCache(m_highestBlock.hash());
         PBFTENGINE_LOG(INFO) << LOG_DESC("^^^^^Report:") << LOG_KV("num", m_highestBlock.number())
                              << LOG_KV("idx", m_highestBlock.sealer())
@@ -927,8 +925,15 @@ bool PBFTEngine::isValidSignReq(SignReq const& req, std::ostringstream& oss) con
                               << LOG_KV("INFO", oss.str());
         return false;
     }
+    if (hasConsensused(req))
+    {
+        PBFTENGINE_LOG(TRACE) << LOG_DESC("Sign requests have been consensused")
+                              << LOG_KV("INFO", oss.str());
+        return false;
+    }
     CheckResult result = checkReq(req, oss);
-    if (result == CheckResult::FUTURE)
+    if (result == CheckResult::FUTURE &&
+        m_reqCache->getSigCacheSize(req.block_hash) == (size_t)(minValidNodes() - 1))
     {
         m_reqCache->addSignReq(req);
         PBFTENGINE_LOG(INFO) << LOG_DESC("FutureBlock") << LOG_KV("INFO", oss.str());
@@ -984,6 +989,11 @@ bool PBFTEngine::isValidCommitReq(CommitReq const& req, std::ostringstream& oss)
     {
         PBFTENGINE_LOG(TRACE) << LOG_DESC("InvalidCommitReq: Duplicated")
                               << LOG_KV("INFO", oss.str());
+        return false;
+    }
+    if (hasConsensused(req))
+    {
+        LOG(TRACE) << LOG_DESC("InvalidCommitReq: has consensued") << LOG_KV("INFO", oss.str());
         return false;
     }
     CheckResult result = checkReq(req, oss);

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -356,11 +356,9 @@ protected:
     template <class T>
     inline bool hasConsensused(T const& req) const
     {
-        if (req.height < m_consensusBlockNumber || req.view < m_view)
+        if (req.height < m_consensusBlockNumber ||
+            (req.height == m_consensusBlockNumber && req.view < m_view))
         {
-            PBFTENGINE_LOG(DEBUG) << "[#hasConsensused] [height/consNum/reqView/Cview]:  "
-                                  << req.height << "/" << m_consensusBlockNumber << "/" << req.view
-                                  << "/" << m_view << std::endl;
             return true;
         }
         return false;
@@ -369,12 +367,22 @@ protected:
     template <typename T>
     inline bool isFutureBlock(T const& req) const
     {
-        if (req.height > m_consensusBlockNumber ||
-            (req.height == m_consensusBlockNumber && req.view > m_view))
+        if (req.height >= m_consensusBlockNumber || req.view > m_view)
         {
             PBFTENGINE_LOG(DEBUG) << LOG_DESC("FutureBlock") << LOG_KV("height", req.height)
                                   << LOG_KV("consNum", m_consensusBlockNumber)
                                   << LOG_KV("reqView", req.view) << LOG_KV("view", m_view);
+            return true;
+        }
+        return false;
+    }
+
+    template <typename T>
+    inline bool isFuturePrepare(T const& req) const
+    {
+        if (req.height > m_consensusBlockNumber ||
+            (req.height == m_consensusBlockNumber && req.view > m_view))
+        {
             return true;
         }
         return false;

--- a/libexecutive/StateFace.h
+++ b/libexecutive/StateFace.h
@@ -129,7 +129,7 @@ public:
     virtual u256 getNonce(Address const& _addr) const = 0;
 
     /// The hash of the root of our state tree.
-    virtual h256 rootHash() const = 0;
+    virtual h256 rootHash(bool needCalculate = true) const = 0;
 
     /// Commit all changes waiting in the address cache to the DB.
     /// @param _commitBehaviour whether or not to remove empty accounts during commit.

--- a/libinitializer/BoostLogInitializer.h
+++ b/libinitializer/BoostLogInitializer.h
@@ -46,7 +46,9 @@ public:
     LogInitializer() {}
     void initLog(boost::property_tree::ptree const& _pt,
         std::string const& channel = dev::FileLogger, std::string const& logType = "log");
+
     void stopLogging();
+
     unsigned getLogLevel(std::string const& levelStr);
     static void inline logRotateByTime(){};
     static int m_currentHour;

--- a/libinitializer/EasyLogInitializer.h
+++ b/libinitializer/EasyLogInitializer.h
@@ -62,6 +62,8 @@ public:
         }
     }
 
+    void stopLogging() {}
+
 private:
     static const std::chrono::seconds wakeUpDelta;
     static std::chrono::system_clock::time_point nextWakeUp;

--- a/libinitializer/Initializer.h
+++ b/libinitializer/Initializer.h
@@ -45,6 +45,18 @@ class Initializer : public InitializerInterface, public std::enable_shared_from_
 public:
     typedef std::shared_ptr<Initializer> Ptr;
 
+    virtual ~Initializer()
+    {
+        /// modify the destructure order to ensure that the log is destructed at last
+        /// stop the ledger
+        m_ledgerInitializer->stopAll();
+        /// stop p2p
+        m_p2pInitializer->stop();
+        /// stop rpc
+        m_rpcInitializer->stop();
+        /// stop log
+        m_logInitializer->stopLogging();
+    }
     void init(std::string const& _path);
 
     GlobalConfigureInitializer::Ptr globalConfigureInitializer()

--- a/libinitializer/P2PInitializer.h
+++ b/libinitializer/P2PInitializer.h
@@ -37,7 +37,9 @@ class P2PInitializer : public std::enable_shared_from_this<P2PInitializer>
 public:
     typedef std::shared_ptr<P2PInitializer> Ptr;
 
-    ~P2PInitializer()
+    ~P2PInitializer() { stop(); }
+
+    void stop()
     {
         if (m_p2pService)
         {

--- a/libinitializer/RPCInitializer.h
+++ b/libinitializer/RPCInitializer.h
@@ -38,7 +38,9 @@ class RPCInitializer : public std::enable_shared_from_this<RPCInitializer>
 public:
     typedef std::shared_ptr<RPCInitializer> Ptr;
 
-    virtual ~RPCInitializer()
+    virtual ~RPCInitializer() { stop(); }
+
+    void stop()
     {
         if (m_channelRPCHttpServer)
         {
@@ -50,7 +52,7 @@ public:
             m_jsonrpcHttpServer->StopListening();
             INITIALIZER_LOG(INFO) << "JsonrpcHttpServer stoped.";
         }
-    };
+    }
 
     void initConfig(boost::property_tree::ptree const& _pt);
     void setP2PService(std::shared_ptr<p2p::P2PInterface> _p2pService)

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -123,6 +123,9 @@ void Ledger::initIniConfig(std::string const& iniConfigFileName)
         initTxPoolConfig(pt);
         /// init params related to sync
         initSyncConfig(pt);
+
+        /// init params releated to consensus(ttl)
+        initConsensusIniConfig(pt);
     }
     catch (std::exception& e)
     {
@@ -147,6 +150,15 @@ void Ledger::initTxPoolConfig(ptree const& pt)
     }
 }
 
+
+void Ledger::initConsensusIniConfig(ptree const& pt)
+{
+    m_param->mutableConsensusParam().maxTTL = pt.get<uint8_t>("consensus.ttl", MAXTTL);
+    Ledger_LOG(DEBUG) << LOG_BADGE("initConsensusIniConfig")
+                      << LOG_KV("maxTTL", std::to_string(m_param->mutableConsensusParam().maxTTL));
+}
+
+
 /// init consensus configurations:
 /// 1. consensusType: current support pbft only (default is pbft)
 /// 2. maxTransNum: max number of transactions can be sealed into a block
@@ -159,7 +171,7 @@ void Ledger::initConsensusConfig(ptree const& pt)
 
     m_param->mutableConsensusParam().maxTransactions =
         pt.get<uint64_t>("consensus.max_trans_num", 1000);
-    m_param->mutableConsensusParam().maxTTL = pt.get<uint8_t>("consensus.ttl", MAXTTL);
+
 
     m_param->mutableConsensusParam().minElectTime =
         pt.get<uint64_t>("consensus.min_elect_time", 1000);
@@ -168,8 +180,7 @@ void Ledger::initConsensusConfig(ptree const& pt)
 
     Ledger_LOG(DEBUG) << LOG_BADGE("initConsensusConfig")
                       << LOG_KV("type", m_param->mutableConsensusParam().consensusType)
-                      << LOG_KV("maxTxNum", m_param->mutableConsensusParam().maxTransactions)
-                      << LOG_KV("maxTTL", std::to_string(m_param->mutableConsensusParam().maxTTL));
+                      << LOG_KV("maxTxNum", m_param->mutableConsensusParam().maxTransactions);
     std::stringstream nodeListMark;
     try
     {

--- a/libledger/Ledger.h
+++ b/libledger/Ledger.h
@@ -149,7 +149,10 @@ private:
     /// init configurations
     void initCommonConfig(boost::property_tree::ptree const& pt);
     void initTxPoolConfig(boost::property_tree::ptree const& pt);
+
     void initConsensusConfig(boost::property_tree::ptree const& pt);
+    void initConsensusIniConfig(boost::property_tree::ptree const& pt);
+
     void initSyncConfig(boost::property_tree::ptree const& pt);
     void initDBConfig(boost::property_tree::ptree const& pt);
     void initTxConfig(boost::property_tree::ptree const& pt);

--- a/libmptstate/MPTState.cpp
+++ b/libmptstate/MPTState.cpp
@@ -140,9 +140,8 @@ u256 MPTState::getNonce(Address const& _addr) const
     return m_state.getNonce(_addr);
 }
 
-h256 MPTState::rootHash(bool needCalculate) const
+h256 MPTState::rootHash(bool) const
 {
-    (void)needCalculate;
     return m_state.rootHash();
 }
 

--- a/libmptstate/MPTState.cpp
+++ b/libmptstate/MPTState.cpp
@@ -140,8 +140,9 @@ u256 MPTState::getNonce(Address const& _addr) const
     return m_state.getNonce(_addr);
 }
 
-h256 MPTState::rootHash() const
+h256 MPTState::rootHash(bool needCalculate) const
 {
+    (void)needCalculate;
     return m_state.rootHash();
 }
 

--- a/libmptstate/MPTState.h
+++ b/libmptstate/MPTState.h
@@ -108,7 +108,7 @@ public:
 
     virtual u256 getNonce(Address const& _addr) const override;
 
-    virtual h256 rootHash() const override;
+    virtual h256 rootHash(bool needCalculate = true) const override;
 
     virtual void commit() override;
 

--- a/libmptstate/State.cpp
+++ b/libmptstate/State.cpp
@@ -432,6 +432,12 @@ u256 State::getNonce(Address const& _addr) const
         return m_accountStartNonce;
 }
 
+/// The hash of the root of our state tree.
+h256 State::rootHash(bool) const
+{
+    return m_state.root();
+}
+
 u256 State::storage(Address const& _id, u256 const& _key) const
 {
     if (Account const* a = account(_id))

--- a/libmptstate/State.h
+++ b/libmptstate/State.h
@@ -306,7 +306,11 @@ public:
     u256 getNonce(Address const& _addr) const;
 
     /// The hash of the root of our state tree.
-    h256 rootHash() const { return m_state.root(); }
+    h256 rootHash(bool needCalculate = true) const 
+    {
+        (void)needCalculate;
+        return m_state.root(); 
+    }
 
     /// Commit all changes waiting in the address cache to the DB. Remove empty account
     void commit();

--- a/libmptstate/State.h
+++ b/libmptstate/State.h
@@ -306,12 +306,7 @@ public:
     u256 getNonce(Address const& _addr) const;
 
     /// The hash of the root of our state tree.
-    h256 rootHash(bool needCalculate = true) const 
-    {
-        (void)needCalculate;
-        return m_state.root(); 
-    }
-
+    h256 rootHash(bool needCalculate = true) const;
     /// Commit all changes waiting in the address cache to the DB. Remove empty account
     void commit();
 

--- a/libstorage/MemoryTable.cpp
+++ b/libstorage/MemoryTable.cpp
@@ -119,7 +119,7 @@ inline int dev::storage::MemoryTable::update(
             STORAGE_LOG(ERROR) << LOG_BADGE("MemoryTable") << LOG_DESC("Can't find data");
             return 0;
         }
-        checkFiled(entry);
+        checkField(entry);
         auto indexes = processEntries(entries, condition);
         std::vector<Change::Record> records;
 
@@ -178,7 +178,7 @@ inline int dev::storage::MemoryTable::insert(
         {
             entries = it->second;
         }
-        checkFiled(entry);
+        checkField(entry);
         Change::Record record(entries->size() + 1u);
         std::vector<Change::Record> value{record};
         m_recorder(shared_from_this(), Change::Insert, key, value);
@@ -446,7 +446,7 @@ void MemoryTable::setTableInfo(TableInfo::Ptr _tableInfo)
     m_tableInfo = _tableInfo;
 }
 
-inline void MemoryTable::checkFiled(Entry::Ptr entry)
+inline void MemoryTable::checkField(Entry::Ptr entry)
 {
     for (auto& it : *(entry->fields()))
     {

--- a/libstorage/MemoryTable.h
+++ b/libstorage/MemoryTable.h
@@ -58,7 +58,7 @@ private:
     std::vector<size_t> processEntries(Entries::Ptr entries, Condition::Ptr condition);
     bool processCondition(Entry::Ptr entry, Condition::Ptr condition);
     bool isHashField(const std::string& _key);
-    void checkFiled(Entry::Ptr entry);
+    void checkField(Entry::Ptr entry);
     Storage::Ptr m_remoteDB;
     TableInfo::Ptr m_tableInfo;
     std::map<std::string, Entries::Ptr> m_cache;

--- a/libstoragestate/StorageState.cpp
+++ b/libstoragestate/StorageState.cpp
@@ -338,9 +338,13 @@ u256 StorageState::getNonce(Address const& _address) const
     return m_accountStartNonce;
 }
 
-h256 StorageState::rootHash() const
+h256 StorageState::rootHash(bool needCalculate) const
 {
-    return m_memoryTableFactory->hash();
+    if (needCalculate)
+    {
+        return m_memoryTableFactory->hash();
+    }
+    return h256();
 }
 
 void StorageState::commit()

--- a/libstoragestate/StorageState.h
+++ b/libstoragestate/StorageState.h
@@ -139,7 +139,7 @@ public:
     virtual u256 getNonce(Address const& _address) const override;
 
     /// The hash of the root of our state tree.
-    virtual h256 rootHash() const override;
+    virtual h256 rootHash(bool needCalculate = true) const override;
 
     /// Commit all changes waiting in the address cache to the DB.
     /// @param _commitBehaviour whether or not to remove empty accounts during commit.

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -311,6 +311,7 @@ void SyncMaster::maintainPeersStatus()
     }
 
     // Skip downloading if last if not timeout
+    /*
     uint64_t currentTime = utcTime();
     if (currentTime - m_lastDownloadingRequestTime < c_downloadingRequestTimeout)
     {
@@ -320,7 +321,7 @@ void SyncMaster::maintainPeersStatus()
                         << LOG_KV("maxPeerNumber", maxPeerNumber);
         return;  // no need to sync
     }
-    m_lastDownloadingRequestTime = currentTime;
+    m_lastDownloadingRequestTime = currentTime;*/
 
     // Start download
     noteDownloadingBegin();

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -311,7 +311,7 @@ void SyncMaster::maintainPeersStatus()
     }
 
     // Skip downloading if last if not timeout
-    /*
+
     uint64_t currentTime = utcTime();
     if (currentTime - m_lastDownloadingRequestTime < c_downloadingRequestTimeout)
     {
@@ -321,7 +321,7 @@ void SyncMaster::maintainPeersStatus()
                         << LOG_KV("maxPeerNumber", maxPeerNumber);
         return;  // no need to sync
     }
-    m_lastDownloadingRequestTime = currentTime;*/
+    m_lastDownloadingRequestTime = currentTime;
 
     // Start download
     noteDownloadingBegin();

--- a/test/unittests/libconsensus/PBFTEngine.h
+++ b/test/unittests/libconsensus/PBFTEngine.h
@@ -510,8 +510,8 @@ static void testCheckReq(FakeConsensus<FakePBFTEngine>& fake_pbft, PrepareReq co
     {
         /// test inconsistent with the prepareCache
         fake_pbft.consensus()->reqCache()->clearAll();
-        BOOST_CHECK(fake_pbft.consensus()->isValidSignReq(signReq) == false);
         /// test is the future block
+        FakeValidNodeNum(fake_pbft, 4);
         SignReq copiedReq = signReq;
         copiedReq.height = fake_pbft.consensus()->mutableConsensusNumber() + 1;
         BOOST_CHECK(fake_pbft.consensus()->isValidSignReq(copiedReq) == false);

--- a/test/unittests/libdevcore/Assertions.cpp
+++ b/test/unittests/libdevcore/Assertions.cpp
@@ -87,16 +87,13 @@ BOOST_AUTO_TEST_CASE(testAssertEqualAux)
 {
     unsigned int a = 0xffffffff;
     unsigned b = -1;
-    int c = -1;
     const char* aStr = "(signed)(-1)";
     const char* bStr = "(unsigned)(-1)";
     unsigned line = 11;
     char const* file = "test/unittests/Assertions.cpp";
     char const* func = "testAssertEqualAux_BOOST_AUTO_TEST_CASE";
     BOOST_CHECK(assertEqualAux(a, b, aStr, bStr, line, file, func) == false);
-    BOOST_CHECK(assertEqualAux(a, c, aStr, aStr, line, file, func) == false);
     BOOST_CHECK(assertEqualAux(a, b, aStr, bStr, __LINE__, __FILE__, ETH_FUNC) == false);
-    BOOST_CHECK(assertEqualAux(a, c, aStr, aStr, __LINE__, __FILE__, ETH_FUNC) == false);
 }
 
 /// test micro "assertThrow"

--- a/test/unittests/libdevcore/Assertions.cpp
+++ b/test/unittests/libdevcore/Assertions.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(testAssertAux)
 /// test template function "assertEqualAux"
 BOOST_AUTO_TEST_CASE(testAssertEqualAux)
 {
-    int a = 0xffffffff;
+    unsigned int a = 0xffffffff;
     unsigned b = -1;
     int c = -1;
     const char* aStr = "(signed)(-1)";

--- a/test/unittests/libdevcore/Common.cpp
+++ b/test/unittests/libdevcore/Common.cpp
@@ -34,10 +34,6 @@ namespace dev
 namespace test
 {
 BOOST_FIXTURE_TEST_SUITE(DevcoreCommonTest, TestOutputHelperFixture)
-BOOST_AUTO_TEST_CASE(testIgnoreExceptions)
-{
-    BOOST_REQUIRE_NO_THROW(DEV_IGNORE_EXCEPTIONS(10 / 0));
-}
 /// test Arith Calculations
 BOOST_AUTO_TEST_CASE(testArithCal)
 {

--- a/test/unittests/libevm/ExtVMFace.cpp
+++ b/test/unittests/libevm/ExtVMFace.cpp
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(testCodeRelated)
     BOOST_CHECK(fromEvmC(result.tx_gas_price) == fake_ext_vm.gasPrice());
     BOOST_CHECK(fromEvmC(result.tx_origin) == fake_ext_vm.origin());
     BOOST_CHECK(result.block_number == fake_ext_vm.envInfo().number());
-    BOOST_CHECK(result.block_timestamp == (uint64_t)fake_ext_vm.envInfo().timestamp());
+    BOOST_CHECK((uint64_t)result.block_timestamp == fake_ext_vm.envInfo().timestamp());
     BOOST_CHECK(result.block_gas_limit == static_cast<int64_t>(fake_ext_vm.envInfo().gasLimit()));
     ///========== test getBlockHash =====================
     evmc_uint256be block_hash;

--- a/test/unittests/libevm/ExtVMFace.cpp
+++ b/test/unittests/libevm/ExtVMFace.cpp
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(testCodeRelated)
     BOOST_CHECK(fromEvmC(result.tx_gas_price) == fake_ext_vm.gasPrice());
     BOOST_CHECK(fromEvmC(result.tx_origin) == fake_ext_vm.origin());
     BOOST_CHECK(result.block_number == fake_ext_vm.envInfo().number());
-    BOOST_CHECK(result.block_timestamp == fake_ext_vm.envInfo().timestamp());
+    BOOST_CHECK(result.block_timestamp == (uint64_t)fake_ext_vm.envInfo().timestamp());
     BOOST_CHECK(result.block_gas_limit == static_cast<int64_t>(fake_ext_vm.envInfo().gasLimit()));
     ///========== test getBlockHash =====================
     evmc_uint256be block_hash;

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -575,8 +575,6 @@ generate_group_genesis()
     consensus_type=${consensus_type}
     ;the max number of transactions of a block
     max_trans_num=1000
-    ;the ttl of broadcasted pbft message
-    ;ttl=2
     ;the node id of leaders
     ${node_list}
 
@@ -597,6 +595,10 @@ function generate_group_ini()
 {
     local output="${1}"
     cat << EOF > ${output}
+
+; the ttl for broadcasting pbft message
+[consensus]
+    ;ttl=2
 ;sync period time
 [sync]
     idle_wait_ms=200


### PR DESCRIPTION
1. fix compile warnings related to ut
2.  only the call rootHash to calculate stateRoot once when using storage state
3. fix future block logic of pbft
4. move ttl configuration of consensus from genesis configuration to ini configuration 
5. modify the order of stop all the modules when the program exits