### PR TITLE
deduct gas when executing transactions

### DIFF
--- a/libblockverifier/BlockVerifierInterface.h
+++ b/libblockverifier/BlockVerifierInterface.h
@@ -53,6 +53,8 @@ public:
 
     virtual dev::eth::TransactionReceipt::Ptr executeTransaction(
         const dev::eth::BlockHeader& blockHeader, dev::eth::Transaction::Ptr _t) = 0;
+    virtual void setEnableGasCharge(bool) {}
+    virtual void setGasFreeAccounts(std::set<Address> const&) {}
 };
 }  // namespace blockverifier
 }  // namespace dev

--- a/libconsensus/ConsensusEngineBase.cpp
+++ b/libconsensus/ConsensusEngineBase.cpp
@@ -22,6 +22,7 @@
  * @date: 2018-09-28
  */
 #include "ConsensusEngineBase.h"
+#include <libprecompiled/Common.h>
 using namespace dev::eth;
 using namespace dev::db;
 using namespace dev::blockverifier;
@@ -222,6 +223,7 @@ void ConsensusEngineBase::updateConsensusNodeList()
 void ConsensusEngineBase::resetConfig()
 {
     updateMaxBlockTransactions();
+    updateGasChargeManageSwitch();
     auto node_idx = MAXIDX;
     m_accountType = NodeAccountType::ObserverAccount;
     size_t nodeNum = 0;
@@ -263,6 +265,11 @@ void ConsensusEngineBase::reportBlock(dev::eth::Block const& _block)
     {
         return;
     }
+    statGasUsed(_block);
+}
+
+void ConsensusEngineBase::statGasUsed(dev::eth::Block const& _block)
+{
     // print the block gasUsed
     auto txsNum = _block.transactions()->size();
     if (txsNum == 0)
@@ -283,11 +290,46 @@ void ConsensusEngineBase::reportBlock(dev::eth::Block const& _block)
     for (auto const& tx : *_block.transactions())
     {
         auto receipt = (*receipts)[receiptIndex];
-        auto gasUsed = receipt->gasUsed() - prevGasUsed;
+        u256 gasUsed = receipt->gasUsed();
+        if (g_BCOSConfig.version() < V2_8_0)
+        {
+            gasUsed = receipt->gasUsed() - prevGasUsed;
+        }
         STAT_LOG(INFO) << LOG_TYPE("TxsGasUsed") << LOG_KV("g", m_groupId)
                        << LOG_KV("txHash", toHex(tx->hash())) << LOG_KV("gasUsed", gasUsed);
         prevGasUsed = receipt->gasUsed();
         receiptIndex++;
+    }
+}
+
+void ConsensusEngineBase::updateMaxBlockTransactions()
+{
+    /// update m_maxBlockTransactions stored in sealer when reporting a new block
+    std::string ret =
+        m_blockChain->getSystemConfigByKey(dev::precompiled::SYSTEM_KEY_TX_COUNT_LIMIT);
+    {
+        m_maxBlockTransactions = boost::lexical_cast<uint64_t>(ret);
+    }
+    ENGINE_LOG(DEBUG) << LOG_DESC("resetConfig: updateMaxBlockTransactions")
+                      << LOG_KV("txCountLimit", m_maxBlockTransactions);
+}
+
+void ConsensusEngineBase::updateGasChargeManageSwitch()
+{
+    // only support GasChargeManage when supported_version >= 2.8.0
+    if (g_BCOSConfig.version() < V2_8_0)
+    {
+        return;
+    }
+    std::string ret =
+        m_blockChain->getSystemConfigByKey(dev::precompiled::SYSTEM_KEY_CHARGE_MANAGE_SWITCH);
+    if (ret.compare(dev::precompiled::SYSTEM_KEY_CHARGE_MANAGE_SWITCH_ON) == 0)
+    {
+        m_blockVerifier->setEnableGasCharge(true);
+    }
+    if (ret.compare(dev::precompiled::SYSTEM_KEY_CHARGE_MANAGE_SWITCH_OFF) == 0)
+    {
+        m_blockVerifier->setEnableGasCharge(false);
     }
 }
 

--- a/libconsensus/ConsensusEngineBase.h
+++ b/libconsensus/ConsensusEngineBase.h
@@ -276,22 +276,16 @@ protected:
     virtual void updateConsensusNodeList();
 
     /// set the max number of transactions in a block
-    virtual void updateMaxBlockTransactions()
-    {
-        /// update m_maxBlockTransactions stored in sealer when reporting a new block
-        std::string ret = m_blockChain->getSystemConfigByKey("tx_count_limit");
-        {
-            m_maxBlockTransactions = boost::lexical_cast<uint64_t>(ret);
-        }
-        ENGINE_LOG(DEBUG) << LOG_DESC("resetConfig: updateMaxBlockTransactions")
-                          << LOG_KV("txCountLimit", m_maxBlockTransactions);
-    }
+    virtual void updateMaxBlockTransactions();
+    virtual void updateGasChargeManageSwitch();
 
     dev::h512s consensusList() const override
     {
         ReadGuard l(m_sealerListMutex);
         return m_sealerList;
     }
+
+    void statGasUsed(dev::eth::Block const& _block);
 
 protected:
     std::atomic<uint64_t> m_maxBlockTransactions = {1000};

--- a/libconsensus/raft/RaftEngine.cpp
+++ b/libconsensus/raft/RaftEngine.cpp
@@ -82,6 +82,7 @@ void RaftEngine::initRaftEnv()
 void RaftEngine::resetConfig()
 {
     updateMaxBlockTransactions();
+    updateGasChargeManageSwitch();
     updateConsensusNodeList();
 
     auto shouldSwitchToFollower = false;

--- a/libdevcore/Address.cpp
+++ b/libdevcore/Address.cpp
@@ -14,12 +14,53 @@
     You should have received a copy of the GNU General Public License
     along with cpp-ethereum.  If not, see <http://www.gnu.org/licenses/>.
 */
-
 #include "Address.h"
+#include "Exceptions.h"
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 namespace dev
 {
 Address const ZeroAddress;
 Address const MaxAddress{"0xffffffffffffffffffffffffffffffffffffffff"};
 Address const SystemAddress{"0xfffffffffffffffffffffffffffffffffffffffe"};
+
+Address toAddress(std::string const& _s)
+{
+    try
+    {
+        auto b = fromHex(_s.substr(0, 2) == "0x" ? _s.substr(2) : _s, WhenError::Throw);
+        if (b.size() == 20)
+            return Address(b);
+    }
+    catch (BadHexCharacter&)
+    {
+    }
+    BOOST_THROW_EXCEPTION(InvalidAddress());
+}
+
+std::shared_ptr<std::set<Address>> convertStringToAddressSet(
+    std::string const& _addressListStr, std::string const& _splitStr)
+{
+    std::vector<std::string> addressList;
+    boost::split(addressList, _addressListStr, boost::is_any_of(_splitStr));
+    std::shared_ptr<std::set<Address>> addressSet = std::make_shared<std::set<Address>>();
+    for (auto const& address : addressList)
+    {
+        if (address.length() == 0)
+        {
+            continue;
+        }
+        try
+        {
+            addressSet->insert(toAddress(address));
+        }
+        catch (const std::exception& e)
+        {
+            LOG(WARNING) << LOG_DESC("convert String to address failed")
+                         << LOG_KV("_addressListStr", _addressListStr);
+        }
+    }
+    return addressSet;
+}
 }  // namespace dev

--- a/libdevcore/Address.h
+++ b/libdevcore/Address.h
@@ -43,4 +43,9 @@ extern Address const MaxAddress;
 /// The SYSTEM address.
 extern Address const SystemAddress;
 
+/// Convert the given string into an address.
+Address toAddress(std::string const& _s);
+
+std::shared_ptr<std::set<Address>> convertStringToAddressSet(
+    std::string const& _addressListStr, std::string const& _splitStr);
 }  // namespace dev

--- a/libdevcore/Exceptions.h
+++ b/libdevcore/Exceptions.h
@@ -113,6 +113,8 @@ DEV_SIMPLE_EXCEPTION(ForbidNegativeValue);
 DEV_SIMPLE_EXCEPTION(InvalidConfiguration);
 DEV_SIMPLE_EXCEPTION(InvalidPort);
 DEV_SIMPLE_EXCEPTION(InvalidSupportedVersion);
+
+DEV_SIMPLE_EXCEPTION(InvalidAddress);
 /**
  * @brief : error information to be added to exceptions
  */

--- a/libethcore/Common.cpp
+++ b/libethcore/Common.cpp
@@ -44,20 +44,6 @@ const unsigned c_BlockFieldSize = 4;
 const unsigned c_databaseVersion =
     c_databaseBaseVersion + (c_databaseVersionModifier << 8) + (23 << 9);
 
-Address toAddress(std::string const& _s)
-{
-    try
-    {
-        auto b = fromHex(_s.substr(0, 2) == "0x" ? _s.substr(2) : _s, WhenError::Throw);
-        if (b.size() == 20)
-            return Address(b);
-    }
-    catch (BadHexCharacter&)
-    {
-    }
-    BOOST_THROW_EXCEPTION(InvalidAddress());
-}
-
 static void badBlockInfo(BlockHeader const& _bi, string const& _err)
 {
     string const c_line = string(80, ' ');

--- a/libethcore/Common.h
+++ b/libethcore/Common.h
@@ -56,8 +56,6 @@ extern const unsigned c_minorProtocolVersion;
 /// Current database version.
 extern const unsigned c_databaseVersion;
 extern const unsigned c_BlockFieldSize;
-/// Convert the given string into an address.
-Address toAddress(std::string const& _s);
 
 /// The log bloom's size (2048-bit).
 using LogBloom = h2048;

--- a/libethcore/CommonJS.h
+++ b/libethcore/CommonJS.h
@@ -49,7 +49,7 @@ inline Secret jsToSecret(std::string const& _s)
 /// Leniently convert string to Address (h160). Accepts integers, "0x" prefixing, non-exact length.
 inline Address jsToAddress(std::string const& _s)
 {
-    return eth::toAddress(_s);
+    return toAddress(_s);
 }
 
 namespace eth

--- a/libethcore/Exceptions.h
+++ b/libethcore/Exceptions.h
@@ -45,6 +45,7 @@ using BadFieldError = boost::tuple<errinfo_field, errinfo_data>;
 /// gas related exceptions
 DEV_SIMPLE_EXCEPTION(OutOfGasBase);
 DEV_SIMPLE_EXCEPTION(OutOfGasIntrinsic);
+DEV_SIMPLE_EXCEPTION(NotEnoughRemainGas);
 DEV_SIMPLE_EXCEPTION(NotEnoughCash);
 DEV_SIMPLE_EXCEPTION(GasPriceTooLow);
 DEV_SIMPLE_EXCEPTION(BlockGasLimitReached);
@@ -92,7 +93,6 @@ DEV_SIMPLE_EXCEPTION(InvalidSyncPeerCreation);
 /// common exceptions
 DEV_SIMPLE_EXCEPTION(InvalidNonce);
 DEV_SIMPLE_EXCEPTION(InvalidSignature);
-DEV_SIMPLE_EXCEPTION(InvalidAddress);
 DEV_SIMPLE_EXCEPTION(AddressAlreadyUsed);
 DEV_SIMPLE_EXCEPTION(InvalidTimestamp);
 DEV_SIMPLE_EXCEPTION(InvalidProtocolID);

--- a/libethcore/TransactionException.h
+++ b/libethcore/TransactionException.h
@@ -65,6 +65,7 @@ enum class TransactionException : uint32_t
     TransactionRefused = 29,
     ContractFrozen = 30,
     AccountFrozen = 31,
+    NotEnoughRemainGas = 32,
     AlreadyKnown = 10000,  /// txPool related errors
     AlreadyInChain = 10001,
     InvalidChainId = 10002,

--- a/libexecutive/Executive.h
+++ b/libexecutive/Executive.h
@@ -192,8 +192,17 @@ public:
         m_logs.clear();
         m_t.reset();
     }
+    void setGasFreeAccounts(std::set<Address> _gasFreeAccounts)
+    {
+        m_gasFreeAccounts = _gasFreeAccounts;
+    }
+    void setEnableGasCharge(bool _enableGasCharge) { m_enableGasCharge = _enableGasCharge; }
 
 private:
+    bool shouldCheckAccountGas(dev::eth::Transaction::Ptr _tx);
+    void checkAccountRemainGas(dev::eth::Transaction::Ptr _tx, int64_t const& _requiredGas);
+    void deductRuntimeGas(dev::eth::Transaction::Ptr _tx, u256 const& _refundedGas);
+
     void parseEVMCResult(std::shared_ptr<eth::Result> _result);
     /// @returns false iff go() must be called (and thus a VM execution in required).
     bool executeCreate(Address const& _txSender, u256 const& _endowment, u256 const& _gasPrice,
@@ -239,6 +248,9 @@ private:
 
     // determine whether the freeStorageVMSchedule enabled or not
     bool m_enableFreeStorage = false;
+
+    bool m_enableGasCharge = false;
+    std::set<Address> m_gasFreeAccounts;
 };
 
 }  // namespace executive

--- a/libprecompiled/Common.h
+++ b/libprecompiled/Common.h
@@ -232,6 +232,9 @@ const char* const SYSTEM_INIT_VALUE_TX_GAS_LIMIT = "300000000";
 
 // system configuration for charger-list
 const char* const SYSTEM_KEY_CHARGER_LIST = "charger_list";
+const char* const SYSTEM_KEY_CHARGE_MANAGE_SWITCH = "enable_charge_mgr";
+const char* const SYSTEM_KEY_CHARGE_MANAGE_SWITCH_ON = "on";
+const char* const SYSTEM_KEY_CHARGE_MANAGE_SWITCH_OFF = "off";
 
 const int TX_COUNT_LIMIT_MIN = 1;
 const int TX_GAS_LIMIT_MIN = 100000;

--- a/libprecompiled/ContractLifeCyclePrecompiled.cpp
+++ b/libprecompiled/ContractLifeCyclePrecompiled.cpp
@@ -390,7 +390,7 @@ void ContractLifeCyclePrecompiled::listManager(
                 for (size_t i = 0; i < entries->size(); i++)
                 {
                     auto authority = entries->get(i)->getField(storagestate::STORAGE_VALUE);
-                    addrs.push_back(dev::eth::toAddress(authority));
+                    addrs.push_back(toAddress(authority));
                 }
             }
             else

--- a/libprecompiled/GasChargeManagePrecompiled.cpp
+++ b/libprecompiled/GasChargeManagePrecompiled.cpp
@@ -101,31 +101,6 @@ PrecompiledExecResult::Ptr GasChargeManagePrecompiled::call(
     return callResult;
 }
 
-std::shared_ptr<std::set<Address>> GasChargeManagePrecompiled::parseChargerList(
-    std::string const& _chargerListStr)
-{
-    std::vector<std::string> chargerList;
-    boost::split(chargerList, _chargerListStr, boost::is_any_of(c_chargerListSplitStr));
-    std::shared_ptr<std::set<Address>> chargerAddressList = std::make_shared<std::set<Address>>();
-    for (auto const& charger : chargerList)
-    {
-        if (charger.length() == 0)
-        {
-            continue;
-        }
-        try
-        {
-            chargerAddressList->insert(dev::eth::toAddress(charger));
-        }
-        catch (const std::exception& e)
-        {
-            PRECOMPILED_LOG(WARNING) << LOG_DESC("convert charger str to address failed")
-                                     << LOG_KV("chargerAccount", charger);
-        }
-    }
-    return chargerAddressList;
-}
-
 std::shared_ptr<std::set<Address>> GasChargeManagePrecompiled::getChargerList(
     std::shared_ptr<ExecutiveContext> _context)
 {
@@ -139,7 +114,7 @@ std::shared_ptr<std::set<Address>> GasChargeManagePrecompiled::getChargerList(
         sysConfigTable, SYSTEM_KEY_CHARGER_LIST, _context->blockInfo().number);
 
     PRECOMPILED_LOG(DEBUG) << LOG_DESC("getChargerList") << LOG_KV("chargerList", result->first);
-    return parseChargerList(result->first);
+    return convertStringToAddressSet(result->first, c_chargerListSplitStr);
 }
 
 // check the account status

--- a/libprecompiled/GasChargeManagePrecompiled.h
+++ b/libprecompiled/GasChargeManagePrecompiled.h
@@ -88,7 +88,6 @@ private:
 
     std::shared_ptr<std::set<Address>> getChargerList(
         std::shared_ptr<dev::blockverifier::ExecutiveContext> _context);
-    std::shared_ptr<std::set<Address>> parseChargerList(std::string const& _chargerListStr);
     void updateChargers(std::shared_ptr<dev::blockverifier::ExecutiveContext> _context,
         std::shared_ptr<std::set<Address>> _chargerList, Address const& _origin);
 

--- a/libprecompiled/SystemConfigPrecompiled.cpp
+++ b/libprecompiled/SystemConfigPrecompiled.cpp
@@ -118,6 +118,17 @@ PrecompiledExecResult::Ptr SystemConfigPrecompiled::call(
 
 bool SystemConfigPrecompiled::checkValueValid(std::string const& key, std::string const& value)
 {
+    // switch for gasChargeManager
+    if (SYSTEM_KEY_CHARGE_MANAGE_SWITCH == key)
+    {
+        if (g_BCOSConfig.version() < V2_8_0)
+        {
+            return false;
+        }
+        return ((value.compare(SYSTEM_KEY_CHARGE_MANAGE_SWITCH_ON) == 0) ||
+                (value.compare(SYSTEM_KEY_CHARGE_MANAGE_SWITCH_OFF) == 0));
+    }
+
     int64_t configuredValue = 0;
     try
     {

--- a/librpc/Rpc.h
+++ b/librpc/Rpc.h
@@ -210,7 +210,8 @@ protected:
         dev::precompiled::SYSTEM_KEY_TX_COUNT_LIMIT, dev::precompiled::SYSTEM_KEY_TX_GAS_LIMIT,
         dev::precompiled::SYSTEM_KEY_RPBFT_EPOCH_BLOCK_NUM,
         dev::precompiled::SYSTEM_KEY_RPBFT_EPOCH_SEALER_NUM,
-        dev::precompiled::SYSTEM_KEY_CONSENSUS_TIMEOUT};
+        dev::precompiled::SYSTEM_KEY_CONSENSUS_TIMEOUT,
+        dev::precompiled::SYSTEM_KEY_CHARGE_MANAGE_SWITCH};
 
 private:
     bool isValidNodeId(dev::bytes const& precompileData,

--- a/test/unittests/libconsensus/FakePBFTEngine.h
+++ b/test/unittests/libconsensus/FakePBFTEngine.h
@@ -135,6 +135,7 @@ public:
 
     void setMaxBlockTransactions(size_t const& maxTrans) { m_maxBlockTransactions = maxTrans; }
     void updateMaxBlockTransactions() override {}
+    virtual void updateGasChargeManageSwitch() override {}
     bool checkBlock(dev::eth::Block const& block)
     {
         auto orgNumber = m_blockChain->number();

--- a/test/unittests/libethcore/Common.cpp
+++ b/test/unittests/libethcore/Common.cpp
@@ -69,8 +69,8 @@ BOOST_AUTO_TEST_CASE(testBadBlock)
 
 BOOST_AUTO_TEST_CASE(testToAddress)
 {
-    BOOST_CHECK_NO_THROW(dev::eth::toAddress("0x64fa644d2a694681bd6addd6c5e36cccd8dcdde3"));
-    BOOST_CHECK_THROW(dev::eth::toAddress("0x64fa644d"), InvalidAddress);
+    BOOST_CHECK_NO_THROW(toAddress("0x64fa644d2a694681bd6addd6c5e36cccd8dcdde3"));
+    BOOST_CHECK_THROW(toAddress("0x64fa644d"), InvalidAddress);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unittests/libethcore/EthCoreCommonJS.cpp
+++ b/test/unittests/libethcore/EthCoreCommonJS.cpp
@@ -64,9 +64,9 @@ BOOST_AUTO_TEST_CASE(testJsToPublic)
     BOOST_CHECK(jsToAddress(addr) == toAddress(key_pair.pub()));
     // exception test
     std::string invalid_addr = "0x1234";
-    BOOST_CHECK_THROW(jsToAddress(invalid_addr), dev::eth::InvalidAddress);
+    BOOST_CHECK_THROW(jsToAddress(invalid_addr), InvalidAddress);
     invalid_addr = "adb234ef";
-    BOOST_CHECK_THROW(jsToAddress(invalid_addr), dev::eth::InvalidAddress);
+    BOOST_CHECK_THROW(jsToAddress(invalid_addr), InvalidAddress);
 }
 
 BOOST_AUTO_TEST_CASE(testToBlockNumber)

--- a/test/unittests/libprecompiled/test_CryptoPrecompiled.cpp
+++ b/test/unittests/libprecompiled/test_CryptoPrecompiled.cpp
@@ -52,7 +52,6 @@ public:
     }
 
     ~CryptoPrecompiledFixture() {}
-
     CryptoPrecompiled::Ptr cryptoPrecompiled;
     ExecutiveContext::Ptr precompiledContext;
 };
@@ -60,8 +59,9 @@ public:
 class SMCryptoPrecompiledFixture : public CryptoPrecompiledFixture
 {
 public:
-    SMCryptoPrecompiledFixture() : smCrypto(g_BCOSConfig.SMCrypto())
+    SMCryptoPrecompiledFixture()
     {
+        smCrypto = g_BCOSConfig.SMCrypto();
         g_BCOSConfig.setUseSMCrypto(true);
         if (!smCrypto)
         {
@@ -74,8 +74,11 @@ public:
     {
         g_BCOSConfig.setUseSMCrypto(smCrypto);
         clearName2SelectCache();
+        if (!smCrypto)
+        {
+            crypto::initCrypto();
+        }
     }
-
     bool smCrypto;
 };
 
@@ -169,7 +172,7 @@ void testVRFVerify(
     BOOST_CHECK(verifySucc == false);
     BOOST_CHECK(randomValue == 0);
 }
-BOOST_FIXTURE_TEST_SUITE(CryptoPrecompiled, CryptoPrecompiledFixture)
+BOOST_FIXTURE_TEST_SUITE(CryptoPrecompiledTest, CryptoPrecompiledFixture)
 BOOST_AUTO_TEST_CASE(testSM3AndKeccak256)
 {
     testHash(cryptoPrecompiled, precompiledContext);


### PR DESCRIPTION
1. deduct gas when executing transactions
2. add `enable_charge_mgr` key to enable/disable transaction-runtime gas deduction
3. disable parallel when `enable_charge_mgr` is on
4. update  the calculation logic of transaction receipt gasUsed