### PR TITLE
feat(storage): add SchemaVersion read/write/checkExpected (M1.2)

### DIFF
--- a/bcos-storage/CMakeLists.txt
+++ b/bcos-storage/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(Boost REQUIRED serialization thread context filesystem)
 
 set(SRC_LIST bcos-storage/Common.cpp)
 list(APPEND SRC_LIST bcos-storage/RocksDBStorage.cpp)
+list(APPEND SRC_LIST bcos-storage/SchemaVersion.cpp)
 
 set(LIB_LIST table bcos-framework Boost::serialization Boost::filesystem zstd::libzstd_static RocksDB::rocksdb ittapi)
 

--- a/bcos-storage/bcos-storage/KeyPrefixes.h
+++ b/bcos-storage/bcos-storage/KeyPrefixes.h
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief MPT key namespace constants and encode/decode helpers (spec §5.1)
+ * @file KeyPrefixes.h
+ * @author: kyonRay
+ * @date: 2026-05-12
+ */
+#pragma once
+#include <bcos-utilities/FixedBytes.h>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace bcos::storage2
+{
+
+/// The sole "/mpt/" ASCII prefix for MPT node keys in the default ColumnFamily.
+/// All MPT keys are exactly 37 bytes: kMPTPrefix (5) + raw keccak hash (32).
+/// Do NOT write "/mpt/" literals anywhere else — use makeMPTNodeKey / parseMPTNodeKey.
+inline constexpr std::string_view kMPTPrefix = "/mpt/";
+inline constexpr std::size_t kMPTKeyLength = kMPTPrefix.size() + 32;  // 37
+
+/// Encode a 32-byte keccak hash into a 37-byte RocksDB key with the /mpt/ namespace prefix.
+/// This is the ONLY place that embeds kMPTPrefix into a key.
+inline std::string makeMPTNodeKey(const h256& hash)
+{
+    std::string key;
+    key.reserve(kMPTPrefix.size() + h256::SIZE);
+    key.append(kMPTPrefix);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    key.append(reinterpret_cast<const char*>(hash.data()), h256::SIZE);
+    return key;
+}
+
+/// Decode a raw RocksDB key back to its h256 hash.
+/// Returns std::nullopt if the key is not a valid 37-byte /mpt/-prefixed key.
+/// Never throws — this is runtime data validation.
+inline std::optional<h256> parseMPTNodeKey(std::string_view key) noexcept
+{
+    if (key.size() != kMPTKeyLength)
+    {
+        return std::nullopt;
+    }
+    if (key.substr(0, kMPTPrefix.size()) != kMPTPrefix)
+    {
+        return std::nullopt;
+    }
+    h256 hash;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    std::memcpy(hash.data(), key.data() + kMPTPrefix.size(), h256::SIZE);
+    return hash;
+}
+
+}  // namespace bcos::storage2

--- a/bcos-storage/bcos-storage/RocksDBStorage2.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage2.h
@@ -43,6 +43,12 @@ public:
     using Key = KeyType;
     using Value = ValueType;
 
+    /// Expose the underlying rocksdb::DB pointer for callers that need to build
+    /// cross-prefix WriteBatches (e.g. the MPT module).  The returned pointer is
+    /// non-owning: callers MUST NOT delete or Close it.  Lifetime is tied to the
+    /// ::rocksdb::DB object passed at construction.
+    ::rocksdb::DB* rawDb() const noexcept { return &m_rocksDB.get(); }
+
     auto readSomeRaw(::ranges::input_range auto keys, auto&&... /*args*/)
         -> task::Task<std::vector<StorageValueType<ValueType>>>
     {

--- a/bcos-storage/bcos-storage/SchemaVersion.cpp
+++ b/bcos-storage/bcos-storage/SchemaVersion.cpp
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Schema version read/write/checkExpected facility for RocksDB (spec §8.2)
+ * @file SchemaVersion.cpp
+ * @author: kyonRay
+ * @date: 2026-05-12
+ */
+#include "SchemaVersion.h"
+#include <fmt/format.h>
+#include <rocksdb/write_batch.h>
+#include <charconv>
+#include <string>
+
+namespace bcos::storage2::rocksdb
+{
+
+void SchemaVersion::write(::rocksdb::DB& db, int version)
+{
+    std::string value = std::to_string(version);
+    ::rocksdb::WriteOptions wo;
+    auto status = db.Put(wo, db.DefaultColumnFamily(), kKey, value);
+    if (!status.ok())
+    {
+        throw std::runtime_error(fmt::format("SchemaVersion::write failed: {}", status.ToString()));
+    }
+}
+
+std::optional<int> SchemaVersion::read(::rocksdb::DB& db)
+{
+    std::string value;
+    ::rocksdb::ReadOptions ro;
+    auto status = db.Get(ro, db.DefaultColumnFamily(), kKey, &value);
+    if (status.IsNotFound())
+    {
+        return std::nullopt;
+    }
+    if (!status.ok())
+    {
+        throw std::runtime_error(fmt::format("SchemaVersion::read failed: {}", status.ToString()));
+    }
+
+    int version = 0;
+    auto [ptr, ec] = std::from_chars(value.data(), value.data() + value.size(), version);
+    if (ec != std::errc{} || ptr != value.data() + value.size())
+    {
+        throw std::runtime_error(
+            fmt::format("SchemaVersion::read: stored value '{}' is not a valid integer", value));
+    }
+    return version;
+}
+
+void SchemaVersion::checkExpected(::rocksdb::DB& db, int expected)
+{
+    auto actual = read(db);
+    if (!actual.has_value())
+    {
+        throw SchemaVersionMismatch(
+            fmt::format("SchemaVersion::checkExpected: key '{}' is absent "
+                        "(expected version {})",
+                kKey, expected));
+    }
+    if (*actual != expected)
+    {
+        throw SchemaVersionMismatch(
+            fmt::format("SchemaVersion::checkExpected: stored version {} != expected version {}",
+                *actual, expected));
+    }
+}
+
+}  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/SchemaVersion.h
+++ b/bcos-storage/bcos-storage/SchemaVersion.h
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Schema version read/write/checkExpected facility for RocksDB (spec §8.2)
+ * @file SchemaVersion.h
+ * @author: kyonRay
+ * @date: 2026-05-12
+ */
+#pragma once
+
+#include <rocksdb/db.h>
+#include <optional>
+#include <stdexcept>
+
+namespace bcos::storage2::rocksdb
+{
+
+struct SchemaVersionMismatch : public std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
+class SchemaVersion
+{
+public:
+    static constexpr char kKey[] = "__schema_version__";
+
+    /// Write (or overwrite) the schema version integer as ASCII into the default CF.
+    static void write(::rocksdb::DB& db, int version);
+
+    /// Read the persisted schema version.
+    /// Returns std::nullopt if the key is absent (legacy / fresh DB).
+    /// Never throws on I/O success — a missing key is not an error.
+    static std::optional<int> read(::rocksdb::DB& db);
+
+    /// Verify that the persisted version equals @p expected.
+    /// Throws SchemaVersionMismatch if:
+    ///   - the key is absent (legacy DB treated as mismatch when an expectation is provided), or
+    ///   - the stored value differs from @p expected.
+    static void checkExpected(::rocksdb::DB& db, int expected);
+};
+
+}  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/test/unittest/CMakeLists.txt
+++ b/bcos-storage/test/unittest/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "main.cpp")
+list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "main.cpp")
 # cmake settings
 set(TEST_BINARY_NAME test-storage)
 

--- a/bcos-storage/test/unittest/CMakeLists.txt
+++ b/bcos-storage/test/unittest/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "main.cpp")
+list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "TestSchemaVersion.cpp" "main.cpp")
 # cmake settings
 set(TEST_BINARY_NAME test-storage)
 

--- a/bcos-storage/test/unittest/TestKeyPrefixes.cpp
+++ b/bcos-storage/test/unittest/TestKeyPrefixes.cpp
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Unit tests for KeyPrefixes.h (MPT key namespace utilities)
+ * @file TestKeyPrefixes.cpp
+ * @author: kyonRay
+ * @date: 2026-05-12
+ */
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-storage/RocksDBStorage2.h>
+#include <bcos-storage/StateKVResolver.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <random>
+#include <string_view>
+
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::storage2::rocksdb;
+
+BOOST_AUTO_TEST_SUITE(KeyPrefixesSuite)
+
+BOOST_AUTO_TEST_CASE(MakeMPTNodeKeyFormat)
+{
+    h256 hash;
+    // Fill with a recognisable pattern
+    for (unsigned i = 0; i < 32; ++i)
+    {
+        hash[i] = static_cast<byte>(i + 1);
+    }
+
+    std::string key = makeMPTNodeKey(hash);
+
+    // Must be exactly 37 bytes: 5 (prefix) + 32 (hash)
+    BOOST_CHECK_EQUAL(key.size(), 37U);
+
+    // Must start with "/mpt/"
+    BOOST_CHECK_EQUAL(key.substr(0, 5), "/mpt/");
+
+    // Last 32 bytes must match the raw hash bytes
+    for (unsigned i = 0; i < 32; ++i)
+    {
+        BOOST_CHECK_EQUAL(static_cast<uint8_t>(key[5 + i]), hash[i]);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ParseMPTNodeKeyRoundTrip)
+{
+    h256 original = h256::generateRandomFixedBytes();
+    std::string encoded = makeMPTNodeKey(original);
+    auto decoded = parseMPTNodeKey(encoded);
+
+    BOOST_REQUIRE(decoded.has_value());
+    BOOST_CHECK_EQUAL(decoded.value(), original);
+}
+
+BOOST_AUTO_TEST_CASE(ParseMPTNodeKeyRejectsBadInputs)
+{
+    // Empty string
+    BOOST_CHECK(!parseMPTNodeKey("").has_value());
+
+    // Prefix only, no hash bytes
+    BOOST_CHECK(!parseMPTNodeKey("/mpt/").has_value());
+
+    // Prefix + truncated hash (less than 32 bytes)
+    BOOST_CHECK(!parseMPTNodeKey("/mpt/short").has_value());
+
+    // Wrong prefix: existing /apps/ namespace key
+    BOOST_CHECK(!parseMPTNodeKey("/apps/abc:def").has_value());
+
+    // Wrong prefix: existing s_ namespace key
+    BOOST_CHECK(!parseMPTNodeKey("s_number_2_hash:123").has_value());
+
+    // Exactly 37 bytes but wrong prefix: "/abc/" + 32 nul bytes (spec example)
+    std::string almost(37, '\0');
+    almost.replace(0, 5, "/abc/");
+    BOOST_CHECK(!parseMPTNodeKey(almost).has_value());
+}
+
+BOOST_AUTO_TEST_CASE(RawDbExposed)
+{
+    std::string path = "./mptkey_test_" + std::to_string(std::random_device{}());
+    ::rocksdb::DB* rawPtr = nullptr;
+
+    {
+        ::rocksdb::Options options;
+        options.create_if_missing = true;
+        ::rocksdb::Status s = ::rocksdb::DB::Open(options, path, &rawPtr);
+        BOOST_REQUIRE(s.ok());
+        BOOST_REQUIRE(rawPtr != nullptr);
+    }
+
+    std::unique_ptr<::rocksdb::DB> dbOwner(rawPtr);
+
+    // Construct RocksDBStorage2 wrapping our DB
+    RocksDBStorage2<executor_v1::StateKey, storage::Entry, StateKeyResolver, StateValueResolver>
+        storage(*dbOwner, StateKeyResolver{}, StateValueResolver{});
+
+    // rawDb() must return the same non-null pointer
+    BOOST_REQUIRE(storage.rawDb() != nullptr);
+    BOOST_CHECK_EQUAL(storage.rawDb(), rawPtr);
+
+    // Demonstrate writing and reading a /mpt/<hash> key via rawDb()
+    h256 hash = h256::generateRandomFixedBytes();
+    std::string mptKey = makeMPTNodeKey(hash);
+    std::string mptValue = "mpt_node_data";
+
+    ::rocksdb::WriteOptions wo;
+    auto putStatus =
+        storage.rawDb()->Put(wo, storage.rawDb()->DefaultColumnFamily(), mptKey, mptValue);
+    BOOST_REQUIRE(putStatus.ok());
+
+    std::string readback;
+    ::rocksdb::ReadOptions ro;
+    auto getStatus =
+        storage.rawDb()->Get(ro, storage.rawDb()->DefaultColumnFamily(), mptKey, &readback);
+    BOOST_REQUIRE(getStatus.ok());
+    BOOST_CHECK_EQUAL(readback, mptValue);
+
+    // Cleanup
+    boost::filesystem::remove_all(path);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-storage/test/unittest/TestSchemaVersion.cpp
+++ b/bcos-storage/test/unittest/TestSchemaVersion.cpp
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Unit tests for SchemaVersion (spec §8.2)
+ * @file TestSchemaVersion.cpp
+ * @author: kyonRay
+ * @date: 2026-05-12
+ */
+#include <bcos-storage/SchemaVersion.h>
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos::storage2::rocksdb;
+
+struct SchemaVersionFixture
+{
+    std::string path = "./schema_v_" + std::to_string(std::random_device{}());
+
+    SchemaVersionFixture()
+    {
+        ::rocksdb::Options options;
+        options.create_if_missing = true;
+
+        ::rocksdb::DB* raw = nullptr;
+        ::rocksdb::Status s = ::rocksdb::DB::Open(options, path, &raw);
+        BOOST_REQUIRE(s.ok());
+        db.reset(raw);
+    }
+
+    ~SchemaVersionFixture() { boost::filesystem::remove_all(path); }
+
+    std::unique_ptr<::rocksdb::DB> db;
+};
+
+BOOST_FIXTURE_TEST_SUITE(SchemaVersionSuite, SchemaVersionFixture)
+
+BOOST_AUTO_TEST_CASE(WriteAndReadSchemaVersion)
+{
+    // Write version 1 and verify read-back from the same open DB
+    SchemaVersion::write(*db, 1);
+    auto result = SchemaVersion::read(*db);
+    BOOST_REQUIRE(result.has_value());
+    BOOST_CHECK_EQUAL(*result, 1);
+
+    // Durability: close the DB, reopen the same path, read again
+    db.reset();
+
+    ::rocksdb::Options options;
+    options.create_if_missing = false;
+    ::rocksdb::DB* raw = nullptr;
+    ::rocksdb::Status s = ::rocksdb::DB::Open(options, path, &raw);
+    BOOST_REQUIRE(s.ok());
+    db.reset(raw);
+
+    auto result2 = SchemaVersion::read(*db);
+    BOOST_REQUIRE(result2.has_value());
+    BOOST_CHECK_EQUAL(*result2, 1);
+}
+
+BOOST_AUTO_TEST_CASE(LegacyDbReturnsNullopt)
+{
+    // Fresh DB with no version key written — must return nullopt (legacy-DB compatible)
+    auto result = SchemaVersion::read(*db);
+    BOOST_CHECK(!result.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(MismatchedExpectedVersionThrows)
+{
+    // Write version 2; checkExpected(db, 1) must throw SchemaVersionMismatch
+    SchemaVersion::write(*db, 2);
+    BOOST_CHECK_THROW(SchemaVersion::checkExpected(*db, 1), SchemaVersionMismatch);
+
+    // checkExpected(db, 2) must NOT throw
+    BOOST_CHECK_NO_THROW(SchemaVersion::checkExpected(*db, 2));
+
+    // Absent-key case: fresh DB (no key) + non-zero expectation → throws
+    db.reset();
+    boost::filesystem::remove_all(path);
+
+    ::rocksdb::Options opts;
+    opts.create_if_missing = true;
+    ::rocksdb::DB* raw = nullptr;
+    ::rocksdb::Status s = ::rocksdb::DB::Open(opts, path, &raw);
+    BOOST_REQUIRE(s.ok());
+    db.reset(raw);
+
+    BOOST_CHECK_THROW(SchemaVersion::checkExpected(*db, 1), SchemaVersionMismatch);
+}
+
+BOOST_AUTO_TEST_CASE(ReadRejectsValueWithTrailingGarbage)
+{
+    // Bypass write() to inject a malformed value directly.
+    auto status =
+        db->Put(::rocksdb::WriteOptions{}, db->DefaultColumnFamily(), SchemaVersion::kKey, "5xyz");
+    BOOST_REQUIRE(status.ok());
+
+    BOOST_CHECK_THROW(SchemaVersion::read(*db), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

**PR-02 of the MPT phase-a series** (M1.2). Adds the schema-version facility used by genesis (Scenario B) and by every subsequent startup to validate the database against an expected schema version.

> **Stacked on:** #5196 (PR-01 — KeyPrefixes + rawDb()). Diff below includes PR-01's commit; the incremental PR-02 work is the single ``7cc7c93ce`` (then amended) commit. Once #5196 lands, this PR's base will auto-rebase against ``release-3.18.0`` and only the PR-02 diff will remain.

## Why

Per spec §8.2, Scenario B writes the schema version at genesis; every subsequent start re-checks it. **Legacy databases without a schema-version key are accepted as v0** — no migration, no startup blocking. This PR is decoupled from the Trie module itself so it can land independently of the larger MPT work.

## What

| File | Change |
| --- | --- |
| ``bcos-storage/bcos-storage/SchemaVersion.h`` (new) | Public API: ``kKey``, ``SchemaVersionMismatch``, ``write`` / ``read`` / ``checkExpected`` |
| ``bcos-storage/bcos-storage/SchemaVersion.cpp`` (new) | Implementation — RocksDB ``Get``/``Put`` + ``std::from_chars`` |
| ``bcos-storage/test/unittest/TestSchemaVersion.cpp`` (new) | ``SchemaVersionSuite`` — 4 cases |
| ``bcos-storage/CMakeLists.txt`` | Register ``SchemaVersion.cpp`` in ``SRC_LIST`` |
| ``bcos-storage/test/unittest/CMakeLists.txt`` | Register ``TestSchemaVersion.cpp`` in ``SOURCES`` |

Surface-area: ~140 production LOC, ~110 test LOC. All within the ≤300 inserted-line PR cap (UT excluded).

## Key design decisions

- **Storage key**: ``__schema_version__`` in the **default ColumnFamily** as ASCII int (``std::to_string``). No new CF, consistent with PR-01.
- **Signatures take ``rocksdb::DB&``** directly (not ``RocksDBStorage2&``). Reason: ``rocksdb::DB::Get`` / ``Put`` are non-const, and the SchemaVersion facility is conceptually a thin wrapper around a single key — there's no value in coupling it to a particular storage abstraction. Callers pass ``storage.rawDb()`` (PR-01 exposes that).
- **``checkExpected`` throws ``SchemaVersionMismatch``** for both value-mismatch and absent-key-with-expected (treat absent-key as a mismatch when the caller has a specific expectation).
- **``read`` is strict**: rejects values with trailing garbage (``"5xyz"``) by checking ``from_chars`` consumed the full buffer. This is the integrity gate guarding every subsequent startup — being permissive here defeats its purpose.
- **No migration code**: a single-int key needs no schema format.

## Test plan

- [x] ``SchemaVersionSuite``: 4/4 PASS
  - ``WriteAndReadSchemaVersion`` — write, read, close, reopen, read again (durability)
  - ``LegacyDbReturnsNullopt`` — fresh DB returns ``std::nullopt``
  - ``MismatchedExpectedVersionThrows`` — mismatch + matching-no-throw + absent-key-with-expectation cases
  - ``ReadRejectsValueWithTrailingGarbage`` — ``"5xyz"`` parse rejection (integrity gate)
- [x] Full ``test-storage`` regression: 19/19 PASS — no behavior change in PR-01 suites or any other existing suite
- [x] Pre-commit hook: clang-format clean, license header present, file count and inserted-line count within limit
- [ ] CI

Refs: spec §8.2.