### PR TITLE
support print groupID in all modules related to consensus and sync thread

### DIFF
--- a/libblockchain/BlockChainImp.cpp
+++ b/libblockchain/BlockChainImp.cpp
@@ -81,8 +81,6 @@ std::shared_ptr<Block> BlockCache::add(Block const& _block)
 
 std::pair<std::shared_ptr<Block>, h256> BlockCache::get(h256 const& _hash)
 {
-    BLOCKCHAIN_LOG(DEBUG) << LOG_DESC("[get]Read block from block cache")
-                          << LOG_KV("blockHash", _hash.abridged());
     {
         ReadGuard guard(m_sharedMutex);
 

--- a/libblockchain/BlockChainImp.h
+++ b/libblockchain/BlockChainImp.h
@@ -42,8 +42,7 @@
 #include <memory>
 #include <mutex>
 
-#define BLOCKCHAIN_LOG(LEVEL) \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "]" << LOG_BADGE("BLOCKCHAIN")
+#define BLOCKCHAIN_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("BLOCKCHAIN")
 
 namespace dev
 {
@@ -111,8 +110,6 @@ public:
         m_tableFactoryFactory = tableFactoryFactory;
     }
 
-    void setGroupID(GROUP_ID const& groupId) { m_groupId = groupId; }
-
 private:
     std::shared_ptr<dev::eth::Block> getBlock(int64_t _i);
     std::shared_ptr<dev::eth::Block> getBlock(dev::h256 const& _blockHash);
@@ -163,7 +160,6 @@ private:
     int64_t m_blockNumber = -1;
 
     dev::storage::TableFactoryFactory::Ptr m_tableFactoryFactory;
-    GROUP_ID m_groupId;
 };
 }  // namespace blockchain
 }  // namespace dev

--- a/libblockchain/BlockChainImp.h
+++ b/libblockchain/BlockChainImp.h
@@ -42,7 +42,8 @@
 #include <memory>
 #include <mutex>
 
-#define BLOCKCHAIN_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("BLOCKCHAIN")
+#define BLOCKCHAIN_LOG(LEVEL) \
+    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "]" << LOG_BADGE("BLOCKCHAIN")
 
 namespace dev
 {
@@ -110,6 +111,8 @@ public:
         m_tableFactoryFactory = tableFactoryFactory;
     }
 
+    void setGroupID(GROUP_ID const& groupId) { m_groupId = groupId; }
+
 private:
     std::shared_ptr<dev::eth::Block> getBlock(int64_t _i);
     std::shared_ptr<dev::eth::Block> getBlock(dev::h256 const& _blockHash);
@@ -160,6 +163,7 @@ private:
     int64_t m_blockNumber = -1;
 
     dev::storage::TableFactoryFactory::Ptr m_tableFactoryFactory;
+    GROUP_ID m_groupId;
 };
 }  // namespace blockchain
 }  // namespace dev

--- a/libblockverifier/BlockVerifier.h
+++ b/libblockverifier/BlockVerifier.h
@@ -94,11 +94,14 @@ public:
         m_pNumberHash = _pNumberHash;
     }
 
+    void setGroupID(GROUP_ID const& groupId) { m_groupId = groupId; }
+
 private:
     ExecutiveContextFactory::Ptr m_executiveContextFactory;
     NumberHashCallBackFunction m_pNumberHash;
     bool m_enableParallel;
     unsigned int m_threadNum = -1;
+    GROUP_ID m_groupId;
 };
 
 }  // namespace blockverifier

--- a/libblockverifier/BlockVerifier.h
+++ b/libblockverifier/BlockVerifier.h
@@ -94,14 +94,11 @@ public:
         m_pNumberHash = _pNumberHash;
     }
 
-    void setGroupID(GROUP_ID const& groupId) { m_groupId = groupId; }
-
 private:
     ExecutiveContextFactory::Ptr m_executiveContextFactory;
     NumberHashCallBackFunction m_pNumberHash;
     bool m_enableParallel;
     unsigned int m_threadNum = -1;
-    GROUP_ID m_groupId;
 };
 
 }  // namespace blockverifier

--- a/libblockverifier/Common.h
+++ b/libblockverifier/Common.h
@@ -27,7 +27,8 @@
 #include <libdevcore/easylog.h>
 #include <memory>
 
-#define BLOCKVERIFIER_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("BLOCKVERIFIER")
+#define BLOCKVERIFIER_LOG(LEVEL) \
+    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "]" << LOG_BADGE("BLOCKVERIFIER")
 #define EXECUTIVECONTEXT_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("EXECUTIVECONTEXT")
 #define PARA_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("PARA") << LOG_BADGE(utcTime())
 

--- a/libblockverifier/Common.h
+++ b/libblockverifier/Common.h
@@ -27,8 +27,7 @@
 #include <libdevcore/easylog.h>
 #include <memory>
 
-#define BLOCKVERIFIER_LOG(LEVEL) \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "]" << LOG_BADGE("BLOCKVERIFIER")
+#define BLOCKVERIFIER_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("BLOCKVERIFIER")
 #define EXECUTIVECONTEXT_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("EXECUTIVECONTEXT")
 #define PARA_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("PARA") << LOG_BADGE(utcTime())
 

--- a/libconsensus/Common.h
+++ b/libconsensus/Common.h
@@ -27,11 +27,11 @@
 #include <libdevcore/easylog.h>
 #include <libethcore/Block.h>
 
-#define SEAL_LOG(LEVEL)                                                             \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_consensusEngine->protocolId())) \
+#define SEAL_LOG(LEVEL)                                                            \
+    LOG(LEVEL) << "[p:" << std::to_string(m_consensusEngine->protocolId()) << "] " \
                << LOG_BADGE("CONSENSUS") << LOG_BADGE("SEALER")
-#define ENGINE_LOG(LEVEL)                                                                  \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS") \
+#define ENGINE_LOG(LEVEL)                                                                 \
+    LOG(LEVEL) << "[p:" << std::to_string(m_protocolId) << "] " << LOG_BADGE("CONSENSUS") \
                << LOG_BADGE("ConsensusEngine")
 namespace dev
 {

--- a/libconsensus/Common.h
+++ b/libconsensus/Common.h
@@ -27,13 +27,12 @@
 #include <libdevcore/easylog.h>
 #include <libethcore/Block.h>
 
-#define SEAL_LOG(LEVEL)                                                     \
-    LOG(LEVEL) << "[g:" << std::to_string(m_consensusEngine->groupId())     \
-               << "][p:" << std::to_string(m_consensusEngine->protocolId()) \
-               << "][CONSENSUS][SEAL]"
-#define ENGINE_LOG(LEVEL)                                                                      \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "][p:" << std::to_string(m_protocolId) \
-               << "][CONSENSUS][ConsensusEngine]"
+#define SEAL_LOG(LEVEL)                                                             \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_consensusEngine->protocolId())) \
+               << LOG_BADGE("CONSENSUS") << LOG_BADGE("SEALER")
+#define ENGINE_LOG(LEVEL)                                                                  \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS") \
+               << LOG_BADGE("ConsensusEngine")
 namespace dev
 {
 namespace consensus

--- a/libconsensus/pbft/Common.h
+++ b/libconsensus/pbft/Common.h
@@ -28,14 +28,14 @@
 #include <libethcore/Block.h>
 #include <libethcore/Exceptions.h>
 
-#define PBFTENGINE_LOG(LEVEL)                                                              \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS") \
+#define PBFTENGINE_LOG(LEVEL)                                                             \
+    LOG(LEVEL) << "[p:" << std::to_string(m_protocolId) << "] " << LOG_BADGE("CONSENSUS") \
                << LOG_BADGE("PBFT")
-#define PBFTSEALER_LOG(LEVEL)                                                  \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_pbftEngine->protocolId())) \
+#define PBFTSEALER_LOG(LEVEL)                                                 \
+    LOG(LEVEL) << "[p:" << std::to_string(m_pbftEngine->protocolId()) << "] " \
                << LOG_BADGE("CONSENSUS") << LOG_BADGE("SEALER")
 #define PBFTReqCache_LOG(LEVEL) \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS")
+    LOG(LEVEL) << "[p:" << std::to_string(m_protocolId) << "] " << LOG_BADGE("CONSENSUS")
 namespace dev
 {
 namespace consensus

--- a/libconsensus/pbft/Common.h
+++ b/libconsensus/pbft/Common.h
@@ -27,17 +27,15 @@
 #include <libdevcrypto/Hash.h>
 #include <libethcore/Block.h>
 #include <libethcore/Exceptions.h>
-#define PBFTENGINE_LOG(LEVEL)                                                                  \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "][p:" << std::to_string(m_protocolId) \
-               << "][CONSENSUS][PBFT]"
 
-#define PBFTSEALER_LOG(LEVEL)                                      \
-    LOG(LEVEL) << "[g:" << std::to_string(m_pbftEngine->groupId()) \
-               << "][p:" << std::to_string(m_pbftEngine->protocolId()) << "][CONSENSUS][SEALER]"
-
-#define PBFTReqCache_LOG(LEVEL)                                                                 \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "] [p:" << std::to_string(m_protocolId) \
-               << "][CONSENSUS]"
+#define PBFTENGINE_LOG(LEVEL)                                                              \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS") \
+               << LOG_BADGE("PBFT")
+#define PBFTSEALER_LOG(LEVEL)                                                  \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_pbftEngine->protocolId())) \
+               << LOG_BADGE("CONSENSUS") << LOG_BADGE("SEALER")
+#define PBFTReqCache_LOG(LEVEL) \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS")
 namespace dev
 {
 namespace consensus

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -72,6 +72,10 @@ public:
         m_broadCastCache = std::make_shared<PBFTBroadcastCache>();
         m_reqCache = std::make_shared<PBFTReqCache>(m_protocolId);
 
+        /// set thread name for PBFTEngine
+        std::string threadName = "PBFTEngine-" + std::to_string(m_groupId);
+        setName(threadName);
+
         /// register checkSealerList to blockSync for check SealerList
         m_blockSync->registerConsensusVerifyHandler(boost::bind(&PBFTEngine::checkBlock, this, _1));
     }

--- a/libconsensus/pbft/PBFTReqCache.h
+++ b/libconsensus/pbft/PBFTReqCache.h
@@ -35,8 +35,7 @@ namespace consensus
 class PBFTReqCache : public std::enable_shared_from_this<PBFTReqCache>
 {
 public:
-    PBFTReqCache(dev::PROTOCOL_ID const& protocol) : m_protocolId(protocol)
-    {}
+    PBFTReqCache(dev::PROTOCOL_ID const& protocol) : m_protocolId(protocol) {}
 
     virtual ~PBFTReqCache() { m_futurePrepareCache.clear(); }
     /// specified prepareRequest exists in raw-prepare-cache or not?

--- a/libconsensus/pbft/PBFTReqCache.h
+++ b/libconsensus/pbft/PBFTReqCache.h
@@ -36,9 +36,7 @@ class PBFTReqCache : public std::enable_shared_from_this<PBFTReqCache>
 {
 public:
     PBFTReqCache(dev::PROTOCOL_ID const& protocol) : m_protocolId(protocol)
-    {
-        m_groupId = dev::eth::getGroupAndProtocol(m_protocolId).first;
-    }
+    {}
 
     virtual ~PBFTReqCache() { m_futurePrepareCache.clear(); }
     /// specified prepareRequest exists in raw-prepare-cache or not?
@@ -352,7 +350,6 @@ private:
 
 private:
     dev::PROTOCOL_ID m_protocolId;
-    dev::GROUP_ID m_groupId;
     /// cache for prepare request
     PrepareReq m_prepareCache = PrepareReq();
     /// cache for raw prepare request

--- a/libconsensus/pbft/PBFTSealer.h
+++ b/libconsensus/pbft/PBFTSealer.h
@@ -55,6 +55,10 @@ public:
         /// called by the next leader to reset block when it receives the prepare block
         m_pbftEngine->onNotifyNextLeaderReset(
             boost::bind(&PBFTSealer::resetBlockForNextLeader, this, _1));
+
+        /// set thread name for PBFTSealer
+        std::string threadName = "PBFTSealer-" + std::to_string(m_pbftEngine->groupId());
+        setName(threadName);
     }
 
     void start() override;

--- a/libconsensus/raft/Common.h
+++ b/libconsensus/raft/Common.h
@@ -31,11 +31,11 @@
 #include <libdevcrypto/Common.h>
 #include <libethcore/Exceptions.h>
 
-#define RAFTENGINE_LOG(LEVEL)                                                              \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS") \
+#define RAFTENGINE_LOG(LEVEL)                                                             \
+    LOG(LEVEL) << "[p:" << std::to_string(m_protocolId) << "] " << LOG_BADGE("CONSENSUS") \
                << LOG_BADGE("RAFTENGINE")
-#define RAFTSEALER_LOG(LEVEL)                                                  \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_raftEngine->protocolId())) \
+#define RAFTSEALER_LOG(LEVEL)                                                 \
+    LOG(LEVEL) << "[p:" << std::to_string(m_raftEngine->protocolId()) << "] " \
                << LOG_BADGE("CONSENSUS") << LOG_BADGE("RAFTSEALER")
 
 namespace dev

--- a/libconsensus/raft/Common.h
+++ b/libconsensus/raft/Common.h
@@ -31,14 +31,11 @@
 #include <libdevcrypto/Common.h>
 #include <libethcore/Exceptions.h>
 
-#define RAFTENGINE_LOG(LEVEL)                                                            \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "]"                              \
-               << "[p:" << std::to_string(m_protocolId) << "]" << LOG_BADGE("CONSENSUS") \
+#define RAFTENGINE_LOG(LEVEL)                                                              \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("CONSENSUS") \
                << LOG_BADGE("RAFTENGINE")
-
-#define RAFTSEALER_LOG(LEVEL)                                                \
-    LOG(LEVEL) << "[g:" << std::to_string(m_raftEngine->groupId()) << "]"    \
-               << "[p:" << std::to_string(m_raftEngine->protocolId()) << "]" \
+#define RAFTSEALER_LOG(LEVEL)                                                  \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_raftEngine->protocolId())) \
                << LOG_BADGE("CONSENSUS") << LOG_BADGE("RAFTSEALER")
 
 namespace dev

--- a/libconsensus/raft/RaftEngine.h
+++ b/libconsensus/raft/RaftEngine.h
@@ -69,6 +69,9 @@ public:
         m_service->registerHandlerByProtoclID(
             m_protocolId, boost::bind(&RaftEngine::onRecvRaftMessage, this, _1, _2, _3));
         m_blockSync->registerConsensusVerifyHandler([](dev::eth::Block const&) { return true; });
+        /// set thread name for raftEngine
+        std::string threadName = "RaftEngine-" + std::to_string(m_groupId);
+        setName(threadName);
     }
 
     raft::NodeIndex getNodeIdx() const

--- a/libconsensus/raft/RaftSealer.h
+++ b/libconsensus/raft/RaftSealer.h
@@ -46,6 +46,10 @@ public:
         m_consensusEngine = std::make_shared<RaftEngine>(_service, _txPool, _blockChain, _blockSync,
             _blockVerifier, _keyPair, _minElectTime, _maxElectTime, _protocolId, _sealerList);
         m_raftEngine = std::dynamic_pointer_cast<RaftEngine>(m_consensusEngine);
+
+        /// set thread name for PBFTSealer
+        std::string threadName = "RaftSealer-" + std::to_string(m_raftEngine->groupId());
+        setName(threadName);
     }
     void start() override;
     void stop() override;

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -22,6 +22,8 @@
  */
 #pragma once
 
+#include <boost/log/attributes/constant.hpp>
+#include <boost/log/attributes/scoped_attribute.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/trivial.hpp>
 

--- a/libdevcore/SnappyCompress.cpp
+++ b/libdevcore/SnappyCompress.cpp
@@ -40,11 +40,12 @@ size_t SnappyCompress::compress(bytesConstRef inputData, bytes& compressedData)
         LOG(ERROR) << LOG_BADGE("SnappyCompressio") << LOG_DESC("compress failed");
         return 0;
     }
+#if 0
     LOG(DEBUG) << LOG_BADGE("SnappyCompress") << LOG_DESC("Compress")
                << LOG_KV("org_len", inputData.size()) << LOG_KV("compressed_len", compressLen)
                << LOG_KV("ratio", (float)inputData.size() / (float)compressedData.size())
                << LOG_KV("timecost", (utcTimeUs() - start_t));
-
+#endif
 
     return compressLen;
 }
@@ -64,11 +65,13 @@ size_t SnappyCompress::uncompress(bytesConstRef compressedData, bytes& uncompres
         LOG(ERROR) << LOG_BADGE("SnappyCompressio") << LOG_DESC("uncompress failed");
         return 0;
     }
+#if 0
     LOG(DEBUG) << LOG_BADGE("SnappyCompressio") << LOG_DESC("uncompress")
                << LOG_KV("org_len", uncompressedLen)
                << LOG_KV("compress_len", compressedData.size())
                << LOG_KV("ratio", (float)uncompressedLen / (float)compressedData.size())
                << LOG_KV("timecost", (utcTimeUs() - start_t));
+#endif
     return uncompressedLen;
 }
 }  // namespace compress

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -54,17 +54,20 @@ void Worker::startWorking()
         m_work.reset(new thread([&]() {
 /// set threadName for log
 #ifndef FISCO_EASYLOG
-            std::vector<std::string> fields;
-            boost::split(fields, m_name, boost::is_any_of("-"), boost::token_compress_on);
-            if (fields.size() > 0)
+            if (boost::log::core::get())
             {
-                boost::log::core::get()->add_thread_attribute(
-                    "ThreadName", boost::log::attributes::constant<std::string>(fields[1]));
-            }
-            else
-            {
-                boost::log::core::get()->add_thread_attribute(
-                    "ThreadName", boost::log::attributes::constant<std::string>(fields[0]));
+                std::vector<std::string> fields;
+                boost::split(fields, m_name, boost::is_any_of("-"), boost::token_compress_on);
+                if (fields.size() > 0)
+                {
+                    boost::log::core::get()->add_thread_attribute(
+                        "ThreadName", boost::log::attributes::constant<std::string>(fields[1]));
+                }
+                else
+                {
+                    boost::log::core::get()->add_thread_attribute(
+                        "ThreadName", boost::log::attributes::constant<std::string>(fields[0]));
+                }
             }
 #endif
             setThreadName(m_name.c_str());

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -24,7 +24,6 @@
 #include <pthread.h>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/log/attributes/constant.hpp>
 #include <chrono>
 #include <thread>
 using namespace std;

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -58,15 +58,10 @@ void Worker::startWorking()
             {
                 std::vector<std::string> fields;
                 boost::split(fields, m_name, boost::is_any_of("-"), boost::token_compress_on);
-                if (fields.size() > 0)
+                if (fields.size() > 1)
                 {
                     boost::log::core::get()->add_thread_attribute(
                         "ThreadName", boost::log::attributes::constant<std::string>(fields[1]));
-                }
-                else
-                {
-                    boost::log::core::get()->add_thread_attribute(
-                        "ThreadName", boost::log::attributes::constant<std::string>(fields[0]));
                 }
             }
 #endif

--- a/libdevcore/Worker.cpp
+++ b/libdevcore/Worker.cpp
@@ -52,7 +52,8 @@ void Worker::startWorking()
         m_state = WorkerState::Starting;
         m_state_notifier.notify_all();
         m_work.reset(new thread([&]() {
-            /// set threadName for log
+/// set threadName for log
+#ifndef FISCO_EASYLOG
             std::vector<std::string> fields;
             boost::split(fields, m_name, boost::is_any_of("-"), boost::token_compress_on);
             if (fields.size() > 0)
@@ -65,6 +66,7 @@ void Worker::startWorking()
                 boost::log::core::get()->add_thread_attribute(
                     "ThreadName", boost::log::attributes::constant<std::string>(fields[0]));
             }
+#endif
             setThreadName(m_name.c_str());
             while (m_state != WorkerState::Killing)
             {

--- a/libdevcore/Worker.h
+++ b/libdevcore/Worker.h
@@ -67,6 +67,7 @@ protected:
     virtual ~Worker() { terminate(); }
 
     /// Allows changing worker name if work is stopped.
+    /// m_name: ${module}-${groupID}
     void setName(std::string const& _n)
     {
         if (!isWorking())

--- a/libinitializer/BoostLogInitializer.cpp
+++ b/libinitializer/BoostLogInitializer.cpp
@@ -28,6 +28,7 @@ namespace logging = boost::log;
 namespace expr = boost::log::expressions;
 
 BOOST_LOG_ATTRIBUTE_KEYWORD(thread_name, "ThreadName", std::string)
+BOOST_LOG_ATTRIBUTE_KEYWORD(group_id, "GroupId", std::string)
 
 using namespace dev::initializer;
 int LogInitializer::m_currentHour =
@@ -79,8 +80,9 @@ void LogInitializer::initLog(
         << boost::log::expressions::attr<boost::log::trivial::severity_level>("Severity") << "|"
         << boost::log::expressions::format_date_time<boost::posix_time::ptime>(
                "TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
-        << "|"
-        << expr::if_(expr::has_attr(thread_name))[expr::stream << "[g:" << thread_name << "] "]
+        << "|" << expr::if_(expr::has_attr(group_id))[expr::stream << "[g:" << group_id << "] "]
+        << expr::if_(expr::has_attr(thread_name) &&
+                     !expr::has_attr(group_id))[expr::stream << "[g:" << thread_name << "] "]
         << boost::log::expressions::smessage);
     /// set log level
     unsigned log_level = getLogLevel(pt.get<std::string>("log.level", "info"));

--- a/libinitializer/BoostLogInitializer.cpp
+++ b/libinitializer/BoostLogInitializer.cpp
@@ -80,9 +80,9 @@ void LogInitializer::initLog(
         << boost::log::expressions::attr<boost::log::trivial::severity_level>("Severity") << "|"
         << boost::log::expressions::format_date_time<boost::posix_time::ptime>(
                "TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
-        << "|" << expr::if_(expr::has_attr(group_id))[expr::stream << "[g:" << group_id << "] "]
+        << "|" << expr::if_(expr::has_attr(group_id))[expr::stream << "[g:" << group_id << "]"]
         << expr::if_(expr::has_attr(thread_name) &&
-                     !expr::has_attr(group_id))[expr::stream << "[g:" << thread_name << "] "]
+                     !expr::has_attr(group_id))[expr::stream << "[g:" << thread_name << "]"]
         << boost::log::expressions::smessage);
     /// set log level
     unsigned log_level = getLogLevel(pt.get<std::string>("log.level", "info"));

--- a/libinitializer/BoostLogInitializer.cpp
+++ b/libinitializer/BoostLogInitializer.cpp
@@ -24,6 +24,11 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/log/support/date_time.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
+namespace logging = boost::log;
+namespace expr = boost::log::expressions;
+
+BOOST_LOG_ATTRIBUTE_KEYWORD(thread_name, "ThreadName", std::string)
+
 using namespace dev::initializer;
 int LogInitializer::m_currentHour =
     (int)boost::posix_time::second_clock::local_time().time_of_day().hours();
@@ -67,14 +72,16 @@ void LogInitializer::initLog(
     /// set auto-flush according to log configuration
     bool need_flush = pt.get<bool>("log.flush", true);
     sink->locked_backend()->auto_flush(need_flush);
-
     /// set file format
+    /// log-level|timestamp |[g:groupId] message
     sink->set_formatter(
-        boost::log::expressions::format("%1%|%2%| %3%") %
-        boost::log::expressions::attr<boost::log::trivial::severity_level>("Severity") %
-        boost::log::expressions::format_date_time<boost::posix_time::ptime>(
-            "TimeStamp", "%Y-%m-%d %H:%M:%S.%f") %
-        boost::log::expressions::smessage);
+        expr::stream
+        << boost::log::expressions::attr<boost::log::trivial::severity_level>("Severity") << "|"
+        << boost::log::expressions::format_date_time<boost::posix_time::ptime>(
+               "TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
+        << "|"
+        << expr::if_(expr::has_attr(thread_name))[expr::stream << "[g:" << thread_name << "] "]
+        << boost::log::expressions::smessage);
     /// set log level
     unsigned log_level = getLogLevel(pt.get<std::string>("log.level", "info"));
     sink->set_filter(boost::log::expressions::attr<std::string>("Channel") == channel &&

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -463,6 +463,7 @@ bool Ledger::initBlockVerifier()
     std::shared_ptr<BlockChainImp> blockChain =
         std::dynamic_pointer_cast<BlockChainImp>(m_blockChain);
     blockVerifier->setNumberHash(boost::bind(&BlockChainImp::numberHash, blockChain, _1));
+    blockVerifier->setGroupID(m_groupId);
     m_blockVerifier = blockVerifier;
     Ledger_LOG(DEBUG) << LOG_BADGE("initLedger") << LOG_BADGE("initBlockVerifier SUCC");
     return true;
@@ -480,6 +481,7 @@ bool Ledger::initBlockChain(GenesisBlockParam& _genesisParam)
     std::shared_ptr<BlockChainImp> blockChain = std::make_shared<BlockChainImp>();
     blockChain->setStateStorage(m_dbInitializer->storage());
     blockChain->setTableFactoryFactory(m_dbInitializer->tableFactoryFactory());
+    blockChain->setGroupID(m_groupId);
     m_blockChain = blockChain;
     bool ret = m_blockChain->checkAndBuildGenesisBlock(_genesisParam);
     if (!ret)

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -463,7 +463,6 @@ bool Ledger::initBlockVerifier()
     std::shared_ptr<BlockChainImp> blockChain =
         std::dynamic_pointer_cast<BlockChainImp>(m_blockChain);
     blockVerifier->setNumberHash(boost::bind(&BlockChainImp::numberHash, blockChain, _1));
-    blockVerifier->setGroupID(m_groupId);
     m_blockVerifier = blockVerifier;
     Ledger_LOG(DEBUG) << LOG_BADGE("initLedger") << LOG_BADGE("initBlockVerifier SUCC");
     return true;
@@ -481,7 +480,6 @@ bool Ledger::initBlockChain(GenesisBlockParam& _genesisParam)
     std::shared_ptr<BlockChainImp> blockChain = std::make_shared<BlockChainImp>();
     blockChain->setStateStorage(m_dbInitializer->storage());
     blockChain->setTableFactoryFactory(m_dbInitializer->tableFactoryFactory());
-    blockChain->setGroupID(m_groupId);
     m_blockChain = blockChain;
     bool ret = m_blockChain->checkAndBuildGenesisBlock(_genesisParam);
     if (!ret)

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -51,9 +51,10 @@ namespace ledger
 {
 bool Ledger::initLedger(const std::string& _configFilePath)
 {
+#ifndef FISCO_EASYLOG
     BOOST_LOG_SCOPED_THREAD_ATTR(
         "GroupId", boost::log::attributes::constant<std::string>(std::to_string(m_groupId)));
-
+#endif
     Ledger_LOG(INFO) << LOG_DESC("LedgerConstructor") << LOG_KV("configPath", _configFilePath)
                      << LOG_KV("baseDir", m_param->baseDir());
     /// The file group.X.genesis is required, otherwise the program terminates.

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -51,6 +51,9 @@ namespace ledger
 {
 bool Ledger::initLedger(const std::string& _configFilePath)
 {
+    BOOST_LOG_SCOPED_THREAD_ATTR(
+        "GroupId", boost::log::attributes::constant<std::string>(std::to_string(m_groupId)));
+
     Ledger_LOG(INFO) << LOG_DESC("LedgerConstructor") << LOG_KV("configPath", _configFilePath)
                      << LOG_KV("baseDir", m_param->baseDir());
     /// The file group.X.genesis is required, otherwise the program terminates.
@@ -76,6 +79,8 @@ bool Ledger::initLedger(const std::string& _configFilePath)
     if (!m_dbInitializer)
         return false;
     m_dbInitializer->initStorageDB();
+    /// set group ID for storage
+    m_dbInitializer->storage()->setGroupID(m_groupId);
     /// init the DB
     bool ret = initBlockChain(genesisParam);
     if (!ret)

--- a/libledger/Ledger.h
+++ b/libledger/Ledger.h
@@ -34,7 +34,7 @@
 #include <libp2p/Service.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/ptree.hpp>
-#define Ledger_LOG(LEVEL) LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "][LEDGER]"
+#define Ledger_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("LEDGER")
 
 namespace dev
 {
@@ -75,6 +75,10 @@ public:
     void startAll() override
     {
         assert(m_sync && m_sealer);
+        /// tag this scope with GroupId
+        BOOST_LOG_SCOPED_THREAD_ATTR(
+            "GroupId", boost::log::attributes::constant<std::string>(std::to_string(m_groupId)));
+
         Ledger_LOG(INFO) << LOG_DESC("startAll...");
         m_sync->start();
         m_sealer->start();

--- a/libledger/Ledger.h
+++ b/libledger/Ledger.h
@@ -75,9 +75,11 @@ public:
     void startAll() override
     {
         assert(m_sync && m_sealer);
+#ifndef FISCO_EASYLOG
         /// tag this scope with GroupId
         BOOST_LOG_SCOPED_THREAD_ATTR(
             "GroupId", boost::log::attributes::constant<std::string>(std::to_string(m_groupId)));
+#endif
 
         Ledger_LOG(INFO) << LOG_DESC("startAll...");
         m_sync->start();

--- a/libnetwork/Common.h
+++ b/libnetwork/Common.h
@@ -50,7 +50,7 @@
 namespace ba = boost::asio;
 namespace bi = boost::asio::ip;
 #define HOST_LOG(LEVEL) LOG(LEVEL) << "[NETWORK][Host]"
-#define SESSION_LOG(LEVEL) LOG(LEVEL) << "[NETWORK][Seeion]"
+#define SESSION_LOG(LEVEL) LOG(LEVEL) << "[NETWORK][Session]"
 
 namespace dev
 {

--- a/libstorage/CachedStorage.cpp
+++ b/libstorage/CachedStorage.cpp
@@ -108,7 +108,7 @@ tbb::concurrent_unordered_map<std::string, Caches::Ptr>* TableCaches::caches()
 
 CachedStorage::CachedStorage()
 {
-    LOG(INFO) << "Init flushStorage thread";
+    CACHED_STORAGE_LOG(INFO) << "Init flushStorage thread";
     m_taskThreadPool = std::make_shared<dev::ThreadPool>("FlushStorage", 1);
     m_syncNum.store(0);
     m_commitNum.store(0);
@@ -123,8 +123,8 @@ CachedStorage::~CachedStorage()
 Entries::Ptr CachedStorage::select(
     h256 hash, int num, TableInfo::Ptr tableInfo, const std::string& key, Condition::Ptr condition)
 {
-    STORAGE_LOG(TRACE) << "Query data from cachedStorage table: " << tableInfo->name
-                       << " key: " << key;
+    CACHED_STORAGE_LOG(TRACE) << "Query data from cachedStorage table: " << tableInfo->name
+                              << " key: " << key;
     auto out = std::make_shared<Entries>();
 
     auto entries = selectNoCondition(hash, num, tableInfo, key, condition)->entries();
@@ -190,7 +190,7 @@ Caches::Ptr CachedStorage::selectNoCondition(
             tableIt->second->setTableInfo(tableInfo);
         }
 
-        STORAGE_LOG(DEBUG) << tableInfo->name << "-" << key << " miss the cache";
+        CACHED_STORAGE_LOG(DEBUG) << tableInfo->name << "-" << key << " miss the cache";
 
         auto caches = std::make_shared<Caches>();
         caches->setKey(key);
@@ -204,8 +204,8 @@ Caches::Ptr CachedStorage::selectNoCondition(
             totalCapacity += it->capacity();
         }
 
-        LOG(TRACE) << "backend capacity: " << tableInfo->name << "-" << key
-                   << ", capacity: " << totalCapacity;
+        CACHED_STORAGE_LOG(TRACE) << "backend capacity: " << tableInfo->name << "-" << key
+                                  << ", capacity: " << totalCapacity;
         updateCapacity(0, totalCapacity);
         touchMRU(tableInfo->name, key);
 
@@ -217,7 +217,7 @@ Caches::Ptr CachedStorage::selectNoCondition(
 
 size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas)
 {
-    STORAGE_LOG(TRACE) << "CachedStorage commit: " << datas.size();
+    CACHED_STORAGE_LOG(TRACE) << "CachedStorage commit: " << datas.size();
 
     tbb::atomic<size_t> total = 0;
 
@@ -272,9 +272,10 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
                                         (*entryIt)->setField(fieldIt.first, fieldIt.second);
                                     }
 
-                                    LOG(TRACE) << "update capacity: " << commitData->info->name
-                                               << "-" << key << ", from capacity: " << oldSize
-                                               << " to capacity: " << (*entryIt)->capacity();
+                                    CACHED_STORAGE_LOG(TRACE)
+                                        << "update capacity: " << commitData->info->name << "-"
+                                        << key << ", from capacity: " << oldSize
+                                        << " to capacity: " << (*entryIt)->capacity();
                                     updateCapacity(oldSize, (*entryIt)->capacity());
 
                                     (*entryIt)->setNum(num);
@@ -285,7 +286,7 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
                                 }
                                 else
                                 {
-                                    STORAGE_LOG(ERROR)
+                                    CACHED_STORAGE_LOG(ERROR)
                                         << "Can not find entry in cache, id:" << entry->getID()
                                         << " key:" << key;
 
@@ -320,7 +321,7 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
             auto commitEntry = commitData->newEntries->get(j);
             commitEntry->setID(++m_ID);
 
-            LOG(TRACE) << "Set new entry ID: " << m_ID;
+            CACHED_STORAGE_LOG(TRACE) << "Set new entry ID: " << m_ID;
         }
     }
 
@@ -372,8 +373,9 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
                             }
 
                             cacheEntry->setNum(num);
-                            LOG(TRACE) << "new cached: " << commitData->info->name << "-" << key
-                                       << ", capacity: " << cacheEntry->capacity();
+                            CACHED_STORAGE_LOG(TRACE)
+                                << "new cached: " << commitData->info->name << "-" << key
+                                << ", capacity: " << cacheEntry->capacity();
                             updateCapacity(0, cacheEntry->capacity());
                             touchMRU(commitData->info->name, key);
                         }
@@ -419,7 +421,6 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
         auto now = std::chrono::system_clock::now();
         STORAGE_LOG(INFO) << "Start commit block: " << task->num << " to backend storage";
         backend->commit(task->hash, task->num, *(task->datas));
-
         auto storage = self.lock();
         if (storage)
         {
@@ -427,6 +428,7 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
 
             std::chrono::duration<double> elapsed = std::chrono::system_clock::now() - now;
             STORAGE_LOG(INFO)
+                << LOG_BADGE("g:" + std::to_string(storage->groupID()))
                 << "\n---------------------------------------------------------------------\n"
                 << "Commit block: " << task->num
                 << " to backend storage finished, current cached block: " << storage->m_commitNum
@@ -445,7 +447,8 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
         }
     });
 
-    STORAGE_LOG(INFO) << "Submited block task: " << num << ", current syncd block: " << m_syncNum;
+    CACHED_STORAGE_LOG(INFO) << "Submited block task: " << num
+                             << ", current syncd block: " << m_syncNum;
     checkAndClear();
 
     return total;
@@ -541,15 +544,16 @@ void CachedStorage::checkAndClear()
 
         if ((size_t)(m_commitNum - m_syncNum) > m_maxForwardBlock)
         {
-            STORAGE_LOG(INFO) << "Current block number: " << m_commitNum
-                              << " greater than syncd block number: " << m_syncNum
-                              << ", waiting...";
+            CACHED_STORAGE_LOG(INFO)
+                << "Current block number: " << m_commitNum
+                << " greater than syncd block number: " << m_syncNum << ", waiting...";
             needClear = true;
         }
         else if (m_capacity > (int64_t)m_maxCapacity)
         {
-            STORAGE_LOG(INFO) << "Current capacity: " << m_capacity
-                              << " greater than max capacity: " << m_maxCapacity << ", waiting...";
+            CACHED_STORAGE_LOG(INFO)
+                << "Current capacity: " << m_capacity
+                << " greater than max capacity: " << m_maxCapacity << ", waiting...";
             needClear = true;
         }
 
@@ -565,28 +569,30 @@ void CachedStorage::checkAndClear()
                     {
                         if ((size_t)cache->num() <= m_syncNum)
                         {
-                            STORAGE_LOG(DEBUG)
+                            CACHED_STORAGE_LOG(DEBUG)
                                 << "Clear last recent record: "
                                 << tableIt->second->tableInfo()->name << "-" << it->second;
 
                             size_t totalCapacity = 0;
                             for (auto entryIt : *(cache->entries()))
                             {
-                                LOG(TRACE) << "entry remove capacity: "
-                                           << tableIt->second->tableInfo()->name << "-"
-                                           << it->second << ", capacity: " << entryIt->capacity();
+                                CACHED_STORAGE_LOG(TRACE)
+                                    << "entry remove capacity: "
+                                    << tableIt->second->tableInfo()->name << "-" << it->second
+                                    << ", capacity: " << entryIt->capacity();
                                 for (auto fieldIt : *(entryIt->fields()))
                                 {
-                                    STORAGE_LOG(TRACE) << "field: " << fieldIt.first
-                                                       << ", value: " << fieldIt.second;
+                                    CACHED_STORAGE_LOG(TRACE) << "field: " << fieldIt.first
+                                                              << ", value: " << fieldIt.second;
                                 }
                                 totalCapacity += entryIt->capacity();
                             }
 
                             ++clearCount;
 
-                            LOG(TRACE) << "remove capacity: " << tableIt->second->tableInfo()->name
-                                       << "-" << it->second << ", capacity: " << totalCapacity;
+                            CACHED_STORAGE_LOG(TRACE)
+                                << "remove capacity: " << tableIt->second->tableInfo()->name << "-"
+                                << it->second << ", capacity: " << totalCapacity;
                             updateCapacity(totalCapacity, 0);
 
                             tableIt->second->removeCache(it->second);
@@ -620,11 +626,11 @@ void CachedStorage::checkAndClear()
     if (clearTimes > 0)
     {
         std::chrono::duration<double> elapsed = std::chrono::system_clock::now() - now;
-        LOG(INFO) << "Clear finished, total: " << clearCount << " entries, "
-                  << readableCapacity(currentCapacity - m_capacity)
-                  << " capacity, elapsed: " << elapsed.count() << "s\n"
-                  << "Current total cached entries: " << m_mru.size()
-                  << ", total capacaity: " << readableCapacity(m_capacity);
+        CACHED_STORAGE_LOG(INFO) << "Clear finished, total: " << clearCount << " entries, "
+                                 << readableCapacity(currentCapacity - m_capacity)
+                                 << " capacity, elapsed: " << elapsed.count() << "s\n"
+                                 << "Current total cached entries: " << m_mru.size()
+                                 << ", total capacaity: " << readableCapacity(m_capacity);
     }
 }
 
@@ -633,8 +639,8 @@ void CachedStorage::updateCapacity(ssize_t oldSize, ssize_t newSize)
     // m_capacity += (newSize - oldSize);
     auto oldValue = m_capacity.fetch_and_add((newSize - oldSize));
 
-    LOG(TRACE) << "Capacity change by: " << (newSize - oldSize) << " , from: " << oldValue
-               << " to: " << m_capacity;
+    CACHED_STORAGE_LOG(TRACE) << "Capacity change by: " << (newSize - oldSize)
+                              << " , from: " << oldValue << " to: " << m_capacity;
 }
 
 std::string CachedStorage::readableCapacity(size_t num)

--- a/libstorage/CachedStorage.cpp
+++ b/libstorage/CachedStorage.cpp
@@ -468,7 +468,7 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
 
                 std::chrono::duration<double> elapsed = std::chrono::system_clock::now() - now;
                 STORAGE_LOG(INFO)
-                    << LOG_BADGE("g:" + std::to_string(storage->groupID()))
+                    << "[g:" << std::to_string(storage->groupID()) << "]"
                     << "\n---------------------------------------------------------------------\n"
                     << "Commit block: " << task->num
                     << " to backend storage finished, current cached block: "

--- a/libstorage/CachedStorage.cpp
+++ b/libstorage/CachedStorage.cpp
@@ -697,13 +697,20 @@ std::string CachedStorage::readableCapacity(size_t num)
     {
         capacityNum << std::setiosflags(std::ios::fixed) << std::setprecision(4)
                     << ((double)num / (1024 * 1024 * 1024)) << " GB";
-        else if (num > 1024 * 1024)
-        {
-            {
-                capacityNum << std::setiosflags(std::ios::fixed) << std::setprecision(4)
-                            << ((double)num / (1024)) << " KB";
-            }
-            else { capacityNum << num << " B"; }
-
-            return capacityNum.str();
-        }
+    }
+    else if (num > 1024 * 1024)
+    {
+        capacityNum << std::setiosflags(std::ios::fixed) << std::setprecision(4)
+                    << ((double)num / (1024 * 1024)) << " MB";
+    }
+    else if (num > 1024)
+    {
+        capacityNum << std::setiosflags(std::ios::fixed) << std::setprecision(4)
+                    << ((double)num / (1024)) << " KB";
+    }
+    else
+    {
+        capacityNum << num << " B";
+    }
+    return capacityNum.str();
+}

--- a/libstorage/Common.h
+++ b/libstorage/Common.h
@@ -26,7 +26,8 @@ namespace dev
 namespace storage
 {
 #define STORAGE_LOG(LEVEL) LOG(LEVEL) << "[STORAGE]"
-#define STORAGE_LEVELDB_LOG(LEVEL) LOG(LEVEL) << "[STORAGE] [LEVELDB]"
+#define STORAGE_LEVELDB_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("STORAGE") << LOG_BADGE("LEVELDB")
+#define CACHED_STORAGE_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("STORAGE") << LOG_BADGE("CachedStorage")
 
 /// \brief Sign of the DB key is valid or not
 const char* const ID_FIELD = "_id_";

--- a/libstorage/Common.h
+++ b/libstorage/Common.h
@@ -27,8 +27,8 @@ namespace storage
 {
 #define STORAGE_LOG(LEVEL) LOG(LEVEL) << "[STORAGE]"
 #define STORAGE_LEVELDB_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("STORAGE") << LOG_BADGE("LEVELDB")
-#define CACHED_STORAGE_LOG(LEVEL)                                                     \
-    LOG(LEVEL) << LOG_BADGE("g:" + std::to_string(groupID())) << LOG_BADGE("STORAGE") \
+#define CACHED_STORAGE_LOG(LEVEL)                                                   \
+    LOG(LEVEL) << "[g:" << std::to_string(groupID()) << "]" << LOG_BADGE("STORAGE") \
                << LOG_BADGE("CachedStorage")
 
 /// \brief Sign of the DB key is valid or not

--- a/libstorage/Common.h
+++ b/libstorage/Common.h
@@ -27,7 +27,9 @@ namespace storage
 {
 #define STORAGE_LOG(LEVEL) LOG(LEVEL) << "[STORAGE]"
 #define STORAGE_LEVELDB_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("STORAGE") << LOG_BADGE("LEVELDB")
-#define CACHED_STORAGE_LOG(LEVEL) LOG(LEVEL) << LOG_BADGE("STORAGE") << LOG_BADGE("CachedStorage")
+#define CACHED_STORAGE_LOG(LEVEL)                                                     \
+    LOG(LEVEL) << LOG_BADGE("g:" + std::to_string(groupID())) << LOG_BADGE("STORAGE") \
+               << LOG_BADGE("CachedStorage")
 
 /// \brief Sign of the DB key is valid or not
 const char* const ID_FIELD = "_id_";

--- a/libstorage/Storage.h
+++ b/libstorage/Storage.h
@@ -22,6 +22,7 @@
 
 #include "Table.h"
 #include <libdevcore/FixedHash.h>
+#include <libethcore/Protocol.h>
 
 namespace dev
 {
@@ -39,6 +40,12 @@ public:
     virtual size_t commit(h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas) = 0;
 
     virtual bool onlyDirty() = 0;
+
+    void setGroupID(dev::GROUP_ID const& groupID) { m_groupID = groupID; }
+    dev::GROUP_ID groupID() const { return m_groupID; }
+
+protected:
+    dev::GROUP_ID m_groupID = 0;
 };
 
 }  // namespace storage

--- a/libsync/Common.h
+++ b/libsync/Common.h
@@ -66,9 +66,12 @@ using NodeIDs = std::vector<dev::p2p::NodeID>;
 using BlockPtr = std::shared_ptr<dev::eth::Block>;
 using BlockPtrVec = std::vector<BlockPtr>;
 
-#define SYNC_LOG(_OBV)                                                               \
-    LOG(_OBV) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("SYNC") \
-              << LOG_BADGE("id:" + m_nodeId.abridged())
+#define PUBLIC_LOG                                 \
+    LOG_BADGE("p:" + std::to_string(m_protocolId)) \
+        << LOG_BADGE("SYNC") << LOG_BADGE("id:" + m_nodeId.abridged())
+
+#define SYNC_LOG(_OBV) LOG(_OBV) << PUBLIC_LOG
+#define SYNC_ENGINE_LOG(_OBV) LOG(_OBV) << LOG_BADGE("g:" + std::to_string(m_groupId)) << PUBLIC_LOG
 
 enum SyncPacketType : byte
 {

--- a/libsync/Common.h
+++ b/libsync/Common.h
@@ -66,9 +66,9 @@ using NodeIDs = std::vector<dev::p2p::NodeID>;
 using BlockPtr = std::shared_ptr<dev::eth::Block>;
 using BlockPtrVec = std::vector<BlockPtr>;
 
-#define SYNC_LOG(_OBV)                                     \
-    LOG(_OBV) << "[g:" << std::to_string(m_groupId) << "]" \
-              << "[p:" << std::dec << m_protocolId << "][SYNC][id:" << m_nodeId.abridged() << "]"
+#define SYNC_LOG(_OBV)                                                               \
+    LOG(_OBV) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("SYNC") \
+              << LOG_BADGE("id:" + m_nodeId.abridged())
 
 enum SyncPacketType : byte
 {

--- a/libsync/Common.h
+++ b/libsync/Common.h
@@ -66,12 +66,12 @@ using NodeIDs = std::vector<dev::p2p::NodeID>;
 using BlockPtr = std::shared_ptr<dev::eth::Block>;
 using BlockPtrVec = std::vector<BlockPtr>;
 
-#define PUBLIC_LOG                                 \
-    LOG_BADGE("p:" + std::to_string(m_protocolId)) \
-        << LOG_BADGE("SYNC") << LOG_BADGE("id:" + m_nodeId.abridged())
+#define PUBLIC_LOG                                                     \
+    "[p:" << std::to_string(m_protocolId) << "] " << LOG_BADGE("SYNC") \
+          << LOG_BADGE("id:" + m_nodeId.abridged())
 
 #define SYNC_LOG(_OBV) LOG(_OBV) << PUBLIC_LOG
-#define SYNC_ENGINE_LOG(_OBV) LOG(_OBV) << LOG_BADGE("g:" + std::to_string(m_groupId)) << PUBLIC_LOG
+#define SYNC_ENGINE_LOG(_OBV) LOG(_OBV) << "[g:" << std::to_string(m_groupId) << "] " << PUBLIC_LOG
 
 enum SyncPacketType : byte
 {

--- a/libsync/DownloadingBlockQueue.h
+++ b/libsync/DownloadingBlockQueue.h
@@ -68,9 +68,7 @@ public:
         m_nodeId(_nodeId),
         m_blocks(),
         m_buffer(std::make_shared<ShardPtrVec>())
-    {
-        m_groupId = dev::eth::getGroupAndProtocol(m_protocolId).first;
-    }
+    {}
 
     DownloadingBlockQueue()
       : m_blockChain(nullptr),
@@ -110,7 +108,6 @@ private:
     std::shared_ptr<dev::blockchain::BlockChainInterface> m_blockChain;
     PROTOCOL_ID m_protocolId;
     NodeID m_nodeId;
-    GROUP_ID m_groupId;
 
     std::priority_queue<BlockPtr, BlockPtrVec, BlockQueueCmp> m_blocks;  //
     std::shared_ptr<ShardPtrVec> m_buffer;  // use buffer for faster push return

--- a/libsync/DownloadingTxsQueue.h
+++ b/libsync/DownloadingTxsQueue.h
@@ -48,7 +48,6 @@ class DownloadingTxsQueue
 public:
     DownloadingTxsQueue(PROTOCOL_ID const& _protocolId, NodeID const& _nodeId)
       : m_protocolId(_protocolId),
-        m_groupId(dev::eth::getGroupAndProtocol(_protocolId).first),
         m_nodeId(_nodeId),
         m_buffer(std::make_shared<std::vector<DownloadTxsShard>>())
     {}
@@ -61,7 +60,6 @@ public:
 
 private:
     PROTOCOL_ID m_protocolId;
-    GROUP_ID m_groupId;
     NodeID m_nodeId;
     std::shared_ptr<std::vector<DownloadTxsShard>> m_buffer;
     mutable SharedMutex x_buffer;

--- a/libsync/RspBlockReq.h
+++ b/libsync/RspBlockReq.h
@@ -65,7 +65,6 @@ public:
 private:
     NodeID m_nodeId;
     PROTOCOL_ID m_protocolId = 0;
-    GROUP_ID m_groupId = 0;
     std::priority_queue<DownloadRequest, std::vector<DownloadRequest>, RequestQueueCmp> m_reqQueue;
     mutable std::mutex x_canPush;  // pop() wait for push(), push() drop when pop()
     mutable std::mutex x_push;     // To serialize push()

--- a/libsync/SyncMaster.h
+++ b/libsync/SyncMaster.h
@@ -74,6 +74,10 @@ public:
         // signal registration
         m_tqReady = m_txPool->onReady([&]() { this->noteNewTransactions(); });
         m_blockSubmitted = m_blockChain->onReady([&](int64_t) { this->noteNewBlocks(); });
+
+        /// set thread name
+        std::string threadName = "Sync-" + std::to_string(m_groupId);
+        setName(threadName);
     }
 
     virtual ~SyncMaster() { stop(); };

--- a/libsync/SyncMsgEngine.cpp
+++ b/libsync/SyncMsgEngine.cpp
@@ -34,10 +34,11 @@ static size_t const c_maxPayload = dev::p2p::P2PMessage::MAX_LENGTH - 2048;
 void SyncMsgEngine::messageHandler(
     NetworkException, std::shared_ptr<dev::p2p::P2PSession> _session, P2PMessage::Ptr _msg)
 {
+#ifndef FISCO_EASYLOG
     /// tag this scope with GroupId
     BOOST_LOG_SCOPED_THREAD_ATTR(
         "GroupId", boost::log::attributes::constant<std::string>(std::to_string(m_groupId)));
-
+#endif
     SYNC_LOG(DEBUG) << LOG_BADGE("Rcv") << LOG_BADGE("Packet") << LOG_DESC("Receive packet from")
                     << LOG_KV("peer", _session->nodeID().abridged());
     if (!checkSession(_session) || !checkMessage(_msg))

--- a/libsync/SyncMsgEngine.cpp
+++ b/libsync/SyncMsgEngine.cpp
@@ -34,6 +34,10 @@ static size_t const c_maxPayload = dev::p2p::P2PMessage::MAX_LENGTH - 2048;
 void SyncMsgEngine::messageHandler(
     NetworkException, std::shared_ptr<dev::p2p::P2PSession> _session, P2PMessage::Ptr _msg)
 {
+    /// tag this scope with GroupId
+    BOOST_LOG_SCOPED_THREAD_ATTR(
+        "GroupId", boost::log::attributes::constant<std::string>(std::to_string(m_groupId)));
+
     SYNC_LOG(DEBUG) << LOG_BADGE("Rcv") << LOG_BADGE("Packet") << LOG_DESC("Receive packet from")
                     << LOG_KV("peer", _session->nodeID().abridged());
     if (!checkSession(_session) || !checkMessage(_msg))

--- a/libsync/SyncMsgEngine.cpp
+++ b/libsync/SyncMsgEngine.cpp
@@ -34,36 +34,42 @@ static size_t const c_maxPayload = dev::p2p::P2PMessage::MAX_LENGTH - 2048;
 void SyncMsgEngine::messageHandler(
     NetworkException, std::shared_ptr<dev::p2p::P2PSession> _session, P2PMessage::Ptr _msg)
 {
+#if 0
+// here will degrade the performance
 #ifndef FISCO_EASYLOG
     /// tag this scope with GroupId
     BOOST_LOG_SCOPED_THREAD_ATTR(
         "GroupId", boost::log::attributes::constant<std::string>(std::to_string(m_groupId)));
 #endif
-    SYNC_LOG(DEBUG) << LOG_BADGE("Rcv") << LOG_BADGE("Packet") << LOG_DESC("Receive packet from")
-                    << LOG_KV("peer", _session->nodeID().abridged());
+#endif
+
+    SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
+                           << LOG_DESC("Receive packet from")
+                           << LOG_KV("peer", _session->nodeID().abridged());
     if (!checkSession(_session) || !checkMessage(_msg))
     {
-        SYNC_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
-                          << LOG_DESC("Reject packet: [reason]: session/msg/group illegal");
+        SYNC_ENGINE_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
+                                 << LOG_DESC("Reject packet: [reason]: session/msg/group illegal");
         return;
     }
 
     SyncMsgPacket packet;
     if (!packet.decode(_session, _msg))
     {
-        SYNC_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet") << LOG_DESC("Reject packet")
-                          << LOG_KV("reason", "decode failed")
-                          << LOG_KV("nodeId", _session->nodeID().abridged())
-                          << LOG_KV("size", _msg->buffer()->size())
-                          << LOG_KV("message", toHex(*_msg->buffer()));
+        SYNC_ENGINE_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
+                                 << LOG_DESC("Reject packet") << LOG_KV("reason", "decode failed")
+                                 << LOG_KV("nodeId", _session->nodeID().abridged())
+                                 << LOG_KV("size", _msg->buffer()->size())
+                                 << LOG_KV("message", toHex(*_msg->buffer()));
         return;
     }
 
     bool ok = interpret(packet);
     if (!ok)
-        SYNC_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet") << LOG_DESC("Reject packet")
-                          << LOG_KV("reason", "illegal packet type")
-                          << LOG_KV("packetType", int(packet.packetType));
+        SYNC_ENGINE_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
+                                 << LOG_DESC("Reject packet")
+                                 << LOG_KV("reason", "illegal packet type")
+                                 << LOG_KV("packetType", int(packet.packetType));
 }
 
 bool SyncMsgEngine::checkSession(std::shared_ptr<dev::p2p::P2PSession> _session)
@@ -90,8 +96,9 @@ bool SyncMsgEngine::checkMessage(P2PMessage::Ptr _msg)
 
 bool SyncMsgEngine::interpret(SyncMsgPacket const& _packet)
 {
-    SYNC_LOG(TRACE) << LOG_BADGE("Rcv") << LOG_BADGE("Packet") << LOG_DESC("interpret packet type")
-                    << LOG_KV("type", int(_packet.packetType));
+    SYNC_ENGINE_LOG(TRACE) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
+                           << LOG_DESC("interpret packet type")
+                           << LOG_KV("type", int(_packet.packetType));
     try
     {
         switch (_packet.packetType)
@@ -114,8 +121,8 @@ bool SyncMsgEngine::interpret(SyncMsgPacket const& _packet)
     }
     catch (std::exception& e)
     {
-        SYNC_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
-                          << LOG_DESC("Interpret error for") << LOG_KV("reason", e.what());
+        SYNC_ENGINE_LOG(WARNING) << LOG_BADGE("Rcv") << LOG_BADGE("Packet")
+                                 << LOG_DESC("Interpret error for") << LOG_KV("reason", e.what());
         return false;
     }
     return true;
@@ -129,8 +136,9 @@ void SyncMsgEngine::onPeerStatus(SyncMsgPacket const& _packet)
 
     if (rlps.itemCount() != 3)
     {
-        SYNC_LOG(TRACE) << LOG_BADGE("Status") << LOG_DESC("Receive invalid status packet format")
-                        << LOG_KV("peer", _packet.nodeId.abridged());
+        SYNC_ENGINE_LOG(TRACE) << LOG_BADGE("Status")
+                               << LOG_DESC("Receive invalid status packet format")
+                               << LOG_KV("peer", _packet.nodeId.abridged());
         return;
     }
 
@@ -139,29 +147,30 @@ void SyncMsgEngine::onPeerStatus(SyncMsgPacket const& _packet)
 
     if (info.genesisHash != m_genesisHash)
     {
-        SYNC_LOG(TRACE) << LOG_BADGE("Status")
-                        << LOG_DESC("Receive invalid status packet with different genesis hash")
-                        << LOG_KV("peer", _packet.nodeId.abridged())
-                        << LOG_KV("genesisHash", info.genesisHash);
+        SYNC_ENGINE_LOG(TRACE) << LOG_BADGE("Status")
+                               << LOG_DESC(
+                                      "Receive invalid status packet with different genesis hash")
+                               << LOG_KV("peer", _packet.nodeId.abridged())
+                               << LOG_KV("genesisHash", info.genesisHash);
         return;
     }
 
     if (status == nullptr)
     {
-        SYNC_LOG(DEBUG) << LOG_BADGE("Status") << LOG_DESC("Receive status from new peer")
-                        << LOG_KV("peer", info.nodeId.abridged())
-                        << LOG_KV("peerBlockNumber", info.number)
-                        << LOG_KV("genesisHash", info.genesisHash.abridged())
-                        << LOG_KV("latestHash", info.latestHash.abridged());
+        SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Status") << LOG_DESC("Receive status from new peer")
+                               << LOG_KV("peer", info.nodeId.abridged())
+                               << LOG_KV("peerBlockNumber", info.number)
+                               << LOG_KV("genesisHash", info.genesisHash.abridged())
+                               << LOG_KV("latestHash", info.latestHash.abridged());
         m_syncStatus->newSyncPeerStatus(info);
     }
     else
     {
-        SYNC_LOG(DEBUG) << LOG_BADGE("Status") << LOG_DESC("Receive status from peer")
-                        << LOG_KV("peerNodeId", info.nodeId.abridged())
-                        << LOG_KV("peerBlockNumber", info.number)
-                        << LOG_KV("genesisHash", info.genesisHash.abridged())
-                        << LOG_KV("latestHash", info.latestHash.abridged());
+        SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Status") << LOG_DESC("Receive status from peer")
+                               << LOG_KV("peerNodeId", info.nodeId.abridged())
+                               << LOG_KV("peerBlockNumber", info.number)
+                               << LOG_KV("genesisHash", info.genesisHash.abridged())
+                               << LOG_KV("latestHash", info.latestHash.abridged());
         status->update(info);
     }
 }
@@ -170,25 +179,25 @@ void SyncMsgEngine::onPeerTransactions(SyncMsgPacket const& _packet)
 {
     if (m_syncStatus->state == SyncState::Downloading)
     {
-        SYNC_LOG(TRACE) << LOG_BADGE("Tx")
-                        << LOG_DESC("Drop peer transactions when dowloading blocks")
-                        << LOG_KV("fromNodeId", _packet.nodeId.abridged());
+        SYNC_ENGINE_LOG(TRACE) << LOG_BADGE("Tx")
+                               << LOG_DESC("Drop peer transactions when dowloading blocks")
+                               << LOG_KV("fromNodeId", _packet.nodeId.abridged());
         return;
     }
 
     RLP const& rlps = _packet.rlp();
     m_txQueue->push(rlps.data(), _packet.nodeId);
-    SYNC_LOG(DEBUG) << LOG_BADGE("Tx") << LOG_DESC("Receive peer txs packet")
-                    << LOG_KV("packetSize(B)", rlps.data().size());
+    SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Tx") << LOG_DESC("Receive peer txs packet")
+                           << LOG_KV("packetSize(B)", rlps.data().size());
 }
 
 void SyncMsgEngine::onPeerBlocks(SyncMsgPacket const& _packet)
 {
     RLP const& rlps = _packet.rlp();
 
-    SYNC_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("BlockSync")
-                    << LOG_DESC("Receive peer block packet")
-                    << LOG_KV("packetSize(B)", rlps.data().size());
+    SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("BlockSync")
+                           << LOG_DESC("Receive peer block packet")
+                           << LOG_KV("packetSize(B)", rlps.data().size());
 
     m_syncStatus->bq().push(rlps);
 }
@@ -199,9 +208,9 @@ void SyncMsgEngine::onPeerRequestBlocks(SyncMsgPacket const& _packet)
 
     if (rlp.itemCount() != 2)
     {
-        SYNC_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("Request")
-                        << LOG_DESC("Receive invalid request blocks packet format")
-                        << LOG_KV("peer", _packet.nodeId.abridged());
+        SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("Request")
+                               << LOG_DESC("Receive invalid request blocks packet format")
+                               << LOG_KV("peer", _packet.nodeId.abridged());
         return;
     }
 
@@ -209,10 +218,10 @@ void SyncMsgEngine::onPeerRequestBlocks(SyncMsgPacket const& _packet)
     int64_t from = rlp[0].toInt<int64_t>();
     unsigned size = rlp[1].toInt<unsigned>();
 
-    SYNC_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("Request")
-                    << LOG_DESC("Receive block request")
-                    << LOG_KV("peer", _packet.nodeId.abridged()) << LOG_KV("from", from)
-                    << LOG_KV("to", from + size - 1);
+    SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("Request")
+                           << LOG_DESC("Receive block request")
+                           << LOG_KV("peer", _packet.nodeId.abridged()) << LOG_KV("from", from)
+                           << LOG_KV("to", from + size - 1);
 
     auto peerStatus = m_syncStatus->peerStatus(_packet.nodeId);
     if (peerStatus != nullptr && peerStatus)
@@ -258,10 +267,11 @@ void DownloadBlocksContainer::clearBatchAndSend()
 
     auto msg = retPacket.toMessage(m_protocolId);
     m_service->asyncSendMessageByNodeID(m_nodeId, msg, CallbackFuncWithSession(), Options());
-    SYNC_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("Request") << LOG_BADGE("BlockSync")
-                    << LOG_DESC("Send block packet") << LOG_KV("peer", m_nodeId.abridged())
-                    << LOG_KV("blocks", m_blockRLPsBatch.size())
-                    << LOG_KV("bytes(V)", msg->buffer()->size());
+    SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Download") << LOG_BADGE("Request")
+                           << LOG_BADGE("BlockSync") << LOG_DESC("Send block packet")
+                           << LOG_KV("peer", m_nodeId.abridged())
+                           << LOG_KV("blocks", m_blockRLPsBatch.size())
+                           << LOG_KV("bytes(V)", msg->buffer()->size());
 
     m_blockRLPsBatch.clear();
     m_currentBatchSize = 0;
@@ -274,7 +284,7 @@ void DownloadBlocksContainer::sendBigBlock(bytes const& _blockRLP)
 
     auto msg = retPacket.toMessage(m_protocolId);
     m_service->asyncSendMessageByNodeID(m_nodeId, msg, CallbackFuncWithSession(), Options());
-    SYNC_LOG(DEBUG) << LOG_BADGE("Rcv") << LOG_BADGE("Send") << LOG_BADGE("Download")
-                    << LOG_DESC("Block back") << LOG_KV("peer", m_nodeId.abridged())
-                    << LOG_KV("blocks", 1) << LOG_KV("bytes(B)", msg->buffer()->size());
+    SYNC_ENGINE_LOG(DEBUG) << LOG_BADGE("Rcv") << LOG_BADGE("Send") << LOG_BADGE("Download")
+                           << LOG_DESC("Block back") << LOG_KV("peer", m_nodeId.abridged())
+                           << LOG_KV("blocks", 1) << LOG_KV("bytes(B)", msg->buffer()->size());
 }

--- a/libsync/SyncMsgEngine.h
+++ b/libsync/SyncMsgEngine.h
@@ -55,12 +55,12 @@ public:
         m_syncStatus(_syncStatus),
         m_txQueue(_txQueue),
         m_protocolId(_protocolId),
+        m_groupId(dev::eth::getGroupAndProtocol(_protocolId).first),
         m_nodeId(_nodeId),
         m_genesisHash(_genesisHash)
     {
         m_service->registerHandlerByProtoclID(
             m_protocolId, boost::bind(&SyncMsgEngine::messageHandler, this, _1, _2, _3));
-        m_groupId = dev::eth::getGroupAndProtocol(m_protocolId).first;
     }
 
     void messageHandler(dev::p2p::NetworkException _e,
@@ -101,9 +101,7 @@ public:
     DownloadBlocksContainer(
         std::shared_ptr<dev::p2p::P2PInterface> _service, PROTOCOL_ID _protocolId, NodeID _nodeId)
       : m_service(_service), m_protocolId(_protocolId), m_nodeId(_nodeId), m_blockRLPsBatch()
-    {
-        m_groupId = dev::eth::getGroupAndProtocol(m_protocolId).first;
-    }
+    {}
     ~DownloadBlocksContainer() { clearBatchAndSend(); }
 
     void batchAndSend(BlockPtr _block);
@@ -116,7 +114,6 @@ private:
 private:
     std::shared_ptr<dev::p2p::P2PInterface> m_service;
     PROTOCOL_ID m_protocolId;
-    PROTOCOL_ID m_groupId;
     NodeID m_nodeId;
     std::vector<dev::bytes> m_blockRLPsBatch;
     size_t m_currentBatchSize = 0;

--- a/libsync/SyncMsgEngine.h
+++ b/libsync/SyncMsgEngine.h
@@ -101,7 +101,9 @@ public:
     DownloadBlocksContainer(
         std::shared_ptr<dev::p2p::P2PInterface> _service, PROTOCOL_ID _protocolId, NodeID _nodeId)
       : m_service(_service), m_protocolId(_protocolId), m_nodeId(_nodeId), m_blockRLPsBatch()
-    {}
+    {
+        m_groupId = dev::eth::getGroupAndProtocol(_protocolId).first;
+    }
     ~DownloadBlocksContainer() { clearBatchAndSend(); }
 
     void batchAndSend(BlockPtr _block);
@@ -114,6 +116,7 @@ private:
 private:
     std::shared_ptr<dev::p2p::P2PInterface> m_service;
     PROTOCOL_ID m_protocolId;
+    GROUP_ID m_groupId;
     NodeID m_nodeId;
     std::vector<dev::bytes> m_blockRLPsBatch;
     size_t m_currentBatchSize = 0;

--- a/libsync/SyncStatus.h
+++ b/libsync/SyncStatus.h
@@ -97,9 +97,7 @@ public:
         m_protocolId(_protocolId),
         m_nodeId(_nodeId),
         m_downloadingBlockQueue(_blockChain, _protocolId, _nodeId)
-    {
-        m_groupId = dev::eth::getGroupAndProtocol(m_protocolId).first;
-    }
+    {}
 
     SyncMasterStatus(h256 const& _genesisHash)
       : genesisHash(_genesisHash),
@@ -144,7 +142,6 @@ public:
 private:
     PROTOCOL_ID m_protocolId;
     NodeID m_nodeId;
-    GROUP_ID m_groupId;
     mutable SharedMutex x_peerStatus;
     std::map<NodeID, std::shared_ptr<SyncPeerStatus>> m_peersStatus;
     DownloadingBlockQueue m_downloadingBlockQueue;

--- a/libtxpool/CommonTransactionNonceCheck.h
+++ b/libtxpool/CommonTransactionNonceCheck.h
@@ -36,10 +36,7 @@ namespace txpool
 class CommonTransactionNonceCheck
 {
 public:
-    CommonTransactionNonceCheck(dev::PROTOCOL_ID const& protocolId) : m_protocolId(protocolId)
-    {
-        m_groupId = dev::eth::getGroupAndProtocol(m_protocolId).first;
-    }
+    CommonTransactionNonceCheck(dev::PROTOCOL_ID const& protocolId) : m_protocolId(protocolId) {}
     virtual ~CommonTransactionNonceCheck() = default;
     virtual void delCache(dev::eth::NonceKeyType const& key);
     virtual void delCache(dev::eth::Transactions const& _transcations);
@@ -50,7 +47,6 @@ public:
 
 protected:
     dev::PROTOCOL_ID m_protocolId;
-    dev::GROUP_ID m_groupId;
     mutable SharedMutex m_lock;
     std::unordered_set<dev::eth::NonceKeyType> m_cache;
 };

--- a/libtxpool/TransactionNonceCheck.cpp
+++ b/libtxpool/TransactionNonceCheck.cpp
@@ -64,7 +64,7 @@ void TransactionNonceCheck::getNonceAndUpdateCache(
     if (m_blockNonceCache.count(blockNumber))
     {
         nonceVec = m_blockNonceCache[blockNumber];
-        NONCECHECKER_LOG(DEBUG) << LOG_DESC("updateCache: getNonceAndUpdateCache cache hit ")
+        NONCECHECKER_LOG(TRACE) << LOG_DESC("updateCache: getNonceAndUpdateCache cache hit ")
                                 << LOG_KV("blockNumber", blockNumber)
                                 << LOG_KV("nonceSize", nonceVec.size())
                                 << LOG_KV("nonceCacheSize", m_blockNonceCache.size());
@@ -76,7 +76,7 @@ void TransactionNonceCheck::getNonceAndUpdateCache(
         if (pBlock)
         {
             nonceVec = pBlock->getAllNonces();
-            NONCECHECKER_LOG(DEBUG)
+            NONCECHECKER_LOG(TRACE)
                 << LOG_DESC("updateCache: getNonceAndUpdateCache block cache hit ")
                 << LOG_KV("blockNumber", blockNumber) << LOG_KV("nonceSize", nonceVec.size())
                 << LOG_KV("nonceCacheSize", m_blockNonceCache.size());
@@ -85,7 +85,7 @@ void TransactionNonceCheck::getNonceAndUpdateCache(
     else
     {
         m_blockChain->getNonces(nonceVec, blockNumber);
-        NONCECHECKER_LOG(DEBUG) << LOG_DESC("updateCache: getNonceAndUpdateCache cache miss ")
+        NONCECHECKER_LOG(TRACE) << LOG_DESC("updateCache: getNonceAndUpdateCache cache miss ")
                                 << LOG_KV("blockNumber", blockNumber)
                                 << LOG_KV("nonceSize", nonceVec.size())
                                 << LOG_KV("nonceCacheSize", m_blockNonceCache.size());

--- a/libtxpool/TransactionNonceCheck.h
+++ b/libtxpool/TransactionNonceCheck.h
@@ -30,9 +30,9 @@
 using namespace dev::eth;
 using namespace dev::blockchain;
 
-#define NONCECHECKER_LOG(LEVEL)                                                                \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "][p:" << std::to_string(m_protocolId) \
-               << "][TXPOOL][TransactionNonceChecker]"
+#define NONCECHECKER_LOG(LEVEL)                                                         \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("TXPOOL") \
+               << LOG_BADGE("TransactionNonceChecker")
 
 namespace dev
 {

--- a/libtxpool/TransactionNonceCheck.h
+++ b/libtxpool/TransactionNonceCheck.h
@@ -30,8 +30,8 @@
 using namespace dev::eth;
 using namespace dev::blockchain;
 
-#define NONCECHECKER_LOG(LEVEL)                                                         \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("TXPOOL") \
+#define NONCECHECKER_LOG(LEVEL)                                                        \
+    LOG(LEVEL) << "[p:" << std::to_string(m_protocolId) << "] " << LOG_BADGE("TXPOOL") \
                << LOG_BADGE("TransactionNonceChecker")
 
 namespace dev

--- a/libtxpool/TxPool.h
+++ b/libtxpool/TxPool.h
@@ -36,9 +36,8 @@
 using namespace dev::eth;
 using namespace dev::p2p;
 
-#define TXPOOL_LOG(LEVEL)                                                                      \
-    LOG(LEVEL) << "[g:" << std::to_string(m_groupId) << "][p:" << std::to_string(m_protocolId) \
-               << "][TXPOOL]"
+#define TXPOOL_LOG(LEVEL) \
+    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("TXPOOL")
 
 namespace dev
 {

--- a/libtxpool/TxPool.h
+++ b/libtxpool/TxPool.h
@@ -37,7 +37,7 @@ using namespace dev::eth;
 using namespace dev::p2p;
 
 #define TXPOOL_LOG(LEVEL) \
-    LOG(LEVEL) << LOG_BADGE("p:" + std::to_string(m_protocolId)) << LOG_BADGE("TXPOOL")
+    LOG(LEVEL) << "[p:" << std::to_string(m_protocolId) << "] " << LOG_BADGE("TXPOOL")
 
 namespace dev
 {


### PR DESCRIPTION
1. update thread name related to consensus and sync 
2. register "ThreadName" when workers start for obtain and output groupID in the thread level
3. remove useless group id