### PR TITLE
add selectWithoutCache into LevelDBStorage 

### DIFF
--- a/libblockchain/BlockChainImp.cpp
+++ b/libblockchain/BlockChainImp.cpp
@@ -166,7 +166,8 @@ std::shared_ptr<Block> BlockChainImp::getBlock(dev::h256 const& _blockHash)
         record_time = utcTime();
         if (tb)
         {
-            auto entries = tb->select(_blockHash.hex(), tb->newCondition());
+            auto entries = m_stateStorage->selectWithoutCache(
+                SYS_HASH_2_BLOCK, _blockHash.hex(), tb->newCondition());
             auto select_time_cost = utcTime() - record_time;
             record_time = utcTime();
             if (entries->size() > 0)
@@ -251,7 +252,8 @@ std::shared_ptr<bytes> BlockChainImp::getBlockRLP(dev::h256 const& _blockHash)
         record_time = utcTime();
         if (tb)
         {
-            auto entries = tb->select(_blockHash.hex(), tb->newCondition());
+            auto entries = m_stateStorage->selectWithoutCache(
+                SYS_HASH_2_BLOCK, _blockHash.hex(), tb->newCondition());
             auto select_time_cost = utcTime() - record_time;
             record_time = utcTime();
             if (entries->size() > 0)
@@ -323,7 +325,8 @@ void BlockChainImp::getNonces(
     Table::Ptr tb = getMemoryTableFactory()->openTable(SYS_BLOCK_2_NONCES);
     if (tb)
     {
-        auto entries = tb->select(lexical_cast<std::string>(_blockNumber), tb->newCondition());
+        auto entries = m_stateStorage->selectWithoutCache(
+            SYS_BLOCK_2_NONCES, lexical_cast<std::string>(_blockNumber), tb->newCondition());
         if (entries->size() > 0)
         {
             auto entry = entries->get(0);

--- a/libdevcore/LevelDB.cpp
+++ b/libdevcore/LevelDB.cpp
@@ -64,7 +64,7 @@ leveldb::Options LevelDB::defaultDBOptions()
 {
     leveldb::Options options;
     options.create_if_missing = true;
-    options.max_open_files = 1000;
+    options.max_open_files = 500;
     // https://github.com/google/leveldb/blob/04470825ac96cab0d9d16e4ed410349d082fbf82/include/leveldb/options.h#L137-L141
     options.compression = leveldb::kSnappyCompression;
     return options;

--- a/libethcore/Block.h
+++ b/libethcore/Block.h
@@ -160,11 +160,11 @@ public:
         }
         /// sealer must be reseted since it's used to decide a block is valid or not
         m_blockHeader.setSealer(Invalid256);
-        m_transactions.clear();
-        m_transactionReceipts.clear();
-        m_sigList.clear();
-        m_txsCache.clear();
-        m_tReceiptsCache.clear();
+        Transactions().swap(m_transactions);
+        TransactionReceipts().swap(m_transactionReceipts);
+        std::vector<std::pair<u256, Signature>>().swap(m_sigList);
+        bytes().swap(m_txsCache);
+        bytes().swap(m_tReceiptsCache);
         noteChange();
         noteReceiptChange();
     }

--- a/libethcore/BlockHeader.cpp
+++ b/libethcore/BlockHeader.cpp
@@ -118,9 +118,9 @@ void BlockHeader::clear()
     m_gasLimit = 0;
     m_gasUsed = 0;
     m_timestamp = UINT64_MAX;
-    m_extraData.clear();
+    std::vector<bytes>().swap(m_extraData);
     m_sealer = Invalid256;
-    m_sealerList.clear();
+    h512s().swap(m_sealerList);
     noteDirty();
 }
 

--- a/libledger/DBInitializer.cpp
+++ b/libledger/DBInitializer.cpp
@@ -78,7 +78,7 @@ void DBInitializer::initLevelDBStorage()
     {
         boost::filesystem::create_directories(m_param->mutableStorageParam().path);
         ldb_option.create_if_missing = true;
-        ldb_option.max_open_files = 1000;
+        ldb_option.max_open_files = 500;
         ldb_option.compression = leveldb::kSnappyCompression;
         leveldb::Status status;
 

--- a/libnetwork/Session.cpp
+++ b/libnetwork/Session.cpp
@@ -104,7 +104,7 @@ void Session::asyncSendMessage(Message::Ptr message, Options options, CallbackFu
                        << LOG_KV("seq2Callback.size", m_seq2Callback->size());
     std::shared_ptr<bytes> p_buffer = std::make_shared<bytes>();
     message->encode(*p_buffer);
-    send(p_buffer);
+    send(std::move(p_buffer));
 }
 
 bool Session::actived() const
@@ -135,7 +135,7 @@ void Session::send(std::shared_ptr<bytes> _msg)
     write();
 }
 
-void Session::onWrite(boost::system::error_code ec, std::size_t, std::shared_ptr<bytes>)
+void Session::onWrite(boost::system::error_code ec, std::size_t, std::shared_ptr<bytes> buffer)
 {
     if (!actived())
     {
@@ -157,6 +157,7 @@ void Session::onWrite(boost::system::error_code ec, std::size_t, std::shared_ptr
             if (m_writing)
             {
                 m_writing = false;
+                buffer.reset();
             }
         }
 

--- a/libp2p/P2PMessage.cpp
+++ b/libp2p/P2PMessage.cpp
@@ -28,7 +28,7 @@ using namespace dev::p2p;
 
 void P2PMessage::encode(bytes& buffer)
 {
-    buffer.clear();  ///< It is not allowed to be assembled outside.
+    bytes().swap(buffer);
     m_length = HEADER_LENGTH + m_buffer->size();
 
     uint32_t length = htonl(m_length);

--- a/libp2p/P2PMessageRC2.cpp
+++ b/libp2p/P2PMessageRC2.cpp
@@ -55,7 +55,7 @@ void P2PMessageRC2::encode(bytes& buffer)
  */
 void P2PMessageRC2::encode(std::shared_ptr<bytes> encodeBuffer)
 {
-    m_cache->clear();  ///< It is not allowed to be assembled outside.
+    bytes().swap(*m_cache);
     m_length = HEADER_LENGTH + encodeBuffer->size();
 
     uint32_t length = htonl(m_length);

--- a/libstorage/LevelDBStorage.cpp
+++ b/libstorage/LevelDBStorage.cpp
@@ -43,13 +43,11 @@ Entries::Ptr LevelDBStorage::selectWithoutCache(
         /// obtain the name of the table
         std::string entryKey = table;
         entryKey.append("_").append(key);
-
-        std::string value;
         /// read without cache
         leveldb::ReadOptions readOption;
         readOption.fill_cache = false;
         std::string value;
-        auto s = m_db->Get(readOption, leveldb::Slice(entryKey), &value);
+        auto status = m_db->Get(readOption, leveldb::Slice(entryKey), &value);
 
         if (!status.ok() && !status.IsNotFound())
         {

--- a/libstorage/LevelDBStorage.h
+++ b/libstorage/LevelDBStorage.h
@@ -47,12 +47,16 @@ public:
     virtual bool onlyDirty() override;
 
     void setDB(std::shared_ptr<dev::db::BasicLevelDB> db);
+    
+    Entries::Ptr selectWithoutCache(
+        const std::string& table, const std::string& key, Condition::Ptr condition);
 
 private:
     size_t commitTableDataRange(std::shared_ptr<dev::db::LevelDBWriteBatch>& batch,
         TableData::Ptr tableData, h256 hash, int64_t num, size_t from, size_t to);
     std::shared_ptr<dev::db::BasicLevelDB> m_db;
     dev::SharedMutex m_remoteDBMutex;
+    void decode(Entries::Ptr entries, std::string const& value);
 };
 
 }  // namespace storage

--- a/libstorage/LevelDBStorage.h
+++ b/libstorage/LevelDBStorage.h
@@ -47,9 +47,9 @@ public:
     virtual bool onlyDirty() override;
 
     void setDB(std::shared_ptr<dev::db::BasicLevelDB> db);
-    
+
     Entries::Ptr selectWithoutCache(
-        const std::string& table, const std::string& key, Condition::Ptr condition);
+        const std::string& table, const std::string& key, Condition::Ptr condition) override;
 
 private:
     size_t commitTableDataRange(std::shared_ptr<dev::db::LevelDBWriteBatch>& batch,

--- a/libstorage/Storage.h
+++ b/libstorage/Storage.h
@@ -34,6 +34,11 @@ public:
 
     virtual ~Storage(){};
 
+    virtual Entries::Ptr selectWithoutCache(const std::string&, const std::string&, Condition::Ptr)
+    {
+        return nullptr;
+    }
+
     virtual Entries::Ptr select(h256 hash, int num, TableInfo::Ptr tableInfo,
         const std::string& key, Condition::Ptr condition = nullptr) = 0;
     virtual size_t commit(h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas) = 0;

--- a/libsync/DownloadingBlockQueue.cpp
+++ b/libsync/DownloadingBlockQueue.cpp
@@ -108,7 +108,8 @@ void DownloadingBlockQueue::clear()
 {
     {
         WriteGuard l(x_buffer);
-        m_buffer->clear();
+        ShardPtrVec empty;
+        empty.swap(*m_buffer);
     }
 
     clearQueue();

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -272,7 +272,7 @@ void SyncMaster::maintainTransactions()
         packet.encode(txRLPs);
 
         auto msg = packet.toMessage(m_protocolId);
-        m_service->asyncSendMessageByNodeID(_p->nodeId, msg, CallbackFuncWithSession(), Options());
+        m_service->asyncSendMessageByNodeID(_p->nodeId, msg, nullptr);
 
         SYNC_LOG(DEBUG) << LOG_BADGE("Tx") << LOG_DESC("Send transaction to peer")
                         << LOG_KV("txNum", int(txsSize))
@@ -304,8 +304,7 @@ void SyncMaster::maintainBlocks()
         SyncStatusPacket packet;
         packet.encode(number, m_genesisHash, currentHash);
 
-        m_service->asyncSendMessageByNodeID(
-            _p->nodeId, packet.toMessage(m_protocolId), CallbackFuncWithSession(), Options());
+        m_service->asyncSendMessageByNodeID(_p->nodeId, packet.toMessage(m_protocolId), nullptr);
 
         SYNC_LOG(DEBUG) << LOG_BADGE("Status")
                         << LOG_DESC("Send current status when maintainBlocks")
@@ -427,7 +426,7 @@ void SyncMaster::maintainPeersStatus()
             unsigned size = to - from + 1;
             packet.encode(from, size);
             m_service->asyncSendMessageByNodeID(
-                _p->nodeId, packet.toMessage(m_protocolId), CallbackFuncWithSession(), Options());
+                _p->nodeId, packet.toMessage(m_protocolId), nullptr);
 
             // update max request number
             m_maxRequestNumber = max(m_maxRequestNumber, to);
@@ -619,8 +618,7 @@ void SyncMaster::maintainPeersConnection()
             SyncStatusPacket packet;
             packet.encode(currentNumber, m_genesisHash, currentHash);
 
-            m_service->asyncSendMessageByNodeID(
-                member, packet.toMessage(m_protocolId), CallbackFuncWithSession(), Options());
+            m_service->asyncSendMessageByNodeID(member, packet.toMessage(m_protocolId), nullptr);
             SYNC_LOG(DEBUG) << LOG_BADGE("Status") << LOG_DESC("Send current status to new peer")
                             << LOG_KV("number", int(currentNumber))
                             << LOG_KV("genesisHash", m_genesisHash.abridged())

--- a/libsync/SyncMsgEngine.cpp
+++ b/libsync/SyncMsgEngine.cpp
@@ -260,7 +260,7 @@ void DownloadBlocksContainer::clearBatchAndSend()
     retPacket.encode(m_blockRLPsBatch);
 
     auto msg = retPacket.toMessage(m_protocolId);
-    m_service->asyncSendMessageByNodeID(m_nodeId, msg, CallbackFuncWithSession(), Options());
+    m_service->asyncSendMessageByNodeID(m_nodeId, msg, nullptr);
     SYNC_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("Request") << LOG_BADGE("BlockSync")
                     << LOG_DESC("Send block packet") << LOG_KV("peer", m_nodeId.abridged())
                     << LOG_KV("blocks", m_blockRLPsBatch.size())
@@ -276,7 +276,7 @@ void DownloadBlocksContainer::sendBigBlock(bytes const& _blockRLP)
     retPacket.singleEncode(_blockRLP);
 
     auto msg = retPacket.toMessage(m_protocolId);
-    m_service->asyncSendMessageByNodeID(m_nodeId, msg, CallbackFuncWithSession(), Options());
+    m_service->asyncSendMessageByNodeID(m_nodeId, msg, nullptr);
     SYNC_LOG(DEBUG) << LOG_BADGE("Rcv") << LOG_BADGE("Send") << LOG_BADGE("Download")
                     << LOG_DESC("Block back") << LOG_KV("peer", m_nodeId.abridged())
                     << LOG_KV("blocks", 1) << LOG_KV("bytes(B)", msg->buffer()->size());

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -29,7 +29,8 @@ current_dir=$(pwd)
 consensus_type="pbft"
 TASSL_CMD="${HOME}"/.tassl
 auto_flush="true"
-timestamp=$(date +%s)
+# trans timestamp from seconds to milliseconds
+timestamp=$((`date '+%s'`*1000+`date '+%N'`/1000000))
 chain_id=1
 fisco_version=""
 OS=

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -30,7 +30,7 @@ consensus_type="pbft"
 TASSL_CMD="${HOME}"/.tassl
 auto_flush="true"
 # trans timestamp from seconds to milliseconds
-timestamp=$((`date '+%s'`*1000+`date '+%N'`/1000000))
+timestamp=$(($(date '+%s')*1000+$(date '+%N')/1000000))
 chain_id=1
 fisco_version=""
 OS=


### PR DESCRIPTION

1. add selectWithoutCache into LevelDBStorage and call this function directly when access the once-accessed big objects such as block, nonces
2. modify max_open_files to from 1000->500
3. fix build_chain: modify timestamp from seconds->milliseconds
4. modify the method of release vector