### PR TITLE
not trigger reach-new-view when the node already been recovered

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -1111,12 +1111,18 @@ bool PBFTCacheProcessor::checkAndTryToRecover()
     {
         return false;
     }
+    // the node has already been recovered
+    if (!m_config->timeout())
+    {
+        return false;
+    }
     m_config->resetNewViewState(recoveredView);
     resetCacheAfterViewChange(recoveredView, m_config->committedProposal()->index());
     // clear the recoverReqCache
     m_recoverReqCache.clear();
     m_recoverCacheWeight.clear();
     // try to preCommit/commit after no-timeout
+    // Note: the checkAndPreCommit and checkAndCommit will trigger fast-view-change
     checkAndPreCommit();
     checkAndCommit();
     PBFT_LOG(INFO) << LOG_DESC("checkAndTryToRecoverView: reachNewView")

--- a/bcos-pbft/bcos-pbft/pbft/config/PBFTConfig.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/config/PBFTConfig.cpp
@@ -19,8 +19,8 @@
  * @date 2021-04-12
  */
 #include "PBFTConfig.h"
-#include "bcos-txpool/sync/protocol/PB/TxsSyncMsgFactoryImpl.h"
 #include "bcos-txpool/sync/interfaces/TxsSyncMsgFactory.h"
+#include "bcos-txpool/sync/protocol/PB/TxsSyncMsgFactoryImpl.h"
 #include "bcos-txpool/sync/utilities/Common.h"
 
 using namespace bcos;


### PR DESCRIPTION
not trigger reach-new-view when the node already been recovered   
 (in the bug case: chechAndPreCommit/checkAndCommit will trigger
     fast-view-change for the leader looply)