### PR TITLE
fix(txpool): prevent use-after-free and double-resume in receipt-waiting submission (FIB-48)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -312,20 +312,24 @@ TransactionStatus MemoryStorage::verifyAndSubmitTransaction(
     ittapi::Report report(
         ittapi::ITT_DOMAINS::instance().TXPOOL, ittapi::ITT_DOMAINS::instance().SUBMIT_TX);
 
-    // Define validation steps as a chain of validators
+    // Step 1: Check if transaction already exists in txpool
+    {
+        auto result = txpoolStorageCheck(*transaction, txSubmitCallback);
+        if (result == TransactionStatus::AlreadyInTxPoolAndAccept) [[unlikely]]
+        {
+            // Callback has been moved to the existing transaction; return success immediately
+            // without proceeding to insert() to avoid use-after-free and double-resume (FIB-48)
+            return TransactionStatus::None;
+        }
+        if (result != TransactionStatus::None)
+        {
+            return result;
+        }
+    }
+
+    // Define remaining validation steps as a chain
     // Each step returns TransactionStatus::None if validation passes, or an error status otherwise
     const std::vector<std::function<TransactionStatus()>> validationSteps = {
-        [this, transaction, &txSubmitCallback]() {
-            // Step 1: Check if transaction already exists in txpool
-            auto result = txpoolStorageCheck(*transaction, txSubmitCallback);
-            if (result == TransactionStatus::AlreadyInTxPoolAndAccept) [[unlikely]]
-            {
-                // Note: if rpc is slower than p2p tx sync, we also need to accept this tx and
-                // record callback
-                return TransactionStatus::None;
-            }
-            return result;
-        },
         [this, transaction]() {
             // Step 2: Verify transaction signature (if enabled)
             return m_config->checkTransactionSignature() ?

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -640,4 +640,33 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB48_AlreadyInTxPoolAndAcceptReturnsNone)
+{
+    // FIB-48: When a transaction without a callback is re-submitted with a callback,
+    // txpoolStorageCheck() returns AlreadyInTxPoolAndAccept and sets the callback.
+    // The old code continued through the lambda chain into insert(), causing a
+    // use-after-free and potential double-resume of the coroutine handle.
+    // The fix returns TransactionStatus::None immediately after registering the callback.
+
+    auto tx1 = makeTx("fib48_n1", false);
+    storage.insert(tx1);  // Insert without callback
+    BOOST_CHECK_EQUAL(storage.size(), 1U);
+
+    // Re-submit with a callback: tx exists, no prior callback → AlreadyInTxPoolAndAccept
+    // Fix: returns None immediately (callback accepted) without re-entering insert()
+    bool callbackCalled = false;
+    auto result = storage.verifyAndSubmitTransaction(
+        tx1,
+        [&callbackCalled](
+            Error::Ptr, protocol::TransactionSubmitResult::Ptr) { callbackCalled = true; },
+        false, false);
+    BOOST_CHECK(result == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(storage.size(), 1U);  // No duplicate insert
+
+    // Re-submit again: tx now has a callback → AlreadyInTxPool (rejected outright)
+    auto result2 = storage.verifyAndSubmitTransaction(tx1, nullptr, false, false);
+    BOOST_CHECK(result2 == TransactionStatus::AlreadyInTxPool);
+    BOOST_CHECK_EQUAL(storage.size(), 1U);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- **Issue**: When a duplicate tx is submitted with `waitForReceipt=true`, `txpoolStorageCheck()` moves the callback to the existing transaction and returns `AlreadyInTxPoolAndAccept`. The old code returned `None` from the inner lambda, causing the validation chain to continue and eventually call `insert()`, which returned `AlreadyInTxPool`. This caused the awaitable to immediately resume the coroutine. When the existing tx finalizes, it resumes again (double-resume) and accesses a dangling `this` pointer (use-after-free).
- **Fix**: When `txpoolStorageCheck` returns `AlreadyInTxPoolAndAccept`, immediately return `TransactionStatus::None` at the outer scope, skipping all further validation steps and the `insert()` call entirely.

## Test plan
- [ ] Submit a duplicate transaction with `waitForReceipt=true` concurrently — verify no double-resume crash
- [ ] Verify normal transaction submission flow is unaffected
- [ ] Verify `AlreadyInTxPool` (without callback) still returns the correct error

🤖 Generated with [Claude Code](https://claude.com/claude-code)