### PR TITLE
fix bug stopGroup makes deadlock && genesis block timestamp can be a negative integer

### DIFF
--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -114,7 +114,6 @@ bool Ledger::initTxPool()
     m_txPool = std::make_shared<dev::txpool::TxPool>(
         m_service, m_blockChain, protocol_id, m_param->mutableTxPoolParam().txPoolLimit);
     m_txPool->setMaxBlockLimit(g_BCOSConfig.c_blockLimit);
-    m_txPool->start();
     Ledger_LOG(INFO) << LOG_BADGE("initLedger") << LOG_DESC("initTxPool SUCC");
     return true;
 }

--- a/libledger/LedgerManager.h
+++ b/libledger/LedgerManager.h
@@ -237,8 +237,6 @@ private:
         const std::set<std::string>& _sealerList);
     std::string generateGroupConfig();
 
-    void clearLedger(dev::GROUP_ID const& _groupID);
-
     mutable RecursiveMutex x_ledgerManager;
     /// cache for the group List
     std::set<dev::GROUP_ID> m_groupListCache;

--- a/libledger/LedgerParam.cpp
+++ b/libledger/LedgerParam.cpp
@@ -53,7 +53,15 @@ void LedgerParam::parseGenesisConfig(const std::string& _genesisFile)
         initConsensusConfig(pt);
         initEventLogFilterManagerConfig(pt);
         /// use UTCTime directly as timeStamp in case of the clock differences between machines
-        mutableGenesisParam().timeStamp = pt.get<uint64_t>("group.timestamp", UINT64_MAX);
+        auto timeStamp = pt.get<int64_t>("group.timestamp", INT64_MAX);
+        if (timeStamp < 0)
+        {
+            LedgerParam_LOG(ERROR)
+                << LOG_BADGE("parseGenesisConfig") << LOG_DESC("invalid group timeStamp")
+                << LOG_KV("timeStamp", timeStamp);
+            BOOST_THROW_EXCEPTION(Exception("invalid group timestamp"));
+        }
+        mutableGenesisParam().timeStamp = timeStamp;
         LedgerParam_LOG(INFO) << LOG_BADGE("parseGenesisConfig")
                               << LOG_KV("timestamp", mutableGenesisParam().timeStamp);
         mutableStateParam().type = pt.get<std::string>("state.type", "storage");

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -67,29 +67,6 @@ Rpc::Rpc(
     setLedgerInitializer(_ledgerInitializer);
 }
 
-void Rpc::registerSyncChecker()
-{
-    if (m_ledgerManager)
-    {
-        auto groupList = m_ledgerManager->getGroupListForRpc();
-        for (auto const& group : groupList)
-        {
-            auto txPool = m_ledgerManager->txPool(group);
-            txPool->registerSyncStatusChecker([this, group]() {
-                try
-                {
-                    checkSyncStatus(group);
-                }
-                catch (std::exception const& _e)
-                {
-                    return false;
-                }
-                return true;
-            });
-        }
-    }
-}
-
 std::shared_ptr<dev::ledger::LedgerManager> Rpc::ledgerManager()
 {
     if (!m_ledgerManager)
@@ -1753,6 +1730,10 @@ bool Rpc::checkTimestamp(const std::string& _timestamp)
     try
     {
         int64_t cmp = boost::lexical_cast<int64_t>(_timestamp);
+        if (cmp < 0)
+        {
+            return false;
+        }
         return _timestamp == std::to_string(cmp);
     }
     catch (...)

--- a/librpc/Rpc.h
+++ b/librpc/Rpc.h
@@ -154,7 +154,6 @@ public:
         {
             m_ledgerManager = _ledgerInitializer->ledgerManager();
         }
-        registerSyncChecker();
     }
     void setService(std::shared_ptr<dev::p2p::P2PInterface> _service) { m_service = _service; }
 
@@ -167,7 +166,6 @@ protected:
     std::shared_ptr<dev::p2p::P2PInterface> m_service;
 
 private:
-    void registerSyncChecker();
     bool isValidNodeId(dev::bytes const& precompileData,
         std::shared_ptr<dev::ledger::LedgerParamInterface> ledgerParam);
     bool isValidSystemConfig(std::string const& key);


### PR DESCRIPTION
1. calls `stopGroupByGroupID`
2. `stopGroupByGroupID` acquires `x_ledgerManager`
3. meanwhile, sdk is continue sending txs
4. `submit` threads calls `checkSyncStatus`
5. `checkSyncStatus` calls `sync` of ledger manager
6. `sync` tries to acquire `x_ledgerManager`, it's then be blocked
8. `stopGroupByGroupID` is also waiting for the quit of `submit` thread, deadlock occurs