### PR TITLE
Refactor: Replace ThreadPool with IOServicePool and optimize buffer move semantics

### DIFF
--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -20,7 +20,6 @@
 
 #include <bcos-boostssl/context/NodeInfoTools.h>
 #include <bcos-boostssl/httpserver/HttpServer.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <memory>
 #include <utility>
 

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.h
@@ -22,7 +22,6 @@
 #include <bcos-boostssl/httpserver/HttpQueue.h>
 #include <bcos-boostssl/httpserver/HttpStream.h>
 #include <bcos-utilities/BoostLog.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/ssl/stream.hpp>
 #include <boost/asio/strand.hpp>

--- a/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsInitializer.cpp
@@ -30,7 +30,6 @@
 #include <bcos-boostssl/websocket/WsTools.h>
 #include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/IOServicePool.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <boost/system/detail/error_code.hpp>
 
 using namespace bcos;

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
@@ -25,7 +25,6 @@
 #include <bcos-boostssl/websocket/WsSession.h>
 #include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/Common.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <json/json.h>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/case_conv.hpp>

--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.h
@@ -30,7 +30,6 @@
 #include <bcos-boostssl/websocket/WsStream.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/IOServicePool.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/strand.hpp>

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.cpp
@@ -24,7 +24,6 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/IOServicePool.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <boost/asio/post.hpp>
 #include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/beast/websocket/stream.hpp>
@@ -32,7 +31,6 @@
 #include <chrono>
 #include <exception>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <utility>
 
@@ -227,10 +225,9 @@ void WsSession::drop(WsError _reason)
             WEBSOCKET_SESSION(TRACE)
                 << LOG_DESC("the session has been disconnected") << LOG_KV("seq", cbEntry.first);
 
-            m_ioServicePool->dispatch(
-                [callback = std::move(callback), error]() mutable {
-                    callback->respCallBack(error, nullptr, nullptr);
-                });
+            m_ioServicePool->dispatch([callback = std::move(callback), error]() mutable {
+                callback->respCallBack(error, nullptr, nullptr);
+            });
         }
     }
 
@@ -328,15 +325,14 @@ void WsSession::onReadPacket()
         m_buffer->consume(m_buffer->size());
 
         auto self = weak_from_this();
-        m_ioServicePool->post(
-            [self, message = std::move(message)]() {
-                auto session = self.lock();
-                if (!session)
-                {
-                    return;
-                }
-                session->onMessage(message);
-            });
+        m_ioServicePool->post([self, message = std::move(message)]() {
+            auto session = self.lock();
+            if (!session)
+            {
+                return;
+            }
+            session->onMessage(message);
+        });
     }
     catch (std::exception const& e)
     {
@@ -632,8 +628,7 @@ void WsSession::onRespTimeout(const boost::system::error_code& _error, const std
 
     auto error = BCOS_ERROR_PTR(WsError::TimeOut, "waiting for message response timed out");
 
-    m_ioServicePool->post(
-        [callback = std::move(callback), error = std::move(error)]() mutable {
-            callback->respCallBack(error, nullptr, nullptr);
-        });
+    m_ioServicePool->post([callback = std::move(callback), error = std::move(error)]() mutable {
+        callback->respCallBack(error, nullptr, nullptr);
+    });
 }

--- a/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsSession.h
@@ -27,7 +27,6 @@
 #include <bcos-boostssl/websocket/WsStream.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/IOServicePool.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <bcos-utilities/Timer.h>
 #include <boost/asio/post.hpp>
 #include <boost/asio/steady_timer.hpp>

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -35,9 +35,9 @@
 namespace
 {
 template <class Task>
-void postToIOServicePool(bcos::IOServicePool& ioServicePool, Task&& task)
+void dispatchTo(bcos::IOServicePool& ioServicePool, Task&& task)
 {
-    ioServicePool.post(std::forward<Task>(task));
+    ioServicePool.dispatch(std::forward<Task>(task));
 }
 }  // namespace
 
@@ -308,7 +308,7 @@ void FrontService::asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInf
                             (groupNodeInfo ? groupNodeInfo->nodeIDList().size() : 0));
     if (_onGetGroupNodeInfo)
     {
-        postToIOServicePool(
+        dispatchTo(
             *m_ioServicePool, [_onGetGroupNodeInfo = std::move(_onGetGroupNodeInfo),
                                   groupNodeInfo = std::move(groupNodeInfo)]() mutable {
                 _onGetGroupNodeInfo(nullptr, groupNodeInfo);
@@ -454,7 +454,7 @@ void FrontService::onReceiveGroupNodeInfo(const std::string& _groupID,
                            (_groupNodeInfo ? _groupNodeInfo->nodeIDList().size() : 0));
 
     auto self = weak_from_this();
-    postToIOServicePool(
+    dispatchTo(
         *m_ioServicePool, [self, _groupID, _groupNodeInfo = std::move(_groupNodeInfo)]() mutable {
             if (auto frontService = self.lock())
             {
@@ -558,7 +558,7 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
 
     // Copy the payload before dispatching asynchronously.
     auto buffer = bytes(_payLoad.begin(), _payLoad.end());
-    postToIOServicePool(
+    dispatchTo(
         *m_ioServicePool, [_uuid, _error = std::move(_error), callback = std::move(callback),
                               buffer = std::move(buffer), _nodeID = std::move(_nodeID),
                               respFunc = std::move(respFunc)]() mutable {
@@ -610,7 +610,8 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
                 // Copy the payload before dispatching asynchronously.
                 bytes buffer(message.payload().begin(), message.payload().end());
 
-                postToIOServicePool(
+                // dispatch to io service pool
+                dispatchTo(
                     *m_ioServicePool, [uuid, callback = std::move(callback),
                                           buffer = std::move(buffer), _nodeID]() mutable {
                         callback(_nodeID, uuid, bytesConstRef(buffer.data(), buffer.size()));
@@ -631,7 +632,7 @@ void FrontService::onReceiveMessage(const std::string& _groupID,
 
     if (_receiveMsgCallback)
     {
-        postToIOServicePool(
+        dispatchTo(
             *m_ioServicePool, [_receiveMsgCallback = std::move(_receiveMsgCallback)]() mutable {
                 _receiveMsgCallback(nullptr);
             });
@@ -708,7 +709,7 @@ void FrontService::onMessageTimeout(const boost::system::error_code& _error,
         if (callback)
         {
             auto errorPtr = BCOS_ERROR_PTR(CommonError::TIMEOUT, "timeout");
-            postToIOServicePool(*m_ioServicePool,
+            dispatchTo(*m_ioServicePool,
                 [_uuid, _nodeID = std::move(_nodeID), callback = std::move(callback),
                     errorPtr = std::move(errorPtr)]() mutable {
                     callback->callbackFunc(errorPtr, _nodeID, {}, _uuid, {});

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -24,7 +24,6 @@
 #include <bcos-framework/gateway/GroupNodeInfo.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/IOServicePool.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <boost/asio.hpp>
 
 namespace bcos::front

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -85,7 +85,6 @@ ba::io_context& Socket::ioService()
 ASIOInterface::ASIOInterface(
     IOServicePool::Ptr _ioServicePool, std::string listenHost, uint16_t listenPort)
   : m_ioServicePool(std::move(_ioServicePool)),
-    m_strand(*m_ioServicePool->getIOService()),
     m_acceptor(*m_ioServicePool->getIOService(),
         bi::tcp::endpoint(bi::make_address(listenHost), listenPort)),
     m_resolver(*m_ioServicePool->getIOService())
@@ -196,11 +195,6 @@ void ASIOInterface::setVerifyCallback(
     const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool)
 {
     socket->sslref().set_verify_callback(std::move(callback));
-}
-
-void ASIOInterface::strandPost(Base_Handler handler)
-{
-    m_strand.post(std::move(handler), std::allocator<void>());
 }
 
 void ASIOInterface::asyncResolveConnect(

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.cpp
@@ -147,7 +147,7 @@ bi::tcp::acceptor* ASIOInterface::acceptor()
 void ASIOInterface::asyncAccept(
     const std::shared_ptr<SocketFace>& socket, Handler_Type handler, boost::system::error_code)
 {
-    m_acceptor.async_accept(socket->ref(), handler);
+    m_acceptor.async_accept(socket->ref(), std::move(handler));
 }
 
 void ASIOInterface::asyncRead(const std::shared_ptr<SocketFace>& socket,
@@ -200,7 +200,7 @@ void ASIOInterface::setVerifyCallback(
 
 void ASIOInterface::strandPost(Base_Handler handler)
 {
-    m_strand.post(handler, std::allocator<void>());
+    m_strand.post(std::move(handler), std::allocator<void>());
 }
 
 void ASIOInterface::asyncResolveConnect(

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -99,11 +99,20 @@ public:
     virtual void setVerifyCallback(
         const std::shared_ptr<SocketFace>& socket, VerifyCallback callback, bool /*unused*/ = true);
 
-    virtual void strandPost(Base_Handler handler);
+    template <class Task>
+    void dispatch(Task&& task)
+    {
+        m_ioServicePool->dispatch(std::forward<Task>(task));
+    }
+
+    template <class Task>
+    void post(Task&& task)
+    {
+        m_ioServicePool->post(std::forward<Task>(task));
+    }
 
 private:
     IOServicePool::Ptr m_ioServicePool;
-    ba::io_context::strand m_strand;
     bi::tcp::acceptor m_acceptor;
     bi::tcp::resolver m_resolver;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/ASIOInterface.h
@@ -62,28 +62,28 @@ public:
     virtual void asyncResolveConnect(
         const std::shared_ptr<SocketFace>& socket, Handler_Type handler);
 
-    void asyncWrite(const std::shared_ptr<SocketFace>& socket, const auto& buffers, auto handler)
+    void asyncWrite(const std::shared_ptr<SocketFace>& socket, auto buffers, auto handler)
     {
         auto type = m_type;
         if (socket->isConnected())
         {
             auto& ioService = socket->ioService();
-            boost::asio::post(
-                ioService, [type, socket, &buffers, handler = std::move(handler)]() mutable {
-                    switch (type)
-                    {
-                    case TCP_ONLY:
-                    {
-                        ba::async_write(socket->ref(), buffers, std::move(handler));
-                        break;
-                    }
-                    case SSL:
-                    {
-                        ba::async_write(socket->sslref(), buffers, std::move(handler));
-                        break;
-                    }
-                    }
-                });
+            boost::asio::post(ioService, [type, socket, buffers = std::move(buffers),
+                                             handler = std::move(handler)]() mutable {
+                switch (type)
+                {
+                case TCP_ONLY:
+                {
+                    ba::async_write(socket->ref(), buffers, std::move(handler));
+                    break;
+                }
+                case SSL:
+                {
+                    ba::async_write(socket->sslref(), buffers, std::move(handler));
+                    break;
+                }
+                }
+            });
         }
     }
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -626,7 +626,7 @@ void bcos::gateway::Host::setSessionCallbackManager(
 {
     m_sessionCallbackManager = std::move(sessionCallbackManager);
 }
-std::shared_ptr<ASIOInterface> bcos::gateway::Host::asioInterface() const
+const std::shared_ptr<ASIOInterface>& bcos::gateway::Host::asioInterface() const
 {
     return m_asioInterface;
 }

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -11,13 +11,12 @@
 #include "bcos-gateway/libnetwork/PeerBlackWhitelistInterface.h"
 #include "bcos-gateway/libnetwork/SessionCallback.h"
 #include "bcos-utilities/Common.h"
-#include <boost/asio/steady_timer.hpp>
+#include <openssl/x509.h>
 #include <boost/asio/ssl/stream_base.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/system/error_code.hpp>
 #include <memory>
-#include <openssl/x509.h>
 #include <string>
-#include <utility>
 
 
 namespace boost::asio::ssl
@@ -84,7 +83,7 @@ public:
     virtual void setSessionCallbackManager(
         SessionCallbackManagerInterface::Ptr sessionCallbackManager);
 
-    virtual std::shared_ptr<ASIOInterface> asioInterface() const;
+    virtual const std::shared_ptr<ASIOInterface>& asioInterface() const;
     virtual std::shared_ptr<SessionFactory> sessionFactory() const;
     virtual MessageFactory::Ptr messageFactory() const;
     virtual P2PInfo p2pInfo();

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -357,7 +357,16 @@ void Session::drop(DisconnectReason _reason)
 
     if (m_messageHandler)
     {
-        m_messageHandler(NetworkException(errorCode, errorMsg), shared_from_this(), Message::Ptr());
+        boost::asio::post(m_socket->ioService(),
+            [self = weak_from_this(), errorCode, errorMsg = std::move(errorMsg)]() {
+                auto session = self.lock();
+                if (!session)
+                {
+                    return;
+                }
+                session->m_messageHandler(
+                    NetworkException(errorCode, errorMsg), session, Message::Ptr());
+            });
     }
 
     if (m_socket->isConnected())

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -125,7 +125,7 @@ void Session::asyncSendMessage(Message::Ptr message, Options options, SessionCal
         SESSION_LOG(WARNING) << "Session inactive";
         if (callback)
         {
-            boost::asio::post(m_socket->ioService(), [callback = std::move(callback)] {
+            m_server.get().asioInterface()->dispatch([callback = std::move(callback)] {
                 callback(NetworkException(-1, "Session inactive"), Message::Ptr());
             });
         }
@@ -140,7 +140,7 @@ void Session::asyncSendMessage(Message::Ptr message, Options options, SessionCal
                              << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
         if (callback)
         {
-            boost::asio::post(m_socket->ioService(), [callback = std::move(callback)] {
+            m_server.get().asioInterface()->dispatch([callback = std::move(callback)] {
                 callback(NetworkException(-1, "Msg size overflow"), Message::Ptr());
             });
         }
@@ -157,7 +157,7 @@ void Session::asyncSendMessage(Message::Ptr message, Options options, SessionCal
             const auto& error = result.value();
             auto errorCode = error.errorCode();
             auto errorMessage = error.errorMessage();
-            boost::asio::post(m_socket->ioService(), [callback = std::move(callback), errorCode,
+            m_server.get().asioInterface()->dispatch([callback = std::move(callback), errorCode,
                                                          errorMessage = std::move(errorMessage)] {
                 callback(NetworkException((int64_t)errorCode, errorMessage), Message::Ptr());
             });
@@ -311,7 +311,7 @@ void Session::write()
                     {
                         if (payload.m_callback)
                         {
-                            boost::asio::post(session->m_socket->ioService(),
+                            session->m_server.get().asioInterface()->post(
                                 [callback = std::move(payload.m_callback), error = _error]() {
                                     callback(error);
                                 });
@@ -348,16 +348,7 @@ void Session::drop(DisconnectReason _reason)
 
     if (m_messageHandler)
     {
-        boost::asio::post(m_socket->ioService(),
-            [self = weak_from_this(), errorCode, errorMsg = std::move(errorMsg)]() {
-                auto session = self.lock();
-                if (!session)
-                {
-                    return;
-                }
-                session->m_messageHandler(
-                    NetworkException(errorCode, errorMsg), session, Message::Ptr());
-            });
+        m_messageHandler(NetworkException(errorCode, errorMsg), shared_from_this(), Message::Ptr());
     }
 
     if (m_socket->isConnected())
@@ -451,8 +442,7 @@ void Session::start()
         m_active = true;
         m_lastWriteTime.store(utcSteadyTime());
         m_lastReadTime.store(utcSteadyTime());
-        m_server.get().asioInterface()->strandPost(
-            [session = shared_from_this()] { session->doRead(); });
+        doRead();
     }
 
     auto self = weak_from_this();
@@ -617,8 +607,8 @@ bool Session::checkRead(boost::system::error_code _ec)
 
 void Session::onMessage(NetworkException const& e, Message::Ptr message)
 {
-    boost::asio::post(
-        m_socket->ioService(), [self = weak_from_this(), e, message = std::move(message)]() {
+    m_server.get().asioInterface()->post(
+        [self = weak_from_this(), e, message = std::move(message)]() {
             try
             {
                 auto session = self.lock();
@@ -692,10 +682,8 @@ void Session::onTimeout(const boost::system::error_code& error, uint32_t seq)
     {
         return;
     }
-    boost::asio::post(m_socket->ioService(), [callback = std::move(callback)]() {
-        NetworkException e(P2PExceptionType::NetworkTimeout, "NetworkTimeout");
-        callback->callback(e, Message::Ptr());
-    });
+    NetworkException e(P2PExceptionType::NetworkTimeout, "NetworkTimeout");
+    callback->callback(e, Message::Ptr());
 }
 
 void Session::checkNetworkStatus()

--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -24,6 +24,7 @@
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/Socket.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/ThreadPool.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <boost/test/unit_test.hpp>
@@ -43,7 +44,9 @@ class FakeASIO_FIB : public bcos::gateway::ASIOInterface
 {
 public:
     using Packet = std::shared_ptr<std::vector<uint8_t>>;
-    FakeASIO_FIB() : m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB", 1)) {}
+    FakeASIO_FIB()
+      : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB"), "0.0.0.0", 0),
+        m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB", 1)) {}
     ~FakeASIO_FIB() noexcept override {}
 
     void readSome(std::shared_ptr<SocketFace> socket, boost::asio::mutable_buffer buffers,
@@ -89,8 +92,8 @@ public:
         });
     }
 
-    void strandPost(Base_Handler handler) override { m_handler = handler; }
-    void stop() override { m_threadPool->stop(); }
+    void strandPost(Base_Handler handler) { m_handler = handler; }
+    void stop() { m_threadPool->stop(); }
 
     void appendRecvPacket(Packet packet) { m_recvPackets.push(packet); }
     void asyncAppendRecvPacket(Packet packet)

--- a/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
+++ b/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
@@ -25,6 +25,7 @@
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/Socket.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/ThreadPool.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <boost/test/unit_test.hpp>
@@ -46,7 +47,9 @@ namespace
 class FakeASIO_FIB97new : public bcos::gateway::ASIOInterface
 {
 public:
-    FakeASIO_FIB97new() = default;
+    FakeASIO_FIB97new()
+      : ASIOInterface(std::make_shared<bcos::IOServicePool>(1, "FakeASIO_FIB97new"), "0.0.0.0", 0)
+    {}
     ~FakeASIO_FIB97new() noexcept override = default;
 
     // Never issues actual async reads — tests that call drop() don't need reads.
@@ -54,8 +57,8 @@ public:
         boost::asio::mutable_buffer /*buffers*/, ReadWriteHandler /*handler*/) override
     {}
 
-    void strandPost(Base_Handler /*handler*/) override {}
-    void stop() override {}
+    void strandPost(Base_Handler /*handler*/) {}
+    void stop() {}
 };
 
 class FakeSocket_FIB97new : public SocketFace

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -88,7 +88,6 @@ public:
             readSome(socket, buffers, handler);
         });
     }
-    void strandPost(Base_Handler handler) override { m_handler = handler; }
     void stop() { m_threadPool->stop(); }
 
 public:  // for testing
@@ -99,18 +98,7 @@ public:  // for testing
         m_threadPool->enqueue([this, packet]() { appendRecvPacket(packet); });
     }
 
-    void triggerRead()
-    {
-        m_threadPool->enqueue([this]() {
-            if (m_handler)
-            {
-                m_handler();
-            }
-        });
-    }
-
 protected:
-    Base_Handler m_handler;
     std::queue<Packet> m_recvPackets;
     bcos::ThreadPool::Ptr m_threadPool;
 };
@@ -350,7 +338,6 @@ BOOST_AUTO_TEST_CASE(doReadTest)
             });
 
         session->start();
-        std::dynamic_pointer_cast<FakeASIO>(fakeHost->asioInterface())->triggerRead();
 
         // send packets
         while (auto packet = messageBuilder.nextPacket())

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -39,7 +39,6 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/FileUtility.h>
-#include <bcos-utilities/ThreadPool.h>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>


### PR DESCRIPTION
## 变更概述

本 PR 在 #5207（Replace task_group with IOServicePool）和 #5216（Refactor IOServicePool and ASIOInterface）的基础上，进一步优化网络层的任务调度与内存管理，包含以下 3 个提交：

---

### 1. Add move to buffers（`124e5ba2f`）

**改动文件**：`ASIOInterface.h`、`ASIOInterface.cpp`

- 将 `ASIOInterface::asyncWrite` 的 `buffers` 参数从 `const auto&`（const 引用）改为 `auto`（值传递），配合 lambda 内 `std::move(buffers)` 实现移动语义
- 将 `socket` 从引用捕获改为值捕获（`shared_ptr`），避免异步回调中潜在的生命周期问题
- **性能收益**：对于大消息发送场景，buffer 不再进行不必要的拷贝，直接通过移动语义将所有权转移到异步写操作的 lambda 中，减少了内存分配和拷贝开销

---

### 2. Update task dispatch logic（`b6da07e12`）

**改动文件**：`FrontService.cpp`、`ASIOInterface.h/cpp`、`Session.cpp`、`Host.cpp/h`、`SessionTest.cpp`

核心变更：

- **`dispatch` 替代 `post`**：将 `FrontService` 中的 `postToIOServicePool` 重命名为 `dispatchTo`，并使用 `IOServicePool::dispatch` 替代 `IOServicePool::post`
  - `dispatch` 的优势：当调用者已在 IO 线程池的某个线程中时，`dispatch` 会直接在当前线程执行任务，避免不必要的任务入队/出队和上下文切换；只有在调用者不在 IO 线程池中时才会将任务入队
  - `post` 总是将任务入队，即使调用者已经在 IO 线程中也会产生一次无意义的调度开销

- **减少异步层级**：在 `Session` 中移除了多处不必要的 `boost::asio::post` 包装：
  - `Session::drop()` 中直接调用 `m_messageHandler`，不再通过 post 间接调用
  - `Session::onTimeout()` 中直接调用 `callback->callback()`，不再通过 post 包装
  - `Session::start()` 中直接调用 `doRead()`，不再通过 `strandPost` 间接调用
  - `Session::onMessage()` 统一使用 `asioInterface()->post` 替代 `m_socket->ioService()` 上的 post

- **简化 Host 接口**：清理了 `Host` 中不再需要的 `asioInterface()` 间接调用层，移除测试中相应的 mock 期望

- **性能收益**：
  - 减少不必要的任务入队/出队操作，降低调度延迟
  - 在已在 IO 线程的场景下，`dispatch` 直接执行可消除一次完整的上下文切换（~数微秒级别）
  - 对于高频消息处理路径（如 `onReceiveMessage`、`handleCallback`），延迟降低明显

---

### 3. Remove ThreadPool.h include（`4afce0450`）

**改动文件**：`HttpServer.cpp`、`HttpSession.h`、`WsInitializer.cpp`、`WsService.cpp/h`、`WsSession.cpp/h`、`FrontService.h`、`RpcFactory.cpp`

- 清理所有遗留的 `#include <bcos-utilities/ThreadPool.h>` 头文件引用
- 在 `WsSession.cpp` 中同步清理了不再需要的 `#include <mutex>` 头文件
- 修复了 `WsSession` 中多处回调的代码格式（缩进规范化）

这是从 ThreadPool 到 IOServicePool 迁移的最后一步——确保没有任何模块仍然依赖已废弃的 ThreadPool 头文件，使编译依赖关系更加清晰。

---

## 整体性能改进总结

| 优化项 | 技术手段 | 收益 |
|--------|----------|------|
| Buffer 移动语义 | 值传递 + `std::move` | 消除大消息发送时的额外内存拷贝 |
| 任务调度优化 | `dispatch` 替代 `post` | 已在 IO 线程时避免任务入队，减少上下文切换 |
| 减少异步层级 | 移除不必要的 `post` 包装 | 减少回调链深度，降低延迟抖动 |
| 依赖清理 | 移除 ThreadPool 头文件 | 减少编译依赖，加快增量编译 |

## 关联 PR

- #5207 Replace task_group with IOServicePool
- #5216 Refactor IOServicePool and ASIOInterface: RAII lifecycle, value semantics, and improved dispatch