### PR TITLE
fault-tolerance for broadcast rawPrepare by tree

### DIFF
--- a/libconsensus/pbft/Common.h
+++ b/libconsensus/pbft/Common.h
@@ -250,6 +250,25 @@ struct PBFTMsg
         list_rlp.swapOut(encodedBytes);
     }
 
+    virtual void encodeStatus(bytes& encodedBytes) const
+    {
+        RLPStream tmp;
+        tmp << height << view << idx << block_hash;
+        RLPStream list_rlp;
+        list_rlp.appendList(1).append(tmp.out());
+        list_rlp.swapOut(encodedBytes);
+    }
+
+    virtual void decodeStatus(bytesConstRef _data)
+    {
+        RLP rlp(_data);
+        RLP const& statusRlp = rlp[0];
+        height = statusRlp[0].toInt<int64_t>();
+        view = statusRlp[1].toInt<VIEWTYPE>();
+        idx = statusRlp[2].toInt<IDXTYPE>();
+        block_hash = statusRlp[3].toHash<h256>(RLP::VeryStrict);
+    }
+
     /**
      * @brief : decode the bytes received from network into PBFTMsg object
      * @param data : network-received data to be decoded

--- a/libconsensus/rotating_pbft/RotatingPBFTEngine.cpp
+++ b/libconsensus/rotating_pbft/RotatingPBFTEngine.cpp
@@ -347,6 +347,8 @@ void RotatingPBFTEngine::sendPrepareMsgFromLeader(
     {
         return PBFTEngine::sendPrepareMsgFromLeader(_prepareReq, _data, _p2pPacketType);
     }
+    m_rpbftReqCache->insertRequestedRawPrepare(_prepareReq->block_hash);
+
     // send prepareReq by tree
     std::shared_ptr<dev::h512s> selectedNodes;
     {
@@ -386,6 +388,7 @@ void RotatingPBFTEngine::forwardReceivedPrepareMsgByTree(
         std::shared_ptr<PBFTMsg> decodedPrepareMsg = std::make_shared<PBFTMsg>();
         decodedPrepareMsg->decode(ref(_pbftMsg->data));
         auto leaderIdx = decodedPrepareMsg->idx;
+        m_rpbftReqCache->insertRequestedRawPrepare(decodedPrepareMsg->block_hash);
 
         // select the nodes that should forward the prepareMsg
         std::shared_ptr<dev::h512s> selectedNodes;
@@ -435,7 +438,6 @@ void RotatingPBFTEngine::onRecvPBFTMessage(
         });
 }
 
-
 bool RotatingPBFTEngine::handlePartiallyPrepare(
     std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _message)
 {
@@ -450,4 +452,210 @@ bool RotatingPBFTEngine::handlePartiallyPrepare(
                 forwardReceivedPrepareMsgByTree(_session, _message, _pbftMsg);
             }
         });
+}
+
+void RotatingPBFTEngine::createPBFTReqCache()
+{
+    m_rpbftReqCache = std::make_shared<RPBFTReqCache>();
+    // only broadcast rawPrepareStatus randomly when broadcast prepare by tree
+    if (m_treeRouter)
+    {
+        m_rpbftReqCache->setRandomSendRawPrepareStatusCallback(
+            boost::bind(&RotatingPBFTEngine::sendRawPrepareStatusRandomly, this, _1));
+    }
+    m_reqCache = m_rpbftReqCache;
+    if (m_enablePrepareWithTxsHash)
+    {
+        m_partiallyPrepareCache = m_rpbftReqCache;
+    }
+}
+
+// send the rawPrepareReq status to other nodes after addRawPrepare
+void RotatingPBFTEngine::sendRawPrepareStatusRandomly(PBFTMsg::Ptr _rawPrepareReq)
+{
+    std::shared_ptr<bytes> rawPrepareReqData = std::make_shared<bytes>();
+    _rawPrepareReq->encodeStatus(*rawPrepareReqData);
+
+    // only chose 25% peers to broadcast RPBFTRawPrepareStatusPacket
+    std::shared_ptr<P2PSessionInfos> sessions = std::make_shared<P2PSessionInfos>();
+    *sessions = m_service->sessionInfosByProtocolID(m_protocolId);
+    size_t selectedSize = std::min(sessions->size(),
+        (m_prepareStatusBroadcastPercent * m_chosedConsensusNodes->size() + 99) / 100);
+    if (selectedSize < sessions->size())
+    {
+        std::srand(utcTime());
+        for (size_t i = 0; i < selectedSize; i++)
+        {
+            size_t randomValue = (std::rand() + selectedSize * nodeIdx()) % sessions->size();
+            std::swap((*sessions)[i], (*sessions)[randomValue]);
+        }
+    }
+    auto p2pMessage = toP2PMessage(rawPrepareReqData, P2PRawPrepareStatusPacket);
+    for (size_t i = 0; i < selectedSize; i++)
+    {
+        auto const& targetNode = (*sessions)[i].nodeID();
+        m_service->asyncSendMessageByNodeID(targetNode, p2pMessage, nullptr);
+        RPBFTENGINE_LOG(DEBUG) << LOG_DESC("sendRawPrepareStatusRandomly")
+                               << LOG_KV("targetNode", targetNode.abridged());
+    }
+    RPBFTENGINE_LOG(DEBUG) << LOG_DESC("sendRawPrepareStatusRandomly")
+                           << LOG_KV("peers", selectedSize)
+                           << LOG_KV("rawPrepHeight", _rawPrepareReq->height)
+                           << LOG_KV("rawPrepHash", _rawPrepareReq->block_hash.abridged())
+                           << LOG_KV("rawPrepView", _rawPrepareReq->view)
+                           << LOG_KV("rawPrepIdx", _rawPrepareReq->idx)
+                           << LOG_KV("packetSize", p2pMessage->length())
+                           << LOG_KV("idx", nodeIdx());
+}
+
+PBFTMsg::Ptr RotatingPBFTEngine::decodeP2PMsgIntoPBFTMsg(
+    std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _message)
+{
+    ssize_t consIndex = 0;
+    bool valid = isValidReq(_message, _session, consIndex);
+    if (!valid)
+    {
+        return nullptr;
+    }
+    PBFTMsg::Ptr pbftMsg = std::make_shared<PBFTMsg>();
+    pbftMsg->decodeStatus(ref(*(_message->buffer())));
+    return pbftMsg;
+}
+
+// receive the rawPrepareReqStatus packet and update the cachedRawPrepareStatus
+void RotatingPBFTEngine::onReceiveRawPrepareStatus(
+    std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message)
+{
+    try
+    {
+        auto pbftMsg = decodeP2PMsgIntoPBFTMsg(_session, _message);
+        if (!pbftMsg)
+        {
+            return;
+        }
+        if (!m_rpbftReqCache->checkReceivedRawPrepareStatus(
+                _session->nodeID(), pbftMsg, m_view, m_blockChain->number()))
+        {
+            return;
+        }
+        // request rawPreparePacket to the selectedNode
+        auto parentNodeList = m_treeRouter->selectParent(m_chosedConsensusNodes, pbftMsg->idx);
+        // the root node of the tree-topology
+        if (parentNodeList->size() == 0)
+        {
+            return;
+        }
+        std::shared_ptr<std::set<dev::h512>> parentNodeSet =
+            std::make_shared<std::set<dev::h512>>(parentNodeList->begin(), parentNodeList->end());
+        auto sessionsInfo = m_service->sessionInfosByProtocolID(m_protocolId);
+
+        bool connectedWithParent = false;
+        for (auto const& sessionInfo : sessionsInfo)
+        {
+            if (parentNodeSet->count(sessionInfo.nodeID()))
+            {
+                connectedWithParent = true;
+                break;
+            }
+        }
+        // the node disconnected with the parent node
+        if (!connectedWithParent)
+        {
+            if (!m_rpbftReqCache->checkAndRequestRawPrepare(pbftMsg))
+            {
+                return;
+            }
+            requestRawPreparePacket(_session->nodeID(), pbftMsg);
+        }
+    }
+    catch (std::exception const& _e)
+    {
+        RPBFTENGINE_LOG(WARNING) << LOG_DESC("onReceiveRawPrepareStatus exceptioned")
+                                 << LOG_KV("peer", _session->nodeID().abridged())
+                                 << LOG_KV("errorInfo", boost::diagnostic_information(_e));
+    }
+}
+
+// request rawPreparePacket from other node when the local rawPrepareReq is empty
+void RotatingPBFTEngine::requestRawPreparePacket(
+    dev::h512 const& _targetNode, PBFTMsg::Ptr _requestedRawPrepareStatus)
+{
+    // encode and send the _requestedRawPrepareStatus to targetNode
+    std::shared_ptr<bytes> rawPrepareStatusData = std::make_shared<bytes>();
+    _requestedRawPrepareStatus->encodeStatus(*rawPrepareStatusData);
+    auto p2pMessage = toP2PMessage(rawPrepareStatusData, RequestRawPreparePacket);
+    m_service->asyncSendMessageByNodeID(_targetNode, p2pMessage, nullptr);
+    if (m_statisticHandler)
+    {
+        m_statisticHandler->updateConsOutPacketsInfo(PrepareReqPacket, 1, p2pMessage->length());
+    }
+    RPBFTENGINE_LOG(DEBUG) << LOG_DESC("requestRawPreparePacket for disconnect with parentNodeList")
+                           << LOG_KV("targetNode", _targetNode.abridged())
+                           << LOG_KV("hash", _requestedRawPrepareStatus->block_hash.abridged())
+                           << LOG_KV("height", _requestedRawPrepareStatus->height)
+                           << LOG_KV("view", _requestedRawPrepareStatus->view)
+                           << LOG_KV("consNumber", m_consensusBlockNumber)
+                           << LOG_KV("curView", m_view)
+                           << LOG_KV("packetSize", p2pMessage->length()) << LOG_KV("idx", m_idx);
+}
+
+// receive rawPrepare request
+void RotatingPBFTEngine::onReceiveRawPrepareRequest(
+    std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message)
+{
+    try
+    {
+        PBFTMsg::Ptr pbftMsg = decodeP2PMsgIntoPBFTMsg(_session, _message);
+        if (!pbftMsg)
+        {
+            return;
+        }
+        std::shared_ptr<bytes> encodedRawPrepare = std::make_shared<bytes>();
+        m_rpbftReqCache->responseRawPrepare(encodedRawPrepare, pbftMsg);
+        // response the rawPrepare
+        auto p2pMessage = transDataToMessage(ref(*encodedRawPrepare), PrepareReqPacket, 0);
+        p2pMessage->setPacketType(RawPrepareResponse);
+        m_service->asyncSendMessageByNodeID(_session->nodeID(), p2pMessage, nullptr);
+        if (m_statisticHandler)
+        {
+            m_statisticHandler->updateConsOutPacketsInfo(PrepareReqPacket, 1, p2pMessage->length());
+        }
+        RPBFTENGINE_LOG(DEBUG) << LOG_DESC("onReceiveRawPrepareRequest and responseRawPrepare")
+                               << LOG_KV("peer", _session->nodeID().abridged())
+                               << LOG_KV("hash", pbftMsg->block_hash.abridged())
+                               << LOG_KV("view", pbftMsg->view) << LOG_KV("height", pbftMsg->height)
+                               << LOG_KV("prepIdx", pbftMsg->idx)
+                               << LOG_KV("packetSize", p2pMessage->length())
+                               << LOG_KV("idx", nodeIdx());
+    }
+    catch (std::exception const& _e)
+    {
+        RPBFTENGINE_LOG(WARNING) << LOG_DESC("onReceiveRawPrepareRequest exceptioned")
+                                 << LOG_KV("peer", _session->nodeID().abridged())
+                                 << LOG_KV("errorInfo", boost::diagnostic_information(_e));
+    }
+}
+
+
+void RotatingPBFTEngine::onReceiveRawPrepareResponse(
+    std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _message)
+{
+    PBFTMsgPacket::Ptr pbftMsgPacket = m_pbftMsgFactory->createPBFTMsgPacket();
+    // invalid pbftMsgPacket
+    if (!decodePBFTMsgPacket(pbftMsgPacket, _message, _session))
+    {
+        return;
+    }
+    PrepareReq::Ptr prepareReq = std::make_shared<PrepareReq>();
+    prepareReq->decode(ref(pbftMsgPacket->data));
+    RPBFTENGINE_LOG(DEBUG) << LOG_DESC("onReceiveRawPrepareResponse")
+                           << LOG_KV("respHash", prepareReq->block_hash.abridged())
+                           << LOG_KV("respHeight", prepareReq->height)
+                           << LOG_KV("respView", prepareReq->view)
+                           << LOG_KV("respIdx", prepareReq->idx)
+                           << LOG_KV("consNumber", m_consensusBlockNumber)
+                           << LOG_KV("curView", m_view) << LOG_KV("idx", m_idx);
+
+    Guard l(m_mutex);
+    handlePrepareMsg(prepareReq, pbftMsgPacket->endpoint);
 }

--- a/libconsensus/rotating_pbft/RotatingPBFTEngine.h
+++ b/libconsensus/rotating_pbft/RotatingPBFTEngine.h
@@ -21,6 +21,7 @@
  * @date: 2019-09-11
  */
 #pragma once
+#include "RPBFTReqCache.h"
 #include <libconsensus/pbft/PBFTEngine.h>
 #include <libdevcore/TreeTopology.h>
 
@@ -61,6 +62,13 @@ public:
                 return selectedNode;
             });
         m_chosedSealerList = std::make_shared<dev::h512s>();
+
+        m_requestRawPrepareWorker =
+            std::make_shared<dev::ThreadPool>("prepRequest-" + std::to_string(m_groupId), 1);
+        m_rawPrepareStatusReceiver =
+            std::make_shared<dev::ThreadPool>("prepRecv-" + std::to_string(m_groupId), 1);
+        m_rawPrepareResponse =
+            std::make_shared<dev::ThreadPool>("prepResp-" + std::to_string(m_groupId), 1);
     }
 
     // create TreeTopology to forward prepare message
@@ -92,6 +100,11 @@ public:
         return *m_chosedSealerList;
     }
 
+    void setPrepareStatusBroadcastPercent(unsigned const& _prepareStatusBroadcastPercent)
+    {
+        m_prepareStatusBroadcastPercent = _prepareStatusBroadcastPercent;
+    }
+
 protected:
     // get the currentLeader
     std::pair<bool, IDXTYPE> getLeader() const override;
@@ -112,6 +125,18 @@ protected:
     bool handlePartiallyPrepare(std::shared_ptr<dev::p2p::P2PSession> _session,
         dev::p2p::P2PMessage::Ptr _message) override;
 
+    // fault-tolerant logic for broadcast-prepare-by-tree
+    virtual void sendRawPrepareStatusRandomly(PBFTMsg::Ptr _rawPrepareReq);
+    virtual void onReceiveRawPrepareStatus(
+        std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _message);
+
+    // receive the requested rawPreparePacket
+    virtual void onReceiveRawPrepareRequest(
+        std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _message);
+
+    virtual void onReceiveRawPrepareResponse(
+        std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _message);
+
     // TODO: select nodes with VRF algorithm
     IDXTYPE VRFSelection() const;
 
@@ -126,6 +151,16 @@ protected:
 
     virtual bool updateEpochSize();
     virtual bool updateRotatingInterval();
+
+    void createPBFTReqCache() override;
+
+private:
+    PBFTMsg::Ptr decodeP2PMsgIntoPBFTMsg(
+        std::shared_ptr<dev::p2p::P2PSession> _session, dev::p2p::P2PMessage::Ptr _message);
+
+    // request RawPrepare packet to the _targetNode
+    void requestRawPreparePacket(
+        dev::h512 const& _targetNode, PBFTMsg::Ptr _requestedRawPrepareStatus);
 
 protected:
     // configured epoch size
@@ -151,6 +186,13 @@ protected:
     bool m_rotatingIntervalUpdated = false;
 
     std::shared_ptr<dev::sync::TreeTopology> m_treeRouter;
+    std::shared_ptr<RPBFTReqCache> m_rpbftReqCache;
+
+    dev::ThreadPool::Ptr m_requestRawPrepareWorker;
+    dev::ThreadPool::Ptr m_rawPrepareStatusReceiver;
+    dev::ThreadPool::Ptr m_rawPrepareResponse;
+
+    unsigned m_prepareStatusBroadcastPercent = 33;
 };
 }  // namespace consensus
 }  // namespace dev

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -297,6 +297,8 @@ void Ledger::initRotatingPBFTEngine(dev::consensus::Sealer::Ptr _sealer)
     if (m_param->mutableConsensusParam().broadcastPrepareByTree)
     {
         rotatingPBFT->createTreeTopology(m_param->mutableConsensusParam().treeWidth);
+        rotatingPBFT->setPrepareStatusBroadcastPercent(
+            m_param->mutableConsensusParam().prepareStatusBroadcastPercent);
         Ledger_LOG(INFO) << LOG_DESC("createTreeTopology")
                          << LOG_KV("treeWidth", m_param->mutableConsensusParam().treeWidth);
     }

--- a/libledger/LedgerParam.cpp
+++ b/libledger/LedgerParam.cpp
@@ -247,6 +247,16 @@ void LedgerParam::initConsensusIniConfig(ptree const& pt)
     }
     mutableConsensusParam().broadcastPrepareByTree =
         pt.get<bool>("consensus.broadcast_prepare_by_tree", true);
+
+    mutableConsensusParam().prepareStatusBroadcastPercent =
+        pt.get<signed>("consensus.prepare_status_broadcast_percent", 33);
+    if (mutableConsensusParam().prepareStatusBroadcastPercent < 25 ||
+        mutableConsensusParam().prepareStatusBroadcastPercent > 100)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidConfiguration() << errinfo_comment(
+                "consensus.prepare_status_broadcast_percent must between 25 and 100"));
+    }
     LedgerParam_LOG(INFO)
         << LOG_BADGE("initConsensusIniConfig")
         << LOG_KV("maxTTL", std::to_string(mutableConsensusParam().maxTTL))
@@ -255,7 +265,9 @@ void LedgerParam::initConsensusIniConfig(ptree const& pt)
         << LOG_KV("blockSizeIncreaseRatio", mutableConsensusParam().blockSizeIncreaseRatio)
         << LOG_KV("enableTTLOptimize", mutableConsensusParam().enableTTLOptimize)
         << LOG_KV("enablePrepareWithTxsHash", mutableConsensusParam().enablePrepareWithTxsHash)
-        << LOG_KV("broadcastPrepareByTree", mutableConsensusParam().broadcastPrepareByTree);
+        << LOG_KV("broadcastPrepareByTree", mutableConsensusParam().broadcastPrepareByTree)
+        << LOG_KV("prepareStatusBroadcastPercent",
+               mutableConsensusParam().prepareStatusBroadcastPercent);
 }
 
 

--- a/libledger/LedgerParam.h
+++ b/libledger/LedgerParam.h
@@ -71,6 +71,7 @@ struct ConsensusParam
 
     bool broadcastPrepareByTree;
     unsigned treeWidth = 3;
+    unsigned prepareStatusBroadcastPercent;
 };
 
 struct AMDBParam


### PR DESCRIPTION
1. select random nodes to broadcast the newest rawPrepare status,
2. the disconnected node request newest rawPrepare according to received
rawPrepare status