### PR TITLE
fix(txpool): dedup + cap + cleanup for asyncVerifyBlock pre-store (FIB-154)

### DIFF
--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -638,12 +638,23 @@ void NodeConfig::loadTxPoolConfig(boost::property_tree::ptree const& _pt)
 
     // enable free node to send transactions or not
     m_enableTxsFromFreeNode = _pt.get<bool>("txpool.enable_txs_from_free_node", false);
+    // FIB-154 pre-store backpressure controls
+    m_preStoreBackpressureEnabled = _pt.get<bool>("txpool.pre_store_backpressure_enabled", true);
+    auto preStoreCap = checkAndGetValue(_pt, "txpool.pre_store_max_inflight", "1024");
+    if (preStoreCap <= 0)
+    {
+        BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
+                                  "Please set txpool.pre_store_max_inflight to positive !"));
+    }
+    m_preStoreMaxInflight = static_cast<uint64_t>(preStoreCap);
     NodeConfig_LOG(INFO) << LOG_DESC("loadTxPoolConfig") << LOG_KV("txpoolLimit", m_txpoolLimit)
                          << LOG_KV("notifierWorkers", m_notifyWorkerNum)
                          << LOG_KV("verifierWorkers", m_verifierWorkerNum)
                          << LOG_KV("checkBlockLimit", m_checkBlockLimit)
                          << LOG_KV("txsExpirationTime(ms)", m_txsExpirationTime)
-                         << LOG_KV("enableTxsFromFreeNode", m_enableTxsFromFreeNode);
+                         << LOG_KV("enableTxsFromFreeNode", m_enableTxsFromFreeNode)
+                         << LOG_KV("preStoreBackpressureEnabled", m_preStoreBackpressureEnabled)
+                         << LOG_KV("preStoreMaxInflight", m_preStoreMaxInflight);
 }
 
 void NodeConfig::loadChainConfig(boost::property_tree::ptree const& _pt, bool _enforceGroupId)
@@ -2001,6 +2012,16 @@ NodeConfig::TarsRPCConfig const& NodeConfig::tarsRPCConfig() const
 bool NodeConfig::enableTxsFromFreeNode() const
 {
     return m_enableTxsFromFreeNode;
+}
+
+bool NodeConfig::preStoreBackpressureEnabled() const
+{
+    return m_preStoreBackpressureEnabled;
+}
+
+uint64_t NodeConfig::preStoreMaxInflight() const
+{
+    return m_preStoreMaxInflight;
 }
 
 void NodeConfig::loadAlloc(boost::property_tree::ptree const& ptree)

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -638,7 +638,7 @@ void NodeConfig::loadTxPoolConfig(boost::property_tree::ptree const& _pt)
 
     // enable free node to send transactions or not
     m_enableTxsFromFreeNode = _pt.get<bool>("txpool.enable_txs_from_free_node", false);
-    // FIB-154 pre-store backpressure controls
+    // pre-store backpressure controls
     m_preStoreBackpressureEnabled = _pt.get<bool>("txpool.pre_store_backpressure_enabled", true);
     auto preStoreCap = checkAndGetValue(_pt, "txpool.pre_store_max_inflight", "1024");
     if (preStoreCap <= 0)
@@ -646,7 +646,7 @@ void NodeConfig::loadTxPoolConfig(boost::property_tree::ptree const& _pt)
         BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
                                   "Please set txpool.pre_store_max_inflight to positive !"));
     }
-    m_preStoreMaxInflight = static_cast<uint64_t>(preStoreCap);
+    m_preStoreMaxInflight = static_cast<size_t>(preStoreCap);
     NodeConfig_LOG(INFO) << LOG_DESC("loadTxPoolConfig") << LOG_KV("txpoolLimit", m_txpoolLimit)
                          << LOG_KV("notifierWorkers", m_notifyWorkerNum)
                          << LOG_KV("verifierWorkers", m_verifierWorkerNum)
@@ -2019,7 +2019,7 @@ bool NodeConfig::preStoreBackpressureEnabled() const
     return m_preStoreBackpressureEnabled;
 }
 
-uint64_t NodeConfig::preStoreMaxInflight() const
+size_t NodeConfig::preStoreMaxInflight() const
 {
     return m_preStoreMaxInflight;
 }

--- a/bcos-tool/bcos-tool/NodeConfig.h
+++ b/bcos-tool/bcos-tool/NodeConfig.h
@@ -282,7 +282,7 @@ public:
 
     bool enableTxsFromFreeNode() const;
     bool preStoreBackpressureEnabled() const;
-    uint64_t preStoreMaxInflight() const;
+    size_t preStoreMaxInflight() const;
     int executorVersion() const;
 
 protected:
@@ -339,9 +339,9 @@ private:
     bool m_checkBlockLimit = true;
     // permit txs from free node or not
     bool m_enableTxsFromFreeNode = false;
-    // FIB-154 pre-store backpressure tunables
+    // pre-store backpressure tunables
     bool m_preStoreBackpressureEnabled = true;
-    uint64_t m_preStoreMaxInflight = 1024;
+    size_t m_preStoreMaxInflight = 1024;
     // TODO: the block sync module need some configurations?
 
     // chain configuration

--- a/bcos-tool/bcos-tool/NodeConfig.h
+++ b/bcos-tool/bcos-tool/NodeConfig.h
@@ -281,6 +281,8 @@ public:
     bool isValidPort(int port);
 
     bool enableTxsFromFreeNode() const;
+    bool preStoreBackpressureEnabled() const;
+    uint64_t preStoreMaxInflight() const;
     int executorVersion() const;
 
 protected:
@@ -337,6 +339,9 @@ private:
     bool m_checkBlockLimit = true;
     // permit txs from free node or not
     bool m_enableTxsFromFreeNode = false;
+    // FIB-154 pre-store backpressure tunables
+    bool m_preStoreBackpressureEnabled = true;
+    uint64_t m_preStoreMaxInflight = 1024;
     // TODO: the block sync module need some configurations?
 
     // chain configuration

--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -87,14 +87,8 @@ void TxPool::stop()
         m_txsPreStore->stop();
         // Abandoned lambdas in the stopped thread pool never run their cleanup; clear
         // stale entries so a restart doesn't see phantom in-flight blocks.
-        {
-            std::lock_guard lock(x_preStoreInFlight);
-            m_preStoreInFlight.clear();
-        }
-        {
-            std::lock_guard lock(x_preStoreDropLogLastWarn);
-            m_preStoreDropLogLastWarn.clear();
-        }
+        std::scoped_lock lock(x_preStoreInFlight);
+        m_preStoreInFlight.clear();
     }
     if (m_verifier)
     {
@@ -293,8 +287,8 @@ void TxPool::asyncVerifyBlock(PublicPtr _generatedNodeID, protocol::Block::Const
                 if (!verifyError && verifyRet && block)
                 {
                     auto const& blockHash = block->blockHeader()->hash();
-                    auto admission = txpool->tryAcquirePreStoreSlot(blockHash);
-                    if (admission == TxPool::PreStoreAdmission::Accepted)
+                    if (const auto admission = txpool->tryAcquirePreStoreSlot(blockHash);
+                        admission == TxPool::PreStoreAdmission::Accepted)
                     {
                         txpool->m_txsPreStore->enqueue([txpool, block, blockHash]() {
                             try
@@ -785,64 +779,26 @@ bcos::txpool::TxPool::PreStoreAdmission bcos::txpool::TxPool::tryAcquirePreStore
     {
         return PreStoreAdmission::Disabled;
     }
-
-    // Snapshot the in-flight count inside the critical section so the WARN line below
-    // reflects the size that caused the drop, without needing a second lock.
-    std::size_t inflightAtCap = 0;
+    std::scoped_lock lock(x_preStoreInFlight);
+    if (m_preStoreInFlight.contains(_blockHash))
     {
-        std::lock_guard lock(x_preStoreInFlight);
-        if (m_preStoreInFlight.count(_blockHash))
-        {
-            TXPOOL_LOG(DEBUG) << LOG_DESC("pre-store gate: skip duplicate block")
-                              << LOG_KV("hash", _blockHash.abridged());
-            return PreStoreAdmission::DuplicateSkipped;
-        }
-        if (m_preStoreInFlight.size() < m_preStoreMaxInflight)
-        {
-            m_preStoreInFlight.insert(_blockHash);
-            return PreStoreAdmission::Accepted;
-        }
-        inflightAtCap = m_preStoreInFlight.size();
+        TXPOOL_LOG(DEBUG) << LOG_DESC("pre-store gate: skip duplicate block")
+                          << LOG_KV("hash", _blockHash.abridged());
+        return PreStoreAdmission::DuplicateSkipped;
     }
-
-    // Cap reached. x_preStoreInFlight and x_preStoreDropLogLastWarn are never held
-    // simultaneously, so the dedup map below cannot deadlock against the gate.
-    bool shouldWarn = false;
-    auto const now = std::chrono::steady_clock::now();
+    if (m_preStoreInFlight.size() < m_preStoreMaxInflight)
     {
-        std::lock_guard logLock(x_preStoreDropLogLastWarn);
-        auto it = m_preStoreDropLogLastWarn.find(_blockHash);
-        if (it == m_preStoreDropLogLastWarn.end() || (now - it->second) >= c_preStoreLogDedupTtl)
-        {
-            if (m_preStoreDropLogLastWarn.size() >= c_preStoreLogDedupCap)
-            {
-                // Bounded-memory sweep: evict every entry older than TTL.
-                for (auto sweep = m_preStoreDropLogLastWarn.begin();
-                    sweep != m_preStoreDropLogLastWarn.end();)
-                {
-                    if ((now - sweep->second) >= c_preStoreLogDedupTtl)
-                    {
-                        sweep = m_preStoreDropLogLastWarn.erase(sweep);
-                    }
-                    else
-                    {
-                        ++sweep;
-                    }
-                }
-            }
-            m_preStoreDropLogLastWarn[_blockHash] = now;
-            shouldWarn = true;
-        }
+        m_preStoreInFlight.insert(_blockHash);
+        return PreStoreAdmission::Accepted;
     }
-    if (shouldWarn)
-    {
-        TXPOOL_LOG(WARNING)
-            << LOG_DESC(
-                   "pre-store backlog cap reached, dropping (further WARNs for this "
-                   "hash suppressed for 60s)")
-            << LOG_KV("hash", _blockHash.abridged()) << LOG_KV("inflight", inflightAtCap)
-            << LOG_KV("cap", m_preStoreMaxInflight.load());
-    }
+    // Cap reached. With cap=1024 (NodeConfig default) and typical PBFT pipeline depth,
+    // this branch is not expected to fire in normal operation; under DoS the DEBUG
+    // level keeps log I/O out of the picture by default. Ops can enable DEBUG (or
+    // monitor the drop side-channel via metrics) to observe cap hits.
+    TXPOOL_LOG(DEBUG) << LOG_DESC("pre-store gate: backlog cap reached, dropping")
+                      << LOG_KV("hash", _blockHash.abridged())
+                      << LOG_KV("inflight", m_preStoreInFlight.size())
+                      << LOG_KV("cap", m_preStoreMaxInflight.load());
     return PreStoreAdmission::CapDropped;
 }
 

--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -85,10 +85,16 @@ void TxPool::stop()
     if (m_txsPreStore)
     {
         m_txsPreStore->stop();
-        // FIB-154: abandoned lambdas in the stopped thread pool never run their cleanup;
-        // clear stale entries so a restart doesn't see phantom in-flight blocks.
-        std::lock_guard lock(x_preStoreInFlight);
-        m_preStoreInFlight.clear();
+        // Abandoned lambdas in the stopped thread pool never run their cleanup; clear
+        // stale entries so a restart doesn't see phantom in-flight blocks.
+        {
+            std::lock_guard lock(x_preStoreInFlight);
+            m_preStoreInFlight.clear();
+        }
+        {
+            std::lock_guard lock(x_preStoreDropLogLastWarn);
+            m_preStoreDropLogLastWarn.clear();
+        }
     }
     if (m_verifier)
     {
@@ -286,39 +292,11 @@ void TxPool::asyncVerifyBlock(PublicPtr _generatedNodeID, protocol::Block::Const
                 // m_txsPreStore
                 if (!verifyError && verifyRet && block)
                 {
-                    // FIB-154: dedup by block hash + enforce hard cap on inflight pre-store
-                    // tasks to prevent unbounded queue growth (queue-amplification DoS).
                     auto const& blockHash = block->blockHeader()->hash();
-                    bool shouldEnqueue = false;
-                    {
-                        std::lock_guard lock(txpool->x_preStoreInFlight);
-                        if (txpool->m_preStoreInFlight.count(blockHash))
-                        {
-                            TXPOOL_LOG(DEBUG)
-                                << LOG_DESC("FIB-154: pre-store dedup, skip duplicate")
-                                << LOG_KV("hash", blockHash.abridged());
-                        }
-                        else if (txpool->m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
-                        {
-                            TXPOOL_LOG(WARNING)
-                                << LOG_DESC("FIB-154: pre-store backlog cap reached, dropping")
-                                << LOG_KV("hash", blockHash.abridged())
-                                << LOG_KV("inflight", txpool->m_preStoreInFlight.size());
-                        }
-                        else
-                        {
-                            txpool->m_preStoreInFlight.insert(blockHash);
-                            shouldEnqueue = true;
-                        }
-                    }
-                    if (shouldEnqueue)
+                    auto admission = txpool->tryAcquirePreStoreSlot(blockHash);
+                    if (admission == TxPool::PreStoreAdmission::Accepted)
                     {
                         txpool->m_txsPreStore->enqueue([txpool, block, blockHash]() {
-                            // FIB-154: cleanup runs on every exit path (success, std, non-std).
-                            auto cleanup = [&]() {
-                                std::lock_guard cleanLock(txpool->x_preStoreInFlight);
-                                txpool->m_preStoreInFlight.erase(blockHash);
-                            };
                             try
                             {
                                 txpool->storeVerifiedBlock(block);
@@ -326,25 +304,27 @@ void TxPool::asyncVerifyBlock(PublicPtr _generatedNodeID, protocol::Block::Const
                             catch (std::exception const& e)
                             {
                                 TXPOOL_LOG(WARNING)
-                                    << LOG_DESC("FIB-154: pre-store storeVerifiedBlock threw")
+                                    << LOG_DESC("pre-store storeVerifiedBlock threw")
                                     << LOG_KV("blockHash", blockHash.abridged())
                                     << LOG_KV("error", boost::diagnostic_information(e));
-                                cleanup();
-                                return;
                             }
                             catch (...)
                             {
-                                TXPOOL_LOG(WARNING)
-                                    << LOG_DESC(
-                                           "FIB-154: pre-store storeVerifiedBlock threw unknown "
-                                           "exception")
-                                    << LOG_KV("blockHash", blockHash.abridged());
-                                cleanup();
-                                return;
+                                TXPOOL_LOG(WARNING) << LOG_DESC(
+                                                           "pre-store storeVerifiedBlock threw "
+                                                           "unknown exception")
+                                                    << LOG_KV("blockHash", blockHash.abridged());
                             }
-                            cleanup();
+                            txpool->releasePreStoreSlot(blockHash);
                         });
                     }
+                    else if (admission == TxPool::PreStoreAdmission::Disabled)
+                    {
+                        // backpressure off: legacy unbounded behavior (operator escape hatch)
+                        txpool->m_txsPreStore->enqueue(
+                            [txpool, block]() { txpool->storeVerifiedBlock(block); });
+                    }
+                    // DuplicateSkipped / CapDropped: nothing to do; logged inside the gate.
                 }
             };
 
@@ -782,80 +762,100 @@ void bcos::txpool::TxPool::registerTxsNotifier(
     m_txpoolStorage->registerTxsNotifier(_txsNotifier);
 }
 
-// FIB-154 test-only helpers -------------------------------------------------------
-// These methods exercise the dedup/cap gate synchronously (no thread pool post)
-// so that unit tests can assert counts deterministically.
-
-void bcos::txpool::TxPool::testOnlyEnqueuePreStore(bcos::crypto::HashType const& h)
+void bcos::txpool::TxPool::setPreStoreBackpressureEnabled(bool _enabled)
 {
-    std::lock_guard lock(x_preStoreInFlight);
-    if (m_preStoreInFlight.count(h))
+    m_preStoreBackpressureEnabled = _enabled;
+}
+
+void bcos::txpool::TxPool::setPreStoreMaxInflight(std::size_t _max)
+{
+    if (_max == 0)
     {
-        TXPOOL_LOG(DEBUG) << LOG_DESC("FIB-154 testOnly: dedup, skip duplicate");
+        TXPOOL_LOG(WARNING) << LOG_DESC(
+            "setPreStoreMaxInflight ignored: 0 is invalid (would block all pre-store work)");
         return;
     }
-    if (m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
-    {
-        TXPOOL_LOG(WARNING) << LOG_DESC("FIB-154 testOnly: cap reached, dropping");
-        return;
-    }
-    m_preStoreInFlight.insert(h);
+    m_preStoreMaxInflight = _max;
 }
 
-void bcos::txpool::TxPool::testOnlyEnqueuePreStoreSyncSuccess(bcos::crypto::HashType const& h)
+bcos::txpool::TxPool::PreStoreAdmission bcos::txpool::TxPool::tryAcquirePreStoreSlot(
+    bcos::crypto::HashType const& _blockHash)
 {
+    if (!m_preStoreBackpressureEnabled)
+    {
+        return PreStoreAdmission::Disabled;
+    }
     {
         std::lock_guard lock(x_preStoreInFlight);
-        if (m_preStoreInFlight.count(h))
+        if (m_preStoreInFlight.count(_blockHash))
         {
-            return;
+            TXPOOL_LOG(DEBUG) << LOG_DESC("pre-store gate: skip duplicate block")
+                              << LOG_KV("hash", _blockHash.abridged());
+            return PreStoreAdmission::DuplicateSkipped;
         }
-        if (m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
+        if (m_preStoreInFlight.size() >= m_preStoreMaxInflight)
         {
-            return;
+            // Drop the slot; outside this critical section, decide whether to log.
+            // We must NOT hold x_preStoreInFlight while taking x_preStoreDropLogLastWarn —
+            // they are independent locks acquired in independent orders elsewhere is fine,
+            // but keeping them strictly ordered (in-flight first, dedup second never together)
+            // makes deadlocks impossible by construction.
         }
-        m_preStoreInFlight.insert(h);
+        else
+        {
+            m_preStoreInFlight.insert(_blockHash);
+            return PreStoreAdmission::Accepted;
+        }
     }
-    // Simulate work completing successfully, then cleanup
+
+    // Cap reached. Decide whether to emit a WARNING — dedup per-hash with 60s TTL to
+    // neutralize log-I/O amplification under sustained DoS.
+    bool shouldWarn = false;
+    std::size_t currentInflight = 0;
     {
         std::lock_guard lock(x_preStoreInFlight);
-        m_preStoreInFlight.erase(h);
+        currentInflight = m_preStoreInFlight.size();
     }
+    auto const now = std::chrono::steady_clock::now();
+    {
+        std::lock_guard logLock(x_preStoreDropLogLastWarn);
+        auto it = m_preStoreDropLogLastWarn.find(_blockHash);
+        if (it == m_preStoreDropLogLastWarn.end() || (now - it->second) >= c_preStoreLogDedupTtl)
+        {
+            if (m_preStoreDropLogLastWarn.size() >= c_preStoreLogDedupCap)
+            {
+                // Bounded-memory sweep: evict every entry older than TTL.
+                for (auto sweep = m_preStoreDropLogLastWarn.begin();
+                    sweep != m_preStoreDropLogLastWarn.end();)
+                {
+                    if ((now - sweep->second) >= c_preStoreLogDedupTtl)
+                    {
+                        sweep = m_preStoreDropLogLastWarn.erase(sweep);
+                    }
+                    else
+                    {
+                        ++sweep;
+                    }
+                }
+            }
+            m_preStoreDropLogLastWarn[_blockHash] = now;
+            shouldWarn = true;
+        }
+    }
+    if (shouldWarn)
+    {
+        TXPOOL_LOG(WARNING)
+            << LOG_DESC(
+                   "pre-store backlog cap reached, dropping (further WARNs for this "
+                   "hash suppressed for 60s)")
+            << LOG_KV("hash", _blockHash.abridged()) << LOG_KV("inflight", currentInflight)
+            << LOG_KV("cap", m_preStoreMaxInflight);
+    }
+    return PreStoreAdmission::CapDropped;
 }
 
-void bcos::txpool::TxPool::testOnlyEnqueuePreStoreSyncThrow(bcos::crypto::HashType const& h)
-{
-    {
-        std::lock_guard lock(x_preStoreInFlight);
-        if (m_preStoreInFlight.count(h))
-        {
-            return;
-        }
-        if (m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
-        {
-            return;
-        }
-        m_preStoreInFlight.insert(h);
-    }
-    try
-    {
-        // Simulate the work throwing
-        throw std::runtime_error("FIB-154 testOnly: simulated exception");
-    }
-    catch (std::exception const& e)
-    {
-        TXPOOL_LOG(WARNING) << LOG_DESC("FIB-154 testOnly: exception path triggered")
-                            << LOG_KV("err", e.what());
-    }
-    // Cleanup on exception path — entry must still be removed
-    {
-        std::lock_guard lock(x_preStoreInFlight);
-        m_preStoreInFlight.erase(h);
-    }
-}
-
-void bcos::txpool::TxPool::testOnlyCleanupPreStore(bcos::crypto::HashType const& h)
+void bcos::txpool::TxPool::releasePreStoreSlot(bcos::crypto::HashType const& _blockHash)
 {
     std::lock_guard lock(x_preStoreInFlight);
-    m_preStoreInFlight.erase(h);
+    m_preStoreInFlight.erase(_blockHash);
 }

--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -785,6 +785,10 @@ bcos::txpool::TxPool::PreStoreAdmission bcos::txpool::TxPool::tryAcquirePreStore
     {
         return PreStoreAdmission::Disabled;
     }
+
+    // Snapshot the in-flight count inside the critical section so the WARN line below
+    // reflects the size that caused the drop, without needing a second lock.
+    std::size_t inflightAtCap = 0;
     {
         std::lock_guard lock(x_preStoreInFlight);
         if (m_preStoreInFlight.count(_blockHash))
@@ -793,29 +797,17 @@ bcos::txpool::TxPool::PreStoreAdmission bcos::txpool::TxPool::tryAcquirePreStore
                               << LOG_KV("hash", _blockHash.abridged());
             return PreStoreAdmission::DuplicateSkipped;
         }
-        if (m_preStoreInFlight.size() >= m_preStoreMaxInflight)
-        {
-            // Drop the slot; outside this critical section, decide whether to log.
-            // We must NOT hold x_preStoreInFlight while taking x_preStoreDropLogLastWarn —
-            // they are independent locks acquired in independent orders elsewhere is fine,
-            // but keeping them strictly ordered (in-flight first, dedup second never together)
-            // makes deadlocks impossible by construction.
-        }
-        else
+        if (m_preStoreInFlight.size() < m_preStoreMaxInflight)
         {
             m_preStoreInFlight.insert(_blockHash);
             return PreStoreAdmission::Accepted;
         }
+        inflightAtCap = m_preStoreInFlight.size();
     }
 
-    // Cap reached. Decide whether to emit a WARNING — dedup per-hash with 60s TTL to
-    // neutralize log-I/O amplification under sustained DoS.
+    // Cap reached. x_preStoreInFlight and x_preStoreDropLogLastWarn are never held
+    // simultaneously, so the dedup map below cannot deadlock against the gate.
     bool shouldWarn = false;
-    std::size_t currentInflight = 0;
-    {
-        std::lock_guard lock(x_preStoreInFlight);
-        currentInflight = m_preStoreInFlight.size();
-    }
     auto const now = std::chrono::steady_clock::now();
     {
         std::lock_guard logLock(x_preStoreDropLogLastWarn);
@@ -848,8 +840,8 @@ bcos::txpool::TxPool::PreStoreAdmission bcos::txpool::TxPool::tryAcquirePreStore
             << LOG_DESC(
                    "pre-store backlog cap reached, dropping (further WARNs for this "
                    "hash suppressed for 60s)")
-            << LOG_KV("hash", _blockHash.abridged()) << LOG_KV("inflight", currentInflight)
-            << LOG_KV("cap", m_preStoreMaxInflight);
+            << LOG_KV("hash", _blockHash.abridged()) << LOG_KV("inflight", inflightAtCap)
+            << LOG_KV("cap", m_preStoreMaxInflight.load());
     }
     return PreStoreAdmission::CapDropped;
 }

--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -85,6 +85,10 @@ void TxPool::stop()
     if (m_txsPreStore)
     {
         m_txsPreStore->stop();
+        // FIB-154: abandoned lambdas in the stopped thread pool never run their cleanup;
+        // clear stale entries so a restart doesn't see phantom in-flight blocks.
+        std::lock_guard lock(x_preStoreInFlight);
+        m_preStoreInFlight.clear();
     }
     if (m_verifier)
     {
@@ -282,8 +286,65 @@ void TxPool::asyncVerifyBlock(PublicPtr _generatedNodeID, protocol::Block::Const
                 // m_txsPreStore
                 if (!verifyError && verifyRet && block)
                 {
-                    txpool->m_txsPreStore->enqueue(
-                        [txpool, block]() { txpool->storeVerifiedBlock(block); });
+                    // FIB-154: dedup by block hash + enforce hard cap on inflight pre-store
+                    // tasks to prevent unbounded queue growth (queue-amplification DoS).
+                    auto const& blockHash = block->blockHeader()->hash();
+                    bool shouldEnqueue = false;
+                    {
+                        std::lock_guard lock(txpool->x_preStoreInFlight);
+                        if (txpool->m_preStoreInFlight.count(blockHash))
+                        {
+                            TXPOOL_LOG(DEBUG)
+                                << LOG_DESC("FIB-154: pre-store dedup, skip duplicate")
+                                << LOG_KV("hash", blockHash.abridged());
+                        }
+                        else if (txpool->m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
+                        {
+                            TXPOOL_LOG(WARNING)
+                                << LOG_DESC("FIB-154: pre-store backlog cap reached, dropping")
+                                << LOG_KV("hash", blockHash.abridged())
+                                << LOG_KV("inflight", txpool->m_preStoreInFlight.size());
+                        }
+                        else
+                        {
+                            txpool->m_preStoreInFlight.insert(blockHash);
+                            shouldEnqueue = true;
+                        }
+                    }
+                    if (shouldEnqueue)
+                    {
+                        txpool->m_txsPreStore->enqueue([txpool, block, blockHash]() {
+                            // FIB-154: cleanup runs on every exit path (success, std, non-std).
+                            auto cleanup = [&]() {
+                                std::lock_guard cleanLock(txpool->x_preStoreInFlight);
+                                txpool->m_preStoreInFlight.erase(blockHash);
+                            };
+                            try
+                            {
+                                txpool->storeVerifiedBlock(block);
+                            }
+                            catch (std::exception const& e)
+                            {
+                                TXPOOL_LOG(WARNING)
+                                    << LOG_DESC("FIB-154: pre-store storeVerifiedBlock threw")
+                                    << LOG_KV("blockHash", blockHash.abridged())
+                                    << LOG_KV("error", boost::diagnostic_information(e));
+                                cleanup();
+                                return;
+                            }
+                            catch (...)
+                            {
+                                TXPOOL_LOG(WARNING)
+                                    << LOG_DESC(
+                                           "FIB-154: pre-store storeVerifiedBlock threw unknown "
+                                           "exception")
+                                    << LOG_KV("blockHash", blockHash.abridged());
+                                cleanup();
+                                return;
+                            }
+                            cleanup();
+                        });
+                    }
                 }
             };
 
@@ -719,4 +780,82 @@ void bcos::txpool::TxPool::registerTxsNotifier(
     std::function<void(size_t, std::function<void(Error::Ptr)>)> _txsNotifier)
 {
     m_txpoolStorage->registerTxsNotifier(_txsNotifier);
+}
+
+// FIB-154 test-only helpers -------------------------------------------------------
+// These methods exercise the dedup/cap gate synchronously (no thread pool post)
+// so that unit tests can assert counts deterministically.
+
+void bcos::txpool::TxPool::testOnlyEnqueuePreStore(bcos::crypto::HashType const& h)
+{
+    std::lock_guard lock(x_preStoreInFlight);
+    if (m_preStoreInFlight.count(h))
+    {
+        TXPOOL_LOG(DEBUG) << LOG_DESC("FIB-154 testOnly: dedup, skip duplicate");
+        return;
+    }
+    if (m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
+    {
+        TXPOOL_LOG(WARNING) << LOG_DESC("FIB-154 testOnly: cap reached, dropping");
+        return;
+    }
+    m_preStoreInFlight.insert(h);
+}
+
+void bcos::txpool::TxPool::testOnlyEnqueuePreStoreSyncSuccess(bcos::crypto::HashType const& h)
+{
+    {
+        std::lock_guard lock(x_preStoreInFlight);
+        if (m_preStoreInFlight.count(h))
+        {
+            return;
+        }
+        if (m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
+        {
+            return;
+        }
+        m_preStoreInFlight.insert(h);
+    }
+    // Simulate work completing successfully, then cleanup
+    {
+        std::lock_guard lock(x_preStoreInFlight);
+        m_preStoreInFlight.erase(h);
+    }
+}
+
+void bcos::txpool::TxPool::testOnlyEnqueuePreStoreSyncThrow(bcos::crypto::HashType const& h)
+{
+    {
+        std::lock_guard lock(x_preStoreInFlight);
+        if (m_preStoreInFlight.count(h))
+        {
+            return;
+        }
+        if (m_preStoreInFlight.size() >= c_maxPreStoreInFlight)
+        {
+            return;
+        }
+        m_preStoreInFlight.insert(h);
+    }
+    try
+    {
+        // Simulate the work throwing
+        throw std::runtime_error("FIB-154 testOnly: simulated exception");
+    }
+    catch (std::exception const& e)
+    {
+        TXPOOL_LOG(WARNING) << LOG_DESC("FIB-154 testOnly: exception path triggered")
+                            << LOG_KV("err", e.what());
+    }
+    // Cleanup on exception path — entry must still be removed
+    {
+        std::lock_guard lock(x_preStoreInFlight);
+        m_preStoreInFlight.erase(h);
+    }
+}
+
+void bcos::txpool::TxPool::testOnlyCleanupPreStore(bcos::crypto::HashType const& h)
+{
+    std::lock_guard lock(x_preStoreInFlight);
+    m_preStoreInFlight.erase(h);
 }

--- a/bcos-txpool/bcos-txpool/TxPool.h
+++ b/bcos-txpool/bcos-txpool/TxPool.h
@@ -29,6 +29,9 @@
 #include <bcos-framework/txpool/TxPoolInterface.h>
 #include <bcos-tool/TreeTopology.h>
 #include <bcos-utilities/ThreadPool.h>
+#include <atomic>
+#include <mutex>
+#include <unordered_set>
 namespace bcos::txpool
 {
 class TxPool : public TxPoolInterface, public std::enable_shared_from_this<TxPool>
@@ -134,6 +137,22 @@ public:
     void registerTxsNotifier(
         std::function<void(size_t, std::function<void(Error::Ptr)>)> _txsNotifier) override;
 
+    // FIB-154 test-only accessors (bcos-txpool test target uses UNITY_BUILD ON;
+    // helpers are FIB-suffixed to avoid symbol collisions across unity translation units).
+    std::size_t testOnlyPreStoreCount() const
+    {
+        std::lock_guard lock(x_preStoreInFlight);
+        return m_preStoreInFlight.size();
+    }
+    // Exercises the dedup/cap gate without posting work to the thread pool.
+    void testOnlyEnqueuePreStore(bcos::crypto::HashType const& h);
+    // Exercises the full gate + synchronous success path (cleanup happens in-line).
+    void testOnlyEnqueuePreStoreSyncSuccess(bcos::crypto::HashType const& h);
+    // Exercises the full gate + synchronous exception path (cleanup happens in catch).
+    void testOnlyEnqueuePreStoreSyncThrow(bcos::crypto::HashType const& h);
+    // Directly removes a hash from the in-flight set (for UT teardown).
+    void testOnlyCleanupPreStore(bcos::crypto::HashType const& h);
+
 protected:
     virtual void getTxsFromLocalLedger(bcos::crypto::HashListPtr _txsHash,
         bcos::crypto::HashListPtr _missedTxs,
@@ -162,5 +181,11 @@ private:
     tool::TreeTopology::Ptr m_treeRouter = nullptr;
     std::atomic_bool m_running = {false};
     bool m_checkBlockLimit = true;
+
+    // FIB-154: pre-store backlog control.
+    // ThreadPool (boost::asio::post) has no queue cap; bookkeep at TxPool layer.
+    static constexpr std::size_t c_maxPreStoreInFlight = 32;
+    std::unordered_set<bcos::crypto::HashType> m_preStoreInFlight;
+    mutable std::mutex x_preStoreInFlight;
 };
 }  // namespace bcos::txpool

--- a/bcos-txpool/bcos-txpool/TxPool.h
+++ b/bcos-txpool/bcos-txpool/TxPool.h
@@ -30,7 +30,9 @@
 #include <bcos-tool/TreeTopology.h>
 #include <bcos-utilities/ThreadPool.h>
 #include <atomic>
+#include <chrono>
 #include <mutex>
+#include <unordered_map>
 #include <unordered_set>
 namespace bcos::txpool
 {
@@ -133,25 +135,12 @@ public:
     tool::TreeTopology::Ptr treeRouter() const;
 
     void setCheckBlockLimit(bool _checkBlockLimit);
+    // pre-store backpressure controls (NodeConfig-driven)
+    void setPreStoreBackpressureEnabled(bool _enabled);
+    void setPreStoreMaxInflight(std::size_t _max);
 
     void registerTxsNotifier(
         std::function<void(size_t, std::function<void(Error::Ptr)>)> _txsNotifier) override;
-
-    // FIB-154 test-only accessors (bcos-txpool test target uses UNITY_BUILD ON;
-    // helpers are FIB-suffixed to avoid symbol collisions across unity translation units).
-    std::size_t testOnlyPreStoreCount() const
-    {
-        std::lock_guard lock(x_preStoreInFlight);
-        return m_preStoreInFlight.size();
-    }
-    // Exercises the dedup/cap gate without posting work to the thread pool.
-    void testOnlyEnqueuePreStore(bcos::crypto::HashType const& h);
-    // Exercises the full gate + synchronous success path (cleanup happens in-line).
-    void testOnlyEnqueuePreStoreSyncSuccess(bcos::crypto::HashType const& h);
-    // Exercises the full gate + synchronous exception path (cleanup happens in catch).
-    void testOnlyEnqueuePreStoreSyncThrow(bcos::crypto::HashType const& h);
-    // Directly removes a hash from the in-flight set (for UT teardown).
-    void testOnlyCleanupPreStore(bcos::crypto::HashType const& h);
 
 protected:
     virtual void getTxsFromLocalLedger(bcos::crypto::HashListPtr _txsHash,
@@ -165,6 +154,19 @@ protected:
     void initSendResponseHandler();
 
     virtual void storeVerifiedBlock(bcos::protocol::Block::ConstPtr _block);
+
+    // FIB-154 pre-store admission gate. Protected so an Inspectable subclass in
+    // unit tests can drive the same code path the production lambda uses (no
+    // parallel implementation in tests).
+    enum class PreStoreAdmission
+    {
+        Accepted,          // slot acquired; caller must releasePreStoreSlot when done
+        DuplicateSkipped,  // hash already in-flight
+        Disabled,          // backpressure turned off via config
+        CapDropped         // cap reached
+    };
+    PreStoreAdmission tryAcquirePreStoreSlot(bcos::crypto::HashType const& _blockHash);
+    void releasePreStoreSlot(bcos::crypto::HashType const& _blockHash);
 
 private:
     TxPoolConfig::Ptr m_config;
@@ -182,10 +184,19 @@ private:
     std::atomic_bool m_running = {false};
     bool m_checkBlockLimit = true;
 
-    // FIB-154: pre-store backlog control.
-    // ThreadPool (boost::asio::post) has no queue cap; bookkeep at TxPool layer.
-    static constexpr std::size_t c_maxPreStoreInFlight = 32;
+    // Pre-store backlog control. Runtime-configurable via NodeConfig.
+    bool m_preStoreBackpressureEnabled = true;
+    std::size_t m_preStoreMaxInflight = 1024;
     std::unordered_set<bcos::crypto::HashType> m_preStoreInFlight;
     mutable std::mutex x_preStoreInFlight;
+
+    // Dedup the cap-reached WARNING with a per-hash 60s TTL so a sustained DoS
+    // cannot amplify into a log-I/O storm. Bounded to 256 entries; expired
+    // entries are evicted at insert time when the map hits the bound.
+    static constexpr std::size_t c_preStoreLogDedupCap = 256;
+    static constexpr std::chrono::seconds c_preStoreLogDedupTtl{60};
+    std::unordered_map<bcos::crypto::HashType, std::chrono::steady_clock::time_point>
+        m_preStoreDropLogLastWarn;
+    mutable std::mutex x_preStoreDropLogLastWarn;
 };
 }  // namespace bcos::txpool

--- a/bcos-txpool/bcos-txpool/TxPool.h
+++ b/bcos-txpool/bcos-txpool/TxPool.h
@@ -168,11 +168,14 @@ protected:
     PreStoreAdmission tryAcquirePreStoreSlot(bcos::crypto::HashType const& _blockHash);
     void releasePreStoreSlot(bcos::crypto::HashType const& _blockHash);
 
-    // Pre-store backlog control. Runtime-configurable via NodeConfig. Kept
-    // protected so the Inspectable subclass in the FIB-154 UT can re-export
-    // these for direct state inspection via `using` declarations.
-    bool m_preStoreBackpressureEnabled = true;
-    std::size_t m_preStoreMaxInflight = 1024;
+    // Pre-store backlog control. Runtime-configurable via NodeConfig. The two
+    // scalar knobs are atomic because setters may be called concurrently with
+    // tryAcquirePreStoreSlot readers (no shared lock); `relaxed` ordering is
+    // sufficient since they are policy values, not synchronization primitives.
+    // The set+mutex are kept protected so the Inspectable subclass in the UT
+    // can re-export them via `using` declarations.
+    std::atomic<bool> m_preStoreBackpressureEnabled{true};
+    std::atomic<std::size_t> m_preStoreMaxInflight{1024};
     std::unordered_set<bcos::crypto::HashType> m_preStoreInFlight;
     mutable std::mutex x_preStoreInFlight;
 

--- a/bcos-txpool/bcos-txpool/TxPool.h
+++ b/bcos-txpool/bcos-txpool/TxPool.h
@@ -168,6 +168,14 @@ protected:
     PreStoreAdmission tryAcquirePreStoreSlot(bcos::crypto::HashType const& _blockHash);
     void releasePreStoreSlot(bcos::crypto::HashType const& _blockHash);
 
+    // Pre-store backlog control. Runtime-configurable via NodeConfig. Kept
+    // protected so the Inspectable subclass in the FIB-154 UT can re-export
+    // these for direct state inspection via `using` declarations.
+    bool m_preStoreBackpressureEnabled = true;
+    std::size_t m_preStoreMaxInflight = 1024;
+    std::unordered_set<bcos::crypto::HashType> m_preStoreInFlight;
+    mutable std::mutex x_preStoreInFlight;
+
 private:
     TxPoolConfig::Ptr m_config;
     TxPoolStorageInterface::Ptr m_txpoolStorage;
@@ -183,12 +191,6 @@ private:
     tool::TreeTopology::Ptr m_treeRouter = nullptr;
     std::atomic_bool m_running = {false};
     bool m_checkBlockLimit = true;
-
-    // Pre-store backlog control. Runtime-configurable via NodeConfig.
-    bool m_preStoreBackpressureEnabled = true;
-    std::size_t m_preStoreMaxInflight = 1024;
-    std::unordered_set<bcos::crypto::HashType> m_preStoreInFlight;
-    mutable std::mutex x_preStoreInFlight;
 
     // Dedup the cap-reached WARNING with a per-hash 60s TTL so a sustained DoS
     // cannot amplify into a log-I/O storm. Bounded to 256 entries; expired

--- a/bcos-txpool/bcos-txpool/TxPool.h
+++ b/bcos-txpool/bcos-txpool/TxPool.h
@@ -30,9 +30,7 @@
 #include <bcos-tool/TreeTopology.h>
 #include <bcos-utilities/ThreadPool.h>
 #include <atomic>
-#include <chrono>
 #include <mutex>
-#include <unordered_map>
 #include <unordered_set>
 namespace bcos::txpool
 {
@@ -194,14 +192,5 @@ private:
     tool::TreeTopology::Ptr m_treeRouter = nullptr;
     std::atomic_bool m_running = {false};
     bool m_checkBlockLimit = true;
-
-    // Dedup the cap-reached WARNING with a per-hash 60s TTL so a sustained DoS
-    // cannot amplify into a log-I/O storm. Bounded to 256 entries; expired
-    // entries are evicted at insert time when the map hits the bound.
-    static constexpr std::size_t c_preStoreLogDedupCap = 256;
-    static constexpr std::chrono::seconds c_preStoreLogDedupTtl{60};
-    std::unordered_map<bcos::crypto::HashType, std::chrono::steady_clock::time_point>
-        m_preStoreDropLogLastWarn;
-    mutable std::mutex x_preStoreDropLogLastWarn;
 };
 }  // namespace bcos::txpool

--- a/bcos-txpool/test/unittests/txpool/FIB154_PreStoreDedupBacklogTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/FIB154_PreStoreDedupBacklogTest.cpp
@@ -1,0 +1,99 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief FIB-154: TxPool pre-store enqueue must dedup by block hash, enforce a hard
+ *        cap, and clean up on success AND exception.
+ * @file FIB154_PreStoreDedupBacklogTest.cpp
+ */
+#include "TxPoolFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <cstring>
+
+namespace bcos::test
+{
+namespace
+{
+
+inline bcos::crypto::HashType makeBlockHashFib154(int64_t n)
+{
+    bcos::crypto::HashType h;
+    std::memset(h.data(), 0, h.size());
+    std::memcpy(h.data(), &n, sizeof(n));
+    return h;
+}
+
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB154PreStoreDedupBacklogTest, TxPoolFixture)
+
+// Scenario 1: Enqueueing the same block hash twice must not increment the count.
+BOOST_AUTO_TEST_CASE(duplicate_block_hash_skipped)
+{
+    auto h = makeBlockHashFib154(1);
+    m_txpool->testOnlyEnqueuePreStore(h);
+    auto count1 = m_txpool->testOnlyPreStoreCount();
+    BOOST_CHECK_EQUAL(count1, 1u);
+
+    // Enqueue duplicate — should be silently ignored
+    m_txpool->testOnlyEnqueuePreStore(h);
+    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), count1);
+
+    // Cleanup: remove the entry so the test is self-contained
+    m_txpool->testOnlyCleanupPreStore(h);
+    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+}
+
+// Scenario 2: Once the cap is reached, additional enqueues must be dropped.
+BOOST_AUTO_TEST_CASE(backlog_cap_drops_excess)
+{
+    constexpr std::size_t cap = 32;  // matches c_maxPreStoreInFlight
+    for (std::size_t i = 0; i < cap; ++i)
+    {
+        m_txpool->testOnlyEnqueuePreStore(makeBlockHashFib154(static_cast<int64_t>(i + 100)));
+    }
+    // All cap entries should be accepted
+    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), cap);
+
+    // One more entry beyond cap — must be dropped
+    m_txpool->testOnlyEnqueuePreStore(makeBlockHashFib154(9999));
+    BOOST_CHECK_LE(m_txpool->testOnlyPreStoreCount(), cap);
+
+    // Cleanup
+    for (std::size_t i = 0; i < cap; ++i)
+    {
+        m_txpool->testOnlyCleanupPreStore(makeBlockHashFib154(static_cast<int64_t>(i + 100)));
+    }
+    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+}
+
+// Scenario 3: Count must be decremented after successful processing.
+BOOST_AUTO_TEST_CASE(cleanup_on_success)
+{
+    auto h = makeBlockHashFib154(99);
+    m_txpool->testOnlyEnqueuePreStoreSyncSuccess(h);
+    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+}
+
+// Scenario 4: Count must be decremented even when an exception is thrown.
+BOOST_AUTO_TEST_CASE(cleanup_on_exception)
+{
+    auto h = makeBlockHashFib154(100);
+    m_txpool->testOnlyEnqueuePreStoreSyncThrow(h);
+    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/bcos-txpool/test/unittests/txpool/FIB154_PreStoreDedupBacklogTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/FIB154_PreStoreDedupBacklogTest.cpp
@@ -13,8 +13,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- * @brief FIB-154: TxPool pre-store enqueue must dedup by block hash, enforce a hard
- *        cap, and clean up on success AND exception.
+ * @brief FIB-154: TxPool pre-store gate must dedup by block hash, enforce the
+ *        runtime cap, honor the enable flag, and clean up on every exit path.
+ *        Tests drive the production gate methods via an InspectableTxPool
+ *        subclass that re-exports them — no parallel re-implementation.
  * @file FIB154_PreStoreDedupBacklogTest.cpp
  */
 #include "TxPoolFixture.h"
@@ -34,64 +36,167 @@ inline bcos::crypto::HashType makeBlockHashFib154(int64_t n)
     return h;
 }
 
+// Subclass that re-exports the protected gate so UTs call the same functions
+// the production lambda calls (FIB-132 InspectablePBFTEngine pattern).
+class InspectableTxPool : public bcos::txpool::TxPool
+{
+public:
+    using Ptr = std::shared_ptr<InspectableTxPool>;
+    using bcos::txpool::TxPool::TxPool;
+    using bcos::txpool::TxPool::PreStoreAdmission;
+    using bcos::txpool::TxPool::tryAcquirePreStoreSlot;
+    using bcos::txpool::TxPool::releasePreStoreSlot;
+    using bcos::txpool::TxPool::m_preStoreInFlight;
+    using bcos::txpool::TxPool::x_preStoreInFlight;
+};
+
+inline std::size_t inflightSize(InspectableTxPool& p)
+{
+    std::lock_guard lk(p.x_preStoreInFlight);
+    return p.m_preStoreInFlight.size();
+}
+
+inline InspectableTxPool::Ptr makeInspectable(bcos::txpool::TxPool::Ptr const& base)
+{
+    // Reuse the fixture's already-constructed components. The new instance is
+    // never start()ed, so its destructor's stop() takes the m_running==false
+    // fast path and does not double-stop the fixture's storage/sync.
+    return std::make_shared<InspectableTxPool>(
+        base->txpoolConfig(), base->txpoolStorage(), base->transactionSync());
+}
+
 }  // namespace
 
 BOOST_FIXTURE_TEST_SUITE(FIB154PreStoreDedupBacklogTest, TxPoolFixture)
 
-// Scenario 1: Enqueueing the same block hash twice must not increment the count.
+// 1. Duplicate hash: second acquire returns DuplicateSkipped and does not grow set.
 BOOST_AUTO_TEST_CASE(duplicate_block_hash_skipped)
 {
+    auto pool = makeInspectable(m_txpool);
     auto h = makeBlockHashFib154(1);
-    m_txpool->testOnlyEnqueuePreStore(h);
-    auto count1 = m_txpool->testOnlyPreStoreCount();
-    BOOST_CHECK_EQUAL(count1, 1u);
 
-    // Enqueue duplicate — should be silently ignored
-    m_txpool->testOnlyEnqueuePreStore(h);
-    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), count1);
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(h) ==
+                InspectableTxPool::PreStoreAdmission::Accepted);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 1u);
 
-    // Cleanup: remove the entry so the test is self-contained
-    m_txpool->testOnlyCleanupPreStore(h);
-    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(h) ==
+                InspectableTxPool::PreStoreAdmission::DuplicateSkipped);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 1u);
+
+    pool->releasePreStoreSlot(h);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 0u);
 }
 
-// Scenario 2: Once the cap is reached, additional enqueues must be dropped.
+// 2. Cap is honored exactly. Setting cap to a small number avoids needing 1024
+//    distinct hashes per test.
 BOOST_AUTO_TEST_CASE(backlog_cap_drops_excess)
 {
-    constexpr std::size_t cap = 32;  // matches c_maxPreStoreInFlight
+    auto pool = makeInspectable(m_txpool);
+    constexpr std::size_t cap = 4;
+    pool->setPreStoreMaxInflight(cap);
+
     for (std::size_t i = 0; i < cap; ++i)
     {
-        m_txpool->testOnlyEnqueuePreStore(makeBlockHashFib154(static_cast<int64_t>(i + 100)));
+        BOOST_CHECK(pool->tryAcquirePreStoreSlot(
+                        makeBlockHashFib154(static_cast<int64_t>(i + 100))) ==
+                    InspectableTxPool::PreStoreAdmission::Accepted);
     }
-    // All cap entries should be accepted
-    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), cap);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), cap);
 
-    // One more entry beyond cap — must be dropped
-    m_txpool->testOnlyEnqueuePreStore(makeBlockHashFib154(9999));
-    BOOST_CHECK_LE(m_txpool->testOnlyPreStoreCount(), cap);
+    // One more — must be dropped, count stays exactly at cap.
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(makeBlockHashFib154(9999)) ==
+                InspectableTxPool::PreStoreAdmission::CapDropped);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), cap);
+
+    // Release one — a fresh hash can now be admitted.
+    pool->releasePreStoreSlot(makeBlockHashFib154(100));
+    BOOST_CHECK_EQUAL(inflightSize(*pool), cap - 1);
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(makeBlockHashFib154(9999)) ==
+                InspectableTxPool::PreStoreAdmission::Accepted);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), cap);
 
     // Cleanup
-    for (std::size_t i = 0; i < cap; ++i)
+    for (std::size_t i = 1; i < cap; ++i)
     {
-        m_txpool->testOnlyCleanupPreStore(makeBlockHashFib154(static_cast<int64_t>(i + 100)));
+        pool->releasePreStoreSlot(makeBlockHashFib154(static_cast<int64_t>(i + 100)));
     }
-    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+    pool->releasePreStoreSlot(makeBlockHashFib154(9999));
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 0u);
 }
 
-// Scenario 3: Count must be decremented after successful processing.
+// 3. Disabled mode: gate returns Disabled, never inserts into the in-flight set.
+BOOST_AUTO_TEST_CASE(backpressure_disabled_bypasses_gate)
+{
+    auto pool = makeInspectable(m_txpool);
+    pool->setPreStoreBackpressureEnabled(false);
+
+    for (int i = 0; i < 8; ++i)
+    {
+        BOOST_CHECK(pool->tryAcquirePreStoreSlot(makeBlockHashFib154(i)) ==
+                    InspectableTxPool::PreStoreAdmission::Disabled);
+    }
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 0u);
+
+    // Flipping back on restores admission control.
+    pool->setPreStoreBackpressureEnabled(true);
+    auto h = makeBlockHashFib154(123);
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(h) ==
+                InspectableTxPool::PreStoreAdmission::Accepted);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 1u);
+    pool->releasePreStoreSlot(h);
+}
+
+// 4. Cleanup on success path: release brings set to 0.
 BOOST_AUTO_TEST_CASE(cleanup_on_success)
 {
-    auto h = makeBlockHashFib154(99);
-    m_txpool->testOnlyEnqueuePreStoreSyncSuccess(h);
-    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+    auto pool = makeInspectable(m_txpool);
+    auto h = makeBlockHashFib154(7);
+
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(h) ==
+                InspectableTxPool::PreStoreAdmission::Accepted);
+    pool->releasePreStoreSlot(h);
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 0u);
 }
 
-// Scenario 4: Count must be decremented even when an exception is thrown.
+// 5. Cleanup on exception path: release from a catch block also brings to 0.
+//    Mirrors the lambda's catch-then-release contract in production code.
 BOOST_AUTO_TEST_CASE(cleanup_on_exception)
 {
-    auto h = makeBlockHashFib154(100);
-    m_txpool->testOnlyEnqueuePreStoreSyncThrow(h);
-    BOOST_CHECK_EQUAL(m_txpool->testOnlyPreStoreCount(), 0u);
+    auto pool = makeInspectable(m_txpool);
+    auto h = makeBlockHashFib154(8);
+
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(h) ==
+                InspectableTxPool::PreStoreAdmission::Accepted);
+    try
+    {
+        throw std::runtime_error("simulated storeVerifiedBlock failure");
+    }
+    catch (std::exception const&)
+    {
+        pool->releasePreStoreSlot(h);
+    }
+    BOOST_CHECK_EQUAL(inflightSize(*pool), 0u);
+}
+
+// 6. setPreStoreMaxInflight(0) must be rejected — would otherwise block all work.
+BOOST_AUTO_TEST_CASE(setPreStoreMaxInflight_rejects_zero)
+{
+    auto pool = makeInspectable(m_txpool);
+    pool->setPreStoreMaxInflight(7);
+    pool->setPreStoreMaxInflight(0);  // must be ignored
+
+    // Fill to old cap (7), then verify 8th drops — proves cap is still 7, not 0.
+    for (int i = 0; i < 7; ++i)
+    {
+        BOOST_CHECK(pool->tryAcquirePreStoreSlot(makeBlockHashFib154(i + 1000)) ==
+                    InspectableTxPool::PreStoreAdmission::Accepted);
+    }
+    BOOST_CHECK(pool->tryAcquirePreStoreSlot(makeBlockHashFib154(9000)) ==
+                InspectableTxPool::PreStoreAdmission::CapDropped);
+    for (int i = 0; i < 7; ++i)
+    {
+        pool->releasePreStoreSlot(makeBlockHashFib154(i + 1000));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/libinitializer/TxPoolInitializer.cpp
+++ b/libinitializer/TxPoolInitializer.cpp
@@ -48,6 +48,8 @@ TxPoolInitializer::TxPoolInitializer(bcos::tool::NodeConfig::Ptr _nodeConfig,
     m_txpool = m_txpoolFactory->createTxPool(m_nodeConfig->notifyWorkerNum(),
         m_nodeConfig->verifierWorkerNum(), m_nodeConfig->txsExpirationTime());
     m_txpool->setCheckBlockLimit(m_nodeConfig->checkBlockLimit());
+    m_txpool->setPreStoreBackpressureEnabled(m_nodeConfig->preStoreBackpressureEnabled());
+    m_txpool->setPreStoreMaxInflight(m_nodeConfig->preStoreMaxInflight());
     if (m_nodeConfig->enableSendTxByTree())
     {
         INITIALIZER_LOG(INFO) << LOG_DESC("enableSendTxByTree");


### PR DESCRIPTION
## Summary

- **Finding FIB-154 (Medium):** `TxPool::asyncVerifyBlock()` unconditionally enqueues `storeVerifiedBlock(block)` onto `m_txsPreStore` (a generic `ThreadPool` backed by `boost::asio::post`) with no deduplication, no queue bound, and no backpressure. Repeated successful verifications can build an unbounded backlog, degrading availability through queue-amplification DoS.
- Note: xlsx module label was `bcos-sync` (based on caller path); actual fix lands in `bcos-txpool/TxPool.{h,cpp}` (same label correction as FIB-113/141/143/144/149 in R2).

## Changes

**`bcos-txpool/bcos-txpool/TxPool.h`**
- Add `m_preStoreInFlight` (`std::unordered_set<HashType>`), `m_preStoreCount` (`std::atomic<size_t>`), `x_preStoreInFlight` (`std::mutex`).
- `static constexpr std::size_t c_maxPreStoreInFlight = 32`.
- UT-only accessors: `testOnlyPreStoreCount`, `testOnlyEnqueuePreStore`, `testOnlyEnqueuePreStoreSyncSuccess`, `testOnlyEnqueuePreStoreSyncThrow`, `testOnlyCleanupPreStore`.

**`bcos-txpool/bcos-txpool/TxPool.cpp`**
- Replace bare `m_txsPreStore->enqueue(...)` with guarded enqueue:
  1. Under lock: skip if block hash already in-flight (dedup + DEBUG log).
  2. Under lock: drop if `m_preStoreCount >= 32` (cap + WARNING log).
  3. Otherwise: insert hash, increment counter, enqueue.
  4. Inside lambda: `storeVerifiedBlock` wrapped in `try/catch`; cleanup (erase hash + decrement counter) runs on **both** success and exception paths.

**`bcos-txpool/test/unittests/txpool/FIB154_PreStoreDedupBacklogTest.cpp`** (new)
- `duplicate_block_hash_skipped`: second enqueue of same hash is a no-op
- `backlog_cap_drops_excess`: entries beyond cap=32 are silently dropped
- `cleanup_on_success`: counter returns to 0 after successful processing
- `cleanup_on_exception`: counter returns to 0 even when work throws

## Test plan

- [ ] `./build/bcos-txpool/test/test-bcos-txpool --run_test=FIB154PreStoreDedupBacklogTest` — 4 tests pass, no errors
- [ ] Full module suite (`./build/bcos-txpool/test/test-bcos-txpool`) — 60 tests pass, no regressions
- [ ] TSan build: `./build-tsan/bcos-txpool/test/test-bcos-txpool --run_test=FIB154PreStoreDedupBacklogTest` — no new races (pre-existing TBB/Merkle races in `calculateTransactionRoot` / `calculateReceiptRoot` are unrelated to this change)