### PR TITLE
fix memory problem of rocksdb caused by rocksdb.option && modify the logic that forbids pushing received transactions to DownloadingTxsQueue when is syncing block

### DIFF
--- a/libledger/DBInitializer.cpp
+++ b/libledger/DBInitializer.cpp
@@ -241,7 +241,9 @@ std::shared_ptr<dev::db::BasicRocksDB> DBInitializer::initBasicRocksDB()
     // set Parallelism to the hardware concurrency
     options.IncreaseParallelism(std::max(1, (int)std::thread::hardware_concurrency()));
 
-    options.OptimizeLevelStyleCompaction();
+    // fix the memory problem
+    // options.OptimizeLevelStyleCompaction(); // This option will increase much memory
+
     options.create_if_missing = true;
     options.max_open_files = 1000;
     options.compression = rocksdb::kSnappyCompression;

--- a/libsync/DownloadingTxsQueue.cpp
+++ b/libsync/DownloadingTxsQueue.cpp
@@ -33,6 +33,7 @@ void DownloadingTxsQueue::push(bytesConstRef _txsBytes, NodeID const& _fromPeer)
     m_buffer->emplace_back(_txsBytes, _fromPeer);
 }
 
+
 void DownloadingTxsQueue::pop2TxPool(
     std::shared_ptr<dev::txpool::TxPoolInterface> _txPool, dev::eth::CheckTransaction _checkSig)
 {

--- a/libsync/DownloadingTxsQueue.h
+++ b/libsync/DownloadingTxsQueue.h
@@ -56,6 +56,12 @@ public:
     void pop2TxPool(std::shared_ptr<dev::txpool::TxPoolInterface> _txPool,
         dev::eth::CheckTransaction _checkSig = dev::eth::CheckTransaction::None);
 
+    ssize_t bufferSize() const
+    {
+        ReadGuard l(x_buffer);
+        return m_buffer->size();
+    }
+
 private:
     NodeID m_nodeId;
     std::shared_ptr<std::vector<DownloadTxsShard>> m_buffer;

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -202,7 +202,7 @@ void SyncMaster::workLoop()
     while (workerState() == WorkerState::Started)
     {
         doWork();
-        if (idleWaitMs() && !m_newTransactions)
+        if (idleWaitMs() && !m_newTransactions && m_txQueue->bufferSize() == 0)
         {
             std::unique_lock<std::mutex> l(x_signalled);
             m_signalled.wait_for(l, std::chrono::milliseconds(idleWaitMs()));
@@ -226,8 +226,7 @@ bool SyncMaster::isSyncing() const
 // is my number is far smaller than max block number of this block chain
 bool SyncMaster::isFarSyncing() const
 {
-    int64_t currentNumber = m_blockChain->number();
-    return m_syncStatus->knownHighestNumber - currentNumber > 10;
+    return m_msgEngine->isFarSyncing();
 }
 
 void SyncMaster::maintainTransactions()

--- a/libsync/SyncMsgEngine.h
+++ b/libsync/SyncMsgEngine.h
@@ -66,6 +66,8 @@ public:
     void messageHandler(dev::p2p::NetworkException _e,
         std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _msg);
 
+    bool isFarSyncing() const;
+
 private:
     bool checkSession(std::shared_ptr<dev::p2p::P2PSession> _session);
     bool checkMessage(dev::p2p::P2PMessage::Ptr _msg);


### PR DESCRIPTION
1. modify the logic that forbids pushing received transactions to DownloadingTxsQueue when is syncing block
2. fix memory problem of rocksdb caused by rocksdb.option