### PR TITLE
feat(storage): DeferredWriteBatch single-CF atomic write helper (M5.2a)

### DIFF
--- a/bcos-storage/CMakeLists.txt
+++ b/bcos-storage/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(Boost REQUIRED serialization thread context filesystem)
 set(SRC_LIST bcos-storage/Common.cpp)
 list(APPEND SRC_LIST bcos-storage/RocksDBStorage.cpp)
 list(APPEND SRC_LIST bcos-storage/CheckpointRocksDBStorage.cpp)
+list(APPEND SRC_LIST bcos-storage/DeferredWriteBatch.cpp)
 
 set(LIB_LIST table bcos-framework Boost::serialization Boost::filesystem zstd::libzstd_static RocksDB::rocksdb ittapi)
 

--- a/bcos-storage/bcos-storage/DeferredWriteBatch.cpp
+++ b/bcos-storage/bcos-storage/DeferredWriteBatch.cpp
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Single-CF atomic write handle over rocksdb::WriteBatch (spec §5.6 / §5.7)
+ * @file DeferredWriteBatch.cpp
+ * @author: kyonRay
+ * @date: 2026-06-23
+ */
+#include "DeferredWriteBatch.h"
+#include <rocksdb/slice.h>
+
+namespace bcos::storage2::rocksdb
+{
+DeferredWriteBatch::DeferredWriteBatch(::rocksdb::DB& db) : m_db(std::addressof(db)) {}
+
+void DeferredWriteBatch::put(std::string_view key, std::string_view value)
+{
+    m_batch.Put(m_db->DefaultColumnFamily(), ::rocksdb::Slice{key.data(), key.size()},
+        ::rocksdb::Slice{value.data(), value.size()});
+}
+
+void DeferredWriteBatch::del(std::string_view key)
+{
+    m_batch.Delete(m_db->DefaultColumnFamily(), ::rocksdb::Slice{key.data(), key.size()});
+}
+
+::rocksdb::Status DeferredWriteBatch::commit() noexcept
+{
+    if (m_committed)
+    {
+        return ::rocksdb::Status::InvalidArgument("DeferredWriteBatch already committed");
+    }
+    m_committed = true;
+    // WriteOptions.sync left at default — spec §5.6 forbids relaxing durability for MPT nodes.
+    ::rocksdb::WriteOptions wopts;
+    return m_db->Write(wopts, &m_batch);
+}
+}  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/DeferredWriteBatch.h
+++ b/bcos-storage/bcos-storage/DeferredWriteBatch.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Single-CF atomic write handle over rocksdb::WriteBatch (spec §5.6 / §5.7)
+ * @file DeferredWriteBatch.h
+ * @author: kyonRay
+ * @date: 2026-06-23
+ */
+#pragma once
+#include <rocksdb/db.h>
+#include <rocksdb/write_batch.h>
+#include <string_view>
+
+namespace bcos::storage2::rocksdb
+{
+/// Single-CF (default) atomic write handle. Move-only; one commit then inert.
+/// Accumulates Put/Delete on the default column family and flushes them with a
+/// single db->Write(). Used by mergeBackStorageWithMPT (PR-14b) to atomically
+/// persist /apps/* flat state + /mpt/<hash> nodes + manifest deletes.
+class DeferredWriteBatch
+{
+public:
+    explicit DeferredWriteBatch(::rocksdb::DB& db);
+    ~DeferredWriteBatch() = default;
+    DeferredWriteBatch(DeferredWriteBatch const&) = delete;
+    DeferredWriteBatch& operator=(DeferredWriteBatch const&) = delete;
+    DeferredWriteBatch(DeferredWriteBatch&&) noexcept = default;
+    DeferredWriteBatch& operator=(DeferredWriteBatch&&) noexcept = default;
+
+    void put(std::string_view key, std::string_view value);
+    void del(std::string_view key);
+    ::rocksdb::Status commit() noexcept;  // one-shot; second call -> InvalidArgument
+    ::rocksdb::WriteBatch& rawBatch() noexcept { return m_batch; }
+
+private:
+    ::rocksdb::DB* m_db;
+    ::rocksdb::WriteBatch m_batch;
+    bool m_committed = false;
+};
+}  // namespace bcos::storage2::rocksdb

--- a/bcos-storage/bcos-storage/RocksDBStorage2.h
+++ b/bcos-storage/bcos-storage/RocksDBStorage2.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "DeferredWriteBatch.h"
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-task/AwaitableValue.h"
 #include "bcos-utilities/Error.h"
@@ -69,6 +70,9 @@ public:
 
     ::rocksdb::DB& rocksDB() noexcept { return rocksDBRef(); }
     ::rocksdb::DB const& rocksDB() const noexcept { return rocksDBRef(); }
+
+    /// Create a single-CF atomic write handle over the underlying DB (spec §5.6 / §5.7).
+    DeferredWriteBatch makeDeferredBatch() { return DeferredWriteBatch{rocksDBRef()}; }
 
     auto readSomeRaw(::ranges::input_range auto keys, auto&&... /*args*/)
         -> task::Task<std::vector<StorageValueType<ValueType>>>

--- a/bcos-storage/test/unittest/CMakeLists.txt
+++ b/bcos-storage/test/unittest/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "main.cpp")
+list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "DeferredWriteBatchTest.cpp" "main.cpp")
 # cmake settings
 set(TEST_BINARY_NAME test-storage)
 

--- a/bcos-storage/test/unittest/DeferredWriteBatchTest.cpp
+++ b/bcos-storage/test/unittest/DeferredWriteBatchTest.cpp
@@ -1,0 +1,193 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Unit tests for DeferredWriteBatch (single-CF atomic write helper)
+ * @file DeferredWriteBatchTest.cpp
+ * @author: kyonRay
+ * @date: 2026-06-23
+ */
+#include <bcos-storage/DeferredWriteBatch.h>
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-storage/RocksDBStorage2.h>
+#include <bcos-storage/StateKVResolver.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <random>
+#include <string>
+#include <string_view>
+
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::storage2::rocksdb;
+
+BOOST_AUTO_TEST_SUITE(DeferredWriteBatchSuite)
+
+namespace
+{
+std::string dwbUniqueTempPath()
+{
+    return "./dwb_test_" + std::to_string(std::random_device{}());
+}
+
+::rocksdb::DB* dwbOpenDB(const std::string& path)
+{
+    ::rocksdb::DB* rawPtr = nullptr;
+    ::rocksdb::Options options;
+    options.create_if_missing = true;
+    ::rocksdb::Status s = ::rocksdb::DB::Open(options, path, &rawPtr);
+    BOOST_REQUIRE(s.ok());
+    BOOST_REQUIRE(rawPtr != nullptr);
+    return rawPtr;
+}
+
+std::string dwbGet(::rocksdb::DB& db, std::string_view key, bool& found)
+{
+    std::string value;
+    auto status = db.Get(::rocksdb::ReadOptions(), db.DefaultColumnFamily(),
+        ::rocksdb::Slice{key.data(), key.size()}, &value);
+    found = status.ok();
+    if (!found)
+    {
+        BOOST_REQUIRE(status.IsNotFound());
+    }
+    return value;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(MultiPutCommitsAtomically)
+{
+    std::string path = dwbUniqueTempPath();
+    ::rocksdb::DB* rawPtr = dwbOpenDB(path);
+
+    // Inner scope: keep dbOwner/batch lifetime strictly shorter than the on-disk path so the
+    // DB is fully closed (background compaction/flush threads release lock/SST files) before
+    // remove_all runs — otherwise remove_all races the close path on lock-tracking filesystems.
+    {
+        std::unique_ptr<::rocksdb::DB> dbOwner(rawPtr);
+
+        // Seed a key we will delete via the batch.
+        ::rocksdb::WriteOptions wo;
+        BOOST_REQUIRE(dbOwner
+                ->Put(wo, dbOwner->DefaultColumnFamily(), std::string{"/apps/to_delete"},
+                    std::string{"old_value"})
+                .ok());
+
+        h256 hash = h256::generateRandomFixedBytes();
+        std::string mptKey = makeMPTNodeKey(hash);
+
+        DeferredWriteBatch batch(*dbOwner);
+        batch.put("/apps/acc1:balance", "100");
+        batch.put("/apps/acc2:balance", "200");
+        batch.put(mptKey, "mpt_node_data");
+        batch.del("/apps/to_delete");
+
+        BOOST_CHECK(batch.commit().ok());
+
+        bool found = false;
+        BOOST_CHECK_EQUAL(dwbGet(*dbOwner, "/apps/acc1:balance", found), "100");
+        BOOST_CHECK(found);
+        BOOST_CHECK_EQUAL(dwbGet(*dbOwner, "/apps/acc2:balance", found), "200");
+        BOOST_CHECK(found);
+        BOOST_CHECK_EQUAL(dwbGet(*dbOwner, mptKey, found), "mpt_node_data");
+        BOOST_CHECK(found);
+
+        // Deleted key must be gone.
+        dwbGet(*dbOwner, "/apps/to_delete", found);
+        BOOST_CHECK(!found);
+    }
+
+    boost::filesystem::remove_all(path);
+}
+
+BOOST_AUTO_TEST_CASE(EmptyBatchCommitIsNoop)
+{
+    std::string path = dwbUniqueTempPath();
+    ::rocksdb::DB* rawPtr = dwbOpenDB(path);
+
+    {
+        std::unique_ptr<::rocksdb::DB> dbOwner(rawPtr);
+        DeferredWriteBatch batch(*dbOwner);
+        BOOST_CHECK(batch.commit().ok());
+    }
+
+    boost::filesystem::remove_all(path);
+}
+
+BOOST_AUTO_TEST_CASE(DoubleCommitReturnsInvalidArgument)
+{
+    std::string path = dwbUniqueTempPath();
+    ::rocksdb::DB* rawPtr = dwbOpenDB(path);
+
+    {
+        std::unique_ptr<::rocksdb::DB> dbOwner(rawPtr);
+        DeferredWriteBatch batch(*dbOwner);
+        batch.put("/apps/k", "v");
+        BOOST_CHECK(batch.commit().ok());
+        BOOST_CHECK(batch.commit().IsInvalidArgument());
+    }
+
+    boost::filesystem::remove_all(path);
+}
+
+BOOST_AUTO_TEST_CASE(MoveSemanticsTransferOwnership)
+{
+    std::string path = dwbUniqueTempPath();
+    ::rocksdb::DB* rawPtr = dwbOpenDB(path);
+
+    {
+        std::unique_ptr<::rocksdb::DB> dbOwner(rawPtr);
+
+        DeferredWriteBatch batch1(*dbOwner);
+        batch1.put("/apps/moved", "after_move");
+
+        DeferredWriteBatch batch2 = std::move(batch1);
+        BOOST_CHECK(batch2.commit().ok());
+
+        bool found = false;
+        BOOST_CHECK_EQUAL(dwbGet(*dbOwner, "/apps/moved", found), "after_move");
+        BOOST_CHECK(found);
+    }
+
+    boost::filesystem::remove_all(path);
+}
+
+BOOST_AUTO_TEST_CASE(FactoryFromStorageCommits)
+{
+    std::string path = dwbUniqueTempPath();
+    ::rocksdb::DB* rawPtr = dwbOpenDB(path);
+
+    {
+        std::unique_ptr<::rocksdb::DB> dbOwner(rawPtr);
+
+        RocksDBStorage2<executor_v1::StateKey, storage::Entry, StateKeyResolver, StateValueResolver>
+            storage(*dbOwner, StateKeyResolver{}, StateValueResolver{});
+
+        auto batch = storage.makeDeferredBatch();
+        batch.put("/apps/factory_key", "factory_value");
+        BOOST_CHECK(batch.commit().ok());
+
+        bool found = false;
+        BOOST_CHECK_EQUAL(dwbGet(*dbOwner, "/apps/factory_key", found), "factory_value");
+        BOOST_CHECK(found);
+    }
+
+    boost::filesystem::remove_all(path);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Phase-A M5.2a. A move-only RAII wrapper over `rocksdb::WriteBatch` that lets a caller accumulate many Put/Delete ops on the default column family and flush them in one atomic `db->Write()`. Its consumer (PR-14b, `mergeBackStorageWithMPT`) needs to persist `/apps/*` flat state + `/mpt/<hash>` MPT nodes + manifest deletes as a single atomic unit (spec §5.6). 6 files, all under `bcos-storage/`.

## What lands

**DeferredWriteBatch** (`DeferredWriteBatch.h/.cpp`) — wraps a plain `::rocksdb::DB&`:
- `put(key, value)` / `del(key)` accumulate into an internal `rocksdb::WriteBatch` on the default CF.
- `commit()` does a single `db->Write()` and returns the `rocksdb::Status`; it is one-shot — a second call returns `InvalidArgument` (guards double-commit / handle reuse).
- Move-only (copy deleted) so ownership of the pending batch can't be aliased.
- `WriteOptions.sync` left at the RocksDB default — not relaxed for MPT nodes (spec §5.6 durability constraint).

**RocksDBStorage2::makeDeferredBatch()** — a 3-line factory on the existing storage template returning `DeferredWriteBatch{rocksDBRef()}`.

## Deviations from the plan (PR-14a doc)

The plan's storage API was fiction. Reality, used here:

- `RocksDBStorage2` is a **template** (`<KeyType, ValueType, KeyResolver, ValueResolver>`) constructed from a `::rocksdb::DB&` (or `unique_ptr<DB>`); there is **no `open(path)`, no `rawDb()`**. `DeferredWriteBatch` therefore wraps a `::rocksdb::DB&` directly (decoupled from the template, trivially testable), and the factory uses the real `rocksDBRef()` accessor.
- Both `bcos-storage/CMakeLists.txt` and the test `CMakeLists.txt` use **explicit source lists, not GLOB**; the new files are added to those lists.

## Test plan

- `DeferredWriteBatchSuite` (5) — all green:
  - `MultiPutCommitsAtomically` (flat-state keys + a `makeMPTNodeKey(h256)` node key + a delete, all read back after one commit),
  - `EmptyBatchCommitIsNoop`, `DoubleCommitReturnsInvalidArgument`, `MoveSemanticsTransferOwnership`,
  - `FactoryFromStorageCommits` (exercises `RocksDBStorage2::makeDeferredBatch()` end to end).
- Each case uses a unique temp dir and closes the DB (inner scope) before `remove_all`, matching the lifetime discipline in `TestKeyPrefixes.cpp` so background RocksDB threads don't race the directory delete.
- Full `test-storage` binary: `*** No errors detected` (no regression).
- clang-format `--dry-run --Werror` clean on all changed files. Verified by an independent rebuild + test run on the merged-M3 base.

Refs: spec §5.6, §5.7