### PR TITLE
fix bug caused by node with pbftBackup rejecting empty block

### DIFF
--- a/libledger/LedgerParam.cpp
+++ b/libledger/LedgerParam.cpp
@@ -234,10 +234,12 @@ void LedgerParam::initRPBFTConsensusIniConfig(boost::property_tree::ptree const&
 void LedgerParam::initConsensusIniConfig(ptree const& pt)
 {
     mutableConsensusParam().maxTTL = pt.get<int8_t>("consensus.ttl", consensus::MAXTTL);
-    if (mutableConsensusParam().maxTTL < 0)
+    if (mutableConsensusParam().maxTTL < 0 ||
+        mutableConsensusParam().maxTTL > mutableConsensusParam().ttlLimit)
     {
-        BOOST_THROW_EXCEPTION(
-            ForbidNegativeValue() << errinfo_comment("Please set consensus.ttl to positive !"));
+        BOOST_THROW_EXCEPTION(ForbidNegativeValue() << errinfo_comment(
+                                  "Please set consensus.ttl between 0 and " +
+                                  std::to_string(mutableConsensusParam().ttlLimit) + " !"));
     }
 
     // the minimum block generation time(ms)

--- a/libledger/LedgerParam.h
+++ b/libledger/LedgerParam.h
@@ -51,6 +51,8 @@ struct ConsensusParam
     dev::h512s observerList = dev::h512s();
     int64_t maxTransactions;
     int8_t maxTTL;
+    // limit ttl to 5
+    int8_t ttlLimit = 5;
     /// the minimum block time
     signed minBlockGenTime = 0;
     /// unsigned intervalBlockTime;

--- a/test/unittests/libconsensus/FakePBFTEngine.h
+++ b/test/unittests/libconsensus/FakePBFTEngine.h
@@ -114,16 +114,16 @@ public:
         PBFTEngine::onRecvPBFTMessage(exception, session, message);
     }
 
-    P2PMessage::Ptr transDataToMessageWrapper(bytesConstRef data, PACKET_TYPE const& packetType,
-        PROTOCOL_ID const& protocolId, unsigned const& ttl)
+    P2PMessage::Ptr transDataToMessageWrapper(
+        bytesConstRef data, PACKET_TYPE const& packetType, unsigned const& ttl)
     {
-        return PBFTEngine::transDataToMessage(data, packetType, protocolId, ttl);
+        return PBFTEngine::transDataToMessage(data, packetType, ttl);
     }
-    bool broadcastMsgWrapper(unsigned const& packetType, std::string const& key, bytesConstRef data,
-        std::unordered_set<h512> const& filter = std::unordered_set<h512>(),
+    bool broadcastMsgWrapper(unsigned const& packetType, PBFTMsg const& _pbftMsg,
+        bytesConstRef data, std::unordered_set<h512> const& filter = std::unordered_set<h512>(),
         unsigned const& ttl = 0)
     {
-        return PBFTEngine::broadcastMsg(packetType, key, data, 0, filter, ttl);
+        return PBFTEngine::broadcastMsg(packetType, _pbftMsg, data, 0, filter, ttl);
     }
 
     bool broadcastFilter(h512 const& nodeId, unsigned const& packetType, std::string const& key)

--- a/test/unittests/libconsensus/PBFTEngine.cpp
+++ b/test/unittests/libconsensus/PBFTEngine.cpp
@@ -318,8 +318,7 @@ BOOST_AUTO_TEST_CASE(testBroadcastMsg)
     bytes data;
     prepare_req.encode(data);
     /// case1: all peer is not the sealer, stop broadcasting
-    fake_pbft.consensus()->broadcastMsgWrapper(
-        PrepareReqPacket, prepare_req.uniqueKey(), ref(data));
+    fake_pbft.consensus()->broadcastMsgWrapper(PrepareReqPacket, prepare_req, ref(data));
     BOOST_CHECK(fake_pbft.consensus()->broadcastFilter(
                     peer_keyPair.pub(), PrepareReqPacket, prepare_req.uniqueKey()) == false);
     BOOST_CHECK(fake_pbft.consensus()->broadcastFilter(
@@ -331,8 +330,7 @@ BOOST_AUTO_TEST_CASE(testBroadcastMsg)
     fake_pbft.m_sealerList.push_back(peer_keyPair.pub());
     fake_pbft.consensus()->appendSealer(peer_keyPair.pub());
     FakePBFTSealer(fake_pbft);
-    fake_pbft.consensus()->broadcastMsgWrapper(
-        PrepareReqPacket, prepare_req.uniqueKey(), ref(data));
+    fake_pbft.consensus()->broadcastMsgWrapper(PrepareReqPacket, prepare_req, ref(data));
 
     BOOST_CHECK(fake_pbft.consensus()->broadcastFilter(
                     peer_keyPair.pub(), PrepareReqPacket, prepare_req.uniqueKey()) == true);
@@ -345,8 +343,7 @@ BOOST_AUTO_TEST_CASE(testBroadcastMsg)
     fake_pbft.m_sealerList.push_back(peer2_keyPair.pub());
     fake_pbft.consensus()->appendSealer(peer2_keyPair.pub());
     FakePBFTSealer(fake_pbft);
-    fake_pbft.consensus()->broadcastMsgWrapper(
-        PrepareReqPacket, prepare_req.uniqueKey(), ref(data));
+    fake_pbft.consensus()->broadcastMsgWrapper(PrepareReqPacket, prepare_req, ref(data));
 
     BOOST_CHECK(fake_pbft.consensus()->broadcastFilter(
                     peer_keyPair.pub(), PrepareReqPacket, prepare_req.uniqueKey()) == true);
@@ -364,8 +361,7 @@ BOOST_AUTO_TEST_CASE(testBroadcastMsg)
     /// fake the filter with node id of peer3
     std::unordered_set<h512> filter;
     filter.insert(peer3_keyPair.pub());
-    fake_pbft.consensus()->broadcastMsgWrapper(
-        PrepareReqPacket, prepare_req.uniqueKey(), ref(data), filter);
+    fake_pbft.consensus()->broadcastMsgWrapper(PrepareReqPacket, prepare_req, ref(data), filter);
 
     BOOST_CHECK(fake_pbft.consensus()->broadcastFilter(
                     peer3_keyPair.pub(), PrepareReqPacket, prepare_req.uniqueKey()) == true);

--- a/test/unittests/libconsensus/PBFTEngine.h
+++ b/test/unittests/libconsensus/PBFTEngine.h
@@ -102,11 +102,11 @@ std::shared_ptr<FakeSession> FakeSessionFunc(Public node_id);
 /// fake message
 template <typename T, typename S>
 P2PMessage::Ptr FakeReqMessage(std::shared_ptr<S> pbft, T const& req, PACKET_TYPE const& packetType,
-    PROTOCOL_ID const& protocolId, unsigned const& ttl = 0)
+    PROTOCOL_ID const&, unsigned const& ttl = 0)
 {
     bytes data;
     req.encode(data);
-    return pbft->transDataToMessageWrapper(ref(data), packetType, protocolId, ttl);
+    return pbft->transDataToMessageWrapper(ref(data), packetType, ttl);
 }
 
 /// check the data received from the network
@@ -329,12 +329,11 @@ static void checkBroadcastSpecifiedMsg(FakeConsensus<S>& fake_pbft, T& tmp_req, 
     FakePBFTSealer(fake_pbft);
 
     T req(prepare_req, fake_pbft.consensus()->keyPair(), fake_pbft.consensus()->nodeIdx());
-    key = req.uniqueKey();
     bytes data;
     req.encode(data);
-    fake_pbft.consensus()->broadcastMsgWrapper(SignReqPacket, key, ref(data));
-    BOOST_CHECK(
-        fake_pbft.consensus()->broadcastFilter(peer_keyPair.pub(), SignReqPacket, key) == true);
+    fake_pbft.consensus()->broadcastMsgWrapper(SignReqPacket, req, ref(data));
+    BOOST_CHECK(fake_pbft.consensus()->broadcastFilter(
+                    peer_keyPair.pub(), SignReqPacket, req.uniqueKey()) == true);
     compareAsyncSendTime(fake_pbft, peer_keyPair.pub(), 1);
 }
 


### PR DESCRIPTION
  don't check isHashSavedAfterCommit when receive prepare with empty block