### PR TITLE
<fix>(pbft): fix validator not update consensus list cause performance reduction bug.

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/config/PBFTConfig.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/config/PBFTConfig.cpp
@@ -83,6 +83,17 @@ void PBFTConfig::resetConfig(LedgerConfig::Ptr _ledgerConfig, bool _syncedBlock)
         }
     }
 
+    // notify the txpool validator to update the consensusNodeList and the observerNodeList
+    if (m_consensusNodeListUpdated || m_observerNodeListUpdated)
+    {
+        m_validator->updateValidatorConfig(consensusList, *observerList);
+        PBFT_LOG(INFO) << LOG_DESC("updateValidatorConfig")
+                       << LOG_KV("consensusNodeListUpdated", m_consensusNodeListUpdated)
+                       << LOG_KV("observerNodeListUpdated", m_observerNodeListUpdated)
+                       << LOG_KV("consensusNodeSize", consensusList.size())
+                       << LOG_KV("observerNodeSize", observerList->size());
+    }
+
     // notify the latest block number to the sealer
     if (m_stateNotifier)
     {

--- a/bcos-pbft/bcos-pbft/pbft/engine/Validator.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/Validator.h
@@ -48,6 +48,9 @@ public:
     virtual void notifyTransactionsResult(
         bcos::protocol::Block::Ptr _block, bcos::protocol::BlockHeader::Ptr _header) = 0;
 
+    virtual void updateValidatorConfig(bcos::consensus::ConsensusNodeList const& _consensusNodeList,
+        bcos::consensus::ConsensusNodeList const& _observerNodeList) = 0;
+
     virtual void stop() = 0;
     virtual void init() = 0;
     virtual void asyncResetTxPool() = 0;
@@ -144,6 +147,32 @@ public:
                                << LOG_KV("code", _error->errorCode())
                                << LOG_KV("msg", _error->errorMessage());
             });
+    }
+
+    void updateValidatorConfig(bcos::consensus::ConsensusNodeList const& _consensusNodeList,
+        bcos::consensus::ConsensusNodeList const& _observerNodeList) override
+    {
+        m_txPool->notifyConsensusNodeList(_consensusNodeList, [](Error::Ptr _error) {
+            if (_error == nullptr)
+            {
+                PBFT_LOG(DEBUG) << LOG_DESC("notify to update consensusNodeList config success");
+                return;
+            }
+            PBFT_LOG(WARNING) << LOG_DESC("notify to update consensusNodeList config failed")
+                              << LOG_KV("code", _error->errorCode())
+                              << LOG_KV("msg", _error->errorMessage());
+        });
+
+        m_txPool->notifyObserverNodeList(_observerNodeList, [](Error::Ptr _error) {
+            if (_error == nullptr)
+            {
+                PBFT_LOG(DEBUG) << LOG_DESC("notify to update observerNodeList config success");
+                return;
+            }
+            PBFT_LOG(WARNING) << LOG_DESC("notify to update observerNodeList config failed")
+                              << LOG_KV("code", _error->errorCode())
+                              << LOG_KV("msg", _error->errorMessage());
+        });
     }
 
     void setVerifyCompletedHook(std::function<void()> _hook) override


### PR DESCRIPTION
if not update node list, all tx sync from p2p will be reject because node list is empty.