### PR TITLE
fix the consensus problem caused by viewchange

### DIFF
--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1493,7 +1493,7 @@ void PBFTEngine::checkAndChangeView()
         m_timeManager.m_lastConsensusTime = utcSteadyTime();
         m_view = m_toView.load();
         m_notifyNextLeaderSeal = false;
-        m_reqCache->triggerViewChange(m_view);
+        m_reqCache->triggerViewChange(m_view, m_blockChain->number());
         m_blockSync->noteSealingBlockNumber(m_blockChain->number());
     }
 }

--- a/test/unittests/libconsensus/PBFTReqCache.cpp
+++ b/test/unittests/libconsensus/PBFTReqCache.cpp
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(testViewChangeReqRelated)
     FakeInvalidReq<SignReq>(req, req_cache, req_cache.mutableSignCache(), highest, invalid_hash,
         invalidHeightNum, invalidHash, validNum);
     /// trigger viewChange
-    req_cache.triggerViewChange(0);
+    req_cache.triggerViewChange(0, 0);
     BOOST_CHECK(req_cache.isExistViewChange(*viewChange_req3));
     BOOST_CHECK(req_cache.mutableSignCache().size() == 0);
     BOOST_CHECK(req_cache.mutableCommitCache().size() == 0);


### PR DESCRIPTION
1. delete the expired viewchange from specified node when receive newer viewchange
2. delete invalid signReq, futurePrepareReq from the cache when the commitReqCache doesn't contain the req.