### PR TITLE
Replace TBB GC arena with io_context-based deferred destruction via IOServicePool

### DIFF
--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -297,7 +297,8 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     if (baselineSchedulerConfig.parallel)
     {
         auto parallelScheduler =
-            std::make_shared<scheduler_v1::SchedulerParallelImpl<GlobalStateMutableStorage>>();
+            std::make_shared<scheduler_v1::SchedulerParallelImpl<GlobalStateMutableStorage>>(
+                m_ioServicePool);
         parallelScheduler->m_grainSize = baselineSchedulerConfig.grainSize;
         parallelScheduler->m_maxConcurrency = baselineSchedulerConfig.maxThread;
         std::tie(m_baselineSchedulerHolder, m_setBaselineSchedulerBlockNumberNotifier) =
@@ -312,7 +313,8 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     }
     else
     {
-        auto serialScheduler = std::make_shared<scheduler_v1::SchedulerSerialImpl>();
+        auto serialScheduler =
+            std::make_shared<scheduler_v1::SchedulerSerialImpl>(m_ioServicePool);
         std::tie(m_baselineSchedulerHolder, m_setBaselineSchedulerBlockNumberNotifier) =
             scheduler_v1::BaselineSchedulerInitializer::build(m_globalStateStorageInitializer,
                 m_protocolInitializer->blockFactory(), serialScheduler,

--- a/transaction-scheduler/bcos-transaction-scheduler/GC.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/GC.h
@@ -8,7 +8,9 @@ namespace bcos::scheduler_v1
 {
 class GC
 {
-    std::atomic<size_t> m_pendingCount{0};
+    // Shared ownership so that in-flight deferred lambdas can safely
+    // decrement the counter even after the GC object itself is destroyed.
+    std::shared_ptr<std::atomic<size_t>> m_pendingCount = std::make_shared<std::atomic<size_t>>(0);
     bcos::IOServicePool::Ptr m_ioServicePool;
 
 public:
@@ -18,21 +20,21 @@ public:
     // per-call payload is unusually large or small.
     static constexpr size_t MAX_PENDING_GC = 64;
 
-    explicit GC(bcos::IOServicePool::Ptr ioServicePool)
-      : m_ioServicePool(std::move(ioServicePool))
+    explicit GC(bcos::IOServicePool::Ptr ioServicePool) : m_ioServicePool(std::move(ioServicePool))
     {}
 
     void collect(auto&&... resources)
     {
+        auto& counter = *m_pendingCount;
         // Optimistically reserve a slot. fetch_add is a single RMW that never
         // retries; if we observe the pre-increment value already at or above
         // the cap, roll back and fall through to synchronous destruction. The
         // queue itself never exceeds the cap because over-reservers never
         // enqueue; only the counter can briefly overshoot before the matching
         // fetch_sub, and that transient is not observable outside this class.
-        if (m_pendingCount.fetch_add(1, std::memory_order_relaxed) >= MAX_PENDING_GC)
+        if (counter.fetch_add(1, std::memory_order_relaxed) >= MAX_PENDING_GC)
         {
-            m_pendingCount.fetch_sub(1, std::memory_order_relaxed);
+            counter.fetch_sub(1, std::memory_order_relaxed);
             // Backpressure: destroy synchronously in the caller's scope.
             [[maybe_unused]] auto tuple =
                 std::make_tuple(std::forward<decltype(resources)>(resources)...);
@@ -40,11 +42,12 @@ public:
         }
 
         auto& ioService = m_ioServicePool->getIOService();
-        boost::asio::defer(*ioService,
-            [this, resources = std::make_tuple(
-                       std::forward<decltype(resources)>(resources)...)]() noexcept {
+        auto pendingCount = m_pendingCount;
+        boost::asio::post(*ioService,
+            [pendingCount, resources = std::make_tuple(
+                               std::forward<decltype(resources)>(resources)...)]() noexcept {
                 (void)resources;
-                m_pendingCount.fetch_sub(1, std::memory_order_relaxed);
+                pendingCount->fetch_sub(1, std::memory_order_relaxed);
             });
     }
 };

--- a/transaction-scheduler/bcos-transaction-scheduler/GC.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/GC.h
@@ -1,5 +1,6 @@
 #pragma once
-#include <oneapi/tbb/task_arena.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <boost/asio/defer.hpp>
 #include <atomic>
 #include <tuple>
 
@@ -7,39 +8,44 @@ namespace bcos::scheduler_v1
 {
 class GC
 {
-    inline static std::atomic<size_t> s_pendingCount{0};
+    std::atomic<size_t> m_pendingCount{0};
+    bcos::IOServicePool::Ptr m_ioServicePool;
 
 public:
     // Cap on in-flight deferred-destruction tasks. Above this we destroy
-    // synchronously to bound the backlog when the low-priority GC arena is
-    // starved by high-priority work. Sized for "a few blocks worth" of
-    // contexts; tune if per-call payload is unusually large or small.
+    // synchronously to bound the backlog when the io_context pool is
+    // starved. Sized for "a few blocks worth" of contexts; tune if
+    // per-call payload is unusually large or small.
     static constexpr size_t MAX_PENDING_GC = 64;
 
-    static void collect(auto&&... resources)
-    {
-        static tbb::task_arena arena(1, 1, tbb::task_arena::priority::low);
+    explicit GC(bcos::IOServicePool::Ptr ioServicePool)
+      : m_ioServicePool(std::move(ioServicePool))
+    {}
 
+    void collect(auto&&... resources)
+    {
         // Optimistically reserve a slot. fetch_add is a single RMW that never
         // retries; if we observe the pre-increment value already at or above
         // the cap, roll back and fall through to synchronous destruction. The
         // queue itself never exceeds the cap because over-reservers never
         // enqueue; only the counter can briefly overshoot before the matching
         // fetch_sub, and that transient is not observable outside this class.
-        if (s_pendingCount.fetch_add(1, std::memory_order_relaxed) >= MAX_PENDING_GC)
+        if (m_pendingCount.fetch_add(1, std::memory_order_relaxed) >= MAX_PENDING_GC)
         {
-            s_pendingCount.fetch_sub(1, std::memory_order_relaxed);
+            m_pendingCount.fetch_sub(1, std::memory_order_relaxed);
             // Backpressure: destroy synchronously in the caller's scope.
             [[maybe_unused]] auto tuple =
                 std::make_tuple(std::forward<decltype(resources)>(resources)...);
             return;
         }
 
-        arena.enqueue([resources = std::make_tuple(
-                           std::forward<decltype(resources)>(resources)...)]() noexcept {
-            (void)resources;
-            s_pendingCount.fetch_sub(1, std::memory_order_relaxed);
-        });
+        auto& ioService = m_ioServicePool->getIOService();
+        boost::asio::defer(*ioService,
+            [this, resources = std::make_tuple(
+                       std::forward<decltype(resources)>(resources)...)]() noexcept {
+                (void)resources;
+                m_pendingCount.fetch_sub(1, std::memory_order_relaxed);
+            });
     }
 };
 }  // namespace bcos::scheduler_v1

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -143,12 +143,18 @@ constexpr static auto DEFAULT_MAX_CONCURRENCY = 8UL;
 template <class MutableStorageType>
 class SchedulerParallelImpl
 {
+    GC m_gc;
+
 public:
     constexpr static bool isSchedulerParallelImpl = true;
     using MutableStorage = MutableStorageType;
 
     size_t m_grainSize = DEFAULT_GRAIN_SIZE;
     size_t m_maxConcurrency = DEFAULT_MAX_CONCURRENCY;
+
+    explicit SchedulerParallelImpl(bcos::IOServicePool::Ptr ioServicePool)
+      : m_gc(std::move(ioServicePool))
+    {}
 
     task::Task<void> mergeLastStorage(auto& storage, auto& lastStorage)
     {
@@ -244,7 +250,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_5);
                         if (hasRAW.test())
                         {
-                            GC::collect(std::move(chunk));
+                            m_gc.collect(std::move(chunk));
                             return {};
                         }
 
@@ -259,7 +265,7 @@ public:
                                 hasRAW.test_and_set();
                                 PARALLEL_SCHEDULER_LOG(DEBUG)
                                     << "Detected RAW Intersection:" << index;
-                                GC::collect(std::move(chunk));
+                                m_gc.collect(std::move(chunk));
                                 return {};
                             }
                         }
@@ -299,7 +305,7 @@ public:
                                 << chunk->count();
                             task::tbb::syncWait(
                                 storage2::merge(lastStorage, mutableStorage(chunk->storageView())));
-                            GC::collect(std::move(chunk));
+                            m_gc.collect(std::move(chunk));
                         }
                         else
                         {
@@ -309,7 +315,7 @@ public:
             context);
 
         task::tbb::syncWait(mergeLastStorage(storage, lastStorage));
-        GC::collect(std::move(writeSet));
+        m_gc.collect(std::move(writeSet));
         if (offset < count)
         {
             PARALLEL_SCHEDULER_LOG(DEBUG)
@@ -345,7 +351,7 @@ public:
         arena.execute([&]() {
             auto retryCount = executeSinglePass(
                 storage, executor, blockHeader, ledgerConfig, contexts, m_grainSize);
-            GC::collect(std::move(contexts));
+            m_gc.collect(std::move(contexts));
             PARALLEL_SCHEDULER_LOG(INFO) << "Parallel execute block retry count: " << retryCount;
         });
 

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
@@ -21,8 +21,14 @@ namespace bcos::scheduler_v1
 
 class SchedulerSerialImpl
 {
+    GC m_gc;
+
 public:
     constexpr static auto MIN_TRANSACTION_GRAIN_SIZE = 16;
+
+    explicit SchedulerSerialImpl(bcos::IOServicePool::Ptr ioServicePool)
+      : m_gc(std::move(ioServicePool))
+    {}
 
     template <class Storage, executor_v1::TransactionExecutor<Storage> TransactionExecutor>
     task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage& storage,
@@ -116,7 +122,7 @@ public:
                         }));
         });
 
-        GC::collect(std::move(contexts));
+        m_gc.collect(std::move(contexts));
         co_return receipts;
     }
 };

--- a/transaction-scheduler/benchmark/benchmarkScheduler.cpp
+++ b/transaction-scheduler/benchmark/benchmarkScheduler.cpp
@@ -16,6 +16,7 @@
 #include "bcos-transaction-executor/precompiled/PrecompiledManager.h"
 #include "bcos-transaction-scheduler/SchedulerParallelImpl.h"
 #include "bcos-transaction-scheduler/SchedulerSerialImpl.h"
+#include <bcos-utilities/IOServicePool.h>
 #include "transaction-executor/tests/TestBytecode.h"
 #include <benchmark/benchmark.h>
 #include <boost/throw_exception.hpp>
@@ -53,6 +54,7 @@ struct Fixture
     MultiLayerStorageType m_multiLayerStorage;
     bcos::bytes m_helloworldBytecodeBinary;
 
+    bcos::IOServicePool::Ptr m_ioServicePool;
     PrecompiledManager m_precompiledManager;
     TransactionExecutorImpl m_executor;
     std::variant<std::monostate, SchedulerSerialImpl, SchedulerParallelImpl<MutableStorage>>
@@ -90,13 +92,15 @@ struct Fixture
         bcos::executor::GlobalHashImpl::g_hashImpl = std::make_shared<bcos::crypto::Keccak256>();
         boost::algorithm::unhex(helloworldBytecode, std::back_inserter(m_helloworldBytecodeBinary));
 
+        m_ioServicePool = std::make_shared<bcos::IOServicePool>(1, "benchmarkGC");
+
         if constexpr (parallel)
         {
-            m_scheduler.emplace<SchedulerParallelImpl<MutableStorage>>();
+            m_scheduler.emplace<SchedulerParallelImpl<MutableStorage>>(m_ioServicePool);
         }
         else
         {
-            m_scheduler.emplace<SchedulerSerialImpl>();
+            m_scheduler.emplace<SchedulerSerialImpl>(m_ioServicePool);
         }
 
         ledger::Features features;

--- a/transaction-scheduler/tests/FIB100_RevertWAWCorruptionTest.cpp
+++ b/transaction-scheduler/tests/FIB100_RevertWAWCorruptionTest.cpp
@@ -139,7 +139,8 @@ BOOST_AUTO_TEST_CASE(revertedLaterChunkMustNotOverwriteEarlierWrite)
         }
 
         MockRevertExecutor executor;
-        SchedulerParallelImpl<MutableStorage> scheduler;
+        auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "testFIB100GC");
+        SchedulerParallelImpl<MutableStorage> scheduler(ioServicePool);
         scheduler.m_grainSize = 1;       // each tx is its own chunk
         scheduler.m_maxConcurrency = 2;  // allow the two chunks to overlap
 

--- a/transaction-scheduler/tests/FIB110_GCBackpressureTest.cpp
+++ b/transaction-scheduler/tests/FIB110_GCBackpressureTest.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "bcos-transaction-scheduler/GC.h"
+#include <bcos-utilities/IOServicePool.h>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
 #include <chrono>
@@ -31,8 +32,8 @@ using namespace bcos::scheduler_v1;
 namespace
 {
 // Resource with an observable destructor used to verify GC paths.
-// Optionally blocks on a shared gate so a single instance can pin the
-// single-threaded GC arena thread, forcing the queue to fill up.
+// Optionally blocks on a shared gate so a single instance can pin an
+// io_context thread, forcing the queue to fill up.
 struct Resource
 {
     static inline std::atomic<int> destroyed{0};
@@ -86,26 +87,32 @@ BOOST_AUTO_TEST_CASE(MaxPendingGCConstant)
 
 BOOST_AUTO_TEST_CASE(NormalCollectWorks)
 {
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "gcTest");
+    GC gc(ioServicePool);
+
     auto ptr = std::make_shared<int>(42);
     BOOST_CHECK_EQUAL(ptr.use_count(), 1);
-    GC::collect(std::move(ptr));
+    gc.collect(std::move(ptr));
     BOOST_CHECK(!ptr);
 }
 
 BOOST_AUTO_TEST_CASE(CollectMultipleResources)
 {
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "gcTest");
+    GC gc(ioServicePool);
+
     auto ptr1 = std::make_shared<int>(1);
     auto ptr2 = std::make_shared<std::string>("hello");
-    GC::collect(std::move(ptr1), std::move(ptr2));
+    gc.collect(std::move(ptr1), std::move(ptr2));
     BOOST_CHECK(!ptr1);
     BOOST_CHECK(!ptr2);
 }
 
 // Core regression: when the deferred-destruction queue is at capacity,
 // the next collect() MUST destroy synchronously instead of growing the
-// backlog. We pin the GC arena's single thread with a Blocker resource
+// backlog. We pin an io_context thread with a Blocker resource
 // whose destructor waits on a gate, then prove:
-//   1. While the arena is blocked, pending climbs to MAX_PENDING_GC.
+//   1. While a thread is blocked, pending climbs to MAX_PENDING_GC.
 //   2. The (MAX_PENDING_GC + 1)-th call destructs in the caller's thread
 //      (observable: destroyed counter ticks before we open the gate).
 BOOST_AUTO_TEST_CASE(BackpressureForcesSynchronousDestruction)
@@ -115,10 +122,15 @@ BOOST_AUTO_TEST_CASE(BackpressureForcesSynchronousDestruction)
     std::promise<void> gatePromise;
     Resource::gate = gatePromise.get_future().share();
 
-    // 1. Pin the GC arena with a blocker. Its lambda body runs (decrementing
-    //    pending), then its capture is destroyed, parking the arena thread
+    // Use a single-thread pool so that one blocker can pin the sole
+    // io_context thread.
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "gcTest");
+    GC gc(ioServicePool);
+
+    // 1. Pin the io_context thread with a blocker. Its lambda body runs,
+    //    then its capture is destroyed, parking the io_context thread
     //    inside gate.wait().
-    GC::collect(Resource{true});
+    gc.collect(Resource{true});
 
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
     while (!Resource::blockerStarted.load(std::memory_order_acquire))
@@ -126,27 +138,27 @@ BOOST_AUTO_TEST_CASE(BackpressureForcesSynchronousDestruction)
         if (std::chrono::steady_clock::now() > deadline)
         {
             gatePromise.set_value();  // unblock so process can exit
-            BOOST_FAIL("GC arena did not start running blocker within 5s");
+            BOOST_FAIL("GC io_context thread did not start running blocker within 5s");
         }
         std::this_thread::yield();
     }
-    // Arena is now stuck in the blocker's destructor. pending==0.
+    // io_context thread is now stuck in the blocker's destructor. pending==0.
 
     // 2. Saturate the queue exactly to capacity. Nothing runs because the
-    //    arena thread is parked.
+    //    io_context thread is parked.
     for (size_t i = 0; i < GC::MAX_PENDING_GC; ++i)
     {
-        GC::collect(Resource{false});
+        gc.collect(Resource{false});
     }
     BOOST_CHECK_EQUAL(Resource::destroyed.load(std::memory_order_relaxed), 0);
 
     // 3. The next call must hit the synchronous fallback in this thread,
     //    so destroyed ticks immediately (still no async work has run).
-    GC::collect(Resource{false});
+    gc.collect(Resource{false});
     BOOST_CHECK_EQUAL(Resource::destroyed.load(std::memory_order_relaxed), 1);
 
-    // 4. Release the arena and wait for it to drain so we don't leave a
-    //    blocked thread for the rest of the test binary to deal with.
+    // 4. Release the io_context thread and wait for it to drain so we don't
+    //    leave a blocked thread for the rest of the test binary to deal with.
     gatePromise.set_value();
     auto const expected = static_cast<int>(GC::MAX_PENDING_GC) + 2;
     deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
@@ -154,7 +166,7 @@ BOOST_AUTO_TEST_CASE(BackpressureForcesSynchronousDestruction)
     {
         if (std::chrono::steady_clock::now() > deadline)
         {
-            BOOST_FAIL("GC arena did not drain after gate opened within 5s");
+            BOOST_FAIL("GC io_context did not drain after gate opened within 5s");
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }

--- a/transaction-scheduler/tests/testSchedulerParallel.cpp
+++ b/transaction-scheduler/tests/testSchedulerParallel.cpp
@@ -78,7 +78,8 @@ BOOST_AUTO_TEST_CASE(simple)
 {
     task::syncWait([&, this]() -> task::Task<void> {
         MockExecutorParallel executor;
-        SchedulerParallelImpl<MutableStorage> scheduler;
+        auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "testParallelGC");
+        SchedulerParallelImpl<MutableStorage> scheduler(ioServicePool);
 
         bcostars::protocol::BlockHeaderImpl blockHeader(
             [inner = bcostars::BlockHeader()]() mutable { return std::addressof(inner); });
@@ -173,7 +174,8 @@ BOOST_AUTO_TEST_CASE(conflict)
 {
     task::syncWait([&, this]() -> task::Task<void> {
         MockConflictExecutor executor;
-        SchedulerParallelImpl<MutableStorage> scheduler;
+        auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "testParallelGC");
+        SchedulerParallelImpl<MutableStorage> scheduler(ioServicePool);
 
         auto view1 = multiLayerStorage.fork();
         view1.newMutable();

--- a/transaction-scheduler/tests/testSchedulerSerial.cpp
+++ b/transaction-scheduler/tests/testSchedulerSerial.cpp
@@ -60,7 +60,9 @@ public:
             std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr)),
         receiptFactory(cryptoSuite),
         checkpointBackend(backendStorage),
-        multiLayerStorage(checkpointBackend)
+        multiLayerStorage(checkpointBackend),
+        ioServicePool(std::make_shared<bcos::IOServicePool>(1, "testSerialGC")),
+        scheduler(ioServicePool)
     {}
 
     bcos::crypto::CryptoSuite::Ptr cryptoSuite;
@@ -68,6 +70,7 @@ public:
     BackendStorage backendStorage;
     CheckpointBackend checkpointBackend;
     MultiLayerStorage<MutableStorage, void, CheckpointBackend> multiLayerStorage;
+    bcos::IOServicePool::Ptr ioServicePool;
     SchedulerSerialImpl scheduler;
 
     crypto::Hash::Ptr hashImpl = std::make_shared<bcos::crypto::Keccak256>();


### PR DESCRIPTION
## 变更说明

将 `GC` 类的异步析构机制从 TBB 低优先级 `task_arena` 迁移到 `boost::asio::io_context` + `IOServicePool`。

### 动机

原先 `GC` 使用 TBB 的 `task_arena`（`priority::low`）作为异步析构池，在高负载场景下低优先级 arena 可能被高优先级 TBB 任务饿死，从而影响 TBB 整体吞吐量。改用 `IOServicePool` 配合 `boost::asio::defer()` 可以将析构工作从 TBB 线程池中分离出来，避免与计算任务争抢 TBB 资源。

### 核心改动

- **`GC.h`**：从纯静态类改为实例类，构造函数接受 `bcos::IOServicePool::Ptr`，`collect()` 使用 `boost::asio::defer` 将析构任务投递到独立的 io_context 线程池。反压机制（`MAX_PENDING_GC` 上限 + 同步回退）保持不变。
- **`SchedulerSerialImpl.h` / `SchedulerParallelImpl.h`**：新增 `GC m_gc` 成员，构造函数接收 `IOServicePool::Ptr` 并透传给 GC。
- **`libinitializer/Initializer.cpp`**：初始化 scheduler 时传入 `m_ioServicePool`。
- 更新所有测试与 benchmark 的构造调用点。

### 改动文件

| 文件 | 说明 |
|---|---|
| `transaction-scheduler/bcos-transaction-scheduler/GC.h` | 核心：TBB arena → io_context + IOServicePool |
| `transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h` | 持 GC 实例，构造函数注入 |
| `transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h` | 同上 |
| `libinitializer/Initializer.cpp` | 透传 IOServicePool |
| `transaction-scheduler/benchmark/benchmarkScheduler.cpp` | 适配 |
| `transaction-scheduler/tests/FIB110_GCBackpressureTest.cpp` | 适配测试 |
| `transaction-scheduler/tests/*.cpp` | 其余测试适配 |