### PR TITLE
Remove shared_ptr fromHexString and toHexString

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ if(FULLNODE)
     endif()
 
     if(TESTS)
+        include(CTest)
         enable_testing()
         add_subdirectory(tests)
         add_subdirectory(benchmark)

--- a/bcos-boostssl/bcos-boostssl/context/NodeInfoTools.cpp
+++ b/bcos-boostssl/bcos-boostssl/context/NodeInfoTools.cpp
@@ -146,8 +146,7 @@ NodeInfoTools::initCert2PubHexHandler()
                 break;
             }
 
-            auto hex = bcos::toHexString(pubKey->data, pubKey->data + pubKey->length, "");
-            _pubHex = *hex.get();
+            _pubHex = bcos::toHex(bytesConstRef((const byte*)pubKey->data, pubKey->length));
 
             NODEINFO_LOG(INFO) << LOG_DESC("initCert2PubHexHandler ") << LOG_KV("cert", _cert)
                                << LOG_KV("pubHex: ", _pubHex);
@@ -170,8 +169,7 @@ std::function<bool(X509* cert, std::string& pubHex)> NodeInfoTools::initSSLConte
             return false;
         }
 
-        auto hex = bcos::toHexString(pubKey->data, pubKey->data + pubKey->length, "");
-        _pubHex = *hex.get();
+        _pubHex = bcos::toHex(bytesConstRef((const byte*)pubKey->data, pubKey->length));
 
         NODEINFO_LOG(INFO) << LOG_DESC("[NEW]SSLContext pubHex: " + _pubHex);
         return true;

--- a/bcos-codec/bcos-codec/abi/ContractABICodec.h
+++ b/bcos-codec/bcos-codec/abi/ContractABICodec.h
@@ -416,7 +416,7 @@ private:
         {
             std::stringstream ss;
             ss << " deserialize failed, invalid offset , offset is " << _offset << " , length is "
-               << data.size() << " , data is " << *toHexString(data);
+               << data.size() << " , data is " << toHex(data);
 
             throw std::length_error(ss.str().c_str());
         }
@@ -504,7 +504,7 @@ public:
     template <class... T>
     bool abiOutHex(const std::string& _data, T&... _t)
     {
-        auto dataFromHex = *fromHexString(_data);
+        auto dataFromHex = fromHex(_data);
         return abiOut(bytesConstRef(&dataFromHex), _t...);
     }
 
@@ -528,7 +528,7 @@ public:
     template <class... T>
     std::string abiInHex(const std::string& _sig, T const&... _t)
     {
-        return *toHexString(abiIn(_sig, _t...));
+        return toHex(abiIn(_sig, _t...));
     }
 };
 

--- a/bcos-codec/bcos-codec/rlp/RLPDecode.h
+++ b/bcos-codec/bcos-codec/rlp/RLPDecode.h
@@ -20,10 +20,10 @@
 
 #pragma once
 #include "Common.h"
+#include "bcos-utilities/Error.h"
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <utility>
-#include <vector>
 
 // THANKS TO: RLP implement based on silkworm: https://github.com/erigontech/silkworm.git
 // Note:https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/

--- a/bcos-codec/test/unittests/ContractABICodecTest.cpp
+++ b/bcos-codec/test/unittests/ContractABICodecTest.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_func0)
 
     auto r = ct.abiInHex("", a, b, c, d);
     auto rb = ct.abiIn("", a, b, c, d);
-    BOOST_CHECK(r == *toHexString(rb));
+    BOOST_CHECK(r == toHex(rb));
 
     BOOST_CHECK_EQUAL(
         r, std::string("0000000000000000000000000000000000000000000000000000000000000123"
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_func1)
     std::vector<u256> c{1, 2, 3};
 
     auto rb = ct.abiIn("", a, b, c);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
     BOOST_CHECK_EQUAL(
         r, std::string("0000000000000000000000000000000000000000000000000000000000000060"
                        "0000000000000000000000000000000000000000000000000000000000000001"
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_func2)
     Address f("0x692a70d2e424a56d2c6c27aa97d1a86395877b3a");
 
     auto rb = ct.abiIn("", a, b, c, d, e, f);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
 
     std::string outA;
     u256 outB;
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_func3)
     int d = -11111;
 
     auto rb = ct.abiIn("", a, b, c, d);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
 
     BOOST_CHECK_EQUAL(
         r, std::string(
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_func4)
     std::vector<std::array<std::string, 3>> f(3);
 
     auto rb = ct.abiIn("", a, b, c, d, e, f);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
 
     std::string outA = "HelloWorld";
     u256 outB = 11111;
@@ -213,19 +213,19 @@ BOOST_AUTO_TEST_CASE(ContractABIType_u256)
     ContractABICodec ct(*hashImpl);
 
     u256 x = 0;
-    std::string r = *toHexString(ct.serialise(x));
+    std::string r = toHex(ct.serialise(x));
     BOOST_CHECK(r == "0000000000000000000000000000000000000000000000000000000000000000");
 
     u256 y("0x7fffffffffffffff");
-    r = *toHexString(ct.serialise(y));
+    r = toHex(ct.serialise(y));
     BOOST_CHECK(r == "0000000000000000000000000000000000000000000000007fffffffffffffff");
 
     u256 z("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-    r = *toHexString(ct.serialise(z));
+    r = toHex(ct.serialise(z));
     BOOST_CHECK(r == "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
     u256 u("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe");
-    r = *toHexString(ct.serialise(u));
+    r = toHex(ct.serialise(u));
     BOOST_CHECK(r == "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe");
 }
 
@@ -235,19 +235,19 @@ BOOST_AUTO_TEST_CASE(ContractABIType_s256)
     ContractABICodec ct(*hashImpl);
 
     s256 x = 0;
-    std::string r = *toHexString(ct.serialise(x));
+    std::string r = toHex(ct.serialise(x));
     BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000000");
 
     s256 y("0x7fffffffffffffff");
-    r = *toHexString(ct.serialise(y));
+    r = toHex(ct.serialise(y));
     BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000007fffffffffffffff");
 
     s256 z = -1;
-    r = *toHexString(ct.serialise(z));
+    r = toHex(ct.serialise(z));
     BOOST_CHECK_EQUAL(r, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
 
     s256 s = 1000;
-    r = *toHexString(ct.serialise(s));
+    r = toHex(ct.serialise(s));
     BOOST_CHECK_EQUAL(r, "00000000000000000000000000000000000000000000000000000000000003e8");
 }
 
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         int8_t i8 = INT8_MAX;
         auto b = codec.encode(i8);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "000000000000000000000000000000000000000000000000000000000000007f");
         int8_t ri8;
         codec.decode(ref(b), ri8);
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         i8 = INT8_MIN;
         b = codec.encode(i8);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80");
         codec.decode(ref(b), ri8);
         BOOST_CHECK(i8 == ri8);
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         int16_t i16 = INT16_MAX;
         auto b = codec.encode(i16);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000007fff");
         int16_t ri16;
         codec.decode(ref(b), ri16);
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         i16 = INT16_MIN;
         b = codec.encode(i16);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff8000");
         codec.decode(ref(b), ri16);
         BOOST_CHECK(i16 == ri16);
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         int32_t i32 = INT32_MAX;
         auto b = codec.encode(i32);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "000000000000000000000000000000000000000000000000000000007fffffff");
         int32_t ri32;
         codec.decode(ref(b), ri32);
@@ -304,7 +304,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         i32 = INT32_MIN;
         b = codec.encode(i32);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffff80000000");
         codec.decode(ref(b), ri32);
         BOOST_CHECK(i32 == ri32);
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         int64_t i64 = INT64_MAX;
         auto b = codec.encode(i64);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000007fffffffffffffff");
         int64_t ri64;
         codec.decode(ref(b), ri64);
@@ -322,7 +322,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         i64 = INT64_MIN;
         b = codec.encode(i64);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "ffffffffffffffffffffffffffffffffffffffffffffffff8000000000000000");
         codec.decode(ref(b), ri64);
         BOOST_CHECK(i64 == ri64);
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         uint8_t u8 = UINT8_MAX;
         auto b = codec.encode(u8);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "00000000000000000000000000000000000000000000000000000000000000ff");
         uint8_t ru8;
         codec.decode(ref(b), ru8);
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         u8 = 0;
         b = codec.encode(u8);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000000");
         codec.decode(ref(b), ru8);
         BOOST_CHECK(u8 == ru8);
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         uint16_t u16 = UINT16_MAX;
         auto b = codec.encode(u16);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "000000000000000000000000000000000000000000000000000000000000ffff");
         uint16_t ru16;
         codec.decode(ref(b), ru16);
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         u16 = 0;
         b = codec.encode(u16);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000000");
         codec.decode(ref(b), ru16);
         BOOST_CHECK(u16 == ru16);
@@ -368,7 +368,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         uint32_t u32 = UINT32_MAX;
         auto b = codec.encode(u32);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "00000000000000000000000000000000000000000000000000000000ffffffff");
         uint32_t ru32;
         codec.decode(ref(b), ru32);
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         u32 = 0;
         b = codec.encode(u32);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000000");
         codec.decode(ref(b), ru32);
         BOOST_CHECK(u32 == ru32);
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
     {
         uint64_t u64 = UINT64_MAX;
         auto b = codec.encode(u64);
-        std::string r = *toHexString(b);
+        std::string r = toHex(b);
         BOOST_CHECK_EQUAL(r, "000000000000000000000000000000000000000000000000ffffffffffffffff");
         uint64_t ru64;
         codec.decode(ref(b), ru64);
@@ -394,7 +394,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_integer)
 
         u64 = 0;
         b = codec.encode(u64);
-        r = *toHexString(b);
+        r = toHex(b);
         BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000000");
         codec.decode(ref(b), ru64);
         BOOST_CHECK(u64 == ru64);
@@ -417,12 +417,12 @@ BOOST_AUTO_TEST_CASE(ContractABIType_bool)
     ContractABICodec ct(*hashImpl);
 
     bool x = true;
-    std::string r = *toHexString(ct.serialise(x));
+    std::string r = toHex(ct.serialise(x));
     BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000001");
 
 
     bool y = false;
-    r = *toHexString(ct.serialise(y));
+    r = toHex(ct.serialise(y));
     BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000000");
 }
 
@@ -432,12 +432,12 @@ BOOST_AUTO_TEST_CASE(ContractABIType_addr)
     ContractABICodec ct(*hashImpl);
 
     Address x;
-    std::string r = *toHexString(ct.serialise(x));
+    std::string r = toHex(ct.serialise(x));
     BOOST_CHECK_EQUAL(r, "0000000000000000000000000000000000000000000000000000000000000000");
 
 
     Address y("0xbe5422d15f39373eb0a97ff8c10fbd0e40e29338");
-    r = *toHexString(ct.serialise(y));
+    r = toHex(ct.serialise(y));
     BOOST_CHECK_EQUAL(r, "000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338");
 }
 
@@ -447,13 +447,13 @@ BOOST_AUTO_TEST_CASE(ContractABIType_string)
     ContractABICodec ct(*hashImpl);
 
     std::string x("Hello, world!");
-    std::string r = *toHexString(ct.serialise(x));
+    std::string r = toHex(ct.serialise(x));
     BOOST_CHECK_EQUAL(
         r, std::string("000000000000000000000000000000000000000000000000000000000000000d48656c6c6"
                        "f2c20776f726c642100000000000000000000000000000000000000"));
 
     std::string y("");
-    r = *toHexString(ct.serialise(y));
+    r = toHex(ct.serialise(y));
     BOOST_CHECK_EQUAL(
         r, std::string("0000000000000000000000000000000000000000000000000000000000000000"));
 }
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_array_uint256)
     ContractABICodec ct(*hashImpl);
 
     std::array<u256, 3> x{1, 2, 3};
-    std::string r = *toHexString(ct.serialise(x));
+    std::string r = toHex(ct.serialise(x));
     BOOST_CHECK_EQUAL(
         r, std::string("00000000000000000000000000000000000000000000000000000000000000010"
                        "0000000000000000000000000"
@@ -473,7 +473,7 @@ BOOST_AUTO_TEST_CASE(ContractABIType_array_uint256)
                        "000000000003"));
 
     std::vector<u256> y{1, 2, 3};
-    r = *toHexString(ct.serialise(y));
+    r = toHex(ct.serialise(y));
     BOOST_CHECK_EQUAL(
         r, std::string("000000000000000000000000000000000000000000000000000000000000000300000000000"
                        "000000000000000"
@@ -494,7 +494,7 @@ BOOST_AUTO_TEST_CASE(ContractABITest0)
     string32 d = toString32(std::string("adsggsakjffl;kajsdf"));
 
     auto rb = ct.abiIn("", a, b, c, d);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
 
     u256 outA;
     s256 outB;
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE(ContractABITest1)
     auto hashImpl = std::make_shared<Keccak256>();
     ContractABICodec ct(*hashImpl);
     auto rb = ct.abiIn("", a, b, c, d, e);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
     BOOST_CHECK_EQUAL(r, expect);
 
     u256 outA;
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE(ContractABITest2)
     auto hashImpl = std::make_shared<Keccak256>();
     ContractABICodec ct(*hashImpl);
     auto rb = ct.abiIn("", a);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
 
     BOOST_CHECK(r == expect);
 
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(ContractABITest3)
     std::vector<std::array<u256, 3>> i{{4, 4, 4}, {5, 5, 5}};
 
     auto rb = ct.abiIn("", a, b, c, d, e, f, g, h, i);
-    auto r = *toHexString(rb);
+    auto r = toHex(rb);
 
     std::string expect =
         "000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000069"
@@ -850,7 +850,7 @@ BOOST_AUTO_TEST_CASE(testABIOutBytes)
     std::string hashStr = "1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b";
     h256 hashData = h256(hashStr);
     std::string plainText = "test";
-    bytes plainBytes = *fromHexString(*toHexString(plainText));
+    bytes plainBytes = fromHex(toHex(plainText));
     ABIFunc afunc;
     auto ok = afunc.parser("f(bytes32,bytes,bytes32)");
     BOOST_CHECK(ok == true);
@@ -869,12 +869,12 @@ BOOST_AUTO_TEST_CASE(testABIOutBytes)
     string32 decodedParam3;
     abi.abiOut(ref(paramData), decodedParam1, decodedParam2, decodedParam3);
 
-    BOOST_CHECK(*toHexString(fromString32(decodedParam1)) == hashStr);
-    BOOST_CHECK(*toHexString(fromString32(decodedParam3)) == hashStr);
-    std::cout << "decodedParam1: " << *toHexString(decodedParam1) << std::endl;
-    std::cout << "decodedParam2: " << *toHexString(decodedParam2) << std::endl;
-    std::cout << "decodedParam3: " << *toHexString(decodedParam3) << std::endl;
-    BOOST_CHECK(*toHexString(decodedParam2) == *toHexString(plainText));
+    BOOST_CHECK(toHex(fromString32(decodedParam1)) == hashStr);
+    BOOST_CHECK(toHex(fromString32(decodedParam3)) == hashStr);
+    std::cout << "decodedParam1: " << toHex(decodedParam1) << std::endl;
+    std::cout << "decodedParam2: " << toHex(decodedParam2) << std::endl;
+    std::cout << "decodedParam3: " << toHex(decodedParam3) << std::endl;
+    BOOST_CHECK(toHex(decodedParam2) == toHex(plainText));
 
     // test bytes
     plainText = "testabcxxd";
@@ -882,7 +882,7 @@ BOOST_AUTO_TEST_CASE(testABIOutBytes)
     paramData = abi.abiIn("", refPlainBytes.toBytes());
     bytes decodedParam;
     abi.abiOut(ref(paramData), decodedParam);
-    BOOST_CHECK(*toHexString(decodedParam) == *toHexString(plainText));
+    BOOST_CHECK(toHex(decodedParam) == toHex(plainText));
 }
 
 BOOST_AUTO_TEST_CASE(testABITuple)
@@ -1016,7 +1016,7 @@ BOOST_AUTO_TEST_CASE(testABITuple)
             "00000000000000000000000000000005746573743200000000000000000000000000000000000000000000"
             "0000"
             "000000";
-        std::string hexString = *toHexString(encodedBytes);
+        std::string hexString = toHex(encodedBytes);
         BOOST_CHECK(hexString == bytesString);
 
         decltype(testEncode) testDecode;
@@ -1041,7 +1041,7 @@ BOOST_AUTO_TEST_CASE(testABITuple)
     {
         auto test1 = std::make_tuple(std::string("123"), s256(-1),
             Address("0x420f853b49838bd3e9466c85a4cc3428c960dde2"),
-            *fromHexString("420f853b49838bd3e9466c85a4cc3428c960dde2"),
+            fromHex("420f853b49838bd3e9466c85a4cc3428c960dde2"),
             std::vector<std::string>({"123", "456"}));
         auto test1Encode = abi.abiIn("", test1);
         decltype(test1) test1Decode;
@@ -1059,12 +1059,12 @@ BOOST_AUTO_TEST_CASE(testABITuple)
     {
         auto tuple1 = std::make_tuple(std::string("123"), s256(-1),
             Address("0x420f853b49838bd3e9466c85a4cc3428c960dde2"),
-            *fromHexString("420f853b49838bd3e9466c85a4cc3428c960dde2"),
+            fromHex("420f853b49838bd3e9466c85a4cc3428c960dde2"),
             std::vector<std::string>({"123", "456"}));
 
         auto tuple2 = std::make_tuple(std::string("456"), s256(-123),
             Address("0x420f853b49838bd3e9466c85a4cc3428c360dde2"),
-            *fromHexString("420f853b49838bd3e9466c85a4cc3528c960dde2"),
+            fromHex("420f853b49838bd3e9466c85a4cc3528c960dde2"),
             std::vector<std::string>({"321", "33333"}));
 
         std::vector<decltype(tuple1)> tupleV1{tuple1, tuple2};

--- a/bcos-codec/test/unittests/ScaleCodecTest.cpp
+++ b/bcos-codec/test/unittests/ScaleCodecTest.cpp
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(testString)
 
 BOOST_AUTO_TEST_CASE(testBytes1)
 {
-    std::string v = "0x1";
+    std::string v = "0x01";
     FixedBytes<1> fb1(v);
     ScaleEncoderStream s{};
     s << fb1;
@@ -555,8 +555,8 @@ BOOST_AUTO_TEST_CASE(scaleCompactTest)
                                        "655037778630591879033574393515952034305194542857496045"
                                        "531676044756160413302774714984450425759043258192756735"),
             fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-                           "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
-                           "FFFF"));
+                    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+                    "FFFF"));
     testCompactEncodeAndDecode(compactPair);
 }
 

--- a/bcos-codec/test/unittests/ScaleCodecTest.cpp
+++ b/bcos-codec/test/unittests/ScaleCodecTest.cpp
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE(scaleCompactTest)
         makeCompactPair(CompactInteger("224945689727159819140526925384299092943484855915095831"
                                        "655037778630591879033574393515952034305194542857496045"
                                        "531676044756160413302774714984450425759043258192756735"),
-            *fromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+            fromHex("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
                            "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
                            "FFFF"));
     testCompactEncodeAndDecode(compactPair);
@@ -632,7 +632,7 @@ void testFixedWidthInteger(std::pair<T, bytes> const& _matchPair, bool _check = 
         s2 >> v;
         BOOST_CHECK(v == value);
     }
-    std::cout << "##### value:" << std::to_string(value) << ", data:" << *toHexString(s.data())
+    std::cout << "##### value:" << std::to_string(value) << ", data:" << toHex(s.data())
               << std::endl;
 }
 
@@ -1040,7 +1040,7 @@ void printData(T const& _data)
     ScaleDecoderStream decoder(gsl::make_span(out));
     decoder >> decodedNumber;
     BOOST_CHECK(_data == decodedNumber);
-    std::cout << "#### value:" << _data << ", encoded:" << *toHexString(encoder.data()) << std::endl;
+    std::cout << "#### value:" << _data << ", encoded:" << toHex(encoder.data()) << std::endl;
 }
 BOOST_AUTO_TEST_CASE(testU256)
 {

--- a/bcos-crypto/bcos-crypto/ChecksumAddress.h
+++ b/bcos-crypto/bcos-crypto/ChecksumAddress.h
@@ -94,7 +94,7 @@ inline void toAddress(std::string& _hexAddress)
 inline std::string toChecksumAddressFromBytes(
     const std::string_view& _AddressBytes, crypto::Hash::Ptr _hashImpl)
 {
-    auto hexAddress = *toHexString(_AddressBytes);
+    auto hexAddress = toHex(_AddressBytes);
     toAddress(hexAddress);
     return hexAddress;
 }
@@ -159,9 +159,9 @@ inline std::string newLegacyEVMAddressString(
 inline std::string newCreate2EVMAddress(bcos::crypto::Hash::Ptr _hashImpl,
     const std::string_view& _sender, bytesConstRef _init, u256 const& _salt)
 {
-    auto hash = _hashImpl->hash(
-        bytes{0xff} + (_sender.starts_with("0x") ? fromHexWithPrefix(_sender) : fromHex(_sender)) +
-        toBigEndian(_salt) + _hashImpl->hash(_init));
+    auto hash = _hashImpl->hash(bytes{0xff} +
+                                (_sender.starts_with("0x") ? fromHex(_sender) : fromHex(_sender)) +
+                                toBigEndian(_salt) + _hashImpl->hash(_init));
 
     std::string hexAddress;
     hexAddress.reserve(40);

--- a/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
+++ b/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
@@ -19,7 +19,6 @@
  * @date 2021-04-01
  */
 #pragma once
-#include "range/v3/view/any_view.hpp"
 #include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <range/v3/view/any_view.hpp>

--- a/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
+++ b/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
@@ -19,6 +19,7 @@
  * @date 2021-04-01
  */
 #pragma once
+#include "range/v3/view/any_view.hpp"
 #include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/FixedBytes.h>
 

--- a/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519Crypto.cpp
@@ -85,7 +85,7 @@ PublicPtr bcos::crypto::ed25519Recover(const HashType& _messageHash, bytesConstR
         BOOST_THROW_EXCEPTION(
             InvalidSignature() << errinfo_comment(
                 "invalid signature: ed25519 recover failed, msgHash : " + _messageHash.hex() +
-                ", signature:" + *toHexString(_signatureData)));
+                ", signature:" + toHex(_signatureData)));
     }
     return ed25519Pub;
 }

--- a/bcos-crypto/bcos-crypto/signature/fastsm2/fast_sm2.cpp
+++ b/bcos-crypto/bcos-crypto/signature/fastsm2/fast_sm2.cpp
@@ -76,9 +76,10 @@ int8_t bcos::crypto::fast_sm2_sign(const CInputBuffer* raw_private_key,
         CRYPTO_LOG(WARNING) << LOG_DESC(
                                    "sm2: fast_sm2_sign: error of EC_POINT_bn2point for publicKey")
                             << LOG_KV("len", raw_public_key->len)
-                            << LOG_KV(
-                                   "pubHex", *toHexString(raw_public_key->data,
-                                                 raw_public_key->data + raw_public_key->len, "0x"));
+                    << LOG_KV("pubHex",
+                        toHex(bytesConstRef((const byte*)raw_public_key->data,
+                            raw_public_key->len),
+                            "0x"));
         goto done;
     }
     sm2Key = EC_KEY_new();

--- a/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.cpp
@@ -156,7 +156,7 @@ PublicPtr HsmSM2Crypto::recover(const HashType& _hash, bytesConstRef _signData) 
     }
     BOOST_THROW_EXCEPTION(InvalidSignature() << errinfo_comment(
                               "invalid signature: hsm sm2 recover public key failed, msgHash : " +
-                              _hash.hex() + ", signature:" + *toHexString(_signData)));
+                              _hash.hex() + ", signature:" + toHex(_signData)));
 }
 
 std::pair<bool, bytes> HsmSM2Crypto::recoverAddress(Hash::Ptr _hashImpl, bytesConstRef _input) const

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
@@ -88,7 +88,7 @@ bool bcos::crypto::secp256k1Verify(
     {
         BOOST_THROW_EXCEPTION(InvalidSignature() << errinfo_comment(
                                   "invalid signature: secp256k1Recover failed, msgHash : " +
-                                  _hash.hex() + ", signData:" + *toHexString(_signatureData)));
+                                  _hash.hex() + ", signData:" + toHex(_signatureData)));
     }
     std::array<unsigned char, SECP256K1_UNCOMPRESS_PUBLICKEY_LEN> data{};
     size_t serializedPubKeySize = SECP256K1_UNCOMPRESS_PUBLICKEY_LEN;
@@ -124,7 +124,7 @@ void secp256k1RecoverPrimitive(const HashType& _hash, char* _pubKey, bytesConstR
     {
         BOOST_THROW_EXCEPTION(InvalidSignature() << errinfo_comment(
                                   "invalid signature: secp256k1Recover failed, msgHash : " +
-                                  _hash.hex() + ", signData:" + *toHexString(_signatureData)));
+                                  _hash.hex() + ", signData:" + toHex(_signatureData)));
     }
     size_t serializedPubkeySize = SECP256K1_UNCOMPRESS_PUBLICKEY_LEN;
     std::array<unsigned char, SECP256K1_UNCOMPRESS_PUBLICKEY_LEN> data{};
@@ -194,7 +194,7 @@ std::pair<bool, bytes> Secp256k1Crypto::recoverAddress(
     {
         BOOST_THROW_EXCEPTION(InvalidSignature() << errinfo_comment(
                                   "invalid signature: secp256k1Recover failed, msgHash : " +
-                                  _hash.hex() + ", signData:" + *toHexString(_signatureData)));
+                                  _hash.hex() + ", signData:" + toHex(_signatureData)));
     }
     size_t serializedPubkeySize = SECP256K1_UNCOMPRESS_PUBLICKEY_LEN;
 

--- a/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
@@ -86,7 +86,7 @@ PublicPtr SM2Crypto::recover(const HashType& _hash, bytesConstRef _signData) con
     }
     BOOST_THROW_EXCEPTION(InvalidSignature() << errinfo_comment(
                               "invalid signature: sm2 recover public key failed, msgHash : " +
-                              _hash.hex() + ", signature:" + *toHexString(_signData)));
+                              _hash.hex() + ", signature:" + toHex(_signData)));
 }
 
 std::pair<bool, bytes> SM2Crypto::recoverAddress(Hash::Ptr _hashImpl, bytesConstRef _input) const

--- a/bcos-crypto/test/unittests/HashTest.cpp
+++ b/bcos-crypto/test/unittests/HashTest.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(testKeccak256)
         ts, std::string("6377c7e66081cb65e473c1b95db5195a27d04a7108b468890224bedbe1a8a6eb"));
 
     h256 emptyKeccak256(
-        *fromHexString("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        fromHex("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
     BOOST_REQUIRE_EQUAL(emptyKeccak256, keccak256->emptyHash());
 
     BOOST_REQUIRE_EQUAL(cryptoSuite->hash(""sv),
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(testSM3)
         ts, std::string("afe4ccac5ab7d52bcae36373676215368baf52d3905e1fecbe369cc120e97628"));
 
     h256 emptySM3(
-        *fromHexString("1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b"));
+        fromHex("1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b"));
     BOOST_REQUIRE_EQUAL(emptySM3, sm3->emptyHash());
 
     BOOST_REQUIRE_EQUAL(cryptoSuite->hash(""sv),
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(testSha3)
         ts, std::string("d716ec61e18904a8f58679b71cb065d4d5db72e0e0c3f155a4feff7add0e58eb"));
 
     h256 emptySha3(
-        *fromHexString("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"));
+        fromHex("a7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"));
     BOOST_REQUIRE_EQUAL(emptySha3, sha3->emptyHash());
 
     BOOST_REQUIRE_EQUAL(cryptoSuite->hash(""sv),

--- a/bcos-crypto/test/unittests/SignatureTest.cpp
+++ b/bcos-crypto/test/unittests/SignatureTest.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(testSecp256k1KeyPair)
     for (int i = 0; i < 10; i++)
     {
         pub1 = secp256k1PriToPub(sec1);
-        BOOST_CHECK_EQUAL(*toHexString(pub1->data()),
+        BOOST_CHECK_EQUAL(toHex(pub1->data()),
             "3378c2b7bcdce20357eb3dbb62590b88d4711dae74e1ea47dd4207441734d2fc7cf6df92fd8c0a3368ba5a"
             "1f5f9c3318d19a3f00ba2f2bd9f508b953be299fb5");
     }
@@ -108,14 +108,14 @@ BOOST_AUTO_TEST_CASE(testSecp256k1SignAndVerify)
 {
     auto keyPair = secp256k1GenerateKeyPair();
     auto hashData = keccak256Hash(bytesConstRef((std::string)("abcd")));
-    std::cout << "### hashData:" << *toHexString(hashData) << std::endl;
+    std::cout << "### hashData:" << toHex(hashData) << std::endl;
     std::cout << "#### publicKey:" << keyPair->publicKey()->hex() << std::endl;
     std::cout << "#### publicKey shortHex:" << keyPair->publicKey()->shortHex() << std::endl;
     /// normal check
     // sign
     auto signData = secp256k1Sign(*keyPair, hashData);
-    std::cout << "### signData:" << *toHexString(*signData) << std::endl;
-    std::cout << "### hashData:" << *toHexString(hashData) << std::endl;
+    std::cout << "### signData:" << toHex(*signData) << std::endl;
+    std::cout << "### hashData:" << toHex(hashData) << std::endl;
     std::cout << "#### publicKey:" << keyPair->publicKey()->hex() << std::endl;
 
     // verify
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(testSecp256k1SignAndVerify)
         keyPair->publicKey(), hashData, bytesConstRef(signData->data(), signData->size()));
     BOOST_CHECK(result == true);
     std::cout << "### verify result:" << result << std::endl;
-    std::cout << "### hashData:" << *toHexString(hashData) << std::endl;
+    std::cout << "### hashData:" << toHex(hashData) << std::endl;
     std::cout << "#### publicKey:" << keyPair->publicKey()->hex() << std::endl;
 
     // recover
@@ -138,8 +138,8 @@ BOOST_AUTO_TEST_CASE(testSecp256k1SignAndVerify)
 
     BOOST_CHECK(address.asBytes() == ret.second);
     std::cout << "### secp256k1Recover begin, publicKey:"
-              << *toHexString(keyPair->publicKey()->data()) << std::endl;
-    std::cout << "#### recoverd publicKey:" << *toHexString(pub->data()) << std::endl;
+              << toHex(keyPair->publicKey()->data()) << std::endl;
+    std::cout << "#### recoverd publicKey:" << toHex(pub->data()) << std::endl;
     BOOST_CHECK(pub->data() == keyPair->publicKey()->data());
     BOOST_TEST(toHex(pub->data()) == toHex(keyPair->publicKey()->data()));
     /// exception check:
@@ -268,15 +268,15 @@ inline void SM2SignAndVerifyTest(SM2Crypto::Ptr _smCrypto)
     auto sec = std::make_shared<KeyImpl>(secret.asBytes());
     auto keyPair = _smCrypto->createKeyPair(sec);
     BOOST_CHECK(keyPair->publicKey()->data() ==
-                *(fromHexString("f7dee65e76603ed7cd4c598d53cabe875c459e0fae4c6fd7b858189fd4741081e9"
-                                "70bca0d5cb571a7ac30586aec71b23187d4b25e59143812f74a2744604d42b")));
-    auto signatureData = fromHexString(
+            fromHex("f7dee65e76603ed7cd4c598d53cabe875c459e0fae4c6fd7b858189fd4741081e9"
+                "70bca0d5cb571a7ac30586aec71b23187d4b25e59143812f74a2744604d42b"));
+    auto signatureData = fromHex(
         "cd39bf939d999ca710576a629c962edfc28608701a3a7b61c971daeac5a1399cf4a7272fa80783e171c7fd5b03"
         "8a3af4521f681ebe9fd44db3b60e750c438293f7dee65e76603ed7cd4c598d53cabe875c459e0fae4c6fd7b858"
         "189fd4741081e970bca0d5cb571a7ac30586aec71b23187d4b25e59143812f74a2744604d42b");
     // check verify
     bool result = _smCrypto->verify(keyPair->publicKey(), hashData,
-        bytesConstRef(signatureData->data(), signatureData->size()));
+        bytesConstRef(signatureData.data(), signatureData.size()));
     BOOST_CHECK(result == true);
 
     keyPair = _smCrypto->generateKeyPair();
@@ -286,8 +286,8 @@ inline void SM2SignAndVerifyTest(SM2Crypto::Ptr _smCrypto)
     result =
         _smCrypto->verify(keyPair->publicKey(), hashData, bytesConstRef(sig->data(), sig->size()));
 
-    std::cout << "#### privateKey:" << *toHexString(keyPair->secretKey()->data()) << std::endl;
-    std::cout << "#### phase 1, signatureData:" << *toHexString(*sig) << std::endl;
+    std::cout << "#### privateKey:" << toHex(keyPair->secretKey()->data()) << std::endl;
+    std::cout << "#### phase 1, signatureData:" << toHex(*sig) << std::endl;
     BOOST_CHECK(result == true);
     // recover
     auto pub = _smCrypto->recover(hashData, bytesConstRef(sig->data(), sig->size()));
@@ -333,13 +333,13 @@ inline void SM2SignAndVerifyTest(SM2Crypto::Ptr _smCrypto)
     // test padding
     unsigned fieldLen = 32;
     std::shared_ptr<bytes> data = std::make_shared<bytes>(fieldLen, 0);
-    auto binData = fromHexString("508b2b49c1d2dc46cbd5a011686fdc19937dbc704afe6c547a862b3e2b6c69");
-    memcpy(data->data(), binData->data(), binData->size());
+    auto binData = fromHex("508b2b49c1d2dc46cbd5a011686fdc19937dbc704afe6c547a862b3e2b6c69");
+    memcpy(data->data(), binData.data(), binData.size());
     // padding zero to the r field
-    memmove(data->data() + (fieldLen - binData->size()), data->data(), binData->size());
-    memset(data->data(), 0, (fieldLen - binData->size()));
-    std::cout << "#### data:" << *toHexString(*data) << std::endl;
-    std::cout << "#### binData:" << *toHexString(*binData) << std::endl;
+    memmove(data->data() + (fieldLen - binData.size()), data->data(), binData.size());
+    memset(data->data(), 0, (fieldLen - binData.size()));
+    std::cout << "#### data:" << toHex(*data) << std::endl;
+    std::cout << "#### binData:" << toHex(binData) << std::endl;
     std::cout << "### data 0:" << int((*data)[0]) << std::endl;
     std::cout << "### data 1:" << int((*data)[1]) << std::endl;
 }
@@ -368,8 +368,8 @@ BOOST_AUTO_TEST_CASE(testED25519SignAndVerify)
     // verify
     bool result = signatureCrypto->verify(
         keyPair->publicKey(), hashData, bytesConstRef(sig->data(), sig->size()));
-    std::cout << "#### phase 1, signatureData:" << *toHexString(*sig) << std::endl;
-    std::cout << "#### keyPair->publicKey():" << *toHexString(keyPair->publicKey()->data())
+    std::cout << "#### phase 1, signatureData:" << toHex(*sig) << std::endl;
+    std::cout << "#### keyPair->publicKey():" << toHex(keyPair->publicKey()->data())
               << std::endl;
     BOOST_CHECK(result == true);
     // recover

--- a/bcos-crypto/test/unittests/ZkpTest.cpp
+++ b/bcos-crypto/test/unittests/ZkpTest.cpp
@@ -37,20 +37,20 @@ BOOST_AUTO_TEST_CASE(testAggregateRistrettoPoint)
     std::string point2 = "d21b3e0fde82da359493b96b8f3633f9ba39bbb8d8d72c951c173639c750c248";
     auto zkpImpl = std::make_shared<DiscreteLogarithmZkp>();
 
-    auto result = zkpImpl->aggregateRistrettoPoint(*fromHexString(point1), *fromHexString(point2));
+    auto result = zkpImpl->aggregateRistrettoPoint(fromHex(point1), fromHex(point2));
     BOOST_CHECK(
-        *toHexString(result) == "327ea1e62fd6c6a3fc8fb203618fbf2f7924bbfbdec52a9324bd6964c4c0ca12");
+        toHex(result) == "327ea1e62fd6c6a3fc8fb203618fbf2f7924bbfbdec52a9324bd6964c4c0ca12");
 
     point1 = "786058ceffe85198ef127b6a9781b07adbe3b2d21de87a26804e6a1b43cd4135";
     point2 = "18df09397eed2a614062649be865da8e26cbdd8848fdbed7e8ae8b0e67745d52";
-    result = zkpImpl->aggregateRistrettoPoint(*fromHexString(point1), *fromHexString(point2));
+    result = zkpImpl->aggregateRistrettoPoint(fromHex(point1), fromHex(point2));
     BOOST_CHECK(
-        *toHexString(result) == "36f238ce7215e9704a60c631ac0d576a5d816baf6fc1092798d3bd6ae260f540");
+        toHex(result) == "36f238ce7215e9704a60c631ac0d576a5d816baf6fc1092798d3bd6ae260f540");
 
     point2 = "c25d4eed8b636edaa06e2ee0b3a16d1ea7058a3fd455702180cc9bdb14ce8016";
-    result = zkpImpl->aggregateRistrettoPoint(*fromHexString(point1), *fromHexString(point2));
+    result = zkpImpl->aggregateRistrettoPoint(fromHex(point1), fromHex(point2));
     BOOST_CHECK(
-        *toHexString(result) != "36f238ce7215e9704a60c631ac0d576a5d816baf6fc1092798d3bd6ae260f540");
+        toHex(result) != "36f238ce7215e9704a60c631ac0d576a5d816baf6fc1092798d3bd6ae260f540");
 }
 // verifyEitherEqualityProof
 BOOST_AUTO_TEST_CASE(testVerifyEitherEqualityProof)
@@ -69,15 +69,15 @@ BOOST_AUTO_TEST_CASE(testVerifyEitherEqualityProof)
         "703d8069b6c3fae2b4406d06f54a46f05c5d321c4ed01f1c72c9a89c3d3ba7adbd807da14148dd4c77b41c07c4"
         "3d026dd14fa7c025ad3a06a9a891149d6a25268b49f79cc016c6c49bafd107";
     auto zkpImpl = std::make_shared<DiscreteLogarithmZkp>();
-    auto result = zkpImpl->verifyEitherEqualityProof(*fromHexString(c1_point),
-        *fromHexString(c2_point), *fromHexString(c3_point), *fromHexString(proof),
-        *fromHexString(basepoint), *fromHexString(blinding_basepoint));
+    auto result = zkpImpl->verifyEitherEqualityProof(fromHex(c1_point),
+        fromHex(c2_point), fromHex(c3_point), fromHex(proof),
+        fromHex(basepoint), fromHex(blinding_basepoint));
     BOOST_CHECK(result == true);
 
     // invalid case
-    result = zkpImpl->verifyEitherEqualityProof(*fromHexString(c2_point), *fromHexString(c2_point),
-        *fromHexString(c1_point), *fromHexString(proof), *fromHexString(basepoint),
-        *fromHexString(blinding_basepoint));
+    result = zkpImpl->verifyEitherEqualityProof(fromHex(c2_point), fromHex(c2_point),
+        fromHex(c1_point), fromHex(proof), fromHex(basepoint),
+        fromHex(blinding_basepoint));
     BOOST_CHECK(result == false);
 
     // case equal to zeror
@@ -89,9 +89,9 @@ BOOST_AUTO_TEST_CASE(testVerifyEitherEqualityProof)
         "a333d67298562f994857b73cc241cc550cb8ec19057c669e0b7535f5c0b3f73d6778a6d6f9d762cd35be7d6603"
         "a04767c24de80b6544577306bf42cc0f703fddfefffc50b88a1f275c31ceed85cbf0de458fc570ddf4ba570185"
         "d6c0a0b18c136fd2fc16e7bdde856e90ab7488b44ed829ca305d861df1e30e";
-    result = zkpImpl->verifyEitherEqualityProof(*fromHexString(c1_point), *fromHexString(c2_point),
-        *fromHexString(c3_point), *fromHexString(proof), *fromHexString(basepoint),
-        *fromHexString(blinding_basepoint));
+    result = zkpImpl->verifyEitherEqualityProof(fromHex(c1_point), fromHex(c2_point),
+        fromHex(c3_point), fromHex(proof), fromHex(basepoint),
+        fromHex(blinding_basepoint));
     BOOST_CHECK(result == true);
 }
 
@@ -100,15 +100,15 @@ BOOST_AUTO_TEST_CASE(testVerifyKnowledgeProof)
 {
     auto zkpImpl = std::make_shared<DiscreteLogarithmZkp>();
     bytes point =
-        *fromHexString("c2e63cef83875e81ea26e00546102cfbbca50ec21a92d077df9100d1bc3a461e");
-    bytes proof = *fromHexString(
+        fromHex("c2e63cef83875e81ea26e00546102cfbbca50ec21a92d077df9100d1bc3a461e");
+    bytes proof = fromHex(
         "5466f3449a00af0d922670b9f80295c6a685c23713349a91a36e4c082a3e282f9aa835448523cfc62b527d7533"
         "0845f4e889c2e70e844c35177a9f0647e3d00b0d17ac6a70acbf14f9a7d838a0b4fe251ba59dc00404cb7d243d"
         "d4cba1832d0f");
     bytes base_point =
-        *fromHexString("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
+        fromHex("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
     bytes blinding_base_point =
-        *fromHexString("625c50529218ebb9f80e296886f4ac5bb55e06416db27b901c552d3e06ec4871");
+        fromHex("625c50529218ebb9f80e296886f4ac5bb55e06416db27b901c552d3e06ec4871");
     auto ret = zkpImpl->verifyKnowledgeProof(point, proof, base_point, blinding_base_point);
     BOOST_CHECK(ret == true);
 
@@ -121,18 +121,18 @@ BOOST_AUTO_TEST_CASE(testVerifyKnowledgeProof)
 BOOST_AUTO_TEST_CASE(testVerifyFormatProof)
 {
     auto zkpImpl = std::make_shared<DiscreteLogarithmZkp>();
-    bytes c1 = *fromHexString("febd4c0d856502a95986a7181c42c51768846755147f178c3646a12834b4e63d");
-    bytes c2 = *fromHexString("ce8c95f13b202defc2bd0e3ddf62dddeb478b693b5f20ce9cd28b64c473aef0f");
-    bytes proof = *fromHexString(
+    bytes c1 = fromHex("febd4c0d856502a95986a7181c42c51768846755147f178c3646a12834b4e63d");
+    bytes c2 = fromHex("ce8c95f13b202defc2bd0e3ddf62dddeb478b693b5f20ce9cd28b64c473aef0f");
+    bytes proof = fromHex(
         "80b7cb7fe7f4aa86b86b7d375d15242cc33336e8b2b735807d9a786be353f0544e99b6d416ce1f1b8d97894f33"
         "d2c94dbe4987dea483ac68cf44b2abf7c6594dc12255a9babc8bd275fe3103ea44d0a33cc3cad8f2d0ef4ca5fc"
         "9257464ecd0405bde6b3bb5e612b14c738e6221940a3f07e82344693867bcd6c85360bbff40e");
     bytes c1_basepoint =
-        *fromHexString("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
+        fromHex("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
     bytes c2_basepoint =
-        *fromHexString("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
+        fromHex("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
     bytes blinding_base_point =
-        *fromHexString("c2b614cc98c793bff0298b0c0881fa78261f0bc6d5f826484257b34d3480c22e");
+        fromHex("c2b614cc98c793bff0298b0c0881fa78261f0bc6d5f826484257b34d3480c22e");
     auto ret =
         zkpImpl->verifyFormatProof(c1, c2, proof, c1_basepoint, c2_basepoint, blinding_base_point);
     BOOST_CHECK(ret == true);
@@ -147,10 +147,10 @@ BOOST_AUTO_TEST_CASE(testVerifyFormatProof)
 BOOST_AUTO_TEST_CASE(testVerifySumProof)
 {
     auto zkpImpl = std::make_shared<DiscreteLogarithmZkp>();
-    bytes c1 = *fromHexString("d4cc1326224453213b6a8d758a87bda4612cfabc7992127580e39cddba6ca234");
-    bytes c2 = *fromHexString("6839477d311c001e605001c6f270b99429b0b2a3fc7e8e0ae70fe77c4c203a1e");
-    bytes c3 = *fromHexString("b050a9a8baae17bdaa7d0cac3f3f2fbb2634a02ca0a86962f2ece308b6fffa3e");
-    bytes proof = *fromHexString(
+    bytes c1 = fromHex("d4cc1326224453213b6a8d758a87bda4612cfabc7992127580e39cddba6ca234");
+    bytes c2 = fromHex("6839477d311c001e605001c6f270b99429b0b2a3fc7e8e0ae70fe77c4c203a1e");
+    bytes c3 = fromHex("b050a9a8baae17bdaa7d0cac3f3f2fbb2634a02ca0a86962f2ece308b6fffa3e");
+    bytes proof = fromHex(
         "fca6e4c20eaa0c167aecd92579b726851369cd993b2204aef6d48064522b2f17849ad5218b1caf6857db0df2f9"
         "db348f981e928f61b26aa4b83d2f834332237bf6a293eb4e1161db741fe77c4c22e4109cb4d9fc2baada7c46d1"
         "2a567fe1114cc24be6612d716b0ff984a98d52a6b0215ffd3ae05afb1e3ce2ea326bb1f66f0ed805efec8c1b73"
@@ -158,9 +158,9 @@ BOOST_AUTO_TEST_CASE(testVerifySumProof)
         "897e090e46671b6272ecde05412f27c2cd4f06d738473a561bf23cb6bf96960db30a6b414660977417ae580d44"
         "8123c5f895f563adf7bc56fe7ca7a42149dc0ac4a4203ccc3b68daa5cc1504");
     bytes value_basepoint =
-        *fromHexString("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
+        fromHex("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
     bytes blinding_base_point =
-        *fromHexString("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
+        fromHex("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
     auto ret = zkpImpl->verifySumProof(c1, c2, c3, proof, value_basepoint, blinding_base_point);
     BOOST_CHECK(ret == true);
 
@@ -173,10 +173,10 @@ BOOST_AUTO_TEST_CASE(testVerifySumProof)
 BOOST_AUTO_TEST_CASE(testVerifyProductProof)
 {
     auto zkpImpl = std::make_shared<DiscreteLogarithmZkp>();
-    bytes c1 = *fromHexString("54a33c1e4a2f7c9201b888b2260aade604a546e5acf49c63bd016fc442270640");
-    bytes c2 = *fromHexString("80c99be28493d198e4c2780446d54701a7773ef0d5c4f511d04a832047c62971");
-    bytes c3 = *fromHexString("66b290292161da6e43fcd32ef103a674fa9535155443bcba462455a838bac71f");
-    bytes proof = *fromHexString(
+    bytes c1 = fromHex("54a33c1e4a2f7c9201b888b2260aade604a546e5acf49c63bd016fc442270640");
+    bytes c2 = fromHex("80c99be28493d198e4c2780446d54701a7773ef0d5c4f511d04a832047c62971");
+    bytes c3 = fromHex("66b290292161da6e43fcd32ef103a674fa9535155443bcba462455a838bac71f");
+    bytes proof = fromHex(
         "687f1bed4716b0e1b0ab3c855594bf82e119b48f71f0f2c42cdb43725bbe2d39b0ed1666b78c87b785e2c7bbd0"
         "69981be08634a8c9ee712bd94cf30153f63e2974a00e328f42b3992fce13f66a44adb0a5b8814a3bc34d3da406"
         "f3d90014bc679cd0e0456ae03f1cf34156aec93d1b0c81f2e14de374c4d90540562181073500512781dc90f142"
@@ -184,9 +184,9 @@ BOOST_AUTO_TEST_CASE(testVerifyProductProof)
         "3ea94cbd5ed83ca23d7c760d70231328c4a4008cc58de545712dae4f1d336b8562ec59468b737c30b76938002f"
         "79a5923855cf48c6399fa25cebeea13502768ed584dc04b2821b35fb32540d");
     bytes value_basepoint =
-        *fromHexString("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
+        fromHex("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
     bytes blinding_base_point =
-        *fromHexString("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
+        fromHex("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
     auto ret = zkpImpl->verifyProductProof(c1, c2, c3, proof, value_basepoint, blinding_base_point);
     BOOST_CHECK(ret == true);
 
@@ -199,16 +199,16 @@ BOOST_AUTO_TEST_CASE(testVerifyProductProof)
 BOOST_AUTO_TEST_CASE(testVerifyEqualityProof)
 {
     auto zkpImpl = std::make_shared<DiscreteLogarithmZkp>();
-    bytes c1 = *fromHexString("62bf13dcf116499f3970b8497120741e9dc66fe1d9c3a34274b5e7e851398f40");
-    bytes c2 = *fromHexString("6c07f2bd045bd4058e2f8c15b618193229a749827784c6e0b62ee175a987c510");
-    bytes proof = *fromHexString(
+    bytes c1 = fromHex("62bf13dcf116499f3970b8497120741e9dc66fe1d9c3a34274b5e7e851398f40");
+    bytes c2 = fromHex("6c07f2bd045bd4058e2f8c15b618193229a749827784c6e0b62ee175a987c510");
+    bytes proof = fromHex(
         "a782e114de54fd1460081bae2b05edfc157b6ff31cb55c85d81c130556fb5b03e2569d3ec8e78be9732e73a6c5"
         "e9c0e231aff1171ae87453747cabaaf2cfdc1de474d1c45b0ac1454e5b3ba860d73d5938b2536f06a13b321fe9"
         "664acfc0c013");
     bytes basepoint1 =
-        *fromHexString("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
+        fromHex("e2f2ae0a6abc4e71a884a961c500515f58e30b6aa582dd8db6a65945e08d2d76");
     bytes basepoint2 =
-        *fromHexString("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
+        fromHex("8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134");
     auto ret = zkpImpl->verifyEqualityProof(c1, c2, proof, basepoint1, basepoint2);
     BOOST_CHECK(ret == true);
 

--- a/bcos-crypto/test/unittests/testMerkle.cpp
+++ b/bcos-crypto/test/unittests/testMerkle.cpp
@@ -150,14 +150,14 @@ std::shared_ptr<std::string> calculateRootByMerkleProof(
         auto& right = oneLevel.second;
         // left
         std::for_each(left.begin(), left.end(),
-            [&hasher](const std::string& _hash) { hasher.update(*fromHexString(_hash)); });
+            [&hasher](const std::string& _hash) { hasher.update(fromHex(_hash)); });
         hasher.update(txHash);
         // right
         std::for_each(right.begin(), right.end(),
-            [&hasher](const std::string& _hash) { hasher.update(*fromHexString(_hash)); });
+            [&hasher](const std::string& _hash) { hasher.update(fromHex(_hash)); });
         hasher.final(txHash);
     }
-    return toHexString(txHash);
+    return std::make_shared<std::string>(toHex(txHash));
 }
 
 BOOST_AUTO_TEST_CASE(performance) {}

--- a/bcos-executor/src/executive/ExecutiveDagFlow.cpp
+++ b/bcos-executor/src/executive/ExecutiveDagFlow.cpp
@@ -345,7 +345,7 @@ critical::CriticalFieldsInterface::Ptr ExecutiveDagFlow::generateDagCriticals(
 
                                 DAGFLOW_LOG(TRACE) << "generateDags: " << LOG_DESC("ABI loaded")
                                                    << LOG_KV("address", to)
-                                                   << LOG_KV("selector", toHexString(selector))
+                                                   << LOG_KV("selector", toHex(selector))
                                                    << LOG_KV("ABI", abiStr);
                                 auto functionAbi = FunctionAbi::deserialize(
                                     abiStr, selector.toBytes(), isSmCrypto);

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -1686,7 +1686,7 @@ void TransactionExecutor::dagExecuteTransactionsInternal(
                                 EXECUTOR_NAME_LOG(TRACE)
                                     << LOG_BADGE("dagExecuteTransactionsInternal")
                                     << LOG_DESC("ABI loaded") << LOG_KV("address", to)
-                                    << LOG_KV("selector", toHexString(selector))
+                                    << LOG_KV("selector", toHex(selector))
                                     << LOG_KV("ABI", abiStr);
                                 auto functionAbi = FunctionAbi::deserialize(
                                     abiStr, selector.toBytes(), isSmCrypto);

--- a/bcos-executor/src/precompiled/CryptoPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/CryptoPrecompiled.cpp
@@ -75,8 +75,8 @@ std::shared_ptr<PrecompiledExecResult> CryptoPrecompiled::call(
 
         auto sm3Hash = crypto::sm3Hash(ref(inputData));
         PRECOMPILED_LOG(TRACE) << LOG_DESC("CryptoPrecompiled: sm3")
-                               << LOG_KV("input", toHexString(inputData))
-                               << LOG_KV("result", toHexString(sm3Hash));
+                               << LOG_KV("input", toHex(inputData))
+                               << LOG_KV("result", toHex(sm3Hash));
         _callParameters->setExecResult(codec.encode(codec::toString32(sm3Hash)));
     }
     else if (funcSelector == name2Selector[CRYPTO_METHOD_KECCAK256_STR])
@@ -85,8 +85,8 @@ std::shared_ptr<PrecompiledExecResult> CryptoPrecompiled::call(
         codec.decode(paramData, inputData);
         auto keccak256Hash = crypto::keccak256Hash(ref(inputData));
         PRECOMPILED_LOG(TRACE) << LOG_DESC("CryptoPrecompiled: keccak256")
-                               << LOG_KV("input", toHexString(inputData))
-                               << LOG_KV("result", toHexString(keccak256Hash));
+                               << LOG_KV("input", toHex(inputData))
+                               << LOG_KV("result", toHex(keccak256Hash));
         _callParameters->setExecResult(codec.encode(codec::toString32(keccak256Hash)));
     }
     else if (funcSelector == name2Selector[CRYPTO_METHOD_SM2_VERIFY_STR])

--- a/bcos-executor/src/precompiled/extension/CpuHeavyPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/CpuHeavyPrecompiled.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<PrecompiledExecResult> CpuHeavyPrecompiled::call(
     PrecompiledExecResult::Ptr _callParameters)
 {
     PRECOMPILED_LOG(TRACE) << LOG_BADGE("CpuHeavyPrecompiled") << LOG_DESC("call")
-                           << LOG_KV("param", toHexString(_callParameters->input()));
+                           << LOG_KV("param", toHex(_callParameters->input()));
 
     // parse function name
     // uint32_t func = getParamFunc(_param);

--- a/bcos-executor/src/precompiled/extension/HelloWorldPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/HelloWorldPrecompiled.cpp
@@ -62,7 +62,7 @@ std::shared_ptr<PrecompiledExecResult> HelloWorldPrecompiled::call(
     PrecompiledExecResult::Ptr _callParameters)
 {
     PRECOMPILED_LOG(TRACE) << LOG_BADGE("HelloWorldPrecompiled") << LOG_DESC("call")
-                           << LOG_KV("param", toHexString(_callParameters->input()));
+                           << LOG_KV("param", toHex(_callParameters->input()));
 
     // parse function name
     uint32_t func = getParamFunc(_callParameters->input());

--- a/bcos-executor/src/precompiled/extension/SmallBankPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/SmallBankPrecompiled.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<PrecompiledExecResult> SmallBankPrecompiled::call(
     PrecompiledExecResult::Ptr _callParameters)
 {
     PRECOMPILED_LOG(TRACE) << LOG_BADGE("SmallBankPrecompiled") << LOG_DESC("call")
-                           << LOG_KV("param", toHexString(_callParameters->input()));
+                           << LOG_KV("param", toHex(_callParameters->input()));
     // parse function name
     uint32_t func = getParamFunc(_callParameters->input());
     bytesConstRef data = _callParameters->params();

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -658,7 +658,7 @@ void HostContext::log(h256s&& _topics, bytesConstRef _data)
     // else
     // {
     //     // convert solidity address to hex string
-    //     auto hexAddress = *toHexString(myAddress());
+    //     auto hexAddress = toHex(myAddress());
     //     boost::algorithm::to_lower(hexAddress);  // this is in case of toHexString be modified
     //     toChecksumAddress(hexAddress, hashImpl()->hash(hexAddress).hex());
     //     m_sub.logs->push_back(

--- a/bcos-executor/src/vm/Precompiled.cpp
+++ b/bcos-executor/src/vm/Precompiled.cpp
@@ -329,7 +329,7 @@ ETH_REGISTER_PRECOMPILED(point_evaluation)(bytesConstRef _in)
     // U256(BLS_MODULUS).to_be_bytes32()) refer to
     // https://github.com/erigontech/silkworm/blob/85ba5171e88855a6702602d38f102aae9b896f9c/silkworm/core/execution/precompile.cpp#L502-L524
     return {true,
-        *bcos::fromHexString("000000000000000000000000000000000000000000000000000000000000100073eda"
+        bcos::fromHex("000000000000000000000000000000000000000000000000000000000000100073eda"
                              "753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")};
 }
 
@@ -552,7 +552,7 @@ pair<bool, bytes> ecRecover(bytesConstRef _in)
     pair<bool, bytes> ret{true, bytes(crypto::HashType::SIZE, 0)};
     BCOS_LOG(TRACE) << LOG_BADGE("Precompiled") << LOG_DESC("wedpr_secp256k1_recover_public_key")
                     << LOG_KV("hash", toHexStringWithPrefix(mHash))
-                    << LOG_KV("rsv", *toHexString(rawRSV, rawRSV + RSV_LENGTH));
+                    << LOG_KV("rsv", toHex(bytesConstRef(rawRSV, RSV_LENGTH)));
     if (pk == nullptr)
     {
         BCOS_LOG(TRACE) << LOG_BADGE("Precompiled") << LOG_DESC("ecRecover publicKey failed");

--- a/bcos-executor/test/unittest/fixture/TransactionFixture.h
+++ b/bcos-executor/test/unittest/fixture/TransactionFixture.h
@@ -114,15 +114,16 @@ public:
 
         codec = std::make_shared<CodecWrapper>(hashImpl, _isWasm);
         keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
+        auto secretKeyBytes =
+            fromHex("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e");
         memcpy(keyPair->secretKey()->mutableData(),
-            fromHexString("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e")
-                ->data(),
+            secretKeyBytes.data(),
             32);
+        auto publicKeyBytes = fromHex(
+            "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
+            "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae");
         memcpy(keyPair->publicKey()->mutableData(),
-            fromHexString(
-                "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
-                "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae")
-                ->data(),
+            publicKeyBytes.data(),
             64);
         boost::log::core::get()->set_logging_enabled(false);
         createSysTable(version);

--- a/bcos-executor/test/unittest/libexecutor/TestAbiReader.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestAbiReader.cpp
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(NormalCase)
     ]
     )"sv;
 
-    auto result = FunctionAbi::deserialize(abiStr, *fromHexString("150666b3"), false);
+    auto result = FunctionAbi::deserialize(abiStr, fromHex("150666b3"), false);
     BOOST_CHECK(result.get() != nullptr);
     BOOST_CHECK_EQUAL(result->inputs.size(), 1);
 
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(NormalCase)
 BOOST_AUTO_TEST_CASE(InvalidAbi)
 {
     auto abiStr = "vita"sv;
-    auto result = FunctionAbi::deserialize(abiStr, *fromHexString("150666b3"), false);
+    auto result = FunctionAbi::deserialize(abiStr, fromHex("150666b3"), false);
     BOOST_CHECK(!result);
 }
 
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(InvalidSelector)
     ]
     )"sv;
 
-    auto result = FunctionAbi::deserialize(abiStr, *fromHexString("150666b3"), false);
+    auto result = FunctionAbi::deserialize(abiStr, fromHex("150666b3"), false);
     BOOST_CHECK(!result);
 }
 
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(EmptyConflictFields)
     ]
     )"sv;
 
-    auto result = FunctionAbi::deserialize(abiStr, *fromHexString("4ed3885e"), false);
+    auto result = FunctionAbi::deserialize(abiStr, fromHex("4ed3885e"), false);
     BOOST_CHECK(result.get() != nullptr);
     BOOST_CHECK(result->conflictFields.empty());
 }

--- a/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
@@ -89,15 +89,16 @@ struct DagExecutorFixture
         ledger = std::make_shared<MockLedger>();
 
         keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
+        auto secretKeyBytes =
+            fromHex("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e");
         memcpy(keyPair->secretKey()->mutableData(),
-            fromHexString("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e")
-                ->data(),
+            secretKeyBytes.data(),
             32);
+        auto publicKeyBytes = fromHex(
+            "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
+            "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae");
         memcpy(keyPair->publicKey()->mutableData(),
-            fromHexString(
-                "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
-                "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae")
-                ->data(),
+            publicKeyBytes.data(),
             64);
         createSysTable();
     }

--- a/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
@@ -85,16 +85,17 @@ struct TransactionExecutorFixture
 
 
         keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
+        auto secretKeyBytes =
+            fromHex("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e");
         memcpy(keyPair->secretKey()->mutableData(),
-            fromHexString("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e")
-                ->data(),
+            secretKeyBytes.data(),
             32);
         // address: "11ac3ca85a307ae2aff614e83949ab691ba019c5"
+        auto publicKeyBytes = fromHex(
+            "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
+            "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae");
         memcpy(keyPair->publicKey()->mutableData(),
-            fromHexString(
-                "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
-                "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae")
-                ->data(),
+            publicKeyBytes.data(),
             64);
         eoa = keyPair->address(hashImpl).hex();
 
@@ -161,7 +162,7 @@ BOOST_AUTO_TEST_CASE(deployAndCall)
     boost::algorithm::unhex(helloworld, std::back_inserter(input));
     auto tx =
         fakeTransaction(cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1");
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = toHex(string_view((char*)tx->sender().data(), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);
@@ -1039,7 +1040,7 @@ BOOST_AUTO_TEST_CASE(multiDeploy)
         params->setContextID(100 + i);
         params->setSeq(1000);
         params->setDepth(0);
-        auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+        auto sender = toHex(string_view((char*)tx->sender().data(), tx->sender().size()));
 
         auto addressCreate =
             cryptoSuite->hashImpl()->hash("i am a address" + boost::lexical_cast<std::string>(i));

--- a/bcos-executor/test/unittest/libexecutor/TestScaleUtils.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestScaleUtils.cpp
@@ -61,56 +61,56 @@ BOOST_AUTO_TEST_CASE(DecodeCompactInteger)
 BOOST_AUTO_TEST_CASE(CalculateEncodingLength)
 {
     // Encoding of string "Alice"
-    auto encodedBytes = fromHexString("14616c696365");
+    auto encodedBytes = fromHex("14616c696365");
     auto paramAbi = ParameterAbi("string");
 
-    auto result = scaleEncodingLength(paramAbi, *encodedBytes, 0);
+    auto result = scaleEncodingLength(paramAbi, encodedBytes, 0);
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(result.value(), 6);
 
     // Encoding of uint32 number 20210926
-    encodedBytes = fromHexString("ee643401");
+    encodedBytes = fromHex("ee643401");
     paramAbi.type = "uint32";
-    result = scaleEncodingLength(paramAbi, *encodedBytes, 0);
+    result = scaleEncodingLength(paramAbi, encodedBytes, 0);
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(result.value(), 4);
 
     // Encoding of int128 number 20180710
-    encodedBytes = fromHexString("e6ee3301000000000000000000000000");
+    encodedBytes = fromHex("e6ee3301000000000000000000000000");
     paramAbi.type = "int128";
-    result = scaleEncodingLength(paramAbi, *encodedBytes, 0);
+    result = scaleEncodingLength(paramAbi, encodedBytes, 0);
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(result.value(), 16);
 
     // Encoding of vector of string ["Alice", "Bob"]
-    encodedBytes = fromHexString("0814416c6963650c426f62");
+    encodedBytes = fromHex("0814416c6963650c426f62");
     paramAbi.type = "string[]";
-    result = scaleEncodingLength(paramAbi, *encodedBytes, 0);
+    result = scaleEncodingLength(paramAbi, encodedBytes, 0);
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(result.value(), 11);
 
     // Encoding of static array of string ["Alice", "Bob"]
-    encodedBytes = fromHexString("14416c6963650c426f62");
+    encodedBytes = fromHex("14416c6963650c426f62");
     paramAbi.type = "string[2]";
-    result = scaleEncodingLength(paramAbi, *encodedBytes, 0);
+    result = scaleEncodingLength(paramAbi, encodedBytes, 0);
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(result.value(), 10);
 
     // Encoding of tuple<string, bytes32, bytes, bool>("Alice", [0, 0, ...], [0, 0, 0], false)
-    encodedBytes = fromHexString(
+    encodedBytes = fromHex(
         "14416c69636500000000000000000000000000000000000000000000000000000000000000000c00000000");
     paramAbi.type = "tuple";
     paramAbi.components.push_back(ParameterAbi("string"));
     paramAbi.components.push_back(ParameterAbi("bytes32"));
     paramAbi.components.push_back(ParameterAbi("bytes"));
     paramAbi.components.push_back(ParameterAbi("bool"));
-    result = scaleEncodingLength(paramAbi, *encodedBytes, 0);
+    result = scaleEncodingLength(paramAbi, encodedBytes, 0);
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(result.value(), 43);
 
     // Encoding of tuple<string, tuple<uint32[], string>>("Alice", ([0, 1], "Dwell not negative
     // signs"))
-    encodedBytes = fromHexString(
+    encodedBytes = fromHex(
         "14416c696365080000000001000000604477656c6c206e6f74206e65676174697665207369676e73");
     paramAbi.type = "tuple";
     paramAbi.components.clear();
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(CalculateEncodingLength)
                                                             ParameterAbi("uint32[]"),
                                                             ParameterAbi("string"),
                                                         }));
-    result = scaleEncodingLength(paramAbi, *encodedBytes, 0);
+    result = scaleEncodingLength(paramAbi, encodedBytes, 0);
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(result.value(), 40);
 }

--- a/bcos-executor/test/unittest/libexecutor/TestWasmExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestWasmExecutor.cpp
@@ -96,11 +96,11 @@ struct WasmExecutorFixture
 
         keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
         memcpy(keyPair->secretKey()->mutableData(),
-            fromHexString("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e")
+            fromHex("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e")
                 ->data(),
             32);
         memcpy(keyPair->publicKey()->mutableData(),
-            fromHexString(
+            fromHex(
                 "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
                 "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae")
                 ->data(),
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(deployAndCall)
 
     auto tx = fakeTransaction(
         cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1", helloWorldAbi);
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = toHex(string_view((char*)tx->sender().data(), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(deployError)
 
     auto tx = fakeTransaction(
         cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1", helloWorldAbi);
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = toHex(string_view((char*)tx->sender().data(), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);
@@ -655,7 +655,7 @@ BOOST_AUTO_TEST_CASE(deployAndCall_100)
 
     auto tx = fakeTransaction(
         cryptoSuite, keyPair, "", input, std::to_string(101), 100001, "1", "1", helloWorldAbi);
-    auto sender = *toHexString(string_view((char*)tx->sender().data(), tx->sender().size()));
+    auto sender = toHex(string_view((char*)tx->sender().data(), tx->sender().size()));
 
     auto hash = tx->hash();
     txpool->hash2Transaction.emplace(hash, tx);

--- a/bcos-executor/test/unittest/libprecompiled/PreCompiledFixture.h
+++ b/bcos-executor/test/unittest/libprecompiled/PreCompiledFixture.h
@@ -125,15 +125,16 @@ public:
 
         codec = std::make_shared<CodecWrapper>(hashImpl, _isWasm);
         keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
+        auto secretKeyBytes =
+            fromHex("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e");
         memcpy(keyPair->secretKey()->mutableData(),
-            fromHexString("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e")
-                ->data(),
+            secretKeyBytes.data(),
             32);
+        auto publicKeyBytes = fromHex(
+            "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
+            "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae");
         memcpy(keyPair->publicKey()->mutableData(),
-            fromHexString(
-                "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
-                "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae")
-                ->data(),
+            publicKeyBytes.data(),
             64);
         boost::log::core::get()->set_logging_enabled(false);
         createSysTable(version);

--- a/bcos-executor/test/unittest/libprecompiled/PrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/PrecompiledTest.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(PointEvaluatePrecompiledTest)
     static constexpr intx::uint256 kBlsModulus{intx::from_string<intx::uint256>(
         "52435875175126190479447740508185965837690552500527637822603658699938581184513")};
 
-    bytes in = *bcos::fromHexString(
+    bytes in = bcos::fromHex(
         "014edfed8547661f6cb416eba53061a2f6dce872c0497e6dd485a876fe2567f1564c0a11a0f704f4fc3e8acfe0"
         "f8245f0ad1347b378fbf96e206da11a5d363066d928e13fe443e957d82e3e71d48cb65d51028eb4483e719bf8e"
         "fcdf12f7c321a421e229565952cfff4ef3517100a97da1d4fe57956fa50a442f92af03b1bf37adacc8ad4ed209"

--- a/bcos-executor/test/unittest/libprecompiled/VRFPrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/VRFPrecompiledTest.cpp
@@ -111,9 +111,9 @@ void testVRFVerify(VRFPrecompiledFixture _fixture)
     u256 lastRandomValue;
     bool verifySucc;
     u256 randomValue;
-    std::cout << "### inputBytes: " << *toHexString(inputBytes) << std::endl;
-    std::cout << "### vrfPublicKey: " << *toHexString(vrfPublicKey) << std::endl;
-    std::cout << "### vrfProof: " << *toHexString(vrfProof) << std::endl;
+    std::cout << "### inputBytes: " << toHex(inputBytes) << std::endl;
+    std::cout << "### vrfPublicKey: " << toHex(vrfPublicKey) << std::endl;
+    std::cout << "### vrfProof: " << toHex(vrfProof) << std::endl;
     for (int i = 0; i < 10; i++)
     {
         bytes in =

--- a/bcos-executor/test/unittest/libvm/PrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libvm/PrecompiledTest.cpp
@@ -33,7 +33,7 @@ BOOST_FIXTURE_TEST_SUITE(testPercompiled, PrecompiledTestFixture)
 
 BOOST_AUTO_TEST_CASE(ecrecoverSuccessTest)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"    // hash
         "000000000000000000000000000000000000000000000000000000000000001c"    // v
         "acd0d6c91242e514655815073f5f0e9aed671f68a4ed3e3e9d693095779f704b"    // r
@@ -41,15 +41,14 @@ BOOST_AUTO_TEST_CASE(ecrecoverSuccessTest)
 
     auto [success, addressBytes] = crypto::ecRecover(ref(params));
     BOOST_CHECK(success);
-    auto address =
-        *bcos::toHexString(addressBytes.data() + 12, addressBytes.data() + 12 + 20, "0x");
+    auto address = bcos::toHex(bytesConstRef(addressBytes.data() + 12, 20), "0x");
     // 0x6DA0599583855F1618B380f6782c0c5C25CB96Ec lower cases
     BOOST_CHECK_EQUAL(address, "0x6da0599583855f1618b380f6782c0c5c25cb96ec");
 }
 
 BOOST_AUTO_TEST_CASE(ecrecoverSuccessTest2)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"    // hash
         "000000000000000000000000000000000000000000000000000000000000001b"    // v
         "acd0d6c91242e514655815073f5f0e9aed671f68a4ed3e3e9d693095779f704b"    // r
@@ -57,15 +56,14 @@ BOOST_AUTO_TEST_CASE(ecrecoverSuccessTest2)
 
     auto [success, addressBytes] = crypto::ecRecover(ref(params));
     BOOST_CHECK(success);
-    auto address =
-        *bcos::toHexString(addressBytes.data() + 12, addressBytes.data() + 12 + 20, "0x");
+    auto address = bcos::toHex(bytesConstRef(addressBytes.data() + 12, 20), "0x");
     // 0xA5b4792dcAD4fE78D13f6Abd7BA1F302945DE4f7 lower cases
     BOOST_CHECK_EQUAL(address, "0xa5b4792dcad4fe78d13f6abd7ba1f302945de4f7");
 }
 
 BOOST_AUTO_TEST_CASE(ecrecoverSuccessLargerTest)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"  // hash
         "000000000000000000000000000000000000000000000000000000000000001b"  // v
         "acd0d6c91242e514655815073f5f0e9aed671f68a4ed3e3e9d693095779f704b"  // r
@@ -74,15 +72,14 @@ BOOST_AUTO_TEST_CASE(ecrecoverSuccessLargerTest)
 
     auto [success, addressBytes] = crypto::ecRecover(ref(params));
     BOOST_CHECK(success);
-    auto address =
-        *bcos::toHexString(addressBytes.data() + 12, addressBytes.data() + 12 + 20, "0x");
+    auto address = bcos::toHex(bytesConstRef(addressBytes.data() + 12, 20), "0x");
     // 0xA5b4792dcAD4fE78D13f6Abd7BA1F302945DE4f7 lower cases
     BOOST_CHECK_EQUAL(address, "0xa5b4792dcad4fe78d13f6abd7ba1f302945de4f7");
 }
 
 BOOST_AUTO_TEST_CASE(ecrecoverFailedTest)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "96d107f6"  // use selector by mistake "ecrecover(bytes32,uint8,bytes32,bytes32)"
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"    // hash
         "000000000000000000000000000000000000000000000000000000000000001c"    // v
@@ -97,7 +94,7 @@ BOOST_AUTO_TEST_CASE(ecrecoverFailedTest)
 
 BOOST_AUTO_TEST_CASE(ecrecoverInvalidVTest)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"    // hash
         "000000000000000000000000000000000000000000000000000000000000001a"    // v
         "acd0d6c91242e514655815073f5f0e9aed671f68a4ed3e3e9d693095779f704b"    // r
@@ -110,7 +107,7 @@ BOOST_AUTO_TEST_CASE(ecrecoverInvalidVTest)
 
 BOOST_AUTO_TEST_CASE(ecrecoverInvalidVTest2)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"    // hash
         "000000000000000000000000000000000000000000000000000000000000001d"    // v
         "acd0d6c91242e514655815073f5f0e9aed671f68a4ed3e3e9d693095779f704b"    // r
@@ -123,7 +120,7 @@ BOOST_AUTO_TEST_CASE(ecrecoverInvalidVTest2)
 
 BOOST_AUTO_TEST_CASE(ecrecoverInvalidInputLenTest)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"    // hash
         "000000000000000000000000000000000000000000000000000000000000001c"    // v
         "acd0d6c91242e514655815073f5f0e9aed671f68a4ed3e3e9d693095779f704b"    // r
@@ -131,15 +128,14 @@ BOOST_AUTO_TEST_CASE(ecrecoverInvalidInputLenTest)
 
     auto [success, addressBytes] = crypto::ecRecover(ref(params));
     BOOST_CHECK(success);
-    auto address =
-        *bcos::toHexString(addressBytes.data() + 12, addressBytes.data() + 12 + 20, "0x");
+    auto address = bcos::toHex(bytesConstRef(addressBytes.data() + 12, 20), "0x");
     // 0x509eAd8B20064f21E35f920cB0c6d6cBC0C0Aa0d lower cases
     BOOST_CHECK_EQUAL(address, "0x509ead8b20064f21e35f920cb0c6d6cbc0c0aa0d");
 }
 
 BOOST_AUTO_TEST_CASE(ecrecoverInvalidInputLenTest2)
 {
-    bytes params = *bcos::fromHexString(
+    bytes params = bcos::fromHex(
         "aa0f7414b7f8648410f9818df3a1f43419d5c30313f430712033937ae57854c8"    // hash
         "000000000000000000000000000000000000000000000000000000000000001c"    // v
         "acd0d6c91242e514655815073f5f0e9aed671f68a4ed3e3e9d693095779f704b");  // s

--- a/bcos-framework/bcos-framework/gateway/GatewayTypeDef.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayTypeDef.h
@@ -192,7 +192,7 @@ inline std::string printShortP2pID(std::string const& data)
         {
             endIt = startIt + 4 * sizeof(byte);
         }
-        return toHex(std::string(startIt, endIt), "hash-");
+        return toHex(std::string_view(startIt, endIt), "hash-");
     }
     return data.substr(RSA_PUBLIC_KEY_PREFIX, RSA_PUBLIC_KEY_TRUNC);
 }

--- a/bcos-framework/bcos-framework/gateway/GatewayTypeDef.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayTypeDef.h
@@ -192,7 +192,7 @@ inline std::string printShortP2pID(std::string const& data)
         {
             endIt = startIt + 4 * sizeof(byte);
         }
-        return *toHexString(startIt, endIt, "hash-");
+        return toHex(std::string(startIt, endIt), "hash-");
     }
     return data.substr(RSA_PUBLIC_KEY_PREFIX, RSA_PUBLIC_KEY_TRUNC);
 }

--- a/bcos-framework/bcos-framework/protocol/BlockHeader.h
+++ b/bcos-framework/bcos-framework/protocol/BlockHeader.h
@@ -89,7 +89,7 @@ public:
             {
                 throwTrace(InvalidSignatureList() << errinfo_comment(
                                    "Invalid signatureList for verify failed, signatureData:" +
-                                   *toHexString(signatureData)));
+                                   toHex(signatureData)));
             }
         }
     }

--- a/bcos-framework/bcos-framework/testutils/faker/FakeBlockHeader.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeBlockHeader.h
@@ -88,7 +88,7 @@ inline void checkBlockHeader(BlockHeader::Ptr blockHeader, BlockHeader::Ptr deco
     std::cout << "### PBBlockHeaderTest: timestamp:" << decodedBlockHeader->timestamp()
               << std::endl;
     std::cout << "### PBBlockHeaderTest: sealer:" << decodedBlockHeader->sealer() << std::endl;
-    std::cout << "### PBBlockHeaderTest: sealer:" << *toHexString(decodedBlockHeader->extraData())
+    std::cout << "### PBBlockHeaderTest: sealer:" << toHex(decodedBlockHeader->extraData())
               << std::endl;
     std::cout << "#### hash:" << decodedBlockHeader->hash().hex() << std::endl;
     if (blockHeader->parentInfo().size() >= 1)
@@ -152,7 +152,7 @@ inline BlockHeader::Ptr fakeAndTestBlockHeader(CryptoSuite::Ptr _cryptoSuite, in
         BOOST_CHECK(!decodedBlockHeaderImpl->inner().dataHash.empty());
         decodedBlockHeader->calculateHash(*_cryptoSuite->hashImpl());
 #if 0
-    std::cout << "### PBBlockHeaderTest: encodedData:" << *toHexString(*encodedData) << std::endl;
+    std::cout << "### PBBlockHeaderTest: encodedData:" << toHex(*encodedData) << std::endl;
 #endif
         // update the hash data field
         blockHeader->setNumber(_number + 1);

--- a/bcos-framework/bcos-framework/testutils/faker/FakeTransaction.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeTransaction.h
@@ -99,11 +99,11 @@ inline Transaction::Ptr testTransaction(CryptoSuite::Ptr _cryptoSuite,
     // auto encodedDataCache = pbTransaction->encode();
     // BOOST_CHECK(encodedData.toBytes() == encodedDataCache.toBytes());
 #if 0
-    std::cout << "#### encodedData is:" << *toHexString(encodedData) << std::endl;
+    std::cout << "#### encodedData is:" << toHex(encodedData) << std::endl;
     std::cout << "### hash:" << pbTransaction->hash().hex() << std::endl;
-    std::cout << "### sender:" << *toHexString(pbTransaction->sender()) << std::endl;
+    std::cout << "### sender:" << toHex(pbTransaction->sender()) << std::endl;
     std::cout << "### type:" << pbTransaction->type() << std::endl;
-    std::cout << "### to:" << *toHexString(pbTransaction->to()) << std::endl;
+    std::cout << "### to:" << toHex(pbTransaction->to()) << std::endl;
 #endif
     // decode
     auto decodedTransaction = factory->createTransaction(bcos::ref(encodedData), true);
@@ -117,7 +117,7 @@ inline Transaction::Ptr testTransaction(CryptoSuite::Ptr _cryptoSuite,
 inline Transaction::Ptr fakeTransaction(CryptoSuite::Ptr _cryptoSuite, bool isCheck = true)
 {
     bcos::crypto::KeyPairInterface::Ptr keyPair = _cryptoSuite->signatureImpl()->generateKeyPair();
-    auto to = *toHexString(keyPair->address(_cryptoSuite->hashImpl()).asBytes());
+    auto to = toHex(keyPair->address(_cryptoSuite->hashImpl()).asBytes());
     std::string inputStr = "testTransaction";
     bytes input = asBytes(inputStr);
     u256 nonce = 120012323;
@@ -176,7 +176,7 @@ inline TransactionsPtr fakeTransactions(int _size)
     auto signatureImpl = std::make_shared<Secp256k1Crypto>();
     auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
     bcos::crypto::KeyPairInterface::Ptr keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
-    auto to = *toHexString(cryptoSuite->calculateAddress(keyPair->publicKey()).asBytes());
+    auto to = toHex(cryptoSuite->calculateAddress(keyPair->publicKey()).asBytes());
 
     TransactionsPtr txs = std::make_shared<Transactions>();
     for (int i = 0; i < _size; ++i)
@@ -199,7 +199,7 @@ inline Transaction::Ptr fakeInvalidateTransacton(std::string inputStr, const uin
     auto signatureImpl = std::make_shared<Secp256k1Crypto>();
     auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
     bcos::crypto::KeyPairInterface::Ptr keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
-    auto to = *toHexString(cryptoSuite->calculateAddress(keyPair->publicKey()).asBytes());
+    auto to = toHex(cryptoSuite->calculateAddress(keyPair->publicKey()).asBytes());
     bytes input = asBytes(inputStr);
     u256 nonce = 120012323;
     int64_t blockLimit = 1001;

--- a/bcos-framework/bcos-framework/testutils/faker/FakeTransactionReceipt.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeTransactionReceipt.h
@@ -104,16 +104,16 @@ inline TransactionReceipt::Ptr testPBTransactionReceipt(
     }
 #if 0
     std::cout << "##### testPBTransactionReceipt:"
-              << "encodedData:" << *toHexString(*encodedData) << std::endl;
-    std::cout << "receipt->output():" << *toHexString(receipt->output()) << std::endl;
-    std::cout << "receipt->contractAddress():" << *toHexString(receipt->contractAddress())
+              << "encodedData:" << toHex(*encodedData) << std::endl;
+    std::cout << "receipt->output():" << toHex(receipt->output()) << std::endl;
+    std::cout << "receipt->contractAddress():" << toHex(receipt->contractAddress())
               << std::endl;
     std::cout << "receipt->hash().hex(): " << receipt->hash().hex() << std::endl;
     auto& logEntry = (receipt->logEntries())[1];
     std::cout << "(logEntry.topics()[0]).hex():" << (logEntry.topics()[0]).hex() << std::endl;
-    std::cout << "*toHexString(logEntry.address()):" << *toHexString(logEntry.address())
+    std::cout << "toHex(logEntry.address()):" << toHex(logEntry.address())
               << std::endl;
-    std::cout << "*toHexString(logEntry.data()):" << *toHexString(logEntry.data()) << std::endl;
+    std::cout << "toHex(logEntry.data()):" << toHex(logEntry.data()) << std::endl;
 
     std::cout << "##### ScaleReceipt encodeT: " << (utcTime() - start)
               << ", encodedData size:" << encodedData->size() << std::endl;

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -156,8 +156,7 @@ void GatewayFactory::initSSLContextPubHexHandler()
             return false;
         }
 
-        auto hex = bcos::toHexString(pubKey->data, pubKey->data + pubKey->length, "");
-        _pubHex = *hex.get();
+        _pubHex = bcos::toHex(bytesConstRef((const byte*)pubKey->data, pubKey->length));
 
         GATEWAY_FACTORY_LOG(INFO) << LOG_DESC("[NEW]SSLContext pubHex: " + _pubHex);
         return true;

--- a/bcos-gateway/bcos-gateway/libamop/AMOPMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPMessage.cpp
@@ -50,7 +50,7 @@ ssize_t AMOPMessage::decode(bcos::bytesConstRef _buffer)
             << LOG_BADGE("decode")
             << LOG_DESC("the topic length smaller than the minimum length(2), data size:" +
                         std::to_string(_buffer.size()))
-            << LOG_KV("data", *toHexString(_buffer));
+            << LOG_KV("data", toHex(_buffer));
         return -1;
     }
     std::size_t offset = 0;

--- a/bcos-ledger/test/mock/MockKeyFactor.h
+++ b/bcos-ledger/test/mock/MockKeyFactor.h
@@ -69,10 +69,10 @@ public:
         {
             endIt = startIt + 4 * sizeof(byte);
         }
-        return *toHexString(startIt, endIt) + "...";
+        return toHex(bytes(startIt, endIt)) + "...";
     }
 
-    std::string hex() override { return *toHexString(*m_keyData); }
+    std::string hex() override { return toHex(*m_keyData); }
 
 private:
     std::shared_ptr<bytes> m_keyData;

--- a/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
@@ -688,7 +688,7 @@ BOOST_AUTO_TEST_CASE(getBlockNumberByHash)
     std::promise<bool> p2;
     auto f2 = p2.get_future();
     m_ledger->asyncGetBlockNumberByHash(
-        HashType("123"), [&](Error::Ptr _error, bcos::protocol::BlockNumber _number) {
+        HashType("1234"), [&](Error::Ptr _error, bcos::protocol::BlockNumber _number) {
             BOOST_CHECK_EQUAL(_error->errorCode(), LedgerError::GetStorageError);
             BOOST_CHECK_EQUAL(_number, -1);
             p2.set_value(true);

--- a/bcos-pbft/bcos-pbft/pbft/PBFTImpl.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/PBFTImpl.cpp
@@ -110,7 +110,7 @@ void PBFTImpl::asyncGetConsensusStatus(
 {
     auto config = m_pbftEngine->pbftConfig();
     Json::Value consensusStatus;
-    consensusStatus["nodeID"] = *toHexString(config->nodeID()->data());
+    consensusStatus["nodeID"] = toHex(config->nodeID()->data());
     consensusStatus["index"] = (Json::UInt64)config->nodeIndex();
     consensusStatus["leaderIndex"] = (Json::UInt64)config->getLeader();
     consensusStatus["consensusNodesNum"] = (Json::UInt64)config->consensusNodesNum();
@@ -118,7 +118,7 @@ void PBFTImpl::asyncGetConsensusStatus(
     consensusStatus["minRequiredQuorum"] = (Json::UInt64)config->minRequiredQuorum();
     consensusStatus["isConsensusNode"] = config->isConsensusNode();
     consensusStatus["blockNumber"] = (Json::UInt64)config->committedProposal()->index();
-    consensusStatus["hash"] = *toHexString(config->committedProposal()->hash());
+    consensusStatus["hash"] = toHex(config->committedProposal()->hash());
     if (config->isConsensusNode())
     {
         consensusStatus["timeout"] = config->timeout();
@@ -138,7 +138,7 @@ void PBFTImpl::asyncGetConsensusStatus(
     for (auto const& node : nodeList)
     {
         Json::Value info;
-        info["nodeID"] = *toHexString(node.nodeID->data());
+        info["nodeID"] = toHex(node.nodeID->data());
         info["weight"] = (Json::UInt64)node.voteWeight;
         info["termWeight"] = (Json::UInt64)node.termWeight;
         info["index"] = (Json::Int64)(i);

--- a/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.cpp
@@ -114,7 +114,7 @@ bool BlockValidator::checkSealerListAndWeightList(Block::Ptr _block)
         {
             PBFT_LOG(ERROR) << LOG_DESC("checkBlock for sync module: inconsistent sealerList")
                             << LOG_KV("blkSealer", consNodePtr.nodeID->shortHex())
-                            << LOG_KV("chainSealer", *toHexString(blockSealer))
+                            << LOG_KV("chainSealer", toHex(blockSealer))
                             << LOG_KV("number", blockHeader->number())
                             << LOG_KV("weight", consNodePtr.voteWeight)
                             << m_config->printCurrentState();
@@ -129,7 +129,7 @@ bool BlockValidator::checkSealerListAndWeightList(Block::Ptr _block)
                             << LOG_KV("chainWeight", consNodePtr.voteWeight)
                             << LOG_KV("number", blockHeader->number())
                             << LOG_KV("blkSealer", consNodePtr.nodeID->shortHex())
-                            << LOG_KV("chainSealer", *toHexString(blockSealer))
+                            << LOG_KV("chainSealer", toHex(blockSealer))
                             << m_config->printCurrentState();
             return false;
         }

--- a/bcos-protocol/bcos-protocol/Common.h
+++ b/bcos-protocol/bcos-protocol/Common.h
@@ -82,7 +82,7 @@ void decodePBObject(T _pbObject, bytesConstRef _data)
         // Truncate hex output to avoid excessive memory usage for large payloads
         constexpr size_t c_maxHexBytes = 64;
         const auto truncatedRef = _data.getCroppedData(0, std::min(_data.size(), c_maxHexBytes));
-        auto hexStr = *toHexString(truncatedRef);
+        auto hexStr = toHex(truncatedRef);
         const auto shownBytes = std::min(_data.size(), c_maxHexBytes);
         if (_data.size() > c_maxHexBytes)
         {

--- a/bcos-scheduler/src/GraphKeyLocks.cpp
+++ b/bcos-scheduler/src/GraphKeyLocks.cpp
@@ -143,7 +143,7 @@ void GraphKeyLocks::releaseKeyLocks(int64_t contextID, int64_t seq)
 
                     const auto& [contract, key] = std::get<1>(*source);
                     SCHEDULER_LOG(TRACE) << "Releasing key lock, contract: " << contract
-                                         << " key: " << bcos::toHexString(key);
+                                         << " key: " << bcos::toHex(key);
                 }
                 boost::remove_edge(*range.first, *graph);
             }

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABICodec.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABICodec.cpp
@@ -69,7 +69,7 @@ void ContractABICodec::stringToJsonValue(const std::string& _params, Json::Value
 bcos::bytes ContractABICodec::encodeConstructor(
     const std::string& _abi, const std::string& _bin, const std::string& _jsonParams)
 {
-    return *fromHexString(_bin) +
+    return fromHex(_bin) +
            encodeMethod(_abi, ContractABIMethodDefinition::CONSTRUCTOR_TYPE, _jsonParams);
 }
 
@@ -236,7 +236,7 @@ bcos::bytes decodeBytesFromString(const std::string& _str)
     {  // hex format
         try
         {
-            return std::move(*fromHexString(_str.substr(hexPrefix.size())));
+            return std::move(fromHex(_str.substr(hexPrefix.size())));
         }
         catch (...)
         {

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABICodec.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABICodec.cpp
@@ -236,7 +236,7 @@ bcos::bytes decodeBytesFromString(const std::string& _str)
     {  // hex format
         try
         {
-            return std::move(fromHex(_str.substr(hexPrefix.size())));
+            return fromHex(_str.substr(hexPrefix.size()));
         }
         catch (...)
         {
@@ -249,7 +249,7 @@ bcos::bytes decodeBytesFromString(const std::string& _str)
         try
         {
             // base64 format
-            return std::move(*base64DecodeBytes(_str.substr(base64Prefix.size())));
+            return *base64DecodeBytes(_str.substr(base64Prefix.size()));
         }
         catch (...)
         {

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIType.h
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIType.h
@@ -349,7 +349,7 @@ public:
     virtual Json::Value toJson() const
     {
         Json::Value jRet(Json::stringValue);
-        jRet = "hex://" + *toHexString(m_value);
+        jRet = "hex://" + toHex(m_value);
         return jRet;
     }
 
@@ -441,7 +441,7 @@ public:
     virtual Json::Value toJson() const
     {
         Json::Value jRet(Json::stringValue);
-        jRet = "hex://" + *toHexString(m_value);
+        jRet = "hex://" + toHex(m_value);
         return jRet;
     }
 

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABITypeCodec.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABITypeCodec.cpp
@@ -43,7 +43,7 @@ using namespace bcos::cppsdk::abi;
         {                                                                                         \
             std::stringstream ss;                                                                 \
             ss << "abi encode exception for offset overflow, offset: " << _offset                 \
-               << " ,buffer length: " << _buffer.size() << " ,buffer: " << *toHexString(_buffer); \
+               << " ,buffer length: " << _buffer.size() << " ,buffer: " << toHex(_buffer); \
             BOOST_THROW_EXCEPTION(std::length_error(ss.str().c_str()));                           \
         }                                                                                         \
     } while (0);

--- a/bcos-sdk/sample/tx/deploy_hello.cpp
+++ b/bcos-sdk/sample/tx/deploy_hello.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
               << std::endl;
 
     auto hexBin = getBinary(groupInfo->smCryptoType());
-    auto binBytes = fromHexString(std::string(hexBin));
+    auto binBytes = fromHex(std::string(hexBin));
 
     auto rpcService = sdk->jsonRpcService();
 

--- a/bcos-sdk/sample/tx/deploy_hello.cpp
+++ b/bcos-sdk/sample/tx/deploy_hello.cpp
@@ -194,7 +194,7 @@ int main(int argc, char** argv)
 
     std::promise<bool> p;
     auto f = p.get_future();
-    rpcService->sendTransaction(*keyPair, group, "", "", std::move(*binBytes), "", 0, "extraData",
+    rpcService->sendTransaction(*keyPair, group, "", "", std::move(binBytes), "", 0, "extraData",
         [&p](bcos::Error::Ptr _error, std::shared_ptr<bcos::bytes> _resp) {
             if (_error && _error->errorCode() != 0)
             {

--- a/bcos-sdk/sample/tx/hello_perf.cpp
+++ b/bcos-sdk/sample/tx/hello_perf.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
     //           << std::endl;
 
     auto hexBin = getBinary(groupInfo->smCryptoType());
-    auto binBytes = fromHexString(hexBin);
+    auto binBytes = fromHex(hexBin);
 
     auto rpcService = sdk->jsonRpcService();
 
@@ -250,7 +250,7 @@ int main(int argc, char** argv)
         {
             ratelimit->acquire(1);
             sendRateReporter->update(1, true);
-            auto getBytes = fromHexString(getData);
+            auto getBytes = fromHex(getData);
             rpcService->sendTransaction(*keyPair, group, "", contractAddress, std::move(*getBytes),
                 "", 0, "extraData",
                 [&recvRateReporter](bcos::Error::Ptr _error, std::shared_ptr<bcos::bytes> _resp) {

--- a/bcos-sdk/sample/tx/hello_perf.cpp
+++ b/bcos-sdk/sample/tx/hello_perf.cpp
@@ -201,7 +201,7 @@ int main(int argc, char** argv)
 
     std::promise<bool> p;
     auto f = p.get_future();
-    rpcService->sendTransaction(*keyPair, group, "", "", std::move(*binBytes), "", 0, "extraData",
+    rpcService->sendTransaction(*keyPair, group, "", "", std::move(binBytes), "", 0, "extraData",
         [&contractAddress, &p](bcos::Error::Ptr _error, std::shared_ptr<bcos::bytes> _resp) {
             if (_error && _error->errorCode() != 0)
             {
@@ -251,7 +251,7 @@ int main(int argc, char** argv)
             ratelimit->acquire(1);
             sendRateReporter->update(1, true);
             auto getBytes = fromHex(getData);
-            rpcService->sendTransaction(*keyPair, group, "", contractAddress, std::move(*getBytes),
+            rpcService->sendTransaction(*keyPair, group, "", contractAddress, std::move(getBytes),
                 "", 0, "extraData",
                 [&recvRateReporter](bcos::Error::Ptr _error, std::shared_ptr<bcos::bytes> _resp) {
                     recvRateReporter->update(1, true);

--- a/bcos-sdk/sample/tx/tx_sign_perf.cpp
+++ b/bcos-sdk/sample/tx/tx_sign_perf.cpp
@@ -150,7 +150,7 @@ int main(int argc, char** argv)
                                               bcos::cppsdk::utilities::CryptoType::Secp256K1);
 
     auto transactionBuilder = std::make_shared<bcos::cppsdk::utilities::TransactionBuilder>();
-    auto code = *bcos::fromHexString(getBinary(smCrypto ? 1 : 0));
+    auto code = bcos::fromHex(getBinary(smCrypto ? 1 : 0));
 
     int64_t block_limit = 111111;
     const char* group_id = "group0";

--- a/bcos-sdk/tests/unittests/abi/ContractABICodecTest.cpp
+++ b/bcos-sdk/tests/unittests/abi/ContractABICodecTest.cpp
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test_encodeMethod)
     auto solcImpl = std::make_shared<ContractABITypeCodecSolImpl>();
     ContractABICodec codec(hashImpl, solcImpl);
 
-    auto methodID = *toHexString(test->getMethodID(hashImpl));
+    auto methodID = toHex(test->getMethodID(hashImpl));
 
     BOOST_CHECK_EQUAL(methodID, "00a3c75d");
 
@@ -135,8 +135,8 @@ BOOST_AUTO_TEST_CASE(test_encodeMethod)
     auto encodeBytes = codec.encodeMethod(abi, "test", objParams);
     auto arrayParamsEncodeBytes = codec.encodeMethod(abi, "test", objParams);
 
-    BOOST_CHECK_EQUAL(*toHexString(encodeBytes), expectEncode);
-    BOOST_CHECK_EQUAL(*toHexString(arrayParamsEncodeBytes), expectEncode);
+    BOOST_CHECK_EQUAL(toHex(encodeBytes), expectEncode);
+    BOOST_CHECK_EQUAL(toHex(arrayParamsEncodeBytes), expectEncode);
 
     auto decodeParams = codec.decodeMethodInput(abi, "test", encodeBytes);
 
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(test_initAbstractTypeWithJsonParams)
         bcos::bytes buffer;
         solcImpl->serialize(*sPtr, buffer);
         BOOST_CHECK_EQUAL("000000000000000000000000000000000000000000000000000000000001b207",
-            *toHexString(buffer));
+            toHex(buffer));
         sPtr->clear();
         solcImpl->deserialize(*sPtr, buffer, 0);
         BOOST_CHECK_EQUAL(sPtr->toJsonString(), params);
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(test_initAbstractTypeWithJsonParams)
             "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000"
             "00000000000000000000000000000000000000000200000000000000000000000000000000000000000000"
             "00000000000000000003",
-            *toHexString(buffer));
+            toHex(buffer));
         sPtr->clear();
         solcImpl->deserialize(*sPtr, buffer, 0);
         BOOST_CHECK_EQUAL(sPtr->toJsonString(), params);
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(test_initAbstractTypeWithJsonParams)
             "00000000000000000000000000000000000000000000000000000000000700000000000000000000000000"
             "00000000000000000000000000000000000008000000000000000000000000000000000000000000000000"
             "00000000000000090000000000000000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
         sPtr->clear();
         solcImpl->deserialize(*sPtr, buffer, 0);
         BOOST_CHECK_EQUAL(sPtr->toJsonString(), params);
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(test_initAbstractTypeWithJsonParams)
         bcos::bytes buffer;
         solcImpl->serialize(*sPtr, buffer);
         BOOST_CHECK_EQUAL("fffffffffffffffffffffffffffffffffffffffffffffda5aa5b91a256638e39",
-            *toHexString(buffer));
+            toHex(buffer));
         sPtr->clear();
         solcImpl->deserialize(*sPtr, buffer, 0);
         BOOST_CHECK_EQUAL(sPtr->toJsonString(), params);
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(test_initAbstractTypeWithJsonParams)
             "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
             "fffffffffffffffffffffffffffffffffffffffffeffffffffffffffffffffffffffffffffffffffffffff"
             "fffffffffffffffffffd",
-            *toHexString(buffer));
+            toHex(buffer));
         sPtr->clear();
         solcImpl->deserialize(*sPtr, buffer, 0);
         BOOST_CHECK_EQUAL(sPtr->toJsonString(), params);
@@ -439,7 +439,7 @@ BOOST_AUTO_TEST_CASE(test_initAbstractTypeWithJsonParams)
             "00000000000000000000000000000000000000000000000000000000000700000000000000000000000000"
             "00000000000000000000000000000000000008000000000000000000000000000000000000000000000000"
             "00000000000000090000000000000000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
         sPtr->clear();
         solcImpl->deserialize(*sPtr, buffer, 0);
         BOOST_CHECK_EQUAL(sPtr->toJsonString(), params);

--- a/bcos-sdk/tests/unittests/abi/ContractABIDefinitionFactoryTest.cpp
+++ b/bcos-sdk/tests/unittests/abi/ContractABIDefinitionFactoryTest.cpp
@@ -1672,7 +1672,7 @@ BOOST_AUTO_TEST_CASE(test_loadABI_SolTypes)
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
             "00",
-            *toHexString(buffer));
+            toHex(buffer));
         auto decodeParams = codec.decodeMethodInput(*method[0], buffer);
         BOOST_CHECK_EQUAL(decodeParams, params);
     }

--- a/bcos-sdk/tests/unittests/abi/ContractABITypeCodecTest.cpp
+++ b/bcos-sdk/tests/unittests/abi/ContractABITypeCodecTest.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
 
         codec.serialize(u0, 256, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000001",
-            *toHexString(buffer));
+            toHex(buffer));
 
         u256 u00 = 0;
         codec.deserialize(u00, buffer, 0);
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         // uint
         codec.serialize(u1, 256, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000f6b75ab2bc471c7",
-            *toHexString(buffer));
+            toHex(buffer));
 
         u256 u10 = 0;
         codec.deserialize(u10, buffer, 0);
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         // uint
         codec.serialize(u2, 256, buffer);
         BOOST_CHECK_EQUAL("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            *toHexString(buffer));
+            toHex(buffer));
 
         u256 u20 = 0;
         codec.deserialize(u20, buffer, 0);
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         // int
         codec.serialize(s0, 256, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000001",
-            *toHexString(buffer));
+            toHex(buffer));
 
         s256 s00 = 0;
         codec.deserialize(s00, buffer, 0);
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         // int
         codec.serialize(s1, 256, buffer);
         BOOST_CHECK_EQUAL("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            *toHexString(buffer));
+            toHex(buffer));
 
         s256 s10 = 0;
         codec.deserialize(s10, buffer, 0);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         // int
         codec.serialize(s2, 2565, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000007fffffffffffffff",
-            *toHexString(buffer));
+            toHex(buffer));
 
         s256 s20 = 0;
         codec.deserialize(s20, buffer, 0);
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         // int
         codec.serialize(s3, 256, buffer);
         BOOST_CHECK_EQUAL("fffffffffffffffffffffffffffffffffffffffffffffffff0948a54d43b8e39",
-            *toHexString(buffer));
+            toHex(buffer));
 
         s256 s30 = 0;
         codec.deserialize(s30, buffer, 0);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         bcos::bytes buffer;
         codec.serialize(b0, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000001",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bool b00;
         codec.deserialize(b00, buffer, 0);
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         bool b1(false);
         codec.serialize(b1, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bool b10;
         codec.deserialize(b10, buffer, 0);
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         bcos::bytes buffer;
         codec.serialize(addr0, buffer);
         BOOST_CHECK_EQUAL("000000000000000000000000be5422d15f39373eb0a97ff8c10fbd0e40e29338",
-            *toHexString(buffer));
+            toHex(buffer));
 
         Address addr00;
         codec.deserialize(addr00, buffer, 0);
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         Address addr1("0x0");
         codec.serialize(addr1, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         Address addr10;
         codec.deserialize(addr10, buffer, 0);
@@ -171,22 +171,22 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         codec.serialize(bs0, true, buffer);
 
         BOOST_CHECK_EQUAL("0001020304050000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bcos::bytes bs00;
         codec.deserialize(bs00, buffer, 0, 6);
-        BOOST_CHECK_EQUAL(*toHexString(bs0), *toHexString(bs00));
+        BOOST_CHECK_EQUAL(toHex(bs0), toHex(bs00));
 
         buffer.clear();
 
         bcos::bytes bs1{0};
         codec.serialize(bs1, true, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bcos::bytes bs10;
         codec.deserialize(bs10, buffer, 0, 1);
-        BOOST_CHECK_EQUAL(*toHexString(bs1), *toHexString(bs10));
+        BOOST_CHECK_EQUAL(toHex(bs1), toHex(bs10));
 
         buffer.clear();
 
@@ -195,11 +195,11 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         bcos::bytes bs2(s.begin(), s.end());
         codec.serialize(bs2, true, buffer);
         BOOST_CHECK_EQUAL("6461766500000000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bcos::bytes bs20;
         codec.deserialize(bs20, buffer, 0, 4);
-        BOOST_CHECK_EQUAL(*toHexString(bs2), *toHexString(bs20));
+        BOOST_CHECK_EQUAL(toHex(bs2), toHex(bs20));
 
         std::string s1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         bcos::bytes bs3(s1.begin(), s1.end());
@@ -208,17 +208,17 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
 
     {
         // bytes
-        bcos::bytes bs0(*fromHexString("692a70d2e424a56d2c6c27aa97d1a86395877b3a"));
+        bcos::bytes bs0(fromHex("692a70d2e424a56d2c6c27aa97d1a86395877b3a"));
         bcos::bytes buffer;
         codec.serialize(bs0, buffer);
         BOOST_CHECK_EQUAL(
             "0000000000000000000000000000000000000000000000000000000000000014692a70d2e424a56d2c6c27"
             "aa97d1a86395877b3a000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bcos::bytes bs00;
         codec.deserialize(bs00, buffer, 0);
-        BOOST_CHECK_EQUAL(*toHexString(bs0), *toHexString(bs00));
+        BOOST_CHECK_EQUAL(toHex(bs0), toHex(bs00));
 
         buffer.clear();
 
@@ -248,11 +248,11 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
             "63617420637570696461746174206e6f6e2070726f6964656e742c2073756e7420696e2063756c70612071"
             "7569206f666669636961206465736572756e74206d6f6c6c697420616e696d20696420657374206c61626f"
             "72756d2e000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bcos::bytes bs10;
         codec.deserialize(bs10, buffer, 0);
-        BOOST_CHECK_EQUAL(*toHexString(bs1), *toHexString(bs10));
+        BOOST_CHECK_EQUAL(toHex(bs1), toHex(bs10));
 
         buffer.clear();
 
@@ -261,11 +261,11 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         BOOST_CHECK_EQUAL(
             "0000000000000000000000000000000000000000000000000000000000000006"
             "0001020304050000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         bcos::bytes bs20;
         codec.deserialize(bs20, buffer, 0);
-        BOOST_CHECK_EQUAL(*toHexString(bs2), *toHexString(bs20));
+        BOOST_CHECK_EQUAL(toHex(bs2), toHex(bs20));
     }
 
     {
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         BOOST_CHECK_EQUAL(
             "00000000000000000000000000000000000000000000000000000000000000046461766500000000000000"
             "000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         std::string s00;
         codec.deserialize(s00, buffer, 0);
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
         std::string s1;
         codec.serialize(s1, buffer);
         BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         std::string s10;
         codec.deserialize(s10, buffer, 0);
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(test_solBaseTypeABIType)
             "63617420637570696461746174206e6f6e2070726f6964656e742c2073756e7420696e2063756c70612071"
             "7569206f666669636961206465736572756e74206d6f6c6c697420616e696d20696420657374206c61626f"
             "72756d2e000000",
-            *toHexString(buffer));
+            toHex(buffer));
 
         std::string s20;
         codec.deserialize(s20, buffer, 0);
@@ -346,7 +346,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
                 "0000000000000000000000000000000000000000000000000000000000000020"
                 "000000000000000000000000000000000000000000000000000000000000000a"
                 "4772656574696e67732100000000000000000000000000000000000000000000",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = sPtr->clone();
             sPtr0->clear();
@@ -373,7 +373,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
             BOOST_CHECK_EQUAL(
                 "0000000000000000000000000000000000000000000000000000000000000045"
                 "0000000000000000000000000000000000000000000000000000000000000001",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = sPtr->clone();
             sPtr0->clear();
@@ -407,7 +407,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
             BOOST_CHECK_EQUAL(
                 "6162630000000000000000000000000000000000000000000000000000000000"
                 "6465660000000000000000000000000000000000000000000000000000000000",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = sPtr->clone();
             sPtr0->clear();
@@ -456,7 +456,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
                 "0000000000000000000000000000000000000000000000000000000000000001"
                 "0000000000000000000000000000000000000000000000000000000000000002"
                 "0000000000000000000000000000000000000000000000000000000000000003",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = sPtr->clone();
             sPtr0->clear();
@@ -473,7 +473,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
             codec.serialize(*dyList, buffer);
 
             BOOST_CHECK_EQUAL("0000000000000000000000000000000000000000000000000000000000000000",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = dyList->clone();
             sPtr0->clear();
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
                 "0000000000000000000000000000000000078900000000000000000000000000000000000000000000"
                 "0000000000000000000d48656c6c6f2c20776f726c6421000000000000000000000000000000000000"
                 "00",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = sPtr->clone();
             sPtr0->clear();
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
                 "74776f0000000000000000000000000000000000000000000000000000000000"
                 "0000000000000000000000000000000000000000000000000000000000000005"
                 "7468726565000000000000000000000000000000000000000000000000000000",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = sPtr->clone();
             sPtr0->clear();
@@ -716,7 +716,7 @@ BOOST_AUTO_TEST_CASE(test_abstractType)
                 "0000000000000000000000000000000000000000000000000000000000000007"
                 "000000000000000000000000000000000000000000000000000000000000000c"
                 "48656c6c6f20776f726c64210000000000000000000000000000000000000000",
-                *toHexString(buffer));
+                toHex(buffer));
 
             auto sPtr0 = sPtr->clone();
             sPtr0->clear();

--- a/bcos-sdk/tests/unittests/abi/ContractABITypeTest.cpp
+++ b/bcos-sdk/tests/unittests/abi/ContractABITypeTest.cpp
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(test_contractABIType)
         // BOOST_CHECK(value->name());
         BOOST_CHECK_EQUAL(value->offsetAsBytes(), MAX_BYTE_LENGTH);
         BOOST_CHECK(value->value() == bs);
-        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + *toHexString(bs));
+        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + toHex(bs));
 
         // clone test
         auto cloneValuePtr = value->clone();
@@ -171,11 +171,11 @@ BOOST_AUTO_TEST_CASE(test_contractABIType)
         BOOST_CHECK_EQUAL(
             toHexStringWithPrefix(cloneValue->value()), toHexStringWithPrefix(cloneU));
         BOOST_CHECK_EQUAL(cloneValue->name(), value->name());
-        BOOST_CHECK_EQUAL(cloneValue->toJson().asString(), "hex://" + *toHexString(cloneU));
+        BOOST_CHECK_EQUAL(cloneValue->toJson().asString(), "hex://" + toHex(cloneU));
 
         // old value compare
         BOOST_CHECK_EQUAL(toHexStringWithPrefix(value->value()), toHexStringWithPrefix(bs));
-        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + *toHexString(bs));
+        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + toHex(bs));
     }
 
     {
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(test_contractABIType)
         // BOOST_CHECK(value->name());
         BOOST_CHECK_EQUAL(value->offsetAsBytes(), MAX_BYTE_LENGTH);
         BOOST_CHECK_EQUAL(toHexStringWithPrefix(value->value()), toHexStringWithPrefix(bs));
-        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + *toHexString(bs));
+        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + toHex(bs));
 
         // clone test
         auto cloneValuePtr = value->clone();
@@ -207,11 +207,11 @@ BOOST_AUTO_TEST_CASE(test_contractABIType)
         BOOST_CHECK_EQUAL(
             toHexStringWithPrefix(cloneValue->value()), toHexStringWithPrefix(cloneU));
         BOOST_CHECK_EQUAL(cloneValue->name(), value->name());
-        BOOST_CHECK_EQUAL(cloneValue->toJson().asString(), "hex://" + *toHexString(cloneU));
+        BOOST_CHECK_EQUAL(cloneValue->toJson().asString(), "hex://" + toHex(cloneU));
 
         // old value compare
         BOOST_CHECK_EQUAL(toHexStringWithPrefix(value->value()), toHexStringWithPrefix(bs));
-        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + *toHexString(bs));
+        BOOST_CHECK_EQUAL(value->toJson().asString(), "hex://" + toHex(bs));
     }
 
     {
@@ -700,7 +700,7 @@ BOOST_AUTO_TEST_CASE(test_contractABIType)
                     "000000000000000000000000000000000000000000000000000000000000000000000000000000"
                     "000000000000000000053132333435000000000000000000000000000000000000000000000000"
                     "000000",
-                    *toHexString(buffer));
+                    toHex(buffer));
 
                 auto cloneStruct = struct_->clone();
                 BOOST_CHECK(struct_->isEqual(*cloneStruct));

--- a/bcos-storage/test/unittest/TestRocksDBStorage.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage.cpp
@@ -551,7 +551,7 @@ BOOST_AUTO_TEST_CASE(rocksDBiter)
 
         for (size_t j = 0; j != 1000; ++j)
         {
-            std::string key = *(bcos::toHexString(std::string((char*)&i, sizeof(i)))) + "_key_" +
+            std::string key = bcos::toHex(std::string((char*)&i, sizeof(i))) + "_key_" +
                               boost::lexical_cast<std::string>(j);
             std::string value = "hello world!";
 

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -1056,15 +1056,15 @@ void BlockSync::asyncGetSyncInfo(std::function<void(Error::Ptr, std::string)> _o
 {
     Json::Value syncInfo;
     syncInfo["isSyncing"] = isSyncing();
-    syncInfo["genesisHash"] = *toHexString(m_config->genesisHash());
-    syncInfo["nodeID"] = *toHexString(m_config->nodeID()->data());
+    syncInfo["genesisHash"] = toHex(m_config->genesisHash());
+    syncInfo["nodeID"] = toHex(m_config->nodeID()->data());
 
     int64_t currentNumber = m_config->blockNumber();
     syncInfo["blockNumber"] = currentNumber;
     syncInfo["archivedBlockNumber"] = m_config->archiveBlockNumber();
-    syncInfo["latestHash"] = *toHexString(m_config->hash());
+    syncInfo["latestHash"] = toHex(m_config->hash());
     syncInfo["knownHighestNumber"] = m_config->knownHighestNumber();
-    syncInfo["knownLatestHash"] = *toHexString(m_config->knownLatestHash());
+    syncInfo["knownLatestHash"] = toHex(m_config->knownLatestHash());
 
     Json::Value peersInfo(Json::arrayValue);
     m_syncStatus->foreachPeer([&](PeerStatus::Ptr _p) {
@@ -1074,10 +1074,10 @@ void BlockSync::asyncGetSyncInfo(std::function<void(Error::Ptr, std::string)> _o
             return true;
         }
         Json::Value info;
-        info["nodeID"] = *toHexString(_p->nodeId()->data());
-        info["genesisHash"] = *toHexString(_p->genesisHash());
+        info["nodeID"] = toHex(_p->nodeId()->data());
+        info["genesisHash"] = toHex(_p->genesisHash());
         info["blockNumber"] = Json::UInt64(_p->number());
-        info["latestHash"] = *toHexString(_p->hash());
+        info["latestHash"] = toHex(_p->hash());
         info["archivedBlockNumber"] = Json::UInt64(_p->archivedBlockNumber());
         peersInfo.append(info);
         return true;
@@ -1197,12 +1197,12 @@ void BlockSync::verifyAndCommitArchivedBlock(bcos::protocol::BlockNumber archive
     {
         BLKSYNC_LOG(ERROR) << LOG_DESC("BlockSync verify archived block failed")
                            << LOG_KV("number", topBlockNumber)
-                           << LOG_KV("transactionRoot", *toHexString(transactionRoot))
+                           << LOG_KV("transactionRoot", toHex(transactionRoot))
                            << LOG_KV(
-                                  "localTransactionRoot", *toHexString(localBlockHeader->txsRoot()))
-                           << LOG_KV("receiptRoot", *toHexString(receiptRoot))
+                                  "localTransactionRoot", toHex(localBlockHeader->txsRoot()))
+                           << LOG_KV("receiptRoot", toHex(receiptRoot))
                            << LOG_KV("localReceiptRoot",
-                                  *toHexString(localBlockHeader->receiptsRoot()))
+                                  toHex(localBlockHeader->receiptsRoot()))
                            << LOG_KV("reason", "transactionRoot or receiptRoot not match");
         WriteGuard lock(x_archivedBlockQueue);
         m_archivedBlockQueue.pop();

--- a/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
+++ b/bcos-sync/bcos-sync/state/DownloadingQueue.cpp
@@ -279,13 +279,13 @@ std::string DownloadingQueue::printBlockHeader(BlockHeader::Ptr const& _header) 
         sealerListStr << ", sealer list: ";
         for (auto const& sealer : sealerList)
         {
-            sealerListStr << *toHexString(sealer) << ", ";
+            sealerListStr << toHex(sealer) << ", ";
         }
         auto signatureList = _header->signatureList();
         signatureListStr << ", sign list: ";
         for (auto const& signatureData : signatureList)
         {
-            signatureListStr << (*toHexString(signatureData.signature)) << ":"
+            signatureListStr << (toHex(signatureData.signature)) << ":"
                              << signatureData.index << ", ";
         }
     }
@@ -308,7 +308,7 @@ std::string DownloadingQueue::printBlockHeader(BlockHeader::Ptr const& _header) 
         << LOG_KV("sealer", _header->sealer()) << LOG_KV("sealerList", sealerListStr.str())
         << LOG_KV("signatureList", signatureListStr.str())
         << LOG_KV("consensusWeights", weightsStr.str()) << LOG_KV("parents", parentInfoStr.str())
-        << LOG_KV("extraData", *toHexString(_header->extraData()));
+        << LOG_KV("extraData", toHex(_header->extraData()));
     return oss.str();
 }
 

--- a/bcos-tars-protocol/test/ProtocolTest.cpp
+++ b/bcos-tars-protocol/test/ProtocolTest.cpp
@@ -623,8 +623,8 @@ void checkExecutionMessage(bcostars::protocol::ExecutionMessageImpl::Ptr executi
     BOOST_CHECK_EQUAL(anotherExecutionMsg->internalCreate(), executionMsg->internalCreate());
     BOOST_CHECK_EQUAL(anotherExecutionMsg->internalCall(), executionMsg->internalCall());
     BOOST_CHECK_EQUAL(anotherExecutionMsg->gasAvailable(), executionMsg->gasAvailable());
-    BOOST_CHECK_EQUAL(*(bcos::toHexString(anotherExecutionMsg->data().toBytes())),
-        *(bcos::toHexString(executionMsg->data().toBytes())));
+    BOOST_CHECK_EQUAL(bcos::toHex(anotherExecutionMsg->data().toBytes()),
+        bcos::toHex(executionMsg->data().toBytes()));
     BOOST_CHECK_EQUAL(anotherExecutionMsg->staticCall(), executionMsg->staticCall());
     BOOST_CHECK_EQUAL(
         anotherExecutionMsg->createSalt().value(), executionMsg->createSalt().value());
@@ -697,8 +697,7 @@ BOOST_AUTO_TEST_CASE(testExecutionMessage)
     BOOST_CHECK_EQUAL(executionMsg->internalCreate(), internalCreate);
     BOOST_CHECK_EQUAL(executionMsg->internalCall(), internalCall);
     BOOST_CHECK_EQUAL(executionMsg->gasAvailable(), gasAvailable);
-    BOOST_CHECK_EQUAL(
-        *(bcos::toHexString(executionMsg->data().toBytes())), *(bcos::toHexString(data)));
+    BOOST_CHECK_EQUAL(bcos::toHex(executionMsg->data().toBytes()), bcos::toHex(data));
     BOOST_CHECK_EQUAL(executionMsg->staticCall(), staticCall);
     BOOST_CHECK_EQUAL(executionMsg->createSalt().value(), salt);
     BOOST_CHECK_EQUAL(executionMsg->status(), status);

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -1353,7 +1353,7 @@ std::string bcos::tool::generateGenesisData(
         for (const auto& node : ledgerConfig.consensusNodeList())
         {
             ss << "node." + boost::lexical_cast<std::string>(j) + ":" +
-                      *toHexString(node.nodeID->data()) + "," + std::to_string(node.voteWeight) +
+                      toHex(node.nodeID->data()) + "," + std::to_string(node.voteWeight) +
                       "\n";
             ++j;
         }
@@ -1375,7 +1375,7 @@ std::string bcos::tool::generateGenesisData(
        << executorStream.str();
     for (const auto& node : ledgerConfig.consensusNodeList())
     {
-        ss << *toHexString(node.nodeID->data()) << "," << node.voteWeight << ";";
+        ss << toHex(node.nodeID->data()) << "," << node.voteWeight << ";";
     }
     auto genesisdata = ss.str();
     NodeConfig_LOG(INFO) << LOG_BADGE("generateGenesisData") << LOG_KV("genesisData", genesisdata);

--- a/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/Web3NonceChecker.cpp
@@ -138,7 +138,7 @@ task::Task<bool> Web3NonceChecker::insertMemoryNonce(std::string sender, std::st
 task::Task<std::optional<u256>> Web3NonceChecker::getPendingNonce(std::string_view sender)
 {
     const auto bytesSender =
-        fromHex<std::string_view, std::string>(sender, sender.starts_with("0x") ? "0x" : "");
+            fromHex<std::string_view, std::string>(sender);
     if (auto nonce = co_await storage2::readOne(m_maxNonces, bytesSender))
     {
         co_return nonce;

--- a/bcos-utilities/bcos-utilities/DataConvertUtility.cpp
+++ b/bcos-utilities/bcos-utilities/DataConvertUtility.cpp
@@ -67,35 +67,6 @@ bool bcos::isHexStringV2(string const& _string)
     return boost::regex_match(_string, pattern);
 }
 
-std::shared_ptr<bytes> bcos::fromHexString(std::string const& _hexedString)
-{
-    unsigned startIndex =
-        (_hexedString.size() >= 2 && _hexedString[0] == '0' && _hexedString[1] == 'x') ? 2 : 0;
-    std::shared_ptr<bytes> bytesData = std::make_shared<bytes>();
-    bytesData->reserve((_hexedString.size() - startIndex + 1) / 2);
-
-    if (_hexedString.size() % 2)
-    {
-        int h = convertCharToHexNumber(_hexedString[startIndex++]);
-        if (h == -1)
-        {
-            BOOST_THROW_EXCEPTION(BadHexCharacter());
-        }
-        bytesData->push_back(h);
-    }
-    for (unsigned i = startIndex; i < _hexedString.size(); i += 2)
-    {
-        int highValue = convertCharToHexNumber(_hexedString[i]);
-        int lowValue = convertCharToHexNumber(_hexedString[i + 1]);
-        if (highValue == -1 || lowValue == -1)
-        {
-            BOOST_THROW_EXCEPTION(BadHexCharacter());
-        }
-        bytesData->push_back((bcos::byte)(highValue << 4) + lowValue);
-    }
-    return bytesData;
-}
-
 std::string bcos::toString(string32 const& _s)
 {
     std::string ret;

--- a/bcos-utilities/bcos-utilities/DataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/DataConvertUtility.h
@@ -114,36 +114,59 @@ concept BigNumber = !std::is_integral_v<T> && std::convertible_to<T, bigint>;
 std::string toQuantity(BigNumber auto number);
 
 template <class Hex, class Out = bytes>
-Out fromHex(const Hex& hex, std::string_view prefix = std::string_view())
+Out fromHex(const Hex& hex)
 {
-    if (hex.empty())
+    std::string_view hexView = [&]() -> std::string_view {
+        if constexpr (std::is_convertible_v<Hex, std::string_view>)
+        {
+            return std::string_view{hex};
+        }
+        else
+        {
+            return std::string_view{hex.data(), hex.size()};
+        }
+    }();
+
+    if (hexView.empty())
     {
         BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Empty input hex string"));
     }
 
-    if ((hex.size() < prefix.size() + 2) || (hex.size() % 2 != 0))
+    auto payload = hexView;
+    if (payload.starts_with("0x") || payload.starts_with("0X"))
     {
-        // can be 0x
-        if (hex == prefix)
-        {
-            return {};
-        }
+        payload.remove_prefix(2);
+    }
+    if (payload.empty())
+    {
+        return {};
+    }
+
+    if (payload.size() % 2 != 0)
+    {
         BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Invalid input hex string size"));
     }
 
     Out out;
-    out.reserve(hex.size() / 2);
+    out.reserve(payload.size() / 2);
+    try
+    {
+        boost::algorithm::unhex(payload.begin(), payload.end(), std::back_inserter(out));
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(BadHexCharacter());
+    }
 
-    boost::algorithm::unhex(hex.begin() + prefix.size(), hex.end(), std::back_inserter(out));
     return out;
 }
 
 template <class Hex, class Out = bytes>
-std::optional<Out> safeFromHex(const Hex& hex, std::string_view prefix = std::string_view())
+std::optional<Out> safeFromHex(const Hex& hex)
 {
     try
     {
-        auto out = fromHex(hex, prefix);
+        auto out = fromHex(hex);
         return std::make_optional(std::move(out));
     }
     catch (...)
@@ -155,62 +178,18 @@ std::optional<Out> safeFromHex(const Hex& hex, std::string_view prefix = std::st
 template <class Hex, class Out = bytes>
 std::optional<Out> safeFromHexWithPrefix(const Hex& hex)
 {
-    return safeFromHex(hex, "0x");
+    return safeFromHex(hex);
 }
-
 
 template <class Hex, class Out = bytes>
 Out fromHexWithPrefix(const Hex& hex)
 {
-    return fromHex(hex, "0x");
+    return fromHex(hex);
 }
 
 uint64_t fromQuantity(std::string const& quantity);
 
 u256 fromBigQuantity(std::string_view quantity);
-
-/**
- * @brief convert the specified bytes data into hex string
- *
- * @tparam Iterator: the iterator type of the data
- * @param _begin : the begin pointer of the data that need to be converted to hex string
- * @param _end : the end pointer of the data that need to be converted to the hex string
- * @param _prefix: prefix of the converted hex string
- * @return std::shared_ptr<std::string> : the converted hex string
- */
-template <class Iterator>
-std::shared_ptr<std::string> toHexString(
-    Iterator _begin, Iterator _end, std::string const& _prefix = "")
-{
-    static_assert(sizeof(typename std::iterator_traits<Iterator>::value_type) == 1,
-        "only support byte-sized element type");
-    auto hexStringSize = std::distance(_begin, _end) * 2 + _prefix.size();
-    std::shared_ptr<std::string> hexString = std::make_shared<std::string>(hexStringSize, '0');
-    // set the _prefix
-    memcpy((void*)hexString->data(), (const void*)_prefix.data(), _prefix.size());
-    static char const* hexCharsCollection = "0123456789abcdef";
-    // covert the bytes into hex chars
-    size_t offset = _prefix.size();
-    for (auto it = _begin; it != _end; it++)
-    {
-        (*hexString)[offset++] = hexCharsCollection[(*it >> 4) & 0x0f];
-        (*hexString)[offset++] = hexCharsCollection[*it & 0x0f];
-    }
-    return hexString;
-}
-
-/**
- * @brief : convert the given data to hex string(without prefix)
- *
- * @tparam T : the type of the given data
- * @param _data : the data need to be converted to hex
- * @return std::shared_ptr<std::string> : the pointer of the converted hex string
- */
-template <class T>
-std::shared_ptr<std::string> toHexString(T const& _data)
-{
-    return toHexString(_data.begin(), _data.end());
-}
 
 /**
  * @brief convert the bytes into hex string with 0x prefixed
@@ -247,14 +226,6 @@ std::string toPaddingHexStringWithPrefix(size_t paddingSize, T const& _data)
 
     return out;
 }
-
-/**
- * @brief convert hex string to bytes
- *
- * @param _hexedString: the hex string need to be converted
- * @return std::shared_ptr<bytes>: the converted bytes
- */
-std::shared_ptr<bytes> fromHexString(std::string const& _hexedString);
 
 /**
  * @brief determine the input string is hex string or not

--- a/bcos-utilities/bcos-utilities/DataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/DataConvertUtility.h
@@ -127,11 +127,6 @@ Out fromHex(const Hex& hex)
         }
     }();
 
-    if (hexView.empty())
-    {
-        BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Empty input hex string"));
-    }
-
     auto payload = hexView;
     if (payload.starts_with("0x") || payload.starts_with("0X"))
     {

--- a/bcos-utilities/bcos-utilities/DataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/DataConvertUtility.h
@@ -19,14 +19,15 @@
 #pragma once
 
 #include "Common.h"
-#include "Error.h"
-#include "Ranges.h"
+#include "bcos-utilities/Exceptions.h"
 #include <boost/algorithm/hex.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <cstring>
 #include <iterator>
+#include <range/v3/view/concat.hpp>
+#include <range/v3/view/single.hpp>
 #include <set>
 #include <string>
 #include <type_traits>
@@ -137,16 +138,22 @@ Out fromHex(const Hex& hex)
         return {};
     }
 
-    if (payload.size() % 2 != 0)
-    {
-        BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Invalid input hex string size"));
-    }
+    const bool needPadding = (payload.size() % 2 != 0);
 
     Out out;
-    out.reserve(payload.size() / 2);
+    out.reserve((payload.size() + (needPadding ? 1 : 0)) / 2);
     try
     {
-        boost::algorithm::unhex(payload.begin(), payload.end(), std::back_inserter(out));
+        if (needPadding)
+        {
+            auto padded = ::ranges::views::concat(::ranges::views::single('0'), payload);
+            boost::algorithm::unhex(
+                ::ranges::begin(padded), ::ranges::end(padded), std::back_inserter(out));
+        }
+        else
+        {
+            boost::algorithm::unhex(payload.begin(), payload.end(), std::back_inserter(out));
+        }
     }
     catch (...)
     {

--- a/bcos-utilities/bcos-utilities/FixedBytes.h
+++ b/bcos-utilities/bcos-utilities/FixedBytes.h
@@ -188,7 +188,7 @@ public:
     /// Explicitly construct, copying from a  string.
     explicit FixedBytes(std::string const& _s, StringDataType _t = FromHex,
         DataAlignType _alignType = DataAlignType::AlignRight)
-      : FixedBytes(_t == FromHex ? *fromHexString(_s) : bcos::asBytes(_s), _alignType)
+      : FixedBytes(_t == FromHex ? fromHex(_s) : bcos::asBytes(_s), _alignType)
     {}
 
     // Convert to Arith type.
@@ -282,9 +282,9 @@ public:
     byte operator[](unsigned _index) const { return m_data[_index]; }
 
     // @returns an abridged version of the hash as a user-readable hex string
-    std::string abridged() const { return *toHexString(ref().getCroppedData(0, 4)) + "..."; }
+    std::string abridged() const { return toHex(ref().getCroppedData(0, 4)) + "..."; }
     /// @returns the hash as a user-readable hex string.
-    std::string hex() const { return *toHexString(ref()); }
+    std::string hex() const { return toHex(ref()); }
     /// @returns the hash as a user-readable hex string with 0x perfix.
     std::string hexPrefixed() const { return toHexStringWithPrefix(ref()); }
 
@@ -632,7 +632,7 @@ inline size_t FixedBytes<32>::hash::operator()(FixedBytes<32> const& value) cons
 template <unsigned N>
 inline std::ostream& operator<<(std::ostream& _out, FixedBytes<N> const& _h)
 {
-    _out << *toHexString(_h);
+    _out << toHex(_h);
     return _out;
 }
 
@@ -717,10 +717,10 @@ inline u256 fromAddress(Address _a)
 
 inline Address toAddress(std::string const& _address)
 {
-    auto address = fromHexString(_address);
-    if (address->size() == 20)
+    auto address = fromHex(_address);
+    if (address.size() == 20)
     {
-        return Address(*address);
+        return Address(address);
     }
     BOOST_THROW_EXCEPTION(InvalidAddress());
 }

--- a/bcos-utilities/bcos-utilities/JsonDataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/JsonDataConvertUtility.h
@@ -39,7 +39,7 @@ std::string toJonString(boost::multiprecision::number<boost::multiprecision::cpp
         boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void>> const&
         _arithNumber)
 {
-    auto hexString = toHexString(toCompactBigEndian(_arithNumber, 1));
+    auto hexString = toHex(toCompactBigEndian(_arithNumber, 1));
     return "0x" + ((*hexString)[0] == '0' ? (hexString->substr(1)) : *hexString);
 }
 
@@ -61,7 +61,7 @@ std::string toJonString(T const& _i)
 
 bytes jonStringToBytes(std::string const& _stringData)
 {
-    return *fromHexString(_stringData);
+    return fromHex(_stringData);
 }
 
 template <unsigned N>
@@ -88,7 +88,7 @@ jsonStringToInt(std::string const& _s)
     {
         return fromBigEndian<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<
             N * 8, N * 8, boost::multiprecision::unsigned_magnitude,
-            boost::multiprecision::unchecked, void>>>(*fromHexString(_s.substr(2)));
+            boost::multiprecision::unchecked, void>>>(fromHex(_s.substr(2)));
     }
     // Decimal
     else if (_s.find_first_not_of("0123456789") == std::string::npos)

--- a/bcos-utilities/bcos-utilities/JsonDataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/JsonDataConvertUtility.h
@@ -40,7 +40,7 @@ std::string toJonString(boost::multiprecision::number<boost::multiprecision::cpp
         _arithNumber)
 {
     auto hexString = toHex(toCompactBigEndian(_arithNumber, 1));
-    return "0x" + ((*hexString)[0] == '0' ? (hexString->substr(1)) : *hexString);
+    return "0x" + (hexString[0] == '0' ? (hexString.substr(1)) : hexString);
 }
 
 template <unsigned T>

--- a/bcos-utilities/test/unittests/libutilities/Base64Test.cpp
+++ b/bcos-utilities/test/unittests/libutilities/Base64Test.cpp
@@ -41,14 +41,14 @@ BOOST_AUTO_TEST_CASE(testBase64DecodeBytes)
     BOOST_CHECK(oriStr == "1234ABcd");
 
     std::string originString = "1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b";
-    bytes originBytes = *fromHexString(originString);
+    bytes originBytes = fromHex(originString);
     std::string base64Str = base64Encode(bytesConstRef(originBytes.data(), originBytes.size()));
-    std::cout << "base64Encode for " << *toHexString(originBytes) << " is: " << base64Str
+    std::cout << "base64Encode for " << toHex(originBytes) << " is: " << base64Str
               << std::endl;
     // decode the base64Str
     auto decodedBytes = base64DecodeBytes(base64Str);
-    std::cout << "decodedBytes is: " << *toHexString(*decodedBytes) << std::endl;
-    BOOST_CHECK(*toHexString(*decodedBytes) == originString);
+    std::cout << "decodedBytes is: " << toHex(*decodedBytes) << std::endl;
+    BOOST_CHECK(toHex(*decodedBytes) == originString);
 
     auto encodedStr = base64Encode(originString);
     std::string decodedString = base64Decode(encodedStr);

--- a/bcos-utilities/test/unittests/libutilities/DataConvertUtilityTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/DataConvertUtilityTest.cpp
@@ -47,13 +47,14 @@ BOOST_AUTO_TEST_CASE(testHex)
         {
             hexVec[j] = std::rand() % 16;
         }
-        hexStr = *toHexString(hexVec);
-        hexStrWithPrefix = *toHexString(hexVec);
-        BOOST_CHECK(*fromHexString(hexStr) == hexVec);
-        BOOST_CHECK(*fromHexString(hexStrWithPrefix) == hexVec);
+        hexStr = toHex(hexVec);
+        hexStrWithPrefix = toHex(hexVec, "0x");
+        BOOST_CHECK(fromHex(hexStr) == hexVec);
+        BOOST_CHECK(fromHex(hexStrWithPrefix) == hexVec);
     }
     // fromHexString Exception
-    BOOST_CHECK_THROW(fromHexString("0934xyz"), BadHexCharacter);
+    BOOST_CHECK_THROW(fromHex("0934xyza"), BadHexCharacter);
+    BOOST_CHECK_THROW(fromHex("093"), boost::wrapexcept<Error>);
     BOOST_CHECK(isHexString("0934xyz") == false);
 
     BOOST_CHECK(isHexString("0x000abc") == true);

--- a/bcos-utilities/test/unittests/libutilities/DataConvertUtilityTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/DataConvertUtilityTest.cpp
@@ -54,7 +54,8 @@ BOOST_AUTO_TEST_CASE(testHex)
     }
     // fromHexString Exception
     BOOST_CHECK_THROW(fromHex("0934xyza"), BadHexCharacter);
-    BOOST_CHECK_THROW(fromHex("093"), boost::wrapexcept<Error>);
+    BOOST_CHECK(fromHex("093") == fromHex("0093"));
+    BOOST_CHECK(fromHex("0xabc") == fromHex("0abc"));
     BOOST_CHECK(isHexString("0934xyz") == false);
 
     BOOST_CHECK(isHexString("0x000abc") == true);

--- a/bcos-utilities/test/unittests/libutilities/JsonDataConvertUtilityTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/JsonDataConvertUtilityTest.cpp
@@ -45,13 +45,13 @@ BOOST_AUTO_TEST_CASE(testRight160)
     BOOST_CHECK("0x5548007e067150c07dab4facb7160e075548007e" == toJonString(right160(h)));
     // test u256
     h256 h256Data(
-        *fromHexString("12b5155eda010a5b7ae26a4a268e466a4b8d31547ad875fce9ab298c639a1b2f"));
+        fromHex("12b5155eda010a5b7ae26a4a268e466a4b8d31547ad875fce9ab298c639a1b2f"));
     // trans h256Data to u256
     u256 value(h256Data);
     // trans value to h256 again
     h256 convertedH256Data = value;
-    std::cout << "### value: " << value << ", h256Data:" << *toHexString(h256Data)
-              << "convertedH256Data" << *toHexString(convertedH256Data) << std::endl;
+    std::cout << "### value: " << value << ", h256Data:" << toHex(h256Data)
+              << "convertedH256Data" << toHex(convertedH256Data) << std::endl;
     BOOST_CHECK(convertedH256Data == h256Data);
 }
 

--- a/bcos-utilities/testutils/TestPromptFixture.h
+++ b/bcos-utilities/testutils/TestPromptFixture.h
@@ -18,8 +18,8 @@
  */
 
 #pragma once
-#include "bcos-utilities/Common.h"
 #include "bcos-crypto/interfaces/crypto/CommonType.h"
+#include "bcos-utilities/Common.h"
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -28,7 +28,7 @@ namespace bcos::test
 {
 inline bcos::bytes operator""_bytes(const char* s) noexcept
 {
-    return fromHexWithPrefix(std::string_view(s));
+    return fromHex(std::string_view(s));
 }
 inline bcos::crypto::HashType operator""_hash(const char* s) noexcept
 {

--- a/benchmark/ParallelMerkleProof.cpp
+++ b/benchmark/ParallelMerkleProof.cpp
@@ -104,16 +104,16 @@ void bcos::protocol::calculateMerkleProof(bcos::crypto::CryptoSuite::Ptr _crypto
                     }
                     higherLevelList[i] = _cryptoSuite->hash(byteValue).asBytes();
                     std::lock_guard<std::mutex> l(mapMutex);
-                    std::string parentNode = *toHexString(higherLevelList[i]);
+                    std::string parentNode = toHex(higherLevelList[i]);
                     for (const auto& child : childList)
                     {
-                        (*_parent2ChildList)[parentNode].emplace_back(*toHexString(child));
+                        (*_parent2ChildList)[parentNode].emplace_back(toHex(child));
                     }
                 }
             });
         bytesCachesTemp = std::move(higherLevelList);
     }
 
-    (*_parent2ChildList)[*toHexString(_cryptoSuite->hash(bytesCachesTemp[0]).asBytes())].push_back(
-        *toHexString(bytesCachesTemp[0]));
+    (*_parent2ChildList)[toHex(_cryptoSuite->hash(bytesCachesTemp[0]).asBytes())].push_back(
+        toHex(bytesCachesTemp[0]));
 }

--- a/libinitializer/Common.h
+++ b/libinitializer/Common.h
@@ -82,12 +82,12 @@ inline std::shared_ptr<bytes> loadPrivateKey(std::string const& _keyPath,
     std::string keyHex(privateKeyData.get());
     if (keyHex.size() >= _hexedPrivateKeySize)
     {
-        return fromHexString(keyHex);
+        return std::make_shared<bytes>(fromHex(keyHex));
     }
     for (size_t i = keyHex.size(); i < _hexedPrivateKeySize; i++)
     {
         keyHex = '0' + keyHex;
     }
-    return fromHexString(keyHex);
+    return std::make_shared<bytes>(fromHex(keyHex));
 }
 }  // namespace bcos::initializer

--- a/tools/storage-tool/storageTool.cpp
+++ b/tools/storage-tool/storageTool.cpp
@@ -486,7 +486,7 @@ int main(int argc, const char* argv[])
         cout << "read " << tableName << ", key is " << key << endl;
         if (hexEncoded)
         {
-            auto keyBytes = fromHexString(key);
+            auto keyBytes = fromHex(key);
             key = std::string((char*)keyBytes->data(), keyBytes->size());
         }
         // create secondary instance
@@ -539,7 +539,7 @@ int main(int argc, const char* argv[])
         std::string value;
         if (hexEncoded)
         {
-            auto keyBytes = fromHexString(key);
+            auto keyBytes = fromHex(key);
             key = std::string((char*)keyBytes->data(), keyBytes->size());
             auto tempBytes = fromHex(writeParameters[2]);
             value = std::string((char*)tempBytes.data(), tempBytes.size());

--- a/tools/storage-tool/storageTool.cpp
+++ b/tools/storage-tool/storageTool.cpp
@@ -487,7 +487,7 @@ int main(int argc, const char* argv[])
         if (hexEncoded)
         {
             auto keyBytes = fromHex(key);
-            key = std::string((char*)keyBytes->data(), keyBytes->size());
+            key = std::string((char*)keyBytes.data(), keyBytes.size());
         }
         // create secondary instance
         StorageInterface::Ptr storage = createBackendStorage(nodeConfig, logInitializer->logPath());
@@ -540,7 +540,7 @@ int main(int argc, const char* argv[])
         if (hexEncoded)
         {
             auto keyBytes = fromHex(key);
-            key = std::string((char*)keyBytes->data(), keyBytes->size());
+            key = std::string((char*)keyBytes.data(), keyBytes.size());
             auto tempBytes = fromHex(writeParameters[2]);
             value = std::string((char*)tempBytes.data(), tempBytes.size());
         }


### PR DESCRIPTION
Refactor the code to eliminate the use of `shared_ptr` in the `fromHexString` and `toHexString` functions, replacing them with direct calls to `fromHex` and `toHex`. This change simplifies memory management and improves code clarity.