### PR TITLE
Remove unnecessary cmake_minimum_required statements

### DIFF
--- a/bcos-executor/CMakeLists.txt
+++ b/bcos-executor/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 project(bcos-executor VERSION ${VERSION})
 

--- a/bcos-framework/CMakeLists.txt
+++ b/bcos-framework/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.12)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/bcos-framework)
 

--- a/bcos-front/CMakeLists.txt
+++ b/bcos-front/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 aux_source_directory(bcos-front SRCS)
 

--- a/bcos-gateway/CMakeLists.txt
+++ b/bcos-gateway/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-gateway VERSION ${VERSION})
 

--- a/bcos-leader-election/CMakeLists.txt
+++ b/bcos-leader-election/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 if(WITH_LEDGER_ELECTION)
     project(bcos-leader-election VERSION ${VERSION})

--- a/bcos-ledger/CMakeLists.txt
+++ b/bcos-ledger/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 find_package(Boost REQUIRED serialization)
 

--- a/bcos-protocol/CMakeLists.txt
+++ b/bcos-protocol/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 add_subdirectory(bcos-protocol)
 

--- a/bcos-rpbft/CMakeLists.txt
+++ b/bcos-rpbft/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-rpbft VERSION ${VERSION})
 

--- a/bcos-rpc/CMakeLists.txt
+++ b/bcos-rpc/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-rpc VERSION ${VERSION})
 

--- a/bcos-scheduler/CMakeLists.txt
+++ b/bcos-scheduler/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 
 project(bcos-scheduler VERSION ${VERSION})

--- a/bcos-sealer/CMakeLists.txt
+++ b/bcos-sealer/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-sealer VERSION ${VERSION})
 

--- a/bcos-security/CMakeLists.txt
+++ b/bcos-security/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-security VERSION ${VERSION})
 

--- a/bcos-storage/CMakeLists.txt
+++ b/bcos-storage/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 project(bcos-storage VERSION ${VERSION})
 

--- a/bcos-sync/CMakeLists.txt
+++ b/bcos-sync/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-sync VERSION ${VERSION})
 

--- a/bcos-table/CMakeLists.txt
+++ b/bcos-table/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-table VERSION ${VERSION})
 

--- a/bcos-tars-protocol/CMakeLists.txt
+++ b/bcos-tars-protocol/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 
 # for tars generator
 set(TARS_HEADER_DIR ${CMAKE_BINARY_DIR}/generated/bcos-tars-protocol/tars)

--- a/bcos-tool/CMakeLists.txt
+++ b/bcos-tool/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 
 project(bcos-tool VERSION ${VERSION})

--- a/bcos-txpool/CMakeLists.txt
+++ b/bcos-txpool/CMakeLists.txt
@@ -16,7 +16,6 @@
 # limitations under the License.
 #------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-txpool VERSION ${VERSION})
 

--- a/concepts/CMakeLists.txt
+++ b/concepts/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
 project(bcos-concepts VERSION ${VERSION})
 
 add_library(bcos-concepts INTERFACE)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Top-level CMake file for bcos-engine
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-engine VERSION ${VERSION})
 

--- a/fisco-bcos-tars-service/CMakeLists.txt
+++ b/fisco-bcos-tars-service/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 

--- a/fisco-bcos-tars-service/GatewayService/main/CMakeLists.txt
+++ b/fisco-bcos-tars-service/GatewayService/main/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 project(bcostars-Gateway)
 

--- a/fisco-bcos-tars-service/LedgerService/CMakeLists.txt
+++ b/fisco-bcos-tars-service/LedgerService/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 project(bcostars-ledger)
 file(GLOB SRC_LIST "*.cpp")

--- a/fisco-bcos-tars-service/RpcService/main/CMakeLists.txt
+++ b/fisco-bcos-tars-service/RpcService/main/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 project(bcostars-rpc)
 file(GLOB SRC_LIST "*.cpp")

--- a/libtask/CMakeLists.txt
+++ b/libtask/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
 
 find_package(Boost REQUIRED COMPONENTS atomic)
 

--- a/libtask/tests/CMakeLists.txt
+++ b/libtask/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
 
 find_package(Boost REQUIRED unit_test_framework)
 find_package(TBB REQUIRED)

--- a/lightnode/CMakeLists.txt
+++ b/lightnode/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
 project(lightnode VERSION ${VERSION})
 
 add_library(bcos-lightnode INTERFACE)

--- a/lightnode/fisco-bcos-lightnode/CMakeLists.txt
+++ b/lightnode/fisco-bcos-lightnode/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
 
 file(GLOB_RECURSE SOURCES "bcos-lightnode/*.h")
 

--- a/lightnode/tests/CMakeLists.txt
+++ b/lightnode/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.17)
 
 project(test-lightnode)
 

--- a/mempool/CMakeLists.txt
+++ b/mempool/CMakeLists.txt
@@ -2,7 +2,6 @@
 # Top-level CMake file for bcos-mempool
 # ------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.10)
 
 project(bcos-mempool VERSION ${VERSION})
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 project(FISCO-BCOS-Test)
 

--- a/transaction-executor/CMakeLists.txt
+++ b/transaction-executor/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 find_package(evmc REQUIRED)
 find_package(evmone REQUIRED)

--- a/transaction-scheduler/CMakeLists.txt
+++ b/transaction-scheduler/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.14)
 
 find_package(fmt REQUIRED)
 


### PR DESCRIPTION
Eliminate redundant `cmake_minimum_required` directives across multiple CMake files to streamline the configuration process.