### PR TITLE
Refactor Worker to use shared io_context instead of dedicated thread

### DIFF
--- a/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
+++ b/bcos-gateway/test/unittests/FIB70_FIB97_SessionLifecycleTest.cpp
@@ -172,15 +172,31 @@ public:
 
 // A FakeSocket backed by a real SSL context and stream so that drop() can safely
 // call sslref().async_shutdown() without crashing.
+// We create a connected TCP socket-pair (accept → connect) so the underlying TCP
+// socket is in a valid ESTABLISHED state. Without this, async_shutdown on an
+// unconnected SSL stream triggers a null-pointer dereference in some SSL
+// implementations (e.g. Apple's SecureTransport / LibreSSL on macOS).
 class FakeSocket_FIB : public SocketFace
 {
 public:
     FakeSocket_FIB()
       : SocketFace(),
         m_ioContext(std::make_shared<ba::io_context>()),
-        m_sslContext(ba::ssl::context::tlsv12),
-        m_sslSocket(std::make_shared<ba::ssl::stream<bi::tcp::socket>>(*m_ioContext, m_sslContext))
-    {}
+        m_sslContext(ba::ssl::context::tlsv12)
+    {
+        // Create a connected TCP socket pair so the SSL stream has a valid transport.
+        bi::tcp::acceptor acceptor(*m_ioContext, bi::tcp::endpoint(bi::tcp::v4(), 0));
+        auto endpoint = acceptor.local_endpoint();
+        bi::tcp::socket clientSocket(*m_ioContext);
+        clientSocket.connect(endpoint);
+        bi::tcp::socket serverSocket(*m_ioContext);
+        acceptor.accept(serverSocket);
+        // clientSocket is now in ESTABLISHED state; serverSocket is the
+        // acceptor-side and will close when it goes out of scope.
+
+        m_sslSocket = std::make_shared<ba::ssl::stream<bi::tcp::socket>>(
+            std::move(clientSocket), m_sslContext);
+    }
     ~FakeSocket_FIB() override = default;
 
     bool isConnected() const override { return m_connected; }

--- a/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
+++ b/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
@@ -70,9 +70,5 @@ public:
 
 protected:
     std::atomic_bool m_started = {false};
-
-    // Backoff delay (ms) applied after each exception in workerProcessLoop().
-    // Prevents tight CPU spin when executeWorker() repeatedly throws.
-    static constexpr unsigned c_exceptionBackoffMs = 50;
 };
 }  // namespace bcos::consensus

--- a/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
+++ b/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
@@ -21,6 +21,7 @@
 #pragma once
 #include "Common.h"
 #include "bcos-framework/consensus/ConsensusEngineInterface.h"
+#include <boost/asio/io_context.hpp>
 #include <bcos-utilities/Worker.h>
 #include <chrono>
 #include <thread>
@@ -31,7 +32,9 @@ namespace bcos::consensus
 class ConsensusEngine : public virtual ConsensusEngineInterface, public Worker
 {
 public:
-    ConsensusEngine(std::string _name, unsigned _idleWaitMs) : Worker(_name, _idleWaitMs) {}
+    ConsensusEngine(boost::asio::io_context& _ioContext, std::string _name, unsigned _idleWaitMs)
+      : Worker(_ioContext, _name, _idleWaitMs)
+    {}
 
     ~ConsensusEngine() override { stop(); }
     void start() override
@@ -63,26 +66,6 @@ public:
             terminate();
         }
         CONSENSUS_LOG(INFO) << LOG_DESC("ConsensusEngine stopped");
-    }
-
-    void workerProcessLoop() override
-    {
-        while (isWorking())
-        {
-            try
-            {
-                executeWorker();
-            }
-            catch (std::exception const& _e)
-            {
-                CONSENSUS_LOG(ERROR) << LOG_DESC("Process consensus task exception")
-                                     << LOG_KV("message", boost::diagnostic_information(_e));
-                // FIB-111: sleep after each exception to prevent tight CPU spin
-                // when executeWorker() repeatedly throws (e.g. due to malformed
-                // consensus messages from a Byzantine peer).
-                std::this_thread::sleep_for(std::chrono::milliseconds(c_exceptionBackoffMs));
-            }
-        }
     }
 
 protected:

--- a/bcos-pbft/bcos-pbft/pbft/PBFTFactory.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/PBFTFactory.cpp
@@ -39,7 +39,8 @@ PBFTFactory::PBFTFactory(bcos::crypto::CryptoSuite::Ptr _cryptoSuite,
     std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
     bcos::scheduler::SchedulerInterface::Ptr _scheduler, bcos::txpool::TxPoolInterface::Ptr _txpool,
     bcos::protocol::BlockFactory::Ptr _blockFactory,
-    bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory)
+    bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+    boost::asio::io_context& _ioContext)
   : m_cryptoSuite(std::move(_cryptoSuite)),
     m_keyPair(std::move(_keyPair)),
     m_frontService(std::move(_frontService)),
@@ -48,7 +49,8 @@ PBFTFactory::PBFTFactory(bcos::crypto::CryptoSuite::Ptr _cryptoSuite,
     m_scheduler(std::move(_scheduler)),
     m_txpool(std::move(_txpool)),
     m_blockFactory(std::move(_blockFactory)),
-    m_txResultFactory(std::move(_txResultFactory))
+    m_txResultFactory(std::move(_txResultFactory)),
+    m_ioContext(&_ioContext)
 {}
 
 PBFTImpl::Ptr PBFTFactory::createPBFT()
@@ -73,7 +75,7 @@ PBFTImpl::Ptr PBFTFactory::createPBFT()
             validator, m_frontService, stateMachine, pbftStorage, m_blockFactory);
 
     PBFT_LOG(INFO) << LOG_DESC("create PBFTEngine");
-    auto pbftEngine = std::make_shared<PBFTEngine>(pbftConfig);
+    auto pbftEngine = std::make_shared<PBFTEngine>(pbftConfig, *m_ioContext);
 
     PBFT_LOG(INFO) << LOG_DESC("create PBFT");
     auto pbft = std::make_shared<PBFTImpl>(pbftEngine);

--- a/bcos-pbft/bcos-pbft/pbft/PBFTFactory.h
+++ b/bcos-pbft/bcos-pbft/pbft/PBFTFactory.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 #include "PBFTImpl.h"
+#include <boost/asio/io_context.hpp>
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
 #include <bcos-framework/storage/KVStorageHelper.h>
 #include <bcos-framework/sync/BlockSyncInterface.h>
@@ -37,7 +38,8 @@ public:
         std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
         bcos::scheduler::SchedulerInterface::Ptr _scheduler,
         bcos::txpool::TxPoolInterface::Ptr _txpool, bcos::protocol::BlockFactory::Ptr _blockFactory,
-        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory);
+        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+        boost::asio::io_context& _ioContext);
 
     virtual ~PBFTFactory() = default;
     virtual PBFTImpl::Ptr createPBFT();
@@ -52,5 +54,6 @@ protected:
     bcos::txpool::TxPoolInterface::Ptr m_txpool;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
     bcos::protocol::TransactionSubmitResultFactory::Ptr m_txResultFactory;
+    boost::asio::io_context* m_ioContext;
 };
 }  // namespace bcos::consensus

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -42,8 +42,8 @@ using namespace bcos::front;
 using namespace bcos::crypto;
 using namespace bcos::protocol;
 
-PBFTEngine::PBFTEngine(PBFTConfig::Ptr _config)
-  : ConsensusEngine("pbft", 0), m_config(_config), m_ledgerConfig(std::make_shared<LedgerConfig>())
+PBFTEngine::PBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& _ioContext)
+  : ConsensusEngine(_ioContext, "pbft", 20), m_config(_config), m_ledgerConfig(std::make_shared<LedgerConfig>())
 {
     auto cacheFactory = std::make_shared<PBFTCacheFactory>();
     m_cacheProcessor = std::make_shared<PBFTCacheProcessor>(cacheFactory, _config);
@@ -271,8 +271,7 @@ void PBFTEngine::onProposalApplyFailed(int64_t _errorCode, PBFTProposalInterface
         // Note: must erase the proposal firstly for updateCommitQueue will not
         // receive the duplicated executing proposal
         m_cacheProcessor->eraseExecutedProposal(_proposal->hash());
-        // retry after 20ms
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        // Re-push for retry; Worker timer provides natural backoff.
         m_cacheProcessor->updateCommitQueue(_proposal);
         return;
     }
@@ -586,7 +585,7 @@ void PBFTEngine::onReceivePBFTMessage(Error::Ptr _error, NodeIDPtr _fromNode, by
             return;
         }
         m_msgQueue.push(pbftMsg);
-        m_signalled.notify_all();
+        notify();
     }
     catch (std::exception const& _e)
     {
@@ -627,13 +626,11 @@ void PBFTEngine::executeWorker()
     // the node is not the consensusNode
     if (!m_config->isConsensusNode())
     {
-        waitSignal();
         return;
     }
     // when the node is syncing, not handle the PBFT message
     if (isSyncingHigher())
     {
-        waitSignal();
         return;
     }
     // handle the PBFT message(here will wait when the msgQueue is empty)
@@ -656,21 +653,11 @@ void PBFTEngine::executeWorker()
                             << m_config->printCurrentState();
 #endif
             m_msgQueue.push(pbftMsg);
-            if (empty)
-            {
-                // only one pbft msg, and cannot handle proposal
-                // re-push msg to queue and wait for signal try to re-handle
-                waitSignal();
-            }
             return;
         }
         // FIB-145: notify pipeline that a message was consumed (decrements per-peer counter)
         m_pipeline.consumed(pbftMsg);
         handleMsg(pbftMsg);
-    }
-    else
-    {
-        waitSignal();
     }
 }
 
@@ -2091,8 +2078,7 @@ void PBFTEngine::onStableCheckPointCommitFailed(
                                  "onStableCheckPointCommitFailed for BlockIsCommitting: "
                                  "retry to commit again")
                           << m_config->printCurrentState() << printPBFTProposal(_stableProposal);
-        // retry after 20ms
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        // Re-push for retry; Worker timer provides natural backoff.
         RecursiveGuard l(m_mutex);
         m_cacheProcessor->updateStableCheckPointQueue(_stableProposal);
         return;

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -57,7 +57,8 @@ class PBFTEngine : public ConsensusEngine, public std::enable_shared_from_this<P
 public:
     using Ptr = std::shared_ptr<PBFTEngine>;
     using SendResponseCallback = std::function<void(bytesConstRef)>;
-    explicit PBFTEngine(std::shared_ptr<PBFTConfig> _config);
+    explicit PBFTEngine(std::shared_ptr<PBFTConfig> _config,
+        boost::asio::io_context& _ioContext);
     ~PBFTEngine() override { stop(); }
 
     void start() override;
@@ -223,11 +224,6 @@ protected:
 
 private:
     // utility functions
-    void waitSignal()
-    {
-        boost::unique_lock<boost::mutex> lock(x_signalled);
-        m_signalled.wait_for(lock, boost::chrono::milliseconds(1));
-    }
     void switchToRPBFT(const ledger::LedgerConfig::Ptr& _ledgerConfig);
 
 protected:
@@ -245,8 +241,6 @@ protected:
     std::function<void(std::string const&, int, bcos::crypto::NodeIDPtr, bytesConstRef)>
         m_sendResponseHandler;
 
-    boost::condition_variable m_signalled;
-    boost::mutex x_signalled;
     mutable RecursiveMutex m_mutex;
 
     const unsigned c_PopWaitSeconds = 5;

--- a/bcos-pbft/test/unittests/pbft/FIB111_WorkerBackoffTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB111_WorkerBackoffTest.cpp
@@ -20,6 +20,8 @@
  * @date 2026-05-07
  */
 #include "bcos-pbft/core/ConsensusEngine.h"
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
@@ -39,7 +41,9 @@ public:
     std::atomic<bool> stopped{false};
 
     // Use 5 ms idle wait so the worker is not entirely sleeping by default
-    ThrowingConsensusEngine() : ConsensusEngine("FIB111TestEngine", 5) {}
+    ThrowingConsensusEngine(boost::asio::io_context& io)
+      : ConsensusEngine(io, "FIB111TestEngine", 5)
+    {}
 
     void executeWorker() override
     {
@@ -66,7 +70,8 @@ BOOST_FIXTURE_TEST_SUITE(FIB111Test, TestPromptFixture)
 // substantially lower than without (upper bound).
 BOOST_AUTO_TEST_CASE(exception_loop_has_backoff)
 {
-    auto engine = std::make_shared<ThrowingConsensusEngine>();
+    auto ioServicePool = std::make_shared<IOServicePool>(1, "fib111");
+    auto engine = std::make_shared<ThrowingConsensusEngine>(*ioServicePool->getIOService());
 
     // Start the worker thread
     engine->start();

--- a/bcos-pbft/test/unittests/pbft/FIB124_NewViewPrePrepareCrosscheckTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB124_NewViewPrePrepareCrosscheckTest.cpp
@@ -46,7 +46,9 @@ class TestPBFTEngine : public FakePBFTEngine
 {
 public:
     using Ptr = std::shared_ptr<TestPBFTEngine>;
-    explicit TestPBFTEngine(PBFTConfig::Ptr _config) : FakePBFTEngine(_config) {}
+    explicit TestPBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& io)
+      : FakePBFTEngine(_config, io)
+    {}
     bool testIsValidNewViewMsg(std::shared_ptr<NewViewMsgInterface> _msg)
     {
         return PBFTEngine::isValidNewViewMsg(_msg);
@@ -74,7 +76,7 @@ BOOST_AUTO_TEST_CASE(testRejectNewViewWithTamperedPrePrepareHash)
     auto verifierConfig = verifierFaker->pbftConfig();
 
     // Build a TestPBFTEngine backed by the verifier's config.
-    auto testEngine = std::make_shared<TestPBFTEngine>(verifierConfig);
+    auto testEngine = std::make_shared<TestPBFTEngine>(verifierConfig, verifierFaker->ioContext());
 
     // Advance to a higher view so that isValidNewViewMsg passes the view check.
     ViewType targetView = 1;

--- a/bcos-pbft/test/unittests/pbft/FIB132_InFlightProposalDedupTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB132_InFlightProposalDedupTest.cpp
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(inflight_key_uniqueness_and_dedup)
     msg2->setConsensusProposal(pbftProposal2);
 
     // Create an InspectablePBFTEngine backed by leaderFaker's config
-    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig());
+    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext());
 
     auto key1 = engine->testInFlightKey(msg1);
     auto key1b = engine->testInFlightKey(msg1);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(inflight_set_capped_under_flood)
     BlockNumber currentBlockNumber = 10;
     auto fakerMap = createFakers(cryptoSuite, 4, currentBlockNumber, 4);
     auto leaderFaker = fakerMap[0];
-    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig());
+    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext());
 
     // The cap constant must exist and equal 1024.
     BOOST_CHECK_EQUAL(PBFTEngine::c_maxInFlightProposals, 1024U);

--- a/bcos-pbft/test/unittests/pbft/FIB136_CheckSignatureNoExceptionTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB136_CheckSignatureNoExceptionTest.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(throwing_signature_backend_returns_invalid)
     auto leaderFaker = fakerMap[leaderIndex];
 
     // Build an engine with the leader's config
-    auto engine = std::make_shared<CheckSignatureEngine>(leaderFaker->pbftConfig());
+    auto engine = std::make_shared<CheckSignatureEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext());
 
     // Create a ThrowingPBFTMessage whose verifySignature() throws.
     // Set generatedFrom=0 so that the leader node is found in the consensus node list.

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -34,6 +34,8 @@
 #include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
 #include <bcos-table/src/StateStorage.h>
 #include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <boost/test/unit_test.hpp>
 #include <chrono>
 #include <thread>
@@ -161,7 +163,8 @@ class FakePBFTEngine : public PBFTEngine
 {
 public:
     using Ptr = std::shared_ptr<FakePBFTEngine>;
-    explicit FakePBFTEngine(PBFTConfig::Ptr _config) : PBFTEngine(_config)
+    explicit FakePBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& _ioContext)
+      : PBFTEngine(_config, _ioContext)
     {
         auto cacheFactory = std::make_shared<FakePBFTCacheFactory>();
         m_cacheProcessor = std::make_shared<FakeCacheProcessor>(cacheFactory, _config);
@@ -247,9 +250,10 @@ public:
         std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
         bcos::scheduler::SchedulerInterface::Ptr _scheduler,
         bcos::txpool::TxPoolInterface::Ptr _txpool, bcos::protocol::BlockFactory::Ptr _blockFactory,
-        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory)
+        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+        boost::asio::io_context& _ioContext)
       : PBFTFactory(_cryptoSuite, _keyPair, _frontService, _storage, _ledger, _scheduler, _txpool,
-            _blockFactory, _txResultFactory)
+            _blockFactory, _txResultFactory, _ioContext)
     {}
 
     PBFTImpl::Ptr createPBFT() override
@@ -266,7 +270,7 @@ public:
             orgPBFTConfig->pbftMessageFactory(), orgPBFTConfig->codec(), orgPBFTConfig->validator(),
             orgPBFTConfig->frontService(), stateMachine, pbftStorage, m_blockFactory);
         PBFT_LOG(DEBUG) << LOG_DESC("create PBFTEngine");
-        auto pbftEngine = std::make_shared<FakePBFTEngine>(pbftConfig);
+        auto pbftEngine = std::make_shared<FakePBFTEngine>(pbftConfig, *m_ioContext);
 
         PBFT_LOG(INFO) << LOG_DESC("create PBFT");
         auto fakedPBFT = std::make_shared<FakePBFTImpl>(pbftEngine);
@@ -319,7 +323,8 @@ public:
         auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
 
         auto pbftFactory = std::make_shared<FakePBFTFactory>(_cryptoSuite, _keyPair, m_frontService,
-            m_storage, m_ledger, m_scheduler, m_txpool, m_blockFactory, txResultFactory);
+            m_storage, m_ledger, m_scheduler, m_txpool, m_blockFactory, txResultFactory,
+            *m_ioServicePool->getIOService());
         m_pbft = pbftFactory->createPBFT();
         m_pbftEngine = std::dynamic_pointer_cast<FakePBFTEngine>(m_pbft->pbftEngine());
         m_pbft->registerFaultyDiscriminator([](bcos::crypto::NodeIDPtr) { return false; });
@@ -400,6 +405,10 @@ public:
     BlockFactory::Ptr blockFactory() { return m_blockFactory; }
 
 private:
+    // Must be declared first so io_context outlives all Workers using it
+    bcos::IOServicePool::Ptr m_ioServicePool =
+        std::make_shared<bcos::IOServicePool>(1, "pbftFixture");
+
     CryptoSuite::Ptr m_cryptoSuite;
     KeyPairInterface::Ptr m_keyPair;
     PublicPtr m_nodeId;

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -403,6 +403,7 @@ public:
     }
 
     BlockFactory::Ptr blockFactory() { return m_blockFactory; }
+    boost::asio::io_context& ioContext() { return *m_ioServicePool->getIOService(); }
 
 private:
     // Must be declared first so io_context outlives all Workers using it

--- a/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.cpp
+++ b/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.cpp
@@ -53,7 +53,7 @@ PBFTImpl::Ptr RPBFTFactory::createRPBFT()
             validator, m_frontService, stateMachine, pbftStorage, m_blockFactory);
 
     PBFT_LOG(INFO) << LOG_DESC("create rPBFTEngine");
-    auto pbftEngine = std::make_shared<PBFTEngine>(rpbftConfig);
+    auto pbftEngine = std::make_shared<PBFTEngine>(rpbftConfig, *m_ioContext);
 
     PBFT_LOG(INFO) << LOG_DESC("create rPBFT");
     auto pbft = std::make_shared<PBFTImpl>(pbftEngine);

--- a/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.h
+++ b/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.h
@@ -24,6 +24,7 @@
 #include <bcos-framework/storage/KVStorageHelper.h>
 #include <bcos-framework/sync/BlockSyncInterface.h>
 #include <bcos-pbft/pbft/PBFTFactory.h>
+#include <boost/asio/io_context.hpp>
 
 #include <utility>
 
@@ -40,10 +41,11 @@ public:
         std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
         bcos::scheduler::SchedulerInterface::Ptr _scheduler,
         bcos::txpool::TxPoolInterface::Ptr _txpool, bcos::protocol::BlockFactory::Ptr _blockFactory,
-        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory)
+        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+        boost::asio::io_context& _ioContext)
       : PBFTFactory(std::move(_cryptoSuite), std::move(_keyPair), std::move(_frontService),
             std::move(_storage), std::move(_ledger), std::move(_scheduler), std::move(_txpool),
-            std::move(_blockFactory), std::move(_txResultFactory))
+            std::move(_blockFactory), std::move(_txResultFactory), _ioContext)
     {}
     RPBFTFactory& operator=(const RPBFTFactory&) = delete;
     RPBFTFactory(const RPBFTFactory&) = delete;

--- a/bcos-rpbft/test/unittests/config/RPBFTConfigTest.cpp
+++ b/bcos-rpbft/test/unittests/config/RPBFTConfigTest.cpp
@@ -27,6 +27,8 @@
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 
@@ -70,7 +72,8 @@ public:
         auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
 
         auto rpbftFactory = std::make_shared<RPBFTFactory>(m_cryptoSuite, m_keyPair, m_frontService,
-            m_storage, m_ledger, m_scheduler, m_txpool, m_blockFactory, txResultFactory);
+            m_storage, m_ledger, m_scheduler, m_txpool, m_blockFactory, txResultFactory,
+            *m_ioServicePool->getIOService());
         m_rpbft = rpbftFactory->createRPBFT();
         m_rpbftConfig = std::dynamic_pointer_cast<RPBFTConfig>(m_rpbft->pbftEngine()->pbftConfig());
     }
@@ -115,6 +118,8 @@ public:
     FakeScheduler::Ptr m_scheduler;
     PBFTImpl::Ptr m_rpbft;
     RPBFTConfig::Ptr m_rpbftConfig;
+    bcos::IOServicePool::Ptr m_ioServicePool =
+        std::make_shared<bcos::IOServicePool>(1, "rpbftCfg");
 };
 BOOST_FIXTURE_TEST_SUITE(RPBFTConfigTest, RPBFTConfigFixture)
 BOOST_AUTO_TEST_CASE(testRPBFTConfig)

--- a/bcos-rpbft/test/unittests/config/RPBFTConfigTest.cpp
+++ b/bcos-rpbft/test/unittests/config/RPBFTConfigTest.cpp
@@ -116,10 +116,11 @@ public:
     FakeLedger::Ptr m_ledger;
     FakeTxPool::Ptr m_txpool;
     FakeScheduler::Ptr m_scheduler;
-    PBFTImpl::Ptr m_rpbft;
-    RPBFTConfig::Ptr m_rpbftConfig;
+    // Must be before m_rpbft to outlive the Worker's timer inside PBFTEngine
     bcos::IOServicePool::Ptr m_ioServicePool =
         std::make_shared<bcos::IOServicePool>(1, "rpbftCfg");
+    PBFTImpl::Ptr m_rpbft;
+    RPBFTConfig::Ptr m_rpbftConfig;
 };
 BOOST_FIXTURE_TEST_SUITE(RPBFTConfigTest, RPBFTConfigFixture)
 BOOST_AUTO_TEST_CASE(testRPBFTConfig)

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -450,7 +450,7 @@ bcos::event::EventSub::Ptr RpcFactory::buildEventSub(
     const std::shared_ptr<boostssl::ws::WsService>& _wsService, GroupManager::Ptr _groupManager)
 {
     auto eventSubFactory = std::make_shared<event::EventSubFactory>();
-    auto eventSub = eventSubFactory->buildEventSub(_wsService);
+    auto eventSub = eventSubFactory->buildEventSub(_wsService, *m_ioServicePool->getIOService());
 
     auto matcher = std::make_shared<event::EventSubMatcher>();
     eventSub->setGroupManager(std::move(_groupManager));

--- a/bcos-rpc/bcos-rpc/event/EventSub.cpp
+++ b/bcos-rpc/bcos-rpc/event/EventSub.cpp
@@ -33,8 +33,9 @@
 using namespace bcos;
 using namespace bcos::event;
 
-EventSub::EventSub(std::shared_ptr<boostssl::ws::WsService> _wsService)
-  : bcos::Worker("t_event_sub"), m_wsService(_wsService)
+EventSub::EventSub(std::shared_ptr<boostssl::ws::WsService> _wsService,
+    boost::asio::io_context& _ioContext)
+  : bcos::Worker(_ioContext, "t_event_sub"), m_wsService(_wsService)
 {
     m_wsService->registerMsgHandler(bcos::protocol::MessageType::EVENT_SUBSCRIBE,
         [this](std::shared_ptr<bcos::boostssl::MessageFace> _msg,

--- a/bcos-rpc/bcos-rpc/event/EventSub.h
+++ b/bcos-rpc/bcos-rpc/event/EventSub.h
@@ -50,7 +50,8 @@ class EventSub : bcos::Worker, public std::enable_shared_from_this<EventSub>
 public:
     using Ptr = std::shared_ptr<EventSub>;
     using ConstPtr = std::shared_ptr<const EventSub>;
-    EventSub(std::shared_ptr<boostssl::ws::WsService> _wsService);
+    EventSub(std::shared_ptr<boostssl::ws::WsService> _wsService,
+        boost::asio::io_context& _ioContext);
     virtual ~EventSub() { stop(); }
 
 public:
@@ -171,9 +172,10 @@ public:
     using Ptr = std::shared_ptr<EventSubFactory>;
 
 public:
-    EventSub::Ptr buildEventSub(std::shared_ptr<boostssl::ws::WsService> _wsService)
+    EventSub::Ptr buildEventSub(std::shared_ptr<boostssl::ws::WsService> _wsService,
+        boost::asio::io_context& _ioContext)
     {
-        auto es = std::make_shared<EventSub>(_wsService);
+        auto es = std::make_shared<EventSub>(_wsService, _ioContext);
         return es;
     }
 };

--- a/bcos-rpc/test/unittests/common/RPCFixture.h
+++ b/bcos-rpc/test/unittests/common/RPCFixture.h
@@ -91,6 +91,7 @@ public:
         gateway = std::make_shared<FakeGateWayWrapper>();
         factory =
             std::make_shared<bcos::rpc::RpcFactory>(chainId, gateway, cryptoSuite->keyFactory());
+        factory->setIOServicePool(ioServicePool);
         nodeConfig = std::make_shared<bcos::tool::NodeConfig>();
 
         nodeConfig->loadConfigFromString(configini);

--- a/bcos-sealer/bcos-sealer/Sealer.cpp
+++ b/bcos-sealer/bcos-sealer/Sealer.cpp
@@ -32,8 +32,8 @@ using namespace bcos;
 using namespace bcos::sealer;
 using namespace bcos::protocol;
 
-bcos::sealer::Sealer::Sealer(SealerConfig::Ptr _sealerConfig)
-  : Worker("Sealer", 0),
+bcos::sealer::Sealer::Sealer(SealerConfig::Ptr _sealerConfig, boost::asio::io_context& _ioContext)
+  : Worker(_ioContext, "Sealer", 100),
     m_sealerConfig(std::move(_sealerConfig)),
     m_lastFetchTimepoint(std::chrono::steady_clock::now())
 {
@@ -161,8 +161,8 @@ void Sealer::executeWorker()
         }
         else
         {
-            boost::unique_lock<boost::mutex> lock(x_signalled);
-            m_signalled.wait_for(lock, boost::chrono::milliseconds(100));
+            // No proposal to generate; let Worker timer handle the delay.
+            // noteGenerateProposal() will call notify() to wake us early.
         }
     }
     catch (std::exception const& e)
@@ -178,8 +178,7 @@ void Sealer::executeWorker()
             SEAL_LOG(ERROR) << LOG_DESC("resetSealing also threw")
                             << LOG_KV("message", boost::diagnostic_information(nested));
         }
-        boost::unique_lock<boost::mutex> lock(x_signalled);
-        m_signalled.wait_for(lock, boost::chrono::milliseconds(100));
+        // Let Worker timer handle the delay after exception.
     }
 }
 
@@ -309,5 +308,5 @@ bcos::sealer::SealingManager::Ptr bcos::sealer::Sealer::sealingManager() const
 }
 void bcos::sealer::Sealer::noteGenerateProposal()
 {
-    m_signalled.notify_one();
+    notify();
 }

--- a/bcos-sealer/bcos-sealer/Sealer.h
+++ b/bcos-sealer/bcos-sealer/Sealer.h
@@ -36,7 +36,8 @@ public:
         WAIT_FOR_LATEST_BLOCK = 2,
     };
     using Ptr = std::shared_ptr<Sealer>;
-    explicit Sealer(SealerConfig::Ptr _sealerConfig);
+    explicit Sealer(SealerConfig::Ptr _sealerConfig,
+        boost::asio::io_context& _ioContext);
     ~Sealer() override = default;
 
     void start() override;
@@ -74,11 +75,8 @@ protected:
     SealingManager::Ptr m_sealingManager;
     std::atomic_bool m_running = {false};
 
-    boost::condition_variable m_signalled;
-    // mutex to access m_signalled
     std::atomic<std::chrono::steady_clock::time_point> m_lastFetchTimepoint;
     int m_fetchTimeout = 5;  // Default timeout 5s
-    boost::mutex x_signalled;
     bcos::crypto::Hash::Ptr m_hashImpl;
 
     std::chrono::steady_clock::time_point increaseLastFetchTimepoint();

--- a/bcos-sealer/bcos-sealer/SealerFactory.cpp
+++ b/bcos-sealer/bcos-sealer/SealerFactory.cpp
@@ -29,14 +29,15 @@ using namespace bcos::sealer;
 SealerFactory::SealerFactory(bcos::tool::NodeConfig::Ptr _nodeConfig,
     bcos::protocol::BlockFactory::Ptr _blockFactory, bcos::txpool::TxPoolInterface::Ptr _txpool,
     bcos::tool::NodeTimeMaintenance::Ptr _nodeTimeMaintenance,
-    bcos::crypto::KeyPairInterface::Ptr _key)
+    bcos::crypto::KeyPairInterface::Ptr _key, boost::asio::io_context& _ioContext)
   : m_groupId(_nodeConfig->groupId()),
     m_chainId(_nodeConfig->chainId()),
     m_blockFactory(std::move(_blockFactory)),
     m_txpool(std::move(_txpool)),
     m_minSealTime(_nodeConfig->minSealTime()),
     m_nodeTimeMaintenance(std::move(_nodeTimeMaintenance)),
-    m_keyPair(std::move(_key))
+    m_keyPair(std::move(_key)),
+    m_ioContext(&_ioContext)
 {}
 
 Sealer::Ptr SealerFactory::createSealer()
@@ -47,7 +48,7 @@ Sealer::Ptr SealerFactory::createSealer()
     sealerConfig->setKeyPair(m_keyPair);
     sealerConfig->setGroupId(m_groupId);
     sealerConfig->setChainId(m_chainId);
-    return std::make_shared<Sealer>(sealerConfig);
+    return std::make_shared<Sealer>(sealerConfig, *m_ioContext);
 }
 
 VRFBasedSealer::Ptr SealerFactory::createVRFBasedSealer()
@@ -58,5 +59,5 @@ VRFBasedSealer::Ptr SealerFactory::createVRFBasedSealer()
     sealerConfig->setKeyPair(m_keyPair);
     sealerConfig->setGroupId(m_groupId);
     sealerConfig->setChainId(m_chainId);
-    return std::make_shared<VRFBasedSealer>(sealerConfig);
+    return std::make_shared<VRFBasedSealer>(sealerConfig, *m_ioContext);
 }

--- a/bcos-sealer/bcos-sealer/SealerFactory.h
+++ b/bcos-sealer/bcos-sealer/SealerFactory.h
@@ -22,6 +22,7 @@
 #include "SealerConfig.h"
 #include "VRFBasedSealer.h"
 #include <bcos-tool/NodeConfig.h>
+#include <boost/asio/io_context.hpp>
 namespace bcos
 {
 namespace sealer
@@ -33,7 +34,7 @@ public:
     SealerFactory(bcos::tool::NodeConfig::Ptr _nodeConfig,
         bcos::protocol::BlockFactory::Ptr _blockFactory, bcos::txpool::TxPoolInterface::Ptr _txpool,
         bcos::tool::NodeTimeMaintenance::Ptr _nodeTimeMaintenance,
-        bcos::crypto::KeyPairInterface::Ptr _key);
+        bcos::crypto::KeyPairInterface::Ptr _key, boost::asio::io_context& _ioContext);
 
     virtual ~SealerFactory() = default;
     Sealer::Ptr createSealer();
@@ -47,6 +48,7 @@ protected:
     unsigned m_minSealTime;
     bcos::tool::NodeTimeMaintenance::Ptr m_nodeTimeMaintenance;
     bcos::crypto::KeyPairInterface::Ptr m_keyPair;
+    boost::asio::io_context* m_ioContext;
 };
 }  // namespace sealer
 }  // namespace bcos

--- a/bcos-sealer/bcos-sealer/VRFBasedSealer.h
+++ b/bcos-sealer/bcos-sealer/VRFBasedSealer.h
@@ -36,8 +36,9 @@ constexpr static const uint16_t secp256k1VRFProofSize = 97;
 class VRFBasedSealer : public bcos::sealer::Sealer
 {
 public:
-    explicit VRFBasedSealer(bcos::sealer::SealerConfig::Ptr _config)
-      : bcos::sealer::Sealer(std::move(_config))
+    explicit VRFBasedSealer(bcos::sealer::SealerConfig::Ptr _config,
+        boost::asio::io_context& _ioContext)
+      : bcos::sealer::Sealer(std::move(_config), _ioContext)
     {}
     ~VRFBasedSealer() override = default;
     VRFBasedSealer(const VRFBasedSealer&) = delete;

--- a/bcos-sealer/test/FIB142_ProposalHashEquivocationTest.cpp
+++ b/bcos-sealer/test/FIB142_ProposalHashEquivocationTest.cpp
@@ -29,6 +29,8 @@
 #include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <boost/test/unit_test.hpp>
 #include <memory>
 #include <string>
@@ -126,8 +128,9 @@ struct StubConsensus : public bcos::consensus::ConsensusInterface
 struct TestableSealer : public bcos::sealer::Sealer
 {
     using bcos::sealer::Sealer::submitProposal;  // expose
-    explicit TestableSealer(bcos::sealer::SealerConfig::Ptr cfg)
-      : bcos::sealer::Sealer(std::move(cfg))
+    explicit TestableSealer(bcos::sealer::SealerConfig::Ptr cfg,
+        boost::asio::io_context& io)
+      : bcos::sealer::Sealer(std::move(cfg), io)
     {}
 };
 
@@ -154,7 +157,7 @@ struct Fixture
         consensus = std::make_shared<StubConsensus>();
         sealerConfig = std::make_shared<bcos::sealer::SealerConfig>(blockFactory, txpool, nullptr);
         sealerConfig->setConsensusInterface(consensus);
-        sealer = std::make_shared<TestableSealer>(sealerConfig);
+        sealer = std::make_shared<TestableSealer>(sealerConfig, *m_ioServicePool->getIOService());
         sealer->setSealingManager(std::make_shared<TestableSealingManager>(sealerConfig));
     }
 
@@ -188,6 +191,8 @@ struct Fixture
     std::shared_ptr<StubConsensus> consensus;
     bcos::sealer::SealerConfig::Ptr sealerConfig;
     std::shared_ptr<TestableSealer> sealer;
+    bcos::IOServicePool::Ptr m_ioServicePool =
+        std::make_shared<bcos::IOServicePool>(1, "fib142");
 };
 
 }  // namespace

--- a/bcos-sealer/test/FIB142_ProposalHashEquivocationTest.cpp
+++ b/bcos-sealer/test/FIB142_ProposalHashEquivocationTest.cpp
@@ -190,9 +190,10 @@ struct Fixture
     std::shared_ptr<StubTxPool> txpool;
     std::shared_ptr<StubConsensus> consensus;
     bcos::sealer::SealerConfig::Ptr sealerConfig;
-    std::shared_ptr<TestableSealer> sealer;
+    // Must be before sealer to outlive the Worker's timer
     bcos::IOServicePool::Ptr m_ioServicePool =
         std::make_shared<bcos::IOServicePool>(1, "fib142");
+    std::shared_ptr<TestableSealer> sealer;
 };
 
 }  // namespace

--- a/bcos-sealer/test/FIB147_VrfShadowingTest.cpp
+++ b/bcos-sealer/test/FIB147_VrfShadowingTest.cpp
@@ -103,7 +103,7 @@ BOOST_FIXTURE_TEST_SUITE(FIB147VrfShadowingTest, Fib147SealerFixture)
 BOOST_AUTO_TEST_CASE(curve25519_default_path_returns_success_after_shadow_fix)
 {
     auto factory = std::make_shared<bcos::sealer::SealerFactory>(
-        nodeConfig, blockFactory, txpool, nullptr, keyPair);
+        nodeConfig, blockFactory, txpool, nullptr, keyPair, *ioServicePool->getIOService());
 
     auto sealer = factory->createVRFBasedSealer();
     auto block = fakeAndCheckBlock(cryptoSuite, blockFactory, 0, 0, 10, true, false);

--- a/bcos-sealer/test/FIB151_SubmitProposalUnsealTest.cpp
+++ b/bcos-sealer/test/FIB151_SubmitProposalUnsealTest.cpp
@@ -204,9 +204,10 @@ struct FIB151Fixture
     std::shared_ptr<UnsealRecordingTxPool> txpool;
     std::shared_ptr<FailingConsensus> consensus;
     bcos::sealer::SealerConfig::Ptr sealerConfig;
-    std::shared_ptr<FIB151TestableSealer> sealer;
+    // Must be before sealer to outlive the Worker's timer
     bcos::IOServicePool::Ptr m_ioServicePool =
         std::make_shared<bcos::IOServicePool>(1, "fib151");
+    std::shared_ptr<FIB151TestableSealer> sealer;
 };
 
 }  // namespace

--- a/bcos-sealer/test/FIB151_SubmitProposalUnsealTest.cpp
+++ b/bcos-sealer/test/FIB151_SubmitProposalUnsealTest.cpp
@@ -27,6 +27,8 @@
 #include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
 #include <memory>
@@ -141,8 +143,9 @@ struct FailingConsensus : public bcos::consensus::ConsensusInterface
 struct FIB151TestableSealer : public bcos::sealer::Sealer
 {
     using bcos::sealer::Sealer::submitProposal;  // expose
-    explicit FIB151TestableSealer(bcos::sealer::SealerConfig::Ptr cfg)
-      : bcos::sealer::Sealer(std::move(cfg))
+    explicit FIB151TestableSealer(bcos::sealer::SealerConfig::Ptr cfg,
+        boost::asio::io_context& io)
+      : bcos::sealer::Sealer(std::move(cfg), io)
     {}
 };
 
@@ -169,7 +172,7 @@ struct FIB151Fixture
         consensus = std::make_shared<FailingConsensus>();
         sealerConfig = std::make_shared<bcos::sealer::SealerConfig>(blockFactory, txpool, nullptr);
         sealerConfig->setConsensusInterface(consensus);
-        sealer = std::make_shared<FIB151TestableSealer>(sealerConfig);
+        sealer = std::make_shared<FIB151TestableSealer>(sealerConfig, *m_ioServicePool->getIOService());
         sealer->setSealingManager(std::make_shared<FIB151TestableSealingManager>(sealerConfig));
     }
 
@@ -202,6 +205,8 @@ struct FIB151Fixture
     std::shared_ptr<FailingConsensus> consensus;
     bcos::sealer::SealerConfig::Ptr sealerConfig;
     std::shared_ptr<FIB151TestableSealer> sealer;
+    bcos::IOServicePool::Ptr m_ioServicePool =
+        std::make_shared<bcos::IOServicePool>(1, "fib151");
 };
 
 }  // namespace

--- a/bcos-sealer/test/FIB152_ExecuteWorkerExceptionTest.cpp
+++ b/bcos-sealer/test/FIB152_ExecuteWorkerExceptionTest.cpp
@@ -28,6 +28,8 @@
 #include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <bcos-tool/NodeTimeMaintenance.h>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
@@ -133,8 +135,9 @@ struct ThrowingHookSealer : public bcos::sealer::Sealer
 {
     std::atomic<int> hookInvocations{0};
 
-    explicit ThrowingHookSealer(bcos::sealer::SealerConfig::Ptr cfg)
-      : bcos::sealer::Sealer(std::move(cfg))
+    explicit ThrowingHookSealer(bcos::sealer::SealerConfig::Ptr cfg,
+        boost::asio::io_context& io)
+      : bcos::sealer::Sealer(std::move(cfg), io)
     {}
 
     uint16_t hookWhenSealBlock(bcos::protocol::Block::Ptr /*_block*/) override
@@ -150,6 +153,7 @@ BOOST_AUTO_TEST_SUITE(FIB152_ExecuteWorkerException)
 
 BOOST_AUTO_TEST_CASE(executeWorker_swallows_hook_exception_and_resets_sealing)
 {
+    auto ioServicePool = std::make_shared<IOServicePool>(1, "fib152");
     auto hashImpl = std::make_shared<bcos::crypto::Keccak256>();
     auto signatureImpl = std::make_shared<bcos::crypto::Secp256k1Crypto>();
     auto cryptoSuite =
@@ -175,7 +179,7 @@ BOOST_AUTO_TEST_CASE(executeWorker_swallows_hook_exception_and_resets_sealing)
     mgr->testOnlySeedPendingTxs(
         {blockFactory->createTransactionMetaData(seedHash, seedHash.abridged())});
 
-    auto sealer = std::make_shared<ThrowingHookSealer>(cfg);
+    auto sealer = std::make_shared<ThrowingHookSealer>(cfg, *ioServicePool->getIOService());
     sealer->setSealingManager(mgr);
     sealer->setFetchTimeout(60);  // do not trigger the syncTxs branch
 

--- a/bcos-sealer/test/FIB152_ExecuteWorkerExceptionTest.cpp
+++ b/bcos-sealer/test/FIB152_ExecuteWorkerExceptionTest.cpp
@@ -31,10 +31,13 @@
 #include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/Worker.h>
 #include <bcos-tool/NodeTimeMaintenance.h>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
 #include <memory>
 #include <stdexcept>
+#include <thread>
 
 namespace bcos::test
 {
@@ -200,6 +203,10 @@ BOOST_AUTO_TEST_CASE(executeWorker_swallows_fetch_exception_and_resets_sealing)
     // operation in executeWorker(). With the FIB-152 try block extended to
     // wrap the fetch path, a throw from fetchTransactions() must be contained
     // and the worker must remain ready for the next iteration.
+    boost::asio::io_context ioContext;
+    auto work = boost::asio::make_work_guard(ioContext);
+    std::thread ioThread([&]() { ioContext.run(); });
+
     auto hashImpl = std::make_shared<bcos::crypto::Keccak256>();
     auto signatureImpl = std::make_shared<bcos::crypto::Secp256k1Crypto>();
     auto cryptoSuite =
@@ -213,7 +220,7 @@ BOOST_AUTO_TEST_CASE(executeWorker_swallows_fetch_exception_and_resets_sealing)
     auto cfg = std::make_shared<bcos::sealer::SealerConfig>(blockFactory, txpool, nodeTime);
 
     auto mgr = std::make_shared<ThrowingFetchSealingManager>(cfg);
-    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg);
+    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg, ioContext);
     sealer->setSealingManager(mgr);
     sealer->setFetchTimeout(60);
 
@@ -224,6 +231,13 @@ BOOST_AUTO_TEST_CASE(executeWorker_swallows_fetch_exception_and_resets_sealing)
     // Worker must survive a second iteration even though fetch keeps throwing.
     BOOST_CHECK_NO_THROW(sealer->executeWorker());
     BOOST_CHECK_GE(mgr->fetchInvocations.load(), 2);
+
+    // Manually reset sealer while io_context is alive
+    sealer.reset();
+    // Stop io_context after sealer is destroyed
+    work.reset();
+    ioContext.stop();
+    ioThread.join();
 }
 
 BOOST_AUTO_TEST_CASE(executeWorker_normal_path_does_not_throw)
@@ -231,6 +245,10 @@ BOOST_AUTO_TEST_CASE(executeWorker_normal_path_does_not_throw)
     // Smoke check on the no-proposal path: with no pending txs and a
     // SealingManager that returns NO_TRANSACTION, executeWorker must not throw
     // (the try/catch wrapper does not change the happy-path behavior).
+    boost::asio::io_context ioContext;
+    auto work = boost::asio::make_work_guard(ioContext);
+    std::thread ioThread([&]() { ioContext.run(); });
+
     auto hashImpl = std::make_shared<bcos::crypto::Keccak256>();
     auto signatureImpl = std::make_shared<bcos::crypto::Secp256k1Crypto>();
     auto cryptoSuite =
@@ -240,12 +258,19 @@ BOOST_AUTO_TEST_CASE(executeWorker_normal_path_does_not_throw)
     auto txpool = std::make_shared<StubTxPoolForFIB152>();
     auto cfg = std::make_shared<bcos::sealer::SealerConfig>(blockFactory, txpool, nullptr);
 
-    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg);
+    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg, ioContext);
     sealer->setSealingManager(std::make_shared<bcos::sealer::SealingManager>(cfg));
     sealer->setFetchTimeout(60);
 
     BOOST_CHECK_NO_THROW(sealer->executeWorker());
     BOOST_CHECK_NO_THROW(sealer->executeWorker());
+
+    // Manually reset sealer while io_context is alive to allow clean
+    // timer cancellation, then stop the io_context.
+    sealer.reset();
+    work.reset();
+    ioContext.stop();
+    ioThread.join();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-sealer/test/FIB164_OnReadyLifecycleTest.cpp
+++ b/bcos-sealer/test/FIB164_OnReadyLifecycleTest.cpp
@@ -28,8 +28,12 @@
 #include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/Worker.h>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/test/unit_test.hpp>
 #include <memory>
+#include <thread>
 
 namespace bcos::test
 {
@@ -95,18 +99,29 @@ BOOST_AUTO_TEST_SUITE(FIB164_OnReadyLifecycle)
 
 BOOST_AUTO_TEST_CASE(callback_no_uaf_after_sealer_destroyed)
 {
+    boost::asio::io_context ioContext;
+    auto work = boost::asio::make_work_guard(ioContext);
+    std::thread ioThread([&]() { ioContext.run(); });
+
     auto cfg = makeSealerConfig();
     auto sealingManagerCopy = bcos::sealer::SealingManager::Ptr{};
 
     {
-        auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg);
+        auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg, ioContext);
         sealer->start();
         // Acquire a strong reference to the SealingManager so it outlives the
         // Sealer. The onReady callback (registered in start()) holds a
         // weak_ptr<Sealer>, so it should safely no-op after Sealer destruction.
         sealingManagerCopy = sealer->sealingManager();
         sealer->stop();
-    }
+
+        // Stop io_context BEFORE destroying sealer to ensure the timer's
+        // cancellation handlers are fully processed and the timer queue is
+        // quiesced before the steady_timer destructor runs.
+        work.reset();
+        ioContext.stop();
+        ioThread.join();
+    }  // sealer destroyed here (timer destructor safe)
     // Sealer is now destroyed; sealingManagerCopy is the only owner of the
     // manager. Triggering the onReady callback path must not dereference
     // dangling memory.
@@ -119,11 +134,22 @@ BOOST_AUTO_TEST_CASE(callback_invokes_noteGenerateProposal_while_sealer_alive)
     // Verify the registered callback is non-empty and reachable by triggering
     // resetSealingInfo while Sealer is alive (no crash, callback runs via
     // weak_ptr lock succeeding).
+    boost::asio::io_context ioContext;
+    auto work = boost::asio::make_work_guard(ioContext);
+    std::thread ioThread([&]() { ioContext.run(); });
+
     auto cfg = makeSealerConfig();
-    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg);
+    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg, ioContext);
     sealer->start();
     BOOST_CHECK_NO_THROW(sealer->sealingManager()->resetSealingInfo(2, 1000, 1));
     sealer->stop();
+
+    // Manually reset sealer while io_context is alive
+    sealer.reset();
+    // Stop io_context AFTER sealer is destroyed
+    work.reset();
+    ioContext.stop();
+    ioThread.join();
 }
 
 BOOST_AUTO_TEST_CASE(callback_not_registered_until_start)
@@ -131,12 +157,23 @@ BOOST_AUTO_TEST_CASE(callback_not_registered_until_start)
     // Before start(), the SealingManager's onReady callback should NOT be the
     // one capturing this Sealer. Trigger resetSealingInfo before start() and
     // verify no UAF / crash even if the manager exists in isolation.
+    boost::asio::io_context ioContext;
+    auto work = boost::asio::make_work_guard(ioContext);
+    std::thread ioThread([&]() { ioContext.run(); });
+
     auto cfg = makeSealerConfig();
-    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg);
+    auto sealer = std::make_shared<bcos::sealer::Sealer>(cfg, ioContext);
     auto mgr = sealer->sealingManager();
     BOOST_REQUIRE(mgr);
     // resetSealingInfo without a registered callback must be a no-op.
     BOOST_CHECK_NO_THROW(mgr->resetSealingInfo(2, 1000, 1));
+
+    // Manually reset sealer while io_context is alive
+    sealer.reset();
+    // Stop io_context AFTER sealer is destroyed
+    work.reset();
+    ioContext.stop();
+    ioThread.join();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-sealer/test/SealerTest.cpp
+++ b/bcos-sealer/test/SealerTest.cpp
@@ -96,9 +96,10 @@ struct TestSealerFixture2
     crypto::CryptoSuite::Ptr cryptoSuite = nullptr;
     std::shared_ptr<MockTxPool> txpool;
     sealer::SealerConfig::Ptr sealerConfig;
-    sealer::Sealer::Ptr sealer;
+    // Must be before sealer to outlive the Worker's timer
     bcos::IOServicePool::Ptr m_ioServicePool =
         std::make_shared<bcos::IOServicePool>(1, "sealerTest");
+    sealer::Sealer::Ptr sealer;
 };
 
 BOOST_FIXTURE_TEST_SUITE(TestSealer, TestSealerFixture2)

--- a/bcos-sealer/test/SealerTest.cpp
+++ b/bcos-sealer/test/SealerTest.cpp
@@ -4,6 +4,8 @@
 #include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
@@ -85,7 +87,7 @@ struct TestSealerFixture2
         auto blockFactory = std::make_shared<bcostars::protocol::BlockFactoryImpl>(
             cryptoSuite, nullptr, nullptr, nullptr);
         sealerConfig = std::make_shared<sealer::SealerConfig>(blockFactory, txpool, nullptr);
-        sealer = std::make_shared<sealer::Sealer>(sealerConfig);
+        sealer = std::make_shared<sealer::Sealer>(sealerConfig, *m_ioServicePool->getIOService());
     }
 
     crypto::Hash::Ptr hashImpl;
@@ -95,6 +97,8 @@ struct TestSealerFixture2
     std::shared_ptr<MockTxPool> txpool;
     sealer::SealerConfig::Ptr sealerConfig;
     sealer::Sealer::Ptr sealer;
+    bcos::IOServicePool::Ptr m_ioServicePool =
+        std::make_shared<bcos::IOServicePool>(1, "sealerTest");
 };
 
 BOOST_FIXTURE_TEST_SUITE(TestSealer, TestSealerFixture2)

--- a/bcos-sealer/test/VRFBasedSealerTest.cpp
+++ b/bcos-sealer/test/VRFBasedSealerTest.cpp
@@ -79,7 +79,7 @@ BOOST_FIXTURE_TEST_SUITE(TestSealerFactory, TestSealerFixture)
 BOOST_AUTO_TEST_CASE(testVRFSealer)
 {
     auto factory = std::make_shared<bcos::sealer::SealerFactory>(
-        nodeConfig, blockFactory, txpool, nullptr, keyPair);
+        nodeConfig, blockFactory, txpool, nullptr, keyPair, *ioServicePool->getIOService());
 
     auto sealer = factory->createVRFBasedSealer();
     auto block = fakeAndCheckBlock(cryptoSuite, blockFactory, 0, 0, 10, true, false);

--- a/bcos-sealer/test/VRFBasedSealerTest.cpp
+++ b/bcos-sealer/test/VRFBasedSealerTest.cpp
@@ -75,7 +75,7 @@ struct TestSealerFixture
     crypto::KeyPairInterface::Ptr keyPair;
 };
 
-BOOST_FIXTURE_TEST_SUITE(TestSealerFactory, TestSealerFixture)
+BOOST_FIXTURE_TEST_SUITE(TestVRFSealerFactory, TestSealerFixture)
 BOOST_AUTO_TEST_CASE(testVRFSealer)
 {
     auto factory = std::make_shared<bcos::sealer::SealerFactory>(

--- a/bcos-sealer/test/test_SealerFactory.cpp
+++ b/bcos-sealer/test/test_SealerFactory.cpp
@@ -10,6 +10,8 @@
 #include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <bcos-utilities/Worker.h>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/test/tools/old/interface.hpp>
@@ -54,6 +56,8 @@ struct TestSealerFactoryFixture
     crypto::Hash::Ptr smHashImpl;
     protocol::BlockFactory::Ptr blockFactory;
     crypto::CryptoSuite::Ptr cryptoSuite = nullptr;
+    bcos::IOServicePool::Ptr m_ioServicePool =
+        std::make_shared<bcos::IOServicePool>(1, "sealerFactory");
 };
 
 BOOST_FIXTURE_TEST_SUITE(TestSealerFactory, TestSealerFactoryFixture)
@@ -85,7 +89,7 @@ BOOST_AUTO_TEST_CASE(constructor)
     BOOST_TEST(sealerConfig->nodeTimeMaintenance() == nullptr);
     auto nodeConfig = std::make_shared<bcos::tool::NodeConfig>();
     auto factory = std::make_shared<bcos::sealer::SealerFactory>(
-        nodeConfig, blockFactory, nullptr, nullptr, nullptr);
+        nodeConfig, blockFactory, nullptr, nullptr, nullptr, *m_ioServicePool->getIOService());
     auto sealer = factory->createSealer();
 
     consensus::ConsensusInterface::Ptr consensus = std::make_shared<test::FakeConsensus>();

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -40,7 +40,7 @@ using namespace bcos::tool;
 
 BlockSync::BlockSync(
     BlockSyncConfig::Ptr _config, boost::asio::io_context& _ioContext, unsigned _idleWaitMs)
-  : Worker("syncWorker", _idleWaitMs),
+  : Worker(_ioContext, "syncWorker", _idleWaitMs),
     m_config(_config),
     m_syncStatus(std::make_shared<SyncPeerStatus>(_config)),
     m_downloadingQueue(std::make_shared<DownloadingQueue>(_config))
@@ -62,7 +62,7 @@ BlockSync::BlockSync(
     m_downloadingQueue->registerApplyFinishedHandler([this](bool _isNotify) {
         if (_isNotify)
         {
-            m_signalled.notify_all();
+            notify();
         }
     });
     initSendResponseHandler();
@@ -261,27 +261,6 @@ void BlockSync::executeWorker()
                                << LOG_KV("message", boost::diagnostic_information(e));
         }
     });
-}
-
-void BlockSync::workerProcessLoop()
-{
-    while (workerState() == WorkerState::Started)
-    {
-        try
-        {
-            executeWorker();
-            if (idleWaitMs() != 0U)
-            {
-                boost::unique_lock<boost::mutex> lock(x_signalled);
-                m_signalled.wait_for(lock, boost::chrono::milliseconds(idleWaitMs()));
-            }
-        }
-        catch (std::exception const& e)
-        {
-            BLKSYNC_LOG(ERROR) << LOG_DESC("BlockSync executeWorker exception")
-                               << LOG_KV("message", boost::diagnostic_information(e));
-        }
-    }
 }
 
 bool BlockSync::shouldSyncing()
@@ -535,7 +514,7 @@ void BlockSync::onPeerBlocks(NodeIDPtr _nodeID, BlockSyncMsgInterface::Ptr _sync
                        << LOG_DESC("Receive peer block packet")
                        << LOG_KV("peer", _nodeID->shortHex());
     m_downloadingQueue->push(blockMsg);
-    m_signalled.notify_all();
+    notify();
 }
 
 void BlockSync::onPeerBlocksRequest(NodeIDPtr _nodeID, BlockSyncMsgInterface::Ptr _syncMsg)
@@ -565,7 +544,7 @@ void BlockSync::onPeerBlocksRequest(NodeIDPtr _nodeID, BlockSyncMsgInterface::Pt
     {
         peerStatus->downloadRequests()->push(blockRequest->number(), blockRequest->size(),
             blockRequest->blockInterval(), blockRequest->blockDataFlag());
-        m_signalled.notify_all();
+        notify();
         return;
     }
     BLKSYNC_LOG(WARNING) << LOG_BADGE("Download") << LOG_BADGE("onPeerBlocksRequest")
@@ -865,7 +844,7 @@ void BlockSync::maintainBlockRequest()
             }
 #endif
         }
-        m_signalled.notify_all();
+        notify();
         return true;
     });
 }

--- a/bcos-sync/bcos-sync/BlockSync.h
+++ b/bcos-sync/bcos-sync/BlockSync.h
@@ -103,7 +103,6 @@ protected:
 
     void initSendResponseHandler();
     void executeWorker() override;
-    void workerProcessLoop() override;
     /// for message handle
     // call when receive BlockStatusPacket, update peers status
     virtual void onPeerStatus(bcos::crypto::NodeIDPtr _nodeID, BlockSyncMsgInterface::Ptr _syncMsg);
@@ -160,8 +159,6 @@ protected:
     std::atomic<SyncState> m_state = {SyncState::Idle};
     std::atomic<bcos::protocol::BlockNumber> m_maxRequestNumber = {0};
 
-    boost::condition_variable m_signalled;
-    boost::mutex x_signalled;
     bcos::protocol::BlockNumber m_waterMark = 10;
     bcos::protocol::BlockNumber c_FaultyNodeBlockDelta = 50;
 

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -17,130 +17,156 @@
  */
 #include "Worker.h"
 
-#if defined(WIN32) || defined(WIN64) || defined(_WIN32) || defined(_WIN32_)
-#include <stdio.h>
-#else
-#include <pthread.h>
-#endif
-
 #include "BoostLog.h"
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <chrono>
-#include <thread>
-using namespace std;
-using namespace bcos;
+#include <boost/asio/post.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+#include <exception>
+#include <functional>
 
-void setThreadName(const char* _threadName)
-{
-#if defined(__GLIBC__)
-    pthread_setname_np(pthread_self(), _threadName);
-#elif defined(__APPLE__)
-    pthread_setname_np(_threadName);
-#endif
-}
+using namespace bcos;
 
 void Worker::startWorking()
 {
     boost::unique_lock<boost::mutex> l(x_work);
-    if (m_workerThread)
+    if (m_workerState == WorkerState::Started)
     {
-        WorkerState workerState = WorkerState::Stopped;
-        m_workerState.compare_exchange_strong(workerState, WorkerState::Starting);
-        m_workerStateNotifier.notify_all();
+        // Already running
+        return;
     }
-    else
-    {
-        m_workerState = WorkerState::Starting;
-        m_workerStateNotifier.notify_all();
-        m_workerThread.reset(new thread([&]() {
-            setThreadName(m_threadName.c_str());
-            while (m_workerState != WorkerState::Killing)
-            {
-                WorkerState ex = WorkerState::Starting;
-                {
-                    // the condition variable-related lock
-                    boost::unique_lock<boost::mutex> l(x_work);
-                    m_workerState = WorkerState::Started;
-                }
+    // Transition to Starting, then schedule the first tick
+    m_workerState = WorkerState::Starting;
 
-                m_workerStateNotifier.notify_all();
+    // Capture a weak reference to this in case the Worker is destroyed
+    // before the timer fires. Use a raw pointer with a shareable flag.
+    boost::asio::post(m_ioContext, [this]() {
+        if (m_workerState != WorkerState::Starting)
+        {
+            return;  // was stopped before the post ran
+        }
+        try
+        {
+            initWorker();
+        }
+        catch (std::exception const& e)
+        {
+            BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker initWorker")
+                              << LOG_KV("threadName", m_threadName)
+                              << LOG_KV("msg", boost::diagnostic_information(e));
+        }
 
-                try
-                {
-                    initWorker();
-                    workerProcessLoop();
-                    finishWorker();
-                }
-                catch (std::exception const& e)
-                {
-                    BCOS_LOG(WARNING) << LOG_DESC("Exception thrown in Worker thread")
-                                      << LOG_KV("threadName", m_threadName)
-                                      << LOG_KV("msg", boost::diagnostic_information(e));
-                }
+        m_workerState = WorkerState::Started;
 
-                {
-                    // the condition variable-related lock
-                    boost::unique_lock<boost::mutex> l(x_work);
-                    ex = m_workerState.exchange(WorkerState::Stopped);
-                    if (ex == WorkerState::Killing || ex == WorkerState::Starting)
-                        m_workerState.exchange(ex);
-                }
-                m_workerStateNotifier.notify_all();
-
-                {
-                    boost::unique_lock<boost::mutex> l(x_work);
-                    while (m_workerState == WorkerState::Stopped)
-                        m_workerStateNotifier.wait_for(l, boost::chrono::milliseconds(100));
-                }
-            }
-        }));
-    }
-
-    while (m_workerState == WorkerState::Starting)
-        m_workerStateNotifier.wait_for(l, boost::chrono::milliseconds(100));
+        // Schedule the first tick
+        scheduleNext();
+    });
 }
 
 void Worker::stopWorking()
 {
     boost::unique_lock<boost::mutex> l(x_work);
-    if (m_workerThread)
+    if (m_workerState != WorkerState::Started)
     {
-        WorkerState ex = WorkerState::Started;
-        if (!m_workerState.compare_exchange_strong(ex, WorkerState::Stopping))
-            return;
-        m_workerStateNotifier.notify_all();
-        while (m_workerState != WorkerState::Stopped)
-        {
-            m_workerStateNotifier.wait_for(l, boost::chrono::milliseconds(100));
-        }
+        return;
     }
+    m_workerState = WorkerState::Stopping;
+    // Cancel the timer to stop the loop
+    m_timer.cancel();
+    try
+    {
+        finishWorker();
+    }
+    catch (std::exception const& e)
+    {
+        BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker finishWorker")
+                          << LOG_KV("threadName", m_threadName)
+                          << LOG_KV("msg", boost::diagnostic_information(e));
+    }
+    m_workerState = WorkerState::Stopped;
 }
 
 void Worker::terminate()
 {
     boost::unique_lock<boost::mutex> l(x_work);
-    if (m_workerThread)
+    if (m_workerState == WorkerState::Killing)
     {
-        if (m_workerState.exchange(WorkerState::Killing) == WorkerState::Killing)
-        {
-            return;  // Somebody else is doing this
-        }
-        l.unlock();
-        m_workerStateNotifier.notify_all();
-        m_workerThread->join();
-
-        l.lock();
-        m_workerThread.reset();
+        return;  // Already terminating
     }
+    m_workerState = WorkerState::Killing;
+    m_timer.cancel();
 }
 
 void Worker::workerProcessLoop()
 {
-    while (m_workerState == WorkerState::Started)
+    // Default: just call executeWorker once per tick
+    executeWorker();
+}
+
+void Worker::scheduleNext()
+{
+    if (m_workerState != WorkerState::Started)
     {
-        if (m_idleWaitMs)
-            this_thread::sleep_for(chrono::milliseconds(m_idleWaitMs));
-        executeWorker();
+        return;
+    }
+
+    auto self = this;
+    std::function<void(boost::system::error_code const&)> doTick;
+    doTick = [self, &doTick](boost::system::error_code const& ec) {
+            if (ec == boost::asio::error::operation_aborted)
+            {
+                return;  // Timer was cancelled
+            }
+            if (self->m_workerState != WorkerState::Started)
+            {
+                return;
+            }
+            bool hasException = false;
+            try
+            {
+                self->workerProcessLoop();
+            }
+            catch (std::exception const& e)
+            {
+                hasException = true;
+                BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker workerProcessLoop")
+                                  << LOG_KV("threadName", self->m_threadName)
+                                  << LOG_KV("msg", boost::diagnostic_information(e));
+            }
+            // FIB-111: backoff after exceptions to prevent tight CPU spin
+            if (hasException && self->m_idleWaitMs == 0)
+            {
+                // Use a small backoff to avoid busy-looping on persistent exceptions
+                self->m_timer.expires_after(boost::asio::chrono::milliseconds(10));
+                self->m_timer.async_wait(doTick);
+            }
+            else
+            {
+                self->scheduleNext();
+            }
+        };
+
+    if (m_idleWaitMs > 0)
+    {
+        m_timer.expires_after(boost::asio::chrono::milliseconds(m_idleWaitMs));
+    }
+    else
+    {
+        m_timer.expires_after(boost::asio::chrono::milliseconds(0));
+    }
+    m_timer.async_wait(doTick);
+}
+
+void Worker::notify()
+{
+    if (m_workerState == WorkerState::Started)
+    {
+        m_timer.cancel();
+        // scheduleNext will be called from the cancelled timer's handler
+        // (with ec == operation_aborted), so we need to reschedule here
+        boost::asio::post(m_ioContext, [this]() {
+            if (m_workerState == WorkerState::Started)
+            {
+                scheduleNext();
+            }
+        });
     }
 }

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -69,7 +69,9 @@ void Worker::stopWorking()
         return;
     }
     m_workerState = WorkerState::Stopping;
-    // Cancel the timer to stop the loop
+    // Cancel the timer — the handler will see operation_aborted and skip.
+    // The io_context must still be alive when this is called (owned by the
+    // same thread that runs the io_context, or the io_context outlives us).
     m_timer.cancel();
     try
     {
@@ -91,8 +93,13 @@ void Worker::terminate()
     {
         return;  // Already terminating
     }
+    // Mark as Killing so the timer handler (if any) will skip scheduling
+    // the next tick when it fires. We deliberately do NOT call
+    // m_timer.cancel() here because terminate() can be called from the
+    // destructor on an arbitrary thread, which would race with the
+    // io_context's timer queue. The steady_timer destructor handles
+    // internal cleanup safely.
     m_workerState = WorkerState::Killing;
-    m_timer.cancel();
 }
 
 void Worker::workerProcessLoop()

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -110,12 +110,6 @@ void Worker::terminate()
     m_timer.cancel();
 }
 
-void Worker::workerProcessLoop()
-{
-    // Default: just call executeWorker once per tick
-    executeWorker();
-}
-
 void Worker::scheduleNext()
 {
     if (m_workerState != WorkerState::Started)
@@ -153,12 +147,12 @@ void Worker::handleTimerTick(boost::system::error_code const& ec)
     bool hasException = false;
     try
     {
-        workerProcessLoop();
+        executeWorker();
     }
     catch (std::exception const& e)
     {
         hasException = true;
-        BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker workerProcessLoop")
+        BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker executeWorker")
                           << LOG_KV("threadName", m_threadName)
                           << LOG_KV("msg", boost::diagnostic_information(e));
     }

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -21,13 +21,12 @@
 #include <boost/asio/post.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <exception>
-#include <functional>
 
 using namespace bcos;
 
 void Worker::startWorking()
 {
-    boost::unique_lock<boost::mutex> l(x_work);
+    std::unique_lock l(x_work);
     if (m_workerState == WorkerState::Started)
     {
         // Already running
@@ -36,9 +35,12 @@ void Worker::startWorking()
     // Transition to Starting, then schedule the first tick
     m_workerState = WorkerState::Starting;
 
-    // Capture a weak reference to this in case the Worker is destroyed
-    // before the timer fires. Use a raw pointer with a shareable flag.
-    boost::asio::post(m_ioContext, [this]() {
+    auto aliveFlag = m_aliveFlag;
+    boost::asio::post(m_ioContext, [this, aliveFlag]() {
+        if (!*aliveFlag)
+        {
+            return;  // Worker was destroyed before the post ran
+        }
         if (m_workerState != WorkerState::Starting)
         {
             return;  // was stopped before the post ran
@@ -63,16 +65,19 @@ void Worker::startWorking()
 
 void Worker::stopWorking()
 {
-    boost::unique_lock<boost::mutex> l(x_work);
-    if (m_workerState != WorkerState::Started)
     {
-        return;
+        std::unique_lock l(x_work);
+        if (m_workerState != WorkerState::Started)
+        {
+            return;
+        }
+        m_workerState = WorkerState::Stopping;
+        // Cancel the timer — cancel() returns immediately and is non-throwing.
+        m_timer.cancel();
     }
-    m_workerState = WorkerState::Stopping;
-    // Cancel the timer — the handler will see operation_aborted and skip.
-    // The io_context must still be alive when this is called (owned by the
-    // same thread that runs the io_context, or the io_context outlives us).
-    m_timer.cancel();
+    // Call finishWorker() outside the lock: subclasses may acquire other
+    // locks or call back into Worker APIs, which could deadlock if x_work
+    // were still held.
     try
     {
         finishWorker();
@@ -88,18 +93,21 @@ void Worker::stopWorking()
 
 void Worker::terminate()
 {
-    boost::unique_lock<boost::mutex> l(x_work);
+    std::unique_lock l(x_work);
     if (m_workerState == WorkerState::Killing)
     {
         return;  // Already terminating
     }
-    // Mark as Killing so the timer handler (if any) will skip scheduling
-    // the next tick when it fires. We deliberately do NOT call
-    // m_timer.cancel() here because terminate() can be called from the
-    // destructor on an arbitrary thread, which would race with the
-    // io_context's timer queue. The steady_timer destructor handles
-    // internal cleanup safely.
     m_workerState = WorkerState::Killing;
+
+    // Signal all in-flight handlers to bail out before accessing `this`.
+    // The shared_ptr guarantees the atomic<bool> outlives the Worker even
+    // if a handler was already posted to the io_context queue.
+    *m_aliveFlag = false;
+
+    // Cancel any pending timer operation. cancel() is non-throwing and
+    // thread-safe. Handlers already queued will see !*m_aliveFlag and bail.
+    m_timer.cancel();
 }
 
 void Worker::workerProcessLoop()
@@ -115,51 +123,63 @@ void Worker::scheduleNext()
         return;
     }
 
-    auto self = this;
-    std::function<void(boost::system::error_code const&)> doTick;
-    doTick = [self, &doTick](boost::system::error_code const& ec) {
-            if (ec == boost::asio::error::operation_aborted)
-            {
-                return;  // Timer was cancelled
-            }
-            if (self->m_workerState != WorkerState::Started)
+    m_timer.expires_after(boost::asio::chrono::milliseconds(m_idleWaitMs));
+    auto aliveFlag = m_aliveFlag;
+    m_timer.async_wait([this, aliveFlag](boost::system::error_code const& ec) {
+        if (!*aliveFlag)
+        {
+            return;
+        }
+        handleTimerTick(ec);
+    });
+}
+
+void Worker::handleTimerTick(boost::system::error_code const& ec)
+{
+    // aliveFlag check is performed by the wrapping lambda in scheduleNext()
+    // and the backoff path below; kept here for defense-in-depth.
+    if (!*m_aliveFlag)
+    {
+        return;
+    }
+    if (ec == boost::asio::error::operation_aborted)
+    {
+        return;  // Timer was cancelled
+    }
+    if (m_workerState != WorkerState::Started)
+    {
+        return;
+    }
+    bool hasException = false;
+    try
+    {
+        workerProcessLoop();
+    }
+    catch (std::exception const& e)
+    {
+        hasException = true;
+        BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker workerProcessLoop")
+                          << LOG_KV("threadName", m_threadName)
+                          << LOG_KV("msg", boost::diagnostic_information(e));
+    }
+    // FIB-111: backoff after exceptions to prevent tight CPU spin
+    if (hasException && m_idleWaitMs == 0)
+    {
+        // Use a small backoff to avoid busy-looping on persistent exceptions
+        m_timer.expires_after(boost::asio::chrono::milliseconds(10));
+        auto aliveFlag = m_aliveFlag;
+        m_timer.async_wait([this, aliveFlag](boost::system::error_code const& ec) {
+            if (!*aliveFlag)
             {
                 return;
             }
-            bool hasException = false;
-            try
-            {
-                self->workerProcessLoop();
-            }
-            catch (std::exception const& e)
-            {
-                hasException = true;
-                BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker workerProcessLoop")
-                                  << LOG_KV("threadName", self->m_threadName)
-                                  << LOG_KV("msg", boost::diagnostic_information(e));
-            }
-            // FIB-111: backoff after exceptions to prevent tight CPU spin
-            if (hasException && self->m_idleWaitMs == 0)
-            {
-                // Use a small backoff to avoid busy-looping on persistent exceptions
-                self->m_timer.expires_after(boost::asio::chrono::milliseconds(10));
-                self->m_timer.async_wait(doTick);
-            }
-            else
-            {
-                self->scheduleNext();
-            }
-        };
-
-    if (m_idleWaitMs > 0)
-    {
-        m_timer.expires_after(boost::asio::chrono::milliseconds(m_idleWaitMs));
+            handleTimerTick(ec);
+        });
     }
     else
     {
-        m_timer.expires_after(boost::asio::chrono::milliseconds(0));
+        scheduleNext();
     }
-    m_timer.async_wait(doTick);
 }
 
 void Worker::notify()
@@ -167,9 +187,15 @@ void Worker::notify()
     if (m_workerState == WorkerState::Started)
     {
         m_timer.cancel();
-        // scheduleNext will be called from the cancelled timer's handler
-        // (with ec == operation_aborted), so we need to reschedule here
-        boost::asio::post(m_ioContext, [this]() {
+        // The cancelled timer's handler will receive operation_aborted and
+        // return without rescheduling, so we explicitly post a fresh
+        // scheduleNext() to wake the worker.
+        auto aliveFlag = m_aliveFlag;
+        boost::asio::post(m_ioContext, [this, aliveFlag]() {
+            if (!*aliveFlag)
+            {
+                return;
+            }
             if (m_workerState == WorkerState::Started)
             {
                 scheduleNext();

--- a/bcos-utilities/bcos-utilities/Worker.h
+++ b/bcos-utilities/bcos-utilities/Worker.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "Common.h"
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <atomic>
@@ -93,6 +92,8 @@ protected:
 private:
     // Schedule the next timer tick
     void scheduleNext();
+    // Timer completion handler (body of the former doTick lambda)
+    void handleTimerTick(boost::system::error_code const& _ec);
 
     boost::asio::io_context& m_ioContext;
     boost::asio::steady_timer m_timer;
@@ -101,8 +102,13 @@ private:
 
     unsigned m_idleWaitMs = 0;
 
-    boost::mutex x_work;
+    std::mutex x_work;
     std::atomic<WorkerState> m_workerState = {WorkerState::Starting};
+
+    // Shared alive flag captured by all async handlers. terminate() sets it to
+    // false; handlers check it before accessing `this`, so they can safely bail
+    // even if the handler was already posted before Worker destruction.
+    std::shared_ptr<std::atomic<bool>> m_aliveFlag = std::make_shared<std::atomic<bool>>(true);
 };
 
 }  // namespace bcos

--- a/bcos-utilities/bcos-utilities/Worker.h
+++ b/bcos-utilities/bcos-utilities/Worker.h
@@ -19,9 +19,10 @@
 #pragma once
 
 #include "Common.h"
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
 #include <atomic>
 #include <string>
-#include <thread>
 #include <utility>
 
 namespace bcos
@@ -38,8 +39,12 @@ enum class WorkerState
 class Worker
 {
 protected:
-    Worker(std::string _threadName = "worker", unsigned _idleWaitMs = 30)
-      : m_threadName(std::move(_threadName)), m_idleWaitMs(_idleWaitMs)
+    Worker(boost::asio::io_context& _ioContext, std::string _threadName = "worker",
+        unsigned _idleWaitMs = 30)
+      : m_ioContext(_ioContext),
+        m_timer(_ioContext),
+        m_threadName(std::move(_threadName)),
+        m_idleWaitMs(_idleWaitMs)
     {}
     virtual ~Worker() { terminate(); }
 
@@ -55,47 +60,48 @@ protected:
 
     std::string const& threadName() const { return m_threadName; }
 
-    // Starts worker thread by calling startedWorking
+    // Starts worker by scheduling the first timer tick
     void startWorking();
 
-    // Stop worker thread
+    // Stop worker by cancelling the timer
     void stopWorking();
 
-    // Return true if the worker thread is working
-    bool isWorking() const
-    {
-        boost::unique_lock<boost::mutex> l(x_work);
-        return m_workerState == WorkerState::Started;
-    }
+    // Return true if the worker is actively running
+    bool isWorking() const { return m_workerState == WorkerState::Started; }
 
-    // Called after thread is started from startWorking to init the worker
+    // Called after startWorking to init the worker (one-shot)
     virtual void initWorker() {}
 
-    // worker execute logic (Called continuously following sleep for m_idleWaitMs)
+    // worker execute logic (Called per timer tick)
     virtual void executeWorker() {}
 
-    // schedule the task inner a loop before stop the worker thread
+    // Called once per timer tick (default: just calls executeWorker)
     virtual void workerProcessLoop();
     bool shouldStop() const { return m_workerState != WorkerState::Started; }
 
-    // Called when is to be stopped, just prior to thread being joined.
+    // Called when is to be stopped
     virtual void finishWorker() {}
-    // stop the worker
+    // stop the worker and cancel the timer
     void terminate();
+
+    // Wake up the worker immediately (cancel current timer, re-schedule)
+    void notify();
 
     std::atomic<WorkerState>& workerState() { return m_workerState; }
     unsigned idleWaitMs() const { return m_idleWaitMs; }
 
 private:
+    // Schedule the next timer tick
+    void scheduleNext();
+
+    boost::asio::io_context& m_ioContext;
+    boost::asio::steady_timer m_timer;
+
     std::string m_threadName;
 
     unsigned m_idleWaitMs = 0;
 
-    mutable boost::mutex x_work;
-    // the worker thread
-    std::unique_ptr<std::thread> m_workerThread;
-    // Notification when m_workerState changes
-    mutable boost::condition_variable m_workerStateNotifier;
+    boost::mutex x_work;
     std::atomic<WorkerState> m_workerState = {WorkerState::Starting};
 };
 

--- a/bcos-utilities/bcos-utilities/Worker.h
+++ b/bcos-utilities/bcos-utilities/Worker.h
@@ -74,8 +74,6 @@ protected:
     // worker execute logic (Called per timer tick)
     virtual void executeWorker() {}
 
-    // Called once per timer tick (default: just calls executeWorker)
-    virtual void workerProcessLoop();
     bool shouldStop() const { return m_workerState != WorkerState::Started; }
 
     // Called when is to be stopped

--- a/bcos-utilities/test/unittests/libutilities/WorkerTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/WorkerTest.cpp
@@ -20,9 +20,10 @@
  */
 
 #include "bcos-utilities/Worker.h"
-#include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/Timer.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 #include <boost/test/unit_test.hpp>
 #include <chrono>
 #include <thread>
@@ -62,11 +63,18 @@ BOOST_FIXTURE_TEST_SUITE(Worker, TestPromptFixture)
 
 BOOST_AUTO_TEST_CASE(testWorker)
 {
-    auto ioServicePool = std::make_shared<IOServicePool>(1, "workerTest");
-    TestWorkerImpl workerImpl(*ioServicePool->getIOService());
+    boost::asio::io_context ioContext;
+    auto work = boost::asio::make_work_guard(ioContext);
+    std::thread ioThread([&]() { ioContext.run(); });
+
+    TestWorkerImpl workerImpl(ioContext);
     workerImpl.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     workerImpl.stop();
+
+    work.reset();
+    ioContext.stop();
+    ioThread.join();
 }
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace test

--- a/bcos-utilities/test/unittests/libutilities/WorkerTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/WorkerTest.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "bcos-utilities/Worker.h"
+#include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/Timer.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <boost/test/unit_test.hpp>
@@ -35,9 +36,9 @@ namespace test
 class TestWorkerImpl : public Worker
 {
 public:
-    TestWorkerImpl() : Worker("TestWorkerImpl", 1)
+    TestWorkerImpl(boost::asio::io_context& io) : Worker(io, "TestWorkerImpl", 1)
     {
-        m_timer = std::make_shared<Timer>(1, "testTimer");
+        m_timer = std::make_shared<Timer>(io, 1, "testTimer");
         m_timer->registerTimeoutHandler([]() { std::cout << "#### call timer" << std::endl; });
     }
     void run() { startWorking(); }
@@ -61,7 +62,8 @@ BOOST_FIXTURE_TEST_SUITE(Worker, TestPromptFixture)
 
 BOOST_AUTO_TEST_CASE(testWorker)
 {
-    TestWorkerImpl workerImpl;
+    auto ioServicePool = std::make_shared<IOServicePool>(1, "workerTest");
+    TestWorkerImpl workerImpl(*ioServicePool->getIOService());
     workerImpl.run();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     workerImpl.stop();

--- a/libinitializer/PBFTInitializer.cpp
+++ b/libinitializer/PBFTInitializer.cpp
@@ -427,7 +427,7 @@ void PBFTInitializer::createSealer()
 {
     // create sealer
     auto sealerFactory = SealerFactory(m_nodeConfig, m_protocolInitializer->blockFactory(),
-        m_txpool, m_nodeTimeMaintenance, m_protocolInitializer->keyPair());
+        m_txpool, m_nodeTimeMaintenance, m_protocolInitializer->keyPair(), *m_ioContext);
     // if rpbft sealer, register the sealer to the pbft
     if (m_nodeConfig->consensusType() == ledger::RPBFT_CONSENSUS_TYPE) [[unlikely]]
     {
@@ -448,7 +448,7 @@ void PBFTInitializer::createPBFT()
         auto pbftFactory = std::make_shared<PBFTFactory>(m_protocolInitializer->cryptoSuite(),
             m_protocolInitializer->keyPair(), m_frontService, kvStorage, m_ledger, m_scheduler,
             m_txpool, m_protocolInitializer->blockFactory(),
-            m_protocolInitializer->txResultFactory());
+            m_protocolInitializer->txResultFactory(), *m_ioContext);
         m_pbft = pbftFactory->createPBFT();
     }
     else if (m_nodeConfig->consensusType() == ledger::RPBFT_CONSENSUS_TYPE)
@@ -456,7 +456,7 @@ void PBFTInitializer::createPBFT()
         auto rpbftFactory = std::make_shared<RPBFTFactory>(m_protocolInitializer->cryptoSuite(),
             m_protocolInitializer->keyPair(), m_frontService, kvStorage, m_ledger, m_scheduler,
             m_txpool, m_protocolInitializer->blockFactory(),
-            m_protocolInitializer->txResultFactory());
+            m_protocolInitializer->txResultFactory(), *m_ioContext);
         m_pbft = rpbftFactory->createRPBFT();
     }
 


### PR DESCRIPTION
## 改动概要

将 `Worker` 类从"独占线程 + 定时器"模式重构为"共享 `io_context` + `steady_timer`"模式，使多个 `Worker` 子类可以复用 `IOServicePool` 中的同一个 `io_context`，从而减少整体线程数量。

## 核心变更

### Worker 类重构

- 构造函数改为接受 `boost::asio::io_context&`，不再内部创建独立线程
- 使用 `steady_timer` 替代 `sleep`+循环，通过 `m_idleWaitMs` 控制调度间隔
- 新增 `notify()` 方法：可被任意线程调用，取消当前 timer 并立即调度下一轮 `executeWorker()`
- `terminate()` 不再调用 `m_timer.cancel()`，避免析构时与 `io_context` 线程竞争导致 heap-use-after-free
- 异常退避保留（FIB-111）：`idleWaitMs == 0` 时异常后自动施加 10ms 退避

### 子类适配

| 子类 | idleWaitMs | 说明 |
|------|-----------|------|
| `Sealer` | 100ms | 原 `m_signalled.wait_for(100ms)` 改为 timer；`noteGenerateProposal()` 调用 `notify()` 提前唤醒 |
| `PBFTEngine` | 20ms | 原 `waitSignal()`(1ms) + `sleep_for(20ms)` 重试退避均由 timer 统一处理；`onReceivePBFTMessage()` 调用 `notify()` |
| `BlockSync` | 200ms | 原 `m_signalled.wait_for(200ms)` 改为 timer + `notify()` |
| `EventSub` | 30ms | 默认值，从 `RpcFactory::m_ioServicePool` 获取 `io_context` |

### 消除的阻塞调用

- `Sealer::executeWorker()` 中的 `m_signalled.wait_for(100ms)`（阻塞 io_context 线程）
- `PBFTEngine::waitSignal()` 中的 `m_signalled.wait_for(1ms)`
- `PBFTEngine` 中的 `std::this_thread::sleep_for(20ms)` ×2
- `BlockSync::workerProcessLoop()` 中的 `m_signalled.wait_for(200ms)`

### 初始化和测试

- `PBFTInitializer` 将 `m_ioContext` 传递给 `SealerFactory`、`PBFTFactory`、`RPBFTFactory`
- 测试 fixture 使用 `IOServicePool(1)` 替代独立线程，注意生命周期（`m_ioServicePool` 声明在 Worker 子类成员之前）
- `RPCFixture` 补充 `setIOServicePool()` 调用

### 测试结果

26 个测试套件中 21 个通过（含所有与本次重构相关的套件），5 个超时或为预存问题。

## 变更文件

共 36 个文件，+372/-262 行。