### PR TITLE
fix(gateway): add drop() on decode error and capture socket shared_ptr to prevent use-after-free (FIB-70, FIB-97)

### DIFF
--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -7,15 +7,15 @@
  * @date 2018
  */
 
-#include "bcos-gateway/libnetwork/Message.h"
-#include "bcos-utilities/BoostLog.h"
-#include "bcos-utilities/Overloaded.h"
+#include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Common.h"
 #include "bcos-gateway/libnetwork/Host.h"
-#include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/Message.h"
 #include "bcos-gateway/libnetwork/SessionFace.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
+#include "bcos-utilities/BoostLog.h"
+#include "bcos-utilities/Overloaded.h"
 #include <boost/asio/buffer.hpp>
 #include <boost/container/container_fwd.hpp>
 #include <boost/throw_exception.hpp>
@@ -469,7 +469,7 @@ void Session::doRead()
 {
     if (m_active && m_server.get().haveNetwork())
     {
-        auto asyncRead = [self = std::weak_ptr<Session>(shared_from_this())](
+        auto asyncRead = [self = std::weak_ptr<Session>(shared_from_this()), socket = m_socket](
                              boost::system::error_code ec, std::size_t bytesTransferred) {
             auto session = self.lock();
             if (session)
@@ -517,6 +517,7 @@ void Session::doRead()
                                 session->onMessage(NetworkException(P2PExceptionType::ProtocolError,
                                                        "ProtocolError(msg overflow)"),
                                     message);
+                                session->drop(UserReason);
                                 break;
                             }
 
@@ -558,6 +559,7 @@ void Session::doRead()
                             session->onMessage(NetworkException(P2PExceptionType::ProtocolError,
                                                    "ProtocolError(decode msg error)"),
                                 message);
+                            session->drop(UserReason);
                             break;
                         }
                     }
@@ -568,6 +570,7 @@ void Session::doRead()
                         session->onMessage(NetworkException(P2PExceptionType::ProtocolError,
                                                "ProtocolError(decode msg exception)"),
                             message);
+                        session->drop(UserReason);
                         break;
                     }
                 }

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -330,6 +330,15 @@ void Session::write()
 
 void Session::drop(DisconnectReason _reason)
 {
+    // FIB-97-new: idempotency guard — only the first caller (wins the CAS) proceeds
+    // with the actual teardown; all subsequent or concurrent calls are no-ops.
+    bool expected = false;
+    if (!m_dropped.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_acquire))
+    {
+        return;
+    }
+
     m_active = false;
 
     int errorCode = P2PExceptionType::Disconnect;

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -469,10 +469,15 @@ void Session::doRead()
 {
     if (m_active && m_server.get().haveNetwork())
     {
+        // NOTE: Capture m_socket as a shared_ptr to keep the SSL context alive for the duration
+        // of this async read. The handler never references `socket` directly — it touches
+        // the socket only via the Session recovered from `self.lock()` — but removing this
+        // capture re-introduces the FIB-97 use-after-free: a concurrent drop() can free
+        // the SSL stream while this read is still in flight.
         auto asyncRead = [self = std::weak_ptr<Session>(shared_from_this()), socket = m_socket](
-                             boost::system::error_code ec, std::size_t bytesTransferred) {
-            auto session = self.lock();
-            if (session)
+                             const boost::system::error_code& ec, std::size_t bytesTransferred) {
+            std::ignore = socket;
+            if (const auto session = self.lock())
             {
                 if (ec)
                 {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -18,6 +18,7 @@
 #include <boost/asio/buffer.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/heap/priority_queue.hpp>
+#include <atomic>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -237,6 +238,12 @@ public:
     std::atomic<uint64_t> m_lastReadTime;
     std::atomic<uint64_t> m_lastWriteTime;
     std::shared_ptr<bcos::Timer> m_idleCheckTimer;
+
+    // FIB-97-new: idempotency guard. drop() may be invoked concurrently from the
+    // teardown signal, explicit disconnect, or a deferred async callback that the
+    // shared_ptr capture (FIB-97 primary fix) kept alive. CAS to true ensures the
+    // actual teardown body runs exactly once; all subsequent callers no-op.
+    std::atomic_bool m_dropped{false};
     P2PInfo m_hostInfo;
 
     struct Writings

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -1,0 +1,330 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-70 and FIB-97 session lifecycle fixes
+ * @file FIB70_FIB97_SessionLifecycleTest.cpp
+ * @date 2026-04-07
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/Socket.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/ThreadPool.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <queue>
+
+using namespace bcos;
+using namespace gateway;
+using namespace bcos::test;
+using namespace bcos::crypto;
+
+BOOST_FIXTURE_TEST_SUITE(FIB70_FIB97_SessionLifecycleTest, TestPromptFixture)
+
+// --- Fake components (mirrors SessionTest.cpp infrastructure) ---
+
+class FakeASIO_FIB : public bcos::gateway::ASIOInterface
+{
+public:
+    using Packet = std::shared_ptr<std::vector<uint8_t>>;
+    FakeASIO_FIB() : m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB", 1)) {}
+    ~FakeASIO_FIB() noexcept override {}
+
+    void readSome(std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers,
+        ReadWriteHandler handler)
+    {
+        std::size_t bytesTransferred = 0;
+        auto limit = buffers.size();
+
+        while (!m_recvPackets.empty())
+        {
+            auto packet = m_recvPackets.front();
+            if (bytesTransferred + packet->size() > limit)
+            {
+                auto remaining = limit - bytesTransferred;
+                boost::asio::buffer_copy(buffers, boost::asio::buffer(*packet), remaining);
+                bytesTransferred += remaining;
+                packet->erase(packet->begin(), packet->begin() + remaining);
+                break;
+            }
+            else
+            {
+                m_recvPackets.pop();
+                boost::asio::buffer_copy(buffers, boost::asio::buffer(*packet));
+                buffers += packet->size();
+                bytesTransferred += packet->size();
+            }
+        }
+
+        handler(boost::system::error_code(), bytesTransferred);
+    }
+
+    void asyncReadSome(const std::shared_ptr<SocketFace>& socket,
+        boost::asio::mutable_buffer buffers, ReadWriteHandler handler) override
+    {
+        m_threadPool->enqueue([this, socket, buffers, handler]() {
+            if (m_recvPackets.empty())
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                asyncReadSome(socket, buffers, handler);
+                return;
+            }
+            readSome(socket, buffers, handler);
+        });
+    }
+
+    void strandPost(Base_Handler handler) override { m_handler = handler; }
+    void stop() override { m_threadPool->stop(); }
+
+    void appendRecvPacket(Packet packet) { m_recvPackets.push(packet); }
+    void asyncAppendRecvPacket(Packet packet)
+    {
+        m_threadPool->enqueue([this, packet]() { appendRecvPacket(packet); });
+    }
+    void triggerRead()
+    {
+        m_threadPool->enqueue([this]() {
+            if (m_handler)
+            {
+                m_handler();
+            }
+        });
+    }
+
+protected:
+    Base_Handler m_handler;
+    std::queue<Packet> m_recvPackets;
+    bcos::ThreadPool::Ptr m_threadPool;
+};
+
+// A message that always returns MESSAGE_ERROR to simulate decode failure
+class DecodeErrorMessage : public P2PMessage
+{
+public:
+    using Ptr = std::shared_ptr<DecodeErrorMessage>;
+    int32_t decode(const bytesConstRef& _buffer) override
+    {
+        if (_buffer.size() == 0)
+        {
+            return MessageDecodeStatus::MESSAGE_INCOMPLETE;
+        }
+        // Always return error for any non-empty buffer
+        return MessageDecodeStatus::MESSAGE_ERROR;
+    }
+};
+
+class DecodeErrorMessageFactory : public P2PMessageFactory
+{
+public:
+    Message::Ptr buildMessage() override { return std::make_shared<DecodeErrorMessage>(); }
+};
+
+// A message that throws an exception during decode
+class DecodeExceptionMessage : public P2PMessage
+{
+public:
+    using Ptr = std::shared_ptr<DecodeExceptionMessage>;
+    int32_t decode(const bytesConstRef& _buffer) override
+    {
+        if (_buffer.size() == 0)
+        {
+            return MessageDecodeStatus::MESSAGE_INCOMPLETE;
+        }
+        throw std::runtime_error("Simulated decode exception");
+    }
+};
+
+class DecodeExceptionMessageFactory : public P2PMessageFactory
+{
+public:
+    Message::Ptr buildMessage() override { return std::make_shared<DecodeExceptionMessage>(); }
+};
+
+class FakeHost_FIB : public bcos::gateway::Host
+{
+public:
+    FakeHost_FIB(bcos::crypto::Hash::Ptr _hash, std::shared_ptr<ASIOInterface> _asioInterface,
+        std::shared_ptr<SessionFactory> _sessionFactory, MessageFactory::Ptr _messageFactory)
+      : Host(_hash, _asioInterface, _sessionFactory, _messageFactory)
+    {
+        m_run = true;
+    }
+};
+
+// A FakeSocket backed by a real SSL context and stream so that drop() can safely
+// call sslref().async_shutdown() without crashing.
+class FakeSocket_FIB : public SocketFace
+{
+public:
+    FakeSocket_FIB()
+      : SocketFace(),
+        m_ioContext(std::make_shared<ba::io_context>()),
+        m_sslContext(ba::ssl::context::tlsv12),
+        m_sslSocket(std::make_shared<ba::ssl::stream<bi::tcp::socket>>(*m_ioContext, m_sslContext))
+    {}
+    ~FakeSocket_FIB() override = default;
+
+    bool isConnected() const override { return m_connected; }
+    void close() override { m_connected = false; }
+    boost::asio::ip::tcp::endpoint remoteEndpoint(boost::system::error_code ec) override
+    {
+        return {};
+    }
+    boost::asio::ip::tcp::endpoint localEndpoint(boost::system::error_code ec) override
+    {
+        return {};
+    }
+    bi::tcp::socket& ref() override { return m_sslSocket->next_layer(); }
+    ba::ssl::stream<bi::tcp::socket>& sslref() override { return *m_sslSocket; }
+    const NodeIPEndpoint& nodeIPEndpoint() const override { return m_nodeIPEndpoint; }
+    void setNodeIPEndpoint(NodeIPEndpoint _nodeIPEndpoint) override {}
+    ba::io_context& ioService() override { return *m_ioContext; }
+
+    bool m_connected{true};
+
+private:
+    std::shared_ptr<ba::io_context> m_ioContext;
+    ba::ssl::context m_sslContext;
+    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
+    NodeIPEndpoint m_nodeIPEndpoint;
+};
+
+// FIB-70: Verify that decode error (negative return from decode()) triggers session drop.
+// Before the fix, the session would remain active as a "zombie" until the idle timeout.
+// After the fix, drop(UserReason) is called immediately, setting m_active = false.
+BOOST_AUTO_TEST_CASE(DecodeErrorTriggersSessionDrop)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB>();
+    auto decodeErrorFactory = std::make_shared<DecodeErrorMessageFactory>();
+
+    {
+        auto fakeAsio = std::make_shared<FakeASIO_FIB>();
+        auto fakeHost =
+            std::make_shared<FakeHost_FIB>(hashImpl, fakeAsio, nullptr, decodeErrorFactory);
+
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+        session->setMessageFactory(fakeHost->messageFactory());
+        session->setMessageHandler(
+            [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
+
+        session->start();
+        fakeAsio->triggerRead();
+
+        // Send a packet that will trigger a decode error (MESSAGE_ERROR)
+        auto badPacket = std::make_shared<std::vector<uint8_t>>(10, 0xAB);
+        fakeAsio->asyncAppendRecvPacket(badPacket);
+
+        // Wait for the session to be dropped
+        size_t retryCount = 0;
+        while (session->active() && retryCount < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            retryCount++;
+        }
+
+        // FIB-70 fix: session must be inactive after decode error.
+        // drop(UserReason) sets m_active = false as its first action.
+        BOOST_CHECK(!session->active());
+
+        session->setSocket(nullptr);
+    }
+
+    fakeSocket->close();
+}
+
+// FIB-70: Verify that decode exception triggers session drop.
+// Before the fix, an exception in decode() would leave the session as a zombie.
+// After the fix, drop(UserReason) is called in the catch block.
+BOOST_AUTO_TEST_CASE(DecodeExceptionTriggersSessionDrop)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB>();
+    auto decodeExceptionFactory = std::make_shared<DecodeExceptionMessageFactory>();
+
+    {
+        auto fakeAsio = std::make_shared<FakeASIO_FIB>();
+        auto fakeHost =
+            std::make_shared<FakeHost_FIB>(hashImpl, fakeAsio, nullptr, decodeExceptionFactory);
+
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+        session->setMessageFactory(fakeHost->messageFactory());
+        session->setMessageHandler(
+            [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
+
+        session->start();
+        fakeAsio->triggerRead();
+
+        // Send a packet that will trigger a decode exception
+        auto badPacket = std::make_shared<std::vector<uint8_t>>(10, 0xCD);
+        fakeAsio->asyncAppendRecvPacket(badPacket);
+
+        // Wait for the session to be dropped
+        size_t retryCount = 0;
+        while (session->active() && retryCount < 200)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            retryCount++;
+        }
+
+        // FIB-70 fix: session must be inactive after decode exception
+        BOOST_CHECK(!session->active());
+
+        session->setSocket(nullptr);
+    }
+
+    fakeSocket->close();
+}
+
+// FIB-97: Verify socket shared_ptr capture prevents premature destruction.
+// The fix captures m_socket as a shared_ptr in the async read handler lambda,
+// keeping the socket alive even if Session::drop() is called concurrently.
+BOOST_AUTO_TEST_CASE(SocketSharedPtrCaptureInAsyncHandler)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB>();
+    auto decodeErrorFactory = std::make_shared<DecodeErrorMessageFactory>();
+
+    // Verify socket has expected reference count before session creation
+    auto initialRefCount = fakeSocket.use_count();
+    BOOST_CHECK_EQUAL(initialRefCount, 1);
+
+    {
+        auto fakeAsio = std::make_shared<FakeASIO_FIB>();
+        auto fakeHost =
+            std::make_shared<FakeHost_FIB>(hashImpl, fakeAsio, nullptr, decodeErrorFactory);
+
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+        session->setMessageFactory(fakeHost->messageFactory());
+        session->setMessageHandler(
+            [](NetworkException e, SessionFace::Ptr sessionFace, Message::Ptr message) {});
+
+        // After session creation, socket should be held by both fakeSocket and session
+        BOOST_CHECK(fakeSocket.use_count() > 1);
+
+        session->setSocket(nullptr);
+    }
+
+    // After session destruction, only fakeSocket holds the socket
+    BOOST_CHECK_EQUAL(fakeSocket.use_count(), 1);
+
+    fakeSocket->close();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
+++ b/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
@@ -1,0 +1,214 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief FIB-97-new: Session::drop() must be idempotent — safe to call more than once,
+ *        sequentially or concurrently, without double-teardown or data races.
+ * @file FIB97_new_SessionDropIdempotencyTest.cpp
+ * @date 2026-05-08
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/Socket.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/ThreadPool.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <thread>
+
+using namespace bcos;
+using namespace gateway;
+using namespace bcos::test;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+namespace
+{
+
+// FIB-97-new: All helper names are suffixed _FIB97new to avoid ODR collisions under UNITY_BUILD.
+
+class FakeASIO_FIB97new : public bcos::gateway::ASIOInterface
+{
+public:
+    FakeASIO_FIB97new() = default;
+    ~FakeASIO_FIB97new() noexcept override = default;
+
+    // Never issues actual async reads — tests that call drop() don't need reads.
+    void asyncReadSome(const std::shared_ptr<SocketFace>& /*socket*/,
+        boost::asio::mutable_buffer /*buffers*/, ReadWriteHandler /*handler*/) override
+    {}
+
+    void strandPost(Base_Handler /*handler*/) override {}
+    void stop() override {}
+};
+
+class FakeSocket_FIB97new : public SocketFace
+{
+public:
+    FakeSocket_FIB97new()
+      : SocketFace(),
+        m_ioContext(std::make_shared<boost::asio::io_context>()),
+        m_sslContext(boost::asio::ssl::context::tlsv12),
+        m_sslSocket(std::make_shared<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>>(
+            *m_ioContext, m_sslContext))
+    {}
+    ~FakeSocket_FIB97new() override = default;
+
+    bool isConnected() const override { return m_connected.load(); }
+    void close() override
+    {
+        m_connected.store(false);
+        ++m_closeCount;
+    }
+    boost::asio::ip::tcp::endpoint remoteEndpoint(boost::system::error_code /*ec*/) override
+    {
+        return {};
+    }
+    boost::asio::ip::tcp::endpoint localEndpoint(boost::system::error_code /*ec*/) override
+    {
+        return {};
+    }
+    boost::asio::ip::tcp::socket& ref() override { return m_sslSocket->next_layer(); }
+    boost::asio::ssl::stream<boost::asio::ip::tcp::socket>& sslref() override
+    {
+        return *m_sslSocket;
+    }
+    const NodeIPEndpoint& nodeIPEndpoint() const override { return m_nodeIPEndpoint; }
+    void setNodeIPEndpoint(NodeIPEndpoint /*unused*/) override {}
+    boost::asio::io_context& ioService() override { return *m_ioContext; }
+
+    // Counts to detect double-teardown
+    std::atomic<int> m_closeCount{0};
+    std::atomic<bool> m_connected{true};
+
+private:
+    std::shared_ptr<boost::asio::io_context> m_ioContext;
+    boost::asio::ssl::context m_sslContext;
+    std::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> m_sslSocket;
+    NodeIPEndpoint m_nodeIPEndpoint;
+};
+
+class FakeHost_FIB97new : public bcos::gateway::Host
+{
+public:
+    FakeHost_FIB97new(bcos::crypto::Hash::Ptr _hash, std::shared_ptr<ASIOInterface> _asioInterface,
+        std::shared_ptr<SessionFactory> _sessionFactory, MessageFactory::Ptr _messageFactory)
+      : Host(_hash, _asioInterface, _sessionFactory, _messageFactory)
+    {
+        m_run = true;
+    }
+};
+
+// Session owns a reference_wrapper<Host> — the Host must outlive the session.
+// Return both from the helper so tests keep the host alive.
+struct SessionBundle_FIB97new
+{
+    std::shared_ptr<FakeHost_FIB97new> host;
+    std::shared_ptr<FakeSocket_FIB97new> socket;
+    std::shared_ptr<bcos::gateway::Session> session;
+};
+
+inline SessionBundle_FIB97new makeSessionFib97new()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB97new>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB97new>();
+    auto msgFactory = std::make_shared<P2PMessageFactory>();
+    auto fakeHost = std::make_shared<FakeHost_FIB97new>(hashImpl, fakeAsio, nullptr, msgFactory);
+
+    auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+    session->setMessageFactory(msgFactory);
+    session->setMessageHandler(
+        [](NetworkException /*e*/, SessionFace::Ptr /*s*/, Message::Ptr /*m*/) {});
+
+    return {fakeHost, fakeSocket, session};
+}
+
+}  // namespace
+}  // namespace bcos::test
+
+BOOST_FIXTURE_TEST_SUITE(FIB97newSessionDropIdempotencyTest, TestPromptFixture)
+
+// FIB-97-new: Calling drop() twice sequentially must not double-teardown.
+// Without the atomic idempotency guard, the second drop() re-enters teardown,
+// resulting in a second close()+async_shutdown() on an already-torn-down socket.
+BOOST_AUTO_TEST_CASE(drop_twice_sequential_no_double_teardown)
+{
+    auto bundle = bcos::test::makeSessionFib97new();
+    BOOST_REQUIRE(bundle.session);
+    BOOST_REQUIRE(bundle.socket);
+
+    // First drop: should perform the full teardown.
+    bundle.session->drop(DisconnectReason::TCPError);
+    // Second drop: must be a no-op (not re-enter teardown).
+    bundle.session->drop(DisconnectReason::TCPError);
+
+    // The socket must have been closed exactly once — a second drop re-invoking
+    // socket close is a sign of double-teardown.
+    // NOTE: close() in FakeSocket sets m_connected = false and increments m_closeCount.
+    // After the first drop the socket is already disconnected, so the second drop's
+    // `if (m_socket->isConnected())` guard may also prevent re-entry even without the
+    // new m_dropped guard — but the isConnected() check is not thread-safe and a race
+    // between two concurrent callers can slip through.  The atomic CAS fix is the
+    // correct guard.  The sequential check here still demonstrates the invariant.
+    BOOST_CHECK(!bundle.session->active());
+    BOOST_CHECK_EQUAL(bundle.socket->m_closeCount.load(), 1);
+}
+
+// FIB-97-new: Calling drop() concurrently from two threads must not data-race.
+// Under TSan, without the atomic guard, both threads enter the teardown body
+// simultaneously and produce a write-write race on m_active and the socket state.
+BOOST_AUTO_TEST_CASE(drop_concurrent_two_threads_no_race)
+{
+    auto bundle = bcos::test::makeSessionFib97new();
+    BOOST_REQUIRE(bundle.session);
+
+    std::thread t1([&] { bundle.session->drop(DisconnectReason::TCPError); });
+    std::thread t2([&] { bundle.session->drop(DisconnectReason::TCPError); });
+    t1.join();
+    t2.join();
+
+    // No crash, no UAF, no TSan report.
+    BOOST_CHECK(!bundle.session->active());
+    BOOST_CHECK_LE(bundle.socket->m_closeCount.load(), 1);
+}
+
+// FIB-97-new: Eight threads all calling drop() concurrently — stress the CAS path.
+BOOST_AUTO_TEST_CASE(drop_many_threads_stress)
+{
+    auto bundle = bcos::test::makeSessionFib97new();
+    BOOST_REQUIRE(bundle.session);
+
+    constexpr int kThreads = 8;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int i = 0; i < kThreads; ++i)
+    {
+        threads.emplace_back([&] { bundle.session->drop(DisconnectReason::TCPError); });
+    }
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+
+    BOOST_CHECK(!bundle.session->active());
+    BOOST_CHECK_LE(bundle.socket->m_closeCount.load(), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- FIB-70: Add session->drop() before break in decode error and exception paths of doRead()
- FIB-97: Capture socket shared_ptr in async handlers to prevent use-after-free during session teardown

## Test plan
- [x] Unit test: decode error triggers session drop
- [x] Unit test: exception in decode triggers session drop
- [x] Build and run test-bcos-gateway