### PR TITLE
reject message from the outside-group 

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -995,9 +995,13 @@ void PBFTCacheProcessor::tryToCommitStableCheckPoint()
 bool PBFTCacheProcessor::shouldRequestCheckPoint(PBFTMessageInterface::Ptr _checkPointMsg)
 {
     auto checkPointIndex = _checkPointMsg->index();
+    auto committedIndex = m_config->committedProposal()->index();
     // expired checkpoint
-    if (checkPointIndex <= m_config->committedProposal()->index() ||
-        checkPointIndex <= m_config->syncingHighestNumber())
+    if (checkPointIndex <= committedIndex || checkPointIndex <= m_config->syncingHighestNumber())
+    {
+        return false;
+    }
+    if (checkPointIndex > (committedIndex + m_config->waterMarkLimit()))
     {
         return false;
     }

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -95,6 +95,11 @@ void TransactionSync::onRecvSyncMessage(
                               << LOG_KV("errorMsg", _error->errorMessage());
             return;
         }
+        // reject the message from the outside-group
+        if (!m_config->existsInGroup(_nodeID))
+        {
+            return;
+        }
         auto txsSyncMsg = m_config->msgFactory()->createTxsSyncMsg(_data);
         // receive transactions
         if (txsSyncMsg->type() == TxsSyncPacketType::TxsPacket)
@@ -726,7 +731,7 @@ void TransactionSync::onPeerTxsStatus(NodeIDPtr _fromNode, TxsSyncMsgInterface::
     {
         return;
     }
-    requestMissedTxs(_fromNode, requestTxs, nullptr, nullptr);
+    requestMissedTxsFromPeer(_fromNode, requestTxs, nullptr, nullptr);
     SYNC_LOG(DEBUG) << LOG_DESC("onPeerTxsStatus") << LOG_KV("reqSize", requestTxs->size())
                     << LOG_KV("peerTxsSize", _txsStatus->txsHash().size())
                     << LOG_KV("peer", _fromNode->shortHex());

--- a/bcos-txpool/test/unittests/txpool/TxsSyncTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/TxsSyncTest.cpp
@@ -84,6 +84,8 @@ void testTransactionSync(bool _onlyTxsStatus = false)
     // append sessions
     size_t sessionSize = 8;
     std::vector<TxPoolFixture::Ptr> txpoolPeerList;
+    std::vector<NodeIDPtr> sessionNodeIDs;
+    sessionNodeIDs.emplace_back(keyPair->publicKey());
     for (size_t i = 0; i < sessionSize; i++)
     {
         auto nodeId = signatureImpl->generateKeyPair()->publicKey();
@@ -94,10 +96,17 @@ void testTransactionSync(bool _onlyTxsStatus = false)
         {
             sessionFaker->resetToFakeTransactionSync();
         }
+        sessionNodeIDs.emplace_back(nodeId);
         faker->appendSealer(nodeId);
-        // make sure the session in the group
-        sessionFaker->appendSealer(nodeId);
         txpoolPeerList.push_back(sessionFaker);
+    }
+    for (auto& sessionFaker : txpoolPeerList)
+    {
+        for (auto const& nodeID : sessionNodeIDs)
+        {
+            // make sure the session in the group
+            sessionFaker->appendSealer(nodeID);
+        }
     }
     size_t txsNum = 10;
     importTransactions(txsNum, cryptoSuite, faker);


### PR DESCRIPTION
1.  not request the checkPoint far-higher than the committedIndex
2. reject message from the outside-group && not access db when txs-missed
