### PR TITLE
Add updateForkChoice logic

### DIFF
--- a/bcos-storage/CMakeLists.txt
+++ b/bcos-storage/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(Boost REQUIRED serialization thread context filesystem)
 
 set(SRC_LIST bcos-storage/Common.cpp)
 list(APPEND SRC_LIST bcos-storage/RocksDBStorage.cpp)
+list(APPEND SRC_LIST bcos-storage/CheckpointRocksDBStorage.cpp)
 
 set(LIB_LIST table bcos-framework Boost::serialization Boost::filesystem zstd::libzstd_static RocksDB::rocksdb ittapi)
 

--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
@@ -1,0 +1,82 @@
+#include "bcos-storage/CheckpointRocksDBStorage.h"
+#include "bcos-utilities/Exceptions.h"
+#include <rocksdb/options.h>
+#include <boost/throw_exception.hpp>
+#include <filesystem>
+
+namespace bcos::storage2::rocksdb
+{
+
+CheckpointRocksDBStorage::CheckpointRocksDBStorage(std::string_view rootDir)
+  : m_path(std::filesystem::path(rootDir).lexically_normal().string())
+{}
+
+const std::string& CheckpointRocksDBStorage::path() const noexcept
+{
+    return m_path;
+}
+
+std::string CheckpointRocksDBStorage::latestPath() const
+{
+    return resolveLatestPath(m_path);
+}
+
+std::string CheckpointRocksDBStorage::checkpointPath(std::string_view checkpointName) const
+{
+    return resolveCheckpointPath(m_path, checkpointName);
+}
+
+std::unique_ptr<::rocksdb::DB> CheckpointRocksDBStorage::open(
+    LatestCheckpointStorageTag latestTag) const
+{
+    return openRocksDB(resolveLatestPath(m_path), latestOptions(latestTag));
+}
+
+std::unique_ptr<::rocksdb::DB> CheckpointRocksDBStorage::open(std::string_view checkpointName) const
+{
+    return openRocksDB(resolveCheckpointPath(m_path, checkpointName), checkpointOptions());
+}
+
+std::unique_ptr<::rocksdb::DB> CheckpointRocksDBStorage::openRocksDB(
+    const std::string& path, const ::rocksdb::Options& options)
+{
+    ::rocksdb::DB* rocksDB = nullptr;
+    auto status = ::rocksdb::DB::Open(options, path, &rocksDB);
+    if (!status.ok())
+    {
+        BOOST_THROW_EXCEPTION(
+            CheckpointRocksDBException{} << bcos::errinfo_comment(
+                "Open rocksdb failed, path: " + path + ", error: " + status.ToString()));
+    }
+    return std::unique_ptr<::rocksdb::DB>(rocksDB);
+}
+
+::rocksdb::Options CheckpointRocksDBStorage::latestOptions(LatestCheckpointStorageTag /*latestTag*/)
+{
+    ::rocksdb::Options options;
+    options.create_if_missing = true;
+    return options;
+}
+
+::rocksdb::Options CheckpointRocksDBStorage::checkpointOptions()
+{
+    ::rocksdb::Options options;
+    options.create_if_missing = false;
+    return options;
+}
+
+std::string CheckpointRocksDBStorage::resolveLatestPath(std::string_view rootDir)
+{
+    auto path = std::filesystem::path(rootDir) / "latest";
+    return path.lexically_normal().string();
+}
+
+std::string CheckpointRocksDBStorage::resolveCheckpointPath(
+    std::string_view rootDir, std::string_view checkpointName)
+{
+    auto path =
+        std::filesystem::path(rootDir) / "checkpoints" / std::filesystem::path(checkpointName);
+    return path.lexically_normal().string();
+}
+
+}  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "bcos-utilities/Exceptions.h"
+#include <rocksdb/db.h>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace bcos::storage2::rocksdb
+{
+
+DERIVE_BCOS_EXCEPTION(CheckpointRocksDBException);
+
+inline constexpr struct LatestCheckpointStorageTag
+{
+} latestCheckpointStorage;
+
+class CheckpointRocksDBStorage
+{
+public:
+    explicit CheckpointRocksDBStorage(std::string_view rootDir);
+
+    const std::string& path() const noexcept;
+
+    std::string latestPath() const;
+
+    std::string checkpointPath(std::string_view checkpointName) const;
+
+    std::unique_ptr<::rocksdb::DB> open(LatestCheckpointStorageTag latestTag) const;
+
+    std::unique_ptr<::rocksdb::DB> open(std::string_view checkpointName) const;
+
+private:
+    static std::unique_ptr<::rocksdb::DB> openRocksDB(
+        const std::string& path, const ::rocksdb::Options& options);
+
+    static ::rocksdb::Options latestOptions(LatestCheckpointStorageTag latestTag);
+
+    static ::rocksdb::Options checkpointOptions();
+
+    static std::string resolveLatestPath(std::string_view rootDir);
+
+    static std::string resolveCheckpointPath(
+        std::string_view rootDir, std::string_view checkpointName);
+
+    std::string m_path;
+};
+
+}  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/RocksDBStorage2.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage2.h
@@ -84,9 +84,9 @@ public:
 
         auto encodedKey = m_keyResolver.encode(std::move(key));
         ::rocksdb::PinnableSlice result;
-        auto status = m_rocksDB.get().Get(::rocksdb::ReadOptions(),
-            m_rocksDB.get().DefaultColumnFamily(),
-            ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey)), &result);
+        auto status =
+            m_rocksDB.get().Get(::rocksdb::ReadOptions(), m_rocksDB.get().DefaultColumnFamily(),
+                ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey)), &result);
 
         if (!status.ok())
         {
@@ -94,7 +94,8 @@ public:
             {
                 co_return StorageValueType<ValueType>{};
             }
-            BOOST_THROW_EXCEPTION(RocksDBException{} << bcos::Error::ErrorMessage(status.ToString()));
+            BOOST_THROW_EXCEPTION(
+                RocksDBException{} << bcos::Error::ErrorMessage(status.ToString()));
         }
 
         co_return StorageValueType<ValueType>{m_valueResolver.decode(result.ToStringView())};
@@ -103,8 +104,7 @@ public:
     auto readSome(::ranges::input_range auto keys, auto&&... args)
         -> task::Task<std::vector<std::optional<ValueType>>>
     {
-        auto values =
-            co_await readSomeRaw(std::move(keys), std::forward<decltype(args)>(args)...);
+        auto values = co_await readSomeRaw(std::move(keys), std::forward<decltype(args)>(args)...);
         co_return ::ranges::views::transform(values, [](auto&& value) -> std::optional<ValueType> {
             if (auto* entry = std::get_if<ValueType>(std::addressof(value)))
             {
@@ -136,8 +136,7 @@ public:
         }
 
         ::rocksdb::WriteOptions options;
-        auto status = m_rocksDB.get().Write(options, std::addressof(writeBatch));
-        if (!status.ok())
+        if (auto status = m_rocksDB.get().Write(options, std::addressof(writeBatch)); !status.ok())
         {
             BOOST_THROW_EXCEPTION(RocksDBException{} << errinfo_comment(status.ToString()));
         }
@@ -150,11 +149,10 @@ public:
         auto rocksDBValue = m_valueResolver.encode(value);
 
         ::rocksdb::WriteOptions options;
-        auto status = m_rocksDB.get().Put(options,
-            ::rocksdb::Slice(::ranges::data(rocksDBKey), ::ranges::size(rocksDBKey)),
-            ::rocksdb::Slice(::ranges::data(rocksDBValue), ::ranges::size(rocksDBValue)));
-
-        if (!status.ok())
+        if (auto status = m_rocksDB.get().Put(options,
+                ::rocksdb::Slice(::ranges::data(rocksDBKey), ::ranges::size(rocksDBKey)),
+                ::rocksdb::Slice(::ranges::data(rocksDBValue), ::ranges::size(rocksDBValue)));
+            !status.ok())
         {
             BOOST_THROW_EXCEPTION(RocksDBException{} << errinfo_comment(status.ToString()));
         }
@@ -173,8 +171,7 @@ public:
         }
 
         ::rocksdb::WriteOptions options;
-        auto status = m_rocksDB.get().Write(options, &writeBatch);
-        if (!status.ok())
+        if (auto status = m_rocksDB.get().Write(options, &writeBatch); !status.ok())
         {
             BOOST_THROW_EXCEPTION(RocksDBException{} << errinfo_comment(status.ToString()));
         }

--- a/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
@@ -2,12 +2,14 @@
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-task/Wait.h"
+#include <bcos-storage/CheckpointRocksDBStorage.h>
 #include <bcos-framework/storage/Entry.h>
 #include <bcos-storage/RocksDBStorage2.h>
 #include <bcos-storage/StateKVResolver.h>
 #include <fmt/format.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
+#include <filesystem>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/iota.hpp>
 #include <range/v3/view/repeat.hpp>
@@ -37,6 +39,25 @@ struct TestRocksDBStorage2Fixture
 
     ~TestRocksDBStorage2Fixture() { boost::filesystem::remove_all(path); }
     std::unique_ptr<rocksdb::DB> originRocksDB;
+
+    static void populate(const std::string& dbPath, std::string_view table, std::string_view key,
+        std::string_view value)
+    {
+        boost::filesystem::create_directories(dbPath);
+
+        ::rocksdb::Options options;
+        options.create_if_missing = true;
+
+        rocksdb::DB* db = nullptr;
+        auto status = rocksdb::DB::Open(options, dbPath, &db);
+        BOOST_REQUIRE(status.ok());
+        std::unique_ptr<rocksdb::DB> guard(db);
+
+        RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver> storage(
+            *guard, StateKeyResolver{}, StateValueResolver{});
+        task::syncWait(storage2::writeOne(
+            storage, StateKey{table, key}, storage::Entry(std::string(value))));
+    }
 };
 
 BOOST_FIXTURE_TEST_SUITE(TestRocksDBStorage2, TestRocksDBStorage2Fixture)
@@ -210,6 +231,53 @@ BOOST_AUTO_TEST_CASE(merge)
 
         co_return;
     }());
+}
+
+BOOST_AUTO_TEST_CASE(openLatestOrCheckpointByDirectory)
+{
+    auto root = path + "_checkpoint_root";
+    CheckpointRocksDBStorage checkpointRocksDBStorage(root);
+    auto latestPath = checkpointRocksDBStorage.latestPath();
+    auto checkpointName = std::string("blockHash123");
+    auto checkpointPath = checkpointRocksDBStorage.checkpointPath(checkpointName);
+
+    populate(latestPath, "sys"sv, "key"sv, "latest-value"sv);
+    populate(checkpointPath, "sys"sv, "key"sv, "checkpoint-value"sv);
+
+    task::syncWait([&]() -> task::Task<void> {
+        auto latestDB = checkpointRocksDBStorage.open(latestCheckpointStorage);
+        RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver> latestStorage(
+            *latestDB, StateKeyResolver{}, StateValueResolver{});
+        auto latestValue =
+            co_await storage2::readOne(latestStorage, StateKey{"sys"sv, "key"sv});
+        BOOST_REQUIRE(latestValue);
+        BOOST_CHECK_EQUAL(latestValue->get(), "latest-value");
+        BOOST_CHECK_EQUAL(checkpointRocksDBStorage.latestPath(), latestPath);
+
+        {
+            auto checkpointDB = checkpointRocksDBStorage.open(checkpointName);
+            RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver>
+                checkpointStorage(*checkpointDB, StateKeyResolver{}, StateValueResolver{});
+            auto checkpointValue = co_await storage2::readOne(
+                checkpointStorage, StateKey{"sys"sv, "key"sv});
+            BOOST_REQUIRE(checkpointValue);
+            BOOST_CHECK_EQUAL(checkpointValue->get(), "checkpoint-value");
+            BOOST_CHECK_EQUAL(checkpointRocksDBStorage.checkpointPath(checkpointName), checkpointPath);
+        }
+
+        auto checkpointDBByBlock = checkpointRocksDBStorage.open("blockHash123"sv);
+        RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver>
+            checkpointStorageByBlock(*checkpointDBByBlock, StateKeyResolver{}, StateValueResolver{});
+        auto checkpointValueByBlock = co_await storage2::readOne(
+            checkpointStorageByBlock, StateKey{"sys"sv, "key"sv});
+        BOOST_REQUIRE(checkpointValueByBlock);
+        BOOST_CHECK_EQUAL(checkpointValueByBlock->get(), "checkpoint-value");
+        BOOST_CHECK_EQUAL(checkpointRocksDBStorage.checkpointPath("blockHash123"sv), checkpointPath);
+
+        co_return;
+    }());
+
+    boost::filesystem::remove_all(root);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(engine ${SRC_LIST})
 target_include_directories(engine PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-engine>)
-target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities)
+target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger)
 set_target_properties(engine PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/engine/bcos-engine/EngineService.h
+++ b/engine/bcos-engine/EngineService.h
@@ -19,18 +19,19 @@
 
 #pragma once
 
+#include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "bcos-framework/protocol/Transaction.h"
+#include "bcos-ledger/LedgerMethods.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/Common.h"
+#include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
 #include <cstdint>
-#include <memory>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
-#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -39,6 +40,13 @@
 
 namespace bcos::engine
 {
+DERIVE_BCOS_EXCEPTION(UnsupportedEngineApiVersion);
+DERIVE_BCOS_EXCEPTION(GlobalStateStorageNotConfigured);
+DERIVE_BCOS_EXCEPTION(UnknownForkchoiceHeadBlock);
+DERIVE_BCOS_EXCEPTION(InvalidForkchoiceState);
+DERIVE_BCOS_EXCEPTION(UnknownPayload);
+DERIVE_BCOS_EXCEPTION(IncompatiblePayloadVersion);
+
 enum class EngineApiVersion : std::uint8_t
 {
     V1 = 1,
@@ -191,7 +199,113 @@ public:
         const ForkchoiceState& forkchoiceState,
         const std::optional<PayloadAttributes>& payloadAttributes, std::uint32_t version)
     {
-        co_return handleForkchoiceUpdate(forkchoiceState, payloadAttributes, version);
+        if (!isVersionSupported(version))
+        {
+            BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
+                                  << bcos::errinfo_comment{"Unsupported Engine API version"});
+        }
+        if (payloadAttributes)
+        {
+            if (auto validationError =
+                    detail::validatePayloadAttributes(*payloadAttributes, version);
+                validationError.has_value())
+            {
+                ForkchoiceUpdatedResult result;
+                result.payloadStatus =
+                    makeStatus(PayloadValidationStatus::Invalid, std::nullopt, validationError);
+                co_return result;
+            }
+        }
+
+        auto view = m_globalStateStorage->fork();
+        auto headBlockNumber = co_await bcos::ledger::getBlockNumber(
+            view, forkchoiceState.headBlockHash, bcos::ledger::fromStorage);
+        auto safeBlockNumber = co_await bcos::ledger::getBlockNumber(
+            view, forkchoiceState.safeBlockHash, bcos::ledger::fromStorage);
+        auto finalizedBlockNumber = co_await bcos::ledger::getBlockNumber(
+            view, forkchoiceState.finalizedBlockHash, bcos::ledger::fromStorage);
+
+        if (!headBlockNumber.has_value())
+        {
+            BOOST_THROW_EXCEPTION(UnknownForkchoiceHeadBlock{}
+                                  << bcos::errinfo_comment{"Unknown forkchoice head block hash"});
+        }
+        if (safeBlockNumber.has_value() && *safeBlockNumber > *headBlockNumber)
+        {
+            BOOST_THROW_EXCEPTION(
+                InvalidForkchoiceState{} << bcos::errinfo_comment{
+                    "Forkchoice safe block number must not exceed head block number"});
+        }
+        if (finalizedBlockNumber.has_value() && *finalizedBlockNumber > *headBlockNumber)
+        {
+            BOOST_THROW_EXCEPTION(
+                InvalidForkchoiceState{} << bcos::errinfo_comment{
+                    "Forkchoice finalized block number must not exceed head block number"});
+        }
+        if (safeBlockNumber.has_value() && finalizedBlockNumber.has_value() &&
+            *finalizedBlockNumber > *safeBlockNumber)
+        {
+            BOOST_THROW_EXCEPTION(
+                InvalidForkchoiceState{} << bcos::errinfo_comment{
+                    "Forkchoice finalized block number must not exceed safe block number"});
+        }
+
+        std::unique_lock lock(x_state);
+        if (m_trackedHeadBlock.has_value())
+        {
+            auto const& trackedHeadBlock = *m_trackedHeadBlock;
+            if (*headBlockNumber < trackedHeadBlock.blockNumber)
+            {
+                ForkchoiceUpdatedResult result;
+                result.payloadStatus = makeStatus(
+                    PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt);
+                co_return result;
+            }
+            if (*headBlockNumber == trackedHeadBlock.blockNumber)
+            {
+                if (forkchoiceState.headBlockHash != trackedHeadBlock.hash)
+                {
+                    BOOST_THROW_EXCEPTION(
+                        InvalidForkchoiceState{} << bcos::errinfo_comment{
+                            "Forkchoice head block hash conflicts with tracked block number"});
+                }
+            }
+            else if (*headBlockNumber != trackedHeadBlock.blockNumber + 1)
+            {
+                BOOST_THROW_EXCEPTION(
+                    InvalidForkchoiceState{} << bcos::errinfo_comment{
+                        "Forkchoice head block number must increase by exactly 1"});
+            }
+        }
+
+        m_forkchoiceState = forkchoiceState;
+        m_trackedHeadBlock = TrackedHeadBlock{forkchoiceState.headBlockHash, *headBlockNumber};
+        updateTrackedBlockNumbers(safeBlockNumber, finalizedBlockNumber);
+
+        ForkchoiceUpdatedResult result;
+        result.payloadStatus =
+            makeStatus(PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt);
+        if (!payloadAttributes)
+        {
+            co_return result;
+        }
+
+        auto payloadId = nextPayloadID();
+        auto payload =
+            buildPayloadSkeleton(forkchoiceState, *payloadAttributes, payloadId, version);
+        PayloadEntry entry;
+        entry.version = version;
+        entry.executionPayload = std::move(payload);
+        entry.blockValue = 0;
+        if (version == static_cast<std::uint32_t>(EngineApiVersion::V3))
+        {
+            entry.blobsBundle = BlobsBundleV1{};
+        }
+
+        m_blockHashToPayloadId[entry.executionPayload.blockHash] = payloadId;
+        m_payloadCache[payloadId] = entry;
+        result.payloadId = payloadId;
+        co_return result;
     }
 
     bcos::task::Task<GetPayloadResult> getPayload(const PayloadID& payloadId, std::uint32_t version)
@@ -218,6 +332,12 @@ public:
     }
 
 private:
+    struct TrackedHeadBlock
+    {
+        h256 hash;
+        bcos::protocol::BlockNumber blockNumber = 0;
+    };
+
     struct PayloadEntry
     {
         std::uint32_t version = 0;
@@ -244,74 +364,26 @@ private:
         return statusObject;
     }
 
-    ForkchoiceUpdatedResult handleForkchoiceUpdate(const ForkchoiceState& forkchoiceState,
-        const std::optional<PayloadAttributes>& payloadAttributes, std::uint32_t version)
-    {
-        if (!isVersionSupported(version))
-        {
-            throw std::invalid_argument("Unsupported Engine API version");
-        }
-        if (payloadAttributes)
-        {
-            if (auto validationError =
-                    detail::validatePayloadAttributes(*payloadAttributes, version);
-                validationError.has_value())
-            {
-                ForkchoiceUpdatedResult result;
-                result.payloadStatus =
-                    makeStatus(PayloadValidationStatus::Invalid, std::nullopt, validationError);
-                return result;
-            }
-        }
-
-        std::unique_lock lock(x_state);
-        m_forkchoiceState = forkchoiceState;
-        updateTrackedBlockNumbers(forkchoiceState);
-
-        ForkchoiceUpdatedResult result;
-        result.payloadStatus =
-            makeStatus(PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt);
-        if (!payloadAttributes)
-        {
-            return result;
-        }
-
-        auto payloadId = nextPayloadID();
-        auto payload =
-            buildPayloadSkeleton(forkchoiceState, *payloadAttributes, payloadId, version);
-        PayloadEntry entry;
-        entry.version = version;
-        entry.executionPayload = std::move(payload);
-        entry.blockValue = 0;
-        if (version == static_cast<std::uint32_t>(EngineApiVersion::V3))
-        {
-            entry.blobsBundle = BlobsBundleV1{};
-        }
-
-        m_blockHashToPayloadId[entry.executionPayload.blockHash] = payloadId;
-        m_payloadCache[payloadId] = entry;
-        result.payloadId = payloadId;
-        return result;
-    }
-
     GetPayloadResult handleGetPayload(const PayloadID& payloadId, std::uint32_t version) const
     {
         if (!isVersionSupported(version))
         {
-            throw std::invalid_argument("Unsupported Engine API version");
+            BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
+                                  << bcos::errinfo_comment{"Unsupported Engine API version"});
         }
 
         std::shared_lock lock(x_state);
         auto it = m_payloadCache.find(payloadId);
         if (it == m_payloadCache.end())
         {
-            throw std::out_of_range("Unknown payload");
+            BOOST_THROW_EXCEPTION(UnknownPayload{} << bcos::errinfo_comment{"Unknown payload"});
         }
         if (!detail::isGetPayloadVersionCompatible(
                 static_cast<EngineApiVersion>(version), it->second.version))
         {
-            throw std::invalid_argument(
-                "Payload version is incompatible with requested method version");
+            BOOST_THROW_EXCEPTION(
+                IncompatiblePayloadVersion{} << bcos::errinfo_comment{
+                    "Payload version is incompatible with requested method version"});
         }
 
         GetPayloadResult result;
@@ -326,7 +398,8 @@ private:
     {
         if (!isVersionSupported(version))
         {
-            throw std::invalid_argument("Unsupported Engine API version");
+            BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
+                                  << bcos::errinfo_comment{"Unsupported Engine API version"});
         }
 
         if (auto validationError =
@@ -448,16 +521,18 @@ private:
         return payloadIt->second.executionPayload.blockNumber;
     }
 
-    void updateTrackedBlockNumbers(const ForkchoiceState& forkchoiceState)
+    void updateTrackedBlockNumbers(std::optional<bcos::protocol::BlockNumber> safeBlockNumber,
+        std::optional<bcos::protocol::BlockNumber> finalizedBlockNumber)
     {
-        m_safeBlockNumber = lookupBlockNumberByHash(forkchoiceState.safeBlockHash);
-        m_finalizedBlockNumber = lookupBlockNumberByHash(forkchoiceState.finalizedBlockHash);
+        m_safeBlockNumber = safeBlockNumber;
+        m_finalizedBlockNumber = finalizedBlockNumber;
     }
 
     mutable std::shared_mutex x_state;
     MemPoolType* m_memPool = nullptr;
     GlobalStateStorageType* m_globalStateStorage = nullptr;
     ForkchoiceState m_forkchoiceState;
+    std::optional<TrackedHeadBlock> m_trackedHeadBlock;
     std::optional<bcos::protocol::BlockNumber> m_safeBlockNumber;
     std::optional<bcos::protocol::BlockNumber> m_finalizedBlockNumber;
     std::unordered_map<PayloadID, PayloadEntry> m_payloadCache;

--- a/engine/bcos-engine/EngineService.h
+++ b/engine/bcos-engine/EngineService.h
@@ -145,10 +145,6 @@ struct GetPayloadResult
     bool shouldOverrideBuilder = false;
 };
 
-struct NoGlobalStateStorage
-{
-};
-
 namespace detail
 {
 std::string encodePayloadSequence(std::uint64_t value);
@@ -196,15 +192,15 @@ public:
     }
 
     bcos::task::Task<ForkchoiceUpdatedResult> updateForkchoice(
-        const ForkchoiceState& forkchoiceState,
-        const std::optional<PayloadAttributes>& payloadAttributes, std::uint32_t version)
+        const ForkchoiceState& forkchoiceState, const PayloadAttributes* payloadAttributes,
+        std::uint32_t version)
     {
         if (!isVersionSupported(version))
         {
             BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
                                   << bcos::errinfo_comment{"Unsupported Engine API version"});
         }
-        if (payloadAttributes)
+        if (payloadAttributes != nullptr)
         {
             if (auto validationError =
                     detail::validatePayloadAttributes(*payloadAttributes, version);
@@ -225,25 +221,27 @@ public:
         auto finalizedBlockNumber = co_await bcos::ledger::getBlockNumber(
             view, forkchoiceState.finalizedBlockHash, bcos::ledger::fromStorage);
 
-        if (!headBlockNumber.has_value())
+        if (!headBlockNumber.has_value() || !safeBlockNumber.has_value() ||
+            !finalizedBlockNumber.has_value())
         {
-            BOOST_THROW_EXCEPTION(UnknownForkchoiceHeadBlock{}
-                                  << bcos::errinfo_comment{"Unknown forkchoice head block hash"});
+            ForkchoiceUpdatedResult result;
+            result.payloadStatus =
+                makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+            co_return result;
         }
-        if (safeBlockNumber.has_value() && *safeBlockNumber > *headBlockNumber)
+        if (*safeBlockNumber > *headBlockNumber)
         {
             BOOST_THROW_EXCEPTION(
                 InvalidForkchoiceState{} << bcos::errinfo_comment{
                     "Forkchoice safe block number must not exceed head block number"});
         }
-        if (finalizedBlockNumber.has_value() && *finalizedBlockNumber > *headBlockNumber)
+        if (*finalizedBlockNumber > *headBlockNumber)
         {
             BOOST_THROW_EXCEPTION(
                 InvalidForkchoiceState{} << bcos::errinfo_comment{
                     "Forkchoice finalized block number must not exceed head block number"});
         }
-        if (safeBlockNumber.has_value() && finalizedBlockNumber.has_value() &&
-            *finalizedBlockNumber > *safeBlockNumber)
+        if (*finalizedBlockNumber > *safeBlockNumber)
         {
             BOOST_THROW_EXCEPTION(
                 InvalidForkchoiceState{} << bcos::errinfo_comment{
@@ -285,7 +283,7 @@ public:
         ForkchoiceUpdatedResult result;
         result.payloadStatus =
             makeStatus(PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt);
-        if (!payloadAttributes)
+        if (payloadAttributes == nullptr)
         {
             co_return result;
         }

--- a/engine/bcos-engine/EngineService.h
+++ b/engine/bcos-engine/EngineService.h
@@ -29,6 +29,7 @@
 #include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
 #include <cstdint>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -166,23 +167,14 @@ template <class MemPoolType, class GlobalStateStorageType>
 class EngineService
 {
 public:
-    EngineService() = default;
     EngineService(MemPoolType& memPool, GlobalStateStorageType& globalStateStorage)
-      : m_memPool(&memPool), m_globalStateStorage(&globalStateStorage)
+      : m_memPool(std::ref(memPool)), m_globalStateStorage(std::ref(globalStateStorage))
     {}
     ~EngineService() = default;
     EngineService(const EngineService&) = delete;
     EngineService(EngineService&&) = delete;
     EngineService& operator=(const EngineService&) = delete;
     EngineService& operator=(EngineService&&) = delete;
-
-    MemPoolType* memPool() noexcept { return m_memPool; }
-    MemPoolType const* memPool() const noexcept { return m_memPool; }
-    GlobalStateStorageType* globalStateStorage() noexcept { return m_globalStateStorage; }
-    GlobalStateStorageType const* globalStateStorage() const noexcept
-    {
-        return m_globalStateStorage;
-    }
 
     bcos::task::Task<std::vector<std::string>> exchangeCapabilities(
         std::vector<std::string> remoteCapabilities)
@@ -206,14 +198,16 @@ public:
                     detail::validatePayloadAttributes(*payloadAttributes, version);
                 validationError.has_value())
             {
-                ForkchoiceUpdatedResult result;
-                result.payloadStatus =
-                    makeStatus(PayloadValidationStatus::Invalid, std::nullopt, validationError);
+                ForkchoiceUpdatedResult result{
+                    .payloadStatus =
+                        makeStatus(PayloadValidationStatus::Invalid, std::nullopt, validationError),
+                    .payloadId = std::nullopt,
+                };
                 co_return result;
             }
         }
 
-        auto view = m_globalStateStorage->fork();
+        auto view = m_globalStateStorage.get().fork();
         auto headBlockNumber = co_await bcos::ledger::getBlockNumber(
             view, forkchoiceState.headBlockHash, bcos::ledger::fromStorage);
         auto safeBlockNumber = co_await bcos::ledger::getBlockNumber(
@@ -224,9 +218,11 @@ public:
         if (!headBlockNumber.has_value() || !safeBlockNumber.has_value() ||
             !finalizedBlockNumber.has_value())
         {
-            ForkchoiceUpdatedResult result;
-            result.payloadStatus =
-                makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+            ForkchoiceUpdatedResult result{
+                .payloadStatus =
+                    makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt),
+                .payloadId = std::nullopt,
+            };
             co_return result;
         }
         if (*safeBlockNumber > *headBlockNumber)
@@ -254,9 +250,11 @@ public:
             auto const& trackedHeadBlock = *m_trackedHeadBlock;
             if (*headBlockNumber < trackedHeadBlock.blockNumber)
             {
-                ForkchoiceUpdatedResult result;
-                result.payloadStatus = makeStatus(
-                    PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt);
+                ForkchoiceUpdatedResult result{
+                    .payloadStatus = makeStatus(PayloadValidationStatus::Valid,
+                        forkchoiceState.headBlockHash, std::nullopt),
+                    .payloadId = std::nullopt,
+                };
                 co_return result;
             }
             if (*headBlockNumber == trackedHeadBlock.blockNumber)
@@ -277,12 +275,18 @@ public:
         }
 
         m_forkchoiceState = forkchoiceState;
-        m_trackedHeadBlock = TrackedHeadBlock{forkchoiceState.headBlockHash, *headBlockNumber};
+        m_trackedHeadBlock = TrackedHeadBlock{
+            .hash = forkchoiceState.headBlockHash,
+            .blockNumber = *headBlockNumber,
+        };
         updateTrackedBlockNumbers(safeBlockNumber, finalizedBlockNumber);
+        m_memPool.get().remove(view);
 
-        ForkchoiceUpdatedResult result;
-        result.payloadStatus =
-            makeStatus(PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt);
+        ForkchoiceUpdatedResult result{
+            .payloadStatus = makeStatus(
+                PayloadValidationStatus::Valid, forkchoiceState.headBlockHash, std::nullopt),
+            .payloadId = std::nullopt,
+        };
         if (payloadAttributes == nullptr)
         {
             co_return result;
@@ -291,10 +295,13 @@ public:
         auto payloadId = nextPayloadID();
         auto payload =
             buildPayloadSkeleton(forkchoiceState, *payloadAttributes, payloadId, version);
-        PayloadEntry entry;
-        entry.version = version;
-        entry.executionPayload = std::move(payload);
-        entry.blockValue = 0;
+        PayloadEntry entry{
+            .version = version,
+            .executionPayload = std::move(payload),
+            .blockValue = 0,
+            .blobsBundle = std::nullopt,
+            .shouldOverrideBuilder = false,
+        };
         if (version == static_cast<std::uint32_t>(EngineApiVersion::V3))
         {
             entry.blobsBundle = BlobsBundleV1{};
@@ -355,11 +362,11 @@ private:
         std::optional<h256> latestValidHash = std::nullopt,
         std::optional<std::string> validationError = std::nullopt)
     {
-        PayloadStatus statusObject;
-        statusObject.status = status;
-        statusObject.latestValidHash = latestValidHash;
-        statusObject.validationError = std::move(validationError);
-        return statusObject;
+        return PayloadStatus{
+            .status = status,
+            .latestValidHash = latestValidHash,
+            .validationError = std::move(validationError),
+        };
     }
 
     GetPayloadResult handleGetPayload(const PayloadID& payloadId, std::uint32_t version) const
@@ -384,12 +391,12 @@ private:
                     "Payload version is incompatible with requested method version"});
         }
 
-        GetPayloadResult result;
-        result.executionPayload = it->second.executionPayload;
-        result.blockValue = it->second.blockValue;
-        result.blobsBundle = it->second.blobsBundle;
-        result.shouldOverrideBuilder = it->second.shouldOverrideBuilder;
-        return result;
+        return GetPayloadResult{
+            .executionPayload = it->second.executionPayload,
+            .blockValue = it->second.blockValue,
+            .blobsBundle = it->second.blobsBundle,
+            .shouldOverrideBuilder = it->second.shouldOverrideBuilder,
+        };
     }
 
     PayloadStatus handleNewPayload(const NewPayloadRequest& request, std::uint32_t version)
@@ -448,10 +455,13 @@ private:
             payloadId = payloadIdIt->second;
         }
 
-        PayloadEntry entry;
-        entry.version = version;
-        entry.executionPayload = request.executionPayload;
-        entry.blockValue = 0;
+        PayloadEntry entry{
+            .version = version,
+            .executionPayload = request.executionPayload,
+            .blockValue = 0,
+            .blobsBundle = std::nullopt,
+            .shouldOverrideBuilder = false,
+        };
         if (version == static_cast<std::uint32_t>(EngineApiVersion::V3))
         {
             entry.blobsBundle = BlobsBundleV1{};
@@ -475,20 +485,25 @@ private:
             nextBlockNumber = *currentBlockNumber + 1;
         }
 
-        ExecutionPayload executionPayload;
-        executionPayload.parentHash = forkchoiceState.headBlockHash;
-        executionPayload.feeRecipient = payloadAttributes.suggestedFeeRecipient;
-        executionPayload.stateRoot = detail::syntheticHash(std::string("state") + payloadId);
-        executionPayload.receiptsRoot = detail::syntheticHash(std::string("receipts") + payloadId);
-        executionPayload.logsBloom = Bloom{};
-        executionPayload.prevRandao = payloadAttributes.prevRandao;
-        executionPayload.blockNumber = nextBlockNumber;
-        executionPayload.gasLimit = 0;
-        executionPayload.gasUsed = 0;
-        executionPayload.timestamp = payloadAttributes.timestamp;
-        executionPayload.extraData = {};
-        executionPayload.baseFeePerGas = 0;
-        executionPayload.blockHash = detail::syntheticHash(payloadId);
+        ExecutionPayload executionPayload{
+            .parentHash = forkchoiceState.headBlockHash,
+            .feeRecipient = payloadAttributes.suggestedFeeRecipient,
+            .stateRoot = detail::syntheticHash(std::string("state") + payloadId),
+            .receiptsRoot = detail::syntheticHash(std::string("receipts") + payloadId),
+            .logsBloom = Bloom{},
+            .prevRandao = payloadAttributes.prevRandao,
+            .blockNumber = nextBlockNumber,
+            .gasLimit = 0,
+            .gasUsed = 0,
+            .timestamp = payloadAttributes.timestamp,
+            .extraData = {},
+            .baseFeePerGas = 0,
+            .blockHash = detail::syntheticHash(payloadId),
+            .transactions = {},
+            .withdrawals = std::nullopt,
+            .blobGasUsed = std::nullopt,
+            .excessBlobGas = std::nullopt,
+        };
 
         if (version >= static_cast<std::uint32_t>(EngineApiVersion::V2))
         {
@@ -527,8 +542,8 @@ private:
     }
 
     mutable std::shared_mutex x_state;
-    MemPoolType* m_memPool = nullptr;
-    GlobalStateStorageType* m_globalStateStorage = nullptr;
+    std::reference_wrapper<MemPoolType> m_memPool;
+    std::reference_wrapper<GlobalStateStorageType> m_globalStateStorage;
     ForkchoiceState m_forkchoiceState;
     std::optional<TrackedHeadBlock> m_trackedHeadBlock;
     std::optional<bcos::protocol::BlockNumber> m_safeBlockNumber;

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${TEST_BINARY_NAME} PRIVATE . ${CMAKE_SOURCE_DIR})
 
 find_package(Boost REQUIRED unit_test_framework)
 
-target_link_libraries(${TEST_BINARY_NAME} PUBLIC engine Boost::unit_test_framework)
+target_link_libraries(${TEST_BINARY_NAME} PUBLIC engine mempool protocol-tars Boost::unit_test_framework)
 set_source_files_properties("unittests/main/main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" ${TEST_BINARY_NAME} "" "")

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -6,8 +6,14 @@
 #include "engine/bcos-engine/EngineService.h"
 
 #include <algorithm>
+#include <bcos-concepts/ByteBuffer.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
 #include <bcos-task/Wait.h>
+#include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
+#include <unordered_map>
 
 using namespace bcos;
 using namespace bcos::engine;
@@ -15,15 +21,78 @@ using namespace bcos::engine;
 namespace
 {
 constexpr std::uint64_t c_timestamp = 123456;
+constexpr bcos::protocol::BlockNumber c_initialBlockNumber = 5;
+constexpr bcos::protocol::BlockNumber c_trackedInitialBlockNumber = 10;
+constexpr bcos::protocol::BlockNumber c_trackedNextBlockNumber = 11;
+constexpr bcos::protocol::BlockNumber c_validationBlockNumber = 20;
+constexpr bcos::protocol::BlockNumber c_reorgStartBlockNumber = 30;
+constexpr bcos::protocol::BlockNumber c_reorgTargetBlockNumber = 32;
+constexpr bcos::protocol::BlockNumber c_headOrderingBlockNumber = 40;
+constexpr bcos::protocol::BlockNumber c_safeOrderingBlockNumber = 41;
+constexpr bcos::protocol::BlockNumber c_finalizedOrderingBlockNumber = 42;
+constexpr bcos::protocol::BlockNumber c_staleInitialBlockNumber = 50;
+constexpr bcos::protocol::BlockNumber c_staleNextBlockNumber = 51;
+constexpr bcos::protocol::BlockNumber c_staleThirdBlockNumber = 52;
 
 struct FakeMemPool
 {};
 
 struct FakeGlobalStateStorage
-{};
+{
+    using Value = storage::Entry;
 
-using TestEngineService = EngineService<FakeMemPool, NoGlobalStateStorage>;
+    std::unordered_map<std::string, std::unordered_map<std::string, Value>> data;
 
+    void setBlockNumber(const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
+    {
+        storage::Entry entry;
+        entry.setField(0, boost::lexical_cast<std::string>(blockNumber));
+        data[std::string(ledger::SYS_HASH_2_NUMBER)]
+            [std::string(bcos::concepts::bytebuffer::toView(blockHash))] = std::move(entry);
+    }
+
+    task::Task<std::optional<Value>> readOne(executor_v1::StateKeyView key)
+    {
+        auto [table, field] = key.get();
+        if (auto tableIt = data.find(std::string(table)); tableIt != data.end())
+        {
+            if (auto fieldIt = tableIt->second.find(std::string(field)); fieldIt != tableIt->second.end())
+            {
+                co_return std::make_optional(fieldIt->second);
+            }
+        }
+        co_return std::nullopt;
+    }
+
+    task::Task<std::optional<Value>> readOne(executor_v1::StateKey key)
+    {
+        co_return co_await readOne(executor_v1::StateKeyView{key});
+    }
+
+    template <class Keys>
+    task::Task<std::vector<std::optional<Value>>> readSome(Keys keys)
+    {
+        std::vector<std::optional<Value>> results;
+        if constexpr (::ranges::sized_range<Keys>)
+        {
+            results.reserve(::ranges::size(keys));
+        }
+        else
+        {
+            results.reserve(::ranges::distance(keys));
+        }
+
+        for (auto&& key : keys)
+        {
+            results.emplace_back(co_await readOne(executor_v1::StateKeyView{key}));
+        }
+        co_return results;
+    }
+
+    FakeGlobalStateStorage fork() { return *this; }
+};
+
+using TestEngineService = EngineService<FakeMemPool, FakeGlobalStateStorage>;
 ForkchoiceState makeForkchoiceState()
 {
     return {h256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
@@ -96,9 +165,13 @@ BOOST_AUTO_TEST_CASE(custom_dependency_types_can_be_injected)
 
 BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_payload)
 {
-    TestEngineService engineService;
-
+    FakeMemPool memPool;
+    FakeGlobalStateStorage globalStateStorage;
     auto forkchoiceState = makeForkchoiceState();
+    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_initialBlockNumber);
+
+    TestEngineService engineService(memPool, globalStateStorage);
+
     auto result = task::syncWait(
         engineService.updateForkchoice(forkchoiceState, makePayloadAttributesV2(), 2));
 
@@ -116,13 +189,19 @@ BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_paylo
 
 BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 {
-    TestEngineService engineService;
+    FakeMemPool memPool;
+    FakeGlobalStateStorage globalStateStorage;
+    TestEngineService engineService(memPool, globalStateStorage);
 
     auto initialForkchoice = makeForkchoiceState();
+    globalStateStorage.setBlockNumber(
+        initialForkchoice.headBlockHash, c_trackedInitialBlockNumber);
     auto initialResult =
         task::syncWait(engineService.updateForkchoice(initialForkchoice, makePayloadAttributesV3(), 3));
     BOOST_REQUIRE(initialResult.payloadId.has_value());
     auto builtPayload = task::syncWait(engineService.getPayload(*initialResult.payloadId, 3));
+    globalStateStorage.setBlockNumber(
+        builtPayload.executionPayload.blockHash, c_trackedNextBlockNumber);
 
     auto request = makeNewPayloadRequestV3(builtPayload.executionPayload);
     auto newPayloadStatus = task::syncWait(engineService.newPayload(request, 3));
@@ -139,16 +218,20 @@ BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
     auto finalizedBlockNumber = engineService.getFinalizedBlockNumber();
     BOOST_REQUIRE(safeBlockNumber.has_value());
     BOOST_REQUIRE(finalizedBlockNumber.has_value());
-    BOOST_CHECK_EQUAL(*safeBlockNumber, builtPayload.executionPayload.blockNumber);
-    BOOST_CHECK_EQUAL(*finalizedBlockNumber, builtPayload.executionPayload.blockNumber);
+    BOOST_CHECK_EQUAL(*safeBlockNumber, c_trackedNextBlockNumber);
+    BOOST_CHECK_EQUAL(*finalizedBlockNumber, c_trackedNextBlockNumber);
 }
 
 BOOST_AUTO_TEST_CASE(new_payload_rejects_missing_required_v3_fields)
 {
-    TestEngineService engineService;
+    FakeMemPool memPool;
+    FakeGlobalStateStorage globalStateStorage;
+    auto forkchoiceState = makeForkchoiceState();
+    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_validationBlockNumber);
+    TestEngineService engineService(memPool, globalStateStorage);
 
     auto result = task::syncWait(
-        engineService.updateForkchoice(makeForkchoiceState(), makePayloadAttributesV3(), 3));
+        engineService.updateForkchoice(forkchoiceState, makePayloadAttributesV3(), 3));
     BOOST_REQUIRE(result.payloadId.has_value());
 
     auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
@@ -161,6 +244,118 @@ BOOST_AUTO_TEST_CASE(new_payload_rejects_missing_required_v3_fields)
         static_cast<int>(PayloadValidationStatus::Invalid));
     BOOST_REQUIRE(status.validationError.has_value());
     BOOST_CHECK_NE(status.validationError->find("parentBeaconBlockRoot"), std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(forkchoice_rejects_non_sequential_head_block_number)
+{
+    FakeMemPool memPool;
+    FakeGlobalStateStorage globalStateStorage;
+    TestEngineService engineService(memPool, globalStateStorage);
+
+    auto initialForkchoice = makeForkchoiceState();
+    globalStateStorage.setBlockNumber(
+        initialForkchoice.headBlockHash, c_reorgStartBlockNumber);
+    auto initialResult =
+        task::syncWait(engineService.updateForkchoice(initialForkchoice, std::nullopt, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(initialResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Valid));
+
+    ForkchoiceState reorgForkchoice{
+        h256("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+        h256("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+        h256("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")};
+    globalStateStorage.setBlockNumber(
+        reorgForkchoice.headBlockHash, c_reorgTargetBlockNumber);
+
+    BOOST_CHECK_THROW(
+        task::syncWait(engineService.updateForkchoice(reorgForkchoice, std::nullopt, 3)),
+        bcos::engine::InvalidForkchoiceState);
+}
+
+BOOST_AUTO_TEST_CASE(forkchoice_rejects_safe_block_number_above_head)
+{
+    FakeMemPool memPool;
+    FakeGlobalStateStorage globalStateStorage;
+    TestEngineService engineService(memPool, globalStateStorage);
+
+    ForkchoiceState forkchoiceState{
+        h256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
+        h256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+        h256("0000000000000000000000000000000000000000000000000000000000000011")};
+    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_headOrderingBlockNumber);
+    globalStateStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_safeOrderingBlockNumber);
+    globalStateStorage.setBlockNumber(forkchoiceState.finalizedBlockHash, c_headOrderingBlockNumber);
+
+    BOOST_CHECK_THROW(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, std::nullopt, 3)),
+        bcos::engine::InvalidForkchoiceState);
+}
+
+BOOST_AUTO_TEST_CASE(forkchoice_rejects_finalized_block_number_above_safe)
+{
+    FakeMemPool memPool;
+    FakeGlobalStateStorage globalStateStorage;
+    TestEngineService engineService(memPool, globalStateStorage);
+
+    ForkchoiceState forkchoiceState{
+        h256("1212121212121212121212121212121212121212121212121212121212121212"),
+        h256("1313131313131313131313131313131313131313131313131313131313131313"),
+        h256("1414141414141414141414141414141414141414141414141414141414141414")};
+    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_finalizedOrderingBlockNumber);
+    globalStateStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_headOrderingBlockNumber);
+    globalStateStorage.setBlockNumber(
+        forkchoiceState.finalizedBlockHash, c_safeOrderingBlockNumber);
+
+    BOOST_CHECK_THROW(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, std::nullopt, 3)),
+        bcos::engine::InvalidForkchoiceState);
+}
+
+BOOST_AUTO_TEST_CASE(forkchoice_ignores_stale_update_after_newer_head_wins)
+{
+    FakeMemPool memPool;
+    FakeGlobalStateStorage globalStateStorage;
+    TestEngineService engineService(memPool, globalStateStorage);
+
+    ForkchoiceState firstForkchoice{
+        h256("1515151515151515151515151515151515151515151515151515151515151515"),
+        h256("1515151515151515151515151515151515151515151515151515151515151515"),
+        h256("1515151515151515151515151515151515151515151515151515151515151515")};
+    ForkchoiceState secondForkchoice{
+        h256("1616161616161616161616161616161616161616161616161616161616161616"),
+        h256("1616161616161616161616161616161616161616161616161616161616161616"),
+        h256("1616161616161616161616161616161616161616161616161616161616161616")};
+    ForkchoiceState thirdForkchoice{
+        h256("1717171717171717171717171717171717171717171717171717171717171717"),
+        h256("1717171717171717171717171717171717171717171717171717171717171717"),
+        h256("1717171717171717171717171717171717171717171717171717171717171717")};
+
+    globalStateStorage.setBlockNumber(
+        firstForkchoice.headBlockHash, c_staleInitialBlockNumber);
+    globalStateStorage.setBlockNumber(
+        secondForkchoice.headBlockHash, c_staleNextBlockNumber);
+    globalStateStorage.setBlockNumber(
+        thirdForkchoice.headBlockHash, c_staleThirdBlockNumber);
+
+    auto firstResult =
+        task::syncWait(engineService.updateForkchoice(firstForkchoice, std::nullopt, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(firstResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Valid));
+
+    auto secondResult =
+        task::syncWait(engineService.updateForkchoice(secondForkchoice, std::nullopt, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(secondResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Valid));
+
+    auto staleResult =
+        task::syncWait(engineService.updateForkchoice(firstForkchoice, std::nullopt, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(staleResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Valid));
+
+    auto thirdResult =
+        task::syncWait(engineService.updateForkchoice(thirdForkchoice, std::nullopt, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(thirdResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Valid));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -5,15 +5,16 @@
 
 #include "engine/bcos-engine/EngineService.h"
 
-#include <algorithm>
 #include <bcos-concepts/ByteBuffer.h>
 #include <bcos-framework/ledger/LedgerTypeDef.h>
 #include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <bcos-task/Wait.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
-#include <unordered_map>
+#include <algorithm>
 
 using namespace bcos;
 using namespace bcos::engine;
@@ -35,64 +36,55 @@ constexpr bcos::protocol::BlockNumber c_staleNextBlockNumber = 51;
 constexpr bcos::protocol::BlockNumber c_staleThirdBlockNumber = 52;
 
 struct FakeMemPool
-{};
-
-struct FakeGlobalStateStorage
 {
-    using Value = storage::Entry;
+};
 
-    std::unordered_map<std::string, std::unordered_map<std::string, Value>> data;
+using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStorage<
+    bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
+    bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
+                                              bcos::storage2::memory_storage::LOGICAL_DELETION)>;
+using RealGlobalStateBackendStorage =
+    bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+        bcos::executor_v1::StateValue,
+        bcos::storage2::memory_storage::Attribute(
+            bcos::storage2::memory_storage::ORDERED | bcos::storage2::memory_storage::CONCURRENT),
+        std::hash<bcos::executor_v1::StateKey>>;
+using RealGlobalStateStorage = bcos::storage2::MultiLayerStorage<RealGlobalStateMutableStorage,
+    void, RealGlobalStateBackendStorage>;
+
+task::Task<void> writeBlockNumberToStorage(RealGlobalStateBackendStorage& backendStorage,
+    const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
+{
+    storage::Entry entry;
+    entry.importFields({boost::lexical_cast<std::string>(blockNumber)});
+    co_await bcos::storage2::writeOne(backendStorage,
+        bcos::executor_v1::StateKey{
+            ledger::SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(blockHash)},
+        std::move(entry));
+}
+
+struct RealGlobalStateStorageFixture
+{
+    RealGlobalStateBackendStorage backendStorage;
+    RealGlobalStateStorage storage{backendStorage};
 
     void setBlockNumber(const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
     {
-        storage::Entry entry;
-        entry.setField(0, boost::lexical_cast<std::string>(blockNumber));
-        data[std::string(ledger::SYS_HASH_2_NUMBER)]
-            [std::string(bcos::concepts::bytebuffer::toView(blockHash))] = std::move(entry);
+        task::syncWait(writeBlockNumberToStorage(backendStorage, blockHash, blockNumber));
     }
-
-    task::Task<std::optional<Value>> readOne(executor_v1::StateKeyView key)
-    {
-        auto [table, field] = key.get();
-        if (auto tableIt = data.find(std::string(table)); tableIt != data.end())
-        {
-            if (auto fieldIt = tableIt->second.find(std::string(field)); fieldIt != tableIt->second.end())
-            {
-                co_return std::make_optional(fieldIt->second);
-            }
-        }
-        co_return std::nullopt;
-    }
-
-    task::Task<std::optional<Value>> readOne(executor_v1::StateKey key)
-    {
-        co_return co_await readOne(executor_v1::StateKeyView{key});
-    }
-
-    template <class Keys>
-    task::Task<std::vector<std::optional<Value>>> readSome(Keys keys)
-    {
-        std::vector<std::optional<Value>> results;
-        if constexpr (::ranges::sized_range<Keys>)
-        {
-            results.reserve(::ranges::size(keys));
-        }
-        else
-        {
-            results.reserve(::ranges::distance(keys));
-        }
-
-        for (auto&& key : keys)
-        {
-            results.emplace_back(co_await readOne(executor_v1::StateKeyView{key}));
-        }
-        co_return results;
-    }
-
-    FakeGlobalStateStorage fork() { return *this; }
 };
 
-using TestEngineService = EngineService<FakeMemPool, FakeGlobalStateStorage>;
+void setForkchoiceBlockNumbers(RealGlobalStateStorageFixture& storageFixture,
+    const ForkchoiceState& forkchoiceState, bcos::protocol::BlockNumber headBlockNumber,
+    bcos::protocol::BlockNumber safeBlockNumber,
+    bcos::protocol::BlockNumber finalizedBlockNumber)
+{
+    storageFixture.setBlockNumber(forkchoiceState.headBlockHash, headBlockNumber);
+    storageFixture.setBlockNumber(forkchoiceState.safeBlockHash, safeBlockNumber);
+    storageFixture.setBlockNumber(forkchoiceState.finalizedBlockHash, finalizedBlockNumber);
+}
+
+using TestEngineService = EngineService<FakeMemPool, RealGlobalStateStorage>;
 ForkchoiceState makeForkchoiceState()
 {
     return {h256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
@@ -106,8 +98,7 @@ PayloadAttributes makePayloadAttributesV2()
     payloadAttributes.timestamp = c_timestamp;
     payloadAttributes.prevRandao =
         h256("1111111111111111111111111111111111111111111111111111111111111111");
-    payloadAttributes.suggestedFeeRecipient =
-        Address("1234567890abcdef1234567890abcdef12345678");
+    payloadAttributes.suggestedFeeRecipient = Address("1234567890abcdef1234567890abcdef12345678");
     WithdrawalV1 withdrawal;
     withdrawal.index = 1;
     withdrawal.validatorIndex = 2;
@@ -147,33 +138,33 @@ BOOST_AUTO_TEST_CASE(exchange_capabilities_returns_supported_methods)
         engineService.exchangeCapabilities({"engine_forkchoiceUpdatedV1", "unknown_method"}));
 
     BOOST_CHECK_EQUAL(capabilities.size(), 10);
-    BOOST_CHECK(
-        std::find(capabilities.begin(), capabilities.end(), "engine_getPayloadV3") !=
-        capabilities.end());
+    BOOST_CHECK(std::find(capabilities.begin(), capabilities.end(), "engine_getPayloadV3") !=
+                capabilities.end());
 }
 
 BOOST_AUTO_TEST_CASE(custom_dependency_types_can_be_injected)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
-    EngineService<FakeMemPool, FakeGlobalStateStorage> engineService(
-        memPool, globalStateStorage);
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     BOOST_CHECK(engineService.memPool() == &memPool);
-    BOOST_CHECK(engineService.globalStateStorage() == &globalStateStorage);
+    BOOST_CHECK(engineService.globalStateStorage() == &globalStateStorageFixture.storage);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_payload)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
     auto forkchoiceState = makeForkchoiceState();
-    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_initialBlockNumber);
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV2();
 
-    TestEngineService engineService(memPool, globalStateStorage);
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     auto result = task::syncWait(
-        engineService.updateForkchoice(forkchoiceState, makePayloadAttributesV2(), 2));
+        engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));
 
     BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
@@ -190,17 +181,18 @@ BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_paylo
 BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
-    TestEngineService engineService(memPool, globalStateStorage);
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     auto initialForkchoice = makeForkchoiceState();
-    globalStateStorage.setBlockNumber(
-        initialForkchoice.headBlockHash, c_trackedInitialBlockNumber);
-    auto initialResult =
-        task::syncWait(engineService.updateForkchoice(initialForkchoice, makePayloadAttributesV3(), 3));
+    setForkchoiceBlockNumbers(globalStateStorageFixture, initialForkchoice,
+        c_trackedInitialBlockNumber, c_trackedInitialBlockNumber, c_trackedInitialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto initialResult = task::syncWait(
+        engineService.updateForkchoice(initialForkchoice, &payloadAttributes, 3));
     BOOST_REQUIRE(initialResult.payloadId.has_value());
     auto builtPayload = task::syncWait(engineService.getPayload(*initialResult.payloadId, 3));
-    globalStateStorage.setBlockNumber(
+    globalStateStorageFixture.setBlockNumber(
         builtPayload.executionPayload.blockHash, c_trackedNextBlockNumber);
 
     auto request = makeNewPayloadRequestV3(builtPayload.executionPayload);
@@ -210,7 +202,8 @@ BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 
     ForkchoiceState trackedForkchoice{builtPayload.executionPayload.blockHash,
         builtPayload.executionPayload.blockHash, builtPayload.executionPayload.blockHash};
-    auto trackedResult = task::syncWait(engineService.updateForkchoice(trackedForkchoice, std::nullopt, 3));
+    auto trackedResult =
+        task::syncWait(engineService.updateForkchoice(trackedForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(trackedResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
@@ -225,13 +218,15 @@ BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 BOOST_AUTO_TEST_CASE(new_payload_rejects_missing_required_v3_fields)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
     auto forkchoiceState = makeForkchoiceState();
-    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_validationBlockNumber);
-    TestEngineService engineService(memPool, globalStateStorage);
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_validationBlockNumber,
+        c_validationBlockNumber, c_validationBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV3();
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     auto result = task::syncWait(
-        engineService.updateForkchoice(forkchoiceState, makePayloadAttributesV3(), 3));
+        engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
     BOOST_REQUIRE(result.payloadId.has_value());
 
     auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
@@ -240,23 +235,59 @@ BOOST_AUTO_TEST_CASE(new_payload_rejects_missing_required_v3_fields)
 
     auto status = task::syncWait(engineService.newPayload(request, 3));
 
-    BOOST_CHECK_EQUAL(static_cast<int>(status.status),
-        static_cast<int>(PayloadValidationStatus::Invalid));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Invalid));
     BOOST_REQUIRE(status.validationError.has_value());
     BOOST_CHECK_NE(status.validationError->find("parentBeaconBlockRoot"), std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(forkchoice_returns_syncing_when_head_block_number_missing)
+{
+    FakeMemPool memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    globalStateStorageFixture.setBlockNumber(forkchoiceState.safeBlockHash, c_validationBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.finalizedBlockHash, c_validationBlockNumber);
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3));
+
+    BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Syncing));
+    BOOST_CHECK(!result.payloadId.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(forkchoice_returns_syncing_when_safe_block_number_missing)
+{
+    FakeMemPool memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    globalStateStorageFixture.setBlockNumber(forkchoiceState.headBlockHash, c_validationBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.finalizedBlockHash, c_validationBlockNumber);
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3));
+
+    BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Syncing));
+    BOOST_CHECK(!result.payloadId.has_value());
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_rejects_non_sequential_head_block_number)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
-    TestEngineService engineService(memPool, globalStateStorage);
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     auto initialForkchoice = makeForkchoiceState();
-    globalStateStorage.setBlockNumber(
-        initialForkchoice.headBlockHash, c_reorgStartBlockNumber);
+    setForkchoiceBlockNumbers(globalStateStorageFixture, initialForkchoice, c_reorgStartBlockNumber,
+        c_reorgStartBlockNumber, c_reorgStartBlockNumber);
     auto initialResult =
-        task::syncWait(engineService.updateForkchoice(initialForkchoice, std::nullopt, 3));
+        task::syncWait(engineService.updateForkchoice(initialForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(initialResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
@@ -264,58 +295,63 @@ BOOST_AUTO_TEST_CASE(forkchoice_rejects_non_sequential_head_block_number)
         h256("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
         h256("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
         h256("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")};
-    globalStateStorage.setBlockNumber(
-        reorgForkchoice.headBlockHash, c_reorgTargetBlockNumber);
+    setForkchoiceBlockNumbers(globalStateStorageFixture, reorgForkchoice, c_reorgTargetBlockNumber,
+        c_reorgTargetBlockNumber, c_reorgTargetBlockNumber);
 
     BOOST_CHECK_THROW(
-        task::syncWait(engineService.updateForkchoice(reorgForkchoice, std::nullopt, 3)),
+        task::syncWait(engineService.updateForkchoice(reorgForkchoice, nullptr, 3)),
         bcos::engine::InvalidForkchoiceState);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_rejects_safe_block_number_above_head)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
-    TestEngineService engineService(memPool, globalStateStorage);
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     ForkchoiceState forkchoiceState{
         h256("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
         h256("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
         h256("0000000000000000000000000000000000000000000000000000000000000011")};
-    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_headOrderingBlockNumber);
-    globalStateStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_safeOrderingBlockNumber);
-    globalStateStorage.setBlockNumber(forkchoiceState.finalizedBlockHash, c_headOrderingBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.headBlockHash, c_headOrderingBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.safeBlockHash, c_safeOrderingBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.finalizedBlockHash, c_headOrderingBlockNumber);
 
     BOOST_CHECK_THROW(
-        task::syncWait(engineService.updateForkchoice(forkchoiceState, std::nullopt, 3)),
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3)),
         bcos::engine::InvalidForkchoiceState);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_rejects_finalized_block_number_above_safe)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
-    TestEngineService engineService(memPool, globalStateStorage);
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     ForkchoiceState forkchoiceState{
         h256("1212121212121212121212121212121212121212121212121212121212121212"),
         h256("1313131313131313131313131313131313131313131313131313131313131313"),
         h256("1414141414141414141414141414141414141414141414141414141414141414")};
-    globalStateStorage.setBlockNumber(forkchoiceState.headBlockHash, c_finalizedOrderingBlockNumber);
-    globalStateStorage.setBlockNumber(forkchoiceState.safeBlockHash, c_headOrderingBlockNumber);
-    globalStateStorage.setBlockNumber(
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.headBlockHash, c_finalizedOrderingBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.safeBlockHash, c_headOrderingBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
         forkchoiceState.finalizedBlockHash, c_safeOrderingBlockNumber);
 
     BOOST_CHECK_THROW(
-        task::syncWait(engineService.updateForkchoice(forkchoiceState, std::nullopt, 3)),
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3)),
         bcos::engine::InvalidForkchoiceState);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_ignores_stale_update_after_newer_head_wins)
 {
     FakeMemPool memPool;
-    FakeGlobalStateStorage globalStateStorage;
-    TestEngineService engineService(memPool, globalStateStorage);
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     ForkchoiceState firstForkchoice{
         h256("1515151515151515151515151515151515151515151515151515151515151515"),
@@ -330,30 +366,30 @@ BOOST_AUTO_TEST_CASE(forkchoice_ignores_stale_update_after_newer_head_wins)
         h256("1717171717171717171717171717171717171717171717171717171717171717"),
         h256("1717171717171717171717171717171717171717171717171717171717171717")};
 
-    globalStateStorage.setBlockNumber(
+    globalStateStorageFixture.setBlockNumber(
         firstForkchoice.headBlockHash, c_staleInitialBlockNumber);
-    globalStateStorage.setBlockNumber(
+    globalStateStorageFixture.setBlockNumber(
         secondForkchoice.headBlockHash, c_staleNextBlockNumber);
-    globalStateStorage.setBlockNumber(
+    globalStateStorageFixture.setBlockNumber(
         thirdForkchoice.headBlockHash, c_staleThirdBlockNumber);
 
     auto firstResult =
-        task::syncWait(engineService.updateForkchoice(firstForkchoice, std::nullopt, 3));
+        task::syncWait(engineService.updateForkchoice(firstForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(firstResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
     auto secondResult =
-        task::syncWait(engineService.updateForkchoice(secondForkchoice, std::nullopt, 3));
+        task::syncWait(engineService.updateForkchoice(secondForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(secondResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
     auto staleResult =
-        task::syncWait(engineService.updateForkchoice(firstForkchoice, std::nullopt, 3));
+        task::syncWait(engineService.updateForkchoice(firstForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(staleResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
     auto thirdResult =
-        task::syncWait(engineService.updateForkchoice(thirdForkchoice, std::nullopt, 3));
+        task::syncWait(engineService.updateForkchoice(thirdForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(thirdResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 }

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -6,11 +6,15 @@
 #include "engine/bcos-engine/EngineService.h"
 
 #include <bcos-concepts/ByteBuffer.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/ledger/EVMAccount.h>
 #include <bcos-framework/ledger/LedgerTypeDef.h>
 #include <bcos-framework/storage/Entry.h>
 #include <bcos-framework/storage2/MemoryStorage.h>
 #include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-mempool/MemPoolImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-task/Wait.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
@@ -35,9 +39,34 @@ constexpr bcos::protocol::BlockNumber c_staleInitialBlockNumber = 50;
 constexpr bcos::protocol::BlockNumber c_staleNextBlockNumber = 51;
 constexpr bcos::protocol::BlockNumber c_staleThirdBlockNumber = 52;
 
-struct FakeMemPool
+using namespace bcos::txpool;
+using namespace bcos::protocol;
+using namespace bcos::crypto;
+
+static bytes toBytes(std::string_view input)
 {
+    return {reinterpret_cast<const byte*>(input.data()),
+        reinterpret_cast<const byte*>(input.data()) + input.size()};
+}
+
+class TestTransactionImpl : public bcostars::protocol::TransactionImpl
+{
+public:
+    void markClean() { setTainted(false); }
 };
+
+static protocol::Transaction::Ptr makeTx(std::string_view senderBytes, int64_t nonce)
+{
+    auto tx = std::make_shared<TestTransactionImpl>();
+    tx->mutableInner().data.to.assign(senderBytes.begin(), senderBytes.end());
+    tx->setNonce(std::to_string(nonce));
+    tx->forceSender(toBytes(senderBytes));
+    Keccak256 hasher;
+    tx->calculateHash(hasher);
+    tx->markClean();
+    tx->setImportTime(nonce);
+    return tx;
+}
 
 using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStorage<
     bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
@@ -72,19 +101,24 @@ struct RealGlobalStateStorageFixture
     {
         task::syncWait(writeBlockNumberToStorage(backendStorage, blockHash, blockNumber));
     }
+
+    void setNonce(std::string_view sender, std::string nonce)
+    {
+        ledger::account::EVMAccount account{backendStorage, sender, false};
+        task::syncWait(account.setNonce(std::move(nonce)));
+    }
 };
 
 void setForkchoiceBlockNumbers(RealGlobalStateStorageFixture& storageFixture,
     const ForkchoiceState& forkchoiceState, bcos::protocol::BlockNumber headBlockNumber,
-    bcos::protocol::BlockNumber safeBlockNumber,
-    bcos::protocol::BlockNumber finalizedBlockNumber)
+    bcos::protocol::BlockNumber safeBlockNumber, bcos::protocol::BlockNumber finalizedBlockNumber)
 {
     storageFixture.setBlockNumber(forkchoiceState.headBlockHash, headBlockNumber);
     storageFixture.setBlockNumber(forkchoiceState.safeBlockHash, safeBlockNumber);
     storageFixture.setBlockNumber(forkchoiceState.finalizedBlockHash, finalizedBlockNumber);
 }
 
-using TestEngineService = EngineService<FakeMemPool, RealGlobalStateStorage>;
+using TestEngineService = EngineService<MemPoolImpl, RealGlobalStateStorage>;
 ForkchoiceState makeForkchoiceState()
 {
     return {h256("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
@@ -132,7 +166,9 @@ BOOST_AUTO_TEST_SUITE(EngineServiceTest)
 
 BOOST_AUTO_TEST_CASE(exchange_capabilities_returns_supported_methods)
 {
-    TestEngineService engineService;
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
     auto capabilities = task::syncWait(
         engineService.exchangeCapabilities({"engine_forkchoiceUpdatedV1", "unknown_method"}));
@@ -142,29 +178,23 @@ BOOST_AUTO_TEST_CASE(exchange_capabilities_returns_supported_methods)
                 capabilities.end());
 }
 
-BOOST_AUTO_TEST_CASE(custom_dependency_types_can_be_injected)
-{
-    FakeMemPool memPool;
-    RealGlobalStateStorageFixture globalStateStorageFixture;
-    TestEngineService engineService(memPool, globalStateStorageFixture.storage);
-
-    BOOST_CHECK(engineService.memPool() == &memPool);
-    BOOST_CHECK(engineService.globalStateStorage() == &globalStateStorageFixture.storage);
-}
-
 BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_payload)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     auto forkchoiceState = makeForkchoiceState();
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
         c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("aaaaaaaaaaaaaaaaaaaa", 20);
+    auto tx = makeTx(sender, 0);
+    memPool.add(std::vector{tx});
+    globalStateStorageFixture.setNonce(sender, "1");
     auto payloadAttributes = makePayloadAttributesV2();
 
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
-    auto result = task::syncWait(
-        engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));
 
     BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
@@ -176,11 +206,14 @@ BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_paylo
     BOOST_CHECK_EQUAL(payload.executionPayload.timestamp, c_timestamp);
     BOOST_CHECK(payload.executionPayload.withdrawals.has_value());
     BOOST_CHECK(!payload.executionPayload.blobGasUsed.has_value());
+    auto fetched = memPool.get(std::vector{tx->hash()});
+    BOOST_CHECK_EQUAL(fetched.size(), 1);
+    BOOST_CHECK(!fetched[0]);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
@@ -188,8 +221,8 @@ BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
     setForkchoiceBlockNumbers(globalStateStorageFixture, initialForkchoice,
         c_trackedInitialBlockNumber, c_trackedInitialBlockNumber, c_trackedInitialBlockNumber);
     auto payloadAttributes = makePayloadAttributesV3();
-    auto initialResult = task::syncWait(
-        engineService.updateForkchoice(initialForkchoice, &payloadAttributes, 3));
+    auto initialResult =
+        task::syncWait(engineService.updateForkchoice(initialForkchoice, &payloadAttributes, 3));
     BOOST_REQUIRE(initialResult.payloadId.has_value());
     auto builtPayload = task::syncWait(engineService.getPayload(*initialResult.payloadId, 3));
     globalStateStorageFixture.setBlockNumber(
@@ -217,7 +250,7 @@ BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 
 BOOST_AUTO_TEST_CASE(new_payload_rejects_missing_required_v3_fields)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     auto forkchoiceState = makeForkchoiceState();
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_validationBlockNumber,
@@ -225,8 +258,8 @@ BOOST_AUTO_TEST_CASE(new_payload_rejects_missing_required_v3_fields)
     auto payloadAttributes = makePayloadAttributesV3();
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
-    auto result = task::syncWait(
-        engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
     BOOST_REQUIRE(result.payloadId.has_value());
 
     auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
@@ -243,34 +276,41 @@ BOOST_AUTO_TEST_CASE(new_payload_rejects_missing_required_v3_fields)
 
 BOOST_AUTO_TEST_CASE(forkchoice_returns_syncing_when_head_block_number_missing)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     auto forkchoiceState = makeForkchoiceState();
-    globalStateStorageFixture.setBlockNumber(forkchoiceState.safeBlockHash, c_validationBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.safeBlockHash, c_validationBlockNumber);
     globalStateStorageFixture.setBlockNumber(
         forkchoiceState.finalizedBlockHash, c_validationBlockNumber);
+    std::string sender("bbbbbbbbbbbbbbbbbbbb", 20);
+    auto tx = makeTx(sender, 0);
+    memPool.add(std::vector{tx});
+    globalStateStorageFixture.setNonce(sender, "1");
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
-    auto result =
-        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3));
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3));
 
     BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Syncing));
     BOOST_CHECK(!result.payloadId.has_value());
+    auto fetched = memPool.get(std::vector{tx->hash()});
+    BOOST_CHECK_EQUAL(fetched.size(), 1);
+    BOOST_CHECK(fetched[0]);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_returns_syncing_when_safe_block_number_missing)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     auto forkchoiceState = makeForkchoiceState();
-    globalStateStorageFixture.setBlockNumber(forkchoiceState.headBlockHash, c_validationBlockNumber);
+    globalStateStorageFixture.setBlockNumber(
+        forkchoiceState.headBlockHash, c_validationBlockNumber);
     globalStateStorageFixture.setBlockNumber(
         forkchoiceState.finalizedBlockHash, c_validationBlockNumber);
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
-    auto result =
-        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3));
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3));
 
     BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Syncing));
@@ -279,7 +319,7 @@ BOOST_AUTO_TEST_CASE(forkchoice_returns_syncing_when_safe_block_number_missing)
 
 BOOST_AUTO_TEST_CASE(forkchoice_rejects_non_sequential_head_block_number)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
@@ -298,14 +338,13 @@ BOOST_AUTO_TEST_CASE(forkchoice_rejects_non_sequential_head_block_number)
     setForkchoiceBlockNumbers(globalStateStorageFixture, reorgForkchoice, c_reorgTargetBlockNumber,
         c_reorgTargetBlockNumber, c_reorgTargetBlockNumber);
 
-    BOOST_CHECK_THROW(
-        task::syncWait(engineService.updateForkchoice(reorgForkchoice, nullptr, 3)),
+    BOOST_CHECK_THROW(task::syncWait(engineService.updateForkchoice(reorgForkchoice, nullptr, 3)),
         bcos::engine::InvalidForkchoiceState);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_rejects_safe_block_number_above_head)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
@@ -320,14 +359,13 @@ BOOST_AUTO_TEST_CASE(forkchoice_rejects_safe_block_number_above_head)
     globalStateStorageFixture.setBlockNumber(
         forkchoiceState.finalizedBlockHash, c_headOrderingBlockNumber);
 
-    BOOST_CHECK_THROW(
-        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3)),
+    BOOST_CHECK_THROW(task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3)),
         bcos::engine::InvalidForkchoiceState);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_rejects_finalized_block_number_above_safe)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
@@ -342,14 +380,13 @@ BOOST_AUTO_TEST_CASE(forkchoice_rejects_finalized_block_number_above_safe)
     globalStateStorageFixture.setBlockNumber(
         forkchoiceState.finalizedBlockHash, c_safeOrderingBlockNumber);
 
-    BOOST_CHECK_THROW(
-        task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3)),
+    BOOST_CHECK_THROW(task::syncWait(engineService.updateForkchoice(forkchoiceState, nullptr, 3)),
         bcos::engine::InvalidForkchoiceState);
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_ignores_stale_update_after_newer_head_wins)
 {
-    FakeMemPool memPool;
+    MemPoolImpl memPool;
     RealGlobalStateStorageFixture globalStateStorageFixture;
     TestEngineService engineService(memPool, globalStateStorageFixture.storage);
 
@@ -373,8 +410,7 @@ BOOST_AUTO_TEST_CASE(forkchoice_ignores_stale_update_after_newer_head_wins)
     globalStateStorageFixture.setBlockNumber(
         thirdForkchoice.headBlockHash, c_staleThirdBlockNumber);
 
-    auto firstResult =
-        task::syncWait(engineService.updateForkchoice(firstForkchoice, nullptr, 3));
+    auto firstResult = task::syncWait(engineService.updateForkchoice(firstForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(firstResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
@@ -383,13 +419,11 @@ BOOST_AUTO_TEST_CASE(forkchoice_ignores_stale_update_after_newer_head_wins)
     BOOST_CHECK_EQUAL(static_cast<int>(secondResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
-    auto staleResult =
-        task::syncWait(engineService.updateForkchoice(firstForkchoice, nullptr, 3));
+    auto staleResult = task::syncWait(engineService.updateForkchoice(firstForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(staleResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 
-    auto thirdResult =
-        task::syncWait(engineService.updateForkchoice(thirdForkchoice, nullptr, 3));
+    auto thirdResult = task::syncWait(engineService.updateForkchoice(thirdForkchoice, nullptr, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(thirdResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
 }


### PR DESCRIPTION
Implement logic for updating the fork choice, including validation of payload attributes and handling of block numbers. Update tests to ensure correctness of the new functionality.