### PR TITLE
avoid forward txs by tree from the non-consensus-nodes

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -11,11 +11,11 @@ coverage:
   status:
     project:
       app:
-        target: 65
+        target: 64
         threshold: 0.5
         paths: "!test/"
       default:
-        target: 75
+        target: 74
         threshold: 0.5
     patch:
       default:

--- a/libconsensus/rotating_pbft/RotatingPBFTEngine.cpp
+++ b/libconsensus/rotating_pbft/RotatingPBFTEngine.cpp
@@ -723,6 +723,12 @@ void RotatingPBFTEngine::handleP2PMessage(dev::p2p::NetworkException _exception,
 {
     try
     {
+        // disable broadcast prepare by tree
+        if (!m_treeRouter)
+        {
+            return PBFTEngine::handleP2PMessage(_exception, _session, _message);
+        }
+        // enable broadcast prepare by tree
         switch (_message->packetType())
         {
         // status of RawPrepareReq

--- a/libdevcore/TreeTopology.cpp
+++ b/libdevcore/TreeTopology.cpp
@@ -189,14 +189,19 @@ int64_t TreeTopology::getNodeIndex(int64_t const& _consIndex)
     return nodeIndex;
 }
 
-std::shared_ptr<dev::h512s> TreeTopology::selectNodes(
-    std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _consIndex)
+std::shared_ptr<dev::h512s> TreeTopology::selectNodes(std::shared_ptr<std::set<dev::h512>> _peers,
+    int64_t const& _consIndex, bool const& _isTheStartNode)
 {
     Guard l(m_mutex);
     std::shared_ptr<dev::h512s> selectedNodeList = std::make_shared<dev::h512s>();
-    // the observer nodes
+    // the first node is the  observer nodes or not belong to the group
+    // send messages to the given consNode or the child of the given consNode
     if (m_consIndex < 0)
     {
+        if (!_isTheStartNode)
+        {
+            return selectedNodeList;
+        }
         dev::h512 selectedNode;
         if (getNodeIDByIndex(selectedNode, _consIndex) && _peers->count(selectedNode))
         {
@@ -235,10 +240,11 @@ std::shared_ptr<dev::h512s> TreeTopology::selectParent(
 }
 
 std::shared_ptr<dev::h512s> TreeTopology::selectNodesByNodeID(
-    std::shared_ptr<std::set<dev::h512>> _peers, dev::h512 const& _nodeID)
+    std::shared_ptr<std::set<dev::h512>> _peers, dev::h512 const& _nodeID,
+    bool const& _isTheStartNode)
 {
     auto consIndex = getNodeIndexByNodeId(m_currentConsensusNodes, _nodeID);
-    return selectNodes(_peers, consIndex);
+    return selectNodes(_peers, consIndex, _isTheStartNode);
 }
 
 std::shared_ptr<dev::h512s> TreeTopology::selectParentByNodeID(

--- a/libdevcore/TreeTopology.h
+++ b/libdevcore/TreeTopology.h
@@ -49,11 +49,12 @@ public:
     virtual void updateConsensusNodeInfo(dev::h512s const& _consensusNodes);
 
     // select the nodes by tree topology
-    virtual std::shared_ptr<dev::h512s> selectNodes(
-        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _consIndex = 0);
+    virtual std::shared_ptr<dev::h512s> selectNodes(std::shared_ptr<std::set<dev::h512>> _peers,
+        int64_t const& _consIndex = 0, bool const& _isTheStartNode = false);
 
     virtual std::shared_ptr<dev::h512s> selectNodesByNodeID(
-        std::shared_ptr<std::set<dev::h512>> _peers, dev::h512 const& _nodeID);
+        std::shared_ptr<std::set<dev::h512>> _peers, dev::h512 const& _nodeID,
+        bool const& _isTheStartNode = false);
 
     virtual std::shared_ptr<dev::h512s> selectParentByNodeID(
         std::shared_ptr<std::set<dev::h512>> _peers, dev::h512 const& _nodeID);

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -81,7 +81,6 @@ DEV_SIMPLE_EXCEPTION(InvalidBlockFormat);
 DEV_SIMPLE_EXCEPTION(InvalidBlockHeaderItemCount);
 DEV_SIMPLE_EXCEPTION(InvalidBlockWithBadStateOrReceipt);
 DEV_SIMPLE_EXCEPTION(ErrorBlockHash);
-DEV_SIMPLE_EXCEPTION(NotCompleteBlock);
 
 /// block execution related
 DEV_SIMPLE_EXCEPTION(BlockExecutionFailed);

--- a/libethcore/PartiallyBlock.cpp
+++ b/libethcore/PartiallyBlock.cpp
@@ -175,14 +175,6 @@ void PartiallyBlock::encodeMissedInfo(std::shared_ptr<bytes> _encodedBytes)
 void PartiallyBlock::fetchMissedTxs(
     std::shared_ptr<bytes> _encodedBytes, bytesConstRef _missInfo, dev::h256 const& _expectedHash)
 {
-    if (m_missedTransactions->size() > 0)
-    {
-        PartiallyBlock_LOG(WARNING) << LOG_DESC(
-            "fetchMissedTxs failed for the block-self does not has complete transactions");
-        BOOST_THROW_EXCEPTION(
-            NotCompleteBlock() << errinfo_comment(
-                "fetchMissedTxs: the block-self does not has complete transactions"));
-    }
     // decode _missInfo
     RLP missedInfoRlp(_missInfo);
     // Note: since the blockHash maybe changed after the block executed,

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -1158,6 +1158,8 @@ std::string Rpc::sendRawTransaction(int _groupID, const std::string& _rlp)
     }
     catch (std::exception& e)
     {
+        RPC_LOG(ERROR) << LOG_DESC("sendRawTransaction exceptioned") << LOG_KV("groupID", _groupID)
+                       << LOG_KV("errorMessage", boost::diagnostic_information(e));
         BOOST_THROW_EXCEPTION(
             JsonRpcException(Errors::ERROR_RPC_INTERNAL_ERROR, boost::diagnostic_information(e)));
     }

--- a/libsync/DownloadingTxsQueue.cpp
+++ b/libsync/DownloadingTxsQueue.cpp
@@ -36,7 +36,7 @@ void DownloadingTxsQueue::push(
     if (_msg->packetType() == RPCPacketType && m_treeRouter)
     {
         int64_t consIndex = _packet->rlp()[1].toPositiveInt64();
-        SYNC_LOG(TRACE) << LOG_DESC("receive and send transactions by tree")
+        SYNC_LOG(DEBUG) << LOG_DESC("receive and send transactions by tree")
                         << LOG_KV("consIndex", consIndex)
                         << LOG_KV("fromPeer", _fromPeer.abridged());
 
@@ -54,7 +54,7 @@ void DownloadingTxsQueue::push(
                 m_statisticHandler->updateSendedTxsInfo(_msg->length());
             }
             txsShard->appendForwardNodes(selectedNode);
-            SYNC_LOG(TRACE) << LOG_DESC("forward transaction")
+            SYNC_LOG(DEBUG) << LOG_DESC("forward transaction")
                             << LOG_KV("selectedNode", selectedNode.abridged());
         }
     }

--- a/libsync/SyncMaster.cpp
+++ b/libsync/SyncMaster.cpp
@@ -251,7 +251,7 @@ void SyncMaster::maintainBlocks()
 
 void SyncMaster::sendSyncStatusByTree(BlockNumber const& _blockNumber, h256 const& _currentHash)
 {
-    auto selectedNodes = m_syncTreeRouter->selectNodes(m_syncStatus->peersSet());
+    auto selectedNodes = m_syncTreeRouter->selectNodesForBlockSync(m_syncStatus->peersSet());
     SYNC_LOG(DEBUG) << LOG_BADGE("sendSyncStatusByTree") << LOG_KV("blockNumber", _blockNumber)
                     << LOG_KV("currentHash", _currentHash.abridged())
                     << LOG_KV("selectedNodes", selectedNodes->size());

--- a/libsync/SyncTransaction.cpp
+++ b/libsync/SyncTransaction.cpp
@@ -160,7 +160,8 @@ void SyncTransaction::broadcastTransactions(std::shared_ptr<NodeIDs> _selectedPe
         }
         if (_fromRpc && m_treeRouter && !randomSelectedPeersInited)
         {
-            randomSelectedPeers = m_treeRouter->selectNodes(m_syncStatus->peersSet(), consIndex);
+            randomSelectedPeers =
+                m_treeRouter->selectNodes(m_syncStatus->peersSet(), consIndex, true);
             randomSelectedPeersInited = true;
         }
         // the randomSelectedPeers is empty, continue without setTransactionIsKnownBy

--- a/libsync/SyncTreeTopology.cpp
+++ b/libsync/SyncTreeTopology.cpp
@@ -177,8 +177,8 @@ void SyncTreeTopology::selectParentNodes(std::shared_ptr<dev::h512s> _selectedNo
     return TreeTopology::selectParentNodes(_selectedNodeList, _peers, _nodeIndex, _startIndex);
 }
 
-std::shared_ptr<dev::h512s> SyncTreeTopology::selectNodes(
-    std::shared_ptr<std::set<dev::h512>> _peers, int64_t const&)
+std::shared_ptr<dev::h512s> SyncTreeTopology::selectNodesForBlockSync(
+    std::shared_ptr<std::set<dev::h512>> _peers)
 {
     Guard l(m_mutex);
     std::shared_ptr<dev::h512s> selectedNodeList = std::make_shared<dev::h512s>();

--- a/libsync/SyncTreeTopology.h
+++ b/libsync/SyncTreeTopology.h
@@ -47,8 +47,8 @@ public:
     // consensus info must be updated with nodeList
     virtual void updateAllNodeInfo(dev::h512s const& _consensusNodes, dev::h512s const& _nodeList);
     // select the nodes by tree topology
-    std::shared_ptr<dev::h512s> selectNodes(
-        std::shared_ptr<std::set<dev::h512>> _peers, int64_t const& _consIndex = 0) override;
+    virtual std::shared_ptr<dev::h512s> selectNodesForBlockSync(
+        std::shared_ptr<std::set<dev::h512>> _peers);
 
 protected:
     bool getNodeIDByIndex(dev::h512& _nodeID, ssize_t const& _nodeIndex) const override;

--- a/libtxpool/TxPool.cpp
+++ b/libtxpool/TxPool.cpp
@@ -644,7 +644,6 @@ std::shared_ptr<Transactions> TxPool::topTransactions(
                     << LOG_DESC("Invalid blocklimit") << LOG_KV("hash", (*it)->sha3().abridged())
                     << LOG_KV("blockLimit", (*it)->blockLimit())
                     << LOG_KV("blockNumber", m_blockChain->number());
-                ;
                 continue;
             }
             if (!_avoid.count((*it)->sha3()))

--- a/test/unittests/libtxpool/TxPool.cpp
+++ b/test/unittests/libtxpool/TxPool.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(testImportAndSubmit)
         BOOST_CHECK(pending_list[i - 1]->importTime() <= pending_list[i]->importTime());
     }
     /// test out of limit, clear the queue
-    tx->setNonce(u256(tx->nonce() + u256(10)));
+    tx->setNonce(u256(tx->nonce() + u256(i) + u256(10)));
     tx->setBlockLimit(pool_test.m_blockChain->number() + u256(1));
     sig = sign(pool_test.m_blockChain->m_keyPair, tx->sha3(WithoutSignature));
     tx->updateSignature(SignatureStruct(sig));


### PR DESCRIPTION
don't forward txs by tree when the intermediate node who is observer or not belongs to the group