### PR TITLE
SnappyCompress::uncompress(), Support max uncompressed length.

### DIFF
--- a/libdevcore/SnappyCompress.cpp
+++ b/libdevcore/SnappyCompress.cpp
@@ -50,12 +50,19 @@ size_t SnappyCompress::compress(bytesConstRef inputData, bytes& compressedData)
     return compressLen;
 }
 
-size_t SnappyCompress::uncompress(bytesConstRef compressedData, bytes& uncompressedData)
+size_t SnappyCompress::uncompress(bytesConstRef compressedData, bytes& uncompressedData, size_t maxUncompressedLen)
 {
     size_t uncompressedLen = 0;
     // auto start_t = utcTimeUs();
     snappy::GetUncompressedLength(
         (const char*)compressedData.data(), compressedData.size(), &uncompressedLen);
+
+    if (maxUncompressedLen > 0 && uncompressedLen > maxUncompressedLen) {
+        LOG(ERROR) << LOG_BADGE("SnappyCompress") << LOG_DESC("uncompress size exceeds the limit")
+                   << LOG_KV("uncompressedLen", uncompressedLen) << LOG_KV("maxUncompressedLen", maxUncompressedLen);
+        return 0;
+    }
+
     uncompressedData.resize(uncompressedLen);
     bool status = snappy::RawUncompress(
         (const char*)compressedData.data(), compressedData.size(), (char*)&uncompressedData[0]);

--- a/libdevcore/SnappyCompress.h
+++ b/libdevcore/SnappyCompress.h
@@ -32,7 +32,7 @@ class SnappyCompress
 {
 public:
     static size_t compress(bytesConstRef inputData, bytes& compressedData);
-    static size_t uncompress(bytesConstRef compressedData, bytes& uncompressedData);
+    static size_t uncompress(bytesConstRef compressedData, bytes& uncompressedData, size_t maxUncompressedLen = 0);
 };
 }  // namespace compress
 }  // namespace dev

--- a/libp2p/P2PMessageRC2.cpp
+++ b/libp2p/P2PMessageRC2.cpp
@@ -140,7 +140,8 @@ ssize_t P2PMessageRC2::decode(const byte* buffer, size_t size)
         /// uncompress data
         SnappyCompress::uncompress(
             bytesConstRef((const byte*)(&buffer[HEADER_LENGTH]), m_length - HEADER_LENGTH),
-            *m_buffer);
+            *m_buffer,
+            P2PMessage::MAX_MESSAGE_LENGTH);
         // reset version
         m_version &= (~dev::eth::CompressFlag);
     }


### PR DESCRIPTION
https://github.com/FISCO-BCOS/FISCO-BCOS/issues/3927