### PR TITLE
support Configure outgoing_bandwidth_limiter to support decimals

### DIFF
--- a/libchannelserver/ChannelRPCServer.cpp
+++ b/libchannelserver/ChannelRPCServer.cpp
@@ -651,6 +651,7 @@ void dev::ChannelRPCServer::asyncPushChannelMessageHandler(
     }
 }
 
+// Note: No restrictions on AMOP traffic between nodes
 void dev::ChannelRPCServer::onNodeChannelRequest(
     dev::network::NetworkException, std::shared_ptr<p2p::P2PSession> s, p2p::P2PMessage::Ptr msg)
 {
@@ -823,7 +824,8 @@ bool dev::ChannelRPCServer::limitAMOPBandwidth(dev::channel::ChannelSession::Ptr
         return true;
     }
     CHANNEL_LOG(DEBUG) << LOG_BADGE("limitAMOPBandwidth: over bandwidth limitation")
-                       << LOG_KV("messageSize", requiredPermitsAfterCompress)
+                       << LOG_KV("requiredPermitsAfterCompress", requiredPermitsAfterCompress)
+                       << LOG_KV("maxPermitsPerSecond(Bytes)", m_networkBandwidthLimiter->maxQPS())
                        << LOG_KV("seq", _AMOPReq->seq().substr(0, c_seqAbridgedLen));
     // send REJECT_AMOP_REQ_FOR_OVER_BANDWIDTHLIMIT to client
     sendRejectAMOPResponse(_session, _AMOPReq);

--- a/libconfig/GlobalConfigure.h
+++ b/libconfig/GlobalConfigure.h
@@ -117,7 +117,9 @@ public:
     const uint64_t c_binaryLogSize = 128 * 1024 * 1024;
     // the max block size: 20MB
     // the max permits size(for network bandwidth limit), default is 20MB
-    const uint64_t c_maxPermitsSize = 20 * 1024 * 1024;
+    // default compressRate is 3
+    const uint64_t c_compressRate = 3;
+    const uint64_t c_maxPermitsSize = 20 * 1024 * 1024 / c_compressRate;
 
     std::atomic_bool shouldExit;
 

--- a/libethcore/Protocol.h
+++ b/libethcore/Protocol.h
@@ -26,6 +26,9 @@
 #include <stdint.h>
 #include <iosfwd>
 
+#define MAX_VALUE_IN_MB (INT64_MAX / (1024 * 1024))
+#define MAX_VALUE_IN_Mb (INT64_MAX / (1024 * 128))
+
 namespace dev
 {
 typedef int16_t GROUP_ID;

--- a/libflowlimit/RateLimiter.h
+++ b/libflowlimit/RateLimiter.h
@@ -34,7 +34,7 @@ class RateLimiter
 {
 public:
     using Ptr = std::shared_ptr<RateLimiter>;
-    RateLimiter(uint64_t const& _maxQPS);
+    RateLimiter(int64_t const& _maxQPS);
     virtual ~RateLimiter() {}
     // acquire permits
     virtual int64_t acquire(int64_t const& _requiredPermits = 1, bool const& _wait = false,
@@ -55,6 +55,8 @@ public:
     void setBurstTimeInterval(int64_t const& _burstInterval);
     void setMaxBurstReqNum(int64_t const& _maxBurstReqNum);
 
+    int64_t const& maxQPS() { return m_maxQPS; }
+
 protected:
     int64_t fetchPermitsAndGetWaitTime(int64_t const& _requiredPermits,
         bool const& _fetchPermitsWhenRequireWait, int64_t const& _now);
@@ -66,7 +68,7 @@ protected:
     mutable dev::Mutex m_mutex;
 
     // the max QPS
-    uint64_t m_maxQPS;
+    int64_t m_maxQPS;
 
     // stored permits
     int64_t m_currentStoredPermits = 0;

--- a/libinitializer/RPCInitializer.cpp
+++ b/libinitializer/RPCInitializer.cpp
@@ -69,7 +69,7 @@ void RPCInitializer::initChannelRPCServer(boost::property_tree::ptree const& _pt
     m_channelRPCServer->setNetworkStatHandler(m_networkStatHandler);
     // create network-bandwidth-limiter
     auto networkBandwidth = createNetworkBandwidthLimit(_pt);
-    if (networkBandwidth && m_networkStatHandler)
+    if (networkBandwidth)
     {
         m_channelRPCServer->setNetworkBandwidthLimiter(networkBandwidth);
     }
@@ -293,21 +293,26 @@ dev::flowlimit::RPCQPSLimiter::Ptr RPCInitializer::createQPSLimiter(
 dev::flowlimit::RateLimiter::Ptr RPCInitializer::createNetworkBandwidthLimit(
     boost::property_tree::ptree const& _pt)
 {
-    int64_t outGoingBandwidthLimit =
-        _pt.get<int64_t>("flow_control.outgoing_bandwidth_limit", INT64_MAX);
-    if (outGoingBandwidthLimit <= 0)
-    {
-        BOOST_THROW_EXCEPTION(dev::InvalidConfig()
-                              << errinfo_comment("createNetworkBandwidthLimit for channel failed, "
-                                                 "flow_control.limit_req_qps must be positive!"));
-    }
-    if (outGoingBandwidthLimit == INT64_MAX)
+    auto outGoingBandwidthLimit =
+        _pt.get<double>("flow_control.outgoing_bandwidth_limit", INT64_MAX);
+    // default value
+    if (outGoingBandwidthLimit == (double)INT64_MAX)
     {
         INITIALIZER_LOG(DEBUG) << LOG_DESC("Disable NetworkBandwidthLimit for channel");
         return nullptr;
     }
+    // Configured outgoing_bandwidth_limit
+    if (outGoingBandwidthLimit <= (double)0 || outGoingBandwidthLimit >= (double)MAX_VALUE_IN_Mb)
+    {
+        BOOST_THROW_EXCEPTION(
+            dev::InvalidConfig() << errinfo_comment(
+                "createNetworkBandwidthLimit for channel failed, "
+                "flow_control.limit_req_qps must be larger than 0 and smaller than " +
+                std::to_string(MAX_VALUE_IN_Mb)));
+    }
     outGoingBandwidthLimit *= 1024 * 1024 / 8;
-    auto bandwidthLimiter = std::make_shared<dev::flowlimit::RateLimiter>(outGoingBandwidthLimit);
+    auto bandwidthLimiter =
+        std::make_shared<dev::flowlimit::RateLimiter>((int64_t)outGoingBandwidthLimit);
     bandwidthLimiter->setMaxPermitsSize(g_BCOSConfig.c_maxPermitsSize);
     INITIALIZER_LOG(INFO) << LOG_BADGE("createNetworkBandwidthLimit")
                           << LOG_KV("outGoingBandwidthLimit(Bytes)", outGoingBandwidthLimit)

--- a/libp2p/Service.cpp
+++ b/libp2p/Service.cpp
@@ -636,11 +636,13 @@ bool Service::asyncMulticastMessageByTopic(
         auto requiredPermits = message->length() * nodeIDsToSend.size() / m_compressRate;
         if (!_bandwidthLimiter->tryAcquire(requiredPermits))
         {
-            SERVICE_LOG(DEBUG)
-                << LOG_DESC("asyncMulticastMessageByTopic failed for over bandwidth limitation")
-                << LOG_KV("requiredPermits", requiredPermits)
-                << LOG_KV("broadcastTargetSize", nodeIDsToSend.size())
-                << LOG_KV("msgSize", message->length());
+            SERVICE_LOG(DEBUG) << LOG_DESC(
+                                      "asyncMulticastMessageByTopic from channel failed for over "
+                                      "bandwidth limitation")
+                               << LOG_KV("requiredPermits", requiredPermits)
+                               << LOG_KV("maxPermitsPerSecond(Bytes)", _bandwidthLimiter->maxQPS())
+                               << LOG_KV("broadcastTargetSize", nodeIDsToSend.size())
+                               << LOG_KV("msgSize", message->length());
             return false;
         }
         message->setPermitsAcquired(true);

--- a/tools/build_chain.sh
+++ b/tools/build_chain.sh
@@ -567,6 +567,7 @@ generate_config_ini()
     ; The number of brust requests as a percentage of limit_req_qps must be between 0 and 100
     ;qps_burst_percent=20
     ; restrict the outgoing bandwidth of the node
+    ; Mb, can be a decimal
     ; when the outgoing bandwidth exceeds the limit, the block synchronization operation will not proceed
     ;outgoing_bandwidth_limit=2
 EOF
@@ -674,6 +675,7 @@ function generate_group_ini()
     ; The number of brust requests as a percentage of limit_req_qps must be between 0 and 100
     ;qps_burst_percent=20
     ; restrict the outgoing bandwidth of the group
+    ; Mb, can be a decimal
     ; when the outgoing bandwidth exceeds the limit, the block synchronization operation will not proceed
     ;outgoing_bandwidth_limit=2
 EOF


### PR DESCRIPTION
1. support Configure outgoing_bandwidth_limiter to support decimals
2. Fix the problems found in the process of self-testing AMOP traffic:
(1) the AMOP bandwidth limiter is disabled when disables the network-stat
(2) permits are overused in advance, leading to unrestricted first-time traffic 