### PR TITLE
bugfix: add condition before reset the sealing block && reset m_changeCycle to 0 when fast viewchange happend

### DIFF
--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -257,7 +257,7 @@ bool PBFTEngine::generatePrepare(Block const& block)
         if (prepare_req.pBlock->getTransactionSize() == 0 && m_omitEmptyBlock)
         {
             m_leaderFailed = true;
-            changeViewForEmptyBlock();
+            changeViewForFastViewChange();
             return true;
         }
         handlePrepareMsg(prepare_req);
@@ -809,7 +809,7 @@ bool PBFTEngine::handlePrepareMsg(PrepareReq const& prepareReq, std::string cons
     /// whether to omit empty block
     if (needOmit(workingSealing))
     {
-        changeViewForEmptyBlock();
+        changeViewForFastViewChange();
         return true;
     }
 
@@ -1190,13 +1190,11 @@ bool PBFTEngine::handleViewChangeMsg(ViewChangeReq& viewChange_req, PBFTMsgPacke
             min_view, m_f, m_toView, m_highestBlock, m_consensusBlockNumber);
         if (should_trigger)
         {
-            m_timeManager.changeView();
             m_toView = min_view - 1;
-            m_fastViewChange = true;
             PBFTENGINE_LOG(INFO) << LOG_DESC("Trigger fast-viewchange") << LOG_KV("view", m_view)
                                  << LOG_KV("toView", m_toView) << LOG_KV("minView", min_view)
                                  << LOG_KV("INFO", oss.str());
-            m_signalled.notify_all();
+            changeViewForFastViewChange();
         }
     }
     PBFTENGINE_LOG(DEBUG) << LOG_DESC("handleViewChangeMsg Succ ") << oss.str();

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -508,10 +508,9 @@ protected:
     /// check block
     bool checkBlock(dev::eth::Block const& block);
     void execBlock(Sealing& sealing, PrepareReq const& req, std::ostringstream& oss);
-    void changeViewForEmptyBlock()
+    void changeViewForFastViewChange()
     {
         m_timeManager.changeView();
-        m_timeManager.m_changeCycle = 0;
         m_fastViewChange = true;
         m_signalled.notify_all();
     }

--- a/libconsensus/pbft/PBFTSealer.h
+++ b/libconsensus/pbft/PBFTSealer.h
@@ -93,6 +93,18 @@ private:
     /// reset block when view changes
     void resetBlockForViewChange()
     {
+        /// in case of that:
+        /// time1: checkTimeout, blockNumber = n - 1
+        /// time2: Report block, blockNumber = n
+        /// time2: handleBlock, seal a new block, blockNumber(m_sealing) = n + 1, and broadcast the
+        /// prepare request time3: callback onViewChange, reset the sealed block time4: seal again,
+        /// blockNumber(m_sealing) = n + 1 the result is: generate two block with the same block in
+        /// a period solution: if there has been  a higher sealed block, return directly without
+        /// reset
+        if (m_sealing.block.isSealed() && shouldHandleBlock())
+        {
+            return;
+        }
         {
             DEV_WRITE_GUARDED(x_sealing)
             resetSealingBlock();


### PR DESCRIPTION
1. add condition before reset the sealing block to in case of reset the handling block; 
2. reset m_changeCycle to 0 when fast viewchange happend