### PR TITLE
fix(executor): add feature-aware precompiled lookup to enforce feature gating (FIB-84)

### DIFF
--- a/transaction-executor/bcos-transaction-executor/precompiled/ExecutiveWrapper.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/ExecutiveWrapper.h
@@ -57,8 +57,10 @@ public:
     std::shared_ptr<precompiled::Precompiled> getPrecompiled(std::string_view _address,
         uint32_t version, bool isAuth, const ledger::Features& features) const override
     {
-        auto evmcAddr = unhexAddress(_address);
-        const auto* precompiled = m_precompiledManager.getPrecompiled(evmcAddr);
+        auto addressBytes = fromHex(_address);
+        auto address = fromBigEndian<u160>(addressBytes);
+        const auto* precompiled =
+            m_precompiledManager.getPrecompiled(address.convert_to<unsigned long>(), features);
         if (precompiled == nullptr)
         {
             return nullptr;

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
@@ -146,17 +146,24 @@ bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::get
     return nullptr;
 }
 
-// FIB-84: feature-aware lookup
+// FIB-84: feature-aware lookup, gated by bugfix_precompiled_feature_gate
+// When the bugfix flag is off, returns unconditionally (pre-fix behavior) to preserve
+// replay of historical blocks that ran with feature flags improperly enforced.
 bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::getPrecompiled(
     unsigned long contractAddress, const ledger::Features& features) const
 {
     const auto* precompiled = getPrecompiled(contractAddress);
-    if (precompiled != nullptr)
+    if (precompiled == nullptr)
     {
-        if (const auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
-        {
-            return nullptr;
-        }
+        return nullptr;
+    }
+    if (!features.get(ledger::Features::Flag::bugfix_precompiled_feature_gate))
+    {
+        return precompiled;
+    }
+    if (const auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
+    {
+        return nullptr;
     }
     return precompiled;
 }
@@ -165,12 +172,17 @@ bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::get
     const evmc_address& address, const ledger::Features& features) const
 {
     const auto* precompiled = getPrecompiled(address);
-    if (precompiled != nullptr)
+    if (precompiled == nullptr)
     {
-        if (const auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
-        {
-            return nullptr;
-        }
+        return nullptr;
+    }
+    if (!features.get(ledger::Features::Flag::bugfix_precompiled_feature_gate))
+    {
+        return precompiled;
+    }
+    if (const auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
+    {
+        return nullptr;
     }
     return precompiled;
 }

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
@@ -144,3 +144,32 @@ bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::get
 
     return nullptr;
 }
+
+// FIB-84: feature-aware lookup
+bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::getPrecompiled(
+    unsigned long contractAddress, const ledger::Features& features) const
+{
+    auto* precompiled = getPrecompiled(contractAddress);
+    if (precompiled != nullptr)
+    {
+        if (auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
+        {
+            return nullptr;
+        }
+    }
+    return precompiled;
+}
+
+bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::getPrecompiled(
+    const evmc_address& address, const ledger::Features& features) const
+{
+    auto* precompiled = getPrecompiled(address);
+    if (precompiled != nullptr)
+    {
+        if (auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
+        {
+            return nullptr;
+        }
+    }
+    return precompiled;
+}

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
@@ -82,7 +82,8 @@ bcos::executor_v1::PrecompiledManager::PrecompiledManager(crypto::Hash::Ptr hash
     m_address2Precompiled.emplace_back(
         0x100e, std::make_shared<precompiled::BFSPrecompiled>(m_hashImpl));
     m_address2Precompiled.emplace_back(
-        0x5003, std::make_shared<precompiled::PaillierPrecompiled>(m_hashImpl));
+        0x5003, Precompiled{std::make_shared<precompiled::PaillierPrecompiled>(m_hashImpl),
+                    ledger::Features::Flag::feature_paillier});
     m_address2Precompiled.emplace_back(
         0x5004, std::make_shared<precompiled::GroupSigPrecompiled>(m_hashImpl));
     m_address2Precompiled.emplace_back(
@@ -149,10 +150,10 @@ bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::get
 bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::getPrecompiled(
     unsigned long contractAddress, const ledger::Features& features) const
 {
-    auto* precompiled = getPrecompiled(contractAddress);
+    const auto* precompiled = getPrecompiled(contractAddress);
     if (precompiled != nullptr)
     {
-        if (auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
+        if (const auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
         {
             return nullptr;
         }
@@ -163,10 +164,10 @@ bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::get
 bcos::executor_v1::Precompiled const* bcos::executor_v1::PrecompiledManager::getPrecompiled(
     const evmc_address& address, const ledger::Features& features) const
 {
-    auto* precompiled = getPrecompiled(address);
+    const auto* precompiled = getPrecompiled(address);
     if (precompiled != nullptr)
     {
-        if (auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
+        if (const auto flag = featureFlag(*precompiled); flag && !features.get(*flag))
         {
             return nullptr;
         }

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "PrecompiledImpl.h"
+#include "bcos-framework/ledger/Features.h"
 
 namespace bcos::executor_v1
 {
@@ -11,6 +12,12 @@ public:
     PrecompiledManager(crypto::Hash::Ptr hashImpl);
     Precompiled const* getPrecompiled(unsigned long contractAddress) const;
     Precompiled const* getPrecompiled(const evmc_address& address) const;
+
+    // FIB-84: feature-aware lookup - returns nullptr if precompiled's flag is disabled
+    Precompiled const* getPrecompiled(
+        unsigned long contractAddress, const ledger::Features& features) const;
+    Precompiled const* getPrecompiled(
+        const evmc_address& address, const ledger::Features& features) const;
 
 private:
     crypto::Hash::Ptr m_hashImpl;

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.h
@@ -9,7 +9,7 @@ namespace bcos::executor_v1
 class PrecompiledManager
 {
 public:
-    PrecompiledManager(crypto::Hash::Ptr hashImpl);
+    explicit PrecompiledManager(crypto::Hash::Ptr hashImpl);
     Precompiled const* getPrecompiled(unsigned long contractAddress) const;
     Precompiled const* getPrecompiled(const evmc_address& address) const;
 
@@ -21,7 +21,7 @@ public:
 
 private:
     crypto::Hash::Ptr m_hashImpl;
-    std::vector<std::tuple<unsigned long, Precompiled>> m_address2Precompiled;
+    std::vector<std::tuple<unsigned long, Precompiled>> m_address2Precompiled{};
 };
 
 }  // namespace bcos::executor_v1

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -303,7 +303,8 @@ public:
 
     task::Task<size_t> codeSizeAt(const evmc_address& address, auto&&... /*unused*/)
     {
-        if (auto const* precompiled = m_precompiledManager.get().getPrecompiled(address))
+        if (auto const* precompiled =
+                m_precompiledManager.get().getPrecompiled(address, m_ledgerConfig.get().features()))
         {
             co_return executor_v1::size(*precompiled);
         }
@@ -662,8 +663,8 @@ private:
                 << LOG_DESC("callDynamicPrecompiled") << LOG_KV("codeAddr", message.code_address)
                 << LOG_KV("recvAddr", message.recipient) << LOG_KV("code", code);
 
-            if (m_preparedPrecompiled =
-                    m_precompiledManager.get().getPrecompiled(message.recipient);
+            if (m_preparedPrecompiled = m_precompiledManager.get().getPrecompiled(
+                    message.recipient, m_ledgerConfig.get().features());
                 m_preparedPrecompiled == nullptr)
             {
                 BOOST_THROW_EXCEPTION(NotFoundCodeError());
@@ -677,15 +678,11 @@ private:
         // delegatecall static precompiled is not allowed
         if (ref.kind != EVMC_DELEGATECALL)
         {
-            if (auto const* precompiled =
-                    m_precompiledManager.get().getPrecompiled(ref.code_address))
+            if (auto const* precompiled = m_precompiledManager.get().getPrecompiled(
+                    ref.code_address, m_ledgerConfig.get().features()))
             {
-                if (auto flag = executor_v1::featureFlag(*precompiled);
-                    !flag || m_ledgerConfig.get().features().get(*flag))
-                {
-                    m_preparedPrecompiled = precompiled;
-                    co_return;
-                }
+                m_preparedPrecompiled = precompiled;
+                co_return;
             }
         }
     }

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -678,11 +678,23 @@ private:
         // delegatecall static precompiled is not allowed
         if (ref.kind != EVMC_DELEGATECALL)
         {
-            if (auto const* precompiled = m_precompiledManager.get().getPrecompiled(
-                    ref.code_address, m_ledgerConfig.get().features()))
+            auto const& features = m_ledgerConfig.get().features();
+            if (auto const* precompiled =
+                    m_precompiledManager.get().getPrecompiled(ref.code_address, features))
             {
-                m_preparedPrecompiled = precompiled;
-                co_return;
+                // FIB-84: preserve pre-fix manual feature check when bugfix flag is off,
+                // since getPrecompiled(...) in that mode skips enforcement.
+                if (features.get(ledger::Features::Flag::bugfix_precompiled_feature_gate))
+                {
+                    m_preparedPrecompiled = precompiled;
+                    co_return;
+                }
+                if (auto flag = executor_v1::featureFlag(*precompiled);
+                    !flag || features.get(*flag))
+                {
+                    m_preparedPrecompiled = precompiled;
+                    co_return;
+                }
             }
         }
     }

--- a/transaction-executor/tests/FIB84_PrecompiledFeatureGateTest.cpp
+++ b/transaction-executor/tests/FIB84_PrecompiledFeatureGateTest.cpp
@@ -28,6 +28,13 @@ struct PrecompiledFeatureGateFixture
     bcos::crypto::Hash::Ptr hashImpl = std::make_shared<bcos::crypto::Keccak256>();
     PrecompiledManager manager{hashImpl};
     Features features;
+
+    // Enable the bugfix flag so feature gating is actively enforced.
+    // Tests that exercise pre-fix legacy behavior construct their own Features instance.
+    PrecompiledFeatureGateFixture()
+    {
+        features.set(Features::Flag::bugfix_precompiled_feature_gate);
+    }
 };
 
 BOOST_FIXTURE_TEST_SUITE(FIB84_PrecompiledFeatureGateTest, PrecompiledFeatureGateFixture)
@@ -36,15 +43,12 @@ BOOST_FIXTURE_TEST_SUITE(FIB84_PrecompiledFeatureGateTest, PrecompiledFeatureGat
 
 BOOST_AUTO_TEST_CASE(NonGatedPrecompiled_AlwaysReturned)
 {
-    // ecrecover (0x1) has no feature flag
     auto* result = manager.getPrecompiled(1UL, features);
     BOOST_CHECK(result != nullptr);
 
-    // SystemConfig (0x1000) has no feature flag
     result = manager.getPrecompiled(0x1000UL, features);
     BOOST_CHECK(result != nullptr);
 
-    // CryptoPrecompiled (0x100a) has no feature flag
     result = manager.getPrecompiled(0x100aUL, features);
     BOOST_CHECK(result != nullptr);
 }
@@ -53,7 +57,6 @@ BOOST_AUTO_TEST_CASE(NonGatedPrecompiled_AlwaysReturned)
 
 BOOST_AUTO_TEST_CASE(ShardingPrecompiled_BlockedWhenDisabled)
 {
-    // feature_sharding is disabled by default
     auto* result = manager.getPrecompiled(0x1010UL, features);
     BOOST_CHECK(result == nullptr);
 }
@@ -69,7 +72,6 @@ BOOST_AUTO_TEST_CASE(ShardingPrecompiled_ReturnedWhenEnabled)
 
 BOOST_AUTO_TEST_CASE(PaillierPrecompiled_BlockedWhenDisabled)
 {
-    // feature_paillier is disabled by default
     auto* result = manager.getPrecompiled(0x5003UL, features);
     BOOST_CHECK(result == nullptr);
 }
@@ -91,6 +93,7 @@ BOOST_AUTO_TEST_CASE(BalancePrecompiled_BlockedWhenDisabled)
 
 BOOST_AUTO_TEST_CASE(BalancePrecompiled_ReturnedWhenEnabled)
 {
+    features.set(Features::Flag::feature_balance);
     features.set(Features::Flag::feature_balance_precompiled);
     auto* result = manager.getPrecompiled(0x1011UL, features);
     BOOST_CHECK(result != nullptr);
@@ -100,26 +103,22 @@ BOOST_AUTO_TEST_CASE(BalancePrecompiled_ReturnedWhenEnabled)
 
 BOOST_AUTO_TEST_CASE(EvmcAddressOverload_FeatureGateEnforced)
 {
-    // Build evmc_address for 0x5003 (PaillierPrecompiled)
     evmc_address addr{};
     addr.bytes[18] = 0x50;
     addr.bytes[19] = 0x03;
 
-    // Disabled → nullptr
     auto* result = manager.getPrecompiled(addr, features);
     BOOST_CHECK(result == nullptr);
 
-    // Enabled → non-null
     features.set(Features::Flag::feature_paillier);
     result = manager.getPrecompiled(addr, features);
     BOOST_CHECK(result != nullptr);
 }
 
-// --- Non-feature-aware overload still works (backward compat for internal use) ---
+// --- Non-feature-aware overload ---
 
 BOOST_AUTO_TEST_CASE(NonFeatureAwareOverload_AlwaysReturns)
 {
-    // The old overload ignores feature flags — returns the precompiled regardless
     auto* result = manager.getPrecompiled(0x5003UL);
     BOOST_CHECK(result != nullptr);
 
@@ -127,7 +126,7 @@ BOOST_AUTO_TEST_CASE(NonFeatureAwareOverload_AlwaysReturns)
     BOOST_CHECK(result != nullptr);
 }
 
-// --- Unknown address returns nullptr ---
+// --- Unknown address ---
 
 BOOST_AUTO_TEST_CASE(UnknownAddress_ReturnsNullptr)
 {
@@ -136,6 +135,42 @@ BOOST_AUTO_TEST_CASE(UnknownAddress_ReturnsNullptr)
 
     result = manager.getPrecompiled(0xFFFFUL);
     BOOST_CHECK(result == nullptr);
+}
+
+// --- Bugfix flag gating: pre-fix behavior must be preserved for old blocks ---
+
+BOOST_AUTO_TEST_CASE(BugfixFlagOff_PaillierReturnedRegardless)
+{
+    // Old blocks (bugfix flag off) must still see PaillierPrecompiled even without feature_paillier
+    // to preserve consensus with historical execution.
+    Features legacyFeatures;
+    auto* result = manager.getPrecompiled(0x5003UL, legacyFeatures);
+    BOOST_CHECK(result != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(BugfixFlagOff_ShardingReturnedRegardless)
+{
+    Features legacyFeatures;
+    auto* result = manager.getPrecompiled(0x1010UL, legacyFeatures);
+    BOOST_CHECK(result != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(BugfixFlagOff_BalanceReturnedRegardless)
+{
+    Features legacyFeatures;
+    auto* result = manager.getPrecompiled(0x1011UL, legacyFeatures);
+    BOOST_CHECK(result != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(BugfixFlagOn_EnforcesGating)
+{
+    // Explicit coverage: flag on + target feature off => blocked
+    Features strictFeatures;
+    strictFeatures.set(Features::Flag::bugfix_precompiled_feature_gate);
+
+    BOOST_CHECK(manager.getPrecompiled(0x5003UL, strictFeatures) == nullptr);
+    BOOST_CHECK(manager.getPrecompiled(0x1010UL, strictFeatures) == nullptr);
+    BOOST_CHECK(manager.getPrecompiled(0x1011UL, strictFeatures) == nullptr);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-executor/tests/FIB84_PrecompiledFeatureGateTest.cpp
+++ b/transaction-executor/tests/FIB84_PrecompiledFeatureGateTest.cpp
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Unit tests for FIB-84: feature-aware precompiled lookup
+ */
+
+#include "../bcos-transaction-executor/precompiled/PrecompiledManager.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos::executor_v1;
+using namespace bcos::ledger;
+
+struct PrecompiledFeatureGateFixture
+{
+    bcos::crypto::Hash::Ptr hashImpl = std::make_shared<bcos::crypto::Keccak256>();
+    PrecompiledManager manager{hashImpl};
+    Features features;
+};
+
+BOOST_FIXTURE_TEST_SUITE(FIB84_PrecompiledFeatureGateTest, PrecompiledFeatureGateFixture)
+
+// --- Non-gated precompileds should always be returned ---
+
+BOOST_AUTO_TEST_CASE(NonGatedPrecompiled_AlwaysReturned)
+{
+    // ecrecover (0x1) has no feature flag
+    auto* result = manager.getPrecompiled(1UL, features);
+    BOOST_CHECK(result != nullptr);
+
+    // SystemConfig (0x1000) has no feature flag
+    result = manager.getPrecompiled(0x1000UL, features);
+    BOOST_CHECK(result != nullptr);
+
+    // CryptoPrecompiled (0x100a) has no feature flag
+    result = manager.getPrecompiled(0x100aUL, features);
+    BOOST_CHECK(result != nullptr);
+}
+
+// --- ShardingPrecompiled (0x1010) gated by feature_sharding ---
+
+BOOST_AUTO_TEST_CASE(ShardingPrecompiled_BlockedWhenDisabled)
+{
+    // feature_sharding is disabled by default
+    auto* result = manager.getPrecompiled(0x1010UL, features);
+    BOOST_CHECK(result == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(ShardingPrecompiled_ReturnedWhenEnabled)
+{
+    features.set(Features::Flag::feature_sharding);
+    auto* result = manager.getPrecompiled(0x1010UL, features);
+    BOOST_CHECK(result != nullptr);
+}
+
+// --- PaillierPrecompiled (0x5003) gated by feature_paillier (FIB-84 fix) ---
+
+BOOST_AUTO_TEST_CASE(PaillierPrecompiled_BlockedWhenDisabled)
+{
+    // feature_paillier is disabled by default
+    auto* result = manager.getPrecompiled(0x5003UL, features);
+    BOOST_CHECK(result == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(PaillierPrecompiled_ReturnedWhenEnabled)
+{
+    features.set(Features::Flag::feature_paillier);
+    auto* result = manager.getPrecompiled(0x5003UL, features);
+    BOOST_CHECK(result != nullptr);
+}
+
+// --- BalancePrecompiled (0x1011) gated by feature_balance_precompiled ---
+
+BOOST_AUTO_TEST_CASE(BalancePrecompiled_BlockedWhenDisabled)
+{
+    auto* result = manager.getPrecompiled(0x1011UL, features);
+    BOOST_CHECK(result == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(BalancePrecompiled_ReturnedWhenEnabled)
+{
+    features.set(Features::Flag::feature_balance_precompiled);
+    auto* result = manager.getPrecompiled(0x1011UL, features);
+    BOOST_CHECK(result != nullptr);
+}
+
+// --- evmc_address overload ---
+
+BOOST_AUTO_TEST_CASE(EvmcAddressOverload_FeatureGateEnforced)
+{
+    // Build evmc_address for 0x5003 (PaillierPrecompiled)
+    evmc_address addr{};
+    addr.bytes[18] = 0x50;
+    addr.bytes[19] = 0x03;
+
+    // Disabled → nullptr
+    auto* result = manager.getPrecompiled(addr, features);
+    BOOST_CHECK(result == nullptr);
+
+    // Enabled → non-null
+    features.set(Features::Flag::feature_paillier);
+    result = manager.getPrecompiled(addr, features);
+    BOOST_CHECK(result != nullptr);
+}
+
+// --- Non-feature-aware overload still works (backward compat for internal use) ---
+
+BOOST_AUTO_TEST_CASE(NonFeatureAwareOverload_AlwaysReturns)
+{
+    // The old overload ignores feature flags — returns the precompiled regardless
+    auto* result = manager.getPrecompiled(0x5003UL);
+    BOOST_CHECK(result != nullptr);
+
+    result = manager.getPrecompiled(0x1010UL);
+    BOOST_CHECK(result != nullptr);
+}
+
+// --- Unknown address returns nullptr ---
+
+BOOST_AUTO_TEST_CASE(UnknownAddress_ReturnsNullptr)
+{
+    auto* result = manager.getPrecompiled(0xFFFFUL, features);
+    BOOST_CHECK(result == nullptr);
+
+    result = manager.getPrecompiled(0xFFFFUL);
+    BOOST_CHECK(result == nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- **FIB-84 (Medium)**: `PrecompiledManager` stores optional `ledger::Features::Flag` per precompiled but does not enforce them in `getPrecompiled()` lookups. Callers must manually check `featureFlag()`, creating a fragile opt-in pattern. Added `getPrecompiled(address, features)` overloads that return `nullptr` if the precompiled's flag is present but disabled.

## Test plan
- [x] Build passes
- [x] Existing tests pass