### PR TITLE
block指针在std::move后使用lambda捕获，但是lambda没用到block，所以只是个小笔误

### DIFF
--- a/bcos-scheduler/src/SchedulerImpl.cpp
+++ b/bcos-scheduler/src/SchedulerImpl.cpp
@@ -913,7 +913,7 @@ void SchedulerImpl::preExecuteBlock(
 
         setPreparedBlock(blockNumber, timestamp, blockExecutive);
 
-        m_preExeWorker.enqueue([this, blockNumber, timestamp, block, blockExecutive,
+        m_preExeWorker.enqueue([this, blockNumber, timestamp, blockExecutive,
                                    callback = std::move(callback)]() {
             try
             {


### PR DESCRIPTION
use block after std::move it