### PR TITLE
fix(executor): precompiled gas validation, remove noexcept, fix gas refund (FIB-76, FIB-79, FIB-80)

### DIFF
--- a/bcos-executor/src/vm/Precompiled.cpp
+++ b/bcos-executor/src/vm/Precompiled.cpp
@@ -61,16 +61,22 @@ bool bcos::executor::PrecompiledMap::contains(std::string const& key, uint32_t v
 
 PrecompiledExecutor const& PrecompiledRegistrar::executor(std::string const& _name)
 {
-    if (!get()->m_execs.count(_name))
+    auto const it = get()->m_execs.find(_name);
+    if (it == get()->m_execs.end())
+    {
         BOOST_THROW_EXCEPTION(ExecutorNotFound());
-    return get()->m_execs[_name];
+    }
+    return it->second;
 }
 
 PrecompiledPricer const& PrecompiledRegistrar::pricer(std::string const& _name)
 {
-    if (!get()->m_pricers.count(_name))
+    const auto it = get()->m_pricers.find(_name);
+    if (it == get()->m_pricers.end())
+    {
         BOOST_THROW_EXCEPTION(PricerNotFound());
-    return get()->m_pricers[_name];
+    }
+    return it->second;
 }
 
 }  // namespace bcos::executor

--- a/bcos-executor/src/vm/Precompiled.h
+++ b/bcos-executor/src/vm/Precompiled.h
@@ -37,8 +37,8 @@ namespace bcos
 namespace executor
 {
 class BlockContext;
-using PrecompiledExecutor = std::function<std::pair<bool, bytes>(bytesConstRef _in)>;
-using PrecompiledPricer = std::function<bigint(bytesConstRef _in)>;
+using PrecompiledExecutor = std::function<std::pair<bool, bytes>(bytesConstRef)>;
+using PrecompiledPricer = std::function<bigint(bytesConstRef)>;
 
 DERIVE_BCOS_EXCEPTION(ExecutorNotFound);
 DERIVE_BCOS_EXCEPTION(PricerNotFound);
@@ -73,8 +73,10 @@ public:
 private:
     static PrecompiledRegistrar* get()
     {
-        if (!s_this)
+        if (s_this == nullptr)
+        {
             s_this = new PrecompiledRegistrar;
+        }
         return s_this;
     }
 

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
@@ -37,70 +37,45 @@ std::optional<ledger::Features::Flag> featureFlag(Precompiled const& precompiled
 
 inline constexpr struct
 {
+    // FIB-79: removed noexcept to prevent std::terminate on exceptions
     EVMCResult operator()(Precompiled const& precompiled, auto& storage,
         protocol::BlockHeader const& blockHeader, evmc_message const& message,
         evmc_address const& origin, ExternalCaller auto&& externalCaller,
-        auto const& precompiledManager, int64_t contextID, int64_t seq,
-        bool authCheck) const noexcept
+        auto const& precompiledManager, int64_t contextID, int64_t seq, bool authCheck) const
     {
-        return std::visit(
-            bcos::overloaded{
-                [&](executor::PrecompiledContract const& precompiled) {
-                    auto [success, output] =
-                        precompiled.execute({message.input_data, message.input_size});
-                    auto gas = precompiled.cost({message.input_data, message.input_size});
+        try
+        {
+            return std::visit(
+                bcos::overloaded{
+                    [&](executor::PrecompiledContract const& precompiled) {
+                        // FIB-76: compute gas cost BEFORE execution and validate
+                        auto gas = precompiled.cost({message.input_data, message.input_size});
+                        int64_t gasCost = 0;
+                        if (gas > std::numeric_limits<int64_t>::max() || gas < 0)
+                        {
+                            return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
+                                protocol::TransactionStatus::OutOfGas, EVMC_OUT_OF_GAS, 0,
+                                "Precompiled contract gas cost overflow");
+                        }
+                        gasCost = gas.template convert_to<int64_t>();
+                        if (gasCost > message.gas)
+                        {
+                            return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
+                                protocol::TransactionStatus::OutOfGas, EVMC_OUT_OF_GAS, 0,
+                                "Precompiled contract out of gas");
+                        }
 
-                    auto buffer = std::make_unique_for_overwrite<uint8_t[]>(output.size());
-                    ::ranges::copy(output, buffer.get());
-                    EVMCResult result{
-                        evmc_result{
-                            .status_code = success ? EVMC_SUCCESS : EVMC_REVERT,
-                            .gas_left = message.gas - gas.template convert_to<int64_t>(),
-                            .gas_refund = 0,
-                            .output_data = buffer.release(),
-                            .output_size = output.size(),
-                            .release =
-                                [](const struct evmc_result* result) {
-                                    delete[] result->output_data;
-                                },
-                            .create_address = {},
-                            .padding = {},
-                        },
-                        success ? protocol::TransactionStatus::None :
-                                  protocol::TransactionStatus::RevertInstruction};
+                        auto [success, output] =
+                            precompiled.execute({message.input_data, message.input_size});
 
-                    return result;
-                },
-                [&](std::shared_ptr<precompiled::Precompiled> const& precompiled) {
-                    using namespace std::string_literals;
-                    auto contractAddress = address2HexString(message.code_address);
-                    auto executive = buildLegacyExecutive(storage, blockHeader, contractAddress,
-                        std::forward<decltype(externalCaller)>(externalCaller), precompiledManager,
-                        contextID, seq, authCheck);
-
-                    auto params = std::make_shared<precompiled::PrecompiledExecResult>();
-                    params->m_sender = address2HexString(message.sender);
-                    params->m_codeAddress = std::move(contractAddress);
-                    params->m_precompiledAddress = address2HexString(message.recipient);
-                    params->m_origin = address2HexString(origin);
-                    params->m_input = {message.input_data, message.input_size};
-                    params->m_gasLeft = message.gas;
-                    params->m_staticCall = (message.flags & EVMC_STATIC) != 0;
-                    params->m_create = (message.kind == EVMC_CREATE);
-
-                    try
-                    {
-                        auto response = precompiled->call(executive, params);
-
-                        auto buffer = std::make_unique<uint8_t[]>(params->m_execResult.size());
-                        std::uninitialized_copy(
-                            params->m_execResult.begin(), params->m_execResult.end(), buffer.get());
+                        auto buffer = std::make_unique_for_overwrite<uint8_t[]>(output.size());
+                        ::ranges::copy(output, buffer.get());
                         EVMCResult result{evmc_result{
-                                              .status_code = EVMC_SUCCESS,
-                                              .gas_left = response->m_gasLeft,
+                                              .status_code = success ? EVMC_SUCCESS : EVMC_REVERT,
+                                              .gas_left = message.gas - gasCost,
                                               .gas_refund = 0,
                                               .output_data = buffer.release(),
-                                              .output_size = params->m_execResult.size(),
+                                              .output_size = output.size(),
                                               .release =
                                                   [](const struct evmc_result* result) {
                                                       delete[] result->output_data;
@@ -108,29 +83,82 @@ inline constexpr struct
                                               .create_address = {},
                                               .padding = {},
                                           },
-                            protocol::TransactionStatus::None};
+                            success ? protocol::TransactionStatus::None :
+                                      protocol::TransactionStatus::RevertInstruction};
 
                         return result;
-                    }
-                    catch (protocol::PrecompiledError const& e)
-                    {
-                        PRECOMPILE_LOG(WARNING)
-                            << "Revert transaction: PrecompiledFailed"
-                            << LOG_KV("address", contractAddress) << LOG_KV("message", e.what());
-                        return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
-                            protocol::TransactionStatus::PrecompiledError, EVMC_REVERT, message.gas,
-                            e.what());
-                    }
-                    catch (std::exception& e)
-                    {
-                        PRECOMPILE_LOG(WARNING)
-                            << "Precompiled execute error: " << boost::diagnostic_information(e);
-                        return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
-                            protocol::TransactionStatus::PrecompiledError, EVMC_REVERT, message.gas,
-                            "InternalPrecompiledFailed"s);
-                    }
-                }},
-            precompiled.m_precompiled);
+                    },
+                    [&](std::shared_ptr<precompiled::Precompiled> const& precompiled) {
+                        using namespace std::string_literals;
+                        auto contractAddress = address2HexString(message.code_address);
+                        auto executive = buildLegacyExecutive(storage, blockHeader, contractAddress,
+                            std::forward<decltype(externalCaller)>(externalCaller),
+                            precompiledManager, contextID, seq, authCheck);
+
+                        auto params = std::make_shared<precompiled::PrecompiledExecResult>();
+                        params->m_sender = address2HexString(message.sender);
+                        params->m_codeAddress = std::move(contractAddress);
+                        params->m_precompiledAddress = address2HexString(message.recipient);
+                        params->m_origin = address2HexString(origin);
+                        params->m_input = {message.input_data, message.input_size};
+                        params->m_gasLeft = message.gas;
+                        params->m_staticCall = (message.flags & EVMC_STATIC) != 0;
+                        params->m_create = (message.kind == EVMC_CREATE);
+
+                        try
+                        {
+                            auto response = precompiled->call(executive, params);
+
+                            auto buffer = std::make_unique<uint8_t[]>(params->m_execResult.size());
+                            std::uninitialized_copy(params->m_execResult.begin(),
+                                params->m_execResult.end(), buffer.get());
+                            EVMCResult result{evmc_result{
+                                                  .status_code = EVMC_SUCCESS,
+                                                  .gas_left = response->m_gasLeft,
+                                                  .gas_refund = 0,
+                                                  .output_data = buffer.release(),
+                                                  .output_size = params->m_execResult.size(),
+                                                  .release =
+                                                      [](const struct evmc_result* result) {
+                                                          delete[] result->output_data;
+                                                      },
+                                                  .create_address = {},
+                                                  .padding = {},
+                                              },
+                                protocol::TransactionStatus::None};
+
+                            return result;
+                        }
+                        catch (protocol::PrecompiledError const& e)
+                        {
+                            PRECOMPILE_LOG(WARNING) << "Revert transaction: PrecompiledFailed"
+                                                    << LOG_KV("address", params->m_codeAddress)
+                                                    << LOG_KV("message", e.what());
+                            // FIB-80: use remaining gas instead of original gas limit
+                            return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
+                                protocol::TransactionStatus::PrecompiledError, EVMC_REVERT,
+                                params->m_gasLeft, e.what());
+                        }
+                        catch (std::exception& e)
+                        {
+                            PRECOMPILE_LOG(WARNING) << "Precompiled execute error: "
+                                                    << boost::diagnostic_information(e);
+                            // FIB-80: use remaining gas instead of original gas limit
+                            return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
+                                protocol::TransactionStatus::PrecompiledError, EVMC_REVERT,
+                                params->m_gasLeft, "InternalPrecompiledFailed"s);
+                        }
+                    }},
+                precompiled.m_precompiled);
+        }
+        // FIB-79: outer catch to prevent std::terminate from uncaught exceptions
+        catch (std::exception& e)
+        {
+            PRECOMPILE_LOG(ERROR) << "Unexpected precompiled exception: " << e.what();
+            return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
+                protocol::TransactionStatus::PrecompiledError, EVMC_INTERNAL_ERROR, 0,
+                "InternalPrecompiledError");
+        }
     }
 } callPrecompiled{};
 

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
@@ -10,8 +10,8 @@
 #include "bcos-utilities/Overloaded.h"
 #include <evmc/evmc.h>
 #include <boost/exception/diagnostic_information.hpp>
-#include <boost/throw_exception.hpp>
 #include <exception>
+#include <limits>
 #include <memory>
 #include <variant>
 
@@ -46,10 +46,11 @@ inline constexpr struct
         try
         {
             return std::visit(
-                bcos::overloaded{
-                    [&](executor::PrecompiledContract const& precompiled) {
+                bcos::overloaded{// evm built-in precompiled contracts
+                    [&](executor::PrecompiledContract const& precompiledContract) {
                         // FIB-76: compute gas cost BEFORE execution and validate
-                        auto gas = precompiled.cost({message.input_data, message.input_size});
+                        const auto gas =
+                            precompiledContract.cost({message.input_data, message.input_size});
                         int64_t gasCost = 0;
                         if (gas > std::numeric_limits<int64_t>::max() || gas < 0)
                         {
@@ -66,7 +67,7 @@ inline constexpr struct
                         }
 
                         auto [success, output] =
-                            precompiled.execute({message.input_data, message.input_size});
+                            precompiledContract.execute({message.input_data, message.input_size});
 
                         auto buffer = std::make_unique_for_overwrite<uint8_t[]>(output.size());
                         ::ranges::copy(output, buffer.get());
@@ -88,7 +89,8 @@ inline constexpr struct
 
                         return result;
                     },
-                    [&](std::shared_ptr<precompiled::Precompiled> const& precompiled) {
+                    // bcos precompiled contracts
+                    [&](std::shared_ptr<precompiled::Precompiled> const& precompiledContract) {
                         using namespace std::string_literals;
                         auto contractAddress = address2HexString(message.code_address);
                         auto executive = buildLegacyExecutive(storage, blockHeader, contractAddress,
@@ -107,7 +109,7 @@ inline constexpr struct
 
                         try
                         {
-                            auto response = precompiled->call(executive, params);
+                            auto response = precompiledContract->call(executive, params);
 
                             auto buffer = std::make_unique<uint8_t[]>(params->m_execResult.size());
                             std::uninitialized_copy(params->m_execResult.begin(),


### PR DESCRIPTION
## Summary
- **FIB-76 (Major)**: Compute gas cost BEFORE executing precompiled contracts and validate `message.gas >= gasCost`. Return `EVMC_OUT_OF_GAS` if insufficient. Prevents negative `gas_left` and execution without paying gas.
- **FIB-79 (Medium)**: Remove `noexcept` from `callPrecompiled` `operator()` and add outer `try/catch` to prevent `std::terminate` on unexpected exceptions from `std::visit`, heap allocations, or bigint conversions.
- **FIB-80 (Medium)**: Use `params->m_gasLeft` (remaining gas after precompiled execution) instead of `message.gas` (original gas limit) in exception handlers to prevent full gas refund on precompiled errors.

## Test plan
- [x] Existing `TestHostContext/precompiled` test passes
- [x] All transaction-executor tests pass