### PR TITLE
reset m_notifyNextLeaderSeal when a new view has been consensused

### DIFF
--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1241,6 +1241,7 @@ void PBFTEngine::checkAndChangeView()
         m_leaderFailed = false;
         m_timeManager.m_lastConsensusTime = utcTime();
         m_view = m_toView;
+        m_notifyNextLeaderSeal = false;
         m_reqCache->triggerViewChange(m_view);
         m_blockSync->noteSealingBlockNumber(m_blockChain->number());
     }


### PR DESCRIPTION
reset m_notifyNextLeaderSeal when a new view has been consensused (in case of receive empty prepare packet from other node, and this node is the nextLeader before)