### PR TITLE
 fix problem of adjusting maxTxCanSeal inner a block which doesn't increase maxTxCanSeal when m_lastTimeoutTx

### DIFF
--- a/libconsensus/pbft/PBFTSealer.h
+++ b/libconsensus/pbft/PBFTSealer.h
@@ -104,6 +104,7 @@ protected:
         return m_pbftEngine->canHandleBlockForNextLeader();
     }
     void setBlock();
+    void attempIncreaseTimeoutTx();
 
 private:
     void onTimeout(uint64_t const& sealingTxNumber);


### PR DESCRIPTION
fix problem of adjusting maxTxCanSeal inner a block which doesn't increase maxTxCanSeal when m_lastTimeoutTx is equal to m_lastNoTimeout