### PR TITLE
fix the node whose view falling behind can't cache up with the latest view for checkPrecommitMsg failed

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -730,7 +730,7 @@ ViewType PBFTCacheProcessor::tryToTriggerFastViewChange()
 bool PBFTCacheProcessor::checkPrecommitMsg(PBFTMessageInterface::Ptr _precommitMsg)
 {
     // check the view(the first started node no need to check the view)
-    if (m_config->startRecovered() && (_precommitMsg->view() > m_config->view()))
+    if (m_config->startRecovered() && (_precommitMsg->view() > m_config->toView()))
     {
         return false;
     }

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -1101,6 +1101,13 @@ bool PBFTEngine::isValidViewChangeMsg(bcos::crypto::NodeIDPtr _fromNode,
     // check the precommmitted proposals
     for (auto precommitMsg : _viewChangeMsg->preparedProposals())
     {
+        if (precommitMsg->view() > _viewChangeMsg->view())
+        {
+            PBFT_LOG(INFO) << LOG_DESC("InvalidViewChangeReq for invalid view")
+                           << printPBFTMsgInfo(precommitMsg) << printPBFTMsgInfo(_viewChangeMsg)
+                           << m_config->printCurrentState();
+            return false;
+        }
         if (!m_cacheProcessor->checkPrecommitMsg(precommitMsg))
         {
             PBFT_LOG(INFO) << LOG_DESC("InvalidViewChangeReq for invalid proposal")


### PR DESCRIPTION
fix the node whose view falling behind can't cache up with the latest view for checkPrecommitMsg failed