### PR TITLE
Fix type casting and remove warnings

### DIFF
--- a/bcos-boostssl/bcos-boostssl/context/ContextBuilder.cpp
+++ b/bcos-boostssl/bcos-boostssl/context/ContextBuilder.cpp
@@ -55,7 +55,7 @@ std::string ContextBuilder::readFileContent(boost::filesystem::path const& _file
     }
     fileStream.seekg(0, boost::filesystem::ifstream::beg);
     content.resize(length);
-    fileStream.read((char*)content.data(), length);
+    fileStream.read(content.data(), length);
     return content;
 }
 

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
@@ -1,4 +1,5 @@
 #include "HttpSession.h"
+#include <bit>
 #include <boost/system/error_code.hpp>
 
 bcos::boostssl::http::HttpSession::HttpSession(uint32_t _httpBodySizeLimit, CorsConfig _corsConfig)
@@ -139,7 +140,7 @@ void bcos::boostssl::http::HttpSession::handleRequest(const HttpRequest& _httpRe
             version, {}, m_corsConfig);
 
         BCOS_LOG(TRACE) << LOG_BADGE("handleRequest") << LOG_DESC("options response")
-                        << LOG_KV("body", std::string_view((const char*)resp->body().data(),
+                        << LOG_KV("body", std::string_view(std::bit_cast<const char*>(resp->body().data()),
                                               resp->body().size()))
                         << LOG_KV("keep_alive", resp->keep_alive())
                         << LOG_KV("need_eof", resp->need_eof())
@@ -159,7 +160,7 @@ void bcos::boostssl::http::HttpSession::handleRequest(const HttpRequest& _httpRe
                 std::move(_content), session->corsConfig());
             // put the response into the queue and waiting to be send
             BCOS_LOG(TRACE) << LOG_BADGE("handleRequest") << LOG_DESC("response")
-                            << LOG_KV("body", std::string_view((const char*)resp->body().data(),
+                            << LOG_KV("body", std::string_view(std::bit_cast<const char*>(resp->body().data()),
                                                   resp->body().size()))
                             << LOG_KV("keep_alive", resp->keep_alive())
                             << LOG_KV("need_eof", resp->need_eof())
@@ -174,7 +175,7 @@ void bcos::boostssl::http::HttpSession::handleRequest(const HttpRequest& _httpRe
             _httpRequest.keep_alive(), version, {}, m_corsConfig);
         // put the response into the queue and waiting to be send
         HTTP_SESSION(WARNING) << LOG_BADGE("handleRequest") << LOG_DESC("unsupported http service")
-                              << LOG_KV("body", std::string_view((const char*)resp->body().data(),
+                              << LOG_KV("body", std::string_view(std::bit_cast<const char*>(resp->body().data()),
                                                     resp->body().size()));
         queue().enqueue(std::move(resp));
     }

--- a/bcos-codec/bcos-codec/abi/ContractABICodec.cpp
+++ b/bcos-codec/bcos-codec/abi/ContractABICodec.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ContractABICodec.h"
+#include <bit>
 
 using namespace std;
 using namespace bcos;
@@ -103,7 +104,7 @@ bytes ContractABICodec::serialise(const Address& _in)
 bytes ContractABICodec::serialise(const string32& _in)
 {
     bytes ret(32, 0);
-    bytesConstRef((byte const*)_in.data(), 32).populate(bytesRef(&ret));
+    bytesConstRef(std::bit_cast<byte const*>(_in.data()), 32).populate(bytesRef(&ret));
     return ret;
 }
 
@@ -185,7 +186,7 @@ void ContractABICodec::deserialize(string32& _out, std::size_t _offset)
     validOffset(_offset + MAX_BYTE_LENGTH - 1);
 
     data.getCroppedData(_offset, MAX_BYTE_LENGTH)
-        .populate(bytesRef((byte*)_out.data(), MAX_BYTE_LENGTH));
+        .populate(bytesRef(std::bit_cast<byte*>(_out.data()), MAX_BYTE_LENGTH));
 }
 
 void ContractABICodec::deserialize(std::string& _out, std::size_t _offset)
@@ -195,7 +196,7 @@ void ContractABICodec::deserialize(std::string& _out, std::size_t _offset)
     u256 len = fromBigEndian<u256>(data.getCroppedData(_offset, MAX_BYTE_LENGTH));
     validOffset(_offset + MAX_BYTE_LENGTH + (std::size_t)len - 1);
     auto result = data.getCroppedData(_offset + MAX_BYTE_LENGTH, static_cast<size_t>(len));
-    _out.assign((const char*)result.data(), result.size());
+    _out.assign(std::bit_cast<const char*>(result.data()), result.size());
 }
 
 void ContractABICodec::deserialize(bytes& _out, std::size_t _offset)

--- a/bcos-crypto/bcos-crypto/encrypt/AESCrypto.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/AESCrypto.cpp
@@ -22,6 +22,7 @@
 #include <bcos-crypto/encrypt/Exceptions.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <wedpr-crypto/WedprCrypto.h>
+#include <bit>
 
 using namespace bcos;
 using namespace bcos::crypto;
@@ -29,18 +30,18 @@ using namespace bcos::crypto;
 bytesPointer bcos::crypto::AESEncrypt(const unsigned char* _plainData, size_t _plainDataSize,
     const unsigned char* _key, size_t _keySize, const unsigned char* _ivData, size_t _ivDataSize)
 {
-    CInputBuffer plainText{(const char*)_plainData, _plainDataSize};
+    CInputBuffer plainText{std::bit_cast<const char*>(_plainData), _plainDataSize};
 
     FixedBytes<AES_KEY_SIZE> fixedKeyData(_key, _keySize);
-    CInputBuffer key{(const char*)fixedKeyData.data(), AES_KEY_SIZE};
+    CInputBuffer key{std::bit_cast<const char*>(fixedKeyData.data()), AES_KEY_SIZE};
 
     FixedBytes<AES_IV_DATA_SIZE> FixedIVData(_ivData, _ivDataSize);
-    CInputBuffer ivData{(const char*)FixedIVData.data(), AES_IV_DATA_SIZE};
+    CInputBuffer ivData{std::bit_cast<const char*>(FixedIVData.data()), AES_IV_DATA_SIZE};
 
     auto encryptedData = std::make_shared<bytes>();
     size_t ciperDataSize = _plainDataSize + AES_MAX_PADDING_SIZE;
     encryptedData->resize(ciperDataSize);
-    COutputBuffer encryptResult{(char*)(encryptedData->data()), ciperDataSize};
+    COutputBuffer encryptResult{std::bit_cast<char*>(encryptedData->data()), ciperDataSize};
 
     if (wedpr_aes256_encrypt(&plainText, &key, &ivData, &encryptResult) == WEDPR_ERROR)
     {
@@ -54,18 +55,18 @@ bytesPointer bcos::crypto::AESEncrypt(const unsigned char* _plainData, size_t _p
 bytesPointer bcos::crypto::AESDecrypt(const unsigned char* _cipherData, size_t _cipherDataSize,
     const unsigned char* _key, size_t _keySize, const unsigned char* _ivData, size_t _ivDataSize)
 {
-    CInputBuffer ciper{(const char*)_cipherData, _cipherDataSize};
+    CInputBuffer ciper{std::bit_cast<const char*>(_cipherData), _cipherDataSize};
 
     FixedBytes<AES_KEY_SIZE> fixedKeyData(_key, _keySize);
-    CInputBuffer key{(const char*)fixedKeyData.data(), AES_KEY_SIZE};
+    CInputBuffer key{std::bit_cast<const char*>(fixedKeyData.data()), AES_KEY_SIZE};
 
     FixedBytes<AES_IV_DATA_SIZE> fixedIVData(_ivData, _ivDataSize);
-    CInputBuffer iv{(const char*)fixedIVData.data(), AES_IV_DATA_SIZE};
+    CInputBuffer iv{std::bit_cast<const char*>(fixedIVData.data()), AES_IV_DATA_SIZE};
 
     auto decodedData = std::make_shared<bytes>();
     auto plainDataSize = _cipherDataSize;
     decodedData->resize(plainDataSize);
-    COutputBuffer decodedResult{(char*)decodedData->data(), plainDataSize};
+    COutputBuffer decodedResult{std::bit_cast<char*>(decodedData->data()), plainDataSize};
 
     if (wedpr_aes256_decrypt(&ciper, &key, &iv, &decodedResult) == WEDPR_ERROR)
     {

--- a/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.cpp
@@ -24,6 +24,7 @@
 
 #include "hsm-crypto/hsm/CryptoProvider.h"
 #include "hsm-crypto/hsm/SDFCryptoProvider.h"
+#include <bit>
 
 using namespace hsm;
 using namespace bcos;
@@ -62,8 +63,9 @@ bcos::bytesPointer HsmSM4Crypto::HsmSM4Encrypt(const unsigned char* _plainData,
     unsigned int size;
     auto encryptedData = std::make_shared<bytes>();
     encryptedData->resize(inDataVLen);
-    provider.Encrypt(key, SM4_CBC, (unsigned char*)_ivData, (unsigned char*)inDataV.data(),
-        inDataVLen, (unsigned char*)encryptedData->data(), &size);
+    provider.Encrypt(key, SM4_CBC, std::bit_cast<unsigned char*>(_ivData),
+        std::bit_cast<unsigned char*>(inDataV.data()), inDataVLen,
+        std::bit_cast<unsigned char*>(encryptedData->data()), &size);
     CRYPTO_LOG(DEBUG) << "[HsmSM4Crypto::Encrypt] Encrypt Success";
     return encryptedData;
 }
@@ -91,8 +93,8 @@ bcos::bytesPointer HsmSM4Crypto::HsmSM4Decrypt(const unsigned char* _cipherData,
     CryptoProvider& provider = SDFCryptoProvider::GetInstance(m_hsmLibPath);
 
     unsigned int size;
-    provider.Decrypt(key, SM4_CBC, (unsigned char*)_ivData, _cipherData, _cipherDataSize,
-        (unsigned char*)decryptedData->data(), &size);
+    provider.Decrypt(key, SM4_CBC, std::bit_cast<unsigned char*>(_ivData), _cipherData,
+        _cipherDataSize, std::bit_cast<unsigned char*>(decryptedData->data()), &size);
     CRYPTO_LOG(DEBUG) << "[HsmSM4Crypto::Decrypt] Decrypt Success";
     return decryptedData;
 }
@@ -125,8 +127,8 @@ bcos::bytesPointer HsmSM4Crypto::symmetricEncryptWithInternalKey(const unsigned 
     encryptedData->resize(inDataVLen);
     SDFCryptoProvider& provider = SDFCryptoProvider::GetInstance(m_hsmLibPath);
     auto encryptCode = provider.EncryptWithInternalKey((unsigned int)_keyIndex, SM4_CBC,
-        (unsigned char*)_ivData, (unsigned char*)inDataV.data(), inDataVLen,
-        (unsigned char*)(encryptedData->data()), &size);
+        std::bit_cast<unsigned char*>(_ivData), std::bit_cast<unsigned char*>(inDataV.data()),
+        inDataVLen, std::bit_cast<unsigned char*>(encryptedData->data()), &size);
     if (encryptCode != SDR_OK)
     {
         CRYPTO_LOG(WARNING) << "[HsmSM4Crypto::symmetricEncryptWithInternalKey] encrypt ERROR "
@@ -156,8 +158,9 @@ bcos::bytesPointer HsmSM4Crypto::symmetricDecryptWithInternalKey(const unsigned 
     SDFCryptoProvider& provider = SDFCryptoProvider::GetInstance(m_hsmLibPath);
     unsigned int size;
     auto decryptCode =
-        provider.DecryptWithInternalKey((unsigned int)_keyIndex, SM4_CBC, (unsigned char*)_ivData,
-            _cipherData, _cipherDataSize, (unsigned char*)decryptedData->data(), &size);
+        provider.DecryptWithInternalKey((unsigned int)_keyIndex, SM4_CBC,
+            std::bit_cast<unsigned char*>(_ivData), _cipherData, _cipherDataSize,
+            std::bit_cast<unsigned char*>(decryptedData->data()), &size);
     if (decryptCode != SDR_OK)
     {
         CRYPTO_LOG(WARNING) << "[HsmSM4Crypto::symmetricDecryptWithInternalKey] decrypt ERROR "

--- a/bcos-crypto/bcos-crypto/encrypt/SM4Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/SM4Crypto.cpp
@@ -22,23 +22,24 @@
 #include <bcos-crypto/encrypt/SM4Crypto.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <wedpr-crypto/WedprCrypto.h>
+#include <bit>
 using namespace bcos;
 using namespace bcos::crypto;
 
 bytesPointer bcos::crypto::SM4Encrypt(const unsigned char* _plainData, size_t _plainDataSize,
     const unsigned char* _key, size_t _keySize, const unsigned char* _ivData, size_t _ivDataSize)
 {
-    CInputBuffer plain{(const char*)_plainData, _plainDataSize};
+    CInputBuffer plain{std::bit_cast<const char*>(_plainData), _plainDataSize};
 
     FixedBytes<SM4_KEY_SIZE> fixedKeyData(_key, _keySize);
-    CInputBuffer key{(const char*)fixedKeyData.data(), SM4_KEY_SIZE};
+    CInputBuffer key{std::bit_cast<const char*>(fixedKeyData.data()), SM4_KEY_SIZE};
 
     FixedBytes<SM4_IV_SIZE> fixedIVData(_ivData, _ivDataSize);
-    CInputBuffer iv{(const char*)fixedIVData.data(), SM4_IV_SIZE};
+    CInputBuffer iv{std::bit_cast<const char*>(fixedIVData.data()), SM4_IV_SIZE};
 
     auto encryptedData = std::make_shared<bytes>();
     encryptedData->resize(_plainDataSize + SM4_MAX_PADDING_LEN);
-    COutputBuffer ciper{(char*)(encryptedData->data()), encryptedData->size()};
+    COutputBuffer ciper{std::bit_cast<char*>(encryptedData->data()), encryptedData->size()};
 
     if (wedpr_sm4_encrypt(&plain, &key, &iv, &ciper) == WEDPR_ERROR)
     {
@@ -52,17 +53,17 @@ bytesPointer bcos::crypto::SM4Encrypt(const unsigned char* _plainData, size_t _p
 bytesPointer bcos::crypto::SM4Decrypt(const unsigned char* _cipherData, size_t _cipherDataSize,
     const unsigned char* _key, size_t _keySize, const unsigned char* _ivData, size_t _ivDataSize)
 {
-    CInputBuffer cipher{(const char*)_cipherData, _cipherDataSize};
+    CInputBuffer cipher{std::bit_cast<const char*>(_cipherData), _cipherDataSize};
 
     FixedBytes<SM4_KEY_SIZE> fixedKeyData(_key, _keySize);
-    CInputBuffer key{(const char*)fixedKeyData.data(), SM4_KEY_SIZE};
+    CInputBuffer key{std::bit_cast<const char*>(fixedKeyData.data()), SM4_KEY_SIZE};
 
     FixedBytes<SM4_IV_SIZE> fixedIVData(_ivData, _ivDataSize);
-    CInputBuffer iv{(const char*)fixedIVData.data(), SM4_IV_SIZE};
+    CInputBuffer iv{std::bit_cast<const char*>(fixedIVData.data()), SM4_IV_SIZE};
 
     auto decryptedData = std::make_shared<bytes>();
     decryptedData->resize(_cipherDataSize);
-    COutputBuffer plain{(char*)decryptedData->data(), decryptedData->size()};
+    COutputBuffer plain{std::bit_cast<char*>(decryptedData->data()), decryptedData->size()};
 
     if (wedpr_sm4_decrypt(&cipher, &key, &iv, &plain) == WEDPR_ERROR)
     {

--- a/bcos-crypto/bcos-crypto/hasher/OpenSSLHasher.h
+++ b/bcos-crypto/bcos-crypto/hasher/OpenSSLHasher.h
@@ -4,6 +4,7 @@
 #include "Hasher.h"
 #include <openssl/crypto.h>
 #include <openssl/evp.h>
+#include <bit>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/throw_exception.hpp>
 #include <span>
@@ -104,7 +105,7 @@ public:
             m_init = true;
         }
 
-        if (!EVP_DigestUpdate(m_mdCtx.get(), reinterpret_cast<unsigned char const*>(in.data()),
+        if (!EVP_DigestUpdate(m_mdCtx.get(), std::bit_cast<unsigned char const*>(in.data()),
                 in.size())) [[unlikely]]
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"EVP_DigestUpdate error!"});
@@ -117,7 +118,7 @@ public:
         bcos::crypto::trivial::resizeTo(out, HASH_SIZE);
         auto view = bcos::crypto::trivial::toView(std::forward<decltype(out)>(out));
 
-        if (!EVP_DigestFinal(m_mdCtx.get(), reinterpret_cast<unsigned char*>(view.data()), nullptr))
+            if (!EVP_DigestFinal(m_mdCtx.get(), std::bit_cast<unsigned char*>(view.data()), nullptr))
             [[unlikely]]
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"EVP_DigestFinal error!"});
@@ -128,7 +129,7 @@ public:
     {
         m_init = false;
 
-        if (!EVP_DigestFinal(m_mdCtx.get(), reinterpret_cast<unsigned char*>(out.data()), nullptr))
+            if (!EVP_DigestFinal(m_mdCtx.get(), std::bit_cast<unsigned char*>(out.data()), nullptr))
             [[unlikely]]
         {
             BOOST_THROW_EXCEPTION(std::runtime_error{"EVP_DigestFinal error!"});

--- a/bcos-crypto/bcos-crypto/interfaces/crypto/Hash.h
+++ b/bcos-crypto/bcos-crypto/interfaces/crypto/Hash.h
@@ -23,6 +23,7 @@
 #include <bcos-crypto/interfaces/crypto/CommonType.h>
 #include <bcos-crypto/interfaces/crypto/KeyInterface.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <bit>
 #include <memory>
 namespace bcos::crypto
 {
@@ -42,7 +43,7 @@ public:
     virtual HashType hash(bytesConstRef _data) const = 0;
     HashType hash(std::string_view view) const
     {
-        return hash(bytesConstRef((const unsigned char*)view.data(), view.size()));
+        return hash(bytesConstRef(std::bit_cast<const unsigned char*>(view.data()), view.size()));
     }
     virtual HashType emptyHash()
     {

--- a/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519Crypto.cpp
@@ -23,6 +23,7 @@
 #include <bcos-crypto/signature/ed25519/Ed25519Crypto.h>
 #include <bcos-crypto/signature/ed25519/Ed25519KeyPair.h>
 #include <wedpr-crypto/WedprCrypto.h>
+#include <bit>
 #include <memory>
 
 using namespace bcos;
@@ -31,9 +32,9 @@ std::shared_ptr<bytes> bcos::crypto::ed25519Sign(
     const KeyPairInterface& _keyPair, const HashType& _messageHash, bool _signatureWithPub)
 {
     CInputBuffer privateKey{_keyPair.secretKey()->constData(), _keyPair.secretKey()->size()};
-    CInputBuffer messagHash{(const char*)_messageHash.data(), HashType::SIZE};
+    CInputBuffer messagHash{std::bit_cast<const char*>(_messageHash.data()), HashType::SIZE};
     FixedBytes<ED25519_SIGNATURE_LEN> signatureArray;
-    COutputBuffer signatureResult{(char*)signatureArray.data(), ED25519_SIGNATURE_LEN};
+    COutputBuffer signatureResult{std::bit_cast<char*>(signatureArray.data()), ED25519_SIGNATURE_LEN};
     auto retCode = wedpr_ed25519_sign(&privateKey, &messagHash, &signatureResult);
     if (retCode != WEDPR_SUCCESS)
     {
@@ -69,10 +70,11 @@ bool bcos::crypto::ed25519Verify(
     PublicPtr _pubKey, const HashType& _messageHash, bytesConstRef _signatureData)
 {
     CInputBuffer publicKey{_pubKey->constData(), _pubKey->size()};
-    CInputBuffer msgHash{(const char*)_messageHash.data(), HashType::SIZE};
+    CInputBuffer msgHash{std::bit_cast<const char*>(_messageHash.data()), HashType::SIZE};
 
     auto signatureWithoutPub = bytesConstRef(_signatureData.data(), ED25519_SIGNATURE_LEN);
-    CInputBuffer signatureData{(const char*)signatureWithoutPub.data(), signatureWithoutPub.size()};
+    CInputBuffer signatureData{
+        std::bit_cast<const char*>(signatureWithoutPub.data()), signatureWithoutPub.size()};
     return wedpr_ed25519_verify(&publicKey, &msgHash, &signatureData) == WEDPR_SUCCESS;
 }
 

--- a/bcos-crypto/bcos-crypto/signature/fastsm2/fast_sm2.cpp
+++ b/bcos-crypto/bcos-crypto/signature/fastsm2/fast_sm2.cpp
@@ -27,6 +27,7 @@
 #include <openssl/evp.h>
 #include <openssl/obj_mac.h>
 #include <openssl/sm2.h>
+#include <bit>
 
 #ifdef WITH_SM2_OPTIMIZE
 using namespace bcos;
@@ -55,7 +56,7 @@ int8_t bcos::crypto::fast_sm2_sign(const CInputBuffer* raw_private_key,
     int8_t ret = WEDPR_ERROR;
     uint8_t publicKeyData[65] = {4};
     memcpy(publicKeyData + 1, raw_public_key->data, raw_public_key->len);
-    bn = BN_bin2bn((const unsigned char*)publicKeyData, 65, NULL);
+    bn = BN_bin2bn(publicKeyData, 65, NULL);
     if (bn == nullptr)
     {
         CRYPTO_LOG(WARNING) << LOG_DESC("fast_sm2_sign: error of BN_bin2bn for publicKey");
@@ -63,7 +64,8 @@ int8_t bcos::crypto::fast_sm2_sign(const CInputBuffer* raw_private_key,
     }
 
     // load privateKey
-    privateKey = BN_bin2bn((const unsigned char*)raw_private_key->data, raw_private_key->len, NULL);
+    privateKey = BN_bin2bn(
+        std::bit_cast<const unsigned char*>(raw_private_key->data), raw_private_key->len, NULL);
     if (privateKey == nullptr)
     {
         CRYPTO_LOG(WARNING) << LOG_DESC("sm2: fast_sm2_sign: error of BN_bin2bn for privateKey");
@@ -112,7 +114,7 @@ int8_t bcos::crypto::fast_sm2_sign(const CInputBuffer* raw_private_key,
         goto done;
     }
     // set (r, s) to output_signature
-    len = BN_bn2bin(ECDSA_SIG_get0_r(sig), (unsigned char*)output_signature->data);
+    len = BN_bn2bin(ECDSA_SIG_get0_r(sig), std::bit_cast<unsigned char*>(output_signature->data));
     if (len < c_R_FIELD_LEN)
     {
         // padding zero to the r field
@@ -120,8 +122,8 @@ int8_t bcos::crypto::fast_sm2_sign(const CInputBuffer* raw_private_key,
         memset(output_signature->data, 0, (c_R_FIELD_LEN - len));
     }
     // get s filed
-    len =
-        BN_bn2bin(ECDSA_SIG_get0_s(sig), (unsigned char*)(output_signature->data + c_R_FIELD_LEN));
+    len = BN_bn2bin(
+        ECDSA_SIG_get0_s(sig), std::bit_cast<unsigned char*>(output_signature->data + c_R_FIELD_LEN));
     if (len < c_S_FIELD_LEN)
     {
         auto startPointer = output_signature->data + c_R_FIELD_LEN;
@@ -165,7 +167,7 @@ int8_t bcos::crypto::fast_sm2_verify(const CInputBuffer* raw_public_key,
     int8_t ret = WEDPR_ERROR;
     uint8_t publicKeyData[65] = {4};
     memcpy(publicKeyData + 1, raw_public_key->data, raw_public_key->len);
-    BIGNUM* bn = BN_bin2bn((const unsigned char*)publicKeyData, 65, NULL);
+    BIGNUM* bn = BN_bin2bn(publicKeyData, 65, NULL);
     point = EC_POINT_new(sm2Group);
     if (point == NULL)
     {
@@ -196,13 +198,15 @@ int8_t bcos::crypto::fast_sm2_verify(const CInputBuffer* raw_public_key,
         CRYPTO_LOG(WARNING) << "EC_KEY_set_public_key of EC_KEY_set_public_key";
         goto done;
     }
-    r = BN_bin2bn((const unsigned char*)raw_signature->data, c_R_FIELD_LEN, NULL);
+    r = BN_bin2bn(std::bit_cast<const unsigned char*>(raw_signature->data), c_R_FIELD_LEN, NULL);
     if (r == NULL)
     {
         CRYPTO_LOG(WARNING) << "sm2: fast_sm2_verify: error of BN_bin2bn for r";
         goto done;
     }
-    s = BN_bin2bn((const unsigned char*)(raw_signature->data + c_R_FIELD_LEN), c_S_FIELD_LEN, NULL);
+    s = BN_bin2bn(
+        std::bit_cast<const unsigned char*>(raw_signature->data + c_R_FIELD_LEN), c_S_FIELD_LEN,
+        NULL);
     if (s == NULL)
     {
         CRYPTO_LOG(WARNING) << "sm2: fast_sm2_verify: error of BN_bin2bn for s";
@@ -255,8 +259,8 @@ int8_t bcos::crypto::fast_sm2_derive_public_key(
     EC_POINT* pubPoint = NULL;
     BN_CTX* ctx = NULL;
     char* publicKey = NULL;
-    BIGNUM* privateKey =
-        BN_bin2bn((const unsigned char*)raw_private_key->data, raw_private_key->len, NULL);
+    BIGNUM* privateKey = BN_bin2bn(
+        std::bit_cast<const unsigned char*>(raw_private_key->data), raw_private_key->len, NULL);
     if (!privateKey)
     {
         CRYPTO_LOG(WARNING) << "sm2: fast_sm2_derive_public_key: error of BN_bin2bn for privateKey";

--- a/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.cpp
@@ -25,6 +25,7 @@
 #include <bcos-utilities/BoostLog.h>
 #include <hsm-crypto/hsm/CryptoProvider.h>
 #include <hsm-crypto/hsm/SDFCryptoProvider.h>
+#include <bit>
 #include <algorithm>
 
 using namespace bcos;
@@ -75,7 +76,7 @@ std::shared_ptr<bytes> HsmSM2Crypto::sign(
     unsigned char hashResult[HSM_SM3_DIGEST_LENGTH];
     unsigned int uiHashResultLen;
     unsigned int code = provider.Hash(&key, hsm::SM3, _hash.data(), HSM_SM3_DIGEST_LENGTH,
-        (unsigned char*)hashResult, &uiHashResultLen);
+        hashResult, &uiHashResultLen);
     if (code != SDR_OK)
     {
         CRYPTO_LOG(WARNING) << "[HSMSignature::sign] ERROR of compute H(M')"
@@ -85,8 +86,8 @@ std::shared_ptr<bytes> HsmSM2Crypto::sign(
 
     // step 3 : signature = Sign(e)
     unsigned int signLen;
-    code = provider.Sign(
-        key, hsm::SM2, (const unsigned char*)hashResult, 32, signatureData->data(), &signLen);
+    code = provider.Sign(key, hsm::SM2, hashResult, 32,
+        signatureData->data(), &signLen);
     if (code != SDR_OK)
     {
         CRYPTO_LOG(WARNING) << "[HSMSignature::sign] ERROR of Sign"
@@ -127,7 +128,7 @@ bool HsmSM2Crypto::verify(
     bytes hashResult(HSM_SM3_DIGEST_LENGTH);
     unsigned int uiHashResultLen;
     unsigned int code = provider.Hash(&key, hsm::SM3, _hash.data(), HSM_SM3_DIGEST_LENGTH,
-        (unsigned char*)hashResult.data(), &uiHashResultLen);
+        std::bit_cast<unsigned char*>(hashResult.data()), &uiHashResultLen);
     if (code != SDR_OK)
     {
         CRYPTO_LOG(WARNING) << "[HSMSignature::verify] ERROR of Hash"
@@ -135,7 +136,7 @@ bool HsmSM2Crypto::verify(
         return false;
     }
 
-    code = provider.Verify(key, hsm::SM2, (const unsigned char*)hashResult.data(),
+    code = provider.Verify(key, hsm::SM2, std::bit_cast<const unsigned char*>(hashResult.data()),
         HSM_SM3_DIGEST_LENGTH, _signatureData.data(), 64, &verifyResult);
     if (code != SDR_OK)
     {

--- a/bcos-crypto/bcos-crypto/signature/key/KeyImpl.h
+++ b/bcos-crypto/bcos-crypto/signature/key/KeyImpl.h
@@ -22,6 +22,7 @@
 #include <bcos-crypto/interfaces/crypto/KeyInterface.h>
 #include <bcos-crypto/signature/Exceptions.h>
 #include <bcos-utilities/DataConvertUtility.h>
+#include <bit>
 
 namespace bcos::crypto
 {
@@ -53,8 +54,8 @@ public:
 
     const bytes& data() const override { return m_keyData; }
     size_t size() const override { return m_keyData.size(); }
-    char* mutableData() override { return (char*)m_keyData.data(); }
-    const char* constData() const override { return (const char*)m_keyData.data(); }
+    char* mutableData() override { return std::bit_cast<char*>(m_keyData.data()); }
+    const char* constData() const override { return std::bit_cast<const char*>(m_keyData.data()); }
     bytes encode() const override { return m_keyData; }
     void decode(bytesConstRef _data) override { m_keyData = _data.toBytes(); }
     void decode(bytes _data) override { m_keyData = std::move(_data); }

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
@@ -26,6 +26,7 @@
 #include <secp256k1.h>
 #include <secp256k1_recovery.h>
 #include <wedpr-crypto/WedprCrypto.h>
+#include <bit>
 #include <array>
 #include <memory>
 
@@ -55,14 +56,16 @@ std::shared_ptr<bytes> bcos::crypto::secp256k1Sign(
     // secp256k1_ecdsa_recoverable_signature rawSig;
     auto* rawSig = (secp256k1_ecdsa_recoverable_signature*)(signatureData->data());
     if (secp256k1_ecdsa_sign_recoverable(g_SECP256K1_CTX.get(), rawSig, _hash.data(),
-            (const unsigned char*)_keyPair.secretKey()->constData(), nullptr, nullptr) == 0)
+            std::bit_cast<const unsigned char*>(_keyPair.secretKey()->constData()), nullptr,
+            nullptr) == 0)
     {
         BOOST_THROW_EXCEPTION(SignException() << errinfo_comment(
                                   "secp256k1Sign exception, raw data: " + _hash.hex()));
     }
     int recid = 0;
     secp256k1_ecdsa_recoverable_signature_serialize_compact(
-        g_SECP256K1_CTX.get(), (unsigned char*)signatureData->data(), &recid, rawSig);
+        g_SECP256K1_CTX.get(), std::bit_cast<unsigned char*>(signatureData->data()), &recid,
+        rawSig);
     signatureData->back() = (uint8_t)recid;
     return signatureData;
 }

--- a/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
@@ -23,6 +23,7 @@
 #include <bcos-crypto/signature/codec/SignatureDataWithPub.h>
 #include <bcos-crypto/signature/sm2/SM2Crypto.h>
 #include <bcos-crypto/signature/sm2/SM2KeyPair.h>
+#include <bit>
 
 using namespace bcos;
 using namespace bcos::crypto;
@@ -44,8 +45,8 @@ std::shared_ptr<bytes> SM2Crypto::sign(
     std::shared_ptr<bytes> signatureData = std::make_shared<bytes>(SM2_SIGNATURE_LEN, 0);
     CInputBuffer rawPrivateKey{_keyPair.secretKey()->constData(), _keyPair.secretKey()->size()};
     CInputBuffer rawPublicKey{_keyPair.publicKey()->constData(), _keyPair.publicKey()->size()};
-    CInputBuffer rawMsgHash{(const char*)_hash.data(), HashType::SIZE};
-    COutputBuffer sm2SignatureResult{(char*)signatureData->data(), SM2_SIGNATURE_LEN};
+    CInputBuffer rawMsgHash{std::bit_cast<const char*>(_hash.data()), HashType::SIZE};
+    COutputBuffer sm2SignatureResult{std::bit_cast<char*>(signatureData->data()), SM2_SIGNATURE_LEN};
     auto retCode = m_signer(&rawPrivateKey, &rawPublicKey, &rawMsgHash, &sm2SignatureResult);
     if (retCode != WEDPR_SUCCESS)
     {
@@ -64,10 +65,11 @@ std::shared_ptr<bytes> SM2Crypto::sign(
 bool SM2Crypto::verify(PublicPtr _pubKey, const HashType& _hash, bytesConstRef _signatureData) const
 {
     CInputBuffer publicKey{_pubKey->constData(), _pubKey->size()};
-    CInputBuffer messageHash{(const char*)_hash.data(), HashType::SIZE};
+    CInputBuffer messageHash{std::bit_cast<const char*>(_hash.data()), HashType::SIZE};
 
     auto signatureWithoutPub = bytesConstRef(_signatureData.data(), SM2_SIGNATURE_LEN);
-    CInputBuffer signature{(const char*)signatureWithoutPub.data(), signatureWithoutPub.size()};
+    CInputBuffer signature{
+        std::bit_cast<const char*>(signatureWithoutPub.data()), signatureWithoutPub.size()};
     auto verifyResult = m_verifier(&publicKey, &messageHash, &signature);
     if (verifyResult == WEDPR_SUCCESS)
     {

--- a/bcos-crypto/bcos-crypto/zkp/Common.h
+++ b/bcos-crypto/bcos-crypto/zkp/Common.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 #include "Exceptions.h"
+#include <bit>
 #include <bcos-utilities/Common.h>
 #include <wedpr-crypto/WedprUtilities.h>
 
@@ -35,7 +36,7 @@ inline CInputBuffer bytesToInputBuffer(bytes const& data, size_t _length)
             InvalidInputInput() << errinfo_comment(
                 "InvalidInputInput: the data size must be at least " + std::to_string(_length)));
     }
-    return CInputBuffer{(const char*)data.data(), _length};
+    return CInputBuffer{std::bit_cast<const char*>(data.data()), _length};
 }
 }  // namespace crypto
 }  // namespace bcos

--- a/bcos-crypto/bcos-crypto/zkp/discretezkp/DiscreteLogarithmZkp.cpp
+++ b/bcos-crypto/bcos-crypto/zkp/discretezkp/DiscreteLogarithmZkp.cpp
@@ -20,6 +20,7 @@
  */
 #include "DiscreteLogarithmZkp.h"
 #include "bcos-crypto/zkp/Common.h"
+#include <bit>
 
 using namespace bcos;
 using namespace bcos::crypto;
@@ -32,7 +33,8 @@ bool DiscreteLogarithmZkp::verifyEitherEqualityProof(bytes const& c1PointData,
     auto c1Point = bytesToInputBuffer(c1PointData, m_pointLen);
     auto c2Point = bytesToInputBuffer(c2PointData, m_pointLen);
     auto c3Point = bytesToInputBuffer(c3PointData, m_pointLen);
-    CInputBuffer proof{(const char*)equalityProofData.data(), equalityProofData.size()};
+    CInputBuffer proof{std::bit_cast<const char*>(equalityProofData.data()),
+        equalityProofData.size()};
     auto basePoint = bytesToInputBuffer(basePointData, m_pointLen);
     auto blindingBasePoint = bytesToInputBuffer(blindingBasePointData, m_pointLen);
     auto ret = wedpr_verify_either_equality_relationship_proof(
@@ -49,7 +51,8 @@ bool DiscreteLogarithmZkp::verifyKnowledgeProof(bytes const& pointData,
     bytes const& knowledgeProofData, bytes const& basePointData, bytes const& blindingBasePointData)
 {
     auto point = bytesToInputBuffer(pointData, m_pointLen);
-    CInputBuffer proof{(const char*)knowledgeProofData.data(), knowledgeProofData.size()};
+    CInputBuffer proof{std::bit_cast<const char*>(knowledgeProofData.data()),
+        knowledgeProofData.size()};
     auto basePoint = bytesToInputBuffer(basePointData, m_pointLen);
     auto blindingBasePoint = bytesToInputBuffer(blindingBasePointData, m_pointLen);
 
@@ -68,7 +71,8 @@ bool DiscreteLogarithmZkp::verifyFormatProof(bytes const& c1Point, bytes const& 
 {
     auto c1 = bytesToInputBuffer(c1Point, m_pointLen);
     auto c2 = bytesToInputBuffer(c2Point, m_pointLen);
-    CInputBuffer proof{(const char*)formatProofData.data(), formatProofData.size()};
+    CInputBuffer proof{std::bit_cast<const char*>(formatProofData.data()),
+        formatProofData.size()};
     auto c1BasePoint = bytesToInputBuffer(c1BasePointData, m_pointLen);
     auto c2BasePoint = bytesToInputBuffer(c2BasePointData, m_pointLen);
     auto blindingBasePoint = bytesToInputBuffer(blindingBasePointData, m_pointLen);
@@ -89,7 +93,8 @@ bool DiscreteLogarithmZkp::verifySumProof(bytes const& c1Point, bytes const& c2P
     auto c1 = bytesToInputBuffer(c1Point, m_pointLen);
     auto c2 = bytesToInputBuffer(c2Point, m_pointLen);
     auto c3 = bytesToInputBuffer(c3Point, m_pointLen);
-    CInputBuffer proof{(const char*)arithmeticProofData.data(), arithmeticProofData.size()};
+    CInputBuffer proof{std::bit_cast<const char*>(arithmeticProofData.data()),
+        arithmeticProofData.size()};
     auto valueBasePoint = bytesToInputBuffer(valueBasePointData, m_pointLen);
     auto blindingBasePoint = bytesToInputBuffer(blindingBasePointData, m_pointLen);
     auto ret =
@@ -109,7 +114,8 @@ bool DiscreteLogarithmZkp::verifyProductProof(bytes const& c1Point, bytes const&
     auto c1 = bytesToInputBuffer(c1Point, m_pointLen);
     auto c2 = bytesToInputBuffer(c2Point, m_pointLen);
     auto c3 = bytesToInputBuffer(c3Point, m_pointLen);
-    CInputBuffer proof{(const char*)arithmeticProofData.data(), arithmeticProofData.size()};
+    CInputBuffer proof{std::bit_cast<const char*>(arithmeticProofData.data()),
+        arithmeticProofData.size()};
     auto valueBasePoint = bytesToInputBuffer(valueBasePointData, m_pointLen);
     auto blindingBasePoint = bytesToInputBuffer(blindingBasePointData, m_pointLen);
     auto ret = wedpr_verify_product_relationship(
@@ -127,7 +133,8 @@ bool DiscreteLogarithmZkp::verifyEqualityProof(bytes const& c1Point, bytes const
 {
     auto c1 = bytesToInputBuffer(c1Point, m_pointLen);
     auto c2 = bytesToInputBuffer(c2Point, m_pointLen);
-    CInputBuffer proof{(const char*)equalityProofData.data(), equalityProofData.size()};
+    CInputBuffer proof{std::bit_cast<const char*>(equalityProofData.data()),
+        equalityProofData.size()};
 
     auto basePoint1 = bytesToInputBuffer(basePoint1Data, m_pointLen);
     auto basePoint2 = bytesToInputBuffer(basePoint2Data, m_pointLen);
@@ -151,7 +158,7 @@ bytes DiscreteLogarithmZkp::aggregateRistrettoPoint(bytes const& pointSum, bytes
     auto pointShareInput = bytesToInputBuffer(pointShare, m_pointLen);
     bytes aggregatedResult;
     aggregatedResult.resize(m_pointLen);
-    COutputBuffer result{(char*)aggregatedResult.data(), m_pointLen};
+    COutputBuffer result{std::bit_cast<char*>(aggregatedResult.data()), m_pointLen};
     auto ret = wedpr_aggregate_ristretto_point(&pointSumInput, &pointShareInput, &result);
     if (ret == WEDPR_SUCCESS)
     {

--- a/bcos-crypto/demo/perf_demo.cpp
+++ b/bcos-crypto/demo/perf_demo.cpp
@@ -33,6 +33,7 @@
 #include <bcos-utilities/Common.h>
 #include <boost/core/ignore_unused.hpp>
 #include <cassert>
+#include <bit>
 #include <ethash/keccak.hpp>
 #include <span>
 
@@ -336,11 +337,12 @@ void encryptPerf(SymmetricEncryption::Ptr _encryptor, std::string const& _inputD
     auto startT = utcTime();
     for (size_t i = 0; i < _count; i++)
     {
-        encryptedData = _encryptor->symmetricEncrypt((const unsigned char*)_inputData.c_str(),
-            _inputData.size(), (const unsigned char*)key.c_str(), key.size());
+        encryptedData = _encryptor->symmetricEncrypt(
+            std::bit_cast<const unsigned char*>(_inputData.c_str()), _inputData.size(),
+            std::bit_cast<const unsigned char*>(key.c_str()), key.size());
     }
     std::cout << "PlainData size:" << (double)_inputData.size() / 1000.0 << " KB, loops: " << _count
-              << ", timeCost: " << utcTime() - startT << " ms" << std::endl;
+                  << ", timeCost: " << utcTime() - startT << " ms" << std::endl;
     std::cout << "TPS of " << _encryptorName << " encrypt:"
               << (getTPS(utcTime(), startT, _count) * (double)(_inputData.size())) / 1000.0
               << "KB/s" << std::endl;
@@ -350,8 +352,9 @@ void encryptPerf(SymmetricEncryption::Ptr _encryptor, std::string const& _inputD
     bytesPointer decryptedData;
     for (size_t i = 0; i < _count; i++)
     {
-        decryptedData = _encryptor->symmetricDecrypt((const unsigned char*)encryptedData->data(),
-            encryptedData->size(), (const unsigned char*)key.c_str(), key.size());
+            decryptedData = _encryptor->symmetricDecrypt(
+                std::bit_cast<const unsigned char*>(encryptedData->data()), encryptedData->size(),
+                std::bit_cast<const unsigned char*>(key.c_str()), key.size());
     }
     std::cout << "CiperData size:" << (double)encryptedData->size() / 1000.0
               << " KB, loops: " << _count << ", timeCost:" << utcTime() - startT << " ms"

--- a/bcos-crypto/test/unittests/EncryptionTest.cpp
+++ b/bcos-crypto/test/unittests/EncryptionTest.cpp
@@ -23,6 +23,7 @@
 #include <bcos-crypto/encrypt/SM4Crypto.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
+#include <bit>
 
 using namespace bcos;
 using namespace bcos::crypto;
@@ -38,11 +39,12 @@ void testEncryption(SymmetricEncryption::Ptr _encrypt)
     std::string plainData = "testAESx%$234sdfjl234129p";
     std::string key = "abcd";
     // encrypt
-    auto ciperData = _encrypt->symmetricEncrypt((const unsigned char*)plainData.c_str(),
-        plainData.size(), (const unsigned char*)key.c_str(), key.size());
+    auto ciperData = _encrypt->symmetricEncrypt(std::bit_cast<const unsigned char*>(plainData.c_str()),
+        plainData.size(), std::bit_cast<const unsigned char*>(key.c_str()), key.size());
     // decrypt
-    auto decryptedData = _encrypt->symmetricDecrypt((const unsigned char*)ciperData->data(),
-        ciperData->size(), (const unsigned char*)key.c_str(), key.size());
+    auto decryptedData = _encrypt->symmetricDecrypt(
+        std::bit_cast<const unsigned char*>(ciperData->data()), ciperData->size(),
+        std::bit_cast<const unsigned char*>(key.c_str()), key.size());
     bytes plainDataBytes(plainData.begin(), plainData.end());
     BOOST_CHECK(*decryptedData == plainDataBytes);
 
@@ -50,9 +52,9 @@ void testEncryption(SymmetricEncryption::Ptr _encrypt)
     std::string invalidKey = "ABCDCD";
     try
     {
-        _encrypt->symmetricDecrypt((const unsigned char*)ciperData->data(), ciperData->size(),
-            (const unsigned char*)invalidKey.c_str(), invalidKey.size());
-        BOOST_CHECK(std::string_view((const char*)ciperData->data(), ciperData->size()) !=
+        _encrypt->symmetricDecrypt(std::bit_cast<const unsigned char*>(ciperData->data()), ciperData->size(),
+            std::bit_cast<const unsigned char*>(invalidKey.c_str()), invalidKey.size());
+        BOOST_CHECK(std::string_view(std::bit_cast<const char*>(ciperData->data()), ciperData->size()) !=
                     std::string_view(plainData));
     }
     catch (std::exception& e)
@@ -65,29 +67,29 @@ void testEncryption(SymmetricEncryption::Ptr _encrypt)
 
     // invalid ciper
     (*ciperData)[0] += 10;
-    decryptedData = _encrypt->symmetricDecrypt((const unsigned char*)ciperData->data(),
-        ciperData->size(), (const unsigned char*)key.c_str(), key.size());
+    decryptedData = _encrypt->symmetricDecrypt(std::bit_cast<const unsigned char*>(ciperData->data()),
+        ciperData->size(), std::bit_cast<const unsigned char*>(key.c_str()), key.size());
     plainDataBytes = bytes(plainData.begin(), plainData.end());
     BOOST_CHECK(*decryptedData != plainDataBytes);
     // test encrypt/decrypt with given ivData
     std::string ivData = "adfwerivswerwerwerpi9werlwerwasdfa234523423dsfa";
     key = "werwlerewkrjewwwwwwwr4234981034%wer23423&3453453453465646778)7897678";
     plainData += "testAESx%$234sdfjl234129p" + ivData + key;
-    ciperData = _encrypt->symmetricEncrypt((const unsigned char*)plainData.c_str(),
-        plainData.size(), (const unsigned char*)key.c_str(), key.size(),
-        (const unsigned char*)ivData.c_str(), ivData.size());
+    ciperData = _encrypt->symmetricEncrypt(std::bit_cast<const unsigned char*>(plainData.c_str()),
+        plainData.size(), std::bit_cast<const unsigned char*>(key.c_str()), key.size(),
+        std::bit_cast<const unsigned char*>(ivData.c_str()), ivData.size());
 
-    decryptedData = _encrypt->symmetricDecrypt((const unsigned char*)ciperData->data(),
-        ciperData->size(), (const unsigned char*)key.c_str(), key.size(),
-        (const unsigned char*)ivData.c_str(), ivData.size());
+    decryptedData = _encrypt->symmetricDecrypt(std::bit_cast<const unsigned char*>(ciperData->data()),
+        ciperData->size(), std::bit_cast<const unsigned char*>(key.c_str()), key.size(),
+        std::bit_cast<const unsigned char*>(ivData.c_str()), ivData.size());
     plainDataBytes = bytes(plainData.begin(), plainData.end());
     BOOST_CHECK(*decryptedData == plainDataBytes);
 
     // invalid ivData
     std::string invalidIVData = "bdfwerivswerwerwerpi9werlwerwasdfa234523423dsf";
-    decryptedData = _encrypt->symmetricDecrypt((const unsigned char*)ciperData->data(),
-        ciperData->size(), (const unsigned char*)key.c_str(), key.size(),
-        (const unsigned char*)invalidIVData.c_str(), invalidIVData.size());
+    decryptedData = _encrypt->symmetricDecrypt(std::bit_cast<const unsigned char*>(ciperData->data()),
+        ciperData->size(), std::bit_cast<const unsigned char*>(key.c_str()), key.size(),
+        std::bit_cast<const unsigned char*>(invalidIVData.c_str()), invalidIVData.size());
     plainDataBytes = bytes(plainData.begin(), plainData.end());
     BOOST_CHECK(*decryptedData != plainDataBytes);
 }

--- a/bcos-crypto/test/unittests/HasherTest.cpp
+++ b/bcos-crypto/test/unittests/HasherTest.cpp
@@ -24,6 +24,7 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/unit_test_suite.hpp>
+#include <bit>
 #include <iterator>
 #include <string>
 
@@ -127,7 +128,7 @@ template <size_t length>
 {
     std::string str;
     str.reserve(hash.size() * 2);
-    std::span<char> view{(char*)hash.data(), hash.size()};
+    std::span<char> view{std::bit_cast<char*>(hash.data()), hash.size()};
 
     boost::algorithm::hex_lower(view.begin(), view.end(), std::back_inserter(str));
     stream << str;

--- a/bcos-crypto/test/unittests/testMerkle.cpp
+++ b/bcos-crypto/test/unittests/testMerkle.cpp
@@ -6,6 +6,7 @@
 #include <boost/archive/basic_archive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
+#include <bit>
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <boost/test/unit_test.hpp>
@@ -22,8 +23,8 @@ namespace std
 std::ostream& operator<<(std::ostream& stream, const HashType& hash)
 {
     std::string hex;
-    boost::algorithm::hex_lower(
-        (char*)hash.data(), (char*)hash.data() + hash.size(), std::back_inserter(hex));
+    boost::algorithm::hex_lower(std::bit_cast<char*>(hash.data()),
+        std::bit_cast<char*>(hash.data()) + hash.size(), std::back_inserter(hex));
     std::string_view view{hex.data(), 8};
     stream << view;
     return stream;

--- a/bcos-executor/src/Common.h
+++ b/bcos-executor/src/Common.h
@@ -35,6 +35,7 @@
 #include "bcos-protocol/TransactionStatus.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Exceptions.h"
+#include <bit>
 #include <evmc/evmc.h>
 #include <evmc/instructions.h>
 #include <boost/algorithm/string/case_conv.hpp>
@@ -277,12 +278,12 @@ inline u256 fromEvmC(evmc_bytes32 const& _n)
  */
 inline std::string_view fromEvmC(evmc_address const& _addr)
 {
-    return {(char*)_addr.bytes, 20};
+    return {std::bit_cast<const char*>(_addr.bytes + 0), 20};
 }
 
 inline std::string fromBytes(const bytes& _addr)
 {
-    return {(char*)_addr.data(), _addr.size()};
+    return {std::bit_cast<const char*>(_addr.data()), _addr.size()};
 }
 
 inline std::string fromBytes(const bytesConstRef& _addr)
@@ -292,7 +293,8 @@ inline std::string fromBytes(const bytesConstRef& _addr)
 
 inline bytes toBytes(const std::string_view& _addr)
 {
-    return {(char*)_addr.data(), (char*)(_addr.data() + _addr.size())};
+    return {std::bit_cast<const char*>(_addr.data()),
+        std::bit_cast<const char*>(_addr.data() + _addr.size())};
 }
 
 inline std::string getContractTableName(

--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -30,6 +30,7 @@
 #include "../vm/Precompiled.h"
 #include "../vm/VMFactory.h"
 #include "../vm/VMInstance.h"
+#include <bit>
 #include "bcos-executor/src/Common.h"
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
 #include "bcos-framework/ledger/EVMAccount.h"
@@ -472,7 +473,7 @@ std::tuple<h256, std::optional<storage::Entry>> TransactionExecutive::getCodeByC
     const std::string_view& contractTableName, bool tryFromContractTable)
 {
     auto hash = getCodeHash(contractTableName);
-    auto entry = getCodeByHash(std::string_view((char*)hash.data(), hash.size()));
+    auto entry = getCodeByHash(std::string_view(std::bit_cast<const char*>(hash.data()), hash.size()));
     if (entry && entry.has_value() && !entry->get().empty())
     {
         return {hash, std::move(entry)};

--- a/bcos-executor/src/precompiled/CryptoPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/CryptoPrecompiled.cpp
@@ -27,6 +27,7 @@
 #include "bcos-executor/src/precompiled/common/PrecompiledResult.h"
 #include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-framework/protocol/Protocol.h"
+#include <bit>
 
 using namespace bcos;
 using namespace bcos::codec;
@@ -126,11 +127,11 @@ void CryptoPrecompiled::curve25519VRFVerify(
         bytes publicKey;
         bytes proof;
         codec.decode(_paramData, message, publicKey, proof);
-        CInputBuffer rawPublicKey{(const char*)publicKey.data(), publicKey.size()};
-        CInputBuffer rawMsg{(const char*)message.data(), message.size()};
-        CInputBuffer rawProof{(const char*)proof.data(), proof.size()};
+        CInputBuffer rawPublicKey{std::bit_cast<const char*>(publicKey.data()), publicKey.size()};
+        CInputBuffer rawMsg{std::bit_cast<const char*>(message.data()), message.size()};
+        CInputBuffer rawProof{std::bit_cast<const char*>(proof.data()), proof.size()};
         HashType vrfHash;
-        COutputBuffer outputHash{(char*)vrfHash.data(), vrfHash.size()};
+        COutputBuffer outputHash{std::bit_cast<char*>(vrfHash.data()), vrfHash.size()};
         if ((wedpr_curve25519_vrf_is_valid_public_key(&rawPublicKey) == WEDPR_SUCCESS) &&
             (wedpr_curve25519_vrf_verify_utf8(&rawPublicKey, &rawMsg, &rawProof) ==
                 WEDPR_SUCCESS) &&

--- a/bcos-executor/src/precompiled/common/VRFInfo.cpp
+++ b/bcos-executor/src/precompiled/common/VRFInfo.cpp
@@ -20,6 +20,7 @@
 
 #include "VRFInfo.h"
 #include "bcos-framework/sealer/VrfCurveType.h"
+#include <bit>
 #include <wedpr-crypto/WedprCrypto.h>
 #include <wedpr-crypto/WedprUtilities.h>
 
@@ -29,7 +30,7 @@ using namespace bcos::precompiled;
 
 bool VRFInfo::isValidVRFPublicKey()
 {
-    CInputBuffer rawPk{(const char*)m_vrfPublicKey.data(), m_vrfPublicKey.size()};
+    CInputBuffer rawPk{std::bit_cast<const char*>(m_vrfPublicKey.data()), m_vrfPublicKey.size()};
     switch (m_vrfCurveType)
     {
     case sealer::VrfCurveType::CURVE25519:
@@ -43,9 +44,9 @@ bool VRFInfo::isValidVRFPublicKey()
 
 bool VRFInfo::verifyProof()
 {
-    CInputBuffer rawPk{(const char*)m_vrfPublicKey.data(), m_vrfPublicKey.size()};
-    CInputBuffer rawInput{(const char*)m_vrfInput.data(), m_vrfInput.size()};
-    CInputBuffer rawProof{(const char*)m_vrfProof.data(), m_vrfProof.size()};
+    CInputBuffer rawPk{std::bit_cast<const char*>(m_vrfPublicKey.data()), m_vrfPublicKey.size()};
+    CInputBuffer rawInput{std::bit_cast<const char*>(m_vrfInput.data()), m_vrfInput.size()};
+    CInputBuffer rawProof{std::bit_cast<const char*>(m_vrfProof.data()), m_vrfProof.size()};
     switch (m_vrfCurveType)
     {
     case sealer::VrfCurveType::CURVE25519:
@@ -59,9 +60,10 @@ bool VRFInfo::verifyProof()
 
 HashType VRFInfo::getHashFromProof()
 {
-    CInputBuffer rawProof{.data = (const char*)m_vrfProof.data(), .len = m_vrfProof.size()};
+    CInputBuffer rawProof{
+        .data = std::bit_cast<const char*>(m_vrfProof.data()), .len = m_vrfProof.size()};
     HashType vrfHash;
-    COutputBuffer outputHash{.data = (char*)vrfHash.data(), .len = vrfHash.size()};
+    COutputBuffer outputHash{.data = std::bit_cast<char*>(vrfHash.data()), .len = vrfHash.size()};
     switch (m_vrfCurveType)
     {
     case sealer::VrfCurveType::CURVE25519:

--- a/bcos-executor/src/vm/EVMHostInterface.cpp
+++ b/bcos-executor/src/vm/EVMHostInterface.cpp
@@ -28,6 +28,7 @@
 #include "HostContext.h"
 #include "bcos-utilities/Common.h"
 #include <evmc/evmc.h>
+#include <bit>
 #include <boost/algorithm/hex.hpp>
 #include <boost/core/ignore_unused.hpp>
 
@@ -225,7 +226,8 @@ evmc_tx_context getTxContext(evmc_host_context* _context) noexcept
     else
     {
         auto origin = fromHex(hostContext.origin());
-        result.tx_origin = toEvmC(std::string_view((char*)origin.data(), origin.size()));
+        result.tx_origin =
+            toEvmC(std::string_view(std::bit_cast<const char*>(origin.data()), origin.size()));
     }
     result.block_number = hostContext.blockNumber();
     result.block_timestamp = hostContext.timestamp();
@@ -307,7 +309,7 @@ bool wasmAccountExists(
     evmc_host_context* _context, const uint8_t* address, int32_t addressLength) noexcept
 {
     auto& hostContext = static_cast<HostContext&>(*_context);
-    return hostContext.exists(string_view((char*)address, addressLength));
+    return hostContext.exists(string_view(std::bit_cast<const char*>(address), addressLength));
 }
 
 int32_t get(evmc_host_context* _context, const uint8_t* _addr, int32_t _addressLength,
@@ -317,8 +319,8 @@ int32_t get(evmc_host_context* _context, const uint8_t* _addr, int32_t _addressL
     auto& hostContext = static_cast<HostContext&>(*_context);
 
     // programming assert for debug
-    assert(string_view((char*)_addr, _addressLength) == hostContext.myAddress());
-    auto value = hostContext.get(std::string_view((char*)_key, _keyLength));
+    assert(string_view(std::bit_cast<const char*>(_addr), _addressLength) == hostContext.myAddress());
+    auto value = hostContext.get(std::string_view(std::bit_cast<const char*>(_key), _keyLength));
     if (value.size() > (size_t)_valueLength)
     {
         return -1;
@@ -337,9 +339,9 @@ evmc_storage_status set(evmc_host_context* _context, const uint8_t* _addr, int32
     // {  // FIXME: RETURN STATUS INSTEAD OF THROW EXCEPTION
     //     BOOST_THROW_EXCEPTION(PERMISSIONDENIED());
     // }
-    assert(string_view((char*)_addr, _addressLength) == hostContext.myAddress());
-    string key((char*)_key, _keyLength);
-    string value((char*)_value, _valueLength);
+    assert(string_view(std::bit_cast<const char*>(_addr), _addressLength) == hostContext.myAddress());
+    string key(std::bit_cast<const char*>(_key), _keyLength);
+    string value(std::bit_cast<const char*>(_value), _valueLength);
 
     auto status = EVMC_STORAGE_MODIFIED;
     if (value.empty())  // TODO: should use 32 bytes 0?
@@ -354,14 +356,14 @@ evmc_storage_status set(evmc_host_context* _context, const uint8_t* _addr, int32
 size_t wasmGetCodeSize(evmc_host_context* _context, const uint8_t* _addr, int32_t _addressLength)
 {
     auto& hostContext = static_cast<HostContext&>(*_context);
-    return hostContext.codeSizeAt(string_view((char*)_addr, _addressLength));
+    return hostContext.codeSizeAt(string_view(std::bit_cast<const char*>(_addr), _addressLength));
 }
 
 evmc_bytes32 wasmGetCodeHash(
     evmc_host_context* _context, const uint8_t* _addr, int32_t _addressLength)
 {
     auto& hostContext = static_cast<HostContext&>(*_context);
-    return toEvmC(hostContext.codeHashAt(string_view((char*)_addr, _addressLength)));
+    return toEvmC(hostContext.codeHashAt(string_view(std::bit_cast<const char*>(_addr), _addressLength)));
 }
 
 size_t wasmCopyCode(evmc_host_context* _context, const uint8_t*, int32_t, size_t,
@@ -393,7 +395,7 @@ void wasmLog(evmc_host_context* _context, const uint8_t* _addr, int32_t _address
     boost::ignore_unused(_addr, _addressLength);
 
     auto& hostContext = static_cast<HostContext&>(*_context);
-    assert(string_view((char*)_addr, _addressLength) == hostContext.myAddress());
+    assert(string_view(std::bit_cast<const char*>(_addr), _addressLength) == hostContext.myAddress());
     h256 const* pTopics = reinterpret_cast<h256 const*>(_topics);
     hostContext.log(h256s{pTopics, pTopics + _numTopics}, bytesConstRef{_data, _dataSize});
 }

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -31,6 +31,7 @@
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/protocol/Protocol.h"
 #include "bcos-utilities/Common.h"
+#include <bit>
 #include <evmc/evmc.h>
 #include <evmc/helpers.h>
 #include <boost/algorithm/hex.hpp>
@@ -150,7 +151,8 @@ evmc_result HostContext::externalRequest(const evmc_message* _msg)
     case EVMC_CALL:
         if (blockContext.isWasm())
         {
-            request->receiveAddress.assign((char*)_msg->destination_ptr, _msg->destination_len);
+            request->receiveAddress.assign(
+                std::bit_cast<const char*>(_msg->destination_ptr), _msg->destination_len);
         }
         else
         {
@@ -500,8 +502,8 @@ bcos::bytes HostContext::externalCodeRequest(const std::string_view& address)
             precompiled::isDynamicPrecompiledAccountCode(fromBytes(response->data))) ||
         (m_executive->blockContext().features().get(
              ledger::Features::Flag::bugfix_eoa_match_failed) &&
-            bcos::precompiled::matchDynamicAccountCode(
-                std::string_view((char*)response->data.data(), response->data.size()))))
+            bcos::precompiled::matchDynamicAccountCode(std::string_view(
+                std::bit_cast<const char*>(response->data.data()), response->data.size()))))
     {
         return bytes();
     }
@@ -571,7 +573,8 @@ VMSchedule const& HostContext::vmSchedule() const
 evmc_bytes32 HostContext::store(const evmc_bytes32* key)
 {
     evmc_bytes32 result;
-    auto keyView = std::string_view((char*)key->bytes, sizeof(key->bytes));
+    auto keyView =
+        std::string_view(std::bit_cast<const char*>(key->bytes + 0), sizeof(key->bytes));
 
     auto entry = m_executive->storage().getRow(m_tableName, keyView);
     if (entry)
@@ -588,7 +591,8 @@ evmc_bytes32 HostContext::store(const evmc_bytes32* key)
 evmc_bytes32 HostContext::getTransientStorage(const evmc_bytes32* key)
 {
     evmc_bytes32 result;
-    auto keyView = std::string_view((char*)key->bytes, sizeof(key->bytes));
+    auto keyView =
+        std::string_view(std::bit_cast<const char*>(key->bytes + 0), sizeof(key->bytes));
 
     auto transientStorageMap = m_executive->blockContext().getTransientStorageMap();
     using TSMap = bcos::BucketMap<int64_t, std::shared_ptr<storage::StateStorageInterface>>;
@@ -618,7 +622,8 @@ evmc_bytes32 HostContext::getTransientStorage(const evmc_bytes32* key)
 
 void HostContext::setStore(const evmc_bytes32* key, const evmc_bytes32* value)
 {
-    auto keyView = std::string_view((char*)key->bytes, sizeof(key->bytes));
+    auto keyView =
+        std::string_view(std::bit_cast<const char*>(key->bytes + 0), sizeof(key->bytes));
     bytes valueBytes(value->bytes, value->bytes + sizeof(value->bytes));
 
     Entry entry;
@@ -628,7 +633,8 @@ void HostContext::setStore(const evmc_bytes32* key, const evmc_bytes32* value)
 
 void HostContext::setTransientStorage(const evmc_bytes32* key, const evmc_bytes32* value)
 {
-    auto keyView = std::string_view((char*)key->bytes, sizeof(key->bytes));
+    auto keyView =
+        std::string_view(std::bit_cast<const char*>(key->bytes + 0), sizeof(key->bytes));
     bytes valueBytes(value->bytes, value->bytes + sizeof(value->bytes));
 
     Entry entry;
@@ -719,7 +725,8 @@ std::optional<storage::Entry> HostContext::code()
     if (blockVersion() >= uint32_t(bcos::protocol::BlockVersion::V3_1_VERSION))
     {
         auto hash = codeHash();
-        auto entry = m_executive->getCodeByHash(std::string_view((char*)hash.data(), hash.size()));
+        auto entry =
+            m_executive->getCodeByHash(std::string_view(std::bit_cast<const char*>(hash.data()), hash.size()));
         if (entry && entry.has_value() && !entry->get().empty())
         {
             return entry;

--- a/bcos-executor/src/vm/Precompiled.cpp
+++ b/bcos-executor/src/vm/Precompiled.cpp
@@ -25,6 +25,7 @@
 #include "kzgPrecompiled.h"
 #include "wedpr-crypto/WedprBn128.h"
 #include "wedpr-crypto/WedprCrypto.h"
+#include <bit>
 #include <algorithm>
 
 using namespace std;
@@ -193,8 +194,8 @@ ETH_REGISTER_PRECOMPILED_PRICER(modexp)(bytesConstRef _in)
 ETH_REGISTER_PRECOMPILED(alt_bn128_G1_add)(bytesConstRef _in)
 {
     pair<bool, bytes> ret{false, bytes(64, 0)};
-    CInputBuffer in{(const char*)_in.data(), _in.size()};
-    COutputBuffer result{(char*)ret.second.data(), 64};
+    CInputBuffer in{std::bit_cast<const char*>(_in.data()), _in.size()};
+    COutputBuffer result{std::bit_cast<char*>(ret.second.data()), 64};
     if (wedpr_fb_alt_bn128_g1_add(&in, &result) != 0)
     {
         return ret;
@@ -206,8 +207,8 @@ ETH_REGISTER_PRECOMPILED(alt_bn128_G1_add)(bytesConstRef _in)
 ETH_REGISTER_PRECOMPILED(alt_bn128_G1_mul)(bytesConstRef _in)
 {
     pair<bool, bytes> ret{false, bytes(64, 0)};
-    CInputBuffer in{(const char*)_in.data(), _in.size()};
-    COutputBuffer result{(char*)ret.second.data(), 64};
+    CInputBuffer in{std::bit_cast<const char*>(_in.data()), _in.size()};
+    COutputBuffer result{std::bit_cast<char*>(ret.second.data()), 64};
     if (wedpr_fb_alt_bn128_g1_mul(&in, &result) != 0)
     {
         return ret;
@@ -229,8 +230,8 @@ ETH_REGISTER_PRECOMPILED(alt_bn128_pairing_product)(bytesConstRef _in)
         return ret;
     }
 
-    CInputBuffer in{(const char*)_in.data(), _in.size()};
-    COutputBuffer result{(char*)ret.second.data(), 32};
+    CInputBuffer in{std::bit_cast<const char*>(_in.data()), _in.size()};
+    COutputBuffer result{std::bit_cast<char*>(ret.second.data()), 32};
     if (wedpr_fb_alt_bn128_pairing_product(&in, &result) != 0)
     {
         return ret;
@@ -347,8 +348,8 @@ namespace crypto
 h256 sha256(bytesConstRef _in) noexcept
 {
     h256 ret;
-    CInputBuffer in{(const char*)_in.data(), _in.size()};
-    COutputBuffer result{(char*)ret.data(), h256::SIZE};
+    CInputBuffer in{std::bit_cast<const char*>(_in.data()), _in.size()};
+    COutputBuffer result{std::bit_cast<char*>(ret.data()), h256::SIZE};
     if (wedpr_sha256_hash(&in, &result) != 0) [[unlikely]]
     {
         BCOS_LOG(TRACE) << LOG_BADGE("Precompiled") << LOG_DESC("sha256 failed.") << _in.toString();
@@ -360,8 +361,8 @@ h256 sha256(bytesConstRef _in) noexcept
 h160 ripemd160(bytesConstRef _in)
 {
     h160 ret;
-    CInputBuffer in{(const char*)_in.data(), _in.size()};
-    COutputBuffer result{(char*)ret.data(), h160::SIZE};
+    CInputBuffer in{std::bit_cast<const char*>(_in.data()), _in.size()};
+    COutputBuffer result{std::bit_cast<char*>(ret.data()), h160::SIZE};
     if (wedpr_ripemd160_hash(&in, &result) != 0) [[unlikely]]
     {
         BCOS_LOG(TRACE) << LOG_BADGE("Precompiled") << LOG_DESC("ripemd160 failed.")
@@ -556,7 +557,7 @@ pair<bool, bytes> ecRecover(bytesConstRef _in)
                     << LOG_DESC("wedpr_secp256k1_recover_public_key success");
     // keccak256 and set first 12 byte to zero
     CInputBuffer pubkeyBuffer{pk->constData(), PUBLIC_KEY_LENGTH};
-    COutputBuffer pubkeyHash{(char*)ret.second.data(), crypto::HashType::SIZE};
+    COutputBuffer pubkeyHash{std::bit_cast<char*>(ret.second.data()), crypto::HashType::SIZE};
     auto retCode = wedpr_keccak256_hash(&pubkeyBuffer, &pubkeyHash);
     if (retCode != 0)
     {

--- a/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
@@ -23,6 +23,7 @@
 #include "../mock/MockTransactionalStorage.h"
 #include "../mock/MockTxPool.h"
 #include "bcos-codec/wrapper/CodecWrapper.h"
+#include <bit>
 #include "bcos-crypto/ChecksumAddress.h"
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/interfaces/crypto/CommonType.h"
@@ -161,7 +162,8 @@ BOOST_AUTO_TEST_CASE(deployAndCall)
     boost::algorithm::unhex(helloworld, std::back_inserter(input));
     auto tx =
         fakeTransaction(cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1");
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = *toHexString(
+        string_view(std::bit_cast<const char*>(tx->sender().data()), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);
@@ -1039,7 +1041,8 @@ BOOST_AUTO_TEST_CASE(multiDeploy)
         params->setContextID(100 + i);
         params->setSeq(1000);
         params->setDepth(0);
-        auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+        auto sender = *toHexString(
+            string_view(std::bit_cast<const char*>(tx->sender().data()), tx->sender().size()));
 
         auto addressCreate =
             cryptoSuite->hashImpl()->hash("i am a address" + boost::lexical_cast<std::string>(i));

--- a/bcos-executor/test/unittest/libexecutor/TestWasmExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestWasmExecutor.cpp
@@ -23,6 +23,7 @@
 // #if !defined(__aarch64__) && !defined(__linux__)
 
 #include "bcos-codec/scale/Scale.h"
+#include <bit>
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #ifdef WITH_WASM
 
@@ -244,7 +245,8 @@ BOOST_AUTO_TEST_CASE(deployAndCall)
 
     auto tx = fakeTransaction(
         cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1", helloWorldAbi);
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = *toHexString(
+        string_view(std::bit_cast<const char*>(tx->sender().data()), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);
@@ -452,7 +454,8 @@ BOOST_AUTO_TEST_CASE(deployError)
 
     auto tx = fakeTransaction(
         cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1", helloWorldAbi);
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = *toHexString(
+        string_view(std::bit_cast<const char*>(tx->sender().data()), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);
@@ -655,7 +658,8 @@ BOOST_AUTO_TEST_CASE(deployAndCall_100)
 
     auto tx = fakeTransaction(
         cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1", helloWorldAbi);
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = *toHexString(
+        string_view(std::bit_cast<const char*>(tx->sender().data()), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);

--- a/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
@@ -21,6 +21,7 @@
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "libprecompiled/PreCompiledFixture.h"
+#include <bit>
 #include <boost/endian/conversion.hpp>
 
 using namespace bcos;
@@ -283,24 +284,24 @@ public:
         crypto::KeyPairInterface::UniquePtr const& keyPair, HashType const& blockHash,
         protocol::BlockNumber blockNumber = 0)
     {
-        CInputBuffer privateKey{reinterpret_cast<const char*>(keyPair->secretKey()->data().data()),
+        CInputBuffer privateKey{std::bit_cast<const char*>(keyPair->secretKey()->data().data()),
             keyPair->secretKey()->size()};
         bytes vrfPublicKey;
         vrfPublicKey.resize(32);
-        COutputBuffer publicKey{(char*)vrfPublicKey.data(), vrfPublicKey.size()};
+        COutputBuffer publicKey{std::bit_cast<char*>(vrfPublicKey.data()), vrfPublicKey.size()};
         auto ret = wedpr_curve25519_vrf_derive_public_key(&privateKey, &publicKey);
         BOOST_CHECK_EQUAL(ret, WEDPR_SUCCESS);
 
         auto blockNumberBigEndian = boost::endian::native_to_big(blockNumber);
         CInputBuffer inputMsg{.data = blockNumber > 0 ?
-                                          reinterpret_cast<const char*>(&blockNumberBigEndian) :
-                                          reinterpret_cast<const char*>(blockHash.data()),
+                          std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)) :
+                          std::bit_cast<const char*>(blockHash.data()),
             .len = blockNumber > 0 ? sizeof(blockNumberBigEndian) : (size_t)blockHash.size()};
         bytes vrfInput(inputMsg.data, inputMsg.data + inputMsg.len);
         bytes vrfProof;
         size_t proofSize = 96;
         vrfProof.resize(proofSize);
-        COutputBuffer proof{(char*)vrfProof.data(), proofSize};
+        COutputBuffer proof{std::bit_cast<char*>(vrfProof.data()), proofSize};
         ret = wedpr_curve25519_vrf_prove_utf8(&privateKey, &inputMsg, &proof);
         BOOST_CHECK(ret == WEDPR_SUCCESS);
 
@@ -744,8 +745,9 @@ BOOST_AUTO_TEST_CASE(rotateValidTest)
     // case4: invalid public key(the origin is not one of the sealers)
     auto blockNumberBigEndian = boost::endian::native_to_big(blockNumber);
     bytes input;
-    input.assign(reinterpret_cast<const char*>(&blockNumberBigEndian),
-        reinterpret_cast<const char*>(&blockNumberBigEndian) + sizeof(blockNumberBigEndian));
+    input.assign(std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)),
+        std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)) +
+            sizeof(blockNumberBigEndian));
     result = rotate(blockNumber++, keyPair->publicKey()->data(), input, vrfProof,
         covertPublicToHexAddress(keyPair->publicKey()));
     BOOST_CHECK(result->status() == (uint32_t)TransactionStatus::PrecompiledError);
@@ -754,8 +756,9 @@ BOOST_AUTO_TEST_CASE(rotateValidTest)
     // case5: invalid proof
     // vrfProof invalid now
     blockNumberBigEndian = boost::endian::native_to_big(blockNumber);
-    input.assign(reinterpret_cast<const char*>(&blockNumberBigEndian),
-        reinterpret_cast<const char*>(&blockNumberBigEndian) + sizeof(blockNumberBigEndian));
+    input.assign(std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)),
+        std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)) +
+            sizeof(blockNumberBigEndian));
     result = rotate(blockNumber++, vrfPublicKey, input, vrfProof,
         covertPublicToHexAddress(keyPair->publicKey()));
     BOOST_CHECK(result->status() == (uint32_t)TransactionStatus::PrecompiledError);
@@ -763,8 +766,9 @@ BOOST_AUTO_TEST_CASE(rotateValidTest)
 
     // case6: valid proof now
     blockNumberBigEndian = boost::endian::native_to_big(blockNumber);
-    input.assign(reinterpret_cast<const char*>(&blockNumberBigEndian),
-        reinterpret_cast<const char*>(&blockNumberBigEndian) + sizeof(blockNumberBigEndian));
+    input.assign(std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)),
+        std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)) +
+            sizeof(blockNumberBigEndian));
     std::tie(vrfPublicKey, vrfProof, vrfInput) = generateVRFProof(keyPair, blockHash, blockNumber);
     result = rotate(blockNumber++, vrfPublicKey, input, vrfProof,
         covertPublicToHexAddress(keyPair->publicKey()));

--- a/bcos-executor/test/unittest/libprecompiled/VRFPrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/VRFPrecompiledTest.cpp
@@ -23,6 +23,7 @@
 #include "vm/gas_meter/GasInjector.h"
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/hash/SM3.h"
+#include <bit>
 #include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
 #include "bcos-crypto/signature/sm2/SM2Crypto.h"
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
@@ -86,9 +87,9 @@ void testVRFVerify(VRFPrecompiledFixture _fixture)
     std::string input = "abcd";
     bytes vrfPublicKey;
     vrfPublicKey.resize(32);
-    CInputBuffer privateKey{
-        (const char*)keyPair->secretKey()->data().data(), keyPair->secretKey()->size()};
-    COutputBuffer publicKey{(char*)vrfPublicKey.data(), vrfPublicKey.size()};
+    CInputBuffer privateKey{std::bit_cast<const char*>(keyPair->secretKey()->data().data()),
+        keyPair->secretKey()->size()};
+    COutputBuffer publicKey{std::bit_cast<char*>(vrfPublicKey.data()), vrfPublicKey.size()};
     // derive the public key
     std::cout << "try to wedpr_curve25519_vrf_derive_public_key" << std::endl;
     auto ret = wedpr_curve25519_vrf_derive_public_key(&privateKey, &publicKey);
@@ -97,11 +98,11 @@ void testVRFVerify(VRFPrecompiledFixture _fixture)
 
     // generate proof
     bytes inputBytes = bytes(input.begin(), input.end());
-    CInputBuffer inputMsg{(const char*)inputBytes.data(), inputBytes.size()};
+    CInputBuffer inputMsg{std::bit_cast<const char*>(inputBytes.data()), inputBytes.size()};
     bytes vrfProof;
     size_t proofSize = 96;
     vrfProof.resize(proofSize);
-    COutputBuffer proof{(char*)vrfProof.data(), proofSize};
+    COutputBuffer proof{std::bit_cast<char*>(vrfProof.data()), proofSize};
     std::cout << "try to wedpr_curve25519_vrf_prove_utf8" << std::endl;
     ret = wedpr_curve25519_vrf_prove_utf8(&privateKey, &inputMsg, &proof);
     BOOST_CHECK_EQUAL(ret, WEDPR_SUCCESS);

--- a/bcos-executor/tools/inject_meter.cpp
+++ b/bcos-executor/tools/inject_meter.cpp
@@ -28,6 +28,7 @@
 #include "src/validator.h"
 #include "src/wast-lexer.h"
 #include "vm/gas_meter/GasInjector.h"
+#include <bit>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -62,7 +63,8 @@ int main(int argc, char* argv[])
             ReadBinaryOptions options(
                 defaultFeature, s_log_stream.get(), true, kStopOnFirstError, true);
             result = ReadBinaryIr(p.filename().generic_string().c_str(),
-                (const char*)ret.byteCode->data(), ret.byteCode->size(), options, &errors, &module);
+                std::bit_cast<const char*>(ret.byteCode->data()), ret.byteCode->size(), options,
+                &errors, &module);
             if (Succeeded(result))
             {
                 ValidateOptions voptions(defaultFeature);
@@ -71,7 +73,8 @@ int main(int argc, char* argv[])
                 {
                     ofstream out("metric_" + p.filename().generic_string(),
                         std::ofstream::out | std::ofstream::binary | std::ofstream::trunc);
-                    out.write((const char*)ret.byteCode->data(), ret.byteCode->size());
+                    out.write(std::bit_cast<const char*>(ret.byteCode->data()),
+                        ret.byteCode->size());
                     out.close();
                     cout << "InjectMeter success" << endl;
                     return 0;

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -3,7 +3,6 @@
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/Entry.h"
-// #include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Exceptions.h"
 #include <evmc/evmc.h>
@@ -231,7 +230,8 @@ public:
                 auto addressView = std::span(address.bytes);
                 m_tableName.reserve(ledger::SYS_DIRECTORY::USER_APPS.size() + addressView.size());
                 m_tableName.append(ledger::SYS_DIRECTORY::USER_APPS);
-                m_tableName.append((const char*)addressView.data(), addressView.size());
+                m_tableName.append(
+                    std::bit_cast<const char*>(addressView.data()), addressView.size());
             }
             else
             {

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -3,7 +3,7 @@
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/Entry.h"
-#include "bcos-framework/storage/LegacyStorageMethods.h"
+// #include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Exceptions.h"
 #include <evmc/evmc.h>
@@ -279,7 +279,7 @@ public:
             storage,
             [](const bcos::Address& address) {
                 evmc_address evmcAddress;
-                ::ranges::copy(address, evmcAddress.bytes);
+                ::ranges::copy(address, std::span(evmcAddress.bytes).data());
                 return evmcAddress;
             }(address),
             binaryAddress)

--- a/bcos-framework/bcos-framework/protocol/LogEntry.h
+++ b/bcos-framework/bcos-framework/protocol/LogEntry.h
@@ -20,6 +20,7 @@
 #pragma once
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <bit>
 #include <gsl/span>
 
 namespace bcos::protocol
@@ -38,7 +39,10 @@ public:
     {}
     ~LogEntry() noexcept = default;
 
-    std::string_view address() const { return {(const char*)m_address.data(), m_address.size()}; }
+    std::string_view address() const
+    {
+        return {std::bit_cast<const char*>(m_address.data()), m_address.size()};
+    }
     gsl::span<const bcos::h256> topics() const { return {m_topics.data(), m_topics.size()}; }
     bcos::bytesConstRef data() const { return ref(m_data); }
     bytes takeAddress() { return std::move(m_address); }

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -11,6 +11,7 @@
 #include <boost/iostreams/stream.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
+#include <bit>
 #include <cstdint>
 #include <initializer_list>
 #include <type_traits>
@@ -303,14 +304,14 @@ private:
     template <typename T>
     [[nodiscard]] auto inputValueView(const T& value) const -> std::string_view
     {
-        std::string_view view((const char*)value.data(), value.size());
+        std::string_view view(std::bit_cast<const char*>(value.data()), value.size());
         return view;
     }
 
     template <typename T>
     [[nodiscard]] auto inputValueView(const std::shared_ptr<T>& value) const -> std::string_view
     {
-        std::string_view view((const char*)value->data(), value->size());
+        std::string_view view(std::bit_cast<const char*>(value->data()), value->size());
         return view;
     }
 

--- a/bcos-framework/bcos-framework/testutils/faker/FakeTransaction.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeTransaction.h
@@ -28,6 +28,7 @@
 #include "bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionImpl.h"
 #include "bcos-utilities/Common.h"
+#include <bit>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -92,7 +93,8 @@ inline Transaction::Ptr testTransaction(CryptoSuite::Ptr _cryptoSuite,
     auto addr = _keyPair->address(_cryptoSuite->hashImpl());
     if (isCheck)
     {
-        BOOST_CHECK(pbTransaction->sender() == std::string_view((char*)addr.data(), 20));
+        BOOST_CHECK(pbTransaction->sender() ==
+                    std::string_view(std::bit_cast<const char*>(addr.data()), 20));
     }
     bcos::bytes encodedData;
     pbTransaction->encode(encodedData);
@@ -140,8 +142,9 @@ inline Transaction::Ptr fakeTransaction(CryptoSuite::Ptr _cryptoSuite, const std
     }
     std::string inputStr = "testTransaction";
     bytes input = asBytes(inputStr);
-    return fakeTransaction(_cryptoSuite, keyPair, std::string_view((char*)_to.data(), _to.size()),
-        input, nonce, blockLimit, chainId, groupId);
+    return fakeTransaction(_cryptoSuite, keyPair,
+        std::string_view(std::bit_cast<const char*>(_to.data()), _to.size()), input, nonce,
+        blockLimit, chainId, groupId);
 }
 
 inline Transaction::Ptr fakeWeb3Tx(CryptoSuite::Ptr _cryptoSuite, std::string nonce,

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -31,6 +31,7 @@
 #include <bcos-front/FrontServiceFactory.h>
 #include <bcos-tars-protocol/protocol/GroupNodeInfoImpl.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <bit>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -104,7 +105,8 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeID_withoutCallback)
                 frontService->moduleID2MessageDispatcher().end());
 
     frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-        bytesConstRef((unsigned char*)data.data(), data.size()), 0, CallbackFunc());
+        bytesConstRef(std::bit_cast<const unsigned char*>(data.data()), data.size()), 0,
+        CallbackFunc());
     BOOST_CHECK(frontService->callback().empty());
     f.get();
 }
@@ -169,11 +171,12 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeID_callback)
             p.set_value(true);
         };
         frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()), 0, callback);
+            bytesConstRef(std::bit_cast<const unsigned char*>(data.data()), data.size()), 0,
+            callback);
         BOOST_CHECK(!frontService->callback().empty());
         auto uuid = frontService->callback().begin()->first;
         frontService->asyncSendResponse(uuid, moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()),
+            bytesConstRef(std::bit_cast<const unsigned char*>(data.data()), data.size()),
             [](Error::Ptr _error) { (void)_error; });
         f.get();
         BOOST_CHECK(frontService->callback().empty());
@@ -207,7 +210,8 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDcmak_timeout)
         };
 
         frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()), 2000, callback);
+            bytesConstRef(std::bit_cast<const unsigned char*>(data.data()), data.size()), 2000,
+            callback);
 
         BOOST_CHECK(frontService->callback().size() == 1);
         std::future<void> barrier_future = barrier.get_future();
@@ -241,7 +245,8 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendBroadcastMessage)
 
     task::syncWait(
         frontService->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE, moduleID,
-            ::ranges::views::single(bytesConstRef((unsigned char*)data.data(), data.size()))));
+            ::ranges::views::single(
+                bytesConstRef(std::bit_cast<const unsigned char*>(data.data()), data.size()))));
     BOOST_CHECK(frontService->callback().empty());
     f.get();
 }
@@ -270,7 +275,7 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDs)
                 frontService->moduleID2MessageDispatcher().end());
 
     frontService->asyncSendMessageByNodeIDs(moduleID, bcos::crypto::NodeIDs{dstNodeID},
-        bytesConstRef((unsigned char*)data.data(), data.size()));
+        bytesConstRef(std::bit_cast<const unsigned char*>(data.data()), data.size()));
 
     BOOST_CHECK(frontService->callback().empty());
     f.get();
@@ -306,7 +311,8 @@ BOOST_AUTO_TEST_CASE(testFrontService_loopTimeout)
         };
 
         frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()), 2000, callback);
+            bytesConstRef(std::bit_cast<const unsigned char*>(data.data()), data.size()), 2000,
+            callback);
     }
 
     BOOST_CHECK(frontService->callback().size() == barriers.size());

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -31,6 +31,7 @@
 #include "bcos-gateway/libratelimit/GatewayRateLimiter.h"
 #include "bcos-utilities/BoostLog.h"
 #include "filter/ReadOnlyFilter.h"
+#include <bit>
 
 
 namespace bcos::gateway
@@ -133,7 +134,7 @@ public:
             {
                 auto payload = message->payload();
                 int respCode = boost::lexical_cast<int>(std::string_view(
-                    reinterpret_cast<const char*>(payload.data()), payload.size()));
+                    std::bit_cast<const char*>(payload.data()), payload.size()));
                 // the peer gateway not response not ok ,it means the gateway not dispatch the
                 // message successfully,find another gateway and try again
                 if (respCode != bcos::protocol::CommonError::SUCCESS)

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -34,6 +34,7 @@
 #include "bcos-utilities/IOServicePool.h"
 #include <openssl/evp.h>
 #include <openssl/x509.h>
+#include <bit>
 #include <chrono>
 #include <exception>
 #include <optional>
@@ -440,7 +441,8 @@ std::shared_ptr<boost::asio::ssl::context> GatewayFactory::buildSSLContext(
                                           *_smCertConfig.enNodeKey));
             }
         }
-        std::string enNodeKeyStr((const char*)enNodeKeyContent->data(), enNodeKeyContent->size());
+        std::string enNodeKeyStr(
+            std::bit_cast<const char*>(enNodeKeyContent->data()), enNodeKeyContent->size());
         if (SSL_CTX_use_enc_PrivateKey(
                 sslContext->native_handle(), toEvpPkey(enNodeKeyStr.c_str())) <= 0)
         {

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -23,6 +23,7 @@
 #include "bcos-gateway/Common.h"
 #include "bcos-gateway/libp2p/Common.h"
 #include "bcos-utilities/ZstdCompress.h"
+#include <bit>
 #include <boost/asio/detail/socket_ops.hpp>
 
 using namespace bcos;
@@ -261,7 +262,7 @@ bool P2PMessage::encode(bcos::bytes& _buffer)
     if (isCompressSuccess)
     {
         P2PMSG_LOG(TRACE) << LOG_DESC("compress payload success")
-                          << LOG_KV("compressedData", (char*)compressData.data())
+                          << LOG_KV("compressedData", std::bit_cast<char*>(compressData.data()))
                           << LOG_KV("packageType", m_packetType) << LOG_KV("ext", m_ext)
                           << LOG_KV("seq", m_seq);
         _buffer.insert(_buffer.end(), compressData.begin(), compressData.end());

--- a/bcos-gateway/bcos-gateway/libp2p/router/RouterTableImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/router/RouterTableImpl.cpp
@@ -22,6 +22,7 @@
 #include "../P2PSession.h"
 #include "bcos-tars-protocol/Common.h"
 #include "bcos-utilities/BoostLog.h"
+#include <bit>
 #include <boost/algorithm/string/join.hpp>
 
 using namespace bcos;
@@ -45,7 +46,7 @@ void RouterTable::encode(bcos::bytes& _encodedData)
 void RouterTable::decode(bcos::bytesConstRef _decodedData)
 {
     tars::TarsInputStream<tars::BufferReader> input;
-    input.setBuffer((const char*)_decodedData.data(), _decodedData.size());
+    input.setBuffer(std::bit_cast<const char*>(_decodedData.data()), _decodedData.size());
     WriteGuard writeGuard(x_routerEntries);
     m_inner()->readFrom(input);
     // decode into m_routerEntries

--- a/bcos-gateway/bcos-gateway/protocol/GatewayNodeStatus.cpp
+++ b/bcos-gateway/bcos-gateway/protocol/GatewayNodeStatus.cpp
@@ -20,6 +20,7 @@
 #include "GatewayNodeStatus.h"
 #include "bcos-tars-protocol/Common.h"
 #include "bcos-tars-protocol/protocol/GroupNodeInfoImpl.h"
+#include <bit>
 using namespace bcos;
 using namespace bcos::protocol;
 using namespace bcos::gateway;
@@ -48,7 +49,7 @@ bytesPointer GatewayNodeStatus::encode()
 void GatewayNodeStatus::decode(bytesConstRef _data)
 {
     tars::TarsInputStream<tars::BufferReader> input;
-    input.setBuffer((const char*)_data.data(), _data.size());
+    input.setBuffer(std::bit_cast<const char*>(_data.data()), _data.size());
     m_tarsStatus->readFrom(input);
     // decode into m_groupNodeInfos
     m_groupNodeInfos.clear();

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -60,6 +60,7 @@
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstddef>
 #include <cstdlib>
 #include <exception>
@@ -308,7 +309,8 @@ void Ledger::asyncPrewriteBlock(bcos::storage::StorageInterface::Ptr storage,
                 for (size_t i = range.begin(); i < range.end(); ++i)
                 {
                     auto hash = transactionsBlock->transactionHash(i);
-                    txsHash[i] = std::string((char*)hash.data(), hash.size());
+                    txsHash[i] =
+                        std::string(std::bit_cast<const char*>(hash.data()), hash.size());
                     auto receipt = blockReceipts[i];
                     if (receipt->status() != 0)
                     {
@@ -474,9 +476,11 @@ bcos::Error::Ptr Ledger::storeTransactionsAndReceipts(
             for (size_t i = range.begin(); i < range.end(); ++i)
             {
                 auto hash = blockTxs ? blockTxs->at(i)->hash() : transactions[i]->hash();
-                txsHash[i] = std::string((char*)hash.data(), hash.size());
+                txsHash[i] = std::string(std::bit_cast<const char*>(hash.data()), hash.size());
                 blockReceipts[i]->encode(receipts[i]);
-                receiptsView[i] = std::string_view((char*)receipts[i].data(), receipts[i].size());
+                receiptsView[i] =
+                    std::string_view(std::bit_cast<const char*>(receipts[i].data()),
+                        receipts[i].size());
             }
         });
     auto promise = std::make_shared<std::promise<bcos::Error::Ptr>>();

--- a/bcos-ledger/test/mock/MockKeyFactor.h
+++ b/bcos-ledger/test/mock/MockKeyFactor.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <bcos-crypto/interfaces/crypto/KeyFactory.h>
+#include <bit>
 
 using namespace bcos;
 using namespace bcos::crypto;
@@ -54,8 +55,8 @@ public:
 
     const bytes& data() const override { return *m_keyData; }
     size_t size() const override { return m_keyData->size(); }
-    char* mutableData() override { return (char*)m_keyData->data(); }
-    const char* constData() const override { return (const char*)m_keyData->data(); }
+    char* mutableData() override { return std::bit_cast<char*>(m_keyData->data()); }
+    const char* constData() const override { return std::bit_cast<const char*>(m_keyData->data()); }
     bytes encode() const override { return *m_keyData; }
     void decode(bytesConstRef _data) override { *m_keyData = _data.toBytes(); }
 

--- a/bcos-ledger/test/unittests/ledger/LedgerImplTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerImplTest.cpp
@@ -19,6 +19,7 @@
 #include <boost/algorithm/hex.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/throw_exception.hpp>
+#include <bit>
 #include <iterator>
 #include <optional>
 
@@ -29,7 +30,7 @@ namespace std
 ostream& operator<<(ostream& os, std::vector<tars::Char> const& buffer)
 {
     auto hexBuffer = boost::algorithm::hex_lower(buffer);
-    os << string_view{(const char*)hexBuffer.data(), hexBuffer.size()};
+    os << string_view{std::bit_cast<const char*>(hexBuffer.data()), hexBuffer.size()};
     return os;
 }
 
@@ -44,8 +45,8 @@ ostream& operator<<(
 ostream& operator<<(ostream& os, std::array<std::byte, 32> const& buffer)
 {
     std::string hex;
-    boost::algorithm::hex_lower((const char*)buffer.data(),
-        (const char*)buffer.data() + buffer.size(), std::back_inserter(hex));
+    boost::algorithm::hex_lower(std::bit_cast<const char*>(buffer.data()),
+        std::bit_cast<const char*>(buffer.data()) + buffer.size(), std::back_inserter(hex));
     os << hex;
     return os;
 }

--- a/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
@@ -56,6 +56,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
+#include <bit>
 #include <memory>
 
 using namespace bcos;
@@ -634,7 +635,8 @@ BOOST_AUTO_TEST_CASE(getBlockNumberByHash)
 
             Entry numberEntry;
             m_storage->asyncSetRow(SYS_HASH_2_NUMBER,
-                std::string_view((const char*)hash.data(), hash.size()), std::move(numberEntry),
+                std::string_view(std::bit_cast<const char*>(hash.data()), hash.size()),
+                std::move(numberEntry),
                 [&](auto&& error) {
                     BOOST_CHECK(!error);
 
@@ -1489,7 +1491,8 @@ BOOST_AUTO_TEST_CASE(genesisBlockWithAllocs)
                 bcos::bytesConstRef((const uint8_t*)codeView.data(), codeView.size()));
             auto codeHashBytes = codeHash.asBytes();
             BOOST_CHECK_EQUAL(codeHashEntry->get(),
-                std::string_view((const char*)codeHashBytes.data(), codeHashBytes.size()));
+                std::string_view(
+                    std::bit_cast<const char*>(codeHashBytes.data()), codeHashBytes.size()));
         }
     }());
 }

--- a/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
@@ -23,6 +23,7 @@
 #include <bcos-framework/protocol/CommonError.h>
 #include <bcos-framework/protocol/ProtocolTypeDef.h>
 #include <bcos-framework/storage/Table.h>
+#include <bit>
 
 using namespace bcos;
 using namespace bcos::consensus;
@@ -259,7 +260,7 @@ void LedgerStorage::asyncPutProposal(std::string const& _dbName, std::string con
     // Note: asyncPut now is a sync implementation, but no need to async here since this
     // timeout-head is only between 5-10ms
     m_storage->asyncPut(_dbName, _key,
-        std::string((const char*)_committedData->data(), _committedData->size()),
+        std::string(std::bit_cast<const char*>(_committedData->data()), _committedData->size()),
         [startT, _dbName, _committedData, _key, _proposalIndex, _retryTime, self](
             Error::UniquePtr&& _error) {
             if (_error == nullptr)

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -43,6 +43,7 @@
 #include <boost/core/ignore_unused.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
+#include <bit>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -407,7 +408,8 @@ bcos::rpc::Web3JsonRpcImpl::Ptr RpcFactory::buildWeb3JsonRpc(
         WS_RAW_MESSAGE_TYPE, [web3JsonRpc](std::shared_ptr<bcos::boostssl::MessageFace> msg,
                                  std::shared_ptr<bcos::boostssl::ws::WsSession> session) {
             auto payload = msg->payload();
-            std::string_view strRequest((char*)payload->data(), payload->size());
+            std::string_view strRequest(
+                std::bit_cast<const char*>(payload->data()), payload->size());
 
             // RPC_LOG(INFO) << "web3 websocket request" << LOG_KV("request", strRequest);
 

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -43,6 +43,7 @@
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/throw_exception.hpp>
+#include <bit>
 #include <exception>
 #include <iterator>
 #include <stdexcept>
@@ -78,7 +79,7 @@ void JsonRpcImpl_2_0::handleRpcRequest(
     std::shared_ptr<boostssl::MessageFace> _msg, std::shared_ptr<boostssl::ws::WsSession> _session)
 {
     auto buffer = _msg->payload();
-    auto req = std::string_view((const char*)buffer->data(), buffer->size());
+    auto req = std::string_view(std::bit_cast<const char*>(buffer->data()), buffer->size());
 
     auto start = std::chrono::high_resolution_clock::now();
     auto seq = _msg->seq();

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcInterface.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcInterface.cpp
@@ -5,6 +5,7 @@
 #include <boost/iostreams/device/back_inserter.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/stream.hpp>
+#include <bit>
 
 using namespace bcos::rpc;
 
@@ -159,7 +160,8 @@ void JsonRpcInterface::onRPCRequest(std::string_view _requestBody, Sender _sende
                     RPC_IMPL_LOG(TRACE)
                         << LOG_BADGE("onRPCRequest")
                         << LOG_KV("response",
-                               std::string_view((const char*)strResp.data(), strResp.size()));
+                               std::string_view(
+                                   std::bit_cast<const char*>(strResp.data()), strResp.size()));
                 }
                 _sender(std::move(strResp));
             });
@@ -191,7 +193,8 @@ void JsonRpcInterface::onRPCRequest(std::string_view _requestBody, Sender _sende
     RPC_IMPL_LOG(DEBUG) << LOG_BADGE("onRPCRequest") << LOG_DESC("response with exception")
                         << LOG_KV("request", _requestBody)
                         << LOG_KV("response",
-                               std::string_view((const char*)strResp.data(), strResp.size()));
+                               std::string_view(
+                                   std::bit_cast<const char*>(strResp.data()), strResp.size()));
     _sender(std::move(strResp));
 }
 

--- a/bcos-rpc/test/unittests/rpc/FilterSystemTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/FilterSystemTest.cpp
@@ -4,6 +4,7 @@
 #include <bcos-rpc/filter/FilterSystem.h>
 #include <bcos-utilities/Common.h>
 #include <json/json.h>
+#include <bit>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -34,7 +35,8 @@ public:
                 request, [&promise](bcos::bytes resp) { promise.set_value(std::move(resp)); });
             auto jsonBytes = promise.get_future().get();
             std::string_view json(
-                (char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
+                std::bit_cast<const char*>(jsonBytes.data()),
+                std::bit_cast<const char*>(jsonBytes.data()) + jsonBytes.size());
             reader.parse(json.begin(), json.end(), value);
         }
         else

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -36,6 +36,7 @@
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
 #include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <bit>
 #include <ostream>
 #include <string_view>
 
@@ -66,7 +67,8 @@ public:
                 request, [&promise](bcos::bytes resp) { promise.set_value(std::move(resp)); });
             auto jsonBytes = promise.get_future().get();
             std::string_view json(
-                (char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
+                std::bit_cast<const char*>(jsonBytes.data()),
+                std::bit_cast<const char*>(jsonBytes.data()) + jsonBytes.size());
             reader.parse(json.begin(), json.end(), value);
         }
         else

--- a/bcos-scheduler/test/mock/MockExecutorForCall.h
+++ b/bcos-scheduler/test/mock/MockExecutorForCall.h
@@ -4,6 +4,7 @@
 #include "MockExecutor.h"
 #include "bcos-framework/executor/ExecutionMessage.h"
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
+#include <bit>
 #include <boost/lexical_cast.hpp>
 #include <tuple>
 
@@ -58,7 +59,7 @@ public:
         // BOOST_CHECK_EQUAL(input->from().size(), 40);
 
         auto inputBytes = input->data();
-        std::string inputStr((char*)inputBytes.data(), inputBytes.size());
+        std::string inputStr(std::bit_cast<const char*>(inputBytes.data()), inputBytes.size());
 
         BOOST_CHECK_EQUAL(inputStr, "Hello world! request");
 

--- a/bcos-scheduler/test/testDmcExecutor.cpp
+++ b/bcos-scheduler/test/testDmcExecutor.cpp
@@ -18,6 +18,7 @@
 #include <bcos-framework/protocol/TransactionFactory.h>
 #include <bcos-framework/protocol/TransactionReceiptFactory.h>
 #include <bcos-utilities/Common.h>
+#include <bit>
 #include <boost/test/unit_test.hpp>
 #include <string>
 
@@ -110,7 +111,8 @@ BOOST_AUTO_TEST_CASE(stateSwitchTest)
     dmcExecutor->setOnTxFinishedHandler(
         [&dmcFlagStruct](bcos::protocol::ExecutionMessage::UniquePtr output) {
             auto outputBytes = output->data();
-            std::string outputStr((char*)outputBytes.data(), outputBytes.size());
+            std::string outputStr(
+                std::bit_cast<const char*>(outputBytes.data()), outputBytes.size());
             SCHEDULER_LOG(DEBUG) << LOG_KV("output data is ", outputStr);
             if (outputStr == "Call Finished!")
             {
@@ -274,7 +276,8 @@ BOOST_AUTO_TEST_CASE(keyLocksTest)
     dmcExecutor->setOnTxFinishedHandler(
         [&dmcFlagStruct](bcos::protocol::ExecutionMessage::UniquePtr output) {
             auto outputBytes = output->data();
-            std::string outputStr((char*)outputBytes.data(), outputBytes.size());
+            std::string outputStr(
+                std::bit_cast<const char*>(outputBytes.data()), outputBytes.size());
             SCHEDULER_LOG(DEBUG) << LOG_KV("output data is ", outputStr);
             if (outputStr == "Call Finished!")
             {

--- a/bcos-scheduler/test/testScheduler.cpp
+++ b/bcos-scheduler/test/testScheduler.cpp
@@ -23,6 +23,7 @@
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/hash/SM3.h>
 #include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bit>
 #include <bcos-crypto/interfaces/crypto/KeyPairInterface.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-framework/executor/NativeExecutionMessage.h>
@@ -228,7 +229,7 @@ BOOST_AUTO_TEST_CASE(call)
         BOOST_CHECK_GT(receipt->gasUsed(), 0);
         auto output = receipt->output();
 
-        std::string outputStr((char*)output.data(), output.size());
+        std::string outputStr(std::bit_cast<const char*>(output.data()), output.size());
         BOOST_CHECK_EQUAL(outputStr, "Hello world! response");
     }
 

--- a/bcos-scheduler/test/testSchedulerImpl.cpp
+++ b/bcos-scheduler/test/testSchedulerImpl.cpp
@@ -23,6 +23,7 @@
 #include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-framework/executor/NativeExecutionMessage.h>
+#include <bit>
 #include <bcos-framework/storage/Table.h>
 #include <bcos-storage/RocksDBStorage.h>
 #include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
@@ -534,7 +535,7 @@ BOOST_AUTO_TEST_CASE(call)
         BOOST_CHECK_GT(receipt->gasUsed(), 0);
         auto output = receipt->output();
 
-        std::string outputStr((char*)output.data(), output.size());
+        std::string outputStr(std::bit_cast<const char*>(output.data()), output.size());
         SCHEDULER_LOG(DEBUG) << LOG_KV("outputStr", outputStr);
         BOOST_CHECK_EQUAL(outputStr, "Hello world! response");
     }

--- a/bcos-sdk/SWIG/Helper.h
+++ b/bcos-sdk/SWIG/Helper.h
@@ -3,6 +3,7 @@
 #include "bcos-cpp-sdk/tarsRPC/Handle.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/FixedBytes.h"
+#include <bit>
 #include <oneapi/tbb/concurrent_queue.h>
 #include <memory>
 #include <string_view>
@@ -12,13 +13,14 @@ namespace bcos::sdk::swig
 template <class Buffer>
 bcos::bytesConstRef toBytesConstRef(Buffer const& input)
 {
-    return {(const bcos::byte*)input.data(), input.size()};
+    return {std::bit_cast<const bcos::byte*>(input.data()), input.size()};
 }
 
 template <class Buffer>
 bcos::bytes toBytes(Buffer const& input)
 {
-    return {(const bcos::byte*)input.data(), (const bcos::byte*)input.data() + input.size()};
+    return {std::bit_cast<const bcos::byte*>(input.data()),
+        std::bit_cast<const bcos::byte*>(input.data()) + input.size()};
 }
 bcos::bytes toBytes(char* STRING, size_t LENGTH);
 
@@ -37,14 +39,14 @@ std::string toString(Input const& input)
     }
     else
     {
-        return {(const char*)input.data(), input.size()};
+        return {std::bit_cast<const char*>(input.data()), input.size()};
     }
 }
 
 template <class Buffer>
 std::string_view toStringView(Buffer input)
 {
-    return {(const char*)input.data(), input.size()};
+    return {std::bit_cast<const char*>(input.data()), input.size()};
 }
 
 template <class Input>

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABITypeCodec.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABITypeCodec.cpp
@@ -25,6 +25,7 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <bit>
 #include <climits>
 #include <exception>
 #include <iterator>
@@ -369,7 +370,7 @@ void ContractABITypeCodecSolImpl::deserialize(
                           .getCroppedData(_offset + MAX_BYTE_LENGTH, static_cast<size_t>(len))
                           .toBytes();
 
-    _out.assign((const char*)bytesValue.data(), bytesValue.size());
+    _out.assign(std::bit_cast<const char*>(bytesValue.data()), bytesValue.size());
 }
 
 // AbstractType

--- a/bcos-sdk/bcos-cpp-sdk/utilities/receipt/ReceiptBuilder.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/receipt/ReceiptBuilder.cpp
@@ -20,6 +20,7 @@
 
 #include "ReceiptBuilder.h"
 #include "bcos-tars-protocol/impl/TarsHashable.h"
+#include <bit>
 
 bcostars::ReceiptDataUniquePtr bcos::cppsdk::utilities::ReceiptBuilder::createReceiptData(
     const std::string& _gasUsed, const std::string& _contractAddress, const bcos::bytes& _output,
@@ -83,7 +84,7 @@ std::string bcos::cppsdk::utilities::ReceiptBuilder::decodeReceiptDataToJsonObj(
     const bcos::bytes& _receiptBytes)
 {
     tars::TarsInputStream<tars::BufferReader> inputStream;
-    inputStream.setBuffer((const char*)_receiptBytes.data(), _receiptBytes.size());
+    inputStream.setBuffer(std::bit_cast<const char*>(_receiptBytes.data()), _receiptBytes.size());
     bcostars::TransactionReceiptData receiptData;
     receiptData.readFrom(inputStream);
     auto receiptDataJson = TarsReceiptDataWriteToJsonString(receiptData);

--- a/bcos-sdk/bcos-cpp-sdk/utilities/tx/TransactionBuilder.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/tx/TransactionBuilder.cpp
@@ -26,6 +26,7 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <bit>
 #include <time.h>
 
 #include <chrono>
@@ -95,7 +96,7 @@ bcostars::TransactionDataUniquePtr TransactionBuilder::decodeTransactionData(
     const bcos::bytes& _txBytes)
 {
     tars::TarsInputStream<tars::BufferReader> inputStream;
-    inputStream.setBuffer((const char*)_txBytes.data(), _txBytes.size());
+    inputStream.setBuffer(std::bit_cast<const char*>(_txBytes.data()), _txBytes.size());
     auto txData = std::make_unique<bcostars::TransactionData>();
     txData->readFrom(inputStream);
     return txData;
@@ -239,7 +240,7 @@ bytesConstPtr TransactionBuilder::encodeTransaction(const bcostars::Transaction&
 bcostars::TransactionUniquePtr TransactionBuilder::decodeTransaction(const bcos::bytes& _txBytes)
 {
     tars::TarsInputStream<tars::BufferReader> inputStream;
-    inputStream.setBuffer((const char*)_txBytes.data(), _txBytes.size());
+    inputStream.setBuffer(std::bit_cast<const char*>(_txBytes.data()), _txBytes.size());
     auto tx = std::make_unique<bcostars::Transaction>();
     tx->readFrom(inputStream);
     return tx;

--- a/bcos-sdk/sample/rpc/rpc_test.cpp
+++ b/bcos-sdk/sample/rpc/rpc_test.cpp
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <bit>
 #include <unistd.h>
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
@@ -178,7 +179,7 @@ int main(int argc, char** argv)
     {
         is_sm_ssl = 0;
     }
-    auto config = bcos_sdk_create_config(is_sm_ssl, (char*)host, port);
+    auto config = bcos_sdk_create_config(is_sm_ssl, std::bit_cast<char*>(host), port);
     config->disable_ssl = 1;
     // check success or not
     std::thread threads[100];

--- a/bcos-sdk/sample/tars/performanceTransfer.cpp
+++ b/bcos-sdk/sample/tars/performanceTransfer.cpp
@@ -13,9 +13,11 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/thread/latch.hpp>
 #include <boost/throw_exception.hpp>
+#include <bit>
 #include <atomic>
 #include <chrono>
 #include <exception>
+#include <array>
 #include <string>
 #include <thread>
 
@@ -26,9 +28,9 @@ const static std::string DAG_TRANSFER_ADDRESS = "0000000000000000000000000000000
 
 static std::string generateNonce(int64_t number)
 {
-    std::string nonce(8, '\0');
-    std::copy(
-        reinterpret_cast<char*>(&number), reinterpret_cast<char*>(&number) + 8, nonce.begin());
+    auto raw = std::bit_cast<std::array<char, sizeof(number)>>(number);
+    std::string nonce(sizeof(number), '\0');
+    std::copy(raw.begin(), raw.end(), nonce.begin());
     return nonce;
 }
 

--- a/bcos-sealer/bcos-sealer/VRFBasedSealer.cpp
+++ b/bcos-sealer/bcos-sealer/VRFBasedSealer.cpp
@@ -24,12 +24,14 @@
 #include "bcos-framework/sealer/VrfCurveType.h"
 #include "bcos-pbft/core/ConsensusConfig.h"
 #include "bcos-txpool/txpool/storage/MemoryStorage.h"
+#include <bit>
 #include <bcos-codec/wrapper/CodecWrapper.h>
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
 #include <bcos-framework/protocol/GlobalConfig.h>
 #include <bcos-txpool/TxPool.h>
 #include <wedpr-crypto/WedprCrypto.h>
 #include <boost/endian/conversion.hpp>
+#include <bit>
 #include <cstdint>
 
 namespace bcos::sealer
@@ -77,7 +79,7 @@ uint16_t VRFBasedSealer::generateTransactionForRotating(bcos::protocol::Block::P
             return SealBlockResult::WAIT_FOR_LATEST_BLOCK;
         }
         auto keyPair = _sealerConfig->keyPair();
-        CInputBuffer privateKey{reinterpret_cast<const char*>(keyPair->secretKey()->data().data()),
+        CInputBuffer privateKey{std::bit_cast<const char*>(keyPair->secretKey()->data().data()),
             keyPair->secretKey()->size()};
         bytes vrfPublicKey;
         bcos::bytes vrfProof;
@@ -88,30 +90,30 @@ uint16_t VRFBasedSealer::generateTransactionForRotating(bcos::protocol::Block::P
         auto blockNumberBigEndian = boost::endian::native_to_big(blockNumber);
         CInputBuffer inputMsg = {
             .data = blockNumberInput ?
-                        reinterpret_cast<const char*>(std::addressof(blockNumberBigEndian)) :
-                        reinterpret_cast<const char*>(blockHash.data()),
+                        std::bit_cast<const char*>(std::addressof(blockNumberBigEndian)) :
+                        std::bit_cast<const char*>(blockHash.data()),
             .len = blockNumberInput ? sizeof(blockNumberBigEndian) :
                                       static_cast<size_t>(blockHash.size())};
         if (vrfCurveType == sealer::VrfCurveType::CURVE25519)
         {
             vrfPublicKey.resize(curve25519PublicKeySize);
-            COutputBuffer publicKey{(char*)vrfPublicKey.data(), vrfPublicKey.size()};
+            COutputBuffer publicKey{std::bit_cast<char*>(vrfPublicKey.data()), vrfPublicKey.size()};
             // NOTE: curve25519 fits sm2 and secp256k1 private key value range, so if you want to
             // change elliptic curve, do think twice here.
             pubkeyDerive = wedpr_curve25519_vrf_derive_public_key(&privateKey, &publicKey);
 
             vrfProof.resize(curve25519VRFProofSize);
-            COutputBuffer proof{(char*)vrfProof.data(), curve25519VRFProofSize};
+            COutputBuffer proof{std::bit_cast<char*>(vrfProof.data()), curve25519VRFProofSize};
             auto vrfProve = wedpr_curve25519_vrf_prove_utf8(&privateKey, &inputMsg, &proof);
         }
         else if (vrfCurveType == sealer::VrfCurveType::SECKP256K1)
         {
             vrfPublicKey.resize(secp256k1PublicKeySize);
-            COutputBuffer publicKey{(char*)vrfPublicKey.data(), vrfPublicKey.size()};
+            COutputBuffer publicKey{std::bit_cast<char*>(vrfPublicKey.data()), vrfPublicKey.size()};
             pubkeyDerive = wedpr_secp256k1_vrf_derive_public_key(&privateKey, &publicKey);
 
             vrfProof.resize(secp256k1VRFProofSize);
-            COutputBuffer proof{(char*)vrfProof.data(), secp256k1VRFProofSize};
+            COutputBuffer proof{std::bit_cast<char*>(vrfProof.data()), secp256k1VRFProofSize};
             vrfProve = wedpr_secp256k1_vrf_prove_utf8(&privateKey, &inputMsg, &proof);
         }
 

--- a/bcos-sealer/test/VRFBasedSealerTest.cpp
+++ b/bcos-sealer/test/VRFBasedSealerTest.cpp
@@ -29,6 +29,7 @@
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
 #include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
 #include <wedpr-crypto/WedprUtilities.h>
+#include <bit>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <memory>
@@ -114,39 +115,40 @@ BOOST_AUTO_TEST_CASE(testVRFSecp256k1)
     blockFactory = createBlockFactory(cryptoSuite);
     keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
 
-    CInputBuffer privateKey{reinterpret_cast<const char*>(keyPair->secretKey()->data().data()),
+    CInputBuffer privateKey{std::bit_cast<const char*>(keyPair->secretKey()->data().data()),
         keyPair->secretKey()->size()};
     bytes vrfPublicKey;
     bcos::bytes vrfProof;
     int8_t vrfProve = -1;
     int8_t pubkeyDerive = -1;
     CInputBuffer inputMsg = {
-        .data = reinterpret_cast<const char*>("test"),
+        .data = "test",
         .len = 4,
     };
 
     vrfPublicKey.resize(sealer::secp256k1PublicKeySize);
-    COutputBuffer publicKey{(char*)vrfPublicKey.data(), vrfPublicKey.size()};
+    COutputBuffer publicKey{std::bit_cast<char*>(vrfPublicKey.data()), vrfPublicKey.size()};
     pubkeyDerive = wedpr_secp256k1_vrf_derive_public_key(&privateKey, &publicKey);
 
     vrfProof.resize(sealer::secp256k1VRFProofSize);
     // vrfProof.resize(200);
-    COutputBuffer proof{(char*)vrfProof.data(), sealer::secp256k1VRFProofSize};
+    COutputBuffer proof{std::bit_cast<char*>(vrfProof.data()), sealer::secp256k1VRFProofSize};
     vrfProve = wedpr_secp256k1_vrf_prove_utf8(&privateKey, &inputMsg, &proof);
     BOOST_CHECK(vrfProve == 0);
     BOOST_CHECK(pubkeyDerive == 0);
 
-    CInputBuffer publicKeyInput{
-        reinterpret_cast<const char*>(vrfPublicKey.data()), vrfPublicKey.size()};
+    CInputBuffer publicKeyInput{std::bit_cast<const char*>(vrfPublicKey.data()),
+        vrfPublicKey.size()};
 
     uint8_t isSuccessFlag = wedpr_secp256k1_vrf_is_valid_public_key(&publicKeyInput);
     BOOST_CHECK(isSuccessFlag == 0);
 
     bytes vrfProofHash;
     vrfProofHash.resize(32);
-    COutputBuffer proofHash{(char*)vrfProofHash.data(), vrfProofHash.size()};
+    COutputBuffer proofHash{std::bit_cast<char*>(vrfProofHash.data()), vrfProofHash.size()};
 
-    CInputBuffer proofBuffer{reinterpret_cast<const char*>(vrfProof.data()), vrfProof.size()};
+    CInputBuffer proofBuffer{
+        std::bit_cast<const char*>(vrfProof.data()), vrfProof.size()};
     uint8_t proofToHash = wedpr_secp256k1_vrf_proof_to_hash(&proofBuffer, &proofHash);
     BOOST_CHECK(proofToHash == 0);
 
@@ -154,7 +156,7 @@ BOOST_AUTO_TEST_CASE(testVRFSecp256k1)
     BOOST_CHECK(verifyFlag == 0);
 
     CInputBuffer inputMsgError = {
-        .data = reinterpret_cast<const char*>("test error"),
+        .data = "test error",
         .len = 10,
     };
 
@@ -165,8 +167,8 @@ BOOST_AUTO_TEST_CASE(testVRFSecp256k1)
     // check error public key
     bytes vrfPublicKeyError;
     vrfPublicKeyError.resize(sealer::secp256k1PublicKeySize);
-    CInputBuffer publicKeyError{
-        reinterpret_cast<const char*>(vrfPublicKeyError.data()), vrfPublicKeyError.size()};
+    CInputBuffer publicKeyError{std::bit_cast<const char*>(vrfPublicKeyError.data()),
+        vrfPublicKeyError.size()};
     int8_t verifyFlagErrorPublicKey =
         wedpr_secp256k1_vrf_verify_utf8(&publicKeyError, &inputMsg, &proofBuffer);
     BOOST_CHECK(verifyFlagErrorPublicKey == -1);
@@ -174,8 +176,8 @@ BOOST_AUTO_TEST_CASE(testVRFSecp256k1)
     // check error proof
     bytes vrfProofError;
     vrfProofError.resize(sealer::secp256k1VRFProofSize);
-    CInputBuffer proofBufferError{
-        reinterpret_cast<const char*>(vrfProofError.data()), vrfProofError.size()};
+    CInputBuffer proofBufferError{std::bit_cast<const char*>(vrfProofError.data()),
+        vrfProofError.size()};
 
     int8_t verifyFlagErrorProof =
         wedpr_secp256k1_vrf_verify_utf8(&publicKeyInput, &inputMsg, &proofBufferError);

--- a/bcos-security/bcos-security/BcosKmsDataEncryption.cpp
+++ b/bcos-security/bcos-security/BcosKmsDataEncryption.cpp
@@ -29,6 +29,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
+#include <bit>
 
 using namespace std;
 using namespace bcos;
@@ -108,18 +109,18 @@ std::string BcosKmsDataEncryption::encrypt(const std::string& data)
         std::generate(std::begin(ivData), std::end(ivData), std::ref(rbe));
 
         encData = m_symmetricEncrypt->symmetricEncrypt(
-            reinterpret_cast<const unsigned char*>(data.data()), data.size(),
-            reinterpret_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size(),
+            std::bit_cast<const unsigned char*>(data.data()), data.size(),
+            std::bit_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size(),
             ivData.data(), 16);
         encData->insert(encData->end(), ivData.begin(), ivData.end());
     }
     else
     {
         encData = m_symmetricEncrypt->symmetricEncrypt(
-            reinterpret_cast<const unsigned char*>(data.data()), data.size(),
-            reinterpret_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size());
+            std::bit_cast<const unsigned char*>(data.data()), data.size(),
+            std::bit_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size());
     }
-    std::string value((char*)encData->data(), encData->size());
+    std::string value(std::bit_cast<const char*>(encData->data()), encData->size());
 
     return value;
 }
@@ -132,17 +133,17 @@ std::string BcosKmsDataEncryption::decrypt(const std::string& data)
         size_t offsetIv = data.size() - 16;
         size_t cipherDataSize = data.size() - 16;
         decData = m_symmetricEncrypt->symmetricDecrypt(
-            reinterpret_cast<const unsigned char*>(data.data()), cipherDataSize,
-            reinterpret_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size(),
-            reinterpret_cast<const unsigned char*>(data.data() + offsetIv), 16);
+            std::bit_cast<const unsigned char*>(data.data()), cipherDataSize,
+            std::bit_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size(),
+            std::bit_cast<const unsigned char*>(data.data() + offsetIv), 16);
     }
     else
     {
         decData = m_symmetricEncrypt->symmetricDecrypt(
-            reinterpret_cast<const unsigned char*>(data.data()), data.size(),
-            reinterpret_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size());
+            std::bit_cast<const unsigned char*>(data.data()), data.size(),
+            std::bit_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size());
     }
-    std::string value((char*)decData->data(), decData->size());
+    std::string value(std::bit_cast<const char*>(decData->data()), decData->size());
 
     return value;
 }

--- a/bcos-security/bcos-security/BcosKmsKeyEncryption.cpp
+++ b/bcos-security/bcos-security/BcosKmsKeyEncryption.cpp
@@ -35,6 +35,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
+#include <bit>
 
 using namespace std;
 using namespace bcos;
@@ -106,7 +107,7 @@ std::shared_ptr<bytes> BcosKmsKeyEncryption::decryptContents(const std::shared_p
     bytesPointer decFileBytesBase64Ptr = nullptr;
     try
     {
-        std::string encContextsStr((const char*)content->data(), content->size());
+        std::string encContextsStr(std::bit_cast<const char*>(content->data()), content->size());
 
         bytes encFileBytes = fromHex(encContextsStr);
         BCOS_LOG(DEBUG) << LOG_BADGE("DECFILE") << LOG_DESC("Decrypt file contents")
@@ -126,8 +127,9 @@ std::shared_ptr<bytes> BcosKmsKeyEncryption::decryptContents(const std::shared_p
         // else
         //{
         decFileBytesBase64Ptr =
-            m_symmetricEncrypt->symmetricDecrypt((const unsigned char*)encFileBytes.data(),
-                encFileBytes.size(), (const unsigned char*)m_dataKey.data(), m_dataKey.size());
+            m_symmetricEncrypt->symmetricDecrypt(
+                std::bit_cast<const unsigned char*>(encFileBytes.data()), encFileBytes.size(),
+                std::bit_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size());
         //}
 
         BCOS_LOG(DEBUG) << "[ENCFILE] DecryptedFile Base64 key: "
@@ -150,7 +152,7 @@ std::shared_ptr<bytes> BcosKmsKeyEncryption::decryptFile(const std::string& file
     try
     {
         std::shared_ptr<bytes> keyContent = readContents(boost::filesystem::path(filename));
-        std::string encContextsStr((const char*)keyContent->data(), keyContent->size());
+        std::string encContextsStr(std::bit_cast<const char*>(keyContent->data()), keyContent->size());
         bytes encFileBytes = fromHex(encContextsStr);
         BCOS_LOG(DEBUG) << LOG_BADGE("ENCFILE") << LOG_DESC("Enc file contents")
                         << LOG_KV("string", encContextsStr) << LOG_KV("bytes", toHex(encFileBytes));
@@ -170,8 +172,9 @@ std::shared_ptr<bytes> BcosKmsKeyEncryption::decryptFile(const std::string& file
         // else
         // {
         decFileBytesBase64Ptr =
-            m_symmetricEncrypt->symmetricDecrypt((const unsigned char*)encFileBytes.data(),
-                encFileBytes.size(), (const unsigned char*)m_dataKey.data(), m_dataKey.size());
+            m_symmetricEncrypt->symmetricDecrypt(
+                std::bit_cast<const unsigned char*>(encFileBytes.data()), encFileBytes.size(),
+                std::bit_cast<const unsigned char*>(m_dataKey.data()), m_dataKey.size());
         //}
         BCOS_LOG(DEBUG) << "[ENCFILE] EncryptedFile Base64 key: "
                         << asString(*decFileBytesBase64Ptr) << endl;

--- a/bcos-security/bcos-security/HsmDataEncryption.cpp
+++ b/bcos-security/bcos-security/HsmDataEncryption.cpp
@@ -25,6 +25,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
+#include <bit>
 
 using namespace std;
 using namespace bcos;
@@ -52,10 +53,10 @@ std::string HsmDataEncryption::encrypt(uint8_t* data, size_t size)
     auto originIvData = ivData;
 
     bytesPointer encData = m_symmetricEncrypt->symmetricEncryptWithInternalKey(
-        reinterpret_cast<const unsigned char*>(data), size, m_encKeyIndex, ivData.data(),
+        std::bit_cast<const unsigned char*>(data), size, m_encKeyIndex, ivData.data(),
         SM4_IV_DATA_SIZE);
     // append iv data to end of encData
-    std::string value((char*)encData->data(), encData->size());
+    std::string value(std::bit_cast<const char*>(encData->data()), encData->size());
     value.insert(value.end(), originIvData.begin(), originIvData.end());
 
     return value;
@@ -66,7 +67,7 @@ std::string HsmDataEncryption::decrypt(uint8_t* data, size_t size)
     size_t cipherDataSize = size - SM4_IV_DATA_SIZE;
     bytesPointer decData = m_symmetricEncrypt->symmetricDecryptWithInternalKey(
         data, cipherDataSize, m_encKeyIndex, data + cipherDataSize, SM4_IV_DATA_SIZE);
-    std::string value((char*)decData->data(), decData->size());
+    std::string value(std::bit_cast<const char*>(decData->data()), decData->size());
 
     return value;
 }

--- a/bcos-security/bcos-security/HsmDataEncryption.h
+++ b/bcos-security/bcos-security/HsmDataEncryption.h
@@ -27,6 +27,7 @@
 #include <bcos-framework/security/StorageEncryptInterface.h>
 #include <bcos-tool/NodeConfig.h>
 #include <bcos-utilities/FileUtility.h>
+#include <bit>
 #include <memory>
 
 namespace bcos
@@ -43,11 +44,11 @@ public:
     // use to encrypt/decrypt in rocksdb
     std::string encrypt(const std::string& data) override
     {
-        return encrypt((unsigned char*)(data.data()), data.size());
+        return encrypt(std::bit_cast<unsigned char*>(const_cast<char*>(data.data())), data.size());
     }
     std::string decrypt(const std::string& data) override
     {
-        return decrypt((unsigned char*)(data.data()), data.size());
+        return decrypt(std::bit_cast<unsigned char*>(const_cast<char*>(data.data())), data.size());
     }
     std::string encrypt(uint8_t* data, size_t size);
     std::string decrypt(uint8_t* data, size_t size);

--- a/bcos-security/bcos-security/HsmKeyEncryption.cpp
+++ b/bcos-security/bcos-security/HsmKeyEncryption.cpp
@@ -25,6 +25,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
+#include <bit>
 
 using namespace std;
 using namespace bcos;
@@ -52,7 +53,7 @@ std::shared_ptr<bytes> HsmKeyEncryption::encryptContents(const std::shared_ptr<b
     auto originIvData = ivData;
 
     bytesPointer encData = m_symmetricEncrypt->symmetricEncryptWithInternalKey(
-        reinterpret_cast<const unsigned char*>(contents->data()), contents->size(), m_encKeyIndex,
+        std::bit_cast<const unsigned char*>(contents->data()), contents->size(), m_encKeyIndex,
         ivData.data(), SM4_IV_DATA_SIZE);
     // append iv data to end of encData
     encData->insert(encData->end(), originIvData.begin(), originIvData.end());
@@ -63,8 +64,8 @@ std::shared_ptr<bytes> HsmKeyEncryption::decryptContents(const std::shared_ptr<b
 {
     size_t cipherDataSize = contents->size() - SM4_IV_DATA_SIZE;
     bytesPointer decData = m_symmetricEncrypt->symmetricDecryptWithInternalKey(
-        reinterpret_cast<const unsigned char*>(contents->data()), cipherDataSize, m_encKeyIndex,
-        reinterpret_cast<const unsigned char*>(contents->data() + cipherDataSize),
+        std::bit_cast<const unsigned char*>(contents->data()), cipherDataSize, m_encKeyIndex,
+        std::bit_cast<const unsigned char*>(contents->data() + cipherDataSize),
         SM4_IV_DATA_SIZE);
     return decData;
 }

--- a/bcos-security/test/unittests/libsecurity/CloudKmsInterfaceTest.cpp
+++ b/bcos-security/test/unittests/libsecurity/CloudKmsInterfaceTest.cpp
@@ -13,6 +13,7 @@
 #include <aws/kms/model/EncryptRequest.h>
 #include <bcos-security/cloudkms/AwsKmsWrapper.h>
 #include <boost/test/unit_test.hpp>
+#include <bit>
 
 using namespace bcos::security;
 
@@ -45,12 +46,12 @@ public:
         Aws::KMS::Model::EncryptResult result;
         // Simulate encryption by base64 encoding
         Aws::Utils::ByteBuffer plainBuffer(
-            (unsigned char*)request.GetPlaintext().GetUnderlyingData(),
+            std::bit_cast<unsigned char*>(request.GetPlaintext().GetUnderlyingData()),
             request.GetPlaintext().GetLength());
         Aws::Utils::Base64::Base64 base64;
         auto encoded = base64.Encode(plainBuffer);
         result.SetCiphertextBlob(
-            Aws::Utils::ByteBuffer((unsigned char*)encoded.data(), encoded.length()));
+            Aws::Utils::ByteBuffer(std::bit_cast<unsigned char*>(encoded.data()), encoded.length()));
         lastCiphertext = result.GetCiphertextBlob();
         return Aws::KMS::Model::EncryptOutcome(result);
     }
@@ -69,12 +70,12 @@ public:
         Aws::KMS::Model::DecryptResult result;
         const auto& resultCipher = request.GetCiphertextBlob();
         auto resultCipherStr =
-            std::string((char*)resultCipher.GetUnderlyingData(), resultCipher.GetLength());
+            std::string(std::bit_cast<char*>(resultCipher.GetUnderlyingData()), resultCipher.GetLength());
         // Simulate decryption by base64 decoding
         Aws::Utils::Base64::Base64 base64;
         auto decoded = base64.Decode(resultCipherStr);
         result.SetPlaintext(Aws::Utils::ByteBuffer(
-            (unsigned char*)decoded.GetUnderlyingData(), decoded.GetLength()));
+            std::bit_cast<unsigned char*>(decoded.GetUnderlyingData()), decoded.GetLength()));
         return Aws::KMS::Model::DecryptOutcome(result);
     }
 

--- a/bcos-storage/bcos-storage/StorageWrapperImpl.h
+++ b/bcos-storage/bcos-storage/StorageWrapperImpl.h
@@ -3,6 +3,7 @@
 #include <bcos-concepts/Basic.h>
 #include <bcos-concepts/storage/Storage.h>
 #include <bcos-framework/storage/Entry.h>
+#include <bit>
 #include <boost/throw_exception.hpp>
 
 namespace bcos::storage
@@ -55,7 +56,7 @@ public:
         for (auto&& it : keys)
         {
             viewArray.emplace_back(
-                std::string_view((const char*)RANGES::data(it), RANGES::size(it)));
+                std::string_view(std::bit_cast<const char*>(RANGES::data(it)), RANGES::size(it)));
         }
         storage().asyncGetRows(table, viewArray, std::move(callback));
 

--- a/bcos-storage/test/unittest/TestRocksDBStorage.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage.cpp
@@ -14,6 +14,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/test/unit_test.hpp>
+#include <bit>
 #include <future>
 #include <optional>
 #include <random>
@@ -39,7 +40,7 @@ public:
     {
         std::hash<std::string_view> hash;
         return bcos::crypto::HashType(
-            hash(std::string_view((const char*)_data.data(), _data.size())));
+            hash(std::string_view(std::bit_cast<const char*>(_data.data()), _data.size())));
     }
     bcos::crypto::hasher::AnyHasher hasher() const override
     {
@@ -551,7 +552,8 @@ BOOST_AUTO_TEST_CASE(rocksDBiter)
 
         for (size_t j = 0; j != 1000; ++j)
         {
-            std::string key = *(bcos::toHexString(std::string((char*)&i, sizeof(i)))) + "_key_" +
+            std::string key =
+                              *(bcos::toHexString(std::string(std::bit_cast<const char*>(std::addressof(i)), sizeof(i)))) + "_key_" +
                               boost::lexical_cast<std::string>(j);
             std::string value = "hello world!";
 

--- a/bcos-storage/test/unittest/TestTiKVStorage.cpp
+++ b/bcos-storage/test/unittest/TestTiKVStorage.cpp
@@ -14,6 +14,7 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
+#include <bit>
 #include <future>
 #include <optional>
 
@@ -34,7 +35,7 @@ public:
     {
         std::hash<std::string_view> hash;
         return bcos::crypto::HashType(
-            hash(std::string_view((const char*)_data.data(), _data.size())));
+            hash(std::string_view(std::bit_cast<const char*>(_data.data()), _data.size())));
     }
     bcos::crypto::hasher::AnyHasher hasher() const override
     {

--- a/bcos-table/test/unittests/libtable/Hash.h
+++ b/bcos-table/test/unittests/libtable/Hash.h
@@ -20,6 +20,7 @@
 #pragma once
 #include "bcos-framework/storage/Entry.h"
 #include "bcos-framework/storage/Table.h"
+#include <bit>
 #include <bcos-crypto/hasher/OpenSSLHasher.h>
 #include <bcos-crypto/interfaces/crypto/Hash.h>
 #include <functional>
@@ -64,7 +65,7 @@ public:
     HashType hash(bytesConstRef _data) const override
     {
         std::hash<std::string_view> hash;
-        auto h = hash(std::string_view((const char*)_data.data(), _data.size()));
+        auto h = hash(std::string_view(std::bit_cast<const char*>(_data.data()), _data.size()));
         uint8_t hash_result[32] = {0};
         memcpy(hash_result, &h, sizeof(h));
         return HashType(hash_result, 32);

--- a/bcos-tars-protocol/bcos-tars-protocol/impl/TarsSerializable.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/impl/TarsSerializable.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../Common.h"
 #include "TarsStruct.h"
+#include <bit>
 #include <bcos-concepts/Basic.h>
 #include <bcos-concepts/ByteBuffer.h>
 
@@ -22,7 +23,7 @@ void impl_decode(bcos::concepts::bytebuffer::ByteBuffer auto const& buffer,
     bcostars::protocol::impl::TarsStruct auto& out)
 {
     tars::TarsInputStream<tars::BufferReader> input;
-    input.setBuffer((const char*)RANGES::data(buffer), RANGES::size(buffer));
+    input.setBuffer(std::bit_cast<const char*>(RANGES::data(buffer)), RANGES::size(buffer));
     out.readFrom(input);
 }
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
@@ -25,6 +25,7 @@
 #include "bcos-concepts/Hash.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/Exceptions.h"
+#include <bit>
 #include <boost/endian/conversion.hpp>
 
 using namespace bcostars;
@@ -35,7 +36,7 @@ DERIVE_BCOS_EXCEPTION(EmptyBlockHeaderHash);
 void BlockHeaderImpl::decode(bcos::bytesConstRef _data)
 {
     tars::TarsInputStream<tars::BufferReader> input;
-    input.setBuffer((const char*)_data.data(), _data.size());
+    input.setBuffer(std::bit_cast<const char*>(_data.data()), _data.size());
 
     m_inner()->readFrom(input);
 }

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
@@ -29,6 +29,7 @@
 #include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
 #include "bcos-tars-protocol/tars/TransactionReceipt.h"
 #include "bcos-utilities/AnyHolder.h"
+#include <bit>
 #include <boost/throw_exception.hpp>
 
 using namespace bcostars;
@@ -263,7 +264,7 @@ size_t bcostars::protocol::BlockImpl::size() const
 bcos::bytesConstRef bcostars::protocol::BlockImpl::logsBloom() const
 {
     const auto& data = inner();
-    return {(const unsigned char*)data.logsBloom.data(), data.logsBloom.size()};
+    return {std::bit_cast<const unsigned char*>(data.logsBloom.data()), data.logsBloom.size()};
 }
 
 void bcostars::protocol::BlockImpl::setLogsBloom(bcos::bytesConstRef logsBloom)

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/GroupInfoCodecImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/GroupInfoCodecImpl.h
@@ -39,7 +39,7 @@ public:
     bcos::group::GroupInfo::Ptr deserialize(const std::string& _encodedData) override
     {
         tars::TarsInputStream<tars::BufferReader> input;
-        input.setBuffer((const char*)_encodedData.data(), _encodedData.size());
+        input.setBuffer(_encodedData.data(), _encodedData.size());
 
         bcostars::GroupInfo tarsGroupInfo;
         tarsGroupInfo.readFrom(input);

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.cpp
@@ -20,6 +20,7 @@
  */
 #include "ProtocolInfoCodecImpl.h"
 #include "../Common.h"
+#include <bit>
 
 using namespace bcostars;
 using namespace bcostars::protocol;
@@ -39,7 +40,7 @@ void ProtocolInfoCodecImpl::encode(
 bcos::protocol::ProtocolInfo::Ptr ProtocolInfoCodecImpl::decode(bcos::bytesConstRef _data) const
 {
     tars::TarsInputStream<tars::BufferReader> input;
-    input.setBuffer((const char*)_data.data(), _data.size());
+    input.setBuffer(std::bit_cast<const char*>(_data.data()), _data.size());
     bcostars::ProtocolInfo tarsProtocolInfo;
     tarsProtocolInfo.readFrom(input);
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptImpl.cpp
@@ -23,6 +23,7 @@
 #include "../impl/TarsSerializable.h"
 #include <bcos-concepts/Hash.h>
 #include <bcos-concepts/Serialize.h>
+#include <bit>
 
 using namespace bcostars;
 using namespace bcostars::protocol;
@@ -84,7 +85,8 @@ int32_t bcostars::protocol::TransactionReceiptImpl::status() const
 }
 bcos::bytesConstRef bcostars::protocol::TransactionReceiptImpl::output() const
 {
-    return {(const unsigned char*)m_inner()->data.output.data(), m_inner()->data.output.size()};
+    return {std::bit_cast<const unsigned char*>(m_inner()->data.output.data()),
+        m_inner()->data.output.size()};
 }
 gsl::span<const bcos::protocol::LogEntry> bcostars::protocol::TransactionReceiptImpl::logEntries()
     const

--- a/bcos-tars-protocol/test/ProtocolTest.cpp
+++ b/bcos-tars-protocol/test/ProtocolTest.cpp
@@ -22,6 +22,7 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 #include <gsl/span>
+#include <bit>
 #include <memory>
 
 using namespace std::string_view_literals;
@@ -135,7 +136,7 @@ BOOST_AUTO_TEST_CASE(transactionMetaData)
     bcostars::protocol::TransactionMetaDataImpl metaData2(
         [inner = bcostars::TransactionMetaData()]() mutable { return &inner; });
     tars::TarsInputStream<tars::BufferReader> input;
-    input.setBuffer((const char*)buffer.data(), buffer.size());
+    input.setBuffer(std::bit_cast<const char*>(buffer.data()), buffer.size());
     metaData2.mutableInner().readFrom(input);
 
     BOOST_CHECK_EQUAL(metaData2.hash().hex(), metaData.hash().hex());

--- a/bcos-utilities/bcos-utilities/Bloom.cpp
+++ b/bcos-utilities/bcos-utilities/Bloom.cpp
@@ -19,10 +19,11 @@
  */
 
 #include "Bloom.h"
+#include <bit>
 
 using namespace bcos;
 
 std::string_view bcos::toStringView(Bloom const& bloom)
 {
-    return {reinterpret_cast<const char*>(bloom.data()), bloom.size()};
+    return {std::bit_cast<const char*>(bloom.data()), bloom.size()};
 }

--- a/bcos-utilities/bcos-utilities/Common.cpp
+++ b/bcos-utilities/bcos-utilities/Common.cpp
@@ -194,7 +194,7 @@ std::string bcos::pthread_getThreadName()
 {
 #if defined(__GLIBC__) || defined(__APPLE__)
     std::array<char, 16> name = {0};
-    auto err = pthread_getname_np(pthread_self(), (char*)name.data(), name.size());
+    auto err = pthread_getname_np(pthread_self(), name.data(), name.size());
     if (err == 0)
     {
         if (name[0] == '\0')

--- a/bcos-utilities/bcos-utilities/ThreeWay4Apple.h
+++ b/bcos-utilities/bcos-utilities/ThreeWay4Apple.h
@@ -2,6 +2,7 @@
 
 #ifdef __APPLE__
 #include "Common.h"
+#include <bit>
 #include <string_view>
 namespace std
 {
@@ -11,8 +12,8 @@ constexpr strong_ordering operator<=>(const string_view& lhs, const string_view&
 }
 constexpr strong_ordering operator<=>(const bcos::bytes& lhs, const bcos::bytes& rhs)
 {
-    string_view lhsView((const char*)lhs.data(), lhs.size());
-    string_view rhsView((const char*)rhs.data(), rhs.size());
+    string_view lhsView(std::bit_cast<const char*>(lhs.data()), lhs.size());
+    string_view rhsView(std::bit_cast<const char*>(rhs.data()), rhs.size());
     return lhsView <=> rhsView;
 }
 }  // namespace std

--- a/bcos-utilities/test/unittests/libutilities/DataConvertUtilityTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/DataConvertUtilityTest.cpp
@@ -20,6 +20,7 @@
  */
 #include "bcos-utilities/DataConvertUtility.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <bit>
 #include <boost/test/unit_test.hpp>
 #include <cstdlib>
 #include <ctime>
@@ -107,7 +108,8 @@ BOOST_AUTO_TEST_CASE(testBigEndianToU64)
     std::cout << "bigEndU64:" << toHex(bigEndU64) << std::endl;
     // check u256
     uint64_t fromBig0 = 0;
-    std::reverse_copy(bigEndU64.data() + 24, bigEndU64.data() + 32, (char*)&fromBig0);
+    std::reverse_copy(bigEndU64.data() + 24, bigEndU64.data() + 32,
+        std::bit_cast<char*>(std::addressof(fromBig0)));
     std::cout << "fromBig:" << fromBig0 << std::endl;
     BOOST_CHECK(fromBig0 == number);
 

--- a/transaction-scheduler/tests/testSchedulerParallel.cpp
+++ b/transaction-scheduler/tests/testSchedulerParallel.cpp
@@ -8,6 +8,7 @@
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-task/Wait.h>
 #include <bcos-transaction-scheduler/SchedulerParallelImpl.h>
+#include <bit>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -116,7 +117,7 @@ struct MockConflictExecutor
             {
                 auto input = transaction->input();
                 auto inputNum = boost::lexical_cast<int>(
-                    std::string_view((const char*)input.data(), input.size()));
+                    std::string_view(std::bit_cast<const char*>(input.data()), input.size()));
                 fromAddress = std::to_string(inputNum % MOCK_USER_COUNT);
                 toAddress = std::to_string((inputNum + (MOCK_USER_COUNT / 2)) % MOCK_USER_COUNT);
             }


### PR DESCRIPTION
Address warnings related to type casting by replacing character casts with `std::bit_cast` where appropriate, ensuring safer and more modern C++ practices. Additionally, fix instances of direct character pointer casts to improve code quality.