### PR TITLE
fix(txpool): eliminate data race in BucketMap::size() with atomic counter (FIB-62)

### DIFF
--- a/bcos-utilities/bcos-utilities/BucketMap.h
+++ b/bcos-utilities/bcos-utilities/BucketMap.h
@@ -27,6 +27,7 @@
 #include <oneapi/tbb/parallel_for.h>
 #include <oneapi/tbb/parallel_for_each.h>
 #include <oneapi/tbb/rw_mutex.h>
+#include <atomic>
 #include <concepts>
 #include <optional>
 #include <random>
@@ -179,16 +180,37 @@ private:
     }
 
     std::vector<typename BucketType::Ptr> m_buckets;
+    // FIB-62: atomic size counter to avoid data races in BucketMap::size()
+    std::atomic<size_t> m_size{0};
 
 public:
     using Ptr = std::shared_ptr<BucketMap>;
     using WriteAccessor = typename BucketType::WriteAccessor;
     using ReadAccessor = typename BucketType::ReadAccessor;
 
-    BucketMap(const BucketMap&) = default;
-    BucketMap(BucketMap&&) noexcept = default;
-    BucketMap& operator=(const BucketMap&) = default;
-    BucketMap& operator=(BucketMap&&) noexcept = default;
+    // std::atomic is not copyable/movable, so we provide explicit ctors/assignment
+    BucketMap(const BucketMap& other) : m_buckets(other.m_buckets), m_size(other.m_size.load()) {}
+    BucketMap(BucketMap&& other) noexcept
+      : m_buckets(std::move(other.m_buckets)), m_size(other.m_size.load())
+    {}
+    BucketMap& operator=(const BucketMap& other)
+    {
+        if (this != &other)
+        {
+            m_buckets = other.m_buckets;
+            m_size.store(other.m_size.load());
+        }
+        return *this;
+    }
+    BucketMap& operator=(BucketMap&& other) noexcept
+    {
+        if (this != &other)
+        {
+            m_buckets = std::move(other.m_buckets);
+            m_size.store(other.m_size.load());
+        }
+        return *this;
+    }
     BucketMap(size_t bucketSize)
     {
         m_buckets.reserve(bucketSize);
@@ -262,7 +284,11 @@ public:
             [&](WriteAccessor& accessor, const auto& range, BucketType& bucket) {
                 for (auto index : range)
                 {
-                    bucket.insert(accessor, keyValues[index]);
+                    // FIB-62: track size atomically
+                    if (bucket.insert(accessor, keyValues[index]))
+                    {
+                        ++m_size;
+                    }
                 }
             });
     }
@@ -298,6 +324,7 @@ public:
                     if (bucket.find(accessor, keys[index]))
                     {
                         bucket.remove(accessor);
+                        --m_size;  // FIB-62: track size atomically
                     }
                 }
             });
@@ -307,20 +334,22 @@ public:
     {
         auto idx = getBucketIndex(keyValue.first);
         auto& bucket = m_buckets[idx];
-        return bucket->insert(accessor, std::move(keyValue));
-    }
-
-    void remove(WriteAccessor& accessor) { accessor.bucket()->remove(accessor); }
-
-    size_t size() const
-    {
-        size_t size = 0;
-        for (const auto& bucket : m_buckets)
+        bool inserted = bucket->insert(accessor, std::move(keyValue));
+        if (inserted)
         {
-            size += bucket->size();
+            ++m_size;  // FIB-62: track size atomically
         }
-        return size;
+        return inserted;
     }
+
+    void remove(WriteAccessor& accessor)
+    {
+        accessor.bucket()->remove(accessor);
+        --m_size;  // FIB-62: track size atomically
+    }
+
+    // FIB-62: return atomic counter instead of summing all buckets without locks
+    size_t size() const { return m_size.load(std::memory_order_relaxed); }
 
     bool empty() const { return size() == 0; }
 
@@ -343,6 +372,7 @@ public:
         {
             bucket->clear();
         }
+        m_size.store(0, std::memory_order_relaxed);  // FIB-62: reset atomic counter
     }
 
     template <class AccessorType>
@@ -416,6 +446,10 @@ public:
                 for (auto index : range)
                 {
                     bool inserted = bucket.insert(accessor, {keys[index], EmptyType()});
+                    if (inserted)
+                    {
+                        ++this->m_size;  // FIB-62: track size atomically
+                    }
                     if constexpr (returnInsertResult)
                     {
                         if (inserted)

--- a/bcos-utilities/bcos-utilities/BucketMap.h
+++ b/bcos-utilities/bcos-utilities/BucketMap.h
@@ -180,6 +180,8 @@ private:
     }
 
     std::vector<typename BucketType::Ptr> m_buckets;
+
+protected:
     // FIB-62: atomic size counter to avoid data races in BucketMap::size()
     std::atomic<size_t> m_size{0};
 

--- a/bcos-utilities/bcos-utilities/BucketMap.h
+++ b/bcos-utilities/bcos-utilities/BucketMap.h
@@ -211,7 +211,7 @@ public:
         }
         return *this;
     }
-    BucketMap(size_t bucketSize)
+    explicit BucketMap(size_t bucketSize)
     {
         m_buckets.reserve(bucketSize);
         for (size_t i = 0; i < bucketSize; i++)
@@ -287,7 +287,7 @@ public:
                     // FIB-62: track size atomically
                     if (bucket.insert(accessor, keyValues[index]))
                     {
-                        ++m_size;
+                        m_size.fetch_add(1, std::memory_order_relaxed);
                     }
                 }
             });
@@ -324,7 +324,8 @@ public:
                     if (bucket.find(accessor, keys[index]))
                     {
                         bucket.remove(accessor);
-                        --m_size;  // FIB-62: track size atomically
+                        m_size.fetch_sub(1, std::memory_order_relaxed);  // FIB-62: track size
+                                                                         // atomically
                     }
                 }
             });
@@ -337,7 +338,7 @@ public:
         bool inserted = bucket->insert(accessor, std::move(keyValue));
         if (inserted)
         {
-            ++m_size;  // FIB-62: track size atomically
+            m_size.fetch_add(1, std::memory_order_relaxed);  // FIB-62: track size atomically
         }
         return inserted;
     }
@@ -345,7 +346,7 @@ public:
     void remove(WriteAccessor& accessor)
     {
         accessor.bucket()->remove(accessor);
-        --m_size;  // FIB-62: track size atomically
+        m_size.fetch_sub(1, std::memory_order_relaxed);  // FIB-62: track size atomically
     }
 
     // FIB-62: return atomic counter instead of summing all buckets without locks
@@ -448,7 +449,8 @@ public:
                     bool inserted = bucket.insert(accessor, {keys[index], EmptyType()});
                     if (inserted)
                     {
-                        ++this->m_size;  // FIB-62: track size atomically
+                        this->m_size.fetch_add(1, std::memory_order_relaxed);  // FIB-62: track size
+                                                                               // atomically
                     }
                     if constexpr (returnInsertResult)
                     {

--- a/bcos-utilities/test/unittests/libutilities/BucketMapTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/BucketMapTest.cpp
@@ -491,6 +491,86 @@ BOOST_AUTO_TEST_CASE(bucketSetBatchInsertReturn)
     }
 }
 
+BOOST_AUTO_TEST_CASE(FIB62_AtomicSizeAccuracy)
+{
+    // FIB-62: BucketMap::size() used to sum all bucket sizes without a lock, which is a
+    // data race under concurrent modification. The fix tracks size via std::atomic<size_t>
+    // updated by insert/remove/batchInsert/batchRemove/clear.
+    using BKMap = bcos::BucketMap<std::string, int, std::hash<std::string>>;
+    using WriteAccessor = BKMap::WriteAccessor;
+
+    // Serial correctness: insert, remove, clear
+    {
+        BKMap m(16);
+        BOOST_CHECK_EQUAL(m.size(), 0);
+
+        for (int i = 0; i < 100; ++i)
+        {
+            WriteAccessor acc;
+            m.insert(acc, {std::to_string(i), i});
+        }
+        BOOST_CHECK_EQUAL(m.size(), 100);
+
+        for (int i = 0; i < 30; ++i)
+        {
+            WriteAccessor acc;
+            if (m.find<WriteAccessor>(acc, std::to_string(i)))
+            {
+                m.remove(acc);
+            }
+        }
+        BOOST_CHECK_EQUAL(m.size(), 70);
+
+        m.clear();
+        BOOST_CHECK_EQUAL(m.size(), 0);
+    }
+
+    // Parallel insert: atomic counter must stay consistent
+    {
+        BKMap m(16);
+        tbb::parallel_for(tbb::blocked_range<int>(0, 1000), [&](const auto& range) {
+            for (int i = range.begin(); i < range.end(); ++i)
+            {
+                WriteAccessor acc;
+                m.insert(acc, {std::to_string(i), i});
+            }
+        });
+        BOOST_CHECK_EQUAL(m.size(), 1000);
+    }
+
+    // Duplicate inserts must not change size
+    {
+        BKMap m(8);
+        WriteAccessor acc1;
+        m.insert(acc1, {"dup_key", 1});
+        BOOST_CHECK_EQUAL(m.size(), 1);
+        WriteAccessor acc2;
+        bool inserted = m.insert(acc2, {"dup_key", 2});
+        BOOST_CHECK(!inserted);
+        BOOST_CHECK_EQUAL(m.size(), 1);
+    }
+
+    // batchInsert and batchRemove maintain size correctly
+    {
+        BKMap m(16);
+        std::vector<std::pair<std::string, int>> kvPairs;
+        for (int i = 0; i < 500; ++i)
+        {
+            kvPairs.emplace_back(std::to_string(i), i);
+        }
+        m.batchInsert(kvPairs);
+        BOOST_CHECK_EQUAL(m.size(), 500);
+
+        std::vector<std::string> keysToRemove;
+        for (int i = 0; i < 200; ++i)
+        {
+            keysToRemove.push_back(std::to_string(i));
+        }
+        m.batchRemove(keysToRemove);
+        BOOST_CHECK_EQUAL(m.size(), 300);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace test
 }  // namespace bcos


### PR DESCRIPTION
## Summary
- `BucketMap::size()` previously iterated all buckets reading `unordered_map::size()` without holding any lock, creating a data race under concurrent inserts/removes
- Added `std::atomic<size_t> m_size{0}` to `BucketMap` and increment/decrement it at every mutation point: `insert()`, `remove()`, `batchInsert()`, `batchRemove()`, `clear()`, and `BucketSet::batchInsert()`
- `size()` now returns the atomic counter in O(1) with no locking needed
- Provided explicit copy/move constructors and assignment operators since `std::atomic` is not copyable/movable by default

## Test plan
- [ ] Existing txpool unit tests pass
- [ ] Concurrent insert/remove threads do not race on `size()`
- [ ] `empty()` (which calls `size()`) is correct after operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)