### PR TITLE
fix(txpool): reject unknown transaction types in verify (FB-035)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -40,6 +40,12 @@ TransactionStatus TxValidator::verify(const bcos::protocol::Transaction& _tx)
     {
         return TransactionStatus::InvalidSignature;
     }
+    // Reject unknown transaction types to prevent signature binding bypass
+    if (_tx.type() != static_cast<uint8_t>(TransactionType::BCOSTransaction) &&
+        _tx.type() != static_cast<uint8_t>(TransactionType::Web3Transaction)) [[unlikely]]
+    {
+        return TransactionStatus::Malformed;
+    }
     if (_tx.type() == static_cast<uint8_t>(TransactionType::BCOSTransaction))
     {
         // check groupId and chainId


### PR DESCRIPTION
## Summary
- **Severity: Major**
- Reject unsupported transaction type values early with `Malformed` status
- Unknown types cause signature verification to use a constant zero hash, bypassing groupId/chainId checks and Web3 chain-id validation

## Test plan
- [ ] Verify BCOSTransaction and Web3Transaction types still pass validation
- [ ] Test with unknown type values (e.g., type=2) are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)