### PR TITLE
refactor(rpc): eth_chainId reads from LedgerConfig (A6.9)

### DIFF
--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -82,20 +82,16 @@ task::Task<void> EthEndpoint::coinbase(const Json::Value&, Json::Value& response
 }
 task::Task<void> EthEndpoint::chainId(const Json::Value&, Json::Value& response)
 {
+    // Reads via LedgerConfig (not a raw SYS_CONFIG single-key read) so that L2-mode
+    // governance (SystemConfig.sol via L2ConfigLoader, wired in A4) flows through one
+    // path. getLedgerConfig over-fetches (~5 storage reads) per call; per plan decision,
+    // RPC-side caching is deferred to Phase B.
     auto const ledger = m_nodeService->ledger();
-    auto config = co_await ledger::getSystemConfig(*ledger, ledger::SYSTEM_KEY_WEB3_CHAIN_ID);
+    auto const ledgerConfig = co_await ledger::getLedgerConfig(*ledger);
     Json::Value result;
-    if (config.has_value())
+    if (ledgerConfig->chainId().has_value())
     {
-        try
-        {
-            auto [chainId, _] = config.value();
-            result = toQuantity(std::stoull(chainId));
-        }
-        catch (...)
-        {
-            result = "0x0";  // 0x0 for default
-        }
+        result = toQuantity(fromEvmC(ledgerConfig->chainId().value()));
     }
     else
     {

--- a/bcos-rpc/test/unittests/rpc/EthEndpointSystemConfigTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthEndpointSystemConfigTest.cpp
@@ -1,0 +1,111 @@
+/**
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthEndpointSystemConfigTest.cpp
+ * @brief EthEndpoint::chainId() must source from LedgerConfig (A6.9 / PR-6).
+ *
+ * In L2 mode the SystemConfigPrecompiled (0x1000) is disabled and L2ConfigLoader
+ * (PR-4) fills LedgerConfig::chainId per block from SystemConfig.sol's
+ * getChainConfig(). EthEndpoint must therefore read chainId from LedgerConfig
+ * (getLedgerConfig -> fetchAllSystemConfigs) rather than parsing it itself, so
+ * what dApps observe via eth_chainId is L2 governance.
+ */
+
+#include "../common/RPCFixture.h"
+#include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+
+class EthSystemConfigFixture : public RPCFixture
+{
+public:
+    EthSystemConfigFixture()
+    {
+        rpc = factory->buildLocalRpc(groupInfo, nodeService);
+        web3JsonRpc = rpc->web3JsonRpc();
+        BOOST_TEST(web3JsonRpc != nullptr);
+    }
+
+    Json::Value request(std::string_view req)
+    {
+        Json::Value value;
+        Json::Reader reader;
+        std::promise<bcos::bytes> promise;
+        web3JsonRpc->onRPCRequest(
+            req, [&promise](bcos::bytes resp) { promise.set_value(std::move(resp)); });
+        auto jsonBytes = promise.get_future().get();
+        std::string_view json((char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    }
+
+    static void validRespCheck(Json::Value const& resp)
+    {
+        BOOST_TEST(!resp.isMember("error"));
+        BOOST_TEST(resp.isMember("result"));
+        BOOST_TEST(resp["jsonrpc"].asString() == "2.0");
+    }
+
+    Rpc::Ptr rpc;
+    Web3JsonRpcImpl::Ptr web3JsonRpc;
+};
+
+BOOST_FIXTURE_TEST_SUITE(EthEndpointSystemConfigTest, EthSystemConfigFixture)
+
+// Contract 1: eth_chainId returns the value carried by LedgerConfig.
+// The mock's getLedgerConfig path reads web3_chain_id through fetchAllSystemConfigs
+// (the same row SystemConfig.sol governs in L2), so setting it here and reading it
+// back over the wire proves the endpoint consumes LedgerConfig::chainId().
+BOOST_AUTO_TEST_CASE(chainIdFromLedgerConfig)
+{
+    constexpr uint64_t kChainId = 11155111ULL;  // sepolia
+    m_ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, std::to_string(kChainId));
+
+    auto resp = request(R"({"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]})");
+    validRespCheck(resp);
+    BOOST_TEST(resp["id"].asInt64() == 1);
+    BOOST_TEST(fromQuantity(resp["result"].asString()) == kChainId);
+}
+
+// Contract 2: the value flows through LedgerConfig's 256-bit chainId, NOT a raw
+// scalar read. A chainId larger than uint64::max round-trips correctly only via
+// LedgerConfig::chainId() (an evmc_uint256be parsed by boost::lexical_cast<u256>).
+// The previous raw path (std::stoull(web3_chain_id)) would have thrown out_of_range
+// and degraded the response to "0x0". A correct big value is therefore positive
+// evidence that LedgerConfig is the source.
+BOOST_AUTO_TEST_CASE(chainIdRoutesThroughLedgerConfigNotRawScalar)
+{
+    // 2^64 + 1 = 18446744073709551617, unrepresentable as uint64.
+    const std::string bigChainId = "18446744073709551617";
+    m_ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, bigChainId);
+
+    auto resp = request(R"({"jsonrpc":"2.0","id":2,"method":"eth_chainId","params":[]})");
+    validRespCheck(resp);
+    BOOST_TEST(resp["id"].asInt64() == 2);
+    // Expected hex of 2^64 + 1.
+    BOOST_TEST(resp["result"].asString() == "0x10000000000000001");
+    // Guard against the old degraded behaviour.
+    BOOST_TEST(resp["result"].asString() != "0x0");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
## Summary

Refactor `EthEndpoint::eth_chainId` to source the chain id from `LedgerConfig` (`getLedgerConfig` → `fetchAllSystemConfigs`) instead of calling `ledger::getSystemConfig("web3_chain_id")` directly against the SYS_CONFIG table.

## Why

Preparation for OP-Stack L2 mode (FISCO-BCOS L2 spec §A6). In L2 mode the SystemConfig precompile is disabled — `LedgerConfig` is the only valid source for chain-config values, populated each block from `SystemConfig.sol`'s `getChainConfig()` via the loader. In pbft mode `fetchAllSystemConfigs` still routes to SYS_CONFIG internally, so wire behavior is unchanged.

## What changes

- `bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp::eth_chainId`: rewritten to consume `LedgerConfig::chainId()` (~18 lines net change in the endpoint body).
- `bcos-rpc/test/unittests/rpc/EthEndpointSystemConfigTest.cpp` (new, 111 lines): two cases — pbft mode with a populated `LedgerConfig` (verifies wire encoding of the `0x...` chain id string) and the empty-`LedgerConfig` case (chain id 0 surfaces as a clean error, not a silent `"0x0"`).

## Coverage

Covers A6.9 of the L2 OP-Stack precompile-predeploys plan. Independent of the other A6 PRs — can be reviewed and merged on its own. The OP-Stack `SystemConfig.sol` predeploy that ultimately populates `LedgerConfig.chainId` in L2 mode arrives in a separate PR; this PR only changes which field in `LedgerConfig` `eth_chainId` reads.

## Test plan

- [ ] CI green
- [ ] `cmake --build build --target test-bcos-rpc -j && ./build/bcos-rpc/test/test-bcos-rpc --run_test=EthEndpointSystemConfigTest`
- [ ] Manual: run a pbft node, hit `eth_chainId` via JSON-RPC, verify the value matches `[chain].web3_chain_id` in `config.genesis`