### PR TITLE
 Add transaction exception log

### DIFF
--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -398,8 +398,9 @@ std::pair<ExecutionResult, TransactionReceipt> BlockVerifier::execute(EnvInfo co
     {
         BLOCKVERIFIER_LOG(ERROR) << _e.what();
     }
-    /// mptstate calculates every transactions
-    /// storagestate ignore hash calculation
+
+    e.loggingException();
+
     return make_pair(
         res, TransactionReceipt(executiveContext->getState()->rootHash(false), e.gasUsed(),
                  e.logs(), e.status(), e.takeOutput().takeBytes(), e.newAddress()));

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -184,6 +184,9 @@ public:
     /// @returns the transaction-count of the sender.
     u256 nonce() const { return m_nonce; }
 
+    /// @returns the groupId of this transaction
+    u256 groupId() const { return m_groupId; }
+
     /// Sets the nonce to the given value. Clears any signature.
     void setNonce(u256 const& _n)
     {

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -184,9 +184,6 @@ public:
     /// @returns the transaction-count of the sender.
     u256 nonce() const { return m_nonce; }
 
-    /// @returns the groupId of this transaction
-    u256 groupId() const { return m_groupId; }
-
     /// Sets the nonce to the given value. Clears any signature.
     void setNonce(u256 const& _n)
     {

--- a/libexecutive/Executive.cpp
+++ b/libexecutive/Executive.cpp
@@ -78,6 +78,8 @@ void Executive::verifyTransaction(
         _t.baseGasRequired(schedule) > (bigint)txGasLimit)
     {
         m_excepted = TransactionException::OutOfGasIntrinsic;
+        m_exceptionReason << LOG_KV(
+            "reason", "The gas required by deploying this contract is more than tx_gas_limit");
         BOOST_THROW_EXCEPTION(OutOfGasIntrinsic() << RequirementError(
                                   (bigint)(_t.baseGasRequired(schedule)), (bigint)txGasLimit));
     }
@@ -92,6 +94,8 @@ bool Executive::execute()
         if (txGasLimit < (u256)m_baseGasRequired)
         {
             m_excepted = TransactionException::OutOfGasBase;
+            m_exceptionReason << LOG_KV(
+                "reason", "The gas required by deploying this contract is more than tx_gas_limit");
             BOOST_THROW_EXCEPTION(
                 OutOfGasBase() << errinfo_comment(
                     "Not enough gas, base gas required:" + std::to_string(m_baseGasRequired)));
@@ -102,6 +106,8 @@ bool Executive::execute()
         if (m_t.gas() < (u256)m_baseGasRequired)
         {
             m_excepted = TransactionException::OutOfGasBase;
+            m_exceptionReason << LOG_KV(
+                "reason", "The gas required by deploying this contract is more than sender given");
             BOOST_THROW_EXCEPTION(
                 OutOfGasBase() << errinfo_comment(
                     "Not enough gas, base gas required:" + std::to_string(m_baseGasRequired)));
@@ -352,7 +358,12 @@ bool Executive::go(OnOpFunc const& _onOp)
                     m_res->depositSize = out.size();
                 }
                 if (out.size() > m_ext->evmSchedule().maxCodeSize)
+                {
+                    m_exceptionReason << LOG_KV("reason", "Code is too long")
+                                      << LOG_KV("size_limit", m_ext->evmSchedule().maxCodeSize)
+                                      << LOG_KV("size", out.size());
                     BOOST_THROW_EXCEPTION(OutOfGas());
+                }
                 else if (out.size() * m_ext->evmSchedule().createDataGas <= m_gas)
                 {
                     if (m_res)
@@ -362,7 +373,10 @@ bool Executive::go(OnOpFunc const& _onOp)
                 else
                 {
                     if (m_ext->evmSchedule().exceptionalFailedCodeDeposit)
+                    {
+                        m_exceptionReason << LOG_KV("reason", "exceptionalFailedCodeDeposit");
                         BOOST_THROW_EXCEPTION(OutOfGas());
+                    }
                     else
                     {
                         if (m_res)
@@ -497,4 +511,15 @@ void Executive::revert()
     m_s->rollback(m_savepoint);
     auto memoryTableFactory = m_envInfo.precompiledEngine()->getMemoryTableFactory();
     memoryTableFactory->rollback(m_tableFactorySavepoint);
+}
+
+
+void Executive::loggingException()
+{
+    if (m_excepted != TransactionException::None)
+    {
+        LOG(ERROR) << LOG_BADGE("TxExeError") << LOG_DESC("Transaction execution error")
+                   << LOG_KV("hash", m_t.sha3().abridged()) << LOG_KV("exception", m_excepted)
+                   << m_exceptionReason.str();
+    }
 }

--- a/libexecutive/Executive.cpp
+++ b/libexecutive/Executive.cpp
@@ -78,8 +78,10 @@ void Executive::verifyTransaction(
         _t.baseGasRequired(schedule) > (bigint)txGasLimit)
     {
         m_excepted = TransactionException::OutOfGasIntrinsic;
-        m_exceptionReason << LOG_KV(
-            "reason", "The gas required by deploying this contract is more than tx_gas_limit");
+        m_exceptionReason
+            << LOG_KV("reason",
+                   "The gas required by deploying this contract is more than tx_gas_limit")
+            << LOG_KV("limit", txGasLimit) << LOG_KV("require", _t.baseGasRequired(schedule));
         BOOST_THROW_EXCEPTION(OutOfGasIntrinsic() << RequirementError(
                                   (bigint)(_t.baseGasRequired(schedule)), (bigint)txGasLimit));
     }
@@ -94,8 +96,10 @@ bool Executive::execute()
         if (txGasLimit < (u256)m_baseGasRequired)
         {
             m_excepted = TransactionException::OutOfGasBase;
-            m_exceptionReason << LOG_KV(
-                "reason", "The gas required by deploying this contract is more than tx_gas_limit");
+            m_exceptionReason
+                << LOG_KV("reason",
+                       "The gas required by deploying this contract is more than tx_gas_limit")
+                << LOG_KV("limit", txGasLimit) << LOG_KV("require", m_baseGasRequired);
             BOOST_THROW_EXCEPTION(
                 OutOfGasBase() << errinfo_comment(
                     "Not enough gas, base gas required:" + std::to_string(m_baseGasRequired)));
@@ -106,8 +110,10 @@ bool Executive::execute()
         if (m_t.gas() < (u256)m_baseGasRequired)
         {
             m_excepted = TransactionException::OutOfGasBase;
-            m_exceptionReason << LOG_KV(
-                "reason", "The gas required by deploying this contract is more than sender given");
+            m_exceptionReason
+                << LOG_KV("reason",
+                       "The gas required by deploying this contract is more than sender given")
+                << LOG_KV("given", m_t.gas()) << LOG_KV("require", m_baseGasRequired);
             BOOST_THROW_EXCEPTION(
                 OutOfGasBase() << errinfo_comment(
                     "Not enough gas, base gas required:" + std::to_string(m_baseGasRequired)));

--- a/libexecutive/Executive.h
+++ b/libexecutive/Executive.h
@@ -166,6 +166,9 @@ public:
     /// Revert all changes made to the state by this execution.
     void revert();
 
+    /// print exception to log
+    void loggingException();
+
 private:
     /// @returns false iff go() must be called (and thus a VM execution in required).
     bool executeCreate(Address const& _txSender, u256 const& _endowment, u256 const& _gasPrice,
@@ -184,6 +187,8 @@ private:
     unsigned m_depth = 0;  ///< The context's call-depth.
     TransactionException m_excepted =
         TransactionException::None;  ///< Details if the VM's execution resulted in an exception.
+    std::stringstream m_exceptionReason;
+
     int64_t m_baseGasRequired;  ///< The base amount of gas requried for executing this transaction.
     u256 m_gas = 0;       ///< The gas for EVM code execution. Initial amount before go() execution,
                           ///< final amount after go() execution.


### PR DESCRIPTION
The log looks like:
``` log
error|2019-07-30 17:30:36.707582|[g:1][TxExeError]Transaction execution error,hash=ac30992b...,exception=OutOfGas
error|2019-07-30 17:30:43.494353|[g:1][TxExeError]Transaction execution error,hash=2d11f40e...,exception=OutOfGas,reason=Code is too long,size_limit=24576,size=29234
error|2019-07-30 17:38:06.504413|[g:1][TxExeError]Transaction execution error,hash=f232e985...,exception=OutOfGasIntrinsic,reason=The gas required by deploying this contract is more than tx_gas_limit,limit=100000,require=1974308
```