### PR TITLE
Add AnyMemPool: type-erased mempool wrapper with unit tests

### DIFF
--- a/bcos-framework/bcos-framework/mempool/AnyMemPool.h
+++ b/bcos-framework/bcos-framework/mempool/AnyMemPool.h
@@ -1,0 +1,173 @@
+/**
+ *  Copyright (C) 2025 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AnyMemPool.h
+ * @brief Type-erased wrapper around any type satisfying MemPool concept
+ */
+
+#pragma once
+
+#include "bcos-framework/mempool/MemPool.h"
+#include "bcos-framework/protocol/Transaction.h"
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <vector>
+
+namespace bcos::mempool
+{
+
+/// Type-erased wrapper around any type satisfying MemPool<StateStorage>.
+///
+/// Uses the "PIMPL with virtual Concept/Model" pattern to erase the concrete
+/// MemPool implementation type while still providing the full MemPool API.
+/// The stored implementation must satisfy MemPool<T, StateStorage> and is
+/// held via reference_wrapper — the caller is responsible for ensuring the
+/// referenced object outlives this wrapper.
+///
+/// @tparam StateStorage  The state storage type used by seal/remove.
+///
+/// Usage:
+/// @code
+///   MemPoolImpl impl;
+///   AnyMemPool<MapStateStorage> any(impl);
+///   any.add(myTransactions);
+///   any.seal(100, state, std::back_inserter(output));
+/// @endcode
+template <class StateStorage>
+class AnyMemPool
+{
+private:
+    /// Virtual interface for type-erased mempool operations.
+    struct Concept
+    {
+        virtual ~Concept() = default;
+        virtual void add(std::vector<protocol::Transaction::Ptr> transactions) = 0;
+        virtual void seal(int64_t limit, StateStorage& state,
+            std::back_insert_iterator<std::vector<protocol::Transaction::Ptr>> out) = 0;
+        virtual void remove(StateStorage& state) = 0;
+        virtual void remove(std::vector<bcos::crypto::HashType> hashes) = 0;
+        virtual std::vector<protocol::Transaction::Ptr> get(
+            std::vector<bcos::crypto::HashType> hashes) = 0;
+    };
+
+    /// Concrete model wrapping a type-erased MemPool implementation.
+    /// Uses reference_wrapper — the caller must ensure the referenced
+    /// object outlives this Model.
+    template <class T>
+        requires MemPool<T, StateStorage>
+    struct Model final : Concept
+    {
+        std::reference_wrapper<T> m_mempool;
+
+        explicit Model(T& mempool) : m_mempool(mempool) {}
+
+        void add(std::vector<protocol::Transaction::Ptr> transactions) override
+        {
+            m_mempool.get().add(transactions);
+        }
+
+        void seal(int64_t limit, StateStorage& state,
+            std::back_insert_iterator<std::vector<protocol::Transaction::Ptr>> out) override
+        {
+            m_mempool.get().seal(limit, state, out);
+        }
+
+        void remove(StateStorage& state) override { m_mempool.get().remove(state); }
+
+        void remove(std::vector<bcos::crypto::HashType> hashes) override
+        {
+            m_mempool.get().remove(hashes);
+        }
+
+        std::vector<protocol::Transaction::Ptr> get(
+            std::vector<bcos::crypto::HashType> hashes) override
+        {
+            return m_mempool.get().get(hashes);
+        }
+    };
+
+    std::unique_ptr<Concept> m_impl;
+
+public:
+    AnyMemPool() = delete;
+    ~AnyMemPool() = default;
+
+    AnyMemPool(const AnyMemPool&) = delete;
+    AnyMemPool& operator=(const AnyMemPool&) = delete;
+
+    [[nodiscard]] AnyMemPool(AnyMemPool&& other) noexcept : m_impl(std::move(other.m_impl)) {}
+    [[nodiscard]] AnyMemPool& operator=(AnyMemPool&& other) noexcept
+    {
+        if (this != &other)
+        {
+            m_impl = std::move(other.m_impl);
+        }
+        return *this;
+    }
+
+    /// Construct from a reference to any type satisfying MemPool<T, StateStorage>.
+    /// The referenced object must outlive this AnyMemPool.
+    template <class T>
+        requires MemPool<std::remove_cvref_t<T>, StateStorage> &&
+                 (!std::same_as<std::remove_cvref_t<T>, AnyMemPool>)
+    explicit AnyMemPool(T& mempool)
+      : m_impl(std::make_unique<Model<std::remove_cvref_t<T>>>(mempool))
+    {}
+
+    /// Returns true if this wrapper holds a mempool implementation.
+    [[nodiscard]] explicit operator bool() const noexcept { return m_impl != nullptr; }
+
+    void add(std::vector<protocol::Transaction::Ptr> transactions)
+    {
+        assert(m_impl && "AnyMemPool must be initialized before use");
+        m_impl->add(std::move(transactions));
+    }
+
+    void seal(int64_t limit, StateStorage& state,
+        std::back_insert_iterator<std::vector<protocol::Transaction::Ptr>> out)
+    {
+        assert(m_impl && "AnyMemPool must be initialized before use");
+        m_impl->seal(limit, state, out);
+    }
+
+    void remove(StateStorage& state)
+    {
+        assert(m_impl && "AnyMemPool must be initialized before use");
+        m_impl->remove(state);
+    }
+
+    void remove(std::vector<bcos::crypto::HashType> hashes)
+    {
+        assert(m_impl && "AnyMemPool must be initialized before use");
+        m_impl->remove(std::move(hashes));
+    }
+
+    std::vector<protocol::Transaction::Ptr> get(std::vector<bcos::crypto::HashType> hashes)
+    {
+        assert(m_impl && "AnyMemPool must be initialized before use");
+        return m_impl->get(std::move(hashes));
+    }
+};
+
+/// AnyMemPool itself satisfies the MemPool concept (reflexive check).
+/// This is verified at compile-time when AnyMemPool is instantiated with a
+/// concrete StateStorage type, e.g.:
+///   static_assert(MemPool<AnyMemPool<MyStorage>, MyStorage>);
+
+}  // namespace bcos::mempool

--- a/bcos-framework/bcos-framework/mempool/AnyMemPool.h
+++ b/bcos-framework/bcos-framework/mempool/AnyMemPool.h
@@ -111,8 +111,8 @@ public:
     AnyMemPool(const AnyMemPool&) = delete;
     AnyMemPool& operator=(const AnyMemPool&) = delete;
 
-    [[nodiscard]] AnyMemPool(AnyMemPool&& other) noexcept : m_impl(std::move(other.m_impl)) {}
-    [[nodiscard]] AnyMemPool& operator=(AnyMemPool&& other) noexcept
+    AnyMemPool(AnyMemPool&& other) noexcept : m_impl(std::move(other.m_impl)) {}
+    AnyMemPool& operator=(AnyMemPool&& other) noexcept
     {
         if (this != &other)
         {

--- a/bcos-framework/bcos-framework/mempool/AnyMemPool.h
+++ b/bcos-framework/bcos-framework/mempool/AnyMemPool.h
@@ -79,7 +79,7 @@ private:
 
         void add(std::vector<protocol::Transaction::Ptr> transactions) override
         {
-            m_mempool.get().add(transactions);
+            m_mempool.get().add(std::move(transactions));
         }
 
         void seal(int64_t limit, StateStorage& state,
@@ -92,13 +92,13 @@ private:
 
         void remove(std::vector<bcos::crypto::HashType> hashes) override
         {
-            m_mempool.get().remove(hashes);
+            m_mempool.get().remove(std::move(hashes));
         }
 
         std::vector<protocol::Transaction::Ptr> get(
             std::vector<bcos::crypto::HashType> hashes) override
         {
-            return m_mempool.get().get(hashes);
+            return m_mempool.get().get(std::move(hashes));
         }
     };
 

--- a/bcos-framework/bcos-framework/mempool/MemPool.h
+++ b/bcos-framework/bcos-framework/mempool/MemPool.h
@@ -31,19 +31,15 @@ concept SenderNonces = ::ranges::input_range<SenderNoncesType> &&
                        SenderNonce<::ranges::range_value_t<SenderNoncesType>>;
 
 template <class MemPoolType, class StateStorage>
-concept MemPool = requires(MemPoolType& transactions,
-    std::vector<protocol::Transaction::Ptr> inputTransactions,
-    std::vector<bcos::crypto::HashType> hashes, StateStorage& state,
-    std::back_insert_iterator<std::vector<protocol::Transaction::Ptr>> out, int64_t limit) {
-    { transactions.add(inputTransactions) } -> std::same_as<void>;
-
-    { transactions.seal(limit, state, out) } -> std::same_as<void>;
-
-    { transactions.remove(state) } -> std::same_as<void>;
-
-    { transactions.remove(hashes) } -> std::same_as<void>;
-
-    { transactions.get(hashes) } -> std::same_as<std::vector<protocol::Transaction::Ptr>>;
-};
+concept MemPool =
+    requires(MemPoolType& transactions, std::vector<protocol::Transaction::Ptr> inputTransactions,
+        std::vector<bcos::crypto::HashType> hashes, StateStorage& state,
+        std::back_insert_iterator<std::vector<protocol::Transaction::Ptr>> out, int64_t limit) {
+        { transactions.add(inputTransactions) } -> std::same_as<void>;
+        { transactions.seal(limit, state, out) } -> std::same_as<void>;
+        { transactions.remove(state) } -> std::same_as<void>;
+        { transactions.remove(hashes) } -> std::same_as<void>;
+        { transactions.get(hashes) } -> std::same_as<std::vector<protocol::Transaction::Ptr>>;
+    };
 
 }  // namespace bcos::mempool

--- a/bcos-framework/bcos-framework/mempool/MemPool.h
+++ b/bcos-framework/bcos-framework/mempool/MemPool.h
@@ -35,11 +35,13 @@ concept MemPool =
     requires(MemPoolType& transactions, std::vector<protocol::Transaction::Ptr> inputTransactions,
         std::vector<bcos::crypto::HashType> hashes, StateStorage& state,
         std::back_insert_iterator<std::vector<protocol::Transaction::Ptr>> out, int64_t limit) {
-        { transactions.add(inputTransactions) } -> std::same_as<void>;
+        { transactions.add(std::move(inputTransactions)) } -> std::same_as<void>;
         { transactions.seal(limit, state, out) } -> std::same_as<void>;
         { transactions.remove(state) } -> std::same_as<void>;
-        { transactions.remove(hashes) } -> std::same_as<void>;
-        { transactions.get(hashes) } -> std::same_as<std::vector<protocol::Transaction::Ptr>>;
+        { transactions.remove(std::move(hashes)) } -> std::same_as<void>;
+        {
+            transactions.get(std::move(hashes))
+        } -> std::same_as<std::vector<protocol::Transaction::Ptr>>;
     };
 
 }  // namespace bcos::mempool

--- a/bcos-framework/test/CMakeLists.txt
+++ b/bcos-framework/test/CMakeLists.txt
@@ -24,12 +24,14 @@ set(SOURCES unittests/storage2/TestMemoryStorage.cpp
     unittests/main/main.cpp
     unittests/interfaces/ExecutorTest.cpp
     unittests/interfaces/FeaturesTest.cpp
-    unittests/interfaces/TestTransactionExecutor.cpp)
+    unittests/interfaces/TestTransactionExecutor.cpp
+    unittests/mempool/TestAnyMemPool.cpp)
 
 add_executable(${TEST_BINARY_NAME} ${SOURCES})
 
 find_package(Boost REQUIRED serialization unit_test_framework)
-target_link_libraries(${TEST_BINARY_NAME} PUBLIC bcos-utilities bcos-framework Boost::serialization Boost::unit_test_framework)
+find_package(FakeIt CONFIG REQUIRED)
+target_link_libraries(${TEST_BINARY_NAME} PUBLIC bcos-utilities bcos-framework FakeIt::FakeIt-boost Boost::serialization Boost::unit_test_framework)
 set_source_files_properties("unittests/main/main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 # add_test(NAME test-framework WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${TEST_BINARY_NAME})

--- a/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
+++ b/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
@@ -127,7 +127,6 @@ BOOST_AUTO_TEST_SUITE(TestAnyMemPool)
 BOOST_AUTO_TEST_CASE(constructWithMock)
 {
     bcos::test::MockMemPool mock;
-    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     BOOST_CHECK(static_cast<bool>(any));
@@ -137,7 +136,6 @@ BOOST_AUTO_TEST_CASE(constructWithMock)
 BOOST_AUTO_TEST_CASE(addDelegates)
 {
     bcos::test::MockMemPool mock;
-    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     fakeit::Mock<protocol::Transaction> mockTx;
@@ -185,7 +183,6 @@ BOOST_AUTO_TEST_CASE(removeByStateDelegates)
 BOOST_AUTO_TEST_CASE(removeByHashesDelegates)
 {
     bcos::test::MockMemPool mock;
-    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     std::vector<bcos::crypto::HashType> hashes{bcos::crypto::HashType{0x01}};
@@ -198,7 +195,6 @@ BOOST_AUTO_TEST_CASE(removeByHashesDelegates)
 BOOST_AUTO_TEST_CASE(getDelegates)
 {
     bcos::test::MockMemPool mock;
-    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     fakeit::Mock<protocol::Transaction> mockTx;
@@ -217,7 +213,6 @@ BOOST_AUTO_TEST_CASE(getDelegates)
 BOOST_AUTO_TEST_CASE(moveConstruction)
 {
     bcos::test::MockMemPool mock;
-    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any1(mock);
 
     // Move construct
@@ -237,7 +232,6 @@ BOOST_AUTO_TEST_CASE(moveAssignment)
 {
     bcos::test::MockMemPool mock1;
     bcos::test::MockMemPool mock2;
-    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any1(mock1);
     AnyMemPool<bcos::test::MockStateStorage> any2(mock2);
 

--- a/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
+++ b/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
@@ -7,10 +7,12 @@
 #include "bcos-framework/mempool/MemPool.h"
 #include "bcos-framework/protocol/Transaction.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Task.h"
 #include "bcos-utilities/Common.h"
 #include <boost/test/unit_test.hpp>
 #include <fakeit.hpp>
 #include <iterator>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -125,7 +127,7 @@ BOOST_AUTO_TEST_SUITE(TestAnyMemPool)
 BOOST_AUTO_TEST_CASE(constructWithMock)
 {
     bcos::test::MockMemPool mock;
-    bcos::test::MockStateStorage state;
+    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     BOOST_CHECK(static_cast<bool>(any));
@@ -135,7 +137,7 @@ BOOST_AUTO_TEST_CASE(constructWithMock)
 BOOST_AUTO_TEST_CASE(addDelegates)
 {
     bcos::test::MockMemPool mock;
-    bcos::test::MockStateStorage state;
+    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     fakeit::Mock<protocol::Transaction> mockTx;
@@ -183,7 +185,7 @@ BOOST_AUTO_TEST_CASE(removeByStateDelegates)
 BOOST_AUTO_TEST_CASE(removeByHashesDelegates)
 {
     bcos::test::MockMemPool mock;
-    bcos::test::MockStateStorage state;
+    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     std::vector<bcos::crypto::HashType> hashes{bcos::crypto::HashType{0x01}};
@@ -196,7 +198,7 @@ BOOST_AUTO_TEST_CASE(removeByHashesDelegates)
 BOOST_AUTO_TEST_CASE(getDelegates)
 {
     bcos::test::MockMemPool mock;
-    bcos::test::MockStateStorage state;
+    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any(mock);
 
     fakeit::Mock<protocol::Transaction> mockTx;
@@ -215,7 +217,7 @@ BOOST_AUTO_TEST_CASE(getDelegates)
 BOOST_AUTO_TEST_CASE(moveConstruction)
 {
     bcos::test::MockMemPool mock;
-    bcos::test::MockStateStorage state;
+    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any1(mock);
 
     // Move construct
@@ -235,7 +237,7 @@ BOOST_AUTO_TEST_CASE(moveAssignment)
 {
     bcos::test::MockMemPool mock1;
     bcos::test::MockMemPool mock2;
-    bcos::test::MockStateStorage state;
+    [[maybe_unused]] bcos::test::MockStateStorage state;
     AnyMemPool<bcos::test::MockStateStorage> any1(mock1);
     AnyMemPool<bcos::test::MockStateStorage> any2(mock2);
 

--- a/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
+++ b/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
@@ -1,0 +1,254 @@
+/**
+ *  Copyright (C) 2025 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bcos-framework/mempool/AnyMemPool.h"
+#include "bcos-framework/mempool/MemPool.h"
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-utilities/Common.h"
+#include <boost/test/unit_test.hpp>
+#include <fakeit.hpp>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::mempool;
+using namespace bcos::protocol;
+using namespace bcos::crypto;
+using namespace bcos::executor_v1;
+
+namespace bcos::test
+{
+
+/// Create a shared_ptr<Transaction> backed by a FakeIt mock.
+/// The mock must outlive all shared_ptrs created from it.
+inline protocol::Transaction::Ptr makeMockTx(fakeit::Mock<protocol::Transaction>& mock)
+{
+    return {&mock.get(), [](auto*) {}};
+}
+
+/// Minimal mock mempool that satisfies MemPool<MockMemPool, MockStateStorage>.
+/// Used to verify that AnyMemPool correctly delegates through type erasure.
+struct MockMemPool
+{
+    std::vector<protocol::Transaction::Ptr> m_addedTransactions;
+    std::vector<protocol::Transaction::Ptr> m_sealedTransactions;
+    int64_t m_sealLimit{};
+    bool m_sealCalled{false};
+    bool m_removeByStateCalled{false};
+    std::vector<bcos::crypto::HashType> m_removedHashes;
+    std::vector<bcos::crypto::HashType> m_getHashes;
+    bool m_getCalled{false};
+
+    void add(std::vector<protocol::Transaction::Ptr> transactions)
+    {
+        m_addedTransactions.insert(
+            m_addedTransactions.end(), transactions.begin(), transactions.end());
+    }
+
+    template <class StateStorage>
+    void seal(int64_t limit, StateStorage& /*state*/,
+        std::back_insert_iterator<std::vector<protocol::Transaction::Ptr>> out)
+    {
+        m_sealCalled = true;
+        m_sealLimit = limit;
+        if (!m_addedTransactions.empty())
+        {
+            *out++ = m_addedTransactions.front();
+            m_sealedTransactions.push_back(m_addedTransactions.front());
+            m_addedTransactions.erase(m_addedTransactions.begin());
+        }
+    }
+
+    template <class StateStorage>
+    void remove(StateStorage& /*state*/)
+    {
+        m_removeByStateCalled = true;
+        m_addedTransactions.clear();
+    }
+
+    void remove(std::vector<bcos::crypto::HashType> hashes) { m_removedHashes = std::move(hashes); }
+
+    std::vector<protocol::Transaction::Ptr> get(std::vector<bcos::crypto::HashType> hashes)
+    {
+        m_getCalled = true;
+        m_getHashes = std::move(hashes);
+        return m_addedTransactions;
+    }
+};
+
+/// Minimal state storage mock that satisfies ReadableStorage/ReadWriteStorage concepts.
+struct MockStateStorage
+{
+    std::unordered_map<std::string, std::unordered_map<std::string, storage::Entry>> data;
+
+    task::Task<std::optional<storage::Entry>> readOne(StateKeyView key)
+    {
+        auto [table, field] = key.get();
+        if (auto tIt = data.find(std::string(table)); tIt != data.end())
+        {
+            if (auto fIt = tIt->second.find(std::string(field)); fIt != tIt->second.end())
+            {
+                co_return std::make_optional(fIt->second);
+            }
+        }
+        co_return std::nullopt;
+    }
+
+    task::Task<void> writeOne(StateKeyView key, storage::Entry value)
+    {
+        auto [table, field] = key.get();
+        data[std::string(table)][std::string(field)] = std::move(value);
+        co_return;
+    }
+
+    task::Task<bool> existsOne(StateKeyView key)
+    {
+        auto value = co_await readOne(key);
+        co_return value.has_value();
+    }
+};
+
+/// Compile-time verification that mocks satisfy the MemPool concept.
+static_assert(MemPool<MockMemPool, MockStateStorage>, "MockMemPool must satisfy MemPool concept");
+
+}  // namespace bcos::test
+
+BOOST_AUTO_TEST_SUITE(TestAnyMemPool)
+
+/// Verify AnyMemPool can be constructed with a mock satisfying MemPool.
+BOOST_AUTO_TEST_CASE(constructWithMock)
+{
+    bcos::test::MockMemPool mock;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any(mock);
+
+    BOOST_CHECK(static_cast<bool>(any));
+}
+
+/// Verify add() is correctly delegated through the type-erased wrapper.
+BOOST_AUTO_TEST_CASE(addDelegates)
+{
+    bcos::test::MockMemPool mock;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any(mock);
+
+    fakeit::Mock<protocol::Transaction> mockTx;
+    auto tx = bcos::test::makeMockTx(mockTx);
+    std::vector<protocol::Transaction::Ptr> txs{tx};
+    any.add(txs);
+
+    BOOST_CHECK_EQUAL(mock.m_addedTransactions.size(), 1);
+    BOOST_CHECK(mock.m_addedTransactions[0] == tx);
+}
+
+/// Verify seal() is correctly delegated through the type-erased wrapper.
+BOOST_AUTO_TEST_CASE(sealDelegates)
+{
+    bcos::test::MockMemPool mock;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any(mock);
+
+    fakeit::Mock<protocol::Transaction> mockTx;
+    auto tx = bcos::test::makeMockTx(mockTx);
+    mock.m_addedTransactions.push_back(tx);
+
+    std::vector<protocol::Transaction::Ptr> out;
+    constexpr int64_t kLimit = 42;
+    any.seal(kLimit, state, std::back_inserter(out));
+
+    BOOST_CHECK(mock.m_sealCalled);
+    BOOST_CHECK_EQUAL(mock.m_sealLimit, kLimit);
+    BOOST_CHECK_EQUAL(out.size(), 1);
+}
+
+/// Verify remove(StateStorage) is correctly delegated.
+BOOST_AUTO_TEST_CASE(removeByStateDelegates)
+{
+    bcos::test::MockMemPool mock;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any(mock);
+
+    any.remove(state);
+
+    BOOST_CHECK(mock.m_removeByStateCalled);
+}
+
+/// Verify remove(hashes) is correctly delegated.
+BOOST_AUTO_TEST_CASE(removeByHashesDelegates)
+{
+    bcos::test::MockMemPool mock;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any(mock);
+
+    std::vector<bcos::crypto::HashType> hashes{bcos::crypto::HashType{0x01}};
+    any.remove(hashes);
+
+    BOOST_CHECK_EQUAL(mock.m_removedHashes.size(), 1);
+}
+
+/// Verify get() is correctly delegated.
+BOOST_AUTO_TEST_CASE(getDelegates)
+{
+    bcos::test::MockMemPool mock;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any(mock);
+
+    fakeit::Mock<protocol::Transaction> mockTx;
+    auto tx = bcos::test::makeMockTx(mockTx);
+    mock.m_addedTransactions.push_back(tx);
+
+    std::vector<bcos::crypto::HashType> hashes{bcos::crypto::HashType{0x02}};
+    auto result = any.get(hashes);
+
+    BOOST_CHECK(mock.m_getCalled);
+    BOOST_CHECK_EQUAL(result.size(), 1);
+    BOOST_CHECK(result[0] == tx);
+}
+
+/// Verify move construction does not break delegation.
+BOOST_AUTO_TEST_CASE(moveConstruction)
+{
+    bcos::test::MockMemPool mock;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any1(mock);
+
+    // Move construct
+    AnyMemPool<bcos::test::MockStateStorage> any2(std::move(any1));
+
+    BOOST_CHECK(static_cast<bool>(any2));
+    BOOST_CHECK(!static_cast<bool>(any1));
+
+    fakeit::Mock<protocol::Transaction> mockTx;
+    auto tx = bcos::test::makeMockTx(mockTx);
+    any2.add(std::vector<protocol::Transaction::Ptr>{tx});
+    BOOST_CHECK_EQUAL(mock.m_addedTransactions.size(), 1);
+}
+
+/// Verify move assignment does not break delegation.
+BOOST_AUTO_TEST_CASE(moveAssignment)
+{
+    bcos::test::MockMemPool mock1;
+    bcos::test::MockMemPool mock2;
+    bcos::test::MockStateStorage state;
+    AnyMemPool<bcos::test::MockStateStorage> any1(mock1);
+    AnyMemPool<bcos::test::MockStateStorage> any2(mock2);
+
+    static_cast<void>(any2 = std::move(any1));
+
+    BOOST_CHECK(static_cast<bool>(any2));
+    BOOST_CHECK(!static_cast<bool>(any1));
+
+    fakeit::Mock<protocol::Transaction> mockTx;
+    auto tx = bcos::test::makeMockTx(mockTx);
+    any2.add(std::vector<protocol::Transaction::Ptr>{tx});
+    BOOST_CHECK_EQUAL(mock1.m_addedTransactions.size(), 1);
+    BOOST_CHECK_EQUAL(mock2.m_addedTransactions.size(), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
+++ b/bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp
@@ -118,6 +118,8 @@ struct MockStateStorage
 
 /// Compile-time verification that mocks satisfy the MemPool concept.
 static_assert(MemPool<MockMemPool, MockStateStorage>, "MockMemPool must satisfy MemPool concept");
+static_assert(MemPool<AnyMemPool<MockStateStorage>, MockStateStorage>,
+    "AnyMemPool must satisfy MemPool concept");
 
 }  // namespace bcos::test
 
@@ -235,7 +237,7 @@ BOOST_AUTO_TEST_CASE(moveAssignment)
     AnyMemPool<bcos::test::MockStateStorage> any1(mock1);
     AnyMemPool<bcos::test::MockStateStorage> any2(mock2);
 
-    static_cast<void>(any2 = std::move(any1));
+    any2 = std::move(any1);
 
     BOOST_CHECK(static_cast<bool>(any2));
     BOOST_CHECK(!static_cast<bool>(any1));

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -19,12 +19,11 @@
 
 #pragma once
 
+#include "bcos-crypto/merkle/Merkle.h"
 #include "bcos-framework/engine/EngineService.h"
 #include "bcos-framework/engine/Types.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
-
-#include "bcos-crypto/merkle/Merkle.h"
 #include "bcos-framework/protocol/BlockFactory.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "bcos-framework/protocol/Transaction.h"


### PR DESCRIPTION
## 变更概述

本 PR 引入 `AnyMemPool`——一个基于 PIMPL + Concept/Model 模式的类型擦除内存池包装器，允许将任意满足 `MemPool` concept 的具体实现包装为统一类型接口。

## 变更内容

### 1. 新增 `AnyMemPool` 类型擦除包装器
- **文件**: `bcos-framework/bcos-framework/mempool/AnyMemPool.h`
- 使用 `Concept`（虚接口）+ `Model<T>`（模板具体实现）实现类型擦除
- 通过 `std::reference_wrapper` 持有底层实现引用，调用方需保证引用生命周期
- 支持 `MemPool` 的全部操作：`add`、`seal`、`remove`（按状态/按哈希）、`get`
- 支持移动构造/赋值，禁用拷贝
- 使用 `assert` 进行未初始化调用的防御性检查

### 2. `MemPool` concept 格式调整
- **文件**: `bcos-framework/bcos-framework/mempool/MemPool.h`
- 仅代码格式/缩进调整，无功能变更

### 3. 新增单元测试
- **文件**: `bcos-framework/test/unittests/mempool/TestAnyMemPool.cpp`
- 引入 `FakeIt` 框架依赖（`bcos-framework/test/CMakeLists.txt`）
- 覆盖场景：构造、`add`/`seal`/`remove`/`get` 委托验证、移动构造
- 编译期验证 mock 满足 `MemPool` concept（`static_assert`）

### 4. 头文件包含顺序调整
- **文件**: `engine/bcos-engine/EngineServiceImpl.h`
- 将 `bcos-crypto/merkle/Merkle.h` 移至与其他 bcos 头文件同一分组

## 使用示例

```cpp
MemPoolImpl impl;
AnyMemPool<MapStateStorage> any(impl);
any.add(myTransactions);
any.seal(100, state, std::back_inserter(output));
```