### PR TITLE
trigger rotate when workingSealer size is less than min(epoch_sealer_num, sealer_num)

### DIFF
--- a/libconsensus/vrf_rpbft/VRFBasedrPBFTEngine.cpp
+++ b/libconsensus/vrf_rpbft/VRFBasedrPBFTEngine.cpp
@@ -61,6 +61,7 @@ void VRFBasedrPBFTEngine::updateConsensusNodeList()
         *m_chosedSealerList = workingSealers;
         m_workingSealersNum = workingSealers.size();
         std::string workingSealersStr;
+        // TODO: remove this
         for (auto const& node : workingSealers)
         {
             workingSealersStr += node.abridged() + ",";
@@ -124,7 +125,15 @@ void VRFBasedrPBFTEngine::resetConfig()
     {
         return;
     }
-    // After the last batch of workingsealer agreed on m_rotatingInterval blocks,
+
+    // the number of workingSealers is smaller than epochSize,
+    // trigger rotate in case of the number of working sealers has been decreased to 0
+    auto epochSize = std::min(m_epochSize.load(), m_sealersNum.load());
+    if (m_workingSealersNum.load() < epochSize)
+    {
+        m_shouldRotateSealers.store(true);
+    }
+    // After the last batch of workingsealers agreed on m_rotatingInterval blocks,
     // set m_shouldRotateSealers to true to notify VRFBasedrPBFTSealer to update workingSealer
     if (epochUpdated ||
         (0 == (m_blockChain->number() - m_rotatingIntervalEnableNumber) % m_rotatingInterval))

--- a/libinitializer/LedgerInitializer.cpp
+++ b/libinitializer/LedgerInitializer.cpp
@@ -119,16 +119,19 @@ vector<dev::GROUP_ID> LedgerInitializer::initLedgers()
             }
             catch (exception& e)
             {
+                // Note: This exception is thrown by the lamda expression,
+                //        and the outer function cannot catch the specific error
+                ERROR_OUTPUT << LOG_BADGE("LedgerInitializer") << LOG_DESC("initLedger failed")
+                             << LOG_KV("errorInfo", boost::diagnostic_information(e));
                 BOOST_THROW_EXCEPTION(e);
             }
         });
     }
     catch (exception& e)
     {
-        INITIALIZER_LOG(ERROR) << LOG_BADGE("LedgerInitializer")
-                               << LOG_DESC("parse group config failed")
+        INITIALIZER_LOG(ERROR) << LOG_BADGE("LedgerInitializer") << LOG_DESC("initLedger failed")
                                << LOG_KV("EINFO", boost::diagnostic_information(e));
-        ERROR_OUTPUT << LOG_BADGE("LedgerInitializer") << LOG_DESC("parse group config failed")
+        ERROR_OUTPUT << LOG_BADGE("LedgerInitializer") << LOG_DESC("initLedger failed")
                      << LOG_KV("EINFO", boost::diagnostic_information(e)) << endl;
         BOOST_THROW_EXCEPTION(e);
     }

--- a/libledger/Ledger.cpp
+++ b/libledger/Ledger.cpp
@@ -337,9 +337,21 @@ ConsensusInterface::Ptr Ledger::createConsensusEngine(dev::PROTOCOL_ID const& _p
     }
     if (vrfBasedrPBFTEnabled())
     {
-        Ledger_LOG(INFO) << LOG_DESC("createConsensusEngine: create VRFBasedrPBFTEngine");
-        return std::make_shared<VRFBasedrPBFTEngine>(m_service, m_txPool, m_blockChain, m_sync,
-            m_blockVerifier, _protocolId, m_keyPair, m_param->mutableConsensusParam().sealerList);
+        // Note: since WorkingSealerManagerPrecompiled is enabled after v2.6.0,
+        //       vrf_rpbft is supported after v2.6.0
+        if (g_BCOSConfig.version() >= V2_6_0)
+        {
+            Ledger_LOG(INFO) << LOG_DESC("createConsensusEngine: create VRFBasedrPBFTEngine");
+            return std::make_shared<VRFBasedrPBFTEngine>(m_service, m_txPool, m_blockChain, m_sync,
+                m_blockVerifier, _protocolId, m_keyPair,
+                m_param->mutableConsensusParam().sealerList);
+        }
+        else
+        {
+            BOOST_THROW_EXCEPTION(dev::InitLedgerConfigFailed() << errinfo_comment(
+                                      m_param->mutableConsensusParam().consensusType +
+                                      " is supported after when supported_version >= v2.6.0!"));
+        }
     }
     return nullptr;
 }

--- a/libprecompiled/WorkingSealerManagerImpl.cpp
+++ b/libprecompiled/WorkingSealerManagerImpl.cpp
@@ -285,7 +285,14 @@ bool WorkingSealerManagerImpl::shouldRotate()
                            << LOG_KV("value", epochSealersInfo->first)
                            << LOG_KV("enableBlk", epochSealersInfo->second)
                            << LOG_KV("epochSealersNum", m_configuredEpochSealersSize);
+    // the epoch_sealer_num has updated in the previous block
     if (epochSealersInfo->second == m_context->blockInfo().number)
+    {
+        return true;
+    }
+    int64_t sealersNum = m_pendingSealerList->size() + m_workingSealerList->size();
+    auto epochSize = std::min(m_configuredEpochSealersSize, sealersNum);
+    if ((int64_t)(m_workingSealerList->size()) < epochSize)
     {
         return true;
     }
@@ -300,7 +307,8 @@ bool WorkingSealerManagerImpl::shouldRotate()
     PRECOMPILED_LOG(WARNING)
         << LOG_DESC("should not rotate working sealers for not meet the requirements")
         << LOG_KV("epochBlockNum", epochBlockNum) << LOG_KV("curNum", m_context->blockInfo().number)
-        << LOG_KV("enableNum", epochBlockInfo->second);
+        << LOG_KV("enableNum", epochBlockInfo->second) << LOG_KV("sealersNum", sealersNum)
+        << LOG_KV("epochSealersNum", m_configuredEpochSealersSize);
     return false;
 }
 


### PR DESCRIPTION
1. When workingSealer size is less than min(epoch_sealer_num, sealer_num), workingSealer rotate is triggered
2. only enable vrf_rpbft when supported_version >= v2.6.0