### PR TITLE
Remove FrontMessage::Ptr and factory

### DIFF
--- a/bcos-front/bcos-front/FrontMessage.cpp
+++ b/bcos-front/bcos-front/FrontMessage.cpp
@@ -74,14 +74,6 @@ bool FrontMessage::isResponse()
     return m_ext & ExtFlag::Response;
 }
 
-FrontMessageFactory::~FrontMessageFactory() = default;
-
-FrontMessage::Ptr FrontMessageFactory::buildMessage()
-{
-    auto message = std::make_shared<FrontMessage>();
-    return message;
-}
-
 bool bcos::front::FrontMessage::encodeHeader(bytes& buffer)
 {
     /// moduleID          :2 bytes

--- a/bcos-front/bcos-front/FrontMessage.h
+++ b/bcos-front/bcos-front/FrontMessage.h
@@ -40,8 +40,6 @@ enum MessageDecodeStatus
 class FrontMessage
 {
 public:
-    using Ptr = std::shared_ptr<FrontMessage>;
-
     /// moduleID(2) + UUID length(1) + ext(2)
     const static size_t HEADER_MIN_LENGTH = 5;
     /// The maximum front uuid length  10M
@@ -52,27 +50,24 @@ public:
         Response = 0x0001,
     };
 
-    FrontMessage() = default;
-    virtual ~FrontMessage() = default;
+    uint16_t moduleID();
+    void setModuleID(uint16_t _moduleID);
 
-    virtual uint16_t moduleID();
-    virtual void setModuleID(uint16_t _moduleID);
+    uint16_t ext();
+    void setExt(uint16_t _ext);
 
-    virtual uint16_t ext();
-    virtual void setExt(uint16_t _ext);
+    bytesConstRef uuid();
+    void setUuid(bytes _uuid);
 
-    virtual bytesConstRef uuid();
-    virtual void setUuid(bytes _uuid);
+    bytesConstRef payload();
+    void setPayload(bytesConstRef _payload);
 
-    virtual bytesConstRef payload();
-    virtual void setPayload(bytesConstRef _payload);
-
-    virtual void setResponse();
-    virtual bool isResponse();
+    void setResponse();
+    bool isResponse();
 
     bool encodeHeader(bytes& buffer);
-    virtual bool encode(bytes& _buffer);
-    virtual ssize_t decode(bytesConstRef _buffer);
+    bool encode(bytes& _buffer);
+    ssize_t decode(bytesConstRef _buffer);
 
     static uint16_t tryDecodeModuleID(bytesConstRef _buffer);
 
@@ -81,16 +76,6 @@ private:
     bytesConstRef m_payload;
     uint16_t m_moduleID = 0;
     uint16_t m_ext = 0;
-};
-
-class FrontMessageFactory
-{
-public:
-    using Ptr = std::shared_ptr<FrontMessageFactory>;
-
-    virtual ~FrontMessageFactory();
-
-    virtual FrontMessage::Ptr buildMessage();
 };
 
 }  // namespace bcos::front

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -52,16 +52,6 @@ FrontService::~FrontService() noexcept
     FRONT_LOG(INFO) << LOG_DESC("~FrontService") << LOG_KV("this", this);
 }
 
-FrontMessageFactory::Ptr FrontService::messageFactory() const
-{
-    return m_messageFactory;
-}
-
-void FrontService::setMessageFactory(FrontMessageFactory::Ptr _messageFactory)
-{
-    m_messageFactory = std::move(_messageFactory);
-}
-
 bcos::crypto::NodeIDPtr FrontService::nodeID() const
 {
     return m_nodeID;
@@ -190,12 +180,6 @@ void FrontService::checkParams()
     {
         BOOST_THROW_EXCEPTION(InvalidParameter() << errinfo_comment(
                                   " FrontService gatewayInterface is uninitialized"));
-    }
-
-    if (!m_messageFactory)
-    {
-        BOOST_THROW_EXCEPTION(
-            InvalidParameter() << errinfo_comment(" FrontService messageFactory is uninitialized"));
     }
 
     if (!m_ioService)
@@ -585,8 +569,7 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
         callback->timeoutHandler->cancel();
     }
 
-    // construct shared_ptr<bytes> from message->payload() first for
-    // thead safe
+    // Copy the payload before dispatching asynchronously.
     auto buffer = bytes(_payLoad.begin(), _payLoad.end());
     m_taskArena.execute([&]() {
         m_asyncGroup.run([_uuid, _error = std::move(_error), callback = std::move(callback),
@@ -610,8 +593,8 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
 {
     try
     {
-        auto message = messageFactory()->buildMessage();
-        auto ret = message->decode(_data);
+        FrontMessage message;
+        auto ret = message.decode(_data);
         if (MessageDecodeStatus::MESSAGE_COMPLETE != ret)
         {
             FRONT_LOG(ERROR) << LOG_DESC("onReceiveMessage") << LOG_DESC("illegal message")
@@ -619,18 +602,18 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
             BOOST_THROW_EXCEPTION(InvalidParameter() << errinfo_comment("illegal message"));
         }
 
-        int moduleID = message->moduleID();
-        int ext = message->ext();
-        std::string uuid = std::string(message->uuid().begin(), message->uuid().end());
+        int moduleID = message.moduleID();
+        int ext = message.ext();
+        std::string uuid = std::string(message.uuid().begin(), message.uuid().end());
 
         FRONT_LOG(TRACE) << LOG_BADGE("onReceiveMessage") << LOG_KV("moduleID", moduleID)
                          << LOG_KV("uuid", uuid) << LOG_KV("ext", ext)
                          << LOG_KV("groupID", _groupID) << LOG_KV("nodeID", _nodeID->hex())
                          << LOG_KV("length", _data.size());
 
-        if (message->isResponse())
+        if (message.isResponse())
         {
-            handleCallback(nullptr, message->payload(), uuid, moduleID, _nodeID);
+            handleCallback(nullptr, message.payload(), uuid, moduleID, _nodeID);
         }
         else
         {
@@ -638,14 +621,12 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
                 it != m_moduleID2MessageDispatcher.end())
             {
                 auto callback = it->second;
-                // construct shared_ptr<bytes> from message->payload() first for
-                // thead safe
-                bytes buffer(message->payload().begin(), message->payload().end());
+                // Copy the payload before dispatching asynchronously.
+                bytes buffer(message.payload().begin(), message.payload().end());
 
                 m_taskArena.execute([&]() mutable {
                     m_asyncGroup.run(
-                        [uuid, callback = std::move(callback), buffer = std::move(buffer),
-                            message = std::move(message), _nodeID] {
+                        [uuid, callback = std::move(callback), buffer = std::move(buffer), _nodeID] {
                             callback(_nodeID, uuid, bytesConstRef(buffer.data(), buffer.size()));
                         });
                 });
@@ -701,17 +682,17 @@ void FrontService::sendMessage(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
     const std::string& _uuid, bytesConstRef _data, bool isResponse,
     const ReceiveMsgFunc& _receiveMsgCallback)
 {
-    auto message = messageFactory()->buildMessage();
-    message->setModuleID(_moduleID);
-    message->setUuid(bytes(_uuid.begin(), _uuid.end()));
-    message->setPayload(_data);
+    FrontMessage message;
+    message.setModuleID(_moduleID);
+    message.setUuid(bytes(_uuid.begin(), _uuid.end()));
+    message.setPayload(_data);
     if (isResponse)
     {
-        message->setResponse();
+        message.setResponse();
     }
 
     auto buffer = std::make_shared<bytes>();
-    message->encode(*buffer);
+    message.encode(*buffer);
 
     // call gateway interface to send the message
     m_gatewayInterface->asyncSendMessageByNodeID(m_groupID, _moduleID, m_nodeID, std::move(_nodeID),

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -149,10 +149,6 @@ public:
     void onMessageTimeout(const boost::system::error_code& _error, bcos::crypto::NodeIDPtr _nodeID,
         const std::string& _uuid);
 
-    FrontMessageFactory::Ptr messageFactory() const;
-
-    void setMessageFactory(FrontMessageFactory::Ptr _messageFactory);
-
     bcos::crypto::NodeIDPtr nodeID() const;
     void setNodeID(bcos::crypto::NodeIDPtr _nodeID);
     std::string groupID() const;
@@ -222,7 +218,6 @@ private:
     std::shared_ptr<boost::asio::io_context> m_ioService;
     /// gateway interface
     std::shared_ptr<bcos::gateway::GatewayInterface> m_gatewayInterface;
-    FrontMessageFactory::Ptr m_messageFactory;
 
     std::unordered_map<int,
         std::function<void(bcos::crypto::NodeIDPtr, const std::string&, bytesConstRef)>>

--- a/bcos-front/bcos-front/FrontServiceFactory.cpp
+++ b/bcos-front/bcos-front/FrontServiceFactory.cpp
@@ -39,7 +39,6 @@ FrontService::Ptr FrontServiceFactory::buildFrontService(
                     << LOG_KV("groupID", _groupID) << LOG_KV("nodeID", _nodeID->hex());
 
     auto frontService = std::make_shared<FrontService>();
-    frontService->setMessageFactory(std::make_shared<FrontMessageFactory>());
     frontService->setGroupID(_groupID);
     frontService->setNodeID(std::move(_nodeID));
     frontService->setIoService(std::make_shared<boost::asio::io_context>());

--- a/bcos-front/test/unittests/FrontMessageTest.cpp
+++ b/bcos-front/test/unittests/FrontMessageTest.cpp
@@ -31,134 +31,129 @@ BOOST_FIXTURE_TEST_SUITE(FrontMessageTest, TestPromptFixture)
 
 BOOST_AUTO_TEST_CASE(testFrontMessage_0)
 {
-    auto factory = std::make_shared<FrontMessageFactory>();
-    auto message = factory->buildMessage();
-    BOOST_CHECK_EQUAL(message->moduleID(), 0);
-    BOOST_CHECK_EQUAL(message->ext(), 0);
-    BOOST_CHECK_EQUAL(message->uuid().size(), 0);
-    BOOST_CHECK_EQUAL(message->payload().size(), 0);
+    FrontMessage message;
+    BOOST_CHECK_EQUAL(message.moduleID(), 0);
+    BOOST_CHECK_EQUAL(message.ext(), 0);
+    BOOST_CHECK_EQUAL(message.uuid().size(), 0);
+    BOOST_CHECK_EQUAL(message.payload().size(), 0);
 
     std::shared_ptr<bytes> buffer = std::make_shared<bytes>();
-    auto r = message->encode(*buffer);
+    auto r = message.encode(*buffer);
     BOOST_CHECK(r);
     BOOST_CHECK(buffer->size() == FrontMessage::HEADER_MIN_LENGTH);
 }
 
 BOOST_AUTO_TEST_CASE(testFrontMessage_1)
 {
-    auto factory = std::make_shared<FrontMessageFactory>();
-    auto message = factory->buildMessage();
+    FrontMessage message;
     int moduleID = 0;
     int ext = 0;
     std::string uuid = "";
     std::string payload = "";
 
-    message->setModuleID(moduleID);
-    message->setExt(ext);
-    message->setUuid(bytes(uuid.begin(), uuid.end()));
+    message.setModuleID(moduleID);
+    message.setExt(ext);
+    message.setUuid(bytes(uuid.begin(), uuid.end()));
     auto payloadPtr = std::make_shared<bytes>(payload.begin(), payload.end());
-    message->setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
+    message.setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
 
     // encode
     std::shared_ptr<bytes> buffer = std::make_shared<bytes>();
-    auto r = message->encode(*buffer.get());
+    auto r = message.encode(*buffer.get());
     BOOST_CHECK(r);
     BOOST_CHECK(!buffer->empty());
 
     // decode
-    auto decodeMessage = factory->buildMessage();
+    FrontMessage decodeMessage;
 
     auto bcr = bytesConstRef(buffer->data(), buffer->size());
 
-    auto r1 = decodeMessage->decode(bcr);
+    auto r1 = decodeMessage.decode(bcr);
     BOOST_CHECK_EQUAL(r1, MessageDecodeStatus::MESSAGE_COMPLETE);
 
-    BOOST_CHECK_EQUAL(moduleID, decodeMessage->moduleID());
-    BOOST_CHECK_EQUAL(ext, decodeMessage->ext());
+    BOOST_CHECK_EQUAL(moduleID, decodeMessage.moduleID());
+    BOOST_CHECK_EQUAL(ext, decodeMessage.ext());
     BOOST_CHECK_EQUAL(
-        uuid, std::string(decodeMessage->uuid().begin(), decodeMessage->uuid().end()));
+        uuid, std::string(decodeMessage.uuid().begin(), decodeMessage.uuid().end()));
     BOOST_CHECK_EQUAL(
-        payload, std::string(decodeMessage->payload().begin(), decodeMessage->payload().end()));
+        payload, std::string(decodeMessage.payload().begin(), decodeMessage.payload().end()));
 }
 
 BOOST_AUTO_TEST_CASE(testFrontMessage_2)
 {
-    auto factory = std::make_shared<FrontMessageFactory>();
-    auto message = factory->buildMessage();
+    FrontMessage message;
     int moduleID = 1;
     int ext = 2;
     std::string uuid = "1234567890";
     std::string payload = "payload";
 
-    message->setModuleID(moduleID);
-    message->setExt(ext);
-    message->setUuid(bytes(uuid.begin(), uuid.end()));
+    message.setModuleID(moduleID);
+    message.setExt(ext);
+    message.setUuid(bytes(uuid.begin(), uuid.end()));
     auto payloadPtr = std::make_shared<bytes>(payload.begin(), payload.end());
-    message->setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
+    message.setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
 
     // encode
     std::shared_ptr<bytes> buffer = std::make_shared<bytes>();
-    auto r = message->encode(*buffer.get());
+    auto r = message.encode(*buffer.get());
     BOOST_CHECK(r);
     BOOST_CHECK(!buffer->empty());
 
     // decode
-    auto decodeMessage = factory->buildMessage();
+    FrontMessage decodeMessage;
 
     auto bcr = bytesConstRef(buffer->data(), buffer->size());
 
-    auto r1 = decodeMessage->decode(bcr);
+    auto r1 = decodeMessage.decode(bcr);
     BOOST_CHECK_EQUAL(r1, MessageDecodeStatus::MESSAGE_COMPLETE);
 
-    BOOST_CHECK_EQUAL(moduleID, decodeMessage->moduleID());
-    BOOST_CHECK_EQUAL(ext, decodeMessage->ext());
+    BOOST_CHECK_EQUAL(moduleID, decodeMessage.moduleID());
+    BOOST_CHECK_EQUAL(ext, decodeMessage.ext());
     BOOST_CHECK_EQUAL(
-        uuid, std::string(decodeMessage->uuid().begin(), decodeMessage->uuid().end()));
+        uuid, std::string(decodeMessage.uuid().begin(), decodeMessage.uuid().end()));
     BOOST_CHECK_EQUAL(
-        payload, std::string(decodeMessage->payload().begin(), decodeMessage->payload().end()));
+        payload, std::string(decodeMessage.payload().begin(), decodeMessage.payload().end()));
 }
 
 BOOST_AUTO_TEST_CASE(testFrontMessage_3)
 {
-    auto factory = std::make_shared<FrontMessageFactory>();
-    auto message = factory->buildMessage();
+    FrontMessage message;
     int moduleID = 1;
     int ext = 2;
     std::string uuid = "1234567890";
     std::string payload = "payload";
 
-    message->setModuleID(moduleID);
-    message->setExt(ext);
-    message->setUuid(bytes(uuid.begin(), uuid.end()));
+    message.setModuleID(moduleID);
+    message.setExt(ext);
+    message.setUuid(bytes(uuid.begin(), uuid.end()));
     auto payloadPtr = std::make_shared<bytes>(payload.begin(), payload.end());
-    message->setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
+    message.setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
 
     // encode
     std::shared_ptr<bytes> buffer = std::make_shared<bytes>();
-    auto r = message->encode(*buffer.get());
+    auto r = message.encode(*buffer.get());
     BOOST_CHECK(r);
     BOOST_CHECK(!buffer->empty());
 
     // decode
-    auto decodeMessage = factory->buildMessage();
+    FrontMessage decodeMessage;
 
     auto bcr = bytesConstRef(buffer->data(), buffer->size());
 
-    auto r1 = decodeMessage->decode(bcr);
+    auto r1 = decodeMessage.decode(bcr);
     BOOST_CHECK_EQUAL(r1, MessageDecodeStatus::MESSAGE_COMPLETE);
 
-    BOOST_CHECK_EQUAL(moduleID, decodeMessage->moduleID());
-    BOOST_CHECK_EQUAL(ext, decodeMessage->ext());
+    BOOST_CHECK_EQUAL(moduleID, decodeMessage.moduleID());
+    BOOST_CHECK_EQUAL(ext, decodeMessage.ext());
     BOOST_CHECK_EQUAL(
-        uuid, std::string(decodeMessage->uuid().begin(), decodeMessage->uuid().end()));
+        uuid, std::string(decodeMessage.uuid().begin(), decodeMessage.uuid().end()));
     BOOST_CHECK_EQUAL(
-        payload, std::string(decodeMessage->payload().begin(), decodeMessage->payload().end()));
+        payload, std::string(decodeMessage.payload().begin(), decodeMessage.payload().end()));
 }
 
 BOOST_AUTO_TEST_CASE(testFrontMessage_4)
 {
-    auto factory = std::make_shared<FrontMessageFactory>();
-    auto message = factory->buildMessage();
+    FrontMessage message;
     int moduleID = 1;
     int ext = 2;
     std::string uuid =
@@ -185,46 +180,45 @@ BOOST_AUTO_TEST_CASE(testFrontMessage_4)
         "8";
     std::string payload = "payload";
 
-    message->setModuleID(moduleID);
-    message->setExt(ext);
-    message->setUuid(bytes(uuid.begin(), uuid.end()));
+    message.setModuleID(moduleID);
+    message.setExt(ext);
+    message.setUuid(bytes(uuid.begin(), uuid.end()));
     auto payloadPtr = std::make_shared<bytes>(payload.begin(), payload.end());
-    message->setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
+    message.setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
 
     // encode
     std::shared_ptr<bytes> buffer = std::make_shared<bytes>();
-    auto r = message->encode(*buffer);
+    auto r = message.encode(*buffer);
     BOOST_CHECK(!r);
 
     buffer->clear();
-    auto decodeMessage = factory->buildMessage();
-    auto r1 = decodeMessage->decode(bytesConstRef(buffer->data(), buffer->size()));
+    FrontMessage decodeMessage;
+    auto r1 = decodeMessage.decode(bytesConstRef(buffer->data(), buffer->size()));
     BOOST_CHECK_EQUAL(r1, MessageDecodeStatus::MESSAGE_ERROR);
 }
 
 BOOST_AUTO_TEST_CASE(testFrontMessage_5)
 {
-    auto factory = std::make_shared<FrontMessageFactory>();
-    auto message = factory->buildMessage();
+    FrontMessage message;
     int moduleID = 111;
     std::string uuid;
     std::string payload = std::string(1000, 'x');
 
-    message->setModuleID(moduleID);
-    message->setUuid(bytes(uuid.begin(), uuid.end()));
+    message.setModuleID(moduleID);
+    message.setUuid(bytes(uuid.begin(), uuid.end()));
     auto payloadPtr = std::make_shared<bytes>(payload.begin(), payload.end());
-    message->setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
+    message.setPayload(bytesConstRef(payloadPtr->data(), payloadPtr->size()));
 
     // encode
     std::shared_ptr<bytes> buffer = std::make_shared<bytes>();
-    auto r = message->encode(*buffer.get());
+    auto r = message.encode(*buffer.get());
     BOOST_CHECK(r);
 
-    auto decodeMessage = factory->buildMessage();
-    auto r1 = decodeMessage->decode(bytesConstRef(buffer->data(), buffer->size()));
+    FrontMessage decodeMessage;
+    auto r1 = decodeMessage.decode(bytesConstRef(buffer->data(), buffer->size()));
     BOOST_CHECK_EQUAL(r1, MessageDecodeStatus::MESSAGE_COMPLETE);
     BOOST_CHECK_EQUAL(
-        payload, std::string(decodeMessage->payload().begin(), decodeMessage->payload().end()));
+        payload, std::string(decodeMessage.payload().begin(), decodeMessage.payload().end()));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -75,7 +75,6 @@ BOOST_AUTO_TEST_CASE(testFrontService_buildFrontService)
     BOOST_CHECK_EQUAL(frontService->groupID(), g_groupID);
     // BOOST_CHECK_EQUAL(frontService->nodeID()->hex(), g_srcNodeID);
     BOOST_CHECK(frontService->gatewayInterface());
-    BOOST_CHECK(frontService->messageFactory());
     BOOST_CHECK(frontService->ioService());
     BOOST_CHECK(frontService->callback().empty());
     BOOST_CHECK(frontService->moduleID2MessageDispatcher().empty());
@@ -185,7 +184,6 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDcmak_timeout)
 {
     auto frontService = buildFrontService();
     auto gateway = std::static_pointer_cast<FakeGateway>(frontService->gatewayInterface());
-    auto message = frontService->messageFactory()->buildMessage();
 
     int moduleID = 222;
     auto dstNodeID = createKey(g_dstNodeID_0);
@@ -281,7 +279,6 @@ BOOST_AUTO_TEST_CASE(testFrontService_loopTimeout)
 {
     auto frontService = buildFrontService();
     auto gateway = std::static_pointer_cast<FakeGateway>(frontService->gatewayInterface());
-    auto message = frontService->messageFactory()->buildMessage();
 
     int moduleID = 12345;
     auto dstNodeID = createKey(g_dstNodeID_0);

--- a/lightnode/fisco-bcos-lightnode/main.cpp
+++ b/lightnode/fisco-bcos-lightnode/main.cpp
@@ -237,7 +237,6 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
 
 
     // front
-    front->setMessageFactory(std::make_shared<bcos::front::FrontMessageFactory>());
     front->setGroupID(nodeConfig->groupId());
     front->setNodeID(protocolInitializer.keyPair()->publicKey());
     front->setIoService(std::make_shared<boost::asio::io_context>());


### PR DESCRIPTION
Eliminate the `FrontMessage::Ptr` and `FrontMessageFactory`, simplifying the message handling in the front service. This change enhances code clarity and reduces unnecessary complexity.