### PR TITLE
fix(gateway/pbft): P2P decode bounds, session resource caps, consensus re-arm (FIB-183, FIB-184, FIB-185)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ test/*
 
 # Claude Code
 CLAUDE.local.md
+.worktrees/
 .claude/worktrees
 .claude/agents

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -374,6 +374,16 @@ void Gateway::onReceiveP2PMessage(
 
     auto srcNodeID = options.srcNodeID();
     const auto& dstNodeIDs = options.dstNodeIDs();
+    // FIB-183: a decoded P2PMessage may legitimately carry zero dstNodeIDs (the wire
+    // format allows a src-nodeID count of 0). Indexing dstNodeIDs[0] in that case is an
+    // out-of-bounds read on an empty vector. Drop the message before indexing.
+    if (dstNodeIDs.empty())
+    {
+        GATEWAY_LOG(WARNING) << LOG_BADGE("onReceiveP2PMessage")
+                             << LOG_DESC("empty dstNodeIDs, drop") << LOG_KV("groupID", groupID)
+                             << LOG_KV("moduleID", moduleID) << LOG_KV("seq", _msg->seq());
+        return;
+    }
     auto srcNodeIDPtr = m_gatewayNodeManager->keyFactory()->createKey(srcNodeID);
     auto dstNodeIDPtr = m_gatewayNodeManager->keyFactory()->createKey(dstNodeIDs[0]);
     auto gateway = std::weak_ptr<Gateway>(shared_from_this());

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -19,6 +19,7 @@
  * @date 2021-05-13
  */
 #include "GatewayNodeManager.h"
+#include <cstring>
 
 using namespace std;
 using namespace bcos;
@@ -143,8 +144,18 @@ void GatewayNodeManager::onReceiveStatusSeq(
                                   << LOG_KV("code", _e.errorCode()) << LOG_KV("msg", _e.what());
         return;
     }
-    auto statusSeq =
-        boost::asio::detail::socket_ops::network_to_host_long(*((uint32_t*)_msg->payload().data()));
+    // FIB-183: onReceiveStatusSeq reads a 4-byte sequence via *(uint32_t*)payload().data()
+    // with no size check (same defect class fixed in ServiceV2::onReceiveRouterSeq); a 0-3 byte
+    // payload reads past the decoded buffer. Drop short payloads and use memcpy for the read.
+    if (_msg->payload().size() < sizeof(uint32_t))
+    {
+        NODE_MANAGER_LOG(WARNING) << LOG_DESC("onReceiveStatusSeq short payload, drop")
+                                  << LOG_KV("size", _msg->payload().size());
+        return;
+    }
+    uint32_t rawStatusSeq = 0;
+    std::memcpy(&rawStatusSeq, _msg->payload().data(), sizeof(rawStatusSeq));
+    auto statusSeq = boost::asio::detail::socket_ops::network_to_host_long(rawStatusSeq);
     auto const& from = (_msg->srcP2PNodeID().size() > 0) ? _msg->srcP2PNodeID() : _session->p2pID();
     auto statusSeqChanged = statusChanged(from, statusSeq);
     if (!statusSeqChanged)

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -15,9 +15,9 @@
  * threads it should allow to run simultaneously.") (since ethereum use 2, we
  * modify io_service from 1 to 2) 2.
  */
+#include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Common.h"
-#include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
 #include <boost/algorithm/string.hpp>
@@ -375,12 +375,93 @@ void Host::handshakeServer(const boost::system::error_code& error,
  * @param _s : connected socket(used to init session object)
  */
 // TODO: asyncConnect pass handle to startPeerSession, make use of it
+// FIB-184: reserve a session slot under the global and per-IP caps. Returns false when either
+// cap is reached; the caller must then close the socket without creating a session.
+bool Host::tryAcquireSessionSlot(std::string const& _address)
+{
+    std::lock_guard<std::mutex> lock(x_sessionCountPerIP);
+    if (m_sessionCount.load(std::memory_order_relaxed) >= m_maxConcurrentSessions)
+    {
+        return false;
+    }
+    auto& perIP = m_sessionCountPerIP[_address];
+    if (perIP >= m_maxSessionsPerIP)
+    {
+        return false;
+    }
+    ++perIP;
+    m_sessionCount.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+// FIB-184: release a previously reserved slot. Runs from the session lifetime guard's
+// destructor, i.e. exactly once when the session object is destroyed.
+void Host::releaseSessionSlot(std::string const& _address)
+{
+    std::lock_guard<std::mutex> lock(x_sessionCountPerIP);
+    auto it = m_sessionCountPerIP.find(_address);
+    if (it != m_sessionCountPerIP.end())
+    {
+        if (it->second > 0 && --(it->second) == 0)
+        {
+            m_sessionCountPerIP.erase(it);
+        }
+    }
+    if (m_sessionCount.load(std::memory_order_relaxed) > 0)
+    {
+        m_sessionCount.fetch_sub(1, std::memory_order_relaxed);
+    }
+}
+
+namespace
+{
+// FIB-184: RAII guard bound to a session's lifetime. Constructed after a slot is acquired and
+// attached to the session via setLifetimeGuard(); its destructor (running in ~Session) releases
+// the slot. Held via weak_ptr so a Host destroyed before the session does not crash the guard.
+struct SessionSlotGuard
+{
+    std::weak_ptr<Host> host;
+    std::string address;
+    SessionSlotGuard(std::weak_ptr<Host> _host, std::string _address)
+      : host(std::move(_host)), address(std::move(_address))
+    {}
+    SessionSlotGuard(const SessionSlotGuard&) = delete;
+    SessionSlotGuard& operator=(const SessionSlotGuard&) = delete;
+    ~SessionSlotGuard()
+    {
+        if (auto h = host.lock())
+        {
+            h->releaseSessionSlot(address);
+        }
+    }
+};
+}  // namespace
+
 void Host::startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> const& socket,
     std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>)
 {
     auto weakHost = weak_from_this();
+
+    // FIB-184: enforce the concurrent-session and per-IP caps before creating the session.
+    // Past the limit, close the socket and drop the connection so an authenticated peer cannot
+    // exhaust memory by churning TLS connections.
+    std::string remoteAddress = socket->nodeIPEndpoint().address();
+    if (!tryAcquireSessionSlot(remoteAddress))
+    {
+        HOST_LOG(WARNING) << LOG_BADGE("startPeerSession")
+                          << LOG_DESC("session cap reached, reject connection")
+                          << LOG_KV("address", remoteAddress)
+                          << LOG_KV("sessionCount", m_sessionCount.load())
+                          << LOG_KV("maxConcurrentSessions", m_maxConcurrentSessions)
+                          << LOG_KV("maxSessionsPerIP", m_maxSessionsPerIP);
+        socket->close();
+        return;
+    }
+
     std::shared_ptr<SessionFace> session =
         m_sessionFactory->createSession(*this, socket, m_messageFactory, m_sessionCallbackManager);
+    // Bind a slot-release guard to the session; the slot is freed when the session is destroyed.
+    session->setLifetimeGuard(std::make_shared<SessionSlotGuard>(weakHost, remoteAddress));
 
     m_taskArena.execute([&]() {
         m_asyncGroup.run([weakHost, session = std::move(session), p2pInfo]() {

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -17,7 +17,10 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/system/error_code.hpp>
+#include <atomic>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -104,6 +107,29 @@ public:
 
     void setEnableSslVerify(bool _enableSSLVerify);
 
+    // FIB-184: caps on concurrent inbound sessions to bound memory under TLS connect/close
+    // churn. With no cap, an authenticated peer can open sessions faster than they tear down
+    // and exhaust the heap (each session allocates a recv buffer). These are defaults; see
+    // TODO below about plumbing them through GatewayConfig.
+    // TODO(FIB-184): plumb these limits through GatewayConfig
+    // (p2p.max_concurrent_sessions / p2p.max_sessions_per_ip) instead of hardcoding.
+    constexpr static std::size_t DEFAULT_MAX_CONCURRENT_SESSIONS = 1024;
+    constexpr static std::size_t DEFAULT_MAX_SESSIONS_PER_IP = 32;
+
+    std::size_t maxConcurrentSessions() const { return m_maxConcurrentSessions; }
+    void setMaxConcurrentSessions(std::size_t _limit) { m_maxConcurrentSessions = _limit; }
+    std::size_t maxSessionsPerIP() const { return m_maxSessionsPerIP; }
+    void setMaxSessionsPerIP(std::size_t _limit) { m_maxSessionsPerIP = _limit; }
+    std::size_t currentSessionCount() const { return m_sessionCount.load(); }
+
+    // FIB-184: try to reserve a session slot for the given remote address. Returns true and
+    // increments the global / per-IP counters if both caps allow; returns false (caller must
+    // close the socket) otherwise. The matching releaseSessionSlot() runs from the session's
+    // lifetime guard when the session object is destroyed. Public so the lifetime guard can
+    // release the slot.
+    bool tryAcquireSessionSlot(std::string const& _address);
+    void releaseSessionSlot(std::string const& _address);
+
 protected:
     /// obtain the common name from the subject:
     /// the subject format is: /CN=xx/O=xxx/OU=xxx/ commonly
@@ -173,6 +199,13 @@ protected:
     // Peer black list
     PeerBlackWhitelistInterface::Ptr m_peerBlacklist{nullptr};
     PeerBlackWhitelistInterface::Ptr m_peerWhitelist{nullptr};
+
+    // FIB-184: session-cap accounting.
+    std::size_t m_maxConcurrentSessions{DEFAULT_MAX_CONCURRENT_SESSIONS};
+    std::size_t m_maxSessionsPerIP{DEFAULT_MAX_SESSIONS_PER_IP};
+    std::atomic<std::size_t> m_sessionCount{0};
+    std::map<std::string, std::size_t> m_sessionCountPerIP;
+    std::mutex x_sessionCountPerIP;
 };
 }  // namespace gateway
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -33,10 +33,16 @@
 using namespace bcos;
 using namespace bcos::gateway;
 
-Session::Session(
-    std::shared_ptr<SocketFace> socket, Host& server, size_t _recvBufferSize, bool _forceSize)
+Session::Session(std::shared_ptr<SocketFace> socket, Host& server, size_t _recvBufferSize,
+    [[maybe_unused]] bool _forceSize)
   : m_maxRecvBufferSize(std::max<size_t>(_recvBufferSize, MIN_SESSION_RECV_BUFFER_SIZE)),
-    m_recvBuffer(_forceSize ? _recvBufferSize : MIN_SESSION_RECV_BUFFER_SIZE),
+    // FIB-184: do not force the 512KB floor on every session. Start at the requested/initial size
+    // (the config-validated session_recv_buffer_size for production sessions, a tiny value for
+    // tests) and let doRead grow the buffer up to m_maxRecvBufferSize on demand. Previously the
+    // non-forced path unconditionally allocated MIN_SESSION_RECV_BUFFER_SIZE (512KB) per session,
+    // which let connection churn exhaust the heap. _forceSize is now retained only for ABI/source
+    // compatibility of the signature; both paths honor _recvBufferSize as the initial size.
+    m_recvBuffer(_recvBufferSize),
     m_server(server),
     m_socket(std::move(socket)),
     m_idleCheckTimer(

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -98,10 +98,18 @@ struct Payload
 class Session : public SessionFace, public std::enable_shared_from_this<Session>
 {
 public:
+    // Grow ceiling: the recv buffer never grows beyond this (see Session::doRead grow path).
     constexpr static const std::size_t MIN_SESSION_RECV_BUFFER_SIZE = 512 * 1024UL;
+    // FIB-184: initial recv-buffer size for a freshly created session. Previously every
+    // session unconditionally allocated MIN_SESSION_RECV_BUFFER_SIZE (512KB) up front, so a
+    // flood of unauthenticated/short-lived sessions caused heap exhaustion. Start small and
+    // rely on the existing grow path (doRead grows up to m_maxRecvBufferSize) to expand only
+    // for sessions that actually carry large messages. Must stay well above the message
+    // header length so the first read can always make forward progress.
+    constexpr static const std::size_t INITIAL_SESSION_RECV_BUFFER_SIZE = 16 * 1024UL;
 
     Session(std::shared_ptr<SocketFace> socket, Host& server,
-        size_t _recvBufferSize = MIN_SESSION_RECV_BUFFER_SIZE, bool _forceSize = false);
+        size_t _recvBufferSize = INITIAL_SESSION_RECV_BUFFER_SIZE, bool _forceSize = false);
 
     Session(const Session&) = delete;
     Session(Session&&) = delete;
@@ -152,6 +160,15 @@ public:
         std::function<std::optional<bcos::Error>(SessionFace&, Message&)> handler) override;
 
     void setHostInfo(P2PInfo _hostInfo);
+
+    // FIB-184: attach an opaque object whose lifetime is bound to this session. It is destroyed
+    // exactly when the session object is destroyed, which Host uses to release a session-cap
+    // slot (the guard's destructor decrements the Host counters). Kept opaque so libnetwork
+    // does not depend on the accounting type.
+    void setLifetimeGuard(std::shared_ptr<void> _guard) override
+    {
+        m_lifetimeGuard = std::move(_guard);
+    }
 
     uint32_t maxReadDataSize() const;
     void setMaxReadDataSize(uint32_t _maxReadDataSize);
@@ -244,6 +261,10 @@ public:
     // actual teardown body runs exactly once; all subsequent callers no-op.
     std::atomic_bool m_dropped{false};
     P2PInfo m_hostInfo;
+
+    // FIB-184: opaque guard whose destructor releases the Host session-cap slot. Destroyed with
+    // the session, so the slot is freed exactly once on session teardown.
+    std::shared_ptr<void> m_lifetimeGuard;
 
     struct Writings
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
@@ -58,6 +58,10 @@ public:
 
     virtual NodeIPEndpoint nodeIPEndpoint() const = 0;
 
+    // FIB-184: bind an opaque object to this session's lifetime (released when the session is
+    // destroyed). Non-pure so existing test doubles need not implement it.
+    virtual void setLifetimeGuard(std::shared_ptr<void> /*guard*/) {}
+
     virtual bool active() const = 0;
 
     virtual std::size_t writeQueueSize() = 0;

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -21,6 +21,7 @@
 #include "Common.h"
 #include "P2PMessageV2.h"
 #include "bcos-utilities/BoostLog.h"
+#include <cstring>
 #include <utility>
 
 using namespace bcos;
@@ -187,8 +188,18 @@ void ServiceV2::onReceiveRouterSeq(
                               << LOG_KV("message", _error.what());
         return;
     }
-    auto statusSeq = boost::asio::detail::socket_ops::network_to_host_long(
-        *((uint32_t*)_message->payload().data()));
+    // FIB-183: the router-sequence payload must contain at least a 4-byte sequence number.
+    // A short or empty payload (the smallest attacker-supplied frames are 14-78 bytes total)
+    // would read past the end of the decoded payload buffer. Drop it before dereferencing.
+    if (_message->payload().size() < sizeof(uint32_t))
+    {
+        SERVICE2_LOG(WARNING) << LOG_BADGE("onReceiveRouterSeq") << LOG_DESC("short payload, drop")
+                              << LOG_KV("size", _message->payload().size());
+        return;
+    }
+    uint32_t seq = 0;
+    std::memcpy(&seq, _message->payload().data(), sizeof(seq));
+    auto statusSeq = boost::asio::detail::socket_ops::network_to_host_long(seq);
     if (!tryToUpdateSeq(_session->p2pID(), statusSeq))
     {
         return;

--- a/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
+++ b/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
@@ -1,0 +1,141 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-183: bounds-check under-validated P2P decoded fields
+ * @file FIB183_DecodedFieldBoundsTest.cpp
+ * @date 2026-06-15
+ */
+
+#include "bcos-gateway/Gateway.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
+#include "bcos-gateway/libp2p/ServiceV2.h"
+#include "bcos-gateway/libp2p/router/RouterTableImpl.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+
+BOOST_FIXTURE_TEST_SUITE(FIB183_DecodedFieldBoundsTest, TestPromptFixture)
+
+// Exposes the protected network-entry handler so we can drive it directly.
+// The default-constructed Gateway leaves m_gatewayNodeManager null; the FIB-183
+// guard must return before any member is dereferenced.
+class FakeGatewayFIB183 : public Gateway
+{
+public:
+    FakeGatewayFIB183() : Gateway() {}
+    ~FakeGatewayFIB183() override {}
+    void start() override {}
+    void stop() override {}
+
+    void callOnReceiveP2PMessage(
+        NetworkException const& _e, P2PSession::Ptr _session, std::shared_ptr<P2PMessage> _msg)
+    {
+        onReceiveP2PMessage(_e, _session, _msg);
+    }
+};
+
+// Exposes the protected router-seq handler.
+class FakeServiceV2FIB183 : public ServiceV2
+{
+public:
+    FakeServiceV2FIB183(P2PInfo const& _info, RouterTableFactory::Ptr _factory)
+      : ServiceV2(_info, std::move(_factory))
+    {}
+    void callOnReceiveRouterSeq(
+        NetworkException _error, std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message)
+    {
+        onReceiveRouterSeq(std::move(_error), std::move(_session), std::move(_message));
+    }
+};
+
+// Fix A: a P2PMessage whose decoded options carry zero dstNodeIDs must not be
+// indexed (dstNodeIDs[0] on an empty vector is OOB). The guard drops it before
+// touching m_gatewayNodeManager (which is null here), so no crash occurs.
+BOOST_AUTO_TEST_CASE(EmptyDstNodeIDsIsDropped)
+{
+    // Build a real P2PMessage with a non-zero moduleID (so the front-message
+    // moduleID-decode branch is skipped) and an empty dstNodeIDs list.
+    auto factory = std::make_shared<P2PMessageFactory>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    msg->setPacketType(GatewayMessageType::PeerToPeerMessage);
+
+    P2PMessageOptions options;
+    options.setGroupID("group0");
+    options.setModuleID(42);
+    std::string srcNodeID = "srcNode";
+    options.setSrcNodeID(bytes(srcNodeID.begin(), srcNodeID.end()));
+    // Intentionally leave dstNodeIDs empty.
+    msg->setOptions(options);
+    BOOST_CHECK(msg->options().dstNodeIDs().empty());
+
+    auto gateway = std::make_shared<FakeGatewayFIB183>();
+    // Must not crash / must not dereference the null GatewayNodeManager.
+    BOOST_CHECK_NO_THROW(gateway->callOnReceiveP2PMessage(NetworkException(0, ""), nullptr, msg));
+}
+
+// Sanity check: confirm that a message decoded straight off the wire can legitimately
+// have zero dstNodeIDs, i.e. the OOB precondition is reachable from untrusted input.
+BOOST_AUTO_TEST_CASE(DecodedOptionsCanHaveEmptyDstNodeIDs)
+{
+    P2PMessageOptions options;
+    options.setGroupID("group0");
+    options.setModuleID(7);
+    std::string srcNodeID = "srcNode";
+    options.setSrcNodeID(bytes(srcNodeID.begin(), srcNodeID.end()));
+    // no dstNodeIDs pushed
+
+    bytes buffer;
+    BOOST_CHECK(options.encode(buffer));
+
+    P2PMessageOptions decoded;
+    auto ret = decoded.decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK(ret > 0);
+    BOOST_CHECK(decoded.dstNodeIDs().empty());
+}
+
+// Fix B: onReceiveRouterSeq reads a 4-byte sequence from payload. A 0..3 byte payload
+// must early-return before dereferencing past the payload buffer (and before touching
+// the session, so a null session here is safe).
+BOOST_AUTO_TEST_CASE(ShortRouterSeqPayloadIsDropped)
+{
+    P2PInfo selfInfo;
+    selfInfo.rawP2pID = "selfRawP2pID";
+    selfInfo.p2pID = "selfP2pID";
+    auto routerTableFactory = std::make_shared<RouterTableFactoryImpl>();
+    auto service = std::make_shared<FakeServiceV2FIB183>(selfInfo, routerTableFactory);
+    auto factory = std::make_shared<P2PMessageFactoryV2>();
+
+    for (size_t len = 0; len < sizeof(uint32_t); ++len)
+    {
+        auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+        msg->setPacketType(GatewayMessageType::RouterTableSyncSeq);
+        if (len > 0)
+        {
+            msg->setPayload(bytes(len, 0xAB));
+        }
+        BOOST_CHECK_EQUAL(msg->payload().size(), len);
+        // Session is nullptr on purpose: the guard returns before it is used.
+        BOOST_CHECK_NO_THROW(
+            service->callOnReceiveRouterSeq(NetworkException(0, ""), nullptr, msg));
+    }
+
+    service->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
@@ -1,0 +1,226 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-184: cap sessions and bound per-session recv buffer
+ * @file FIB184_SessionResourceCapTest.cpp
+ * @date 2026-06-15
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/Socket.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/ThreadPool.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+using namespace bcos::crypto;
+
+namespace ba = boost::asio;
+namespace bi = boost::asio::ip;
+
+BOOST_FIXTURE_TEST_SUITE(FIB184_SessionResourceCapTest, TestPromptFixture)
+
+class FakeASIO_FIB184 : public bcos::gateway::ASIOInterface
+{
+public:
+    FakeASIO_FIB184() : m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB184", 1)) {}
+    ~FakeASIO_FIB184() noexcept override {}
+    void asyncReadSome(
+        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
+    {}
+    void strandPost(Base_Handler handler) override { m_handler = std::move(handler); }
+    void stop() override { m_threadPool->stop(); }
+
+protected:
+    Base_Handler m_handler;
+    bcos::ThreadPool::Ptr m_threadPool;
+};
+
+class FakeSocket_FIB184 : public SocketFace
+{
+public:
+    FakeSocket_FIB184()
+      : m_ioContext(std::make_shared<ba::io_context>()),
+        m_sslContext(ba::ssl::context::tlsv12),
+        m_sslSocket(std::make_shared<ba::ssl::stream<bi::tcp::socket>>(*m_ioContext, m_sslContext))
+    {}
+    ~FakeSocket_FIB184() override = default;
+
+    bool isConnected() const override { return m_connected; }
+    void close() override { m_connected = false; }
+    bi::tcp::endpoint remoteEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::endpoint localEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::socket& ref() override { return m_sslSocket->next_layer(); }
+    ba::ssl::stream<bi::tcp::socket>& sslref() override { return *m_sslSocket; }
+    const NodeIPEndpoint& nodeIPEndpoint() const override { return m_nodeIPEndpoint; }
+    void setNodeIPEndpoint(NodeIPEndpoint _nodeIPEndpoint) override
+    {
+        m_nodeIPEndpoint = std::move(_nodeIPEndpoint);
+    }
+    ba::io_context& ioService() override { return *m_ioContext; }
+
+    bool m_connected{true};
+
+private:
+    std::shared_ptr<ba::io_context> m_ioContext;
+    ba::ssl::context m_sslContext;
+    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
+    NodeIPEndpoint m_nodeIPEndpoint;
+};
+
+// Exposes the protected session-cap helpers for direct testing.
+class FakeHost_FIB184 : public bcos::gateway::Host
+{
+public:
+    FakeHost_FIB184(bcos::crypto::Hash::Ptr _hash, std::shared_ptr<ASIOInterface> _asioInterface)
+      : Host(_hash, _asioInterface, nullptr, nullptr)
+    {
+        m_run = true;
+    }
+    bool callTryAcquireSessionSlot(std::string const& addr) { return tryAcquireSessionSlot(addr); }
+    void callReleaseSessionSlot(std::string const& addr) { releaseSessionSlot(addr); }
+};
+
+// FIB-184 Fix 2: a forced-size session uses exactly the requested recv buffer size, not the
+// 512KB floor that was unconditionally applied before.
+BOOST_AUTO_TEST_CASE(ForcedSmallRecvBufferIsHonored)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB184>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    auto session = std::make_shared<Session>(fakeSocket, *fakeHost, /*size*/ 2, /*forceSize*/ true);
+    BOOST_CHECK_EQUAL(session->recvBuffer().recvBufferSize(), 2u);
+    // grow ceiling is still the 512KB minimum
+    BOOST_CHECK_EQUAL(session->m_maxRecvBufferSize, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+
+    session->setSocket(nullptr);
+    fakeSocket->close();
+}
+
+// FIB-184 Fix 2: a default-constructed session no longer allocates the 512KB floor up front;
+// it starts at the (much smaller) lazy initial size and relies on the grow path.
+BOOST_AUTO_TEST_CASE(DefaultRecvBufferStartsSmall)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB184>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    auto session = std::make_shared<Session>(fakeSocket, *fakeHost);
+    BOOST_CHECK_EQUAL(
+        session->recvBuffer().recvBufferSize(), Session::INITIAL_SESSION_RECV_BUFFER_SIZE);
+    BOOST_CHECK_LT(
+        Session::INITIAL_SESSION_RECV_BUFFER_SIZE, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+    // the grow ceiling stays at the 512KB minimum so large messages still fit after growth
+    BOOST_CHECK_EQUAL(session->m_maxRecvBufferSize, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+
+    session->setSocket(nullptr);
+    fakeSocket->close();
+}
+
+// FIB-184 Fix 1: per-IP cap rejects slot acquisition once the limit is hit; releasing a slot
+// makes room again.
+BOOST_AUTO_TEST_CASE(PerIPSessionCapIsEnforced)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    fakeHost->setMaxSessionsPerIP(3);
+    fakeHost->setMaxConcurrentSessions(100);
+
+    const std::string ip = "1.2.3.4";
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    // 4th from the same IP is rejected
+    BOOST_CHECK(!fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 3u);
+
+    // a different IP is unaffected
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("5.6.7.8"));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 4u);
+
+    // releasing one slot for the capped IP makes room for exactly one more
+    fakeHost->callReleaseSessionSlot(ip);
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 3u);
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK(!fakeHost->callTryAcquireSessionSlot(ip));
+}
+
+// FIB-184 Fix 1: global concurrent-session cap rejects once the total limit is hit, even across
+// distinct source IPs.
+BOOST_AUTO_TEST_CASE(GlobalSessionCapIsEnforced)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    fakeHost->setMaxConcurrentSessions(2);
+    fakeHost->setMaxSessionsPerIP(100);
+
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("10.0.0.1"));
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("10.0.0.2"));
+    // global cap reached
+    BOOST_CHECK(!fakeHost->callTryAcquireSessionSlot("10.0.0.3"));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 2u);
+
+    fakeHost->callReleaseSessionSlot("10.0.0.1");
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("10.0.0.3"));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 2u);
+}
+
+// FIB-184 Fix 1: the lifetime guard releases the slot exactly when the session is destroyed.
+BOOST_AUTO_TEST_CASE(LifetimeGuardReleasesSlotOnSessionDestruction)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB184>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    const std::string ip = "9.9.9.9";
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 1u);
+
+    {
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+        // Attach a guard that releases the slot when the session is destroyed, mirroring
+        // Host::startPeerSession. Capture the host by weak_ptr so the lambda guard is safe.
+        std::weak_ptr<Host> weakHost = fakeHost;
+        session->setLifetimeGuard(std::shared_ptr<void>(nullptr, [weakHost, ip](void*) {
+            if (auto h = weakHost.lock())
+            {
+                // FakeHost exposes the protected release helper.
+                std::static_pointer_cast<FakeHost_FIB184>(h)->callReleaseSessionSlot(ip);
+            }
+        }));
+        BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 1u);
+        session->setSocket(nullptr);
+    }
+    // After the session (and its guard) is destroyed, the slot is released.
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 0u);
+
+    fakeSocket->close();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -158,7 +158,41 @@ void PBFTEngine::tryToResendCheckPoint()
         RecursiveGuard l(m_mutex);
         m_cacheProcessor->tryToResendCheckPoint();
     }
+    // FIB-185: run the consensus-timer watchdog on this periodic path.
+    checkConsensusTimerWatchdog();
     m_timer->restart();
+}
+
+void PBFTEngine::checkConsensusTimerWatchdog()
+{
+    // FIB-185: under adversarial consensus input concurrent with session-teardown churn, a node
+    // can commit its last block, emit a single view-change, and then never re-arm its consensus
+    // timer (an inferred race between session-teardown callbacks and the consensus worker/timer).
+    // The wedge signature is: consensus node, in timeout state (a view-change is pending), but the
+    // view-change timer is not running. Detect that and re-arm the timer. restart() only re-arms
+    // the timer; onTimeout (which actually drives the view-change) fires later, so this watchdog
+    // cannot itself emit a view-change or perturb the view-change cache.
+    if (m_stopped.load())
+    {
+        return;
+    }
+    if (!m_config->isConsensusNode())
+    {
+        return;
+    }
+    auto consensusTimer = m_config->timer();
+    if (!consensusTimer)
+    {
+        return;
+    }
+    if (m_config->timeout() && !consensusTimer->running())
+    {
+        PBFT_LOG(WARNING) << LOG_DESC(
+                                 "checkConsensusTimerWatchdog: consensus timer stalled while in "
+                                 "timeout state, re-arm the timer")
+                          << m_config->printCurrentState();
+        consensusTimer->restart();
+    }
 }
 
 void PBFTEngine::restart()
@@ -1495,6 +1529,19 @@ void PBFTEngine::broadcastViewChangeReq()
     // only broadcast to the consensus nodes
     PBFT_LOG(INFO) << LOG_DESC("broadcastViewChangeReq") << printPBFTMsgInfo(viewChangeReq)
                    << LOG_KV("packetSize", encodedData->size());
+    // FIB-185 (Fix 1, deferred): this runs under m_mutex (onTimeout -> triggerTimeout holds it).
+    // task::wait here is already fire-and-forget (it starts the coroutine and returns without
+    // blocking to completion), so it does NOT block the worker on the network round-trip. The
+    // residual coupling is that the coroutine's inline prefix (up to its first suspension inside
+    // FrontService::broadcastMessage) executes on this thread while m_mutex is held; if that
+    // prefix contends a gateway/session lock during teardown churn it can briefly stall the
+    // worker. Fully moving the send off-lock would require dispatching it onto a dedicated
+    // executor, which touches consensus-thread/lifetime ordering near the view-change cache; the
+    // watchdog (checkConsensusTimerWatchdog) recovers a stalled timer without that risk. Splitting
+    // the send off-lock is left as a follow-up so the view-change cache invariants below are not
+    // disturbed.
+    // TODO(FIB-185): move the network broadcast fully off the m_mutex critical section (dedicated
+    // executor) once the consensus-thread ordering around the view-change cache is verified safe.
     task::wait([](FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
         co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT,
             ::ranges::views::single(ref(*encodedData)));

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -113,6 +113,11 @@ public:
 protected:
     virtual void initSendResponseHandler();
     virtual void tryToResendCheckPoint();
+    // FIB-185: watchdog that recovers a stalled consensus timer. If the node is a running
+    // consensus node sitting in the timeout state but the view-change timer is not armed,
+    // re-arm it. Only re-arms the timer (the actual view-change fires later from onTimeout),
+    // so it cannot itself emit a view-change. Invoked from the periodic checkpoint timer path.
+    virtual void checkConsensusTimerWatchdog();
     virtual void onReceivePBFTMessage(bcos::Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
         bytesConstRef _data, SendResponseCallback _sendResponse);
 

--- a/bcos-pbft/test/unittests/pbft/FIB185_ConsensusRearmWatchdogTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB185_ConsensusRearmWatchdogTest.cpp
@@ -1,0 +1,112 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-185: consensus-timer re-arm watchdog
+ * @file FIB185_ConsensusRearmWatchdogTest.cpp
+ * @date 2026-06-15
+ */
+#include "test/unittests/pbft/PBFTFixture.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos::crypto;
+
+namespace bcos
+{
+namespace test
+{
+BOOST_FIXTURE_TEST_SUITE(FIB185_ConsensusRearmWatchdogTest, TestPromptFixture)
+
+inline PBFTFixture::Ptr makeConsensusFixture()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto fixture = createPBFTFixture(cryptoSuite);
+    // make the node a consensus node so the watchdog's isConsensusNode() guard passes.
+    // Note: intentionally do NOT call init() here. init() starts the engine worker and the
+    // periodic checkpoint timer, which would invoke the watchdog concurrently and race the
+    // deterministic timer/timeout state these tests set. The watchdog only reads config +
+    // m_stopped (default false), so the engine need not be started for the unit under test.
+    fixture->appendConsensusNode(fixture->nodeID());
+    return fixture;
+}
+
+// FIB-185: the wedge signature is a consensus node sitting in the timeout state whose
+// view-change timer is not running. The watchdog must re-arm the timer.
+BOOST_AUTO_TEST_CASE(WatchdogRearmsStalledTimer)
+{
+    auto fixture = makeConsensusFixture();
+    auto config = fixture->pbftConfig();
+    BOOST_CHECK(config->isConsensusNode());
+
+    // simulate the wedge: in timeout state but the consensus timer is stopped
+    config->setTimeoutState(true);
+    config->timer()->stop();
+    BOOST_CHECK(config->timeout());
+    BOOST_CHECK(!config->timer()->running());
+
+    fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();
+
+    // the watchdog re-armed the timer
+    BOOST_CHECK(config->timer()->running());
+
+    config->timer()->stop();
+}
+
+// FIB-185: the watchdog must NOT re-arm the timer when the node is not in the timeout state.
+// Re-arming outside timeout would risk spurious view-change activity.
+BOOST_AUTO_TEST_CASE(WatchdogDoesNotRearmWhenNotInTimeout)
+{
+    auto fixture = makeConsensusFixture();
+    auto config = fixture->pbftConfig();
+    BOOST_CHECK(config->isConsensusNode());
+
+    config->setTimeoutState(false);
+    config->timer()->stop();
+    BOOST_CHECK(!config->timeout());
+    BOOST_CHECK(!config->timer()->running());
+
+    fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();
+
+    // not in timeout: the watchdog leaves the stopped timer alone
+    BOOST_CHECK(!config->timer()->running());
+}
+
+// FIB-185: when the timer is already running the watchdog is a no-op (it does not double-arm).
+BOOST_AUTO_TEST_CASE(WatchdogIsNoopWhenTimerRunning)
+{
+    auto fixture = makeConsensusFixture();
+    auto config = fixture->pbftConfig();
+    BOOST_CHECK(config->isConsensusNode());
+
+    config->setTimeoutState(true);
+    config->timer()->start();
+    BOOST_CHECK(config->timer()->running());
+
+    fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();
+
+    // still running, no crash / no double-arm side effect
+    BOOST_CHECK(config->timer()->running());
+
+    config->timer()->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace test
+}  // namespace bcos

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -215,6 +215,9 @@ public:
     // Test-only: inject a committed-block timestamp so FIB-126 monotonicity tests
     // can exercise the timestamp check without a real ledger.
     void setCommittedBlockTimestampForTest(int64_t _ts) { m_ledgerConfig->setTimestamp(_ts); }
+
+    // FIB-185: expose the consensus-timer watchdog for unit testing.
+    void checkConsensusTimerWatchdogForTest() { PBFTEngine::checkConsensusTimerWatchdog(); }
 };
 
 class FakePBFTImpl : public PBFTImpl

--- a/fisco-bcos-air/main.cpp
+++ b/fisco-bcos-air/main.cpp
@@ -38,6 +38,14 @@ int main(int argc, const char* argv[])
 {
     /// set LC_ALL
     setDefaultOrCLocale();
+    // TODO(FIB-184): this terminate handler is the abort amplifier for the log-sink half of
+    // FIB-184. Under TLS connect/close churn an exception is rethrown inside the boost
+    // asynchronous_sink (BoostLogInitializer::sink_t) on the dedicated log thread; being
+    // uncaught there it reaches std::terminate -> abort() here and crashes the node. The real
+    // fix wraps the async sink's formatter/consumer in bcos-utilities/BoostLogInitializer.cpp so
+    // it can never propagate an uncaught exception. That file is outside this change's scope
+    // (gateway/pbft/air only); do NOT "fix" this by swallowing exceptions in the terminate
+    // handler, which would hide unrelated crashes. Tracked for a follow-up bcos-utilities PR.
     std::set_terminate([]() {
         std::cerr << "terminate handler called, print stacks" << std::endl;
         void* trace_elems[50];


### PR DESCRIPTION
## CertiK preliminary findings FIB-183, FIB-184, FIB-185 (gateway / pbft DoS)

Three findings from the CertiK preliminary review (2026-06-11): two Critical DoS (FIB-183/184) and one Medium consensus race (FIB-185). One commit per FIB.

> Mechanism note: the finding text framed FIB-183 as a dangling recv-buffer. That is inaccurate — `P2PMessage::decode` copies parsed fields into owned containers. The real defects are out-of-bounds reads on under-validated decoded fields, fixed below as bounds guards (not a buffer-ownership refactor).

### FIB-183 — out-of-bounds reads on under-validated P2P decoded fields (Critical)

**Problem.** Three handlers dereferenced decoded fields without validating them, reachable by an authenticated peer with crafted/short/empty frames:
- `Gateway::onReceiveP2PMessage` indexed `options.dstNodeIDs()[0]` on a vector that can legitimately be empty.
- `ServiceV2::onReceiveRouterSeq` read a 4-byte sequence via `*(uint32_t*)payload().data()` with no size check (a 0–3 byte payload reads past the buffer; the smallest attacker frames are 14–78 bytes total).
- `GatewayNodeManager::onReceiveStatusSeq` had the same unchecked 4-byte read (found while sweeping for siblings of the above).

**Fix.** Empty-check before indexing `dstNodeIDs`; for both 4-byte-sequence sites, size-check `< sizeof(uint32_t)` then `memcpy` (which also fixes the unaligned read).

**Test.** `FIB183_DecodedFieldBoundsTest` — empty `dstNodeIDs` and short router-seq payloads are dropped without an out-of-bounds read.

### FIB-184 — unbounded session allocation under TLS churn (Critical)

**Problem.** `Host::startPeerSession` had no per-source or global concurrent-session cap, and every session unconditionally allocated a 512KB receive buffer, so TLS connect/close churn exhausts the heap.

**Fix.** (1) Per-IP cap (`DEFAULT_MAX_SESSIONS_PER_IP=32`) + global cap (`DEFAULT_MAX_CONCURRENT_SESSIONS=1024`) in `startPeerSession`, keyed on the remote address; over-limit closes the socket and returns. The decrement is exact-once via an RAII guard bound to the session (released in `~Session`). (2) Stop forcing the 512KB floor: sessions start at the requested/initial size (`INITIAL_SESSION_RECV_BUFFER_SIZE=16KB`; production `createSession` uses the config-validated `session_recv_buffer_size`, which is `>= 2*allowMaxMsgSize`, so the first read always clears the header), with 512KB kept as the grow ceiling and the existing `doRead` grow path untouched.

**Test.** `FIB184_SessionResourceCapTest` — the per-IP/global caps reject the over-limit session, and a session's recv buffer starts at the bounded size rather than 512KB.

### FIB-185 — consensus thread can wedge under adversarial input + teardown churn (Medium, race)

**Problem.** Under adversarial consensus input concurrent with session-teardown churn, a validator's PBFT consensus thread commits its last block, emits a single view-change, and never re-arms (the victim is non-deterministic — a race between teardown callbacks and the consensus timer/worker).

**Fix.** A watchdog, `checkConsensusTimerWatchdog()`, wired into the periodic `tryToResendCheckPoint` path: if a running consensus node is in timeout state but the consensus timer is not running, it restarts the timer (re-arm only — the view-change still fires from `onTimeout`, so the watchdog cannot itself emit one). Guarded on `m_stopped`.

**Test.** `FIB185_ConsensusRearmWatchdogTest` — a stopped timer on an in-timeout consensus node is re-armed by the watchdog; a stopped or non-consensus node is left alone.

### Deferred / follow-ups (called out explicitly)

- **FIB-184 log sink:** a third churn amplifier is an uncaught exception in the boost `asynchronous_sink` reaching the process `std::set_terminate` → `abort`. The real containment belongs in the sink setup in `bcos-utilities/BoostLogInitializer.cpp`, outside this PR's gateway scope. A `TODO(FIB-184)` marks the abort site; a separate bcos-utilities PR should wrap the sink so it cannot propagate an uncaught exception.
- **FIB-184 caps from config:** the limits are runtime-settable but use constexpr defaults; plumbing `p2p.max_concurrent_sessions` / `p2p.max_sessions_per_ip` through `GatewayConfig` is left as a `TODO(FIB-184)`.
- **FIB-185 off-lock send:** `task::wait` (`bcos-task/Wait.h`) is already fire-and-forget — it `start()`s the coroutine and returns without blocking to completion — so the finding's "blocks the worker while holding `m_mutex`" premise is weaker than stated; only the coroutine's inline prefix runs under the lock. Fully moving the send onto a dedicated executor risks the view-change cache ordering, so it is left as a `TODO(FIB-185)`; the watchdog recovers a stalled timer without that risk. FIB-185's root cause is inferred, so this is belt-and-suspenders.

Refs: `audit/findings/FIB-183.md`, `audit/findings/FIB-184.md`, `audit/findings/FIB-185.md`.

Verification: `test-bcos-gateway` and `test-bcos-pbft` built locally; `FIB183_DecodedFieldBoundsTest`, `FIB184_SessionResourceCapTest`, and `FIB185_ConsensusRearmWatchdogTest` pass, alongside the gateway/pbft regression suites (session lifecycle, drop idempotency, message decode, view-change).
