### PR TITLE
Fix the problem of m_latestViewChangeReqCache update

### DIFF
--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -1512,6 +1512,8 @@ void PBFTEngine::catchupView(ViewChangeReq const& req, std::ostringstream& oss)
         if (succ)
         {
             sendViewChangeMsg(nodeId);
+            // erase the cache
+            m_reqCache->eraseLatestViewChangeCacheForNodeUpdated(req);
         }
     }
 }

--- a/libconsensus/pbft/PBFTReqCache.cpp
+++ b/libconsensus/pbft/PBFTReqCache.cpp
@@ -98,7 +98,7 @@ bool PBFTReqCache::checkViewChangeReq(ViewChangeReq::Ptr _req, int64_t const& _b
     // only store the newest viewChangeReq
     auto viewChangeReq = (*m_latestViewChangeReqCache)[_req->idx];
     // remove the cached viewChangeReq with older Height
-    if (viewChangeReq->height < _blockNumber)
+    if (viewChangeReq && viewChangeReq->height < _blockNumber)
     {
         eraseExpiredViewChange(viewChangeReq, _blockNumber);
         return true;
@@ -129,12 +129,12 @@ void PBFTReqCache::eraseExpiredViewChange(ViewChangeReq::Ptr _req, int64_t const
     if (m_latestViewChangeReqCache->count(_req->idx))
     {
         auto viewChangeReq = (*m_latestViewChangeReqCache)[_req->idx];
-        if (m_recvViewChangeReq.count(_req->view) &&
-            m_recvViewChangeReq[_req->view].count(_req->idx))
+        if (viewChangeReq && m_recvViewChangeReq.count(viewChangeReq->view) &&
+            m_recvViewChangeReq[viewChangeReq->view].count(_req->idx))
         {
-            if (viewChangeReq == m_recvViewChangeReq[_req->view][_req->idx])
+            if (viewChangeReq == m_recvViewChangeReq[viewChangeReq->view][_req->idx])
             {
-                m_recvViewChangeReq[_req->view].erase(_req->idx);
+                m_recvViewChangeReq[viewChangeReq->view].erase(_req->idx);
             }
             m_latestViewChangeReqCache->erase(_req->idx);
             PBFTReqCache_LOG(DEBUG)
@@ -387,5 +387,9 @@ void PBFTReqCache::triggerViewChange(VIEWTYPE const& curView, int64_t const& _hi
     removeInvalidViewChange(curView);
 }
 
+void PBFTReqCache::eraseLatestViewChangeCacheForNodeUpdated(ViewChangeReq const& _req)
+{
+    m_latestViewChangeReqCache->erase(_req.idx);
+}
 }  // namespace consensus
 }  // namespace dev

--- a/libconsensus/pbft/PBFTReqCache.h
+++ b/libconsensus/pbft/PBFTReqCache.h
@@ -295,6 +295,11 @@ public:
     /// add specified viewchange cache to the viewchange-cache
     bool checkViewChangeReq(ViewChangeReq::Ptr _req, int64_t const& _blockNumber);
     void eraseExpiredViewChange(ViewChangeReq::Ptr _req, int64_t const& _blockNumber);
+
+    // When the node restarts and the view becomes smaller, call this function to clear the history
+    // cache
+    void eraseLatestViewChangeCacheForNodeUpdated(ViewChangeReq const& _req);
+
     void addViewChangeReq(ViewChangeReq::Ptr _req, int64_t const& _blockNumber = 0);
 
     template <typename T, typename S>


### PR DESCRIPTION
Fix the problem that the corresponding m_latestViewChangeReqCache is not cleaned after the node restarts