### PR TITLE
fix(FIB-111): use ref->gas instead of evmResult->gas_left in OutOfGas catch

### DIFF
--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -161,7 +161,8 @@ private:
             HOST_CONTEXT_LOG(DEBUG) << m_blockHeader.get().number() << " "
                                     << LOG_BADGE("AccountPrecompiled, subAccountBalance")
                                     << LOG_DESC("account balance not enough");
-            BOOST_THROW_EXCEPTION(protocol::NotEnoughCashError{} << errinfo_comment("Account balance is not enough!"));
+            BOOST_THROW_EXCEPTION(protocol::NotEnoughCashError{}
+                                  << errinfo_comment("Account balance is not enough!"));
         }
 
         if (!co_await m_recipientAccount.exists())
@@ -447,9 +448,9 @@ public:
             {
                 HOST_CONTEXT_LOG(DEBUG)
                     << "OutOfGas exception: " << boost::diagnostic_information(e);
-                evmResult.emplace(
-                    makeErrorEVMCResult(m_hashImpl, protocol::TransactionStatus::OutOfGas,
-                        EVMC_OUT_OF_GAS, evmResult->gas_left, e.what()));
+                // Use ref->gas since evmResult may be empty if auth check was skipped (FIB-111)
+                evmResult.emplace(makeErrorEVMCResult(m_hashImpl,
+                    protocol::TransactionStatus::OutOfGas, EVMC_OUT_OF_GAS, ref->gas, e.what()));
             }
             catch (protocol::NotEnoughCashError& e)
 


### PR DESCRIPTION
## Summary
- FIB-111: Use-of-Uninitialized-Memory in HostContext::execute()
- When authCheckStatus() returns 0 (auth check disabled), the auth check block is skipped. If transferBalance then throws an OutOfGas exception, the catch block tried to access evmResult->gas_left, but evmResult was never set in this code path
- This fix uses ref->gas instead, which is the original gas from the message and is always valid

## Test plan
- [x] Build passes
- [x] precompiledFileSystem tests pass