### PR TITLE
FIB-49: Add tainted state for transactions

### DIFF
--- a/bcos-framework/bcos-framework/protocol/Transaction.h
+++ b/bcos-framework/bcos-framework/protocol/Transaction.h
@@ -33,6 +33,12 @@
 #include <boost/throw_exception.hpp>
 #include <utility>
 
+namespace bcostars::protocol
+{
+class TransactionImpl;
+class TransactionFactoryImpl;
+}
+
 namespace bcos::protocol
 {
 enum class TransactionType : uint8_t
@@ -81,6 +87,7 @@ public:
         m_sealed(other.m_sealed),
         m_invalid(other.m_invalid),
         m_systemTx(other.m_systemTx.load(std::memory_order_acquire)),
+                m_tainted(other.m_tainted),
         m_storeToBackend(other.m_storeToBackend)
     {}
     Transaction(Transaction&& other) noexcept
@@ -91,6 +98,7 @@ public:
         m_sealed(other.m_sealed),
         m_invalid(other.m_invalid),
         m_systemTx(other.m_systemTx.load(std::memory_order_acquire)),
+                m_tainted(other.m_tainted),
         m_storeToBackend(other.m_storeToBackend)
     {}
     Transaction& operator=(const Transaction& other)
@@ -105,6 +113,7 @@ public:
             m_invalid = other.m_invalid;
             m_systemTx.store(
                 other.m_systemTx.load(std::memory_order_acquire), std::memory_order_release);
+            m_tainted = other.m_tainted;
             m_storeToBackend = other.m_storeToBackend;
         }
         return *this;
@@ -121,6 +130,7 @@ public:
             m_invalid = other.m_invalid;
             m_systemTx.store(
                 other.m_systemTx.load(std::memory_order_acquire), std::memory_order_release);
+            m_tainted = other.m_tainted;
             m_storeToBackend = other.m_storeToBackend;
         }
         return *this;
@@ -139,7 +149,7 @@ public:
             ittapi::ITT_DOMAINS::instance().VERIFY_TRANSACTION);
 #endif
         // The tx has already been verified
-        if (!sender().empty())
+        if (!tainted())
         {
             return;
         }
@@ -168,6 +178,7 @@ public:
                 std::invalid_argument("recover sender address from signature failed"));
         }
         forceSender(sender);
+        setTainted(false);
     }
 
     virtual int32_t version() const = 0;
@@ -199,7 +210,7 @@ public:
     virtual uint8_t type() const = 0;
 
     virtual void forceSender(const bcos::bytes& _sender) = 0;
-    // Clear both sender and hash fields so that verify() will recompute them
+    // Clear both sender and hash fields and mark transaction tainted for re-verification
     virtual void clearSenderAndHash() = 0;
     // Recompute hash from transaction data fields
     virtual void calculateHash(const crypto::Hash& hashImpl) = 0;
@@ -235,12 +246,20 @@ public:
     void setBatchHash(bcos::crypto::HashType const& _hash) const { m_batchHash = _hash; }
     bcos::crypto::HashType const& batchHash() const { return m_batchHash; }
 
+    bool tainted() const { return m_tainted; }
+
     bool storeToBackend() const { return m_storeToBackend; }
     void setStoreToBackend(bool _storeToBackend) const { m_storeToBackend = _storeToBackend; }
 
     virtual size_t size() const { return 0; }
 
+protected:
+    void setTainted(bool _tainted) const { m_tainted = _tainted; }
+
 private:
+    friend class bcostars::protocol::TransactionImpl;
+    friend class bcostars::protocol::TransactionFactoryImpl;
+
     TxSubmitCallback m_submitCallback;
     // the tx has been synced or not
 
@@ -257,6 +276,8 @@ private:
     mutable bool m_invalid = {false};
     // the transaction is the system transaction or not
     mutable std::atomic<bool> m_systemTx = {false};
+    // tainted transactions come from external input and must be verified before trusted use
+    mutable bool m_tainted = {true};
     // the transaction has been stored to the storage or not
     mutable bool m_storeToBackend = {false};
 };

--- a/bcos-framework/bcos-framework/protocol/TransactionFactory.h
+++ b/bcos-framework/bcos-framework/protocol/TransactionFactory.h
@@ -39,7 +39,8 @@ public:
     virtual Transaction::Ptr createTransaction() = 0;
     virtual Transaction::Ptr createTransaction(Transaction& input) = 0;
     virtual Transaction::Ptr createTransaction(
-        bytesConstRef txData, bool checkSig = true, bool checkHash = false) = 0;
+        bytesConstRef txData, bool checkSig = true, bool checkHash = false,
+        bool tainted = true) = 0;
     virtual Transaction::Ptr createTransaction(int32_t _version, std::string _to,
         bytes const& _input, std::string const& _nonce, int64_t blockLimit, std::string _chainId,
         std::string _groupId, int64_t _importTime, std::string _abi = "", std::string _value = "",
@@ -62,7 +63,7 @@ public:
     }
     // Decode transaction from bytes without hash computation or signature verification.
     // Caller should call clearSenderAndHash() before submitting for verification.
-    virtual Transaction::Ptr decodeTransaction(bytesConstRef txData) = 0;
+    virtual Transaction::Ptr decodeTransaction(bytesConstRef txData, bool tainted = true) = 0;
 
     virtual bcos::crypto::CryptoSuite::Ptr cryptoSuite() = 0;
 };

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -154,7 +154,7 @@ public:
             auto txpool = m_nodeId2TxPool[_nodeId];
             auto txFactory =
                 std::make_shared<bcostars::protocol::TransactionFactoryImpl>(m_cryptoSuite);
-            auto tx = txFactory->createTransaction(_data);
+            auto tx = txFactory->createTransaction(_data, false, false, false);
             bcos::task::wait([](decltype(txpool) txpool, decltype(_data) _data, decltype(tx) tx,
                                  decltype(_fromNode) fromNode) -> bcos::task::Task<void> {
                 co_await txpool->broadcastTransactionBufferByTree(_data, false, fromNode);
@@ -168,7 +168,7 @@ public:
             auto txpool = m_nodeId2TxPool[_nodeId];
             auto txFactory =
                 std::make_shared<bcostars::protocol::TransactionFactoryImpl>(m_cryptoSuite);
-            auto tx = txFactory->createTransaction(_data);
+            auto tx = txFactory->createTransaction(_data, false, false, false);
             bcos::task::wait(
                 [](decltype(txpool) txpool, decltype(tx) tx) -> bcos::task::Task<void> {
                     auto submit = co_await txpool->submitTransaction(tx, true);

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -1432,7 +1432,8 @@ void Ledger::asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>>
                 {
                     auto field = entry->getField(0);
                     auto transaction = m_blockFactory->transactionFactory()->createTransaction(
-                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false, false);
+                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false,
+                        false, false);
                     transactions.push_back(std::move(transaction));
                 }
 
@@ -1500,7 +1501,7 @@ void Ledger::asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>>
                         auto field = entry->getField(0);
                         auto transaction = m_blockFactory->transactionFactory()->createTransaction(
                             bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false,
-                            false);
+                            false, false);
                         transactions.push_back(std::move(transaction));
                     }
 

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -152,7 +152,8 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
                 {
                     auto field = txEntry->getField(0);
                     auto transaction = blockFactory.transactionFactory()->createTransaction(
-                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false, false);
+                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false,
+                        false, false);
                     block->appendTransaction(std::move(transaction));
                 }
             }

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionFactoryImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionFactoryImpl.cpp
@@ -8,7 +8,9 @@ bcostars::protocol::TransactionFactoryImpl::TransactionFactoryImpl(
 
 bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::createTransaction()
 {
-    return std::make_shared<TransactionImpl>();
+    auto transaction = std::make_shared<TransactionImpl>();
+    transaction->setTainted(true);
+    return transaction;
 }
 
 bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::createTransaction(
@@ -23,6 +25,7 @@ bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::cre
     transaction->setSystemTx(input.systemTx());
     transaction->setBatchId(input.batchId());
     transaction->setBatchHash(input.batchHash());
+    transaction->setTainted(input.tainted());
     transaction->setStoreToBackend(input.storeToBackend());
     transaction->setSubmitCallback(input.takeSubmitCallback());
 
@@ -30,10 +33,11 @@ bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::cre
 }
 
 bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::createTransaction(
-    bcos::bytesConstRef txData, bool checkSig, bool checkHash)
+    bcos::bytesConstRef txData, bool checkSig, bool checkHash, bool tainted)
 {
     auto transaction = std::make_shared<TransactionImpl>(
         [m_transaction = bcostars::Transaction()]() mutable { return &m_transaction; });
+    transaction->setTainted(tainted);
 
     transaction->decode(txData);
     // check value or gasPrice or maxFeePerGas or maxPriorityFeePerGas is hex string
@@ -94,10 +98,11 @@ bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::cre
 }
 
 bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::decodeTransaction(
-    bcos::bytesConstRef txData)
+    bcos::bytesConstRef txData, bool tainted)
 {
     auto transaction = std::make_shared<TransactionImpl>(
         [m_transaction = bcostars::Transaction()]() mutable { return &m_transaction; });
+    transaction->setTainted(tainted);
 
     transaction->decode(txData);
     // check value or gasPrice or maxFeePerGas or maxPriorityFeePerGas is hex string
@@ -177,6 +182,7 @@ bcostars::protocol::TransactionFactoryImpl::createTransaction(int32_t _version, 
         }
     }
     inner.importTime = _importTime;
+    transaction->setTainted(true);
 
     // Update the hash field
     bcos::concepts::hash::calculate(inner, m_cryptoSuite->hashImpl()->hasher(), inner.dataHash);
@@ -209,6 +215,7 @@ bcos::protocol::Transaction::Ptr bcostars::protocol::TransactionFactoryImpl::cre
     auto tarsTx = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
     auto& inner = tarsTx->mutableInner();
     inner.signature.assign(sign->begin(), sign->end());
+    tx->setTainted(true);
 
     return tx;
 }

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionFactoryImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionFactoryImpl.h
@@ -38,7 +38,8 @@ public:
     bcos::protocol::Transaction::Ptr createTransaction() override;
     bcos::protocol::Transaction::Ptr createTransaction(bcos::protocol::Transaction& input) override;
     bcos::protocol::Transaction::Ptr createTransaction(
-        bcos::bytesConstRef txData, bool checkSig = true, bool checkHash = false) override;
+        bcos::bytesConstRef txData, bool checkSig = true, bool checkHash = false,
+        bool tainted = true) override;
 
     std::shared_ptr<bcos::protocol::Transaction> createTransaction(int32_t _version,
         std::string _to, bcos::bytes const& _input, std::string const& _nonce, int64_t _blockLimit,
@@ -54,7 +55,8 @@ public:
         std::string _value = {}, std::string _gasPrice = {}, int64_t _gasLimit = 0,
         std::string _maxFeePerGas = {}, std::string _maxPriorityFeePerGas = {}) override;
 
-    bcos::protocol::Transaction::Ptr decodeTransaction(bcos::bytesConstRef txData) override;
+    bcos::protocol::Transaction::Ptr decodeTransaction(
+        bcos::bytesConstRef txData, bool tainted = true) override;
 
     void setCryptoSuite(bcos::crypto::CryptoSuite::Ptr cryptoSuite);
     bcos::crypto::CryptoSuite::Ptr cryptoSuite() override;

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
@@ -166,12 +166,17 @@ std::string_view bcostars::protocol::TransactionImpl::sender() const
 }
 void bcostars::protocol::TransactionImpl::forceSender(const bcos::bytes& _sender)
 {
+    if (!tainted())
+    {
+        BOOST_THROW_EXCEPTION(std::invalid_argument("sender of clean transaction is immutable"));
+    }
     m_inner()->sender.assign(_sender.begin(), _sender.end());
 }
 void bcostars::protocol::TransactionImpl::clearSenderAndHash()
 {
     m_inner()->sender.clear();
     m_inner()->dataHash.clear();
+    setTainted(true);
 }
 void bcostars::protocol::TransactionImpl::setSignatureData(bcos::bytes& signature)
 {

--- a/bcos-tars-protocol/test/ProtocolTest.cpp
+++ b/bcos-tars-protocol/test/ProtocolTest.cpp
@@ -92,12 +92,23 @@ BOOST_AUTO_TEST_CASE(transaction)
     auto tx = factory.createTransaction(
         0, to, input, nonce, 100, "testChain", "testGroup", 1000, *keyPair);
 
+    BOOST_CHECK(tx->tainted());
+
     tx->verify(*cryptoSuite->hashImpl(), *cryptoSuite->signatureImpl());
     BOOST_CHECK(!tx->sender().empty());
+    BOOST_CHECK(!tx->tainted());
+    BOOST_CHECK_THROW(tx->forceSender(bcos::bytes{0x1}), std::invalid_argument);
     bcos::bytes buffer;
     tx->encode(buffer);
 
     auto decodedTx = factory.createTransaction(bcos::ref(buffer), true);
+    BOOST_CHECK(!decodedTx->tainted());
+
+    auto storageTx = factory.createTransaction(bcos::ref(buffer), false, false, false);
+    BOOST_CHECK(!storageTx->tainted());
+    BOOST_CHECK_THROW(storageTx->forceSender(bcos::bytes{0x2}), std::invalid_argument);
+    storageTx->clearSenderAndHash();
+    BOOST_CHECK(storageTx->tainted());
 
     BOOST_CHECK_EQUAL(tx->hash(), decodedTx->hash());
     BOOST_CHECK_EQUAL(tx->version(), 0);

--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -32,6 +32,7 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
+#include <atomic>
 #include <memory>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/filter.hpp>
@@ -85,6 +86,17 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
         co_return nullptr;
     }
     transaction->setImportTime(utcTime());
+    // SharedState holds the once-flag and result independently of the Awaitable's lifetime.
+    // The callback lambda captures a shared_ptr<SharedState>, so even if the coroutine frame
+    // (and the Awaitable embedded in it) is destroyed after the first resume(), a late second
+    // callback invocation will only touch the still-alive SharedState and safely see
+    // m_resumed==true — avoiding heap-use-after-free on the sentinel (FIB-48).
+    struct SharedState
+    {
+        std::atomic_bool m_resumed{false};
+        std::variant<std::monostate, bcos::protocol::TransactionSubmitResult::Ptr, Error::Ptr>
+            m_submitResult;
+    };
     struct Awaitable
     {
         [[maybe_unused]] bool await_ready()
@@ -101,7 +113,7 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
                                   << LOG_KV(
                                          "TxHash", m_transaction ? m_transaction->hash().hex() : "")
                                   << LOG_KV("result", result);
-                m_submitResult.emplace<Error::Ptr>(
+                m_state->m_submitResult.emplace<Error::Ptr>(
                     BCOS_ERROR_PTR((int32_t)result, bcos::protocol::toString(result)));
             }
             else
@@ -111,34 +123,43 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
                 res->setTxHash(m_transaction->hash());
                 res->setSender(std::string(m_transaction->sender()));
                 res->setTo(std::string(m_transaction->to()));
-                m_submitResult.emplace<TransactionSubmitResult::Ptr>(std::move(res));
+                m_state->m_submitResult.emplace<TransactionSubmitResult::Ptr>(std::move(res));
             }
             return true;
         }
 
         [[maybe_unused]] void await_suspend(std::coroutine_handle<> handle)
         {
+            // Build a self-contained completeOnce that owns SharedState via shared_ptr.
+            // This lambda may outlive the Awaitable (e.g. stored in a Transaction callback),
+            // so it must NOT capture 'this'.
+            auto completeOnce = [state = m_state, handle](Error::Ptr error,
+                                     bcos::protocol::TransactionSubmitResult::Ptr result) mutable {
+                bool expected = false;
+                if (!state->m_resumed.compare_exchange_strong(
+                        expected, true, std::memory_order_acq_rel, std::memory_order_acquire))
+                {
+                    return;
+                }
+                if (error)
+                {
+                    state->m_submitResult.emplace<Error::Ptr>(std::move(error));
+                }
+                else
+                {
+                    state->m_submitResult.emplace<bcos::protocol::TransactionSubmitResult::Ptr>(
+                        std::move(result));
+                }
+                if (handle)
+                {
+                    handle.resume();
+                }
+            };
+
             try
             {
                 auto result = m_self->verifyAndSubmitTransaction(
-                    m_transaction,
-                    [this, m_handle = handle](Error::Ptr error,
-                        bcos::protocol::TransactionSubmitResult::Ptr result) mutable {
-                        if (error)
-                        {
-                            m_submitResult.emplace<Error::Ptr>(std::move(error));
-                        }
-                        else
-                        {
-                            m_submitResult.emplace<bcos::protocol::TransactionSubmitResult::Ptr>(
-                                std::move(result));
-                        }
-                        if (m_handle)
-                        {
-                            m_handle.resume();
-                        }
-                    },
-                    true, true);
+                    m_transaction, completeOnce, true, true);
 
                 if (result != TransactionStatus::None)
                 {
@@ -146,38 +167,38 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
                         << "Submit transaction failed! "
                         << LOG_KV("TxHash", m_transaction ? m_transaction->hash().hex() : "")
                         << LOG_KV("result", result);
-                    m_submitResult.emplace<Error::Ptr>(
-                        BCOS_ERROR_PTR((int32_t)result, bcos::protocol::toString(result)));
-                    handle.resume();
+                    completeOnce(
+                        BCOS_ERROR_PTR((int32_t)result, bcos::protocol::toString(result)),
+                        nullptr);
                 }
             }
             catch (std::exception& e)
             {
                 TXPOOL_LOG(WARNING) << "Unexpected exception: " << boost::diagnostic_information(e);
-                m_submitResult.emplace<Error::Ptr>(
-                    BCOS_ERROR_PTR((int32_t)TransactionStatus::Malformed, "Unknown exception"));
-                handle.resume();
+                completeOnce(
+                    BCOS_ERROR_PTR((int32_t)TransactionStatus::Malformed, "Unknown exception"),
+                    nullptr);
             }
         }
+
         bcos::protocol::TransactionSubmitResult::Ptr await_resume()
         {
-            if (std::holds_alternative<Error::Ptr>(m_submitResult))
+            if (std::holds_alternative<Error::Ptr>(m_state->m_submitResult))
             {
-                BOOST_THROW_EXCEPTION(*std::get<Error::Ptr>(m_submitResult));
+                BOOST_THROW_EXCEPTION(*std::get<Error::Ptr>(m_state->m_submitResult));
             }
 
             return std::move(
-                std::get<bcos::protocol::TransactionSubmitResult::Ptr>(m_submitResult));
+                std::get<bcos::protocol::TransactionSubmitResult::Ptr>(m_state->m_submitResult));
         }
 
         protocol::Transaction::Ptr m_transaction;
         std::shared_ptr<MemoryStorage> m_self;
-        std::variant<std::monostate, bcos::protocol::TransactionSubmitResult::Ptr, Error::Ptr>
-            m_submitResult;
+        std::shared_ptr<SharedState> m_state;
         bool m_waitForReceipt;
     } awaitable{.m_transaction = std::move(transaction),
         .m_self = shared_from_this(),
-        .m_submitResult = {},
+        .m_state = std::make_shared<SharedState>(),
         .m_waitForReceipt = waitForReceipt};
 
     co_return co_await awaitable;

--- a/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.cpp
@@ -4,7 +4,7 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <charconv>
 
-DERIVE_BCOS_EXCEPTION(InvalidTainedTransaction);
+DERIVE_BCOS_EXCEPTION(InvalidTaintedTransaction);
 
 int64_t bcos::txpool::TransactionData::importTime() const
 {
@@ -44,7 +44,7 @@ void bcos::txpool::Web3Transactions::add(protocol::Transaction::Ptr transaction)
 
     if (transaction->tainted()) [[unlikely]]
     {
-        bcos::throwTrace(InvalidTainedTransaction{});
+        bcos::throwTrace(InvalidTaintedTransaction{});
     }
 
     auto& nonceIndex = m_transactions.get<0>();

--- a/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/Web3Transactions.cpp
@@ -1,7 +1,10 @@
 #include "Web3Transactions.h"
+#include "bcos-utilities/Exceptions.h"
 #include <bcos-framework/txpool/TxPoolTypeDef.h>
 #include <boost/exception/diagnostic_information.hpp>
 #include <charconv>
+
+DERIVE_BCOS_EXCEPTION(InvalidTainedTransaction);
 
 int64_t bcos::txpool::TransactionData::importTime() const
 {
@@ -37,6 +40,11 @@ void bcos::txpool::Web3Transactions::add(protocol::Transaction::Ptr transaction)
     if (!transaction) [[unlikely]]
     {
         return;
+    }
+
+    if (transaction->tainted()) [[unlikely]]
+    {
+        bcos::throwTrace(InvalidTainedTransaction{});
     }
 
     auto& nonceIndex = m_transactions.get<0>();

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -63,9 +63,8 @@ TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
     // remove in front module check signature
     try
     {
-        // Defensively clear sender to ensure signature verification is always performed,
-        // preventing bypass via pre-filled sender field from untrusted sources
-        _tx.forceSender({});
+        // Defensively reset sender/hash and mark tx tainted so verify() always performs
+        // signature recovery even when the input transaction was previously clean.
         _tx.verify(*m_cryptoSuite->hashImpl(), *m_cryptoSuite->signatureImpl());
     }
     catch (...)

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -65,6 +65,7 @@ TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
     {
         // Defensively reset sender/hash and mark tx tainted so verify() always performs
         // signature recovery even when the input transaction was previously clean.
+        _tx.clearSenderAndHash();
         _tx.verify(*m_cryptoSuite->hashImpl(), *m_cryptoSuite->signatureImpl());
     }
     catch (...)

--- a/bcos-txpool/test/unittests/sync/TxpoolSyncByTreeTest.cpp
+++ b/bcos-txpool/test/unittests/sync/TxpoolSyncByTreeTest.cpp
@@ -33,6 +33,8 @@
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/test/unit_test.hpp>
+#include <chrono>
+#include <thread>
 using namespace bcos;
 using namespace bcos::sync;
 using namespace bcos::crypto;
@@ -77,6 +79,28 @@ BOOST_AUTO_TEST_CASE(testConsensusNodeTreeSync)
             co_await txpool.submitTransaction(std::move(transaction), true);
     }(txpool, tx));
     task::syncWait(txpool.broadcastTransactionBufferByTree(bcos::ref(data), true));
+
+    // TREE_PUSH_TRANSACTION is forwarded asynchronously in FakeGateWay; wait briefly
+    // until all destination txpools have received and inserted the transaction.
+    for (size_t i = 0; i < 100; ++i)
+    {
+        bool allReady = true;
+        for (const auto& item : this->m_nodeIdList)
+        {
+            auto& nodeTxpool = dynamic_cast<TxPool&>(*m_fakeGateWay->m_nodeId2TxPool.at(item));
+            if (nodeTxpool.txpoolStorage()->size() != 1)
+            {
+                allReady = false;
+                break;
+            }
+        }
+        if (allReady)
+        {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
     // broadcast to all nodes finally
     auto totalMsg = m_frontService->totalSendMsgSize();
     for (const auto& item : this->m_nodeIdList)

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -31,6 +31,8 @@
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
 #include <atomic>
+#include <future>
+#include <thread>
 #include <fakeit.hpp>
 
 using namespace bcos;
@@ -826,6 +828,64 @@ BOOST_AUTO_TEST_CASE(FIB48_AlreadyInTxPoolAndAcceptReturnsNone)
     auto result2 = storage.verifyAndSubmitTransaction(tx1, nullptr, false, false);
     BOOST_CHECK(result2 == TransactionStatus::AlreadyInTxPool);
     BOOST_CHECK_EQUAL(storage.size(), 1U);
+}
+
+BOOST_AUTO_TEST_CASE(FIB48_SubmitTransactionResumesOnce)
+{
+    // Regression for double-resume risk in submitTransaction(waitForReceipt=true).
+    // Scenario:
+    // 1) tx already exists in pool without callback.
+    // 2) submitTransaction(waitForReceipt=true) registers callback on existing tx
+    //    through AlreadyInTxPoolAndAccept path.
+    // 3) batchRemoveSealedTxs notifies result and resumes awaiting coroutine.
+    // Expectation: coroutine continuation runs exactly once.
+
+    auto tx = makeTx("fib48_submit_once", false);
+    BOOST_CHECK_EQUAL(storage.insert(tx), TransactionStatus::None);
+
+    std::atomic<int> resumeCount{0};
+    std::promise<void> donePromise;
+    auto doneFuture = donePromise.get_future();
+
+    std::thread waitThread([&]() {
+        try
+        {
+            auto submitResult = task::syncWait(storage.submitTransaction(tx, true));
+            BOOST_REQUIRE(submitResult);
+            resumeCount.fetch_add(1, std::memory_order_relaxed);
+            donePromise.set_value();
+        }
+        catch (...)
+        {
+            donePromise.set_exception(std::current_exception());
+        }
+    });
+
+    // Wait until callback has been attached to the existing tx.
+    for (size_t i = 0; i < 1000 && !tx->submitCallback(); ++i)
+    {
+        std::this_thread::yield();
+    }
+    BOOST_REQUIRE(tx->submitCallback());
+
+    // Seal tx then notify execution result to trigger callback resume path.
+    HashType batchHash = HashType::generateRandomFixedBytes();
+    HashList txHashes{tx->hash()};
+    BOOST_CHECK(storage.batchMarkTxs(txHashes, /*batchId*/ 1, batchHash, /*sealFlag*/ true));
+
+    TransactionSubmitResults txsResult;
+    auto txResult = std::make_shared<TransactionSubmitResultImpl>();
+    txResult->setTxHash(tx->hash());
+    txResult->setStatus(static_cast<uint32_t>(TransactionStatus::None));
+    txsResult.push_back(txResult);
+    storage.batchRemoveSealedTxs(/*batchId*/ 1, txsResult);
+
+    BOOST_CHECK(doneFuture.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
+    waitThread.join();
+
+    // Triggering removal notification again should not re-run continuation.
+    storage.batchRemoveSealedTxs(/*batchId*/ 1, txsResult);
+    BOOST_CHECK_EQUAL(resumeCount.load(std::memory_order_relaxed), 1);
 }
 
 BOOST_AUTO_TEST_CASE(FIB50_NonceNotInsertedOnValidationFailure)

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -840,8 +840,11 @@ BOOST_AUTO_TEST_CASE(FIB48_SubmitTransactionResumesOnce)
     // 3) batchRemoveSealedTxs notifies result and resumes awaiting coroutine.
     // Expectation: coroutine continuation runs exactly once.
 
+    // submitTransaction() uses shared_from_this(), so this instance must be owned by shared_ptr.
+    auto sharedStorage = std::make_shared<MemoryStorage>(config);
+
     auto tx = makeTx("fib48_submit_once", false);
-    BOOST_CHECK_EQUAL(storage.insert(tx), TransactionStatus::None);
+    BOOST_CHECK_EQUAL(sharedStorage->insert(tx), TransactionStatus::None);
 
     std::atomic<int> resumeCount{0};
     std::promise<void> donePromise;
@@ -850,7 +853,7 @@ BOOST_AUTO_TEST_CASE(FIB48_SubmitTransactionResumesOnce)
     std::thread waitThread([&]() {
         try
         {
-            auto submitResult = task::syncWait(storage.submitTransaction(tx, true));
+            auto submitResult = task::syncWait(sharedStorage->submitTransaction(tx, true));
             BOOST_REQUIRE(submitResult);
             resumeCount.fetch_add(1, std::memory_order_relaxed);
             donePromise.set_value();
@@ -861,30 +864,48 @@ BOOST_AUTO_TEST_CASE(FIB48_SubmitTransactionResumesOnce)
         }
     });
 
-    // Wait until callback has been attached to the existing tx.
-    for (size_t i = 0; i < 1000 && !tx->submitCallback(); ++i)
+    // Wait until callback is attached, or submit coroutine has already completed.
+    bool callbackAttached = false;
+    for (size_t i = 0; i < 10000; ++i)
     {
+        if (tx->submitCallback())
+        {
+            callbackAttached = true;
+            break;
+        }
+        if (doneFuture.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
+        {
+            break;
+        }
         std::this_thread::yield();
     }
-    BOOST_REQUIRE(tx->submitCallback());
-
-    // Seal tx then notify execution result to trigger callback resume path.
-    HashType batchHash = HashType::generateRandomFixedBytes();
-    HashList txHashes{tx->hash()};
-    BOOST_CHECK(storage.batchMarkTxs(txHashes, /*batchId*/ 1, batchHash, /*sealFlag*/ true));
 
     TransactionSubmitResults txsResult;
-    auto txResult = std::make_shared<TransactionSubmitResultImpl>();
-    txResult->setTxHash(tx->hash());
-    txResult->setStatus(static_cast<uint32_t>(TransactionStatus::None));
-    txsResult.push_back(txResult);
-    storage.batchRemoveSealedTxs(/*batchId*/ 1, txsResult);
+    if (callbackAttached)
+    {
+        // Seal tx then notify execution result to trigger callback resume path.
+        HashType batchHash = HashType::generateRandomFixedBytes();
+        HashList txHashes{tx->hash()};
+        BOOST_CHECK(
+            sharedStorage->batchMarkTxs(txHashes, /*batchId*/ 1, batchHash, /*sealFlag*/ true));
+
+        auto txResult = std::make_shared<TransactionSubmitResultImpl>();
+        txResult->setTxHash(tx->hash());
+        txResult->setStatus(static_cast<uint32_t>(TransactionStatus::None));
+        txsResult.push_back(txResult);
+        sharedStorage->batchRemoveSealedTxs(/*batchId*/ 1, txsResult);
+    }
 
     BOOST_CHECK(doneFuture.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
-    waitThread.join();
+    if (waitThread.joinable())
+    {
+        waitThread.join();
+    }
+    BOOST_REQUIRE_NO_THROW(doneFuture.get());
+    BOOST_REQUIRE(callbackAttached);
 
     // Triggering removal notification again should not re-run continuation.
-    storage.batchRemoveSealedTxs(/*batchId*/ 1, txsResult);
+    sharedStorage->batchRemoveSealedTxs(/*batchId*/ 1, txsResult);
     BOOST_CHECK_EQUAL(resumeCount.load(std::memory_order_relaxed), 1);
 }
 

--- a/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
@@ -528,10 +528,11 @@ BOOST_AUTO_TEST_CASE(testAddNullTransaction)
 BOOST_AUTO_TEST_CASE(testAddEmptyHashTransaction)
 {
     Web3Transactions pool;
-    // Create a transaction without calling calculateHash() — hash() will throw EmptyTransactionHash
-    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    // Create a clean transaction without calculateHash() so hash() throws EmptyTransactionHash
+    auto tx = std::make_shared<TestTransactionImpl>();
     tx->setNonce("0");
     tx->forceSender(toBytes("aaaaaaaaaaaaaaaaaaaa"));
+    tx->markClean();
     // Do NOT call tx->calculateHash() so that hash() throws
     std::vector<protocol::Transaction::Ptr> txs{tx};
     BOOST_CHECK_NO_THROW(pool.add(txs));
@@ -540,12 +541,13 @@ BOOST_AUTO_TEST_CASE(testAddEmptyHashTransaction)
 BOOST_AUTO_TEST_CASE(testAddInvalidNonceTransaction)
 {
     Web3Transactions pool;
-    // Create a transaction with a non-numeric nonce — TransactionData ctor will throw InvalidNonce
-    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    // Create a clean transaction with a non-numeric nonce — TransactionData ctor throws InvalidNonce
+    auto tx = std::make_shared<TestTransactionImpl>();
     tx->setNonce("not_a_number");
     tx->forceSender(toBytes("bbbbbbbbbbbbbbbbbbbb"));
     Keccak256 hasher;
     tx->calculateHash(hasher);
+    tx->markClean();
     std::vector<protocol::Transaction::Ptr> txs{tx};
     BOOST_CHECK_NO_THROW(pool.add(txs));
 }
@@ -553,14 +555,14 @@ BOOST_AUTO_TEST_CASE(testAddInvalidNonceTransaction)
 BOOST_AUTO_TEST_CASE(testAddTaintedTransaction)
 {
     Web3Transactions pool;
-    auto taintedTx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    auto taintedTx = std::make_shared<TestTransactionImpl>();
     taintedTx->setNonce("0");
     taintedTx->forceSender(toBytes("cccccccccccccccccccc"));
     Keccak256 hasher;
     taintedTx->calculateHash(hasher);
 
     auto taintedHash = taintedTx->hash();
-    pool.add(std::vector<protocol::Transaction::Ptr>{taintedTx});
+    BOOST_CHECK_THROW(pool.add(std::vector<protocol::Transaction::Ptr>{taintedTx}), bcos::Exception);
 
     auto result = pool.get(std::vector<bcos::crypto::HashType>{taintedHash});
     BOOST_CHECK_EQUAL(result.size(), 1);

--- a/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Web3TransactionsTest.cpp
@@ -40,7 +40,10 @@ struct MapStateStorage
         co_return std::nullopt;
     }
 
-    task::Task<std::optional<Value>> readOne(StateKey key) { co_return co_await readOne(StateKeyView{key}); }
+    task::Task<std::optional<Value>> readOne(StateKey key)
+    {
+        co_return co_await readOne(StateKeyView{key});
+    }
 
     template <class Keys>
     task::Task<std::vector<std::optional<Value>>> readSome(Keys keys)
@@ -102,18 +105,25 @@ struct MapStateStorage
 
 static bytes toBytes(std::string_view s)
 {
-    return bytes(reinterpret_cast<const byte*>(s.data()),
-        reinterpret_cast<const byte*>(s.data()) + s.size());
+    return {reinterpret_cast<const byte*>(s.data()),
+        reinterpret_cast<const byte*>(s.data()) + s.size()};
 }
+
+class TestTransactionImpl : public bcostars::protocol::TransactionImpl
+{
+public:
+    void markClean() { setTainted(false); }
+};
 
 static protocol::Transaction::Ptr makeTx(std::string_view senderBytes, int64_t nonce)
 {
-    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    auto tx = std::make_shared<TestTransactionImpl>();
     tx->mutableInner().data.to.assign(senderBytes.begin(), senderBytes.end());
     tx->setNonce(std::to_string(nonce));
     tx->forceSender(toBytes(senderBytes));
     Keccak256 hasher;
     tx->calculateHash(hasher);
+    tx->markClean();
     // give it a stable importTime ordering same as nonce
     tx->setImportTime(nonce);
     return tx;
@@ -538,6 +548,23 @@ BOOST_AUTO_TEST_CASE(testAddInvalidNonceTransaction)
     tx->calculateHash(hasher);
     std::vector<protocol::Transaction::Ptr> txs{tx};
     BOOST_CHECK_NO_THROW(pool.add(txs));
+}
+
+BOOST_AUTO_TEST_CASE(testAddTaintedTransaction)
+{
+    Web3Transactions pool;
+    auto taintedTx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    taintedTx->setNonce("0");
+    taintedTx->forceSender(toBytes("cccccccccccccccccccc"));
+    Keccak256 hasher;
+    taintedTx->calculateHash(hasher);
+
+    auto taintedHash = taintedTx->hash();
+    pool.add(std::vector<protocol::Transaction::Ptr>{taintedTx});
+
+    auto result = pool.get(std::vector<bcos::crypto::HashType>{taintedHash});
+    BOOST_CHECK_EQUAL(result.size(), 1);
+    BOOST_CHECK(!result[0]);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Introduce a tainted state for transactions to ensure that signature verification is enforced even when transactions are initially clean. This change includes checks for tainted transactions in the Web3 transaction handling and updates tests to validate the new behavior. Additionally, it fixes a related test case.