### PR TITLE
remove getCacheConsensusStatus interface of PBFTReqCache && update getPbftView

### DIFF
--- a/libconsensus/ConsensusEngineBase.h
+++ b/libconsensus/ConsensusEngineBase.h
@@ -151,7 +151,6 @@ public:
     /// obtain maxBlockTransactions
     uint64_t maxBlockTransactions() override { return m_maxBlockTransactions; }
 
-
 protected:
     virtual void resetConfig() { m_nodeNum = m_sealerList.size(); }
     void dropHandledTransactions(dev::eth::Block const& block) { m_txPool->dropBlockTrans(block); }

--- a/libconsensus/ConsensusEngineBase.h
+++ b/libconsensus/ConsensusEngineBase.h
@@ -151,6 +151,7 @@ public:
     /// obtain maxBlockTransactions
     uint64_t maxBlockTransactions() override { return m_maxBlockTransactions; }
 
+
 protected:
     virtual void resetConfig() { m_nodeNum = m_sealerList.size(); }
     void dropHandledTransactions(dev::eth::Block const& block) { m_txPool->dropBlockTrans(block); }

--- a/libconsensus/ConsensusInterface.h
+++ b/libconsensus/ConsensusInterface.h
@@ -57,6 +57,8 @@ public:
     /// update the context of PBFT after commit a block into the block-chain
     virtual void reportBlock(dev::eth::Block const& block) = 0;
     virtual uint64_t maxBlockTransactions() { return 1000; }
+    virtual VIEWTYPE view() const { return 0; }
+    virtual VIEWTYPE toView() const { return 0; }
 };
 }  // namespace consensus
 }  // namespace dev

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1362,8 +1362,7 @@ void PBFTEngine::checkAndChangeView()
 
         m_leaderFailed = false;
         m_timeManager.m_lastConsensusTime = utcTime();
-        VIEWTYPE toView = m_toView;
-        m_view = toView;
+        m_view = m_toView.load();
         m_notifyNextLeaderSeal = false;
         m_reqCache->triggerViewChange(m_view);
         m_blockSync->noteSealingBlockNumber(m_blockChain->number());
@@ -1578,9 +1577,6 @@ const std::string PBFTEngine::consensusStatus()
     status.append(statusObj);
     /// get view of node id
     getAllNodesViewStatus(status);
-
-    /// get cache-related informations
-    m_reqCache->getCacheConsensusStatus(status);
 
     Json::FastWriter fastWriter;
     std::string status_str = fastWriter.write(status);

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -50,11 +50,10 @@ void PBFTEngine::start()
 
 void PBFTEngine::initPBFTEnv(unsigned view_timeout)
 {
-    Guard l(m_mutex);
-    resetConfig();
     m_consensusBlockNumber = 0;
     m_view = m_toView = 0;
     m_leaderFailed = false;
+    reportBlock(*(m_blockChain->getBlockByNumber(m_blockChain->number())));
     initBackupDB();
     m_timeManager.initTimerManager(view_timeout);
     PBFTENGINE_LOG(INFO) << "[PBFT init env successfully]";
@@ -121,6 +120,7 @@ void PBFTEngine::resetConfig()
     updateMaxBlockTransactions();
     auto node_idx = MAXIDX;
     m_accountType = NodeAccountType::ObserverAccount;
+    size_t nodeNum = 0;
     updateConsensusNodeList();
     {
         ReadGuard l(m_sealerListMutex);
@@ -133,15 +133,20 @@ void PBFTEngine::resetConfig()
                 break;
             }
         }
-        m_nodeNum = m_sealerList.size();
+        nodeNum = m_sealerList.size();
     }
-    if (m_nodeNum < 1)
+    if (nodeNum < 1)
     {
         PBFTENGINE_LOG(ERROR) << LOG_DESC(
             "Must set at least one pbft sealer, current number of sealers is zero");
         raise(SIGTERM);
         BOOST_THROW_EXCEPTION(
             EmptySealers() << errinfo_comment("Must set at least one pbft sealer!"));
+    }
+    // update m_nodeNum
+    if (m_nodeNum != nodeNum)
+    {
+        m_nodeNum = nodeNum;
     }
     m_f = (m_nodeNum - 1) / 3;
     m_cfgErr = (node_idx == MAXIDX);
@@ -557,7 +562,10 @@ bool PBFTEngine::checkBlock(Block const& block)
     {
         return false;
     }
-    resetConfig();
+    {
+        Guard l(m_mutex);
+        resetConfig();
+    }
     auto sealers = sealerList();
     /// ignore the genesis block
     if (block.blockHeader().number() == 0)
@@ -1354,7 +1362,8 @@ void PBFTEngine::checkAndChangeView()
 
         m_leaderFailed = false;
         m_timeManager.m_lastConsensusTime = utcTime();
-        m_view = m_toView;
+        VIEWTYPE toView = m_toView;
+        m_view = toView;
         m_notifyNextLeaderSeal = false;
         m_reqCache->triggerViewChange(m_view);
         m_blockSync->noteSealingBlockNumber(m_blockChain->number());
@@ -1561,9 +1570,9 @@ const std::string PBFTEngine::consensusStatus()
     /// get other informations related to PBFT
     statusObj["connectedNodes"] = IDXTYPE(m_connectedNode);
     /// get the current view
-    statusObj["currentView"] = m_view;
+    statusObj["currentView"] = VIEWTYPE(m_view);
     /// get toView
-    statusObj["toView"] = m_toView;
+    statusObj["toView"] = VIEWTYPE(m_toView);
     /// get leader failed or not
     statusObj["leaderFailed"] = bool(m_leaderFailed);
     status.append(statusObj);

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -196,6 +196,9 @@ public:
 
     uint64_t sealingTxNumber() const { return m_sealingNumber; }
 
+    VIEWTYPE view() const override { return m_view; }
+    VIEWTYPE toView() const override { return m_toView; }
+
 protected:
     void reportBlockWithoutLock(dev::eth::Block const& block);
     void workLoop() override;
@@ -558,8 +561,8 @@ protected:
 
 
 protected:
-    VIEWTYPE m_view = 0;
-    VIEWTYPE m_toView = 0;
+    std::atomic<VIEWTYPE> m_view = {0};
+    std::atomic<VIEWTYPE> m_toView = {0};
     std::string m_baseDir;
     std::atomic_bool m_leaderFailed = {false};
     std::atomic_bool m_notifyNextLeaderSeal = {false};

--- a/libconsensus/pbft/PBFTReqCache.cpp
+++ b/libconsensus/pbft/PBFTReqCache.cpp
@@ -206,21 +206,5 @@ void PBFTReqCache::removeInvalidFutureCache(dev::eth::BlockHeader const& highest
     }
 }
 
-/// get the consensus status
-void PBFTReqCache::getCacheConsensusStatus(Json::Value& status_array) const
-{
-    /// prepare cache
-    getCacheStatus(status_array, "prepareCache", m_prepareCache);
-    /// raw prepare cache
-    getCacheStatus(status_array, "rawPrepareCache", m_rawPrepareCache);
-    /// commited prepare cache
-    getCacheStatus(status_array, "committedPrepareCache", m_committedPrepareCache);
-    /// future prepare cache
-    /// signCache
-    getCollectedCacheStatus(status_array, "signCache", m_signCache);
-    getCollectedCacheStatus(status_array, "commitCache", m_commitCache);
-    getCollectedCacheStatus(status_array, "viewChangeCache", m_recvViewChangeReq);
-}
-
 }  // namespace consensus
 }  // namespace dev

--- a/libconsensus/pbft/PBFTReqCache.h
+++ b/libconsensus/pbft/PBFTReqCache.h
@@ -262,7 +262,6 @@ public:
     {
         return m_recvViewChangeReq;
     }
-    void getCacheConsensusStatus(Json::Value& statusArray) const;
 
 private:
     /// remove invalid requests cached in cache according to current block
@@ -313,37 +312,6 @@ private:
         if (it == cache.end())
             return false;
         return (it->second.find(key)) != (it->second.end());
-    }
-
-    /// get the status of specified cache into the json object
-    /// (maily for prepareCache, m_committedPrepareCache, m_futurePrepareCache and rawPrepareCache)
-    template <typename T>
-    void getCacheStatus(Json::Value& jsonArray, std::string const& key, T const& cache) const
-    {
-        Json::Value cacheStatus;
-        cacheStatus[key + "_blockHash"] = "0x" + toHex(cache.block_hash);
-        cacheStatus[key + "_height"] = cache.height;
-        cacheStatus[key + "_idx"] = toString(cache.idx);
-        cacheStatus[key + "_view"] = toString(cache.view);
-        jsonArray.append(cacheStatus);
-    }
-
-    template <typename T>
-    void getCollectedCacheStatus(
-        Json::Value& cacheJsonArray, std::string const& key, T const& cache) const
-    {
-        Json::Value tmp_array(Json::arrayValue);
-        Json::Value tmp_obj;
-        for (auto i : cache)
-        {
-            Json::Value entry;
-            entry[key + "_key"] = toJS(i.first);
-            entry[key + "_collectedSize"] = std::to_string(i.second.size());
-            tmp_array.append(entry);
-        }
-        tmp_obj[key + "_cachedSize"] = toString(cache.size());
-        tmp_obj["info"] = tmp_array;
-        cacheJsonArray.append(tmp_obj);
     }
 
 private:

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -168,15 +168,7 @@ std::string Rpc::getPbftView(int _groupID)
             BOOST_THROW_EXCEPTION(
                 JsonRpcException(RPCExceptionType::GroupID, RPCMsg[RPCExceptionType::GroupID]));
         }
-        std::string status = consensus->consensusStatus();
-        Json::Reader reader;
-        Json::Value statusJson;
-        u256 view;
-        if (!reader.parse(status, statusJson))
-            BOOST_THROW_EXCEPTION(
-                JsonRpcException(RPCExceptionType::JsonParse, RPCMsg[RPCExceptionType::JsonParse]));
-
-        view = statusJson[0]["currentView"].asUInt64();
+        dev::consensus::VIEWTYPE view = consensus->view();
         return toJS(view);
     }
     catch (JsonRpcException& e)

--- a/test/unittests/libconsensus/FakePBFTEngine.h
+++ b/test/unittests/libconsensus/FakePBFTEngine.h
@@ -74,9 +74,9 @@ public:
     int64_t consensusBlockNumber() const { return m_consensusBlockNumber; }
     void setConsensusBlockNumber(int64_t const& number) { m_consensusBlockNumber = number; }
 
-    VIEWTYPE const& toView() const { return m_toView; }
+    VIEWTYPE toView() const { return m_toView; }
     void setToView(VIEWTYPE const& view) { m_toView = view; }
-    VIEWTYPE const& view() const { return m_view; }
+    VIEWTYPE view() const { return m_view; }
 
     bool isDiskSpaceEnough(std::string const& path) override
     {


### PR DESCRIPTION

1. add view() and toView() interface to ConsensusEngine to support RPC obtain view directly
2. remove getCacheConsensusStatus interface of PBFTReqCache for thread-safe and performance-fridendly consideration