### PR TITLE
fix(txpool): fix dangling string_view and mutable index keys in Web3Transactions (FIB-49)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.cpp
@@ -13,14 +13,15 @@ bcos::crypto::HashType bcos::txpool::TransactionData::hash() const
 }
 std::string_view bcos::txpool::TransactionData::sender() const
 {
-    return m_transaction->sender();
+    return m_sender;
 }
 int64_t bcos::txpool::TransactionData::nonce() const
 {
     return m_nonce;
 }
 bcos::txpool::TransactionData::TransactionData(protocol::Transaction::Ptr transaction)
-  : m_transaction(std::move(transaction)), m_nonce([&]() {
+  : m_transaction(std::move(transaction)),
+    m_nonce([&]() {
         int64_t nonce;  // NOLINT(cppcoreguidelines-init-variables) - initialized by
                         // std::from_chars
         auto view = m_transaction->nonce();
@@ -30,7 +31,10 @@ bcos::txpool::TransactionData::TransactionData(protocol::Transaction::Ptr transa
             bcos::throwTrace(InvalidNonce{} << bcos::errinfo_comment(std::string{view}));
         }
         return nonce;
-    }())
+    }()),
+    // Copy sender at construction time to own a stable copy; prevents dangling string_view when
+    // forceSender() is called later or when elements are erased from the index (FIB-49)
+    m_sender(m_transaction->sender())
 {}
 void bcos::txpool::Web3Transactions::add(protocol::Transaction::Ptr transaction)
 {

--- a/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
+++ b/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
@@ -25,6 +25,7 @@ struct TransactionData
 {
     protocol::Transaction::Ptr m_transaction;
     int64_t m_nonce;
+    std::string m_sender;  // owned copy to prevent dangling string_view (FIB-49)
 
     int64_t importTime() const;
     crypto::HashType hash() const;
@@ -207,7 +208,9 @@ public:
 
     void remove(InputHashes auto hashes)
     {
-        std::unordered_map<std::string_view, int64_t> senderNonceMap;
+        // Use std::string keys (not string_view) so keys remain valid after elements are erased
+        // from m_transactions (FIB-49)
+        std::unordered_map<std::string, int64_t> senderNonceMap;
         std::unique_lock lock(m_mutex);
         auto& hashIndex = m_transactions.get<1>();
         for (const auto& hash : hashes)

--- a/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
+++ b/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
@@ -217,7 +217,7 @@ public:
         {
             if (auto it = hashIndex.find(hash); it != hashIndex.end())
             {
-                if (auto nonceIt = senderNonceMap.find(it->sender());
+                if (auto nonceIt = senderNonceMap.find(std::string(it->sender()));
                     nonceIt != senderNonceMap.end())
                 {
                     nonceIt->second = std::max(it->nonce(), nonceIt->second);


### PR DESCRIPTION
## Summary
- **Issue**: `TransactionData::sender()` returned a `string_view` directly from `Transaction::sender()`, which could become stale if `forceSender()` was called post-insertion. Also, `remove(InputHashes)` built a `senderNonceMap` with `string_view` keys pointing into container elements, then erased those elements — leaving dangling views.
- **Fix**: Add `std::string m_sender` to `TransactionData` copied at construction; change `sender()` to return from owned `m_sender`; change `senderNonceMap` key type to `std::string`.

## Test plan
- [ ] Verify Web3 transaction insertion with same sender doesn't corrupt index
- [ ] Verify `remove(hashes)` correctly removes all matching transactions without UB
- [ ] Run Web3TransactionsTest suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)