### PR TITLE
fix duplicated message transfer && remove checkSign when add future req

### DIFF
--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -951,7 +951,10 @@ bool PBFTEngine::handlePrepareMsg(PrepareReq::Ptr prepareReq, std::string const&
         << LOG_KV("myNode", m_keyPair.pub().abridged())
         << LOG_KV("curChangeCycle", m_timeManager.m_changeCycle);
     /// check the prepare request is valid or not
-    auto valid_ret = isValidPrepare(*prepareReq, oss);
+    // since the sealer list of the future block maybe different from the current block, and
+    // the sign will be checked again when handle the future prepareReq, so remove checkSign here
+    // in case of check the valid signature as invalid
+    auto valid_ret = isValidPrepare(*prepareReq, oss, false);
     if (valid_ret == CheckResult::INVALID)
     {
         clearPreRawPrepare();

--- a/libdevcore/TreeTopology.cpp
+++ b/libdevcore/TreeTopology.cpp
@@ -238,6 +238,8 @@ std::shared_ptr<dev::h512s> TreeTopology::selectNodesByNodeID(
     std::shared_ptr<std::set<dev::h512>> _peers, dev::h512 const& _nodeID)
 {
     auto consIndex = getNodeIndexByNodeId(m_currentConsensusNodes, _nodeID);
+    TREE_LOG(DEBUG) << LOG_DESC("selectNodesByNodeID") << LOG_KV("consIndex", consIndex)
+                    << LOG_KV("nodeID", _nodeID.abridged());
     return selectNodes(_peers, consIndex);
 }
 


### PR DESCRIPTION
1. add sended message info into the cache to in case of repeated message-transfer,
2. remove checkSign when add-future-req