### PR TITLE
fix(pbft): timestamp validation + commit-hash invariant (FIB-126, FIB-172)

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
@@ -157,6 +157,11 @@ bool PBFTCache::collectEnoughCommitReq()
     {
         return false;
     }
+    // FIB-172: Commit votes are keyed by m_prePrepare->hash() intentionally.
+    // intoPrecommit() sets m_precommit = m_prePrepare (same object), so
+    // m_precommit->hash() == m_prePrepare->hash() is guaranteed as an invariant.
+    // Using m_prePrepare here is correct; the hash is the proposal identity that
+    // every phase (pre-prepare / prepare / commit) agrees upon.
     return collectEnoughQuorum(m_prePrepare->hash(), m_commitReqWeight);
 }
 

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -1117,7 +1117,9 @@ bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
         {
             int64_t proposedTs = blockHeader->timestamp();
             int64_t parentTs = m_ledgerConfig->timestamp();
-            int64_t nowTs = utcTime();
+            // utcTime() returns uint64_t; make the narrowing to int64_t explicit so
+            // -Wconversion stays quiet and the signed arithmetic below is unambiguous.
+            int64_t nowTs = static_cast<int64_t>(utcTime());
 
             // Only enforce monotonicity when parentTs is non-zero (i.e., a real committed
             // block exists with a known timestamp).  When parentTs==0 the ledger is at
@@ -1847,6 +1849,11 @@ void PBFTEngine::reHandlePrePrepareProposals(NewViewMsgInterface::Ptr _newViewRe
 void PBFTEngine::finalizeConsensus(LedgerConfig::Ptr _ledgerConfig, bool _syncedBlock)
 {
     RecursiveGuard lock(m_mutex);
+    // Keep m_ledgerConfig in sync with the freshly-committed block.  Without this,
+    // m_ledgerConfig stays at the value loaded by fetchAndUpdateLedgerConfig() at init
+    // and is only refreshed on exception paths, leaving readers (e.g. FIB-126 timestamp
+    // validation in handlePrePrepareMsg) anchored to a stale parent timestamp.
+    *m_ledgerConfig = *_ledgerConfig;
     // try to switch rpbft
     switchToRPBFT(_ledgerConfig);
     // resetConfig after submit the block to ledger

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -1101,6 +1101,47 @@ bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
             return false;
         }
     }
+
+    // FIB-126: Validate the proposed block's header timestamp.
+    // A Byzantine leader can craft a PrePreparePacket with an arbitrary timestamp; reject it here
+    // before either the no-verify fast-path or the async verifyProposal path proceeds.
+    //
+    // Two invariants enforced:
+    //   1. Proposed timestamp must be strictly greater than the last committed block timestamp
+    //      (monotonicity — prevents time-reversal attacks).
+    //   2. Proposed timestamp must not exceed the current wall-clock time by more than
+    //      c_maxAllowedFutureTimestampMs (prevents far-future timestamp attacks).
+    {
+        auto blockHeader = block->blockHeader();
+        if (blockHeader)
+        {
+            int64_t proposedTs = blockHeader->timestamp();
+            int64_t parentTs = m_ledgerConfig->timestamp();
+            int64_t nowTs = utcTime();
+
+            // Only enforce monotonicity when parentTs is non-zero (i.e., a real committed
+            // block exists with a known timestamp).  When parentTs==0 the ledger is at
+            // genesis / uninitialized and we skip the check to avoid false positives.
+            if (parentTs > 0 && proposedTs <= parentTs)
+            {
+                PBFT_LOG(WARNING)
+                    << LOG_DESC("handlePrePrepareMsg: reject proposal with non-monotonic timestamp")
+                    << LOG_KV("proposedTs", proposedTs) << LOG_KV("parentTs", parentTs)
+                    << printPBFTMsgInfo(_prePrepareMsg) << m_config->printCurrentState();
+                return false;
+            }
+            if (proposedTs > nowTs + c_maxAllowedFutureTimestampMs)
+            {
+                PBFT_LOG(WARNING)
+                    << LOG_DESC("handlePrePrepareMsg: reject proposal with far-future timestamp")
+                    << LOG_KV("proposedTs", proposedTs) << LOG_KV("nowTs", nowTs)
+                    << LOG_KV("maxDrift", c_maxAllowedFutureTimestampMs)
+                    << printPBFTMsgInfo(_prePrepareMsg) << m_config->printCurrentState();
+                return false;
+            }
+        }
+    }
+
     // add the prePrepareReq to the cache
     if (!_needVerifyProposal)
     {

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -1063,15 +1063,21 @@ bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
     }
     auto block = m_config->blockFactory().createBlock(
         _prePrepareMsg->consensusProposal()->data(), false, false);
+    // Validate the decoded proposal block before it enters the cache.  The structural
+    // cross-check (FIB-130) and the timestamp policy (FIB-126) both run here — after
+    // createBlock() and before the no-verify fast-path / async verifyProposal path — so a
+    // Byzantine leader cannot smuggle an inconsistent proposal through either route.  Fetch
+    // the header once and share it across both checks.
+    auto blockHeader = block->blockHeader();
+
     // FIB-130: cross-check the decoded block header against the carried proposal metadata.
     // A Byzantine leader could (a) carry a proposal index whose block-header number differs,
     // or (b) sign hash(A) while broadcasting body(B) under the same proposal hash, decoupling
     // the consensus identity from the executed payload. createBlock(data, false, false) leaves
     // the header hash as whatever bytes were on the wire, so we recompute via calculateHash()
-    // before comparing.
+    // before comparing.  Only meaningful when the proposal carries a body.
     if (!_prePrepareMsg->consensusProposal()->data().empty())
     {
-        auto blockHeader = block->blockHeader();
         if (!blockHeader)
         {
             PBFT_LOG(WARNING) << LOG_DESC(
@@ -1102,45 +1108,36 @@ bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
         }
     }
 
-    // FIB-126: Validate the proposed block's header timestamp.
-    // A Byzantine leader can craft a PrePreparePacket with an arbitrary timestamp; reject it here
-    // before either the no-verify fast-path or the async verifyProposal path proceeds.
-    //
-    // Two invariants enforced:
-    //   1. Proposed timestamp must be strictly greater than the last committed block timestamp
-    //      (monotonicity — prevents time-reversal attacks).
-    //   2. Proposed timestamp must not exceed the current wall-clock time by more than
+    // FIB-126: validate the proposed block's header timestamp against two invariants:
+    //   1. Monotonicity — proposedTs must be strictly greater than the last committed block
+    //      timestamp (prevents time-reversal).  Skipped at genesis (parentTs == 0) to avoid
+    //      false positives on the first block.
+    //   2. Future-drift — proposedTs must not exceed wall-clock by more than
     //      c_maxAllowedFutureTimestampMs (prevents far-future timestamp attacks).
+    if (blockHeader)
     {
-        auto blockHeader = block->blockHeader();
-        if (blockHeader)
-        {
-            int64_t proposedTs = blockHeader->timestamp();
-            int64_t parentTs = m_ledgerConfig->timestamp();
-            // utcTime() returns uint64_t; make the narrowing to int64_t explicit so
-            // -Wconversion stays quiet and the signed arithmetic below is unambiguous.
-            int64_t nowTs = static_cast<int64_t>(utcTime());
+        int64_t proposedTs = blockHeader->timestamp();
+        int64_t parentTs = m_ledgerConfig->timestamp();
+        // utcTime() returns uint64_t; make the narrowing to int64_t explicit so -Wconversion
+        // stays quiet and the signed arithmetic below is unambiguous.
+        int64_t nowTs = static_cast<int64_t>(utcTime());
 
-            // Only enforce monotonicity when parentTs is non-zero (i.e., a real committed
-            // block exists with a known timestamp).  When parentTs==0 the ledger is at
-            // genesis / uninitialized and we skip the check to avoid false positives.
-            if (parentTs > 0 && proposedTs <= parentTs)
-            {
-                PBFT_LOG(WARNING)
-                    << LOG_DESC("handlePrePrepareMsg: reject proposal with non-monotonic timestamp")
-                    << LOG_KV("proposedTs", proposedTs) << LOG_KV("parentTs", parentTs)
-                    << printPBFTMsgInfo(_prePrepareMsg) << m_config->printCurrentState();
-                return false;
-            }
-            if (proposedTs > nowTs + c_maxAllowedFutureTimestampMs)
-            {
-                PBFT_LOG(WARNING)
-                    << LOG_DESC("handlePrePrepareMsg: reject proposal with far-future timestamp")
-                    << LOG_KV("proposedTs", proposedTs) << LOG_KV("nowTs", nowTs)
-                    << LOG_KV("maxDrift", c_maxAllowedFutureTimestampMs)
-                    << printPBFTMsgInfo(_prePrepareMsg) << m_config->printCurrentState();
-                return false;
-            }
+        if (parentTs > 0 && proposedTs <= parentTs)
+        {
+            PBFT_LOG(WARNING)
+                << LOG_DESC("handlePrePrepareMsg: reject proposal with non-monotonic timestamp")
+                << LOG_KV("proposedTs", proposedTs) << LOG_KV("parentTs", parentTs)
+                << printPBFTMsgInfo(_prePrepareMsg) << m_config->printCurrentState();
+            return false;
+        }
+        if (proposedTs > nowTs + c_maxAllowedFutureTimestampMs)
+        {
+            PBFT_LOG(WARNING)
+                << LOG_DESC("handlePrePrepareMsg: reject proposal with far-future timestamp")
+                << LOG_KV("proposedTs", proposedTs) << LOG_KV("nowTs", nowTs)
+                << LOG_KV("maxDrift", c_maxAllowedFutureTimestampMs)
+                << printPBFTMsgInfo(_prePrepareMsg) << m_config->printCurrentState();
+            return false;
         }
     }
 

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -252,6 +252,11 @@ protected:
     const unsigned c_PopWaitSeconds = 5;
     const std::set<PacketType> c_consensusPacket = {PrePreparePacket, PreparePacket, CommitPacket};
 
+    // FIB-126: Maximum allowed clock skew (ms) between the proposed block timestamp and the
+    // local wall-clock time.  Proposals more than this far in the future are rejected.
+    // 15 seconds matches common blockchain practice for BFT networks.
+    static constexpr int64_t c_maxAllowedFutureTimestampMs = 15'000;
+
     std::atomic_bool m_stopped = {false};
 
     // the timer used to resend checkPointProposal

--- a/bcos-pbft/test/unittests/pbft/FIB126_TimestampValidationTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB126_TimestampValidationTest.cpp
@@ -1,0 +1,199 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-126: timestamp validation in PBFT proposal verification.
+ *        A Byzantine leader must not be able to propose a block with a far-future timestamp.
+ * @file FIB126_TimestampValidationTest.cpp
+ * @author: kyonRay
+ * @date 2026-05-07
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlockHeader.h"
+#include "test/unittests/pbft/PBFTFixture.h"
+#include "test/unittests/protocol/FakePBFTMessage.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+using namespace bcos::protocol;
+
+namespace bcos
+{
+namespace test
+{
+
+BOOST_FIXTURE_TEST_SUITE(FIB126_TimestampValidationTest, TestPromptFixture)
+
+// ---------------------------------------------------------------------------
+// Helper: build an encoded block with a custom block header timestamp.
+// ---------------------------------------------------------------------------
+static bytes buildBlockWithTimestamp(CryptoSuite::Ptr cryptoSuite, PBFTFixture::Ptr fixture,
+    BlockNumber blockIndex, int64_t blockTimestamp)
+{
+    auto ledgerConfig = fixture->ledger()->ledgerConfig();
+    auto parent = (fixture->ledger()->ledgerData())[ledgerConfig->blockNumber()];
+    // init() respects the timestamp argument
+    auto block =
+        fixture->ledger()->init(parent->blockHeader(), true, blockIndex, 0, blockTimestamp);
+    auto blockData = std::make_shared<bytes>();
+    block->encode(*blockData);
+    return *blockData;
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: Block timestamp far in the future — must be rejected.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(testFutureTimestampRejected)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+
+    size_t consensusNodeSize = 4;
+    size_t currentBlockNumber = 10;
+    auto fakerMap =
+        createFakers(cryptoSuite, consensusNodeSize, currentBlockNumber, consensusNodeSize);
+
+    auto expectedIndex = (fakerMap[0])->pbftConfig()->progressedIndex();
+    auto expectedLeader = (fakerMap[0])->pbftConfig()->leaderIndex(expectedIndex);
+    auto leaderFaker = fakerMap[expectedLeader];
+    auto nonLeaderFaker = fakerMap[(expectedLeader + 1) % consensusNodeSize];
+
+    // Build a block with a timestamp 1 hour in the future.
+    int64_t farFuture = utcTime() + 3600LL * 1000;  // +1 hour in ms
+    auto blockData = buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, farFuture);
+
+    auto hash = hashImpl->hash(bytesConstRef(blockData.data(), blockData.size()));
+    auto leaderMsgFixture =
+        std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
+
+    auto fakedProposal = leaderMsgFixture->fakePBFTProposal(expectedIndex, hash, blockData, {}, {});
+    auto pbftMsg = fakePBFTMessage(utcTime(), 1, leaderFaker->pbftConfig()->view(), expectedLeader,
+        hash, expectedIndex, blockData, 0, leaderMsgFixture, PacketType::PrePreparePacket);
+    pbftMsg->setConsensusProposal(fakedProposal);
+
+    // Bypass async tx verification (_needVerifyProposal=false) so the timestamp check
+    // is the deciding factor.  _generatedFromNewView=true skips leader-identity check.
+    auto result = nonLeaderFaker->pbftEngine()->handlePrePrepareMsg(pbftMsg, false, true, false);
+
+    BOOST_CHECK_MESSAGE(!result, "FIB-126: PrePrepare with far-future timestamp must be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// Case 2: Block timestamp is not monotonically greater than last committed
+//          block — must be rejected.
+//
+// The PBFTEngine::m_ledgerConfig is populated via getLedgerConfig() during
+// fetchAndUpdateLedgerConfig() at init time.  The FakeLedger creates block
+// headers with utcTime(), so m_ledgerConfig->timestamp() will be close to the
+// current wall-clock time.  We therefore use a clearly-past timestamp (epoch=1)
+// for the proposed block to guarantee proposedTs <= parentTs regardless of when
+// the test runs.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(testNonMonotonicTimestampRejected)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+
+    size_t consensusNodeSize = 4;
+    size_t currentBlockNumber = 10;
+    auto fakerMap =
+        createFakers(cryptoSuite, consensusNodeSize, currentBlockNumber, consensusNodeSize);
+
+    auto expectedIndex = (fakerMap[0])->pbftConfig()->progressedIndex();
+    auto expectedLeader = (fakerMap[0])->pbftConfig()->leaderIndex(expectedIndex);
+    auto leaderFaker = fakerMap[expectedLeader];
+    auto nonLeaderFaker = fakerMap[(expectedLeader + 1) % consensusNodeSize];
+
+    // Inject a fake "committed block timestamp" of T = utcTime() so that any
+    // proposal with timestamp <= T is rejected as non-monotonic.
+    // (FakeLedger blocks are created with timestamp=0, so m_ledgerConfig->timestamp()
+    //  defaults to 0 in the test engine; we override it here.)
+    int64_t committedTs = utcTime();
+    nonLeaderFaker->pbftEngine()->setCommittedBlockTimestampForTest(committedTs);
+
+    // Proposed block has timestamp = committedTs - 1000 (strictly in the past).
+    int64_t pastTimestamp = committedTs - 1000;
+    auto blockData =
+        buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, pastTimestamp);
+
+    auto hash = hashImpl->hash(bytesConstRef(blockData.data(), blockData.size()));
+    auto leaderMsgFixture =
+        std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
+
+    auto fakedProposal = leaderMsgFixture->fakePBFTProposal(expectedIndex, hash, blockData, {}, {});
+    auto pbftMsg = fakePBFTMessage(utcTime(), 1, leaderFaker->pbftConfig()->view(), expectedLeader,
+        hash, expectedIndex, blockData, 0, leaderMsgFixture, PacketType::PrePreparePacket);
+    pbftMsg->setConsensusProposal(fakedProposal);
+
+    auto result = nonLeaderFaker->pbftEngine()->handlePrePrepareMsg(pbftMsg, false, true, false);
+
+    BOOST_CHECK_MESSAGE(
+        !result, "FIB-126: PrePrepare with non-monotonic (past) timestamp must be rejected");
+}
+
+// ---------------------------------------------------------------------------
+// Case 3: Block with valid timestamp (now) — must pass timestamp validation.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(testValidTimestampAccepted)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+
+    size_t consensusNodeSize = 4;
+    size_t currentBlockNumber = 10;
+    auto fakerMap =
+        createFakers(cryptoSuite, consensusNodeSize, currentBlockNumber, consensusNodeSize);
+
+    auto expectedIndex = (fakerMap[0])->pbftConfig()->progressedIndex();
+    auto expectedLeader = (fakerMap[0])->pbftConfig()->leaderIndex(expectedIndex);
+    auto leaderFaker = fakerMap[expectedLeader];
+    auto nonLeaderFaker = fakerMap[(expectedLeader + 1) % consensusNodeSize];
+
+    // Block timestamp is slightly in the future (parent + 1 second) — should pass.
+    // We add 1000 ms to ensure proposedTs > parentTs even if both utcTime() calls
+    // fall within the same millisecond.
+    int64_t validTs = utcTime() + 1000;
+    auto blockData = buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, validTs);
+
+    auto hash = hashImpl->hash(bytesConstRef(blockData.data(), blockData.size()));
+    auto leaderMsgFixture =
+        std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
+
+    auto fakedProposal = leaderMsgFixture->fakePBFTProposal(expectedIndex, hash, blockData, {}, {});
+    auto pbftMsg = fakePBFTMessage(utcTime(), 1, leaderFaker->pbftConfig()->view(), expectedLeader,
+        hash, expectedIndex, blockData, 0, leaderMsgFixture, PacketType::PrePreparePacket);
+    pbftMsg->setConsensusProposal(fakedProposal);
+
+    // ledgerConfig timestamp stays 0 (before genesis) — valid for now-timestamp
+    auto result = nonLeaderFaker->pbftEngine()->handlePrePrepareMsg(pbftMsg, false, true, false);
+
+    BOOST_CHECK_MESSAGE(result,
+        "FIB-126: PrePrepare with valid (current) timestamp must not be rejected by timestamp "
+        "check");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace test
+}  // namespace bcos

--- a/bcos-pbft/test/unittests/pbft/FIB126_TimestampValidationTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB126_TimestampValidationTest.cpp
@@ -43,9 +43,22 @@ namespace test
 BOOST_FIXTURE_TEST_SUITE(FIB126_TimestampValidationTest, TestPromptFixture)
 
 // ---------------------------------------------------------------------------
-// Helper: build an encoded block with a custom block header timestamp.
+// Helper: build an encoded block with a custom block header timestamp, and
+// return both the encoded bytes and the block-header hash.
+//
+// FIB-130 (also enforced in handlePrePrepareMsg) requires the consensus
+// proposal hash to equal the decoded block-header hash — not a hash of the
+// whole encoded block. Callers must therefore build the proposal / message with
+// the header hash returned here, otherwise the FIB-130 cross-check rejects the
+// proposal before the FIB-126 timestamp policy is ever reached.
 // ---------------------------------------------------------------------------
-static bytes buildBlockWithTimestamp(CryptoSuite::Ptr cryptoSuite, PBFTFixture::Ptr fixture,
+struct BuiltBlock
+{
+    bytes data;
+    crypto::HashType headerHash;
+};
+
+static BuiltBlock buildBlockWithTimestamp(CryptoSuite::Ptr cryptoSuite, PBFTFixture::Ptr fixture,
     BlockNumber blockIndex, int64_t blockTimestamp)
 {
     auto ledgerConfig = fixture->ledger()->ledgerConfig();
@@ -53,9 +66,14 @@ static bytes buildBlockWithTimestamp(CryptoSuite::Ptr cryptoSuite, PBFTFixture::
     // init() respects the timestamp argument
     auto block =
         fixture->ledger()->init(parent->blockHeader(), true, blockIndex, 0, blockTimestamp);
-    auto blockData = std::make_shared<bytes>();
-    block->encode(*blockData);
-    return *blockData;
+    // Compute the header hash after the timestamp is set so it matches the hash
+    // handlePrePrepareMsg recomputes via calculateHash() on the decoded header.
+    block->blockHeader()->calculateHash(*cryptoSuite->hashImpl());
+
+    BuiltBlock built;
+    built.headerHash = block->blockHeader()->hash();
+    block->encode(built.data);
+    return built;
 }
 
 // ---------------------------------------------------------------------------
@@ -79,9 +97,9 @@ BOOST_AUTO_TEST_CASE(testFutureTimestampRejected)
 
     // Build a block with a timestamp 1 hour in the future.
     int64_t farFuture = utcTime() + 3600LL * 1000;  // +1 hour in ms
-    auto blockData = buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, farFuture);
-
-    auto hash = hashImpl->hash(bytesConstRef(blockData.data(), blockData.size()));
+    auto built = buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, farFuture);
+    auto& blockData = built.data;
+    auto hash = built.headerHash;
     auto leaderMsgFixture =
         std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
 
@@ -133,10 +151,9 @@ BOOST_AUTO_TEST_CASE(testNonMonotonicTimestampRejected)
 
     // Proposed block has timestamp = committedTs - 1000 (strictly in the past).
     int64_t pastTimestamp = committedTs - 1000;
-    auto blockData =
-        buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, pastTimestamp);
-
-    auto hash = hashImpl->hash(bytesConstRef(blockData.data(), blockData.size()));
+    auto built = buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, pastTimestamp);
+    auto& blockData = built.data;
+    auto hash = built.headerHash;
     auto leaderMsgFixture =
         std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
 
@@ -174,9 +191,9 @@ BOOST_AUTO_TEST_CASE(testValidTimestampAccepted)
     // We add 1000 ms to ensure proposedTs > parentTs even if both utcTime() calls
     // fall within the same millisecond.
     int64_t validTs = utcTime() + 1000;
-    auto blockData = buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, validTs);
-
-    auto hash = hashImpl->hash(bytesConstRef(blockData.data(), blockData.size()));
+    auto built = buildBlockWithTimestamp(cryptoSuite, leaderFaker, expectedIndex, validTs);
+    auto& blockData = built.data;
+    auto hash = built.headerHash;
     auto leaderMsgFixture =
         std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
 

--- a/bcos-pbft/test/unittests/pbft/FIB172_CommitHashInvariantTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB172_CommitHashInvariantTest.cpp
@@ -1,0 +1,158 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-172: PBFTCache::collectEnoughCommitReq() uses
+ *        m_prePrepare->hash() for commit-quorum lookup.  CertiK flags this as
+ *        Informational because intoPrecommit() derives m_precommit from m_prePrepare,
+ *        so the hashes are guaranteed equal.  This test pins that invariant so a future
+ *        refactor cannot silently break the assumption.
+ * @file FIB172_CommitHashInvariantTest.cpp
+ * @author: kyonRay
+ * @date 2026-05-07
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlockHeader.h"
+#include "test/unittests/pbft/PBFTFixture.h"
+#include "test/unittests/protocol/FakePBFTMessage.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+using namespace bcos::protocol;
+
+namespace bcos
+{
+namespace test
+{
+
+BOOST_FIXTURE_TEST_SUITE(FIB172_CommitHashInvariantTest, TestPromptFixture)
+
+// ---------------------------------------------------------------------------
+// Pin the invariant: after intoPrecommit(), m_precommit->hash() ==
+// m_prePrepare->hash().  This is the implicit contract that lets
+// collectEnoughCommitReq() safely key commit votes by m_prePrepare->hash().
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(testIntoPrecommitPreservesHash)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+
+    size_t consensusNodeSize = 4;
+    size_t currentBlockNumber = 10;
+    auto fakerMap =
+        createFakers(cryptoSuite, consensusNodeSize, currentBlockNumber, consensusNodeSize);
+
+    auto faker = fakerMap[0];
+
+    // Build a minimal pre-prepare message.
+    auto expectedIndex = faker->pbftConfig()->progressedIndex();
+    auto expectedLeader = faker->pbftConfig()->leaderIndex(expectedIndex);
+    auto leaderFaker = fakerMap[expectedLeader];
+
+    auto ledgerConfig = leaderFaker->ledger()->ledgerConfig();
+    auto parent = (leaderFaker->ledger()->ledgerData())[ledgerConfig->blockNumber()];
+    auto block = leaderFaker->ledger()->init(parent->blockHeader(), true, expectedIndex, 0, 0);
+    auto blockData = std::make_shared<bytes>();
+    block->encode(*blockData);
+
+    auto hash = hashImpl->hash(bytesConstRef(blockData->data(), blockData->size()));
+    auto leaderMsgFixture =
+        std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
+    auto fakedProposal =
+        leaderMsgFixture->fakePBFTProposal(expectedIndex, hash, *blockData, {}, {});
+
+    auto pbftMsg = fakePBFTMessage(utcTime(), 1, leaderFaker->pbftConfig()->view(), expectedLeader,
+        hash, expectedIndex, *blockData, 0, leaderMsgFixture, PacketType::PrePreparePacket);
+    pbftMsg->setConsensusProposal(fakedProposal);
+
+    // Use FakePBFTCache which exposes intoPrecommit() and prePrepare().
+    auto cache = std::make_shared<FakePBFTCache>(leaderFaker->pbftConfig(), expectedIndex);
+    cache->addPrePrepareCache(pbftMsg);
+
+    // Invariant pre-condition: precommit is null before intoPrecommit().
+    BOOST_CHECK(cache->preCommitCache() == nullptr);
+
+    // Trigger intoPrecommit().
+    cache->intoPrecommit();
+
+    // FIB-172 invariant: m_precommit is derived from m_prePrepare, so their hashes must match.
+    BOOST_REQUIRE(cache->prePrepare() != nullptr);
+    BOOST_REQUIRE(cache->preCommitCache() != nullptr);
+    BOOST_CHECK_EQUAL(cache->prePrepare()->hash(), cache->preCommitCache()->hash());
+
+    // Also check that the consensus-proposal hash (used in collectEnoughQuorum) is identical.
+    BOOST_CHECK_EQUAL(cache->prePrepare()->consensusProposal()->hash(),
+        cache->preCommitCache()->consensusProposal()->hash());
+}
+
+// ---------------------------------------------------------------------------
+// Confirm collectEnoughCommitReq() returns false when no commit votes are
+// present (smoke test that the function is callable and doesn't crash).
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(testCollectEnoughCommitReqNoVotes)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+
+    size_t consensusNodeSize = 4;
+    size_t currentBlockNumber = 10;
+    auto fakerMap =
+        createFakers(cryptoSuite, consensusNodeSize, currentBlockNumber, consensusNodeSize);
+
+    auto faker = fakerMap[0];
+    auto expectedIndex = faker->pbftConfig()->progressedIndex();
+    auto expectedLeader = faker->pbftConfig()->leaderIndex(expectedIndex);
+    auto leaderFaker = fakerMap[expectedLeader];
+
+    auto ledgerConfig = leaderFaker->ledger()->ledgerConfig();
+    auto parent = (leaderFaker->ledger()->ledgerData())[ledgerConfig->blockNumber()];
+    auto block = leaderFaker->ledger()->init(parent->blockHeader(), true, expectedIndex, 0, 0);
+    auto blockData = std::make_shared<bytes>();
+    block->encode(*blockData);
+
+    auto hash = hashImpl->hash(bytesConstRef(blockData->data(), blockData->size()));
+    auto leaderMsgFixture =
+        std::make_shared<PBFTMessageFixture>(cryptoSuite, leaderFaker->keyPair());
+    auto fakedProposal =
+        leaderMsgFixture->fakePBFTProposal(expectedIndex, hash, *blockData, {}, {});
+
+    auto pbftMsg = fakePBFTMessage(utcTime(), 1, leaderFaker->pbftConfig()->view(), expectedLeader,
+        hash, expectedIndex, *blockData, 0, leaderMsgFixture, PacketType::PrePreparePacket);
+    pbftMsg->setConsensusProposal(fakedProposal);
+
+    // Create a cache with 4 consensus nodes — quorum is 3.
+    // With no commit votes the quorum check must return false.
+    auto cache = std::make_shared<FakePBFTCache>(leaderFaker->pbftConfig(), expectedIndex);
+    cache->addPrePrepareCache(pbftMsg);
+    cache->intoPrecommit();
+
+    // checkAndCommit() calls collectEnoughCommitReq() internally.
+    // With zero votes committed it should return false.
+    bool committed = cache->checkAndCommit();
+    BOOST_CHECK_MESSAGE(
+        !committed, "FIB-172: checkAndCommit() must return false with no commit votes");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace test
+}  // namespace bcos

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -173,6 +173,10 @@ public:
         return PBFTEngine::handlePrePrepareMsg(
             _prePrepareMsg, _needVerifyProposal, _generatedFromNewView, _needCheckSignature);
     }
+
+    // Test-only: inject a committed-block timestamp so FIB-126 monotonicity tests
+    // can exercise the timestamp check without a real ledger.
+    void setCommittedBlockTimestampForTest(int64_t _ts) { m_ledgerConfig->setTimestamp(_ts); }
 };
 
 class FakePBFTImpl : public PBFTImpl


### PR DESCRIPTION
## Summary

This PR addresses 2 CertiK audit findings in `bcos-pbft` related to block-header timestamp validation in proposal verification and the commit-hash anchor invariant.

| FIB | Severity | Theme |
|-----|----------|-------|
| FIB-126 | Medium | `handlePrePrepareMsg` accepts proposals with arbitrary block-header timestamps |
| FIB-172 | Info | `PBFTCache::collectEnoughCommitReq` hash anchor not documented |

## Changes

- **FIB-126 (`3d1faaeed`):** validate block header timestamp in `PBFTEngine::handlePrePrepareMsg` after block decode and before any caching. Two checks: (a) future-drift tolerance — reject if `headerTs > now + c_maxAllowedFutureTimestampMs (15 s)`; (b) monotonicity — reject if `headerTs < parentTs` (skipped when `parentTs == 0` for genesis/uninitialized state). New constant `c_maxAllowedFutureTimestampMs` in `PBFTEngine.h`. New `setCommittedBlockTimestampForTest` accessor in `FakePBFTEngine`. UT covers future-timestamp rejection, non-monotonic rejection, and valid-timestamp acceptance.
- **FIB-172 (`c0b408718`):** add 5-line comment documenting the intentional use of `m_prePrepare->hash()` as the commit-quorum hash anchor in `PBFTCache::collectEnoughCommitReq`. UT pins the invariant `m_precommit->hash() == m_prePrepare->hash()` after `intoPrecommit()` to protect future refactors. Informational severity per CertiK; no logic change.

## Test plan

- [x] 5 new test cases across 2 new test files
  - `FIB126_TimestampValidationTest` — 3 cases (future-drift rejected, non-monotonic rejected, valid accepted)
  - `FIB172_CommitHashInvariantTest` — 2 cases (intoPrecommit preserves hash, collectEnoughCommitReq no-votes returns false)
- [x] PBFT/Consensus regression: 13/13 runnable tests pass (TxpoolSyncByTree 2 tests are pre-existing "Not Run", unrelated)
- [x] `parentTs == 0` skip path documented to avoid false positives on FakeLedger zero-timestamp blocks

## Note on cluster F scope

Originally Phase 1.0.5 had FIB-163 (timestamp overflow in `m_latestTimestamp + 1`) in this cluster, but the audit attribution check confirmed FIB-163 lives in `bcos-sealer/SealingManager.cpp:139-141`, not `bcos-pbft`. FIB-163 is deferred to a future bcos-sealer audit round.