### PR TITLE
fix(txpool): normalize address prefix in isSystemTransaction (FB-046)

### DIFF
--- a/bcos-executor/src/precompiled/common/Utilities.h
+++ b/bcos-executor/src/precompiled/common/Utilities.h
@@ -98,9 +98,19 @@ inline bool isDynamicPrecompiledAccountCode(const std::string_view& _code)
     return getDynamicPrecompiledCodeString(ACCOUNT_ADDRESS, "") == _code;
 }
 
-inline std::string trimHexPrefix(const std::string& _hex)
+inline std::string trimHexPrefix(std::string _hex)
 {
-    if (_hex.size() >= 2 && _hex[1] == 'x' && _hex[0] == '0')
+    if (_hex.size() >= 2 && (_hex.starts_with("0x") || _hex.starts_with("0X")))
+    {
+        _hex.erase(0, 2);
+    }
+    // NRVO
+    return _hex;
+}
+
+inline std::string_view trimHexPrefix(const std::string_view _hex)
+{
+    if (_hex.size() >= 2 && (_hex.starts_with("0x") || _hex.starts_with("0X")))
     {
         return _hex.substr(2);
     }

--- a/bcos-executor/src/precompiled/common/Utilities.h
+++ b/bcos-executor/src/precompiled/common/Utilities.h
@@ -98,13 +98,12 @@ inline bool isDynamicPrecompiledAccountCode(const std::string_view& _code)
     return getDynamicPrecompiledCodeString(ACCOUNT_ADDRESS, "") == _code;
 }
 
-inline std::string trimHexPrefix(std::string _hex)
+inline std::string& trimHexPrefix(std::string& _hex)
 {
     if (_hex.size() >= 2 && (_hex.starts_with("0x") || _hex.starts_with("0X")))
     {
-        _hex.erase(0, 2);
+        return _hex.erase(0, 2);
     }
-    // NRVO
     return _hex;
 }
 

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
@@ -79,7 +79,13 @@ public:
 protected:
     virtual bool isSystemTransaction(const bcos::protocol::Transaction& _tx)
     {
-        return precompiled::contains(bcos::precompiled::c_systemTxsAddress, _tx.to());
+        auto to = _tx.to();
+        // Normalize: strip 0x/0X prefix to match c_systemTxsAddress entries (unprefixed)
+        if (to.size() > 2 && (to.substr(0, 2) == "0x" || to.substr(0, 2) == "0X"))
+        {
+            to = to.substr(2);
+        }
+        return precompiled::contains(bcos::precompiled::c_systemTxsAddress, to);
     }
 
 private:

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
@@ -19,6 +19,7 @@
  * @date 2021-05-11
  */
 #pragma once
+#include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-txpool/txpool/interfaces/NonceCheckerInterface.h"
 #include "bcos-txpool/txpool/interfaces/TxValidatorInterface.h"
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
@@ -27,6 +28,7 @@
 #include <bcos-task/Task.h>
 #include <bcos-txpool/txpool/validator/Web3NonceChecker.h>
 #include <bcos-utilities/DataConvertUtility.h>
+#include <algorithm>
 
 namespace bcos::txpool
 {
@@ -79,12 +81,17 @@ public:
 protected:
     virtual bool isSystemTransaction(const bcos::protocol::Transaction& _tx)
     {
-        auto to = _tx.to();
-        // Normalize: strip 0x/0X prefix to match c_systemTxsAddress entries (unprefixed)
-        if (to.size() > 2 && (to.substr(0, 2) == "0x" || to.substr(0, 2) == "0X"))
+        // Normalize: strip 0x/0X prefix and convert to lowercase to match
+        // c_systemTxsAddress entries (unprefixed, lowercase hex)
+        auto to = precompiled::trimHexPrefix(_tx.to());
+        // deployment
+        if (to.empty()) [[unlikely]]
         {
-            to = to.substr(2);
+            return false;
         }
+        std::string lower = std::string(to);
+        boost::algorithm::to_lower(lower);
+        to = std::string_view(lower);
         return precompiled::contains(bcos::precompiled::c_systemTxsAddress, to);
     }
 

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
@@ -81,6 +81,11 @@ public:
 protected:
     virtual bool isSystemTransaction(const bcos::protocol::Transaction& _tx)
     {
+        if (_tx.type() == static_cast<uint8_t>(bcos::protocol::TransactionType::BCOSTransaction))
+            [[likely]]
+        {
+            return precompiled::contains(bcos::precompiled::c_systemTxsAddress, _tx.to());
+        }
         // Normalize: strip 0x/0X prefix and convert to lowercase to match
         // c_systemTxsAddress entries (unprefixed, lowercase hex)
         auto to = precompiled::trimHexPrefix(_tx.to());

--- a/bcos-txpool/test/unittests/txpool/TxPoolFixture.h
+++ b/bcos-txpool/test/unittests/txpool/TxPoolFixture.h
@@ -250,7 +250,8 @@ public:
     TransactionSync::Ptr sync() { return m_sync; }
     void appendSealer(NodeIDPtr _nodeId)
     {
-        auto consensusNode = ConsensusNode{_nodeId, consensus::Type::consensus_sealer, 1, 0, 0};
+        auto consensusNode =
+            bcos::consensus::ConsensusNode{_nodeId, consensus::Type::consensus_sealer, 1, 0, 0};
         m_ledger->ledgerConfig()->mutableConsensusNodeList().emplace_back(consensusNode);
         m_txpool->notifyConsensusNodeList(m_ledger->ledgerConfig()->consensusNodeList(), nullptr);
         for (const auto& item : m_fakeGateWay->m_nodeId2TxPool)
@@ -262,7 +263,8 @@ public:
     }
     void appendObserver(NodeIDPtr _nodeId)
     {
-        auto consensusNode = ConsensusNode{_nodeId, consensus::Type::consensus_observer, 0, 0, 0};
+        auto consensusNode =
+            bcos::consensus::ConsensusNode{_nodeId, consensus::Type::consensus_observer, 0, 0, 0};
         m_ledger->ledgerConfig()->mutableObserverList().emplace_back(consensusNode);
         m_txpool->notifyObserverNodeList(m_ledger->ledgerConfig()->observerNodeList(), nullptr);
         for (const auto& item : m_fakeGateWay->m_nodeId2TxPool)


### PR DESCRIPTION
## Summary
- **Severity: Medium**
- Strip `0x`/`0X` prefix from `_tx.to()` before comparing with `c_systemTxsAddress`
- Web3 transactions use prefixed addresses while system address list uses unprefixed 40-hex strings, causing false negatives

## Test plan
- [ ] Verify system transaction detection works with both prefixed and unprefixed addresses
- [ ] Test Web3 transactions to system addresses are correctly identified

🤖 Generated with [Claude Code](https://claude.com/claude-code)