### PR TITLE
Fix thread-safety in FrontService and stabilize flaky CI tests

### DIFF
--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -134,6 +134,7 @@ void FrontService::registerGroupNodeInfoNotification(int _moduleID,
         bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo, ReceiveMsgFunc _receiveMsgCallback)>
         _dispatcher)
 {
+    Guard l(x_notifierLock);
     m_module2GroupNodeInfoNotifier[_moduleID] = _dispatcher;
 }
 

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -134,18 +134,24 @@ BOOST_AUTO_TEST_CASE(testFrontService_onRecieveNodeIDsAnd)
             }
         });
 
-    BOOST_CHECK(frontService->module2GroupNodeInfoNotifier().find(moduleID) !=
-                frontService->module2GroupNodeInfoNotifier().end());
-    BOOST_CHECK(frontService->module2GroupNodeInfoNotifier().find(moduleID + 1) ==
-                frontService->module2GroupNodeInfoNotifier().end());
+    auto notifierMap = frontService->module2GroupNodeInfoNotifier();
+    BOOST_CHECK(notifierMap.find(moduleID) != notifierMap.end());
+    BOOST_CHECK(notifierMap.find(moduleID + 1) == notifierMap.end());
 
     auto groupNodeInfo = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>();
     groupNodeInfo->setNodeIDList(std::move(expectedNodeIDList));
     frontService->onReceiveGroupNodeInfo(
         "1", groupNodeInfo, [](Error::Ptr _error) { BOOST_CHECK(_error == nullptr); });
 
-    f.get();
-    BOOST_CHECK(nodeIDs0.size() == orgExpectedNodeIDList.size());
+    // Use wait_for with timeout to avoid hanging indefinitely on CI
+    auto status = f.wait_for(std::chrono::seconds(10));
+    BOOST_CHECK_MESSAGE(status == std::future_status::ready,
+        "Timed out waiting for group node info notification");
+    if (status == std::future_status::ready)
+    {
+        f.get();
+        BOOST_CHECK(nodeIDs0.size() == orgExpectedNodeIDList.size());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeID_callback)

--- a/bcos-gateway/test/unittests/RateLimiterManagerTest.cpp
+++ b/bcos-gateway/test/unittests/RateLimiterManagerTest.cpp
@@ -84,8 +84,12 @@ BOOST_AUTO_TEST_CASE(test_timeWindowRateLimiter_allowExceedMaxPermitSize)
 
 BOOST_AUTO_TEST_CASE(test_timeWindowRateLimiter)
 {
+    // Use a larger time window (500ms instead of 100ms) to avoid CI flakiness
+    // caused by std::this_thread::sleep_for imprecision under high system load.
+    // With 100ms window, a 50ms sleep can occasionally take >100ms on CI,
+    // causing the rate limiter window to reset unexpectedly.
     uint64_t maxPermitsSize = 2000;
-    uint64_t timeWindowMS = 100;
+    uint64_t timeWindowMS = 500;
     auto allowExceedMaxPermitSize = false;
     auto rateLimiter = std::make_shared<bcos::ratelimiter::TimeWindowRateLimiter>(
         maxPermitsSize, timeWindowMS, allowExceedMaxPermitSize);
@@ -112,12 +116,15 @@ BOOST_AUTO_TEST_CASE(test_timeWindowRateLimiter)
 
     {
         int64_t permitsSize = 2000;
+        // Sleep for half the time window; tryAcquire should still fail
+        // because the window has not yet reset
         std::this_thread::sleep_for(std::chrono::milliseconds(timeWindowMS / 2));
         BOOST_CHECK(!rateLimiter->tryAcquire(permitsSize));
         BOOST_CHECK(rateLimiter->currentPermitsSize() == 0);
         BOOST_CHECK(rateLimiter->timeWindowMS() == timeWindowMS);
         BOOST_CHECK(rateLimiter->maxPermitsSize() == maxPermitsSize);
 
+        // Sleep for a full window; permits should now be replenished
         std::this_thread::sleep_for(std::chrono::milliseconds(timeWindowMS));
         BOOST_CHECK(rateLimiter->timeWindowMS() == timeWindowMS);
         BOOST_CHECK(rateLimiter->maxPermitsSize() == maxPermitsSize);
@@ -132,6 +139,7 @@ BOOST_AUTO_TEST_CASE(test_timeWindowRateLimiter)
         BOOST_CHECK(rateLimiter->currentPermitsSize() == (uint64_t)permitsSize);
         BOOST_CHECK(rateLimiter->tryAcquire(permitsSize));
 
+        // Wait for window reset, then test incremental acquires
         std::this_thread::sleep_for(std::chrono::milliseconds(timeWindowMS));
         BOOST_CHECK(rateLimiter->tryAcquire(200));
         BOOST_CHECK(rateLimiter->tryAcquire(400));


### PR DESCRIPTION
## 修改摘要

本 PR 修复了 `release-3.18.0` 分支上的单元测试并发安全问题和 CI 随机失败问题，共涉及 3 个文件。

### 修改详情

#### 1. `bcos-front/bcos-front/FrontService.cpp` — 修复线程安全问题
- 在 `registerGroupNodeInfoNotification` 方法中添加 `Guard l(x_notifierLock)` 互斥锁保护，防止对 `m_module2GroupNodeInfoNotifier` 的并发写入导致数据竞争。

#### 2. `bcos-front/test/unittests/FrontServiceTest.cpp` — 修复测试并发访问和挂起问题
- 使用 `module2GroupNodeInfoNotifier()` 的**本地副本**进行断言检查，避免在测试验证期间发生并发修改导致迭代器失效。
- 将阻塞式的 `f.get()` 替换为带超时的 `f.wait_for(std::chrono::seconds(10))`，防止 CI 环境下异步通知未到达时测试无限挂起。

#### 3. `bcos-gateway/test/unittests/RateLimiterManagerTest.cpp` — 修复 CI 随机失败
- 将限流器测试的时间窗口从 **100ms 增加到 500ms**，避免因 CI 高负载下 `std::this_thread::sleep_for` 精度不足（50ms 的 sleep 偶尔超过 100ms），导致限流窗口意外重置，造成随机测试失败。
- 添加注释说明设计决策。

### 影响范围
仅涉及单元测试代码和一处生产代码的锁保护，对现有功能无破坏性影响。