### PR TITLE
<fix>(HostContext): Fix 3.0.0 delegateCall old logic, not init size overflow bug

### DIFF
--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -178,7 +178,7 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
         // To compat with lower version,
         // we must give a big number to trigger OUT_OF_GAS
         // 200M is ok
-        result.output_size = 2 * 1024 * 1024;  // 200M is ok
+        result.output_size = 200 * 1024 * 1024;  // 200M is ok
 
         return result;
     }

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -173,7 +173,13 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
         result.release = nullptr;  // no output to release
         result.gas_left = 0;
         result.gas_refund = 0;
-        result.output_size = 0;
+
+        // Bugfix:
+        // To compat with lower version,
+        // we must give a big number to trigger OUT_OF_GAS
+        // 200M is ok
+        result.output_size = 2 * 1024 * 1024;  // 200M is ok
+
         return result;
     }
     case EVMC_CREATE:

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -173,6 +173,7 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
         result.release = nullptr;  // no output to release
         result.gas_left = 0;
         result.gas_refund = 0;
+        result.output_size = 0;
         return result;
     }
     case EVMC_CREATE:

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -183,7 +183,8 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
         result.output_data = response->data.data();
         EXECUTOR_LOG(WARNING) << LOG_DESC(
                                      "delegatecall/callcode is unsupported in your compatibility "
-                                     "version, please update it using console. Otherwise it may "
+                                     "version(3.0.0), please update it to 3.1.0(or after) using "
+                                     "console. Otherwise it may "
                                      "lead to unpredictable behavior.")
                               << LOG_KV("version", blockContext->blockVersion());
 

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -177,9 +177,13 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
         // Bugfix:
         // To compat with lower version,
         // we must give a big number to trigger OUT_OF_GAS
-        // 200M is ok
-        result.output_size = 200 * 1024 * 1024;  // 200M is ok
-
+        // 130M is ok
+        result.output_size = 130 * 1024 * 1024;  // 130M is ok
+        EXECUTOR_LOG(WARNING) << LOG_DESC(
+                                     "delegatecall/callcode is unsupported in your compatibility "
+                                     "version, please update it using console. Otherwise it may "
+                                     "lead to unpredictable behavior.")
+                              << LOG_KV("version", blockContext->blockVersion());
         return result;
     }
     case EVMC_CREATE:

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -176,14 +176,17 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
 
         // Bugfix:
         // To compat with lower version,
-        // we must give a big number to trigger OUT_OF_GAS
-        // 130M is ok
-        result.output_size = 130 * 1024 * 1024;  // 130M is ok
+        // we must set output_size larger than 0 to trigger OUT_OF_GAS
+        static auto response = std::make_unique<CallParameters>(CallParameters::MESSAGE);
+        response->data = bytes(130 * 1024 * 1024);
+        result.output_size = response->data.size();
+        result.output_data = response->data.data();
         EXECUTOR_LOG(WARNING) << LOG_DESC(
                                      "delegatecall/callcode is unsupported in your compatibility "
                                      "version, please update it using console. Otherwise it may "
                                      "lead to unpredictable behavior.")
                               << LOG_KV("version", blockContext->blockVersion());
+
         return result;
     }
     case EVMC_CREATE:


### PR DESCRIPTION
if not init evmone will exception at assign:

evmone: instructions_calls.cpp

``` cpp
    const auto result = state.host.call(msg);
    state.return_data.assign(result.output_data, result.output_size); // here!!!!
    stack.top() = result.status_code == EVMC_SUCCESS;
```