### PR TITLE
refactor(Worker): integrate enable_shared_from_this to eliminate use-after-free risks

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
@@ -167,6 +167,12 @@ bool PBFTCache::collectEnoughCommitReq()
 
 void PBFTCache::intoPrecommit()
 {
+    if (!checkPrePrepareProposalStatus())
+    {
+        PBFT_LOG(WARNING) << LOG_DESC("intoPrecommit called without valid prePrepare")
+                          << LOG_KV("index", m_index);
+        return;
+    }
     m_precommit = m_prePrepare;
     m_precommit->setGeneratedFrom(m_config->nodeIndex());
     setSignatureList(m_precommit->consensusProposal(), m_prepareCacheList);

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -134,7 +134,7 @@ void PBFTEngine::start()
     // when the node setup, start the timer for view recovery
     m_config->timer()->start();
     // register timeout handler
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<PBFTEngine>::weak_from_this();
     m_timer->registerTimeoutHandler([self]() {
         try
         {
@@ -503,7 +503,7 @@ void PBFTEngine::asyncNotifyNewBlock(
 void PBFTEngine::onReceivePBFTMessage(
     bcos::Error::Ptr _error, std::string const& _id, NodeIDPtr _nodeID, bytesConstRef _data)
 {
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<PBFTEngine>::weak_from_this();
     onReceivePBFTMessage(
         std::move(_error), _nodeID, _data, [_id, _nodeID, self](bytesConstRef _respData) {
             try
@@ -1187,7 +1187,7 @@ bool PBFTEngine::handlePrePrepareMsg(PBFTMessageInterface::Ptr _prePrepareMsg,
         return true;
     }
     // verify the proposal
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<PBFTEngine>::weak_from_this();
     auto leaderNodeInfo = m_config->getConsensusNodeByIndex(_prePrepareMsg->generatedFrom());
     if (!leaderNodeInfo)
     {
@@ -1809,7 +1809,7 @@ void PBFTEngine::reHandlePrePrepareProposals(NewViewMsgInterface::Ptr _newViewRe
     m_config->notifyResetSealing();
     auto const& prePrepareList = _newViewReq->prePrepareList();
     auto maxProposalIndex = m_config->committedProposal()->index();
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<PBFTEngine>::weak_from_this();
     for (const auto& prePrepare : prePrepareList)
     {
         // empty block proposal
@@ -2004,7 +2004,7 @@ void PBFTEngine::onReceiveCommittedProposalRequest(
         sendCommittedProposalResponse(proposalList, _sendResponse);
         return;
     }
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<PBFTEngine>::weak_from_this();
     m_config->storage()->asyncGetCommittedProposals(pbftRequest->index(), pbftRequest->size(),
         [self, pbftRequest, _sendResponse](PBFTProposalListPtr _proposalList) {
             auto engine = self.lock();

--- a/bcos-rpc/bcos-rpc/event/EventSub.cpp
+++ b/bcos-rpc/bcos-rpc/event/EventSub.cpp
@@ -111,7 +111,8 @@ void EventSub::onRecvSubscribeEvent(std::shared_ptr<bcos::boostssl::MessageFace>
     task->setParams(eventSubRequest->params());
     task->setState(state);
 
-    auto eventSubWeakPtr = std::weak_ptr<EventSub>(shared_from_this());
+    auto eventSubWeakPtr =
+        std::weak_ptr<EventSub>(std::enable_shared_from_this<EventSub>::shared_from_this());
     task->setCallback([eventSubWeakPtr, _session](const std::string& _id, bool _complete,
                           const Json::Value& _result) -> bool {
         auto eventSub = eventSubWeakPtr.lock();
@@ -124,7 +125,6 @@ void EventSub::onRecvSubscribeEvent(std::shared_ptr<bcos::boostssl::MessageFace>
 
     subscribeEventSub(task);
     sendResponse(_session, _msg, eventSubRequest->id(), EP_STATUS_CODE::SUCCESS);
-    return;
 }
 
 void EventSub::onRecvUnsubscribeEvent(std::shared_ptr<bcos::boostssl::MessageFace> _msg,
@@ -438,7 +438,7 @@ int64_t EventSub::executeEventSubTask(EventSubTask::Ptr _task, int64_t _blockNum
 
     auto p = std::make_shared<RecursiveProcess>();
     p->m_endBlockNumber = currentBlockNumber + blockCanProcess - 1;
-    p->m_eventSub = shared_from_this();
+    p->m_eventSub = std::enable_shared_from_this<EventSub>::shared_from_this();
     p->m_task = _task;
     p->process(currentBlockNumber);
 
@@ -491,7 +491,7 @@ int64_t EventSub::executeEventSubTask(EventSubTask::Ptr _task)
 void EventSub::processNextBlock(
     int64_t _blockNumber, EventSubTask::Ptr _task, std::function<void(Error::Ptr _error)> _callback)
 {
-    auto self = std::weak_ptr<EventSub>(shared_from_this());
+    auto self = std::weak_ptr<EventSub>(std::enable_shared_from_this<EventSub>::shared_from_this());
     auto matcher = m_matcher;
 
     std::string group = _task->group();

--- a/bcos-sealer/bcos-sealer/Sealer.cpp
+++ b/bcos-sealer/bcos-sealer/Sealer.cpp
@@ -56,7 +56,7 @@ void Sealer::start()
     SEAL_LOG(INFO) << LOG_DESC("start the sealer");
     // FIB-164: register the onReady callback now via weak_from_this() so the
     // callback safely no-ops after Sealer is destroyed.
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<Sealer>::weak_from_this();
     m_sealingManager->setOnReadyCallback([self]() {
         if (auto sealer = self.lock())
         {

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -322,7 +322,7 @@ void BlockSync::asyncNotifyBlockSyncMessage(Error::Ptr _error, std::string const
         }
         return;
     }
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<BlockSync>::weak_from_this();
     asyncNotifyBlockSyncMessage(
         _error, _nodeID, _data,
         [_uuid, _nodeID, self](bytesConstRef _respData) {
@@ -852,7 +852,7 @@ void BlockSync::fetchAndSendBlock(
     PublicPtr const& _peer, BlockNumber _number, int32_t _blockDataFlag = HEADER | TRANSACTIONS)
 {
     // only fetch blockHeader and transactions
-    auto self = weak_from_this();
+    auto self = std::enable_shared_from_this<BlockSync>::weak_from_this();
     m_config->ledger()->asyncGetBlockDataByNumber(_number, _blockDataFlag,
         [self, _peer = std::move(_peer), _number, _blockDataFlag](
             auto&& _error, Block::Ptr _block) {

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -21,33 +21,18 @@
 #include <boost/asio/dispatch.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/exception/diagnostic_information.hpp>
-#include <chrono>
 #include <exception>
-#include <future>
 
 using namespace bcos;
 
 Worker::~Worker()
 {
     stopWorking();
-    // stopWorking() may return early when m_workerState is already
-    // Stopped (e.g. Sealer::stop() called stopWorking() before the
-    // destructor).  In that case pending [this]-capturing handlers
-    // (operation_aborted from cancel, notify() posts) may still be
-    // queued in the io_context.  Post a drain barrier and wait so
-    // that all such handlers are processed before *this is freed.
-    if (!m_ioContext.stopped() && !m_ioContext.get_executor().running_in_this_thread())
-    {
-        auto drainPromise = std::make_shared<std::promise<void>>();
-        auto drainFuture = drainPromise->get_future();
-        boost::asio::post(m_ioContext, [drainPromise]() { drainPromise->set_value(); });
-        auto drainStatus = drainFuture.wait_for(std::chrono::seconds(5));
-        if (drainStatus != std::future_status::ready)
-        {
-            BCOS_LOG(ERROR) << LOG_DESC("Worker::~Worker() timed out waiting for handler drain")
-                            << LOG_KV("threadName", m_threadName);
-        }
-    }
+    // All asynchronous handlers (post / dispatch / async_wait) capture a
+    // weak_ptr from weak_from_this().  Once the last shared_ptr to this
+    // Worker is released the weak_ptrs expire, so queued handlers will
+    // safely no-op without accessing freed memory.  No explicit drain is
+    // required.
 }
 
 void Worker::startWorking()
@@ -80,11 +65,15 @@ void Worker::startWorking()
     // must only happen on the io_context thread.  dispatch() runs the
     // handler synchronously if we are already on the io_context thread;
     // otherwise it behaves like post() and queues it for later execution.
-    boost::asio::dispatch(m_ioContext, [this]() {
-        if (m_workerState == WorkerState::Started)
+    // Use weak_from_this() so the dispatch no-ops if the Worker was
+    // destroyed before the handler runs.
+    boost::asio::dispatch(m_ioContext, [weak = weak_from_this()]() {
+        auto self = weak.lock();
+        if (!self || self->m_workerState != WorkerState::Started)
         {
-            scheduleNext();
+            return;
         }
+        self->scheduleNext();
     });
 }
 
@@ -96,19 +85,16 @@ void Worker::stopWorking()
         return;  // Not running, or another thread is already stopping
     }
 
-    // Cancel the timer.  If we are already on the io_context thread we
-    // can mutate m_timer directly; otherwise we post the cancel.
-    // No need to wait — ~Worker() drains all [this]-capturing handlers
-    // before the object can be freed, and any timer tick that fires
-    // between now and the cancel will early-return on !Started.
-    if (m_ioContext.get_executor().running_in_this_thread())
-    {
-        m_timer.cancel();
-    }
-    else
-    {
-        boost::asio::post(m_ioContext, [this]() { m_timer.cancel(); });
-    }
+    // Cancel the timer.  dispatch() runs synchronously if we are already
+    // on the io_context thread; otherwise it posts asynchronously.
+    // The weak_from_this() capture ensures the handler no-ops if the
+    // Worker has already been destroyed.
+    boost::asio::dispatch(m_ioContext, [weak = weak_from_this()]() {
+        if (auto self = weak.lock())
+        {
+            self->m_timer.cancel();
+        }
+    });
 
     try
     {
@@ -136,7 +122,12 @@ void Worker::scheduleNext()
     }
 
     m_timer.expires_after(boost::asio::chrono::milliseconds(m_idleWaitMs));
-    m_timer.async_wait([this](boost::system::error_code const& ec) { handleTimerTick(ec); });
+    m_timer.async_wait([weak = weak_from_this()](boost::system::error_code const& ec) {
+        if (auto self = weak.lock())
+        {
+            self->handleTimerTick(ec);
+        }
+    });
 }
 
 void Worker::handleTimerTick(boost::system::error_code const& ec)
@@ -169,7 +160,12 @@ void Worker::handleTimerTick(boost::system::error_code const& ec)
     {
         // Use a small backoff to avoid busy-looping on persistent exceptions
         m_timer.expires_after(boost::asio::chrono::milliseconds(10));
-        m_timer.async_wait([this](boost::system::error_code const& ec) { handleTimerTick(ec); });
+        m_timer.async_wait([weak = weak_from_this()](boost::system::error_code const& ec) {
+            if (auto self = weak.lock())
+            {
+                self->handleTimerTick(ec);
+            }
+        });
     }
     else
     {
@@ -190,11 +186,13 @@ void Worker::notify()
         // broadcastViewChangeReq() -> onReceivePBFTMessage() -> notify()).
         // dispatch() would run handleTimerTick synchronously, causing
         // nested PBFT message processing that breaks consensus ordering.
-        boost::asio::post(m_ioContext, [this]() {
-            if (m_workerState == WorkerState::Started)
+        boost::asio::post(m_ioContext, [weak = weak_from_this()]() {
+            auto self = weak.lock();
+            if (!self || self->m_workerState != WorkerState::Started)
             {
-                handleTimerTick(boost::system::error_code());
+                return;
             }
+            self->handleTimerTick(boost::system::error_code());
         });
     }
 }

--- a/bcos-utilities/bcos-utilities/Worker.h
+++ b/bcos-utilities/bcos-utilities/Worker.h
@@ -21,6 +21,8 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <atomic>
+#include <concepts>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -32,8 +34,26 @@ enum class WorkerState
     Started
 };
 
-class Worker
+/// Concept: T must derive from std::enable_shared_from_this<T> so that
+/// weak_from_this() / shared_from_this() are always usable.  Worker itself
+/// and all of its subclasses satisfy this once Worker inherits from
+/// std::enable_shared_from_this<Worker>.
+template <typename T>
+concept SharedFromThisEnabled =
+    std::derived_from<T, std::enable_shared_from_this<T>>;
+
+class Worker : public std::enable_shared_from_this<Worker>
 {
+public:
+    /// Factory: the only blessed way to create a Worker (or subclass) on the
+    /// heap.  Returns a shared_ptr so enable_shared_from_this is initialised.
+    template <typename T, typename... Args>
+        requires std::derived_from<T, Worker>
+    static std::shared_ptr<T> createShared(Args&&... args)
+    {
+        return std::make_shared<T>(std::forward<Args>(args)...);
+    }
+
 protected:
     Worker(boost::asio::io_context& _ioContext, std::string _threadName = "worker",
         unsigned _idleWaitMs = 30)
@@ -100,5 +120,12 @@ private:
 
     std::atomic<WorkerState> m_workerState = {WorkerState::Stopped};
 };
+
+// Compile-time guard: Worker must satisfy SharedFromThisEnabled so that
+// weak_from_this() functions correctly in all async handlers.  The
+// check is placed after the closing brace because std::derived_from
+// requires a complete type.
+static_assert(SharedFromThisEnabled<Worker>,
+    "Worker must be managed by std::shared_ptr via createShared()");
 
 }  // namespace bcos

--- a/bcos-utilities/test/unittests/libutilities/WorkerTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/WorkerTest.cpp
@@ -67,10 +67,10 @@ BOOST_AUTO_TEST_CASE(testWorker)
     auto work = boost::asio::make_work_guard(ioContext);
     std::thread ioThread([&]() { ioContext.run(); });
 
-    TestWorkerImpl workerImpl(ioContext);
-    workerImpl.run();
+    auto workerImpl = bcos::Worker::createShared<TestWorkerImpl>(ioContext);
+    workerImpl->run();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    workerImpl.stop();
+    workerImpl->stop();
 
     work.reset();
     ioContext.stop();


### PR DESCRIPTION
## 变更概述

将 `bcos::Worker` 重构为继承 `std::enable_shared_from_this<Worker>`，彻底解决析构时异步回调中的 use-after-free 风险。

## 核心变更

### 1. Worker 生命周期安全化（`bcos-utilities`）

- **`Worker.h`**：Worker 继承 `std::enable_shared_from_this<Worker>`，新增 `SharedFromThisEnabled<T>` concept 作为编译期约束，新增 `createShared<T>()` 静态工厂方法确保 `shared_ptr` 管理。
- **`Worker.cpp`**：所有异步回调 (`dispatch` / `post` / `async_wait`) 从 `[this]` 裸指针捕获改为 `[weak = weak_from_this()]` + `weak.lock()` 检查，彻底消除析构后的悬空指针访问。移除析构函数中的 `promise/future` drain + `wait_for(5s)` 超时等待逻辑。`stopWorking()` 的 `if-else` 简化为 `dispatch()` 统一处理。

### 2. 双 `enable_shared_from_this` 歧义修复

由于 Worker 新增 `enable_shared_from_this<Worker>` 基类，以下已有自身 `enable_shared_from_this<Derived>` 的派生类出现 `weak_from_this()`/`shared_from_this()` 歧义，已用完全限定名修复：

- `Sealer.cpp`
- `EventSub.cpp`
- `BlockSync.cpp`
- `PBFTEngine.cpp`

### 3. `PBFTCache::intoPrecommit()` 空指针守卫

新增 `checkPrePrepareProposalStatus()` 空值检查。

### 4. 测试更新

`WorkerTest.cpp` 改用 `Worker::createShared<TestWorkerImpl>()` 工厂创建。