### PR TITLE
fix bug of dynamic block size adjustment

### DIFF
--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1033,11 +1033,6 @@ void PBFTEngine::reportBlockWithoutLock(Block const& block)
 {
     if (m_blockChain->number() == 0 || m_highestBlock.number() < block.blockHeader().number())
     {
-        if (m_onCommitBlock)
-        {
-            m_onCommitBlock(block.blockHeader().number(), block.getTransactionSize(),
-                m_timeManager.m_changeCycle);
-        }
         /// remove invalid future block
         m_reqCache->removeInvalidFutureCache(m_highestBlock);
         /// update the highest block
@@ -1053,6 +1048,11 @@ void PBFTEngine::reportBlockWithoutLock(Block const& block)
             m_reqCache->delInvalidViewChange(m_highestBlock);
         }
         resetConfig();
+        if (m_onCommitBlock)
+        {
+            m_onCommitBlock(block.blockHeader().number(), block.getTransactionSize(),
+                m_timeManager.m_changeCycle);
+        }
         m_reqCache->delCache(m_highestBlock.hash());
         PBFTENGINE_LOG(INFO) << LOG_DESC("^^^^^^^^Report") << LOG_KV("num", m_highestBlock.number())
                              << LOG_KV("sealerIdx", m_highestBlock.sealer())

--- a/libconsensus/pbft/PBFTSealer.cpp
+++ b/libconsensus/pbft/PBFTSealer.cpp
@@ -111,6 +111,7 @@ void PBFTSealer::attempIncreaseTimeoutTx()
     // 1. m_lastTimeoutTx or m_maxNoTimeoutTx is large enough, return directly
     if (m_lastTimeoutTx >= m_pbftEngine->maxBlockTransactions())
     {
+        m_lastTimeoutTx = m_pbftEngine->maxBlockTransactions();
         return;
     }
     if (m_maxNoTimeoutTx == m_pbftEngine->maxBlockTransactions())
@@ -141,6 +142,12 @@ void PBFTSealer::attempIncreaseTimeoutTx()
 /// decrease maxBlockCanSeal to half when timeout
 void PBFTSealer::onTimeout(uint64_t const& sealingTxNumber)
 {
+    // fix the case that maxBlockTransactions of pbftEngine has been decreased through sysconfig
+    // precompile while the  m_maxBlockCanSeal remain high
+    if (maxBlockCanSeal() >= m_pbftEngine->maxBlockTransactions())
+    {
+        m_maxBlockCanSeal = m_pbftEngine->maxBlockTransactions();
+    }
     /// is syncing, modify the latest block number
     if (m_blockSync->isSyncing())
     {
@@ -173,6 +180,10 @@ void PBFTSealer::onTimeout(uint64_t const& sealingTxNumber)
 void PBFTSealer::onCommitBlock(
     uint64_t const& blockNumber, uint64_t const& sealingTxNumber, unsigned const& changeCycle)
 {
+    if (maxBlockCanSeal() >= m_pbftEngine->maxBlockTransactions())
+    {
+        m_maxBlockCanSeal = m_pbftEngine->maxBlockTransactions();
+    }
     /// if is syncing or timeout, return directly
     if (m_blockSync->isSyncing() || changeCycle > 0)
     {
@@ -201,6 +212,7 @@ void PBFTSealer::onCommitBlock(
     /// maxBlockTransactions, increase maxBlockCanSeal
     if (maxBlockCanSeal() >= m_pbftEngine->maxBlockTransactions())
     {
+        m_maxBlockCanSeal = m_pbftEngine->maxBlockTransactions();
         return;
     }
     // if m_lastTimeoutTx is no large than to m_maxNoTimeoutTx, try to increase m_TimeoutTx


### PR DESCRIPTION
fix the bug that tx_count_limit has decreased while the adjusted max transaction size of a block can seal doesn't decrease