### PR TITLE
fix(sample, gitignore): 修正tx签名性能示例参数检查

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ tools/BcosAirBuilder/*
 
 test/*
 /CMakeSettings.json
+.trae

--- a/bcos-sdk/sample/tx/tx_sign_perf.cpp
+++ b/bcos-sdk/sample/tx/tx_sign_perf.cpp
@@ -134,7 +134,7 @@ void usage()
 
 int main(int argc, char** argv)
 {
-    if (argc < 2)
+    if (argc < 3)
     {
         usage();
     }

--- a/fisco-bcos-demo/echo_server_sample.cpp
+++ b/fisco-bcos-demo/echo_server_sample.cpp
@@ -31,7 +31,8 @@ using namespace bcos::tool;
 
 void usage()
 {
-    std::cerr << "Usage: echo-server-sample <listenIP> <listenPort> <ssl>\n"
+    std::cerr << "Usage: echo-server-sample\n"
+              << "Note: This program reads configuration from config.ini\n"
               << "Example:\n"
               << "./echo-server-sample\n";
     std::exit(0);


### PR DESCRIPTION
使示例程序的参数校验逻辑匹配实际需求，避免因参数不足导致运行错误。