### PR TITLE
<fix>(dmc): Support DMC transfer balance

### DIFF
--- a/bcos-executor/src/CallParameters.h
+++ b/bcos-executor/src/CallParameters.h
@@ -114,6 +114,7 @@ struct CallParameters
            << "receiveAddress:" << receiveAddress << "|"
            << "origin:" << origin << "|"
            << "gas:" << gas << "|"
+           << "value:" << value << "|"
            << "dataSize:" << data.size() << "|"
            << "abiSize:" << abi.size() << "|"
            << "acquireKeyLock:" << acquireKeyLock << "|"

--- a/bcos-executor/src/Common.h
+++ b/bcos-executor/src/Common.h
@@ -187,6 +187,8 @@ static const VMSchedule FiscoBcosScheduleV320 = [] {
     return schedule;
 }();
 
+static const int64_t BALANCE_TRANSFER_GAS = 21000;
+
 constexpr evmc_gas_metrics ethMetrics{32000, 20000, 5000, 200, 9000, 2300, 25000};
 
 protocol::TransactionStatus toTransactionStatus(Exception const& _e);

--- a/bcos-executor/src/executive/BillingTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/BillingTransactionExecutive.cpp
@@ -9,33 +9,55 @@ CallParameters::UniquePtr BillingTransactionExecutive::start(CallParameters::Uni
 {
     int64_t originGas = input->gas;
     uint64_t currentSeq = input->seq;
-    std::string currentSenderAddr = input->origin;
+    std::string balanceSpenderAddr = input->origin;
     bool staticCall = input->staticCall;
     u256 gasPrice = input->gasPrice;
     auto message = TransactionExecutive::execute(std::move(input));
 
-    if ((currentSeq == 0) && !staticCall)
+    if ((currentSeq == 0) && !staticCall &&
+        message->status == (int32_t)protocol::TransactionStatus::None)
     {
         CallParameters::UniquePtr callParam4AccountPre =
             std::make_unique<CallParameters>(CallParameters::MESSAGE);
         auto codec = CodecWrapper(m_blockContext.hashHandler(), m_blockContext.isWasm());
-        callParam4AccountPre->senderAddress = TXEXEC_GAS_CONSUMER_ADDRESS;
+        callParam4AccountPre->origin = TXEXEC_GAS_CONSUMER_ADDRESS;
+        callParam4AccountPre->senderAddress =
+            contractAddress();  // because seq = 0, not delegatecall
         callParam4AccountPre->receiveAddress = ACCOUNT_ADDRESS;
 
-        int64_t gasUsed = originGas - message->gas;
-        bytes subBalanceIn = codec.encodeWithSig("subAccountBalance(uint256)", gasUsed * gasPrice);
-        std::vector<std::string> codeParameters{getContractTableName(currentSenderAddr)};
+        int64_t gasUsed = originGas - message->gas;  // TODO: consider revert
+        u256 balanceUsed = gasUsed * gasPrice;
+        bytes subBalanceIn = codec.encodeWithSig("subAccountBalance(uint256)", balanceUsed);
+        std::vector<std::string> codeParameters{getContractTableName(balanceSpenderAddr)};
         auto newParams = codec.encode(codeParameters, subBalanceIn);
         callParam4AccountPre->data = std::move(newParams);
 
+        EXECUTIVE_LOG(TRACE) << LOG_BADGE("Billing") << "Try to subAccount balance: "
+                             << LOG_KV("subBalance", gasUsed * gasPrice)
+                             << LOG_KV("gasUsed", gasUsed) << LOG_KV("gasPrice", gasPrice)
+                             << LOG_KV("balanceSpenderAddr", balanceSpenderAddr);
         auto subBalanceRet = callPrecompiled(std::move(callParam4AccountPre));
+        /* leave this code for future use
+        auto subBalanceRet = externalRequest(shared_from_this(), ref(callParam4AccountPre->data),
+                                             balanceSpenderAddr,
+        callParam4AccountPre->senderAddress, callParam4AccountPre->receiveAddress, false, false,
+                                                message->gas, true);
+                                             */
         if (subBalanceRet->type == CallParameters::REVERT)
         {
             message->type = subBalanceRet->type;
             message->status = subBalanceRet->status;
             message->message = subBalanceRet->message;
+            EXECUTIVE_LOG(TRACE) << LOG_BADGE("Billing") << "SubAccount balance failed: "
+                                 << LOG_KV("subBalance", gasUsed * gasPrice)
+                                 << LOG_KV("gasUsed", gasUsed) << LOG_KV("gasPrice", gasPrice)
+                                 << LOG_KV("status", message->status) << LOG_KV("message", message);
             return message;
         }
+        EXECUTIVE_LOG(TRACE) << LOG_BADGE("Billing") << "SubAccount balance success: "
+                             << LOG_KV("subBalance", gasUsed * gasPrice)
+                             << LOG_KV("gasUsed", gasUsed) << LOG_KV("gasPrice", gasPrice)
+                             << LOG_KV("status", message->status) << LOG_KV("message", message);
     }
 
     EXECUTIVE_LOG(TRACE) << "Execute billing executive finish\t" << message->toFullString();

--- a/bcos-executor/src/executive/TransactionExecutive.h
+++ b/bcos-executor/src/executive/TransactionExecutive.h
@@ -97,6 +97,7 @@ public:
     int64_t contextID() const { return m_contextID; }
     int64_t seq() const { return m_seq; }
 
+    // in delegatecall this is codeAddress
     std::string_view contractAddress() const { return m_contractAddress; }
 
     CallParameters::UniquePtr execute(
@@ -156,8 +157,8 @@ public:
     std::optional<storage::Entry> getCodeByContractTableName(
         const std::string_view& contractTableName, bool needTryFromContractTable = true);
 
-    bool transferBalance(std::string_view origin, std::string_view sender,
-        std::string_view receiver, const u256& value, int64_t gas);
+    CallParameters::UniquePtr transferBalance(CallParameters::UniquePtr callParameters,
+        int64_t requireGas, std::string_view currentContextAddress);
 
     std::string getContractTableName(
         const std::string_view& _address, bool isWasm = false, bool isCreate = false);

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -1081,6 +1081,16 @@ void TransactionExecutor::dmcExecuteTransactions(std::string contractAddress,
         bcos::Error::UniquePtr, std::vector<bcos::protocol::ExecutionMessage::UniquePtr>)>
         _callback)
 {
+    if (!m_isWasm)
+    {
+        // padding the address
+        constexpr static auto addressSize = Address::SIZE * 2;
+        if (contractAddress.size() < addressSize) [[unlikely]]
+        {
+            contractAddress.insert(0, addressSize - contractAddress.size(), '0');
+        }
+    }
+
     executeTransactionsInternal(
         std::move(contractAddress), std::move(inputs), true, std::move(_callback));
 }
@@ -2476,6 +2486,7 @@ std::unique_ptr<protocol::ExecutionMessage> TransactionExecutor::toExecutionResu
     message->setContextID(params->contextID);
     message->setSeq(params->seq);
     message->setOrigin(std::move(params->origin));
+    message->setValue("0x" + params->value.str(256, std::ios_base::hex));
     message->setGasAvailable(params->gas);
     std::string eGasPriceStr = "0x" + params->effectiveGasPrice.str(256, std::ios_base::hex);
     message->setEffectiveGasPrice(eGasPriceStr);

--- a/bcos-executor/src/precompiled/BFSPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/BFSPrecompiled.cpp
@@ -764,12 +764,16 @@ void BFSPrecompiled::touch(const std::shared_ptr<executor::TransactionExecutive>
         _callParameters->setExecResult(codec.encode(int32_t(CODE_FILE_INVALID_TYPE)));
         return;
     }
-    if (!checkPathPrefixValid(absolutePath, blockContext.blockVersion(), type))
-    {
-        _callParameters->setExecResult(codec.encode(int32_t(CODE_FILE_INVALID_PATH)));
-        return;
-    }
 
+    if (_callParameters->m_origin.compare(ACCOUNT_ADDRESS) != 0)
+    {
+        // if comming from accountPrecompiled, check path prefix
+        if (!checkPathPrefixValid(absolutePath, blockContext.blockVersion(), type))
+        {
+            _callParameters->setExecResult(codec.encode(int32_t(CODE_FILE_INVALID_PATH)));
+            return;
+        }
+    }
 
     std::string parentDir;
     std::string baseName;

--- a/bcos-executor/src/precompiled/extension/AccountPrecompiled.h
+++ b/bcos-executor/src/precompiled/extension/AccountPrecompiled.h
@@ -61,6 +61,10 @@ private:
         const std::shared_ptr<executor::TransactionExecutive>& _executive, bytesConstRef& data,
         PrecompiledExecResult::Ptr const& _callParameters) const;
 
+    std::string getContractTableName(
+        const std::shared_ptr<executor::TransactionExecutive>& _executive,
+        const std::string_view& _address) const;
+
 private:
     // Fake storage for balance,should be removed after real implementation
     mutable std::map<std::string, u256> m_fakeAccountBalances;

--- a/bcos-executor/src/precompiled/extension/BalancePrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/BalancePrecompiled.cpp
@@ -198,7 +198,8 @@ void BalancePrecompiled::addBalance(
     if (!entry.has_value() || entry->get() == "0")
     {
         BOOST_THROW_EXCEPTION(
-            protocol::PrecompiledError("the request's sender not caller, addBalance failed"));
+            protocol::PrecompiledError("Permission denied. Please use \"listBalanceGovernor\" to "
+                                       "check which account(or contract) can addBalance"));
         return;
     }
     PRECOMPILED_LOG(DEBUG) << BLOCK_NUMBER(blockContext.number()) << LOG_BADGE("BalancePrecompiled")
@@ -258,7 +259,8 @@ void BalancePrecompiled::subBalance(
                                  << LOG_KV("caller", caller)
                                  << LOG_KV("callerTableNotExist", "true");
         BOOST_THROW_EXCEPTION(
-            protocol::PrecompiledError("the request's sender not caller, subBalance failed"));
+            protocol::PrecompiledError("Permission denied. Please use \"listBalanceGovernor\" to "
+                                       "check which account(or contract) can addBalance"));
         return;
     }
     auto entry = table->getRow(caller);
@@ -331,7 +333,7 @@ void BalancePrecompiled::transfer(const std::shared_ptr<executor::TransactionExe
     auto entry = table->getRow(caller);
     if (!entry || entry->get() == "0")
     {
-        BOOST_THROW_EXCEPTION(protocol::PrecompiledError("caller not exist"));
+        BOOST_THROW_EXCEPTION(protocol::PrecompiledError("Permission denied"));
     }
 
 
@@ -570,6 +572,9 @@ void BalancePrecompiled::listCaller(
     auto keyCondition = std::make_optional<storage::Condition>();
     keyCondition->limit(0, USER_TABLE_MAX_LIMIT_COUNT);
     auto tableKeyList = table->getPrimaryKeys(*keyCondition);
+    PRECOMPILED_LOG(TRACE) << BLOCK_NUMBER(blockContext.number()) << LOG_BADGE("BalancePrecompiled")
+                           << LOG_DESC("listCaller get from caller table")
+                           << LOG_KV("tableKeyList size", tableKeyList.size());
     if (tableKeyList.size() == 0)
     {
         PRECOMPILED_LOG(INFO) << BLOCK_NUMBER(blockContext.number())

--- a/bcos-executor/src/vm/HostContext.h
+++ b/bcos-executor/src/vm/HostContext.h
@@ -132,6 +132,7 @@ public:
     bool isCreate() const { return m_callParameters->create; }
     bool staticCall() const { return m_callParameters->staticCall; }
     int64_t gas() const { return m_callParameters->gas; }
+    u256 value() const { return m_callParameters->value; }
     void suicide()
     {
         m_executive->setContractTableChanged();
@@ -142,6 +143,9 @@ public:
             blockContext.suicide(m_tableName);
         }
     }
+
+    evmc_bytes32 getBalance(const evmc_address* _addr);
+    bool selfdestruct(const evmc_address* _addr, const evmc_address* _beneficiary);
 
     CallParameters::UniquePtr&& takeCallParameters()
     {

--- a/bcos-framework/bcos-framework/executor/ExecutionMessage.h
+++ b/bcos-framework/bcos-framework/executor/ExecutionMessage.h
@@ -84,8 +84,8 @@ public:
         std::stringstream ss;
         ss << "[" << (staticCall() ? "call" : "tx") << "|" << contextID() << "|" << seq() << "|"
            << getTypeName(type()) << "|" << from() << "->" << to() << "|" << gasAvailable() << "|"
-           << toHex(keyLockAcquired()) << "|" << logEntries().size() << "|" << keyLocks().size()
-           << ":";
+           << value() << "|" << toHex(keyLockAcquired()) << "|" << logEntries().size() << "|"
+           << keyLocks().size() << ":";
         for (auto& lock : keyLocks())
         {
             ss << toHex(lock) << ".";

--- a/bcos-framework/bcos-framework/protocol/Exceptions.h
+++ b/bcos-framework/bcos-framework/protocol/Exceptions.h
@@ -47,5 +47,13 @@ public:
     PrecompiledError() : Exception() {}
     PrecompiledError(std::string const& _msg) : Exception(_msg) {}
 };
+
+class NotEnoughCashError : public Exception
+{
+public:
+    NotEnoughCashError() : Exception() {}
+    NotEnoughCashError(std::string const& _msg) : Exception(_msg) {}
+};
+
 }  // namespace protocol
 }  // namespace bcos

--- a/bcos-scheduler/src/SchedulerImpl.cpp
+++ b/bcos-scheduler/src/SchedulerImpl.cpp
@@ -998,9 +998,9 @@ void SchedulerImpl::fetchConfig(protocol::BlockNumber _number)
         auto [e, value] = p.get_future().get();
         if (e)
         {
-            SCHEDULER_LOG(WARNING)
-                << BLOCK_NUMBER(_number) << LOG_DESC("fetchGasPrice failed")
-                << LOG_KV("code", e->errorCode()) << LOG_KV("message", e->errorMessage());
+            SCHEDULER_LOG(DEBUG) << BLOCK_NUMBER(_number) << LOG_DESC("fetchGasPrice failed")
+                                 << LOG_KV("code", e->errorCode())
+                                 << LOG_KV("message", e->errorMessage());
             // BOOST_THROW_EXCEPTION(
             //     BCOS_ERROR(SchedulerError::fetchGasLimitError, e->errorMessage()));
             value = "0x0";


### PR DESCRIPTION
1. dmc support balance transfer(return message add value, account precompiled verify origin and use sender to return)
2. balance transfer cost gas
3. policy1 disable transfer
4. move transfer code together and return error code
5. fix msg.value
6. add more log of value
7. fix transfer to precompiled substr bug
8. fix dmc addr padding bug