### PR TITLE
Improve logging performance and usage

### DIFF
--- a/bcos-utilities/bcos-utilities/BoostLog.cpp
+++ b/bcos-utilities/bcos-utilities/BoostLog.cpp
@@ -39,6 +39,7 @@
 #include <boost/spirit/home/qi/numeric/numeric_utils.hpp>
 #include <boost/system/detail/error_category.hpp>
 #include <boost/system/detail/error_code.hpp>
+#include <utility>
 namespace bcos
 {
 std::string const FileLogger = "FileLogger";
@@ -538,7 +539,7 @@ private:
 
 public:
     //! Constructor
-    file_collector(boost::shared_ptr<file_collector_repository> const& repo,
+    file_collector(boost::shared_ptr<file_collector_repository> repo,
         boost::filesystem::path const& target_dir, uintmax_t max_size, uintmax_t min_free_space,
         uintmax_t max_files);
 
@@ -625,10 +626,10 @@ private:
 };
 
 //! Constructor
-file_collector::file_collector(boost::shared_ptr<file_collector_repository> const& repo,
+file_collector::file_collector(boost::shared_ptr<file_collector_repository> repo,
     boost::filesystem::path const& target_dir, uintmax_t max_size, uintmax_t min_free_space,
     uintmax_t max_files)
-  : m_pRepository(repo),
+  : m_pRepository(std::move(repo)),
     m_MaxSize(max_size),
     m_MinFreeSpace(min_free_space),
     m_MaxFiles(max_files),
@@ -775,13 +776,14 @@ void file_collector::store_file(boost::filesystem::path const& src_path)
     }
     if (m_ConvertTarGZ)
     {
-        auto from = info.m_Path;
-        info.m_Path = info.m_Path.string() + std::string(".gz");
-        convert_to_tar_gz(from, info.m_Path);
+        auto compressedPath = info.m_Path;
+        compressedPath += ".gz";
+        convert_to_tar_gz(info.m_Path, compressedPath);
+        info.m_Path = std::move(compressedPath);
         info.m_Size = boost::filesystem::file_size(info.m_Path);
     }
 
-    m_Files.push_back(info);
+    m_Files.push_back(std::move(info));
     m_TotalSize += info.m_Size;
 }
 
@@ -875,7 +877,7 @@ boost::log::sinks::file::scan_result file_collector::scan_for_files(
                             info.m_Size = boost::filesystem::file_size(info.m_Path);
                             total_size += info.m_Size;
                             info.m_TimeStamp = boost::filesystem::last_write_time(info.m_Path);
-                            files.push_back(info);
+                            files.push_back(std::move(info));
                             ++result.found_count;
 
                             // Test that the file_number >= result.last_file_counter accounting for

--- a/bcos-utilities/bcos-utilities/BoostLog.cpp
+++ b/bcos-utilities/bcos-utilities/BoostLog.cpp
@@ -783,8 +783,8 @@ void file_collector::store_file(boost::filesystem::path const& src_path)
         info.m_Size = boost::filesystem::file_size(info.m_Path);
     }
 
-    m_Files.push_back(std::move(info));
     m_TotalSize += info.m_Size;
+    m_Files.push_back(std::move(info));
 }
 
 //! The function checks if the specified path refers to an existing file in the storage

--- a/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
+++ b/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
@@ -30,6 +30,7 @@
 #include <boost/log/core/core.hpp>
 #include <boost/log/support/date_time.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
+#include <mutex>
 
 using namespace bcos;
 
@@ -37,6 +38,18 @@ namespace logging = boost::log;
 namespace expr = boost::log::expressions;
 
 constexpr int MB_IN_BYTES = 1048576;
+
+namespace
+{
+void initializeLogAttributes()
+{
+    static std::once_flag once;
+    std::call_once(once, []() {
+        boost::log::add_common_attributes();
+        boost::log::core::get()->add_global_attribute("ThreadName", bcos::log::thread_name());
+    });
+}
+}
 
 // register SIGUSE2 for dynamic reset log level
 struct BoostLogLevelResetHandler
@@ -114,7 +127,7 @@ boost::shared_ptr<bcos::BoostLogInitializer::console_sink_t>
 BoostLogInitializer::initConsoleLogSink(
     boost::property_tree::ptree const& _pt, unsigned _logLevel, std::string const& channel)
 {
-    boost::log::add_common_attributes();
+    initializeLogAttributes();
     boost::shared_ptr<console_sink_t> consoleSink(new console_sink_t());
     consoleSink->locked_backend()->add_stream(
         boost::shared_ptr<std::ostream>(&std::cout, boost::null_deleter()));
@@ -237,7 +250,7 @@ void BoostLogInitializer::initLog(boost::property_tree::ptree const& _pt,
         setLogFormatter(sink, m_logFormat);
     }
     setFileLogLevel((LogLevel)m_logLevel);
-    boost::log::core::get()->add_global_attribute("ThreadName", bcos::log::thread_name());
+    initializeLogAttributes();
 
     auto enableRateCollector = _pt.get<bool>("log.enable_rate_collector", false);
     if (enableRateCollector)
@@ -274,8 +287,6 @@ boost::shared_ptr<bcos::BoostLogInitializer::sink_t> BoostLogInitializer::initHo
     boost::log::core::get()->add_sink(sink);
     m_sinks.push_back(sink);
     boost::log::core::get()->set_logging_enabled(m_enableLog);
-    // add attributes
-    boost::log::add_common_attributes();
     return sink;
 }
 
@@ -318,8 +329,6 @@ boost::shared_ptr<bcos::BoostLogInitializer::sink_t> BoostLogInitializer::initLo
     boost::log::core::get()->add_sink(sink);
     m_sinks.push_back(sink);
     boost::log::core::get()->set_logging_enabled(m_enableLog);
-    // add attributes
-    boost::log::add_common_attributes();
     return sink;
 }
 
@@ -377,7 +386,7 @@ void BoostLogInitializer::stopLogging()
 }
 
 /// stop a single sink
-void BoostLogInitializer::stopLogging(boost::shared_ptr<sink_t> sink)
+void BoostLogInitializer::stopLogging(boost::shared_ptr<sink_t> const& sink)
 {
     if (!sink)
     {
@@ -392,7 +401,6 @@ void BoostLogInitializer::stopLogging(boost::shared_ptr<sink_t> sink)
     sink->stop();
     // flush all log records that may have left buffered
     sink->flush();
-    sink.reset();
 }
 void bcos::BoostLogInitializer::Sink::consume(
     const boost::log::record_view& rec, const std::string& str)

--- a/bcos-utilities/bcos-utilities/BoostLogInitializer.h
+++ b/bcos-utilities/bcos-utilities/BoostLogInitializer.h
@@ -119,7 +119,7 @@ private:
     }
 
     template <typename T>
-    void stopLogging(boost::shared_ptr<T> sink)
+    void stopLogging(boost::shared_ptr<T> const& sink)
     {
         if (!sink)
         {
@@ -131,10 +131,9 @@ private:
         sink->stop();
         // flush all log records that may have left buffered
         sink->flush();
-        sink.reset();
     }
 
-    void stopLogging(boost::shared_ptr<sink_t> sink);
+    void stopLogging(boost::shared_ptr<sink_t> const& sink);
     std::vector<boost::shared_ptr<sink_t>> m_sinks;
     std::vector<boost::shared_ptr<console_sink_t>> m_consoleSinks;
 

--- a/bcos-utilities/bcos-utilities/BoostLogThreadNameAttribute.h
+++ b/bcos-utilities/bcos-utilities/BoostLogThreadNameAttribute.h
@@ -33,7 +33,7 @@ class thread_name_impl : public boost::log::attribute::impl
 public:
     boost::log::attribute_value get_value() override
     {
-        auto name = bcos::pthread_getThreadName();
+        auto const& name = bcos::pthread_getThreadNameRef();
         return boost::log::attributes::make_attribute_value(name.empty() ? "Unnamed" : name);
     }
 };

--- a/bcos-utilities/bcos-utilities/Common.cpp
+++ b/bcos-utilities/bcos-utilities/Common.cpp
@@ -181,6 +181,28 @@ int32_t toMillisecond(int32_t _seconds)
 }
 }  // namespace bcos
 
+namespace
+{
+thread_local std::string c_threadName;
+thread_local bool c_threadNameInitialized = false;
+
+void refreshThreadNameCache()
+{
+#if defined(__GLIBC__) || defined(__APPLE__)
+    std::array<char, 16> name = {0};
+    auto err = pthread_getname_np(pthread_self(), name.data(), name.size());
+    if (err == 0)
+    {
+        c_threadName = name[0] == '\0' ? "" : std::string{name.data()};
+        c_threadNameInitialized = true;
+        return;
+    }
+#endif
+    c_threadName.clear();
+    c_threadNameInitialized = true;
+}
+}  // namespace
+
 void bcos::pthread_setThreadName(std::string const& _n)
 {
 #if defined(__GLIBC__)
@@ -188,21 +210,21 @@ void bcos::pthread_setThreadName(std::string const& _n)
 #elif defined(__APPLE__)
     pthread_setname_np(_n.c_str());
 #endif
+
+    refreshThreadNameCache();
+}
+
+std::string const& bcos::pthread_getThreadNameRef()
+{
+    if (!c_threadNameInitialized)
+    {
+        refreshThreadNameCache();
+    }
+
+    return c_threadName;
 }
 
 std::string bcos::pthread_getThreadName()
 {
-#if defined(__GLIBC__) || defined(__APPLE__)
-    std::array<char, 16> name = {0};
-    auto err = pthread_getname_np(pthread_self(), (char*)name.data(), name.size());
-    if (err == 0)
-    {
-        if (name[0] == '\0')
-        {
-            return "";
-        }
-        return {name.data()};
-    }
-#endif
-    return "";
+    return pthread_getThreadNameRef();
 }

--- a/bcos-utilities/bcos-utilities/Common.h
+++ b/bcos-utilities/bcos-utilities/Common.h
@@ -136,6 +136,7 @@ struct Exception;
 void errorExit(std::stringstream& _exitInfo, Exception const& exception);
 
 void pthread_setThreadName(std::string const& _n);
+std::string const& pthread_getThreadNameRef();
 std::string pthread_getThreadName();
 
 }  // namespace bcos

--- a/bcos-utilities/test/unittests/libutilities/TestBoostLog.cpp
+++ b/bcos-utilities/test/unittests/libutilities/TestBoostLog.cpp
@@ -35,5 +35,14 @@ BOOST_AUTO_TEST_CASE(testCreatFileColletctor)
     auto collector = bcos::log::make_collector(targetDir, 0, 0, 0, false);
     BOOST_CHECK(collector != nullptr);
 }
+
+BOOST_AUTO_TEST_CASE(testThreadNameCache)
+{
+    constexpr auto threadName = "log-test";
+    bcos::pthread_setThreadName(threadName);
+
+    BOOST_CHECK_EQUAL(bcos::pthread_getThreadNameRef(), threadName);
+    BOOST_CHECK_EQUAL(bcos::pthread_getThreadName(), threadName);
+}
 }  // namespace test
 }  // namespace bcos


### PR DESCRIPTION
Enhance logging functionality by optimizing log usage and improving performance. Introduce a thread name cache to reduce overhead and ensure thread names are accurately retrieved. Update log initialization to streamline attribute setup.