### PR TITLE
fix(txpool): clear sender before sig verify & eliminate redundant hash/sig recovery (FIB-34)

### DIFF
--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -28,7 +28,6 @@
 #include <bcos-executor/src/Common.h>
 #include <bcos-rpc/Common.h>
 #include <bcos-rpc/util.h>
-#include <bcos-rpc/validator/TxValidator.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <bcos-rpc/web3jsonrpc/endpoints/EthMethods.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
@@ -438,13 +437,6 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
 
     auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
         [m_tx = web3Tx.takeToTarsTransaction()]() mutable { return &m_tx; });
-    // check transaction validator
-    auto const checkStatus =
-        co_await bcos::rpc::TxValidator::checkSenderBalance(*tx, m_nodeService->scheduler());
-    if (checkStatus != protocol::TransactionStatus::None)
-    {
-        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, bcos::toString(checkStatus)));
-    }
 
 // for web3.eth.sendRawTransaction, return the hash of raw transaction
 #if 0

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
@@ -144,28 +144,22 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
         tarsTx.data.gasPrice = "0x" + this->maxPriorityFeePerGas.str(0, std::ios_base::hex);
     }
     tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
-    auto hashForSign = this->hashForSign();
+
+    // Only call encodeForSign() once, store in extraTransactionBytes for TxValidator::verify()
     auto encodedForSign = this->encodeForSign();
+    tarsTx.extraTransactionBytes.reserve(encodedForSign.size());
+    ::ranges::move(encodedForSign, std::back_inserter(tarsTx.extraTransactionBytes));
+
     // FISCO BCOS signature is r||s||v
     tarsTx.signature.reserve(crypto::SECP256K1_SIGNATURE_LEN);
     ::ranges::move(this->signatureR, std::back_inserter(tarsTx.signature));
     ::ranges::move(this->signatureS, std::back_inserter(tarsTx.signature));
     tarsTx.signature.push_back(static_cast<tars::Char>(this->signatureV));
 
-    tarsTx.extraTransactionBytes.reserve(encodedForSign.size());
-    ::ranges::move(encodedForSign, std::back_inserter(tarsTx.extraTransactionBytes));
-
-    const bcos::crypto::Secp256k1Crypto signatureImpl;
-    bcos::crypto::Keccak256 hashImpl;
-    auto signRef = bcos::bytesConstRef(
-        reinterpret_cast<const bcos::byte*>(tarsTx.signature.data()), tarsTx.signature.size());
-    auto [_, sender] = signatureImpl.recoverAddress(hashImpl, hashForSign, signRef);
     tarsTx.data.nonce = toQuantity(this->nonce);
     tarsTx.data.chainID = std::to_string(this->chainId.value_or(0));
-    tarsTx.dataHash.reserve(crypto::HashType::SIZE);
-    ::ranges::move(hashForSign, std::back_inserter(tarsTx.dataHash));
-    tarsTx.sender.reserve(sender.size());
-    ::ranges::move(sender, std::back_inserter(tarsTx.sender));
+
+    // dataHash and sender left empty — TxValidator::verify() computes them
     return tarsTx;
 }
 std::ostream& operator<<(std::ostream& _out, const TransactionType& _in)

--- a/bcos-rpc/test/unittests/common/RPCFixture.h
+++ b/bcos-rpc/test/unittests/common/RPCFixture.h
@@ -114,10 +114,11 @@ public:
             m_blockFactory, m_frontService, m_ledger, "group0", "chain0", 100000000,
             bcos::txpool::DEFAULT_POOL_LIMIT, true);
 
+        scheduler = std::make_shared<FakeScheduler2>(m_ledger, m_blockFactory);
+        txPoolFactory->setScheduler(scheduler);
         txPool = txPoolFactory->createTxPool();
         txPool->init();
         txPool->start();
-        scheduler = std::make_shared<FakeScheduler2>(m_ledger, m_blockFactory);
 
         nodeService = std::make_shared<rpc::NodeService>(
             m_ledger, scheduler, txPool, nullptr, nullptr, m_blockFactory);

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -336,11 +336,16 @@ TransactionStatus MemoryStorage::verifyAndSubmitTransaction(
             // Step 3: Validate transaction format and constraints
             return m_config->txValidator()->validateTransaction(*transaction);
         },
-        // [this, transaction]() {
-        //     // Step 4: Validate balance
-        //     return task::syncWait(
-        //         m_config->txValidator()->validateBalance(*transaction, m_config->ledger()));
-        // },
+        [this, transaction]() {
+            // Step 4: Validate balance (only for Web3 transactions)
+            if (transaction->type() ==
+                static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction))
+            {
+                return task::syncWait(
+                    m_config->txValidator()->validateBalance(*transaction, m_config->ledger()));
+            }
+            return bcos::protocol::TransactionStatus::None;
+        },
         [this, transaction]() {
             // Step 5: Check chain Id
             return task::syncWait(

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -169,6 +169,10 @@ TransactionStatus TxValidator::validateTransaction(const bcos::protocol::Transac
 task::Task<TransactionStatus> TxValidator::validateBalance(
     const bcos::protocol::Transaction& _tx, std::shared_ptr<bcos::ledger::LedgerInterface> _ledger)
 {
+    if (_tx.type() != static_cast<uint8_t>(TransactionType::Web3Transaction))
+    {
+        co_return TransactionStatus::None;
+    }
     auto sender = toHex(_tx.sender());
 
     u256 balanceValue{};

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -206,8 +206,8 @@ task::Task<TransactionStatus> TxValidator::validateBalance(
     }
     // if gasPriceConfig is not set, we can skip the balance check
     bool skipBalanceCheck = false;
-    if (auto gasPriceConfig = co_await ledger::getSystemConfig(
-            *_ledger->getStateStorage(), ledger::SYSTEM_KEY_TX_GAS_PRICE, ledger::fromStorage))
+    if (auto gasPriceConfig =
+            co_await ledger::getSystemConfig(*_ledger, ledger::SYSTEM_KEY_TX_GAS_PRICE))
     {
         if (auto& [gasPriceStr, blockNumber] = gasPriceConfig.value();
             gasPriceStr == "0x0" || gasPriceStr == "0")

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -63,6 +63,9 @@ TransactionStatus TxValidator::verify(const bcos::protocol::Transaction& _tx)
     // remove in front module check signature
     try
     {
+        // Defensively clear sender to ensure signature verification is always performed,
+        // preventing bypass via pre-filled sender field from untrusted sources
+        _tx.forceSender({});
         _tx.verify(*m_cryptoSuite->hashImpl(), *m_cryptoSuite->signatureImpl());
     }
     catch (...)

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -515,28 +515,32 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 
     // // Test 6: Step 4 - InsufficientFunds
-    // {
-    //     storageNoSig.clear();
-    //     const std::string senderHex = "0x1234567890123456789012345678901234567890";
-    //     auto tx6 = makeWeb3Tx("0x2", senderHex, false);
-    //     // Set a large value - need to cast to TransactionImpl
-    //     auto tx6Impl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx6);
-    //     if (tx6Impl)
-    //     {
-    //         std::string largeValue = "0x1000000000000000000000000";  // Very large value
-    //         tx6Impl->mutableInner().data.value.assign(largeValue.begin(), largeValue.end());
-    //     }
-    //
-    //     fakeit::When(Method(mockLedger, asyncGetSystemConfigByKey)).AlwaysDo(
-    //         [](auto, auto) -> task::Task<std::optional<std::string>> {
-    //             co_return std::nullopt;
-    //         });
-    //
-    //     auto result = storageNoSig.verifyAndSubmitTransaction(tx6, nullptr, false, false);
-    //     // Note: This depends on the balance validation logic
-    //     // If balance is 0 or insufficient, should return InsufficientFunds
-    //     // The actual result depends on how validateBalance handles empty/null storage
-    // }
+    {
+        storageNoSig.clear();
+        const std::string senderHex = "0x1234567890123456789012345678901234567890";
+        auto tx6 = makeWeb3Tx("0x2", senderHex, false);
+        // Set a large value - need to cast to TransactionImpl
+        auto tx6Impl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx6);
+        if (tx6Impl)
+        {
+            std::string largeValue = "0x1000000000000000000000000";  // Very large value
+            tx6Impl->mutableInner().data.value.assign(largeValue.begin(), largeValue.end());
+        }
+
+        fakeit::When(Method(mockLedger, asyncGetSystemConfigByKey))
+            .AlwaysDo(
+                [](auto const&,
+                    std::function<void(Error::Ptr, std::string, protocol::BlockNumber)> callback) {
+                    callback(nullptr, "0x1234", 0);
+                });
+
+        fakeit::When(Method(mockLedger, asyncGetBlockNumber)).AlwaysDo([](auto) -> long long {
+            return 0;
+        });
+
+        auto result = storageNoSig.verifyAndSubmitTransaction(tx6, nullptr, false, false);
+        BOOST_CHECK(result == TransactionStatus::InsufficientFunds);
+    }
 
     // Test 7: Step 5 - InvalidChainId (for Web3Transaction)
     {
@@ -553,12 +557,19 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
 
         fakeit::When(Method(mockLedger, asyncGetSystemConfigByKey))
             .AlwaysDo(
-                [](auto const&,
+                [](auto const& key,
                     std::function<void(Error::Ptr, std::string, protocol::BlockNumber)> callback) {
-                    callback(nullptr, "321", 0);
+                    if (key == ledger::SYSTEM_KEY_WEB3_CHAIN_ID)
+                    {
+                        callback(nullptr, "321", 0);
+                    }
+                    else if (key == ledger::SYSTEM_KEY_TX_GAS_PRICE)
+                    {
+                        callback(nullptr, "0", 0);
+                    }
                 });
         auto result = storageNoSig.verifyAndSubmitTransaction(tx7, nullptr, false, false);
-        // The result depends on how validateChainId is implemented
+        BOOST_CHECK(result == TransactionStatus::InvalidChainId);
     }
 
     // Test 8: Success case - All validations pass
@@ -585,6 +596,7 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
         txValidator->setLedgerNonceChecker(ledgerNonceChecker);
 
         auto result = storageNoSig.verifyAndSubmitTransaction(tx8, nullptr, false, false);
+        BOOST_CHECK(result == TransactionStatus::None);
         // Note: Result may vary depending on balance validation and other checks
         // The test verifies the validation chain executes without crashing
     }

--- a/bcos-txpool/test/unittests/txpool/TransactionValidatorTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/TransactionValidatorTest.cpp
@@ -119,6 +119,9 @@ BOOST_AUTO_TEST_CASE(testTransactionValidator)
 
     const uint64_t value = 1234567;
     auto txNoEoughtValue = fakeInvalidateTransacton(inputStr, value);
+    auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(txNoEoughtValue);
+    txImpl->mutableInner().type =
+        static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction);
     auto resultWithStateNoEnoughBalance =
         task::syncWait(txpoolConfig->txValidator()->validateBalance(*txNoEoughtValue, ledger));
     BOOST_CHECK(resultWithStateNoEnoughBalance == TransactionStatus::InsufficientFunds);

--- a/bcos-txpool/test/unittests/txpool/TxPoolTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/TxPoolTest.cpp
@@ -516,7 +516,7 @@ void txPoolInitAndSubmitWeb3TransactionTest(CryptoSuite::Ptr _cryptoSuite, bool 
     auto txpool = faker->txpool();
     auto txpoolStorage = txpool->txpoolStorage();
     auto ledger = faker->ledger();
-
+    ledger->setSystemConfig(ledger::SYSTEM_KEY_TX_GAS_PRICE, "0");
     auto const eoaKey = _cryptoSuite->signatureImpl()->generateKeyPair();
     // case3: transaction with invalid nonce(conflict with the ledger nonce)
     auto const& blockData = ledger->ledgerData();


### PR DESCRIPTION
## Summary
- **Severity: Major**
- Defensively clear sender before calling `verify()` in `TxValidator::verify()`
- `Transaction::verify()` returns early without signature verification when sender is non-empty, allowing bypass via pre-filled sender fields from untrusted sources

## Test plan
- [ ] Verify normal transaction verification still works
- [ ] Test with transactions containing pre-filled sender fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)