### PR TITLE
fix coredump for send_back without set the executionResult

### DIFF
--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -811,6 +811,7 @@ void TransactionExecutor::dagExecuteTransactionsInternal(
                             << LOG_DESC("The transaction can't be executed concurrently")
                             << LOG_KV("adddress", to)
                             << LOG_KV("abiKey", toHexStringWithPrefix(abiKey));
+                        executionResults[i] = toExecutionResult(std::move(inputs[i]));
                         executionResults[i]->setType(ExecutionMessage::SEND_BACK);
                         continue;
                     }

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -1085,8 +1085,10 @@ void TransactionExecutor::asyncExecute(std::shared_ptr<BlockContext> blockContex
     std::function<void(bcos::Error::UniquePtr&&, bcos::protocol::ExecutionMessage::UniquePtr&&)>
         callback)
 {
-    EXECUTOR_LOG(TRACE) << "Import key locks size: " << input->keyLocks().size();
-
+    EXECUTOR_LOG(TRACE) << LOG_DESC("asyncExecute")
+                        << LOG_KV("keyLockSize", input->keyLocks().size())
+                        << LOG_KV("contextID", input->contextID()) << LOG_KV("seq", input->seq())
+                        << LOG_KV("type", std::to_string(input->type()));
     switch (input->type())
     {
     case bcos::protocol::ExecutionMessage::TXHASH:
@@ -1165,15 +1167,15 @@ void TransactionExecutor::asyncExecute(std::shared_ptr<BlockContext> blockContex
             auto& [executive] = *it;
 
             // Call callback
-            EXECUTOR_LOG(TRACE) << "Entering responseFunc";
+            EXECUTOR_LOG(TRACE) << "Entering responseFunc" << LOG_KV("contextID", contextID)
+                                << LOG_KV("seq", seq);
             executive->setExchangeMessage(std::move(callParameters));
             auto output = executive->resume();
             auto message = toExecutionResult(*executive, std::move(output));
 
             callback(nullptr, std::move(message));
-            return;
-
             EXECUTOR_LOG(TRACE) << "Exiting responseFunc";
+            return;
         }
         else
         {

--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -77,6 +77,7 @@ void BlockExecutive::asyncExecute(
             auto message = m_scheduler->m_executionMessageFactory->createExecutionMessage();
             message->setContextID(i + m_startContextID);
             message->setType(protocol::ExecutionMessage::TXHASH);
+            // Note: set here for fetching txs when send_back
             message->setTransactionHash(metaData->hash());
 
             if (metaData->attribute() & bcos::protocol::Transaction::Attribute::LIQUID_SCALE_CODEC)
@@ -136,7 +137,6 @@ void BlockExecutive::asyncExecute(
             auto message = m_scheduler->m_executionMessageFactory->createExecutionMessage();
             message->setType(protocol::ExecutionMessage::MESSAGE);
             message->setContextID(i + m_startContextID);
-            message->setTransactionHash(tx->hash());
             message->setOrigin(toHex(tx->sender()));
             message->setFrom(std::string(message->origin()));
 
@@ -903,6 +903,8 @@ void BlockExecutive::startBatch(std::function<void(Error::UniquePtr)> callback)
             SCHEDULER_LOG(TRACE) << "Send back, " << contextID << " | " << seq << " | "
                                  << message->transactionHash() << LOG_KV("to", message->to());
 
+            // Note: the executiveMessage for synced block should not setTransactionHash to avoid of
+            // duplicated txs-fetching
             if (message->transactionHash() != h256(0))
             {
                 message->setType(protocol::ExecutionMessage::TXHASH);

--- a/bcos-sealer/bcos-sealer/Sealer.cpp
+++ b/bcos-sealer/bcos-sealer/Sealer.cpp
@@ -113,6 +113,11 @@ void Sealer::executeWorker()
 
 void Sealer::submitProposal(bool _containSysTxs, bcos::protocol::Block::Ptr _block)
 {
+    // Note: the block maybe empty
+    if (!_block)
+    {
+        return;
+    }
     if (_block->blockHeader()->number() <= m_sealingManager->currentNumber())
     {
         m_sealingManager->notifyResetProposal(_block);


### PR DESCRIPTION
1. fix coredump for send_back without set the executionResult
2. fix empty _block for submitProposal caused coredump