### PR TITLE
Refactor implementation from headers to source files

### DIFF
--- a/bcos-codec/bcos-codec/abi/ContractABICodec.cpp
+++ b/bcos-codec/bcos-codec/abi/ContractABICodec.cpp
@@ -26,6 +26,35 @@ using namespace bcos::codec::abi;
 
 const int ContractABICodec::MAX_BYTE_LENGTH;
 
+ContractABICodec::ContractABICodec(const bcos::crypto::Hash& hashImpl) : m_hashImpl(hashImpl) {}
+
+size_t ContractABICodec::getOffset()
+{
+    return offset;
+}
+
+void ContractABICodec::validOffset(std::size_t _offset)
+{
+    if (_offset >= data.size())
+    {
+        std::stringstream ss;
+        ss << " deserialize failed, invalid offset , offset is " << _offset << " , length is "
+           << data.size() << " , data is " << toHex(data);
+
+        throw std::length_error(ss.str().c_str());
+    }
+}
+
+void ContractABICodec::abiInAux()
+{
+    return;
+}
+
+void ContractABICodec::abiOutAux()
+{
+    return;
+}
+
 bool ContractABICodec::abiOutByFuncSelector(
     bytesConstRef _data, const std::vector<std::string>& _allTypes, std::vector<std::string>& _out)
 {

--- a/bcos-codec/bcos-codec/abi/ContractABICodec.h
+++ b/bcos-codec/bcos-codec/abi/ContractABICodec.h
@@ -285,7 +285,7 @@ struct Offset<T>
 class ContractABICodec
 {
 public:
-    explicit ContractABICodec(const bcos::crypto::Hash& hashImpl) : m_hashImpl(hashImpl) {}
+    explicit ContractABICodec(const bcos::crypto::Hash& hashImpl);
     // explicit ContractABICodec(bcos::crypto::Hash::Ptr _hashImpl) : m_hashImpl(_hashImpl) {}
 
     template <class T, std::enable_if_t<!std::is_integral<T>::value>>
@@ -408,19 +408,9 @@ private:
     bytesConstRef data;
 
 private:
-    size_t getOffset() { return offset; }
+    size_t getOffset();
     // check if offset valid and std::length_error will be throw
-    void validOffset(std::size_t _offset)
-    {
-        if (_offset >= data.size())
-        {
-            std::stringstream ss;
-            ss << " deserialize failed, invalid offset , offset is " << _offset << " , length is "
-               << data.size() << " , data is " << toHex(data);
-
-            throw std::length_error(ss.str().c_str());
-        }
-    }
+    void validOffset(std::size_t _offset);
 
     template <class T>
     std::string toString(const T& _t)
@@ -430,7 +420,7 @@ private:
         return ss.str();
     }
 
-    inline void abiInAux() { return; }
+    void abiInAux();
 
     template <class T, class... U>
     void abiInAux(T const& _t, U const&... _u)
@@ -451,7 +441,7 @@ private:
         abiInAux(_u...);
     }
 
-    void abiOutAux() { return; }
+    void abiOutAux();
 
     template <class T, class... U>
     void abiOutAux(T& _t, U&... _u)

--- a/bcos-codec/bcos-codec/abi/ContractABIType.cpp
+++ b/bcos-codec/bcos-codec/abi/ContractABIType.cpp
@@ -108,6 +108,31 @@ void ABIInType::clear()
     extents.clear();
 }
 
+std::size_t ABIInType::rank()
+{
+    return extents.size();
+}
+
+std::size_t ABIInType::extent(std::size_t index)
+{
+    return index > rank() ? 0 : extents[index - 1];
+}
+
+bool ABIInType::valid()
+{
+    return aet != ABI_ELEMENTARY_TYPE::INVALID;
+}
+
+std::string ABIInType::getType() const
+{
+    return strType;
+}
+
+std::string ABIInType::getEleType() const
+{
+    return strEleType;
+}
+
 bool ABIInType::reset(const std::string& _s)
 {
     clear();
@@ -220,6 +245,16 @@ std::vector<std::string> ABIFunc::getParamsType() const
     }
 
     return r;
+}
+
+std::string ABIFunc::getSignature() const
+{
+    return strFuncSignature;
+}
+
+std::string ABIFunc::getFuncName() const
+{
+    return strFuncName;
 }
 
 // parser contract abi function signature, eg: transfer(string,string,uint256)

--- a/bcos-codec/bcos-codec/abi/ContractABIType.h
+++ b/bcos-codec/bcos-codec/abi/ContractABIType.h
@@ -53,14 +53,14 @@ public:
 
 public:
     // the number of dimensions of T or zero
-    std::size_t rank() { return extents.size(); }
+    std::size_t rank();
     // obtains the size of an array type along a specified dimension
-    std::size_t extent(std::size_t index) { return index > rank() ? 0 : extents[index - 1]; }
+    std::size_t extent(std::size_t index);
     bool removeExtent();
     bool dynamic();
-    bool valid() { return aet != ABI_ELEMENTARY_TYPE::INVALID; }
-    std::string getType() const { return strType; }
-    std::string getEleType() const { return strEleType; }
+    bool valid();
+    std::string getType() const;
+    std::string getEleType() const;
 
     // get abi elementary type by string
     ABI_ELEMENTARY_TYPE getEnumType(const std::string& _strType);
@@ -87,8 +87,8 @@ public:
 
 public:
     std::vector<std::string> getParamsType() const;
-    inline std::string getSignature() const { return strFuncSignature; }
-    inline std::string getFuncName() const { return strFuncName; }
+    std::string getSignature() const;
+    std::string getFuncName() const;
 };
 
 }  // namespace abi

--- a/bcos-codec/bcos-codec/scale/ScaleDecoderStream.cpp
+++ b/bcos-codec/bcos-codec/scale/ScaleDecoderStream.cpp
@@ -149,6 +149,27 @@ bool ScaleDecoderStream::hasMore(uint64_t n) const
     return static_cast<SizeType>(m_currentIndex + n) <= m_span.size();
 }
 
+uint8_t ScaleDecoderStream::nextByte()
+{
+    if (!hasMore(1))
+    {
+        BOOST_THROW_EXCEPTION(ScaleDecodeException()
+                              << errinfo_comment("nextByte exception for NOT_ENOUGH_DATA"));
+    }
+    ++m_currentIndex;
+    return *m_currentIterator++;
+}
+
+gsl::span<const unsigned char> ScaleDecoderStream::span() const
+{
+    return m_span;
+}
+
+ScaleDecoderStream::SizeType ScaleDecoderStream::currentIndex() const
+{
+    return m_currentIndex;
+}
+
 ScaleDecoderStream& ScaleDecoderStream::operator>>(u256& v)
 {
     bytes decodedBigEndianData;

--- a/bcos-codec/bcos-codec/scale/ScaleDecoderStream.h
+++ b/bcos-codec/bcos-codec/scale/ScaleDecoderStream.h
@@ -369,20 +369,11 @@ public:
      * advances current byte iterator by one
      * @return current byte
      */
-    uint8_t nextByte()
-    {
-        if (!hasMore(1))
-        {
-            BOOST_THROW_EXCEPTION(ScaleDecodeException()
-                                  << errinfo_comment("nextByte exception for NOT_ENOUGH_DATA"));
-        }
-        ++m_currentIndex;
-        return *m_currentIterator++;
-    }
+    uint8_t nextByte();
     using SizeType = gsl::span<const byte>::size_type;
 
-    gsl::span<byte const> span() const { return m_span; }
-    SizeType currentIndex() const { return m_currentIndex; }
+    gsl::span<byte const> span() const;
+    SizeType currentIndex() const;
 
 private:
     bool decodeBool();

--- a/bcos-codec/bcos-codec/scale/ScaleEncoderStream.cpp
+++ b/bcos-codec/bcos-codec/scale/ScaleEncoderStream.cpp
@@ -120,6 +120,17 @@ void encodeCompactInteger(const CompactInteger& value, ScaleEncoderStream& out)
     }
 }
 
+ScaleEncoderStream& ScaleEncoderStream::operator<<(std::string_view sv)
+{
+    return encodeCollection(sv.size(), sv.begin(), sv.end());
+}
+
+ScaleEncoderStream& ScaleEncoderStream::operator<<(s256 const& v)
+{
+    u256 unsignedValue = s2u(v);
+    return *this << unsignedValue;
+}
+
 ScaleEncoderStream& ScaleEncoderStream::operator<<(const u256& _value)
 {
     // convert u256 to big-edian bytes(Note: must be 32bytes)
@@ -153,4 +164,10 @@ ScaleEncoderStream& ScaleEncoderStream::encodeOptionalBool(const boost::optional
         result = OptionalBool::FalseValue;
     }
     return putByte(static_cast<uint8_t>(result));
+}
+
+ScaleEncoderStream& ScaleEncoderStream::putByte(uint8_t v)
+{
+    m_stream.emplace_back(v);
+    return *this;
 }

--- a/bcos-codec/bcos-codec/scale/ScaleEncoderStream.h
+++ b/bcos-codec/bcos-codec/scale/ScaleEncoderStream.h
@@ -231,10 +231,7 @@ public:
      * @param sv string_view item
      * @return reference to stream
      */
-    ScaleEncoderStream& operator<<(std::string_view sv)
-    {
-        return encodeCollection(sv.size(), sv.begin(), sv.end());
-    }
+    ScaleEncoderStream& operator<<(std::string_view sv);
 
     /**
      * @brief scale-encodes any integral type including bool
@@ -284,11 +281,7 @@ public:
      */
     ScaleEncoderStream& operator<<(const CompactInteger& v);
 
-    ScaleEncoderStream& operator<<(s256 const& v)
-    {
-        u256 unsignedValue = s2u(v);
-        return *this << unsignedValue;
-    }
+    ScaleEncoderStream& operator<<(s256 const& v);
 
     ScaleEncoderStream& operator<<(const u256& v);
 
@@ -342,11 +335,7 @@ protected:
      * @param v byte value
      * @return reference to stream
      */
-    ScaleEncoderStream& putByte(uint8_t v)
-    {
-        m_stream.emplace_back(v);
-        return *this;
-    }
+    ScaleEncoderStream& putByte(uint8_t v);
 
 private:
     ScaleEncoderStream& encodeOptionalBool(const boost::optional<bool>& v);

--- a/bcos-crypto/bcos-crypto/ChecksumAddress.cpp
+++ b/bcos-crypto/bcos-crypto/ChecksumAddress.cpp
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bcos-crypto/ChecksumAddress.h>
+
+#include <bcos-codec/bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/bcos-codec/rlp/RLPEncode.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+#include <fmt/format.h>
+#include <cctype>
+#include <memory>
+#include <span>
+
+namespace
+{
+int convertHexCharToInt(char byte)
+{
+    if (byte >= '0' && byte <= '9')
+    {
+        return byte - '0';
+    }
+    if (byte >= 'a' && byte <= 'f')
+    {
+        return byte - 'a' + 10;
+    }
+    if (byte >= 'A' && byte <= 'F')
+    {
+        return byte - 'A' + 10;
+    }
+    return 0;
+}
+}  // namespace
+
+namespace bcos
+{
+void toChecksumAddress(
+    std::string& _addr, const std::string_view& addressHashHex, std::string_view prefix)
+{
+    for (size_t i = prefix.size(); i < _addr.size(); ++i)
+    {
+        if (std::isdigit(static_cast<unsigned char>(_addr[i])))
+        {
+            continue;
+        }
+        if (convertHexCharToInt(addressHashHex[i]) >= 8)
+        {
+            _addr[i] = static_cast<char>(std::toupper(static_cast<unsigned char>(_addr[i])));
+        }
+    }
+}
+
+void toCheckSumAddress(std::string& _hexAddress, crypto::Hash::Ptr _hashImpl)
+{
+    boost::algorithm::to_lower(_hexAddress);
+    toChecksumAddress(_hexAddress, _hashImpl->hash(_hexAddress).hex());
+}
+
+void toCheckSumAddressWithChainId(
+    std::string& _hexAddress, crypto::Hash::Ptr _hashImpl, uint64_t _chainId)
+{
+    boost::algorithm::to_lower(_hexAddress);
+    std::string hashInput = _hexAddress;
+    if (_chainId != 0 && _chainId != 1)
+    {
+        hashInput = fmt::format("{}0x{}", _chainId, _hexAddress);
+    }
+    toChecksumAddress(_hexAddress, _hashImpl->hash(hashInput).hex());
+}
+
+void toAddress(std::string& _hexAddress)
+{
+    boost::algorithm::to_lower(_hexAddress);
+}
+
+std::string toChecksumAddressFromBytes(
+    const std::string_view& _AddressBytes, crypto::Hash::Ptr _hashImpl)
+{
+    auto hexAddress = toHex(_AddressBytes);
+    toAddress(hexAddress);
+    return hexAddress;
+}
+
+std::string newEVMAddress(
+    const bcos::crypto::Hash& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq)
+{
+    auto hash = _hashImpl.hash(boost::lexical_cast<std::string>(blockNumber) + "_" +
+                               boost::lexical_cast<std::string>(contextID) + "_" +
+                               boost::lexical_cast<std::string>(seq));
+
+    std::string hexAddress;
+    hexAddress.reserve(40);
+    boost::algorithm::hex(hash.data(), hash.data() + 20, std::back_inserter(hexAddress));
+
+    toAddress(hexAddress);
+
+    return hexAddress;
+}
+
+std::string newEVMAddress(
+    const bcos::crypto::Hash::Ptr& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq)
+{
+    return newEVMAddress(*_hashImpl, blockNumber, contextID, seq);
+}
+
+evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept
+{
+    codec::rlp::Header header{.isList = true, .payloadLength = 1 + sender.size()};
+    header.payloadLength += codec::rlp::length(nonce);
+    bcos::bytes rlp;
+    codec::rlp::encodeHeader(rlp, header);
+    codec::rlp::encode(rlp, sender);
+    codec::rlp::encode(rlp, nonce);
+    auto hash = bcos::crypto::keccak256Hash(ref(rlp));
+    evmc_address address;
+    std::uninitialized_copy(hash.begin() + 12, hash.end(), address.bytes);
+
+    return address;
+}
+
+std::string newLegacyEVMAddressString(bytesConstRef sender, const u256& nonce) noexcept
+{
+    auto address = newLegacyEVMAddress(sender, nonce);
+    auto view = std::span{address.bytes};
+    std::string out;
+    out.reserve(view.size() * 2);
+    boost::algorithm::hex_lower(view.begin(), view.end(), std::back_inserter(out));
+    return out;
+}
+
+std::string newLegacyEVMAddressString(bytesConstRef sender, std::string const& nonce) noexcept
+{
+    const auto uNonce = hex2u(nonce);
+    return newLegacyEVMAddressString(sender, uNonce);
+}
+
+std::string newCreate2EVMAddress(bcos::crypto::Hash::Ptr _hashImpl,
+    const std::string_view& _sender, bytesConstRef _init, u256 const& _salt)
+{
+    auto hash = _hashImpl->hash(bytes{0xff} + fromHex(_sender) + toBigEndian(_salt) +
+                                _hashImpl->hash(_init));
+
+    std::string hexAddress;
+    hexAddress.reserve(40);
+    boost::algorithm::hex(hash.data() + 12, hash.data() + 32, std::back_inserter(hexAddress));
+
+    toAddress(hexAddress);
+
+    return hexAddress;
+}
+}  // namespace bcos

--- a/bcos-crypto/bcos-crypto/ChecksumAddress.h
+++ b/bcos-crypto/bcos-crypto/ChecksumAddress.h
@@ -20,156 +20,44 @@
 
 #pragma once
 
-#include <bcos-codec/bcos-codec/rlp/RLPDecode.h>
-#include <bcos-codec/bcos-codec/rlp/RLPEncode.h>
-#include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/interfaces/crypto/Hash.h>
-#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Common.h>
 #include <evmc/evmc.h>
-#include <fmt/format.h>
-#include <boost/algorithm/string.hpp>
-#include <memory>
 #include <string>
+#include <string_view>
 
 namespace bcos
 {
-inline void toChecksumAddress(
-    std::string& _addr, const std::string_view& addressHashHex, std::string_view prefix = "")
-{
-    auto convertHexCharToInt = [](char byte) {
-        int ret = 0;
-        if (byte >= '0' && byte <= '9')
-        {
-            ret = byte - '0';
-        }
-        else if (byte >= 'a' && byte <= 'f')
-        {
-            ret = byte - 'a' + 10;
-        }
-        else if (byte >= 'A' && byte <= 'F')
-        {
-            ret = byte - 'A' + 10;
-        }
-        return ret;
-    };
-    for (size_t i = prefix.size(); i < _addr.size(); ++i)
-    {
-        if (isdigit(_addr[i]))
-        {
-            continue;
-        }
-        if (convertHexCharToInt(addressHashHex[i]) >= 8)
-        {
-            _addr[i] = toupper(_addr[i]);
-        }
-    }
-}
+void toChecksumAddress(
+    std::string& _addr, const std::string_view& addressHashHex, std::string_view prefix = "");
 
-inline void toCheckSumAddress(std::string& _hexAddress, crypto::Hash::Ptr _hashImpl)
-{
-    boost::algorithm::to_lower(_hexAddress);
-    toChecksumAddress(_hexAddress, _hashImpl->hash(_hexAddress).hex());
-}
+void toCheckSumAddress(std::string& _hexAddress, crypto::Hash::Ptr _hashImpl);
 
 // for EIP-1191, hexAdress input should NOT have prefix "0x"
-inline void toCheckSumAddressWithChainId(
-    std::string& _hexAddress, crypto::Hash::Ptr _hashImpl, uint64_t _chainId = 0)
-{
-    boost::algorithm::to_lower(_hexAddress);
-    std::string hashInput = _hexAddress;
-    if (_chainId != 0 && _chainId != 1)
-    {
-        hashInput = fmt::format("{}0x{}", _chainId, _hexAddress);
-    }
-    toChecksumAddress(_hexAddress, _hashImpl->hash(hashInput).hex());
-}
+void toCheckSumAddressWithChainId(
+    std::string& _hexAddress, crypto::Hash::Ptr _hashImpl, uint64_t _chainId = 0);
 
-inline void toAddress(std::string& _hexAddress)
-{
-    boost::algorithm::to_lower(_hexAddress);
-    // toChecksumAddress(_hexAddress, _hashImpl->hash(_hexAddress).hex()); notice :
-    // toChecksumAddress must be used before rpc return
-}
+void toAddress(std::string& _hexAddress);
 
-inline std::string toChecksumAddressFromBytes(
-    const std::string_view& _AddressBytes, crypto::Hash::Ptr _hashImpl)
-{
-    auto hexAddress = toHex(_AddressBytes);
-    toAddress(hexAddress);
-    return hexAddress;
-}
+std::string toChecksumAddressFromBytes(
+    const std::string_view& _AddressBytes, crypto::Hash::Ptr _hashImpl);
 
 // address based on blockNumber, contextID, seq
-inline std::string newEVMAddress(
-    const bcos::crypto::Hash& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq)
-{
-    auto hash = _hashImpl.hash(boost::lexical_cast<std::string>(blockNumber) + "_" +
-                               boost::lexical_cast<std::string>(contextID) + "_" +
-                               boost::lexical_cast<std::string>(seq));
+std::string newEVMAddress(
+    const bcos::crypto::Hash& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq);
 
-    std::string hexAddress;
-    hexAddress.reserve(40);
-    boost::algorithm::hex(hash.data(), hash.data() + 20, std::back_inserter(hexAddress));
-
-    toAddress(hexAddress);
-
-    return hexAddress;
-}
-
-inline std::string newEVMAddress(
-    const bcos::crypto::Hash::Ptr& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq)
-{
-    return newEVMAddress(*_hashImpl, blockNumber, contextID, seq);
-}
+std::string newEVMAddress(
+    const bcos::crypto::Hash::Ptr& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq);
 
 // keccak256(rlp.encode([normalize_address(sender), nonce]))[12:]
-inline evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept
-{
-    codec::rlp::Header header{.isList = true, .payloadLength = 1 + sender.size()};
-    header.payloadLength += codec::rlp::length(nonce);
-    bcos::bytes rlp;
-    codec::rlp::encodeHeader(rlp, header);
-    codec::rlp::encode(rlp, sender);
-    codec::rlp::encode(rlp, nonce);
-    auto hash = bcos::crypto::keccak256Hash(ref(rlp));
-    evmc_address address;
-    std::uninitialized_copy(hash.begin() + 12, hash.end(), address.bytes);
+evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept;
 
-    return address;
-}
+std::string newLegacyEVMAddressString(bytesConstRef sender, const u256& nonce) noexcept;
 
-inline std::string newLegacyEVMAddressString(bytesConstRef sender, const u256& nonce) noexcept
-{
-    auto address = newLegacyEVMAddress(sender, nonce);
-    auto view = std::span{address.bytes};
-    std::string out;
-    out.reserve(view.size() * 2);
-    boost::algorithm::hex_lower(view.begin(), view.end(), std::back_inserter(out));
-    return out;
-}
-
-inline std::string newLegacyEVMAddressString(
-    bytesConstRef sender, std::string const& nonce) noexcept
-{
-    const auto uNonce = hex2u(nonce);
-    return newLegacyEVMAddressString(sender, uNonce);
-}
+std::string newLegacyEVMAddressString(bytesConstRef sender, std::string const& nonce) noexcept;
 
 // EIP-1014
-inline std::string newCreate2EVMAddress(bcos::crypto::Hash::Ptr _hashImpl,
-    const std::string_view& _sender, bytesConstRef _init, u256 const& _salt)
-{
-    auto hash = _hashImpl->hash(bytes{0xff} +
-                                (_sender.starts_with("0x") ? fromHex(_sender) : fromHex(_sender)) +
-                                toBigEndian(_salt) + _hashImpl->hash(_init));
-
-    std::string hexAddress;
-    hexAddress.reserve(40);
-    boost::algorithm::hex(hash.data() + 12, hash.data() + 32, std::back_inserter(hexAddress));
-
-    toAddress(hexAddress);
-
-    return hexAddress;
-}
+std::string newCreate2EVMAddress(bcos::crypto::Hash::Ptr _hashImpl,
+    const std::string_view& _sender, bytesConstRef _init, u256 const& _salt);
 
 }  // namespace bcos

--- a/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.cpp
@@ -29,6 +29,8 @@ using namespace hsm;
 using namespace bcos;
 using namespace bcos::crypto;
 
+HsmSM4Crypto::HsmSM4Crypto(std::string _libPath) : m_hsmLibPath(std::move(_libPath)) {}
+
 bcos::bytesPointer HsmSM4Crypto::HsmSM4Encrypt(const unsigned char* _plainData,
     size_t _plainDataSize, const unsigned char* _key, size_t, const unsigned char* _ivData,
     size_t _ivDataSize)

--- a/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.h
+++ b/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.h
@@ -33,7 +33,7 @@ class HsmSM4Crypto : public SymmetricEncryption
 {
 public:
     using Ptr = std::shared_ptr<HsmSM4Crypto>;
-    HsmSM4Crypto(std::string _libPath) { m_hsmLibPath = _libPath; }
+    HsmSM4Crypto(std::string _libPath);
     ~HsmSM4Crypto() override {}
 
     // encrypt decrypt with external key

--- a/bcos-crypto/bcos-crypto/hash/HashImpl.cpp
+++ b/bcos-crypto/bcos-crypto/hash/HashImpl.cpp
@@ -1,0 +1,124 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/hash/SM3.h>
+#include <bcos-crypto/hash/Sha256.h>
+#include <bcos-crypto/hash/Sha3.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+
+namespace bcos::crypto
+{
+HashType keccak256Hash(bytesConstRef _data)
+{
+    hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    hasher.update(_data);
+
+    HashType out;
+    hasher.final(out);
+    return out;
+}
+
+Keccak256::Keccak256()
+{
+    setHashImplType(HashImplType::Keccak256Hash);
+}
+
+HashType Keccak256::hash(bytesConstRef _data) const
+{
+    return keccak256Hash(_data);
+}
+
+bcos::crypto::hasher::AnyHasher Keccak256::hasher() const
+{
+    return bcos::crypto::hasher::AnyHasher{hasher::openssl::OpenSSL_Keccak256_Hasher{}};
+}
+
+HashType sha256Hash(bytesConstRef _data)
+{
+    hasher::openssl::OpenSSL_SHA2_256_Hasher hasher;
+    hasher.update(_data);
+
+    HashType out;
+    hasher.final(out);
+    return out;
+}
+
+Sha256::Sha256()
+{
+    setHashImplType(HashImplType::Sha3);
+}
+
+HashType Sha256::hash(bytesConstRef _data) const
+{
+    return sha256Hash(_data);
+}
+
+bcos::crypto::hasher::AnyHasher Sha256::hasher() const
+{
+    return bcos::crypto::hasher::AnyHasher{hasher::openssl::OpenSSL_SHA3_256_Hasher{}};
+}
+
+HashType sha3Hash(bytesConstRef _data)
+{
+    hasher::openssl::OpenSSL_SHA3_256_Hasher hasher;
+    hasher.update(_data);
+
+    HashType out;
+    hasher.final(out);
+    return out;
+}
+
+Sha3::Sha3()
+{
+    setHashImplType(HashImplType::Sha3);
+}
+
+HashType Sha3::hash(bytesConstRef _data) const
+{
+    return sha3Hash(_data);
+}
+
+bcos::crypto::hasher::AnyHasher Sha3::hasher() const
+{
+    return bcos::crypto::hasher::AnyHasher{hasher::openssl::OpenSSL_SHA3_256_Hasher{}};
+}
+
+HashType sm3Hash(bytesConstRef _data)
+{
+    hasher::openssl::OpenSSL_SM3_Hasher hasher;
+    hasher.update(_data);
+
+    HashType out;
+    hasher.final(out);
+    return out;
+}
+
+SM3::SM3()
+{
+    setHashImplType(HashImplType::Sm3Hash);
+}
+
+HashType SM3::hash(bytesConstRef _data) const
+{
+    return sm3Hash(_data);
+}
+
+bcos::crypto::hasher::AnyHasher SM3::hasher() const
+{
+    return bcos::crypto::hasher::AnyHasher{hasher::openssl::OpenSSL_SM3_Hasher{}};
+}
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/hash/Keccak256.h
+++ b/bcos-crypto/bcos-crypto/hash/Keccak256.h
@@ -20,34 +20,20 @@
  */
 #pragma once
 
-#include "bcos-crypto/hasher/OpenSSLHasher.h"
 #include <bcos-crypto/interfaces/crypto/Hash.h>
 
 namespace bcos::crypto
 {
-
-inline HashType keccak256Hash(bytesConstRef _data)
-{
-    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
-    hasher.update(_data);
-
-    HashType out;
-    hasher.final(out);
-    return out;
-}
+HashType keccak256Hash(bytesConstRef _data);
 
 class Keccak256 : public Hash
 {
 public:
     using Ptr = std::shared_ptr<Keccak256>;
-    Keccak256() { setHashImplType(HashImplType::Keccak256Hash); }
+    Keccak256();
     ~Keccak256() noexcept override = default;
-    HashType hash(bytesConstRef _data) const override { return keccak256Hash(_data); }
-    bcos::crypto::hasher::AnyHasher hasher() const override
-    {
-        return bcos::crypto::hasher::AnyHasher{
-            bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher{}};
-    }
+    HashType hash(bytesConstRef _data) const override;
+    bcos::crypto::hasher::AnyHasher hasher() const override;
 };
 
 }  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/hash/SM3.h
+++ b/bcos-crypto/bcos-crypto/hash/SM3.h
@@ -19,32 +19,19 @@
  * @author yujiechen
  */
 #pragma once
-#include "bcos-crypto/hasher/OpenSSLHasher.h"
 #include <bcos-crypto/interfaces/crypto/Hash.h>
-#include <wedpr-crypto/WedprCrypto.h>
 
 namespace bcos::crypto
 {
-HashType inline sm3Hash(bytesConstRef _data)
-{
-    hasher::openssl::OpenSSL_SM3_Hasher hasher;
-    hasher.update(_data);
+HashType sm3Hash(bytesConstRef _data);
 
-    HashType out;
-    hasher.final(out);
-    return out;
-}
 class SM3 : public Hash
 {
 public:
     using Ptr = std::shared_ptr<SM3>;
-    SM3() { setHashImplType(HashImplType::Sm3Hash); }
+    SM3();
     ~SM3() override = default;
-    HashType hash(bytesConstRef _data) const override { return sm3Hash(_data); }
-
-    bcos::crypto::hasher::AnyHasher hasher() const override
-    {
-        return bcos::crypto::hasher::AnyHasher{bcos::crypto::hasher::openssl::OpenSSL_SM3_Hasher{}};
-    };
+    HashType hash(bytesConstRef _data) const override;
+    bcos::crypto::hasher::AnyHasher hasher() const override;
 };
 }  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/hash/Sha256.h
+++ b/bcos-crypto/bcos-crypto/hash/Sha256.h
@@ -19,31 +19,19 @@
  * @author yujiechen
  */
 #pragma once
-#include "bcos-crypto/hasher/OpenSSLHasher.h"
 #include <bcos-crypto/interfaces/crypto/Hash.h>
 
 namespace bcos::crypto
 {
-HashType inline sha256Hash(bytesConstRef _data)
-{
-    hasher::openssl::OpenSSL_SHA2_256_Hasher hasher;
-    hasher.update(_data);
+HashType sha256Hash(bytesConstRef _data);
 
-    HashType out;
-    hasher.final(out);
-    return out;
-}
 class Sha256 : public Hash
 {
 public:
     using Ptr = std::shared_ptr<Sha256>;
-    Sha256() { setHashImplType(HashImplType::Sha3); }
+    Sha256();
     ~Sha256() override = default;
-    HashType hash(bytesConstRef _data) const override { return sha256Hash(_data); }
-    bcos::crypto::hasher::AnyHasher hasher() const override
-    {
-        return bcos::crypto::hasher::AnyHasher{
-            bcos::crypto::hasher::openssl::OpenSSL_SHA3_256_Hasher{}};
-    };
+    HashType hash(bytesConstRef _data) const override;
+    bcos::crypto::hasher::AnyHasher hasher() const override;
 };
 }  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/hash/Sha3.h
+++ b/bcos-crypto/bcos-crypto/hash/Sha3.h
@@ -19,32 +19,19 @@
  * @author yujiechen
  */
 #pragma once
-#include "bcos-crypto/hasher/OpenSSLHasher.h"
 #include <bcos-crypto/interfaces/crypto/Hash.h>
 
 namespace bcos::crypto
 {
-HashType inline sha3Hash(bytesConstRef _data)
-{
-    hasher::openssl::OpenSSL_SHA3_256_Hasher hasher;
-    hasher.update(_data);
-
-    HashType out;
-    hasher.final(out);
-    return out;
-}
+HashType sha3Hash(bytesConstRef _data);
 
 class Sha3 : public Hash
 {
 public:
     using Ptr = std::shared_ptr<Sha3>;
-    Sha3() { setHashImplType(HashImplType::Sha3); }
+    Sha3();
     ~Sha3() noexcept override = default;
-    HashType hash(bytesConstRef _data) const override { return sha3Hash(_data); }
-    bcos::crypto::hasher::AnyHasher hasher() const override
-    {
-        return bcos::crypto::hasher::AnyHasher{
-            bcos::crypto::hasher::openssl::OpenSSL_SHA3_256_Hasher{}};
-    };
+    HashType hash(bytesConstRef _data) const override;
+    bcos::crypto::hasher::AnyHasher hasher() const override;
 };
 }  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519KeyPair.cpp
+++ b/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519KeyPair.cpp
@@ -26,6 +26,22 @@
 using namespace bcos;
 using namespace bcos::crypto;
 
+Ed25519KeyPair::Ed25519KeyPair()
+  : KeyPair(ED25519_PUBLIC_LEN, ED25519_PRIVATE_LEN, KeyPairType::Ed25519)
+{}
+
+Ed25519KeyPair::Ed25519KeyPair(SecretPtr _secretKey) : Ed25519KeyPair()
+{
+    m_secretKey = _secretKey;
+    m_publicKey = priToPub(_secretKey);
+    m_type = KeyPairType::Ed25519;
+}
+
+PublicPtr Ed25519KeyPair::priToPub(SecretPtr _secretKey)
+{
+    return ed25519PriToPub(_secretKey);
+}
+
 PublicPtr bcos::crypto::ed25519PriToPub(SecretPtr _secretKey)
 {
     CInputBuffer privateKey{_secretKey->constData(), _secretKey->size()};

--- a/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519KeyPair.h
+++ b/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519KeyPair.h
@@ -33,15 +33,10 @@ PublicPtr ed25519PriToPub(SecretPtr _secretKey);
 class Ed25519KeyPair : public KeyPair
 {
 public:
-    Ed25519KeyPair() : KeyPair(ED25519_PUBLIC_LEN, ED25519_PRIVATE_LEN, KeyPairType::Ed25519) {}
-    explicit Ed25519KeyPair(SecretPtr _secretKey) : Ed25519KeyPair()
-    {
-        m_secretKey = _secretKey;
-        m_publicKey = priToPub(_secretKey);
-        m_type = KeyPairType::Ed25519;
-    }
+    Ed25519KeyPair();
+    explicit Ed25519KeyPair(SecretPtr _secretKey);
     ~Ed25519KeyPair() override {}
-    virtual PublicPtr priToPub(SecretPtr _secretKey) { return ed25519PriToPub(_secretKey); }
+    virtual PublicPtr priToPub(SecretPtr _secretKey);
 };
 }  // namespace crypto
 }  // namespace bcos

--- a/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.cpp
@@ -35,6 +35,12 @@ using namespace hsm;
 #define SDR_BASE 0x01000000
 #define SDR_VERIFYERR (SDR_BASE + 0x0000000E)
 
+HsmSM2Crypto::HsmSM2Crypto(std::string _libPath)
+{
+    m_hsmLibPath = std::move(_libPath);
+    m_keyPairFactory = std::make_shared<HsmSM2KeyPairFactory>(m_hsmLibPath);
+}
+
 std::shared_ptr<bytes> HsmSM2Crypto::sign(
     const KeyPairInterface& _keyPair, const HashType& _hash, bool _signatureWithPub) const
 {

--- a/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.h
+++ b/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2Crypto.h
@@ -32,11 +32,7 @@ class HsmSM2Crypto : public SignatureCrypto
 {
 public:
     using Ptr = std::shared_ptr<HsmSM2Crypto>;
-    HsmSM2Crypto(std::string _libPath)
-    {
-        m_hsmLibPath = _libPath;
-        m_keyPairFactory = std::make_shared<HsmSM2KeyPairFactory>(m_hsmLibPath);
-    }
+    HsmSM2Crypto(std::string _libPath);
     ~HsmSM2Crypto() override = default;
 
     std::shared_ptr<bytes> sign(const KeyPairInterface& _keyPair, const HashType& _hash,

--- a/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2KeyPair.cpp
+++ b/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2KeyPair.cpp
@@ -30,6 +30,13 @@ using namespace hsm;
 
 #define SDR_OK 0x0
 
+HsmSM2KeyPair::HsmSM2KeyPair(std::string _libPath)
+    : KeyPair(HSM_SM2_PUBLIC_KEY_LEN, HSM_SM2_PRIVATE_KEY_LEN, KeyPairType::HsmSM2)
+{
+        m_hsmLibPath = std::move(_libPath);
+        m_publicKeyDeriver = wedpr_sm2_derive_public_key;
+}
+
 HsmSM2KeyPair::HsmSM2KeyPair(std::string _libPath, SecretPtr _secretKey) : HsmSM2KeyPair(_libPath)
 {
     if (_secretKey->size() != HSM_SM2_PRIVATE_KEY_LEN)
@@ -73,4 +80,16 @@ PublicPtr HsmSM2KeyPair::priToPub(SecretPtr _secretKey)
             PriToPublicKeyException() << errinfo_comment("HsmSM2PriToPub exception"));
     }
     return pubKey;
+}
+
+void HsmSM2KeyPair::setKeyIndex(unsigned int _keyIndex)
+{
+    m_keyIndex = _keyIndex;
+    m_isInternalKey = true;
+}
+
+void HsmSM2KeyPair::setPassword(std::string _password)
+{
+    m_password = std::move(_password);
+    m_isInternalKey = true;
 }

--- a/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2KeyPair.h
+++ b/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2KeyPair.h
@@ -35,12 +35,7 @@ class HsmSM2KeyPair : public KeyPair
 {
 public:
     using Ptr = std::shared_ptr<HsmSM2KeyPair>;
-    HsmSM2KeyPair(std::string _libPath)
-      : KeyPair(HSM_SM2_PUBLIC_KEY_LEN, HSM_SM2_PRIVATE_KEY_LEN, KeyPairType::HsmSM2)
-    {
-        m_hsmLibPath = _libPath;
-        m_publicKeyDeriver = wedpr_sm2_derive_public_key;
-    }
+    HsmSM2KeyPair(std::string _libPath);
     HsmSM2KeyPair(std::string _libPath, SecretPtr _secretKey);
     HsmSM2KeyPair(std::string _libPath, unsigned int _keyIndex, std::string _password);
     ~HsmSM2KeyPair() override {}
@@ -51,17 +46,9 @@ public:
     const std::string& hsmLibPath() const { return m_hsmLibPath; }
     void setHsmLibPath(std::string _libPath) { m_hsmLibPath = _libPath; }
     unsigned int keyIndex() const { return m_keyIndex; }
-    void setKeyIndex(unsigned int _keyIndex)
-    {
-        m_keyIndex = _keyIndex;
-        m_isInternalKey = true;
-    }
+    void setKeyIndex(unsigned int _keyIndex);
     const std::string& password() const { return m_password; }
-    void setPassword(std::string _password)
-    {
-        m_password = _password;
-        m_isInternalKey = true;
-    }
+    void setPassword(std::string _password);
 
 private:
     std::function<int8_t(const CInputBuffer* private_key, COutputBuffer* output_public_key)>

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1KeyPair.cpp
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1KeyPair.cpp
@@ -24,6 +24,22 @@
 #include <wedpr-crypto/WedprUtilities.h>
 #include <wedpr-crypto/WedprCrypto.h>
 
+bcos::crypto::Secp256k1KeyPair::Secp256k1KeyPair()
+  : KeyPair(SECP256K1_PUBLIC_LEN, SECP256K1_PRIVATE_LEN, KeyPairType::Secp256K1)
+{}
+
+bcos::crypto::Secp256k1KeyPair::Secp256k1KeyPair(SecretPtr _secretKey) : Secp256k1KeyPair()
+{
+    m_secretKey = _secretKey;
+    m_publicKey = priToPub(_secretKey);
+    m_type = KeyPairType::Secp256K1;
+}
+
+bcos::crypto::PublicPtr bcos::crypto::Secp256k1KeyPair::priToPub(SecretPtr _secret)
+{
+    return secp256k1PriToPub(_secret);
+}
+
 bcos::crypto::PublicPtr bcos::crypto::secp256k1PriToPub(bcos::crypto::SecretPtr _secret)
 {
     CInputBuffer privateKey{_secret->constData(), _secret->size()};

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1KeyPair.h
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1KeyPair.h
@@ -32,15 +32,8 @@ class Secp256k1KeyPair : public KeyPair
 {
 public:
     using Ptr = std::shared_ptr<Secp256k1KeyPair>;
-    Secp256k1KeyPair()
-      : KeyPair(SECP256K1_PUBLIC_LEN, SECP256K1_PRIVATE_LEN, KeyPairType::Secp256K1)
-    {}
-    explicit Secp256k1KeyPair(SecretPtr _secretKey) : Secp256k1KeyPair()
-    {
-        m_secretKey = _secretKey;
-        m_publicKey = priToPub(_secretKey);
-        m_type = KeyPairType::Secp256K1;
-    }
-    virtual PublicPtr priToPub(SecretPtr _secret) { return secp256k1PriToPub(_secret); }
+  Secp256k1KeyPair();
+  explicit Secp256k1KeyPair(SecretPtr _secretKey);
+  virtual PublicPtr priToPub(SecretPtr _secret);
 };
 }  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
@@ -26,6 +26,14 @@
 
 using namespace bcos;
 using namespace bcos::crypto;
+
+SM2Crypto::SM2Crypto()
+{
+    m_signer = wedpr_sm2_sign_fast;
+    m_verifier = wedpr_sm2_verify;
+    m_keyPairFactory = std::make_shared<SM2KeyPairFactory>();
+}
+
 bool SM2Crypto::verify(std::shared_ptr<bytes const> _pubKeyBytes, const HashType& _hash,
     bytesConstRef _signatureData) const
 {

--- a/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.h
+++ b/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.h
@@ -33,12 +33,7 @@ class SM2Crypto : public SignatureCrypto
 {
 public:
     using Ptr = std::shared_ptr<SM2Crypto>;
-    SM2Crypto()
-    {
-        m_signer = wedpr_sm2_sign_fast;
-        m_verifier = wedpr_sm2_verify;
-        m_keyPairFactory = std::make_shared<SM2KeyPairFactory>();
-    }
+    SM2Crypto();
     ~SM2Crypto() = default;
     std::shared_ptr<bytes> sign(const KeyPairInterface& _keyPair, const HashType& _hash,
         bool _signatureWithPub = false) const override;

--- a/bcos-executor/src/precompiled/CryptoPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/CryptoPrecompiled.cpp
@@ -27,6 +27,8 @@
 #include "bcos-executor/src/precompiled/common/PrecompiledResult.h"
 #include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-framework/protocol/Protocol.h"
+#include <wedpr-crypto/WedprCrypto.h>
+#include <wedpr-crypto/WedprUtilities.h>
 
 using namespace bcos;
 using namespace bcos::codec;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/Web3Endpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/Web3Endpoint.cpp
@@ -21,6 +21,7 @@
 #include "Web3Endpoint.h"
 #include "include/BuildInfo.h"
 #include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 using namespace bcos::rpc;
 bcos::task::Task<void> Web3Endpoint::clientVersion(

--- a/libinitializer/LedgerInitializer.cpp
+++ b/libinitializer/LedgerInitializer.cpp
@@ -1,6 +1,7 @@
 #include "LedgerInitializer.h"
 #include "bcos-ledger/LedgerImpl.h"
 #include "bcos-storage/bcos-storage/StorageWrapperImpl.h"
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
 
 std::shared_ptr<bcos::ledger::Ledger> bcos::initializer::LedgerInitializer::build(
     bcos::protocol::BlockFactory::Ptr blockFactory, bcos::storage::StorageInterface::Ptr storage,


### PR DESCRIPTION
Move implementation details from header files into corresponding CPP source files to improve code organization and maintainability. This change enhances clarity by separating interface from implementation.