### PR TITLE
Fix bug: No syncing after biggest block number node broken down

### DIFF
--- a/libexecutive/Executive.cpp
+++ b/libexecutive/Executive.cpp
@@ -136,7 +136,7 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
     {
         m_gas = _p.gas;
 
-        LOG(DEBUG) << "Execute Precompiled: " << _p.codeAddress;
+        LOG(TRACE) << "Execute Precompiled: " << _p.codeAddress;
 
         auto result = m_envInfo.precompiledEngine()->call(_origin, _p.codeAddress, _p.data);
         size_t outputSize = result.size();

--- a/libexecutive/ExtVM.cpp
+++ b/libexecutive/ExtVM.cpp
@@ -203,7 +203,7 @@ size_t ExtVM::codeSizeAt(dev::Address const& _a)
 {
     if (m_envInfo.precompiledEngine()->isPrecompiled(_a))
     {
-        LOG(TRACE) << _a << "Precompiled codeSizeAt return 1";
+        LOG(TRACE) << _a << " precompiled codeSizeAt return 1";
         return 1;
     }
     return m_s->codeSize(_a);

--- a/libsync/DownloadingBlockQueue.cpp
+++ b/libsync/DownloadingBlockQueue.cpp
@@ -106,8 +106,10 @@ BlockPtr DownloadingBlockQueue::top(bool isFlushBuffer)
 
 void DownloadingBlockQueue::clear()
 {
-    WriteGuard l(x_buffer);
-    m_buffer->clear();
+    {
+        WriteGuard l(x_buffer);
+        m_buffer->clear();
+    }
 
     clearQueue();
 }

--- a/test/unittests/libsync/SyncMasterTest.cpp
+++ b/test/unittests/libsync/SyncMasterTest.cpp
@@ -246,6 +246,17 @@ BOOST_AUTO_TEST_CASE(MaintainPeersStatusTest)
                           service->getAsyncSendSizeByNodeID(NodeID(102)) +
                           service->getAsyncSendSizeByNodeID(NodeID(103));
     BOOST_CHECK_EQUAL(reqPacketSum, c_maxRequestShards);
+
+    // Reset peers test
+    sync->syncStatus()->foreachPeer([&](shared_ptr<SyncPeerStatus> _p) {
+        _p->number = currentBlockNumber - 1;  // set peers number smaller than myself
+        return true;
+    });
+    sync->maintainPeersStatus();
+    reqPacketSum = service->getAsyncSendSizeByNodeID(NodeID(101)) +
+                   service->getAsyncSendSizeByNodeID(NodeID(102)) +
+                   service->getAsyncSendSizeByNodeID(NodeID(103));
+    BOOST_CHECK_EQUAL(reqPacketSum, c_maxRequestShards);  //
 }
 
 BOOST_AUTO_TEST_CASE(MaintainDownloadingQueueTest)


### PR DESCRIPTION
**Fix bug**: The biggest block number node break down during block downloding, other node will not sync from others and always waiting for the broken node to start
**Fix**: Update max known number to myself if peers biggest number is smaller than number of myself.