### PR TITLE
make updateConsensusNodeList and updateNodeList atomic when use SyncTreeTopology 

### DIFF
--- a/libconsensus/ConsensusEngineBase.cpp
+++ b/libconsensus/ConsensusEngineBase.cpp
@@ -157,11 +157,12 @@ void ConsensusEngineBase::updateConsensusNodeList()
         dev::h512s observerList = m_blockChain->observerList();
         for (dev::h512 node : observerList)
             s2 << node.abridged() << ",";
-        ENGINE_LOG(TRACE) << s2.str();
 
         if (m_lastNodeList != s2.str())
         {
-            ENGINE_LOG(TRACE) << "[updateConsensusNodeList] update P2P List done.";
+            ENGINE_LOG(DEBUG) << LOG_DESC(
+                                     "updateConsensusNodeList: nodeList updated, updated nodeList:")
+                              << s2.str();
 
             // get all nodes
             auto sealerList = m_blockChain->sealerList();
@@ -169,8 +170,15 @@ void ConsensusEngineBase::updateConsensusNodeList()
             std::sort(nodeList.begin(), nodeList.end());
             if (m_blockSync->syncTreeRouterEnabled())
             {
-                // update the nodeList
-                m_blockSync->updateNodeListInfo(nodeList);
+                if (m_sealerListUpdated)
+                {
+                    m_blockSync->updateConsensusNodeInfo(sealerList, nodeList);
+                }
+                else
+                {
+                    // update the nodeList
+                    m_blockSync->updateNodeListInfo(nodeList);
+                }
             }
             m_service->setNodeListByGroupID(m_groupId, nodeList);
 

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1930,10 +1930,6 @@ void PBFTEngine::resetConfig()
     {
         return;
     }
-    if (m_blockSync->syncTreeRouterEnabled())
-    {
-        m_blockSync->updateConsensusNodeInfo(sealerList());
-    }
     if (!m_enableTTLOptimize)
     {
         return;

--- a/libsync/SyncInterface.h
+++ b/libsync/SyncInterface.h
@@ -66,7 +66,7 @@ public:
             std::shared_ptr<std::set<dev::network::NodeID>>)>)
     {}
     virtual void updateNodeListInfo(dev::h512s const&) {}
-    virtual void updateConsensusNodeInfo(dev::h512s const&) {}
+    virtual void updateConsensusNodeInfo(dev::h512s const&, dev::h512s const&) {}
     virtual bool syncTreeRouterEnabled() { return false; }
     virtual void noteForwardRemainTxs(dev::h512 const&) {}
 };

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -138,18 +138,11 @@ void SyncMaster::stop()
 
 void SyncMaster::doWork()
 {
-    auto start_time = utcTime();
-    auto record_time = utcTime();
     // Debug print
     if (isSyncing())
         printSyncInfo();
-    auto printSyncInfo_time_cost = utcTime() - record_time;
-    record_time = utcTime();
     // maintain the connections between observers/sealers
     maintainPeersConnection();
-    auto maintainPeersConnection_time_cost = utcTime() - record_time;
-    record_time = utcTime();
-
     m_downloadBlockProcessor->enqueue([this]() {
         try
         {
@@ -176,14 +169,8 @@ void SyncMaster::doWork()
                             << LOG_KV("errorInfo", boost::diagnostic_information(e));
         }
     });
-    record_time = utcTime();
-
     // send block-status to other nodes when commit a new block
     maintainBlocks();
-    auto maintainBlocks_time_cost = utcTime() - record_time;
-    record_time = utcTime();
-    auto maintainBlockRequest_time_cost = 0;
-
     // send block to other nodes
     m_sendBlockProcessor->enqueue([this]() {
         try
@@ -196,14 +183,6 @@ void SyncMaster::doWork()
                             << LOG_KV("errorInfo", boost::diagnostic_information(e));
         }
     });
-    maintainBlockRequest_time_cost = utcTime() - record_time;
-
-    SYNC_LOG(TRACE) << LOG_BADGE("Record") << LOG_DESC("Sync loop time record")
-                    << LOG_KV("printSyncInfoTimeCost", printSyncInfo_time_cost)
-                    << LOG_KV("maintainPeersConnection", maintainPeersConnection_time_cost)
-                    << LOG_KV("maintainBlocksTimeCost", maintainBlocks_time_cost)
-                    << LOG_KV("maintainBlockRequestTimeCost", maintainBlockRequest_time_cost)
-                    << LOG_KV("syncTotalTimeCost", utcTime() - start_time);
 }
 
 void SyncMaster::workLoop()

--- a/libsync/SyncMaster.h
+++ b/libsync/SyncMaster.h
@@ -206,14 +206,15 @@ public:
         m_syncTreeRouter->updateNodeListInfo(_nodeList);
     }
 
-    void updateConsensusNodeInfo(dev::h512s const& _consensusNodes) override
+    void updateConsensusNodeInfo(
+        dev::h512s const& _consensusNodes, dev::h512s const& _nodeList) override
     {
         m_txQueue->updateConsensusNodeInfo(_consensusNodes);
         if (!m_syncTreeRouter)
         {
             return;
         }
-        m_syncTreeRouter->updateConsensusNodeInfo(_consensusNodes);
+        m_syncTreeRouter->updateAllNodeInfo(_consensusNodes, _nodeList);
     }
 
     bool syncTreeRouterEnabled() override { return (m_syncTreeRouter != nullptr); }
@@ -231,8 +232,7 @@ private:
         auto observerList = m_blockChain->observerList();
         auto nodeList = sealerList + observerList;
         std::sort(nodeList.begin(), nodeList.end());
-        updateNodeListInfo(nodeList);
-        updateConsensusNodeInfo(sealerList);
+        updateConsensusNodeInfo(sealerList, nodeList);
     }
 
 private:

--- a/libsync/SyncTreeTopology.h
+++ b/libsync/SyncTreeTopology.h
@@ -45,6 +45,8 @@ public:
     virtual ~SyncTreeTopology() {}
     // update corresponding info when the nodes changed
     virtual void updateNodeListInfo(dev::h512s const& _nodeList);
+    // consensus info must be updated with nodeList
+    virtual void updateAllNodeInfo(dev::h512s const& _consensusNodes, dev::h512s const& _nodeList);
     // select the nodes by tree topology
     std::shared_ptr<dev::h512s> selectNodes(std::shared_ptr<std::set<dev::h512>> _peers) override;
 

--- a/test/unittests/libsync/SyncTreeTopologyTest.cpp
+++ b/test/unittests/libsync/SyncTreeTopologyTest.cpp
@@ -123,7 +123,10 @@ public:
 
     void updateNodeListInfo() { m_syncTreeRouter->updateNodeListInfo(m_nodeList); }
 
-    void updateConsensusNodeInfo() { m_syncTreeRouter->updateConsensusNodeInfo(m_consensusList); }
+    void updateConsensusNodeInfo()
+    {
+        m_syncTreeRouter->updateAllNodeInfo(m_consensusList, m_nodeList);
+    }
     std::shared_ptr<FakeSyncTreeTopology> syncTreeRouter() { return m_syncTreeRouter; }
     dev::h512s const& consensusList() { return m_consensusList; }
     dev::h512s const& nodeList() { return m_nodeList; }
@@ -161,7 +164,8 @@ BOOST_AUTO_TEST_CASE(testFreeNode)
                 fakeSyncTreeTopology->syncTreeRouter()->currentConsensusNodes());
     BOOST_CHECK(fakeSyncTreeTopology->syncTreeRouter()->consIndex() == -1);
     // check node list
-    BOOST_CHECK(fakeSyncTreeTopology->syncTreeRouter()->nodeList() == dev::h512s());
+    BOOST_CHECK(
+        fakeSyncTreeTopology->syncTreeRouter()->nodeList() == fakeSyncTreeTopology->nodeList());
     // check startIndex and endIndex
     BOOST_CHECK(fakeSyncTreeTopology->syncTreeRouter()->startIndex() == 0);
     BOOST_CHECK(fakeSyncTreeTopology->syncTreeRouter()->endIndex() == 0);


### PR DESCRIPTION
1. make updateConsensusNodeList and updateNodeList atomic when use SyncTreeTopology 
2. remove useless log