### PR TITLE
fix(sync): invoke callback on exception in requestMissedTxsFromPeer (FB-036)

### DIFF
--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -283,6 +283,12 @@ void TransactionSync::requestMissedTxsFromPeer(PublicPtr _generatedNodeID, HashL
                            "requestMissedTxs: verifyFetchedTxs when recv txs response exception")
                     << LOG_KV("message", boost::diagnostic_information(e))
                     << LOG_KV("_peer", _nodeID->shortHex());
+                if (_onVerifyFinished)
+                {
+                    _onVerifyFinished(BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
+                                          "verifyFetchedTxs exception: " + std::string(e.what())),
+                        false);
+                }
             }
         });
 }

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -285,8 +285,9 @@ void TransactionSync::requestMissedTxsFromPeer(PublicPtr _generatedNodeID, HashL
                     << LOG_KV("_peer", _nodeID->shortHex());
                 if (_onVerifyFinished)
                 {
-                    _onVerifyFinished(BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
-                                          "verifyFetchedTxs exception: " + std::string(e.what())),
+                    _onVerifyFinished(
+                        BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
+                            "verifyFetchedTxs exception: " + boost::diagnostic_information(e)),
                         false);
                 }
             }


### PR DESCRIPTION
## Summary
- **Severity: Medium**
- Call `_onVerifyFinished` with error in the catch block of `requestMissedTxsFromPeer()`
- Previously, exceptions in `verifyFetchedTxs()` caused the verification pipeline to stall indefinitely

## Test plan
- [ ] Verify normal transaction fetch and verify flow works
- [ ] Test exception path does not stall the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)