### PR TITLE
Fix thread-safety issues in NewTimer using atomic operations and io_context dispatch

### DIFF
--- a/bcos-utilities/bcos-utilities/NewTimer.cpp
+++ b/bcos-utilities/bcos-utilities/NewTimer.cpp
@@ -28,43 +28,61 @@ bcos::timer::TimerTask bcos::timer::Timer::timerTask() const
 }
 void bcos::timer::Timer::start()
 {
-    if (m_running)
+    if (bool running = false; !m_running.compare_exchange_strong(running, true))
     {
         return;
     }
-    m_running = true;
 
-    if (m_delayMS > 0)
-    {  // delay handle
-        startDelayTask();
-    }
-    else if (m_periodMS > 0)
-    {
-        // periodic task handle
-        startPeriodTask();
-    }
-    else
-    {
-        // execute the task directly
-        executeTask();
-    }
+    // Dispatch to io_context thread for thread safety (steady_timer is not
+    // thread-safe).  If already on the io_context thread this runs
+    // synchronously; otherwise it posts asynchronously.
+    boost::asio::dispatch(*m_ioService, [weak = weak_from_this()]() {
+        auto self = weak.lock();
+        if (!self || !self->m_running)
+        {
+            return;
+        }
+
+        if (self->m_delayMS > 0)
+        {
+            self->startDelayTask();
+        }
+        else if (self->m_periodMS > 0)
+        {
+            self->startPeriodTask();
+        }
+        else
+        {
+            self->executeTask();
+        }
+    });
 }
 void bcos::timer::Timer::stop()
 {
-    if (!m_running)
+    if (bool running = true; !m_running.compare_exchange_strong(running, false))
     {
         return;
     }
 
-    if (m_delayHandler)
-    {
-        m_delayHandler->cancel();
-    }
+    // Dispatch cancel to io_context thread to avoid racing with async_wait
+    // handlers.  Lifecycle protected by weak_ptr.
+    boost::asio::dispatch(*m_ioService, [weak = weak_from_this()]() {
+        auto self = weak.lock();
+        if (!self)
+        {
+            return;
+        }
 
-    if (m_timerHandler)
-    {
-        m_timerHandler->cancel();
-    }
+        if (self->m_delayHandler)
+        {
+            self->m_delayHandler->cancel();
+        }
+
+        if (self->m_timerHandler)
+        {
+            self->m_timerHandler->cancel();
+        }
+    });
 }
 void bcos::timer::Timer::startDelayTask()
 {
@@ -72,9 +90,15 @@ void bcos::timer::Timer::startDelayTask()
 
     auto self = weak_from_this();
     m_delayHandler->expires_after(std::chrono::milliseconds(m_delayMS));
-    m_delayHandler->async_wait([self](const boost::system::error_code& e) {
+    m_delayHandler->async_wait([self](const boost::system::error_code& error) {
+        // The timer has been cancelled
+        if (error == boost::asio::error::operation_aborted)
+        {
+            return;
+        }
+
         auto timer = self.lock();
-        if (!timer)
+        if (!timer || !timer->m_running)
         {
             return;
         }
@@ -94,15 +118,26 @@ void bcos::timer::Timer::startPeriodTask()
     m_timerHandler = std::make_shared<boost::asio::steady_timer>(*m_ioService);
     auto self = weak_from_this();
     m_timerHandler->expires_after(std::chrono::milliseconds(m_periodMS));
-    m_timerHandler->async_wait([self](const boost::system::error_code& e) {
+    m_timerHandler->async_wait([self](const boost::system::error_code& error) {
+        // The timer has been cancelled
+        if (error == boost::asio::error::operation_aborted)
+        {
+            return;
+        }
+
         auto timer = self.lock();
-        if (!timer)
+        if (!timer || !timer->m_running)
         {
             return;
         }
 
         timer->executeTask();
-        timer->startPeriodTask();
+        // Only re-arm if still running (stop() may have been called during
+        // executeTask())
+        if (timer->m_running)
+        {
+            timer->startPeriodTask();
+        }
     });
 }
 void bcos::timer::Timer::executeTask()

--- a/bcos-utilities/bcos-utilities/NewTimer.cpp
+++ b/bcos-utilities/bcos-utilities/NewTimer.cpp
@@ -33,6 +33,14 @@ void bcos::timer::Timer::start()
         return;
     }
 
+    // For direct execution (no steady_timer involved), execute synchronously.
+    // This preserves the original behavior and avoids unnecessary dispatch.
+    if (m_delayMS <= 0 && m_periodMS <= 0)
+    {
+        executeTask();
+        return;
+    }
+
     // Dispatch to io_context thread for thread safety (steady_timer is not
     // thread-safe).  If already on the io_context thread this runs
     // synchronously; otherwise it posts asynchronously.
@@ -50,10 +58,6 @@ void bcos::timer::Timer::start()
         else if (self->m_periodMS > 0)
         {
             self->startPeriodTask();
-        }
-        else
-        {
-            self->executeTask();
         }
     });
 }

--- a/bcos-utilities/bcos-utilities/NewTimer.h
+++ b/bcos-utilities/bcos-utilities/NewTimer.h
@@ -23,6 +23,7 @@
 #pragma once
 #include <boost/asio.hpp>
 #include <boost/asio/steady_timer.hpp>
+#include <atomic>
 #include <memory>
 
 namespace bcos::timer
@@ -57,7 +58,7 @@ private:
     void startPeriodTask();
     void executeTask();
 
-    bool m_running = false;
+    std::atomic_bool m_running = false;
     std::shared_ptr<boost::asio::io_context> m_ioService;
     TimerTask m_timerTask;
     int m_delayMS;


### PR DESCRIPTION
## 问题描述

`NewTimer` 存在多处线程安全隐患：

1. **`m_running` 非原子操作**：`m_running` 为普通 `bool` 类型，在多线程环境下 `start()`/`stop()` 的读写存在竞态条件。
2. **`steady_timer` 非线程安全**：`steady_timer` 本身不是线程安全的，直接从其他线程调用 `start()`/`stop()` 可能导致未定义行为。
3. **定时器回调中的生命周期问题**：`async_wait` 回调中未检查 `operation_aborted` 错误码，cancel 后的回调仍可能执行任务；周期性任务在 `executeTask()` 执行期间 `stop()` 被调用后仍会重新调度。

## 修复内容

1. 将 `m_running` 改为 `std::atomic_bool`，使用 `compare_exchange_strong` 保证 `start()`/`stop()` 的原子性。
2. `start()` 和 `stop()` 的核心逻辑通过 `boost::asio::dispatch` 投递到 `io_context` 线程执行，确保 `steady_timer` 操作在正确的线程上下文中进行。
3. 在 `async_wait` 回调中增加 `operation_aborted` 检查，cancel 后直接返回，避免执行已取消的任务。
4. 周期性任务重新调度前检查 `m_running` 状态，防止 `stop()` 后继续调度下一轮任务。
5. 使用 `weak_from_this()` 模式保护异步回调中的对象生命周期，避免 use-after-free。

## 变更文件

- `bcos-utilities/bcos-utilities/NewTimer.h`：`m_running` 类型由 `bool` 改为 `std::atomic_bool`
- `bcos-utilities/bcos-utilities/NewTimer.cpp`：重构 `start()`/`stop()`/`startPeriodTask()`/`startDelayTask()` 的线程安全逻辑