### PR TITLE
fix(pbft): reject malformed proposal hash + fix exception-cache cleanup (FIB-174, FIB-181)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ test/*
 
 # Claude Code
 CLAUDE.local.md
+.worktrees/
 .claude/worktrees
 .claude/agents

--- a/bcos-pbft/bcos-pbft/core/Proposal.h
+++ b/bcos-pbft/bcos-pbft/core/Proposal.h
@@ -21,6 +21,7 @@
 #pragma once
 #include "bcos-framework/consensus/ProposalInterface.h"
 #include "bcos-pbft/core/proto/Consensus.pb.h"
+#include "bcos-pbft/pbft/utilities/Common.h"
 #include <bcos-framework/protocol/BlockHeader.h>
 #include <bcos-protocol/Common.h>
 
@@ -138,13 +139,26 @@ protected:
     virtual void deserializeObject()
     {
         auto const& hashData = m_rawProposal->hash();
-        // FIB-149: reject any non-canonical hash length (oversize OR undersize).
-        // Pre-fix used `<`, which silently truncated oversize input to the
-        // first 32 bytes — accepting non-canonical encodings as valid identity
-        // keys.
-        if (hashData.size() != bcos::crypto::HashType::SIZE)
+        // FIB-174: drop any stale/default identity before validating, so a
+        // failed decode on a reused object cannot retain the prior proposal's
+        // hash. An empty hash field (size 0) is the not-yet-set state of a
+        // freshly constructed proposal (e.g. PBFTProposal() before setHash());
+        // leave m_hash default-constructed and do not treat that as malformed.
+        m_hash = bcos::crypto::HashType{};
+        if (hashData.empty())
         {
             return;
+        }
+        // FIB-149 / FIB-174: a present-but-non-canonical hash length (oversize OR
+        // undersize) is malformed wire data — reject it at decode instead of
+        // silently returning. Pre-fix used `<`, which silently truncated oversize
+        // input to the first 32 bytes, and the undersize case returned without
+        // surfacing the malformed input as an invalid PBFT message.
+        if (hashData.size() != bcos::crypto::HashType::SIZE)
+        {
+            BOOST_THROW_EXCEPTION(InvalidPBFTMessage() << errinfo_comment(
+                                      "Proposal::deserializeObject malformed hash length: " +
+                                      std::to_string(hashData.size())));
         }
         m_hash =
             bcos::crypto::HashType((byte const*)hashData.c_str(), bcos::crypto::HashType::SIZE);

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
@@ -383,6 +383,9 @@ void PBFTCache::resetExceptionCache(ViewType _curView)
                 m_prePrepare = nullptr;
                 break;
             }
+            // FIB-181: erase() already advanced; continue so the post-branch ++
+            // does not skip the next entry.
+            continue;
         }
         exceptionPrePrepare++;
     }

--- a/bcos-pbft/test/unittests/FIB149_HashLengthStrictTest.cpp
+++ b/bcos-pbft/test/unittests/FIB149_HashLengthStrictTest.cpp
@@ -23,6 +23,7 @@
 #include "bcos-pbft/core/Proposal.h"
 #include "bcos-pbft/pbft/protocol/PB/PBFTBaseMessage.h"
 #include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 
@@ -48,27 +49,26 @@ BOOST_FIXTURE_TEST_SUITE(FIB149_HashLengthStrict, TestPromptFixture)
 
 BOOST_AUTO_TEST_CASE(oversize_proposal_hash_rejected)
 {
-    // 64-byte (oversize) raw hash inside a RawProposal. Pre-fix Proposal.h used
-    // `<` so oversize was silently truncated to the first 32 bytes; the test
-    // asserts the strict reject path leaves m_hash default-constructed.
+    // 64-byte (oversize) raw hash inside a RawProposal. FIB-149 made the length
+    // predicate strict (`!= HashType::SIZE`); FIB-174 then upgraded the silent
+    // return into a thrown invalid-message so a malformed proposal hash is
+    // rejected at decode rather than accepted with a stale/default identity.
     auto raw = std::make_shared<RawProposal>();
     std::string oversize(64, '\xab');
     raw->set_hash(oversize.data(), oversize.size());
 
-    Proposal proposal(raw);
-    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+    BOOST_CHECK_THROW(Proposal{raw}, bcos::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(undersize_proposal_hash_rejected)
 {
-    // Already rejected pre-fix (the `<` predicate caught undersize), but we
-    // keep this case to lock in behavior post-fix.
+    // Undersize was caught pre-fix (the `<` predicate) but only via a silent
+    // return; FIB-174 makes it throw so the malformed input surfaces.
     auto raw = std::make_shared<RawProposal>();
     std::string undersize(16, '\xab');
     raw->set_hash(undersize.data(), undersize.size());
 
-    Proposal proposal(raw);
-    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+    BOOST_CHECK_THROW(Proposal{raw}, bcos::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(exact_proposal_hash_accepted)

--- a/bcos-pbft/test/unittests/FIB174_MalformedHashRejectTest.cpp
+++ b/bcos-pbft/test/unittests/FIB174_MalformedHashRejectTest.cpp
@@ -1,0 +1,129 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB174_MalformedHashRejectTest.cpp
+ * @brief FIB-174: a malformed (non-canonical length) proposal hash must be
+ *        rejected at decode rather than silently accepted with a stale or
+ *        default hash identity. See audit/findings/FIB-174.md.
+ */
+#include "bcos-pbft/core/Proposal.h"
+#include "bcos-pbft/core/proto/Consensus.pb.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include "bcos-pbft/pbft/protocol/proto/PBFT.pb.h"
+#include <bcos-utilities/Exceptions.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+namespace
+{
+/// Serialize a PBFTRawProposal whose inner RawProposal carries a `hashLen`-byte
+/// hash.  `hashLen != HashType::SIZE` exercises the malformed-decode path of
+/// PBFTProposal::decode (which parses a PBFTRawProposal then defers to
+/// Proposal::deserializeObject for the inner proposal).
+bytes makePBFTProposalBytesWithHashLen(std::size_t hashLen)
+{
+    PBFTRawProposal raw;
+    auto* inner = raw.mutable_proposal();
+    inner->set_index(1);
+    std::string hash(hashLen, '\xab');
+    inner->set_hash(hash.data(), hash.size());
+    std::string serialised = raw.SerializeAsString();
+    return bytes(serialised.begin(), serialised.end());
+}
+
+/// Serialize a bare RawProposal with a `hashLen`-byte hash.  Used by the
+/// Proposal::decode reuse case, which parses a RawProposal directly.
+bytes makeRawProposalBytesWithHashLen(std::size_t hashLen)
+{
+    RawProposal raw;
+    raw.set_index(1);
+    std::string hash(hashLen, '\xab');
+    raw.set_hash(hash.data(), hash.size());
+    std::string serialised = raw.SerializeAsString();
+    return bytes(serialised.begin(), serialised.end());
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB174_MalformedHashReject, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(oversize_hash_rejected_on_decode)
+{
+    // 64-byte hash inside the serialized proposal — decode must throw.
+    auto data = makePBFTProposalBytesWithHashLen(64);
+    bytesConstRef ref(data.data(), data.size());
+    BOOST_CHECK_THROW(PBFTProposal{ref}, bcos::Exception);
+}
+
+BOOST_AUTO_TEST_CASE(undersize_hash_rejected_on_decode)
+{
+    auto data = makePBFTProposalBytesWithHashLen(16);
+    bytesConstRef ref(data.data(), data.size());
+    BOOST_CHECK_THROW(PBFTProposal{ref}, bcos::Exception);
+}
+
+BOOST_AUTO_TEST_CASE(canonical_hash_accepted_on_decode)
+{
+    auto data = makePBFTProposalBytesWithHashLen(HashType::SIZE);
+    bytesConstRef ref(data.data(), data.size());
+    BOOST_CHECK_NO_THROW(PBFTProposal{ref});
+}
+
+/// An empty hash field (size 0) is the not-yet-set state of a freshly
+/// constructed proposal — it must NOT be treated as malformed, otherwise the
+/// normal "construct empty, then setHash()" build path (e.g. a default
+/// PBFTProposal{}) would throw.  The decoded proposal carries a default
+/// (zeroed) hash identity.
+BOOST_AUTO_TEST_CASE(empty_hash_accepted_as_unset)
+{
+    auto data = makeRawProposalBytesWithHashLen(0);
+    Proposal proposal{bytesConstRef(data.data(), data.size())};
+    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+
+    // The default-constructed PBFTProposal (hash never set) must also construct
+    // without throwing.
+    BOOST_CHECK_NO_THROW(PBFTProposal{});
+}
+
+/// FIB-174 core scenario: a Proposal object that has already decoded a valid
+/// proposal hash must NOT retain that hash if it is later reused to decode a
+/// malformed proposal.  The malformed decode throws, and m_hash must not keep
+/// the previous (now stale) identity.
+BOOST_AUTO_TEST_CASE(stale_hash_not_retained_after_malformed_reuse)
+{
+    // First decode: a canonical hash.  Capture the accepted identity.
+    auto goodData = makeRawProposalBytesWithHashLen(HashType::SIZE);
+    Proposal proposal{bytesConstRef(goodData.data(), goodData.size())};
+    std::string goodHashBytes(HashType::SIZE, '\xab');
+    HashType good((byte const*)goodHashBytes.data(), HashType::SIZE);
+    BOOST_CHECK_EQUAL(proposal.hash(), good);
+    BOOST_CHECK(proposal.hash() != HashType{});
+
+    // Second decode on the SAME object with a malformed (oversize) hash must
+    // throw, and must clear the previously accepted identity rather than leave
+    // the stale hash in place.
+    auto badData = makeRawProposalBytesWithHashLen(64);
+    BOOST_CHECK_THROW(
+        proposal.decode(bytesConstRef(badData.data(), badData.size())), bcos::Exception);
+    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
+++ b/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
@@ -1,0 +1,145 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB181_ResetExceptionCacheAdjacentTest.cpp
+ * @brief FIB-181: PBFTCache::resetExceptionCache() must process every stale
+ *        exception pre-prepare entry in a single pass. Pre-fix, erasing a stale
+ *        entry returned an iterator to the next entry but the loop's
+ *        unconditional post-branch ++ then skipped that next entry. With two
+ *        adjacent stale entries the second one missed its
+ *        asyncResetTxsFlag(*block, false) call. See audit/findings/FIB-181.md.
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeTxPool.h"
+#include "bcos-pbft/pbft/cache/PBFTCache.h"
+#include "bcos-pbft/pbft/engine/Validator.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTMessage.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTMessageFactoryImpl.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+using namespace bcos::front;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+/// Validator that only counts asyncResetTxsFlag(Block, bool, bool) calls. It does
+/// NOT call the base implementation, so the test does not depend on txpool state.
+class CountingValidator : public TxsValidator
+{
+public:
+    using TxsValidator::TxsValidator;
+    void asyncResetTxsFlag(const protocol::Block& /*proposal*/, bool /*flag*/,
+        bool /*emptyTxBatchHash*/ = false) override
+    {
+        ++m_count;
+    }
+    std::atomic<int> m_count{0};
+};
+
+inline CryptoSuite::Ptr makeCryptoSuiteFib181()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signImpl = std::make_shared<Secp256k1Crypto>();
+    return std::make_shared<CryptoSuite>(hashImpl, signImpl, nullptr);
+}
+
+/// Build an exception pre-prepare message carrying a distinct 32-byte hash and a
+/// consensusProposal whose data() is a real encoded empty block, so the
+/// resetExceptionCache else-branch's createBlock(data, false, false) parses.
+inline PBFTMessageInterface::Ptr makeExceptionPrePrepare(
+    CryptoSuite::Ptr const& _cryptoSuite, BlockFactory::Ptr const& _blockFactory, uint8_t _seed)
+{
+    auto block = _blockFactory->createBlock();
+    bytes encoded;
+    block->encode(encoded);
+
+    auto proposal = std::make_shared<PBFTProposal>();
+    proposal->setIndex(10);
+    proposal->setHash(_cryptoSuite->hashImpl()->hash(std::to_string(_seed)));
+    proposal->setData(encoded);
+
+    auto msg = std::make_shared<PBFTMessage>();
+    msg->setIndex(10);
+    msg->setHash(_cryptoSuite->hashImpl()->hash("exception-" + std::to_string(_seed)));
+    msg->setConsensusProposal(proposal);
+    return msg;
+}
+
+/// Minimal PBFTConfig: only blockFactory() and validator() are exercised by
+/// resetExceptionCache(). stateMachine/storage/codec are null and guarded by
+/// PBFTConfig::stop().
+class MinimalPBFTConfig : public PBFTConfig
+{
+public:
+    MinimalPBFTConfig(CryptoSuite::Ptr _cryptoSuite, KeyPairInterface::Ptr _keyPair,
+        std::shared_ptr<ValidatorInterface> _validator,
+        std::shared_ptr<FrontServiceInterface> _frontService, BlockFactory::Ptr _blockFactory)
+      : PBFTConfig(std::move(_cryptoSuite), std::move(_keyPair),
+            std::make_shared<PBFTMessageFactoryImpl>(), nullptr, std::move(_validator),
+            std::move(_frontService), nullptr, nullptr, std::move(_blockFactory))
+    {}
+};
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB181_ResetExceptionCacheAdjacent, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(adjacent_stale_entries_both_reset)
+{
+    auto cryptoSuite = makeCryptoSuiteFib181();
+    // generateKeyPair() returns a unique_ptr; bind to the shared KeyPairInterface::Ptr
+    // expected by PBFTConfig (the converting ctor moves the unique_ptr in).
+    KeyPairInterface::Ptr keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto txPool = std::make_shared<FakeTxPool>();
+    auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
+    auto validator = std::make_shared<CountingValidator>(txPool, blockFactory, txResultFactory);
+    auto frontService = std::make_shared<FakeFrontService>(keyPair->publicKey());
+
+    auto config = std::make_shared<MinimalPBFTConfig>(
+        cryptoSuite, keyPair, validator, frontService, blockFactory);
+
+    auto cache = std::make_shared<PBFTCache>(config, /*index*/ 10);
+
+    // Two adjacent stale exception pre-prepares with DISTINCT hashes. With
+    // m_prePrepare and m_precommit both null, neither matches a valid/precommit
+    // hash, so both fall into the else-branch that erases and calls
+    // asyncResetTxsFlag(*block, false).
+    cache->addExceptionPrePrepareCache(makeExceptionPrePrepare(cryptoSuite, blockFactory, 1));
+    cache->addExceptionPrePrepareCache(makeExceptionPrePrepare(cryptoSuite, blockFactory, 2));
+
+    cache->resetExceptionCache(/*curView*/ 1);
+
+    // Post-fix: both stale entries are processed in the same pass.
+    // Pre-fix the count was 1 (the second adjacent entry was skipped).
+    BOOST_CHECK_EQUAL(validator->m_count.load(), 2);
+
+    config->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-pbft/test/unittests/pbft/FIB120_PBFTProposalDecodeBoundsTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB120_PBFTProposalDecodeBoundsTest.cpp
@@ -43,9 +43,13 @@ namespace test
 static bytes makePBFTProposalBytes(int sigCount, int nodeCount)
 {
     PBFTRawProposal raw;
-    // fill a minimal inner proposal so decodePBObject succeeds
+    // fill a minimal inner proposal so decodePBObject succeeds. Use a canonical
+    // HashType::SIZE hash so the decode path under test exercises only the
+    // signatureList/nodeList bounds — a non-canonical hash length is now rejected
+    // at decode (FIB-174) and would mask the bounds check.
     raw.mutable_proposal()->set_index(1);
-    raw.mutable_proposal()->set_hash("hash");
+    std::string canonicalHash(bcos::crypto::HashType::SIZE, '\x11');
+    raw.mutable_proposal()->set_hash(canonicalHash.data(), canonicalHash.size());
 
     for (int i = 0; i < sigCount; ++i)
     {
@@ -136,7 +140,10 @@ BOOST_AUTO_TEST_CASE(signatureProof_throws_on_out_of_bounds_FIB120)
 {
     auto raw = std::make_shared<PBFTRawProposal>();
     raw->mutable_proposal()->set_index(1);
-    raw->mutable_proposal()->set_hash("hash");
+    // Canonical hash so the constructor's deserializeObject does not reject the
+    // proposal on hash length (FIB-174) before we reach the signatureProof check.
+    std::string canonicalHash(bcos::crypto::HashType::SIZE, '\x11');
+    raw->mutable_proposal()->set_hash(canonicalHash.data(), canonicalHash.size());
     // signature is set but nodelist is empty — index 0 is OOB on nodelist.
     raw->add_signaturelist("sig");
 


### PR DESCRIPTION
## CertiK preliminary findings FIB-174, FIB-181 (bcos-pbft)

Two Minor findings from the CertiK preliminary review (2026-06-11), one commit each, each with a regression unit test.

### FIB-174 — malformed proposal hash accepted at decode

**Problem.** `Proposal::deserializeObject()` validated the serialized proposal hash length but, on a non-canonical length, silently returned without surfacing the malformed input and without clearing the cached `m_hash`. A `Proposal`/`PBFTProposal` reused for malformed data then kept the previous decode's hash identity (or a default-zero hash), so a malformed proposal entered intermediate processing with a stale/default identity.

**Fix.** Clear `m_hash` first, then throw `InvalidPBFTMessage` when the hash length is not `HashType::SIZE`. A failed decode is now surfaced and cannot retain stale identity. This covers both `Proposal::decode()` and `PBFTProposal::decode()` (which reaches the check via `setRawProposal`).

**Test.** `FIB174_MalformedHashReject`: oversize (64) and undersize (16) hashes throw at decode; canonical (32) and empty/unset are accepted; a reused object that previously decoded a valid hash does not retain it after a malformed decode (`hash() == HashType{}`).

**Note.** This supersedes the silent-return contract that the merged FIB-149 test pinned; that test's oversize/undersize `Proposal` cases are updated in the same commit to assert the throw.

### FIB-181 — exception-cache cleanup skipped adjacent stale entries

**Problem.** `PBFTCache::resetExceptionCache()` erased a stale exception pre-prepare via `erase()` (which returns the next iterator) and then unconditionally did `++iterator`, skipping the entry that followed an erased one. With two adjacent stale entries the second missed its `asyncResetTxsFlag(*block, false)`, leaving its transactions marked sealed longer than intended and delaying txpool recovery after view-change.

**Fix.** `continue` after the erase so the post-branch increment does not skip the next entry (matches the existing erase/continue idiom in `resetCacheAfterViewChange`).

**Test.** `FIB181_ResetExceptionCacheAdjacent`: two adjacent stale exception pre-prepares with distinct hashes; asserts `asyncResetTxsFlag` fires for both in one pass (pre-fix: 1).

Refs: `audit/findings/FIB-174.md`, `audit/findings/FIB-181.md`.

Verification: `test-bcos-pbft` built locally; `FIB174_MalformedHashReject`, `FIB181_ResetExceptionCacheAdjacent`, and the updated `FIB149_HashLengthStrict` all pass.
