### PR TITLE
fix exit coredump && fix the logic of syncTreeTopology

### DIFF
--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -294,7 +294,11 @@ ExecutiveContext::Ptr BlockVerifier::parallelExecuteBlock(
         BOOST_THROW_EXCEPTION(
             BlockExecutionFailed() << errinfo_comment("Error during parallel block execution"));
     }
-
+    // if the program is going to exit, return nullptr directly
+    if (g_BCOSConfig.shouldExit)
+    {
+        return nullptr;
+    }
     auto exe_time_cost = utcTime() - record_time;
     record_time = utcTime();
 

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -55,7 +55,7 @@ enum CheckResult
     FUTURE = 2
 };
 using PBFTMsgQueue = dev::concurrent_queue<PBFTMsgPacket::Ptr>;
-class PBFTEngine : public ConsensusEngineBase
+class PBFTEngine : public ConsensusEngineBase, public std::enable_shared_from_this<PBFTEngine>
 {
 public:
     using Ptr = std::shared_ptr<PBFTEngine>;

--- a/libp2p/P2PInterface.h
+++ b/libp2p/P2PInterface.h
@@ -72,6 +72,8 @@ public:
     virtual void registerHandlerByProtoclID(
         PROTOCOL_ID protocolID, CallbackFuncWithSession handler) = 0;
 
+    virtual void removeHandlerByProtocolID(PROTOCOL_ID const&) {}
+
     virtual void registerHandlerByTopic(std::string topic, CallbackFuncWithSession handler) = 0;
 
     virtual P2PSessionInfos sessionInfos() = 0;

--- a/libp2p/Service.cpp
+++ b/libp2p/Service.cpp
@@ -700,6 +700,15 @@ void Service::registerHandlerByProtoclID(PROTOCOL_ID protocolID, CallbackFuncWit
     }
 }
 
+void Service::removeHandlerByProtocolID(PROTOCOL_ID const& _protocolID)
+{
+    RecursiveGuard l(x_protocolID2Handler);
+    if (m_protocolID2Handler && m_protocolID2Handler->count(_protocolID))
+    {
+        m_protocolID2Handler->erase(_protocolID);
+    }
+}
+
 void Service::registerHandlerByTopic(std::string topic, CallbackFuncWithSession handler)
 {
     RecursiveGuard l(x_topic2Handler);

--- a/libp2p/Service.h
+++ b/libp2p/Service.h
@@ -86,6 +86,9 @@ public:
 
     void registerHandlerByProtoclID(
         PROTOCOL_ID protocolID, CallbackFuncWithSession handler) override;
+
+    void removeHandlerByProtocolID(PROTOCOL_ID const& _protocolID) override;
+
     void registerHandlerByTopic(std::string topic, CallbackFuncWithSession handler) override;
 
     virtual std::map<dev::network::NodeIPEndpoint, NodeID> staticNodes() { return m_staticNodes; }

--- a/libsync/SyncMsgEngine.h
+++ b/libsync/SyncMsgEngine.h
@@ -41,7 +41,7 @@ namespace dev
 {
 namespace sync
 {
-class SyncMsgEngine
+class SyncMsgEngine : public std::enable_shared_from_this<SyncMsgEngine>
 {
 public:
     SyncMsgEngine(std::shared_ptr<dev::p2p::P2PInterface> _service,
@@ -69,21 +69,8 @@ public:
             std::make_shared<dev::ThreadPool>("txsRecv-" + std::to_string(m_groupId), 1);
     }
 
-    virtual ~SyncMsgEngine()
-    {
-        if (m_txsWorker)
-        {
-            m_txsWorker->stop();
-        }
-        if (m_txsSender)
-        {
-            m_txsSender->stop();
-        }
-        if (m_txsReceiver)
-        {
-            m_txsReceiver->stop();
-        }
-    }
+    virtual void stop();
+    virtual ~SyncMsgEngine() { stop(); }
 
     void messageHandler(dev::p2p::NetworkException _e,
         std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _msg);

--- a/libsync/SyncStatus.cpp
+++ b/libsync/SyncStatus.cpp
@@ -119,6 +119,7 @@ NodeIDs SyncMasterStatus::filterPeers(int64_t const& _neighborSize, std::shared_
         selectedSize = selectPeers(_neighborSize, _peers);
     }
     NodeIDs chosen;
+    ReadGuard l(x_peerStatus);
     for (auto const& peer : (*_peers))
     {
         if (m_peersStatus.count(peer) && m_peersStatus[peer] && _allow(m_peersStatus[peer]))

--- a/libsync/SyncTreeTopology.cpp
+++ b/libsync/SyncTreeTopology.cpp
@@ -78,6 +78,10 @@ void SyncTreeTopology::updateStartAndEndIndex()
     {
         m_startIndex = (m_nodeIndex / slotSize) * slotSize;
     }
+    if (m_startIndex > (m_nodeNum - 1))
+    {
+        m_startIndex = m_nodeNum - 1;
+    }
     int64_t endIndex = m_startIndex + slotSize - 1;
     if (endIndex > (m_nodeNum - 1))
     {

--- a/libsync/TreeTopology.cpp
+++ b/libsync/TreeTopology.cpp
@@ -116,7 +116,7 @@ void TreeTopology::recursiveSelectChildNodes(std::shared_ptr<h512s> _selectedNod
         // the child node exists in the peers
         if (_peers->count(selectedNode))
         {
-            TREE_LOG(TRACE) << LOG_DESC("recursiveSelectChildNodes")
+            TREE_LOG(DEBUG) << LOG_DESC("recursiveSelectChildNodes")
                             << LOG_KV("selectedNode", selectedNode.abridged())
                             << LOG_KV("selectedIndex", expectedIndex);
             _selectedNodeList->push_back(selectedNode);
@@ -160,7 +160,7 @@ void TreeTopology::selectParentNodes(std::shared_ptr<dev::h512s> _selectedNodeLi
         if (getNodeIDByIndex(selectedNode, parentIndex) && _peers->count(selectedNode))
         {
             _selectedNodeList->push_back(selectedNode);
-            TREE_LOG(TRACE) << LOG_DESC("selectParentNodes") << LOG_KV("parentIndex", parentIndex)
+            TREE_LOG(DEBUG) << LOG_DESC("selectParentNodes") << LOG_KV("parentIndex", parentIndex)
                             << LOG_KV("selectedNode", selectedNode.abridged())
                             << LOG_KV("idx", m_consIndex);
             break;

--- a/test/unittests/libsync/SyncMsgEngineTest.cpp
+++ b/test/unittests/libsync/SyncMsgEngineTest.cpp
@@ -76,9 +76,17 @@ public:
             case TxsRequestPacekt:
                 onReceiveTxsRequest(_packet, _peer, _msg);
                 break;
-            default:
-                SyncMsgEngine::interpret(_packet, _msg, _peer);
+            case StatusPacket:
+                onPeerStatus(*_packet);
                 break;
+            case BlocksPacket:
+                onPeerBlocks(*_packet);
+                break;
+            case ReqBlocskPacket:
+                onPeerRequestBlocks(*_packet);
+                break;
+            default:
+                return false;
             }
         }
         catch (std::exception& e)


### PR DESCRIPTION
1. add removeHandlerByProtocolID to stop the consensus and sync handle p2p message after the ledger stopped
2. modify `this` to `weak_ptr<enable_from_this>` to in case of coredump after `this` object deconstructed
3. modify the logic of syncTreeTopology