### PR TITLE
ci(codecov): disable 12h report-age check so coverage reports stop erroring

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,12 @@
 
 codecov:
   require_ci_to_pass: false # don't block the Codecov status on unrelated matrix flakes
+  # Disable the report-age check. Codecov's default rejects reports older than
+  # 12h ("Upload exceeds the max age of 12h"); on this freshly-activated repo the
+  # processing queue lags long enough that fresh reports get flagged as expired
+  # and error out, leaving every commit at 0.00%. We never want to drop a real
+  # CI report for being "old".
+  max_report_age: false
   notify:
     wait_for_ci: false
 
@@ -35,9 +41,9 @@ comment:
 
 flags:
   unittests:
-    paths:
-      - "!**/test/**"
-      - "!**/tests/**"
+    # No path filter: coverage.info already excludes tests (lcov --remove
+    # '*test*'), and a negative-only paths list can collapse the flag's file set
+    # to empty. Let the flag include every uploaded source file.
     carryforward: true # reuse the last upload for a flag if a run didn't re-upload it
 
 github_checks:


### PR DESCRIPTION
## Problem

Every commit on Codecov is stuck at `0.00%` with **"There is an error processing the coverage reports"** / "Upload exceeds the max age of 12h", even though the uploads succeed (HTTP 200) and the `coverage.info` is valid (800+ files, repo-relative paths).

## Root cause

Codecov's default `max_report_age` rejects reports older than **12h**. This repo's Codecov project was activated very recently, and its processing queue lags long enough (the first PR comment took ~16h to appear) that by the time a report is processed it's flagged as **expired** → errors out → `0.00%` everywhere. It's an age rejection, not a problem with the coverage data.

## Fix

- `codecov.max_report_age: false` — never drop a real CI report for being "old".
- Remove the negative-only `flags.unittests.paths` filter: `coverage.info` already excludes tests (`lcov --remove '*test*'`), and an all-exclusion `paths` list can collapse the flag's file set to empty.

Repo-level `codecov:` config is read from the default branch, so this lives on `master`; the same change goes to `release-3.17.0` for consistency.