### PR TITLE
Remove Ranges.h and resolve namespace conflicts

### DIFF
--- a/bcos-crypto/bcos-crypto/KeyCompareTools.h
+++ b/bcos-crypto/bcos-crypto/KeyCompareTools.h
@@ -21,9 +21,8 @@
 
 #pragma once
 
-#include "bcos-crypto/interfaces/crypto/CommonType.h"
-#include "bcos-utilities/FixedBytes.h"
-
+#include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/view/enumerate.hpp>
 namespace bcos::crypto
 {
 template <class NodeType>

--- a/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
+++ b/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <range/v3/view/any_view.hpp>
 
 #define CRYPTO_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("CRYPTO")
 namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/merkle/Merkle.h
+++ b/bcos-crypto/bcos-crypto/merkle/Merkle.h
@@ -11,6 +11,9 @@
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <iterator>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/subrange.hpp>
 #include <stdexcept>
 #include <type_traits>
 

--- a/bcos-crypto/demo/hasher_test.cpp
+++ b/bcos-crypto/demo/hasher_test.cpp
@@ -17,10 +17,10 @@ using namespace bcos;
 using namespace bcos::crypto::hasher;
 
 template <Hasher HasherType>
-auto hasherTest(std::string_view name, RANGES::random_access_range auto&& input, size_t totalSize,
+auto hasherTest(std::string_view name, ::ranges::random_access_range auto&& input, size_t totalSize,
     bool multiThread)
 {
-    std::vector<std::array<std::byte, 32>> results{RANGES::size(input)};
+    std::vector<std::array<std::byte, 32>> results{::ranges::size(input)};
 
     std::cout << "  " << name;
     auto begin = std::chrono::high_resolution_clock::now();
@@ -30,7 +30,7 @@ auto hasherTest(std::string_view name, RANGES::random_access_range auto&& input,
         HasherType hasher;
 
 #pragma omp for
-        for (RANGES::range_size_t<decltype(input)> i = 0; i < RANGES::size(input); ++i)
+        for (::ranges::range_size_t<decltype(input)> i = 0; i < ::ranges::size(input); ++i)
         {
             hasher.update(input[i]);
             results[i] = hasher.final();

--- a/bcos-executor/src/Common.h
+++ b/bcos-executor/src/Common.h
@@ -40,6 +40,8 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <iterator>
 #include <memory>
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/view/drop.hpp>
 #include <set>
 
 namespace bcos

--- a/bcos-executor/src/dag/Abi.cpp
+++ b/bcos-executor/src/dag/Abi.cpp
@@ -30,13 +30,12 @@
 #include <cstring>
 #include <string>
 
-using namespace std;
 using namespace bcos::executor;
 
 ParameterAbi parseParameter(const Json::Value& input)
 {
     auto paramType = input["type"].asString();
-    auto components = vector<ParameterAbi>();
+    auto components = std::vector<ParameterAbi>();
     if (boost::starts_with(paramType, "tuple"))
     {
         auto& paramComponents = input["components"];
@@ -52,13 +51,13 @@ ParameterAbi parseParameter(const Json::Value& input)
     return parameterAbi;
 }
 
-vector<string> flattenStaticParameter(const ParameterAbi& param)
+std::vector<std::string> flattenStaticParameter(const ParameterAbi& param)
 {  // TODO: return vector<std::pair<string, vector<uint8>>>, pair is type and access path
     const auto TUPLE_STR = "tuple";
-    auto flatTypes = vector<string>();
+    auto flatTypes = std::vector<std::string>();
     if (boost::starts_with(param.type, TUPLE_STR))
     {
-        for (auto i = (size_t)0; i < param.components.size(); i++)
+        for (auto i = (std::size_t)0; i < param.components.size(); i++)
         {
             auto types = flattenStaticParameter(param.components[i]);
             flatTypes.insert(flatTypes.end(), types.begin(), types.end());
@@ -68,7 +67,7 @@ vector<string> flattenStaticParameter(const ParameterAbi& param)
              !boost::algorithm::contains(param.type, "[]"))
     {
         auto type = param.type.substr(0, param.type.find("["));
-        size_t len = std::stoi(param.type.substr(param.type.find("["), param.type.find("]")));
+        std::size_t len = std::stoi(param.type.substr(param.type.find("["), param.type.find("]")));
         flatTypes.insert(flatTypes.end(), len, type);
     }
     else
@@ -78,8 +77,8 @@ vector<string> flattenStaticParameter(const ParameterAbi& param)
     return flatTypes;
 }
 
-unique_ptr<FunctionAbi> FunctionAbi::deserialize(
-    string_view abiStr, const bytes& expected, bool isSMCrypto)
+std::unique_ptr<FunctionAbi> FunctionAbi::deserialize(
+    std::string_view abiStr, const bytes& expected, bool isSMCrypto)
 {
     try
     {
@@ -158,13 +157,13 @@ unique_ptr<FunctionAbi> FunctionAbi::deserialize(
             }
 
             auto& functionConflictFields = function["conflictFields"];
-            auto conflictFields = vector<ConflictField>();
+            auto conflictFields = std::vector<ConflictField>();
             conflictFields.reserve(functionConflictFields.size());
             if (!functionConflictFields.isNull())
             {
                 for (auto& conflictField : functionConflictFields)
                 {
-                    auto value = vector<uint8_t>();
+                    auto value = std::vector<uint8_t>();
                     if (!conflictField["value"].isNull())
                     {
                         value.reserve(conflictField["value"].size());
@@ -185,9 +184,9 @@ unique_ptr<FunctionAbi> FunctionAbi::deserialize(
 
             auto& functionInputs = function["inputs"];
             assert(!functionInputs.isNull());
-            auto inputs = vector<ParameterAbi>();
+            auto inputs = std::vector<ParameterAbi>();
             inputs.reserve(functionInputs.size());
-            auto flatInputs = vector<string>();
+            auto flatInputs = std::vector<std::string>();
             for (auto i = (Json::ArrayIndex)0; i < functionInputs.size(); ++i)
             {
                 auto param = parseParameter(functionInputs[i]);
@@ -196,7 +195,7 @@ unique_ptr<FunctionAbi> FunctionAbi::deserialize(
                 inputs.emplace_back(std::move(param));
             }
 
-            return unique_ptr<FunctionAbi>(new FunctionAbi{
+            return std::unique_ptr<FunctionAbi>(new FunctionAbi{
                 functionName.asString(), inputs, selector, conflictFields, flatInputs});
         }
     }

--- a/bcos-executor/src/dag/ClockCache.cpp
+++ b/bcos-executor/src/dag/ClockCache.cpp
@@ -27,13 +27,12 @@
 #include <cstddef>
 #include <mutex>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 
-CacheItem* CacheShard::insert(size_t hash, void* value, bool holdReference)
+CacheItem* CacheShard::insert(std::size_t hash, void* value, bool holdReference)
 {
-    auto guard = lock_guard<mutex>(m_mutex);
+    auto guard = std::lock_guard<std::mutex>(m_mutex);
     auto success = evictFromCache();
     if (!success)
     {
@@ -71,7 +70,7 @@ CacheItem* CacheShard::insert(size_t hash, void* value, bool holdReference)
     return item;
 }
 
-CacheItem* CacheShard::lookup(size_t hash)
+CacheItem* CacheShard::lookup(std::size_t hash)
 {
     HashTable::const_accessor accessor;
     if (!m_table.find(accessor, hash))
@@ -132,7 +131,7 @@ bool CacheShard::unref(CacheItem* item, bool setUsage)
     {
         if (!inCache(flags))
         {
-            auto guard = lock_guard<mutex>(m_mutex);
+            auto guard = std::lock_guard<std::mutex>(m_mutex);
             recycleItem(item);
             return true;
         }
@@ -159,7 +158,7 @@ bool CacheShard::evictFromCache()
 {
     assert(!m_mutex.try_lock());
     auto usage = m_usage.load(std::memory_order_relaxed);
-    auto capacity = m_capacity.load(memory_order_relaxed);
+    auto capacity = m_capacity.load(std::memory_order_relaxed);
     if (usage == 0)
     {
         return true;
@@ -174,7 +173,7 @@ bool CacheShard::evictFromCache()
         newHead = (newHead + 1 >= m_list.size()) ? 0 : newHead + 1;
         if (evicted)
         {
-            usage = m_usage.load(memory_order_relaxed);
+            usage = m_usage.load(std::memory_order_relaxed);
         }
         else
         {
@@ -210,7 +209,7 @@ bool CacheShard::tryEvict(CacheItem* item)
         recycleItem(item);
         return true;
     }
-    item->flags.fetch_and(~s_usageBit, memory_order_relaxed);
+    item->flags.fetch_and(~s_usageBit, std::memory_order_relaxed);
     return false;
 }
 
@@ -226,10 +225,10 @@ void CacheShard::recycleItem(CacheItem* item)
     m_usage.fetch_sub(1, std::memory_order_relaxed);
 }
 
-void CacheShard::setCapacity(size_t capacity)
+void CacheShard::setCapacity(std::size_t capacity)
 {
     assert(capacity > 0);
-    auto guard = lock_guard<mutex>(m_mutex);
+    auto guard = std::lock_guard<std::mutex>(m_mutex);
     m_capacity.store(capacity, std::memory_order_relaxed);
     evictFromCache();
 }

--- a/bcos-executor/src/dag/DAG.cpp
+++ b/bcos-executor/src/dag/DAG.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "DAG.h"
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 
@@ -33,7 +32,7 @@ void DAG::init(ID _maxSize)
 {
     clear();
     for (ID i = 0; i < _maxSize; ++i)
-        m_vtxs.emplace_back(make_shared<Vertex>());
+        m_vtxs.emplace_back(std::make_shared<Vertex>());
     m_totalVtxs = _maxSize;
     m_totalConsume = 0;
 }

--- a/bcos-executor/src/dag/ScaleUtils.cpp
+++ b/bcos-executor/src/dag/ScaleUtils.cpp
@@ -25,15 +25,15 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <string>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 
-optional<size_t> bcos::executor::decodeCompactInteger(const bytes& encodedBytes, size_t startPos)
+std::optional<std::size_t> bcos::executor::decodeCompactInteger(
+    const bytes& encodedBytes, std::size_t startPos)
 {
     if (encodedBytes.size() - startPos < 1)
     {
-        return nullopt;
+        return std::nullopt;
     }
 
     auto _1stByte = encodedBytes[startPos];
@@ -46,7 +46,7 @@ optional<size_t> bcos::executor::decodeCompactInteger(const bytes& encodedBytes,
     {
         // single-byte mode:
         // upper six bits are the LE encoding of the value (valid only for values of 0-63).
-        number = static_cast<size_t>(_1stByte >> 2u);
+        number = static_cast<std::size_t>(_1stByte >> 2u);
         break;
     }
     case 0b01u:
@@ -58,11 +58,11 @@ optional<size_t> bcos::executor::decodeCompactInteger(const bytes& encodedBytes,
         {
             BCOS_LOG(TRACE) << LOG_BADGE("decodeCompactInteger")
                             << LOG_DESC("not enough data to decode compact integer");
-            return nullopt;
+            return std::nullopt;
         }
         auto _2ndByte = encodedBytes[startPos + 1];
-        number = (static_cast<size_t>((_1stByte) & 0b11111100u) +
-                     static_cast<size_t>(_2ndByte) * 256u) >>
+        number = (static_cast<std::size_t>((_1stByte) & 0b11111100u) +
+                     static_cast<std::size_t>(_2ndByte) * 256u) >>
                  2u;
         break;
     }
@@ -72,12 +72,12 @@ optional<size_t> bcos::executor::decodeCompactInteger(const bytes& encodedBytes,
         // upper six bits and the following three bytes are the LE encoding of the value
         // (valid only for values (2**14)-(2**30-1))
         number = _1stByte;
-        size_t multiplier = 256u;
+        std::size_t multiplier = 256u;
         if (encodedBytes.size() - startPos < 4)
         {
             BCOS_LOG(TRACE) << LOG_BADGE("decodeCompactInteger")
                             << LOG_DESC("not enough data to decode compact integer");
-            return nullopt;
+            return std::nullopt;
         }
 
         for (auto i = 1u; i < 4u; ++i)
@@ -99,7 +99,7 @@ optional<size_t> bcos::executor::decodeCompactInteger(const bytes& encodedBytes,
         {
             BCOS_LOG(TRACE) << LOG_BADGE("decodeCompactInteger")
                             << LOG_DESC("not enough data to decode compact integer");
-            return nullopt;
+            return std::nullopt;
         }
 
         auto multiplier = 1u;
@@ -111,13 +111,13 @@ optional<size_t> bcos::executor::decodeCompactInteger(const bytes& encodedBytes,
         break;
     }
     default:
-        return nullopt;
+        return std::nullopt;
     }
     return number;
 }
 
-optional<size_t> bcos::executor::scaleEncodingLength(
-    const ParameterAbi& param, const bytes& encodedBytes, size_t startPos)
+std::optional<std::size_t> bcos::executor::scaleEncodingLength(
+    const ParameterAbi& param, const bytes& encodedBytes, std::size_t startPos)
 {
     auto& type = param.type;
     if (boost::ends_with(type, "]"))
@@ -127,7 +127,7 @@ optional<size_t> bcos::executor::scaleEncodingLength(
         {
             BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength")
                             << LOG_DESC("unable to parse array type") << LOG_KV("type", type);
-            return nullopt;
+            return std::nullopt;
         }
 
         auto size = 0u;
@@ -145,7 +145,7 @@ optional<size_t> bcos::executor::scaleEncodingLength(
             {
                 BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength")
                                 << LOG_DESC("unable to parse length of dynamic array");
-                return nullopt;
+                return std::nullopt;
             }
         }
         else
@@ -153,14 +153,14 @@ optional<size_t> bcos::executor::scaleEncodingLength(
             auto dimension = type.substr(leftBracketPos + 1, type.length() - leftBracketPos - 1);
             try
             {
-                size = stoul(dimension);
+                size = std::stoul(dimension);
             }
             catch (...)
             {
                 BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength")
                                 << LOG_DESC("unable to parse dimension")
                                 << LOG_KV("dimension", dimension);
-                return nullopt;
+                return std::nullopt;
             }
         }
 
@@ -178,7 +178,7 @@ optional<size_t> bcos::executor::scaleEncodingLength(
             {
                 BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength")
                                 << LOG_DESC("unable to calculate length of element");
-                return nullopt;
+                return std::nullopt;
             }
         }
         return {length};
@@ -190,13 +190,13 @@ optional<size_t> bcos::executor::scaleEncodingLength(
         auto digitsNum = 0u;
         try
         {
-            digitsNum = stoul(type.substr(digitStartPos + 1));
+            digitsNum = std::stoul(type.substr(digitStartPos + 1));
         }
         catch (...)
         {
             BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength") << LOG_DESC("unable to parse type")
                             << LOG_KV("type", type);
-            return nullopt;
+            return std::nullopt;
         }
         return digitsNum >> 3;
     }
@@ -213,7 +213,7 @@ optional<size_t> bcos::executor::scaleEncodingLength(
         {
             BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength")
                             << LOG_DESC("unable to parse string or bytes");
-            return nullopt;
+            return std::nullopt;
         }
     }
 
@@ -228,13 +228,13 @@ optional<size_t> bcos::executor::scaleEncodingLength(
         auto digitsNum = 0u;
         try
         {
-            digitsNum = stoul(type.substr(digitStartPos + 1));
+            digitsNum = std::stoul(type.substr(digitStartPos + 1));
         }
         catch (...)
         {
             BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength") << LOG_DESC("unable to parse type")
                             << LOG_KV("type", type);
-            return nullopt;
+            return std::nullopt;
         }
         return digitsNum;
     }
@@ -256,7 +256,7 @@ optional<size_t> bcos::executor::scaleEncodingLength(
                 BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength")
                                 << LOG_DESC("unable to parse component")
                                 << LOG_KV("type", component);
-                return nullopt;
+                return std::nullopt;
             }
         }
         return {length};
@@ -264,5 +264,5 @@ optional<size_t> bcos::executor::scaleEncodingLength(
 
     BCOS_LOG(TRACE) << LOG_BADGE("scaleEncodingLength") << LOG_DESC("unable to parse type")
                     << LOG_KV("type", type);
-    return nullopt;
+    return std::nullopt;
 }

--- a/bcos-executor/src/dag/TxDAG2.cpp
+++ b/bcos-executor/src/dag/TxDAG2.cpp
@@ -23,7 +23,6 @@
 #include "TxDAG2.h"
 #include "CriticalFields.h"
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 using namespace bcos::executor::critical;
@@ -45,7 +44,7 @@ void TxDAG2::init(critical::CriticalFieldsInterface::Ptr _txsCriticals)
     // Generate tasks in m_tasks
     // Note: we must generate every task in m_tasks before make_edge(). Otherwise, may lead to core.
     using Msg = const continue_msg&;
-    std::vector<size_t> id2TaskId(txsSize);
+    std::vector<std::size_t> id2TaskId(txsSize);
     for (ID id = 0; id < _txsCriticals->size(); ++id)
     {
         if (_txsCriticals->contains(id))

--- a/bcos-executor/src/executive/CoroutineTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/CoroutineTransactionExecutive.cpp
@@ -42,7 +42,8 @@ CallParameters::UniquePtr CoroutineTransactionExecutive::dispatcher()
 {
     try
     {
-        for (auto it = RANGES::begin(*getPullMessage()); it != RANGES::end(*getPullMessage()); ++it)
+           for (auto it = ::ranges::begin(*getPullMessage());
+               it != ::ranges::end(*getPullMessage()); ++it)
         {
             if (*it)
             {

--- a/bcos-executor/src/executive/ShardingSyncStorageWrapper.h
+++ b/bcos-executor/src/executive/ShardingSyncStorageWrapper.h
@@ -111,8 +111,9 @@ public:
     }
 
     std::vector<std::optional<storage::Entry>> getRows(const std::string_view& table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys) override
     {
         for (auto it : keys)

--- a/bcos-executor/src/executive/ShardingTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/ShardingTransactionExecutive.cpp
@@ -5,6 +5,10 @@
 #include "ShardingTransactionExecutive.h"
 #include "ShardingSyncStorageWrapper.h"
 #include "bcos-table/src/ContractShardUtils.h"
+#include <range/v3/algorithm/all_of.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/view/drop.hpp>
+#include <range/v3/view/all.hpp>
 
 using namespace bcos::executor;
 using namespace bcos::storage;

--- a/bcos-executor/src/executive/SyncStorageWrapper.h
+++ b/bcos-executor/src/executive/SyncStorageWrapper.h
@@ -39,8 +39,9 @@ public:
     }
 
     virtual std::vector<std::optional<storage::Entry>> getRows(const std::string_view& table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys) override
     {
         for (auto it : keys)

--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -36,6 +36,7 @@
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-table/src/ContractShardUtils.h"
 #include "bcos-utilities/Exceptions.h"
+#include <range/v3/view/reverse.hpp>
 
 #ifdef WITH_WASM
 #include "../vm/gas_meter/GasInjector.h"
@@ -1532,7 +1533,7 @@ void TransactionExecutive::revert()
     if (m_blockContext.features().get(ledger::Features::Flag::bugfix_revert))
     {
         // revert child beforehand from back to front
-        for (auto& childExecutive : RANGES::views::reverse(m_childExecutives))
+        for (auto& childExecutive : ::ranges::views::reverse(m_childExecutives))
         {
             childExecutive->revert();
         }

--- a/bcos-executor/src/precompiled/BFSPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/BFSPrecompiled.cpp
@@ -351,7 +351,7 @@ void BFSPrecompiled::listDir(const std::shared_ptr<executor::TransactionExecutiv
                 // max return is 500
                 keyCondition->limit(0, USER_TABLE_MAX_LIMIT_COUNT);
                 auto keys = _executive->storage().getPrimaryKeys(absolutePath, keyCondition);
-                for (const auto& key : keys | RANGES::views::all)
+                for (const auto& key : keys | ::ranges::views::all)
                 {
                     auto entry = _executive->storage().getRow(absolutePath, key);
                     auto fields = entry->getObject<std::vector<std::string>>();
@@ -488,7 +488,7 @@ void BFSPrecompiled::listDirPage(const std::shared_ptr<executor::TransactionExec
         keyCondition->limit((size_t)offset, (size_t)count);
         auto keys = _executive->storage().getPrimaryKeys(absolutePath, keyCondition);
 
-        for (const auto& key : keys | RANGES::views::all)
+        for (const auto& key : keys | ::ranges::views::all)
         {
             auto entry = _executive->storage().getRow(absolutePath, key);
             auto fields = entry->getObject<std::vector<std::string>>();
@@ -883,7 +883,7 @@ void BFSPrecompiled::initBfs(const std::shared_ptr<executor::TransactionExecutiv
     // create / dir
     _executive->storage().createTable(std::string(tool::FS_ROOT), std::string(tool::FS_DIR_FIELDS));
     // build root subs metadata
-    for (const auto& subName : tool::FS_ROOT_SUBS | RANGES::views::drop(1))
+    for (const auto& subName : tool::FS_ROOT_SUBS | ::ranges::views::drop(1))
     {
         Entry entry;
         // type, status, acl_type, acl_white, acl_black, extra

--- a/bcos-executor/src/precompiled/ConsensusPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/ConsensusPrecompiled.cpp
@@ -68,7 +68,7 @@ static bool checkAuthByGovernors(const std::shared_ptr<executor::TransactionExec
                            << LOG_BADGE("BalancePrecompiled") << LOG_DESC("checkOriginAuth")
                            << LOG_KV("governors size", governors.size())
                            << LOG_KV("origin address", origin);
-    if (RANGES::find(governors, Address(origin)) == governors.end())
+    if (::ranges::find(governors, Address(origin)) == governors.end())
     {
         PRECOMPILED_LOG(TRACE)
             << BLOCK_NUMBER(_executive->blockContext().number()) << LOG_BADGE("BalancePrecompiled")

--- a/bcos-executor/src/precompiled/KVTablePrecompiled.cpp
+++ b/bcos-executor/src/precompiled/KVTablePrecompiled.cpp
@@ -1,3 +1,8 @@
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/algorithm/result_types.hpp>
+#include <range/v3/view/drop.hpp>
 /**
  *  Copyright (C) 2021 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0

--- a/bcos-executor/src/precompiled/ShardingPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/ShardingPrecompiled.cpp
@@ -28,6 +28,7 @@
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/throw_exception.hpp>
+#include <range/v3/algorithm/find_if.hpp>
 
 using namespace bcos;
 using namespace bcos::executor;

--- a/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
@@ -28,8 +28,10 @@
 #include "bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-framework/protocol/Protocol.h"
 #include "bcos-tool/VersionConverter.h"
+#include <algorithm>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
+#include <range/v3/algorithm/find.hpp>
 
 using namespace bcos;
 using namespace bcos::storage;

--- a/bcos-executor/src/precompiled/common/Utilities.cpp
+++ b/bcos-executor/src/precompiled/common/Utilities.cpp
@@ -310,7 +310,7 @@ bool precompiled::checkPathValid(std::string_view _path,
     }
     std::vector<std::string> pathList;
     //    constexpr std::string_view delim{"/"};
-    //    auto spliter = RANGES::split_view(absoluteDir, delim);
+    //    auto spliter = ::ranges::split_view(absoluteDir, delim);
     boost::split(pathList, absoluteDir, boost::is_any_of("/"), boost::token_compress_on);
     if (pathList.size() > FS_PATH_MAX_LEVEL || pathList.empty())
     {

--- a/bcos-executor/src/precompiled/common/WorkingSealerManagerImpl.cpp
+++ b/bcos-executor/src/precompiled/common/WorkingSealerManagerImpl.cpp
@@ -1,3 +1,6 @@
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/algorithm/result_types.hpp>
 /**
  *  Copyright (C) 2022 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0
@@ -30,6 +33,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/view/concat.hpp>
 
 using namespace bcos;
 using namespace bcos::precompiled;
@@ -449,7 +453,7 @@ static consensus::ConsensusNode& pickNodeByWeight(
     auto weight =
         nodeIt->offset - ((nodeWeightRanges.begin() == nodeIt) ? 0LU : (nodeIt - 1)->offset);
     totalWeight -= weight;
-    for (auto& it : RANGES::subrange<decltype(nodeIt)>(nodeIt + 1, nodeWeightRanges.end()))
+    for (auto& it : ::ranges::subrange<decltype(nodeIt)>(nodeIt + 1, nodeWeightRanges.end()))
     {
         it.offset -= weight;
     }
@@ -465,7 +469,7 @@ static std::vector<std::reference_wrapper<consensus::ConsensusNode>> getNodeList
         std::reference_wrapper<consensus::ConsensusNode>>
 {
     std::vector<NodeWeightRange> nodeWeightRanges;
-    nodeWeightRanges.reserve(RANGES::size(nodeList));
+    nodeWeightRanges.reserve(::ranges::size(nodeList));
 
     size_t totalWeight = 0;
     for (consensus::ConsensusNode& node : nodeList)

--- a/bcos-executor/src/precompiled/extension/AccountManagerPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/AccountManagerPrecompiled.cpp
@@ -26,6 +26,8 @@
 #include "bcos-framework/protocol/Exceptions.h"
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/throw_exception.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/algorithm/find_if.hpp>
 
 using namespace bcos;
 using namespace bcos::precompiled;
@@ -130,7 +132,7 @@ void AccountManagerPrecompiled::setAccountStatus(
 
     // check is governor
     auto governors = getGovernorList(_executive, _callParameters, codec);
-    if (RANGES::find_if(governors, [&_callParameters](const Address& address) {
+    if (::ranges::find_if(governors, [&_callParameters](const Address& address) {
             return address.hex() == _callParameters->m_sender;
         }) == governors.end())
     {
@@ -138,7 +140,7 @@ void AccountManagerPrecompiled::setAccountStatus(
         getErrorCodeOut(_callParameters->mutableExecResult(), CODE_NO_AUTHORIZED, codec);
         return;
     }
-    if (RANGES::find(governors, account) != governors.end())
+    if (::ranges::find(governors, account) != governors.end())
     {
         // set governor's status
         PRECOMPILED_LOG(INFO) << BLOCK_NUMBER(blockContext.number())

--- a/bcos-executor/test/unittest/container/TestHashMap.cpp
+++ b/bcos-executor/test/unittest/container/TestHashMap.cpp
@@ -1,3 +1,8 @@
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/algorithm/partition_point.hpp>
+#include <range/v3/algorithm/lower_bound.hpp>
+#include <range/v3/algorithm/binary_search.hpp>
+
 #include <tbb/concurrent_hash_map.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <boost/lexical_cast.hpp>

--- a/bcos-executor/test/unittest/libexecutive/TestShardingSyncStorageWrapper.h.cpp
+++ b/bcos-executor/test/unittest/libexecutive/TestShardingSyncStorageWrapper.h.cpp
@@ -21,8 +21,6 @@
 #include "../src/executive/ShardingSyncStorageWrapper.h"
 #include <boost/test/unit_test.hpp>
 
-
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 
@@ -30,6 +28,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 BOOST_AUTO_TEST_SUITE(TestShardingSyncStorageWrapper)
 
 BOOST_AUTO_TEST_CASE(test_keyName)

--- a/bcos-executor/test/unittest/libexecutor/TestAbiReader.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestAbiReader.cpp
@@ -26,7 +26,6 @@
 #include <boost/test/unit_test.hpp>
 #include <string>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 using namespace bcos::crypto;
@@ -35,6 +34,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct AbiReaderFixture
 {
     AbiReaderFixture() { hashImpl = std::make_shared<Keccak256>(); }

--- a/bcos-executor/test/unittest/libexecutor/TestBlockContext.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestBlockContext.cpp
@@ -7,8 +7,6 @@
 #include <tbb/concurrent_unordered_map.h>
 #include <boost/test/unit_test.hpp>
 
-
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 
@@ -16,6 +14,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 BOOST_AUTO_TEST_SUITE(TestBlockContext)
 
 BOOST_AUTO_TEST_CASE(BlockContextTest)

--- a/bcos-executor/test/unittest/libexecutor/TestClockCache.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestClockCache.cpp
@@ -23,7 +23,6 @@
 #include <boost/test/unit_test.hpp>
 #include <memory>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 
@@ -31,6 +30,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct ClockCacheFixture
 {
     ClockCacheFixture()

--- a/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
@@ -63,7 +63,6 @@
 #include <memory>
 #include <set>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 using namespace bcos::storage;
@@ -73,6 +72,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct DagExecutorFixture
 {
     DagExecutorFixture()

--- a/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
@@ -51,7 +51,6 @@
 #include <iterator>
 #include <memory>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 using namespace bcos::storage;
@@ -62,6 +61,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct TransactionExecutorFixture
 {
     TransactionExecutorFixture()

--- a/bcos-executor/test/unittest/libexecutor/TestExecutiveStackFlow.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestExecutiveStackFlow.cpp
@@ -28,8 +28,6 @@
 #include <atomic>
 #include <stack>
 
-
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 
@@ -37,6 +35,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct ExecutiveStackFlowFixture
 {
     ExecutiveStackFlowFixture()

--- a/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
@@ -22,6 +22,7 @@
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "libprecompiled/PreCompiledFixture.h"
 #include <boost/endian/conversion.hpp>
+#include <range/v3/algorithm/any_of.hpp>
 
 using namespace bcos;
 using namespace bcos::precompiled;

--- a/bcos-executor/test/unittest/libprecompiled/FileSystemPrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/FileSystemPrecompiledTest.cpp
@@ -22,6 +22,8 @@
 #include "bcos-framework/protocol/Protocol.h"
 #include "libprecompiled/PreCompiledFixture.h"
 #include <json/json.h>
+#include <range/v3/view/drop.hpp>
+#include <range/v3/view/take.hpp>
 
 using namespace bcos;
 using namespace bcos::precompiled;
@@ -661,14 +663,14 @@ BOOST_AUTO_TEST_CASE(lsTest)
         BOOST_CHECK(code == (int)CODE_SUCCESS);
         BOOST_CHECK(ls.size() == 4);
         std::set<std::string> lsSet;
-        for (const auto& item : ls | RANGES::views::transform([](auto&& bfs) -> std::string {
+        for (const auto& item : ls | ::ranges::views::transform([](auto&& bfs) -> std::string {
                  return std::get<0>(bfs);
              }))
         {
             lsSet.insert(item);
         }
 
-        for (auto const& rootSub : tool::FS_ROOT_SUBS | RANGES::views::drop(1))
+        for (auto const& rootSub : tool::FS_ROOT_SUBS | ::ranges::views::drop(1))
         {
             BOOST_CHECK(lsSet.contains(std::string(rootSub.substr(1))));
         }
@@ -694,7 +696,7 @@ BOOST_AUTO_TEST_CASE(lsTest)
             BOOST_CHECK(ls.size() == precompiled::BFS_SYS_SUBS_COUNT);
         }
         std::set<std::string> lsSet;
-        for (const auto& item : ls | RANGES::views::transform([](auto&& bfs) -> std::string {
+        for (const auto& item : ls | ::ranges::views::transform([](auto&& bfs) -> std::string {
                  return std::get<0>(bfs);
              }))
         {
@@ -713,7 +715,7 @@ BOOST_AUTO_TEST_CASE(lsTest)
             take--;
         }
         for (auto const& sysSub :
-            precompiled::BFS_SYS_SUBS | RANGES::views::take(take) | RANGES::views::drop(1))
+            precompiled::BFS_SYS_SUBS | ::ranges::views::take(take) | ::ranges::views::drop(1))
         {
             BOOST_CHECK(lsSet.contains(std::string(sysSub.substr(tool::FS_SYS_BIN.size() + 1))));
         }
@@ -785,14 +787,14 @@ BOOST_AUTO_TEST_CASE(lsPageTest)
         BOOST_CHECK(code == (int)CODE_SUCCESS);
         BOOST_CHECK(ls.size() == 4);
         std::set<std::string> lsSet;
-        for (const auto& item : ls | RANGES::views::transform([](auto&& bfs) -> std::string {
+        for (const auto& item : ls | ::ranges::views::transform([](auto&& bfs) -> std::string {
                  return std::get<0>(bfs);
              }))
         {
             lsSet.insert(item);
         }
 
-        for (auto const& rootSub : tool::FS_ROOT_SUBS | RANGES::views::drop(1))
+        for (auto const& rootSub : tool::FS_ROOT_SUBS | ::ranges::views::drop(1))
         {
             BOOST_CHECK(lsSet.contains(std::string(rootSub.substr(1))));
         }
@@ -818,7 +820,7 @@ BOOST_AUTO_TEST_CASE(lsPageTest)
             BOOST_CHECK(ls.size() == precompiled::BFS_SYS_SUBS_COUNT);
         }
         std::set<std::string> lsSet;
-        for (const auto& item : ls | RANGES::views::transform([](auto&& bfs) -> std::string {
+        for (const auto& item : ls | ::ranges::views::transform([](auto&& bfs) -> std::string {
                  return std::get<0>(bfs);
              }))
         {
@@ -837,7 +839,7 @@ BOOST_AUTO_TEST_CASE(lsPageTest)
             take--;
         }
         for (auto const& sysSub :
-            precompiled::BFS_SYS_SUBS | RANGES::views::take(take) | RANGES::views::drop(1))
+            precompiled::BFS_SYS_SUBS | ::ranges::views::take(take) | ::ranges::views::drop(1))
         {
             BOOST_CHECK(lsSet.contains(std::string(sysSub.substr(tool::FS_SYS_BIN.size() + 1))));
         }
@@ -909,14 +911,14 @@ BOOST_AUTO_TEST_CASE(lsPagWasmTest)
         BOOST_CHECK(code == (int)CODE_SUCCESS);
         BOOST_CHECK(ls.size() == 4);
         std::set<std::string> lsSet;
-        for (const auto& item : ls | RANGES::views::transform([](auto&& bfs) -> std::string {
+        for (const auto& item : ls | ::ranges::views::transform([](auto&& bfs) -> std::string {
                  return std::get<0>(bfs);
              }))
         {
             lsSet.insert(item);
         }
 
-        for (auto const& rootSub : tool::FS_ROOT_SUBS | RANGES::views::drop(1))
+        for (auto const& rootSub : tool::FS_ROOT_SUBS | ::ranges::views::drop(1))
         {
             BOOST_CHECK(lsSet.contains(std::string(rootSub.substr(1))));
         }
@@ -942,7 +944,7 @@ BOOST_AUTO_TEST_CASE(lsPagWasmTest)
             BOOST_CHECK(ls.size() == precompiled::BFS_SYS_SUBS_COUNT);
         }
         std::set<std::string> lsSet;
-        for (const auto& item : ls | RANGES::views::transform([](auto&& bfs) -> std::string {
+        for (const auto& item : ls | ::ranges::views::transform([](auto&& bfs) -> std::string {
                  return std::get<0>(bfs);
              }))
         {
@@ -961,7 +963,7 @@ BOOST_AUTO_TEST_CASE(lsPagWasmTest)
             take--;
         }
         for (auto const& sysSub :
-            precompiled::BFS_SYS_SUBS | RANGES::views::take(take) | RANGES::views::drop(1))
+            precompiled::BFS_SYS_SUBS | ::ranges::views::take(take) | ::ranges::views::drop(1))
         {
             BOOST_CHECK(lsSet.contains(std::string(sysSub.substr(tool::FS_SYS_BIN.size() + 1))));
         }

--- a/bcos-executor/test/unittest/libprecompiled/WorkingSealerManagerTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/WorkingSealerManagerTest.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(testRotate)
         auto blockHeader = std::make_unique<bcostars::protocol::BlockHeaderImpl>(
             [m_header = bcostars::BlockHeader()]() mutable { return std::addressof(m_header); });
         bcos::protocol::ParentInfo parentInfo;
-        blockHeader->setParentInfo(RANGES::views::single(parentInfo));
+        blockHeader->setParentInfo(::ranges::views::single(parentInfo));
         blockHeader->calculateHash(*hashImpl);
 
         auto blockContext = std::make_unique<executor::BlockContext>(storageWrapper, nullptr,

--- a/bcos-executor/test/unittest/libvm/TestTransactionExecutive.cpp
+++ b/bcos-executor/test/unittest/libvm/TestTransactionExecutive.cpp
@@ -295,7 +295,7 @@ public:
     }
 
     auto rawNewHelloWorld(uint blockNumber, TransactionType type, std::string contractAddress,
-        RANGES::input_range auto nonces, int32_t status)
+        ::ranges::input_range auto nonces, int32_t status)
     {
         auto const sender = keyPair->address(hashImpl);
         bcos::ledger::account::EVMAccount eoa(*storage, sender.hex(), false);
@@ -316,7 +316,7 @@ public:
             params->setNonce(toQuantity(nonce));
             params->setTransactionHash(hash);
             params->setContextID(blockNumber);
-            params->setSeq(RANGES::distance(RANGES::begin(nonces), it));
+            params->setSeq(::ranges::distance(::ranges::begin(nonces), it));
             params->setDepth(0);
             params->setFrom(sender.hex());
             params->setTo(contractAddress);
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(testMultiNonce)
     nextBlock(newBlock, protocol::BlockVersion::MAX_VERSION, web3Features);
     // [10000, 10020)
     rawNewHelloWorld(
-        newBlock, TransactionType::Web3Transaction, address, RANGES::views::iota(10000, 10020), 0);
+        newBlock, TransactionType::Web3Transaction, address, ::ranges::views::iota(10000, 10020), 0);
     commitBlock(newBlock);
 
     auto const sender = keyPair->address(hashImpl);
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(testMultiNonce)
     // protocol::BlockVersion::MAX_VERSION, web3Features);
     // // [10000, 10020)
     // rawNewHelloWorld(
-    //     newBlock, TransactionType::Web3Transaction, address, RANGES::views::iota(10000, 10020),
+    //     newBlock, TransactionType::Web3Transaction, address, ::ranges::views::iota(10000, 10020),
     //     16);
     // commitBlock(newBlock);
 }

--- a/bcos-executor/test/unittest/mock/MockBlock.h
+++ b/bcos-executor/test/unittest/mock/MockBlock.h
@@ -49,8 +49,8 @@ public:
     uint64_t transactionsMetaDataSize() const override { return 0; }
     uint64_t transactionsHashSize() const override { return Block::transactionsHashSize(); }
     uint64_t receiptsSize() const override { return 0; }
-    void setNonceList(RANGES::any_view<protocol::NonceType> nonces) override {}
-    RANGES::any_view<protocol::NonceType> nonceList() const override { return m_nodelist; }
+    void setNonceList(::ranges::any_view<protocol::NonceType> nonces) override {}
+    ::ranges::any_view<protocol::NonceType> nonceList() const override { return m_nodelist; }
     size_t size() const override { return 0; }
 
     protocol::ViewResult<crypto::HashType> transactionHashes() const override { return {}; }

--- a/bcos-executor/test/unittest/mock/MockBlockHeader.h
+++ b/bcos-executor/test/unittest/mock/MockBlockHeader.h
@@ -20,7 +20,7 @@ public:
     void encode(bytes& _encodeData) const override {}
     void clear() override {}
     uint32_t version() const override { return 0; }
-    RANGES::any_view<bcos::protocol::ParentInfo, RANGES::category::input | RANGES::category::sized>
+    ::ranges::any_view<bcos::protocol::ParentInfo, ::ranges::category::input | ::ranges::category::sized>
     parentInfo() const override
     {
         return {};
@@ -38,7 +38,7 @@ public:
     gsl::span<const uint64_t> consensusWeights() const override { return {}; }
 
     void setVersion(uint32_t _version) override {}
-    void setParentInfo(RANGES::any_view<bcos::protocol::ParentInfo> parentInfo) override {}
+    void setParentInfo(::ranges::any_view<bcos::protocol::ParentInfo> parentInfo) override {}
     void setTxsRoot(bcos::crypto::HashType _txsRoot) override {}
     void setReceiptsRoot(bcos::crypto::HashType _receiptsRoot) override {}
     void setStateRoot(bcos::crypto::HashType _stateRoot) override {}

--- a/bcos-executor/test/unittest/mock/MockKeyPageStorage.h
+++ b/bcos-executor/test/unittest/mock/MockKeyPageStorage.h
@@ -65,8 +65,8 @@ public:
     }
 
     void asyncGetRows(std::string_view table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<storage::Entry>>)>
             _callback) noexcept override
@@ -137,11 +137,11 @@ public:
     }
 
     Error::Ptr setRows(std::string_view tableName,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             keys,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             values) noexcept override
     {
         std::promise<bool> p;

--- a/bcos-executor/test/unittest/mock/MockTransactionalStorage.h
+++ b/bcos-executor/test/unittest/mock/MockTransactionalStorage.h
@@ -35,8 +35,8 @@ public:
     }
 
     void asyncGetRows(std::string_view table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<storage::Entry>>)>
             _callback) noexcept override

--- a/bcos-framework/bcos-framework/executor/PrecompiledTypeDef.h
+++ b/bcos-framework/bcos-framework/executor/PrecompiledTypeDef.h
@@ -22,6 +22,7 @@
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include <bcos-utilities/Common.h>
 #include <charconv>
+#include <range/v3/algorithm/binary_search.hpp>
 
 namespace bcos
 {

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -7,6 +7,7 @@
 #include "bcos-utilities/Exceptions.h"
 #include <evmc/evmc.h>
 #include <boost/throw_exception.hpp>
+#include <range/v3/algorithm/copy.hpp>
 
 namespace bcos::ledger::account
 {

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -10,6 +10,10 @@
 #include <array>
 #include <bitset>
 #include <magic_enum/magic_enum.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/zip.hpp>
 namespace bcos::ledger
 {
 DERIVE_BCOS_EXCEPTION(NoSuchFeatureError);

--- a/bcos-framework/bcos-framework/ledger/Ledger.h
+++ b/bcos-framework/bcos-framework/ledger/Ledger.h
@@ -9,6 +9,7 @@
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-task/Task.h"
+#include <range/v3/range/concepts.hpp>
 
 #define LEDGER_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("LEDGER")
 
@@ -159,7 +160,7 @@ inline constexpr struct SetNodeList
 {
     task::Task<void> operator()(
         storage2::WritableStorage<executor_v1::StateKey, executor_v1::StateValue> auto& storage,
-        RANGES::input_range auto&& nodeList, auto&&... args) const
+        ::ranges::input_range auto&& nodeList, auto&&... args) const
     {
         co_await tag_invoke(*this, storage, std::forward<decltype(nodeList)>(nodeList),
             std::forward<decltype(args)>(args)...);

--- a/bcos-framework/bcos-framework/ledger/SystemConfigs.h
+++ b/bcos-framework/bcos-framework/ledger/SystemConfigs.h
@@ -90,7 +90,7 @@ public:
 
     auto systemConfigs() const
     {
-        return ::ranges::views::iota(0LU, m_sysConfigs.size()) |
+        return ::ranges::views::iota(std::size_t{0}, std::size_t{m_sysConfigs.size()}) |
                ::ranges::views::transform([this](size_t index) {
                    auto flag = magic_enum::enum_value<SystemConfig>(index);
                    return std::make_tuple(
@@ -101,7 +101,8 @@ public:
     // return all config names
     static auto supportConfigs()
     {
-        return ::ranges::views::iota(0LU, magic_enum::enum_count<SystemConfig>()) |
+        return ::ranges::views::iota(
+               std::size_t{0}, std::size_t{magic_enum::enum_count<SystemConfig>()}) |
                ::ranges::views::transform([](size_t index) {
                    auto flag = magic_enum::enum_value<SystemConfig>(index);
                    return magic_enum::enum_name(flag);

--- a/bcos-framework/bcos-framework/storage/StorageInterface.h
+++ b/bcos-framework/bcos-framework/storage/StorageInterface.h
@@ -28,6 +28,7 @@
 #include "Common.h"
 #include "Entry.h"
 #include <bcos-utilities/Error.h>
+#include <range/v3/view/any_view.hpp>
 #include <memory>
 #include <optional>
 #include <string>
@@ -57,8 +58,9 @@ public:
         std::function<void(Error::UniquePtr, std::optional<Entry>)> _callback) = 0;
 
     virtual void asyncGetRows(std::string_view table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback) = 0;
 
@@ -74,11 +76,11 @@ public:
     virtual void asyncGetTableInfo(std::string_view tableName,
         std::function<void(Error::UniquePtr, TableInfo::ConstPtr)> callback);
     virtual Error::Ptr setRows(std::string_view tableName,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             keys,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             values)
     {
         throw std::invalid_argument("unimplemented method");

--- a/bcos-framework/bcos-framework/storage/Table.h
+++ b/bcos-framework/bcos-framework/storage/Table.h
@@ -24,6 +24,7 @@
 #include "StorageInterface.h"
 #include <future>
 #include <gsl/span>
+#include <range/v3/view/any_view.hpp>
 
 namespace bcos::storage
 {
@@ -41,8 +42,8 @@ public:
     ~Table() = default;
 
     std::optional<Entry> getRow(std::string_view _key);
-    std::vector<std::optional<Entry>> getRows(RANGES::any_view<std::string_view,
-        RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+    std::vector<std::optional<Entry>> getRows(::ranges::any_view<std::string_view,
+        ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
             keys);
     std::vector<std::string> getPrimaryKeys(const std::optional<const Condition>& _condition);
 
@@ -55,8 +56,8 @@ public:
         std::function<void(Error::UniquePtr, std::optional<Entry>)> _callback) noexcept;
 
     void asyncGetRows(
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)>
             _callback) noexcept;

--- a/bcos-framework/bcos-framework/sync/SyncConfig.h
+++ b/bcos-framework/bcos-framework/sync/SyncConfig.h
@@ -24,6 +24,7 @@
 #include <bcos-framework/protocol/ProtocolTypeDef.h>
 #include <bcos-utilities/Log.h>
 #include <mutex>
+#include <range/v3/view/filter.hpp>
 namespace bcos::sync
 {
 class SyncConfig
@@ -122,7 +123,7 @@ public:
     {
         std::scoped_lock lock(x_nodeList, x_connectedNodeList);
         auto nodeList =
-            m_nodeList | RANGES::views::filter([this](const bcos::crypto::NodeIDPtr& _nodeId) {
+            m_nodeList | ::ranges::views::filter([this](const bcos::crypto::NodeIDPtr& _nodeId) {
                 return m_connectedNodeList.contains(_nodeId);
             });
         return {nodeList.begin(), nodeList.end()};

--- a/bcos-framework/bcos-framework/testutils/faker/FakeBlockHeader.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeBlockHeader.h
@@ -29,6 +29,7 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 #include <memory>
+#include <range/v3/view/zip.hpp>
 using namespace bcos;
 using namespace bcos::protocol;
 using namespace bcos::crypto;
@@ -45,7 +46,7 @@ inline void checkBlockHeader(BlockHeader::Ptr blockHeader, BlockHeader::Ptr deco
     auto decodedParent = decodedBlockHeader->parentInfo();
     BOOST_CHECK_EQUAL(originParent.size(), decodedParent.size());
     for (auto [originParentInfo, decodedParentInfo] :
-        RANGES::views::zip(originParent, decodedParent))
+        ::ranges::views::zip(originParent, decodedParent))
     {
         BOOST_CHECK_EQUAL(originParentInfo.blockHash, decodedParentInfo.blockHash);
         BOOST_CHECK_EQUAL(originParentInfo.blockNumber, decodedParentInfo.blockNumber);

--- a/bcos-framework/bcos-framework/testutils/faker/FakeLedger.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeLedger.h
@@ -26,6 +26,7 @@
 #include <bcos-utilities/ThreadPool.h>
 
 #include <map>
+#include <range/v3/view/concat.hpp>
 #include <string>
 #include <utility>
 
@@ -79,8 +80,8 @@ public:
 
         // 修复 asyncGetRows 方法签名
         void asyncGetRows(std::string_view table,
-            RANGES::any_view<std::string_view,
-                RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+            ::ranges::any_view<std::string_view,
+                ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
                 keys,
             std::function<void(Error::UniquePtr, std::vector<std::optional<storage::Entry>>)>
                 _callback) override

--- a/bcos-framework/bcos-framework/txpool/TxPoolInterface.h
+++ b/bcos-framework/bcos-framework/txpool/TxPoolInterface.h
@@ -137,7 +137,7 @@ public:
     // called by frontService to dispatch message
     virtual void asyncNotifyTxsSyncMessage(bcos::Error::Ptr _error, std::string const& _id,
         bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data,
-        std::function<void(Error::Ptr _error)> _onRecv) = 0;
+        std::function<void(Error::Ptr)> _onRecv) = 0;
     virtual void notifyConsensusNodeList(
         bcos::consensus::ConsensusNodeList const& _consensusNodeList,
         std::function<void(Error::Ptr)> _onRecvResponse) = 0;
@@ -158,8 +158,7 @@ public:
     virtual void registerTxsCleanUpSwitch(std::function<bool()>) {}
 
     virtual void tryToSyncTxsFromPeers() {}
-    virtual void registerTxsNotifier(
-        std::function<void(size_t, std::function<void(Error::Ptr)>)> _txsNotifier)
+    virtual void registerTxsNotifier(std::function<void(size_t, std::function<void(Error::Ptr)>)>)
     {}
 };
 

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -208,8 +208,8 @@ BOOST_AUTO_TEST_CASE(feature)
 auto validFlags(const Features& features)
 {
     return features.flags() |
-           RANGES::views::filter([](auto feature) { return std::get<2>(feature); }) |
-           RANGES::to<std::vector>();
+           ::ranges::views::filter([](auto feature) { return std::get<2>(feature); }) |
+           ::ranges::to<std::vector>();
 }
 
 BOOST_AUTO_TEST_CASE(upgrade)

--- a/bcos-framework/test/unittests/interfaces/TestTransactionExecutor.cpp
+++ b/bcos-framework/test/unittests/interfaces/TestTransactionExecutor.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(single_view)
     int i = 100;
     auto& ref = i;
 
-    auto view = RANGES::views::single(ref);
+    auto view = ::ranges::views::single(ref);
     auto&& j = view[0];
     BOOST_CHECK_EQUAL(view[0], 100);
 }

--- a/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
@@ -1,3 +1,4 @@
+#include <range/v3/view/filter.hpp>
 #include "bcos-framework/storage/Entry.h"
 #include "bcos-framework/storage2/MemoryStorage.h"
 #include "bcos-framework/storage2/Storage.h"
@@ -7,7 +8,11 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 #include <functional>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/repeat.hpp>
 #include <range/v3/view/transform.hpp>
+#include <range/v3/view/zip.hpp>
 #include <string>
 #include <variant>
 
@@ -151,7 +156,7 @@ BOOST_AUTO_TEST_CASE(lru)
         storage::Entry entry;
         entry.set(std::string(100, 'a'));
         co_await storage2::writeSome(storage,
-            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view(entry)));
+            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::views::repeat(entry)));
 
         // ensure 10 are useable
         auto values = co_await storage2::readSome(storage, ::ranges::views::iota(0, 10));
@@ -268,7 +273,7 @@ BOOST_AUTO_TEST_CASE(range)
                 bcos::storage2::memory_storage::ORDERED)>
             intStorage;
         co_await storage2::writeSome(intStorage,
-            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
+            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::views::repeat(100)));
         auto start = 4;
         auto range3 = co_await storage2::range(intStorage, storage2::RANGE_SEEK, start);
         while (auto pair = co_await range3.next())
@@ -287,9 +292,9 @@ BOOST_AUTO_TEST_CASE(merge)
         MemoryStorage<int, int, ORDERED> storage2;
 
         co_await storage2::writeSome(storage1,
-            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
+            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::views::repeat(100)));
         co_await storage2::writeSome(storage2,
-            ::ranges::views::zip(::ranges::views::iota(9, 19), ::ranges::repeat_view<int>(200)));
+            ::ranges::views::zip(::ranges::views::iota(9, 19), ::ranges::views::repeat(200)));
 
         co_await storage2::merge(storage1, storage2);
         auto values = co_await storage2::range(storage1);
@@ -319,9 +324,9 @@ BOOST_AUTO_TEST_CASE(merge)
         MemoryStorage<int, int, ORDERED | CONCURRENT> storage5;
 
         co_await storage2::writeSome(storage3,
-            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
+            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::views::repeat(100)));
         co_await storage2::writeSome(storage4,
-            ::ranges::views::zip(::ranges::views::iota(10, 20), ::ranges::repeat_view<int>(100)));
+            ::ranges::views::zip(::ranges::views::iota(10, 20), ::ranges::views::repeat(100)));
         co_await storage2::merge(storage5, storage3, storage4);
 
         auto values2 = co_await storage2::readSome(storage5, ::ranges::views::iota(0, 20));
@@ -339,7 +344,7 @@ BOOST_AUTO_TEST_CASE(directDelete)
         MemoryStorage<int, int, bcos::storage2::memory_storage::LOGICAL_DELETION, std::hash<int>>
             storage;
         co_await storage2::writeSome(storage,
-            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
+            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::views::repeat(100)));
 
         auto range1 = co_await storage2::range(storage);
         int count1 = 0;
@@ -498,7 +503,7 @@ BOOST_AUTO_TEST_CASE(dirtctReadOne)
                 bcos::storage2::memory_storage::LOGICAL_DELETION>
             storage;
         co_await storage2::writeSome(storage,
-            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
+            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::views::repeat(100)));
         co_await storage2::removeOne(storage, 6);
 
         auto value = co_await storage2::readOne(storage, 6);
@@ -518,7 +523,7 @@ BOOST_AUTO_TEST_CASE(dirtctReadOne)
 
         MemoryStorage<int, int, bcos::storage2::memory_storage::ORDERED> storage_2;
         co_await storage2::writeSome(storage_2,
-            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::repeat_view<int>(100)));
+            ::ranges::views::zip(::ranges::views::iota(0, 10), ::ranges::views::repeat(100)));
         co_await storage2::removeOne(storage_2, 6);
 
         auto value21 = co_await storage2::readOne(storage_2, 6);

--- a/bcos-front/test/unittests/FakeGateway.cpp
+++ b/bcos-front/test/unittests/FakeGateway.cpp
@@ -21,6 +21,8 @@
 
 #include "FakeGateway.h"
 #include <bcos-front/Common.h>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/join.hpp>
 
 using namespace bcos;
 using namespace bcos::front;

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -32,6 +32,7 @@
 #include <bcos-tars-protocol/protocol/GroupNodeInfoImpl.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
+#include <range/v3/view/single.hpp>
 
 using namespace bcos;
 using namespace bcos::test;

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -31,6 +31,7 @@
 #include "bcos-gateway/libratelimit/GatewayRateLimiter.h"
 #include "bcos-utilities/BoostLog.h"
 #include "filter/ReadOnlyFilter.h"
+#include <range/v3/range/concepts.hpp>
 
 
 namespace bcos::gateway
@@ -177,7 +178,7 @@ public:
     }
 
     // insert p2pIDs
-    void insertP2pIDs(RANGES::range auto const& _p2pIDs)
+    void insertP2pIDs(::ranges::range auto const& _p2pIDs)
     {
         std::lock_guard<std::mutex> lock(x_mutex);
         m_p2pIDs.insert(m_p2pIDs.end(), _p2pIDs.begin(), _p2pIDs.end());

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -17,6 +17,9 @@
  * @author: octopus
  * @date 2021-10-26
  */
+#include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/view/concat.hpp>
+#include <range/v3/view/single.hpp>
 #include "AMOPImpl.h"
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-framework/protocol/CommonError.h"

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -24,6 +24,8 @@
 #include <functional>
 #include <iterator>
 #include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/view/concat.hpp>
+#include <range/v3/view/single.hpp>
 #include <range/v3/view/transform.hpp>
 #include <utility>
 #include <variant>

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <range/v3/numeric/accumulate.hpp>
 #include <utility>
 #include <variant>
 

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -18,6 +18,8 @@
  * @date 2021-05-04
  */
 
+#include <range/v3/view/map.hpp>
+#include <range/v3/view/transform.hpp>
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-framework/gateway/GatewayTypeDef.h"
 #include "bcos-gateway/Common.h"

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -16,6 +16,8 @@
 #include "bcos-utilities/Common.h"
 #include <boost/random.hpp>
 #include <boost/throw_exception.hpp>
+#include <range/v3/view/map.hpp>
+#include <range/v3/view/transform.hpp>
 #include <shared_mutex>
 #include <utility>
 

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -66,6 +66,10 @@
 #include <future>
 #include <iterator>
 #include <memory>
+#include <range/v3/algorithm/sort.hpp>
+#include <range/v3/view/chunk.hpp>
+#include <range/v3/view/concat.hpp>
+#include <range/v3/view/take.hpp>
 #include <utility>
 
 using namespace bcos;

--- a/bcos-ledger/bcos-ledger/LedgerImpl.h
+++ b/bcos-ledger/bcos-ledger/LedgerImpl.h
@@ -15,7 +15,10 @@
 #include <bcos-table/src/StateStorageFactory.h>
 #include <bcos-tool/VersionConverter.h>
 #include <bcos-utilities/DataConvertUtility.h>
-#include <bcos-utilities/Ranges.h>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/traits.hpp>
+#include <range/v3/view/transform.hpp>
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
 #include <boost/lexical_cast.hpp>
@@ -60,7 +63,7 @@ public:
         std::array<std::byte, Hasher::HASH_SIZE> parentHash;
         bcos::concepts::hash::calculate(parentBlock, m_hasher.clone(), parentHash);
 
-        if (RANGES::empty(block.blockHeader.data.parentInfo) ||
+        if (::ranges::empty(block.blockHeader.data.parentInfo) ||
             (block.blockHeader.data.parentInfo[0].blockNumber !=
                 parentBlock.blockHeader.data.blockNumber) ||
             !bcos::concepts::bytebuffer::equalTo(
@@ -224,19 +227,19 @@ private:
         co_return abiStr;
     }
 
-    task::Task<void> impl_getTransactions(RANGES::range auto const& hashes, RANGES::range auto& out)
+    task::Task<void> impl_getTransactions(::ranges::range auto const& hashes, ::ranges::range auto& out)
     {
-        bcos::concepts::resizeTo(out, RANGES::size(hashes));
-        using DataType = RANGES::range_value_t<std::remove_cvref_t<decltype(out)>>;
+        bcos::concepts::resizeTo(out, ::ranges::size(hashes));
+        using DataType = ::ranges::range_value_t<std::remove_cvref_t<decltype(out)>>;
 
         constexpr auto tableName =
             bcos::concepts::transaction::Transaction<DataType> ? SYS_HASH_2_TX : SYS_HASH_2_RECEIPT;
 
-        LEDGER_LOG(INFO) << "getTransactions: " << tableName << " " << RANGES::size(hashes);
+        LEDGER_LOG(INFO) << "getTransactions: " << tableName << " " << ::ranges::size(hashes);
         auto entries = storage().getRows(std::string_view{tableName}, hashes);
 
-        bcos::concepts::resizeTo(out, RANGES::size(hashes));
-        tbb::parallel_for(tbb::blocked_range<size_t>(0U, RANGES::size(entries)),
+        bcos::concepts::resizeTo(out, ::ranges::size(hashes));
+        tbb::parallel_for(tbb::blocked_range<size_t>(0U, ::ranges::size(entries)),
             [&entries, &out](const tbb::blocked_range<size_t>& range) {
                 for (auto index = range.begin(); index != range.end(); ++index)
                 {
@@ -264,7 +267,7 @@ private:
 
         bcos::concepts::ledger::Status status;
         auto entries = storage().getRows(SYS_CURRENT_STATE, keys);
-        for (auto i = 0U; i < RANGES::size(entries); ++i)
+        for (auto i = 0U; i < ::ranges::size(entries); ++i)
         {
             auto& entry = entries[i];
 
@@ -347,7 +350,7 @@ private:
                     blockNumber, block, syncNodeList);
             }
             // if getBlockByNodeList return empty block, break
-            if (RANGES::empty(block.blockHeader.data.parentInfo))
+            if (::ranges::empty(block.blockHeader.data.parentInfo))
             {
                 LEDGER_LOG(WARNING)
                     << LOG_DESC("No blockHeader in block") << LOG_KV("blockNumber", blockNumber);
@@ -425,7 +428,7 @@ private:
     {
         LEDGER_LOG(DEBUG) << "getBlockData transactions or receipts: " << blockNumberKey;
 
-        if (RANGES::empty(block.transactionsMetaData))
+        if (::ranges::empty(block.transactionsMetaData))
         {
             LEDGER_LOG(INFO) << "GetBlock not found transaction meta data!";
             co_return;
@@ -433,10 +436,10 @@ private:
 
         auto hashesRange =
             block.transactionsMetaData |
-            RANGES::views::transform(
+            ::ranges::views::transform(
                 [](typename decltype(block.transactionsMetaData)::value_type const& metaData)
                     -> auto& { return metaData.hash; });
-        auto outputSize = RANGES::size(block.transactionsMetaData);
+        auto outputSize = ::ranges::size(block.transactionsMetaData);
 
         if constexpr (std::is_same_v<Type, concepts::ledger::TRANSACTIONS>)
         {
@@ -547,7 +550,7 @@ private:
     {
         LEDGER_LOG(DEBUG) << "setBlockData transaction metadata: " << blockNumberKey;
 
-        if (RANGES::empty(block.transactionsMetaData) && !RANGES::empty(block.transactions))
+        if (::ranges::empty(block.transactionsMetaData) && !::ranges::empty(block.transactions))
         {
             block.transactionsMetaData.resize(block.transactions.size());
             tbb::parallel_for(tbb::blocked_range<size_t>(0, block.transactions.size()),

--- a/bcos-ledger/test/unittests/ledger/LedgerImplTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerImplTest.cpp
@@ -73,10 +73,10 @@ struct MockMemoryStorage : bcos::concepts::storage::StorageBase<MockMemoryStorag
     }
 
     std::vector<std::optional<bcos::storage::Entry>> impl_getRows(
-        std::string_view table, RANGES::range auto const& keys)
+        std::string_view table, ::ranges::range auto const& keys)
     {
         std::vector<std::optional<bcos::storage::Entry>> output;
-        output.reserve(RANGES::size(keys));
+        output.reserve(::ranges::size(keys));
         for (auto&& key : keys)
         {
             output.emplace_back(getRow(table, bcos::concepts::bytebuffer::toView(key)));
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(notExistsBlock)
 
     std::vector<std::byte> hash;
     bcos::task::syncWait(ledger.getBlockHashByNumber(50, hash));
-    BOOST_CHECK(RANGES::empty(hash));
+    BOOST_CHECK(::ranges::empty(hash));
 
     int64_t number = 0;
     bcos::task::syncWait(ledger.getBlockNumberByHash(hash, number));

--- a/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
@@ -96,11 +96,11 @@ public:
       : storage::StateStorageInterface(prev), StateStorage(prev, false)
     {}
     bcos::Error::Ptr setRows(std::string_view tableName,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             keys,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             values) override
     {
         for (size_t i = 0; i < keys.size(); ++i)
@@ -1456,8 +1456,8 @@ BOOST_AUTO_TEST_CASE(genesisBlockWithAllocs)
         std::string hexCode;
         boost::algorithm::hex_lower(code, std::back_inserter(hexCode));
 
-        genesisConfig.m_allocs = RANGES::views::iota(0, 10) |
-                                 RANGES::views::transform([&](int index) {
+        genesisConfig.m_allocs = ::ranges::views::iota(0, 10) |
+                                 ::ranges::views::transform([&](int index) {
                                      Alloc alloc{.address = fmt::format("{:0>40}", index),
                                          .balance = bcos::u256(index * 10),
                                          .nonce = {},
@@ -1471,11 +1471,11 @@ BOOST_AUTO_TEST_CASE(genesisBlockWithAllocs)
                                      }
                                      return alloc;
                                  }) |
-                                 RANGES::to<std::vector>();
+                                 ::ranges::to<std::vector>();
 
         co_await ledger::buildGenesisBlock(*ledger, genesisConfig, param);
 
-        for (auto i : RANGES::views::iota(0, 10))
+        for (auto i : ::ranges::views::iota(0, 10))
         {
             auto tableName = fmt::format("{}{:0>40}", SYS_DIRECTORY::USER_APPS, i);
             auto codeHashEntry = co_await storage2::readOne(

--- a/bcos-pbft/bcos-pbft/core/ConsensusConfig.cpp
+++ b/bcos-pbft/bcos-pbft/core/ConsensusConfig.cpp
@@ -19,6 +19,7 @@
  * @date 2021-04-09
  */
 #include "ConsensusConfig.h"
+#include <range/v3/algorithm/sort.hpp>
 
 using namespace bcos;
 using namespace bcos::crypto;

--- a/bcos-rpc/bcos-rpc/Rpc.cpp
+++ b/bcos-rpc/bcos-rpc/Rpc.cpp
@@ -1,3 +1,6 @@
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/algorithm/result_types.hpp>
 /**
  *  Copyright (C) 2021 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/NetEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/NetEndpoint.cpp
@@ -1,3 +1,6 @@
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/algorithm/result_types.hpp>
 /**
  *  Copyright (C) 2024 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
@@ -25,6 +25,7 @@
 #include <bcos-framework/protocol/Transaction.h>
 #include <bcos-rpc/jsonrpc/Common.h>
 #include <range/v3/algorithm/find_if.hpp>
+#include <range/v3/algorithm/move.hpp>
 #include <utility>
 
 namespace bcos

--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -1,3 +1,9 @@
+#include <range/v3/range_fwd.hpp>
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/algorithm/result_types.hpp>
+#include <range/v3/view/drop.hpp>
+
 #include "BlockExecutive.h"
 #include "Common.h"
 #include "DmcExecutor.h"

--- a/bcos-scheduler/test/mock/MockLedger3.h
+++ b/bcos-scheduler/test/mock/MockLedger3.h
@@ -16,6 +16,7 @@
 #include <bcos-utilities/Error.h>
 #include <boost/test/unit_test.hpp>
 #include <gsl/span>
+#include <range/v3/algorithm/count.hpp>
 #include <map>
 
 using namespace bcos::ledger;
@@ -146,7 +147,7 @@ public:
         {
             _onGetConfig(nullptr, "20200", commitBlockNumber);
         }
-        else if (RANGES::count(ledger::Features::featureKeys(), _key) > 0)
+        else if (::ranges::count(ledger::Features::featureKeys(), _key) > 0)
         {
             _onGetConfig(BCOS_ERROR_PTR(-1, "Not found!"), "0", commitBlockNumber);
         }

--- a/bcos-scheduler/test/mock/MockTransactionalStorage.h
+++ b/bcos-scheduler/test/mock/MockTransactionalStorage.h
@@ -30,8 +30,8 @@ public:
     }
 
     void asyncGetRows(std::string_view table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<storage::Entry>>)>
             _callback) noexcept override

--- a/bcos-sealer/bcos-sealer/SealingManager.cpp
+++ b/bcos-sealer/bcos-sealer/SealingManager.cpp
@@ -20,6 +20,7 @@
 #include "SealingManager.h"
 #include "Common.h"
 #include "Sealer.h"
+#include <range/v3/view/concat.hpp>
 
 using namespace bcos;
 using namespace bcos::sealer;

--- a/bcos-security/bcos-security/BcosKms.cpp
+++ b/bcos-security/bcos-security/BcosKms.cpp
@@ -29,7 +29,11 @@
 #include <iostream>
 #include <string>
 
-using namespace std;
+using std::endl;
+using std::exception;
+using std::make_shared;
+using std::string;
+using std::to_string;
 using namespace bcos;
 using namespace crypto;
 using namespace security;

--- a/bcos-security/bcos-security/BcosKmsDataEncryption.cpp
+++ b/bcos-security/bcos-security/BcosKmsDataEncryption.cpp
@@ -30,7 +30,6 @@
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
 
-using namespace std;
 using namespace bcos;
 using namespace crypto;
 using namespace tool;
@@ -39,6 +38,8 @@ namespace bcos
 {
 namespace security
 {
+using namespace std;
+
 BcosKmsDataEncryption::BcosKmsDataEncryption(const bcos::tool::NodeConfig::Ptr nodeConfig)
 {
     m_nodeConfig = nodeConfig;

--- a/bcos-security/bcos-security/BcosKmsKeyEncryption.cpp
+++ b/bcos-security/bcos-security/BcosKmsKeyEncryption.cpp
@@ -36,13 +36,14 @@
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
 
-using namespace std;
 using namespace bcos;
 using namespace crypto;
 using namespace tool;
 
 namespace bcos::security
 {
+using namespace std;
+
 BcosKmsKeyEncryption::BcosKmsKeyEncryption(const bcos::tool::NodeConfig::Ptr nodeConfig)
 {
     m_nodeConfig = nodeConfig;

--- a/bcos-security/bcos-security/HsmDataEncryption.cpp
+++ b/bcos-security/bcos-security/HsmDataEncryption.cpp
@@ -26,7 +26,6 @@
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
 
-using namespace std;
 using namespace bcos;
 using namespace crypto;
 using namespace tool;
@@ -35,6 +34,8 @@ namespace bcos
 {
 namespace security
 {
+using namespace std;
+
 HsmDataEncryption::HsmDataEncryption(const bcos::tool::NodeConfig::Ptr nodeConfig)
 {
     m_nodeConfig = nodeConfig;

--- a/bcos-security/bcos-security/HsmKeyEncryption.cpp
+++ b/bcos-security/bcos-security/HsmKeyEncryption.cpp
@@ -26,7 +26,6 @@
 #include <bcos-utilities/FileUtility.h>
 #include <bcos-utilities/Log.h>
 
-using namespace std;
 using namespace bcos;
 using namespace crypto;
 using namespace tool;
@@ -35,6 +34,8 @@ namespace bcos
 {
 namespace security
 {
+using namespace std;
+
 HsmKeyEncryption::HsmKeyEncryption(const bcos::tool::NodeConfig::Ptr nodeConfig)
 {
     m_nodeConfig = nodeConfig;

--- a/bcos-storage/bcos-storage/RocksDBStorage.cpp
+++ b/bcos-storage/bcos-storage/RocksDBStorage.cpp
@@ -154,8 +154,8 @@ void RocksDBStorage::asyncGetRow(std::string_view _table, std::string_view _key,
 }
 
 void RocksDBStorage::asyncGetRows(std::string_view _table,
-    RANGES::any_view<std::string_view,
-        RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view,
+        ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
         keys,
     std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback)
 {
@@ -505,9 +505,9 @@ void RocksDBStorage::asyncRollback(
 }
 
 bcos::Error::Ptr RocksDBStorage::setRows(std::string_view tableName,
-    RANGES::any_view<std::string_view, RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view, ::ranges::category::random_access | ::ranges::category::sized>
         keys,
-    RANGES::any_view<std::string_view, RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view, ::ranges::category::random_access | ::ranges::category::sized>
         values) noexcept
 {
     __itt_task_begin(ittapi::ITT_DOMAINS::instance().ITT_DOMAIN_STORAGE, __itt_null, __itt_null,

--- a/bcos-storage/bcos-storage/RocksDBStorage.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage.h
@@ -54,8 +54,9 @@ public:
 
     // due to the blocking of m_db->MultiGet, this interface is actually a synchronous interface
     void asyncGetRows(std::string_view table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback)
         override;
@@ -73,11 +74,11 @@ public:
     void asyncRollback(const bcos::protocol::TwoPCParams& params,
         std::function<void(Error::Ptr)> callback) override;
     Error::Ptr setRows(std::string_view tableName,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             keys,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             values) noexcept override;
     virtual Error::Ptr deleteRows(
         std::string_view, const std::variant<const gsl::span<std::string_view const>,

--- a/bcos-storage/bcos-storage/StorageWrapperImpl.h
+++ b/bcos-storage/bcos-storage/StorageWrapperImpl.h
@@ -4,6 +4,8 @@
 #include <bcos-concepts/storage/Storage.h>
 #include <bcos-framework/storage/Entry.h>
 #include <boost/throw_exception.hpp>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/concepts.hpp>
 
 namespace bcos::storage
 {
@@ -39,7 +41,7 @@ public:
     }
 
     std::vector<std::optional<Entry>> impl_getRows(
-        std::string_view table, RANGES::range auto const& keys)
+        std::string_view table, ::ranges::range auto const& keys)
     {
         Error::UniquePtr error;
         std::vector<std::optional<Entry>> entries;
@@ -51,11 +53,11 @@ public:
         };
 
         std::vector<std::string_view> viewArray;
-        viewArray.reserve(RANGES::size(keys));
+        viewArray.reserve(::ranges::size(keys));
         for (auto&& it : keys)
         {
             viewArray.emplace_back(
-                std::string_view((const char*)RANGES::data(it), RANGES::size(it)));
+            std::string_view((const char*)::ranges::data(it), ::ranges::size(it)));
         }
         storage().asyncGetRows(table, viewArray, std::move(callback));
 

--- a/bcos-storage/bcos-storage/TiKVStorage.cpp
+++ b/bcos-storage/bcos-storage/TiKVStorage.cpp
@@ -176,8 +176,8 @@ void TiKVStorage::asyncGetRow(std::string_view _table, std::string_view _key,
 }
 
 void TiKVStorage::asyncGetRows(std::string_view _table,
-    RANGES::any_view<std::string_view,
-        RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view,
+        ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
         keys,
     std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback) noexcept
 {
@@ -528,9 +528,9 @@ void TiKVStorage::asyncRollback(
 }
 
 bcos::Error::Ptr TiKVStorage::setRows(std::string_view tableName,
-    RANGES::any_view<std::string_view, RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view, ::ranges::category::random_access | ::ranges::category::sized>
         keys,
-    RANGES::any_view<std::string_view, RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view, ::ranges::category::random_access | ::ranges::category::sized>
         values) noexcept
 {
     bcos::Error::Ptr err = nullptr;

--- a/bcos-storage/bcos-storage/TiKVStorage.h
+++ b/bcos-storage/bcos-storage/TiKVStorage.h
@@ -59,8 +59,9 @@ public:
         std::function<void(Error::UniquePtr, std::optional<Entry>)> _callback) noexcept override;
 
     void asyncGetRows(std::string_view table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback) noexcept
         override;
@@ -79,11 +80,11 @@ public:
         std::function<void(Error::Ptr)> callback) noexcept override;
 
     Error::Ptr setRows(std::string_view tableName,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             keys,
-        RANGES::any_view<std::string_view,
-            RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::random_access | ::ranges::category::sized>
             values) noexcept override;
     virtual Error::Ptr deleteRows(
         std::string_view, const std::variant<const gsl::span<std::string_view const>,

--- a/bcos-storage/test/unittest/TestRocksDBStorage.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage.cpp
@@ -19,7 +19,6 @@
 #include <random>
 
 using namespace bcos::storage;
-using namespace std;
 
 // ostream& operator<<(ostream& os, const std::unique_ptr<bcos::Error>& error)
 // {
@@ -29,6 +28,8 @@ using namespace std;
 
 namespace bcos::test::rocksdb_test
 {
+using namespace std;
+
 class Header256Hash : public bcos::crypto::Hash
 {
 public:

--- a/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
@@ -8,6 +8,10 @@
 #include <fmt/format.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/repeat.hpp>
+#include <range/v3/view/zip.hpp>
 #include <string_view>
 
 using namespace bcos;
@@ -184,13 +188,13 @@ BOOST_AUTO_TEST_CASE(merge)
                           ::ranges::views::iota(0, 10) | ::ranges::views::transform([](int i) {
                               return StateKey{"Hello"sv, fmt::format("key{}", i)};
                           }),
-                          ::ranges::repeat_view<storage::Entry>(storage::Entry{"Hello"})));
+                          ::ranges::views::repeat(storage::Entry{"Hello"})));
         co_await storage2::writeSome(
             storage4, ::ranges::views::zip(
                           ::ranges::views::iota(10, 20) | ::ranges::views::transform([](int i) {
                               return StateKey{"Hello"sv, fmt::format("key{}", i)};
                           }),
-                          ::ranges::repeat_view<storage::Entry>(storage::Entry{"Hello"})));
+                          ::ranges::views::repeat(storage::Entry{"Hello"})));
         co_await storage2::merge(rocksDB2, storage3, storage4);
 
         auto values2 = co_await storage2::readSome(

--- a/bcos-storage/test/unittest/TestTiKVStorage.cpp
+++ b/bcos-storage/test/unittest/TestTiKVStorage.cpp
@@ -18,10 +18,11 @@
 #include <optional>
 
 using namespace bcos::storage;
-using namespace std;
 
 namespace bcos::test
 {
+using namespace std;
+
 size_t total = 500;
 
 class Header256Hash : public bcos::crypto::Hash

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -28,6 +28,8 @@
 #include "bcos-ledger/LedgerMethods.h"
 #include <json/json.h>
 #include <boost/bind/bind.hpp>
+#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/algorithm/sort.hpp>
 #include <string>
 
 using namespace bcos;
@@ -1026,16 +1028,16 @@ void BlockSync::updateTreeTopologyNodeInfo()
     bcos::crypto::NodeIDs allNodeIDs;
 
     // extract NodeIDs
-    RANGES::for_each(m_config->consensusNodeList(), [&consensusNodeIDs, &allNodeIDs](auto& node) {
+    ::ranges::for_each(m_config->consensusNodeList(), [&consensusNodeIDs, &allNodeIDs](auto& node) {
         consensusNodeIDs.emplace_back(node.nodeID);
         allNodeIDs.emplace_back(node.nodeID);
     });
-    RANGES::for_each(m_config->observerNodeList(),
+    ::ranges::for_each(m_config->observerNodeList(),
         [&allNodeIDs](auto& node) { allNodeIDs.emplace_back(node.nodeID); });
 
-    RANGES::sort(consensusNodeIDs.begin(), consensusNodeIDs.end(),
+    ::ranges::sort(consensusNodeIDs.begin(), consensusNodeIDs.end(),
         [](auto& a, auto& b) { return a->data() < b->data(); });
-    RANGES::sort(allNodeIDs.begin(), allNodeIDs.end(),
+    ::ranges::sort(allNodeIDs.begin(), allNodeIDs.end(),
         [](auto& a, auto& b) { return a->data() < b->data(); });
 
     m_syncTreeTopology->updateAllNodeInfo(consensusNodeIDs, allNodeIDs);

--- a/bcos-sync/bcos-sync/utilities/SyncTreeTopology.cpp
+++ b/bcos-sync/bcos-sync/utilities/SyncTreeTopology.cpp
@@ -19,6 +19,8 @@
  * @date 2023-03-22
  */
 #include "bcos-sync/bcos-sync/utilities/SyncTreeTopology.h"
+#include "bcos-utilities/BoostLog.h"
+#include <range/v3/view/enumerate.hpp>
 
 using namespace bcos;
 using namespace bcos::sync;
@@ -151,7 +153,7 @@ bcos::crypto::NodeIDSetPtr SyncTreeTopology::selectParentNodes(
     if (m_consIndex >= 0)
     {
         auto selectedNodeSet = std::make_shared<bcos::crypto::NodeIDSet>();
-        for (auto const& [idx, consNode] : *m_consensusNodes | RANGES::views::enumerate)
+        for (auto const& [idx, consNode] : *m_consensusNodes | ::ranges::views::enumerate)
         {
             if (_peers.contains(consNode) && static_cast<std::uint64_t>(m_consIndex) != idx)
             {

--- a/bcos-table/src/KeyPageStorage.cpp
+++ b/bcos-table/src/KeyPageStorage.cpp
@@ -131,8 +131,8 @@ void KeyPageStorage::asyncGetRow(std::string_view tableView, std::string_view ke
 }
 
 void KeyPageStorage::asyncGetRows(std::string_view tableView,
-    RANGES::any_view<std::string_view,
-        RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view,
+        ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
         keys,
     std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback)
 {

--- a/bcos-table/src/KeyPageStorage.h
+++ b/bcos-table/src/KeyPageStorage.h
@@ -128,8 +128,9 @@ public:
         std::function<void(Error::UniquePtr, std::optional<Entry>)> _callback) override;
 
     void asyncGetRows(std::string_view tableView,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback)
         override;

--- a/bcos-table/src/StateStorage.h
+++ b/bcos-table/src/StateStorage.h
@@ -220,8 +220,9 @@ public:
     }
 
     void asyncGetRows(std::string_view tableView,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys,
         std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback) override
     {

--- a/bcos-table/src/StorageWrapper.h
+++ b/bcos-table/src/StorageWrapper.h
@@ -119,8 +119,9 @@ public:
     }
 
     virtual std::vector<std::optional<storage::Entry>> getRows(const std::string_view& table,
-        RANGES::any_view<std::string_view,
-            RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+        ::ranges::any_view<std::string_view,
+            ::ranges::category::input | ::ranges::category::random_access |
+                ::ranges::category::sized>
             keys)
     {
         GetRowsResponse value;

--- a/bcos-table/src/Table.cpp
+++ b/bcos-table/src/Table.cpp
@@ -26,10 +26,10 @@
 #include <boost/throw_exception.hpp>
 #include <sstream>
 
-using namespace std;
-
 namespace bcos::storage
 {
+using namespace std;
+
 std::optional<Entry> Table::getRow(std::string_view _key)
 {
     std::promise<std::tuple<Error::UniquePtr, std::optional<Entry>>> promise;
@@ -48,8 +48,8 @@ std::optional<Entry> Table::getRow(std::string_view _key)
     return std::get<1>(result);
 }
 
-std::vector<std::optional<Entry>> Table::getRows(RANGES::any_view<std::string_view,
-    RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+std::vector<std::optional<Entry>> Table::getRows(::ranges::any_view<std::string_view,
+    ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
         keys)
 {
     std::promise<std::tuple<Error::UniquePtr, std::vector<std::optional<Entry>>>> promise;
@@ -112,8 +112,8 @@ void Table::asyncGetRow(std::string_view _key,
 }
 
 void Table::asyncGetRows(
-    RANGES::any_view<std::string_view,
-        RANGES::category::input | RANGES::category::random_access | RANGES::category::sized>
+    ::ranges::any_view<std::string_view,
+        ::ranges::category::input | ::ranges::category::random_access | ::ranges::category::sized>
         keys,
     std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback) noexcept
 {

--- a/bcos-table/test/unittests/libtable/Entry.cpp
+++ b/bcos-table/test/unittests/libtable/Entry.cpp
@@ -29,7 +29,6 @@
 #include <iostream>
 #include <string>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::storage;
 
@@ -37,6 +36,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct EntryFixture
 {
     EntryFixture()

--- a/bcos-table/test/unittests/libtable/Table.cpp
+++ b/bcos-table/test/unittests/libtable/Table.cpp
@@ -30,7 +30,6 @@
 #include <optional>
 #include <string>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::storage;
 using namespace bcos::crypto;
@@ -39,6 +38,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct TableFixture
 {
     TableFixture()

--- a/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
@@ -41,7 +41,6 @@
 #include <string>
 #include <unordered_map>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::storage;
 using namespace bcos::crypto;
@@ -51,6 +50,8 @@ using namespace bcos::crypto;
 #endif
 namespace bcos::test
 {
+using namespace std;
+
 struct KeyPageStorageFixture
 {
     KeyPageStorageFixture()

--- a/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestLegacyStorage.cpp
@@ -25,6 +25,8 @@
 #include "bcos-task/Wait.h"
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
+#include <range/v3/algorithm/sort.hpp>
+#include <range/v3/view/concat.hpp>
 #include <tuple>
 
 struct LegacyStorageTestFixture

--- a/bcos-table/test/unittests/libtable/TestStateStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestStateStorage.cpp
@@ -34,7 +34,6 @@
 #include <random>
 #include <string>
 
-using namespace std;
 using namespace bcos;
 using namespace bcos::storage;
 using namespace bcos::crypto;
@@ -46,6 +45,8 @@ namespace bcos
 {
 namespace test
 {
+using namespace std;
+
 struct TableFactoryFixture
 {
     TableFactoryFixture()

--- a/bcos-tars-protocol/bcos-tars-protocol/Common.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/Common.h
@@ -43,6 +43,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <range/v3/algorithm/move.hpp>
 
 namespace bcostars
 {
@@ -442,13 +443,13 @@ inline bcos::protocol::LogEntry takeToBcosLogEntry(bcostars::LogEntry&& _logEntr
     for (auto&& topicIt : _logEntry.topic)
     {
         bcos::h256 topic;
-        RANGES::move(topicIt.begin(), topicIt.end(), topic.mutableData().data());
-        topics.push_back(std::move(topic));
+        ::ranges::move(topicIt.begin(), topicIt.end(), topic.mutableData().data());
+        topics.push_back(topic);
     }
     bcos::bytes address;
-    RANGES::move(std::move(_logEntry.address), std::back_inserter(address));
+    ::ranges::move(std::move(_logEntry.address), std::back_inserter(address));
     bcos::bytes data;
-    RANGES::move(std::move(_logEntry.data), std::back_inserter(data));
+    ::ranges::move(std::move(_logEntry.data), std::back_inserter(data));
     return {std::move(address), std::move(topics), std::move(data)};
 }
 }  // namespace bcostars

--- a/bcos-tars-protocol/bcos-tars-protocol/Common.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/Common.h
@@ -42,8 +42,9 @@
 #include <bcos-utilities/Common.h>
 #include <cstdint>
 #include <functional>
+#include <iterator>
 #include <memory>
-#include <range/v3/algorithm/move.hpp>
+#include <range/v3/algorithm/copy.hpp>
 
 namespace bcostars
 {
@@ -443,13 +444,15 @@ inline bcos::protocol::LogEntry takeToBcosLogEntry(bcostars::LogEntry&& _logEntr
     for (auto&& topicIt : _logEntry.topic)
     {
         bcos::h256 topic;
-        ::ranges::move(topicIt.begin(), topicIt.end(), topic.mutableData().data());
+        ::ranges::copy(topicIt.begin(), topicIt.end(), topic.mutableData().data());
         topics.push_back(topic);
     }
     bcos::bytes address;
-    ::ranges::move(std::move(_logEntry.address), std::back_inserter(address));
+    ::ranges::copy(std::make_move_iterator(_logEntry.address.begin()),
+        std::make_move_iterator(_logEntry.address.end()), std::back_inserter(address));
     bcos::bytes data;
-    ::ranges::move(std::move(_logEntry.data), std::back_inserter(data));
+    ::ranges::copy(std::make_move_iterator(_logEntry.data.begin()),
+        std::make_move_iterator(_logEntry.data.end()), std::back_inserter(data));
     return {std::move(address), std::move(topics), std::move(data)};
 }
 }  // namespace bcostars

--- a/bcos-tars-protocol/bcos-tars-protocol/Common.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/Common.h
@@ -21,6 +21,7 @@
 #pragma once
 // if windows, manual include tup/Tars.h first
 #include <bcos-framework/consensus/ConsensusNode.h>
+#include <algorithm>
 #ifdef _WIN32
 #include <tup/Tars.h>
 #endif
@@ -44,7 +45,6 @@
 #include <functional>
 #include <iterator>
 #include <memory>
-#include <range/v3/algorithm/copy.hpp>
 
 namespace bcostars
 {
@@ -419,9 +419,9 @@ inline bcostars::LogEntry toTarsLogEntry(bcos::protocol::LogEntry const& _logEnt
 {
     bcostars::LogEntry logEntry;
     logEntry.address.assign(_logEntry.address().begin(), _logEntry.address().end());
-    for (auto& topicIt : _logEntry.topics())
+    for (const auto& topicIt : _logEntry.topics())
     {
-        logEntry.topic.push_back(std::vector<char>(topicIt.begin(), topicIt.end()));
+        logEntry.topic.emplace_back(topicIt.begin(), topicIt.end());
     }
     logEntry.data.assign(_logEntry.data().begin(), _logEntry.data().end());
     return logEntry;
@@ -430,12 +430,13 @@ inline bcostars::LogEntry toTarsLogEntry(bcos::protocol::LogEntry const& _logEnt
 inline bcos::protocol::LogEntry toBcosLogEntry(bcostars::LogEntry const& _logEntry)
 {
     std::vector<bcos::h256> topics;
-    for (auto& topicIt : _logEntry.topic)
+    topics.reserve(_logEntry.topic.size());
+    for (const auto& topicIt : _logEntry.topic)
     {
         topics.emplace_back((const bcos::byte*)topicIt.data(), topicIt.size());
     }
-    return bcos::protocol::LogEntry(bcos::bytes(_logEntry.address.begin(), _logEntry.address.end()),
-        topics, bcos::bytes(_logEntry.data.begin(), _logEntry.data.end()));
+    return {bcos::bytes(_logEntry.address.begin(), _logEntry.address.end()), topics,
+        bcos::bytes(_logEntry.data.begin(), _logEntry.data.end())};
 }
 
 inline bcos::protocol::LogEntry takeToBcosLogEntry(bcostars::LogEntry&& _logEntry)
@@ -444,15 +445,14 @@ inline bcos::protocol::LogEntry takeToBcosLogEntry(bcostars::LogEntry&& _logEntr
     for (auto&& topicIt : _logEntry.topic)
     {
         bcos::h256 topic;
-        ::ranges::copy(topicIt.begin(), topicIt.end(), topic.mutableData().data());
+        std::move(topicIt.begin(), topicIt.end(), topic.mutableData().data());
         topics.push_back(topic);
     }
     bcos::bytes address;
-    ::ranges::copy(std::make_move_iterator(_logEntry.address.begin()),
-        std::make_move_iterator(_logEntry.address.end()), std::back_inserter(address));
+    std::move(_logEntry.address.begin(), _logEntry.address.end(), std::back_inserter(address));
     bcos::bytes data;
-    ::ranges::copy(std::make_move_iterator(_logEntry.data.begin()),
-        std::make_move_iterator(_logEntry.data.end()), std::back_inserter(data));
+    std::move(_logEntry.data.begin(), _logEntry.data.end(), std::back_inserter(data));
     return {std::move(address), std::move(topics), std::move(data)};
 }
+
 }  // namespace bcostars

--- a/bcos-tars-protocol/bcos-tars-protocol/client/ExecutorServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/ExecutorServiceClient.cpp
@@ -17,6 +17,11 @@
  * @author: yujiechen
  * @date 2022-5-9
  */
+#include <range/v3/algorithm/find.hpp>
+#include <range/v3/view/join.hpp>
+#include <range/v3/view/all.hpp>
+#include <range/v3/view/subrange.hpp>
+#include <range/v3/algorithm/copy.hpp>
 #include "ExecutorServiceClient.h"
 #include "../Common.h"
 #include "../ErrorConverter.h"

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -24,6 +24,8 @@
 #include "bcos-tars-protocol/impl/TarsServantProxyCallback.h"
 #include "bcos-tars-protocol/protocol/GroupNodeInfoImpl.h"
 #include "fisco-bcos-tars-service/Common/TarsUtils.h"
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/join.hpp>
 
 std::atomic<int64_t> bcostars::GatewayServiceClient::s_tarsTimeoutCount = {0};
 const int64_t bcostars::GatewayServiceClient::c_maxTarsTimeoutCount = 500;

--- a/bcos-tars-protocol/bcos-tars-protocol/impl/TarsSerializable.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/impl/TarsSerializable.h
@@ -22,7 +22,7 @@ void impl_decode(bcos::concepts::bytebuffer::ByteBuffer auto const& buffer,
     bcostars::protocol::impl::TarsStruct auto& out)
 {
     tars::TarsInputStream<tars::BufferReader> input;
-    input.setBuffer((const char*)RANGES::data(buffer), RANGES::size(buffer));
+    input.setBuffer((const char*)::ranges::data(buffer), ::ranges::size(buffer));
     out.readFrom(input);
 }
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
@@ -73,11 +73,11 @@ void BlockHeaderImpl::clear()
     m_inner()->resetDefautlt();
 }
 
-RANGES::any_view<bcos::protocol::ParentInfo, RANGES::category::input | RANGES::category::sized>
+::ranges::any_view<bcos::protocol::ParentInfo, ::ranges::category::input | ::ranges::category::sized>
 BlockHeaderImpl::parentInfo() const
 {
     return m_inner()->data.parentInfo |
-           RANGES::views::transform([](const bcostars::ParentInfo& tarsParentInfo) {
+           ::ranges::views::transform([](const bcostars::ParentInfo& tarsParentInfo) {
                return bcos::protocol::ParentInfo{.blockNumber = tarsParentInfo.blockNumber,
                    .blockHash = bcos::crypto::HashType((bcos::byte*)tarsParentInfo.blockHash.data(),
                        tarsParentInfo.blockHash.size())};
@@ -121,7 +121,7 @@ bcos::u256 BlockHeaderImpl::gasUsed() const
     return {};
 }
 
-void BlockHeaderImpl::setParentInfo(RANGES::any_view<bcos::protocol::ParentInfo> parentInfos)
+void BlockHeaderImpl::setParentInfo(::ranges::any_view<bcos::protocol::ParentInfo> parentInfos)
 {
     auto* inner = m_inner();
     inner->data.parentInfo.clear();

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
@@ -27,12 +27,9 @@
 #include "bcos-utilities/Exceptions.h"
 #include <boost/endian/conversion.hpp>
 
-using namespace bcostars;
-using namespace bcostars::protocol;
-
 DERIVE_BCOS_EXCEPTION(EmptyBlockHeaderHash);
 
-void BlockHeaderImpl::decode(bcos::bytesConstRef _data)
+void bcostars::protocol::BlockHeaderImpl::decode(bcos::bytesConstRef _data)
 {
     tars::TarsInputStream<tars::BufferReader> input;
     input.setBuffer((const char*)_data.data(), _data.size());
@@ -40,7 +37,7 @@ void BlockHeaderImpl::decode(bcos::bytesConstRef _data)
     m_inner()->readFrom(input);
 }
 
-void BlockHeaderImpl::encode(bcos::bytes& _encodeData) const
+void bcostars::protocol::BlockHeaderImpl::encode(bcos::bytes& _encodeData) const
 {
     tars::TarsOutputStream<bcostars::protocol::BufferWriterByteVector> output;
 
@@ -48,7 +45,7 @@ void BlockHeaderImpl::encode(bcos::bytes& _encodeData) const
     output.getByteBuffer().swap(_encodeData);
 }
 
-bcos::crypto::HashType BlockHeaderImpl::hash() const
+bcos::crypto::HashType bcostars::protocol::BlockHeaderImpl::hash() const
 {
     if (m_inner()->dataHash.empty())
     {
@@ -61,20 +58,20 @@ bcos::crypto::HashType BlockHeaderImpl::hash() const
     return hashResult;
 }
 
-void BlockHeaderImpl::calculateHash(const bcos::crypto::Hash& hashImpl)
+void bcostars::protocol::BlockHeaderImpl::calculateHash(const bcos::crypto::Hash& hashImpl)
 {
     bcos::crypto::HashType hashResult;
     bcos::concepts::hash::calculate(*m_inner(), hashImpl.hasher(), hashResult);
     m_inner()->dataHash.assign(hashResult.begin(), hashResult.end());
 }
 
-void BlockHeaderImpl::clear()
+void bcostars::protocol::BlockHeaderImpl::clear()
 {
     m_inner()->resetDefautlt();
 }
 
 ::ranges::any_view<bcos::protocol::ParentInfo, ::ranges::category::input | ::ranges::category::sized>
-BlockHeaderImpl::parentInfo() const
+bcostars::protocol::BlockHeaderImpl::parentInfo() const
 {
     return m_inner()->data.parentInfo |
            ::ranges::views::transform([](const bcostars::ParentInfo& tarsParentInfo) {
@@ -84,7 +81,7 @@ BlockHeaderImpl::parentInfo() const
            });
 }
 
-bcos::crypto::HashType BlockHeaderImpl::txsRoot() const
+bcos::crypto::HashType bcostars::protocol::BlockHeaderImpl::txsRoot() const
 {
     if (!m_inner()->data.txsRoot.empty())
     {
@@ -93,7 +90,7 @@ bcos::crypto::HashType BlockHeaderImpl::txsRoot() const
     return {};
 }
 
-bcos::crypto::HashType BlockHeaderImpl::stateRoot() const
+bcos::crypto::HashType bcostars::protocol::BlockHeaderImpl::stateRoot() const
 {
     if (!m_inner()->data.stateRoot.empty())
     {
@@ -102,7 +99,7 @@ bcos::crypto::HashType BlockHeaderImpl::stateRoot() const
     return {};
 }
 
-bcos::crypto::HashType BlockHeaderImpl::receiptsRoot() const
+bcos::crypto::HashType bcostars::protocol::BlockHeaderImpl::receiptsRoot() const
 {
     if (!m_inner()->data.receiptRoot.empty())
     {
@@ -112,7 +109,7 @@ bcos::crypto::HashType BlockHeaderImpl::receiptsRoot() const
     return {};
 }
 
-bcos::u256 BlockHeaderImpl::gasUsed() const
+bcos::u256 bcostars::protocol::BlockHeaderImpl::gasUsed() const
 {
     if (!m_inner()->data.gasUsed.empty())
     {
@@ -121,7 +118,8 @@ bcos::u256 BlockHeaderImpl::gasUsed() const
     return {};
 }
 
-void BlockHeaderImpl::setParentInfo(::ranges::any_view<bcos::protocol::ParentInfo> parentInfos)
+void bcostars::protocol::BlockHeaderImpl::setParentInfo(
+    ::ranges::any_view<bcos::protocol::ParentInfo> parentInfos)
 {
     auto* inner = m_inner();
     inner->data.parentInfo.clear();
@@ -134,7 +132,8 @@ void BlockHeaderImpl::setParentInfo(::ranges::any_view<bcos::protocol::ParentInf
     clearDataHash();
 }
 
-void BlockHeaderImpl::setSealerList(gsl::span<const bcos::bytes> const& _sealerList)
+void bcostars::protocol::BlockHeaderImpl::setSealerList(
+    gsl::span<const bcos::bytes> const& _sealerList)
 {
     m_inner()->data.sealerList.clear();
     for (auto const& it : _sealerList)
@@ -144,7 +143,7 @@ void BlockHeaderImpl::setSealerList(gsl::span<const bcos::bytes> const& _sealerL
     clearDataHash();
 }
 
-void BlockHeaderImpl::setSignatureList(
+void bcostars::protocol::BlockHeaderImpl::setSignatureList(
     gsl::span<const bcos::protocol::Signature> const& _signatureList)
 {
     // Note: must clear the old signatureList when set the new signatureList
@@ -153,7 +152,7 @@ void BlockHeaderImpl::setSignatureList(
     m_inner()->signatureList.clear();
     for (const auto& it : _signatureList)
     {
-        Signature signature;
+        bcostars::Signature signature;
         signature.sealerIndex = it.index;
         signature.signature.assign(it.signature.begin(), it.signature.end());
         m_inner()->signatureList.emplace_back(signature);

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
@@ -30,6 +30,7 @@
 #include "bcos-tars-protocol/tars/TransactionReceipt.h"
 #include "bcos-utilities/AnyHolder.h"
 #include <boost/throw_exception.hpp>
+#include <range/v3/algorithm/transform.hpp>
 
 using namespace bcostars;
 using namespace bcostars::protocol;

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
@@ -30,22 +30,19 @@
 #include "bcos-tars-protocol/tars/TransactionReceipt.h"
 #include "bcos-utilities/AnyHolder.h"
 #include <boost/throw_exception.hpp>
-#include <range/v3/algorithm/transform.hpp>
+#include <range/v3/view/transform.hpp>
 
-using namespace bcostars;
-using namespace bcostars::protocol;
-
-void BlockImpl::decode(bcos::bytesConstRef _data, bool, bool)
+void bcostars::protocol::BlockImpl::decode(bcos::bytesConstRef _data, bool, bool)
 {
     bcos::concepts::serialize::decode(_data, m_inner);
 }
 
-void BlockImpl::encode(bcos::bytes& _encodeData) const
+void bcostars::protocol::BlockImpl::encode(bcos::bytes& _encodeData) const
 {
     bcos::concepts::serialize::encode(m_inner, _encodeData);
 }
 
-bcos::protocol::BlockHeader::Ptr BlockImpl::blockHeader()
+bcos::protocol::BlockHeader::Ptr bcostars::protocol::BlockImpl::blockHeader()
 {
     return std::make_shared<bcostars::protocol::BlockHeaderImpl>(
         [self = shared_from_this()]() mutable {
@@ -53,7 +50,7 @@ bcos::protocol::BlockHeader::Ptr BlockImpl::blockHeader()
         });
 }
 
-bcos::protocol::AnyBlockHeader BlockImpl::blockHeader() const
+bcos::protocol::AnyBlockHeader bcostars::protocol::BlockImpl::blockHeader() const
 {
     bcos::protocol::AnyBlockHeader header(bcos::InPlace<bcostars::protocol::BlockHeaderImpl>{},
         [self = std::const_pointer_cast<BlockImpl>(shared_from_this())]() mutable
@@ -61,7 +58,7 @@ bcos::protocol::AnyBlockHeader BlockImpl::blockHeader() const
     return header;
 }
 
-void BlockImpl::setBlockHeader(bcos::protocol::BlockHeader::Ptr _blockHeader)
+void bcostars::protocol::BlockImpl::setBlockHeader(bcos::protocol::BlockHeader::Ptr _blockHeader)
 {
     if (_blockHeader)
     {
@@ -70,7 +67,8 @@ void BlockImpl::setBlockHeader(bcos::protocol::BlockHeader::Ptr _blockHeader)
     }
 }
 
-void BlockImpl::setReceipt(uint64_t _index, bcos::protocol::TransactionReceipt::Ptr _receipt)
+void bcostars::protocol::BlockImpl::setReceipt(
+    uint64_t _index, bcos::protocol::TransactionReceipt::Ptr _receipt)
 {
     if (_index >= m_inner.receipts.size())
     {
@@ -81,18 +79,18 @@ void BlockImpl::setReceipt(uint64_t _index, bcos::protocol::TransactionReceipt::
     m_inner.receipts[_index] = innerReceipt;
 }
 
-void BlockImpl::appendReceipt(bcos::protocol::TransactionReceipt::Ptr _receipt)
+void bcostars::protocol::BlockImpl::appendReceipt(bcos::protocol::TransactionReceipt::Ptr _receipt)
 {
     m_inner.receipts.emplace_back(
         std::dynamic_pointer_cast<bcostars::protocol::TransactionReceiptImpl>(_receipt)->inner());
 }
 
-void BlockImpl::setNonceList(::ranges::any_view<std::string> nonces)
+void bcostars::protocol::BlockImpl::setNonceList(::ranges::any_view<std::string> nonces)
 {
     m_inner.nonceList = ::ranges::to<std::vector>(nonces);
 }
 
-::ranges::any_view<std::string> BlockImpl::nonceList() const
+::ranges::any_view<std::string> bcostars::protocol::BlockImpl::nonceList() const
 {
     return m_inner.nonceList;
 }
@@ -104,14 +102,15 @@ bcos::crypto::HashType bcostars::protocol::BlockImpl::transactionHash(uint64_t _
         bcos::bytesConstRef((const bcos::byte*)hashBytes.data(), hashBytes.size())};
 }
 
-void BlockImpl::appendTransactionMetaData(bcos::protocol::TransactionMetaData::Ptr _txMetaData)
+void bcostars::protocol::BlockImpl::appendTransactionMetaData(
+    bcos::protocol::TransactionMetaData::Ptr _txMetaData)
 {
     auto txMetaDataImpl =
         std::dynamic_pointer_cast<bcostars::protocol::TransactionMetaDataImpl>(_txMetaData);
     m_inner.transactionsMetaData.emplace_back(txMetaDataImpl->inner());
 }
 
-uint64_t BlockImpl::transactionsMetaDataSize() const
+uint64_t bcostars::protocol::BlockImpl::transactionsMetaDataSize() const
 {
     return m_inner.transactionsMetaData.size();
 }

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.h
@@ -79,8 +79,8 @@ public:
     // get receipts size
     uint64_t receiptsSize() const override;
 
-    void setNonceList(RANGES::any_view<std::string> nonces) override;
-    RANGES::any_view<std::string> nonceList() const override;
+    void setNonceList(::ranges::any_view<std::string> nonces) override;
+    ::ranges::any_view<std::string> nonceList() const override;
 
     const bcostars::Block& inner() const;
     bcostars::Block& inner();

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/ExecutionMessageImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/ExecutionMessageImpl.cpp
@@ -19,10 +19,8 @@
  * @date 2022-05-09
  */
 #include "ExecutionMessageImpl.h"
-using namespace bcostars;
-using namespace bcostars::protocol;
 
-void ExecutionMessageImpl::decodeLogEntries()
+void bcostars::protocol::ExecutionMessageImpl::decodeLogEntries()
 {
     m_logEntries.reserve(m_inner()->logEntries.size());
     for (auto& it : m_inner()->logEntries)
@@ -32,7 +30,7 @@ void ExecutionMessageImpl::decodeLogEntries()
     }
 }
 
-void ExecutionMessageImpl::decodeKeyLocks()
+void bcostars::protocol::ExecutionMessageImpl::decodeKeyLocks()
 {
     for (auto const& _keyLock : m_inner()->keyLocks)
     {
@@ -40,16 +38,18 @@ void ExecutionMessageImpl::decodeKeyLocks()
     }
 }
 
-gsl::span<bcos::protocol::LogEntry const> const ExecutionMessageImpl::logEntries() const
+gsl::span<bcos::protocol::LogEntry const> const
+bcostars::protocol::ExecutionMessageImpl::logEntries() const
 {
     return m_logEntries;
 }
-std::vector<bcos::protocol::LogEntry> ExecutionMessageImpl::takeLogEntries()
+std::vector<bcos::protocol::LogEntry> bcostars::protocol::ExecutionMessageImpl::takeLogEntries()
 {
     return std::move(m_logEntries);
 }
 
-void ExecutionMessageImpl::setLogEntries(std::vector<bcos::protocol::LogEntry> _logEntries)
+void bcostars::protocol::ExecutionMessageImpl::setLogEntries(
+    std::vector<bcos::protocol::LogEntry> _logEntries)
 {
     m_logEntries = _logEntries;
     m_inner()->logEntries.clear();
@@ -62,18 +62,18 @@ void ExecutionMessageImpl::setLogEntries(std::vector<bcos::protocol::LogEntry> _
     }
 }
 
-gsl::span<std::string const> ExecutionMessageImpl::keyLocks() const
+gsl::span<std::string const> bcostars::protocol::ExecutionMessageImpl::keyLocks() const
 {
     return m_keyLocks;
 }
-std::vector<std::string> ExecutionMessageImpl::takeKeyLocks()
+std::vector<std::string> bcostars::protocol::ExecutionMessageImpl::takeKeyLocks()
 {
     // Note: must clear the tars-container here when takeKeyLocks
     m_inner()->keyLocks.clear();
     return std::move(m_keyLocks);
 }
 
-void ExecutionMessageImpl::setKeyLocks(std::vector<std::string> keyLocks)
+void bcostars::protocol::ExecutionMessageImpl::setKeyLocks(std::vector<std::string> keyLocks)
 {
     m_keyLocks = std::move(keyLocks);
     // Note: must clear the tars-container here before set new keyLocks

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.cpp
@@ -21,10 +21,7 @@
 #include "ProtocolInfoCodecImpl.h"
 #include "../Common.h"
 
-using namespace bcostars;
-using namespace bcostars::protocol;
-
-void ProtocolInfoCodecImpl::encode(
+void bcostars::protocol::ProtocolInfoCodecImpl::encode(
     bcos::protocol::ProtocolInfo::ConstPtr _protocol, bcos::bytes& _encodeData) const
 {
     bcostars::ProtocolInfo tarsProtocolInfo;
@@ -36,7 +33,8 @@ void ProtocolInfoCodecImpl::encode(
     output.getByteBuffer().swap(_encodeData);
 }
 
-bcos::protocol::ProtocolInfo::Ptr ProtocolInfoCodecImpl::decode(bcos::bytesConstRef _data) const
+bcos::protocol::ProtocolInfo::Ptr bcostars::protocol::ProtocolInfoCodecImpl::decode(
+    bcos::bytesConstRef _data) const
 {
     tars::TarsInputStream<tars::BufferReader> input;
     input.setBuffer((const char*)_data.data(), _data.size());

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
@@ -29,9 +29,6 @@
 #include <boost/throw_exception.hpp>
 #include <range/v3/view/any_view.hpp>
 
-using namespace bcostars;
-using namespace bcostars::protocol;
-
 DERIVE_BCOS_EXCEPTION(EmptyTransactionHash);
 
 bcostars::protocol::TransactionImpl::TransactionImpl(std::function<bcostars::Transaction*()> inner)
@@ -43,17 +40,17 @@ bcostars::protocol::TransactionImpl::TransactionImpl()
     })
 {}
 
-void TransactionImpl::decode(bcos::bytesConstRef _txData)
+void bcostars::protocol::TransactionImpl::decode(bcos::bytesConstRef _txData)
 {
     bcos::concepts::serialize::decode(_txData, *m_inner());
 }
 
-void TransactionImpl::encode(bcos::bytes& txData) const
+void bcostars::protocol::TransactionImpl::encode(bcos::bytes& txData) const
 {
     bcos::concepts::serialize::encode(*m_inner(), txData);
 }
 
-bcos::crypto::HashType TransactionImpl::hash() const
+bcos::crypto::HashType bcostars::protocol::TransactionImpl::hash() const
 {
     if (m_inner()->dataHash.empty() && m_inner()->extraTransactionHash.empty())
     {
@@ -77,12 +74,12 @@ void bcostars::protocol::TransactionImpl::calculateHash(const bcos::crypto::Hash
     bcos::concepts::hash::calculate(*m_inner(), hashImpl.hasher(), m_inner()->dataHash);
 }
 
-std::string_view TransactionImpl::nonce() const
+std::string_view bcostars::protocol::TransactionImpl::nonce() const
 {
     return m_inner()->data.nonce;
 }
 
-bcos::bytesConstRef TransactionImpl::input() const
+bcos::bytesConstRef bcostars::protocol::TransactionImpl::input() const
 {
     return {reinterpret_cast<const bcos::byte*>(m_inner()->data.input.data()),
         m_inner()->data.input.size()};
@@ -193,7 +190,7 @@ uint8_t bcostars::protocol::TransactionImpl::type() const
 {
     return static_cast<uint8_t>(m_inner()->type);
 }
-bcos::bytesConstRef TransactionImpl::extraTransactionBytes() const
+bcos::bytesConstRef bcostars::protocol::TransactionImpl::extraTransactionBytes() const
 {
     return {reinterpret_cast<const bcos::byte*>(m_inner()->extraTransactionBytes.data()),
         m_inner()->extraTransactionBytes.size()};

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptImpl.cpp
@@ -24,9 +24,6 @@
 #include <bcos-concepts/Hash.h>
 #include <bcos-concepts/Serialize.h>
 
-using namespace bcostars;
-using namespace bcostars::protocol;
-
 DERIVE_BCOS_EXCEPTION(EmptyReceiptHash);
 
 bcostars::protocol::TransactionReceiptImpl::TransactionReceiptImpl()
@@ -35,17 +32,17 @@ bcostars::protocol::TransactionReceiptImpl::TransactionReceiptImpl()
     })
 {}
 
-void TransactionReceiptImpl::decode(bcos::bytesConstRef _receiptData)
+void bcostars::protocol::TransactionReceiptImpl::decode(bcos::bytesConstRef _receiptData)
 {
     bcos::concepts::serialize::decode(_receiptData, *m_inner());
 }
 
-void TransactionReceiptImpl::encode(bcos::bytes& _encodedData) const
+void bcostars::protocol::TransactionReceiptImpl::encode(bcos::bytes& _encodedData) const
 {
     bcos::concepts::serialize::encode(*m_inner(), _encodedData);
 }
 
-bcos::crypto::HashType TransactionReceiptImpl::hash() const
+bcos::crypto::HashType bcostars::protocol::TransactionReceiptImpl::hash() const
 {
     if (m_inner()->dataHash.empty())
     {
@@ -62,7 +59,7 @@ void bcostars::protocol::TransactionReceiptImpl::calculateHash(const bcos::crypt
     bcos::concepts::hash::calculate(*m_inner(), hashImpl.hasher(), m_inner()->dataHash);
 }
 
-bcos::u256 TransactionReceiptImpl::gasUsed() const
+bcos::u256 bcostars::protocol::TransactionReceiptImpl::gasUsed() const
 {
     if (!m_inner()->data.gasUsed.empty())
     {

--- a/bcos-tars-protocol/benchmark/benchmarkAnyHolder.cpp
+++ b/bcos-tars-protocol/benchmark/benchmarkAnyHolder.cpp
@@ -1,6 +1,7 @@
 #include "bcos-tars-protocol/protocol/BlockImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionImpl.h"
 #include <benchmark/benchmark.h>
+#include <range/v3/view/iota.hpp>
 #include <utility>
 
 struct Fixture

--- a/bcos-tars-protocol/test/ProtocolTest.cpp
+++ b/bcos-tars-protocol/test/ProtocolTest.cpp
@@ -479,7 +479,7 @@ BOOST_AUTO_TEST_CASE(blockHeader)
     BOOST_CHECK_EQUAL(header->gasUsed(), decodedHeader->gasUsed());
     BOOST_CHECK_EQUAL(header->parentInfo().size(), decodedHeader->parentInfo().size());
     for (auto [originParentInfo, decodeParentInfo] :
-        RANGES::views::zip(header->parentInfo(), decodedHeader->parentInfo()))
+        ::ranges::views::zip(header->parentInfo(), decodedHeader->parentInfo()))
     {
         BOOST_CHECK_EQUAL(
             bcos::toString(originParentInfo.blockHash), bcos::toString(decodeParentInfo.blockHash));

--- a/bcos-tool/bcos-tool/BfsFileFactory.h
+++ b/bcos-tool/bcos-tool/BfsFileFactory.h
@@ -23,7 +23,6 @@
 #include <bcos-framework/storage/Common.h>
 #include <bcos-framework/storage/StorageInterface.h>
 #include <bcos-framework/storage/Table.h>
-#include <bcos-utilities/Ranges.h>
 #include <boost/algorithm/string/join.hpp>
 
 namespace bcos::tool
@@ -52,7 +51,7 @@ constexpr static const std::string_view FS_KEY_EXTRA{"extra"};
 constexpr static const std::array<std::string_view, 6> FS_FIELDS = {
     FS_KEY_TYPE, FS_KEY_STAT, FS_ACL_TYPE, FS_ACL_WHITE, FS_ACL_BLACK, FS_KEY_EXTRA};
 // static const auto FS_DIR_FIELDS = boost::join(
-//     FS_FIELDS | RANGES::views::transform([](auto& str) -> std::string { return std::string(str);
+//     FS_FIELDS | ::ranges::views::transform([](auto& str) -> std::string { return std::string(str);
 //     }),
 //     ",");
 constexpr static const std::string_view FS_DIR_FIELDS{

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -23,6 +23,8 @@
 #include "bcos-txpool/sync/utilities/Common.h"
 #include <bcos-framework/protocol/CommonError.h>
 #include <bcos-framework/protocol/Protocol.h>
+#include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/view/zip.hpp>
 
 using namespace bcos;
 using namespace bcos::sync;

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -33,7 +33,10 @@
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <memory>
+#include <range/v3/algorithm/all_of.hpp>
+#include <range/v3/algorithm/remove_if.hpp>
 #include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/concat.hpp>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/transform.hpp>
 #include <variant>

--- a/bcos-txpool/test/unittests/txpool/TxPoolTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/TxPoolTest.cpp
@@ -32,6 +32,8 @@
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/test/unit_test.hpp>
+#include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/view/filter.hpp>
 
 using namespace bcos;
 using namespace bcos::txpool;

--- a/bcos-utilities/bcos-utilities/DataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/DataConvertUtility.h
@@ -20,7 +20,7 @@
 
 #include "Common.h"
 #include "Error.h"
-#include "Ranges.h"
+#include <range/v3/range/concepts.hpp>
 #include <boost/algorithm/hex.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/throw_exception.hpp>

--- a/bcos-utilities/bcos-utilities/Ranges.h
+++ b/bcos-utilities/bcos-utilities/Ranges.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#ifdef USE_STD_RANGES
-#include <ranges>
-namespace RANGES = ::std::ranges;
-#else
-#include <range/v3/all.hpp>
-namespace RANGES = ::ranges;
-#endif

--- a/bcos-utilities/test/unittests/libutilities/BucketMapTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/BucketMapTest.cpp
@@ -277,8 +277,8 @@ BOOST_AUTO_TEST_CASE(parallelTest2)
 
     tbb::parallel_for(
         tbb::blocked_range<int>(0, total), [&bucketMap](const tbb::blocked_range<int>& range) {
-            auto kvs = RANGES::iota_view<int, int>(range.begin(), range.end()) |
-                       RANGES::views::transform([](int i) { return std::make_pair(i, i); }) |
+            auto kvs = ::ranges::iota_view<int, int>(range.begin(), range.end()) |
+                       ::ranges::views::transform([](int i) { return std::make_pair(i, i); }) |
                        ::ranges::to<std::vector>();
 
             bucketMap.batchInsert(kvs);
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(parallelTest2)
 
     tbb::parallel_for(
         tbb::blocked_range<int>(0, total), [&bucketMap](const tbb::blocked_range<int>& range) {
-            auto ks = RANGES::iota_view<int, int>(range.begin(), range.end()) |
+            auto ks = ::ranges::iota_view<int, int>(range.begin(), range.end()) |
                       ::ranges::to<std::vector>();
 
             bucketMap.traverse<WriteAccessor, true>(
@@ -310,7 +310,7 @@ BOOST_AUTO_TEST_CASE(parallelTest2)
 
     tbb::parallel_for(
         tbb::blocked_range<int>(0, total), [&bucketMap](const tbb::blocked_range<int>& range) {
-            auto ks = RANGES::iota_view<int, int>(range.begin(), range.end()) |
+            auto ks = ::ranges::iota_view<int, int>(range.begin(), range.end()) |
                       ::ranges::to<std::vector>();
 
             bucketMap.batchRemove(ks);

--- a/benchmark/benchmarkMemoryStorage.cpp
+++ b/benchmark/benchmarkMemoryStorage.cpp
@@ -8,6 +8,8 @@
 #include <tbb/concurrent_map.h>
 #include <tbb/concurrent_unordered_map.h>
 #include <boost/container_hash/hash_fwd.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/zip.hpp>
 #include <variant>
 
 using namespace bcos;
@@ -25,7 +27,7 @@ struct Fixture
     {
         allKeys.clear();
         allValues.clear();
-        for (auto i : RANGES::views::iota(0, count))
+        for (auto i : ::ranges::views::iota(0, count))
         {
             auto tableName = fmt::format("Table-{}", i % 1000);  // All 1000 tables
             auto key = fmt::format("Key-{}", i);
@@ -143,7 +145,7 @@ static void readTBBHashMap(benchmark::State& state)
         fixture.prepareData(state.range(0));
         tbbHashMap.clear();
 
-        for (auto&& [key, value] : RANGES::views::zip(fixture.allKeys, fixture.allValues))
+        for (auto&& [key, value] : ::ranges::views::zip(fixture.allKeys, fixture.allValues))
         {
             tbbHashMap.emplace(key, value);
         }
@@ -167,7 +169,7 @@ static void readTBBUnorderedMap(benchmark::State& state)
         fixture.prepareData(state.range(0));
         tbbUnorderedMap.clear();
 
-        for (auto&& [key, value] : RANGES::views::zip(fixture.allKeys, fixture.allValues))
+        for (auto&& [key, value] : ::ranges::views::zip(fixture.allKeys, fixture.allValues))
         {
             tbbUnorderedMap.emplace(key, value);
         }
@@ -190,7 +192,7 @@ static void readTBBMap(benchmark::State& state)
         fixture.prepareData(state.range(0));
         tbbMap.clear();
 
-        for (auto&& [key, value] : RANGES::views::zip(fixture.allKeys, fixture.allValues))
+        for (auto&& [key, value] : ::ranges::views::zip(fixture.allKeys, fixture.allValues))
         {
             tbbMap.emplace(key, value);
         }

--- a/concepts/bcos-concepts/ledger/Ledger.h
+++ b/concepts/bcos-concepts/ledger/Ledger.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "../ByteBuffer.h"
 #include "../protocol/Block.h"
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/traits.hpp>
 
 namespace bcos::concepts::ledger
 {
@@ -68,8 +70,9 @@ public:
     auto getABI(std::string contractAddress) { return impl().impl_getABI(contractAddress); }
 
 
-    auto getTransactions(RANGES::range auto const& hashes, RANGES::range auto& out)
-        requires TransactionOrReceipt<RANGES::range_value_t<std::remove_cvref_t<decltype(out)>>>
+    auto getTransactions(::ranges::range auto const& hashes, ::ranges::range auto& out)
+        requires TransactionOrReceipt<
+            ::ranges::range_value_t<std::remove_cvref_t<decltype(out)>>>
     {
         return impl().impl_getTransactions(hashes, out);
     }

--- a/concepts/bcos-concepts/protocol/Block.h
+++ b/concepts/bcos-concepts/protocol/Block.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "Receipt.h"
 #include "Transaction.h"
-#include <bcos-utilities/Ranges.h>
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/traits.hpp>
 #include <concepts>
 
 namespace bcos::concepts::block
@@ -25,17 +26,17 @@ concept Signature = requires(SignatureType signature) {
 template <class BlockHeaderDataType>
 concept BlockHeaderData = requires(BlockHeaderDataType blockHeaderData) {
     requires std::integral<decltype(blockHeaderData.version)>;
-    requires RANGES::range<decltype(blockHeaderData.parentInfo)> &&
-                 ParentInfo<RANGES::range_value_t<decltype(blockHeaderData.parentInfo)>>;
+    requires ::ranges::range<decltype(blockHeaderData.parentInfo)> &&
+                 ParentInfo<::ranges::range_value_t<decltype(blockHeaderData.parentInfo)>>;
     blockHeaderData.txsRoot;
     blockHeaderData.receiptRoot;
     blockHeaderData.stateRoot;
     requires BlockNumber<decltype(blockHeaderData.blockNumber)>;
     requires std::integral<decltype(blockHeaderData.timestamp)>;
     requires std::integral<decltype(blockHeaderData.sealer)>;
-    requires RANGES::range<decltype(blockHeaderData.sealerList)>;
+    requires ::ranges::range<decltype(blockHeaderData.sealerList)>;
     blockHeaderData.extraData;
-    requires RANGES::range<decltype(blockHeaderData.consensusWeights)>;
+    requires ::ranges::range<decltype(blockHeaderData.consensusWeights)>;
 };
 
 template <class BlockHeaderType>
@@ -43,8 +44,8 @@ concept BlockHeader = requires(BlockHeaderType block) {
     BlockHeaderType{};
     requires BlockHeaderData<decltype(block.data)>;
     block.dataHash;
-    requires RANGES::range<decltype(block.signatureList)> &&
-                 Signature<RANGES::range_value_t<decltype(block.signatureList)>>;
+    requires ::ranges::range<decltype(block.signatureList)> &&
+                 Signature<::ranges::range_value_t<decltype(block.signatureList)>>;
 };
 
 template <class BlockType>
@@ -53,16 +54,16 @@ concept Block = requires(BlockType block) {
     requires std::integral<decltype(block.version)>;
     requires std::integral<decltype(block.type)>;
     requires BlockHeader<decltype(block.blockHeader)>;
-    requires RANGES::range<decltype(block.transactions)> &&
+    requires ::ranges::range<decltype(block.transactions)> &&
                  bcos::concepts::transaction::Transaction<
-                     RANGES::range_value_t<decltype(block.transactions)>>;
-    requires RANGES::range<decltype(block.receipts)> &&
+                     ::ranges::range_value_t<decltype(block.transactions)>>;
+    requires ::ranges::range<decltype(block.receipts)> &&
                  bcos::concepts::receipt::TransactionReceipt<
-                     RANGES::range_value_t<decltype(block.receipts)>>;
-    requires RANGES::range<decltype(block.transactionsMetaData)>;  // TODO: add metadata concept
-    requires RANGES::range<decltype(block.receiptsHash)> &&
-                 ByteBuffer<RANGES::range_value_t<decltype(block.receiptsHash)>>;
-    requires RANGES::range<decltype(block.nonceList)> &&
-                 ByteBuffer<RANGES::range_value_t<decltype(block.nonceList)>>;
+                     ::ranges::range_value_t<decltype(block.receipts)>>;
+    requires ::ranges::range<decltype(block.transactionsMetaData)>;  // TODO: add metadata concept
+    requires ::ranges::range<decltype(block.receiptsHash)> &&
+                 ByteBuffer<::ranges::range_value_t<decltype(block.receiptsHash)>>;
+    requires ::ranges::range<decltype(block.nonceList)> &&
+                 ByteBuffer<::ranges::range_value_t<decltype(block.nonceList)>>;
 };
 }  // namespace bcos::concepts::block

--- a/concepts/bcos-concepts/protocol/Transaction.h
+++ b/concepts/bcos-concepts/protocol/Transaction.h
@@ -4,7 +4,6 @@
 #include "../Hash.h"
 #include "../Serialize.h"
 #include <bcos-framework/protocol/Transaction.h>
-#include <bcos-utilities/Ranges.h>
 #include <concepts>
 #include <type_traits>
 

--- a/concepts/bcos-concepts/storage/Storage.h
+++ b/concepts/bcos-concepts/storage/Storage.h
@@ -2,7 +2,7 @@
 
 #include "../Basic.h"
 #include <bcos-framework/storage/Entry.h>
-#include <bcos-utilities/Ranges.h>
+#include <range/v3/range/concepts.hpp>
 #include <type_traits>
 
 namespace bcos::concepts::storage
@@ -18,7 +18,7 @@ public:
     }
 
     std::vector<std::optional<bcos::storage::Entry>> getRows(
-        std::string_view table, RANGES::range auto&& keys)
+        std::string_view table, ::ranges::range auto&& keys)
     {
         return impl().impl_getRows(table, std::forward<decltype(keys)>(keys));
     }

--- a/lightnode/bcos-lightnode/rpc/Converter.h
+++ b/lightnode/bcos-lightnode/rpc/Converter.h
@@ -6,6 +6,9 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <json/value.h>
 #include <boost/algorithm/hex.hpp>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/traits.hpp>
+#include <range/v3/view/subrange.hpp>
 
 namespace bcos::rpc
 {
@@ -13,21 +16,21 @@ namespace bcos::rpc
 void hex2Bin(bcos::concepts::bytebuffer::ByteBuffer auto const& hex,
     bcos::concepts::bytebuffer::ByteBuffer auto& out)
 {
-    auto view =
-        RANGES::subrange<decltype(RANGES::begin(hex))>(RANGES::begin(hex), RANGES::end(hex));
+    auto view = ::ranges::subrange<decltype(::ranges::begin(hex))>(
+        ::ranges::begin(hex), ::ranges::end(hex));
 
-    if (RANGES::size(view) >= 2 && (view[0] == '0' && view[1] == 'x'))
+    if (::ranges::size(view) >= 2 && (view[0] == '0' && view[1] == 'x'))
     {
-        view = RANGES::subrange<decltype(RANGES::begin(hex))>(
-            RANGES::begin(hex) + 2, RANGES::end(hex));
+        view = ::ranges::subrange<decltype(::ranges::begin(hex))>(
+            ::ranges::begin(hex) + 2, ::ranges::end(hex));
     }
 
-    if ((RANGES::size(view) % 2 != 0)) [[unlikely]]
+    if ((::ranges::size(view) % 2 != 0)) [[unlikely]]
         BOOST_THROW_EXCEPTION(std::invalid_argument{"Invalid input hex string!"});
 
-    bcos::concepts::resizeTo(out, RANGES::size(view) / 2);
-    boost::algorithm::unhex(RANGES::begin(view), RANGES::end(view),
-        (RANGES::range_value_t<decltype(view)>*)RANGES::data(out));
+    bcos::concepts::resizeTo(out, ::ranges::size(view) / 2);
+    boost::algorithm::unhex(::ranges::begin(view), ::ranges::end(view),
+        (::ranges::range_value_t<decltype(view)>*)::ranges::data(out));
 }
 
 void toJsonResp(bcos::crypto::hasher::Hasher auto&& hasher,

--- a/lightnode/bcos-lightnode/rpc/LightNodeRPC.h
+++ b/lightnode/bcos-lightnode/rpc/LightNodeRPC.h
@@ -26,6 +26,8 @@
 #include <exception>
 #include <iterator>
 #include <memory>
+#include <range/v3/range/access.hpp>
+#include <range/v3/view/transform.hpp>
 #include <stdexcept>
 
 namespace bcos::rpc
@@ -295,7 +297,7 @@ public:
                     {
                         BOOST_THROW_EXCEPTION(std::runtime_error{e.what()});
                     }
-                    if (RANGES::empty(block.transactionsMetaData) && blockNumber != 0)
+                    if (::ranges::empty(block.transactionsMetaData) && blockNumber != 0)
                     {
                         LIGHTNODE_LOG(ERROR)
                             << LOG_DESC("getBlockByNumber")
@@ -304,19 +306,19 @@ public:
                         self->toErrorResp(error, respFunc);
                         co_return;
                     }
-                    if (!RANGES::empty(block.transactionsMetaData))
+                    if (!::ranges::empty(block.transactionsMetaData))
                     {
                         // Check transaction merkle
                         crypto::merkle::Merkle<Hasher> merkle(self->m_hasher.clone());
                         auto hashesRange =
                             block.transactionsMetaData |
-                            RANGES::views::transform(
+                            ::ranges::views::transform(
                                 [](const bcostars::TransactionMetaData& transactionMetaData)
                                     -> auto& { return transactionMetaData.hash; });
                         std::vector<bcos::bytes> merkles;
                         merkle.generateMerkle(hashesRange, merkles);
 
-                        if (RANGES::empty(merkles))
+                        if (::ranges::empty(merkles))
                         {
                             BOOST_THROW_EXCEPTION(
                                 std::runtime_error{"Unable to generate transaction merkle root!"});
@@ -328,9 +330,9 @@ public:
                             << LOG_KV("transaction number", block.transactions.size());
 
                         if (!bcos::concepts::bytebuffer::equalTo(
-                                block.blockHeader.data.txsRoot, *RANGES::rbegin(merkles)))
+                                block.blockHeader.data.txsRoot, *::ranges::rbegin(merkles)))
                         {
-                            auto merkleRoot = *RANGES::rbegin(merkles);
+                            auto merkleRoot = *::ranges::rbegin(merkles);
                             std::ostringstream strHex;
                             strHex << "0x" << std::hex << std::setfill('0');
                             for (size_t i = 0; i < Hasher::HASH_SIZE; ++i)
@@ -364,7 +366,7 @@ public:
                         bcos::concepts::hash::calculate(
                             parentBlock, self->m_hasher.clone(), parentHash);
 
-                        if (RANGES::empty(block.blockHeader.data.parentInfo) ||
+                        if (::ranges::empty(block.blockHeader.data.parentInfo) ||
                             (block.blockHeader.data.parentInfo[0].blockNumber !=
                                 parentBlock.blockHeader.data.blockNumber) ||
                             !bcos::concepts::bytebuffer::equalTo(
@@ -632,9 +634,9 @@ private:
     void decodeData(bcos::concepts::bytebuffer::ByteBuffer auto const& input,
         bcos::concepts::bytebuffer::ByteBuffer auto& out)
     {
-        auto begin = RANGES::begin(input);
-        auto end = RANGES::end(input);
-        auto length = RANGES::size(input);
+        auto begin = ::ranges::begin(input);
+        auto end = ::ranges::end(input);
+        auto length = ::ranges::size(input);
 
         if ((length == 0) || (length % 2 != 0)) [[unlikely]]
         {
@@ -648,7 +650,7 @@ private:
         }
 
         bcos::concepts::resizeTo(out, length / 2);
-        boost::algorithm::unhex(begin, end, RANGES::begin(out));
+        boost::algorithm::unhex(begin, end, ::ranges::begin(out));
     }
 
     LocalLedgerType m_localLedger;

--- a/lightnode/fisco-bcos-lightnode/client/LedgerClientImpl.h
+++ b/lightnode/fisco-bcos-lightnode/client/LedgerClientImpl.h
@@ -14,6 +14,10 @@
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <iterator>
+#include <range/v3/algorithm/move.hpp>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/traits.hpp>
 #include <random>
 #include <stdexcept>
 #include <type_traits>
@@ -132,9 +136,10 @@ private:
         std::swap(response.block, block);
     }
 
-    task::Task<void> impl_getTransactions(RANGES::range auto const& hashes, RANGES::range auto& out)
+    task::Task<void> impl_getTransactions(
+        ::ranges::range auto const& hashes, ::ranges::range auto& out)
     {
-        using DataType = RANGES::range_value_t<std::remove_cvref_t<decltype(out)>>;
+        using DataType = ::ranges::range_value_t<std::remove_cvref_t<decltype(out)>>;
         using RequestType = std::conditional_t<bcos::concepts::transaction::Transaction<DataType>,
             bcostars::RequestTransactions, bcostars::RequestReceipts>;
         using ResponseType = std::conditional_t<bcos::concepts::transaction::Transaction<DataType>,
@@ -144,7 +149,7 @@ private:
                             protocol::LIGHTNODE_GET_RECEIPTS;
 
         RequestType request;
-        request.hashes.reserve(RANGES::size(hashes));
+        request.hashes.reserve(::ranges::size(hashes));
         for (auto& hash : hashes)
         {
             request.hashes.emplace_back(std::vector<char>(hash.begin(), hash.end()));
@@ -161,14 +166,14 @@ private:
         if constexpr (bcos::concepts::transaction::Transaction<DataType>)
         {
             bcos::concepts::resizeTo(out, response.transactions.size());
-            std::move(RANGES::begin(response.transactions), RANGES::end(response.transactions),
-                RANGES::begin(out));
+            ::ranges::move(::ranges::begin(response.transactions), ::ranges::end(response.transactions),
+                ::ranges::begin(out));
         }
         else
         {
             bcos::concepts::resizeTo(out, response.receipts.size());
-            std::move(RANGES::begin(response.receipts), RANGES::end(response.receipts),
-                RANGES::begin(out));
+            ::ranges::move(::ranges::begin(response.receipts), ::ranges::end(response.receipts),
+                ::ranges::begin(out));
         }
     }
 

--- a/tools/archive-tool/ArchiveService.h
+++ b/tools/archive-tool/ArchiveService.h
@@ -173,12 +173,12 @@ public:
             if (lastBlockToDeleteNonces != 1)
             {
                 auto numberRange =
-                    RANGES::iota_view<uint64_t, uint64_t>(1, lastBlockToDeleteNonces);
+                    ::ranges::iota_view<uint64_t, uint64_t>(1, lastBlockToDeleteNonces);
                 auto numberList = numberRange |
-                                  RANGES::views::transform([](protocol::BlockNumber blockNumber) {
+                                  ::ranges::views::transform([](protocol::BlockNumber blockNumber) {
                                       return boost::lexical_cast<std::string>(blockNumber);
                                   }) |
-                                  RANGES::to<std::vector<std::string>>();
+                                  ::ranges::to<std::vector<std::string>>();
                 auto err = m_storage->deleteRows(ledger::SYS_BLOCK_NUMBER_2_NONCES, numberList);
                 if (err)
                 {

--- a/tools/archive-tool/archiveTool.cpp
+++ b/tools/archive-tool/archiveTool.cpp
@@ -340,14 +340,14 @@ void archiveBlocks(auto archiveStorage, auto ledger,
                 }
             });
         archiveStorage->setRows(ledger::SYS_HASH_2_TX,
-            keys | RANGES::views::transform(
+            keys | ::ranges::views::transform(
                        [](const std::string& str) { return std::string_view{str}; }),
-            transactionValues | RANGES::views::transform(
+            transactionValues | ::ranges::views::transform(
                                     [](const std::string& str) { return std::string_view{str}; }));
         archiveStorage->setRows(ledger::SYS_HASH_2_RECEIPT,
-            keys | RANGES::views::transform(
+            keys | ::ranges::views::transform(
                        [](const std::string& str) { return std::string_view{str}; }),
-            receiptValues | RANGES::views::transform(
+            receiptValues | ::ranges::views::transform(
                                 [](const std::string& str) { return std::string_view{str}; }));
         std::cout << "\r" << "write block " << i << " size: " << size << std::flush;
     }

--- a/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
@@ -1,3 +1,8 @@
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/partition_point.hpp>
+#include <range/v3/algorithm/lower_bound.hpp>
+#include <range/v3/algorithm/binary_search.hpp>
+
 #include "EVMCResult.h"
 #include "bcos-codec/abi/ContractABICodec.h"
 #include "bcos-protocol/TransactionStatus.h"

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
@@ -13,6 +13,7 @@
 #include <exception>
 #include <limits>
 #include <memory>
+#include <range/v3/algorithm/copy.hpp>
 #include <variant>
 
 namespace bcos::executor_v1

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledManager.cpp
@@ -20,6 +20,7 @@
 #include "bcos-executor/src/precompiled/extension/ZkpPrecompiled.h"
 #include "bcos-transaction-executor/precompiled/PrecompiledImpl.h"
 #include <memory>
+#include <range/v3/algorithm/sort.hpp>
 
 
 bcos::executor_v1::PrecompiledManager::PrecompiledManager(crypto::Hash::Ptr hashImpl)

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -59,6 +59,9 @@
 #include <intx/intx.hpp>
 #include <iterator>
 #include <memory>
+#include <range/v3/algorithm/equal.hpp>
+#include <range/v3/algorithm/fill.hpp>
+#include <range/v3/algorithm/move.hpp>
 #include <string_view>
 
 namespace bcos::executor_v1::hostcontext

--- a/transaction-executor/tests/TestHostContext.cpp
+++ b/transaction-executor/tests/TestHostContext.cpp
@@ -30,6 +30,8 @@
 #include <atomic>
 #include <iterator>
 #include <memory>
+#include <range/v3/algorithm/sort.hpp>
+#include <range/v3/algorithm/unique.hpp>
 
 using namespace bcos::task;
 using namespace bcos::storage2;

--- a/transaction-executor/tests/TestMemoryStorage.h
+++ b/transaction-executor/tests/TestMemoryStorage.h
@@ -9,7 +9,7 @@ using MutableStorage = storage2::memory_storage::MemoryStorage<StateKey, StateVa
     storage2::memory_storage::ORDERED>;
 
 auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/, MutableStorage& storage,
-    RANGES::input_range auto&& keys, storage2::DIRECT_TYPE /*unused*/)
+    ::ranges::input_range auto&& keys, storage2::DIRECT_TYPE /*unused*/)
     -> task::Task<task::AwaitableReturnType<decltype(storage2::readSome(storage, keys))>>
 {
     co_return co_await storage2::readSome(storage, std::forward<decltype(keys)>(keys));

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -40,6 +40,7 @@
 #include <chrono>
 #include <exception>
 #include <memory>
+#include <range/v3/algorithm/any_of.hpp>
 #include <range/v3/iterator/operations.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <type_traits>

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -17,7 +17,10 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <range/v3/view/chunk.hpp>
+#include <range/v3/view/drop.hpp>
 #include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/zip.hpp>
 
 namespace bcos::scheduler_v1
 {

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
@@ -11,6 +11,8 @@
 #include <oneapi/tbb/partitioner.h>
 #include <oneapi/tbb/task_arena.h>
 #include <tbb/task_arena.h>
+#include <range/v3/view/chunk.hpp>
+#include <range/v3/view/iota.hpp>
 
 namespace bcos::scheduler_v1
 {

--- a/transaction-scheduler/benchmark/benchmarkMultiLayerStorage.cpp
+++ b/transaction-scheduler/benchmark/benchmarkMultiLayerStorage.cpp
@@ -4,6 +4,10 @@
 #include <bcos-task/Wait.h>
 #include <benchmark/benchmark.h>
 #include <fmt/format.h>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/iota.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/zip.hpp>
 
 using namespace bcos;
 using namespace bcos::storage2::memory_storage;
@@ -21,12 +25,12 @@ struct Fixture
         task::syncWait([this](int64_t count) -> task::Task<void> {
             auto view = multiLayerStorage.fork();
             view.newMutable();
-            allKeys = RANGES::views::iota(0, count) | RANGES::views::transform([](int num) {
+            allKeys = ::ranges::views::iota(0, count) | ::ranges::views::transform([](int num) {
                 auto key = fmt::format("key: {}", num);
                 return executor_v1::StateKey{"test_table"sv, std::string_view(key)};
-            }) | RANGES::to<decltype(allKeys)>();
+            }) | ::ranges::to<decltype(allKeys)>();
 
-            auto allValues = RANGES::views::iota(0, count) | RANGES::views::transform([](int num) {
+            auto allValues = ::ranges::views::iota(0, count) | ::ranges::views::transform([](int num) {
                 storage::Entry entry;
                 entry.set(fmt::format("value: {}", num));
 

--- a/transaction-scheduler/tests/testMultiLayerStorage.cpp
+++ b/transaction-scheduler/tests/testMultiLayerStorage.cpp
@@ -6,6 +6,7 @@
 #include "bcos-transaction-scheduler/ReadWriteSetStorage.h"
 #include <fmt/format.h>
 #include <boost/test/unit_test.hpp>
+#include <range/v3/view/repeat.hpp>
 #include <variant>
 
 using namespace bcos;


### PR DESCRIPTION
Eliminate the Ranges.h header to streamline dependencies and address a conflict with the std namespace, ensuring cleaner code and improved compatibility.