### PR TITLE
<fix>(txpool): FIB-56-Fix web3transactions coroutine with mutex error

### DIFF
--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -3,7 +3,6 @@
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/Entry.h"
-#include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Exceptions.h"
 #include <evmc/evmc.h>
@@ -231,7 +230,8 @@ public:
                 auto addressView = std::span(address.bytes);
                 m_tableName.reserve(ledger::SYS_DIRECTORY::USER_APPS.size() + addressView.size());
                 m_tableName.append(ledger::SYS_DIRECTORY::USER_APPS);
-                m_tableName.append((const char*)addressView.data(), addressView.size());
+                m_tableName.append(reinterpret_cast<const char*>(addressView.data()),  // NOLINT
+                    addressView.size());
             }
             else
             {
@@ -279,7 +279,7 @@ public:
             storage,
             [](const bcos::Address& address) {
                 evmc_address evmcAddress;
-                ::ranges::copy(address, evmcAddress.bytes);
+                ::ranges::copy(address, std::span{evmcAddress.bytes}.data());
                 return evmcAddress;
             }(address),
             binaryAddress)

--- a/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
+++ b/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.h
@@ -4,6 +4,7 @@
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Wait.h"
 #include "bcos-utilities/Exceptions.h"
 #include <tbb/concurrent_unordered_map.h>
 #include <boost/multi_index/composite_key.hpp>
@@ -104,7 +105,7 @@ private:
     bool m_rawAddress{};
 
     void add(protocol::Transaction::Ptr transaction);
-    void remove(SenderNonces auto senderNonces)
+    void removeBySenderNonces(SenderNonces auto senderNonces)
     {
         auto& senderNonceIndex = m_transactions.get<0>();
 
@@ -129,7 +130,7 @@ public:
         }
     }
 
-    task::Task<void> seal(int64_t limit,
+    void seal(int64_t limit,
         storage2::ReadWriteStorage<executor_v1::StateKeyView, executor_v1::StateValue> auto& state,
         std::output_iterator<protocol::Transaction::Ptr> auto out)
     {
@@ -143,7 +144,7 @@ public:
             ledger::account::EVMAccount account(state, sender, m_rawAddress);
 
             int64_t currentNonce = 0;
-            if (auto nonceStr = co_await account.nonce())
+            if (auto nonceStr = task::syncWait(account.nonce()))
             {
                 if (auto result = std::from_chars(
                         nonceStr->data(), nonceStr->data() + nonceStr->size(), currentNonce);
@@ -170,7 +171,7 @@ public:
             }
             if (currentNonce > startNonce)
             {
-                co_await account.setNonce(std::to_string(currentNonce));
+                task::syncWait(account.setNonce(std::to_string(currentNonce)));
             }
             if (count >= limit)
             {
@@ -179,7 +180,7 @@ public:
         }
     }
 
-    task::Task<void> remove(storage2::ReadableStorage<executor_v1::StateKeyView> auto& state)
+    void remove(storage2::ReadableStorage<executor_v1::StateKeyView> auto& state)
     {
         std::unique_lock lock(m_mutex);
         auto& senderNonceIndex = m_transactions.get<0>();
@@ -192,7 +193,7 @@ public:
         for (auto& [sender, nonce] : senderNonces)
         {
             ledger::account::EVMAccount account(state, sender, m_rawAddress);
-            if (auto nonceStr = co_await account.nonce())
+            if (auto nonceStr = task::syncWait(account.nonce()))
             {
                 if (auto result = std::from_chars(
                         nonceStr->data(), nonceStr->data() + nonceStr->size(), nonce);
@@ -202,7 +203,7 @@ public:
                 }
             }
         }
-        remove(::ranges::views::all(senderNonces));
+        removeBySenderNonces(::ranges::views::all(senderNonces));
     }
 
     void remove(InputHashes auto hashes)
@@ -225,7 +226,7 @@ public:
                 }
             }
         }
-        remove(::ranges::views::all(senderNonceMap));
+        removeBySenderNonces(::ranges::views::all(senderNonceMap));
     }
 
     template <InputHashes TransactionHashes>

--- a/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(seal_single_sender_contiguous)
 
     MapStateStorage state{};  // empty state implies starting nonce = 0
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(100, state, std::back_inserter(out)));
+    pool.seal(100, state, std::back_inserter(out));
 
     BOOST_CHECK_EQUAL(out.size(), 3);
     auto nonce = readNonce(state, sender);
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(seal_limit_within_single_sender)
 
     MapStateStorage state{};  // empty state -> start nonces at 0
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(kSealLimit, state, std::back_inserter(out)));
+    pool.seal(kSealLimit, state, std::back_inserter(out));
 
     // Expect only first two from the first sender
     BOOST_CHECK_EQUAL(out.size(), 2);
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(seal_limit_across_senders)
 
     MapStateStorage state{};
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(kSealLimit, state, std::back_inserter(out)));
+    pool.seal(kSealLimit, state, std::back_inserter(out));
 
     // Expect A:0 and B:0
     BOOST_CHECK_EQUAL(out.size(), 2);
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(seal_limit_exact_boundary)
     pool.add(std::vector{makeTx(sender, 0), makeTx(sender, 1), makeTx(sender, 2)});
     MapStateStorage state{};
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(kSealLimit, state, std::back_inserter(out)));
+    pool.seal(kSealLimit, state, std::back_inserter(out));
 
     BOOST_CHECK_EQUAL(out.size(), 2);
     auto nonces = ::ranges::views::transform(out, [](auto& txPtr) {
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(seal_multiple_senders_and_gaps)
 
     MapStateStorage state{};
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(kSealLimit, state, std::back_inserter(out)));
+    pool.seal(kSealLimit, state, std::back_inserter(out));
 
     // Expect to seal A:0 and B:0 only; A:2 is blocked by gap at 1
     // Order across senders is implementation-defined; check membership and counts
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(seal_with_existing_ledger_nonce)
         makeTx(sender, kNonce6)});
 
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(kSealLimit2, state, std::back_inserter(out)));
+    pool.seal(kSealLimit2, state, std::back_inserter(out));
 
     // Expect only 5 and 6 sealed
     BOOST_CHECK_EQUAL(out.size(), 2);
@@ -345,12 +345,12 @@ BOOST_AUTO_TEST_CASE(remove_by_state_drops_confirmed)
     MapStateStorage state{};
     // Ledger reports nonce = 3 (i.e., 0..3 already confirmed)
     setNonce(state, sender, "3");
-    task::syncWait(pool.remove(state));
+    pool.remove(state);
 
     // Now set ledger to 4 and seal, should only see 4 and 5
     setNonce(state, sender, "4");
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(kSealLimit, state, std::back_inserter(out)));
+    pool.seal(kSealLimit, state, std::back_inserter(out));
 
     BOOST_CHECK_EQUAL(out.size(), 2);
     auto firstNonce = std::stoll(std::string(out[0]->nonce()));
@@ -397,7 +397,7 @@ BOOST_AUTO_TEST_CASE(remove_by_hashes_respects_per_sender_max)
     setNonce(state, senderBName, "2");
 
     std::vector<protocol::Transaction::Ptr> out;
-    task::syncWait(pool.seal(kSealLimit, state, std::back_inserter(out)));
+    pool.seal(kSealLimit, state, std::back_inserter(out));
 
     // Expect three txs: A:4,5 and B:2
     BOOST_CHECK_EQUAL(out.size(), 3);


### PR DESCRIPTION
Resolve a coroutine issue in the Web3Transactions class by replacing co_await with synchronous wait calls to ensure proper mutex handling. Adjust method names for clarity and consistency.