### PR TITLE
FIB-71/72: Remove LOGICAL_DELETE

### DIFF
--- a/bcos-framework/bcos-framework/storage2/AnyStorage.h
+++ b/bcos-framework/bcos-framework/storage2/AnyStorage.h
@@ -33,7 +33,7 @@ namespace bcos::storage2
 // 说明
 // - 批量 API 接受通用 range；AnyStorage 在内部使用 any_view 别名进行适配
 // - merge(to, from) 会遍历来源的 range，并以通用方式对目标执行写入/删除
-// - 使用 DIRECT 进行删除时，如果底层存储支持，将绕过“逻辑删除”
+// - 删除接口统一为物理删除，不再区分 DIRECT 语义
 //
 // 通过将 Key/Value 作为模板参数保留，在擦除具体存储实现的同时保持强类型。
 
@@ -57,7 +57,7 @@ namespace bcos::storage2
 // Notes
 // - Bulk APIs accept generic ranges; AnyStorage adapts them internally using any_view aliases
 // - merge(to, from) iterates source's range and applies writes/removes to destination generically
-// - Removing with DIRECT will bypass logical-deletion if the underlying storage supports it
+// - Remove APIs always perform physical deletion
 //
 // Keep Key/Value as template parameters to preserve strong types while
 // erasing the concrete storage implementation.
@@ -108,11 +108,11 @@ private:
         virtual ~StorageConcept() = default;
         virtual task::Task<std::vector<std::optional<ValueType>>> readSome(AnyKeyView keys) = 0;
         virtual task::Task<void> writeSome(AnyKeyValueView keyValues) = 0;
-        virtual task::Task<void> removeSome(AnyKeyView keys, bool direct) = 0;
+        virtual task::Task<void> removeSome(AnyKeyView keys) = 0;
 
         virtual task::Task<std::optional<ValueType>> readOne(Key key) = 0;
         virtual task::Task<void> writeOne(Key key, ValueType value) = 0;
-        virtual task::Task<void> removeOne(Key key, bool direct) = 0;
+        virtual task::Task<void> removeOne(Key key) = 0;
 
         virtual task::Task<std::unique_ptr<IteratorConcept>> rangeBegin() = 0;
         virtual task::Task<std::unique_ptr<IteratorConcept>> rangeSeekBegin(const Key& key) = 0;
@@ -177,16 +177,9 @@ private:
             co_await storage2::writeSome(*m_storage, ::ranges::views::all(keyValues));
         }
 
-        task::Task<void> removeSome(AnyKeyView keys, bool direct) override
+        task::Task<void> removeSome(AnyKeyView keys) override
         {
-            if (direct)
-            {
-                co_await storage2::removeSome(*m_storage, ::ranges::views::all(keys), DIRECT);
-            }
-            else
-            {
-                co_await storage2::removeSome(*m_storage, ::ranges::views::all(keys));
-            }
+            co_await storage2::removeSome(*m_storage, ::ranges::views::all(keys));
         }
 
         task::Task<std::optional<ValueType>> readOne(Key key) override
@@ -199,16 +192,9 @@ private:
             co_await storage2::writeOne(*m_storage, std::move(key), std::move(value));
         }
 
-        task::Task<void> removeOne(Key key, bool direct) override
+        task::Task<void> removeOne(Key key) override
         {
-            if (direct)
-            {
-                co_await storage2::removeOne(*m_storage, std::move(key), DIRECT);
-            }
-            else
-            {
-                co_await storage2::removeOne(*m_storage, std::move(key));
-            }
+            co_await storage2::removeOne(*m_storage, std::move(key));
         }
 
         task::Task<std::unique_ptr<IteratorConcept>> rangeBegin() override
@@ -297,13 +283,7 @@ public:
     friend auto tag_invoke(storage2::tag_t<storage2::removeSome> /*unused*/, AnyStorage& storage,
         ::ranges::input_range auto keys) -> task::Task<void>
     {
-        co_await storage.m_self->removeSome(::ranges::views::all(keys), false);
-    }
-
-    friend auto tag_invoke(storage2::tag_t<storage2::removeSome> /*unused*/, AnyStorage& storage,
-        ::ranges::input_range auto keys, DIRECT_TYPE /*unused*/) -> task::Task<void>
-    {
-        co_await storage.m_self->removeSome(::ranges::views::all(keys), true);
+        co_await storage.m_self->removeSome(::ranges::views::all(keys));
     }
 
     friend auto tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/, AnyStorage& storage,
@@ -321,13 +301,7 @@ public:
     friend auto tag_invoke(storage2::tag_t<storage2::removeOne> /*unused*/, AnyStorage& storage,
         auto key) -> task::Task<void>
     {
-        co_await storage.m_self->removeOne(std::move(key), false);
-    }
-
-    friend auto tag_invoke(storage2::tag_t<storage2::removeOne> /*unused*/, AnyStorage& storage,
-        auto key, DIRECT_TYPE /*unused*/) -> task::Task<void>
-    {
-        co_await storage.m_self->removeOne(std::move(key), true);
+        co_await storage.m_self->removeOne(std::move(key));
     }
 
     friend auto tag_invoke(storage2::tag_t<storage2::range> /*unused*/, AnyStorage& storage)

--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -56,8 +56,7 @@ enum Attribute : uint8_t
     UNORDERED = 0,
     ORDERED = 1,
     CONCURRENT = 1 << 1,
-    LRU = 1 << 2,
-    LOGICAL_DELETION = 1 << 3
+    LRU = 1 << 2
 };
 
 template <class KeyType, class ValueType = Empty, uint8_t attribute = Attribute::UNORDERED,
@@ -69,7 +68,6 @@ public:
     constexpr static bool withOrdered = (attribute & Attribute::ORDERED) != 0;
     constexpr static bool withConcurrent = (attribute & Attribute::CONCURRENT) != 0;
     constexpr static bool withLRU = (attribute & Attribute::LRU) != 0;
-    constexpr static bool withLogicalDeletion = (attribute & Attribute::LOGICAL_DELETION) != 0;
 
     using Key = KeyType;
     using Value = ValueType;
@@ -221,8 +219,7 @@ public:
         }) | ::ranges::to<std::vector>();
     }
 
-    bool writeOne(
-        Bucket& bucket, auto key, auto value, bool ignoreLogicalDeletion, bool insertOnly = false)
+    bool writeOne(Bucket& bucket, auto key, auto value, bool insertOnly = false)
     {
         auto const& index = bucket.container.template get<0>();
         int64_t updatedCapacity = 0;
@@ -251,7 +248,7 @@ public:
             {
                 return false;
             }
-            if (!deleteOP || (withLogicalDeletion && !ignoreLogicalDeletion))
+            if (!deleteOP)
             {
                 bucket.container.modify(it, [&](Data& data) mutable {
                     if constexpr (withLRU)
@@ -271,12 +268,12 @@ public:
                 {
                     updatedCapacity = -(getSize(it->key) + getSize(it->value));
                 }
-                it = bucket.container.erase(it);
+                bucket.container.erase(it);
             }
         }
         else
         {
-            if (!deleteOP || (withLogicalDeletion && !ignoreLogicalDeletion))
+            if (!deleteOP)
             {
                 it = bucket.container.emplace_hint(
                     it, Data{.key = Key{std::move(key)}, .value = {std::move(value)}});
@@ -287,21 +284,24 @@ public:
             }
         }
 
-        if constexpr (withLRU && !deleteOP)
+        if constexpr (withLRU)
         {
             bucket.capacity += updatedCapacity;
-            updateLRUAndCheck(bucket, it);
+            if constexpr (!deleteOP)
+            {
+                updateLRUAndCheck(bucket, it);
+            }
         }
         return !found;
     }
 
-    void removeSome(::ranges::input_range auto keys, bool ignoreLogicalDeletion)
+    void removeSome(::ranges::input_range auto keys)
     {
         for (auto&& key : keys)
         {
             auto& bucket = getBucket(key);
             Lock lock(bucket.mutex, true);
-            writeOne(bucket, std::forward<decltype(key)>(key), deleteItem, ignoreLogicalDeletion);
+            writeOne(bucket, std::forward<decltype(key)>(key), deleteItem);
         }
     }
 
@@ -335,7 +335,7 @@ public:
     {
         auto& bucket = storage.getBucket(key);
         Lock lock(bucket.mutex, true);
-        storage.writeOne(bucket, std::move(key), std::move(value), false);
+        storage.writeOne(bucket, std::move(key), std::move(value));
         return {};
     }
 
@@ -345,8 +345,7 @@ public:
     {
         auto& bucket = storage.getBucket(key);
         Lock lock(bucket.mutex, true);
-        return {
-            storage.writeOne(bucket, std::move(key), std::move(value), false, /*insertOnly=*/true)};
+        return {storage.writeOne(bucket, std::move(key), std::move(value), /*insertOnly=*/true)};
     }
 
     friend task::AwaitableValue<bool> tag_invoke(storage2::tag_t<storage2::writeOneIf> /*unused*/,
@@ -371,7 +370,7 @@ public:
             return {false};
         }
 
-        storage.writeOne(bucket, std::move(key), std::move(value), false);
+        storage.writeOne(bucket, std::move(key), std::move(value));
         return {true};
     }
 
@@ -383,7 +382,7 @@ public:
             auto& bucket = storage.getBucket(key);
             Lock lock(bucket.mutex, true);
             storage.writeOne(bucket, std::forward<decltype(key)>(key),
-                std::forward<decltype(value)>(value), false);
+                std::forward<decltype(value)>(value));
         }
 
         return {};
@@ -392,28 +391,14 @@ public:
     friend task::AwaitableValue<void> tag_invoke(
         storage2::tag_t<storage2::removeOne> /*unused*/, MemoryStorage& storage, auto key)
     {
-        storage.removeSome(::ranges::views::single(std::move(key)), false);
-        return {};
-    }
-
-    friend task::AwaitableValue<void> tag_invoke(storage2::tag_t<storage2::removeOne> /*unused*/,
-        MemoryStorage& storage, auto key, DIRECT_TYPE /*unused*/)
-    {
-        storage.removeSome(::ranges::views::single(std::move(key)), true);
+        storage.removeSome(::ranges::views::single(std::move(key)));
         return {};
     }
 
     friend task::AwaitableValue<void> tag_invoke(storage2::tag_t<storage2::removeSome> /*unused*/,
         MemoryStorage& storage, ::ranges::input_range auto keys)
     {
-        storage.removeSome(std::move(keys), false);
-        return {};
-    }
-
-    friend task::AwaitableValue<void> tag_invoke(storage2::tag_t<storage2::removeSome> /*unused*/,
-        MemoryStorage& storage, ::ranges::input_range auto keys, DIRECT_TYPE /*unused*/)
-    {
-        storage.removeSome(std::move(keys), true);
+        storage.removeSome(std::move(keys));
         return {};
     }
 
@@ -553,7 +538,7 @@ public:
                     auto&& [key, value] = *data;
                     std::visit(
                         [&](auto& innerValue) {
-                            toStorage.writeOne(bucket, key, std::move(innerValue), false);
+                            toStorage.writeOne(bucket, key, std::move(innerValue));
                         },
                         value);
                 }

--- a/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
@@ -178,29 +178,6 @@ public:
         }) | ::ranges::to<std::vector>();
     }
 
-    friend auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/, View& view,
-        ::ranges::input_range auto keys, storage2::DIRECT_TYPE /*unused*/)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadSome, MutableStorage&, decltype(keys)>>>
-    {
-        if (view.m_mutableStorage)
-        {
-            co_return co_await storage2::readSome(*view.m_mutableStorage, std::move(keys));
-        }
-
-        for (auto& immutableStorage : view.m_immutableStorages)
-        {
-            co_return co_await storage2::readSome(*immutableStorage, std::move(keys));
-        }
-
-        if constexpr (View::withCacheStorage)
-        {
-            co_return co_await storage2::readSome(view.m_cacheStorage.get(), std::move(keys));
-        }
-
-        co_return co_await storage2::readSome(view.m_backendStorage.get(), std::move(keys));
-    }
-
     friend auto tag_invoke(
         storage2::tag_t<storage2::readOne> /*unused*/, View& view, const auto& key)
         -> task::Task<task::AwaitableReturnType<
@@ -230,29 +207,6 @@ public:
             {
                 co_return value;
             }
-        }
-
-        co_return co_await storage2::readOne(view.m_backendStorage.get(), key);
-    }
-
-    friend auto tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/, View& view,
-        const auto& key, storage2::DIRECT_TYPE /*unused*/)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadOne, MutableStorage&, decltype(key)>>>
-    {
-        if (view.m_mutableStorage)
-        {
-            co_return co_await storage2::readOne(*view.m_mutableStorage, key);
-        }
-
-        for (auto& immutableStorage : view.m_immutableStorages)
-        {
-            co_return co_await storage2::readOne(*immutableStorage, key);
-        }
-
-        if constexpr (View::withCacheStorage)
-        {
-            co_return co_await storage2::readOne(view.m_cacheStorage.get(), key);
         }
 
         co_return co_await storage2::readOne(view.m_backendStorage.get(), key);
@@ -406,7 +360,6 @@ public:
 };
 
 template <class MutableStorageType, class CachedStorage, class BackendStorage>
-    requires MutableStorageType::withLogicalDeletion
 class MultiLayerStorage
 {
 public:

--- a/bcos-framework/test/unittests/storage2/TestAnyStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestAnyStorage.cpp
@@ -151,30 +151,28 @@ BOOST_AUTO_TEST_CASE(merge_cross_types)
     }());
 }
 
-BOOST_AUTO_TEST_CASE(merge_with_logical_deletion)
+BOOST_AUTO_TEST_CASE(merge_without_logical_deletion)
 {
     task::syncWait([]() -> task::Task<void> {
-        // Source enables logical deletion so its range() emits DELETED_TYPE; destination plain
-        // ordered
-        MemoryStorage<int, std::string, ORDERED> toPlain;                         // dest
-        MemoryStorage<int, std::string, Attribute(LOGICAL_DELETION)> fromWithLD;  // source
+        MemoryStorage<int, std::string, ORDERED> toPlain;    // dest
+        MemoryStorage<int, std::string, ORDERED> fromPlain;  // source
 
         AnyStorage<int, std::string> anyTo(toPlain);
-        AnyStorage<int, std::string> anyFrom(fromWithLD);
+        AnyStorage<int, std::string> anyFrom(fromPlain);
 
         // Seed data
         co_await writeSome(
             anyTo, std::vector<std::pair<int, std::string>>{{1, "x1"}, {2, "x2"}, {3, "x3"}});
         co_await writeSome(anyFrom, std::vector<std::pair<int, std::string>>{{2, "y2"}});
 
-        // Source expresses a deletion for key=1 via removeOne (kept as logical deletion in source)
+        // Source performs physical deletion for key=1; merge won't carry deletion tombstones.
         co_await removeOne(anyFrom, 1);
 
-        // Merge: expect key=1 deleted in dest, key=2 overwritten to y2, key=3 untouched
+        // Merge: key=2 overwritten, key=3 untouched, key=1 keeps destination value.
         co_await merge(anyTo, anyFrom);
 
         auto res = co_await readSome(anyTo, std::vector<int>{1, 2, 3});
-        BOOST_CHECK(!res[0]);  // deleted
+        BOOST_CHECK(res[0] && *res[0] == "x1");
         BOOST_CHECK(res[1] && *res[1] == "y2");
         BOOST_CHECK(res[2] && *res[2] == "x3");
     }());

--- a/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(lru)
 BOOST_AUTO_TEST_CASE(logicalDeletion)
 {
     task::syncWait([]() -> task::Task<void> {
-        MemoryStorage<int, storage::Entry, Attribute(ORDERED | LOGICAL_DELETION)> storage;
+        MemoryStorage<int, storage::Entry, ORDERED> storage;
 
         // Write 100 items
         co_await storage2::writeSome(
@@ -201,22 +201,24 @@ BOOST_AUTO_TEST_CASE(logicalDeletion)
             storage, ::ranges::views::iota(0, 50) |
                          ::ranges::views::transform([](int num) { return num * 2; }));
 
-        // Query and check if deleted items
-        int i = 0;
+        // Query and check deleted items are physically removed
+        int i = 1;
         auto values = co_await storage2::range(storage);
         while (auto item = co_await values.next())
         {
             auto [key, value] = *item;
-            if (i % 2 == 0)
-            {
-                BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(value));
-            }
-            else
-            {
-                BOOST_CHECK_EQUAL(
-                    std::get<storage::Entry>(value).get(), fmt::format("Item: {}", i));
-            }
-            ++i;
+            BOOST_CHECK_EQUAL(key, i);
+            BOOST_CHECK_EQUAL(std::get<storage::Entry>(value).get(), fmt::format("Item: {}", i));
+            i += 2;
+        }
+        BOOST_CHECK_EQUAL(i, 101);
+
+        auto removedValues = co_await storage2::readSome(
+            storage, ::ranges::views::iota(0, 50) |
+                         ::ranges::views::transform([](int num) { return num * 2; }));
+        for (auto const& removed : removedValues)
+        {
+            BOOST_CHECK(!removed);
         }
 
         co_return;
@@ -264,7 +266,6 @@ BOOST_AUTO_TEST_CASE(range)
 
         MemoryStorage<int, int,
             bcos::storage2::memory_storage::Attribute(
-                bcos::storage2::memory_storage::LOGICAL_DELETION |
                 bcos::storage2::memory_storage::ORDERED)>
             intStorage;
         co_await storage2::writeSome(intStorage,
@@ -336,8 +337,7 @@ BOOST_AUTO_TEST_CASE(merge)
 BOOST_AUTO_TEST_CASE(directDelete)
 {
     task::syncWait([]() -> task::Task<void> {
-        MemoryStorage<int, int, bcos::storage2::memory_storage::LOGICAL_DELETION, std::hash<int>>
-            storage;
+        MemoryStorage<int, int, bcos::storage2::memory_storage::ORDERED, std::hash<int>> storage;
         co_await storage2::writeSome(storage,
             ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
 
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(directDelete)
         }
         BOOST_CHECK_EQUAL(count1, 10);
 
-        co_await storage2::removeOne(storage, 6, bcos::storage2::DIRECT);
+        co_await storage2::removeOne(storage, 6);
         auto range2 = co_await storage2::range(storage);
         int count2 = 0;
         while (co_await range2.next())
@@ -403,9 +403,7 @@ BOOST_AUTO_TEST_CASE(keyComp)
 
     bcos::task::syncWait([&]() -> task::Task<void> {
         bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
-            bcos::executor_v1::StateValue,
-            bcos::storage2::memory_storage::ORDERED |
-                bcos::storage2::memory_storage::LOGICAL_DELETION>
+            bcos::executor_v1::StateValue, bcos::storage2::memory_storage::ORDERED>
             storage;
         for (const auto& key : keys)
         {
@@ -493,10 +491,7 @@ BOOST_AUTO_TEST_CASE(concurrentRange)
 BOOST_AUTO_TEST_CASE(dirtctReadOne)
 {
     task::syncWait([]() -> task::Task<void> {
-        MemoryStorage<int, int,
-            bcos::storage2::memory_storage::ORDERED |
-                bcos::storage2::memory_storage::LOGICAL_DELETION>
-            storage;
+        MemoryStorage<int, int, bcos::storage2::memory_storage::ORDERED> storage;
         co_await storage2::writeSome(storage,
             ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
         co_await storage2::removeOne(storage, 6);
@@ -504,7 +499,7 @@ BOOST_AUTO_TEST_CASE(dirtctReadOne)
         auto value = co_await storage2::readOne(storage, 6);
         BOOST_CHECK(!value);
         auto value2 = storage.readOne(6);
-        BOOST_CHECK(std::holds_alternative<bcos::storage2::DELETED_TYPE>(value2));
+        BOOST_CHECK(std::holds_alternative<bcos::storage2::NOT_EXISTS_TYPE>(value2));
 
         auto value3 = storage.readOne(11);
         BOOST_CHECK(std::holds_alternative<bcos::storage2::NOT_EXISTS_TYPE>(value3));

--- a/bcos-storage/bcos-storage/RocksDBStorage2.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage2.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "bcos-framework/storage/Entry.h"
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-task/AwaitableValue.h"
 #include "bcos-utilities/Error.h"
@@ -11,6 +12,7 @@
 #include <boost/throw_exception.hpp>
 #include <memory>
 #include <range/v3/view/chunk.hpp>
+#include <type_traits>
 #include <variant>
 
 namespace bcos::storage2::rocksdb
@@ -186,17 +188,26 @@ public:
         {
             auto&& [key, variantValue] = *keyValue;
             auto encodedKey = m_keyResolver.encode(key);
+            auto keySlice =
+                ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey));
             if (auto* value = std::get_if<ValueType>(std::addressof(variantValue)))
             {
+                if constexpr (std::is_same_v<std::remove_cvref_t<ValueType>, bcos::storage::Entry>)
+                {
+                    if (value->status() == bcos::storage::Entry::DELETED)
+                    {
+                        writeBatch.Delete(keySlice);
+                        continue;
+                    }
+                }
+
                 auto encodedValue = m_valueResolver.encode(*value);
-                writeBatch.Put(
-                    ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey)),
+                writeBatch.Put(keySlice,
                     ::rocksdb::Slice(::ranges::data(encodedValue), ::ranges::size(encodedValue)));
             }
             else
             {
-                writeBatch.Delete(
-                    ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey)));
+                continue;
             }
         }
         co_await writeToBatch(writeBatch, fromStorage...);

--- a/bcos-storage/bcos-storage/RocksDBStorage2.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage2.h
@@ -205,10 +205,6 @@ public:
                 writeBatch.Put(keySlice,
                     ::rocksdb::Slice(::ranges::data(encodedValue), ::ranges::size(encodedValue)));
             }
-            else
-            {
-                continue;
-            }
         }
         co_await writeToBatch(writeBatch, fromStorage...);
     }

--- a/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
@@ -207,4 +207,37 @@ BOOST_AUTO_TEST_CASE(merge)
     }());
 }
 
+BOOST_AUTO_TEST_CASE(mergeDeletedEntryToDelete)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        RocksDBStorage2<StateKey, StateValue, StateKeyResolver,
+            bcos::storage2::rocksdb::StateValueResolver>
+            rocksDB(*originRocksDB, StateKeyResolver{}, StateValueResolver{});
+
+        StateKey key{"test_table"sv, "deleted_key"sv};
+        storage::Entry initialEntry;
+        initialEntry.set("initial value");
+        co_await storage2::writeOne(rocksDB, key, initialEntry);
+
+        auto beforeMerge = co_await storage2::readOne(rocksDB, key);
+        BOOST_REQUIRE(beforeMerge);
+        BOOST_CHECK_EQUAL(beforeMerge->get(), "initial value");
+
+        storage2::memory_storage::MemoryStorage<StateKey, StateValue,
+            storage2::memory_storage::ORDERED>
+            memoryStorage;
+
+        storage::Entry deletedEntry;
+        deletedEntry.setStatus(storage::Entry::DELETED);
+        co_await storage2::writeOne(memoryStorage, key, deletedEntry);
+
+        co_await storage2::merge(rocksDB, memoryStorage);
+
+        auto afterMerge = co_await storage2::readOne(rocksDB, key);
+        BOOST_CHECK(!afterMerge);
+
+        co_return;
+    }());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-table/src/LegacyStorageWrapper.h
+++ b/bcos-table/src/LegacyStorageWrapper.h
@@ -56,6 +56,12 @@ public:
                 if ((!condition || condition->isValid(entryKey)) &&
                     std::holds_alternative<storage::Entry>(value))
                 {
+                    auto const& entry = std::get<storage::Entry>(value);
+                    if (entry.status() == storage::Entry::DELETED)
+                    {
+                        continue;
+                    }
+
                     if (start != 0 || count != 0)
                     {
                         if (((start == 0 || index >= start) &&
@@ -85,6 +91,12 @@ public:
             {
                 auto value = co_await storage2::readOne(
                     self->m_storage.get(), executor_v1::StateKeyView{table, key});
+
+                if (value && value->status() == storage::Entry::DELETED)
+                {
+                    value.reset();
+                }
+
                 callback(nullptr, std::move(value));
             }
             catch (std::exception& e)
@@ -110,6 +122,15 @@ public:
                     return executor_v1::StateKeyView{table, std::forward<decltype(key)>(key)};
                 });
                 auto values = co_await storage2::readSome(self->m_storage.get(), stateKeys);
+
+                for (auto& value : values)
+                {
+                    if (value && value->status() == storage::Entry::DELETED)
+                    {
+                        value.reset();
+                    }
+                }
+
                 callback(nullptr, std::move(values));
             }
             catch (std::exception& e)

--- a/bcos-table/src/LegacyStorageWrapper.h
+++ b/bcos-table/src/LegacyStorageWrapper.h
@@ -126,16 +126,8 @@ public:
                        decltype(entry) entry, decltype(callback) callback) -> task::Task<void> {
             try
             {
-                if (entry.status() == storage::Entry::Status::DELETED)
-                {
-                    co_await storage2::removeOne(
-                        self->m_storage.get(), executor_v1::StateKeyView(table, key));
-                }
-                else
-                {
-                    co_await storage2::writeOne(
-                        self->m_storage.get(), executor_v1::StateKey(table, key), std::move(entry));
-                }
+                co_await storage2::writeOne(
+                    self->m_storage.get(), executor_v1::StateKey(table, key), std::move(entry));
                 callback(nullptr);
             }
             catch (std::exception& e)

--- a/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(getPrimaryKeys)
             "t_test", {}, [](bcos::Error::UniquePtr error, std::vector<std::string> keys) {
                 BOOST_CHECK(!error);
                 BOOST_CHECK(!keys.empty());
-                BOOST_CHECK_EQUAL(keys.size(), 9);
+                BOOST_CHECK_EQUAL(keys.size(), 10);
                 auto expectedKeys = std::vector<std::string>{
                     "0",
                     "1",
@@ -79,6 +79,7 @@ BOOST_AUTO_TEST_CASE(getPrimaryKeys)
                     "6",
                     "7",
                     "8",
+                    "9",
                 };
                 BOOST_CHECK_EQUAL_COLLECTIONS(
                     keys.begin(), keys.end(), expectedKeys.begin(), expectedKeys.end());
@@ -138,11 +139,12 @@ BOOST_AUTO_TEST_CASE(balanceCase)
             [](bcos::Error::UniquePtr error, std::vector<std::string> gotKeys) {
                 BOOST_CHECK(!error);
                 BOOST_CHECK(!gotKeys.empty());
-                BOOST_CHECK_EQUAL(gotKeys.size(), 3);
+                BOOST_CHECK_EQUAL(gotKeys.size(), 4);
                 auto expectedKeys =
                     std::vector<std::string>{"00000000000000000000000000000195cb2ccc38",
                         "57e8f689daed377a69915c0ddce26da288f3aa65",
-                        "893de00e32b0765e03366ce8b3bfcd0404b24995"};
+                        "893de00e32b0765e03366ce8b3bfcd0404b24995",
+                        "d24180cc0fef2f3e545de4f9aafc09345cd08903"};
                 BOOST_CHECK_EQUAL_COLLECTIONS(
                     gotKeys.begin(), gotKeys.end(), expectedKeys.begin(), expectedKeys.end());
             });

--- a/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
@@ -30,8 +30,7 @@
 struct LegacyStorageTestFixture
 {
     bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey, bcos::storage::Entry,
-        bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
-                                                  bcos::storage2::memory_storage::LOGICAL_DELETION)>
+    bcos::storage2::memory_storage::ORDERED>
         storage;
 };
 

--- a/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(getPrimaryKeys)
             "t_test", {}, [](bcos::Error::UniquePtr error, std::vector<std::string> keys) {
                 BOOST_CHECK(!error);
                 BOOST_CHECK(!keys.empty());
-                BOOST_CHECK_EQUAL(keys.size(), 10);
+                BOOST_CHECK_EQUAL(keys.size(), 9);
                 auto expectedKeys = std::vector<std::string>{
                     "0",
                     "1",
@@ -79,7 +79,6 @@ BOOST_AUTO_TEST_CASE(getPrimaryKeys)
                     "6",
                     "7",
                     "8",
-                    "9",
                 };
                 BOOST_CHECK_EQUAL_COLLECTIONS(
                     keys.begin(), keys.end(), expectedKeys.begin(), expectedKeys.end());
@@ -139,14 +138,53 @@ BOOST_AUTO_TEST_CASE(balanceCase)
             [](bcos::Error::UniquePtr error, std::vector<std::string> gotKeys) {
                 BOOST_CHECK(!error);
                 BOOST_CHECK(!gotKeys.empty());
-                BOOST_CHECK_EQUAL(gotKeys.size(), 4);
+                BOOST_CHECK_EQUAL(gotKeys.size(), 3);
                 auto expectedKeys =
                     std::vector<std::string>{"00000000000000000000000000000195cb2ccc38",
                         "57e8f689daed377a69915c0ddce26da288f3aa65",
-                        "893de00e32b0765e03366ce8b3bfcd0404b24995",
-                        "d24180cc0fef2f3e545de4f9aafc09345cd08903"};
+                        "893de00e32b0765e03366ce8b3bfcd0404b24995"};
                 BOOST_CHECK_EQUAL_COLLECTIONS(
                     gotKeys.begin(), gotKeys.end(), expectedKeys.begin(), expectedKeys.end());
+            });
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(getRowAndRowsFilterDeletedEntry)
+{
+    bcos::task::syncWait([this]() -> bcos::task::Task<void> {
+        co_await bcos::storage2::writeSome(
+            storage, ::ranges::views::iota(0, 3) | ::ranges::views::transform([](int i) {
+                auto key = bcos::executor_v1::StateKey("t_test", std::to_string(i));
+                return std::make_tuple(key, bcos::storage::Entry("value"));
+            }));
+
+        bcos::storage::LegacyStorageWrapper legacyStorage(storage);
+
+        bcos::storage::Entry deletedEntry;
+        deletedEntry.setStatus(bcos::storage::Entry::DELETED);
+        legacyStorage.asyncSetRow(
+            "t_test", "1", deletedEntry, [](bcos::Error::UniquePtr error) { BOOST_CHECK(!error); });
+
+        legacyStorage.asyncGetRow(
+            "t_test", "0", [](bcos::Error::UniquePtr error, std::optional<bcos::storage::Entry> entry) {
+                BOOST_CHECK(!error);
+                BOOST_CHECK(entry.has_value());
+            });
+
+        legacyStorage.asyncGetRow(
+            "t_test", "1", [](bcos::Error::UniquePtr error, std::optional<bcos::storage::Entry> entry) {
+                BOOST_CHECK(!error);
+                BOOST_CHECK(!entry.has_value());
+            });
+
+        std::string_view keys[] = {"0", "1", "3"};
+        legacyStorage.asyncGetRows(
+            "t_test", keys, [](bcos::Error::UniquePtr error, std::vector<std::optional<bcos::storage::Entry>> entries) {
+                BOOST_CHECK(!error);
+                BOOST_CHECK_EQUAL(entries.size(), 3);
+                BOOST_CHECK(entries[0].has_value());
+                BOOST_CHECK(!entries[1].has_value());
+                BOOST_CHECK(!entries[2].has_value());
             });
     }());
 }

--- a/libinitializer/BaselineSchedulerInitializer.cpp
+++ b/libinitializer/BaselineSchedulerInitializer.cpp
@@ -10,8 +10,7 @@
 #include <boost/throw_exception.hpp>
 
 using MutableStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
-    bcos::executor_v1::StateValue,
-    bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::LOGICAL_DELETION>;
+    bcos::executor_v1::StateValue, bcos::storage2::memory_storage::ORDERED>;
 using CacheStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
     bcos::executor_v1::StateValue,
     bcos::storage2::memory_storage::CONCURRENT | bcos::storage2::memory_storage::LRU>;

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -9,20 +9,6 @@ namespace bcos::executor_v1
 {
 
 template <class Storage>
-concept HasReadOneDirect = requires(Storage& storage) {
-    {
-        storage2::readOne(storage, std::declval<typename Storage::Key>(), storage2::DIRECT)
-    } -> task::IsAwaitable;
-};
-template <class Storage>
-concept HasReadSomeDirect = requires(Storage& storage) {
-    {
-        storage2::readSome(
-            storage, std::declval<std::vector<typename Storage::Key>>(), storage2::DIRECT)
-    } -> task::IsAwaitable;
-};
-
-template <class Storage>
 class Rollbackable
 {
 public:
@@ -51,8 +37,7 @@ public:
             }
             else
             {
-                co_await storage2::removeOne(
-                    m_storage.get(), std::move(record.key), storage2::DIRECT);
+                co_await storage2::removeOne(m_storage.get(), std::move(record.key));
             }
             m_records.pop_back();
         }
@@ -62,9 +47,7 @@ private:
     struct Record
     {
         Key key;
-        task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadOne, Storage&, Key, storage2::DIRECT_TYPE>>
-            oldValue;
+        task::AwaitableReturnType<std::invoke_result_t<storage2::ReadOne, Storage&, Key>> oldValue;
     };
     std::vector<Record> m_records;
     std::reference_wrapper<Storage> m_storage;
@@ -73,7 +56,7 @@ private:
         requires ::ranges::sized_range<Keys> && ::ranges::input_range<Keys>
     task::Task<void> storeOldValues(Keys keys, bool withEmpty)
     {
-        auto oldValues = co_await storage2::readSome(m_storage.get(), keys, storage2::DIRECT);
+        auto oldValues = co_await storage2::readSome(m_storage.get(), keys);
         m_records.reserve(m_records.size() + ::ranges::size(keys));
         for (auto&& [key, oldValue] : ranges::views::zip(keys, oldValues))
         {
@@ -89,7 +72,6 @@ private:
         ::ranges::input_range auto keyValues)
         -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::WriteSome,
             std::add_lvalue_reference_t<Storage>, decltype(keyValues)>>>
-        requires HasReadSomeDirect<Storage>
     {
         if constexpr (::ranges::borrowed_range<decltype(keyValues)>)
         {
@@ -126,12 +108,10 @@ private:
         storage2::tag_t<storage2::writeOne> /*unused*/, Rollbackable& storage, auto key, auto value)
         -> task::Task<task::AwaitableReturnType<
             std::invoke_result_t<storage2::WriteOne, Storage&, decltype(key), decltype(value)>>>
-        requires HasReadOneDirect<Storage>
     {
         auto& record = storage.m_records.emplace_back();
         record.key = key;
-        record.oldValue =
-            co_await storage2::readOne(storage.m_storage.get(), key, storage2::DIRECT);
+        record.oldValue = co_await storage2::readOne(storage.m_storage.get(), key);
         co_await storage2::writeOne(storage.m_storage.get(), std::move(key), std::move(value));
     }
 

--- a/transaction-executor/benchmark/benchmakrExecutor.cpp
+++ b/transaction-executor/benchmark/benchmakrExecutor.cpp
@@ -19,7 +19,6 @@ using namespace bcos::storage2::memory_storage;
 using namespace bcos::executor_v1;
 
 using ReceiptFactory = bcostars::protocol::TransactionReceiptFactoryImpl;
-static_assert(HasReadOneDirect<MutableStorage>);
 
 struct Fixture
 {

--- a/transaction-executor/tests/TestHostContext.cpp
+++ b/transaction-executor/tests/TestHostContext.cpp
@@ -44,10 +44,7 @@ public:
     Rollbackable<decltype(storage)> rollbackableStorage;
     using MemoryStorageType =
         bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
-            bcos::executor_v1::StateValue,
-            bcos::storage2::memory_storage::Attribute(
-                bcos::storage2::memory_storage::ORDERED |
-                bcos::storage2::memory_storage::LOGICAL_DELETION)>;
+            bcos::executor_v1::StateValue, bcos::storage2::memory_storage::ORDERED>;
     MemoryStorageType transientStorage;
     Rollbackable<MemoryStorageType> rollbackableTransientStorage;
     evmc_address helloworldAddress{};

--- a/transaction-executor/tests/TestMemoryStorage.h
+++ b/transaction-executor/tests/TestMemoryStorage.h
@@ -7,18 +7,4 @@ namespace bcos::executor_v1
 {
 using MutableStorage = storage2::memory_storage::MemoryStorage<StateKey, StateValue,
     storage2::memory_storage::ORDERED>;
-
-auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/, MutableStorage& storage,
-    RANGES::input_range auto&& keys, storage2::DIRECT_TYPE /*unused*/)
-    -> task::Task<task::AwaitableReturnType<decltype(storage2::readSome(storage, keys))>>
-{
-    co_return co_await storage2::readSome(storage, std::forward<decltype(keys)>(keys));
-}
-
-auto tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/, MutableStorage& storage,
-    const auto& key, storage2::DIRECT_TYPE /*unused*/)
-    -> task::Task<task::AwaitableReturnType<decltype(storage2::readOne(storage, key))>>
-{
-    co_return co_await storage2::readOne(storage, key);
-}
 }  // namespace bcos::executor_v1

--- a/transaction-executor/tests/TestRollbackableStorage.cpp
+++ b/transaction-executor/tests/TestRollbackableStorage.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(addRollback)
         Rollbackable rollbackableStorage(memoryStorage);
 
         auto view = ::ranges::single_view(StateKey{"table1"sv, "Key1"sv});
-        co_await storage2::readSome(memoryStorage, view, storage2::DIRECT);
+        co_await storage2::readSome(memoryStorage, view);
 
         std::string_view tableID = "table1";
         auto point = rollbackableStorage.current();

--- a/transaction-scheduler/benchmark/benchmarkMultiLayerStorage.cpp
+++ b/transaction-scheduler/benchmark/benchmarkMultiLayerStorage.cpp
@@ -46,7 +46,7 @@ struct Fixture
     }
 
     using MutableStorage = MemoryStorage<executor_v1::StateKey, executor_v1::StateValue,
-        Attribute(ORDERED | LOGICAL_DELETION)>;
+        Attribute(ORDERED)>;
     using BackendStorage = MemoryStorage<executor_v1::StateKey, executor_v1::StateValue,
         Attribute(ORDERED | CONCURRENT), std::hash<executor_v1::StateKey>>;
 

--- a/transaction-scheduler/benchmark/benchmarkScheduler.cpp
+++ b/transaction-scheduler/benchmark/benchmarkScheduler.cpp
@@ -31,7 +31,7 @@ constexpr static s256 singleIssue = 1000000;
 constexpr static s256 singleTransfer = 1;
 constexpr static std::string_view transferMethod{"transfer(address,address,int256)"};
 
-using MutableStorage = MemoryStorage<StateKey, StateValue, Attribute(ORDERED | LOGICAL_DELETION)>;
+using MutableStorage = MemoryStorage<StateKey, StateValue, Attribute(ORDERED)>;
 using BackendStorage = MemoryStorage<StateKey, StateValue, ORDERED | LRU | CONCURRENT>;
 using MultiLayerStorageType = MultiLayerStorage<MutableStorage, void, BackendStorage>;
 using ReceiptFactory = bcostars::protocol::TransactionReceiptFactoryImpl;

--- a/transaction-scheduler/tests/testBaselineScheduler.cpp
+++ b/transaction-scheduler/tests/testBaselineScheduler.cpp
@@ -28,7 +28,7 @@ using namespace bcos::executor_v1;
 using namespace bcos::scheduler_v1;
 
 using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
-    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+    memory_storage::Attribute(memory_storage::ORDERED)>;
 using BackendStorage = memory_storage::MemoryStorage<StateKey, StateValue,
     memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
     std::hash<StateKey>>;

--- a/transaction-scheduler/tests/testMultiLayerStorage.cpp
+++ b/transaction-scheduler/tests/testMultiLayerStorage.cpp
@@ -18,7 +18,7 @@ class TestMultiLayerStorageFixture
 {
 public:
     using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
-        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+        memory_storage::Attribute(memory_storage::ORDERED)>;
     using BackendStorage = memory_storage::MemoryStorage<StateKey, StateValue,
         memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
         std::hash<StateKey>>;
@@ -111,14 +111,8 @@ BOOST_AUTO_TEST_CASE(merge)
         auto values2 = co_await storage2::readSome(view3, keys);
         for (auto&& [index, value] : ::ranges::views::enumerate(values2))
         {
-            if (index >= 20 && index < 30)
-            {
-                BOOST_CHECK(!value);
-            }
-            else
-            {
-                BOOST_CHECK(value);
-            }
+            BOOST_CHECK(value);
+            BOOST_CHECK_EQUAL(value->get(), fmt::format("value: {}", index));
         }
 
         co_return;
@@ -128,7 +122,7 @@ BOOST_AUTO_TEST_CASE(merge)
 BOOST_AUTO_TEST_CASE(rangeMulti)
 {
     using MutableStorage = memory_storage::MemoryStorage<int, int,
-        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+        memory_storage::Attribute(memory_storage::ORDERED)>;
     using BackendStorage = memory_storage::MemoryStorage<int, int,
         memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LRU)>;
 
@@ -156,7 +150,7 @@ BOOST_AUTO_TEST_CASE(rangeMulti)
                        ::ranges::views::transform([](auto input) { return input.value_or(-1); }) |
                        ::ranges::to<std::vector>();
         BOOST_CHECK_EQUAL(resultList.size(), 8);
-        auto expectList = std::vector<int>({0, 0, -1, 1, 2, 2, 2, 2});
+        auto expectList = std::vector<int>({0, 0, 0, 1, 2, 2, 2, 2});
         BOOST_CHECK_EQUAL_COLLECTIONS(
             vecList.begin(), vecList.end(), expectList.begin(), expectList.end());
 
@@ -205,16 +199,16 @@ BOOST_AUTO_TEST_CASE(deletedEntry)
         view2.newMutable();
         co_await storage2::removeOne(view2, key);
 
-        BOOST_CHECK(!co_await storage2::existsOne(view2, key));
+        BOOST_CHECK(co_await storage2::existsOne(view2, key));
 
         auto values = co_await storage2::readSome(view2, ::ranges::views::single(key));
-        BOOST_CHECK(!values[0]);
+        BOOST_CHECK(values[0]);
 
         auto range = co_await storage2::range(view2);
         auto keyValue = co_await range.next();
         BOOST_CHECK(keyValue);
         BOOST_CHECK_EQUAL(std::get<0>(*keyValue), key);
-        BOOST_CHECK(std::holds_alternative<DELETED_TYPE>(std::get<1>(*keyValue)));
+        BOOST_CHECK(std::holds_alternative<StateValue>(std::get<1>(*keyValue)));
         keyValue = co_await range.next();
         BOOST_CHECK(keyValue);
         BOOST_CHECK_EQUAL(std::get<0>(*keyValue), key2);

--- a/transaction-scheduler/tests/testSchedulerParallel.cpp
+++ b/transaction-scheduler/tests/testSchedulerParallel.cpp
@@ -48,7 +48,7 @@ class TestSchedulerParallelFixture
 {
 public:
     using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
-        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+        memory_storage::Attribute(memory_storage::ORDERED)>;
     using BackendStorage = memory_storage::MemoryStorage<StateKey, StateValue,
         memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
         std::hash<StateKey>>;

--- a/transaction-scheduler/tests/testSchedulerSerial.cpp
+++ b/transaction-scheduler/tests/testSchedulerSerial.cpp
@@ -47,7 +47,7 @@ class TestSchedulerSerialFixture
 {
 public:
     using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
-        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+        memory_storage::Attribute(memory_storage::ORDERED)>;
     using BackendStorage = memory_storage::MemoryStorage<StateKey, StateValue,
         memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
         std::hash<StateKey>>;


### PR DESCRIPTION
Eliminate the use of LOGICAL_DELETION across various storage implementations to simplify the storage logic and improve performance. This change updates the relevant attributes and removes associated code that handled logical deletions.