### PR TITLE
Implement checkpoint storage for RocksDB

### DIFF
--- a/bcos-storage/CMakeLists.txt
+++ b/bcos-storage/CMakeLists.txt
@@ -25,6 +25,8 @@ target_include_directories(storage PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-storage>)
 target_link_libraries(storage PUBLIC ${LIB_LIST})
+set_source_files_properties(
+  "bcos-storage/CheckpointRocksDBStorage.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(storage PROPERTIES UNITY_BUILD "ON")
 
 if (APPLE)

--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
@@ -1,47 +1,40 @@
 #include "bcos-storage/CheckpointRocksDBStorage.h"
-#include "bcos-utilities/Exceptions.h"
-#include <rocksdb/options.h>
+#include <rocksdb/utilities/checkpoint.h>
 #include <boost/throw_exception.hpp>
 #include <filesystem>
+#include <optional>
 
 namespace bcos::storage2::rocksdb
 {
-
-CheckpointRocksDBStorage::CheckpointRocksDBStorage(std::string_view rootDir)
-  : m_path(std::filesystem::path(rootDir).lexically_normal().string())
-{}
-
-const std::string& CheckpointRocksDBStorage::path() const noexcept
+namespace
 {
-    return m_path;
+std::string resolveCheckpointsPath(std::string_view rootDir)
+{
+    auto path = std::filesystem::path(rootDir) / "checkpoints";
+    return path.lexically_normal().string();
 }
 
-std::string CheckpointRocksDBStorage::latestPath() const
+std::optional<bcos::h256> parseCheckpointName(std::string const& checkpointName)
 {
-    return resolveLatestPath(m_path);
+    try
+    {
+        return bcos::h256(checkpointName);
+    }
+    catch (...)
+    {
+        return std::nullopt;
+    }
 }
+}  // namespace
 
-std::string CheckpointRocksDBStorage::checkpointPath(std::string_view checkpointName) const
+namespace detail
 {
-    return resolveCheckpointPath(m_path, checkpointName);
-}
-
-std::unique_ptr<::rocksdb::DB> CheckpointRocksDBStorage::open(
-    LatestCheckpointStorageTag latestTag) const
-{
-    return openRocksDB(resolveLatestPath(m_path), latestOptions(latestTag));
-}
-
-std::unique_ptr<::rocksdb::DB> CheckpointRocksDBStorage::open(std::string_view checkpointName) const
-{
-    return openRocksDB(resolveCheckpointPath(m_path, checkpointName), checkpointOptions());
-}
-
-std::unique_ptr<::rocksdb::DB> CheckpointRocksDBStorage::openRocksDB(
-    const std::string& path, const ::rocksdb::Options& options)
+std::unique_ptr<::rocksdb::DB> openCheckpointRocksDB(
+    const std::string& path, const ::rocksdb::Options& options, bool readOnly)
 {
     ::rocksdb::DB* rocksDB = nullptr;
-    auto status = ::rocksdb::DB::Open(options, path, &rocksDB);
+    auto status = readOnly ? ::rocksdb::DB::OpenForReadOnly(options, path, &rocksDB) :
+                             ::rocksdb::DB::Open(options, path, &rocksDB);
     if (!status.ok())
     {
         BOOST_THROW_EXCEPTION(
@@ -51,32 +44,126 @@ std::unique_ptr<::rocksdb::DB> CheckpointRocksDBStorage::openRocksDB(
     return std::unique_ptr<::rocksdb::DB>(rocksDB);
 }
 
-::rocksdb::Options CheckpointRocksDBStorage::latestOptions(LatestCheckpointStorageTag /*latestTag*/)
+::rocksdb::Options latestCheckpointOptions()
 {
     ::rocksdb::Options options;
     options.create_if_missing = true;
     return options;
 }
 
-::rocksdb::Options CheckpointRocksDBStorage::checkpointOptions()
+::rocksdb::Options historicalCheckpointOptions()
 {
     ::rocksdb::Options options;
     options.create_if_missing = false;
     return options;
 }
 
-std::string CheckpointRocksDBStorage::resolveLatestPath(std::string_view rootDir)
+void ensureCheckpointDirectories(std::string_view rootDir)
+{
+    auto normalizedRoot = std::filesystem::path(rootDir).lexically_normal();
+    std::filesystem::create_directories(normalizedRoot);
+    std::filesystem::create_directories(normalizedRoot / "checkpoints");
+}
+
+std::string resolveLatestCheckpointPath(std::string_view rootDir)
 {
     auto path = std::filesystem::path(rootDir) / "latest";
     return path.lexically_normal().string();
 }
 
-std::string CheckpointRocksDBStorage::resolveCheckpointPath(
-    std::string_view rootDir, std::string_view checkpointName)
+std::string resolveHistoricalCheckpointPath(
+    std::string_view rootDir, bcos::h256 const& checkpointName)
 {
-    auto path =
-        std::filesystem::path(rootDir) / "checkpoints" / std::filesystem::path(checkpointName);
+    auto path = std::filesystem::path(rootDir) / "checkpoints" /
+                std::filesystem::path(checkpointName.hex());
     return path.lexically_normal().string();
 }
 
+void createHistoricalCheckpoint(
+    ::rocksdb::DB& latestStorage, std::string_view rootDir, bcos::h256 const& checkpointName)
+{
+    auto path = resolveHistoricalCheckpointPath(rootDir, checkpointName);
+    if (std::filesystem::exists(path))
+    {
+        BOOST_THROW_EXCEPTION(CheckpointRocksDBException{} << bcos::errinfo_comment(
+                                  "Checkpoint already exists: " + checkpointName.hex()));
+    }
+
+    ::rocksdb::Checkpoint* rawCheckpoint = nullptr;
+    auto status = ::rocksdb::Checkpoint::Create(&latestStorage, &rawCheckpoint);
+    if (!status.ok())
+    {
+        BOOST_THROW_EXCEPTION(
+            CheckpointRocksDBException{} << bcos::errinfo_comment(
+                "Create rocksdb checkpoint handler failed, error: " + status.ToString()));
+    }
+
+    std::unique_ptr<::rocksdb::Checkpoint> checkpointGuard(rawCheckpoint);
+    status = checkpointGuard->CreateCheckpoint(path);
+    if (!status.ok())
+    {
+        BOOST_THROW_EXCEPTION(CheckpointRocksDBException{} << bcos::errinfo_comment(
+                                  "Create rocksdb checkpoint failed, path: " + path +
+                                  ", error: " + status.ToString()));
+    }
+}
+
+void deleteHistoricalCheckpoint(std::string_view rootDir, bcos::h256 const& checkpointName)
+{
+    std::error_code errorCode;
+    std::filesystem::remove_all(
+        resolveHistoricalCheckpointPath(rootDir, checkpointName), errorCode);
+    if (errorCode)
+    {
+        BOOST_THROW_EXCEPTION(CheckpointRocksDBException{} << bcos::errinfo_comment(
+                                  "Delete checkpoint failed, name: " + checkpointName.hex() +
+                                  ", error: " + errorCode.message()));
+    }
+}
+
+std::optional<bcos::h256> findCheckpointByTime(std::string_view rootDir, bool latest)
+{
+    std::error_code errorCode;
+    auto checkpointsPath = resolveCheckpointsPath(rootDir);
+    if (!std::filesystem::exists(checkpointsPath, errorCode) || errorCode)
+    {
+        return std::nullopt;
+    }
+
+    std::optional<std::pair<bcos::h256, std::filesystem::file_time_type>> selected;
+    for (auto const& entry : std::filesystem::directory_iterator(checkpointsPath, errorCode))
+    {
+        if (errorCode)
+        {
+            break;
+        }
+
+        if (!entry.is_directory(errorCode) || errorCode)
+        {
+            errorCode.clear();
+            continue;
+        }
+
+        auto checkpoint = parseCheckpointName(entry.path().filename().string());
+        if (!checkpoint)
+        {
+            continue;
+        }
+
+        auto time = entry.last_write_time(errorCode);
+        if (errorCode)
+        {
+            errorCode.clear();
+            continue;
+        }
+
+        if (!selected || (latest ? time > selected->second : time < selected->second))
+        {
+            selected = std::make_pair(*checkpoint, time);
+        }
+    }
+
+    return selected ? std::make_optional(selected->first) : std::nullopt;
+}
+}  // namespace detail
 }  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include "bcos-storage/RocksDBStorage2.h"
 #include "bcos-utilities/Exceptions.h"
+#include "bcos-utilities/FixedBytes.h"
 #include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -11,39 +16,95 @@ namespace bcos::storage2::rocksdb
 
 DERIVE_BCOS_EXCEPTION(CheckpointRocksDBException);
 
-inline constexpr struct LatestCheckpointStorageTag
+namespace detail
 {
-} latestCheckpointStorage;
+std::unique_ptr<::rocksdb::DB> openCheckpointRocksDB(
+    const std::string& path, const ::rocksdb::Options& options, bool readOnly);
 
+::rocksdb::Options latestCheckpointOptions();
+
+::rocksdb::Options historicalCheckpointOptions();
+
+void ensureCheckpointDirectories(std::string_view rootDir);
+
+std::string resolveLatestCheckpointPath(std::string_view rootDir);
+
+std::string resolveHistoricalCheckpointPath(
+    std::string_view rootDir, bcos::h256 const& checkpointName);
+
+void createHistoricalCheckpoint(
+    ::rocksdb::DB& latestStorage, std::string_view rootDir, bcos::h256 const& checkpointName);
+
+void deleteHistoricalCheckpoint(std::string_view rootDir, bcos::h256 const& checkpointName);
+
+std::optional<bcos::h256> findCheckpointByTime(std::string_view rootDir, bool latest);
+}  // namespace detail
+
+template <class KeyType, class ValueType, Resolver<KeyType> KeyResolver,
+    Resolver<ValueType> ValueResolver>
 class CheckpointRocksDBStorage
 {
 public:
-    explicit CheckpointRocksDBStorage(std::string_view rootDir);
+    using Storage = RocksDBStorage2<KeyType, ValueType, KeyResolver, ValueResolver>;
+    using CheckpointName = bcos::h256;
 
-    const std::string& path() const noexcept;
+    explicit CheckpointRocksDBStorage(
+        std::string_view rootDir, KeyResolver keyResolver = {}, ValueResolver valueResolver = {})
+      : m_path(std::filesystem::path(rootDir).lexically_normal().string()),
+        m_keyResolver(std::move(keyResolver)),
+        m_valueResolver(std::move(valueResolver))
+    {
+        detail::ensureCheckpointDirectories(m_path);
+    }
 
-    std::string latestPath() const;
+    const std::string& path() const noexcept { return m_path; }
 
-    std::string checkpointPath(std::string_view checkpointName) const;
+    std::string latestPath() const { return detail::resolveLatestCheckpointPath(m_path); }
 
-    std::unique_ptr<::rocksdb::DB> open(LatestCheckpointStorageTag latestTag) const;
+    std::string checkpointPath(CheckpointName const& checkpointName) const
+    {
+        return detail::resolveHistoricalCheckpointPath(m_path, checkpointName);
+    }
 
-    std::unique_ptr<::rocksdb::DB> open(std::string_view checkpointName) const;
+    Storage open()
+    {
+        return Storage(detail::openCheckpointRocksDB(detail::resolveLatestCheckpointPath(m_path),
+                           detail::latestCheckpointOptions(), false),
+            m_keyResolver, m_valueResolver);
+    }
+
+    Storage open(CheckpointName const& checkpointName)
+    {
+        return Storage(detail::openCheckpointRocksDB(
+                           detail::resolveHistoricalCheckpointPath(m_path, checkpointName),
+                           detail::historicalCheckpointOptions(), true),
+            m_keyResolver, m_valueResolver);
+    }
+
+    void createCheckpoint(Storage& latestStorage, CheckpointName const& checkpointName)
+    {
+        detail::createHistoricalCheckpoint(latestStorage.rocksDB(), m_path, checkpointName);
+    }
+
+    void deleteCheckpoint(CheckpointName const& checkpointName)
+    {
+        detail::deleteHistoricalCheckpoint(m_path, checkpointName);
+    }
+
+    std::optional<CheckpointName> latestCheckpointName() const
+    {
+        return detail::findCheckpointByTime(m_path, true);
+    }
+
+    std::optional<CheckpointName> oldestCheckpointName() const
+    {
+        return detail::findCheckpointByTime(m_path, false);
+    }
 
 private:
-    static std::unique_ptr<::rocksdb::DB> openRocksDB(
-        const std::string& path, const ::rocksdb::Options& options);
-
-    static ::rocksdb::Options latestOptions(LatestCheckpointStorageTag latestTag);
-
-    static ::rocksdb::Options checkpointOptions();
-
-    static std::string resolveLatestPath(std::string_view rootDir);
-
-    static std::string resolveCheckpointPath(
-        std::string_view rootDir, std::string_view checkpointName);
-
     std::string m_path;
+    [[no_unique_address]] KeyResolver m_keyResolver;
+    [[no_unique_address]] ValueResolver m_valueResolver;
 };
 
 }  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/RocksDBStorage2.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage2.h
@@ -29,19 +29,46 @@ template <class KeyType, class ValueType, Resolver<KeyType> KeyResolver,
 class RocksDBStorage2
 {
 private:
-    std::reference_wrapper<::rocksdb::DB> m_rocksDB;
+    std::variant<std::reference_wrapper<::rocksdb::DB>, std::unique_ptr<::rocksdb::DB>> m_rocksDB;
     [[no_unique_address]] KeyResolver m_keyResolver;
     [[no_unique_address]] ValueResolver m_valueResolver;
 
+    ::rocksdb::DB& rocksDBRef() noexcept
+    {
+        return std::visit(
+            [](auto& handle) -> ::rocksdb::DB& {
+                using Handle = std::decay_t<decltype(handle)>;
+                if constexpr (std::is_same_v<Handle, std::reference_wrapper<::rocksdb::DB>>)
+                {
+                    return handle.get();
+                }
+                else
+                {
+                    return *handle;
+                }
+            },
+            m_rocksDB);
+    }
+
 public:
     RocksDBStorage2(::rocksdb::DB& rocksDB) : m_rocksDB(rocksDB) {}
+    RocksDBStorage2(std::unique_ptr<::rocksdb::DB> rocksDB) : m_rocksDB(std::move(rocksDB)) {}
     RocksDBStorage2(::rocksdb::DB& rocksDB, KeyResolver keyResolver, ValueResolver valueResolver)
       : m_rocksDB(rocksDB),
         m_keyResolver(std::move(keyResolver)),
         m_valueResolver(std::move(valueResolver))
     {}
+    RocksDBStorage2(std::unique_ptr<::rocksdb::DB> rocksDB, KeyResolver keyResolver,
+        ValueResolver valueResolver)
+      : m_rocksDB(std::move(rocksDB)),
+        m_keyResolver(std::move(keyResolver)),
+        m_valueResolver(std::move(valueResolver))
+    {}
     using Key = KeyType;
     using Value = ValueType;
+
+    ::rocksdb::DB& rocksDB() noexcept { return rocksDBRef(); }
+    ::rocksdb::DB const& rocksDB() const noexcept { return rocksDBRef(); }
 
     auto readSomeRaw(::ranges::input_range auto keys, auto&&... /*args*/)
         -> task::Task<std::vector<StorageValueType<ValueType>>>
@@ -56,7 +83,7 @@ public:
         auto rocksDBKeys = encodedKeys | ::ranges::views::transform([](const auto& encodedKey) {
             return ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey));
         }) | ::ranges::to<std::vector>();
-        m_rocksDB.get().MultiGet(::rocksdb::ReadOptions(), m_rocksDB.get().DefaultColumnFamily(),
+        rocksDBRef().MultiGet(::rocksdb::ReadOptions(), rocksDBRef().DefaultColumnFamily(),
             rocksDBKeys.size(), rocksDBKeys.data(), results.data(), status.data());
 
         auto values =
@@ -84,9 +111,8 @@ public:
 
         auto encodedKey = m_keyResolver.encode(std::move(key));
         ::rocksdb::PinnableSlice result;
-        auto status =
-            m_rocksDB.get().Get(::rocksdb::ReadOptions(), m_rocksDB.get().DefaultColumnFamily(),
-                ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey)), &result);
+        auto status = rocksDBRef().Get(::rocksdb::ReadOptions(), rocksDBRef().DefaultColumnFamily(),
+            ::rocksdb::Slice(::ranges::data(encodedKey), ::ranges::size(encodedKey)), &result);
 
         if (!status.ok())
         {
@@ -136,7 +162,7 @@ public:
         }
 
         ::rocksdb::WriteOptions options;
-        if (auto status = m_rocksDB.get().Write(options, std::addressof(writeBatch)); !status.ok())
+        if (auto status = rocksDBRef().Write(options, std::addressof(writeBatch)); !status.ok())
         {
             BOOST_THROW_EXCEPTION(RocksDBException{} << errinfo_comment(status.ToString()));
         }
@@ -149,7 +175,7 @@ public:
         auto rocksDBValue = m_valueResolver.encode(value);
 
         ::rocksdb::WriteOptions options;
-        if (auto status = m_rocksDB.get().Put(options,
+        if (auto status = rocksDBRef().Put(options,
                 ::rocksdb::Slice(::ranges::data(rocksDBKey), ::ranges::size(rocksDBKey)),
                 ::rocksdb::Slice(::ranges::data(rocksDBValue), ::ranges::size(rocksDBValue)));
             !status.ok())
@@ -171,7 +197,7 @@ public:
         }
 
         ::rocksdb::WriteOptions options;
-        if (auto status = m_rocksDB.get().Write(options, &writeBatch); !status.ok())
+        if (auto status = rocksDBRef().Write(options, &writeBatch); !status.ok())
         {
             BOOST_THROW_EXCEPTION(RocksDBException{} << errinfo_comment(status.ToString()));
         }
@@ -212,7 +238,7 @@ public:
 
         co_await writeToBatch(*currentWriteBatch, fromStorage...);
         ::rocksdb::WriteOptions options;
-        auto status = m_rocksDB.get().Write(options, currentWriteBatch.get());
+        auto status = rocksDBRef().Write(options, currentWriteBatch.get());
 
         currentWriteBatch->Clear();
         if (!writeBatch || currentWriteBatch->Data().capacity() > writeBatch->Data().capacity())
@@ -231,7 +257,7 @@ public:
     private:
         const ::rocksdb::Snapshot* m_snapshot;
         std::unique_ptr<::rocksdb::Iterator> m_iterator;
-        const RocksDBStorage2* m_storage;
+        RocksDBStorage2* m_storage;
 
     public:
         Iterator(const Iterator&) = delete;
@@ -254,14 +280,14 @@ public:
             return *this;
         }
         Iterator(const ::rocksdb::Snapshot* snapshot, ::rocksdb::Iterator* iterator,
-            const RocksDBStorage2* storage)
+            RocksDBStorage2* storage)
           : m_snapshot(snapshot), m_iterator(iterator), m_storage(storage)
         {}
         ~Iterator() noexcept
         {
             if (m_snapshot != nullptr && m_storage != nullptr)
             {
-                m_storage->m_rocksDB.get().ReleaseSnapshot(m_snapshot);
+                m_storage->rocksDBRef().ReleaseSnapshot(m_snapshot);
             }
         }
 
@@ -283,10 +309,10 @@ public:
     static task::AwaitableValue<Iterator> rangeImpl(
         RocksDBStorage2& storage, const ::rocksdb::Slice* startSlice = nullptr)
     {
-        const auto* snapshot = storage.m_rocksDB.get().GetSnapshot();
+        const auto* snapshot = storage.rocksDBRef().GetSnapshot();
         ::rocksdb::ReadOptions readOptions;
         readOptions.snapshot = snapshot;
-        auto* iterator = storage.m_rocksDB.get().NewIterator(readOptions);
+        auto* iterator = storage.rocksDBRef().NewIterator(readOptions);
         if (startSlice != nullptr)
         {
             iterator->Seek(*startSlice);

--- a/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
@@ -21,6 +21,9 @@ using namespace bcos::storage2::rocksdb;
 using namespace bcos::executor_v1;
 using namespace std::string_view_literals;
 
+using TestCheckpointStorage =
+    CheckpointRocksDBStorage<StateKey, StateValue, StateKeyResolver, StateValueResolver>;
+
 struct TestRocksDBStorage2Fixture
 {
     std::string path = "./rocksdbtestdb" + std::to_string(std::random_device{}());
@@ -236,43 +239,72 @@ BOOST_AUTO_TEST_CASE(merge)
 BOOST_AUTO_TEST_CASE(openLatestOrCheckpointByDirectory)
 {
     auto root = path + "_checkpoint_root";
-    CheckpointRocksDBStorage checkpointRocksDBStorage(root);
+    TestCheckpointStorage checkpointRocksDBStorage(root, StateKeyResolver{}, StateValueResolver{});
     auto latestPath = checkpointRocksDBStorage.latestPath();
-    auto checkpointName = std::string("blockHash123");
-    auto checkpointPath = checkpointRocksDBStorage.checkpointPath(checkpointName);
-
-    populate(latestPath, "sys"sv, "key"sv, "latest-value"sv);
-    populate(checkpointPath, "sys"sv, "key"sv, "checkpoint-value"sv);
+    auto firstCheckpointName = h256("1111111111111111111111111111111111111111111111111111111111111111");
+    auto secondCheckpointName = h256("2222222222222222222222222222222222222222222222222222222222222222");
+    auto firstCheckpointPath = checkpointRocksDBStorage.checkpointPath(firstCheckpointName);
+    auto secondCheckpointPath = checkpointRocksDBStorage.checkpointPath(secondCheckpointName);
 
     task::syncWait([&]() -> task::Task<void> {
-        auto latestDB = checkpointRocksDBStorage.open(latestCheckpointStorage);
-        RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver> latestStorage(
-            *latestDB, StateKeyResolver{}, StateValueResolver{});
-        auto latestValue =
-            co_await storage2::readOne(latestStorage, StateKey{"sys"sv, "key"sv});
+        auto latestStorage = checkpointRocksDBStorage.open();
+        co_await storage2::writeOne(
+            latestStorage, StateKey{"sys"sv, "key"sv}, storage::Entry("latest-value-1"));
+        auto latestValue = co_await storage2::readOne(latestStorage, StateKey{"sys"sv, "key"sv});
         BOOST_REQUIRE(latestValue);
-        BOOST_CHECK_EQUAL(latestValue->get(), "latest-value");
+        BOOST_CHECK_EQUAL(latestValue->get(), "latest-value-1");
         BOOST_CHECK_EQUAL(checkpointRocksDBStorage.latestPath(), latestPath);
+        BOOST_CHECK(!checkpointRocksDBStorage.latestCheckpointName());
+        BOOST_CHECK(!checkpointRocksDBStorage.oldestCheckpointName());
 
-        {
-            auto checkpointDB = checkpointRocksDBStorage.open(checkpointName);
-            RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver>
-                checkpointStorage(*checkpointDB, StateKeyResolver{}, StateValueResolver{});
-            auto checkpointValue = co_await storage2::readOne(
-                checkpointStorage, StateKey{"sys"sv, "key"sv});
-            BOOST_REQUIRE(checkpointValue);
-            BOOST_CHECK_EQUAL(checkpointValue->get(), "checkpoint-value");
-            BOOST_CHECK_EQUAL(checkpointRocksDBStorage.checkpointPath(checkpointName), checkpointPath);
-        }
+        checkpointRocksDBStorage.createCheckpoint(latestStorage, firstCheckpointName);
+        auto firstCheckpointTime = std::filesystem::file_time_type::clock::now();
+        std::filesystem::last_write_time(firstCheckpointPath, firstCheckpointTime);
+        BOOST_REQUIRE(checkpointRocksDBStorage.latestCheckpointName());
+        BOOST_REQUIRE(checkpointRocksDBStorage.oldestCheckpointName());
+        BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.latestCheckpointName(), firstCheckpointName);
+        BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.oldestCheckpointName(), firstCheckpointName);
 
-        auto checkpointDBByBlock = checkpointRocksDBStorage.open("blockHash123"sv);
-        RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver>
-            checkpointStorageByBlock(*checkpointDBByBlock, StateKeyResolver{}, StateValueResolver{});
-        auto checkpointValueByBlock = co_await storage2::readOne(
-            checkpointStorageByBlock, StateKey{"sys"sv, "key"sv});
-        BOOST_REQUIRE(checkpointValueByBlock);
-        BOOST_CHECK_EQUAL(checkpointValueByBlock->get(), "checkpoint-value");
-        BOOST_CHECK_EQUAL(checkpointRocksDBStorage.checkpointPath("blockHash123"sv), checkpointPath);
+        auto firstCheckpointStorage = checkpointRocksDBStorage.open(firstCheckpointName);
+        auto firstCheckpointValue = co_await storage2::readOne(
+            firstCheckpointStorage, StateKey{"sys"sv, "key"sv});
+        BOOST_REQUIRE(firstCheckpointValue);
+        BOOST_CHECK_EQUAL(firstCheckpointValue->get(), "latest-value-1");
+        BOOST_CHECK_EQUAL(
+            checkpointRocksDBStorage.checkpointPath(firstCheckpointName), firstCheckpointPath);
+
+        co_await storage2::writeOne(
+            latestStorage, StateKey{"sys"sv, "key"sv}, storage::Entry("latest-value-2"));
+        checkpointRocksDBStorage.createCheckpoint(latestStorage, secondCheckpointName);
+        auto secondCheckpointTime = firstCheckpointTime + std::chrono::seconds(1);
+        std::filesystem::last_write_time(secondCheckpointPath, secondCheckpointTime);
+        BOOST_REQUIRE(checkpointRocksDBStorage.latestCheckpointName());
+        BOOST_REQUIRE(checkpointRocksDBStorage.oldestCheckpointName());
+        BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.latestCheckpointName(), secondCheckpointName);
+        BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.oldestCheckpointName(), firstCheckpointName);
+
+        auto secondCheckpointStorage = checkpointRocksDBStorage.open(secondCheckpointName);
+        auto secondCheckpointValue = co_await storage2::readOne(
+            secondCheckpointStorage, StateKey{"sys"sv, "key"sv});
+        BOOST_REQUIRE(secondCheckpointValue);
+        BOOST_CHECK_EQUAL(secondCheckpointValue->get(), "latest-value-2");
+        BOOST_CHECK_EQUAL(
+            checkpointRocksDBStorage.checkpointPath(secondCheckpointName), secondCheckpointPath);
+
+        auto latestValueAfterSecondCheckpoint =
+            co_await storage2::readOne(latestStorage, StateKey{"sys"sv, "key"sv});
+        BOOST_REQUIRE(latestValueAfterSecondCheckpoint);
+        BOOST_CHECK_EQUAL(latestValueAfterSecondCheckpoint->get(), "latest-value-2");
+
+        checkpointRocksDBStorage.deleteCheckpoint(firstCheckpointName);
+        BOOST_REQUIRE(checkpointRocksDBStorage.latestCheckpointName());
+        BOOST_REQUIRE(checkpointRocksDBStorage.oldestCheckpointName());
+        BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.latestCheckpointName(), secondCheckpointName);
+        BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.oldestCheckpointName(), secondCheckpointName);
+
+        checkpointRocksDBStorage.deleteCheckpoint(secondCheckpointName);
+        BOOST_CHECK(!checkpointRocksDBStorage.latestCheckpointName());
+        BOOST_CHECK(!checkpointRocksDBStorage.oldestCheckpointName());
 
         co_return;
     }());


### PR DESCRIPTION
Introduce a new `CheckpointRocksDBStorage` class to manage checkpointing in RocksDB, including methods for creating, deleting, and resolving checkpoints. Update existing storage classes to accommodate the new functionality.