### PR TITLE
optimize performance and improve concurrency

### DIFF
--- a/libblockverifier/BlockVerifier.h
+++ b/libblockverifier/BlockVerifier.h
@@ -65,8 +65,7 @@ public:
     {
         if (_enableParallel)
         {
-            // m_threadNum = std::max(std::thread::hardware_concurrency(), (unsigned int)1);
-            m_threadNum = 8;
+            m_threadNum = std::max(std::thread::hardware_concurrency(), (unsigned int)1);
         }
     }
 

--- a/libblockverifier/ExecutiveContext.cpp
+++ b/libblockverifier/ExecutiveContext.cpp
@@ -97,8 +97,7 @@ Address ExecutiveContext::registerPrecompiled(std::shared_ptr<precompiled::Preco
 
 bool ExecutiveContext::isPrecompiled(Address address) const
 {
-    auto p = getPrecompiled(address);
-    return p.get() != NULL;
+    return (m_address2Precompiled.count(address));
 }
 
 std::shared_ptr<precompiled::Precompiled> ExecutiveContext::getPrecompiled(Address address) const

--- a/libdevcore/Log.cpp
+++ b/libdevcore/Log.cpp
@@ -32,4 +32,17 @@ boost::log::sources::severity_channel_logger_mt<boost::log::trivial::severity_le
 std::string const StatFileLogger = "StatFileLogger";
 boost::log::sources::severity_channel_logger_mt<boost::log::trivial::severity_level, std::string>
     StatFileLoggerHandler(boost::log::keywords::channel = StatFileLogger);
+
+LogLevel c_fileLogLevel = LogLevel::INFO;
+LogLevel c_statLogLevel = LogLevel::INFO;
+
+void setFileLogLevel(LogLevel const& _level)
+{
+    c_fileLogLevel = _level;
+}
+
+void setStatLogLevel(LogLevel const& _level)
+{
+    c_statLogLevel = _level;
+}
 }  // namespace dev

--- a/libdevcore/Log.h
+++ b/libdevcore/Log.h
@@ -57,11 +57,19 @@ enum LogLevel
     TRACE = boost::log::trivial::trace
 };
 
-#define LOG(level)                        \
-    BOOST_LOG_SEV(dev::FileLoggerHandler, \
+extern LogLevel c_fileLogLevel;
+extern LogLevel c_statLogLevel;
+
+void setFileLogLevel(LogLevel const& _level);
+void setStatLogLevel(LogLevel const& _level);
+
+#define LOG(level)                                   \
+    if (dev::LogLevel::level >= dev::c_fileLogLevel) \
+    BOOST_LOG_SEV(dev::FileLoggerHandler,            \
         (boost::log::v2s_mt_posix::trivial::severity_level)(dev::LogLevel::level))
 
-#define STAT_LOG(level)                       \
-    BOOST_LOG_SEV(dev::StatFileLoggerHandler, \
+#define STAT_LOG(level)                              \
+    if (dev::LogLevel::level >= dev::c_statLogLevel) \
+    BOOST_LOG_SEV(dev::StatFileLoggerHandler,        \
         (boost::log::v2s_mt_posix::trivial::severity_level)(dev::LogLevel::level))
 }  // namespace dev

--- a/libexecutive/ExtVM.cpp
+++ b/libexecutive/ExtVM.cpp
@@ -204,7 +204,6 @@ size_t ExtVM::codeSizeAt(dev::Address const& _a)
 {
     if (m_envInfo.precompiledEngine()->isPrecompiled(_a))
     {
-        LOG(TRACE) << _a << " precompiled codeSizeAt return 1";
         return 1;
     }
     return m_s->codeSize(_a);

--- a/libinitializer/BoostLogInitializer.h
+++ b/libinitializer/BoostLogInitializer.h
@@ -79,7 +79,8 @@ private:
     bool canRotate(size_t const& _index);
 
     boost::shared_ptr<sink_t> initLogSink(boost::property_tree::ptree const& _pt,
-        std::string const& _logPath, std::string const& _logPrefix, std::string const& channel);
+        unsigned const& _logLevel, std::string const& _logPath, std::string const& _logPrefix,
+        std::string const& channel);
 
 private:
     void stopLogging(boost::shared_ptr<sink_t> sink);

--- a/libinterpreter/VMCalls.cpp
+++ b/libinterpreter/VMCalls.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "VM.h"
+#include <libconfig/GlobalConfigure.h>
 
 namespace dev
 {
@@ -231,7 +232,11 @@ bool VM::caseCallSetup(evmc_message& o_msg, bytesRef& o_output)
     bool const haveValueArg = m_OP == Instruction::CALL || m_OP == Instruction::CALLCODE;
 
     evmc_address destination = toEvmC(asAddress(m_SP[1]));
-    int destinationExists = m_context->fn_table->account_exists(m_context, &destination);
+    int destinationExists = 1;
+    if (g_BCOSConfig.version() < V2_5_0)
+    {
+        destinationExists = m_context->fn_table->account_exists(m_context, &destination);
+    }
 
     if (m_OP == Instruction::CALL && !destinationExists)
     {

--- a/libprecompiled/ChainGovernancePrecompiled.cpp
+++ b/libprecompiled/ChainGovernancePrecompiled.cpp
@@ -92,8 +92,6 @@ string ChainGovernancePrecompiled::toString()
 PrecompiledExecResult::Ptr ChainGovernancePrecompiled::call(
     ExecutiveContext::Ptr _context, bytesConstRef _param, Address const& _origin, Address const&)
 {
-    CHAIN_GOVERNANCE_LOG(TRACE) << LOG_DESC("call") << LOG_KV("param", toHex(_param));
-
     // parse function name
     uint32_t func = getParamFunc(_param);
     bytesConstRef data = getParamData(_param);

--- a/libprecompiled/ConditionPrecompiled.cpp
+++ b/libprecompiled/ConditionPrecompiled.cpp
@@ -62,8 +62,6 @@ std::string ConditionPrecompiled::toString()
 PrecompiledExecResult::Ptr ConditionPrecompiled::call(
     ExecutiveContext::Ptr, bytesConstRef param, Address const&, Address const&)
 {
-    STORAGE_LOG(DEBUG) << "call Condition:" << toHex(param);
-
     // parse function name
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);

--- a/libprecompiled/ConsensusPrecompiled.cpp
+++ b/libprecompiled/ConsensusPrecompiled.cpp
@@ -54,9 +54,6 @@ ConsensusPrecompiled::ConsensusPrecompiled()
 PrecompiledExecResult::Ptr ConsensusPrecompiled::call(
     ExecutiveContext::Ptr context, bytesConstRef param, Address const& origin, Address const&)
 {
-    PRECOMPILED_LOG(TRACE) << LOG_BADGE("ConsensusPrecompiled") << LOG_DESC("call")
-                           << LOG_KV("param", toHex(param));
-
     // parse function name
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);

--- a/libprecompiled/ContractLifeCyclePrecompiled.cpp
+++ b/libprecompiled/ContractLifeCyclePrecompiled.cpp
@@ -385,8 +385,7 @@ void ContractLifeCyclePrecompiled::listManager(
 PrecompiledExecResult::Ptr ContractLifeCyclePrecompiled::call(
     ExecutiveContext::Ptr context, bytesConstRef param, Address const& origin, Address const&)
 {
-    PRECOMPILED_LOG(DEBUG) << LOG_BADGE("ContractLifeCyclePrecompiled")
-                           << LOG_KV("call param", toHex(param));
+    PRECOMPILED_LOG(DEBUG) << LOG_BADGE("ContractLifeCyclePrecompiled");
 
     // parse function name
     uint32_t func = getParamFunc(param);

--- a/libprecompiled/EntriesPrecompiled.cpp
+++ b/libprecompiled/EntriesPrecompiled.cpp
@@ -44,8 +44,6 @@ std::string EntriesPrecompiled::toString()
 PrecompiledExecResult::Ptr EntriesPrecompiled::call(
     ExecutiveContext::Ptr context, bytesConstRef param, Address const&, Address const&)
 {
-    STORAGE_LOG(TRACE) << LOG_BADGE("EntriesPrecompiled") << LOG_DESC("call")
-                       << LOG_KV("param", toHex(param));
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);
 

--- a/libprecompiled/EntryPrecompiled.cpp
+++ b/libprecompiled/EntryPrecompiled.cpp
@@ -82,9 +82,6 @@ std::string EntryPrecompiled::toString()
 PrecompiledExecResult::Ptr EntryPrecompiled::call(
     std::shared_ptr<ExecutiveContext>, bytesConstRef param, Address const&, Address const&)
 {
-    STORAGE_LOG(TRACE) << LOG_BADGE("EntryPrecompiled") << LOG_DESC("call")
-                       << LOG_KV("param", toHex(param));
-
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);
 

--- a/libprecompiled/KVTablePrecompiled.cpp
+++ b/libprecompiled/KVTablePrecompiled.cpp
@@ -100,7 +100,7 @@ PrecompiledExecResult::Ptr KVTablePrecompiled::call(ExecutiveContext::Ptr contex
         std::string key;
         Address entryAddress;
         abi.abiOut(data, key, entryAddress);
-        PRECOMPILED_LOG(INFO) << LOG_BADGE("KVTable") << LOG_KV("set", key);
+        PRECOMPILED_LOG(DEBUG) << LOG_BADGE("KVTable") << LOG_KV("set", key);
         EntryPrecompiled::Ptr entryPrecompiled =
             std::dynamic_pointer_cast<EntryPrecompiled>(context->getPrecompiled(entryAddress));
         auto entry = entryPrecompiled->getEntry();

--- a/libprecompiled/PermissionPrecompiled.cpp
+++ b/libprecompiled/PermissionPrecompiled.cpp
@@ -63,9 +63,6 @@ std::string PermissionPrecompiled::toString()
 PrecompiledExecResult::Ptr PermissionPrecompiled::call(
     ExecutiveContext::Ptr context, bytesConstRef param, Address const& origin, Address const&)
 {
-    PRECOMPILED_LOG(TRACE) << LOG_BADGE("PermissionPrecompiled") << LOG_DESC("call")
-                           << LOG_KV("param", toHex(param));
-
     // parse function name
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);

--- a/libprecompiled/Precompiled.h
+++ b/libprecompiled/Precompiled.h
@@ -98,7 +98,8 @@ protected:
 
     PrecompiledExecResultFactory::Ptr m_precompiledExecResultFactory;
 };
+// for UT
+void clearName2SelectCache();
 
 }  // namespace precompiled
-
 }  // namespace dev

--- a/libprecompiled/SystemConfigPrecompiled.cpp
+++ b/libprecompiled/SystemConfigPrecompiled.cpp
@@ -41,9 +41,6 @@ SystemConfigPrecompiled::SystemConfigPrecompiled()
 PrecompiledExecResult::Ptr SystemConfigPrecompiled::call(
     ExecutiveContext::Ptr context, bytesConstRef param, Address const& origin, Address const&)
 {
-    PRECOMPILED_LOG(TRACE) << LOG_BADGE("SystemConfigPrecompiled") << LOG_DESC("call")
-                           << LOG_KV("param", toHex(param));
-
     // parse function name
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);

--- a/libprecompiled/TableFactoryPrecompiled.cpp
+++ b/libprecompiled/TableFactoryPrecompiled.cpp
@@ -58,9 +58,6 @@ std::string TableFactoryPrecompiled::toString()
 PrecompiledExecResult::Ptr TableFactoryPrecompiled::call(ExecutiveContext::Ptr context,
     bytesConstRef param, Address const& origin, Address const& sender)
 {
-    STORAGE_LOG(TRACE) << LOG_BADGE("TableFactoryPrecompiled") << LOG_DESC("call")
-                       << LOG_KV("param", toHex(param));
-
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);
 

--- a/libprecompiled/TablePrecompiled.cpp
+++ b/libprecompiled/TablePrecompiled.cpp
@@ -59,9 +59,6 @@ std::string TablePrecompiled::toString()
 PrecompiledExecResult::Ptr TablePrecompiled::call(ExecutiveContext::Ptr context,
     bytesConstRef param, Address const& origin, Address const& sender)
 {
-    PRECOMPILED_LOG(TRACE) << LOG_BADGE("TablePrecompiled") << LOG_DESC("call")
-                           << LOG_KV("param", toHex(param));
-
     uint32_t func = getParamFunc(param);
     bytesConstRef data = getParamData(param);
 
@@ -107,7 +104,7 @@ PrecompiledExecResult::Ptr TablePrecompiled::call(ExecutiveContext::Ptr context,
         Address entryAddress;
         abi.abiOut(data, key, entryAddress);
 
-        PRECOMPILED_LOG(INFO) << LOG_DESC("Table insert") << LOG_KV("key", key);
+        PRECOMPILED_LOG(DEBUG) << LOG_DESC("Table insert") << LOG_KV("key", key);
 
         EntryPrecompiled::Ptr entryPrecompiled =
             std::dynamic_pointer_cast<EntryPrecompiled>(context->getPrecompiled(entryAddress));
@@ -161,7 +158,7 @@ PrecompiledExecResult::Ptr TablePrecompiled::call(ExecutiveContext::Ptr context,
         std::string key;
         Address conditionAddress;
         abi.abiOut(data, key, conditionAddress);
-        PRECOMPILED_LOG(INFO) << LOG_DESC("Table remove") << LOG_KV("key", key);
+        PRECOMPILED_LOG(DEBUG) << LOG_DESC("Table remove") << LOG_KV("key", key);
 
         ConditionPrecompiled::Ptr conditionPrecompiled =
             std::dynamic_pointer_cast<ConditionPrecompiled>(
@@ -191,7 +188,7 @@ PrecompiledExecResult::Ptr TablePrecompiled::call(ExecutiveContext::Ptr context,
         Address entryAddress;
         Address conditionAddress;
         abi.abiOut(data, key, entryAddress, conditionAddress);
-        PRECOMPILED_LOG(INFO) << LOG_DESC("Table update") << LOG_KV("key", key);
+        PRECOMPILED_LOG(DEBUG) << LOG_DESC("Table update") << LOG_KV("key", key);
         EntryPrecompiled::Ptr entryPrecompiled =
             std::dynamic_pointer_cast<EntryPrecompiled>(context->getPrecompiled(entryAddress));
         ConditionPrecompiled::Ptr conditionPrecompiled =

--- a/libstorage/MemoryTableFactory2.cpp
+++ b/libstorage/MemoryTableFactory2.cpp
@@ -252,7 +252,8 @@ h256 MemoryTableFactory2::hash()
         {
             // in previous version(<= 2.4.0), we use sha256(...) to calculate hash of the data,
             // for now, to keep consistent with transction's implementation, we decide to use
-            // sha3(...) to calculate hash of the data. This `else` branch is just for compatibility.
+            // sha3(...) to calculate hash of the data. This `else` branch is just for
+            // compatibility.
             m_hash = dev::sha256(&data);
         }
     }
@@ -353,7 +354,6 @@ void MemoryTableFactory2::commitDB(dev::h256 const&, int64_t _blockNumber)
     }
     auto commit_time_cost = utcTime() - record_time;
     record_time = utcTime();
-
     m_name2Table.clear();
     auto clear_time_cost = utcTime() - record_time;
     STORAGE_LOG(DEBUG) << LOG_BADGE("Commit") << LOG_DESC("Commit db time record")

--- a/test/unittests/libconsensus/RotatingPBFTEngineTest.cpp
+++ b/test/unittests/libconsensus/RotatingPBFTEngineTest.cpp
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(testRawPrepareTreeBroadcast)
 
     std::shared_ptr<P2PMessage> receivedP2pMsg = nullptr;
     // wait broadcast enqueue finished
-    int count = 5000;
+    int count = 10000;
     while (!receivedP2pMsg && --count > 0)
     {
         receivedP2pMsg = leaderService->getAsyncSendMessageByNodeID(
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(testRawPrepareTreeBroadcast)
         sealerSet, leaderRPBFT->fakePBFTSuite()->consensus()->nodeIdx());
     BOOST_CHECK(selectedNodes->size() == 3);
     receivedP2pMsg = nullptr;
-    count = 5000;
+    count = 10000;
     while (!receivedP2pMsg && --count > 0)
     {
         receivedP2pMsg = leaderService->getAsyncSendMessageByNodeID((*selectedNodes)[0]);
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(testRawPrepareTreeBroadcast)
     else
     {
         receivedP2pMsg = nullptr;
-        count = 5000;
+        count = 10000;
         while (!receivedP2pMsg && --count > 0)
         {
             receivedP2pMsg = followService->getAsyncSendMessageByNodeID((*selectedNodes)[0]);
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(testRawPrepareTreeBroadcast)
         leaderSession2, receivedP2pMsg);
     // wait for request
     std::shared_ptr<P2PMessage> receivedP2pMsg2 = nullptr;
-    count = 5000;
+    count = 10000;
     while (!receivedP2pMsg2 && --count > 0)
     {
         receivedP2pMsg2 = followService->getAsyncSendMessageByNodeID(
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(testRawPrepareTreeBroadcast)
         networkException, leaderSession2, receivedP2pMsg);
 
     receivedP2pMsg = nullptr;
-    count = 5000;
+    count = 10000;
     while (!receivedP2pMsg && --count > 0)
     {
         receivedP2pMsg = followService->getAsyncSendMessageByNodeID(
@@ -324,7 +324,7 @@ BOOST_AUTO_TEST_CASE(testRawPrepareTreeBroadcast)
     leaderRPBFT->fakePBFTSuite()->consensus()->wrapperHandleP2PMessage(
         networkException, followSession, receivedP2pMsg);
     receivedP2pMsg = nullptr;
-    count = 5000;
+    count = 10000;
     while (!receivedP2pMsg && --count > 0)
     {
         receivedP2pMsg = leaderService->getAsyncSendMessageByNodeID(

--- a/test/unittests/libprecompiled/test_PermissionPrecompiled.cpp
+++ b/test/unittests/libprecompiled/test_PermissionPrecompiled.cpp
@@ -55,6 +55,8 @@ struct AuthorityPrecompiledFixture
             m_supportedVersion = g_BCOSConfig.supportedVersion();
             g_BCOSConfig.setSupportedVersion("2.3.0", V2_3_0);
         }
+        // clear global name2Selector cache
+        clearName2SelectCache();
         context = std::make_shared<ExecutiveContext>();
         ExecutiveContextFactory factory;
         auto storage = std::make_shared<MemoryStorage>();
@@ -79,6 +81,8 @@ struct AuthorityPrecompiledFixture
         {
             g_BCOSConfig.setSupportedVersion(m_supportedVersion, m_version);
         }
+        // clear global name2Selector cache
+        clearName2SelectCache();
     }
 
     ExecutiveContext::Ptr context;


### PR DESCRIPTION
1. Delete frequently output logs
2. Reduce time-consuming accout_exists call