### PR TITLE
Move storage header implementation to cpp

### DIFF
--- a/bcos-table/src/CacheStorageFactory.cpp
+++ b/bcos-table/src/CacheStorageFactory.cpp
@@ -3,6 +3,11 @@
 
 using namespace bcos::storage;
 
+CacheStorageFactory::CacheStorageFactory(
+        bcos::storage::TransactionalStorageInterface::Ptr backendStorage, ssize_t cacheSize)
+    : m_cacheSize(cacheSize), m_backendStorage(std::move(backendStorage))
+{}
+
 MergeableStorageInterface::Ptr CacheStorageFactory::build()
 {
     auto cache = std::make_shared<bcos::storage::LRUStateStorage>(m_backendStorage, false);

--- a/bcos-table/src/CacheStorageFactory.h
+++ b/bcos-table/src/CacheStorageFactory.h
@@ -28,10 +28,8 @@ class CacheStorageFactory
 {
 public:
     using Ptr = std::shared_ptr<CacheStorageFactory>;
-    CacheStorageFactory(
-        bcos::storage::TransactionalStorageInterface::Ptr backendStorage, ssize_t cacheSize)
-      : m_cacheSize(cacheSize), m_backendStorage(backendStorage)
-    {}
+        CacheStorageFactory(
+                bcos::storage::TransactionalStorageInterface::Ptr backendStorage, ssize_t cacheSize);
 
     virtual ~CacheStorageFactory() = default;
     storage::MergeableStorageInterface::Ptr build();

--- a/bcos-table/src/ContractShardUtils.cpp
+++ b/bcos-table/src/ContractShardUtils.cpp
@@ -23,6 +23,11 @@
 
 using namespace bcos::storage;
 
+bool ContractShardUtils::isInherent(std::optional<bcos::storage::Entry> entry)
+{
+    return entry && entry->getField(0).starts_with(INHERENT_PREFIX);
+}
+
 void ContractShardUtils::setContractShard(bcos::storage::StorageWrapper& storage,
     const std::string_view& contractTableName, const std::string_view& shard)
 {

--- a/bcos-table/src/ContractShardUtils.h
+++ b/bcos-table/src/ContractShardUtils.h
@@ -46,9 +46,6 @@ private:
     static void setShard(bcos::storage::StorageWrapper& storage,
         const std::string_view& contractTableName, const std::string_view& shard);
 
-    static bool isInherent(std::optional<bcos::storage::Entry> entry)
-    {
-        return !entry ? false : entry->getField(0).starts_with(INHERENT_PREFIX);
-    }
+    static bool isInherent(std::optional<bcos::storage::Entry> entry);
 };
 }  // namespace bcos::storage

--- a/bcos-table/src/KeyPageStorage.cpp
+++ b/bcos-table/src/KeyPageStorage.cpp
@@ -26,6 +26,34 @@
 
 namespace bcos::storage
 {
+KeyPageStorage::KeyPageStorage(std::shared_ptr<StorageInterface> _prev, bool setRowWithDirtyFlag,
+    size_t _pageSize, uint32_t _blockVersion,
+    std::shared_ptr<const std::set<std::string, std::less<>>> _ignoreTables,
+    bool _ignoreNotExist)
+  : storage::StateStorageInterface(std::move(_prev)),
+    m_blockVersion(_blockVersion),
+    m_pageSize(_pageSize > MIN_PAGE_SIZE ? _pageSize : MIN_PAGE_SIZE),
+    m_splitSize(m_pageSize / 3 * 2),
+    m_mergeSize(m_pageSize / 4),
+    m_buckets(std::max(1u, std::thread::hardware_concurrency())),
+    m_ignoreTables(std::move(_ignoreTables)),
+    m_ignoreNotExist(_ignoreNotExist),
+    m_setRowWithDirtyFlag(setRowWithDirtyFlag)
+{
+    if (!m_ignoreTables)
+    {
+        auto ignore = std::make_shared<std::set<std::string, std::less<>>>();
+        ignore->insert(std::string(SYS_TABLES));
+        m_ignoreTables = ignore;
+    }
+}
+
+KeyPageStorage::~KeyPageStorage()
+{
+    m_recoder.clear();
+    m_buckets.clear();
+}
+
 void KeyPageStorage::asyncGetPrimaryKeys(std::string_view tableView,
     const std::optional<storage::Condition const>& _condition,
     std::function<void(Error::UniquePtr, std::vector<std::string>)> _callback)

--- a/bcos-table/src/KeyPageStorage.h
+++ b/bcos-table/src/KeyPageStorage.h
@@ -89,24 +89,7 @@ public:
         size_t _pageSize = 10240,
         uint32_t _blockVersion = (uint32_t)bcos::protocol::BlockVersion::V3_0_VERSION,
         std::shared_ptr<const std::set<std::string, std::less<>>> _ignoreTables = nullptr,
-        bool _ignoreNotExist = false)
-      : storage::StateStorageInterface(std::move(_prev)),
-        m_blockVersion(_blockVersion),
-        m_pageSize(_pageSize > MIN_PAGE_SIZE ? _pageSize : MIN_PAGE_SIZE),
-        m_splitSize(m_pageSize / 3 * 2),
-        m_mergeSize(m_pageSize / 4),
-        m_buckets(std::max(1u, std::thread::hardware_concurrency())),
-        m_ignoreTables(std::move(_ignoreTables)),
-        m_ignoreNotExist(_ignoreNotExist),
-        m_setRowWithDirtyFlag(setRowWithDirtyFlag)
-    {
-        if (!m_ignoreTables)
-        {
-            auto ignore = std::make_shared<std::set<std::string, std::less<>>>();
-            ignore->insert(std::string(SYS_TABLES));
-            m_ignoreTables = ignore;
-        }
-    }
+        bool _ignoreNotExist = false);
 
     KeyPageStorage(const KeyPageStorage&) = delete;
     KeyPageStorage& operator=(const KeyPageStorage&) = delete;
@@ -114,11 +97,7 @@ public:
     KeyPageStorage(KeyPageStorage&&) = delete;
     KeyPageStorage& operator=(KeyPageStorage&&) = delete;
 
-    ~KeyPageStorage() override
-    {
-        m_recoder.clear();
-        m_buckets.clear();
-    }
+    ~KeyPageStorage() override;
 
     void asyncGetPrimaryKeys(std::string_view table,
         const std::optional<storage::Condition const>& _condition,

--- a/bcos-table/src/StateStorage.cpp
+++ b/bcos-table/src/StateStorage.cpp
@@ -1,0 +1,575 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "StateStorage.h"
+
+namespace bcos::storage
+{
+template <bool enableLRU>
+BaseStorage<enableLRU>::BaseStorage(
+    std::shared_ptr<StorageInterface> prev, bool setRowWithDirtyFlag)
+  : storage::StateStorageInterface(std::move(prev)),
+    m_buckets(std::thread::hardware_concurrency() + 1),
+    m_setRowWithDirtyFlag(setRowWithDirtyFlag)
+{}
+
+template <bool enableLRU>
+BaseStorage<enableLRU>::~BaseStorage()
+{
+    m_recoder.clear();
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::asyncGetPrimaryKeys(std::string_view table,
+    const std::optional<storage::Condition const>& condition,
+    std::function<void(Error::UniquePtr, std::vector<std::string>)> _callback)
+{
+    std::map<std::string_view, storage::Entry::Status> localKeys;
+
+    if (m_enableTraverse)
+    {
+        std::mutex mergeMutex;
+        tbb::parallel_for(tbb::blocked_range<size_t>(0U, m_buckets.size()),
+            [this, &mergeMutex, &localKeys, &table, &condition](auto const& range) {
+                for (auto i = range.begin(); i < range.end(); ++i)
+                {
+                    auto& bucket = m_buckets[i];
+                    std::unique_lock<std::mutex> lock(bucket.mutex);
+
+                    decltype(localKeys) bucketKeys;
+                    for (auto& it : bucket.container)
+                    {
+                        if (it.table == table && (!condition || condition->isValid(it.key)))
+                        {
+                            bucketKeys.emplace(it.key, it.entry.status());
+                        }
+                    }
+
+                    std::unique_lock mergeLock(mergeMutex);
+                    localKeys.merge(std::move(bucketKeys));
+                }
+            });
+    }
+
+    auto prev = getPrev();
+    if (!prev)
+    {
+        std::vector<std::string> resultKeys;
+        for (auto& localIt : localKeys)
+        {
+            if (localIt.second == Entry::NORMAL || localIt.second == Entry::MODIFIED)
+            {
+                resultKeys.push_back(std::string(localIt.first));
+            }
+        }
+
+        _callback(nullptr, std::move(resultKeys));
+        return;
+    }
+
+    prev->asyncGetPrimaryKeys(table, condition,
+        [localKeys = std::move(localKeys), callback = std::move(_callback)](
+            auto&& error, auto&& remoteKeys) mutable {
+            if (error)
+            {
+                callback(BCOS_ERROR_WITH_PREV_UNIQUE_PTR(StorageError::ReadError,
+                             "Get primary keys from prev failed!", *error),
+                    std::vector<std::string>());
+                return;
+            }
+
+            for (auto it = remoteKeys.begin(); it != remoteKeys.end();)
+            {
+                bool deleted = false;
+
+                auto localIt = localKeys.find(*it);
+                if (localIt != localKeys.end())
+                {
+                    if (localIt->second == Entry::DELETED)
+                    {
+                        it = remoteKeys.erase(it);
+                        deleted = true;
+                    }
+
+                    localKeys.erase(localIt);
+                }
+
+                if (!deleted)
+                {
+                    ++it;
+                }
+            }
+
+            for (auto& localIt : localKeys)
+            {
+                if (localIt.second == Entry::NORMAL || localIt.second == Entry::MODIFIED)
+                {
+                    remoteKeys.push_back(std::string(localIt.first));
+                }
+            }
+
+            callback(nullptr, std::forward<decltype(remoteKeys)>(remoteKeys));
+        });
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::asyncGetRow(std::string_view tableView, std::string_view keyView,
+    std::function<void(Error::UniquePtr, std::optional<Entry>)> _callback)
+{
+    auto [bucket, lock] = getBucket(tableView, keyView);
+    boost::ignore_unused(lock);
+
+    auto it = bucket->container.template get<0>().find(std::make_tuple(tableView, keyView));
+    if (it != bucket->container.template get<0>().end())
+    {
+        auto& entry = it->entry;
+
+        if (entry.status() == Entry::DELETED)
+        {
+            lock.unlock();
+            _callback(nullptr, std::nullopt);
+        }
+        else
+        {
+            auto optionalEntry = std::make_optional(entry);
+            if constexpr (enableLRU)
+            {
+                updateMRUAndCheck(*bucket, it);
+            }
+
+            lock.unlock();
+            _callback(nullptr, std::move(optionalEntry));
+        }
+        return;
+    }
+
+    lock.unlock();
+
+    auto prev = getPrev();
+    if (prev)
+    {
+        prev->asyncGetRow(tableView, keyView,
+            [this, prev, table = std::string(tableView), key = std::string(keyView), _callback](
+                Error::UniquePtr error, std::optional<Entry> entry) {
+                if (error)
+                {
+                    _callback(BCOS_ERROR_WITH_PREV_UNIQUE_PTR(StorageError::ReadError,
+                                  "Get row from storage failed!", *error),
+                        {});
+                    return;
+                }
+
+                if (entry)
+                {
+                    _callback(nullptr,
+                        std::make_optional(importExistingEntry(table, key, std::move(*entry))));
+                }
+                else
+                {
+                    _callback(nullptr, std::nullopt);
+                }
+            });
+    }
+    else
+    {
+        _callback(nullptr, std::nullopt);
+    }
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::asyncGetRows(std::string_view tableView,
+    ::ranges::any_view<std::string_view,
+        ::ranges::category::input | ::ranges::category::random_access |
+            ::ranges::category::sized>
+        keys,
+    std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback)
+{
+    std::vector<std::optional<Entry>> results(keys.size());
+    auto missinges = std::tuple<std::vector<std::string_view>,
+        std::vector<std::tuple<std::string, size_t>>>();
+
+    std::atomic_ulong existsCount = 0;
+
+    for (auto i = 0U; i < keys.size(); ++i)
+    {
+        auto [bucket, lock] = getBucket(tableView, keys[i]);
+        boost::ignore_unused(lock);
+
+        auto it = bucket->container.find(std::make_tuple(tableView, std::string_view(keys[i])));
+        if (it != bucket->container.end())
+        {
+            auto& entry = it->entry;
+            if (entry.status() == Entry::NORMAL || entry.status() == Entry::MODIFIED)
+            {
+                results[i].emplace(entry);
+
+                if constexpr (enableLRU)
+                {
+                    updateMRUAndCheck(*bucket, it);
+                }
+            }
+            else
+            {
+                results[i] = std::nullopt;
+            }
+            ++existsCount;
+        }
+        else
+        {
+            std::get<1>(missinges).emplace_back(std::string(keys[i]), i);
+            std::get<0>(missinges).emplace_back(keys[i]);
+        }
+    }
+
+    auto prev = getPrev();
+    if (existsCount < keys.size() && prev)
+    {
+        prev->asyncGetRows(tableView, std::get<0>(missinges),
+            [this, table = std::string(tableView), callback = std::move(_callback),
+                missingIndexes = std::move(std::get<1>(missinges)), results = std::move(results)](
+                auto&& error, std::vector<std::optional<Entry>>&& entries) mutable {
+                if (error)
+                {
+                    callback(BCOS_ERROR_WITH_PREV_UNIQUE_PTR(StorageError::ReadError,
+                                 "async get perv rows failed!", *error),
+                        std::vector<std::optional<Entry>>());
+                    return;
+                }
+
+                for (size_t i = 0; i < entries.size(); ++i)
+                {
+                    auto& entry = entries[i];
+                    if (entry)
+                    {
+                        results[std::get<1>(missingIndexes[i])].emplace(importExistingEntry(table,
+                            std::move(std::get<0>(missingIndexes[i])), std::move(*entry)));
+                    }
+                }
+
+                callback(nullptr, std::move(results));
+            });
+    }
+    else
+    {
+        _callback(nullptr, std::move(results));
+    }
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::asyncSetRow(std::string_view tableView, std::string_view keyView,
+    Entry entry, std::function<void(Error::UniquePtr)> callback)
+{
+    if (m_readOnly)
+    {
+        callback(BCOS_ERROR_UNIQUE_PTR(
+            StorageError::ReadOnly, "Try to operate a read-only storage"));
+        return;
+    }
+
+    ssize_t updatedCapacity = entry.size();
+    std::optional<Entry> entryOld;
+
+    if (m_setRowWithDirtyFlag && entry.status() == Entry::NORMAL)
+    {
+        entry.setStatus(Entry::MODIFIED);
+    }
+    auto [bucket, lock] = getBucket(tableView, keyView);
+    auto it = bucket->container.find(std::make_tuple(tableView, keyView));
+    if (it != bucket->container.end())
+    {
+        auto& existsEntry = it->entry;
+        entryOld.emplace(std::move(existsEntry));
+
+        updatedCapacity -= entryOld->size();
+
+        bucket->container.modify(it, [&entry](Data& data) { data.entry = std::move(entry); });
+    }
+    else
+    {
+        auto [iter, inserted] =
+            bucket->container.emplace(Data{std::string(tableView), std::string(keyView), std::move(entry)});
+        boost::ignore_unused(inserted);
+        it = iter;
+    }
+    if constexpr (enableLRU)
+    {
+        updateMRUAndCheck(*bucket, it);
+    }
+
+    if (m_recoder.local())
+    {
+        m_recoder.local()->log(
+            Recoder::Change(std::string(tableView), std::string(keyView), std::move(entryOld)));
+    }
+
+    bucket->capacity += updatedCapacity;
+
+    lock.unlock();
+    callback(nullptr);
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::parallelTraverse(bool onlyDirty,
+    std::function<bool(const std::string_view& table, const std::string_view& key,
+        const Entry& entry)> callback) const
+{
+    std::lock_guard<std::mutex> lock(x_cacheMutex);
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, m_buckets.size()),
+        [this, &onlyDirty, &callback](auto const& range) {
+            for (auto i = range.begin(); i < range.end(); ++i)
+            {
+                auto& bucket = m_buckets[i];
+
+                for (auto& it : bucket.container)
+                {
+                    auto& entry = it.entry;
+                    if (!onlyDirty || entry.dirty())
+                    {
+                        callback(it.table, it.key, entry);
+                    }
+                }
+            }
+        });
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::merge(bool onlyDirty, const TraverseStorageInterface& source)
+{
+    if (&source == this)
+    {
+        STORAGE_LOG(ERROR) << "Can't merge from self!";
+        BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Can't merge from self!"));
+    }
+
+    std::atomic_size_t count = 0;
+    source.parallelTraverse(
+        onlyDirty, [this, &count](const std::string_view& table, const std::string_view& key,
+                       const storage::Entry& entry) {
+            asyncSetRow(table, key, entry, [](Error::UniquePtr) {});
+            ++count;
+            return true;
+        });
+
+    STORAGE_LOG(INFO) << "Successful merged records" << LOG_KV("count", count);
+}
+
+template <bool enableLRU>
+crypto::HashType BaseStorage<enableLRU>::hash(
+    const bcos::crypto::Hash::Ptr& hashImpl, const ledger::Features& features) const
+{
+    bcos::crypto::HashType totalHash;
+    auto blockVersion = features.get(ledger::Features::Flag::bugfix_statestorage_hash) ?
+                            (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION :
+                            (uint32_t)bcos::protocol::BlockVersion::V3_0_VERSION;
+
+    std::vector<bcos::crypto::HashType> hashes(m_buckets.size());
+    tbb::parallel_for(tbb::blocked_range<size_t>(0U, m_buckets.size()), [&, this](auto const& range) {
+        for (auto i = range.begin(); i < range.end(); ++i)
+        {
+            auto& bucket = m_buckets[i];
+
+            bcos::crypto::HashType bucketHash(0);
+            for (auto& it : bucket.container)
+            {
+                auto& entry = it.entry;
+                if (entry.dirty())
+                {
+                    bcos::crypto::HashType entryHash;
+                    if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
+                    {
+                        entryHash = entry.hash(it.table, it.key, *hashImpl, blockVersion);
+                    }
+                    else
+                    {
+                        entryHash = hashImpl->hash(it.table) ^ hashImpl->hash(it.key) ^
+                                    entry.hash(it.table, it.key, *hashImpl, blockVersion);
+                    }
+                    bucketHash ^= entryHash;
+                }
+            }
+
+            hashes[i] ^= bucketHash;
+        }
+    });
+
+    for (auto const& it : hashes)
+    {
+        totalHash ^= it;
+    }
+
+    return totalHash;
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::rollback(const Recoder& recoder)
+{
+    if (m_readOnly)
+    {
+        return;
+    }
+
+    for (const auto& change : recoder)
+    {
+        ssize_t updateCapacity = 0;
+        auto [bucket, lock] = getBucket(change.table, std::string_view(change.key));
+        boost::ignore_unused(lock);
+
+        auto it = bucket->container.find(
+            std::make_tuple(std::string_view(change.table), std::string_view(change.key)));
+        if (change.entry)
+        {
+            if (it != bucket->container.end())
+            {
+                if (c_fileLogLevel <= bcos::LogLevel::TRACE)
+                {
+                    STORAGE_LOG(TRACE) << "Revert exists: " << change.table << " | "
+                                       << toHex(change.key) << " | "
+                                       << toHex(change.entry->get());
+                }
+
+                updateCapacity = change.entry->size() - it->entry.size();
+
+                const auto& rollbackEntry = change.entry;
+                bucket->container.modify(
+                    it, [&rollbackEntry](Data& data) { data.entry = std::move(*rollbackEntry); });
+            }
+            else
+            {
+                if (c_fileLogLevel <= bcos::LogLevel::TRACE)
+                {
+                    STORAGE_LOG(TRACE) << "Revert deleted: " << change.table << " | "
+                                       << toHex(change.key) << " | "
+                                       << toHex(change.entry->get());
+                }
+                updateCapacity = change.entry->size();
+                bucket->container.emplace(Data{change.table, change.key, std::move(*(change.entry))});
+            }
+        }
+        else
+        {
+            if (it != bucket->container.end())
+            {
+                if (c_fileLogLevel <= bcos::LogLevel::TRACE)
+                {
+                    STORAGE_LOG(TRACE)
+                        << "Revert insert: " << change.table << " | " << toHex(change.key);
+                }
+
+                updateCapacity = 0 - it->entry.size();
+                bucket->container.erase(it);
+            }
+            else
+            {
+                auto message =
+                    fmt::format("Not found rollback entry: {}:{}", change.table, change.key);
+
+                BOOST_THROW_EXCEPTION(BCOS_ERROR(StorageError::UnknownError, message));
+            }
+        }
+
+        bucket->capacity += updateCapacity;
+    }
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::setEnableTraverse(bool enableTraverse)
+{
+    m_enableTraverse = enableTraverse;
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::setMaxCapacity(ssize_t capacity)
+{
+    m_maxCapacity = capacity;
+}
+
+template <bool enableLRU>
+Entry BaseStorage<enableLRU>::importExistingEntry(
+    std::string_view table, std::string_view key, Entry entry)
+{
+    if (m_readOnly)
+    {
+        return entry;
+    }
+    if (x_cacheMutex.try_lock())
+    {
+        entry.setStatus(Entry::NORMAL);
+        auto updateCapacity = entry.size();
+
+        auto [bucket, lock] = getBucket(table, key);
+        auto it = bucket->container.find(std::make_tuple(table, key));
+
+        if (it == bucket->container.end())
+        {
+            it = bucket->container
+                     .emplace(Data{std::string(table), std::string(key), std::move(entry)})
+                     .first;
+
+            bucket->capacity += updateCapacity;
+        }
+        else
+        {
+            STORAGE_LOG(DEBUG) << "Fail import existsing entry, " << table << " | " << toHex(key);
+        }
+        x_cacheMutex.unlock();
+        return it->entry;
+    }
+    return entry;
+}
+
+template <bool enableLRU>
+std::shared_ptr<StorageInterface> BaseStorage<enableLRU>::getPrev()
+{
+    std::shared_lock<std::shared_mutex> lock(m_prevMutex);
+    auto prev = m_prev;
+    return prev;
+}
+
+template <bool enableLRU>
+std::tuple<typename BaseStorage<enableLRU>::Bucket*, std::unique_lock<std::mutex>>
+BaseStorage<enableLRU>::getBucket(const std::string_view& table, const std::string_view& key)
+{
+    auto hash = std::hash<std::string_view>{}(table);
+    boost::hash_combine(hash, std::hash<std::string_view>{}(key));
+    auto index = hash % m_buckets.size();
+
+    auto& bucket = m_buckets[index];
+    return std::make_tuple(&bucket, std::unique_lock<std::mutex>(bucket.mutex));
+}
+
+template <bool enableLRU>
+void BaseStorage<enableLRU>::updateMRUAndCheck(Bucket& bucket, typename Container::iterator it)
+{
+    if constexpr (enableLRU)
+    {
+        auto seqIt = bucket.container.template get<1>().iterator_to(*it);
+        bucket.container.template get<1>().relocate(bucket.container.template get<1>().end(), seqIt);
+
+        size_t clearCount = 0;
+        while (bucket.capacity > m_maxCapacity && !bucket.container.empty())
+        {
+            auto& item = bucket.container.template get<1>().front();
+            bucket.capacity -= item.entry.size();
+
+            bucket.container.template get<1>().pop_front();
+            ++clearCount;
+        }
+
+        if (clearCount > 0)
+        {
+            STORAGE_LOG(TRACE) << "LRUStorage cleared:" << clearCount
+                               << ", current size: " << bucket.container.size();
+        }
+    }
+    else
+    {
+        boost::ignore_unused(bucket, it);
+    }
+}
+
+template class BaseStorage<false>;
+template class BaseStorage<true>;
+
+}  // namespace bcos::storage

--- a/bcos-table/src/StateStorage.h
+++ b/bcos-table/src/StateStorage.h
@@ -48,11 +48,7 @@ class BaseStorage : public virtual storage::StateStorageInterface,
 public:
     using Ptr = std::shared_ptr<BaseStorage<enableLRU>>;
 
-    BaseStorage(std::shared_ptr<StorageInterface> prev, bool setRowWithDirtyFlag)
-      : storage::StateStorageInterface(prev),
-        m_buckets(std::thread::hardware_concurrency() + 1),
-        m_setRowWithDirtyFlag(setRowWithDirtyFlag)
-    {}
+        BaseStorage(std::shared_ptr<StorageInterface> prev, bool setRowWithDirtyFlag);
 
     BaseStorage(const BaseStorage&) = delete;
     BaseStorage& operator=(const BaseStorage&) = delete;
@@ -60,504 +56,44 @@ public:
     BaseStorage(BaseStorage&&) = delete;
     BaseStorage& operator=(BaseStorage&&) = delete;
 
-    ~BaseStorage() override { m_recoder.clear(); }
+    ~BaseStorage() override;
 
     void asyncGetPrimaryKeys(std::string_view table,
         const std::optional<storage::Condition const>& condition,
-        std::function<void(Error::UniquePtr, std::vector<std::string>)> _callback) override
-    {
-        std::map<std::string_view, storage::Entry::Status> localKeys;
-
-        if (m_enableTraverse)
-        {
-            std::mutex mergeMutex;
-            tbb::parallel_for(tbb::blocked_range<size_t>(0U, m_buckets.size()),
-                [this, &mergeMutex, &localKeys, &table, &condition](auto const& range) {
-                    for (auto i = range.begin(); i < range.end(); ++i)
-                    {
-                        auto& bucket = m_buckets[i];
-                        std::unique_lock<std::mutex> lock(bucket.mutex);
-
-                        decltype(localKeys) bucketKeys;
-                        for (auto& it : bucket.container)
-                        {
-                            if (it.table == table && (!condition || condition->isValid(it.key)))
-                            {
-                                bucketKeys.emplace(it.key, it.entry.status());
-                            }
-                        }
-
-                        std::unique_lock mergeLock(mergeMutex);
-                        localKeys.merge(std::move(bucketKeys));
-                    }
-                });
-        }
-
-        auto prev = getPrev();
-        if (!prev)
-        {
-            std::vector<std::string> resultKeys;
-            for (auto& localIt : localKeys)
-            {
-                if (localIt.second == Entry::NORMAL || localIt.second == Entry::MODIFIED)
-                {
-                    resultKeys.push_back(std::string(localIt.first));
-                }
-            }
-
-            _callback(nullptr, std::move(resultKeys));
-            return;
-        }
-
-        prev->asyncGetPrimaryKeys(table, condition,
-            [localKeys = std::move(localKeys), callback = std::move(_callback)](
-                auto&& error, auto&& remoteKeys) mutable {
-                if (error)
-                {
-                    callback(BCOS_ERROR_WITH_PREV_UNIQUE_PTR(StorageError::ReadError,
-                                 "Get primary keys from prev failed!", *error),
-                        std::vector<std::string>());
-                    return;
-                }
-
-                for (auto it = remoteKeys.begin(); it != remoteKeys.end();)
-                {
-                    bool deleted = false;
-
-                    auto localIt = localKeys.find(*it);
-                    if (localIt != localKeys.end())
-                    {
-                        if (localIt->second == Entry::DELETED)
-                        {
-                            it = remoteKeys.erase(it);
-                            deleted = true;
-                        }
-
-                        localKeys.erase(localIt);
-                    }
-
-                    if (!deleted)
-                    {
-                        ++it;
-                    }
-                }
-
-                for (auto& localIt : localKeys)
-                {
-                    if (localIt.second == Entry::NORMAL || localIt.second == Entry::MODIFIED)
-                    {
-                        remoteKeys.push_back(std::string(localIt.first));
-                    }
-                }
-
-                callback(nullptr, std::forward<decltype(remoteKeys)>(remoteKeys));
-            });
-    }
+        std::function<void(Error::UniquePtr, std::vector<std::string>)> _callback) override;
 
     void asyncGetRow(std::string_view tableView, std::string_view keyView,
-        std::function<void(Error::UniquePtr, std::optional<Entry>)> _callback) override
-    {
-        auto [bucket, lock] = getBucket(tableView, keyView);
-        boost::ignore_unused(lock);
-
-        auto it = bucket->container.template get<0>().find(std::make_tuple(tableView, keyView));
-        if (it != bucket->container.template get<0>().end())
-        {
-            auto& entry = it->entry;
-
-            if (entry.status() == Entry::DELETED)
-            {
-                lock.unlock();
-
-                _callback(nullptr, std::nullopt);
-            }
-            else
-            {
-                auto optionalEntry = std::make_optional(entry);
-                if constexpr (enableLRU)
-                {
-                    updateMRUAndCheck(*bucket, it);
-                }
-
-                lock.unlock();
-
-                _callback(nullptr, std::move(optionalEntry));
-            }
-            return;
-        }
-
-        lock.unlock();
-
-        auto prev = getPrev();
-        if (prev)
-        {
-            prev->asyncGetRow(tableView, keyView,
-                [this, prev, table = std::string(tableView), key = std::string(keyView), _callback](
-                    Error::UniquePtr error, std::optional<Entry> entry) {
-                    if (error)
-                    {
-                        _callback(BCOS_ERROR_WITH_PREV_UNIQUE_PTR(StorageError::ReadError,
-                                      "Get row from storage failed!", *error),
-                            {});
-                        return;
-                    }
-
-                    if (entry)
-                    {
-                        _callback(nullptr,
-                            std::make_optional(importExistingEntry(table, key, std::move(*entry))));
-                    }
-                    else
-                    {
-                        _callback(nullptr, std::nullopt);
-                    }
-                });
-        }
-        else
-        {
-            _callback(nullptr, std::nullopt);
-        }
-    }
+        std::function<void(Error::UniquePtr, std::optional<Entry>)> _callback) override;
 
     void asyncGetRows(std::string_view tableView,
         ::ranges::any_view<std::string_view,
             ::ranges::category::input | ::ranges::category::random_access |
                 ::ranges::category::sized>
             keys,
-        std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback) override
-    {
-        auto size = keys.size();
-        std::vector<std::optional<Entry>> results(keys.size());
-        auto missinges = std::tuple<std::vector<std::string_view>,
-            std::vector<std::tuple<std::string, size_t>>>();
-
-        std::atomic_ulong existsCount = 0;
-
-        for (auto i = 0U; i < keys.size(); ++i)
-        {
-            auto [bucket, lock] = getBucket(tableView, keys[i]);
-            boost::ignore_unused(lock);
-
-            auto it = bucket->container.find(std::make_tuple(tableView, std::string_view(keys[i])));
-            if (it != bucket->container.end())
-            {
-                auto& entry = it->entry;
-                if (entry.status() == Entry::NORMAL || entry.status() == Entry::MODIFIED)
-                {
-                    results[i].emplace(entry);
-
-                    if constexpr (enableLRU)
-                    {
-                        updateMRUAndCheck(*bucket, it);
-                    }
-                }
-                else
-                {
-                    results[i] = std::nullopt;
-                }
-                ++existsCount;
-            }
-            else
-            {
-                std::get<1>(missinges).emplace_back(std::string(keys[i]), i);
-                std::get<0>(missinges).emplace_back(keys[i]);
-            }
-        }
-
-        auto prev = getPrev();
-        if (existsCount < keys.size() && prev)
-        {
-            prev->asyncGetRows(tableView, std::get<0>(missinges),
-                [this, table = std::string(tableView), callback = std::move(_callback),
-                    missingIndexes = std::move(std::get<1>(missinges)),
-                    results = std::move(results)](
-                    auto&& error, std::vector<std::optional<Entry>>&& entries) mutable {
-                    if (error)
-                    {
-                        callback(BCOS_ERROR_WITH_PREV_UNIQUE_PTR(StorageError::ReadError,
-                                     "async get perv rows failed!", *error),
-                            std::vector<std::optional<Entry>>());
-                        return;
-                    }
-
-                    for (size_t i = 0; i < entries.size(); ++i)
-                    {
-                        auto& entry = entries[i];
-
-                        if (entry)
-                        {
-                            results[std::get<1>(missingIndexes[i])].emplace(
-                                importExistingEntry(table,
-                                    std::move(std::get<0>(missingIndexes[i])), std::move(*entry)));
-                        }
-                    }
-
-                    callback(nullptr, std::move(results));
-                });
-        }
-        else
-        {
-            _callback(nullptr, std::move(results));
-        }
-    }
+        std::function<void(Error::UniquePtr, std::vector<std::optional<Entry>>)> _callback) override;
 
     void asyncSetRow(std::string_view tableView, std::string_view keyView, Entry entry,
-        std::function<void(Error::UniquePtr)> callback) override
-    {
-        if (m_readOnly)
-        {
-            callback(BCOS_ERROR_UNIQUE_PTR(
-                StorageError::ReadOnly, "Try to operate a read-only storage"));
-            return;
-        }
-
-        ssize_t updatedCapacity = entry.size();
-        std::optional<Entry> entryOld;
-
-        if (m_setRowWithDirtyFlag && entry.status() == Entry::NORMAL)
-        {
-            entry.setStatus(Entry::MODIFIED);
-        }
-        auto [bucket, lock] = getBucket(tableView, keyView);
-        auto it = bucket->container.find(std::make_tuple(tableView, keyView));
-        if (it != bucket->container.end())
-        {
-            auto& existsEntry = it->entry;
-            entryOld.emplace(std::move(existsEntry));
-
-            updatedCapacity -= entryOld->size();
-
-            bucket->container.modify(it, [&entry](Data& data) { data.entry = std::move(entry); });
-        }
-        else
-        {
-            auto [iter, _] = bucket->container.emplace(
-                Data{std::string(tableView), std::string(keyView), std::move(entry)});
-            it = iter;
-        }
-        if constexpr (enableLRU)
-        {
-            updateMRUAndCheck(*bucket, it);
-        }
-
-        if (m_recoder.local())
-        {
-            m_recoder.local()->log(
-                Recoder::Change(std::string(tableView), std::string(keyView), std::move(entryOld)));
-        }
-
-        bucket->capacity += updatedCapacity;
-
-        lock.unlock();
-        callback(nullptr);
-    }
+        std::function<void(Error::UniquePtr)> callback) override;
 
     void parallelTraverse(bool onlyDirty, std::function<bool(const std::string_view& table,
                                               const std::string_view& key, const Entry& entry)>
-                                              callback) const override
-    {
-        std::lock_guard<std::mutex> lock(x_cacheMutex);
-        tbb::parallel_for(tbb::blocked_range<size_t>(0, m_buckets.size()),
-            [this, &onlyDirty, &callback](auto const& range) {
-                for (auto i = range.begin(); i < range.end(); ++i)
-                {
-                    auto& bucket = m_buckets[i];
+                                              callback) const override;
 
-                    for (auto& it : bucket.container)
-                    {
-                        auto& entry = it.entry;
-                        if (!onlyDirty || entry.dirty())
-                        {
-                            callback(it.table, it.key, entry);
-                        }
-                    }
-                }
-            });
-    }
-
-    void merge(bool onlyDirty, const TraverseStorageInterface& source) override
-    {
-        if (&source == this)
-        {
-            STORAGE_LOG(ERROR) << "Can't merge from self!";
-            BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Can't merge from self!"));
-        }
-
-        std::atomic_size_t count = 0;
-        source.parallelTraverse(
-            onlyDirty, [this, &count](const std::string_view& table, const std::string_view& key,
-                           const storage::Entry& entry) {
-                asyncSetRow(table, key, entry, [](Error::UniquePtr) {});
-                ++count;
-                return true;
-            });
-
-        STORAGE_LOG(INFO) << "Successful merged records" << LOG_KV("count", count);
-    }
+    void merge(bool onlyDirty, const TraverseStorageInterface& source) override;
 
     crypto::HashType hash(
-        const bcos::crypto::Hash::Ptr& hashImpl, const ledger::Features& features) const override
-    {
-        bcos::crypto::HashType totalHash;
-        auto blockVersion = features.get(ledger::Features::Flag::bugfix_statestorage_hash) ?
-                                (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION :
-                                (uint32_t)bcos::protocol::BlockVersion::V3_0_VERSION;
-
-        std::vector<bcos::crypto::HashType> hashes(m_buckets.size());
-        tbb::parallel_for(tbb::blocked_range<size_t>(0U, m_buckets.size()), [&, this](
-                                                                                auto const& range) {
-            for (auto i = range.begin(); i < range.end(); ++i)
-            {
-                auto& bucket = m_buckets[i];
-
-                bcos::crypto::HashType bucketHash(0);
-                for (auto& it : bucket.container)
-                {
-                    auto& entry = it.entry;
-                    if (entry.dirty())
-                    {
-                        bcos::crypto::HashType entryHash;
-                        if (blockVersion >= (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
-                        {
-                            entryHash = entry.hash(it.table, it.key, *hashImpl, blockVersion);
-                        }
-                        else
-                        {  // v3.0.0-v3.2.0 use this which will make it not compatible with
-                           // v3.1.0 keyPageStorage
-                            entryHash = hashImpl->hash(it.table) ^ hashImpl->hash(it.key) ^
-                                        entry.hash(it.table, it.key, *hashImpl, blockVersion);
-                        }
-                        bucketHash ^= entryHash;
-                    }
-                }
-
-                hashes[i] ^= bucketHash;
-            }
-        });
-
-        for (auto const& it : hashes)
-        {
-            totalHash ^= it;
-        }
-
-        return totalHash;
-    }
+        const bcos::crypto::Hash::Ptr& hashImpl, const ledger::Features& features) const override;
 
 
-    void rollback(const Recoder& recoder) override
-    {
-        if (m_readOnly)
-        {
-            return;
-        }
+    void rollback(const Recoder& recoder) override;
 
-        for (const auto& change : recoder)
-        {
-            ssize_t updateCapacity = 0;
-            auto [bucket, lock] = getBucket(change.table, std::string_view(change.key));
-            boost::ignore_unused(lock);
-
-            auto it = bucket->container.find(
-                std::make_tuple(std::string_view(change.table), std::string_view(change.key)));
-            if (change.entry)
-            {
-                if (it != bucket->container.end())
-                {
-                    if (c_fileLogLevel <= bcos::LogLevel::TRACE)
-                    {
-                        STORAGE_LOG(TRACE)
-                            << "Revert exists: " << change.table << " | " << toHex(change.key)
-                            << " | " << toHex(change.entry->get());
-                    }
-
-                    updateCapacity = change.entry->size() - it->entry.size();
-
-                    const auto& rollbackEntry = change.entry;
-                    bucket->container.modify(it,
-                        [&rollbackEntry](Data& data) { data.entry = std::move(*rollbackEntry); });
-                }
-                else
-                {
-                    if (c_fileLogLevel <= bcos::LogLevel::TRACE)
-                    {
-                        STORAGE_LOG(TRACE)
-                            << "Revert deleted: " << change.table << " | " << toHex(change.key)
-                            << " | " << toHex(change.entry->get());
-                    }
-                    updateCapacity = change.entry->size();
-                    bucket->container.emplace(
-                        Data{change.table, change.key, std::move(*(change.entry))});
-                }
-            }
-            else
-            {  // nullopt means the key is not exist in m_cache
-                if (it != bucket->container.end())
-                {
-                    if (c_fileLogLevel <= bcos::LogLevel::TRACE)
-                    {
-                        STORAGE_LOG(TRACE)
-                            << "Revert insert: " << change.table << " | " << toHex(change.key);
-                    }
-
-                    updateCapacity = 0 - it->entry.size();
-                    bucket->container.erase(it);
-                }
-                else
-                {
-                    auto message =
-                        fmt::format("Not found rollback entry: {}:{}", change.table, change.key);
-
-                    BOOST_THROW_EXCEPTION(BCOS_ERROR(StorageError::UnknownError, message));
-                }
-            }
-
-            bucket->capacity += updateCapacity;
-        }
-    }
-
-    void setEnableTraverse(bool enableTraverse) { m_enableTraverse = enableTraverse; }
-    void setMaxCapacity(ssize_t capacity) { m_maxCapacity = capacity; }
+    void setEnableTraverse(bool enableTraverse);
+    void setMaxCapacity(ssize_t capacity);
 
 private:
-    Entry importExistingEntry(std::string_view table, std::string_view key, Entry entry)
-    {
-        if (m_readOnly)
-        {
-            return entry;
-        }
-        if (x_cacheMutex.try_lock())
-        {
-            entry.setStatus(Entry::NORMAL);
-            auto updateCapacity = entry.size();
+    Entry importExistingEntry(std::string_view table, std::string_view key, Entry entry);
 
-            auto [bucket, lock] = getBucket(table, key);
-            auto it = bucket->container.find(std::make_tuple(table, key));
-
-            if (it == bucket->container.end())
-            {
-                it = bucket->container
-                         .emplace(Data{std::string(table), std::string(key), std::move(entry)})
-                         .first;
-
-                bucket->capacity += updateCapacity;
-            }
-            else
-            {
-                STORAGE_LOG(DEBUG)
-                    << "Fail import existsing entry, " << table << " | " << toHex(key);
-            }
-            x_cacheMutex.unlock();
-            return it->entry;
-        }
-        return entry;
-    }
-
-    std::shared_ptr<StorageInterface> getPrev()
-    {
-        std::shared_lock<std::shared_mutex> lock(m_prevMutex);
-        auto prev = m_prev;
-        return prev;
-    }
+    std::shared_ptr<StorageInterface> getPrev();
 
     bool m_enableTraverse = false;
 
@@ -597,42 +133,15 @@ private:
     bool m_setRowWithDirtyFlag = false;
 
     std::tuple<Bucket*, std::unique_lock<std::mutex>> getBucket(
-        const std::string_view& table, const std::string_view& key)
-    {
-        auto hash = std::hash<std::string_view>{}(table);
-        boost::hash_combine(hash, std::hash<std::string_view>{}(key));
-        auto index = hash % m_buckets.size();
+        const std::string_view& table, const std::string_view& key);
 
-        auto& bucket = m_buckets[index];
-        return std::make_tuple(&bucket, std::unique_lock<std::mutex>(bucket.mutex));
-    }
-
-    void updateMRUAndCheck(
-        Bucket& bucket, typename Container::template nth_index<0>::type::iterator it)
-    {
-        auto seqIt = bucket.container.template get<1>().iterator_to(*it);
-        bucket.container.template get<1>().relocate(
-            bucket.container.template get<1>().end(), seqIt);
-
-        size_t clearCount = 0;
-        while (bucket.capacity > m_maxCapacity && !bucket.container.empty())
-        {
-            auto& item = bucket.container.template get<1>().front();
-            bucket.capacity -= item.entry.size();
-
-            bucket.container.template get<1>().pop_front();
-            ++clearCount;
-        }
-
-        if (clearCount > 0)
-        {
-            STORAGE_LOG(TRACE) << "LRUStorage cleared:" << clearCount
-                               << ", current size: " << bucket.container.size();
-        }
-    }
+    void updateMRUAndCheck(Bucket& bucket, typename Container::iterator it);
 };
 
 using StateStorage = BaseStorage<false>;
 using LRUStateStorage = BaseStorage<true>;
+
+extern template class BaseStorage<false>;
+extern template class BaseStorage<true>;
 
 }  // namespace bcos::storage

--- a/bcos-table/src/StateStorageFactory.cpp
+++ b/bcos-table/src/StateStorageFactory.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2022 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "StateStorageFactory.h"
+
+using namespace bcos::storage;
+
+StateStorageFactory::StateStorageFactory(size_t keyPageSize) : m_keyPageSize(keyPageSize) {}
+
+StateStorageInterface::Ptr StateStorageFactory::createStateStorage(
+    bcos::storage::StorageInterface::Ptr storage, uint32_t compatibilityVersion,
+    bool setRowWithDirtyFlag, bool ignoreNotExist,
+    std::shared_ptr<std::set<std::string, std::less<>>> const& keyPageIgnoreTables)
+{
+    STORAGE_LOG(TRACE) << LOG_KV("compatibilityVersion", compatibilityVersion)
+                       << LOG_KV("protocol::BlockVersion::V3_1_VERSION",
+                              (uint32_t)protocol::BlockVersion::V3_1_VERSION)
+                       << LOG_KV("keyPageSize", m_keyPageSize)
+                       << LOG_KV("setRowWithDirtyFlag", setRowWithDirtyFlag);
+
+    if (m_keyPageSize > 0)
+    {
+        if (compatibilityVersion >= (uint32_t)protocol::BlockVersion::V3_1_VERSION &&
+            keyPageIgnoreTables != nullptr)
+        {
+            if (keyPageIgnoreTables->contains(tool::FS_ROOT))
+            {
+                for (const auto& subPath : tool::FS_ROOT_SUBS)
+                {
+                    std::string sub(subPath);
+                    keyPageIgnoreTables->erase(sub);
+                }
+            }
+            keyPageIgnoreTables->insert(
+                {std::string(ledger::SYS_CODE_BINARY), std::string(ledger::SYS_CONTRACT_ABI)});
+        }
+        STORAGE_LOG(TRACE) << LOG_KV("keyPageSize", m_keyPageSize)
+                           << LOG_KV("compatibilityVersion", compatibilityVersion)
+                           << LOG_KV("keyPageIgnoreTables size",
+                                  keyPageIgnoreTables == nullptr ? 0 : keyPageIgnoreTables->size());
+        return std::make_shared<bcos::storage::KeyPageStorage>(storage, setRowWithDirtyFlag,
+            m_keyPageSize, compatibilityVersion, keyPageIgnoreTables, ignoreNotExist);
+    }
+
+    return std::make_shared<bcos::storage::StateStorage>(storage, setRowWithDirtyFlag);
+}

--- a/bcos-table/src/StateStorageFactory.h
+++ b/bcos-table/src/StateStorageFactory.h
@@ -57,49 +57,14 @@ class StateStorageFactory
 {
 public:
     using Ptr = std::shared_ptr<StateStorageFactory>;
-    StateStorageFactory(size_t keyPageSize) : m_keyPageSize(keyPageSize) {}
+    explicit StateStorageFactory(size_t keyPageSize);
 
     virtual ~StateStorageFactory() = default;
 
     virtual storage::StateStorageInterface::Ptr createStateStorage(
         bcos::storage::StorageInterface::Ptr storage, uint32_t compatibilityVersion,
         bool setRowWithDirtyFlag, bool ignoreNotExist = false,
-        std::shared_ptr<std::set<std::string, std::less<>>> const& keyPageIgnoreTables = nullptr)
-    {
-        STORAGE_LOG(TRACE) << LOG_KV("compatibilityVersion", compatibilityVersion)
-                           << LOG_KV("protocol::BlockVersion::V3_1_VERSION",
-                                  (uint32_t)protocol::BlockVersion::V3_1_VERSION)
-                           << LOG_KV("keyPageSize", m_keyPageSize)
-                           << LOG_KV("setRowWithDirtyFlag", setRowWithDirtyFlag);
-
-        if (m_keyPageSize > 0)
-        {
-            if (compatibilityVersion >= (uint32_t)protocol::BlockVersion::V3_1_VERSION &&
-                keyPageIgnoreTables != nullptr)
-            {
-                if (keyPageIgnoreTables->contains(tool::FS_ROOT))
-                {
-                    for (const auto& _sub : tool::FS_ROOT_SUBS)
-                    {
-                        std::string sub(_sub);
-                        keyPageIgnoreTables->erase(sub);
-                    }
-                }
-                keyPageIgnoreTables->insert(
-                    {std::string(ledger::SYS_CODE_BINARY), std::string(ledger::SYS_CONTRACT_ABI)});
-            }
-            STORAGE_LOG(TRACE) << LOG_KV("keyPageSize", m_keyPageSize)
-                               << LOG_KV("compatibilityVersion", compatibilityVersion)
-                               << LOG_KV("keyPageIgnoreTables size",
-                                      keyPageIgnoreTables == nullptr ? 0 :
-                                                                       keyPageIgnoreTables->size());
-            return std::make_shared<bcos::storage::KeyPageStorage>(storage, setRowWithDirtyFlag,
-                m_keyPageSize, compatibilityVersion, keyPageIgnoreTables, ignoreNotExist);
-        }
-
-        // Pass useHashV310 flag to hash() insted of compatibilityVersion
-        return std::make_shared<bcos::storage::StateStorage>(storage, setRowWithDirtyFlag);
-    }
+        std::shared_ptr<std::set<std::string, std::less<>>> const& keyPageIgnoreTables = nullptr);
 
 private:
     size_t m_keyPageSize;

--- a/bcos-table/src/StateStorageInterface.cpp
+++ b/bcos-table/src/StateStorageInterface.cpp
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "StateStorageInterface.h"
+
+using namespace bcos::storage;
+
+Recoder::Change::Change(std::string _table, std::string _key, std::optional<Entry> _entry)
+  : table(std::move(_table)), key(std::move(_key)), entry(std::move(_entry))
+{}
+
+void Recoder::log(Change&& change)
+{
+    m_changes.emplace_front(std::move(change));
+}
+
+std::list<Recoder::Change>::const_iterator Recoder::begin() const
+{
+    return m_changes.cbegin();
+}
+
+std::list<Recoder::Change>::const_iterator Recoder::end() const
+{
+    return m_changes.cend();
+}
+
+void Recoder::clear()
+{
+    m_changes.clear();
+}
+
+StateStorageInterface::StateStorageInterface(std::shared_ptr<StorageInterface> prev)
+  : storage::TraverseStorageInterface(), m_prev(std::move(prev))
+{}
+
+std::optional<Table> StateStorageInterface::openTable(const std::string_view& tableView)
+{
+    std::promise<std::tuple<Error::UniquePtr, std::optional<Table>>> openPromise;
+    asyncOpenTable(tableView, [&](auto&& error, auto&& table) {
+        openPromise.set_value({std::move(error), std::move(table)});
+    });
+
+    auto [error, table] = openPromise.get_future().get();
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(*error);
+    }
+    return table;
+}
+
+std::optional<Table> StateStorageInterface::createTable(
+    std::string _tableName, std::string _valueFields)
+{
+    std::promise<std::tuple<Error::UniquePtr, std::optional<Table>>> createPromise;
+    asyncCreateTable(
+        std::move(_tableName), std::move(_valueFields),
+        [&](Error::UniquePtr&& error, std::optional<Table>&& table) {
+            createPromise.set_value({std::move(error), std::move(table)});
+        });
+    auto [error, table] = createPromise.get_future().get();
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(*error);
+    }
+    return table;
+}
+
+std::pair<size_t, bcos::Error::Ptr> StateStorageInterface::count(
+    const std::string_view& _table [[maybe_unused]])
+{
+    BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Called interface count method"));
+}
+
+void StateStorageInterface::setPrev(std::shared_ptr<StorageInterface> prev)
+{
+    std::unique_lock<std::shared_mutex> lock(m_prevMutex);
+    m_prev = std::move(prev);
+}
+
+void StateStorageInterface::setRecoder(typename Recoder::Ptr recoder)
+{
+    m_recoder.local().swap(recoder);
+}
+
+void StateStorageInterface::setReadOnly(bool readOnly)
+{
+    m_readOnly = readOnly;
+}

--- a/bcos-table/src/StateStorageInterface.h
+++ b/bcos-table/src/StateStorageInterface.h
@@ -43,9 +43,7 @@ public:
 
     struct Change
     {
-        Change(std::string _table, std::string _key, std::optional<Entry> _entry)
-          : table(std::move(_table)), key(std::move(_key)), entry(std::move(_entry))
-        {}
+                Change(std::string _table, std::string _key, std::optional<Entry> _entry);
         Change(const Change&) = delete;
         Change& operator=(const Change&) = delete;
         Change(Change&&) noexcept = default;
@@ -56,10 +54,10 @@ public:
         std::optional<Entry> entry;
     };
 
-    void log(Change&& change) { m_changes.emplace_front(std::move(change)); }
-    auto begin() const { return m_changes.cbegin(); }
-    auto end() const { return m_changes.cend(); }
-    void clear() { m_changes.clear(); }
+    void log(Change&& change);
+    std::list<Change>::const_iterator begin() const;
+    std::list<Change>::const_iterator end() const;
+    void clear();
 
 private:
     std::list<Change> m_changes;
@@ -70,53 +68,19 @@ class StateStorageInterface : public virtual storage::TraverseStorageInterface
 {
 public:
     using Ptr = std::shared_ptr<StateStorageInterface>;
-    StateStorageInterface(std::shared_ptr<StorageInterface> prev)
-      : storage::TraverseStorageInterface(), m_prev(std::move(prev)){};
-    virtual std::optional<Table> openTable(const std::string_view& tableView)
-    {
-        std::promise<std::tuple<Error::UniquePtr, std::optional<Table>>> openPromise;
-        asyncOpenTable(tableView, [&](auto&& error, auto&& table) {
-            openPromise.set_value({std::move(error), std::move(table)});
-        });
+    explicit StateStorageInterface(std::shared_ptr<StorageInterface> prev);
+    virtual std::optional<Table> openTable(const std::string_view& tableView);
 
-        auto [error, table] = openPromise.get_future().get();
-        if (error)
-        {
-            BOOST_THROW_EXCEPTION(*error);
-        }
-        return table;
-    }
+    virtual std::optional<Table> createTable(std::string _tableName, std::string _valueFields);
 
-    virtual std::optional<Table> createTable(std::string _tableName, std::string _valueFields)
-    {
-        std::promise<std::tuple<Error::UniquePtr, std::optional<Table>>> createPromise;
-        asyncCreateTable(
-            _tableName, _valueFields, [&](Error::UniquePtr&& error, std::optional<Table>&& table) {
-                createPromise.set_value({std::move(error), std::move(table)});
-            });
-        auto [error, table] = createPromise.get_future().get();
-        if (error)
-        {
-            BOOST_THROW_EXCEPTION(*error);
-        }
-        return table;
-    }
-
-    virtual std::pair<size_t, Error::Ptr> count(const std::string_view& _table [[maybe_unused]])
-    {
-        BOOST_THROW_EXCEPTION(BCOS_ERROR(-1, "Called interface count method"));
-    }
+    virtual std::pair<size_t, Error::Ptr> count(const std::string_view& _table [[maybe_unused]]);
 
     virtual crypto::HashType hash(
         const bcos::crypto::Hash::Ptr& hashImpl, const ledger::Features& features) const = 0;
-    virtual void setPrev(std::shared_ptr<StorageInterface> prev)
-    {
-        std::unique_lock<std::shared_mutex> lock(m_prevMutex);
-        m_prev = std::move(prev);
-    }
+    virtual void setPrev(std::shared_ptr<StorageInterface> prev);
     virtual void rollback(const Recoder& recoder) = 0;
-    virtual void setRecoder(typename Recoder::Ptr recoder) { m_recoder.local().swap(recoder); }
-    virtual void setReadOnly(bool readOnly) { m_readOnly = readOnly; }
+    virtual void setRecoder(typename Recoder::Ptr recoder);
+    virtual void setReadOnly(bool readOnly);
 
 protected:
     bool m_readOnly = false;

--- a/bcos-table/src/StorageWrapper.cpp
+++ b/bcos-table/src/StorageWrapper.cpp
@@ -1,0 +1,204 @@
+/*
+ *  Copyright (C) 2022 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "StorageWrapper.h"
+
+using namespace bcos::storage;
+
+StorageWrapper::StorageWrapper(
+    storage::StateStorageInterface::Ptr storage, bcos::storage::Recoder::Ptr recoder)
+  : m_storage(std::move(storage)), m_recoder(std::move(recoder))
+{}
+
+std::vector<std::string> StorageWrapper::getPrimaryKeys(
+    const std::string_view& table, const std::optional<storage::Condition const>& _condition)
+{
+    GetPrimaryKeysReponse value;
+    m_storage->asyncGetPrimaryKeys(table, _condition, [&value](auto&& error, auto&& keys) mutable {
+        value = {std::move(error), std::move(keys)};
+    });
+
+    setRecoder(m_recoder);
+
+    auto& [error, keys] = value;
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(*error);
+    }
+
+    return std::move(keys);
+}
+
+std::optional<Entry> StorageWrapper::getRowInternal(
+    const std::string_view& table, const std::string_view& _key)
+{
+    GetRowResponse value;
+    m_storage->asyncGetRow(table, _key, [&value](auto&& error, auto&& entry) mutable {
+        value = {std::forward<decltype(error)>(error), std::forward<decltype(entry)>(entry)};
+    });
+
+    auto& [error, entry] = value;
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(*error);
+    }
+
+    return std::move(entry);
+}
+
+std::optional<Entry> StorageWrapper::getRow(
+    const std::string_view& table, const std::string_view& _key)
+{
+    if (m_codeCache && table.compare(M_SYS_CODE_BINARY) == 0)
+    {
+        auto it = m_codeCache->find(std::string(_key));
+        if (it != m_codeCache->end())
+        {
+            return it->second;
+        }
+
+        auto code = getRowInternal(table, _key);
+        if (code.has_value())
+        {
+            m_codeCache->emplace(std::string(_key), code);
+        }
+
+        return code;
+    }
+    if (m_codeHashCache && _key.compare(M_ACCOUNT_CODE_HASH) == 0)
+    {
+        auto it = m_codeHashCache->find(std::string(table));
+        if (it != m_codeHashCache->end())
+        {
+            return it->second;
+        }
+
+        auto codeHash = getRowInternal(table, _key);
+        if (codeHash.has_value())
+        {
+            m_codeHashCache->emplace(std::string(table), codeHash);
+        }
+
+        return codeHash;
+    }
+
+    return getRowInternal(table, _key);
+}
+
+std::vector<std::optional<Entry>> StorageWrapper::getRows(const std::string_view& table,
+    ::ranges::any_view<std::string_view,
+        ::ranges::category::input | ::ranges::category::random_access |
+            ::ranges::category::sized>
+        keys)
+{
+    GetRowsResponse value;
+    m_storage->asyncGetRows(table, keys, [&value](auto&& error, auto&& entries) mutable {
+        value = {std::move(error), std::move(entries)};
+    });
+
+    auto& [error, entries] = value;
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(*error);
+    }
+
+    return std::move(entries);
+}
+
+void StorageWrapper::setRow(
+    const std::string_view& table, const std::string_view& key, Entry entry)
+{
+    SetRowResponse value;
+
+    m_storage->asyncSetRow(table, key, std::move(entry),
+        [&value](auto&& error) mutable { value = std::tuple{std::move(error)}; });
+
+    auto& [error] = value;
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(*error);
+    }
+}
+
+std::optional<Table> StorageWrapper::createTable(
+    std::string _tableName, std::string _valueFields)
+{
+    auto ret = createTableWithoutException(std::move(_tableName), std::move(_valueFields));
+    if (std::get<0>(ret))
+    {
+        BOOST_THROW_EXCEPTION(*(std::get<0>(ret)));
+    }
+
+    return std::get<1>(ret);
+}
+
+std::tuple<bcos::Error::UniquePtr, std::optional<Table>>
+StorageWrapper::createTableWithoutException(std::string _tableName, std::string _valueFields)
+{
+    std::promise<OpenTableResponse> createPromise;
+    m_storage->asyncCreateTable(std::move(_tableName), std::move(_valueFields),
+        [&](Error::UniquePtr&& error, auto&& table) mutable {
+            createPromise.set_value({std::move(error), std::move(table)});
+        });
+    auto value = createPromise.get_future().get();
+    return value;
+}
+
+std::optional<Table> StorageWrapper::openTable(std::string_view tableName)
+{
+    auto it = m_tableCache.find(std::string(tableName));
+    if (it != m_tableCache.end())
+    {
+        return it->second;
+    }
+
+    auto ret = openTableWithoutException(tableName);
+    if (std::get<0>(ret))
+    {
+        BOOST_THROW_EXCEPTION(*(std::get<0>(ret)));
+    }
+    auto table = std::get<1>(ret);
+    if (table)
+    {
+        m_tableCache.insert(std::make_pair(std::string(tableName), std::get<1>(ret)));
+    }
+    return table;
+}
+
+std::pair<size_t, bcos::Error::Ptr> StorageWrapper::count(const std::string_view& _table)
+{
+    return m_storage->count(_table);
+}
+
+std::tuple<bcos::Error::UniquePtr, std::optional<Table>>
+StorageWrapper::openTableWithoutException(std::string_view tableName)
+{
+    std::promise<OpenTableResponse> openPromise;
+    m_storage->asyncOpenTable(tableName, [&](auto&& error, auto&& table) mutable {
+        openPromise.set_value({std::move(error), std::move(table)});
+    });
+    auto value = openPromise.get_future().get();
+    return value;
+}
+
+void StorageWrapper::setRecoder(storage::Recoder::Ptr recoder)
+{
+    m_storage->setRecoder(std::move(recoder));
+}
+
+void StorageWrapper::setCodeCache(EntryCachePtr cache)
+{
+    m_codeCache = std::move(cache);
+}
+
+void StorageWrapper::setCodeHashCache(EntryCachePtr cache)
+{
+    m_codeHashCache = std::move(cache);
+}
+
+StateStorageInterface::Ptr StorageWrapper::getRawStorage()
+{
+    return m_storage;
+}

--- a/bcos-table/src/StorageWrapper.h
+++ b/bcos-table/src/StorageWrapper.h
@@ -27,8 +27,7 @@ class StorageWrapper
 {
 public:
     StorageWrapper(storage::StateStorageInterface::Ptr storage, bcos::storage::Recoder::Ptr recoder)
-      : m_storage(std::move(storage)), m_recoder(std::move(recoder))
-    {}
+            ;
 
     StorageWrapper(const StorageWrapper&) = delete;
     StorageWrapper(StorageWrapper&&) = delete;
@@ -38,190 +37,41 @@ public:
     virtual ~StorageWrapper() = default;
 
     std::vector<std::string> getPrimaryKeys(
-        const std::string_view& table, const std::optional<storage::Condition const>& _condition)
-    {
-        GetPrimaryKeysReponse value;
-        m_storage->asyncGetPrimaryKeys(
-            table, _condition, [&value](auto&& error, auto&& keys) mutable {
-                value = {std::move(error), std::move(keys)};
-            });
-
-        // After coroutine switch, set the recoder
-        setRecoder(m_recoder);
-
-        auto& [error, keys] = value;
-
-        if (error)
-        {
-            BOOST_THROW_EXCEPTION(*error);
-        }
-
-        return std::move(keys);
-    }
+        const std::string_view& table, const std::optional<storage::Condition const>& _condition);
 
     std::optional<storage::Entry> getRowInternal(
-        const std::string_view& table, const std::string_view& _key)
-    {
-        GetRowResponse value;
-        m_storage->asyncGetRow(table, _key, [&value](auto&& error, auto&& entry) mutable {
-            value = {std::forward<decltype(error)>(error), std::forward<decltype(entry)>(entry)};
-        });
-
-        auto& [error, entry] = value;
-
-        if (error)
-        {
-            BOOST_THROW_EXCEPTION(*error);
-        }
-
-        return std::move(entry);
-    }
+        const std::string_view& table, const std::string_view& _key);
 
     virtual std::optional<storage::Entry> getRow(
-        const std::string_view& table, const std::string_view& _key)
-    {
-        if (m_codeCache && table.compare(M_SYS_CODE_BINARY) == 0)
-        {
-            auto it = m_codeCache->find(std::string(_key));
-            if (it != m_codeCache->end())
-            {
-                return it->second;
-            }
-
-            auto code = getRowInternal(table, _key);
-            if (code.has_value())
-            {
-                m_codeCache->emplace(std::string(_key), code);
-            }
-
-            return code;
-        }
-        else if (m_codeHashCache && _key.compare(M_ACCOUNT_CODE_HASH) == 0)
-        {
-            auto it = m_codeHashCache->find(std::string(table));
-            if (it != m_codeHashCache->end())
-            {
-                return it->second;
-            }
-
-            auto codeHash = getRowInternal(table, _key);
-            if (codeHash.has_value())
-            {
-                m_codeHashCache->emplace(std::string(table), codeHash);
-            }
-
-            return codeHash;
-        }
-        else
-        {
-            return getRowInternal(table, _key);
-        }
-    }
+        const std::string_view& table, const std::string_view& _key);
 
     virtual std::vector<std::optional<storage::Entry>> getRows(const std::string_view& table,
         ::ranges::any_view<std::string_view,
             ::ranges::category::input | ::ranges::category::random_access |
                 ::ranges::category::sized>
-            keys)
-    {
-        GetRowsResponse value;
-        m_storage->asyncGetRows(table, keys, [&value](auto&& error, auto&& entries) mutable {
-            value = {std::move(error), std::move(entries)};
-        });
-
-
-        auto& [error, entries] = value;
-
-        if (error)
-        {
-            BOOST_THROW_EXCEPTION(*error);
-        }
-
-        return std::move(entries);
-    }
+            keys);
 
     virtual void setRow(
-        const std::string_view& table, const std::string_view& key, storage::Entry entry)
-    {
-        SetRowResponse value;
+        const std::string_view& table, const std::string_view& key, storage::Entry entry);
 
-        m_storage->asyncSetRow(table, key, std::move(entry),
-            [&value](auto&& error) mutable { value = std::tuple{std::move(error)}; });
-
-        auto& [error] = value;
-
-        if (error)
-        {
-            BOOST_THROW_EXCEPTION(*error);
-        }
-    }
-
-    std::optional<storage::Table> createTable(std::string _tableName, std::string _valueFields)
-    {
-        auto ret = createTableWithoutException(_tableName, _valueFields);
-        if (std::get<0>(ret))
-        {
-            BOOST_THROW_EXCEPTION(*(std::get<0>(ret)));
-        }
-
-        return std::get<1>(ret);
-    }
+    std::optional<storage::Table> createTable(std::string _tableName, std::string _valueFields);
 
     std::tuple<Error::UniquePtr, std::optional<storage::Table>> createTableWithoutException(
-        std::string _tableName, std::string _valueFields)
-    {
-        std::promise<OpenTableResponse> createPromise;
-        m_storage->asyncCreateTable(std::move(_tableName), std::move(_valueFields),
-            [&](Error::UniquePtr&& error, auto&& table) mutable {
-                createPromise.set_value({std::move(error), std::move(table)});
-            });
-        auto value = createPromise.get_future().get();
-        return value;
-    }
+        std::string _tableName, std::string _valueFields);
 
-    std::optional<storage::Table> openTable(std::string_view tableName)
-    {
-        auto it = m_tableCache.find(std::string(tableName));
-        if (it != m_tableCache.end())
-        {
-            return it->second;
-        }
+    std::optional<storage::Table> openTable(std::string_view tableName);
 
-        auto ret = openTableWithoutException(tableName);
-        if (std::get<0>(ret))
-        {
-            BOOST_THROW_EXCEPTION(*(std::get<0>(ret)));
-        }
-        auto table = std::get<1>(ret);
-        if (table)
-        {
-            m_tableCache.insert(std::make_pair(std::string(tableName), std::get<1>(ret)));
-        }
-        return table;
-    }
-
-    std::pair<size_t, Error::Ptr> count(const std::string_view& _table)
-    {
-        return m_storage->count(_table);
-    }
+    std::pair<size_t, Error::Ptr> count(const std::string_view& _table);
 
     std::tuple<Error::UniquePtr, std::optional<storage::Table>> openTableWithoutException(
-        std::string_view tableName)
-    {
-        std::promise<OpenTableResponse> openPromise;
-        m_storage->asyncOpenTable(tableName, [&](auto&& error, auto&& table) mutable {
-            openPromise.set_value({std::move(error), std::move(table)});
-        });
-        auto value = openPromise.get_future().get();
-        return value;
-    }
+        std::string_view tableName);
 
-    void setRecoder(storage::Recoder::Ptr recoder) { m_storage->setRecoder(std::move(recoder)); }
+    void setRecoder(storage::Recoder::Ptr recoder);
 
-    void setCodeCache(EntryCachePtr cache) { m_codeCache = cache; }
-    void setCodeHashCache(EntryCachePtr cache) { m_codeHashCache = cache; }
+    void setCodeCache(EntryCachePtr cache);
+    void setCodeHashCache(EntryCachePtr cache);
 
-    auto getRawStorage() { return m_storage; }
+    storage::StateStorageInterface::Ptr getRawStorage();
 
 private:
     storage::StateStorageInterface::Ptr m_storage;


### PR DESCRIPTION
Refactor the storage header implementation by moving function definitions to the corresponding cpp files, improving code organization and readability. This change enhances maintainability without altering existing functionality.