### PR TITLE
fix(txpool): guard against hardware_concurrency() returning 0 (FB-041)

### DIFF
--- a/bcos-executor/src/executor/SwitchExecutorManager.h
+++ b/bcos-executor/src/executor/SwitchExecutorManager.h
@@ -19,7 +19,7 @@ public:
     const int64_t STOPPED_TERM_ID = -1;
 
     SwitchExecutorManager(bcos::executor::TransactionExecutorFactory::Ptr factory)
-      : m_pool("exec", std::thread::hardware_concurrency()), m_factory(factory)
+      : m_pool("exec", std::max(1u, std::thread::hardware_concurrency())), m_factory(factory)
     {
         factory->registerNeedSwitchEvent([this]() { selfAsyncRefreshExecutor(); });
 

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -150,7 +150,8 @@ TransactionExecutor::TransactionExecutor(bcos::ledger::LedgerInterface::Ptr ledg
     m_gasInjector = std::make_shared<wasm::GasInjector>(wasm::GetInstructionTable());
 #endif
 
-    m_threadPool = std::make_shared<bcos::ThreadPool>(name, std::thread::hardware_concurrency());
+    m_threadPool =
+        std::make_shared<bcos::ThreadPool>(name, std::max(1u, std::thread::hardware_concurrency()));
     setBlockVersion(m_ledgerCache->ledgerConfig().compatibilityVersion());
     if (m_ledgerCache->ledgerConfig().compatibilityVersion() >= BlockVersion::V3_3_VERSION)
     {

--- a/bcos-table/src/KeyPageStorage.h
+++ b/bcos-table/src/KeyPageStorage.h
@@ -95,7 +95,7 @@ public:
         m_pageSize(_pageSize > MIN_PAGE_SIZE ? _pageSize : MIN_PAGE_SIZE),
         m_splitSize(m_pageSize / 3 * 2),
         m_mergeSize(m_pageSize / 4),
-        m_buckets(std::thread::hardware_concurrency()),
+        m_buckets(std::max(1u, std::thread::hardware_concurrency())),
         m_ignoreTables(std::move(_ignoreTables)),
         m_ignoreNotExist(_ignoreNotExist),
         m_setRowWithDirtyFlag(setRowWithDirtyFlag)

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.h
@@ -27,7 +27,7 @@ namespace bcos::txpool
 class TxPoolNonceChecker : public NonceCheckerInterface
 {
 public:
-    TxPoolNonceChecker() : m_nonces(std::thread::hardware_concurrency()) {};
+    TxPoolNonceChecker() : m_nonces(std::max(1u, std::thread::hardware_concurrency())) {};
     bcos::protocol::TransactionStatus checkNonce(const bcos::protocol::Transaction& _tx) override;
     void batchInsert(bcos::protocol::BlockNumber _batchId,
         bcos::protocol::NonceListPtr const& _nonceList) override;


### PR DESCRIPTION
## Summary
- **Severity: Medium**
- Use `std::max(1u, std::thread::hardware_concurrency())` in TxPoolNonceChecker constructor
- `hardware_concurrency()` can return 0 in constrained environments, causing division by zero in BucketMap

## Test plan
- [ ] Verify TxPoolNonceChecker works normally
- [ ] No division by zero in constrained environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)