### PR TITLE
perf(transaction-executor): add VMFactory analysis cache (FIB-93)

### DIFF
--- a/transaction-executor/CMakeLists.txt
+++ b/transaction-executor/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(jsoncpp REQUIRED)
 add_library(transaction-executor
     bcos-transaction-executor/EVMCResult.cpp
     bcos-transaction-executor/vm/VMInstance.cpp
+    bcos-transaction-executor/vm/VMFactory.cpp
     bcos-transaction-executor/precompiled/PrecompiledManager.cpp
     bcos-transaction-executor/precompiled/PrecompiledImpl.cpp
     bcos-transaction-executor/vm/HostContext.cpp

--- a/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
+++ b/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
@@ -10,6 +10,7 @@
 #include "bcos-utilities/Exceptions.h"
 #include "precompiled/PrecompiledManager.h"
 #include "vm/HostContext.h"
+#include "vm/VMFactory.h"
 #include <evmc/evmc.h>
 #include <boost/algorithm/hex.hpp>
 #include <boost/exception/diagnostic_information.hpp>
@@ -37,6 +38,15 @@ public:
     crypto::Hash::Ptr m_hashImpl;
     std::reference_wrapper<PrecompiledManager> m_precompiledManager;
 
+private:
+    // FIB-93: long-lived VMFactory shared across all transactions executed by
+    // this executor. Caches evmone::baseline::CodeAnalysis keyed by code hash
+    // so that identical bytecode at different addresses (clones, proxies,
+    // redeployments) reuses analysis instead of running evmone::baseline::analyze
+    // per address.
+    VMFactory m_vmFactory{c_EVMONE_CACHE_SIZE};
+
+public:
     using TransientStorage =
         bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
             bcos::executor_v1::StateValue, bcos::storage2::memory_storage::ORDERED>;
@@ -89,8 +99,8 @@ public:
                 m_hostContext(m_rollbackableStorage, m_rollbackableTransientStorage, blockHeader,
                     newEVMCMessage(m_blockHeader.get().number(), transaction, m_gasLimit, m_origin),
                     m_origin, transaction.abi(), contextID, m_seq, executor.m_precompiledManager,
-                    ledgerConfig, *executor.m_hashImpl, transaction.type() != 0, m_nonce,
-                    task::syncWait)
+                    ledgerConfig, *executor.m_hashImpl, executor.m_vmFactory,
+                    transaction.type() != 0, m_nonce, task::syncWait)
             {}
         };
         std::unique_ptr<Data> m_data;

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
@@ -79,12 +79,15 @@ bcos::executor_v1::hostcontext::getCacheExecutables()
     return cachedExecutables.m_cachedExecutables;
 }
 
-bcos::executor_v1::hostcontext::Executable::Executable(storage::Entry code, evmc_revision revision)
+bcos::executor_v1::hostcontext::Executable::Executable(
+    VMFactory& vmFactory, storage::Entry code, evmc_revision revision)
   : m_code(std::make_optional(std::move(code))),
-    m_vmInstance(VMFactory::create(VMKind::evmone,
-        bytesConstRef(reinterpret_cast<const uint8_t*>(m_code->data()), m_code->size()), revision))
+    m_vmInstance(vmFactory.create(VMKind::evmone,
+        bytesConstRef(reinterpret_cast<const uint8_t*>(m_code->data()), m_code->size()), revision,
+        /*isCreate=*/false))
 {}
 
-bcos::executor_v1::hostcontext::Executable::Executable(bytesConstRef code, evmc_revision revision)
-  : m_vmInstance(VMFactory::create(VMKind::evmone, code, revision))
+bcos::executor_v1::hostcontext::Executable::Executable(
+    VMFactory& vmFactory, bytesConstRef code, evmc_revision revision, bool isCreate)
+  : m_vmInstance(vmFactory.create(VMKind::evmone, code, revision, isCreate))
 {}

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -25,6 +25,7 @@
 #include "../precompiled/PrecompiledImpl.h"
 #include "../precompiled/PrecompiledManager.h"
 #include "EVMHostInterface.h"
+#include "VMFactory.h"
 #include "VMInstance.h"
 #include "bcos-codec/abi/ContractABICodec.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
@@ -81,8 +82,10 @@ evmc_message getMessage(bool web3Tx, const evmc_message& inputMessage,
 
 struct Executable
 {
-    Executable(storage::Entry code, evmc_revision revision);
-    Executable(bytesConstRef code, evmc_revision revision);
+    // FIB-93: VMFactory& threaded in for code-hash analysis caching.
+    Executable(VMFactory& vmFactory, storage::Entry code, evmc_revision revision);
+    Executable(
+        VMFactory& vmFactory, bytesConstRef code, evmc_revision revision, bool isCreate = false);
 
     std::optional<storage::Entry> m_code;
     VMInstance m_vmInstance;
@@ -98,8 +101,8 @@ using CacheExecutables =
         std::hash<evmc_address>>;
 CacheExecutables& getCacheExecutables();
 
-task::Task<std::shared_ptr<Executable>> getExecutable(
-    auto& storage, const evmc_address& address, const evmc_revision& revision, bool binaryAddress)
+task::Task<std::shared_ptr<Executable>> getExecutable(auto& storage, VMFactory& vmFactory,
+    const evmc_address& address, const evmc_revision& revision, bool binaryAddress)
 {
     if (auto executable = co_await storage2::readOne(getCacheExecutables(), address))
     {
@@ -109,7 +112,7 @@ task::Task<std::shared_ptr<Executable>> getExecutable(
     if (Account<std::decay_t<decltype(storage)>> account(storage, address, binaryAddress);
         auto codeEntry = co_await account.code())
     {
-        auto executable = std::make_shared<Executable>(std::move(*codeEntry), revision);
+        auto executable = std::make_shared<Executable>(vmFactory, std::move(*codeEntry), revision);
         co_await storage2::writeOne(getCacheExecutables(), address, executable);
         co_return executable;
     }
@@ -130,6 +133,10 @@ private:
     std::reference_wrapper<const PrecompiledManager> m_precompiledManager;
     std::reference_wrapper<const ledger::LedgerConfig> m_ledgerConfig;
     std::reference_wrapper<const crypto::Hash> m_hashImpl;
+    // FIB-93: long-lived VMFactory owned by TransactionExecutorImpl, threaded
+    // through HostContext to avoid per-call instantiation. Cache entries persist
+    // across HostContexts so identical bytecode reuses analysis.
+    std::reference_wrapper<VMFactory> m_vmFactory;
     evmc_message m_message;
     Account<Storage> m_recipientAccount;
 
@@ -186,7 +193,7 @@ private:
         const protocol::BlockHeader& blockHeader, const evmc_message& message,
         const evmc_address& origin, std::string_view abi, int contextID, int64_t& seq,
         PrecompiledManager const& precompiledManager, ledger::LedgerConfig const& ledgerConfig,
-        crypto::Hash const& hashImpl, bool web3Tx, const u256& nonce,
+        crypto::Hash const& hashImpl, VMFactory& vmFactory, bool web3Tx, const u256& nonce,
         const evmc_host_interface* hostInterface)
       : evmc_host_context{.interface = hostInterface,
             .wasm_interface = nullptr,
@@ -204,6 +211,7 @@ private:
         m_precompiledManager(precompiledManager),
         m_ledgerConfig(ledgerConfig),
         m_hashImpl(hashImpl),
+        m_vmFactory(vmFactory),
         m_message(getMessage(
             web3Tx, message, m_blockHeader.get().number(), m_contextID, m_seq, nonce, m_hashImpl)),
         m_recipientAccount(getAccount(*this, this->message().recipient)),
@@ -217,9 +225,10 @@ public:
         protocol::BlockHeader const& blockHeader, const evmc_message& message,
         const evmc_address& origin, std::string_view abi, int contextID, int64_t& seq,
         PrecompiledManager const& precompiledManager, ledger::LedgerConfig const& ledgerConfig,
-        crypto::Hash const& hashImpl, bool web3Tx, const u256& nonce, auto&& waitOperator)
+        crypto::Hash const& hashImpl, VMFactory& vmFactory, bool web3Tx, const u256& nonce,
+        auto&& waitOperator)
       : HostContext(innerConstructor, storage, transientStorage, blockHeader, message, origin, abi,
-            contextID, seq, precompiledManager, ledgerConfig, hashImpl, web3Tx, nonce,
+            contextID, seq, precompiledManager, ledgerConfig, hashImpl, vmFactory, web3Tx, nonce,
             getHostInterface<HostContext>(std::forward<decltype(waitOperator)>(waitOperator)))
     {}
 
@@ -291,8 +300,8 @@ public:
     task::Task<std::optional<storage::Entry>> code(
         const evmc_address& address, auto&&... /*unused*/)
     {
-        if (auto executable = co_await getExecutable(m_rollbackableStorage.get(), address,
-                m_revision,
+        if (auto executable = co_await getExecutable(m_rollbackableStorage.get(), m_vmFactory.get(),
+                address, m_revision,
                 m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
             executable && executable->m_code)
         {
@@ -530,8 +539,8 @@ public:
         auto nonce = u256(nonceStr.value_or(std::string("0")));
         HostContext hostcontext(innerConstructor, m_rollbackableStorage.get(),
             m_rollbackableTransientStorage.get(), m_blockHeader, message, m_origin, {}, m_contextID,
-            m_seq, m_precompiledManager.get(), m_ledgerConfig, m_hashImpl, m_web3Tx, nonce,
-            interface);
+            m_seq, m_precompiledManager.get(), m_ledgerConfig, m_hashImpl, m_vmFactory.get(),
+            m_web3Tx, nonce, interface);
 
         co_await hostcontext.prepare();
         auto result = co_await hostcontext.execute();
@@ -551,7 +560,9 @@ private:
     {
         auto& ref = message();
         bytesConstRef createCode(ref.input_data, ref.input_size);
-        m_executable = std::make_shared<Executable>(createCode, m_revision);
+        // FIB-93: isCreate=true bypasses the code-hash cache (mirrors non-v1).
+        m_executable = std::make_shared<Executable>(
+            m_vmFactory.get(), createCode, m_revision, /*isCreate=*/true);
     }
 
     task::Task<EVMCResult> executeCreate()
@@ -705,8 +716,8 @@ private:
                 m_ledgerConfig.get().authCheckStatus(), m_ledgerConfig.get().features());
         }
 
-        if (m_executable = co_await getExecutable(m_rollbackableStorage.get(), ref.code_address,
-                m_revision,
+        if (m_executable = co_await getExecutable(m_rollbackableStorage.get(), m_vmFactory.get(),
+                ref.code_address, m_revision,
                 m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address));
             !m_executable)
         {

--- a/transaction-executor/bcos-transaction-executor/vm/VMFactory.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/VMFactory.cpp
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief factory of vm
+ * @file VMFactory.cpp
+ * @author: ancelmo
+ * @date: 2022-12-15
+ */
+
+#include "VMFactory.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include <evmone/baseline.hpp>
+
+namespace bcos::executor_v1
+{
+
+VMFactory::VMFactory(std::size_t cacheSize) : m_cache(cacheSize) {}
+
+VMInstance VMFactory::create(VMKind kind, bytesConstRef code, evmc_revision mode, bool isCreate)
+{
+    switch (kind)
+    {
+    case VMKind::evmone:
+    {
+        try
+        {
+            // FIB-93: matches non-v1 semantics (bcos-executor/src/vm/VMFactory.cpp:60) —
+            // bypass code-hash cache for CREATE paths. Each CREATE gets a fresh analysis
+            // because the bytecode is deployment input that may not be cacheable across
+            // calls and conventionally wins no benefit from caching.
+            if (isCreate)
+            {
+                auto analysis = std::make_shared<evmone::baseline::CodeAnalysis const>(
+                    evmone::baseline::analyze(
+                        mode, evmone::bytes_view(
+                                  reinterpret_cast<const uint8_t*>(code.data()), code.size())));
+                return VMInstance{std::move(analysis)};
+            }
+            return VMInstance{getOrCompute(bcos::crypto::keccak256Hash(code), mode, code)};
+        }
+        catch (const std::exception& e)
+        {
+            BCOS_LOG(ERROR) << LOG_BADGE("VM") << "Failed to analyze bytecode: " << e.what();
+            BOOST_THROW_EXCEPTION(UnknownVMError{});
+        }
+    }
+    default:
+        BOOST_THROW_EXCEPTION(UnknownVMError{});
+    }
+}
+
+std::shared_ptr<evmone::baseline::CodeAnalysis const> VMFactory::getOrCompute(
+    const bcos::crypto::HashType& key, evmc_revision revision, bytesConstRef code)
+{
+    {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        // Mirror non-v1 strategy: only return a cache hit if revision matches.
+        if (revision == m_revision)
+        {
+            if (auto entry = m_cache.get(key); entry)
+            {
+                return *entry;
+            }
+        }
+    }
+
+    // Compute outside the lock: race-tolerant per Codex review — concurrent
+    // same-key analyses produce equivalent results, last-writer-wins on insert.
+    auto analysis =
+        std::make_shared<evmone::baseline::CodeAnalysis const>(evmone::baseline::analyze(revision,
+            evmone::bytes_view(reinterpret_cast<const uint8_t*>(code.data()), code.size())));
+
+    {
+        std::lock_guard<std::mutex> lock(m_cacheMutex);
+        if (revision != m_revision)
+        {
+            // Mirror non-v1 (VMFactory.cpp:99): revision change clears the cache.
+            m_cache.clear();
+            m_revision = revision;
+        }
+        m_cache.insert(key, analysis);
+    }
+    return analysis;
+}
+
+std::size_t VMFactory::testOnlyCacheSize() const noexcept
+{
+    std::lock_guard<std::mutex> lock(m_cacheMutex);
+    return m_cache.size();
+}
+
+}  // namespace bcos::executor_v1

--- a/transaction-executor/bcos-transaction-executor/vm/VMFactory.h
+++ b/transaction-executor/bcos-transaction-executor/vm/VMFactory.h
@@ -21,15 +21,23 @@
 
 #pragma once
 #include "VMInstance.h"
+#include "bcos-crypto/interfaces/crypto/CommonType.h"
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Error.h"
 #include "bcos-utilities/Exceptions.h"
+#include <evmc/evmc.h>
 #include <evmone/evmone.h>
+#include <boost/compute/detail/lru_cache.hpp>
 #include <boost/throw_exception.hpp>
+#include <evmone/baseline.hpp>
 #include <memory>
+#include <mutex>
 
 namespace bcos::executor_v1
 {
+
+constexpr std::size_t c_EVMONE_CACHE_SIZE = 1024;
+
 enum class VMKind
 {
     evmone,
@@ -37,31 +45,34 @@ enum class VMKind
 
 DERIVE_BCOS_EXCEPTION(UnknownVMError);
 
+/// FIB-93: stateful VM factory holding a single-revision LRU cache of
+/// evmone CodeAnalysis keyed by code hash. Mirrors the strategy of the non-v1
+/// executor in bcos-executor/src/vm/VMFactory: cache entries belong to ONE
+/// EVMC revision; inserting with a different revision clears the cache.
+/// Sits BENEATH HostContext's address-keyed Executable cache: identical
+/// bytecode at distinct addresses (clones / proxies / redeployments) reuses
+/// the same CodeAnalysis instead of re-running evmone::baseline::analyze.
 class VMFactory
 {
 public:
-    static VMInstance create(VMKind kind, bytesConstRef code, evmc_revision mode)
-    {
-        switch (kind)
-        {
-        case VMKind::evmone:
-        {
-            // FIB-95: wrap analyze() in try/catch to prevent unhandled exceptions
-            try
-            {
-                return VMInstance{
-                    std::make_shared<evmone::baseline::CodeAnalysis>(evmone::baseline::analyze(
-                        mode, evmone::bytes_view((const uint8_t*)code.data(), code.size())))};
-            }
-            catch (const std::exception& e)
-            {
-                BCOS_LOG(ERROR) << LOG_BADGE("VM") << "Failed to analyze bytecode: " << e.what();
-                BOOST_THROW_EXCEPTION(UnknownVMError{});
-            }
-        }
-        default:
-            BOOST_THROW_EXCEPTION(UnknownVMError{});
-        }
-    }
+    explicit VMFactory(std::size_t cacheSize = c_EVMONE_CACHE_SIZE);
+
+    /// Returns a VMInstance wrapping a (possibly cached) CodeAnalysis.
+    /// isCreate=true bypasses the cache (mirrors non-v1 VMFactory.cpp:60).
+    VMInstance create(VMKind kind, bytesConstRef code, evmc_revision mode, bool isCreate = false);
+
+    /// Test-only accessor for the current cache occupancy. NOT for production.
+    std::size_t testOnlyCacheSize() const noexcept;
+
+private:
+    std::shared_ptr<evmone::baseline::CodeAnalysis const> getOrCompute(
+        const bcos::crypto::HashType& key, evmc_revision revision, bytesConstRef code);
+
+    boost::compute::detail::lru_cache<bcos::crypto::HashType,
+        std::shared_ptr<evmone::baseline::CodeAnalysis const>>
+        m_cache;
+    evmc_revision m_revision = EVMC_PARIS;
+    mutable std::mutex m_cacheMutex;
 };
+
 }  // namespace bcos::executor_v1

--- a/transaction-executor/bcos-transaction-executor/vm/VMInstance.h
+++ b/transaction-executor/bcos-transaction-executor/vm/VMInstance.h
@@ -52,6 +52,14 @@ public:
         evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t codeSize);
 
     void enableDebugOutput();
+
+    /// FIB-93 test-only: returns the raw pointer to the held CodeAnalysis to
+    /// enable identity comparison in cache-hit unit tests. NOT for production
+    /// callers — execution always goes through execute().
+    evmone::baseline::CodeAnalysis const* analysisRawPtr() const noexcept
+    {
+        return m_instance.get();
+    }
 };
 
 }  // namespace bcos::executor_v1

--- a/transaction-executor/tests/FIB88_92_ErrorHandlingTest.cpp
+++ b/transaction-executor/tests/FIB88_92_ErrorHandlingTest.cpp
@@ -59,6 +59,8 @@ public:
     std::optional<PrecompiledManager> precompiledManager;
     bcos::ledger::LedgerConfig ledgerConfig;
     bcostars::protocol::BlockHeaderImpl blockHeader;
+    // FIB-93: long-lived VMFactory shared across HostContexts in this fixture.
+    bcos::executor_v1::VMFactory vmFactory;
 
     FIB88_92_Fixture()
       : rollbackableStorage(storage), rollbackableTransientStorage(transientStorage)
@@ -97,8 +99,8 @@ public:
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         syncWait(hostContext.prepare());
         auto result = syncWait(hostContext.execute());
         BOOST_REQUIRE_EQUAL(result.status_code, 0);
@@ -150,8 +152,8 @@ BOOST_AUTO_TEST_CASE(FIB88_InsufficientBalanceConsumesAllGas)
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         co_await hostContext.prepare();
         auto result = co_await hostContext.execute();
 
@@ -195,8 +197,8 @@ BOOST_AUTO_TEST_CASE(FIB88_NotFoundCodeRevertPreservesGas)
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         co_await hostContext.prepare();
         auto result = co_await hostContext.execute();
 
@@ -237,8 +239,8 @@ BOOST_AUTO_TEST_CASE(FIB88_NotFoundCodeStaticCallReturnsSuccess)
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         co_await hostContext.prepare();
         auto result = co_await hostContext.execute();
 
@@ -304,8 +306,8 @@ BOOST_AUTO_TEST_CASE(FIB91_AuthCheckInsideTryBlock)
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         co_await hostContext.prepare();
 
         // FIB-91: execute() must not throw even when auth checking is enabled.
@@ -398,7 +400,7 @@ BOOST_AUTO_TEST_CASE(FIB88_FlagOff_InsufficientBalancePreservesGas)
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, oldHeader, message,
-                origin, "", 0, seq, *precompiledManager, oldConfig, *hashImpl, false, 0,
+                origin, "", 0, seq, *precompiledManager, oldConfig, *hashImpl, vmFactory, false, 0,
                 bcos::task::syncWait);
         co_await hostContext.prepare();
         auto result = co_await hostContext.execute();

--- a/transaction-executor/tests/FIB93_VMFactoryAnalysisCacheTest.cpp
+++ b/transaction-executor/tests/FIB93_VMFactoryAnalysisCacheTest.cpp
@@ -1,0 +1,160 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief FIB-93 unit tests for VMFactory analysis cache.
+ *        Same code at the same revision reuses analysis (cache hit). Distinct
+ *        code yields distinct analyses. Cache is single-revision: switching
+ *        revision clears the cache (mirrors non-v1 VMFactory.cpp:99).
+ *        isCreate path bypasses the cache.
+ */
+
+#include "../bcos-transaction-executor/vm/VMFactory.h"
+#include "../bcos-transaction-executor/vm/VMInstance.h"
+#include <bcos-utilities/Common.h>
+#include <evmc/evmc.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+namespace bcos::test
+{
+namespace
+{
+
+inline bcos::bytes makeBytecodeFib93(int seed)
+{
+    // 64-byte deterministic payload; varying seed yields different code hashes.
+    bcos::bytes code;
+    code.resize(64);
+    for (int i = 0; i < 64; ++i)
+    {
+        code[i] = static_cast<bcos::byte>(seed + i);
+    }
+    return code;
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(FIB93VMFactoryAnalysisCacheTest)
+
+BOOST_AUTO_TEST_CASE(same_code_same_revision_cache_hit)
+{
+    bcos::executor_v1::VMFactory factory;
+    auto code = makeBytecodeFib93(1);
+    auto vm1 = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(code.data(), code.size()), EVMC_PARIS, false);
+    auto vm2 = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(code.data(), code.size()), EVMC_PARIS, false);
+    // Cache hit: both VMInstances share the same CodeAnalysis pointer.
+    BOOST_CHECK(vm1.analysisRawPtr() != nullptr);
+    BOOST_CHECK_EQUAL(vm1.analysisRawPtr(), vm2.analysisRawPtr());
+    BOOST_CHECK_EQUAL(factory.testOnlyCacheSize(), 1U);
+}
+
+BOOST_AUTO_TEST_CASE(different_code_distinct_analyses)
+{
+    bcos::executor_v1::VMFactory factory;
+    auto codeA = makeBytecodeFib93(1);
+    auto codeB = makeBytecodeFib93(2);
+    auto vmA = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(codeA.data(), codeA.size()), EVMC_PARIS, false);
+    auto vmB = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(codeB.data(), codeB.size()), EVMC_PARIS, false);
+    BOOST_CHECK(vmA.analysisRawPtr() != vmB.analysisRawPtr());
+    BOOST_CHECK_EQUAL(factory.testOnlyCacheSize(), 2U);
+}
+
+BOOST_AUTO_TEST_CASE(revision_change_clears_cache)
+{
+    // Mirrors non-v1 behavior (bcos-executor/src/vm/VMFactory.cpp:99): cache holds
+    // entries for ONE revision; insert with a different revision clears the cache.
+    // Hence the same code at a different revision results in a fresh analysis,
+    // and going back to the original revision after the switch ALSO re-analyzes
+    // because the prior PARIS entry was evicted by the SHANGHAI insert.
+    bcos::executor_v1::VMFactory factory;
+    auto code = makeBytecodeFib93(1);
+    auto vmParis = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(code.data(), code.size()), EVMC_PARIS, false);
+    auto vmShang = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(code.data(), code.size()), EVMC_SHANGHAI, false);
+    BOOST_CHECK(vmParis.analysisRawPtr() != vmShang.analysisRawPtr());
+    // After SHANGHAI insert, cache only holds SHANGHAI entries.
+    BOOST_CHECK_EQUAL(factory.testOnlyCacheSize(), 1U);
+
+    // PARIS lookup re-analyzes (different from the original PARIS analysis).
+    auto vmParis2 = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(code.data(), code.size()), EVMC_PARIS, false);
+    BOOST_CHECK(vmParis2.analysisRawPtr() != vmParis.analysisRawPtr());
+    BOOST_CHECK(vmParis2.analysisRawPtr() != vmShang.analysisRawPtr());
+}
+
+BOOST_AUTO_TEST_CASE(isCreate_bypasses_cache)
+{
+    bcos::executor_v1::VMFactory factory;
+    auto code = makeBytecodeFib93(11);
+    auto vm1 = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(code.data(), code.size()), EVMC_PARIS, /*isCreate=*/true);
+    auto vm2 = factory.create(bcos::executor_v1::VMKind::evmone,
+        bcos::bytesConstRef(code.data(), code.size()), EVMC_PARIS, /*isCreate=*/true);
+    // isCreate path mirrors non-v1 semantics: bypass cache; each call freshly
+    // analyzes. The two analyses are distinct heap objects.
+    BOOST_CHECK(vm1.analysisRawPtr() != nullptr);
+    BOOST_CHECK(vm2.analysisRawPtr() != nullptr);
+    BOOST_CHECK(vm1.analysisRawPtr() != vm2.analysisRawPtr());
+    // Cache untouched by isCreate path.
+    BOOST_CHECK_EQUAL(factory.testOnlyCacheSize(), 0U);
+}
+
+BOOST_AUTO_TEST_CASE(concurrent_create_no_data_race)
+{
+    // Per Codex review: get/put pattern is race-tolerant — concurrent same-key
+    // analyses produce equivalent results (last-writer-wins on insert). This UT
+    // verifies the contract of "no crash + cache eventually populated"; the
+    // stronger "only-once analyze" property is NOT promised. Run with TSan to
+    // confirm no data race.
+    bcos::executor_v1::VMFactory factory;
+    auto code = makeBytecodeFib93(7);
+    constexpr int N = 8;
+    constexpr int ITER = 100;
+    std::vector<std::thread> threads;
+    threads.reserve(N);
+    std::atomic<int> nonNullCount{0};
+    for (int i = 0; i < N; ++i)
+    {
+        threads.emplace_back([&]() {
+            for (int j = 0; j < ITER; ++j)
+            {
+                auto vm = factory.create(bcos::executor_v1::VMKind::evmone,
+                    bcos::bytesConstRef(code.data(), code.size()), EVMC_PARIS, false);
+                if (vm.analysisRawPtr() != nullptr)
+                {
+                    nonNullCount.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& t : threads)
+    {
+        t.join();
+    }
+    BOOST_CHECK_EQUAL(nonNullCount.load(), N * ITER);
+    // Cache holds exactly one entry (single distinct code hash at single revision).
+    BOOST_CHECK_EQUAL(factory.testOnlyCacheSize(), 1U);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/transaction-executor/tests/TestHostContext.cpp
+++ b/transaction-executor/tests/TestHostContext.cpp
@@ -57,6 +57,8 @@ public:
     std::optional<PrecompiledManager> precompiledManager;
     bcos::ledger::LedgerConfig ledgerConfig;
     bcostars::protocol::BlockHeaderImpl blockHeader;
+    // FIB-93: long-lived VMFactory shared across HostContexts in this fixture.
+    bcos::executor_v1::VMFactory vmFactory;
 
     TestHostContextFixture()
       : rollbackableStorage(storage), rollbackableTransientStorage(transientStorage)
@@ -90,8 +92,8 @@ public:
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         syncWait(hostContext.prepare());
         auto result = syncWait(hostContext.execute());
         BOOST_REQUIRE_EQUAL(result.status_code, 0);
@@ -129,8 +131,8 @@ public:
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, web3, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, web3,
+                0, bcos::task::syncWait);
         co_await hostContext.prepare();
         auto result = co_await hostContext.execute();
 
@@ -179,7 +181,7 @@ public:
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, header, message, origin,
-                "", 0, seq, *precompiledManager, ledgerConfig, hashImpl, false, 0,
+                "", 0, seq, *precompiledManager, ledgerConfig, hashImpl, vmFactory, false, 0,
                 bcos::task::syncWait);
         co_await hostContext.prepare();
         BOOST_CHECK_NO_THROW(auto result = co_await hostContext.execute());
@@ -289,8 +291,8 @@ BOOST_AUTO_TEST_CASE(emptyCreate)
         evmc_address origin{};
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
 
         co_await hostContext.prepare();
         auto result = co_await hostContext.execute();
@@ -404,8 +406,8 @@ BOOST_AUTO_TEST_CASE(precompiled)
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         syncWait(hostContext.prepare());
 
         auto notFoundResult = syncWait(hostContext.execute());
@@ -421,8 +423,8 @@ BOOST_AUTO_TEST_CASE(precompiled)
         features.set(bcos::ledger::Features::Flag::feature_sharding);
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             hostContext2(rollbackableStorage, rollbackableTransientStorage, blockHeader, message,
-                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory, false,
+                0, bcos::task::syncWait);
         syncWait(hostContext2.prepare());
         BOOST_CHECK_NO_THROW(result.emplace(syncWait(hostContext2.execute())));
     }
@@ -509,8 +511,8 @@ BOOST_AUTO_TEST_CASE(codeSize)
 
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             codeSizeHostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader,
-                message, {}, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                message, {}, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, vmFactory,
+                false, 0, bcos::task::syncWait);
 
         auto builtinAddress = bcos::unhexAddress("0000000000000000000000000000000000000001");
         auto size = co_await codeSizeHostContext.codeSizeAt(builtinAddress);
@@ -549,8 +551,8 @@ BOOST_AUTO_TEST_CASE(transferBalance)
         evmc_address origin{};
         HostContext<decltype(rollbackableStorage), decltype(rollbackableTransientStorage)>
             transferHostContext(rollbackableStorage, rollbackableTransientStorage, blockHeader,
-                message, origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl, false, 0,
-                bcos::task::syncWait);
+                message, origin, "", 0, seq, *precompiledManager, ledgerConfig, *hashImpl,
+                vmFactory, false, 0, bcos::task::syncWait);
         co_await transferHostContext.prepare();
         auto evmResult = co_await transferHostContext.execute();
         BOOST_CHECK_EQUAL(evmResult.status_code, EVMC_SUCCESS);


### PR DESCRIPTION
## Summary

Port the evmone-baseline analysis cache from the non-v1 executor (`bcos-executor/src/vm/VMFactory`) into `transaction-executor/bcos-transaction-executor/vm/VMFactory`. The v1 path previously invoked `evmone::baseline::analyze()` on every Executable construction, with no code-hash keyed reuse. Although HostContext maintains an LRU keyed by `evmc_address`, identical bytecode at distinct addresses (clones, proxies, redeployments) repeatedly re-analyzes — CPU overhead and a sustained DoS vector when an attacker deploys the same code at many addresses.

## Fix

- VMFactory transitions from a static-method-only class to a stateful instance class holding a single-revision LRU cache keyed by `keccak256(code)`. Cache strategy mirrors the non-v1 reference exactly: cache entries belong to ONE EVMC revision; inserting a new revision clears the cache (`bcos-executor/src/vm/VMFactory.cpp:99`).
- `isCreate=true` bypasses the cache (matches non-v1 semantics at `bcos-executor/src/vm/VMFactory.cpp:60`).
- The factory's lookup uses a get-then-insert pattern that releases the mutex during `evmone::baseline::analyze()`. Per the Codex review, concurrent same-key analyses are race-tolerant: equivalent results, last-writer-wins on insert. The UT therefore validates "no data race + non-null result" rather than "only-once analyze".
- v1 callers (`HostContext::prepareCreate`, `executeCall`, `externalCall` recursion, and the `getExecutable` free function) are migrated to take a `VMFactory&` reference owned by `TransactionExecutorImpl` (long-lived; shared across all transactions executed by an instance).
- `VMInstance.h` exposes a UT-only `analysisRawPtr()` accessor so cache-hit assertions can compare identity.
- `transaction-executor/CMakeLists.txt:10-17` (hand-list of sources) is updated to include the new `vm/VMFactory.cpp`.

## Test plan

- [x] `cmake --build build --target test-transaction-executor`
- [x] `./build/transaction-executor/tests/test-transaction-executor --run_test=FIB93VMFactoryAnalysisCacheTest` — five scenarios pass (15 assertions): `same_code_same_revision_cache_hit`, `different_code_distinct_analyses`, `revision_change_clears_cache`, `isCreate_bypasses_cache`, `concurrent_create_no_data_race`.
- [x] Full `test-transaction-executor` suite: no new regressions vs `release-3.17.0` baseline (the 5 pre-existing `proxyReceive` failures are reproducible without this change and are unrelated).
