### PR TITLE
fix(leader-election): keepalive/campaign/lease/watcher recovery and validation (FIB-173, FIB-175, FIB-176, FIB-177, FIB-178, FIB-182)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ test/*
 
 # Claude Code
 CLAUDE.local.md
+.worktrees/
 .claude/worktrees
 .claude/agents

--- a/bcos-leader-election/src/CampaignConfig.cpp
+++ b/bcos-leader-election/src/CampaignConfig.cpp
@@ -108,7 +108,44 @@ bool CampaignConfig::checkAndUpdateLeaderKey(etcd::Response _response)
                               << LOG_KV("key", m_leaderKey) << LOG_KV("success", ret);
         return false;
     }
-    auto leader = m_memberFactory->createMember(_response.value().as_string());
+    bcos::protocol::MemberInterface::Ptr leader;
+    try
+    {
+        leader = m_memberFactory->createMember(_response.value().as_string());
+    }
+    catch (std::exception const& e)
+    {
+        // FIB-177: a malformed/corrupt etcd leader value must not wedge the
+        // election. Mirror the version==0 recovery path: drop the stale leader
+        // and trigger a fresh campaign so the node can recover instead of
+        // propagating the decode exception up to the watcher callback.
+        ELECTION_LOG(WARNING) << LOG_DESC(
+                                     "checkAndUpdateLeaderKey: malformed leader value, recover")
+                              << LOG_KV("key", m_leaderKey)
+                              << LOG_KV("message", boost::diagnostic_information(e));
+        resetLeader(nullptr);
+        if (m_triggerCampaign)
+        {
+            m_triggerCampaign();
+        }
+        return false;
+    }
+    catch (...)
+    {
+        // FIB-177: createMember may throw a non-std exception; it must not escape
+        // into the watcher callback either. Apply the same drop-stale-leader plus
+        // re-campaign recovery so an exotic throwable cannot wedge the election.
+        ELECTION_LOG(WARNING) << LOG_DESC(
+                                     "checkAndUpdateLeaderKey: malformed leader value (non-std "
+                                     "exception), recover")
+                              << LOG_KV("key", m_leaderKey);
+        resetLeader(nullptr);
+        if (m_triggerCampaign)
+        {
+            m_triggerCampaign();
+        }
+        return false;
+    }
     auto seq = _response.value().modified_index();
     leader->setSeq(seq);
     leader->setLeaseID(_response.value().lease());

--- a/bcos-leader-election/src/CampaignConfig.h
+++ b/bcos-leader-election/src/CampaignConfig.h
@@ -37,7 +37,19 @@ public:
       : ElectionConfig(_etcdEndPoint, _memberFactory, _purpose, _caPath, _certPath, _keyPath)
     {
         m_leaderKey = _leaderKey;
-        m_leaseTTL = _leaseTTL;
+        // FIB-176: leaseTTL is unsigned and feeds directly into the election
+        // timers. A value of 0 yields a 0ms campaign timer and underflows
+        // `leaseTTL() - 1` (the keepAlive interval) to a huge value; a value of
+        // 1 yields a 0s keepAlive interval. Clamp to a safe minimum before any
+        // timer is derived from it.
+        if (_leaseTTL < c_minLeaseTTL)
+        {
+            ELECTION_LOG(WARNING) << LOG_DESC(
+                                         "CampaignConfig: leaseTTL too small, clamp to minimum")
+                                  << LOG_KV("requested", _leaseTTL)
+                                  << LOG_KV("clamped", c_minLeaseTTL);
+        }
+        m_leaseTTL = clampLeaseTTL(_leaseTTL);
         m_self = _self;
         m_self->encode(m_leaderValue);
         ELECTION_LOG(INFO) << LOG_DESC("CampaignConfig") << LOG_KV("selfID", m_self->memberID())
@@ -45,6 +57,15 @@ public:
     }
 
     ~CampaignConfig() override {}
+
+    // FIB-176: minimum lease TTL (seconds). Below this the derived campaign
+    // timer (leaseTTL*1000 ms) and keepAlive interval (leaseTTL-1 s) degenerate
+    // or underflow.
+    static constexpr unsigned c_minLeaseTTL = 2;
+    static unsigned clampLeaseTTL(unsigned _ttl) noexcept
+    {
+        return _ttl < c_minLeaseTTL ? c_minLeaseTTL : _ttl;
+    }
 
     std::string const& leaderKey() const { return m_leaderKey; }
     virtual bcos::protocol::MemberInterface::Ptr fetchLeader();

--- a/bcos-leader-election/src/CampaignConfig.h
+++ b/bcos-leader-election/src/CampaignConfig.h
@@ -107,6 +107,11 @@ public:
         m_self->encode(m_leaderValue);
     }
 
+    // FIB-173: exposed so the election layer can drop the stale self-leader
+    // pointer when the keepAlive heartbeat dies (the etcd lease is gone, so
+    // node-self is no longer the leader).
+    void resetLeader(bcos::protocol::MemberInterface::Ptr _leader);
+
 protected:
     virtual void fetchLeaderInfoFromEtcd();
     virtual void onLeaderKeyChanged(etcd::Response _response);
@@ -125,8 +130,6 @@ protected:
                 self->onLeaderKeyChanged(std::move(response));
             });
     }
-
-    void resetLeader(bcos::protocol::MemberInterface::Ptr _leader);
 
 protected:
     // the leader key that multiple workers compete for, eg: "/consensus"

--- a/bcos-leader-election/src/LeaderElection.cpp
+++ b/bcos-leader-election/src/LeaderElection.cpp
@@ -241,6 +241,27 @@ void LeaderElection::onKeepAliveException(std::exception_ptr _exception)
         ELECTION_LOG(WARNING) << LOG_DESC("onKeepAliveException, restart campaign")
                               << LOG_KV("message", boost::diagnostic_information(e));
     }
+    // FIB-173: the keepAlive heartbeat is dead, so the etcd lease that made
+    // node-self the leader is gone. Drop our reference to the dead keepAlive and
+    // the stale self-leader pointer, and notify the upper layer to leave master
+    // mode BEFORE restarting the campaign. Otherwise node-self keeps believing
+    // it is the leader (and stays in master mode) even though etcd no longer
+    // holds its key, which can produce two masters once another node wins.
+    //
+    // Do NOT call Cancel() on this keepAlive here: this handler runs ON the
+    // keepAlive's own refresh thread, and etcd::KeepAlive::Cancel() joins that
+    // thread — calling it here would self-join and deadlock. The thread is
+    // already terminating (it just raised this exception); moving the shared_ptr
+    // out releases our reference and lets it tear down.
+    {
+        RecursiveGuard l(m_mutex);
+        m_keepAlive.reset();
+    }
+    m_config->resetLeader(nullptr);
+    if (m_onCampaignHandler)
+    {
+        m_onCampaignHandler(false, nullptr);
+    }
     if (m_campaignTimer)
     {
         m_campaignTimer->restart();

--- a/bcos-leader-election/src/LeaderElection.cpp
+++ b/bcos-leader-election/src/LeaderElection.cpp
@@ -71,6 +71,13 @@ void LeaderElection::stop()
 
 std::pair<bool, int64_t> LeaderElection::grantLease()
 {
+    // FIB-175: leasegrant().get() blocks until etcd answers. A stalled or
+    // unreachable etcd would otherwise wedge the campaign thread (and the
+    // campaign timer callback that drives it) indefinitely. The client is armed
+    // with a grpc timeout (set_grpc_timeout in the constructor), so etcd-cpp-apiv3
+    // bounds this blocking get() on its completion-queue wait and returns a
+    // not-ok response once the deadline elapses; callers (campaignLeader) already
+    // fall back to backup + restart the timer on a non-ok result.
     auto response = m_etcdClient->leasegrant(m_config->leaseTTL()).get();
     if (!response.is_ok())
     {

--- a/bcos-leader-election/src/LeaderElection.cpp
+++ b/bcos-leader-election/src/LeaderElection.cpp
@@ -230,6 +230,16 @@ bool LeaderElection::campaignLeader()
                                << LOG_KV("leaderKey", m_config->leaderKey());
             keepAlive->Cancel();
         }
+        // FIB-178: the non-exception failure paths above all re-arm local
+        // recovery (tryToSwitchToBackup + campaign timer restart). The catch-all
+        // previously just returned, leaving the node stuck: no campaign retry is
+        // scheduled and the upper layer is never told to drop master mode. Mirror
+        // the normal failure path so a transient exception self-heals.
+        tryToSwitchToBackup();
+        if (m_campaignTimer)
+        {
+            m_campaignTimer->restart();
+        }
     }
     return false;
 }

--- a/bcos-leader-election/src/LeaderElection.h
+++ b/bcos-leader-election/src/LeaderElection.h
@@ -22,6 +22,7 @@
 #include "CampaignConfig.h"
 #include <bcos-framework/election/LeaderElectionInterface.h>
 #include <bcos-utilities/Timer.h>
+#include <chrono>
 #include <memory>
 namespace bcos
 {
@@ -33,9 +34,24 @@ class LeaderElection : public LeaderElectionInterface,
 public:
     using Ptr = std::shared_ptr<LeaderElection>;
     LeaderElection(CampaignConfig::Ptr _config)
-      : m_config(_config), m_etcdClient(_config->etcdClient())
+      : m_config(_config),
+        m_etcdClient(_config->etcdClient()),
+        // FIB-175: bound every blocking unary etcd op (leasegrant/txn/get) to
+        // roughly one lease period so a stalled or unreachable etcd cannot wedge
+        // the campaign thread forever. Build the duration in chrono's 64-bit
+        // representation (seconds -> milliseconds) so a large leaseTTL cannot
+        // overflow the unsigned multiply before the cast.
+        m_etcdOpTimeout(std::chrono::seconds(m_config->leaseTTL()))
     {
         m_campaignTimer = std::make_shared<Timer>(m_config->leaseTTL() * 1000, "campTimer");
+        // FIB-175: arm the bound as a client-level grpc timeout. etcd-cpp-apiv3
+        // applies this deadline on the completion-queue wait of unary RPCs only;
+        // the watch stream pumps an unbounded cq_.Next() loop and is unaffected,
+        // while a keepalive refresh becomes bounded by one lease period (benign: a
+        // refresh that cannot complete within a full TTL means the lease is gone).
+        // This replaces the previous detached-thread+promise workaround, so a
+        // stalled leasegrant().get() now returns a not-ok response on its own.
+        m_etcdClient->set_grpc_timeout(m_etcdOpTimeout);
     }
     ~LeaderElection() override { stop(); }
     void start() override;
@@ -85,6 +101,10 @@ protected:
     std::function<void(std::exception_ptr)> m_onKeepAliveException;
     std::function<void(bool, bcos::protocol::MemberInterface::Ptr)> m_onCampaignHandler;
     mutable RecursiveMutex m_mutex;
+
+    // FIB-175: upper bound on a single blocking unary etcd op, applied via
+    // etcd::Client::set_grpc_timeout in the constructor.
+    std::chrono::milliseconds m_etcdOpTimeout;
 
     // for trigger campaign after disconnect
     std::shared_ptr<Timer> m_campaignTimer;

--- a/bcos-leader-election/src/WatcherConfig.cpp
+++ b/bcos-leader-election/src/WatcherConfig.cpp
@@ -23,6 +23,8 @@
 #include "bcos-utilities/BoostLog.h"
 #include <algorithm>
 #include <cstddef>
+#include <set>
+#include <utility>
 
 using namespace bcos;
 using namespace bcos::election;
@@ -75,12 +77,42 @@ void WatcherConfig::fetchLeadersInfo()
         return;
     }
     auto const& values = response.values();
+    // FIB-182: this is a full snapshot of m_watchDir. A delete event that
+    // arrives while the watcher is disconnected is never delivered, so the old
+    // logic (add/update only) leaves a stale leader entry in m_keyToLeader
+    // forever. Track every key present in the snapshot and prune any tracked
+    // key that is absent from it.
+    std::set<std::string> snapshotKeys;
     for (auto const& value : values)
     {
+        snapshotKeys.insert(value.key());
         updateLeaderInfo(value);
     }
+    std::vector<std::pair<std::string, bcos::protocol::MemberInterface::Ptr>> prunedMembers;
+    {
+        WriteGuard l(x_keyToLeader);
+        for (auto it = m_keyToLeader.begin(); it != m_keyToLeader.end();)
+        {
+            if (snapshotKeys.count(it->first) != 0)
+            {
+                ++it;
+                continue;
+            }
+            prunedMembers.emplace_back(it->first, it->second);
+            m_keyToLeaderSeq.erase(it->first);
+            it = m_keyToLeader.erase(it);
+        }
+    }
+    // invoke delete callbacks outside the lock to prevent self-deadlock
+    for (auto const& pruned : prunedMembers)
+    {
+        ELECTION_LOG(INFO) << LOG_DESC("fetchLeadersInfo: prune missed-delete leader key")
+                           << LOG_KV("watchDir", m_watchDir) << LOG_KV("leaderKey", pruned.first);
+        onMemberDeleted(pruned.first, pruned.second);
+    }
     ELECTION_LOG(INFO) << LOG_DESC("fetchLeadersInfo success") << LOG_KV("watchDir", m_watchDir)
-                       << LOG_KV("nodesSize", values.size());
+                       << LOG_KV("nodesSize", values.size())
+                       << LOG_KV("prunedSize", prunedMembers.size());
 }
 
 void WatcherConfig::updateLeaderInfo(etcd::Value const& _value)


### PR DESCRIPTION
## CertiK preliminary findings FIB-173/175/176/177/178/182 (bcos-leader-election)

Six Minor findings from the CertiK preliminary review (2026-06-11), one commit each. All are defensive/robustness fixes in the etcd-backed leader-election path.

### FIB-176 — invalid `leaseTTL` not validated before deriving timers
`leaseTTL` (unsigned) was stored unchecked: `0` builds a 0 ms campaign timer and `leaseTTL()-1` underflows to a huge value passed to `etcd::KeepAlive`; `1` yields a 0 s keepalive interval. Fix: add `c_minLeaseTTL=2` + `clampLeaseTTL()` and clamp in the ctor (WARNING when clamped).

### FIB-182 — watcher reconnect snapshot didn't prune deleted keys
`WatcherConfig::fetchLeadersInfo()` only added/updated keys from the `ls()` snapshot and never removed keys absent from it, so a leader key deleted while the watcher was disconnected stayed cached indefinitely (still visible via `getLeaderByKey()`/`getAllLeaders()`; delete handlers never fired). Fix: treat the snapshot as authoritative — under the state lock, erase cached keys absent from the snapshot and fire `onMemberDeleted()` for each outside the lock.

### FIB-173 — stale self-leader state after keepalive failure
`onKeepAliveException()` restarted the campaign timer but did not clear the cached self-leader, so the next campaign short-circuited on the stale `getLeader()==self` and the node kept master state until an external watcher event. Fix: clear the cached self-leader (`resetLeader(nullptr)`, made public) and notify the upper layer to leave master mode before restarting. The dead keepalive is released via `m_keepAlive.reset()` rather than `Cancel()`, because `Cancel()` joins the refresh thread that invokes this very handler (self-deadlock).

### FIB-175 — unbounded blocking etcd lease grant
`grantLease()` called `leasegrant(...).get()` with no timeout/cancellation; a stalled/unreachable etcd wedged the timer-driven campaign thread and `stop()` could not interrupt it. Fix: arm a client-level grpc timeout (`set_grpc_timeout(m_etcdOpTimeout)`, ~one lease period) once in the constructor. In etcd-cpp-apiv3 v0.15.4 this deadline is applied on the completion-queue wait (`cq_.AsyncNext(grpc_deadline())`) of unary RPCs (leasegrant/txn/get) — not a stream `context.set_deadline` — so the blocking `get()` returns a not-ok response when the deadline elapses (callers already fall back to backup + restart the timer). The watch stream pumps an unbounded `cq_.Next()` loop and is unaffected; only a keepalive refresh becomes bounded by one lease period, which is benign (a refresh that cannot complete within a full TTL means the lease is already lost). The duration is built as `chrono::seconds(leaseTTL)` so a large TTL cannot overflow the unsigned multiply before the cast. The same client-level bound also covers the previously-unbounded `txn`/`get` blocking calls.

### FIB-177 — malformed etcd leader value had no bounded recovery
`checkAndUpdateLeaderKey()` decoded the leader value via `createMember()`; a malformed value threw, the startup path only logged it, and nothing cleared/quarantined the bad key, so every fetch re-failed with no progress. Fix: wrap the decode in try/catch; on failure clear the leader and trigger a bounded re-campaign. A `catch (...)` fallback applies the same recovery to non-std throwables so an exotic exception cannot escape into the watcher callback.

### FIB-178 — `campaignLeader()` exception path didn't reschedule recovery
The catch-all logged and cancelled keepalive but returned without restarting the timer or switching to backup, so a transient exception left the node dependent on an external trigger to campaign again. Fix: mirror the non-exception failure paths — `tryToSwitchToBackup()` + restart the campaign timer.

Refs: `audit/findings/FIB-173.md`, `FIB-175.md`, `FIB-176.md`, `FIB-177.md`, `FIB-178.md`, `FIB-182.md`.

Verification: changes pass `clang-format`; type signatures checked against the etcd/cpprestsdk headers, and the FIB-175 `grpc_timeout` semantics confirmed against etcd-cpp-apiv3 v0.15.4 source (the deadline binds the unary completion-queue wait, not the watch stream). Unit tests are not included for this module (it is constructor-bound to a live `etcd::Client` with no in-tree mock); behavior is gated by the CI build (which provides etcd/gRPC) plus review. Each fix is surgical and self-contained.
