### PR TITLE
Fix ttl forwarding not taking effect when using  rpbft

### DIFF
--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -650,8 +650,7 @@ protected:
 
     virtual void broadcastMsg(dev::h512s const& _targetNodes, bytesConstRef _data,
         unsigned const& _packetType, unsigned const& _ttl, PACKET_TYPE const& _p2pPacketType);
-    std::shared_ptr<dev::h512s> getForwardNodes(
-        dev::p2p::P2PSessionInfos const& _sessions, bool const& _printLog = false);
+    std::shared_ptr<dev::h512s> getForwardNodes(bool const& _printLog = false);
 
 
     // BIP 152 related logic

--- a/libconsensus/rotating_pbft/RotatingPBFTEngine.cpp
+++ b/libconsensus/rotating_pbft/RotatingPBFTEngine.cpp
@@ -57,7 +57,7 @@ bool RotatingPBFTEngine::locatedInChosedConsensensusNodes() const
 
 void RotatingPBFTEngine::resetConfig()
 {
-    ConsensusEngineBase::resetConfig();
+    PBFTEngine::resetConfig();
     // update the epochBlockNum
     m_rotatingIntervalUpdated = updateRotatingInterval();
     if (m_rotatingIntervalUpdated)

--- a/libconsensus/rotating_pbft/RotatingPBFTEngine.h
+++ b/libconsensus/rotating_pbft/RotatingPBFTEngine.h
@@ -116,6 +116,11 @@ public:
         m_maxRequestMissedTxsWaitTime = _maxRequestMissedTxsWaitTime;
     }
 
+    void setMaxRequestPrepareWaitTime(int64_t const& _maxRequestPrepareWaitTime)
+    {
+        m_maxRequestPrepareWaitTime = _maxRequestPrepareWaitTime;
+    }
+
 protected:
     // get the currentLeader
     std::pair<bool, IDXTYPE> getLeader() const override;

--- a/libexecutive/Executive.cpp
+++ b/libexecutive/Executive.cpp
@@ -182,6 +182,8 @@ bool Executive::call(CallParameters const& _p, u256 const& _gasPrice, Address co
             m_gas = _p.gas;
             if (m_s->frozen(_p.codeAddress))
             {
+                LOG(DEBUG) << LOG_DESC("execute transaction failed for ContractFrozen")
+                           << LOG_KV("contractAddr", _p.codeAddress);
                 m_excepted = TransactionException::ContractFrozen;
             }
             else if (m_s->addressHasCode(_p.codeAddress))
@@ -260,6 +262,8 @@ bool Executive::callRC2(CallParameters const& _p, u256 const& _gasPrice, Address
     }
     else if (m_s->frozen(_p.codeAddress))
     {
+        LOG(DEBUG) << LOG_DESC("execute RC2 transaction failed for ContractFrozen")
+                   << LOG_KV("contractAddr", _p.codeAddress);
         m_excepted = TransactionException::ContractFrozen;
     }
     else if (m_s->addressHasCode(_p.codeAddress))
@@ -556,7 +560,7 @@ void Executive::loggingException()
     if (m_excepted != TransactionException::None)
     {
         LOG(ERROR) << LOG_BADGE("TxExeError") << LOG_DESC("Transaction execution error")
-                   << LOG_KV("hash", (m_t->hasSignature()) ? m_t->sha3().abridged() : "call")
+                   << LOG_KV("hash", (m_t->hasSignature()) ? toHex(m_t->sha3()) : "call")
                    << m_exceptionReason.str();
     }
 }

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -294,6 +294,8 @@ void Ledger::initRotatingPBFTEngine(dev::consensus::Sealer::Ptr _sealer)
     rotatingPBFT->setEpochBlockNum(m_param->mutableConsensusParam().epochBlockNum);
     rotatingPBFT->setMaxRequestMissedTxsWaitTime(
         m_param->mutableConsensusParam().maxRequestMissedTxsWaitTime);
+    rotatingPBFT->setMaxRequestPrepareWaitTime(
+        m_param->mutableConsensusParam().maxRequestPrepareWaitTime);
     if (m_param->mutableConsensusParam().broadcastPrepareByTree)
     {
         rotatingPBFT->createTreeTopology(m_param->mutableConsensusParam().treeWidth);

--- a/libledger/LedgerParam.cpp
+++ b/libledger/LedgerParam.cpp
@@ -186,6 +186,50 @@ void LedgerParam::initTxPoolConfig(ptree const& pt)
     }
 }
 
+void LedgerParam::initRPBFTConsensusIniConfig(boost::property_tree::ptree const& pt)
+{
+    mutableConsensusParam().broadcastPrepareByTree =
+        pt.get<bool>("consensus.broadcast_prepare_by_tree", true);
+
+    mutableConsensusParam().prepareStatusBroadcastPercent =
+        pt.get<signed>("consensus.prepare_status_broadcast_percent", 33);
+    if (mutableConsensusParam().prepareStatusBroadcastPercent < 25 ||
+        mutableConsensusParam().prepareStatusBroadcastPercent > 100)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidConfiguration() << errinfo_comment(
+                "consensus.prepare_status_broadcast_percent must be between 25 and 100"));
+    }
+    // maxRequestMissedTxsWaitTime
+    mutableConsensusParam().maxRequestMissedTxsWaitTime =
+        pt.get<int64_t>("consensus.max_request_missedTxs_waitTime", 100);
+    if (mutableConsensusParam().maxRequestMissedTxsWaitTime < 5 ||
+        mutableConsensusParam().maxRequestMissedTxsWaitTime > 1000)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidConfiguration()
+            << errinfo_comment("consensus.max_request_missedTxs_waitTime must between 5 and 1000"));
+    }
+    // maxRequestPrepareWaitTime;
+    mutableConsensusParam().maxRequestPrepareWaitTime =
+        pt.get<int64_t>("consensus.max_request_prepare_waitTime", 100);
+    if (mutableConsensusParam().maxRequestPrepareWaitTime < 10 ||
+        mutableConsensusParam().maxRequestPrepareWaitTime > 1000)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidConfiguration()
+            << errinfo_comment("consensus.max_request_prepare_waitTime must between 10 and 1000"));
+    }
+    LedgerParam_LOG(INFO) << LOG_BADGE("initRPBFTConsensusIniConfig")
+                          << LOG_KV("broadcastPrepareByTree",
+                                 mutableConsensusParam().broadcastPrepareByTree)
+                          << LOG_KV("prepareStatusBroadcastPercent",
+                                 mutableConsensusParam().prepareStatusBroadcastPercent)
+                          << LOG_KV("maxRequestMissedTxsWaitTime",
+                                 mutableConsensusParam().maxRequestMissedTxsWaitTime)
+                          << LOG_KV("maxRequestPrepareWaitTime",
+                                 mutableConsensusParam().maxRequestPrepareWaitTime);
+}
 
 void LedgerParam::initConsensusIniConfig(ptree const& pt)
 {
@@ -245,28 +289,7 @@ void LedgerParam::initConsensusIniConfig(ptree const& pt)
     {
         mutableConsensusParam().enablePrepareWithTxsHash = false;
     }
-    mutableConsensusParam().broadcastPrepareByTree =
-        pt.get<bool>("consensus.broadcast_prepare_by_tree", true);
 
-    mutableConsensusParam().prepareStatusBroadcastPercent =
-        pt.get<signed>("consensus.prepare_status_broadcast_percent", 33);
-    if (mutableConsensusParam().prepareStatusBroadcastPercent < 25 ||
-        mutableConsensusParam().prepareStatusBroadcastPercent > 100)
-    {
-        BOOST_THROW_EXCEPTION(
-            InvalidConfiguration() << errinfo_comment(
-                "consensus.prepare_status_broadcast_percent must be between 25 and 100"));
-    }
-    mutableConsensusParam().maxRequestMissedTxsWaitTime =
-        pt.get<int64_t>("consensus.max_request_missedTxs_waitTime", 100);
-    if (mutableConsensusParam().maxRequestMissedTxsWaitTime < 5 ||
-        mutableConsensusParam().maxRequestMissedTxsWaitTime > 1000)
-    {
-        BOOST_THROW_EXCEPTION(
-            InvalidConfiguration()
-            << errinfo_comment("consensus.max_request_missedTxs_waitTime must between 5 and 1000"));
-    }
-    // maxRequestMissedTxsWaitTime
     LedgerParam_LOG(INFO)
         << LOG_BADGE("initConsensusIniConfig")
         << LOG_KV("maxTTL", std::to_string(mutableConsensusParam().maxTTL))
@@ -274,12 +297,9 @@ void LedgerParam::initConsensusIniConfig(ptree const& pt)
         << LOG_KV("enablDynamicBlockSize", mutableConsensusParam().enableDynamicBlockSize)
         << LOG_KV("blockSizeIncreaseRatio", mutableConsensusParam().blockSizeIncreaseRatio)
         << LOG_KV("enableTTLOptimize", mutableConsensusParam().enableTTLOptimize)
-        << LOG_KV("enablePrepareWithTxsHash", mutableConsensusParam().enablePrepareWithTxsHash)
-        << LOG_KV("broadcastPrepareByTree", mutableConsensusParam().broadcastPrepareByTree)
-        << LOG_KV("prepareStatusBroadcastPercent",
-               mutableConsensusParam().prepareStatusBroadcastPercent)
-        << LOG_KV(
-               "maxRequestMissedTxsWaitTime", mutableConsensusParam().maxRequestMissedTxsWaitTime);
+        << LOG_KV("enablePrepareWithTxsHash", mutableConsensusParam().enablePrepareWithTxsHash);
+    // init rpbft related configurations
+    initRPBFTConsensusIniConfig(pt);
 }
 
 

--- a/libledger/LedgerParam.h
+++ b/libledger/LedgerParam.h
@@ -73,6 +73,7 @@ struct ConsensusParam
     unsigned treeWidth = 3;
     unsigned prepareStatusBroadcastPercent;
     int64_t maxRequestMissedTxsWaitTime;
+    int64_t maxRequestPrepareWaitTime;
 };
 
 struct AMDBParam
@@ -184,6 +185,7 @@ private:
     void initTxExecuteConfig(boost::property_tree::ptree const& pt);
     void initConsensusConfig(boost::property_tree::ptree const& pt);
     void initConsensusIniConfig(boost::property_tree::ptree const& pt);
+    void initRPBFTConsensusIniConfig(boost::property_tree::ptree const& pt);
     void initSyncConfig(boost::property_tree::ptree const& pt);
     void initEventLogFilterManagerConfig(boost::property_tree::ptree const& pt);
 

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -530,20 +530,22 @@ function generate_group_ini()
     cat << EOF > ${output}
 [consensus]
     ; the ttl for broadcasting pbft message
-    ;ttl=2
+    ttl=2
     ; min block generation time(ms), the max block generation time is 1000 ms
-    ;min_block_generation_time=500
+    min_block_generation_time=500
     ;enable_dynamic_block_size=true
-    ;enable_ttl_optimization=true
-    ;enable_prepare_with_txsHash=true
+    enable_ttl_optimization=true
+    enable_prepare_with_txsHash=true
+    ; The following is the relevant configuration of rpbft
     ; set true to enable broadcast prepare request by tree
-    ;broadcast_prepare_by_tree=true
-    ; percent of selected nodes to receive prepare status
-    ; must be no smaller than 25 and no larger than 100
-    ;prepare_status_broadcast_percent=33
-    ; max wait time before request missed transactions to the leader, ms
-    ; must be no smaller than 5ms and no larger than 1000ms
-    ;max_request_missedTxs_waitTime=100
+    broadcast_prepare_by_tree=true
+    ; percent of nodes that broadcast prepare status to, must be between 25 and 100
+    prepare_status_broadcast_percent=33
+    ; max wait time before request missed transactions, ms, must be between 5ms and 1000ms
+    max_request_missedTxs_waitTime=100
+    ; maximum wait time before requesting a prepare, ms, must be between 10ms and 1000ms
+    max_request_prepare_waitTime=100
+
 [storage]
     ; storage db type, rocksdb / mysql / scalable, rocksdb is recommended
     type=${storage_type}
@@ -580,8 +582,7 @@ function generate_group_ini()
     ; only enabled when sync_by_tree is true
     gossip_interval_ms=1000
     gossip_peers_number=3
-    ; the max peers the txs gossip to
-    ; recommend no large than 5
+    ; max number of nodes that broadcast txs status to, recommended less than 5 
     txs_max_gossip_peers_num=5
 EOF
 }


### PR DESCRIPTION
1. Fix ttl forwarding not taking effect caused by rpbft calling consensusEngine::resetConfig
2. add max_request_prepare_waitTime configuration into group.ini 