### PR TITLE
Fix bug: Syncing is not triggered when a genesis node's data is deleted

### DIFF
--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -623,8 +623,11 @@ void SyncMaster::maintainPeersConnection()
         return true;
     });
 
-    // If myself is not in group, ignore receive packet checking from all peers
-    m_msgEngine->needCheckPacketInGroup = hasMyself;
+    if (!isSyncing())
+    {
+        // Set flag to check packet from group peers
+        m_msgEngine->needCheckPacketInGroup = (hasMyself && (currentNumber != 0));
+    }
 
     // If myself is not in group, no need to maintain transactions(send transactions to peers)
     m_needMaintainTransactions = hasMyself;


### PR DESCRIPTION
**Bug**: A genesis node will not sycing after its data is deleted. Because the node only knows the peer from the  genesis node after restarting. But if not a genesis node is in group in current state, the genesis node will ignore all packet coming form others which are not in genesis list of genesis.x.genesis.

**Fix**: If the node is at 0 block number, not to trigger packet checking.