### PR TITLE
ci(coverage): post Codecov PR comment + checks via workflow_run

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,69 @@
+name: Coverage comment
+
+# Posts the Codecov coverage comment + project/patch checks on pull requests,
+# including PRs from forks.
+#
+# Why a separate workflow_run job instead of uploading inside the build:
+# GitHub runs a fork PR's own workflow with NO repository secrets and a
+# read-only token, so it can neither upload to Codecov (needs CODECOV_TOKEN)
+# nor comment (needs write). A workflow_run job runs in the BASE-repo context
+# after the build finishes, so it gets the token and write permission even for
+# fork PRs. workflow_run only triggers from the file on the default branch.
+#
+# Security: this job never checks out PR code. It consumes the coverage-data
+# artifact produced by the build and passes only a digits-validated PR number
+# to Codecov, avoiding the workflow_run "pwn request" pitfall.
+
+on:
+  workflow_run:
+    workflows: ["Github runner"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  upload:
+    name: Upload PR coverage to Codecov
+    runs-on: ubuntu-24.04
+    # Only PR-triggered builds carry a coverage-data artifact with a PR number.
+    if: github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download coverage artifact
+        id: download
+        continue-on-error: true # build may have skipped coverage (e.g. docs-only)
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-data
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: cov
+      - name: Validate PR number
+        id: pr
+        if: steps.download.outcome == 'success'
+        run: |
+          set -euo pipefail
+          num="$(cat cov/pr-number.txt)"
+          # cov/* originates from the untrusted fork run: accept digits only.
+          if ! printf '%s' "$num" | grep -Eq '^[0-9]+$'; then
+            echo "Refusing non-numeric PR number: '$num'" >&2
+            exit 1
+          fi
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+      - name: Upload to Codecov
+        if: steps.pr.outputs.number != ''
+        uses: codecov/codecov-action@v5
+        with:
+          files: cov/coverage.info
+          flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # workflow_run runs on the default branch, so point Codecov back at the
+          # PR's head commit and number explicitly. (override_branch is omitted on
+          # purpose: the fork branch name is attacker-controlled and Codecov only
+          # needs the commit + PR number to attach the report.)
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_pr: ${{ steps.pr.outputs.number }}
+          fail_ci_if_error: false
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,44 @@
+# Codecov configuration for FISCO-BCOS unit-test line coverage.
+# Drives two things on every pull request:
+#   1. A sticky PR comment summarizing coverage (the "comment" block).
+#   2. Status checks shown in the PR checks list (the "status" block):
+#      - codecov/project : total line coverage vs the target floor
+#      - codecov/patch   : coverage of the lines changed by the PR (informational)
+# Coverage data is uploaded under the "unittests" flag by the coverage-comment
+# workflow_run job (.github/workflows/coverage-comment.yml) for pull requests,
+# and directly by the Coverage build job for base-branch pushes.
+
+codecov:
+  require_ci_to_pass: false # don't block the Codecov status on unrelated matrix flakes
+  notify:
+    wait_for_ci: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...70" # red below 50%, green at 70%+ in the UI
+  status:
+    project:
+      default:
+        target: 55% # gcc-measured baseline ~59%; floor leaves headroom
+        threshold: 1% # tolerate a 1% drop before failing the check
+        flags:
+          - unittests
+    patch:
+      default:
+        informational: true # report changed-line coverage, never block on it
+
+comment:
+  layout: "header, diff, flags, files, footer"
+  behavior: default # update the same comment in place instead of posting new ones
+  require_changes: false # always comment, even if coverage is unchanged
+
+flags:
+  unittests:
+    paths:
+      - "!**/test/**"
+      - "!**/tests/**"
+    carryforward: true # reuse the last upload for a flag if a run didn't re-upload it
+
+github_checks:
+  annotations: true # inline coverage annotations on the PR diff


### PR DESCRIPTION
## What

Enables an automatic **Codecov coverage comment + status checks** (`codecov/project`, `codecov/patch`) on pull requests — **including PRs from forks**.

- `.github/workflows/coverage-comment.yml` — a `workflow_run` listener that uploads PR coverage to Codecov from the base-repo context.
- `codecov.yml` — comment layout + project (55% floor, 1% drop tolerance) / patch (informational) checks.

## Why a `workflow_run` job

A fork PR's own workflow run gets **no repository secrets and a read-only token**, so it can neither upload to Codecov (needs `CODECOV_TOKEN`) nor post a comment (needs write). A `workflow_run` job runs in the **base-repo context** after the build finishes, so it has the token and write permission even for fork PRs. `workflow_run` only triggers from the **default branch**, which is why this must live on `master`.

## Security

The job never checks out PR code. It consumes the `coverage-data` artifact produced by the build and passes only a **digits-validated** PR number to Codecov, avoiding the `workflow_run` pwn-request class of issues. The attacker-controlled fork branch name is intentionally not forwarded.

## Prerequisites

- `CODECOV_TOKEN` repo secret (set).
- Codecov GitHub App installed (done).
- The PR's target branch must have a Coverage job that publishes a `coverage-data` artifact (`coverage.info` + `pr-number.txt`). `release-3.17.0` gets this via #5228. `master` still builds with `COVERAGE=OFF`; adding a Coverage job to `master` is a separate change.