### PR TITLE
fix coredump caused by thread-pool and pbft-worker concurrent accessing

### DIFF
--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -330,7 +330,7 @@ protected:
     void initPBFTEnv(unsigned _view_timeout);
     virtual void initBackupDB();
     void reloadMsg(std::string const& _key, PBFTMsg* _msg);
-    void backupMsg(std::string const& _key, PBFTMsg const& _msg);
+    void backupMsg(std::string const& _key, std::shared_ptr<bytes> _msg);
     inline std::string getBackupMsgPath() { return m_baseDir + "/" + c_backupMsgDirName; }
 
     bool checkSign(PBFTMsg const& req) const;

--- a/libconsensus/pbft/PBFTMsgCache.h
+++ b/libconsensus/pbft/PBFTMsgCache.h
@@ -171,8 +171,12 @@ public:
      */
     inline bool insertKey(h512 const& nodeId, unsigned const& type, std::string const& key)
     {
+        UpgradableGuard l(x_broadCastKeyCache);
         if (!m_broadCastKeyCache.count(nodeId))
+        {
+            UpgradeGuard ul(l);
             m_broadCastKeyCache[nodeId] = std::make_shared<PBFTMsgCache>();
+        }
         return m_broadCastKeyCache[nodeId]->insertByPacketType(type, key);
     }
 
@@ -187,6 +191,7 @@ public:
      */
     inline bool keyExists(h512 const& nodeId, unsigned const& type, std::string const& key)
     {
+        ReadGuard l(x_broadCastKeyCache);
         if (!m_broadCastKeyCache.count(nodeId))
             return false;
         return m_broadCastKeyCache[nodeId]->exists(type, key);
@@ -195,6 +200,7 @@ public:
     /// clear all caches
     inline void clearAll()
     {
+        WriteGuard l(x_broadCastKeyCache);
         for (auto& item : m_broadCastKeyCache)
             item.second->clearAll();
     }
@@ -202,6 +208,7 @@ public:
 private:
     /// maps between node id and its broadcast cache
     std::unordered_map<h512, std::shared_ptr<PBFTMsgCache>> m_broadCastKeyCache;
+    mutable SharedMutex x_broadCastKeyCache;
 };
 }  // namespace consensus
 }  // namespace dev


### PR DESCRIPTION
1.  add lock when access committedPrepareCache in the worker-thread and the threadPool
2. lock when access PBFTBroadcastCache since part of broadcast operations are async