### PR TITLE
Fix: macos build failed caused by jsoncpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ deps/**
 
 # others
 .clang-format
+
+#idea
+.idea
+cmake-build-debug/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ set(FISCO_BCOS_CMAKE_DIR "${CMAKE_CURRENT_LIST_DIR}/cmake" CACHE PATH "The path 
 list(APPEND CMAKE_MODULE_PATH ${FISCO_BCOS_CMAKE_DIR})
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Minimum OS X deployment version")
 
+if(APPLE)
+  set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINNKER_FLAGS} "-w")
+endif()
+
 project(FISCO-BCOS VERSION "2.7.2")
 # Suffix like "-rc1" e.t.c. to append to versions wherever needed.
 set(VERSION_SUFFIX "")

--- a/cmake/ProjectJsonCpp.cmake
+++ b/cmake/ProjectJsonCpp.cmake
@@ -22,6 +22,8 @@
 #------------------------------------------------------------------------------
 include(ExternalProject)
 
+add_compile_options(-std=c++11)
+
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     set(JSONCPP_CMAKE_COMMAND emcmake cmake)
 else()
@@ -57,7 +59,13 @@ ExternalProject_Add(jsoncpp
 # Create jsoncpp imported library
 ExternalProject_Get_Property(jsoncpp INSTALL_DIR)
 add_library(JsonCpp STATIC IMPORTED)
-set(JSONCPP_LIBRARY ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX})
+
+if(APPLE)
+    set(JSONCPP_LIBRARY ${INSTALL_DIR}/lib/libjsoncpp.a)
+ELSE()
+    set(JSONCPP_LIBRARY ${INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}jsoncpp${CMAKE_STATIC_LIBRARY_SUFFIX})
+ENDIF()
+
 set(JSONCPP_INCLUDE_DIR ${INSTALL_DIR}/include)
 file(MAKE_DIRECTORY ${JSONCPP_INCLUDE_DIR})  # Must exist.
 set_property(TARGET JsonCpp PROPERTY IMPORTED_LOCATION ${JSONCPP_LIBRARY})


### PR DESCRIPTION
This pr fixes the build error in the macos:

```
error: undefined reference to `Json::Value::operator=(Json::Value&&)'
```

and this pr prevents the warnings on higher version macos that:

```
was built for newer OSX version (11.0) than being linked (10.13)
```