### PR TITLE
limit channelRPCServer requests and block-sync-bandwidth 

### DIFF
--- a/libp2p/CMakeLists.txt
+++ b/libp2p/CMakeLists.txt
@@ -5,4 +5,4 @@ file(GLOB HEADERS "*.h")
 
 add_library(p2p ${SRC_LIST} ${HEADERS})
 
-target_link_libraries(p2p PUBLIC network stat devcore)
+target_link_libraries(p2p PUBLIC devcore network flowlimit stat)

--- a/libp2p/P2PInterface.h
+++ b/libp2p/P2PInterface.h
@@ -33,6 +33,10 @@ namespace stat
 {
 class NetworkStatHandler;
 }
+namespace flowlimit
+{
+class QPSLimiter;
+}
 namespace p2p
 {
 class P2PMessage;
@@ -103,6 +107,12 @@ public:
         GROUP_ID const&, std::shared_ptr<dev::stat::NetworkStatHandler>)
     {}
     virtual void removeNetworkStatHandlerByGroupID(GROUP_ID const&) {}
+
+    virtual void setNodeBandwidthLimiter(std::shared_ptr<dev::flowlimit::QPSLimiter>) {}
+    virtual void registerGroupBandwidthLimiter(
+        GROUP_ID const&, std::shared_ptr<dev::flowlimit::QPSLimiter>)
+    {}
+    virtual void removeGroupBandwidthLimiter(GROUP_ID const&) {}
 };
 
 }  // namespace p2p

--- a/libp2p/P2PMessage.h
+++ b/libp2p/P2PMessage.h
@@ -93,6 +93,13 @@ public:
 
     virtual uint32_t deliveredLength() { return m_length; }
 
+    // bandwidth limiter related logic
+    virtual bool permitsAcquired() const { return m_permitsAcquired; }
+    virtual void setPermitsAcquired(bool const& _permitsAcquired)
+    {
+        m_permitsAcquired = _permitsAcquired;
+    }
+
 protected:
     uint32_t m_length = 0;            ///< m_length = HEADER_LENGTH + length(m_buffer)
     PROTOCOL_ID m_protocolID = 0;     ///< message type, the first two bytes of information, when
@@ -101,6 +108,7 @@ protected:
     uint32_t m_seq = 0;               ///< the message identify
     std::shared_ptr<bytes> m_buffer;  ///< message data
     bool m_dirty = true;
+    bool m_permitsAcquired = false;
 };
 enum AMOPPacketType
 {

--- a/libp2p/Service.cpp
+++ b/libp2p/Service.cpp
@@ -45,7 +45,9 @@ Service::Service()
   : m_topics(std::make_shared<std::set<std::string>>()),
     m_protocolID2Handler(std::make_shared<std::unordered_map<uint32_t, CallbackFuncWithSession>>()),
     m_topic2Handler(std::make_shared<std::unordered_map<std::string, CallbackFuncWithSession>>()),
-    m_group2NetworkStatHandler(std::make_shared<std::map<GROUP_ID, NetworkStatHandler::Ptr>>())
+    m_group2NetworkStatHandler(std::make_shared<std::map<GROUP_ID, NetworkStatHandler::Ptr>>()),
+    m_group2BandwidthLimiter(
+        std::make_shared<std::map<GROUP_ID, dev::flowlimit::QPSLimiter::Ptr>>())
 {}
 
 void Service::start()
@@ -459,10 +461,12 @@ void Service::asyncSendMessageByNodeID(NodeID nodeID, P2PMessage::Ptr message,
             {
                 session->session()->asyncSendMessage(message, options, nullptr);
             }
+            // update stat information
             if (g_BCOSConfig.enableStat())
             {
-                updateOutcomingTraffic(message);
+                updateOutgoingTraffic(message);
             }
+            acquirePermits(message);
         }
         else
         {
@@ -851,20 +855,80 @@ void Service::updateIncomingTraffic(P2PMessage::Ptr _msg)
 {
     // split groupID and moduleID from the _protocolID
     auto ret = dev::eth::getGroupAndProtocol(abs(_msg->protocolID()));
-    ReadGuard l(x_group2NetworkStatHandler);
-    if (m_group2NetworkStatHandler->count(ret.first))
+    auto networkStatHandler =
+        getHandlerByGroupId(ret.first, m_group2NetworkStatHandler, x_group2NetworkStatHandler);
+
+    if (networkStatHandler)
     {
-        (*m_group2NetworkStatHandler)[ret.first]->updateIncomingTraffic(ret.second, _msg->length());
+        networkStatHandler->updateIncomingTraffic(ret.second, _msg->length());
     }
 }
 
-void Service::updateOutcomingTraffic(P2PMessage::Ptr _msg)
+void Service::updateOutgoingTraffic(P2PMessage::Ptr _msg)
 {
     auto ret = dev::eth::getGroupAndProtocol(abs(_msg->protocolID()));
-    ReadGuard l(x_group2NetworkStatHandler);
-    if (m_group2NetworkStatHandler->count(ret.first))
+    auto networkStatHandler =
+        getHandlerByGroupId(ret.first, m_group2NetworkStatHandler, x_group2NetworkStatHandler);
+    if (networkStatHandler)
     {
-        (*m_group2NetworkStatHandler)[ret.first]->updateOutcomingTraffic(
-            ret.second, _msg->length());
+        networkStatHandler->updateOutgoingTraffic(ret.second, _msg->length());
     }
+}
+
+void Service::acquirePermits(P2PMessage::Ptr _msg)
+{
+    if (_msg->permitsAcquired())
+    {
+        return;
+    }
+    if (m_nodeBandwidthLimiter)
+    {
+        m_nodeBandwidthLimiter->acquire(_msg->length(), false, true);
+    }
+    // get groupId
+    auto ret = dev::eth::getGroupAndProtocol(abs(_msg->protocolID()));
+    auto bandwidthLimiter =
+        getHandlerByGroupId(ret.first, m_group2BandwidthLimiter, x_group2BandwidthLimiter);
+    if (!bandwidthLimiter)
+    {
+        return;
+    }
+    bandwidthLimiter->acquire(_msg->length(), false, true);
+}
+
+void Service::setNodeBandwidthLimiter(dev::flowlimit::QPSLimiter::Ptr _bandwidthLimiter)
+{
+    m_nodeBandwidthLimiter = _bandwidthLimiter;
+}
+
+
+void Service::registerGroupBandwidthLimiter(
+    GROUP_ID const& _groupID, dev::flowlimit::QPSLimiter::Ptr _bandwidthLimiter)
+{
+    UpgradableGuard l(x_group2BandwidthLimiter);
+    if (m_group2BandwidthLimiter->count(_groupID))
+    {
+        SERVICE_LOG(DEBUG) << LOG_DESC("registerGroupBandwidthLimiter: already registered")
+                           << LOG_KV("group", std::to_string(_groupID));
+        return;
+    }
+    UpgradeGuard ul(l);
+    (*m_group2BandwidthLimiter)[_groupID] = _bandwidthLimiter;
+    SERVICE_LOG(INFO) << LOG_DESC("registerGroupBandwidthLimiter")
+                      << LOG_KV("group", std::to_string(_groupID));
+}
+
+void Service::removeGroupBandwidthLimiter(GROUP_ID const& _groupID)
+{
+    UpgradableGuard l(x_group2BandwidthLimiter);
+    if (!m_group2BandwidthLimiter->count(_groupID))
+    {
+        SERVICE_LOG(DEBUG) << LOG_DESC("removeGroupBandwidthLimiter: already removed")
+                           << LOG_KV("group", std::to_string(_groupID));
+        return;
+    }
+    UpgradeGuard ul(l);
+    m_group2BandwidthLimiter->erase(_groupID);
+    SERVICE_LOG(INFO) << LOG_DESC("removeGroupBandwidthLimiter")
+                      << LOG_KV("group", std::to_string(_groupID));
 }

--- a/librpc/CMakeLists.txt
+++ b/librpc/CMakeLists.txt
@@ -5,4 +5,4 @@ file(GLOB HEADERS "*.h")
 
 add_library(rpc ${SRC_LIST} ${HEADERS})
 target_include_directories(rpc PRIVATE ..)
-target_link_libraries(rpc PUBLIC ledger consensus JsonRpcCpp::Server initializer)
+target_link_libraries(rpc PUBLIC flowlimit ledger consensus JsonRpcCpp::Server initializer)

--- a/librpc/Common.h
+++ b/librpc/Common.h
@@ -43,7 +43,8 @@ enum RPCExceptionType : int
     BlockNumberT = -40004,
     BlockHash = -40003,
     JsonParse = -40002,
-    GroupID = -40001
+    GroupID = -40001,
+    OverQPSLimit = -503,
 };
 
 extern std::map<int, std::string> RPCMsg;

--- a/librpc/ModularServer.h
+++ b/librpc/ModularServer.h
@@ -220,6 +220,11 @@ public:
         this->m_handler->setNetworkStatHandler(_handler);
     }
 
+    void setQPSLimiter(dev::flowlimit::RPCQPSLimiter::Ptr _qpsLimiter)
+    {
+        this->m_handler->setQPSLimiter(_qpsLimiter);
+    }
+
 private:
     std::unique_ptr<I> m_interface;
     std::map<std::string, MethodPointer> m_methods;

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -57,7 +57,8 @@ std::map<int, std::string> dev::rpc::RPCMsg{{RPCExceptionType::Success, "Success
     {RPCExceptionType::InvalidSystemConfig, "Invalid System Config"},
     {RPCExceptionType::InvalidRequest,
         "Don't send request to this node who doesn't belong to the group"},
-    {RPCExceptionType::IncompleteInitialization, "RPC module initialization is incomplete."}};
+    {RPCExceptionType::IncompleteInitialization, "RPC module initialization is incomplete."},
+    {RPCExceptionType::OverQPSLimit, "Over QPS limit"}};
 
 Rpc::Rpc(
     LedgerInitializer::Ptr _ledgerInitializer, std::shared_ptr<dev::p2p::P2PInterface> _service)

--- a/librpc/StatisticProtocolServer.h
+++ b/librpc/StatisticProtocolServer.h
@@ -22,6 +22,7 @@
 #include "Common.h"
 #include "jsonrpccpp/server/rpcprotocolserverv2.h"
 #include <libethcore/Protocol.h>
+#include <libflowlimit/RPCQPSLimiter.h>
 #include <libstat/ChannelNetworkStatHandler.h>
 
 namespace dev
@@ -37,9 +38,21 @@ public:
         m_networkStatHandler = _networkStatHandler;
     }
 
+    void setQPSLimiter(dev::flowlimit::RPCQPSLimiter::Ptr _qpsLimiter)
+    {
+        m_qpsLimiter = _qpsLimiter;
+    }
+
 private:
+    bool limitRPCQPS(Json::Value const& _request, std::string& _retValue);
+    bool limitGroupQPS(
+        dev::GROUP_ID const& _groupId, Json::Value const& _request, std::string& _retValue);
+    void wrapResponseForNodeBusy(
+        bool const& _canHandle, Json::Value const& _request, std::string& _retValue);
+
     dev::GROUP_ID getGroupID(Json::Value const& _input);
 
     dev::stat::ChannelNetworkStatHandler::Ptr m_networkStatHandler;
+    dev::flowlimit::RPCQPSLimiter::Ptr m_qpsLimiter;
 };
 }  // namespace dev

--- a/libstat/ChannelNetworkStatHandler.cpp
+++ b/libstat/ChannelNetworkStatHandler.cpp
@@ -55,48 +55,47 @@ void ChannelNetworkStatHandler::removeGroupP2PStatHandler(GROUP_ID const& _group
     }
 }
 
+NetworkStatHandler::Ptr ChannelNetworkStatHandler::getP2PHandlerByGroupId(GROUP_ID const& _groupId)
+{
+    ReadGuard l(x_p2pStatHandlers);
+    if (!m_p2pStatHandlers->count(_groupId))
+    {
+        return nullptr;
+    }
+    return (*m_p2pStatHandlers)[_groupId];
+}
+
 void ChannelNetworkStatHandler::updateGroupResponseTraffic(
     GROUP_ID const& _groupId, uint32_t const& _msgType, uint64_t const& _msgSize)
 {
-    ReadGuard l(x_p2pStatHandlers);
-    if (m_p2pStatHandlers->count(_groupId))
+    auto p2pStatHandler = getP2PHandlerByGroupId(_groupId);
+    if (!p2pStatHandler)
     {
-        (*m_p2pStatHandlers)[_groupId]->updateOutcomingTraffic(_msgType, _msgSize);
+        return;
     }
+    p2pStatHandler->updateOutgoingTraffic(_msgType, _msgSize);
 }
-
-void ChannelNetworkStatHandler::updateGroupRequestTraffic(
-    GROUP_ID const& _groupId, uint32_t const& _msgType, uint64_t const& _msgSize)
-{
-    ReadGuard l(x_p2pStatHandlers);
-    if (m_p2pStatHandlers->count(_groupId))
-    {
-        (*m_p2pStatHandlers)[_groupId]->updateIncomingTraffic(_msgType, _msgSize);
-    }
-}
-
 
 void ChannelNetworkStatHandler::updateIncomingTrafficForRPC(
     GROUP_ID _groupId, uint64_t const& _msgSize)
 {
-    ReadGuard l(x_p2pStatHandlers);
-    if (!m_p2pStatHandlers->count(_groupId))
+    auto p2pStatHandler = getP2PHandlerByGroupId(_groupId);
+    if (!p2pStatHandler)
     {
         return;
     }
-    (*m_p2pStatHandlers)[_groupId]->updateIncomingTraffic(
-        ChannelMessageType::CHANNEL_RPC_REQUEST, _msgSize);
+    p2pStatHandler->updateIncomingTraffic(ChannelMessageType::CHANNEL_RPC_REQUEST, _msgSize);
 }
-void ChannelNetworkStatHandler::updateOutcomingTrafficForRPC(
+
+void ChannelNetworkStatHandler::updateOutgoingTrafficForRPC(
     GROUP_ID _groupId, uint64_t const& _msgSize)
 {
-    ReadGuard l(x_p2pStatHandlers);
-    if (!m_p2pStatHandlers->count(_groupId))
+    auto p2pStatHandler = getP2PHandlerByGroupId(_groupId);
+    if (!p2pStatHandler)
     {
         return;
     }
-    (*m_p2pStatHandlers)[_groupId]->updateOutcomingTraffic(
-        ChannelMessageType::CHANNEL_RPC_REQUEST, _msgSize);
+    p2pStatHandler->updateOutgoingTraffic(ChannelMessageType::CHANNEL_RPC_REQUEST, _msgSize);
 }
 
 void ChannelNetworkStatHandler::flushLog()

--- a/libstat/ChannelNetworkStatHandler.h
+++ b/libstat/ChannelNetworkStatHandler.h
@@ -53,11 +53,8 @@ public:
     virtual void updateGroupResponseTraffic(
         GROUP_ID const& _groupId, uint32_t const& _msgType, uint64_t const& _msgSize);
 
-    virtual void updateGroupRequestTraffic(
-        GROUP_ID const& _groupId, uint32_t const& _msgType, uint64_t const& _msgSize);
-
     void updateIncomingTrafficForRPC(GROUP_ID _groupId, uint64_t const& _msgSize);
-    void updateOutcomingTrafficForRPC(GROUP_ID _groupId, uint64_t const& _msgSize);
+    void updateOutgoingTrafficForRPC(GROUP_ID _groupId, uint64_t const& _msgSize);
 
     bool running() const { return m_running; }
 
@@ -68,6 +65,7 @@ public:
 
 private:
     void flushLog();
+    NetworkStatHandler::Ptr getP2PHandlerByGroupId(GROUP_ID const& _groupId);
 
 private:
     std::string m_statisticName;

--- a/libstat/NetworkStatHandler.cpp
+++ b/libstat/NetworkStatHandler.cpp
@@ -32,8 +32,8 @@ void NetworkStatHandler::updateIncomingTraffic(int32_t const& _msgType, uint64_t
     updateTraffic(m_InMsgTypeToBytes, _msgType, _msgSize);
 }
 
-// update outcoming traffic
-void NetworkStatHandler::updateOutcomingTraffic(int32_t const& _msgType, uint64_t _msgSize)
+// update outgoing traffic
+void NetworkStatHandler::updateOutgoingTraffic(int32_t const& _msgType, uint64_t _msgSize)
 {
     m_totalOutMsgBytes += _msgSize;
     WriteGuard l(x_OutMsgTypeToBytes);

--- a/libstat/NetworkStatHandler.h
+++ b/libstat/NetworkStatHandler.h
@@ -58,7 +58,7 @@ public:
     void setGroupId(dev::GROUP_ID const& _groupId) { m_groupId = _groupId; }
 
     virtual void updateIncomingTraffic(int32_t const& _msgType, uint64_t _msgSize);
-    virtual void updateOutcomingTraffic(int32_t const& _msgType, uint64_t _msgSize);
+    virtual void updateOutgoingTraffic(int32_t const& _msgType, uint64_t _msgSize);
 
     virtual void updateTraffic(StatPtr _statMap, int32_t const& _msgType, uint64_t _msgSize);
 
@@ -100,7 +100,7 @@ protected:
     std::atomic<uint64_t> m_totalInMsgBytes = {0};
     std::string const m_InMsgDescSuffix = "In";
 
-    // outcoming traffic statistics
+    // outgoing traffic statistics
     std::shared_ptr<std::map<int32_t, uint64_t>> m_OutMsgTypeToBytes;
     mutable SharedMutex x_OutMsgTypeToBytes;
     std::atomic<uint64_t> m_totalOutMsgBytes = {0};

--- a/libsync/SyncMaster.h
+++ b/libsync/SyncMaster.h
@@ -37,6 +37,7 @@
 #include <libdevcore/Worker.h>
 #include <libethcore/Common.h>
 #include <libethcore/Exceptions.h>
+#include <libflowlimit/QPSLimiter.h>
 #include <libnetwork/Common.h>
 #include <libnetwork/Session.h>
 #include <libp2p/P2PInterface.h>
@@ -234,6 +235,16 @@ public:
         m_syncTrans->noteForwardRemainTxs(_targetNodeId);
     }
 
+    void setBandwidthLimiter(dev::flowlimit::QPSLimiter::Ptr _bandwidthLimiter)
+    {
+        m_bandwidthLimiter = _bandwidthLimiter;
+    }
+
+    void setNodeBandwidthLimiter(dev::flowlimit::QPSLimiter::Ptr _nodeBandwidthLimiter)
+    {
+        m_nodeBandwidthLimiter = _nodeBandwidthLimiter;
+    }
+
 private:
     // init via blockchain when the sync thread started
     void updateNodeInfo()
@@ -311,6 +322,11 @@ private:
 
     // verify handler to check downloading block
     std::function<bool(dev::eth::Block const&)> fp_isConsensusOk = nullptr;
+
+    dev::flowlimit::QPSLimiter::Ptr m_bandwidthLimiter;
+    dev::flowlimit::QPSLimiter::Ptr m_nodeBandwidthLimiter;
+
+    const unsigned m_compressRate = 3;
 
 public:
     void maintainBlocks();

--- a/libsync/SyncMsgEngine.cpp
+++ b/libsync/SyncMsgEngine.cpp
@@ -340,6 +340,7 @@ void DownloadBlocksContainer::clearBatchAndSend()
     retPacket.encode(m_blockRLPsBatch);
 
     auto msg = retPacket.toMessage(m_protocolId);
+    msg->setPermitsAcquired(true);
     m_service->asyncSendMessageByNodeID(m_nodeId, msg, CallbackFuncWithSession(), Options());
     SYNC_ENGINE_LOG(INFO) << LOG_BADGE("Download") << LOG_BADGE("Request") << LOG_BADGE("BlockSync")
                           << LOG_DESC("Send block packet") << LOG_KV("peer", m_nodeId.abridged())


### PR DESCRIPTION
1. limit channelRPCServer requests and block-sync-bandwidth using QPSLimiter 
2. update ChannelNetworkStatHandler