### PR TITLE
Added sleep before sendTxsStatus to prevent excessive redundant txs-packet

### DIFF
--- a/libsync/SyncTransaction.h
+++ b/libsync/SyncTransaction.h
@@ -179,6 +179,8 @@ private:
 
     unsigned m_txsStatusGossipMaxPeers = 5;
 
+    std::atomic_bool m_running = {false};
+
 private:
     void forwardRemainingTxs();
 

--- a/test/unittests/libsync/SyncMasterTest.cpp
+++ b/test/unittests/libsync/SyncMasterTest.cpp
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(MaintainTransactionsTest)
 
     BOOST_CHECK_EQUAL(service->getAsyncSendSizeByNodeID(NodeID(101)), 2);
     // the transaction won't be sent to other nodes if received from P2P
-    BOOST_CHECK_EQUAL(service->getAsyncSendSizeByNodeID(NodeID(102)), 3);
+    BOOST_CHECK_EQUAL(service->getAsyncSendSizeByNodeID(NodeID(102)), 2);
 
     // test transaction already sent
     sync->maintainTransactions();
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(MaintainTransactionsTest)
     cout << "Msg number: " << service->getAsyncSendSizeByNodeID(NodeID(102)) << endl;
 
     BOOST_CHECK_EQUAL(service->getAsyncSendSizeByNodeID(NodeID(101)), 2);
-    BOOST_CHECK_EQUAL(service->getAsyncSendSizeByNodeID(NodeID(102)), 3);
+    BOOST_CHECK_EQUAL(service->getAsyncSendSizeByNodeID(NodeID(102)), 2);
 }
 
 BOOST_AUTO_TEST_CASE(MaintainBlocksTest)


### PR DESCRIPTION
Added sleep before sendTxsStatus to prevent excessive redundant transaction message packets caused by transaction status spreading too fast