### PR TITLE
forward the remaining transactions when the working sealer has been rotated-out

### DIFF
--- a/libconsensus/vrf_rpbft/VRFBasedrPBFTEngine.h
+++ b/libconsensus/vrf_rpbft/VRFBasedrPBFTEngine.h
@@ -59,6 +59,7 @@ protected:
     void updateConsensusInfo() override;
 
     void checkTransactionsValid(dev::eth::Block::Ptr _block, PrepareReq::Ptr _prepareReq) override;
+    void forwardRemaingTxs(std::set<dev::h512> const& _lastEpochWorkingSealers);
 
 private:
     // Used to notify Sealer whether it needs to rotate sealers

--- a/libconsensus/vrf_rpbft/VRFBasedrPBFTSealer.cpp
+++ b/libconsensus/vrf_rpbft/VRFBasedrPBFTSealer.cpp
@@ -102,8 +102,8 @@ bool VRFBasedrPBFTSealer::generateAndSealerRotatingTx()
                 dev::eth::Transaction::Type::MessageCall, m_vrfPublicKey, blockHashStr, vrfProof);
 
         // put the generated transaction into the 0th position of the block transactions
-        m_sealing.block->transactions()->push_back(generatedTx);
-
+        // Note: here must use appendTransaction for this function will notify updating the txsCache
+        m_sealing.block->appendTransaction(generatedTx);
         VRFRPBFTSealer_LOG(DEBUG) << LOG_DESC("generateAndSealerRotatingTx succ")
                                   << LOG_KV("nodeIdx", m_vrfBasedrPBFTEngine->nodeIdx())
                                   << LOG_KV("blkNum", blockNumber)


### PR DESCRIPTION
1. fix bug caused by txsCache of block has not been flushed after push_back the generated transaction,
2. forward the remaining transactions when the working sealer has been rotated-out