### PR TITLE
ci(codecov): disable 12h report-age check on release-3.17.0

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,17 @@
 #      - codecov/project : total line coverage vs the target floor
 #      - codecov/patch   : coverage of the lines changed by the PR (informational)
 # Coverage data is uploaded under the "unittests" flag by the coverage-comment
-# workflow_run job (on master) for pull requests, and directly by the Coverage
-# build job here for base-branch pushes.
+# workflow_run job (.github/workflows/coverage-comment.yml) for pull requests,
+# and directly by the Coverage build job for base-branch pushes.
 
 codecov:
   require_ci_to_pass: false # don't block the Codecov status on unrelated matrix flakes
+  # Disable the report-age check. Codecov's default rejects reports older than
+  # 12h ("Upload exceeds the max age of 12h"); on this freshly-activated repo the
+  # processing queue lags long enough that fresh reports get flagged as expired
+  # and error out, leaving every commit at 0.00%. We never want to drop a real
+  # CI report for being "old".
+  max_report_age: false
   notify:
     wait_for_ci: false
 
@@ -35,9 +41,9 @@ comment:
 
 flags:
   unittests:
-    paths:
-      - "!**/test/**"
-      - "!**/tests/**"
+    # No path filter: coverage.info already excludes tests (lcov --remove
+    # '*test*'), and a negative-only paths list can collapse the flag's file set
+    # to empty. Let the flag include every uploaded source file.
     carryforward: true # reuse the last upload for a flag if a run didn't re-upload it
 
 github_checks:


### PR DESCRIPTION
Mirror of #5242 onto `release-3.17.0` so `codecov.yml` is consistent across branches.

## Problem
Coverage commits are stuck at `0.00%` with "error processing the coverage reports" / "Upload exceeds the max age of 12h", despite valid uploads.

## Cause
Codecov's default `max_report_age` rejects reports older than 12h. This freshly-activated Codecov project's processing queue lags long enough that fresh CI reports get flagged expired → error.

## Fix
- `codecov.max_report_age: false`
- Drop the negative-only `flags.unittests.paths` filter (redundant — `coverage.info` already excludes tests; an all-exclusion list can empty the flag).

See #5242 for the master-branch counterpart.