### PR TITLE
refactor(ledger): consolidate audit bugfix flags into bugfix_auth_check and bugfix_v1_error_handling

### DIFF
--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -1873,8 +1873,7 @@ void TransactionExecutive::creatAuthTable(std::string_view _tableName, std::stri
                          << LOG_KV("admin", admin);
     auto table = m_storageWrapper->createTable(authTableName, std::string(STORAGE_VALUE));
     // FIB-83: if table already exists (e.g. squatting), open it and overwrite auth rows
-    if (!table &&
-        m_blockContext.features().get(ledger::Features::Flag::bugfix_auth_table_squatting))
+    if (!table && m_blockContext.features().get(ledger::Features::Flag::bugfix_auth_check))
     {
         table = m_storageWrapper->openTable(authTableName);
     }
@@ -1901,7 +1900,7 @@ bool TransactionExecutive::checkAuth(const CallParameters::UniquePtr& callParame
 {
     // FIB-81: cache flag to ensure auth failures always report EVMC_REVERT
     const bool fixRevertStatus =
-        m_blockContext.features().get(ledger::Features::Flag::bugfix_auth_check_revert_status);
+        m_blockContext.features().get(ledger::Features::Flag::bugfix_auth_check);
 
     auto revertAuth = [&](int32_t status, std::string_view message) {
         callParameters->status = status;

--- a/bcos-executor/src/precompiled/common/Utilities.cpp
+++ b/bcos-executor/src/precompiled/common/Utilities.cpp
@@ -321,7 +321,7 @@ bool precompiled::checkPathValid(std::string_view _path,
         return false;
     }
     // FIB-83: reject paths ending with reserved _accessAuth suffix to prevent auth table squatting
-    if (features != nullptr && features->get(ledger::Features::Flag::bugfix_auth_table_squatting))
+    if (features != nullptr && features->get(ledger::Features::Flag::bugfix_auth_check))
     {
         for (const auto& component : pathList)
         {

--- a/bcos-executor/test/unittest/libprecompiled/FIB83_AccessAuthSuffixTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/FIB83_AccessAuthSuffixTest.cpp
@@ -32,16 +32,16 @@ BOOST_AUTO_TEST_SUITE(FIB83_AccessAuthSuffixTest)
 
 BOOST_AUTO_TEST_CASE(rejectAccessAuthSuffix_WithFlag)
 {
-    // Set up features with bugfix_auth_table_squatting enabled
+    // Set up features with bugfix_auth_check enabled
     ledger::Features features;
-    features.set(ledger::Features::Flag::bugfix_auth_table_squatting);
+    features.set(ledger::Features::Flag::bugfix_auth_check);
 
     // Paths ending with _accessAuth should be rejected when the flag is on
     BOOST_CHECK(
-        !checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_16_5_VERSION, &features));
+        !checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_17_0_VERSION, &features));
     BOOST_CHECK(!checkPathValid(
-        "/apps/aabbccddee1234_accessAuth", BlockVersion::V3_16_5_VERSION, &features));
-    BOOST_CHECK(!checkPathValid("/apps/_accessAuth", BlockVersion::V3_16_5_VERSION, &features));
+        "/apps/aabbccddee1234_accessAuth", BlockVersion::V3_17_0_VERSION, &features));
+    BOOST_CHECK(!checkPathValid("/apps/_accessAuth", BlockVersion::V3_17_0_VERSION, &features));
 }
 
 BOOST_AUTO_TEST_CASE(allowAccessAuthSuffix_WithoutFlag)
@@ -49,10 +49,10 @@ BOOST_AUTO_TEST_CASE(allowAccessAuthSuffix_WithoutFlag)
     // Without the flag, paths ending with _accessAuth should pass (backward compat)
     ledger::Features noFlag;
     BOOST_CHECK(
-        checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_16_5_VERSION, &noFlag));
+        checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_17_0_VERSION, &noFlag));
 
     // Even with nullptr features (e.g. ShardingPrecompiled path), should pass
-    BOOST_CHECK(checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_16_5_VERSION));
+    BOOST_CHECK(checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_17_0_VERSION));
     BOOST_CHECK(checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_2_VERSION));
     BOOST_CHECK(checkPathValid("/apps/contract_accessAuth", BlockVersion::V3_1_VERSION));
 }
@@ -60,23 +60,23 @@ BOOST_AUTO_TEST_CASE(allowAccessAuthSuffix_WithoutFlag)
 BOOST_AUTO_TEST_CASE(allowNonSuffixPaths_WithFlag)
 {
     ledger::Features features;
-    features.set(ledger::Features::Flag::bugfix_auth_table_squatting);
+    features.set(ledger::Features::Flag::bugfix_auth_check);
 
     // Paths that don't end with _accessAuth should still be valid
-    BOOST_CHECK(checkPathValid("/apps/mycontract", BlockVersion::V3_16_5_VERSION, &features));
+    BOOST_CHECK(checkPathValid("/apps/mycontract", BlockVersion::V3_17_0_VERSION, &features));
     BOOST_CHECK(
-        checkPathValid("/apps/accessAuth_contract", BlockVersion::V3_16_5_VERSION, &features));
-    BOOST_CHECK(checkPathValid("/apps/my_accessAuthx", BlockVersion::V3_16_5_VERSION, &features));
+        checkPathValid("/apps/accessAuth_contract", BlockVersion::V3_17_0_VERSION, &features));
+    BOOST_CHECK(checkPathValid("/apps/my_accessAuthx", BlockVersion::V3_17_0_VERSION, &features));
 }
 
 BOOST_AUTO_TEST_CASE(rejectNestedAccessAuthSuffix)
 {
     ledger::Features features;
-    features.set(ledger::Features::Flag::bugfix_auth_table_squatting);
+    features.set(ledger::Features::Flag::bugfix_auth_check);
 
     // Intermediate path components ending with _accessAuth should also be rejected
     BOOST_CHECK(
-        !checkPathValid("/apps/contract_accessAuth/sub", BlockVersion::V3_16_5_VERSION, &features));
+        !checkPathValid("/apps/contract_accessAuth/sub", BlockVersion::V3_17_0_VERSION, &features));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-framework/bcos-framework/ledger/Features.cpp
+++ b/bcos-framework/bcos-framework/ledger/Features.cpp
@@ -194,22 +194,12 @@ void Features::setUpgradeFeatures(
                 .flags = {Flag::bugfix_delegatecall_transfer, Flag::bugfix_nonce_initialize,
                     Flag::bugfix_v1_timestamp}},
             {.to = protocol::BlockVersion::V3_16_4_VERSION, .flags = {Flag::bugfix_revert_logs}},
-            {.to = protocol::BlockVersion::V3_16_5_VERSION,
-                .flags =
-                    {
-                        Flag::bugfix_auth_check_create2,
-                        Flag::bugfix_auth_check_revert_status,
-                        Flag::bugfix_auth_table_raw_address,
-                        Flag::bugfix_auth_table_squatting,
-                        Flag::bugfix_v1_exec_error_gas_used,
-                        Flag::bugfix_v1_precompiled_error_gas,
-                    }},
             {.to = protocol::BlockVersion::V3_17_0_VERSION,
                 .flags = {
+                    Flag::bugfix_auth_check,
+                    Flag::bugfix_v1_error_handling,
                     Flag::bugfix_gas_payment_balance_precheck,
-                    Flag::bugfix_clamp_gas_left_on_error,
                     Flag::bugfix_precompiled_feature_gate,
-                    Flag::bugfix_v1_executive_wrapper,
                     Flag::bugfix_evm_storage_status,
                     Flag::bugfix_statestorage_hash_v3_17,
                 }}});

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -74,17 +74,14 @@ public:
         bugfix_nonce_initialize,
         bugfix_v1_timestamp,
         bugfix_revert_logs,
-        bugfix_auth_check_create2,
-        bugfix_auth_check_revert_status,
-        bugfix_auth_table_raw_address,
-        bugfix_auth_table_squatting,
-        bugfix_v1_exec_error_gas_used,
-        bugfix_v1_precompiled_error_gas,      // FIB-76/79/80: precompiled gas overflow check,
-                                              // exception safety, and use remaining gas on revert
+        bugfix_auth_check,         // FIB-77/81/82/83: CREATE2 deploy auth check, auth failure
+                                   // revert status, auth table raw-address path, auth table
+                                   // squatting (merged, all activate at V3_17_0)
+        bugfix_v1_error_handling,  // FIB-76/78/79/80/85~92: v1 executor error-path gas
+                                   // accounting, gas_left clamp on fatal error, executive
+                                   // wrapper status/message marshaling (merged)
         bugfix_gas_payment_balance_precheck,  // FIB-75
-        bugfix_clamp_gas_left_on_error,       // FIB-78
         bugfix_precompiled_feature_gate,      // FIB-84
-        bugfix_v1_executive_wrapper,          // FIB-85/86/87
         bugfix_evm_storage_status,            // FIB-94
         bugfix_statestorage_hash_v3_17,       // FIB-99/105
         feature_dmc2serial,

--- a/bcos-framework/bcos-framework/protocol/Protocol.h
+++ b/bcos-framework/bcos-framework/protocol/Protocol.h
@@ -174,7 +174,7 @@ const std::string RC4_VERSION_STR = "3.0.0-rc4";
 const std::string RC_VERSION_PREFIX = "3.0.0-rc";
 const std::string V3_9_VERSION_STR = "3.9.0";
 
-constexpr BlockVersion DEFAULT_VERSION = bcos::protocol::BlockVersion::V3_16_5_VERSION;  // 3.16.5
+constexpr BlockVersion DEFAULT_VERSION = bcos::protocol::BlockVersion::V3_17_0_VERSION;  // 3.17.0
 const std::string DEFAULT_VERSION_STR = V3_9_VERSION_STR;
 constexpr uint8_t MAX_MAJOR_VERSION = std::numeric_limits<uint8_t>::max();
 constexpr uint8_t MIN_MAJOR_VERSION = 3;

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -178,16 +178,10 @@ BOOST_AUTO_TEST_CASE(feature)
         "bugfix_nonce_initialize",
         "bugfix_v1_timestamp",
         "bugfix_revert_logs",
-        "bugfix_auth_check_create2",
-        "bugfix_auth_check_revert_status",
-        "bugfix_auth_table_raw_address",
-        "bugfix_auth_table_squatting",
-        "bugfix_v1_exec_error_gas_used",
-        "bugfix_v1_precompiled_error_gas",
+        "bugfix_auth_check",
+        "bugfix_v1_error_handling",
         "bugfix_gas_payment_balance_precheck",
-        "bugfix_clamp_gas_left_on_error",
         "bugfix_precompiled_feature_gate",
-        "bugfix_v1_executive_wrapper",
         "bugfix_evm_storage_status",
         "bugfix_statestorage_hash_v3_17",
         "feature_dmc2serial",
@@ -365,34 +359,31 @@ BOOST_AUTO_TEST_CASE(upgrade)
         bcos::protocol::BlockVersion::V3_16_4_VERSION);
     BOOST_TEST(validFlags(features13).size() == 1);
 
-    // 3.15.2 to 3.16.5: expect 3.16.0, 3.16.4 and 3.16.5 feature flags
+    // 3.16.4 to 3.16.5: ghost version, no flags activate
     Features features14;
-    features14.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_15_2_VERSION,
+    features14.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_16_4_VERSION,
         bcos::protocol::BlockVersion::V3_16_5_VERSION);
-    auto expect11 = std::to_array<std::string_view>(
-        {"bugfix_delegatecall_transfer", "bugfix_nonce_initialize", "bugfix_v1_timestamp",
-            "bugfix_revert_logs", "bugfix_auth_check_create2", "bugfix_auth_check_revert_status",
-            "bugfix_auth_table_raw_address", "bugfix_auth_table_squatting",
-            "bugfix_v1_exec_error_gas_used", "bugfix_v1_precompiled_error_gas"});
-    BOOST_CHECK_EQUAL(validFlags(features14).size(), expect11.size());
-    for (auto feature : expect11)
-    {
-        BOOST_CHECK(features14.get(feature));
-    }
+    BOOST_CHECK_EQUAL(validFlags(features14).size(), 0);
 
-    // 3.16.5 to 3.17.0: expect the six FIB-75/78/84/85-87/94/99-105 flags only
+    // 3.16.4 to 3.17.0: the six consolidated audit flags
     Features features15;
-    features15.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_16_5_VERSION,
+    features15.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_16_4_VERSION,
         bcos::protocol::BlockVersion::V3_17_0_VERSION);
-    auto expect12 = std::to_array<std::string_view>(
-        {"bugfix_gas_payment_balance_precheck", "bugfix_clamp_gas_left_on_error",
-            "bugfix_precompiled_feature_gate", "bugfix_v1_executive_wrapper",
+    auto expect12 =
+        std::to_array<std::string_view>({"bugfix_auth_check", "bugfix_v1_error_handling",
+            "bugfix_gas_payment_balance_precheck", "bugfix_precompiled_feature_gate",
             "bugfix_evm_storage_status", "bugfix_statestorage_hash_v3_17"});
     BOOST_CHECK_EQUAL(validFlags(features15).size(), expect12.size());
     for (auto feature : expect12)
     {
         BOOST_CHECK(features15.get(feature));
     }
+
+    // 3.16.5 to 3.17.0: same six flags (3.16.5 chains, if any existed, lose nothing)
+    Features features16;
+    features16.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_16_5_VERSION,
+        bcos::protocol::BlockVersion::V3_17_0_VERSION);
+    BOOST_CHECK_EQUAL(validFlags(features16).size(), expect12.size());
 }
 
 BOOST_AUTO_TEST_CASE(genesis)
@@ -537,7 +528,7 @@ BOOST_AUTO_TEST_CASE(genesis)
         BOOST_CHECK(features3_152.get(feature));
     }
 
-    // 3.16.5
+    // 3.16.5 (ghost version, behaves as 3.16.4)
     Features features3_16_5;
     features3_16_5.setGenesisFeatures(bcos::protocol::BlockVersion::V3_16_5_VERSION);
     auto expect3_16_5 = std::to_array<std::string_view>({// up to 3.15.1
@@ -558,17 +549,30 @@ BOOST_AUTO_TEST_CASE(genesis)
         // 3.16.0
         "bugfix_delegatecall_transfer", "bugfix_nonce_initialize", "bugfix_v1_timestamp",
         // 3.16.4
-        "bugfix_revert_logs",
-        // 3.16.5
-        "bugfix_auth_check_create2", "bugfix_auth_check_revert_status",
-        "bugfix_auth_table_raw_address", "bugfix_auth_table_squatting",
-        "bugfix_v1_exec_error_gas_used", "bugfix_v1_precompiled_error_gas"});
+        "bugfix_revert_logs"});
     BOOST_CHECK_EQUAL(validFlags(features3_16_5).size(), expect3_16_5.size());
     for (auto feature : expect3_16_5)
     {
         BOOST_CHECK(features3_16_5.get(feature));
     }
     BOOST_CHECK_EQUAL(features3_16_5.get(bcos::ledger::Features::Flag::bugfix_revert_logs), true);
+
+    // 3.17.0: everything in 3.16.5 plus the six consolidated audit flags
+    Features features3_17_0;
+    features3_17_0.setGenesisFeatures(bcos::protocol::BlockVersion::V3_17_0_VERSION);
+    auto extra3_17_0 =
+        std::to_array<std::string_view>({"bugfix_auth_check", "bugfix_v1_error_handling",
+            "bugfix_gas_payment_balance_precheck", "bugfix_precompiled_feature_gate",
+            "bugfix_evm_storage_status", "bugfix_statestorage_hash_v3_17"});
+    BOOST_CHECK_EQUAL(validFlags(features3_17_0).size(), expect3_16_5.size() + extra3_17_0.size());
+    for (auto feature : expect3_16_5)
+    {
+        BOOST_CHECK(features3_17_0.get(feature));
+    }
+    for (auto feature : extra3_17_0)
+    {
+        BOOST_CHECK(features3_17_0.get(feature));
+    }
 }
 
 

--- a/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
@@ -170,7 +170,7 @@ bcos::executor_v1::EVMCResult bcos::executor_v1::makeErrorEVMCResult(crypto::Has
     protocol::TransactionStatus status, evmc_status_code evmStatus, int64_t gas,
     const std::string& errorInfo, bool clampGasLeft)
 {
-    // FIB-78: when bugfix_clamp_gas_left_on_error is active, force gas_left to 0 for
+    // FIB-78: when bugfix_v1_error_handling is active, force gas_left to 0 for
     // fatal EVM error statuses so downstream gasUsed computations cannot under-charge,
     // and clamp any negative value to prevent signed-overflow in (gasLimit - gas_left).
     // Gated by a feature flag to preserve consensus with pre-fix nodes.

--- a/transaction-executor/bcos-transaction-executor/precompiled/AuthCheck.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/AuthCheck.h
@@ -48,7 +48,7 @@ inline std::optional<EVMCResult> checkAuth(auto& storage, protocol::BlockHeader 
     params->gas = message.gas;
     params->staticCall = (message.flags & EVMC_STATIC) != 0;
     // FIB-77: include EVMC_CREATE2 in deploy authorization check
-    if (features.get(ledger::Features::Flag::bugfix_auth_check_create2))
+    if (features.get(ledger::Features::Flag::bugfix_auth_check))
     {
         params->create = (message.kind == EVMC_CREATE || message.kind == EVMC_CREATE2);
     }
@@ -62,7 +62,7 @@ inline std::optional<EVMCResult> checkAuth(auto& storage, protocol::BlockHeader 
     {
         // FIB-81: return ABI-encoded error message instead of full transaction input
         bcos::bytes errorOutput;
-        if (features.get(ledger::Features::Flag::bugfix_auth_check_revert_status))
+        if (features.get(ledger::Features::Flag::bugfix_auth_check))
         {
             errorOutput = writeErrInfoToOutput(
                 hashImpl, params->message.empty() ? "Authorization check failed" : params->message);

--- a/transaction-executor/bcos-transaction-executor/precompiled/ExecutiveWrapper.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/ExecutiveWrapper.h
@@ -132,7 +132,7 @@ public:
         callResult->data.assign(result.output_data, result.output_data + result.output_size);
 
         const bool applyBugfix =
-            m_blockContext->features().get(ledger::Features::Flag::bugfix_v1_executive_wrapper);
+            m_blockContext->features().get(ledger::Features::Flag::bugfix_v1_error_handling);
         if (applyBugfix)
         {
             callResult->status = static_cast<int32_t>(result.status);

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
@@ -60,7 +60,7 @@ inline EVMCResult buildBuiltinPrecompiledResult(bool success, auto const& output
 inline EVMCResult callBuiltinPrecompiled(executor::PrecompiledContract const& precompiledContract,
     evmc_message const& message, ledger::Features const& features)
 {
-    if (features.get(ledger::Features::Flag::bugfix_v1_precompiled_error_gas))
+    if (features.get(ledger::Features::Flag::bugfix_v1_error_handling))
     {
         // FIB-76: validate cost BEFORE execute to guard against overflow / insufficient gas.
         const auto gas = precompiledContract.cost({message.input_data, message.input_size});
@@ -69,7 +69,7 @@ inline EVMCResult callBuiltinPrecompiled(executor::PrecompiledContract const& pr
             return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
                 protocol::TransactionStatus::OutOfGas, EVMC_OUT_OF_GAS, 0,
                 "Precompiled contract gas cost overflow",
-                features.get(ledger::Features::Flag::bugfix_clamp_gas_left_on_error));
+                features.get(ledger::Features::Flag::bugfix_v1_error_handling));
         }
         const auto gasCost = gas.template convert_to<int64_t>();
         if (gasCost > message.gas)
@@ -77,7 +77,7 @@ inline EVMCResult callBuiltinPrecompiled(executor::PrecompiledContract const& pr
             return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
                 protocol::TransactionStatus::OutOfGas, EVMC_OUT_OF_GAS, 0,
                 "Precompiled contract out of gas",
-                features.get(ledger::Features::Flag::bugfix_clamp_gas_left_on_error));
+                features.get(ledger::Features::Flag::bugfix_v1_error_handling));
         }
         auto [success, output] =
             precompiledContract.execute({message.input_data, message.input_size});
@@ -118,7 +118,7 @@ inline EVMCResult callBcosPrecompiled(
     // FIB-80: use remaining gas on revert (EVM-spec). Clamp to [0, message.gas] to defend
     // against buggy precompiled implementations.
     auto errorGas = [&] {
-        return features.get(ledger::Features::Flag::bugfix_v1_precompiled_error_gas) ?
+        return features.get(ledger::Features::Flag::bugfix_v1_error_handling) ?
                    std::clamp(params->m_gasLeft, static_cast<int64_t>(0), message.gas) :
                    message.gas;
     };
@@ -150,7 +150,7 @@ inline EVMCResult callBcosPrecompiled(
                                 << LOG_KV("message", e.what());
         return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
             protocol::TransactionStatus::PrecompiledError, EVMC_REVERT, errorGas(), e.what(),
-            features.get(ledger::Features::Flag::bugfix_clamp_gas_left_on_error));
+            features.get(ledger::Features::Flag::bugfix_v1_error_handling));
     }
     catch (std::exception& e)
     {
@@ -159,7 +159,7 @@ inline EVMCResult callBcosPrecompiled(
         return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
             protocol::TransactionStatus::PrecompiledError, EVMC_REVERT, errorGas(),
             "InternalPrecompiledFailed"s,
-            features.get(ledger::Features::Flag::bugfix_clamp_gas_left_on_error));
+            features.get(ledger::Features::Flag::bugfix_v1_error_handling));
     }
 }
 
@@ -174,7 +174,7 @@ inline constexpr struct
         ledger::Features const& features) const
     {
         const bool bugfixPrecompiled =
-            features.get(ledger::Features::Flag::bugfix_v1_precompiled_error_gas);
+            features.get(ledger::Features::Flag::bugfix_v1_error_handling);
 
         try
         {
@@ -200,7 +200,7 @@ inline constexpr struct
             return makeErrorEVMCResult(*executor::GlobalHashImpl::g_hashImpl,
                 protocol::TransactionStatus::PrecompiledError, EVMC_INTERNAL_ERROR, 0,
                 "InternalPrecompiledError",
-                features.get(ledger::Features::Flag::bugfix_clamp_gas_left_on_error));
+                features.get(ledger::Features::Flag::bugfix_v1_error_handling));
         }
     }
 } callPrecompiled{};

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -407,9 +407,10 @@ public:
         auto transientSavepoint = m_rollbackableTransientStorage.get().current();
 
         std::optional<EVMCResult> evmResult;
-        // FIB-88/89/92: read once, gate receipt-affecting error paths for hard-fork compat
-        const bool fixErrorGas = m_ledgerConfig.get().features().get(
-            ledger::Features::Flag::bugfix_v1_exec_error_gas_used);
+        // FIB-76~92 (bugfix_v1_error_handling): read once, gates all receipt-affecting
+        // error paths below for hard-fork compat
+        const bool fixErrorHandling =
+            m_ledgerConfig.get().features().get(ledger::Features::Flag::bugfix_v1_error_handling);
         try
         {
             // FIB-91: checkAuth() moved inside try block so exceptions
@@ -467,9 +468,7 @@ public:
             HOST_CONTEXT_LOG(DEBUG) << "OutOfGas exception: " << boost::diagnostic_information(e);
             // FIB-89: use 0 instead of potentially uninitialized evmResult->gas_left
             evmResult.emplace(makeErrorEVMCResult(m_hashImpl, protocol::TransactionStatus::OutOfGas,
-                EVMC_OUT_OF_GAS, 0, e.what(),
-                m_ledgerConfig.get().features().get(
-                    ledger::Features::Flag::bugfix_clamp_gas_left_on_error)));
+                EVMC_OUT_OF_GAS, 0, e.what(), fixErrorHandling));
         }
         catch (protocol::NotEnoughCashError& e)
         {
@@ -478,7 +477,7 @@ public:
             // FIB-88: fatal error consumes all gas when bugfix flag enabled
             evmResult.emplace(
                 makeErrorEVMCResult(m_hashImpl, protocol::TransactionStatus::NotEnoughCash,
-                    EVMC_INSUFFICIENT_BALANCE, fixErrorGas ? 0 : ref->gas, e.what()));
+                    EVMC_INSUFFICIENT_BALANCE, fixErrorHandling ? 0 : ref->gas, e.what()));
         }
         catch (NotFoundCodeError& e)
         {
@@ -497,9 +496,7 @@ public:
                 // FIB-88: EVMC_REVERT preserves ref->gas per EVM spec
                 evmResult.emplace(
                     makeErrorEVMCResult(m_hashImpl, protocol::TransactionStatus::RevertInstruction,
-                        EVMC_REVERT, ref->gas, "Call address error."s,
-                        m_ledgerConfig.get().features().get(
-                            ledger::Features::Flag::bugfix_clamp_gas_left_on_error)));
+                        EVMC_REVERT, ref->gas, "Call address error."s, fixErrorHandling));
             }
         }
         catch (std::exception& e)
@@ -508,11 +505,9 @@ public:
             // FIB-88: fatal error consumes all gas
             // FIB-92: use Unknown instead of OutOfGas for EVMC_INTERNAL_ERROR
             evmResult.emplace(makeErrorEVMCResult(m_hashImpl,
-                fixErrorGas ? protocol::TransactionStatus::Unknown :
-                              protocol::TransactionStatus::OutOfGas,
-                EVMC_INTERNAL_ERROR, fixErrorGas ? 0 : ref->gas, "",
-                m_ledgerConfig.get().features().get(
-                    ledger::Features::Flag::bugfix_clamp_gas_left_on_error)));
+                fixErrorHandling ? protocol::TransactionStatus::Unknown :
+                                   protocol::TransactionStatus::OutOfGas,
+                EVMC_INTERNAL_ERROR, fixErrorHandling ? 0 : ref->gas, "", fixErrorHandling));
         }
 
         if (evmResult->gas_left < 0)
@@ -520,9 +515,7 @@ public:
             HOST_CONTEXT_LOG(DEBUG) << "Execute gas < 0: " << evmResult->gas_left;
             // FIB-88: fatal error consumes all gas when bugfix flag enabled
             evmResult.emplace(makeErrorEVMCResult(m_hashImpl, protocol::TransactionStatus::OutOfGas,
-                EVMC_OUT_OF_GAS, fixErrorGas ? 0 : ref->gas, "",
-                m_ledgerConfig.get().features().get(
-                    ledger::Features::Flag::bugfix_clamp_gas_left_on_error)));
+                EVMC_OUT_OF_GAS, fixErrorHandling ? 0 : ref->gas, "", fixErrorHandling));
         }
 
         if (evmResult->status_code != EVMC_SUCCESS)
@@ -580,8 +573,7 @@ private:
             // FIB-82: when feature_raw_address is on, m_recipientAccount.path() returns a binary
             // path, but ContractAuthMgrPrecompiled always looks up auth tables using hex paths.
             // Force hex to match the lookup path.
-            if (m_ledgerConfig.get().features().get(
-                    ledger::Features::Flag::bugfix_auth_table_raw_address) &&
+            if (m_ledgerConfig.get().features().get(ledger::Features::Flag::bugfix_auth_check) &&
                 m_ledgerConfig.get().features().get(ledger::Features::Flag::feature_raw_address))
             {
                 authTablePath =

--- a/transaction-executor/tests/FIB77_81_AuthCheckTest.cpp
+++ b/transaction-executor/tests/FIB77_81_AuthCheckTest.cpp
@@ -60,18 +60,16 @@ public:
 BOOST_FIXTURE_TEST_SUITE(FIB77_81_AuthCheckTest, AuthCheckBugfixFixture)
 
 // FIB-81: When auth check is enabled and deployment is denied, receipt should have
-// non-zero status (EVMC_REVERT) when bugfix_auth_check_revert_status is enabled.
+// non-zero status (EVMC_REVERT) when bugfix_auth_check is enabled.
 BOOST_AUTO_TEST_CASE(authFailureSetsRevertStatus)
 {
     task::syncWait([this]() mutable -> task::Task<void> {
         bcostars::protocol::BlockHeaderImpl blockHeader;
-        blockHeader.setVersion((uint32_t)bcos::protocol::BlockVersion::V3_16_5_VERSION);
+        blockHeader.setVersion((uint32_t)bcos::protocol::BlockVersion::V3_17_0_VERSION);
         blockHeader.calculateHash(*cryptoSuite->hashImpl());
 
         auto features = ledgerConfig.features();
-        features.setGenesisFeatures(bcos::protocol::BlockVersion::V3_16_5_VERSION);
-        features.set(ledger::Features::Flag::bugfix_auth_check_revert_status);
-        features.set(ledger::Features::Flag::bugfix_auth_check_create2);
+        features.setGenesisFeatures(bcos::protocol::BlockVersion::V3_17_0_VERSION);
         ledgerConfig.setFeatures(features);
         // Enable auth checking
         ledgerConfig.setAuthCheckStatus(1);
@@ -107,7 +105,7 @@ BOOST_AUTO_TEST_CASE(authFailureWithoutBugfix)
 
         auto features = ledgerConfig.features();
         features.setGenesisFeatures(bcos::protocol::BlockVersion::V3_16_0_VERSION);
-        // Do NOT set bugfix_auth_check_revert_status
+        // Do NOT set bugfix_auth_check
         ledgerConfig.setFeatures(features);
         ledgerConfig.setAuthCheckStatus(1);
 
@@ -125,46 +123,33 @@ BOOST_AUTO_TEST_CASE(authFailureWithoutBugfix)
     }());
 }
 
-// FIB-77: Verify feature flag controls CREATE2 auth path
+// FIB-77: Verify the merged feature flag controls the CREATE2 auth path
 BOOST_AUTO_TEST_CASE(featureFlagCreate2)
 {
-    // Verify the feature flags can be set and read correctly
     ledger::Features features;
+    BOOST_CHECK(!features.get(ledger::Features::Flag::bugfix_auth_check));
+    features.set(ledger::Features::Flag::bugfix_auth_check);
+    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_auth_check));
 
-    // Without bugfix_auth_check_create2
-    BOOST_CHECK(!features.get(ledger::Features::Flag::bugfix_auth_check_create2));
-
-    // With bugfix_auth_check_create2
-    features.set(ledger::Features::Flag::bugfix_auth_check_create2);
-    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_auth_check_create2));
-
-    // Verify setGenesisFeatures at V3_16_5 includes the new flags
+    // Verify setGenesisFeatures at V3_17_0 includes the merged flag
     ledger::Features genesisFeatures;
-    genesisFeatures.setGenesisFeatures(bcos::protocol::BlockVersion::V3_16_5_VERSION);
-    BOOST_CHECK(genesisFeatures.get(ledger::Features::Flag::bugfix_auth_check_create2));
-    BOOST_CHECK(genesisFeatures.get(ledger::Features::Flag::bugfix_auth_check_revert_status));
-    BOOST_CHECK(genesisFeatures.get(ledger::Features::Flag::bugfix_auth_table_raw_address));
-    BOOST_CHECK(genesisFeatures.get(ledger::Features::Flag::bugfix_auth_table_squatting));
+    genesisFeatures.setGenesisFeatures(bcos::protocol::BlockVersion::V3_17_0_VERSION);
+    BOOST_CHECK(genesisFeatures.get(ledger::Features::Flag::bugfix_auth_check));
 }
 
-// FIB-77: Verify upgrade from V3_16_4 to V3_16_5 enables the new flags
+// FIB-77: Verify upgrade from V3_16_4 to V3_17_0 enables the merged flag
 BOOST_AUTO_TEST_CASE(upgradeEnablesAuthFlags)
 {
     ledger::Features features;
     features.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_16_4_VERSION,
-        bcos::protocol::BlockVersion::V3_16_5_VERSION);
-    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_auth_check_create2));
-    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_auth_check_revert_status));
-    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_auth_table_raw_address));
-    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_auth_table_squatting));
+        bcos::protocol::BlockVersion::V3_17_0_VERSION);
+    BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_auth_check));
 
-    // Should NOT have flags from before (only the diff)
-    // The upgrade from V3_16_4 to V3_16_5 should only add the new auth flags
+    // The upgrade path that stops at V3_16_4 must NOT enable it
     ledger::Features features2;
     features2.setUpgradeFeatures(bcos::protocol::BlockVersion::V3_16_0_VERSION,
         bcos::protocol::BlockVersion::V3_16_4_VERSION);
-    BOOST_CHECK(!features2.get(ledger::Features::Flag::bugfix_auth_check_create2));
-    BOOST_CHECK(!features2.get(ledger::Features::Flag::bugfix_auth_check_revert_status));
+    BOOST_CHECK(!features2.get(ledger::Features::Flag::bugfix_auth_check));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-executor/tests/FIB88_92_ErrorHandlingTest.cpp
+++ b/transaction-executor/tests/FIB88_92_ErrorHandlingTest.cpp
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(FIB88_NegativeGasFixupConsumesAllGas)
 }
 
 // ---------------------------------------------------------------------------
-// Flag-off backward compatibility: when bugfix_v1_exec_error_gas_used is
+// Flag-off backward compatibility: when bugfix_v1_error_handling is
 // disabled, error paths must preserve the old gas_left / status values so
 // that receipt hashes stay identical to older nodes.
 // ---------------------------------------------------------------------------
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(FIB88_NegativeGasFixupConsumesAllGas)
 BOOST_AUTO_TEST_CASE(FIB88_FlagOff_InsufficientBalancePreservesGas)
 {
     syncWait([this]() -> Task<void> {
-        // Use V3_16_3 which does NOT activate bugfix_v1_exec_error_gas_used
+        // Use V3_16_3 which does NOT activate bugfix_v1_error_handling
         bcostars::protocol::BlockHeaderImpl oldHeader;
         oldHeader.setVersion(static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_16_3_VERSION));
         oldHeader.setNumber(seq++);

--- a/transaction-executor/tests/TestEVMCResult.cpp
+++ b/transaction-executor/tests/TestEVMCResult.cpp
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(testResourceManagement)
     }
 }
 
-// FIB-78: gas_left clamping is gated by bugfix_clamp_gas_left_on_error.
+// FIB-78: gas_left clamping is gated by bugfix_v1_error_handling.
 BOOST_AUTO_TEST_CASE(makeErrorEVMCResult_clampDisabled_preservesGas)
 {
     auto result =

--- a/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
+++ b/transaction-scheduler/tests/FIB99_FIB105_StateRootTest.cpp
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(bugfixFlagActivatedAtV3_17_0)
     BOOST_CHECK(!features.get(ledger::Features::Flag::bugfix_statestorage_hash_v3_17));
 
     features.setUpgradeFeatures(
-        protocol::BlockVersion::V3_16_5_VERSION, protocol::BlockVersion::V3_17_0_VERSION);
+        protocol::BlockVersion::V3_16_4_VERSION, protocol::BlockVersion::V3_17_0_VERSION);
     BOOST_CHECK(features.get(ledger::Features::Flag::bugfix_statestorage_hash_v3_17));
 }
 


### PR DESCRIPTION
## Summary

Merge the eight CertiK-audit bugfix feature flags that always activate together at V3_17_0 into two consolidated flags, and bump DEFAULT_VERSION to 3.17.0:

- `bugfix_auth_check` <- `bugfix_auth_check_create2`, `bugfix_auth_check_revert_status`, `bugfix_auth_table_raw_address`, `bugfix_auth_table_squatting` (FIB-77/81/82/83, all from PR #5117)
- `bugfix_v1_error_handling` <- `bugfix_v1_exec_error_gas_used`, `bugfix_v1_precompiled_error_gas`, `bugfix_clamp_gas_left_on_error`, `bugfix_v1_executive_wrapper` (FIB-76/78/79/80/85-92, PRs #5112/#5114/#5115/#5116)

The four remaining audit flags (`bugfix_gas_payment_balance_precheck`, `bugfix_precompiled_feature_gate`, `bugfix_evm_storage_status`, `bugfix_statestorage_hash_v3_17`) each gate an independent consensus behavior and stay separate.

## Why renaming is safe

Flag names are storage keys, but neither 3.16.5 nor 3.17.0 has ever been released (tags stop at v3.16.4), so no deployed chain has persisted the old names. 3.16.5 is treated as a ghost version: `V3_16_5_VERSION` stays in the `BlockVersion` enum, but its upgradeRoadmap entry is folded into `V3_17_0_VERSION`, so upgrading to 3.16.5 activates nothing and upgrading from 3.16.5 to 3.17.0 activates all six flags. Regression assertions in FeaturesTest pin both properties.

`DEFAULT_VERSION` moves from `V3_16_5_VERSION` to `V3_17_0_VERSION` in a separate commit, so new chains genesis with all consolidated audit fixes active by default.

## Behavior invariant

Zero behavior change for any chain: the eight merged flags all activated at the same V3_17_0 roadmap entry, so the merged flag flips at exactly the same version boundaries. In `HostContext::execute()` the previously separate error-gas and gas-clamp lookups now read one local `fixErrorHandling`; each error path was verified parameter-for-parameter equivalent against the two-flag original.

## Test plan

- [x] FeaturesTest: featureKeys order, upgrade roadmap (3.16.4->3.16.5 activates 0 flags, 3.16.4->3.17.0 and 3.16.5->3.17.0 activate the six), genesis superset assertions
- [x] FIB77_81_AuthCheckTest / FIB83_AccessAuthSuffixTest rewired to the merged auth flag
- [x] FIB88_92_ErrorHandlingTest / TestEVMCResult / FIB99_FIB105_StateRootTest pass unchanged (comment-only or version-baseline updates)
- [x] Full test suite: 1012/1012 pass on top of current release-3.17.0 head (2ce3e81f1)
- [x] Repo-wide grep: zero references to the eight removed flag names