### PR TITLE
Add contract binary table, and only one copy of the contract binary file is stored. 

### DIFF
--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -637,7 +637,6 @@ CallParameters::UniquePtr TransactionExecutive::go(
             }
 
             assert(extraData != nullptr);
-            hostContext.setCodeAndAbi(outputRef.toBytes(), extraData->abi);
             if (!blockContext->isWasm())
             {
                 if (outputRef.empty())
@@ -655,8 +654,8 @@ CallParameters::UniquePtr TransactionExecutive::go(
                     revert();
                     return callResults;
                 }
-                hostContext.setCode(outputRef.toBytes());
             }
+            hostContext.setCodeAndAbi(outputRef.toBytes(), extraData->abi, blockContext->blockVersion());
 
             callResults->gas -= outputRef.size() * hostContext.vmSchedule().createDataGas;
             callResults->newEVMContractAddress = callResults->codeAddress;
@@ -671,7 +670,7 @@ CallParameters::UniquePtr TransactionExecutive::go(
         }
         else
         {
-            auto codeEntry = hostContext.code();
+            auto codeEntry = hostContext.code(blockContext->blockVersion());
             if (!codeEntry.has_value())
             {
                 revert();

--- a/bcos-executor/src/vm/EVMHostInterface.cpp
+++ b/bcos-executor/src/vm/EVMHostInterface.cpp
@@ -26,6 +26,7 @@
 #include "EVMHostInterface.h"
 #include "../Common.h"
 #include "HostContext.h"
+#include "bcos-framework/bcos-framework/protocol/Protocol.h"
 #include <bcos-utilities/Common.h>
 #include <evmc/evmc.h>
 #include <boost/algorithm/hex.hpp>
@@ -137,6 +138,12 @@ size_t copyCode(evmc_host_context* _context, const evmc_address*, size_t, uint8_
 {
     auto& hostContext = static_cast<HostContext&>(*_context);
 
+    if(hostContext.blockVersion() >= uint32_t(bcos::protocol::Version::V3_0_VERSION))
+    {
+        hostContext.setCodeNewVersion(bytes((bcos::byte*)_bufferData, (bcos::byte*)_bufferData + _bufferSize));
+        return _bufferSize;
+    }
+    
     hostContext.setCode(bytes((bcos::byte*)_bufferData, (bcos::byte*)_bufferData + _bufferSize));
     return _bufferSize;
     // auto addr = fromEvmC(*_addr);

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -23,6 +23,8 @@
 #include "../Common.h"
 #include "../executive/TransactionExecutive.h"
 #include "EVMHostInterface.h"
+#include "bcos-framework/bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/bcos-framework/protocol/Protocol.h"
 #include "bcos-framework/storage/Table.h"
 #include "bcos-table/src/StateStorage.h"
 #include "evmc/evmc.hpp"
@@ -299,6 +301,52 @@ void HostContext::setCodeAndAbi(bytes code, string abi)
     }
 }
 
+bool HostContext::setCodeNewVersion(bytes code)
+{
+    auto contractTable = m_executive->storage().openTable(m_tableName);
+    Entry codeHashEntry;
+    auto codeHash = hashImpl()->hash(code);
+    if (contractTable)
+    {
+        codeHashEntry.importFields({codeHash.asBytes()});
+        m_executive->storage().setRow(m_tableName, ACCOUNT_CODE_HASH, std::move(codeHashEntry));
+    }
+    auto codeTable = m_executive->storage().openTable(bcos::ledger::SYS_CODE_BINARY);
+    if (codeTable)
+    {
+        if (m_executive->storage().getRow(bcos::ledger::SYS_CODE_BINARY, codeHash.hex()))
+        {
+            return true;
+        }
+        Entry codeEntry;
+        codeEntry.importFields({std::move(code)});
+        m_executive->storage().setRow(
+            bcos::ledger::SYS_CODE_BINARY, codeHash.hex(), std::move(codeEntry));
+        return true;
+    }
+    EXECUTOR_LOG(INFO) << LOG_DESC("SYS_CODE_BINARY is not existed");
+    return false;
+}
+
+void HostContext::setCodeAndAbi(bytes code, string abi, uint32_t blockVersion)
+{
+    EXECUTOR_LOG(TRACE) << LOG_DESC("save code and abi") << LOG_KV("tableName", m_tableName)
+                        << LOG_KV("codeSize", code.size()) << LOG_KV("abiSize", abi.size());
+    // blockVersion is 0x03000000 in FISCO Version V3.0.0
+    if (blockVersion >= uint32_t(bcos::protocol::Version::V3_0_VERSION))
+    {
+        if (setCodeNewVersion(std::move(code)))
+        {
+            Entry abiEntry;
+            abiEntry.importFields({std::move(abi)});
+            m_executive->storage().setRow(m_tableName, ACCOUNT_ABI, abiEntry);
+        }
+        return;
+    }
+    setCodeAndAbi(code, abi);
+    return;
+}
+
 size_t HostContext::codeSizeAt(const std::string_view& _a)
 {
     (void)_a;
@@ -394,6 +442,10 @@ int64_t HostContext::blockNumber() const
 {
     return m_executive->blockContext().lock()->number();
 }
+uint32_t HostContext::blockVersion() const
+{
+    return m_executive->blockContext().lock()->blockVersion();
+}
 int64_t HostContext::timestamp() const
 {
     return m_executive->blockContext().lock()->timestamp();
@@ -412,16 +464,27 @@ std::optional<storage::Entry> HostContext::code()
     return entry;
 }
 
+std::optional<storage::Entry> HostContext::code(uint32_t blockVersion)
+{
+    if (blockVersion >= uint32_t(bcos::protocol::Version::V3_0_VERSION))
+    {
+        auto codehash = codeHash();
+        auto start = utcTimeUs();
+        auto entry = m_executive->storage().getRow(bcos::ledger::SYS_CODE_BINARY, codehash.hex());
+        m_getTimeUsed.fetch_add(utcTimeUs() - start);
+        return entry;
+    }
+    return code();
+}
+
 h256 HostContext::codeHash()
 {
     auto entry = m_executive->storage().getRow(m_tableName, ACCOUNT_CODE_HASH);
     if (entry)
     {
-        auto code = entry->getField(0);
-
-        return h256(std::string(code));  // TODO: h256 support decode from string_view
+        auto codehash = entry->getField(0);
+        return h256(codehash, FixedBytes<32>::StringDataType::FromBinary);  // TODO: h256 support decode from string_view
     }
-
     return h256();
 }
 

--- a/bcos-executor/src/vm/HostContext.h
+++ b/bcos-executor/src/vm/HostContext.h
@@ -95,6 +95,10 @@ public:
 
     void setCodeAndAbi(bytes code, std::string abi);
 
+    bool setCodeNewVersion(bytes code);
+
+    void setCodeAndAbi(bytes code, std::string abi, uint32_t blockVersion);
+
     size_t codeSizeAt(const std::string_view& _a);
 
     h256 codeHashAt(const std::string_view& _a);
@@ -108,6 +112,7 @@ public:
     /// Hash of a block if within the last 256 blocks, or h256() otherwise.
     h256 blockHash() const;
     int64_t blockNumber() const;
+    uint32_t blockVersion() const;
     int64_t timestamp() const;
     int64_t blockGasLimit() const
     {
@@ -126,6 +131,7 @@ public:
     std::string_view codeAddress() const { return m_callParameters->codeAddress; }
     bytesConstRef data() const { return ref(m_callParameters->data); }
     std::optional<storage::Entry> code();
+    std::optional<storage::Entry> code(uint32_t blockVersion);
     bool isCodeHasPrefix(std::string_view _prefix) const;
     h256 codeHash();
     u256 salt() const { return m_salt; }
@@ -152,7 +158,6 @@ private:
     CallParameters::UniquePtr m_callParameters;
     std::shared_ptr<TransactionExecutive> m_executive;
     std::string m_tableName;
-
     u256 m_salt;     ///< Values used in new address construction by CREATE2
     SubState m_sub;  ///< Sub-band VM state (suicides, refund counter, logs).
 

--- a/bcos-framework/bcos-framework/ledger/LedgerTypeDef.h
+++ b/bcos-framework/bcos-framework/ledger/LedgerTypeDef.h
@@ -68,4 +68,5 @@ constexpr static std::string_view SYS_HASH_2_TX{"s_hash_2_tx"};
 constexpr static std::string_view SYS_HASH_2_RECEIPT{"s_hash_2_receipt"};
 constexpr static std::string_view DAG_TRANSFER{"/tables/dag_transfer"};
 constexpr static std::string_view SMALLBANK_TRANSFER{"/tables/smallbank_transfer"};
+constexpr static std::string_view SYS_CODE_BINARY{"s_code_binary"};
 }  // namespace bcos::ledger

--- a/bcos-framework/bcos-framework/protocol/Protocol.h
+++ b/bcos-framework/bcos-framework/protocol/Protocol.h
@@ -95,6 +95,7 @@ enum ProtocolVersion : uint32_t
 enum class Version : uint32_t
 {
     V3_0_VERSION = 0x03000000,
+    V3_1_VERSION = 0x03000001,
     RC4_VERSION = 4,
     MIN_VERSION = RC4_VERSION,
     MAX_VERSION = V3_0_VERSION,


### PR DESCRIPTION
Add contract binary table, and only one copy of the contract binary file is stored. 