### PR TITLE
Add mutable fork() for multilayer storage to avoid conflicit write

### DIFF
--- a/bcos-crypto/bcos-crypto/merkle/Merkle.h
+++ b/bcos-crypto/bcos-crypto/merkle/Merkle.h
@@ -93,7 +93,6 @@ public:
 
         std::vector<HashType> merkle;
         generateMerkle(originHashes, merkle);
-
         generateMerkleProof(
             originHashes, merkle, RANGES::distance(RANGES::begin(originHashes), it), out);
     }
@@ -107,7 +106,6 @@ public:
         {
             BOOST_THROW_EXCEPTION(std::invalid_argument{"Not found hash!"});
         }
-
         generateMerkleProof(
             originHashes, merkle, RANGES::distance(RANGES::begin(originHashes), it), out);
     }

--- a/transaction-scheduler/bcos-transaction-scheduler/MultiLayerStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/MultiLayerStorage.h
@@ -6,7 +6,6 @@
 #include <boost/container/small_vector.hpp>
 #include <boost/throw_exception.hpp>
 #include <iterator>
-#include <range/v3/algorithm/set_algorithm.hpp>
 #include <stdexcept>
 #include <type_traits>
 #include <variant>
@@ -35,8 +34,8 @@ private:
     static_assert(std::same_as<typename MutableStorageType::Value, typename BackendStorage::Value>);
 
     std::shared_ptr<MutableStorageType> m_mutableStorage;
-    std::list<std::shared_ptr<MutableStorageType>> m_immutableStorages;  // Ledger read data from
-                                                                         // here
+    std::deque<std::shared_ptr<MutableStorageType>> m_immutableStorages;  // Ledger read data from
+                                                                          // here
     BackendStorage& m_backendStorage;
     [[no_unique_address]] std::conditional_t<withCacheStorage,
         std::add_lvalue_reference_t<CachedStorage>, std::monostate>
@@ -45,69 +44,239 @@ private:
     std::mutex m_listMutex;
     std::mutex m_mergeMutex;
 
-    auto readStorage(
-        RANGES::input_range auto const& keys, RANGES::input_range auto& values, auto& storage)
-        -> task::Task<
-            boost::container::small_vector<std::tuple<const RANGES::range_value_t<decltype(keys)>*,
-                                               RANGES::range_value_t<decltype(values)>*>,
-                1>>
-    {
-        boost::container::small_vector<std::tuple<const RANGES::range_value_t<decltype(keys)>*,
-                                           RANGES::range_value_t<decltype(values)>*>,
-            1>
-            missings;
-
-        auto keyIt = RANGES::begin(keys);
-        auto valueIt = RANGES::begin(values);
-        auto it = co_await storage.read(keys);
-        while (co_await it.next())
-        {
-            if (co_await it.hasValue())
-            {
-                (*valueIt).emplace(co_await it.value());
-            }
-            else
-            {
-                missings.emplace_back(
-                    std::make_tuple(std::addressof(*keyIt), std::addressof(*valueIt)));
-            }
-            RANGES::advance(keyIt, 1);
-            RANGES::advance(valueIt, 1);
-        }
-        co_return missings;
-    }
-
 public:
     using MutableStorage = MutableStorageType;
 
-    class ReadIterator
+    class View
     {
         friend class MultiLayerStorage;
 
     private:
-        boost::container::small_vector<KeyType, 1> m_keys;
-        boost::container::small_vector<std::optional<ValueType>, 1> m_values;
-        int64_t m_index = -1;
+        std::shared_ptr<MutableStorageType> m_mutableStorage;
+        std::deque<std::shared_ptr<MutableStorageType>> m_immutableStorages;
+        BackendStorage& m_backendStorage;
+        [[no_unique_address]] std::conditional_t<withCacheStorage,
+            std::add_lvalue_reference_t<CachedStorage>, std::monostate>
+            m_cacheStorage;
+
+        class ReadIterator
+        {
+            friend class View;
+
+        private:
+            boost::container::small_vector<KeyType, 1> m_keys;
+            boost::container::small_vector<std::optional<ValueType>, 1> m_values;
+            int64_t m_index = -1;
+
+        public:
+            using Key = std::remove_cvref_t<typename MultiLayerStorage::KeyType> const&;
+            using Value = std::remove_cvref_t<typename MultiLayerStorage::ValueType> const&;
+
+            ReadIterator() = default;
+
+            ReadIterator(const ReadIterator&) = delete;
+            ReadIterator(ReadIterator&& rhs) noexcept = default;
+            ReadIterator& operator=(const ReadIterator&) = delete;
+            ReadIterator& operator=(ReadIterator&&) noexcept = default;
+            ~ReadIterator() noexcept = default;
+
+            task::AwaitableValue<bool> next()
+            {
+                return {static_cast<size_t>(++m_index) != m_values.size()};
+            }
+            task::AwaitableValue<Key> key() const { return {m_keys[m_index]}; }
+            task::AwaitableValue<Value> value() const { return {*(m_values[m_index])}; }
+            task::AwaitableValue<bool> hasValue() const { return {m_values[m_index].has_value()}; }
+        };
+
+        auto readStorage(
+            RANGES::input_range auto const& keys, RANGES::input_range auto& values, auto& storage)
+            -> task::Task<boost::container::small_vector<
+                std::tuple<const RANGES::range_value_t<decltype(keys)>*,
+                    RANGES::range_value_t<decltype(values)>*>,
+                1>>
+        {
+            boost::container::small_vector<std::tuple<const RANGES::range_value_t<decltype(keys)>*,
+                                               RANGES::range_value_t<decltype(values)>*>,
+                1>
+                missings;
+
+            auto keyIt = RANGES::begin(keys);
+            auto valueIt = RANGES::begin(values);
+            auto it = co_await storage.read(keys);
+            while (co_await it.next())
+            {
+                if (co_await it.hasValue())
+                {
+                    (*valueIt).emplace(co_await it.value());
+                }
+                else
+                {
+                    missings.emplace_back(
+                        std::make_tuple(std::addressof(*keyIt), std::addressof(*valueIt)));
+                }
+                RANGES::advance(keyIt, 1);
+                RANGES::advance(valueIt, 1);
+            }
+            co_return missings;
+        }
 
     public:
-        using Key = std::remove_cvref_t<typename MultiLayerStorage::KeyType> const&;
-        using Value = std::remove_cvref_t<typename MultiLayerStorage::ValueType> const&;
+        using Key = KeyType;
+        using Value = ValueType;
 
-        ReadIterator() = default;
+        View(BackendStorage& backendStorage) requires(!withCacheStorage)
+          : m_backendStorage(backendStorage)
+        {}
+        View(BackendStorage& backendStorage,
+            std::conditional_t<withCacheStorage, std::add_lvalue_reference_t<CachedStorage>,
+                std::monostate>
+                cacheStorage) requires(withCacheStorage)
+          : m_backendStorage(backendStorage), m_cacheStorage(cacheStorage)
+        {}
 
-        ReadIterator(const ReadIterator&) = delete;
-        ReadIterator(ReadIterator&& rhs) noexcept = default;
-        ReadIterator& operator=(const ReadIterator&) = delete;
-        ReadIterator& operator=(ReadIterator&&) noexcept = default;
-        ~ReadIterator() noexcept = default;
-
-        task::AwaitableValue<bool> next()
+        template <class... Args>
+        void newTemporaryMutable(Args... args)
         {
-            return {static_cast<size_t>(++m_index) != m_values.size()};
+            if (m_mutableStorage)
+            {
+                BOOST_THROW_EXCEPTION(DuplicateMutableStorageError{});
+            }
+
+            m_mutableStorage = std::make_shared<MutableStorageType>(args...);
         }
-        task::AwaitableValue<Key> key() const { return {m_keys[m_index]}; }
-        task::AwaitableValue<Value> value() const { return {*(m_values[m_index])}; }
-        task::AwaitableValue<bool> hasValue() const { return {m_values[m_index].has_value()}; }
+
+        task::Task<ReadIterator> read(RANGES::input_range auto const& keys)
+        {
+            ReadIterator iterator;
+            iterator.m_keys = keys | RANGES::to<decltype(iterator.m_keys)>();
+            iterator.m_values.resize(RANGES::size(iterator.m_keys));
+            auto const& myKeys = iterator.m_keys;
+            auto& myValues = iterator.m_values;
+
+            boost::container::small_vector<
+                std::tuple<const RANGES::range_value_t<decltype(myKeys)>*,
+                    RANGES::range_value_t<decltype(myValues)>*>,
+                1>
+                missing;
+
+            bool started = false;
+            if (m_mutableStorage)
+            {
+                started = true;
+                missing = co_await readStorage(myKeys, myValues, *m_mutableStorage);
+                if (RANGES::empty(missing))
+                {
+                    co_return iterator;
+                }
+            }
+
+            if (!RANGES::empty(m_immutableStorages))
+            {
+                for (auto& immutableStorage : m_immutableStorages)
+                {
+                    if (!started)
+                    {
+                        started = true;
+                        missing = co_await readStorage(myKeys, myValues, *immutableStorage);
+                    }
+                    else
+                    {
+                        auto keysView = missing | RANGES::views::transform([
+                        ](auto& tuple) -> auto const& { return *std::get<0>(tuple); });
+                        auto valuesView = missing | RANGES::views::transform([
+                        ](auto& tuple) -> auto& { return *std::get<1>(tuple); });
+                        missing = co_await readStorage(keysView, valuesView, *immutableStorage);
+                    }
+
+                    if (RANGES::empty(missing))
+                    {
+                        co_return iterator;
+                    }
+                }
+            }
+
+            if constexpr (withCacheStorage)
+            {
+                if (!started)
+                {
+                    missing = co_await readStorage(myKeys, myValues, m_cacheStorage);
+                }
+                else
+                {
+                    auto keysView = missing | RANGES::views::transform([
+                    ](auto& tuple) -> auto const& { return *std::get<0>(tuple); });
+                    auto valuesView = missing | RANGES::views::transform([
+                    ](auto& tuple) -> auto& { return *std::get<1>(tuple); });
+                    missing = co_await readStorage(keysView, valuesView, m_cacheStorage);
+                }
+
+                if (RANGES::empty(missing))
+                {
+                    co_return iterator;
+                }
+            }
+
+            if (!started)
+            {
+                co_await readStorage(myKeys, myValues, m_backendStorage);
+            }
+            else
+            {
+                auto keysView = missing | RANGES::views::transform([
+                ](auto& tuple) -> auto const& { return *std::get<0>(tuple); });
+                auto valuesView = missing | RANGES::views::transform([
+                ](auto& tuple) -> auto& { return *std::get<1>(tuple); });
+                co_await readStorage(keysView, valuesView, m_backendStorage);
+
+                // Write data into cache
+                if constexpr (withCacheStorage)
+                {
+                    for (auto&& [key, value] : RANGES::zip_view(keysView, valuesView))
+                    {
+                        if (value)
+                        {
+                            co_await storage2::writeOne(m_cacheStorage, key, *value);
+                        }
+                    }
+                }
+            }
+
+            co_return iterator;
+        }
+
+        task::Task<void> write(RANGES::input_range auto&& keys, RANGES::input_range auto&& values)
+        {
+            if (!m_mutableStorage) [[unlikely]]
+            {
+                BOOST_THROW_EXCEPTION(NotExistsMutableStorageError{});
+            }
+
+            co_await m_mutableStorage->write(
+                std::forward<decltype(keys)>(keys), std::forward<decltype(values)>(values));
+            co_return;
+        }
+
+        task::Task<void> remove(RANGES::input_range auto const& keys)
+        {
+            if (!m_mutableStorage)
+            {
+                BOOST_THROW_EXCEPTION(NotExistsMutableStorageError{});
+            }
+
+            co_await m_mutableStorage->remove(keys);
+            co_return;
+        }
+
+        MutableStorageType& mutableStorage()
+        {
+            if (!m_mutableStorage)
+            {
+                BOOST_THROW_EXCEPTION(NotExistsMutableStorageError{});
+            }
+            return *m_mutableStorage;
+        }
+        BackendStorage& backendStorage() { return m_backendStorage; }
     };
 
     using Key = KeyType;
@@ -128,153 +297,32 @@ public:
     MultiLayerStorage& operator=(const MultiLayerStorage&) = delete;
     MultiLayerStorage& operator=(MultiLayerStorage&&) = delete;
 
-    task::Task<ReadIterator> read(RANGES::input_range auto const& keys)
+    View fork(bool withMutable)
     {
-        ReadIterator iterator;
-        iterator.m_keys = keys | RANGES::to<decltype(iterator.m_keys)>();
-        iterator.m_values.resize(RANGES::size(iterator.m_keys));
-        auto const& myKeys = iterator.m_keys;
-        auto& myValues = iterator.m_values;
-
-        boost::container::small_vector<std::tuple<const RANGES::range_value_t<decltype(myKeys)>*,
-                                           RANGES::range_value_t<decltype(myValues)>*>,
-            1>
-            missing;
-
-        bool started = false;
-        if (m_mutableStorage)
-        {
-            started = true;
-            missing = co_await readStorage(myKeys, myValues, *m_mutableStorage);
-            if (RANGES::empty(missing))
-            {
-                co_return iterator;
-            }
-        }
-
-        if (!RANGES::empty(m_immutableStorages))
-        {
-            for (auto& immutableStorage : m_immutableStorages)
-            {
-                if (!started)
-                {
-                    started = true;
-                    missing = co_await readStorage(myKeys, myValues, *immutableStorage);
-                }
-                else
-                {
-                    auto keysView = missing | RANGES::views::transform([
-                    ](auto& tuple) -> auto const& { return *std::get<0>(tuple); });
-                    auto valuesView = missing | RANGES::views::transform([
-                    ](auto& tuple) -> auto& { return *std::get<1>(tuple); });
-                    missing = co_await readStorage(keysView, valuesView, *immutableStorage);
-                }
-
-                if (RANGES::empty(missing))
-                {
-                    co_return iterator;
-                }
-            }
-        }
-
+        std::unique_lock lock(m_listMutex);
         if constexpr (withCacheStorage)
         {
-            if (!started)
-            {
-                missing = co_await readStorage(myKeys, myValues, m_cacheStorage);
-            }
-            else
-            {
-                auto keysView = missing | RANGES::views::transform([
-                ](auto& tuple) -> auto const& { return *std::get<0>(tuple); });
-                auto valuesView = missing | RANGES::views::transform([
-                ](auto& tuple) -> auto& { return *std::get<1>(tuple); });
-                missing = co_await readStorage(keysView, valuesView, m_cacheStorage);
-            }
+            View view(m_backendStorage, m_cacheStorage);
 
-            if (RANGES::empty(missing))
-            {
-                co_return iterator;
-            }
-        }
-
-        if (!started)
-        {
-            co_await readStorage(myKeys, myValues, m_backendStorage);
-        }
-        else
-        {
-            auto keysView = missing | RANGES::views::transform([
-            ](auto& tuple) -> auto const& { return *std::get<0>(tuple); });
-            auto valuesView = missing | RANGES::views::transform([
-            ](auto& tuple) -> auto& { return *std::get<1>(tuple); });
-            co_await readStorage(keysView, valuesView, m_backendStorage);
-
-            // Write data into cache
-            if constexpr (withCacheStorage)
-            {
-                for (auto&& [key, value] : RANGES::zip_view(keysView, valuesView))
-                {
-                    if (value)
-                    {
-                        co_await storage2::writeOne(m_cacheStorage, key, *value);
-                    }
-                }
-            }
-        }
-
-        co_return iterator;
-    }
-
-    task::Task<void> write(RANGES::input_range auto&& keys, RANGES::input_range auto&& values)
-    {
-        if (!m_mutableStorage) [[unlikely]]
-        {
-            BOOST_THROW_EXCEPTION(NotExistsMutableStorageError{});
-        }
-
-        co_await m_mutableStorage->write(
-            std::forward<decltype(keys)>(keys), std::forward<decltype(values)>(values));
-        co_return;
-    }
-
-    task::Task<void> remove(RANGES::input_range auto const& keys)
-    {
-        if (!m_mutableStorage)
-        {
-            BOOST_THROW_EXCEPTION(NotExistsMutableStorageError{});
-        }
-
-        co_await m_mutableStorage->remove(keys);
-        co_return;
-    }
-
-    std::unique_ptr<MultiLayerStorage> fork(bool withMutable)
-    {
-        if constexpr (withCacheStorage)
-        {
-            auto newMultiLayerStorage =
-                std::make_unique<MultiLayerStorage>(m_backendStorage, m_cacheStorage);
-            std::unique_lock lock(m_listMutex);
-            newMultiLayerStorage->m_immutableStorages = m_immutableStorages;
+            view.m_immutableStorages = m_immutableStorages;
             if (withMutable)
             {
-                newMultiLayerStorage->m_mutableStorage = m_mutableStorage;
+                view.m_mutableStorage = m_mutableStorage;
             }
 
-            return newMultiLayerStorage;
+            return view;
         }
         else
         {
             auto newMultiLayerStorage = std::make_unique<MultiLayerStorage>(m_backendStorage);
-            std::unique_lock lock(m_listMutex);
-            newMultiLayerStorage->m_immutableStorages = m_immutableStorages;
+            View view(m_backendStorage);
+            view.m_immutableStorages = m_immutableStorages;
             if (withMutable)
             {
-                newMultiLayerStorage->m_mutableStorage = m_mutableStorage;
+                view.m_mutableStorage = m_mutableStorage;
             }
 
-            return newMultiLayerStorage;
+            return view;
         }
     }
 
@@ -290,13 +338,6 @@ public:
         m_mutableStorage = std::make_shared<MutableStorageType>(args...);
     }
 
-    void setMutable(std::shared_ptr<MutableStorageType> mutableStorage)
-    {
-        m_mutableStorage = std::move(mutableStorage);
-    }
-
-    void dropMutable() { m_mutableStorage.reset(); }
-
     void pushMutableToImmutableFront()
     {
         if (!m_mutableStorage)
@@ -306,16 +347,6 @@ public:
         std::unique_lock lock(m_listMutex);
         m_immutableStorages.push_front(std::move(m_mutableStorage));
         m_mutableStorage.reset();
-    }
-
-    void popImmutableFront()
-    {
-        std::unique_lock lock(m_listMutex);
-        if (m_immutableStorages.empty())
-        {
-            BOOST_THROW_EXCEPTION(NotExistsImmutableStorageError{});
-        }
-        m_immutableStorages.pop_front();
     }
 
     task::Task<void> mergeAndPopImmutableBack()

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerBaseImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerBaseImpl.h
@@ -14,8 +14,7 @@
 namespace bcos::transaction_scheduler
 {
 
-template <transaction_executor::StateStorage MultiLayerStorage,
-    protocol::IsTransactionReceiptFactory ReceiptFactory,
+template <class MultiLayerStorage, protocol::IsTransactionReceiptFactory ReceiptFactory,
     template <typename, typename> class Executor>
 class SchedulerBaseImpl
 {
@@ -107,11 +106,10 @@ public:
         protocol::IsBlockHeader auto const& blockHeader,
         protocol::IsTransaction auto const& transaction)
     {
-        auto storage = m_multiLayerStorage.fork(false);
-        storage->newMutable();
+        auto view = m_multiLayerStorage.fork(false);
+        view.newTemporaryMutable();
 
-        Executor<MultiLayerStorage, ReceiptFactory> executor(
-            *storage, m_receiptFactory, m_tableNamePool);
+        Executor<decltype(view), ReceiptFactory> executor(view, m_receiptFactory, m_tableNamePool);
         co_return co_await executor.execute(blockHeader, transaction, 0);
     }
 

--- a/transaction-scheduler/tests/testMultiLayerStorage.cpp
+++ b/transaction-scheduler/tests/testMultiLayerStorage.cpp
@@ -36,7 +36,8 @@ public:
     BackendStorage backendStorage;
     MultiLayerStorage<MutableStorage, void, BackendStorage> multiLayerStorage;
 
-    static_assert(storage2::ReadableStorage<decltype(multiLayerStorage)>, "No match storage!");
+    static_assert(
+        storage2::ReadableStorage<decltype(multiLayerStorage.fork(true))>, "No match storage!");
 };
 
 BOOST_FIXTURE_TEST_SUITE(TestMultiLayerStorage, TestMultiLayerStorageFixture)
@@ -44,9 +45,10 @@ BOOST_FIXTURE_TEST_SUITE(TestMultiLayerStorage, TestMultiLayerStorageFixture)
 BOOST_AUTO_TEST_CASE(noMutable)
 {
     task::syncWait([this]() -> task::Task<void> {
+        auto view = multiLayerStorage.fork(true);
         storage::Entry entry;
         BOOST_CHECK_THROW(
-            co_await storage2::writeOne(multiLayerStorage,
+            co_await storage2::writeOne(view,
                 StateKey{
                     storage2::string_pool::makeStringID(tableNamePool, "test_table"), "test_key"},
                 std::move(entry)),
@@ -61,24 +63,25 @@ BOOST_AUTO_TEST_CASE(readWriteMutable)
     task::syncWait([this]() -> task::Task<void> {
         BOOST_CHECK_THROW(
             multiLayerStorage.pushMutableToImmutableFront(), NotExistsMutableStorageError);
+        auto view = multiLayerStorage.fork(true);
 
         multiLayerStorage.newMutable();
         StateKey key{storage2::string_pool::makeStringID(tableNamePool, "test_table"), "test_key"};
 
         storage::Entry entry;
         entry.set("Hello world!");
-        co_await storage2::writeOne(multiLayerStorage, key, entry);
+        co_await storage2::writeOne(view, key, entry);
 
         RANGES::single_view keyViews(key);
-        auto it = co_await multiLayerStorage.read(keyViews);
+        auto it = co_await view.read(keyViews);
 
         co_await it.next();
         const auto& iteratorValue = co_await it.value();
         BOOST_CHECK_EQUAL(iteratorValue.get(), entry.get());
 
         BOOST_CHECK_NO_THROW(multiLayerStorage.pushMutableToImmutableFront());
-        BOOST_CHECK_THROW(co_await storage2::writeOne(multiLayerStorage, key, entry),
-            NotExistsMutableStorageError);
+        BOOST_CHECK_THROW(
+            co_await storage2::writeOne(view, key, entry), NotExistsMutableStorageError);
 
         co_return;
     }());
@@ -91,6 +94,7 @@ BOOST_AUTO_TEST_CASE(merge)
             multiLayerStorage.pushMutableToImmutableFront(), NotExistsMutableStorageError);
 
         multiLayerStorage.newMutable();
+        auto view = std::make_optional(multiLayerStorage.fork(true));
         auto toKey = RANGES::views::transform([tableNamePool = &tableNamePool](int num) {
             return StateKey{storage2::string_pool::makeStringID(*tableNamePool, "test_table"),
                 fmt::format("key: {}", num)};
@@ -102,7 +106,7 @@ BOOST_AUTO_TEST_CASE(merge)
             return entry;
         });
 
-        co_await multiLayerStorage.write(RANGES::iota_view<int, int>(0, 100) | toKey,
+        co_await view->write(RANGES::iota_view<int, int>(0, 100) | toKey,
             RANGES::iota_view<int, int>(0, 100) | toValue);
 
         BOOST_CHECK_THROW(
@@ -110,9 +114,11 @@ BOOST_AUTO_TEST_CASE(merge)
 
         multiLayerStorage.pushMutableToImmutableFront();
         co_await multiLayerStorage.mergeAndPopImmutableBack();
+        view.reset();
 
+        auto view2 = multiLayerStorage.fork(false);
         auto keys = RANGES::iota_view<int, int>(0, 100) | toKey;
-        auto it = co_await multiLayerStorage.read(keys);
+        auto it = co_await view2.read(keys);
 
         int i = 0;
         while (co_await it.next())
@@ -124,11 +130,13 @@ BOOST_AUTO_TEST_CASE(merge)
         BOOST_CHECK_EQUAL(i, 100);
 
         multiLayerStorage.newMutable();
-        co_await multiLayerStorage.remove(RANGES::iota_view<int, int>(20, 30) | toKey);
+
+        auto view3 = multiLayerStorage.fork(true);
+        co_await view3.remove(RANGES::iota_view<int, int>(20, 30) | toKey);
         multiLayerStorage.pushMutableToImmutableFront();
         co_await multiLayerStorage.mergeAndPopImmutableBack();
 
-        auto removedIt = co_await multiLayerStorage.read(keys);
+        auto removedIt = co_await view3.read(keys);
         i = 0;
         while (co_await removedIt.next())
         {

--- a/transaction-scheduler/tests/testSchedulerParallel.cpp
+++ b/transaction-scheduler/tests/testSchedulerParallel.cpp
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(conflict)
             MockConflictExecutor>
             scheduler(multiLayerStorage, receiptFactory, tableNamePool);
         scheduler.setChunkSize(1);
-        scheduler.setMaxThreads(4);
+        scheduler.setMaxToken(4);
         scheduler.start();
         bcostars::protocol::BlockHeaderImpl blockHeader(
             [inner = bcostars::BlockHeader()]() mutable { return std::addressof(inner); });


### PR DESCRIPTION
Add mutable fork() for multilayer storage to avoid conflicit write