### PR TITLE
Fix the problem of getting CommonName error

### DIFF
--- a/libnetwork/Host.cpp
+++ b/libnetwork/Host.cpp
@@ -270,6 +270,11 @@ std::string Host::obtainCommonNameFromSubject(std::string const& subject)
             {
                 return field;
             }
+            // the key field must be CN
+            if (dev::stringCmpIgnoreCase(cn_fields[0], "CN") != 0)
+            {
+                continue;
+            }
             /// return real common name
             return cn_fields[1];
         }


### PR DESCRIPTION
Fix the problem of getting CommonName error when matching wrong CN string when parsing agency and node name

Fix  #1894 