### PR TITLE
Fix Windows compile error

### DIFF
--- a/bcos-crypto/bcos-crypto/ChecksumAddress.cpp
+++ b/bcos-crypto/bcos-crypto/ChecksumAddress.cpp
@@ -118,6 +118,7 @@ std::string newEVMAddress(
     return newEVMAddress(*_hashImpl, blockNumber, contextID, seq);
 }
 
+#ifdef BCOS_CRYPTO_HAS_EVMC
 evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept
 {
     codec::rlp::Header header{.isList = true, .payloadLength = 1 + sender.size()};
@@ -132,6 +133,7 @@ evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexce
 
     return address;
 }
+#endif
 
 std::string newLegacyEVMAddressString(bytesConstRef sender, const u256& nonce) noexcept
 {

--- a/bcos-crypto/bcos-crypto/ChecksumAddress.h
+++ b/bcos-crypto/bcos-crypto/ChecksumAddress.h
@@ -22,9 +22,13 @@
 
 #include <bcos-crypto/interfaces/crypto/Hash.h>
 #include <bcos-utilities/Common.h>
-#include <evmc/evmc.h>
 #include <string>
 #include <string_view>
+
+#if __has_include(<evmc/evmc.h>)
+#include <evmc/evmc.h>
+#define BCOS_CRYPTO_HAS_EVMC 1
+#endif
 
 namespace bcos
 {
@@ -50,7 +54,9 @@ std::string newEVMAddress(
     const bcos::crypto::Hash::Ptr& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq);
 
 // keccak256(rlp.encode([normalize_address(sender), nonce]))[12:]
+#ifdef BCOS_CRYPTO_HAS_EVMC
 evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept;
+#endif
 
 std::string newLegacyEVMAddressString(bytesConstRef sender, const u256& nonce) noexcept;
 


### PR DESCRIPTION
Address a compilation issue on Windows by conditionally including the EVMC header and defining a macro to manage compatibility.