### PR TITLE
Parallelize newEntries processing

### DIFF
--- a/libprecompiled/extension/DagTransferPrecompiled.cpp
+++ b/libprecompiled/extension/DagTransferPrecompiled.cpp
@@ -155,14 +155,22 @@ Table::Ptr DagTransferPrecompiled::openTable(
     }
     auto table = Precompiled::openTable(context, dagTableName);
     if (!table)
-    {  //__dat_transfer__ is not exist, then create it first.
+    {
+        PRECOMPILED_LOG(DEBUG) << LOG_BADGE(
+                                      "DagTransferPrecompiled openTable: ready to create table")
+                               << LOG_KV("tableName", dagTableName);
+        //__dag_transfer__ is not exist, then create it first.
         table = createTable(
             context, dagTableName, DAG_TRANSFER_FIELD_NAME, DAG_TRANSFER_FIELD_BALANCE, origin);
-
-        PRECOMPILED_LOG(DEBUG) << LOG_BADGE("DagTransferPrecompiled") << LOG_DESC("open table")
-                               << LOG_DESC(" create __dag_transfer__ table. ");
+        // table already exists
+        if (!table)
+        {
+            PRECOMPILED_LOG(DEBUG) << LOG_BADGE("DagTransferPrecompiled: table already exist")
+                                   << LOG_KV("tableName", dagTableName);
+            // try to openTable and get the table again
+            table = Precompiled::openTable(context, dagTableName);
+        }
     }
-
     return table;
 }
 

--- a/libstorage/CachedStorage.h
+++ b/libstorage/CachedStorage.h
@@ -27,6 +27,7 @@
 #include <libdevcore/ThreadPool.h>
 #include <tbb/concurrent_queue.h>
 #include <tbb/concurrent_unordered_map.h>
+#include <tbb/concurrent_unordered_set.h>
 #include <tbb/spin_mutex.h>
 #include <tbb/spin_rw_mutex.h>
 #include <boost/multi_index/hashed_index.hpp>
@@ -81,7 +82,7 @@ public:
     typedef std::shared_ptr<Task> Ptr;
 
     int64_t num = 0;
-    std::shared_ptr<std::vector<TableData::Ptr> > datas;
+    std::shared_ptr<std::vector<TableData::Ptr>> datas;
 };
 
 class CachedStorage : public Storage
@@ -131,6 +132,9 @@ private:
         TableInfo::Ptr table, const std::string& key, bool write = false);
     void restoreCache(TableInfo::Ptr table, const std::string& key, Cache::Ptr cache);
 
+    void sortCaches(std::shared_ptr<std::vector<TableData::Ptr>> _commitDatas,
+        std::shared_ptr<std::vector<tbb::concurrent_unordered_set<std::string>>> _processedKeys);
+
     void removeCache(const std::string& table, const std::string& key);
 
     bool disabled();
@@ -150,9 +154,9 @@ private:
     std::shared_ptr<boost::multi_index_container<std::pair<std::string, std::string>,
         boost::multi_index::indexed_by<boost::multi_index::sequenced<>,
             boost::multi_index::hashed_unique<
-                boost::multi_index::identity<std::pair<std::string, std::string> > > > > >
+                boost::multi_index::identity<std::pair<std::string, std::string>>>>>>
         m_mru;
-    std::shared_ptr<tbb::concurrent_queue<std::tuple<std::string, std::string, ssize_t> > >
+    std::shared_ptr<tbb::concurrent_queue<std::tuple<std::string, std::string, ssize_t>>>
         m_mruQueue;
 
     // boost::multi_index
@@ -175,7 +179,7 @@ private:
     tbb::atomic<uint64_t> m_hitTimes;
     tbb::atomic<uint64_t> m_queryTimes;
 
-    std::shared_ptr<tbb::atomic<bool> > m_running;
+    std::shared_ptr<tbb::atomic<bool>> m_running;
 };
 
 }  // namespace storage


### PR DESCRIPTION
1. Parallelize newEntries processing

2.solve inconsistencies caused by multiple transactions concurrently accessing DagTransfer OpenTable, creating and opening DagTransfer tables