### PR TITLE
Decrease memory usage

### DIFF
--- a/libledger/DBInitializer.cpp
+++ b/libledger/DBInitializer.cpp
@@ -25,6 +25,7 @@
 #include "LedgerParam.h"
 #include "rocksdb/db.h"
 #include "rocksdb/options.h"
+#include "rocksdb/table.h"
 #include <libconfig/GlobalConfigure.h>
 #include <libdevcore/Common.h>
 #include <libdevcore/Exceptions.h>
@@ -237,13 +238,16 @@ std::shared_ptr<dev::db::BasicRocksDB> DBInitializer::initBasicRocksDB()
     boost::filesystem::create_directories(m_param->mutableStorageParam().path);
     /// open and init the rocksDB
     rocksdb::Options options;
+    rocksdb::BlockBasedTableOptions table_options;
+    // table_options.cache_index_and_filter_blocks = true;
+    table_options.block_cache = rocksdb::NewLRUCache(1 * 256 * 1024 * 1024);
+    options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
     // set Parallelism to the hardware concurrency
-    options.IncreaseParallelism(std::max(1, (int)std::thread::hardware_concurrency()));
+    // This option will increase much memory
+    // options.IncreaseParallelism(std::max(1, (int)std::thread::hardware_concurrency()));
 
-    // fix the memory problem
-    // options.OptimizeLevelStyleCompaction(); // This option will increase much memory
-
+    // options.OptimizeLevelStyleCompaction();  // This option will increase much memory too
     options.create_if_missing = true;
     options.max_open_files = 1000;
     options.compression = rocksdb::kSnappyCompression;

--- a/libledger/DBInitializer.cpp
+++ b/libledger/DBInitializer.cpp
@@ -238,10 +238,6 @@ std::shared_ptr<dev::db::BasicRocksDB> DBInitializer::initBasicRocksDB()
     boost::filesystem::create_directories(m_param->mutableStorageParam().path);
     /// open and init the rocksDB
     rocksdb::Options options;
-    rocksdb::BlockBasedTableOptions table_options;
-    // table_options.cache_index_and_filter_blocks = true;
-    table_options.block_cache = rocksdb::NewLRUCache(1 * 256 * 1024 * 1024);
-    options.table_factory.reset(NewBlockBasedTableFactory(table_options));
 
     // set Parallelism to the hardware concurrency
     // This option will increase much memory
@@ -249,7 +245,7 @@ std::shared_ptr<dev::db::BasicRocksDB> DBInitializer::initBasicRocksDB()
 
     // options.OptimizeLevelStyleCompaction();  // This option will increase much memory too
     options.create_if_missing = true;
-    options.max_open_files = 1000;
+    options.max_open_files = 200;
     options.compression = rocksdb::kSnappyCompression;
     std::shared_ptr<BasicRocksDB> rocksDB = std::make_shared<BasicRocksDB>();
 

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -524,7 +524,7 @@ function generate_group_ini()
     ; storage db type, rocksdb / mysql / external, rocksdb is recommended
     type=${storage_type}
     ; max cache memeory, MB
-    max_capacity=256
+    max_capacity=32
     max_forward_block=10
     ; only for external
     max_retry=100


### PR DESCRIPTION
**1. Modify initialize param of rocksdb.**
* No compatibility problems
* No performance decreasing. Test result：ParallelOk, capability=0, 10w user: 2071tps(before), 2121tps(after)
* No memory increasing without limit

**2. Decrease cachedStorage default capacity from 256M to 32M in generated group.x.ini.**

* Performance tests result(ParallelOk,):
256M，1G memory occupation
1w user，2900tps
10w user，2841tps

* 128M，512M memory occupation
1w user，2912tps
10w user，2699tps

* 64M，256M memory occupation
1w user，2850tps
10w user，2347tps

* 32M，128M memory occupation
1w user，2850tps
10w user，2296tps