### PR TITLE
<fix> fix bug that nodes start failed with binary file which version …

### DIFF
--- a/cmake/ProjectSDF.cmake
+++ b/cmake/ProjectSDF.cmake
@@ -7,7 +7,7 @@ set(SDF_LIB_NAME "libsdf-crypto.a")
 ExternalProject_Add(libsdf
     PREFIX ${CMAKE_SOURCE_DIR}/deps
     GIT_REPOSITORY https://${URL_BASE}/WeBankBlockchain/hsm-crypto.git
-    GIT_TAG        0ec6b68c262fcdc49520bafb9544790625dfa7f5
+    GIT_TAG        b8a1f5e27cf87028d35f9c1ee80be535b312fa00
     CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
     BUILD_IN_SOURCE true
     LOG_CONFIGURE 1


### PR DESCRIPTION
…is release

<fix>(precompiled): fix descWithKeyOrder bug when table doesnt exist. (#3311)