### PR TITLE
fix bug in Raft

### DIFF
--- a/libconsensus/raft/RaftEngine.cpp
+++ b/libconsensus/raft/RaftEngine.cpp
@@ -1439,18 +1439,13 @@ bool RaftEngine::shouldSeal()
 
 bool RaftEngine::commit(Block const& _block)
 {
-    {
-        Guard guard(m_commitMutex);
-        m_uncommittedBlock = _block;
-        m_uncommittedBlockNumber = m_consensusBlockNumber;
-        RAFTENGINE_LOG(DEBUG) << LOG_DESC("[#commit]Prepare to commit block")
-                              << LOG_KV("nextHeight", m_uncommittedBlockNumber);
-    }
-
     std::unique_lock<std::mutex> ul(m_commitMutex);
+    m_uncommittedBlock = _block;
+    m_uncommittedBlockNumber = m_consensusBlockNumber;
     m_waitingForCommitting = true;
     m_commitReady = false;
-    RAFTENGINE_LOG(DEBUG) << LOG_DESC("[#commit]Wait to commit block");
+    RAFTENGINE_LOG(DEBUG) << LOG_DESC("[#commit]Wait to commit block")
+                          << LOG_KV("nextHeight", m_uncommittedBlockNumber);
     m_commitCV.wait(ul, [this]() { return m_commitReady; });
 
     m_commitReady = false;


### PR DESCRIPTION
 in RaftEngine::commit, the assignment to m_uncommittedBlock and m_waitingForCommitting is not atomic