### PR TITLE
Replace task_group with IOServicePool

### DIFF
--- a/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
@@ -195,11 +195,8 @@ void WsInitializer::initWsService(WsService::Ptr _wsService)
         }
     }
 
-    auto threadPoolSize = _config->threadPoolSize();
-    if (threadPoolSize > 0)
-    {
-        _wsService->initTaskArena(threadPoolSize);
-    }
+    // Note: IOServicePool must be set before starting wsService.
+    // The threadPoolSize was previously used for tbb::task_arena, now IOServicePool handles it.
 
     connector->setCtx(clientCtx);
     connector->setBuilder(builder);

--- a/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
@@ -32,7 +32,6 @@
 #include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/ThreadPool.h>
 #include <boost/system/detail/error_code.hpp>
-#include <cstddef>
 
 using namespace bcos;
 using namespace bcos::boostssl;
@@ -87,7 +86,12 @@ void WsInitializer::initWsService(WsService::Ptr _wsService)
     }
 
     auto wsServiceWeakPtr = std::weak_ptr<WsService>(_wsService);
-    auto ioServicePool = std::make_shared<IOServicePool>();
+    if (!m_ioServicePool)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidParameter() << errinfo_comment("IOServicePool must be set in WsInitializer!"));
+    }
+    auto ioServicePool = m_ioServicePool;
     _wsService->setIOServicePool(ioServicePool);
 
     auto resolver =

--- a/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.h
@@ -22,6 +22,7 @@
 #include <bcos-boostssl/websocket/WsConfig.h>
 #include <bcos-boostssl/websocket/WsService.h>
 #include <bcos-boostssl/websocket/WsSession.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <utility>
 
 namespace bcos::boostssl::ws
@@ -41,11 +42,17 @@ public:
     std::shared_ptr<WsSessionFactory> sessionFactory();
     void setSessionFactory(std::shared_ptr<WsSessionFactory> _sessionFactory);
 
+    void setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool)
+    {
+        m_ioServicePool = std::move(_ioServicePool);
+    }
+
     void initWsService(WsService::Ptr _wsService);
 
 private:
     std::shared_ptr<MessageFaceFactory> m_messageFactory;
     std::shared_ptr<WsConfig> m_config;
     WsSessionFactory::Ptr m_sessionFactory;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace bcos::boostssl::ws

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
@@ -52,7 +52,6 @@ WsService::WsService()
 WsService::~WsService()
 {
     stop();
-    m_taskGroup.wait();
     WEBSOCKET_SERVICE(INFO) << LOG_KV("[DELOBJ][WsService]", this);
 }
 
@@ -175,11 +174,6 @@ EndPointsPtr WsService::reconnectedPeers() const
     return m_reconnectedPeers;
 }
 
-void WsService::initTaskArena(uint32_t _taskArenaPoolSize)
-{
-    m_taskArena.initialize(_taskArenaPoolSize, 0);
-}
-
 void WsService::start()
 {
     if (m_running)
@@ -247,7 +241,6 @@ void WsService::start()
     WEBSOCKET_SERVICE(INFO) << LOG_BADGE("start")
                             << LOG_DESC("start websocket service successfully")
                             << LOG_KV("model", m_config->model())
-                            << LOG_KV("taskArenaMaxConcurrency", m_taskArena.max_concurrency())
                             << LOG_KV("max msg size", m_config->maxMsgSize());
 }
 
@@ -272,9 +265,6 @@ void WsService::stop()
     {
         m_ioservicePool->stop();
     }
-
-    m_taskGroup.cancel();
-    m_taskGroup.wait();
 
     if (m_statTimer)
     {
@@ -532,7 +522,7 @@ std::shared_ptr<WsSession> WsService::newSession(
     _wsStreamDelegate->setMaxReadMsgSize(m_config->maxMsgSize());
 
     std::string endPoint = _wsStreamDelegate->remoteEndpoint();
-    auto session = m_sessionFactory->createSession(m_taskArena, m_taskGroup);
+    auto session = m_sessionFactory->createSession(m_ioservicePool);
 
     session->setWsStreamDelegate(std::move(_wsStreamDelegate));
     session->setIoc(m_ioservicePool->getIOService());

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.h
@@ -31,8 +31,6 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/ThreadPool.h>
-#include <oneapi/tbb/task_arena.h>
-#include <oneapi/tbb/task_group.h>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/strand.hpp>
@@ -146,14 +144,8 @@ public:
     void setReconnectedPeers(EndPointsPtr _reconnectedPeers);
     EndPointsPtr reconnectedPeers() const;
 
-    // init
-    void initTaskArena(uint32_t _taskArenaPoolSize);
-
 private:
     bool m_running{false};
-
-    tbb::task_arena m_taskArena;
-    tbb::task_group m_taskGroup;
 
     int32_t m_waitConnectFinishTimeout = 30000;
 

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
@@ -23,13 +23,13 @@
 #include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
-#include <chrono>
-#include <bcos-utilities/ThreadPool.h>
 #include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/ThreadPool.h>
 #include <boost/asio/post.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/beast/websocket/stream.hpp>
 #include <boost/core/ignore_unused.hpp>
+#include <chrono>
 #include <exception>
 #include <memory>
 #include <mutex>
@@ -44,8 +44,7 @@ using namespace bcos::boostssl;
 using namespace bcos::boostssl::ws;
 using namespace bcos::boostssl::http;
 
-WsSession::WsSession(IOServicePool::Ptr ioServicePool)
-  : m_ioServicePool(std::move(ioServicePool))
+WsSession::WsSession(IOServicePool::Ptr ioServicePool) : m_ioServicePool(std::move(ioServicePool))
 {
     WEBSOCKET_SESSION(INFO) << LOG_KV("[NEWOBJ][WSSESSION]", this);
 
@@ -229,7 +228,7 @@ void WsSession::drop(WsError _reason)
                 << LOG_DESC("the session has been disconnected") << LOG_KV("seq", cbEntry.first);
 
             boost::asio::post(m_ioServicePool->getIOService()->get_executor(),
-                [callback = std::move(callback), error = std::move(error)]() mutable {
+                [callback = std::move(callback), error]() mutable {
                     callback->respCallBack(error, nullptr, nullptr);
                 });
         }
@@ -255,8 +254,7 @@ void WsSession::drop(WsError _reason)
     });
 }
 
-WsSession::Ptr WsSessionFactory::createSession(
-    IOServicePool::Ptr ioServicePool)
+WsSession::Ptr WsSessionFactory::createSession(IOServicePool::Ptr ioServicePool)
 {
     return std::make_shared<WsSession>(std::move(ioServicePool));
 }
@@ -550,8 +548,7 @@ void WsSession::asyncSendMessage(
         WEBSOCKET_SESSION(WARNING)
             << LOG_BADGE("asyncSendMessage") << LOG_DESC("message encode failed")
             << LOG_KV("endpoint", endPoint()) << LOG_KV("seq", seq)
-            << LOG_KV("packetType", _msg->packetType())
-            << LOG_KV("msgSize", _msg->payload().size())
+            << LOG_KV("packetType", _msg->packetType()) << LOG_KV("msgSize", _msg->payload().size())
             << LOG_KV("maxWriteMsgSize", maxWriteMsgSize());
         return;
     }

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
@@ -25,8 +25,8 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <chrono>
 #include <bcos-utilities/ThreadPool.h>
-#include <oneapi/tbb/task_arena.h>
-#include <oneapi/tbb/task_group.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <boost/asio/post.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/beast/websocket/stream.hpp>
 #include <boost/core/ignore_unused.hpp>
@@ -44,8 +44,8 @@ using namespace bcos::boostssl;
 using namespace bcos::boostssl::ws;
 using namespace bcos::boostssl::http;
 
-WsSession::WsSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup)
-  : m_taskArena(taskArena), m_taskGroup(taskGroup)
+WsSession::WsSession(IOServicePool::Ptr ioServicePool)
+  : m_ioServicePool(std::move(ioServicePool))
 {
     WEBSOCKET_SESSION(INFO) << LOG_KV("[NEWOBJ][WSSESSION]", this);
 
@@ -228,11 +228,9 @@ void WsSession::drop(WsError _reason)
             WEBSOCKET_SESSION(TRACE)
                 << LOG_DESC("the session has been disconnected") << LOG_KV("seq", cbEntry.first);
 
-            m_taskArena.execute(
-                [&, callback = std::move(callback), error = std::move(error)]() mutable {
-                    m_taskGroup.run([callback = std::move(callback), error = std::move(error)]() {
-                        callback->respCallBack(error, nullptr, nullptr);
-                    });
+            boost::asio::post(m_ioServicePool->getIOService()->get_executor(),
+                [callback = std::move(callback), error = std::move(error)]() mutable {
+                    callback->respCallBack(error, nullptr, nullptr);
                 });
         }
     }
@@ -248,21 +246,19 @@ void WsSession::drop(WsError _reason)
         m_wsStreamDelegate->close();
     }
 
-    m_taskArena.execute([&, self]() {
-        m_taskGroup.run([self]() {
-            auto session = self.lock();
-            if (session)
-            {
-                session->disconnectHandler()(nullptr, session);
-            }
-        });
+    boost::asio::post(m_ioServicePool->getIOService()->get_executor(), [self]() {
+        auto session = self.lock();
+        if (session)
+        {
+            session->disconnectHandler()(nullptr, session);
+        }
     });
 }
 
 WsSession::Ptr WsSessionFactory::createSession(
-    tbb::task_arena& taskArena, tbb::task_group& taskGroup)
+    IOServicePool::Ptr ioServicePool)
 {
-    return std::make_shared<WsSession>(taskArena, taskGroup);
+    return std::make_shared<WsSession>(std::move(ioServicePool));
 }
 
 // start WsSession as client
@@ -334,8 +330,8 @@ void WsSession::onReadPacket()
         m_buffer->consume(m_buffer->size());
 
         auto self = weak_from_this();
-        m_taskArena.execute([&, self, message = std::move(message)]() mutable {
-            m_taskGroup.run([self, message = std::move(message)]() {
+        boost::asio::post(m_ioServicePool->getIOService()->get_executor(),
+            [self, message = std::move(message)]() {
                 auto session = self.lock();
                 if (!session)
                 {
@@ -343,7 +339,6 @@ void WsSession::onReadPacket()
                 }
                 session->onMessage(message);
             });
-        });
     }
     catch (std::exception const& e)
     {
@@ -640,9 +635,8 @@ void WsSession::onRespTimeout(const boost::system::error_code& _error, const std
 
     auto error = BCOS_ERROR_PTR(WsError::TimeOut, "waiting for message response timed out");
 
-    m_taskArena.execute([&, callback = std::move(callback), error = std::move(error)]() mutable {
-        m_taskGroup.run([callback = std::move(callback), error = std::move(error)]() {
+    boost::asio::post(m_ioServicePool->getIOService()->get_executor(),
+        [callback = std::move(callback), error = std::move(error)]() mutable {
             callback->respCallBack(error, nullptr, nullptr);
         });
-    });
 }

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
@@ -26,10 +26,10 @@
 #include <bcos-boostssl/websocket/WsMessage.h>
 #include <bcos-boostssl/websocket/WsStream.h>
 #include <bcos-utilities/Common.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/ThreadPool.h>
 #include <bcos-utilities/Timer.h>
-#include <oneapi/tbb/task_arena.h>
-#include <oneapi/tbb/task_group.h>
+#include <boost/asio/post.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/beast/core.hpp>
@@ -55,7 +55,7 @@ public:
     using Ptrs = std::vector<std::shared_ptr<WsSession>>;
 
 public:
-    explicit WsSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup);
+    explicit WsSession(IOServicePool::Ptr ioServicePool);
 
     virtual ~WsSession() noexcept;
 
@@ -149,8 +149,7 @@ public:
     };
 
 protected:
-    tbb::task_arena& m_taskArena;
-    tbb::task_group& m_taskGroup;
+    IOServicePool::Ptr m_ioServicePool;
 
     // flag for message that need to check respond packet like p2p message
     bool m_needCheckRspPacket = false;
@@ -200,7 +199,7 @@ public:
     virtual ~WsSessionFactory() = default;
 
 public:
-    virtual WsSession::Ptr createSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup);
+    virtual WsSession::Ptr createSession(IOServicePool::Ptr ioServicePool);
 };
 
 }  // namespace bcos::boostssl::ws

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -359,14 +359,11 @@ bcos::boostssl::ws::WsService::Ptr RpcFactory::buildWsService(
     auto wsService = std::make_shared<bcos::boostssl::ws::WsService>();
     auto initializer = std::make_shared<bcos::boostssl::ws::WsInitializer>();
 
+    // Check threadPoolSize configuration (read before moving _config)
+    size_t threadPoolSize = _config ? _config->threadPoolSize() : 0;
+
     initializer->setConfig(std::move(_config));
 
-    // Check threadPoolSize configuration
-    size_t threadPoolSize = 0;
-    if (_config)
-    {
-        threadPoolSize = _config->threadPoolSize();
-    }
     if (threadPoolSize > 0)
     {
         // Use a dedicated thread pool for RPC

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -360,6 +360,32 @@ bcos::boostssl::ws::WsService::Ptr RpcFactory::buildWsService(
     auto initializer = std::make_shared<bcos::boostssl::ws::WsInitializer>();
 
     initializer->setConfig(std::move(_config));
+
+    // Check threadPoolSize configuration
+    size_t threadPoolSize = 0;
+    if (_config)
+    {
+        threadPoolSize = _config->threadPoolSize();
+    }
+    if (threadPoolSize > 0)
+    {
+        // Use a dedicated thread pool for RPC
+        auto rpcIOServicePool = std::make_shared<bcos::IOServicePool>(threadPoolSize);
+        rpcIOServicePool->start();
+        initializer->setIOServicePool(rpcIOServicePool);
+    }
+    else if (m_ioServicePool)
+    {
+        // Use the shared external IOServicePool
+        initializer->setIOServicePool(m_ioServicePool);
+    }
+    else
+    {
+        // No external pool and no threadPoolSize configured, throw exception
+        BOOST_THROW_EXCEPTION(InvalidParameter() << errinfo_comment(
+                                  "No IOServicePool available for RPC: please configure "
+                                  "threadPoolSize or set shared IOServicePool!"));
+    }
     initializer->initWsService(wsService);
 
     return wsService;

--- a/bcos-rpc/bcos-rpc/RpcFactory.h
+++ b/bcos-rpc/bcos-rpc/RpcFactory.h
@@ -32,6 +32,7 @@
 #include "bcos-rpc/groupmgr/GroupManager.h"
 #include "bcos-rpc/jsonrpc/JsonRpcImpl_2_0.h"
 #include "bcos-tool/NodeConfig.h"
+#include "bcos-utilities/IOServicePool.h"
 #include "web3jsonrpc/Web3JsonRpcImpl.h"
 #include <utility>
 
@@ -74,6 +75,11 @@ public:
         m_nodeConfig = std::move(_nodeConfig);
     }
 
+    void setIOServicePool(bcos::IOServicePool::Ptr _ioServicePool)
+    {
+        m_ioServicePool = std::move(_ioServicePool);
+    }
+
 protected:
     // for groupManager builder
     GroupManager::Ptr buildGroupManager(std::string const& _rpcServiceName,
@@ -103,6 +109,7 @@ private:
     std::shared_ptr<bcos::crypto::KeyFactory> m_keyFactory;
     bcos::tool::NodeConfig::Ptr m_nodeConfig;
     bcos::security::KeyEncryptInterface::Ptr m_dataEncrypt;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace rpc
 }  // namespace bcos

--- a/bcos-rpc/test/unittests/rpc/Web3SubscribleTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3SubscribleTest.cpp
@@ -28,7 +28,6 @@
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <bcos-rpc/web3jsonrpc/Web3Subscribe.h>
 #include <bcos-utilities/IOServicePool.h>
-#
 using namespace bcos;
 using namespace bcos::rpc;
 using namespace bcos::crypto;

--- a/bcos-rpc/test/unittests/rpc/Web3SubscribleTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3SubscribleTest.cpp
@@ -27,6 +27,7 @@
 #include <bcos-rpc/groupmgr/GroupManager.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <bcos-rpc/web3jsonrpc/Web3Subscribe.h>
+#include <bcos-utilities/IOServicePool.h>
 #
 using namespace bcos;
 using namespace bcos::rpc;
@@ -62,8 +63,8 @@ class MockWsSession : public WsSession
 public:
     using Ptr = std::shared_ptr<MockWsSession>;
 
-    MockWsSession(tbb::task_arena& taskArena, tbb::task_group& taskGroup)
-      : WsSession(taskArena, taskGroup)
+    MockWsSession(IOServicePool::Ptr ioServicePool)
+      : WsSession(std::move(ioServicePool))
     {
         setEndPoint("127.0.0.1:8080");
     }
@@ -139,11 +140,11 @@ BOOST_AUTO_TEST_CASE(testOnHttpSubscribeRequest)
     mockWeb3JsonRpcImpl->setWeb3Subscribe(web3Subscribe);
 
     // Create mock session
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session = std::make_shared<MockWsSession>(ioServicePool);
 
-    auto mockSession = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto mockSession = std::make_shared<MockWsSession>(ioServicePool);
 
     int id = 111;
     // Test newHeads subscription
@@ -195,11 +196,11 @@ BOOST_AUTO_TEST_CASE(testOnSubscribeRequest)
     mockWeb3JsonRpcImpl->setWeb3Subscribe(web3Subscribe);
 
     // Create mock session
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session = std::make_shared<MockWsSession>(ioServicePool);
 
-    auto mockSession = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto mockSession = std::make_shared<MockWsSession>(ioServicePool);
 
     int id = 111;
     // Test newHeads subscription
@@ -268,9 +269,9 @@ BOOST_AUTO_TEST_CASE(testOnSubscribeNewHeads)
     mockWeb3JsonRpcImpl->setWeb3Subscribe(web3Subscribe);
 
     // Create mock session
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session = std::make_shared<MockWsSession>(ioServicePool);
 
     int id = 123;
     Json::Value request;
@@ -313,13 +314,13 @@ BOOST_AUTO_TEST_CASE(testOnUnsubscribeRequest)
     std::string subscriptionId4;
 
     // Create mock session
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    // auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    // auto session = std::make_shared<MockWsSession>(ioServicePool);
 
-    auto session1 = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto session1 = std::make_shared<MockWsSession>(ioServicePool);
     session1->setEndPoint("127.0.0.1:8080");
-    auto session2 = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto session2 = std::make_shared<MockWsSession>(ioServicePool);
     session2->setEndPoint("127.0.0.1:8081");
 
     Json::Reader reader;
@@ -588,13 +589,13 @@ BOOST_AUTO_TEST_CASE(testOnRemoveSubscribeBySession)
     std::string subscriptionId4;
 
     // Create mock session
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    // auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    // auto session = std::make_shared<MockWsSession>(ioServicePool);
 
-    auto session1 = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto session1 = std::make_shared<MockWsSession>(ioServicePool);
     session1->setEndPoint("127.0.0.1:8080");
-    auto session2 = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto session2 = std::make_shared<MockWsSession>(ioServicePool);
     session2->setEndPoint("127.0.0.1:8081");
 
     Json::Reader reader;
@@ -718,9 +719,9 @@ BOOST_AUTO_TEST_CASE(testOnNewBlock)
     mockWeb3JsonRpcImpl->setWeb3Subscribe(web3Subscribe);
 
     // Create mock session
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session = std::make_shared<MockWsSession>(ioServicePool);
 
     Json::Value request;
     request["jsonrpc"] = "2.0";
@@ -758,9 +759,9 @@ BOOST_AUTO_TEST_CASE(testWeb3SubscribeInvalidRequests)
     auto web3Subscribe = std::make_shared<Web3Subscribe>(weakPtr);
 
     // Create mock session
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session = std::make_shared<MockWsSession>(ioServicePool);
 
     // Test with empty request
     Json::Value emptyRequest;
@@ -793,11 +794,11 @@ BOOST_AUTO_TEST_CASE(testConcurrentAccess)
     mockWeb3JsonRpcImpl->setWeb3Subscribe(web3Subscribe);
 
     // Create multiple mock sessions
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session1 = std::make_shared<MockWsSession>(taskArena, taskGroup);
-    auto session2 = std::make_shared<MockWsSession>(taskArena, taskGroup);
-    auto session3 = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session1 = std::make_shared<MockWsSession>(ioServicePool);
+    auto session2 = std::make_shared<MockWsSession>(ioServicePool);
+    auto session3 = std::make_shared<MockWsSession>(ioServicePool);
 
     // Create subscription requests
     Json::Value request1, request2, request3;
@@ -865,9 +866,9 @@ BOOST_AUTO_TEST_CASE(testMultiSubInOneRequest)
     mockWeb3JsonRpcImpl->setWeb3Subscribe(web3Subscribe);
 
     // Create multiple mock sessions
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session = std::make_shared<MockWsSession>(ioServicePool);
 
 
     Json::Value request;
@@ -934,9 +935,9 @@ BOOST_AUTO_TEST_CASE(testMultiRequestInOneRequest)
     mockWeb3JsonRpcImpl->setWeb3Subscribe(web3Subscribe);
 
     // Create multiple mock sessions
-    tbb::task_arena taskArena(1);
-    tbb::task_group taskGroup;
-    auto session = std::make_shared<MockWsSession>(taskArena, taskGroup);
+    auto ioServicePool = std::make_shared<IOServicePool>(1);
+    ioServicePool->start();
+    auto session = std::make_shared<MockWsSession>(ioServicePool);
 
 
     Json::Value request;

--- a/bcos-sdk/tests/unittests/event/EventSubTest.cpp
+++ b/bcos-sdk/tests/unittests/event/EventSubTest.cpp
@@ -23,8 +23,8 @@
 #include <bcos-cpp-sdk/event/EventSub.h>
 #include <bcos-cpp-sdk/event/EventSubResponse.h>
 #include <bcos-utilities/Common.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
-#include <oneapi/tbb/task_arena.h>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 #include <chrono>
@@ -170,11 +170,11 @@ BOOST_AUTO_TEST_CASE(test_EventSub_unsubscribeEvent)
         BOOST_CHECK_EQUAL(es->suspendTasksCount(), 0);
     }
 
-    tbb::task_group taskGroup;
-    tbb::task_arena taskArena;
+    auto ioServicePool = std::make_shared<IOServicePool>(2);
+    ioServicePool->start();
     {
         // task is running
-        auto session = std::make_shared<bcos::cppsdk::test::WsSessionFake>(taskArena, taskGroup);
+        auto session = std::make_shared<bcos::cppsdk::test::WsSessionFake>(ioServicePool);
         task->setSession(session);
 
         std::string resp = "{}";
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(test_EventSub_unsubscribeEvent)
 
     {
         // task is running
-        auto session = std::make_shared<bcos::cppsdk::test::WsSessionFake>(taskArena, taskGroup);
+        auto session = std::make_shared<bcos::cppsdk::test::WsSessionFake>(ioServicePool);
 
         task->setSession(session);
 
@@ -209,6 +209,8 @@ BOOST_AUTO_TEST_CASE(test_EventSub_unsubscribeEvent)
         BOOST_CHECK(!es->getTask(id));
         BOOST_CHECK_EQUAL(es->suspendTasksCount(), 0);
     }
+
+    ioServicePool->stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-sdk/tests/unittests/fake/WsSessionFake.h
+++ b/bcos-sdk/tests/unittests/fake/WsSessionFake.h
@@ -22,7 +22,7 @@
 #include <bcos-boostssl/websocket/WsMessage.h>
 #include <bcos-boostssl/websocket/WsSession.h>
 #include <bcos-utilities/Common.h>
-#include <oneapi/tbb/task_arena.h>
+#include <bcos-utilities/IOServicePool.h>
 
 namespace bcos
 {
@@ -33,8 +33,8 @@ namespace test
 class WsSessionFake : public bcos::boostssl::ws::WsSession
 {
 public:
-    WsSessionFake(tbb::task_arena& taskArena, tbb::task_group& taskGroup)
-      : bcos::boostssl::ws::WsSession(taskArena, taskGroup)
+    WsSessionFake(IOServicePool::Ptr ioServicePool)
+      : bcos::boostssl::ws::WsSession(std::move(ioServicePool))
     {
         WEBSOCKET_SESSION(INFO) << LOG_KV("[NEWOBJ][WSSESSION]", this);
     }

--- a/bcos-utilities/bcos-utilities/IOServicePool.cpp
+++ b/bcos-utilities/bcos-utilities/IOServicePool.cpp
@@ -61,14 +61,19 @@ void IOServicePool::stop()
     }
     m_running = false;
 
-    // 1. Reset work to release keep-alive, allowing io_context to exit naturally after all tasks
-    // are finished
+    // 1. Reset work to release keep-alive, allowing io_context to exit when no handlers remain
     for (auto& work : m_works)
     {
         work.reset();
     }
 
-    // 2. Do not call stop() on ioService, let run() return automatically when no tasks remain
+    // 2. Signal all io_contexts to stop. This causes run() to return after finishing
+    //    currently queued handlers. Without this, recurring timers/callbacks would
+    //    keep run() alive indefinitely, causing join() to hang.
+    for (auto& ioService : m_ioServices)
+    {
+        ioService->stop();
+    }
 
     // 3. Wait for all threads to exit
     for (auto& thread : m_threads)

--- a/bcos-utilities/bcos-utilities/IOServicePool.cpp
+++ b/bcos-utilities/bcos-utilities/IOServicePool.cpp
@@ -61,16 +61,16 @@ void IOServicePool::stop()
     }
     m_running = false;
 
+    // 1. Reset work to release keep-alive, allowing io_context to exit naturally after all tasks
+    // are finished
     for (auto& work : m_works)
     {
         work.reset();
     }
 
-    for (auto& ioService : m_ioServices)
-    {
-        ioService->stop();
-    }
+    // 2. Do not call stop() on ioService, let run() return automatically when no tasks remain
 
+    // 3. Wait for all threads to exit
     for (auto& thread : m_threads)
     {
         if (thread.joinable())

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -91,6 +91,7 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
         m_nodeInitializer->protocolInitializer()->getKeyEncryptionByType(
             nodeConfig->keyEncryptionType()));
     rpcFactory.setNodeConfig(nodeConfig);
+    rpcFactory.setIOServicePool(ioServicePool);
     m_rpc = rpcFactory.buildLocalRpc(groupInfo, nodeService);
     if (gateway->amop())
     {

--- a/fisco-bcos-demo/echo_client_sample.cpp
+++ b/fisco-bcos-demo/echo_client_sample.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
     auto msg = std::dynamic_pointer_cast<P2PMessage>(service->messageFactory()->buildMessage());
     msg->setPacketType(999);
     std::string randStr(payLoadSize, 'a');
-    msg->setPayload(std::make_shared<bytes>(randStr.begin(), randStr.end()));
+    msg->setPayload(bcos::bytes(randStr.begin(), randStr.end()));
     auto rateLimiter = std::make_shared<RateLimiter>(packetQPS);
     sendMessage(serverEndPoint, msg, service, rateLimiter);
     return EXIT_SUCCESS;


### PR DESCRIPTION
Refactor the code to replace the use of `tbb::task_group` and `tbb::task_arena` with `IOServicePool`, simplifying the threading model and improving service initialization. Fix tests related to these changes.