### PR TITLE
fix(txpool): use CAS loop for monotonic block number in batchInsert (FB-040)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/validator/LedgerNonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/LedgerNonceChecker.cpp
@@ -66,9 +66,9 @@ TransactionStatus LedgerNonceChecker::checkBlockLimit(const bcos::protocol::Tran
 
 void LedgerNonceChecker::batchInsert(BlockNumber _batchId, NonceListPtr const& _nonceList)
 {
-    if (m_blockNumber < _batchId)
+    auto current = m_blockNumber.load();
+    while (current < _batchId && !m_blockNumber.compare_exchange_weak(current, _batchId))
     {
-        m_blockNumber.store(_batchId);
     }
     ssize_t batchToBeRemoved = _batchId - m_blockLimit;
     // insert the latest nonces


### PR DESCRIPTION
## Summary
- **Severity: Medium**
- Replace non-atomic check-then-store with `compare_exchange_weak` loop in `LedgerNonceChecker::batchInsert()`
- Concurrent calls could cause block number regression (T1 reads 99, T2 stores 101, T1 stores 100)

## Test plan
- [ ] Verify block number updates correctly under concurrent calls
- [ ] Test checkBlockLimit works correctly after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)