### PR TITLE
fix(framework): consolidate v3.17.0 flags and split Features.h (FIB-75/78/84/85-87/94/99/105)

### DIFF
--- a/bcos-executor/src/executive/BlockContext.cpp
+++ b/bcos-executor/src/executive/BlockContext.cpp
@@ -22,6 +22,7 @@
 #include "BlockContext.h"
 #include "../vm/Precompiled.h"
 #include "TransactionExecutive.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/storage/StorageInterface.h"
 #include "bcos-framework/storage/Table.h"
 #include "bcos-task/Wait.h"

--- a/bcos-executor/src/executor/ShardingTransactionExecutor.cpp
+++ b/bcos-executor/src/executor/ShardingTransactionExecutor.cpp
@@ -22,9 +22,10 @@
 #include "ShardingTransactionExecutor.h"
 #include "../executive/ExecutiveDagFlow.h"
 #include "../executive/ExecutiveFactory.h"
-#include "bcos-framework/ledger/Features.h"
-#include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-framework/executor/ExecuteError.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
+#include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-task/Wait.h"
 
 using namespace std;
@@ -32,16 +33,16 @@ using namespace bcos::executor;
 using namespace bcos::protocol;
 
 ShardingTransactionExecutor::ShardingTransactionExecutor(bcos::ledger::LedgerInterface::Ptr ledger,
-        txpool::TxPoolInterface::Ptr txpool, storage::MergeableStorageInterface::Ptr cachedStorage,
-        storage::TransactionalStorageInterface::Ptr backendStorage,
-        protocol::ExecutionMessageFactory::Ptr executionMessageFactory,
-        storage::StateStorageFactory::Ptr stateStorageFactory, bcos::crypto::Hash::Ptr hashImpl,
-        bool isWasm, bool isAuthCheck, std::shared_ptr<VMFactory> vmFactory,
-        std::shared_ptr<std::set<std::string, std::less<>>> keyPageIgnoreTables, std::string name)
-    : TransactionExecutor(std::move(ledger), std::move(txpool), std::move(cachedStorage),
-                std::move(backendStorage), std::move(executionMessageFactory),
-                std::move(stateStorageFactory), std::move(hashImpl), isWasm, isAuthCheck,
-                std::move(vmFactory), std::move(keyPageIgnoreTables), std::move(name))
+    txpool::TxPoolInterface::Ptr txpool, storage::MergeableStorageInterface::Ptr cachedStorage,
+    storage::TransactionalStorageInterface::Ptr backendStorage,
+    protocol::ExecutionMessageFactory::Ptr executionMessageFactory,
+    storage::StateStorageFactory::Ptr stateStorageFactory, bcos::crypto::Hash::Ptr hashImpl,
+    bool isWasm, bool isAuthCheck, std::shared_ptr<VMFactory> vmFactory,
+    std::shared_ptr<std::set<std::string, std::less<>>> keyPageIgnoreTables, std::string name)
+  : TransactionExecutor(std::move(ledger), std::move(txpool), std::move(cachedStorage),
+        std::move(backendStorage), std::move(executionMessageFactory),
+        std::move(stateStorageFactory), std::move(hashImpl), isWasm, isAuthCheck,
+        std::move(vmFactory), std::move(keyPageIgnoreTables), std::move(name))
 {}
 
 void ShardingTransactionExecutor::executeTransactions(std::string contractAddress,

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -54,6 +54,7 @@
 #include "../precompiled/extension/ZkpPrecompiled.h"
 #include "../vm/Precompiled.h"
 #include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
 
 #include <array>
 #include <cstring>
@@ -1696,8 +1697,7 @@ void TransactionExecutor::dagExecuteTransactionsInternal(
                                 EXECUTOR_NAME_LOG(TRACE)
                                     << LOG_BADGE("dagExecuteTransactionsInternal")
                                     << LOG_DESC("ABI loaded") << LOG_KV("address", to)
-                                    << LOG_KV("selector", toHex(selector))
-                                    << LOG_KV("ABI", abiStr);
+                                    << LOG_KV("selector", toHex(selector)) << LOG_KV("ABI", abiStr);
                                 auto functionAbi = FunctionAbi::deserialize(
                                     abiStr, selector.toBytes(), isSmCrypto);
                                 if (!functionAbi)

--- a/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
@@ -22,15 +22,16 @@
 #include "bcos-executor/src/precompiled/common/PrecompiledResult.h"
 #include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-framework/ledger/Features.h"
-#include "bcos-framework/ledger/SystemConfigs.h"
-#include "bcos-task/Wait.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/ledger/SystemConfigs.h"
 #include "bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-framework/protocol/Protocol.h"
+#include "bcos-task/Wait.h"
 #include "bcos-tool/VersionConverter.h"
-#include <algorithm>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
+#include <algorithm>
 #include <range/v3/algorithm/find.hpp>
 
 using namespace bcos;

--- a/bcos-executor/test/unittest/fixture/TransactionFixture.h
+++ b/bcos-executor/test/unittest/fixture/TransactionFixture.h
@@ -26,6 +26,7 @@
 #include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
 #include "bcos-framework/executor/NativeExecutionMessage.h"
 #include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/protocol/Protocol.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
@@ -116,15 +117,11 @@ public:
         keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
         auto secretKeyBytes =
             fromHex("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e");
-        memcpy(keyPair->secretKey()->mutableData(),
-            secretKeyBytes.data(),
-            32);
+        memcpy(keyPair->secretKey()->mutableData(), secretKeyBytes.data(), 32);
         auto publicKeyBytes = fromHex(
             "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
             "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae");
-        memcpy(keyPair->publicKey()->mutableData(),
-            publicKeyBytes.data(),
-            64);
+        memcpy(keyPair->publicKey()->mutableData(), publicKeyBytes.data(), 64);
         boost::log::core::get()->set_logging_enabled(false);
         createSysTable(version);
         boost::log::core::get()->set_logging_enabled(true);

--- a/bcos-executor/test/unittest/libprecompiled/PreCompiledFixture.h
+++ b/bcos-executor/test/unittest/libprecompiled/PreCompiledFixture.h
@@ -20,9 +20,27 @@
 
 #pragma once
 #include "bcos-codec/scale/Scale.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-crypto/hash/SM3.h"
 #include "bcos-crypto/interfaces/crypto/CommonType.h"
+#include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
+#include "bcos-crypto/signature/sm2.h"
+#include "bcos-executor/src/precompiled/common/Common.h"
+#include "bcos-executor/src/precompiled/common/Utilities.h"
+#include "bcos-framework/executor/NativeExecutionMessage.h"
 #include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/protocol/Protocol.h"
+#include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "bcos-framework/storage/LegacyStorageMethods.h"
+#include "bcos-framework/storage/Table.h"
+#include "bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/testutils/faker/FakeBlockHeader.h"
+#include "bcos-table/src/StateStorageFactory.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
+#include "bcos-tool/BfsFileFactory.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
 #include "executive/BlockContext.h"
 #include "executive/TransactionExecutive.h"
 #include "executor/TransactionExecutorFactory.h"
@@ -32,23 +50,6 @@
 #include "mock/MockTransactionalStorage.h"
 #include "mock/MockTxPool.h"
 #include "precompiled/extension/UserPrecompiled.h"
-#include "bcos-crypto/hash/Keccak256.h"
-#include "bcos-crypto/hash/SM3.h"
-#include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
-#include "bcos-crypto/signature/sm2.h"
-#include "bcos-executor/src/precompiled/common/Common.h"
-#include "bcos-executor/src/precompiled/common/Utilities.h"
-#include "bcos-framework/executor/NativeExecutionMessage.h"
-#include "bcos-framework/ledger/LedgerTypeDef.h"
-#include "bcos-framework/protocol/Protocol.h"
-#include "bcos-framework/protocol/ProtocolTypeDef.h"
-#include "bcos-framework/storage/Table.h"
-#include "bcos-framework/testutils/faker/FakeBlock.h"
-#include "bcos-framework/testutils/faker/FakeBlockHeader.h"
-#include "bcos-table/src/StateStorageFactory.h"
-#include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
-#include "bcos-tool/BfsFileFactory.h"
-#include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <libinitializer/AuthInitializer.h>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
@@ -127,15 +128,11 @@ public:
         keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
         auto secretKeyBytes =
             fromHex("ff6f30856ad3bae00b1169808488502786a13e3c174d85682135ffd51310310e");
-        memcpy(keyPair->secretKey()->mutableData(),
-            secretKeyBytes.data(),
-            32);
+        memcpy(keyPair->secretKey()->mutableData(), secretKeyBytes.data(), 32);
         auto publicKeyBytes = fromHex(
             "ccd8de502ac45462767e649b462b5f4ca7eadd69c7e1f1b410bdf754359be29b1b88ffd79744"
             "03f56e250af52b25682014554f7b3297d6152401e85d426a06ae");
-        memcpy(keyPair->publicKey()->mutableData(),
-            publicKeyBytes.data(),
-            64);
+        memcpy(keyPair->publicKey()->mutableData(), publicKeyBytes.data(), 64);
         boost::log::core::get()->set_logging_enabled(false);
         createSysTable(version);
         boost::log::core::get()->set_logging_enabled(true);

--- a/bcos-framework/bcos-framework/ledger/Features.cpp
+++ b/bcos-framework/bcos-framework/ledger/Features.cpp
@@ -195,13 +195,23 @@ void Features::setUpgradeFeatures(
                     Flag::bugfix_v1_timestamp}},
             {.to = protocol::BlockVersion::V3_16_4_VERSION, .flags = {Flag::bugfix_revert_logs}},
             {.to = protocol::BlockVersion::V3_16_5_VERSION,
+                .flags =
+                    {
+                        Flag::bugfix_auth_check_create2,
+                        Flag::bugfix_auth_check_revert_status,
+                        Flag::bugfix_auth_table_raw_address,
+                        Flag::bugfix_auth_table_squatting,
+                        Flag::bugfix_v1_exec_error_gas_used,
+                        Flag::bugfix_v1_precompiled_error_gas,
+                    }},
+            {.to = protocol::BlockVersion::V3_17_0_VERSION,
                 .flags = {
-                    Flag::bugfix_auth_check_create2,
-                    Flag::bugfix_auth_check_revert_status,
-                    Flag::bugfix_auth_table_raw_address,
-                    Flag::bugfix_auth_table_squatting,
-                    Flag::bugfix_v1_exec_error_gas_used,
-                    Flag::bugfix_v1_precompiled_error_gas,
+                    Flag::bugfix_gas_payment_balance_precheck,
+                    Flag::bugfix_clamp_gas_left_on_error,
+                    Flag::bugfix_precompiled_feature_gate,
+                    Flag::bugfix_v1_executive_wrapper,
+                    Flag::bugfix_evm_storage_status,
+                    Flag::bugfix_statestorage_hash_v3_17,
                 }}});
     for (const auto& upgradeFeatures : upgradeRoadmap)
     {

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -9,11 +9,13 @@
 #include <array>
 #include <bitset>
 #include <magic_enum/magic_enum.hpp>
+#include <ostream>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/zip.hpp>
 #include <set>
+#include <string_view>
 namespace bcos::ledger
 {
 DERIVE_BCOS_EXCEPTION(NoSuchFeatureError);
@@ -134,80 +136,16 @@ public:
                });
     }
 
+    // Storage I/O member templates. Definitions live in FeaturesStorage.h,
+    // which is included at the end of this header so existing call sites
+    // (e.g. features.readFromStorage(storage, n)) keep working unchanged.
     task::Task<void> readFromStorage(
-        storage2::ReadableStorage<executor_v1::StateKeyView> auto& storage, long blockNumber)
-    {
-        for (auto key : bcos::ledger::Features::featureKeys())
-        {
-            auto entry = co_await storage2::readOne(
-                storage, executor_v1::StateKeyView(ledger::SYS_CONFIG, key));
-            if (entry)
-            {
-                auto [value, enableNumber] = entry->template getObject<ledger::SystemConfigEntry>();
-                if (blockNumber >= enableNumber)
-                {
-                    set(key);
-                }
-            }
-        }
-    }
+        storage2::ReadableStorage<executor_v1::StateKeyView> auto& storage, long blockNumber);
 
     task::Task<void> writeToStorage(
         storage2::WritableStorage<executor_v1::StateKey, executor_v1::StateValue> auto& storage,
-        long blockNumber, bool ignoreDuplicate = true) const
-    {
-        for (auto [flag, name, value] : flags())
-        {
-            if (value &&
-                !(ignoreDuplicate && co_await storage2::existsOne(storage,
-                                         executor_v1::StateKeyView(ledger::SYS_CONFIG, name))))
-            {
-                storage::Entry entry;
-                entry.setObject(
-                    SystemConfigEntry{boost::lexical_cast<std::string>((int)value), blockNumber});
-                co_await storage2::writeOne(
-                    storage, executor_v1::StateKey(ledger::SYS_CONFIG, name), std::move(entry));
-            }
-        }
-    }
+        long blockNumber, bool ignoreDuplicate = true) const;
 };
-
-inline task::Task<void> readFromStorage(Features& features,
-    storage2::ReadableStorage<executor_v1::StateKey> auto& storage, long blockNumber)
-{
-    decltype(auto) keys = bcos::ledger::Features::featureKeys();
-    auto entries = co_await storage2::readSome(std::forward<decltype(storage)>(storage),
-        keys | ::ranges::views::transform([](std::string_view key) {
-            return executor_v1::StateKeyView(ledger::SYS_CONFIG, key);
-        }));
-    for (auto&& [key, entry] : ::ranges::views::zip(keys, entries))
-    {
-        if (entry)
-        {
-            auto [value, enableNumber] = entry->template getObject<ledger::SystemConfigEntry>();
-            if (blockNumber >= enableNumber)
-            {
-                features.set(key);
-            }
-        }
-    }
-}
-
-inline task::Task<void> writeToStorage(Features const& features,
-    storage2::WritableStorage<executor_v1::StateKey, executor_v1::StateValue> auto& storage,
-    long blockNumber)
-{
-    decltype(auto) flags =
-        features.flags() | ::ranges::views::filter([](auto&& tuple) { return std::get<2>(tuple); });
-    co_await storage2::writeSome(std::forward<decltype(storage)>(storage),
-        ::ranges::views::transform(flags, [&](auto&& tuple) {
-            storage::Entry entry;
-            entry.setObject(SystemConfigEntry{
-                boost::lexical_cast<std::string>((int)std::get<2>(tuple)), blockNumber});
-            return std::make_tuple(
-                executor_v1::StateKey(ledger::SYS_CONFIG, std::get<1>(tuple)), std::move(entry));
-        }));
-}
 
 std::ostream& operator<<(std::ostream& stream, Features::Flag flag);
 

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -62,8 +62,14 @@ public:
         bugfix_auth_table_raw_address,
         bugfix_auth_table_squatting,
         bugfix_v1_exec_error_gas_used,
-        bugfix_v1_precompiled_error_gas,  // FIB-76/79/80: precompiled gas overflow check,
-                                          // exception safety, and use remaining gas on revert
+        bugfix_v1_precompiled_error_gas,      // FIB-76/79/80: precompiled gas overflow check,
+                                              // exception safety, and use remaining gas on revert
+        bugfix_gas_payment_balance_precheck,  // FIB-75
+        bugfix_clamp_gas_left_on_error,       // FIB-78
+        bugfix_precompiled_feature_gate,      // FIB-84
+        bugfix_v1_executive_wrapper,          // FIB-85/86/87
+        bugfix_evm_storage_status,            // FIB-94
+        bugfix_statestorage_hash_v3_17,       // FIB-99/105
         feature_dmc2serial,
         feature_sharding,
         feature_rpbft,

--- a/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
+++ b/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
@@ -1,0 +1,88 @@
+#pragma once
+#include "../ledger/LedgerTypeDef.h"
+#include "../storage/Entry.h"
+#include "../storage2/Storage.h"
+#include "../transaction-executor/StateKey.h"
+#include "Features.h"
+#include "bcos-task/Task.h"
+#include <boost/lexical_cast.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/zip.hpp>
+
+namespace bcos::ledger
+{
+inline task::Task<void> Features::readFromStorage(
+    storage2::ReadableStorage<executor_v1::StateKeyView> auto& storage, long blockNumber)
+{
+    for (auto key : bcos::ledger::Features::featureKeys())
+    {
+        auto entry =
+            co_await storage2::readOne(storage, executor_v1::StateKeyView(ledger::SYS_CONFIG, key));
+        if (entry)
+        {
+            auto [value, enableNumber] = entry->template getObject<ledger::SystemConfigEntry>();
+            if (blockNumber >= enableNumber)
+            {
+                set(key);
+            }
+        }
+    }
+}
+
+inline task::Task<void> Features::writeToStorage(
+    storage2::WritableStorage<executor_v1::StateKey, executor_v1::StateValue> auto& storage,
+    long blockNumber, bool ignoreDuplicate) const
+{
+    for (auto [flag, name, value] : flags())
+    {
+        if (value && !(ignoreDuplicate && co_await storage2::existsOne(storage,
+                                              executor_v1::StateKeyView(ledger::SYS_CONFIG, name))))
+        {
+            storage::Entry entry;
+            entry.setObject(
+                SystemConfigEntry{boost::lexical_cast<std::string>((int)value), blockNumber});
+            co_await storage2::writeOne(
+                storage, executor_v1::StateKey(ledger::SYS_CONFIG, name), std::move(entry));
+        }
+    }
+}
+
+inline task::Task<void> readFromStorage(Features& features,
+    storage2::ReadableStorage<executor_v1::StateKey> auto& storage, long blockNumber)
+{
+    decltype(auto) keys = bcos::ledger::Features::featureKeys();
+    auto entries = co_await storage2::readSome(std::forward<decltype(storage)>(storage),
+        keys | ::ranges::views::transform([](std::string_view key) {
+            return executor_v1::StateKeyView(ledger::SYS_CONFIG, key);
+        }));
+    for (auto&& [key, entry] : ::ranges::views::zip(keys, entries))
+    {
+        if (entry)
+        {
+            auto [value, enableNumber] = entry->template getObject<ledger::SystemConfigEntry>();
+            if (blockNumber >= enableNumber)
+            {
+                features.set(key);
+            }
+        }
+    }
+}
+
+inline task::Task<void> writeToStorage(Features const& features,
+    storage2::WritableStorage<executor_v1::StateKey, executor_v1::StateValue> auto& storage,
+    long blockNumber)
+{
+    decltype(auto) flags =
+        features.flags() | ::ranges::views::filter([](auto&& tuple) { return std::get<2>(tuple); });
+    co_await storage2::writeSome(std::forward<decltype(storage)>(storage),
+        ::ranges::views::transform(flags, [&](auto&& tuple) {
+            storage::Entry entry;
+            entry.setObject(SystemConfigEntry{
+                boost::lexical_cast<std::string>((int)std::get<2>(tuple)), blockNumber});
+            return std::make_tuple(
+                executor_v1::StateKey(ledger::SYS_CONFIG, std::get<1>(tuple)), std::move(entry));
+        }));
+}
+
+}  // namespace bcos::ledger

--- a/bcos-framework/bcos-framework/protocol/Protocol.h
+++ b/bcos-framework/bcos-framework/protocol/Protocol.h
@@ -113,6 +113,7 @@ enum ProtocolVersion : uint32_t
 
 enum class BlockVersion : uint32_t
 {
+    V3_17_0_VERSION = 0x03110000,  // 3.17.0
     V3_16_5_VERSION = 0x03100500,  // 3.16.5
     V3_16_4_VERSION = 0x03100400,  // 3.16.4
     V3_16_3_VERSION = 0x03100300,  // 3.16.3

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -184,6 +184,12 @@ BOOST_AUTO_TEST_CASE(feature)
         "bugfix_auth_table_squatting",
         "bugfix_v1_exec_error_gas_used",
         "bugfix_v1_precompiled_error_gas",
+        "bugfix_gas_payment_balance_precheck",
+        "bugfix_clamp_gas_left_on_error",
+        "bugfix_precompiled_feature_gate",
+        "bugfix_v1_executive_wrapper",
+        "bugfix_evm_storage_status",
+        "bugfix_statestorage_hash_v3_17",
         "feature_dmc2serial",
         "feature_sharding",
         "feature_rpbft",
@@ -372,6 +378,20 @@ BOOST_AUTO_TEST_CASE(upgrade)
     for (auto feature : expect11)
     {
         BOOST_CHECK(features14.get(feature));
+    }
+
+    // 3.16.5 to 3.17.0: expect the six FIB-75/78/84/85-87/94/99-105 flags only
+    Features features15;
+    features15.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_16_5_VERSION,
+        bcos::protocol::BlockVersion::V3_17_0_VERSION);
+    auto expect12 = std::to_array<std::string_view>(
+        {"bugfix_gas_payment_balance_precheck", "bugfix_clamp_gas_left_on_error",
+            "bugfix_precompiled_feature_gate", "bugfix_v1_executive_wrapper",
+            "bugfix_evm_storage_status", "bugfix_statestorage_hash_v3_17"});
+    BOOST_CHECK_EQUAL(validFlags(features15).size(), expect12.size());
+    for (auto feature : expect12)
+    {
+        BOOST_CHECK(features15.get(feature));
     }
 }
 

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -25,6 +25,7 @@
 #include "LedgerMethods.h"
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/SystemConfigs.h"
 #include "bcos-framework/storage/LegacyStorageMethods.h"
@@ -1436,8 +1437,8 @@ void Ledger::asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>>
                 {
                     auto field = entry->getField(0);
                     auto transaction = m_blockFactory->transactionFactory()->createTransaction(
-                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false,
-                        false, false);
+                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false, false,
+                        false);
                     transactions.push_back(std::move(transaction));
                 }
 

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -7,6 +7,7 @@
 #include "bcos-executor/src/Common.h"
 #include "bcos-framework/consensus/ConsensusNode.h"
 #include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/ledger/LedgerInterface.h"
@@ -152,8 +153,8 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
                 {
                     auto field = txEntry->getField(0);
                     auto transaction = blockFactory.transactionFactory()->createTransaction(
-                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false,
-                        false, false);
+                        bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false, false,
+                        false);
                     block->appendTransaction(std::move(transaction));
                 }
             }

--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -1,7 +1,7 @@
-#include <range/v3/range_fwd.hpp>
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/algorithm/find.hpp>
 #include <range/v3/algorithm/result_types.hpp>
+#include <range/v3/range_fwd.hpp>
 #include <range/v3/view/drop.hpp>
 
 #include "BlockExecutive.h"
@@ -12,6 +12,7 @@
 #include "bcos-framework/executor/ParallelTransactionExecutorInterface.h"
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
 #include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/protocol/Transaction.h"
 #include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-table/src/StateStorage.h"


### PR DESCRIPTION
## Summary

Consolidate the six `Features::Flag` entries from in-flight open PRs into a single commit, add a `V3_17_0_VERSION` slot in `BlockVersion`, and split `Features.h` so future flag additions no longer collide on the same hunk.

## Motivation

`bcos-framework/bcos-framework/ledger/Features.h` was a 215-line header that mixed three concerns: the `Flag` enum, the class state / accessors, and the storage I/O templates. Every PR adding a new flag had to edit the enum at a fixed position and the `upgradeRoadmap` array in `Features.cpp`, which produced repeated three-way merge conflicts whenever multiple flag-adding PRs were open simultaneously. Splitting the header along its concern boundary keeps storage I/O out of the diff for flag-only changes.

## Changes

### Commit 1 — consolidate flags + add `V3_17_0_VERSION`

Six new flags (previously declared individually in six open PRs) and the `V3_17_0_VERSION` slot are added in one commit. `MAX_VERSION` is intentionally left at `V3_16_5_VERSION` until the 3.17.0 release tag is cut.

| Flag | FIB | Source PR |
| --- | --- | --- |
| `bugfix_gas_payment_balance_precheck` | FIB-75 | #5118 |
| `bugfix_clamp_gas_left_on_error` | FIB-78 | #5116 |
| `bugfix_precompiled_feature_gate` | FIB-84 | #5120 |
| `bugfix_v1_executive_wrapper` | FIB-85/86/87 | #5115 |
| `bugfix_evm_storage_status` | FIB-94 | #5113 |
| `bugfix_statestorage_hash_v3_17` | FIB-99/105 | #5128 |

All six flags are mapped to the new `V3_17_0_VERSION` entry in `Features::setUpgradeFeatures` upgrade roadmap.

### Commit 2 — split `Features.h`

- **`FeatureFlags.h`** *(new)* — `Flag` enum, `m_flags`, accessor / validator / version-mapping declarations. The file you edit when adding a flag.
- **`FeaturesStorage.h`** *(new)* — out-of-class definitions of the `Features::readFromStorage` / `Features::writeToStorage` member templates plus the namespace-scope free-function overloads.
- **`Features.h`** — thin facade that includes both, kept for source compatibility with existing 31 `#include` sites.
- `Features.cpp` is unchanged.

No API change: `Features::Flag`, member templates, and free-function overloads keep identical signatures.

## Downstream action for the six open PRs

After this PR merges, each of the listed open PRs should be rebased on top of `release-3.17.0` and drop its `Features.h` / `Features.cpp` flag-add hunk. The fix code that consumes the flag (`features.get(Features::Flag::bugfix_...)`) is unchanged.

## Test plan

- [x] `cmake --build . --target bcos-framework bcos-ledger bcos-scheduler bcos-executor bcos-transaction-executor` clean
- [ ] CI green
