### PR TITLE
remove enable_parallel from build_chain && add stateRoot to receipt before calculate receiptRoot

### DIFF
--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -156,7 +156,7 @@ ExecutiveContext::Ptr BlockVerifier::serialExecuteBlock(
 
     h256 stateRoot = executiveContext->getState()->rootHash();
     // set stateRoot in receipts
-    // block.setStateRootToAllReceipt(stateRoot); no need
+    block.setStateRootToAllReceipt(stateRoot);
     block.updateSequenceReceiptGas();
     block.calReceiptRoot();
     block.header().setStateRoot(stateRoot);

--- a/libconsensus/ConsensusEngineBase.cpp
+++ b/libconsensus/ConsensusEngineBase.cpp
@@ -135,7 +135,10 @@ void ConsensusEngineBase::updateConsensusNodeList()
         std::stringstream s2;
         s2 << "[updateConsensusNodeList] Sealers:";
         {
+            /// to make sure the index of all sealers are consistent
             auto sealerList = m_blockChain->sealerList();
+            std::sort(sealerList.begin(), sealerList.end());
+
             UpgradableGuard l(m_sealerListMutex);
             if (sealerList != m_sealerList)
             {
@@ -148,8 +151,6 @@ void ConsensusEngineBase::updateConsensusNodeList()
             {
                 m_sealerListUpdated = false;
             }
-            /// to make sure the index of all sealers are consistent
-            std::sort(m_sealerList.begin(), m_sealerList.end());
             for (dev::h512 node : m_sealerList)
                 s2 << node.abridged() << ",";
         }

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -31,7 +31,6 @@ gm_conf_path="gmconf/"
 current_dir=$(pwd)
 consensus_type="pbft"
 TASSL_CMD="${HOME}"/.tassl
-enable_parallel=true
 auto_flush="true"
 # trans timestamp from seconds to milliseconds
 timestamp=$(($(date '+%s')*1000))
@@ -547,8 +546,6 @@ function generate_group_ini()
     db_name=
 [tx_pool]
     limit=150000
-[tx_execute]
-    enable_parallel=${enable_parallel}
 [sync]
     idle_wait_ms=200
     ; send block status and transaction by tree-topology


### PR DESCRIPTION
1. remove enable_parallel from build_chain && add stateRoot to receipt before calculate receiptRoot
2. sort before update sealerList to make cache effective,