### PR TITLE
fix viewchange overflow

### DIFF
--- a/bcos-framework/interfaces/consensus/ConsensusTypeDef.h
+++ b/bcos-framework/interfaces/consensus/ConsensusTypeDef.h
@@ -26,5 +26,6 @@ namespace consensus
 {
 using IndexType = uint64_t;
 using ViewType = uint64_t;
+const ViewType MaxView = std::numeric_limits<ViewType>::max() / 2;
 }  // namespace consensus
 }  // namespace bcos

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -499,6 +499,13 @@ void PBFTEngine::executeWorker()
 
 void PBFTEngine::handleMsg(std::shared_ptr<PBFTBaseMessageInterface> _msg)
 {
+    // check the view
+    if (_msg->view() > MaxView)
+    {
+        PBFT_LOG(WARNING) << LOG_DESC("handleMsg: reject msg with invalid view")
+                          << printPBFTMsgInfo(_msg);
+        return;
+    }
     RecursiveGuard l(m_mutex);
     switch (_msg->packetType())
     {


### PR DESCRIPTION
Fix the problem that malicious nodes set the view to int64_t max and cause the view to overflow when the fastViewChange


**try to fix #2312**