### PR TITLE
avoid repeated message transfer && check signature for the future req when collecting requests

### DIFF
--- a/libconsensus/pbft/Common.h
+++ b/libconsensus/pbft/Common.h
@@ -214,6 +214,8 @@ struct PBFTMsg
     Signature sig = Signature();
     /// signature to the hash of other fields except block_hash, sig and sig2
     Signature sig2 = Signature();
+    bool isFuture = false;
+    bool signChecked = true;
 
     PBFTMsg() = default;
     PBFTMsg(KeyPair const& _keyPair, int64_t const& _height, VIEWTYPE const& _view,

--- a/libdevcore/TreeTopology.cpp
+++ b/libdevcore/TreeTopology.cpp
@@ -244,6 +244,8 @@ std::shared_ptr<dev::h512s> TreeTopology::selectNodesByNodeID(
     bool const& _isTheStartNode)
 {
     auto consIndex = getNodeIndexByNodeId(m_currentConsensusNodes, _nodeID);
+    TREE_LOG(DEBUG) << LOG_DESC("selectNodesByNodeID") << LOG_KV("consIndex", consIndex)
+                    << LOG_KV("nodeID", _nodeID.abridged());
     return selectNodes(_peers, consIndex, _isTheStartNode);
 }
 

--- a/libdevcrypto/gm/sm2/sm2.cpp
+++ b/libdevcrypto/gm/sm2/sm2.cpp
@@ -215,19 +215,22 @@ int SM2::verify(const string& _signData, int, const char* originalData, int orig
     sm2Group = EC_GROUP_new_by_curve_name(NID_sm2);
     if (sm2Group == NULL)
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_GROUP_new_by_curve_namee";
+        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_GROUP_new_by_curve_name"
+                          << LOG_KV("pubKey", publicKey);
         goto err;
     }
 
     if ((pubPoint = EC_POINT_new(sm2Group)) == NULL)
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_POINT_new";
+        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_POINT_new"
+                          << LOG_KV("pubKey", publicKey);
         goto err;
     }
 
     if (!EC_POINT_hex2point(sm2Group, (const char*)publicKey.c_str(), pubPoint, NULL))
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_POINT_hex2point";
+        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_POINT_hex2point"
+                          << LOG_KV("pubKey", publicKey);
         goto err;
     }
 
@@ -235,19 +238,21 @@ int SM2::verify(const string& _signData, int, const char* originalData, int orig
 
     if (sm2Key == NULL)
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_KEY_new_by_curve_name";
+        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_KEY_new_by_curve_name"
+                          << LOG_KV("pubKey", publicKey);
         goto err;
     }
 
     if (!EC_KEY_set_public_key(sm2Key, pubPoint))
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_KEY_set_public_key";
+        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of Verify EC_KEY_set_public_key"
+                          << LOG_KV("pubKey", publicKey);
         goto err;
     }
 
     if (!ECDSA_sm2_get_Z((const EC_KEY*)sm2Key, NULL, NULL, 0, zValue, &zValueLen))
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] Error Of Compute Z";
+        CRYPTO_LOG(ERROR) << "[SM2::veify] Error Of Compute Z" << LOG_KV("pubKey", publicKey);
         goto err;
     }
     // SM3 Degist
@@ -260,19 +265,21 @@ int SM2::verify(const string& _signData, int, const char* originalData, int orig
     signData = ECDSA_SIG_new();
     if (!BN_hex2bn(&signData->r, r.c_str()))
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of BN_hex2bn R:" << r;
+        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR of BN_hex2bn" << LOG_KV("R", r)
+                          << LOG_KV("pubKey", publicKey);
         goto err;
     }
 
     if (!BN_hex2bn(&signData->s, s.c_str()))
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR BN_hex2bn S:" << s;
+        CRYPTO_LOG(ERROR) << "[SM2::veify] ERROR BN_hex2bn:" << LOG_KV("S", s)
+                          << LOG_KV("pubKey", publicKey);
         goto err;
     }
 
     if (ECDSA_do_verify(zValue, zValueLen, signData, sm2Key) != 1)
     {
-        CRYPTO_LOG(ERROR) << "[SM2::veify] Error Of SM2 Verify";
+        CRYPTO_LOG(ERROR) << "[SM2::veify] Error Of SM2 Verify" << LOG_KV("pubKey", publicKey);
         goto err;
     }
     // LOG(DEBUG)<<"SM2 Verify successed.";

--- a/test/unittests/libconsensus/FakePBFTEngine.h
+++ b/test/unittests/libconsensus/FakePBFTEngine.h
@@ -67,6 +67,7 @@ public:
         createPBFTMsgFactory();
         m_blockFactory = std::make_shared<dev::eth::BlockFactory>();
         m_reqCache = std::make_shared<PBFTReqCache>();
+        m_reqCache->setCheckSignCallback(boost::bind(&FakePBFTEngine::checkSign, this, _1));
     }
     void updateConsensusNodeList() override {}
     void fakeUpdateConsensusNodeList() { return PBFTEngine::updateConsensusNodeList(); }

--- a/test/unittests/libconsensus/PBFTEngine.h
+++ b/test/unittests/libconsensus/PBFTEngine.h
@@ -170,8 +170,8 @@ static void FakeSignAndCommitCache(FakeConsensus<T>& fake_pbft, PrepareReq::Ptr 
             fake_pbft.consensus()->reqCache()->mutableSignCache(), highest, invalid_hash,
             invalidHeightNum, invalidHash, validNum, false);
         fake_pbft.consensus()->reqCache()->collectGarbage(highest);
-        BOOST_CHECK(
-            fake_pbft.consensus()->reqCache()->getSigCacheSize(prepareReq->block_hash) == validNum);
+        BOOST_CHECK(fake_pbft.consensus()->reqCache()->getSigCacheSize(
+                        prepareReq->block_hash, validNum) == validNum);
     }
     /// fake commitReq
     if (type == 1 || type == 2)
@@ -180,8 +180,8 @@ static void FakeSignAndCommitCache(FakeConsensus<T>& fake_pbft, PrepareReq::Ptr 
             fake_pbft.consensus()->reqCache()->mutableCommitCache(), highest, invalid_hash,
             invalidHeightNum, invalidHash, validNum, false);
         fake_pbft.consensus()->reqCache()->collectGarbage(highest);
-        BOOST_CHECK(fake_pbft.consensus()->reqCache()->getCommitCacheSize(prepareReq->block_hash) ==
-                    validNum);
+        BOOST_CHECK(fake_pbft.consensus()->reqCache()->getCommitCacheSize(
+                        prepareReq->block_hash, validNum) == validNum);
     }
 }
 

--- a/test/unittests/libconsensus/PBFTReqCache.cpp
+++ b/test/unittests/libconsensus/PBFTReqCache.cpp
@@ -47,14 +47,15 @@ BOOST_AUTO_TEST_CASE(testAddAndExistCase)
     sign_req->view = prepare_req->view + 1;
     req_cache.addSignReq(sign_req);
     BOOST_CHECK(req_cache.isExistSign(*sign_req));
-    BOOST_CHECK(req_cache.getSigCacheSize(sign_req->block_hash) == 1);
+    auto fakeFutureReqCheckNum = 100;
+    BOOST_CHECK(req_cache.getSigCacheSize(sign_req->block_hash, fakeFutureReqCheckNum) == 1);
     /// test addCommitReq
     CommitReq::Ptr commit_req =
         std::make_shared<CommitReq>(*prepare_req, key_pair, prepare_req->idx);
     commit_req->view = prepare_req->view + 1;
     req_cache.addCommitReq(commit_req);
     BOOST_CHECK(req_cache.isExistCommit(*commit_req));
-    BOOST_CHECK(req_cache.getCommitCacheSize(commit_req->block_hash) == 1);
+    BOOST_CHECK(req_cache.getCommitCacheSize(commit_req->block_hash, fakeFutureReqCheckNum) == 1);
     /// test addPrepareReq
     req_cache.addPrepareReq(prepare_req);
     /// test invalid signReq and commitReq removement
@@ -62,8 +63,8 @@ BOOST_AUTO_TEST_CASE(testAddAndExistCase)
         prepare_req->idx, req_cache.prepareCache().timestamp, prepare_req->block_hash);
     BOOST_CHECK(!req_cache.isExistSign(*sign_req));
     BOOST_CHECK(!req_cache.isExistCommit(*commit_req));
-    BOOST_CHECK(req_cache.getSigCacheSize(sign_req->block_hash) == 0);
-    BOOST_CHECK(req_cache.getCommitCacheSize(commit_req->block_hash) == 0);
+    BOOST_CHECK(req_cache.getSigCacheSize(sign_req->block_hash, fakeFutureReqCheckNum) == 0);
+    BOOST_CHECK(req_cache.getCommitCacheSize(commit_req->block_hash, fakeFutureReqCheckNum) == 0);
 
     /// test addFuturePrepareCache
     req_cache.addFuturePrepareCache(prepare_req);
@@ -105,7 +106,7 @@ BOOST_AUTO_TEST_CASE(testSigListSetting)
         req_cache.addCommitReq(commit_req);
         BOOST_CHECK(req_cache.isExistCommit(*commit_req));
     }
-    BOOST_CHECK(req_cache.getCommitCacheSize(prepare_req->block_hash) == node_num);
+    BOOST_CHECK(req_cache.getCommitCacheSize(prepare_req->block_hash, node_num) == node_num);
     /// generateAndSetSigList
     Block block;
     bool ret = req_cache.generateAndSetSigList(block, node_num);
@@ -141,15 +142,15 @@ BOOST_AUTO_TEST_CASE(testCollectGarbage)
     FakeInvalidReq<CommitReq>(req, req_cache, req_cache.mutableCommitCache(), highest, invalid_hash,
         invalidHeightNum, invalidHash, validNum);
     req_cache.collectGarbage(highest);
-    BOOST_CHECK(req_cache.getSigCacheSize(req->block_hash) == validNum);
-    BOOST_CHECK(req_cache.getSigCacheSize(invalid_hash) == 0);
+    BOOST_CHECK(req_cache.getSigCacheSize(req->block_hash, validNum) == validNum);
+    BOOST_CHECK(req_cache.getSigCacheSize(invalid_hash, validNum) == 0);
 
-    BOOST_CHECK(req_cache.getCommitCacheSize(req->block_hash) == validNum);
-    BOOST_CHECK(req_cache.getCommitCacheSize(invalid_hash) == 0);
+    BOOST_CHECK(req_cache.getCommitCacheSize(req->block_hash, validNum) == validNum);
+    BOOST_CHECK(req_cache.getCommitCacheSize(invalid_hash, validNum) == 0);
     /// test delCache
     req_cache.delCache(highest);
-    BOOST_CHECK(req_cache.getSigCacheSize(req->block_hash) == 0);
-    BOOST_CHECK(req_cache.getCommitCacheSize(req->block_hash) == 0);
+    BOOST_CHECK(req_cache.getSigCacheSize(req->block_hash, validNum) == 0);
+    BOOST_CHECK(req_cache.getCommitCacheSize(req->block_hash, validNum) == 0);
 }
 /// test canTriggerViewChange
 BOOST_AUTO_TEST_CASE(testCanTriggerViewChange)


### PR DESCRIPTION
1. mark the sended-requests into the cache to avoid repeated message-transfer
2. check signature for the futureReq when collecting requests