### PR TITLE
fix lexical_cast<uint64_t>("-1") fail to throw

### DIFF
--- a/libchannelserver/ChannelMessage.h
+++ b/libchannelserver/ChannelMessage.h
@@ -44,19 +44,19 @@ namespace channel
 {
 enum ChannelMessageType
 {
-    CHANNEL_RPC_REQUEST = 0x12,        // type for rpc request
-    CLIENT_HEARTBEAT = 0x13,           // type for heart beat for sdk
-    CLIENT_HANDSHAKE = 0x14,           // type for hand shake
-    CLIENT_REGISTER_EVENT_LOG = 0x15,  // type for event log filter register request and response
-    AMOP_REQUEST = 0x30,               // type for request from sdk
-    AMOP_RESPONSE = 0x31,              // type for response to sdk
-    AMOP_CLIENT_TOPICS = 0x32,         // type for topic request
-    AMOP_MULBROADCAST = 0x35,          // type for mult broadcast
-    REQUEST_TOPICCERT = 0x37,          // type request verify
-    UPDATE_TOPIICSTATUS = 0x38,        // type for update status
-    TRANSACTION_NOTIFY = 0x1000,       // type for  transaction notify
-    BLOCK_NOTIFY = 0x1001,             // type for  block notify
-    EVENT_LOG_PUSH = 0x1002            // type for event log push
+    CHANNEL_RPC_REQUEST = 0x12,           // type for rpc request
+    CLIENT_HEARTBEAT = 0x13,              // type for heart beat for sdk
+    CLIENT_HANDSHAKE = 0x14,              // type for hand shake
+    CLIENT_REGISTER_EVENT_LOG = 0x15,     // type for event log filter register request and response
+    AMOP_REQUEST = 0x30,                  // type for request from sdk
+    AMOP_RESPONSE = 0x31,                 // type for response to sdk
+    AMOP_CLIENT_SUBSCRIBE_TOPICS = 0x32,  // type for topic request
+    AMOP_MULBROADCAST = 0x35,             // type for mult broadcast
+    REQUEST_TOPICCERT = 0x37,             // type request verify
+    UPDATE_TOPIICSTATUS = 0x38,           // type for update status
+    TRANSACTION_NOTIFY = 0x1000,          // type for  transaction notify
+    BLOCK_NOTIFY = 0x1001,                // type for  block notify
+    EVENT_LOG_PUSH = 0x1002               // type for event log push
 };
 
 class ChannelMessage : public Message

--- a/libchannelserver/ChannelRPCServer.cpp
+++ b/libchannelserver/ChannelRPCServer.cpp
@@ -292,7 +292,7 @@ void dev::ChannelRPCServer::onClientRequest(dev::channel::ChannelSession::Ptr se
         case AMOP_MULBROADCAST:
             onClientChannelRequest(session, message);
             break;
-        case AMOP_CLIENT_TOPICS:
+        case AMOP_CLIENT_SUBSCRIBE_TOPICS:
             onClientTopicRequest(session, message);
             break;
         case UPDATE_TOPIICSTATUS:

--- a/libethcore/TransactionReceipt.cpp
+++ b/libethcore/TransactionReceipt.cpp
@@ -109,6 +109,8 @@ std::ostream& dev::eth::operator<<(std::ostream& _out, TransactionReceipt const&
     _out << "Root: " << _r.stateRoot() << "\n";
     _out << "Gas used: " << _r.gasUsed() << "\n";
     _out << "contractAddress : " << _r.contractAddress() << "\n";
+    _out << "status : " << int(_r.status()) << "\n";
+    _out << "output: " << toHex(_r.outputBytes()) << " \n";
     _out << "Logs: " << _r.log().size() << " entries:"
          << "\n";
     for (LogEntry const& i : _r.log())

--- a/libprecompiled/KVTableFactoryPrecompiled.cpp
+++ b/libprecompiled/KVTableFactoryPrecompiled.cpp
@@ -85,6 +85,7 @@ bytes KVTableFactoryPrecompiled::call(
             STORAGE_LOG(WARNING) << LOG_BADGE("KVTableFactoryPrecompiled")
                                  << LOG_DESC("Open new table failed")
                                  << LOG_KV("table name", tableName);
+            BOOST_THROW_EXCEPTION(PrecompiledException(tableName + " does not exist"));
         }
 
         out = abi.abiIn("", address);
@@ -138,7 +139,6 @@ bytes KVTableFactoryPrecompiled::call(
         }
 
         int result = 0;
-
         try
         {
             auto table =
@@ -152,6 +152,10 @@ bytes KVTableFactoryPrecompiled::call(
         {
             STORAGE_LOG(ERROR) << "Create table failed: " << boost::diagnostic_information(e);
             result = e.errorCode();
+            if (e.errorCode() == storage::CODE_NO_AUTHORIZED)
+            {
+                BOOST_THROW_EXCEPTION(PrecompiledException(std::string("permission denied")));
+            }
         }
         getErrorCodeOut(out, result);
     }

--- a/libprecompiled/SystemConfigPrecompiled.cpp
+++ b/libprecompiled/SystemConfigPrecompiled.cpp
@@ -66,8 +66,7 @@ bytes SystemConfigPrecompiled::call(
         if (!checkValueValid(configKey, configValue))
         {
             PRECOMPILED_LOG(DEBUG)
-                << LOG_BADGE("SystemConfigPrecompiled")
-                << LOG_DESC("SystemConfigPrecompiled set invalid value")
+                << LOG_BADGE("SystemConfigPrecompiled") << LOG_DESC("set invalid value")
                 << LOG_KV("configKey", configKey) << LOG_KV("configValue", configValue);
             getErrorCodeOut(out, CODE_INVALID_CONFIGURATION_VALUES);
             return out;
@@ -132,7 +131,7 @@ bool SystemConfigPrecompiled::checkValueValid(std::string const& key, std::strin
     {
         try
         {
-            return (boost::lexical_cast<uint64_t>(value) >= TX_COUNT_LIMIT_MIN);
+            return (boost::lexical_cast<int64_t>(value) >= TX_COUNT_LIMIT_MIN);
         }
         catch (boost::bad_lexical_cast& e)
         {
@@ -144,7 +143,7 @@ bool SystemConfigPrecompiled::checkValueValid(std::string const& key, std::strin
     {
         try
         {
-            return (boost::lexical_cast<uint64_t>(value) >= TX_GAS_LIMIT_MIN);
+            return (boost::lexical_cast<int64_t>(value) >= TX_GAS_LIMIT_MIN);
         }
         catch (boost::bad_lexical_cast& e)
         {
@@ -156,7 +155,7 @@ bool SystemConfigPrecompiled::checkValueValid(std::string const& key, std::strin
     {
         try
         {
-            return (boost::lexical_cast<uint64_t>(value) >= RPBFT_EPOCH_SIZE_MIN);
+            return (boost::lexical_cast<int64_t>(value) >= RPBFT_EPOCH_SIZE_MIN);
         }
         catch (boost::bad_lexical_cast& e)
         {
@@ -169,7 +168,7 @@ bool SystemConfigPrecompiled::checkValueValid(std::string const& key, std::strin
     {
         try
         {
-            return (boost::lexical_cast<uint64_t>(value) >= RPBFT_ROTATING_INTERVAL_MIN);
+            return (boost::lexical_cast<int64_t>(value) >= RPBFT_ROTATING_INTERVAL_MIN);
         }
         catch (boost::bad_lexical_cast& e)
         {

--- a/libprecompiled/solidity/Table.sol
+++ b/libprecompiled/solidity/Table.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.4.24;
 
 contract TableFactory {
-    function openTable(string) public constant returns (Table); //open table
+    function openTable(string) public view returns (Table); //open table
     function createTable(string, string, string) public returns (int256); //create table
 }
 
@@ -25,12 +25,12 @@ contract Condition {
 
 //one record
 contract Entry {
-    function getInt(string) public constant returns (int256);
-    function getUInt(string) public constant returns (int256);
-    function getAddress(string) public constant returns (address);
-    function getBytes64(string) public constant returns (bytes1[64]);
-    function getBytes32(string) public constant returns (bytes32);
-    function getString(string) public constant returns (string);
+    function getInt(string) public view returns (int256);
+    function getUInt(string) public view returns (int256);
+    function getAddress(string) public view returns (address);
+    function getBytes64(string) public view returns (bytes1[64]);
+    function getBytes32(string) public view returns (bytes32);
+    function getString(string) public view returns (string);
 
     function set(string, int256) public;
     function set(string, uint256) public;
@@ -40,29 +40,29 @@ contract Entry {
 
 //record sets
 contract Entries {
-    function get(int256) public constant returns (Entry);
-    function size() public constant returns (int256);
+    function get(int256) public view returns (Entry);
+    function size() public view returns (int256);
 }
 
 //Table main contract
 contract Table {
-    function select(string, Condition) public constant returns (Entries);
+    function select(string, Condition) public view returns (Entries);
     function insert(string, Entry) public returns (int256);
     function update(string, Entry, Condition) public returns (int256);
     function remove(string, Condition) public returns (int256);
 
-    function newEntry() public constant returns (Entry);
-    function newCondition() public constant returns (Condition);
+    function newEntry() public view returns (Entry);
+    function newCondition() public view returns (Condition);
 }
 
 contract KVTableFactory {
-    function openTable(string) public constant returns (KVTable);
+    function openTable(string) public view returns (KVTable);
     function createTable(string, string, string) public returns (int256);
 }
 
 //KVTable per permiary key has only one Entry
 contract KVTable {
-    function get(string) public constant returns (bool, Entry);
+    function get(string) public view returns (bool, Entry);
     function set(string, Entry) public returns (int256);
-    function newEntry() public constant returns (Entry);
+    function newEntry() public view returns (Entry);
 }

--- a/test/unittests/libprecompiled/test_KVTableFactoryPrecompiled.cpp
+++ b/test/unittests/libprecompiled/test_KVTableFactoryPrecompiled.cpp
@@ -89,30 +89,21 @@ BOOST_AUTO_TEST_CASE(call_afterBlock)
         std::string("item_name,item_id"));
     out = tableFactoryPrecompiled->call(context, bytesConstRef(&param));
     abi.abiOut(&out, errCode);
-    if (g_BCOSConfig.version() > RC2_VERSION)
-    {
-        BOOST_TEST(errCode == CODE_TABLE_NAME_ALREADY_EXIST);
-    }
-    else
-    {
-        BOOST_TEST(errCode == -CODE_TABLE_NAME_ALREADY_EXIST);
-    }
+
+    BOOST_TEST(errCode == CODE_TABLE_NAME_ALREADY_EXIST);
 
     // openTable not exist
     param.clear();
     out.clear();
     param = abi.abiIn("openTable(string)", std::string("t_poor"));
-    out = tableFactoryPrecompiled->call(context, bytesConstRef(&param));
-    Address addressOut;
-    addressOut.clear();
-    abi.abiOut(&out, addressOut);
-    BOOST_TEST(addressOut == Address(0x0));
+    BOOST_CHECK_THROW(
+        tableFactoryPrecompiled->call(context, bytesConstRef(&param)), PrecompiledException);
 
     param.clear();
     out.clear();
     param = abi.abiIn("openTable(string)", std::string("t_test"));
     out = tableFactoryPrecompiled->call(context, bytesConstRef(&param));
-    addressOut.clear();
+    Address addressOut;
     abi.abiOut(&out, addressOut);
     BOOST_TEST(addressOut == Address(++addressCount));
 }


### PR DESCRIPTION
1. make KVTableFactory output error message to receipt
2. fix lexical_cast<uint64_t>("-1") fail to throw

https://www.boost.org/doc/libs/1_54_0/doc/html/boost_lexical_cast/frequently_asked_questions.html
>>>Question: Why std::cout << boost::lexical_cast<unsigned int>("-1"); does not throw, but outputs 4294967295?
Answer: boost::lexical_cast has the behavior of std::stringstream, which uses num_get functions of std::locale to convert numbers. If we look at the Programming languages — C++, we'll see, that num_get uses the rules of scanf for conversions. And in the C99 standard for unsigned input value minus sign is optional, so if a negative number is read, no errors will arise and the result will be the two's complement.

https://stackoverflow.com/questions/13199008/check-for-negative-values-when-using-lexical-cast-to-unsigned-type