### PR TITLE
fix(gateway): validate P2P frame headers and options bounds during decode (FIB-66, FIB-67)

### DIFF
--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -114,6 +114,14 @@ int32_t P2PMessageOptions::decode(const bytesConstRef& _buffer)
             boost::asio::detail::socket_ops::network_to_host_short(*((uint16_t*)&_buffer[offset]));
         offset += 2;
 
+        // FIB-67: validate groupID length against protocol maximum
+        if (groupIDLength > MAX_GROUPID_LENGTH)
+        {
+            P2PMSG_LOG(ERROR) << LOG_DESC("decode: groupID length overflow")
+                              << LOG_KV("groupIDLength", groupIDLength);
+            return MessageDecodeStatus::MESSAGE_ERROR;
+        }
+
         // groupID
         if (groupIDLength > 0)
         {
@@ -128,6 +136,14 @@ int32_t P2PMessageOptions::decode(const bytesConstRef& _buffer)
             boost::asio::detail::socket_ops::network_to_host_short(*((uint16_t*)&_buffer[offset]));
         offset += 2;
 
+        // FIB-67: validate nodeID length against protocol maximum
+        if (nodeIDLength > MAX_NODEID_LENGTH)
+        {
+            P2PMSG_LOG(ERROR) << LOG_DESC("decode: nodeID length overflow")
+                              << LOG_KV("nodeIDLength", nodeIDLength);
+            return MessageDecodeStatus::MESSAGE_ERROR;
+        }
+
         checkOffset(offset + nodeIDLength, length);
         m_srcNodeID.clear();
         m_srcNodeID.insert(
@@ -139,7 +155,15 @@ int32_t P2PMessageOptions::decode(const bytesConstRef& _buffer)
         uint8_t dstNodeCount = *((uint8_t*)&_buffer[offset]);
         offset += 1;
 
-        checkOffset(offset + dstNodeCount * nodeIDLength, length);
+        // FIB-67: validate dstNodeCount against protocol maximum
+        if (dstNodeCount > MAX_DST_NODEID_COUNT)
+        {
+            P2PMSG_LOG(ERROR) << LOG_DESC("decode: dstNodeID count overflow")
+                              << LOG_KV("dstNodeCount", dstNodeCount);
+            return MessageDecodeStatus::MESSAGE_ERROR;
+        }
+
+        checkOffset(offset + static_cast<size_t>(dstNodeCount) * nodeIDLength, length);
         // dstNodeIDs
         m_dstNodeIDs.reserve(dstNodeCount);
         for (size_t i = 0; i < dstNodeCount; i++)
@@ -304,10 +328,27 @@ int32_t P2PMessage::decodeHeader(const bytesConstRef& _buffer)
         boost::asio::detail::socket_ops::network_to_host_long(*((uint32_t*)&_buffer[offset]));
     offset += 4;
 
+    // FIB-66: reject frames where length is less than header size
+    if (m_length < MESSAGE_HEADER_LENGTH)
+    {
+        P2PMSG_LOG(WARNING) << LOG_DESC("Invalid frame: length less than header")
+                            << LOG_KV("length", m_length)
+                            << LOG_KV("headerLen", MESSAGE_HEADER_LENGTH);
+        return MessageDecodeStatus::MESSAGE_ERROR;
+    }
+
     // version
     m_version =
         boost::asio::detail::socket_ops::network_to_host_short(*((uint16_t*)&_buffer[offset]));
     offset += 2;
+
+    // FIB-66: validate version range
+    if (m_version > static_cast<uint16_t>(bcos::protocol::ProtocolVersion::V3))
+    {
+        P2PMSG_LOG(WARNING) << LOG_DESC("Invalid frame: unsupported version")
+                            << LOG_KV("version", m_version);
+        return MessageDecodeStatus::MESSAGE_ERROR;
+    }
 
     // packetType
     m_packetType =
@@ -334,8 +375,12 @@ int32_t P2PMessage::decode(const bytesConstRef& _buffer)
     }
 
     int32_t offset = decodeHeader(_buffer);
-    if (offset <= 0)
-    {  // The packet was not fully received by the network.
+    if (offset < 0)
+    {
+        return MessageDecodeStatus::MESSAGE_ERROR;
+    }
+    if (offset == 0)
+    {
         return MessageDecodeStatus::MESSAGE_INCOMPLETE;
     }
 
@@ -361,8 +406,13 @@ int32_t P2PMessage::decode(const bytesConstRef& _buffer)
         offset += optionsOffset;
     }
 
-    uint32_t length = _buffer.size();
-    checkOffset(offset, m_length);
+    // FIB-66: verify offset does not exceed m_length to prevent unsigned underflow
+    if (static_cast<uint32_t>(offset) > m_length)
+    {
+        P2PMSG_LOG(WARNING) << LOG_DESC("Invalid frame: offset exceeds length")
+                            << LOG_KV("offset", offset) << LOG_KV("length", m_length);
+        return MessageDecodeStatus::MESSAGE_ERROR;
+    }
     auto data = _buffer.getCroppedData(offset, m_length - offset);
     // raw data cropped from buffer, maybe be compressed or not
 

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -24,6 +24,7 @@
 #include "bcos-gateway/libp2p/Common.h"
 #include "bcos-utilities/ZstdCompress.h"
 #include <boost/asio/detail/socket_ops.hpp>
+#include <utility>
 
 using namespace bcos;
 using namespace bcos::gateway;
@@ -31,19 +32,19 @@ using namespace bcos::gateway;
 bool P2PMessageOptions::encode(bytes& _buffer) const
 {
     // parameters check
-    if (m_groupID.size() > MAX_GROUPID_LENGTH)
+    if (m_groupID.size() > MAX_GROUPID_LENGTH) [[unlikely]]
     {
         P2PMSG_LOG(ERROR) << LOG_DESC("groupID length overflow")
                           << LOG_KV("groupID length", m_groupID.size());
         return false;
     }
-    if (m_srcNodeID.empty() || (m_srcNodeID.size() > MAX_NODEID_LENGTH))
+    if (m_srcNodeID.empty() || (m_srcNodeID.size() > MAX_NODEID_LENGTH)) [[unlikely]]
     {
         P2PMSG_LOG(ERROR) << LOG_DESC("srcNodeID length valid")
                           << LOG_KV("srcNodeID length", m_srcNodeID.size());
         return false;
     }
-    if (m_dstNodeIDs.size() > MAX_DST_NODEID_COUNT)
+    if (m_dstNodeIDs.size() > MAX_DST_NODEID_COUNT) [[unlikely]]
     {
         P2PMSG_LOG(ERROR) << LOG_DESC("dstNodeID amount overfow")
                           << LOG_KV("dstNodeID size", m_dstNodeIDs.size());
@@ -137,7 +138,7 @@ int32_t P2PMessageOptions::decode(const bytesConstRef& _buffer)
         offset += 2;
 
         // FIB-67: validate nodeID length against protocol maximum
-        if (nodeIDLength > MAX_NODEID_LENGTH)
+        if (nodeIDLength > MAX_NODEID_LENGTH) [[unlikely]]
         {
             P2PMSG_LOG(ERROR) << LOG_DESC("decode: nodeID length overflow")
                               << LOG_KV("nodeIDLength", nodeIDLength);
@@ -156,14 +157,14 @@ int32_t P2PMessageOptions::decode(const bytesConstRef& _buffer)
         offset += 1;
 
         // FIB-67: validate dstNodeCount against protocol maximum
-        if (dstNodeCount > MAX_DST_NODEID_COUNT)
+        if (dstNodeCount > MAX_DST_NODEID_COUNT) [[unlikely]]
         {
             P2PMSG_LOG(ERROR) << LOG_DESC("decode: dstNodeID count overflow")
                               << LOG_KV("dstNodeCount", dstNodeCount);
             return MessageDecodeStatus::MESSAGE_ERROR;
         }
 
-        checkOffset(offset + static_cast<size_t>(dstNodeCount) * nodeIDLength, length);
+        checkOffset(offset + (static_cast<size_t>(dstNodeCount) * nodeIDLength), length);
         // dstNodeIDs
         m_dstNodeIDs.reserve(dstNodeCount);
         for (size_t i = 0; i < dstNodeCount; i++)
@@ -209,8 +210,6 @@ bool P2PMessage::encodeHeader(bytes& _buffer) const
 
 bool bcos::gateway::P2PMessage::encodeHeaderImpl(bytes& _buffer) const
 {
-    auto offset = _buffer.size();
-
     // set length to zero first
     uint32_t length = 0;
     uint16_t version = boost::asio::detail::socket_ops::host_to_network_short(m_version);
@@ -329,7 +328,7 @@ int32_t P2PMessage::decodeHeader(const bytesConstRef& _buffer)
     offset += 4;
 
     // FIB-66: reject frames where length is less than header size
-    if (m_length < MESSAGE_HEADER_LENGTH)
+    if (m_length < MESSAGE_HEADER_LENGTH) [[unlikely]]
     {
         P2PMSG_LOG(WARNING) << LOG_DESC("Invalid frame: length less than header")
                             << LOG_KV("length", m_length)
@@ -407,7 +406,7 @@ int32_t P2PMessage::decode(const bytesConstRef& _buffer)
     }
 
     // FIB-66: verify offset does not exceed m_length to prevent unsigned underflow
-    if (static_cast<uint32_t>(offset) > m_length)
+    if (std::cmp_greater(offset, m_length)) [[unlikely]]
     {
         P2PMSG_LOG(WARNING) << LOG_DESC("Invalid frame: offset exceeds length")
                             << LOG_KV("offset", offset) << LOG_KV("length", m_length);

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessageV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessageV2.cpp
@@ -64,6 +64,11 @@ bool P2PMessageV2::encodeHeaderImpl(bytes& _buffer) const
 int32_t P2PMessageV2::decodeHeader(const bytesConstRef& _buffer)
 {
     int32_t offset = P2PMessage::decodeHeader(_buffer);
+    // FIB-66: propagate error from base decodeHeader
+    if (offset < 0)
+    {
+        return offset;
+    }
     if (m_version <= bcos::protocol::ProtocolVersion::V0)
     {
         return offset;

--- a/bcos-gateway/test/unittests/GatewayMessageTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayMessageTest.cpp
@@ -125,15 +125,10 @@ void testP2PMessage(std::shared_ptr<MessageFactory> factory, uint32_t _version =
     auto p2pMsg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
     p2pMsg->setVersion(_version);
 
-    if (_version > 0)
     {
+        // Invalid messages may return MESSAGE_ERROR (e.g. invalid version) or MESSAGE_INCOMPLETE
         auto ret3 = p2pMsg->decode(ref(invalidMsgBytes));
-        BOOST_CHECK_EQUAL(ret3, MessageDecodeStatus::MESSAGE_INCOMPLETE);
-    }
-    else
-    {
-        BOOST_CHECK_EQUAL(
-            p2pMsg->decode(ref(invalidMsgBytes)), MessageDecodeStatus::MESSAGE_INCOMPLETE);
+        BOOST_CHECK(ret3 <= 0);
     }
 }
 
@@ -194,15 +189,10 @@ void test_P2PMessageWithoutOptions(std::shared_ptr<MessageFactory> factory, uint
     auto p2pMsg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
     p2pMsg->setVersion(_version);
 
-    if (_version > 0)
     {
+        // Invalid messages may return MESSAGE_ERROR (e.g. invalid version) or MESSAGE_INCOMPLETE
         auto ret1 = p2pMsg->decode(ref(invalidMsgBytes));
-        BOOST_CHECK_EQUAL(ret1, MessageDecodeStatus::MESSAGE_INCOMPLETE);
-    }
-    else
-    {
-        BOOST_CHECK_EQUAL(
-            p2pMsg->decode(ref(invalidMsgBytes)), MessageDecodeStatus::MESSAGE_INCOMPLETE);
+        BOOST_CHECK(ret1 <= 0);
     }
 }
 
@@ -347,7 +337,7 @@ void testP2PMessageCodec(std::shared_ptr<MessageFactory> factory, uint32_t _vers
     auto encodeMsg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
     encodeMsg->setVersion(_version);
 
-    uint16_t version = 0x1234;
+    uint16_t version = static_cast<uint16_t>(bcos::protocol::ProtocolVersion::V3);
     uint32_t seq = 0x12345678;
     uint16_t packetType = GatewayMessageType::PeerToPeerMessage;
     uint16_t ext = 0x1101;
@@ -481,6 +471,177 @@ BOOST_AUTO_TEST_CASE(test_P2PMessage_attr)
 
     BOOST_CHECK_EQUAL(attr->groupID(), group);
     BOOST_CHECK_EQUAL(attr->moduleID(), moduleID);
+}
+
+// FIB-66: Test malformed frame header validation
+BOOST_AUTO_TEST_CASE(test_P2PMessage_decodeHeader_invalidLength)
+{
+    // Craft a 14-byte buffer where m_length field is set to a value less than header size (14)
+    bytes buffer(P2PMessage::MESSAGE_HEADER_LENGTH, 0);
+    // Set length field to 5 (less than MESSAGE_HEADER_LENGTH=14)
+    uint32_t invalidLength = boost::asio::detail::socket_ops::host_to_network_long(5);
+    std::memcpy(buffer.data(), &invalidLength, 4);
+    // Set version to 0 (valid)
+    uint16_t version = 0;
+    std::memcpy(buffer.data() + 4, &version, 2);
+
+    auto factory = std::make_shared<P2PMessageFactory>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    auto ret = msg->decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK_EQUAL(ret, MessageDecodeStatus::MESSAGE_ERROR);
+}
+
+BOOST_AUTO_TEST_CASE(test_P2PMessage_decodeHeader_zeroLength)
+{
+    bytes buffer(P2PMessage::MESSAGE_HEADER_LENGTH, 0);
+    // length = 0, less than header
+    auto factory = std::make_shared<P2PMessageFactory>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    auto ret = msg->decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK_EQUAL(ret, MessageDecodeStatus::MESSAGE_ERROR);
+}
+
+BOOST_AUTO_TEST_CASE(test_P2PMessage_decodeHeader_invalidVersion)
+{
+    bytes buffer(P2PMessage::MESSAGE_HEADER_LENGTH, 0);
+    // Set length = 14 (valid minimum)
+    uint32_t validLength =
+        boost::asio::detail::socket_ops::host_to_network_long(P2PMessage::MESSAGE_HEADER_LENGTH);
+    std::memcpy(buffer.data(), &validLength, 4);
+    // Set version = 99 (beyond V3=3)
+    uint16_t invalidVersion = boost::asio::detail::socket_ops::host_to_network_short(99);
+    std::memcpy(buffer.data() + 4, &invalidVersion, 2);
+
+    auto factory = std::make_shared<P2PMessageFactory>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    auto ret = msg->decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK_EQUAL(ret, MessageDecodeStatus::MESSAGE_ERROR);
+}
+
+BOOST_AUTO_TEST_CASE(test_P2PMessage_decode_offsetExceedsLength)
+{
+    // Create a message with PeerToPeerMessage type (has options) but m_length
+    // set to just the header size. After header parsing, options parsing will make
+    // offset > m_length, triggering the underflow check.
+    bytes buffer(P2PMessage::MESSAGE_HEADER_LENGTH + P2PMessageOptions::OPTIONS_MIN_LENGTH, 0);
+    // Set length = MESSAGE_HEADER_LENGTH (too small for header + options)
+    uint32_t tightLength =
+        boost::asio::detail::socket_ops::host_to_network_long(P2PMessage::MESSAGE_HEADER_LENGTH);
+    std::memcpy(buffer.data(), &tightLength, 4);
+    // version = 0 (valid)
+    // packetType = PeerToPeerMessage (0x5, has options)
+    uint16_t peerType = boost::asio::detail::socket_ops::host_to_network_short(
+        GatewayMessageType::PeerToPeerMessage);
+    std::memcpy(buffer.data() + 6, &peerType, 2);
+
+    auto factory = std::make_shared<P2PMessageFactory>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    auto ret = msg->decode(bytesConstRef(buffer.data(), buffer.size()));
+    // Should return MESSAGE_ERROR (either from options decode or offset>length check)
+    BOOST_CHECK(ret < 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_P2PMessageV2_decodeHeader_errorPropagation)
+{
+    // V2 message with invalid version should propagate error from base decodeHeader
+    bytes buffer(20, 0);  // V2 header is 20 bytes
+    // Set length = 20 (valid for V2)
+    uint32_t validLength = boost::asio::detail::socket_ops::host_to_network_long(20);
+    std::memcpy(buffer.data(), &validLength, 4);
+    // Set version = 200 (invalid, > V3)
+    uint16_t invalidVersion = boost::asio::detail::socket_ops::host_to_network_short(200);
+    std::memcpy(buffer.data() + 4, &invalidVersion, 2);
+
+    auto factory = std::make_shared<P2PMessageFactoryV2>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    auto ret = msg->decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK_EQUAL(ret, MessageDecodeStatus::MESSAGE_ERROR);
+}
+
+// FIB-67: Test options decode bounds validation
+BOOST_AUTO_TEST_CASE(test_P2PMessageOptions_decode_groupIDOverflow)
+{
+    // Craft an options buffer with groupIDLength > MAX_GROUPID_LENGTH
+    // We just need to set the groupIDLength field to a value > 65535 - but since it's uint16_t,
+    // the max is 65535 which equals MAX_GROUPID_LENGTH. So this specific overflow can't happen
+    // with the current wire format. Test that MAX_GROUPID_LENGTH values still work.
+
+    // Instead, test that normal decode works with valid bounds
+    auto options = std::make_shared<P2PMessageOptions>();
+    std::string groupID = "testGroup";
+    std::string srcNodeID = "testNode";
+    uint16_t moduleID = 42;
+
+    options->setGroupID(groupID);
+    options->setSrcNodeID(bytes(srcNodeID.begin(), srcNodeID.end()));
+    options->setModuleID(moduleID);
+
+    bytes buffer;
+    auto r = options->encode(buffer);
+    BOOST_CHECK(r);
+
+    auto decoded = std::make_shared<P2PMessageOptions>();
+    auto ret = decoded->decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK(ret > 0);
+    BOOST_CHECK_EQUAL(decoded->groupID(), groupID);
+}
+
+BOOST_AUTO_TEST_CASE(test_P2PMessageOptions_decode_truncatedBuffer)
+{
+    // Craft a buffer that claims large groupIDLength but has insufficient data
+    bytes buffer(P2PMessageOptions::OPTIONS_MIN_LENGTH, 0);
+    // Set groupIDLength to 1000 but buffer only has OPTIONS_MIN_LENGTH bytes
+    uint16_t largeGroupIDLen = boost::asio::detail::socket_ops::host_to_network_short(1000);
+    std::memcpy(buffer.data(), &largeGroupIDLen, 2);
+
+    auto decoded = std::make_shared<P2PMessageOptions>();
+    auto ret = decoded->decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK_EQUAL(ret, MessageDecodeStatus::MESSAGE_ERROR);
+}
+
+BOOST_AUTO_TEST_CASE(test_P2PMessageOptions_decode_truncatedNodeID)
+{
+    // Create a buffer where nodeIDLength is large but buffer is too small
+    bytes buffer(10, 0);
+    // groupIDLength = 0
+    uint16_t zeroLen = 0;
+    std::memcpy(buffer.data(), &zeroLen, 2);
+    // nodeIDLength = 5000
+    uint16_t largeNodeIDLen = boost::asio::detail::socket_ops::host_to_network_short(5000);
+    std::memcpy(buffer.data() + 2, &largeNodeIDLen, 2);
+
+    auto decoded = std::make_shared<P2PMessageOptions>();
+    auto ret = decoded->decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK_EQUAL(ret, MessageDecodeStatus::MESSAGE_ERROR);
+}
+
+BOOST_AUTO_TEST_CASE(test_P2PMessage_decode_validVersionBoundary)
+{
+    // Test that V3 (max valid) is accepted
+    bytes buffer(P2PMessage::MESSAGE_HEADER_LENGTH, 0);
+    uint32_t validLength =
+        boost::asio::detail::socket_ops::host_to_network_long(P2PMessage::MESSAGE_HEADER_LENGTH);
+    std::memcpy(buffer.data(), &validLength, 4);
+    uint16_t v3 = boost::asio::detail::socket_ops::host_to_network_short(
+        static_cast<uint16_t>(bcos::protocol::ProtocolVersion::V3));
+    std::memcpy(buffer.data() + 4, &v3, 2);
+
+    auto factory = std::make_shared<P2PMessageFactory>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    auto ret = msg->decode(bytesConstRef(buffer.data(), buffer.size()));
+    // V3 is valid, should succeed (return the length)
+    BOOST_CHECK_EQUAL(ret, static_cast<int32_t>(P2PMessage::MESSAGE_HEADER_LENGTH));
+
+    // Test that V3+1 is rejected
+    bytes buffer2(P2PMessage::MESSAGE_HEADER_LENGTH, 0);
+    std::memcpy(buffer2.data(), &validLength, 4);
+    uint16_t v4 = boost::asio::detail::socket_ops::host_to_network_short(
+        static_cast<uint16_t>(bcos::protocol::ProtocolVersion::V3) + 1);
+    std::memcpy(buffer2.data() + 4, &v4, 2);
+
+    auto msg2 = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    auto ret2 = msg2->decode(bytesConstRef(buffer2.data(), buffer2.size()));
+    BOOST_CHECK_EQUAL(ret2, MessageDecodeStatus::MESSAGE_ERROR);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- **FIB-66 (Critical)**: Add range validation in `decodeHeader()` - reject frames where `m_length < MESSAGE_HEADER_LENGTH` and `m_version > ProtocolVersion::V3`. Fix unsigned integer underflow by checking `offset <= m_length` before subtraction in `decode()`. Propagate `MESSAGE_ERROR` in `P2PMessageV2::decodeHeader()`.
- **FIB-67 (Critical)**: Mirror `encode()`-side validation in `P2PMessageOptions::decode()` - enforce `MAX_GROUPID_LENGTH`, `MAX_NODEID_LENGTH`, and `MAX_DST_NODEID_COUNT` during deserialization before any allocation or iteration to prevent memory amplification attacks.

## Test plan
- [x] Added tests for invalid frame length (less than header size)
- [x] Added tests for zero-length frames
- [x] Added tests for invalid protocol version
- [x] Added tests for offset exceeding length (underflow prevention)
- [x] Added tests for V2 error propagation
- [x] Added tests for truncated options buffer
- [x] Added tests for oversized nodeID fields
- [x] Added tests for version boundary validation (V3 accepted, V3+1 rejected)
- [x] All existing tests pass