### PR TITLE
Strip vcpkg debug symbols and decouple newLegacyEVMAddress from evmc_address type

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -161,6 +161,10 @@ jobs:
         run: |
           cd tools
           bash .ci/ci_check_air.sh ${{ github.base_ref }} "true"
+      - name: Strip debug symbols from vcpkg static libs
+        if: matrix.os != 'windows-2025'
+        run: |
+          find build/vcpkg_installed -path "*/debug/*" \( -name "*.a" -o -name "*.dylib" \) -print -exec strip --strip-debug {} \; 2>/dev/null || true
       - name: Set packaging variables
         if: github.event_name == 'release' && matrix.os != 'windows-2025'
         id: pkgvars

--- a/bcos-crypto/bcos-crypto/ChecksumAddress.cpp
+++ b/bcos-crypto/bcos-crypto/ChecksumAddress.cpp
@@ -118,7 +118,7 @@ std::string newEVMAddress(
     return newEVMAddress(*_hashImpl, blockNumber, contextID, seq);
 }
 
-evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept
+std::array<bcos::byte, 20> newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept
 {
     codec::rlp::Header header{.isList = true, .payloadLength = 1 + sender.size()};
     header.payloadLength += codec::rlp::length(nonce);
@@ -127,8 +127,8 @@ evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexce
     codec::rlp::encode(rlp, sender);
     codec::rlp::encode(rlp, nonce);
     auto hash = bcos::crypto::keccak256Hash(ref(rlp));
-    evmc_address address;
-    std::uninitialized_copy(hash.begin() + 12, hash.end(), address.bytes);
+    std::array<bcos::byte, 20> address;
+    std::uninitialized_copy(hash.begin() + 12, hash.end(), address.begin());
 
     return address;
 }
@@ -136,7 +136,7 @@ evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexce
 std::string newLegacyEVMAddressString(bytesConstRef sender, const u256& nonce) noexcept
 {
     auto address = newLegacyEVMAddress(sender, nonce);
-    auto view = std::span{address.bytes};
+    auto view = std::span{address};
     std::string out;
     out.reserve(view.size() * 2);
     boost::algorithm::hex_lower(view.begin(), view.end(), std::back_inserter(out));

--- a/bcos-crypto/bcos-crypto/ChecksumAddress.h
+++ b/bcos-crypto/bcos-crypto/ChecksumAddress.h
@@ -22,7 +22,7 @@
 
 #include <bcos-crypto/interfaces/crypto/Hash.h>
 #include <bcos-utilities/Common.h>
-#include <evmc/evmc.h>
+#include <array>
 #include <string>
 #include <string_view>
 
@@ -50,7 +50,7 @@ std::string newEVMAddress(
     const bcos::crypto::Hash::Ptr& _hashImpl, int64_t blockNumber, int64_t contextID, int64_t seq);
 
 // keccak256(rlp.encode([normalize_address(sender), nonce]))[12:]
-evmc_address newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept;
+std::array<bcos::byte, 20> newLegacyEVMAddress(bytesConstRef sender, const u256& nonce) noexcept;
 
 std::string newLegacyEVMAddressString(bytesConstRef sender, const u256& nonce) noexcept;
 

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
@@ -32,7 +32,7 @@
 using namespace bcos;
 using namespace bcos::crypto;
 
-static const std::unique_ptr<secp256k1_context, decltype(&secp256k1_context_destroy)>
+static const std::unique_ptr<secp256k1_context, void (*)(secp256k1_context*)>
     g_SECP256K1_CTX{secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY),
         &secp256k1_context_destroy};
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
@@ -26,6 +26,7 @@
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/Exceptions.h"
 #include <boost/endian/conversion.hpp>
+#include <range/v3/view/transform.hpp>
 
 DERIVE_BCOS_EXCEPTION(EmptyBlockHeaderHash);
 
@@ -70,7 +71,8 @@ void bcostars::protocol::BlockHeaderImpl::clear()
     m_inner()->resetDefautlt();
 }
 
-::ranges::any_view<bcos::protocol::ParentInfo, ::ranges::category::input | ::ranges::category::sized>
+::ranges::any_view<bcos::protocol::ParentInfo,
+    ::ranges::category::input | ::ranges::category::sized>
 bcostars::protocol::BlockHeaderImpl::parentInfo() const
 {
     return m_inner()->data.parentInfo |

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.cpp
@@ -31,8 +31,10 @@ evmc_message bcos::executor_v1::hostcontext::getMessage(bool web3Tx,
             }
             else
             {
-                message.code_address =
+                auto legacyAddr =
                     newLegacyEVMAddress(bytesConstRef(message.sender.bytes), nonce);
+                std::copy(
+                    legacyAddr.begin(), legacyAddr.end(), message.code_address.bytes);
             }
         }
         message.recipient = message.code_address;

--- a/transaction-executor/tests/TestTransactionExecutor.cpp
+++ b/transaction-executor/tests/TestTransactionExecutor.cpp
@@ -400,7 +400,9 @@ BOOST_AUTO_TEST_CASE(web3Nonce)
 
         std::string hexHelloworldAddress(receipt->contractAddress());
         auto helloworldAddress = unhexAddress(hexHelloworldAddress);
-        auto expectAddress = newLegacyEVMAddress(bytesConstRef{helloworldAddress.bytes}, 1);
+        auto rawExpectAddr = newLegacyEVMAddress(bytesConstRef{helloworldAddress.bytes}, 1);
+        evmc_address expectAddress;
+        std::copy(rawExpectAddr.begin(), rawExpectAddr.end(), expectAddress.bytes);
         ledger::account::EVMAccount expectAccount(storage, expectAddress, false);
 
         auto input = abiCodec.abiIn("deployAndCall(int256)", bcos::s256(90));
@@ -453,8 +455,10 @@ BOOST_AUTO_TEST_CASE(web3Nonce)
 
         for (auto i : ::ranges::views::iota(1, 11))
         {
-            auto expectAddress =
+            auto rawAddr =
                 newLegacyEVMAddress(bytesConstRef{address1.data(), address1.size()}, i);
+            evmc_address expectAddress;
+            std::copy(rawAddr.begin(), rawAddr.end(), expectAddress.bytes);
             ledger::account::EVMAccount account(storage, expectAddress, false);
             BOOST_TEST(co_await account.exists());
             BOOST_TEST((co_await account.nonce()).value() == "1");


### PR DESCRIPTION
## 改动说明

### 1. CI：Strip vcpkg 静态库调试符号
在 CI 工作流中新增步骤，对 `build/vcpkg_installed` 下 debug 目录中的 `.a` 和 `.dylib` 静态库执行 `strip --strip-debug`，以减小最终二进制体积。

### 2. ChecksumAddress 解耦 evmc 类型依赖
将 `newLegacyEVMAddress` 的返回类型从 `evmc_address` 改为 `std::array<bcos::byte, 20>`，并移除了对 `<evmc/evmc.h>` 头文件的直接依赖。这使得 `bcos-crypto` 模块不再需要依赖 evmc 库的类型定义，降低模块间耦合度。

### 3. 适配调用方
- `bcos-transaction-executor/vm/HostContext.cpp`：通过 `std::copy` 将 `std::array` 结果复制到 `evmc_address.bytes`
- `transaction-executor/tests/TestTransactionExecutor.cpp`：测试代码同步适配新返回类型

### 变更文件
| 文件 | 变更 |
|------|------|
| `.github/workflows/workflow.yml` | 新增 strip debug symbols 步骤 |
| `bcos-crypto/bcos-crypto/ChecksumAddress.h` | 返回类型改为 `std::array`，移除 evmc 头文件 |
| `bcos-crypto/bcos-crypto/ChecksumAddress.cpp` | 适配新返回类型 |
| `transaction-executor/.../HostContext.cpp` | 调用侧适配 |
| `transaction-executor/tests/TestTransactionExecutor.cpp` | 测试侧适配 |