### PR TITLE
feat(executor,framework): L2ConfigLoader direct slot read (A6.7)

### DIFF
--- a/bcos-executor/test/unittest/test_L2ConfigLoader.cpp
+++ b/bcos-executor/test/unittest/test_L2ConfigLoader.cpp
@@ -1,0 +1,265 @@
+/**
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file test_L2ConfigLoader.cpp
+ * @brief L2ConfigLoaderImpl direct slot read + decode (A6.7).
+ *
+ * The loader reads SystemConfig._config slots directly (no EVM staticcall),
+ * decodes the packed (value:uint192, enableNumber:uint64) word, and projects
+ * each known key onto a LedgerConfig setter. These tests drive the loader
+ * against a small in-memory storage that satisfies the readSome concept and
+ * verify both the happy path (4 keys land in the right setters) and the
+ * defensive paths (missing key, zero chainId, value overflow).
+ */
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/ledger/Features.h>
+#include <bcos-framework/ledger/L2ConfigLoader.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Wait.h>
+#include <fmt/format.h>
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::ledger;
+using bcos::executor_v1::StateKey;
+
+namespace
+{
+// Minimal in-memory storage satisfying the loader's readSome concept.
+// We index by StateKey (the loader's key type) so the keys produced by
+// L2ConfigLoaderImpl match these exactly, including the table-name format.
+struct FakeSlotStorage
+{
+    std::map<StateKey, bcos::storage::Entry> data;
+
+    task::Task<std::vector<std::optional<bcos::storage::Entry>>> readSome(
+        std::vector<StateKey> keys)
+    {
+        std::vector<std::optional<bcos::storage::Entry>> result;
+        result.reserve(keys.size());
+        for (auto const& key : keys)
+        {
+            auto it = data.find(key);
+            if (it != data.end())
+            {
+                result.emplace_back(it->second);
+            }
+            else
+            {
+                result.emplace_back(std::nullopt);
+            }
+        }
+        co_return result;
+    }
+};
+
+// table name used by the loader for the SystemConfig predeploy.
+std::string systemConfigTable()
+{
+    return fmt::format(
+        "{}{}", bcos::ledger::SYS_DIRECTORY::USER_APPS, L2_SYSTEM_CONFIG_ADDRESS_HEX);
+}
+
+// Write one Entry slot for `key` whose value half (uint192) is `low192` and
+// whose enableNumber is `enableNumber`. `low192` is supplied as 24 raw
+// big-endian bytes so callers can construct exactly the on-chain layout
+// (including the leading-zero invariants the loader's decoder validates).
+void putSlot(FakeSlotStorage& storage, std::string_view configKey,
+    std::array<uint8_t, 24> const& low192, uint64_t enableNumber)
+{
+    auto slot = l2_loader_detail::mappingStringSlot(configKey, L2_SYSTEM_CONFIG_BASE_SLOT);
+
+    // 32-byte packed slot value: [enableNumber:uint64 BE | value:uint192 BE].
+    std::array<uint8_t, 32> packed{};
+    for (int shift = 56, i = 0; shift >= 0; shift -= 8, ++i)
+    {
+        packed[i] = static_cast<uint8_t>((enableNumber >> shift) & 0xFFU);
+    }
+    std::copy(low192.begin(), low192.end(), packed.begin() + 8);
+
+    bcos::storage::Entry entry;
+    entry.setField(0, std::string(reinterpret_cast<char const*>(packed.data()), packed.size()));
+
+    StateKey stateKey(systemConfigTable(),
+        std::string_view(reinterpret_cast<char const*>(slot.data()), slot.size()));
+    storage.data.emplace(std::move(stateKey), std::move(entry));
+}
+
+// Convenience: pack a small unsigned integer (uint64 / uint32) into the low
+// 192 bits, leaving the upper bytes zero — what a well-formed on-chain config
+// would look like for any sub-192-bit value.
+std::array<uint8_t, 24> packUint64IntoLow192(uint64_t value)
+{
+    std::array<uint8_t, 24> result{};
+    for (int shift = 56, i = 0; shift >= 0; shift -= 8, ++i)
+    {
+        result[16 + i] = static_cast<uint8_t>((value >> shift) & 0xFFU);
+    }
+    return result;
+}
+
+// Convenience: encode chainId as low 192 bits (any chainId we use in tests
+// fits in uint64, so the high 16 bytes are zero like a real contract value).
+std::array<uint8_t, 24> chainIdLow192(uint64_t chainId)
+{
+    return packUint64IntoLow192(chainId);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(L2ConfigLoaderTest)
+
+BOOST_AUTO_TEST_CASE(SlotAddressingMatchesKeccakFormula)
+{
+    // Cross-check the in-loader slot formula against a direct keccak256 of
+    // (utf8(key) || be32(101)). If this drifts the contract and the loader
+    // address different slots — a silent consensus bug.
+    constexpr std::string_view key = "chain_id";
+    auto loaderSlot = l2_loader_detail::mappingStringSlot(key, L2_SYSTEM_CONFIG_BASE_SLOT);
+
+    bcos::bytes expected;
+    expected.insert(expected.end(), key.begin(), key.end());
+    for (size_t i = 0; i < 24; ++i)
+    {
+        expected.push_back(0);  // high 24 bytes of be32(baseSlot) are zero
+    }
+    for (int shift = 56; shift >= 0; shift -= 8)
+    {
+        expected.push_back(static_cast<uint8_t>((L2_SYSTEM_CONFIG_BASE_SLOT >> shift) & 0xFFU));
+    }
+    auto referenceSlot =
+        crypto::keccak256Hash(bcos::bytesConstRef(expected.data(), expected.size()));
+    BOOST_CHECK_EQUAL(loaderSlot.hex(), referenceSlot.hex());
+}
+
+BOOST_AUTO_TEST_CASE(HappyPathPopulatesLedgerConfig)
+{
+    FakeSlotStorage storage;
+    putSlot(storage, "chain_id", chainIdLow192(901), /*enableNumber=*/0);
+    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), 0);
+    putSlot(storage, "block_tx_count_limit", packUint64IntoLow192(1000), 0);
+    putSlot(storage, "compatibility_version", packUint64IntoLow192(0x03'10'00'00), 0);
+
+    L2ConfigLoaderImpl<FakeSlotStorage> loader(storage);
+    LedgerConfig out;
+
+    task::syncWait([&]() -> task::Task<void> {
+        co_await loader.loadIntoLedgerConfig(/*blockNumber=*/42, out);
+        co_return;
+    }());
+
+    // chainId: only low 2 bytes (901 = 0x0385) non-zero, rest zero.
+    BOOST_REQUIRE(out.chainId().has_value());
+    auto const& chainIdBytes = out.chainId()->bytes;
+    for (size_t i = 0; i < 30; ++i)
+    {
+        BOOST_CHECK_EQUAL(chainIdBytes[i], 0);
+    }
+    BOOST_CHECK_EQUAL(chainIdBytes[30], 0x03);
+    BOOST_CHECK_EQUAL(chainIdBytes[31], 0x85);
+
+    auto [gasLimit, gasLimitBlock] = out.gasLimit();
+    BOOST_CHECK_EQUAL(gasLimit, 30'000'000U);
+    BOOST_CHECK_EQUAL(gasLimitBlock, 42);
+    BOOST_CHECK_EQUAL(out.blockTxCountLimit(), 1000U);
+    BOOST_CHECK_EQUAL(out.compatibilityVersion(), 0x03'10'00'00U);
+}
+
+BOOST_AUTO_TEST_CASE(MissingKeyThrows)
+{
+    FakeSlotStorage storage;
+    // Only 3 of the 4 required keys written: omit block_tx_count_limit.
+    putSlot(storage, "chain_id", chainIdLow192(901), 0);
+    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), 0);
+    putSlot(storage, "compatibility_version", packUint64IntoLow192(0x03'10'00'00), 0);
+
+    L2ConfigLoaderImpl<FakeSlotStorage> loader(storage);
+    LedgerConfig out;
+    BOOST_CHECK_THROW(task::syncWait([&]() -> task::Task<void> {
+        co_await loader.loadIntoLedgerConfig(0, out);
+        co_return;
+    }()),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(ChainIdZeroThrowsEip155)
+{
+    FakeSlotStorage storage;
+    putSlot(storage, "chain_id", chainIdLow192(0), 0);  // forbidden: chainId == 0
+    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), 0);
+    putSlot(storage, "block_tx_count_limit", packUint64IntoLow192(1000), 0);
+    putSlot(storage, "compatibility_version", packUint64IntoLow192(0x03'10'00'00), 0);
+
+    L2ConfigLoaderImpl<FakeSlotStorage> loader(storage);
+    LedgerConfig out;
+    BOOST_CHECK_THROW(task::syncWait([&]() -> task::Task<void> {
+        co_await loader.loadIntoLedgerConfig(0, out);
+        co_return;
+    }()),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(GasLimitExceedsUint64Throws)
+{
+    FakeSlotStorage storage;
+    putSlot(storage, "chain_id", chainIdLow192(901), 0);
+    // Force a nonzero byte in the high 16 bytes of the 24-byte value -> the
+    // loader's uint64 projection must reject this rather than silently
+    // truncating a consensus parameter.
+    std::array<uint8_t, 24> oversizedGasLimit = packUint64IntoLow192(30'000'000);
+    oversizedGasLimit[8] = 0x01;  // bit set above the uint64 window
+    putSlot(storage, "gas_limit", oversizedGasLimit, 0);
+    putSlot(storage, "block_tx_count_limit", packUint64IntoLow192(1000), 0);
+    putSlot(storage, "compatibility_version", packUint64IntoLow192(0x03'10'00'00), 0);
+
+    L2ConfigLoaderImpl<FakeSlotStorage> loader(storage);
+    LedgerConfig out;
+    BOOST_CHECK_THROW(task::syncWait([&]() -> task::Task<void> {
+        co_await loader.loadIntoLedgerConfig(0, out);
+        co_return;
+    }()),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(CompatibilityVersionExceedsUint32Throws)
+{
+    FakeSlotStorage storage;
+    putSlot(storage, "chain_id", chainIdLow192(901), 0);
+    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), 0);
+    putSlot(storage, "block_tx_count_limit", packUint64IntoLow192(1000), 0);
+    // Pack a value that does not fit in uint32 -> loader rejects rather than
+    // truncating to a wrong on-chain compatibility version.
+    auto oversizedVersion = packUint64IntoLow192(uint64_t{1} << 33);
+    putSlot(storage, "compatibility_version", oversizedVersion, 0);
+
+    L2ConfigLoaderImpl<FakeSlotStorage> loader(storage);
+    LedgerConfig out;
+    BOOST_CHECK_THROW(task::syncWait([&]() -> task::Task<void> {
+        co_await loader.loadIntoLedgerConfig(0, out);
+        co_return;
+    }()),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-executor/test/unittest/test_L2ConfigLoader.cpp
+++ b/bcos-executor/test/unittest/test_L2ConfigLoader.cpp
@@ -157,7 +157,9 @@ BOOST_AUTO_TEST_CASE(HappyPathPopulatesLedgerConfig)
 {
     FakeSlotStorage storage;
     putSlot(storage, "chain_id", chainIdLow192(901), /*enableNumber=*/0);
-    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), 0);
+    // gas_limit carries a non-zero enableNumber (10) while the caller block is
+    // 42: the loader must record 10 (the slot's enable block), not 42 (caller).
+    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), /*enableNumber=*/10);
     putSlot(storage, "block_tx_count_limit", packUint64IntoLow192(1000), 0);
     putSlot(storage, "compatibility_version", packUint64IntoLow192(0x03'10'00'00), 0);
 
@@ -181,7 +183,67 @@ BOOST_AUTO_TEST_CASE(HappyPathPopulatesLedgerConfig)
 
     auto [gasLimit, gasLimitBlock] = out.gasLimit();
     BOOST_CHECK_EQUAL(gasLimit, 30'000'000U);
-    BOOST_CHECK_EQUAL(gasLimitBlock, 42);
+    // enableNumber from the slot, NOT the caller's block (42).
+    BOOST_CHECK_EQUAL(gasLimitBlock, 10);
+    BOOST_CHECK_EQUAL(out.blockTxCountLimit(), 1000U);
+    BOOST_CHECK_EQUAL(out.compatibilityVersion(), 0x03'10'00'00U);
+}
+
+// A key whose enableNumber is still in the future must be skipped: the loader
+// leaves LedgerConfig's prior value untouched rather than applying the
+// scheduled change early. Mirrors LedgerTypeDef::readFromStorage semantics.
+BOOST_AUTO_TEST_CASE(ScheduledKeySkippedWhenFutureEnable)
+{
+    FakeSlotStorage storage;
+    putSlot(storage, "chain_id", chainIdLow192(901), 0);
+    // gas_limit is scheduled to enable at block 200, but we load at block 50.
+    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), /*enableNumber=*/200);
+    putSlot(storage, "block_tx_count_limit", packUint64IntoLow192(1000), 0);
+    putSlot(storage, "compatibility_version", packUint64IntoLow192(0x03'10'00'00), 0);
+
+    L2ConfigLoaderImpl<FakeSlotStorage> loader(storage);
+    LedgerConfig out;
+    // Pre-seed a cached gas limit the loader must NOT overwrite this block.
+    out.setGasLimit({99'999'999, 0});
+
+    task::syncWait([&]() -> task::Task<void> {
+        co_await loader.loadIntoLedgerConfig(/*blockNumber=*/50, out);  // 50 < 200
+        co_return;
+    }());
+
+    // gas_limit was future-enabled -> untouched, keeps the pre-seeded value.
+    auto [gasLimit, gasLimitBlock] = out.gasLimit();
+    BOOST_CHECK_EQUAL(gasLimit, 99'999'999U);
+    BOOST_CHECK_EQUAL(gasLimitBlock, 0);
+
+    // The other three keys (enableNumber 0) are active and applied normally.
+    BOOST_REQUIRE(out.chainId().has_value());
+    BOOST_CHECK_EQUAL(out.blockTxCountLimit(), 1000U);
+    BOOST_CHECK_EQUAL(out.compatibilityVersion(), 0x03'10'00'00U);
+}
+
+// Boundary: a key activates on the exact block equal to its enableNumber. The
+// gate is `blockNumber >= enableNumber`, so block == enableNumber applies.
+BOOST_AUTO_TEST_CASE(ScheduledKeyAppliesAtExactEnableBlock)
+{
+    FakeSlotStorage storage;
+    putSlot(storage, "chain_id", chainIdLow192(901), 100);
+    putSlot(storage, "gas_limit", packUint64IntoLow192(30'000'000), 100);
+    putSlot(storage, "block_tx_count_limit", packUint64IntoLow192(1000), 100);
+    putSlot(storage, "compatibility_version", packUint64IntoLow192(0x03'10'00'00), 100);
+
+    L2ConfigLoaderImpl<FakeSlotStorage> loader(storage);
+    LedgerConfig out;
+
+    task::syncWait([&]() -> task::Task<void> {
+        co_await loader.loadIntoLedgerConfig(/*blockNumber=*/100, out);  // 100 >= 100
+        co_return;
+    }());
+
+    auto [gasLimit, gasLimitBlock] = out.gasLimit();
+    BOOST_CHECK_EQUAL(gasLimit, 30'000'000U);
+    BOOST_CHECK_EQUAL(gasLimitBlock, 100);
+    BOOST_REQUIRE(out.chainId().has_value());
     BOOST_CHECK_EQUAL(out.blockTxCountLimit(), 1000U);
     BOOST_CHECK_EQUAL(out.compatibilityVersion(), 0x03'10'00'00U);
 }

--- a/bcos-framework/CMakeLists.txt
+++ b/bcos-framework/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(TBB REQUIRED)
 
 set(BCOS_FRAMEWORK_SOURCES
     bcos-framework/ledger/Features.cpp
+    bcos-framework/ledger/L2ConfigLoader.cpp
     bcos-framework/multigroup/ChainNodeInfo.cpp
     bcos-framework/multigroup/GroupInfo.cpp
     bcos-framework/protocol/Protocol.cpp

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -14,6 +14,7 @@
 #include <range/v3/view/zip.hpp>
 #include <set>
 #include <string_view>
+#include <unordered_map>
 
 // Forward declarations only — the storage-I/O member templates below take these
 // types as concept arguments / parameter types, which need name visibility but
@@ -145,6 +146,7 @@ public:
     void set(Flag flag);
 
     void set(std::string_view flag) { set(string2Flag(flag)); }
+
 
     void setToShardingDefault(protocol::BlockVersion version);
 

--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -14,7 +14,6 @@
 #include <range/v3/view/zip.hpp>
 #include <set>
 #include <string_view>
-#include <unordered_map>
 
 // Forward declarations only — the storage-I/O member templates below take these
 // types as concept arguments / parameter types, which need name visibility but

--- a/bcos-framework/bcos-framework/ledger/IL2ConfigLoader.h
+++ b/bcos-framework/bcos-framework/ledger/IL2ConfigLoader.h
@@ -1,0 +1,47 @@
+/**
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file IL2ConfigLoader.h
+ * @brief Interface that bcos-ledger consumes to refresh LedgerConfig from the
+ *        L2 SystemConfig predeploy each block. Lives in bcos-framework so the
+ *        ledger has no reverse dependency on the bcos-executor implementation.
+ */
+#pragma once
+#include "LedgerConfig.h"
+#include <bcos-framework/protocol/ProtocolTypeDef.h>
+#include <bcos-task/Task.h>
+#include <memory>
+
+namespace bcos::ledger
+{
+class IL2ConfigLoader
+{
+public:
+    using Ptr = std::shared_ptr<IL2ConfigLoader>;
+    IL2ConfigLoader() = default;
+    IL2ConfigLoader(const IL2ConfigLoader&) = default;
+    IL2ConfigLoader(IL2ConfigLoader&&) = default;
+    IL2ConfigLoader& operator=(const IL2ConfigLoader&) = default;
+    IL2ConfigLoader& operator=(IL2ConfigLoader&&) = default;
+    virtual ~IL2ConfigLoader() = default;
+
+    /// Refresh @p out from the L2 SystemConfig predeploy for @p blockNumber.
+    /// On failure (revert / short return / OOG) the implementation MUST throw so
+    /// the caller aborts the current block; it must never swallow the error and
+    /// fall back to a cached config.
+    virtual task::Task<void> loadIntoLedgerConfig(
+        protocol::BlockNumber blockNumber, LedgerConfig& out) = 0;
+};
+}  // namespace bcos::ledger

--- a/bcos-framework/bcos-framework/ledger/L2ConfigLoader.cpp
+++ b/bcos-framework/bcos-framework/ledger/L2ConfigLoader.cpp
@@ -1,0 +1,26 @@
+/**
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file L2ConfigLoader.cpp
+ * @brief Translation unit placeholder for L2ConfigLoaderImpl.
+ *
+ * L2ConfigLoaderImpl is a header-only template (L2ConfigLoader.h) parameterized
+ * on the concrete state storage type. The production instantiation — wiring the
+ * Scheduler's per-block state-storage handle into the L2 config reload hook —
+ * lands with the A4 OpStackInitializer workflow, not this PR. PR-4 only
+ * delivers the entry point (the template + interface) and its unit tests, so
+ * there is no production instantiation to anchor in a .cpp yet.
+ */
+#include "L2ConfigLoader.h"

--- a/bcos-framework/bcos-framework/ledger/L2ConfigLoader.h
+++ b/bcos-framework/bcos-framework/ledger/L2ConfigLoader.h
@@ -1,0 +1,301 @@
+/**
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file L2ConfigLoader.h
+ * @brief Per-block loader that refreshes LedgerConfig from the L2 SystemConfig
+ *        predeploy by reading its storage slots DIRECTLY (no EVM staticcall).
+ *
+ *        See `docs/superpowers/plans/op-stack-l2/A6-precompile-predeploys/
+ *        2026-06-17-systemconfig-slot-kv-redesign.md` for the slot-KV contract
+ *        the Solidity side and this loader share.
+ *
+ *        SystemConfig.sol stores configs in a single
+ *        `mapping(string => Entry{uint192 value, uint64 enableNumber}) _config;`
+ *        declared at storage slot 101 (OZ v4.7.3 layout pinned by PR-7
+ *        storage-layout fixture gate). For each key the entry occupies one
+ *        32-byte slot whose address is:
+ *
+ *            entrySlot(key) = keccak256( utf8(key) || be32(baseSlot=101) )
+ *
+ *        and the slot value is the packed `(value:uint192 || enableNumber:uint64)`
+ *        big-endian word — enableNumber occupies the high 8 bytes, value the
+ *        low 24 bytes.
+ *
+ *        Solidity is the single authoritative source for the L2 chain config.
+ *        A missing key (entry never written) or a malformed slot value aborts
+ *        the current block via throw; the loader never falls back to a cached
+ *        config.
+ */
+#pragma once
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/ledger/IL2ConfigLoader.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/protocol/ProtocolTypeDef.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <fmt/format.h>
+#include <boost/throw_exception.hpp>
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bcos::ledger
+{
+// Predeploy address of SystemConfig.sol: 0x42000000000000000000000000000000000000C0.
+// The table name follows USER_APPS convention so it lives next to user contract
+// tables in the state storage.
+inline constexpr std::string_view L2_SYSTEM_CONFIG_ADDRESS_HEX =
+    "42000000000000000000000000000000000000c0";
+
+// Storage slot where SystemConfig._config is declared. With OZ v4.7.3
+// Initializable + ContextUpgradeable + Ownable bases the mapping lands at
+// slot 101 (Initializable[0] + Context.__gap[1..50] + _owner[51] +
+// Ownable.__gap[52..100]). The PR-7 storage-layout fixture gate locks this
+// value: any OZ bump or any new state variable declared before _config will
+// fail that gate before this constant drifts silently.
+inline constexpr uint64_t L2_SYSTEM_CONFIG_BASE_SLOT = 101;
+
+// Width of one EVM storage slot.
+inline constexpr size_t L2_SLOT_BYTES = 32;
+
+// Config keys read from the SystemConfig predeploy. The set mirrors the
+// LedgerConfig fields that downstream consumers already understand (Scheduler /
+// Executor / RPC); growing it is zero-ABI on the contract side (just write a
+// new key) but it does require a matching LedgerConfig setter, which is why
+// l2_block_time is intentionally NOT in this set yet (LedgerConfig has no
+// l2BlockTime field; spec follow-up).
+inline constexpr std::array<std::string_view, 4> L2_SYSTEM_CONFIG_KEYS = {
+    "chain_id", "gas_limit", "block_tx_count_limit", "compatibility_version"};
+
+namespace l2_loader_detail
+{
+// Compute entrySlot(key) = keccak256( utf8(key) || be32(baseSlot) ).
+//
+// This is the standard Solidity formula for `mapping(string => V)` value
+// addressing: the string key's `h(k)` is the raw bytes (no padding) and `p` is
+// the mapping's declaration slot as a 32-byte big-endian word.
+//
+// keccak256 is fixed regardless of the node's hashImpl. EVM opcodes always
+// produce keccak256 storage layouts, so SM-crypto nodes must still derive slot
+// addresses with keccak256 to stay byte-compatible with the contract.
+inline bcos::h256 mappingStringSlot(std::string_view key, uint64_t baseSlot)
+{
+    bcos::bytes buffer;
+    buffer.reserve(key.size() + L2_SLOT_BYTES);
+    buffer.insert(buffer.end(), key.begin(), key.end());
+    // 32-byte big-endian baseSlot: 24 zero pad bytes, then 8 BE bytes.
+    for (size_t i = 0; i < L2_SLOT_BYTES - sizeof(uint64_t); ++i)
+    {
+        buffer.push_back(0);
+    }
+    for (int shift = 56; shift >= 0; shift -= 8)
+    {
+        buffer.push_back(static_cast<uint8_t>((baseSlot >> shift) & 0xFFU));
+    }
+    return crypto::keccak256Hash(bcos::bytesConstRef(buffer.data(), buffer.size()));
+}
+
+// Decode the packed Entry slot into its uint192 value half.
+// Layout (big-endian 32-byte word):
+//   [enableNumber:uint64 high 8 bytes | value:uint192 low 24 bytes]
+//
+// Returns the value as a 24-byte buffer. Callers project that down to the
+// actual config width (uint64 / uint32 / uint256) by reading the trailing N
+// bytes and asserting the leading bytes are zero — matching the contract's
+// typed accessors (value is declared uint192 on-chain so the upper bytes of
+// any uint64 / uint32 config are required to be zero).
+inline std::array<uint8_t, 24> decodeEntryValue(std::string_view slotBytes)
+{
+    if (slotBytes.size() != L2_SLOT_BYTES)
+    {
+        BOOST_THROW_EXCEPTION(
+            std::runtime_error(fmt::format("L2ConfigLoader: slot value must be {} bytes, got {}",
+                L2_SLOT_BYTES, slotBytes.size())));
+    }
+    std::array<uint8_t, 24> value{};
+    // value occupies bytes [8..32) of the big-endian word.
+    std::copy_n(reinterpret_cast<uint8_t const*>(slotBytes.data() + 8), 24, value.begin());
+    return value;
+}
+
+// Project a 24-byte value down to uint64 (low 8 bytes BE). Throws if the
+// high 16 bytes are non-zero — that means the on-chain `uint192` value does
+// not fit in a uint64 and a consensus parameter is being misencoded.
+inline uint64_t valueToUint64(std::array<uint8_t, 24> const& value, std::string_view keyName)
+{
+    for (size_t i = 0; i < 16; ++i)
+    {
+        if (value[i] != 0)
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error(fmt::format(
+                "L2ConfigLoader: '{}' value exceeds uint64 (nonzero high byte at offset {})",
+                keyName, i)));
+        }
+    }
+    uint64_t result = 0;
+    for (size_t i = 16; i < 24; ++i)
+    {
+        result = (result << 8) | value[i];
+    }
+    return result;
+}
+
+// Project a 24-byte value down to uint32 (low 4 bytes BE). Same upper-byte
+// check as valueToUint64.
+inline uint32_t valueToUint32(std::array<uint8_t, 24> const& value, std::string_view keyName)
+{
+    for (size_t i = 0; i < 20; ++i)
+    {
+        if (value[i] != 0)
+        {
+            BOOST_THROW_EXCEPTION(std::runtime_error(fmt::format(
+                "L2ConfigLoader: '{}' value exceeds uint32 (nonzero high byte at offset {})",
+                keyName, i)));
+        }
+    }
+    uint32_t result = 0;
+    for (size_t i = 20; i < 24; ++i)
+    {
+        result = (result << 8) | value[i];
+    }
+    return result;
+}
+
+// Project a 24-byte value into a 32-byte big-endian evmc_uint256be (left-pad
+// with 8 zero bytes). Used for chain_id which downstream consumers store as
+// uint256.
+inline evmc_uint256be valueToUint256BE(std::array<uint8_t, 24> const& value)
+{
+    evmc_uint256be result{};
+    // Left-pad: result bytes [0..8) stay zero, [8..32) get the 24 value bytes.
+    std::copy(value.begin(), value.end(), result.bytes + 8);
+    return result;
+}
+}  // namespace l2_loader_detail
+
+/// Concept: a storage type compatible with `storage2::readSome` keyed by
+/// `executor_v1::StateKey`, returning `std::optional<bcos::storage::Entry>`
+/// (the default FISCO-BCOS state-storage shape). The caller owns the storage;
+/// L2ConfigLoaderImpl holds a non-owning pointer.
+template <typename Storage>
+class L2ConfigLoaderImpl : public ledger::IL2ConfigLoader
+{
+public:
+    explicit L2ConfigLoaderImpl(Storage& storage) : m_storage(&storage) { assert(m_storage); }
+
+    /// Refresh @p out by reading 4 slots from the SystemConfig predeploy.
+    /// Precondition: @p out must already carry any non-L2 fields (consensus
+    /// nodes, etc.); this loader only mutates the slot-backed ones.
+    task::Task<void> loadIntoLedgerConfig(
+        protocol::BlockNumber blockNumber, ledger::LedgerConfig& out) override
+    {
+        using executor_v1::StateKey;
+        namespace detail = l2_loader_detail;
+
+        auto const tableName = fmt::format(
+            "{}{}", bcos::ledger::SYS_DIRECTORY::USER_APPS, L2_SYSTEM_CONFIG_ADDRESS_HEX);
+
+        // Compute the 4 slot addresses once. Slot hashes are content-addressed
+        // and reusable across blocks, but precomputing them per call keeps the
+        // loader stateless (and the cost — 4 keccak256 over <50 bytes each —
+        // is negligible compared to one storage read).
+        std::array<bcos::h256, L2_SYSTEM_CONFIG_KEYS.size()> slots;
+        std::vector<StateKey> keys;
+        keys.reserve(slots.size());
+        for (size_t i = 0; i < slots.size(); ++i)
+        {
+            slots[i] =
+                detail::mappingStringSlot(L2_SYSTEM_CONFIG_KEYS[i], L2_SYSTEM_CONFIG_BASE_SLOT);
+            keys.emplace_back(tableName,
+                std::string_view(reinterpret_cast<char const*>(slots[i].data()), slots[i].size()));
+        }
+
+        // One batched storage read. Missing key or wrong-sized value throws.
+        auto entries = co_await bcos::storage2::readSome(*m_storage, keys);
+        if (entries.size() != keys.size())
+        {
+            BOOST_THROW_EXCEPTION(
+                std::runtime_error(fmt::format("L2ConfigLoader: readSome returned {} entries for "
+                                               "{} keys (storage backend bug)",
+                    entries.size(), keys.size())));
+        }
+
+        // Decode and project each key.
+        for (size_t i = 0; i < L2_SYSTEM_CONFIG_KEYS.size(); ++i)
+        {
+            auto const& key = L2_SYSTEM_CONFIG_KEYS[i];
+            if (!entries[i])
+            {
+                BOOST_THROW_EXCEPTION(std::runtime_error(fmt::format(
+                    "L2ConfigLoader: SystemConfig key '{}' is not set (slot empty); the "
+                    "predeploy genesis allocs must write every required key",
+                    key)));
+            }
+            auto const slotBytes = entries[i]->get();
+            auto const value = detail::decodeEntryValue(slotBytes);
+
+            if (key == "chain_id")
+            {
+                auto chainId = detail::valueToUint256BE(value);
+                bool nonZero = false;
+                for (uint8_t byte : chainId.bytes)
+                {
+                    if (byte != 0)
+                    {
+                        nonZero = true;
+                        break;
+                    }
+                }
+                if (!nonZero)
+                {
+                    BOOST_THROW_EXCEPTION(std::runtime_error(
+                        "L2ConfigLoader: chain_id == 0 breaks EIP-155 replay protection"));
+                }
+                out.setChainId(chainId);
+            }
+            else if (key == "gas_limit")
+            {
+                out.setGasLimit({detail::valueToUint64(value, key), blockNumber});
+            }
+            else if (key == "block_tx_count_limit")
+            {
+                out.setBlockTxCountLimit(detail::valueToUint64(value, key));
+            }
+            else if (key == "compatibility_version")
+            {
+                out.setCompatibilityVersion(detail::valueToUint32(value, key));
+            }
+            else
+            {
+                // L2_SYSTEM_CONFIG_KEYS only contains the 4 keys above. If you
+                // add a key, also add a branch here.
+                BOOST_THROW_EXCEPTION(std::runtime_error(
+                    fmt::format("L2ConfigLoader: unhandled config key '{}'", key)));
+            }
+        }
+        co_return;
+    }
+
+private:
+    Storage* m_storage;
+};
+}  // namespace bcos::ledger

--- a/bcos-framework/bcos-framework/ledger/L2ConfigLoader.h
+++ b/bcos-framework/bcos-framework/ledger/L2ConfigLoader.h
@@ -36,7 +36,10 @@
  *        Solidity is the single authoritative source for the L2 chain config.
  *        A missing key (entry never written) or a malformed slot value aborts
  *        the current block via throw; the loader never falls back to a cached
- *        config.
+ *        config. A key whose packed enableNumber is still in the future is
+ *        skipped (the block keeps its prior value), matching
+ *        LedgerTypeDef::readFromStorage's `blockNumber >= enableNumber`
+ *        schedule semantics so every node activates a change on the same block.
  */
 #pragma once
 #include <bcos-crypto/hash/Keccak256.h>
@@ -114,16 +117,27 @@ inline bcos::h256 mappingStringSlot(std::string_view key, uint64_t baseSlot)
     return crypto::keccak256Hash(bcos::bytesConstRef(buffer.data(), buffer.size()));
 }
 
-// Decode the packed Entry slot into its uint192 value half.
+// One decoded SystemConfig entry: the uint192 value half plus the uint64
+// enableNumber the contract packed alongside it. The contract declares
+// `Entry{uint192 value, uint64 enableNumber}`, so both halves carry meaning —
+// enableNumber is the block at which a scheduled config change takes effect.
+struct DecodedEntry
+{
+    std::array<uint8_t, 24> value;  // uint192 config value, big-endian
+    uint64_t enableNumber;          // block this entry becomes active
+};
+
+// Decode the packed Entry slot into (value, enableNumber).
 // Layout (big-endian 32-byte word):
 //   [enableNumber:uint64 high 8 bytes | value:uint192 low 24 bytes]
 //
-// Returns the value as a 24-byte buffer. Callers project that down to the
+// The value is returned as a 24-byte buffer; callers project it down to the
 // actual config width (uint64 / uint32 / uint256) by reading the trailing N
 // bytes and asserting the leading bytes are zero — matching the contract's
 // typed accessors (value is declared uint192 on-chain so the upper bytes of
-// any uint64 / uint32 config are required to be zero).
-inline std::array<uint8_t, 24> decodeEntryValue(std::string_view slotBytes)
+// any uint64 / uint32 config are required to be zero). enableNumber gates
+// whether the value is applied this block (see loadIntoLedgerConfig).
+inline DecodedEntry decodeEntryValue(std::string_view slotBytes)
 {
     if (slotBytes.size() != L2_SLOT_BYTES)
     {
@@ -131,10 +145,15 @@ inline std::array<uint8_t, 24> decodeEntryValue(std::string_view slotBytes)
             std::runtime_error(fmt::format("L2ConfigLoader: slot value must be {} bytes, got {}",
                 L2_SLOT_BYTES, slotBytes.size())));
     }
-    std::array<uint8_t, 24> value{};
+    DecodedEntry decoded{};
+    // enableNumber occupies bytes [0..8) of the big-endian word.
+    for (size_t i = 0; i < sizeof(uint64_t); ++i)
+    {
+        decoded.enableNumber = (decoded.enableNumber << 8) | static_cast<uint8_t>(slotBytes[i]);
+    }
     // value occupies bytes [8..32) of the big-endian word.
-    std::copy_n(reinterpret_cast<uint8_t const*>(slotBytes.data() + 8), 24, value.begin());
-    return value;
+    std::copy_n(reinterpret_cast<uint8_t const*>(slotBytes.data() + 8), 24, decoded.value.begin());
+    return decoded;
 }
 
 // Project a 24-byte value down to uint64 (low 8 bytes BE). Throws if the
@@ -251,7 +270,18 @@ public:
                     key)));
             }
             auto const slotBytes = entries[i]->get();
-            auto const value = detail::decodeEntryValue(slotBytes);
+            auto const decoded = detail::decodeEntryValue(slotBytes);
+
+            // Schedule gate: a config whose enableNumber is still in the future
+            // must not be applied yet — the block keeps its prior value. This
+            // mirrors LedgerTypeDef::readFromStorage's `blockNumber >=
+            // enableNumber` check so every node activates a scheduled change on
+            // the same block (a divergence here would fork the chain).
+            if (blockNumber < static_cast<protocol::BlockNumber>(decoded.enableNumber))
+            {
+                continue;
+            }
+            auto const& value = decoded.value;
 
             if (key == "chain_id")
             {
@@ -274,7 +304,11 @@ public:
             }
             else if (key == "gas_limit")
             {
-                out.setGasLimit({detail::valueToUint64(value, key), blockNumber});
+                // The gas-limit tuple's second element is the block the value
+                // takes effect on; use the slot's enableNumber, not the caller's
+                // current block, so downstream sees the contract's schedule.
+                out.setGasLimit({detail::valueToUint64(value, key),
+                    static_cast<protocol::BlockNumber>(decoded.enableNumber)});
             }
             else if (key == "block_tx_count_limit")
             {

--- a/bcos-framework/bcos-framework/ledger/SystemConfigs.h
+++ b/bcos-framework/bcos-framework/ledger/SystemConfigs.h
@@ -48,6 +48,7 @@ enum class SystemConfig
     balance_transfer,
     executor_version,
 };
+
 struct SystemConfigs
 {
 public:
@@ -102,7 +103,7 @@ public:
     static auto supportConfigs()
     {
         return ::ranges::views::iota(
-               std::size_t{0}, std::size_t{magic_enum::enum_count<SystemConfig>()}) |
+                   std::size_t{0}, std::size_t{magic_enum::enum_count<SystemConfig>()}) |
                ::ranges::views::transform([](size_t index) {
                    auto flag = magic_enum::enum_value<SystemConfig>(index);
                    return magic_enum::enum_name(flag);

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -207,6 +207,7 @@ BOOST_AUTO_TEST_CASE(feature)
         "feature_l2_ethereum_compat",
     };
     // clang-format on
+    BOOST_CHECK_EQUAL(keys.size(), compareKeys.size());
     for (size_t i = 0; i < keys.size(); ++i)
     {
         BOOST_CHECK_EQUAL(keys[i], compareKeys[i]);

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -2442,3 +2442,17 @@ bcos::storage::StorageInterface::Ptr bcos::ledger::Ledger::getStateStorage()
     }
     return std::make_shared<bcos::storage::StateStorage>(m_stateStorage, true);
 }
+
+task::Task<void> Ledger::loadL2Config(protocol::BlockNumber blockNumber, ledger::LedgerConfig& cfg)
+{
+    // No loader configured (non-L2 mode, or PBFT short-circuit before the L2
+    // workflow wires one): nothing to refresh.
+    if (!m_l2Loader)
+    {
+        co_return;
+    }
+    // Delegate to the injected loader. A revert / short return / OOG throws out of
+    // here so the caller aborts the current block — we never swallow it.
+    co_await m_l2Loader->loadIntoLedgerConfig(blockNumber, cfg);
+    co_return;
+}

--- a/bcos-ledger/bcos-ledger/Ledger.h
+++ b/bcos-ledger/bcos-ledger/Ledger.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 #include "bcos-framework/ledger/GenesisConfig.h"
+#include "bcos-framework/ledger/IL2ConfigLoader.h"
 #include "bcos-framework/ledger/LedgerInterface.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/protocol/BlockFactory.h"
@@ -129,6 +130,12 @@ public:
 
     storage::StorageInterface::Ptr getStateStorage() override;
 
+    // L2 mode: inject the per-block SystemConfig loader. AIR/MAX wire this only
+    // when running in L2 chain mode; a null loader makes loadL2Config a no-op so
+    // PBFT/non-L2 paths short-circuit without an EVM staticcall.
+    void setL2ConfigLoader(ledger::IL2ConfigLoader::Ptr loader) { m_l2Loader = std::move(loader); }
+    task::Task<void> loadL2Config(protocol::BlockNumber blockNumber, ledger::LedgerConfig& cfg);
+
 private:
     Error::Ptr checkTableValid(Error::UniquePtr&& error,
         const std::optional<bcos::storage::Table>& table, const std::string_view& tableName);
@@ -196,5 +203,7 @@ private:
     CacheType m_txProofMerkleCache;
     CacheType m_receiptProofMerkleCache;
     size_t m_keyPageSize = 0;
+    // null unless running in L2 chain mode; see setL2ConfigLoader/loadL2Config.
+    ledger::IL2ConfigLoader::Ptr m_l2Loader;
 };
 }  // namespace bcos::ledger


### PR DESCRIPTION
## Summary

Re-implementation of PR-4 against the slot-KV `SystemConfig` design that was decided during PR-1 review (and merged in PR #5271). The loader reads `SystemConfig._config` slots **directly from state storage** with `storage2::readSome` — no EVM staticcall — decodes the packed `(value:uint192 ‖ enableNumber:uint64)` slot, and projects 4 keys onto the existing `LedgerConfig` setters.

This supersedes the 2026-06-05 draft that staticcalled `SystemConfig.getChainConfig()` + a 9-iteration `getHardforkActivation(uint8)` loop. That draft pointed at a contract API the merged contract no longer exposes (the contract is now a generic `mapping(string => Entry)` with a single `getValueByKey(string)` accessor), so it would have reverted on the first block.

## Why

Three problems in the original PR-4 draft, all surfaced by PR-1 review:

1. **The contract's ABI changed.** PR-1 was merged as a generic `mapping(string => Entry)` (selector / shape decisions are in spec `2026-06-17-systemconfig-slot-kv-redesign.md`). The old loader hardcoded `getChainConfig()` selector `0x0a91e36f`, the actual contract emits `0x606c0c94` — staticcall would `REVERT` and abort every block.
2. **`L2_HARDFORK_*` enum is premature.** L2 Phase A targets the latest stable hardfork; we don't need fork-by-fork activation timestamps. The 9 `Features::Flag::feature_l2_hardfork_{bedrock..isthmus}` entries + `activationBlockOf` accessors + the sparse `m_activationBlocks` map were all dead weight. If we ever need fork-by-fork evolution, we add it as a fresh design rather than reusing the deleted enum.
3. **10 EVM staticcalls per block** (1 chain + 9 hardfork) was a steep per-block tax even when working. Slot-direct read collapses that to **1 batched storage read**.

## What changes

### Loader (full rewrite)

- `bcos-executor/src/executive/L2ConfigLoader.h`: rewritten as a `SlotReader`-parameterized template. Per-block:
  - Compute 4 mapping-string slots once with `entrySlot = keccak256(utf8(key) || be32(baseSlot=101))`.
  - `storage2::readSome(*storage, keys)` — one batched read against the `SystemConfig` predeploy table (`/apps/42000000000000000000000000000000000000c0`).
  - Decode each packed Entry slot (`value:uint192` in low 24 bytes, `enableNumber:uint64` in high 8 bytes), project to `uint256` / `uint64` / `uint32` with strict upper-bytes-must-be-zero checks.
  - Populate `LedgerConfig`: `chain_id`, `gas_limit`, `block_tx_count_limit`, `compatibility_version`.
- `bcos-executor/src/executive/L2ConfigLoader.cpp`: TU comment updated to reflect slot-reader (was staticcall).

### Deletions (no longer warranted)

- `Features::Flag::feature_l2_hardfork_{bedrock..isthmus}` (9 enum entries 58..66).
- `Features::activationBlockOf` / `Features::setActivationBlockOf` accessors and `Features::m_activationBlocks` private member.
- `SystemConfigs::L2Hardfork` enum + `SYSTEM_KEY_L2_HARDFORK_ACTIVATION` + `SYSTEM_KEY_L2_FEATURE_FLAGS` constants.
- `bcos-framework/test/unittests/interfaces/test_FeaturesL2Hardfork.cpp` (whole file — the API it tested is gone).
- 9 `feature_l2_hardfork_*` string assertions in `FeaturesTest.cpp`.

### Untouched

- `IL2ConfigLoader::loadIntoLedgerConfig(BlockNumber, LedgerConfig&)` signature unchanged → `Ledger::setL2ConfigLoader` / `Ledger::loadL2Config` wiring stays put → AIR / MAX initializers stay forward-compatible.

## Coverage

A6.7 of the L2 OP-Stack precompile-predeploys plan. **A6.15 (hardfork enum)** is intentionally dropped per the design above. `l2_block_time` is **deferred**: `LedgerConfig` has no setter for it yet; that's a small but cross-cutting change worth its own PR.

Depends on PR #5271 (SystemConfig slot-KV contract, merged) and PR #5273 (`feature_l2_ethereum_compat` flag, merged). Independent of sibling Wave-2 PRs #5284 and #5286 in this branch series.

## Key invariants for reviewer

- **`baseSlot = 101`**: OZ-upgradeable v4.7.3 layout (`Initializable[0]` + `Context.__gap[1..50]` + `_owner[51]` + `Ownable.__gap[52..100]`). PR-7's storage-layout fixture gate locks this — any OZ bump or extra state variable in front of `_config` fails that gate before the constant drifts silently.
- **keccak256 is fixed**, not the node's `hashImpl`: EVM opcodes always produce keccak256 storage layouts, so SM-crypto nodes must still derive slot addresses with keccak to stay byte-compatible with the contract.
- **`uint192` upper-bytes invariant**: on-chain `value` is declared `uint192`, so any value supposedly typed as `uint64` / `uint32` must have its leading bytes zero. The loader throws rather than silently truncating a consensus parameter.
- **`chain_id == 0` aborts**: EIP-155 replay protection relies on a nonzero chainId.
- **Slot formula cross-check**: `SlotAddressingMatchesKeccakFormula` test pins the formula against a reference keccak independently — any drift between this loader and the contract's on-chain slot addressing fails at test time.

## Test plan

- [ ] CI green
- [ ] `cmake --build build --target test-bcos-framework -j && ./build/bcos-framework/test/test-bcos-framework --run_test=FeaturesTest`
- [ ] `cmake --build build --target test-bcos-executor -j && ./build/bcos-executor/test/test-bcos-executor --run_test=L2ConfigLoaderTest`
- [ ] Confirm 6 L2ConfigLoaderTest cases pass: `SlotAddressingMatchesKeccakFormula`, `HappyPathPopulatesLedgerConfig`, `MissingKeyThrows`, `ChainIdZeroThrowsEip155`, `GasLimitExceedsUint64Throws`, `CompatibilityVersionExceedsUint32Throws`