### PR TITLE
Optimize vcpkg cache: remove unused debug libs and strip release artifacts

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -52,13 +52,14 @@ jobs:
         id: vcpkg-cache
         with:
           path: |
-            ${{ github.workspace }}/vcpkg
+            ${{ github.workspace }}/vcpkg/.vcpkg-root
+            ${{ github.workspace }}/vcpkg/vcpkg
+            ${{ github.workspace }}/vcpkg/ports
+            ${{ github.workspace }}/vcpkg/scripts
+            ${{ github.workspace }}/vcpkg/triplets
+            ${{ github.workspace }}/vcpkg/versions
             ${{ github.workspace }}/build/vcpkg_installed
-            !${{ github.workspace }}/vcpkg/.git
-            !${{ github.workspace }}/vcpkg/buildtrees
-            !${{ github.workspace }}/vcpkg/packages
-            !${{ github.workspace }}/vcpkg/downloads
-          key: vcpkg-${{ hashFiles( 'vcpkg.json' ) }}-${{ hashFiles( 'vcpkg-configuration.json' ) }}-${{ runner.os }}-${{ runner.arch }}-cache-key-v1
+          key: vcpkg-${{ hashFiles( 'vcpkg.json' ) }}-${{ hashFiles( 'vcpkg-configuration.json' ) }}-${{ runner.os }}-${{ runner.arch }}-cache-key-v2
       - name: Set up Node.js 20
         if: matrix.os != 'windows-2025'
         uses: actions/setup-node@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -175,7 +175,7 @@ jobs:
 
           # 2) Strip release static libs (remove debug info, keep symbols needed for linking)
           echo "Stripping release static libraries..."
-          find build/vcpkg_installed \( -name "*.a" -o -name "*.dylib" \) -print -exec strip --strip-debug {} \; 2>/dev/null || true
+          find build/vcpkg_installed \( -name "*.a" -o -name "*.dylib" \) -print -exec strip -S {} \; 2>/dev/null || true
 
           # 3) Remove per-package build workdirs if present (already excluded from cache, paranoia)
           rm -rf build/vcpkg_installed/*/src 2>/dev/null || true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -161,10 +161,26 @@ jobs:
         run: |
           cd tools
           bash .ci/ci_check_air.sh ${{ github.base_ref }} "true"
-      - name: Strip debug symbols from vcpkg static libs
+      - name: Reduce vcpkg cache size
         if: matrix.os != 'windows-2025'
         run: |
-          find build/vcpkg_installed -path "*/debug/*" \( -name "*.a" -o -name "*.dylib" \) -print -exec strip --strip-debug {} \; 2>/dev/null || true
+          set -euo pipefail
+          echo "=== Before cleanup ==="
+          du -sh build/vcpkg_installed 2>/dev/null || true
+
+          # 1) Remove entire debug/ tree — MinSizeRel CI never links debug libs
+          echo "Removing debug libraries..."
+          find build/vcpkg_installed -type d -name debug -prune -print -exec rm -rf {} + 2>/dev/null || true
+
+          # 2) Strip release static libs (remove debug info, keep symbols needed for linking)
+          echo "Stripping release static libraries..."
+          find build/vcpkg_installed \( -name "*.a" -o -name "*.dylib" \) -print -exec strip --strip-debug {} \; 2>/dev/null || true
+
+          # 3) Remove per-package build workdirs if present (already excluded from cache, paranoia)
+          rm -rf build/vcpkg_installed/*/src 2>/dev/null || true
+
+          echo "=== After cleanup ==="
+          du -sh build/vcpkg_installed 2>/dev/null || true
       - name: Set packaging variables
         if: github.event_name == 'release' && matrix.os != 'windows-2025'
         id: pkgvars

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -37,6 +37,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           clean: false
+      - name: Initialize vcpkg submodule
+        run: git submodule update --init --recursive -- vcpkg
+      - name: Compute vcpkg revision
+        id: vcpkg-revision
+        shell: bash
+        run: echo "revision=$(git -C vcpkg rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Set up JDK 11
         if: matrix.os != 'windows-2025'
         uses: actions/setup-java@v5
@@ -52,14 +58,8 @@ jobs:
         id: vcpkg-cache
         with:
           path: |
-            ${{ github.workspace }}/vcpkg/.vcpkg-root
-            ${{ github.workspace }}/vcpkg/vcpkg
-            ${{ github.workspace }}/vcpkg/ports
-            ${{ github.workspace }}/vcpkg/scripts
-            ${{ github.workspace }}/vcpkg/triplets
-            ${{ github.workspace }}/vcpkg/versions
             ${{ github.workspace }}/build/vcpkg_installed
-          key: vcpkg-${{ hashFiles( 'vcpkg.json' ) }}-${{ hashFiles( 'vcpkg-configuration.json' ) }}-${{ runner.os }}-${{ runner.arch }}-cache-key-v2
+          key: vcpkg-${{ hashFiles( 'vcpkg.json', 'vcpkg-configuration.json', 'ports/**' ) }}-${{ steps.vcpkg-revision.outputs.revision }}-${{ runner.os }}-${{ runner.arch }}-cache-key-v3
       - name: Set up Node.js 20
         if: matrix.os != 'windows-2025'
         uses: actions/setup-node@v4

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/build/vcpkg_installed
-          key: vcpkg-${{ hashFiles( 'vcpkg.json', 'vcpkg-configuration.json', 'ports/**' ) }}-${{ steps.vcpkg-revision.outputs.revision }}-${{ runner.os }}-${{ runner.arch }}-cache-key-v3
+          key: vcpkg-${{ hashFiles( 'vcpkg.json', 'vcpkg-configuration.json', 'ports/**' ) }}-${{ steps.vcpkg-revision.outputs.revision }}-${{ runner.os }}-${{ runner.arch }}-cache-key-v4
       - name: Set up Node.js 20
         if: matrix.os != 'windows-2025'
         uses: actions/setup-node@v4
@@ -169,9 +169,9 @@ jobs:
           echo "=== Before cleanup ==="
           du -sh build/vcpkg_installed 2>/dev/null || true
 
-          # 1) Remove entire debug/ — MinSizeRel CI never links debug libs
+          # 1) Remove only debug libraries — keep debug metadata/includes intact
           echo "Removing debug libraries..."
-          find build/vcpkg_installed -type d -name debug -prune -print -exec rm -rf {} + 2>/dev/null || true
+          find build/vcpkg_installed -path '*/debug/lib/*' \( -name "*.a" -o -name "*.so" -o -name "*.so.*" -o -name "*.dylib" \) -print -delete 2>/dev/null || true
 
           # 2) Strip release static libs (remove debug info, keep symbols needed for linking)
           echo "Stripping release static libraries..."

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -169,7 +169,7 @@ jobs:
           echo "=== Before cleanup ==="
           du -sh build/vcpkg_installed 2>/dev/null || true
 
-          # 1) Remove entire debug/ tree — MinSizeRel CI never links debug libs
+          # 1) Remove entire debug/ — MinSizeRel CI never links debug libs
           echo "Removing debug libraries..."
           find build/vcpkg_installed -type d -name debug -prune -print -exec rm -rf {} + 2>/dev/null || true
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -167,7 +167,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "=== Before cleanup ==="
-          du -sh build/vcpkg_installed 2>/dev/null || true
+          du -sh build/vcpkg_installed 2>/dev/null  || true
 
           # 1) Remove only debug libraries — keep debug metadata/includes intact
           echo "Removing debug libraries..."


### PR DESCRIPTION
## 变更说明

优化 GitHub Actions CI 中 vcpkg 缓存的体积，解决此前 strip 步骤效果不明显的问题。

### 问题诊断

之前在 workflow 中增加了 `strip --strip-debug` 来压缩 vcpkg 静态库，但效果不明显。经分析发现三层原因：

1. **debug/ 目录占 2.6GB（84%）**：CI 配置了 `x64-linux-release` triplet，但该文件在 vcpkg 的 `community/` 子目录中，直接写名字无法找到，实际回退到默认 `x64-linux` triplet（同时构建 debug + release）。而 CI 使用 `MinSizeRel` 构建，根本不需要 debug 库。
2. **Strip 后仍有 ~500MB 残留**：即使 strip 能把 `librocksdbd.a` 从 873MB 压缩到 182MB，debug/ 目录仍保留大量数据。
3. **release lib 从未被 strip**：原来的 strip 仅匹配 `*/debug/*` 路径，release `lib/` 的 270MB 未处理。

### 修改内容

将原来的 `Strip debug symbols from vcpkg static libs` 步骤替换为 `Reduce vcpkg cache size`：

- **直接删除 debug/ 目录**：对 MinSizeRel CI 完全无用，节省 2.6GB
- **Strip 所有 .a/.dylib**：包括 release lib，进一步压缩
- **清理残留 src/**：额外保险

预期效果：vcpkg 缓存从 ~3.1GB 降至 ~400MB（约 87% 缩减）。
