### PR TITLE
 fix coredump caused by access the thread-unsafe stl-set and stl-vector concurrently

### DIFF
--- a/fisco-bcos/p2p/p2p_main.cpp
+++ b/fisco-bcos/p2p/p2p_main.cpp
@@ -44,10 +44,10 @@ int main()
     uint32_t counter = 0;
     while (true)
     {
-        std::shared_ptr<std::vector<std::string>> topics = p2pService->topics();
+        std::vector<std::string> topics = p2pService->topics();
         std::string topic = "Topic" + to_string(counter++);
-        topics->push_back(topic);
-        P2PMSG_LOG(TRACE) << "Add topic periodically, now Topics[" << topics->size() - 1
+        topics.push_back(topic);
+        P2PMSG_LOG(TRACE) << "Add topic periodically, now Topics[" << topics.size() - 1
                           << "]:" << topic;
         p2pService->setTopics(topics);
         LogInitializer::logRotateByTime();

--- a/libchannelserver/ChannelRPCServer.cpp
+++ b/libchannelserver/ChannelRPCServer.cpp
@@ -437,7 +437,7 @@ void dev::ChannelRPCServer::onClientTopicRequest(
         Json::Value root;
         ss >> root;
 
-        std::shared_ptr<std::set<std::string> > topics = std::make_shared<std::set<std::string> >();
+        std::set<std::string> topics;
         Json::Value topicsValue = root;
         if (!topicsValue.empty())
         {
@@ -447,7 +447,7 @@ void dev::ChannelRPCServer::onClientTopicRequest(
 
                 CHANNEL_LOG(TRACE) << "onClientTopicRequest insert" << LOG_KV("topic", topic);
 
-                topics->insert(topic);
+                topics.insert(topic);
             }
         }
 
@@ -758,13 +758,13 @@ std::string ChannelRPCServer::newSeq()
 
 void ChannelRPCServer::updateHostTopics()
 {
-    auto allTopics = std::make_shared<std::vector<std::string> >();
+    std::vector<std::string> allTopics;
 
     std::lock_guard<std::mutex> lock(_sessionMutex);
     for (auto& it : _sessions)
     {
         auto topics = it.second->topics();
-        allTopics->insert(allTopics->end(), topics->begin(), topics->end());
+        allTopics.insert(allTopics.end(), topics.begin(), topics.end());
     }
 
     m_service->setTopics(allTopics);
@@ -778,13 +778,13 @@ std::vector<dev::channel::ChannelSession::Ptr> ChannelRPCServer::getSessionByTop
     std::lock_guard<std::mutex> lock(_sessionMutex);
     for (auto& it : _sessions)
     {
-        if (it.second->topics()->empty() || !it.second->actived())
+        if (it.second->topics().empty() || !it.second->actived())
         {
             continue;
         }
 
-        auto topicIt = it.second->topics()->find(topic);
-        if (topicIt != it.second->topics()->end())
+        auto topicIt = it.second->topics().find(topic);
+        if (topicIt != it.second->topics().end())
         {
             activedSessions.push_back(it.second);
         }

--- a/libchannelserver/ChannelSession.cpp
+++ b/libchannelserver/ChannelSession.cpp
@@ -400,7 +400,7 @@ void ChannelSession::onMessage(ChannelException e, Message::Ptr message)
 
             if (it->second->callback)
             {
-                _threadPool->enqueue([=]() {
+                m_threadPool->enqueue([=]() {
                     it->second->callback(e, message);
                     _responseCallbacks.erase(it);
                 });
@@ -417,7 +417,7 @@ void ChannelSession::onMessage(ChannelException e, Message::Ptr message)
             if (_messageHandler)
             {
                 auto session = std::weak_ptr<dev::channel::ChannelSession>(shared_from_this());
-                _threadPool->enqueue([session, message]() {
+                m_threadPool->enqueue([session, message]() {
                     auto s = session.lock();
                     if (s && s->_messageHandler)
                     {
@@ -532,7 +532,8 @@ void ChannelSession::disconnect(dev::channel::ChannelException e)
 
                         if (it.second->callback)
                         {
-                            _threadPool->enqueue([=]() { it.second->callback(e, Message::Ptr()); });
+                            m_threadPool->enqueue(
+                                [=]() { it.second->callback(e, Message::Ptr()); });
                         }
                         else
                         {

--- a/libchannelserver/ChannelSession.cpp
+++ b/libchannelserver/ChannelSession.cpp
@@ -31,10 +31,7 @@
 
 using namespace dev::channel;
 
-ChannelSession::ChannelSession()
-{
-    _topics = std::make_shared<std::set<std::string> >();
-}
+ChannelSession::ChannelSession() {}
 
 Message::Ptr ChannelSession::sendMessage(Message::Ptr request, size_t timeout)
 {

--- a/libchannelserver/ChannelSession.h
+++ b/libchannelserver/ChannelSession.h
@@ -95,15 +95,15 @@ public:
     std::set<std::string> topics()
     {
         dev::ReadGuard l(x_topics);
-        return _topics;
+        return m_topics;
     };
     void setTopics(std::set<std::string> topics)
     {
         dev::WriteGuard l(x_topics);
-        _topics = topics;
+        m_topics = topics;
     };
 
-    void setThreadPool(ThreadPool::Ptr threadPool) { _threadPool = threadPool; }
+    void setThreadPool(ThreadPool::Ptr threadPool) { m_threadPool = threadPool; }
 
     MessageFactory::Ptr messageFactory() { return _messageFactory; }
     void setMessageFactory(MessageFactory::Ptr messageFactory) { _messageFactory = messageFactory; }
@@ -164,8 +164,8 @@ private:
     std::map<std::string, ResponseCallback::Ptr> _responseCallbacks;
 
     mutable dev::SharedMutex x_topics;
-    std::set<std::string> _topics;
-    ThreadPool::Ptr _threadPool;
+    std::set<std::string> m_topics;
+    ThreadPool::Ptr m_threadPool;
 
     size_t _idleTime = 30000;
 };

--- a/libchannelserver/ChannelSession.h
+++ b/libchannelserver/ChannelSession.h
@@ -97,10 +97,10 @@ public:
         dev::ReadGuard l(x_topics);
         return m_topics;
     };
-    void setTopics(std::set<std::string> topics)
+    void setTopics(std::set<std::string> const& topics)
     {
         dev::WriteGuard l(x_topics);
-        m_topics = topics;
+        m_topics = std::move(topics);
     };
 
     void setThreadPool(ThreadPool::Ptr threadPool) { m_threadPool = threadPool; }

--- a/libexecutive/Executive.cpp
+++ b/libexecutive/Executive.cpp
@@ -110,8 +110,6 @@ bool Executive::execute()
 
     uint64_t txGasLimit = m_envInfo.precompiledEngine()->txGasLimit();
     LOG(TRACE) << "Practical limitation of tx gas: " << txGasLimit;
-
-    assert(txGasLimit >= (u256)m_baseGasRequired);
     if (m_t.isCreation())
         return create(m_t.sender(), m_t.value(), m_t.gasPrice(),
             txGasLimit - (u256)m_baseGasRequired, &m_t.data(), m_t.sender());

--- a/libp2p/P2PInterface.h
+++ b/libp2p/P2PInterface.h
@@ -76,13 +76,13 @@ public:
 
     virtual bool isConnected(NodeID const& _nodeID) const = 0;
 
-    virtual std::shared_ptr<std::vector<std::string>> topics() = 0;
+    virtual std::vector<std::string> topics() = 0;
 
     virtual dev::h512s getNodeListByGroupID(GROUP_ID groupID) = 0;
     virtual void setGroupID2NodeList(std::map<GROUP_ID, dev::h512s> _groupID2NodeList) = 0;
     virtual void setNodeListByGroupID(GROUP_ID _groupID, dev::h512s _nodeList) = 0;
 
-    virtual void setTopics(std::shared_ptr<std::vector<std::string>> _topics) = 0;
+    virtual void setTopics(std::vector<std::string> const& _topics) = 0;
 
     virtual std::shared_ptr<P2PMessageFactory> p2pMessageFactory() = 0;
 };

--- a/libp2p/P2PSession.cpp
+++ b/libp2p/P2PSession.cpp
@@ -157,7 +157,7 @@ void P2PSession::onTopicMessage(P2PMessage::Ptr message)
                                     boost::split(topics, s, boost::is_any_of("\t"));
 
                                     uint32_t topicSeq = 0;
-                                    auto topicList = std::make_shared<std::set<std::string> >();
+                                    std::set<std::string> topicList;
                                     for (uint32_t i = 0; i < topics.size(); ++i)
                                     {
                                         if (i == 0)
@@ -166,7 +166,7 @@ void P2PSession::onTopicMessage(P2PMessage::Ptr message)
                                         }
                                         else
                                         {
-                                            topicList->insert(topics[i]);
+                                            topicList.insert(topics[i]);
                                         }
                                     }
 
@@ -197,7 +197,7 @@ void P2PSession::onTopicMessage(P2PMessage::Ptr message)
                 if (service)
                 {
                     std::string s = boost::lexical_cast<std::string>(service->topicSeq());
-                    for (auto& it : *service->topics())
+                    for (auto& it : service->topics())
                     {
                         s.append("\t");
                         s.append(it);

--- a/libp2p/P2PSession.h
+++ b/libp2p/P2PSession.h
@@ -38,7 +38,7 @@ class P2PSession : public std::enable_shared_from_this<P2PSession>
 public:
     typedef std::shared_ptr<P2PSession> Ptr;
 
-    P2PSession() { m_topics = std::make_shared<std::set<std::string> >(); }
+    P2PSession() {}
 
     virtual ~P2PSession(){};
 
@@ -56,14 +56,18 @@ public:
     virtual NodeID nodeID() { return m_nodeID; }
     virtual void setNodeID(NodeID nodeID) { m_nodeID = nodeID; }
 
-    virtual std::shared_ptr<std::set<std::string> > topics() { return m_topics; }
+    virtual std::set<std::string> topics()
+    {
+        std::lock_guard<std::mutex> lock(x_topic);
+        return m_topics;
+    }
 
     virtual std::weak_ptr<Service> service() { return m_service; }
     virtual void setService(std::weak_ptr<Service> service) { m_service = service; }
 
     virtual void onTopicMessage(std::shared_ptr<P2PMessage> message);
 
-    virtual void setTopics(uint32_t seq, std::shared_ptr<std::set<std::string> > topics)
+    virtual void setTopics(uint32_t seq, std::set<std::string> const& topics)
     {
         std::lock_guard<std::mutex> lock(x_topic);
 
@@ -77,7 +81,7 @@ private:
 
     std::mutex x_topic;
     uint32_t m_topicSeq = 0;
-    std::shared_ptr<std::set<std::string> > m_topics;
+    std::set<std::string> m_topics;
     std::weak_ptr<Service> m_service;
     std::shared_ptr<boost::asio::deadline_timer> m_timer;
     bool m_run = false;

--- a/libp2p/Service.cpp
+++ b/libp2p/Service.cpp
@@ -40,7 +40,6 @@ Service::Service()
     m_protocolID2Handler =
         std::make_shared<std::unordered_map<uint32_t, CallbackFuncWithSession>>();
     m_topic2Handler = std::make_shared<std::unordered_map<std::string, CallbackFuncWithSession>>();
-    m_topics = std::make_shared<std::vector<std::string>>();
 }
 
 void Service::start()
@@ -674,8 +673,8 @@ P2PSessionInfos Service::sessionInfos()
         auto s = m_sessions;
         for (auto const& i : s)
         {
-            infos.push_back(P2PSessionInfo(
-                i.first, i.second->session()->nodeIPEndpoint(), *(i.second->topics())));
+            infos.push_back(
+                P2PSessionInfo(i.first, i.second->session()->nodeIPEndpoint(), i.second->topics()));
         }
     }
     catch (std::exception& e)
@@ -712,7 +711,7 @@ P2PSessionInfos Service::sessionInfosByProtocolID(PROTOCOL_ID _protocolID) const
             if (find(it->second.begin(), it->second.end(), i.first) != it->second.end())
             {
                 infos.push_back(P2PSessionInfo(
-                    i.first, i.second->session()->nodeIPEndpoint(), *(i.second->topics())));
+                    i.first, i.second->session()->nodeIPEndpoint(), i.second->topics()));
             }
         }
     }
@@ -733,7 +732,7 @@ NodeIDs Service::getPeersByTopic(std::string const& topic)
         auto s = m_sessions;
         for (auto const& it : s)
         {
-            for (auto j : *(it.second->topics()))
+            for (auto j : it.second->topics())
             {
                 if (j == topic)
                 {

--- a/libp2p/Service.h
+++ b/libp2p/Service.h
@@ -122,7 +122,7 @@ public:
     virtual void setTopics(std::vector<std::string> const& _topics) override
     {
         RecursiveGuard l(x_topics);
-        m_topics = _topics;
+        m_topics = std::move(_topics);
         ++m_topicSeq;
     }
 

--- a/libp2p/Service.h
+++ b/libp2p/Service.h
@@ -114,8 +114,12 @@ public:
     virtual uint32_t topicSeq() { return m_topicSeq; }
     virtual void increaseTopicSeq() { ++m_topicSeq; }
 
-    virtual std::shared_ptr<std::vector<std::string>> topics() override { return m_topics; }
-    virtual void setTopics(std::shared_ptr<std::vector<std::string>> _topics) override
+    virtual std::vector<std::string> topics() override
+    {
+        RecursiveGuard l(x_topics);
+        return m_topics;
+    }
+    virtual void setTopics(std::vector<std::string> const& _topics) override
     {
         RecursiveGuard l(x_topics);
         m_topics = _topics;
@@ -153,7 +157,7 @@ private:
     mutable RecursiveMutex x_sessions;
 
     std::atomic<uint32_t> m_topicSeq = {0};
-    std::shared_ptr<std::vector<std::string>> m_topics;
+    std::vector<std::string> m_topics;
     RecursiveMutex x_topics;
 
     ///< key is the group that the node joins


### PR DESCRIPTION
 fix coredump caused by access the thread-unsafe stl-set and stl-vector concurrently