### PR TITLE
Add engineService to NodeService and implement real Engine API endpoints

### DIFF
--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp
@@ -94,7 +94,7 @@ NodeService::Ptr NodeServiceFactory::buildNodeService(std::string const&, std::s
     }
 
     auto nodeService = std::make_shared<NodeService>(ledgerClient.first, schedulerClient.first,
-        txpoolClient.first, consensusClient.first, syncClient.first, blockFactory);
+        txpoolClient.first, consensusClient.first, syncClient.first, blockFactory, nullptr);
 
     nodeService->setLedgerPrx(ledgerClient.second);
     return nodeService;

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
@@ -24,6 +24,7 @@
 #include "fisco-bcos-tars-service/Common/TarsUtils.h"
 #include <bcos-framework/consensus/ConsensusInterface.h>
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
+#include <bcos-framework/engine/AnyEngineService.h>
 #include <bcos-framework/ledger/LedgerInterface.h>
 #include <bcos-framework/multigroup/ChainNodeInfo.h>
 #include <bcos-framework/multigroup/GroupInfo.h>
@@ -33,6 +34,7 @@
 #include <bcos-framework/txpool/TxPoolInterface.h>
 #include <bcos-tars-protocol/client/LedgerServiceClient.h>
 #include <servant/Application.h>
+#include <optional>
 #include <utility>
 
 namespace bcos::rpc
@@ -45,13 +47,15 @@ public:
         std::shared_ptr<bcos::scheduler::SchedulerInterface> _scheduler,
         bcos::txpool::TxPoolInterface::Ptr _txpool,
         bcos::consensus::ConsensusInterface::Ptr _consensus,
-        bcos::sync::BlockSyncInterface::Ptr _sync, bcos::protocol::BlockFactory::Ptr _blockFactory)
+        bcos::sync::BlockSyncInterface::Ptr _sync, bcos::protocol::BlockFactory::Ptr _blockFactory,
+        std::shared_ptr<bcos::engine::AnyEngineService> _engineService)
       : m_ledger(std::move(_ledger)),
         m_scheduler(std::move(_scheduler)),
         m_txpool(std::move(_txpool)),
         m_consensus(std::move(_consensus)),
         m_sync(std::move(_sync)),
-        m_blockFactory(std::move(_blockFactory))
+        m_blockFactory(std::move(_blockFactory)),
+        m_engineService(std::move(_engineService))
     {}
     ~NodeService() = default;
 
@@ -63,6 +67,12 @@ public:
     bcos::protocol::BlockFactory::Ptr blockFactory() { return m_blockFactory; }
 
     bcos::txpool::TxPoolInterface& txpoolRef() { return *m_txpool; }
+
+    std::shared_ptr<bcos::engine::AnyEngineService>& engineService() { return m_engineService; }
+    std::shared_ptr<bcos::engine::AnyEngineService> const& engineService() const
+    {
+        return m_engineService;
+    }
 
     void setLedgerPrx(bcostars::LedgerServicePrx const& _ledgerPrx) { m_ledgerPrx = _ledgerPrx; }
 
@@ -79,6 +89,8 @@ private:
     bcos::consensus::ConsensusInterface::Ptr m_consensus;
     bcos::sync::BlockSyncInterface::Ptr m_sync;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
+
+    std::shared_ptr<bcos::engine::AnyEngineService> m_engineService;
 
     bcostars::LedgerServicePrx m_ledgerPrx;
 };

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -125,11 +125,11 @@ engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
         .prevRandao = parseH256(ep["prevRandao"].asString()),
         .blockNumber = static_cast<bcos::protocol::BlockNumber>(
             fromQuantity(std::string(ep["blockNumber"].asString()))),
-        .gasLimit = u256(fromQuantity(std::string(ep["gasLimit"].asString()))),
-        .gasUsed = u256(fromQuantity(std::string(ep["gasUsed"].asString()))),
+        .gasLimit = fromBigQuantity(ep["gasLimit"].asString()),
+        .gasUsed = fromBigQuantity(ep["gasUsed"].asString()),
         .timestamp = fromQuantity(std::string(ep["timestamp"].asString())),
         .extraData = {},
-        .baseFeePerGas = u256(fromQuantity(std::string(ep["baseFeePerGas"].asString()))),
+        .baseFeePerGas = fromBigQuantity(ep["baseFeePerGas"].asString()),
         .blockHash = parseH256(ep["blockHash"].asString()),
         .transactions = {},
         .withdrawals = std::nullopt,
@@ -145,10 +145,13 @@ engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
     if (ep.isMember("logsBloom"))
     {
         auto bloomBytes = fromHex(ep["logsBloom"].asString());
-        if (bloomBytes.size() == 256)
+        if (bloomBytes.size() != BloomBytesSize)
         {
-            std::copy(bloomBytes.begin(), bloomBytes.end(), payload.logsBloom.begin());
+            BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams,
+                "Expected 256-byte hex string for logsBloom, got " +
+                    std::to_string(bloomBytes.size()) + " bytes"));
         }
+        std::copy(bloomBytes.begin(), bloomBytes.end(), payload.logsBloom.begin());
     }
     // transactions — requires TransactionFactory to decode; left empty for now
     // TODO: parse transactions when a TransactionFactory is accessible from NodeService
@@ -203,7 +206,22 @@ engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
 Json::Value serializePayloadStatus(const engine::PayloadStatus& status)
 {
     Json::Value result(Json::objectValue);
-    result["status"] = std::string(magic_enum::enum_name(status.status));
+    result["status"] = [&] {
+        switch (status.status)
+        {
+        case engine::PayloadValidationStatus::Valid:
+            return "VALID";
+        case engine::PayloadValidationStatus::Invalid:
+            return "INVALID";
+        case engine::PayloadValidationStatus::Syncing:
+            return "SYNCING";
+        case engine::PayloadValidationStatus::Accepted:
+            return "ACCEPTED";
+        case engine::PayloadValidationStatus::InvalidBlockHash:
+            return "INVALID_BLOCK_HASH";
+        }
+        return "SYNCING";
+    }();
     if (status.latestValidHash.has_value())
     {
         result["latestValidHash"] = status.latestValidHash->hexPrefixed();
@@ -234,13 +252,13 @@ Json::Value serializeExecutionPayload(const engine::ExecutionPayload& payload)
     ep["feeRecipient"] = payload.feeRecipient.hexPrefixed();
     ep["stateRoot"] = payload.stateRoot.hexPrefixed();
     ep["receiptsRoot"] = payload.receiptsRoot.hexPrefixed();
-    ep["logsBloom"] = toHex(payload.logsBloom);
+    ep["logsBloom"] = toPaddingHexStringWithPrefix(BloomBytesSize, payload.logsBloom);
     ep["prevRandao"] = payload.prevRandao.hexPrefixed();
     ep["blockNumber"] = toQuantity(payload.blockNumber);
     ep["gasLimit"] = toQuantity(payload.gasLimit);
     ep["gasUsed"] = toQuantity(payload.gasUsed);
     ep["timestamp"] = toQuantity(payload.timestamp);
-    ep["extraData"] = toHex(payload.extraData);
+    ep["extraData"] = toHexStringWithPrefix(payload.extraData);
     ep["baseFeePerGas"] = toQuantity(payload.baseFeePerGas);
     ep["blockHash"] = payload.blockHash.hexPrefixed();
 
@@ -287,7 +305,7 @@ task::Task<void> EngineEndpoint::exchangeCapabilities(
     }
 
     std::vector<std::string> remoteCaps;
-    for (auto const& cap : request["params"])
+    for (auto const& cap : request)
     {
         remoteCaps.push_back(cap.asString());
     }
@@ -311,7 +329,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV1(
         co_return;
     }
 
-    auto const& params = request["params"];
+    auto const& params = request;
     auto forkchoiceState = parseForkchoiceState(params);
     auto payloadAttrs = parsePayloadAttributes(params);
 
@@ -370,7 +388,7 @@ task::Task<void> EngineEndpoint::getPayloadV1(const Json::Value& request, Json::
         co_return;
     }
 
-    auto const& params = request["params"];
+    auto const& params = request;
     engine::PayloadID payloadId = params[0u].asString();
 
     auto engineResult = co_await engineService->getPayload(payloadId, 1);
@@ -417,19 +435,19 @@ task::Task<void> EngineEndpoint::getPayloadV3(const Json::Value& request, Json::
         Json::Value commitments(Json::arrayValue);
         for (auto const& c : engineResult.blobsBundle->commitments)
         {
-            commitments.append(toHex(c));
+            commitments.append(toHexStringWithPrefix(c));
         }
         bb["commitments"] = std::move(commitments);
         Json::Value proofs(Json::arrayValue);
         for (auto const& p : engineResult.blobsBundle->proofs)
         {
-            proofs.append(toHex(p));
+            proofs.append(toHexStringWithPrefix(p));
         }
         bb["proofs"] = std::move(proofs);
         Json::Value blobs(Json::arrayValue);
         for (auto const& b : engineResult.blobsBundle->blobs)
         {
-            blobs.append(toHex(b));
+            blobs.append(toHexStringWithPrefix(b));
         }
         bb["blobs"] = std::move(blobs);
         jsonResult["blobsBundle"] = std::move(bb);
@@ -447,7 +465,7 @@ task::Task<void> EngineEndpoint::newPayloadV1(const Json::Value& request, Json::
         co_return;
     }
 
-    auto const& params = request["params"];
+    auto const& params = request;
     auto newPayloadReq = parseNewPayloadRequest(params);
 
     auto engineResult = co_await engineService->newPayload(newPayloadReq, 1);

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -97,10 +97,10 @@ std::optional<engine::PayloadAttributes> parsePayloadAttributes(const Json::Valu
         for (auto const& w : pa["withdrawals"])
         {
             withdrawals.push_back(engine::WithdrawalV1{
-                .index = u256(fromQuantity(std::string(w["index"].asString()))),
-                .validatorIndex = u256(fromQuantity(std::string(w["validatorIndex"].asString()))),
+                .index = fromBigQuantity(w["index"].asString()),
+                .validatorIndex = fromBigQuantity(w["validatorIndex"].asString()),
                 .address = parseAddress(w["address"].asString()),
-                .amount = u256(fromQuantity(std::string(w["amount"].asString()))),
+                .amount = fromBigQuantity(w["amount"].asString()),
             });
         }
         attrs.withdrawals = std::move(withdrawals);
@@ -113,7 +113,8 @@ std::optional<engine::PayloadAttributes> parsePayloadAttributes(const Json::Valu
 }
 
 /// Parse newPayload request from JSON params.
-engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
+engine::NewPayloadRequest parseNewPayloadRequest(
+    const Json::Value& params, bcos::protocol::TransactionFactory& transactionFactory)
 {
     auto const& ep = params[0u];
     engine::ExecutionPayload payload{
@@ -153,8 +154,16 @@ engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
         }
         std::copy(bloomBytes.begin(), bloomBytes.end(), payload.logsBloom.begin());
     }
-    // transactions — requires TransactionFactory to decode; left empty for now
-    // TODO: parse transactions when a TransactionFactory is accessible from NodeService
+    if (ep.isMember("transactions") && !ep["transactions"].isNull())
+    {
+        payload.transactions.reserve(ep["transactions"].size());
+        for (auto const& tx : ep["transactions"])
+        {
+            auto txData = fromHex(tx.asString());
+            payload.transactions.push_back(transactionFactory.decodeTransaction(ref(txData)));
+        }
+    }
+
     // withdrawals
     if (ep.isMember("withdrawals") && !ep["withdrawals"].isNull())
     {
@@ -162,10 +171,10 @@ engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
         for (auto const& w : ep["withdrawals"])
         {
             withdrawals.push_back(engine::WithdrawalV1{
-                .index = u256(fromQuantity(std::string(w["index"].asString()))),
-                .validatorIndex = u256(fromQuantity(std::string(w["validatorIndex"].asString()))),
+                .index = fromBigQuantity(w["index"].asString()),
+                .validatorIndex = fromBigQuantity(w["validatorIndex"].asString()),
                 .address = parseAddress(w["address"].asString()),
-                .amount = u256(fromQuantity(std::string(w["amount"].asString()))),
+                .amount = fromBigQuantity(w["amount"].asString()),
             });
         }
         payload.withdrawals = std::move(withdrawals);
@@ -173,11 +182,11 @@ engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
     // blobGasUsed / excessBlobGas
     if (ep.isMember("blobGasUsed"))
     {
-        payload.blobGasUsed = u256(fromQuantity(std::string(ep["blobGasUsed"].asString())));
+        payload.blobGasUsed = fromBigQuantity(ep["blobGasUsed"].asString());
     }
     if (ep.isMember("excessBlobGas"))
     {
-        payload.excessBlobGas = u256(fromQuantity(std::string(ep["excessBlobGas"].asString())));
+        payload.excessBlobGas = fromBigQuantity(ep["excessBlobGas"].asString());
     }
 
     engine::NewPayloadRequest request{
@@ -262,8 +271,14 @@ Json::Value serializeExecutionPayload(const engine::ExecutionPayload& payload)
     ep["baseFeePerGas"] = toQuantity(payload.baseFeePerGas);
     ep["blockHash"] = payload.blockHash.hexPrefixed();
 
-    // TODO: serialize transactions when Transaction encode is accessible
-    ep["transactions"] = Json::Value(Json::arrayValue);
+    Json::Value transactions(Json::arrayValue);
+    for (auto const& transaction : payload.transactions)
+    {
+        bytes encoded;
+        transaction->encode(encoded);
+        transactions.append(toHexStringWithPrefix(encoded));
+    }
+    ep["transactions"] = std::move(transactions);
 
     if (payload.withdrawals.has_value())
     {
@@ -349,7 +364,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV2(
         co_return;
     }
 
-    auto const& params = request["params"];
+    auto const& params = request;
     auto forkchoiceState = parseForkchoiceState(params);
     auto payloadAttrs = parsePayloadAttributes(params);
 
@@ -369,7 +384,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV3(
         co_return;
     }
 
-    auto const& params = request["params"];
+    auto const& params = request;
     auto forkchoiceState = parseForkchoiceState(params);
     auto payloadAttrs = parsePayloadAttributes(params);
 
@@ -405,7 +420,7 @@ task::Task<void> EngineEndpoint::getPayloadV2(const Json::Value& request, Json::
         co_return;
     }
 
-    auto const& params = request["params"];
+    auto const& params = request;
     engine::PayloadID payloadId = params[0u].asString();
 
     auto engineResult = co_await engineService->getPayload(payloadId, 2);
@@ -423,7 +438,7 @@ task::Task<void> EngineEndpoint::getPayloadV3(const Json::Value& request, Json::
         co_return;
     }
 
-    auto const& params = request["params"];
+    auto const& params = request;
     engine::PayloadID payloadId = params[0u].asString();
 
     auto engineResult = co_await engineService->getPayload(payloadId, 3);
@@ -466,7 +481,8 @@ task::Task<void> EngineEndpoint::newPayloadV1(const Json::Value& request, Json::
     }
 
     auto const& params = request;
-    auto newPayloadReq = parseNewPayloadRequest(params);
+    auto newPayloadReq =
+        parseNewPayloadRequest(params, *m_nodeService->blockFactory()->transactionFactory());
 
     auto engineResult = co_await engineService->newPayload(newPayloadReq, 1);
     auto jsonResult = serializePayloadStatus(engineResult);
@@ -482,8 +498,9 @@ task::Task<void> EngineEndpoint::newPayloadV2(const Json::Value& request, Json::
         co_return;
     }
 
-    auto const& params = request["params"];
-    auto newPayloadReq = parseNewPayloadRequest(params);
+    auto const& params = request;
+    auto newPayloadReq =
+        parseNewPayloadRequest(params, *m_nodeService->blockFactory()->transactionFactory());
 
     auto engineResult = co_await engineService->newPayload(newPayloadReq, 2);
     auto jsonResult = serializePayloadStatus(engineResult);
@@ -499,8 +516,9 @@ task::Task<void> EngineEndpoint::newPayloadV3(const Json::Value& request, Json::
         co_return;
     }
 
-    auto const& params = request["params"];
-    auto newPayloadReq = parseNewPayloadRequest(params);
+    auto const& params = request;
+    auto newPayloadReq =
+        parseNewPayloadRequest(params, *m_nodeService->blockFactory()->transactionFactory());
 
     auto engineResult = co_await engineService->newPayload(newPayloadReq, 3);
     auto jsonResult = serializePayloadStatus(engineResult);

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -21,47 +21,255 @@
 #include "EngineEndpoint.h"
 
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
 
 using namespace bcos;
 using namespace bcos::rpc;
 
 namespace
 {
-Json::Value mockArrayResult()
+constexpr int32_t kEngineNotAvailable = -32000;
+
+/// Build a JSON-RPC error response when the engine service is not available.
+void buildEngineNotAvailableError(const Json::Value& request, Json::Value& response)
 {
-    return {Json::arrayValue};
+    buildJsonError(request, kEngineNotAvailable,
+        "Engine service is not available on this node", response);
 }
 
-Json::Value mockObjectResult()
+/// Parse a hex-prefixed string into h256.
+h256 parseH256(std::string_view hex)
 {
-    return {Json::objectValue};
+    auto bytes = fromHex(hex);
+    if (bytes.size() != 32)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "Expected 32-byte hex string for h256, got " + std::to_string(bytes.size()) + " bytes"));
+    }
+    h256 result;
+    std::copy(bytes.begin(), bytes.end(), result.begin());
+    return result;
 }
 
-task::Task<void> handleForkchoiceRequest(NodeService::Ptr nodeService, std::uint32_t version,
-    Json::Value const& request, Json::Value& response)
+/// Parse a hex-prefixed string into Address.
+Address parseAddress(std::string_view hex)
 {
-    boost::ignore_unused(nodeService, version, request);
-    auto result = mockObjectResult();
-    buildJsonContent(result, response);
-    co_return;
+    auto bytes = fromHex(hex);
+    if (bytes.size() != 20)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "Expected 20-byte hex string for address, got " + std::to_string(bytes.size()) + " bytes"));
+    }
+    Address result;
+    std::copy(bytes.begin(), bytes.end(), result.begin());
+    return result;
 }
 
-task::Task<void> handleGetPayloadRequest(NodeService::Ptr nodeService, std::uint32_t version,
-    Json::Value const& request, Json::Value& response)
+/// Parse forkchoice state from JSON params[0].
+engine::ForkchoiceState parseForkchoiceState(const Json::Value& params)
 {
-    boost::ignore_unused(nodeService, version, request);
-    auto result = mockObjectResult();
-    buildJsonContent(result, response);
-    co_return;
+    auto const& fc = params[0u];
+    return engine::ForkchoiceState{
+        .headBlockHash = parseH256(fc["headBlockHash"].asString()),
+        .safeBlockHash = parseH256(fc["safeBlockHash"].asString()),
+        .finalizedBlockHash = parseH256(fc["finalizedBlockHash"].asString()),
+    };
 }
 
-task::Task<void> handleNewPayloadRequest(NodeService::Ptr nodeService, std::uint32_t version,
-    Json::Value const& request, Json::Value& response)
+/// Parse optional payload attributes from JSON params[1].
+std::optional<engine::PayloadAttributes> parsePayloadAttributes(const Json::Value& params)
 {
-    boost::ignore_unused(nodeService, version, request);
-    auto result = mockObjectResult();
-    buildJsonContent(result, response);
-    co_return;
+    if (params.size() < 2 || params[1].isNull())
+    {
+        return std::nullopt;
+    }
+    auto const& pa = params[1];
+    engine::PayloadAttributes attrs{
+        .timestamp = fromQuantity(std::string(pa["timestamp"].asString())),
+        .prevRandao = parseH256(pa["prevRandao"].asString()),
+        .suggestedFeeRecipient = parseAddress(pa["suggestedFeeRecipient"].asString()),
+        .withdrawals = std::nullopt,
+        .parentBeaconBlockRoot = std::nullopt,
+    };
+    if (pa.isMember("withdrawals") && !pa["withdrawals"].isNull())
+    {
+        std::vector<engine::WithdrawalV1> withdrawals;
+        for (auto const& w : pa["withdrawals"])
+        {
+            withdrawals.push_back(engine::WithdrawalV1{
+                .index = u256(fromQuantity(std::string(w["index"].asString()))),
+                .validatorIndex = u256(fromQuantity(std::string(w["validatorIndex"].asString()))),
+                .address = parseAddress(w["address"].asString()),
+                .amount = u256(fromQuantity(std::string(w["amount"].asString()))),
+            });
+        }
+        attrs.withdrawals = std::move(withdrawals);
+    }
+    if (pa.isMember("parentBeaconBlockRoot") && !pa["parentBeaconBlockRoot"].isNull())
+    {
+        attrs.parentBeaconBlockRoot = parseH256(pa["parentBeaconBlockRoot"].asString());
+    }
+    return attrs;
+}
+
+/// Parse newPayload request from JSON params.
+engine::NewPayloadRequest parseNewPayloadRequest(const Json::Value& params)
+{
+    auto const& ep = params[0u];
+    engine::ExecutionPayload payload{
+        .parentHash = parseH256(ep["parentHash"].asString()),
+        .feeRecipient = parseAddress(ep["feeRecipient"].asString()),
+        .stateRoot = parseH256(ep["stateRoot"].asString()),
+        .receiptsRoot = parseH256(ep["receiptsRoot"].asString()),
+        .logsBloom = {},
+        .prevRandao = parseH256(ep["prevRandao"].asString()),
+        .blockNumber = static_cast<bcos::protocol::BlockNumber>(
+            fromQuantity(std::string(ep["blockNumber"].asString()))),
+        .gasLimit = u256(fromQuantity(std::string(ep["gasLimit"].asString()))),
+        .gasUsed = u256(fromQuantity(std::string(ep["gasUsed"].asString()))),
+        .timestamp = fromQuantity(std::string(ep["timestamp"].asString())),
+        .extraData = {},
+        .baseFeePerGas = u256(fromQuantity(std::string(ep["baseFeePerGas"].asString()))),
+        .blockHash = parseH256(ep["blockHash"].asString()),
+        .transactions = {},
+        .withdrawals = std::nullopt,
+        .blobGasUsed = std::nullopt,
+        .excessBlobGas = std::nullopt,
+    };
+    // extraData
+    if (ep.isMember("extraData"))
+    {
+        payload.extraData = fromHex(ep["extraData"].asString());
+    }
+    // logsBloom
+    if (ep.isMember("logsBloom"))
+    {
+        auto bloomBytes = fromHex(ep["logsBloom"].asString());
+        if (bloomBytes.size() == 256)
+        {
+            std::copy(bloomBytes.begin(), bloomBytes.end(), payload.logsBloom.begin());
+        }
+    }
+    // transactions — requires TransactionFactory to decode; left empty for now
+    // TODO: parse transactions when a TransactionFactory is accessible from NodeService
+    // withdrawals
+    if (ep.isMember("withdrawals") && !ep["withdrawals"].isNull())
+    {
+        std::vector<engine::WithdrawalV1> withdrawals;
+        for (auto const& w : ep["withdrawals"])
+        {
+            withdrawals.push_back(engine::WithdrawalV1{
+                .index = u256(fromQuantity(std::string(w["index"].asString()))),
+                .validatorIndex = u256(fromQuantity(std::string(w["validatorIndex"].asString()))),
+                .address = parseAddress(w["address"].asString()),
+                .amount = u256(fromQuantity(std::string(w["amount"].asString()))),
+            });
+        }
+        payload.withdrawals = std::move(withdrawals);
+    }
+    // blobGasUsed / excessBlobGas
+    if (ep.isMember("blobGasUsed"))
+    {
+        payload.blobGasUsed = u256(fromQuantity(std::string(ep["blobGasUsed"].asString())));
+    }
+    if (ep.isMember("excessBlobGas"))
+    {
+        payload.excessBlobGas = u256(fromQuantity(std::string(ep["excessBlobGas"].asString())));
+    }
+
+    engine::NewPayloadRequest request{
+        .executionPayload = std::move(payload),
+        .expectedBlobVersionedHashes = {},
+        .parentBeaconBlockRoot = std::nullopt,
+    };
+
+    // expectedBlobVersionedHashes
+    if (params.size() >= 2 && params[1].isArray())
+    {
+        for (auto const& h : params[1])
+        {
+            request.expectedBlobVersionedHashes.push_back(parseH256(h.asString()));
+        }
+    }
+    // parentBeaconBlockRoot
+    if (params.size() >= 3 && !params[2].isNull())
+    {
+        request.parentBeaconBlockRoot = parseH256(params[2].asString());
+    }
+    return request;
+}
+
+/// Serialize PayloadStatus to JSON.
+Json::Value serializePayloadStatus(const engine::PayloadStatus& status)
+{
+    Json::Value result(Json::objectValue);
+    result["status"] = std::string(magic_enum::enum_name(status.status));
+    if (status.latestValidHash.has_value())
+    {
+        result["latestValidHash"] = status.latestValidHash->hexPrefixed();
+    }
+    if (status.validationError.has_value())
+    {
+        result["validationError"] = *status.validationError;
+    }
+    return result;
+}
+
+/// Serialize ForkchoiceUpdatedResult to JSON.
+Json::Value serializForkchoiceUpdatedResult(const engine::ForkchoiceUpdatedResult& result)
+{
+    auto json = serializePayloadStatus(result.payloadStatus);
+    if (result.payloadId.has_value())
+    {
+        json["payloadId"] = *result.payloadId;
+    }
+    return json;
+}
+
+/// Serialize ExecutionPayload to JSON.
+Json::Value serializeExecutionPayload(const engine::ExecutionPayload& payload)
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = payload.parentHash.hexPrefixed();
+    ep["feeRecipient"] = payload.feeRecipient.hexPrefixed();
+    ep["stateRoot"] = payload.stateRoot.hexPrefixed();
+    ep["receiptsRoot"] = payload.receiptsRoot.hexPrefixed();
+    ep["logsBloom"] = toHex(payload.logsBloom);
+    ep["prevRandao"] = payload.prevRandao.hexPrefixed();
+    ep["blockNumber"] = toQuantity(payload.blockNumber);
+    ep["gasLimit"] = toQuantity(payload.gasLimit);
+    ep["gasUsed"] = toQuantity(payload.gasUsed);
+    ep["timestamp"] = toQuantity(payload.timestamp);
+    ep["extraData"] = toHex(payload.extraData);
+    ep["baseFeePerGas"] = toQuantity(payload.baseFeePerGas);
+    ep["blockHash"] = payload.blockHash.hexPrefixed();
+
+    // TODO: serialize transactions when Transaction encode is accessible
+    ep["transactions"] = Json::Value(Json::arrayValue);
+
+    if (payload.withdrawals.has_value())
+    {
+        Json::Value ws(Json::arrayValue);
+        for (auto const& w : *payload.withdrawals)
+        {
+            Json::Value wj(Json::objectValue);
+            wj["index"] = toQuantity(w.index);
+            wj["validatorIndex"] = toQuantity(w.validatorIndex);
+            wj["address"] = w.address.hexPrefixed();
+            wj["amount"] = toQuantity(w.amount);
+            ws.append(std::move(wj));
+        }
+        ep["withdrawals"] = std::move(ws);
+    }
+    if (payload.blobGasUsed.has_value())
+    {
+        ep["blobGasUsed"] = toQuantity(*payload.blobGasUsed);
+    }
+    if (payload.excessBlobGas.has_value())
+    {
+        ep["excessBlobGas"] = toQuantity(*payload.excessBlobGas);
+    }
+    return ep;
 }
 }  // namespace
 
@@ -71,56 +279,212 @@ EngineEndpoint::EngineEndpoint(NodeService::Ptr nodeService) : m_nodeService(std
 task::Task<void> EngineEndpoint::exchangeCapabilities(
     const Json::Value& request, Json::Value& response)
 {
-    boost::ignore_unused(request);
-    auto result = mockArrayResult();
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    std::vector<std::string> remoteCaps;
+    for (auto const& cap : request["params"])
+    {
+        remoteCaps.push_back(cap.asString());
+    }
+
+    auto caps = co_await engineService->exchangeCapabilities(std::move(remoteCaps));
+    Json::Value result(Json::arrayValue);
+    for (auto const& cap : caps)
+    {
+        result.append(cap);
+    }
     buildJsonContent(result, response);
-    co_return;
 }
 
 task::Task<void> EngineEndpoint::forkchoiceUpdatedV1(
     const Json::Value& request, Json::Value& response)
 {
-    co_await handleForkchoiceRequest(m_nodeService, 1, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    auto forkchoiceState = parseForkchoiceState(params);
+    auto payloadAttrs = parsePayloadAttributes(params);
+
+    auto engineResult = co_await engineService->updateForkchoice(
+        forkchoiceState, payloadAttrs.has_value() ? &*payloadAttrs : nullptr, 1);
+    auto jsonResult = serializForkchoiceUpdatedResult(engineResult);
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::forkchoiceUpdatedV2(
     const Json::Value& request, Json::Value& response)
 {
-    co_await handleForkchoiceRequest(m_nodeService, 2, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    auto forkchoiceState = parseForkchoiceState(params);
+    auto payloadAttrs = parsePayloadAttributes(params);
+
+    auto engineResult = co_await engineService->updateForkchoice(
+        forkchoiceState, payloadAttrs.has_value() ? &*payloadAttrs : nullptr, 2);
+    auto jsonResult = serializForkchoiceUpdatedResult(engineResult);
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::forkchoiceUpdatedV3(
     const Json::Value& request, Json::Value& response)
 {
-    co_await handleForkchoiceRequest(m_nodeService, 3, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    auto forkchoiceState = parseForkchoiceState(params);
+    auto payloadAttrs = parsePayloadAttributes(params);
+
+    auto engineResult = co_await engineService->updateForkchoice(
+        forkchoiceState, payloadAttrs.has_value() ? &*payloadAttrs : nullptr, 3);
+    auto jsonResult = serializForkchoiceUpdatedResult(engineResult);
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::getPayloadV1(const Json::Value& request, Json::Value& response)
 {
-    co_await handleGetPayloadRequest(m_nodeService, 1, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    engine::PayloadID payloadId = params[0u].asString();
+
+    auto engineResult = co_await engineService->getPayload(payloadId, 1);
+    auto jsonResult = serializeExecutionPayload(engineResult.executionPayload);
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::getPayloadV2(const Json::Value& request, Json::Value& response)
 {
-    co_await handleGetPayloadRequest(m_nodeService, 2, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    engine::PayloadID payloadId = params[0u].asString();
+
+    auto engineResult = co_await engineService->getPayload(payloadId, 2);
+    auto jsonResult = serializeExecutionPayload(engineResult.executionPayload);
+    jsonResult["blockValue"] = toQuantity(engineResult.blockValue);
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::getPayloadV3(const Json::Value& request, Json::Value& response)
 {
-    co_await handleGetPayloadRequest(m_nodeService, 3, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    engine::PayloadID payloadId = params[0u].asString();
+
+    auto engineResult = co_await engineService->getPayload(payloadId, 3);
+    auto jsonResult = serializeExecutionPayload(engineResult.executionPayload);
+    jsonResult["blockValue"] = toQuantity(engineResult.blockValue);
+    if (engineResult.blobsBundle.has_value())
+    {
+        Json::Value bb(Json::objectValue);
+        Json::Value commitments(Json::arrayValue);
+        for (auto const& c : engineResult.blobsBundle->commitments)
+        {
+            commitments.append(toHex(c));
+        }
+        bb["commitments"] = std::move(commitments);
+        Json::Value proofs(Json::arrayValue);
+        for (auto const& p : engineResult.blobsBundle->proofs)
+        {
+            proofs.append(toHex(p));
+        }
+        bb["proofs"] = std::move(proofs);
+        Json::Value blobs(Json::arrayValue);
+        for (auto const& b : engineResult.blobsBundle->blobs)
+        {
+            blobs.append(toHex(b));
+        }
+        bb["blobs"] = std::move(blobs);
+        jsonResult["blobsBundle"] = std::move(bb);
+    }
+    jsonResult["shouldOverrideBuilder"] = engineResult.shouldOverrideBuilder;
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::newPayloadV1(const Json::Value& request, Json::Value& response)
 {
-    co_await handleNewPayloadRequest(m_nodeService, 1, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    auto newPayloadReq = parseNewPayloadRequest(params);
+
+    auto engineResult = co_await engineService->newPayload(newPayloadReq, 1);
+    auto jsonResult = serializePayloadStatus(engineResult);
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::newPayloadV2(const Json::Value& request, Json::Value& response)
 {
-    co_await handleNewPayloadRequest(m_nodeService, 2, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    auto newPayloadReq = parseNewPayloadRequest(params);
+
+    auto engineResult = co_await engineService->newPayload(newPayloadReq, 2);
+    auto jsonResult = serializePayloadStatus(engineResult);
+    buildJsonContent(jsonResult, response);
 }
 
 task::Task<void> EngineEndpoint::newPayloadV3(const Json::Value& request, Json::Value& response)
 {
-    co_await handleNewPayloadRequest(m_nodeService, 3, request, response);
+    auto& engineService = m_nodeService->engineService();
+    if (!engineService)
+    {
+        buildEngineNotAvailableError(request, response);
+        co_return;
+    }
+
+    auto const& params = request["params"];
+    auto newPayloadReq = parseNewPayloadRequest(params);
+
+    auto engineResult = co_await engineService->newPayload(newPayloadReq, 3);
+    auto jsonResult = serializePayloadStatus(engineResult);
+    buildJsonContent(jsonResult, response);
 }

--- a/bcos-rpc/test/unittests/common/RPCFixture.h
+++ b/bcos-rpc/test/unittests/common/RPCFixture.h
@@ -121,7 +121,7 @@ public:
         txPool->start();
 
         nodeService = std::make_shared<rpc::NodeService>(
-            m_ledger, scheduler, txPool, nullptr, nullptr, m_blockFactory);
+            m_ledger, scheduler, txPool, nullptr, nullptr, m_blockFactory, nullptr);
 
 
         groupInfo = std::make_shared<group::GroupInfo>();

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -21,6 +21,7 @@
 
 #include "../common/RPCFixture.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-framework/engine/AnyEngineService.h>
 #include <bcos-codec/wrapper/CodecWrapper.h>
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/hash/SM3.h>
@@ -34,6 +35,7 @@
 #include <bcos-rpc/validator/CallValidator.h>
 #include <bcos-rpc/web3jsonrpc/model/Web3FilterRequest.h>
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-task/Task.h>
 #include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <ostream>
@@ -45,6 +47,50 @@ using namespace bcos::crypto;
 
 namespace bcos::test
 {
+
+class TestEngineService
+{
+public:
+    task::Task<std::vector<std::string>> exchangeCapabilities(
+        std::vector<std::string> remoteCapabilities)
+    {
+        co_return remoteCapabilities;
+    }
+
+    task::Task<engine::ForkchoiceUpdatedResult> updateForkchoice(
+        const engine::ForkchoiceState&, const engine::PayloadAttributes*, std::uint32_t)
+    {
+        co_return engine::ForkchoiceUpdatedResult{
+            .payloadStatus = payloadStatusResult, .payloadId = std::nullopt};
+    }
+
+    task::Task<engine::GetPayloadResult> getPayload(
+        const engine::PayloadID& payloadId, std::uint32_t version)
+    {
+        capturedPayloadId = payloadId;
+        capturedGetPayloadVersion = version;
+        co_return getPayloadResult;
+    }
+
+    task::Task<engine::PayloadStatus> newPayload(
+        const engine::NewPayloadRequest& request, std::uint32_t version)
+    {
+        capturedNewPayloadRequest = request;
+        capturedNewPayloadVersion = version;
+        co_return payloadStatusResult;
+    }
+
+    std::optional<bcos::protocol::BlockNumber> getSafeBlockNumber() { return std::nullopt; }
+    std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() { return std::nullopt; }
+
+    engine::PayloadStatus payloadStatusResult{.status = engine::PayloadValidationStatus::Valid,
+        .latestValidHash = std::nullopt, .validationError = std::nullopt};
+    engine::GetPayloadResult getPayloadResult;
+    std::optional<engine::NewPayloadRequest> capturedNewPayloadRequest;
+    std::optional<std::uint32_t> capturedNewPayloadVersion;
+    std::optional<engine::PayloadID> capturedPayloadId;
+    std::optional<std::uint32_t> capturedGetPayloadVersion;
+};
 
 class Web3TestFixture : public RPCFixture
 {
@@ -468,6 +514,92 @@ BOOST_AUTO_TEST_CASE(handleEIP4844TxTest)
         "0xa8fd95a70b4f2b6cea8c52bcb782b5c3f806a0d5250cf75a1d97a6e899f09979");
     // clang-format on
 }
+
+BOOST_AUTO_TEST_CASE(handleEngineNotAvailableTest)
+{
+    const auto request =
+        R"({"jsonrpc":"2.0","id":7,"method":"engine_exchangeCapabilities","params":["engine_newPayloadV2"]})";
+    auto response = onRPCRequestWrapper(request);
+    BOOST_TEST(response.isMember("error"));
+    BOOST_TEST(response["error"]["code"].asInt() == -32000);
+    BOOST_TEST(
+        response["error"]["message"].asString() == "Engine service is not available on this node");
+}
+
+BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
+{
+    TestEngineService testEngineService;
+    nodeService->engineService() = std::make_shared<bcos::engine::AnyEngineService>(testEngineService);
+
+    auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
+        "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100,
+        chainId, groupId, static_cast<int64_t>(utcTime()));
+    bytes encodedTx;
+    tx->encode(encodedTx);
+    auto encodedTxHex = toHexStringWithPrefix(encodedTx);
+
+    auto const largeQuantity = std::string("0x100000000000000000");
+    auto const expectedLargeValue = fromBigQuantity(largeQuantity);
+    auto const logsBloom = "0x" + std::string(BloomBytesSize * 2, '0');
+
+    std::string newPayloadRequest =
+        R"({"jsonrpc":"2.0","id":8,"method":"engine_newPayloadV2","params":[{"parentHash":"0x1111111111111111111111111111111111111111111111111111111111111111","feeRecipient":"0x2222222222222222222222222222222222222222","stateRoot":"0x3333333333333333333333333333333333333333333333333333333333333333","receiptsRoot":"0x4444444444444444444444444444444444444444444444444444444444444444","logsBloom":")";
+    newPayloadRequest += logsBloom;
+    newPayloadRequest +=
+        R"(","prevRandao":"0x5555555555555555555555555555555555555555555555555555555555555555","blockNumber":"0x1","gasLimit":"0x5208","gasUsed":"0x5208","timestamp":"0x1","extraData":"0x1234","baseFeePerGas":"0x1","blockHash":"0x6666666666666666666666666666666666666666666666666666666666666666","transactions":[")";
+    newPayloadRequest += encodedTxHex;
+    newPayloadRequest +=
+        R"("],"withdrawals":[{"index":"0x1","validatorIndex":"0x2","address":"0x7777777777777777777777777777777777777777","amount":")";
+    newPayloadRequest += largeQuantity;
+    newPayloadRequest += R"("}],"blobGasUsed":")";
+    newPayloadRequest += largeQuantity;
+    newPayloadRequest += R"(","excessBlobGas":")";
+    newPayloadRequest += largeQuantity;
+    newPayloadRequest += R"("}]})";
+
+    auto newPayloadResponse = onRPCRequestWrapper(newPayloadRequest);
+    validRespCheck(newPayloadResponse);
+    BOOST_TEST(newPayloadResponse["result"]["status"].asString() == "VALID");
+    BOOST_REQUIRE(testEngineService.capturedNewPayloadRequest.has_value());
+    BOOST_REQUIRE(testEngineService.capturedNewPayloadVersion.has_value());
+    BOOST_TEST(*testEngineService.capturedNewPayloadVersion == 2);
+    BOOST_TEST(testEngineService.capturedNewPayloadRequest->executionPayload.transactions.size() == 1);
+    BOOST_REQUIRE(testEngineService.capturedNewPayloadRequest->executionPayload.withdrawals.has_value());
+    BOOST_TEST(testEngineService.capturedNewPayloadRequest->executionPayload.withdrawals->front().amount ==
+               expectedLargeValue);
+    BOOST_REQUIRE(testEngineService.capturedNewPayloadRequest->executionPayload.blobGasUsed.has_value());
+    BOOST_REQUIRE(testEngineService.capturedNewPayloadRequest->executionPayload.excessBlobGas.has_value());
+    BOOST_TEST(*testEngineService.capturedNewPayloadRequest->executionPayload.blobGasUsed ==
+               expectedLargeValue);
+    BOOST_TEST(*testEngineService.capturedNewPayloadRequest->executionPayload.excessBlobGas ==
+               expectedLargeValue);
+
+    bytes decodedEncodedTx;
+    testEngineService.capturedNewPayloadRequest->executionPayload.transactions.front()->encode(
+        decodedEncodedTx);
+    BOOST_TEST(toHexStringWithPrefix(decodedEncodedTx) == encodedTxHex);
+
+    testEngineService.getPayloadResult.executionPayload =
+        testEngineService.capturedNewPayloadRequest->executionPayload;
+    testEngineService.getPayloadResult.blockValue = expectedLargeValue;
+
+    const auto getPayloadRequest =
+        R"({"jsonrpc":"2.0","id":9,"method":"engine_getPayloadV2","params":["payload-id-1"]})";
+    auto getPayloadResponse = onRPCRequestWrapper(getPayloadRequest);
+    validRespCheck(getPayloadResponse);
+    BOOST_REQUIRE(testEngineService.capturedPayloadId.has_value());
+    BOOST_REQUIRE(testEngineService.capturedGetPayloadVersion.has_value());
+    BOOST_TEST(*testEngineService.capturedPayloadId == "payload-id-1");
+    BOOST_TEST(*testEngineService.capturedGetPayloadVersion == 2);
+    BOOST_TEST(getPayloadResponse["result"]["transactions"].size() == 1);
+    BOOST_TEST(getPayloadResponse["result"]["transactions"][0].asString() == encodedTxHex);
+    BOOST_TEST(getPayloadResponse["result"]["withdrawals"][0]["amount"].asString() ==
+               largeQuantity);
+    BOOST_TEST(getPayloadResponse["result"]["blobGasUsed"].asString() == largeQuantity);
+    BOOST_TEST(getPayloadResponse["result"]["excessBlobGas"].asString() == largeQuantity);
+    BOOST_TEST(getPayloadResponse["result"]["blockValue"].asString() == largeQuantity);
+}
+
 BOOST_AUTO_TEST_CASE(logMatcherTest)
 {
     // clang-format off

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -84,7 +84,8 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
     auto nodeService =
         std::make_shared<NodeService>(m_nodeInitializer->ledger(), m_nodeInitializer->scheduler(),
             m_nodeInitializer->txPoolInitializer()->txpool(), pbftInitializer->pbft(),
-            pbftInitializer->blockSync(), m_nodeInitializer->protocolInitializer()->blockFactory());
+            pbftInitializer->blockSync(), m_nodeInitializer->protocolInitializer()->blockFactory(),
+            nullptr);
 
     // create rpc
     RpcFactory rpcFactory(nodeConfig->chainId(), m_gateway, keyFactory,


### PR DESCRIPTION
## Summary

将 Engine API 端点从 mock 实现替换为对 `engineService` 的真实调用，并在 `NodeService` 中集成 `AnyEngineService`。

## Changes

### 1. NodeService 集成 engineService
- **`bcos-rpc/bcos-rpc/groupmgr/NodeService.h`**: 新增 `m_engineService` 成员（`std::shared_ptr<bcos::engine::AnyEngineService>`），构造函数增加对应参数，并提供 getter 方法
- **`bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp`**: `NodeServiceFactory::buildNodeService` 传入 `nullptr` 作为 engineService 初始值

### 2. EngineEndpoint 真实实现
- **`bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp`**: 从 ~80 行 mock 实现重写为 ~450 行真实 Engine API 调用
  - 新增 JSON 解析辅助函数：`parseH256`、`parseAddress`、`parseForkchoiceState`、`parsePayloadAttributes`、`parseNewPayloadRequest`
  - 新增 JSON 序列化辅助函数：`serializePayloadStatus`、`serializForkchoiceUpdatedResult`、`serializeExecutionPayload`
  - 新增 `buildEngineNotAvailableError`：当 engine 服务不可用时返回 JSON-RPC 错误码 -32000
  - 11 个端点（forkchoiceUpdated V1/V2/V3、getPayload V1/V2/V3、newPayload V1/V2/V3、exchangeCapabilities）全部改为调用 `engineService` 真实接口
  - 支持 withdrawals、blob transactions、Capella payload attributes 的解析与序列化

### 3. AirNodeInitializer 适配
- **`fisco-bcos-air/AirNodeInitializer.cpp`**: `NodeService` 构造增加 `nullptr` 参数以匹配新签名

## Files Changed
| File | +/- |
|------|-----|
| `bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp` | +1/-1 |
| `bcos-rpc/bcos-rpc/groupmgr/NodeService.h` | +16/-0 |
| `bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp` | +395/-37 |
| `fisco-bcos-air/AirNodeInitializer.cpp` | +3/-1 |