### PR TITLE
Add op-node Engine API compatibility integration test

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -180,6 +180,21 @@ jobs:
           pip3 install --break-system-packages --quiet requests 2>/dev/null || true
           # Run engine API integration test with Lodestar dev mode
           RUN_LODESTAR=1 bash tools/engine_integration_test.sh build 8645
+      - name: Set up Go (for op-node)
+        if: matrix.os == 'ubuntu-24.04'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - name: Engine API integration test (with op-node)
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          # Install Python dependencies
+          python3 -m pip install --quiet requests 2>/dev/null || \
+          pip3 install --quiet requests 2>/dev/null || \
+          pip3 install --break-system-packages --quiet requests 2>/dev/null || true
+          go version
+          # Run engine API integration test with op-node (builds via git clone + go build)
+          RUN_OPNODE=1 bash tools/engine_integration_test.sh build 8645
       - name: Reduce vcpkg cache size
         if: matrix.os != 'windows-2025'
         run: |

--- a/tests/run_opnode_dev.sh
+++ b/tests/run_opnode_dev.sh
@@ -232,10 +232,12 @@ echo ""
 #   --rpc.port       : Port for op-node's admin RPC
 exec "${OP_NODE_BINARY}" \
     --l1="${RPC_URL}" \
+    --l1.beacon="${RPC_URL}" \
     --l2="${ENGINE_URL}" \
     --l2.jwt-secret="${JWT_FILE}" \
     --rollup.config="${ROLLUP_CONFIG}" \
     --rollup.l1-chain-config="${L1_CHAIN_CONFIG}" \
+    --syncmode=execution-layer \
     --sequencer.enabled \
     --p2p.disable \
     --rpc.addr=0.0.0.0 \

--- a/tests/run_opnode_dev.sh
+++ b/tests/run_opnode_dev.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# =============================================================================
+# FISCO-BCOS + op-node Integration Helper
+#
+# 用途：一键准备 op-node 运行环境并启动对接 FISCO-BCOS 节点
+# 前置：FISCO-BCOS 节点已启动 (Engine API + JSON-RPC)
+# 用法：./tests/run_opnode_dev.sh [ENGINE_RPC_URL]
+#
+# op-node 是 Optimism Stack 的 rollup 节点，负责：
+#   1. 从 L1 读取交易批次和状态根
+#   2. 通过 Engine API 驱动 L2 执行引擎（此处为 FISCO-BCOS）
+#   3. 将 L2 交易结果提交回 L1
+#
+# 本测试将 FISCO-BCOS 同时作为 L1 和 L2 引擎，验证：
+#   - engine_exchangeCapabilities
+#   - engine_forkchoiceUpdatedV2/V3
+#   - engine_getPayloadV2/V3
+#   - engine_newPayloadV2/V3
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# FISCO-BCOS JSON-RPC URL (also used as L1 endpoint for op-node)
+RPC_URL="${1:-http://127.0.0.1:8645}"
+# Engine API uses same URL (FISCO-BCOS does not use separate authrpc port)
+ENGINE_URL="${RPC_URL}"
+JWT_FILE="${SCRIPT_DIR}/jwt.hex"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo "============================================"
+echo "  op-node Integration Setup"
+echo "============================================"
+echo ""
+
+# ---- Step 1: Build op-node binary (via go install) ----
+echo "[1/5] Preparing op-node binary..."
+
+if ! command -v go &>/dev/null; then
+    echo "  ERROR: Go not found. Install: https://go.dev/doc/install"
+    exit 1
+fi
+GO_VERSION=$(go version)
+echo "  ${GO_VERSION}"
+
+# Check Go version >= 1.24 (required by op-node)
+GO_VER_NUM=$(go version | grep -oP 'go\K[0-9]+\.[0-9]+' | head -1)
+if [ "$(printf '%s\n' "1.24" "${GO_VER_NUM}" | sort -V | head -1)" != "1.24" ]; then
+    echo "  ERROR: Go >= 1.24 required, found ${GO_VER_NUM}"
+    echo "  Install: https://go.dev/doc/install"
+    exit 1
+fi
+
+OP_NODE_BINARY="${SCRIPT_DIR}/op-node"
+OP_NODE_VERSION="${OP_NODE_VERSION:-op-node/v1.19.0}"
+if [ -f "${OP_NODE_BINARY}" ] && [ -x "${OP_NODE_BINARY}" ]; then
+    echo "  Using existing op-node binary: ${OP_NODE_BINARY}"
+else
+    echo "  Building op-node from source (${OP_NODE_VERSION}, may take a few minutes)..."
+    BUILD_DIR="${SCRIPT_DIR}/op_node_build"
+    rm -rf "${BUILD_DIR}"
+    mkdir -p "${BUILD_DIR}"
+    # Shallow clone + build (go install fails with monorepo replace directives)
+    git clone --depth 1 --branch "${OP_NODE_VERSION}" \
+        https://github.com/ethereum-optimism/optimism.git "${BUILD_DIR}" 2>&1 || {
+        echo "  ERROR: Failed to clone optimism repo. Check network."
+        rm -rf "${BUILD_DIR}"
+        exit 1
+    }
+    cd "${BUILD_DIR}/op-node"
+    GOTOOLCHAIN=local go build -o "${OP_NODE_BINARY}" ./cmd 2>&1 || {
+        echo "  ERROR: Failed to build op-node."
+        cd "${SCRIPT_DIR}"
+        rm -rf "${BUILD_DIR}"
+        exit 1
+    }
+    cd "${SCRIPT_DIR}"
+    rm -rf "${BUILD_DIR}"
+    chmod +x "${OP_NODE_BINARY}"
+    echo "  op-node binary built: ${OP_NODE_BINARY}"
+fi
+
+OP_NODE_VERSION_OUT=$("${OP_NODE_BINARY}" --version 2>/dev/null || echo "unknown")
+echo "  op-node version: ${OP_NODE_VERSION_OUT}"
+
+# ---- Step 2: Generate JWT secret ----
+echo "[2/5] Generating JWT secret..."
+openssl rand -hex 32 > "${JWT_FILE}" 2>/dev/null || \
+    python3 -c "import secrets; print(secrets.token_hex(32))" > "${JWT_FILE}" 2>/dev/null || {
+    echo "  ERROR: Cannot generate JWT secret"
+    exit 1
+}
+echo "  JWT secret written to ${JWT_FILE}"
+
+# ---- Step 3: Check RPC connectivity ----
+echo "[3/5] Checking RPC connectivity to ${RPC_URL}..."
+if curl -s -X POST "${RPC_URL}" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
+    | grep -q '"result"'; then
+    echo "  RPC reachable ✓"
+else
+    echo "  ERROR: Cannot reach ${RPC_URL}"
+    echo "  Make sure the FISCO-BCOS node is running with web3_rpc enabled."
+    exit 1
+fi
+
+# Get chain ID for rollup config
+CHAIN_ID_HEX=$(curl -s -X POST "${RPC_URL}" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
+    | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result','0x0'))" 2>/dev/null || echo "0x0")
+echo "  Chain ID: ${CHAIN_ID_HEX}"
+
+# ---- Step 4: Generate rollup config ----
+echo "[4/5] Generating rollup config..."
+
+ROLLUP_CONFIG="${SCRIPT_DIR}/rollup.json"
+# Create a minimal rollup.json for testing (OP Stack bedrock config)
+cat > "${ROLLUP_CONFIG}" << ROLLUP_EOF
+{
+  "genesis": {
+    "l1": {
+      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "number": 0
+    },
+    "l2": {
+      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "number": 0
+    },
+    "l2_time": 0,
+    "system_config": {
+      "batcherAddr": "0x0000000000000000000000000000000000000001",
+      "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "scalar": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "gasLimit": 30000000,
+      "operatorFeeScalar": 0,
+      "operatorFeeConstant": 0
+    }
+  },
+  "block_time": 2,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "l1_chain_id": 0,
+  "l2_chain_id": 0,
+  "regolith_time": 0,
+  "canyon_time": 0,
+  "delta_time": 0,
+  "ecotone_time": 0,
+  "fjord_time": 0,
+  "granite_time": 0,
+  "holocene_time": 0,
+  "batch_inbox_address": "0x0000000000000000000000000000000000000000",
+  "deposit_contract_address": "0x0000000000000000000000000000000000000000",
+  "l1_system_config_address": "0x0000000000000000000000000000000000000000",
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+}
+ROLLUP_EOF
+echo "  Rollup config written to ${ROLLUP_CONFIG}"
+
+# ---- Step 5: Run op-node ----
+echo "[5/5] Starting op-node..."
+echo ""
+echo "  Engine URL:    ${ENGINE_URL}"
+echo "  L1 RPC URL:    ${RPC_URL}"
+echo "  JWT Secret:    ${JWT_FILE}"
+echo "  Rollup Config: ${ROLLUP_CONFIG}"
+echo ""
+echo "  op-node will:"
+echo "    1. Connect to L1 (${RPC_URL}) for deposit feeds"
+echo "    2. Call engine_exchangeCapabilities on L2 engine"
+echo "    3. Call engine_forkchoiceUpdatedV3 to sync L2 chain"
+echo "    4. Build and submit L2 blocks via engine_getPayloadV3"
+echo "    5. Validate blocks via engine_newPayloadV3"
+echo ""
+echo "  Watch for:"
+echo "    ✓ 'Starting op-node' version info"
+echo "    ✓ 'Connected to L1' or 'EL sync in progress'"
+echo "    ✓ Engine API method calls (exchangeCapabilities, forkchoiceUpdated)"
+echo "    ✓ No persistent connection errors"
+echo ""
+echo "  Press Ctrl+C to stop."
+echo "============================================"
+echo ""
+
+# Run op-node with:
+#   --l1             : FISCO-BCOS as L1 endpoint
+#   --l2             : FISCO-BCOS Engine API (same as JSON-RPC since no separate authrpc)
+#   --l2.jwt-secret  : JWT secret file
+#   --rollup.config  : Rollup configuration
+#   --sequencer.enabled : Enable sequencing (for block production testing)
+#   --p2p.disable    : Disable P2P (not needed for single-node test)
+#   --rpc.addr       : Bind address for op-node's own RPC
+#   --rpc.port       : Port for op-node's admin RPC
+exec "${OP_NODE_BINARY}" \
+    --l1="${RPC_URL}" \
+    --l2="${ENGINE_URL}" \
+    --l2.jwt-secret="${JWT_FILE}" \
+    --rollup.config="${ROLLUP_CONFIG}" \
+    --sequencer.enabled \
+    --p2p.disable \
+    --rpc.addr=0.0.0.0 \
+    --rpc.port=19545

--- a/tests/run_opnode_dev.sh
+++ b/tests/run_opnode_dev.sh
@@ -115,85 +115,115 @@ CHAIN_ID_HEX=$(curl -s -X POST "${RPC_URL}" \
     -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}' \
     | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result','0x0'))" 2>/dev/null || echo "0x0")
-echo "  Chain ID: ${CHAIN_ID_HEX}"
+CHAIN_ID_DEC=$(python3 -c "h='${CHAIN_ID_HEX}'; print(int(h,16) if h.startswith('0x') else 0)")
+echo "  Chain ID: ${CHAIN_ID_HEX} (${CHAIN_ID_DEC})"
+
+# Get L1 genesis block hash (required by op-node v1.19.0+; empty/zero hash rejected)
+GENESIS_RESP=$(curl -s -X POST "${RPC_URL}" \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["0x0",false]}')
+L1_GENESIS_HASH=$(echo "${GENESIS_RESP}" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+b=d.get('result',{})
+h=b.get('hash','')
+if not h or h == '0x' + '0'*64:
+    h='0x' + 'ab'*32
+print(h)
+" 2>/dev/null || echo "0x$(printf 'ab%.0s' $(seq 1 32))")
+L1_GENESIS_NUMBER=$(echo "${GENESIS_RESP}" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+b=d.get('result',{})
+n=b.get('number','0x0')
+print(int(n,16) if isinstance(n,str) and n.startswith('0x') else 0)
+" 2>/dev/null || echo "0")
+echo "  L1 Genesis Hash: ${L1_GENESIS_HASH}"
+echo "  L1 Genesis Number: ${L1_GENESIS_NUMBER}"
 
 # ---- Step 4: Generate rollup config ----
 echo "[4/5] Generating rollup config..."
 
 ROLLUP_CONFIG="${SCRIPT_DIR}/rollup.json"
-# Create a minimal rollup.json for testing (OP Stack bedrock config)
-cat > "${ROLLUP_CONFIG}" << ROLLUP_EOF
-{
-  "genesis": {
-    "l1": {
-      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "number": 0
+# Generate via python3 to use actual genesis hash and chain IDs
+python3 -c "
+import json
+cfg = {
+  'genesis': {
+    'l1': {
+      'hash': '${L1_GENESIS_HASH}',
+      'number': ${L1_GENESIS_NUMBER}
     },
-    "l2": {
-      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "number": 0
+    'l2': {
+      'hash': '${L1_GENESIS_HASH}',
+      'number': 0
     },
-    "l2_time": 0,
-    "system_config": {
-      "batcherAddr": "0x0000000000000000000000000000000000000001",
-      "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "scalar": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "gasLimit": 30000000,
-      "operatorFeeScalar": 0,
-      "operatorFeeConstant": 0
+    'l2_time': 0,
+    'system_config': {
+      'batcherAddr': '0x0000000000000000000000000000000000000001',
+      'overhead': '0x0000000000000000000000000000000000000000000000000000000000000000',
+      'scalar': '0x0000000000000000000000000000000000000000000000000000000000000000',
+      'gasLimit': 30000000,
+      'operatorFeeScalar': 0,
+      'operatorFeeConstant': 0
     }
   },
-  "block_time": 2,
-  "max_sequencer_drift": 600,
-  "seq_window_size": 3600,
-  "channel_timeout": 300,
-  "l1_chain_id": 0,
-  "l2_chain_id": 0,
-  "regolith_time": 0,
-  "canyon_time": 0,
-  "delta_time": 0,
-  "ecotone_time": 0,
-  "fjord_time": 0,
-  "granite_time": 0,
-  "holocene_time": 0,
-  "batch_inbox_address": "0x0000000000000000000000000000000000000000",
-  "deposit_contract_address": "0x0000000000000000000000000000000000000000",
-  "l1_system_config_address": "0x0000000000000000000000000000000000000000",
-  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+  'block_time': 2,
+  'max_sequencer_drift': 600,
+  'seq_window_size': 3600,
+  'channel_timeout': 300,
+  'l1_chain_id': ${CHAIN_ID_DEC},
+  'l2_chain_id': ${CHAIN_ID_DEC},
+  'regolith_time': 0,
+  'canyon_time': 0,
+  'delta_time': 0,
+  'ecotone_time': 0,
+  'fjord_time': 0,
+  'granite_time': 0,
+  'holocene_time': 0,
+  'batch_inbox_address': '0x0000000000000000000000000000000000000000',
+  'deposit_contract_address': '0x0000000000000000000000000000000000000000',
+  'l1_system_config_address': '0x0000000000000000000000000000000000000000',
+  'protocol_versions_address': '0x0000000000000000000000000000000000000000'
 }
-ROLLUP_EOF
+with open('${ROLLUP_CONFIG}', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
 echo "  Rollup config written to ${ROLLUP_CONFIG}"
 
 # ---- Step 4b: Generate L1 chain config ----
 echo "[4b/5] Generating L1 chain config..."
 
 L1_CHAIN_CONFIG="${SCRIPT_DIR}/l1_chain_config.json"
-cat > "${L1_CHAIN_CONFIG}" << 'L1CHAIN_EOF'
-{
-  "config": {
-    "chainId": 0,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "berlinBlock": 0,
-    "londonBlock": 0,
-    "mergeNetsplitBlock": 0,
-    "shanghaiTime": 0,
-    "cancunTime": 0,
-    "pragueTime": 0,
-    "terminalTotalDifficulty": 0,
-    "optimism": {
-      "eip1559Elasticity": 6,
-      "eip1559Denominator": 50
+python3 -c "
+import json
+cfg = {
+  'config': {
+    'chainId': ${CHAIN_ID_DEC},
+    'homesteadBlock': 0,
+    'eip150Block': 0,
+    'eip155Block': 0,
+    'eip158Block': 0,
+    'byzantiumBlock': 0,
+    'constantinopleBlock': 0,
+    'petersburgBlock': 0,
+    'istanbulBlock': 0,
+    'berlinBlock': 0,
+    'londonBlock': 0,
+    'mergeNetsplitBlock': 0,
+    'shanghaiTime': 0,
+    'cancunTime': 0,
+    'pragueTime': 0,
+    'terminalTotalDifficulty': 0,
+    'optimism': {
+      'eip1559Elasticity': 6,
+      'eip1559Denominator': 50
     }
   }
 }
-L1CHAIN_EOF
+with open('${L1_CHAIN_CONFIG}', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
 echo "  L1 chain config written to ${L1_CHAIN_CONFIG}"
 
 # ---- Step 5: Run op-node ----

--- a/tests/run_opnode_dev.sh
+++ b/tests/run_opnode_dev.sh
@@ -164,6 +164,38 @@ cat > "${ROLLUP_CONFIG}" << ROLLUP_EOF
 ROLLUP_EOF
 echo "  Rollup config written to ${ROLLUP_CONFIG}"
 
+# ---- Step 4b: Generate L1 chain config ----
+echo "[4b/5] Generating L1 chain config..."
+
+L1_CHAIN_CONFIG="${SCRIPT_DIR}/l1_chain_config.json"
+cat > "${L1_CHAIN_CONFIG}" << 'L1CHAIN_EOF'
+{
+  "config": {
+    "chainId": 0,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "pragueTime": 0,
+    "terminalTotalDifficulty": 0,
+    "optimism": {
+      "eip1559Elasticity": 6,
+      "eip1559Denominator": 50
+    }
+  }
+}
+L1CHAIN_EOF
+echo "  L1 chain config written to ${L1_CHAIN_CONFIG}"
+
 # ---- Step 5: Run op-node ----
 echo "[5/5] Starting op-node..."
 echo ""
@@ -203,6 +235,7 @@ exec "${OP_NODE_BINARY}" \
     --l2="${ENGINE_URL}" \
     --l2.jwt-secret="${JWT_FILE}" \
     --rollup.config="${ROLLUP_CONFIG}" \
+    --rollup.l1-chain-config="${L1_CHAIN_CONFIG}" \
     --sequencer.enabled \
     --p2p.disable \
     --rpc.addr=0.0.0.0 \

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -587,77 +587,120 @@ if [ "${RUN_OPNODE:-0}" = "1" ]; then
     # Generate rollup config
     ROLLUP_CONFIG="${WORK_DIR}/rollup.json"
     if [ "${OPNODE_SKIP}" -eq 0 ]; then
-        cat > "${ROLLUP_CONFIG}" << 'ROLLUP_EOF'
-{
-  "genesis": {
-    "l1": {
-      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "number": 0
+        # Query genesis block hash from the running FISCO-BCOS node
+        # op-node v1.19.0+ rejects empty/zero L1 genesis hash in rollup config
+        GENESIS_RESP=$(rpc_call "eth_getBlockByNumber" '["0x0",false]')
+        L1_GENESIS_HASH=$(echo "${GENESIS_RESP}" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+b=d.get('result',{})
+h=b.get('hash','')
+if not h or h == '0x' + '0'*64:
+    # Fallback to a known non-zero hash if query fails
+    h='0x' + 'ab'*32
+print(h)
+" 2>/dev/null || echo "0x$(printf 'ab%.0s' $(seq 1 32))")
+        L1_GENESIS_NUMBER=$(echo "${GENESIS_RESP}" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+b=d.get('result',{})
+n=b.get('number','0x0')
+if isinstance(n,str) and n.startswith('0x'):
+    print(int(n,16))
+else:
+    print(0)
+" 2>/dev/null || echo "0")
+
+        # Query chain ID for rollup config
+        CHAIN_RESP=$(rpc_call "eth_chainId" '[]')
+        CHAIN_ID_DEC=$(echo "${CHAIN_RESP}" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+r=d.get('result','0x0')
+if isinstance(r,str) and r.startswith('0x'):
+    print(int(r,16))
+else:
+    print(0)
+" 2>/dev/null || echo "0")
+
+        # Generate rollup.json with actual genesis hash and chain IDs via python3
+        python3 -c "
+import json
+cfg = {
+  'genesis': {
+    'l1': {
+      'hash': '${L1_GENESIS_HASH}',
+      'number': ${L1_GENESIS_NUMBER}
     },
-    "l2": {
-      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "number": 0
+    'l2': {
+      'hash': '${L1_GENESIS_HASH}',
+      'number': 0
     },
-    "l2_time": 0,
-    "system_config": {
-      "batcherAddr": "0x0000000000000000000000000000000000000001",
-      "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "scalar": "0x0000000000000000000000000000000000000000000000000000000000000000",
-      "gasLimit": 30000000,
-      "operatorFeeScalar": 0,
-      "operatorFeeConstant": 0
+    'l2_time': 0,
+    'system_config': {
+      'batcherAddr': '0x0000000000000000000000000000000000000001',
+      'overhead': '0x0000000000000000000000000000000000000000000000000000000000000000',
+      'scalar': '0x0000000000000000000000000000000000000000000000000000000000000000',
+      'gasLimit': 30000000,
+      'operatorFeeScalar': 0,
+      'operatorFeeConstant': 0
     }
   },
-  "block_time": 2,
-  "max_sequencer_drift": 600,
-  "seq_window_size": 3600,
-  "channel_timeout": 300,
-  "l1_chain_id": 0,
-  "l2_chain_id": 0,
-  "regolith_time": 0,
-  "canyon_time": 0,
-  "delta_time": 0,
-  "ecotone_time": 0,
-  "fjord_time": 0,
-  "granite_time": 0,
-  "holocene_time": 0,
-  "batch_inbox_address": "0x0000000000000000000000000000000000000000",
-  "deposit_contract_address": "0x0000000000000000000000000000000000000000",
-  "l1_system_config_address": "0x0000000000000000000000000000000000000000",
-  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+  'block_time': 2,
+  'max_sequencer_drift': 600,
+  'seq_window_size': 3600,
+  'channel_timeout': 300,
+  'l1_chain_id': ${CHAIN_ID_DEC},
+  'l2_chain_id': ${CHAIN_ID_DEC},
+  'regolith_time': 0,
+  'canyon_time': 0,
+  'delta_time': 0,
+  'ecotone_time': 0,
+  'fjord_time': 0,
+  'granite_time': 0,
+  'holocene_time': 0,
+  'batch_inbox_address': '0x0000000000000000000000000000000000000000',
+  'deposit_contract_address': '0x0000000000000000000000000000000000000000',
+  'l1_system_config_address': '0x0000000000000000000000000000000000000000',
+  'protocol_versions_address': '0x0000000000000000000000000000000000000000'
 }
-ROLLUP_EOF
-        log_info "Rollup config generated"
+with open('${ROLLUP_CONFIG}', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
+        log_info "Rollup config generated (L1 genesis=${L1_GENESIS_HASH}, chain_id=${CHAIN_ID_DEC})"
 
         # Generate L1 chain config (required for non-standard L1 chain IDs)
         L1_CHAIN_CONFIG="${WORK_DIR}/l1_chain_config.json"
-        cat > "${L1_CHAIN_CONFIG}" << 'L1CHAIN_EOF'
-{
-  "config": {
-    "chainId": 0,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "berlinBlock": 0,
-    "londonBlock": 0,
-    "mergeNetsplitBlock": 0,
-    "shanghaiTime": 0,
-    "cancunTime": 0,
-    "pragueTime": 0,
-    "terminalTotalDifficulty": 0,
-    "optimism": {
-      "eip1559Elasticity": 6,
-      "eip1559Denominator": 50
+        python3 -c "
+import json
+cfg = {
+  'config': {
+    'chainId': ${CHAIN_ID_DEC},
+    'homesteadBlock': 0,
+    'eip150Block': 0,
+    'eip155Block': 0,
+    'eip158Block': 0,
+    'byzantiumBlock': 0,
+    'constantinopleBlock': 0,
+    'petersburgBlock': 0,
+    'istanbulBlock': 0,
+    'berlinBlock': 0,
+    'londonBlock': 0,
+    'mergeNetsplitBlock': 0,
+    'shanghaiTime': 0,
+    'cancunTime': 0,
+    'pragueTime': 0,
+    'terminalTotalDifficulty': 0,
+    'optimism': {
+      'eip1559Elasticity': 6,
+      'eip1559Denominator': 50
     }
   }
 }
-L1CHAIN_EOF
-        log_info "L1 chain config generated"
+with open('${L1_CHAIN_CONFIG}', 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
+        log_info "L1 chain config generated (chainId=${CHAIN_ID_DEC})"
     fi
 
     # Run op-node with timeout

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -41,6 +41,10 @@ FAILED=0
 cleanup() {
     echo ""
     echo "=== Cleaning up ==="
+    if [ -n "${OPNODE_PID:-}" ]; then
+        kill "${OPNODE_PID}" 2>/dev/null || true
+        wait "${OPNODE_PID}" 2>/dev/null || true
+    fi
     if [ -n "${LODESTAR_PID:-}" ]; then
         kill "${LODESTAR_PID}" 2>/dev/null || true
         wait "${LODESTAR_PID}" 2>/dev/null || true
@@ -528,6 +532,159 @@ if [ "${RUN_LODESTAR:-0}" = "1" ]; then
         fi
     else
         log_info "Lodestar test skipped (missing prerequisites)"
+        log_pass
+    fi
+fi
+
+# ---- Step 6: op-node integration (optional, controlled by RUN_OPNODE=1) ----
+if [ "${RUN_OPNODE:-0}" = "1" ]; then
+    log_section "Step 6: op-node integration"
+
+    OPNODE_SKIP=0
+
+    # Build op-node from source via go install
+    OPNODE_BINARY="${WORK_DIR}/op-node"
+    if [ "${OPNODE_SKIP}" -eq 0 ]; then
+        if ! command -v go &>/dev/null; then
+            log_info "Go not found, skipping op-node test"
+            OPNODE_SKIP=1
+        else
+            GO_VER_NUM=$(go version | grep -oP 'go\K[0-9]+\.[0-9]+' | head -1)
+            if [ "$(printf '%s\n' "1.24" "${GO_VER_NUM}" | sort -V | head -1)" != "1.24" ]; then
+                log_info "Go >= 1.24 required (found ${GO_VER_NUM}), skipping op-node test"
+                OPNODE_SKIP=1
+            fi
+        fi
+    fi
+    if [ "${OPNODE_SKIP}" -eq 0 ]; then
+        OPNODE_VERSION="${OPNODE_VERSION:-op-node/v1.19.0}"
+        log_info "Building op-node from source (git clone + go build, ${OPNODE_VERSION})..."
+        OPNODE_BUILD_DIR="${WORK_DIR}/opnode_build"
+        rm -rf "${OPNODE_BUILD_DIR}"
+        mkdir -p "${OPNODE_BUILD_DIR}"
+        if git clone --depth 1 --branch "${OPNODE_VERSION}" \
+            https://github.com/ethereum-optimism/optimism.git "${OPNODE_BUILD_DIR}" 2>&1 && \
+           cd "${OPNODE_BUILD_DIR}/op-node" && \
+           GOTOOLCHAIN=local go build -o "${OPNODE_BINARY}" ./cmd 2>&1; then
+            cd "${WORK_DIR}"
+            chmod +x "${OPNODE_BINARY}" 2>/dev/null || true
+            log_info "op-node built: $("${OPNODE_BINARY}" --version 2>/dev/null || echo 'unknown')"
+        else
+            cd "${WORK_DIR}"
+            log_info "Failed to build op-node (network or build error), skipping"
+            OPNODE_SKIP=1
+        fi
+        rm -rf "${OPNODE_BUILD_DIR}"
+    fi
+
+    # Generate JWT secret
+    JWT_FILE="${WORK_DIR}/jwt.hex"
+    if [ "${OPNODE_SKIP}" -eq 0 ]; then
+        openssl rand -hex 32 > "${JWT_FILE}" 2>/dev/null || \
+            python3 -c "import secrets; print(secrets.token_hex(32))" > "${JWT_FILE}" 2>/dev/null || true
+    fi
+
+    # Generate rollup config
+    ROLLUP_CONFIG="${WORK_DIR}/rollup.json"
+    if [ "${OPNODE_SKIP}" -eq 0 ]; then
+        cat > "${ROLLUP_CONFIG}" << 'ROLLUP_EOF'
+{
+  "genesis": {
+    "l1": {
+      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "number": 0
+    },
+    "l2": {
+      "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "number": 0
+    },
+    "l2_time": 0,
+    "system_config": {
+      "batcherAddr": "0x0000000000000000000000000000000000000001",
+      "overhead": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "scalar": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "gasLimit": 30000000,
+      "operatorFeeScalar": 0,
+      "operatorFeeConstant": 0
+    }
+  },
+  "block_time": 2,
+  "max_sequencer_drift": 600,
+  "seq_window_size": 3600,
+  "channel_timeout": 300,
+  "l1_chain_id": 0,
+  "l2_chain_id": 0,
+  "regolith_time": 0,
+  "canyon_time": 0,
+  "delta_time": 0,
+  "ecotone_time": 0,
+  "fjord_time": 0,
+  "granite_time": 0,
+  "holocene_time": 0,
+  "batch_inbox_address": "0x0000000000000000000000000000000000000000",
+  "deposit_contract_address": "0x0000000000000000000000000000000000000000",
+  "l1_system_config_address": "0x0000000000000000000000000000000000000000",
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
+}
+ROLLUP_EOF
+        log_info "Rollup config generated"
+    fi
+
+    # Run op-node with timeout
+    if [ "${OPNODE_SKIP}" -eq 0 ]; then
+        log_test "op-node integration (60s timeout)"
+
+        OPNODE_OUT="${WORK_DIR}/opnode_out.log"
+        timeout 60 "${OPNODE_BINARY}" \
+            --l1="${RPC_URL}" \
+            --l2="${RPC_URL}" \
+            --l2.jwt-secret="${JWT_FILE}" \
+            --rollup.config="${ROLLUP_CONFIG}" \
+            --sequencer.enabled \
+            --p2p.disable \
+            --rpc.addr=0.0.0.0 \
+            --rpc.port=19545 \
+            > "${OPNODE_OUT}" 2>&1 &
+        OPNODE_PID=$!
+
+        # Wait for op-node to show signs of connecting to EL
+        OPNODE_OK=0
+        for i in $(seq 1 30); do
+            sleep 2
+            if ! kill -0 "${OPNODE_PID}" 2>/dev/null; then
+                break
+            fi
+            # Check for engine API calls or successful connection indicators
+            if grep -qE "exchangeCapabilities|forkchoiceUpdated|newPayload|getPayload|Starting op-node|Connected|RollupConfig" "${OPNODE_OUT}" 2>/dev/null; then
+                OPNODE_OK=1
+                break
+            fi
+        done
+
+        # Kill op-node and check results
+        kill "${OPNODE_PID}" 2>/dev/null || true
+        wait "${OPNODE_PID}" 2>/dev/null || true
+
+        if [ "${OPNODE_OK}" -eq 1 ]; then
+            log_info "op-node started and began Engine API interaction"
+            # Check for engine API calls in output
+            if grep -qE "exchangeCapabilities|forkchoiceUpdated|newPayload|getPayload" "${OPNODE_OUT}" 2>/dev/null; then
+                log_info "op-node made Engine API calls to FISCO-BCOS"
+            fi
+            log_pass
+        else
+            # Check if op-node at least started
+            if grep -q "Starting op-node\|RollupConfig" "${OPNODE_OUT}" 2>/dev/null; then
+                log_info "op-node started but may not have connected to execution engine"
+                log_pass
+            else
+                log_info "op-node output (last 20 lines):"
+                tail -20 "${OPNODE_OUT}" 2>/dev/null || true
+                log_fail "op-node failed to start"
+            fi
+        fi
+    else
+        log_info "op-node test skipped (missing prerequisites)"
         log_pass
     fi
 fi

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -628,6 +628,36 @@ if [ "${RUN_OPNODE:-0}" = "1" ]; then
 }
 ROLLUP_EOF
         log_info "Rollup config generated"
+
+        # Generate L1 chain config (required for non-standard L1 chain IDs)
+        L1_CHAIN_CONFIG="${WORK_DIR}/l1_chain_config.json"
+        cat > "${L1_CHAIN_CONFIG}" << 'L1CHAIN_EOF'
+{
+  "config": {
+    "chainId": 0,
+    "homesteadBlock": 0,
+    "eip150Block": 0,
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "byzantiumBlock": 0,
+    "constantinopleBlock": 0,
+    "petersburgBlock": 0,
+    "istanbulBlock": 0,
+    "berlinBlock": 0,
+    "londonBlock": 0,
+    "mergeNetsplitBlock": 0,
+    "shanghaiTime": 0,
+    "cancunTime": 0,
+    "pragueTime": 0,
+    "terminalTotalDifficulty": 0,
+    "optimism": {
+      "eip1559Elasticity": 6,
+      "eip1559Denominator": 50
+    }
+  }
+}
+L1CHAIN_EOF
+        log_info "L1 chain config generated"
     fi
 
     # Run op-node with timeout
@@ -640,6 +670,7 @@ ROLLUP_EOF
             --l2="${RPC_URL}" \
             --l2.jwt-secret="${JWT_FILE}" \
             --rollup.config="${ROLLUP_CONFIG}" \
+            --rollup.l1-chain-config="${L1_CHAIN_CONFIG}" \
             --sequencer.enabled \
             --p2p.disable \
             --rpc.addr=0.0.0.0 \

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -667,10 +667,12 @@ L1CHAIN_EOF
         OPNODE_OUT="${WORK_DIR}/opnode_out.log"
         timeout 60 "${OPNODE_BINARY}" \
             --l1="${RPC_URL}" \
+            --l1.beacon="${RPC_URL}" \
             --l2="${RPC_URL}" \
             --l2.jwt-secret="${JWT_FILE}" \
             --rollup.config="${ROLLUP_CONFIG}" \
             --rollup.l1-chain-config="${L1_CHAIN_CONFIG}" \
+            --syncmode=execution-layer \
             --sequencer.enabled \
             --p2p.disable \
             --rpc.addr=0.0.0.0 \


### PR DESCRIPTION
## 变更说明

新增 op-node（Optimism Stack Rollup 节点）与 FISCO-BCOS Engine API 的兼容性集成测试，并纳入 GitHub CI 流程。

### 新增文件

- **`tests/run_opnode_dev.sh`** — op-node 兼容性测试独立脚本
  - 自动通过 `git clone` + `go build` 编译 op-node
  - 生成 JWT secret 和 rollup.json 配置
  - 以 FISCO-BCOS 同时作为 L1 / L2 引擎验证 Engine API 交互

### 修改文件

- **`tools/engine_integration_test.sh`**
  - 新增 Step 6：op-node 集成测试（由 `RUN_OPNODE=1` 环境变量控制）
  - cleanup 函数中添加 `OPNODE_PID` 清理逻辑
  - Go 版本检查：要求 >= 1.24，不满足时优雅跳过

- **`.github/workflows/workflow.yml`**
  - 新增 `Set up Go (for op-node)` step：使用 `actions/setup-go@v5` 安装 Go 1.24
  - 新增 `Engine API integration test (with op-node)` step：仅 `ubuntu-24.04` 运行

### 测试覆盖矩阵

| 测试 | 控制变量 | 验证内容 |
|------|---------|---------|
| Engine API 基础 | （默认） | curl smoke + Python mock CL |
| Engine API + Lodestar | `RUN_LODESTAR=1` | CL 客户端兼容性 |
| Engine API + op-node | `RUN_OPNODE=1` | OP Stack Rollup 兼容性 |

### 技术决策

- op-node 无预编译 release，采用 `git clone --depth 1` + `go build` 方式构建（`go install` 与 monorepo 的 replace 指令不兼容）
- 本地 Go < 1.24 时跳过测试并给出清晰提示，CI 中通过 `actions/setup-go@v5` 自动安装