### PR TITLE
fix the process is stucked in para-execute when the storage has been exceptioned and going on to exit

### DIFF
--- a/libblockverifier/DAG.cpp
+++ b/libblockverifier/DAG.cpp
@@ -21,7 +21,7 @@
  */
 
 #include "DAG.h"
-
+#include <libconfig/GlobalConfigure.h>
 using namespace std;
 using namespace dev;
 using namespace dev::blockverifier;
@@ -107,6 +107,13 @@ ID DAG::waitPop(bool _needWait)
             return true;
         }
         else if (!_needWait)
+        {
+            return true;
+        }
+        // process-exit related:
+        // if the g_BCOSConfig.shouldExit is true (may be the storage has exceptioned)
+        // return true, will pop INVALID_ID
+        else if (g_BCOSConfig.shouldExit.load())
         {
             return true;
         }

--- a/libblockverifier/TxDAG.h
+++ b/libblockverifier/TxDAG.h
@@ -23,6 +23,7 @@
 #pragma once
 #include "DAG.h"
 #include "ExecutiveContext.h"
+#include <libconfig/GlobalConfigure.h>
 #include <libethcore/Block.h>
 #include <libethcore/Transaction.h>
 #include <libexecutive/Executive.h>
@@ -67,7 +68,13 @@ public:
 
     // Called by thread
     // Has the DAG reach the end?
-    bool hasFinished() override { return m_exeCnt >= m_totalParaTxs; }
+    // process-exit related:
+    // if the g_BCOSConfig.shouldExit is true(may be the storage has exceptioned), return true
+    // directly
+    bool hasFinished() override
+    {
+        return (m_exeCnt >= m_totalParaTxs) || (g_BCOSConfig.shouldExit.load());
+    }
 
     // Called by thread
     // Execute a unit in DAG

--- a/libledger/LedgerParam.cpp
+++ b/libledger/LedgerParam.cpp
@@ -227,7 +227,7 @@ void LedgerParam::initConsensusIniConfig(ptree const& pt)
     else
     {
         mutableConsensusParam().enablePrepareWithTxsHash =
-            pt.get<bool>("consensus.enable_prepare_with_txsHash", true);
+            pt.get<bool>("consensus.enable_prepare_with_txsHash", false);
     }
     LedgerParam_LOG(DEBUG)
         << LOG_BADGE("initConsensusIniConfig")

--- a/libtxpool/TxPool.cpp
+++ b/libtxpool/TxPool.cpp
@@ -120,6 +120,9 @@ void TxPool::notifyReceipt(dev::eth::Transaction::Ptr _tx, ImportResult const& _
     default:
         txException = TransactionException::TransactionRefused;
     }
+    TXPOOL_LOG(ERROR) << LOG_DESC("notifyReceipt: txException")
+                      << LOG_KV("hash", _tx->sha3().abridged())
+                      << LOG_KV("exception", int(txException));
     dev::eth::LocalisedTransactionReceipt::Ptr receipt =
         std::make_shared<dev::eth::LocalisedTransactionReceipt>(txException);
     m_workerPool->enqueue([callback, receipt] { callback(receipt, bytesConstRef()); });


### PR DESCRIPTION
1. fix the process is stucked in para-execute when the storage has been exceptioned and going on to exit
2. fix default value of enablePrepareWithTxsHash to false when supported_version is smaller than 2.2.0