### PR TITLE
Change the sync status package from object to pointer

### DIFF
--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -34,6 +34,7 @@
 #include <libconsensus/vrf_rpbft/VRFBasedrPBFTSealer.h>
 #include <libflowlimit/RateLimiter.h>
 #include <libsync/SyncMaster.h>
+#include <libsync/SyncMsgPacketFactory.h>
 #include <libtxpool/TxPool.h>
 #include <boost/property_tree/ini_parser.hpp>
 
@@ -490,6 +491,19 @@ bool Ledger::initSync()
         m_param->mutableSyncParam().idleWaitMs, m_param->mutableSyncParam().gossipInterval,
         m_param->mutableSyncParam().gossipPeers, enableSendTxsByTree, enableSendBlockStatusByTree,
         m_param->mutableSyncParam().syncTreeWidth);
+
+    // create and setSyncMsgPacketFactory
+    SyncMsgPacketFactory::Ptr syncMsgPacketFactory;
+    if (g_BCOSConfig.version() >= V2_6_0)
+    {
+        syncMsgPacketFactory = std::make_shared<SyncMsgPacketWithAlignedTimeFactory>();
+    }
+    else
+    {
+        syncMsgPacketFactory = std::make_shared<SyncMsgPacketFactory>();
+    }
+    syncMaster->setSyncMsgPacketFactory(syncMsgPacketFactory);
+
     // set the max block queue size for sync module(bytes)
     syncMaster->setMaxBlockQueueSize(m_param->mutableSyncParam().maxQueueSizeForBlockSync);
     syncMaster->setTxsStatusGossipMaxPeers(m_param->mutableSyncParam().txsStatusGossipMaxPeers);

--- a/libsync/Common.h
+++ b/libsync/Common.h
@@ -42,6 +42,7 @@ namespace dev
 namespace sync
 {
 DEV_SIMPLE_EXCEPTION(SyncVerifyHandlerNotSet);
+DEV_SIMPLE_EXCEPTION(InValidSyncPacket);
 // Every downloading request timeout request:
 // c_maxRequestBlocks(each peer) * c_maxRequestShards(peer num) = blocks
 static int64_t const c_maxRequestBlocks = 32;
@@ -88,14 +89,5 @@ enum class SyncState
     Downloading,  ///< Downloading blocks
     Size          /// Must be kept last
 };
-
-struct SyncPeerInfo
-{
-    NodeID nodeId;
-    int64_t number;
-    h256 genesisHash;
-    h256 latestHash;
-};
-
 }  // namespace sync
 }  // namespace dev

--- a/libsync/SyncMaster.h
+++ b/libsync/SyncMaster.h
@@ -27,6 +27,7 @@
 #include "RspBlockReq.h"
 #include "SyncInterface.h"
 #include "SyncMsgEngine.h"
+#include "SyncMsgPacketFactory.h"
 #include "SyncStatus.h"
 #include "SyncTransaction.h"
 #include "SyncTreeTopology.h"
@@ -128,6 +129,12 @@ public:
     virtual void setTxsStatusGossipMaxPeers(unsigned const& _txsStatusGossipMaxPeers)
     {
         m_syncTrans->setTxsStatusGossipMaxPeers(_txsStatusGossipMaxPeers);
+    }
+
+    void setSyncMsgPacketFactory(SyncMsgPacketFactory::Ptr _syncMsgPacketFactory)
+    {
+        m_syncMsgPacketFactory = _syncMsgPacketFactory;
+        m_msgEngine->setSyncMsgPacketFactory(_syncMsgPacketFactory);
     }
 
     virtual ~SyncMaster() { stop(); };
@@ -256,6 +263,10 @@ private:
         std::sort(nodeList.begin(), nodeList.end());
         updateConsensusNodeInfo(sealerList, nodeList);
     }
+
+protected:
+    // factory used to create sync related packet
+    SyncMsgPacketFactory::Ptr m_syncMsgPacketFactory;
 
 private:
     /// p2p service handler

--- a/libsync/SyncMsgEngine.h
+++ b/libsync/SyncMsgEngine.h
@@ -25,6 +25,7 @@
 #include "DownloadingTxsQueue.h"
 #include "RspBlockReq.h"
 #include "SyncMsgPacket.h"
+#include "SyncMsgPacketFactory.h"
 #include "SyncStatus.h"
 #include <libblockchain/BlockChainInterface.h>
 #include <libdevcore/FixedHash.h>
@@ -80,6 +81,11 @@ public:
     void onNotifyWorker(std::function<void()> const& _f) { m_onNotifyWorker = _f; }
     void onNotifySyncTrans(std::function<void()> const& _f) { m_onNotifySyncTrans = _f; }
 
+    void setSyncMsgPacketFactory(SyncMsgPacketFactory::Ptr _syncMsgPacketFactory)
+    {
+        m_syncMsgPacketFactory = _syncMsgPacketFactory;
+    }
+
 private:
     bool checkSession(std::shared_ptr<dev::p2p::P2PSession> _session);
     bool checkMessage(dev::p2p::P2PMessage::Ptr _msg);
@@ -119,6 +125,9 @@ protected:
     std::shared_ptr<dev::ThreadPool> m_txsWorker;
     std::shared_ptr<dev::ThreadPool> m_txsSender;
     std::shared_ptr<dev::ThreadPool> m_txsReceiver;
+
+    // factory used to create sync related packet
+    SyncMsgPacketFactory::Ptr m_syncMsgPacketFactory;
 };
 
 class DownloadBlocksContainer

--- a/libsync/SyncMsgPacketFactory.h
+++ b/libsync/SyncMsgPacketFactory.h
@@ -1,0 +1,71 @@
+/*
+ * @CopyRight:
+ * FISCO-BCOS is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FISCO-BCOS is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with FISCO-BCOS.  If not, see <http://www.gnu.org/licenses/>
+ * (c) 2016-2020 fisco-dev contributors.
+ */
+
+/**
+ * @brief : implementation of VRF based rPBFTEngine
+ * @file: SyncMsgPacketFactory.h
+ * @author: yujiechen
+ * @date: 2020-06-12
+ */
+
+#pragma once
+#include "SyncMsgPacket.h"
+
+namespace dev
+{
+namespace sync
+{
+class SyncMsgPacketFactory
+{
+public:
+    using Ptr = std::shared_ptr<SyncMsgPacketFactory>;
+    SyncMsgPacketFactory() = default;
+    virtual ~SyncMsgPacketFactory() {}
+
+    virtual SyncStatusPacket::Ptr createSyncStatusPacket()
+    {
+        return std::make_shared<SyncStatusPacket>();
+    }
+    virtual SyncStatusPacket::Ptr createSyncStatusPacket(NodeID const& _nodeId,
+        int64_t const& _number, h256 const& _genesisHash, h256 const& _latestHash)
+    {
+        return std::make_shared<SyncStatusPacket>(_nodeId, _number, _genesisHash, _latestHash);
+    }
+};
+
+class SyncMsgPacketWithAlignedTimeFactory : public SyncMsgPacketFactory
+{
+public:
+    using Ptr = std::shared_ptr<SyncMsgPacketWithAlignedTimeFactory>;
+
+    SyncMsgPacketWithAlignedTimeFactory() : SyncMsgPacketFactory() {}
+    ~SyncMsgPacketWithAlignedTimeFactory() override {}
+
+    SyncStatusPacket::Ptr createSyncStatusPacket() override
+    {
+        return std::make_shared<SyncStatusPacketWithAlignedTime>();
+    }
+
+    SyncStatusPacket::Ptr createSyncStatusPacket(NodeID const& _nodeId, int64_t const& _number,
+        h256 const& _genesisHash, h256 const& _latestHash) override
+    {
+        return std::make_shared<SyncStatusPacketWithAlignedTime>(
+            _nodeId, _number, _genesisHash, _latestHash);
+    }
+};
+}  // namespace sync
+}  // namespace dev

--- a/libsync/SyncStatus.cpp
+++ b/libsync/SyncStatus.cpp
@@ -37,9 +37,9 @@ bool SyncMasterStatus::hasPeer(NodeID const& _id)
     return m_peersStatus.count(_id);
 }
 
-bool SyncMasterStatus::newSyncPeerStatus(SyncPeerInfo const& _info)
+bool SyncMasterStatus::newSyncPeerStatus(SyncStatusPacket::Ptr _info)
 {
-    if (hasPeer(_info.nodeId))
+    if (hasPeer(_info->nodeId))
     {
         SYNC_LOG(WARNING) << LOG_BADGE("Status")
                           << LOG_DESC("Peer status is exist, no need to create");

--- a/libsync/SyncStatus.h
+++ b/libsync/SyncStatus.h
@@ -23,6 +23,7 @@
 #include "Common.h"
 #include "DownloadingBlockQueue.h"
 #include "RspBlockReq.h"
+#include "SyncMsgPacket.h"
 #include <libblockchain/BlockChainInterface.h>
 #include <libdevcore/FixedHash.h>
 #include <libdevcore/Worker.h>
@@ -61,20 +62,20 @@ public:
         latestHash(_latestHash),
         reqQueue(_nodeId)
     {}
-    SyncPeerStatus(const SyncPeerInfo& _info, PROTOCOL_ID)
-      : nodeId(_info.nodeId),
-        number(_info.number),
-        genesisHash(_info.genesisHash),
-        latestHash(_info.latestHash),
-        reqQueue(_info.nodeId)
+    SyncPeerStatus(SyncStatusPacket::Ptr _info, PROTOCOL_ID)
+      : nodeId(_info->nodeId),
+        number(_info->number),
+        genesisHash(_info->genesisHash),
+        latestHash(_info->latestHash),
+        reqQueue(_info->nodeId)
     {}
 
-    void update(const SyncPeerInfo& _info)
+    void update(SyncStatusPacket::Ptr _info)
     {
-        nodeId = _info.nodeId;
-        number = _info.number;
-        genesisHash = _info.genesisHash;
-        latestHash = _info.latestHash;
+        nodeId = _info->nodeId;
+        number = _info->number;
+        genesisHash = _info->genesisHash;
+        latestHash = _info->latestHash;
     }
 
 public:
@@ -111,7 +112,7 @@ public:
 
     bool hasPeer(NodeID const& _id);
 
-    bool newSyncPeerStatus(SyncPeerInfo const& _info);
+    bool newSyncPeerStatus(SyncStatusPacket::Ptr _info);
 
     void deletePeer(NodeID const& _id);
 

--- a/test/unittests/libsync/SyncMasterTest.cpp
+++ b/test/unittests/libsync/SyncMasterTest.cpp
@@ -56,7 +56,9 @@ public:
       : SyncMaster(_service, _txPool, _blockChain, _blockVerifier, _protocolId, _nodeId,
             _genesisHash, _idleWaitMs, _gossipInterval, _gossipPeers, _enableSendTxsByTree,
             _enableSendBlockStatusByTree)
-    {}
+    {
+        m_syncMsgPacketFactory = std::make_shared<SyncMsgPacketFactory>();
+    }
 
     /// start blockSync
     void start() override
@@ -152,9 +154,9 @@ BOOST_AUTO_TEST_CASE(syncInfoFormatTest)
 {
     std::shared_ptr<SyncMaster> sync = fakeSyncToolsSet(5, 5, NodeID(100)).sync;
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(101), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(101), 0, m_genesisHash, m_genesisHash));
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(102), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(102), 0, m_genesisHash, m_genesisHash));
 
     std::string info = sync->syncInfo();
 
@@ -180,9 +182,9 @@ BOOST_AUTO_TEST_CASE(MaintainTransactionsTest)
     std::shared_ptr<TxPoolInterface> txPool = syncTools.txPool;
 
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(101), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(101), 0, m_genesisHash, m_genesisHash));
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(102), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(102), 0, m_genesisHash, m_genesisHash));
 
     std::shared_ptr<FakeBlock> fakedBlock = std::make_shared<FakeBlock>();
     shared_ptr<Transactions> txs = fakedBlock->fakeTransactions(2, currentBlockNumber);
@@ -259,9 +261,9 @@ BOOST_AUTO_TEST_CASE(MaintainBlocksTest)
     std::shared_ptr<FakeService> service = syncTools.service;
 
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(101), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(101), 0, m_genesisHash, m_genesisHash));
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(102), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(102), 0, m_genesisHash, m_genesisHash));
 
     sync->maintainBlocks();
     cout << "Msg number: " << service->getAsyncSendSizeByNodeID(NodeID(101)) << endl;
@@ -277,14 +279,14 @@ BOOST_AUTO_TEST_CASE(MaintainPeersStatusTest)
     std::shared_ptr<FakeService> service = syncTools.service;
 
     // Can recieve 5 req
-    sync->syncStatus()->newSyncPeerStatus(SyncPeerInfo{
-        NodeID(101), c_maxRequestBlocks * 5 + currentBlockNumber, m_genesisHash, m_genesisHash});
+    sync->syncStatus()->newSyncPeerStatus(std::make_shared<SyncStatusPacket>(
+        NodeID(101), c_maxRequestBlocks * 5 + currentBlockNumber, m_genesisHash, m_genesisHash));
     // Can recieve 1 req
-    sync->syncStatus()->newSyncPeerStatus(SyncPeerInfo{
-        NodeID(102), c_maxRequestBlocks + currentBlockNumber, m_genesisHash, m_genesisHash});
+    sync->syncStatus()->newSyncPeerStatus(std::make_shared<SyncStatusPacket>(
+        NodeID(102), c_maxRequestBlocks + currentBlockNumber, m_genesisHash, m_genesisHash));
     // Can recieve 10(at least 5)req
-    sync->syncStatus()->newSyncPeerStatus(SyncPeerInfo{
-        NodeID(103), c_maxRequestBlocks * 10 + currentBlockNumber, m_genesisHash, m_genesisHash});
+    sync->syncStatus()->newSyncPeerStatus(std::make_shared<SyncStatusPacket>(
+        NodeID(103), c_maxRequestBlocks * 10 + currentBlockNumber, m_genesisHash, m_genesisHash));
 
     sync->maintainPeersStatus();
     cout << "Msg number: " << service->getAsyncSendSizeByNodeID(NodeID(103)) << endl;
@@ -417,9 +419,9 @@ BOOST_AUTO_TEST_CASE(maintainBlockRequestTest)
     std::shared_ptr<FakeService> service = syncTools.service;
 
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(101), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(101), 0, m_genesisHash, m_genesisHash));
     sync->syncStatus()->newSyncPeerStatus(
-        SyncPeerInfo{NodeID(102), 0, m_genesisHash, m_genesisHash});
+        std::make_shared<SyncStatusPacket>(NodeID(102), 0, m_genesisHash, m_genesisHash));
 
     maintainAllBlockRequest(sync);
     // No request, msg is 0

--- a/test/unittests/libsync/SyncMsgPacketTest.cpp
+++ b/test/unittests/libsync/SyncMsgPacketTest.cpp
@@ -132,8 +132,8 @@ BOOST_AUTO_TEST_CASE(PacketDecodeTest)
 
 BOOST_AUTO_TEST_CASE(SyncStatusPacketTest)
 {
-    SyncStatusPacket statusPacket;
-    statusPacket.encode(0x00, h256(0xab), h256(0xcd));
+    SyncStatusPacket statusPacket(h512(), 0x00, h256(0xab), h256(0xcd));
+    statusPacket.encode();
     auto msgPtr = statusPacket.toMessage(0x01);
     statusPacket.decode(fakeSessionPtr, msgPtr);
     auto rlpStatus = statusPacket.rlp();

--- a/test/unittests/libsync/SyncStatusTest.cpp
+++ b/test/unittests/libsync/SyncStatusTest.cpp
@@ -52,11 +52,11 @@ BOOST_AUTO_TEST_CASE(PeerNewHasDeleteTest)
 {
     for (unsigned id = 0; id < 10; id++)
     {
-        SyncPeerInfo node{NodeID(id), id, h256(id), h256(id)};
-        BOOST_CHECK(!status.hasPeer(node.nodeId));
+        auto node = std::make_shared<SyncStatusPacket>(NodeID(id), id, h256(id), h256(id));
+        BOOST_CHECK(!status.hasPeer(node->nodeId));
         BOOST_CHECK(status.newSyncPeerStatus(node));
         BOOST_CHECK(!status.newSyncPeerStatus(node));
-        BOOST_CHECK(status.hasPeer(node.nodeId));
+        BOOST_CHECK(status.hasPeer(node->nodeId));
     }
 
     NodeIDs peers = *(status.peers());
@@ -72,21 +72,21 @@ BOOST_AUTO_TEST_CASE(PeerNewHasDeleteTest)
 BOOST_AUTO_TEST_CASE(PeerStatusTest)
 {
     unsigned id = 999;
-    SyncPeerInfo node{NodeID(id), id, h256(id), h256(id)};
+    auto node = std::make_shared<SyncStatusPacket>(NodeID(id), id, h256(id), h256(id));
     status.newSyncPeerStatus(node);
-    shared_ptr<SyncPeerStatus> peerStatus = status.peerStatus(node.nodeId);
+    shared_ptr<SyncPeerStatus> peerStatus = status.peerStatus(node->nodeId);
 
-    BOOST_CHECK_EQUAL(peerStatus->nodeId, node.nodeId);
-    BOOST_CHECK_EQUAL(peerStatus->number, node.number);
-    BOOST_CHECK_EQUAL(peerStatus->genesisHash, node.genesisHash);
-    BOOST_CHECK_EQUAL(peerStatus->latestHash, node.latestHash);
+    BOOST_CHECK_EQUAL(peerStatus->nodeId, node->nodeId);
+    BOOST_CHECK_EQUAL(peerStatus->number, node->number);
+    BOOST_CHECK_EQUAL(peerStatus->genesisHash, node->genesisHash);
+    BOOST_CHECK_EQUAL(peerStatus->latestHash, node->latestHash);
 }
 
 BOOST_AUTO_TEST_CASE(ForeachPeerTest)
 {
     for (unsigned id = 0; id < 10; id++)
     {
-        SyncPeerInfo node{NodeID(id), id, h256(id), h256(id)};
+        auto node = std::make_shared<SyncStatusPacket>(NodeID(id), id, h256(id), h256(id));
         status.newSyncPeerStatus(node);
     }
 
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(ForeachPeerRandomTest)
 {
     for (unsigned id = 0; id < 10; id++)
     {
-        SyncPeerInfo node{NodeID(id), id, h256(id), h256(id)};
+        auto node = std::make_shared<SyncStatusPacket>(NodeID(id), id, h256(id), h256(id));
         status.newSyncPeerStatus(node);
     }
 
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(RandomSelectionTest)
 {
     for (unsigned id = 0; id < 10; id++)
     {
-        SyncPeerInfo node{NodeID(id), id, h256(id), h256(id)};
+        auto node = std::make_shared<SyncStatusPacket>(NodeID(id), id, h256(id), h256(id));
         status.newSyncPeerStatus(node);
     }
 
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(RandomSelectionSizeTest)
 {
     for (unsigned id = 0; id < 10; id++)
     {
-        SyncPeerInfo node{NodeID(id), id, h256(id), h256(id)};
+        auto node = std::make_shared<SyncStatusPacket>(NodeID(id), id, h256(id), h256(id));
         status.newSyncPeerStatus(node);
     }
 


### PR DESCRIPTION
Change the objects related to the status package of the sync module to pointers to support code scalability