### PR TITLE
 Fix ambiguous precompiled error when supported_version >= 2.7.0

### DIFF
--- a/libnetwork/Host.cpp
+++ b/libnetwork/Host.cpp
@@ -418,9 +418,9 @@ void Host::asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
     m_asioInterface->asyncResolveConnect(socket, [=](boost::system::error_code const& ec) {
         if (ec)
         {
-            HOST_LOG(WARNING) << LOG_DESC("TCP Connection refused by node")
-                              << LOG_KV("endpoint", _nodeIPEndpoint)
-                              << LOG_KV("message", ec.message());
+            HOST_LOG(ERROR) << LOG_DESC("TCP Connection refused by node")
+                            << LOG_KV("endpoint", _nodeIPEndpoint)
+                            << LOG_KV("message", ec.message());
             socket->close();
 
             m_threadPool->enqueue([callback, _nodeIPEndpoint]() {

--- a/libp2p/Service.cpp
+++ b/libp2p/Service.cpp
@@ -224,15 +224,23 @@ void Service::onConnect(dev::network::NetworkException e, dev::network::NodeInfo
     std::shared_ptr<dev::network::SessionFace> session)
 {
     NodeID nodeID = nodeInfo.nodeID;
+    std::string peer = "unknown";
+    if (session)
+    {
+        peer = session->nodeIPEndpoint().address();
+    }
     if (e.errorCode())
     {
         SERVICE_LOG(WARNING) << LOG_DESC("onConnect") << LOG_KV("errorCode", e.errorCode())
+                             << LOG_KV("nodeID", nodeID.abridged())
+                             << LOG_KV("nodeName", nodeInfo.nodeName) << LOG_KV("endpoint", peer)
                              << LOG_KV("what", e.what());
 
         return;
     }
 
-    SERVICE_LOG(TRACE) << LOG_DESC("Service onConnect") << LOG_KV("nodeID", nodeID.abridged());
+    SERVICE_LOG(TRACE) << LOG_DESC("Service onConnect") << LOG_KV("nodeID", nodeID.abridged())
+                       << LOG_KV("endpoint", peer);
 
     RecursiveGuard l(x_sessions);
     auto it = m_sessions.find(nodeID);

--- a/libprecompiled/Common.cpp
+++ b/libprecompiled/Common.cpp
@@ -75,22 +75,27 @@ void dev::precompiled::checkNameValidate(const string& tableName, string& keyFie
         set<string> valueFieldSet;
         boost::trim(keyField);
         valueFieldSet.insert(keyField);
-
         vector<char> allowChar = {'$', '_', '@'};
-
-        auto checkTableNameValidate = [allowChar, throwStorageException](const string& tableName) {
+        std::string allowCharString = "{$, _, @}";
+        auto checkTableNameValidate = [allowChar, allowCharString, throwStorageException](
+                                          const string& tableName) {
             size_t iSize = tableName.size();
             for (size_t i = 0; i < iSize; i++)
             {
                 if (!isalnum(tableName[i]) &&
                     (allowChar.end() == find(allowChar.begin(), allowChar.end(), tableName[i])))
                 {
-                    STORAGE_LOG(ERROR)
-                        << LOG_DESC("invalid tablename") << LOG_KV("table name", tableName);
+                    std::string errorMessage =
+                        "Invalid table name \"" + tableName +
+                        "\", the table name must be letters or numbers, and only supports \"" +
+                        allowCharString + "\" as special character set";
+                    STORAGE_LOG(ERROR) << LOG_DESC(errorMessage);
+                    // Note: the StorageException and PrecompiledException content can't be modified
+                    // at will for the information will be write to the blockchain
                     if (throwStorageException)
                     {
-                        BOOST_THROW_EXCEPTION(StorageException(
-                            CODE_TABLE_INVALIDATE_FIELD, string("invalid tablename:") + tableName));
+                        BOOST_THROW_EXCEPTION(
+                            StorageException(CODE_TABLE_INVALIDATE_FIELD, errorMessage));
                     }
                     else
                     {
@@ -100,16 +105,19 @@ void dev::precompiled::checkNameValidate(const string& tableName, string& keyFie
                 }
             }
         };
-        auto checkFieldNameValidate = [allowChar, throwStorageException](
+        auto checkFieldNameValidate = [allowChar, allowCharString, throwStorageException](
                                           const string& tableName, const string& fieldName) {
             if (fieldName.size() == 0 || fieldName[0] == '_')
             {
+                string errorMessage = "Invalid field \"" + fieldName +
+                                      "\", the size of the field must be larger than 0 and the "
+                                      "field can't start with \"_\"";
                 STORAGE_LOG(ERROR) << LOG_DESC("error key") << LOG_KV("field name", fieldName)
                                    << LOG_KV("table name", tableName);
                 if (throwStorageException)
                 {
-                    BOOST_THROW_EXCEPTION(StorageException(
-                        CODE_TABLE_INVALIDATE_FIELD, string("invalid field:") + fieldName));
+                    BOOST_THROW_EXCEPTION(
+                        StorageException(CODE_TABLE_INVALIDATE_FIELD, errorMessage));
                 }
                 else
                 {
@@ -123,13 +131,18 @@ void dev::precompiled::checkNameValidate(const string& tableName, string& keyFie
                 if (!isalnum(fieldName[i]) &&
                     (allowChar.end() == find(allowChar.begin(), allowChar.end(), fieldName[i])))
                 {
+                    std::string errorMessage =
+                        "Invalid field \"" + fieldName +
+                        "\", the field name must be letters or numbers, and only supports \"" +
+                        allowCharString + "\" as special character set";
+
                     STORAGE_LOG(ERROR)
                         << LOG_DESC("invalid fieldname") << LOG_KV("field name", fieldName)
                         << LOG_KV("table name", tableName);
                     if (throwStorageException)
                     {
-                        BOOST_THROW_EXCEPTION(StorageException(
-                            CODE_TABLE_INVALIDATE_FIELD, string("invalid field:") + fieldName));
+                        BOOST_THROW_EXCEPTION(
+                            StorageException(CODE_TABLE_INVALIDATE_FIELD, errorMessage));
                     }
                     else
                     {

--- a/libprecompiled/Common.h
+++ b/libprecompiled/Common.h
@@ -22,6 +22,7 @@
 #include "libdevcore/Exceptions.h"
 #include "libprecompiled/Precompiled.h"
 #include <libdevcore/Address.h>
+#include <libstorage/StorageException.h>
 #include <memory>
 #include <string>
 
@@ -124,6 +125,8 @@ enum PrecompiledError : int
 class PrecompiledException : public dev::Exception
 {
 public:
+    // covert StorageException to  PrecompiledException
+    PrecompiledException(dev::storage::StorageException const& _e) : dev::Exception(_e.what()) {}
     PrecompiledException(const std::string& what) : dev::Exception(what) {}
     bytes ToOutput();
 };

--- a/libstorage/StorageException.h
+++ b/libstorage/StorageException.h
@@ -35,7 +35,7 @@ public:
       : dev::Exception(what), m_errorCode(errorCode)
     {}
 
-    virtual int errorCode() { return m_errorCode; }
+    virtual int errorCode() const { return m_errorCode; }
 
 private:
     int m_errorCode = 0;


### PR DESCRIPTION
supported_version is no smaller than 2.7.0, convert storageException to PrecompiledException to make the precompiledError thrown by the evm more clear