### PR TITLE
bug fix: modify m_blockNumber before out of the lock-area when commitBlock && fix warning condition releated to PBFT

### DIFF
--- a/libblockchain/BlockChainImp.cpp
+++ b/libblockchain/BlockChainImp.cpp
@@ -879,14 +879,12 @@ CommitResult BlockChainImp::commitBlock(Block& block, std::shared_ptr<ExecutiveC
             writeTotalTransactionCount(block, context);
             writeTxToBlock(block, context);
             context->dbCommit(block);
+            {
+                WriteGuard ll(m_blockNumberMutex);
+                m_blockNumber = block.blockHeader().number();
+            }
         }
         m_blockCache.add(block);
-
-        {
-            WriteGuard ll(m_blockNumberMutex);
-            m_blockNumber = block.blockHeader().number();
-        }
-
         m_onReady(m_blockNumber);
         return CommitResult::OK;
     }

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1451,7 +1451,8 @@ void PBFTEngine::getAllNodesViewStatus(json_spirit::Array& status)
         dev::network::NodeID node_id = getSealerByIndex(it.first);
         if (node_id != dev::network::NodeID())
         {
-            view_obj.push_back(json_spirit::Pair("0x" + dev::toHex(node_id), it.second));
+            view_obj.push_back(json_spirit::Pair("nodeId", dev::toHex(node_id)));
+            view_obj.push_back(json_spirit::Pair("view", it.second));
             view_array.push_back(view_obj);
         }
     }

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -355,7 +355,7 @@ bool PBFTEngine::broadcastViewChangeReq()
                           << LOG_KV("nodeIdx", nodeIdx())
                           << LOG_KV("myNode", m_keyPair.pub().abridged());
     /// view change not caused by omit empty block
-    if (!m_emptyBlockViewChange)
+    if (!m_fastViewChange)
     {
         PBFTENGINE_LOG(WARNING) << LOG_DESC("ViewChangeWarning: not caused by omit empty block ")
                                 << LOG_KV("v", m_view) << LOG_KV("toV", m_toView)
@@ -365,7 +365,7 @@ bool PBFTEngine::broadcastViewChangeReq()
                                 << LOG_KV("myNode", m_keyPair.pub().abridged());
     }
     /// reset the flag
-    m_emptyBlockViewChange = false;
+    m_fastViewChange = false;
     bytes view_change_data;
     req.encode(view_change_data);
     return broadcastMsg(ViewChangeReqPacket, req.uniqueKey(), ref(view_change_data));
@@ -1156,7 +1156,8 @@ bool PBFTEngine::handleViewChangeMsg(ViewChangeReq& viewChange_req, PBFTMsgPacke
         {
             m_timeManager.changeView();
             m_toView = min_view - 1;
-            PBFTENGINE_LOG(INFO) << LOG_DESC("Tigger fast-viewchange") << LOG_KV("view", m_view)
+            m_fastViewChange = true;
+            PBFTENGINE_LOG(INFO) << LOG_DESC("Trigger fast-viewchange") << LOG_KV("view", m_view)
                                  << LOG_KV("toView", m_toView) << LOG_KV("minView", min_view)
                                  << LOG_KV("INFO", oss.str());
             m_signalled.notify_all();

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -458,18 +458,6 @@ protected:
         /// get leader failed or this prepareReq is not broadcasted from leader
         if (!leader.first || req.idx != leader.second)
         {
-            /// leader failure doesn't caused by view change should output warning
-            if (!m_fastViewChange)
-            {
-                PBFTENGINE_LOG(WARNING)
-                    << LOG_DESC("InvalidPrepare: Get leader failed") << LOG_KV("cfgErr", m_cfgErr)
-                    << LOG_KV("reqIdx", req.idx) << LOG_KV("reqView", req.view)
-                    << LOG_KV("reqHeight", req.height)
-                    << LOG_KV("reqHash", req.block_hash.abridged())
-                    << LOG_KV("sealerIdx", leader.second) << LOG_KV("leaderFailed", m_leaderFailed)
-                    << LOG_KV("view", m_view) << LOG_KV("highSealer", m_highestBlock.sealer())
-                    << LOG_KV("highNum", m_highestBlock.number()) << LOG_KV("nodeIdx", nodeIdx());
-            }
             return false;
         }
 

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -458,7 +458,8 @@ protected:
         /// get leader failed or this prepareReq is not broadcasted from leader
         if (!leader.first || req.idx != leader.second)
         {
-            if (!m_fastViewChange)
+            /// leader failure doesn't caused by view change should output warning
+            if (!m_leaderFailed)
             {
                 PBFTENGINE_LOG(WARNING)
                     << LOG_DESC("InvalidPrepare: Get leader failed") << LOG_KV("cfgErr", m_cfgErr)

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -463,9 +463,11 @@ protected:
             {
                 PBFTENGINE_LOG(WARNING)
                     << LOG_DESC("InvalidPrepare: Get leader failed") << LOG_KV("cfgErr", m_cfgErr)
-                    << LOG_KV("reqIdx", req.idx) << LOG_KV("sealerIdx", leader.second)
-                    << LOG_KV("leaderFailed", m_leaderFailed) << LOG_KV("view", m_view)
-                    << LOG_KV("highSealer", m_highestBlock.sealer())
+                    << LOG_KV("reqIdx", req.idx) << LOG_KV("reqView", req.view)
+                    << LOG_KV("reqHeight", req.height)
+                    << LOG_KV("reqHash", req.block_hash.abridged())
+                    << LOG_KV("sealerIdx", leader.second) << LOG_KV("leaderFailed", m_leaderFailed)
+                    << LOG_KV("view", m_view) << LOG_KV("highSealer", m_highestBlock.sealer())
                     << LOG_KV("highNum", m_highestBlock.number()) << LOG_KV("nodeIdx", nodeIdx());
             }
             return false;

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -459,7 +459,7 @@ protected:
         if (!leader.first || req.idx != leader.second)
         {
             /// leader failure doesn't caused by view change should output warning
-            if (!m_leaderFailed)
+            if (!m_fastViewChange)
             {
                 PBFTENGINE_LOG(WARNING)
                     << LOG_DESC("InvalidPrepare: Get leader failed") << LOG_KV("cfgErr", m_cfgErr)

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -458,7 +458,7 @@ protected:
         /// get leader failed or this prepareReq is not broadcasted from leader
         if (!leader.first || req.idx != leader.second)
         {
-            if (!m_emptyBlockViewChange)
+            if (!m_fastViewChange)
             {
                 PBFTENGINE_LOG(WARNING)
                     << LOG_DESC("InvalidPrepare: Get leader failed") << LOG_KV("cfgErr", m_cfgErr)
@@ -481,7 +481,7 @@ protected:
     {
         m_timeManager.changeView();
         m_timeManager.m_changeCycle = 0;
-        m_emptyBlockViewChange = true;
+        m_fastViewChange = true;
         m_signalled.notify_all();
     }
     void notifySealing(dev::eth::Block const& block);
@@ -525,7 +525,7 @@ protected:
     std::function<void()> m_onViewChange;
     std::function<void(dev::h256Hash const& filter)> m_onNotifyNextLeaderReset;
 
-    bool m_emptyBlockViewChange = false;
+    bool m_fastViewChange = false;
 
     uint8_t maxTTL = MAXTTL;
 

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -441,6 +441,7 @@ protected:
         if (req.height == m_reqCache->committedPrepareCache().height &&
             req.block_hash != m_reqCache->committedPrepareCache().block_hash)
         {
+            /// TODO: remove these logs in the atomic functions
             PBFTENGINE_LOG(DEBUG)
                 << LOG_DESC("isHashSavedAfterCommit: hasn't been cached after commit")
                 << LOG_KV("height", req.height)
@@ -516,6 +517,8 @@ protected:
     std::function<void()> m_onViewChange;
     std::function<void(dev::h256Hash const& filter)> m_onNotifyNextLeaderReset;
 
+    /// for output time-out caused viewchange
+    /// m_fastViewChange is false: output viewchangeWarning to indicate PBFT consensus timeout
     bool m_fastViewChange = false;
 
     uint8_t maxTTL = MAXTTL;

--- a/libconsensus/pbft/PBFTReqCache.h
+++ b/libconsensus/pbft/PBFTReqCache.h
@@ -199,6 +199,7 @@ public:
         m_prepareCache.clear();
         m_signCache.clear();
         m_commitCache.clear();
+        m_futurePrepareCache.clear();
         removeInvalidViewChange(curView);
     }
     /// delete requests cached in m_signCache, m_commitCache and m_prepareCache according to hash


### PR DESCRIPTION
1. modify m_blockNumber before out of the lock-area when commitBlock to in case of commit the same block;

2. modif m_omitEmptyViewChange to m_fastViewChange and ignore viewchange warning when trigger fast viewchange

3. fix the logic when output get leader failed warning: doesn't output warning log when get leader failed caused by checkTimeOut.

4. clear future cache when view changed.