### PR TITLE
Fix keycenter exit core

### DIFF
--- a/libinitializer/KeyCenterInitializer.h
+++ b/libinitializer/KeyCenterInitializer.h
@@ -32,7 +32,7 @@ class KeyCenterInitializer
 public:
     static void init()
     {
-        g_keyCenter.setIpPort(
+        g_keyCenter->setIpPort(
             g_BCOSConfig.diskEncryption.keyCenterIP, g_BCOSConfig.diskEncryption.keyCenterPort);
     }
 };

--- a/libsecurity/EncryptedFile.cpp
+++ b/libsecurity/EncryptedFile.cpp
@@ -43,7 +43,7 @@ bytes EncryptedFile::decryptContents(
         bytes dataKey;
         if (nullptr == _keyCenter)
         {
-            dataKey = g_keyCenter.getDataKey(g_BCOSConfig.diskEncryption.cipherDataKey);
+            dataKey = g_keyCenter->getDataKey(g_BCOSConfig.diskEncryption.cipherDataKey);
         }
         else
         {

--- a/libsecurity/EncryptedLevelDB.cpp
+++ b/libsecurity/EncryptedLevelDB.cpp
@@ -105,7 +105,9 @@ EncryptedLevelDB::EncryptedLevelDB(const leveldb::Options& _options, const std::
     m_name = _name;
 
     if (!m_keyCenter)
-        m_keyCenter.reset(&(g_keyCenter));
+    {
+        m_keyCenter = g_keyCenter;
+    }
 
     // Encrypted leveldb initralization
 

--- a/libsecurity/KeyCenter.cpp
+++ b/libsecurity/KeyCenter.cpp
@@ -236,9 +236,9 @@ void KeyCenter::setIpPort(const std::string& _ip, int _port)
     KC_LOG(DEBUG) << LOG_DESC("Set instance url") << LOG_KV("IP", m_ip) << LOG_KV("port", m_port);
 }
 
-KeyCenter& KeyCenter::instance()
+shared_ptr<KeyCenter> KeyCenter::instance()
 {
-    static KeyCenter ins;
+    static shared_ptr<KeyCenter> ins = make_shared<KeyCenter>();
     return ins;
 }
 

--- a/libsecurity/KeyCenter.h
+++ b/libsecurity/KeyCenter.h
@@ -73,7 +73,7 @@ public:
     void setIpPort(const std::string& _ip, int _port);
     const std::string url() { return m_ip + ":" + std::to_string(m_port); }
 
-    static KeyCenter& instance();
+    static std::shared_ptr<KeyCenter> instance();
 
     void clearCache()
     {


### PR DESCRIPTION
Instant shared_ptr of keycenter instead of a pure instance of keycenter