### PR TITLE
add writeHash2BlockHeader to store block header and sigList

### DIFF
--- a/libblockchain/BlockChainImp.h
+++ b/libblockchain/BlockChainImp.h
@@ -85,6 +85,8 @@ DEV_SIMPLE_EXCEPTION(OpenSysTableFailed);
 
 using Parent2ChildListMap = std::map<std::string, std::vector<std::string>>;
 using Child2ParentMap = tbb::concurrent_unordered_map<std::string, std::string>;
+using BlockHeaderInfo =
+    std::pair<std::shared_ptr<dev::eth::BlockHeader>, dev::eth::Block::SigListPtrType>;
 class BlockChainImp : public BlockChainInterface
 {
 public:
@@ -161,7 +163,12 @@ public:
     std::shared_ptr<MerkleProofType> getTransactionProof(
         dev::eth::Block::Ptr _block, uint64_t const& _index) override;
 
+    std::shared_ptr<BlockHeaderInfo> getBlockHeaderInfo(int64_t _blockNumber);
+    std::shared_ptr<BlockHeaderInfo> getBlockHeaderInfoByHash(dev::h256 const& _blockHash);
+
 private:
+    std::shared_ptr<BlockHeaderInfo> getBlockHeaderFromBlock(dev::eth::Block::Ptr _block);
+
     // Randomly select epochSealerSize nodes from workingList as workingSealer and write them into
     // the system table Only used in vrf_rpbft consensus type
     virtual void initGenesisWorkingSealers(dev::storage::Table::Ptr _consTable,
@@ -200,7 +207,8 @@ private:
     void writeBlockToField(dev::eth::Block const& _block, dev::storage::Entry::Ptr _entry);
 
     std::shared_ptr<dev::eth::Block> getBlock(int64_t _blockNumber);
-    std::shared_ptr<dev::eth::Block> getBlock(dev::h256 const& _blockHash, int64_t _blockNumber);
+    std::shared_ptr<dev::eth::Block> getBlock(
+        dev::h256 const& _blockHash, int64_t _blockNumber = -1);
     std::shared_ptr<dev::bytes> getBlockRLP(int64_t _i);
     std::shared_ptr<dev::bytes> getBlockRLP(dev::h256 const& _blockHash, int64_t _blockNumber);
     int64_t obtainNumber();
@@ -214,6 +222,8 @@ private:
         std::shared_ptr<dev::blockverifier::ExecutiveContext> context);
     void writeHash2Block(
         dev::eth::Block& block, std::shared_ptr<dev::blockverifier::ExecutiveContext> context);
+    void writeHash2BlockHeader(
+        dev::eth::Block& _block, std::shared_ptr<dev::blockverifier::ExecutiveContext> _context);
 
     bool isBlockShouldCommit(int64_t const& _blockNumber);
 

--- a/libethcore/Block.cpp
+++ b/libethcore/Block.cpp
@@ -61,8 +61,7 @@ Block::Block(Block const& _block)
   : m_blockHeader(_block.blockHeader()),
     m_transactions(std::make_shared<Transactions>(*_block.transactions())),
     m_transactionReceipts(std::make_shared<TransactionReceipts>(*_block.transactionReceipts())),
-    m_sigList(std::make_shared<std::vector<std::pair<u256, std::vector<unsigned char>>>>(
-        *_block.sigList())),
+    m_sigList(std::make_shared<SigListType>(*_block.sigList())),
     m_txsCache(_block.m_txsCache),
     m_tReceiptsCache(_block.m_tReceiptsCache),
     m_transRootCache(_block.m_transRootCache),
@@ -77,8 +76,7 @@ Block& Block::operator=(Block const& _block)
     /// init transactionReceipts
     m_transactionReceipts = std::make_shared<TransactionReceipts>(*_block.transactionReceipts());
     /// init sigList
-    m_sigList = std::make_shared<std::vector<std::pair<u256, std::vector<unsigned char>>>>(
-        *_block.sigList());
+    m_sigList = std::make_shared<SigListType>(*_block.sigList());
     m_txsCache = _block.m_txsCache;
     m_tReceiptsCache = _block.m_tReceiptsCache;
     m_transRootCache = _block.m_transRootCache;
@@ -452,7 +450,7 @@ void Block::decode(
         BOOST_THROW_EXCEPTION(ErrorBlockHash() << errinfo_comment("BlockHeader hash error"));
     }
     /// get sig_list
-    m_sigList = std::make_shared<std::vector<std::pair<u256, std::vector<unsigned char>>>>(
+    m_sigList = std::make_shared<SigListType>(
         block_rlp[4].toVector<std::pair<u256, std::vector<unsigned char>>>());
 }
 
@@ -480,7 +478,7 @@ void Block::decodeRC2(
         BOOST_THROW_EXCEPTION(ErrorBlockHash() << errinfo_comment("BlockHeader hash error"));
     }
     /// get sig_list
-    m_sigList = std::make_shared<std::vector<std::pair<u256, std::vector<unsigned char>>>>(
+    m_sigList = std::make_shared<SigListType>(
         block_rlp[3].toVector<std::pair<u256, std::vector<unsigned char>>>());
 
     /// get transactionReceipt list

--- a/libethcore/Block.h
+++ b/libethcore/Block.h
@@ -38,13 +38,16 @@ namespace eth
 class Block
 {
 public:
+    using SigListType = std::vector<std::pair<u256, std::vector<unsigned char>>>;
+    using SigListPtrType =
+        std::shared_ptr<std::vector<std::pair<u256, std::vector<unsigned char>>>>;
     using Ptr = std::shared_ptr<Block>;
     ///-----constructors of Block
     Block()
     {
         m_transactions = std::make_shared<Transactions>();
         m_transactionReceipts = std::make_shared<TransactionReceipts>();
-        m_sigList = std::make_shared<std::vector<std::pair<u256, std::vector<unsigned char>>>>();
+        m_sigList = std::make_shared<SigListType>();
     }
     explicit Block(bytesConstRef _data,
         CheckTransaction const _option = CheckTransaction::Everything, bool _withReceipt = true,
@@ -126,10 +129,7 @@ public:
     BlockHeader const& blockHeader() const { return m_blockHeader; }
     BlockHeader& header() { return m_blockHeader; }
     h256 headerHash() const { return m_blockHeader.hash(); }
-    std::shared_ptr<std::vector<std::pair<u256, std::vector<unsigned char>>>> sigList() const
-    {
-        return m_sigList;
-    }
+    SigListPtrType sigList() const { return m_sigList; }
 
     std::shared_ptr<std::vector<u256>> getAllNonces() const
     {
@@ -173,11 +173,7 @@ public:
     /// set block header
     void setBlockHeader(BlockHeader const& _blockHeader) { m_blockHeader = _blockHeader; }
     /// set sig list
-    void inline setSigList(
-        std::shared_ptr<std::vector<std::pair<u256, std::vector<unsigned char>>>> _sigList)
-    {
-        m_sigList = _sigList;
-    }
+    void inline setSigList(SigListPtrType _sigList) { m_sigList = _sigList; }
     /// get hash of block header
     h256 blockHeaderHash() { return m_blockHeader.hash(); }
     bool isSealed() const { return (m_blockHeader.sealer() != Invalid256); }
@@ -317,7 +313,7 @@ protected:
     mutable std::shared_ptr<Transactions> m_transactions;
     std::shared_ptr<TransactionReceipts> m_transactionReceipts;
     /// sig list (field 3)
-    std::shared_ptr<std::vector<std::pair<u256, std::vector<unsigned char>>>> m_sigList;
+    SigListPtrType m_sigList;
     /// m_transactions converted bytes, when m_transactions changed,
     /// should refresh this catch when encode
 

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -284,10 +284,18 @@ bool Ledger::initBlockChain()
     if (!dev::stringCmpIgnoreCase(m_param->mutableStorageParam().type, "External") ||
         !dev::stringCmpIgnoreCase(m_param->mutableStorageParam().type, "MySQL"))
     {
-        Ledger_LOG(INFO) << LOG_DESC("set enableHexBlock to be true")
-                         << LOG_KV("version", g_BCOSConfig.version())
+        if (g_BCOSConfig.version() < V2_6_0)
+        {
+            Ledger_LOG(INFO) << LOG_DESC("set enableHexBlock to be true");
+            blockChain->setEnableHexBlock(true);
+        }
+        // supported_version >= v2.6.0, store block and nonce in bytes in mysql
+        else
+        {
+            blockChain->setEnableHexBlock(false);
+        }
+        Ledger_LOG(INFO) << LOG_DESC("initBlockChain") << LOG_KV("version", g_BCOSConfig.version())
                          << LOG_KV("storageType", m_param->mutableStorageParam().type);
-        blockChain->setEnableHexBlock(true);
     }
     // >= v2.2.0
     else if (g_BCOSConfig.version() >= V2_2_0)

--- a/libstorage/BinLogHandler.cpp
+++ b/libstorage/BinLogHandler.cpp
@@ -369,8 +369,8 @@ void BinLogHandler::encodeTable(TableData::Ptr table, bytes& buffer)
         }
     }
     writeString(buffer, ss.str());
-    // BINLOG_HANDLER_LOG(TRACE) << "table name:" << info->name << ",fields(include key):" << ss.str();
-    // table data : dirty entries and new entries
+    // BINLOG_HANDLER_LOG(TRACE) << "table name:" << info->name << ",fields(include key):" <<
+    // ss.str(); table data : dirty entries and new entries
     encodeEntries(vecField, table->dirtyEntries, buffer);
     encodeEntries(vecField, table->newEntries, buffer);
 }
@@ -508,7 +508,8 @@ DecodeBlockResult BinLogHandler::decodeBlock(const bytes& buffer, int64_t startN
         {
             vecField.push_back(field);
         }
-        bool force = (data->info->name == SYS_BLOCK_2_NONCES || data->info->name == SYS_HASH_2_BLOCK);
+        bool force =
+            (data->info->name == SYS_BLOCK_2_NONCES || data->info->name == SYS_HASH_2_BLOCK);
         decodeEntries(buffer, offset, vecField, data->dirtyEntries, force);
         decodeEntries(buffer, offset, vecField, data->newEntries, force);
         datas.push_back(data);

--- a/libstorage/Common.cpp
+++ b/libstorage/Common.cpp
@@ -26,6 +26,10 @@ using namespace std;
 using namespace dev;
 using namespace dev::storage;
 
+std::map<SQLFieldType, std::string> dev::storage::SQLFieldTypeName{
+    {SQLFieldType::MediumBlobType, "mediumblob"}, {SQLFieldType::LongBlobType, "longblob"},
+    {SQLFieldType::MediumStringType, "mediumtext"}, {SQLFieldType::LongStringType, "longtext"}};
+
 bool dev::storage::isHashField(const std::string& _key)
 {
     if (!_key.empty())

--- a/libstorage/Common.h
+++ b/libstorage/Common.h
@@ -19,6 +19,7 @@
  *  @date 20180921
  */
 #pragma once
+#include <map>
 #include <string>
 
 namespace dev
@@ -43,6 +44,7 @@ static const std::string SYS_KEY_CURRENT_ID = "current_id";
 static const std::string SYS_KEY_TOTAL_TRANSACTION_COUNT = "total_transaction_count";
 static const std::string SYS_KEY_TOTAL_FAILED_TRANSACTION = "total_failed_transaction_count";
 static const std::string SYS_VALUE = "value";
+static const std::string SYS_SIG_LIST = "sigs";
 static const std::string SYS_KEY = "key";
 
 static const std::string SYS_TABLES = "_sys_tables_";
@@ -55,6 +57,7 @@ static const std::string SYS_CNS = "_sys_cns_";
 static const std::string SYS_CONFIG = "_sys_config_";
 static const std::string SYS_ACCESS_TABLE = "_sys_table_access_";
 static const std::string SYS_BLOCK_2_NONCES = "_sys_block_2_nonces_";
+static const std::string SYS_HASH_2_BLOCKHEADER = "_sys_hash_2_header_";
 
 #if 0
 const char* const ID_FIELD = "_id_";
@@ -86,6 +89,15 @@ const int CODE_TABLE_KEYVALUE_LENGTH_OVERFLOW = -50005;
 const int CODE_TABLE_FIELDVALUE_LENGTH_OVERFLOW = -50006;
 const int CODE_TABLE_DUMPLICATE_FIELD = -50007;
 const int CODE_TABLE_INVALIDATE_FIELD = -50008;
+
+enum SQLFieldType : int8_t
+{
+    MediumBlobType = 0,
+    LongBlobType = 1,
+    MediumStringType = 2,
+    LongStringType = 3,
+};
+extern std::map<SQLFieldType, std::string> SQLFieldTypeName;
 
 bool isHashField(const std::string& _key);
 }  // namespace storage

--- a/libstorage/MemoryTableFactory.cpp
+++ b/libstorage/MemoryTableFactory.cpp
@@ -36,7 +36,7 @@ using namespace std;
 
 const std::vector<string> MemoryTableFactory::c_sysTables = std::vector<string>{SYS_CONSENSUS,
     SYS_TABLES, SYS_ACCESS_TABLE, SYS_CURRENT_STATE, SYS_NUMBER_2_HASH, SYS_TX_HASH_2_BLOCK,
-    SYS_HASH_2_BLOCK, SYS_CNS, SYS_CONFIG, SYS_BLOCK_2_NONCES};
+    SYS_HASH_2_BLOCK, SYS_CNS, SYS_CONFIG, SYS_BLOCK_2_NONCES, SYS_HASH_2_BLOCKHEADER};
 
 // according to
 // https://fisco-bcos-documentation.readthedocs.io/zh_CN/latest/docs/design/security_control/permission_control.html

--- a/libstorage/MemoryTableFactory2.cpp
+++ b/libstorage/MemoryTableFactory2.cpp
@@ -51,6 +51,7 @@ MemoryTableFactory2::MemoryTableFactory2()
     m_sysTables.push_back(SYS_CNS);
     m_sysTables.push_back(SYS_CONFIG);
     m_sysTables.push_back(SYS_BLOCK_2_NONCES);
+    m_sysTables.push_back(SYS_HASH_2_BLOCKHEADER);
 }
 
 

--- a/libstorage/SQLBasicAccess.h
+++ b/libstorage/SQLBasicAccess.h
@@ -75,6 +75,17 @@ private:
 
     int CommitDo(int64_t _num, const std::vector<TableData::Ptr>& _datas, std::string& _errorMsg);
 
+    SQLFieldType getFieldType(std::string const& _tableName);
+    bool inline isBlobType(std::string const& _tableName)
+    {
+        auto fieldType = getFieldType(_tableName);
+        if (fieldType == SQLFieldType::MediumBlobType || fieldType == SQLFieldType::LongBlobType)
+        {
+            return true;
+        }
+        return false;
+    }
+
 public:
     virtual void ExecuteSql(const std::string& _sql);
     void setConnPool(std::shared_ptr<SQLConnectionPool>& _connPool);

--- a/libstorage/Table.cpp
+++ b/libstorage/Table.cpp
@@ -889,6 +889,13 @@ TableInfo::Ptr dev::storage::getSysTableInfo(const string& tableName)
         tableInfo->fields = vector<string>{"value"};
         tableInfo->enableConsensus = false;
     }
+    // SYS_HASH_2_BLOCKHEADER won't change the state
+    else if (tableName == SYS_HASH_2_BLOCKHEADER)
+    {
+        tableInfo->key = "hash";
+        tableInfo->fields = std::vector<string>{SYS_VALUE, SYS_SIG_LIST};
+        tableInfo->enableConsensus = false;
+    }
     else if (tableName == SYS_CNS)
     {
         tableInfo->key = "name";

--- a/libstorage/ZdbStorage.cpp
+++ b/libstorage/ZdbStorage.cpp
@@ -131,10 +131,20 @@ void ZdbStorage::initSysTables()
     createCurrentStateTables();
     createNumber2HashTables();
     createTxHash2BlockTables();
-    createHash2BlockTables();
+
     createCnsTables();
     createSysConfigTables();
-    createSysBlock2NoncesTables();
+    if (g_BCOSConfig.version() >= V2_6_0)
+    {
+        createBlobHash2BlockTables();
+        createBlobSysBlock2NoncesTables();
+    }
+    else
+    {
+        createHash2BlockTables();
+        createSysBlock2NoncesTables();
+    }
+    createBlobSysHash2BlockHeaderTable();
     insertSysTables();
 }
 
@@ -249,6 +259,37 @@ void ZdbStorage::createHash2BlockTables()
     string sql = ss.str();
     m_sqlBasicAcc->ExecuteSql(sql);
 }
+
+void ZdbStorage::createBlobHash2BlockTables()
+{
+    stringstream ss;
+    ss << "CREATE TABLE IF NOT EXISTS `" << SYS_HASH_2_BLOCK << "` (\n";
+    ss << getCommonFileds();
+    ss << "`hash` varchar(128) DEFAULT NULL,\n";
+    ss << "`value` longblob,\n";
+    ss << " PRIMARY KEY (`_id_`),\n";
+    ss << "KEY `hash` (`hash`)\n";
+    ss << ") ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4;";
+    string sql = ss.str();
+    m_sqlBasicAcc->ExecuteSql(sql);
+}
+
+void ZdbStorage::createBlobSysHash2BlockHeaderTable()
+{
+    stringstream ss;
+    ss << "CREATE TABLE IF NOT EXISTS `" << SYS_HASH_2_BLOCKHEADER << "` (\n";
+    ss << getCommonFileds();
+    ss << "`hash` varchar(128) DEFAULT NULL,\n";
+    ss << "`value` longblob,\n";
+    ss << "`sigs` longblob,\n";
+    ss << " PRIMARY KEY (`_id_`),\n";
+    ss << "KEY `hash` (`hash`)\n";
+    ss << ") ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4;";
+    string sql = ss.str();
+    m_sqlBasicAcc->ExecuteSql(sql);
+}
+
+
 void ZdbStorage::createSysConsensus()
 {
     stringstream ss;
@@ -292,6 +333,21 @@ void ZdbStorage::createSysBlock2NoncesTables()
     string sql = ss.str();
     m_sqlBasicAcc->ExecuteSql(sql);
 }
+
+void ZdbStorage::createBlobSysBlock2NoncesTables()
+{
+    stringstream ss;
+    ss << "CREATE TABLE IF NOT EXISTS `" << SYS_BLOCK_2_NONCES << "` (\n";
+    ss << getCommonFileds();
+    ss << "`number` varchar(128) DEFAULT NULL,\n";
+    ss << " `value` longblob,\n";
+    ss << "PRIMARY KEY (`_id_`),";
+    ss << "KEY `number` (`number`)";
+    ss << ") ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4;";
+    string sql = ss.str();
+    m_sqlBasicAcc->ExecuteSql(sql);
+}
+
 void ZdbStorage::insertSysTables()
 {
     stringstream ss;
@@ -307,6 +363,7 @@ void ZdbStorage::insertSysTables()
     ss << "	('" << SYS_CNS << "', 'name','version,address,abi'),\n";
     ss << "	('" << SYS_CONFIG << "', 'key','value,enable_num'),\n";
     ss << "	('" << SYS_BLOCK_2_NONCES << "', 'number','value');";
+    ss << "	('" << SYS_HASH_2_BLOCKHEADER << "', 'hash','value', 'sigs');";
     string sql = ss.str();
     m_sqlBasicAcc->ExecuteSql(sql);
 }

--- a/libstorage/ZdbStorage.h
+++ b/libstorage/ZdbStorage.h
@@ -76,6 +76,11 @@ private:
     void createSysBlock2NoncesTables();
     void insertSysTables();
 
+    // create blob table
+    void createBlobHash2BlockTables();
+    void createBlobSysBlock2NoncesTables();
+    void createBlobSysHash2BlockHeaderTable();
+
     int m_maxRetry = 60;
 };
 


### PR DESCRIPTION
1. add writeHash2BlockHeader to store block header and sigList
2. support store blocks and nonces in bytes since 2.6.0