### PR TITLE
feat(mpt): M3 trie runtime (NodeCache, HashBuilder, Trie read view)

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/HashBuilder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/HashBuilder.cpp
@@ -1,0 +1,211 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HashBuilder.cpp
+ * @brief Canonical MPT construction from a key-set; computes the 32-byte state root (spec §5.3)
+ */
+
+#include "HashBuilder.h"
+#include "Constants.h"
+#include "Errors.h"
+#include "Nibble.h"
+#include "NodeEncoder.h"
+#include <bcos-crypto/hasher/AnyHasher.h>
+#include <span>
+#include <utility>
+
+namespace bcos::ledger::mpt
+{
+
+namespace
+{
+
+// One sorted entry: the full 64-nibble path and its value. Built once per key in commit().
+struct HBEntry
+{
+    bcos::bytes nibbles;  // exactly 64 nibbles (the key's bytesToNibbles form)
+    bcos::bytes value;
+};
+
+// State threaded through the synchronous recursion. emit() records every hash-kind node into
+// newNodes; commit() flushes them into the cache afterwards (avoids coroutine recursion).
+struct HBContext
+{
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher& hasher;
+    std::unordered_map<bcos::h256, bcos::bytes>& newNodes;
+};
+
+// Encode `node`, compute its ref, and record the raw bytes when the ref is a hash.
+NodeRef hbEmit(HBContext& ctx, TrieNode const& node)
+{
+    auto [raw, ref] = NodeEncoder<>::encodeAndRef(node, ctx.hasher);
+    if (ref.kind == NodeRef::Kind::Hash)
+    {
+        ctx.newNodes.emplace(ref.hash, std::move(raw));
+    }
+    return ref;
+}
+
+// Turn a NodeRef into the bytes an ExtensionNode.child expects: inline → raw bytes; hash → the
+// 33-byte RLP byte-string 0xa0 + hash.
+bcos::bytes hbRefToRaw(NodeRef const& ref)
+{
+    if (ref.kind == NodeRef::Kind::Inline)
+    {
+        return ref.inlineBytes;
+    }
+    bcos::bytes out;
+    out.reserve(1 + bcos::h256::SIZE);
+    out.push_back(0xa0);
+    out.insert(out.end(), ref.hash.begin(), ref.hash.end());
+    return out;
+}
+
+NodeRef hbBuild(HBContext& ctx, std::span<HBEntry const> entries, size_t depth);
+
+// Keys differ at `depth` (common prefix at this depth is empty) → a 16-way branch. Entries are
+// sorted, so equal nibble-at-depth values form contiguous groups.
+NodeRef hbBuildBranch(HBContext& ctx, std::span<HBEntry const> entries, size_t depth)
+{
+    BranchNode branch;
+    size_t i = 0;
+    while (i < entries.size())
+    {
+        bcos::byte const nibble = entries[i].nibbles[depth];
+        size_t j = i + 1;
+        while (j < entries.size() && entries[j].nibbles[depth] == nibble)
+        {
+            ++j;
+        }
+        branch.children[nibble] = hbBuild(ctx, entries.subspan(i, j - i), depth + 1);
+        i = j;
+    }
+    // With distinct 64-nibble keys, no key terminates before depth 64 → branch value stays empty.
+    return hbEmit(ctx, TrieNode{std::move(branch)});
+}
+
+// Build the subtree covering `entries`, whose paths all agree on the first `depth` nibbles.
+NodeRef hbBuild(HBContext& ctx, std::span<HBEntry const> entries, size_t depth)
+{
+    if (entries.size() == 1)
+    {
+        HBEntry const& only = entries.front();
+        LeafNode leaf;
+        // keyNibbles is the SUFFIX from `depth` to the end (64), not the full key.
+        leaf.keyNibbles.assign(only.nibbles.begin() + depth, only.nibbles.end());
+        leaf.value = only.value;
+        return hbEmit(ctx, TrieNode{std::move(leaf)});
+    }
+
+    // entries are sorted → the longest common prefix at `depth` is shared by first and last.
+    bcos::bytesConstRef const firstSuffix(
+        entries.front().nibbles.data() + depth, entries.front().nibbles.size() - depth);
+    bcos::bytesConstRef const lastSuffix(
+        entries.back().nibbles.data() + depth, entries.back().nibbles.size() - depth);
+    size_t const cpl = commonPrefixLen(firstSuffix, lastSuffix);
+
+    if (cpl > 0)
+    {
+        // Shared prefix → extension over [depth, depth+cpl) pointing at a branch below it.
+        NodeRef const childRef = hbBuildBranch(ctx, entries, depth + cpl);
+        ExtensionNode ext;
+        ext.sharedNibbles.assign(
+            entries.front().nibbles.begin() + depth, entries.front().nibbles.begin() + depth + cpl);
+        ext.child = hbRefToRaw(childRef);
+        return hbEmit(ctx, TrieNode{std::move(ext)});
+    }
+
+    return hbBuildBranch(ctx, entries, depth);
+}
+
+}  // namespace
+
+HashBuilder::HashBuilder(NodeCache& cache, bcos::h256 priorRoot)
+  : m_cache(cache), m_priorRoot(priorRoot)
+{}
+
+bcos::task::Task<void> HashBuilder::put(bcos::h256 const& keyHash, bcos::bytes value)
+{
+    m_changes[keyHash] = std::move(value);
+    co_return;
+}
+
+bcos::task::Task<void> HashBuilder::remove(bcos::h256 const& keyHash)
+{
+    m_changes[keyHash] = std::nullopt;
+    co_return;
+}
+
+bcos::task::Task<bcos::h256> HashBuilder::commit()
+{
+    if (m_priorRoot != emptyRootHash())
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTInvariantViolation{} << bcos::errinfo_comment(
+                "HashBuilder incremental rebuild on non-empty root is implemented in M4 (PR-10)"));
+    }
+
+    // 1) Drop deletes (no-op from empty); collect survivors in sorted order (map is sorted).
+    std::vector<HBEntry> entries;
+    entries.reserve(m_changes.size());
+    for (auto const& [key, maybeValue] : m_changes)
+    {
+        if (maybeValue.has_value())
+        {
+            entries.push_back(HBEntry{bytesToNibbles(key.ref()), *maybeValue});
+        }
+    }
+    if (entries.empty())
+    {
+        co_return emptyRootHash();
+    }
+
+    // 2) Build the canonical node tree synchronously, recording hash-kind nodes.
+    HBContext ctx{m_hasher, m_newNodes};
+    NodeRef const rootRef =
+        hbBuild(ctx, std::span<HBEntry const>{entries.data(), entries.size()}, /*depth=*/0);
+
+    // 3) A trie root is ALWAYS a 32-byte hash, even when the top node encodes to < 32 bytes.
+    bcos::h256 root;
+    if (rootRef.kind == NodeRef::Kind::Hash)
+    {
+        root = rootRef.hash;
+    }
+    else
+    {
+        bcos::crypto::hasher::hash(m_hasher, bcos::ref(rootRef.inlineBytes), root);
+        m_newNodes.emplace(root, rootRef.inlineBytes);
+    }
+
+    // 4) Flush every new node into the cache in one pass.
+    for (auto const& [hash, raw] : m_newNodes)
+    {
+        co_await m_cache.put(hash, raw);
+    }
+
+    co_return root;
+}
+
+std::unordered_map<bcos::h256, bcos::bytes> HashBuilder::drainNewNodes()
+{
+    return std::exchange(m_newNodes, {});
+}
+
+std::unordered_set<bcos::h256> HashBuilder::drainObsoletedNodes()
+{
+    return std::exchange(m_obsoleted, {});
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/HashBuilder.h
+++ b/bcos-ledger/bcos-ledger/mpt/HashBuilder.h
@@ -1,0 +1,77 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HashBuilder.h
+ * @brief Canonical MPT construction from a key-set; computes the 32-byte state root (spec §5.3)
+ */
+#pragma once
+
+#include "NodeCache.h"
+#include "TrieNode.h"
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <map>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace bcos::ledger::mpt
+{
+
+/// Accumulates put/remove operations keyed by a 32-byte keccak path, then builds the canonical
+/// Ethereum MPT and returns its 32-byte root.
+///
+/// Keys are full 32-byte hashes (the "secure trie" key transform happens upstream): their
+/// 64-nibble paths are all the same length, so no key ever terminates inside a branch — branch
+/// nodes never carry a value here. Because 32-byte lexicographic order equals 64-nibble order,
+/// the std::map of changes already yields paths in canonical sorted order.
+///
+/// SCOPE: only the from-empty build is implemented (m_priorRoot == emptyRootHash()). Incremental
+/// rebuild on a non-empty prior root throws MPTInvariantViolation and is deferred to M4 (PR-10).
+class HashBuilder
+{
+public:
+    HashBuilder(NodeCache& cache, bcos::h256 priorRoot);
+
+    /// Records a key→value insertion. Coroutine for call-style symmetry; body is trivial.
+    bcos::task::Task<void> put(bcos::h256 const& keyHash, bcos::bytes value);
+
+    /// Records a key deletion (no-op from an empty trie).
+    bcos::task::Task<void> remove(bcos::h256 const& keyHash);
+
+    /// Builds the canonical trie from the accumulated changes and returns the 32-byte root.
+    /// @throws MPTInvariantViolation when m_priorRoot != emptyRootHash() (M4 functionality).
+    bcos::task::Task<bcos::h256> commit();
+
+    /// Hash-keyed RLP encodings of every newly produced (>=32 byte) node, transferred out.
+    std::unordered_map<bcos::h256, bcos::bytes> drainNewNodes();
+
+    /// Hashes of nodes made obsolete by this commit (always empty for from-empty builds).
+    std::unordered_set<bcos::h256> drainObsoletedNodes();
+
+private:
+    NodeCache& m_cache;
+    bcos::h256 m_priorRoot;
+    /// key → value, or nullopt for a recorded delete. Sorted by 32-byte key == 64-nibble path.
+    std::map<bcos::h256, std::optional<bcos::bytes>> m_changes;
+    std::unordered_map<bcos::h256, bcos::bytes> m_newNodes;
+    std::unordered_set<bcos::h256> m_obsoleted;
+    /// Reused across encodeAndRef calls to amortise EVP_MD_CTX allocation.
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher m_hasher;
+};
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/NodeCache.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeCache.cpp
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeCache.cpp
+ * @brief LRU+CONCURRENT cache mapping node hash -> RLP-encoded MPT node (spec §5.1)
+ */
+#include "NodeCache.h"
+
+namespace bcos::ledger::mpt
+{
+NodeCache::NodeCache(size_t capacity) : m_inner(/*buckets=*/0, static_cast<int64_t>(capacity)) {}
+
+bcos::task::Task<std::optional<bcos::bytes>> NodeCache::get(bcos::h256 const& key)
+{
+    co_return co_await bcos::storage2::readOne(m_inner, key);
+}
+
+bcos::task::Task<void> NodeCache::put(bcos::h256 const& key, bcos::bytes value)
+{
+    co_await bcos::storage2::writeOne(m_inner, key, std::move(value));
+}
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/NodeCache.h
+++ b/bcos-ledger/bcos-ledger/mpt/NodeCache.h
@@ -1,0 +1,52 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeCache.h
+ * @brief LRU+CONCURRENT cache mapping node hash -> RLP-encoded MPT node (spec §5.1)
+ */
+#pragma once
+
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <optional>
+
+namespace bcos::ledger::mpt
+{
+/// Bounded cache for decoded/encoded MPT nodes. Keys are 32-byte node hashes,
+/// values are the RLP encoding of the node. Wraps bcos-framework MemoryStorage
+/// with CONCURRENT (thread-safe sharded buckets) and LRU (capacity-bounded)
+/// attributes so a hot working set stays resident while cold nodes are evicted.
+class NodeCache
+{
+public:
+    /// @param capacity LRU byte budget (sum of key+value sizes) before eviction.
+    explicit NodeCache(size_t capacity = 64 * 1024);
+
+    /// Returns the cached RLP encoding for @p key, or nullopt on a miss.
+    bcos::task::Task<std::optional<bcos::bytes>> get(bcos::h256 const& key);
+
+    /// Inserts or overwrites the RLP encoding for @p key.
+    bcos::task::Task<void> put(bcos::h256 const& key, bcos::bytes value);
+
+private:
+    using Inner = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes,
+        bcos::storage2::memory_storage::Attribute::CONCURRENT |
+            bcos::storage2::memory_storage::Attribute::LRU>;
+    Inner m_inner;
+};
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
@@ -20,8 +20,9 @@
 #include "NodeDecoder.h"
 #include "Errors.h"
 #include "HexPrefix.h"
-#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <vector>
 
 namespace bcos::ledger::mpt
 {
@@ -29,126 +30,37 @@ namespace bcos::ledger::mpt
 namespace
 {
 
-// A parsed RLP item header. The item occupies the raw span [pos, pos + headerLen + payloadLen);
-// for a string the content is [pos + headerLen, pos + headerLen + payloadLen) — except a
-// single-byte string (b < 0x80) whose content is the one byte at `pos` (headerLen == 0).
-struct DecoderItemView
+// One RLP item read out of a buffer: its full raw span (header + payload), its string content span
+// (payload only; for a single byte < 0x80 the lone byte itself), and whether the item is a list.
+// MPT keeps branch/extension child references RLP-encoded, so we must track the raw span — the
+// high-level codec::rlp::decode strips headers and rejects lists-into-byte-strings, hence we drop
+// to decodeHeader and capture spans ourselves.
+struct DecoderItem
 {
+    bcos::bytesConstRef raw;
+    bcos::bytesConstRef content;
     bool isList{false};
-    size_t headerLen{0};
-    size_t payloadLen{0};
 };
 
-// Reads `count` big-endian bytes starting at raw[pos] into a size_t. Throws if the span is
-// truncated. `count` is at most 8 (RLP long-form length-of-length never needs more for our sizes).
-size_t readBigEndianLen(bcos::bytesConstRef raw, size_t pos, size_t count)
+// Read one RLP item from `cursor`, advancing it past the whole item. All head-byte / long-length
+// parsing is delegated to the shared bcos::codec::rlp::decodeHeader (which also bounds-checks the
+// payload against the remaining input). Throws MPTDecodeError on malformed input.
+DecoderItem readItem(bcos::bytesRef& cursor)
 {
-    if (count == 0 || count > sizeof(size_t) || pos + count > raw.size())
+    bcos::byte const* const itemStart = cursor.data();
+    auto&& [error, header] = bcos::codec::rlp::decodeHeader(cursor);
+    if (error)
     {
-        BOOST_THROW_EXCEPTION(
-            MPTDecodeError{} << bcos::errinfo_comment("RLP length-of-length truncated"));
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "malformed RLP header while decoding MPT node"));
     }
-    size_t value = 0;
-    for (size_t i = 0; i < count; ++i)
-    {
-        value = (value << 8) | static_cast<size_t>(raw[pos + i]);
-    }
-    return value;
-}
-
-// Parse the RLP header of the item that starts at raw[pos]. Throws MPTDecodeError if the declared
-// span runs past raw.size().
-DecoderItemView parseItem(bcos::bytesConstRef raw, size_t pos)
-{
-    using namespace bcos::codec::rlp;
-    if (pos >= raw.size())
-    {
-        BOOST_THROW_EXCEPTION(
-            MPTDecodeError{} << bcos::errinfo_comment("RLP item starts past end of input"));
-    }
-
-    bcos::byte const b = raw[pos];
-    DecoderItemView view;
-    if (b < BYTES_HEAD_BASE)  // < 0x80: single-byte string, the byte IS the content
-    {
-        view = {.isList = false, .headerLen = 0, .payloadLen = 1};
-    }
-    else if (b <= LONG_BYTES_HEAD_BASE)  // 0x80..0xb7: short string
-    {
-        view = {.isList = false, .headerLen = 1, .payloadLen = static_cast<size_t>(b) - BYTES_HEAD_BASE};
-    }
-    else if (b < LIST_HEAD_BASE)  // 0xb8..0xbf: long string
-    {
-        size_t const lenOfLen = static_cast<size_t>(b) - LONG_BYTES_HEAD_BASE;
-        view = {.isList = false,
-            .headerLen = 1 + lenOfLen,
-            .payloadLen = readBigEndianLen(raw, pos + 1, lenOfLen)};
-    }
-    else if (b <= LONG_LIST_HEAD_BASE)  // 0xc0..0xf7: short list
-    {
-        view = {.isList = true, .headerLen = 1, .payloadLen = static_cast<size_t>(b) - LIST_HEAD_BASE};
-    }
-    else  // 0xf8..0xff: long list
-    {
-        size_t const lenOfLen = static_cast<size_t>(b) - LONG_LIST_HEAD_BASE;
-        view = {.isList = true,
-            .headerLen = 1 + lenOfLen,
-            .payloadLen = readBigEndianLen(raw, pos + 1, lenOfLen)};
-    }
-
-    if (pos + view.headerLen + view.payloadLen > raw.size())
-    {
-        BOOST_THROW_EXCEPTION(
-            MPTDecodeError{} << bcos::errinfo_comment("RLP item span exceeds input length"));
-    }
-    return view;
-}
-
-// One child item discovered while walking a list payload: its full RLP raw span, its string
-// content span, and whether the item is itself a list.
-struct DecoderChild
-{
-    bcos::bytesConstRef raw;      // [pos, pos + headerLen + payloadLen)
-    bcos::bytesConstRef content;  // [pos + headerLen, pos + headerLen + payloadLen), or the lone byte
-    bool isList{false};
-    size_t payloadLen{0};
-};
-
-// Walk the payload region [start, end) of a list, collecting one DecoderChild per item.
-std::vector<DecoderChild> walkList(bcos::bytesConstRef raw, size_t start, size_t end)
-{
-    std::vector<DecoderChild> items;
-    size_t pos = start;
-    while (pos < end)
-    {
-        DecoderItemView const view = parseItem(raw, pos);
-        size_t const total = view.headerLen + view.payloadLen;
-        DecoderChild child;
-        child.raw = raw.getCroppedData(pos, total);
-        child.isList = view.isList;
-        child.payloadLen = view.payloadLen;
-        if (view.headerLen == 0)  // single-byte string: content is the lone byte at pos
-        {
-            child.content = raw.getCroppedData(pos, 1);
-        }
-        else
-        {
-            child.content = raw.getCroppedData(pos + view.headerLen, view.payloadLen);
-        }
-        items.push_back(child);
-        pos += total;
-    }
-    if (pos != end)
-    {
-        BOOST_THROW_EXCEPTION(
-            MPTDecodeError{} << bcos::errinfo_comment("RLP list payload not exactly consumed"));
-    }
-    return items;
-}
-
-bcos::h256 toHash(bcos::bytesConstRef content)
-{
-    return bcos::h256{content.data(), content.size()};
+    // decodeHeader consumed the header (0 bytes for a single byte < 0x80) so cursor now starts at
+    // the payload; headerLen is how far it advanced.
+    auto const headerLen = static_cast<size_t>(cursor.data() - itemStart);
+    bcos::bytesConstRef const content(cursor.data(), header.payloadLength);
+    bcos::bytesConstRef const raw(itemStart, headerLen + header.payloadLength);
+    cursor = cursor.getCroppedData(header.payloadLength);
+    return DecoderItem{.raw = raw, .content = content, .isList = header.isList};
 }
 
 bcos::bytes toBytes(bcos::bytesConstRef ref)
@@ -158,14 +70,19 @@ bcos::bytes toBytes(bcos::bytesConstRef ref)
 
 }  // namespace
 
-TrieNode decodeNode(bcos::bytesConstRef raw)
+TrieNode decodeNode(bcos::bytesConstRef rawInput)
 {
-    DecoderItemView const top = parseItem(raw, 0);
+    // decodeHeader takes a mutable view but only advances it (never writes through the pointer);
+    // MPT node buffers are always real mutable vectors, so this const_cast is sound.
+    bcos::bytesRef cursor(const_cast<bcos::byte*>(rawInput.data()), rawInput.size());
 
-    // 1) Not a list → must be the empty-string EmptyNode {0x80}; any other string is malformed.
+    DecoderItem const top = readItem(cursor);
+
+    // 1) Not a list → only the empty string {0x80} is a valid node (EmptyNode); any other string
+    //    is malformed.
     if (!top.isList)
     {
-        if (top.payloadLen == 0 && top.headerLen == 1)
+        if (top.content.empty())
         {
             return EmptyNode{};
         }
@@ -173,9 +90,13 @@ TrieNode decodeNode(bcos::bytesConstRef raw)
                                   "top-level RLP item is a non-empty string, not a node list"));
     }
 
-    // 2) Walk the list payload.
-    std::vector<DecoderChild> items =
-        walkList(raw, top.headerLen, top.headerLen + top.payloadLen);
+    // 2) Walk the list payload into its items.
+    bcos::bytesRef payload(const_cast<bcos::byte*>(top.content.data()), top.content.size());
+    std::vector<DecoderItem> items;
+    while (!payload.empty())
+    {
+        items.push_back(readItem(payload));
+    }
 
     // 3) Two items → Leaf or Extension, distinguished by the HP terminator flag.
     if (items.size() == 2)
@@ -183,15 +104,10 @@ TrieNode decodeNode(bcos::bytesConstRef raw)
         auto [nibbles, isLeaf] = hexPrefixDecode(items[0].content);
         if (isLeaf)
         {
-            LeafNode leaf;
-            leaf.keyNibbles = std::move(nibbles);
-            leaf.value = toBytes(items[1].content);  // value byte-string content
-            return leaf;
+            return LeafNode{.keyNibbles = std::move(nibbles), .value = toBytes(items[1].content)};
         }
-        ExtensionNode ext;
-        ext.sharedNibbles = std::move(nibbles);
-        ext.child = toBytes(items[1].raw);  // keep the child RLP-encoded (raw span)
-        return ext;
+        // Keep the child RLP-encoded (raw span): it is itself a node reference, not a byte-string.
+        return ExtensionNode{.sharedNibbles = std::move(nibbles), .child = toBytes(items[1].raw)};
     }
 
     // 4) Seventeen items → Branch: 16 children + value.
@@ -200,19 +116,18 @@ TrieNode decodeNode(bcos::bytesConstRef raw)
         BranchNode branch;
         for (size_t i = 0; i < NIBBLE_RANGE; ++i)
         {
-            DecoderChild const& child = items[i];
-            if (!child.isList && child.payloadLen == 0)
+            DecoderItem const& child = items[i];
+            if (!child.isList && child.content.empty())  // empty string 0x80 → absent child
             {
                 branch.children[i] = NodeRef::absent();
             }
-            else if (!child.isList && child.payloadLen == bcos::h256::SIZE)
+            else if (!child.isList && child.content.size() == bcos::h256::SIZE)  // 0xa0 + 32 bytes
             {
                 branch.children[i].kind = NodeRef::Kind::Hash;
-                branch.children[i].hash = toHash(child.content);
+                branch.children[i].hash = bcos::h256{child.content.data(), child.content.size()};
             }
-            else
+            else  // inline subtree (a list) → keep the raw span
             {
-                // Inline subtree (a list) or any other non-empty/non-32 string: keep the raw span.
                 branch.children[i].kind = NodeRef::Kind::Inline;
                 branch.children[i].inlineBytes = toBytes(child.raw);
             }

--- a/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
@@ -1,0 +1,229 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeDecoder.cpp
+ * @brief RLP node decoding for MPT nodes — inverse of NodeEncoder (spec §5.5)
+ */
+
+#include "NodeDecoder.h"
+#include "Errors.h"
+#include "HexPrefix.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+
+namespace bcos::ledger::mpt
+{
+
+namespace
+{
+
+// A parsed RLP item header. The item occupies the raw span [pos, pos + headerLen + payloadLen);
+// for a string the content is [pos + headerLen, pos + headerLen + payloadLen) — except a
+// single-byte string (b < 0x80) whose content is the one byte at `pos` (headerLen == 0).
+struct DecoderItemView
+{
+    bool isList{false};
+    size_t headerLen{0};
+    size_t payloadLen{0};
+};
+
+// Reads `count` big-endian bytes starting at raw[pos] into a size_t. Throws if the span is
+// truncated. `count` is at most 8 (RLP long-form length-of-length never needs more for our sizes).
+size_t readBigEndianLen(bcos::bytesConstRef raw, size_t pos, size_t count)
+{
+    if (count == 0 || count > sizeof(size_t) || pos + count > raw.size())
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment("RLP length-of-length truncated"));
+    }
+    size_t value = 0;
+    for (size_t i = 0; i < count; ++i)
+    {
+        value = (value << 8) | static_cast<size_t>(raw[pos + i]);
+    }
+    return value;
+}
+
+// Parse the RLP header of the item that starts at raw[pos]. Throws MPTDecodeError if the declared
+// span runs past raw.size().
+DecoderItemView parseItem(bcos::bytesConstRef raw, size_t pos)
+{
+    using namespace bcos::codec::rlp;
+    if (pos >= raw.size())
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment("RLP item starts past end of input"));
+    }
+
+    bcos::byte const b = raw[pos];
+    DecoderItemView view;
+    if (b < BYTES_HEAD_BASE)  // < 0x80: single-byte string, the byte IS the content
+    {
+        view = {.isList = false, .headerLen = 0, .payloadLen = 1};
+    }
+    else if (b <= LONG_BYTES_HEAD_BASE)  // 0x80..0xb7: short string
+    {
+        view = {.isList = false, .headerLen = 1, .payloadLen = static_cast<size_t>(b) - BYTES_HEAD_BASE};
+    }
+    else if (b < LIST_HEAD_BASE)  // 0xb8..0xbf: long string
+    {
+        size_t const lenOfLen = static_cast<size_t>(b) - LONG_BYTES_HEAD_BASE;
+        view = {.isList = false,
+            .headerLen = 1 + lenOfLen,
+            .payloadLen = readBigEndianLen(raw, pos + 1, lenOfLen)};
+    }
+    else if (b <= LONG_LIST_HEAD_BASE)  // 0xc0..0xf7: short list
+    {
+        view = {.isList = true, .headerLen = 1, .payloadLen = static_cast<size_t>(b) - LIST_HEAD_BASE};
+    }
+    else  // 0xf8..0xff: long list
+    {
+        size_t const lenOfLen = static_cast<size_t>(b) - LONG_LIST_HEAD_BASE;
+        view = {.isList = true,
+            .headerLen = 1 + lenOfLen,
+            .payloadLen = readBigEndianLen(raw, pos + 1, lenOfLen)};
+    }
+
+    if (pos + view.headerLen + view.payloadLen > raw.size())
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment("RLP item span exceeds input length"));
+    }
+    return view;
+}
+
+// One child item discovered while walking a list payload: its full RLP raw span, its string
+// content span, and whether the item is itself a list.
+struct DecoderChild
+{
+    bcos::bytesConstRef raw;      // [pos, pos + headerLen + payloadLen)
+    bcos::bytesConstRef content;  // [pos + headerLen, pos + headerLen + payloadLen), or the lone byte
+    bool isList{false};
+    size_t payloadLen{0};
+};
+
+// Walk the payload region [start, end) of a list, collecting one DecoderChild per item.
+std::vector<DecoderChild> walkList(bcos::bytesConstRef raw, size_t start, size_t end)
+{
+    std::vector<DecoderChild> items;
+    size_t pos = start;
+    while (pos < end)
+    {
+        DecoderItemView const view = parseItem(raw, pos);
+        size_t const total = view.headerLen + view.payloadLen;
+        DecoderChild child;
+        child.raw = raw.getCroppedData(pos, total);
+        child.isList = view.isList;
+        child.payloadLen = view.payloadLen;
+        if (view.headerLen == 0)  // single-byte string: content is the lone byte at pos
+        {
+            child.content = raw.getCroppedData(pos, 1);
+        }
+        else
+        {
+            child.content = raw.getCroppedData(pos + view.headerLen, view.payloadLen);
+        }
+        items.push_back(child);
+        pos += total;
+    }
+    if (pos != end)
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment("RLP list payload not exactly consumed"));
+    }
+    return items;
+}
+
+bcos::h256 toHash(bcos::bytesConstRef content)
+{
+    return bcos::h256{content.data(), content.size()};
+}
+
+bcos::bytes toBytes(bcos::bytesConstRef ref)
+{
+    return bcos::bytes{ref.begin(), ref.end()};
+}
+
+}  // namespace
+
+TrieNode decodeNode(bcos::bytesConstRef raw)
+{
+    DecoderItemView const top = parseItem(raw, 0);
+
+    // 1) Not a list → must be the empty-string EmptyNode {0x80}; any other string is malformed.
+    if (!top.isList)
+    {
+        if (top.payloadLen == 0 && top.headerLen == 1)
+        {
+            return EmptyNode{};
+        }
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "top-level RLP item is a non-empty string, not a node list"));
+    }
+
+    // 2) Walk the list payload.
+    std::vector<DecoderChild> items =
+        walkList(raw, top.headerLen, top.headerLen + top.payloadLen);
+
+    // 3) Two items → Leaf or Extension, distinguished by the HP terminator flag.
+    if (items.size() == 2)
+    {
+        auto [nibbles, isLeaf] = hexPrefixDecode(items[0].content);
+        if (isLeaf)
+        {
+            LeafNode leaf;
+            leaf.keyNibbles = std::move(nibbles);
+            leaf.value = toBytes(items[1].content);  // value byte-string content
+            return leaf;
+        }
+        ExtensionNode ext;
+        ext.sharedNibbles = std::move(nibbles);
+        ext.child = toBytes(items[1].raw);  // keep the child RLP-encoded (raw span)
+        return ext;
+    }
+
+    // 4) Seventeen items → Branch: 16 children + value.
+    if (items.size() == NIBBLE_RANGE + 1)
+    {
+        BranchNode branch;
+        for (size_t i = 0; i < NIBBLE_RANGE; ++i)
+        {
+            DecoderChild const& child = items[i];
+            if (!child.isList && child.payloadLen == 0)
+            {
+                branch.children[i] = NodeRef::absent();
+            }
+            else if (!child.isList && child.payloadLen == bcos::h256::SIZE)
+            {
+                branch.children[i].kind = NodeRef::Kind::Hash;
+                branch.children[i].hash = toHash(child.content);
+            }
+            else
+            {
+                // Inline subtree (a list) or any other non-empty/non-32 string: keep the raw span.
+                branch.children[i].kind = NodeRef::Kind::Inline;
+                branch.children[i].inlineBytes = toBytes(child.raw);
+            }
+        }
+        branch.value = toBytes(items[NIBBLE_RANGE].content);
+        return branch;
+    }
+
+    // 5) Any other item count is not a valid MPT node.
+    BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                              "RLP list has an item count that is not a valid MPT node (2 or 17)"));
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/NodeDecoder.h
+++ b/bcos-ledger/bcos-ledger/mpt/NodeDecoder.h
@@ -1,0 +1,38 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeDecoder.h
+ * @brief RLP node decoding for MPT nodes — inverse of NodeEncoder (spec §5.5)
+ */
+#pragma once
+
+#include "TrieNode.h"
+#include <bcos-utilities/Common.h>
+
+namespace bcos::ledger::mpt
+{
+
+/// Reconstruct a TrieNode from its canonical RLP encoding (inverse of encodeRaw).
+///
+/// The decoder mirrors the wire format produced by NodeEncoder:
+///   {0x80}                                  → EmptyNode
+///   2-item list [HP(leaf=1), value]         → LeafNode (keyNibbles have no HP terminator)
+///   2-item list [HP(leaf=0), child_ref_raw] → ExtensionNode (child kept RLP-encoded)
+///   17-item list [c0..c15, value]           → BranchNode (absent/Hash/Inline children)
+///
+/// @throws MPTDecodeError on malformed input (truncated header, span past end, wrong item count).
+TrieNode decodeNode(bcos::bytesConstRef raw);
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Trie.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Trie.cpp
@@ -1,0 +1,142 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Trie.cpp
+ * @brief Read-only walk over an MPT given its root hash (spec §5.6, §7.1)
+ */
+#include "Trie.h"
+#include "Constants.h"
+#include "Errors.h"
+#include "Nibble.h"
+#include "NodeDecoder.h"
+#include "TrieNode.h"
+#include <algorithm>
+#include <variant>
+
+namespace bcos::ledger::mpt
+{
+namespace
+{
+/// Load a node by its hash from the cache and decode it. A miss means the caller failed to
+/// prefetch a referenced node — a programming error, not a "not found" — so we throw rather than
+/// return nullopt.
+bcos::task::Task<TrieNode> trieLoadByHash(NodeCache& cache, bcos::h256 const& hash)
+{
+    auto raw = co_await cache.get(hash);
+    if (!raw)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
+                                  "Trie: cache miss for node hash; cache must be prefetched"));
+    }
+    co_return decodeNode(bcos::ref(*raw));
+}
+
+/// Resolve a BranchNode child reference. Absent children are handled by the caller before this is
+/// reached, so only Hash and (non-empty) Inline are seen here.
+bcos::task::Task<TrieNode> trieLoadFromRef(NodeCache& cache, NodeRef const& ref)
+{
+    if (ref.kind == NodeRef::Kind::Hash)
+    {
+        co_return co_await trieLoadByHash(cache, ref.hash);
+    }
+    // Inline (non-empty): the child's complete RLP encoding is stored directly.
+    co_return decodeNode(bcos::ref(ref.inlineBytes));
+}
+
+/// Resolve an ExtensionNode.child, which is kept as a raw RLP child reference: EITHER the 33-byte
+/// hash string (0xa0 followed by the 32-byte digest) OR the inline node's complete RLP encoding.
+bcos::task::Task<TrieNode> trieLoadFromRawRef(NodeCache& cache, bcos::bytes const& childRaw)
+{
+    if (childRaw.size() == 33 && childRaw[0] == 0xa0)
+    {
+        bcos::h256 const childHash(childRaw.data() + 1, 32);
+        co_return co_await trieLoadByHash(cache, childHash);
+    }
+    co_return decodeNode(bcos::ref(childRaw));
+}
+}  // namespace
+
+Trie::Trie(NodeCache& cache, bcos::h256 root) : m_cache(cache), m_root(root) {}
+
+bcos::task::Task<std::optional<bcos::bytes>> Trie::get(bcos::h256 const& keyHash) const
+{
+    if (m_root == emptyRootHash())
+    {
+        co_return std::nullopt;
+    }
+
+    bcos::bytes const path = bytesToNibbles(keyHash.ref());  // 64 nibbles
+    size_t pos = 0;                                          // nibbles consumed so far
+
+    TrieNode node = co_await trieLoadByHash(m_cache, m_root);
+    while (true)
+    {
+        if (std::holds_alternative<EmptyNode>(node))
+        {
+            co_return std::nullopt;
+        }
+
+        if (auto const* leaf = std::get_if<LeafNode>(&node))
+        {
+            // The remaining path is path[pos..end]; it must equal the leaf suffix exactly.
+            size_t const remaining = path.size() - pos;
+            if (remaining != leaf->keyNibbles.size())
+            {
+                co_return std::nullopt;
+            }
+            if (!std::equal(leaf->keyNibbles.begin(), leaf->keyNibbles.end(), path.begin() + pos))
+            {
+                co_return std::nullopt;
+            }
+            co_return leaf->value;
+        }
+
+        if (auto const* ext = std::get_if<ExtensionNode>(&node))
+        {
+            // The remaining path must start with the shared nibbles.
+            size_t const remaining = path.size() - pos;
+            if (remaining < ext->sharedNibbles.size())
+            {
+                co_return std::nullopt;
+            }
+            if (!std::equal(
+                    ext->sharedNibbles.begin(), ext->sharedNibbles.end(), path.begin() + pos))
+            {
+                co_return std::nullopt;
+            }
+            pos += ext->sharedNibbles.size();
+            node = co_await trieLoadFromRawRef(m_cache, ext->child);
+            continue;
+        }
+
+        // BranchNode
+        auto const& br = std::get<BranchNode>(node);
+        if (pos == path.size())
+        {
+            // All nibbles consumed at a branch: the value (if any) belongs to this key.
+            co_return br.value.empty() ? std::nullopt : std::optional<bcos::bytes>{br.value};
+        }
+        bcos::byte const nib = path[pos];
+        NodeRef const& child = br.children[nib];
+        // Absent child == Inline with empty inlineBytes.
+        if (child.kind == NodeRef::Kind::Inline && child.inlineBytes.empty())
+        {
+            co_return std::nullopt;
+        }
+        pos += 1;
+        node = co_await trieLoadFromRef(m_cache, child);
+    }
+}
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Trie.h
+++ b/bcos-ledger/bcos-ledger/mpt/Trie.h
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Trie.h
+ * @brief Read-only walk over an MPT given its root hash (spec §5.6, §7.1)
+ */
+#pragma once
+#include "NodeCache.h"
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <optional>
+
+namespace bcos::ledger::mpt
+{
+/// Read-only walk over an MPT given its root hash. Nodes are fetched from NodeCache (the caller is
+/// responsible for having populated/prefetched it — e.g. HashBuilder::commit writes the nodes it
+/// creates). A cache miss for a referenced hash is a programming error and throws.
+class Trie
+{
+public:
+    Trie(NodeCache& cache, bcos::h256 root);
+    bcos::task::Task<std::optional<bcos::bytes>> get(bcos::h256 const& keyHash) const;
+    bcos::h256 root() const noexcept { return m_root; }
+
+private:
+    NodeCache& m_cache;
+    bcos::h256 m_root;
+};
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/test/unittests/mpt/HashBuilderPurityTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/HashBuilderPurityTest.cpp
@@ -1,0 +1,131 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HashBuilderPurityTest.cpp
+ * @brief Determinism gate: identical inputs yield a byte-identical root + node set (spec §5.6)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/NodeCache.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <random>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(HashBuilderPuritySuite)
+
+namespace
+{
+// Distinct random h256 keys + small random values from a fixed seed. Named uniquely (purity*) to
+// avoid an anonymous-namespace ODR clash with HashBuilderTest under UNITY_BUILD.
+std::vector<std::pair<bcos::h256, bcos::bytes>> purityKvs(size_t count, uint32_t seed)
+{
+    auto rng = seededRng(seed);
+    std::uniform_int_distribution<int> byteDist(0, 255);
+    std::uniform_int_distribution<int> valLenDist(1, 40);
+    std::set<bcos::h256> seen;
+    std::vector<std::pair<bcos::h256, bcos::bytes>> kvs;
+    while (kvs.size() < count)
+    {
+        bcos::h256 key;
+        for (size_t i = 0; i < bcos::h256::SIZE; ++i)
+        {
+            key.data()[i] = static_cast<bcos::byte>(byteDist(rng));
+        }
+        if (!seen.insert(key).second)
+        {
+            continue;
+        }
+        bcos::bytes value(static_cast<size_t>(valLenDist(rng)));
+        for (auto& b : value)
+        {
+            b = static_cast<bcos::byte>(byteDist(rng));
+        }
+        kvs.emplace_back(key, std::move(value));
+    }
+    return kvs;
+}
+}  // namespace
+
+// Spec §5.6 hard requirement: the same input set, fed in different (shuffled) orders across many
+// runs, MUST produce a byte-identical 32-byte root AND a byte-identical new-node set. This is the
+// precondition for crash-replay convergence — two nodes that replay the same change-set in any
+// order must land on the same state root and persist the same nodes. Do NOT reduce 1000.
+BOOST_AUTO_TEST_CASE(SameInputProducesByteIdenticalRootOver1000Runs)
+{
+    auto const entries = purityKvs(100, /*seed=*/0x9176AB);
+
+    bcos::h256 referenceRootHash{};
+    std::unordered_map<bcos::h256, bcos::bytes> referenceNodes;
+
+    for (uint32_t run = 0; run < 1000; ++run)
+    {
+        auto shuffled = entries;  // fresh copy each run
+        std::mt19937 orderRng{run};
+        std::shuffle(shuffled.begin(), shuffled.end(), orderRng);
+
+        NodeCache cache;
+        HashBuilder hb(cache, emptyRootHash());
+        for (auto const& [key, value] : shuffled)
+        {
+            bcos::task::syncWait(hb.put(key, value));
+        }
+        auto const root = bcos::task::syncWait(hb.commit());
+        auto nodes = hb.drainNewNodes();
+
+        if (run == 0)
+        {
+            referenceRootHash = root;
+            referenceNodes = std::move(nodes);
+        }
+        else
+        {
+            // unordered_map operator== is content/order-independent: this is a byte-identical
+            // check of the entire produced node set, not just the root.
+            BOOST_REQUIRE_MESSAGE(root == referenceRootHash,
+                "root drift at run " << run << " got=" << root.hex()
+                                     << " expected=" << referenceRootHash.hex());
+            BOOST_REQUIRE_MESSAGE(nodes == referenceNodes, "node-set drift at run " << run);
+        }
+    }
+}
+
+// An empty change-set commits to the canonical empty-trie root every time.
+BOOST_AUTO_TEST_CASE(EmptyInputDeterministicallyEmptyRoot)
+{
+    for (int run = 0; run < 8; ++run)
+    {
+        NodeCache cache;
+        HashBuilder hb(cache, emptyRootHash());
+        auto const root = bcos::task::syncWait(hb.commit());
+        BOOST_CHECK_EQUAL(root, emptyRootHash());
+        BOOST_CHECK(hb.drainNewNodes().empty());
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/HashBuilderTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/HashBuilderTest.cpp
@@ -1,0 +1,208 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HashBuilderTest.cpp
+ * @brief Unit tests for HashBuilder canonical trie construction (spec §5.3)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-crypto/hasher/AnyHasher.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/Nibble.h>
+#include <bcos-ledger/mpt/NodeCache.h>
+#include <bcos-ledger/mpt/NodeEncoder.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <set>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(HashBuilderSuite)
+
+namespace
+{
+// keccak256 of `raw` using a fresh hasher (independent recompute for cache/drain checks).
+bcos::h256 hbKeccak(bcos::bytes const& raw)
+{
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    bcos::h256 out;
+    bcos::crypto::hasher::hash(hasher, bcos::ref(raw), out);
+    return out;
+}
+
+// Hash of a single leaf the way commit() does: encode → inline ? keccak(raw) : ref.hash.
+bcos::h256 singleLeafRoot(bcos::h256 const& key, bcos::bytes const& value)
+{
+    LeafNode leaf;
+    leaf.keyNibbles = bytesToNibbles(key.ref());
+    leaf.value = value;
+    bcos::bytes const raw = encodeRaw(TrieNode{leaf});
+    if (raw.size() < 32)
+    {
+        return hbKeccak(raw);
+    }
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    bcos::h256 out;
+    bcos::crypto::hasher::hash(hasher, bcos::ref(raw), out);
+    return out;
+}
+
+// Distinct random h256 keys + small random values, generated from a fixed seed.
+std::vector<std::pair<bcos::h256, bcos::bytes>> randomKvs(size_t count, uint32_t seed)
+{
+    auto rng = seededRng(seed);
+    std::uniform_int_distribution<int> byteDist(0, 255);
+    std::uniform_int_distribution<int> valLenDist(1, 40);
+    std::set<bcos::h256> seen;
+    std::vector<std::pair<bcos::h256, bcos::bytes>> kvs;
+    while (kvs.size() < count)
+    {
+        bcos::h256 key;
+        for (size_t i = 0; i < bcos::h256::SIZE; ++i)
+        {
+            key.data()[i] = static_cast<bcos::byte>(byteDist(rng));
+        }
+        if (!seen.insert(key).second)
+        {
+            continue;
+        }
+        bcos::bytes value(static_cast<size_t>(valLenDist(rng)));
+        for (auto& b : value)
+        {
+            b = static_cast<bcos::byte>(byteDist(rng));
+        }
+        kvs.emplace_back(key, std::move(value));
+    }
+    return kvs;
+}
+}  // namespace
+
+// An empty change-set yields the canonical empty-trie root.
+BOOST_AUTO_TEST_CASE(EmptyTrieReturnsEmptyRootHash)
+{
+    NodeCache cache;
+    HashBuilder builder(cache, emptyRootHash());
+    auto root = bcos::task::syncWait(builder.commit());
+    BOOST_CHECK_EQUAL(root, emptyRootHash());
+}
+
+// A single key+value must match an independently computed leaf root (anchors to M2 encoder).
+BOOST_AUTO_TEST_CASE(SingleLeafMatchesNodeEncoder)
+{
+    NodeCache cache;
+    HashBuilder builder(cache, emptyRootHash());
+    auto key = makeHash(0x42);
+    bcos::bytes value{0xca, 0xfe, 0xba, 0xbe};
+
+    bcos::task::syncWait(builder.put(key, value));
+    auto root = bcos::task::syncWait(builder.commit());
+
+    BOOST_CHECK_EQUAL(root, singleLeafRoot(key, value));
+}
+
+// Two keys sharing a long prefix, differing late → extension + branch + two leaves.
+BOOST_AUTO_TEST_CASE(TwoKeysSharedPrefix)
+{
+    // Keys identical except in the final byte → 63 shared nibbles.
+    bcos::h256 keyA{};
+    bcos::h256 keyB{};
+    for (size_t i = 0; i < bcos::h256::SIZE; ++i)
+    {
+        keyA.data()[i] = 0xab;
+        keyB.data()[i] = 0xab;
+    }
+    keyB.data()[bcos::h256::SIZE - 1] = 0xcd;
+
+    bcos::bytes valA{0x01, 0x02};
+    bcos::bytes valB{0x03, 0x04};
+
+    NodeCache cache;
+    HashBuilder builder(cache, emptyRootHash());
+    bcos::task::syncWait(builder.put(keyA, valA));
+    bcos::task::syncWait(builder.put(keyB, valB));
+    auto root = bcos::task::syncWait(builder.commit());
+
+    BOOST_CHECK_EQUAL(root, referenceRoot({{keyA, valA}, {keyB, valB}}));
+
+    // The top node is large here, so the root must be retrievable from cache.
+    auto cached = bcos::task::syncWait(cache.get(root));
+    BOOST_REQUIRE(cached.has_value());
+    BOOST_CHECK_EQUAL(hbKeccak(*cached), root);
+}
+
+// Main correctness gate: random batches across several sizes, inserted SHUFFLED, must match the
+// independent reference oracle (order-independence + structural correctness).
+BOOST_AUTO_TEST_CASE(RandomBatchMatchesReference)
+{
+    for (size_t size : {size_t{1}, size_t{2}, size_t{5}, size_t{20}, size_t{100}})
+    {
+        auto kvs = randomKvs(size, /*seed=*/0x5eed + static_cast<uint32_t>(size));
+        bcos::h256 const expected = referenceRoot(kvs);
+
+        // Insert into the builder in shuffled order to prove order-independence.
+        auto shuffled = kvs;
+        auto rng = seededRng(0xC0FFEE + static_cast<uint32_t>(size));
+        std::shuffle(shuffled.begin(), shuffled.end(), rng);
+
+        NodeCache cache;
+        HashBuilder builder(cache, emptyRootHash());
+        for (auto const& [key, value] : shuffled)
+        {
+            bcos::task::syncWait(builder.put(key, value));
+        }
+        auto root = bcos::task::syncWait(builder.commit());
+
+        BOOST_CHECK_MESSAGE(
+            root == expected, "root mismatch for size=" << size << " got=" << root.hex()
+                                                        << " expected=" << expected.hex());
+    }
+}
+
+// A multi-node trie must produce new nodes; every (hash, bytes) must satisfy keccak(bytes)==hash.
+BOOST_AUTO_TEST_CASE(DrainNewNodesNonEmptyForLargeTrie)
+{
+    auto kvs = randomKvs(50, /*seed=*/0xABCD);
+
+    NodeCache cache;
+    HashBuilder builder(cache, emptyRootHash());
+    for (auto const& [key, value] : kvs)
+    {
+        bcos::task::syncWait(builder.put(key, value));
+    }
+    auto root = bcos::task::syncWait(builder.commit());
+
+    auto newNodes = builder.drainNewNodes();
+    BOOST_REQUIRE(!newNodes.empty());
+    for (auto const& [hash, raw] : newNodes)
+    {
+        BOOST_CHECK_EQUAL(hbKeccak(raw), hash);
+    }
+    // The root must be among the produced nodes (top node is large for 50 keys).
+    BOOST_CHECK(newNodes.find(root) != newNodes.end());
+
+    // A second drain returns nothing.
+    BOOST_CHECK(builder.drainNewNodes().empty());
+    BOOST_CHECK(builder.drainObsoletedNodes().empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/NodeCacheTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/NodeCacheTest.cpp
@@ -1,0 +1,148 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeCacheTest.cpp
+ * @brief Unit tests for NodeCache (LRU+CONCURRENT MPT node cache, spec §5.1)
+ */
+
+#include <bcos-ledger/mpt/NodeCache.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <thread>
+
+namespace bcos::ledger::mpt::test
+{
+
+namespace
+{
+/// A key whose low byte is @p tag and all other bytes zero.
+bcos::h256 makeKey(bcos::byte tag)
+{
+    bcos::h256 key{};  // zero-initialised
+    key.data()[0] = tag;
+    return key;
+}
+
+/// Mirror of MemoryStorage's bucket sizing for a CONCURRENT storage created with
+/// buckets==0: getBucketSize() == hardware_concurrency() * 2 + 1.
+unsigned bucketCount()
+{
+    return std::thread::hardware_concurrency() * 2 + 1;
+}
+
+/// Mirror of MemoryStorage::getBucketIndex: std::hash<h256>(key) % numBuckets.
+size_t bucketIndexOf(bcos::h256 const& key, unsigned numBuckets)
+{
+    return std::hash<bcos::h256>{}(key) % numBuckets;
+}
+
+/// Find @p howMany distinct keys that all land in the same CONCURRENT bucket,
+/// so per-bucket LRU eviction is exercised deterministically regardless of the
+/// host CPU count.
+std::vector<bcos::h256> sameBucketKeys(size_t howMany)
+{
+    unsigned const numBuckets = bucketCount();
+    std::vector<bcos::h256> result;
+    for (int target = 0; target < (int)numBuckets && result.empty(); ++target)
+    {
+        std::vector<bcos::h256> candidates;
+        for (int tag = 1; tag < 256 && candidates.size() < howMany; ++tag)
+        {
+            auto key = makeKey(static_cast<bcos::byte>(tag));
+            if (bucketIndexOf(key, numBuckets) == (size_t)target)
+            {
+                candidates.push_back(key);
+            }
+        }
+        if (candidates.size() >= howMany)
+        {
+            result = std::move(candidates);
+        }
+    }
+    return result;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(NodeCacheSuite)
+
+// ---------------------------------------------------------------------------
+// Test 1: a value put under a key is returned verbatim by get.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(PutGetRoundTrip)
+{
+    NodeCache cache;
+    auto key = makeKey(0x11);
+    bcos::bytes value{0xde, 0xad, 0xbe, 0xef};
+
+    bcos::task::syncWait(cache.put(key, value));
+    auto got = bcos::task::syncWait(cache.get(key));
+
+    BOOST_REQUIRE(got.has_value());
+    BOOST_CHECK(*got == value);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: a get for a key that was never put returns nullopt.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(MissReturnsNullopt)
+{
+    NodeCache cache;
+    auto present = makeKey(0x01);
+    auto absent = makeKey(0x02);
+
+    bcos::task::syncWait(cache.put(present, bcos::bytes{0xaa}));
+    auto got = bcos::task::syncWait(cache.get(absent));
+
+    BOOST_CHECK(!got.has_value());
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: when the byte budget is exceeded, the least-recently-used entry is
+// evicted. Capacity is measured in bytes (getSize(key)+getSize(value)); each
+// entry here is 32 (h256) + 1 (value) = 33 bytes. With a 50-byte budget only one
+// entry fits, so inserting three keys (oldest first) leaves only the newest.
+//
+// Eviction is per-bucket, so the three keys are chosen to share a single bucket;
+// otherwise they would scatter across the CONCURRENT shards and never collide.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(LRUEvictionWhenOverCapacity)
+{
+    auto keys = sameBucketKeys(3);
+    BOOST_REQUIRE_EQUAL(keys.size(), 3u);
+
+    NodeCache cache(/*capacity=*/50);
+
+    // Insert oldest -> newest.
+    bcos::task::syncWait(cache.put(keys[0], bcos::bytes{0x10}));
+    bcos::task::syncWait(cache.put(keys[1], bcos::bytes{0x20}));
+    bcos::task::syncWait(cache.put(keys[2], bcos::bytes{0x30}));
+
+    auto first = bcos::task::syncWait(cache.get(keys[0]));
+    auto second = bcos::task::syncWait(cache.get(keys[1]));
+    auto third = bcos::task::syncWait(cache.get(keys[2]));
+
+    // Oldest two evicted, newest survives.
+    BOOST_CHECK(!first.has_value());
+    BOOST_CHECK(!second.has_value());
+    BOOST_REQUIRE(third.has_value());
+    BOOST_CHECK_EQUAL((*third)[0], 0x30);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/NodeDecoderTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/NodeDecoderTest.cpp
@@ -1,0 +1,171 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NodeDecoderTest.cpp
+ * @brief Unit tests for TrieNode RLP decoding — round-trips against NodeEncoder (spec §5.5)
+ */
+
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-ledger/mpt/NodeDecoder.h>
+#include <bcos-ledger/mpt/NodeEncoder.h>
+#include <bcos-ledger/mpt/TrieNode.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(NodeDecoderSuite)
+
+namespace
+{
+// A 33-byte RLP-encoded hash child reference: 0xa0 followed by 32 hash bytes.
+bcos::bytes decoderHashChildRef(bcos::byte fill)
+{
+    bcos::bytes out{0xa0};
+    out.insert(out.end(), 32, fill);
+    return out;
+}
+}  // namespace
+
+// EmptyNode decodes from the single byte {0x80}.
+BOOST_AUTO_TEST_CASE(DecodeEmptyNode)
+{
+    TrieNode node = decodeNode(bcos::ref(bcos::bytes{0x80}));
+    BOOST_CHECK(std::holds_alternative<EmptyNode>(node));
+}
+
+// Leaf round-trip, short value: encode → decode → re-encode must be byte-identical.
+BOOST_AUTO_TEST_CASE(RoundTripLeafShort)
+{
+    LeafNode leaf;
+    leaf.keyNibbles = {1, 2, 3, 4, 5};  // odd count exercises HP odd-path
+    leaf.value = bcos::bytes{0xaa, 0xbb};
+
+    bcos::bytes raw = encodeRaw(TrieNode{leaf});
+    TrieNode decoded = decodeNode(bcos::ref(raw));
+
+    BOOST_REQUIRE(std::holds_alternative<LeafNode>(decoded));
+    BOOST_CHECK(std::get<LeafNode>(decoded).keyNibbles == leaf.keyNibbles);
+    BOOST_CHECK(std::get<LeafNode>(decoded).value == leaf.value);
+    BOOST_CHECK(encodeRaw(decoded) == raw);
+}
+
+// Leaf round-trip with a >=32 byte value so the leaf itself encodes large (long-string value head).
+BOOST_AUTO_TEST_CASE(RoundTripLeafLarge)
+{
+    LeafNode leaf;
+    leaf.keyNibbles = {0x0a, 0x0b, 0x0c, 0x0d};
+    leaf.value = bcos::bytes(64, 0xee);  // forces a long byte-string value
+
+    bcos::bytes raw = encodeRaw(TrieNode{leaf});
+    BOOST_CHECK(raw.size() >= 32);
+    TrieNode decoded = decodeNode(bcos::ref(raw));
+
+    BOOST_REQUIRE(std::holds_alternative<LeafNode>(decoded));
+    BOOST_CHECK(std::get<LeafNode>(decoded).value == leaf.value);
+    BOOST_CHECK(encodeRaw(decoded) == raw);
+}
+
+// Extension whose child is a Hash ref (0xa0 + 32 bytes).
+BOOST_AUTO_TEST_CASE(RoundTripExtensionHashChild)
+{
+    ExtensionNode ext;
+    ext.sharedNibbles = {3, 4, 5};
+    ext.child = decoderHashChildRef(0x77);
+
+    bcos::bytes raw = encodeRaw(TrieNode{ext});
+    TrieNode decoded = decodeNode(bcos::ref(raw));
+
+    BOOST_REQUIRE(std::holds_alternative<ExtensionNode>(decoded));
+    BOOST_CHECK(std::get<ExtensionNode>(decoded).sharedNibbles == ext.sharedNibbles);
+    BOOST_CHECK(std::get<ExtensionNode>(decoded).child == ext.child);
+    BOOST_CHECK(encodeRaw(decoded) == raw);
+}
+
+// Extension whose child is an inline small node (a short leaf encoded < 32 bytes, spliced raw).
+BOOST_AUTO_TEST_CASE(RoundTripExtensionInlineChild)
+{
+    LeafNode inlineLeaf;
+    inlineLeaf.keyNibbles = {1, 2};
+    inlineLeaf.value = bcos::bytes{0x42};
+    bcos::bytes inlineRaw = encodeRaw(TrieNode{inlineLeaf});
+    BOOST_REQUIRE(inlineRaw.size() < 32);
+
+    ExtensionNode ext;
+    ext.sharedNibbles = {9};
+    ext.child = inlineRaw;  // raw inline child node bytes
+
+    bcos::bytes raw = encodeRaw(TrieNode{ext});
+    TrieNode decoded = decodeNode(bcos::ref(raw));
+
+    BOOST_REQUIRE(std::holds_alternative<ExtensionNode>(decoded));
+    BOOST_CHECK(std::get<ExtensionNode>(decoded).child == ext.child);
+    BOOST_CHECK(encodeRaw(decoded) == raw);
+}
+
+// Branch with a mix of absent + Hash + Inline children and an empty value.
+BOOST_AUTO_TEST_CASE(RoundTripBranchMixedChildren)
+{
+    // An inline child: a tiny leaf node encoded < 32 bytes.
+    LeafNode tiny;
+    tiny.keyNibbles = {7};
+    tiny.value = bcos::bytes{0x01};
+    bcos::bytes tinyRaw = encodeRaw(TrieNode{tiny});
+    BOOST_REQUIRE(tinyRaw.size() < 32);
+
+    BranchNode branch;
+    // children[0] absent (default)
+    branch.children[3].kind = NodeRef::Kind::Hash;
+    branch.children[3].hash =
+        bcos::h256("0x2222222222222222222222222222222222222222222222222222222222222222");
+    branch.children[10].kind = NodeRef::Kind::Inline;
+    branch.children[10].inlineBytes = tinyRaw;
+    // value left empty
+
+    bcos::bytes raw = encodeRaw(TrieNode{branch});
+    TrieNode decoded = decodeNode(bcos::ref(raw));
+
+    BOOST_REQUIRE(std::holds_alternative<BranchNode>(decoded));
+    auto const& got = std::get<BranchNode>(decoded);
+    // child 0 absent
+    BOOST_CHECK(got.children[0].kind == NodeRef::Kind::Inline);
+    BOOST_CHECK(got.children[0].inlineBytes.empty());
+    // child 3 hash
+    BOOST_CHECK(got.children[3].kind == NodeRef::Kind::Hash);
+    BOOST_CHECK(got.children[3].hash == branch.children[3].hash);
+    // child 10 inline
+    BOOST_CHECK(got.children[10].kind == NodeRef::Kind::Inline);
+    BOOST_CHECK(got.children[10].inlineBytes == tinyRaw);
+    BOOST_CHECK(got.value.empty());
+    BOOST_CHECK(encodeRaw(decoded) == raw);
+}
+
+// Malformed input: a non-empty top-level string is not a valid node.
+BOOST_AUTO_TEST_CASE(DecodeRejectsNonNodeString)
+{
+    BOOST_CHECK_THROW(decodeNode(bcos::ref(bcos::bytes{0x83, 0x01, 0x02, 0x03})), MPTDecodeError);
+}
+
+// Malformed input: a truncated header (declares 5 payload bytes but only 2 present).
+BOOST_AUTO_TEST_CASE(DecodeRejectsTruncatedItem)
+{
+    BOOST_CHECK_THROW(decodeNode(bcos::ref(bcos::bytes{0xc5, 0x01, 0x02})), MPTDecodeError);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/TestHelpers.h
+++ b/bcos-ledger/test/unittests/mpt/TestHelpers.h
@@ -1,0 +1,267 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TestHelpers.h
+ * @brief Shared MPT test utilities + an independent reference trie oracle (spec §5.3, §5.5)
+ */
+#pragma once
+
+#include <bcos-crypto/hasher/AnyHasher.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/Nibble.h>
+#include <bcos-ledger/mpt/NodeEncoder.h>
+#include <bcos-ledger/mpt/TrieNode.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <memory>
+#include <random>
+#include <utility>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+/// A zero h256 with only its first byte set to @p firstByte.
+inline bcos::h256 makeHash(uint8_t firstByte)
+{
+    bcos::h256 h{};
+    h.data()[0] = firstByte;
+    return h;
+}
+
+/// Fixed-seed RNG so random-batch tests are reproducible.
+inline std::mt19937 seededRng(uint32_t s)
+{
+    return std::mt19937{s};
+}
+
+// ---------------------------------------------------------------------------
+// Independent reference trie (correctness oracle).
+//
+// This is deliberately a DIFFERENT algorithm than HashBuilder: it inserts keys one at a time into
+// a mutable pointer tree (leaf-split-on-first-differing-nibble, descend through extension/branch),
+// then encodes the finished tree through the trusted NodeEncoder and hashes the root exactly like
+// HashBuilder::commit(). A bug shared by both implementations is therefore unlikely.
+// ---------------------------------------------------------------------------
+namespace reftrie
+{
+
+struct RefNode;
+using RefNodePtr = std::shared_ptr<RefNode>;
+
+// A mutable node. Empty = null pointer.
+//   Leaf:      keyNibbles (suffix) + value
+//   Extension: sharedNibbles + a single child node
+//   Branch:    16 child nodes (+ value, unused here since all keys are 64 nibbles)
+struct RefNode
+{
+    enum class Kind
+    {
+        Leaf,
+        Extension,
+        Branch
+    };
+    Kind kind{Kind::Leaf};
+    bcos::bytes path;                             // leaf keyNibbles or extension sharedNibbles
+    bcos::bytes value;                            // leaf/branch value
+    RefNodePtr extChild;                          // extension child
+    std::array<RefNodePtr, 16> branchChildren{};  // branch children
+};
+
+inline RefNodePtr makeLeaf(bcos::bytes path, bcos::bytes value)
+{
+    auto n = std::make_shared<RefNode>();
+    n->kind = RefNode::Kind::Leaf;
+    n->path = std::move(path);
+    n->value = std::move(value);
+    return n;
+}
+
+// Insert (suffix → value) into the subtree rooted at `node` (may be null). Returns the new subtree.
+inline RefNodePtr refInsert(RefNodePtr node, bcos::bytes const& suffix, bcos::bytes const& value)
+{
+    if (!node)
+    {
+        return makeLeaf(suffix, value);
+    }
+
+    if (node->kind == RefNode::Kind::Leaf)
+    {
+        if (node->path == suffix)
+        {
+            node->value = value;  // overwrite
+            return node;
+        }
+        size_t const cpl =
+            commonPrefixLen(bcos::bytesConstRef(node->path.data(), node->path.size()),
+                bcos::bytesConstRef(suffix.data(), suffix.size()));
+        // Build a branch at depth cpl holding the two distinct suffixes.
+        auto branch = std::make_shared<RefNode>();
+        branch->kind = RefNode::Kind::Branch;
+        {
+            bcos::bytes existingRest(node->path.begin() + cpl, node->path.end());
+            bcos::byte n0 = existingRest.front();
+            branch->branchChildren[n0] =
+                makeLeaf(bcos::bytes(existingRest.begin() + 1, existingRest.end()), node->value);
+        }
+        {
+            bcos::bytes newRest(suffix.begin() + cpl, suffix.end());
+            bcos::byte n1 = newRest.front();
+            branch->branchChildren[n1] =
+                makeLeaf(bcos::bytes(newRest.begin() + 1, newRest.end()), value);
+        }
+        if (cpl == 0)
+        {
+            return branch;
+        }
+        auto ext = std::make_shared<RefNode>();
+        ext->kind = RefNode::Kind::Extension;
+        ext->path.assign(suffix.begin(), suffix.begin() + cpl);
+        ext->extChild = branch;
+        return ext;
+    }
+
+    if (node->kind == RefNode::Kind::Extension)
+    {
+        size_t const cpl =
+            commonPrefixLen(bcos::bytesConstRef(node->path.data(), node->path.size()),
+                bcos::bytesConstRef(suffix.data(), suffix.size()));
+        if (cpl == node->path.size())
+        {
+            // Descend fully through the extension.
+            bcos::bytes rest(suffix.begin() + cpl, suffix.end());
+            node->extChild = refInsert(node->extChild, rest, value);
+            return node;
+        }
+        // Split the extension at cpl into a branch.
+        auto branch = std::make_shared<RefNode>();
+        branch->kind = RefNode::Kind::Branch;
+        // Existing extension's remaining path → a child of the branch.
+        {
+            bcos::bytes existingRest(node->path.begin() + cpl, node->path.end());
+            bcos::byte n0 = existingRest.front();
+            if (existingRest.size() == 1)
+            {
+                branch->branchChildren[n0] = node->extChild;
+            }
+            else
+            {
+                auto innerExt = std::make_shared<RefNode>();
+                innerExt->kind = RefNode::Kind::Extension;
+                innerExt->path.assign(existingRest.begin() + 1, existingRest.end());
+                innerExt->extChild = node->extChild;
+                branch->branchChildren[n0] = innerExt;
+            }
+        }
+        // New suffix → another child of the branch.
+        {
+            bcos::bytes newRest(suffix.begin() + cpl, suffix.end());
+            bcos::byte n1 = newRest.front();
+            branch->branchChildren[n1] = refInsert(
+                branch->branchChildren[n1], bcos::bytes(newRest.begin() + 1, newRest.end()), value);
+        }
+        if (cpl == 0)
+        {
+            return branch;
+        }
+        auto ext = std::make_shared<RefNode>();
+        ext->kind = RefNode::Kind::Extension;
+        ext->path.assign(suffix.begin(), suffix.begin() + cpl);
+        ext->extChild = branch;
+        return ext;
+    }
+
+    // Branch: route by the first nibble.
+    bcos::byte const n = suffix.front();
+    node->branchChildren[n] =
+        refInsert(node->branchChildren[n], bcos::bytes(suffix.begin() + 1, suffix.end()), value);
+    return node;
+}
+
+// Encode a reference subtree to a NodeRef via the trusted NodeEncoder.
+inline NodeRef refEncode(
+    RefNodePtr const& node, bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher& hasher)
+{
+    if (!node)
+    {
+        return NodeRef::absent();
+    }
+    if (node->kind == RefNode::Kind::Leaf)
+    {
+        LeafNode leaf;
+        leaf.keyNibbles = node->path;
+        leaf.value = node->value;
+        return NodeEncoder<>::encodeAndRef(TrieNode{leaf}, hasher).second;
+    }
+    if (node->kind == RefNode::Kind::Extension)
+    {
+        NodeRef const childRef = refEncode(node->extChild, hasher);
+        bcos::bytes childRaw;
+        if (childRef.kind == NodeRef::Kind::Inline)
+        {
+            childRaw = childRef.inlineBytes;
+        }
+        else
+        {
+            childRaw.push_back(0xa0);
+            childRaw.insert(childRaw.end(), childRef.hash.begin(), childRef.hash.end());
+        }
+        ExtensionNode ext;
+        ext.sharedNibbles = node->path;
+        ext.child = childRaw;
+        return NodeEncoder<>::encodeAndRef(TrieNode{ext}, hasher).second;
+    }
+    BranchNode branch;
+    for (size_t i = 0; i < 16; ++i)
+    {
+        branch.children[i] = refEncode(node->branchChildren[i], hasher);
+    }
+    branch.value = node->value;
+    return NodeEncoder<>::encodeAndRef(TrieNode{branch}, hasher).second;
+}
+
+}  // namespace reftrie
+
+/// Build the canonical MPT root for @p kvs by one-at-a-time insertion into a mutable reference
+/// trie, then encoding through the trusted NodeEncoder. Used as the correctness oracle.
+inline bcos::h256 referenceRoot(std::vector<std::pair<bcos::h256, bcos::bytes>> const& kvs)
+{
+    if (kvs.empty())
+    {
+        return emptyRootHash();
+    }
+    reftrie::RefNodePtr rootNode;
+    for (auto const& [key, value] : kvs)
+    {
+        bcos::bytes const nibbles = bytesToNibbles(key.ref());
+        rootNode = reftrie::refInsert(rootNode, nibbles, value);
+    }
+
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    NodeRef const rootRef = reftrie::refEncode(rootNode, hasher);
+    bcos::h256 root;
+    if (rootRef.kind == NodeRef::Kind::Hash)
+    {
+        root = rootRef.hash;
+    }
+    else
+    {
+        bcos::crypto::hasher::hash(hasher, bcos::ref(rootRef.inlineBytes), root);
+    }
+    return root;
+}
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/TrieTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/TrieTest.cpp
@@ -1,0 +1,141 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TrieTest.cpp
+ * @brief Unit tests for the read-only Trie walk (spec §5.6, §7.1)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/NodeCache.h>
+#include <bcos-ledger/mpt/Trie.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <utility>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(TrieSuite)
+
+namespace
+{
+// A 32-byte key whose every byte is `fill`, then `tailLen` trailing bytes overwritten by `tail`.
+// Lets us craft keys that share a long nibble prefix (forcing an extension above a branch) while
+// still differing late enough to fan out across distinct branch slots.
+bcos::h256 trieKey(bcos::byte fill, bcos::byte tail, size_t tailLen)
+{
+    bcos::h256 key{};
+    for (size_t i = 0; i < bcos::h256::SIZE; ++i)
+    {
+        key.data()[i] = fill;
+    }
+    for (size_t i = 0; i < tailLen && i < bcos::h256::SIZE; ++i)
+    {
+        key.data()[bcos::h256::SIZE - 1 - i] = tail;
+    }
+    return key;
+}
+}  // namespace
+
+// A key that was inserted reads back its exact value through a freshly built root.
+BOOST_AUTO_TEST_CASE(GetExistentKeyReturnsValue)
+{
+    NodeCache cache;
+    HashBuilder hb(cache, emptyRootHash());
+
+    auto const key = makeHash(0xab);
+    bcos::bytes const value{0x42};
+    bcos::task::syncWait(hb.put(key, value));
+    auto const root = bcos::task::syncWait(hb.commit());
+
+    Trie trie(cache, root);
+    auto got = bcos::task::syncWait(trie.get(key));
+    BOOST_REQUIRE(got.has_value());
+    BOOST_CHECK(*got == value);
+}
+
+// An empty trie returns nullopt for any key (no node fetch happens at all).
+BOOST_AUTO_TEST_CASE(GetNonexistentKeyReturnsNullopt)
+{
+    NodeCache cache;
+    Trie trie(cache, emptyRootHash());
+
+    BOOST_CHECK(!bcos::task::syncWait(trie.get(makeHash(0x01))).has_value());
+    BOOST_CHECK(!bcos::task::syncWait(trie.get(makeHash(0xff))).has_value());
+    BOOST_CHECK(!bcos::task::syncWait(trie.get(bcos::h256{})).has_value());
+}
+
+// The real traversal test: a multi-key trie whose shape exercises extension nodes (long shared
+// prefix), branch nodes (the late fan-out), hash-child loading (large subtrees), and inline-child
+// decoding (tiny subtrees spliced raw). Every inserted key must read back its exact value, and a
+// key that was never inserted must return nullopt.
+BOOST_AUTO_TEST_CASE(MultiKeyEachKeyResolves)
+{
+    std::vector<std::pair<bcos::h256, bcos::bytes>> kvs;
+
+    // Group A: all share the 0xab... prefix, differing only in the final 1-2 bytes. This forces a
+    // deep extension above a branch; the differing nibbles land in distinct branch slots.
+    kvs.emplace_back(trieKey(0xab, 0x00, 1), bcos::bytes{0xa0});
+    kvs.emplace_back(trieKey(0xab, 0x10, 1), bcos::bytes{0xa1});
+    kvs.emplace_back(trieKey(0xab, 0x20, 1), bcos::bytes(40, 0xee));  // long value -> hashed
+                                                                      // subtree
+    kvs.emplace_back(trieKey(0xab, 0xcd, 2), bcos::bytes{0xa3});
+
+    // Group B: a different top prefix (0x12...) so the root itself becomes a branch/extension over
+    // two top-level groups.
+    kvs.emplace_back(trieKey(0x12, 0x00, 1), bcos::bytes{0xb0});
+    kvs.emplace_back(trieKey(0x12, 0x34, 2), bcos::bytes(64, 0x77));  // long value -> hashed
+                                                                      // subtree
+
+    // Group C: short single-byte-distinct top nibbles that drop straight into the root branch with
+    // tiny leaf subtrees (inline children).
+    kvs.emplace_back(makeHash(0x30), bcos::bytes{0xc0});
+    kvs.emplace_back(makeHash(0x4f), bcos::bytes{0xc1});
+
+    NodeCache cache;
+    HashBuilder hb(cache, emptyRootHash());
+    for (auto const& [key, value] : kvs)
+    {
+        bcos::task::syncWait(hb.put(key, value));
+    }
+    auto const root = bcos::task::syncWait(hb.commit());
+
+    Trie trie(cache, root);
+    for (auto const& [key, value] : kvs)
+    {
+        auto got = bcos::task::syncWait(trie.get(key));
+        BOOST_REQUIRE_MESSAGE(got.has_value(), "missing key " << key.hex());
+        BOOST_CHECK_MESSAGE(*got == value, "wrong value for key " << key.hex());
+    }
+
+    // A key that was never inserted must not resolve. 0xaa... diverges from group A at the very
+    // first nibble of the shared prefix, exercising the extension-mismatch early-out.
+    auto const absentA = trieKey(0xaa, 0x00, 1);
+    BOOST_CHECK(!bcos::task::syncWait(trie.get(absentA)).has_value());
+    // 0xab...0x99 shares the long prefix but lands on an empty branch slot.
+    auto const absentB = trieKey(0xab, 0x90, 1);
+    BOOST_CHECK(!bcos::task::syncWait(trie.get(absentB)).has_value());
+    // A completely unrelated key.
+    BOOST_CHECK(!bcos::task::syncWait(trie.get(makeHash(0xfe))).has_value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test


### PR DESCRIPTION
## Summary

Lands phase-A M3 of the MPT lazy-build plan: an LRU node cache, an RLP node decoder, a canonical HashBuilder that turns a key→value set into the 32-byte Ethereum state root, and a read-only Trie that walks a root down to a leaf. 5 commits, only `bcos-ledger/{bcos-ledger,test/unittests}/mpt/` is touched.

## M3.1 — NodeCache (5c293fb83)

`NodeCache` wraps `bcos::storage2::memory_storage::MemoryStorage<h256, bytes, CONCURRENT|LRU>` with async `get`/`put`. Same pattern as the existing `CacheStorage`; default capacity 64K nodes (byte-budgeted by `MemoryStorage`). It is the shared "node-hash → RLP bytes" store every other M3 component reads from and writes to. RocksDB-backed source-of-truth lands later (M5); for M3 the cache stands alone.

## M3.2 — NodeDecoder + HashBuilder (12be0d660, 7f4feda98)

`decodeNode(bytesConstRef) → TrieNode` is the inverse of M2's `encodeRaw` (M2 shipped only the encoder; the decoder is needed by both Trie and any future incremental builder). It handles all four node shapes: `{0x80}` → EmptyNode; 2-item list → Leaf or Extension distinguished by the HP terminator flag (extension child kept RLP-encoded raw); 17-item list → Branch (each child classified as absent / 32-byte hash / inline list).

`HashBuilder` accumulates `put(h256 key, bytes value)` / `remove(h256)` into a sorted `std::map`, then `commit()` builds the canonical MPT and returns the 32-byte root, writing every new hash-kind node into the `NodeCache`. The recursion is straight canonical construction (common-prefix → extension; cpl==0 → 16-way branch; single entry → leaf-with-suffix). All new nodes are recorded synchronously and flushed into the cache in one pass after the recursion returns, so there is no coroutine recursion.

**Scope note (read before reviewing the algorithm):** `commit()` is from-scratch canonical only. `priorRoot != emptyRootHash()` throws `MPTInvariantViolation` pointing at M4/PR-10 — the plan's headline "path-level incremental load from a prior root" is deferred there, because every M3 test builds from the empty root so the incremental path would have shipped with zero coverage. `remove()` records a tombstone in `m_changes` but its real effect (branch/extension collapse) belongs to the incremental path and is deferred too. `drainObsoletedNodes()` exists in the API but always returns empty for the same reason.

## M3.3 — Trie read view + 1000× purity gate (912057a07)

`Trie::get(h256 keyHash) const` walks from a root hash down to the value via `NodeCache` + `decodeNode`. Three child-ref resolvers cover the asymmetry the node model carries: `BranchNode.children[i]` is a typed `NodeRef` (handled by `trieLoadFromRef`); `ExtensionNode.child` is raw RLP bytes (handled by `trieLoadFromRawRef`, which classifies as 33-byte `0xa0`+hash vs inline list); both reduce to `trieLoadByHash` for the hash case.

`HashBuilderPuritySuite::SameInputProducesByteIdenticalRootOver1000Runs` is the determinism gate required by spec §5.6: the same 100-entry input is fed into a fresh HashBuilder 1000 times with the insertion order reshuffled each run, and the root plus every new-node entry must be byte-identical across all runs. Runs in ~170ms.

## Decoder simplification (ef1f79222, top commit)

After the initial NodeDecoder commit landed, a review pass pointed out that `parseItem` / `readBigEndianLen` (~66 lines) duplicated `bcos::codec::rlp::decodeHeader`. That commit deletes both and routes header parsing through the shared library, taking `NodeDecoder.cpp` from 232 → 144 lines. The MPT-specific structure dispatch and raw-span capture stay — `codec::rlp::decode` / `decodeItems` cannot express MPT child refs (string-OR-list polymorphic, must preserve raw RLP bytes for splicing into parents). One documented `const_cast` at `NodeDecoder.cpp:77` bridges the `bytesConstRef` input to `decodeHeader`'s mutable-view parameter; eliminating it would require either copies in the read hot path or rippling a `bytesRef` signature into Trie's loaders.

## Test plan

- 21 new test cases across 5 suites, all green:
  - `NodeCacheSuite` (3): put/get round-trip, miss → nullopt, LRU eviction (uses same-bucket-key selection so per-bucket eviction is deterministic regardless of CPU count).
  - `NodeDecoderSuite` (8): empty-node decode, 5 round-trips covering leaf (short + ≥32-byte value), extension (hash child and inline child), branch (mixed children), plus 2 reject cases (non-empty top string, truncated item).
  - `HashBuilderSuite` (5): empty root, single-leaf anchored to `encodeRaw`, two-key shared prefix, **`RandomBatchMatchesReference`** cross-checking against an independently coded one-at-a-time-insert reference trie (`TestHelpers.h::referenceRoot`) for sizes 1/2/5/20/100 with shuffled insertion, `drainNewNodes` consistency.
  - `TrieSuite` (3): existent key returns value, nonexistent returns nullopt, multi-key trie that forces extension + branch + both hash and inline child resolution.
  - `HashBuilderPuritySuite` (2): the 1000× determinism case plus the empty-input case.
- Full `test-bcos-ledger` binary: `*** No errors detected` (no regression in the other ~46 ledger cases).
- Branch is rebased onto current `release-3.18.0` (`990c82736`); full build + tests re-run on the new base.

## Notes for reviewers

- The from-scratch builder vs the spec's "path-incremental" headline is the largest deviation; it is explicit at `HashBuilder.cpp:153-158`. The expectation is M4/PR-10 replaces just that throw with the incremental rebuild; the canonical path and the independent reference oracle stay as the regression baseline.
- The correctness oracle is in-tree (`TestHelpers.h::referenceRoot`) rather than go-ethereum's `trietest.json`, because the latter uses raw variable-length keys while this trie uses 32-byte keccak keys (64-nibble paths). The oracle is a genuinely different algorithm (one-at-a-time mutable insert) than HashBuilder's batch sorted recursion; the single-leaf test additionally anchors directly to the M2-validated `encodeRaw`.
- The `const_cast` in `NodeDecoder.cpp` is intentional and documented; clang-tidy will flag it. See the "Decoder simplification" section above for the trade-off.

Refs: spec §5.1 / §5.3 / §5.5 / §5.6 / §7.1