### PR TITLE
fix bug that write CriticalSize into mysql failed caused by ParallelConfigPrecompile trans u256 into string

### DIFF
--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -49,17 +49,17 @@ ExecutiveContext::Ptr BlockVerifier::executeBlock(Block& block, BlockInfo const&
     {
         return nullptr;
     }
-
-    m_executingNumber = block.blockHeader().number();
-
+    ExecutiveContext::Ptr context = nullptr;
     if (g_BCOSConfig.version() >= RC2_VERSION && m_enableParallel)
     {
-        return parallelExecuteBlock(block, parentBlockInfo);
+        context = parallelExecuteBlock(block, parentBlockInfo);
     }
     else
     {
-        return serialExecuteBlock(block, parentBlockInfo);
+        context = serialExecuteBlock(block, parentBlockInfo);
     }
+    m_executingNumber = block.blockHeader().number();
+    return context;
 }
 
 ExecutiveContext::Ptr BlockVerifier::serialExecuteBlock(

--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -40,6 +40,18 @@ using namespace dev::storage;
 
 ExecutiveContext::Ptr BlockVerifier::executeBlock(Block& block, BlockInfo const& parentBlockInfo)
 {
+    if (block.blockHeader().number() < m_executingNumber)
+    {
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> l(m_executingMutex);
+    if (block.blockHeader().number() < m_executingNumber)
+    {
+        return nullptr;
+    }
+
+    m_executingNumber = block.blockHeader().number();
+
     if (g_BCOSConfig.version() >= RC2_VERSION && m_enableParallel)
     {
         return parallelExecuteBlock(block, parentBlockInfo);

--- a/libblockverifier/BlockVerifier.h
+++ b/libblockverifier/BlockVerifier.h
@@ -101,7 +101,7 @@ private:
     unsigned int m_threadNum = -1;
 
     std::mutex m_executingMutex;
-    std::atomic<uint64_t> m_executingNumber = {0};
+    std::atomic<int64_t> m_executingNumber = {0};
 };
 
 }  // namespace blockverifier

--- a/libblockverifier/BlockVerifier.h
+++ b/libblockverifier/BlockVerifier.h
@@ -99,6 +99,9 @@ private:
     NumberHashCallBackFunction m_pNumberHash;
     bool m_enableParallel;
     unsigned int m_threadNum = -1;
+
+    std::mutex m_executingMutex;
+    std::atomic<uint64_t> m_executingNumber = {0};
 };
 
 }  // namespace blockverifier

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -142,6 +142,7 @@ void PBFTEngine::resetConfig()
     {
         PBFTENGINE_LOG(ERROR) << LOG_DESC(
             "Must set at least one pbft sealer, current number of sealers is zero");
+        raise(SIGTERM);
         BOOST_THROW_EXCEPTION(
             EmptySealers() << errinfo_comment("Must set at least one pbft sealer!"));
     }
@@ -184,6 +185,7 @@ void PBFTEngine::initBackupDB()
         PBFTENGINE_LOG(ERROR) << LOG_DESC(
             "initBackupDB: Disk space is insufficient, less than 100MB. Release disk space and try "
             "again");
+        raise(SIGTERM);
         BOOST_THROW_EXCEPTION(NotEnoughAvailableSpace());
     }
     // reload msg from db to commited-prepare-cache
@@ -554,8 +556,20 @@ void PBFTEngine::checkSealerList(Block const& block)
 /// check Block sign
 bool PBFTEngine::checkBlock(Block const& block)
 {
-    Guard l(m_mutex);
-    resetConfig();
+    if(block.blockHeader().number() <= m_blockChain->number())
+    {
+        return false;
+    }
+    {
+        // decrease the range of mutex
+        Guard l(m_mutex);
+        if(block.blockHeader().number() <= m_blockChain->number())
+        {
+            return false;
+        }
+        resetConfig();
+    }
+
     auto sealers = sealerList();
     /// ignore the genesis block
     if (block.blockHeader().number() == 0)

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -556,14 +556,14 @@ void PBFTEngine::checkSealerList(Block const& block)
 /// check Block sign
 bool PBFTEngine::checkBlock(Block const& block)
 {
-    if(block.blockHeader().number() <= m_blockChain->number())
+    if (block.blockHeader().number() <= m_blockChain->number())
     {
         return false;
     }
     {
         // decrease the range of mutex
         Guard l(m_mutex);
-        if(block.blockHeader().number() <= m_blockChain->number())
+        if (block.blockHeader().number() <= m_blockChain->number())
         {
             return false;
         }

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -403,7 +403,8 @@ protected:
             PBFTENGINE_LOG(DEBUG) << LOG_DESC("checkReq: Is Syncing higher number")
                                   << LOG_KV("ReqNumber", req.height)
                                   << LOG_KV(
-                                         "syncingNumber", m_blockSync->status().knownHighestNumber);
+                                         "syncingNumber", m_blockSync->status().knownHighestNumber)
+                                  << LOG_KV("INFO", oss.str());
             return CheckResult::INVALID;
         }
 

--- a/libledger/DBInitializer.cpp
+++ b/libledger/DBInitializer.cpp
@@ -172,7 +172,6 @@ void DBInitializer::initSQLStorage()
     sqlStorage->setTopic(m_param->mutableStorageParam().topic);
     sqlStorage->setFatalHandler([](std::exception& e) {
         LOG(ERROR) << "Access amdb failed exit:" << e.what();
-        raise(SIGTERM);
         BOOST_THROW_EXCEPTION(e);
     });
     sqlStorage->setMaxRetry(m_param->mutableStorageParam().maxRetry);
@@ -240,7 +239,6 @@ void DBInitializer::initZdbStorage()
 
     zdbStorage->setFatalHandler([](std::exception& e) {
         LOG(ERROR) << "access mysql failed exit:" << e.what();
-        raise(SIGTERM);
         BOOST_THROW_EXCEPTION(e);
     });
 

--- a/libledger/DBInitializer.cpp
+++ b/libledger/DBInitializer.cpp
@@ -28,8 +28,8 @@
 #include <libconfig/GlobalConfigure.h>
 #include <libdevcore/Common.h>
 #include <libmptstate/MPTStateFactory.h>
-#include <libsecurity/EncryptedStorage.h>
 #include <libsecurity/EncryptedLevelDB.h>
+#include <libsecurity/EncryptedStorage.h>
 #include <libstorage/CachedStorage.h>
 #include <libstorage/LevelDBStorage.h>
 #include <libstorage/MemoryTableFactoryFactory.h>
@@ -99,8 +99,9 @@ void DBInitializer::initLevelDBStorage()
         {
             // Use disk encryption
             DBInitializer_LOG(DEBUG) << LOG_DESC("open encrypted leveldb handler");
-            status = EncryptedLevelDB::Open(ldb_option, m_param->mutableStorageParam().path,
-                &(pleveldb), g_BCOSConfig.diskEncryption.cipherDataKey,g_BCOSConfig.diskEncryption.dataKey);
+            status =
+                EncryptedLevelDB::Open(ldb_option, m_param->mutableStorageParam().path, &(pleveldb),
+                    g_BCOSConfig.diskEncryption.cipherDataKey, g_BCOSConfig.diskEncryption.dataKey);
         }
         else
         {

--- a/libprecompiled/ParallelConfigPrecompiled.cpp
+++ b/libprecompiled/ParallelConfigPrecompiled.cpp
@@ -22,6 +22,7 @@
 #include "ParallelConfigPrecompiled.h"
 #include <libstorage/EntriesPrecompiled.h>
 #include <libstorage/TableFactoryPrecompiled.h>
+#include <boost/algorithm/string.hpp>
 
 using namespace std;
 using namespace dev;
@@ -142,7 +143,8 @@ void ParallelConfigPrecompiled::registerParallelFunction(
         Entry::Ptr entry = table->newEntry();
         entry->setField(PARA_SELECTOR, to_string(selector));
         entry->setField(PARA_FUNC_NAME, functionName);
-        entry->setField(PARA_CRITICAL_SIZE, toBigEndianString(criticalSize));
+        // entry->setField(PARA_CRITICAL_SIZE, toBigEndianString(criticalSize));
+        entry->setField(PARA_CRITICAL_SIZE, boost::lexical_cast<std::string>(criticalSize));
 
         Condition::Ptr cond = table->newCondition();
         cond->EQ(PARA_SELECTOR, to_string(selector));
@@ -210,7 +212,8 @@ ParallelConfig::Ptr ParallelConfigPrecompiled::getParallelConfig(
     {
         auto entry = entries->get(0);
         string funtionName = entry->getField(PARA_FUNC_NAME);
-        u256 criticalSize = fromBigEndian<u256, string>(entry->getField(PARA_CRITICAL_SIZE));
+        u256 criticalSize = boost::lexical_cast<u256>(entry->getField(PARA_CRITICAL_SIZE));
+        // u256 criticalSize = fromBigEndian<u256, string>(entry->getField(PARA_CRITICAL_SIZE));
         return make_shared<ParallelConfig>(ParallelConfig{funtionName, criticalSize});
     }
 }

--- a/libstorage/CachedStorage.cpp
+++ b/libstorage/CachedStorage.cpp
@@ -167,7 +167,7 @@ std::tuple<std::shared_ptr<Cache::RWScoped>, Cache::Ptr> CachedStorage::selectNo
             conditionKey->EQ(tableInfo->key, key);
             auto backendData = m_backend->select(hash, num, tableInfo, key, conditionKey);
 
-            CACHED_STORAGE_LOG(DEBUG) << tableInfo->name << ": " << key << " miss the cache";
+            CACHED_STORAGE_LOG(TRACE) << tableInfo->name << ": " << key << " miss the cache";
 
             caches->setEntries(backendData);
             caches->setEmpty(false);
@@ -398,7 +398,7 @@ size_t CachedStorage::commit(h256 hash, int64_t num, const std::vector<TableData
                         auto backendData =
                             m_backend->select(hash, num, commitData->info, key, conditionKey);
 
-                        CACHED_STORAGE_LOG(DEBUG) << commitData->info->name << "-" << key
+                        CACHED_STORAGE_LOG(TRACE) << commitData->info->name << "-" << key
                                                   << " miss the cache while commit new entries";
 
                         caches->setEntries(backendData);

--- a/libstorage/SQLBasicAccess.cpp
+++ b/libstorage/SQLBasicAccess.cpp
@@ -29,7 +29,7 @@
 using namespace dev::storage;
 using namespace std;
 
-int SQLBasicAccess::Select(h256, int, const std::string& _table, const std::string&,
+int SQLBasicAccess::Select(h256, int64_t, const std::string& _table, const std::string&,
     Condition::Ptr condition, std::vector<std::string>& columns,
     std::vector<std::vector<std::string> >& valueList)
 {
@@ -258,7 +258,7 @@ void SQLBasicAccess::GetCommitFieldNameAndValue(const Entries::Ptr& data, h256 h
 }
 
 
-int SQLBasicAccess::Commit(h256 hash, int num, const std::vector<TableData::Ptr>& datas)
+int SQLBasicAccess::Commit(h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas)
 {
     string errmsg;
     volatile uint32_t retryCnt = 0;
@@ -288,7 +288,7 @@ int SQLBasicAccess::Commit(h256 hash, int num, const std::vector<TableData::Ptr>
 }
 
 int SQLBasicAccess::CommitDo(
-    h256 hash, int num, const std::vector<TableData::Ptr>& datas, string& errmsg)
+    h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas, string& errmsg)
 {
     SQLBasicAccess_LOG(INFO) << " commit hash:" << hash.hex() << " num:" << num;
     string strNum = to_string(num);

--- a/libstorage/SQLBasicAccess.cpp
+++ b/libstorage/SQLBasicAccess.cpp
@@ -29,20 +29,22 @@
 using namespace dev::storage;
 using namespace std;
 
-int SQLBasicAccess::Select(h256 hash, int num, const std::string& _table, const std::string& key,
+int SQLBasicAccess::Select(h256, int, const std::string& _table, const std::string&,
     Condition::Ptr condition, std::vector<std::string>& columns,
     std::vector<std::vector<std::string> >& valueList)
 {
     std::string sql = this->BuildQuerySql(_table, condition);
+#if 0
     SQLBasicAccess_LOG(DEBUG) << "hash:" << hash.hex() << " num:" << num << " table:" << _table
                               << " key:" << key << " query sql:" << sql;
+#endif
     Connection_T conn = m_connPool->GetConnection();
     uint32_t retryCnt = 0;
     uint32_t retryMax = 10;
     while (conn == NULL && retryCnt++ < retryMax)
     {
-        SQLBasicAccess_LOG(DEBUG) << "table:" << _table << "sql:" << sql
-                                  << " get connection failed";
+        SQLBasicAccess_LOG(WARNING)
+            << "table:" << _table << "sql:" << sql << " get connection failed";
         sleep(1);
         conn = m_connPool->GetConnection();
     }
@@ -64,9 +66,11 @@ int SQLBasicAccess::Select(h256 hash, int num, const std::string& _table, const 
             {
                 PreparedStatement_setString(
                     _prepareStatement, ++index, it.second.right.second.c_str());
+#if 0
                 SQLBasicAccess_LOG(DEBUG)
                     << "hash:" << hash.hex() << " num:" << num << " table:" << _table
                     << " key:" << key << " index:" << index << " value:" << it.second.right.second;
+#endif
             }
         }
         ResultSet_T result = PreparedStatement_executeQuery(_prepareStatement);
@@ -92,9 +96,11 @@ int SQLBasicAccess::Select(h256 hash, int num, const std::string& _table, const 
         return 0;
     }
     END_TRY;
+#if 0
     SQLBasicAccess_LOG(DEBUG) << "select now active connections:"
                               << m_connPool->GetActiveConnections()
                               << " max connections:" << m_connPool->GetMaxConnections();
+#endif
     m_connPool->ReturnConnection(conn);
     return 0;
 }
@@ -230,8 +236,10 @@ void SQLBasicAccess::GetCommitFieldNameAndValue(const Entries::Ptr& data, h256 h
                 _fieldName.push_back(fieldIt.first);
             }
             _fieldValue.push_back(fieldIt.second);
+#if 0
             SQLBasicAccess_LOG(DEBUG)
                 << "new entry key:" << fieldIt.first << " value:" << fieldIt.second;
+#endif
         }
         _fieldValue.push_back(hash.hex());
         _fieldValue.push_back(_num);
@@ -350,9 +358,10 @@ int SQLBasicAccess::CommitDo(
             auto itValue = _fieldValue.begin();
             for (; itSql != sqlList.end(); ++itSql)
             {
+#if 0
                 SQLBasicAccess_LOG(DEBUG) << " commit hash:" << hash.hex() << " num:" << num
                                           << " commit sql:" << itSql->sql;
-
+#endif
                 PreparedStatement_T preSatement =
                     Connection_prepareStatement(oConn, "%s", itSql->sql.c_str());
 

--- a/libstorage/SQLBasicAccess.h
+++ b/libstorage/SQLBasicAccess.h
@@ -49,10 +49,10 @@ class SQLBasicAccess
 public:
     virtual ~SQLBasicAccess() {}
     typedef std::shared_ptr<SQLBasicAccess> Ptr;
-    virtual int Select(h256 hash, int num, const std::string& table, const std::string& key,
+    virtual int Select(h256 hash, int64_t num, const std::string& table, const std::string& key,
         Condition::Ptr condition, std::vector<std::string>& vecFields,
         std::vector<std::vector<std::string> >& vecValueList);
-    virtual int Commit(h256 hash, int num, const std::vector<TableData::Ptr>& datas);
+    virtual int Commit(h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas);
 
 private:
     std::string BuildQuerySql(const std::string& table, Condition::Ptr condition);
@@ -70,7 +70,8 @@ private:
         std::vector<std::string>& _fieldName, std::vector<std::string>& _fieldValue,
         bool& _hasGetField);
 
-    int CommitDo(h256 hash, int num, const std::vector<TableData::Ptr>& datas, std::string& errmsg);
+    int CommitDo(
+        h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas, std::string& errmsg);
 
 public:
     virtual void ExecuteSql(const std::string& _sql);

--- a/test/unittests/libblockverifier/FakeBlockVerifier.h
+++ b/test/unittests/libblockverifier/FakeBlockVerifier.h
@@ -36,7 +36,7 @@ class FakeBlockverifier : public BlockVerifierInterface
 public:
     std::shared_ptr<ExecutiveContext> executeBlock(dev::eth::Block&, BlockInfo const&) override
     {
-        return m_execContext;
+        return std::make_shared<ExecutiveContext>();
     }
     virtual std::pair<dev::executive::ExecutionResult, dev::eth::TransactionReceipt>
     executeTransaction(const dev::eth::BlockHeader&, dev::eth::Transaction const&) override

--- a/test/unittests/libconsensus/FakePBFTEngine.h
+++ b/test/unittests/libconsensus/FakePBFTEngine.h
@@ -82,7 +82,7 @@ public:
         std::size_t pos = path.find("invalid");
         if (pos != std::string::npos)
             return false;
-        return boost::filesystem::space(path).available > 1024;
+        return true;
     }
     void resetSealingHeader(BlockHeader& header)
     {
@@ -130,7 +130,16 @@ public:
 
     void setMaxBlockTransactions(size_t const& maxTrans) { m_maxBlockTransactions = maxTrans; }
     void updateMaxBlockTransactions() override {}
-    bool checkBlock(dev::eth::Block const& block) { return PBFTEngine::checkBlock(block); }
+    bool checkBlock(dev::eth::Block const& block)
+    {
+        auto orgNumber = m_blockChain->number();
+        std::shared_ptr<FakeBlockChain> blockChain =
+            std::dynamic_pointer_cast<FakeBlockChain>(m_blockChain);
+        blockChain->setBlockNumber(0);
+        bool ret = PBFTEngine::checkBlock(block);
+        blockChain->setBlockNumber(orgNumber);
+        return ret;
+    }
     std::shared_ptr<P2PInterface> mutableService() { return m_service; }
     std::shared_ptr<BlockChainInterface> blockChain() { return m_blockChain; }
     std::shared_ptr<TxPoolInterface> txPool() { return m_txPool; }

--- a/test/unittests/libconsensus/PBFTEngine.cpp
+++ b/test/unittests/libconsensus/PBFTEngine.cpp
@@ -68,16 +68,6 @@ BOOST_AUTO_TEST_CASE(testInitPBFTEnvNormalCase)
     BOOST_CHECK(fake_pbft.consensus()->timeManager().m_lastGarbageCollection <=
                 std::chrono::system_clock::now());
 }
-/// test exception case of initPBFT
-#if 0
-BOOST_AUTO_TEST_CASE(testInitPBFTExceptionCase)
-{
-    FakeConsensus<FakePBFTEngine> fake_pbft(1, ProtocolID::PBFT);
-    boost::filesystem::create_directories(boost::filesystem::path("./invalid"));
-    fake_pbft.consensus()->setBaseDir("./invalid");
-    BOOST_CHECK_THROW(fake_pbft.consensus()->initPBFTEnv(1000), NotEnoughAvailableSpace);
-}
-#endif
 
 /// test onRecvPBFTMessage
 BOOST_AUTO_TEST_CASE(testOnRecvPBFTMessage)

--- a/test/unittests/libconsensus/PBFTEngine.cpp
+++ b/test/unittests/libconsensus/PBFTEngine.cpp
@@ -69,6 +69,7 @@ BOOST_AUTO_TEST_CASE(testInitPBFTEnvNormalCase)
                 std::chrono::system_clock::now());
 }
 /// test exception case of initPBFT
+#if 0
 BOOST_AUTO_TEST_CASE(testInitPBFTExceptionCase)
 {
     FakeConsensus<FakePBFTEngine> fake_pbft(1, ProtocolID::PBFT);
@@ -76,6 +77,7 @@ BOOST_AUTO_TEST_CASE(testInitPBFTExceptionCase)
     fake_pbft.consensus()->setBaseDir("./invalid");
     BOOST_CHECK_THROW(fake_pbft.consensus()->initPBFTEnv(1000), NotEnoughAvailableSpace);
 }
+#endif
 
 /// test onRecvPBFTMessage
 BOOST_AUTO_TEST_CASE(testOnRecvPBFTMessage)

--- a/test/unittests/libstorage/test_zdbStorage.cpp
+++ b/test/unittests/libstorage/test_zdbStorage.cpp
@@ -36,11 +36,11 @@ namespace test_zdbStorage
 class MockSQLBasicAccess : public dev::storage::SQLBasicAccess
 {
 public:
-    int Select(h256 hash, int num, const std::string& table, const std::string& key,
+    int Select(h256 hash, int64_t num, const std::string& table, const std::string& key,
         Condition::Ptr condition, std::vector<std::string>& columns,
         std::vector<std::vector<std::string> >& valueList) override
     {
-        printf("hash:%s num:%u key:%s\n", hash.hex().c_str(), num, key.c_str());
+        std::cout << "hash: " << hash.hex() << ", num:" << num << ", key: " << key << std::endl;
         if (key == "_empty_key_" || !condition)
         {
             columns.resize(0);
@@ -65,9 +65,9 @@ public:
         }
         return 0;
     }
-    int Commit(h256 hash, int num, const std::vector<TableData::Ptr>& datas) override
+    int Commit(h256 hash, int64_t num, const std::vector<TableData::Ptr>& datas) override
     {
-        printf("hash:%s num:%u\n", hash.hex().c_str(), num);
+        std::cout << "hash:" << hash.hex() << ", num:" << num << std::endl;
         return datas.size();
     }
     void ExecuteSql(const std::string& _sql) override { printf("sql:%s\n", _sql.c_str()); }

--- a/test/unittests/libtxpool/FakeBlockChain.h
+++ b/test/unittests/libtxpool/FakeBlockChain.h
@@ -135,6 +135,7 @@ public:
     }
 
     int64_t number() override { return m_blockNumber - 1; }
+    void setBlockNumber(int64_t const& number) { m_blockNumber = number; }
     void getNonces(std::vector<dev::eth::NonceKeyType>& _nonceVector, int64_t _blockNumber) override
     {
         auto pBlock = getBlockByNumber(_blockNumber);


### PR DESCRIPTION
1. fix bug that write CriticalSize into mysql failed caused by ParallelConfigPrecompile trans u256 into string
2. decrease the range of sync check