### PR TITLE
Move header implementation to cpp files

### DIFF
--- a/bcos-boostssl/bcos-boostssl/context/Common.cpp
+++ b/bcos-boostssl/bcos-boostssl/context/Common.cpp
@@ -12,25 +12,25 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
- * @file Common.h
- * @author: octopus
- * @date 2021-06-14
  */
 
-#pragma once
-#include <bcos-utilities/BoostLog.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
+#include <bcos-boostssl/context/Common.h>
 
+using namespace bcos::boostssl;
 
-#define CONTEXT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][CTX]"
-#define NODEINFO_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][NODEINFO]"
-
-namespace bcos::boostssl
+X509* bcos::boostssl::toX509(const char* _pemBuffer)
 {
-X509* toX509(const char* _pemBuffer);
+    BIO* bio_mem = BIO_new(BIO_s_mem());
+    BIO_puts(bio_mem, _pemBuffer);
+    X509* x509 = PEM_read_bio_X509(bio_mem, NULL, NULL, NULL);
+    BIO_free(bio_mem);
+    return x509;
+}
 
-EVP_PKEY* toEvpPkey(const char* _pemBuffer);
-
-}  // namespace bcos::boostssl
+EVP_PKEY* bcos::boostssl::toEvpPkey(const char* _pemBuffer)
+{
+    BIO* bio_mem = BIO_new_mem_buf(_pemBuffer, -1);
+    EVP_PKEY* pkey = PEM_read_bio_PrivateKey(bio_mem, NULL, NULL, NULL);
+    BIO_free(bio_mem);
+    return pkey;
+}

--- a/bcos-boostssl/bcos-boostssl/context/ContextConfig.cpp
+++ b/bcos-boostssl/bcos-boostssl/context/ContextConfig.cpp
@@ -126,3 +126,43 @@ void ContextConfig::checkFileExist(const std::string& _path)
         BOOST_THROW_EXCEPTION(std::runtime_error("file not exist: " + _path));
     }
 }
+
+bool ContextConfig::isCertPath() const
+{
+    return m_isCertPath;
+}
+
+void ContextConfig::setIsCertPath(bool _isCertPath)
+{
+    m_isCertPath = _isCertPath;
+}
+
+std::string ContextConfig::sslType() const
+{
+    return m_sslType;
+}
+
+void ContextConfig::setSslType(std::string _sslType)
+{
+    m_sslType = std::move(_sslType);
+}
+
+const ContextConfig::CertConfig& ContextConfig::certConfig() const
+{
+    return m_certConfig;
+}
+
+void ContextConfig::setCertConfig(const CertConfig& _certConfig)
+{
+    m_certConfig = _certConfig;
+}
+
+const ContextConfig::SMCertConfig& ContextConfig::smCertConfig() const
+{
+    return m_smCertConfig;
+}
+
+void ContextConfig::setSmCertConfig(const SMCertConfig& _smCertConfig)
+{
+    m_smCertConfig = _smCertConfig;
+}

--- a/bcos-boostssl/bcos-boostssl/context/ContextConfig.h
+++ b/bcos-boostssl/bcos-boostssl/context/ContextConfig.h
@@ -55,17 +55,17 @@ public:
     void checkFileExist(const std::string& _path);
 
 public:
-    bool isCertPath() const { return m_isCertPath; }
-    void setIsCertPath(bool _isCertPath) { m_isCertPath = _isCertPath; }
+    bool isCertPath() const;
+    void setIsCertPath(bool _isCertPath);
 
-    std::string sslType() const { return m_sslType; }
-    void setSslType(std::string _sslType) { m_sslType = std::move(_sslType); }
+    std::string sslType() const;
+    void setSslType(std::string _sslType);
 
-    const CertConfig& certConfig() const { return m_certConfig; }
-    void setCertConfig(const CertConfig& _certConfig) { m_certConfig = _certConfig; }
+    const CertConfig& certConfig() const;
+    void setCertConfig(const CertConfig& _certConfig);
 
-    const SMCertConfig& smCertConfig() const { return m_smCertConfig; }
-    void setSmCertConfig(const SMCertConfig& _smCertConfig) { m_smCertConfig = _smCertConfig; }
+    const SMCertConfig& smCertConfig() const;
+    void setSmCertConfig(const SMCertConfig& _smCertConfig);
 
 private:
     // is the cert path or cert file content

--- a/bcos-boostssl/bcos-boostssl/httpserver/Common.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/Common.cpp
@@ -12,25 +12,14 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
- * @file Common.h
- * @author: octopus
- * @date 2021-06-14
  */
 
-#pragma once
-#include <bcos-utilities/BoostLog.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
+#include <bcos-boostssl/httpserver/Common.h>
 
-
-#define CONTEXT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][CTX]"
-#define NODEINFO_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][NODEINFO]"
-
-namespace bcos::boostssl
+std::string bcos::boostssl::http::CorsConfig::toString() const
 {
-X509* toX509(const char* _pemBuffer);
-
-EVP_PKEY* toEvpPkey(const char* _pemBuffer);
-
-}  // namespace bcos::boostssl
+    return std::string("CorsConfig{") + "enableCORS=" + (enableCORS ? "true" : "false") +
+           ", allowedOrigins=" + allowedOrigins + ", allowedMethods=" + allowedMethods +
+           ", allowedHeaders=" + allowedHeaders + ", maxAge=" + std::to_string(maxAge) +
+           ", allowCredentials=" + (allowCredentials ? "true" : "false") + "}}";
+}

--- a/bcos-boostssl/bcos-boostssl/httpserver/Common.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/Common.h
@@ -56,12 +56,6 @@ struct CorsConfig
     std::string allowedHeaders{"Content-Type, Authorization, X-Requested-With"};
     int maxAge{86400};
 
-    std::string toString() const
-    {
-        return std::string("CorsConfig{") + "enableCORS=" + (enableCORS ? "true" : "false") +
-               ", allowedOrigins=" + allowedOrigins + ", allowedMethods=" + allowedMethods +
-               ", allowedHeaders=" + allowedHeaders + ", maxAge=" + std::to_string(maxAge) +
-               ", allowCredentials=" + (allowCredentials ? "true" : "false") + "}}";
-    }
+    std::string toString() const;
 };
 }  // namespace bcos::boostssl::http

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -29,6 +29,19 @@ using namespace bcos::boostssl;
 using namespace bcos::boostssl::http;
 using namespace bcos::boostssl::context;
 
+HttpServer::HttpServer(std::string _listenIP, uint16_t _listenPort, uint32_t _httpBodySizeLimit,
+        CorsConfig _corsConfig)
+    : m_listenIP(std::move(_listenIP)),
+        m_listenPort(_listenPort),
+        m_httpBodySizeLimit(_httpBodySizeLimit),
+        m_corsConfig(std::move(_corsConfig))
+{}
+
+HttpServer::~HttpServer()
+{
+        stop();
+}
+
 // start http server
 void HttpServer::start()
 {
@@ -212,6 +225,91 @@ HttpSession::Ptr HttpServer::buildHttpSession(
     session->setNodeId(std::move(_nodeId));
 
     return session;
+}
+
+HttpReqHandler HttpServer::httpReqHandler() const
+{
+    return m_httpReqHandler;
+}
+
+void HttpServer::setHttpReqHandler(HttpReqHandler _httpReqHandler)
+{
+    m_httpReqHandler = std::move(_httpReqHandler);
+}
+
+std::shared_ptr<boost::asio::ip::tcp::acceptor> HttpServer::acceptor() const
+{
+    return m_acceptor;
+}
+
+void HttpServer::setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor)
+{
+    m_acceptor = std::move(_acceptor);
+}
+
+std::shared_ptr<boost::asio::ssl::context> HttpServer::ctx() const
+{
+    return m_ctx;
+}
+
+void HttpServer::setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx)
+{
+    m_ctx = std::move(_ctx);
+}
+
+WsUpgradeHandler HttpServer::wsUpgradeHandler() const
+{
+    return m_wsUpgradeHandler;
+}
+
+void HttpServer::setWsUpgradeHandler(WsUpgradeHandler _wsUpgradeHandler)
+{
+    m_wsUpgradeHandler = std::move(_wsUpgradeHandler);
+}
+
+HttpStreamFactory::Ptr HttpServer::httpStreamFactory() const
+{
+    return m_httpStreamFactory;
+}
+
+void HttpServer::setHttpStreamFactory(HttpStreamFactory::Ptr _httpStreamFactory)
+{
+    m_httpStreamFactory = std::move(_httpStreamFactory);
+}
+
+bool HttpServer::disableSsl() const
+{
+    return m_disableSsl;
+}
+
+void HttpServer::setDisableSsl(bool _disableSsl)
+{
+    m_disableSsl = _disableSsl;
+}
+
+void HttpServer::setIOServicePool(bcos::IOServicePool::Ptr _ioservicePool)
+{
+    m_ioservicePool = std::move(_ioservicePool);
+}
+
+uint32_t HttpServer::httpBodySizeLimit() const
+{
+    return m_httpBodySizeLimit;
+}
+
+void HttpServer::setHttpBodySizeLimit(uint32_t _httpBodySizeLimit)
+{
+    m_httpBodySizeLimit = _httpBodySizeLimit;
+}
+
+CorsConfig HttpServer::corsConfig() const
+{
+    return m_corsConfig;
+}
+
+void HttpServer::setCorsConfig(CorsConfig _corsConfig)
+{
+    m_corsConfig = std::move(_corsConfig);
 }
 
 /**

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.h
@@ -31,14 +31,9 @@ public:
     using Ptr = std::shared_ptr<HttpServer>;
 
     HttpServer(std::string _listenIP, uint16_t _listenPort, uint32_t _httpBodySizeLimit,
-        CorsConfig _corsConfig)
-      : m_listenIP(std::move(_listenIP)),
-        m_listenPort(_listenPort),
-        m_httpBodySizeLimit(_httpBodySizeLimit),
-        m_corsConfig(std::move(_corsConfig))
-    {}
+        CorsConfig _corsConfig);
 
-    ~HttpServer() { stop(); }
+    ~HttpServer();
 
     // start http server
     void start();
@@ -52,49 +47,31 @@ public:
     HttpSession::Ptr buildHttpSession(
         HttpStream::Ptr _stream, std::shared_ptr<std::string> _nodeId);
 
-    HttpReqHandler httpReqHandler() const { return m_httpReqHandler; }
-    void setHttpReqHandler(HttpReqHandler _httpReqHandler)
-    {
-        m_httpReqHandler = std::move(_httpReqHandler);
-    }
+    HttpReqHandler httpReqHandler() const;
+    void setHttpReqHandler(HttpReqHandler _httpReqHandler);
 
-    std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor() const { return m_acceptor; }
-    void setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor)
-    {
-        m_acceptor = std::move(_acceptor);
-    }
+    std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor() const;
+    void setAcceptor(std::shared_ptr<boost::asio::ip::tcp::acceptor> _acceptor);
 
-    std::shared_ptr<boost::asio::ssl::context> ctx() const { return m_ctx; }
-    void setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx) { m_ctx = std::move(_ctx); }
+    std::shared_ptr<boost::asio::ssl::context> ctx() const;
+    void setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx);
 
-    WsUpgradeHandler wsUpgradeHandler() const { return m_wsUpgradeHandler; }
-    void setWsUpgradeHandler(WsUpgradeHandler _wsUpgradeHandler)
-    {
-        m_wsUpgradeHandler = std::move(_wsUpgradeHandler);
-    }
+    WsUpgradeHandler wsUpgradeHandler() const;
+    void setWsUpgradeHandler(WsUpgradeHandler _wsUpgradeHandler);
 
-    HttpStreamFactory::Ptr httpStreamFactory() const { return m_httpStreamFactory; }
-    void setHttpStreamFactory(HttpStreamFactory::Ptr _httpStreamFactory)
-    {
-        m_httpStreamFactory = std::move(_httpStreamFactory);
-    }
+    HttpStreamFactory::Ptr httpStreamFactory() const;
+    void setHttpStreamFactory(HttpStreamFactory::Ptr _httpStreamFactory);
 
-    bool disableSsl() const { return m_disableSsl; }
-    void setDisableSsl(bool _disableSsl) { m_disableSsl = _disableSsl; }
+    bool disableSsl() const;
+    void setDisableSsl(bool _disableSsl);
 
-    void setIOServicePool(bcos::IOServicePool::Ptr _ioservicePool)
-    {
-        m_ioservicePool = std::move(_ioservicePool);
-    }
+    void setIOServicePool(bcos::IOServicePool::Ptr _ioservicePool);
 
-    uint32_t httpBodySizeLimit() const { return m_httpBodySizeLimit; }
-    void setHttpBodySizeLimit(uint32_t _httpBodySizeLimit)
-    {
-        m_httpBodySizeLimit = _httpBodySizeLimit;
-    }
+    uint32_t httpBodySizeLimit() const;
+    void setHttpBodySizeLimit(uint32_t _httpBodySizeLimit);
 
-    CorsConfig corsConfig() const { return m_corsConfig; }
-    void setCorsConfig(CorsConfig _corsConfig) { m_corsConfig = std::move(_corsConfig); }
+    CorsConfig corsConfig() const;
+    void setCorsConfig(CorsConfig _corsConfig);
 
 private:
     std::string m_listenIP;

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
@@ -248,3 +248,23 @@ void bcos::boostssl::http::HttpSession::setNodeId(std::shared_ptr<std::string> _
 {
     m_nodeId = std::move(_nodeId);
 }
+
+uint32_t bcos::boostssl::http::HttpSession::httpBodySizeLimit() const
+{
+    return m_httpBodySizeLimit;
+}
+
+void bcos::boostssl::http::HttpSession::setHttpBodySizeLimit(uint32_t _httpBodySizeLimit)
+{
+    m_httpBodySizeLimit = _httpBodySizeLimit;
+}
+
+bcos::boostssl::http::CorsConfig bcos::boostssl::http::HttpSession::corsConfig() const
+{
+    return m_corsConfig;
+}
+
+void bcos::boostssl::http::HttpSession::setCorsConfig(CorsConfig _corsConfig)
+{
+    m_corsConfig = std::move(_corsConfig);
+}

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.h
@@ -85,13 +85,10 @@ public:
     std::shared_ptr<std::string> nodeId();
     void setNodeId(std::shared_ptr<std::string> _nodeId);
 
-    uint32_t httpBodySizeLimit() const { return m_httpBodySizeLimit; }
-    void setHttpBodySizeLimit(uint32_t _httpBodySizeLimit)
-    {
-        m_httpBodySizeLimit = _httpBodySizeLimit;
-    }
-    CorsConfig corsConfig() const { return m_corsConfig; }
-    void setCorsConfig(CorsConfig _corsConfig) { m_corsConfig = std::move(_corsConfig); }
+    uint32_t httpBodySizeLimit() const;
+    void setHttpBodySizeLimit(uint32_t _httpBodySizeLimit);
+    CorsConfig corsConfig() const;
+    void setCorsConfig(CorsConfig _corsConfig);
 
 private:
     HttpStream::Ptr m_httpStream;

--- a/bcos-boostssl/bcos-boostssl/interfaces/MessageFace.cpp
+++ b/bcos-boostssl/bcos-boostssl/interfaces/MessageFace.cpp
@@ -12,25 +12,14 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
- * @file Common.h
- * @author: octopus
- * @date 2021-06-14
  */
 
-#pragma once
-#include <bcos-utilities/BoostLog.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
+#include <bcos-boostssl/interfaces/MessageFace.h>
+#include <algorithm>
 
-
-#define CONTEXT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][CTX]"
-#define NODEINFO_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][NODEINFO]"
-
-namespace bcos::boostssl
+std::string bcos::boostssl::MessageFaceFactory::newSeq()
 {
-X509* toX509(const char* _pemBuffer);
-
-EVP_PKEY* toEvpPkey(const char* _pemBuffer);
-
-}  // namespace bcos::boostssl
+    std::string seq = boost::uuids::to_string(boost::uuids::random_generator()());
+    seq.erase(std::remove(seq.begin(), seq.end(), '-'), seq.end());
+    return seq;
+}

--- a/bcos-boostssl/bcos-boostssl/interfaces/MessageFace.h
+++ b/bcos-boostssl/bcos-boostssl/interfaces/MessageFace.h
@@ -72,12 +72,7 @@ public:
 
     virtual MessageFace::Ptr buildMessage() = 0;
 
-    virtual std::string newSeq()
-    {
-        std::string seq = boost::uuids::to_string(boost::uuids::random_generator()());
-        seq.erase(std::remove(seq.begin(), seq.end(), '-'), seq.end());
-        return seq;
-    }
+    virtual std::string newSeq();
 };
 
 }  // namespace bcos::boostssl

--- a/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.cpp
+++ b/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.cpp
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bcos-boostssl/interfaces/NodeInfoDef.h>
+
+bcos::boostssl::NodeIPEndpoint::NodeIPEndpoint(std::string _host, uint16_t _port)
+  : m_host(std::move(_host)), m_port(_port)
+{}
+
+bcos::boostssl::NodeIPEndpoint::NodeIPEndpoint(
+    const boost::asio::ip::address& _addr, uint16_t _port)
+  : m_host(_addr.to_string()), m_port(_port), m_ipv6(_addr.is_v6())
+{}
+
+bcos::boostssl::NodeIPEndpoint::NodeIPEndpoint(
+    const boost::asio::ip::tcp::endpoint& _endpoint)
+  : m_host(_endpoint.address().to_string()),
+    m_port(_endpoint.port()),
+    m_ipv6(_endpoint.address().is_v6())
+{}
+
+bool bcos::boostssl::NodeIPEndpoint::operator<(const NodeIPEndpoint& rhs) const
+{
+    if (m_host != rhs.m_host)
+    {
+        return m_host < rhs.m_host;
+    }
+    return m_port < rhs.m_port;
+}
+
+bool bcos::boostssl::NodeIPEndpoint::operator==(const NodeIPEndpoint& rhs) const
+{
+    return m_host == rhs.m_host && m_port == rhs.m_port;
+}
+
+bcos::boostssl::NodeIPEndpoint::operator boost::asio::ip::tcp::endpoint() const
+{
+    return {boost::asio::ip::make_address(m_host), m_port};
+}
+
+uint16_t bcos::boostssl::NodeIPEndpoint::port() const
+{
+    return m_port;
+}
+
+std::string bcos::boostssl::NodeIPEndpoint::address() const
+{
+    return m_host;
+}
+
+bool bcos::boostssl::NodeIPEndpoint::isIPv6() const
+{
+    return m_ipv6;
+}
+
+std::ostream& bcos::boostssl::operator<<(std::ostream& _out, NodeIPEndpoint const& _endpoint)
+{
+    _out << _endpoint.address() << ":" << _endpoint.port();
+    return _out;
+}

--- a/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.h
+++ b/bcos-boostssl/bcos-boostssl/interfaces/NodeInfoDef.h
@@ -35,56 +35,31 @@ struct NodeIPEndpoint
 {
     using Ptr = std::shared_ptr<NodeIPEndpoint>;
     NodeIPEndpoint() = default;
-    NodeIPEndpoint(std::string _host, uint16_t _port) : m_host(std::move(_host)), m_port(_port) {}
-    NodeIPEndpoint(const boost::asio::ip::address& _addr, uint16_t _port)
-      : m_host(_addr.to_string()), m_port(_port), m_ipv6(_addr.is_v6())
-    {}
+        NodeIPEndpoint(std::string _host, uint16_t _port);
+        NodeIPEndpoint(const boost::asio::ip::address& _addr, uint16_t _port);
     NodeIPEndpoint(const NodeIPEndpoint& _nodeIPEndpoint) = default;
     NodeIPEndpoint(NodeIPEndpoint&& _nodeIPEndpoint) noexcept = default;
     NodeIPEndpoint& operator=(const NodeIPEndpoint& _nodeIPEndpoint) = default;
     NodeIPEndpoint& operator=(NodeIPEndpoint&& _nodeIPEndpoint) noexcept = default;
 
     virtual ~NodeIPEndpoint() = default;
-    NodeIPEndpoint(const boost::asio::ip::tcp::endpoint& _endpoint)
-      : m_host(_endpoint.address().to_string()),
-        m_port(_endpoint.port()),
-        m_ipv6(_endpoint.address().is_v6())
-    {}
-    bool operator<(const NodeIPEndpoint& rhs) const
-    {
-        // return m_host + std::to_string(m_port) < rhs.m_host + std::to_string(rhs.m_port);
-
-        if (m_host != rhs.m_host)
-        {
-            return m_host < rhs.m_host;
-        }
-        return m_port < rhs.m_port;
-    }
-    bool operator==(const NodeIPEndpoint& rhs) const
-    {
-        return m_host == rhs.m_host && m_port == rhs.m_port;
-    }
-    operator boost::asio::ip::tcp::endpoint() const
-    {
-        return {boost::asio::ip::make_address(m_host), m_port};
-    }
+    NodeIPEndpoint(const boost::asio::ip::tcp::endpoint& _endpoint);
+    bool operator<(const NodeIPEndpoint& rhs) const;
+    bool operator==(const NodeIPEndpoint& rhs) const;
+    operator boost::asio::ip::tcp::endpoint() const;
 
     // Get the port associated with the endpoint.
-    uint16_t port() const { return m_port; }
+    uint16_t port() const;
 
     // Get the IP address associated with the endpoint.
-    std::string address() const { return m_host; }
-    bool isIPv6() const { return m_ipv6; }
+    std::string address() const;
+    bool isIPv6() const;
 
     std::string m_host;
     uint16_t m_port = 0;
     bool m_ipv6 = false;
 };
 
-inline std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _endpoint)
-{
-    _out << _endpoint.address() << ":" << _endpoint.port();
-    return _out;
-}
+std::ostream& operator<<(std::ostream& _out, NodeIPEndpoint const& _endpoint);
 
 }  // namespace bcos::boostssl

--- a/bcos-boostssl/bcos-boostssl/websocket/Common.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/Common.cpp
@@ -12,25 +12,10 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
- * @file Common.h
- * @author: octopus
- * @date 2021-06-14
  */
 
-#pragma once
-#include <bcos-utilities/BoostLog.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
+#include <bcos-boostssl/websocket/Common.h>
 
+bcos::boostssl::ws::Options::Options(uint32_t _timeout) : timeout(_timeout) {}
 
-#define CONTEXT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][CTX]"
-#define NODEINFO_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][NODEINFO]"
-
-namespace bcos::boostssl
-{
-X509* toX509(const char* _pemBuffer);
-
-EVP_PKEY* toEvpPkey(const char* _pemBuffer);
-
-}  // namespace bcos::boostssl
+bcos::boostssl::ws::Options::Options() = default;

--- a/bcos-boostssl/bcos-boostssl/websocket/Common.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/Common.h
@@ -54,8 +54,8 @@ using VerifyCallback = boost::function<bool(bool, boost::asio::ssl::verify_conte
 
 struct Options
 {
-    Options(uint32_t _timeout) : timeout(_timeout) {}
-    Options() = default;
+    Options(uint32_t _timeout);
+    Options();
     uint32_t timeout = 0;  ///< The timeout value of async function, in milliseconds.
 };
 

--- a/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.cpp
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bcos-boostssl/websocket/RawWsMessage.h>
+
+using namespace bcos::boostssl::ws;
+
+RawWsMessage::RawWsMessage()
+{
+    m_payload = std::make_shared<bcos::bytes>();
+    if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
+    {
+        WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[NEWOBJ][RawWsMessage]", this);
+    }
+}
+
+RawWsMessage::~RawWsMessage()
+{
+    if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
+    {
+        WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[DELOBJ][RawWsMessage]", this);
+    }
+}
+
+uint16_t RawWsMessage::version() const
+{
+    return 0;
+}
+
+void RawWsMessage::setVersion(uint16_t)
+{}
+
+uint16_t RawWsMessage::packetType() const
+{
+    return m_packetType;
+}
+
+void RawWsMessage::setPacketType(uint16_t)
+{}
+
+std::string const& RawWsMessage::seq() const
+{
+    return m_seq;
+}
+
+void RawWsMessage::setSeq(std::string _seq)
+{
+    m_seq = std::move(_seq);
+}
+
+std::shared_ptr<bcos::bytes> RawWsMessage::payload() const
+{
+    return m_payload;
+}
+
+void RawWsMessage::setPayload(std::shared_ptr<bcos::bytes> _payload)
+{
+    m_payload = std::move(_payload);
+}
+
+uint16_t RawWsMessage::ext() const
+{
+    return 0;
+}
+
+void RawWsMessage::setExt(uint16_t)
+{}
+
+bool RawWsMessage::encode(bcos::bytes& _buffer)
+{
+    _buffer.insert(_buffer.end(), m_payload->begin(), m_payload->end());
+    return true;
+}
+
+int64_t RawWsMessage::decode(bytesConstRef _buffer)
+{
+    m_payload = std::make_shared<bcos::bytes>(_buffer.begin(), _buffer.end());
+    return static_cast<int64_t>(_buffer.size());
+}
+
+bool RawWsMessage::isRespPacket() const
+{
+    return false;
+}
+
+void RawWsMessage::setRespPacket()
+{}
+
+uint32_t RawWsMessage::length() const
+{
+    return m_payload->size();
+}
+
+bcos::boostssl::MessageFace::Ptr RawWsMessageFactory::buildMessage()
+{
+    return std::make_shared<RawWsMessage>();
+}

--- a/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.h
@@ -36,58 +36,34 @@ class RawWsMessage : public boostssl::MessageFace, public bcos::ObjectCounter<Ra
 {
 public:
     using Ptr = std::shared_ptr<RawWsMessage>;
-    RawWsMessage()
-    {
-        m_payload = std::make_shared<bcos::bytes>();
-        if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
-        {
-            WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[NEWOBJ][RawWsMessage]", this);
-        }
-    }
+    RawWsMessage();
 
     RawWsMessage(const RawWsMessage&) = delete;
     RawWsMessage& operator=(const RawWsMessage&) = delete;
     RawWsMessage(RawWsMessage&&) = delete;
     RawWsMessage& operator=(RawWsMessage&&) = delete;
-    ~RawWsMessage() override
-    {
-        if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
-        {
-            WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[DELOBJ][RawWsMessage]", this);
-        }
-    }
+    ~RawWsMessage() override;
 
-    uint16_t version() const override { return 0; }
-    void setVersion(uint16_t /*unused*/) override {}
-    uint16_t packetType() const override { return m_packetType; }
-    void setPacketType(uint16_t _packetType) override {}
+    uint16_t version() const override;
+    void setVersion(uint16_t /*unused*/) override;
+    uint16_t packetType() const override;
+    void setPacketType(uint16_t _packetType) override;
 
-    std::string const& seq() const override { return m_seq; }
-    void setSeq(std::string _seq) override { m_seq = _seq; }
-    std::shared_ptr<bcos::bytes> payload() const override { return m_payload; }
-    void setPayload(std::shared_ptr<bcos::bytes> _payload) override
-    {
-        m_payload = std::move(_payload);
-    }
-    uint16_t ext() const override { return 0; }
-    void setExt(uint16_t /*unused*/) override {}
+    std::string const& seq() const override;
+    void setSeq(std::string _seq) override;
+    std::shared_ptr<bcos::bytes> payload() const override;
+    void setPayload(std::shared_ptr<bcos::bytes> _payload) override;
+    uint16_t ext() const override;
+    void setExt(uint16_t /*unused*/) override;
 
-    bool encode(bcos::bytes& _buffer) override
-    {
-        _buffer.insert(_buffer.end(), m_payload->begin(), m_payload->end());
-        return true;
-    }
+    bool encode(bcos::bytes& _buffer) override;
 
-    int64_t decode(bytesConstRef _buffer) override
-    {
-        m_payload = std::make_shared<bcos::bytes>(_buffer.begin(), _buffer.end());
-        return static_cast<int64_t>(_buffer.size());
-    }
+    int64_t decode(bytesConstRef _buffer) override;
 
-    bool isRespPacket() const override { return false; }
-    void setRespPacket() override {}
+    bool isRespPacket() const override;
+    void setRespPacket() override;
 
-    uint32_t length() const override { return m_payload->size(); }
+    uint32_t length() const override;
 
 private:
     uint16_t m_packetType = WS_RAW_MESSAGE_TYPE;
@@ -106,11 +82,7 @@ public:
     RawWsMessageFactory& operator=(RawWsMessageFactory&&) = delete;
     ~RawWsMessageFactory() override = default;
 
-    boostssl::MessageFace::Ptr buildMessage() override
-    {
-        auto msg = std::make_shared<RawWsMessage>();
-        return msg;
-    }
+    boostssl::MessageFace::Ptr buildMessage() override;
 };
 
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConfig.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConfig.cpp
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bcos-boostssl/websocket/WsConfig.h>
+
+using namespace bcos::boostssl::ws;
+
+void WsConfig::setModel(WsModel _model)
+{
+    m_model = _model;
+}
+
+WsModel WsConfig::model() const
+{
+    return m_model;
+}
+
+bool WsConfig::asClient() const
+{
+    return (m_model & WsModel::Client) != 0;
+}
+
+bool WsConfig::asServer() const
+{
+    return (m_model & WsModel::Server) != 0;
+}
+
+void WsConfig::setListenIP(std::string _listenIP)
+{
+    m_listenIP = std::move(_listenIP);
+}
+
+std::string WsConfig::listenIP() const
+{
+    return m_listenIP;
+}
+
+void WsConfig::setListenPort(uint16_t _listenPort)
+{
+    m_listenPort = _listenPort;
+}
+
+uint16_t WsConfig::listenPort() const
+{
+    return m_listenPort;
+}
+
+void WsConfig::setSmSSL(bool _isSmSSL)
+{
+    m_smSSL = _isSmSSL;
+}
+
+bool WsConfig::smSSL() const
+{
+    return m_smSSL;
+}
+
+void WsConfig::setMaxMsgSize(uint32_t _maxMsgSize)
+{
+    m_maxMsgSize = _maxMsgSize;
+}
+
+uint32_t WsConfig::maxMsgSize() const
+{
+    return m_maxMsgSize;
+}
+
+uint32_t WsConfig::reconnectPeriod() const
+{
+    return m_reconnectPeriod > MIN_RECONNECT_PERIOD_MS ? m_reconnectPeriod :
+                                                         MIN_RECONNECT_PERIOD_MS;
+}
+
+void WsConfig::setReconnectPeriod(uint32_t _reconnectPeriod)
+{
+    m_reconnectPeriod = _reconnectPeriod;
+}
+
+uint32_t WsConfig::heartbeatPeriod() const
+{
+    return m_heartbeatPeriod > MIN_HEART_BEAT_PERIOD_MS ? m_heartbeatPeriod :
+                                                          MIN_HEART_BEAT_PERIOD_MS;
+}
+
+void WsConfig::setHeartbeatPeriod(uint32_t _heartbeatPeriod)
+{
+    m_heartbeatPeriod = _heartbeatPeriod;
+}
+
+int32_t WsConfig::sendMsgTimeout() const
+{
+    return m_sendMsgTimeout;
+}
+
+void WsConfig::setSendMsgTimeout(int32_t _sendMsgTimeout)
+{
+    m_sendMsgTimeout = _sendMsgTimeout;
+}
+
+uint32_t WsConfig::threadPoolSize() const
+{
+    return m_threadPoolSize != 0U ? m_threadPoolSize : MIN_THREAD_POOL_SIZE;
+}
+
+void WsConfig::setThreadPoolSize(uint32_t _threadPoolSize)
+{
+    m_threadPoolSize = _threadPoolSize;
+}
+
+EndPointsPtr WsConfig::connectPeers() const
+{
+    return m_connectPeers;
+}
+
+void WsConfig::setConnectPeers(EndPointsPtr _connectPeers)
+{
+    m_connectPeers = std::move(_connectPeers);
+}
+
+bool WsConfig::disableSsl() const
+{
+    return m_disableSsl;
+}
+
+void WsConfig::setDisableSsl(bool _disableSsl)
+{
+    m_disableSsl = _disableSsl;
+}
+
+std::shared_ptr<bcos::boostssl::context::ContextConfig> WsConfig::contextConfig() const
+{
+    return m_contextConfig;
+}
+
+void WsConfig::setContextConfig(std::shared_ptr<bcos::boostssl::context::ContextConfig> _contextConfig)
+{
+    m_contextConfig = std::move(_contextConfig);
+}
+
+bcos::boostssl::http::CorsConfig WsConfig::corsConfig() const
+{
+    return m_corsConfig;
+}
+
+void WsConfig::setCorsConfig(bcos::boostssl::http::CorsConfig _corsConfig)
+{
+    m_corsConfig = std::move(_corsConfig);
+}

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConfig.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConfig.h
@@ -93,59 +93,45 @@ private:
     http::CorsConfig m_corsConfig;
 
 public:
-    void setModel(WsModel _model) { m_model = _model; }
-    WsModel model() const { return m_model; }
+    void setModel(WsModel _model);
+    WsModel model() const;
 
-    bool asClient() const { return (m_model & WsModel::Client) != 0; }
-    bool asServer() const { return (m_model & WsModel::Server) != 0; }
+    bool asClient() const;
+    bool asServer() const;
 
-    void setListenIP(std::string _listenIP) { m_listenIP = std::move(_listenIP); }
-    std::string listenIP() const { return m_listenIP; }
+    void setListenIP(std::string _listenIP);
+    std::string listenIP() const;
 
-    void setListenPort(uint16_t _listenPort) { m_listenPort = _listenPort; }
-    uint16_t listenPort() const { return m_listenPort; }
+    void setListenPort(uint16_t _listenPort);
+    uint16_t listenPort() const;
 
-    void setSmSSL(bool _isSmSSL) { m_smSSL = _isSmSSL; }
-    bool smSSL() const { return m_smSSL; }
+    void setSmSSL(bool _isSmSSL);
+    bool smSSL() const;
 
-    void setMaxMsgSize(uint32_t _maxMsgSize) { m_maxMsgSize = _maxMsgSize; }
-    uint32_t maxMsgSize() const { return m_maxMsgSize; }
+    void setMaxMsgSize(uint32_t _maxMsgSize);
+    uint32_t maxMsgSize() const;
 
-    uint32_t reconnectPeriod() const
-    {
-        return m_reconnectPeriod > MIN_RECONNECT_PERIOD_MS ? m_reconnectPeriod :
-                                                             MIN_RECONNECT_PERIOD_MS;
-    }
-    void setReconnectPeriod(uint32_t _reconnectPeriod) { m_reconnectPeriod = _reconnectPeriod; }
+    uint32_t reconnectPeriod() const;
+    void setReconnectPeriod(uint32_t _reconnectPeriod);
 
-    uint32_t heartbeatPeriod() const
-    {
-        return m_heartbeatPeriod > MIN_HEART_BEAT_PERIOD_MS ? m_heartbeatPeriod :
-                                                              MIN_HEART_BEAT_PERIOD_MS;
-    }
-    void setHeartbeatPeriod(uint32_t _heartbeatPeriod) { m_heartbeatPeriod = _heartbeatPeriod; }
+    uint32_t heartbeatPeriod() const;
+    void setHeartbeatPeriod(uint32_t _heartbeatPeriod);
 
-    int32_t sendMsgTimeout() const { return m_sendMsgTimeout; }
-    void setSendMsgTimeout(int32_t _sendMsgTimeout) { m_sendMsgTimeout = _sendMsgTimeout; }
+    int32_t sendMsgTimeout() const;
+    void setSendMsgTimeout(int32_t _sendMsgTimeout);
 
-    uint32_t threadPoolSize() const
-    {
-        return m_threadPoolSize != 0U ? m_threadPoolSize : MIN_THREAD_POOL_SIZE;
-    }
-    void setThreadPoolSize(uint32_t _threadPoolSize) { m_threadPoolSize = _threadPoolSize; }
+    uint32_t threadPoolSize() const;
+    void setThreadPoolSize(uint32_t _threadPoolSize);
 
-    EndPointsPtr connectPeers() const { return m_connectPeers; }
-    void setConnectPeers(EndPointsPtr _connectPeers) { m_connectPeers = std::move(_connectPeers); }
-    bool disableSsl() const { return m_disableSsl; }
-    void setDisableSsl(bool _disableSsl) { m_disableSsl = _disableSsl; }
+    EndPointsPtr connectPeers() const;
+    void setConnectPeers(EndPointsPtr _connectPeers);
+    bool disableSsl() const;
+    void setDisableSsl(bool _disableSsl);
 
-    std::shared_ptr<context::ContextConfig> contextConfig() const { return m_contextConfig; }
-    void setContextConfig(std::shared_ptr<context::ContextConfig> _contextConfig)
-    {
-        m_contextConfig = std::move(_contextConfig);
-    }
+    std::shared_ptr<context::ContextConfig> contextConfig() const;
+    void setContextConfig(std::shared_ptr<context::ContextConfig> _contextConfig);
 
-    http::CorsConfig corsConfig() const { return m_corsConfig; }
-    void setCorsConfig(http::CorsConfig _corsConfig) { m_corsConfig = std::move(_corsConfig); }
+    http::CorsConfig corsConfig() const;
+    void setCorsConfig(http::CorsConfig _corsConfig);
 };
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
@@ -34,6 +34,58 @@ using namespace bcos::boostssl;
 using namespace bcos::boostssl::ws;
 using namespace bcos::boostssl::context;
 
+WsConnector::WsConnector(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver)
+  : m_resolver(std::move(_resolver))
+{}
+
+bool WsConnector::erasePendingConns(const std::string& _nodeIPEndpoint)
+{
+    std::lock_guard<std::mutex> lock(x_pendingConns);
+    return m_pendingConns.erase(_nodeIPEndpoint) != 0U;
+}
+
+bool WsConnector::insertPendingConns(const std::string& _nodeIPEndpoint)
+{
+    std::lock_guard<std::mutex> lock(x_pendingConns);
+    auto result = m_pendingConns.insert(_nodeIPEndpoint);
+    return result.second;
+}
+
+void WsConnector::setResolver(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver)
+{
+    m_resolver = std::move(_resolver);
+}
+
+std::shared_ptr<boost::asio::ip::tcp::resolver> WsConnector::resolver() const
+{
+    return m_resolver;
+}
+
+void WsConnector::setIOServicePool(IOServicePool::Ptr _ioservicePool)
+{
+    m_ioservicePool = std::move(_ioservicePool);
+}
+
+void WsConnector::setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx)
+{
+    m_ctx = std::move(_ctx);
+}
+
+std::shared_ptr<boost::asio::ssl::context> WsConnector::ctx() const
+{
+    return m_ctx;
+}
+
+void WsConnector::setBuilder(std::shared_ptr<WsStreamDelegateBuilder> _builder)
+{
+    m_builder = std::move(_builder);
+}
+
+std::shared_ptr<WsStreamDelegateBuilder> WsConnector::builder() const
+{
+    return m_builder;
+}
+
 // TODO: how to set timeout for connect to wsServer ???
 void WsConnector::connectToWsServer(const std::string& _host, uint16_t _port, bool _disableSsl,
     std::function<void(boost::beast::error_code, const std::string&,

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConnector.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConnector.h
@@ -40,9 +40,7 @@ public:
     using Ptr = std::shared_ptr<WsConnector>;
     using ConstPtr = std::shared_ptr<const WsConnector>;
 
-    explicit WsConnector(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver)
-      : m_resolver(std::move(_resolver))
-    {}
+        explicit WsConnector(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver);
 
     /**
      * @brief: connect to the server
@@ -57,38 +55,20 @@ public:
             std::shared_ptr<WsStreamDelegate>, std::shared_ptr<std::string>)>
             _callback);
 
-    bool erasePendingConns(const std::string& _nodeIPEndpoint)
-    {
-        std::lock_guard<std::mutex> lock(x_pendingConns);
-        return m_pendingConns.erase(_nodeIPEndpoint) != 0U;
-    }
+    bool erasePendingConns(const std::string& _nodeIPEndpoint);
 
-    bool insertPendingConns(const std::string& _nodeIPEndpoint)
-    {
-        std::lock_guard<std::mutex> lock(x_pendingConns);
-        auto result = m_pendingConns.insert(_nodeIPEndpoint);
-        return result.second;
-    }
+    bool insertPendingConns(const std::string& _nodeIPEndpoint);
 
-    void setResolver(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver)
-    {
-        m_resolver = std::move(_resolver);
-    }
-    std::shared_ptr<boost::asio::ip::tcp::resolver> resolver() const { return m_resolver; }
+    void setResolver(std::shared_ptr<boost::asio::ip::tcp::resolver> _resolver);
+    std::shared_ptr<boost::asio::ip::tcp::resolver> resolver() const;
 
-    void setIOServicePool(IOServicePool::Ptr _ioservicePool)
-    {
-        m_ioservicePool = std::move(_ioservicePool);
-    }
+    void setIOServicePool(IOServicePool::Ptr _ioservicePool);
 
-    void setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx) { m_ctx = std::move(_ctx); }
-    std::shared_ptr<boost::asio::ssl::context> ctx() const { return m_ctx; }
+    void setCtx(std::shared_ptr<boost::asio::ssl::context> _ctx);
+    std::shared_ptr<boost::asio::ssl::context> ctx() const;
 
-    void setBuilder(std::shared_ptr<WsStreamDelegateBuilder> _builder)
-    {
-        m_builder = std::move(_builder);
-    }
-    std::shared_ptr<WsStreamDelegateBuilder> builder() const { return m_builder; }
+    void setBuilder(std::shared_ptr<WsStreamDelegateBuilder> _builder);
+    std::shared_ptr<WsStreamDelegateBuilder> builder() const;
 
 private:
     std::shared_ptr<WsStreamDelegateBuilder> m_builder;

--- a/bcos-boostssl/bcos-boostssl/websocket/WsError.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsError.cpp
@@ -12,25 +12,16 @@
  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
- *
- * @file Common.h
- * @author: octopus
- * @date 2021-06-14
  */
 
-#pragma once
-#include <bcos-utilities/BoostLog.h>
-#include <openssl/bio.h>
-#include <openssl/pem.h>
+#include <bcos-boostssl/websocket/WsError.h>
 
-
-#define CONTEXT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][CTX]"
-#define NODEINFO_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL][NODEINFO]"
-
-namespace bcos::boostssl
+bool bcos::boostssl::ws::notRetryAgain(int _wsError)
 {
-X509* toX509(const char* _pemBuffer);
+    return (_wsError == boostssl::ws::WsError::MessageOverflow);
+}
 
-EVP_PKEY* toEvpPkey(const char* _pemBuffer);
-
-}  // namespace bcos::boostssl
+std::string bcos::boostssl::ws::wsErrorToString(WsError _wsError)
+{
+    return std::to_string(_wsError);
+}

--- a/bcos-boostssl/bcos-boostssl/websocket/WsError.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsError.h
@@ -40,14 +40,8 @@ enum WsError
     MessageEncodeError = -4013
 };
 
-inline bool notRetryAgain(int _wsError)
-{
-    return (_wsError == boostssl::ws::WsError::MessageOverflow);
-}
+bool notRetryAgain(int _wsError);
 
-inline std::string wsErrorToString(WsError _wsError)
-{
-    return std::to_string(_wsError);
-}
+std::string wsErrorToString(WsError _wsError);
 
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
@@ -40,6 +40,36 @@ using namespace bcos::boostssl::context;
 using namespace bcos::boostssl::ws;
 using namespace bcos::boostssl::http;
 
+std::shared_ptr<MessageFaceFactory> WsInitializer::messageFactory() const
+{
+    return m_messageFactory;
+}
+
+void WsInitializer::setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory)
+{
+    m_messageFactory = std::move(_messageFactory);
+}
+
+std::shared_ptr<WsConfig> WsInitializer::config() const
+{
+    return m_config;
+}
+
+void WsInitializer::setConfig(std::shared_ptr<WsConfig> _config)
+{
+    m_config = std::move(_config);
+}
+
+std::shared_ptr<WsSessionFactory> WsInitializer::sessionFactory()
+{
+    return m_sessionFactory;
+}
+
+void WsInitializer::setSessionFactory(std::shared_ptr<WsSessionFactory> _sessionFactory)
+{
+    m_sessionFactory = std::move(_sessionFactory);
+}
+
 void WsInitializer::initWsService(WsService::Ptr _wsService)
 {
     std::shared_ptr<WsConfig> _config = m_config;

--- a/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.h
@@ -32,20 +32,14 @@ public:
     using Ptr = std::shared_ptr<WsInitializer>;
     using ConstPtr = std::shared_ptr<const WsInitializer>;
 
-    std::shared_ptr<MessageFaceFactory> messageFactory() const { return m_messageFactory; }
-    void setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory)
-    {
-        m_messageFactory = std::move(_messageFactory);
-    }
+    std::shared_ptr<MessageFaceFactory> messageFactory() const;
+    void setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory);
 
-    std::shared_ptr<WsConfig> config() const { return m_config; }
-    void setConfig(std::shared_ptr<WsConfig> _config) { m_config = std::move(_config); }
+    std::shared_ptr<WsConfig> config() const;
+    void setConfig(std::shared_ptr<WsConfig> _config);
 
-    std::shared_ptr<WsSessionFactory> sessionFactory() { return m_sessionFactory; }
-    void setSessionFactory(std::shared_ptr<WsSessionFactory> _sessionFactory)
-    {
-        m_sessionFactory = std::move(_sessionFactory);
-    }
+    std::shared_ptr<WsSessionFactory> sessionFactory();
+    void setSessionFactory(std::shared_ptr<WsSessionFactory> _sessionFactory);
 
     void initWsService(WsService::Ptr _wsService);
 

--- a/bcos-boostssl/bcos-boostssl/websocket/WsMessage.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsMessage.cpp
@@ -26,8 +26,92 @@ using namespace bcos;
 using namespace bcos::boostssl;
 using namespace bcos::boostssl::ws;
 
+void CHECK_OFFSET(uint64_t offset, uint64_t length)
+{
+    if (std::cmp_greater(offset, length))
+    {
+        throw std::out_of_range("Out of range error, offset:" + std::to_string(offset) +
+                                " ,length: " + std::to_string(length));
+    }
+}
+
 // version(2) + type(2) + status(2) + seqLength(2) + ext(2) + payload(N)
 constexpr size_t WsMessage::MESSAGE_MIN_LENGTH = 10;
+
+WsMessage::WsMessage()
+{
+    m_payload = std::make_shared<bcos::bytes>();
+    if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
+    {
+        WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[NEWOBJ][WsMessage]", this);
+    }
+}
+
+WsMessage::~WsMessage()
+{
+    if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
+    {
+        WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[DELOBJ][WsMessage]", this);
+    }
+}
+
+uint16_t WsMessage::version() const
+{
+    return m_version;
+}
+
+void WsMessage::setVersion(uint16_t)
+{}
+
+uint16_t WsMessage::packetType() const
+{
+    return m_packetType;
+}
+
+void WsMessage::setPacketType(uint16_t _packetType)
+{
+    m_packetType = _packetType;
+}
+
+int16_t WsMessage::status() const
+{
+    return m_status;
+}
+
+void WsMessage::setStatus(int16_t _status)
+{
+    m_status = _status;
+}
+
+std::string const& WsMessage::seq() const
+{
+    return m_seq;
+}
+
+void WsMessage::setSeq(std::string _seq)
+{
+    m_seq = std::move(_seq);
+}
+
+std::shared_ptr<bcos::bytes> WsMessage::payload() const
+{
+    return m_payload;
+}
+
+void WsMessage::setPayload(std::shared_ptr<bcos::bytes> _payload)
+{
+    m_payload = std::move(_payload);
+}
+
+uint16_t WsMessage::ext() const
+{
+    return m_ext;
+}
+
+void WsMessage::setExt(uint16_t _ext)
+{
+    m_ext = _ext;
+}
 
 bool WsMessage::encode(bytes& _buffer)
 {
@@ -105,4 +189,24 @@ int64_t WsMessage::decode(bytesConstRef _buffer)
     }
     m_length = length;
     return length;
+}
+
+bool WsMessage::isRespPacket() const
+{
+    return (m_ext & bcos::protocol::MessageExtFieldFlag::RESPONSE) != 0;
+}
+
+void WsMessage::setRespPacket()
+{
+    m_ext |= bcos::protocol::MessageExtFieldFlag::RESPONSE;
+}
+
+uint32_t WsMessage::length() const
+{
+    return m_length;
+}
+
+boostssl::MessageFace::Ptr WsMessageFactory::buildMessage()
+{
+    return std::make_shared<WsMessage>();
 }

--- a/bcos-boostssl/bcos-boostssl/websocket/WsMessage.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsMessage.h
@@ -30,14 +30,7 @@
 #include <string>
 #include <utility>
 
-inline void CHECK_OFFSET(uint64_t offset, uint64_t length)
-{
-    if (std::cmp_greater(offset, length))
-    {
-        throw std::out_of_range("Out of range error, offset:" + std::to_string(offset) +
-                                " ,length: " + std::to_string(length));
-    }
-}
+void CHECK_OFFSET(uint64_t offset, uint64_t length);
 
 namespace bcos::boostssl::ws
 {
@@ -49,54 +42,35 @@ public:
     const static size_t MESSAGE_MIN_LENGTH;
 
     using Ptr = std::shared_ptr<WsMessage>;
-    WsMessage()
-    {
-        m_payload = std::make_shared<bcos::bytes>();
-        if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
-        {
-            WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[NEWOBJ][WsMessage]", this);
-        }
-    }
+    WsMessage();
     WsMessage(const WsMessage&) = delete;
     WsMessage& operator=(const WsMessage&) = delete;
     WsMessage(WsMessage&&) = delete;
     WsMessage& operator=(WsMessage&&) = delete;
-    ~WsMessage() override
-    {
-        if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
-        {
-            WEBSOCKET_MESSAGE(TRACE) << LOG_KV("[DELOBJ][WsMessage]", this);
-        }
-    }
+    ~WsMessage() override;
 
 
-    uint16_t version() const override { return m_version; }
-    void setVersion(uint16_t /*unused*/) override {}
-    uint16_t packetType() const override { return m_packetType; }
-    void setPacketType(uint16_t _packetType) override { m_packetType = _packetType; }
-    int16_t status() const { return m_status; }
-    void setStatus(int16_t _status) { m_status = _status; }
-    std::string const& seq() const override { return m_seq; }
-    void setSeq(std::string _seq) override { m_seq = _seq; }
-    std::shared_ptr<bcos::bytes> payload() const override { return m_payload; }
-    void setPayload(std::shared_ptr<bcos::bytes> _payload) override
-    {
-        m_payload = std::move(_payload);
-    }
-    uint16_t ext() const override { return m_ext; }
-    void setExt(uint16_t _ext) override { m_ext = _ext; }
+    uint16_t version() const override;
+    void setVersion(uint16_t /*unused*/) override;
+    uint16_t packetType() const override;
+    void setPacketType(uint16_t _packetType) override;
+    int16_t status() const;
+    void setStatus(int16_t _status);
+    std::string const& seq() const override;
+    void setSeq(std::string _seq) override;
+    std::shared_ptr<bcos::bytes> payload() const override;
+    void setPayload(std::shared_ptr<bcos::bytes> _payload) override;
+    uint16_t ext() const override;
+    void setExt(uint16_t _ext) override;
 
 
     bool encode(bcos::bytes& _buffer) override;
     int64_t decode(bytesConstRef _buffer) override;
 
-    bool isRespPacket() const override
-    {
-        return (m_ext & bcos::protocol::MessageExtFieldFlag::RESPONSE) != 0;
-    }
-    void setRespPacket() override { m_ext |= bcos::protocol::MessageExtFieldFlag::RESPONSE; }
+    bool isRespPacket() const override;
+    void setRespPacket() override;
 
-    uint32_t length() const override { return m_length; }
+    uint32_t length() const override;
 
 private:
     uint16_t m_version = 0;
@@ -120,11 +94,7 @@ public:
     WsMessageFactory& operator=(WsMessageFactory&&) = delete;
     ~WsMessageFactory() override = default;
 
-    boostssl::MessageFace::Ptr buildMessage() override
-    {
-        auto msg = std::make_shared<WsMessage>();
-        return msg;
-    }
+    boostssl::MessageFace::Ptr buildMessage() override;
 };
 
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
@@ -56,6 +56,130 @@ WsService::~WsService()
     WEBSOCKET_SERVICE(INFO) << LOG_KV("[DELOBJ][WsService]", this);
 }
 
+std::shared_ptr<MessageFaceFactory> WsService::messageFactory()
+{
+    return m_messageFactory;
+}
+
+void WsService::setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory)
+{
+    m_messageFactory = std::move(_messageFactory);
+}
+
+std::shared_ptr<WsSessionFactory> WsService::sessionFactory()
+{
+    return m_sessionFactory;
+}
+
+void WsService::setSessionFactory(std::shared_ptr<WsSessionFactory> _sessionFactory)
+{
+    m_sessionFactory = std::move(_sessionFactory);
+}
+
+int32_t WsService::waitConnectFinishTimeout() const
+{
+    return m_waitConnectFinishTimeout;
+}
+
+void WsService::setWaitConnectFinishTimeout(int32_t _timeout)
+{
+    m_waitConnectFinishTimeout = _timeout;
+}
+
+void WsService::setIOServicePool(IOServicePool::Ptr _ioservicePool)
+{
+    m_ioservicePool = std::move(_ioservicePool);
+    m_timerIoc = m_ioservicePool->getIOService();
+}
+
+std::shared_ptr<WsConnector> WsService::connector() const noexcept
+{
+    return m_connector;
+}
+
+void WsService::setConnector(std::shared_ptr<WsConnector> _connector)
+{
+    m_connector = std::move(_connector);
+}
+
+void WsService::setHostPort(std::string host, uint16_t port)
+{
+    m_listenHost = std::move(host);
+    m_listenPort = port;
+}
+
+std::string WsService::listenHost() const noexcept
+{
+    return m_listenHost;
+}
+
+uint16_t WsService::listenPort() const noexcept
+{
+    return m_listenPort;
+}
+
+WsConfig::Ptr WsService::config() const noexcept
+{
+    return m_config;
+}
+
+void WsService::setConfig(WsConfig::Ptr _config)
+{
+    m_config = std::move(_config);
+}
+
+std::shared_ptr<bcos::boostssl::http::HttpServer> WsService::httpServer() const noexcept
+{
+    return m_httpServer;
+}
+
+void WsService::setHttpServer(std::shared_ptr<bcos::boostssl::http::HttpServer> _httpServer)
+{
+    m_httpServer = std::move(_httpServer);
+}
+
+void WsService::setTimerFactory(timer::TimerFactory::Ptr _timerFactory)
+{
+    m_timerFactory = std::move(_timerFactory);
+}
+
+timer::TimerFactory::Ptr WsService::timerFactory() const
+{
+    return m_timerFactory;
+}
+
+void WsService::registerConnectHandler(ConnectHandler _connectHandler)
+{
+    m_connectHandlers.push_back(std::move(_connectHandler));
+}
+
+void WsService::registerDisconnectHandler(DisconnectHandler _disconnectHandler)
+{
+    m_disconnectHandlers.push_back(std::move(_disconnectHandler));
+}
+
+void WsService::registerHandshakeHandler(HandshakeHandler _handshakeHandler)
+{
+    m_handshakeHandlers.push_back(std::move(_handshakeHandler));
+}
+
+void WsService::setReconnectedPeers(EndPointsPtr _reconnectedPeers)
+{
+    WriteGuard l(x_peers);
+    m_reconnectedPeers = std::move(_reconnectedPeers);
+}
+
+EndPointsPtr WsService::reconnectedPeers() const
+{
+    ReadGuard l(x_peers);
+    return m_reconnectedPeers;
+}
+
+void WsService::initTaskArena(uint32_t _taskArenaPoolSize)
+{
+    m_taskArena.initialize(_taskArenaPoolSize, 0);
+}
+
 void WsService::start()
 {
     if (m_running)

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.h
@@ -106,56 +106,30 @@ public:
     virtual void broadcastMessage(
         const WsSession::Ptrs& _ss, std::shared_ptr<boostssl::MessageFace> _msg);
 
-    std::shared_ptr<MessageFaceFactory> messageFactory() { return m_messageFactory; }
-    void setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory)
-    {
-        m_messageFactory = std::move(_messageFactory);
-    }
+    std::shared_ptr<MessageFaceFactory> messageFactory();
+    void setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory);
 
-    std::shared_ptr<WsSessionFactory> sessionFactory() { return m_sessionFactory; }
-    void setSessionFactory(std::shared_ptr<WsSessionFactory> _sessionFactory)
-    {
-        m_sessionFactory = std::move(_sessionFactory);
-    }
-    int32_t waitConnectFinishTimeout() const { return m_waitConnectFinishTimeout; }
-    void setWaitConnectFinishTimeout(int32_t _timeout) { m_waitConnectFinishTimeout = _timeout; }
+    std::shared_ptr<WsSessionFactory> sessionFactory();
+    void setSessionFactory(std::shared_ptr<WsSessionFactory> _sessionFactory);
+    int32_t waitConnectFinishTimeout() const;
+    void setWaitConnectFinishTimeout(int32_t _timeout);
 
-    void setIOServicePool(IOServicePool::Ptr _ioservicePool)
-    {
-        m_ioservicePool = std::move(_ioservicePool);
-        m_timerIoc = m_ioservicePool->getIOService();
-    }
+    void setIOServicePool(IOServicePool::Ptr _ioservicePool);
 
-    std::shared_ptr<WsConnector> connector() const noexcept { return m_connector; }
-    void setConnector(std::shared_ptr<WsConnector> _connector)
-    {
-        m_connector = std::move(_connector);
-    }
+    std::shared_ptr<WsConnector> connector() const noexcept;
+    void setConnector(std::shared_ptr<WsConnector> _connector);
 
-    void setHostPort(std::string host, uint16_t port)
-    {
-        m_listenHost = std::move(host);
-        m_listenPort = port;
-    }
-    std::string listenHost() const noexcept { return m_listenHost; }
-    uint16_t listenPort() const noexcept { return m_listenPort; }
+    void setHostPort(std::string host, uint16_t port);
+    std::string listenHost() const noexcept;
+    uint16_t listenPort() const noexcept;
 
-    WsConfig::Ptr config() const noexcept { return m_config; }
-    void setConfig(WsConfig::Ptr _config) { m_config = std::move(_config); }
+    WsConfig::Ptr config() const noexcept;
+    void setConfig(WsConfig::Ptr _config);
 
-    std::shared_ptr<bcos::boostssl::http::HttpServer> httpServer() const noexcept
-    {
-        return m_httpServer;
-    }
-    void setHttpServer(std::shared_ptr<bcos::boostssl::http::HttpServer> _httpServer)
-    {
-        m_httpServer = std::move(_httpServer);
-    }
-    void setTimerFactory(timer::TimerFactory::Ptr _timerFactory)
-    {
-        m_timerFactory = std::move(_timerFactory);
-    }
-    timer::TimerFactory::Ptr timerFactory() const { return m_timerFactory; }
+    std::shared_ptr<bcos::boostssl::http::HttpServer> httpServer() const noexcept;
+    void setHttpServer(std::shared_ptr<bcos::boostssl::http::HttpServer> _httpServer);
+    void setTimerFactory(timer::TimerFactory::Ptr _timerFactory);
+    timer::TimerFactory::Ptr timerFactory() const;
 
     bool registerMsgHandler(uint16_t _msgType, MsgHandler _msgHandler);
 
@@ -163,37 +137,17 @@ public:
 
     bool eraseMsgHandler(uint16_t _msgType);
 
-    void registerConnectHandler(ConnectHandler _connectHandler)
-    {
-        m_connectHandlers.push_back(std::move(_connectHandler));
-    }
+    void registerConnectHandler(ConnectHandler _connectHandler);
 
-    void registerDisconnectHandler(DisconnectHandler _disconnectHandler)
-    {
-        m_disconnectHandlers.push_back(std::move(_disconnectHandler));
-    }
+    void registerDisconnectHandler(DisconnectHandler _disconnectHandler);
 
-    void registerHandshakeHandler(HandshakeHandler _handshakeHandler)
-    {
-        m_handshakeHandlers.push_back(std::move(_handshakeHandler));
-    }
+    void registerHandshakeHandler(HandshakeHandler _handshakeHandler);
 
-    void setReconnectedPeers(EndPointsPtr _reconnectedPeers)
-    {
-        WriteGuard l(x_peers);
-        m_reconnectedPeers = std::move(_reconnectedPeers);
-    }
-    EndPointsPtr reconnectedPeers() const
-    {
-        ReadGuard l(x_peers);
-        return m_reconnectedPeers;
-    }
+    void setReconnectedPeers(EndPointsPtr _reconnectedPeers);
+    EndPointsPtr reconnectedPeers() const;
 
     // init
-    void initTaskArena(uint32_t _taskArenaPoolSize)
-    {
-        m_taskArena.initialize(_taskArenaPoolSize, 0);
-    }
+    void initTaskArena(uint32_t _taskArenaPoolSize);
 
 private:
     bool m_running{false};

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
@@ -50,6 +50,148 @@ WsSession::WsSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup)
 
     m_buffer = std::make_shared<boost::beast::flat_buffer>();
 }
+
+WsSession::~WsSession() noexcept
+{
+    WEBSOCKET_SESSION(INFO) << LOG_KV("[DELOBJ][WSSESSION]", this);
+}
+
+bool WsSession::isConnected()
+{
+    return !m_isDrop && m_wsStreamDelegate && m_wsStreamDelegate->open();
+}
+
+std::string WsSession::endPoint() const
+{
+    return m_endPoint;
+}
+
+void WsSession::setEndPoint(const std::string& _endPoint)
+{
+    m_endPoint = _endPoint;
+}
+
+void WsSession::setConnectHandler(WsConnectHandler _connectHandler)
+{
+    m_connectHandler = std::move(_connectHandler);
+}
+
+WsConnectHandler WsSession::connectHandler()
+{
+    return m_connectHandler;
+}
+
+void WsSession::setDisconnectHandler(WsDisconnectHandler _disconnectHandler)
+{
+    m_disconnectHandler = std::move(_disconnectHandler);
+}
+
+WsDisconnectHandler WsSession::disconnectHandler()
+{
+    return m_disconnectHandler;
+}
+
+void WsSession::setRecvMessageHandler(WsRecvMessageHandler _recvMessageHandler)
+{
+    m_recvMessageHandler = std::move(_recvMessageHandler);
+}
+
+const WsRecvMessageHandler& WsSession::recvMessageHandler()
+{
+    return m_recvMessageHandler;
+}
+
+std::shared_ptr<MessageFaceFactory> WsSession::messageFactory()
+{
+    return m_messageFactory;
+}
+
+void WsSession::setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory)
+{
+    m_messageFactory = std::move(_messageFactory);
+}
+
+std::shared_ptr<boost::asio::io_context> WsSession::ioc() const
+{
+    return m_ioc;
+}
+
+void WsSession::setIoc(std::shared_ptr<boost::asio::io_context> _ioc)
+{
+    m_ioc = std::move(_ioc);
+}
+
+void WsSession::setVersion(uint16_t _version)
+{
+    m_version.store(_version);
+}
+
+uint16_t WsSession::version() const
+{
+    return m_version.load();
+}
+
+WsStreamDelegate::Ptr WsSession::wsStreamDelegate()
+{
+    return m_wsStreamDelegate;
+}
+
+void WsSession::setWsStreamDelegate(WsStreamDelegate::Ptr _wsStreamDelegate)
+{
+    m_wsStreamDelegate = std::move(_wsStreamDelegate);
+}
+
+int32_t WsSession::sendMsgTimeout() const
+{
+    return m_sendMsgTimeout;
+}
+
+void WsSession::setSendMsgTimeout(int32_t _sendMsgTimeout)
+{
+    m_sendMsgTimeout = _sendMsgTimeout;
+}
+
+int32_t WsSession::maxWriteMsgSize() const
+{
+    return m_maxWriteMsgSize;
+}
+
+void WsSession::setMaxWriteMsgSize(int32_t _maxWriteMsgSize)
+{
+    m_maxWriteMsgSize = _maxWriteMsgSize;
+}
+
+std::size_t WsSession::writeQueueSize()
+{
+    bcos::Guard lockGuard(x_writeQueue);
+    return m_writeQueue.size();
+}
+
+std::size_t WsSession::callbackQueueSize()
+{
+    bcos::Guard lockGuard(x_callback);
+    return m_callbacks.size();
+}
+
+std::string WsSession::nodeId()
+{
+    return m_nodeId;
+}
+
+void WsSession::setNodeId(std::string _nodeId)
+{
+    m_nodeId = std::move(_nodeId);
+}
+
+bool WsSession::needCheckRspPacket() const
+{
+    return m_needCheckRspPacket;
+}
+
+void WsSession::setNeedCheckRspPacket(bool _needCheckRespPacket)
+{
+    m_needCheckRspPacket = _needCheckRespPacket;
+}
 void WsSession::drop(WsError _reason)
 {
     if (m_isDrop)
@@ -114,6 +256,12 @@ void WsSession::drop(WsError _reason)
             }
         });
     });
+}
+
+WsSession::Ptr WsSessionFactory::createSession(
+    tbb::task_arena& taskArena, tbb::task_group& taskGroup)
+{
+    return std::make_shared<WsSession>(taskArena, taskGroup);
 }
 
 // start WsSession as client

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
@@ -57,10 +57,7 @@ public:
 public:
     explicit WsSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup);
 
-    virtual ~WsSession() noexcept
-    {
-        WEBSOCKET_SESSION(INFO) << LOG_KV("[DELOBJ][WSSESSION]", this);
-    }
+    virtual ~WsSession() noexcept;
 
     void drop(boostssl::ws::WsError _reason);
 
@@ -72,10 +69,7 @@ public:
 
     virtual void onMessage(bcos::boostssl::MessageFace::Ptr _message);
 
-    virtual bool isConnected()
-    {
-        return !m_isDrop && m_wsStreamDelegate && m_wsStreamDelegate->open();
-    }
+    virtual bool isConnected();
     /**
      * @brief: async send message
      * @param _msg: message
@@ -87,71 +81,45 @@ public:
         Options _options = Options(), RespCallBack _respCallback = RespCallBack());
 
 
-    std::string endPoint() const { return m_endPoint; }
-    void setEndPoint(const std::string& _endPoint) { m_endPoint = _endPoint; }
+    std::string endPoint() const;
+    void setEndPoint(const std::string& _endPoint);
 
-    void setConnectHandler(WsConnectHandler _connectHandler)
-    {
-        m_connectHandler = std::move(_connectHandler);
-    }
-    WsConnectHandler connectHandler() { return m_connectHandler; }
+    void setConnectHandler(WsConnectHandler _connectHandler);
+    WsConnectHandler connectHandler();
 
-    void setDisconnectHandler(WsDisconnectHandler _disconnectHandler)
-    {
-        m_disconnectHandler = std::move(_disconnectHandler);
-    }
-    WsDisconnectHandler disconnectHandler() { return m_disconnectHandler; }
+    void setDisconnectHandler(WsDisconnectHandler _disconnectHandler);
+    WsDisconnectHandler disconnectHandler();
 
-    void setRecvMessageHandler(WsRecvMessageHandler _recvMessageHandler)
-    {
-        m_recvMessageHandler = std::move(_recvMessageHandler);
-    }
-    const WsRecvMessageHandler& recvMessageHandler() { return m_recvMessageHandler; }
+    void setRecvMessageHandler(WsRecvMessageHandler _recvMessageHandler);
+    const WsRecvMessageHandler& recvMessageHandler();
 
-    std::shared_ptr<MessageFaceFactory> messageFactory() { return m_messageFactory; }
-    void setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory)
-    {
-        m_messageFactory = std::move(_messageFactory);
-    }
+    std::shared_ptr<MessageFaceFactory> messageFactory();
+    void setMessageFactory(std::shared_ptr<MessageFaceFactory> _messageFactory);
 
-    std::shared_ptr<boost::asio::io_context> ioc() const { return m_ioc; }
-    void setIoc(std::shared_ptr<boost::asio::io_context> _ioc) { m_ioc = std::move(_ioc); }
+    std::shared_ptr<boost::asio::io_context> ioc() const;
+    void setIoc(std::shared_ptr<boost::asio::io_context> _ioc);
 
-    void setVersion(uint16_t _version) { m_version.store(_version); }
-    uint16_t version() const { return m_version.load(); }
+    void setVersion(uint16_t _version);
+    uint16_t version() const;
 
-    WsStreamDelegate::Ptr wsStreamDelegate() { return m_wsStreamDelegate; }
-    void setWsStreamDelegate(WsStreamDelegate::Ptr _wsStreamDelegate)
-    {
-        m_wsStreamDelegate = std::move(_wsStreamDelegate);
-    }
+    WsStreamDelegate::Ptr wsStreamDelegate();
+    void setWsStreamDelegate(WsStreamDelegate::Ptr _wsStreamDelegate);
 
-    int32_t sendMsgTimeout() const { return m_sendMsgTimeout; }
-    void setSendMsgTimeout(int32_t _sendMsgTimeout) { m_sendMsgTimeout = _sendMsgTimeout; }
+    int32_t sendMsgTimeout() const;
+    void setSendMsgTimeout(int32_t _sendMsgTimeout);
 
-    int32_t maxWriteMsgSize() const { return m_maxWriteMsgSize; }
-    void setMaxWriteMsgSize(int32_t _maxWriteMsgSize) { m_maxWriteMsgSize = _maxWriteMsgSize; }
+    int32_t maxWriteMsgSize() const;
+    void setMaxWriteMsgSize(int32_t _maxWriteMsgSize);
 
-    std::size_t writeQueueSize()
-    {
-        bcos::Guard lockGuard(x_writeQueue);
-        return m_writeQueue.size();
-    }
+    std::size_t writeQueueSize();
 
-    std::size_t callbackQueueSize()
-    {
-        bcos::Guard lockGuard(x_callback);
-        return m_callbacks.size();
-    }
+    std::size_t callbackQueueSize();
 
-    std::string nodeId() { return m_nodeId; }
-    void setNodeId(std::string _nodeId) { m_nodeId = std::move(_nodeId); }
+    std::string nodeId();
+    void setNodeId(std::string _nodeId);
 
-    bool needCheckRspPacket() const { return m_needCheckRspPacket; }
-    void setNeedCheckRspPacket(bool _needCheckRespPacket)
-    {
-        m_needCheckRspPacket = _needCheckRespPacket;
-    }
+    bool needCheckRspPacket() const;
+    void setNeedCheckRspPacket(bool _needCheckRespPacket);
 
 public:
     struct CallBack : public bcos::ObjectCounter<CallBack>
@@ -233,11 +201,7 @@ public:
     virtual ~WsSessionFactory() = default;
 
 public:
-    virtual WsSession::Ptr createSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup)
-    {
-        auto session = std::make_shared<WsSession>(taskArena, taskGroup);
-        return session;
-    }
+    virtual WsSession::Ptr createSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup);
 };
 
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsStream.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsStream.cpp
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <bcos-boostssl/websocket/WsStream.h>
+
+using namespace bcos::boostssl::ws;
+
+WsStreamDelegate::WsStreamDelegate(RawWsStream::Ptr _rawStream)
+  : m_isSsl(false), m_rawStream(std::move(_rawStream))
+{}
+
+WsStreamDelegate::WsStreamDelegate(SslWsStream::Ptr _sslStream)
+  : m_isSsl(true), m_sslStream(std::move(_sslStream))
+{}
+
+void WsStreamDelegate::setMaxReadMsgSize(uint32_t _maxValue)
+{
+    if (m_isSsl)
+    {
+        m_sslStream->setMaxReadMsgSize(_maxValue);
+        return;
+    }
+    m_rawStream->setMaxReadMsgSize(_maxValue);
+}
+
+bool WsStreamDelegate::open()
+{
+    return m_isSsl ? m_sslStream->open() : m_rawStream->open();
+}
+
+void WsStreamDelegate::close()
+{
+    if (m_isSsl)
+    {
+        m_sslStream->close();
+        return;
+    }
+    m_rawStream->close();
+}
+
+std::string WsStreamDelegate::localEndpoint()
+{
+    return m_isSsl ? m_sslStream->localEndpoint() : m_rawStream->localEndpoint();
+}
+
+std::string WsStreamDelegate::remoteEndpoint()
+{
+    return m_isSsl ? m_sslStream->remoteEndpoint() : m_rawStream->remoteEndpoint();
+}
+
+void WsStreamDelegate::asyncWrite(const bcos::bytes& _buffer, WsStreamRWHandler _handler)
+{
+    if (m_isSsl)
+    {
+        m_sslStream->asyncWrite(_buffer, std::move(_handler));
+        return;
+    }
+    m_rawStream->asyncWrite(_buffer, std::move(_handler));
+}
+
+void WsStreamDelegate::asyncRead(boost::beast::flat_buffer& _buffer, WsStreamRWHandler _handler)
+{
+    if (m_isSsl)
+    {
+        m_sslStream->asyncRead(_buffer, std::move(_handler));
+        return;
+    }
+    m_rawStream->asyncRead(_buffer, std::move(_handler));
+}
+
+void WsStreamDelegate::asyncWsHandshake(const std::string& _host, const std::string& _target,
+    std::function<void(boost::beast::error_code)> _handler)
+{
+    if (m_isSsl)
+    {
+        m_sslStream->asyncHandshake(_host, _target, std::move(_handler));
+        return;
+    }
+    m_rawStream->asyncHandshake(_host, _target, std::move(_handler));
+}
+
+void WsStreamDelegate::asyncAccept(
+    bcos::boostssl::http::HttpRequest _httpRequest, WsStreamHandshakeHandler _handler)
+{
+    if (m_isSsl)
+    {
+        m_sslStream->asyncAccept(std::move(_httpRequest), std::move(_handler));
+        return;
+    }
+    m_rawStream->asyncAccept(std::move(_httpRequest), std::move(_handler));
+}
+
+void WsStreamDelegate::asyncHandshake(std::function<void(boost::beast::error_code)> _handler)
+{
+    if (m_isSsl)
+    {
+        m_sslStream->stream()->next_layer().async_handshake(
+            boost::asio::ssl::stream_base::client, std::move(_handler));
+        return;
+    }
+    _handler(make_error_code(boost::system::errc::success));
+}
+
+boost::beast::tcp_stream& WsStreamDelegate::tcpStream()
+{
+    return m_isSsl ? m_sslStream->tcpStream() : m_rawStream->tcpStream();
+}
+
+void WsStreamDelegate::setVerifyCallback(bool _disableSsl, VerifyCallback callback, bool)
+{
+    if (!_disableSsl)
+    {
+        m_sslStream->stream()->next_layer().set_verify_callback(std::move(callback));
+    }
+}
+
+WsStreamDelegate::Ptr WsStreamDelegateBuilder::build(
+    std::shared_ptr<boost::beast::tcp_stream> _tcpStream)
+{
+    _tcpStream->socket().set_option(boost::asio::ip::tcp::no_delay(true));
+    auto wsStream = std::make_shared<boost::beast::websocket::stream<boost::beast::tcp_stream>>(
+        std::move(*_tcpStream));
+    auto rawWsStream =
+        std::make_shared<bcos::boostssl::ws::WsStream<boost::beast::tcp_stream>>(wsStream);
+    return std::make_shared<WsStreamDelegate>(rawWsStream);
+}
+
+WsStreamDelegate::Ptr WsStreamDelegateBuilder::build(
+    std::shared_ptr<boost::beast::ssl_stream<boost::beast::tcp_stream>> _sslStream)
+{
+    _sslStream->next_layer().socket().set_option(boost::asio::ip::tcp::no_delay(true));
+    auto wsStream = std::make_shared<
+        boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>>>(
+        std::move(*_sslStream));
+    auto sslWsStream =
+        std::make_shared<bcos::boostssl::ws::WsStream<boost::beast::ssl_stream<boost::beast::tcp_stream>>>(
+            wsStream);
+    return std::make_shared<WsStreamDelegate>(sslWsStream);
+}
+
+WsStreamDelegate::Ptr WsStreamDelegateBuilder::build(bool _disableSsl,
+    std::shared_ptr<boost::asio::ssl::context> _ctx,
+    std::shared_ptr<boost::beast::tcp_stream> _tcpStream)
+{
+    if (_disableSsl)
+    {
+        return build(std::move(_tcpStream));
+    }
+
+    auto sslStream = std::make_shared<boost::beast::ssl_stream<boost::beast::tcp_stream>>(
+        std::move(*_tcpStream), *_ctx);
+    return build(std::move(sslStream));
+}

--- a/bcos-boostssl/bcos-boostssl/websocket/WsStream.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsStream.h
@@ -229,77 +229,31 @@ public:
     using ConstPtr = std::shared_ptr<const WsStreamDelegate>;
 
 public:
-    WsStreamDelegate(RawWsStream::Ptr _rawStream) : m_isSsl(false), m_rawStream(_rawStream) {}
-    WsStreamDelegate(SslWsStream::Ptr _sslStream) : m_isSsl(true), m_sslStream(_sslStream) {}
+    WsStreamDelegate(RawWsStream::Ptr _rawStream);
+    WsStreamDelegate(SslWsStream::Ptr _sslStream);
 
 public:
-    void setMaxReadMsgSize(uint32_t _maxValue)
-    {
-        m_isSsl ? m_sslStream->setMaxReadMsgSize(_maxValue) :
-                  m_rawStream->setMaxReadMsgSize(_maxValue);
-    }
-    bool open() { return m_isSsl ? m_sslStream->open() : m_rawStream->open(); }
-    void close() { return m_isSsl ? m_sslStream->close() : m_rawStream->close(); }
-    std::string localEndpoint()
-    {
-        return m_isSsl ? m_sslStream->localEndpoint() : m_rawStream->localEndpoint();
-    }
-    std::string remoteEndpoint()
-    {
-        return m_isSsl ? m_sslStream->remoteEndpoint() : m_rawStream->remoteEndpoint();
-    }
+    void setMaxReadMsgSize(uint32_t _maxValue);
+    bool open();
+    void close();
+    std::string localEndpoint();
+    std::string remoteEndpoint();
 
-    void asyncWrite(const bcos::bytes& _buffer, WsStreamRWHandler _handler)
-    {
-        return m_isSsl ? m_sslStream->asyncWrite(_buffer, _handler) :
-                         m_rawStream->asyncWrite(_buffer, _handler);
-    }
+    void asyncWrite(const bcos::bytes& _buffer, WsStreamRWHandler _handler);
 
-    void asyncRead(boost::beast::flat_buffer& _buffer, WsStreamRWHandler _handler)
-    {
-        return m_isSsl ? m_sslStream->asyncRead(_buffer, _handler) :
-                         m_rawStream->asyncRead(_buffer, _handler);
-    }
+    void asyncRead(boost::beast::flat_buffer& _buffer, WsStreamRWHandler _handler);
 
     void asyncWsHandshake(const std::string& _host, const std::string& _target,
-        std::function<void(boost::beast::error_code)> _handler)
-    {
-        return m_isSsl ? m_sslStream->asyncHandshake(_host, _target, _handler) :
-                         m_rawStream->asyncHandshake(_host, _target, _handler);
-    }
+        std::function<void(boost::beast::error_code)> _handler);
 
     void asyncAccept(
-        bcos::boostssl::http::HttpRequest _httpRequest, WsStreamHandshakeHandler _handler)
-    {
-        return m_isSsl ? m_sslStream->asyncAccept(_httpRequest, _handler) :
-                         m_rawStream->asyncAccept(_httpRequest, _handler);
-    }
+        bcos::boostssl::http::HttpRequest _httpRequest, WsStreamHandshakeHandler _handler);
 
-    void asyncHandshake(std::function<void(boost::beast::error_code)> _handler)
-    {
-        if (m_isSsl)
-        {
-            m_sslStream->stream()->next_layer().async_handshake(
-                boost::asio::ssl::stream_base::client, _handler);
-        }
-        else
-        {  // callback directly
-            _handler(make_error_code(boost::system::errc::success));
-        }
-    }
+    void asyncHandshake(std::function<void(boost::beast::error_code)> _handler);
 
-    boost::beast::tcp_stream& tcpStream()
-    {
-        return m_isSsl ? m_sslStream->tcpStream() : m_rawStream->tcpStream();
-    }
+    boost::beast::tcp_stream& tcpStream();
 
-    void setVerifyCallback(bool _disableSsl, VerifyCallback callback, bool = true)
-    {
-        if (!_disableSsl)
-        {
-            m_sslStream->stream()->next_layer().set_verify_callback(callback);
-        }
-    }
+    void setVerifyCallback(bool _disableSsl, VerifyCallback callback, bool = true);
 
 private:
     bool m_isSsl{false};
@@ -315,41 +269,13 @@ public:
     using ConstPtr = std::shared_ptr<const WsStreamDelegateBuilder>;
 
 public:
-    WsStreamDelegate::Ptr build(std::shared_ptr<boost::beast::tcp_stream> _tcpStream)
-    {
-        _tcpStream->socket().set_option(boost::asio::ip::tcp::no_delay(true));
-        auto wsStream = std::make_shared<boost::beast::websocket::stream<boost::beast::tcp_stream>>(
-            std::move(*_tcpStream));
-        auto rawWsStream =
-            std::make_shared<bcos::boostssl::ws::WsStream<boost::beast::tcp_stream>>(wsStream);
-        return std::make_shared<WsStreamDelegate>(rawWsStream);
-    }
+    WsStreamDelegate::Ptr build(std::shared_ptr<boost::beast::tcp_stream> _tcpStream);
 
     WsStreamDelegate::Ptr build(
-        std::shared_ptr<boost::beast::ssl_stream<boost::beast::tcp_stream>> _sslStream)
-    {
-        _sslStream->next_layer().socket().set_option(boost::asio::ip::tcp::no_delay(true));
-        auto wsStream = std::make_shared<
-            boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>>>(
-            std::move(*_sslStream));
-        auto sslWsStream = std::make_shared<
-            bcos::boostssl::ws::WsStream<boost::beast::ssl_stream<boost::beast::tcp_stream>>>(
-            wsStream);
-        return std::make_shared<WsStreamDelegate>(sslWsStream);
-    }
+        std::shared_ptr<boost::beast::ssl_stream<boost::beast::tcp_stream>> _sslStream);
 
     WsStreamDelegate::Ptr build(bool _disableSsl, std::shared_ptr<boost::asio::ssl::context> _ctx,
-        std::shared_ptr<boost::beast::tcp_stream> _tcpStream)
-    {
-        if (_disableSsl)
-        {
-            return build(_tcpStream);
-        }
-
-        auto sslStream = std::make_shared<boost::beast::ssl_stream<boost::beast::tcp_stream>>(
-            std::move(*_tcpStream), *_ctx);
-        return build(sslStream);
-    }
+        std::shared_ptr<boost::beast::tcp_stream> _tcpStream);
 };
 
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsTools.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsTools.cpp
@@ -26,6 +26,49 @@ using namespace bcos;
 using namespace bcos::boostssl;
 using namespace bcos::boostssl::ws;
 
+bool WsTools::isIPAddress(std::string const& _input)
+{
+    const static boost::regex ipv4_regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}$");
+    const static boost::regex ipv6_regex(
+        "^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|:|((([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4})"
+        "?::("
+        "([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4})?))$");
+
+    return boost::regex_match(_input, ipv4_regex) || boost::regex_match(_input, ipv6_regex);
+}
+
+bool WsTools::validIP(const std::string& _ip)
+{
+    boost::system::error_code ec;
+    boost::asio::ip::make_address(_ip, ec);
+    return !static_cast<bool>(ec);
+}
+
+bool WsTools::isHostname(const std::string& _input)
+{
+    if (_input.empty())
+    {
+        return false;
+    }
+    boost::asio::io_context io_context;
+    boost::asio::ip::tcp::resolver resolver(io_context);
+
+    try
+    {
+        boost::ignore_unused(resolver.resolve(_input, "80"));
+        return true;
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+bool WsTools::validPort(uint16_t _port)
+{
+    return _port > 1024;
+}
+
 bool WsTools::hostAndPort2Endpoint(const std::string& _host, NodeIPEndpoint& _endpoint)
 {
     std::string ip;

--- a/bcos-boostssl/bcos-boostssl/websocket/WsTools.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsTools.h
@@ -32,44 +32,12 @@ namespace bcos::boostssl::ws
 class WsTools
 {
 public:
-    static bool isIPAddress(std::string const& _input)
-    {
-        const static boost::regex ipv4_regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}$");
-        const static boost::regex ipv6_regex(
-            "^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|:|((([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4})"
-            "?::("
-            "([0-9a-fA-F]{1,4}:){0,6}[0-9a-fA-F]{1,4})?))$");
+    static bool isIPAddress(std::string const& _input);
+    static bool validIP(const std::string& _ip);
 
-        return boost::regex_match(_input, ipv4_regex) || boost::regex_match(_input, ipv6_regex);
-    }
-    static bool validIP(const std::string& _ip)
-    {
-        boost::system::error_code ec;
-        boost::asio::ip::make_address(_ip, ec);
-        return !static_cast<bool>(ec);
-    }
+    static bool isHostname(const std::string& _input);
 
-    static bool isHostname(const std::string& _input)
-    {
-        if (_input.empty())
-        {
-            return false;
-        }
-        boost::asio::io_context io_context;
-        boost::asio::ip::tcp::resolver resolver(io_context);
-
-        try
-        {
-            boost::asio::ip::tcp::resolver::results_type results = resolver.resolve(_input, "80");
-            return true;
-        }
-        catch (...)
-        {
-            return false;
-        }
-    }
-
-    static bool validPort(uint16_t _port) { return _port > 1024; }
+    static bool validPort(uint16_t _port);
     static bool hostAndPort2Endpoint(const std::string& _host, NodeIPEndpoint& _endpoint);
 
     static void close(boost::asio::ip::tcp::socket& skt);


### PR DESCRIPTION
Refactor the code by moving header implementations into corresponding cpp files for better organization and maintainability. This change enhances clarity and separates interface from implementation.