### PR TITLE
fix(executor): rollback moved-from records and tombstone handling (FIB-71, FIB-72)

### DIFF
--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -36,7 +36,7 @@ public:
 
     task::Task<void> rollback(Savepoint savepoint)
     {
-        while (static_cast<Savepoint>(m_records.size()) > savepoint)
+        while (!m_records.empty() && m_records.size() > static_cast<size_t>(savepoint))
         {
             auto record = std::move(m_records.back());
             m_records.pop_back();

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -36,14 +36,10 @@ public:
 
     task::Task<void> rollback(Savepoint savepoint)
     {
-        if (m_records.empty())
+        while (static_cast<Savepoint>(m_records.size()) > savepoint)
         {
-            co_return;
-        }
-        for (auto index = static_cast<int64_t>(m_records.size()); index > savepoint; --index)
-        {
-            assert(index > 0);
-            auto& record = m_records[index - 1];
+            auto record = std::move(m_records.back());
+            m_records.pop_back();
             if (record.oldValue)
             {
                 co_await storage2::writeOne(
@@ -51,10 +47,9 @@ public:
             }
             else
             {
-                co_await storage2::removeOne(
-                    m_storage.get(), std::move(record.key), storage2::DIRECT);
+                // FIB-72: use non-DIRECT remove to write tombstone instead of physical delete
+                co_await storage2::removeOne(m_storage.get(), std::move(record.key));
             }
-            m_records.pop_back();
         }
     }
 

--- a/transaction-executor/tests/FIB72_TombstoneRollbackTest.cpp
+++ b/transaction-executor/tests/FIB72_TombstoneRollbackTest.cpp
@@ -1,0 +1,119 @@
+
+#include "../bcos-transaction-executor/RollbackableStorage.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/Storage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Task.h"
+#include "bcos-task/Wait.h"
+#include "bcos-utilities/Ranges.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::executor_v1;
+using namespace std::string_view_literals;
+
+namespace bcos::executor_v1
+{
+
+// Storage with LOGICAL_DELETION — tombstones are preserved as DELETED_TYPE entries
+// instead of being physically erased from the container.
+using TombstoneStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::ORDERED | memory_storage::LOGICAL_DELETION>;
+
+// DIRECT read overloads required by Rollbackable (HasReadOneDirect / HasReadSomeDirect)
+auto tag_invoke(tag_t<readSome> /*unused*/, TombstoneStorage& storage,
+    RANGES::input_range auto&& keys, DIRECT_TYPE /*unused*/)
+    -> task::Task<task::AwaitableReturnType<decltype(readSome(storage, keys))>>
+{
+    co_return co_await readSome(storage, std::forward<decltype(keys)>(keys));
+}
+
+auto tag_invoke(
+    tag_t<readOne> /*unused*/, TombstoneStorage& storage, const auto& key, DIRECT_TYPE /*unused*/)
+    -> task::Task<task::AwaitableReturnType<decltype(readOne(storage, key))>>
+{
+    co_return co_await readOne(storage, key);
+}
+
+}  // namespace bcos::executor_v1
+
+BOOST_AUTO_TEST_SUITE(FIB72_TombstoneRollback)
+
+BOOST_AUTO_TEST_CASE(rollbackWritesTombstoneNotPhysicalDelete)
+{
+    // FIB-72 scenario with layered storage:
+    //
+    // Lower layer holds a pre-existing value for "Key1". The upper (mutable) layer is
+    // wrapped by Rollbackable. A new value is written through Rollbackable and then
+    // rolled back.
+    //
+    // Correct (tombstone):  rollback writes DELETED_TYPE to the upper layer.
+    //   MultiLayerStorage::fillMissingValues sees DELETED_TYPE → stops → returns nullopt.
+    //
+    // Incorrect (physical delete):  rollback erases the entry from the upper layer.
+    //   fillMissingValues sees NOT_EXISTS_TYPE → falls through to lower layer →
+    //   returns the stale "LowerValue".
+
+    task::syncWait([]() -> task::Task<void> {
+        // Lower layer: pre-existing value
+        TombstoneStorage lowerLayer;
+        StateKey testKey{"table1"sv, "Key1"sv};
+        co_await writeOne(lowerLayer, testKey, storage::Entry{"LowerValue"});
+
+        // Upper layer: empty, LOGICAL_DELETION enabled
+        TombstoneStorage upperLayer;
+        Rollbackable rollbackable(upperLayer);
+
+        auto savepoint = rollbackable.current();
+
+        // Write through Rollbackable.
+        // Rollbackable reads DIRECT from upperLayer → nullopt (key absent).
+        // Records oldValue = nullopt.
+        co_await writeOne(rollbackable, StateKey{"table1"sv, "Key1"sv}, storage::Entry{"NewValue"});
+
+        auto written = co_await readOne(rollbackable, StateKey{"table1"sv, "Key1"sv});
+        BOOST_REQUIRE(written);
+        BOOST_CHECK_EQUAL(written->get(), "NewValue");
+
+        // Rollback: oldValue was nullopt → calls removeOne(upperLayer, key) WITHOUT DIRECT
+        // → writes DELETED_TYPE tombstone (not a physical erase).
+        co_await rollbackable.rollback(savepoint);
+
+        // Public readOne returns nullopt for both DELETED_TYPE and NOT_EXISTS_TYPE,
+        // so it alone cannot distinguish tombstone from physical delete.
+        auto afterRollback = co_await readOne(rollbackable, StateKey{"table1"sv, "Key1"sv});
+        BOOST_CHECK(!afterRollback);
+
+        // Inspect the upper layer via the range iterator to verify the tombstone.
+        // The entry should exist with DELETED_TYPE, not be physically absent.
+        auto iterator = co_await range(upperLayer);
+        auto item = co_await iterator.next();
+
+        BOOST_REQUIRE_MESSAGE(item.has_value(),
+            "Upper layer must contain a tombstone entry after rollback, not be empty. "
+            "A physical delete would leave the upper layer empty, causing layered reads "
+            "to fall through to the lower layer and return a stale value.");
+
+        auto& [entryKey, rawValue] = *item;
+        BOOST_CHECK_EQUAL(entryKey, testKey);
+        BOOST_CHECK_MESSAGE(std::holds_alternative<DELETED_TYPE>(rawValue),
+            "Entry must be DELETED_TYPE (tombstone). "
+            "In MultiLayerStorage::fillMissingValues, DELETED_TYPE blocks fallthrough "
+            "while NOT_EXISTS_TYPE allows it.");
+
+        // Confirm there is exactly one entry in the upper layer
+        auto noMore = co_await iterator.next();
+        BOOST_CHECK(!noMore.has_value());
+
+        // Verify the lower layer still holds the original value — without the tombstone,
+        // a layered read would return this stale value.
+        auto lowerValue = co_await readOne(lowerLayer, testKey);
+        BOOST_REQUIRE(lowerValue);
+        BOOST_CHECK_EQUAL(lowerValue->get(), "LowerValue");
+
+        co_return;
+    }());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-executor/tests/TestRollbackableStorage.cpp
+++ b/transaction-executor/tests/TestRollbackableStorage.cpp
@@ -500,4 +500,79 @@ BOOST_AUTO_TEST_CASE(mixedOperationsRollback)
     }());
 }
 
+BOOST_AUTO_TEST_CASE(rollbackCleansRecords)
+{
+    // FIB-71: Verify that rollback properly cleans m_records (no moved-from leftovers)
+    task::syncWait([]() -> task::Task<void> {
+        MutableStorage memoryStorage;
+        Rollbackable rollbackableStorage(memoryStorage);
+
+        std::string_view tableID = "table1";
+        auto savepoint = rollbackableStorage.current();
+        BOOST_CHECK_EQUAL(savepoint, 0);
+
+        // Write several entries
+        co_await storage2::writeOne(
+            rollbackableStorage, StateKey{tableID, "Key1"sv}, storage::Entry{"Value1"});
+        co_await storage2::writeOne(
+            rollbackableStorage, StateKey{tableID, "Key2"sv}, storage::Entry{"Value2"});
+        co_await storage2::writeOne(
+            rollbackableStorage, StateKey{tableID, "Key3"sv}, storage::Entry{"Value3"});
+
+        // current() should reflect the number of records
+        BOOST_CHECK_EQUAL(rollbackableStorage.current(), 3);
+
+        // Rollback to the original savepoint
+        co_await rollbackableStorage.rollback(savepoint);
+
+        // After rollback, current() must be back to 0 (no leftover records)
+        BOOST_CHECK_EQUAL(rollbackableStorage.current(), 0);
+
+        // Verify the data has been removed
+        auto v1 = co_await storage2::readOne(rollbackableStorage, StateKey{tableID, "Key1"sv});
+        auto v2 = co_await storage2::readOne(rollbackableStorage, StateKey{tableID, "Key2"sv});
+        auto v3 = co_await storage2::readOne(rollbackableStorage, StateKey{tableID, "Key3"sv});
+        BOOST_CHECK(!v1);
+        BOOST_CHECK(!v2);
+        BOOST_CHECK(!v3);
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(rollbackPartialCleansRecords)
+{
+    // FIB-71: Verify partial rollback leaves exactly the right number of records
+    task::syncWait([]() -> task::Task<void> {
+        MutableStorage memoryStorage;
+        Rollbackable rollbackableStorage(memoryStorage);
+
+        std::string_view tableID = "table1";
+
+        co_await storage2::writeOne(
+            rollbackableStorage, StateKey{tableID, "Key1"sv}, storage::Entry{"Value1"});
+        auto midpoint = rollbackableStorage.current();
+        BOOST_CHECK_EQUAL(midpoint, 1);
+
+        co_await storage2::writeOne(
+            rollbackableStorage, StateKey{tableID, "Key2"sv}, storage::Entry{"Value2"});
+        co_await storage2::writeOne(
+            rollbackableStorage, StateKey{tableID, "Key3"sv}, storage::Entry{"Value3"});
+        BOOST_CHECK_EQUAL(rollbackableStorage.current(), 3);
+
+        // Partial rollback to midpoint
+        co_await rollbackableStorage.rollback(midpoint);
+
+        // Should have exactly 1 record remaining
+        BOOST_CHECK_EQUAL(rollbackableStorage.current(), 1);
+
+        // Key1 should still exist, Key2 and Key3 should be gone
+        auto v1 = co_await storage2::readOne(rollbackableStorage, StateKey{tableID, "Key1"sv});
+        auto v2 = co_await storage2::readOne(rollbackableStorage, StateKey{tableID, "Key2"sv});
+        auto v3 = co_await storage2::readOne(rollbackableStorage, StateKey{tableID, "Key3"sv});
+        BOOST_CHECK(v1);
+        BOOST_CHECK_EQUAL(v1->get(), "Value1");
+        BOOST_CHECK(!v2);
+        BOOST_CHECK(!v3);
+    }());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- **FIB-71 (Minor):** Replace for-loop with while-loop in `Rollbackable::rollback()` and move+pop the record from `m_records` *before* the `co_await`. Previously, moving key/oldValue out of a record and only popping after the async operation left moved-from records in `m_records` if the coroutine threw.
- **FIB-72 (Major):** Change rollback's empty-oldValue path from `removeOne(DIRECT)` (physical delete) to `removeOne()` (tombstone write). The original code could not distinguish "key was absent" from "key held a tombstone (logical deletion)". Using non-DIRECT remove writes a tombstone that correctly blocks fall-through to lower storage layers, which is the safe behavior for undoing a write.
- Added two unit tests (`rollbackCleansRecords`, `rollbackPartialCleansRecords`) verifying that `current()` returns the correct savepoint value after full and partial rollbacks.

## Test plan
- [x] Build: `cmake --build build --target test-transaction-executor -j8`
- [x] Run: `./build/transaction-executor/tests/test-transaction-executor --run_test=TestRollbackableStorage` (13/13 pass)
- [ ] Verify no regressions in full test suite