### PR TITLE
fix the txs/sealer information of Report are not matching with committedIndex/committedHash

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -1434,6 +1434,13 @@ void PBFTEngine::onReceivePrecommitRequest(
 void PBFTEngine::onStableCheckPointCommitFailed(
     Error::Ptr&& _error, PBFTProposalInterface::Ptr _stableProposal)
 {
+    if (_stableProposal->index() <= m_config->committedProposal()->index())
+    {
+        PBFT_LOG(INFO) << LOG_DESC(
+                              "onStableCheckPointCommitFailed: drop the expired stable proposal")
+                       << m_config->printCurrentState() << printPBFTProposal(_stableProposal);
+        return;
+    }
     if (_error->errorCode() == bcos::scheduler::SchedulerError::BlockIsCommitting)
     {
         PBFT_LOG(WARNING) << LOG_DESC(

--- a/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
@@ -336,6 +336,9 @@ void LedgerStorage::onStableCheckPointCommitted(
 {
     _ledgerConfig->setSealerId(_blockHeader->sealer());
     _ledgerConfig->setTxsSize(_txsSize);
+    // reset the blockNumber
+    _ledgerConfig->setBlockNumber(_blockHeader->number());
+    _ledgerConfig->setHash(_blockHeader->hash());
     // finalize consensus
     if (m_finalizeHandler)
     {

--- a/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
+++ b/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
@@ -537,6 +537,9 @@ void DownloadingQueue::commitBlockState(bcos::protocol::Block::Ptr _block)
             }
             _ledgerConfig->setTxsSize(_block->transactionsSize());
             _ledgerConfig->setSealerId(blockHeader->sealer());
+            // reset the blockNumber
+            _ledgerConfig->setBlockNumber(blockHeader->number());
+            _ledgerConfig->setHash(blockHeader->hash());
             // notify the txpool the transaction result
             // reset the config for the consensus and the blockSync module
             // broadcast the status to all the peers
@@ -553,7 +556,9 @@ void DownloadingQueue::commitBlockState(bcos::protocol::Block::Ptr _block)
                               << LOG_KV(
                                      "executedBlock", downloadingQueue->m_config->executedBlock())
                               << LOG_KV("commitBlockTimeCost", (utcTime() - startT))
-                              << LOG_KV("node", downloadingQueue->m_config->nodeID()->shortHex());
+                              << LOG_KV("node", downloadingQueue->m_config->nodeID()->shortHex())
+                              << LOG_KV("txsSize", _block->transactionsSize())
+                              << LOG_KV("sealer", blockHeader->sealer());
         }
         catch (std::exception const& e)
         {

--- a/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
+++ b/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
@@ -600,6 +600,14 @@ void DownloadingQueue::onCommitFailed(
     bcos::Error::Ptr _error, bcos::protocol::Block::Ptr _failedBlock)
 {
     auto blockHeader = _failedBlock->blockHeader();
+    if (blockHeader->number() <= m_config->blockNumber())
+    {
+        BLKSYNC_LOG(INFO) << LOG_DESC("onCommitFailed: drop the expired block")
+                          << LOG_KV("number", blockHeader->number())
+                          << LOG_KV("hash", blockHeader->hash().abridged())
+                          << LOG_KV("executedBlock", m_config->executedBlock());
+        return;
+    }
     BLKSYNC_LOG(INFO) << LOG_DESC("onCommitFailed") << LOG_KV("number", blockHeader->number())
                       << LOG_KV("hash", blockHeader->hash().abridged())
                       << LOG_KV("executedBlock", m_config->executedBlock());


### PR DESCRIPTION
fix the txs/sealer information of Report are not matching with committedIndex/committedHash when multiple blocks committing continuously