### PR TITLE
Fix bugs caused by consensus_timeout adjustment and vrfBasedPBFT

### DIFF
--- a/libconsensus/Sealer.cpp
+++ b/libconsensus/Sealer.cpp
@@ -116,7 +116,7 @@ void Sealer::doWork(bool wait)
             {
                 m_syncTxPool = true;
             }
-            auto maxTxsPerBlock = maxTxsSizeSealedInnerBlock();
+            auto maxTxsPerBlock = maxBlockCanSeal();
             /// load transaction from transaction queue
             if (maxTxsPerBlock > tx_num && m_syncTxPool == true && !reachBlockIntervalTime())
                 loadTransactions(maxTxsPerBlock - tx_num);

--- a/libconsensus/Sealer.h
+++ b/libconsensus/Sealer.h
@@ -177,8 +177,6 @@ protected:
     }
 
 protected:
-    virtual uint64_t maxTxsSizeSealedInnerBlock() { return maxBlockCanSeal(); }
-
     uint64_t maxBlockCanSeal()
     {
         ReadGuard l(x_maxBlockCanSeal);

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -854,7 +854,6 @@ void PBFTEngine::execBlock(Sealing& sealing, PrepareReq::Ptr _req, std::ostrings
     m_txPool->verifyAndSetSenderForBlock(*sealing.block);
     auto verifyAndSetSender_time_cost = utcTime() - record_time;
     record_time = utcTime();
-
     sealing.p_execContext = executeBlock(*sealing.block);
     auto exec_time_cost = utcTime() - record_time;
     PBFTENGINE_LOG(INFO)
@@ -1004,6 +1003,8 @@ bool PBFTEngine::handlePrepareMsg(PrepareReq::Ptr prepareReq, std::string const&
     clearPreRawPrepare();
     /// add raw prepare request
     addRawPrepare(prepareReq);
+
+    m_timeManager.m_lastAddRawPrepareTime = utcSteadyTime();
     return execPrepareAndGenerateSignMsg(prepareReq, oss);
 }
 

--- a/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTEngine.cpp
+++ b/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTEngine.cpp
@@ -54,12 +54,16 @@ void VRFBasedrPBFTEngine::updateConsensusNodeList()
 
     UpgradableGuard l(x_chosedSealerList);
     bool chosedSealerListUpdated = false;
+    // udpate m_workingSealersNum
+    if (m_workingSealersNum.load() != (int64_t)workingSealers.size())
+    {
+        m_workingSealersNum = workingSealers.size();
+    }
     if (workingSealers != *m_chosedSealerList)
     {
         chosedSealerListUpdated = true;
         UpgradeGuard ul(l);
         *m_chosedSealerList = workingSealers;
-        m_workingSealersNum = workingSealers.size();
         std::string workingSealersStr;
         // TODO: remove this
         for (auto const& node : workingSealers)
@@ -212,7 +216,7 @@ void VRFBasedrPBFTEngine::checkTransactionsValid(
                               << LOG_KV("hash", _prepareReq->block_hash.abridged())
                               << LOG_KV("leaderIdx", _prepareReq->idx)
                               << LOG_KV("nodeIdx", nodeIdx()) << LOG_KV("txSize", transactionSize);
-    auto nodeRotatingTx = (*(_block->transactions()))[transactionSize - 1];
+    auto nodeRotatingTx = (*(_block->transactions()))[0];
     auto leaderNodeID = RotatingPBFTEngine::getSealerByIndex(_prepareReq->idx);
     if (leaderNodeID == dev::h512())
     {

--- a/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTSealer.h
+++ b/libconsensus/rotating_pbft/vrf_rpbft/VRFBasedrPBFTSealer.h
@@ -51,8 +51,6 @@ protected:
     // generate and seal the workingSealerManagerPrecompiled transaction into _txOffset
     virtual bool generateTransactionForRotating();
 
-    uint64_t maxTxsSizeSealedInnerBlock() override;
-
 private:
     VRFBasedrPBFTEngine::Ptr m_vrfBasedrPBFTEngine;
     TxGenerator::Ptr m_txGenerator;

--- a/libprecompiled/ConsensusPrecompiled.cpp
+++ b/libprecompiled/ConsensusPrecompiled.cpp
@@ -301,5 +301,24 @@ bool ConsensusPrecompiled::checkIsLastSealer(storage::Table::Ptr table, std::str
                                  << LOG_KV("nodeID", nodeID);
         return true;
     }
+    // check the last working sealer
+    condition = table->newCondition();
+    condition->EQ(NODE_KEY_NODEID, nodeID);
+    entries = table->select(PRI_KEY, condition);
+    if (entries->size() > 0 && entries->get(0)->getField(NODE_TYPE) == NODE_TYPE_WORKING_SEALER)
+    {
+        // check working sealer
+        condition = table->newCondition();
+        condition->EQ(NODE_TYPE, NODE_TYPE_WORKING_SEALER);
+        entries = table->select(PRI_KEY, condition);
+        if (entries->size() == 1u && entries->get(0)->getField(NODE_KEY_NODEID) == nodeID)
+        {
+            PRECOMPILED_LOG(WARNING)
+                << LOG_BADGE("ConsensusPrecompiled")
+                << LOG_DESC("the nodeID in param is the last working sealer, cannot be deleted.")
+                << LOG_KV("nodeID", nodeID);
+            return true;
+        }
+    }
     return false;
 }

--- a/libprecompiled/WorkingSealerManagerImpl.h
+++ b/libprecompiled/WorkingSealerManagerImpl.h
@@ -98,7 +98,7 @@ protected:
         std::shared_ptr<dev::h512s> _nodeList, int64_t selectedNode);
 
 private:
-    bool checkPermission(dev::Address const& _origin, dev::h512s const& _allowedAccountInfoList);
+    void checkPermission(dev::Address const& _origin, dev::h512s const& _allowedAccountInfoList);
     void getSealerList();
     bool shouldRotate();
     void UpdateNodeType(dev::h512 const& _node, std::string const& _nodeType);

--- a/tools/ci/ci_check.sh
+++ b/tools/ci/ci_check.sh
@@ -58,7 +58,7 @@ check_reports()
 check_sync_consensus()
 {
     LOG_INFO "***************check_sync_consensus"
-    bash start_all.sh
+    bash start_all.sh && sleep 2
     bash ../../check_node_config.sh -p node0
     sleep 5
     send_transaction
@@ -95,7 +95,7 @@ check_sync_consensus()
 check_consensus_and_sync()
 {
     local sleep_seconds=${1}
-    bash start_all.sh
+    bash start_all.sh && sleep 2
     send_transaction
     check_reports 1 4 "check report block failed!" "==============check report block is ok"
     bash stop_all.sh


### PR DESCRIPTION
1. Fix the problem that when consensus_timeout is set to a large value, consensus spends a lot of time waiting for consensus-messages,

2. fix the case when the size of working-sealers is deleted to 0,

3. Put the workingSealerMgr contract in the first transaction to fix the abnormality caused by other transactions in the same block modifying rPBFT related configuration items,

4. add ut for consensus_timeout adjustment