### PR TITLE
feat(executor): disabledInL2 predicate + KZG point_evaluation (A6.8+A6.14)

### DIFF
--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -36,6 +36,7 @@
 #include "../precompiled/ConsensusPrecompiled.h"
 #include "../precompiled/CryptoPrecompiled.h"
 #include "../precompiled/KVTablePrecompiled.h"
+#include "../precompiled/L2DisabledSet.h"
 #include "../precompiled/ShardingPrecompiled.h"
 #include "../precompiled/SystemConfigPrecompiled.h"
 #include "../precompiled/TableManagerPrecompiled.h"
@@ -265,6 +266,13 @@ void TransactionExecutor::initEvmEnvironment()
     m_evmPrecompiled->insert({fillZero(9),
         make_shared<PrecompiledContract>(PrecompiledRegistrar::pricer("blake2_compression"),
             PrecompiledRegistrar::executor("blake2_compression"))});
+    // EIP-4844 KZG point evaluation (0x0a), Cancun / OP Ecotone+. Registered as
+    // "point_evaluation" via ETH_REGISTER_PRECOMPILED in vm/Precompiled.cpp but
+    // never inserted into m_evmPrecompiled (registrations stopped at blake2).
+    m_evmPrecompiled->insert({fillZero(10),
+        make_shared<PrecompiledContract>(PrecompiledRegistrar::pricer("point_evaluation"),
+            PrecompiledRegistrar::executor("point_evaluation"))});
+
     // EIP-2537 BLS12-381 precompiles (Prague) — gated by feature_evm_prague in
     // callBuiltInPrecompiled
     static const char* bls_names[] = {"bls12_g1add", "bls12_g1msm", "bls12_g2add", "bls12_g2msm",
@@ -291,48 +299,77 @@ void TransactionExecutor::initEvmEnvironment()
     auto tablePrecompiled = std::make_shared<precompiled::TablePrecompiled>(m_hashImpl);
 
     // in EVM
-    m_precompiled->insert(SYS_CONFIG_ADDRESS, std::move(sysConfig));
-    m_precompiled->insert(CONSENSUS_ADDRESS, std::move(consensusPrecompiled));
-    m_precompiled->insert(TABLE_MANAGER_ADDRESS, std::move(tableManagerPrecompiled));
-    m_precompiled->insert(KV_TABLE_ADDRESS, std::move(kvTablePrecompiled));
-    m_precompiled->insert(TABLE_ADDRESS, std::move(tablePrecompiled));
+    m_precompiled->insert(SYS_CONFIG_ADDRESS, std::move(sysConfig), disabledInL2());
+    m_precompiled->insert(CONSENSUS_ADDRESS, std::move(consensusPrecompiled), disabledInL2());
     m_precompiled->insert(
-        DAG_TRANSFER_ADDRESS, std::make_shared<precompiled::DagTransferPrecompiled>(m_hashImpl));
+        TABLE_MANAGER_ADDRESS, std::move(tableManagerPrecompiled), disabledInL2());
+    m_precompiled->insert(KV_TABLE_ADDRESS, std::move(kvTablePrecompiled), disabledInL2());
+    m_precompiled->insert(TABLE_ADDRESS, std::move(tablePrecompiled), disabledInL2());
+    m_precompiled->insert(DAG_TRANSFER_ADDRESS,
+        std::make_shared<precompiled::DagTransferPrecompiled>(m_hashImpl), disabledInL2());
     m_precompiled->insert(CRYPTO_ADDRESS, std::make_shared<CryptoPrecompiled>(m_hashImpl));
-    m_precompiled->insert(BFS_ADDRESS, std::make_shared<BFSPrecompiled>(m_hashImpl));
+    m_precompiled->insert(
+        BFS_ADDRESS, std::make_shared<BFSPrecompiled>(m_hashImpl), disabledInL2());
     m_precompiled->insert(PAILLIER_ADDRESS, std::make_shared<PaillierPrecompiled>(m_hashImpl),
-        [](uint32_t, bool, ledger::Features const& features) {
-            return features.get(ledger::Features::Flag::feature_paillier);
-        });
-    m_precompiled->insert(GROUP_SIG_ADDRESS, std::make_shared<GroupSigPrecompiled>(m_hashImpl));
-    m_precompiled->insert(RING_SIG_ADDRESS, std::make_shared<RingSigPrecompiled>(m_hashImpl));
-    m_precompiled->insert(DISCRETE_ZKP_ADDRESS, std::make_shared<ZkpPrecompiled>(m_hashImpl));
+        predicateAnd(
+            [](uint32_t, bool, ledger::Features const& features) {
+                return features.get(ledger::Features::Flag::feature_paillier);
+            },
+            disabledInL2()));
+    m_precompiled->insert(
+        GROUP_SIG_ADDRESS, std::make_shared<GroupSigPrecompiled>(m_hashImpl), disabledInL2());
+    m_precompiled->insert(
+        RING_SIG_ADDRESS, std::make_shared<RingSigPrecompiled>(m_hashImpl), disabledInL2());
+    m_precompiled->insert(
+        DISCRETE_ZKP_ADDRESS, std::make_shared<ZkpPrecompiled>(m_hashImpl), disabledInL2());
 
     m_precompiled->insert(AUTH_MANAGER_ADDRESS,
         std::make_shared<AuthManagerPrecompiled>(m_hashImpl, m_isWasm),
-        [](uint32_t version, bool isAuthCheck, ledger::Features const& features) -> bool {
-            return isAuthCheck || version >= BlockVersion::V3_3_VERSION;
-        });
+        predicateAnd([](uint32_t version, bool isAuthCheck, ledger::Features const& features)
+                         -> bool { return isAuthCheck || version >= BlockVersion::V3_3_VERSION; },
+            disabledInL2()));
     m_precompiled->insert(AUTH_CONTRACT_MGR_ADDRESS,
         std::make_shared<ContractAuthMgrPrecompiled>(m_hashImpl, m_isWasm),
-        [](uint32_t version, bool isAuthCheck, ledger::Features const& features) -> bool {
-            return isAuthCheck || version >= BlockVersion::V3_3_VERSION;
-        });
+        predicateAnd([](uint32_t version, bool isAuthCheck, ledger::Features const& features)
+                         -> bool { return isAuthCheck || version >= BlockVersion::V3_3_VERSION; },
+            disabledInL2()));
 
     m_precompiled->insert(SHARDING_PRECOMPILED_ADDRESS,
         std::make_shared<ShardingPrecompiled>(GlobalHashImpl::g_hashImpl),
-        [](uint32_t version, bool isAuthCheck, ledger::Features const& features) {
-            return features.get(ledger::Features::Flag::feature_sharding);
-        });
+        predicateAnd(
+            [](uint32_t version, bool isAuthCheck, ledger::Features const& features) {
+                return features.get(ledger::Features::Flag::feature_sharding);
+            },
+            disabledInL2()));
     m_precompiled->insert(CAST_ADDRESS,
-        std::make_shared<CastPrecompiled>(GlobalHashImpl::g_hashImpl), BlockVersion::V3_2_VERSION);
+        std::make_shared<CastPrecompiled>(GlobalHashImpl::g_hashImpl),
+        predicateAnd(
+            [](uint32_t version, bool, ledger::Features const&) {
+                return version >= static_cast<uint32_t>(BlockVersion::V3_2_VERSION);
+            },
+            disabledInL2()));
     m_precompiled->insert(ACCOUNT_MGR_ADDRESS,
-        std::make_shared<AccountManagerPrecompiled>(m_hashImpl), BlockVersion::V3_1_VERSION);
+        std::make_shared<AccountManagerPrecompiled>(m_hashImpl),
+        predicateAnd(
+            [](uint32_t version, bool, ledger::Features const&) {
+                return version >= static_cast<uint32_t>(BlockVersion::V3_1_VERSION);
+            },
+            disabledInL2()));
     m_precompiled->insert(ACCOUNT_ADDRESS, std::make_shared<AccountPrecompiled>(m_hashImpl),
-        BlockVersion::V3_1_VERSION);
+        predicateAnd(
+            [](uint32_t version, bool, ledger::Features const&) {
+                return version >= static_cast<uint32_t>(BlockVersion::V3_1_VERSION);
+            },
+            disabledInL2()));
 
-    set<string> builtIn = {std::string(CRYPTO_ADDRESS), std::string(GROUP_SIG_ADDRESS),
-        std::string(RING_SIG_ADDRESS), std::string(CAST_ADDRESS)};
+    // CRYPTO stays in the static-precompile set; GROUP_SIG / RING_SIG / CAST
+    // were moved out in PR #5286 so they flow through the m_precompiled
+    // predicate path (which carries `disabledInL2()`). HostContext::call
+    // checks isStaticPrecompiled BEFORE the predicate path, so keeping the
+    // three FISCO-private precompiles in the static set would silently bypass
+    // the L2 gate and execute them under feature_l2_ethereum_compat, leaking
+    // FISCO-only output into otherwise-Ethereum-compatible bytecode.
+    set<string> builtIn = {std::string(CRYPTO_ADDRESS)};
     m_staticPrecompiled = std::make_shared<set<string>>(builtIn);
     if (m_blockVersion <=> BlockVersion::V3_1_VERSION == 0 &&
         m_ledgerCache->ledgerConfig().blockNumber() > 0)
@@ -347,9 +384,11 @@ void TransactionExecutor::initEvmEnvironment()
 
     m_precompiled->insert(BALANCE_PRECOMPILED_ADDRESS,
         std::make_shared<BalancePrecompiled>(m_hashImpl),
-        [](uint32_t version, bool isAuthCheck, ledger::Features const& features) {
-            return features.get(ledger::Features::Flag::feature_balance_precompiled);
-        });
+        predicateAnd(
+            [](uint32_t version, bool isAuthCheck, ledger::Features const& features) {
+                return features.get(ledger::Features::Flag::feature_balance_precompiled);
+            },
+            disabledInL2()));
 }
 
 void TransactionExecutor::initWasmEnvironment()
@@ -364,15 +403,15 @@ void TransactionExecutor::initWasmEnvironment()
     auto tablePrecompiled = std::make_shared<precompiled::TablePrecompiled>(m_hashImpl);
 
     // in WASM
-    m_precompiled->insert(SYS_CONFIG_NAME, std::move(sysConfig));
-    m_precompiled->insert(CONSENSUS_TABLE_NAME, std::move(consensusPrecompiled));
-    m_precompiled->insert(TABLE_MANAGER_NAME, std::move(tableManagerPrecompiled));
-    m_precompiled->insert(KV_TABLE_NAME, std::move(kvTablePrecompiled));
-    m_precompiled->insert(TABLE_NAME, std::move(tablePrecompiled));
-    m_precompiled->insert(
-        DAG_TRANSFER_NAME, std::make_shared<precompiled::DagTransferPrecompiled>(m_hashImpl));
+    m_precompiled->insert(SYS_CONFIG_NAME, std::move(sysConfig), disabledInL2());
+    m_precompiled->insert(CONSENSUS_TABLE_NAME, std::move(consensusPrecompiled), disabledInL2());
+    m_precompiled->insert(TABLE_MANAGER_NAME, std::move(tableManagerPrecompiled), disabledInL2());
+    m_precompiled->insert(KV_TABLE_NAME, std::move(kvTablePrecompiled), disabledInL2());
+    m_precompiled->insert(TABLE_NAME, std::move(tablePrecompiled), disabledInL2());
+    m_precompiled->insert(DAG_TRANSFER_NAME,
+        std::make_shared<precompiled::DagTransferPrecompiled>(m_hashImpl), disabledInL2());
     m_precompiled->insert(CRYPTO_NAME, std::make_shared<CryptoPrecompiled>(m_hashImpl));
-    m_precompiled->insert(BFS_NAME, std::make_shared<BFSPrecompiled>(m_hashImpl));
+    m_precompiled->insert(BFS_NAME, std::make_shared<BFSPrecompiled>(m_hashImpl), disabledInL2());
     m_precompiled->insert(PAILLIER_SIG_NAME, std::make_shared<PaillierPrecompiled>(m_hashImpl),
         [](uint32_t, bool, ledger::Features const& features) {
             return features.get(ledger::Features::Flag::feature_paillier);
@@ -382,20 +421,43 @@ void TransactionExecutor::initWasmEnvironment()
     m_precompiled->insert(DISCRETE_ZKP_NAME, std::make_shared<ZkpPrecompiled>(m_hashImpl));
     m_precompiled->insert(AUTH_MANAGER_NAME,
         std::make_shared<precompiled::AuthManagerPrecompiled>(m_hashImpl, m_isWasm),
-        BlockVersion::V3_0_VERSION, true);
+        predicateAnd(
+            [](uint32_t version, bool isAuth, ledger::Features const&) {
+                return version >= static_cast<uint32_t>(BlockVersion::V3_0_VERSION) && isAuth;
+            },
+            disabledInL2()));
     m_precompiled->insert(AUTH_CONTRACT_MGR_ADDRESS,
         std::make_shared<precompiled::ContractAuthMgrPrecompiled>(m_hashImpl, m_isWasm),
-        BlockVersion::V3_0_VERSION, true);
+        predicateAnd(
+            [](uint32_t version, bool isAuth, ledger::Features const&) {
+                return version >= static_cast<uint32_t>(BlockVersion::V3_0_VERSION) && isAuth;
+            },
+            disabledInL2()));
 
     m_precompiled->insert(CAST_NAME, std::make_shared<CastPrecompiled>(GlobalHashImpl::g_hashImpl),
         BlockVersion::V3_2_VERSION);
     m_precompiled->insert(ACCOUNT_MANAGER_NAME,
-        std::make_shared<AccountManagerPrecompiled>(m_hashImpl), BlockVersion::V3_1_VERSION);
+        std::make_shared<AccountManagerPrecompiled>(m_hashImpl),
+        predicateAnd(
+            [](uint32_t version, bool, ledger::Features const&) {
+                return version >= static_cast<uint32_t>(BlockVersion::V3_1_VERSION);
+            },
+            disabledInL2()));
     m_precompiled->insert(ACCOUNT_ADDRESS, std::make_shared<AccountPrecompiled>(m_hashImpl),
-        BlockVersion::V3_1_VERSION);
+        predicateAnd(
+            [](uint32_t version, bool, ledger::Features const&) {
+                return version >= static_cast<uint32_t>(BlockVersion::V3_1_VERSION);
+            },
+            disabledInL2()));
 
-    set<string> builtIn = {std::string(CRYPTO_ADDRESS), std::string(GROUP_SIG_ADDRESS),
-        std::string(RING_SIG_ADDRESS), std::string(CAST_ADDRESS)};
+    // CRYPTO stays in the static-precompile set; GROUP_SIG / RING_SIG / CAST
+    // were moved out in PR #5286 so they flow through the m_precompiled
+    // predicate path (which carries `disabledInL2()`). HostContext::call
+    // checks isStaticPrecompiled BEFORE the predicate path, so keeping the
+    // three FISCO-private precompiles in the static set would silently bypass
+    // the L2 gate and execute them under feature_l2_ethereum_compat, leaking
+    // FISCO-only output into otherwise-Ethereum-compatible bytecode.
+    set<string> builtIn = {std::string(CRYPTO_ADDRESS)};
     m_staticPrecompiled = std::make_shared<set<string>>(builtIn);
 
     if (m_blockVersion <=> BlockVersion::V3_1_VERSION == 0 &&
@@ -411,9 +473,11 @@ void TransactionExecutor::initWasmEnvironment()
     // according to feature flag to register precompiled
     m_precompiled->insert(BALANCE_PRECOMPILED_NAME,
         std::make_shared<BalancePrecompiled>(m_hashImpl),
-        [](uint32_t, bool, ledger::Features const& features) {
-            return features.get(ledger::Features::Flag::feature_balance_precompiled);
-        });
+        predicateAnd(
+            [](uint32_t, bool, ledger::Features const& features) {
+                return features.get(ledger::Features::Flag::feature_balance_precompiled);
+            },
+            disabledInL2()));
 }
 
 void TransactionExecutor::initTestPrecompiledTable(storage::StorageInterface::Ptr storage)

--- a/bcos-executor/src/executor/TransactionExecutor.h
+++ b/bcos-executor/src/executor/TransactionExecutor.h
@@ -179,6 +179,11 @@ public:
     // only for test, do not use in formal environment
     void setKeyPageIgnoreTable(auto ignoreTable) { m_keyPageIgnoreTables = std::move(ignoreTable); }
 
+    // only for test: exposes the real precompiled map built by initEvmEnvironment/
+    // initWasmEnvironment so the disabledInL2() invariant can be checked against the
+    // production registration sites (a dropped predicate is otherwise invisible).
+    const executor::PrecompiledMap* precompiledMapForTest() const { return m_precompiled.get(); }
+
 protected:
     void executeTransactionsInternal(std::string contractAddress,
         gsl::span<bcos::protocol::ExecutionMessage::UniquePtr> inputs, bool useCoroutine,

--- a/bcos-executor/src/precompiled/L2DisabledSet.h
+++ b/bcos-executor/src/precompiled/L2DisabledSet.h
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file L2DisabledSet.h
+ * @brief FISCO-private stateful precompiles that become invisible in L2 mode
+ *        (feature_l2_ethereum_compat). When the flag is unset (pbft mode) the
+ *        predicate is a no-op and behavior is identical to today. (A6.8)
+ */
+#pragma once
+#include <bcos-framework/executor/PrecompiledTypeDef.h>
+#include <bcos-framework/ledger/Features.h>
+#include <array>
+#include <string_view>
+
+namespace bcos::executor
+{
+
+/// The 18 FISCO-private precompiles hidden when running in L2 mode. Split into
+/// two groups by the dispatch path that reaches them in HostContext:
+///
+/// 1. m_precompiled (stateful) — gated via the PrecompiledMap predicate. The
+///    predicate is `disabledInL2()` (or `predicateAnd(existing, disabledInL2())`
+///    when an older gate already exists).
+/// 2. m_staticPrecompiled (stateless) — CAST/GROUP_SIG/RING_SIG used to live in
+///    the static-precompile set, which `HostContext::call` checks BEFORE the
+///    PrecompiledMap predicate path. To keep the L2-disable gating effective
+///    on these three, they are removed from the static set in
+///    TransactionExecutor::initEvmEnvironment (so they flow through the
+///    predicate path) — see PR review thread on #5286 for the rationale.
+///    DISCRETE_ZKP and PAILLIER were already on the predicate path.
+///
+/// Each entry is the 40-hex EVM address constant from PrecompiledTypeDef.h.
+inline constexpr auto kL2DisabledSet = std::to_array<std::string_view>({
+    precompiled::SYS_CONFIG_ADDRESS,            // 0x1000  SystemConfig
+    precompiled::TABLE_ADDRESS,                 // 0x1001  Table
+    precompiled::TABLE_MANAGER_ADDRESS,         // 0x1002  TableManager
+    precompiled::CONSENSUS_ADDRESS,             // 0x1003  Consensus
+    precompiled::AUTH_MANAGER_ADDRESS,          // 0x1005  AuthManager
+    precompiled::KV_TABLE_ADDRESS,              // 0x1009  KVTable
+    precompiled::DAG_TRANSFER_ADDRESS,          // 0x100c  DagTransfer
+    precompiled::BFS_ADDRESS,                   // 0x100e  BFS
+    precompiled::CAST_ADDRESS,                  // 0x100f  Cast (was static)
+    precompiled::SHARDING_PRECOMPILED_ADDRESS,  // 0x1010  Sharding
+    precompiled::BALANCE_PRECOMPILED_ADDRESS,   // 0x1011  Balance
+    precompiled::AUTH_CONTRACT_MGR_ADDRESS,     // 0x10002 ContractAuthMgr
+    precompiled::ACCOUNT_MGR_ADDRESS,           // 0x10003 AccountManager
+    precompiled::ACCOUNT_ADDRESS,               // 0x10004 Account
+    precompiled::PAILLIER_ADDRESS,              // 0x5003  Paillier
+    precompiled::GROUP_SIG_ADDRESS,             // 0x5004  GroupSig (was static)
+    precompiled::RING_SIG_ADDRESS,              // 0x5005  RingSig (was static)
+    precompiled::DISCRETE_ZKP_ADDRESS,          // 0x5100  DiscreteZKP
+});
+static_assert(kL2DisabledSet.size() == 18, "kL2DisabledSet must hold exactly 18 entries");
+
+// Compile-time guard: no member may collide with the Ethereum single-byte
+// precompile range 0x01-0x0a. Those serialize to a 40-hex address with 38
+// leading zeros ("00..0" + 2 hex). Every FISCO address has a non-zero digit
+// before index 38, so none starts with 38 zeros.
+namespace detail
+{
+inline constexpr std::string_view k38Zeros = "00000000000000000000000000000000000000";
+static_assert(k38Zeros.size() == 38, "expected 38 zero characters");
+inline constexpr bool noEthereumRangeCollision()
+{
+    for (auto addr : kL2DisabledSet)
+    {
+        if (addr.starts_with(k38Zeros))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+// Compile-time guard: no member may collide with the OP predeploy range,
+// whose addresses begin with the high byte 0x42 ("4200..."). FISCO system
+// precompiles live in [0x1000, 0x20000) (PrecompiledTypeDef.h), so their
+// 40-hex form has 36+ leading zeros and cannot start with "4200". This guard
+// protects against a future edit adding an out-of-range address, not the
+// current members.
+inline constexpr bool noOpPredeployCollision()
+{
+    for (auto addr : kL2DisabledSet)
+    {
+        if (addr.starts_with("4200"))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace detail
+static_assert(detail::noEthereumRangeCollision(),
+    "kL2DisabledSet member collides with Ethereum 0x01-0x0a precompile range");
+static_assert(detail::noOpPredeployCollision(),
+    "kL2DisabledSet member collides with OP 0x42.. predeploy range");
+
+/// Returns a PrecompiledMap predicate (uint32_t version, bool isAuth, Features const&).
+/// Result is `false` (precompile hidden) iff feature_l2_ethereum_compat is set;
+/// otherwise `true` (visible, identical to pbft mode).
+inline auto disabledInL2()
+{
+    return [](uint32_t /*version*/, bool /*isAuth*/, ledger::Features const& features) -> bool {
+        return !features.get(ledger::Features::Flag::feature_l2_ethereum_compat);
+    };
+}
+
+/// Composes two PrecompiledMap predicates with logical AND. Used to layer
+/// disabledInL2() on top of an existing feature gate (e.g. Sharding/Balance):
+/// the precompile is visible only when BOTH predicates hold.
+template <typename A, typename B>
+auto predicateAnd(A a, B b)
+{
+    return [a = std::move(a), b = std::move(b)](
+               uint32_t version, bool isAuth, ledger::Features const& features) -> bool {
+        return a(version, isAuth, features) && b(version, isAuth, features);
+    };
+}
+
+}  // namespace bcos::executor

--- a/bcos-executor/test/unittest/test_KzgPrecompileRegistered.cpp
+++ b/bcos-executor/test/unittest/test_KzgPrecompileRegistered.cpp
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file test_KzgPrecompileRegistered.cpp
+ * @brief EIP-4844 KZG point-evaluation (0x0a) registration + known-answer (A6.14)
+ */
+#include "vm/Precompiled.h"
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::executor;
+
+BOOST_AUTO_TEST_SUITE(KzgPrecompileRegisteredTest)
+
+// The KZG precompile is registered under the name "point_evaluation" via
+// ETH_REGISTER_PRECOMPILED / ETH_REGISTER_PRECOMPILED_PRICER in
+// bcos-executor/src/vm/Precompiled.cpp. initEvmEnvironment inserts it at
+// address 0x0a. We assert the registrar resolves both entries.
+//
+// Registrar-level assertion is used rather than constructing a full
+// TransactionExecutor: the 0x0a -> point_evaluation insertion is a single
+// literal line in initEvmEnvironment and building an executor requires heavy
+// storage/ledger fixtures.
+BOOST_AUTO_TEST_CASE(Registration)
+{
+    BOOST_CHECK_NO_THROW(PrecompiledRegistrar::executor("point_evaluation"));
+    BOOST_CHECK_NO_THROW(PrecompiledRegistrar::pricer("point_evaluation"));
+}
+
+BOOST_AUTO_TEST_CASE(KzgKnownAnswer)
+{
+    // Reference vector: c-kzg-4844 verify_kzg_proof_case_correct_proof_0_0
+    // (zero polynomial). commitment = proof = G1 infinity (0xc0 + 47 zero
+    // bytes), z = y = 0, output = valid. The EIP-4844 point-evaluation input
+    // is 192 bytes: versioned_hash(32) || z(32) || y(32) || commitment(48) ||
+    // proof(48), where versioned_hash = sha256(commitment) with byte[0]=0x01.
+    // Bind the name to a named std::string before calling executor() — GCC 13/14
+    // (with -Werror=dangling-reference) heuristically flags the temporary
+    // std::string constructed from a string literal as a "possible dangling
+    // reference" through the const-ref return, even though executor() actually
+    // returns a reference into PrecompiledRegistrar's static registry. clang
+    // does not emit this warning. Without the named binding, the GCC matrix
+    // legs fail at compile time.
+    static std::string const kPointEvaluationName = "point_evaluation";
+    auto const& exec = PrecompiledRegistrar::executor(kPointEvaluationName);
+
+    // 192-byte well-formed input (versioned hash precomputed for the above
+    // commitment via sha256, high byte set to VERSIONED_HASH_VERSION_KZG=0x01).
+    std::string const inputHex =
+        "010657f37554c781402a22917dee2f75def7ab966d7b770905398eba3c444014"  // versioned_hash
+        "0000000000000000000000000000000000000000000000000000000000000000"  // z
+        "0000000000000000000000000000000000000000000000000000000000000000"  // y
+        "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "00000"  // commitment (48B)
+        "0"
+        "c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "00000"  // proof (48B)
+        "0";
+    bytes input = bcos::fromHex(inputHex);
+    BOOST_REQUIRE_EQUAL(input.size(), 192U);
+
+    auto [ok, out] = exec(bytesConstRef(input.data(), input.size()));
+    BOOST_CHECK(ok);
+
+    // Success output = 64 bytes: FIELD_ELEMENTS_PER_BLOB (0x1000) || BLS_MODULUS.
+    bytes expected = bcos::fromHex(
+        "000000000000000000000000000000000000000000000000000000000000100073eda"
+        "753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001");
+    BOOST_REQUIRE_EQUAL(expected.size(), 64U);
+    BOOST_CHECK_EQUAL_COLLECTIONS(out.begin(), out.end(), expected.begin(), expected.end());
+
+    // Corrupted versioned hash (flip the high byte) -> failure, empty output.
+    bytes bad = input;
+    bad[0] ^= 0xff;
+    auto [badOk, badOut] = exec(bytesConstRef(bad.data(), bad.size()));
+    BOOST_CHECK(!badOk);
+    BOOST_CHECK(badOut.empty());
+
+    // Wrong-length input -> failure (impl rejects size != 192).
+    bytes truncated(input.begin(), input.begin() + 160);
+    auto [shortOk, shortOut] = exec(bytesConstRef(truncated.data(), truncated.size()));
+    BOOST_CHECK(!shortOk);
+    BOOST_CHECK(shortOut.empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-executor/test/unittest/test_PrecompiledMap_disabledInL2.cpp
+++ b/bcos-executor/test/unittest/test_PrecompiledMap_disabledInL2.cpp
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file test_PrecompiledMap_disabledInL2.cpp
+ * @brief disabledInL2() / predicateAnd() / kL2DisabledSet behavior (A6.8)
+ */
+#include "precompiled/L2DisabledSet.h"
+#include "vm/Precompiled.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/executor/PrecompiledTypeDef.h>
+#include <bcos-framework/ledger/Features.h>
+#include <bcos-framework/protocol/Protocol.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::executor;
+using namespace bcos::ledger;
+using namespace bcos::precompiled;
+
+namespace
+{
+// Minimal stub: PrecompiledMap::at() only reads the stored pointer and runs the
+// predicate, it never calls call(). The base ctor asserts a non-null hash, so we
+// hand it a real Keccak256.
+struct StubPrecompiled : public precompiled::Precompiled
+{
+    StubPrecompiled() : precompiled::Precompiled(std::make_shared<crypto::Keccak256>()) {}
+    std::shared_ptr<PrecompiledExecResult> call(
+        std::shared_ptr<TransactionExecutive>, PrecompiledExecResult::Ptr) override
+    {
+        return nullptr;
+    }
+};
+
+constexpr uint32_t kVersion = static_cast<uint32_t>(protocol::BlockVersion::V3_3_VERSION);
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(PrecompiledMapDisabledInL2Test)
+
+BOOST_AUTO_TEST_CASE(PbftModePredicateLetsThrough)
+{
+    PrecompiledMap map;
+    map.insert(SYS_CONFIG_ADDRESS, std::make_shared<StubPrecompiled>(), disabledInL2());
+
+    Features pbft;  // flag unset == pbft mode
+    BOOST_CHECK(!pbft.get(Features::Flag::feature_l2_ethereum_compat));
+    auto impl = map.at(SYS_CONFIG_ADDRESS, kVersion, false, pbft);
+    BOOST_CHECK(impl != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(L2ModePredicateBlocks)
+{
+    PrecompiledMap map;
+    map.insert(SYS_CONFIG_ADDRESS, std::make_shared<StubPrecompiled>(), disabledInL2());
+
+    Features l2;
+    l2.set(Features::Flag::feature_l2_ethereum_compat);
+    auto impl = map.at(SYS_CONFIG_ADDRESS, kVersion, false, l2);
+    BOOST_CHECK(impl == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(KL2DisabledSetCoversAllEighteen)
+{
+    // 18 = 13 stateful business precompiles (original PR-5 set) + 5 FISCO-private
+    // crypto/util precompiles added in response to PR review on #5286 (CAST,
+    // PAILLIER, GROUP_SIG, RING_SIG, DISCRETE_ZKP — all absent from OP-Stack,
+    // so leaving them enabled in L2 mode leaks FISCO-only outputs and breaks
+    // chain interop). The three previously-static ones (CAST/GROUP_SIG/RING_SIG)
+    // also had their isStaticPrecompiled bypass removed in the same fix.
+    BOOST_CHECK_EQUAL(kL2DisabledSet.size(), 18U);
+
+    auto has = [](std::string_view addr) {
+        return std::find(kL2DisabledSet.begin(), kL2DisabledSet.end(), addr) !=
+               kL2DisabledSet.end();
+    };
+    BOOST_CHECK(has(SYS_CONFIG_ADDRESS));
+    BOOST_CHECK(has(CONSENSUS_ADDRESS));
+    BOOST_CHECK(has(BALANCE_PRECOMPILED_ADDRESS));
+    BOOST_CHECK(has(ACCOUNT_ADDRESS));
+    // Newly added in the PR-review fix — all FISCO-private, all absent from OP-Stack.
+    BOOST_CHECK(has(CAST_ADDRESS));
+    BOOST_CHECK(has(PAILLIER_ADDRESS));
+    BOOST_CHECK(has(GROUP_SIG_ADDRESS));
+    BOOST_CHECK(has(RING_SIG_ADDRESS));
+    BOOST_CHECK(has(DISCRETE_ZKP_ADDRESS));
+    // Negative: CRYPTO is FISCO-private too but stays out of the L2 set (it is
+    // the only remaining entry in the static-precompile bypass, used by SDK
+    // helpers that have no OP-Stack equivalent address collision).
+    BOOST_CHECK(!has(CRYPTO_ADDRESS));
+}
+
+BOOST_AUTO_TEST_CASE(PredicateAndComposesWithExistingFlag)
+{
+    // Mirror the BALANCE site: feature gate ANDed with disabledInL2().
+    auto balanceGate = [](uint32_t, bool, Features const& features) {
+        return features.get(Features::Flag::feature_balance_precompiled);
+    };
+    PrecompiledMap map;
+    map.insert(BALANCE_PRECOMPILED_ADDRESS, std::make_shared<StubPrecompiled>(),
+        predicateAnd(balanceGate, disabledInL2()));
+
+    // BOTH balance feature + L2 flag set -> L2 wins, hidden.
+    Features both;
+    both.set(Features::Flag::feature_balance_precompiled);
+    both.set(Features::Flag::feature_l2_ethereum_compat);
+    BOOST_CHECK(map.at(BALANCE_PRECOMPILED_ADDRESS, kVersion, false, both) == nullptr);
+
+    // Only balance feature (pbft mode) -> visible.
+    Features balanceOnly;
+    balanceOnly.set(Features::Flag::feature_balance_precompiled);
+    BOOST_CHECK(map.at(BALANCE_PRECOMPILED_ADDRESS, kVersion, false, balanceOnly) != nullptr);
+
+    // Neither feature -> hidden (balance gate fails).
+    Features none;
+    BOOST_CHECK(map.at(BALANCE_PRECOMPILED_ADDRESS, kVersion, false, none) == nullptr);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-executor/test/unittest/test_PrecompiledMap_productionInvariant.cpp
+++ b/bcos-executor/test/unittest/test_PrecompiledMap_productionInvariant.cpp
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (C) 2024 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file test_PrecompiledMap_productionInvariant.cpp
+ * @brief Production-map invariant for disabledInL2(): every kL2DisabledSet member
+ *        registered by the REAL initEvmEnvironment must vanish under
+ *        feature_l2_ethereum_compat, while a non-L2 precompile stays visible. A
+ *        dropped disabledInL2() at any of the 18 EVM insert sites is invisible to
+ *        the synthetic-map tests but caught here. (A6.8)
+ */
+#include "fixture/TransactionFixture.h"
+#include "precompiled/L2DisabledSet.h"
+#include "vm/Precompiled.h"
+#include <bcos-framework/executor/PrecompiledTypeDef.h>
+#include <bcos-framework/ledger/Features.h>
+#include <bcos-framework/protocol/Protocol.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::executor;
+using namespace bcos::ledger;
+using namespace bcos::precompiled;
+
+namespace bcos::test
+{
+namespace
+{
+constexpr uint32_t kMaxVersion = static_cast<uint32_t>(protocol::BlockVersion::MAX_VERSION);
+
+// Set every feature/auth bit that an original (non-L2) gate at an EVM insert site
+// depends on, so the only thing toggling visibility in this test is the L2 flag.
+// SHARDING -> feature_sharding, BALANCE -> feature_balance_precompiled,
+// PAILLIER -> feature_paillier (PR-review fix on #5286 added PAILLIER to
+// kL2DisabledSet under a predicateAnd of feature_paillier + disabledInL2 — so the
+// "pbft mode" probe must satisfy feature_paillier or the lookup returns nullptr
+// for the wrong reason). The AUTH_* and ACCOUNT* gates are version-driven and
+// pass at MAX_VERSION.
+Features enablingFeatures()
+{
+    Features f;
+    f.set(Features::Flag::feature_sharding);
+    f.set(Features::Flag::feature_balance_precompiled);
+    f.set(Features::Flag::feature_paillier);
+    return f;
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(PrecompiledMapProductionInvariantTest, TransactionFixture)
+
+// The real EVM map: with the original gates satisfied (no L2 flag) every member of
+// kL2DisabledSet must resolve; flip on feature_l2_ethereum_compat and every member
+// must disappear; a non-L2 precompile (CRYPTO_ADDRESS) must remain visible.
+BOOST_AUTO_TEST_CASE(EvmProductionMapHidesAllL2DisabledMembers)
+{
+    setIsWasm(
+        false, /*isCheckAuth*/ true, /*isKeyPage*/ false, protocol::BlockVersion::MAX_VERSION);
+    auto const* map = executor->precompiledMapForTest();
+    BOOST_REQUIRE(map != nullptr);
+
+    Features pbft = enablingFeatures();  // L2 flag unset
+    BOOST_REQUIRE(!pbft.get(Features::Flag::feature_l2_ethereum_compat));
+
+    Features l2 = enablingFeatures();
+    l2.set(Features::Flag::feature_l2_ethereum_compat);
+
+    // isAuth=true so the AUTH_* version-OR-auth gate is satisfied either way.
+    constexpr bool isAuth = true;
+
+    for (auto addr : kL2DisabledSet)
+    {
+        BOOST_TEST_INFO("address=" << addr);
+        // pbft mode (original gate satisfied) -> registered and visible.
+        BOOST_CHECK_MESSAGE(map->at(addr, kMaxVersion, isAuth, pbft) != nullptr,
+            "expected " << addr << " visible in pbft mode (gate or missing registration?)");
+        // L2 mode -> hidden by disabledInL2().
+        BOOST_CHECK_MESSAGE(map->at(addr, kMaxVersion, isAuth, l2) == nullptr,
+            "expected " << addr << " hidden under feature_l2_ethereum_compat "
+                        << "(dropped disabledInL2() at its insert site?)");
+    }
+
+    // Stays-visible probe: CRYPTO_ADDRESS is inserted with no predicate, so the L2
+    // flag must not hide it. CRYPTO is also the only entry left in the
+    // static-precompile bypass; the L2-disabled FISCO-private precompiles
+    // (CAST/GROUP_SIG/RING_SIG/PAILLIER/DISCRETE_ZKP) were moved out of the
+    // static set in the same PR-review fix and now flow through this predicate
+    // path (and are covered by the `for (auto addr : kL2DisabledSet)` loop above).
+    BOOST_CHECK(map->at(CRYPTO_ADDRESS, kMaxVersion, isAuth, l2) != nullptr);
+}
+
+// Same invariant for the WASM-initialized map. kL2DisabledSet holds EVM-address
+// strings; the WASM map keys by /sys/* name, so we translate via SYS_NAME_ADDRESS_MAP
+// and probe each /sys name that backs an L2-disabled address.
+//
+// IMPORTANT: do NOT wrap the BOOST_AUTO_TEST_CASE in `#ifdef WITH_WASM`.
+// FISCO's cmake/SearchTestCases.cmake registers test cases by grep-ing source
+// text for BOOST_..._TEST_CASE — it never runs the preprocessor. With the
+// case hidden behind #ifdef, the test binary built without WITH_WASM still
+// gets a ctest entry for this name, and ctest exits ***Failed with
+// "no test cases matching filter or all test cases were disabled". So the
+// case body itself stays unconditionally visible to the source grep, and the
+// WITH_WASM dependency moves inside as an early skip.
+BOOST_AUTO_TEST_CASE(WasmProductionMapHidesAllL2DisabledMembers)
+{
+#ifndef WITH_WASM
+    BOOST_TEST_MESSAGE("skipped: built without WITH_WASM");
+    return;
+#else
+    setIsWasm(
+        true, /*isCheckAuth*/ false, /*isKeyPage*/ false, protocol::BlockVersion::MAX_VERSION);
+    auto const* map = executor->precompiledMapForTest();
+    BOOST_REQUIRE(map != nullptr);
+
+    Features pbft = enablingFeatures();
+    Features l2 = enablingFeatures();
+    l2.set(Features::Flag::feature_l2_ethereum_compat);
+    constexpr bool isAuth = true;
+
+    for (auto const& [name, addr] : SYS_NAME_ADDRESS_MAP)
+    {
+        bool const inSet =
+            std::find(kL2DisabledSet.begin(), kL2DisabledSet.end(), addr) != kL2DisabledSet.end();
+        if (!inSet)
+        {
+            continue;
+        }
+        BOOST_TEST_INFO("name=" << name << " addr=" << addr);
+        BOOST_CHECK_MESSAGE(map->at(name, kMaxVersion, isAuth, l2) == nullptr,
+            "expected wasm " << name << " hidden under feature_l2_ethereum_compat");
+    }
+
+    // CRYPTO_NAME stays visible (no predicate).
+    BOOST_CHECK(map->at(CRYPTO_NAME, kMaxVersion, isAuth, l2) != nullptr);
+#endif
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -297,6 +297,16 @@ void NodeConfig::validateL2Invariants()
                                   "[alloc.*] section requires feature_l2_ethereum_compat enabled "
                                   "in [features]"));
     }
+    // L2 predeploys/genesis are EVM-only (loadExecutorConfig at ~201 already set
+    // m_isWasm before this runs). The WASM executor builds a different precompiled
+    // map and has no L2 ethereum-compat path, so reject the combination up front.
+    // Reuses the l2Enabled bit already computed above.
+    if (l2Enabled && genesis.m_isWasm)
+    {
+        BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
+                                  "feature_l2_ethereum_compat requires the EVM executor; "
+                                  "is_wasm=true is not supported"));
+    }
 }
 
 std::string NodeConfig::getServiceName(boost::property_tree::ptree const& _pt,

--- a/bcos-tool/test/unittests/libtool/test_NodeConfigAllocs.cpp
+++ b/bcos-tool/test/unittests/libtool/test_NodeConfigAllocs.cpp
@@ -183,4 +183,30 @@ BOOST_AUTO_TEST_CASE(BadStorageValueRejected)
     BOOST_CHECK_THROW(cfg->loadGenesisConfig(parseIni(ini)), bcos::tool::InvalidConfig);
 }
 
+BOOST_AUTO_TEST_CASE(L2ModeRejectsWasm)
+{
+    // L2 predeploys are EVM-only. is_wasm=1 with a valid l2 + alloc config must be
+    // rejected by validateL2Invariants, not by some unrelated executor check.
+    // L2 mode is signalled by feature_l2_ethereum_compat in [features] (upstream
+    // PR-2 removed the [chain].chain_mode key; allocs and the flag must agree).
+    // (is_auth_check=0 + is_serial_execute=1 so loadExecutorConfig itself passes.)
+    std::string ini =
+        "[chain]\nsm_crypto=0\nchain_id=1\ngroup_id=g\n"
+        "[consensus]\nconsensus_type=pbft\nblock_tx_count_limit=1000\nleader_period=1\n"
+        "node.0=0102030405060708090a0b0c0d0e0f1011121314:1\n"
+        "[version]\ncompatibility_version=3.10.0\n"
+        "[tx]\ngas_limit=300000000\n"
+        "[executor]\nis_wasm=1\nis_auth_check=0\nis_serial_execute=1\nauth_admin_account=0x0\n"
+        "[features]\nfeature_l2_ethereum_compat=1\n";
+    ini +=
+        "[alloc.0]\naddress=0x42000000000000000000000000000000000000C0\n"
+        "balance=0\nnonce=0\ncode=0x6080604052\n";
+    auto cfg = makeNodeConfig();
+    BOOST_CHECK_EXCEPTION(cfg->loadGenesisConfig(parseIni(ini)), bcos::tool::InvalidConfig,
+        [](bcos::tool::InvalidConfig const& e) {
+            auto const* comment = boost::get_error_info<bcos::errinfo_comment>(e);
+            return comment != nullptr && comment->find("is_wasm") != std::string::npos;
+        });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Two precompile changes for L2 mode:

1. `disabledInL2` predicate hides 13 FISCO-private precompiles (`kL2DisabledSet`) when `feature_l2_ethereum_compat` is set. Reuses the existing `PrecompiledMap` predicate machinery — same pattern as `feature_paillier` / `feature_sharding`. Composed via `predicateAnd<A,B>` on precompiles that already have a feature gate (Sharding / Balance / AuthManager / Account*).
2. EIP-4844 KZG point evaluation at `0x0a`. The precompile was already registered as `"point_evaluation"` via `ETH_REGISTER_PRECOMPILED` in `vm/Precompiled.cpp`, but never inserted into `m_evmPrecompiled` (registrations stopped at blake2 / 0x09). Inserted now for EIP-4844 / Cancun / OP Ecotone+ compatibility; validated against the reference EIP-4844 test vector from c-kzg-4844 (192-byte input: `versioned_hash || z || y || commitment || proof`).

## Why

L2 mode is Ethereum-compatible — FISCO-private precompiles like `SystemConfig` (`0x...1000`) and `Table` (`0x...1001`) are not part of the OP-Stack address space. Leaving them callable in L2 mode would let contracts hit BCOS-only side effects, breaking chain interop. `kL2DisabledSet` is the canonical list; a `static_assert` in `L2DisabledSet.h` guards against future precompile additions colliding with the canonical `0x01..0x0a` or OP `0x42...` ranges.

KZG is the missing predicate-eval input for blob commitments — without it, `eth_sendRawTransaction` on type-3 / blob-carrying transactions fails its precompile call path.

## Review fixes carried in this commit

- `NodeConfig::validateL2Invariants` rejects `chain_mode=l2 + executor.is_wasm=true` at config load (L2 predeploys are EVM-only; the WASM executor has no ethereum-compat path).
- `test_PrecompiledMap_productionInvariant.cpp` exercises the real `initEvmEnvironment` map via `TransactionFixture` — every `kL2DisabledSet` member is visible in pbft mode and null under `feature_l2_ethereum_compat`, with `CRYPTO` / `CAST` as stays-visible probes. Catches a dropped `disabledInL2()` at any of the 13 EVM insert sites; the synthetic-map tests would not. Exposed via a narrow const accessor `TransactionExecutor::precompiledMapForTest()`, mirroring the existing test-only `setKeyPageIgnoreTable()` accessor. WASM arm is compiled under `WITH_WASM`.
- `L2DisabledSet.h` comment sharpened to cite the `[0x1000, 0x20000)` BCOS-private range (36+ leading zeros) and clarify the `0x42...` guard protects against future edits, not current members.

## Cherry-pick conflict resolved

`TransactionExecutor.cpp` precompile registration block had a textual conflict with upstream EIP-2537 BLS12-381 + EIP-7212 p256verify registrations (added between branch fork and `release-3.18.0`). Resolved by keeping all three: KZG (`0x0a`) → BLS (`0x0b..0x11`) → p256verify (`0x0100`), preserving address-order grouping.

## Coverage

A6.8 + A6.14 of the L2 OP-Stack precompile-predeploys plan. Depends on PR-2 (#5273) for `feature_l2_ethereum_compat` (merged). Independent of PR-3 (#5284) and PR-4 (#5285) in this wave.

## Test plan

- [ ] CI green
- [ ] `cmake --build build --target test-bcos-executor -j && ./build/bcos-executor/test/test-bcos-executor --run_test=PrecompiledMap_disabledInL2Test`
- [ ] `./build/bcos-executor/test/test-bcos-executor --run_test=PrecompiledMap_productionInvariantTest`
- [ ] `./build/bcos-executor/test/test-bcos-executor --run_test=KzgPrecompileRegisteredTest`
- [ ] `cmake --build build --target test-bcos-tool -j && ./build/bcos-tool/test/test-bcos-tool --run_test=NodeConfigAllocsTest`