### PR TITLE
fix(executor): sync cached TransactionStatus in EVMCResult move assignment (FIB-179)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ test/*
 
 # Claude Code
 CLAUDE.local.md
+.worktrees/
 .claude/worktrees
 .claude/agents

--- a/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
@@ -40,6 +40,8 @@ bcos::executor_v1::EVMCResult::EVMCResult(EVMCResult&& from) noexcept
 bcos::executor_v1::EVMCResult& bcos::executor_v1::EVMCResult::operator=(EVMCResult&& from) noexcept
 {
     evmc_result::operator=(from);
+    // FIB-179: keep cached TransactionStatus in sync with the moved-from result
+    status = from.status;
     cleanEVMCResult(from);
     return *this;
 }

--- a/transaction-executor/tests/FIB179_180_EVMCResultTest.cpp
+++ b/transaction-executor/tests/FIB179_180_EVMCResultTest.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB179_180_EVMCResultTest.cpp
+ * @date 2026
+ */
+
+#include "../bcos-transaction-executor/EVMCResult.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-protocol/TransactionStatus.h"
+#include <evmc/evmc.h>
+#include <boost/test/unit_test.hpp>
+#include <utility>
+using namespace bcos;
+using namespace bcos::executor_v1;
+using namespace bcos::protocol;
+
+BOOST_AUTO_TEST_SUITE(FIB179_180_EVMCResultTest)
+
+BOOST_AUTO_TEST_CASE(moveAssign_updatesCachedStatus)
+{
+    evmc_result dstResult = {};
+    dstResult.status_code = EVMC_SUCCESS;
+    dstResult.release = nullptr;
+    evmc_result srcResult = {};
+    srcResult.status_code = EVMC_REVERT;
+    srcResult.release = nullptr;
+
+    EVMCResult dst(dstResult);
+    EVMCResult src(srcResult);
+    dst = std::move(src);
+    BOOST_CHECK_EQUAL(dst.status_code, EVMC_REVERT);
+    BOOST_CHECK_EQUAL(dst.status, TransactionStatus::RevertInstruction);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## CertiK preliminary finding FIB-179 (transaction-executor / EVMCResult)

Fixes one Minor (Logical/Coding) finding in `transaction-executor/bcos-transaction-executor/EVMCResult.cpp`. FIB-180 was originally bundled here but is now deferred — rationale in the second section.

### FIB-179 — EVMCResult move assignment dropped the cached transaction status

**Problem.** `EVMCResult` caches a `TransactionStatus status` next to the base `evmc_result`. The move constructor copies both, but `operator=(EVMCResult&&)` assigned only the `evmc_result` subobject and left `status` stale. Move-assigning a result with a different execution status then updated `status_code`/`output` while `status` kept its previous value, so any consumer reading the cached `status` saw an outcome inconsistent with the moved data. The existing `TestEVMCResult.cpp` even documented this as a known bug with a commented-out assertion.

**Fix.** Assign `status = from.status;` in the move-assignment operator before clearing the moved-from object.

**Test.** `FIB179_180_EVMCResultTest::moveAssign_updatesCachedStatus` move-assigns a REVERT result over a SUCCESS result and asserts both `status_code == EVMC_REVERT` and `status == RevertInstruction`.

### FIB-180 — EVMC failure-status mapping: deferred, not fixed here

FIB-180 (Minor) notes that `evmcStatusToTransactionStatus()` has no cases for `EVMC_BAD_JUMP_DESTINATION` / `EVMC_INVALID_MEMORY_ACCESS` (they fall into `default:` and throw `UnknownEVMCStatus`), and that `evmcStatusToErrorMessage()` maps `EVMC_INVALID_MEMORY_ACCESS` to `StackUnderflow` while its message describes an out-of-bounds memory access. The audit classifies it as a reporting-accuracy issue only — Minor, with no state corruption or consensus-safety impact.

We are deferring it because the cost is disproportionate to the benefit:

- The receipt `status` field is consensus-critical. It is field #4 of `TransactionReceiptData` in `bcos-tars-protocol/bcos-tars-protocol/tars/TransactionReceipt.tars`, the receipt's `dataHash` (`TransactionReceiptImpl::calculateHash`) is computed over that `data` struct, and that hash feeds the receipts root in the block header. `evmcResult.status` flows straight into it (`TransactionExecutorImpl.h`, `static_cast<int32_t>(evmcResult.status)`).
- So changing the `TransactionStatus` a failing transaction receives — whether by adding the missing mappings (today `default:` throws) or by introducing a dedicated status value — changes the receipt hash for any transaction that hits those statuses. That is a hardfork-class change: applied unconditionally it forks mixed-version networks and breaks historical-block replay/sync. Doing it safely requires `compatibility_version` / feature-flag gating plus dual-path tests.
- That machinery is out of proportion for a cosmetic status/message refinement, especially since the precise failure reason is already carried in the receipt's human-readable error message (e.g. "Execution tried to read outside memory bounds."). The coarse `status` code being generic loses no diagnostic information.

If FIB-180 is revisited, the correct approach is a feature-gated mapping introduced at a defined `compatibility_version`, not an unconditional change.

Refs: `audit/findings/FIB-179.md` (fixed); `audit/findings/FIB-180.md` (deferred, see above) — CertiK preliminary review, 2026-06-11.
