### PR TITLE
fix(scheduler): add backpressure to GC::collect to prevent unbounded memory growth (FIB-110)

### DIFF
--- a/transaction-scheduler/bcos-transaction-scheduler/GC.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/GC.h
@@ -1,16 +1,33 @@
 #pragma once
 #include <oneapi/tbb/task_arena.h>
+#include <atomic>
 
 namespace bcos::scheduler_v1
 {
 class GC
 {
+    inline static std::atomic<size_t> s_pendingCount{0};
+
 public:
+    static constexpr size_t MAX_PENDING_GC = 64;
+
     static void collect(auto&&... resources)
     {
         static tbb::task_arena arena(1, 1, tbb::task_arena::priority::low);
+
+        if (s_pendingCount.load(std::memory_order_relaxed) >= MAX_PENDING_GC)
+        {
+            // Synchronous destruction as backpressure
+            [[maybe_unused]] auto tuple =
+                std::make_tuple(std::forward<decltype(resources)>(resources)...);
+            return;
+        }
+        s_pendingCount.fetch_add(1, std::memory_order_relaxed);
         arena.enqueue([resources = std::make_tuple(
-                           std::forward<decltype(resources)>(resources)...)]() noexcept {});
+                           std::forward<decltype(resources)>(resources)...)]() noexcept {
+            (void)resources;
+            s_pendingCount.fetch_sub(1, std::memory_order_relaxed);
+        });
     }
 };
 }  // namespace bcos::scheduler_v1

--- a/transaction-scheduler/bcos-transaction-scheduler/GC.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/GC.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <oneapi/tbb/task_arena.h>
 #include <atomic>
+#include <tuple>
 
 namespace bcos::scheduler_v1
 {
@@ -9,20 +10,35 @@ class GC
     inline static std::atomic<size_t> s_pendingCount{0};
 
 public:
+    // Cap on in-flight deferred-destruction tasks. Above this we destroy
+    // synchronously to bound the backlog when the low-priority GC arena is
+    // starved by high-priority work. Sized for "a few blocks worth" of
+    // contexts; tune if per-call payload is unusually large or small.
     static constexpr size_t MAX_PENDING_GC = 64;
 
     static void collect(auto&&... resources)
     {
         static tbb::task_arena arena(1, 1, tbb::task_arena::priority::low);
 
-        if (s_pendingCount.load(std::memory_order_relaxed) >= MAX_PENDING_GC)
+        // Atomically reserve a slot iff we are strictly under the cap. Using
+        // compare_exchange_weak as the loop condition avoids the TOCTOU window
+        // of a separate load+fetch_add; on CAS failure cur is updated with the
+        // observed value, so a concurrent fill correctly drops us into the
+        // synchronous-destruction fallback below.
+        size_t cur = s_pendingCount.load(std::memory_order_relaxed);
+        while (cur < MAX_PENDING_GC && !s_pendingCount.compare_exchange_weak(cur, cur + 1,
+                                           std::memory_order_relaxed, std::memory_order_relaxed))
         {
-            // Synchronous destruction as backpressure
+        }
+
+        if (cur >= MAX_PENDING_GC)
+        {
+            // Backpressure: destroy synchronously in the caller's scope.
             [[maybe_unused]] auto tuple =
                 std::make_tuple(std::forward<decltype(resources)>(resources)...);
             return;
         }
-        s_pendingCount.fetch_add(1, std::memory_order_relaxed);
+
         arena.enqueue([resources = std::make_tuple(
                            std::forward<decltype(resources)>(resources)...)]() noexcept {
             (void)resources;

--- a/transaction-scheduler/bcos-transaction-scheduler/GC.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/GC.h
@@ -20,19 +20,15 @@ public:
     {
         static tbb::task_arena arena(1, 1, tbb::task_arena::priority::low);
 
-        // Atomically reserve a slot iff we are strictly under the cap. Using
-        // compare_exchange_weak as the loop condition avoids the TOCTOU window
-        // of a separate load+fetch_add; on CAS failure cur is updated with the
-        // observed value, so a concurrent fill correctly drops us into the
-        // synchronous-destruction fallback below.
-        size_t cur = s_pendingCount.load(std::memory_order_relaxed);
-        while (cur < MAX_PENDING_GC && !s_pendingCount.compare_exchange_weak(cur, cur + 1,
-                                           std::memory_order_relaxed, std::memory_order_relaxed))
+        // Optimistically reserve a slot. fetch_add is a single RMW that never
+        // retries; if we observe the pre-increment value already at or above
+        // the cap, roll back and fall through to synchronous destruction. The
+        // queue itself never exceeds the cap because over-reservers never
+        // enqueue; only the counter can briefly overshoot before the matching
+        // fetch_sub, and that transient is not observable outside this class.
+        if (s_pendingCount.fetch_add(1, std::memory_order_relaxed) >= MAX_PENDING_GC)
         {
-        }
-
-        if (cur >= MAX_PENDING_GC)
-        {
+            s_pendingCount.fetch_sub(1, std::memory_order_relaxed);
             // Backpressure: destroy synchronously in the caller's scope.
             [[maybe_unused]] auto tuple =
                 std::make_tuple(std::forward<decltype(resources)>(resources)...);

--- a/transaction-scheduler/tests/FIB110_GCBackpressureTest.cpp
+++ b/transaction-scheduler/tests/FIB110_GCBackpressureTest.cpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-110: GC backpressure
+ * @file FIB110_GCBackpressureTest.cpp
+ * @date 2026-04-07
+ */
+
+#include "bcos-transaction-scheduler/GC.h"
+#include <boost/test/unit_test.hpp>
+#include <memory>
+
+using namespace bcos::scheduler_v1;
+
+BOOST_AUTO_TEST_SUITE(FIB110_GCBackpressureTest)
+
+BOOST_AUTO_TEST_CASE(MaxPendingGCConstant)
+{
+    BOOST_CHECK_EQUAL(GC::MAX_PENDING_GC, 64u);
+}
+
+BOOST_AUTO_TEST_CASE(NormalCollectWorks)
+{
+    // Create a shared_ptr, collect it via GC - should not crash
+    auto ptr = std::make_shared<int>(42);
+    BOOST_CHECK_EQUAL(ptr.use_count(), 1);
+    GC::collect(std::move(ptr));
+    // ptr is moved, should be null now
+    BOOST_CHECK(!ptr);
+}
+
+BOOST_AUTO_TEST_CASE(CollectMultipleResources)
+{
+    auto ptr1 = std::make_shared<int>(1);
+    auto ptr2 = std::make_shared<std::string>("hello");
+    GC::collect(std::move(ptr1), std::move(ptr2));
+    BOOST_CHECK(!ptr1);
+    BOOST_CHECK(!ptr2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/FIB110_GCBackpressureTest.cpp
+++ b/transaction-scheduler/tests/FIB110_GCBackpressureTest.cpp
@@ -20,9 +20,62 @@
 
 #include "bcos-transaction-scheduler/GC.h"
 #include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
+#include <future>
 #include <memory>
+#include <thread>
 
 using namespace bcos::scheduler_v1;
+
+namespace
+{
+// Resource with an observable destructor used to verify GC paths.
+// Optionally blocks on a shared gate so a single instance can pin the
+// single-threaded GC arena thread, forcing the queue to fill up.
+struct Resource
+{
+    static inline std::atomic<int> destroyed{0};
+    static inline std::atomic<bool> blockerStarted{false};
+    static inline std::shared_future<void> gate;
+
+    bool live = true;
+    bool blocker = false;
+
+    Resource() = default;
+    explicit Resource(bool isBlocker) : blocker(isBlocker) {}
+    Resource(Resource&& other) noexcept : live(other.live), blocker(other.blocker)
+    {
+        other.live = false;
+    }
+    Resource& operator=(Resource&& other) noexcept
+    {
+        live = other.live;
+        blocker = other.blocker;
+        other.live = false;
+        return *this;
+    }
+    Resource(Resource const&) = delete;
+    Resource& operator=(Resource const&) = delete;
+
+    ~Resource()
+    {
+        if (!live)
+        {
+            return;  // moved-from
+        }
+        if (blocker)
+        {
+            blockerStarted.store(true, std::memory_order_release);
+            if (gate.valid())
+            {
+                gate.wait();
+            }
+        }
+        destroyed.fetch_add(1, std::memory_order_relaxed);
+    }
+};
+}  // namespace
 
 BOOST_AUTO_TEST_SUITE(FIB110_GCBackpressureTest)
 
@@ -33,11 +86,9 @@ BOOST_AUTO_TEST_CASE(MaxPendingGCConstant)
 
 BOOST_AUTO_TEST_CASE(NormalCollectWorks)
 {
-    // Create a shared_ptr, collect it via GC - should not crash
     auto ptr = std::make_shared<int>(42);
     BOOST_CHECK_EQUAL(ptr.use_count(), 1);
     GC::collect(std::move(ptr));
-    // ptr is moved, should be null now
     BOOST_CHECK(!ptr);
 }
 
@@ -48,6 +99,66 @@ BOOST_AUTO_TEST_CASE(CollectMultipleResources)
     GC::collect(std::move(ptr1), std::move(ptr2));
     BOOST_CHECK(!ptr1);
     BOOST_CHECK(!ptr2);
+}
+
+// Core regression: when the deferred-destruction queue is at capacity,
+// the next collect() MUST destroy synchronously instead of growing the
+// backlog. We pin the GC arena's single thread with a Blocker resource
+// whose destructor waits on a gate, then prove:
+//   1. While the arena is blocked, pending climbs to MAX_PENDING_GC.
+//   2. The (MAX_PENDING_GC + 1)-th call destructs in the caller's thread
+//      (observable: destroyed counter ticks before we open the gate).
+BOOST_AUTO_TEST_CASE(BackpressureForcesSynchronousDestruction)
+{
+    Resource::destroyed.store(0, std::memory_order_relaxed);
+    Resource::blockerStarted.store(false, std::memory_order_relaxed);
+    std::promise<void> gatePromise;
+    Resource::gate = gatePromise.get_future().share();
+
+    // 1. Pin the GC arena with a blocker. Its lambda body runs (decrementing
+    //    pending), then its capture is destroyed, parking the arena thread
+    //    inside gate.wait().
+    GC::collect(Resource{true});
+
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!Resource::blockerStarted.load(std::memory_order_acquire))
+    {
+        if (std::chrono::steady_clock::now() > deadline)
+        {
+            gatePromise.set_value();  // unblock so process can exit
+            BOOST_FAIL("GC arena did not start running blocker within 5s");
+        }
+        std::this_thread::yield();
+    }
+    // Arena is now stuck in the blocker's destructor. pending==0.
+
+    // 2. Saturate the queue exactly to capacity. Nothing runs because the
+    //    arena thread is parked.
+    for (size_t i = 0; i < GC::MAX_PENDING_GC; ++i)
+    {
+        GC::collect(Resource{false});
+    }
+    BOOST_CHECK_EQUAL(Resource::destroyed.load(std::memory_order_relaxed), 0);
+
+    // 3. The next call must hit the synchronous fallback in this thread,
+    //    so destroyed ticks immediately (still no async work has run).
+    GC::collect(Resource{false});
+    BOOST_CHECK_EQUAL(Resource::destroyed.load(std::memory_order_relaxed), 1);
+
+    // 4. Release the arena and wait for it to drain so we don't leave a
+    //    blocked thread for the rest of the test binary to deal with.
+    gatePromise.set_value();
+    auto const expected = static_cast<int>(GC::MAX_PENDING_GC) + 2;
+    deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (Resource::destroyed.load(std::memory_order_relaxed) < expected)
+    {
+        if (std::chrono::steady_clock::now() > deadline)
+        {
+            BOOST_FAIL("GC arena did not drain after gate opened within 5s");
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    BOOST_CHECK_EQUAL(Resource::destroyed.load(std::memory_order_relaxed), expected);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
+++ b/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
@@ -21,6 +21,7 @@
 #include "bcos-framework/storage2/MemoryStorage.h"
 #include "bcos-framework/storage2/MultiLayerStorage.h"
 #include "bcos-framework/storage2/Storage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
 #include <bcos-crypto/hash/Keccak256.h>

--- a/transaction-scheduler/tests/testBaselineScheduler.cpp
+++ b/transaction-scheduler/tests/testBaselineScheduler.cpp
@@ -6,6 +6,7 @@
 #include "bcos-framework/storage/Entry.h"
 #include "bcos-framework/storage2/MemoryStorage.h"
 #include "bcos-framework/storage2/MultiLayerStorage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-framework/txpool/TxPoolInterface.h"
 #include "bcos-ledger/LedgerMethods.h"
 #include "bcos-protocol/TransactionSubmitResultFactoryImpl.h"

--- a/transaction-scheduler/tests/testSchedulerParallel.cpp
+++ b/transaction-scheduler/tests/testSchedulerParallel.cpp
@@ -1,9 +1,10 @@
 #include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
 #include "bcos-framework/storage2/Storage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
-#include "bcos-framework/storage2/MultiLayerStorage.h"
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-task/Wait.h>

--- a/transaction-scheduler/tests/testSchedulerSerial.cpp
+++ b/transaction-scheduler/tests/testSchedulerSerial.cpp
@@ -1,10 +1,11 @@
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
-#include "bcos-framework/storage2/MultiLayerStorage.h"
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-task/Wait.h>
 #include <bcos-transaction-scheduler/SchedulerSerialImpl.h>


### PR DESCRIPTION
## Summary
- Added MAX_PENDING_GC=64 bound and pendingCount atomic counter
- When queue is full, GC falls back to synchronous destruction (backpressure)
- Prevents memory growth unbounded under sustained high-priority load

## Test plan
- [x] Unit test: GC falls back to synchronous destruction when queue is full
- [x] Unit test: normal deferred destruction works (regression)
- [x] Build and run test-bcos-transaction-scheduler