### PR TITLE
Add m_synced flag for transactions to avoid excessive CPU consumption

### DIFF
--- a/cmake/ProjectTBB.cmake
+++ b/cmake/ProjectTBB.cmake
@@ -12,7 +12,7 @@ ExternalProject_Add(tbb
     DOWNLOAD_NO_PROGRESS 1
     DOWNLOAD_NAME tbb_2019_u3.tar.gz
     URL https://github.com/01org/tbb/archive/2019_U3.tar.gz
-    URL_HASH SHA256=b2244147bc8159cdd8f06a38afeb42f3237d3fc822555499d7ccfbd4b86f8ece
+    URL_HASH SHA256=4cb6bde796ae056e7c29f31bfdc6cfd0cfe848925219e9c82a20f09158e81542
     BUILD_IN_SOURCE 1
     LOG_CONFIGURE 1
     LOG_BUILD 1

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -250,6 +250,9 @@ public:
     void setRpcTx(bool const& _rpcTx) { m_rpcTx = _rpcTx; }
     bool rpcTx() { return m_rpcTx; }
 
+    void setSynced(bool const& _synced) { m_synced = _synced; }
+    bool synced() const { return m_synced; }
+
 protected:
     /// Type of transaction.
     enum Type
@@ -307,6 +310,8 @@ protected:
     bytes m_extraData;  /// < Reserved fields, distinguished by "##".
     // used to represent that the transaction is received from rpc
     bool m_rpcTx = false;
+    // Whether the transaction has been synchronized
+    bool m_synced = false;
 };
 
 /// Nice name for vector of Transaction.

--- a/libtxpool/TxPool.cpp
+++ b/libtxpool/TxPool.cpp
@@ -661,7 +661,7 @@ std::shared_ptr<Transactions> TxPool::topTransactions(
 }
 
 std::shared_ptr<Transactions> TxPool::topTransactionsCondition(
-    uint64_t const& _limit, dev::h512 const& _nodeId)
+    uint64_t const& _limit, dev::h512 const&)
 {
     ReadGuard l(m_lock);
     std::shared_ptr<Transactions> ret = std::make_shared<Transactions>();
@@ -673,17 +673,11 @@ std::shared_ptr<Transactions> TxPool::topTransactionsCondition(
         ReadGuard l_kownTrans(x_transactionKnownBy);
         for (auto it = m_txsQueue.begin(); txCnt < limit && it != m_txsQueue.end(); it++)
         {
-            if (!isTransactionKnownBy((*it)->sha3(), _nodeId))
+            if (!(*it)->synced())
             {
-#if 0
-                if (m_delTransactions.find((*it)->sha3()) != m_delTransactions.end())
-                {
-                    ++ignoreCount;
-                    continue;
-                }
-#endif
                 ret->push_back(*it);
                 txCnt++;
+                (*it)->setSynced(true);
             }
         }
     }


### PR DESCRIPTION
Add m_synced flag for transactions to avoid excessive CPU consumption caused by isTransactionKnownBy