### PR TITLE
fix(sync): stop importing unverified txs on count mismatch (FB-037)

### DIFF
--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -412,6 +412,7 @@ void TxPool::fillBlock(HashListPtr _txsHash,
     ittapi::Report report(
         ittapi::ITT_DOMAINS::instance().TXPOOL, ittapi::ITT_DOMAINS::instance().FILL_BLOCK);
 
+    // getTransactions guarantees that txs and *_txsHash have the same size and order
     auto txs = m_txpoolStorage->getTransactions(*_txsHash);
     auto missedTxs = ::ranges::views::zip(*_txsHash, txs) |
                      ::ranges::views::filter([](const auto& pair) {

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -341,7 +341,26 @@ void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, byt
             BCOS_ERROR_PTR(CommonError::TransactionsMissing, "TransactionsMissing"), false);
         return;
     }
-    // Verify transaction hashes match requested hashes before import
+    // Verify transaction hashes match requested hashes BEFORE import
+    const auto hashMismatch = ::ranges::any_of(
+        ::ranges::views::zip(*_missedTxs, transactions->transactions()), [](auto const& pair) {
+            auto& [expectedHash, tx] = pair;
+            return expectedHash != tx->hash();
+        });
+    if (hashMismatch)
+    {
+        SYNC_LOG(WARNING) << LOG_DESC("verifyFetchedTxs: transaction hash mismatch")
+                          << LOG_KV("peer", _nodeID->shortHex())
+                          << LOG_KV(
+                                 "hash", (_verifiedProposal) ?
+                                             _verifiedProposal->blockHeader()->hash().abridged() :
+                                             "unknown");
+        _onVerifyFinished(
+            BCOS_ERROR_PTR(CommonError::InconsistentTransactions, "InconsistentTransactions"),
+            false);
+        return;
+    }
+    // Hashes verified, now safe to import
     auto [result, txs] = importDownloadedTxsByBlock(transactions, _verifiedProposal);
     if (!result)
     {
@@ -349,16 +368,6 @@ void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, byt
                               "invalid transaction for invalid signature or nonce or blockLimit"),
             false);
         return;
-    }
-    for (size_t i = 0; i < _missedTxs->size(); i++)
-    {
-        if ((*_missedTxs)[i] != (*txs)[i]->hash())
-        {
-            _onVerifyFinished(
-                BCOS_ERROR_PTR(CommonError::InconsistentTransactions, "InconsistentTransactions"),
-                false);
-            return;
-        }
     }
     _onVerifyFinished(error, true);
     SYNC_LOG(DEBUG) << METRIC << LOG_DESC("requestMissedTxs and verify success")

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -327,7 +327,7 @@ void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, byt
     startT = utcTime();
     if (_missedTxs->size() != transactions->transactionsSize())
     {
-        SYNC_LOG(INFO) << LOG_DESC("verifyFetchedTxs failed")
+        SYNC_LOG(INFO) << LOG_DESC("verifyFetchedTxs failed: transaction count mismatch")
                        << LOG_KV("expectedTxs", _missedTxs->size())
                        << LOG_KV("fetchedTxs", transactions->transactionsSize())
                        << LOG_KV("peer", _nodeID->shortHex())
@@ -337,13 +337,11 @@ void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, byt
                        << LOG_KV("consNum", (_verifiedProposal) ?
                                                 _verifiedProposal->blockHeader()->number() :
                                                 -1);
-        // response to verify result
         _onVerifyFinished(
             BCOS_ERROR_PTR(CommonError::TransactionsMissing, "TransactionsMissing"), false);
-        // try to import the transactions even when verify failed
-        importDownloadedTxsByBlock(transactions);
         return;
     }
+    // Verify transaction hashes match requested hashes before import
     auto [result, txs] = importDownloadedTxsByBlock(transactions, _verifiedProposal);
     if (!result)
     {
@@ -352,7 +350,6 @@ void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, byt
             false);
         return;
     }
-    // check the transaction hash
     for (size_t i = 0; i < _missedTxs->size(); i++)
     {
         if ((*_missedTxs)[i] != (*txs)[i]->hash())

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -332,6 +332,14 @@ private:
             auto view = m_multiLayerStorage.get().fork();
             view.newMutable();
             auto transactions = co_await getTransactions(m_txpool.get(), *block);
+            if (::ranges::any_of(transactions, [](auto const& tx) { return tx == nullptr; }))
+            {
+                auto message = fmt::format(
+                    "Not found transactions in txpool for block: {}", blockHeader->number());
+                BASELINE_SCHEDULER_LOG(ERROR) << message;
+                co_return {BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidBlocks, message),
+                    nullptr, false};
+            }
             auto ledgerConfig =
                 co_await ledger::getLedgerConfig(view, blockHeader->number(), m_blockFactory.get());
             auto receipts = co_await m_schedulerImpl.get().executeBlock(view, m_executor.get(),


### PR DESCRIPTION
## Summary
- **Severity: Medium**
- Remove unconditional `importDownloadedTxsByBlock()` call when transaction count mismatches
- Previously, unverified transactions were imported into txpool even on verification failure

## Test plan
- [ ] Verify normal transaction sync import works
- [ ] Test count mismatch does not import unrequested transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)