### PR TITLE
Rollback status sending logic

### DIFF
--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -141,7 +141,7 @@ void SyncMaster::doWork()
             maintainTransactions();
         }
 
-        if (m_needMaintainBlocks && (m_newBlocks || utcTime() > m_maintainBlocksTimeout))
+        if (m_newBlocks || utcTime() > m_maintainBlocksTimeout)
         {
             m_newBlocks = false;
             maintainBlocks();
@@ -565,9 +565,6 @@ void SyncMaster::maintainPeersConnection()
 
     // If myself is not in group, ignore receive packet checking from all peers
     m_msgEngine->needCheckPacketInGroup = hasMyself;
-
-    // If myself is not in group, no need to maintain blocks(send status to peers)
-    m_needMaintainBlocks = hasMyself;
 
     // If myself is not in group, no need to maintain transactions(send transactions to peers)
     m_needMaintainTransactions = hasMyself;

--- a/libsync/SyncMaster.h
+++ b/libsync/SyncMaster.h
@@ -174,7 +174,6 @@ private:
     bool m_newTransactions = false;
     bool m_newBlocks = false;
     uint64_t m_maintainBlocksTimeout = 0;
-    bool m_needMaintainBlocks = false;
     bool m_needMaintainTransactions = false;
 
 


### PR DESCRIPTION
Rollback status sending logic: Send status to peers when the node is not in group