### PR TITLE
enable sdk allowlist control when public_key.i is configured

### DIFF
--- a/libchannelserver/ChannelRPCServer.cpp
+++ b/libchannelserver/ChannelRPCServer.cpp
@@ -919,7 +919,8 @@ void dev::ChannelRPCServer::onClientChannelRequest(
             dev::network::Options options;
             options.timeout = 30 * 1000;  // 30 seconds
 
-            m_service->asyncSendMessageByTopic(topic, p2pMessage,
+            m_service->asyncSendMessageByTopic(
+                topic, p2pMessage,
                 [session, message](dev::network::NetworkException e,
                     std::shared_ptr<dev::p2p::P2PSession>, dev::p2p::P2PMessage::Ptr response) {
                     if (e.errorCode())
@@ -1293,12 +1294,12 @@ std::vector<dev::channel::ChannelSession::Ptr> ChannelRPCServer::getSessionByTop
 }
 
 void ChannelRPCServer::registerSDKAllowListByGroupId(
-    dev::GROUP_ID const& _groupId, dev::PeerWhitelist::Ptr _allowList)
+    dev::GROUP_ID const& _groupId, dev::PeerWhitelist::Ptr _allowList, bool _enableSDKAllowList)
 {
     CHANNEL_LOG(INFO) << LOG_DESC("registerSDKAllowListByGroupId") << LOG_KV("groupId", _groupId)
                       << LOG_KV("size", _allowList->size());
     WriteGuard l(x_group2SDKAllowList);
-    if (_allowList->size() == 0)
+    if (!_enableSDKAllowList)
     {
         CHANNEL_LOG(INFO) << LOG_DESC(
             "Disable group-level sdk permission control for sdk allowlist is empty");

--- a/libchannelserver/ChannelRPCServer.h
+++ b/libchannelserver/ChannelRPCServer.h
@@ -189,8 +189,8 @@ public:
         return m_networkBandwidthLimiter;
     }
 
-    void registerSDKAllowListByGroupId(
-        dev::GROUP_ID const& _groupId, dev::PeerWhitelist::Ptr _allowList);
+    void registerSDKAllowListByGroupId(dev::GROUP_ID const& _groupId,
+        dev::PeerWhitelist::Ptr _allowList, bool _enableSDKAllowList);
 
     // remove the registered sdk allowlist when stop/delete the group
     void removeSDKAllowListByGroupId(dev::GROUP_ID const& _groupId);

--- a/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTEngine.cpp
+++ b/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTEngine.cpp
@@ -109,8 +109,7 @@ void VRFBasedrPBFTEngine::updateConsensusNodeList()
 void VRFBasedrPBFTEngine::tryToForwardRemainingTxs(
     std::set<dev::h512> const& _lastEpochWorkingSealers)
 {
-    // the node is one working sealer of the last epoch
-    // while not the working sealer of this epoch
+    // the node is not the working sealer of this epoch
     auto nodeId = m_keyPair.pub();
     if (!_lastEpochWorkingSealers.count(nodeId) || m_chosedConsensusNodes->count(nodeId))
     {
@@ -125,7 +124,8 @@ void VRFBasedrPBFTEngine::tryToForwardRemainingTxs(
             m_blockSync->noteForwardRemainTxs(workingSealer);
             RPBFTENGINE_LOG(DEBUG)
                 << LOG_DESC("noteForwardRemainTxs after the node rotating out")
-                << LOG_KV("idx", m_idx) << LOG_KV("chosedOutWorkingSealer", m_idx)
+                << LOG_KV("blkNumber", m_highestBlock.number()) << LOG_KV("idx", m_idx)
+                << LOG_KV("chosedOutWorkingSealer", m_idx)
                 << LOG_KV("chosedInWorkingSealer", workingSealer.abridged());
         }
     }

--- a/libledger/Ledger.h
+++ b/libledger/Ledger.h
@@ -214,7 +214,7 @@ protected:
     void initrPBFTEngine(dev::consensus::Sealer::Ptr _sealer);
 
 private:
-    void setSDKAllowList(dev::h512s const& _sdkList);
+    void setSDKAllowList(dev::h512s const& _sdkList, bool _enableSDKAllowList);
     /// create PBFTConsensus
     std::shared_ptr<dev::consensus::Sealer> createPBFTSealer();
     /// create RaftConsensus

--- a/libledger/LedgerParam.h
+++ b/libledger/LedgerParam.h
@@ -183,6 +183,7 @@ struct FlowControlParam
 struct PermissionParam
 {
     dev::h512s sdkAllowList;
+    bool enableSDKAllowList = false;
 };
 
 class LedgerParam : public LedgerParamInterface
@@ -212,8 +213,7 @@ public:
     PermissionParam& mutablePermissionParam() override { return m_permissionParam; }
     void generateGenesisMark();
 
-    void initPermissionParam(
-        dev::h512s& _nodeList, boost::property_tree::ptree const& _pt) override;
+    bool parseSDKAllowList(dev::h512s& _nodeList, boost::property_tree::ptree const& _pt) override;
 
     std::string const& iniConfigPath() override { return m_iniConfigPath; }
     std::string const& genesisConfigPath() override { return m_genesisConfigPath; }
@@ -229,7 +229,7 @@ private:
     void initEventLogFilterManagerConfig(boost::property_tree::ptree const& pt);
     void initFlowControlConfig(boost::property_tree::ptree const& _pt);
     void setEVMFlags(boost::property_tree::ptree const& _pt);
-    void parsePublicKeyListOfSection(dev::h512s& _nodeList, boost::property_tree::ptree const& _pt,
+    bool parsePublicKeyListOfSection(dev::h512s& _nodeList, boost::property_tree::ptree const& _pt,
         std::string const& _sectionName, std::string const& _subSectionName);
 
 private:

--- a/libledger/LedgerParamInterface.h
+++ b/libledger/LedgerParamInterface.h
@@ -68,7 +68,7 @@ public:
     virtual PermissionParam& mutablePermissionParam() = 0;
     virtual std::string const& iniConfigPath() = 0;
     virtual std::string const& genesisConfigPath() = 0;
-    virtual void initPermissionParam(dev::h512s&, boost::property_tree::ptree const&) = 0;
+    virtual bool parseSDKAllowList(dev::h512s&, boost::property_tree::ptree const&) = 0;
 };
 }  // namespace ledger
 }  // namespace dev

--- a/librpc/StatisticProtocolServer.h
+++ b/librpc/StatisticProtocolServer.h
@@ -63,8 +63,11 @@ private:
         "getBlockByNumber", "getBlockHashByNumber", "getTransactionByHash",
         "getTransactionByBlockHashAndIndex", "getTransactionByBlockNumberAndIndex",
         "getTransactionReceipt", "getPendingTransactions", "getPendingTxSize", "call",
-        "sendRawTransaction", "getCode", "getTotalTransactionCount",
-        "getTransactionByHashWithProof", "getTransactionReceiptByHashWithProof"};
+        "sendRawTransaction", "sendRawTransactionAndGetProof", "getCode",
+        "getTotalTransactionCount", "getTransactionByHashWithProof",
+        "getTransactionReceiptByHashWithProof", "getGroupList", "getBlockHeaderByNumber",
+        "getBlockHeaderByHash", "startGroup", "stopGroup", "removeGroup", "recoverGroup",
+        "queryGroupStatus"};
 
     // RPC interface without restrictions
     std::set<std::string> const m_noRestrictRpcMethodSet = {"getClientVersion"};

--- a/libsync/SyncTransaction.cpp
+++ b/libsync/SyncTransaction.cpp
@@ -173,7 +173,7 @@ void SyncTransaction::broadcastTransactions(std::shared_ptr<NodeIDs> _selectedPe
                 selectSize = (selectSize * percent + 99) / 100;
             }
         }
-        if (_fromRpc && m_treeRouter && !randomSelectedPeersInited)
+        if (_fromRpc && m_treeRouter && !randomSelectedPeersInited && !_fastForwardRemainTxs)
         {
             randomSelectedPeers =
                 m_treeRouter->selectNodes(m_syncStatus->peersSet(), consIndex, true);
@@ -182,6 +182,7 @@ void SyncTransaction::broadcastTransactions(std::shared_ptr<NodeIDs> _selectedPe
         // the randomSelectedPeers is empty, continue without setTransactionIsKnownBy
         if (randomSelectedPeers->size() == 0)
         {
+            randomSelectedPeersInited = false;
             continue;
         }
         peers = m_syncStatus->filterPeers(


### PR DESCRIPTION
1. add missing group dimension rpc interface to StatisticProtocolServer
2. Even when all configured sdk public keys are invalid, as long as `public_key.i` is configured, the SDK allowlist control function will be enabled