### PR TITLE
add network statistic and gas statistic

### DIFF
--- a/libchannelserver/ChannelMessage.h
+++ b/libchannelserver/ChannelMessage.h
@@ -69,6 +69,7 @@ public:
 
     virtual void encode(bytes& buffer)
     {
+        m_length = HEADER_LENGTH + m_data->size();
         uint32_t lengthN = htonl(HEADER_LENGTH + m_data->size());
         uint16_t typeN = htons(m_type);
         int32_t resultN = htonl(m_result);

--- a/libchannelserver/ChannelRPCServer.h
+++ b/libchannelserver/ChannelRPCServer.h
@@ -32,6 +32,7 @@
 #include "libethcore/Common.h"
 #include "libp2p/P2PMessage.h"
 #include <jsonrpccpp/server/abstractserverconnector.h>
+#include <libstat/ChannelNetworkStatHandler.h>
 #include <boost/asio/io_service.hpp>  // for io_service
 #include <atomic>                     // for atomic
 #include <map>                        // for map
@@ -139,15 +140,16 @@ public:
         dev::channel::TopicChannelMessage::Ptr message, size_t timeout);
 
     void setCallbackSetter(std::function<void(
-            std::function<void(const std::string& receiptContext)>*, std::function<uint32_t()>*)>
+            std::function<void(const std::string& receiptContext, GROUP_ID _groupId)>*,
+            std::function<uint32_t()>*)>
             callbackSetter)
     {
         m_callbackSetter = callbackSetter;
     };
 
     void setEventFilterCallback(std::function<int32_t(const std::string&, uint32_t,
-            std::function<bool(
-                const std::string& _filterID, int32_t _result, const Json::Value& _logs)>,
+            std::function<bool(const std::string& _filterID, int32_t _result,
+                const Json::Value& _logs, GROUP_ID const& _groupId)>,
             std::function<bool()>)>
             _callback)
     {
@@ -155,6 +157,13 @@ public:
     };
 
     void addHandler(const dev::eth::Handler<int64_t>& handler) { m_handlers.push_back(handler); }
+
+    void setNetworkStatHandler(dev::stat::ChannelNetworkStatHandler::Ptr _handler)
+    {
+        m_networkStatHandler = _handler;
+    }
+
+    dev::stat::ChannelNetworkStatHandler::Ptr networkStatHandler() { return m_networkStatHandler; }
 
 private:
     virtual void onClientRPCRequest(
@@ -204,17 +213,19 @@ private:
 
     std::shared_ptr<dev::p2p::P2PInterface> m_service;
 
-    std::function<void(
-        std::function<void(const std::string& receiptContext)>*, std::function<uint32_t()>*)>
+    std::function<void(std::function<void(const std::string& receiptContext, GROUP_ID _groupId)>*,
+        std::function<uint32_t()>*)>
         m_callbackSetter;
 
     std::function<int32_t(const std::string&, uint32_t,
-        std::function<bool(
-            const std::string& _filterID, int32_t _result, const Json::Value& _logs)>,
+        std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs,
+            GROUP_ID const& _groupId)>,
         std::function<bool()>)>
         m_eventFilterCallBack;
 
     std::vector<dev::eth::Handler<int64_t>> m_handlers;
+
+    dev::stat::ChannelNetworkStatHandler::Ptr m_networkStatHandler;
 };
 
 }  // namespace dev

--- a/libchannelserver/ChannelSession.cpp
+++ b/libchannelserver/ChannelSession.cpp
@@ -124,6 +124,12 @@ void ChannelSession::asyncSendMessage(Message::Ptr request,
         std::shared_ptr<bytes> p_buffer = std::make_shared<bytes>();
         request->encode(*p_buffer);
         writeBuffer(p_buffer);
+        // update the group outgoing traffic
+        if (request->groupID() != -1)
+        {
+            m_networkStat->updateGroupResponseTraffic(
+                request->groupID(), request->type(), request->length());
+        }
     }
     catch (std::exception& e)
     {
@@ -392,6 +398,7 @@ void ChannelSession::onMessage(ChannelException e, Message::Ptr message)
 
             return;
         }
+        // m_networkStat->updateIncomingTraffic(message->type(), message->length());
 
         auto response_callback = findResponseCallbackBySeq(message->seq());
         if (response_callback != nullptr)

--- a/libchannelserver/ChannelSession.h
+++ b/libchannelserver/ChannelSession.h
@@ -35,6 +35,7 @@
 #include <libdevcore/Common.h>
 #include <libdevcore/FixedHash.h>
 #include <libdevcore/Guards.h>
+#include <libstat/ChannelNetworkStatHandler.h>
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/ssl/stream.hpp>
@@ -126,6 +127,11 @@ public:
     }
     std::string clientType() { return m_clientType; }
 
+    void setNetworkStat(dev::stat::ChannelNetworkStatHandler::Ptr _handler)
+    {
+        m_networkStat = _handler;
+    }
+
 private:
     void startRead();
     void onRead(const boost::system::error_code& error, size_t bytesTransferred);
@@ -181,6 +187,9 @@ private:
         WriteGuard l(x_responseCallbacks);
         m_responseCallbacks.clear();
     }
+
+private:
+    dev::stat::ChannelNetworkStatHandler::Ptr m_networkStat;
 
     mutable SharedMutex x_responseCallbacks;
     std::map<std::string, ResponseCallback::Ptr> m_responseCallbacks;

--- a/libchannelserver/Message.h
+++ b/libchannelserver/Message.h
@@ -26,6 +26,7 @@
 
 #include <libdevcore/Common.h>
 #include <libdevcore/FixedHash.h>
+#include <libethcore/Protocol.h>
 #include <boost/lexical_cast.hpp>
 #include <memory>
 #include <queue>
@@ -66,11 +67,16 @@ public:
 
     virtual void clearData() { m_data->clear(); }
 
+    // for network statistic
+    virtual void setGroupID(GROUP_ID const& _groupId) { m_groupId = _groupId; }
+    GROUP_ID const& groupID() const { return m_groupId; }
+
 protected:
     uint32_t m_length = 0;
     uint16_t m_type = 0;
     std::string m_seq = std::string(32, '0');
     int m_result = 0;
+    dev::GROUP_ID m_groupId = -1;
 
     std::shared_ptr<bytes> m_data;
 };

--- a/libconsensus/ConsensusEngineBase.h
+++ b/libconsensus/ConsensusEngineBase.h
@@ -165,7 +165,7 @@ public:
 
     virtual IDXTYPE minValidNodes() const { return m_nodeNum - m_f; }
     /// update the context of PBFT after commit a block into the block-chain
-    virtual void reportBlock(dev::eth::Block const&) override {}
+    void reportBlock(dev::eth::Block const&) override;
 
     /// obtain maxBlockTransactions
     uint64_t maxBlockTransactions() override { return m_maxBlockTransactions; }

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1201,6 +1201,7 @@ void PBFTEngine::checkAndSave()
 
 void PBFTEngine::reportBlock(Block const& block)
 {
+    ConsensusEngineBase::reportBlock(block);
     Guard l(m_mutex);
     reportBlockWithoutLock(block);
 }

--- a/libconsensus/raft/RaftEngine.cpp
+++ b/libconsensus/raft/RaftEngine.cpp
@@ -140,6 +140,7 @@ void RaftEngine::start()
 
 void RaftEngine::reportBlock(dev::eth::Block const& _block)
 {
+    ConsensusEngineBase::reportBlock(_block);
     auto shouldReport = false;
     {
         Guard guard(m_mutex);

--- a/libeventfilter/EventLogFilter.h
+++ b/libeventfilter/EventLogFilter.h
@@ -49,7 +49,8 @@ public:
     // m_nextBlockToProcess
     eth::BlockNumber getNextBlockToProcess() const { return m_nextBlockToProcess; }
     // m_responseCallback
-    std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs)>
+    std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs,
+        GROUP_ID const& _groupId)>
     getResponseCallback()
     {
         return m_responseCallback;
@@ -66,8 +67,8 @@ public:
         m_nextBlockToProcess = _nextBlockToProcess;
     }
     // set response call back
-    void setResponseCallBack(
-        std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs)>
+    void setResponseCallBack(std::function<bool(const std::string& _filterID, int32_t _result,
+            const Json::Value& _logs, GROUP_ID const& _groupId)>
             _callback)
     {
         m_responseCallback = _callback;
@@ -92,7 +93,8 @@ private:
     // channel protocol version
     uint32_t m_channelProtocolVersion;
     // response callback function
-    std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs)>
+    std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs,
+        GROUP_ID const& _groupId)>
         m_responseCallback;
     // connect active check function
     std::function<bool()> m_isSessionActive;

--- a/libeventfilter/EventLogFilterManager.cpp
+++ b/libeventfilter/EventLogFilterManager.cpp
@@ -102,8 +102,8 @@ EventLogFilterManager::filter_status EventLogFilterManager::executeFilter(
         filter->updateNextBlockToProcess(nextBlockToProcess + thisLoopBlockCanProcess);
 
         // call back
-        if (!response.empty() &&
-            !filter->getResponseCallback()(filter->getParams()->getFilterID(), 0, response))
+        if (!response.empty() && !filter->getResponseCallback()(filter->getParams()->getFilterID(),
+                                     0, response, filter->getParams()->getGroupID()))
         {  // call back failed, maybe sesseion disconnect
             strDesc = "response callback failed, session not active";
             status = filter_status::CALLBACK_FAILED;
@@ -113,8 +113,8 @@ EventLogFilterManager::filter_status EventLogFilterManager::executeFilter(
         // this filter push completed, remove this filter
         if (filter->pushCompleted())
         {
-            filter->getResponseCallback()(
-                filter->getParams()->getFilterID(), PUSH_COMPLETED, Json::Value());
+            filter->getResponseCallback()(filter->getParams()->getFilterID(), PUSH_COMPLETED,
+                Json::Value(), filter->getParams()->getGroupID());
             status = filter_status::PUSH_COMPLETED;
             break;
         }
@@ -131,7 +131,8 @@ EventLogFilterManager::filter_status EventLogFilterManager::executeFilter(
 // add EventLogFilter to m_filters by client json request
 int32_t EventLogFilterManager::addEventLogFilterByRequest(const EventLogFilterParams::Ptr _params,
     uint32_t _version,
-    std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs)>
+    std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs,
+        GROUP_ID const& _groupId)>
         _respCallback,
     std::function<bool()> _activeCallback)
 {

--- a/libeventfilter/EventLogFilterManager.h
+++ b/libeventfilter/EventLogFilterManager.h
@@ -84,7 +84,8 @@ public:
 public:
     // add EventLogFilter to m_filters by client json request
     int32_t addEventLogFilterByRequest(const EventLogFilterParams::Ptr _params, uint32_t _version,
-        std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs)>
+        std::function<bool(const std::string& _filterID, int32_t _result, const Json::Value& _logs,
+            GROUP_ID const& _groupId)>
             _respCallback,
         std::function<bool()> _activeCallback);
 

--- a/libinitializer/BoostLogInitializer.cpp
+++ b/libinitializer/BoostLogInitializer.cpp
@@ -60,7 +60,7 @@ void LogInitializer::initStatLog(boost::property_tree::ptree const& _pt,
                         << "|"
                         << boost::log::expressions::format_date_time<boost::posix_time::ptime>(
                                "TimeStamp", "%Y-%m-%d %H:%M:%S.%f")
-                        << boost::log::expressions::smessage);
+                        << "|" << boost::log::expressions::smessage);
 }
 /**
  * @brief: set log for specified channel

--- a/libinitializer/RPCInitializer.cpp
+++ b/libinitializer/RPCInitializer.cpp
@@ -30,9 +30,11 @@
 #include "libledger/LedgerManager.h"
 #include "librpc/Rpc.h"  // for Rpc
 #include "librpc/SafeHttpServer.h"
+#include <libstat/ChannelNetworkStatHandler.h>
 
 using namespace dev;
 using namespace dev::initializer;
+using namespace dev::channel;
 
 void RPCInitializer::initChannelRPCServer(boost::property_tree::ptree const& _pt)
 {
@@ -57,6 +59,9 @@ void RPCInitializer::initChannelRPCServer(boost::property_tree::ptree const& _pt
     m_channelRPCServer->setListenPort(listenPort);
     m_channelRPCServer->setSSLContext(m_sslContext);
     m_channelRPCServer->setService(m_p2pService);
+    // set networkStatHandler for channelRPCServer
+    m_networkStatHandler = createNetWorkStatHandler(_pt);
+    m_channelRPCServer->setNetworkStatHandler(m_networkStatHandler);
 
     auto ioService = std::make_shared<boost::asio::io_service>();
 
@@ -71,7 +76,11 @@ void RPCInitializer::initChannelRPCServer(boost::property_tree::ptree const& _pt
 
     // start channelServer before initialize ledger, because amdb-proxy depends on channel
     auto rpcEntity = new rpc::Rpc(nullptr, nullptr);
-    m_channelRPCHttpServer = new ModularServer<rpc::Rpc>(rpcEntity);
+
+    auto modularServer = new ModularServer<rpc::Rpc>(rpcEntity);
+    modularServer->setNetworkStatHandler(m_networkStatHandler);
+    m_channelRPCHttpServer = modularServer;
+
     m_rpcForChannel.reset(rpcEntity, [](rpc::Rpc*) {});
     m_channelRPCHttpServer->addConnector(m_channelRPCServer.get());
     try
@@ -94,6 +103,7 @@ void RPCInitializer::initChannelRPCServer(boost::property_tree::ptree const& _pt
             ListenPortIsUsed() << errinfo_comment(
                 "Please check channel_listenIP and channel_listen_port are valid"));
     }
+    m_networkStatHandler->start();
     INITIALIZER_LOG(INFO) << LOG_BADGE("RPCInitializer")
                           << LOG_DESC("ChannelRPCHttpServer started.");
     m_channelRPCServer->setCallbackSetter(std::bind(&rpc::Rpc::setCurrentTransactionCallback,
@@ -125,8 +135,8 @@ void RPCInitializer::initConfig(boost::property_tree::ptree const& _pt)
         // event log filter callback
         m_channelRPCServer->setEventFilterCallback(
             [this](const std::string& _json, uint32_t _version,
-                std::function<bool(
-                    const std::string& _filterID, int32_t _result, const Json::Value& _logs)>
+                std::function<bool(const std::string& _filterID, int32_t _result,
+                    const Json::Value& _logs, GROUP_ID const& _groupId)>
                     _respCallback,
                 std::function<bool()> _activeCallback) -> int32_t {
                 auto params =
@@ -207,4 +217,23 @@ void RPCInitializer::initConfig(boost::property_tree::ptree const& _pt)
                      << LOG_KV("EINFO", boost::diagnostic_information(e)) << std::endl;
         exit(1);
     }
+}
+
+dev::stat::ChannelNetworkStatHandler::Ptr RPCInitializer::createNetWorkStatHandler(
+    boost::property_tree::ptree const& _pt)
+{
+    auto networkStatHandler = std::make_shared<dev::stat::ChannelNetworkStatHandler>("SDK");
+    // get flush interval in seconds
+    int64_t flushInterval = _pt.get<int64_t>("log.stat_flush_interval", 60);
+    if (flushInterval <= 0)
+    {
+        BOOST_THROW_EXCEPTION(
+            dev::InvalidConfig() << errinfo_comment(
+                "init network-stat-handler failed, log.stat_flush_interval must be positive!"));
+    }
+    INITIALIZER_LOG(DEBUG) << LOG_DESC("createNetWorkStatHandler")
+                           << LOG_KV("flushInterval(s)", flushInterval);
+
+    networkStatHandler->setFlushInterval(flushInterval * 1000);
+    return networkStatHandler;
 }

--- a/libinitializer/RPCInitializer.h
+++ b/libinitializer/RPCInitializer.h
@@ -55,6 +55,10 @@ namespace rpc
 {
 class Rpc;
 }
+namespace stat
+{
+class ChannelNetworkStatHandler;
+}
 namespace initializer
 {
 class RPCInitializer : public std::enable_shared_from_this<RPCInitializer>
@@ -66,6 +70,12 @@ public:
 
     void stop()
     {
+        // stop networkStatHandler
+        if (m_networkStatHandler)
+        {
+            m_networkStatHandler->stop();
+            INITIALIZER_LOG(INFO) << "stop channelNetworkStatistics.";
+        }
         /// stop channel first
         if (m_channelRPCHttpServer)
         {
@@ -105,6 +115,10 @@ public:
     std::shared_ptr<ledger::LedgerManager> getLedgerManager() { return m_ledgerManager; }
 
 private:
+    std::shared_ptr<dev::stat::ChannelNetworkStatHandler> createNetWorkStatHandler(
+        boost::property_tree::ptree const& _pt);
+
+private:
     std::shared_ptr<p2p::P2PInterface> m_p2pService;
     std::shared_ptr<ledger::LedgerManager> m_ledgerManager;
     LedgerInitializer::Ptr m_ledgerInitializer;
@@ -114,6 +128,7 @@ private:
     ChannelRPCServer::Ptr m_channelRPCServer;
     ModularServer<>* m_channelRPCHttpServer;
     ModularServer<>* m_jsonrpcHttpServer;
+    dev::stat::ChannelNetworkStatHandler::Ptr m_networkStatHandler;
 };
 
 }  // namespace initializer

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -81,9 +81,23 @@ bool Ledger::initLedger(std::shared_ptr<LedgerParamInterface> _ledgerParams)
     // setSyncNum for cachedStorage
     m_dbInitializer->setSyncNumForCachedStorage(m_blockChain->number());
 
+    // init network statistic handler
+    initNetworkStatHandler();
+
     /// init blockVerifier, txPool, sync and consensus
     return (initBlockVerifier() && initTxPool() && initSync() && consensusInitFactory() &&
             initEventLogFilterManager());
+}
+
+void Ledger::initNetworkStatHandler()
+{
+    Ledger_LOG(INFO) << LOG_BADGE("initNetworkStatHandler");
+    m_networkStatHandler = std::make_shared<dev::stat::NetworkStatHandler>();
+    m_networkStatHandler->setGroupId(m_groupId);
+    m_networkStatHandler->setConsensusMsgType(m_param->mutableConsensusParam().consensusType);
+    m_service->appendNetworkStatHandlerByGroupID(m_groupId, m_networkStatHandler);
+    m_channelRPCServer->networkStatHandler()->appendGroupP2PStatHandler(
+        m_groupId, m_networkStatHandler);
 }
 
 /// init txpool

--- a/libledger/Ledger.h
+++ b/libledger/Ledger.h
@@ -34,6 +34,7 @@
 #include <libeventfilter/EventLogFilterManager.h>
 #include <libp2p/P2PInterface.h>
 #include <libp2p/Service.h>
+#include <libstat/NetworkStatHandler.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/property_tree/ptree.hpp>
 
@@ -148,6 +149,8 @@ protected:
     virtual bool initSync();
     // init EventLogFilterManager
     virtual bool initEventLogFilterManager();
+    // init statHandler
+    virtual void initNetworkStatHandler();
 
     void initGenesisMark(GenesisBlockParam& genesisParam);
     /// load ini config of group
@@ -179,6 +182,8 @@ protected:
     std::shared_ptr<dev::consensus::Sealer> m_sealer = nullptr;
     std::shared_ptr<dev::sync::SyncInterface> m_sync = nullptr;
     std::shared_ptr<dev::event::EventLogFilterManager> m_eventLogFilterManger = nullptr;
+    // for network statistic
+    std::shared_ptr<dev::stat::NetworkStatHandler> m_networkStatHandler = nullptr;
 
     std::shared_ptr<dev::ledger::DBInitializer> m_dbInitializer = nullptr;
     ChannelRPCServer::Ptr m_channelRPCServer;

--- a/libp2p/P2PInterface.h
+++ b/libp2p/P2PInterface.h
@@ -99,6 +99,9 @@ public:
     virtual CallbackFuncForTopicVerify callbackFuncForTopicVerify() = 0;
 
     virtual std::shared_ptr<dev::p2p::P2PSession> getP2PSessionByNodeId(NodeID const& _nodeID) = 0;
+    virtual void appendNetworkStatHandlerByGroupID(
+        GROUP_ID const&, std::shared_ptr<dev::stat::NetworkStatHandler>)
+    {}
 };
 
 }  // namespace p2p

--- a/libp2p/Service.cpp
+++ b/libp2p/Service.cpp
@@ -815,6 +815,20 @@ bool Service::isConnected(NodeID const& nodeID) const
     return false;
 }
 
+void Service::appendNetworkStatHandlerByGroupID(
+    GROUP_ID const& _groupID, std::shared_ptr<dev::stat::NetworkStatHandler> _handler)
+{
+    UpgradableGuard l(x_group2NetworkStatHandler);
+    if (!m_group2NetworkStatHandler->count(_groupID))
+    {
+        UpgradeGuard ul(l);
+        (*m_group2NetworkStatHandler)[_groupID] = _handler;
+        return;
+    }
+    SERVICE_LOG(WARNING) << LOG_DESC("appendNetworkStatHandlerByGroupID: already exists")
+                         << LOG_KV("group", std::to_string(_groupID));
+}
+
 void Service::updateIncomingTraffic(P2PMessage::Ptr _msg)
 {
     // split groupID and moduleID from the _protocolID

--- a/libp2p/Service.h
+++ b/libp2p/Service.h
@@ -165,6 +165,9 @@ public:
         return nullptr;
     }
 
+    void appendNetworkStatHandlerByGroupID(
+        GROUP_ID const& _groupID, std::shared_ptr<dev::stat::NetworkStatHandler> _handler) override;
+
 private:
     NodeIDs getPeersByTopic(std::string const& topic);
     void checkWhitelistAndClearSession();

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -1130,7 +1130,7 @@ std::string Rpc::sendRawTransaction(int _groupID, const std::string& _rlp)
             auto transactionCallback = *currentTransactionCallback;
             clientProtocolversion = (*m_transactionCallbackVersion)();
             tx->setRpcCallback(
-                [transactionCallback, clientProtocolversion](
+                [transactionCallback, clientProtocolversion, _groupID](
                     LocalisedTransactionReceipt::Ptr receipt, dev::bytesConstRef input) {
                     Json::Value response;
                     if (clientProtocolversion > 0)
@@ -1165,7 +1165,7 @@ std::string Rpc::sendRawTransaction(int _groupID, const std::string& _rlp)
                     }
 
                     auto receiptContent = response.toStyledString();
-                    transactionCallback(receiptContent);
+                    transactionCallback(receiptContent, _groupID);
                 });
         }
         // calculate the sha3 before submit into the transaction pool

--- a/librpc/Rpc.h
+++ b/librpc/Rpc.h
@@ -140,7 +140,7 @@ public:
     Json::Value queryGroupStatus(int _groupID) override;
 
     void setCurrentTransactionCallback(
-        std::function<void(const std::string& receiptContext)>* _callback,
+        std::function<void(const std::string& receiptContext, GROUP_ID _groupId)>* _callback,
         std::function<uint32_t()>* _callbackVersion)
     {
         m_currentTransactionCallback.reset(_callback);
@@ -173,7 +173,8 @@ private:
     bool isValidSystemConfig(std::string const& key);
 
     /// transaction callback related
-    boost::thread_specific_ptr<std::function<void(const std::string& receiptContext)> >
+    boost::thread_specific_ptr<
+        std::function<void(const std::string& receiptContext, GROUP_ID _groupId)> >
         m_currentTransactionCallback;
     boost::thread_specific_ptr<std::function<uint32_t()> > m_transactionCallbackVersion;
 

--- a/test/unittests/libeventfilter/EventLogFilterTest.cpp
+++ b/test/unittests/libeventfilter/EventLogFilterTest.cpp
@@ -158,14 +158,15 @@ BOOST_AUTO_TEST_CASE(EventLogFilter_test0)
     filter->updateNextBlockToProcess(-1);
     BOOST_CHECK_EQUAL(filter->getNextBlockToProcess(), -1);
 
-    filter->setResponseCallBack(
-        [](const std::string& _filterID, int32_t _result, const Json::Value& _logs) -> bool {
-            EVENT_LOG(INFO) << LOG_KV("result", _result) << LOG_KV("_filterID", _filterID);
-            (void)_logs;
-            return true;
-        });
+    filter->setResponseCallBack([](const std::string& _filterID, int32_t _result,
+                                    const Json::Value& _logs, GROUP_ID const& _groupId) -> bool {
+        EVENT_LOG(INFO) << LOG_KV("result", _result) << LOG_KV("_filterID", _filterID)
+                        << LOG_KV("groupId", _groupId);
+        (void)_logs;
+        return true;
+    });
 
-    auto r0 = filter->getResponseCallback()("aaa", -1, Json::Value());
+    auto r0 = filter->getResponseCallback()("aaa", -1, Json::Value(), 1);
     BOOST_CHECK_EQUAL(r0, true);
 }
 

--- a/test/unittests/libledger/LedgerTest.cpp
+++ b/test/unittests/libledger/LedgerTest.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 
 using namespace dev;
+using namespace dev::stat;
 using namespace dev::ledger;
 namespace dev
 {
@@ -266,6 +267,14 @@ BOOST_AUTO_TEST_CASE(testInitLedger)
     BOOST_CHECK(ledgerManager->blockChain(groupId)->number() == 1);
 }
 
+void initChannel(std::shared_ptr<LedgerInterface> ledger)
+{
+    auto channelServer = std::make_shared<ChannelRPCServer>();
+    auto handler = std::make_shared<ChannelNetworkStatHandler>("SDK");
+    channelServer->setNetworkStatHandler(handler);
+    ledger->setChannelRPCServer(channelServer);
+}
+
 BOOST_AUTO_TEST_CASE(testInitStorageLevelDB)
 {
     boost::system::error_code err;
@@ -280,6 +289,7 @@ BOOST_AUTO_TEST_CASE(testInitStorageLevelDB)
         std::make_shared<Ledger>(txpool_creator.m_topicService, groupId, key_pair);
     auto ledgerParams = std::make_shared<LedgerParam>();
     ledgerParams->init(configurationPath);
+    initChannel(ledger);
     BOOST_CHECK_NO_THROW(ledger->initLedger(ledgerParams));
 }
 
@@ -297,6 +307,7 @@ BOOST_AUTO_TEST_CASE(testInitStorageRocksDB)
         std::make_shared<Ledger>(txpool_creator.m_topicService, groupId, key_pair);
     auto ledgerParams = std::make_shared<LedgerParam>();
     ledgerParams->init(configurationPath);
+    initChannel(ledger);
     BOOST_CHECK_NO_THROW(ledger->initLedger(ledgerParams));
 }
 


### PR DESCRIPTION
1. In the transaction push and event push callback parameters, groupid is added to transmit the group number; a groupid field is added to channelmessage, but it does not participate in coding. The groupid parameter of callback is used to set the field;

2. when asyncsendmessage, the statistics value of corresponding message package is updated according to groupid and MessageType; 

3. the statistics value of RPC method is added