### PR TITLE
Move executor header implementation to source files

### DIFF
--- a/bcos-executor/src/executive/BillingTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/BillingTransactionExecutive.cpp
@@ -5,6 +5,12 @@ using namespace bcos::executor;
 using namespace bcos::codec;
 using namespace bcos::precompiled;
 
+BillingTransactionExecutive::BillingTransactionExecutive(const BlockContext& blockContext,
+        std::string contractAddress, int64_t contextID, int64_t seq,
+        const wasm::GasInjector& gasInjector)
+    : TransactionExecutive(blockContext, std::move(contractAddress), contextID, seq, gasInjector)
+{}
+
 CallParameters::UniquePtr BillingTransactionExecutive::start(CallParameters::UniquePtr input)
 {
     int64_t originGas = input->gas;

--- a/bcos-executor/src/executive/BillingTransactionExecutive.h
+++ b/bcos-executor/src/executive/BillingTransactionExecutive.h
@@ -11,9 +11,7 @@ class BillingTransactionExecutive : public TransactionExecutive
 {
 public:
     BillingTransactionExecutive(const BlockContext& blockContext, std::string contractAddress,
-        int64_t contextID, int64_t seq, const wasm::GasInjector& gasInjector)
-    : TransactionExecutive(blockContext, contractAddress, contextID, seq, gasInjector)
-    {}
+        int64_t contextID, int64_t seq, const wasm::GasInjector& gasInjector);
 
     CallParameters::UniquePtr start(CallParameters::UniquePtr input) override;
 };

--- a/bcos-executor/src/executive/BlockContext.cpp
+++ b/bcos-executor/src/executive/BlockContext.cpp
@@ -140,6 +140,48 @@ void BlockContext::setVMSchedule()
     }
 }
 
+void BlockContext::stop()
+{
+    std::vector<ExecutiveFlowInterface::Ptr> executiveFlow2Stop;
+    {
+        bcos::ReadGuard l(x_executiveFlows);
+        for (auto it : m_executiveFlows)
+        {
+            EXECUTOR_LOG(INFO) << "Try to stop flow: " << it.first;
+            executiveFlow2Stop.push_back(it.second);
+        }
+    }
+
+    if (executiveFlow2Stop.empty())
+    {
+        return;
+    }
+
+    for (auto& executiveFlow : executiveFlow2Stop)
+    {
+        executiveFlow->stop();
+    }
+}
+
+void BlockContext::clear()
+{
+    bcos::WriteGuard l(x_executiveFlows);
+    m_executiveFlows.clear();
+}
+
+void BlockContext::registerNeedSwitchEvent(std::function<void()> event)
+{
+    f_onNeedSwitchEvent = std::move(event);
+}
+
+void BlockContext::triggerSwitch()
+{
+    if (f_onNeedSwitchEvent)
+    {
+        f_onNeedSwitchEvent();
+    }
+}
+
 void BlockContext::suicide(std::string_view contract2Suicide)
 {
     {

--- a/bcos-executor/src/executive/BlockContext.h
+++ b/bcos-executor/src/executive/BlockContext.h
@@ -97,43 +97,12 @@ public:
     void setVMSchedule();
     void setVMFactory(std::shared_ptr<VMFactory> factory) { m_vmFactory = factory; }
 
-    void stop()
-    {
-        std::vector<ExecutiveFlowInterface::Ptr> executiveFlow2Stop;
-        {
-            bcos::ReadGuard l(x_executiveFlows);
-            for (auto it : m_executiveFlows)
-            {
-                EXECUTOR_LOG(INFO) << "Try to stop flow: " << it.first;
-                executiveFlow2Stop.push_back(it.second);
-            }
-        }
+    void stop();
+    void clear();
 
-        if (executiveFlow2Stop.empty())
-        {
-            return;
-        }
+    void registerNeedSwitchEvent(std::function<void()> event);
 
-        for (auto executiveFlow : executiveFlow2Stop)
-        {
-            executiveFlow->stop();
-        }
-    }
-    void clear()
-    {
-        bcos::WriteGuard l(x_executiveFlows);
-        m_executiveFlows.clear();
-    }
-
-    void registerNeedSwitchEvent(std::function<void()> event) { f_onNeedSwitchEvent = event; }
-
-    void triggerSwitch()
-    {
-        if (f_onNeedSwitchEvent)
-        {
-            f_onNeedSwitchEvent();
-        }
-    }
+    void triggerSwitch();
 
     auto keyPageIgnoreTables() const { return m_keyPageIgnoreTables; }
 

--- a/bcos-executor/src/executive/CoroutineTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/CoroutineTransactionExecutive.cpp
@@ -2,6 +2,82 @@
 #include "bcos-framework/executor/ExecuteError.h"
 
 using namespace bcos::executor;
+
+CoroutineTransactionExecutive::ResumeHandler::ResumeHandler(
+    CoroutineTransactionExecutive& executive)
+  : m_executive(executive)
+{}
+
+void CoroutineTransactionExecutive::ResumeHandler::operator()()
+{
+    COROUTINE_TRACE_LOG(TRACE, m_executive.contextID(), m_executive.seq())
+        << "Context switch to executive coroutine, from ResumeHandler";
+    (*m_executive.m_pullMessage)();
+}
+
+CoroutineTransactionExecutive::CoroutineTransactionExecutive(const BlockContext& blockContext,
+    std::string contractAddress, int64_t contextID, int64_t seq,
+    const wasm::GasInjector& gasInjector)
+  : TransactionExecutive(
+        std::move(blockContext), std::move(contractAddress), contextID, seq, gasInjector),
+    m_syncStorageWrapper(std::make_shared<SyncStorageWrapper>(m_blockContext.storage(),
+        [this](auto&& PH1) { externalAcquireKeyLocks(std::forward<decltype(PH1)>(PH1)); },
+        m_recoder))
+{
+    m_storageWrapper = m_syncStorageWrapper.get();
+}
+
+void CoroutineTransactionExecutive::setExchangeMessage(CallParameters::UniquePtr callParameters)
+{
+    getExchangeMessageRef() = std::move(callParameters);
+}
+
+std::string CoroutineTransactionExecutive::getExchangeMessageStr()
+{
+    if (getExchangeMessageRef())
+    {
+        return getExchangeMessageRef()->toString();
+    }
+
+    return "[empty exchange message]";
+}
+
+void CoroutineTransactionExecutive::appendResumeKeyLocks(std::vector<std::string> keyLocks)
+{
+    std::copy(
+        keyLocks.begin(), keyLocks.end(), std::back_inserter(getExchangeMessageRef()->keyLocks));
+}
+
+CallParameters::UniquePtr CoroutineTransactionExecutive::resume()
+{
+    EXECUTOR_LOG(TRACE) << "Context switch to executive coroutine, from resume";
+    (*m_pullMessage)();
+
+    return dispatcher();
+}
+
+std::optional<CoroutineTransactionExecutive::Coroutine::pull_type>&
+CoroutineTransactionExecutive::getPullMessage()
+{
+    return m_pullMessage;
+}
+
+std::optional<CoroutineTransactionExecutive::Coroutine::push_type>&
+CoroutineTransactionExecutive::getPushMessage()
+{
+    return m_pushMessage;
+}
+
+CallParameters::UniquePtr& CoroutineTransactionExecutive::getExchangeMessageRef()
+{
+    return m_exchangeMessage;
+}
+
+std::shared_ptr<SyncStorageWrapper> CoroutineTransactionExecutive::getSyncStorageWrapper()
+{
+    return m_syncStorageWrapper;
+}
+
 CallParameters::UniquePtr CoroutineTransactionExecutive::start(CallParameters::UniquePtr input)
 {
     m_pullMessage.emplace([this, inputPtr = input.release()](Coroutine::push_type& push) {

--- a/bcos-executor/src/executive/CoroutineTransactionExecutive.h
+++ b/bcos-executor/src/executive/CoroutineTransactionExecutive.h
@@ -42,14 +42,9 @@ public:
     class ResumeHandler
     {
     public:
-        ResumeHandler(CoroutineTransactionExecutive& executive) : m_executive(executive) {}
+        ResumeHandler(CoroutineTransactionExecutive& executive);
 
-        void operator()()
-        {
-            COROUTINE_TRACE_LOG(TRACE, m_executive.contextID(), m_executive.seq())
-                << "Context switch to executive coroutine, from ResumeHandler";
-            (*m_executive.m_pullMessage)();
-        }
+        void operator()();
 
     private:
         CoroutineTransactionExecutive& m_executive;
@@ -57,16 +52,7 @@ public:
 
 
     CoroutineTransactionExecutive(const BlockContext& blockContext, std::string contractAddress,
-        int64_t contextID, int64_t seq, const wasm::GasInjector& gasInjector)
-      : TransactionExecutive(
-            std::move(blockContext), std::move(contractAddress), contextID, seq, gasInjector),
-        m_syncStorageWrapper(std::make_shared<SyncStorageWrapper>(
-            m_blockContext.storage(),
-            [this](auto&& PH1) { externalAcquireKeyLocks(std::forward<decltype(PH1)>(PH1)); },
-            m_recoder))
-    {
-        m_storageWrapper = m_syncStorageWrapper.get();
-    }
+        int64_t contextID, int64_t seq, const wasm::GasInjector& gasInjector);
 
     CallParameters::UniquePtr start(CallParameters::UniquePtr input) override;  // start a new
     // coroutine to
@@ -82,43 +68,20 @@ public:
     // External request key locks, throw exception if dead lock detected
     void externalAcquireKeyLocks(std::string acquireKeyLock);
 
-    virtual void setExchangeMessage(CallParameters::UniquePtr callParameters)
-    {
-        getExchangeMessageRef() = std::move(callParameters);
-    }
+    virtual void setExchangeMessage(CallParameters::UniquePtr callParameters);
 
-    std::string getExchangeMessageStr()
-    {
-        if (getExchangeMessageRef())
-        {
-            return getExchangeMessageRef()->toString();
-        }
-        else
-        {
-            return "[empty exchange message]";
-        }
-    }
+    std::string getExchangeMessageStr();
 
 
-    virtual void appendResumeKeyLocks(std::vector<std::string> keyLocks)
-    {
-        std::copy(keyLocks.begin(), keyLocks.end(),
-            std::back_inserter(getExchangeMessageRef()->keyLocks));
-    }
+    virtual void appendResumeKeyLocks(std::vector<std::string> keyLocks);
 
-    virtual CallParameters::UniquePtr resume()
-    {
-        EXECUTOR_LOG(TRACE) << "Context switch to executive coroutine, from resume";
-        (*m_pullMessage)();
+    virtual CallParameters::UniquePtr resume();
 
-        return dispatcher();
-    }
+    virtual std::optional<Coroutine::pull_type>& getPullMessage();
+    virtual std::optional<Coroutine::push_type>& getPushMessage();
+    virtual CallParameters::UniquePtr& getExchangeMessageRef();
 
-    virtual std::optional<Coroutine::pull_type>& getPullMessage() { return m_pullMessage; }
-    virtual std::optional<Coroutine::push_type>& getPushMessage() { return m_pushMessage; }
-    virtual CallParameters::UniquePtr& getExchangeMessageRef() { return m_exchangeMessage; }
-
-    std::shared_ptr<SyncStorageWrapper> getSyncStorageWrapper() { return m_syncStorageWrapper; }
+    std::shared_ptr<SyncStorageWrapper> getSyncStorageWrapper();
 
 protected:
     CallParameters::UniquePtr m_exchangeMessage = nullptr;

--- a/bcos-executor/src/executive/ExecutiveDagFlow.cpp
+++ b/bcos-executor/src/executive/ExecutiveDagFlow.cpp
@@ -16,6 +16,42 @@ using namespace bcos::executor;
 using namespace bcos::executor::critical;
 using namespace std;
 
+ExecutiveDagFlow::ExecutiveDagFlow(ExecutiveFactory::Ptr executiveFactory,
+    std::shared_ptr<ClockCache<bcos::bytes, FunctionAbi>> abiCache)
+  : ExecutiveStackFlow(std::move(executiveFactory)), m_abiCache(std::move(abiCache))
+{}
+
+void ExecutiveDagFlow::stop()
+{
+    EXECUTOR_LOG(DEBUG) << "Try to stop ExecutiveDagFlow";
+    if (!m_isRunning)
+    {
+        EXECUTOR_LOG(DEBUG) << "Executor has tried to stop";
+        return;
+    }
+
+    m_isRunning = false;
+    ExecutiveStackFlow::stop();
+}
+
+void ExecutiveDagFlow::setDagFlowIfNotExists(TxDAGFlow::Ptr dagFlow)
+{
+    bcos::RecursiveGuard lock(x_lock);
+    if (!m_dagFlow)
+    {
+        m_dagFlow = std::move(dagFlow);
+    }
+}
+
+TxDAGFlow::Ptr ExecutiveDagFlow::prepareDagFlow(const BlockContext& blockContext,
+    ExecutiveFactory::Ptr executiveFactory, std::vector<std::unique_ptr<CallParameters>>& inputs,
+    std::shared_ptr<ClockCache<bcos::bytes, FunctionAbi>> abiCache)
+{
+    critical::CriticalFieldsInterface::Ptr criticals =
+        generateDagCriticals(blockContext, std::move(executiveFactory), inputs, std::move(abiCache));
+    return generateDagFlow(blockContext, std::move(criticals));
+}
+
 
 void ExecutiveDagFlow::submit(CallParameters::UniquePtr txInput)
 {

--- a/bcos-executor/src/executive/ExecutiveDagFlow.h
+++ b/bcos-executor/src/executive/ExecutiveDagFlow.h
@@ -42,46 +42,21 @@ public:
     using Ptr = std::shared_ptr<ExecutiveDagFlow>;
 
     ExecutiveDagFlow(ExecutiveFactory::Ptr executiveFactory,
-        std::shared_ptr<ClockCache<bcos::bytes, FunctionAbi>> abiCache)
-      : ExecutiveStackFlow(executiveFactory), m_abiCache(abiCache)
-    {}
+                std::shared_ptr<ClockCache<bcos::bytes, FunctionAbi>> abiCache);
     virtual ~ExecutiveDagFlow() = default;
 
     void submit(CallParameters::UniquePtr txInput) override;
     void submit(std::shared_ptr<std::vector<CallParameters::UniquePtr>> txInputs) override;
 
 
-    void stop() override
-    {
-        EXECUTOR_LOG(DEBUG) << "Try to stop ExecutiveDagFlow";
-        if (!m_isRunning)
-        {
-            EXECUTOR_LOG(DEBUG) << "Executor has tried to stop";
-            return;
-        }
+    void stop() override;
 
-        m_isRunning = false;
-        ExecutiveStackFlow::stop();
-    };
-
-    void setDagFlowIfNotExists(TxDAGFlow::Ptr dagFlow)
-    {
-        bcos::RecursiveGuard lock(x_lock);
-        if (!m_dagFlow)
-        {
-            m_dagFlow = dagFlow;
-        }
-    }
+    void setDagFlowIfNotExists(TxDAGFlow::Ptr dagFlow);
 
     static TxDAGFlow::Ptr prepareDagFlow(const BlockContext& blockContext,
         ExecutiveFactory::Ptr executiveFactory,
         std::vector<std::unique_ptr<CallParameters>>& inputs,
-        std::shared_ptr<ClockCache<bcos::bytes, FunctionAbi>> abiCache)
-    {
-        critical::CriticalFieldsInterface::Ptr criticals =
-            generateDagCriticals(blockContext, executiveFactory, inputs, abiCache);
-        return generateDagFlow(blockContext, criticals);
-    }
+        std::shared_ptr<ClockCache<bcos::bytes, FunctionAbi>> abiCache);
 
 protected:
     void runOriginFlow(std::function<void(CallParameters::UniquePtr)> onTxReturn) override;

--- a/bcos-executor/src/executive/ExecutiveFactory.cpp
+++ b/bcos-executor/src/executive/ExecutiveFactory.cpp
@@ -35,6 +35,39 @@
 using namespace bcos::executor;
 using namespace bcos::precompiled;
 
+ExecutiveFactory::ExecutiveFactory(const BlockContext& blockContext,
+    std::shared_ptr<std::map<std::string, std::shared_ptr<PrecompiledContract>>> evmPrecompiled,
+    std::shared_ptr<PrecompiledMap> precompiled,
+    std::shared_ptr<const std::set<std::string>> staticPrecompiled,
+    const wasm::GasInjector& gasInjector)
+  : m_evmPrecompiled(std::move(evmPrecompiled)),
+    m_precompiled(std::move(precompiled)),
+    m_staticPrecompiled(std::move(staticPrecompiled)),
+    m_blockContext(blockContext),
+    m_gasInjector(gasInjector),
+    m_isTiKVStorage(boost::iequals("tikv", protocol::g_BCOSConfig.storageType()))
+{
+    if (m_isTiKVStorage)
+    {
+        m_poolForPromiseWait =
+            std::make_shared<bcos::ThreadPool>("promiseWait", 128);
+    }
+}
+
+const BlockContext& ExecutiveFactory::getBlockContext()
+{
+    return m_blockContext;
+}
+
+ShardingExecutiveFactory::ShardingExecutiveFactory(const BlockContext& blockContext,
+    std::shared_ptr<std::map<std::string, std::shared_ptr<PrecompiledContract>>> evmPrecompiled,
+    std::shared_ptr<PrecompiledMap> precompiled,
+    std::shared_ptr<const std::set<std::string>> staticPrecompiled,
+    const wasm::GasInjector& gasInjector)
+  : ExecutiveFactory(blockContext, std::move(evmPrecompiled), std::move(precompiled),
+        std::move(staticPrecompiled), gasInjector)
+{}
+
 
 std::shared_ptr<TransactionExecutive> ExecutiveFactory::build(
     const std::string& _contractAddress, int64_t contextID, int64_t seq, ExecutiveType execType)

--- a/bcos-executor/src/executive/ExecutiveFactory.h
+++ b/bcos-executor/src/executive/ExecutiveFactory.h
@@ -41,27 +41,14 @@ public:
         std::shared_ptr<std::map<std::string, std::shared_ptr<PrecompiledContract>>> evmPrecompiled,
         std::shared_ptr<PrecompiledMap> precompiled,
         std::shared_ptr<const std::set<std::string>> staticPrecompiled,
-        const wasm::GasInjector& gasInjector)
-      : m_evmPrecompiled(std::move(evmPrecompiled)),
-        m_precompiled(std::move(precompiled)),
-        m_staticPrecompiled(std::move(staticPrecompiled)),
-        m_blockContext(blockContext),
-        m_gasInjector(gasInjector),
-        m_isTiKVStorage(boost::iequals("tikv", protocol::g_BCOSConfig.storageType()))
-    {
-        if (m_isTiKVStorage)
-        {
-            m_poolForPromiseWait = std::make_shared<bcos::ThreadPool>(
-                "promiseWait", 128);  // should max enough for promise wait
-        }
-    }
+        const wasm::GasInjector& gasInjector);
 
     virtual ~ExecutiveFactory() = default;
     //    virtual std::shared_ptr<TransactionExecutive> build(const std::string& _contractAddress,
     //        int64_t contextID, int64_t seq, bool useCoroutine = true);
     virtual std::shared_ptr<TransactionExecutive> build(const std::string& _contractAddress,
         int64_t contextID, int64_t seq, ExecutiveType execType = ExecutiveType::coroutine);
-    const BlockContext& getBlockContext() { return m_blockContext; };
+    const BlockContext& getBlockContext();
 
     std::shared_ptr<precompiled::Precompiled> getPrecompiled(const std::string& address) const;
 
@@ -91,10 +78,7 @@ public:
         std::shared_ptr<std::map<std::string, std::shared_ptr<PrecompiledContract>>> evmPrecompiled,
         std::shared_ptr<PrecompiledMap> precompiled,
         std::shared_ptr<const std::set<std::string>> staticPrecompiled,
-        const wasm::GasInjector& gasInjector)
-      : ExecutiveFactory(blockContext, std::move(evmPrecompiled), std::move(precompiled),
-            std::move(staticPrecompiled), gasInjector)
-    {}
+                const wasm::GasInjector& gasInjector);
     ~ShardingExecutiveFactory() override = default;
 
     std::shared_ptr<TransactionExecutive> build(const std::string& _contractAddress,

--- a/bcos-executor/src/executive/ExecutiveSerialFlow.cpp
+++ b/bcos-executor/src/executive/ExecutiveSerialFlow.cpp
@@ -6,6 +6,25 @@
 using namespace bcos;
 using namespace bcos::executor;
 
+ExecutiveSerialFlow::ExecutiveSerialFlow(ExecutiveFactory::Ptr executiveFactory)
+    : m_executiveFactory(std::move(executiveFactory))
+{}
+
+ExecutiveSerialFlow::~ExecutiveSerialFlow() = default;
+
+void ExecutiveSerialFlow::stop()
+{
+        EXECUTOR_LOG(DEBUG) << "Try to stop ExecutiveSerialFlow";
+        if (!m_isRunning)
+        {
+                EXECUTOR_LOG(DEBUG) << "Executor has tried to stop";
+                return;
+        }
+
+        m_isRunning = false;
+        ExecutiveFlowInterface::stop();
+}
+
 void ExecutiveSerialFlow::submit(CallParameters::UniquePtr txInput)
 {
     WriteGuard lock(x_lock);

--- a/bcos-executor/src/executive/ExecutiveSerialFlow.h
+++ b/bcos-executor/src/executive/ExecutiveSerialFlow.h
@@ -36,11 +36,9 @@ class ExecutiveSerialFlow : public virtual ExecutiveFlowInterface,
                             public std::enable_shared_from_this<ExecutiveSerialFlow>
 {
 public:
-    ExecutiveSerialFlow(ExecutiveFactory::Ptr executiveFactory)
-      : m_executiveFactory(executiveFactory)
-    {}
+        ExecutiveSerialFlow(ExecutiveFactory::Ptr executiveFactory);
 
-    virtual ~ExecutiveSerialFlow() {}
+        virtual ~ExecutiveSerialFlow();
 
     void submit(CallParameters::UniquePtr txInput) override;
     void submit(std::shared_ptr<std::vector<CallParameters::UniquePtr>> txInputs) override;
@@ -52,18 +50,7 @@ public:
         // onFinished(success, errorMessage)
         std::function<void(bcos::Error::UniquePtr)> onFinished) override;
 
-    void stop() override
-    {
-        EXECUTOR_LOG(DEBUG) << "Try to stop ExecutiveSerialFlow";
-        if (!m_isRunning)
-        {
-            EXECUTOR_LOG(DEBUG) << "Executor has tried to stop";
-            return;
-        }
-
-        m_isRunning = false;
-        ExecutiveFlowInterface::stop();
-    };
+    void stop() override;
 
 protected:
     virtual std::shared_ptr<TransactionExecutive> buildExecutive(CallParameters::UniquePtr& input);

--- a/bcos-executor/src/executive/ExecutiveStackFlow.cpp
+++ b/bcos-executor/src/executive/ExecutiveStackFlow.cpp
@@ -26,6 +26,25 @@
 using namespace bcos;
 using namespace bcos::executor;
 
+ExecutiveStackFlow::ExecutiveStackFlow(ExecutiveFactory::Ptr executiveFactory)
+    : m_executiveFactory(std::move(executiveFactory))
+{}
+
+ExecutiveStackFlow::~ExecutiveStackFlow() = default;
+
+void ExecutiveStackFlow::stop()
+{
+        EXECUTOR_LOG(DEBUG) << "Try to stop ExecutiveStackFlow";
+        if (!m_isRunning)
+        {
+                EXECUTOR_LOG(DEBUG) << "Executor has tried to stop";
+                return;
+        }
+
+        m_isRunning = false;
+        ExecutiveFlowInterface::stop();
+}
+
 void ExecutiveStackFlow::submit(CallParameters::UniquePtr txInput)
 {
     auto contextID = txInput->contextID;

--- a/bcos-executor/src/executive/ExecutiveStackFlow.h
+++ b/bcos-executor/src/executive/ExecutiveStackFlow.h
@@ -37,11 +37,9 @@ class ExecutiveStackFlow : public virtual ExecutiveFlowInterface,
                            public std::enable_shared_from_this<ExecutiveStackFlow>
 {
 public:
-    ExecutiveStackFlow(ExecutiveFactory::Ptr executiveFactory)
-      : m_executiveFactory(executiveFactory)
-    {}
+        ExecutiveStackFlow(ExecutiveFactory::Ptr executiveFactory);
 
-    virtual ~ExecutiveStackFlow() {}
+        virtual ~ExecutiveStackFlow();
 
     void submit(CallParameters::UniquePtr txInput) override;
     void submit(std::shared_ptr<std::vector<CallParameters::UniquePtr>> txInputs) override;
@@ -64,18 +62,7 @@ public:
         }
     };
 
-    void stop() override
-    {
-        EXECUTOR_LOG(DEBUG) << "Try to stop ExecutiveStackFlow";
-        if (!m_isRunning)
-        {
-            EXECUTOR_LOG(DEBUG) << "Executor has tried to stop";
-            return;
-        }
-
-        m_isRunning = false;
-        ExecutiveFlowInterface::stop();
-    };
+    void stop() override;
 
 protected:
     void run(std::function<void(CallParameters::UniquePtr)> onTxReturn,

--- a/bcos-executor/src/executive/ExecutiveState.cpp
+++ b/bcos-executor/src/executive/ExecutiveState.cpp
@@ -24,6 +24,30 @@
 using namespace bcos;
 using namespace bcos::executor;
 
+ExecutiveState::ExecutiveState(
+    ExecutiveFactory::Ptr executiveFactory, CallParameters::UniquePtr input)
+  : m_isStaticCall(input->staticCall),
+    m_contextID(input->contextID),
+    m_seq(input->seq),
+    m_input(std::move(input)),
+    m_executiveFactory(std::move(executiveFactory))
+{}
+
+ExecutiveState::Status ExecutiveState::getStatus()
+{
+    return m_status;
+}
+
+int64_t ExecutiveState::getContextID() const
+{
+    return m_contextID;
+}
+
+int64_t ExecutiveState::getSeq() const
+{
+    return m_seq;
+}
+
 CallParameters::UniquePtr ExecutiveState::go()
 {
     // init

--- a/bcos-executor/src/executive/ExecutiveState.h
+++ b/bcos-executor/src/executive/ExecutiveState.h
@@ -34,12 +34,7 @@ class ExecutiveState
 public:
     using Ptr = std::shared_ptr<ExecutiveState>;
 
-    ExecutiveState(ExecutiveFactory::Ptr executiveFactory, CallParameters::UniquePtr input)
-      : m_isStaticCall(input->staticCall),
-        m_contextID(input->contextID),
-        m_seq(input->seq),
-        m_input(std::move(input)),
-        m_executiveFactory(executiveFactory){};
+        ExecutiveState(ExecutiveFactory::Ptr executiveFactory, CallParameters::UniquePtr input);
 
     enum Status
     {
@@ -49,11 +44,11 @@ public:
         FINISHED = 3,
     };
 
-    Status getStatus() { return m_status; }
+    Status getStatus();
     CallParameters::UniquePtr go();
     void setResumeParam(CallParameters::UniquePtr pullParam);
-    int64_t getContextID() const { return m_contextID; }
-    int64_t getSeq() const { return m_seq; }
+    int64_t getContextID() const;
+    int64_t getSeq() const;
 
     void appendKeyLocks(std::vector<std::string> keyLocks);
 

--- a/bcos-executor/src/executive/PromiseTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/PromiseTransactionExecutive.cpp
@@ -2,6 +2,58 @@
 #include "bcos-framework/executor/ExecuteError.h"
 
 using namespace bcos::executor;
+
+MessagePromiseSwapper::MessagePromiseSwapper(ThreadPool::Ptr pool) : m_pool(std::move(pool)) {}
+
+void MessagePromiseSwapper::spawnAndCall(
+    std::function<CallParameters::UniquePtr()> spawnCall,
+    std::function<void(CallParameters::UniquePtr)> waitAndDo)
+{
+    assert(m_pool);
+
+    auto lastPromise = m_currentPromise;
+
+    m_currentPromise = std::make_shared<std::promise<CallParameters::UniquePtr>>();
+    m_pool->enqueue([this, lastPromise, spawnCall = std::move(spawnCall)]() {
+        auto message = spawnCall();
+
+        auto promise = lastPromise ? lastPromise : m_currentPromise;
+        promise->set_value(std::move(message));
+    });
+
+    auto message = m_currentPromise->get_future().get();
+    waitAndDo(std::move(message));
+}
+
+PromiseTransactionExecutive::PromiseTransactionExecutive(ThreadPool::Ptr pool,
+    const BlockContext& blockContext, std::string contractAddress, int64_t contextID,
+    int64_t seq, const wasm::GasInjector& gasInjector)
+  : CoroutineTransactionExecutive(
+        blockContext, std::move(contractAddress), contextID, seq, gasInjector),
+    m_messageSwapper(std::make_shared<MessagePromiseSwapper>(std::move(pool)))
+{}
+
+CallParameters::UniquePtr PromiseTransactionExecutive::resume()
+{
+    CallParameters::UniquePtr exchangeMessage;
+    m_messageSwapper->spawnAndCall([this]() { return std::move(m_exchangeMessage); },
+        [&exchangeMessage](CallParameters::UniquePtr message) {
+            exchangeMessage = std::move(message);
+        });
+
+    return exchangeMessage;
+}
+
+MessagePromiseSwapper::Ptr PromiseTransactionExecutive::getPromiseMessageSwapper()
+{
+    return m_messageSwapper;
+}
+
+void PromiseTransactionExecutive::setPromiseMessageSwapper(MessagePromiseSwapper::Ptr swapper)
+{
+    m_messageSwapper = std::move(swapper);
+}
+
 CallParameters::UniquePtr PromiseTransactionExecutive::start(CallParameters::UniquePtr input)
 {
     auto spawnCall = [this, &input]() {

--- a/bcos-executor/src/executive/PromiseTransactionExecutive.h
+++ b/bcos-executor/src/executive/PromiseTransactionExecutive.h
@@ -34,28 +34,9 @@ class MessagePromiseSwapper
 {
 public:
     using Ptr = std::shared_ptr<MessagePromiseSwapper>;
-    MessagePromiseSwapper(ThreadPool::Ptr pool) : m_pool(pool) {}
+    MessagePromiseSwapper(ThreadPool::Ptr pool);
     void spawnAndCall(std::function<CallParameters::UniquePtr()> spawnCall,
-        std::function<void(CallParameters::UniquePtr)> waitAndDo)
-    {
-        assert(m_pool);
-
-        auto lastPromise = m_currentPromise;
-
-        m_currentPromise = std::make_shared<std::promise<CallParameters::UniquePtr>>();
-        m_pool->enqueue([this, lastPromise, spawnCall = std::move(spawnCall)]() {
-            auto message = spawnCall();
-
-            auto promise = lastPromise ? lastPromise : m_currentPromise;
-            // std::cout << "resume " << promise.get() << std::endl;
-            promise->set_value(std::move(message));
-        });
-
-        // std::cout << "await " << m_currentPromise.get() << std::endl;
-        auto message = m_currentPromise->get_future().get();
-
-        waitAndDo(std::move(message));
-    }
+        std::function<void(CallParameters::UniquePtr)> waitAndDo);
 
 private:
     std::shared_ptr<std::promise<CallParameters::UniquePtr>> m_lastPromise;
@@ -73,11 +54,7 @@ public:
 
     PromiseTransactionExecutive(ThreadPool::Ptr pool, const BlockContext& blockContext,
         std::string contractAddress, int64_t contextID, int64_t seq,
-        const wasm::GasInjector& gasInjector)
-      : CoroutineTransactionExecutive(
-            blockContext, std::move(contractAddress), contextID, seq, gasInjector),
-        m_messageSwapper(std::make_shared<MessagePromiseSwapper>(pool))
-    {}
+        const wasm::GasInjector& gasInjector);
 
     CallParameters::UniquePtr start(CallParameters::UniquePtr input) override;  // start a new
     // coroutine to
@@ -94,21 +71,10 @@ public:
     void externalAcquireKeyLocks(std::string acquireKeyLock);
 
 
-    virtual CallParameters::UniquePtr resume() override
-    {
-        CallParameters::UniquePtr exchangeMessage;
-        m_messageSwapper->spawnAndCall([this]() { return std::move(m_exchangeMessage); },
-            [&exchangeMessage](
-                CallParameters::UniquePtr message) { exchangeMessage = std::move(message); });
+    virtual CallParameters::UniquePtr resume() override;
 
-        return exchangeMessage;
-    }
-
-    MessagePromiseSwapper::Ptr getPromiseMessageSwapper() { return m_messageSwapper; }
-    void setPromiseMessageSwapper(MessagePromiseSwapper::Ptr swapper)
-    {
-        m_messageSwapper = swapper;
-    }
+    MessagePromiseSwapper::Ptr getPromiseMessageSwapper();
+    void setPromiseMessageSwapper(MessagePromiseSwapper::Ptr swapper);
 
 private:
     MessagePromiseSwapper::Ptr m_messageSwapper;

--- a/bcos-executor/src/executive/ShardingTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/ShardingTransactionExecutive.cpp
@@ -13,6 +13,26 @@
 using namespace bcos::executor;
 using namespace bcos::storage;
 
+TransactionExecutive::Ptr ShardingTransactionExecutive::buildChildExecutive(
+    const std::string& _contractAddress, int64_t contextID, int64_t seq)
+{
+    ShardingExecutiveFactory executiveFactory = ShardingExecutiveFactory(
+        m_blockContext, m_evmPrecompiled, m_precompiled, m_staticPrecompiled, m_gasInjector);
+
+    if (m_blockContext.features().get(
+            ledger::Features::Flag::bugfix_sharding_call_in_child_executive))
+    {
+        return executiveFactory.buildChild(this, _contractAddress, contextID, seq);
+    }
+
+    return executiveFactory.build(_contractAddress, contextID, seq, ExecutiveType::common);
+}
+
+bool ShardingTransactionExecutive::isUsePromise() const
+{
+    return m_usePromise;
+}
+
 ShardingTransactionExecutive::ShardingTransactionExecutive(const BlockContext& blockContext,
     std::string contractAddress, int64_t contextID, int64_t seq,
     const wasm::GasInjector& gasInjector, ThreadPool::Ptr pool, bool usePromise)
@@ -128,6 +148,48 @@ std::string ShardingTransactionExecutive::getContractShard(const std::string_vie
 {
     auto tableName = getContractTableName(contractAddress, m_blockContext.isWasm());
     return ContractShardUtils::getContractShard(storage(), tableName);
+}
+
+CallParameters::UniquePtr ShardingChildTransactionExecutive::start(CallParameters::UniquePtr input)
+{
+    if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
+    {
+        EXECUTIVE_LOG(TRACE) << LOG_BADGE("Sharding")
+                             << "ShardingChildTransactionExecutive start: "
+                             << input->toFullString();
+    }
+
+    return TransactionExecutive::start(std::move(input));
+}
+
+CallParameters::UniquePtr ShardingChildTransactionExecutive::externalCall(
+    CallParameters::UniquePtr input)
+{
+    if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
+    {
+        EXECUTIVE_LOG(TRACE) << LOG_BADGE("Sharding")
+                             << "ShardingChildTransactionExecutive externalCall: "
+                             << input->toFullString();
+    }
+
+    return ShardingTransactionExecutive::externalCall(std::move(input));
+}
+
+std::optional<CoroutineTransactionExecutive::Coroutine::pull_type>&
+ShardingChildTransactionExecutive::getPullMessage()
+{
+    return m_pullMessageRef;
+}
+
+std::optional<CoroutineTransactionExecutive::Coroutine::push_type>&
+ShardingChildTransactionExecutive::getPushMessage()
+{
+    return m_pushMessageRef;
+}
+
+CallParameters::UniquePtr& ShardingChildTransactionExecutive::getExchangeMessageRef()
+{
+    return m_exchangeMessageRef;
 }
 
 ShardingChildTransactionExecutive::ShardingChildTransactionExecutive(

--- a/bcos-executor/src/executive/ShardingTransactionExecutive.h
+++ b/bcos-executor/src/executive/ShardingTransactionExecutive.h
@@ -43,23 +43,11 @@ public:
     CallParameters::UniquePtr resume() override;
 
     TransactionExecutive::Ptr buildChildExecutive(
-        const std::string& _contractAddress, int64_t contextID, int64_t seq) override
-    {
-        ShardingExecutiveFactory executiveFactory = ShardingExecutiveFactory(
-            m_blockContext, m_evmPrecompiled, m_precompiled, m_staticPrecompiled, m_gasInjector);
-
-        if (m_blockContext.features().get(
-                ledger::Features::Flag::bugfix_sharding_call_in_child_executive))
-        {
-            return executiveFactory.buildChild(this, _contractAddress, contextID, seq);
-        }
-
-        return executiveFactory.build(_contractAddress, contextID, seq, ExecutiveType::common);
-    }
+        const std::string& _contractAddress, int64_t contextID, int64_t seq) override;
 
     std::string getContractShard(const std::string_view& contractAddress);
 
-    bool isUsePromise() const { return m_usePromise; }
+    bool isUsePromise() const;
 
 private:
     std::optional<std::string> m_shardName;
@@ -74,43 +62,14 @@ public:
         int64_t seq, const wasm::GasInjector& gasInjector, ThreadPool::Ptr pool = nullptr,
         bool usePromise = false);
 
-    CallParameters::UniquePtr start(CallParameters::UniquePtr input) override
-    {
-        if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
-        {
-            EXECUTIVE_LOG(TRACE) << LOG_BADGE("Sharding")
-                                 << "ShardingChildTransactionExecutive start: "
-                                 << input->toFullString();
-        }
+    CallParameters::UniquePtr start(CallParameters::UniquePtr input) override;
 
-        return TransactionExecutive::start(std::move(input));
-    }
+    CallParameters::UniquePtr externalCall(CallParameters::UniquePtr input) override;
 
-    CallParameters::UniquePtr externalCall(CallParameters::UniquePtr input) override
-    {
-        if (c_fileLogLevel == LogLevel::TRACE) [[unlikely]]
-        {
-            EXECUTIVE_LOG(TRACE) << LOG_BADGE("Sharding")
-                                 << "ShardingChildTransactionExecutive externalCall: "
-                                 << input->toFullString();
-        }
+    virtual std::optional<Coroutine::pull_type>& getPullMessage() override;
+    virtual std::optional<Coroutine::push_type>& getPushMessage() override;
 
-        return ShardingTransactionExecutive::externalCall(std::move(input));
-    }
-
-    virtual std::optional<Coroutine::pull_type>& getPullMessage() override
-    {
-        return m_pullMessageRef;
-    }
-    virtual std::optional<Coroutine::push_type>& getPushMessage() override
-    {
-        return m_pushMessageRef;
-    }
-
-    virtual CallParameters::UniquePtr& getExchangeMessageRef() override
-    {
-        return m_exchangeMessageRef;
-    }
+    virtual CallParameters::UniquePtr& getExchangeMessageRef() override;
 
 private:
     std::optional<Coroutine::pull_type>& m_pullMessageRef;

--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -74,6 +74,46 @@ using namespace bcos::precompiled;
 /// Error info for VMInstance status code.
 using errinfo_evmcStatusCode = boost::error_info<struct tag_evmcStatusCode, evmc_status_code>;
 
+storage::StorageWrapper& TransactionExecutive::storage()
+{
+    assert(m_storageWrapper);
+    return *m_storageWrapper;
+}
+
+void TransactionExecutive::setStaticPrecompiled(
+    std::shared_ptr<const std::set<std::string>> _staticPrecompiled)
+{
+    m_staticPrecompiled = std::move(_staticPrecompiled);
+}
+
+bool TransactionExecutive::isStaticPrecompiled(const std::string& _a) const
+{
+    return _a.starts_with(precompiled::SYS_ADDRESS_PREFIX) && m_staticPrecompiled->contains(_a);
+}
+
+bool TransactionExecutive::isEthereumPrecompiled(const std::string& _a) const
+{
+    return m_evmPrecompiled != nullptr && _a.starts_with(precompiled::EVM_PRECOMPILED_PREFIX) &&
+           m_evmPrecompiled->contains(_a);
+}
+
+TransactionExecutive::Ptr TransactionExecutive::buildChildExecutive(
+    const std::string& _contractAddress, int64_t contextID, int64_t seq)
+{
+    auto executiveFactory = std::make_shared<ExecutiveFactory>(
+        m_blockContext, m_evmPrecompiled, m_precompiled, m_staticPrecompiled, m_gasInjector);
+
+    return executiveFactory->build(_contractAddress, contextID, seq, ExecutiveType::common);
+}
+
+void TransactionExecutive::writeErrInfoToOutput(
+    std::string const& errInfo, CallParameters& _callParameters)
+{
+    bcos::codec::abi::ContractABICodec abi(*m_hashImpl);
+    auto codecOutput = abi.abiIn("Error(string)", errInfo);
+    _callParameters.data = std::move(codecOutput);
+}
+
 CallParameters::UniquePtr TransactionExecutive::start(CallParameters::UniquePtr input)
 {
     EXECUTIVE_LOG(TRACE) << "Execute start\t" << input->toFullString();

--- a/bcos-executor/src/executive/TransactionExecutive.h
+++ b/bcos-executor/src/executive/TransactionExecutive.h
@@ -24,7 +24,6 @@
 #include "../Common.h"
 #include "../executor/TransactionExecutor.h"
 #include "BlockContext.h"
-#include "bcos-codec/abi/ContractABICodec.h"
 #include "bcos-executor/src/precompiled/common/PrecompiledResult.h"
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
 #include "bcos-table/src/StorageWrapper.h"
@@ -81,11 +80,7 @@ public:
     // External call request
     virtual CallParameters::UniquePtr externalCall(CallParameters::UniquePtr input);
 
-    auto& storage()
-    {
-        assert(m_storageWrapper);
-        return *m_storageWrapper;
-    }
+    storage::StorageWrapper& storage();
 
 
     const BlockContext& blockContext() { return m_blockContext; }
@@ -106,21 +101,11 @@ public:
     virtual std::shared_ptr<precompiled::Precompiled> getPrecompiled(std::string_view _address,
         uint32_t version, bool isAuth, const ledger::Features& features) const;
 
-    void setStaticPrecompiled(std::shared_ptr<const std::set<std::string>> _staticPrecompiled)
-    {
-        m_staticPrecompiled = std::move(_staticPrecompiled);
-    }
+    void setStaticPrecompiled(std::shared_ptr<const std::set<std::string>> _staticPrecompiled);
 
-    inline bool isStaticPrecompiled(const std::string& _a) const
-    {
-        return _a.starts_with(precompiled::SYS_ADDRESS_PREFIX) && m_staticPrecompiled->contains(_a);
-    }
+    bool isStaticPrecompiled(const std::string& _a) const;
 
-    inline bool isEthereumPrecompiled(const std::string& _a) const
-    {
-        return m_evmPrecompiled != nullptr && _a.starts_with(precompiled::EVM_PRECOMPILED_PREFIX) &&
-               m_evmPrecompiled->contains(_a);
-    }
+    bool isEthereumPrecompiled(const std::string& _a) const;
 
     std::pair<bool, bytes> executeOriginPrecompiled(const std::string& _a, bytesConstRef _in) const;
 
@@ -182,14 +167,7 @@ protected:
     //    virtual TransactionExecutive::Ptr buildChildExecutive(const std::string& _contractAddress,
     //        int64_t contextID, int64_t seq, bool useCoroutine = true)
     virtual TransactionExecutive::Ptr buildChildExecutive(
-        const std::string& _contractAddress, int64_t contextID, int64_t seq)
-    {
-        auto executiveFactory = std::make_shared<ExecutiveFactory>(
-            m_blockContext, m_evmPrecompiled, m_precompiled, m_staticPrecompiled, m_gasInjector);
-
-
-        return executiveFactory->build(_contractAddress, contextID, seq, ExecutiveType::common);
-    }
+        const std::string& _contractAddress, int64_t contextID, int64_t seq);
 
     void revert();
 
@@ -197,12 +175,7 @@ protected:
     CallParameters::UniquePtr parseEVMCResult(
         CallParameters::UniquePtr callResults, const Result& _result);
 
-    void writeErrInfoToOutput(std::string const& errInfo, CallParameters& _callParameters)
-    {
-        bcos::codec::abi::ContractABICodec abi(*m_hashImpl);
-        auto codecOutput = abi.abiIn("Error(string)", errInfo);
-        _callParameters.data = std::move(codecOutput);
-    }
+    void writeErrInfoToOutput(std::string const& errInfo, CallParameters& _callParameters);
 
     bool checkExecAuth(const CallParameters::UniquePtr& callParameters);
     int32_t checkContractAvailable(const CallParameters::UniquePtr& callParameters);

--- a/bcos-executor/src/executor/ShardingTransactionExecutor.cpp
+++ b/bcos-executor/src/executor/ShardingTransactionExecutor.cpp
@@ -31,6 +31,19 @@ using namespace std;
 using namespace bcos::executor;
 using namespace bcos::protocol;
 
+ShardingTransactionExecutor::ShardingTransactionExecutor(bcos::ledger::LedgerInterface::Ptr ledger,
+        txpool::TxPoolInterface::Ptr txpool, storage::MergeableStorageInterface::Ptr cachedStorage,
+        storage::TransactionalStorageInterface::Ptr backendStorage,
+        protocol::ExecutionMessageFactory::Ptr executionMessageFactory,
+        storage::StateStorageFactory::Ptr stateStorageFactory, bcos::crypto::Hash::Ptr hashImpl,
+        bool isWasm, bool isAuthCheck, std::shared_ptr<VMFactory> vmFactory,
+        std::shared_ptr<std::set<std::string, std::less<>>> keyPageIgnoreTables, std::string name)
+    : TransactionExecutor(std::move(ledger), std::move(txpool), std::move(cachedStorage),
+                std::move(backendStorage), std::move(executionMessageFactory),
+                std::move(stateStorageFactory), std::move(hashImpl), isWasm, isAuthCheck,
+                std::move(vmFactory), std::move(keyPageIgnoreTables), std::move(name))
+{}
+
 void ShardingTransactionExecutor::executeTransactions(std::string contractAddress,
     gsl::span<bcos::protocol::ExecutionMessage::UniquePtr> inputs,
     std::function<void(

--- a/bcos-executor/src/executor/ShardingTransactionExecutor.h
+++ b/bcos-executor/src/executor/ShardingTransactionExecutor.h
@@ -34,10 +34,8 @@ public:
         protocol::ExecutionMessageFactory::Ptr executionMessageFactory,
         storage::StateStorageFactory::Ptr stateStorageFactory, bcos::crypto::Hash::Ptr hashImpl,
         bool isWasm, bool isAuthCheck, std::shared_ptr<VMFactory> vmFactory,
-        std::shared_ptr<std::set<std::string, std::less<>>> keyPageIgnoreTables, std::string name)
-      : TransactionExecutor(ledger, txpool, cachedStorage, backendStorage, executionMessageFactory,
-            stateStorageFactory, hashImpl, isWasm, isAuthCheck, vmFactory, keyPageIgnoreTables,
-            name){};
+                std::shared_ptr<std::set<std::string, std::less<>>> keyPageIgnoreTables,
+                std::string name);
 
     ~ShardingTransactionExecutor() override = default;
 

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -183,6 +183,16 @@ TransactionExecutor::TransactionExecutor(bcos::ledger::LedgerInterface::Ptr ledg
     start();
 }
 
+void TransactionExecutor::start()
+{
+    m_isRunning = true;
+}
+
+void TransactionExecutor::registerNeedSwitchEvent(std::function<void()> event)
+{
+    f_onNeedSwitchEvent = std::move(event);
+}
+
 void TransactionExecutor::setBlockVersion(uint32_t blockVersion)
 {
     if (m_blockVersion == blockVersion)

--- a/bcos-executor/src/executor/TransactionExecutor.h
+++ b/bcos-executor/src/executor/TransactionExecutor.h
@@ -169,12 +169,12 @@ public:
 
     void updateEoaNonce(std::unordered_map<std::string, u256> const& nonceMap) override;
 
-    void start() override { m_isRunning = true; }
+    void start() override;
     void stop() override;
     task::Task<std::optional<bcos::storage::Entry>> getPendingStorageAt(std::string_view address,
         std::string_view key, bcos::protocol::BlockNumber number) override;
 
-    void registerNeedSwitchEvent(std::function<void()> event) { f_onNeedSwitchEvent = event; }
+    void registerNeedSwitchEvent(std::function<void()> event);
 
     // only for test, do not use in formal environment
     void setKeyPageIgnoreTable(auto ignoreTable) { m_keyPageIgnoreTables = std::move(ignoreTable); }

--- a/bcos-executor/src/precompiled/BFSPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/BFSPrecompiled.cpp
@@ -116,6 +116,16 @@ BFSPrecompiled::BFSPrecompiled(crypto::Hash::Ptr _hashImpl) : Precompiled(_hashI
         std::string(FS_TYPE_DIR), std::string(FS_TYPE_CONTRACT), std::string(FS_TYPE_LINK)};
 }
 
+std::string BFSPrecompiled::getThisAddress(bool _isWasm)
+{
+    return std::string(_isWasm ? BFS_NAME : BFS_ADDRESS);
+}
+
+std::string_view BFSPrecompiled::getLinkRootDir()
+{
+    return executor::USER_APPS_PREFIX;
+}
+
 std::shared_ptr<PrecompiledExecResult> BFSPrecompiled::call(
     std::shared_ptr<executor::TransactionExecutive> _executive,
     PrecompiledExecResult::Ptr _callParameters)

--- a/bcos-executor/src/precompiled/BFSPrecompiled.h
+++ b/bcos-executor/src/precompiled/BFSPrecompiled.h
@@ -73,11 +73,8 @@ protected:
         const std::shared_ptr<executor::TransactionExecutive>& _executive,
         PrecompiledExecResult::Ptr const& _callParameters);
 
-    virtual std::string getThisAddress(bool _isWasm)
-    {
-        return std::string(_isWasm ? BFS_NAME : BFS_ADDRESS);
-    }
-    virtual std::string_view getLinkRootDir() { return executor::USER_APPS_PREFIX; }
+    virtual std::string getThisAddress(bool _isWasm);
+    virtual std::string_view getLinkRootDir();
     virtual bool checkPathPrefixValid(
         const std::string_view& path, uint32_t blockVersion, const std::string_view& type);
 

--- a/bcos-executor/src/precompiled/ShardingPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/ShardingPrecompiled.cpp
@@ -57,6 +57,16 @@ ShardingPrecompiled::ShardingPrecompiled(crypto::Hash::Ptr _hashImpl) : BFSPreco
         getFuncSelector(FILE_SYSTEM_GET_CONTRACT_SHARD_INTERNAL, _hashImpl);
 }
 
+std::string ShardingPrecompiled::getThisAddress(bool _isWasm)
+{
+    return std::string(_isWasm ? SHARDING_PRECOMPILED_NAME : SHARDING_PRECOMPILED_ADDRESS);
+}
+
+std::string_view ShardingPrecompiled::getLinkRootDir()
+{
+    return executor::USER_SHARD_PREFIX;
+}
+
 inline bool isFromThisOrSDK(
     PrecompiledExecResult::Ptr _callParameters, const std::string& thisAddress)
 {

--- a/bcos-executor/src/precompiled/ShardingPrecompiled.h
+++ b/bcos-executor/src/precompiled/ShardingPrecompiled.h
@@ -53,12 +53,9 @@ private:
 
 
 private:
-    std::string getThisAddress(bool _isWasm) override
-    {
-        return std::string(_isWasm ? SHARDING_PRECOMPILED_NAME : SHARDING_PRECOMPILED_ADDRESS);
-    }
+    std::string getThisAddress(bool _isWasm) override;
 
-    std::string_view getLinkRootDir() override { return executor::USER_SHARD_PREFIX; }
+    std::string_view getLinkRootDir() override;
 
     bool checkPathPrefixValid(
         const std::string_view& path, uint32_t blockVersion, const std::string_view& type) override;

--- a/bcos-executor/src/precompiled/common/VRFInfo.cpp
+++ b/bcos-executor/src/precompiled/common/VRFInfo.cpp
@@ -27,6 +27,34 @@ using namespace bcos;
 using namespace bcos::crypto;
 using namespace bcos::precompiled;
 
+VRFInfo::VRFInfo(bcos::bytes _vrfProof, bcos::bytes _vrfPk, bcos::bytes _vrfInput,
+    bcos::sealer::VrfCurveType vrfCurveType)
+  : m_vrfProof(std::move(_vrfProof)),
+    m_vrfPublicKey(std::move(_vrfPk)),
+    m_vrfInput(std::move(_vrfInput)),
+    m_vrfCurveType(vrfCurveType)
+{}
+
+bcos::bytes const& VRFInfo::vrfProof() const
+{
+    return m_vrfProof;
+}
+
+bcos::bytes const& VRFInfo::vrfPublicKey() const
+{
+    return m_vrfPublicKey;
+}
+
+bcos::bytes const& VRFInfo::vrfInput() const
+{
+    return m_vrfInput;
+}
+
+bcos::sealer::VrfCurveType VRFInfo::vrfCurveType() const
+{
+    return m_vrfCurveType;
+}
+
 bool VRFInfo::isValidVRFPublicKey()
 {
     CInputBuffer rawPk{(const char*)m_vrfPublicKey.data(), m_vrfPublicKey.size()};

--- a/bcos-executor/src/precompiled/common/VRFInfo.h
+++ b/bcos-executor/src/precompiled/common/VRFInfo.h
@@ -33,22 +33,18 @@ public:
     VRFInfo(VRFInfo&&) = default;
     VRFInfo& operator=(const VRFInfo&) = default;
     VRFInfo& operator=(VRFInfo&&) = default;
-    VRFInfo(bcos::bytes _vrfProof, bcos::bytes _vrfPk, bcos::bytes _vrfInput, bcos::sealer::VrfCurveType vrfCurveType = bcos::sealer::VrfCurveType::CURVE25519)
-      : m_vrfProof(std::move(_vrfProof)),
-        m_vrfPublicKey(std::move(_vrfPk)),
-        m_vrfInput(std::move(_vrfInput)),
-        m_vrfCurveType(vrfCurveType)
-    {}
+        VRFInfo(bcos::bytes _vrfProof, bcos::bytes _vrfPk, bcos::bytes _vrfInput,
+                bcos::sealer::VrfCurveType vrfCurveType = bcos::sealer::VrfCurveType::CURVE25519);
 
     virtual ~VRFInfo() = default;
     virtual bool verifyProof();
     virtual bcos::crypto::HashType getHashFromProof();
     virtual bool isValidVRFPublicKey();
 
-    bcos::bytes const& vrfProof() const { return m_vrfProof; }
-    bcos::bytes const& vrfPublicKey() const { return m_vrfPublicKey; }
-    bcos::bytes const& vrfInput() const { return m_vrfInput; }
-    bcos::sealer::VrfCurveType vrfCurveType() const { return m_vrfCurveType; }
+    bcos::bytes const& vrfProof() const;
+    bcos::bytes const& vrfPublicKey() const;
+    bcos::bytes const& vrfInput() const;
+    bcos::sealer::VrfCurveType vrfCurveType() const;
 
 private:
     bcos::bytes m_vrfProof;

--- a/bcos-executor/src/precompiled/extension/PaillierPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/PaillierPrecompiled.cpp
@@ -51,6 +51,18 @@ PaillierPrecompiled::PaillierPrecompiled(const crypto::Hash::Ptr& _hashImpl)
         getFuncSelector(PAILLIER_METHOD_ADD_RAW_STR, _hashImpl);
 }
 
+PaillierPrecompiled::~PaillierPrecompiled() = default;
+
+bool PaillierPrecompiled::isParallelPrecompiled()
+{
+    return true;
+}
+
+std::vector<std::string> PaillierPrecompiled::getParallelTag(bytesConstRef, bool)
+{
+    return {};
+}
+
 PrecompiledExecResult::Ptr PaillierPrecompiled::call(
     std::shared_ptr<executor::TransactionExecutive> _executive,
     PrecompiledExecResult::Ptr _callParameters)

--- a/bcos-executor/src/precompiled/extension/PaillierPrecompiled.h
+++ b/bcos-executor/src/precompiled/extension/PaillierPrecompiled.h
@@ -35,14 +35,14 @@ class PaillierPrecompiled : public bcos::precompiled::Precompiled
 public:
     using Ptr = std::shared_ptr<PaillierPrecompiled>;
     PaillierPrecompiled(const crypto::Hash::Ptr& _hashImpl);
-    ~PaillierPrecompiled() override= default;
+    ~PaillierPrecompiled() override;
 
     std::shared_ptr<PrecompiledExecResult> call(
         std::shared_ptr<executor::TransactionExecutive> _executive,
         PrecompiledExecResult::Ptr _callParameters) override;
-     bool isParallelPrecompiled() override { return true; }
+     bool isParallelPrecompiled() override;
 
-     std::vector<std::string> getParallelTag(bytesConstRef, bool) override { return {}; }
+     std::vector<std::string> getParallelTag(bytesConstRef, bool) override;
 private:
     std::shared_ptr<CallPaillier> m_callPaillier;
 };

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -101,6 +101,37 @@ void HostContext::set(const std::string_view& _key, std::string _value)
     m_executive->storage().setRow(m_tableName, _key, std::move(entry));
 }
 
+int64_t HostContext::blockGasLimit() const
+{
+    if (m_executive->blockContext().blockVersion() >=
+        (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
+    {
+        return m_executive->blockContext().txGasLimit();
+    }
+
+    return 3000000000;
+}
+
+CallParameters::UniquePtr&& HostContext::takeCallParameters()
+{
+    if (m_executive->blockContext().blockVersion() >=
+        (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
+    {
+        for (const auto& response : m_responseStore)
+        {
+            m_callParameters->logEntries.insert(m_callParameters->logEntries.end(),
+                std::make_move_iterator(response->logEntries.begin()),
+                std::make_move_iterator(response->logEntries.end()));
+        }
+    }
+    return std::move(m_callParameters);
+}
+
+std::string HostContext::getContractTableName(const std::string_view& _address)
+{
+    return m_executive->getContractTableName(_address, isWasm(), isCreate());
+}
+
 
 std::string addressBytesStr2String(std::string_view receiveAddressBytes)
 {

--- a/bcos-executor/src/vm/HostContext.h
+++ b/bcos-executor/src/vm/HostContext.h
@@ -94,19 +94,7 @@ public:
     int64_t blockNumber() const;
     uint32_t blockVersion() const;
     uint64_t timestamp() const;
-    int64_t blockGasLimit() const
-    {
-        if (m_executive->blockContext().blockVersion() >=
-            (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
-        {
-            // FISCO BCOS only has tx Gas limit. We use it as block gas limit
-            return m_executive->blockContext().txGasLimit();
-        }
-        else
-        {
-            return 3000000000;
-        }
-    }
+    int64_t blockGasLimit() const;
 
     evmc_uint256be chainId() const { return m_executive->blockContext().ledgerCache()->chainId(); }
 
@@ -147,20 +135,7 @@ public:
     evmc_bytes32 getBalance(const evmc_address* _addr);
     bool selfdestruct(const evmc_address* _addr, const evmc_address* _beneficiary);
 
-    CallParameters::UniquePtr&& takeCallParameters()
-    {
-        if (m_executive->blockContext().blockVersion() >=
-            (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION)
-        {
-            for (const auto& response : m_responseStore)
-            {
-                m_callParameters->logEntries.insert(m_callParameters->logEntries.end(),
-                    std::make_move_iterator(response->logEntries.begin()),
-                    std::make_move_iterator(response->logEntries.end()));
-            }
-        }
-        return std::move(m_callParameters);
-    }
+    CallParameters::UniquePtr&& takeCallParameters();
 
     static crypto::Hash::Ptr& hashImpl() { return GlobalHashImpl::g_hashImpl; }
 
@@ -176,10 +151,7 @@ public:
         return m_executive->blockContext().features();
     }
 
-    std::string getContractTableName(const std::string_view& _address)
-    {
-        return m_executive->getContractTableName(_address, isWasm(), isCreate());
-    }
+    std::string getContractTableName(const std::string_view& _address);
 
 protected:
     const CallParameters::UniquePtr& getCallParameters() const { return m_callParameters; }

--- a/bcos-executor/src/vm/Precompiled.cpp
+++ b/bcos-executor/src/vm/Precompiled.cpp
@@ -35,6 +35,69 @@ namespace bcos::executor
 {
 PrecompiledRegistrar* PrecompiledRegistrar::s_this = nullptr;
 
+PrecompiledRegistrar* PrecompiledRegistrar::get()
+{
+    if (s_this == nullptr)
+    {
+        s_this = new PrecompiledRegistrar;
+    }
+    return s_this;
+}
+
+PrecompiledExecutor PrecompiledRegistrar::registerExecutor(
+    std::string const& _name, PrecompiledExecutor const& _exec)
+{
+    return (get()->m_execs[_name] = _exec);
+}
+
+void PrecompiledRegistrar::unregisterExecutor(std::string const& _name)
+{
+    get()->m_execs.erase(_name);
+}
+
+PrecompiledPricer PrecompiledRegistrar::registerPricer(
+    std::string const& _name, PrecompiledPricer const& _exec)
+{
+    return (get()->m_pricers[_name] = _exec);
+}
+
+void PrecompiledRegistrar::unregisterPricer(std::string const& _name)
+{
+    get()->m_pricers.erase(_name);
+}
+
+PrecompiledContract::PrecompiledContract(PrecompiledPricer const& _cost,
+    PrecompiledExecutor const& _exec, u256 const& _startingBlock)
+  : m_cost(_cost), m_execute(_exec), m_startingBlock(_startingBlock)
+{}
+
+PrecompiledContract::PrecompiledContract(
+    unsigned _base, unsigned _word, PrecompiledExecutor const& _exec, u256 const& _startingBlock)
+  : PrecompiledContract(
+        [=](bytesConstRef _in) -> bigint {
+            bigint size = _in.size();
+            bigint base = _base;
+            bigint word = _word;
+            return base + (size + 31) / 32 * word;
+        },
+        _exec, _startingBlock)
+{}
+
+bigint PrecompiledContract::cost(bytesConstRef _in) const
+{
+    return m_cost(_in);
+}
+
+std::pair<bool, bytes> PrecompiledContract::execute(bytesConstRef _in) const
+{
+    return m_execute(_in);
+}
+
+u256 const& PrecompiledContract::startingBlock() const
+{
+    return m_startingBlock;
+}
+
 bcos::precompiled::Precompiled::Ptr bcos::executor::PrecompiledMap::at(std::string_view _key,
     uint32_t version, bool isAuth, ledger::Features const& features) const noexcept
 {
@@ -80,6 +143,29 @@ PrecompiledPricer const& PrecompiledRegistrar::pricer(std::string const& _name)
 }
 
 }  // namespace bcos::executor
+
+namespace bcos::precompiled
+{
+
+Precompiled::Precompiled(crypto::Hash::Ptr _hashImpl)
+  : m_hashImpl(std::move(_hashImpl))
+{
+    assert(m_hashImpl);
+    m_precompiledGasFactory = std::make_shared<PrecompiledGasFactory>();
+    assert(m_precompiledGasFactory);
+}
+
+bool Precompiled::isParallelPrecompiled()
+{
+    return false;
+}
+
+std::vector<std::string> Precompiled::getParallelTag(bytesConstRef, bool)
+{
+    return {};
+}
+
+}  // namespace bcos::precompiled
 
 namespace
 {

--- a/bcos-executor/src/vm/Precompiled.h
+++ b/bcos-executor/src/vm/Precompiled.h
@@ -54,31 +54,18 @@ public:
 
     /// Register an executor. In general just use ETH_REGISTER_PRECOMPILED.
     static PrecompiledExecutor registerExecutor(
-        std::string const& _name, PrecompiledExecutor const& _exec)
-    {
-        return (get()->m_execs[_name] = _exec);
-    }
+        std::string const& _name, PrecompiledExecutor const& _exec);
     /// Unregister an executor. Shouldn't generally be necessary.
-    static void unregisterExecutor(std::string const& _name) { get()->m_execs.erase(_name); }
+    static void unregisterExecutor(std::string const& _name);
 
     /// Register a pricer. In general just use ETH_REGISTER_PRECOMPILED_PRICER.
     static PrecompiledPricer registerPricer(
-        std::string const& _name, PrecompiledPricer const& _exec)
-    {
-        return (get()->m_pricers[_name] = _exec);
-    }
+        std::string const& _name, PrecompiledPricer const& _exec);
     /// Unregister a pricer. Shouldn't generally be necessary.
-    static void unregisterPricer(std::string const& _name) { get()->m_pricers.erase(_name); }
+    static void unregisterPricer(std::string const& _name);
 
 private:
-    static PrecompiledRegistrar* get()
-    {
-        if (s_this == nullptr)
-        {
-            s_this = new PrecompiledRegistrar;
-        }
-        return s_this;
-    }
+    static PrecompiledRegistrar* get();
 
     std::unordered_map<std::string, PrecompiledExecutor> m_execs;
     std::unordered_map<std::string, PrecompiledPricer> m_pricers;
@@ -104,26 +91,15 @@ public:
     typedef std::shared_ptr<PrecompiledContract> Ptr;
     PrecompiledContract() = default;
     PrecompiledContract(PrecompiledPricer const& _cost, PrecompiledExecutor const& _exec,
-        u256 const& _startingBlock = 0)
-      : m_cost(_cost), m_execute(_exec), m_startingBlock(_startingBlock)
-    {}
+                u256 const& _startingBlock = 0);
 
     PrecompiledContract(unsigned _base, unsigned _word, PrecompiledExecutor const& _exec,
-        u256 const& _startingBlock = 0)
-      : PrecompiledContract(
-            [=](bytesConstRef _in) -> bigint {
-                bigint s = _in.size();
-                bigint b = _base;
-                bigint w = _word;
-                return b + (s + 31) / 32 * w;
-            },
-            _exec, _startingBlock)
-    {}
+                u256 const& _startingBlock = 0);
 
-    bigint cost(bytesConstRef _in) const { return m_cost(_in); }
-    std::pair<bool, bytes> execute(bytesConstRef _in) const { return m_execute(_in); }
+        bigint cost(bytesConstRef _in) const;
+        std::pair<bool, bytes> execute(bytesConstRef _in) const;
 
-    u256 const& startingBlock() const { return m_startingBlock; }
+        u256 const& startingBlock() const;
 
 private:
     PrecompiledPricer m_cost;
@@ -144,20 +120,15 @@ public:
         std::function<void(const std::shared_ptr<executor::TransactionExecutive>& executive,
             PrecompiledExecResult::Ptr const& callParameters)>;
 
-    Precompiled(crypto::Hash::Ptr _hashImpl) : m_hashImpl(std::move(_hashImpl))
-    {
-        assert(m_hashImpl);
-        m_precompiledGasFactory = std::make_shared<PrecompiledGasFactory>();
-        assert(m_precompiledGasFactory);
-    }
+    Precompiled(crypto::Hash::Ptr _hashImpl);
     virtual ~Precompiled() = default;
 
     virtual std::shared_ptr<PrecompiledExecResult> call(
         std::shared_ptr<executor::TransactionExecutive> _executive,
         PrecompiledExecResult::Ptr _callParameters) = 0;
-    virtual bool isParallelPrecompiled() { return false; }
+    virtual bool isParallelPrecompiled();
 
-    virtual std::vector<std::string> getParallelTag(bytesConstRef, bool) { return {}; }
+    virtual std::vector<std::string> getParallelTag(bytesConstRef, bool);
 
 protected:
     std::map<std::string, uint32_t, std::less<>> name2Selector;

--- a/bcos-executor/src/vm/VMFactory.cpp
+++ b/bcos-executor/src/vm/VMFactory.cpp
@@ -32,6 +32,8 @@ namespace po = boost::program_options;
 namespace bcos::executor
 {
 
+VMFactory::VMFactory(size_t cache_size) : m_cache(cache_size) {}
+
 /// The pointer to VMInstance create function in DLL VMInstance VM.
 ///
 /// This variable is only written once when processing command line arguments,

--- a/bcos-executor/src/vm/VMFactory.h
+++ b/bcos-executor/src/vm/VMFactory.h
@@ -46,7 +46,7 @@ enum class VMKind
 class VMFactory
 {
 public:
-    VMFactory(size_t cache_size = c_EVMONE_CACHE_SIZE) : m_cache(cache_size) {}
+    VMFactory(size_t cache_size = c_EVMONE_CACHE_SIZE);
 
     /// Creates a VM instance of the kind provided.
     VMInstance create(VMKind _kind, evmc_revision revision, const crypto::HashType& codeHash,

--- a/bcos-executor/src/vm/VMInstance.cpp
+++ b/bcos-executor/src/vm/VMInstance.cpp
@@ -29,6 +29,19 @@ using namespace std;
 namespace bcos::executor
 {
 
+Result::~Result()
+{
+    if (release != nullptr)
+    {
+        release(this);
+    }
+}
+
+Result::Result(Result&& _other) noexcept : evmc_result(_other)
+{
+    _other.release = nullptr;
+}
+
 VMInstance::VMInstance(evmc_vm* instance, evmc_revision revision, bytes_view code) noexcept
   : m_instance(instance), m_revision(revision), m_code(code)
 {
@@ -50,6 +63,14 @@ VMInstance::VMInstance(
   : m_analysis(std::move(analysis)), m_revision(revision), m_code(code)
 {
     assert(m_analysis != nullptr);
+}
+
+VMInstance::~VMInstance()
+{
+    if (m_instance)
+    {
+        m_instance->destroy(m_instance);
+    }
 }
 
 Result VMInstance::execute(HostContext& _hostContext, evmc_message* _msg)

--- a/bcos-executor/src/vm/VMInstance.h
+++ b/bcos-executor/src/vm/VMInstance.h
@@ -40,15 +40,9 @@ class Result : public evmc_result
 public:
     explicit Result(evmc_result const& _result) : evmc_result(_result) {}
 
-    ~Result()
-    {
-        if (release != nullptr)
-        {
-            release(this);
-        }
-    }
+    ~Result();
 
-    Result(Result&& _other) noexcept : evmc_result(_other) { _other.release = nullptr; }
+    Result(Result&& _other) noexcept;
 
     Result& operator=(Result&&) = delete;
     Result(Result const&) = delete;
@@ -70,13 +64,7 @@ public:
     explicit VMInstance(evmc_vm* instance, evmc_revision revision, bytes_view code) noexcept;
     explicit VMInstance(std::shared_ptr<evmoneCodeAnalysis> analysis, evmc_revision revision,
         bytes_view code) noexcept;
-    ~VMInstance()
-    {
-        if (m_instance)
-        {
-            m_instance->destroy(m_instance);
-        }
-    }
+    ~VMInstance();
 
     VMInstance(VMInstance const&) = delete;
     VMInstance& operator=(VMInstance) = delete;


### PR DESCRIPTION
Refactor the executor header files by moving implementations into corresponding source files, improving code organization and readability. This change enhances maintainability and aligns with best practices for header and source file separation.