### PR TITLE
gossip block status to random peers every gossipInterval

### DIFF
--- a/libledger/LedgerParam.h
+++ b/libledger/LedgerParam.h
@@ -69,6 +69,10 @@ struct SyncParam
 {
     /// TODO: syncParam related
     signed idleWaitMs = SYNC_IDLE_WAIT_DEFAULT;
+    // default block status gossip interval is 3s
+    int64_t gossipInterval = 3000;
+    // default gossip peers is 3
+    int64_t gossipPeers = 3;
 };
 
 /// modification 2019.03.20: add timeStamp field to GenesisParam

--- a/libsync/GossipBlockStatus.cpp
+++ b/libsync/GossipBlockStatus.cpp
@@ -1,0 +1,63 @@
+/*
+ * @CopyRight:
+ * FISCO-BCOS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FISCO-BCOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+ * (c) 2016-2019 fisco-dev contributors.
+ */
+/**
+ * @brief : block status gossip implementation
+ * @author: yujiechen
+ * @date: 2019-10-08
+ */
+#include "GossipBlockStatus.h"
+
+using namespace dev;
+using namespace dev::sync;
+
+// start gossip thread
+void GossipBlockStatus::start()
+{
+    if (m_running)
+    {
+        GOSSIP_LOG(INFO) << LOG_DESC("GossipBlockStatus already started");
+        return;
+    }
+    // start gossipBlockStatus worker
+    startWorking();
+    m_running = true;
+    GOSSIP_LOG(INFO) << LOG_DESC("start GossipBlockStatus succ");
+}
+
+// stop the gossip thread
+void GossipBlockStatus::stop()
+{
+    if (!m_running)
+    {
+        GOSSIP_LOG(INFO) << LOG_DESC("GossipBlockStatus already stopped");
+        return;
+    }
+    GOSSIP_LOG(INFO) << LOG_DESC("stop GossipBlockStatus succ");
+    m_running = false;
+    doneWorking();
+    if (isWorking())
+    {
+        stopWorking();
+        terminate();
+    }
+}
+
+void GossipBlockStatus::doWork()
+{
+    assert(m_gossipBlockStatusHandler);
+    m_gossipBlockStatusHandler(m_gossipPeersNumber);
+}

--- a/libsync/GossipBlockStatus.h
+++ b/libsync/GossipBlockStatus.h
@@ -1,0 +1,61 @@
+/*
+ * @CopyRight:
+ * FISCO-BCOS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FISCO-BCOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+ * (c) 2016-2019 fisco-dev contributors.
+ */
+/**
+ * @brief : block status gossip implementation
+ * @author: yujiechen
+ * @date: 2019-10-08
+ */
+#pragma once
+#include <libdevcore/Worker.h>
+#include <libdevcore/easylog.h>
+#include <libethcore/Protocol.h>
+
+#define GOSSIP_LOG(_OBV) LOG(_OBV) << LOG_BADGE("GossipBlockStatus")
+
+namespace dev
+{
+namespace sync
+{
+class GossipBlockStatus : public Worker
+{
+public:
+    using Ptr = std::shared_ptr<GossipBlockStatus>;
+    GossipBlockStatus(dev::PROTOCOL_ID const& _protocolId, int64_t const& _gossipInterval,
+        int64_t const& _gossipPeersNumber)
+      : Worker("gossip-" + std::to_string(_protocolId), _gossipInterval),
+        m_gossipPeersNumber(_gossipPeersNumber)
+    {}
+    void registerGossipHandler(std::function<void(int64_t const&)> const& _gossipBlockStatusHandler)
+    {
+        m_gossipBlockStatusHandler = _gossipBlockStatusHandler;
+    }
+    // start gossip thread
+    virtual void start();
+    // stop the gossip thread
+    virtual void stop();
+
+    // gossip block status
+    void doWork() override;
+
+private:
+    // send block status to random neighbors every m_gossipInterval
+    std::atomic_bool m_running = {false};
+    std::int64_t m_gossipPeersNumber = 3;
+    std::function<void(int64_t const&)> m_gossipBlockStatusHandler = nullptr;
+};
+}  // namespace sync
+}  // namespace dev

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -735,3 +735,12 @@ bool SyncMaster::isNextBlock(BlockPtr _block)
 
     return true;
 }
+
+void SyncMaster::sendBlockStatus(int64_t const& _gossipPeersNumber)
+{
+    auto blockNumber = m_blockChain->number();
+    auto currentHash = m_blockChain->numberHash(blockNumber);
+    m_syncStatus->forRandomPeers(_gossipPeersNumber, [&](std::shared_ptr<SyncPeerStatus> _p) {
+        return sendSyncStatusByNodeId(blockNumber, currentHash, _p->nodeId);
+    });
+}

--- a/libsync/SyncMaster.h
+++ b/libsync/SyncMaster.h
@@ -23,6 +23,7 @@
 #pragma once
 #include "Common.h"
 #include "DownloadingTxsQueue.h"
+#include "GossipBlockStatus.h"
 #include "RspBlockReq.h"
 #include "SyncInterface.h"
 #include "SyncMsgEngine.h"
@@ -157,6 +158,7 @@ public:
 
     bool sendSyncStatusByNodeId(dev::eth::BlockNumber const& blockNumber,
         dev::h256 const& currentHash, dev::network::NodeID const& nodeId);
+    void sendBlockStatus(int64_t const& _gossipPeersNumber);
 
     void registerTxsReceiversFilter(
         std::function<dev::p2p::NodeIDs(std::set<NodeID> const&)> _handler) override

--- a/libsync/SyncStatus.cpp
+++ b/libsync/SyncStatus.cpp
@@ -166,6 +166,32 @@ void SyncMasterStatus::foreachPeerRandom(
     }
 }
 
+void SyncMasterStatus::forRandomPeers(
+    int64_t const& _neighborSize, std::function<bool(std::shared_ptr<SyncPeerStatus>)> const& _f)
+{
+    std::srand(std::time(0));
+    int64_t peersSize = m_peersStatus.size();
+    int64_t selectedSize = _neighborSize > peersSize ? peersSize : _neighborSize;
+
+    NodeIDs nodeIds;
+    ReadGuard l(x_peerStatus);
+    for (auto& peer : m_peersStatus)
+    {
+        nodeIds.emplace_back(peer.first);
+    }
+    NodeID selectedNode;
+    for (auto i = 0; i < selectedSize; i++)
+    {
+        int64_t randomValue = std::rand() % peersSize;
+        swap(nodeIds[i], nodeIds[randomValue]);
+    }
+    // call _f for the selected nodes
+    for (int i = 0; i < selectedSize; i++)
+    {
+        _f(m_peersStatus[nodeIds[i]]);
+    }
+}
+
 // TODO: return reference
 NodeIDs SyncMasterStatus::randomSelection(
     unsigned _percent, std::function<bool(std::shared_ptr<SyncPeerStatus>)> const& _allow)

--- a/libsync/SyncStatus.h
+++ b/libsync/SyncStatus.h
@@ -126,6 +126,10 @@ public:
     void foreachPeer(std::function<bool(std::shared_ptr<SyncPeerStatus>)> const& _f) const;
 
     void foreachPeerRandom(std::function<bool(std::shared_ptr<SyncPeerStatus>)> const& _f) const;
+    // select neighborSize peers
+    // call _f for each selected peers
+    void forRandomPeers(int64_t const& _neighborSize,
+        std::function<bool(std::shared_ptr<SyncPeerStatus>)> const& _f);
 
     /// Select some peers at _percent when _allow(peer)
     NodeIDs randomSelection(

--- a/libsync/SyncTreeTopology.h
+++ b/libsync/SyncTreeTopology.h
@@ -60,19 +60,17 @@ protected:
 
 private:
     bool getNodeIDByIndex(dev::h512& _nodeID, ssize_t const& _nodeIndex) const;
-    ssize_t getNodeIndexByNodeId(
-        dev::h512s const& _findSet, dev::h512& _nodeId, SharedMutex& _mutex);
+    ssize_t getNodeIndexByNodeId(dev::h512s const& _findSet, dev::h512& _nodeId);
     // update the tree-topology range the nodes located in
     void updateStartAndEndIndex();
     bool locatedInGroup();
 
 protected:
-    mutable SharedMutex x_nodeList;
+    mutable Mutex m_mutex;
     // the nodeList include both the consensus nodes and the observer nodes
     dev::h512s m_nodeList;
     std::atomic<int64_t> m_nodeNum = {0};
 
-    mutable SharedMutex x_currentConsensusNodes;
     // the list of the current consensus nodes
     dev::h512s m_currentConsensusNodes;
     unsigned m_treeWidth;

--- a/test/unittests/libsync/SyncTreeTopologyTest.cpp
+++ b/test/unittests/libsync/SyncTreeTopologyTest.cpp
@@ -40,18 +40,9 @@ public:
       : SyncTreeTopology(_nodeId, _treeWidth)
     {}
 
-    virtual dev::h512s const& currentConsensusNodes()
-    {
-        ReadGuard l(x_nodeList);
+    virtual dev::h512s const& currentConsensusNodes() { return m_currentConsensusNodes; }
 
-        return m_currentConsensusNodes;
-    }
-
-    virtual dev::h512s const& nodeList()
-    {
-        ReadGuard l(x_currentConsensusNodes);
-        return m_nodeList;
-    }
+    virtual dev::h512s const& nodeList() { return m_nodeList; }
     void recursiveSelectChildNodes(
         dev::h512s& selectedNodeList, ssize_t const& parentIndex, std::set<dev::h512> const& peers)
     {


### PR DESCRIPTION
1. gossip block status to random peers every gossipInterval
2. update SyncTreeTopology to make sure modifications of {m_nodeIndex, m_consIndex, m_startIndex, m_endIndex} are atomic.