### PR TITLE
Fix clang-tidy warnings and improve error handling

### DIFF
--- a/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
@@ -6,7 +6,7 @@
 #include <evmc/evmc.h>
 #include <boost/throw_exception.hpp>
 #include <cstdint>
-#include <memory>
+#include <gsl/pointers>
 
 DERIVE_BCOS_EXCEPTION(UnknownEVMCStatus);
 
@@ -21,8 +21,8 @@ bcos::executor_v1::EVMCResult::EVMCResult(evmc_result from)
   : evmc_result(from), status{evmcStatusToTransactionStatus(from.status_code)}
 {}
 
-bcos::executor_v1::EVMCResult::EVMCResult(evmc_result from, protocol::TransactionStatus _status)
-  : evmc_result(from), status(_status)
+bcos::executor_v1::EVMCResult::EVMCResult(evmc_result from, protocol::TransactionStatus statusCode)
+  : evmc_result(from), status(statusCode)
 {}
 
 bcos::executor_v1::EVMCResult::EVMCResult(EVMCResult&& from) noexcept
@@ -54,6 +54,37 @@ bcos::bytes bcos::executor_v1::writeErrInfoToOutput(
 {
     bcos::codec::abi::ContractABICodec abi(hashImpl);
     return abi.abiIn("Error(string)", errInfo);
+}
+
+std::tuple<gsl::owner<uint8_t*>, size_t, decltype(evmc_result::release)>
+bcos::executor_v1::fillErrorOutputInPlace(
+    const crypto::Hash& hashImpl, evmc_status_code status, const std::string& errorInfo)
+{
+    bytes errorBytes;
+    if (!errorInfo.empty())
+    {
+        errorBytes = writeErrInfoToOutput(hashImpl, errorInfo);
+    }
+    else
+    {
+        auto [ignoredStatus, errorMessage] = evmcStatusToErrorMessage(hashImpl, status);
+        (void)ignoredStatus;
+        errorBytes.swap(errorMessage);
+    }
+
+    if (errorBytes.empty())
+    {
+        return {nullptr, 0, nullptr};
+    }
+
+    auto* output = new uint8_t[errorBytes.size()];  // NOLINT
+    ::ranges::copy(errorBytes, output);
+    auto release = +[](const struct evmc_result* result) {
+        gsl::owner<decltype(result->output_data)> ptr{result->output_data};
+        delete[] ptr;
+    };
+
+    return {output, errorBytes.size(), release};
 }
 
 bcos::protocol::TransactionStatus bcos::executor_v1::evmcStatusToTransactionStatus(
@@ -133,36 +164,18 @@ bcos::executor_v1::EVMCResult bcos::executor_v1::makeErrorEVMCResult(crypto::Has
     protocol::TransactionStatus status, evmc_status_code evmStatus, int64_t gas,
     const std::string& errorInfo)
 {
-    bytes errorBytes;
-    if (!errorInfo.empty())
-    {
-        errorBytes = writeErrInfoToOutput(hashImpl, errorInfo);
-    }
-    else
-    {
-        auto [_, errorMessage] = evmcStatusToErrorMessage(hashImpl, evmStatus);
-        errorBytes.swap(errorMessage);
-    }
-
-    std::unique_ptr<uint8_t[]> output;
-    size_t outputSize = 0;
-    if (!errorBytes.empty())
-    {
-        output = std::make_unique_for_overwrite<uint8_t[]>(errorBytes.size());
-        outputSize = errorBytes.size();
-        ::ranges::copy(errorBytes, output.get());
-    }
-
-    return EVMCResult{
-        evmc_result{.status_code = evmStatus,
-            .gas_left = gas,
-            .gas_refund = 0,
-            .output_data = output.release(),
-            .output_size = outputSize,
-            .release = +[](const struct evmc_result* result) { delete[] result->output_data; },
-            .create_address = {},
-            .padding = {}},
+    auto [outputData, outputSize, release] = fillErrorOutputInPlace(hashImpl, evmStatus, errorInfo);
+    EVMCResult result{evmc_result{.status_code = evmStatus,
+                          .gas_left = gas,
+                          .gas_refund = 0,
+                          .output_data = outputData,
+                          .output_size = outputSize,
+                          .release = release,
+                          .create_address = {},
+                          .padding = {}},
         status};
+
+    return result;
 }
 
 std::ostream& operator<<(std::ostream& output, const evmc_message& message)
@@ -189,7 +202,7 @@ std::ostream& operator<<(std::ostream& output, const evmc_result& result)
     output << "gas_refund: " << result.gas_refund << ", ";
     output << "output_data: " << bcos::bytesConstRef(result.output_data, result.output_size)
            << ", ";
-    output << "release: " << result.release << ", ";
+    output << "release: " << (result.release != nullptr) << ", ";
     output << "create_address: " << bcos::bytesConstRef(result.create_address.bytes) << "}";
     return output;
 }

--- a/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
@@ -79,7 +79,7 @@ bcos::executor_v1::fillErrorOutputInPlace(
 
     auto* output = new uint8_t[errorBytes.size()];  // NOLINT
     ::ranges::copy(errorBytes, output);
-    auto release = +[](const struct evmc_result* result) {
+    constexpr static auto* release = +[](const struct evmc_result* result) {
         gsl::owner<decltype(result->output_data)> ptr{result->output_data};
         delete[] ptr;
     };

--- a/transaction-executor/bcos-transaction-executor/EVMCResult.h
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.h
@@ -22,6 +22,8 @@
 #include "bcos-crypto/interfaces/crypto/Hash.h"
 #include "bcos-protocol/TransactionStatus.h"
 #include <evmc/instructions.h>
+#include <gsl/pointers>
+#include <tuple>
 
 namespace bcos::executor_v1
 {
@@ -29,7 +31,7 @@ class EVMCResult : public evmc_result
 {
 public:
     explicit EVMCResult(evmc_result from);
-    EVMCResult(evmc_result from, protocol::TransactionStatus _status);
+    EVMCResult(evmc_result from, protocol::TransactionStatus statusCode);
     EVMCResult(const EVMCResult&) = delete;
     EVMCResult(EVMCResult&& from) noexcept;
     EVMCResult& operator=(const EVMCResult&) = delete;
@@ -40,6 +42,9 @@ public:
 };
 
 bytes writeErrInfoToOutput(const crypto::Hash& hashImpl, std::string const& errInfo);
+
+std::tuple<gsl::owner<uint8_t*>, size_t, decltype(evmc_result::release)> fillErrorOutputInPlace(
+    const crypto::Hash& hashImpl, evmc_status_code status, const std::string& errorInfo = "");
 
 protocol::TransactionStatus evmcStatusToTransactionStatus(evmc_status_code status);
 std::tuple<bcos::protocol::TransactionStatus, bcos::bytes> evmcStatusToErrorMessage(

--- a/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
+++ b/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
@@ -161,7 +161,9 @@ public:
                 if (auto gasPrice = u256{std::get<0>(m_data->m_ledgerConfig.get().gasPrice())};
                     gasPrice > 0)
                 {
-                    m_data->m_gasPriceStr = "0x" + gasPrice.str(256, std::ios_base::hex);
+                    constexpr static const auto GAS_PRICE_DIGITS = 256;
+                    m_data->m_gasPriceStr =
+                        "0x" + gasPrice.str(GAS_PRICE_DIGITS, std::ios_base::hex);
 
                     auto balanceUsed = m_data->m_gasUsed * gasPrice;
                     auto senderAccount = getAccount(m_data->m_hostContext, evmcMessage.sender);
@@ -209,17 +211,17 @@ public:
             {
                 TRANSACTION_EXECUTOR_LOG(DEBUG) << "Transaction revert: " << evmcResult.status_code;
 
-                auto [_, errorMessage] = evmcStatusToErrorMessage(
+                auto [outputData, outputSize, release] = fillErrorOutputInPlace(
                     *m_data->m_executor.get().m_hashImpl, evmcResult.status_code);
-                if (!errorMessage.empty())
+                if (release != nullptr)
                 {
-                    auto output = std::make_unique_for_overwrite<uint8_t[]>(errorMessage.size());
-                    std::uninitialized_copy(errorMessage.begin(), errorMessage.end(), output.get());
-                    evmcResult.output_data = output.release();
-                    evmcResult.output_size = errorMessage.size();
-                    evmcResult.release = [](const struct evmc_result* result) {
-                        delete[] result->output_data;
-                    };
+                    if (evmcResult.release != nullptr)
+                    {
+                        evmcResult.release(std::addressof(evmcResult));
+                    }
+                    evmcResult.output_data = outputData;
+                    evmcResult.output_size = outputSize;
+                    evmcResult.release = release;
                 }
                 if (m_data->m_ledgerConfig.get().features().get(
                         ledger::Features::Flag::bugfix_revert_logs))

--- a/transaction-executor/tests/TestEVMCResult.cpp
+++ b/transaction-executor/tests/TestEVMCResult.cpp
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(testMakeErrorEVMCResult)
         BOOST_CHECK_EQUAL(result.status, TransactionStatus::Unknown);
         BOOST_CHECK_EQUAL(result.output_size, 0);
         BOOST_CHECK_EQUAL(result.output_data, nullptr);
-        BOOST_CHECK_NE(result.release, nullptr);  // Release function is still set
+        BOOST_CHECK_EQUAL(result.release, nullptr);
     }
 }
 


### PR DESCRIPTION
Address clang-tidy warnings and enhance the error handling mechanism by introducing a new function to fill error output in place, streamlining the process of managing error messages and memory.