### PR TITLE
Fix the security issue of rPBFT algorithm based on VRF

### DIFF
--- a/libblockchain/BlockChainImp.cpp
+++ b/libblockchain/BlockChainImp.cpp
@@ -583,7 +583,7 @@ bool BlockChainImp::checkAndBuildGenesisBlock(
                 initSystemConfig(tb, SYSTEM_KEY_RPBFT_EPOCH_BLOCK_NUM,
                     boost::lexical_cast<std::string>(
                         _initParam->mutableConsensusParam().epochBlockNum));
-
+                initSystemConfig(tb, INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE, "0");
                 BLOCKCHAIN_LOG(INFO) << LOG_DESC("set configuration for rPBFT")
                                      << LOG_KV(SYSTEM_KEY_RPBFT_EPOCH_SEALER_NUM,
                                             _initParam->mutableConsensusParam().epochSealerNum)

--- a/libconsensus/pbft/PBFTSealer.cpp
+++ b/libconsensus/pbft/PBFTSealer.cpp
@@ -57,7 +57,6 @@ void PBFTSealer::handleBlock()
         return;
     }
     setBlock();
-    hookAfterHandleBlock();
     PBFTSEALER_LOG(INFO) << LOG_DESC("++++++++++++++++ Generating seal on")
                          << LOG_KV("blkNum", m_sealing.block->header().number())
                          << LOG_KV("tx", m_sealing.block->getTransactionSize())
@@ -76,6 +75,7 @@ void PBFTSealer::setBlock()
     m_sealing.block->header().populateFromParent(
         m_blockChain->getBlockByNumber(m_blockChain->number())->header());
     resetSealingHeader(m_sealing.block->header());
+    hookAfterHandleBlock();
     // calculate transactionRoot before execBlock
     m_sealing.block->calTransactionRoot();
 }

--- a/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTEngine.cpp
+++ b/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTEngine.cpp
@@ -152,6 +152,24 @@ void VRFBasedrPBFTEngine::resetConfig()
         return;
     }
 
+    // The previous leader forged an illegal rotating-tx, resulting in a failed
+    // verification And the INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE flag was set to true, the current
+    // leader needs to rotate workingsealers
+    auto notifyRotateFlagInfo =
+        m_blockChain->getSystemConfigByKey(dev::precompiled::INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE);
+    bool notifyRotateFlag = false;
+    if (notifyRotateFlagInfo != "")
+    {
+        notifyRotateFlag = (bool)(boost::lexical_cast<int64_t>(notifyRotateFlagInfo));
+    }
+    if (notifyRotateFlag)
+    {
+        m_shouldRotateSealers.store(true);
+        VRFRPBFTEngine_LOG(INFO) << LOG_DESC(
+            "resetConfig: the previous leader forged an illegal transaction-rotating, still roate "
+            "working sealers in this epoch");
+    }
+
     // the number of workingSealers is smaller than epochSize,
     // trigger rotate in case of the number of working sealers has been decreased to 0
     auto maxWorkingSealerNum = std::min(m_epochSize.load(), m_sealersNum.load());

--- a/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTSealer.cpp
+++ b/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTSealer.cpp
@@ -103,7 +103,17 @@ bool VRFBasedrPBFTSealer::generateTransactionForRotating()
 
         // put the generated transaction into the 0th position of the block transactions
         // Note: here must use appendTransaction for this function will notify updating the txsCache
-        m_sealing.block->appendTransaction(generatedTx);
+        size_t maxTransacitonSize = m_pbftEngine->maxBlockTransactions();
+        if (m_sealing.block->getTransactionSize() < maxTransacitonSize)
+        {
+            m_sealing.block->appendTransaction(generatedTx);
+        }
+        // update the last transaction
+        else
+        {
+            (*(m_sealing.block->transactions()))[maxTransacitonSize - 1] = generatedTx;
+            m_sealing.block->noteChange();
+        }
         VRFRPBFTSealer_LOG(DEBUG) << LOG_DESC("generateTransactionForRotating succ")
                                   << LOG_KV("nodeIdx", m_vrfBasedrPBFTEngine->nodeIdx())
                                   << LOG_KV("blkNum", blockNumber)

--- a/libethcore/Block.h
+++ b/libethcore/Block.h
@@ -291,13 +291,13 @@ public:
         }
     }
 
-protected:
     /// callback this function when transaction has been changed
     void noteChange()
     {
         WriteGuard l_txscache(x_txsCache);
         m_txsCache = bytes();
     }
+protected:
 
     /// callback this function when transaction receipt has been changed
     void noteReceiptChange()

--- a/libprecompiled/Common.h
+++ b/libprecompiled/Common.h
@@ -198,6 +198,8 @@ const char* const SYSTEM_KEY_RPBFT_EPOCH_BLOCK_NUM = "rpbft_epoch_block_num";
 // system configuration for consensus-time
 const char* const SYSTEM_KEY_CONSENSUS_TIME = "consensus_time";
 
+const char* const INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE = "notify_rotate";
+
 const char* const SYSTEM_INIT_VALUE_TX_GAS_LIMIT = "300000000";
 
 const int TX_COUNT_LIMIT_MIN = 1;

--- a/libprecompiled/WorkingSealerManagerImpl.h
+++ b/libprecompiled/WorkingSealerManagerImpl.h
@@ -98,6 +98,9 @@ private:
     void getSealerList();
     bool shouldRotate();
     void UpdateNodeType(dev::h512 const& _node, std::string const& _nodeType);
+    void setSystemConfigByKey(
+        std::string const& _key, std::string const& _value, int64_t _enableNumber);
+    void tryToResetNotifyNextLeaderFlag();
 
 private:
     std::shared_ptr<dev::blockverifier::ExecutiveContext> m_context;
@@ -109,10 +112,12 @@ private:
     std::shared_ptr<dev::h512s> m_workingSealerList;
 
     std::shared_ptr<dev::storage::Table> m_consTable;
+    std::shared_ptr<dev::storage::Table> m_sysConfigTable;
     dev::h256 m_proofHash;
 
     int64_t m_configuredEpochSealersSize;
     bool m_sealerListObtained = false;
+    bool m_notifyNextLeaderRotateSetted = false;
 };
 }  // namespace precompiled
 }  // namespace dev

--- a/test/unittests/libprecompiled/test_WorkingSealerManagerPrecompiled.h
+++ b/test/unittests/libprecompiled/test_WorkingSealerManagerPrecompiled.h
@@ -139,6 +139,14 @@ public:
         updateNodeListType(sealerList, workingSealersSize, NODE_TYPE_WORKING_SEALER);
     }
 
+    std::string getSystemConfigByKey(std::string const& _key)
+    {
+        auto table = openTable(context, SYS_CONFIG);
+        auto valueInfo =
+            dev::precompiled::getSysteConfigByKey(table, _key, context->blockInfo().number + 1);
+        return valueInfo->first;
+    }
+
     void initrPBFTConfig(std::string const& _key, std::string const& _value)
     {
         auto table = openTable(context, SYS_CONFIG);

--- a/tools/ci/ci_check.sh
+++ b/tools/ci/ci_check.sh
@@ -142,6 +142,8 @@ check_rpbft()
         sed_cmd="sed -i .bkp"
     fi
     ${sed_cmd} "s/consensus_type=raft/consensus_type=rpbft/" node*/conf/group.1.genesis
+    ${sed_cmd} "s/epoch_sealer_num=4/epoch_sealer_num=2/" node*/conf/group.1.genesis
+    ${sed_cmd} "s/epoch_block_num=1000/epoch_block_num=2/" node*/conf/group.1.genesis
     ${sed_cmd} "s/supported_version=${fisco_version}/supported_version=2.5.0/g" node*/config.ini
     # test ipv6
     ${sed_cmd} "s/127.0.0.1:/\[::1\]:/g" node*/config.ini


### PR DESCRIPTION
1. fix the bug that leader seal more than tx_count_tx transactions

2. when the previous leader forged an illegal rotating-tx, the current still needs to roate working-sealers