### PR TITLE
feat(mpt): Account RLP + AccountDelta + classify (M4.1)

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/Account.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Account.cpp
@@ -22,6 +22,7 @@
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-codec/rlp/RLPEncode.h>
 #include <boost/throw_exception.hpp>
+#include <string>
 
 namespace bcos::ledger::mpt
 {
@@ -32,6 +33,38 @@ Account::Account() : storageRoot(emptyRootHash()), codeHash(emptyCodeHash()) {}
 // unqualified names would otherwise bind to Account's own member functions.
 namespace rlp = bcos::codec::rlp;
 
+namespace
+{
+// Decode one RLP string item into `out`, rejecting any payload whose length != 32. The generic
+// FixedBytes<32> decoder zero-pads a short payload (RLPDecode.h: FixedBytes<32>{getCroppedData(0,
+// payloadLength)}), silently accepting malformed input; Ethereum consensus requires storageRoot
+// and codeHash to be exactly 32-byte strings, so enforce that here.
+void decodeHash32(bcos::bytesRef& cursor, bcos::h256& out, char const* field)
+{
+    auto [error, header] = rlp::decodeHeader(cursor);
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment(
+                std::string("Account RLP: bad ") + field + " header: " + error->errorMessage()));
+    }
+    if (header.isList)
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment(
+                std::string("Account RLP: ") + field + " must be a 32-byte string, got a list"));
+    }
+    if (header.payloadLength != bcos::h256::SIZE)
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  std::string("Account RLP: ") + field + " RLP payload is " +
+                                  std::to_string(header.payloadLength) + " bytes, expected 32"));
+    }
+    out = bcos::h256(bcos::bytesConstRef(cursor.data(), header.payloadLength));
+    cursor = cursor.getCroppedData(header.payloadLength);
+}
+}  // namespace
+
 bcos::bytes Account::encode() const
 {
     bcos::bytes out;
@@ -39,6 +72,8 @@ bcos::bytes Account::encode() const
     // the two hashes encode as fixed 32-byte strings.
     size_t const payloadLength = rlp::length(nonce) + rlp::length(balance) +
                                  rlp::length(storageRoot) + rlp::length(codeHash);
+    // Pre-size as the variadic rlp::encode(out, a, b, ...) path does, to avoid 1-2 reallocations.
+    out.reserve(rlp::lengthOfLength(payloadLength) + payloadLength);
     rlp::encodeHeader(out, {.isList = true, .payloadLength = payloadLength});
     rlp::encode(out, nonce);
     rlp::encode(out, balance);
@@ -79,16 +114,10 @@ Account Account::decode(bcos::bytesConstRef rlp)
         BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
                                   "Account RLP: bad balance: " + error->errorMessage()));
     }
-    if (auto error = ::bcos::codec::rlp::decode(cursor, account.storageRoot); error)
-    {
-        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
-                                  "Account RLP: bad storageRoot: " + error->errorMessage()));
-    }
-    if (auto error = ::bcos::codec::rlp::decode(cursor, account.codeHash); error)
-    {
-        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
-                                  "Account RLP: bad codeHash: " + error->errorMessage()));
-    }
+    // storageRoot/codeHash must be exactly 32-byte RLP strings (decodeHash32 rejects shorter
+    // payloads that the generic FixedBytes<32> decoder would silently zero-pad).
+    decodeHash32(cursor, account.storageRoot, "storageRoot");
+    decodeHash32(cursor, account.codeHash, "codeHash");
 
     // The 4 fields must consume exactly the declared payload — no trailing bytes,
     // no missing fields.

--- a/bcos-ledger/bcos-ledger/mpt/Account.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Account.cpp
@@ -1,0 +1,103 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Account.cpp
+ * @brief Ethereum account 4-tuple RLP encode/decode (spec §5.4)
+ */
+#include "Account.h"
+#include "Constants.h"
+#include "Errors.h"
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <boost/throw_exception.hpp>
+
+namespace bcos::ledger::mpt
+{
+
+Account::Account() : storageRoot(emptyRootHash()), codeHash(emptyCodeHash()) {}
+
+// Alias the RLP codec; we must fully qualify encode()/decode() below because the
+// unqualified names would otherwise bind to Account's own member functions.
+namespace rlp = bcos::codec::rlp;
+
+bcos::bytes Account::encode() const
+{
+    bcos::bytes out;
+    // u256 nonce/balance encode big-endian-trimmed (0 → empty string 0x80);
+    // the two hashes encode as fixed 32-byte strings.
+    size_t const payloadLength = rlp::length(nonce) + rlp::length(balance) +
+                                 rlp::length(storageRoot) + rlp::length(codeHash);
+    rlp::encodeHeader(out, {.isList = true, .payloadLength = payloadLength});
+    rlp::encode(out, nonce);
+    rlp::encode(out, balance);
+    rlp::encode(out, storageRoot);
+    rlp::encode(out, codeHash);
+    return out;
+}
+
+Account Account::decode(bcos::bytesConstRef rlp)
+{
+    bcos::bytesRef cursor{const_cast<bcos::byte*>(rlp.data()), rlp.size()};
+
+    auto [headerError, header] = ::bcos::codec::rlp::decodeHeader(cursor);
+    if (headerError)
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "Account RLP: bad list header: " + headerError->errorMessage()));
+    }
+    if (!header.isList)
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment("Account RLP: expected a list"));
+    }
+    if (header.payloadLength != cursor.size())
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "Account RLP: declared payload length does not match input"));
+    }
+
+    Account account;
+    if (auto error = ::bcos::codec::rlp::decode(cursor, account.nonce); error)
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "Account RLP: bad nonce: " + error->errorMessage()));
+    }
+    if (auto error = ::bcos::codec::rlp::decode(cursor, account.balance); error)
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "Account RLP: bad balance: " + error->errorMessage()));
+    }
+    if (auto error = ::bcos::codec::rlp::decode(cursor, account.storageRoot); error)
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "Account RLP: bad storageRoot: " + error->errorMessage()));
+    }
+    if (auto error = ::bcos::codec::rlp::decode(cursor, account.codeHash); error)
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "Account RLP: bad codeHash: " + error->errorMessage()));
+    }
+
+    // The 4 fields must consume exactly the declared payload — no trailing bytes,
+    // no missing fields.
+    if (!cursor.empty())
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "Account RLP: trailing bytes after the 4 fields"));
+    }
+    return account;
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Account.h
+++ b/bcos-ledger/bcos-ledger/mpt/Account.h
@@ -1,0 +1,51 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Account.h
+ * @brief Ethereum account 4-tuple (nonce, balance, storageRoot, codeHash) with RLP
+ *        encode/decode (spec §5.4)
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+
+namespace bcos::ledger::mpt
+{
+
+/// The Ethereum account record stored at each leaf of the state trie.
+/// RLP-encoded as the 4-element list [nonce, balance, storageRoot, codeHash]
+/// (Yellow Paper §4.1). nonce/balance are big-endian-trimmed integers; the two
+/// hashes are fixed 32-byte strings.
+struct Account
+{
+    bcos::u256 nonce{};
+    bcos::u256 balance{};
+    bcos::h256 storageRoot;  ///< default-constructed to emptyRootHash()
+    bcos::h256 codeHash;     ///< default-constructed to emptyCodeHash()
+
+    /// Default account: nonce=0, balance=0, storageRoot=emptyRootHash(),
+    /// codeHash=emptyCodeHash(). Matches a freshly created EOA with no code.
+    Account();
+
+    /// RLP-encode as list [nonce, balance, storageRoot, codeHash].
+    [[nodiscard]] bcos::bytes encode() const;
+
+    /// Inverse of encode(). Throws MPTDecodeError on a malformed input: not a
+    /// list, wrong field count, trailing bytes, or any field-level RLP error.
+    static Account decode(bcos::bytesConstRef rlp);
+};
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/AccountDelta.h
+++ b/bcos-ledger/bcos-ledger/mpt/AccountDelta.h
@@ -1,0 +1,72 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AccountDelta.h
+ * @brief Per-account field changes for one block, grouped by address (spec §5.2)
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <optional>
+#include <unordered_map>
+
+namespace bcos::ledger::mpt
+{
+
+/// All changes a single block makes to a single account. Produced by classify()
+/// from the flat key→Entry delta; consumed by the MPT builder (PR-10).
+///
+/// A field's *State* records whether the block touched it. nonce/balance/codeHash
+/// carry both a State and the new value (only meaningful when State==Updated).
+/// storageChanges holds per-slot new values, where nullopt means the slot was
+/// deleted (zeroed).
+struct AccountDelta
+{
+    enum class FieldState
+    {
+        Unchanged,  ///< the block did not write this field
+        Updated,    ///< the block wrote a new value (held in the sibling member)
+        Deleted     ///< the block deleted this field (Entry status DELETED)
+    };
+
+    FieldState nonceState = FieldState::Unchanged;
+    bcos::u256 nonce{};
+
+    FieldState balanceState = FieldState::Unchanged;
+    bcos::u256 balance{};
+
+    FieldState codeHashState = FieldState::Unchanged;
+    bcos::h256 codeHash{};
+
+    /// slot-key → new value, or nullopt to delete (zero) the slot.
+    std::unordered_map<bcos::h256, std::optional<bcos::bytes>> storageChanges;
+
+    /// All three core fields (nonce, balance, codeHash) deleted in this block →
+    /// the account is destroyed (SELFDESTRUCT). The builder removes its leaf.
+    bool tombstone = false;
+
+    /// The account did not exist in the parent state (readView.hasAccount==false).
+    /// The builder inserts a brand-new leaf rather than merging onto an old one.
+    bool firstTouch = false;
+};
+
+/// One block's changes to every touched account, keyed by 20-byte address.
+struct MPTBuildInput
+{
+    std::unordered_map<bcos::Address, AccountDelta> perAccount;
+};
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Classify.h
+++ b/bcos-ledger/bcos-ledger/mpt/Classify.h
@@ -1,0 +1,269 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Classify.h
+ * @brief classify(): translate a flat key→Entry delta into per-account AccountDelta
+ *        (spec §5.2). Header-only because classify() is a template over the flat-delta
+ *        range type (a storage2 range in production, a vector of pairs in tests).
+ */
+#pragma once
+
+#include "AccountDelta.h"
+#include "Errors.h"
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/throw_exception.hpp>
+#include <optional>
+#include <string_view>
+
+namespace bcos::ledger::mpt
+{
+
+// ---------------------------------------------------------------------------
+// Flat-state key format (VERIFIED against the executor's StateKey layout)
+// ---------------------------------------------------------------------------
+// A flat-state row is keyed by an executor_v1::StateKey, whose serialized form is
+//   "<table>:<key>"
+// with a single ':' separator (StateKey.h:24-30, find_first_of(':') at line 32).
+// For an account/contract the table is "/apps/<40-hex-address>" (executor
+// Common.h:73 USER_APPS_PREFIX, TransactionExecutive::getContractTableName), and
+// the row <key> is one of the field-name strings below (Common.h:79-85,99) or a
+// 32-byte binary storage slot (HostContext::setStore writes a 32-byte evmc key).
+//
+// Ethereum core fields  : "nonce", "balance", "codeHash"
+// BCOS extension fields : "code", "abi", "alive", "frozen", "shard", "status",
+//                         "last_update", "last_status"  (non-Ethereum rows)
+// Storage slot          : a 32-byte binary row key (length 32, not a field name)
+//
+// The table prefix "/apps/" contains no ':' so the first ':' is always the
+// StateKey separator; we split there.
+
+inline constexpr std::string_view APPS_TABLE_PREFIX = "/apps/";
+inline constexpr size_t ADDRESS_HEX_LEN = 40;  // 20-byte address as hex
+
+inline constexpr std::string_view ROW_NONCE = "nonce";
+inline constexpr std::string_view ROW_BALANCE = "balance";
+inline constexpr std::string_view ROW_CODE_HASH = "codeHash";
+
+namespace detail
+{
+
+/// A parsed flat-state key: the account address plus the kind of row it names.
+struct ParsedKey
+{
+    enum class Kind
+    {
+        Nonce,
+        Balance,
+        CodeHash,
+        StorageSlot,
+        BcosExtension,  ///< code/abi/alive/frozen/shard/... — non-Ethereum field
+        NotAnAccount    ///< table is not "/apps/<addr>" → skip entirely
+    };
+    bcos::Address address;
+    Kind kind = Kind::NotAnAccount;
+    bcos::h256 slot;  ///< valid only when kind==StorageSlot
+};
+
+/// Classify a single "<table>:<row>" key. Never throws; l2Mode handling of
+/// BcosExtension rows is the caller's decision.
+inline ParsedKey parseKey(std::string_view fullKey)
+{
+    ParsedKey parsed;
+
+    auto const colon = fullKey.find_first_of(':');
+    if (colon == std::string_view::npos)
+    {
+        return parsed;  // NotAnAccount: no StateKey separator
+    }
+    std::string_view const table = fullKey.substr(0, colon);
+    std::string_view const row = fullKey.substr(colon + 1);
+
+    // Table must be "/apps/<40-hex-address>".
+    if (!table.starts_with(APPS_TABLE_PREFIX))
+    {
+        return parsed;  // NotAnAccount: /sys/, /tables/, _accessAuth, etc.
+    }
+    std::string_view const addrHex = table.substr(APPS_TABLE_PREFIX.size());
+    if (addrHex.size() != ADDRESS_HEX_LEN)
+    {
+        return parsed;  // NotAnAccount: not a 20-byte address table
+    }
+    parsed.address = bcos::Address(std::string(addrHex), bcos::Address::FromHex);
+
+    // A 32-byte binary row key is a storage slot, never a named field.
+    if (row.size() == static_cast<size_t>(bcos::h256::SIZE))
+    {
+        parsed.kind = ParsedKey::Kind::StorageSlot;
+        parsed.slot = bcos::h256(
+            bcos::bytesConstRef(reinterpret_cast<bcos::byte const*>(row.data()), row.size()));
+        return parsed;
+    }
+
+    if (row == ROW_NONCE)
+    {
+        parsed.kind = ParsedKey::Kind::Nonce;
+    }
+    else if (row == ROW_BALANCE)
+    {
+        parsed.kind = ParsedKey::Kind::Balance;
+    }
+    else if (row == ROW_CODE_HASH)
+    {
+        parsed.kind = ParsedKey::Kind::CodeHash;
+    }
+    else
+    {
+        // code/abi/alive/frozen/shard/status/... — a BCOS-specific extension row.
+        parsed.kind = ParsedKey::Kind::BcosExtension;
+    }
+    return parsed;
+}
+
+/// Decode an Entry's stored bytes as a big-endian u256 (nonce/balance values).
+inline bcos::u256 entryToU256(bcos::storage::Entry const& entry)
+{
+    std::string_view const value = entry.get();
+    return bcos::fromBigEndian<bcos::u256>(
+        bcos::bytesConstRef(reinterpret_cast<bcos::byte const*>(value.data()), value.size()));
+}
+
+/// Copy an Entry's stored bytes into a 32-byte hash (codeHash value).
+inline bcos::h256 entryToH256(bcos::storage::Entry const& entry)
+{
+    std::string_view const value = entry.get();
+    return bcos::h256(
+        bcos::bytesConstRef(reinterpret_cast<bcos::byte const*>(value.data()), value.size()));
+}
+
+}  // namespace detail
+
+/// Group a flat key→Entry delta into per-account AccountDelta records.
+///
+/// @param delta    a range yielding (key, Entry) pairs — a storage2 range in
+///                 production, a vector<pair<string, Entry>> in tests.
+/// @param readView any object exposing `task::Task<bool> hasAccount(Address) const`
+///                 (PR-09 supplies the real one; tests pass a mock). Used to set
+///                 firstTouch = !hasAccount(addr).
+/// @param l2Mode   true on an Ethereum-compatible (L2) chain: BCOS extension rows
+///                 (abi/alive/frozen/shard/code/...) are an error and throw
+///                 UnexpectedBCOSFieldInL2. false on a native BCOS chain: those
+///                 rows are silently skipped (they don't affect the Ethereum
+///                 4-tuple state root).
+///
+/// DEVIATION (vs plan): the plan threaded a `Features const&` and read
+/// feature_mpt_state_root / feature_l2_ethereum_compat. Neither flag exists in
+/// bcos-framework Features.h, so classify takes an explicit bool l2Mode instead;
+/// the caller (PR-10) decides the value.
+template <typename FlatDelta>
+bcos::task::Task<MPTBuildInput> classify(FlatDelta const& delta, auto const& readView, bool l2Mode)
+{
+    MPTBuildInput result;
+
+    for (auto&& [key, entry] : delta)
+    {
+        detail::ParsedKey const parsed = detail::parseKey(std::string_view{key});
+        using Kind = detail::ParsedKey::Kind;
+
+        if (parsed.kind == Kind::NotAnAccount)
+        {
+            continue;
+        }
+        if (parsed.kind == Kind::BcosExtension)
+        {
+            if (l2Mode)
+            {
+                BOOST_THROW_EXCEPTION(
+                    UnexpectedBCOSFieldInL2{} << bcos::errinfo_comment(
+                        "classify: BCOS extension field present in L2 (Ethereum-compatible) "
+                        "mode; key=" +
+                        std::string{key}));
+            }
+            continue;  // native BCOS chain: not part of the Ethereum 4-tuple
+        }
+
+        bool const deleted = entry.status() == bcos::storage::Entry::DELETED;
+        AccountDelta& account = result.perAccount[parsed.address];
+
+        switch (parsed.kind)
+        {
+        case Kind::Nonce:
+            if (deleted)
+            {
+                account.nonceState = AccountDelta::FieldState::Deleted;
+            }
+            else
+            {
+                account.nonceState = AccountDelta::FieldState::Updated;
+                account.nonce = detail::entryToU256(entry);
+            }
+            break;
+        case Kind::Balance:
+            if (deleted)
+            {
+                account.balanceState = AccountDelta::FieldState::Deleted;
+            }
+            else
+            {
+                account.balanceState = AccountDelta::FieldState::Updated;
+                account.balance = detail::entryToU256(entry);
+            }
+            break;
+        case Kind::CodeHash:
+            if (deleted)
+            {
+                account.codeHashState = AccountDelta::FieldState::Deleted;
+            }
+            else
+            {
+                account.codeHashState = AccountDelta::FieldState::Updated;
+                account.codeHash = detail::entryToH256(entry);
+            }
+            break;
+        case Kind::StorageSlot:
+            if (deleted)
+            {
+                account.storageChanges[parsed.slot] = std::nullopt;
+            }
+            else
+            {
+                std::string_view const value = entry.get();
+                account.storageChanges[parsed.slot] = bcos::bytes(value.begin(), value.end());
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+    // Post-grouping passes: tombstone synthesis and first-touch probing.
+    for (auto& [address, account] : result.perAccount)
+    {
+        if (account.nonceState == AccountDelta::FieldState::Deleted &&
+            account.balanceState == AccountDelta::FieldState::Deleted &&
+            account.codeHashState == AccountDelta::FieldState::Deleted)
+        {
+            account.tombstone = true;
+        }
+        account.firstTouch = !(co_await readView.hasAccount(address));
+    }
+
+    co_return result;
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Classify.h
+++ b/bcos-ledger/bcos-ledger/mpt/Classify.h
@@ -80,8 +80,9 @@ struct ParsedKey
     bcos::h256 slot;  ///< valid only when kind==StorageSlot
 };
 
-/// Classify a single "<table>:<row>" key. Never throws; l2Mode handling of
-/// BcosExtension rows is the caller's decision.
+/// Classify a single "<table>:<row>" key. Never throws: a malformed (non-hex) address is
+/// reported as NotAnAccount rather than propagating. l2Mode handling of BcosExtension rows is
+/// the caller's decision.
 inline ParsedKey parseKey(std::string_view fullKey)
 {
     ParsedKey parsed;
@@ -104,7 +105,16 @@ inline ParsedKey parseKey(std::string_view fullKey)
     {
         return parsed;  // NotAnAccount: not a 20-byte address table
     }
-    parsed.address = bcos::Address(std::string(addrHex), bcos::Address::FromHex);
+    // Address(..., FromHex) throws BadHexCharacter on a non-hex digit. Real /apps/ table names are
+    // always valid 40-hex, but guard so parseKey's no-throw contract holds for arbitrary input.
+    try
+    {
+        parsed.address = bcos::Address(std::string(addrHex), bcos::Address::FromHex);
+    }
+    catch (...)
+    {
+        return parsed;  // NotAnAccount: address is not valid hex
+    }
 
     // A 32-byte binary row key is a storage slot, never a named field.
     if (row.size() == static_cast<size_t>(bcos::h256::SIZE))
@@ -135,15 +145,24 @@ inline ParsedKey parseKey(std::string_view fullKey)
     return parsed;
 }
 
-/// Decode an Entry's stored bytes as a big-endian u256 (nonce/balance values).
+/// Parse an Entry's stored value as a u256. The executor stores nonce and balance as DECIMAL
+/// ASCII strings, NOT big-endian binary: balance is written with boost::lexical_cast<string> and
+/// read with u256(string) (AccountPrecompiled.cpp), nonce with u256::convert_to<string>()
+/// (TransactionExecutive/EVMAccount). An empty value decodes as 0 (the executor's value_or("0")
+/// convention). Reading these bytes big-endian would corrupt the value (e.g. "100" -> 0x313030).
 inline bcos::u256 entryToU256(bcos::storage::Entry const& entry)
 {
     std::string_view const value = entry.get();
-    return bcos::fromBigEndian<bcos::u256>(
-        bcos::bytesConstRef(reinterpret_cast<bcos::byte const*>(value.data()), value.size()));
+    if (value.empty())
+    {
+        return bcos::u256{0};
+    }
+    return bcos::u256{std::string{value}};
 }
 
-/// Copy an Entry's stored bytes into a 32-byte hash (codeHash value).
+/// Copy an Entry's stored bytes into a 32-byte hash. Unlike nonce/balance, codeHash is stored as
+/// the RAW 32-byte digest: TransactionExecutive writes codeHashEntry.importFields({codeHash
+/// .asBytes()}), so the value bytes ARE the hash and are read directly.
 inline bcos::h256 entryToH256(bcos::storage::Entry const& entry)
 {
     std::string_view const value = entry.get();
@@ -177,7 +196,9 @@ bcos::task::Task<MPTBuildInput> classify(FlatDelta const& delta, auto const& rea
 
     for (auto&& [key, entry] : delta)
     {
-        detail::ParsedKey const parsed = detail::parseKey(std::string_view{key});
+        // string_view{key.data(), key.size()} (not string_view{key}) so this also accepts a
+        // storage2 StateKey in PR-10: it exposes data()/size() but no operator string_view.
+        detail::ParsedKey const parsed = detail::parseKey(std::string_view{key.data(), key.size()});
         using Kind = detail::ParsedKey::Kind;
 
         if (parsed.kind == Kind::NotAnAccount)

--- a/bcos-ledger/bcos-ledger/mpt/Classify.h
+++ b/bcos-ledger/bcos-ledger/mpt/Classify.h
@@ -158,7 +158,9 @@ inline bcos::u256 entryToU256(bcos::storage::Entry const& entry)
     {
         return bcos::u256{0};
     }
-    return bcos::u256{std::string{value}};
+    // boost::multiprecision::number has a string_view constructor (number.hpp) that takes the
+    // length explicitly, so no NUL terminator and no std::string copy are needed.
+    return bcos::u256{value};
 }
 
 /// Copy an Entry's stored bytes into a 32-byte hash. Unlike nonce/balance, codeHash is stored as

--- a/bcos-ledger/bcos-ledger/mpt/Classify.h
+++ b/bcos-ledger/bcos-ledger/mpt/Classify.h
@@ -28,6 +28,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <boost/throw_exception.hpp>
+#include <cassert>
 #include <optional>
 #include <string_view>
 
@@ -162,10 +163,15 @@ inline bcos::u256 entryToU256(bcos::storage::Entry const& entry)
 
 /// Copy an Entry's stored bytes into a 32-byte hash. Unlike nonce/balance, codeHash is stored as
 /// the RAW 32-byte digest: TransactionExecutive writes codeHashEntry.importFields({codeHash
-/// .asBytes()}), so the value bytes ARE the hash and are read directly.
+/// .asBytes()}), so the value bytes ARE the hash and are read directly. A value whose length is
+/// not 32 would be silently zero-padded/truncated by the h256 ctor (and an empty value yields the
+/// all-zero hash, which is NOT emptyCodeHash()); callers only reach here for a non-deleted codeHash
+/// row, which is always 32 raw bytes, so assert the invariant rather than mask a corrupt entry.
 inline bcos::h256 entryToH256(bcos::storage::Entry const& entry)
 {
     std::string_view const value = entry.get();
+    assert(value.size() == static_cast<size_t>(bcos::h256::SIZE) &&
+           "codeHash entry must be exactly 32 raw bytes");
     return bcos::h256(
         bcos::bytesConstRef(reinterpret_cast<bcos::byte const*>(value.data()), value.size()));
 }

--- a/bcos-ledger/bcos-ledger/mpt/Classify.h
+++ b/bcos-ledger/bcos-ledger/mpt/Classify.h
@@ -106,11 +106,12 @@ inline ParsedKey parseKey(std::string_view fullKey)
     {
         return parsed;  // NotAnAccount: not a 20-byte address table
     }
-    // Address(..., FromHex) throws BadHexCharacter on a non-hex digit. Real /apps/ table names are
-    // always valid 40-hex, but guard so parseKey's no-throw contract holds for arbitrary input.
+    // Address (FixedBytes<20>) has a string_view + FromHex constructor, so no std::string temp is
+    // needed. It throws on a non-hex digit / bad length; real /apps/ table names are always valid
+    // 40-hex, but guard so parseKey's no-throw contract holds for arbitrary input.
     try
     {
-        parsed.address = bcos::Address(std::string(addrHex), bcos::Address::FromHex);
+        parsed.address = bcos::Address(addrHex, bcos::Address::FromHex);
     }
     catch (...)
     {

--- a/bcos-ledger/test/unittests/mpt/AccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/AccountTest.cpp
@@ -159,6 +159,29 @@ BOOST_AUTO_TEST_CASE(MalformedInputThrows)
     }
 }
 
+// ---------------------------------------------------------------------------
+// Test 6: a hash field whose RLP payload is not exactly 32 bytes is rejected (the generic
+// FixedBytes<32> decoder would silently zero-pad a short payload — decodeHash32 must not).
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(ShortHashFieldRejected)
+{
+    // Build a 4-field list whose storageRoot is a 31-byte string (one byte short).
+    bcos::bytes payload;
+    payload.push_back(0x80);                                // nonce = 0 (empty string)
+    payload.push_back(0x80);                                // balance = 0 (empty string)
+    payload.push_back(static_cast<bcos::byte>(0x80 + 31));  // storageRoot: 31-byte string header
+    payload.insert(payload.end(), 31, 0x11);                // 31 payload bytes (should be 32)
+    payload.push_back(static_cast<bcos::byte>(0x80 + 32));  // codeHash: 32-byte string header
+    payload.insert(payload.end(), 32, 0x22);                // 32 payload bytes
+
+    bcos::bytes rlp;
+    rlp.push_back(static_cast<bcos::byte>(0xf7 + 1));  // long-list header, 1 length byte
+    rlp.push_back(static_cast<bcos::byte>(payload.size()));
+    rlp.insert(rlp.end(), payload.begin(), payload.end());
+
+    BOOST_CHECK_THROW(Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size())), MPTDecodeError);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/AccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/AccountTest.cpp
@@ -106,6 +106,27 @@ BOOST_AUTO_TEST_CASE(NonDefaultHashesRoundTrip)
 }
 
 // ---------------------------------------------------------------------------
+// Test 4b: a hash with leading zero bytes must encode as a fixed 32-byte string (the
+// FixedBytes<32> RLP overload), NOT be trimmed like an integer. h256 has an implicit
+// operator u256(), so this guards against encode() accidentally selecting the leading-zero-
+// trimming integer path — which would shorten the field and corrupt Ethereum compatibility.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(LeadingZeroHashStaysFixed32Bytes)
+{
+    Account account;
+    account.storageRoot =
+        bcos::h256("0x00000000000000000000000000000000000000000000000000000000000000ab");
+    account.codeHash =
+        bcos::h256("0x0000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+    bcos::bytes const rlp = account.encode();
+    Account const decoded = Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size()));
+
+    BOOST_CHECK_EQUAL(decoded.storageRoot, account.storageRoot);
+    BOOST_CHECK_EQUAL(decoded.codeHash, account.codeHash);
+}
+
+// ---------------------------------------------------------------------------
 // Test 5: malformed inputs throw MPTDecodeError.
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(MalformedInputThrows)

--- a/bcos-ledger/test/unittests/mpt/AccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/AccountTest.cpp
@@ -1,0 +1,143 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AccountTest.cpp
+ * @brief Unit tests for Account 4-tuple RLP encode/decode (spec §5.4)
+ */
+
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-utilities/Common.h>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(AccountSuite)
+
+// ---------------------------------------------------------------------------
+// Test 1: a default-constructed account round-trips and carries the well-known
+// empty roots.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(EmptyAccountRoundTrip)
+{
+    Account account;
+    BOOST_CHECK_EQUAL(account.nonce, 0);
+    BOOST_CHECK_EQUAL(account.balance, 0);
+    BOOST_CHECK_EQUAL(account.storageRoot, emptyRootHash());
+    BOOST_CHECK_EQUAL(account.codeHash, emptyCodeHash());
+
+    bcos::bytes const rlp = account.encode();
+    Account const decoded = Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size()));
+
+    BOOST_CHECK_EQUAL(decoded.nonce, 0);
+    BOOST_CHECK_EQUAL(decoded.balance, 0);
+    BOOST_CHECK_EQUAL(decoded.storageRoot, emptyRootHash());
+    BOOST_CHECK_EQUAL(decoded.codeHash, emptyCodeHash());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: nonce 0 encodes to the empty string (0x80, not 0x00) and round-trips;
+// nonce 256 (a 2-byte big-endian integer) also round-trips.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(NonceZeroAndTwoFiftySixRoundTrip)
+{
+    {
+        Account account;
+        account.nonce = 0;
+        bcos::bytes const rlp = account.encode();
+        Account const decoded = Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size()));
+        BOOST_CHECK_EQUAL(decoded.nonce, 0);
+    }
+    {
+        Account account;
+        account.nonce = 256;
+        bcos::bytes const rlp = account.encode();
+        Account const decoded = Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size()));
+        BOOST_CHECK_EQUAL(decoded.nonce, 256);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: a large u256 balance round-trips exactly (no truncation / sign issues).
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(LargeBalanceRoundTrip)
+{
+    Account account;
+    account.balance = bcos::u256{"0x123456789abcdef0123456789abcdef0123456789abcdef0"};
+    account.nonce = 42;
+
+    bcos::bytes const rlp = account.encode();
+    Account const decoded = Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size()));
+
+    BOOST_CHECK_EQUAL(decoded.balance, account.balance);
+    BOOST_CHECK_EQUAL(decoded.nonce, 42);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: non-default hashes survive the round-trip as fixed 32-byte strings.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(NonDefaultHashesRoundTrip)
+{
+    Account account;
+    account.storageRoot =
+        bcos::h256("0x1111111111111111111111111111111111111111111111111111111111111111");
+    account.codeHash =
+        bcos::h256("0x2222222222222222222222222222222222222222222222222222222222222222");
+
+    bcos::bytes const rlp = account.encode();
+    Account const decoded = Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size()));
+
+    BOOST_CHECK_EQUAL(decoded.storageRoot, account.storageRoot);
+    BOOST_CHECK_EQUAL(decoded.codeHash, account.codeHash);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: malformed inputs throw MPTDecodeError.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(MalformedInputThrows)
+{
+    // Empty input.
+    {
+        bcos::bytes const empty;
+        BOOST_CHECK_THROW(
+            Account::decode(bcos::bytesConstRef(empty.data(), empty.size())), MPTDecodeError);
+    }
+    // A single byte that decodes as a string item, not a list.
+    {
+        bcos::bytes const notAList{0x05};
+        BOOST_CHECK_THROW(
+            Account::decode(bcos::bytesConstRef(notAList.data(), notAList.size())), MPTDecodeError);
+    }
+    // A well-formed list but with too few fields (list of one element).
+    {
+        bcos::bytes const shortList{0xc1, 0x05};  // list(payload=1) holding integer 5
+        BOOST_CHECK_THROW(Account::decode(bcos::bytesConstRef(shortList.data(), shortList.size())),
+            MPTDecodeError);
+    }
+    // A valid account with trailing junk after the list.
+    {
+        Account account;
+        bcos::bytes rlp = account.encode();
+        rlp.push_back(0xff);  // trailing byte beyond the declared list
+        BOOST_CHECK_THROW(
+            Account::decode(bcos::bytesConstRef(rlp.data(), rlp.size())), MPTDecodeError);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/ClassifyTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ClassifyTest.cpp
@@ -1,0 +1,206 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ClassifyTest.cpp
+ * @brief Unit tests for classify(): flat key→Entry delta into per-account
+ *        AccountDelta with first-touch / subsequent / tombstone classification
+ *        (spec §5.2)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-ledger/mpt/Classify.h>
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+namespace
+{
+// The flat-state delta classify() consumes: a range of (key, Entry) pairs.
+using ClassifyFlatDelta = std::vector<std::pair<std::string, bcos::storage::Entry>>;
+
+// A fixed 40-hex account address and the matching 20-byte Address value.
+constexpr std::string_view CLASSIFY_TEST_ADDR_HEX = "00112233445566778899aabbccddeeff00112233";
+constexpr std::string_view CLASSIFY_TEST_TABLE = "/apps/00112233445566778899aabbccddeeff00112233";
+
+bcos::Address classifyTestAddress()
+{
+    return bcos::Address(std::string{CLASSIFY_TEST_ADDR_HEX}, bcos::Address::FromHex);
+}
+
+// Build "<table>:<row>" for a named field row.
+std::string classifyFieldKey(std::string_view row)
+{
+    std::string key{CLASSIFY_TEST_TABLE};
+    key.push_back(':');
+    key.append(row);
+    return key;
+}
+
+// Build "<table>:<32-byte-binary-slot>" for a storage slot.
+std::string classifySlotKey(bcos::h256 const& slot)
+{
+    std::string key{CLASSIFY_TEST_TABLE};
+    key.push_back(':');
+    key.append(reinterpret_cast<char const*>(slot.data()), slot.size());
+    return key;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(ClassifySuite)
+
+// ---------------------------------------------------------------------------
+// Test 1: a single account with nonce + balance writes groups under one address,
+// both fields Updated, firstTouch true (mock hasAccount returns false).
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(GroupsByAddressFirstTouch)
+{
+    ClassifyFlatDelta delta;
+    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("\x01"));
+    delta.emplace_back(classifyFieldKey(ROW_BALANCE), makeEntry("\x64"));  // 100
+
+    MockReadView view;  // address unset → hasAccount false → firstTouch true
+
+    auto const result = bcos::task::syncWait(classify(delta, view, /*l2Mode=*/false));
+
+    BOOST_REQUIRE_EQUAL(result.perAccount.size(), 1U);
+    auto const it = result.perAccount.find(classifyTestAddress());
+    BOOST_REQUIRE(it != result.perAccount.end());
+    auto const& account = it->second;
+
+    BOOST_CHECK(account.firstTouch);
+    BOOST_CHECK(account.nonceState == AccountDelta::FieldState::Updated);
+    BOOST_CHECK(account.balanceState == AccountDelta::FieldState::Updated);
+    BOOST_CHECK_EQUAL(account.nonce, 1);
+    BOOST_CHECK_EQUAL(account.balance, 100);
+    BOOST_CHECK(account.codeHashState == AccountDelta::FieldState::Unchanged);
+    BOOST_CHECK(!account.tombstone);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: a storage slot write lands in storageChanges keyed by the 32-byte slot.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(StorageSlotEntersStorageChanges)
+{
+    bcos::h256 const slot = makeHash(0x05);
+    ClassifyFlatDelta delta;
+    delta.emplace_back(classifySlotKey(slot), makeEntry("\xde\xad"));
+
+    MockReadView view;
+    auto const result = bcos::task::syncWait(classify(delta, view, /*l2Mode=*/false));
+
+    BOOST_REQUIRE_EQUAL(result.perAccount.size(), 1U);
+    auto const& account = result.perAccount.begin()->second;
+    BOOST_REQUIRE_EQUAL(account.storageChanges.size(), 1U);
+    auto const slotIt = account.storageChanges.find(slot);
+    BOOST_REQUIRE(slotIt != account.storageChanges.end());
+    BOOST_REQUIRE(slotIt->second.has_value());
+    BOOST_CHECK_EQUAL(slotIt->second->size(), 2U);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 (Scenario A, l2Mode=false): BCOS extension rows are silently skipped;
+// nonce is kept, storageChanges stays empty.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(BcosExtensionSkippedWhenNotL2)
+{
+    ClassifyFlatDelta delta;
+    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("\x01"));
+    delta.emplace_back(classifyFieldKey("abi"), makeEntry("\xde\xad\xbe\xef"));
+    delta.emplace_back(classifyFieldKey("alive"), makeEntry("\x01"));
+    delta.emplace_back(classifyFieldKey("frozen"), makeEntry("\x00"));
+    delta.emplace_back(classifyFieldKey("shard"), makeEntry("g1"));
+    delta.emplace_back(classifyFieldKey("code"), makeEntry("\x60\x60"));
+
+    MockReadView view;
+    auto const result = bcos::task::syncWait(classify(delta, view, /*l2Mode=*/false));
+
+    BOOST_REQUIRE_EQUAL(result.perAccount.size(), 1U);
+    auto const& account = result.perAccount.begin()->second;
+    BOOST_CHECK(account.nonceState == AccountDelta::FieldState::Updated);
+    BOOST_CHECK(account.balanceState == AccountDelta::FieldState::Unchanged);
+    BOOST_CHECK(account.codeHashState == AccountDelta::FieldState::Unchanged);
+    BOOST_CHECK(account.storageChanges.empty());
+    BOOST_CHECK(!account.tombstone);
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 (Scenario B, l2Mode=true): a BCOS extension row throws.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(BcosExtensionThrowsWhenL2)
+{
+    ClassifyFlatDelta delta;
+    delta.emplace_back(classifyFieldKey("abi"), makeEntry("\xde\xad\xbe\xef"));
+
+    MockReadView view;
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(classify(delta, view, /*l2Mode=*/true)), UnexpectedBCOSFieldInL2);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: SELFDESTRUCT → tombstone. All three core fields DELETED, account
+// already exists (mock hasAccount returns true → firstTouch false).
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(SelfdestructTombstone)
+{
+    ClassifyFlatDelta delta;
+    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeDeletedEntry());
+    delta.emplace_back(classifyFieldKey(ROW_BALANCE), makeDeletedEntry());
+    delta.emplace_back(classifyFieldKey(ROW_CODE_HASH), makeDeletedEntry());
+
+    MockReadView view;
+    view.setHasAccount(classifyTestAddress(), true);  // tombstone needs a pre-existing account
+
+    auto const result = bcos::task::syncWait(classify(delta, view, /*l2Mode=*/false));
+
+    BOOST_REQUIRE_EQUAL(result.perAccount.size(), 1U);
+    auto const& account = result.perAccount.begin()->second;
+    BOOST_CHECK(account.tombstone);
+    BOOST_CHECK(!account.firstTouch);
+    BOOST_CHECK(account.nonceState == AccountDelta::FieldState::Deleted);
+    BOOST_CHECK(account.balanceState == AccountDelta::FieldState::Deleted);
+    BOOST_CHECK(account.codeHashState == AccountDelta::FieldState::Deleted);
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: rows under a non-/apps/ table (and keys with no separator) are ignored.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(NonAccountRowsIgnored)
+{
+    ClassifyFlatDelta delta;
+    delta.emplace_back("/sys/s_tables:value", makeEntry("\x01"));
+    delta.emplace_back("/tables/foo:nonce", makeEntry("\x01"));
+    delta.emplace_back("no_colon_key", makeEntry("\x01"));
+    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("\x07"));  // the only real account
+                                                                         // row
+
+    MockReadView view;
+    auto const result = bcos::task::syncWait(classify(delta, view, /*l2Mode=*/false));
+
+    BOOST_REQUIRE_EQUAL(result.perAccount.size(), 1U);
+    auto const& account = result.perAccount.begin()->second;
+    BOOST_CHECK(account.nonceState == AccountDelta::FieldState::Updated);
+    BOOST_CHECK_EQUAL(account.nonce, 7);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/ClassifyTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ClassifyTest.cpp
@@ -74,8 +74,9 @@ BOOST_AUTO_TEST_SUITE(ClassifySuite)
 BOOST_AUTO_TEST_CASE(GroupsByAddressFirstTouch)
 {
     ClassifyFlatDelta delta;
-    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("\x01"));
-    delta.emplace_back(classifyFieldKey(ROW_BALANCE), makeEntry("\x64"));  // 100
+    // nonce/balance are stored as decimal ASCII strings by the executor, not big-endian binary.
+    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("1"));
+    delta.emplace_back(classifyFieldKey(ROW_BALANCE), makeEntry("100"));
 
     MockReadView view;  // address unset → hasAccount false → firstTouch true
 
@@ -117,13 +118,35 @@ BOOST_AUTO_TEST_CASE(StorageSlotEntersStorageChanges)
 }
 
 // ---------------------------------------------------------------------------
+// Test 2b: a codeHash write is read back as the raw 32-byte digest (the executor stores it via
+// codeHash.asBytes(), not decimal ASCII), with state Updated.
+// ---------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(CodeHashUpdatedReadsRawBytes)
+{
+    bcos::h256 const expected = makeHash(0x42);
+    ClassifyFlatDelta delta;
+    delta.emplace_back(classifyFieldKey(ROW_CODE_HASH),
+        makeEntry(
+            std::string_view(reinterpret_cast<char const*>(expected.data()), expected.size())));
+
+    MockReadView view;
+    auto const result = bcos::task::syncWait(classify(delta, view, /*l2Mode=*/false));
+
+    BOOST_REQUIRE_EQUAL(result.perAccount.size(), 1U);
+    auto const& account = result.perAccount.begin()->second;
+    BOOST_CHECK(account.codeHashState == AccountDelta::FieldState::Updated);
+    BOOST_CHECK_EQUAL(account.codeHash, expected);
+    BOOST_CHECK(account.nonceState == AccountDelta::FieldState::Unchanged);
+}
+
+// ---------------------------------------------------------------------------
 // Test 3 (Scenario A, l2Mode=false): BCOS extension rows are silently skipped;
 // nonce is kept, storageChanges stays empty.
 // ---------------------------------------------------------------------------
 BOOST_AUTO_TEST_CASE(BcosExtensionSkippedWhenNotL2)
 {
     ClassifyFlatDelta delta;
-    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("\x01"));
+    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("1"));
     delta.emplace_back(classifyFieldKey("abi"), makeEntry("\xde\xad\xbe\xef"));
     delta.emplace_back(classifyFieldKey("alive"), makeEntry("\x01"));
     delta.emplace_back(classifyFieldKey("frozen"), makeEntry("\x00"));
@@ -189,8 +212,7 @@ BOOST_AUTO_TEST_CASE(NonAccountRowsIgnored)
     delta.emplace_back("/sys/s_tables:value", makeEntry("\x01"));
     delta.emplace_back("/tables/foo:nonce", makeEntry("\x01"));
     delta.emplace_back("no_colon_key", makeEntry("\x01"));
-    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("\x07"));  // the only real account
-                                                                         // row
+    delta.emplace_back(classifyFieldKey(ROW_NONCE), makeEntry("7"));  // the only real account row
 
     MockReadView view;
     auto const result = bcos::task::syncWait(classify(delta, view, /*l2Mode=*/false));

--- a/bcos-ledger/test/unittests/mpt/TestHelpers.h
+++ b/bcos-ledger/test/unittests/mpt/TestHelpers.h
@@ -20,14 +20,19 @@
 
 #include <bcos-crypto/hasher/AnyHasher.h>
 #include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-framework/storage/Entry.h>
 #include <bcos-ledger/mpt/Constants.h>
 #include <bcos-ledger/mpt/Nibble.h>
 #include <bcos-ledger/mpt/NodeEncoder.h>
 #include <bcos-ledger/mpt/TrieNode.h>
+#include <bcos-task/Task.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <memory>
 #include <random>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -47,6 +52,50 @@ inline std::mt19937 seededRng(uint32_t s)
 {
     return std::mt19937{s};
 }
+
+// ---------------------------------------------------------------------------
+// Account / classify test helpers (PR-08+)
+// ---------------------------------------------------------------------------
+
+/// A 20-byte address with only its first byte set to @p firstByte.
+inline bcos::Address makeAddress(uint8_t firstByte)
+{
+    bcos::Address addr{};
+    addr.data()[0] = firstByte;
+    return addr;
+}
+
+/// A NORMAL Entry holding @p value as its raw stored bytes.
+inline bcos::storage::Entry makeEntry(std::string_view value)
+{
+    bcos::storage::Entry entry;
+    entry.set(std::string{value});
+    return entry;
+}
+
+/// A DELETED Entry (status tombstone, no value).
+inline bcos::storage::Entry makeDeletedEntry()
+{
+    bcos::storage::Entry entry;
+    entry.setStatus(bcos::storage::Entry::DELETED);
+    return entry;
+}
+
+/// Minimal stand-in for the PR-09 MPTReadView: classify() only needs
+/// `task::Task<bool> hasAccount(Address) const`. Unset addresses default to
+/// "absent" (hasAccount → false → firstTouch true).
+struct MockReadView
+{
+    std::unordered_map<bcos::Address, bool> hasMap;
+
+    void setHasAccount(bcos::Address address, bool present) { hasMap[address] = present; }
+
+    bcos::task::Task<bool> hasAccount(bcos::Address address) const
+    {
+        auto const it = hasMap.find(address);
+        co_return it != hasMap.end() && it->second;
+    }
+};
 
 // ---------------------------------------------------------------------------
 // Independent reference trie (correctness oracle).


### PR DESCRIPTION
## Summary

Phase-A M4.1 of the MPT lazy-build plan. Adds the account model the MPT builder works on: the Ethereum 4-tuple account with RLP codec, a per-account change descriptor, and `classify()` which turns a flat state delta into per-account grouped input. Builds on the merged M3 (#5244). 7 files, all under `bcos-ledger/bcos-ledger/mpt/` + its tests.

## What lands

**Account** (`Account.h/.cpp`) — the `(nonce, balance, storageRoot, codeHash)` 4-tuple with `encode()`/`decode()` RLP, matching Ethereum's account encoding (integer fields trim leading zeros via the shared `codec::rlp` integer overloads; `nonce==0`/`balance==0` encode as the empty string `0x80`). A default-constructed `Account` has `storageRoot == emptyRootHash()` and `codeHash == emptyCodeHash()`.

**AccountDelta + MPTBuildInput** (`AccountDelta.h`) — one block's changes to one account: per-field `FieldState {Unchanged, Updated, Deleted}` for nonce/balance/codeHash, a `storageChanges` map (`slotKey → value | nullopt`), plus `tombstone` and `firstTouch` flags. `MPTBuildInput` groups these by `bcos::Address`.

**classify()** (`Classify.h`, header-only template) — parses a flat state delta (`(key, Entry)` range) into `MPTBuildInput`: groups rows by account address, maps `nonce`/`balance`/`codeHash` rows to fields and 32-byte rows to storage slots, synthesizes a tombstone when the three core fields are all deleted, and sets `firstTouch` from a read-view probe (`hasAccount`).

## Deviations from the plan (PR-08 doc)

The plan doc predates the M2/M3 refactors and assumed APIs that do not exist. Concretely:

- **`classify()` takes an explicit `bool l2Mode`, not a `Features` object.** The plan's `feature_mpt_state_root` / `feature_l2_ethereum_compat` flags do not exist in `Features.h`. The caller (future PR-10) supplies the mode. In `l2Mode==false` the BCOS extension rows (`abi`, `alive`, `frozen`, `shard`, `code`, …) are silently skipped; in `l2Mode==true` they throw `UnexpectedBCOSFieldInL2` (already declared in `Errors.h`).
- **No `Types.h` / `Hash32` / `EMPTY_*` macros.** Uses `bcos::h256` / `bcos::Address` / `bcos::u256` and the `emptyRootHash()` / `emptyCodeHash()` functions from `Constants.h`.
- **`classify()` is a header-only template** (no `Classify.cpp`) so it works over both the test's in-memory delta and PR-10's storage2 range.
- **Flat-state key format anchored to the real `StateKey` layout**, not the plan's guess. A row is an `executor_v1::StateKey` serialized as `<table>:<key>` (`bcos-framework/.../transaction-executor/StateKey.h`), where an account table is `/apps/<40-hex-address>` (`bcos-executor/src/Common.h` `USER_APPS_PREFIX`) and the row is a field name (`bcos-executor/src/Common.h` field constants) or a 32-byte binary storage slot. Documented in a header comment; PR-10 must reconcile against the executor's actual writes when it wires classify in.

## Test plan

- `AccountSuite` (5) + `ClassifySuite` (6) = 11 cases, all green:
  - Account: empty-account round-trip to default roots, nonce 0/256 round-trip, large-u256 balance round-trip, malformed decode throws.
  - Classify: group-by-address with first-touch, BCOS-extension-skipped (`l2Mode=false`), BCOS-extension-throws (`l2Mode=true`), selfdestruct→tombstone.
- `TestHelpers.h` extended (additively) with `makeAddress` / `makeEntry` / `makeDeletedEntry` / `MockReadView`.
- Full `test-bcos-ledger` binary: `*** No errors detected` (no regression).
- clang-format `--dry-run --Werror` clean on all 7 files. Verified by an independent rebuild + test run on the merged-M3 base.

Refs: spec §5.2, §5.4, §5.5