### PR TITLE
Rename sha3* related functions and parameters to keccak* 

### DIFF
--- a/fisco-bcos/blockverifier/verifierMain.cpp
+++ b/fisco-bcos/blockverifier/verifierMain.cpp
@@ -330,9 +330,9 @@ int main(int argc, char* argv[])
             auto context = blockVerifier->executeBlock(*block, parentBlockInfo);
             blockChain->commitBlock(block, context);
             dev::eth::TransactionReceipt::Ptr receipt =
-                blockChain->getTransactionReceiptByHash(tx->sha3());
+                blockChain->getTransactionReceiptByHash(tx->hash());
             LOG(INFO) << "receipt " << *receipt;
-            receipt = blockChain->getTransactionReceiptByHash(tx2->sha3());
+            receipt = blockChain->getTransactionReceiptByHash(tx2->hash());
             LOG(INFO) << "receipt2 " << *receipt;
         }
     }

--- a/fisco-bcos/consensus/consensus_main.cpp
+++ b/fisco-bcos/consensus/consensus_main.cpp
@@ -137,7 +137,7 @@ static void createTx(std::shared_ptr<LedgerManager> ledgerManager, float txSpeed
             {
                 tx->setNonce(tx->nonce() + u256(utcTime()));
                 tx->setBlockLimit(u256(ledgerManager->blockChain(group)->number()) + maxBlockLimit);
-                auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+                auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
                 tx->updateSignature(sig);
                 ledgerManager->txPool(group)->submit(tx);
             }

--- a/fisco-bcos/evm/evm_main.cpp
+++ b/fisco-bcos/evm/evm_main.cpp
@@ -120,7 +120,7 @@ int main()
     EnvInfo envInfo(header, boost::bind(&FakeBlockChain::numberHash, blockChain, _1), u256(0));
     /// init state
     std::shared_ptr<MPTState> mptState = std::make_shared<MPTState>(
-        u256(0), MPTState::openDB("./", sha3("0x1234")), BaseState::Empty);
+        u256(0), MPTState::openDB("./", keccak256("0x1234")), BaseState::Empty);
     /// test deploy
     for (size_t i = 0; i < param.code().size(); i++)
     {

--- a/fisco-bcos/para/para_main.cpp
+++ b/fisco-bcos/para/para_main.cpp
@@ -64,7 +64,7 @@ void genTxUserAddBlock(Block& _block, size_t _userNum)
         Transaction::Ptr tx =
             std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
         tx->setBlockLimit(250);
-        auto sig = dev::crypto::Sign(*keyPair, tx->sha3(WithoutSignature));
+        auto sig = dev::crypto::Sign(*keyPair, tx->hash(WithoutSignature));
         tx->updateSignature(sig);
         txs->push_back(tx);
     }
@@ -120,7 +120,7 @@ void genTxUserTransfer(Block& _block, size_t _userNum, size_t _txNum)
         Transaction::Ptr tx =
             std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
         tx->setBlockLimit(250);
-        auto sig = crypto::Sign(*keyPair, tx->sha3(WithoutSignature));
+        auto sig = crypto::Sign(*keyPair, tx->hash(WithoutSignature));
         tx->updateSignature(sig);
         txs->push_back(tx);
     }

--- a/fisco-bcos/para/para_main_node.cpp
+++ b/fisco-bcos/para/para_main_node.cpp
@@ -69,7 +69,7 @@ void generateUserAddTx(std::shared_ptr<LedgerManager> ledgerManager, size_t _use
             u256 nonce = u256(utcTime());
             Transaction::Ptr tx =
                 std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
-            auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+            auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
 
             for (auto group : ledgerManager->getGroupList())
             {
@@ -132,7 +132,7 @@ static void createTx(std::shared_ptr<LedgerManager> ledgerManager, float txSpeed
 
                 Transaction::Ptr tx =
                     std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
-                auto sig = crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+                auto sig = crypto::Sign(keyPair, tx->hash(WithoutSignature));
 
                 tx->setBlockLimit(u256(ledgerManager->blockChain(group)->number()) + maxBlockLimit);
                 tx->updateSignature(sig);

--- a/fisco-bcos/sync/sync_main.cpp
+++ b/fisco-bcos/sync/sync_main.cpp
@@ -139,7 +139,7 @@ static void createTx(std::shared_ptr<dev::txpool::TxPoolInterface> _txPool,
             {
                 tx->setNonce(u256(noncePrefix + to_string(txSeqNonce++)));
                 tx->setBlockLimit(u256(_blockChain->number()) + 50);
-                auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+                auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
                 tx->updateSignature(sig);
                 _txPool->submit(tx);
             }

--- a/fisco-bcos/tools/calculate_address.cpp
+++ b/fisco-bcos/tools/calculate_address.cpp
@@ -32,7 +32,7 @@ int main(int argc, char** argv)
         cout << addr << endl;
         return 0;
     }
-    auto addr = right160(sha3(bytesConstRef((const unsigned char*)source.data(), 64)));
+    auto addr = right160(keccak256(bytesConstRef((const unsigned char*)source.data(), 64)));
     cout << addr << endl;
     return 0;
 }

--- a/fisco-bcos/tools/rocksdb_main.cpp
+++ b/fisco-bcos/tools/rocksdb_main.cpp
@@ -124,7 +124,7 @@ int main(int argc, const char* argv[])
         else
         {  // keccak256
             g_BCOSConfig.setUseSMCrypto(false);
-            encryptKey = sha3(dataKey).asBytes();
+            encryptKey = keccak256(dataKey).asBytes();
         }
     }
 

--- a/libblockchain/BlockChainImp.cpp
+++ b/libblockchain/BlockChainImp.cpp
@@ -1426,7 +1426,7 @@ void BlockChainImp::writeTxToBlock(const Block& block, std::shared_ptr<Executive
                             entry->setField("index", lexical_cast<std::string>(i));
                             entry->setForce(true);
 
-                            tb->insert((*txs)[i]->sha3().hex(), entry,
+                            tb->insert((*txs)[i]->hash().hex(), entry,
                                 std::make_shared<dev::storage::AccessOptions>(), false);
                         }
                     });

--- a/libblockverifier/BlockVerifier.cpp
+++ b/libblockverifier/BlockVerifier.cpp
@@ -361,7 +361,7 @@ ExecutiveContext::Ptr BlockVerifier::parallelExecuteBlock(
             for (size_t i = 0; i < receipts->size(); ++i)
             {
                 BLOCKVERIFIER_LOG(ERROR) << LOG_BADGE("FISCO_DEBUG") << LOG_KV("index", i)
-                                         << LOG_KV("hash", block.transaction(i)->sha3())
+                                         << LOG_KV("hash", block.transaction(i)->hash())
                                          << ",receipt=" << *receipts->at(i);
             }
 #endif

--- a/libconsensus/ConsensusEngineBase.cpp
+++ b/libconsensus/ConsensusEngineBase.cpp
@@ -285,7 +285,7 @@ void ConsensusEngineBase::reportBlock(dev::eth::Block const& _block)
         auto receipt = (*receipts)[receiptIndex];
         auto gasUsed = receipt->gasUsed() - prevGasUsed;
         STAT_LOG(INFO) << LOG_TYPE("TxsGasUsed") << LOG_KV("g", m_groupId)
-                       << LOG_KV("txHash", toHex(tx->sha3())) << LOG_KV("gasUsed", gasUsed);
+                       << LOG_KV("txHash", toHex(tx->hash())) << LOG_KV("gasUsed", gasUsed);
         prevGasUsed = receipt->gasUsed();
         receiptIndex++;
     }

--- a/libconsensus/TxGenerator.h
+++ b/libconsensus/TxGenerator.h
@@ -69,7 +69,7 @@ public:
         auto generatedTx =
             generateTransactionWithoutSig(_interface, _currentNumber, _to, _type, _params...);
         // sign with KeyPair for the generated transaction
-        auto hashToSign = generatedTx->sha3(dev::eth::IncludeSignature::WithoutSignature);
+        auto hashToSign = generatedTx->hash(dev::eth::IncludeSignature::WithoutSignature);
         auto sign = dev::crypto::Sign(_keyPair, hashToSign);
         generatedTx->updateSignature(sign);
         TXGEN_LOG(DEBUG) << LOG_DESC("generateTransactionWithSig")

--- a/libconsensus/pbft/PBFTEngine.cpp
+++ b/libconsensus/pbft/PBFTEngine.cpp
@@ -791,7 +791,7 @@ void PBFTEngine::notifySealing(dev::eth::Block const& block)
         h256Hash filter;
         for (auto& trans : *(block.transactions()))
         {
-            filter.insert(trans->sha3());
+            filter.insert(trans->hash());
         }
         PBFTENGINE_LOG(INFO) << "I am the next leader = " << getNextLeader()
                              << ", filter trans size = " << filter.size()

--- a/libdevcrypto/Common.cpp
+++ b/libdevcrypto/Common.cpp
@@ -55,7 +55,7 @@ secp256k1_context const* getCtx()
 
 /**
  * @brief obtain address from public key
- *        by adding the last 20Bytes of sha3(public key)
+ *        by adding the last 20Bytes of keccak256(public key)
  * @param _public : the public key need to convert to address
  * @return Address : the converted address
  */
@@ -71,8 +71,8 @@ Address dev::toAddress(Secret const& _secret)
 
 /**
  * @brief : 1.serialize (_from address, nonce) into rlpStream
- *          2.calculate the sha3 of serialized (_from, nonce)
- *          3.obtaining the last 20Bytes of the sha3 as address
+ *          2.calculate the keccak256 of serialized (_from, nonce)
+ *          3.obtaining the last 20Bytes of the keccak256 as address
  *          (mainly used for contract address generating)
  * @param _from : address that sending this transaction
  * @param _nonce : random number
@@ -137,7 +137,7 @@ Secret Nonce::next()
     }
     else
     {
-        m_value = sha3Secure(m_value.ref());
+        m_value = keccak256Secure(m_value.ref());
     }
 
     return crypto::Hash(~m_value);

--- a/libdevcrypto/Common.h
+++ b/libdevcrypto/Common.h
@@ -50,7 +50,7 @@ using Secrets = std::vector<Secret>;
 Public toPublic(Secret const& _secret);
 
 /// Convert a public key to address.
-/// right160(sha3(_public.ref()))
+/// right160(keccak256(_public.ref()))
 Address toAddress(Public const& _public);
 
 /// Convert a secret key into address of public key equivalent.

--- a/libdevcrypto/CryptoInterface.cpp
+++ b/libdevcrypto/CryptoInterface.cpp
@@ -34,8 +34,8 @@ using namespace std;
 using namespace dev;
 using namespace dev::crypto;
 
-h256 dev::EmptyHash = sha3(bytesConstRef());
-h256 dev::EmptyTrie = sha3(rlp(""));
+h256 dev::EmptyHash = keccak256(bytesConstRef());
+h256 dev::EmptyTrie = keccak256(rlp(""));
 
 std::function<std::string(const unsigned char* _plainData, size_t _plainDataSize,
     const unsigned char* _key, size_t _keySize, const unsigned char* _ivData)>
@@ -85,8 +85,8 @@ void dev::crypto::initSMCrypto()
 
 void dev::crypto::initCrypto()
 {
-    EmptyHash = sha3(bytesConstRef());
-    EmptyTrie = sha3(rlp(""));
+    EmptyHash = keccak256(bytesConstRef());
+    EmptyTrie = keccak256(rlp(""));
     SignatureFromRLP = ecdsaSignatureFromRLP;
     SignatureFromBytes = ecdsaSignatureFromBytes;
     dev::crypto::SymmetricEncrypt = static_cast<std::string (*)(const unsigned char*, size_t,

--- a/libdevcrypto/CryptoInterface.h
+++ b/libdevcrypto/CryptoInterface.h
@@ -72,7 +72,7 @@ inline SecureFixedHash<32> Hash(SecureFixedHash<N>&& _data)
     {
         return sm3Secure(_data);
     }
-    return sha3Secure(_data);
+    return keccak256Secure(_data);
 }
 
 template <typename T>
@@ -82,7 +82,7 @@ inline h256 Hash(T&& _data)
     {
         return sm3(_data);
     }
-    return sha3(_data);
+    return keccak256(_data);
 }
 
 }  // namespace crypto

--- a/libdevcrypto/ECDSASignature.cpp
+++ b/libdevcrypto/ECDSASignature.cpp
@@ -201,7 +201,7 @@ pair<bool, bytes> dev::ecRecover(bytesConstRef _in)
                 {
                     if (g_BCOSConfig.version() >= V2_5_0)
                     {
-                        ret = dev::sha3(rec);
+                        ret = dev::keccak256(rec);
 
                     }
                     else

--- a/libdevcrypto/Hash.cpp
+++ b/libdevcrypto/Hash.cpp
@@ -36,7 +36,7 @@ namespace keccak
 {
 /** libkeccak-tiny
  *
- * A single-file implementation of SHA-3 and SHAKE.
+ * A single-file implementation of Keccak and SHAKE.
  *
  * Implementor: David Leon Gil
  * License: CC0, attribution kindly requested. Blame taken too,
@@ -45,9 +45,9 @@ namespace keccak
 
 #define decshake(bits) int shake##bits(uint8_t*, size_t, const uint8_t*, size_t);
 
-#define decsha3(bits) int sha3_##bits(uint8_t*, size_t, const uint8_t*, size_t);
+#define deckeccak(bits) int keccak_##bits(uint8_t*, size_t, const uint8_t*, size_t);
 
-decshake(128) decshake(256) decsha3(224) decsha3(256) decsha3(384) decsha3(512)
+decshake(128) decshake(256) deckeccak(224) deckeccak(256) deckeccak(384) deckeccak(512)
 
     /******** The Keccak-f[1600] permutation ********/
 
@@ -150,14 +150,14 @@ mkapply_ds(xorin, dst[i] ^= src[i])      // xorin
     return 0;
 }
 
-/*** Helper macros to define SHA3 and SHAKE instances. ***/
+/*** Helper macros to define Keccak and SHAKE instances. ***/
 #define defshake(bits)                                                            \
     int shake##bits(uint8_t* out, size_t outlen, const uint8_t* in, size_t inlen) \
     {                                                                             \
         return hash(out, outlen, in, inlen, 200 - (bits / 4), 0x1f);              \
     }
-#define defsha3(bits)                                                             \
-    int sha3_##bits(uint8_t* out, size_t outlen, const uint8_t* in, size_t inlen) \
+#define defkeccak(bits)                                                             \
+    int keccak_##bits(uint8_t* out, size_t outlen, const uint8_t* in, size_t inlen) \
     {                                                                             \
         if (outlen > (bits / 8))                                                  \
         {                                                                         \
@@ -169,17 +169,17 @@ mkapply_ds(xorin, dst[i] ^= src[i])      // xorin
 /*** FIPS202 SHAKE VOFs ***/
 defshake(128) defshake(256)
 
-    /*** FIPS202 SHA3 FOFs ***/
-    defsha3(224) defsha3(256) defsha3(384) defsha3(512)
+    /*** FIPS202 Keccak FOFs ***/
+    defkeccak(224) defkeccak(256) defkeccak(384) defkeccak(512)
 
 }  // namespace keccak
 
-bool sha3(bytesConstRef _input, bytesRef o_output)
+bool keccak256(bytesConstRef _input, bytesRef o_output)
 {
     // FIXME: What with unaligned memory?
     if (o_output.size() != 32)
         return false;
-    keccak::sha3_256(o_output.data(), 32, _input.data(), _input.size());
+    keccak::keccak_256(o_output.data(), 32, _input.data(), _input.size());
     return true;
 }
 

--- a/libdevcrypto/Hash.h
+++ b/libdevcrypto/Hash.h
@@ -29,11 +29,11 @@
 
 namespace dev
 {
-// SHA-3 convenience routines.
+// Keccak256 convenience routines.
 
-/// Calculate SHA3-256 hash of the given input and load it into the given output.
+/// Calculate Keccak256 hash of the given input and load it into the given output.
 /// @returns false if o_output.size() != 32.
-bool sha3(bytesConstRef _input, bytesRef o_output);
+bool keccak256(bytesConstRef _input, bytesRef o_output);
 
 // secp256k1_sha256
 h256 standardSha256(bytesConstRef _input) noexcept;
@@ -43,84 +43,84 @@ h256 sha256(bytesConstRef _input) noexcept;
 
 h160 ripemd160(bytesConstRef _input);
 
-/// Calculate SHA3-256 hash of the given input, returning as a 256-bit hash.
-inline h256 sha3(bytesConstRef _input)
+/// Calculate Keccak256 hash of the given input, returning as a 256-bit hash.
+inline h256 keccak256(bytesConstRef _input)
 {
     h256 ret;
-    sha3(_input, ret.ref());
+    keccak256(_input, ret.ref());
     return ret;
 }
-inline SecureFixedHash<32> sha3Secure(bytesConstRef _input)
+inline SecureFixedHash<32> keccak256Secure(bytesConstRef _input)
 {
     SecureFixedHash<32> ret;
-    sha3(_input, ret.writable().ref());
+    keccak256(_input, ret.writable().ref());
     return ret;
 }
 
-/// Calculate SHA3-256 hash of the given input, returning as a 256-bit hash.
-inline h256 sha3(bytes const& _input)
+/// Calculate Keccak256 hash of the given input, returning as a 256-bit hash.
+inline h256 keccak256(bytes const& _input)
 {
-    return sha3(bytesConstRef(&_input));
+    return keccak256(bytesConstRef(&_input));
 }
-inline SecureFixedHash<32> sha3Secure(bytes const& _input)
+inline SecureFixedHash<32> keccak256Secure(bytes const& _input)
 {
-    return sha3Secure(bytesConstRef(&_input));
+    return keccak256Secure(bytesConstRef(&_input));
 }
 
-/// Calculate SHA3-256 hash of the given input (presented as a binary-filled string), returning as a
+/// Calculate Keccak256 hash of the given input (presented as a binary-filled string), returning as a
 /// 256-bit hash.
-inline h256 sha3(std::string const& _input)
+inline h256 keccak256(std::string const& _input)
 {
-    return sha3(bytesConstRef(_input));
+    return keccak256(bytesConstRef(_input));
 }
-inline SecureFixedHash<32> sha3Secure(std::string const& _input)
+inline SecureFixedHash<32> keccak256Secure(std::string const& _input)
 {
-    return sha3Secure(bytesConstRef(_input));
-}
-
-/// Calculate SHA3-256 hash of the given input (presented as a FixedHash), returns a 256-bit hash.
-template <unsigned N>
-inline h256 sha3(FixedHash<N> const& _input)
-{
-    return sha3(_input.ref());
-}
-template <unsigned N>
-inline SecureFixedHash<32> sha3Secure(FixedHash<N> const& _input)
-{
-    return sha3Secure(_input.ref());
+    return keccak256Secure(bytesConstRef(_input));
 }
 
-/// Fully secure variants are equivalent for sha3 and sha3Secure.
-inline SecureFixedHash<32> sha3(bytesSec const& _input)
+/// Calculate Keccak256 hash of the given input (presented as a FixedHash), returns a 256-bit hash.
+template <unsigned N>
+inline h256 keccak256(FixedHash<N> const& _input)
 {
-    return sha3Secure(_input.ref());
-}
-inline SecureFixedHash<32> sha3Secure(bytesSec const& _input)
-{
-    return sha3Secure(_input.ref());
+    return keccak256(_input.ref());
 }
 template <unsigned N>
-inline SecureFixedHash<32> sha3(SecureFixedHash<N> const& _input)
+inline SecureFixedHash<32> keccak256Secure(FixedHash<N> const& _input)
 {
-    return sha3Secure(_input.ref());
-}
-template <unsigned N>
-inline SecureFixedHash<32> sha3Secure(SecureFixedHash<N> const& _input)
-{
-    return sha3Secure(_input.ref());
+    return keccak256Secure(_input.ref());
 }
 
-/// Calculate SHA3-256 hash of the given input, possibly interpreting it as nibbles, and return the
+/// Fully secure variants are equivalent for keccak256 and keccak256Secure.
+inline SecureFixedHash<32> keccak256(bytesSec const& _input)
+{
+    return keccak256Secure(_input.ref());
+}
+inline SecureFixedHash<32> keccak256Secure(bytesSec const& _input)
+{
+    return keccak256Secure(_input.ref());
+}
+template <unsigned N>
+inline SecureFixedHash<32> keccak256(SecureFixedHash<N> const& _input)
+{
+    return keccak256Secure(_input.ref());
+}
+template <unsigned N>
+inline SecureFixedHash<32> keccak256Secure(SecureFixedHash<N> const& _input)
+{
+    return keccak256Secure(_input.ref());
+}
+
+/// Calculate Keccak256 hash of the given input, possibly interpreting it as nibbles, and return the
 /// hash as a string filled with binary data.
-inline std::string sha3(std::string const& _input, bool _isNibbles)
+inline std::string keccak256(std::string const& _input, bool _isNibbles)
 {
-    return asString((_isNibbles ? sha3(fromHex(_input)) : sha3(bytesConstRef(&_input))).asBytes());
+    return asString((_isNibbles ? keccak256(fromHex(_input)) : keccak256(bytesConstRef(&_input))).asBytes());
 }
 
-/// Calculate SHA3-256 MAC
-inline void sha3mac(bytesConstRef _secret, bytesConstRef _plain, bytesRef _output)
+/// Calculate Keccak256 MAC
+inline void keccak256mac(bytesConstRef _secret, bytesConstRef _plain, bytesRef _output)
 {
-    sha3(_secret.toBytes() + _plain.toBytes()).ref().populate(_output);
+    keccak256(_secret.toBytes() + _plain.toBytes()).ref().populate(_output);
 }
 
 }  // namespace dev

--- a/libdevcrypto/SM3Hash.h
+++ b/libdevcrypto/SM3Hash.h
@@ -27,7 +27,6 @@
 
 namespace dev
 {
-// SHA-3 convenience routines.
 
 /// Calculate SM3-256 hash of the given input and load it into the given output.
 /// @returns false if o_output.size() != 32.

--- a/libethcore/Block.cpp
+++ b/libethcore/Block.cpp
@@ -199,7 +199,7 @@ void Block::calTransactionRootV2_2_0(bool update) const
                     RLPStream s;
                     s << i;
                     dev::bytes byteValue = s.out();
-                    dev::h256 hValue = ((*m_transactions)[i])->sha3();
+                    dev::h256 hValue = ((*m_transactions)[i])->hash();
                     byteValue.insert(byteValue.end(), hValue.begin(), hValue.end());
                     transactionList[i] = byteValue;
                 }
@@ -233,7 +233,7 @@ std::shared_ptr<std::map<std::string, std::vector<std::string>>> Block::getTrans
                 RLPStream s;
                 s << i;
                 dev::bytes byteValue = s.out();
-                dev::h256 hValue = ((*m_transactions)[i])->sha3();
+                dev::h256 hValue = ((*m_transactions)[i])->hash();
                 byteValue.insert(byteValue.end(), hValue.begin(), hValue.end());
                 transactionList[i] = byteValue;
             }
@@ -243,7 +243,7 @@ std::shared_ptr<std::map<std::string, std::vector<std::string>>> Block::getTrans
     return merklePath;
 }
 
-void Block::getReceiptAndSha3(RLPStream& txReceipts, std::vector<dev::bytes>& receiptList) const
+void Block::getReceiptAndHash(RLPStream& txReceipts, std::vector<dev::bytes>& receiptList) const
 {
     txReceipts.appendList(m_transactionReceipts->size());
     receiptList.resize(m_transactionReceipts->size());
@@ -252,7 +252,7 @@ void Block::getReceiptAndSha3(RLPStream& txReceipts, std::vector<dev::bytes>& re
             for (uint32_t i = _r.begin(); i < _r.end(); ++i)
             {
                 (*m_transactionReceipts)[i]->receipt();
-                dev::bytes receiptHash = (*m_transactionReceipts)[i]->sha3();
+                dev::bytes receiptHash = (*m_transactionReceipts)[i]->hash();
                 RLPStream s;
                 s << i;
                 dev::bytes receiptValue = s.out();
@@ -276,7 +276,7 @@ void Block::calReceiptRootV2_2_0(bool update) const
     {
         RLPStream txReceipts;
         std::vector<dev::bytes> receiptList;
-        getReceiptAndSha3(txReceipts, receiptList);
+        getReceiptAndHash(txReceipts, receiptList);
         txReceipts.swapOut(m_tReceiptsCache);
         m_receiptRootCache = dev::getHash256(receiptList);
     }
@@ -298,7 +298,7 @@ std::shared_ptr<std::map<std::string, std::vector<std::string>>> Block::getRecei
 
     RLPStream txReceipts;
     std::vector<dev::bytes> receiptList;
-    getReceiptAndSha3(txReceipts, receiptList);
+    getReceiptAndHash(txReceipts, receiptList);
     std::shared_ptr<std::map<std::string, std::vector<std::string>>> merklePath =
         std::make_shared<std::map<std::string, std::vector<std::string>>>();
     dev::getMerkleProof(receiptList, merklePath);

--- a/libethcore/Block.h
+++ b/libethcore/Block.h
@@ -265,7 +265,7 @@ public:
     void calReceiptRoot(bool update = true) const;
     void calReceiptRootRC2(bool update = true) const;
     void calTransactionRootV2_2_0(bool update) const;
-    void getReceiptAndSha3(RLPStream& txReceipts, std::vector<dev::bytes>& receiptList) const;
+    void getReceiptAndHash(RLPStream& txReceipts, std::vector<dev::bytes>& receiptList) const;
     void calReceiptRootV2_2_0(bool update) const;
 
     std::shared_ptr<std::map<std::string, std::vector<std::string>>> getReceiptProof() const;

--- a/libethcore/BlockHeader.h
+++ b/libethcore/BlockHeader.h
@@ -290,7 +290,7 @@ private:  /// private data fields
     h512s m_sealerList;          /// sealer list
     /// -------structure of block header end------
 
-    mutable h256 m_hash;       ///< (Memoised) SHA3 hash of the block header with seal.
+    mutable h256 m_hash;       ///< (Memoised) hash of the block header with seal.
     mutable Mutex m_hashLock;  ///< A lock for both m_hash
 };
 

--- a/libethcore/PartiallyBlock.cpp
+++ b/libethcore/PartiallyBlock.cpp
@@ -59,7 +59,7 @@ void PartiallyBlock::calTxsHashBytes()
         [&](const tbb::blocked_range<size_t>& _r) {
             for (uint32_t i = _r.begin(); i < _r.end(); ++i)
             {
-                (*m_txsHash)[i] = (*m_transactions)[i]->sha3();
+                (*m_txsHash)[i] = (*m_transactions)[i]->hash();
             }
         });
 }
@@ -144,12 +144,12 @@ void PartiallyBlock::fillBlock(RLP const& _rlp)
     int64_t index = 0;
     for (auto tx : *m_missedTransactions)
     {
-        if (tx->sha3() != (*m_missedTxs)[index].first)
+        if (tx->hash() != (*m_missedTxs)[index].first)
         {
             PartiallyBlock_LOG(WARNING)
                 << LOG_DESC("fillBlock failed for inconsistent transaction hash")
                 << LOG_KV("expectedHash", (*m_missedTxs)[index].first.abridged())
-                << LOG_KV("fetchedHash", tx->sha3().abridged());
+                << LOG_KV("fetchedHash", tx->hash().abridged());
             BOOST_THROW_EXCEPTION(
                 InvalidTransaction() << errinfo_comment(
                     "fillBlock: invalid fetched transaction for inconsistent transaction hash"));
@@ -206,12 +206,12 @@ void PartiallyBlock::encodeMissedTxs(std::shared_ptr<bytes> _encodedBytes,
     for (auto const& txsInfo : *_missedTxs)
     {
         auto tx = (*m_transactions)[txsInfo.second];
-        if (tx->sha3() != txsInfo.first)
+        if (tx->hash() != txsInfo.first)
         {
             PartiallyBlock_LOG(WARNING)
                 << LOG_DESC("fetchMissedTxs failed for inconsistent transaction hash")
                 << LOG_KV("requestHash", txsInfo.first.abridged())
-                << LOG_KV("txHash", tx->sha3().abridged());
+                << LOG_KV("txHash", tx->hash().abridged());
             BOOST_THROW_EXCEPTION(
                 InvalidTransaction() << errinfo_comment(
                     "encodeMissedTxs: invalid transaction for inconsistent transaction hash"));

--- a/libethcore/Transaction.cpp
+++ b/libethcore/Transaction.cpp
@@ -179,7 +179,7 @@ Address const& Transaction::sender() const
         if (!m_vrs)
             BOOST_THROW_EXCEPTION(TransactionIsUnsigned());
 
-        auto p = crypto::Recover(m_vrs, sha3(WithoutSignature));
+        auto p = crypto::Recover(m_vrs, hash(WithoutSignature));
         if (!p)
             BOOST_THROW_EXCEPTION(InvalidSignature());
         m_sender = right160(crypto::Hash(bytesConstRef(p.data(), sizeof(p))));
@@ -269,7 +269,7 @@ int64_t Transaction::baseGasRequired(
     return g;
 }
 
-h256 Transaction::sha3(IncludeSignature _sig) const
+h256 Transaction::hash(IncludeSignature _sig) const
 {
     if (_sig == WithSignature && m_hashWith)
         return m_hashWith;

--- a/libethcore/Transaction.h
+++ b/libethcore/Transaction.h
@@ -211,8 +211,8 @@ public:
         return out;
     }
 
-    /// @returns the SHA3 hash of the RLP serialisation of this transaction.
-    h256 sha3(IncludeSignature _sig = WithSignature) const;
+    /// @returns the hash of the RLP serialisation of this transaction.
+    h256 hash(IncludeSignature _sig = WithSignature) const;
 
     /// @returns the amount of ETH to be transferred by this (message-call)
     /// transaction, in Wei. Synonym for endowment().
@@ -417,7 +417,7 @@ using Transactions = std::vector<Transaction::Ptr>;
 /// Simple human-readable stream-shift operator.
 inline std::ostream& operator<<(std::ostream& _out, Transaction const& _t)
 {
-    _out << _t.sha3().abridged() << "{";
+    _out << _t.hash().abridged() << "{";
     if (_t.receiveAddress())
         _out << _t.receiveAddress().abridged();
     else

--- a/libethcore/TransactionReceipt.h
+++ b/libethcore/TransactionReceipt.h
@@ -72,13 +72,13 @@ public:
         return m_receipt;
     }
 
-    const bytes& sha3()
+    const bytes& hash()
     {
-        if (m_sha3 == bytes())
+        if (m_hash == bytes())
         {
-            m_sha3 = crypto::Hash(receipt()).asBytes();
+            m_hash = crypto::Hash(receipt()).asBytes();
         }
-        return m_sha3;
+        return m_hash;
     }
 
     bytes rlp() const
@@ -106,7 +106,7 @@ private:
 
 private:
     bytes m_receipt = bytes();
-    bytes m_sha3 = bytes();
+    bytes m_hash = bytes();
 };
 
 using TransactionReceipts = std::vector<TransactionReceipt::Ptr>;

--- a/libethcore/TxsParallelParser.cpp
+++ b/libethcore/TxsParallelParser.cpp
@@ -157,12 +157,12 @@ void TxsParallelParser::decode(std::shared_ptr<Transactions> _txs, bytesConstRef
                         (*_txs)[i]->decode(txBytes.cropped(offset, size), _checkSig);
                         if (_withHash)
                         {
-                            // cache the sha3
-                            // Note: can't calculate sha3 with sha3(txBytes.cropped(offset, size))
+                            // cache the keccak256
+                            // Note: can't calculate keccak256 with keccak256(txBytes.cropped(offset, size))
                             // directly
                             //       considering that some cases the encodedData is not
                             //       equal to txBytes.cropped(offset, size)
-                            (*_txs)[i]->sha3();
+                            (*_txs)[i]->hash();
                         }
                     }
                 });

--- a/libeventfilter/EventLogFilter.cpp
+++ b/libeventfilter/EventLogFilter.cpp
@@ -37,7 +37,7 @@ void EventLogFilter::matches(Block const& _block, Json::Value& _value)
                 resp["topics"].append(toJS(log.topics[k]));
             }
 
-            resp["transactionHash"] = toJS(tx->sha3());
+            resp["transactionHash"] = toJS(tx->hash());
             resp["transactionIndex"] = toJS(i);
 
             _value.append(resp);

--- a/libexecutive/EVMHostContext.h
+++ b/libexecutive/EVMHostContext.h
@@ -151,7 +151,7 @@ private:
     u256 m_gasPrice;   ///< Price of gas (that we already paid).
     bytesConstRef m_data;       ///< Current input data.
     bytes m_code;               ///< Current code that is executing.
-    h256 m_codeHash;            ///< SHA3 hash of the executing code
+    h256 m_codeHash;            ///< Keccak256 hash of the executing code
     u256 m_salt;                ///< Values used in new address construction by CREATE2
     SubState m_sub;             ///< Sub-band VM state (suicides, refund counter, logs).
     unsigned m_depth = 0;       ///< Depth of the present call.

--- a/libexecutive/Executive.cpp
+++ b/libexecutive/Executive.cpp
@@ -834,7 +834,7 @@ void Executive::loggingException()
     {
         LOG(ERROR) << LOG_BADGE("TxExeError") << LOG_DESC("Transaction execution error")
                    << LOG_KV("TransactionExceptionID", (uint32_t)m_excepted)
-                   << LOG_KV("hash", (m_t->hasSignature()) ? toHex(m_t->sha3()) : "call")
+                   << LOG_KV("hash", (m_t->hasSignature()) ? toHex(m_t->hash()) : "call")
                    << m_exceptionReason.str();
     }
 }

--- a/libmptstate/Account.h
+++ b/libmptstate/Account.h
@@ -237,7 +237,7 @@ public:
         m_codeHash = EmptyHash;
     }
 
-    /// Specify to the object what the actual code is for the account. @a _code must have a SHA3
+    /// Specify to the object what the actual code is for the account. @a _code must have a Keccak256
     /// equal to codeHash() and must only be called when isFreshCode() returns false.
     void noteCode(bytesConstRef _code)
     {
@@ -282,7 +282,7 @@ private:
     /// The map with is overlaid onto whatever storage is implied by the m_storageRoot in the trie.
     std::unordered_map<u256, u256> m_storageOverlay;
 
-    /// The associated code for this account. The SHA3 of this should be equal to m_codeHash unless
+    /// The associated code for this account. The Keccak256 of this should be equal to m_codeHash unless
     /// m_codeHash equals c_contractConceptionCodeHash.
     bytes m_codeCache;
 

--- a/librpc/Rpc.cpp
+++ b/librpc/Rpc.cpp
@@ -588,7 +588,7 @@ Json::Value Rpc::getBlockByHash(
             }
             else
             {
-                response["transactions"].append(toJS((*transactions)[i]->sha3()));
+                response["transactions"].append(toJS((*transactions)[i]->hash()));
             }
         }
 
@@ -755,7 +755,7 @@ Json::Value Rpc::getBlockByNumber(
                 response["transactions"].append(transactionResponse);
             }
             else
-                response["transactions"].append(toJS((*transactions)[i]->sha3()));
+                response["transactions"].append(toJS((*transactions)[i]->hash()));
         }
 
         return response;
@@ -1254,8 +1254,8 @@ std::string Rpc::sendRawTransaction(int _groupID, const std::string& _rlp,
                     transactionCallback(receiptContent, _groupID);
                 });
         }
-        // calculate the sha3 before submit into the transaction pool
-        tx->sha3();
+        // calculate the keccak256 before submit into the transaction pool
+        tx->hash();
         std::pair<h256, Address> ret;
         switch (clientProtocolversion)
         {
@@ -1906,7 +1906,7 @@ void Rpc::parseTransactionIntoResponse(Json::Value& _response, dev::h256 const& 
     }
 
     _response["from"] = toJS(_tx->from());
-    _response["hash"] = toJS(_tx->sha3());
+    _response["hash"] = toJS(_tx->hash());
 
     // the signature
     Json::Value signatureResponse;
@@ -1932,7 +1932,7 @@ void Rpc::parseTransactionIntoResponse(Json::Value& _response, dev::h256 const& 
 void Rpc::parseReceiptIntoResponse(Json::Value& _response, dev::bytesConstRef _input,
     dev::eth::LocalisedTransactionReceipt::Ptr _receipt)
 {
-    // the fields required for calculate sha3 for the transactionReceipt
+    // the fields required for calculate keccak256 for the transactionReceipt
     // Note: the hash of the transactionReceipt is equal to the hash of the corresponding
     // transaction
     _response["root"] = toJS(_receipt->stateRoot());

--- a/libstorage/MemoryTable2.cpp
+++ b/libstorage/MemoryTable2.cpp
@@ -606,7 +606,7 @@ dev::storage::TableData::Ptr MemoryTable2::dump()
                 {
                     // in previous version(<= 2.4.0), we use sha256(...) to calculate hash of the
                     // data, for now, to keep consistent with transction's implementation, we decide
-                    // to use sha3(...) to calculate hash of the data. This `else` branch is just
+                    // to use keccak256(...) to calculate hash of the data. This `else` branch is just
                     // for compatibility.
                     m_hash = dev::sha256(bR);
                 }

--- a/libstorage/MemoryTableFactory2.cpp
+++ b/libstorage/MemoryTableFactory2.cpp
@@ -265,7 +265,7 @@ h256 MemoryTableFactory2::hash()
         {
             // in previous version(<= 2.4.0), we use sha256(...) to calculate hash of the data,
             // for now, to keep consistent with transction's implementation, we decide to use
-            // sha3(...) to calculate hash of the data. This `else` branch is just for
+            // keccak256(...) to calculate hash of the data. This `else` branch is just for
             // compatibility.
             m_hash = dev::sha256(&data);
         }

--- a/libsync/DownloadingTxsQueue.cpp
+++ b/libsync/DownloadingTxsQueue.cpp
@@ -135,7 +135,7 @@ void DownloadingTxsQueue::pop2TxPool(
             tbb::blocked_range<size_t>(0, txs->size()), [&](const tbb::blocked_range<size_t>& _r) {
                 for (size_t j = _r.begin(); j != _r.end(); ++j)
                 {
-                    if (!_txPool->txExists((*txs)[j]->sha3()))
+                    if (!_txPool->txExists((*txs)[j]->hash()))
                         (*txs)[j]->sender();
                 }
             });
@@ -162,7 +162,7 @@ void DownloadingTxsQueue::pop2TxPool(
                         << LOG_DESC("Import peer transaction into txPool DUPLICATED from peer")
                         << LOG_KV("reason", int(importResult))
                         << LOG_KV("peer", fromPeer.abridged())
-                        << LOG_KV("txHash", tx->sha3().abridged());
+                        << LOG_KV("txHash", tx->hash().abridged());
                 }
                 else
                 {
@@ -171,7 +171,7 @@ void DownloadingTxsQueue::pop2TxPool(
                         << LOG_DESC("Import peer transaction into txPool FAILED from peer")
                         << LOG_KV("reason", int(importResult))
                         << LOG_KV("peer", fromPeer.abridged())
-                        << LOG_KV("txHash", tx->sha3().abridged());
+                        << LOG_KV("txHash", tx->hash().abridged());
                 }
             }
             catch (std::exception& e)

--- a/libsync/SyncTransaction.cpp
+++ b/libsync/SyncTransaction.cpp
@@ -283,7 +283,7 @@ void SyncTransaction::sendTxsStatus(
                     m_txsHash->insert(
                         std::make_pair(peer, std::make_shared<std::set<dev::h256>>()));
                 }
-                (*m_txsHash)[peer]->insert(tx->sha3());
+                (*m_txsHash)[peer]->insert(tx->hash());
             }
         }
     }

--- a/libtxpool/CommonTransactionNonceCheck.cpp
+++ b/libtxpool/CommonTransactionNonceCheck.cpp
@@ -35,7 +35,7 @@ bool CommonTransactionNonceCheck::isNonceOk(dev::eth::Transaction const& _trans,
         {
             // dupulated transaction sync may cause duplicated nonce
             LOG(TRACE) << LOG_DESC("CommonTransactionNonceCheck: isNonceOk: duplicated nonce")
-                       << LOG_KV("nonce", key) << LOG_KV("transHash", _trans.sha3().abridged());
+                       << LOG_KV("nonce", key) << LOG_KV("transHash", _trans.hash().abridged());
 
             return false;
         }

--- a/libtxpool/TransactionNonceCheck.cpp
+++ b/libtxpool/TransactionNonceCheck.cpp
@@ -45,7 +45,7 @@ bool TransactionNonceCheck::isBlockLimitOk(Transaction const& _tx)
         NONCECHECKER_LOG(WARNING) << LOG_DESC("InvalidBlockLimit")
                                   << LOG_KV("blkLimit", _tx.blockLimit())
                                   << LOG_KV("maxBlkLimit", m_maxBlockLimit)
-                                  << LOG_KV("curBlk", m_blockNumber) << LOG_KV("tx", _tx.sha3());
+                                  << LOG_KV("curBlk", m_blockNumber) << LOG_KV("tx", _tx.hash());
         return false;
     }
     return true;

--- a/test/unittests/libblockchain/BlockChainImpTest.cpp
+++ b/test/unittests/libblockchain/BlockChainImpTest.cpp
@@ -327,13 +327,13 @@ BOOST_AUTO_TEST_CASE(getBlockRLPByNumber)
 BOOST_AUTO_TEST_CASE(getLocalisedTxByHash)
 {
     Transaction::Ptr tx = m_blockChainImp->getLocalisedTxByHash(h256(c_commonHashPrefix));
-    BOOST_CHECK_EQUAL(tx->sha3(), (*m_fakeBlock->m_transaction)[0]->sha3());
+    BOOST_CHECK_EQUAL(tx->hash(), (*m_fakeBlock->m_transaction)[0]->hash());
 }
 
 BOOST_AUTO_TEST_CASE(getTxByHash)
 {
     Transaction::Ptr tx = m_blockChainImp->getTxByHash(h256(c_commonHashPrefix));
-    BOOST_CHECK_EQUAL(tx->sha3(), (*m_fakeBlock->m_transaction)[0]->sha3());
+    BOOST_CHECK_EQUAL(tx->hash(), (*m_fakeBlock->m_transaction)[0]->hash());
 }
 
 BOOST_AUTO_TEST_CASE(getTransactionReceiptByHash)

--- a/test/unittests/libblockverifier/BlockVerifierTest.cpp
+++ b/test/unittests/libblockverifier/BlockVerifierTest.cpp
@@ -79,7 +79,7 @@ public:
             Transaction::Ptr tx =
                 std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
             tx->setBlockLimit(250);
-            auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+            auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
             tx->updateSignature(sig);
             tx->forceSender(Address(0x2333));
             txs->push_back(tx);
@@ -137,7 +137,7 @@ public:
             Transaction::Ptr tx =
                 std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
             tx->setBlockLimit(250);
-            auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+            auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
             tx->updateSignature(sig);
             tx->forceSender(Address(0x2333));
             txs->push_back(tx);
@@ -167,7 +167,7 @@ public:
             Transaction::Ptr tx =
                 std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
             tx->setBlockLimit(250);
-            auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+            auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
             tx->updateSignature(sig);
             tx->forceSender(Address(0x2333));
             BOOST_CHECK_NO_THROW(_verifier->executeTransaction(_block.header(), tx));

--- a/test/unittests/libblockverifier/TxDAGTest.cpp
+++ b/test/unittests/libblockverifier/TxDAGTest.cpp
@@ -62,7 +62,7 @@ public:
         Transaction::Ptr tx =
             std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
         tx->setBlockLimit(500);
-        auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+        auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
         tx->updateSignature(sig);
         tx->forceSender(Address(0x2333));
 
@@ -84,7 +84,7 @@ public:
             std::make_shared<Transaction>(value, gasPrice, gas, dest, data, nonce);
         tx->setBlockLimit(500);
         auto keyPair = KeyPair::create();
-        auto sig = dev::crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+        auto sig = dev::crypto::Sign(keyPair, tx->hash(WithoutSignature));
         tx->updateSignature(sig);
         tx->forceSender(Address(0x2333));
 
@@ -135,11 +135,11 @@ BOOST_AUTO_TEST_CASE(PureParallelTxDAGTest)
         txDag->executeUnit(executive);
     }
 
-    BOOST_CHECK_EQUAL(exeTrans[0]->sha3(), (*trans)[0]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[1]->sha3(), (*trans)[1]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[2]->sha3(), (*trans)[3]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[3]->sha3(), (*trans)[2]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[4]->sha3(), (*trans)[4]->sha3());
+    BOOST_CHECK_EQUAL(exeTrans[0]->hash(), (*trans)[0]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[1]->hash(), (*trans)[1]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[2]->hash(), (*trans)[3]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[3]->hash(), (*trans)[2]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[4]->hash(), (*trans)[4]->hash());
 }
 
 
@@ -171,12 +171,12 @@ BOOST_AUTO_TEST_CASE(NormalAndParallelTxDAGTest)
         txDag->executeUnit(executive);
     }
 
-    BOOST_CHECK_EQUAL(exeTrans[0]->sha3(), (*trans)[0]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[1]->sha3(), (*trans)[1]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[2]->sha3(), (*trans)[2]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[3]->sha3(), (*trans)[3]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[4]->sha3(), (*trans)[4]->sha3());
-    BOOST_CHECK_EQUAL(exeTrans[5]->sha3(), (*trans)[5]->sha3());
+    BOOST_CHECK_EQUAL(exeTrans[0]->hash(), (*trans)[0]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[1]->hash(), (*trans)[1]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[2]->hash(), (*trans)[2]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[3]->hash(), (*trans)[3]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[4]->hash(), (*trans)[4]->hash());
+    BOOST_CHECK_EQUAL(exeTrans[5]->hash(), (*trans)[5]->hash());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libconsensus/Consensus.cpp
+++ b/test/unittests/libconsensus/Consensus.cpp
@@ -61,7 +61,7 @@ public:
             auto tx = std::make_shared<Transaction>(value, gasPrice, gas, dst, data);
             tx->setNonce(tx->nonce() + utcTime() + u256(i));
             tx->setBlockLimit(m_txpoolCreator->m_blockChain->number() + 2);
-            auto sig = crypto::Sign(keyPair, tx->sha3(WithoutSignature));
+            auto sig = crypto::Sign(keyPair, tx->hash(WithoutSignature));
             tx->updateSignature(sig);
             m_txpoolCreator->m_txPool->submitTransactions(tx);
         }

--- a/test/unittests/libdevcore/MemTrie.cpp
+++ b/test/unittests/libdevcore/MemTrie.cpp
@@ -32,7 +32,7 @@ public:
     virtual MemTrieNode* remove(bytesConstRef _key) = 0;
     void putRLP(RLPStream& _parentStream) const;
 
-    /// 256-bit hash of the node - this is a SHA-3/256 hash of the RLP of the node.
+    /// 256-bit hash of the node - this is a Keccak256 hash of the RLP of the node.
     h256 hash256() const
     {
         RLPStream s;

--- a/test/unittests/libdevcrypto/Hash.cpp
+++ b/test/unittests/libdevcrypto/Hash.cpp
@@ -33,7 +33,7 @@ namespace dev
 namespace test
 {
 BOOST_FIXTURE_TEST_SUITE(SM_Hash, SM_CryptoTestFixture)
-BOOST_AUTO_TEST_CASE(SM_testEmptySHA3)
+BOOST_AUTO_TEST_CASE(SM_testEmptyKeccak256)
 {
     std::string ts = EmptyHash.hex();
     BOOST_CHECK_EQUAL(
@@ -43,11 +43,11 @@ BOOST_AUTO_TEST_CASE(SM_testEmptySHA3)
     BOOST_CHECK_EQUAL(
         ts, std::string("afe4ccac5ab7d52bcae36373676215368baf52d3905e1fecbe369cc120e97628"));
 
-    h256 emptySHA3(fromHex("1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b"));
-    BOOST_REQUIRE_EQUAL(emptySHA3, EmptyHash);
+    h256 emptyKeccak256(fromHex("1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b"));
+    BOOST_REQUIRE_EQUAL(emptyKeccak256, EmptyHash);
 }
 
-BOOST_AUTO_TEST_CASE(SM_testSha3General)
+BOOST_AUTO_TEST_CASE(SM_testKeccak256General)
 {
     BOOST_REQUIRE_EQUAL(
         crypto::Hash(""), h256("1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b"));
@@ -55,23 +55,23 @@ BOOST_AUTO_TEST_CASE(SM_testSha3General)
         h256("becbbfaae6548b8bf0cfcad5a27183cd1be6093b1cceccc303d9c61d0a645268"));
 }
 
-/// test sha3Secure and
-BOOST_AUTO_TEST_CASE(SM_testSha3CommonFunc)
+/// test keccak256Secure and
+BOOST_AUTO_TEST_CASE(SM_testKeccak256CommonFunc)
 {
     std::string content = "abcd";
     bytes content_bytes(content.begin(), content.end());
-    // test sha3Secure
-    SecureFixedHash<32> sec_sha3 = sha3Secure(ref(content_bytes));
-    SecureFixedHash<32> copyed_sha3 = sec_sha3;
-    // const byte* ptr = copyed_sha3.data();
-    /// const byte* p_sec = sec_sha3.data();
-    BOOST_CHECK(copyed_sha3.data() != sec_sha3.data());
-    BOOST_CHECK(sec_sha3.data());
+    // test keccak256Secure
+    SecureFixedHash<32> sec_keccak256 = keccak256Secure(ref(content_bytes));
+    SecureFixedHash<32> copyed_keccak256 = sec_keccak256;
+    // const byte* ptr = copyed_keccak256.data();
+    /// const byte* p_sec = sec_keccak256.data();
+    BOOST_CHECK(copyed_keccak256.data() != sec_keccak256.data());
+    BOOST_CHECK(sec_keccak256.data());
 #if 0
-    // test sha3 with SecureFixedHash input
-    BOOST_CHECK(crypto::Hash(sec_sha3).data());
+    // test keccak256 with SecureFixedHash input
+    BOOST_CHECK(crypto::Hash(sec_keccak256).data());
 #endif
-    // test sha3Mac
+    // test keccak256Mac
     h256 egressMac(crypto::Hash("+++"));
     bytes magic{0x22, 0x40, 0x08, 0x91};
     sm3mac(egressMac.ref(), &magic, egressMac.ref());
@@ -109,8 +109,8 @@ BOOST_AUTO_TEST_CASE(SM_testRipemd160)
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_FIXTURE_TEST_SUITE(Hash, TestOutputHelperFixture)
-// test sha3
-BOOST_AUTO_TEST_CASE(testEmptySHA3)
+// test keccak256
+BOOST_AUTO_TEST_CASE(testEmptyKeccak256)
 {
     std::string ts = EmptyHash.hex();
     BOOST_CHECK_EQUAL(
@@ -120,11 +120,11 @@ BOOST_AUTO_TEST_CASE(testEmptySHA3)
     BOOST_CHECK_EQUAL(
         ts, std::string("6377c7e66081cb65e473c1b95db5195a27d04a7108b468890224bedbe1a8a6eb"));
 
-    h256 emptySHA3(fromHex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
-    BOOST_REQUIRE_EQUAL(emptySHA3, EmptyHash);
+    h256 emptyKeccak256(fromHex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+    BOOST_REQUIRE_EQUAL(emptyKeccak256, EmptyHash);
 }
 
-BOOST_AUTO_TEST_CASE(testSha3General)
+BOOST_AUTO_TEST_CASE(testKeccak256General)
 {
     BOOST_REQUIRE_EQUAL(
         crypto::Hash(""), h256("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
@@ -132,24 +132,24 @@ BOOST_AUTO_TEST_CASE(testSha3General)
         h256("1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8"));
 }
 
-/// test sha3Secure and
-BOOST_AUTO_TEST_CASE(testSha3CommonFunc)
+/// test keccak256Secure and
+BOOST_AUTO_TEST_CASE(testKeccak256CommonFunc)
 {
     std::string content = "abcd";
     bytes content_bytes(content.begin(), content.end());
-    // test sha3Secure
-    SecureFixedHash<32> sec_sha3 = sha3Secure(ref(content_bytes));
-    SecureFixedHash<32> copyed_sha3 = sec_sha3;
-    BOOST_CHECK(copyed_sha3.data() != sec_sha3.data());
-    BOOST_CHECK(sec_sha3.data());
+    // test keccak256Secure
+    SecureFixedHash<32> sec_keccak256 = keccak256Secure(ref(content_bytes));
+    SecureFixedHash<32> copyed_keccak256 = sec_keccak256;
+    BOOST_CHECK(copyed_keccak256.data() != sec_keccak256.data());
+    BOOST_CHECK(sec_keccak256.data());
 #if 0
-    // test sha3 with SecureFixedHash input
-    BOOST_CHECK(crypto::Hash(sec_sha3).data());
+    // test keccak256 with SecureFixedHash input
+    BOOST_CHECK(crypto::Hash(sec_keccak256).data());
 #endif
-    // test sha3Mac
+    // test keccak256Mac
     h256 egressMac(crypto::Hash("+++"));
     bytes magic{0x22, 0x40, 0x08, 0x91};
-    sha3mac(egressMac.ref(), &magic, egressMac.ref());
+    keccak256mac(egressMac.ref(), &magic, egressMac.ref());
     BOOST_CHECK(toHex(egressMac) ==
                 "75759ba49fdef48a80840b669"
                 "9c4cc25ecb5e60f5dd0bf889381084ca6fc4199");

--- a/test/unittests/libethcore/BlockHeader.cpp
+++ b/test/unittests/libethcore/BlockHeader.cpp
@@ -93,7 +93,7 @@ public:
         m_singleTransaction = Transaction(value, gasPrice, gas, dst, data);
         KeyPair sigKeyPair = KeyPair::create();
         std::shared_ptr<crypto::Signature> sig =
-            dev::crypto::Sign(sigKeyPair, m_singleTransaction.sha3(WithoutSignature));
+            dev::crypto::Sign(sigKeyPair, m_singleTransaction.hash(WithoutSignature));
         /// update the signature of transaction
         m_singleTransaction.updateSignature(sig);
     }

--- a/test/unittests/libethcore/FakeBlock.h
+++ b/test/unittests/libethcore/FakeBlock.h
@@ -214,7 +214,7 @@ public:
         bytes data(str.begin(), str.end());
         m_singleTransaction = Transaction(value, gasPrice, gas, dst, data, 2);
         std::shared_ptr<crypto::Signature> sig =
-            dev::crypto::Sign(m_keyPair, m_singleTransaction.sha3(WithoutSignature));
+            dev::crypto::Sign(m_keyPair, m_singleTransaction.hash(WithoutSignature));
         /// update the signature of transaction
         m_singleTransaction.updateSignature(sig);
     }
@@ -250,7 +250,7 @@ public:
             tx->setBlockLimit(u256(_currentBlockNumber) + c_maxBlockLimit);
             tx->setRpcTx(true);
             std::shared_ptr<crypto::Signature> sig =
-                dev::crypto::Sign(sigKeyPair.secret(), tx->sha3(WithoutSignature));
+                dev::crypto::Sign(sigKeyPair.secret(), tx->hash(WithoutSignature));
             /// update the signature of transaction
             tx->updateSignature(sig);
             // std::pair<h256, Address> ret = txPool->submit(tx);

--- a/test/unittests/libethcore/PartiallyBlockTest.cpp
+++ b/test/unittests/libethcore/PartiallyBlockTest.cpp
@@ -50,7 +50,7 @@ public:
             tx->setNonce(utcTime() + index);
             tx->setBlockLimit(200);
             std::shared_ptr<crypto::Signature> sig =
-                dev::crypto::Sign(fakedBlock->m_keyPair, tx->sha3(WithoutSignature));
+                dev::crypto::Sign(fakedBlock->m_keyPair, tx->hash(WithoutSignature));
             tx->updateSignature(sig);
             index++;
         }
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(testEncodeDecodeProposal)
     size_t index = 0;
     for (auto tx : *(fakePartiallyBlock->m_block->transactions()))
     {
-        BOOST_CHECK(tx->sha3() == (*fakePartiallyBlock->m_block->txsHash())[index]);
+        BOOST_CHECK(tx->hash() == (*fakePartiallyBlock->m_block->txsHash())[index]);
         index++;
     }
 

--- a/test/unittests/libethcore/TransactionTest.cpp
+++ b/test/unittests/libethcore/TransactionTest.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(testCreateTxByRLP)
     Transaction tx(value, gasPrice, gas, dst, data);
     KeyPair sigKeyPair = KeyPair::create();
     std::shared_ptr<crypto::Signature> sig =
-        dev::crypto::Sign(sigKeyPair, tx.sha3(WithoutSignature));
+        dev::crypto::Sign(sigKeyPair, tx.hash(WithoutSignature));
     /// update the signature of transaction
     tx.updateSignature(sig);
     /// test encode
@@ -95,7 +95,7 @@ BOOST_FIXTURE_TEST_CASE(SM_testCreateTxByRLP, SM_CryptoTestFixture)
     Transaction tx(value, gasPrice, gas, dst, data);
     KeyPair sigKeyPair = KeyPair::create();
     std::shared_ptr<crypto::Signature> sig =
-        dev::crypto::Sign(sigKeyPair, tx.sha3(WithoutSignature));
+        dev::crypto::Sign(sigKeyPair, tx.hash(WithoutSignature));
     /// update the signature of transaction
     tx.updateSignature(sig);
     /// test encode

--- a/test/unittests/libexecutive/ExecuteVMTest.cpp
+++ b/test/unittests/libexecutive/ExecuteVMTest.cpp
@@ -169,7 +169,7 @@ contract HelloWorld{
     Executive e0(m_mptStates, initEnvInfo());
     Transaction tx(value, gasPrice, gas, code);  // Use contract creation constructor
     auto keyPair = KeyPair::create();
-    auto sig = dev::crypto::Sign(keyPair, tx.sha3(WithoutSignature));
+    auto sig = dev::crypto::Sign(keyPair, tx.hash(WithoutSignature));
     tx.updateSignature(sig);
     tx.forceSender(caller);
     executeTransaction(e0, tx);
@@ -200,7 +200,7 @@ contract HelloWorld{
         fromHex(string("0x60fe47b1") +  // set(0xaa)
                 string("00000000000000000000000000000000000000000000000000000000000000aa"));
     Transaction setTx(value, gasPrice, gas, newAddress, callDataToSet);
-    sig = dev::crypto::Sign(keyPair, setTx.sha3(WithoutSignature));
+    sig = dev::crypto::Sign(keyPair, setTx.hash(WithoutSignature));
     setTx.updateSignature(sig);
     setTx.forceSender(caller);
 
@@ -212,7 +212,7 @@ contract HelloWorld{
                                   string(""));
 
     Transaction getTx(value, gasPrice, gas, newAddress, callDataToGet);
-    sig = dev::crypto::Sign(keyPair, getTx.sha3(WithoutSignature));
+    sig = dev::crypto::Sign(keyPair, getTx.hash(WithoutSignature));
     getTx.updateSignature(sig);
     getTx.forceSender(caller);
 
@@ -228,7 +228,7 @@ contract HelloWorld{
                                         string(""));
 
     Transaction getByCallTx(value, gasPrice, gas, newAddress, callDataToGetByCall);
-    sig = dev::crypto::Sign(keyPair, getByCallTx.sha3(WithoutSignature));
+    sig = dev::crypto::Sign(keyPair, getByCallTx.hash(WithoutSignature));
     getByCallTx.updateSignature(sig);
     getByCallTx.forceSender(caller);
 
@@ -243,7 +243,7 @@ contract HelloWorld{
                                 string(""));
 
     Transaction destroyTx(value, gasPrice, gas, newAddress, callDestroy);
-    sig = dev::crypto::Sign(keyPair, destroyTx.sha3(WithoutSignature));
+    sig = dev::crypto::Sign(keyPair, destroyTx.hash(WithoutSignature));
     destroyTx.updateSignature(sig);
     destroyTx.forceSender(caller);
 
@@ -430,7 +430,7 @@ contract HelloWorld{
 
     Transaction getByCallTx(value, gasPrice, gas, newAddress, callDataToGetByCall);
     auto keyPair = KeyPair::create();
-    auto sig = dev::crypto::Sign(keyPair, tx.sha3(WithoutSignature));
+    auto sig = dev::crypto::Sign(keyPair, tx.hash(WithoutSignature));
     tx.updateSignature(sig);
     getByCallTx.forceSender(caller);
 
@@ -445,7 +445,7 @@ contract HelloWorld{
                                 string(""));
 
     Transaction destroyTx(value, gasPrice, gas, newAddress, callDestroy);
-    sig = dev::crypto::Sign(keyPair, destroyTx.sha3(WithoutSignature));
+    sig = dev::crypto::Sign(keyPair, destroyTx.hash(WithoutSignature));
     destroyTx.updateSignature(sig);
     destroyTx.forceSender(caller);
 

--- a/test/unittests/libprecompiled/test_WorkingSealerManagerPrecompiled.cpp
+++ b/test/unittests/libprecompiled/test_WorkingSealerManagerPrecompiled.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(testRotateWorkingSealerWithoutRotate)
 
     // case3: invalid input(must be lastest hash)
     LOG(INFO) << LOG_DESC("testRotateWorkingSealerWithoutRotate: valid proof, invalid input");
-    in = abi.abiIn(WSM_METHOD_ROTATE_STR, fixture->vrfPublicKey, toHex(dev::sha3("test")),
+    in = abi.abiIn(WSM_METHOD_ROTATE_STR, fixture->vrfPublicKey, toHex(dev::keccak256("test")),
         vrfInputWithProof.second);
     BOOST_CHECK_THROW(fixture->workingSealerManagerPrecompiled->call(
                           fixture->context, bytesConstRef(&in), nonSealerAccount, nonSealerAccount),

--- a/test/unittests/librpc/FakeModule.h
+++ b/test/unittests/librpc/FakeModule.h
@@ -257,7 +257,7 @@ public:
         RLP rlpObj(rlpBytes);
         bytesConstRef d = rlpObj.data();
         transaction = Transaction(d, eth::CheckTransaction::Everything);
-        std::cout << "* MockBlockChain: hash of the transaction: " << transaction.sha3()
+        std::cout << "* MockBlockChain: hash of the transaction: " << transaction.hash()
                   << std::endl;
     }
     dev::h256 numberHash(int64_t) override { return blockHash; }
@@ -283,7 +283,7 @@ public:
     dev::eth::LocalisedTransactionReceipt::Ptr getLocalisedTxReceiptByHash(
         dev::h256 const& _txHash) override
     {
-        if (_txHash == transaction.sha3())
+        if (_txHash == transaction.hash())
         {
             auto tx = getLocalisedTxByHash(_txHash);
             auto txReceipt = getTransactionReceiptByHash(_txHash);
@@ -528,11 +528,11 @@ public:
     }
     std::pair<h256, Address> submit(dev::eth::Transaction::Ptr _tx) override
     {
-        return make_pair(_tx->sha3(), toAddress(_tx->from(), _tx->nonce()));
+        return make_pair(_tx->hash(), toAddress(_tx->from(), _tx->nonce()));
     }
     std::pair<h256, Address> submitTransactions(dev::eth::Transaction::Ptr _tx) override
     {
-        return make_pair(_tx->sha3(), toAddress(_tx->from(), _tx->nonce()));
+        return make_pair(_tx->hash(), toAddress(_tx->from(), _tx->nonce()));
     }
     dev::eth::ImportResult import(
         dev::eth::Transaction::Ptr, dev::eth::IfDropped = dev::eth::IfDropped::Ignore) override

--- a/test/unittests/libsync/FakeSyncToolsSet.h
+++ b/test/unittests/libsync/FakeSyncToolsSet.h
@@ -217,7 +217,7 @@ public:
             std::make_shared<Transaction>(ref(c_txBytes), CheckTransaction::Everything);
         txPtr->setNonce(txPtr->nonce() + utcTime() + u256(1));
         txPtr->setBlockLimit(u256(_currentBlockNumber) + c_maxBlockLimit);
-        auto sig = crypto::Sign(keyPair, txPtr->sha3(WithoutSignature));
+        auto sig = crypto::Sign(keyPair, txPtr->hash(WithoutSignature));
         txPtr->updateSignature(sig);
         return txPtr;
     }

--- a/test/unittests/libsync/SyncMasterTest.cpp
+++ b/test/unittests/libsync/SyncMasterTest.cpp
@@ -132,7 +132,7 @@ public:
             tx->setBlockLimit(u256(_currentBlockNumber) + c_maxBlockLimit);
             tx->setRpcTx(true);
             std::shared_ptr<crypto::Signature> sig =
-                dev::crypto::Sign(sigKeyPair.secret(), tx->sha3(WithoutSignature));
+                dev::crypto::Sign(sigKeyPair.secret(), tx->hash(WithoutSignature));
             /// update the signature of transaction
             tx->updateSignature(sig);
             // std::pair<h256, Address> ret = txPool->submit(tx);

--- a/test/unittests/libsync/SyncMsgEngineTest.cpp
+++ b/test/unittests/libsync/SyncMsgEngineTest.cpp
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(SyncTransactionPacketTest)
     auto topTxs = txPoolPtr->topTransactions(1);
     std::cout << "topTransactions finished" << std::endl;
     BOOST_CHECK(topTxs->size() == 1);
-    BOOST_CHECK_EQUAL((*topTxs)[0]->sha3(), txPtr->sha3());
+    BOOST_CHECK_EQUAL((*topTxs)[0]->hash(), txPtr->hash());
     // TODO: this unit test may cause fatal error randomly
 }
 

--- a/test/unittests/libsync/SyncMsgPacketTest.cpp
+++ b/test/unittests/libsync/SyncMsgPacketTest.cpp
@@ -84,7 +84,7 @@ public:
         KeyPair sigKeyPair = KeyPair::create();
 
         std::shared_ptr<crypto::Signature> sig =
-            dev::crypto::Sign(sigKeyPair, tx.sha3(WithoutSignature));
+            dev::crypto::Sign(sigKeyPair, tx.hash(WithoutSignature));
         /// update the signature of transaction
         tx.updateSignature(sig);
         return tx;
@@ -160,13 +160,13 @@ BOOST_AUTO_TEST_CASE(SyncStatusPacketTest)
     std::srand(utcTime());
     // case1: test without time
     auto syncStatusFactory = std::make_shared<SyncMsgPacketFactory>();
-    testSyncStatus(syncStatusFactory, (utcTime() + std::rand() % 12000), dev::sha3("genesisHash"),
-        dev::sha3("latestHash"), false);
+    testSyncStatus(syncStatusFactory, (utcTime() + std::rand() % 12000), dev::keccak256("genesisHash"),
+        dev::keccak256("latestHash"), false);
 
     // case2: test with large blockNumber and time
     syncStatusFactory = std::make_shared<SyncMsgPacketWithAlignedTimeFactory>();
-    testSyncStatus(syncStatusFactory, (utcTime() + std::rand() % 12000), dev::sha3("genesisHashT"),
-        dev::sha3("latestHashT"), true);
+    testSyncStatus(syncStatusFactory, (utcTime() + std::rand() % 12000), dev::keccak256("genesisHashT"),
+        dev::keccak256("latestHashT"), true);
 }
 
 BOOST_AUTO_TEST_CASE(SyncTransactionsPacketTest)

--- a/test/unittests/libsync/test_NodeTimeMaintenance.cpp
+++ b/test/unittests/libsync/test_NodeTimeMaintenance.cpp
@@ -36,7 +36,7 @@ BOOST_FIXTURE_TEST_SUITE(NodeTimeMaintenanceTest, TestOutputHelperFixture)
 BOOST_AUTO_TEST_CASE(testTryToUpdatePeerTimeInfo)
 {
     auto nodeTimeMaintenance = std::make_shared<NodeTimeMaintenance>();
-    auto genesisHash = dev::sha3("genesis");
+    auto genesisHash = dev::keccak256("genesis");
     std::vector<SyncStatusPacket::Ptr> sycStatusVec;
     std::srand(utcTime());
     std::vector<int64_t> randomValues;

--- a/test/unittests/libtxpool/CommonTransactionNonceCheck.cpp
+++ b/test/unittests/libtxpool/CommonTransactionNonceCheck.cpp
@@ -49,7 +49,7 @@ Transaction fakeTransaction(size_t _idx = 0)
 
     auto keyPair = KeyPair::create();
     std::shared_ptr<crypto::Signature> sig =
-        dev::crypto::Sign(keyPair, fakeTx.sha3(WithoutSignature));
+        dev::crypto::Sign(keyPair, fakeTx.hash(WithoutSignature));
     /// update the signature of transaction
     fakeTx.updateSignature(sig);
     return fakeTx;

--- a/test/unittests/libtxpool/TxPool.cpp
+++ b/test/unittests/libtxpool/TxPool.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(testImportAndSubmit)
         *(pool_test.m_blockChain->getBlockByHash(pool_test.m_blockChain->numberHash(0))
                 ->transactions());
     trans[0]->setBlockLimit(pool_test.m_blockChain->number() + u256(1));
-    auto sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, trans[0]->sha3(WithoutSignature));
+    auto sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, trans[0]->hash(WithoutSignature));
     trans[0]->updateSignature(sig);
     bytes trans_data;
     trans[0]->encode(trans_data);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(testImportAndSubmit)
         tx->setNonce(tx->nonce() + u256(i) + u256(100));
         tx->setBlockLimit(pool_test.m_blockChain->number() + u256(100));
         bytes trans_bytes2;
-        sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, tx->sha3(WithoutSignature));
+        sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, tx->hash(WithoutSignature));
         // tx->encode(trans_bytes2);
         /// resignature
         tx->updateSignature(sig);
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(testImportAndSubmit)
     /// test out of limit, clear the queue
     tx->setNonce(tx->nonce() + utcTime() + u256(100));
     tx->setBlockLimit(pool_test.m_blockChain->number() + u256(1));
-    sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, tx->sha3(WithoutSignature));
+    sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, tx->hash(WithoutSignature));
     tx->updateSignature(sig);
     tx->encode(trans_data);
     pool_test.m_txPool->setTxPoolLimit(5);
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(testImportAndSubmit)
     BOOST_CHECK(m_status.current == 5);
     BOOST_CHECK(m_status.dropped == 0);
     /// test drop
-    bool ret = pool_test.m_txPool->drop(pending_list[0]->sha3());
+    bool ret = pool_test.m_txPool->drop(pending_list[0]->hash());
     BOOST_CHECK(ret == true);
     BOOST_CHECK(pool_test.m_txPool->pendingSize() == 4);
     m_status = pool_test.m_txPool->status();
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(testImportAndSubmit)
     BOOST_CHECK(top_transactions.size() == pool_test.m_txPool->pendingSize());
     h256Hash avoid;
     for (size_t i = 0; i < pool_test.m_txPool->pendingList()->size(); i++)
-        avoid.insert((*pool_test.m_txPool->pendingList())[i]->sha3());
+        avoid.insert((*pool_test.m_txPool->pendingList())[i]->hash());
     top_transactions = *(pool_test.m_txPool->topTransactions(20, avoid));
     BOOST_CHECK(top_transactions.size() == 0);
     /// check getProtocol id
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(BlockLimitCheck)
     Transaction::Ptr tx = std::make_shared<Transaction>(trans_data, CheckTransaction::Everything);
     tx->setNonce(tx->nonce() + utcTime() + u256(100));
     tx->setBlockLimit(pool_test.m_blockChain->number() + u256(10000));
-    auto sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, tx->sha3(WithoutSignature));
+    auto sig = crypto::Sign(pool_test.m_blockChain->m_keyPair, tx->hash(WithoutSignature));
     tx->updateSignature(sig);
     tx->encode(trans_data);
     pool_test.m_txPool->setTxPoolLimit(5);


### PR DESCRIPTION
**Mainly modified libdevcrypto/hash.h libdevcrypto/hash.cpp and other references. Changed the use of sha3 method names and parameter names to keccak.**
