### PR TITLE
enable RPBFT when consensus type is configurated to rotating_pbft

### DIFF
--- a/libconsensus/ConsensusInterface.h
+++ b/libconsensus/ConsensusInterface.h
@@ -60,6 +60,8 @@ public:
     virtual uint64_t maxBlockTransactions() { return 1000; }
     virtual VIEWTYPE view() const { return 0; }
     virtual VIEWTYPE toView() const { return 0; }
+
+    virtual bool shouldRecvTxs() const { return false; }
 };
 }  // namespace consensus
 }  // namespace dev

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -200,8 +200,10 @@ public:
 
     VIEWTYPE view() const override { return m_view; }
     VIEWTYPE toView() const override { return m_toView; }
+    bool shouldRecvTxs() const override { return m_blockSync->isFarSyncing(); }
 
 protected:
+    virtual bool locatedInChosedConsensensusNodes() const { return m_idx != MAXIDX; }
     void reportBlockWithoutLock(dev::eth::Block const& block);
     void workLoop() override;
     void handleFutureBlock();
@@ -567,6 +569,7 @@ protected:
         m_viewMap[idx] = view;
     }
 
+    void waitSignal();
 
 protected:
     std::atomic<VIEWTYPE> m_view = {0};

--- a/libledger/Ledger.h
+++ b/libledger/Ledger.h
@@ -166,6 +166,7 @@ protected:
     dev::consensus::ConsensusInterface::Ptr createConsensusEngine(
         dev::PROTOCOL_ID const& _protocolId);
     void initPBFTEngine(dev::consensus::Sealer::Ptr _sealer);
+    void initRotatingPBFTEngine(dev::consensus::Sealer::Ptr _sealer);
 
 private:
     /// create PBFTConsensus

--- a/libledger/LedgerParam.h
+++ b/libledger/LedgerParam.h
@@ -55,6 +55,11 @@ struct ConsensusParam
     bool enableDynamicBlockSize = true;
     /// block size increase ratio
     float blockSizeIncreaseRatio = 0.5;
+
+    // group size for RPBFT, default is 10
+    int64_t groupSize = 10;
+    // rotating interval, default is 10
+    int64_t rotatingInterval = 10;
 };
 
 struct AMDBParam

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -115,8 +115,8 @@ void Rpc::checkRequest(int _groupID)
 void Rpc::checkTxReceive(int _groupID)
 {
     // Refuse transaction if far syncing
-    auto sync = ledgerManager()->sync(_groupID);
-    if (sync->isFarSyncing())
+    auto consEngine = ledgerManager()->consensus(_groupID);
+    if (consEngine->shouldRecvTxs())
     {
         BOOST_THROW_EXCEPTION(
             TransactionRefused() << errinfo_comment("ImportResult::NodeIsSyncing"));

--- a/libsync/SyncInterface.h
+++ b/libsync/SyncInterface.h
@@ -68,6 +68,7 @@ public:
     virtual void updateNodeListInfo(dev::h512s const&) {}
     virtual void updateConsensusNodeInfo(dev::h512s const&) {}
     virtual bool syncTreeRouterEnabled() { return false; }
+    virtual void noteForwardRemainTxs(dev::h512 const&) {}
 };
 
 }  // namespace sync

--- a/libsync/SyncMaster.h
+++ b/libsync/SyncMaster.h
@@ -196,6 +196,10 @@ public:
     }
 
     bool syncTreeRouterEnabled() override { return (m_syncTreeRouter != nullptr); }
+    void noteForwardRemainTxs(dev::h512 const& _targetNodeId) override
+    {
+        m_syncTrans->noteForwardRemainTxs(_targetNodeId);
+    }
 
 protected:
     // for UT

--- a/libsync/SyncStatus.cpp
+++ b/libsync/SyncStatus.cpp
@@ -117,7 +117,7 @@ NodeIDs SyncMasterStatus::filterPeers(
     NodeIDs chosen;
     for (auto const& peer : peers)
     {
-        if (_allow(m_peersStatus[peer]))
+        if (m_peersStatus.count(peer) && _allow(m_peersStatus[peer]))
         {
             chosen.push_back(peer);
         }

--- a/test/unittests/libconsensus/RotatingPBFTEngineTest.cpp
+++ b/test/unittests/libconsensus/RotatingPBFTEngineTest.cpp
@@ -172,6 +172,7 @@ BOOST_AUTO_TEST_CASE(testConstantSealers)
     // case1: eight sealers with two groups(every group with four members), rotating interval is 10
     auto fixture = std::make_shared<RotatingPBFTEngineFixture>(8);
     fixture->rotatingPBFT()->setSealersNum(8);
+    fixture->rotatingPBFT()->resetConfig();
     int64_t rotatingInterval = 10;
     for (auto groupSize = 4; groupSize < 10; groupSize++)
     {


### PR DESCRIPTION
1. enable RPBFT when consensus type is configurated to rotating_pbft
2. only broadcast transactions to the current consensus nodes
3. if the consensus nodes have been changed, the selected-out consensus node sends the remaining transactions to the newly-inserted consensus node

todo:
enable/disable RPBFT by updating consensused-sys-table
update configuration of RPBFT by updating consensused-sys-table.