### PR TITLE
fix(vm): handle analyze() exceptions and bound cached state memory (FIB-95, FIB-96)

### DIFF
--- a/transaction-executor/bcos-transaction-executor/vm/VMFactory.h
+++ b/transaction-executor/bcos-transaction-executor/vm/VMFactory.h
@@ -21,6 +21,7 @@
 
 #pragma once
 #include "VMInstance.h"
+#include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Error.h"
 #include "bcos-utilities/Exceptions.h"
 #include <evmone/evmone.h>
@@ -45,9 +46,18 @@ public:
         {
         case VMKind::evmone:
         {
-            return VMInstance{
-                std::make_shared<evmone::baseline::CodeAnalysis>(evmone::baseline::analyze(
-                    mode, evmone::bytes_view((const uint8_t*)code.data(), code.size())))};
+            // FIB-95: wrap analyze() in try/catch to prevent unhandled exceptions
+            try
+            {
+                return VMInstance{
+                    std::make_shared<evmone::baseline::CodeAnalysis>(evmone::baseline::analyze(
+                        mode, evmone::bytes_view((const uint8_t*)code.data(), code.size())))};
+            }
+            catch (const std::exception& e)
+            {
+                BCOS_LOG(ERROR) << LOG_BADGE("VM") << "Failed to analyze bytecode: " << e.what();
+                BOOST_THROW_EXCEPTION(UnknownVMError{});
+            }
         }
         default:
             BOOST_THROW_EXCEPTION(UnknownVMError{});

--- a/transaction-executor/bcos-transaction-executor/vm/VMInstance.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/VMInstance.cpp
@@ -20,7 +20,9 @@ bcos::executor_v1::EVMCResult bcos::executor_v1::VMInstance::execute(
         *msg, rev, *host, context, std::basic_string_view<uint8_t>(code, codeSize), {});
     auto result = EVMCResult(evmone::baseline::execute(
         *static_cast<evmone::VM const*>(evm), msg->gas, *executionState, *m_instance));
-    if (!localExecutionState)
+    // FIB-96: only cache ExecutionState if memory usage is reasonable
+    constexpr size_t MAX_CACHED_MEMORY = 1024 * 1024;  // 1MB threshold
+    if (!localExecutionState && executionState->memory.size() <= MAX_CACHED_MEMORY)
     {
         localExecutionState = std::move(executionState);
     }


### PR DESCRIPTION
## Summary
- **FIB-95 (Medium)**: Wrap `evmone::baseline::analyze()` in try/catch in `VMFactory::create()` to prevent unhandled exceptions from crashing the executor.
- **FIB-96 (Medium)**: Add 1MB memory threshold check before caching `ExecutionState` per-thread. If EVM memory exceeds the threshold after execution, the state is discarded to prevent memory exhaustion.
- FIB-93 (Optimization) skipped - bytecode analysis caching requires deeper integration work.

## Test plan
- [x] Build passes
- [x] Existing VM tests pass