### PR TITLE
fix(txpool): bound nonce string length to fix LRU capacity accounting (FIB-57)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -94,6 +94,16 @@ task::Task<TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
 
 task::Task<void> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)
 {
+    // Bound nonce string length to prevent unbounded string content from defeating LRU capacity
+    // accounting (which uses sizeof(pair<string,string>) and ignores dynamic string size) (FIB-57)
+    constexpr static size_t MAX_NONCE_STRING_LENGTH = 78;  // max decimal digits of u256
+    if (nonce.length() > MAX_NONCE_STRING_LENGTH) [[unlikely]]
+    {
+        TXPOOL_LOG(WARNING) << LOG_DESC("Web3Nonce: reject oversized nonce string")
+                            << LOG_KV("sender", toHex(sender))
+                            << LOG_KV("nonceLen", nonce.length());
+        co_return;
+    }
     if (c_fileLogLevel == TRACE) [[unlikely]]
     {
         TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: write memory nonces")

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -32,6 +32,17 @@ using namespace bcos::protocol;
 task::Task<bcos::protocol::TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
     std::string_view sender, std::string_view nonce, bool onlyCheckLedgerNonce)
 {
+    // Reject oversized nonce strings before any u256 conversion to prevent LRU capacity bypass
+    // (FIB-57): max decimal digits of u256 is 78
+    constexpr static size_t MAX_NONCE_STRING_LENGTH = 78;
+    if (nonce.length() > MAX_NONCE_STRING_LENGTH) [[unlikely]]
+    {
+        TXPOOL_LOG(WARNING) << LOG_DESC("Web3Nonce: reject oversized nonce string")
+                            << LOG_KV("sender", toHex(sender))
+                            << LOG_KV("nonceLen", nonce.length());
+        co_return TransactionStatus::NonceCheckFail;
+    }
+
     // sender is bytes view
     auto const senderHex = toHex(sender);
     auto nonceU256 = u256(nonce);
@@ -94,16 +105,6 @@ task::Task<TransactionStatus> Web3NonceChecker::checkWeb3Nonce(
 
 task::Task<void> Web3NonceChecker::insertMemoryNonce(std::string sender, std::string nonce)
 {
-    // Bound nonce string length to prevent unbounded string content from defeating LRU capacity
-    // accounting (which uses sizeof(pair<string,string>) and ignores dynamic string size) (FIB-57)
-    constexpr static size_t MAX_NONCE_STRING_LENGTH = 78;  // max decimal digits of u256
-    if (nonce.length() > MAX_NONCE_STRING_LENGTH) [[unlikely]]
-    {
-        TXPOOL_LOG(WARNING) << LOG_DESC("Web3Nonce: reject oversized nonce string")
-                            << LOG_KV("sender", toHex(sender))
-                            << LOG_KV("nonceLen", nonce.length());
-        co_return;
-    }
     if (c_fileLogLevel == TRACE) [[unlikely]]
     {
         TXPOOL_LOG(TRACE) << LOG_DESC("Web3Nonce: write memory nonces")

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -219,32 +219,27 @@ BOOST_AUTO_TEST_CASE(testStorageLayerNonce)
 
 BOOST_AUTO_TEST_CASE(FIB57_RejectOversizedNonceString)
 {
-    // FIB-57: The LRU capacity accounting used sizeof(pair<string,string>), ignoring dynamic
-    // string allocation. A nonce longer than 78 chars could silently defeat capacity limits.
-    // The fix rejects nonce strings longer than 78 chars (max decimal digits of u256) in
-    // insertMemoryNonce().
-    constexpr size_t MAX_LEN = 78;
+    // FIB-57: Oversized nonce strings must be rejected at the earliest validation point —
+    // checkWeb3Nonce() — before any u256 conversion, to prevent LRU capacity accounting bypass.
+    constexpr size_t MAX_LEN = 78;  // max decimal digits of u256
 
-    // A nonce exactly at the limit (78 chars) should be accepted
-    const std::string senderOk = Address::generateRandomFixedBytes().toRawString();
+    // A nonce exactly at the limit (78 chars) should pass checkWeb3Nonce
+    const std::string sender78 = Address::generateRandomFixedBytes().toRawString();
     const std::string nonce78(MAX_LEN, '1');
-    task::syncWait(checker.insertMemoryNonce(senderOk, nonce78));
-    auto pending78 = task::syncWait(checker.getPendingNonce(toHex(senderOk)));
-    BOOST_CHECK(pending78.has_value());
+    auto status78 = task::syncWait(checker.checkWeb3Nonce(sender78, nonce78));
+    BOOST_CHECK_EQUAL(status78, TransactionStatus::None);
 
-    // A nonce one byte over the limit (79 chars) should be silently dropped
-    const std::string senderOver = Address::generateRandomFixedBytes().toRawString();
+    // A nonce one byte over the limit (79 chars) must be rejected by checkWeb3Nonce
+    const std::string sender79 = Address::generateRandomFixedBytes().toRawString();
     const std::string nonce79(MAX_LEN + 1, '1');
-    task::syncWait(checker.insertMemoryNonce(senderOver, nonce79));
-    auto pending79 = task::syncWait(checker.getPendingNonce(toHex(senderOver)));
-    BOOST_CHECK(!pending79.has_value());
+    auto status79 = task::syncWait(checker.checkWeb3Nonce(sender79, nonce79));
+    BOOST_CHECK_EQUAL(status79, TransactionStatus::NonceCheckFail);
 
-    // A very long nonce (1000 chars) should also be silently dropped
+    // A very long nonce (1000 chars) must also be rejected by checkWeb3Nonce
     const std::string senderLong = Address::generateRandomFixedBytes().toRawString();
     const std::string nonce1000(1000, '9');
-    task::syncWait(checker.insertMemoryNonce(senderLong, nonce1000));
-    auto pendingLong = task::syncWait(checker.getPendingNonce(toHex(senderLong)));
-    BOOST_CHECK(!pendingLong.has_value());
+    auto statusLong = task::syncWait(checker.checkWeb3Nonce(senderLong, nonce1000));
+    BOOST_CHECK_EQUAL(statusLong, TransactionStatus::NonceCheckFail);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3NonceCheckerTest.cpp
@@ -217,5 +217,35 @@ BOOST_AUTO_TEST_CASE(testStorageLayerNonce)
     BOOST_CHECK_EQUAL(errorCount, totalSize);
 }
 
+BOOST_AUTO_TEST_CASE(FIB57_RejectOversizedNonceString)
+{
+    // FIB-57: The LRU capacity accounting used sizeof(pair<string,string>), ignoring dynamic
+    // string allocation. A nonce longer than 78 chars could silently defeat capacity limits.
+    // The fix rejects nonce strings longer than 78 chars (max decimal digits of u256) in
+    // insertMemoryNonce().
+    constexpr size_t MAX_LEN = 78;
+
+    // A nonce exactly at the limit (78 chars) should be accepted
+    const std::string senderOk = Address::generateRandomFixedBytes().toRawString();
+    const std::string nonce78(MAX_LEN, '1');
+    task::syncWait(checker.insertMemoryNonce(senderOk, nonce78));
+    auto pending78 = task::syncWait(checker.getPendingNonce(toHex(senderOk)));
+    BOOST_CHECK(pending78.has_value());
+
+    // A nonce one byte over the limit (79 chars) should be silently dropped
+    const std::string senderOver = Address::generateRandomFixedBytes().toRawString();
+    const std::string nonce79(MAX_LEN + 1, '1');
+    task::syncWait(checker.insertMemoryNonce(senderOver, nonce79));
+    auto pending79 = task::syncWait(checker.getPendingNonce(toHex(senderOver)));
+    BOOST_CHECK(!pending79.has_value());
+
+    // A very long nonce (1000 chars) should also be silently dropped
+    const std::string senderLong = Address::generateRandomFixedBytes().toRawString();
+    const std::string nonce1000(1000, '9');
+    task::syncWait(checker.insertMemoryNonce(senderLong, nonce1000));
+    auto pendingLong = task::syncWait(checker.getPendingNonce(toHex(senderLong)));
+    BOOST_CHECK(!pendingLong.has_value());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test


### PR DESCRIPTION
## Summary
- **Issue**: `m_memoryNonces` LRU uses `sizeof(pair<string,string>)` for capacity accounting, ignoring dynamic string content. An adversary could submit transactions with arbitrarily long nonce strings to bypass the LRU limit and cause unbounded memory growth.
- **Fix**: Reject nonce strings longer than 78 characters (max decimal digits of a u256) in `insertMemoryNonce()`, bounding the dynamic content so the sizeof-based accounting remains effective.

## Test plan
- [ ] Submit a transaction with an oversized nonce string — verify it is rejected
- [ ] Verify normal nonce strings (decimal and hex u256) are accepted
- [ ] Verify LRU eviction behaves correctly under the bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)