### PR TITLE
add compatibility support when setDBHash in mpt-mode

### DIFF
--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -156,11 +156,17 @@ ExecutiveContext::Ptr BlockVerifier::serialExecuteBlock(
 
     h256 stateRoot = executiveContext->getState()->rootHash();
     // set stateRoot in receipts
-    block.setStateRootToAllReceipt(stateRoot);
+    if (g_BCOSConfig.version() >= V2_2_0)
+    {
+        // when support_version is lower than v2.2.0, doesn't setStateRootToAllReceipt
+        // enable_parallel=true can't be run with enable_parallel=false
+        block.setStateRootToAllReceipt(stateRoot);
+    }
     block.updateSequenceReceiptGas();
     block.calReceiptRoot();
     block.header().setStateRoot(stateRoot);
     block.header().setDBhash(executiveContext->getMemoryTableFactory()->hash());
+
     /// if executeBlock is called by consensus module, no need to compare receiptRoot and stateRoot
     /// since origin value is empty if executeBlock is called by sync module, need to compare
     /// receiptRoot, stateRoot and dbHash

--- a/libconsensus/Sealer.cpp
+++ b/libconsensus/Sealer.cpp
@@ -100,7 +100,7 @@ bool Sealer::shouldWait(bool const& wait) const
 void Sealer::doWork(bool wait)
 {
     reportNewBlock();
-    if (shouldSeal())
+    if (shouldSeal() && m_startConsensus.load())
     {
         WriteGuard l(x_sealing);
         {
@@ -240,6 +240,12 @@ void Sealer::stop()
     }
     SEAL_LOG(INFO) << "Stop sealer module...";
     m_startConsensus = false;
+
+    // notify all when stop, in case of the process stucked in 'doWork' when the system-time has
+    // been updated
+    m_signalled.notify_all();
+    m_blockSignalled.notify_all();
+
     doneWorking();
     if (isWorking())
     {

--- a/libconsensus/Sealer.h
+++ b/libconsensus/Sealer.h
@@ -210,7 +210,7 @@ protected:
     ///< Has the remote worker recently been reset?
     bool m_remoteWorking = false;
     /// True if we /should/ be sealing.
-    bool m_startConsensus = false;
+    std::atomic_bool m_startConsensus = {false};
 
     /// handler
     Handler<> m_tqReady;

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -82,6 +82,10 @@ void PBFTEngine::stop()
     {
         m_messageHandler->stop();
     }
+    // notify all when stop, in case of the process stucked in 'doWork' when the system-time has
+    // been updated
+    m_signalled.notify_all();
+
     ConsensusEngineBase::stop();
 }
 

--- a/libledger/LedgerParam.cpp
+++ b/libledger/LedgerParam.cpp
@@ -138,7 +138,7 @@ void LedgerParam::initTxExecuteConfig(ptree const& pt)
 {
     if (dev::stringCmpIgnoreCase(mutableStateParam().type, "storage") == 0)
     {
-        mutableTxParam().enableParallel = pt.get<bool>("tx_execute.enable_parallel", false);
+        mutableTxParam().enableParallel = pt.get<bool>("tx_execute.enable_parallel", true);
     }
     else
     {

--- a/libstorage/RocksDBStorage.cpp
+++ b/libstorage/RocksDBStorage.cpp
@@ -70,19 +70,9 @@ Entries::Ptr RocksDBStorage::select(
             stringstream ss(value);
             boost::archive::binary_iarchive ia(ss);
             ia >> res;
-            std::set<string> duplicateIDs;
             for (auto it = res.begin(); it != res.end(); ++it)
             {  // TODO: use tbb parallel_for
                 Entry::Ptr entry = make_shared<Entry>();
-                if (g_BCOSConfig.version() < V2_2_0)
-                {  // fix dirtyEntries duplicate
-                    bool unique = duplicateIDs.insert(it->at(ID_FIELD)).second;
-                    if (!unique)
-                    {
-                        continue;
-                    }
-                }
-
                 for (auto valueIt = it->begin(); valueIt != it->end(); ++valueIt)
                 {
                     entry->setField(valueIt->first, valueIt->second);

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -129,6 +129,10 @@ void SyncMaster::stop()
     {
         m_blockStatusGossipThread->stop();
     }
+    // notify all when stop, in case of the process stucked in 'doWork' when the system-time has
+    // been updated
+    m_signalled.notify_all();
+
     doneWorking();
     stopWorking();
     // will not restart worker, so terminate it

--- a/libsync/SyncTransaction.cpp
+++ b/libsync/SyncTransaction.cpp
@@ -40,6 +40,10 @@ void SyncTransaction::start()
 
 void SyncTransaction::stop()
 {
+    // notify all when stop, in case of the process stucked in 'doWork' when the system-time has
+    // been updated
+    m_signalled.notify_all();
+
     doneWorking();
     stopWorking();
     // will not restart worker, so terminate it


### PR DESCRIPTION
1. add compatibility support when setDBHash in mpt-mode(support_version<2.2.0)
2. notify all signal when stop worker, in case of the process stucked in 'doWork' when the system-time has been updated
3. remove anti-duplication-read logic of rocksDBStorage
4. set default value of enable_parallel to true when stateType is `storage`