### PR TITLE
fix(txpool): exclude pending nonce from range removal in Web3Transactions (FIB-63)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
+++ b/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
@@ -111,7 +111,9 @@ private:
         for (auto&& [sender, nonce] : senderNonces)
         {
             auto start = senderNonceIndex.lower_bound(std::make_tuple(sender, 0));
-            auto end = senderNonceIndex.upper_bound(std::make_tuple(sender, nonce));
+            // FIB-63: use lower_bound so nonce == accountNonce is excluded from removal;
+            // upper_bound would include the still-pending transaction at accountNonce.
+            auto end = senderNonceIndex.lower_bound(std::make_tuple(sender, nonce));
             for (auto it = start; it != end;)
             {
                 it = senderNonceIndex.erase(it);

--- a/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
@@ -503,5 +503,49 @@ BOOST_AUTO_TEST_CASE(get_empty_input_returns_empty)
     BOOST_CHECK(results.empty());
 }
 
+BOOST_AUTO_TEST_CASE(FIB63_RemoveByStateExcludesPendingNonce)
+{
+    // FIB-63: remove(state) used upper_bound to find the end of confirmed txs, which
+    // included the tx at nonce==accountNonce (the next pending tx), incorrectly dropping it.
+    // The fix uses lower_bound so only txs with nonce < accountNonce are erased.
+    Web3Transactions pool;
+    constexpr int kSenderBytes = 20;
+    constexpr int kSealLimit = 100;
+    std::string sender("PPPPPPPPPPPPPPPPPPPPP", kSenderBytes);
+
+    // Add nonces 0..5
+    std::vector<protocol::Transaction::Ptr> txs;
+    for (int i = 0; i <= 5; ++i)
+    {
+        txs.emplace_back(makeTx(sender, i));
+    }
+    pool.add(txs);
+
+    // Remove with accountNonce=3: nonces 0,1,2 should be erased; nonce 3 must be preserved
+    MapStateStorage removeState{};
+    setNonce(removeState, sender, "3");
+    task::syncWait(pool.remove(removeState));
+
+    // Seal starting from nonce=3: should see txs 3, 4, 5 (nonce 3 was preserved by lower_bound)
+    MapStateStorage sealState{};
+    setNonce(sealState, sender, "3");
+    std::vector<protocol::Transaction::Ptr> out;
+    task::syncWait(pool.seal(kSealLimit, sealState, std::back_inserter(out)));
+
+    BOOST_CHECK_EQUAL(out.size(), 3);
+
+    // Verify nonces 3, 4, 5 are sealed
+    std::vector<int64_t> sealedNonces;
+    sealedNonces.reserve(out.size());
+    for (auto& tx : out)
+    {
+        sealedNonces.push_back(std::stoll(std::string(tx->nonce())));
+    }
+    ::ranges::sort(sealedNonces);
+    BOOST_CHECK_EQUAL(sealedNonces[0], 3);
+    BOOST_CHECK_EQUAL(sealedNonces[1], 4);
+    BOOST_CHECK_EQUAL(sealedNonces[2], 5);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test


### PR DESCRIPTION
## Summary
- `Web3Transactions::remove(SenderNonces)` used `upper_bound(sender, accountNonce)` as the end iterator, which **includes** the element at `nonce == accountNonce` in the removal range
- That transaction is still pending (the account nonce from ledger is the *next expected* nonce) and must not be deleted
- Changed end to `lower_bound(sender, accountNonce)` so the removal range covers `[0, accountNonce)` — all already-confirmed nonces — while the pending nonce is preserved

## Test plan
- [ ] Existing Web3Transactions unit tests pass
- [ ] After `remove(state)`, a pending tx at the current account nonce is still retrievable
- [ ] Confirmed nonces (< accountNonce) are properly evicted

🤖 Generated with [Claude Code](https://claude.com/claude-code)