### PR TITLE
Remove task_group and refactor front service

### DIFF
--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -39,8 +39,7 @@ void dispatchToIOServicePool(bcos::IOServicePool& ioServicePool, Task&& task)
 {
     auto& ioService = ioServicePool.getIOService();
     auto executor = ioService->get_executor();
-    boost::asio::post(executor,
-        [ioService = std::move(ioService), task = std::forward<Task>(task)]() mutable { task(); });
+    boost::asio::post(executor, [task = std::forward<Task>(task)]() mutable { task(); });
 }
 }  // namespace
 

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -24,15 +24,25 @@
 #include <bcos-front/FrontService.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Exceptions.h>
-#include <oneapi/tbb/task_arena.h>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <chrono>
 #include <random>
 #include <range/v3/view/concat.hpp>
 #include <range/v3/view/single.hpp>
-#include <thread>
 #include <utility>
+
+namespace
+{
+template <class Task>
+void dispatchToIOServicePool(bcos::IOServicePool& ioServicePool, Task&& task)
+{
+    auto& ioService = ioServicePool.getIOService();
+    auto executor = ioService->get_executor();
+    boost::asio::post(executor,
+        [ioService = std::move(ioService), task = std::forward<Task>(task)]() mutable { task(); });
+}
+}  // namespace
 
 using namespace bcos;
 using namespace front;
@@ -49,7 +59,6 @@ FrontService::FrontService()
 FrontService::~FrontService() noexcept
 {
     stop();
-    m_asyncGroup.wait();
     FRONT_LOG(INFO) << LOG_DESC("~FrontService") << LOG_KV("this", this);
 }
 
@@ -97,6 +106,11 @@ std::shared_ptr<boost::asio::io_context> FrontService::ioService() const
 void FrontService::setIoService(std::shared_ptr<boost::asio::io_context> _ioService)
 {
     m_ioService = std::move(_ioService);
+}
+
+void FrontService::setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool)
+{
+    m_ioServicePool = std::move(_ioServicePool);
 }
 
 void FrontService::registerModuleMessageDispatcher(int _moduleID,
@@ -188,6 +202,12 @@ void FrontService::checkParams()
         BOOST_THROW_EXCEPTION(
             InvalidParameter() << errinfo_comment(" FrontService ioService is uninitialized"));
     }
+
+    if (!m_ioServicePool)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidParameter() << errinfo_comment(" FrontService ioServicePool is uninitialized"));
+    }
 }
 
 void FrontService::start()
@@ -225,27 +245,6 @@ void FrontService::start()
             }
         });
 
-    m_frontServiceThread = std::make_shared<std::thread>([this]() {
-        while (m_run)
-        {
-            try
-            {
-                auto work = boost::asio::make_work_guard(*m_ioService);
-                m_ioService->run();
-            }
-            catch (std::exception& e)
-            {
-                FRONT_LOG(WARNING)
-                    << LOG_DESC("IOService") << LOG_KV("failed", boost::diagnostic_information(e));
-            }
-
-            if (m_run && m_ioService->stopped())
-            {
-                m_ioService->restart();
-            }
-        }
-    });
-
     FRONT_LOG(INFO) << LOG_DESC("start") << LOG_KV("nodeID", m_nodeID->hex())
                     << LOG_KV("groupID", m_groupID);
 
@@ -282,16 +281,6 @@ void FrontService::stop()
             // clear the callback
             m_callback.clear();
         }
-
-        if (m_ioService)
-        {
-            m_ioService->stop();
-        }
-
-        if (m_frontServiceThread && m_frontServiceThread->joinable())
-        {
-            m_frontServiceThread->join();
-        }
     }
     catch (const std::exception& e)
     {
@@ -322,12 +311,11 @@ void FrontService::asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInf
                             (groupNodeInfo ? groupNodeInfo->nodeIDList().size() : 0));
     if (_onGetGroupNodeInfo)
     {
-        m_taskArena.execute([&]() {
-            m_asyncGroup.run([_onGetGroupNodeInfo = std::move(_onGetGroupNodeInfo),
-                                 groupNodeInfo = std::move(groupNodeInfo)]() {
+        dispatchToIOServicePool(
+            *m_ioServicePool, [_onGetGroupNodeInfo = std::move(_onGetGroupNodeInfo),
+                                  groupNodeInfo = std::move(groupNodeInfo)]() mutable {
                 _onGetGroupNodeInfo(nullptr, groupNodeInfo);
             });
-        });
     }
 }
 
@@ -468,13 +456,14 @@ void FrontService::onReceiveGroupNodeInfo(const std::string& _groupID,
                     << LOG_KV("nodeIDs.size()",
                            (_groupNodeInfo ? _groupNodeInfo->nodeIDList().size() : 0));
 
-    auto self = std::weak_ptr<FrontService>(shared_from_this());
-
-    m_taskArena.execute([&]() {
-        m_asyncGroup.run([this, _groupID, _groupNodeInfo = std::move(_groupNodeInfo)]() {
-            notifyGroupNodeInfo(_groupID, _groupNodeInfo);
+    auto self = weak_from_this();
+    dispatchToIOServicePool(
+        *m_ioServicePool, [self, _groupID, _groupNodeInfo = std::move(_groupNodeInfo)]() mutable {
+            if (auto frontService = self.lock())
+            {
+                frontService->notifyGroupNodeInfo(_groupID, _groupNodeInfo);
+            }
         });
-    });
 
     if (_receiveMsgCallback)
     {
@@ -572,14 +561,13 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
 
     // Copy the payload before dispatching asynchronously.
     auto buffer = bytes(_payLoad.begin(), _payLoad.end());
-    m_taskArena.execute([&]() {
-        m_asyncGroup.run([_uuid, _error = std::move(_error), callback = std::move(callback),
-                             buffer = std::move(buffer), _nodeID = std::move(_nodeID),
-                             respFunc = std::move(respFunc)] {
+    dispatchToIOServicePool(
+        *m_ioServicePool, [_uuid, _error = std::move(_error), callback = std::move(callback),
+                              buffer = std::move(buffer), _nodeID = std::move(_nodeID),
+                              respFunc = std::move(respFunc)]() mutable {
             callback->callbackFunc(
                 _error, _nodeID, bytesConstRef(buffer.data(), buffer.size()), _uuid, respFunc);
         });
-    });
 }
 /**
  * @brief: receive message from gateway
@@ -625,12 +613,11 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
                 // Copy the payload before dispatching asynchronously.
                 bytes buffer(message.payload().begin(), message.payload().end());
 
-                m_taskArena.execute([&]() mutable {
-                    m_asyncGroup.run([uuid, callback = std::move(callback),
-                                         buffer = std::move(buffer), _nodeID] {
+                dispatchToIOServicePool(
+                    *m_ioServicePool, [uuid, callback = std::move(callback),
+                                          buffer = std::move(buffer), _nodeID]() mutable {
                         callback(_nodeID, uuid, bytesConstRef(buffer.data(), buffer.size()));
                     });
-                });
             }
             else
             {
@@ -647,11 +634,10 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
 
     if (_receiveMsgCallback)
     {
-        m_taskArena.execute([&]() mutable {
-            m_asyncGroup.run([_receiveMsgCallback = std::move(_receiveMsgCallback)]() {
+        dispatchToIOServicePool(
+            *m_ioServicePool, [_receiveMsgCallback = std::move(_receiveMsgCallback)]() mutable {
                 _receiveMsgCallback(nullptr);
             });
-        });
     }
 }
 
@@ -725,13 +711,11 @@ void FrontService::onMessageTimeout(const boost::system::error_code& _error,
         if (callback)
         {
             auto errorPtr = BCOS_ERROR_PTR(CommonError::TIMEOUT, "timeout");
-            m_taskArena.execute([&]() {
-                m_asyncGroup.run(
-                    [_uuid, _nodeID = std::move(_nodeID), callback = std::move(callback),
-                        errorPtr = std::move(errorPtr)]() {
-                        callback->callbackFunc(errorPtr, _nodeID, {}, _uuid, {});
-                    });
-            });
+            dispatchToIOServicePool(*m_ioServicePool,
+                [_uuid, _nodeID = std::move(_nodeID), callback = std::move(callback),
+                    errorPtr = std::move(errorPtr)]() mutable {
+                    callback->callbackFunc(errorPtr, _nodeID, {}, _uuid, {});
+                });
         }
 
         FRONT_LOG(WARNING) << LOG_BADGE("onMessageTimeout") << LOG_KV("uuid", _uuid);

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -23,9 +23,8 @@
 #include <bcos-framework/gateway/GatewayInterface.h>
 #include <bcos-framework/gateway/GroupNodeInfo.h>
 #include <bcos-utilities/Common.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/ThreadPool.h>
-#include <oneapi/tbb/task_arena.h>
-#include <oneapi/tbb/task_group.h>
 #include <boost/asio.hpp>
 
 namespace bcos::front
@@ -160,6 +159,7 @@ public:
 
     std::shared_ptr<boost::asio::io_context> ioService() const;
     void setIoService(std::shared_ptr<boost::asio::io_context> _ioService);
+    void setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool);
 
     // register message _dispatcher for module
     void registerModuleMessageDispatcher(int _moduleID,
@@ -210,8 +210,7 @@ protected:
     virtual void protocolNegotiate(bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo);
 
 private:
-    tbb::task_arena m_taskArena;
-    tbb::task_group m_asyncGroup;
+    bcos::IOServicePool::Ptr m_ioServicePool;
     // timer
     std::shared_ptr<boost::asio::io_context> m_ioService;
     /// gateway interface
@@ -226,8 +225,6 @@ private:
 
     // service is running or not
     bool m_run = false;
-    //
-    std::shared_ptr<std::thread> m_frontServiceThread;
     // NodeID
     bcos::crypto::NodeIDPtr m_nodeID;
     // GroupID

--- a/bcos-front/bcos-front/FrontServiceFactory.cpp
+++ b/bcos-front/bcos-front/FrontServiceFactory.cpp
@@ -35,13 +35,20 @@ FrontService::Ptr FrontServiceFactory::buildFrontService(
                                   "FrontServiceFactory::init gateway is uninitialized"));
     }
 
+    if (!m_ioServicePool)
+    {
+        BOOST_THROW_EXCEPTION(InvalidParameter() << errinfo_comment(
+                                  "FrontServiceFactory::init ioServicePool is uninitialized"));
+    }
+
     FRONT_LOG(INFO) << LOG_DESC("FrontServiceFactory::buildFrontService")
                     << LOG_KV("groupID", _groupID) << LOG_KV("nodeID", _nodeID->hex());
 
     auto frontService = std::make_shared<FrontService>();
     frontService->setGroupID(_groupID);
     frontService->setNodeID(std::move(_nodeID));
-    frontService->setIoService(std::make_shared<boost::asio::io_context>());
+    frontService->setIOServicePool(m_ioServicePool);
+    frontService->setIoService(m_ioServicePool->getIOService());
     frontService->setGatewayInterface(m_gatewayInterface);
 
     return frontService;

--- a/bcos-front/bcos-front/FrontServiceFactory.h
+++ b/bcos-front/bcos-front/FrontServiceFactory.h
@@ -23,6 +23,7 @@
 #include <bcos-framework/front/FrontServiceInterface.h>
 #include <bcos-framework/gateway/GatewayInterface.h>
 #include <bcos-front/FrontService.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <utility>
 
 namespace bcos::front
@@ -40,9 +41,15 @@ public:
         m_gatewayInterface = std::move(_gatewayInterface);
     }
 
+    void setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool)
+    {
+        m_ioServicePool = std::move(_ioServicePool);
+    }
+
 private:
     // gatewayInterface
     bcos::gateway::GatewayInterface::Ptr m_gatewayInterface;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 
 }  // namespace bcos::front

--- a/bcos-front/test/unittests/FakeGateway.cpp
+++ b/bcos-front/test/unittests/FakeGateway.cpp
@@ -42,7 +42,10 @@ void FakeGateway::asyncSendMessageByNodeID(const std::string& _groupID, int,
     bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID, bytesConstRef _payload,
     bcos::gateway::ErrorRespFunc _errorRespFunc)
 {
-    m_frontService->onReceiveMessage(_groupID, _dstNodeID, _payload, _errorRespFunc);
+    if (auto frontService = m_frontService.lock())
+    {
+        frontService->onReceiveMessage(_groupID, _dstNodeID, _payload, _errorRespFunc);
+    }
 
     FRONT_LOG(DEBUG) << "[FakeGateway] asyncSendMessageByNodeID" << LOG_KV("groupID", _groupID)
                      << LOG_KV("nodeID", _srcNodeID->hex()) << LOG_KV("nodeID", _dstNodeID->hex());
@@ -62,8 +65,11 @@ void FakeGateway::asyncSendMessageByNodeIDs(const std::string& _groupID, int,
 {
     if (!_dstNodeIDs.empty())
     {
-        m_frontService->onReceiveMessage(
-            _groupID, _srcNodeID, _payload, bcos::gateway::ErrorRespFunc());
+        if (auto frontService = m_frontService.lock())
+        {
+            frontService->onReceiveMessage(
+                _groupID, _srcNodeID, _payload, bcos::gateway::ErrorRespFunc());
+        }
     }
 
     FRONT_LOG(DEBUG) << "[FakeGateway] asyncSendMessageByNodeIDs" << LOG_KV("groupID", _groupID);
@@ -75,8 +81,11 @@ bcos::task::Task<void> bcos::front::test::FakeGateway::broadcastMessage(uint16_t
     auto data = ::ranges::views::join(payloads) | ::ranges::to<bcos::bytes>();
     auto nodeIDPtr = std::shared_ptr<bcos::crypto::NodeID>(
         const_cast<bcos::crypto::NodeID*>(std::addressof(srcNodeID)), [](auto* ptr) {});
-    m_frontService->onReceiveBroadcastMessage(
-        std::string{groupID}, nodeIDPtr, ref(data), ErrorRespFunc());
+    if (auto frontService = m_frontService.lock())
+    {
+        frontService->onReceiveBroadcastMessage(
+            std::string{groupID}, nodeIDPtr, ref(data), ErrorRespFunc());
+    }
     FRONT_LOG(DEBUG) << "asyncSendBroadcastMessage" << LOG_KV("groupID", groupID);
     co_return;
 };

--- a/bcos-front/test/unittests/FakeGateway.h
+++ b/bcos-front/test/unittests/FakeGateway.h
@@ -36,7 +36,7 @@ class FakeGateway : public gateway::GatewayInterface,
 public:
     virtual ~FakeGateway() {}
 
-    std::shared_ptr<FrontServiceInterface> m_frontService;
+    std::weak_ptr<FrontServiceInterface> m_frontService;
     void setFrontService(std::shared_ptr<FrontServiceInterface> _frontService)
     {
         m_frontService = _frontService;

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -56,9 +56,12 @@ std::shared_ptr<FrontService> buildFrontService()
 {
     auto gateway = std::make_shared<FakeGateway>();
     auto srcNodeID = createKey(g_srcNodeID);
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1);
+    ioServicePool->start();
 
     auto frontServiceFactory = std::make_shared<FrontServiceFactory>();
     frontServiceFactory->setGatewayInterface(gateway);
+    frontServiceFactory->setIOServicePool(ioServicePool);
     auto frontService = frontServiceFactory->buildFrontService(g_groupID, srcNodeID);
     frontService->start();
 

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -613,8 +613,8 @@ std::shared_ptr<Service> GatewayFactory::buildService(const GatewayConfig::Ptr& 
 
     // init ASIOInterface
     auto asioInterface = std::make_shared<ASIOInterface>();
-    auto ioServicePool = std::make_shared<IOServicePool>();
-    asioInterface->setIOServicePool(ioServicePool);
+    auto ioServicePool = m_ioServicePool ? m_ioServicePool : std::make_shared<IOServicePool>();
+    asioInterface->setIOServicePool(ioServicePool, !m_ioServicePool);
     asioInterface->setSrvContext(srvCtx);
     asioInterface->setClientContext(clientCtx);
     asioInterface->setType(ASIOInterface::ASIO_TYPE::SSL);

--- a/bcos-gateway/bcos-gateway/GatewayFactory.h
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.h
@@ -11,6 +11,7 @@
 #include "bcos-gateway/GatewayConfig.h"
 #include "bcos-gateway/libamop/AMOPImpl.h"
 #include "bcos-gateway/libratelimit/GatewayRateLimiter.h"
+#include <bcos-utilities/IOServicePool.h>
 #include <sw/redis++/redis++.h>
 #include <boost/asio/ssl.hpp>
 
@@ -72,6 +73,11 @@ public:
 
     // build Service
     std::shared_ptr<Service> buildService(const GatewayConfig::Ptr& _config);
+
+    void setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool)
+    {
+        m_ioServicePool = std::move(_ioServicePool);
+    }
 
     /**
      * @brief construct Gateway for air
@@ -141,5 +147,6 @@ private:
     std::string m_rpcServiceName;
 
     bcos::security::KeyEncryptInterface::Ptr m_dataEncrypt{nullptr};
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace bcos::gateway

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -103,9 +103,10 @@ std::shared_ptr<ba::io_context> ASIOInterface::ioService()
     return m_ioServicePool->getIOService();
 }
 
-void ASIOInterface::setIOServicePool(IOServicePool::Ptr _ioServicePool)
+void ASIOInterface::setIOServicePool(IOServicePool::Ptr _ioServicePool, bool _manageLifecycle)
 {
     m_ioServicePool = std::move(_ioServicePool);
+    m_manageIOServicePool = _manageLifecycle;
     m_timerIOService = m_ioServicePool->getIOService();
 }
 
@@ -158,12 +159,18 @@ void ASIOInterface::init(std::string listenHost, uint16_t listenPort)
 
 void ASIOInterface::start()
 {
-    m_ioServicePool->start();
+    if (m_manageIOServicePool)
+    {
+        m_ioServicePool->start();
+    }
 }
 
 void ASIOInterface::stop()
 {
-    m_ioServicePool->stop();
+    if (m_manageIOServicePool)
+    {
+        m_ioServicePool->stop();
+    }
 }
 
 void ASIOInterface::asyncAccept(const std::shared_ptr<SocketFace>& socket, Handler_Type handler,

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -39,7 +39,8 @@ public:
     virtual void setType(int type);
 
     virtual std::shared_ptr<ba::io_context> ioService();
-    virtual void setIOServicePool(IOServicePool::Ptr _ioServicePool);
+    virtual void setIOServicePool(
+        IOServicePool::Ptr _ioServicePool, bool _manageLifecycle = true);
 
     virtual std::shared_ptr<ba::ssl::context> srvContext();
     virtual std::shared_ptr<ba::ssl::context> clientContext();
@@ -108,6 +109,7 @@ protected:
     IOServicePool::Ptr m_ioServicePool;
     std::shared_ptr<ba::io_context> m_timerIOService;
     std::shared_ptr<ba::io_context::strand> m_strand;
+    bool m_manageIOServicePool = true;
     std::shared_ptr<bi::tcp::acceptor> m_acceptor;
     std::shared_ptr<bi::tcp::resolver> m_resolver;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -385,22 +385,20 @@ void Host::startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> 
     std::shared_ptr<SessionFace> session =
         m_sessionFactory->createSession(*this, socket, m_messageFactory, m_sessionCallbackManager);
 
-    m_taskArena.execute([&]() {
-        m_asyncGroup.run([weakHost, session = std::move(session), p2pInfo]() {
-            auto host = weakHost.lock();
-            if (!host)
-            {
-                return;
-            }
-            if (host->m_connectionHandler)
-            {
-                host->m_connectionHandler(NetworkException(0, ""), p2pInfo, session);
-            }
-            else
-            {
-                HOST_LOG(WARNING) << LOG_DESC("No connectionHandler, new connection may lost");
-            }
-        });
+    boost::asio::post(socket->ioService(), [weakHost, session = std::move(session), p2pInfo]() {
+        auto host = weakHost.lock();
+        if (!host)
+        {
+            return;
+        }
+        if (host->m_connectionHandler)
+        {
+            host->m_connectionHandler(NetworkException(0, ""), p2pInfo, session);
+        }
+        else
+        {
+            HOST_LOG(WARNING) << LOG_DESC("No connectionHandler, new connection may lost");
+        }
     });
     HOST_LOG(INFO) << LOG_DESC("startPeerSession, Remote=") << socket->remoteEndpoint()
                    << LOG_KV("local endpoint", socket->localEndpoint())
@@ -489,10 +487,8 @@ void Host::asyncConnect(NodeIPEndpoint const& _nodeIPEndpoint,
                                 << LOG_KV("message", ec.message());
                 socket->close();
 
-                m_taskArena.execute([&]() {
-                    m_asyncGroup.run([callback = std::move(callback)]() {
-                        callback(NetworkException(ConnectError, "Connect failed"), {}, {});
-                    });
+                boost::asio::post(socket->ioService(), [callback = std::move(callback)]() mutable {
+                    callback(NetworkException(ConnectError, "Connect failed"), {}, {});
                 });
                 return;
             }
@@ -572,7 +568,6 @@ void Host::stop()
     {
         m_asioInterface->stop();
     }
-    m_asyncGroup.wait();
 }
 bcos::gateway::Host::Host(bcos::crypto::Hash::Ptr _hash,
     std::shared_ptr<ASIOInterface> _asioInterface, std::shared_ptr<SessionFactory> _sessionFactory,

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -11,13 +11,11 @@
 #include "bcos-gateway/libnetwork/PeerBlackWhitelistInterface.h"
 #include "bcos-gateway/libnetwork/SessionCallback.h"
 #include "bcos-utilities/Common.h"
-#include <oneapi/tbb/task_arena.h>
-#include <oneapi/tbb/task_group.h>
-#include <openssl/x509.h>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/system/error_code.hpp>
 #include <memory>
+#include <openssl/x509.h>
 #include <string>
 #include <utility>
 
@@ -96,12 +94,6 @@ public:
     virtual void setPeerWhitelist(PeerBlackWhitelistInterface::Ptr _peerWhitelist);
     virtual PeerBlackWhitelistInterface::Ptr peerWhitelist();
 
-    template <class F>
-    void asyncTo(F f)
-    {
-        m_asyncGroup.run(std::move(f));
-    }
-
     void setEnableSslVerify(bool _enableSSLVerify);
 
 protected:
@@ -140,8 +132,6 @@ protected:
 
     void insertPendingConns(NodeIPEndpoint const& nodeIPEndpoint);
 
-    tbb::task_arena m_taskArena;
-    tbb::task_group m_asyncGroup;
     std::shared_ptr<SessionCallbackManagerInterface> m_sessionCallbackManager;
 
     bcos::crypto::Hash::Ptr m_hashImpl;

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -125,7 +125,7 @@ void Session::asyncSendMessage(Message::Ptr message, Options options, SessionCal
         SESSION_LOG(WARNING) << "Session inactive";
         if (callback)
         {
-            m_server.get().asyncTo([callback = std::move(callback)] {
+            boost::asio::post(m_socket->ioService(), [callback = std::move(callback)] {
                 callback(NetworkException(-1, "Session inactive"), Message::Ptr());
             });
         }
@@ -140,7 +140,7 @@ void Session::asyncSendMessage(Message::Ptr message, Options options, SessionCal
                              << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
         if (callback)
         {
-            m_server.get().asyncTo([callback = std::move(callback)] {
+            boost::asio::post(m_socket->ioService(), [callback = std::move(callback)] {
                 callback(NetworkException(-1, "Msg size overflow"), Message::Ptr());
             });
         }
@@ -157,8 +157,8 @@ void Session::asyncSendMessage(Message::Ptr message, Options options, SessionCal
             const auto& error = result.value();
             auto errorCode = error.errorCode();
             auto errorMessage = error.errorMessage();
-            m_server.get().asyncTo([callback = std::move(callback), errorCode,
-                                       errorMessage = std::move(errorMessage)] {
+            boost::asio::post(m_socket->ioService(), [callback = std::move(callback), errorCode,
+                                                      errorMessage = std::move(errorMessage)] {
                 callback(NetworkException((int64_t)errorCode, errorMessage), Message::Ptr());
             });
         }
@@ -311,7 +311,7 @@ void Session::write()
                     {
                         if (payload.m_callback)
                         {
-                            session->m_server.get().asyncTo(
+                            boost::asio::post(session->m_socket->ioService(),
                                 [callback = std::move(payload.m_callback), error = _error]() {
                                     callback(error);
                                 });
@@ -348,7 +348,7 @@ void Session::drop(DisconnectReason _reason)
 
     if (m_messageHandler)
     {
-        m_server.get().asyncTo(
+        boost::asio::post(m_socket->ioService(),
             [self = weak_from_this(), errorCode, errorMsg = std::move(errorMsg)]() {
                 auto session = self.lock();
                 if (!session)
@@ -617,7 +617,8 @@ bool Session::checkRead(boost::system::error_code _ec)
 
 void Session::onMessage(NetworkException const& e, Message::Ptr message)
 {
-    m_server.get().asyncTo([self = weak_from_this(), e, message = std::move(message)]() {
+    boost::asio::post(m_socket->ioService(), [self = weak_from_this(), e,
+                                                  message = std::move(message)]() {
         try
         {
             auto session = self.lock();
@@ -691,7 +692,7 @@ void Session::onTimeout(const boost::system::error_code& error, uint32_t seq)
     {
         return;
     }
-    m_server.get().asyncTo([callback = std::move(callback)]() {
+    boost::asio::post(m_socket->ioService(), [callback = std::move(callback)]() {
         NetworkException e(P2PExceptionType::NetworkTimeout, "NetworkTimeout");
         callback->callback(e, Message::Ptr());
     });

--- a/bcos-gateway/test/common/FrontServiceBuilder.h
+++ b/bcos-gateway/test/common/FrontServiceBuilder.h
@@ -36,9 +36,12 @@ inline std::shared_ptr<bcos::front::FrontService> buildFrontService(
     auto keyFactory = std::make_shared<bcos::crypto::KeyFactoryImpl>();
     auto gatewayFactory = std::make_shared<bcos::gateway::GatewayFactory>("", "");
     auto frontServiceFactory = std::make_shared<bcos::front::FrontServiceFactory>();
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1);
+    ioServicePool->start();
     auto threadPool = std::make_shared<bcos::ThreadPool>("frontServiceTest", 16);
 
     // build gateway
+    gatewayFactory->setIOServicePool(ioServicePool);
     auto gateway = gatewayFactory->buildGateway(_configPath, true, nullptr, "localGateway");
 
     // create nodeID by nodeID str
@@ -46,6 +49,7 @@ inline std::shared_ptr<bcos::front::FrontService> buildFrontService(
         keyFactory->createKey(bcos::bytesConstRef((bcos::byte*)_nodeID.data(), _nodeID.size()));
 
     frontServiceFactory->setGatewayInterface(gateway);
+    frontServiceFactory->setIOServicePool(ioServicePool);
 
     // create frontService
     auto frontService = frontServiceFactory->buildFrontService(_groupID, nodeIDPtr);

--- a/bcos-gateway/test/unittests/GatewayNodeManagerTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayNodeManagerTest.cpp
@@ -121,7 +121,10 @@ BOOST_AUTO_TEST_CASE(test_GatewayNodeManager_registerFrontService)
         keyFactory->createKey(bytesConstRef((bcos::byte*)strNodeID.data(), strNodeID.size()));
 
     auto frontServiceFactory = std::make_shared<bcos::front::FrontServiceFactory>();
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1);
+    ioServicePool->start();
     frontServiceFactory->setGatewayInterface(std::make_shared<FakeGateway>());
+    frontServiceFactory->setIOServicePool(ioServicePool);
 
     auto frontService = frontServiceFactory->buildFrontService(groupID, nodeID);
 

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -247,8 +247,19 @@ public:
 class FakeSocket : public SocketFace
 {
 public:
-    FakeSocket() : SocketFace() {};
-    ~FakeSocket() override = default;
+    FakeSocket() : SocketFace(), m_workGuard(boost::asio::make_work_guard(m_ioService))
+    {
+        m_worker = std::thread([this]() { m_ioService.run(); });
+    };
+    ~FakeSocket() override
+    {
+        m_workGuard.reset();
+        m_ioService.stop();
+        if (m_worker.joinable())
+        {
+            m_worker.join();
+        }
+    }
     bool isConnected() const override { return true; }
     void close() override {}
     boost::asio::ip::tcp::endpoint remoteEndpoint(boost::system::error_code ec) override
@@ -268,6 +279,8 @@ public:
 private:
     std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
     ba::io_context m_ioService;
+    boost::asio::executor_work_guard<ba::io_context::executor_type> m_workGuard;
+    std::thread m_worker;
     NodeIPEndpoint m_nodeIPEndpoint;
 };
 

--- a/bcos-utilities/bcos-utilities/IOServicePool.cpp
+++ b/bcos-utilities/bcos-utilities/IOServicePool.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "bcos-utilities/IOServicePool.h"
+#include "bcos-utilities/Common.h"
 
 using namespace bcos;
 
@@ -46,7 +47,7 @@ void IOServicePool::start()
     }
 }
 
-std::shared_ptr<IOServicePool::IOService> IOServicePool::getIOService()
+std::shared_ptr<IOServicePool::IOService>& IOServicePool::getIOService()
 {
     auto selectedIoService = (m_nextIOService.fetch_add(1) % m_ioServices.size());
     return m_ioServices.at(selectedIoService);

--- a/bcos-utilities/bcos-utilities/IOServicePool.h
+++ b/bcos-utilities/bcos-utilities/IOServicePool.h
@@ -18,7 +18,6 @@
  */
 
 #pragma once
-#include "bcos-utilities/Common.h"
 #include <boost/asio.hpp>
 #include <memory>
 namespace bcos
@@ -39,9 +38,7 @@ public:
     virtual ~IOServicePool();
 
     void start();
-
-    std::shared_ptr<IOService> getIOService();
-
+    std::shared_ptr<IOService>& getIOService();
     void stop();
 
 private:

--- a/bcos-utilities/bcos-utilities/ratelimiter/DistributedRateLimiter.cpp
+++ b/bcos-utilities/bcos-utilities/ratelimiter/DistributedRateLimiter.cpp
@@ -37,6 +37,11 @@ DistributedRateLimiter::DistributedRateLimiter(std::shared_ptr<sw::redis::Redis>
     m_enableLocalCache(_enableLocalCache),
     m_localCachePercent(_localCachePercent)
 {
+    if (!m_redis)
+    {
+        return;
+    }
+
     if (m_enableLocalCache)
     {
         m_clearCacheTimer = std::make_shared<Timer>(toMillisecond(_intervalSec), "clearTimer");
@@ -239,6 +244,11 @@ bool DistributedRateLimiter::tryAcquireLocalCache(int64_t _requiredPermits, bool
  */
 int64_t DistributedRateLimiter::requestRedis(int64_t _requiredPermits)
 {
+    if (!m_redis)
+    {
+        return _requiredPermits;
+    }
+
     try
     {
         auto start = utcTimeUs();

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -30,6 +30,7 @@
 #include <bcos-rpc/tarsRPC/RPCServer.h>
 #include <bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.h>
 #include <bcos-tool/NodeConfig.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <rocksdb/env.h>
 
 using namespace bcos::node;
@@ -60,12 +61,17 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
     m_nodeInitializer = std::make_shared<bcos::initializer::Initializer>();
     m_nodeInitializer->initConfig(_configFilePath, _genesisFile, "", true);
 
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>();
+    ioServicePool->start();
+    m_nodeInitializer->setIOServicePool(ioServicePool);
+
     // create gateway
     // DataEncryption will be inited in ProtocolInitializer when storage_security.enable = true,
     // otherwise keyEncryption() will return nullptr
     GatewayFactory gatewayFactory(nodeConfig->chainId(), "localRpc",
         m_nodeInitializer->protocolInitializer()->getKeyEncryptionByType(
             nodeConfig->keyEncryptionType()));
+    gatewayFactory.setIOServicePool(ioServicePool);
     auto gateway = gatewayFactory.buildGateway(_configFilePath, true, nullptr, "localGateway");
     m_gateway = gateway;
 

--- a/libinitializer/FrontServiceInitializer.cpp
+++ b/libinitializer/FrontServiceInitializer.cpp
@@ -39,13 +39,15 @@ using namespace bcos::front;
 
 FrontServiceInitializer::FrontServiceInitializer(bcos::tool::NodeConfig::Ptr _nodeConfig,
     bcos::initializer::ProtocolInitializer::Ptr _protocolInitializer,
-    bcos::gateway::GatewayInterface::Ptr _gateWay)
+    bcos::gateway::GatewayInterface::Ptr _gateWay, bcos::IOServicePool::Ptr _ioServicePool)
   : m_nodeConfig(std::move(_nodeConfig)),
     m_protocolInitializer(std::move(_protocolInitializer)),
-    m_gateWay(std::move(_gateWay))
+    m_gateWay(std::move(_gateWay)),
+    m_ioServicePool(std::move(_ioServicePool))
 {
     auto frontServiceFactory = std::make_shared<FrontServiceFactory>();
     frontServiceFactory->setGatewayInterface(m_gateWay);
+    frontServiceFactory->setIOServicePool(m_ioServicePool);
 
     m_front = frontServiceFactory->buildFrontService(
         m_nodeConfig->groupId(), m_protocolInitializer->keyPair()->publicKey());

--- a/libinitializer/FrontServiceInitializer.h
+++ b/libinitializer/FrontServiceInitializer.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 #include <bcos-framework/front/FrontServiceInterface.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-tool/NodeConfig.h>
 #include <memory>
 
@@ -56,7 +57,8 @@ public:
     using Ptr = std::shared_ptr<FrontServiceInitializer>;
     FrontServiceInitializer(bcos::tool::NodeConfig::Ptr _nodeConfig,
         std::shared_ptr<bcos::initializer::ProtocolInitializer> _protocolInitializer,
-        std::shared_ptr<bcos::gateway::GatewayInterface> _gateWay);
+        std::shared_ptr<bcos::gateway::GatewayInterface> _gateWay,
+        bcos::IOServicePool::Ptr _ioServicePool);
     virtual ~FrontServiceInitializer() { stop(); }
 
     virtual void init(std::shared_ptr<bcos::consensus::ConsensusInterface> _pbft,
@@ -77,6 +79,7 @@ private:
     bcos::tool::NodeConfig::Ptr m_nodeConfig;
     std::shared_ptr<bcos::initializer::ProtocolInitializer> m_protocolInitializer;
     std::shared_ptr<bcos::gateway::GatewayInterface> m_gateWay;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 
     std::shared_ptr<bcos::front::FrontService> m_front;
     std::atomic_bool m_running = {false};

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -158,9 +158,15 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     std::string const& _configFilePath, std::string const& _genesisFile,
     bcos::gateway::GatewayInterface::Ptr _gateway, bool _airVersion, const std::string& _logPath)
 {
+    if (!m_ioServicePool)
+    {
+        m_ioServicePool = std::make_shared<bcos::IOServicePool>(1);
+        m_ioServicePool->start();
+    }
+
     // build the front service
-    m_frontServiceInitializer =
-        std::make_shared<FrontServiceInitializer>(m_nodeConfig, m_protocolInitializer, _gateway);
+    m_frontServiceInitializer = std::make_shared<FrontServiceInitializer>(
+        m_nodeConfig, m_protocolInitializer, _gateway, m_ioServicePool);
 
     // build the storage
     auto stateDBPath = getStateDBPath(_airVersion);
@@ -632,6 +638,10 @@ void Initializer::stop()
             m_archiveService->stop();
         }
 #endif
+        if (m_ioServicePool)
+        {
+            m_ioServicePool->stop();
+        }
     }
     catch (std::exception const& e)
     {

--- a/libinitializer/Initializer.h
+++ b/libinitializer/Initializer.h
@@ -32,6 +32,7 @@
 #include <bcos-executor/src/executor/SwitchExecutorManager.h>
 #include <bcos-scheduler/src/SchedulerManager.h>
 #include <bcos-utilities/BoostLogInitializer.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <memory>
 #ifdef WITH_LIGHTNODE
 #include "LightNodeInitializer.h"
@@ -77,6 +78,11 @@ public:
 
     FrontServiceInitializer::Ptr frontService() { return m_frontServiceInitializer; }
 
+    void setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool)
+    {
+        m_ioServicePool = std::move(_ioServicePool);
+    }
+
     void initAirNode(std::string const& _configFilePath, std::string const& _genesisFile,
         std::shared_ptr<bcos::gateway::GatewayInterface> _gateway, const std::string& _logPath);
     void initMicroServiceNode(bcos::protocol::NodeArchitectureType _nodeArchType,
@@ -111,6 +117,7 @@ private:
     bcos::tool::NodeConfig::Ptr m_nodeConfig;
     ProtocolInitializer::Ptr m_protocolInitializer;
     FrontServiceInitializer::Ptr m_frontServiceInitializer;
+    bcos::IOServicePool::Ptr m_ioServicePool;
     TxPoolInitializer::Ptr m_txpoolInitializer;
     PBFTInitializer::Ptr m_pbftInitializer;
 #ifdef WITH_LIGHTNODE

--- a/lightnode/fisco-bcos-lightnode/main.cpp
+++ b/lightnode/fisco-bcos-lightnode/main.cpp
@@ -36,6 +36,7 @@
 #include <bcos-tars-protocol/tars/Block.h>
 #include <bcos-task/Task.h>
 #include <bcos-utilities/BoostLogInitializer.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <libinitializer/LedgerInitializer.h>
 #include <libinitializer/ProtocolInitializer.h>
 #include <boost/exception/diagnostic_information.hpp>
@@ -210,6 +211,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
     protocolInitializer.init(nodeConfig);
     protocolInitializer.loadKeyPair(nodeConfig->privateKeyPath());
     auto nodeID = protocolInitializer.keyPair()->publicKey()->hex();
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>();
+    ioServicePool->start();
 
     auto front = std::make_shared<bcos::front::FrontService>();
     // gateway
@@ -217,6 +220,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
     try
     {
         bcos::gateway::GatewayFactory gatewayFactory(nodeConfig->chainId(), "local", nullptr);
+        gatewayFactory.setIOServicePool(ioServicePool);
         gateway = gatewayFactory.buildGateway(configFile, true, nullptr, "localGateway");
         auto protocolInfo = bcos::protocol::g_BCOSConfig.protocolInfo(
             bcos::protocol::ProtocolModuleID::GatewayService);
@@ -238,7 +242,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
     // front
     front->setGroupID(nodeConfig->groupId());
     front->setNodeID(protocolInitializer.keyPair()->publicKey());
-    front->setIoService(std::make_shared<boost::asio::io_context>());
+    front->setIOServicePool(ioServicePool);
+    front->setIoService(ioServicePool->getIOService());
     front->setGatewayInterface(gateway);
     front->registerModuleMessageDispatcher(bcos::protocol::BlockSync,
         [](const bcos::crypto::NodeIDPtr&, const std::string&, bcos::bytesConstRef) {});


### PR DESCRIPTION
Eliminate the task_group from the bcos-gateway and refactor the front service to utilize the IO service pool for improved management of asynchronous operations. This change enhances the overall architecture and efficiency of the service.