### PR TITLE
FIB-72: Add readOne and readSome methods with raw variants

### DIFF
--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -194,7 +194,7 @@ public:
         }
     }
 
-    DataValue readOneRaw(const auto& key)
+    auto readOneRaw(const auto& key, auto&&... /*args*/) -> task::Task<DataValue>
     {
         auto& bucket = this->getBucket(key);
         Lock lock(bucket.mutex, false);
@@ -209,16 +209,25 @@ public:
                     updateLRUAndCheck(bucket, it);
                 }
             }
-            return it->value;
+            co_return it->value;
         }
-        return {};
+        co_return DataValue{};
     }
 
-    auto readSomeRaw(::ranges::input_range auto keys)
+    auto readSomeRaw(::ranges::input_range auto keys, auto&&... args)
+        -> task::Task<std::vector<DataValue>>
     {
-        return ::ranges::views::transform(keys, [&](auto&& key) {
-            return readOneRaw(std::forward<decltype(key)>(key));
-        }) | ::ranges::to<std::vector>();
+        std::vector<DataValue> values;
+        if constexpr (::ranges::sized_range<decltype(keys)>)
+        {
+            values.reserve(::ranges::size(keys));
+        }
+        for (auto&& key : keys)
+        {
+            values.emplace_back(
+                co_await readOneRaw(std::forward<decltype(key)>(key), std::forward<decltype(args)>(args)...));
+        }
+        co_return values;
     }
 
     static std::optional<Value> toOptional(DataValue&& value)
@@ -314,22 +323,10 @@ public:
         }
     }
 
-    auto readSome(::ranges::input_range auto keys) -> task::Task<std::vector<std::optional<Value>>>
-    {
-        auto rawValues = readSomeRaw(std::move(keys));
-        std::vector<std::optional<Value>> values;
-        values.reserve(rawValues.size());
-        for (auto& value : rawValues)
-        {
-            values.emplace_back(toOptional(std::move(value)));
-        }
-        co_return values;
-    }
-
-    auto readSome(::ranges::input_range auto keys, DIRECT_TYPE /*unused*/)
+    auto readSome(::ranges::input_range auto keys, auto&&... args)
         -> task::Task<std::vector<std::optional<Value>>>
     {
-        auto rawValues = readSomeRaw(std::move(keys));
+        auto rawValues = co_await readSomeRaw(std::move(keys), std::forward<decltype(args)>(args)...);
         std::vector<std::optional<Value>> values;
         values.reserve(rawValues.size());
         for (auto& value : rawValues)
@@ -339,24 +336,17 @@ public:
         co_return values;
     }
 
-    auto readOne(auto key) -> task::Task<std::optional<Value>>
+    auto readOne(auto key, auto&&... args) -> task::Task<std::optional<Value>>
     {
-        co_return toOptional(readOneRaw(key));
+        co_return toOptional(
+            co_await readOneRaw(std::move(key), std::forward<decltype(args)>(args)...));
     }
 
-    auto readOne(auto key, DIRECT_TYPE /*unused*/) -> task::Task<std::optional<Value>>
+    auto existsOne(auto key, auto&&... args) -> task::Task<bool>
     {
-        co_return toOptional(readOneRaw(key));
-    }
-
-    auto existsOne(auto key) -> task::Task<bool>
-    {
-        co_return toOptional(readOneRaw(key)).has_value();
-    }
-
-    auto existsOne(auto key, DIRECT_TYPE /*unused*/) -> task::Task<bool>
-    {
-        co_return toOptional(readOneRaw(key)).has_value();
+        co_return toOptional(
+                      co_await readOneRaw(std::move(key), std::forward<decltype(args)>(args)...))
+            .has_value();
     }
 
     task::AwaitableValue<void> writeOne(auto key, auto value)

--- a/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
@@ -166,6 +166,82 @@ public:
     }
 
     template <::ranges::input_range Keys>
+    auto readSomeRaw(Keys keys, storage2::DIRECT_TYPE /*unused*/)
+        -> task::Task<std::vector<storage2::StorageValueType<Value>>>
+        requires ::ranges::sized_range<Keys>
+    {
+        if (m_mutableStorage)
+        {
+            co_return co_await m_mutableStorage->readSomeRaw(std::move(keys));
+        }
+
+        for (auto& immutableStorage : m_immutableStorages)
+        {
+            co_return co_await immutableStorage->readSomeRaw(std::move(keys));
+        }
+
+        if constexpr (withCacheStorage)
+        {
+            co_return co_await m_cacheStorage.get().readSomeRaw(std::move(keys));
+        }
+
+        co_return co_await m_backendStorage.get().readSomeRaw(std::move(keys));
+    }
+
+    auto readOneRaw(const auto& key) -> task::Task<storage2::StorageValueType<Value>>
+    {
+        if (m_mutableStorage)
+        {
+            if (auto value = co_await m_mutableStorage->readOneRaw(key);
+                !std::holds_alternative<storage2::NOT_EXISTS_TYPE>(value))
+            {
+                co_return value;
+            }
+        }
+
+        for (auto& immutableStorage : m_immutableStorages)
+        {
+            if (auto value = co_await immutableStorage->readOneRaw(key);
+                !std::holds_alternative<storage2::NOT_EXISTS_TYPE>(value))
+            {
+                co_return value;
+            }
+        }
+
+        if constexpr (withCacheStorage)
+        {
+            if (auto value = co_await m_cacheStorage.get().readOneRaw(key);
+                !std::holds_alternative<storage2::NOT_EXISTS_TYPE>(value))
+            {
+                co_return value;
+            }
+        }
+
+        co_return co_await m_backendStorage.get().readOneRaw(key);
+    }
+
+    auto readOneRaw(const auto& key, storage2::DIRECT_TYPE /*unused*/)
+        -> task::Task<storage2::StorageValueType<Value>>
+    {
+        if (m_mutableStorage)
+        {
+            co_return co_await m_mutableStorage->readOneRaw(key);
+        }
+
+        for (auto& immutableStorage : m_immutableStorages)
+        {
+            co_return co_await immutableStorage->readOneRaw(key);
+        }
+
+        if constexpr (withCacheStorage)
+        {
+            co_return co_await m_cacheStorage.get().readOneRaw(key);
+        }
+
+        co_return co_await m_backendStorage.get().readOneRaw(key);
+    }
+
+    template <::ranges::input_range Keys>
     task::Task<std::vector<std::optional<Value>>> readSome(Keys keys)
     {
         auto values = co_await readSomeRaw(std::move(keys));
@@ -178,35 +254,13 @@ public:
         }) | ::ranges::to<std::vector>();
     }
 
-    auto readSome(::ranges::input_range auto keys, storage2::DIRECT_TYPE /*unused*/)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadSome, MutableStorage&, decltype(keys)>>>
-    {
-        if (m_mutableStorage)
-        {
-            co_return co_await storage2::readSome(*m_mutableStorage, std::move(keys));
-        }
-
-        for (auto& immutableStorage : m_immutableStorages)
-        {
-            co_return co_await storage2::readSome(*immutableStorage, std::move(keys));
-        }
-
-        if constexpr (View::withCacheStorage)
-        {
-            co_return co_await storage2::readSome(m_cacheStorage.get(), std::move(keys));
-        }
-
-        co_return co_await storage2::readSome(m_backendStorage.get(), std::move(keys));
-    }
-
     auto readOne(const auto& key) -> task::Task<task::AwaitableReturnType<
         std::invoke_result_t<storage2::ReadOne, MutableStorage&, decltype(key)>>>
     {
         if (m_mutableStorage)
         {
-            auto value = m_mutableStorage->readOneRaw(key);
-            if (!std::holds_alternative<storage2::NOT_EXISTS_TYPE>(value))
+            if (auto value = co_await m_mutableStorage->readOneRaw(key);
+                !std::holds_alternative<storage2::NOT_EXISTS_TYPE>(value))
             {
                 co_return getValue<Value>(value);
             }
@@ -214,8 +268,8 @@ public:
 
         for (auto& immutableStorage : m_immutableStorages)
         {
-            auto value = immutableStorage->readOneRaw(key);
-            if (!std::holds_alternative<storage2::NOT_EXISTS_TYPE>(value))
+            if (auto value = co_await immutableStorage->readOneRaw(key);
+                !std::holds_alternative<storage2::NOT_EXISTS_TYPE>(value))
             {
                 co_return getValue<Value>(value);
             }
@@ -227,28 +281,6 @@ public:
             {
                 co_return value;
             }
-        }
-
-        co_return co_await storage2::readOne(m_backendStorage.get(), key);
-    }
-
-    auto readOne(const auto& key, storage2::DIRECT_TYPE /*unused*/)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadOne, MutableStorage&, decltype(key)>>>
-    {
-        if (m_mutableStorage)
-        {
-            co_return co_await storage2::readOne(*m_mutableStorage, key);
-        }
-
-        for (auto& immutableStorage : m_immutableStorages)
-        {
-            co_return co_await storage2::readOne(*immutableStorage, key);
-        }
-
-        if constexpr (View::withCacheStorage)
-        {
-            co_return co_await storage2::readOne(m_cacheStorage.get(), key);
         }
 
         co_return co_await storage2::readOne(m_backendStorage.get(), key);

--- a/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
@@ -506,17 +506,17 @@ BOOST_AUTO_TEST_CASE(dirtctReadOne)
 
         auto value = co_await storage2::readOne(storage, 6);
         BOOST_CHECK(!value);
-        auto value2 = storage.readOneRaw(6);
+        auto value2 = co_await storage.readOneRaw(6);
         BOOST_CHECK(std::holds_alternative<bcos::storage2::DELETED_TYPE>(value2));
 
-        auto value3 = storage.readOneRaw(11);
+        auto value3 = co_await storage.readOneRaw(11);
         BOOST_CHECK(std::holds_alternative<bcos::storage2::NOT_EXISTS_TYPE>(value3));
         auto value4 = co_await storage2::readOne(storage, 11);
         BOOST_CHECK(!value4);
 
         auto value5 = co_await storage2::readOne(storage, 3);
         BOOST_CHECK(value5);
-        auto value6 = storage.readOneRaw(3);
+        auto value6 = co_await storage.readOneRaw(3);
         BOOST_CHECK(std::holds_alternative<int>(value6));
 
         MemoryStorage<int, int, bcos::storage2::memory_storage::ORDERED> storage_2;
@@ -527,10 +527,10 @@ BOOST_AUTO_TEST_CASE(dirtctReadOne)
         auto value21 = co_await storage2::readOne(storage_2, 6);
         BOOST_CHECK(!value21);
 
-        auto value22 = storage_2.readOneRaw(6);
+        auto value22 = co_await storage_2.readOneRaw(6);
         BOOST_CHECK(std::holds_alternative<bcos::storage2::NOT_EXISTS_TYPE>(value22));
 
-        auto value23 = storage_2.readOneRaw(11);
+        auto value23 = co_await storage_2.readOneRaw(11);
         BOOST_CHECK(std::holds_alternative<bcos::storage2::NOT_EXISTS_TYPE>(value23));
         auto value24 = co_await storage2::readOne(storage_2, 11);
         BOOST_CHECK(!value24);

--- a/bcos-storage/bcos-storage/RocksDBStorage2.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage2.h
@@ -43,7 +43,8 @@ public:
     using Key = KeyType;
     using Value = ValueType;
 
-    auto readSomeRaw(::ranges::input_range auto keys)
+    auto readSomeRaw(::ranges::input_range auto keys, auto&&... /*args*/)
+        -> task::Task<std::vector<StorageValueType<ValueType>>>
     {
         auto encodedKeys = keys | ::ranges::views::transform([&](auto&& key) {
             return m_keyResolver.encode(std::forward<decltype(key)>(key));
@@ -74,44 +75,53 @@ public:
                 return {m_valueResolver.decode(result.ToStringView())};
             }) |
             ::ranges::to<std::vector>();
-        return values;
+        co_return values;
     }
 
-    auto readSome(::ranges::input_range auto keys)
-        -> task::AwaitableValue<std::vector<std::optional<ValueType>>>
+    auto readOneRaw(auto key, auto&&... args) -> task::Task<StorageValueType<ValueType>>
     {
-        auto values = readSomeRaw(std::move(keys));
-        return {::ranges::views::transform(values, [](auto&& value) -> std::optional<ValueType> {
+        (void)sizeof...(args);
+
+        auto encodedKey = m_keyResolver.encode(std::move(key));
+        ::rocksdb::PinnableSlice result;
+        auto status = m_rocksDB.get().Get(::rocksdb::ReadOptions(),
+            m_rocksDB.get().DefaultColumnFamily(),
+            ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey)), &result);
+
+        if (!status.ok())
+        {
+            if (status.IsNotFound())
+            {
+                co_return StorageValueType<ValueType>{};
+            }
+            BOOST_THROW_EXCEPTION(RocksDBException{} << bcos::Error::ErrorMessage(status.ToString()));
+        }
+
+        co_return StorageValueType<ValueType>{m_valueResolver.decode(result.ToStringView())};
+    }
+
+    auto readSome(::ranges::input_range auto keys, auto&&... args)
+        -> task::Task<std::vector<std::optional<ValueType>>>
+    {
+        auto values =
+            co_await readSomeRaw(std::move(keys), std::forward<decltype(args)>(args)...);
+        co_return ::ranges::views::transform(values, [](auto&& value) -> std::optional<ValueType> {
             if (auto* entry = std::get_if<ValueType>(std::addressof(value)))
             {
                 return std::make_optional(std::move(*entry));
             }
             return {};
-        }) | ::ranges::to<std::vector>()};
+        }) | ::ranges::to<std::vector>();
     }
 
-    auto readOne(auto key) -> task::AwaitableValue<std::optional<ValueType>>
+    auto readOne(auto key, auto&&... args) -> task::Task<std::optional<ValueType>>
     {
-        task::AwaitableValue<std::optional<ValueType>> result;
-
-        auto rocksDBKey = m_keyResolver.encode(key);
-        std::string value;
-        auto status =
-            m_rocksDB.get().Get(::rocksdb::ReadOptions(), m_rocksDB.get().DefaultColumnFamily(),
-                ::rocksdb::Slice(::ranges::data(rocksDBKey), ::ranges::size(rocksDBKey)),
-                std::addressof(value));
-        if (!status.ok())
+        auto value = co_await readOneRaw(std::move(key), std::forward<decltype(args)>(args)...);
+        if (auto* typed = std::get_if<ValueType>(std::addressof(value)))
         {
-            if (!status.IsNotFound())
-            {
-                BOOST_THROW_EXCEPTION(
-                    RocksDBException{} << bcos::Error::ErrorMessage(status.ToString()));
-            }
-            return result;
+            co_return std::optional<ValueType>{std::move(*typed)};
         }
-        result.value().emplace(m_valueResolver.decode(std::move(value)));
-
-        return result;
+        co_return std::nullopt;
     }
 
     task::AwaitableValue<void> writeSome(::ranges::input_range auto keyValues)

--- a/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(readWriteRemoveSeek)
             auto stateKey = StateKey{std::string_view(tableName), std::string_view(key)};
             return stateKey;
         });
-        auto gotValues = rocksDB.readSomeRaw(queryKeys);
+        auto gotValues = co_await rocksDB.readSomeRaw(queryKeys);
         for (auto&& [i, value] : ::ranges::views::enumerate(gotValues))
         {
             if (i < 100)
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(readWriteRemoveSeek)
         });
         co_await storage2::removeSome(rocksDB, removeKeys);
 
-        auto gotValues2 = rocksDB.readSomeRaw(queryKeys);
+        auto gotValues2 = co_await rocksDB.readSomeRaw(queryKeys);
         for (auto&& [i, value] : ::ranges::views::enumerate(gotValues2))
         {
             if (i >= 50 && i < 70)
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(merge)
                           ::ranges::views::repeat(storage::Entry{"Hello"})));
         co_await storage2::merge(rocksDB2, storage3, storage4);
 
-        auto values2 = rocksDB2.readSomeRaw(
+        auto values2 = co_await rocksDB2.readSomeRaw(
             ::ranges::views::iota(0, 20) | ::ranges::views::transform([](int i) {
                 return StateKey{"Hello"sv, fmt::format("key{}", i)};
             }));

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -9,17 +9,13 @@ namespace bcos::executor_v1
 {
 
 template <class Storage>
-concept HasReadOneDirect = requires(Storage& storage) {
-    {
-        storage2::readOne(storage, std::declval<typename Storage::Key>(), storage2::DIRECT)
-    } -> task::IsAwaitable;
+concept HasReadOneRaw = requires(Storage& storage) {
+    storage.readOneRaw(std::declval<typename Storage::Key>(), storage2::DIRECT);
 };
+
 template <class Storage>
-concept HasReadSomeDirect = requires(Storage& storage) {
-    {
-        storage2::readSome(
-            storage, std::declval<std::vector<typename Storage::Key>>(), storage2::DIRECT)
-    } -> task::IsAwaitable;
+concept HasReadSomeRaw = requires(Storage& storage) {
+    storage.readSomeRaw(std::declval<std::vector<typename Storage::Key>>(), storage2::DIRECT);
 };
 
 template <class Storage>
@@ -44,16 +40,22 @@ public:
         {
             assert(index > 0);
             auto& record = m_records[index - 1];
-            if (record.oldValue)
+
+            if (std::holds_alternative<storage2::NOT_EXISTS_TYPE>(record.oldValue))
+            {
+                co_await storage2::removeOne(m_storage.get(), std::move(record.key));
+            }
+            else if (std::holds_alternative<storage2::DELETED_TYPE>(record.oldValue))
             {
                 co_await storage2::writeOne(
-                    m_storage.get(), std::move(record.key), std::move(*record.oldValue));
+                    m_storage.get(), std::move(record.key), storage2::deleteItem);
             }
-            else
+            else if (auto* value = std::get_if<Value>(&record.oldValue))
             {
-                co_await storage2::removeOne(
-                    m_storage.get(), std::move(record.key), storage2::DIRECT);
+                co_await storage2::writeOne(
+                    m_storage.get(), std::move(record.key), std::move(*value));
             }
+
             m_records.pop_back();
         }
     }
@@ -62,9 +64,7 @@ private:
     struct Record
     {
         Key key;
-        task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadOne, Storage&, Key, storage2::DIRECT_TYPE>>
-            oldValue;
+        storage2::StorageValueType<Value> oldValue;
     };
     std::vector<Record> m_records;
     std::reference_wrapper<Storage> m_storage;
@@ -73,24 +73,29 @@ private:
         requires ::ranges::sized_range<Keys> && ::ranges::input_range<Keys>
     task::Task<void> storeOldValues(Keys keys, bool withEmpty)
     {
-        auto oldValues = co_await storage2::readSome(m_storage.get(), keys, storage2::DIRECT);
-        m_records.reserve(m_records.size() + ::ranges::size(keys));
-        for (auto&& [key, oldValue] : ranges::views::zip(keys, oldValues))
+        auto& storage = m_storage.get();
+        auto keyList = ::ranges::to<std::vector<Key>>(keys);
+        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::DIRECT);
+
+        m_records.reserve(m_records.size() + keyList.size());
+        for (size_t i = 0; i < keyList.size(); ++i)
         {
-            if (oldValue || withEmpty)
+            auto& oldValue = oldValues[i];
+            if (!withEmpty && std::holds_alternative<storage2::NOT_EXISTS_TYPE>(oldValue))
             {
-                m_records.emplace_back(typename Rollbackable::Record{
-                    .key = Key(key), .oldValue = std::forward<decltype(oldValue)>(oldValue)});
+                continue;
             }
+
+            m_records.emplace_back(typename Rollbackable::Record{
+                .key = Key(keyList[i]), .oldValue = std::move(oldValue)});
         }
     }
 
 public:
-
     auto writeSome(::ranges::input_range auto keyValues)
         -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::WriteSome,
             std::add_lvalue_reference_t<Storage>, decltype(keyValues)>>>
-        requires HasReadSomeDirect<Storage>
+        requires HasReadSomeRaw<Storage>
     {
         if constexpr (::ranges::borrowed_range<decltype(keyValues)>)
         {
@@ -106,41 +111,36 @@ public:
         }
     }
 
-    auto readSome(
-        ::ranges::input_range auto keys)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys)>>>
+    auto readSome(::ranges::input_range auto keys) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys)>>>
     {
         co_return co_await storage2::readSome(m_storage.get(), std::move(keys));
     }
 
-    auto readOne(auto key)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key)>>>
+    auto readOne(auto key) -> task::Task<
+        task::AwaitableReturnType<std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key)>>>
     {
         co_return co_await storage2::readOne(m_storage.get(), std::move(key));
     }
 
-    auto existsOne(auto key)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ExistsOne, Storage&, decltype(key)>>>
+    auto existsOne(auto key) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::ExistsOne, Storage&, decltype(key)>>>
     {
         co_return co_await storage2::existsOne(m_storage.get(), std::move(key));
     }
 
-    auto writeOne(auto key, auto value)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::WriteOne, Storage&, decltype(key), decltype(value)>>>
-        requires HasReadOneDirect<Storage>
+    auto writeOne(auto key, auto value) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::WriteOne, Storage&, decltype(key), decltype(value)>>>
+        requires HasReadOneRaw<Storage>
     {
         auto& record = m_records.emplace_back();
         record.key = key;
-        record.oldValue = co_await storage2::readOne(m_storage.get(), key, storage2::DIRECT);
+        auto& storage = m_storage.get();
+        record.oldValue = co_await storage.readOneRaw(key, storage2::DIRECT);
         co_await storage2::writeOne(m_storage.get(), std::move(key), std::move(value));
     }
 
-    auto removeOne(
-        auto key, auto&&... args)
+    auto removeOne(auto key, auto&&... args)
         -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::RemoveOne,
             std::add_lvalue_reference_t<Storage>, decltype(key), decltype(args)...>>>
     {
@@ -149,8 +149,7 @@ public:
             m_storage.get(), std::move(key), std::forward<decltype(args)>(args)...);
     }
 
-    auto removeSome(
-        ::ranges::input_range auto keys)
+    auto removeSome(::ranges::input_range auto keys)
         -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::RemoveSome,
             std::add_lvalue_reference_t<Storage>, decltype(keys)>>>
     {
@@ -158,8 +157,9 @@ public:
         co_return co_await storage2::removeSome(m_storage.get(), std::move(keys));
     }
 
-    auto range(auto&&... args) -> task::Task<storage2::ReturnType<std::invoke_result_t<storage2::Range,
-        std::add_lvalue_reference_t<Storage>, decltype(args)...>>>
+    auto range(auto&&... args)
+        -> task::Task<storage2::ReturnType<std::invoke_result_t<storage2::Range,
+            std::add_lvalue_reference_t<Storage>, decltype(args)...>>>
     {
         co_return co_await storage2::range(m_storage.get(), std::forward<decltype(args)>(args)...);
     }

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -74,14 +74,14 @@ private:
     task::Task<void> storeOldValues(Keys keys, bool withEmpty)
     {
         auto& storage = m_storage.get();
-        decltype(auto) keyList = [&]() {
+        auto keyList = [&]() {
             if constexpr (std::is_same_v<::ranges::range_value_t<std::decay_t<Keys>>, Key>)
             {
                 return ::ranges::views::all(keys);
             }
             else
             {
-                return keys | ::ranges::views::transform([](auto&& k) { return Key(k); }) |
+                return keys | ::ranges::views::transform([](auto&& key) { return Key(key); }) |
                        ::ranges::to<std::vector<Key>>;
             }
         }();
@@ -95,7 +95,7 @@ private:
                 continue;
             }
             m_records.emplace_back(typename Rollbackable::Record{
-                .key = std::move(key), .oldValue = std::move(oldValue)});
+                .key = Key(key), .oldValue = std::move(oldValue)});
         }
     }
 

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -74,20 +74,28 @@ private:
     task::Task<void> storeOldValues(Keys keys, bool withEmpty)
     {
         auto& storage = m_storage.get();
-        auto keyList = ::ranges::to<std::vector<Key>>(keys);
+        decltype(auto) keyList = [&]() {
+            if constexpr (std::is_same_v<::ranges::range_value_t<std::decay_t<Keys>>, Key>)
+            {
+                return ::ranges::views::all(keys);
+            }
+            else
+            {
+                return keys | ::ranges::views::transform([](auto&& k) { return Key(k); }) |
+                       ::ranges::to<std::vector<Key>>;
+            }
+        }();
         auto oldValues = co_await storage.readSomeRaw(keyList, storage2::DIRECT);
 
         m_records.reserve(m_records.size() + keyList.size());
-        for (size_t i = 0; i < keyList.size(); ++i)
+        for (auto&& [key, oldValue] : ::ranges::views::zip(keyList, oldValues))
         {
-            auto& oldValue = oldValues[i];
             if (!withEmpty && std::holds_alternative<storage2::NOT_EXISTS_TYPE>(oldValue))
             {
                 continue;
             }
-
             m_records.emplace_back(typename Rollbackable::Record{
-                .key = Key(keyList[i]), .oldValue = std::move(oldValue)});
+                .key = std::move(key), .oldValue = std::move(oldValue)});
         }
     }
 

--- a/transaction-executor/benchmark/benchmakrExecutor.cpp
+++ b/transaction-executor/benchmark/benchmakrExecutor.cpp
@@ -19,7 +19,6 @@ using namespace bcos::storage2::memory_storage;
 using namespace bcos::executor_v1;
 
 using ReceiptFactory = bcostars::protocol::TransactionReceiptFactoryImpl;
-static_assert(HasReadOneDirect<MutableStorage>);
 
 struct Fixture
 {

--- a/transaction-executor/tests/TestRollbackableStorage.cpp
+++ b/transaction-executor/tests/TestRollbackableStorage.cpp
@@ -21,6 +21,8 @@ BOOST_FIXTURE_TEST_SUITE(TestRollbackableStorage, TestRollbackableStorageFixture
 
 using BackendStorag2 =
     memory_storage::MemoryStorage<StateKey, int, storage2::memory_storage::ORDERED>;
+using LogicalDeletionStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    storage2::memory_storage::ORDERED | storage2::memory_storage::LOGICAL_DELETION>;
 
 BOOST_AUTO_TEST_CASE(addRollback)
 {
@@ -497,6 +499,39 @@ BOOST_AUTO_TEST_CASE(mixedOperationsRollback)
         BOOST_CHECK(restoredDeleted);
         BOOST_CHECK_EQUAL(restoredDeleted->get(), "BaseValue2");
         BOOST_CHECK(!removedNew);
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(rollbackToLogicalDeletionState)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalDeletionStorage memoryStorage;
+        Rollbackable rollbackableStorage(memoryStorage);
+
+        std::string_view tableID = "table1";
+        auto key = StateKey{tableID, "Key1"sv};
+
+        // add -> logical delete
+        co_await storage2::writeOne(rollbackableStorage, key, storage::Entry{"Value1"});
+        co_await storage2::removeOne(rollbackableStorage, key);
+
+        // Savepoint after logical deletion
+        auto savepoint = rollbackableStorage.current();
+
+        // Update value after deleted state
+        co_await storage2::writeOne(rollbackableStorage, key, storage::Entry{"Value2"});
+        auto updated = co_await storage2::readOne(rollbackableStorage, key);
+        BOOST_REQUIRE(updated);
+        BOOST_CHECK_EQUAL(updated->get(), "Value2");
+
+        // Rollback should restore the logical deleted state rather than not-exists
+        co_await rollbackableStorage.rollback(savepoint);
+
+        auto valueAfterRollback = co_await storage2::readOne(rollbackableStorage, key);
+        BOOST_CHECK(!valueAfterRollback);
+
+        auto rawValue = co_await memoryStorage.readOneRaw(key, storage2::DIRECT);
+        BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(rawValue));
     }());
 }
 

--- a/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
@@ -45,6 +45,22 @@ private:
 
 public:
 
+    auto readSomeRaw(::ranges::input_range auto keys, auto&&... args)
+        -> task::Task<task::AwaitableReturnType<
+            decltype(m_storage.get().readSomeRaw(std::move(keys), std::forward<decltype(args)>(args)...))>>
+    {
+        co_return co_await m_storage.get().readSomeRaw(
+            std::move(keys), std::forward<decltype(args)>(args)...);
+    }
+
+    auto readOneRaw(auto key, auto&&... args)
+        -> task::Task<task::AwaitableReturnType<
+            decltype(m_storage.get().readOneRaw(std::move(key), std::forward<decltype(args)>(args)...))>>
+    {
+        co_return co_await m_storage.get().readOneRaw(
+            std::move(key), std::forward<decltype(args)>(args)...);
+    }
+
     auto readSome(::ranges::input_range auto keys)
         -> task::Task<task::AwaitableReturnType<
             std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys)>>>

--- a/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
@@ -44,39 +44,30 @@ private:
     }
 
 public:
-
     auto readSomeRaw(::ranges::input_range auto keys, auto&&... args)
-        -> task::Task<task::AwaitableReturnType<
-            decltype(m_storage.get().readSomeRaw(std::move(keys), std::forward<decltype(args)>(args)...))>>
+        -> task::Task<task::AwaitableReturnType<decltype(m_storage.get().readSomeRaw(
+            std::move(keys), std::forward<decltype(args)>(args)...))>>
     {
         co_return co_await m_storage.get().readSomeRaw(
             std::move(keys), std::forward<decltype(args)>(args)...);
     }
 
     auto readOneRaw(auto key, auto&&... args)
-        -> task::Task<task::AwaitableReturnType<
-            decltype(m_storage.get().readOneRaw(std::move(key), std::forward<decltype(args)>(args)...))>>
+        -> task::Task<task::AwaitableReturnType<decltype(m_storage.get().readOneRaw(
+            std::move(key), std::forward<decltype(args)>(args)...))>>
     {
         co_return co_await m_storage.get().readOneRaw(
             std::move(key), std::forward<decltype(args)>(args)...);
     }
 
-    auto readSome(::ranges::input_range auto keys)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys)>>>
+    auto readSome(::ranges::input_range auto keys) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys)>>>
     {
         for (auto&& key : keys)
         {
             putSet(false, key);
         }
         co_return co_await storage2::readSome(m_storage.get(), std::move(keys));
-    }
-
-    auto readSome(::ranges::input_range auto keys, storage2::DIRECT_TYPE direct)
-        -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::ReadSome,
-            std::add_lvalue_reference_t<Storage>, decltype(std::move(keys))>>>
-    {
-        co_return co_await storage2::readSome(m_storage.get(), std::move(keys), direct);
     }
 
     auto readOne(auto key)
@@ -87,32 +78,22 @@ public:
         co_return co_await storage2::readOne(m_storage.get(), std::move(key));
     }
 
-    auto readOne(const auto& key, storage2::DIRECT_TYPE direct)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key)>>>
-    {
-        co_return co_await storage2::readOne(m_storage.get(), key, direct);
-    }
-
-    auto existsOne(auto key)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::ExistsOne, Storage&, decltype(key)>>>
+    auto existsOne(auto key) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::ExistsOne, Storage&, decltype(key)>>>
     {
         putSet(false, key);
         co_return co_await storage2::existsOne(m_storage.get(), std::move(key));
     }
 
-    auto writeOne(auto key, auto value)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::WriteOne, Storage&, decltype(key), decltype(value)>>>
+    auto writeOne(auto key, auto value) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::WriteOne, Storage&, decltype(key), decltype(value)>>>
     {
         putSet(true, key);
         co_await storage2::writeOne(m_storage.get(), std::move(key), std::move(value));
     }
 
-    auto writeSome(::ranges::input_range auto keyValues)
-        -> task::Task<task::AwaitableReturnType<
-            std::invoke_result_t<storage2::WriteSome, Storage&, decltype(keyValues)>>>
+    auto writeSome(::ranges::input_range auto keyValues) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::WriteSome, Storage&, decltype(keyValues)>>>
     {
         for (auto&& [key, _] : keyValues)
         {
@@ -140,12 +121,10 @@ public:
             m_storage.get(), std::move(keys), std::forward<decltype(args)>(args)...);
     }
 
-    auto range(auto&&... args)
-        -> task::Task<storage2::ReturnType<
-            std::invoke_result_t<storage2::Range, Storage&, decltype(args)...>>>
+    auto range(auto&&... args) -> task::Task<
+        storage2::ReturnType<std::invoke_result_t<storage2::Range, Storage&, decltype(args)...>>>
     {
-        co_return co_await storage2::range(
-            m_storage.get(), std::forward<decltype(args)>(args)...);
+        co_return co_await storage2::range(m_storage.get(), std::forward<decltype(args)>(args)...);
     }
 
     friend auto& readWriteSet(ReadWriteSetStorage& storage) { return storage.m_readWriteSet; }

--- a/transaction-scheduler/tests/testReadWriteSetStorage.cpp
+++ b/transaction-scheduler/tests/testReadWriteSetStorage.cpp
@@ -71,6 +71,22 @@ struct MockStorage
     using Key = int;
     using Value = int;
 
+    auto readSomeRaw(auto&& keys, auto&&...)
+        -> task::Task<std::vector<storage2::StorageValueType<int>>>
+    {
+        std::vector<storage2::StorageValueType<int>> result;
+        for ([[maybe_unused]] auto&& key : keys)
+        {
+            result.emplace_back(100);
+        }
+        co_return result;
+    }
+
+    auto readOneRaw(auto&& key, auto&&...) -> task::Task<storage2::StorageValueType<int>>
+    {
+        co_return 100;
+    }
+
     auto readOne(auto&& key) -> task::Task<std::optional<int>>
     {
         BOOST_FAIL("Unexcept to here!");

--- a/transaction-scheduler/tests/testReadWriteSetStorage.cpp
+++ b/transaction-scheduler/tests/testReadWriteSetStorage.cpp
@@ -105,9 +105,8 @@ BOOST_AUTO_TEST_CASE(directFlag)
         MockStorage lhsStorage;
         ReadWriteSetStorage<decltype(lhsStorage)> firstStorage(lhsStorage);
 
-        auto value = co_await storage2::readOne(firstStorage, 100, storage2::DIRECT);
-        BOOST_CHECK(value);
-        BOOST_CHECK_EQUAL(*value, 100);
+        auto value = co_await firstStorage.readOneRaw(100, storage2::DIRECT);
+        BOOST_CHECK_EQUAL(std::get<int>(value), 100);
     }());
 }
 


### PR DESCRIPTION
Introduce `readOneRaw` and `readSomeRaw` methods to enhance storage access capabilities. Update unit tests to ensure functionality and correctness of the new methods.