### PR TITLE
fix(sync): cap mergeAndPop generated block requests (FIB-19)

### DIFF
--- a/bcos-sync/bcos-sync/state/DownloadRequestQueue.cpp
+++ b/bcos-sync/bcos-sync/state/DownloadRequestQueue.cpp
@@ -137,17 +137,39 @@ std::set<DownloadRequestQueue::BlockRequest> DownloadRequestQueue::mergeAndPop()
     UpgradeGuard ulock(lock);
     std::set<DownloadRequestQueue::BlockRequest> fetchSet{};
 
-    while (!m_reqQueue.empty())
+    // FIB-19: hard cap on the number of generated block requests. A malicious peer can request a
+    // range spanning billions of blocks; without this cap mergeAndPop() expands it into an
+    // unbounded fetchSet and the caller (maintainBlockRequest) issues one ledger read + outbound
+    // message per entry. Stop once the cap is reached and drop the remaining queue; the requester
+    // retries for anything beyond the cap.
+    bool capped = false;
+    while (!m_reqQueue.empty() && !capped)
     {
         auto topReq = m_reqQueue.top();
         auto interval = (topReq->interval() == 0 ? 1 : topReq->interval());
         for (BlockNumber i = topReq->fromNumber(); i <= topReq->toNumber(); i += interval)
         {
+            if (fetchSet.size() >= MAX_MERGED_REQUEST_BLOCKS_COUNT)
+            {
+                capped = true;
+                break;
+            }
             fetchSet.insert({i, topReq->blockDataFlag() > 0 ?
                                     topReq->blockDataFlag() :
                                     (bcos::ledger::HEADER | bcos::ledger::TRANSACTIONS)});
         }
         m_reqQueue.pop();
+    }
+    if (capped)
+    {
+        BLKSYNC_LOG(WARNING) << LOG_BADGE("Download") << LOG_BADGE("Request")
+                             << LOG_DESC("mergeAndPop hit hard cap, dropping remaining requests")
+                             << LOG_KV("cap", MAX_MERGED_REQUEST_BLOCKS_COUNT)
+                             << LOG_KV("fetchSetSize", fetchSet.size())
+                             << LOG_KV("droppedQueueSize", m_reqQueue.size())
+                             << LOG_KV("peer", m_nodeId->shortHex());
+        RequestQueue empty;
+        m_reqQueue.swap(empty);
     }
     if (c_fileLogLevel == LogLevel::TRACE)
     {

--- a/bcos-sync/bcos-sync/utilities/Common.h
+++ b/bcos-sync/bcos-sync/utilities/Common.h
@@ -29,6 +29,15 @@ static constexpr const size_t MAX_DOWNLOAD_BLOCK_QUEUE_SIZE = 256;
 static constexpr const size_t MAX_DOWNLOAD_REQUEST_QUEUE_SIZE = 1000;
 // the max number of blocks this node can request to
 static constexpr const size_t MAX_REQUEST_BLOCKS_COUNT = 8;
+// Hard cap on the number of block requests a single DownloadRequestQueue::mergeAndPop() may
+// generate (FIB-19). A malicious peer can craft a request whose [fromNumber, toNumber] range
+// spans billions of blocks; without a cap, mergeAndPop() expands it into an unbounded fetchSet
+// and maintainBlockRequest() issues one ledger read + outbound message per entry, exhausting
+// CPU/memory/network. The cap equals the worst-case legitimate volume (a full request queue of
+// MAX_DOWNLOAD_REQUEST_QUEUE_SIZE entries, each requesting MAX_REQUEST_BLOCKS_COUNT blocks), so
+// it never truncates honest traffic. The requester retries for any blocks beyond the cap.
+static constexpr const size_t MAX_MERGED_REQUEST_BLOCKS_COUNT =
+    MAX_DOWNLOAD_REQUEST_QUEUE_SIZE * MAX_REQUEST_BLOCKS_COUNT;
 static constexpr const size_t DOWNLOAD_TIMEOUT_TTL = 200;
 enum BlockSyncPacketType : int32_t
 {

--- a/bcos-sync/test/unittests/sync/FIB19_MergeAndPopHardCapTest.cpp
+++ b/bcos-sync/test/unittests/sync/FIB19_MergeAndPopHardCapTest.cpp
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (C) 2021 bcos-sync.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief regression test for FIB-19: DownloadRequestQueue::mergeAndPop() must cap the number of
+ *        generated block requests so a malicious peer cannot trigger unbounded iteration.
+ * @file FIB19_MergeAndPopHardCapTest.cpp
+ */
+
+#include "SyncFixture.h"
+#include "bcos-sync/state/DownloadRequestQueue.h"
+#include "bcos-sync/utilities/Common.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::sync;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+BOOST_FIXTURE_TEST_SUITE(FIB19MergeAndPopHardCapTest, TestPromptFixture)
+
+static DownloadRequestQueue::Ptr makeQueue()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto gateWay = std::make_shared<FakeGateWay>();
+    auto peer = std::make_shared<SyncFixture>(cryptoSuite, gateWay, 1);
+    return std::make_shared<DownloadRequestQueue>(peer->syncConfig(), peer->syncConfig()->nodeID());
+}
+
+// A single request whose range dwarfs the legitimate maximum must be capped, not fully expanded.
+BOOST_AUTO_TEST_CASE(mergeAndPopEnforcesHardCap)
+{
+    auto queue = makeQueue();
+
+    // size is far above MAX_MERGED_REQUEST_BLOCKS_COUNT but small enough that the pre-fix code
+    // still completes quickly, so the cap is demonstrated deterministically (not via OOM).
+    constexpr size_t kMaliciousSize = MAX_MERGED_REQUEST_BLOCKS_COUNT * 4;
+    queue->push(/*fromNumber*/ 1, /*size*/ kMaliciousSize, /*interval*/ 1);
+
+    auto fetchSet = queue->mergeAndPop();
+    // Without the cap this set would hold kMaliciousSize entries.
+    BOOST_CHECK_EQUAL(fetchSet.size(), MAX_MERGED_REQUEST_BLOCKS_COUNT);
+    // The queue is fully drained once the cap is hit.
+    BOOST_CHECK(queue->empty());
+}
+
+// A legitimate, below-cap merge is returned unchanged.
+BOOST_AUTO_TEST_CASE(mergeAndPopBelowCapUnchanged)
+{
+    auto queue = makeQueue();
+
+    queue->push(/*fromNumber*/ 1, /*size*/ 5, /*interval*/ 1);   // blocks 1..5
+    queue->push(/*fromNumber*/ 10, /*size*/ 3, /*interval*/ 1);  // blocks 10..12
+
+    auto fetchSet = queue->mergeAndPop();
+    BOOST_CHECK_EQUAL(fetchSet.size(), 8);
+    BOOST_CHECK(queue->empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
## Overview

CertiK's 2026-06-08 re-review marked FIB-19, FIB-56, and FIB-121 as **Partially Resolved**. This PR completes **FIB-19** only. FIB-56 has been dropped (the change is not being pursued on this line), and FIB-121 is deferred to a dedicated refactor tracked in #5276.

> Note: the branch name (`fix/certik-partial-56-19-121`) is historical; this PR now contains a single FIB-19 commit.

## FIB-19 (Medium, bcos-sync) — hard cap on mergeAndPop generated block requests

`DownloadRequestQueue::mergeAndPop()` expanded a peer's requested `[fromNumber, toNumber]` range into `fetchSet` with no upper bound. The earlier accessor hardening (#5061) only converted negative/overflow values to safe ones — it did **not** bound a large *valid* range. A positive `size` up to `INT64_MAX` flows through the accessor unchanged, so a peer could still request a range spanning billions of blocks, and `BlockSync::maintainBlockRequest()` would then issue one ledger read plus one outbound message per generated entry — CPU/memory/network exhaustion.

Fix: add a hard cap `MAX_MERGED_REQUEST_BLOCKS_COUNT` (= `MAX_DOWNLOAD_REQUEST_QUEUE_SIZE * MAX_REQUEST_BLOCKS_COUNT`) on the number of block requests a single `mergeAndPop()` may generate. The cap equals the worst-case legitimate volume, so honest sync is never truncated; the requester retries for anything beyond it. When the cap is hit the remaining queue is dropped and a warning is logged.

Test: `FIB19_MergeAndPopHardCapTest` covers the capped malicious range and an unaffected below-cap merge (verified RED on the pre-fix code, GREEN after the fix).

## Deferred / not in this PR

- **FIB-56** (Major, bcos-txpool): dropped; not being pursued on this line.
- **FIB-121** (Minor, bcos-pbft): no clean contained fix — it is a family-wide protobuf ownership convention, and the only design that removes the exception-unsafe double-free (release-before-wrap) breaks the encode path. The DoS surface was already closed by the `bb72c0ed` size cap. Tracked for a dedicated refactor in #5276.

## Verification

- `test-bcos-sync` full suite passes locally (exit 0).