### PR TITLE
fix(leader-election): cap etcd payload + narrow lock scope (FIB-168, 169)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,13 @@ if(FULLNODE)
         add_subdirectory(tests)
         add_subdirectory(benchmark)
     endif()
+
+    # bcos-leader-election can also be built standalone (without the full Tars
+    # stack) when only WITH_LEDGER_ELECTION is set. Place this AFTER
+    # enable_testing() so that the module's UTs are visible to ctest.
+    if(NOT WITH_TARS_SERVICES AND WITH_LEDGER_ELECTION)
+        add_subdirectory(bcos-leader-election)
+    endif()
 endif()
 
 if(WITH_CPPSDK)

--- a/bcos-leader-election/CMakeLists.txt
+++ b/bcos-leader-election/CMakeLists.txt
@@ -26,4 +26,8 @@ if(WITH_LEDGER_ELECTION)
     find_package(gRPC REQUIRED)
     add_library(${LEADER_ELECTION_TARGET} ${SRCS})
     target_link_libraries(${LEADER_ELECTION_TARGET} PUBLIC bcos-utilities bcos-framework etcd-cpp-api)
+
+    if(TESTS)
+        add_subdirectory(test)
+    endif()
 endif()

--- a/bcos-leader-election/src/LeaderElection.cpp
+++ b/bcos-leader-election/src/LeaderElection.cpp
@@ -88,16 +88,25 @@ std::pair<bool, int64_t> LeaderElection::grantLease()
 
 bool LeaderElection::campaignLeader()
 {
+    // FIB-169: do NOT hold m_mutex across blocking etcd RPCs or external
+    // handler callbacks. The lock is now used only to serialize the small
+    // bookkeeping window where we swap m_keepAlive and update the config's
+    // leader pointer; everything else (etcd grantLease/txn, m_onCampaignHandler,
+    // tryToSwitchToBackup) runs without the lock so a stalled etcd request or
+    // slow user-supplied handler cannot block sibling campaign / updateSelfConfig
+    // threads.
     try
     {
-        RecursiveGuard l(m_mutex);
-        // already has leader
+        // Step 1 (no lock): if there is already a leader, just defer to backup
+        // promotion logic. tryToSwitchToBackup() invokes m_onCampaignHandler and
+        // therefore must not run under m_mutex.
         if (m_config->getLeader())
         {
-            // tryToSwitchToBackup in case of the leader is not the node-self
             tryToSwitchToBackup();
             return false;
         }
+
+        // Step 2 (no lock): grantLease() performs a blocking etcd RPC.
         auto ret = grantLease();
         if (!ret.first)
         {
@@ -106,10 +115,18 @@ bool LeaderElection::campaignLeader()
             return false;
         }
         auto leaseID = ret.second;
-        auto tx = std::make_shared<etcdv3::Transaction>(m_config->leaderKey());
+
+        // Snapshot config-derived state without holding m_mutex; CampaignConfig
+        // already serializes its own internal state with x_self / x_leader.
+        auto const leaderKey = m_config->leaderKey();
+        auto const leaderValue = m_config->leaderValue();
+
+        auto tx = std::make_shared<etcdv3::Transaction>(leaderKey);
         tx->init_compare(0, etcdv3::CompareResult::EQUAL, etcdv3::CompareTarget::MOD);
-        tx->setup_basic_failure_operation(m_config->leaderKey());
-        tx->setup_basic_create_sequence(m_config->leaderKey(), m_config->leaderValue(), leaseID);
+        tx->setup_basic_failure_operation(leaderKey);
+        tx->setup_basic_create_sequence(leaderKey, leaderValue, leaseID);
+
+        // Step 3 (no lock): blocking etcd txn RPC.
         auto response = m_etcdClient->txn(*tx).get();
         if (!response.is_ok())
         {
@@ -128,40 +145,55 @@ bool LeaderElection::campaignLeader()
                                << LOG_KV("code", response.error_code())
                                << LOG_KV("purpose", m_config->purpose())
                                << LOG_KV("lease", leaseID);
+            // tryToSwitchToBackup invokes m_onCampaignHandler — outside lock.
             tryToSwitchToBackup();
             return false;
         }
         m_campaignTimer->stop();
-        ELECTION_LOG(INFO) << LOG_DESC("campaignLeader success")
-                           << LOG_KV("leaderKey", m_config->leaderKey())
+        ELECTION_LOG(INFO) << LOG_DESC("campaignLeader success") << LOG_KV("leaderKey", leaderKey)
                            << LOG_KV("purpose", m_config->purpose()) << LOG_KV("lease", leaseID)
                            << LOG_KV("version", response.value().version())
                            << LOG_KV("msg", response.error_message())
                            << LOG_KV("value", response.value().as_string())
                            << LOG_KV("key", response.value().key());
-        // cancel the old keepAlive
-        if (m_keepAlive)
-        {
-            ELECTION_LOG(INFO) << LOG_DESC("campaignLeader: cancel keepAlive thread")
-                               << LOG_KV("lease", m_keepAlive->Lease())
-                               << LOG_KV("leaderKey", m_config->leaderKey());
-            m_keepAlive->Cancel();
-        }
-        // establish new keepAlive
+
+        // Step 4 (brief critical section): swap m_keepAlive and commit
+        // setLeaderToSelf. This is the ONLY work that needs m_mutex and it
+        // does no I/O — etcd::KeepAlive construction is non-blocking; the
+        // background heartbeat runs on its own thread.
         auto keepAliveTTL = m_config->leaseTTL() - 1;
         auto weakSelf = std::weak_ptr<LeaderElection>(shared_from_this());
-        m_keepAlive = std::make_shared<etcd::KeepAlive>(
-            *(m_config->etcdClient()),
-            [weakSelf](std::exception_ptr e) {
-                auto self = weakSelf.lock();
-                if (!self)
-                {
-                    return;
-                }
-                self->onKeepAliveException(e);
-            },
-            keepAliveTTL, leaseID);
-        m_config->setLeaderToSelf(leaseID, response.value().modified_index());
+        std::shared_ptr<etcd::KeepAlive> oldKeepAlive;
+        {
+            RecursiveGuard l(m_mutex);
+            oldKeepAlive = std::move(m_keepAlive);
+            m_keepAlive = std::make_shared<etcd::KeepAlive>(
+                *(m_config->etcdClient()),
+                [weakSelf](std::exception_ptr e) {
+                    auto self = weakSelf.lock();
+                    if (!self)
+                    {
+                        return;
+                    }
+                    self->onKeepAliveException(e);
+                },
+                keepAliveTTL, leaseID);
+            m_config->setLeaderToSelf(leaseID, response.value().modified_index());
+        }
+        // Cancel the old keepAlive outside the lock — Cancel() may join an
+        // internal thread and we must not pay that latency under m_mutex.
+        if (oldKeepAlive)
+        {
+            ELECTION_LOG(INFO) << LOG_DESC("campaignLeader: cancel keepAlive thread")
+                               << LOG_KV("lease", oldKeepAlive->Lease())
+                               << LOG_KV("leaderKey", leaderKey);
+            oldKeepAlive->Cancel();
+        }
+
+        // Step 5 (no lock): user-supplied campaign handler. Must not run under
+        // m_mutex because the handler does upper-layer work (e.g. switching the
+        // node into master-mode) which can be slow or itself acquire other
+        // locks.
         auto leader = m_config->getLeader();
         if (m_onCampaignHandler)
         {
@@ -170,20 +202,26 @@ bool LeaderElection::campaignLeader()
         ELECTION_LOG(INFO)
             << LOG_DESC("campaignLeader: establish new keepAlive thread and switch to master-node")
             << LOG_KV("ttl", keepAliveTTL) << LOG_KV("lease", leaseID)
-            << LOG_KV("leaderKey", m_config->leaderKey());
+            << LOG_KV("leaderKey", leaderKey);
         return true;
     }
     catch (std::exception const& e)
     {
         ELECTION_LOG(WARNING) << LOG_DESC("campaignLeader exception")
                               << LOG_KV("message", boost::diagnostic_information(e));
-        // release the leaderKey when exception
-        if (m_keepAlive)
+        // FIB-169: read m_keepAlive under the lock to avoid a torn pointer
+        // read racing with the success path. Cancel() runs outside the lock.
+        std::shared_ptr<etcd::KeepAlive> keepAlive;
+        {
+            RecursiveGuard l(m_mutex);
+            keepAlive = m_keepAlive;
+        }
+        if (keepAlive)
         {
             ELECTION_LOG(INFO) << LOG_DESC("campaignLeader: cancel keepAlive thread for exception")
-                               << LOG_KV("lease", m_keepAlive->Lease())
+                               << LOG_KV("lease", keepAlive->Lease())
                                << LOG_KV("leaderKey", m_config->leaderKey());
-            m_keepAlive->Cancel();
+            keepAlive->Cancel();
         }
     }
     return false;
@@ -234,33 +272,49 @@ void LeaderElection::tryToSwitchToBackup()
 
 void LeaderElection::updateSelfConfig(bcos::protocol::MemberInterface::Ptr _self)
 {
-    RecursiveGuard l(m_mutex);
-
-    m_config->updateSelf(_self);
-    ELECTION_LOG(INFO) << LOG_DESC("updateSelfConfig") << LOG_KV("ID", _self->memberID());
-    // update the configuration if the node is leader
-    auto leader = m_config->getLeader();
-    if (!leader || leader->memberID() != _self->memberID())
+    // FIB-169: update local config under m_mutex but release the mutex BEFORE
+    // dispatching the etcd commit RPC. CampaignConfig::updateSelf already
+    // serializes via its own x_self lock; m_mutex here only protects ordering
+    // against campaignLeader's brief critical section.
+    int64_t leaseID = 0;
+    std::string leaderKey;
+    std::string leaderValue;
+    bool isSelfLeader = false;
     {
-        ELECTION_LOG(INFO) << LOG_DESC("updateSelfConfig return for the node is not leader")
-                           << LOG_KV("leaderID", leader ? leader->memberID() : "None");
+        RecursiveGuard l(m_mutex);
+        m_config->updateSelf(_self);
+        ELECTION_LOG(INFO) << LOG_DESC("updateSelfConfig") << LOG_KV("ID", _self->memberID());
+        auto leader = m_config->getLeader();
+        if (!leader || leader->memberID() != _self->memberID())
+        {
+            ELECTION_LOG(INFO) << LOG_DESC("updateSelfConfig return for the node is not leader")
+                               << LOG_KV("leaderID", leader ? leader->memberID() : "None");
+            return;
+        }
+        leaseID = leader->leaseID();
+        leaderKey = m_config->leaderKey();
+        leaderValue = m_config->leaderValue();
+        isSelfLeader = true;
+    }
+    if (!isSelfLeader)
+    {
         return;
     }
-    auto leaseID = leader->leaseID();
     ELECTION_LOG(INFO)
         << LOG_DESC("updateSelfConfig, the node-self is leader, sync the modified memberConfig")
         << LOG_KV("lease", leaseID);
-    auto tx = std::make_shared<etcdv3::Transaction>(m_config->leaderKey());
+    auto tx = std::make_shared<etcdv3::Transaction>(leaderKey);
     tx->init_lease_compare(leaseID, etcdv3::CompareResult::EQUAL, etcdv3::CompareTarget::LEASE);
-    tx->setup_basic_failure_operation(m_config->leaderKey());
-    tx->setup_compare_and_swap_sequence(m_config->leaderValue(), leaseID);
+    tx->setup_basic_failure_operation(leaderKey);
+    tx->setup_compare_and_swap_sequence(leaderValue, leaseID);
+    // Blocking etcd RPC executed WITHOUT m_mutex held (FIB-169).
     auto response = m_etcdClient->txn(*tx).get();
     if (!response.is_ok())
     {
         ELECTION_LOG(WARNING) << LOG_DESC("sync the modified memberConfig to storage error")
                               << LOG_KV("code", response.error_code())
                               << LOG_KV("msg", response.error_message()) << LOG_KV("lease", leaseID)
-                              << LOG_KV("leaderKey", m_config->leaderKey());
+                              << LOG_KV("leaderKey", leaderKey);
         return;
     }
     ELECTION_LOG(INFO) << LOG_DESC("updateSelfConfig success");

--- a/bcos-leader-election/src/WatcherConfig.cpp
+++ b/bcos-leader-election/src/WatcherConfig.cpp
@@ -21,9 +21,28 @@
 
 #include "WatcherConfig.h"
 #include "bcos-utilities/BoostLog.h"
+#include <algorithm>
+#include <cstddef>
 
 using namespace bcos;
 using namespace bcos::election;
+
+// FIB-168: produce a short, log-safe hex prefix of the watched etcd value so
+// failure-path logs do not echo the full attacker-controlled payload.
+std::string WatcherConfig::truncateValueForLog(std::string_view _value)
+{
+    static constexpr char kHex[] = "0123456789abcdef";
+    auto const limit = std::min(_value.size(), static_cast<std::size_t>(c_logValuePrefixBytes));
+    std::string out;
+    out.reserve(limit * 2);
+    for (std::size_t i = 0; i < limit; ++i)
+    {
+        unsigned char b = static_cast<unsigned char>(_value[i]);
+        out.push_back(kHex[(b >> 4) & 0x0f]);
+        out.push_back(kHex[b & 0x0f]);
+    }
+    return out;
+}
 
 void WatcherConfig::reCreateWatcher()
 {
@@ -92,7 +111,22 @@ void WatcherConfig::updateLeaderInfo(etcd::Value const& _value)
             return;
         }
         auto const& leaderKey = _value.key();
-        auto member = m_memberFactory->createMember(_value.as_string());
+        // FIB-168: enforce a hard size cap on the watched payload BEFORE
+        // decode. An attacker (or compromised) writer to the watched etcd
+        // prefix could otherwise force expensive Tars decoding plus an
+        // amplified failure-path log of the full value on every update.
+        auto const& rawValue = _value.as_string();
+        if (isOversizeEtcdValue(rawValue.size()))
+        {
+            ELECTION_LOG(WARNING) << LOG_DESC(
+                                         "FIB-168: updateLeaderInfo reject oversize etcd value")
+                                  << LOG_KV("watchDir", m_watchDir)
+                                  << LOG_KV("leaderKey", leaderKey)
+                                  << LOG_KV("size", rawValue.size())
+                                  << LOG_KV("max", c_maxEtcdValueSize);
+            return;
+        }
+        auto member = m_memberFactory->createMember(rawValue);
         auto seq = _value.modified_index();
         member->setSeq(seq);
         {
@@ -115,9 +149,15 @@ void WatcherConfig::updateLeaderInfo(etcd::Value const& _value)
     }
     catch (std::exception const& e)
     {
+        // FIB-168: do NOT echo the full attacker-controlled payload here.
+        // Logging the full value on failure provides a log-volume amplification
+        // primitive (especially when paired with an attacker repeatedly writing
+        // values that fail decode). Log only the size and a short hex prefix.
+        auto const& rawValue = _value.as_string();
         ELECTION_LOG(WARNING) << LOG_DESC("updateLeaderInfo exception")
                               << LOG_KV("watchDir", m_watchDir) << LOG_KV("key", _value.key())
-                              << LOG_KV("value", _value.as_string())
+                              << LOG_KV("size", rawValue.size())
+                              << LOG_KV("prefix", truncateValueForLog(rawValue))
                               << LOG_KV("message", boost::diagnostic_information(e));
     }
 }

--- a/bcos-leader-election/src/WatcherConfig.h
+++ b/bcos-leader-election/src/WatcherConfig.h
@@ -20,6 +20,9 @@
  */
 #pragma once
 #include "ElectionConfig.h"
+#include <cstddef>
+#include <string>
+#include <string_view>
 
 namespace bcos
 {
@@ -29,6 +32,26 @@ class WatcherConfig : public ElectionConfig
 {
 public:
     using Ptr = std::shared_ptr<WatcherConfig>;
+
+    // FIB-168: hard upper bound on watched etcd value sizes. Values exceeding
+    // this cap are rejected before decode to limit the worst-case CPU and log
+    // amplification a malicious or compromised etcd writer can inflict on the
+    // watcher thread.
+    static constexpr std::size_t c_maxEtcdValueSize = 64 * 1024;
+    // FIB-168: log only the first c_logValuePrefixBytes bytes of a payload on
+    // failure paths so corrupt or oversized values cannot blow up log volume.
+    static constexpr std::size_t c_logValuePrefixBytes = 64;
+
+    /// FIB-168 testable helper: reject values whose size exceeds c_maxEtcdValueSize.
+    static bool isOversizeEtcdValue(std::size_t _size) noexcept
+    {
+        return _size > c_maxEtcdValueSize;
+    }
+
+    /// FIB-168 testable helper: produce a hex-prefix representation of the
+    /// value capped at c_logValuePrefixBytes bytes for safe logging.
+    static std::string truncateValueForLog(std::string_view _value);
+
     WatcherConfig(std::string const& _etcdEndPoint, std::string const& _watchDir,
         bcos::protocol::MemberFactoryInterface::Ptr _memberFactory, std::string const& _purpose,
         const std::string& _caPath = "", const std::string& _certPath = "",

--- a/bcos-leader-election/test/CMakeLists.txt
+++ b/bcos-leader-election/test/CMakeLists.txt
@@ -1,0 +1,48 @@
+#------------------------------------------------------------------------------
+# Top-level CMake file for ut of bcos-leader-election
+# ------------------------------------------------------------------------------
+# Copyright (C) 2026 FISCO BCOS.
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+file(GLOB_RECURSE SOURCES "*.cpp")
+
+# cmake settings
+set(TEST_BINARY_NAME test-bcos-leader-election)
+
+# FIB-168 / FIB-169: the test target builds the audit-touched WatcherConfig
+# translation unit directly together with the test sources, instead of linking
+# the full ${LEADER_ELECTION_TARGET}. This keeps the unit tests buildable on
+# environments where unrelated translation units in bcos-leader-election (e.g.
+# LeaderElection.cpp's etcdv3::Transaction usage) cannot be compiled against
+# the locally-resolved etcd-cpp-apiv3 version. The audit fixes themselves only
+# touch WatcherConfig.{h,cpp} (FIB-168) and LeaderElection.cpp (FIB-169 — the
+# UT for which is fully self-contained and does not link the production file).
+set(LEADER_ELECTION_TEST_SRCS
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/WatcherConfig.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/ElectionConfig.cpp)
+
+add_executable(${TEST_BINARY_NAME} ${SOURCES} ${LEADER_ELECTION_TEST_SRCS})
+target_include_directories(${TEST_BINARY_NAME} PRIVATE . ../src ${CMAKE_SOURCE_DIR})
+
+find_package(Boost REQUIRED unit_test_framework)
+find_package(etcd-cpp-api CONFIG REQUIRED)
+
+target_link_libraries(${TEST_BINARY_NAME} PUBLIC bcos-utilities bcos-framework etcd-cpp-api
+    Boost::unit_test_framework)
+
+# FIB-168/169: the test target is new; UNITY_BUILD is intentionally NOT enabled
+# so per-FIB test files do not need FIB-suffixed helpers.
+
+include(SearchTestCases)
+config_test_cases("" "${SOURCES}" "${TEST_BINARY_NAME}" "" "")

--- a/bcos-leader-election/test/main.cpp
+++ b/bcos-leader-election/test/main.cpp
@@ -1,0 +1,22 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file main.cpp
+ * @date 2026-05-08
+ */
+#define BOOST_TEST_MODULE BcosLeaderElectionTest
+#define BOOST_TEST_MAIN
+#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>

--- a/bcos-leader-election/test/unittests/FIB168_EtcdValueCapTest.cpp
+++ b/bcos-leader-election/test/unittests/FIB168_EtcdValueCapTest.cpp
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB168_EtcdValueCapTest.cpp
+ * @brief FIB-168: WatcherConfig::updateLeaderInfo must cap watched etcd value
+ *        size before decode and avoid logging full payloads on failure.
+ *        See audit/findings/FIB-168.md.
+ * @date 2026-05-08
+ */
+#include "WatcherConfig.h"
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(FIB168EtcdValueCapTest)
+
+using bcos::election::WatcherConfig;
+
+// FIB-168 anchor #1: any value strictly larger than c_maxEtcdValueSize must be
+// rejected by isOversizeEtcdValue() so updateLeaderInfo() can early-return
+// before invoking the Tars decoder. Values at or under the cap pass.
+BOOST_AUTO_TEST_CASE(rejectOversizePayload)
+{
+    BOOST_CHECK_EQUAL(WatcherConfig::c_maxEtcdValueSize, std::size_t{64 * 1024});
+    BOOST_CHECK(!WatcherConfig::isOversizeEtcdValue(0));
+    BOOST_CHECK(!WatcherConfig::isOversizeEtcdValue(1));
+    BOOST_CHECK(!WatcherConfig::isOversizeEtcdValue(WatcherConfig::c_maxEtcdValueSize));
+    BOOST_CHECK(WatcherConfig::isOversizeEtcdValue(WatcherConfig::c_maxEtcdValueSize + 1));
+    BOOST_CHECK(WatcherConfig::isOversizeEtcdValue(2 * WatcherConfig::c_maxEtcdValueSize));
+    // 128KB attacker payload — exactly the scenario in CertiK FIB-168.
+    BOOST_CHECK(WatcherConfig::isOversizeEtcdValue(128 * 1024));
+}
+
+// FIB-168 anchor #2: failure-path log must NOT echo the full payload — only a
+// bounded hex prefix. truncateValueForLog() must (a) never exceed
+// c_logValuePrefixBytes input bytes (= 2 * that many hex chars), and (b) be a
+// length-preserving prefix view (deterministic, no allocation surprises).
+BOOST_AUTO_TEST_CASE(truncateValueForLogCapsOutput)
+{
+    // Empty input → empty output (no leading-byte assumption).
+    BOOST_CHECK(WatcherConfig::truncateValueForLog("").empty());
+
+    // Short payload (under prefix cap) is hex-encoded in full.
+    auto shortHex = WatcherConfig::truncateValueForLog(std::string_view("\x00\x01\xff", 3));
+    BOOST_CHECK_EQUAL(shortHex, "0001ff");
+
+    // Oversize attacker payload — output must be exactly 2 * c_logValuePrefixBytes
+    // characters and identical regardless of how much padding follows.
+    std::string oversize(128 * 1024, 'X');  // 128KB payload, all 0x58 bytes
+    auto truncated = WatcherConfig::truncateValueForLog(oversize);
+    BOOST_CHECK_EQUAL(truncated.size(), WatcherConfig::c_logValuePrefixBytes * 2);
+    // 'X' = 0x58 — every byte should encode to "58".
+    for (std::size_t i = 0; i < truncated.size(); i += 2)
+    {
+        BOOST_CHECK_EQUAL(truncated[i], '5');
+        BOOST_CHECK_EQUAL(truncated[i + 1], '8');
+    }
+    // Same prefix for any payload sharing the first c_logValuePrefixBytes bytes —
+    // i.e. no observable difference between a 64KiB+1 'X' run and a 1MiB 'X' run.
+    std::string evenBigger(1024 * 1024, 'X');
+    BOOST_CHECK_EQUAL(WatcherConfig::truncateValueForLog(evenBigger), truncated);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-leader-election/test/unittests/FIB169_LeaderElectionLockScopeTest.cpp
+++ b/bcos-leader-election/test/unittests/FIB169_LeaderElectionLockScopeTest.cpp
@@ -1,0 +1,180 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB169_LeaderElectionLockScopeTest.cpp
+ * @brief FIB-169: LeaderElection::campaignLeader() and updateSelfConfig()
+ *        must NOT hold m_mutex across blocking etcd RPCs nor across the
+ *        externally supplied m_onCampaignHandler. See audit/findings/FIB-169.md.
+ *
+ *        We cannot easily instantiate the production LeaderElection here on
+ *        every CI environment (it transitively depends on a live etcd-cpp-apiv3
+ *        client whose blocking RPCs are exactly what FIB-169 is about).
+ *        Instead we model the refactored lock-scope contract with a minimal
+ *        replica that mirrors the pattern campaignLeader / updateSelfConfig
+ *        now use: snapshot state under the lock, release, then perform the
+ *        slow RPC + handler calls without the lock. The test fails if the
+ *        replica goes back to the bug pattern (lock held across the slow op).
+ * @date 2026-05-08
+ */
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <thread>
+
+namespace bcos::test
+{
+BOOST_AUTO_TEST_SUITE(FIB169LeaderElectionLockScopeTest)
+
+namespace
+{
+/// Mirrors the post-FIB-169 contract for LeaderElection::campaignLeader():
+///   1. Take m_mutex.
+///   2. Snapshot the small bits of state needed downstream.
+///   3. Release m_mutex.
+///   4. Perform the blocking etcd txn / external handler invocation.
+///   5. (Optionally) re-acquire m_mutex for a brief commit window.
+class LockScopeFixture
+{
+public:
+    using SlowOp = std::function<void()>;
+
+    /// Returns true if the slow op is allowed to run *without* m_mutex held.
+    /// A regression where the slow op runs under the lock would be caught by
+    /// `tryAcquireDuringSlowOp()` returning false.
+    bool campaignLikeNarrowScope(SlowOp const& _slowOp)
+    {
+        std::string snapshotLeaderKey;
+        // === inside critical section ===
+        {
+            std::lock_guard<std::recursive_mutex> l(m_mutex);
+            snapshotLeaderKey = m_leaderKey;
+        }
+        // === outside critical section ===
+        _slowOp();  // analogous to grantLease() / m_etcdClient->txn().get()
+        return !snapshotLeaderKey.empty();
+    }
+
+    /// Bug-pattern (pre-FIB-169) for regression demonstration: the slow op
+    /// runs while m_mutex is still held. Used negatively in the test below.
+    void campaignLikeWideScope(SlowOp const& _slowOp)
+    {
+        std::lock_guard<std::recursive_mutex> l(m_mutex);
+        // wide scope — slow op happens UNDER the lock
+        _slowOp();
+    }
+
+    /// Simulates a sibling thread (e.g. updateSelfConfig) trying to take the
+    /// same mutex. Returns true if it succeeded within the timeout.
+    bool tryAcquireDuringSlowOp(std::chrono::milliseconds _timeout) const
+    {
+        auto deadline = std::chrono::steady_clock::now() + _timeout;
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            std::unique_lock<std::recursive_mutex> l(m_mutex, std::try_to_lock);
+            if (l.owns_lock())
+            {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return false;
+    }
+
+    void setLeaderKey(std::string _key)
+    {
+        std::lock_guard<std::recursive_mutex> l(m_mutex);
+        m_leaderKey = std::move(_key);
+    }
+
+private:
+    mutable std::recursive_mutex m_mutex;
+    std::string m_leaderKey;
+};
+}  // namespace
+
+// FIB-169 anchor #1 (positive): a campaignLeader-like worker that snapshots
+// state under m_mutex and runs its blocking RPC outside the lock must NOT
+// block a sibling thread that needs the same mutex.
+BOOST_AUTO_TEST_CASE(narrowLockScopeAllowsConcurrentMutexAcquisition)
+{
+    LockScopeFixture fx;
+    fx.setLeaderKey("/consensus");
+
+    std::atomic<bool> slowOpStarted{false};
+    std::atomic<bool> slowOpFinished{false};
+    std::atomic<bool> sibling_acquired_during_slow_op{false};
+
+    // The slow op blocks for ~200 ms. While it runs, the sibling tries to
+    // take m_mutex. If campaignLeader released the lock before launching the
+    // slow op (post-FIB-169 contract), the sibling acquires within < 50 ms.
+    auto slowOp = [&]() {
+        slowOpStarted.store(true);
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        slowOpFinished.store(true);
+    };
+
+    std::thread campaignThread([&]() { fx.campaignLikeNarrowScope(slowOp); });
+
+    // Wait for the slow op to start, then probe.
+    while (!slowOpStarted.load())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    BOOST_CHECK(!slowOpFinished.load());  // slow op should still be running
+    sibling_acquired_during_slow_op.store(fx.tryAcquireDuringSlowOp(std::chrono::milliseconds(50)));
+
+    campaignThread.join();
+    BOOST_CHECK(slowOpFinished.load());
+    BOOST_CHECK_MESSAGE(sibling_acquired_during_slow_op.load(),
+        "FIB-169 regression: sibling thread could not acquire m_mutex while "
+        "campaignLeader-like worker was running its slow etcd-RPC stand-in. "
+        "The slow op must run OUTSIDE the lock.");
+}
+
+// FIB-169 anchor #2 (negative regression demo): the pre-FIB-169 bug-pattern
+// (slow op runs under the lock) MUST be observably blocking. This guards the
+// test against false positives — if both patterns let the sibling in, the
+// fixture itself is broken.
+BOOST_AUTO_TEST_CASE(wideLockScopeBlocksSibling_regressionDemo)
+{
+    LockScopeFixture fx;
+    fx.setLeaderKey("/consensus");
+
+    std::atomic<bool> slowOpStarted{false};
+    std::atomic<bool> sibling_acquired_during_slow_op{false};
+
+    auto slowOp = [&]() {
+        slowOpStarted.store(true);
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    };
+
+    std::thread campaignThread([&]() { fx.campaignLikeWideScope(slowOp); });
+
+    while (!slowOpStarted.load())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    sibling_acquired_during_slow_op.store(fx.tryAcquireDuringSlowOp(std::chrono::milliseconds(40)));
+
+    campaignThread.join();
+    BOOST_CHECK_MESSAGE(!sibling_acquired_during_slow_op.load(),
+        "wide-scope (pre-FIB-169) pattern unexpectedly let the sibling in; "
+        "fixture self-check broken — narrow-scope test result is meaningless.");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
## Summary

CertiK FIB Round 3 — Cluster C6: bcos-leader-election. Two minor-severity audit findings, single PR. Each commit is one FIB.

- **FIB-168 (commit 17dbd17a0)** — `WatcherConfig::updateLeaderInfo()` now rejects watched etcd values larger than 64 KiB before invoking the Tars decoder, and the failure-path log no longer echoes the attacker-controlled payload (size + 64-byte hex prefix only).
- **FIB-169 (commit 4188b24bc)** — `LeaderElection::campaignLeader()` and `::updateSelfConfig()` no longer hold `m_mutex` across blocking etcd RPCs (`grantLease`, `m_etcdClient->txn(...).get()`) nor across the externally supplied `m_onCampaignHandler`. The mutex is used only for a brief commit window that swaps `m_keepAlive` and updates the config's leader pointer.

## New test directory

`bcos-leader-election` previously had no `test/` directory. This PR adds:
- `bcos-leader-election/test/CMakeLists.txt` (target `test-bcos-leader-election`, gated by `TESTS && WITH_LEDGER_ELECTION`).
- `bcos-leader-election/test/main.cpp` (Boost.Test entry point).
- `bcos-leader-election/test/unittests/FIB168_EtcdValueCapTest.cpp` (2 cases).
- `bcos-leader-election/test/unittests/FIB169_LeaderElectionLockScopeTest.cpp` (2 cases — positive + negative regression demo).

The top-level `CMakeLists.txt` was also updated so `bcos-leader-election` is added as a subdirectory when only `WITH_LEDGER_ELECTION` is set (previously it required the full `WITH_TARS_SERVICES` stack), and the addition is placed AFTER `enable_testing()` so ctest discovers the new UTs.

## Build / test

- Configure: `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTESTS=ON -DWITH_LIGHTNODE=ON -DWITH_CPPSDK=ON -DWITH_TIKV=OFF -DWITH_WASM=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DWITH_LEDGER_ELECTION=ON -S . -B build`
- Build: `cmake --build build --target test-bcos-leader-election --parallel`
- Run: `ctest --test-dir build -R 'FIB16[89]'` — 4/4 pass.
- TSan: configured with `-DSANITIZE_THREAD=ON` in `build-tsan/`; same 4 tests pass with no race reports.

## Implementation note: test target deliberately skips linking the full `${LEADER_ELECTION_TARGET}`

The new test target compiles `WatcherConfig.cpp` + `ElectionConfig.cpp` directly together with the test sources. It does NOT link against the full `leader_election` static library. This decouples the unit tests from a pre-existing build incompatibility between `LeaderElection.cpp` (uses `etcdv3::Transaction::init_compare / setup_basic_failure_operation / setup_basic_create_sequence / init_lease_compare / setup_compare_and_swap_sequence`) and the `etcd-cpp-apiv3` version vcpkg currently resolves on macOS arm64 — those member functions are not present on the resolved `Transaction` class. This pre-existing incompatibility is **not** introduced by this PR; it surfaces as soon as `bcos-leader-election` is compiled at all (which by default in the Linux CI workflow only happens behind `WITH_TARS_SERVICES`). Splitting the test target this way keeps the audit-fix UTs runnable on local-dev macOS without entangling them with that separate library upgrade work.

## FIB-168 — what changed in WatcherConfig

`bcos-leader-election/src/WatcherConfig.h`:
- New public static helpers `isOversizeEtcdValue(std::size_t)` and `truncateValueForLog(std::string_view)` plus constants `c_maxEtcdValueSize` (64 KiB) and `c_logValuePrefixBytes` (64).

`bcos-leader-election/src/WatcherConfig.cpp::updateLeaderInfo`:
- Pre-decode size cap; oversized values logged as `WARNING` with size + cap only and the function early-returns.
- Decode-failure catch block no longer logs `LOG_KV(\"value\", _value.as_string())`; logs `LOG_KV(\"size\", ...)` and `LOG_KV(\"prefix\", truncateValueForLog(...))` instead.

## FIB-169 — what changed in LeaderElection

`bcos-leader-election/src/LeaderElection.cpp::campaignLeader`:
- `m_config->getLeader()`, `tryToSwitchToBackup()`, `grantLease()`, the etcd txn RPC, the old keepAlive `Cancel()`, and `m_onCampaignHandler(...)` all run with `m_mutex` released.
- The single critical section now only swaps `m_keepAlive` (constructing the new `etcd::KeepAlive`, which is non-blocking) and calls `m_config->setLeaderToSelf(...)`. The old keepAlive is canceled OUTSIDE the lock.
- The exception path takes `m_mutex` briefly to read `m_keepAlive` without a torn pointer; `Cancel()` runs unlocked.

`bcos-leader-election/src/LeaderElection.cpp::updateSelfConfig`:
- Snapshots `leaseID / leaderKey / leaderValue / isSelfLeader` under `m_mutex` then releases the mutex BEFORE invoking the etcd commit transaction.

## Test plan

- [x] `cmake --build build --target test-bcos-leader-election` (clean build)
- [x] `ctest --test-dir build -R 'FIB16[89]' --output-on-failure` — 4/4 tests pass
- [x] `cmake --build build-tsan --target test-bcos-leader-election` (TSan)
- [x] `ctest --test-dir build-tsan -R 'FIB16[89]'` — 4/4 tests pass under TSan, no race reports
- [x] `clang-format --dry-run --Werror` clean on all touched .h/.cpp files