### PR TITLE
Update word spell, use pipeline calc stateroot, add web3 ci

### DIFF
--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -188,8 +188,7 @@ private:
         }
         else
         {
-            auto view = std::span(value.bytes);
-            std::uninitialized_fill(view.begin(), view.end(), 0);
+            ::ranges::fill(value.bytes, 0);
         }
         co_return value;
     }
@@ -262,7 +261,7 @@ public:
             if (binaryAddress)
             {
                 assert(address.size() % 2 == 0);
-                m_tableName.reserve(ledger::SYS_DIRECTORY::USER_APPS.size() + address.size() / 2);
+                m_tableName.reserve(ledger::SYS_DIRECTORY::USER_APPS.size() + (address.size() / 2));
                 m_tableName.append(ledger::SYS_DIRECTORY::USER_APPS);
                 boost::algorithm::unhex(
                     address.begin(), address.end(), std::back_inserter(m_tableName));

--- a/bcos-sealer/bcos-sealer/Sealer.cpp
+++ b/bcos-sealer/bcos-sealer/Sealer.cpp
@@ -113,13 +113,13 @@ void Sealer::executeWorker()
                 std::chrono::steady_clock::now() - m_lastFetchTimepoint.load());
             duration > std::chrono::seconds(m_fetchTimeout))
         {
-            increseLastFetchTimepoint();
+            increaseLastFetchTimepoint();
             m_sealerConfig->txpool()->tryToSyncTxsFromPeers();
         }
     }
     else
     {
-        increseLastFetchTimepoint();
+        increaseLastFetchTimepoint();
     }
 
     // try to generateProposal
@@ -217,7 +217,7 @@ uint16_t Sealer::hookWhenSealBlock(bcos::protocol::Block::Ptr _block)
             ledger::Features::Flag::bugfix_rpbft_vrf_blocknumber_input));
 }
 
-std::chrono::steady_clock::time_point Sealer::increseLastFetchTimepoint()
+std::chrono::steady_clock::time_point Sealer::increaseLastFetchTimepoint()
 {
     auto now = std::chrono::steady_clock::now();
     auto current = m_lastFetchTimepoint.load();

--- a/bcos-sealer/bcos-sealer/Sealer.h
+++ b/bcos-sealer/bcos-sealer/Sealer.h
@@ -81,6 +81,6 @@ protected:
     boost::mutex x_signalled;
     bcos::crypto::Hash::Ptr m_hashImpl;
 
-    std::chrono::steady_clock::time_point increseLastFetchTimepoint();
+    std::chrono::steady_clock::time_point increaseLastFetchTimepoint();
 };
 }  // namespace bcos::sealer

--- a/bcos-storage/bcos-storage/StateKVResolver.h
+++ b/bcos-storage/bcos-storage/StateKVResolver.h
@@ -15,7 +15,7 @@ struct InvalidStateKey : public Error
 struct StateValueResolver
 {
     static auto encode(const storage::Entry& entry) { return entry; }
-    static auto encode(storage::Entry&& entry) { return std::forward<decltype(entry)>(entry); }
+    static auto encode(storage::Entry&& entry) { return std::move(entry); }
     static storage::Entry decode(std::string_view view)
     {
         storage::Entry entry;
@@ -38,10 +38,9 @@ struct StateKeyResolver
     }
     static executor_v1::StateKey encode(executor_v1::StateKey&& stateKey)
     {
-        return std::forward<executor_v1::StateKey>(stateKey);
+        return std::move(stateKey);
     }
-    static executor_v1::StateKey encode(
-        const executor_v1::StateKeyView& stateKeyView)
+    static executor_v1::StateKey encode(const executor_v1::StateKeyView& stateKeyView)
     {
         return executor_v1::StateKey(stateKeyView);
     }

--- a/tools/.ci/ci_check_air.sh
+++ b/tools/.ci/ci_check_air.sh
@@ -85,6 +85,9 @@ init_baseline()
     # Enable executor v1
     perl -p -i -e 's/version=0/version=1/g' nodes/127.0.0.1/node*/config.genesis
     cd nodes/127.0.0.1 && wait_and_start
+
+    # 为node0启用web3rpc
+    perl -p -i -e 'if (/web3_rpc/) { $flag=1 } elsif ($flag && s/enable\s*=\s*false/enable=true/i) { $flag=0; }' node0/config.ini
 }
 
 expand_node()
@@ -247,6 +250,14 @@ if [[ ${?} == "0" ]]; then
        echo "java_sdk_demo_ci_test error"
        exit 1
 fi
+bash ${current_path}/.ci/web3_test.sh
+if [[ ${?} == "0" ]]; then
+       LOG_INFO "web3 test success"
+   else
+       echo "web3 test error"
+       exit 1
+fi
+
 stop_node
 LOG_INFO "======== check baseline cases success ========"
 clear_node

--- a/tools/.ci/ci_check_air.sh
+++ b/tools/.ci/ci_check_air.sh
@@ -85,9 +85,6 @@ init_baseline()
     # Enable executor v1
     perl -p -i -e 's/version=0/version=1/g' nodes/127.0.0.1/node*/config.genesis
     cd nodes/127.0.0.1 && wait_and_start
-
-    # 为node0启用web3rpc
-    perl -p -i -e 'if (/web3_rpc/) { $flag=1 } elsif ($flag && s/enable\s*=\s*false/enable=true/i) { $flag=0; }' node0/config.ini
 }
 
 expand_node()
@@ -250,14 +247,6 @@ if [[ ${?} == "0" ]]; then
        echo "java_sdk_demo_ci_test error"
        exit 1
 fi
-bash ${current_path}/.ci/web3_test.sh
-if [[ ${?} == "0" ]]; then
-       LOG_INFO "web3 test success"
-   else
-       echo "web3 test error"
-       exit 1
-fi
-
 stop_node
 LOG_INFO "======== check baseline cases success ========"
 clear_node

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
@@ -29,8 +29,8 @@ evmc_message bcos::executor_v1::hostcontext::getMessage(bool web3Tx,
             }
             else
             {
-                message.code_address = newLegacyEVMAddress(
-                    bytesConstRef(message.sender.bytes, sizeof(message.sender.bytes)), nonce);
+                message.code_address =
+                    newLegacyEVMAddress(bytesConstRef(message.sender.bytes), nonce);
             }
         }
         message.recipient = message.code_address;

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -323,7 +323,7 @@ public:
 
     task::Task<bool> exists([[maybe_unused]] const evmc_address& address, auto&&... /*unused*/)
     {
-        // TODO: impl the full suport for solidity
+        // TODO: impl the full support for solidity
         co_return true;
     }
 

--- a/transaction-executor/bcos-transaction-executor/vm/VMInstance.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/VMInstance.cpp
@@ -1,6 +1,7 @@
 #include "VMInstance.h"
 #include <evmone/advanced_analysis.hpp>
 #include <evmone/advanced_execution.hpp>
+#include <range/v3/algorithm/lexicographical_compare.hpp>
 
 bcos::executor_v1::VMInstance::VMInstance(
     std::shared_ptr<evmone::baseline::CodeAnalysis const> instance) noexcept
@@ -14,11 +15,8 @@ bcos::executor_v1::EVMCResult bcos::executor_v1::VMInstance::execute(
     static auto const* evm = evmc_create_evmone();
     static thread_local std::unique_ptr<evmone::ExecutionState> localExecutionState;
 
-    auto executionState = std::move(localExecutionState);
-    if (!executionState)
-    {
-        executionState = std::make_unique<evmone::ExecutionState>();
-    }
+    auto executionState = localExecutionState ? std::move(localExecutionState) :
+                                                std::make_unique<evmone::ExecutionState>();
     executionState->reset(
         *msg, rev, *host, context, std::basic_string_view<uint8_t>(code, codeSize), {});
     auto result = EVMCResult(evmone::baseline::execute(

--- a/transaction-executor/bcos-transaction-executor/vm/VMInstance.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/VMInstance.cpp
@@ -1,7 +1,6 @@
 #include "VMInstance.h"
 #include <evmone/advanced_analysis.hpp>
 #include <evmone/advanced_execution.hpp>
-#include <range/v3/algorithm/lexicographical_compare.hpp>
 
 bcos::executor_v1::VMInstance::VMInstance(
     std::shared_ptr<evmone::baseline::CodeAnalysis const> instance) noexcept

--- a/transaction-executor/bcos-transaction-executor/vm/VMInstance.h
+++ b/transaction-executor/bcos-transaction-executor/vm/VMInstance.h
@@ -33,11 +33,6 @@
 namespace bcos::executor_v1
 {
 
-struct ReleaseEVMC
-{
-    void operator()(evmc_vm* ptr) const noexcept;
-};
-
 /// The RAII wrapper for an VMInstance-C instance.
 class VMInstance
 {

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -29,10 +29,8 @@
 #include "bcos-utilities/ITTAPI.h"
 #include <fmt/format.h>
 #include <oneapi/tbb/blocked_range.h>
-#include <oneapi/tbb/concurrent_vector.h>
 #include <oneapi/tbb/parallel_invoke.h>
 #include <oneapi/tbb/parallel_pipeline.h>
-#include <oneapi/tbb/parallel_reduce.h>
 #include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
 #include <boost/atomic.hpp>

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -31,7 +31,9 @@
 #include <oneapi/tbb/blocked_range.h>
 #include <oneapi/tbb/concurrent_vector.h>
 #include <oneapi/tbb/parallel_invoke.h>
+#include <oneapi/tbb/parallel_pipeline.h>
 #include <oneapi/tbb/parallel_reduce.h>
+#include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
 #include <boost/atomic.hpp>
 #include <boost/exception/diagnostic_information.hpp>
@@ -84,50 +86,39 @@ std::chrono::milliseconds::rep current();
 task::Task<h256> calculateStateRoot(
     auto& storage, uint32_t blockVersion, crypto::Hash const& hashImpl)
 {
-    constexpr static auto STATE_ROOT_CHUNK_SIZE = 64;
     auto range = co_await storage2::range(storage);
     storage::Entry deletedEntry;
     deletedEntry.setStatus(storage::Entry::DELETED);
 
-    tbb::concurrent_vector<h256> hashes;
-    tbb::task_group hashGroup;
-    while (auto keyValue = co_await range.next())
-    {
-        hashGroup.run([keyValue = std::move(keyValue), &hashes, &deletedEntry, &hashImpl]() {
-            auto [key, value] = *keyValue;
-            executor_v1::StateKeyView view(key);
-            auto [tableName, keyName] = view.get();
+    h256 totalHash;
+    using KeyValueType = task::AwaitableReturnType<decltype(range.next())>;
+    tbb::parallel_pipeline(tbb::this_task_arena::max_concurrency(),
+        tbb::make_filter<void, KeyValueType>(tbb::filter_mode::serial_in_order,
+            [&](tbb::flow_control& control) -> KeyValueType {
+                if (auto keyValue = task::tbb::syncWait(range.next()))
+                {
+                    return keyValue;
+                }
+                control.stop();
+                return {};
+            }) &
+            tbb::make_filter<KeyValueType, h256>(tbb::filter_mode::parallel,
+                [&](KeyValueType keyValue) -> h256 {
+                    auto& [key, value] = *keyValue;
+                    executor_v1::StateKeyView view(key);
+                    auto [tableName, keyName] = view.get();
 
-            const storage::Entry* entry = nullptr;
-            if (entry = std::get_if<storage::Entry>(std::addressof(value)); !entry)
-            {
-                entry = std::addressof(deletedEntry);
-            }
-
-            hashes.emplace_back(entry->hash(tableName, keyName, hashImpl,
-                static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION)));
-        });
-    }
-    hashGroup.wait();
-
-    struct XORHash
-    {
-        h256 m_hash;
-        std::reference_wrapper<decltype(hashes) const> m_hashes;
-
-        XORHash(decltype(hashes) const& hashes) : m_hashes(hashes) {};
-        XORHash(XORHash& source, tbb::split /*unused*/) : m_hashes(source.m_hashes) {};
-        void operator()(const tbb::blocked_range<size_t>& range)
-        {
-            for (size_t i = range.begin(); i != range.end(); ++i)
-            {
-                m_hash ^= m_hashes.get()[i];
-            }
-        }
-        void join(XORHash const& rhs) { m_hash ^= rhs.m_hash; }
-    } xorHash(hashes);
-    tbb::parallel_reduce(tbb::blocked_range<size_t>(0, hashes.size()), xorHash);
-    co_return xorHash.m_hash;
+                    const storage::Entry* entry = nullptr;
+                    if (entry = std::get_if<storage::Entry>(std::addressof(value)); !entry)
+                    {
+                        entry = std::addressof(deletedEntry);
+                    }
+                    return entry->hash(tableName, keyName, hashImpl,
+                        static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION));
+                }) &
+            tbb::make_filter<h256, void>(
+                tbb::filter_mode::serial_out_of_order, [&](h256 hash) { totalHash ^= hash; }));
+    co_return totalHash;
 }
 
 std::tuple<u256, h256> calculateReceiptRoot(


### PR DESCRIPTION
1. Refactored BaselineScheduler.h to use pipeline filters instead of task groups and concurrent vectors.
2. Removed unused struct ReleaseEVMC in VMInstance.h and streamlined execution state handling in VMInstance.cpp.
3. Updated CI scripts to enable web3 RPC and run additional web3 tests.