### PR TITLE
update c_compressRate & fix  PBFT backup  strategy

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,7 +23,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterClass: true
-  # AfterCaseLabel: true
+  AfterCaseLabel: true
   AfterControlStatement: true
   AfterEnum: true
   AfterFunction: true

--- a/libconfig/GlobalConfigure.h
+++ b/libconfig/GlobalConfigure.h
@@ -120,8 +120,8 @@ public:
     const uint64_t c_binaryLogSize = 128 * 1024 * 1024;
     // the max block size: 20MB
     // the max permits size(for network bandwidth limit), default is 20MB
-    // default compressRate is 3.5
-    const double c_compressRate = 3.5;
+    // default compressRate is 4.0
+    const double c_compressRate = 4.0;
     const uint64_t c_maxPermitsSize = 20 * 1024 * 1024 / c_compressRate;
 
     std::atomic_bool shouldExit;

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -301,6 +301,10 @@ PrepareReq::Ptr PBFTEngine::constructPrepareReq(dev::eth::Block::Ptr _block)
     *engineBlock = std::move(*_block);
     PrepareReq::Ptr prepareReq = std::make_shared<PrepareReq>(
         engineBlock, m_keyPair, m_view, nodeIdx(), m_enablePrepareWithTxsHash);
+    if (prepareReq->pBlock->transactions()->size() == 0)
+    {
+        prepareReq->isEmpty = true;
+    }
     // the non-empty block only broadcast hash when enable-prepare-with-txs-hash
     if (m_enablePrepareWithTxsHash && prepareReq->pBlock->transactions()->size() > 0)
     {


### PR DESCRIPTION
1.  fix strategy does not take effect that the PBFT backup is not checked when receive empty pbft prepare
2. update c_compressRate to 4.0