### PR TITLE
disable external when supported_version >= 2.3.0

### DIFF
--- a/libdevcore/CommonJS.h
+++ b/libdevcore/CommonJS.h
@@ -129,7 +129,7 @@ jsToInt(std::string const& _s)
         // Hex
         return fromBigEndian<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<
             N * 8, N * 8, boost::multiprecision::unsigned_magnitude,
-            boost::multiprecision::unchecked, void>>>(fromHex(_s.substr(2)));
+            boost::multiprecision::unchecked, void>>>(fromHex(_s.substr(2), WhenError::Throw));
     else if (_s.find_first_not_of("0123456789") == std::string::npos)
         // Decimal
         return boost::multiprecision::number<boost::multiprecision::cpp_int_backend<N * 8, N * 8,
@@ -147,9 +147,9 @@ inline u256 jsToU256(std::string const& _s)
 /// Convert a string representation of a number to an int
 /// String can be a normal decimal number, or a hex prefixed by 0x or 0X, or an octal if prefixed by
 /// 0 Returns 0 in case of failure
-inline int jsToInt(std::string const& _s)
+inline int64_t jsToInt(std::string const& _s)
 {
-    return std::stoi(_s, nullptr, 0);
+    return int64_t(jsToInt<8>(_s));
 }
 
 inline std::string jsToDecimal(std::string const& _s)

--- a/libdevcore/TreeTopology.h
+++ b/libdevcore/TreeTopology.h
@@ -51,6 +51,10 @@ public:
     // select the nodes by tree topology
     virtual std::shared_ptr<dev::h512s> selectNodes(
         std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _consIndex = 0);
+
+    virtual std::shared_ptr<dev::h512s> selectParent(
+        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _consIndex = 0);
+
     virtual int64_t consIndex() const
     {
         if (m_consIndex == -1)
@@ -72,6 +76,8 @@ protected:
     virtual void selectParentNodes(std::shared_ptr<dev::h512s> _selectedNodeList,
         std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _nodeIndex,
         int64_t const& _startIndex);
+
+    int64_t getNodeIndex(int64_t const& _consIndex);
 
     virtual bool getNodeIDByIndex(dev::h512& _nodeID, ssize_t const& _nodeIndex) const;
 

--- a/libledger/DBInitializer.cpp
+++ b/libledger/DBInitializer.cpp
@@ -66,8 +66,22 @@ void DBInitializer::initStorageDB()
     }
     else if (!dev::stringCmpIgnoreCase(m_param->mutableStorageParam().type, "External"))
     {
-        auto storage = initSQLStorage();
-        initTableFactory2(storage, m_param);
+        // only support external when "supported_version < 2.3.0"
+        if (g_BCOSConfig.version() < V2_3_0)
+        {
+            auto storage = initSQLStorage();
+            initTableFactory2(storage, m_param);
+        }
+        else
+        {
+            DBInitializer_LOG(ERROR)
+                << LOG_DESC("Only support external when supported_version is lower than 2.3.0")
+                << LOG_KV("storage_type", m_param->mutableStorageParam().type)
+                << LOG_KV("supported_version", g_BCOSConfig.version());
+            BOOST_THROW_EXCEPTION(
+                UnsupportedFeature() << errinfo_comment(
+                    "Only support external when supported_version is lower than 2.3.0"));
+        }
     }
     else if (!dev::stringCmpIgnoreCase(m_param->mutableStorageParam().type, "MySQL"))
     {

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -735,8 +735,8 @@ Json::Value Rpc::getTransactionByBlockHashAndIndex(
                 JsonRpcException(RPCExceptionType::BlockHash, RPCMsg[RPCExceptionType::BlockHash]));
 
         auto transactions = block->transactions();
-        unsigned int txIndex = jsToInt(_transactionIndex);
-        if (txIndex >= transactions->size())
+        int64_t txIndex = jsToInt(_transactionIndex);
+        if (txIndex >= int64_t(transactions->size()))
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 RPCExceptionType::TransactionIndex, RPCMsg[RPCExceptionType::TransactionIndex]));
 
@@ -788,8 +788,8 @@ Json::Value Rpc::getTransactionByBlockNumberAndIndex(
                 RPCExceptionType::BlockNumberT, RPCMsg[RPCExceptionType::BlockNumberT]));
 
         auto transactions = block->transactions();
-        unsigned int txIndex = jsToInt(_transactionIndex);
-        if (txIndex >= transactions->size())
+        int64_t txIndex = jsToInt(_transactionIndex);
+        if (txIndex >= int64_t(transactions->size()))
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 RPCExceptionType::TransactionIndex, RPCMsg[RPCExceptionType::TransactionIndex]));
 


### PR DESCRIPTION
1. disable external when supported_version >= 2.3.0
2. fix confused response of getTransactionByBlockHashAndIndex when input invalid transaction index
3. add selectParentsNode to TreeTopology