### PR TITLE
fix(scheduler): clear existing receipts in finishExecute to prevent stale data (FIB-108)

### DIFF
--- a/bcos-executor/test/unittest/mock/MockBlock.h
+++ b/bcos-executor/test/unittest/mock/MockBlock.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "MockBlockHeader.h"
+#include "bcos-framework/protocol/Block.h"
 #include "bcos-framework/protocol/BlockHeader.h"
 #include "bcos-utilities/AnyHolder.h"
-#include "bcos-framework/protocol/Block.h"
 
 namespace bcos::test
 {
@@ -44,6 +44,7 @@ public:
     void appendTransaction(protocol::Transaction::Ptr _transaction) override {}
     void setReceipt(uint64_t _index, protocol::TransactionReceipt::Ptr _receipt) override {}
     void appendReceipt(protocol::TransactionReceipt::Ptr _receipt) override {}
+    void clearReceipts() override {}
     void appendTransactionMetaData(protocol::TransactionMetaData::Ptr _txMetaData) override {}
     uint64_t transactionsSize() const override { return 0; }
     uint64_t transactionsMetaDataSize() const override { return 0; }

--- a/bcos-framework/bcos-framework/protocol/Block.h
+++ b/bcos-framework/bcos-framework/protocol/Block.h
@@ -78,6 +78,7 @@ public:
     // set receipts
     virtual void setReceipt(uint64_t _index, TransactionReceipt::Ptr _receipt) = 0;
     virtual void appendReceipt(TransactionReceipt::Ptr _receipt) = 0;
+    virtual void clearReceipts() = 0;
     // set transaction metaData
     // FIXME: appendTransactionMetaData will create, parameter should be object instead of pointer
     virtual void appendTransactionMetaData(TransactionMetaData::Ptr _txMetaData) = 0;

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
@@ -86,6 +86,11 @@ void BlockImpl::appendReceipt(bcos::protocol::TransactionReceipt::Ptr _receipt)
         std::dynamic_pointer_cast<bcostars::protocol::TransactionReceiptImpl>(_receipt)->inner());
 }
 
+void BlockImpl::clearReceipts()
+{
+    m_inner.receipts.clear();
+}
+
 void BlockImpl::setNonceList(::ranges::any_view<std::string> nonces)
 {
     m_inner.nonceList = ::ranges::to<std::vector>(nonces);

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
@@ -100,6 +100,11 @@ void bcostars::protocol::BlockImpl::appendReceipt(bcos::protocol::TransactionRec
         std::dynamic_pointer_cast<bcostars::protocol::TransactionReceiptImpl>(_receipt)->inner());
 }
 
+void bcostars::protocol::BlockImpl::clearReceipts()
+{
+    m_inner.receipts.clear();
+}
+
 void bcostars::protocol::BlockImpl::setNonceList(::ranges::any_view<std::string> nonces)
 {
     m_inner.nonceList = ::ranges::to<std::vector>(nonces);

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.h
@@ -70,6 +70,7 @@ public:
 
     void setReceipt(uint64_t _index, bcos::protocol::TransactionReceipt::Ptr _receipt) override;
     void appendReceipt(bcos::protocol::TransactionReceipt::Ptr _receipt) override;
+    void clearReceipts() override;
 
     void appendTransactionMetaData(bcos::protocol::TransactionMetaData::Ptr _txMetaData) override;
 

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -170,6 +170,7 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
         [&]() { receiptRoot = calculateReceiptRoot(receipts, block, hashImpl); },
         [&]() {
             size_t logIndex = 0;
+            block.clearReceipts();
             for (auto&& [index, receipt] : ::ranges::views::enumerate(receipts))
             {
                 receipt->setTransactionIndex(index);
@@ -180,14 +181,7 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
                 totalGasUsed += receipt->gasUsed();
                 receipt->setCumulativeGasUsed(totalGasUsed.str());
 
-                if (index < block.receiptsSize())
-                {
-                    block.setReceipt(index, receipt);
-                }
-                else
-                {
-                    block.appendReceipt(receipt);
-                }
+                block.appendReceipt(receipt);
             }
         },
         [&]() {

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -175,6 +175,7 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
         [&]() { receiptRoot = calculateReceiptRoot(receipts, block, hashImpl); },
         [&]() {
             size_t logIndex = 0;
+            block.clearReceipts();
             for (auto&& [index, receipt] : ::ranges::views::enumerate(receipts))
             {
                 receipt->setTransactionIndex(index);
@@ -185,14 +186,7 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
                 totalGasUsed += receipt->gasUsed();
                 receipt->setCumulativeGasUsed(totalGasUsed.str());
 
-                if (index < block.receiptsSize())
-                {
-                    block.setReceipt(index, receipt);
-                }
-                else
-                {
-                    block.appendReceipt(receipt);
-                }
+                block.appendReceipt(receipt);
             }
         },
         [&]() {

--- a/transaction-scheduler/tests/FIB108_ReceiptCountTest.cpp
+++ b/transaction-scheduler/tests/FIB108_ReceiptCountTest.cpp
@@ -1,0 +1,90 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-108: verify clearReceipts prevents stale data
+ * @file FIB108_ReceiptCountTest.cpp
+ */
+
+#include "bcos-tars-protocol/protocol/BlockImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(FIB108_ReceiptCountTest)
+
+/// Helper: create a receipt with a given gasUsed value for identification.
+static bcos::protocol::TransactionReceipt::Ptr makeReceipt(int64_t gasUsed)
+{
+    auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+    auto& inner = receipt->inner();
+    inner.data.gasUsed = std::to_string(gasUsed);
+    return receipt;
+}
+
+/**
+ * Scenario: a block has 5 stale receipts from a prior partial execution.
+ * A re-execution produces only 3 new receipts.
+ * Without clearReceipts(), the 2 extra stale receipts would remain, leading
+ * to receiptsSize() == 5 instead of 3.
+ * With clearReceipts() before appending, only the 3 new receipts survive.
+ */
+BOOST_AUTO_TEST_CASE(ClearReceiptsRemovesStaleEntries)
+{
+    auto block = std::make_shared<bcostars::protocol::BlockImpl>();
+
+    // Simulate prior execution that left 5 receipts
+    for (int i = 0; i < 5; ++i)
+    {
+        block->appendReceipt(makeReceipt(100 + i));
+    }
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 5u);
+
+    // Now simulate re-execution: clear then append 3 new receipts
+    block->clearReceipts();
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 0u);
+
+    for (int i = 0; i < 3; ++i)
+    {
+        block->appendReceipt(makeReceipt(200 + i));
+    }
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 3u);
+
+    // Verify the receipts are the new ones (gasUsed 200, 201, 202)
+    size_t idx = 0;
+    for (auto receipt : block->receipts())
+    {
+        auto expectedGas = std::to_string(200 + static_cast<int>(idx));
+        BOOST_CHECK_EQUAL(receipt->gasUsed().str(), expectedGas);
+        ++idx;
+    }
+    BOOST_CHECK_EQUAL(idx, 3u);
+}
+
+/**
+ * Edge case: clearReceipts on an already-empty block is a no-op.
+ */
+BOOST_AUTO_TEST_CASE(ClearReceiptsOnEmptyBlock)
+{
+    auto block = std::make_shared<bcostars::protocol::BlockImpl>();
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 0u);
+
+    block->clearReceipts();
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 0u);
+
+    // Can still append after clearing empty
+    block->appendReceipt(makeReceipt(42));
+    BOOST_CHECK_EQUAL(block->receiptsSize(), 1u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Call block.clearReceipts() before receipt loop in finishExecute()
- Added virtual clearReceipts() to Block interface
- Prevents stale receipts from previous executions persisting

## Test plan
- [x] Unit test: re-execution with fewer receipts doesn't leave stale data
- [x] Unit test: normal execution with matching counts works correctly
- [x] Build and run test-bcos-transaction-scheduler