### PR TITLE
fix(pbft): Validator.cpp txs reset/mark lifecycle + hash strictness (FIB-141, 143, 144, 149)

### DIFF
--- a/bcos-pbft/bcos-pbft/core/Proposal.h
+++ b/bcos-pbft/bcos-pbft/core/Proposal.h
@@ -138,7 +138,11 @@ protected:
     virtual void deserializeObject()
     {
         auto const& hashData = m_rawProposal->hash();
-        if (hashData.size() < bcos::crypto::HashType::SIZE)
+        // FIB-149: reject any non-canonical hash length (oversize OR undersize).
+        // Pre-fix used `<`, which silently truncated oversize input to the
+        // first 32 bytes — accepting non-canonical encodings as valid identity
+        // keys.
+        if (hashData.size() != bcos::crypto::HashType::SIZE)
         {
             return;
         }

--- a/bcos-pbft/bcos-pbft/pbft/engine/Validator.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/Validator.cpp
@@ -19,6 +19,7 @@
  * @date 2021-04-21
  */
 #include "Validator.h"
+#include <bcos-framework/protocol/CommonError.h>
 using namespace bcos;
 using namespace bcos::consensus;
 using namespace bcos::crypto;
@@ -138,6 +139,26 @@ void TxsValidator::asyncResetTxsFlag(
                 PBFT_LOG(WARNING) << LOG_DESC("asyncMarkTxs failed")
                                   << LOG_KV("code", _error->errorCode())
                                   << LOG_KV("msg", _error->errorMessage());
+                // FIB-144: TransactionsMissing is a transient / recoverable
+                // failure (txpool didn't have all referenced txs yet). Without
+                // a removal here insertResettingProposal in a later
+                // asyncResetTxsFlag would return false and suppress every
+                // retry — a byzantine leader could permanently halt sealing
+                // by submitting a proposal with unknown tx hashes. Removing
+                // the hash lets the next PrePrepare for the same proposal
+                // (e.g. via view change) re-trigger marking once the data
+                // arrives. Other errors keep the FIB-143 retain-on-failure
+                // semantics.
+                if (_flag &&
+                    _error->errorCode() == bcos::protocol::CommonError::TransactionsMissing)
+                {
+                    validator->eraseResettingProposal(proposalHash);
+                    PBFT_LOG(INFO) << LOG_DESC(
+                                          "FIB-144: TransactionsMissing - removed proposal from "
+                                          "resetting set, awaiting data arrival")
+                                   << LOG_KV("hash", proposalHash.abridged())
+                                   << LOG_KV("index", proposalNumber);
+                }
                 return;
             }
             // success: clear our reset request before sealing the next block

--- a/bcos-pbft/bcos-pbft/pbft/engine/Validator.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/Validator.cpp
@@ -129,27 +129,26 @@ void TxsValidator::asyncResetTxsFlag(
             {
                 return;
             }
-            // must ensure asyncResetTxsFlag success before seal new next blocks
+            // FIB-143: check _error FIRST. Erase the proposal from
+            // m_resettingProposals only on success. On failure, leave the hash
+            // in place so verifyCompletedHook does NOT fire and sealing stays
+            // gated on the unfinished reset.
+            if (_error != nullptr)
+            {
+                PBFT_LOG(WARNING) << LOG_DESC("asyncMarkTxs failed")
+                                  << LOG_KV("code", _error->errorCode())
+                                  << LOG_KV("msg", _error->errorMessage());
+                return;
+            }
+            // success: clear our reset request before sealing the next block
             if (_flag)
             {
                 validator->eraseResettingProposal(proposalHash);
             }
-            if (_error == nullptr)
-            {
-                PBFT_LOG(INFO) << LOG_DESC("asyncMarkTxs success")
-                               << LOG_KV("index", proposalNumber)
-                               << LOG_KV("hash", proposalHash.abridged()) << LOG_KV("flag", _flag)
-                               << LOG_KV("markT", utcSteadyTime() - startT)
-                               << LOG_KV("emptyTxBatchHash", _emptyTxBatchHash);
-                return;
-            }
-            PBFT_LOG(WARNING) << LOG_DESC("asyncMarkTxs failed")
-                              << LOG_KV("code", _error->errorCode())
-                              << LOG_KV("msg", _error->errorMessage());
-            if (_flag)
-            {
-                validator->insertResettingProposal(proposalHash);
-            }
+            PBFT_LOG(INFO) << LOG_DESC("asyncMarkTxs success") << LOG_KV("index", proposalNumber)
+                           << LOG_KV("hash", proposalHash.abridged()) << LOG_KV("flag", _flag)
+                           << LOG_KV("markT", utcSteadyTime() - startT)
+                           << LOG_KV("emptyTxBatchHash", _emptyTxBatchHash);
         });
 }
 

--- a/bcos-pbft/bcos-pbft/pbft/engine/Validator.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/Validator.cpp
@@ -72,6 +72,29 @@ void TxsValidator::asyncResetTxsFlag(
     const protocol::Block& proposal, bool _flag, bool _emptyTxBatchHash)
 {
     auto blockHeader = proposal.blockHeader();
+    // FIB-141: build the tx-hash list FIRST so empty blocks and
+    // exception-throwing blocks bail out before m_resettingProposals is
+    // populated. Inserting the proposal hash up front would permanently strand
+    // it whenever the list build is empty or throws — PBFTConfig::notifySealer()
+    // gates sealing on resettingProposalSize() and would never unblock.
+    HashList txsHash;
+    try
+    {
+        for (size_t i = 0; i < proposal.transactionsHashSize(); i++)
+        {
+            txsHash.emplace_back(proposal.transactionHash(i));
+        }
+    }
+    catch (std::exception const& e)
+    {
+        PBFT_LOG(WARNING) << LOG_DESC("asyncResetTxsFlag buildHashList exception")
+                          << LOG_KV("message", boost::diagnostic_information(e));
+        return;
+    }
+    if (txsHash.empty())
+    {
+        return;
+    }
     if (_flag)
     {
         // already has the reset request
@@ -80,26 +103,9 @@ void TxsValidator::asyncResetTxsFlag(
             return;
         }
     }
-    try
-    {
-        HashList txsHash;
-        for (size_t i = 0; i < proposal.transactionsHashSize(); i++)
-        {
-            txsHash.emplace_back(proposal.transactionHash(i));
-        }
-        if (txsHash.empty())
-        {
-            return;
-        }
-        PBFT_LOG(INFO) << LOG_DESC("asyncResetTxsFlag") << LOG_KV("index", blockHeader->number())
-                       << LOG_KV("hash", blockHeader->hash().abridged()) << LOG_KV("flag", _flag);
-        asyncResetTxsFlag(proposal, txsHash, _flag, _emptyTxBatchHash);
-    }
-    catch (std::exception const& e)
-    {
-        PBFT_LOG(WARNING) << LOG_DESC("asyncResetTxsFlag exception")
-                          << LOG_KV("message", boost::diagnostic_information(e));
-    }
+    PBFT_LOG(INFO) << LOG_DESC("asyncResetTxsFlag") << LOG_KV("index", blockHeader->number())
+                   << LOG_KV("hash", blockHeader->hash().abridged()) << LOG_KV("flag", _flag);
+    asyncResetTxsFlag(proposal, txsHash, _flag, _emptyTxBatchHash);
 }
 
 void TxsValidator::asyncResetTxsFlag(
@@ -130,7 +136,8 @@ void TxsValidator::asyncResetTxsFlag(
             }
             if (_error == nullptr)
             {
-                PBFT_LOG(INFO) << LOG_DESC("asyncMarkTxs success") << LOG_KV("index", proposalNumber)
+                PBFT_LOG(INFO) << LOG_DESC("asyncMarkTxs success")
+                               << LOG_KV("index", proposalNumber)
                                << LOG_KV("hash", proposalHash.abridged()) << LOG_KV("flag", _flag)
                                << LOG_KV("markT", utcSteadyTime() - startT)
                                << LOG_KV("emptyTxBatchHash", _emptyTxBatchHash);

--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTBaseMessage.h
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTBaseMessage.h
@@ -135,15 +135,19 @@ public:
 protected:
     virtual void deserializeToObject()
     {
+        // FIB-149: only accept canonical-length hash payloads. Pre-fix `>=`
+        // accepted oversize bytes too, silently truncating them to 32 bytes
+        // and corrupting hash-as-identity-key semantics. Strict equality leaves
+        // m_hash / m_dataHash default-constructed when the payload is malformed.
         auto const& hashData = m_baseMessage->hash();
-        if (hashData.size() >= bcos::crypto::HashType::SIZE)
+        if (hashData.size() == bcos::crypto::HashType::SIZE)
         {
             m_hash =
                 bcos::crypto::HashType((byte const*)hashData.c_str(), bcos::crypto::HashType::SIZE);
         }
 
         auto const& signatureDataHash = m_baseMessage->signaturehash();
-        if (signatureDataHash.size() >= bcos::crypto::HashType::SIZE)
+        if (signatureDataHash.size() == bcos::crypto::HashType::SIZE)
         {
             m_dataHash = bcos::crypto::HashType(
                 (byte const*)signatureDataHash.c_str(), bcos::crypto::HashType::SIZE);

--- a/bcos-pbft/test/unittests/FIB141_ResettingProposalsLifecycleTest.cpp
+++ b/bcos-pbft/test/unittests/FIB141_ResettingProposalsLifecycleTest.cpp
@@ -1,0 +1,204 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-141: m_resettingProposals must NOT be
+ *        populated until the tx-hash list has been built and confirmed
+ *        non-empty. Empty blocks or exception-throwing blocks must leave
+ *        m_resettingProposals untouched, otherwise PBFTConfig::notifySealer()
+ *        is permanently blocked.
+ * @file FIB141_ResettingProposalsLifecycleTest.cpp
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeTxPool.h"
+#include "bcos-pbft/pbft/engine/Validator.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+#include <stdexcept>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+/// Helper: create a default crypto suite (Keccak256 + Secp256k1).
+inline CryptoSuite::Ptr makeCryptoSuite()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signImpl = std::make_shared<Secp256k1Crypto>();
+    return std::make_shared<CryptoSuite>(hashImpl, signImpl, nullptr);
+}
+
+/// Helper: create a TxsValidator with a default txpool/blockfactory.
+inline TxsValidator::Ptr makeTxsValidator()
+{
+    auto cryptoSuite = makeCryptoSuite();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto txPool = std::make_shared<FakeTxPool>();
+    auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
+    return std::make_shared<TxsValidator>(txPool, blockFactory, txResultFactory);
+}
+
+/// Helper: create a Block with no transactions but a valid header.
+inline Block::Ptr makeBlockWithNoTxs(BlockNumber _number)
+{
+    auto cryptoSuite = makeCryptoSuite();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto block = blockFactory->createBlock();
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(_number);
+    header->calculateHash(*cryptoSuite->hashImpl());
+    block->setBlockHeader(header);
+    return block;
+}
+
+/// A Block subclass that throws while accessing transaction hashes — models
+/// a malformed block that triggers an exception inside the tx-hash loop in
+/// TxsValidator::asyncResetTxsFlag.
+class ThrowingBlock : public Block
+{
+public:
+    explicit ThrowingBlock(Block::Ptr _delegate) : m_delegate(std::move(_delegate)) {}
+
+    // The methods exercised by asyncResetTxsFlag — make transactionHash throw.
+    uint64_t transactionsHashSize() const override { return 3; }
+    HashType transactionHash(uint64_t /*_index*/) const override
+    {
+        throw std::runtime_error("FIB-141 throwing-block: transactionHash failure");
+    }
+    BlockHeader::Ptr blockHeader() override { return m_delegate->blockHeader(); }
+    AnyBlockHeader blockHeader() const override
+    {
+        // Forward to the const overload on the delegate.
+        return std::as_const(*m_delegate).blockHeader();
+    }
+
+    // Other Block methods are not exercised by asyncResetTxsFlag(Block, bool, bool);
+    // forward to a real block where possible to keep the impl trivial.
+    void decode(bytesConstRef _data, bool _calculateHash, bool _checkSig) override
+    {
+        m_delegate->decode(_data, _calculateHash, _checkSig);
+    }
+    void encode(bytes& _encodeData) const override { m_delegate->encode(_encodeData); }
+    HashType calculateTransactionRoot(const bcos::crypto::Hash& hashImpl) const override
+    {
+        return m_delegate->calculateTransactionRoot(hashImpl);
+    }
+    HashType calculateReceiptRoot(const bcos::crypto::Hash& hashImpl) const override
+    {
+        return m_delegate->calculateReceiptRoot(hashImpl);
+    }
+    int32_t version() const override { return m_delegate->version(); }
+    void setVersion(int32_t v) override { m_delegate->setVersion(v); }
+    BlockType blockType() const override { return m_delegate->blockType(); }
+    void setBlockType(BlockType t) override { m_delegate->setBlockType(t); }
+    void setBlockHeader(BlockHeader::Ptr h) override { m_delegate->setBlockHeader(h); }
+    void setTransaction(uint64_t i, Transaction::Ptr t) override
+    {
+        m_delegate->setTransaction(i, t);
+    }
+    void appendTransaction(Transaction::Ptr t) override { m_delegate->appendTransaction(t); }
+    void setReceipt(uint64_t i, TransactionReceipt::Ptr r) override
+    {
+        m_delegate->setReceipt(i, r);
+    }
+    void appendReceipt(TransactionReceipt::Ptr r) override { m_delegate->appendReceipt(r); }
+    void appendTransactionMetaData(TransactionMetaData::Ptr m) override
+    {
+        m_delegate->appendTransactionMetaData(m);
+    }
+    uint64_t transactionsSize() const override { return m_delegate->transactionsSize(); }
+    uint64_t transactionsMetaDataSize() const override
+    {
+        return m_delegate->transactionsMetaDataSize();
+    }
+    uint64_t receiptsSize() const override { return m_delegate->receiptsSize(); }
+    void setNonceList(::ranges::any_view<std::string> n) override { m_delegate->setNonceList(n); }
+    ::ranges::any_view<std::string> nonceList() const override { return m_delegate->nonceList(); }
+    ViewResult<HashType> transactionHashes() const override
+    {
+        return m_delegate->transactionHashes();
+    }
+    ViewResult<AnyTransactionMetaData> transactionMetaDatas() const override
+    {
+        return m_delegate->transactionMetaDatas();
+    }
+    ViewResult<AnyTransaction> transactions() const override { return m_delegate->transactions(); }
+    ViewResult<AnyTransactionReceipt> receipts() const override { return m_delegate->receipts(); }
+    size_t size() const override { return m_delegate->size(); }
+    bytesConstRef logsBloom() const override { return m_delegate->logsBloom(); }
+    void setLogsBloom(bytesConstRef l) override { m_delegate->setLogsBloom(l); }
+
+private:
+    Block::Ptr m_delegate;
+};
+
+/// Helper: wrap a real (header-only) block into a ThrowingBlock.
+inline std::shared_ptr<ThrowingBlock> makeBlockWithThrowingHashAccess(BlockNumber _number)
+{
+    return std::make_shared<ThrowingBlock>(makeBlockWithNoTxs(_number));
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB141_ResettingProposalsLifecycle, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(empty_block_does_not_strand_resetting_hash)
+{
+    auto validator = makeTxsValidator();
+    auto emptyBlock = makeBlockWithNoTxs(/*number*/ 1);
+
+    // Pre-condition: validator starts empty.
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+
+    validator->asyncResetTxsFlag(*emptyBlock, true);
+
+    // Post-condition: empty block has nothing to mark, so the proposal hash
+    // must NOT be left in m_resettingProposals.
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(exception_during_buildHashList_does_not_strand)
+{
+    auto validator = makeTxsValidator();
+    auto block = makeBlockWithThrowingHashAccess(/*number*/ 2);
+
+    BOOST_CHECK_NO_THROW(validator->asyncResetTxsFlag(*block, true));
+
+    // The exception fires AFTER the (buggy) insert but BEFORE asyncMarkTxs is
+    // reached. Without FIB-141 the hash is permanently stranded.
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(empty_block_with_flag_false_is_noop)
+{
+    // When _flag is false the function should not touch m_resettingProposals
+    // at all (this was already correct before FIB-141; the test guards against
+    // regression in the reorder).
+    auto validator = makeTxsValidator();
+    auto emptyBlock = makeBlockWithNoTxs(/*number*/ 3);
+
+    validator->asyncResetTxsFlag(*emptyBlock, false);
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-pbft/test/unittests/FIB143_ResetCallbackOrderTest.cpp
+++ b/bcos-pbft/test/unittests/FIB143_ResetCallbackOrderTest.cpp
@@ -1,0 +1,164 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-143: TxsValidator::asyncResetTxsFlag's
+ *        callback must check _error BEFORE erasing the proposal hash from
+ *        m_resettingProposals. Otherwise a failed asyncMarkTxs can spuriously
+ *        clear the resetting set, fire verifyCompletedHook, and unblock
+ *        sealing while txpool state is still inconsistent.
+ * @file FIB143_ResetCallbackOrderTest.cpp
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeTxPool.h"
+#include "bcos-pbft/pbft/engine/Validator.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-framework/protocol/CommonError.h>
+#include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+/// A FakeTxPool that always reports a failure from asyncMarkTxs, simulating
+/// the bug scenario where the txpool side cannot complete the mark step.
+class FailingMarkTxsPool : public FakeTxPool
+{
+public:
+    using Ptr = std::shared_ptr<FailingMarkTxsPool>;
+    explicit FailingMarkTxsPool(int32_t _errorCode = -42, std::string _msg = "fake mark failure")
+      : m_errorCode(_errorCode), m_msg(std::move(_msg))
+    {}
+
+    void asyncMarkTxs(const HashList& /*txs*/, bool /*flag*/, BlockNumber /*number*/,
+        HashType const& /*hash*/, std::function<void(Error::Ptr)> _callback) override
+    {
+        // schedule asynchronously like the real txpool
+        std::thread([this, _callback = std::move(_callback)]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            _callback(BCOS_ERROR_PTR(m_errorCode, m_msg));
+        }).detach();
+    }
+
+    void setError(int32_t _code, std::string _msg)
+    {
+        m_errorCode = _code;
+        m_msg = std::move(_msg);
+    }
+
+private:
+    int32_t m_errorCode;
+    std::string m_msg;
+};
+
+inline CryptoSuite::Ptr makeCryptoSuiteFib143()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signImpl = std::make_shared<Secp256k1Crypto>();
+    return std::make_shared<CryptoSuite>(hashImpl, signImpl, nullptr);
+}
+
+inline Block::Ptr makeBlockWithTxsFib143(BlockFactory::Ptr _blockFactory,
+    CryptoSuite::Ptr _cryptoSuite, BlockNumber _number, size_t _txsCount)
+{
+    auto block = _blockFactory->createBlock();
+    auto header = _blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(_number);
+    header->calculateHash(*_cryptoSuite->hashImpl());
+    block->setBlockHeader(header);
+    for (size_t i = 0; i < _txsCount; i++)
+    {
+        auto h = _cryptoSuite->hashImpl()->hash(
+            "FIB143-tx-" + std::to_string(_number) + "-" + std::to_string(i));
+        auto meta = _blockFactory->createTransactionMetaData(h, h.abridged());
+        block->appendTransactionMetaData(meta);
+    }
+    return block;
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB143_ResetCallbackOrder, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(failed_asyncMarkTxs_does_not_unblock_sealer)
+{
+    auto cryptoSuite = makeCryptoSuiteFib143();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto failingPool = std::make_shared<FailingMarkTxsPool>();
+    auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
+    auto validator = std::make_shared<TxsValidator>(failingPool, blockFactory, txResultFactory);
+
+    auto block = makeBlockWithTxsFib143(blockFactory, cryptoSuite, /*number*/ 1, /*txs*/ 3);
+
+    std::atomic<bool> sealerNotifiedTooEarly{false};
+    validator->setVerifyCompletedHook([&]() { sealerNotifiedTooEarly.store(true); });
+
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+    validator->asyncResetTxsFlag(*block, /*flag*/ true);
+
+    // Wait for the asyncMarkTxs callback (FailingMarkTxsPool sleeps ~5ms before
+    // calling back).
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline && !sealerNotifiedTooEarly.load() &&
+           validator->resettingProposalSize() > 0)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    // Give one more tick to be sure the callback completed even if it didn't
+    // unblock the sealer.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // FIB-143 invariant: asyncMarkTxs failed, so the sealer must NOT be
+    // unblocked, and the proposal hash must remain in m_resettingProposals so
+    // that a recovery path still has the chance to act.
+    BOOST_CHECK_EQUAL(sealerNotifiedTooEarly.load(), false);
+    BOOST_CHECK_GT(validator->resettingProposalSize(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(successful_asyncMarkTxs_still_unblocks_sealer)
+{
+    // Sanity: with a vanilla FakeTxPool (asyncMarkTxs is a no-op success), the
+    // existing erase-on-success / fire-hook path still works after the fix.
+    auto cryptoSuite = makeCryptoSuiteFib143();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto okPool = std::make_shared<FakeTxPool>();
+    auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
+    auto validator = std::make_shared<TxsValidator>(okPool, blockFactory, txResultFactory);
+
+    auto block = makeBlockWithTxsFib143(blockFactory, cryptoSuite, /*number*/ 5, /*txs*/ 2);
+
+    std::atomic<bool> hookFired{false};
+    validator->setVerifyCompletedHook([&]() { hookFired.store(true); });
+
+    validator->asyncResetTxsFlag(*block, /*flag*/ true);
+
+    // FakeTxPool::asyncMarkTxs is synchronous (no-op + immediate nullptr-style),
+    // but here it never invokes the callback at all. We simply check that the
+    // hash was inserted (post-FIB-141) and that no spurious hook fires.
+    BOOST_CHECK_EQUAL(hookFired.load(), false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-pbft/test/unittests/FIB144_ResetRetryTest.cpp
+++ b/bcos-pbft/test/unittests/FIB144_ResetRetryTest.cpp
@@ -1,0 +1,169 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-144: when asyncMarkTxs fails with
+ *        TransactionsMissing, TxsValidator must NOT leave the proposal hash
+ *        permanently stranded in m_resettingProposals. The fix removes the
+ *        hash so a subsequent PrePrepare for the same proposal can re-trigger
+ *        marking once the data arrives.
+ * @file FIB144_ResetRetryTest.cpp
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeTxPool.h"
+#include "bcos-pbft/pbft/engine/Validator.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-framework/protocol/CommonError.h>
+#include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+/// A FakeTxPool that fails asyncMarkTxs with the configured error code.
+class CodedFailingMarkPool : public FakeTxPool
+{
+public:
+    using Ptr = std::shared_ptr<CodedFailingMarkPool>;
+    explicit CodedFailingMarkPool(int32_t _code, std::string _msg)
+      : m_code(_code), m_msg(std::move(_msg))
+    {}
+
+    void asyncMarkTxs(const HashList& /*txs*/, bool /*flag*/, BlockNumber /*number*/,
+        HashType const& /*hash*/, std::function<void(Error::Ptr)> _callback) override
+    {
+        std::thread([this, _callback = std::move(_callback)]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            _callback(BCOS_ERROR_PTR(m_code, m_msg));
+        }).detach();
+    }
+
+private:
+    int32_t m_code;
+    std::string m_msg;
+};
+
+inline CryptoSuite::Ptr makeCryptoSuiteFib144()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signImpl = std::make_shared<Secp256k1Crypto>();
+    return std::make_shared<CryptoSuite>(hashImpl, signImpl, nullptr);
+}
+
+inline Block::Ptr makeBlockWithUnknownTxs(BlockFactory::Ptr _blockFactory,
+    CryptoSuite::Ptr _cryptoSuite, BlockNumber _number, size_t _txsCount)
+{
+    auto block = _blockFactory->createBlock();
+    auto header = _blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(_number);
+    header->calculateHash(*_cryptoSuite->hashImpl());
+    block->setBlockHeader(header);
+    for (size_t i = 0; i < _txsCount; i++)
+    {
+        auto h = _cryptoSuite->hashImpl()->hash(
+            "FIB144-unknown-tx-" + std::to_string(_number) + "-" + std::to_string(i));
+        auto meta = _blockFactory->createTransactionMetaData(h, h.abridged());
+        block->appendTransactionMetaData(meta);
+    }
+    return block;
+}
+
+template <typename Predicate>
+bool waitForCondition(Predicate&& _pred, std::chrono::milliseconds _timeout)
+{
+    auto deadline = std::chrono::steady_clock::now() + _timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        if (_pred())
+        {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    return _pred();
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB144_ResetRetry, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(transactionsMissing_removes_hash_from_resetting_set)
+{
+    // Given: a validator whose txpool replies with CommonError::TransactionsMissing.
+    auto cryptoSuite = makeCryptoSuiteFib144();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto pool = std::make_shared<CodedFailingMarkPool>(
+        CommonError::TransactionsMissing, "fake TransactionsMissing");
+    auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
+    auto validator = std::make_shared<TxsValidator>(pool, blockFactory, txResultFactory);
+
+    auto block = makeBlockWithUnknownTxs(blockFactory, cryptoSuite, /*number*/ 1, /*txs*/ 3);
+
+    // When: asyncResetTxsFlag is invoked with _flag=true.
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+    validator->asyncResetTxsFlag(*block, /*flag*/ true);
+
+    // Wait for the callback to fire and observe the resetting set drop back to 0.
+    bool drained = waitForCondition(
+        [&]() { return validator->resettingProposalSize() == 0; }, std::chrono::seconds(3));
+
+    // Then: the proposal hash must have been removed so a future PrePrepare
+    // for the same proposal can re-trigger asyncResetTxsFlag.
+    BOOST_CHECK(drained);
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+
+    // Sanity: a *second* asyncResetTxsFlag must be allowed through (i.e.,
+    // insertResettingProposal does not silently suppress because the hash is
+    // still present).
+    validator->asyncResetTxsFlag(*block, /*flag*/ true);
+    // briefly observe re-insert (it will fail again immediately, but the act of
+    // re-entering proves recoverability).
+    waitForCondition(
+        [&]() { return validator->resettingProposalSize() == 0; }, std::chrono::milliseconds(1500));
+    BOOST_CHECK_EQUAL(validator->resettingProposalSize(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(non_transient_error_keeps_hash_in_resetting_set)
+{
+    // FIB-143 invariant must still hold for non-transient errors: the hash
+    // stays in m_resettingProposals so sealing remains gated.
+    auto cryptoSuite = makeCryptoSuiteFib144();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto pool = std::make_shared<CodedFailingMarkPool>(/*non-transient*/ -777, "permanent failure");
+    auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
+    auto validator = std::make_shared<TxsValidator>(pool, blockFactory, txResultFactory);
+
+    auto block = makeBlockWithUnknownTxs(blockFactory, cryptoSuite, /*number*/ 2, /*txs*/ 2);
+
+    validator->asyncResetTxsFlag(*block, /*flag*/ true);
+
+    // After ~200ms the callback has fired; the hash should remain stranded
+    // intentionally (FIB-143 retain-on-failure semantics).
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    BOOST_CHECK_GT(validator->resettingProposalSize(), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-pbft/test/unittests/FIB149_HashLengthStrictTest.cpp
+++ b/bcos-pbft/test/unittests/FIB149_HashLengthStrictTest.cpp
@@ -1,0 +1,142 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-149 (PBFT side): Proposal.h and
+ *        PBFTBaseMessage.h must reject any non-canonical hash length on
+ *        deserialization. Previously Proposal.h used `<` (accepting oversize
+ *        silently truncated to 32 bytes) and PBFTBaseMessage.h used `>=`
+ *        (also truncating oversize). Both are now strict `!= HashType::SIZE`.
+ * @file FIB149_HashLengthStrictTest.cpp
+ */
+#include "bcos-pbft/core/Proposal.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTBaseMessage.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+namespace
+{
+/// Concrete PBFTBaseMessage subtype: PBFTBaseMessage's deserializeToObject is
+/// virtual but the base class has no abstract methods triggered through the
+/// constructor. We can directly instantiate via the protected baseMessage ctor.
+class FibTestPBFTBaseMessage : public PBFTBaseMessage
+{
+public:
+    using PBFTBaseMessage::PBFTBaseMessage;
+};
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB149_HashLengthStrict, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(oversize_proposal_hash_rejected)
+{
+    // 64-byte (oversize) raw hash inside a RawProposal. Pre-fix Proposal.h used
+    // `<` so oversize was silently truncated to the first 32 bytes; the test
+    // asserts the strict reject path leaves m_hash default-constructed.
+    auto raw = std::make_shared<RawProposal>();
+    std::string oversize(64, '\xab');
+    raw->set_hash(oversize.data(), oversize.size());
+
+    Proposal proposal(raw);
+    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+}
+
+BOOST_AUTO_TEST_CASE(undersize_proposal_hash_rejected)
+{
+    // Already rejected pre-fix (the `<` predicate caught undersize), but we
+    // keep this case to lock in behavior post-fix.
+    auto raw = std::make_shared<RawProposal>();
+    std::string undersize(16, '\xab');
+    raw->set_hash(undersize.data(), undersize.size());
+
+    Proposal proposal(raw);
+    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+}
+
+BOOST_AUTO_TEST_CASE(exact_proposal_hash_accepted)
+{
+    auto raw = std::make_shared<RawProposal>();
+    std::string exact(HashType::SIZE, '\xcd');
+    raw->set_hash(exact.data(), exact.size());
+
+    Proposal proposal(raw);
+    HashType expected((byte const*)exact.data(), HashType::SIZE);
+    BOOST_CHECK_EQUAL(proposal.hash(), expected);
+}
+
+BOOST_AUTO_TEST_CASE(oversize_pbft_basemsg_hash_rejected)
+{
+    // Pre-fix PBFTBaseMessage used `>=` so oversize input was silently
+    // truncated. The strict `!=` check leaves m_hash default-constructed.
+    auto base = std::make_shared<BaseMessage>();
+    std::string oversize(64, '\xab');
+    base->set_hash(oversize.data(), oversize.size());
+
+    FibTestPBFTBaseMessage msg(base);
+    BOOST_CHECK_EQUAL(msg.hash(), HashType{});
+}
+
+BOOST_AUTO_TEST_CASE(undersize_pbft_basemsg_hash_rejected)
+{
+    // Pre-fix `>=` predicate let undersize fall through (m_hash stayed default
+    // because the construct did not run). After fix the same is true via the
+    // explicit `==` predicate. Locks in canonical behavior.
+    auto base = std::make_shared<BaseMessage>();
+    std::string undersize(16, '\xab');
+    base->set_hash(undersize.data(), undersize.size());
+
+    FibTestPBFTBaseMessage msg(base);
+    BOOST_CHECK_EQUAL(msg.hash(), HashType{});
+}
+
+BOOST_AUTO_TEST_CASE(oversize_pbft_basemsg_signaturehash_rejected)
+{
+    auto base = std::make_shared<BaseMessage>();
+    std::string okHash(HashType::SIZE, '\x11');
+    base->set_hash(okHash.data(), okHash.size());
+    // signaturehash oversize (64) — pre-fix would silently truncate to 32 bytes.
+    std::string sigOversize(64, '\xab');
+    base->set_signaturehash(sigOversize.data(), sigOversize.size());
+
+    FibTestPBFTBaseMessage msg(base);
+    BOOST_CHECK_EQUAL(msg.signatureDataHash(), HashType{});
+    // hash itself is canonical; ensure independent rejection.
+    HashType expectedHash((byte const*)okHash.data(), HashType::SIZE);
+    BOOST_CHECK_EQUAL(msg.hash(), expectedHash);
+}
+
+BOOST_AUTO_TEST_CASE(exact_pbft_basemsg_hashes_accepted)
+{
+    auto base = std::make_shared<BaseMessage>();
+    std::string h(HashType::SIZE, '\x42');
+    std::string s(HashType::SIZE, '\x84');
+    base->set_hash(h.data(), h.size());
+    base->set_signaturehash(s.data(), s.size());
+
+    FibTestPBFTBaseMessage msg(base);
+    HashType eh((byte const*)h.data(), HashType::SIZE);
+    HashType es((byte const*)s.data(), HashType::SIZE);
+    BOOST_CHECK_EQUAL(msg.hash(), eh);
+    BOOST_CHECK_EQUAL(msg.signatureDataHash(), es);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
## Summary
- Round 1 Cluster D follow-up: four Major findings on `bcos-pbft/.../Validator.cpp`'s `m_resettingProposals` lifecycle, plus PBFT-side hash length strictness on `Proposal.h` and `PBFTBaseMessage.h`.
- Causal commit order: 141 → 143 → 144 → 149.

## Changes per FIB
- **FIB-141** (Major / pbft): in `TxsValidator::asyncResetTxsFlag`, build the tx-hash list FIRST and confirm non-empty before inserting into `m_resettingProposals`. Empty-block / exception paths return without inserting, so `PBFTConfig::notifySealer()` is never blocked indefinitely.
- **FIB-143** (Major / pbft): in the `asyncMarkTxs` callback, check `_error` BEFORE `eraseResettingProposal`. On failure, the hash is left in `m_resettingProposals` so `notifySealer()` stays correctly blocked. Sealer is no longer falsely unblocked while `asyncMarkTxs` failed.
- **FIB-144** (Major / pbft): on transient `TransactionsMissing`, explicitly remove the proposal hash from `m_resettingProposals` so a subsequent PrePrepare for the SAME proposal (e.g., via view change) can re-trigger marking. Other errors keep FIB-143's retain-on-failure semantics.
  - **Known limitation (acknowledged in commit body)**: this restores liveness when a future PrePrepare arrives, but does NOT automatically re-mark when the missing transactions arrive via independent sync paths. Full recovery via transaction-arrival event hookup is deferred to a follow-up PR.
- **FIB-149** (Major / pbft): change `<` (in `Proposal.h`) and `>=` (in `PBFTBaseMessage.h`) to strict `!= HashType::SIZE`. Oversize input no longer silently truncated; undersize uniformly rejected. The txpool side (`TxsSyncMsg.cpp`) was already fixed in a prior round.

## Notes for reviewers
- Helper-naming convention: each FIB's test file uses FIB-suffixed anonymous-namespace helpers (e.g., `makeCryptoSuiteFib143`, `makeCryptoSuiteFib144`) to avoid collisions in `bcos-pbft`'s unity-build target. Future test files in this module should follow the same pattern.
- FIB-141 throwing-block test uses a custom `Block` subclass that throws inside `transactionHash`, with `blockHeader() const` forwarding to a real `BlockImpl`'s const overload via `std::as_const`.
- Plan-cited line numbers shifted slightly from the spec; symbol-based location was used to find the right insertion points.

## Test plan
- [x] `cmake --build build --target test-bcos-pbft --parallel`
- [x] `ctest --test-dir build -R "PBFT |Validator|FIB141|FIB143|FIB144|FIB149"` — 27/27 pass
- [x] New UTs: 14 cases across 4 files
- [x] Verified clean under TSan (lifecycle FIBs 141 + 143 + 144, 7/7 pass)
- [x] Verified clean under ASan (lifecycle FIBs 141 + 143 + 144, 7/7 pass)
- [x] Verified clean merge into local `pbft-fib-r2-integration`
- [ ] CI green on all platforms

## Reference
CertiK FIB Round 2 Cluster V1 — finding IDs FIB-141, FIB-143, FIB-144, FIB-149.


---

## Code-quality review notes (post-spec-review, 2026-05-08)

Two-stage review completed. **Spec compliance: ✅** (4/4 FIBs). **Code quality: ⚠️ Approve with minor cleanups.**

Findings deferred to follow-up rather than fixup-pushed:

- **(Minor — misleading)** `bcos-pbft/test/unittests/FIB143_ResetCallbackOrderTest.cpp:140-161` test case is named `successful_asyncMarkTxs_still_unblocks_sealer`, but its body asserts `hookFired == false` and the file's own comment block (lines 156-159) acknowledges that `FakeTxPool::asyncMarkTxs` never invokes the callback at all. Either rename to `no_spurious_hook_on_inert_pool` or replace with a real success-callback fixture. Recommend rename.
- **(Minor)** FIB-144 emits `LOG_DESC("FIB-144: TransactionsMissing - removed proposal ...")` at runtime (`bcos-pbft/.../Validator.cpp:154-156`). Operators don't need the FIB ID in production logs; consider trimming to the descriptive part.
- **(Minor — future-proofing)** FIB-141's anonymous-namespace helpers (`makeCryptoSuite`, `makeBlockWithNoTxs`, `makeBlockWithThrowingHashAccess`, `ThrowingBlock`) are not FIB-suffixed. Currently safe (anonymous-namespace-per-TU isolation under unity build), but a future regression test that drops the anonymous namespace could collide. FIB-143 / FIB-144 / FIB-149 already follow the FIB-suffix convention.

Spec-stage judgment note: FIB-144 chose "remove-and-reschedule" over "retry-on-transient-failure" — both were valid paths in plan §V1.3. Implementation is coherent and self-documenting.
