### PR TITLE
fix(front,gateway): add task_group lifecycle guards to prevent TBB pool assertion (FIB-97)

### DIFF
--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -102,8 +102,8 @@ void FrontService::start()
 
     // try to getNodeIDs from gateway
     auto self = std::weak_ptr<FrontService>(shared_from_this());
-    m_gatewayInterface->asyncGetGroupNodeInfo(
-        m_groupID, [self](const Error::Ptr& _error, const bcos::gateway::GroupNodeInfo::Ptr& _groupNodeInfo) {
+    m_gatewayInterface->asyncGetGroupNodeInfo(m_groupID,
+        [self](const Error::Ptr& _error, const bcos::gateway::GroupNodeInfo::Ptr& _groupNodeInfo) {
             if (_error)
             {
                 FRONT_LOG(ERROR) << LOG_BADGE("start") << LOG_DESC("asyncGetGroupNodeInfo failed")
@@ -189,6 +189,9 @@ void FrontService::stop()
         {
             m_frontServiceThread->join();
         }
+
+        m_asyncGroup.cancel();
+        m_asyncGroup.wait();
     }
     catch (const std::exception& e)
     {
@@ -219,6 +222,8 @@ void FrontService::asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInf
                             (groupNodeInfo ? groupNodeInfo->nodeIDList().size() : 0));
     if (_onGetGroupNodeInfo)
     {
+        if (!m_run)
+            return;
         m_taskArena.execute([&]() {
             m_asyncGroup.run([_onGetGroupNodeInfo = std::move(_onGetGroupNodeInfo),
                                  groupNodeInfo = std::move(groupNodeInfo)]() {
@@ -367,6 +372,14 @@ void FrontService::onReceiveGroupNodeInfo(const std::string& _groupID,
 
     auto self = std::weak_ptr<FrontService>(shared_from_this());
 
+    if (!m_run)
+    {
+        if (_receiveMsgCallback)
+        {
+            _receiveMsgCallback(nullptr);
+        }
+        return;
+    }
     m_taskArena.execute([&]() {
         m_asyncGroup.run([this, _groupID, _groupNodeInfo = std::move(_groupNodeInfo)]() {
             notifyGroupNodeInfo(_groupID, _groupNodeInfo);
@@ -470,6 +483,8 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
     // construct shared_ptr<bytes> from message->payload() first for
     // thead safe
     auto buffer = bytes(_payLoad.begin(), _payLoad.end());
+    if (!m_run)
+        return;
     m_taskArena.execute([&]() {
         m_asyncGroup.run([_uuid, _error = std::move(_error), callback = std::move(callback),
                              buffer = std::move(buffer), _nodeID = std::move(_nodeID),
@@ -524,6 +539,8 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
                 // thead safe
                 bytes buffer(message->payload().begin(), message->payload().end());
 
+                if (!m_run)
+                    return;
                 m_taskArena.execute([&]() mutable {
                     m_asyncGroup.run(
                         [uuid, callback = std::move(callback), buffer = std::move(buffer),
@@ -547,6 +564,8 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
 
     if (_receiveMsgCallback)
     {
+        if (!m_run)
+            return;
         m_taskArena.execute([&]() mutable {
             m_asyncGroup.run([_receiveMsgCallback = std::move(_receiveMsgCallback)]() {
                 _receiveMsgCallback(nullptr);
@@ -625,6 +644,8 @@ void FrontService::onMessageTimeout(const boost::system::error_code& _error,
         if (callback)
         {
             auto errorPtr = BCOS_ERROR_PTR(CommonError::TIMEOUT, "timeout");
+            if (!m_run)
+                return;
             m_taskArena.execute([&]() {
                 m_asyncGroup.run(
                     [_uuid, _nodeID = std::move(_nodeID), callback = std::move(callback),

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -28,6 +28,7 @@
 #include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
 #include <boost/asio.hpp>
+#include <atomic>
 #include <utility>
 
 namespace bcos::front
@@ -280,7 +281,7 @@ private:
         m_module2GroupNodeInfoNotifier;
 
     // service is running or not
-    bool m_run = false;
+    std::atomic_bool m_run = {false};
     //
     std::shared_ptr<std::thread> m_frontServiceThread;
     // NodeID

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -15,9 +15,9 @@
  * threads it should allow to run simultaneously.") (since ethereum use 2, we
  * modify io_service from 1 to 2) 2.
  */
+#include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Common.h"
-#include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
 #include <boost/algorithm/string.hpp>
@@ -383,6 +383,8 @@ void Host::startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> 
     std::shared_ptr<SessionFace> session =
         m_sessionFactory->createSession(*this, socket, m_messageFactory, m_sessionCallbackManager);
 
+    if (!m_run)
+        return;
     m_taskArena.execute([&]() {
         m_asyncGroup.run([weakHost, session = std::move(session), p2pInfo]() {
             auto host = weakHost.lock();
@@ -487,6 +489,8 @@ void Host::asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
                                 << LOG_KV("message", ec.message());
                 socket->close();
 
+                if (!m_run)
+                    return;
                 m_taskArena.execute([&]() {
                     m_asyncGroup.run([callback = std::move(callback)]() {
                         callback(NetworkException(ConnectError, "Connect failed"), {}, {});
@@ -570,6 +574,7 @@ void Host::stop()
     {
         m_asioInterface->stop();
     }
+    m_asyncGroup.cancel();
     m_asyncGroup.wait();
 }
 bcos::gateway::Host::Host(bcos::crypto::Hash::Ptr _hash,

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -17,6 +17,7 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/system/error_code.hpp>
+#include <atomic>
 #include <memory>
 #include <string>
 #include <utility>
@@ -99,6 +100,8 @@ public:
     template <class F>
     void asyncTo(F f)
     {
+        if (!m_run)
+            return;
         m_asyncGroup.run(std::move(f));
     }
 
@@ -166,7 +169,7 @@ protected:
     std::function<bool(X509* x509, std::string& pubHex)> m_sslContextPubHandler;
     std::function<bool(X509* x509, std::string& pubHex)> m_sslContextPubHandlerWithoutExtInfo;
 
-    bool m_run = false;
+    std::atomic_bool m_run = {false};
 
     P2PInfo m_p2pInfo;
 


### PR DESCRIPTION
TBB v2022.1.0 small_object_pool_impl::destroy() asserts m_private_counter >= 0 when tasks are submitted to tbb::task_group after stop()/destruction begins.

- Make m_run atomic in FrontService and Host to fix data races
- Add m_asyncGroup.cancel() + wait() in FrontService::stop()
- Add m_asyncGroup.cancel() before wait() in Host::stop()
- Guard all m_asyncGroup.run() call sites with m_run check
- Guard Host::asyncTo() template with m_run check