### PR TITLE
feat(storage2): add MerkleStorage state-root operations and tests

### DIFF
--- a/bcos-framework/bcos-framework/storage2/MerkleStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MerkleStorage.h
@@ -1,0 +1,1596 @@
+#pragma once
+
+#include "Storage.h"
+#include "bcos-storage/bcos-storage/RocksDBStorage2.h"
+#include "bcos-crypto/interfaces/crypto/Hash.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-utilities/DataConvertUtility.h"
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace bcos::storage2
+{
+
+enum class MPTNodeType : uint8_t
+{
+    branch = 0,
+    extension = 1,
+    leaf = 2,
+};
+
+using MPTNibble = uint8_t;
+using MPTPath = std::vector<MPTNibble>;
+using MPTNodeHash = crypto::HashType;
+
+struct MPTNodeHashResolver
+{
+    std::string encode(const MPTNodeHash& nodeHash) const
+    {
+        return std::string(
+            reinterpret_cast<const char*>(nodeHash.data()), nodeHash.size());
+    }
+
+    MPTNodeHash decode(std::string_view encoded) const
+    {
+        if (encoded.size() != MPTNodeHash::SIZE)
+        {
+            throw std::runtime_error("Invalid raw MPT node hash length");
+        }
+
+        MPTNodeHash nodeHash;
+        std::memcpy(nodeHash.data(), encoded.data(), MPTNodeHash::SIZE);
+        return nodeHash;
+    }
+};
+
+struct MPTNodeValueResolver
+{
+    std::string encode(const storage::Entry& entry) const { return std::string(entry.get()); }
+
+    storage::Entry decode(std::string_view encoded) const
+    {
+        return storage::Entry(std::string(encoded));
+    }
+};
+
+using TrieNodeRocksDBStorage = bcos::storage2::rocksdb::RocksDBStorage2<MPTNodeHash,
+    storage::Entry, MPTNodeHashResolver, MPTNodeValueResolver>;
+
+struct MPTAccountValue
+{
+    std::optional<storage::Entry> codeHash;
+    std::optional<storage::Entry> code;
+    std::optional<storage::Entry> balance;
+    std::optional<storage::Entry> abi;
+    std::optional<storage::Entry> nonce;
+    std::optional<storage::Entry> alive;
+    std::optional<storage::Entry> frozen;
+    std::optional<storage::Entry> shard;
+    std::optional<MPTNodeHash> storageRoot;
+
+    bool empty() const noexcept
+    {
+        return !codeHash && !code && !balance && !abi && !nonce && !alive && !frozen && !shard &&
+               !storageRoot;
+    }
+};
+
+struct MPTNode
+{
+    constexpr static uint8_t VERSION = 1;
+
+    MPTNodeType type = MPTNodeType::branch;
+    // `path` is meaningful for extension and leaf nodes. Branch nodes should keep it empty.
+    MPTPath path;
+    std::array<std::optional<MPTNodeHash>, 16> children;
+    std::optional<MPTNodeHash> childHash;
+    MPTAccountValue value;
+    std::optional<storage::Entry> slotValue;
+
+    storage::Entry flatten() const
+    {
+        std::string buffer;
+        buffer.reserve(estimateEncodedSize());
+
+        appendByte(buffer, VERSION);
+        appendByte(buffer, static_cast<uint8_t>(type));
+        appendPath(buffer, path);
+
+        uint16_t childrenMask = 0;
+        for (size_t index = 0; index < children.size(); ++index)
+        {
+            if (children[index].has_value())
+            {
+                childrenMask |= static_cast<uint16_t>(1U << index);
+            }
+        }
+        appendUint16(buffer, childrenMask);
+        for (auto const& child : children)
+        {
+            if (child)
+            {
+                appendHash(buffer, *child);
+            }
+        }
+
+        appendOptionalHash(buffer, childHash);
+        appendAccountValue(buffer, value);
+        appendOptionalEntry(buffer, slotValue);
+
+        return storage::Entry(std::move(buffer));
+    }
+
+    MPTNodeHash hash(const crypto::Hash& hashImpl) const
+    {
+        auto encoded = flatten();
+        return hashImpl.hash(encoded.get());
+    }
+
+    static MPTNode restore(const storage::Entry& entry)
+    {
+        return restore(entry.get());
+    }
+
+    static MPTNode restore(std::string_view encoded)
+    {
+        Reader reader(encoded);
+
+        auto version = reader.readByte();
+        if (version != VERSION)
+        {
+            throw std::runtime_error("Unsupported MPT node encoding version");
+        }
+
+        MPTNode node;
+        node.type = static_cast<MPTNodeType>(reader.readByte());
+        node.path = reader.readPath();
+
+        auto childrenMask = reader.readUint16();
+        for (size_t index = 0; index < node.children.size(); ++index)
+        {
+            if ((childrenMask & static_cast<uint16_t>(1U << index)) != 0)
+            {
+                node.children[index] = reader.readHash();
+            }
+        }
+
+        node.childHash = reader.readOptionalHash();
+        node.value = reader.readAccountValue();
+        node.slotValue = reader.readOptionalEntry();
+
+        reader.ensureFullyConsumed();
+        return node;
+    }
+
+private:
+    struct Reader
+    {
+        explicit Reader(std::string_view data) : m_data(data) {}
+
+        uint8_t readByte()
+        {
+            ensureAvailable(1);
+            return static_cast<uint8_t>(m_data[m_offset++]);
+        }
+
+        uint16_t readUint16()
+        {
+            ensureAvailable(sizeof(uint16_t));
+            uint16_t value = 0;
+            value |= static_cast<uint16_t>(static_cast<uint8_t>(m_data[m_offset])) << 8U;
+            value |= static_cast<uint16_t>(static_cast<uint8_t>(m_data[m_offset + 1]));
+            m_offset += sizeof(uint16_t);
+            return value;
+        }
+
+        uint32_t readUint32()
+        {
+            ensureAvailable(sizeof(uint32_t));
+            uint32_t value = 0;
+            value |= static_cast<uint32_t>(static_cast<uint8_t>(m_data[m_offset])) << 24U;
+            value |= static_cast<uint32_t>(static_cast<uint8_t>(m_data[m_offset + 1])) << 16U;
+            value |= static_cast<uint32_t>(static_cast<uint8_t>(m_data[m_offset + 2])) << 8U;
+            value |= static_cast<uint32_t>(static_cast<uint8_t>(m_data[m_offset + 3]));
+            m_offset += sizeof(uint32_t);
+            return value;
+        }
+
+        std::string_view readBytes()
+        {
+            auto size = readUint32();
+            ensureAvailable(size);
+            auto view = m_data.substr(m_offset, size);
+            m_offset += size;
+            return view;
+        }
+
+        MPTPath readPath()
+        {
+            auto bytes = readBytes();
+            return MPTPath(bytes.begin(), bytes.end());
+        }
+
+        MPTNodeHash readHash()
+        {
+            ensureAvailable(MPTNodeHash::SIZE);
+            MPTNodeHash hash;
+            std::memcpy(hash.data(), m_data.data() + m_offset, MPTNodeHash::SIZE);
+            m_offset += MPTNodeHash::SIZE;
+            return hash;
+        }
+
+        std::optional<MPTNodeHash> readOptionalHash()
+        {
+            if (readByte() == 0)
+            {
+                return std::nullopt;
+            }
+            return readHash();
+        }
+
+        std::optional<storage::Entry> readOptionalEntry()
+        {
+            if (readByte() == 0)
+            {
+                return std::nullopt;
+            }
+            return storage::Entry(std::string(readBytes()));
+        }
+
+        MPTAccountValue readAccountValue()
+        {
+            MPTAccountValue value;
+            value.codeHash = readOptionalEntry();
+            value.code = readOptionalEntry();
+            value.balance = readOptionalEntry();
+            value.abi = readOptionalEntry();
+            value.nonce = readOptionalEntry();
+            value.alive = readOptionalEntry();
+            value.frozen = readOptionalEntry();
+            value.shard = readOptionalEntry();
+            value.storageRoot = readOptionalHash();
+            return value;
+        }
+
+        void ensureFullyConsumed() const
+        {
+            if (m_offset != m_data.size())
+            {
+                throw std::runtime_error("Unexpected trailing bytes in encoded MPT node");
+            }
+        }
+
+    private:
+        void ensureAvailable(size_t size) const
+        {
+            if (size > (m_data.size() - m_offset))
+            {
+                throw std::runtime_error("Invalid encoded MPT node");
+            }
+        }
+
+        std::string_view m_data;
+        size_t m_offset = 0;
+    };
+
+    size_t estimateEncodedSize() const
+    {
+        size_t size = 0;
+        size += 1;  // version
+        size += 1;  // type
+        size += sizeof(uint32_t) + path.size();
+        size += sizeof(uint16_t);  // child mask
+        for (auto const& child : children)
+        {
+            if (child)
+            {
+                size += MPTNodeHash::SIZE;
+            }
+        }
+        size += 1 + (childHash ? MPTNodeHash::SIZE : 0);
+        size += accountValueEncodedSize(value);
+        size += optionalEntryEncodedSize(slotValue);
+        return size;
+    }
+
+    static void appendByte(std::string& buffer, uint8_t value)
+    {
+        buffer.push_back(static_cast<char>(value));
+    }
+
+    static void appendUint16(std::string& buffer, uint16_t value)
+    {
+        buffer.push_back(static_cast<char>((value >> 8U) & 0xFFU));
+        buffer.push_back(static_cast<char>(value & 0xFFU));
+    }
+
+    static void appendUint32(std::string& buffer, uint32_t value)
+    {
+        buffer.push_back(static_cast<char>((value >> 24U) & 0xFFU));
+        buffer.push_back(static_cast<char>((value >> 16U) & 0xFFU));
+        buffer.push_back(static_cast<char>((value >> 8U) & 0xFFU));
+        buffer.push_back(static_cast<char>(value & 0xFFU));
+    }
+
+    static void appendBytes(std::string& buffer, std::string_view bytes)
+    {
+        if (bytes.size() > std::numeric_limits<uint32_t>::max())
+        {
+            throw std::runtime_error("MPT node field is too large to encode");
+        }
+
+        appendUint32(buffer, static_cast<uint32_t>(bytes.size()));
+        if (!bytes.empty())
+        {
+            buffer.append(bytes.data(), bytes.size());
+        }
+    }
+
+    static void appendPath(std::string& buffer, const MPTPath& path)
+    {
+        if (path.empty())
+        {
+            appendBytes(buffer, {});
+            return;
+        }
+
+        appendBytes(buffer, std::string_view(reinterpret_cast<const char*>(path.data()), path.size()));
+    }
+
+    static void appendHash(std::string& buffer, const MPTNodeHash& hash)
+    {
+        buffer.append(reinterpret_cast<const char*>(hash.data()), hash.size());
+    }
+
+    static void appendOptionalHash(std::string& buffer, const std::optional<MPTNodeHash>& hash)
+    {
+        appendByte(buffer, hash ? 1 : 0);
+        if (hash)
+        {
+            appendHash(buffer, *hash);
+        }
+    }
+
+    static void appendOptionalEntry(
+        std::string& buffer, const std::optional<storage::Entry>& maybeValue)
+    {
+        appendByte(buffer, maybeValue ? 1 : 0);
+        if (maybeValue)
+        {
+            appendBytes(buffer, maybeValue->get());
+        }
+    }
+
+    static size_t optionalEntryEncodedSize(const std::optional<storage::Entry>& maybeValue)
+    {
+        size_t size = 1;
+        if (maybeValue)
+        {
+            size += sizeof(uint32_t) + maybeValue->size();
+        }
+        return size;
+    }
+
+    static size_t optionalHashEncodedSize(const std::optional<MPTNodeHash>& hash)
+    {
+        return 1 + (hash ? MPTNodeHash::SIZE : 0);
+    }
+
+    static size_t accountValueEncodedSize(const MPTAccountValue& value)
+    {
+        size_t size = 0;
+        size += optionalEntryEncodedSize(value.codeHash);
+        size += optionalEntryEncodedSize(value.code);
+        size += optionalEntryEncodedSize(value.balance);
+        size += optionalEntryEncodedSize(value.abi);
+        size += optionalEntryEncodedSize(value.nonce);
+        size += optionalEntryEncodedSize(value.alive);
+        size += optionalEntryEncodedSize(value.frozen);
+        size += optionalEntryEncodedSize(value.shard);
+        size += optionalHashEncodedSize(value.storageRoot);
+        return size;
+    }
+
+    static void appendAccountValue(std::string& buffer, const MPTAccountValue& value)
+    {
+        appendOptionalEntry(buffer, value.codeHash);
+        appendOptionalEntry(buffer, value.code);
+        appendOptionalEntry(buffer, value.balance);
+        appendOptionalEntry(buffer, value.abi);
+        appendOptionalEntry(buffer, value.nonce);
+        appendOptionalEntry(buffer, value.alive);
+        appendOptionalEntry(buffer, value.frozen);
+        appendOptionalEntry(buffer, value.shard);
+        appendOptionalHash(buffer, value.storageRoot);
+    }
+};
+
+// MPT skeleton is kept in the same header as MerkleStorage for now,
+// so the account-state interception layer and trie abstraction evolve together.
+template <class TrieNodeStorage>
+class MPT
+{
+public:
+    using NodeStorage = TrieNodeStorage;
+
+    MPT(NodeStorage& nodeStorage, crypto::Hash::Ptr hashImpl)
+      : m_nodeStorage(nodeStorage), m_hashImpl(std::move(hashImpl))
+    {}
+
+    MPT(const MPT&) = delete;
+    MPT& operator=(const MPT&) = delete;
+    MPT(MPT&&) noexcept = default;
+    MPT& operator=(MPT&&) noexcept = default;
+    ~MPT() noexcept = default;
+
+    task::Task<std::optional<MPTNode>> read(MPTNodeHash rootHash, std::string key)
+    {
+        std::string_view remainingKey(key);
+        auto nowNode = co_await getNode(rootHash);
+        while (nowNode)
+        {
+            if (nowNode->type == MPTNodeType::leaf)
+            {
+                if (!pathEquals(remainingKey, nowNode->path))
+                {
+                    co_return std::nullopt;
+                }
+                co_return nowNode;
+            }
+
+            if (nowNode->type == MPTNodeType::branch)
+            {
+                if (remainingKey.empty())
+                {
+                    co_return std::nullopt;
+                }
+
+                auto firstKeyChar = remainingKey.front();
+                auto childIndex = hexCharToNibble(firstKeyChar);
+
+                if (auto const& childHash = nowNode->children[static_cast<size_t>(childIndex)];
+                    childHash)
+                {
+                    nowNode = co_await getNode(*childHash);
+                    remainingKey.remove_prefix(1);
+                    continue;
+                }
+                co_return std::nullopt;
+            }
+
+            if (nowNode->type == MPTNodeType::extension)
+            {
+                if (!pathStartsWith(remainingKey, nowNode->path))
+                {
+                    co_return std::nullopt;
+                }
+
+                if (!nowNode->childHash)
+                {
+                    co_return std::nullopt;
+                }
+
+                remainingKey.remove_prefix(nowNode->path.size());
+                nowNode = co_await getNode(*nowNode->childHash);
+                continue;
+            }
+
+            throw std::runtime_error("Invalid MPT node type");
+        }
+
+        co_return std::nullopt;
+    }
+
+    task::Task<std::optional<MPTNodeHash>> write(
+        MPTNodeHash rootHash, std::string key, std::string fieldKey, storage::Entry value)
+    {
+        co_return co_await writeTrieNode(rootHash, std::move(key),
+            [fieldKey = std::move(fieldKey), value = std::move(value)](MPTNode& node) -> bool {
+                return setAccountField(node.value, fieldKey, value);
+            });
+    }
+
+    task::Task<std::optional<MPTNodeHash>> clear(
+        MPTNodeHash rootHash, std::string key, std::string fieldKey)
+    {
+        co_return co_await writeTrieNode(rootHash, std::move(key),
+            [fieldKey = std::move(fieldKey)](MPTNode& node) -> bool {
+                return clearAccountField(node.value, fieldKey);
+            });
+    }
+
+    task::Task<std::optional<MPTNodeHash>> writeSlot(
+        MPTNodeHash slotRootHash, std::string slotKey, storage::Entry slotValue)
+    {
+        co_return co_await writeTrieNode(slotRootHash, std::move(slotKey),
+            [slotValue = std::move(slotValue)](MPTNode& node) mutable -> bool {
+                node.slotValue = std::move(slotValue);
+                return true;
+            });
+    }
+
+    task::Task<std::optional<MPTNodeHash>> clearSlot(
+        MPTNodeHash slotRootHash, std::string slotKey)
+    {
+        co_return co_await writeTrieNode(slotRootHash, std::move(slotKey), [](MPTNode& node) {
+            if (!node.slotValue)
+            {
+                return false;
+            }
+            node.slotValue.reset();
+            return true;
+        });
+    }
+
+    task::Task<std::optional<MPTNodeHash>> writeStorageRoot(
+        MPTNodeHash rootHash, std::string key, MPTNodeHash storageRoot)
+    {
+        co_return co_await writeTrieNode(rootHash, std::move(key),
+            [storageRoot = std::move(storageRoot)](MPTNode& node) mutable -> bool {
+                node.value.storageRoot = std::move(storageRoot);
+                return true;
+            });
+    }
+
+    task::Task<void> remove(std::string_view key)
+    {
+        // TODO: Delete the leaf mapped by `key`.
+        // TODO: Compact branch / extension nodes after deletion.
+        // TODO: Refresh `m_root` and persist modified nodes.
+        (void)key;
+        co_return;
+    }
+
+    task::Task<std::optional<MPTNode>> getNode(const MPTNodeHash& nodeHash)
+    {
+        static_assert(std::same_as<std::remove_cvref_t<typename NodeStorage::Key>, MPTNodeHash>,
+            "MPT node storage key type must be MPTNodeHash");
+        static_assert(
+            std::same_as<std::remove_cvref_t<typename NodeStorage::Value>, storage::Entry>,
+            "MPT node storage value type must be storage::Entry");
+
+        if (auto encodedNode = co_await ::bcos::storage2::readOne(m_nodeStorage.get(), nodeHash))
+        {
+            co_return MPTNode::restore(*encodedNode);
+        }
+        co_return std::nullopt;
+    }
+
+    MPTNodeHash calcNodeHash(const MPTNode& node) const
+    {
+        if (!m_hashImpl)
+        {
+            throw std::runtime_error("Hash implementation is not configured for MPT");
+        }
+
+        return node.hash(*m_hashImpl);
+    }
+
+    task::Task<MPTNodeHash> putNode(const MPTNode& node)
+    {
+        static_assert(std::same_as<std::remove_cvref_t<typename NodeStorage::Key>, MPTNodeHash>,
+            "MPT node storage key type must be MPTNodeHash");
+        static_assert(
+            std::same_as<std::remove_cvref_t<typename NodeStorage::Value>, storage::Entry>,
+            "MPT node storage value type must be storage::Entry");
+
+        auto nodeHash = calcNodeHash(node);
+        auto encodedNode = node.flatten();
+
+        co_await ::bcos::storage2::writeOne(m_nodeStorage.get(), nodeHash, std::move(encodedNode));
+        co_return nodeHash;
+    }
+
+    task::Task<void> setRoot(MPTNodeHash root)
+    {
+        m_root = std::move(root);
+        // TODO: Persist root hash if the caller wants a durable root record.
+        co_return;
+    }
+
+    task::Task<std::optional<MPTNodeHash>> root() const
+    {
+        co_return m_root;
+    }
+
+    static bool isSlotKey(std::string_view key) noexcept
+    {
+        constexpr static size_t slotKeyLength = 32;
+        return key.size() == slotKeyLength;
+    }
+
+private:
+    template <class UpdateFn>
+    task::Task<std::optional<MPTNodeHash>> writeTrieNode(
+        MPTNodeHash rootHash, std::string key, UpdateFn&& updateFn)
+    {
+        auto nowNode = co_await getNode(rootHash);
+        if (!nowNode)
+        {
+            nowNode.emplace();
+            nowNode->type = MPTNodeType::leaf;
+            nowNode->path = toMPTPath(key);
+            if (!std::invoke(updateFn, *nowNode))
+            {
+                co_return std::nullopt;
+            }
+            co_return co_await putNode(*nowNode);
+        }
+
+        if (nowNode->type == MPTNodeType::leaf)
+        {
+            if (!pathEquals(key, nowNode->path))
+            {
+                auto prefixLength = commonPrefixLength(key, nowNode->path);
+                auto keyPath = toMPTPath(key);
+
+                auto oldLeafNode = *nowNode;
+                oldLeafNode.path = MPTPath(
+                    nowNode->path.begin() + static_cast<std::ptrdiff_t>(prefixLength + 1),
+                    nowNode->path.end());
+
+                MPTNode newLeafNode;
+                newLeafNode.type = MPTNodeType::leaf;
+                newLeafNode.path = MPTPath(
+                    keyPath.begin() + static_cast<std::ptrdiff_t>(prefixLength + 1),
+                    keyPath.end());
+                if (!std::invoke(updateFn, newLeafNode))
+                {
+                    co_return std::nullopt;
+                }
+
+                auto oldLeafHash = co_await putNode(oldLeafNode);
+                auto newLeafHash = co_await putNode(newLeafNode);
+
+                MPTNode branchNode;
+                branchNode.type = MPTNodeType::branch;
+                auto oldBranchNibble = nowNode->path[prefixLength];
+                auto newBranchNibble = keyPath[prefixLength];
+                branchNode.children[oldBranchNibble] = oldLeafHash;
+                branchNode.children[newBranchNibble] = newLeafHash;
+
+                auto branchHash = co_await putNode(branchNode);
+                if (prefixLength == 0)
+                {
+                    co_return branchHash;
+                }
+
+                MPTNode extensionNode;
+                extensionNode.type = MPTNodeType::extension;
+                extensionNode.path = MPTPath(
+                    nowNode->path.begin(),
+                    nowNode->path.begin() + static_cast<std::ptrdiff_t>(prefixLength));
+                extensionNode.childHash = branchHash;
+                co_return co_await putNode(extensionNode);
+            }
+
+            if (!std::invoke(updateFn, *nowNode))
+            {
+                co_return std::nullopt;
+            }
+            co_return co_await putNode(*nowNode);
+        }
+        else if (nowNode->type == MPTNodeType::branch)
+        {
+            if (key.empty())
+            {
+                throw std::runtime_error("Trie write reached branch node with empty key");
+            }
+
+            auto childIndex = static_cast<size_t>(hexCharToNibble(key.front()));
+            auto remainingKey = key.substr(1);
+
+            if (auto& childHash = nowNode->children[childIndex]; childHash)
+            {
+                if (auto updatedChildHash = co_await writeTrieNode(
+                        *childHash, std::string(remainingKey), std::ref(updateFn)))
+                {
+                    childHash = *updatedChildHash;
+                    co_return co_await putNode(*nowNode);
+                }
+                co_return std::nullopt;
+            }
+
+            MPTNode newLeafNode;
+            newLeafNode.type = MPTNodeType::leaf;
+            newLeafNode.path = toMPTPath(remainingKey);
+            if (!std::invoke(updateFn, newLeafNode))
+            {
+                co_return std::nullopt;
+            }
+
+            auto newLeafHash = co_await putNode(newLeafNode);
+            nowNode->children[childIndex] = newLeafHash;
+            co_return co_await putNode(*nowNode);
+        }
+        else if (nowNode->type == MPTNodeType::extension)
+        {
+            if (!pathStartsWith(key, nowNode->path))
+            {
+                auto prefixLength = commonPrefixLength(key, nowNode->path);
+                auto keyPath = toMPTPath(key);
+
+                if (!nowNode->childHash)
+                {
+                    throw std::runtime_error("Extension node is missing child hash");
+                }
+
+                std::optional<MPTNodeHash> oldChildForBranch;
+                MPTNibble oldBranchNibble = 0;
+                MPTNibble newBranchNibble = 0;
+
+                if (prefixLength == 0)
+                {
+                    oldBranchNibble = nowNode->path.front();
+                    newBranchNibble = keyPath.front();
+
+                    if (nowNode->path.size() == 1)
+                    {
+                        oldChildForBranch = *nowNode->childHash;
+                    }
+                    else
+                    {
+                        MPTNode oldExtensionNode;
+                        oldExtensionNode.type = MPTNodeType::extension;
+                        oldExtensionNode.path =
+                            MPTPath(nowNode->path.begin() + 1, nowNode->path.end());
+                        oldExtensionNode.childHash = *nowNode->childHash;
+                        oldChildForBranch = co_await putNode(oldExtensionNode);
+                    }
+                }
+                else
+                {
+                    oldBranchNibble = nowNode->path[prefixLength];
+                    newBranchNibble = keyPath[prefixLength];
+
+                    auto oldSuffixBegin =
+                        nowNode->path.begin() + static_cast<std::ptrdiff_t>(prefixLength + 1);
+                    if (oldSuffixBegin == nowNode->path.end())
+                    {
+                        oldChildForBranch = *nowNode->childHash;
+                    }
+                    else
+                    {
+                        MPTNode oldExtensionNode;
+                        oldExtensionNode.type = MPTNodeType::extension;
+                        oldExtensionNode.path = MPTPath(oldSuffixBegin, nowNode->path.end());
+                        oldExtensionNode.childHash = *nowNode->childHash;
+                        oldChildForBranch = co_await putNode(oldExtensionNode);
+                    }
+                }
+
+                MPTNode newLeafNode;
+                newLeafNode.type = MPTNodeType::leaf;
+                newLeafNode.path = MPTPath(
+                    keyPath.begin() + static_cast<std::ptrdiff_t>(prefixLength + 1),
+                    keyPath.end());
+                if (!std::invoke(updateFn, newLeafNode))
+                {
+                    co_return std::nullopt;
+                }
+                auto newLeafHash = co_await putNode(newLeafNode);
+
+                MPTNode branchNode;
+                branchNode.type = MPTNodeType::branch;
+                branchNode.children[oldBranchNibble] = *oldChildForBranch;
+                branchNode.children[newBranchNibble] = newLeafHash;
+                auto branchHash = co_await putNode(branchNode);
+
+                if (prefixLength == 0)
+                {
+                    co_return branchHash;
+                }
+
+                nowNode->path = MPTPath(
+                    nowNode->path.begin(),
+                    nowNode->path.begin() + static_cast<std::ptrdiff_t>(prefixLength));
+                nowNode->childHash = branchHash;
+                co_return co_await putNode(*nowNode);
+            }
+
+            if (!nowNode->childHash)
+            {
+                throw std::runtime_error("Extension node is missing child hash");
+            }
+
+            auto remainingKey = key.substr(nowNode->path.size());
+            if (auto updatedChildHash = co_await writeTrieNode(
+                    *nowNode->childHash, std::string(remainingKey), std::ref(updateFn)))
+            {
+                nowNode->childHash = *updatedChildHash;
+                co_return co_await putNode(*nowNode);
+            }
+            co_return std::nullopt;
+        }
+
+        throw std::runtime_error("Trie write resolved to unsupported MPT node type");
+    }
+
+    static auto toMPTPath(std::string_view hexKey) -> MPTPath
+    {
+        MPTPath path;
+        path.reserve(hexKey.size());
+        for (char c : hexKey)
+        {
+            path.push_back(static_cast<MPTNibble>(hexCharToNibble(c)));
+        }
+        return path;
+    }
+
+    static bool pathStartsWith(std::string_view key, const MPTPath& path) noexcept
+    {
+        if (key.size() < path.size())
+        {
+            return false;
+        }
+
+        for (size_t index = 0; index < path.size(); ++index)
+        {
+            if (static_cast<uint8_t>(hexCharToNibble(key[index])) != path[index])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool pathEquals(std::string_view key, const MPTPath& path) noexcept
+    {
+        return key.size() == path.size() && pathStartsWith(key, path);
+    }
+
+    static size_t commonPrefixLength(std::string_view key, const MPTPath& path) noexcept
+    {
+        auto prefixLength = std::min(key.size(), path.size());
+        size_t index = 0;
+        for (; index < prefixLength; ++index)
+        {
+            if (static_cast<uint8_t>(hexCharToNibble(key[index])) != path[index])
+            {
+                break;
+            }
+        }
+        return index;
+    }
+
+    static int hexCharToNibble(char c)
+    {
+        if (c >= '0' && c <= '9')
+        {
+            return c - '0';
+        }
+        if (c >= 'a' && c <= 'f')
+        {
+            return 10 + (c - 'a');
+        }
+        if (c >= 'A' && c <= 'F')
+        {
+            return 10 + (c - 'A');
+        }
+        throw std::runtime_error("Invalid hex character in MPT path");
+    }
+
+    static bool setAccountField(
+        MPTAccountValue& accountValue, std::string_view field, const storage::Entry& value)
+    {
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH)
+        {
+            accountValue.codeHash = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE)
+        {
+            accountValue.code = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::BALANCE)
+        {
+            accountValue.balance = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ABI)
+        {
+            accountValue.abi = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::NONCE)
+        {
+            accountValue.nonce = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ALIVE)
+        {
+            accountValue.alive = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::FROZEN)
+        {
+            accountValue.frozen = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::SHARD)
+        {
+            accountValue.shard = value;
+            return true;
+        }
+        return false;
+    }
+
+    static bool clearAccountField(MPTAccountValue& accountValue, std::string_view field)
+    {
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH)
+        {
+            if (!accountValue.codeHash)
+            {
+                return false;
+            }
+            accountValue.codeHash.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE)
+        {
+            if (!accountValue.code)
+            {
+                return false;
+            }
+            accountValue.code.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::BALANCE)
+        {
+            if (!accountValue.balance)
+            {
+                return false;
+            }
+            accountValue.balance.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ABI)
+        {
+            if (!accountValue.abi)
+            {
+                return false;
+            }
+            accountValue.abi.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::NONCE)
+        {
+            if (!accountValue.nonce)
+            {
+                return false;
+            }
+            accountValue.nonce.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ALIVE)
+        {
+            if (!accountValue.alive)
+            {
+                return false;
+            }
+            accountValue.alive.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::FROZEN)
+        {
+            if (!accountValue.frozen)
+            {
+                return false;
+            }
+            accountValue.frozen.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::SHARD)
+        {
+            if (!accountValue.shard)
+            {
+                return false;
+            }
+            accountValue.shard.reset();
+            return true;
+        }
+        return false;
+    }
+
+    std::reference_wrapper<NodeStorage> m_nodeStorage;
+    crypto::Hash::Ptr m_hashImpl;
+    std::optional<MPTNodeHash> m_root;
+};
+
+// A thin wrapper over an existing storage backend.
+//
+// New boundary after the architecture adjustment:
+// - request routing / filtering happens before entering MerkleStorage
+// - any request arriving here is assumed to be CA/EOA-related account-state access
+//
+// Current stage:
+// - keep the existing backend behavior unchanged
+// - reserve the read/write/remove interception points for future MPT integration
+//
+// Future stage:
+// - translate logical state keys (`table:key`) into trie lookup/update paths
+// - read/write account state through MPT instead of directly touching flat KV entries
+// - keep trie nodes in a dedicated node store instead of mixing them with state entries
+template <class BackendStorage, class TrieNodeStorage>
+class MerkleStorage
+{
+public:
+    using Backend = std::remove_reference_t<BackendStorage>;
+    using NodeStorage = std::remove_reference_t<TrieNodeStorage>;
+    using Key = std::remove_cvref_t<typename Backend::Key>;
+    using Value = std::remove_cvref_t<typename Backend::Value>;
+    using Trie = MPT<NodeStorage>;
+
+    explicit MerkleStorage(BackendStorage& backendStorage) : m_backendStorage(backendStorage) {}
+    MerkleStorage(
+        BackendStorage& backendStorage, TrieNodeStorage& nodeStorage, crypto::Hash::Ptr hashImpl)
+      : m_backendStorage(backendStorage),
+        m_trieNodeStorage(std::ref(nodeStorage)),
+        m_mpt(std::in_place, m_trieNodeStorage->get(), std::move(hashImpl))
+    {}
+
+    MerkleStorage(const MerkleStorage&) = delete;
+    MerkleStorage& operator=(const MerkleStorage&) = delete;
+    MerkleStorage(MerkleStorage&&) noexcept = default;
+    MerkleStorage& operator=(MerkleStorage&&) noexcept = default;
+    ~MerkleStorage() noexcept = default;
+
+    auto readOne(const auto& key) -> task::Task<std::optional<Value>>
+    {
+        co_return co_await ::bcos::storage2::readOne(m_backendStorage.get(), key);
+    }
+
+    auto readOne(const auto& key, const MPTNodeHash& stateRoot)
+        -> task::Task<std::optional<Value>>
+    {
+        if (auto stateKey = toStateKeyView(key); stateKey && m_mpt)
+        {
+            auto hexStateKey = toHexStateKey(*stateKey);
+            auto& table = hexStateKey.table;
+            auto& tableKey = hexStateKey.key;
+
+            if (auto mptNode = co_await m_mpt->read(stateRoot, table))
+            {
+                if (isSlotKey(stateKey->m_key))
+                {
+                    if (auto slotRoot = mptNode->value.storageRoot)
+                    {
+                        if (auto slotNode = co_await m_mpt->read(*slotRoot, tableKey))
+                        {
+                            if (slotNode->slotValue)
+                            {
+                                co_return slotNode->slotValue;
+                            }
+                        }
+                    }
+                }
+                else if (auto accountFieldValue = getAccountField(mptNode->value, stateKey->m_key))
+                {
+                    co_return accountFieldValue;
+                }
+            }
+        }
+
+        co_return std::nullopt;
+    }
+
+    auto existsOne(const auto& key) -> task::Task<bool>
+    {
+        co_return (co_await readOne(key)).has_value();
+    }
+
+    auto readSome(::ranges::input_range auto keys) -> task::Task<std::vector<std::optional<Value>>>
+    {
+        std::vector<std::optional<Value>> values;
+        if constexpr (::ranges::sized_range<decltype(keys)>)
+        {
+            values.reserve(::ranges::size(keys));
+        }
+
+        for (auto&& key : keys)
+        {
+            values.emplace_back(co_await readOne(key));
+        }
+
+        co_return values;
+    }
+
+    auto writeOne(auto key, auto value) -> task::Task<void>
+    {
+        co_await ::bcos::storage2::writeOne(
+            m_backendStorage.get(), std::move(key), std::move(value));
+        co_return;
+    }
+
+    auto writeOne(auto key, auto value, const MPTNodeHash& stateRoot)
+        -> task::Task<std::optional<MPTNodeHash>>
+    {
+        std::optional<MPTNodeHash> updatedRoot;
+
+        if (auto stateKey = toStateKeyView(key); stateKey && m_mpt)
+        {
+            auto hexStateKey = toHexStateKey(*stateKey);
+            auto& table = hexStateKey.table;
+            auto& tableKey = hexStateKey.key;
+
+            if constexpr (std::same_as<Value, storage::Entry> &&
+                          std::same_as<std::remove_cvref_t<decltype(value)>, storage::Entry>)
+            {
+                if (isSlotKey(stateKey->m_key))
+                {
+                    if (auto accountNode = co_await m_mpt->read(stateRoot, table))
+                    {
+                        if (auto slotRoot = accountNode->value.storageRoot)
+                        {
+                            if (auto updatedSlotRoot =
+                                    co_await m_mpt->writeSlot(*slotRoot, tableKey, value))
+                            {
+                                updatedRoot =
+                                    co_await m_mpt->writeStorageRoot(stateRoot, table, *updatedSlotRoot);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    updatedRoot = co_await m_mpt->write(
+                        stateRoot, table, std::string(stateKey->m_key), value);
+                }
+            }
+        }
+
+        co_await ::bcos::storage2::writeOne(
+            m_backendStorage.get(), std::move(key), std::move(value));
+        co_return updatedRoot;
+    }
+
+    auto writeSome(::ranges::input_range auto keyValues) -> task::Task<void>
+    {
+        for (auto&& [key, value] : keyValues)
+        {
+            co_await writeOne(std::forward<decltype(key)>(key), std::forward<decltype(value)>(value));
+        }
+        co_return;
+    }
+
+    auto writeSome(::ranges::input_range auto keyValues, const MPTNodeHash& stateRoot)
+        -> task::Task<std::optional<MPTNodeHash>>
+    {
+        std::optional<MPTNodeHash> currentRoot = stateRoot;
+        for (auto&& [key, value] : keyValues)
+        {
+            auto updatedRoot =
+                co_await writeOne(std::forward<decltype(key)>(key),
+                    std::forward<decltype(value)>(value), *currentRoot);
+            if (!updatedRoot)
+            {
+                co_return std::nullopt;
+            }
+            currentRoot = std::move(updatedRoot);
+        }
+        co_return currentRoot;
+    }
+
+    auto removeOne(auto key) -> task::Task<void>
+    {
+        co_await removeOneImpl(std::move(key), false);
+    }
+
+    auto removeOne(auto key, DIRECT_TYPE /*unused*/) -> task::Task<void>
+    {
+        co_await removeOneImpl(std::move(key), true);
+    }
+
+    auto removeOne(auto key, const MPTNodeHash& stateRoot)
+        -> task::Task<std::optional<MPTNodeHash>>
+    {
+        co_return co_await removeOneWithStateRoot(std::move(key), stateRoot, false);
+    }
+
+    auto removeOne(auto key, const MPTNodeHash& stateRoot, DIRECT_TYPE /*unused*/)
+        -> task::Task<std::optional<MPTNodeHash>>
+    {
+        co_return co_await removeOneWithStateRoot(std::move(key), stateRoot, true);
+    }
+
+    auto removeSome(::ranges::input_range auto keys) -> task::Task<void>
+    {
+        for (auto&& key : keys)
+        {
+            co_await removeOne(std::forward<decltype(key)>(key));
+        }
+        co_return;
+    }
+
+    auto removeSome(::ranges::input_range auto keys, DIRECT_TYPE /*unused*/) -> task::Task<void>
+    {
+        for (auto&& key : keys)
+        {
+            co_await removeOne(std::forward<decltype(key)>(key), DIRECT);
+        }
+        co_return;
+    }
+
+    auto removeSome(::ranges::input_range auto keys, const MPTNodeHash& stateRoot)
+        -> task::Task<std::optional<MPTNodeHash>>
+    {
+        std::optional<MPTNodeHash> currentRoot = stateRoot;
+        for (auto&& key : keys)
+        {
+            auto updatedRoot =
+                co_await removeOne(std::forward<decltype(key)>(key), *currentRoot);
+            if (!updatedRoot)
+            {
+                co_return std::nullopt;
+            }
+            currentRoot = std::move(updatedRoot);
+        }
+        co_return currentRoot;
+    }
+
+    auto removeSome(
+        ::ranges::input_range auto keys, const MPTNodeHash& stateRoot, DIRECT_TYPE /*unused*/)
+        -> task::Task<std::optional<MPTNodeHash>>
+    {
+        std::optional<MPTNodeHash> currentRoot = stateRoot;
+        for (auto&& key : keys)
+        {
+            auto updatedRoot =
+                co_await removeOne(std::forward<decltype(key)>(key), *currentRoot, DIRECT);
+            if (!updatedRoot)
+            {
+                co_return std::nullopt;
+            }
+            currentRoot = std::move(updatedRoot);
+        }
+        co_return currentRoot;
+    }
+
+private:
+    task::Task<void> removeOneImpl(auto key, bool direct)
+    {
+        if (auto stateKey = toStateKeyView(key); stateKey && m_mpt)
+        {
+            if (auto currentRoot = co_await m_mpt->root(); currentRoot)
+            {
+                auto updatedRoot = co_await removeOneWithStateRoot(key, *currentRoot, direct);
+                if (updatedRoot)
+                {
+                    co_await m_mpt->setRoot(*updatedRoot);
+                }
+                co_return;
+            }
+        }
+
+        if (direct)
+        {
+            co_await ::bcos::storage2::removeOne(m_backendStorage.get(), std::move(key), DIRECT);
+        }
+        else
+        {
+            co_await ::bcos::storage2::removeOne(m_backendStorage.get(), std::move(key));
+        }
+        co_return;
+    }
+
+    auto removeOneWithStateRoot(auto key, const MPTNodeHash& stateRoot, bool direct)
+        -> task::Task<std::optional<MPTNodeHash>>
+    {
+        std::optional<MPTNodeHash> updatedRoot;
+
+        if (auto stateKey = toStateKeyView(key); stateKey && m_mpt)
+        {
+            auto hexStateKey = toHexStateKey(*stateKey);
+            auto& table = hexStateKey.table;
+            auto& tableKey = hexStateKey.key;
+
+            if (isSlotKey(stateKey->m_key))
+            {
+                if (auto accountNode = co_await m_mpt->read(stateRoot, table))
+                {
+                    if (auto slotRoot = accountNode->value.storageRoot)
+                    {
+                        if (auto updatedSlotRoot = co_await m_mpt->clearSlot(*slotRoot, tableKey))
+                        {
+                            updatedRoot =
+                                co_await m_mpt->writeStorageRoot(stateRoot, table, *updatedSlotRoot);
+                        }
+                    }
+                }
+            }
+            else
+            {
+                updatedRoot =
+                    co_await m_mpt->clear(stateRoot, table, std::string(stateKey->m_key));
+            }
+        }
+
+        if (direct)
+        {
+            co_await ::bcos::storage2::removeOne(m_backendStorage.get(), std::move(key), DIRECT);
+        }
+        else
+        {
+            co_await ::bcos::storage2::removeOne(m_backendStorage.get(), std::move(key));
+        }
+        co_return updatedRoot;
+    }
+
+    std::reference_wrapper<Backend> m_backendStorage;
+    std::optional<std::reference_wrapper<NodeStorage>> m_trieNodeStorage;
+    std::optional<Trie> m_mpt;
+
+    auto readBackendField(std::string_view table, std::string_view field)
+        -> task::Task<std::optional<storage::Entry>>
+    {
+        co_return co_await ::bcos::storage2::readOne(
+            m_backendStorage.get(), executor_v1::StateKeyView{table, field});
+    }
+
+    auto readAccountValueFromBackend(std::string_view table) -> task::Task<MPTAccountValue>
+    {
+        MPTAccountValue accountValue;
+        accountValue.codeHash =
+            co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH);
+        accountValue.code = co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::CODE);
+        accountValue.balance =
+            co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        accountValue.abi = co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::ABI);
+        accountValue.nonce = co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::NONCE);
+        accountValue.alive = co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::ALIVE);
+        accountValue.frozen =
+            co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::FROZEN);
+        accountValue.shard = co_await readBackendField(table, ledger::ACCOUNT_TABLE_FIELDS::SHARD);
+        co_return accountValue;
+    }
+
+    static auto getAccountField(const MPTAccountValue& accountValue, std::string_view field)
+        -> std::optional<storage::Entry>
+    {
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH)
+        {
+            return accountValue.codeHash;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE)
+        {
+            return accountValue.code;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::BALANCE)
+        {
+            return accountValue.balance;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ABI)
+        {
+            return accountValue.abi;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::NONCE)
+        {
+            return accountValue.nonce;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ALIVE)
+        {
+            return accountValue.alive;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::FROZEN)
+        {
+            return accountValue.frozen;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::SHARD)
+        {
+            return accountValue.shard;
+        }
+        return std::nullopt;
+    }
+
+    static bool setAccountField(
+        MPTAccountValue& accountValue, std::string_view field, const storage::Entry& value)
+    {
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH)
+        {
+            accountValue.codeHash = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE)
+        {
+            accountValue.code = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::BALANCE)
+        {
+            accountValue.balance = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ABI)
+        {
+            accountValue.abi = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::NONCE)
+        {
+            accountValue.nonce = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ALIVE)
+        {
+            accountValue.alive = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::FROZEN)
+        {
+            accountValue.frozen = value;
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::SHARD)
+        {
+            accountValue.shard = value;
+            return true;
+        }
+        return false;
+    }
+
+    static bool clearAccountField(MPTAccountValue& accountValue, std::string_view field)
+    {
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH)
+        {
+            if (!accountValue.codeHash)
+            {
+                return false;
+            }
+            accountValue.codeHash.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::CODE)
+        {
+            if (!accountValue.code)
+            {
+                return false;
+            }
+            accountValue.code.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::BALANCE)
+        {
+            if (!accountValue.balance)
+            {
+                return false;
+            }
+            accountValue.balance.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ABI)
+        {
+            if (!accountValue.abi)
+            {
+                return false;
+            }
+            accountValue.abi.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::NONCE)
+        {
+            if (!accountValue.nonce)
+            {
+                return false;
+            }
+            accountValue.nonce.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::ALIVE)
+        {
+            if (!accountValue.alive)
+            {
+                return false;
+            }
+            accountValue.alive.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::FROZEN)
+        {
+            if (!accountValue.frozen)
+            {
+                return false;
+            }
+            accountValue.frozen.reset();
+            return true;
+        }
+        if (field == ledger::ACCOUNT_TABLE_FIELDS::SHARD)
+        {
+            if (!accountValue.shard)
+            {
+                return false;
+            }
+            accountValue.shard.reset();
+            return true;
+        }
+        return false;
+    }
+
+    static auto toStateKeyView(const auto& key) -> std::optional<executor_v1::StateKeyView>
+    {
+        using InputKey = std::remove_cvref_t<decltype(key)>;
+        if constexpr (std::same_as<InputKey, executor_v1::StateKey>)
+        {
+            return executor_v1::StateKeyView(key);
+        }
+        else if constexpr (std::same_as<InputKey, executor_v1::StateKeyView>)
+        {
+            return key;
+        }
+        else
+        {
+            return std::nullopt;
+        }
+    }
+
+    static auto toHexPathKey(std::string_view keyPart) -> std::string
+    {
+        return bcos::toHex(keyPart);
+    }
+
+    static bool isSlotKey(std::string_view key) noexcept { return Trie::isSlotKey(key); }
+
+    struct HexStateKey
+    {
+        std::string table;
+        std::string key;
+    };
+
+    static auto toHexStateKey(const executor_v1::StateKeyView& key) -> HexStateKey
+    {
+        return HexStateKey{toHexPathKey(key.m_table), toHexPathKey(key.m_key)};
+    }
+
+    static bool pathStartsWith(std::string_view key, const MPTPath& path) noexcept
+    {
+        if (key.size() < path.size())
+        {
+            return false;
+        }
+
+        for (size_t index = 0; index < path.size(); ++index)
+        {
+            if (static_cast<uint8_t>(hexCharToNibble(key[index])) != path[index])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool pathEquals(std::string_view key, const MPTPath& path) noexcept
+    {
+        return key.size() == path.size() && pathStartsWith(key, path);
+    }
+
+    static int hexCharToNibble(char c)
+    {
+        if (c >= '0' && c <= '9')
+        {
+            return c - '0';
+        }
+        if (c >= 'a' && c <= 'f')
+        {
+            return 10 + (c - 'a');
+        }
+        if (c >= 'A' && c <= 'F')
+        {
+            return 10 + (c - 'A');
+        }
+        throw std::runtime_error("Invalid hex character in MPT path");
+    }
+};
+
+}  // namespace bcos::storage2

--- a/bcos-framework/test/CMakeLists.txt
+++ b/bcos-framework/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_BINARY_NAME test-bcos-framework)
 include(SearchTestCases)
 set(SOURCES unittests/storage2/TestMemoryStorage.cpp
     unittests/storage2/TestAnyStorage.cpp
+    unittests/storage2/TestMerkleStorage.cpp
     unittests/storage/TestCondition.cpp
     unittests/main/main.cpp
     unittests/interfaces/ExecutorTest.cpp

--- a/bcos-framework/test/unittests/storage2/TestMerkleStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestMerkleStorage.cpp
@@ -1,0 +1,1230 @@
+#include "bcos-storage/bcos-storage/RocksDBStorage2.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MerkleStorage.h"
+#include "bcos-task/Wait.h"
+#include <boost/test/unit_test.hpp>
+#include <range/v3/algorithm/find.hpp>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::storage2::memory_storage;
+
+namespace
+{
+using BackendStorage = MemoryStorage<executor_v1::StateKey, storage::Entry, ORDERED>;
+using LogicalBackendStorage =
+    MemoryStorage<executor_v1::StateKey, storage::Entry, Attribute(ORDERED | LOGICAL_DELETION)>;
+using NodeStorage = MemoryStorage<MPTNodeHash, storage::Entry, ORDERED>;
+
+storage::Entry makeEntry(std::string_view value)
+{
+    storage::Entry entry;
+    entry.set(std::string(value));
+    return entry;
+}
+
+std::string fixedBytes(size_t size, char fill, char tail)
+{
+    std::string value(size, fill);
+    value.back() = tail;
+    return value;
+}
+
+std::string stateKeyId(const executor_v1::StateKey& key) { return key.m_tableAndKey; }
+
+MPTNodeHash emptyRoot() { return {}; }
+
+task::Task<MPTNodeHash> bootstrapRootWithSlot(
+    MPT<NodeStorage>& trie, std::string_view address, std::string_view slotKey, std::string_view value)
+{
+    auto slotRoot = co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey), makeEntry(value));
+    if (!slotRoot)
+    {
+        throw std::runtime_error("bootstrapRootWithSlot: failed to create slot root");
+    }
+    auto root = co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address), *slotRoot);
+    if (!root)
+    {
+        throw std::runtime_error("bootstrapRootWithSlot: failed to create account root");
+    }
+    co_return *root;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(TestMerkleStorage)
+
+BOOST_AUTO_TEST_CASE(writeReadAccountField)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto balanceKey =
+            executor_v1::StateKey("/apps/hello", ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+
+        auto root1 = co_await storage.writeOne(balanceKey, makeEntry("100"), emptyRoot());
+        BOOST_REQUIRE(root1);
+
+        auto trieValue = co_await storage.readOne(balanceKey, *root1);
+        BOOST_REQUIRE(trieValue);
+        BOOST_CHECK_EQUAL(trieValue->get(), "100");
+
+        auto backendValue = co_await storage.readOne(balanceKey);
+        BOOST_REQUIRE(backendValue);
+        BOOST_CHECK_EQUAL(backendValue->get(), "100");
+
+        auto root2 = co_await storage.writeOne(balanceKey, makeEntry("200"), *root1);
+        BOOST_REQUIRE(root2);
+
+        auto oldValue = co_await storage.readOne(balanceKey, *root1);
+        BOOST_REQUIRE(oldValue);
+        BOOST_CHECK_EQUAL(oldValue->get(), "100");
+
+        auto newValue = co_await storage.readOne(balanceKey, *root2);
+        BOOST_REQUIRE(newValue);
+        BOOST_CHECK_EQUAL(newValue->get(), "200");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeReadMultipleAccountFields)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto balanceKey =
+            executor_v1::StateKey("/apps/account", ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto nonceKey =
+            executor_v1::StateKey("/apps/account", ledger::ACCOUNT_TABLE_FIELDS::NONCE);
+
+        auto root1 = co_await storage.writeOne(balanceKey, makeEntry("100"), emptyRoot());
+        BOOST_REQUIRE(root1);
+
+        auto root2 = co_await storage.writeOne(nonceKey, makeEntry("1"), *root1);
+        BOOST_REQUIRE(root2);
+
+        auto balanceValue = co_await storage.readOne(balanceKey, *root2);
+        BOOST_REQUIRE(balanceValue);
+        BOOST_CHECK_EQUAL(balanceValue->get(), "100");
+
+        auto nonceValue = co_await storage.readOne(nonceKey, *root2);
+        BOOST_REQUIRE(nonceValue);
+        BOOST_CHECK_EQUAL(nonceValue->get(), "1");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeReadSlotValue)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        std::string table = "/apps/slot";
+        std::string slotKey = "0123456789abcdef0123456789abcdef";
+
+        auto slotRoot = co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey), makeEntry("7"));
+        BOOST_REQUIRE(slotRoot);
+
+        auto accountRoot =
+            co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(table), *slotRoot);
+        BOOST_REQUIRE(accountRoot);
+
+        auto stateKey = executor_v1::StateKey(table, slotKey);
+        auto slotValue = co_await storage.readOne(stateKey, *accountRoot);
+        BOOST_REQUIRE(slotValue);
+        BOOST_CHECK_EQUAL(slotValue->get(), "7");
+
+        auto updatedRoot = co_await storage.writeOne(stateKey, makeEntry("9"), *accountRoot);
+        BOOST_REQUIRE(updatedRoot);
+
+        auto updatedSlotValue = co_await storage.readOne(stateKey, *updatedRoot);
+        BOOST_REQUIRE(updatedSlotValue);
+        BOOST_CHECK_EQUAL(updatedSlotValue->get(), "9");
+
+        auto backendValue = co_await storage.readOne(stateKey);
+        BOOST_REQUIRE(backendValue);
+        BOOST_CHECK_EQUAL(backendValue->get(), "9");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeReadComplexFixedAddressAndSlotKeys)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address1 = fixedBytes(20, 'a', '1');
+        auto address2 = fixedBytes(20, 'a', '2');
+        auto slotKey1 = fixedBytes(32, 'k', '1');
+        auto slotKey2 = fixedBytes(32, 'k', '2');
+        auto slotKey3 = fixedBytes(32, 'k', '3');
+
+        BOOST_REQUIRE_EQUAL(address1.size(), 20);
+        BOOST_REQUIRE_EQUAL(address2.size(), 20);
+        BOOST_REQUIRE_EQUAL(slotKey1.size(), 32);
+        BOOST_REQUIRE_EQUAL(slotKey2.size(), 32);
+        BOOST_REQUIRE_EQUAL(slotKey3.size(), 32);
+
+        auto slotRoot1 = co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey1), makeEntry("A1"));
+        BOOST_REQUIRE(slotRoot1);
+        auto slotRoot2 = co_await trie.writeSlot(*slotRoot1, bcos::toHex(slotKey2), makeEntry("A2"));
+        BOOST_REQUIRE(slotRoot2);
+        auto root1 = co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address1), *slotRoot2);
+        BOOST_REQUIRE(root1);
+
+        auto slotRoot3 = co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey3), makeEntry("B3"));
+        BOOST_REQUIRE(slotRoot3);
+        auto root2 = co_await trie.writeStorageRoot(*root1, bcos::toHex(address2), *slotRoot3);
+        BOOST_REQUIRE(root2);
+
+        auto address1Slot1 = executor_v1::StateKey(address1, slotKey1);
+        auto address1Slot2 = executor_v1::StateKey(address1, slotKey2);
+        auto address2Slot3 = executor_v1::StateKey(address2, slotKey3);
+
+        auto valueA1Root2 = co_await storage.readOne(address1Slot1, *root2);
+        BOOST_REQUIRE(valueA1Root2);
+        BOOST_CHECK_EQUAL(valueA1Root2->get(), "A1");
+
+        auto valueA2Root2 = co_await storage.readOne(address1Slot2, *root2);
+        BOOST_REQUIRE(valueA2Root2);
+        BOOST_CHECK_EQUAL(valueA2Root2->get(), "A2");
+
+        auto valueB3Root2 = co_await storage.readOne(address2Slot3, *root2);
+        BOOST_REQUIRE(valueB3Root2);
+        BOOST_CHECK_EQUAL(valueB3Root2->get(), "B3");
+
+        auto root3 = co_await storage.writeOne(address1Slot1, makeEntry("A1-v2"), *root2);
+        BOOST_REQUIRE(root3);
+
+        auto oldValueA1 = co_await storage.readOne(address1Slot1, *root2);
+        BOOST_REQUIRE(oldValueA1);
+        BOOST_CHECK_EQUAL(oldValueA1->get(), "A1");
+
+        auto newValueA1 = co_await storage.readOne(address1Slot1, *root3);
+        BOOST_REQUIRE(newValueA1);
+        BOOST_CHECK_EQUAL(newValueA1->get(), "A1-v2");
+
+        auto unchangedA2 = co_await storage.readOne(address1Slot2, *root3);
+        BOOST_REQUIRE(unchangedA2);
+        BOOST_CHECK_EQUAL(unchangedA2->get(), "A2");
+
+        auto unchangedB3 = co_await storage.readOne(address2Slot3, *root3);
+        BOOST_REQUIRE(unchangedB3);
+        BOOST_CHECK_EQUAL(unchangedB3->get(), "B3");
+
+        auto root4 = co_await storage.writeOne(address2Slot3, makeEntry("B3-v2"), *root3);
+        BOOST_REQUIRE(root4);
+
+        auto valueA1Root4 = co_await storage.readOne(address1Slot1, *root4);
+        BOOST_REQUIRE(valueA1Root4);
+        BOOST_CHECK_EQUAL(valueA1Root4->get(), "A1-v2");
+
+        auto valueB3Root4 = co_await storage.readOne(address2Slot3, *root4);
+        BOOST_REQUIRE(valueB3Root4);
+        BOOST_CHECK_EQUAL(valueB3Root4->get(), "B3-v2");
+
+        auto backendA1 = co_await storage.readOne(address1Slot1);
+        BOOST_REQUIRE(backendA1);
+        BOOST_CHECK_EQUAL(backendA1->get(), "A1-v2");
+
+        auto backendB3 = co_await storage.readOne(address2Slot3);
+        BOOST_REQUIRE(backendB3);
+        BOOST_CHECK_EQUAL(backendB3->get(), "B3-v2");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeReadBranchingRootsFromSameBase)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'b', '0');
+        auto slotKey1 = fixedBytes(32, 'x', '1');
+        auto slotKey2 = fixedBytes(32, 'x', '2');
+        auto slotKey3 = fixedBytes(32, 'x', '3');
+
+        auto slotRoot = co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey1), makeEntry("base"));
+        BOOST_REQUIRE(slotRoot);
+        auto baseRoot =
+            co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address), *slotRoot);
+        BOOST_REQUIRE(baseRoot);
+
+        auto stateKey1 = executor_v1::StateKey(address, slotKey1);
+        auto stateKey2 = executor_v1::StateKey(address, slotKey2);
+        auto stateKey3 = executor_v1::StateKey(address, slotKey3);
+
+        auto branchRoot1 = co_await storage.writeOne(stateKey2, makeEntry("branch-1"), *baseRoot);
+        BOOST_REQUIRE(branchRoot1);
+        auto branchRoot2 = co_await storage.writeOne(stateKey3, makeEntry("branch-2"), *baseRoot);
+        BOOST_REQUIRE(branchRoot2);
+
+        auto baseValue1 = co_await storage.readOne(stateKey1, *baseRoot);
+        BOOST_REQUIRE(baseValue1);
+        BOOST_CHECK_EQUAL(baseValue1->get(), "base");
+        BOOST_CHECK(!(co_await storage.readOne(stateKey2, *baseRoot)));
+        BOOST_CHECK(!(co_await storage.readOne(stateKey3, *baseRoot)));
+
+        auto branch1Value1 = co_await storage.readOne(stateKey1, *branchRoot1);
+        BOOST_REQUIRE(branch1Value1);
+        BOOST_CHECK_EQUAL(branch1Value1->get(), "base");
+        auto branch1Value2 = co_await storage.readOne(stateKey2, *branchRoot1);
+        BOOST_REQUIRE(branch1Value2);
+        BOOST_CHECK_EQUAL(branch1Value2->get(), "branch-1");
+        BOOST_CHECK(!(co_await storage.readOne(stateKey3, *branchRoot1)));
+
+        auto branch2Value1 = co_await storage.readOne(stateKey1, *branchRoot2);
+        BOOST_REQUIRE(branch2Value1);
+        BOOST_CHECK_EQUAL(branch2Value1->get(), "base");
+        BOOST_CHECK(!(co_await storage.readOne(stateKey2, *branchRoot2)));
+        auto branch2Value3 = co_await storage.readOne(stateKey3, *branchRoot2);
+        BOOST_REQUIRE(branch2Value3);
+        BOOST_CHECK_EQUAL(branch2Value3->get(), "branch-2");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeReadMixedAccountFieldAndSlotAcrossRoots)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'c', '9');
+        auto slotKey = fixedBytes(32, 's', '9');
+        auto balanceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto nonceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::NONCE);
+        auto slotStateKey = executor_v1::StateKey(address, slotKey);
+
+        auto slotRoot =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey), makeEntry("slot-v1"));
+        BOOST_REQUIRE(slotRoot);
+        auto root1 =
+            co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address), *slotRoot);
+        BOOST_REQUIRE(root1);
+
+        auto root2 = co_await storage.writeOne(balanceKey, makeEntry("100"), *root1);
+        BOOST_REQUIRE(root2);
+        auto root3 = co_await storage.writeOne(nonceKey, makeEntry("7"), *root2);
+        BOOST_REQUIRE(root3);
+
+        auto slotValueRoot3 = co_await storage.readOne(slotStateKey, *root3);
+        BOOST_REQUIRE(slotValueRoot3);
+        BOOST_CHECK_EQUAL(slotValueRoot3->get(), "slot-v1");
+        auto balanceRoot3 = co_await storage.readOne(balanceKey, *root3);
+        BOOST_REQUIRE(balanceRoot3);
+        BOOST_CHECK_EQUAL(balanceRoot3->get(), "100");
+        auto nonceRoot3 = co_await storage.readOne(nonceKey, *root3);
+        BOOST_REQUIRE(nonceRoot3);
+        BOOST_CHECK_EQUAL(nonceRoot3->get(), "7");
+
+        auto root4 = co_await storage.writeOne(slotStateKey, makeEntry("slot-v2"), *root3);
+        BOOST_REQUIRE(root4);
+
+        auto slotValueRoot4 = co_await storage.readOne(slotStateKey, *root4);
+        BOOST_REQUIRE(slotValueRoot4);
+        BOOST_CHECK_EQUAL(slotValueRoot4->get(), "slot-v2");
+        auto balanceRoot4 = co_await storage.readOne(balanceKey, *root4);
+        BOOST_REQUIRE(balanceRoot4);
+        BOOST_CHECK_EQUAL(balanceRoot4->get(), "100");
+        auto nonceRoot4 = co_await storage.readOne(nonceKey, *root4);
+        BOOST_REQUIRE(nonceRoot4);
+        BOOST_CHECK_EQUAL(nonceRoot4->get(), "7");
+
+        auto oldSlotValue = co_await storage.readOne(slotStateKey, *root3);
+        BOOST_REQUIRE(oldSlotValue);
+        BOOST_CHECK_EQUAL(oldSlotValue->get(), "slot-v1");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeReadHistoricalRootsForSequentialSlotUpdates)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'd', '4');
+        std::vector<std::string> slotKeys = {fixedBytes(32, 'p', '1'), fixedBytes(32, 'p', '2'),
+            fixedBytes(32, 'p', '3'), fixedBytes(32, 'p', '4')};
+
+        auto slotRoot =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKeys[0]), makeEntry("v1"));
+        BOOST_REQUIRE(slotRoot);
+        auto initialRoot =
+            co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address), *slotRoot);
+        BOOST_REQUIRE(initialRoot);
+
+        std::vector<MPTNodeHash> roots;
+        roots.push_back(*initialRoot);
+
+        auto updatedRoot1 = co_await storage.writeOne(
+            executor_v1::StateKey(address, slotKeys[1]), makeEntry("v2"), roots.back());
+        BOOST_REQUIRE(updatedRoot1);
+        roots.push_back(*updatedRoot1);
+
+        auto updatedRoot2 = co_await storage.writeOne(
+            executor_v1::StateKey(address, slotKeys[2]), makeEntry("v3"), roots.back());
+        BOOST_REQUIRE(updatedRoot2);
+        roots.push_back(*updatedRoot2);
+
+        auto updatedRoot3 = co_await storage.writeOne(
+            executor_v1::StateKey(address, slotKeys[3]), makeEntry("v4"), roots.back());
+        BOOST_REQUIRE(updatedRoot3);
+        roots.push_back(*updatedRoot3);
+
+        for (size_t rootIndex = 0; rootIndex < roots.size(); ++rootIndex)
+        {
+            for (size_t slotIndex = 0; slotIndex < slotKeys.size(); ++slotIndex)
+            {
+                auto value = co_await storage.readOne(
+                    executor_v1::StateKey(address, slotKeys[slotIndex]), roots[rootIndex]);
+
+                if (slotIndex <= rootIndex)
+                {
+                    BOOST_REQUIRE(value);
+                    BOOST_CHECK_EQUAL(value->get(), "v" + std::to_string(slotIndex + 1));
+                }
+                else
+                {
+                    BOOST_CHECK(!value);
+                }
+            }
+        }
+
+        auto latestBackend = co_await storage.readOne(executor_v1::StateKey(address, slotKeys[3]));
+        BOOST_REQUIRE(latestBackend);
+        BOOST_CHECK_EQUAL(latestBackend->get(), "v4");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeUsesLogicalDeletionByDefault)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalBackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<LogicalBackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'e', '1');
+        auto slotKey = fixedBytes(32, 'r', '1');
+        auto balanceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto slotStateKey = executor_v1::StateKey(address, slotKey);
+
+        auto slotRoot =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey), makeEntry("slot-v1"));
+        BOOST_REQUIRE(slotRoot);
+        auto root0 = co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address), *slotRoot);
+        BOOST_REQUIRE(root0);
+
+        auto root1 = co_await storage.writeOne(balanceKey, makeEntry("100"), *root0);
+        BOOST_REQUIRE(root1);
+        auto root3 = co_await storage.removeOne(balanceKey, *root1);
+        BOOST_REQUIRE(root3);
+
+        auto oldBalance = co_await storage.readOne(balanceKey, *root1);
+        BOOST_REQUIRE(oldBalance);
+        BOOST_CHECK_EQUAL(oldBalance->get(), "100");
+        BOOST_CHECK(!(co_await storage.readOne(balanceKey, *root3)));
+
+        auto slotValue = co_await storage.readOne(slotStateKey, *root3);
+        BOOST_REQUIRE(slotValue);
+        BOOST_CHECK_EQUAL(slotValue->get(), "slot-v1");
+
+        auto backendRead = co_await storage.readOne(balanceKey);
+        BOOST_CHECK(!backendRead);
+
+        auto range = co_await storage2::range(backendStorage);
+        bool sawDeleted = false;
+        while (auto item = co_await range.next())
+        {
+            auto const& [key, value] = *item;
+            if (key == balanceKey)
+            {
+                sawDeleted = std::holds_alternative<storage2::DELETED_TYPE>(value);
+            }
+        }
+        BOOST_CHECK(sawDeleted);
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeDirectUsesPhysicalDeletion)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalBackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<LogicalBackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'f', '2');
+        auto slotKey = fixedBytes(32, 't', '2');
+        auto slotStateKey = executor_v1::StateKey(address, slotKey);
+
+        auto slotRoot =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey), makeEntry("slot-v1"));
+        BOOST_REQUIRE(slotRoot);
+        auto root1 = co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address), *slotRoot);
+        BOOST_REQUIRE(root1);
+        auto root2 = co_await storage.removeOne(slotStateKey, *root1, DIRECT);
+        BOOST_REQUIRE(root2);
+
+        auto oldValue = co_await storage.readOne(slotStateKey, *root1);
+        BOOST_REQUIRE(oldValue);
+        BOOST_CHECK_EQUAL(oldValue->get(), "slot-v1");
+        BOOST_CHECK(!(co_await storage.readOne(slotStateKey, *root2)));
+        BOOST_CHECK(!(co_await storage.readOne(slotStateKey)));
+
+        auto range = co_await storage2::range(backendStorage);
+        bool keyStillExists = false;
+        while (auto item = co_await range.next())
+        {
+            auto const& key = std::get<0>(*item);
+            if (key == slotStateKey)
+            {
+                keyStillExists = true;
+            }
+        }
+        BOOST_CHECK(!keyStillExists);
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeSomeAndRemoveSomeReturnChainedStateRoot)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address1 = fixedBytes(20, 'w', '1');
+        auto address2 = fixedBytes(20, 'w', '2');
+        auto slotKey1 = fixedBytes(32, 'y', '1');
+        auto slotKey2 = fixedBytes(32, 'y', '2');
+
+        auto slotRoot1 =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey1), makeEntry("init-1"));
+        BOOST_REQUIRE(slotRoot1);
+        auto root0 =
+            co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address1), *slotRoot1);
+        BOOST_REQUIRE(root0);
+        auto slotRoot2 =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey2), makeEntry("init-2"));
+        BOOST_REQUIRE(slotRoot2);
+        auto root1 =
+            co_await trie.writeStorageRoot(*root0, bcos::toHex(address2), *slotRoot2);
+        BOOST_REQUIRE(root1);
+
+        auto balanceKey1 = executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto nonceKey1 = executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::NONCE);
+        auto slotStateKey1 = executor_v1::StateKey(address1, slotKey1);
+        auto balanceKey2 = executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto slotStateKey2 = executor_v1::StateKey(address2, slotKey2);
+
+        std::vector<std::tuple<executor_v1::StateKey, storage::Entry>> writes = {
+            {balanceKey1, makeEntry("101")},
+            {nonceKey1, makeEntry("7")},
+            {slotStateKey1, makeEntry("slot-1-v2")},
+            {balanceKey2, makeEntry("202")},
+            {slotStateKey2, makeEntry("slot-2-v2")},
+        };
+
+        auto root2 = co_await storage.writeSome(writes, *root1);
+        BOOST_REQUIRE(root2);
+
+        auto balance1 = co_await storage.readOne(balanceKey1, *root2);
+        BOOST_REQUIRE(balance1);
+        BOOST_CHECK_EQUAL(balance1->get(), "101");
+        auto nonce1 = co_await storage.readOne(nonceKey1, *root2);
+        BOOST_REQUIRE(nonce1);
+        BOOST_CHECK_EQUAL(nonce1->get(), "7");
+        auto slot1 = co_await storage.readOne(slotStateKey1, *root2);
+        BOOST_REQUIRE(slot1);
+        BOOST_CHECK_EQUAL(slot1->get(), "slot-1-v2");
+        auto balance2 = co_await storage.readOne(balanceKey2, *root2);
+        BOOST_REQUIRE(balance2);
+        BOOST_CHECK_EQUAL(balance2->get(), "202");
+        auto slot2 = co_await storage.readOne(slotStateKey2, *root2);
+        BOOST_REQUIRE(slot2);
+        BOOST_CHECK_EQUAL(slot2->get(), "slot-2-v2");
+
+        std::vector<executor_v1::StateKey> removes = {nonceKey1, slotStateKey2};
+        auto root3 = co_await storage.removeSome(removes, *root2);
+        BOOST_REQUIRE(root3);
+
+        auto oldNonce1 = co_await storage.readOne(nonceKey1, *root2);
+        BOOST_REQUIRE(oldNonce1);
+        BOOST_CHECK_EQUAL(oldNonce1->get(), "7");
+        auto oldSlot2 = co_await storage.readOne(slotStateKey2, *root2);
+        BOOST_REQUIRE(oldSlot2);
+        BOOST_CHECK_EQUAL(oldSlot2->get(), "slot-2-v2");
+
+        BOOST_CHECK(!(co_await storage.readOne(nonceKey1, *root3)));
+        BOOST_CHECK(!(co_await storage.readOne(slotStateKey2, *root3)));
+
+        auto retainedBalance1 = co_await storage.readOne(balanceKey1, *root3);
+        BOOST_REQUIRE(retainedBalance1);
+        BOOST_CHECK_EQUAL(retainedBalance1->get(), "101");
+        auto retainedSlot1 = co_await storage.readOne(slotStateKey1, *root3);
+        BOOST_REQUIRE(retainedSlot1);
+        BOOST_CHECK_EQUAL(retainedSlot1->get(), "slot-1-v2");
+        auto retainedBalance2 = co_await storage.readOne(balanceKey2, *root3);
+        BOOST_REQUIRE(retainedBalance2);
+        BOOST_CHECK_EQUAL(retainedBalance2->get(), "202");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(alternatingBackendReadWriteRemoveOperations)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto address1 = fixedBytes(20, 'g', '1');
+        auto address2 = fixedBytes(20, 'g', '2');
+        auto address3 = fixedBytes(20, 'g', '3');
+        auto slotKey1 = fixedBytes(32, 'u', '1');
+        auto slotKey2 = fixedBytes(32, 'u', '2');
+        auto slotKey3 = fixedBytes(32, 'u', '3');
+
+        std::vector<executor_v1::StateKey> candidates = {
+            executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::BALANCE),
+            executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::NONCE),
+            executor_v1::StateKey(address1, slotKey1),
+            executor_v1::StateKey(address1, slotKey2),
+            executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::BALANCE),
+            executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::NONCE),
+            executor_v1::StateKey(address2, slotKey2),
+            executor_v1::StateKey(address2, slotKey3),
+            executor_v1::StateKey(address3, ledger::ACCOUNT_TABLE_FIELDS::BALANCE),
+            executor_v1::StateKey(address3, ledger::ACCOUNT_TABLE_FIELDS::NONCE),
+            executor_v1::StateKey(address3, slotKey1),
+            executor_v1::StateKey(address3, slotKey3),
+        };
+
+        std::map<std::string, std::string> expected;
+        size_t operations = 0;
+
+        for (size_t i = 0; i < 60; ++i)
+        {
+            switch (i % 6)
+            {
+            case 0:
+            {
+                std::vector<std::tuple<executor_v1::StateKey, storage::Entry>> writes;
+                for (size_t offset = 0; offset < 2; ++offset)
+                {
+                    auto const& key = candidates[(i + offset * 3) % candidates.size()];
+                    auto value = "batch-" + std::to_string(i) + "-" + std::to_string(offset);
+                    writes.emplace_back(key, makeEntry(value));
+                    expected[stateKeyId(key)] = value;
+                }
+                co_await storage.writeSome(writes);
+                break;
+            }
+            case 1:
+            {
+                std::vector<executor_v1::StateKey> reads;
+                for (size_t offset = 0; offset < 3; ++offset)
+                {
+                    reads.emplace_back(candidates[(i + offset * 5) % candidates.size()]);
+                }
+                auto values = co_await storage.readSome(reads);
+                for (size_t index = 0; index < reads.size(); ++index)
+                {
+                    auto it = expected.find(stateKeyId(reads[index]));
+                    if (it == expected.end())
+                    {
+                        BOOST_CHECK(!values[index]);
+                    }
+                    else
+                    {
+                        BOOST_REQUIRE(values[index]);
+                        BOOST_CHECK_EQUAL(values[index]->get(), it->second);
+                    }
+                }
+                break;
+            }
+            case 2:
+            {
+                auto const& key = candidates[(i * 7) % candidates.size()];
+                auto value = "single-" + std::to_string(i);
+                co_await storage.writeOne(key, makeEntry(value));
+                expected[stateKeyId(key)] = value;
+                break;
+            }
+            case 3:
+            {
+                auto const& key = candidates[(i * 11 + 1) % candidates.size()];
+                auto value = co_await storage.readOne(key);
+                auto it = expected.find(stateKeyId(key));
+                if (it == expected.end())
+                {
+                    BOOST_CHECK(!value);
+                }
+                else
+                {
+                    BOOST_REQUIRE(value);
+                    BOOST_CHECK_EQUAL(value->get(), it->second);
+                }
+                break;
+            }
+            case 4:
+            {
+                std::vector<executor_v1::StateKey> removes;
+                for (size_t offset = 0; offset < 2; ++offset)
+                {
+                    auto const& key = candidates[(i + offset * 4 + 2) % candidates.size()];
+                    removes.emplace_back(key);
+                    expected.erase(stateKeyId(key));
+                }
+                co_await storage.removeSome(removes);
+                break;
+            }
+            case 5:
+            {
+                auto const& key = candidates[(i * 13 + 3) % candidates.size()];
+                expected.erase(stateKeyId(key));
+                co_await storage.removeOne(key);
+                break;
+            }
+            default:
+                BOOST_FAIL("Unexpected operation selector");
+            }
+            ++operations;
+        }
+
+        BOOST_CHECK_GE(operations, 50);
+
+        auto finalValues = co_await storage.readSome(candidates);
+        for (size_t index = 0; index < candidates.size(); ++index)
+        {
+            auto it = expected.find(stateKeyId(candidates[index]));
+            if (it == expected.end())
+            {
+                BOOST_CHECK(!finalValues[index]);
+            }
+            else
+            {
+                BOOST_REQUIRE(finalValues[index]);
+                BOOST_CHECK_EQUAL(finalValues[index]->get(), it->second);
+            }
+        }
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(alternatingStateRootReadWriteRemoveOperations)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address1 = fixedBytes(20, 'h', '1');
+        auto address2 = fixedBytes(20, 'h', '2');
+        auto slotKey1 = fixedBytes(32, 'v', '1');
+        auto slotKey2 = fixedBytes(32, 'v', '2');
+        auto slotKey3 = fixedBytes(32, 'v', '3');
+        auto slotKey4 = fixedBytes(32, 'v', '4');
+
+        auto slotRoot1 =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey1), makeEntry("init-a1"));
+        BOOST_REQUIRE(slotRoot1);
+        auto root0 =
+            co_await trie.writeStorageRoot(emptyRoot(), bcos::toHex(address1), *slotRoot1);
+        BOOST_REQUIRE(root0);
+        auto slotRoot2 =
+            co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey2), makeEntry("init-b2"));
+        BOOST_REQUIRE(slotRoot2);
+        auto root1 =
+            co_await trie.writeStorageRoot(*root0, bcos::toHex(address2), *slotRoot2);
+        BOOST_REQUIRE(root1);
+
+        std::vector<executor_v1::StateKey> candidates = {
+            executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::BALANCE),
+            executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::NONCE),
+            executor_v1::StateKey(address1, slotKey1),
+            executor_v1::StateKey(address1, slotKey3),
+            executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::BALANCE),
+            executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::NONCE),
+            executor_v1::StateKey(address2, slotKey2),
+            executor_v1::StateKey(address2, slotKey4),
+        };
+
+        std::map<std::string, std::string> expected = {
+            {stateKeyId(candidates[2]), "init-a1"},
+            {stateKeyId(candidates[6]), "init-b2"},
+        };
+
+        MPTNodeHash currentRoot = *root1;
+        size_t operations = 0;
+        std::vector<std::pair<MPTNodeHash, std::map<std::string, std::string>>> snapshots;
+        snapshots.emplace_back(currentRoot, expected);
+
+        for (size_t i = 0; i < 60; ++i)
+        {
+            if (i % 3 == 0)
+            {
+                auto const& key = candidates[(i * 5 + 1) % candidates.size()];
+                auto value = "root-write-" + std::to_string(i);
+                auto updatedRoot = co_await storage.writeOne(key, makeEntry(value), currentRoot);
+                BOOST_REQUIRE(updatedRoot);
+                currentRoot = *updatedRoot;
+                expected[stateKeyId(key)] = value;
+            }
+            else if (i % 3 == 1)
+            {
+                auto const& key = candidates[(i * 7 + 2) % candidates.size()];
+                auto value = co_await storage.readOne(key, currentRoot);
+                auto it = expected.find(stateKeyId(key));
+                if (it == expected.end())
+                {
+                    BOOST_CHECK(!value);
+                }
+                else
+                {
+                    BOOST_REQUIRE(value);
+                    BOOST_CHECK_EQUAL(value->get(), it->second);
+                }
+            }
+            else
+            {
+                executor_v1::StateKey const* existingKey = nullptr;
+                for (auto const& candidate : candidates)
+                {
+                    if (expected.contains(stateKeyId(candidate)))
+                    {
+                        existingKey = &candidate;
+                        break;
+                    }
+                }
+                BOOST_REQUIRE(existingKey != nullptr);
+                auto updatedRoot = co_await storage.removeOne(*existingKey, currentRoot);
+                BOOST_REQUIRE(updatedRoot);
+                expected.erase(stateKeyId(*existingKey));
+                currentRoot = *updatedRoot;
+            }
+
+            ++operations;
+            if ((i + 1) % 15 == 0)
+            {
+                snapshots.emplace_back(currentRoot, expected);
+            }
+        }
+
+        BOOST_CHECK_GE(operations, 50);
+
+        for (auto const& [root, snapshot] : snapshots)
+        {
+            for (auto const& candidate : candidates)
+            {
+                auto value = co_await storage.readOne(candidate, root);
+                auto it = snapshot.find(stateKeyId(candidate));
+                if (it == snapshot.end())
+                {
+                    BOOST_CHECK(!value);
+                }
+                else
+                {
+                    BOOST_REQUIRE(value);
+                    BOOST_CHECK_EQUAL(value->get(), it->second);
+                }
+            }
+        }
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeSomeStateRootPreservesHistoricalRoots)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'i', '1');
+        auto slotKey1 = fixedBytes(32, 'z', '1');
+        auto slotKey2 = fixedBytes(32, 'z', '2');
+        auto root0 = co_await bootstrapRootWithSlot(trie, address, slotKey1, "base-slot");
+
+        auto balanceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto nonceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::NONCE);
+        auto slotStateKey1 = executor_v1::StateKey(address, slotKey1);
+        auto slotStateKey2 = executor_v1::StateKey(address, slotKey2);
+
+        std::vector<std::tuple<executor_v1::StateKey, storage::Entry>> writes = {
+            {balanceKey, makeEntry("300")},
+            {nonceKey, makeEntry("9")},
+            {slotStateKey1, makeEntry("slot-1-v2")},
+            {slotStateKey2, makeEntry("slot-2-v1")},
+        };
+        auto root1 = co_await storage.writeSome(writes, root0);
+        BOOST_REQUIRE(root1);
+
+        BOOST_CHECK(!(co_await storage.readOne(balanceKey, root0)));
+        auto oldSlot1 = co_await storage.readOne(slotStateKey1, root0);
+        BOOST_REQUIRE(oldSlot1);
+        BOOST_CHECK_EQUAL(oldSlot1->get(), "base-slot");
+
+        auto balance = co_await storage.readOne(balanceKey, *root1);
+        BOOST_REQUIRE(balance);
+        BOOST_CHECK_EQUAL(balance->get(), "300");
+        auto nonce = co_await storage.readOne(nonceKey, *root1);
+        BOOST_REQUIRE(nonce);
+        BOOST_CHECK_EQUAL(nonce->get(), "9");
+        auto newSlot1 = co_await storage.readOne(slotStateKey1, *root1);
+        BOOST_REQUIRE(newSlot1);
+        BOOST_CHECK_EQUAL(newSlot1->get(), "slot-1-v2");
+        auto newSlot2 = co_await storage.readOne(slotStateKey2, *root1);
+        BOOST_REQUIRE(newSlot2);
+        BOOST_CHECK_EQUAL(newSlot2->get(), "slot-2-v1");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeSomeStateRootDirectRemovesMultipleBranches)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalBackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<LogicalBackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address1 = fixedBytes(20, 'j', '1');
+        auto address2 = fixedBytes(20, 'j', '2');
+        auto slotKey1 = fixedBytes(32, 'm', '1');
+        auto slotKey2 = fixedBytes(32, 'm', '2');
+
+        auto root0 = co_await bootstrapRootWithSlot(trie, address1, slotKey1, "a-slot");
+        auto slotRoot2 = co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey2), makeEntry("b-slot"));
+        BOOST_REQUIRE(slotRoot2);
+        auto root1 = co_await trie.writeStorageRoot(root0, bcos::toHex(address2), *slotRoot2);
+        BOOST_REQUIRE(root1);
+
+        auto stateKey1 = executor_v1::StateKey(address1, slotKey1);
+        auto stateKey2 = executor_v1::StateKey(address2, slotKey2);
+        auto root2 = co_await storage.removeSome(std::vector{stateKey1, stateKey2}, *root1, DIRECT);
+        BOOST_REQUIRE(root2);
+
+        BOOST_CHECK(!(co_await storage.readOne(stateKey1, *root2)));
+        BOOST_CHECK(!(co_await storage.readOne(stateKey2, *root2)));
+        BOOST_CHECK(!(co_await storage.readOne(stateKey1)));
+        BOOST_CHECK(!(co_await storage.readOne(stateKey2)));
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeSomeLogicalDeletionLeavesMultipleTombstones)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalBackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<LogicalBackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto address = fixedBytes(20, 'k', '7');
+        std::vector<executor_v1::StateKey> keys = {
+            executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE),
+            executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::NONCE),
+            executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::ALIVE),
+        };
+        std::vector<std::tuple<executor_v1::StateKey, storage::Entry>> writes = {
+            {keys[0], makeEntry("1")},
+            {keys[1], makeEntry("2")},
+            {keys[2], makeEntry("3")},
+        };
+        co_await storage.writeSome(writes);
+        co_await storage.removeSome(keys);
+
+        auto range = co_await storage2::range(backendStorage);
+        size_t deletedCount = 0;
+        while (auto item = co_await range.next())
+        {
+            auto const& [key, value] = *item;
+            if (::ranges::find(keys, key) != keys.end() &&
+                std::holds_alternative<storage2::DELETED_TYPE>(value))
+            {
+                ++deletedCount;
+            }
+        }
+        BOOST_CHECK_EQUAL(deletedCount, keys.size());
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeSomeDirectLeavesNoTombstones)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalBackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<LogicalBackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto address = fixedBytes(20, 'l', '8');
+        std::vector<executor_v1::StateKey> keys = {
+            executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE),
+            executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::NONCE),
+        };
+        std::vector<std::tuple<executor_v1::StateKey, storage::Entry>> writes = {
+            {keys[0], makeEntry("11")},
+            {keys[1], makeEntry("22")},
+        };
+        co_await storage.writeSome(writes);
+        co_await storage.removeSome(keys, DIRECT);
+
+        auto range = co_await storage2::range(backendStorage);
+        while (auto item = co_await range.next())
+        {
+            auto const& key = std::get<0>(*item);
+            BOOST_CHECK(::ranges::find(keys, key) == keys.end());
+        }
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeSomeStateRootReturnsNulloptForMissingStorageRootSlotWrite)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto address = fixedBytes(20, 'm', '1');
+        auto slotKey = fixedBytes(32, 'n', '1');
+        auto balanceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto slotStateKey = executor_v1::StateKey(address, slotKey);
+
+        auto root0 = co_await storage.writeOne(balanceKey, makeEntry("100"), emptyRoot());
+        BOOST_REQUIRE(root0);
+
+        std::vector<std::tuple<executor_v1::StateKey, storage::Entry>> writes = {
+            {slotStateKey, makeEntry("slot-v1")},
+        };
+        auto root1 = co_await storage.writeSome(writes, *root0);
+        BOOST_CHECK(!root1);
+
+        auto backendSlot = co_await storage.readOne(slotStateKey);
+        BOOST_REQUIRE(backendSlot);
+        BOOST_CHECK_EQUAL(backendSlot->get(), "slot-v1");
+        BOOST_CHECK(!(co_await storage.readOne(slotStateKey, *root0)));
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeOneStateRootReturnsNulloptForMissingAccountField)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto address = fixedBytes(20, 'n', '2');
+        auto balanceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto nonceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::NONCE);
+
+        auto root0 = co_await storage.writeOne(balanceKey, makeEntry("500"), emptyRoot());
+        BOOST_REQUIRE(root0);
+        auto root1 = co_await storage.removeOne(nonceKey, *root0);
+        BOOST_CHECK(!root1);
+
+        auto balance = co_await storage.readOne(balanceKey, *root0);
+        BOOST_REQUIRE(balance);
+        BOOST_CHECK_EQUAL(balance->get(), "500");
+        BOOST_CHECK(!(co_await storage.readOne(nonceKey)));
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeSomeStateRootReturnsNulloptForMissingSlot)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'o', '3');
+        auto slotKey1 = fixedBytes(32, 'q', '1');
+        auto slotKey2 = fixedBytes(32, 'q', '2');
+        auto root0 = co_await bootstrapRootWithSlot(trie, address, slotKey1, "slot-1");
+        auto missingKey = executor_v1::StateKey(address, slotKey2);
+
+        auto root1 = co_await storage.removeSome(std::vector{missingKey}, root0);
+        BOOST_CHECK(!root1);
+        BOOST_CHECK(!(co_await storage.readOne(missingKey, root0)));
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeOneStateRootCanRecreateAfterLogicalRemove)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalBackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<LogicalBackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto address = fixedBytes(20, 'p', '4');
+        auto balanceKey = executor_v1::StateKey(address, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto root0 = co_await storage.writeOne(balanceKey, makeEntry("1"), emptyRoot());
+        BOOST_REQUIRE(root0);
+        auto root1 = co_await storage.removeOne(balanceKey, *root0);
+        BOOST_REQUIRE(root1);
+        auto root2 = co_await storage.writeOne(balanceKey, makeEntry("2"), *root1);
+        BOOST_REQUIRE(root2);
+
+        BOOST_CHECK(!(co_await storage.readOne(balanceKey, *root1)));
+        auto value = co_await storage.readOne(balanceKey, *root2);
+        BOOST_REQUIRE(value);
+        BOOST_CHECK_EQUAL(value->get(), "2");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeDirectThenRewriteSlotOnHistoricalRoot)
+{
+    task::syncWait([]() -> task::Task<void> {
+        LogicalBackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<LogicalBackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address = fixedBytes(20, 'r', '5');
+        auto slotKey = fixedBytes(32, 's', '5');
+        auto root0 = co_await bootstrapRootWithSlot(trie, address, slotKey, "slot-old");
+        auto stateKey = executor_v1::StateKey(address, slotKey);
+
+        auto root1 = co_await storage.removeOne(stateKey, root0, DIRECT);
+        BOOST_REQUIRE(root1);
+        auto root2 = co_await storage.writeOne(stateKey, makeEntry("slot-new"), root0);
+        BOOST_REQUIRE(root2);
+
+        BOOST_CHECK(!(co_await storage.readOne(stateKey, *root1)));
+        auto value = co_await storage.readOne(stateKey, *root2);
+        BOOST_REQUIRE(value);
+        BOOST_CHECK_EQUAL(value->get(), "slot-new");
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(writeSomeMultipleAddressesFieldsOnlyChainsCorrectly)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, std::make_shared<crypto::Keccak256>());
+
+        auto address1 = fixedBytes(20, 't', '1');
+        auto address2 = fixedBytes(20, 't', '2');
+        auto address3 = fixedBytes(20, 't', '3');
+
+        std::vector<std::tuple<executor_v1::StateKey, storage::Entry>> writes = {
+            {executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::BALANCE), makeEntry("10")},
+            {executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::NONCE), makeEntry("11")},
+            {executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::BALANCE), makeEntry("20")},
+            {executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::NONCE), makeEntry("21")},
+            {executor_v1::StateKey(address3, ledger::ACCOUNT_TABLE_FIELDS::BALANCE), makeEntry("30")},
+            {executor_v1::StateKey(address3, ledger::ACCOUNT_TABLE_FIELDS::NONCE), makeEntry("31")},
+        };
+
+        auto root = co_await storage.writeSome(writes, emptyRoot());
+        BOOST_REQUIRE(root);
+
+        for (auto const& [key, value] : writes)
+        {
+            auto readValue = co_await storage.readOne(key, *root);
+            BOOST_REQUIRE(readValue);
+            BOOST_CHECK_EQUAL(readValue->get(), value.get());
+        }
+    }());
+}
+
+BOOST_AUTO_TEST_CASE(removeSomeStateRootMixedFieldsAndSlotsAcrossAddresses)
+{
+    task::syncWait([]() -> task::Task<void> {
+        BackendStorage backendStorage;
+        NodeStorage nodeStorage;
+        auto hashImpl = std::make_shared<crypto::Keccak256>();
+        MerkleStorage<BackendStorage, NodeStorage> storage(
+            backendStorage, nodeStorage, hashImpl);
+        MPT<NodeStorage> trie(nodeStorage, hashImpl);
+
+        auto address1 = fixedBytes(20, 'u', '1');
+        auto address2 = fixedBytes(20, 'u', '2');
+        auto slotKey1 = fixedBytes(32, 'w', '1');
+        auto slotKey2 = fixedBytes(32, 'w', '2');
+
+        auto root0 = co_await bootstrapRootWithSlot(trie, address1, slotKey1, "slot-a");
+        auto slotRoot2 = co_await trie.writeSlot(emptyRoot(), bcos::toHex(slotKey2), makeEntry("slot-b"));
+        BOOST_REQUIRE(slotRoot2);
+        auto root1 = co_await trie.writeStorageRoot(root0, bcos::toHex(address2), *slotRoot2);
+        BOOST_REQUIRE(root1);
+
+        auto balanceKey1 = executor_v1::StateKey(address1, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto balanceKey2 = executor_v1::StateKey(address2, ledger::ACCOUNT_TABLE_FIELDS::BALANCE);
+        auto slotStateKey1 = executor_v1::StateKey(address1, slotKey1);
+        auto slotStateKey2 = executor_v1::StateKey(address2, slotKey2);
+
+        auto root2 = co_await storage.writeSome(std::vector{
+                std::tuple{balanceKey1, makeEntry("101")},
+                std::tuple{balanceKey2, makeEntry("202")}},
+            *root1);
+        BOOST_REQUIRE(root2);
+
+        auto root3 = co_await storage.removeSome(std::vector{balanceKey1, slotStateKey2}, *root2);
+        BOOST_REQUIRE(root3);
+
+        BOOST_CHECK(!(co_await storage.readOne(balanceKey1, *root3)));
+        BOOST_CHECK(!(co_await storage.readOne(slotStateKey2, *root3)));
+        auto retainBalance2 = co_await storage.readOne(balanceKey2, *root3);
+        BOOST_REQUIRE(retainBalance2);
+        BOOST_CHECK_EQUAL(retainBalance2->get(), "202");
+        auto retainSlot1 = co_await storage.readOne(slotStateKey1, *root3);
+        BOOST_REQUIRE(retainSlot1);
+        BOOST_CHECK_EQUAL(retainSlot1->get(), "slot-a");
+    }());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

This PR extends `MerkleStorage` with state-root-aware batch operations and improves its delete behavior, together with a comprehensive test suite.

## Changes

- fix compile/scope issues in `MerkleStorage.h`
- add logical deletion and physical deletion support in `MerkleStorage`
- align `writeSome` / `removeSome` with `writeOne` / `removeOne` by supporting `stateRoot` input and returning the final updated root
- add `DIRECT` variants for physical deletion with `stateRoot`
- add extensive unit tests for `MerkleStorage`

## Test Coverage

The new tests cover:

- basic account field read/write
- slot read/write
- historical root reads
- branching roots
- mixed account-field and slot updates
- logical deletion vs physical deletion
- `writeSome` / `removeSome` chained root updates
- alternating stress-style read/write/remove operations
- failure cases that should return `nullopt`

## Files

- `bcos-framework/bcos-framework/storage2/MerkleStorage.h`
- `bcos-framework/test/unittests/storage2/TestMerkleStorage.cpp`
- `bcos-framework/test/CMakeLists.txt`

## Validation

```bash
cmake --build . --target test-bcos-framework --parallel 3
./bcos-framework/test/test-bcos-framework --run_test=TestMerkleStorage
