### PR TITLE
fix txs forwarding bug for rPBFT

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -124,11 +124,11 @@ jobs:
         id: ccache
         with:
           path: ccache
-          key: ccache-v1-notest-${{ runner.temp }}-${{ github.base_ref }}-${{ hashFiles('.github/workflows/workflow.yml') }}
+          key: ccache-v2-notest-${{ runner.temp }}-${{ github.base_ref }}-${{ hashFiles('.github/workflows/workflow.yml') }}
           restore-keys: |
-            ccache-v1-notest-${{ runner.temp }}-${{ github.base_ref }}-${{ hashFiles('.github/workflows/workflow.yml') }}
-            ccache-v1-notest-${{ runner.temp }}-${{ github.base_ref }}-
-            ccache-v1-notest-${{ runner.temp }}-
+            ccache-v2-notest-${{ runner.temp }}-${{ github.base_ref }}-${{ hashFiles('.github/workflows/workflow.yml') }}
+            ccache-v2-notest-${{ runner.temp }}-${{ github.base_ref }}-
+            ccache-v2-notest-${{ runner.temp }}-
       - name: install ubuntu dependencies
         run: sudo apt install -y git curl build-essential clang cmake openssl libssl-dev zlib1g-dev ccache libgmp-dev flex bison
       - name: configure

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -100,6 +100,12 @@ public:
         return !m_nodeListWithTheTransaction.empty();
     }
 
+    void clear()
+    {
+        WriteGuard l(x_nodeListWithTheTransaction);
+        m_nodeListWithTheTransaction.clear();
+    }
+
 private:
     mutable dev::SharedMutex x_nodeListWithTheTransaction;
     // Record the node where the transaction exists
@@ -345,6 +351,8 @@ public:
         return m_nodeTransactionMarker.isTheNodeContainsTransaction(_node);
     }
     bool isKnownBySomeone() { return m_nodeTransactionMarker.isKnownBySomeone(); }
+
+    void clearNodeTransactionMarker() { m_nodeTransactionMarker.clear(); }
 
 protected:
     static bool isZeroSignature(u256 const& _r, u256 const& _s) { return !_r && !_s; }

--- a/libtxpool/TxPool.cpp
+++ b/libtxpool/TxPool.cpp
@@ -808,6 +808,7 @@ void TxPool::freshTxsStatus()
         for (auto const& tx : m_txsQueue)
         {
             tx->setSynced(false);
+            tx->clearNodeTransactionMarker();
         }
     }
     {


### PR DESCRIPTION
When the current node is not connected to the transaction forwarding node selected by rPBFT, a connected workingSealer is randomly selected to forward the transaction