### PR TITLE
only reset changeCycle to zero when generate empty block or reach view consensus or report a new block

### DIFF
--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -258,6 +258,7 @@ bool PBFTEngine::generatePrepare(Block const& block)
         {
             m_leaderFailed = true;
             changeViewForFastViewChange();
+            m_timeManager.m_changeCycle = 0;
             return true;
         }
         handlePrepareMsg(prepare_req);
@@ -815,6 +816,7 @@ bool PBFTEngine::handlePrepareMsg(PrepareReq const& prepareReq, std::string cons
     if (needOmit(workingSealing))
     {
         changeViewForFastViewChange();
+        m_timeManager.m_changeCycle = 0;
         return true;
     }
 
@@ -1286,6 +1288,7 @@ void PBFTEngine::checkAndChangeView()
             m_fastViewChange = false;
         }
         m_leaderFailed = false;
+        m_timeManager.m_changeCycle = 0;
         m_timeManager.m_lastConsensusTime = utcTime();
         m_view = m_toView;
         m_notifyNextLeaderSeal = false;

--- a/libconsensus/pbft/TimeManager.h
+++ b/libconsensus/pbft/TimeManager.h
@@ -58,7 +58,7 @@ struct TimeManager
     {
         m_lastConsensusTime = 0;
         m_lastSignTime = 0;
-        m_changeCycle = 0;
+        ///m_changeCycle = 0;
     }
 
     inline void updateChangeCycle()


### PR DESCRIPTION
to solve the problem:
1. if not set changeCycle to 0 when trigger fast viewchange after consensed at a new view, the pbft message will decrease greatly when the node started.

2. if set changeCycle to 0 when trigger fast viewchange before consensused at a new view, the fast-viewchanged node will have a higher view even if the new view has not been consensused for the decreased timeout-bound.

so reset change cycle to 0 only when consensus reached, which means the pbft system has been recovered from timeout.