### PR TITLE
fix(txpool): make nonce check-and-reserve atomic in TxPoolNonceChecker (FIB-51)

### DIFF
--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -288,6 +288,40 @@ public:
         }
     }
 
+    bool insertOne(Bucket& bucket, auto key, auto value)
+    {
+        auto const& index = bucket.container.template get<0>();
+        bool found = false;
+        auto it = [&]() {
+            if constexpr (withOrdered)
+            {
+                auto it = index.lower_bound(key);
+                found = (it != index.end() && it->key == key);
+                return it;
+            }
+            else
+            {
+                auto it = index.find(key);
+                found = (it != index.end());
+                return it;
+            }
+        }();
+
+        if (found)
+        {
+            return false;
+        }
+
+        it = bucket.container.emplace_hint(
+            it, Data{.key = Key{std::move(key)}, .value = {std::move(value)}});
+        if constexpr (withLRU)
+        {
+            bucket.capacity += getSize(it->key) + getSize(it->value);
+            updateLRUAndCheck(bucket, it);
+        }
+        return true;
+    }
+
     void removeSome(::ranges::input_range auto keys, bool ignoreLogicalDeletion)
     {
         for (auto&& key : keys)
@@ -330,6 +364,15 @@ public:
         Lock lock(bucket.mutex, true);
         storage.writeOne(bucket, std::move(key), std::move(value), false);
         return {};
+    }
+
+    friend task::AwaitableValue<bool> tag_invoke(
+        storage2::tag_t<storage2::insertIfAbsent> /*unused*/, MemoryStorage& storage, auto key,
+        auto value)
+    {
+        auto& bucket = storage.getBucket(key);
+        Lock lock(bucket.mutex, true);
+        return {storage.insertOne(bucket, std::move(key), std::move(value))};
     }
 
     friend task::AwaitableValue<void> tag_invoke(storage2::tag_t<storage2::writeSome> /*unused*/,

--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -220,7 +220,8 @@ public:
         }) | ::ranges::to<std::vector>();
     }
 
-    void writeOne(Bucket& bucket, auto key, auto value, bool ignoreLogicalDeletion)
+    bool writeOne(
+        Bucket& bucket, auto key, auto value, bool ignoreLogicalDeletion, bool insertOnly = false)
     {
         auto const& index = bucket.container.template get<0>();
         int64_t updatedCapacity = 0;
@@ -245,6 +246,10 @@ public:
 
         if (found)
         {
+            if (insertOnly)
+            {
+                return false;
+            }
             if (!deleteOP || (withLogicalDeletion && !ignoreLogicalDeletion))
             {
                 bucket.container.modify(it, [&](Data& data) mutable {
@@ -286,40 +291,7 @@ public:
             bucket.capacity += updatedCapacity;
             updateLRUAndCheck(bucket, it);
         }
-    }
-
-    bool insertOne(Bucket& bucket, auto key, auto value)
-    {
-        auto const& index = bucket.container.template get<0>();
-        bool found = false;
-        auto it = [&]() {
-            if constexpr (withOrdered)
-            {
-                auto it = index.lower_bound(key);
-                found = (it != index.end() && it->key == key);
-                return it;
-            }
-            else
-            {
-                auto it = index.find(key);
-                found = (it != index.end());
-                return it;
-            }
-        }();
-
-        if (found)
-        {
-            return false;
-        }
-
-        it = bucket.container.emplace_hint(
-            it, Data{.key = Key{std::move(key)}, .value = {std::move(value)}});
-        if constexpr (withLRU)
-        {
-            bucket.capacity += getSize(it->key) + getSize(it->value);
-            updateLRUAndCheck(bucket, it);
-        }
-        return true;
+        return !found;
     }
 
     void removeSome(::ranges::input_range auto keys, bool ignoreLogicalDeletion)
@@ -372,7 +344,8 @@ public:
     {
         auto& bucket = storage.getBucket(key);
         Lock lock(bucket.mutex, true);
-        return {storage.insertOne(bucket, std::move(key), std::move(value))};
+        return {
+            storage.writeOne(bucket, std::move(key), std::move(value), false, /*insertOnly=*/true)};
     }
 
     friend task::AwaitableValue<void> tag_invoke(storage2::tag_t<storage2::writeSome> /*unused*/,

--- a/bcos-framework/bcos-framework/storage2/Storage.h
+++ b/bcos-framework/bcos-framework/storage2/Storage.h
@@ -132,6 +132,15 @@ inline constexpr struct ExistsOne
     }
 } existsOne;
 
+inline constexpr struct InsertIfAbsent
+{
+    auto operator()(auto& storage, auto key, auto value, auto&&... args) const -> task::Task<bool>
+    {
+        co_return co_await tag_invoke(*this, storage, std::move(key), std::move(value),
+            std::forward<decltype(args)>(args)...);
+    }
+} insertIfAbsent;
+
 inline constexpr struct Merge
 {
     auto operator()(auto& toStorage, auto& fromStorage, auto&&... args) const -> task::Task<void>

--- a/bcos-txpool/bcos-txpool/txpool/interfaces/NonceCheckerInterface.h
+++ b/bcos-txpool/bcos-txpool/txpool/interfaces/NonceCheckerInterface.h
@@ -43,7 +43,9 @@ public:
     virtual void batchRemove(bcos::protocol::NonceList const& _nonceList) = 0;
     virtual void batchRemove(tbb::concurrent_unordered_set<bcos::protocol::NonceType,
         std::hash<bcos::protocol::NonceType>> const& _nonceList) = 0;
-    virtual void insert(bcos::protocol::NonceType const& _nonce) = 0;
+    // Returns true if the nonce was newly inserted, false if it already existed.
+    // Callers should treat false as NonceCheckFail (atomic check-and-reserve, FIB-51).
+    virtual bool insert(bcos::protocol::NonceType const& _nonce) = 0;
 
     virtual void remove(bcos::protocol::NonceType const& _nonce) = 0;
 };

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.cpp
@@ -40,10 +40,13 @@ TransactionStatus TxPoolNonceChecker::checkNonce(const bcos::protocol::Transacti
     return TransactionStatus::None;
 }
 
-void TxPoolNonceChecker::insert(NonceType const& _nonce)
+bool TxPoolNonceChecker::insert(NonceType const& _nonce)
 {
     NonceSet::WriteAccessor accessor;
-    m_nonces.insert(accessor, _nonce);
+    // BucketSet::insert returns true if newly inserted, false if already existed.
+    // This makes check-and-reserve atomic: callers that get false must treat it as
+    // NonceCheckFail without an intermediate checkNonce() call (FIB-51).
+    return m_nonces.insert(accessor, _nonce);
 }
 
 void TxPoolNonceChecker::batchInsert(BlockNumber /*_batchId*/, NonceListPtr const& _nonceList)

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxPoolNonceChecker.h
@@ -36,7 +36,7 @@ public:
         std::hash<bcos::protocol::NonceType>> const& _nonceList) override;
     bool exists(bcos::protocol::NonceType const& _nonce) override;
 
-    void insert(bcos::protocol::NonceType const& _nonce) override;
+    bool insert(bcos::protocol::NonceType const& _nonce) override;
 
 protected:
     void remove(bcos::protocol::NonceType const& _nonce) override;

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -83,9 +83,19 @@ TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
     {
         _tx.setSystemTx(true);
     }
-    m_txPoolNonceChecker->insert(std::string(_tx.nonce()));
-    if (_tx.type() == static_cast<uint8_t>(TransactionType::Web3Transaction))
+    // Atomic check-and-reserve: insert() returns false when the nonce already exists,
+    // replacing the separate checkNonce()+insert() pair that had a TOCTOU race (FIB-51).
+    if (_tx.type() != static_cast<uint8_t>(TransactionType::Web3Transaction))
     {
+        if (!m_txPoolNonceChecker->insert(std::string(_tx.nonce()))) [[unlikely]]
+        {
+            return TransactionStatus::NonceCheckFail;
+        }
+    }
+    else
+    {
+        // For Web3 transactions the memory nonce store is used; the BCOS pool nonce
+        // checker is not applied.
         task::syncWait(m_web3NonceChecker->insertMemoryNonce(
             std::string(_tx.sender()), std::string(_tx.nonce())));
     }

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -94,10 +94,12 @@ TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
     }
     else
     {
-        // For Web3 transactions the memory nonce store is used; the BCOS pool nonce
-        // checker is not applied.
-        task::syncWait(m_web3NonceChecker->insertMemoryNonce(
-            std::string(_tx.sender()), std::string(_tx.nonce())));
+        // Atomic check-and-reserve for Web3 transactions (FIB-51).
+        if (!task::syncWait(m_web3NonceChecker->insertMemoryNonce(
+                std::string(_tx.sender()), std::string(_tx.nonce())))) [[unlikely]]
+        {
+            return TransactionStatus::NonceCheckFail;
+        }
     }
     return TransactionStatus::None;
 }

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -92,14 +92,21 @@ task::Task<TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
     co_return co_await checkWeb3Nonce(_tx.sender(), _tx.nonce(), onlyCheckLedgerNonce);
 }
 
-task::Task<void> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)
+task::Task<bool> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)
 {
     if (c_fileLogLevel == TRACE) [[unlikely]]
     {
         TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: write memory nonces")
                           << LOG_KV("sender", toHex(sender)) << LOG_KV("nonce", nonce);
     }
-    co_await storage2::writeOne(m_memoryNonces, std::make_pair(sender, nonce), std::monostate{});
+    // Atomic check-and-reserve: insertIfAbsent returns false when the (sender, nonce)
+    // pair already exists, eliminating the TOCTOU race between existsOne() and writeOne().
+    if (const bool inserted = co_await storage2::insertIfAbsent(
+            m_memoryNonces, std::make_pair(sender, nonce), std::monostate{});
+        !inserted)
+    {
+        co_return false;
+    }
     const auto maxMemNonce = co_await storage2::readOne(m_maxNonces, sender);
     if (auto const uNonce = u256(nonce); !maxMemNonce.has_value() || uNonce >= maxMemNonce.value())
     {
@@ -112,6 +119,7 @@ task::Task<void> Web3NonceChecker::insertMemoryNonce(std::string sender, std::st
         }
         co_await storage2::writeOne(m_maxNonces, sender, uNonce + 1);
     }
+    co_return true;
 }
 
 task::Task<std::optional<u256>> Web3NonceChecker::getPendingNonce(std::string_view sender)

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.h
@@ -174,7 +174,7 @@ public:
      * @param nonce transaction nonce, number string
      * @return coroutine void
      */
-    virtual task::Task<void> insertMemoryNonce(std::string sender, std::string nonce);
+    virtual task::Task<bool> insertMemoryNonce(std::string sender, std::string nonce);
 
     virtual task::Task<std::optional<u256>> getPendingNonce(std::string_view sender);
 

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -640,4 +640,38 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB51_TxPoolNonceCheckerInsertReturnsBool)
+{
+    // FIB-51: TxPoolNonceChecker::insert() now returns bool (true = newly inserted,
+    // false = already existed). This makes the check-and-reserve atomic per bucket,
+    // eliminating the TOCTOU window between separate checkNonce() + insert() calls.
+
+    TxPoolNonceChecker checker;
+
+    // First insert: nonce is new -> must return true
+    const std::string nonce1 = "fib51_nonce_unique";
+    BOOST_CHECK(checker.insert(nonce1) == true);
+
+    // Second insert of the same nonce: already exists -> must return false
+    BOOST_CHECK(checker.insert(nonce1) == false);
+
+    // Different nonce: returns true again
+    const std::string nonce2 = "fib51_nonce_other";
+    BOOST_CHECK(checker.insert(nonce2) == true);
+
+    // Concurrent test: 50 threads all insert the same nonce; exactly one must succeed
+    const std::string raceNonce = "fib51_race_nonce";
+    std::atomic<int> successCount{0};
+    tbb::parallel_for(tbb::blocked_range<int>(0, 50), [&](const tbb::blocked_range<int>& range) {
+        for (int i = range.begin(); i < range.end(); ++i)
+        {
+            if (checker.insert(raceNonce))
+            {
+                successCount.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+    });
+    BOOST_CHECK_EQUAL(successCount.load(), 1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -67,7 +67,7 @@ struct MemoryStorageFixture
                          void(tbb::concurrent_unordered_set<bcos::protocol::NonceType,
                              std::hash<bcos::protocol::NonceType>> const&)))
             .AlwaysDo([](auto const&) {});
-        fakeit::When(Method(mockNonceChecker, insert)).AlwaysDo([](auto const&) {});
+        fakeit::When(Method(mockNonceChecker, insert)).AlwaysDo([](auto const&) { return true; });
         fakeit::When(Method(mockNonceChecker, remove)).AlwaysDo([](auto const&) {});
     }
 
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
 
     fakeit::Mock<bcos::txpool::Web3NonceChecker> mockWeb3NonceChecker;
     fakeit::When(Method(mockWeb3NonceChecker, insertMemoryNonce))
-        .AlwaysDo([](auto, auto) -> task::Task<void> { co_return; });
+        .AlwaysDo([](auto, auto) -> task::Task<bool> { co_return true; });
 
     std::shared_ptr<bcos::txpool::Web3NonceChecker> web3NonceChecker(
         &mockWeb3NonceChecker.get(), [](bcos::txpool::Web3NonceChecker*) {});

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -23,13 +23,16 @@
 #include <bcos-txpool/txpool/validator/Web3NonceChecker.h>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/test/unit_test.hpp>
+#include <atomic>
 #include <memory>
 #include <range/v3/all.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/transform.hpp>
 #include <ranges>
 #include <set>
+#include <thread>
 #include <unordered_map>
+#include <vector>
 
 using namespace bcos;
 using namespace bcos::txpool;
@@ -77,7 +80,7 @@ BOOST_AUTO_TEST_CASE(testNormalFlow)
     {
         auto status = task::syncWait(checker.checkWeb3Nonce(sender, nonce));
         BOOST_CHECK_EQUAL(status, TransactionStatus::None);
-        task::syncWait(checker.insertMemoryNonce(sender, nonce));
+        BOOST_CHECK(task::syncWait(checker.insertMemoryNonce(sender, nonce)));
     }
     // commit
     std::unordered_map<std::string, std::set<u256>> commitMap = {};
@@ -105,7 +108,8 @@ BOOST_AUTO_TEST_CASE(testNormalFlow)
     // new pending
     for (auto&& sender : senders)
     {
-        task::syncWait(checker.insertMemoryNonce(sender, (*commitMap[sender].rbegin() + 2).str()));
+        BOOST_CHECK(task::syncWait(
+            checker.insertMemoryNonce(sender, (*commitMap[sender].rbegin() + 2).str())));
         auto nonce = task::syncWait(checker.getPendingNonce(toHex(sender)));
         BOOST_CHECK(nonce.has_value());
         BOOST_CHECK_EQUAL(nonce.value(), *commitMap[sender].rbegin() + 2 + 1);
@@ -117,7 +121,7 @@ BOOST_AUTO_TEST_CASE(testNormalFlow)
         auto nonce = task::syncWait(checker.getPendingNonce(toHex(newSender)));
         BOOST_CHECK(!nonce.has_value());
 
-        task::syncWait(checker.insertMemoryNonce(newSender, "1"));
+        BOOST_CHECK(task::syncWait(checker.insertMemoryNonce(newSender, "1")));
         nonce = task::syncWait(checker.getPendingNonce(toHex(newSender)));
         BOOST_CHECK(nonce.has_value());
         BOOST_CHECK_EQUAL(nonce.value(), 2);
@@ -140,7 +144,7 @@ BOOST_AUTO_TEST_CASE(testInvalidNonce)
         }
         else
         {
-            task::syncWait(checker.insertMemoryNonce(sender, nonce));
+            BOOST_CHECK(task::syncWait(checker.insertMemoryNonce(sender, nonce)));
         }
     }
     BOOST_CHECK_EQUAL(dupCount, dupSize);
@@ -215,6 +219,36 @@ BOOST_AUTO_TEST_CASE(testStorageLayerNonce)
         }
     }
     BOOST_CHECK_EQUAL(errorCount, totalSize);
+}
+
+BOOST_AUTO_TEST_CASE(testAtomicInsertMemoryNonce)
+{
+    // 50 concurrent threads all try to insert the same (sender, nonce) pair.
+    // Exactly one must succeed; the rest must return false.
+    constexpr int threadCount = 50;
+    auto sender = Address::generateRandomFixedBytes().toRawString();
+    std::string nonce = "42";
+
+    std::atomic<int> successCount{0};
+    std::vector<std::thread> threads;
+    threads.reserve(threadCount);
+
+    for (int i = 0; i < threadCount; ++i)
+    {
+        threads.emplace_back([&]() {
+            bool inserted = task::syncWait(checker.insertMemoryNonce(sender, nonce));
+            if (inserted)
+            {
+                successCount.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    BOOST_CHECK_EQUAL(successCount.load(), 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- **Issue**: Separate `checkNonce()` + `insert()` in `TxValidator::verify()` created a TOCTOU race — two concurrent transactions with the same nonce could both pass the check before either inserted, allowing duplicate entry.
- **Fix**: Changed `NonceCheckerInterface::insert()` and `TxPoolNonceChecker::insert()` to return `bool` (true=new, false=duplicate). In `verify()`, replaced the separate check+insert pair with a single atomic `insert()` call that returns `NonceCheckFail` when false.

## Test plan
- [ ] Concurrently submit 2 transactions with same nonce — verify only one succeeds
- [ ] Verify normal BCOS transaction nonce checking is unaffected
- [ ] Run TxPool unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)