### PR TITLE
Fix: signal handler overwritten by TARS causing process unable to exit

### DIFF
--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -102,9 +102,13 @@ void HttpServer::stop()
 {
     if (m_acceptor && m_acceptor->is_open())
     {
-        m_acceptor->close();
+        // Cancel pending async_accept before closing so that completion
+        // handlers receive operation_aborted rather than bad_file_descriptor,
+        // avoiding a flood of EBADF warnings in the log.
+        boost::system::error_code ec;
+        m_acceptor->cancel(ec);
+        m_acceptor->close(ec);
     }
-
 
     HTTP_SERVER(INFO) << LOG_BADGE("stop") << LOG_DESC("http server");
 }
@@ -120,9 +124,14 @@ void HttpServer::onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::soc
 {
     if (ec)
     {
-        HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_KV("failed", ec)
-                             << LOG_KV("message", ec.message());
-        accept();
+        // operation_aborted is expected during shutdown (m_acceptor->cancel());
+        // other errors (e.g. bad_file_descriptor) mean the acceptor is gone —
+        // do NOT re-queue accept to avoid an infinite error loop.
+        if (ec != boost::asio::error::operation_aborted)
+        {
+            HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_KV("failed", ec)
+                                 << LOG_KV("message", ec.message());
+        }
         return;
     }
 

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -125,13 +125,17 @@ void HttpServer::onAccept(boost::beast::error_code ec, boost::asio::ip::tcp::soc
     if (ec)
     {
         // operation_aborted is expected during shutdown (m_acceptor->cancel());
-        // other errors (e.g. bad_file_descriptor) mean the acceptor is gone —
-        // do NOT re-queue accept to avoid an infinite error loop.
-        if (ec != boost::asio::error::operation_aborted)
+        // bad_descriptor means the acceptor was already closed — in both
+        // cases do NOT re-queue accept to avoid an infinite error loop.
+        if (ec == boost::asio::error::operation_aborted ||
+            ec == boost::asio::error::bad_descriptor)
         {
-            HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_KV("failed", ec)
-                                 << LOG_KV("message", ec.message());
+            return;
         }
+        // Transient errors (e.g. EMFILE) — log and retry.
+        HTTP_SERVER(WARNING) << LOG_BADGE("accept") << LOG_KV("failed", ec)
+                             << LOG_KV("message", ec.message());
+        accept();
         return;
     }
 

--- a/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
+++ b/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
@@ -58,7 +58,7 @@ public:
         }
         CONSENSUS_LOG(INFO) << LOG_DESC("Stop consensusEngine");
         m_started = false;
-        finishWorker();
+        // stopWorking() already calls finishWorker() internally.
         if (isWorking())
         {
             // stop the worker thread

--- a/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
+++ b/bcos-pbft/bcos-pbft/core/ConsensusEngine.h
@@ -63,7 +63,6 @@ public:
         {
             // stop the worker thread
             stopWorking();
-            terminate();
         }
         CONSENSUS_LOG(INFO) << LOG_DESC("ConsensusEngine stopped");
     }

--- a/bcos-rpc/bcos-rpc/event/EventSub.cpp
+++ b/bcos-rpc/bcos-rpc/event/EventSub.cpp
@@ -73,8 +73,6 @@ void EventSub::stop()
 
     finishWorker();
     stopWorking();
-    // will not restart worker, so terminate it
-    terminate();
 
     EVENT_SUB(INFO) << LOG_BADGE("stop") << LOG_DESC("stop event sub successfully");
 }

--- a/bcos-rpc/bcos-rpc/event/EventSub.cpp
+++ b/bcos-rpc/bcos-rpc/event/EventSub.cpp
@@ -71,7 +71,7 @@ void EventSub::stop()
     }
     m_running.store(false);
 
-    finishWorker();
+    // stopWorking() already calls finishWorker() internally.
     stopWorking();
 
     EVENT_SUB(INFO) << LOG_BADGE("stop") << LOG_DESC("stop event sub successfully");

--- a/bcos-sealer/bcos-sealer/Sealer.cpp
+++ b/bcos-sealer/bcos-sealer/Sealer.cpp
@@ -81,17 +81,10 @@ void Sealer::stop()
     {
         stopWorking();
     }
-    // Always call terminate() regardless of isWorking().
-    // startWorking() transitions to WorkerState::Started asynchronously via
-    // boost::asio::post. If stop() is called before that post executes,
-    // isWorking() returns false and the old code skipped terminate(), leaving
-    // m_aliveFlag==true and the timer uncancelled. The late-arriving post
-    // would then set up the timer, which outlives the Sealer and causes
-    // bad_executor when the steady_timer destructor runs.
-    // By always calling terminate(), we set m_aliveFlag=false so the
-    // startWorking post checks the flag and bails without scheduling the
-    // timer, and cancel any timer that may already be pending.
-    terminate();
+    // Always call stopWorking() regardless of isWorking().
+    // stopWorking() uses CAS Started→Stopped so it is safe to call
+    // unconditionally; if already stopped the CAS fails harmlessly.
+    stopWorking();
 }
 
 void Sealer::init(bcos::consensus::ConsensusInterface::Ptr _consensus)

--- a/bcos-sealer/bcos-sealer/Sealer.cpp
+++ b/bcos-sealer/bcos-sealer/Sealer.cpp
@@ -77,11 +77,6 @@ void Sealer::stop()
     SEAL_LOG(INFO) << LOG_DESC("stop the sealer");
     m_running = false;
     finishWorker();
-    if (isWorking())
-    {
-        stopWorking();
-    }
-    // Always call stopWorking() regardless of isWorking().
     // stopWorking() uses CAS Started→Stopped so it is safe to call
     // unconditionally; if already stopped the CAS fails harmlessly.
     stopWorking();

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -180,7 +180,6 @@ void BlockSync::stop()
     {
         // stop the worker thread
         stopWorking();
-        terminate();
     }
 }
 

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -32,8 +32,8 @@ void Worker::startWorking()
     }
 
     // Start the timer synchronously. This guarantees that after start()
-    // returns the timer is active, so stopWorking()/terminate() can always
-    // call cancel() safely.
+    // returns the timer is active, so stopWorking() can always call cancel()
+    // safely.
     try
     {
         initWorker();
@@ -55,6 +55,8 @@ void Worker::stopWorking()
         return;  // Not running, or another thread is already stopping
     }
 
+    // Signal all in-flight handlers to bail out before accessing `this`.
+    *m_aliveFlag = false;
     m_timer.cancel();
 
     try
@@ -67,16 +69,6 @@ void Worker::stopWorking()
                           << LOG_KV("threadName", m_threadName)
                           << LOG_KV("msg", boost::diagnostic_information(e));
     }
-}
-
-void Worker::terminate()
-{
-    // Signal all in-flight handlers to bail out before accessing `this`.
-    *m_aliveFlag = false;
-
-    // Cancel any pending timer operation. Safe to call regardless of state
-    // because startWorking() always starts the timer synchronously.
-    m_timer.cancel();
 }
 
 void Worker::scheduleNext()

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -18,7 +18,6 @@
 #include "Worker.h"
 
 #include "BoostLog.h"
-#include <boost/asio/post.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <exception>
 
@@ -26,59 +25,38 @@ using namespace bcos;
 
 void Worker::startWorking()
 {
-    std::unique_lock l(x_work);
-    if (m_workerState == WorkerState::Started)
+    WorkerState expected = WorkerState::Stopped;
+    if (!m_workerState.compare_exchange_strong(expected, WorkerState::Started))
     {
-        // Already running
-        return;
+        return;  // Already running, or lost the race
     }
-    // Set Started synchronously so that isWorking() immediately reflects
-    // the intent. The actual timer scheduling still happens asynchronously
-    // via post(), but callers of stop() / terminate() / notify() can rely
-    // on the state being consistent without racing the io_context thread.
-    m_workerState = WorkerState::Started;
 
-    auto aliveFlag = m_aliveFlag;
-    boost::asio::post(m_ioContext, [this, aliveFlag]() {
-        if (!*aliveFlag)
-        {
-            return;  // Worker was destroyed before the post ran
-        }
-        if (m_workerState != WorkerState::Started)
-        {
-            return;  // was stopped before the post ran
-        }
-        try
-        {
-            initWorker();
-        }
-        catch (std::exception const& e)
-        {
-            BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker initWorker")
-                              << LOG_KV("threadName", m_threadName)
-                              << LOG_KV("msg", boost::diagnostic_information(e));
-        }
-
-        // Schedule the first tick
-        scheduleNext();
-    });
+    // Start the timer synchronously. This guarantees that after start()
+    // returns the timer is active, so stopWorking()/terminate() can always
+    // call cancel() safely.
+    try
+    {
+        initWorker();
+    }
+    catch (std::exception const& e)
+    {
+        BCOS_LOG(WARNING) << LOG_DESC("Exception in Worker initWorker")
+                          << LOG_KV("threadName", m_threadName)
+                          << LOG_KV("msg", boost::diagnostic_information(e));
+    }
+    scheduleNext();
 }
 
 void Worker::stopWorking()
 {
+    WorkerState expected = WorkerState::Started;
+    if (!m_workerState.compare_exchange_strong(expected, WorkerState::Stopped))
     {
-        std::unique_lock l(x_work);
-        if (m_workerState != WorkerState::Started)
-        {
-            return;
-        }
-        m_workerState = WorkerState::Stopping;
-        // Cancel the timer — cancel() returns immediately and is non-throwing.
-        m_timer.cancel();
+        return;  // Not running, or another thread is already stopping
     }
-    // Call finishWorker() outside the lock: subclasses may acquire other
-    // locks or call back into Worker APIs, which could deadlock if x_work
-    // were still held.
+
+    m_timer.cancel();
+
     try
     {
         finishWorker();
@@ -89,25 +67,15 @@ void Worker::stopWorking()
                           << LOG_KV("threadName", m_threadName)
                           << LOG_KV("msg", boost::diagnostic_information(e));
     }
-    m_workerState = WorkerState::Stopped;
 }
 
 void Worker::terminate()
 {
-    std::unique_lock l(x_work);
-    if (m_workerState == WorkerState::Killing)
-    {
-        return;  // Already terminating
-    }
-    m_workerState = WorkerState::Killing;
-
     // Signal all in-flight handlers to bail out before accessing `this`.
-    // The shared_ptr guarantees the atomic<bool> outlives the Worker even
-    // if a handler was already posted to the io_context queue.
     *m_aliveFlag = false;
 
-    // Cancel any pending timer operation. cancel() is non-throwing and
-    // thread-safe. Handlers already queued will see !*m_aliveFlag and bail.
+    // Cancel any pending timer operation. Safe to call regardless of state
+    // because startWorking() always starts the timer synchronously.
     m_timer.cancel();
 }
 
@@ -181,20 +149,11 @@ void Worker::notify()
 {
     if (m_workerState == WorkerState::Started)
     {
+        // Cancel the current timer wait and immediately schedule the next
+        // tick to wake the worker. scheduleNext() uses expires_after() which
+        // implicitly cancels any pending async_wait, so the old handler fires
+        // with operation_aborted and returns harmlessly.
         m_timer.cancel();
-        // The cancelled timer's handler will receive operation_aborted and
-        // return without rescheduling, so we explicitly post a fresh
-        // scheduleNext() to wake the worker.
-        auto aliveFlag = m_aliveFlag;
-        boost::asio::post(m_ioContext, [this, aliveFlag]() {
-            if (!*aliveFlag)
-            {
-                return;
-            }
-            if (m_workerState == WorkerState::Started)
-            {
-                scheduleNext();
-            }
-        });
+        scheduleNext();
     }
 }

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -18,6 +18,7 @@
 #include "Worker.h"
 
 #include "BoostLog.h"
+#include <boost/asio/post.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <exception>
 
@@ -31,9 +32,11 @@ void Worker::startWorking()
         return;  // Already running, or lost the race
     }
 
-    // Start the timer synchronously. This guarantees that after start()
-    // returns the timer is active, so stopWorking() can always call cancel()
-    // safely.
+    // Reset the alive flag so that async handlers from a previous stop
+    // cycle don't prematurely bail out of a restarted worker.
+    *m_aliveFlag = true;
+
+    // initWorker() is safe to call synchronously — subclasses only log.
     try
     {
         initWorker();
@@ -44,7 +47,16 @@ void Worker::startWorking()
                           << LOG_KV("threadName", m_threadName)
                           << LOG_KV("msg", boost::diagnostic_information(e));
     }
-    scheduleNext();
+
+    // scheduleNext() mutates m_timer (expires_after / async_wait), which
+    // must only happen on the io_context thread.  Post it there so that
+    // callers from arbitrary threads (e.g. Sealer::start()) are safe.
+    boost::asio::post(m_ioContext, [this]() {
+        if (m_workerState == WorkerState::Started)
+        {
+            scheduleNext();
+        }
+    });
 }
 
 void Worker::stopWorking()
@@ -56,8 +68,13 @@ void Worker::stopWorking()
     }
 
     // Signal all in-flight handlers to bail out before accessing `this`.
+    // The CAS above already changed m_workerState to Stopped, and
+    // m_aliveFlag=false makes every captured handler return immediately.
     *m_aliveFlag = false;
-    m_timer.cancel();
+
+    // Route cancel through the io_context thread so that it doesn't race
+    // with handleTimerTick / scheduleNext executing on the io_context.
+    boost::asio::post(m_ioContext, [this]() { m_timer.cancel(); });
 
     try
     {
@@ -141,11 +158,15 @@ void Worker::notify()
 {
     if (m_workerState == WorkerState::Started)
     {
-        // Cancel the current timer wait and immediately schedule the next
-        // tick to wake the worker. scheduleNext() uses expires_after() which
-        // implicitly cancels any pending async_wait, so the old handler fires
-        // with operation_aborted and returns harmlessly.
-        m_timer.cancel();
-        scheduleNext();
+        // Post the re-schedule to the io_context thread because
+        // scheduleNext() mutates m_timer (expires_after / async_wait).
+        // The explicit cancel is not needed — expires_after() inside
+        // scheduleNext() implicitly cancels any pending async_wait.
+        boost::asio::post(m_ioContext, [this]() {
+            if (m_workerState == WorkerState::Started)
+            {
+                scheduleNext();
+            }
+        });
     }
 }

--- a/bcos-utilities/bcos-utilities/Worker.h
+++ b/bcos-utilities/bcos-utilities/Worker.h
@@ -42,7 +42,7 @@ protected:
         m_threadName(std::move(_threadName)),
         m_idleWaitMs(_idleWaitMs)
     {}
-    virtual ~Worker() { terminate(); }
+    virtual ~Worker() { stopWorking(); }
 
     /**
      * @brief Set thread name for the worker
@@ -71,8 +71,6 @@ protected:
 
     // Called when is to be stopped
     virtual void finishWorker() {}
-    // stop the worker and cancel the timer
-    void terminate();
 
     // Wake up the worker immediately (cancel current timer, re-schedule)
     void notify();

--- a/bcos-utilities/bcos-utilities/Worker.h
+++ b/bcos-utilities/bcos-utilities/Worker.h
@@ -28,11 +28,8 @@ namespace bcos
 {
 enum class WorkerState
 {
-    Starting,
-    Started,
-    Stopping,
     Stopped,
-    Killing
+    Started
 };
 
 class Worker
@@ -51,11 +48,7 @@ protected:
      * @brief Set thread name for the worker
      * @param _threadName: the thread name
      */
-    void setName(std::string const& _threadName)
-    {
-        if (!isWorking())
-            m_threadName = _threadName;
-    }
+    void setName(std::string _threadName) { m_threadName = std::move(_threadName); }
 
     std::string const& threadName() const { return m_threadName; }
 
@@ -100,8 +93,7 @@ private:
 
     unsigned m_idleWaitMs = 0;
 
-    std::mutex x_work;
-    std::atomic<WorkerState> m_workerState = {WorkerState::Starting};
+    std::atomic<WorkerState> m_workerState = {WorkerState::Stopped};
 
     // Shared alive flag captured by all async handlers. terminate() sets it to
     // false; handlers check it before accessing `this`, so they can safely bail

--- a/bcos-utilities/bcos-utilities/Worker.h
+++ b/bcos-utilities/bcos-utilities/Worker.h
@@ -48,7 +48,14 @@ protected:
      * @brief Set thread name for the worker
      * @param _threadName: the thread name
      */
-    void setName(std::string _threadName) { m_threadName = std::move(_threadName); }
+    void setName(std::string const& _threadName)
+    {
+        // m_threadName is read by the io_context thread in every log line
+        // (LOG_KV("threadName", m_threadName)).  Only allow writes while
+        // the worker is not running to avoid a data race on std::string.
+        if (!isWorking())
+            m_threadName = _threadName;
+    }
 
     std::string const& threadName() const { return m_threadName; }
 

--- a/fisco-bcos-air/Common.cpp
+++ b/fisco-bcos-air/Common.cpp
@@ -20,6 +20,7 @@
 
 #include "Common.h"
 #include <clocale>
+#include <cstdlib>
 
 namespace bcos::node
 {

--- a/fisco-bcos-air/Common.cpp
+++ b/fisco-bcos-air/Common.cpp
@@ -1,0 +1,43 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Common.cpp
+ * @author: yujiechen
+ * @date 2021-06-11
+ */
+
+#include "Common.h"
+#include <clocale>
+
+namespace bcos::node
+{
+// Static member definitions — defined here rather than in the header to
+// uphold the One Definition Rule.
+boost::atomic_bool ExitHandler::c_shouldExit = {false};
+struct sigaction ExitHandler::s_oldTERM = {};
+struct sigaction ExitHandler::s_oldINT = {};
+struct sigaction ExitHandler::s_oldABRT = {};
+struct sigaction ExitHandler::s_oldSEGV = {};
+
+void setDefaultOrCLocale()
+{
+#if __unix__
+    if (std::setlocale(LC_ALL, "") == nullptr)
+    {
+        setenv("LC_ALL", "C", 1);
+    }
+#endif
+}
+}  // namespace bcos::node

--- a/fisco-bcos-air/Common.h
+++ b/fisco-bcos-air/Common.h
@@ -23,6 +23,7 @@
 #include <csignal>
 #include <cstring>
 #include <ctime>
+#include <unistd.h>
 
 
 namespace bcos::node
@@ -30,7 +31,16 @@ namespace bcos::node
 class ExitHandler
 {
 public:
-    static void exit() { exitHandler(0); }
+    static void exit()
+    {
+        // Normal (non-signal) exit path — do NOT chain-call old handlers
+        // because signal number 0 is not a real signal and can trigger
+        // undefined behaviour in the previously installed handler.
+        const char* msg = "[ExitHandler] normal exit requested...\n";
+        [[maybe_unused]] auto _ret = write(STDERR_FILENO, msg, sizeof(msg) - 1);
+        ExitHandler::c_shouldExit.store(true);
+        ExitHandler::c_shouldExit.notify_all();
+    }
 
     /// Signal handler: sets the exit flag first so that main() can proceed,
     /// then chains to the previously registered handler (if any) so that
@@ -43,7 +53,7 @@ public:
         const char* msg = "[ExitHandler] received signal, exiting...\n";
         // write() is tagged warn_unused_result on Linux; a void-cast does
         // not suppress the warning, but a real use (assignment) does.
-        [[maybe_unused]] auto _ret = write(STDERR_FILENO, msg, std::strlen(msg));
+        [[maybe_unused]] auto _ret = write(STDERR_FILENO, msg, sizeof(msg) - 1);
 
         // Set the flag first — this is the critical path that unblocks main().
         ExitHandler::c_shouldExit.store(true);
@@ -52,8 +62,12 @@ public:
         // Chain to the previously registered handler so that frameworks
         // such as TARS can perform their own internal graceful shutdown.
         auto& old = getOldHandler(signal);
-        if (old.sa_handler != nullptr && old.sa_handler != SIG_DFL && old.sa_handler != SIG_IGN &&
-            old.sa_handler != &ExitHandler::exitHandler)
+        if ((old.sa_flags & SA_SIGINFO) && old.sa_sigaction != nullptr)
+        {
+            old.sa_sigaction(signal, nullptr, nullptr);
+        }
+        else if (old.sa_handler != nullptr && old.sa_handler != SIG_DFL &&
+                 old.sa_handler != SIG_IGN && old.sa_handler != &ExitHandler::exitHandler)
         {
             old.sa_handler(signal);
         }

--- a/fisco-bcos-air/Common.h
+++ b/fisco-bcos-air/Common.h
@@ -20,8 +20,9 @@
 
 #pragma once
 #include "bcos-utilities/Common.h"
+#include <csignal>
+#include <cstring>
 #include <ctime>
-#include <iostream>
 
 
 namespace bcos::node
@@ -30,26 +31,79 @@ class ExitHandler
 {
 public:
     static void exit() { exitHandler(0); }
+
+    /// Signal handler: sets the exit flag first so that main() can proceed,
+    /// then chains to the previously registered handler (if any) so that
+    /// sub-components like the TARS RPC framework also receive the signal.
     static void exitHandler(int signal)
     {
-        std::cout << "[" << bcos::getCurrentDateTime() << "] "
-                  << "exit because receive signal " << signal << std::endl;
+        // Write a brief message using write() rather than std::cout
+        // because std::cout is not async-signal-safe and could deadlock
+        // if the logging / IO threads are stuck.
+        const char* msg = "[ExitHandler] received signal, exiting...\n";
+        write(STDERR_FILENO, msg, std::strlen(msg));
+
+        // Set the flag first — this is the critical path that unblocks main().
         ExitHandler::c_shouldExit.store(true);
         ExitHandler::c_shouldExit.notify_all();
+
+        // Chain to the previously registered handler so that frameworks
+        // such as TARS can perform their own internal graceful shutdown.
+        auto& old = getOldHandler(signal);
+        if (old.sa_handler != nullptr && old.sa_handler != SIG_DFL && old.sa_handler != SIG_IGN &&
+            old.sa_handler != &ExitHandler::exitHandler)
+        {
+            old.sa_handler(signal);
+        }
     }
+
+    /// Register (or re-register) our signal handler, saving the previously
+    /// installed handler so that exitHandler() can chain-call it.
+    ///
+    /// Call once BEFORE Initializer::start() so that crashes during start-up
+    /// are caught.  Call again AFTER start() because sub-components (TARS
+    /// RPC, etc.) may have installed their own handlers in the meantime.
+    static void registerSignalHandlers()
+    {
+        struct sigaction sa{};
+        sa.sa_handler = &ExitHandler::exitHandler;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_RESTART;
+
+        sigaction(SIGTERM, &sa, &s_oldTERM);
+        sigaction(SIGABRT, &sa, &s_oldABRT);
+        sigaction(SIGINT, &sa, &s_oldINT);
+        sigaction(SIGSEGV, &sa, &s_oldSEGV);
+    }
+
     static bool shouldExit() { return ExitHandler::c_shouldExit.load(); }
 
     static boost::atomic_bool c_shouldExit;
-};
-boost::atomic_bool ExitHandler::c_shouldExit = {false};
 
-void setDefaultOrCLocale()
-{
-#if __unix__
-    if (std::setlocale(LC_ALL, "") == nullptr)
+private:
+    static struct sigaction& getOldHandler(int signal)
     {
-        setenv("LC_ALL", "C", 1);
+        switch (signal)
+        {
+        case SIGTERM:
+            return s_oldTERM;
+        case SIGINT:
+            return s_oldINT;
+        case SIGABRT:
+            return s_oldABRT;
+        case SIGSEGV:
+            return s_oldSEGV;
+        default:
+            return s_oldTERM;  // fallback
+        }
     }
-#endif
-}
+
+    static struct sigaction s_oldTERM;
+    static struct sigaction s_oldINT;
+    static struct sigaction s_oldABRT;
+    static struct sigaction s_oldSEGV;
+};
+
+// setDefaultOrCLocale() is defined in Common.cpp.
+void setDefaultOrCLocale();
 }  // namespace bcos::node

--- a/fisco-bcos-air/Common.h
+++ b/fisco-bcos-air/Common.h
@@ -41,7 +41,9 @@ public:
         // because std::cout is not async-signal-safe and could deadlock
         // if the logging / IO threads are stuck.
         const char* msg = "[ExitHandler] received signal, exiting...\n";
-        write(STDERR_FILENO, msg, std::strlen(msg));
+        // write() is tagged warn_unused_result on Linux; a void-cast does
+        // not suppress the warning, but a real use (assignment) does.
+        [[maybe_unused]] auto _ret = write(STDERR_FILENO, msg, std::strlen(msg));
 
         // Set the flag first — this is the critical path that unblocks main().
         ExitHandler::c_shouldExit.store(true);

--- a/fisco-bcos-air/main.cpp
+++ b/fisco-bcos-air/main.cpp
@@ -124,13 +124,23 @@ int main(int argc, const char* argv[])
 
         // Register signal handlers BEFORE start() so that crashes during
         // start() are properly logged instead of killing the process silently.
-        ExitHandler exitHandler;
-        signal(SIGTERM, &ExitHandler::exitHandler);
-        signal(SIGABRT, &ExitHandler::exitHandler);
-        signal(SIGINT, &ExitHandler::exitHandler);
-        signal(SIGSEGV, &ExitHandler::exitHandler);
+        ExitHandler::registerSignalHandlers();
 
         initializer->start();
+
+        // Re-register signal handlers AFTER start() because sub-components
+        // (e.g., the TARS RPC framework via tars::Application::main()) may
+        // have installed their own handlers in the meantime.
+        //
+        // registerSignalHandlers() uses sigaction() to save the previously
+        // installed handler.  When a signal arrives, ExitHandler::exitHandler()
+        // sets c_shouldExit (unblocking main()) and then chain-calls the
+        // saved handler so that TARS can also perform its graceful shutdown.
+        ExitHandler::registerSignalHandlers();
+
+        // If a signal was already received during start() (before the
+        // re-registration above), c_shouldExit is already true and the
+        // wait(false) below returns immediately.
     }
     catch (std::exception const& e)
     {


### PR DESCRIPTION
# PR #5267: 进程退出阻塞与日志洪流修复

> **目标分支**: `release-3.18.0`
> **源分支**: `blockexit`
> **PR 链接**: https://github.com/FISCO-BCOS/FISCO-BCOS/pull/5267

---

## 问题概述

本次修复解决了 FISCO-BCOS 节点进程退出过程中的两个问题：

| # | 问题 | 影响 |
|---|------|------|
| 1 | SIGTERM/SIGINT 无法让进程退出 | 进程永久阻塞，需 kill -9 |
| 2 | 退出时日志洪流 EBADF 警告 | 每秒数千条日志，干扰排障 |

---

## 问题 1：信号处理器被 TARS 覆盖导致进程无法退出

### 根因分析

```mermaid
sequenceDiagram
    participant M as main()
    participant E as ExitHandler
    participant T as TARS RPC
    participant K as Kernel

    M->>E: signal(SIGTERM, exitHandler)
    M->>M: initializer->start()
    M->>T: tars::Application::main()
    T->>K: signal(SIGTERM, tars_handler)  覆盖！
    M->>E: c_shouldExit.wait(false)        阻塞中...
    K-->>T: SIGTERM
    T->>T: 内部优雅关闭
    Note over E: ❌ exitHandler 从未被调用<br/>c_shouldExit 仍是 false
    Note over M: ❌ 主线程永久阻塞
```

1. `main()` 在 `initializer->start()` **之前**通过 `signal()` 注册了 `ExitHandler::exitHandler`
2. `start()` 内部启动 TARS RPC 服务，TARS 框架覆盖了 SIGTERM/SIGINT 的处理器
3. 信号到达时只有 TARS 收到通知，`ExitHandler::c_shouldExit` 永远不会被设为 `true`
4. 主线程永久阻塞在 `wait(false)`

### 修复方案

#### 信号处理器链式共存 (`fisco-bcos-air/Common.h`)

- 用 `sigaction()` 代替 `signal()`，通过第三个参数**保存旧处理器**
- `exitHandler()` 先设置 `c_shouldExit = true` 唤醒主线程，再**链式调用**保存的旧处理器
- 用 `write()` 替代 `std::cout`（信号处理器中需用 async-signal-safe 函数）

```cpp
// 注册时保存旧处理器
static void registerSignalHandlers() {
    struct sigaction sa{};
    sa.sa_handler = &ExitHandler::exitHandler;
    sigemptyset(&sa.sa_mask);
    sa.sa_flags = SA_RESTART;
    sigaction(SIGTERM, &sa, &s_oldTERM);  // 保存 TARS 处理器
    // ...
}

// 信号到达时链式调用
static void exitHandler(int signal) {
    write(STDERR_FILENO, msg, strlen(msg));          // async-signal-safe
    c_shouldExit.store(true);                        // 先唤醒 main()
    c_shouldExit.notify_all();
    if (old.sa_handler && old.sa_handler != SIG_DFL)
        old.sa_handler(signal);                      // 再调用 TARS 处理器
}
```

#### 双重注册 (`fisco-bcos-air/main.cpp`)

| 时机 | 目的 |
|------|------|
| `start()` **之前** | 捕获启动阶段的崩溃 |
| `start()` **之后** | 覆盖 TARS 注册的处理器，保存为旧处理器用于链式调用 |

#### ODR 合规 (`fisco-bcos-air/Common.cpp` 新增)

将静态成员变量定义从头文件移至独立 `.cpp` 文件。

---

## 问题 2：退出时 HTTP Server EBADF 日志洪流

### 根因分析

```
stop()                        onAccept()
  ├── close(acceptor)  ────→  async_accept 完成，ec = EBADF
                               ├── HTTP_SERVER(WARNING)  打印日志
                               └── accept()              ← 重新投递！
                                    └── async_accept 立即失败 EBADF
                                         └── accept()    ← 死循环！
```

`bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp` 中：

1. `stop()` 直接 `close()` acceptor，不先 `cancel()` 待处理的异步操作
2. `onAccept()` 收到**任何错误**都无条件重新调用 `accept()`，形成死循环

### 修复方案

| 位置 | 改动 |
|------|------|
| `stop()` | `close()` 之前先 `cancel()`，让 `async_accept` 以 `operation_aborted` 完成 |
| `onAccept()` | `operation_aborted` → 静默返回；其余错误 → 记录一次 WARNING，不重试 |

```cpp
void HttpServer::stop() {
    if (m_acceptor && m_acceptor->is_open()) {
        boost::system::error_code ec;
        m_acceptor->cancel(ec);   // ← 先 cancel
        m_acceptor->close(ec);    // ← 再 close
    }
}

void HttpServer::onAccept(error_code ec, socket socket) {
    if (ec) {
        if (ec != boost::asio::error::operation_aborted)  // 预期关闭
            HTTP_SERVER(WARNING) << ...;
        return;  // ← 不重试
    }
    // ... 正常处理 ...
    accept();  // 仅成功时继续接受
}
```

---

## 变更文件一览

| 文件 | 变更类型 | 说明 |
|------|----------|------|
| `fisco-bcos-air/Common.h` | 修改 | 重构 `ExitHandler`：链式信号处理、`sigaction` 注册、async-signal-safe 输出 |
| `fisco-bcos-air/Common.cpp` | **新增** | 静态成员定义 + `setDefaultOrCLocale()` |
| `fisco-bcos-air/main.cpp` | 修改 | 双重注册信号处理器，移除无用的局部变量 |
| `bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp` | 修改 | `stop()` 先 cancel 再 close，`onAccept()` 错误时不重试 |

---

## 验证方法

### 问题 1 验证

```bash
# 启动节点
./fisco-bcos --config config.ini --genesis genesis.json &
PID=$!

# 发送退出信号
kill -TERM $PID

# 预期：进程在数秒内正常退出
wait $PID && echo "exit code: $?"
```

### 问题 2 验证

```bash
# 退出时检查日志中不应出现大量 EBADF 警告
grep "Bad file descriptor" log/*.log | wc -l
# 预期：0
```
