### PR TITLE
bugfix-3.2.0-p2pidcompatiable

### DIFF
--- a/bcos-framework/bcos-framework/gateway/GatewayTypeDef.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayTypeDef.h
@@ -106,6 +106,7 @@ struct P2PInfo
     P2PInfo() = default;
     ~P2PInfo() {}
     std::string p2pID;
+    std::string p2pIDWithoutExtInfo;
     std::string agencyName;
     std::string nodeName;
     NodeIPEndpoint nodeIPEndpoint;

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -144,6 +144,29 @@ void GatewayFactory::initCert2PubHexHandler()
 void GatewayFactory::initSSLContextPubHexHandler()
 {
     auto handler = [](X509* x509, std::string& _pubHex) -> bool {
+        ASN1_BIT_STRING* pubKey =
+            X509_get0_pubkey_bitstr(x509);  // csc->current_cert is an X509 struct
+        if (pubKey == NULL)
+        {
+            GATEWAY_FACTORY_LOG(ERROR)
+                << LOG_DESC("initSSLContextPubHexHandler X509_get0_pubkey_bitstr error");
+            return false;
+        }
+
+        auto hex = bcos::toHexString(pubKey->data, pubKey->data + pubKey->length, "");
+        _pubHex = *hex.get();
+
+        GATEWAY_FACTORY_LOG(INFO) << LOG_DESC("[NEW]SSLContext pubHex: " + _pubHex);
+        return true;
+    };
+
+    m_sslContextPubHandler = handler;
+}
+
+// register the function fetch public key from the ssl context
+void GatewayFactory::initSSLContextPubHexHandlerWithoutExtInfo()
+{
+    auto handler = [](X509* x509, std::string& _pubHex) -> bool {
         EVP_PKEY* pKey = X509_get_pubkey(x509);
         if (nullptr == pKey)
         {
@@ -222,7 +245,7 @@ void GatewayFactory::initSSLContextPubHexHandler()
         return true;
     };
 
-    m_sslContextPubHandler = handler;
+    m_sslContextPubHandlerWithoutExtInfo = handler;
 }
 
 std::shared_ptr<boost::asio::ssl::context> GatewayFactory::buildSSLContext(
@@ -587,6 +610,7 @@ std::shared_ptr<Gateway> GatewayFactory::buildGateway(GatewayConfig::Ptr _config
         host->setHostPort(_config->listenIP(), _config->listenPort());
         host->setThreadPool(std::make_shared<ThreadPool>("P2P", _config->threadPoolSize()));
         host->setSSLContextPubHandler(m_sslContextPubHandler);
+        host->setSSLContextPubHandlerWithoutExtInfo(m_sslContextPubHandlerWithoutExtInfo);
         host->setPeerBlacklist(peerBlacklist);
         host->setPeerWhitelist(peerWhitelist);
         host->setSessionCallbackManager(sessionCallbackManager);

--- a/bcos-gateway/bcos-gateway/GatewayFactory.h
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.h
@@ -29,7 +29,9 @@ public:
         bcos::security::DataEncryptInterface::Ptr _dataEncrypt = nullptr)
       : m_chainID(_chainID), m_rpcServiceName(_rpcServiceName), m_dataEncrypt(_dataEncrypt)
     {
+        // For compatibility, p2p communication between nodes still uses the old public key analysis method
         initSSLContextPubHexHandler();
+        // the new old public key analysis method is used for black white list
         initSSLContextPubHexHandlerWithoutExtInfo();
         initCert2PubHexHandler();
     }
@@ -37,6 +39,8 @@ public:
     virtual ~GatewayFactory() = default;
 
     // init the function calc public key from the ssl context
+    // in this way, the public key will be parsed in front of a string of prefixes: 3082010a02820101
+    // and suffixes: 0203010001 for rsa certificate
     void initSSLContextPubHexHandler();
     // init the function calc public key from the ssl context
     void initSSLContextPubHexHandlerWithoutExtInfo();

--- a/bcos-gateway/bcos-gateway/GatewayFactory.h
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.h
@@ -30,19 +30,27 @@ public:
       : m_chainID(_chainID), m_rpcServiceName(_rpcServiceName), m_dataEncrypt(_dataEncrypt)
     {
         initSSLContextPubHexHandler();
+        initSSLContextPubHexHandlerWithoutExtInfo();
         initCert2PubHexHandler();
     }
 
     virtual ~GatewayFactory() = default;
 
-    // init the function calc public hex from the cert
-    void initCert2PubHexHandler();
     // init the function calc public key from the ssl context
     void initSSLContextPubHexHandler();
+    // init the function calc public key from the ssl context
+    void initSSLContextPubHexHandlerWithoutExtInfo();
+    // init the function calc public hex from the cert
+    void initCert2PubHexHandler();
 
     std::function<bool(X509* cert, std::string& pubHex)> sslContextPubHandler()
     {
         return m_sslContextPubHandler;
+    }
+
+    std::function<bool(X509* cert, std::string& pubHex)> sslContextPubHandlerWithoutExtInfo()
+    {
+        return m_sslContextPubHandlerWithoutExtInfo;
     }
 
     std::function<bool(const std::string& priKey, std::string& pubHex)> certPubHexHandler()
@@ -115,6 +123,7 @@ protected:
 
 private:
     std::function<bool(X509* cert, std::string& pubHex)> m_sslContextPubHandler;
+    std::function<bool(X509* cert, std::string& pubHex)> m_sslContextPubHandlerWithoutExtInfo;
 
     std::function<bool(const std::string& priKey, std::string& pubHex)> m_certPubHexHandler;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -126,6 +126,7 @@ std::function<bool(bool, boost::asio::ssl::verify_context&)> Host::newVerifyCall
                 return preverified;
             }
 
+            // For compatibility, p2p communication between nodes still uses the old public key analysis method
             if (!hostPtr->sslContextPubHandler()(cert, *nodeIDOut))
             {
                 return preverified;
@@ -151,6 +152,7 @@ std::function<bool(bool, boost::asio::ssl::verify_context&)> Host::newVerifyCall
 
             BASIC_CONSTRAINTS_free(basic);
 
+            // The new public key analysis method is used for black and white lists
             std::string nodeIDOutWithoutExtInfo;
             if (!hostPtr->sslContextPubHandlerWithoutExtInfo()(cert, nodeIDOutWithoutExtInfo))
             {

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -151,23 +151,28 @@ std::function<bool(bool, boost::asio::ssl::verify_context&)> Host::newVerifyCall
 
             BASIC_CONSTRAINTS_free(basic);
 
-            std::string nodeID = boost::to_upper_copy(*nodeIDOut);
+            std::string nodeIDOutWithoutExtInfo;
+            if (!hostPtr->sslContextPubHandlerWithoutExtInfo()(cert, nodeIDOutWithoutExtInfo))
+            {
+                return preverified;
+            }
+            nodeIDOutWithoutExtInfo = boost::to_upper_copy(nodeIDOutWithoutExtInfo);
 
             // If the node ID exists in the black and white lists at the same time, the black list
             // takes precedence
             if (nullptr != hostPtr->peerBlacklist() &&
-                true == hostPtr->peerBlacklist()->has(nodeID))
+                true == hostPtr->peerBlacklist()->has(nodeIDOutWithoutExtInfo))
             {
                 HOST_LOG(INFO) << LOG_DESC("NodeID in certificate blacklist")
-                               << LOG_KV("nodeID", NodeID(nodeID).abridged());
+                               << LOG_KV("nodeID", NodeID(nodeIDOutWithoutExtInfo).abridged());
                 return false;
             }
 
             if (nullptr != hostPtr->peerWhitelist() &&
-                false == hostPtr->peerWhitelist()->has(nodeID))
+                false == hostPtr->peerWhitelist()->has(nodeIDOutWithoutExtInfo))
             {
                 HOST_LOG(INFO) << LOG_DESC("NodeID is not in certificate whitelist")
-                               << LOG_KV("nodeID", NodeID(nodeID).abridged());
+                               << LOG_KV("nodeID", NodeID(nodeIDOutWithoutExtInfo).abridged());
                 return false;
             }
 
@@ -177,6 +182,8 @@ std::function<bool(bool, boost::asio::ssl::verify_context&)> Host::newVerifyCall
             /// get issuer name
             const char* issuerName = X509_NAME_oneline(X509_get_issuer_name(cert), NULL, 0);
             /// format: {nodeID}#{issuer-name}#{cert-name}
+            nodeIDOut->append("#");
+            nodeIDOut->append(nodeIDOutWithoutExtInfo);
             nodeIDOut->append("#");
             nodeIDOut->append(issuerName);
             nodeIDOut->append("#");
@@ -219,6 +226,14 @@ P2PInfo Host::p2pInfo()
                 m_p2pInfo.p2pID = boost::to_upper_copy(nodeIDOut);
                 HOST_LOG(INFO) << LOG_DESC("Get node information from cert")
                                << LOG_KV("p2pid", m_p2pInfo.p2pID);
+            }
+
+            std::string nodeIDOutWithoutExtInfo;
+            if (m_sslContextPubHandlerWithoutExtInfo(cert, nodeIDOutWithoutExtInfo))
+            {
+                m_p2pInfo.p2pIDWithoutExtInfo = boost::to_upper_copy(nodeIDOutWithoutExtInfo);
+                HOST_LOG(INFO) << LOG_DESC("Get node information without ext info from cert")
+                               << LOG_KV("p2pid without ext info", m_p2pInfo.p2pIDWithoutExtInfo);
             }
 
             /// fill in the node informations
@@ -280,11 +295,15 @@ void Host::obtainNodeInfo(P2PInfo& info, std::string const& node_info)
     }
     if (node_info_vec.size() > 1)
     {
-        info.agencyName = obtainCommonNameFromSubject(node_info_vec[1]);
+        info.p2pIDWithoutExtInfo = node_info_vec[1];
     }
     if (node_info_vec.size() > 2)
     {
-        info.nodeName = obtainCommonNameFromSubject(node_info_vec[2]);
+        info.agencyName = obtainCommonNameFromSubject(node_info_vec[2]);
+    }
+    if (node_info_vec.size() > 3)
+    {
+        info.nodeName = obtainCommonNameFromSubject(node_info_vec[3]);
     }
 
     HOST_LOG(INFO) << "obtainP2pInfo " << LOG_KV("node_info", node_info)

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -98,6 +98,18 @@ public:
         m_sslContextPubHandler = _sslContextPubHandler;
     }
 
+    virtual std::function<bool(X509* x509, std::string& pubHex)>
+    sslContextPubHandlerWithoutExtInfo()
+    {
+        return m_sslContextPubHandlerWithoutExtInfo;
+    }
+
+    virtual void setSSLContextPubHandlerWithoutExtInfo(
+        std::function<bool(X509* x509, std::string& pubHex)> _sslContextPubHandlerWithoutExtInfo)
+    {
+        m_sslContextPubHandlerWithoutExtInfo = _sslContextPubHandlerWithoutExtInfo;
+    }
+
     virtual std::shared_ptr<bcos::ThreadPool> threadPool() const { return m_threadPool; }
     virtual void setThreadPool(std::shared_ptr<bcos::ThreadPool> threadPool)
     {
@@ -192,6 +204,7 @@ private:
 
     // get the hex public key of the peer from the the SSL connection
     std::function<bool(X509* x509, std::string& pubHex)> m_sslContextPubHandler;
+    std::function<bool(X509* x509, std::string& pubHex)> m_sslContextPubHandlerWithoutExtInfo;
 
     bool m_run = false;
 

--- a/bcos-gateway/test/unittests/GatewayFactoryTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayFactoryTest.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(test_certPubHexHandler)
         auto r = factory->certPubHexHandler()(cert, pubHex);
         BOOST_CHECK(r);
         BOOST_CHECK_EQUAL(boost::to_lower_copy(pubHex),
-            R"(5a0d065954bbc96dba0e9eea163d970a9187c3e5f1a6329daf2898acb888ac2d668f4e3b34b538dcd1be7839d86a0869ca6478913cfd4e46c1517586f9c0b3c0)");
+            R"(045a0d065954bbc96dba0e9eea163d970a9187c3e5f1a6329daf2898acb888ac2d668f4e3b34b538dcd1be7839d86a0869ca6478913cfd4e46c1517586f9c0b3c0)");
     }
 
     {


### PR DESCRIPTION
Solve the problem that the new SSL public key parsing method is incompatible with 3.1.0 and the node network cannot be connected