### PR TITLE
modify implementation of sync-txs-by-tree

### DIFF
--- a/libethcore/Block.cpp
+++ b/libethcore/Block.cpp
@@ -426,6 +426,7 @@ void Block::decode(
     m_transactions->resize(transactions_rlp.itemCount());
     for (size_t i = 0; i < transactions_rlp.itemCount(); i++)
     {
+        (*m_transactions)[i] = std::make_shared<dev::eth::Transaction>();
         (*m_transactions)[i]->decode(transactions_rlp[i], _option);
     }
 

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -331,17 +331,24 @@ bool Ledger::initSync()
     }
     // raft disable enableSendBlockStatusByTree
     bool enableSendBlockStatusByTree = m_param->mutableSyncParam().enableSendBlockStatusByTree;
+    bool enableSendTxsByTree = m_param->mutableSyncParam().enableSendTxsByTree;
     if (dev::stringCmpIgnoreCase(m_param->mutableConsensusParam().consensusType, "raft") == 0)
     {
         Ledger_LOG(INFO) << LOG_DESC("initLedger: disable send_by_tree when use raft");
         enableSendBlockStatusByTree = false;
+        enableSendTxsByTree = false;
     }
+    Ledger_LOG(INFO) << LOG_DESC("Init sync master")
+                     << LOG_KV("enableSendBlockStatusByTree", enableSendBlockStatusByTree)
+                     << LOG_KV("enableSendTxsByTree", enableSendTxsByTree);
+
     dev::PROTOCOL_ID protocol_id = getGroupProtoclID(m_groupId, ProtocolID::BlockSync);
     dev::h256 genesisHash = m_blockChain->getBlockByNumber(int64_t(0))->headerHash();
     m_sync = std::make_shared<SyncMaster>(m_service, m_txPool, m_blockChain, m_blockVerifier,
         protocol_id, m_keyPair.pub(), genesisHash, m_param->mutableSyncParam().idleWaitMs,
         m_param->mutableSyncParam().gossipInterval, m_param->mutableSyncParam().gossipPeers,
-        enableSendBlockStatusByTree, m_param->mutableSyncParam().syncTreeWidth);
+        enableSendTxsByTree, enableSendBlockStatusByTree,
+        m_param->mutableSyncParam().syncTreeWidth);
     Ledger_LOG(INFO) << LOG_BADGE("initLedger") << LOG_DESC("initSync SUCC");
     return true;
 }

--- a/libledger/LedgerParam.h
+++ b/libledger/LedgerParam.h
@@ -77,6 +77,8 @@ struct SyncParam
 {
     /// TODO: syncParam related
     signed idleWaitMs = SYNC_IDLE_WAIT_DEFAULT;
+    // enable send transactions by tree
+    bool enableSendTxsByTree = false;
     // enable send block status by tree or not
     bool enableSendBlockStatusByTree = true;
     // default block status gossip interval is 1s

--- a/libsync/SyncMsgPacket.h
+++ b/libsync/SyncMsgPacket.h
@@ -88,8 +88,9 @@ class SyncTransactionsPacket : public SyncMsgPacket
 {
 public:
     SyncTransactionsPacket() { packetType = TransactionsPacket; }
-    void encode(std::vector<bytes> const& _txRLPs);
-    void encodeRC2(std::vector<bytes> const& _txRLPs);
+    void encode(std::vector<bytes> const& _txRLPs, bool const& _enableTreeRouter = false,
+        uint64_t const& _consIndex = 0);
+    void encodeRC2(std::vector<bytes> const& _txRLPs, unsigned const& _fieldSize);
     dev::p2p::P2PMessage::Ptr toMessage(PROTOCOL_ID _protocolId, bool const& _fromRPC = false);
 };
 

--- a/libsync/SyncTransaction.cpp
+++ b/libsync/SyncTransaction.cpp
@@ -135,6 +135,11 @@ void SyncTransaction::broadcastTransactions(std::shared_ptr<NodeIDs> _selectedPe
 
     auto randomSelectedPeers = _selectedPeers;
     bool randomSelectedPeersInited = false;
+    int64_t consIndex = 0;
+    if (m_treeRouter)
+    {
+        consIndex = m_treeRouter->consIndex();
+    }
 
     UpgradableGuard l(m_txPool->xtransactionKnownBy());
     for (ssize_t i = _startIndex; i <= endIndex; ++i)
@@ -159,7 +164,7 @@ void SyncTransaction::broadcastTransactions(std::shared_ptr<NodeIDs> _selectedPe
         }
         if (_fromRpc && m_treeRouter && !randomSelectedPeersInited)
         {
-            randomSelectedPeers = m_treeRouter->selectNodes(m_syncStatus->peersSet());
+            randomSelectedPeers = m_treeRouter->selectNodes(m_syncStatus->peersSet(), consIndex);
             randomSelectedPeersInited = true;
         }
         peers = m_syncStatus->filterPeers(
@@ -193,7 +198,14 @@ void SyncTransaction::broadcastTransactions(std::shared_ptr<NodeIDs> _selectedPe
 
 
         std::shared_ptr<SyncTransactionsPacket> packet = std::make_shared<SyncTransactionsPacket>();
-        packet->encode(txRLPs);
+        if (m_treeRouter && _fromRpc)
+        {
+            packet->encode(txRLPs, true, consIndex);
+        }
+        else
+        {
+            packet->encode(txRLPs);
+        }
 
         auto msg = packet->toMessage(m_protocolId, _fromRpc);
         m_service->asyncSendMessageByNodeID(_p->nodeId, msg, CallbackFuncWithSession(), Options());

--- a/libsync/SyncTreeTopology.h
+++ b/libsync/SyncTreeTopology.h
@@ -38,7 +38,6 @@ public:
     SyncTreeTopology(dev::h512 const& _nodeId, unsigned const& _treeWidth = 3)
       : TreeTopology(_nodeId, _treeWidth)
     {
-        m_childOffset = 1;
         m_nodeList = std::make_shared<dev::h512s>();
     }
 
@@ -48,22 +47,22 @@ public:
     // consensus info must be updated with nodeList
     virtual void updateAllNodeInfo(dev::h512s const& _consensusNodes, dev::h512s const& _nodeList);
     // select the nodes by tree topology
-    std::shared_ptr<dev::h512s> selectNodes(std::shared_ptr<std::set<dev::h512>> _peers) override;
+    std::shared_ptr<dev::h512s> selectNodes(
+        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _consIndex = 0) override;
 
 protected:
     bool getNodeIDByIndex(dev::h512& _nodeID, ssize_t const& _nodeIndex) const override;
     // update the tree-topology range the nodes located in
     void updateStartAndEndIndex() override;
 
-    ssize_t getChildNodeIndex(ssize_t const& _parentIndex, ssize_t const& _offset) override;
-    ssize_t getParentNodeIndex(ssize_t const& _nodeIndex) override;
-
     // select the child nodes by tree
     void recursiveSelectChildNodes(std::shared_ptr<dev::h512s> _selectedNodeList,
-        ssize_t const& _parentIndex, std::shared_ptr<std::set<dev::h512>> _peers) override;
+        ssize_t const& _parentIndex, std::shared_ptr<std::set<dev::h512>> _peers,
+        int64_t const& _startIndex) override;
     // select the parent nodes by tree
     void selectParentNodes(std::shared_ptr<dev::h512s> _selectedNodeList,
-        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _nodeIndex) override;
+        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _nodeIndex,
+        int64_t const& _startIndex) override;
 
 private:
     bool locatedInGroup();
@@ -72,7 +71,6 @@ protected:
     mutable Mutex m_mutex;
     // the nodeList include both the consensus nodes and the observer nodes
     std::shared_ptr<dev::h512s> m_nodeList;
-    std::atomic<int64_t> m_nodeNum = {0};
 
     std::atomic<int64_t> m_nodeIndex = {0};
 };

--- a/libsync/TreeTopology.h
+++ b/libsync/TreeTopology.h
@@ -50,24 +50,33 @@ public:
     virtual void updateConsensusNodeInfo(dev::h512s const& _consensusNodes);
 
     // select the nodes by tree topology
-    virtual std::shared_ptr<dev::h512s> selectNodes(std::shared_ptr<std::set<dev::h512>> _peers);
+    virtual std::shared_ptr<dev::h512s> selectNodes(
+        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _consIndex = 0);
+    virtual int64_t consIndex() const
+    {
+        if (m_consIndex == -1)
+        {
+            std::srand(utcTime());
+            return std::rand() % m_nodeNum;
+        }
+        return m_consIndex;
+    }
 
 protected:
     virtual void updateStartAndEndIndex();
 
     // select the child nodes by tree
     virtual void recursiveSelectChildNodes(std::shared_ptr<dev::h512s> _selectedNodeList,
-        ssize_t const& _parentIndex, std::shared_ptr<std::set<dev::h512>> _peers);
+        ssize_t const& _parentIndex, std::shared_ptr<std::set<dev::h512>> _peers,
+        int64_t const& _startIndex);
     // select the parent nodes by tree
     virtual void selectParentNodes(std::shared_ptr<dev::h512s> _selectedNodeList,
-        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _nodeIndex);
+        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _nodeIndex,
+        int64_t const& _startIndex);
 
     virtual bool getNodeIDByIndex(dev::h512& _nodeID, ssize_t const& _nodeIndex) const;
 
-    // get the child node index
-    virtual ssize_t getChildNodeIndex(ssize_t const& _parentIndex, ssize_t const& _offset);
-    // get the parent node index
-    virtual ssize_t getParentNodeIndex(ssize_t const& _nodeIndex);
+    virtual ssize_t getSelectedNodeIndex(ssize_t const& _selectedIndex, ssize_t const& _offset);
 
     ssize_t getNodeIndexByNodeId(std::shared_ptr<dev::h512s> _findSet, dev::h512& _nodeId);
 
@@ -75,6 +84,7 @@ protected:
     mutable Mutex m_mutex;
     // the list of the current consensus nodes
     std::shared_ptr<dev::h512s> m_currentConsensusNodes;
+    std::atomic<int64_t> m_nodeNum = {0};
 
     unsigned m_treeWidth;
     dev::h512 m_nodeId;
@@ -82,8 +92,6 @@ protected:
 
     std::atomic<int64_t> m_endIndex = {0};
     std::atomic<int64_t> m_startIndex = {0};
-
-    ssize_t m_childOffset = 0;
 };
 }  // namespace sync
 }  // namespace dev

--- a/test/unittests/libsync/SyncMasterTest.cpp
+++ b/test/unittests/libsync/SyncMasterTest.cpp
@@ -51,9 +51,11 @@ public:
         std::shared_ptr<dev::blockverifier::BlockVerifierInterface> _blockVerifier,
         PROTOCOL_ID const& _protocolId, NodeID const& _nodeId, h256 const& _genesisHash,
         unsigned const& _idleWaitMs = 200, int64_t const& _gossipInterval = 1000,
-        int64_t const& _gossipPeers = 3, bool const& _enableSendBlockStatusByTree = false)
+        int64_t const& _gossipPeers = 3, bool const& _enableSendTxsByTree = false,
+        bool const& _enableSendBlockStatusByTree = false)
       : SyncMaster(_service, _txPool, _blockChain, _blockVerifier, _protocolId, _nodeId,
-            _genesisHash, _idleWaitMs, _gossipInterval, _gossipPeers, _enableSendBlockStatusByTree)
+            _genesisHash, _idleWaitMs, _gossipInterval, _gossipPeers, _enableSendTxsByTree,
+            _enableSendBlockStatusByTree)
     {}
 
     /// start blockSync

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -548,9 +548,11 @@ function generate_group_ini()
     limit=150000
 [sync]
     idle_wait_ms=200
-    ; send block status and transaction by tree-topology
-    ; only supported when use pbft
-    sync_by_tree=true
+    ; send block status by tree-topology, only supported when use pbft
+    sync_block_by_tree=true
+    ; send transaction by tree-topology, only supported when use pbft
+    ; recommend to use when deploy many consensus nodes
+    send_txs_by_tree=true
     ; must between 1000 to 3000
     ; only enabled when sync_by_tree is true
     gossip_interval_ms=1000


### PR DESCRIPTION
1. modify send_by_tree to send_block_by_tree
2. add send_txs_by_tree to control transaction-forward
3. modify implement of sync-txs-by-tree
4. fix nullptr-coredump when set `supported_version` to `2.0.0-rc1`