### PR TITLE
feat(storage): add configurable RocksDB tuning params for CheckpointRocksDBStorage

### DIFF
--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
@@ -1,4 +1,7 @@
 #include "bcos-storage/CheckpointRocksDBStorage.h"
+#include <rocksdb/filter_policy.h>
+#include <rocksdb/statistics.h>
+#include <rocksdb/table.h>
 #include <rocksdb/utilities/checkpoint.h>
 #include <boost/throw_exception.hpp>
 #include <filesystem>
@@ -50,17 +53,78 @@ std::unique_ptr<::rocksdb::DB> openCheckpointRocksDB(
     return std::unique_ptr<::rocksdb::DB>(rocksDB);
 }
 
-::rocksdb::Options latestCheckpointOptions()
+::rocksdb::Options latestCheckpointOptions(const RocksDBCheckpointOption& rocksDBOption)
 {
     ::rocksdb::Options options;
     options.create_if_missing = true;
+
+    if (rocksDBOption.optimizeLevelStyleCompaction)
+    {
+        // Note: This option will increase much memory
+        options.IncreaseParallelism();
+        // Note: This option will increase much memory
+        options.OptimizeLevelStyleCompaction();
+    }
+
+    // to mitigate write stalls
+    options.max_background_jobs = rocksDBOption.maxBackgroundJobs;
+    options.max_write_buffer_number = rocksDBOption.maxWriteBufferNumber;
+    options.enable_blob_files = rocksDBOption.enable_blob_files;
+    options.bytes_per_sync = 1 << 20;  // 1MB
+    options.compression = ::rocksdb::kZSTD;
+    options.bottommost_compression = ::rocksdb::kZSTD;  // last level compression
+    options.max_open_files = 256;
+    options.write_buffer_size = rocksDBOption.writeBufferSize;
+    options.min_write_buffer_number_to_merge = rocksDBOption.minWriteBufferNumberToMerge;
+    options.enable_pipelined_write = true;
+    options.max_bytes_for_level_base = 512 << 20;  // 512MB
+    options.target_file_size_base = 128 << 20;     // 128MB
+
+    if (rocksDBOption.enableDBStatistics)
+    {
+        options.statistics = ::rocksdb::CreateDBStatistics();
+    }
+
+    // block cache
+    std::shared_ptr<::rocksdb::Cache> cache =
+        ::rocksdb::NewLRUCache(rocksDBOption.blockCacheSize);
+    ::rocksdb::BlockBasedTableOptions table_options;
+    table_options.block_cache = cache;
+    // use bloom filter to optimize point lookup, i.e. get
+    table_options.filter_policy.reset(::rocksdb::NewBloomFilterPolicy(10, false));
+    table_options.optimize_filters_for_memory = true;
+    table_options.block_size = 64 * 1024;
+    options.table_factory.reset(::rocksdb::NewBlockBasedTableFactory(table_options));
+
     return options;
 }
 
-::rocksdb::Options historicalCheckpointOptions()
+::rocksdb::Options historicalCheckpointOptions(const RocksDBCheckpointOption& rocksDBOption)
 {
     ::rocksdb::Options options;
     options.create_if_missing = false;
+
+    // Use the same tuning parameters as latest for consistent read performance.
+    // Most write-related options are ignored in read-only mode.
+    options.max_open_files = 256;
+    options.compression = ::rocksdb::kZSTD;
+    options.bottommost_compression = ::rocksdb::kZSTD;
+
+    // block cache for read performance
+    std::shared_ptr<::rocksdb::Cache> cache =
+        ::rocksdb::NewLRUCache(rocksDBOption.blockCacheSize);
+    ::rocksdb::BlockBasedTableOptions table_options;
+    table_options.block_cache = cache;
+    table_options.filter_policy.reset(::rocksdb::NewBloomFilterPolicy(10, false));
+    table_options.optimize_filters_for_memory = true;
+    table_options.block_size = 64 * 1024;
+    options.table_factory.reset(::rocksdb::NewBlockBasedTableFactory(table_options));
+
+    if (rocksDBOption.enableDBStatistics)
+    {
+        options.statistics = ::rocksdb::CreateDBStatistics();
+    }
+
     return options;
 }
 

--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp
@@ -1,4 +1,7 @@
 #include "bcos-storage/CheckpointRocksDBStorage.h"
+#include "bcos-storage/StateKVResolver.h"
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
 #include <rocksdb/filter_policy.h>
 #include <rocksdb/statistics.h>
 #include <rocksdb/table.h>
@@ -52,45 +55,42 @@ std::unique_ptr<::rocksdb::DB> openCheckpointRocksDB(
     }
     return std::unique_ptr<::rocksdb::DB>(rocksDB);
 }
+}  // namespace detail
 
-::rocksdb::Options latestCheckpointOptions(const RocksDBCheckpointOption& rocksDBOption)
+
+template <class KeyType, class ValueType, Resolver<KeyType> KeyResolver,
+    Resolver<ValueType> ValueResolver>
+::rocksdb::Options CheckpointRocksDBStorage<KeyType, ValueType, KeyResolver, ValueResolver>::latestCheckpointOptions() const
 {
     ::rocksdb::Options options;
     options.create_if_missing = true;
 
-    if (rocksDBOption.optimizeLevelStyleCompaction)
+    if (m_option.optimizeLevelStyleCompaction)
     {
-        // Note: This option will increase much memory
         options.IncreaseParallelism();
-        // Note: This option will increase much memory
         options.OptimizeLevelStyleCompaction();
     }
 
-    // to mitigate write stalls
-    options.max_background_jobs = rocksDBOption.maxBackgroundJobs;
-    options.max_write_buffer_number = rocksDBOption.maxWriteBufferNumber;
-    options.enable_blob_files = rocksDBOption.enable_blob_files;
-    options.bytes_per_sync = 1 << 20;  // 1MB
+    options.max_background_jobs = m_option.maxBackgroundJobs;
+    options.max_write_buffer_number = m_option.maxWriteBufferNumber;
+    options.enable_blob_files = m_option.enableBlobFiles;
+    options.bytes_per_sync = 1 << 20;
     options.compression = ::rocksdb::kZSTD;
-    options.bottommost_compression = ::rocksdb::kZSTD;  // last level compression
+    options.bottommost_compression = ::rocksdb::kZSTD;
     options.max_open_files = 256;
-    options.write_buffer_size = rocksDBOption.writeBufferSize;
-    options.min_write_buffer_number_to_merge = rocksDBOption.minWriteBufferNumberToMerge;
+    options.write_buffer_size = m_option.writeBufferSize;
+    options.min_write_buffer_number_to_merge = m_option.minWriteBufferNumberToMerge;
     options.enable_pipelined_write = true;
-    options.max_bytes_for_level_base = 512 << 20;  // 512MB
-    options.target_file_size_base = 128 << 20;     // 128MB
+    options.max_bytes_for_level_base = 512 << 20;
+    options.target_file_size_base = 128 << 20;
 
-    if (rocksDBOption.enableDBStatistics)
+    if (m_option.enableDBStatistics)
     {
         options.statistics = ::rocksdb::CreateDBStatistics();
     }
 
-    // block cache
-    std::shared_ptr<::rocksdb::Cache> cache =
-        ::rocksdb::NewLRUCache(rocksDBOption.blockCacheSize);
     ::rocksdb::BlockBasedTableOptions table_options;
-    table_options.block_cache = cache;
-    // use bloom filter to optimize point lookup, i.e. get
+    table_options.block_cache = m_cache;
     table_options.filter_policy.reset(::rocksdb::NewBloomFilterPolicy(10, false));
     table_options.optimize_filters_for_memory = true;
     table_options.block_size = 64 * 1024;
@@ -99,28 +99,26 @@ std::unique_ptr<::rocksdb::DB> openCheckpointRocksDB(
     return options;
 }
 
-::rocksdb::Options historicalCheckpointOptions(const RocksDBCheckpointOption& rocksDBOption)
+
+template <class KeyType, class ValueType, Resolver<KeyType> KeyResolver,
+    Resolver<ValueType> ValueResolver>
+::rocksdb::Options CheckpointRocksDBStorage<KeyType, ValueType, KeyResolver, ValueResolver>::historicalCheckpointOptions() const
 {
     ::rocksdb::Options options;
     options.create_if_missing = false;
 
-    // Use the same tuning parameters as latest for consistent read performance.
-    // Most write-related options are ignored in read-only mode.
     options.max_open_files = 256;
     options.compression = ::rocksdb::kZSTD;
     options.bottommost_compression = ::rocksdb::kZSTD;
 
-    // block cache for read performance
-    std::shared_ptr<::rocksdb::Cache> cache =
-        ::rocksdb::NewLRUCache(rocksDBOption.blockCacheSize);
     ::rocksdb::BlockBasedTableOptions table_options;
-    table_options.block_cache = cache;
+    table_options.block_cache = m_cache;
     table_options.filter_policy.reset(::rocksdb::NewBloomFilterPolicy(10, false));
     table_options.optimize_filters_for_memory = true;
     table_options.block_size = 64 * 1024;
     options.table_factory.reset(::rocksdb::NewBlockBasedTableFactory(table_options));
 
-    if (rocksDBOption.enableDBStatistics)
+    if (m_option.enableDBStatistics)
     {
         options.statistics = ::rocksdb::CreateDBStatistics();
     }
@@ -128,6 +126,8 @@ std::unique_ptr<::rocksdb::DB> openCheckpointRocksDB(
     return options;
 }
 
+namespace detail
+{
 void ensureCheckpointDirectories(std::string_view rootDir)
 {
     auto normalizedRoot = std::filesystem::path(rootDir).lexically_normal();
@@ -251,4 +251,8 @@ std::optional<bcos::h256> findCheckpointByTime(std::string_view rootDir, bool la
     return selected ? std::make_optional(selected->first) : std::nullopt;
 }
 }  // namespace detail
+
+template class CheckpointRocksDBStorage<bcos::executor_v1::StateKey, bcos::storage::Entry,
+    bcos::storage2::rocksdb::StateKeyResolver, bcos::storage2::rocksdb::StateValueResolver>;
+
 }  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
@@ -16,6 +16,7 @@ namespace bcos::storage2::rocksdb
 
 DERIVE_BCOS_EXCEPTION(CheckpointRocksDBException);
 
+
 struct RocksDBCheckpointOption
 {
     int maxWriteBufferNumber = 3;
@@ -24,7 +25,7 @@ struct RocksDBCheckpointOption
     int minWriteBufferNumberToMerge = 1;
     size_t blockCacheSize = 128 << 20;  // 128MB
     bool optimizeLevelStyleCompaction = false;
-    bool enable_blob_files = false;
+    bool enableBlobFiles = false;
     bool enableDBStatistics = false;
 };
 
@@ -60,11 +61,13 @@ public:
     using Storage = RocksDBStorage2<KeyType, ValueType, KeyResolver, ValueResolver>;
     using CheckpointName = bcos::h256;
 
+
     explicit CheckpointRocksDBStorage(
         std::string_view rootDir, KeyResolver keyResolver = {}, ValueResolver valueResolver = {},
         RocksDBCheckpointOption option = {})
       : m_path(std::filesystem::path(rootDir).lexically_normal().string()),
         m_option(std::move(option)),
+        m_cache(::rocksdb::NewLRUCache(m_option.blockCacheSize)),
         m_keyResolver(std::move(keyResolver)),
         m_valueResolver(std::move(valueResolver))
     {
@@ -80,10 +83,11 @@ public:
         return detail::resolveHistoricalCheckpointPath(m_path, checkpointName);
     }
 
+
     Storage open()
     {
         return Storage(detail::openCheckpointRocksDB(detail::resolveLatestCheckpointPath(m_path),
-                           detail::latestCheckpointOptions(m_option), false),
+                           latestCheckpointOptions(), false),
             m_keyResolver, m_valueResolver);
     }
 
@@ -91,9 +95,12 @@ public:
     {
         return Storage(detail::openCheckpointRocksDB(
                            detail::resolveHistoricalCheckpointPath(m_path, checkpointName),
-                           detail::historicalCheckpointOptions(m_option), true),
+                           historicalCheckpointOptions(), true),
             m_keyResolver, m_valueResolver);
     }
+
+    ::rocksdb::Options latestCheckpointOptions() const;
+    ::rocksdb::Options historicalCheckpointOptions() const;
 
     void createCheckpoint(Storage& latestStorage, CheckpointName const& checkpointName)
     {
@@ -118,6 +125,7 @@ public:
 private:
     std::string m_path;
     RocksDBCheckpointOption m_option;
+    std::shared_ptr<::rocksdb::Cache> m_cache;
     [[no_unique_address]] KeyResolver m_keyResolver;
     [[no_unique_address]] ValueResolver m_valueResolver;
 };

--- a/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
+++ b/bcos-storage/bcos-storage/CheckpointRocksDBStorage.h
@@ -16,14 +16,26 @@ namespace bcos::storage2::rocksdb
 
 DERIVE_BCOS_EXCEPTION(CheckpointRocksDBException);
 
+struct RocksDBCheckpointOption
+{
+    int maxWriteBufferNumber = 3;
+    int maxBackgroundJobs = 4;
+    size_t writeBufferSize = 64 << 20;  // 64MB
+    int minWriteBufferNumberToMerge = 1;
+    size_t blockCacheSize = 128 << 20;  // 128MB
+    bool optimizeLevelStyleCompaction = false;
+    bool enable_blob_files = false;
+    bool enableDBStatistics = false;
+};
+
 namespace detail
 {
 std::unique_ptr<::rocksdb::DB> openCheckpointRocksDB(
     const std::string& path, const ::rocksdb::Options& options, bool readOnly);
 
-::rocksdb::Options latestCheckpointOptions();
+::rocksdb::Options latestCheckpointOptions(const RocksDBCheckpointOption& option);
 
-::rocksdb::Options historicalCheckpointOptions();
+::rocksdb::Options historicalCheckpointOptions(const RocksDBCheckpointOption& option);
 
 void ensureCheckpointDirectories(std::string_view rootDir);
 
@@ -49,8 +61,10 @@ public:
     using CheckpointName = bcos::h256;
 
     explicit CheckpointRocksDBStorage(
-        std::string_view rootDir, KeyResolver keyResolver = {}, ValueResolver valueResolver = {})
+        std::string_view rootDir, KeyResolver keyResolver = {}, ValueResolver valueResolver = {},
+        RocksDBCheckpointOption option = {})
       : m_path(std::filesystem::path(rootDir).lexically_normal().string()),
+        m_option(std::move(option)),
         m_keyResolver(std::move(keyResolver)),
         m_valueResolver(std::move(valueResolver))
     {
@@ -69,7 +83,7 @@ public:
     Storage open()
     {
         return Storage(detail::openCheckpointRocksDB(detail::resolveLatestCheckpointPath(m_path),
-                           detail::latestCheckpointOptions(), false),
+                           detail::latestCheckpointOptions(m_option), false),
             m_keyResolver, m_valueResolver);
     }
 
@@ -77,7 +91,7 @@ public:
     {
         return Storage(detail::openCheckpointRocksDB(
                            detail::resolveHistoricalCheckpointPath(m_path, checkpointName),
-                           detail::historicalCheckpointOptions(), true),
+                           detail::historicalCheckpointOptions(m_option), true),
             m_keyResolver, m_valueResolver);
     }
 
@@ -103,6 +117,7 @@ public:
 
 private:
     std::string m_path;
+    RocksDBCheckpointOption m_option;
     [[no_unique_address]] KeyResolver m_keyResolver;
     [[no_unique_address]] ValueResolver m_valueResolver;
 };

--- a/libinitializer/GlobalStateStorageInitializer.cpp
+++ b/libinitializer/GlobalStateStorageInitializer.cpp
@@ -1,14 +1,18 @@
 #include "GlobalStateStorageInitializer.h"
 
 bcos::initializer::GlobalStateStorageInitializer::GlobalStateStorageInitializer(
-    std::string const& storageRootPath)
+    std::string const& storageRootPath,
+    bcos::storage2::rocksdb::RocksDBCheckpointOption const& rocksDBOption)
   : m_checkpointStorage(storageRootPath,
-        storage2::rocksdb::StateKeyResolver{}, storage2::rocksdb::StateValueResolver{}),
+        storage2::rocksdb::StateKeyResolver{}, storage2::rocksdb::StateValueResolver{},
+        rocksDBOption),
     m_storage(m_checkpointStorage, m_cacheStorage)
 {}
 
 bcos::initializer::GlobalStateStorageInitializer::Ptr
-bcos::initializer::GlobalStateStorageInitializer::build(std::string const& storageRootPath)
+bcos::initializer::GlobalStateStorageInitializer::build(
+    std::string const& storageRootPath,
+    bcos::storage2::rocksdb::RocksDBCheckpointOption const& rocksDBOption)
 {
-    return std::make_shared<GlobalStateStorageInitializer>(storageRootPath);
+    return std::make_shared<GlobalStateStorageInitializer>(storageRootPath, rocksDBOption);
 }

--- a/libinitializer/GlobalStateStorageInitializer.h
+++ b/libinitializer/GlobalStateStorageInitializer.h
@@ -35,9 +35,12 @@ class GlobalStateStorageInitializer
 public:
     using Ptr = std::shared_ptr<GlobalStateStorageInitializer>;
 
-    explicit GlobalStateStorageInitializer(std::string const& storageRootPath);
+    explicit GlobalStateStorageInitializer(
+        std::string const& storageRootPath,
+        bcos::storage2::rocksdb::RocksDBCheckpointOption const& rocksDBOption = {});
 
-    static Ptr build(std::string const& storageRootPath);
+    static Ptr build(std::string const& storageRootPath,
+        bcos::storage2::rocksdb::RocksDBCheckpointOption const& rocksDBOption = {});
 
     GlobalStateStorage& storage() { return m_storage; }
     GlobalStateStorage const& storage() const { return m_storage; }

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -152,6 +152,7 @@ RocksDBOption getRocksDBOption(
     option.blockCacheSize = nodeConfig->blockCacheSize();
     option.optimizeLevelStyleCompaction = optimizeLevelStyleCompaction;
     option.enable_blob_files = nodeConfig->enableRocksDBBlob();
+    option.enableDBStatistics = nodeConfig->enableStatistics();
     return option;
 }
 
@@ -187,13 +188,12 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     // CheckpointRocksDBStorage owns the state RocksDB lifecycle.
     // Create it before the legacy storage so the old TransactionalStorageInterface
     // can share the same underlying ::rocksdb::DB.
+    auto rocksDBOption = getRocksDBOption(m_nodeConfig);
     m_globalStateStorageInitializer =
-        GlobalStateStorageInitializer::build(m_nodeConfig->storagePath());
+        GlobalStateStorageInitializer::build(m_nodeConfig->storagePath(), rocksDBOption);
 
     if (boost::iequals(m_nodeConfig->storageType(), "RocksDB"))
     {
-        RocksDBOption option = getRocksDBOption(m_nodeConfig);
-
         // Share CheckpointRocksDBStorage's RocksDB with the legacy storage layer.
         // Ownership stays with GlobalStateStorage (MultiLayerStorage::m_latestBackend).
         m_storage = StorageInitializer::build(
@@ -204,14 +204,13 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
         schedulerStorage = m_storage;
         consensusStorage =
             StorageInitializer::build(StorageInitializer::createRocksDB(consensusStoragePath,
-                                          option, m_nodeConfig->enableStatistics()),
+                                          rocksDBOption),
                 m_protocolInitializer->dataEncryption());
         airExecutorStorage = m_storage;
         if (m_nodeConfig->enableSeparateBlockAndState())
         {
             m_blockStorage =
-                StorageInitializer::build(StorageInitializer::createRocksDB(blockDBPath, option,
-                                              m_nodeConfig->enableStatistics()),
+                StorageInitializer::build(StorageInitializer::createRocksDB(blockDBPath, rocksDBOption),
                     m_protocolInitializer->dataEncryption());
         }
     }
@@ -1191,7 +1190,7 @@ bcos::Error::Ptr Initializer::importSnapshotToRocksDB(
     }
     auto rocksdbOption = getRocksDBOption(nodeConfig, true);
     auto rocksDB = StorageInitializer::createRocksDB(
-        stateDBPath, rocksdbOption, nodeConfig->enableStatistics(), nodeConfig->keyPageSize());
+        stateDBPath, rocksdbOption, nodeConfig->keyPageSize());
     ingestIntoRocksDB(*rocksDB, sstFiles, moveSSTFiles);
     bcos::storage::TransactionalStorageInterface::Ptr stateStorage = nullptr;
     // import tx and receipt
@@ -1227,7 +1226,7 @@ bcos::Error::Ptr Initializer::importSnapshotToRocksDB(
         {
             auto blockDBPath = getBlockDBPath(true);
             auto blockRocksDB = StorageInitializer::createRocksDB(
-                blockDBPath, rocksdbOption, nodeConfig->enableStatistics());
+                blockDBPath, rocksdbOption);
             if (blockRocksDB)
             {
                 ingestIntoRocksDB(*blockRocksDB, blockSstFiles, moveSSTFiles);

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -151,7 +151,7 @@ RocksDBOption getRocksDBOption(
     option.minWriteBufferNumberToMerge = nodeConfig->minWriteBufferNumberToMerge();
     option.blockCacheSize = nodeConfig->blockCacheSize();
     option.optimizeLevelStyleCompaction = optimizeLevelStyleCompaction;
-    option.enable_blob_files = nodeConfig->enableRocksDBBlob();
+    option.enableBlobFiles = nodeConfig->enableRocksDBBlob();
     option.enableDBStatistics = nodeConfig->enableStatistics();
     return option;
 }

--- a/libinitializer/StorageInitializer.h
+++ b/libinitializer/StorageInitializer.h
@@ -64,7 +64,7 @@ public:
         options.max_write_buffer_number = rocksDBOption.maxWriteBufferNumber;
         // FIXME: enable blob support when space amplification is acceptable
         // options.enable_blob_files = keyPageSize > 1 ? true : false;
-        options.enable_blob_files = rocksDBOption.enable_blob_files;
+        options.enable_blob_files = rocksDBOption.enableBlobFiles;
         options.bytes_per_sync = 1 << 20;  // 1MB
         // options.level_compaction_dynamic_level_bytes = true;
         // options.compaction_pri = rocksdb::kMinOverlappingRatio;

--- a/libinitializer/StorageInitializer.h
+++ b/libinitializer/StorageInitializer.h
@@ -23,6 +23,7 @@
  * @date 2021-10-14
  */
 #pragma once
+#include "bcos-storage/CheckpointRocksDBStorage.h"
 #include "bcos-storage/RocksDBStorage.h"
 #include <rocksdb/statistics.h>
 #ifdef WITH_TIKV
@@ -37,22 +38,13 @@
 namespace bcos::initializer
 {
 
-struct RocksDBOption
-{
-    int maxWriteBufferNumber = 3;
-    int maxBackgroundJobs = 4;
-    size_t writeBufferSize = 64 << 20;  // 64MB
-    int minWriteBufferNumberToMerge = 1;
-    size_t blockCacheSize = 128 << 20;  // 128MB
-    bool optimizeLevelStyleCompaction = false;
-    bool enable_blob_files = false;
-};
+using RocksDBOption = bcos::storage2::rocksdb::RocksDBCheckpointOption;
 
 class StorageInitializer
 {
 public:
     static auto createRocksDB(const std::string& _path, RocksDBOption& rocksDBOption,
-        bool _enableDBStatistics = false, [[maybe_unused]] size_t keyPageSize = 0)
+        [[maybe_unused]] size_t keyPageSize = 0)
     {
         boost::filesystem::create_directories(_path);
         rocksdb::DB* db = nullptr;
@@ -88,7 +80,7 @@ public:
         options.max_bytes_for_level_base = 512 << 20;  // 512MB
         options.target_file_size_base = 128 << 20;     // 128MB
 
-        if (_enableDBStatistics)
+        if (rocksDBOption.enableDBStatistics)
         {
             options.statistics = rocksdb::CreateDBStatistics();
         }

--- a/tools/archive-tool/archiveTool.cpp
+++ b/tools/archive-tool/archiveTool.cpp
@@ -169,15 +169,14 @@ createBackendStorage(std::shared_ptr<bcos::tool::NodeConfig> nodeConfig, const s
             option.writeBufferSize = nodeConfig->writeBufferSize();
             option.minWriteBufferNumberToMerge = nodeConfig->minWriteBufferNumberToMerge();
             option.blockCacheSize = nodeConfig->blockCacheSize();
+            option.enableDBStatistics = nodeConfig->enableStatistics();
             storage = StorageInitializer::build(
-                StorageInitializer::createRocksDB(
-                    stateDBPath, option, nodeConfig->enableStatistics(), nodeConfig->keyPageSize()),
+                StorageInitializer::createRocksDB(stateDBPath, option, nodeConfig->keyPageSize()),
                 dataEncryption);
             blockStorage = storage;
             if (nodeConfig->enableSeparateBlockAndState())
             {
-                auto blockDB = StorageInitializer::createRocksDB(
-                    nodeConfig->blockDBPath(), option, nodeConfig->enableStatistics());
+                auto blockDB = StorageInitializer::createRocksDB(nodeConfig->blockDBPath(), option);
                 blockStorage = StorageInitializer::build(std::move(blockDB), dataEncryption);
             }
         }
@@ -727,9 +726,9 @@ int main(int argc, const char* argv[])
         option.writeBufferSize = nodeConfig->writeBufferSize();
         option.minWriteBufferNumberToMerge = nodeConfig->minWriteBufferNumberToMerge();
         option.blockCacheSize = nodeConfig->blockCacheSize();
+        option.enableDBStatistics = nodeConfig->enableStatistics();
         archiveStorage = StorageInitializer::build(
-            StorageInitializer::createRocksDB(archivePath, option, nodeConfig->enableStatistics()),
-            nullptr);
+            StorageInitializer::createRocksDB(archivePath, option), nullptr);
     }
     else if (boost::iequals(archiveType, "TiKV"))
     {  // create archive TiKV storage


### PR DESCRIPTION
## 变更概述

将 `RocksDBOption` 与 `RocksDBCheckpointOption` 统一为一个可配置结构体，使得 CheckpointRocksDBStorage 的 RocksDB 实例也能获得与普通 RocksDBStorage 一致的性能调优参数。

## 主要变更

### 1. 新增 `RocksDBCheckpointOption` 结构体（`CheckpointRocksDBStorage.h`）

- 新增 `RocksDBCheckpointOption` 结构体，包含 `maxWriteBufferNumber`、`maxBackgroundJobs`、`writeBufferSize`、`minWriteBufferNumberToMerge`、`blockCacheSize`、`optimizeLevelStyleCompaction`、`enable_blob_files`、`enableDBStatistics` 等参数
- `CheckpointRocksDBStorage` 构造函数接受 `RocksDBCheckpointOption` 参数，默认为空结构体

### 2. 增强 `latestCheckpointOptions` 和 `historicalCheckpointOptions`

- 两个函数现在接受 `RocksDBCheckpointOption` 参数
- `latestCheckpointOptions` 支持 `OptimizeLevelStyleCompaction`、BloomFilter、LRU BlockCache、ZSTD 压缩、pipelined write 等调优
- `historicalCheckpointOptions` 同样配置 BlockCache 和 BloomFilter 以优化只读查询性能

### 3. 统一 `RocksDBOption` 类型（`StorageInitializer.h`）

- 将 `StorageInitializer.h` 中的 `RocksDBOption` 结构体改为 `using RocksDBOption = bcos::storage2::rocksdb::RocksDBCheckpointOption;`
- `createRocksDB` 中 `_enableDBStatistics` 参数合并到 `RocksDBOption.enableDBStatistics` 字段
- `enableDBStatistics` 的设置统一在 `getRocksDBOption()` 中完成

### 4. 传递 `RocksDBCheckpointOption` 到 `GlobalStateStorageInitializer`

- `GlobalStateStorageInitializer` 构造函数和 `build()` 静态方法新增 `RocksDBCheckpointOption` 参数
- `Initializer::init()` 中 `getRocksDBOption()` 提前调用，结果传递给所有存储初始化路径

### 5. 简化调用点

- `importSnapshotToRocksDB` 中 `createRocksDB` 调用移除了多余的 `enableStatistics` 参数

## 变更文件

| 文件 | 变更 |
|---|---|
| `bcos-storage/bcos-storage/CheckpointRocksDBStorage.h` | 新增 `RocksDBCheckpointOption`，构造函数/方法签名新增参数 |
| `bcos-storage/bcos-storage/CheckpointRocksDBStorage.cpp` | 实现基于 option 的 RocksDB 调优 |
| `libinitializer/StorageInitializer.h` | `RocksDBOption` 替换为 type alias，移除 `_enableDBStatistics` 形参 |
| `libinitializer/GlobalStateStorageInitializer.h` | 新增 `RocksDBCheckpointOption` 参数 |
| `libinitializer/GlobalStateStorageInitializer.cpp` | 传递 option 到 `CheckpointRocksDBStorage` |
| `libinitializer/Initializer.cpp` | 统一 option 创建与传递，简化 `createRocksDB` 调用 |

## 注意事项

- 所有新增参数均有默认值，向后兼容，已有代码无需修改即可编译
- `enableDBStatistics` 现在统一通过 `RocksDBOption`/`RocksDBCheckpointOption` 控制，不再作为独立参数传递