### PR TITLE
Remove boost::bind and std::bind

### DIFF
--- a/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.h
@@ -28,7 +28,6 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <memory>
 #include <string>
-#include <utility>
 
 namespace bcos::boostssl::ws
 {

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
@@ -121,7 +121,6 @@ public:
     bool needCheckRspPacket() const;
     void setNeedCheckRspPacket(bool _needCheckRespPacket);
 
-public:
     struct CallBack : public bcos::ObjectCounter<CallBack>
     {
         using Ptr = std::shared_ptr<CallBack>;

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -82,16 +82,16 @@ GatewayNodeManager::GatewayNodeManager(std::string const& _uuid, P2pID const& _n
     m_p2pInterface = _p2pInterface;
     // SyncNodeSeq
     m_p2pInterface->registerHandlerByMsgType(GatewayMessageType::SyncNodeSeq,
-        boost::bind(&GatewayNodeManager::onReceiveStatusSeq, this, boost::placeholders::_1,
-            boost::placeholders::_2, boost::placeholders::_3));
+        [this](NetworkException const& _e, P2PSession::Ptr _session,
+            std::shared_ptr<P2PMessage> _msg) { onReceiveStatusSeq(_e, _session, std::move(_msg)); });
     // RequestNodeStatus
     m_p2pInterface->registerHandlerByMsgType(GatewayMessageType::RequestNodeStatus,
-        boost::bind(&GatewayNodeManager::onRequestNodeStatus, this, boost::placeholders::_1,
-            boost::placeholders::_2, boost::placeholders::_3));
+        [this](NetworkException const& _e, P2PSession::Ptr _session,
+            std::shared_ptr<P2PMessage> _msg) { onRequestNodeStatus(_e, _session, std::move(_msg)); });
     // ResponseNodeStatus
     m_p2pInterface->registerHandlerByMsgType(GatewayMessageType::ResponseNodeStatus,
-        boost::bind(&GatewayNodeManager::onReceiveNodeStatus, this, boost::placeholders::_1,
-            boost::placeholders::_2, boost::placeholders::_3));
+        [this](NetworkException const& _e, P2PSession::Ptr _session,
+            std::shared_ptr<P2PMessage> _msg) { onReceiveNodeStatus(_e, _session, std::move(_msg)); });
     m_timer = std::make_shared<Timer>(SEQ_SYNC_PERIOD, "seqSync");
     // broadcast seq periodically
     m_timer->registerTimeoutHandler([this]() { broadcastStatusSeq(); });

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -25,7 +25,6 @@
 #include "bcos-framework/protocol/CommonError.h"
 #include "bcos-gateway/libamop/AMOPMessage.h"
 #include "bcos-gateway/libnetwork/Common.h"
-#include <boost/bind/bind.hpp>
 using namespace bcos;
 using namespace bcos::gateway;
 using namespace bcos::amop;
@@ -52,8 +51,10 @@ AMOPImpl::AMOPImpl(TopicManager::Ptr _topicManager,
     m_timer->registerTimeoutHandler([this]() { broadcastTopicSeq(); });
 
     m_network->registerHandlerByMsgType(GatewayMessageType::AMOPMessageType,
-        boost::bind(&AMOPImpl::onAMOPMessage, this, boost::placeholders::_1,
-            boost::placeholders::_2, boost::placeholders::_3));
+        [this](bcos::gateway::NetworkException const& _e, bcos::gateway::P2PSession::Ptr _session,
+            std::shared_ptr<bcos::gateway::P2PMessage> _message) {
+            onAMOPMessage(_e, std::move(_session), std::move(_message));
+        });
 }
 
 void AMOPImpl::start()

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -79,8 +79,10 @@ void Host::startAccept(boost::system::error_code boost_error)
                 std::shared_ptr<std::string> endpointPublicKey = std::make_shared<std::string>();
                 m_asioInterface->setVerifyCallback(socket, newVerifyCallback(endpointPublicKey));
                 m_asioInterface->asyncHandshake(socket, ba::ssl::stream_base::server,
-                    boost::bind(&Host::handshakeServer, shared_from_this(), ba::placeholders::error,
-                        endpointPublicKey, socket));
+                    [self = shared_from_this(), endpointPublicKey, socket](
+                        const boost::system::error_code& error) {
+                        self->handshakeServer(error, endpointPublicKey, socket);
+                    });
 
                 startAccept();
             },

--- a/bcos-leader-election/src/ElectionConfig.h
+++ b/bcos-leader-election/src/ElectionConfig.h
@@ -22,7 +22,6 @@
 #include "Common.h"
 #include <bcos-framework/protocol/MemberInterface.h>
 #include <bcos-utilities/Timer.h>
-#include <boost/bind/bind.hpp>
 #include <etcd/Client.hpp>
 #include <etcd/Watcher.hpp>
 

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -22,7 +22,6 @@
 #include "bcos-task/Wait.h"
 #include <bcos-framework/protocol/CommonError.h>
 #include <bcos-framework/protocol/Protocol.h>
-#include <boost/bind/bind.hpp>
 #include <utility>
 
 using namespace bcos;
@@ -209,8 +208,7 @@ void PBFTCacheProcessor::addCache(
     if (!_pbftCache.contains(index))
     {
         _pbftCache[index] = m_cacheFactory->createPBFTCache(m_config, index,
-            boost::bind(
-                &PBFTCacheProcessor::notifyCommittedProposalIndex, this, boost::placeholders::_1));
+            [this](bcos::protocol::BlockNumber _index) { notifyCommittedProposalIndex(_index); });
     }
     _handler(_pbftCache[index], _pbftReq);
 }

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -33,7 +33,6 @@
 #include <bcos-framework/protocol/Protocol.h>
 #include <bcos-utilities/ITTAPI.h>
 #include <bcos-utilities/ThreadPool.h>
-#include <boost/bind/bind.hpp>
 #include <utility>
 
 using namespace bcos;
@@ -50,9 +49,11 @@ PBFTEngine::PBFTEngine(PBFTConfig::Ptr _config)
     m_cacheProcessor = std::make_shared<PBFTCacheProcessor>(cacheFactory, _config);
     m_logSync = std::make_shared<PBFTLogSync>(m_config, m_cacheProcessor);
     // register the timeout function
-    m_config->timer()->registerTimeoutHandler(boost::bind(&PBFTEngine::onTimeout, this));
-    m_config->storage()->registerFinalizeHandler(boost::bind(
-        &PBFTEngine::finalizeConsensus, this, boost::placeholders::_1, boost::placeholders::_2));
+    m_config->timer()->registerTimeoutHandler([this]() { onTimeout(); });
+    m_config->storage()->registerFinalizeHandler(
+        [this](std::shared_ptr<bcos::ledger::LedgerConfig> _ledgerConfig, bool _syncedBlock) {
+            finalizeConsensus(std::move(_ledgerConfig), _syncedBlock);
+        });
 
     m_config->storage()->registerOnStableCheckPointCommitFailed(
         [this](Error::Ptr&& _error, PBFTProposalInterface::Ptr _stableProposal) {
@@ -60,12 +61,16 @@ PBFTEngine::PBFTEngine(PBFTConfig::Ptr _config)
         });
 
     m_config->registerFastViewChangeHandler([this]() { triggerTimeout(false); });
-    m_cacheProcessor->registerProposalAppliedHandler(boost::bind(&PBFTEngine::onProposalApplied,
-        this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+    m_cacheProcessor->registerProposalAppliedHandler(
+        [this](int64_t _errorCode, PBFTProposalInterface::Ptr _proposal,
+            PBFTProposalInterface::Ptr _executedProposal) {
+            onProposalApplied(_errorCode, std::move(_proposal), std::move(_executedProposal));
+        });
 
     m_cacheProcessor->registerOnLoadAndVerifyProposalFinish(
-        boost::bind(&PBFTEngine::onLoadAndVerifyProposalFinish, this, boost::placeholders::_1,
-            boost::placeholders::_2, boost::placeholders::_3));
+        [this](bool _verifyResult, Error::Ptr _error, PBFTProposalInterface::Ptr _proposal) {
+            onLoadAndVerifyProposalFinish(_verifyResult, _error, _proposal);
+        });
     initSendResponseHandler();
     // when the node first setup, set timeout to be true for view recovery
     // set timeout to be true to in case of notify-seal before the PBFTEngine

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -34,7 +34,6 @@
 #include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
 #include <bcos-table/src/StateStorage.h>
 #include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
-#include <boost/bind/bind.hpp>
 #include <boost/test/unit_test.hpp>
 #include <chrono>
 #include <thread>
@@ -130,11 +129,14 @@ public:
         m_cacheProcessor = std::make_shared<FakeCacheProcessor>(cacheFactory, _config);
         m_logSync = std::make_shared<PBFTLogSync>(_config, m_cacheProcessor);
         m_cacheProcessor->registerProposalAppliedHandler(
-            boost::bind(&FakePBFTEngine::onProposalApplied, this, boost::placeholders::_1,
-                boost::placeholders::_2, boost::placeholders::_3));
+            [this](int64_t _errorCode, PBFTProposalInterface::Ptr _proposal,
+                PBFTProposalInterface::Ptr _executedProposal) {
+                onProposalApplied(_errorCode, std::move(_proposal), std::move(_executedProposal));
+            });
         m_cacheProcessor->registerOnLoadAndVerifyProposalFinish(
-            boost::bind(&FakePBFTEngine::onLoadAndVerifyProposalFinish, this,
-                boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3));
+            [this](bool _verifyResult, Error::Ptr _error, PBFTProposalInterface::Ptr _proposal) {
+                onLoadAndVerifyProposalFinish(_verifyResult, _error, _proposal);
+            });
         initSendResponseHandler();
         _config->enableAsMasterNode(true);
     }

--- a/bcos-rpc/bcos-rpc/Rpc.cpp
+++ b/bcos-rpc/bcos-rpc/Rpc.cpp
@@ -66,8 +66,10 @@ Rpc::Rpc(std::shared_ptr<boostssl::ws::WsService> _wsService,
 
     // handshake msgHandler
     m_wsService->registerMsgHandler(bcos::protocol::MessageType::HANDSHAKE,
-        boost::bind(
-            &Rpc::onRecvHandshakeRequest, this, boost::placeholders::_1, boost::placeholders::_2));
+        [this](std::shared_ptr<boostssl::MessageFace> _msg,
+            std::shared_ptr<boostssl::ws::WsSession> _session) {
+            onRecvHandshakeRequest(std::move(_msg), std::move(_session));
+        });
 }
 
 void Rpc::start()

--- a/bcos-rpc/bcos-rpc/amop/AMOPClient.cpp
+++ b/bcos-rpc/bcos-rpc/amop/AMOPClient.cpp
@@ -39,16 +39,25 @@ using namespace bcos::protocol;
 void AMOPClient::initMsgHandler()
 {
     m_wsService->registerMsgHandler(AMOPClientMessageType::AMOP_SUBTOPIC,
-        boost::bind(
-            &AMOPClient::onRecvSubTopics, this, boost::placeholders::_1, boost::placeholders::_2));
+        [this](std::shared_ptr<boostssl::MessageFace> _msg,
+            std::shared_ptr<boostssl::ws::WsSession> _session) {
+            onRecvSubTopics(std::move(_msg), std::move(_session));
+        });
     m_wsService->registerMsgHandler(
-        AMOPClientMessageType::AMOP_REQUEST, boost::bind(&AMOPClient::onRecvAMOPRequest, this,
-                                                 boost::placeholders::_1, boost::placeholders::_2));
+        AMOPClientMessageType::AMOP_REQUEST,
+        [this](std::shared_ptr<boostssl::MessageFace> _msg,
+            std::shared_ptr<boostssl::ws::WsSession> _session) {
+            onRecvAMOPRequest(std::move(_msg), std::move(_session));
+        });
     m_wsService->registerMsgHandler(AMOPClientMessageType::AMOP_BROADCAST,
-        boost::bind(&AMOPClient::onRecvAMOPBroadcast, this, boost::placeholders::_1,
-            boost::placeholders::_2));
+        [this](std::shared_ptr<boostssl::MessageFace> _msg,
+            std::shared_ptr<boostssl::ws::WsSession> _session) {
+            onRecvAMOPBroadcast(std::move(_msg), std::move(_session));
+        });
     m_wsService->registerDisconnectHandler(
-        boost::bind(&AMOPClient::onClientDisconnect, this, boost::placeholders::_1));
+        [this](std::shared_ptr<boostssl::ws::WsSession> _session) {
+            onClientDisconnect(std::move(_session));
+        });
 }
 
 bool AMOPClient::updateTopicInfos(

--- a/bcos-rpc/bcos-rpc/event/EventSub.cpp
+++ b/bcos-rpc/bcos-rpc/event/EventSub.cpp
@@ -37,11 +37,15 @@ EventSub::EventSub(std::shared_ptr<boostssl::ws::WsService> _wsService)
   : bcos::Worker("t_event_sub"), m_wsService(_wsService)
 {
     m_wsService->registerMsgHandler(bcos::protocol::MessageType::EVENT_SUBSCRIBE,
-        boost::bind(&EventSub::onRecvSubscribeEvent, this, boost::placeholders::_1,
-            boost::placeholders::_2));
+        [this](std::shared_ptr<bcos::boostssl::MessageFace> _msg,
+            std::shared_ptr<bcos::boostssl::ws::WsSession> _session) {
+            onRecvSubscribeEvent(std::move(_msg), std::move(_session));
+        });
     m_wsService->registerMsgHandler(bcos::protocol::MessageType::EVENT_UNSUBSCRIBE,
-        boost::bind(&EventSub::onRecvUnsubscribeEvent, this, boost::placeholders::_1,
-            boost::placeholders::_2));
+        [this](std::shared_ptr<bcos::boostssl::MessageFace> _msg,
+            std::shared_ptr<bcos::boostssl::ws::WsSession> _session) {
+            onRecvUnsubscribeEvent(std::move(_msg), std::move(_session));
+        });
 }
 
 void EventSub::start()

--- a/bcos-scheduler/src/ExecutorManager.h
+++ b/bcos-scheduler/src/ExecutorManager.h
@@ -55,14 +55,22 @@ public:
 
     auto begin() const
     {
-        return boost::make_transform_iterator(m_name2Executors.cbegin(),
-            std::bind(&ExecutorManager::executorView, this, std::placeholders::_1));
+        return boost::make_transform_iterator(
+            m_name2Executors.cbegin(),
+            +[](const decltype(m_name2Executors)::value_type& value)
+                -> bcos::executor::ParallelTransactionExecutorInterface::Ptr const& {
+                return value.second->executor;
+            });
     }
 
     auto end() const
     {
-        return boost::make_transform_iterator(m_name2Executors.cend(),
-            std::bind(&ExecutorManager::executorView, this, std::placeholders::_1));
+        return boost::make_transform_iterator(
+            m_name2Executors.cend(),
+            +[](const decltype(m_name2Executors)::value_type& value)
+                -> bcos::executor::ParallelTransactionExecutorInterface::Ptr const& {
+                return value.second->executor;
+            });
     }
 
     void forEachExecutor(

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -27,7 +27,6 @@
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "bcos-ledger/LedgerMethods.h"
 #include <json/json.h>
-#include <boost/bind/bind.hpp>
 #include <range/v3/algorithm/for_each.hpp>
 #include <range/v3/algorithm/sort.hpp>
 #include <string>

--- a/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
+++ b/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
@@ -262,7 +262,7 @@ boost::shared_ptr<bcos::BoostLogInitializer::sink_t> BoostLogInitializer::initHo
     boost::shared_ptr<sink_t> sink(new sink_t());
     sink->locked_backend()->set_open_mode(std::ios::ate);
     sink->locked_backend()->set_time_based_rotation(
-        boost::bind(&BoostLogInitializer::canRotate, this, (m_currentHourVec.size() - 1)));
+        [this, index = (m_currentHourVec.size() - 1)]() { return canRotate(index); });
 
     sink->locked_backend()->set_file_name_pattern(fileName);
     /// set rotation size MB

--- a/libinitializer/ProPBFTInitializer.cpp
+++ b/libinitializer/ProPBFTInitializer.cpp
@@ -135,7 +135,7 @@ void ProPBFTInitializer::onGroupInfoChanged()
 
 void ProPBFTInitializer::init()
 {
-    m_timer->registerTimeoutHandler(boost::bind(&ProPBFTInitializer::scheduledTask, this));
+    m_timer->registerTimeoutHandler([this]() { scheduledTask(); });
     m_blockSync->config()->registerOnNodeTypeChanged([this](bcos::protocol::NodeType _type) {
         INITIALIZER_LOG(INFO) << LOG_DESC("OnNodeTypeChange") << LOG_KV("type", _type)
                               << LOG_KV("nodeName", m_nodeConfig->nodeName());


### PR DESCRIPTION
Eliminate the use of `boost::bind` and `std::bind` throughout the codebase, replacing them with lambda expressions for improved readability and modern C++ practices.