### PR TITLE
Fix txPool pending transactions unprocessed when using Raft

### DIFF
--- a/libsync/SyncTransaction.cpp
+++ b/libsync/SyncTransaction.cpp
@@ -316,3 +316,31 @@ void SyncTransaction::sendTxsStatus(
     }
     m_txsHash->clear();
 }
+
+void SyncTransaction::updateNeedMaintainTransactions(bool const& _needMaintainTxs)
+{
+    if (_needMaintainTxs != m_needMaintainTransactions)
+    {
+        // changed from sealer/observer to free-node
+        if (m_needMaintainTransactions)
+        {
+            SYNC_LOG(DEBUG) << LOG_DESC(
+                                   "updateNeedMaintainTransactions: node changed from "
+                                   "sealer/observer to free-node, freshTxsStatus")
+                            << LOG_KV("isSealerOrObserver", _needMaintainTxs)
+                            << LOG_KV("isSealerOrObserverBeforeUpdate", m_needMaintainTransactions);
+            m_txPool->freshTxsStatus();
+        }
+        else
+        {
+            SYNC_LOG(DEBUG) << LOG_DESC(
+                                   "updateNeedMaintainTransactions: node changed from free-node to "
+                                   "sealer/observer, noteNewTransactions")
+                            << LOG_KV("isSealerOrObserver", _needMaintainTxs)
+                            << LOG_KV("isSealerOrObserverBeforeUpdate", m_needMaintainTransactions);
+            // changed from free-node into sealer/observer
+            noteNewTransactions();
+        }
+        m_needMaintainTransactions = _needMaintainTxs;
+    }
+}

--- a/libsync/SyncTransaction.h
+++ b/libsync/SyncTransaction.h
@@ -99,13 +99,7 @@ public:
         fp_txsReceiversFilter = _handler;
     }
 
-    void updateNeedMaintainTransactions(bool const& _needMaintainTxs)
-    {
-        if (_needMaintainTxs != m_needMaintainTransactions)
-        {
-            m_needMaintainTransactions = _needMaintainTxs;
-        }
-    }
+    void updateNeedMaintainTransactions(bool const& _needMaintainTxs);
 
     virtual void noteForwardRemainTxs(dev::h512 const& _targetNodeId)
     {

--- a/libtxpool/TransactionNonceCheck.h
+++ b/libtxpool/TransactionNonceCheck.h
@@ -60,7 +60,6 @@ public:
 
 private:
     std::shared_ptr<dev::blockchain::BlockChainInterface> m_blockChain;
-    std::vector<NonceVec> nonce_vec;
     /// cache the block nonce to in case of accessing the DB to get nonces of given block frequently
     /// key: block number
     /// value: all the nonces of a given block

--- a/libtxpool/TxPool.h
+++ b/libtxpool/TxPool.h
@@ -203,6 +203,7 @@ public:
     bool initPartiallyBlock(dev::eth::Block::Ptr _block) override;
 
     void setMaxMemoryLimit(int64_t const& _maxMemoryLimit) { m_maxMemoryLimit = _maxMemoryLimit; }
+    void freshTxsStatus() override;
 
 protected:
     /**
@@ -285,7 +286,6 @@ private:
     dev::ThreadPool::Ptr m_submitPool;
     dev::ThreadPool::Ptr m_workerPool;
 
-    std::shared_ptr<tbb::concurrent_queue<dev::eth::Transaction::Ptr>> m_txsCache;
     std::atomic_bool m_running = {false};
     std::condition_variable m_signalled;
     std::shared_ptr<std::map<dev::h256, dev::u256>> m_invalidTxs;

--- a/libtxpool/TxPoolInterface.h
+++ b/libtxpool/TxPoolInterface.h
@@ -145,6 +145,11 @@ public:
     virtual bool initPartiallyBlock(std::shared_ptr<dev::eth::Block>) { return true; }
     virtual void registerSyncStatusChecker(std::function<bool()>) {}
 
+    // when the node is changed from sealer/observer node to free-node,
+    // Update the status of all transactions,  so that when the node becomes an observer or a
+    // sealer, broadcast the remaining transactions in the transaction pool to other nodes
+    virtual void freshTxsStatus() {}
+
 protected:
     ///< Called when a subsequent call to import transactions will return a non-empty container. Be
     ///< nice and exit fast.


### PR DESCRIPTION
Fix the problem that the raft node is changed from the free node to the sealer, and the txs in the txpool has been pending unprocessed