### PR TITLE
Optimize the system and improve the system concurrency

### DIFF
--- a/libblockchain/BlockChainImp.cpp
+++ b/libblockchain/BlockChainImp.cpp
@@ -32,6 +32,7 @@
 #include <libstorage/StorageException.h>
 #include <libstorage/Table.h>
 #include <tbb/parallel_for.h>
+#include <tbb/parallel_invoke.h>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/lexical_cast.hpp>
@@ -60,7 +61,13 @@ std::shared_ptr<Block> BlockCache::add(std::shared_ptr<Block> _block)
             BLOCKCHAIN_LOG(TRACE) << LOG_DESC("[add]Block cache full, start to remove old item...");
             auto firstHash = m_blockCacheFIFO.front();
             m_blockCacheFIFO.pop_front();
+            auto removedBlock = m_blockCache[firstHash];
+
             m_blockCache.erase(firstHash);
+            // Destruct the block in m_destructorThread
+            HolderForDestructor<Block> holder(std::move(removedBlock));
+            m_destructorThread->enqueue(std::move(holder));
+
             // in case something unexcept error
             if (m_blockCache.size() > c_blockCacheSize)
             {
@@ -1292,51 +1299,53 @@ void BlockChainImp::writeTxToBlock(const Block& block, std::shared_ptr<Executive
     if (tb && tb_nonces)
     {
         auto txs = block.transactions();
-        std::vector<dev::eth::NonceKeyType> nonce_vector(txs->size());
         auto constructVector_time_cost = utcTime() - record_time;
         record_time = utcTime();
+        std::string blockNumberStr = lexical_cast<std::string>(block.blockHeader().number());
+        tbb::parallel_invoke(
+            [tb, txs, blockNumberStr]() {
+                tbb::parallel_for(tbb::blocked_range<size_t>(0, txs->size()),
+                    [&](const tbb::blocked_range<size_t>& _r) {
+                        for (size_t i = _r.begin(); i != _r.end(); ++i)
+                        {
+                            Entry::Ptr entry = std::make_shared<Entry>();
+                            entry->setField(SYS_VALUE, blockNumberStr);
+                            entry->setField("index", lexical_cast<std::string>(i));
+                            entry->setForce(true);
 
-        tbb::parallel_for(
-            tbb::blocked_range<size_t>(0, txs->size()), [&](const tbb::blocked_range<size_t>& _r) {
-                for (size_t i = _r.begin(); i != _r.end(); ++i)
+                            tb->insert((*txs)[i]->sha3().hex(), entry,
+                                std::make_shared<dev::storage::AccessOptions>(), false);
+                        }
+                    });
+            },
+            [this, tb_nonces, txs, blockNumberStr]() {
+                std::vector<dev::eth::NonceKeyType> nonce_vector(txs->size());
+                for (size_t i = 0; i < txs->size(); i++)
                 {
-                    Entry::Ptr entry = std::make_shared<Entry>();
-                    entry->setField(
-                        SYS_VALUE, lexical_cast<std::string>(block.blockHeader().number()));
-                    entry->setField("index", lexical_cast<std::string>(i));
-                    entry->setForce(true);
-
-                    tb->insert((*txs)[i]->sha3().hex(), entry,
-                        std::make_shared<dev::storage::AccessOptions>(), false);
                     nonce_vector[i] = (*txs)[i]->nonce();
                 }
+                /// insert tb2Nonces
+                RLPStream rs;
+                rs.appendVector(nonce_vector);
+                std::shared_ptr<bytes> nonceData = std::make_shared<bytes>();
+                rs.swapOut(*nonceData);
+                Entry::Ptr entry_tb2nonces = std::make_shared<Entry>();
+                // store nonce directly >= v2.2.0
+                // store the hex string < 2.2.0
+                writeBytesToField(nonceData, entry_tb2nonces, SYS_VALUE);
+
+                entry_tb2nonces->setForce(true);
+                tb_nonces->insert(lexical_cast<std::string>(blockNumberStr), entry_tb2nonces);
+                // Destruct the entry_tb2nonces in m_destructorThread
+                HolderForDestructor<Entry> holder(std::move(entry_tb2nonces));
+                m_destructorThread->enqueue(std::move(holder));
             });
-
         auto insertTable_time_cost = utcTime() - record_time;
-        record_time = utcTime();
-        /// insert tb2Nonces
-        RLPStream rs;
-        rs.appendVector(nonce_vector);
-        auto encodeNonceVector_time_cost = utcTime() - record_time;
-        record_time = utcTime();
-
-        Entry::Ptr entry_tb2nonces = std::make_shared<Entry>();
-        // store nonce directly >= v2.2.0
-        // store the hex string < 2.2.0
-        std::shared_ptr<bytes> nonceData = std::make_shared<bytes>();
-        rs.swapOut(*nonceData);
-        writeBytesToField(nonceData, entry_tb2nonces, SYS_VALUE);
-
-        entry_tb2nonces->setForce(true);
-        tb_nonces->insert(lexical_cast<std::string>(block.blockHeader().number()), entry_tb2nonces);
-        auto insertNonceVector_time_cost = utcTime() - record_time;
         BLOCKCHAIN_LOG(DEBUG) << LOG_BADGE("WriteTxOnCommit")
                               << LOG_DESC("Write tx to block time record")
                               << LOG_KV("openTableTimeCost", openTable_time_cost)
                               << LOG_KV("constructVectorTimeCost", constructVector_time_cost)
                               << LOG_KV("insertTableTimeCost", insertTable_time_cost)
-                              << LOG_KV("encodeNonceVectorTimeCost", encodeNonceVector_time_cost)
-                              << LOG_KV("insertNonceVectorTimeCost", insertNonceVector_time_cost)
                               << LOG_KV("totalTimeCost", utcTime() - start_time);
     }
     else
@@ -1371,17 +1380,15 @@ void BlockChainImp::writeHash2Block(Block& block, std::shared_ptr<ExecutiveConte
         writeBlockToField(block, entry);
         entry->setForce(true);
         tb->insert(block.blockHeader().hash().hex(), entry);
+        // Block entry destructor is time-consuming, add it to the thread pool to destruct
+        // asynchronously, Destruct the entry in m_destructorThread
+        HolderForDestructor<Entry> holder(std::move(entry));
+        m_destructorThread->enqueue(std::move(holder));
     }
     else
     {
         BOOST_THROW_EXCEPTION(OpenSysTableFailed() << errinfo_comment(SYS_HASH_2_BLOCK));
     }
-}
-
-void BlockChainImp::writeBlockInfo(Block& block, std::shared_ptr<ExecutiveContext> context)
-{
-    writeHash2Block(block, context);
-    writeNumber2Hash(block, context);
 }
 
 bool BlockChainImp::isBlockShouldCommit(int64_t const& _blockNumber)
@@ -1428,25 +1435,13 @@ CommitResult BlockChainImp::commitBlock(
                 return CommitResult::ERROR_PARENT_HASH;
             }
             auto write_record_time = utcTime();
-            // writeBlockInfo(block, context);
-            writeHash2Block(*block, context);
-            auto writeHash2Block_time_cost = utcTime() - write_record_time;
-            write_record_time = utcTime();
+            tbb::parallel_invoke([this, block, context]() { writeHash2Block(*block, context); },
+                [this, block, context]() { writeNumber2Hash(*block, context); },
+                [this, block, context]() { writeNumber(*block, context); },
+                [this, block, context]() { writeTotalTransactionCount(*block, context); },
+                [this, block, context]() { writeTxToBlock(*block, context); });
+            auto write_table_time = utcTime() - write_record_time;
 
-            writeNumber2Hash(*block, context);
-            auto writeNumber2Hash_time_cost = utcTime() - write_record_time;
-            write_record_time = utcTime();
-
-            writeNumber(*block, context);
-            auto writeNumber_time_cost = utcTime() - write_record_time;
-            write_record_time = utcTime();
-
-            writeTotalTransactionCount(*block, context);
-            auto writeTotalTransactionCount_time_cost = utcTime() - write_record_time;
-            write_record_time = utcTime();
-
-            writeTxToBlock(*block, context);
-            auto writeTxToBlock_time_cost = utcTime() - write_record_time;
             write_record_time = utcTime();
             try
             {
@@ -1466,15 +1461,9 @@ CommitResult BlockChainImp::commitBlock(
                 m_blockNumber = block->blockHeader().number();
             }
             auto updateBlockNumber_time_cost = utcTime() - write_record_time;
-
             BLOCKCHAIN_LOG(DEBUG) << LOG_BADGE("Commit")
                                   << LOG_DESC("Commit block time record(write)")
-                                  << LOG_KV("writeHash2BlockTimeCost", writeHash2Block_time_cost)
-                                  << LOG_KV("writeNumber2HashTimeCost", writeNumber2Hash_time_cost)
-                                  << LOG_KV("writeNumberTimeCost", writeNumber_time_cost)
-                                  << LOG_KV("writeTotalTransactionCountTimeCost",
-                                         writeTotalTransactionCount_time_cost)
-                                  << LOG_KV("writeTxToBlockTimeCost", writeTxToBlock_time_cost)
+                                  << LOG_KV("writeTableTime", write_table_time)
                                   << LOG_KV("dbCommitTimeCost", dbCommit_time_cost)
                                   << LOG_KV(
                                          "updateBlockNumberTimeCost", updateBlockNumber_time_cost);
@@ -1487,7 +1476,6 @@ CommitResult BlockChainImp::commitBlock(
         record_time = utcTime();
         m_onReady(m_blockNumber);
         auto noteReady_time_cost = utcTime() - record_time;
-        record_time = utcTime();
 
         BLOCKCHAIN_LOG(DEBUG) << LOG_BADGE("Commit") << LOG_DESC("Commit block time record")
                               << LOG_KV("beforeTimeCost", before_write_time_cost)

--- a/libblockverifier/ExecutiveContext.cpp
+++ b/libblockverifier/ExecutiveContext.cpp
@@ -34,6 +34,13 @@ using namespace dev::eth::abi;
 using namespace dev::blockverifier;
 using namespace dev;
 using namespace std;
+void ExecutiveContext::registerParallelPrecompiled(
+    std::shared_ptr<dev::precompiled::Precompiled> _precompiled)
+{
+    m_parallelConfigPrecompiled =
+        std::dynamic_pointer_cast<dev::precompiled::ParallelConfigPrecompiled>(_precompiled);
+}
+
 // set PrecompiledExecResultFactory for each precompiled object
 void ExecutiveContext::setPrecompiledExecResultFactory(
     dev::precompiled::PrecompiledExecResultFactory::Ptr _precompiledExecResultFactory)
@@ -176,14 +183,8 @@ std::shared_ptr<std::vector<std::string>> ExecutiveContext::getTxCriticals(const
     }
     else
     {
-        // Normal transaction
-        auto parallelConfigPrecompiled =
-            std::dynamic_pointer_cast<dev::precompiled::ParallelConfigPrecompiled>(
-                getPrecompiled(Address(0x1006)));
-
-        uint32_t selector = parallelConfigPrecompiled->getParamFunc(ref(_tx.data()));
-
-        auto config = parallelConfigPrecompiled->getParallelConfig(
+        uint32_t selector = m_parallelConfigPrecompiled->getParamFunc(ref(_tx.data()));
+        auto config = m_parallelConfigPrecompiled->getParallelConfig(
             shared_from_this(), _tx.receiveAddress(), selector, _tx.sender());
 
         if (config == nullptr)

--- a/libblockverifier/ExecutiveContext.h
+++ b/libblockverifier/ExecutiveContext.h
@@ -52,6 +52,7 @@ namespace precompiled
 {
 class Precompiled;
 class PrecompiledExecResultFactory;
+class ParallelConfigPrecompiled;
 }  // namespace precompiled
 namespace blockverifier
 {
@@ -59,9 +60,7 @@ class ExecutiveContext : public std::enable_shared_from_this<ExecutiveContext>
 {
 public:
     typedef std::shared_ptr<ExecutiveContext> Ptr;
-
     ExecutiveContext() : m_addressCount(0x10000) {}
-
     virtual ~ExecutiveContext()
     {
         if (m_memoryTableFactory)
@@ -88,6 +87,8 @@ public:
         }
         m_address2Precompiled.insert(std::make_pair(address, precompiled));
     }
+
+    void registerParallelPrecompiled(std::shared_ptr<dev::precompiled::Precompiled> _precompiled);
 
     void setPrecompiledExecResultFactory(
         dev::precompiled::PrecompiledExecResultFactory::Ptr _precompiledExecResultFactory);
@@ -138,6 +139,7 @@ private:
     uint64_t m_txGasLimit = 300000000;
 
     std::shared_ptr<dev::precompiled::PrecompiledExecResultFactory> m_precompiledExecResultFactory;
+    std::shared_ptr<dev::precompiled::ParallelConfigPrecompiled> m_parallelConfigPrecompiled;
 };
 
 }  // namespace blockverifier

--- a/libblockverifier/ExecutiveContextFactory.cpp
+++ b/libblockverifier/ExecutiveContextFactory.cpp
@@ -65,8 +65,11 @@ void ExecutiveContextFactory::initExecutiveContext(
         Address(0x1004), std::make_shared<dev::precompiled::CNSPrecompiled>());
     context->setAddress2Precompiled(
         Address(0x1005), std::make_shared<dev::precompiled::PermissionPrecompiled>());
-    context->setAddress2Precompiled(
-        Address(0x1006), std::make_shared<dev::precompiled::ParallelConfigPrecompiled>());
+
+    auto parallelConfigPrecompiled =
+        std::make_shared<dev::precompiled::ParallelConfigPrecompiled>();
+    context->setAddress2Precompiled(Address(0x1006), parallelConfigPrecompiled);
+    context->registerParallelPrecompiled(parallelConfigPrecompiled);
     if (g_BCOSConfig.version() >= V2_3_0)
     {
         context->setAddress2Precompiled(

--- a/libconsensus/pbft/PBFTEngine.h
+++ b/libconsensus/pbft/PBFTEngine.h
@@ -89,6 +89,9 @@ public:
             std::make_shared<dev::ThreadPool>("PBFTMsg-" + std::to_string(m_groupId), 1);
         m_prepareWorker =
             std::make_shared<dev::ThreadPool>("PBFTWork-" + std::to_string(m_groupId), 1);
+
+        m_destructorThread =
+            std::make_shared<dev::ThreadPool>("PBFTAsync-" + std::to_string(m_groupId), 1);
         m_cachedForwardMsg =
             std::make_shared<std::map<dev::h256, std::pair<int64_t, PBFTMsgPacket::Ptr>>>();
     }
@@ -723,8 +726,6 @@ protected:
 
     // the thread pool is used to execute the async-function
     dev::ThreadPool::Ptr m_threadPool;
-
-    std::vector<dev::blockverifier::ExecutiveContext::Ptr> m_execContextForAsyncReset;
     PBFTMsgFactory::Ptr m_pbftMsgFactory = nullptr;
     // ttl-optimize related logic
     bool m_enableTTLOptimize = false;
@@ -736,6 +737,9 @@ protected:
     std::shared_ptr<std::map<dev::h256, std::pair<int64_t, PBFTMsgPacket::Ptr>>> m_cachedForwardMsg;
     dev::ThreadPool::Ptr m_prepareWorker;
     dev::ThreadPool::Ptr m_messageHandler;
+
+    // Make object destructive overhead asynchronous
+    dev::ThreadPool::Ptr m_destructorThread;
     bool m_enablePrepareWithTxsHash = false;
 };
 }  // namespace consensus

--- a/libdevcore/Common.h
+++ b/libdevcore/Common.h
@@ -425,6 +425,20 @@ private:
         m_record;
 };
 
+template <typename T>
+class HolderForDestructor
+{
+public:
+    HolderForDestructor(std::shared_ptr<T> _elementsToDestroy)
+      : m_elementsToDestroy(std::move(_elementsToDestroy))
+    {}
+    void operator()() {}
+
+private:
+    // Elements to be deconstructed
+    std::shared_ptr<T> m_elementsToDestroy;
+};
+
 std::string newSeq();
 void pthread_setThreadName(std::string const& _n);
 

--- a/libprecompiled/KVTablePrecompiled.cpp
+++ b/libprecompiled/KVTablePrecompiled.cpp
@@ -149,6 +149,7 @@ PrecompiledExecResult::Ptr KVTablePrecompiled::call(ExecutiveContext::Ptr contex
     else if (func == name2Selector[KVTABLE_METHOD_NEWENT])
     {  // newEntry()
         auto entry = m_table->newEntry();
+        entry->setForce(true);
         auto entryPrecompiled = std::make_shared<EntryPrecompiled>();
         entryPrecompiled->setEntry(entry);
 

--- a/libstorage/CachedStorage.h
+++ b/libstorage/CachedStorage.h
@@ -169,6 +169,7 @@ private:
     uint64_t m_clearInterval = 1000;
 
     dev::ThreadPool::Ptr m_taskThreadPool;
+    dev::ThreadPool::Ptr m_asyncThreadPool;
     std::shared_ptr<std::thread> m_clearThread;
 
     tbb::atomic<uint64_t> m_hitTimes;

--- a/libstorage/MemoryTable2.h
+++ b/libstorage/MemoryTable2.h
@@ -86,6 +86,12 @@ public:
     void rollback(const Change& _change) override;
 
 private:
+    void parallelGenData(bytes& _generatedData, std::shared_ptr<std::vector<size_t>> _offsetVec,
+        Entries::Ptr _entries);
+
+    std::shared_ptr<std::vector<size_t>> genDataOffset(Entries::Ptr _entries, size_t _startOffset);
+
+
     Entries::Ptr selectNoLock(const std::string& key, Condition::Ptr condition);
     dev::storage::TableData::Ptr dumpWithoutOptimize();
 

--- a/libstorage/Table.h
+++ b/libstorage/Table.h
@@ -85,6 +85,7 @@ private:
     bool m_force = false;
     bool m_deleted = false;
     ssize_t m_capacity = 0;
+    ssize_t m_capacityOfHashField = 0;
 
     EntryData::Ptr m_data;
 
@@ -141,6 +142,7 @@ public:
     virtual void setDeleted(bool deleted);
 
     virtual ssize_t capacity() const;
+    virtual ssize_t capacityOfHashField() const;
 
     virtual void copyFrom(Entry::ConstPtr entry);
 

--- a/libstoragestate/StorageState.cpp
+++ b/libstoragestate/StorageState.cpp
@@ -209,6 +209,7 @@ void StorageState::setStorage(Address const& _address, u256 const& _location, u2
         if (entries->size() == 0u)
         {
             auto entry = table->newEntry();
+            entry->setForce(true);
             entry->setField(STORAGE_KEY, _location.str());
             entry->setField(STORAGE_VALUE, _value.str());
             table->insert(_location.str(), entry, option);
@@ -216,6 +217,7 @@ void StorageState::setStorage(Address const& _address, u256 const& _location, u2
         else
         {
             auto entry = table->newEntry();
+            entry->setForce(true);
             entry->setField(STORAGE_KEY, _location.str());
             entry->setField(STORAGE_VALUE, _value.str());
             table->update(_location.str(), entry, table->newCondition(), option);

--- a/test/unittests/libblockverifier/TxDAGTest.cpp
+++ b/test/unittests/libblockverifier/TxDAGTest.cpp
@@ -96,8 +96,9 @@ public:
         ExecutiveContext::Ptr ctx = std::make_shared<ExecutiveContext>();
         ctx->setAddress2Precompiled(
             Address(0x5002), make_shared<dev::precompiled::DagTransferPrecompiled>());
-        ctx->setAddress2Precompiled(
-            Address(0x1006), make_shared<dev::precompiled::ParallelConfigPrecompiled>());
+        auto parallelConfigPrecompiled = make_shared<dev::precompiled::ParallelConfigPrecompiled>();
+        ctx->setAddress2Precompiled(Address(0x1006), parallelConfigPrecompiled);
+        ctx->registerParallelPrecompiled(parallelConfigPrecompiled);
         return ctx;
     }
 


### PR DESCRIPTION
1.When KVTable newEntry and sol newEntry, directly overwrite old data,
2. MemoryTable2 writes data in parallel when calculating the hash,
3. Bypass time-consuming destructuring operations to asynchronous threads
4. BlockChain concurrent write table