### PR TITLE
fix coredump when campaign leader failed

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -1091,6 +1091,7 @@ void PBFTCacheProcessor::removeFutureProposals()
         }
         pcache++;
     }
+    resetUnCommittedCacheState();
 }
 
 void PBFTCacheProcessor::clearExpiredExecutingProposal()
@@ -1225,4 +1226,5 @@ void PBFTCacheProcessor::resetUnCommittedCacheState(bcos::protocol::BlockNumber 
     }
     m_committedProposalList.clear();
     m_executingProposals.clear();
+    m_config->setLowWaterMark(_number);
 }

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.h
@@ -136,7 +136,6 @@ public:
     bool tryToPreApplyProposal(ProposalInterface::Ptr _proposal);
     bool tryToApplyCommitQueue();
 
-    void removeFutureProposals();
     // notify the consensusing proposal index to the sync module
     void notifyCommittedProposalIndex(bcos::protocol::BlockNumber _index);
 

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -1278,11 +1278,6 @@ void PBFTEngine::finalizeConsensus(LedgerConfig::Ptr _ledgerConfig, bool _synced
     m_cacheProcessor->removeConsensusedCache(m_config->view(), _ledgerConfig->blockNumber());
     m_cacheProcessor->tryToCommitStableCheckPoint();
     m_cacheProcessor->resetTimer();
-    if (_syncedBlock)
-    {
-        // Note: should reNotifySealer or not?
-        m_cacheProcessor->removeFutureProposals();
-    }
 }
 
 bool PBFTEngine::handleCheckPointMsg(std::shared_ptr<PBFTMessageInterface> _checkPointMsg)

--- a/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
+++ b/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
@@ -618,7 +618,8 @@ void DownloadingQueue::onCommitFailed(bcos::protocol::Block::Ptr _failedBlock)
         {
             return;
         }
-        std::vector<bcos::protocol::Block::Ptr> tmpBlockCache;
+        // Note: since the applied block will be re-pushed into m_commitQueue again, no-need to
+        // write-back the poped block into commitQueue here
         while (!m_commitQueue.empty())
         {
             auto topBlock = m_commitQueue.top();
@@ -627,14 +628,8 @@ void DownloadingQueue::onCommitFailed(bcos::protocol::Block::Ptr _failedBlock)
                 break;
             }
             rePushedBlockCount++;
-            tmpBlockCache.emplace_back(topBlock);
             m_blocks.push(topBlock);
             m_commitQueue.pop();
-        }
-        // writeBack tmpBlockCache to m_commitQueue
-        for (auto block : tmpBlockCache)
-        {
-            m_commitQueue.push(block);
         }
     }
     BLKSYNC_LOG(INFO) << LOG_DESC("onCommitFailed: update commitQueue and executingQueue")

--- a/libinitializer/PBFTInitializer.cpp
+++ b/libinitializer/PBFTInitializer.cpp
@@ -508,7 +508,10 @@ void PBFTInitializer::initConsensusFailOver(KeyInterface::Ptr _nodeID)
             m_blockSync->enableAsMaster(_success);
             INITIALIZER_LOG(INFO) << LOG_DESC("onCampaignHandler") << LOG_KV("success", _success)
                                   << LOG_KV("leader", _leader ? _leader->memberID() : "None");
-
+            if (!_success)
+            {
+                return;
+            }
             auto schedulerManager =
                 std::dynamic_pointer_cast<bcos::scheduler::SchedulerManager>(m_scheduler);
             schedulerManager->asyncSwitchTerm(_leader->seq(), [_leader](Error::Ptr&& error) {


### PR DESCRIPTION
1. fix coredump when campaign leader failed
2. not re-push the block into the commitQueue when onCommitFailed