### PR TITLE
fix(txpool): always run non-signature validation when sig check is disabled (FIB-53)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -323,10 +323,15 @@ TransactionStatus MemoryStorage::verifyAndSubmitTransaction(
             return result;
         },
         [this, transaction]() {
-            // Step 2: Verify transaction signature (if enabled)
-            return m_config->checkTransactionSignature() ?
-                       m_config->txValidator()->verify(*transaction) :
-                       TransactionStatus::None;
+            // Step 2: Verify transaction signature (if enabled); always run non-signature
+            // validation (groupId, chainId, nonce, block limit, system-tx mark) regardless of
+            // signature check setting so that disabling signatures does not bypass critical
+            // validation steps (FIB-53).
+            if (m_config->checkTransactionSignature())
+            {
+                return m_config->txValidator()->verify(*transaction);
+            }
+            return m_config->txValidator()->checkTransaction(*transaction);
         },
         [this, transaction]() {
             // Step 3: Validate transaction format and constraints

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -628,4 +628,74 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB53_CheckSigFalseStillValidates)
+{
+    // FIB-53: When checkSig=false the old code returned None immediately from step 2,
+    // bypassing checkTransaction() (nonce, group-id, chain-id). The fix always calls
+    // checkTransaction() when checkSig is off so that format validation still fires.
+    // This test confirms that validateTransaction() (step 3) catches format violations
+    // even when signature verification is disabled.
+
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+
+    fakeit::Mock<bcos::txpool::Web3NonceChecker> mockW3;
+    fakeit::When(Method(mockW3, insertMemoryNonce)).AlwaysDo([](auto, auto) -> task::Task<void> {
+        co_return;
+    });
+    fakeit::When(OverloadedMethod(mockW3, checkWeb3Nonce,
+                     task::Task<TransactionStatus>(const bcos::protocol::Transaction&, bool)))
+        .AlwaysDo([](const auto&, auto) -> task::Task<TransactionStatus> {
+            co_return TransactionStatus::None;
+        });
+    fakeit::When(OverloadedMethod(mockW3, checkWeb3Nonce,
+                     task::Task<TransactionStatus>(std::string_view, std::string_view, bool)))
+        .AlwaysDo([](auto, auto, auto) -> task::Task<TransactionStatus> {
+            co_return TransactionStatus::None;
+        });
+    std::shared_ptr<bcos::txpool::Web3NonceChecker> w3(
+        &mockW3.get(), [](bcos::txpool::Web3NonceChecker*) {});
+
+    auto realValidator = std::make_shared<TxValidator>(txPoolNonceChecker, w3, cryptoSuite, "g",
+        "c", std::weak_ptr<bcos::scheduler::SchedulerInterface>{});
+    auto lnc = std::make_shared<LedgerNonceChecker>(nullptr, 0, 1000, /*checkBlockLimit*/ false);
+    realValidator->setLedgerNonceChecker(lnc);
+
+    // checkSig=false: signature step is skipped, but format validation must still run
+    auto cfgNoSig = std::make_shared<TxPoolConfig>(realValidator, nullptr, nullptr, nullptr,
+        txPoolNonceChecker, 1000, 1024, /*checkSig=*/false);
+    MemoryStorage storNoSig(cfgNoSig);
+
+    const std::string senderHex = "0x1234567890123456789012345678901234567890";
+
+    // Case 1: Web3 tx with overflow value must be rejected even without sig check
+    auto txBadVal = makeWeb3Tx("0x11", senderHex, false);
+    auto txBadValImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(txBadVal);
+    if (txBadValImpl)
+    {
+        std::string bigVal(TRANSACTION_VALUE_MAX_LENGTH + 1, '1');
+        txBadValImpl->mutableInner().data.value.assign(bigVal.begin(), bigVal.end());
+    }
+    auto r1 = storNoSig.verifyAndSubmitTransaction(txBadVal, nullptr, false, false);
+    BOOST_CHECK_EQUAL(r1, TransactionStatus::OverFlowValue);
+
+    // Case 2: Web3 tx with oversized input (contract creation) must also be rejected
+    auto txBadInput = makeWeb3Tx("0x22", senderHex, false);
+    auto txBadInputImpl =
+        std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(txBadInput);
+    if (txBadInputImpl)
+    {
+        std::string bigInput(MAX_INITCODE_SIZE + 1, '1');
+        txBadInputImpl->mutableInner().data.input.assign(bigInput.begin(), bigInput.end());
+    }
+    auto r2 = storNoSig.verifyAndSubmitTransaction(txBadInput, nullptr, false, false);
+    BOOST_CHECK_EQUAL(r2, TransactionStatus::MaxInitCodeSizeExceeded);
+
+    // Sanity: a well-formed Web3 tx passes
+    auto txGood = makeWeb3Tx("0x33", senderHex, false);
+    auto r3 = storNoSig.verifyAndSubmitTransaction(txGood, nullptr, false, false);
+    BOOST_CHECK_EQUAL(r3, TransactionStatus::None);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- **Issue**: When `checkTransactionSignature()` was false, the ternary in step 2 returned `TransactionStatus::None` immediately, skipping the entire `verify()` call — including groupId/chainId validation, nonce check, block limit check, and system-transaction marking. This allowed arbitrary transactions to bypass all critical protocol-level checks.
- **Fix**: When signature checking is disabled, call `checkTransaction()` instead, which runs all non-cryptographic validations while skipping the signature verification step.

## Test plan
- [ ] With `checkTransactionSignature=false`, submit a tx with invalid groupId — verify it is rejected
- [ ] Verify nonce checking still works when signature check is disabled
- [ ] Verify normal operation with signature checking enabled is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)