### PR TITLE
fix(scheduler): use passed blockVersion and add unambiguous state entry hashing (FIB-99, FIB-105)

### DIFF
--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -1,9 +1,6 @@
 #pragma once
-#include "../ledger/LedgerTypeDef.h"
 #include "../protocol/Protocol.h"
-#include "../storage/Entry.h"
 #include "../storage2/Storage.h"
-#include "../transaction-executor/StateKey.h"
 #include "bcos-task/Task.h"
 #include <bcos-utilities/Exceptions.h>
 #include <array>
@@ -16,6 +13,24 @@
 #include <range/v3/view/zip.hpp>
 #include <set>
 #include <string_view>
+
+// Forward declarations only — the storage-I/O member templates below take these
+// types as concept arguments / parameter types, which need name visibility but
+// not full definitions at declaration time. Full definitions are pulled in by
+// FeaturesStorage.h, where the implementations and concrete call sites live.
+// Breaking the include of storage/Entry.h / StateKey.h here is what lets
+// storage/Entry.h include Features.h without forming a cycle through
+// StateKey.h's `using StateValue = storage::Entry`.
+namespace bcos::storage
+{
+class Entry;
+}
+namespace bcos::executor_v1
+{
+class StateKey;
+class StateKeyView;
+}  // namespace bcos::executor_v1
+
 namespace bcos::ledger
 {
 DERIVE_BCOS_EXCEPTION(NoSuchFeatureError);
@@ -87,7 +102,6 @@ public:
         feature_raw_address,
         feature_rpbft_vrf_type_secp256k1,
         feature_balance_policy2,  // 转账白名单 Transfer whitelist
-        bugfix_gas_payment_balance_precheck,
     };
 
 private:
@@ -115,138 +129,7 @@ public:
 
     void setToShardingDefault(protocol::BlockVersion version);
 
-<<<<<<< HEAD
     void setUpgradeFeatures(protocol::BlockVersion fromVersion, protocol::BlockVersion toVersion);
-=======
-    void setUpgradeFeatures(protocol::BlockVersion fromVersion, protocol::BlockVersion toVersion)
-    {
-        struct UpgradeFeatures
-        {
-            protocol::BlockVersion to;
-            std::vector<Flag> flags;
-        };
-        const static auto upgradeRoadmap =
-            std::to_array<UpgradeFeatures>({{.to = protocol::BlockVersion::V3_2_3_VERSION,
-                                                .flags =
-                                                    {
-                                                        Flag::bugfix_revert,
-                                                    }},
-                {.to = protocol::BlockVersion::V3_2_4_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_statestorage_hash,
-                            Flag::bugfix_evm_create2_delegatecall_staticcall_codecopy,
-                        }},
-                {.to = protocol::BlockVersion::V3_2_7_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_event_log_order,
-                            Flag::bugfix_call_noaddr_return,
-                            Flag::bugfix_precompiled_codehash,
-                            Flag::bugfix_dmc_revert,
-                        }},
-                {.to = protocol::BlockVersion::V3_5_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_revert,
-                            Flag::bugfix_statestorage_hash,
-                        }},
-                {.to = protocol::BlockVersion::V3_6_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_statestorage_hash,
-                            Flag::bugfix_evm_create2_delegatecall_staticcall_codecopy,
-                            Flag::bugfix_event_log_order,
-                            Flag::bugfix_call_noaddr_return,
-                            Flag::bugfix_precompiled_codehash,
-                            Flag::bugfix_dmc_revert,
-                        }},
-                {.to = protocol::BlockVersion::V3_6_1_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_keypage_system_entry_hash,
-                            Flag::bugfix_internal_create_redundant_storage,
-                        }},
-                {.to = protocol::BlockVersion::V3_7_0_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_empty_abi_reset,
-                            Flag::bugfix_eip55_addr,
-                            Flag::bugfix_sharding_call_in_child_executive,
-                            Flag::bugfix_internal_create_permission_denied,
-                        }},
-                {.to = protocol::BlockVersion::V3_8_0_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_eoa_as_contract,
-                            Flag::bugfix_dmc_deploy_gas_used,
-                            Flag::bugfix_evm_exception_gas_used,
-                            Flag::bugfix_set_row_with_dirty_flag,
-                        }},
-                {.to = protocol::BlockVersion::V3_9_0_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_staticcall_noaddr_return,
-                            Flag::bugfix_support_transfer_receive_fallback,
-                            Flag::bugfix_eoa_match_failed,
-                        }},
-                {.to = protocol::BlockVersion::V3_12_0_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_rpbft_vrf_blocknumber_input,
-                        }},
-                {.to = protocol::BlockVersion::V3_13_0_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_delete_account_code,
-                            Flag::bugfix_policy1_empty_code_address,
-                            Flag::bugfix_precompiled_gasused,
-                        }},
-                {.to = protocol::BlockVersion::V3_14_0_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_nonce_not_increase_when_revert,
-                            Flag::bugfix_set_contract_nonce_when_create,
-                        }},
-                {.to = protocol::BlockVersion::V3_15_1_VERSION,
-                    .flags = {Flag::bugfix_precompiled_gascalc}},
-                {.to = protocol::BlockVersion::V3_15_2_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_method_auth_sender,
-                            Flag::bugfix_precompiled_evm_status,
-                        }},
-                {.to = protocol::BlockVersion::V3_16_0_VERSION,
-                    .flags = {Flag::bugfix_delegatecall_transfer, Flag::bugfix_nonce_initialize,
-                        Flag::bugfix_v1_timestamp}},
-                {.to = protocol::BlockVersion::V3_16_4_VERSION,
-                    .flags = {Flag::bugfix_revert_logs}},
-                {.to = protocol::BlockVersion::V3_16_5_VERSION,
-                    .flags =
-                        {
-                            Flag::bugfix_auth_check_create2,
-                            Flag::bugfix_auth_check_revert_status,
-                            Flag::bugfix_auth_table_raw_address,
-                            Flag::bugfix_auth_table_squatting,
-                        }},
-                {.to = protocol::BlockVersion::V3_17_0_VERSION,
-                    .flags = {
-                        Flag::bugfix_statestorage_hash_v3_17,
-                    }}});
-        for (const auto& upgradeFeatures : upgradeRoadmap)
-        {
-            if (((toVersion < protocol::BlockVersion::V3_2_7_VERSION) &&
-                    (toVersion >= upgradeFeatures.to)) ||
-                (fromVersion < upgradeFeatures.to && toVersion >= upgradeFeatures.to))
-            {
-                for (auto flag : upgradeFeatures.flags)
-                {
-                    set(flag);
-                }
-            }
-        }
-    }
->>>>>>> 438c82d82 (refactor(storage): gate FIB-99 hash via Features flag, not block version)
 
     void setGenesisFeatures(protocol::BlockVersion toVersion);
 
@@ -274,8 +157,11 @@ public:
     task::Task<void> readFromStorage(
         storage2::ReadableStorage<executor_v1::StateKeyView> auto& storage, long blockNumber);
 
+    // NOTE: second concept arg used to be executor_v1::StateValue (alias of storage::Entry).
+    // Aliases cannot be forward-declared, so we use storage::Entry directly here so the
+    // declaration parses with just a forward declaration of storage::Entry.
     task::Task<void> writeToStorage(
-        storage2::WritableStorage<executor_v1::StateKey, executor_v1::StateValue> auto& storage,
+        storage2::WritableStorage<executor_v1::StateKey, storage::Entry> auto& storage,
         long blockNumber, bool ignoreDuplicate = true) const;
 };
 

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -63,7 +63,6 @@ public:
         bugfix_auth_check_revert_status,
         bugfix_auth_table_raw_address,
         bugfix_auth_table_squatting,
-        bugfix_v1_executive_wrapper,
         bugfix_v1_exec_error_gas_used,
         bugfix_v1_precompiled_error_gas,      // FIB-76/79/80: precompiled gas overflow check,
                                               // exception safety, and use remaining gas on revert
@@ -116,7 +115,138 @@ public:
 
     void setToShardingDefault(protocol::BlockVersion version);
 
+<<<<<<< HEAD
     void setUpgradeFeatures(protocol::BlockVersion fromVersion, protocol::BlockVersion toVersion);
+=======
+    void setUpgradeFeatures(protocol::BlockVersion fromVersion, protocol::BlockVersion toVersion)
+    {
+        struct UpgradeFeatures
+        {
+            protocol::BlockVersion to;
+            std::vector<Flag> flags;
+        };
+        const static auto upgradeRoadmap =
+            std::to_array<UpgradeFeatures>({{.to = protocol::BlockVersion::V3_2_3_VERSION,
+                                                .flags =
+                                                    {
+                                                        Flag::bugfix_revert,
+                                                    }},
+                {.to = protocol::BlockVersion::V3_2_4_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_statestorage_hash,
+                            Flag::bugfix_evm_create2_delegatecall_staticcall_codecopy,
+                        }},
+                {.to = protocol::BlockVersion::V3_2_7_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_event_log_order,
+                            Flag::bugfix_call_noaddr_return,
+                            Flag::bugfix_precompiled_codehash,
+                            Flag::bugfix_dmc_revert,
+                        }},
+                {.to = protocol::BlockVersion::V3_5_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_revert,
+                            Flag::bugfix_statestorage_hash,
+                        }},
+                {.to = protocol::BlockVersion::V3_6_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_statestorage_hash,
+                            Flag::bugfix_evm_create2_delegatecall_staticcall_codecopy,
+                            Flag::bugfix_event_log_order,
+                            Flag::bugfix_call_noaddr_return,
+                            Flag::bugfix_precompiled_codehash,
+                            Flag::bugfix_dmc_revert,
+                        }},
+                {.to = protocol::BlockVersion::V3_6_1_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_keypage_system_entry_hash,
+                            Flag::bugfix_internal_create_redundant_storage,
+                        }},
+                {.to = protocol::BlockVersion::V3_7_0_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_empty_abi_reset,
+                            Flag::bugfix_eip55_addr,
+                            Flag::bugfix_sharding_call_in_child_executive,
+                            Flag::bugfix_internal_create_permission_denied,
+                        }},
+                {.to = protocol::BlockVersion::V3_8_0_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_eoa_as_contract,
+                            Flag::bugfix_dmc_deploy_gas_used,
+                            Flag::bugfix_evm_exception_gas_used,
+                            Flag::bugfix_set_row_with_dirty_flag,
+                        }},
+                {.to = protocol::BlockVersion::V3_9_0_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_staticcall_noaddr_return,
+                            Flag::bugfix_support_transfer_receive_fallback,
+                            Flag::bugfix_eoa_match_failed,
+                        }},
+                {.to = protocol::BlockVersion::V3_12_0_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_rpbft_vrf_blocknumber_input,
+                        }},
+                {.to = protocol::BlockVersion::V3_13_0_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_delete_account_code,
+                            Flag::bugfix_policy1_empty_code_address,
+                            Flag::bugfix_precompiled_gasused,
+                        }},
+                {.to = protocol::BlockVersion::V3_14_0_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_nonce_not_increase_when_revert,
+                            Flag::bugfix_set_contract_nonce_when_create,
+                        }},
+                {.to = protocol::BlockVersion::V3_15_1_VERSION,
+                    .flags = {Flag::bugfix_precompiled_gascalc}},
+                {.to = protocol::BlockVersion::V3_15_2_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_method_auth_sender,
+                            Flag::bugfix_precompiled_evm_status,
+                        }},
+                {.to = protocol::BlockVersion::V3_16_0_VERSION,
+                    .flags = {Flag::bugfix_delegatecall_transfer, Flag::bugfix_nonce_initialize,
+                        Flag::bugfix_v1_timestamp}},
+                {.to = protocol::BlockVersion::V3_16_4_VERSION,
+                    .flags = {Flag::bugfix_revert_logs}},
+                {.to = protocol::BlockVersion::V3_16_5_VERSION,
+                    .flags =
+                        {
+                            Flag::bugfix_auth_check_create2,
+                            Flag::bugfix_auth_check_revert_status,
+                            Flag::bugfix_auth_table_raw_address,
+                            Flag::bugfix_auth_table_squatting,
+                        }},
+                {.to = protocol::BlockVersion::V3_17_0_VERSION,
+                    .flags = {
+                        Flag::bugfix_statestorage_hash_v3_17,
+                    }}});
+        for (const auto& upgradeFeatures : upgradeRoadmap)
+        {
+            if (((toVersion < protocol::BlockVersion::V3_2_7_VERSION) &&
+                    (toVersion >= upgradeFeatures.to)) ||
+                (fromVersion < upgradeFeatures.to && toVersion >= upgradeFeatures.to))
+            {
+                for (auto flag : upgradeFeatures.flags)
+                {
+                    set(flag);
+                }
+            }
+        }
+    }
+>>>>>>> 438c82d82 (refactor(storage): gate FIB-99 hash via Features flag, not block version)
 
     void setGenesisFeatures(protocol::BlockVersion toVersion);
 

--- a/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
+++ b/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
@@ -31,7 +31,7 @@ inline task::Task<void> Features::readFromStorage(
 }
 
 inline task::Task<void> Features::writeToStorage(
-    storage2::WritableStorage<executor_v1::StateKey, executor_v1::StateValue> auto& storage,
+    storage2::WritableStorage<executor_v1::StateKey, storage::Entry> auto& storage,
     long blockNumber, bool ignoreDuplicate) const
 {
     for (auto [flag, name, value] : flags())

--- a/bcos-framework/bcos-framework/protocol/Protocol.h
+++ b/bcos-framework/bcos-framework/protocol/Protocol.h
@@ -115,6 +115,7 @@ enum ProtocolVersion : uint32_t
 
 enum class BlockVersion : uint32_t
 {
+    V3_17_0_VERSION = 0x03110000,  // 3.17.0
     V3_16_4_VERSION = 0x03100400,  // 3.16.4
     V3_16_3_VERSION = 0x03100300,  // 3.16.3
     V3_16_2_VERSION = 0x03100200,  // 3.16.2
@@ -159,7 +160,7 @@ enum class BlockVersion : uint32_t
     V3_0_VERSION = 0x03000000,
     RC4_VERSION = 4,
     MIN_VERSION = RC4_VERSION,
-    MAX_VERSION = V3_16_4_VERSION,
+    MAX_VERSION = V3_17_0_VERSION,
 };
 
 enum class TransactionVersion : uint32_t

--- a/bcos-framework/bcos-framework/protocol/Protocol.h
+++ b/bcos-framework/bcos-framework/protocol/Protocol.h
@@ -159,7 +159,7 @@ enum class BlockVersion : uint32_t
     V3_0_VERSION = 0x03000000,
     RC4_VERSION = 4,
     MIN_VERSION = RC4_VERSION,
-    MAX_VERSION = V3_16_5_VERSION,
+    MAX_VERSION = V3_17_0_VERSION,
 };
 
 enum class TransactionVersion : uint32_t

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -42,24 +42,21 @@ crypto::HashType Entry::hash(std::string_view table, std::string_view key,
         // FIB-99: Length-prefixed, status-aware hashing to prevent boundary
         // ambiguity and status ambiguity collisions in state root calculation.
         auto hasher = hashImpl.hasher();
-        // Length-prefix table name (4 bytes little-endian)
-        uint32_t tableLen = static_cast<uint32_t>(table.size());
-        hasher.update(std::string_view(reinterpret_cast<const char*>(&tableLen), sizeof(tableLen)));
+        // FIB-99 preimage format (fixed across platforms):
+        //   u32(tableLen) || table || u32(keyLen) || key || i8(status) || [data if MODIFIED]
+        // Use explicit fixed-width types so the hash is independent of sizeof(size_t).
+        hasher.update(static_cast<uint32_t>(table.size()));
         hasher.update(table);
-        // Length-prefix key (4 bytes little-endian)
-        uint32_t keyLen = static_cast<uint32_t>(key.size());
-        hasher.update(std::string_view(reinterpret_cast<const char*>(&keyLen), sizeof(keyLen)));
+        hasher.update(static_cast<uint32_t>(key.size()));
         hasher.update(key);
-        // Include entry status as a byte to distinguish DELETED from empty MODIFIED
-        uint8_t statusByte = static_cast<uint8_t>(m_status);
-        hasher.update(
-            std::string_view(reinterpret_cast<const char*>(&statusByte), sizeof(statusByte)));
+        // Entry status (1 byte) distinguishes DELETED from MODIFIED-with-empty-value.
+        hasher.update(m_status);
 
         switch (m_status)
         {
         case MODIFIED:
         {
-            auto data = get();
+            const auto data = get();
             hasher.update(data);
             hasher.final(entryHash);
             if (c_fileLogLevel == TRACE) [[unlikely]]
@@ -83,7 +80,7 @@ crypto::HashType Entry::hash(std::string_view table, std::string_view key,
         default:
         {
             STORAGE_LOG(DEBUG) << "Entry hash v3.17+, clean entry: " << table << " | " << toHex(key)
-                               << " | " << (int)m_status;
+                               << " | " << static_cast<int>(m_status);
             break;
         }
         }

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -34,13 +34,20 @@ const char* Entry::data() const&
 }
 
 crypto::HashType Entry::hash(std::string_view table, std::string_view key,
-    const bcos::crypto::Hash& hashImpl, uint32_t blockVersion) const
+    const bcos::crypto::Hash& hashImpl, uint32_t blockVersion,
+    std::optional<bcos::ledger::Features> features) const
 {
+    const bool enableHashCollisionFix =
+        features.has_value() &&
+        features->get(bcos::ledger::Features::Flag::bugfix_statestorage_hash_v3_17);
+
     bcos::crypto::HashType entryHash(0);
-    if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_17_0_VERSION)
+    if (enableHashCollisionFix)
     {
         // FIB-99: Length-prefixed, status-aware hashing to prevent boundary
         // ambiguity and status ambiguity collisions in state root calculation.
+        // Gated by Features::Flag::bugfix_statestorage_hash_v3_17 (activated at V3_17_0),
+        // not by blockVersion, so the fix follows the bugfix-flag semantic.
         auto hasher = hashImpl.hasher();
         // FIB-99 preimage format (fixed across platforms):
         //   u32(tableLen) || table || u32(keyLen) || key || i8(status) || [data if MODIFIED]
@@ -85,7 +92,7 @@ crypto::HashType Entry::hash(std::string_view table, std::string_view key,
         }
         }
     }
-    else if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
+    else if (blockVersion >= static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION))
     {
         auto hasher = hashImpl.hasher();
         hasher.update(table);

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -37,7 +37,58 @@ crypto::HashType Entry::hash(std::string_view table, std::string_view key,
     const bcos::crypto::Hash& hashImpl, uint32_t blockVersion) const
 {
     bcos::crypto::HashType entryHash(0);
-    if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
+    if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_17_0_VERSION)
+    {
+        // FIB-99: Length-prefixed, status-aware hashing to prevent boundary
+        // ambiguity and status ambiguity collisions in state root calculation.
+        auto hasher = hashImpl.hasher();
+        // Length-prefix table name (4 bytes little-endian)
+        uint32_t tableLen = static_cast<uint32_t>(table.size());
+        hasher.update(std::string_view(reinterpret_cast<const char*>(&tableLen), sizeof(tableLen)));
+        hasher.update(table);
+        // Length-prefix key (4 bytes little-endian)
+        uint32_t keyLen = static_cast<uint32_t>(key.size());
+        hasher.update(std::string_view(reinterpret_cast<const char*>(&keyLen), sizeof(keyLen)));
+        hasher.update(key);
+        // Include entry status as a byte to distinguish DELETED from empty MODIFIED
+        uint8_t statusByte = static_cast<uint8_t>(m_status);
+        hasher.update(
+            std::string_view(reinterpret_cast<const char*>(&statusByte), sizeof(statusByte)));
+
+        switch (m_status)
+        {
+        case MODIFIED:
+        {
+            auto data = get();
+            hasher.update(data);
+            hasher.final(entryHash);
+            if (c_fileLogLevel == TRACE) [[unlikely]]
+            {
+                STORAGE_LOG(TRACE)
+                    << "Entry hash v3.17+, dirty entry: " << table << " | " << toHex(key) << " | "
+                    << toHex(data) << LOG_KV("hash", entryHash.abridged());
+            }
+            break;
+        }
+        case DELETED:
+        {
+            hasher.final(entryHash);
+            if (c_fileLogLevel == TRACE) [[unlikely]]
+            {
+                STORAGE_LOG(TRACE) << "Entry hash v3.17+, deleted entry: " << table << " | "
+                                   << toHex(key) << LOG_KV("hash", entryHash.abridged());
+            }
+            break;
+        }
+        default:
+        {
+            STORAGE_LOG(DEBUG) << "Entry hash v3.17+, clean entry: " << table << " | " << toHex(key)
+                               << " | " << (int)m_status;
+            break;
+        }
+        }
+    }
+    else if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
     {
         auto hasher = hashImpl.hasher();
         hasher.update(table);
@@ -63,16 +114,15 @@ crypto::HashType Entry::hash(std::string_view table, std::string_view key,
             hasher.final(entryHash);
             if (c_fileLogLevel == TRACE) [[unlikely]]
             {
-                STORAGE_LOG(TRACE) << "Entry hash, deleted entry: " << table << " | "
-                                   << toHex(key) << LOG_KV("hash", entryHash.abridged());
+                STORAGE_LOG(TRACE) << "Entry hash, deleted entry: " << table << " | " << toHex(key)
+                                   << LOG_KV("hash", entryHash.abridged());
             }
             break;
         }
         default:
         {
-            STORAGE_LOG(DEBUG)
-                << "Entry hash, clean entry: " << table << " | " << toHex(key) << " | "
-                << (int)m_status;
+            STORAGE_LOG(DEBUG) << "Entry hash, clean entry: " << table << " | " << toHex(key)
+                               << " | " << (int)m_status;
             break;
         }
         }

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -2,6 +2,7 @@
 
 #include "bcos-framework/protocol/Protocol.h"
 #include <bcos-utilities/BoostLog.h>
+#include <boost/endian/conversion.hpp>
 
 namespace bcos::storage
 {
@@ -50,13 +51,19 @@ crypto::HashType Entry::hash(std::string_view table, std::string_view key,
         // not by blockVersion, so the fix follows the bugfix-flag semantic.
         auto hasher = hashImpl.hasher();
         // FIB-99 preimage format (fixed across platforms):
-        //   u32(tableLen) || table || u32(keyLen) || key || i8(status) || [data if MODIFIED]
-        // Use explicit fixed-width types so the hash is independent of sizeof(size_t).
-        hasher.update(static_cast<uint32_t>(table.size()));
+        //   u32be(tableLen) || table || u32be(keyLen) || key || i8(status) || [data if MODIFIED]
+        // Use explicit fixed-width types so the hash is independent of sizeof(size_t),
+        // and normalize length prefixes to big-endian so the digest is identical on
+        // little-endian and big-endian hosts (matches the convention used in
+        // bcos-tars-protocol TarsHashable.h and bcos-sealer VRFBasedSealer.cpp).
+        const auto tableLenBE = boost::endian::native_to_big(static_cast<uint32_t>(table.size()));
+        const auto keyLenBE = boost::endian::native_to_big(static_cast<uint32_t>(key.size()));
+        hasher.update(tableLenBE);
         hasher.update(table);
-        hasher.update(static_cast<uint32_t>(key.size()));
+        hasher.update(keyLenBE);
         hasher.update(key);
-        // Entry status (1 byte) distinguishes DELETED from MODIFIED-with-empty-value.
+        // Entry status (int8_t) distinguishes DELETED from MODIFIED-with-empty-value;
+        // single-byte field, no endianness conversion needed.
         hasher.update(m_status);
 
         switch (m_status)

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -35,7 +35,7 @@ const char* Entry::data() const&
 
 crypto::HashType Entry::hash(std::string_view table, std::string_view key,
     const bcos::crypto::Hash& hashImpl, uint32_t blockVersion,
-    std::optional<bcos::ledger::Features> features) const
+    std::optional<bcos::ledger::Features> const& features) const
 {
     const bool enableHashCollisionFix =
         features.has_value() &&

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -221,7 +221,59 @@ public:
         const bcos::crypto::Hash& hashImpl, uint32_t blockVersion) const
     {
         bcos::crypto::HashType entryHash(0);
-        if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
+        if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_17_0_VERSION)
+        {
+            // FIB-99: Length-prefixed, status-aware hashing to prevent boundary
+            // ambiguity and status ambiguity collisions in state root calculation.
+            auto hasher = hashImpl.hasher();
+            // Length-prefix table name (4 bytes little-endian)
+            uint32_t tableLen = static_cast<uint32_t>(table.size());
+            hasher.update(
+                std::string_view(reinterpret_cast<const char*>(&tableLen), sizeof(tableLen)));
+            hasher.update(table);
+            // Length-prefix key (4 bytes little-endian)
+            uint32_t keyLen = static_cast<uint32_t>(key.size());
+            hasher.update(std::string_view(reinterpret_cast<const char*>(&keyLen), sizeof(keyLen)));
+            hasher.update(key);
+            // Include entry status as a byte to distinguish DELETED from empty MODIFIED
+            uint8_t statusByte = static_cast<uint8_t>(m_status);
+            hasher.update(
+                std::string_view(reinterpret_cast<const char*>(&statusByte), sizeof(statusByte)));
+
+            switch (m_status)
+            {
+            case MODIFIED:
+            {
+                auto data = get();
+                hasher.update(data);
+                hasher.final(entryHash);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE)
+                        << "Entry hash v3.17+, dirty entry: " << table << " | " << toHex(key)
+                        << " | " << toHex(data) << LOG_KV("hash", entryHash.abridged());
+                }
+                break;
+            }
+            case DELETED:
+            {
+                hasher.final(entryHash);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE) << "Entry hash v3.17+, deleted entry: " << table << " | "
+                                       << toHex(key) << LOG_KV("hash", entryHash.abridged());
+                }
+                break;
+            }
+            default:
+            {
+                STORAGE_LOG(DEBUG) << "Entry hash v3.17+, clean entry: " << table << " | "
+                                   << toHex(key) << " | " << (int)m_status;
+                break;
+            }
+            }
+        }
+        else if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
         {
             auto hasher = hashImpl.hasher();
             hasher.update(table);

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -147,8 +147,8 @@ public:
     }
 
     template <typename T>
-        requires(!EntryBufferInput<std::remove_cvref_t<T>> &&
-                 std::convertible_to<T, std::string_view>)
+        requires(
+            !EntryBufferInput<std::remove_cvref_t<T>> && std::convertible_to<T, std::string_view>)
     void set(T&& value)
     {
         set(std::string_view(std::forward<T>(value)));

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -2,8 +2,8 @@
 
 #include "Common.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
-#include "protocol/Protocol.h"
 #include <bcos-framework/ledger/Features.h>
+#include <bcos-framework/protocol/Protocol.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Error.h>
 #include <boost/archive/basic_archive.hpp>
@@ -18,10 +18,6 @@
 #include <type_traits>
 #include <variant>
 
-namespace bcos::ledger
-{
-class Features;
-}
 namespace bcos::storage
 {
 
@@ -207,20 +203,20 @@ public:
 
     // Convenience overload for callers without Features. Forwards to the 5-arg overload
     // with std::nullopt so all bugfix-flag lookups are skipped (legacy path).
-    // Templated (with a default) so that `std::optional<Features>` instantiation is
-    // deferred to the call site, where Features.h is in scope.
     crypto::HashType hash(std::string_view table, std::string_view key,
         const bcos::crypto::Hash& hashImpl, uint32_t blockVersion) const
     {
         return hash(table, key, hashImpl, blockVersion, std::nullopt);
     }
 
-private:
-    [[nodiscard]] auto outputValueView(const ValueType& value) const& -> std::string_view;
-
+    // 5-arg overload. When features carries bugfix_statestorage_hash_v3_17, uses the
+    // length-prefixed, status-aware preimage that fixes FIB-99 boundary/status ambiguity.
     crypto::HashType hash(std::string_view table, std::string_view key,
         const bcos::crypto::Hash& hashImpl, uint32_t blockVersion,
-        std::optional<bcos::ledger::Features> features) const;
+        std::optional<bcos::ledger::Features> const& features) const;
+
+private:
+    [[nodiscard]] auto outputValueView(const ValueType& value) const& -> std::string_view;
 
     template <typename T>
     [[nodiscard]] auto inputValueView(const T& value) const -> std::string_view

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -2,6 +2,8 @@
 
 #include "Common.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
+#include "protocol/Protocol.h"
+
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Error.h>
 #include <boost/archive/basic_archive.hpp>
@@ -197,11 +199,149 @@ public:
     int32_t size() const { return m_size; }
 
     bool valid() const { return m_status == Status::NORMAL; }
+    // Legacy overload kept for callers that don't have Features available
+    // (test code, KeyPageStorage / StateStorage in the legacy DMC scheduler path).
+    // The V3_17 length-prefixed format is NOT applied here.
     crypto::HashType hash(std::string_view table, std::string_view key,
         const bcos::crypto::Hash& hashImpl, uint32_t blockVersion) const;
 
 private:
     [[nodiscard]] auto outputValueView(const ValueType& value) const& -> std::string_view;
+
+    // Future-proof overload: accepts the full Features set so new bugfix flags can
+    // be plumbed into the hash function without changing its signature again.
+    // Templated on Features to avoid an include cycle (Features.h includes Entry.h).
+    // The Features type only needs `bool get(std::string_view) const`.
+    template <class Features>
+    crypto::HashType hash(std::string_view table, std::string_view key,
+        const bcos::crypto::Hash& hashImpl, uint32_t blockVersion, Features const& features) const
+    {
+        const bool enableHashCollisionFix =
+            features.get(std::string_view{"bugfix_statestorage_hash_v3_17"});
+        return hashImpl_(table, key, hashImpl, blockVersion, enableHashCollisionFix);
+    }
+
+private:
+    crypto::HashType hashImpl_(std::string_view table, std::string_view key,
+        const bcos::crypto::Hash& hashImpl, uint32_t blockVersion,
+        bool enableHashCollisionFix) const
+    {
+        bcos::crypto::HashType entryHash(0);
+        if (enableHashCollisionFix)
+        {
+            // FIB-99: Length-prefixed, status-aware hashing to prevent boundary
+            // ambiguity and status ambiguity collisions in state root calculation.
+            // Gated by Features::Flag::bugfix_statestorage_hash_v3_17 (activated at V3_17_0),
+            // not by blockVersion, so the fix follows the bugfix-flag semantic.
+            auto hasher = hashImpl.hasher();
+            // FIB-99 preimage format (fixed across platforms):
+            //   u32(tableLen) || table || u32(keyLen) || key || i8(status) || [data if MODIFIED]
+            // Use explicit fixed-width types so the hash is independent of sizeof(size_t).
+            hasher.update(static_cast<uint32_t>(table.size()));
+            hasher.update(table);
+            hasher.update(static_cast<uint32_t>(key.size()));
+            hasher.update(key);
+            // Entry status (1 byte) distinguishes DELETED from MODIFIED-with-empty-value.
+            hasher.update(m_status);
+
+            switch (m_status)
+            {
+            case MODIFIED:
+            {
+                const auto data = get();
+                hasher.update(data);
+                hasher.final(entryHash);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE)
+                        << "Entry hash v3.17+, dirty entry: " << table << " | " << toHex(key)
+                        << " | " << toHex(data) << LOG_KV("hash", entryHash.abridged());
+                }
+                break;
+            }
+            case DELETED:
+            {
+                hasher.final(entryHash);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE) << "Entry hash v3.17+, deleted entry: " << table << " | "
+                                       << toHex(key) << LOG_KV("hash", entryHash.abridged());
+                }
+                break;
+            }
+            default:
+            {
+                STORAGE_LOG(DEBUG) << "Entry hash v3.17+, clean entry: " << table << " | "
+                                   << toHex(key) << " | " << static_cast<int>(m_status);
+                break;
+            }
+            }
+        }
+        else if (blockVersion >= static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION))
+        {
+            auto hasher = hashImpl.hasher();
+            hasher.update(table);
+            hasher.update(key);
+
+            switch (m_status)
+            {
+            case MODIFIED:
+            {
+                const auto data = get();
+                hasher.update(data);
+                hasher.final(entryHash);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE)
+                        << "Entry hash, dirty entry: " << table << " | " << toHex(key) << " | "
+                        << toHex(data) << LOG_KV("hash", entryHash.abridged());
+                }
+                break;
+            }
+            case DELETED:
+            {
+                hasher.final(entryHash);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE) << "Entry hash, deleted entry: " << table << " | "
+                                       << toHex(key) << LOG_KV("hash", entryHash.abridged());
+                }
+                break;
+            }
+            default:
+            {
+                STORAGE_LOG(DEBUG) << "Entry hash, clean entry: " << table << " | " << toHex(key)
+                                   << " | " << static_cast<int>(m_status);
+                break;
+            }
+            }
+        }
+        else
+        {  // 3.0.0
+            if (m_status == Entry::MODIFIED)
+            {
+                auto value = get();
+                bcos::bytesConstRef ref((const bcos::byte*)value.data(), value.size());
+                entryHash = hashImpl.hash(ref);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE)
+                        << "Entry Calc hash, dirty entry: " << table << " | " << toHex(key) << " | "
+                        << toHex(value) << LOG_KV("hash", entryHash.abridged());
+                }
+            }
+            else if (m_status == Entry::DELETED)
+            {
+                entryHash = bcos::crypto::HashType(0x1);
+                if (c_fileLogLevel == TRACE) [[unlikely]]
+                {
+                    STORAGE_LOG(TRACE) << "Entry Calc hash, deleted entry: " << table << " | "
+                                       << toHex(key) << LOG_KV("hash", entryHash.abridged());
+                }
+            }
+        }
+        return entryHash;
+    }
 
     template <typename T>
     [[nodiscard]] auto inputValueView(const T& value) const -> std::string_view

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -3,7 +3,7 @@
 #include "Common.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
 #include "protocol/Protocol.h"
-
+#include <bcos-framework/ledger/Features.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Error.h>
 #include <boost/archive/basic_archive.hpp>
@@ -14,9 +14,14 @@
 #include <algorithm>
 #include <cstdint>
 #include <initializer_list>
+#include <optional>
 #include <type_traits>
 #include <variant>
 
+namespace bcos::ledger
+{
+class Features;
+}
 namespace bcos::storage
 {
 
@@ -199,149 +204,23 @@ public:
     int32_t size() const { return m_size; }
 
     bool valid() const { return m_status == Status::NORMAL; }
-    // Legacy overload kept for callers that don't have Features available
-    // (test code, KeyPageStorage / StateStorage in the legacy DMC scheduler path).
-    // The V3_17 length-prefixed format is NOT applied here.
+
+    // Convenience overload for callers without Features. Forwards to the 5-arg overload
+    // with std::nullopt so all bugfix-flag lookups are skipped (legacy path).
+    // Templated (with a default) so that `std::optional<Features>` instantiation is
+    // deferred to the call site, where Features.h is in scope.
     crypto::HashType hash(std::string_view table, std::string_view key,
-        const bcos::crypto::Hash& hashImpl, uint32_t blockVersion) const;
+        const bcos::crypto::Hash& hashImpl, uint32_t blockVersion) const
+    {
+        return hash(table, key, hashImpl, blockVersion, std::nullopt);
+    }
 
 private:
     [[nodiscard]] auto outputValueView(const ValueType& value) const& -> std::string_view;
 
-    // Future-proof overload: accepts the full Features set so new bugfix flags can
-    // be plumbed into the hash function without changing its signature again.
-    // Templated on Features to avoid an include cycle (Features.h includes Entry.h).
-    // The Features type only needs `bool get(std::string_view) const`.
-    template <class Features>
     crypto::HashType hash(std::string_view table, std::string_view key,
-        const bcos::crypto::Hash& hashImpl, uint32_t blockVersion, Features const& features) const
-    {
-        const bool enableHashCollisionFix =
-            features.get(std::string_view{"bugfix_statestorage_hash_v3_17"});
-        return hashImpl_(table, key, hashImpl, blockVersion, enableHashCollisionFix);
-    }
-
-private:
-    crypto::HashType hashImpl_(std::string_view table, std::string_view key,
         const bcos::crypto::Hash& hashImpl, uint32_t blockVersion,
-        bool enableHashCollisionFix) const
-    {
-        bcos::crypto::HashType entryHash(0);
-        if (enableHashCollisionFix)
-        {
-            // FIB-99: Length-prefixed, status-aware hashing to prevent boundary
-            // ambiguity and status ambiguity collisions in state root calculation.
-            // Gated by Features::Flag::bugfix_statestorage_hash_v3_17 (activated at V3_17_0),
-            // not by blockVersion, so the fix follows the bugfix-flag semantic.
-            auto hasher = hashImpl.hasher();
-            // FIB-99 preimage format (fixed across platforms):
-            //   u32(tableLen) || table || u32(keyLen) || key || i8(status) || [data if MODIFIED]
-            // Use explicit fixed-width types so the hash is independent of sizeof(size_t).
-            hasher.update(static_cast<uint32_t>(table.size()));
-            hasher.update(table);
-            hasher.update(static_cast<uint32_t>(key.size()));
-            hasher.update(key);
-            // Entry status (1 byte) distinguishes DELETED from MODIFIED-with-empty-value.
-            hasher.update(m_status);
-
-            switch (m_status)
-            {
-            case MODIFIED:
-            {
-                const auto data = get();
-                hasher.update(data);
-                hasher.final(entryHash);
-                if (c_fileLogLevel == TRACE) [[unlikely]]
-                {
-                    STORAGE_LOG(TRACE)
-                        << "Entry hash v3.17+, dirty entry: " << table << " | " << toHex(key)
-                        << " | " << toHex(data) << LOG_KV("hash", entryHash.abridged());
-                }
-                break;
-            }
-            case DELETED:
-            {
-                hasher.final(entryHash);
-                if (c_fileLogLevel == TRACE) [[unlikely]]
-                {
-                    STORAGE_LOG(TRACE) << "Entry hash v3.17+, deleted entry: " << table << " | "
-                                       << toHex(key) << LOG_KV("hash", entryHash.abridged());
-                }
-                break;
-            }
-            default:
-            {
-                STORAGE_LOG(DEBUG) << "Entry hash v3.17+, clean entry: " << table << " | "
-                                   << toHex(key) << " | " << static_cast<int>(m_status);
-                break;
-            }
-            }
-        }
-        else if (blockVersion >= static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION))
-        {
-            auto hasher = hashImpl.hasher();
-            hasher.update(table);
-            hasher.update(key);
-
-            switch (m_status)
-            {
-            case MODIFIED:
-            {
-                const auto data = get();
-                hasher.update(data);
-                hasher.final(entryHash);
-                if (c_fileLogLevel == TRACE) [[unlikely]]
-                {
-                    STORAGE_LOG(TRACE)
-                        << "Entry hash, dirty entry: " << table << " | " << toHex(key) << " | "
-                        << toHex(data) << LOG_KV("hash", entryHash.abridged());
-                }
-                break;
-            }
-            case DELETED:
-            {
-                hasher.final(entryHash);
-                if (c_fileLogLevel == TRACE) [[unlikely]]
-                {
-                    STORAGE_LOG(TRACE) << "Entry hash, deleted entry: " << table << " | "
-                                       << toHex(key) << LOG_KV("hash", entryHash.abridged());
-                }
-                break;
-            }
-            default:
-            {
-                STORAGE_LOG(DEBUG) << "Entry hash, clean entry: " << table << " | " << toHex(key)
-                                   << " | " << static_cast<int>(m_status);
-                break;
-            }
-            }
-        }
-        else
-        {  // 3.0.0
-            if (m_status == Entry::MODIFIED)
-            {
-                auto value = get();
-                bcos::bytesConstRef ref((const bcos::byte*)value.data(), value.size());
-                entryHash = hashImpl.hash(ref);
-                if (c_fileLogLevel == TRACE) [[unlikely]]
-                {
-                    STORAGE_LOG(TRACE)
-                        << "Entry Calc hash, dirty entry: " << table << " | " << toHex(key) << " | "
-                        << toHex(value) << LOG_KV("hash", entryHash.abridged());
-                }
-            }
-            else if (m_status == Entry::DELETED)
-            {
-                entryHash = bcos::crypto::HashType(0x1);
-                if (c_fileLogLevel == TRACE) [[unlikely]]
-                {
-                    STORAGE_LOG(TRACE) << "Entry Calc hash, deleted entry: " << table << " | "
-                                       << toHex(key) << LOG_KV("hash", entryHash.abridged());
-                }
-            }
-        }
-        return entryHash;
-    }
+        std::optional<bcos::ledger::Features> features) const;
 
     template <typename T>
     [[nodiscard]] auto inputValueView(const T& value) const -> std::string_view

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -182,7 +182,6 @@ BOOST_AUTO_TEST_CASE(feature)
         "bugfix_auth_check_revert_status",
         "bugfix_auth_table_raw_address",
         "bugfix_auth_table_squatting",
-        "bugfix_v1_executive_wrapper",
         "bugfix_v1_exec_error_gas_used",
         "bugfix_v1_precompiled_error_gas",
         "bugfix_gas_payment_balance_precheck",

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -205,7 +205,6 @@ BOOST_AUTO_TEST_CASE(feature)
         "feature_raw_address",
         "feature_rpbft_vrf_type_secp256k1",
         "feature_balance_policy2",
-        "bugfix_gas_payment_balance_precheck",
     };
     // clang-format on
     for (size_t i = 0; i < keys.size(); ++i)

--- a/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
@@ -2048,7 +2048,8 @@ BOOST_AUTO_TEST_CASE(pageSplitRandom)
         ++totalCount;
         return true;
     });
-    // Original scale was 9730, here (tables 100->10, writes 5000->500, reads 500->50) reduced by 100x overall
+    // Original scale was 9730, here (tables 100->10, writes 5000->500, reads 500->50) reduced by
+    // 100x overall
     BOOST_REQUIRE_EQUAL(totalCount, 250);  // meta + 5page + s_table（按比例缩放）
 }
 
@@ -3048,7 +3049,7 @@ BOOST_AUTO_TEST_CASE(bugfix_keypage_system_entry_hash)
         BOOST_REQUIRE_NO_THROW(table0->setRow(key, *entry0));
         auto entry = std::make_optional(table0->newEntry());
         entry->setField(0, value);
-        storage->asyncSetRow(ledger::SYS_TABLES, "1", *entry, [](Error::UniquePtr) {});
+        storage->asyncSetRow(StorageInterface::SYS_TABLES, "1", *entry, [](Error::UniquePtr) {});
         return storage->hash(hashImpl, f);
     };
     auto keypage = std::make_shared<KeyPageStorage>(

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -114,8 +114,7 @@ task::Task<h256> calculateStateRoot(
                     {
                         entry = std::addressof(deletedEntry);
                     }
-                    return entry->hash(tableName, keyName, hashImpl,
-                        static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION));
+                    return entry->hash(tableName, keyName, hashImpl, blockVersion);
                 }) &
             tbb::make_filter<h256, void>(
                 tbb::filter_mode::serial_out_of_order, [&](h256 hash) { totalHash ^= hash; }));

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -92,6 +92,10 @@ task::Task<h256> calculateStateRoot(auto& storage, uint32_t blockVersion,
     storage::Entry deletedEntry;
     deletedEntry.setStatus(storage::Entry::DELETED);
 
+    // Wrap once outside the parallel pipeline so the optional copy is paid only once,
+    // not per entry.
+    const std::optional<ledger::Features> featuresOpt(features);
+
     h256 totalHash;
     using KeyValueType = task::AwaitableReturnType<decltype(range.next())>;
     tbb::parallel_pipeline(tbb::this_task_arena::max_concurrency(),
@@ -115,7 +119,7 @@ task::Task<h256> calculateStateRoot(auto& storage, uint32_t blockVersion,
                     {
                         entry = std::addressof(deletedEntry);
                     }
-                    return entry->hash(tableName, keyName, hashImpl, blockVersion, features);
+                    return entry->hash(tableName, keyName, hashImpl, blockVersion, featuresOpt);
                 }) &
             tbb::make_filter<h256, void>(
                 tbb::filter_mode::serial_out_of_order, [&](h256 hash) { totalHash ^= hash; }));

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -115,8 +115,7 @@ task::Task<h256> calculateStateRoot(
                     {
                         entry = std::addressof(deletedEntry);
                     }
-                    return entry->hash(tableName, keyName, hashImpl,
-                        static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION));
+                    return entry->hash(tableName, keyName, hashImpl, blockVersion);
                 }) &
             tbb::make_filter<h256, void>(
                 tbb::filter_mode::serial_out_of_order, [&](h256 hash) { totalHash ^= hash; }));

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -85,8 +85,8 @@ std::chrono::milliseconds::rep current();
  * @param hashImpl The hash implementation to use for the calculation.
  * @return A task that will eventually resolve to the calculated state root.
  */
-task::Task<h256> calculateStateRoot(
-    auto& storage, uint32_t blockVersion, crypto::Hash const& hashImpl)
+task::Task<h256> calculateStateRoot(auto& storage, uint32_t blockVersion,
+    crypto::Hash const& hashImpl, ledger::Features const& features)
 {
     auto range = co_await storage2::range(storage);
     storage::Entry deletedEntry;
@@ -115,7 +115,7 @@ task::Task<h256> calculateStateRoot(
                     {
                         entry = std::addressof(deletedEntry);
                     }
-                    return entry->hash(tableName, keyName, hashImpl, blockVersion);
+                    return entry->hash(tableName, keyName, hashImpl, blockVersion, features);
                 }) &
             tbb::make_filter<h256, void>(
                 tbb::filter_mode::serial_out_of_order, [&](h256 hash) { totalHash ^= hash; }));
@@ -153,7 +153,8 @@ h256 calculateReceiptRoot(
  */
 task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
     protocol::BlockHeader& newBlockHeader, protocol::Block& block,
-    ::ranges::input_range auto transactions, bool& sysBlock, crypto::Hash const& hashImpl)
+    ::ranges::input_range auto transactions, bool& sysBlock, crypto::Hash const& hashImpl,
+    ledger::Features const& features)
 {
     ittapi::Report finishReport(ittapi::ITT_DOMAINS::instance().BASELINE_SCHEDULER,
         ittapi::ITT_DOMAINS::instance().FINISH_EXECUTE);
@@ -165,7 +166,7 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
     tbb::parallel_invoke([&]() { transactionRoot = calculateTransactionRoot(block, hashImpl); },
         [&]() {
             stateRoot = task::tbb::syncWait(
-                calculateStateRoot(storage, block.blockHeader()->version(), hashImpl));
+                calculateStateRoot(storage, block.blockHeader()->version(), hashImpl, features));
         },
         [&]() { receiptRoot = calculateReceiptRoot(receipts, block, hashImpl); },
         [&]() {
@@ -350,7 +351,7 @@ private:
             bool sysBlock = false;
             co_await finishExecute(mutableStorage(view), ::ranges::views::all(receipts),
                 *executedBlockHeader, *block, ::ranges::views::all(transactions), sysBlock,
-                m_hashImpl.get());
+                m_hashImpl.get(), ledgerConfig->features());
 
             if (verify && (executedBlockHeader->hash() != blockHeader->hash()))
             {

--- a/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
+++ b/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/protocol/Protocol.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Wait.h"
+#include "bcos-transaction-scheduler/BaselineScheduler.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::storage;
+using namespace bcos::storage2;
+using namespace bcos::executor_v1;
+
+BOOST_AUTO_TEST_SUITE(FIB99_FIB105_StateRootTest)
+
+// ---------------------------------------------------------------------------
+// FIB-105: Verify calculateStateRoot uses the passed blockVersion, not a
+// hardcoded V3_1_VERSION.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(calculateStateRootUsesPassedVersion)
+{
+    // Build a small storage with one modified entry
+    using Storage = memory_storage::MemoryStorage<StateKey, StateValue,
+        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+    Storage storage;
+
+    Entry entry;
+    entry.importFields({"hello"});
+    task::syncWait(
+        storage2::writeOne(storage, StateKey{"test_table", "test_key"}, std::move(entry)));
+
+    crypto::Keccak256 hashImpl;
+
+    // Compute state root with V3_1_VERSION
+    auto rootV31 = task::syncWait(scheduler_v1::calculateStateRoot(
+        storage, static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION), hashImpl));
+
+    // Compute state root with V3_17_0_VERSION (new unambiguous hashing)
+    auto rootV317 = task::syncWait(scheduler_v1::calculateStateRoot(
+        storage, static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION), hashImpl));
+
+    // The two roots must differ because the hashing algorithm changed.
+    // If calculateStateRoot still hardcoded V3_1, they would be identical.
+    BOOST_CHECK_NE(rootV31, rootV317);
+
+    // Each should be non-zero (the entry is MODIFIED)
+    BOOST_CHECK_NE(rootV31, h256{});
+    BOOST_CHECK_NE(rootV317, h256{});
+}
+
+// ---------------------------------------------------------------------------
+// FIB-99 boundary collision: (table="a", key="bc") vs (table="ab", key="c")
+// should produce different hashes under V3_17_0 but the same under V3_1.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(boundaryAmbiguityFixedInV317)
+{
+    crypto::Keccak256 hashImpl;
+
+    Entry entryA;
+    entryA.importFields({"d"});  // MODIFIED with data "d"
+
+    Entry entryB;
+    entryB.importFields({"d"});  // MODIFIED with data "d"
+
+    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
+    constexpr auto v317 = static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION);
+
+    // Under V3_1: hash("a" || "bc" || "d") == hash("ab" || "c" || "d") => collision
+    auto hashA_v31 = entryA.hash("a", "bc", hashImpl, v31);
+    auto hashB_v31 = entryB.hash("ab", "c", hashImpl, v31);
+    BOOST_CHECK_EQUAL(hashA_v31, hashB_v31);  // Known collision in old scheme
+
+    // Under V3_17_0: length-prefixed => no collision
+    auto hashA_v317 = entryA.hash("a", "bc", hashImpl, v317);
+    auto hashB_v317 = entryB.hash("ab", "c", hashImpl, v317);
+    BOOST_CHECK_NE(hashA_v317, hashB_v317);  // Fixed!
+}
+
+// ---------------------------------------------------------------------------
+// FIB-99 status collision: DELETED entry vs MODIFIED with empty data should
+// produce different hashes under V3_17_0 but the same under V3_1.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(statusAmbiguityFixedInV317)
+{
+    crypto::Keccak256 hashImpl;
+
+    Entry deletedEntry;
+    deletedEntry.setStatus(Entry::DELETED);
+
+    Entry emptyModified;
+    emptyModified.importFields({""});  // MODIFIED with empty data
+
+    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
+    constexpr auto v317 = static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION);
+
+    // Under V3_1: hash(table || key) vs hash(table || key || "") => same
+    auto hashDel_v31 = deletedEntry.hash("tbl", "k", hashImpl, v31);
+    auto hashMod_v31 = emptyModified.hash("tbl", "k", hashImpl, v31);
+    BOOST_CHECK_EQUAL(hashDel_v31, hashMod_v31);  // Known collision in old scheme
+
+    // Under V3_17_0: status byte distinguishes them
+    auto hashDel_v317 = deletedEntry.hash("tbl", "k", hashImpl, v317);
+    auto hashMod_v317 = emptyModified.hash("tbl", "k", hashImpl, v317);
+    BOOST_CHECK_NE(hashDel_v317, hashMod_v317);  // Fixed!
+}
+
+// ---------------------------------------------------------------------------
+// Backward compatibility: V3_1 and V3_0 hashes remain unchanged.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(backwardCompatibilityPreserved)
+{
+    crypto::Keccak256 hashImpl;
+
+    Entry modifiedEntry;
+    modifiedEntry.importFields({"value123"});
+
+    Entry deletedEntry;
+    deletedEntry.setStatus(Entry::DELETED);
+
+    constexpr auto v30 = static_cast<uint32_t>(protocol::BlockVersion::V3_0_VERSION);
+    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
+    constexpr auto v316 = static_cast<uint32_t>(protocol::BlockVersion::V3_16_4_VERSION);
+
+    // V3_0 hashing: MODIFIED => hash(data), DELETED => 0x1
+    auto hashMod_v30 = modifiedEntry.hash("t", "k", hashImpl, v30);
+    auto hashDel_v30 = deletedEntry.hash("t", "k", hashImpl, v30);
+    BOOST_CHECK_NE(hashMod_v30, h256{});
+    BOOST_CHECK_EQUAL(hashDel_v30, crypto::HashType(0x1));
+
+    // V3_1 hashing: uses hasher with table+key+data, no length prefix
+    auto hashMod_v31 = modifiedEntry.hash("t", "k", hashImpl, v31);
+    auto hashDel_v31 = deletedEntry.hash("t", "k", hashImpl, v31);
+    BOOST_CHECK_NE(hashMod_v31, h256{});
+    BOOST_CHECK_NE(hashDel_v31, h256{});
+
+    // V3_16_4 should still use V3_1 logic (< V3_17_0)
+    auto hashMod_v316 = modifiedEntry.hash("t", "k", hashImpl, v316);
+    auto hashDel_v316 = deletedEntry.hash("t", "k", hashImpl, v316);
+    BOOST_CHECK_EQUAL(hashMod_v31, hashMod_v316);
+    BOOST_CHECK_EQUAL(hashDel_v31, hashDel_v316);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
+++ b/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
@@ -190,4 +190,34 @@ BOOST_AUTO_TEST_CASE(bugfixFlagActivatedAtV3_17_0)
     BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_statestorage_hash_v3_17));
 }
 
+// ---------------------------------------------------------------------------
+// FIB-99 cross-platform stability: pin the V3_17 preimage byte order so that
+// heterogeneous (little-endian and big-endian) nodes compute byte-identical
+// state roots.  The relational tests above (boundary / status collision) only
+// prove that length prefixes exist; they cannot detect a regression where the
+// prefixes are written in native order.  This test pins the canonical digest
+// for a known preimage, computed independently using keccak256 over:
+//   u32be(tableLen) || table || u32be(keyLen) || key || i8(status) || [data]
+// Any change to length-prefix endianness, field ordering, or status byte width
+// will flip these digests.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(crossPlatformHashStable_FIB99_V3_17_BE)
+{
+    crypto::Keccak256 hashImpl;
+    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
+    const auto fix = featuresWithFix();
+
+    // MODIFIED entry: preimage = 00 00 00 03 'tbl' 00 00 00 03 'key' 03 'value'
+    Entry modified;
+    modified.importFields({"value"});
+    BOOST_CHECK_EQUAL(modified.hash("tbl", "key", hashImpl, v31, fix),
+        crypto::HashType("0x8079da3138e857fbdb6c43b1209696220bb398fb4ceb6fdf136bf010b3c5fbad"));
+
+    // DELETED entry: preimage = 00 00 00 03 'tbl' 00 00 00 03 'key' 01  (no data)
+    Entry deleted;
+    deleted.setStatus(Entry::DELETED);
+    BOOST_CHECK_EQUAL(deleted.hash("tbl", "key", hashImpl, v31, fix),
+        crypto::HashType("0x785a147df3f07ff4daf914a8b0f39cd1d67c9ab7da043734f873c4f581cea221"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
+++ b/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/protocol/Protocol.h"
 #include "bcos-framework/storage/Entry.h"
 #include "bcos-framework/storage2/MemoryStorage.h"
@@ -30,13 +31,22 @@ using namespace bcos::executor_v1;
 
 BOOST_AUTO_TEST_SUITE(FIB99_FIB105_StateRootTest)
 
-// ---------------------------------------------------------------------------
-// FIB-105: Verify calculateStateRoot uses the passed blockVersion, not a
-// hardcoded V3_1_VERSION.
-// ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(calculateStateRootUsesPassedVersion)
+namespace
 {
-    // Build a small storage with one modified entry
+ledger::Features featuresWithFix()
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::bugfix_statestorage_hash_v3_17);
+    return features;
+}
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// FIB-105 / FIB-99: calculateStateRoot must select the V3_17 hashing path
+// based on the bugfix flag set in Features, not the block version.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(calculateStateRootRespectsBugfixFlag)
+{
     using Storage = memory_storage::MemoryStorage<StateKey, StateValue,
         memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
     Storage storage;
@@ -47,82 +57,75 @@ BOOST_AUTO_TEST_CASE(calculateStateRootUsesPassedVersion)
         storage2::writeOne(storage, StateKey{"test_table", "test_key"}, std::move(entry)));
 
     crypto::Keccak256 hashImpl;
+    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
 
-    // Compute state root with V3_1_VERSION
-    auto rootV31 = task::syncWait(scheduler_v1::calculateStateRoot(
-        storage, static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION), hashImpl));
+    ledger::Features noFix;
+    auto fix = featuresWithFix();
 
-    // Compute state root with V3_17_0_VERSION (new unambiguous hashing)
-    auto rootV317 = task::syncWait(scheduler_v1::calculateStateRoot(
-        storage, static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION), hashImpl));
+    auto rootLegacy =
+        task::syncWait(scheduler_v1::calculateStateRoot(storage, v31, hashImpl, noFix));
+    auto rootFixed = task::syncWait(scheduler_v1::calculateStateRoot(storage, v31, hashImpl, fix));
 
-    // The two roots must differ because the hashing algorithm changed.
-    // If calculateStateRoot still hardcoded V3_1, they would be identical.
-    BOOST_CHECK_NE(rootV31, rootV317);
-
-    // Each should be non-zero (the entry is MODIFIED)
-    BOOST_CHECK_NE(rootV31, h256{});
-    BOOST_CHECK_NE(rootV317, h256{});
+    // The flag must change the hashing scheme even when blockVersion is identical.
+    BOOST_CHECK_NE(rootLegacy, rootFixed);
+    BOOST_CHECK_NE(rootLegacy, h256{});
+    BOOST_CHECK_NE(rootFixed, h256{});
 }
 
 // ---------------------------------------------------------------------------
 // FIB-99 boundary collision: (table="a", key="bc") vs (table="ab", key="c")
-// should produce different hashes under V3_17_0 but the same under V3_1.
+// collide under the legacy path, are distinct once the bugfix flag is set.
 // ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(boundaryAmbiguityFixedInV317)
+BOOST_AUTO_TEST_CASE(boundaryAmbiguityFixedByFlag)
 {
     crypto::Keccak256 hashImpl;
+    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
 
     Entry entryA;
-    entryA.importFields({"d"});  // MODIFIED with data "d"
-
+    entryA.importFields({"d"});
     Entry entryB;
-    entryB.importFields({"d"});  // MODIFIED with data "d"
+    entryB.importFields({"d"});
 
-    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
-    constexpr auto v317 = static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION);
+    ledger::Features noFix;
+    auto fix = featuresWithFix();
 
-    // Under V3_1: hash("a" || "bc" || "d") == hash("ab" || "c" || "d") => collision
-    auto hashA_v31 = entryA.hash("a", "bc", hashImpl, v31);
-    auto hashB_v31 = entryB.hash("ab", "c", hashImpl, v31);
-    BOOST_CHECK_EQUAL(hashA_v31, hashB_v31);  // Known collision in old scheme
+    // Legacy: hash("a" || "bc" || "d") == hash("ab" || "c" || "d") => collision.
+    BOOST_CHECK_EQUAL(
+        entryA.hash("a", "bc", hashImpl, v31, noFix), entryB.hash("ab", "c", hashImpl, v31, noFix));
 
-    // Under V3_17_0: length-prefixed => no collision
-    auto hashA_v317 = entryA.hash("a", "bc", hashImpl, v317);
-    auto hashB_v317 = entryB.hash("ab", "c", hashImpl, v317);
-    BOOST_CHECK_NE(hashA_v317, hashB_v317);  // Fixed!
+    // With bugfix flag: length-prefixed => no collision.
+    BOOST_CHECK_NE(
+        entryA.hash("a", "bc", hashImpl, v31, fix), entryB.hash("ab", "c", hashImpl, v31, fix));
 }
 
 // ---------------------------------------------------------------------------
-// FIB-99 status collision: DELETED entry vs MODIFIED with empty data should
-// produce different hashes under V3_17_0 but the same under V3_1.
+// FIB-99 status collision: DELETED vs MODIFIED-with-empty-data must be
+// distinguishable once the bugfix flag is set.
 // ---------------------------------------------------------------------------
-BOOST_AUTO_TEST_CASE(statusAmbiguityFixedInV317)
+BOOST_AUTO_TEST_CASE(statusAmbiguityFixedByFlag)
 {
     crypto::Keccak256 hashImpl;
+    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
 
     Entry deletedEntry;
     deletedEntry.setStatus(Entry::DELETED);
-
     Entry emptyModified;
-    emptyModified.importFields({""});  // MODIFIED with empty data
+    emptyModified.importFields({""});
 
-    constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
-    constexpr auto v317 = static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION);
+    ledger::Features noFix;
+    auto fix = featuresWithFix();
 
-    // Under V3_1: hash(table || key) vs hash(table || key || "") => same
-    auto hashDel_v31 = deletedEntry.hash("tbl", "k", hashImpl, v31);
-    auto hashMod_v31 = emptyModified.hash("tbl", "k", hashImpl, v31);
-    BOOST_CHECK_EQUAL(hashDel_v31, hashMod_v31);  // Known collision in old scheme
+    BOOST_CHECK_EQUAL(deletedEntry.hash("tbl", "k", hashImpl, v31, noFix),
+        emptyModified.hash("tbl", "k", hashImpl, v31, noFix));
 
-    // Under V3_17_0: status byte distinguishes them
-    auto hashDel_v317 = deletedEntry.hash("tbl", "k", hashImpl, v317);
-    auto hashMod_v317 = emptyModified.hash("tbl", "k", hashImpl, v317);
-    BOOST_CHECK_NE(hashDel_v317, hashMod_v317);  // Fixed!
+    BOOST_CHECK_NE(deletedEntry.hash("tbl", "k", hashImpl, v31, fix),
+        emptyModified.hash("tbl", "k", hashImpl, v31, fix));
 }
 
 // ---------------------------------------------------------------------------
-// Backward compatibility: V3_1 and V3_0 hashes remain unchanged.
+// Backward compatibility: the legacy overload (no Features) and the new
+// overload with no flag set must produce identical hashes for all versions.
+// The new V3_17 fixed format is gated only by the flag, not by blockVersion.
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(backwardCompatibilityPreserved)
 {
@@ -130,31 +133,53 @@ BOOST_AUTO_TEST_CASE(backwardCompatibilityPreserved)
 
     Entry modifiedEntry;
     modifiedEntry.importFields({"value123"});
-
     Entry deletedEntry;
     deletedEntry.setStatus(Entry::DELETED);
 
     constexpr auto v30 = static_cast<uint32_t>(protocol::BlockVersion::V3_0_VERSION);
     constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
     constexpr auto v316 = static_cast<uint32_t>(protocol::BlockVersion::V3_16_4_VERSION);
+    constexpr auto v317 = static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION);
 
-    // V3_0 hashing: MODIFIED => hash(data), DELETED => 0x1
-    auto hashMod_v30 = modifiedEntry.hash("t", "k", hashImpl, v30);
-    auto hashDel_v30 = deletedEntry.hash("t", "k", hashImpl, v30);
-    BOOST_CHECK_NE(hashMod_v30, h256{});
-    BOOST_CHECK_EQUAL(hashDel_v30, crypto::HashType(0x1));
+    ledger::Features noFix;
 
-    // V3_1 hashing: uses hasher with table+key+data, no length prefix
-    auto hashMod_v31 = modifiedEntry.hash("t", "k", hashImpl, v31);
-    auto hashDel_v31 = deletedEntry.hash("t", "k", hashImpl, v31);
-    BOOST_CHECK_NE(hashMod_v31, h256{});
-    BOOST_CHECK_NE(hashDel_v31, h256{});
+    // Legacy overload and new overload without the flag must agree.
+    BOOST_CHECK_EQUAL(modifiedEntry.hash("t", "k", hashImpl, v31),
+        modifiedEntry.hash("t", "k", hashImpl, v31, noFix));
 
-    // V3_16_4 should still use V3_1 logic (< V3_17_0)
-    auto hashMod_v316 = modifiedEntry.hash("t", "k", hashImpl, v316);
-    auto hashDel_v316 = deletedEntry.hash("t", "k", hashImpl, v316);
-    BOOST_CHECK_EQUAL(hashMod_v31, hashMod_v316);
-    BOOST_CHECK_EQUAL(hashDel_v31, hashDel_v316);
+    // V3_0 path: MODIFIED hashes raw data, DELETED returns 0x1.
+    BOOST_CHECK_NE(modifiedEntry.hash("t", "k", hashImpl, v30, noFix), h256{});
+    BOOST_CHECK_EQUAL(deletedEntry.hash("t", "k", hashImpl, v30, noFix), crypto::HashType(0x1));
+
+    // V3_1+ path is identical regardless of how high blockVersion goes when flag is off.
+    auto modOff_v31 = modifiedEntry.hash("t", "k", hashImpl, v31, noFix);
+    auto modOff_v316 = modifiedEntry.hash("t", "k", hashImpl, v316, noFix);
+    auto modOff_v317 = modifiedEntry.hash("t", "k", hashImpl, v317, noFix);
+    BOOST_CHECK_EQUAL(modOff_v31, modOff_v316);
+    BOOST_CHECK_EQUAL(modOff_v31, modOff_v317);
+
+    // Flag ON: produces a different (length-prefixed, status-aware) hash.
+    auto fix = featuresWithFix();
+    auto modOn_v31 = modifiedEntry.hash("t", "k", hashImpl, v31, fix);
+    BOOST_CHECK_NE(modOff_v31, modOn_v31);
+
+    // Flag ON: result is independent of blockVersion (only the flag matters).
+    auto modOn_v317 = modifiedEntry.hash("t", "k", hashImpl, v317, fix);
+    BOOST_CHECK_EQUAL(modOn_v31, modOn_v317);
+}
+
+// ---------------------------------------------------------------------------
+// Features integration: the bugfix flag is wired into the upgrade roadmap so
+// nodes upgrading to V3_17_0 automatically activate it.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(bugfixFlagActivatedAtV3_17_0)
+{
+    ledger::Features features;
+    BOOST_CHECK(!features.get(ledger::Features::Flag::bugfix_statestorage_hash_v3_17));
+
+    features.setUpgradeFeatures(
+        protocol::BlockVersion::V3_16_5_VERSION, protocol::BlockVersion::V3_17_0_VERSION);
+    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_statestorage_hash_v3_17));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
+++ b/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
@@ -23,6 +23,7 @@
 #include "bcos-task/Wait.h"
 #include "bcos-transaction-scheduler/BaselineScheduler.h"
 #include <boost/test/unit_test.hpp>
+#include <optional>
 
 using namespace bcos;
 using namespace bcos::storage;
@@ -33,7 +34,7 @@ BOOST_AUTO_TEST_SUITE(FIB99_FIB105_StateRootTest)
 
 namespace
 {
-ledger::Features featuresWithFix()
+std::optional<ledger::Features> featuresWithFix()
 {
     ledger::Features features;
     features.set(ledger::Features::Flag::bugfix_statestorage_hash_v3_17);
@@ -60,7 +61,8 @@ BOOST_AUTO_TEST_CASE(calculateStateRootRespectsBugfixFlag)
     constexpr auto v31 = static_cast<uint32_t>(protocol::BlockVersion::V3_1_VERSION);
 
     ledger::Features noFix;
-    auto fix = featuresWithFix();
+    ledger::Features fix;
+    fix.set(ledger::Features::Flag::bugfix_statestorage_hash_v3_17);
 
     auto rootLegacy =
         task::syncWait(scheduler_v1::calculateStateRoot(storage, v31, hashImpl, noFix));
@@ -86,8 +88,8 @@ BOOST_AUTO_TEST_CASE(boundaryAmbiguityFixedByFlag)
     Entry entryB;
     entryB.importFields({"d"});
 
-    ledger::Features noFix;
-    auto fix = featuresWithFix();
+    const std::optional<ledger::Features> noFix{ledger::Features{}};
+    const auto fix = featuresWithFix();
 
     // Legacy: hash("a" || "bc" || "d") == hash("ab" || "c" || "d") => collision.
     BOOST_CHECK_EQUAL(
@@ -112,8 +114,8 @@ BOOST_AUTO_TEST_CASE(statusAmbiguityFixedByFlag)
     Entry emptyModified;
     emptyModified.importFields({""});
 
-    ledger::Features noFix;
-    auto fix = featuresWithFix();
+    const std::optional<ledger::Features> noFix{ledger::Features{}};
+    const auto fix = featuresWithFix();
 
     BOOST_CHECK_EQUAL(deletedEntry.hash("tbl", "k", hashImpl, v31, noFix),
         emptyModified.hash("tbl", "k", hashImpl, v31, noFix));
@@ -123,9 +125,10 @@ BOOST_AUTO_TEST_CASE(statusAmbiguityFixedByFlag)
 }
 
 // ---------------------------------------------------------------------------
-// Backward compatibility: the legacy overload (no Features) and the new
-// overload with no flag set must produce identical hashes for all versions.
-// The new V3_17 fixed format is gated only by the flag, not by blockVersion.
+// Backward compatibility: the 4-arg overload (defaults to no Features) and the
+// 5-arg overload with std::nullopt or an empty-flags Features object must all
+// produce identical hashes. The new V3_17 fixed format is gated only by the
+// flag, never by blockVersion.
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(backwardCompatibilityPreserved)
 {
@@ -141,10 +144,15 @@ BOOST_AUTO_TEST_CASE(backwardCompatibilityPreserved)
     constexpr auto v316 = static_cast<uint32_t>(protocol::BlockVersion::V3_16_4_VERSION);
     constexpr auto v317 = static_cast<uint32_t>(protocol::BlockVersion::V3_17_0_VERSION);
 
-    ledger::Features noFix;
+    const std::optional<ledger::Features> nullopt;  // empty optional
+    const std::optional<ledger::Features> noFix{ledger::Features{}};
 
-    // Legacy overload and new overload without the flag must agree.
+    // 4-arg overload (defaults to nullopt) and 5-arg with nullopt agree.
     BOOST_CHECK_EQUAL(modifiedEntry.hash("t", "k", hashImpl, v31),
+        modifiedEntry.hash("t", "k", hashImpl, v31, nullopt));
+
+    // An empty Features (flag unset) is also equivalent to nullopt for hashing.
+    BOOST_CHECK_EQUAL(modifiedEntry.hash("t", "k", hashImpl, v31, nullopt),
         modifiedEntry.hash("t", "k", hashImpl, v31, noFix));
 
     // V3_0 path: MODIFIED hashes raw data, DELETED returns 0x1.
@@ -159,7 +167,7 @@ BOOST_AUTO_TEST_CASE(backwardCompatibilityPreserved)
     BOOST_CHECK_EQUAL(modOff_v31, modOff_v317);
 
     // Flag ON: produces a different (length-prefixed, status-aware) hash.
-    auto fix = featuresWithFix();
+    const auto fix = featuresWithFix();
     auto modOn_v31 = modifiedEntry.hash("t", "k", hashImpl, v31, fix);
     BOOST_CHECK_NE(modOff_v31, modOn_v31);
 


### PR DESCRIPTION
## Summary
- FIB-105: calculateStateRoot() now uses passed blockVersion instead of hardcoded V3_1_VERSION
- FIB-99: Entry::hash() for V3.17.0+ uses length-prefixed table/key and includes entry status byte
- Fixes hash collision where (table="a", key="bc", data="d") and (table="ab", key="c", data="d") produced identical hashes

## Test plan
- [x] Unit test: boundary ambiguity between different (table, key, data) triples
- [x] Unit test: DELETED vs MODIFIED-with-empty-data produce different hashes
- [x] Unit test: blockVersion is actually used (not hardcoded)
- [x] Build and run test-bcos-transaction-scheduler