### PR TITLE
sync code: batch fixes for leader-election, pbft, gateway, executor, and sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,6 @@ test/*
 
 # Claude Code
 CLAUDE.local.md
+.worktrees/
 .claude/worktrees
 .claude/agents

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -374,6 +374,16 @@ void Gateway::onReceiveP2PMessage(
 
     auto srcNodeID = options.srcNodeID();
     const auto& dstNodeIDs = options.dstNodeIDs();
+    // FIB-183: a decoded P2PMessage may legitimately carry zero dstNodeIDs (the wire
+    // format allows a src-nodeID count of 0). Indexing dstNodeIDs[0] in that case is an
+    // out-of-bounds read on an empty vector. Drop the message before indexing.
+    if (dstNodeIDs.empty())
+    {
+        GATEWAY_LOG(WARNING) << LOG_BADGE("onReceiveP2PMessage")
+                             << LOG_DESC("empty dstNodeIDs, drop") << LOG_KV("groupID", groupID)
+                             << LOG_KV("moduleID", moduleID) << LOG_KV("seq", _msg->seq());
+        return;
+    }
     auto srcNodeIDPtr = m_gatewayNodeManager->keyFactory()->createKey(srcNodeID);
     auto dstNodeIDPtr = m_gatewayNodeManager->keyFactory()->createKey(dstNodeIDs[0]);
     auto gateway = std::weak_ptr<Gateway>(shared_from_this());

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -19,6 +19,7 @@
  * @date 2021-05-13
  */
 #include "GatewayNodeManager.h"
+#include <cstring>
 
 using namespace std;
 using namespace bcos;
@@ -143,8 +144,18 @@ void GatewayNodeManager::onReceiveStatusSeq(
                                   << LOG_KV("code", _e.errorCode()) << LOG_KV("msg", _e.what());
         return;
     }
-    auto statusSeq =
-        boost::asio::detail::socket_ops::network_to_host_long(*((uint32_t*)_msg->payload().data()));
+    // FIB-183: onReceiveStatusSeq reads a 4-byte sequence via *(uint32_t*)payload().data()
+    // with no size check (same defect class fixed in ServiceV2::onReceiveRouterSeq); a 0-3 byte
+    // payload reads past the decoded buffer. Drop short payloads and use memcpy for the read.
+    if (_msg->payload().size() < sizeof(uint32_t))
+    {
+        NODE_MANAGER_LOG(WARNING) << LOG_DESC("onReceiveStatusSeq short payload, drop")
+                                  << LOG_KV("size", _msg->payload().size());
+        return;
+    }
+    uint32_t rawStatusSeq = 0;
+    std::memcpy(&rawStatusSeq, _msg->payload().data(), sizeof(rawStatusSeq));
+    auto statusSeq = boost::asio::detail::socket_ops::network_to_host_long(rawStatusSeq);
     auto const& from = (_msg->srcP2PNodeID().size() > 0) ? _msg->srcP2PNodeID() : _session->p2pID();
     auto statusSeqChanged = statusChanged(from, statusSeq);
     if (!statusSeqChanged)

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -15,9 +15,9 @@
  * threads it should allow to run simultaneously.") (since ethereum use 2, we
  * modify io_service from 1 to 2) 2.
  */
+#include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Common.h"
-#include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
 #include <boost/algorithm/string.hpp>
@@ -375,12 +375,93 @@ void Host::handshakeServer(const boost::system::error_code& error,
  * @param _s : connected socket(used to init session object)
  */
 // TODO: asyncConnect pass handle to startPeerSession, make use of it
+// FIB-184: reserve a session slot under the global and per-IP caps. Returns false when either
+// cap is reached; the caller must then close the socket without creating a session.
+bool Host::tryAcquireSessionSlot(std::string const& _address)
+{
+    std::lock_guard<std::mutex> lock(x_sessionCountPerIP);
+    if (m_sessionCount.load(std::memory_order_relaxed) >= m_maxConcurrentSessions)
+    {
+        return false;
+    }
+    auto& perIP = m_sessionCountPerIP[_address];
+    if (perIP >= m_maxSessionsPerIP)
+    {
+        return false;
+    }
+    ++perIP;
+    m_sessionCount.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+// FIB-184: release a previously reserved slot. Runs from the session lifetime guard's
+// destructor, i.e. exactly once when the session object is destroyed.
+void Host::releaseSessionSlot(std::string const& _address)
+{
+    std::lock_guard<std::mutex> lock(x_sessionCountPerIP);
+    auto it = m_sessionCountPerIP.find(_address);
+    if (it != m_sessionCountPerIP.end())
+    {
+        if (it->second > 0 && --(it->second) == 0)
+        {
+            m_sessionCountPerIP.erase(it);
+        }
+    }
+    if (m_sessionCount.load(std::memory_order_relaxed) > 0)
+    {
+        m_sessionCount.fetch_sub(1, std::memory_order_relaxed);
+    }
+}
+
+namespace
+{
+// FIB-184: RAII guard bound to a session's lifetime. Constructed after a slot is acquired and
+// attached to the session via setLifetimeGuard(); its destructor (running in ~Session) releases
+// the slot. Held via weak_ptr so a Host destroyed before the session does not crash the guard.
+struct SessionSlotGuard
+{
+    std::weak_ptr<Host> host;
+    std::string address;
+    SessionSlotGuard(std::weak_ptr<Host> _host, std::string _address)
+      : host(std::move(_host)), address(std::move(_address))
+    {}
+    SessionSlotGuard(const SessionSlotGuard&) = delete;
+    SessionSlotGuard& operator=(const SessionSlotGuard&) = delete;
+    ~SessionSlotGuard()
+    {
+        if (auto h = host.lock())
+        {
+            h->releaseSessionSlot(address);
+        }
+    }
+};
+}  // namespace
+
 void Host::startPeerSession(P2PInfo const& p2pInfo, std::shared_ptr<SocketFace> const& socket,
     std::function<void(NetworkException, P2PInfo const&, std::shared_ptr<SessionFace>)>)
 {
     auto weakHost = weak_from_this();
+
+    // FIB-184: enforce the concurrent-session and per-IP caps before creating the session.
+    // Past the limit, close the socket and drop the connection so an authenticated peer cannot
+    // exhaust memory by churning TLS connections.
+    std::string remoteAddress = socket->nodeIPEndpoint().address();
+    if (!tryAcquireSessionSlot(remoteAddress))
+    {
+        HOST_LOG(WARNING) << LOG_BADGE("startPeerSession")
+                          << LOG_DESC("session cap reached, reject connection")
+                          << LOG_KV("address", remoteAddress)
+                          << LOG_KV("sessionCount", m_sessionCount.load())
+                          << LOG_KV("maxConcurrentSessions", m_maxConcurrentSessions)
+                          << LOG_KV("maxSessionsPerIP", m_maxSessionsPerIP);
+        socket->close();
+        return;
+    }
+
     std::shared_ptr<SessionFace> session =
         m_sessionFactory->createSession(*this, socket, m_messageFactory, m_sessionCallbackManager);
+    // Bind a slot-release guard to the session; the slot is freed when the session is destroyed.
+    session->setLifetimeGuard(std::make_shared<SessionSlotGuard>(weakHost, remoteAddress));
 
     m_taskArena.execute([&]() {
         m_asyncGroup.run([weakHost, session = std::move(session), p2pInfo]() {

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -17,7 +17,10 @@
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/system/error_code.hpp>
+#include <atomic>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -104,6 +107,29 @@ public:
 
     void setEnableSslVerify(bool _enableSSLVerify);
 
+    // FIB-184: caps on concurrent inbound sessions to bound memory under TLS connect/close
+    // churn. With no cap, an authenticated peer can open sessions faster than they tear down
+    // and exhaust the heap (each session allocates a recv buffer). These are defaults; see
+    // TODO below about plumbing them through GatewayConfig.
+    // TODO(FIB-184): plumb these limits through GatewayConfig
+    // (p2p.max_concurrent_sessions / p2p.max_sessions_per_ip) instead of hardcoding.
+    constexpr static std::size_t DEFAULT_MAX_CONCURRENT_SESSIONS = 1024;
+    constexpr static std::size_t DEFAULT_MAX_SESSIONS_PER_IP = 32;
+
+    std::size_t maxConcurrentSessions() const { return m_maxConcurrentSessions; }
+    void setMaxConcurrentSessions(std::size_t _limit) { m_maxConcurrentSessions = _limit; }
+    std::size_t maxSessionsPerIP() const { return m_maxSessionsPerIP; }
+    void setMaxSessionsPerIP(std::size_t _limit) { m_maxSessionsPerIP = _limit; }
+    std::size_t currentSessionCount() const { return m_sessionCount.load(); }
+
+    // FIB-184: try to reserve a session slot for the given remote address. Returns true and
+    // increments the global / per-IP counters if both caps allow; returns false (caller must
+    // close the socket) otherwise. The matching releaseSessionSlot() runs from the session's
+    // lifetime guard when the session object is destroyed. Public so the lifetime guard can
+    // release the slot.
+    bool tryAcquireSessionSlot(std::string const& _address);
+    void releaseSessionSlot(std::string const& _address);
+
 protected:
     /// obtain the common name from the subject:
     /// the subject format is: /CN=xx/O=xxx/OU=xxx/ commonly
@@ -173,6 +199,13 @@ protected:
     // Peer black list
     PeerBlackWhitelistInterface::Ptr m_peerBlacklist{nullptr};
     PeerBlackWhitelistInterface::Ptr m_peerWhitelist{nullptr};
+
+    // FIB-184: session-cap accounting.
+    std::size_t m_maxConcurrentSessions{DEFAULT_MAX_CONCURRENT_SESSIONS};
+    std::size_t m_maxSessionsPerIP{DEFAULT_MAX_SESSIONS_PER_IP};
+    std::atomic<std::size_t> m_sessionCount{0};
+    std::map<std::string, std::size_t> m_sessionCountPerIP;
+    std::mutex x_sessionCountPerIP;
 };
 }  // namespace gateway
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -33,10 +33,16 @@
 using namespace bcos;
 using namespace bcos::gateway;
 
-Session::Session(
-    std::shared_ptr<SocketFace> socket, Host& server, size_t _recvBufferSize, bool _forceSize)
+Session::Session(std::shared_ptr<SocketFace> socket, Host& server, size_t _recvBufferSize,
+    [[maybe_unused]] bool _forceSize)
   : m_maxRecvBufferSize(std::max<size_t>(_recvBufferSize, MIN_SESSION_RECV_BUFFER_SIZE)),
-    m_recvBuffer(_forceSize ? _recvBufferSize : MIN_SESSION_RECV_BUFFER_SIZE),
+    // FIB-184: do not force the 512KB floor on every session. Start at the requested/initial size
+    // (the config-validated session_recv_buffer_size for production sessions, a tiny value for
+    // tests) and let doRead grow the buffer up to m_maxRecvBufferSize on demand. Previously the
+    // non-forced path unconditionally allocated MIN_SESSION_RECV_BUFFER_SIZE (512KB) per session,
+    // which let connection churn exhaust the heap. _forceSize is now retained only for ABI/source
+    // compatibility of the signature; both paths honor _recvBufferSize as the initial size.
+    m_recvBuffer(_recvBufferSize),
     m_server(server),
     m_socket(std::move(socket)),
     m_idleCheckTimer(

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -98,10 +98,18 @@ struct Payload
 class Session : public SessionFace, public std::enable_shared_from_this<Session>
 {
 public:
+    // Grow ceiling: the recv buffer never grows beyond this (see Session::doRead grow path).
     constexpr static const std::size_t MIN_SESSION_RECV_BUFFER_SIZE = 512 * 1024UL;
+    // FIB-184: initial recv-buffer size for a freshly created session. Previously every
+    // session unconditionally allocated MIN_SESSION_RECV_BUFFER_SIZE (512KB) up front, so a
+    // flood of unauthenticated/short-lived sessions caused heap exhaustion. Start small and
+    // rely on the existing grow path (doRead grows up to m_maxRecvBufferSize) to expand only
+    // for sessions that actually carry large messages. Must stay well above the message
+    // header length so the first read can always make forward progress.
+    constexpr static const std::size_t INITIAL_SESSION_RECV_BUFFER_SIZE = 16 * 1024UL;
 
     Session(std::shared_ptr<SocketFace> socket, Host& server,
-        size_t _recvBufferSize = MIN_SESSION_RECV_BUFFER_SIZE, bool _forceSize = false);
+        size_t _recvBufferSize = INITIAL_SESSION_RECV_BUFFER_SIZE, bool _forceSize = false);
 
     Session(const Session&) = delete;
     Session(Session&&) = delete;
@@ -152,6 +160,15 @@ public:
         std::function<std::optional<bcos::Error>(SessionFace&, Message&)> handler) override;
 
     void setHostInfo(P2PInfo _hostInfo);
+
+    // FIB-184: attach an opaque object whose lifetime is bound to this session. It is destroyed
+    // exactly when the session object is destroyed, which Host uses to release a session-cap
+    // slot (the guard's destructor decrements the Host counters). Kept opaque so libnetwork
+    // does not depend on the accounting type.
+    void setLifetimeGuard(std::shared_ptr<void> _guard) override
+    {
+        m_lifetimeGuard = std::move(_guard);
+    }
 
     uint32_t maxReadDataSize() const;
     void setMaxReadDataSize(uint32_t _maxReadDataSize);
@@ -244,6 +261,10 @@ public:
     // actual teardown body runs exactly once; all subsequent callers no-op.
     std::atomic_bool m_dropped{false};
     P2PInfo m_hostInfo;
+
+    // FIB-184: opaque guard whose destructor releases the Host session-cap slot. Destroyed with
+    // the session, so the slot is freed exactly once on session teardown.
+    std::shared_ptr<void> m_lifetimeGuard;
 
     struct Writings
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
@@ -58,6 +58,10 @@ public:
 
     virtual NodeIPEndpoint nodeIPEndpoint() const = 0;
 
+    // FIB-184: bind an opaque object to this session's lifetime (released when the session is
+    // destroyed). Non-pure so existing test doubles need not implement it.
+    virtual void setLifetimeGuard(std::shared_ptr<void> /*guard*/) {}
+
     virtual bool active() const = 0;
 
     virtual std::size_t writeQueueSize() = 0;

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -21,6 +21,7 @@
 #include "Common.h"
 #include "P2PMessageV2.h"
 #include "bcos-utilities/BoostLog.h"
+#include <cstring>
 #include <utility>
 
 using namespace bcos;
@@ -187,8 +188,18 @@ void ServiceV2::onReceiveRouterSeq(
                               << LOG_KV("message", _error.what());
         return;
     }
-    auto statusSeq = boost::asio::detail::socket_ops::network_to_host_long(
-        *((uint32_t*)_message->payload().data()));
+    // FIB-183: the router-sequence payload must contain at least a 4-byte sequence number.
+    // A short or empty payload (the smallest attacker-supplied frames are 14-78 bytes total)
+    // would read past the end of the decoded payload buffer. Drop it before dereferencing.
+    if (_message->payload().size() < sizeof(uint32_t))
+    {
+        SERVICE2_LOG(WARNING) << LOG_BADGE("onReceiveRouterSeq") << LOG_DESC("short payload, drop")
+                              << LOG_KV("size", _message->payload().size());
+        return;
+    }
+    uint32_t seq = 0;
+    std::memcpy(&seq, _message->payload().data(), sizeof(seq));
+    auto statusSeq = boost::asio::detail::socket_ops::network_to_host_long(seq);
     if (!tryToUpdateSeq(_session->p2pID(), statusSeq))
     {
         return;

--- a/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
+++ b/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
@@ -1,0 +1,141 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-183: bounds-check under-validated P2P decoded fields
+ * @file FIB183_DecodedFieldBoundsTest.cpp
+ * @date 2026-06-15
+ */
+
+#include "bcos-gateway/Gateway.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
+#include "bcos-gateway/libp2p/ServiceV2.h"
+#include "bcos-gateway/libp2p/router/RouterTableImpl.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+
+BOOST_FIXTURE_TEST_SUITE(FIB183_DecodedFieldBoundsTest, TestPromptFixture)
+
+// Exposes the protected network-entry handler so we can drive it directly.
+// The default-constructed Gateway leaves m_gatewayNodeManager null; the FIB-183
+// guard must return before any member is dereferenced.
+class FakeGatewayFIB183 : public Gateway
+{
+public:
+    FakeGatewayFIB183() : Gateway() {}
+    ~FakeGatewayFIB183() override {}
+    void start() override {}
+    void stop() override {}
+
+    void callOnReceiveP2PMessage(
+        NetworkException const& _e, P2PSession::Ptr _session, std::shared_ptr<P2PMessage> _msg)
+    {
+        onReceiveP2PMessage(_e, _session, _msg);
+    }
+};
+
+// Exposes the protected router-seq handler.
+class FakeServiceV2FIB183 : public ServiceV2
+{
+public:
+    FakeServiceV2FIB183(P2PInfo const& _info, RouterTableFactory::Ptr _factory)
+      : ServiceV2(_info, std::move(_factory))
+    {}
+    void callOnReceiveRouterSeq(
+        NetworkException _error, std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message)
+    {
+        onReceiveRouterSeq(std::move(_error), std::move(_session), std::move(_message));
+    }
+};
+
+// Fix A: a P2PMessage whose decoded options carry zero dstNodeIDs must not be
+// indexed (dstNodeIDs[0] on an empty vector is OOB). The guard drops it before
+// touching m_gatewayNodeManager (which is null here), so no crash occurs.
+BOOST_AUTO_TEST_CASE(EmptyDstNodeIDsIsDropped)
+{
+    // Build a real P2PMessage with a non-zero moduleID (so the front-message
+    // moduleID-decode branch is skipped) and an empty dstNodeIDs list.
+    auto factory = std::make_shared<P2PMessageFactory>();
+    auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+    msg->setPacketType(GatewayMessageType::PeerToPeerMessage);
+
+    P2PMessageOptions options;
+    options.setGroupID("group0");
+    options.setModuleID(42);
+    std::string srcNodeID = "srcNode";
+    options.setSrcNodeID(bytes(srcNodeID.begin(), srcNodeID.end()));
+    // Intentionally leave dstNodeIDs empty.
+    msg->setOptions(options);
+    BOOST_CHECK(msg->options().dstNodeIDs().empty());
+
+    auto gateway = std::make_shared<FakeGatewayFIB183>();
+    // Must not crash / must not dereference the null GatewayNodeManager.
+    BOOST_CHECK_NO_THROW(gateway->callOnReceiveP2PMessage(NetworkException(0, ""), nullptr, msg));
+}
+
+// Sanity check: confirm that a message decoded straight off the wire can legitimately
+// have zero dstNodeIDs, i.e. the OOB precondition is reachable from untrusted input.
+BOOST_AUTO_TEST_CASE(DecodedOptionsCanHaveEmptyDstNodeIDs)
+{
+    P2PMessageOptions options;
+    options.setGroupID("group0");
+    options.setModuleID(7);
+    std::string srcNodeID = "srcNode";
+    options.setSrcNodeID(bytes(srcNodeID.begin(), srcNodeID.end()));
+    // no dstNodeIDs pushed
+
+    bytes buffer;
+    BOOST_CHECK(options.encode(buffer));
+
+    P2PMessageOptions decoded;
+    auto ret = decoded.decode(bytesConstRef(buffer.data(), buffer.size()));
+    BOOST_CHECK(ret > 0);
+    BOOST_CHECK(decoded.dstNodeIDs().empty());
+}
+
+// Fix B: onReceiveRouterSeq reads a 4-byte sequence from payload. A 0..3 byte payload
+// must early-return before dereferencing past the payload buffer (and before touching
+// the session, so a null session here is safe).
+BOOST_AUTO_TEST_CASE(ShortRouterSeqPayloadIsDropped)
+{
+    P2PInfo selfInfo;
+    selfInfo.rawP2pID = "selfRawP2pID";
+    selfInfo.p2pID = "selfP2pID";
+    auto routerTableFactory = std::make_shared<RouterTableFactoryImpl>();
+    auto service = std::make_shared<FakeServiceV2FIB183>(selfInfo, routerTableFactory);
+    auto factory = std::make_shared<P2PMessageFactoryV2>();
+
+    for (size_t len = 0; len < sizeof(uint32_t); ++len)
+    {
+        auto msg = std::static_pointer_cast<P2PMessage>(factory->buildMessage());
+        msg->setPacketType(GatewayMessageType::RouterTableSyncSeq);
+        if (len > 0)
+        {
+            msg->setPayload(bytes(len, 0xAB));
+        }
+        BOOST_CHECK_EQUAL(msg->payload().size(), len);
+        // Session is nullptr on purpose: the guard returns before it is used.
+        BOOST_CHECK_NO_THROW(
+            service->callOnReceiveRouterSeq(NetworkException(0, ""), nullptr, msg));
+    }
+
+    service->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
+++ b/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
@@ -55,13 +55,10 @@ public:
 class FakeServiceV2FIB183 : public ServiceV2
 {
 public:
-    FakeServiceV2FIB183(P2PInfo const& _info, RouterTableFactory::Ptr _factory)
-      : ServiceV2(_info, std::move(_factory), m_ioContext)
+    FakeServiceV2FIB183(P2PInfo const& _info, RouterTableFactory::Ptr _factory,
+        boost::asio::io_context& _ioContext)
+      : ServiceV2(_info, std::move(_factory), _ioContext)
     {}
-
-private:
-    boost::asio::io_context m_ioContext;
-public:
     void callOnReceiveRouterSeq(
         NetworkException _error, std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message)
     {
@@ -122,8 +119,9 @@ BOOST_AUTO_TEST_CASE(ShortRouterSeqPayloadIsDropped)
     P2PInfo selfInfo;
     selfInfo.rawP2pID = "selfRawP2pID";
     selfInfo.p2pID = "selfP2pID";
+    boost::asio::io_context ioContext;
     auto routerTableFactory = std::make_shared<RouterTableFactoryImpl>();
-    auto service = std::make_shared<FakeServiceV2FIB183>(selfInfo, routerTableFactory);
+    auto service = std::make_shared<FakeServiceV2FIB183>(selfInfo, routerTableFactory, ioContext);
     auto factory = std::make_shared<P2PMessageFactoryV2>();
 
     for (size_t len = 0; len < sizeof(uint32_t); ++len)

--- a/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
+++ b/bcos-gateway/test/unittests/FIB183_DecodedFieldBoundsTest.cpp
@@ -24,6 +24,7 @@
 #include "bcos-gateway/libp2p/ServiceV2.h"
 #include "bcos-gateway/libp2p/router/RouterTableImpl.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/asio/io_context.hpp>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -55,8 +56,12 @@ class FakeServiceV2FIB183 : public ServiceV2
 {
 public:
     FakeServiceV2FIB183(P2PInfo const& _info, RouterTableFactory::Ptr _factory)
-      : ServiceV2(_info, std::move(_factory))
+      : ServiceV2(_info, std::move(_factory), m_ioContext)
     {}
+
+private:
+    boost::asio::io_context m_ioContext;
+public:
     void callOnReceiveRouterSeq(
         NetworkException _error, std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message)
     {

--- a/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
@@ -1,0 +1,226 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-184: cap sessions and bound per-session recv buffer
+ * @file FIB184_SessionResourceCapTest.cpp
+ * @date 2026-06-15
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/Socket.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/ThreadPool.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+using namespace bcos::crypto;
+
+namespace ba = boost::asio;
+namespace bi = boost::asio::ip;
+
+BOOST_FIXTURE_TEST_SUITE(FIB184_SessionResourceCapTest, TestPromptFixture)
+
+class FakeASIO_FIB184 : public bcos::gateway::ASIOInterface
+{
+public:
+    FakeASIO_FIB184() : m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB184", 1)) {}
+    ~FakeASIO_FIB184() noexcept override {}
+    void asyncReadSome(
+        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
+    {}
+    void strandPost(Base_Handler handler) override { m_handler = std::move(handler); }
+    void stop() override { m_threadPool->stop(); }
+
+protected:
+    Base_Handler m_handler;
+    bcos::ThreadPool::Ptr m_threadPool;
+};
+
+class FakeSocket_FIB184 : public SocketFace
+{
+public:
+    FakeSocket_FIB184()
+      : m_ioContext(std::make_shared<ba::io_context>()),
+        m_sslContext(ba::ssl::context::tlsv12),
+        m_sslSocket(std::make_shared<ba::ssl::stream<bi::tcp::socket>>(*m_ioContext, m_sslContext))
+    {}
+    ~FakeSocket_FIB184() override = default;
+
+    bool isConnected() const override { return m_connected; }
+    void close() override { m_connected = false; }
+    bi::tcp::endpoint remoteEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::endpoint localEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::socket& ref() override { return m_sslSocket->next_layer(); }
+    ba::ssl::stream<bi::tcp::socket>& sslref() override { return *m_sslSocket; }
+    const NodeIPEndpoint& nodeIPEndpoint() const override { return m_nodeIPEndpoint; }
+    void setNodeIPEndpoint(NodeIPEndpoint _nodeIPEndpoint) override
+    {
+        m_nodeIPEndpoint = std::move(_nodeIPEndpoint);
+    }
+    ba::io_context& ioService() override { return *m_ioContext; }
+
+    bool m_connected{true};
+
+private:
+    std::shared_ptr<ba::io_context> m_ioContext;
+    ba::ssl::context m_sslContext;
+    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
+    NodeIPEndpoint m_nodeIPEndpoint;
+};
+
+// Exposes the protected session-cap helpers for direct testing.
+class FakeHost_FIB184 : public bcos::gateway::Host
+{
+public:
+    FakeHost_FIB184(bcos::crypto::Hash::Ptr _hash, std::shared_ptr<ASIOInterface> _asioInterface)
+      : Host(_hash, _asioInterface, nullptr, nullptr)
+    {
+        m_run = true;
+    }
+    bool callTryAcquireSessionSlot(std::string const& addr) { return tryAcquireSessionSlot(addr); }
+    void callReleaseSessionSlot(std::string const& addr) { releaseSessionSlot(addr); }
+};
+
+// FIB-184 Fix 2: a forced-size session uses exactly the requested recv buffer size, not the
+// 512KB floor that was unconditionally applied before.
+BOOST_AUTO_TEST_CASE(ForcedSmallRecvBufferIsHonored)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB184>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    auto session = std::make_shared<Session>(fakeSocket, *fakeHost, /*size*/ 2, /*forceSize*/ true);
+    BOOST_CHECK_EQUAL(session->recvBuffer().recvBufferSize(), 2u);
+    // grow ceiling is still the 512KB minimum
+    BOOST_CHECK_EQUAL(session->m_maxRecvBufferSize, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+
+    session->setSocket(nullptr);
+    fakeSocket->close();
+}
+
+// FIB-184 Fix 2: a default-constructed session no longer allocates the 512KB floor up front;
+// it starts at the (much smaller) lazy initial size and relies on the grow path.
+BOOST_AUTO_TEST_CASE(DefaultRecvBufferStartsSmall)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB184>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    auto session = std::make_shared<Session>(fakeSocket, *fakeHost);
+    BOOST_CHECK_EQUAL(
+        session->recvBuffer().recvBufferSize(), Session::INITIAL_SESSION_RECV_BUFFER_SIZE);
+    BOOST_CHECK_LT(
+        Session::INITIAL_SESSION_RECV_BUFFER_SIZE, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+    // the grow ceiling stays at the 512KB minimum so large messages still fit after growth
+    BOOST_CHECK_EQUAL(session->m_maxRecvBufferSize, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+
+    session->setSocket(nullptr);
+    fakeSocket->close();
+}
+
+// FIB-184 Fix 1: per-IP cap rejects slot acquisition once the limit is hit; releasing a slot
+// makes room again.
+BOOST_AUTO_TEST_CASE(PerIPSessionCapIsEnforced)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    fakeHost->setMaxSessionsPerIP(3);
+    fakeHost->setMaxConcurrentSessions(100);
+
+    const std::string ip = "1.2.3.4";
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    // 4th from the same IP is rejected
+    BOOST_CHECK(!fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 3u);
+
+    // a different IP is unaffected
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("5.6.7.8"));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 4u);
+
+    // releasing one slot for the capped IP makes room for exactly one more
+    fakeHost->callReleaseSessionSlot(ip);
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 3u);
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK(!fakeHost->callTryAcquireSessionSlot(ip));
+}
+
+// FIB-184 Fix 1: global concurrent-session cap rejects once the total limit is hit, even across
+// distinct source IPs.
+BOOST_AUTO_TEST_CASE(GlobalSessionCapIsEnforced)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    fakeHost->setMaxConcurrentSessions(2);
+    fakeHost->setMaxSessionsPerIP(100);
+
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("10.0.0.1"));
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("10.0.0.2"));
+    // global cap reached
+    BOOST_CHECK(!fakeHost->callTryAcquireSessionSlot("10.0.0.3"));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 2u);
+
+    fakeHost->callReleaseSessionSlot("10.0.0.1");
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot("10.0.0.3"));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 2u);
+}
+
+// FIB-184 Fix 1: the lifetime guard releases the slot exactly when the session is destroyed.
+BOOST_AUTO_TEST_CASE(LifetimeGuardReleasesSlotOnSessionDestruction)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB184>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    const std::string ip = "9.9.9.9";
+    BOOST_CHECK(fakeHost->callTryAcquireSessionSlot(ip));
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 1u);
+
+    {
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+        // Attach a guard that releases the slot when the session is destroyed, mirroring
+        // Host::startPeerSession. Capture the host by weak_ptr so the lambda guard is safe.
+        std::weak_ptr<Host> weakHost = fakeHost;
+        session->setLifetimeGuard(std::shared_ptr<void>(nullptr, [weakHost, ip](void*) {
+            if (auto h = weakHost.lock())
+            {
+                // FakeHost exposes the protected release helper.
+                std::static_pointer_cast<FakeHost_FIB184>(h)->callReleaseSessionSlot(ip);
+            }
+        }));
+        BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 1u);
+        session->setSocket(nullptr);
+    }
+    // After the session (and its guard) is destroyed, the slot is released.
+    BOOST_CHECK_EQUAL(fakeHost->currentSessionCount(), 0u);
+
+    fakeSocket->close();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
@@ -41,16 +41,16 @@ BOOST_FIXTURE_TEST_SUITE(FIB184_SessionResourceCapTest, TestPromptFixture)
 class FakeASIO_FIB184 : public bcos::gateway::ASIOInterface
 {
 public:
-    FakeASIO_FIB184() : m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB184", 1)) {}
+    FakeASIO_FIB184()
+      : ASIOInterface(std::make_shared<IOServicePool>(1, "FakeASIO_FIB184"), "0.0.0.0", 0),
+        m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB184", 1))
+    {}
     ~FakeASIO_FIB184() noexcept override {}
     void asyncReadSome(
         const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
     {}
-    void strandPost(Base_Handler handler) override { m_handler = std::move(handler); }
-    void stop() override { m_threadPool->stop(); }
 
 protected:
-    Base_Handler m_handler;
     bcos::ThreadPool::Ptr m_threadPool;
 };
 

--- a/bcos-leader-election/src/CampaignConfig.cpp
+++ b/bcos-leader-election/src/CampaignConfig.cpp
@@ -108,7 +108,44 @@ bool CampaignConfig::checkAndUpdateLeaderKey(etcd::Response _response)
                               << LOG_KV("key", m_leaderKey) << LOG_KV("success", ret);
         return false;
     }
-    auto leader = m_memberFactory->createMember(_response.value().as_string());
+    bcos::protocol::MemberInterface::Ptr leader;
+    try
+    {
+        leader = m_memberFactory->createMember(_response.value().as_string());
+    }
+    catch (std::exception const& e)
+    {
+        // FIB-177: a malformed/corrupt etcd leader value must not wedge the
+        // election. Mirror the version==0 recovery path: drop the stale leader
+        // and trigger a fresh campaign so the node can recover instead of
+        // propagating the decode exception up to the watcher callback.
+        ELECTION_LOG(WARNING) << LOG_DESC(
+                                     "checkAndUpdateLeaderKey: malformed leader value, recover")
+                              << LOG_KV("key", m_leaderKey)
+                              << LOG_KV("message", boost::diagnostic_information(e));
+        resetLeader(nullptr);
+        if (m_triggerCampaign)
+        {
+            m_triggerCampaign();
+        }
+        return false;
+    }
+    catch (...)
+    {
+        // FIB-177: createMember may throw a non-std exception; it must not escape
+        // into the watcher callback either. Apply the same drop-stale-leader plus
+        // re-campaign recovery so an exotic throwable cannot wedge the election.
+        ELECTION_LOG(WARNING) << LOG_DESC(
+                                     "checkAndUpdateLeaderKey: malformed leader value (non-std "
+                                     "exception), recover")
+                              << LOG_KV("key", m_leaderKey);
+        resetLeader(nullptr);
+        if (m_triggerCampaign)
+        {
+            m_triggerCampaign();
+        }
+        return false;
+    }
     auto seq = _response.value().modified_index();
     leader->setSeq(seq);
     leader->setLeaseID(_response.value().lease());

--- a/bcos-leader-election/src/CampaignConfig.h
+++ b/bcos-leader-election/src/CampaignConfig.h
@@ -37,7 +37,19 @@ public:
       : ElectionConfig(_etcdEndPoint, _memberFactory, _purpose, _caPath, _certPath, _keyPath)
     {
         m_leaderKey = _leaderKey;
-        m_leaseTTL = _leaseTTL;
+        // FIB-176: leaseTTL is unsigned and feeds directly into the election
+        // timers. A value of 0 yields a 0ms campaign timer and underflows
+        // `leaseTTL() - 1` (the keepAlive interval) to a huge value; a value of
+        // 1 yields a 0s keepAlive interval. Clamp to a safe minimum before any
+        // timer is derived from it.
+        if (_leaseTTL < c_minLeaseTTL)
+        {
+            ELECTION_LOG(WARNING) << LOG_DESC(
+                                         "CampaignConfig: leaseTTL too small, clamp to minimum")
+                                  << LOG_KV("requested", _leaseTTL)
+                                  << LOG_KV("clamped", c_minLeaseTTL);
+        }
+        m_leaseTTL = clampLeaseTTL(_leaseTTL);
         m_self = _self;
         m_self->encode(m_leaderValue);
         ELECTION_LOG(INFO) << LOG_DESC("CampaignConfig") << LOG_KV("selfID", m_self->memberID())
@@ -45,6 +57,15 @@ public:
     }
 
     ~CampaignConfig() override {}
+
+    // FIB-176: minimum lease TTL (seconds). Below this the derived campaign
+    // timer (leaseTTL*1000 ms) and keepAlive interval (leaseTTL-1 s) degenerate
+    // or underflow.
+    static constexpr unsigned c_minLeaseTTL = 2;
+    static unsigned clampLeaseTTL(unsigned _ttl) noexcept
+    {
+        return _ttl < c_minLeaseTTL ? c_minLeaseTTL : _ttl;
+    }
 
     std::string const& leaderKey() const { return m_leaderKey; }
     virtual bcos::protocol::MemberInterface::Ptr fetchLeader();
@@ -86,6 +107,11 @@ public:
         m_self->encode(m_leaderValue);
     }
 
+    // FIB-173: exposed so the election layer can drop the stale self-leader
+    // pointer when the keepAlive heartbeat dies (the etcd lease is gone, so
+    // node-self is no longer the leader).
+    void resetLeader(bcos::protocol::MemberInterface::Ptr _leader);
+
 protected:
     virtual void fetchLeaderInfoFromEtcd();
     virtual void onLeaderKeyChanged(etcd::Response _response);
@@ -104,8 +130,6 @@ protected:
                 self->onLeaderKeyChanged(std::move(response));
             });
     }
-
-    void resetLeader(bcos::protocol::MemberInterface::Ptr _leader);
 
 protected:
     // the leader key that multiple workers compete for, eg: "/consensus"

--- a/bcos-leader-election/src/LeaderElection.cpp
+++ b/bcos-leader-election/src/LeaderElection.cpp
@@ -71,6 +71,13 @@ void LeaderElection::stop()
 
 std::pair<bool, int64_t> LeaderElection::grantLease()
 {
+    // FIB-175: leasegrant().get() blocks until etcd answers. A stalled or
+    // unreachable etcd would otherwise wedge the campaign thread (and the
+    // campaign timer callback that drives it) indefinitely. The client is armed
+    // with a grpc timeout (set_grpc_timeout in the constructor), so etcd-cpp-apiv3
+    // bounds this blocking get() on its completion-queue wait and returns a
+    // not-ok response once the deadline elapses; callers (campaignLeader) already
+    // fall back to backup + restart the timer on a non-ok result.
     auto response = m_etcdClient->leasegrant(m_config->leaseTTL()).get();
     if (!response.is_ok())
     {
@@ -223,6 +230,16 @@ bool LeaderElection::campaignLeader()
                                << LOG_KV("leaderKey", m_config->leaderKey());
             keepAlive->Cancel();
         }
+        // FIB-178: the non-exception failure paths above all re-arm local
+        // recovery (tryToSwitchToBackup + campaign timer restart). The catch-all
+        // previously just returned, leaving the node stuck: no campaign retry is
+        // scheduled and the upper layer is never told to drop master mode. Mirror
+        // the normal failure path so a transient exception self-heals.
+        tryToSwitchToBackup();
+        if (m_campaignTimer)
+        {
+            m_campaignTimer->restart();
+        }
     }
     return false;
 }
@@ -240,6 +257,27 @@ void LeaderElection::onKeepAliveException(std::exception_ptr _exception)
     {
         ELECTION_LOG(WARNING) << LOG_DESC("onKeepAliveException, restart campaign")
                               << LOG_KV("message", boost::diagnostic_information(e));
+    }
+    // FIB-173: the keepAlive heartbeat is dead, so the etcd lease that made
+    // node-self the leader is gone. Drop our reference to the dead keepAlive and
+    // the stale self-leader pointer, and notify the upper layer to leave master
+    // mode BEFORE restarting the campaign. Otherwise node-self keeps believing
+    // it is the leader (and stays in master mode) even though etcd no longer
+    // holds its key, which can produce two masters once another node wins.
+    //
+    // Do NOT call Cancel() on this keepAlive here: this handler runs ON the
+    // keepAlive's own refresh thread, and etcd::KeepAlive::Cancel() joins that
+    // thread — calling it here would self-join and deadlock. The thread is
+    // already terminating (it just raised this exception); moving the shared_ptr
+    // out releases our reference and lets it tear down.
+    {
+        RecursiveGuard l(m_mutex);
+        m_keepAlive.reset();
+    }
+    m_config->resetLeader(nullptr);
+    if (m_onCampaignHandler)
+    {
+        m_onCampaignHandler(false, nullptr);
     }
     if (m_campaignTimer)
     {

--- a/bcos-leader-election/src/LeaderElection.h
+++ b/bcos-leader-election/src/LeaderElection.h
@@ -22,6 +22,7 @@
 #include "CampaignConfig.h"
 #include <bcos-framework/election/LeaderElectionInterface.h>
 #include <bcos-utilities/Timer.h>
+#include <chrono>
 #include <memory>
 namespace bcos
 {
@@ -33,9 +34,24 @@ class LeaderElection : public LeaderElectionInterface,
 public:
     using Ptr = std::shared_ptr<LeaderElection>;
     LeaderElection(CampaignConfig::Ptr _config)
-      : m_config(_config), m_etcdClient(_config->etcdClient())
+      : m_config(_config),
+        m_etcdClient(_config->etcdClient()),
+        // FIB-175: bound every blocking unary etcd op (leasegrant/txn/get) to
+        // roughly one lease period so a stalled or unreachable etcd cannot wedge
+        // the campaign thread forever. Build the duration in chrono's 64-bit
+        // representation (seconds -> milliseconds) so a large leaseTTL cannot
+        // overflow the unsigned multiply before the cast.
+        m_etcdOpTimeout(std::chrono::seconds(m_config->leaseTTL()))
     {
         m_campaignTimer = std::make_shared<Timer>(m_config->leaseTTL() * 1000, "campTimer");
+        // FIB-175: arm the bound as a client-level grpc timeout. etcd-cpp-apiv3
+        // applies this deadline on the completion-queue wait of unary RPCs only;
+        // the watch stream pumps an unbounded cq_.Next() loop and is unaffected,
+        // while a keepalive refresh becomes bounded by one lease period (benign: a
+        // refresh that cannot complete within a full TTL means the lease is gone).
+        // This replaces the previous detached-thread+promise workaround, so a
+        // stalled leasegrant().get() now returns a not-ok response on its own.
+        m_etcdClient->set_grpc_timeout(m_etcdOpTimeout);
     }
     ~LeaderElection() override { stop(); }
     void start() override;
@@ -85,6 +101,10 @@ protected:
     std::function<void(std::exception_ptr)> m_onKeepAliveException;
     std::function<void(bool, bcos::protocol::MemberInterface::Ptr)> m_onCampaignHandler;
     mutable RecursiveMutex m_mutex;
+
+    // FIB-175: upper bound on a single blocking unary etcd op, applied via
+    // etcd::Client::set_grpc_timeout in the constructor.
+    std::chrono::milliseconds m_etcdOpTimeout;
 
     // for trigger campaign after disconnect
     std::shared_ptr<Timer> m_campaignTimer;

--- a/bcos-leader-election/src/WatcherConfig.cpp
+++ b/bcos-leader-election/src/WatcherConfig.cpp
@@ -23,6 +23,8 @@
 #include "bcos-utilities/BoostLog.h"
 #include <algorithm>
 #include <cstddef>
+#include <set>
+#include <utility>
 
 using namespace bcos;
 using namespace bcos::election;
@@ -75,12 +77,42 @@ void WatcherConfig::fetchLeadersInfo()
         return;
     }
     auto const& values = response.values();
+    // FIB-182: this is a full snapshot of m_watchDir. A delete event that
+    // arrives while the watcher is disconnected is never delivered, so the old
+    // logic (add/update only) leaves a stale leader entry in m_keyToLeader
+    // forever. Track every key present in the snapshot and prune any tracked
+    // key that is absent from it.
+    std::set<std::string> snapshotKeys;
     for (auto const& value : values)
     {
+        snapshotKeys.insert(value.key());
         updateLeaderInfo(value);
     }
+    std::vector<std::pair<std::string, bcos::protocol::MemberInterface::Ptr>> prunedMembers;
+    {
+        WriteGuard l(x_keyToLeader);
+        for (auto it = m_keyToLeader.begin(); it != m_keyToLeader.end();)
+        {
+            if (snapshotKeys.count(it->first) != 0)
+            {
+                ++it;
+                continue;
+            }
+            prunedMembers.emplace_back(it->first, it->second);
+            m_keyToLeaderSeq.erase(it->first);
+            it = m_keyToLeader.erase(it);
+        }
+    }
+    // invoke delete callbacks outside the lock to prevent self-deadlock
+    for (auto const& pruned : prunedMembers)
+    {
+        ELECTION_LOG(INFO) << LOG_DESC("fetchLeadersInfo: prune missed-delete leader key")
+                           << LOG_KV("watchDir", m_watchDir) << LOG_KV("leaderKey", pruned.first);
+        onMemberDeleted(pruned.first, pruned.second);
+    }
     ELECTION_LOG(INFO) << LOG_DESC("fetchLeadersInfo success") << LOG_KV("watchDir", m_watchDir)
-                       << LOG_KV("nodesSize", values.size());
+                       << LOG_KV("nodesSize", values.size())
+                       << LOG_KV("prunedSize", prunedMembers.size());
 }
 
 void WatcherConfig::updateLeaderInfo(etcd::Value const& _value)

--- a/bcos-pbft/bcos-pbft/core/Proposal.h
+++ b/bcos-pbft/bcos-pbft/core/Proposal.h
@@ -21,6 +21,7 @@
 #pragma once
 #include "bcos-framework/consensus/ProposalInterface.h"
 #include "bcos-pbft/core/proto/Consensus.pb.h"
+#include "bcos-pbft/pbft/utilities/Common.h"
 #include <bcos-framework/protocol/BlockHeader.h>
 #include <bcos-protocol/Common.h>
 
@@ -138,13 +139,26 @@ protected:
     virtual void deserializeObject()
     {
         auto const& hashData = m_rawProposal->hash();
-        // FIB-149: reject any non-canonical hash length (oversize OR undersize).
-        // Pre-fix used `<`, which silently truncated oversize input to the
-        // first 32 bytes — accepting non-canonical encodings as valid identity
-        // keys.
-        if (hashData.size() != bcos::crypto::HashType::SIZE)
+        // FIB-174: drop any stale/default identity before validating, so a
+        // failed decode on a reused object cannot retain the prior proposal's
+        // hash. An empty hash field (size 0) is the not-yet-set state of a
+        // freshly constructed proposal (e.g. PBFTProposal() before setHash());
+        // leave m_hash default-constructed and do not treat that as malformed.
+        m_hash = bcos::crypto::HashType{};
+        if (hashData.empty())
         {
             return;
+        }
+        // FIB-149 / FIB-174: a present-but-non-canonical hash length (oversize OR
+        // undersize) is malformed wire data — reject it at decode instead of
+        // silently returning. Pre-fix used `<`, which silently truncated oversize
+        // input to the first 32 bytes, and the undersize case returned without
+        // surfacing the malformed input as an invalid PBFT message.
+        if (hashData.size() != bcos::crypto::HashType::SIZE)
+        {
+            BOOST_THROW_EXCEPTION(InvalidPBFTMessage() << errinfo_comment(
+                                      "Proposal::deserializeObject malformed hash length: " +
+                                      std::to_string(hashData.size())));
         }
         m_hash =
             bcos::crypto::HashType((byte const*)hashData.c_str(), bcos::crypto::HashType::SIZE);

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
@@ -383,6 +383,9 @@ void PBFTCache::resetExceptionCache(ViewType _curView)
                 m_prePrepare = nullptr;
                 break;
             }
+            // FIB-181: erase() already advanced; continue so the post-branch ++
+            // does not skip the next entry.
+            continue;
         }
         exceptionPrePrepare++;
     }

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -158,7 +158,41 @@ void PBFTEngine::tryToResendCheckPoint()
         RecursiveGuard l(m_mutex);
         m_cacheProcessor->tryToResendCheckPoint();
     }
+    // FIB-185: run the consensus-timer watchdog on this periodic path.
+    checkConsensusTimerWatchdog();
     m_timer->restart();
+}
+
+void PBFTEngine::checkConsensusTimerWatchdog()
+{
+    // FIB-185: under adversarial consensus input concurrent with session-teardown churn, a node
+    // can commit its last block, emit a single view-change, and then never re-arm its consensus
+    // timer (an inferred race between session-teardown callbacks and the consensus worker/timer).
+    // The wedge signature is: consensus node, in timeout state (a view-change is pending), but the
+    // view-change timer is not running. Detect that and re-arm the timer. restart() only re-arms
+    // the timer; onTimeout (which actually drives the view-change) fires later, so this watchdog
+    // cannot itself emit a view-change or perturb the view-change cache.
+    if (m_stopped.load())
+    {
+        return;
+    }
+    if (!m_config->isConsensusNode())
+    {
+        return;
+    }
+    auto consensusTimer = m_config->timer();
+    if (!consensusTimer)
+    {
+        return;
+    }
+    if (m_config->timeout() && !consensusTimer->running())
+    {
+        PBFT_LOG(WARNING) << LOG_DESC(
+                                 "checkConsensusTimerWatchdog: consensus timer stalled while in "
+                                 "timeout state, re-arm the timer")
+                          << m_config->printCurrentState();
+        consensusTimer->restart();
+    }
 }
 
 void PBFTEngine::restart()
@@ -1495,6 +1529,19 @@ void PBFTEngine::broadcastViewChangeReq()
     // only broadcast to the consensus nodes
     PBFT_LOG(INFO) << LOG_DESC("broadcastViewChangeReq") << printPBFTMsgInfo(viewChangeReq)
                    << LOG_KV("packetSize", encodedData->size());
+    // FIB-185 (Fix 1, deferred): this runs under m_mutex (onTimeout -> triggerTimeout holds it).
+    // task::wait here is already fire-and-forget (it starts the coroutine and returns without
+    // blocking to completion), so it does NOT block the worker on the network round-trip. The
+    // residual coupling is that the coroutine's inline prefix (up to its first suspension inside
+    // FrontService::broadcastMessage) executes on this thread while m_mutex is held; if that
+    // prefix contends a gateway/session lock during teardown churn it can briefly stall the
+    // worker. Fully moving the send off-lock would require dispatching it onto a dedicated
+    // executor, which touches consensus-thread/lifetime ordering near the view-change cache; the
+    // watchdog (checkConsensusTimerWatchdog) recovers a stalled timer without that risk. Splitting
+    // the send off-lock is left as a follow-up so the view-change cache invariants below are not
+    // disturbed.
+    // TODO(FIB-185): move the network broadcast fully off the m_mutex critical section (dedicated
+    // executor) once the consensus-thread ordering around the view-change cache is verified safe.
     task::wait([](FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
         co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT,
             ::ranges::views::single(ref(*encodedData)));

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -113,6 +113,11 @@ public:
 protected:
     virtual void initSendResponseHandler();
     virtual void tryToResendCheckPoint();
+    // FIB-185: watchdog that recovers a stalled consensus timer. If the node is a running
+    // consensus node sitting in the timeout state but the view-change timer is not armed,
+    // re-arm it. Only re-arms the timer (the actual view-change fires later from onTimeout),
+    // so it cannot itself emit a view-change. Invoked from the periodic checkpoint timer path.
+    virtual void checkConsensusTimerWatchdog();
     virtual void onReceivePBFTMessage(bcos::Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
         bytesConstRef _data, SendResponseCallback _sendResponse);
 

--- a/bcos-pbft/test/unittests/FIB149_HashLengthStrictTest.cpp
+++ b/bcos-pbft/test/unittests/FIB149_HashLengthStrictTest.cpp
@@ -23,6 +23,7 @@
 #include "bcos-pbft/core/Proposal.h"
 #include "bcos-pbft/pbft/protocol/PB/PBFTBaseMessage.h"
 #include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 
@@ -48,27 +49,26 @@ BOOST_FIXTURE_TEST_SUITE(FIB149_HashLengthStrict, TestPromptFixture)
 
 BOOST_AUTO_TEST_CASE(oversize_proposal_hash_rejected)
 {
-    // 64-byte (oversize) raw hash inside a RawProposal. Pre-fix Proposal.h used
-    // `<` so oversize was silently truncated to the first 32 bytes; the test
-    // asserts the strict reject path leaves m_hash default-constructed.
+    // 64-byte (oversize) raw hash inside a RawProposal. FIB-149 made the length
+    // predicate strict (`!= HashType::SIZE`); FIB-174 then upgraded the silent
+    // return into a thrown invalid-message so a malformed proposal hash is
+    // rejected at decode rather than accepted with a stale/default identity.
     auto raw = std::make_shared<RawProposal>();
     std::string oversize(64, '\xab');
     raw->set_hash(oversize.data(), oversize.size());
 
-    Proposal proposal(raw);
-    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+    BOOST_CHECK_THROW(Proposal{raw}, bcos::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(undersize_proposal_hash_rejected)
 {
-    // Already rejected pre-fix (the `<` predicate caught undersize), but we
-    // keep this case to lock in behavior post-fix.
+    // Undersize was caught pre-fix (the `<` predicate) but only via a silent
+    // return; FIB-174 makes it throw so the malformed input surfaces.
     auto raw = std::make_shared<RawProposal>();
     std::string undersize(16, '\xab');
     raw->set_hash(undersize.data(), undersize.size());
 
-    Proposal proposal(raw);
-    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+    BOOST_CHECK_THROW(Proposal{raw}, bcos::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(exact_proposal_hash_accepted)

--- a/bcos-pbft/test/unittests/FIB174_MalformedHashRejectTest.cpp
+++ b/bcos-pbft/test/unittests/FIB174_MalformedHashRejectTest.cpp
@@ -1,0 +1,129 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB174_MalformedHashRejectTest.cpp
+ * @brief FIB-174: a malformed (non-canonical length) proposal hash must be
+ *        rejected at decode rather than silently accepted with a stale or
+ *        default hash identity. See audit/findings/FIB-174.md.
+ */
+#include "bcos-pbft/core/Proposal.h"
+#include "bcos-pbft/core/proto/Consensus.pb.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include "bcos-pbft/pbft/protocol/proto/PBFT.pb.h"
+#include <bcos-utilities/Exceptions.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+namespace
+{
+/// Serialize a PBFTRawProposal whose inner RawProposal carries a `hashLen`-byte
+/// hash.  `hashLen != HashType::SIZE` exercises the malformed-decode path of
+/// PBFTProposal::decode (which parses a PBFTRawProposal then defers to
+/// Proposal::deserializeObject for the inner proposal).
+bytes makePBFTProposalBytesWithHashLen(std::size_t hashLen)
+{
+    PBFTRawProposal raw;
+    auto* inner = raw.mutable_proposal();
+    inner->set_index(1);
+    std::string hash(hashLen, '\xab');
+    inner->set_hash(hash.data(), hash.size());
+    std::string serialised = raw.SerializeAsString();
+    return bytes(serialised.begin(), serialised.end());
+}
+
+/// Serialize a bare RawProposal with a `hashLen`-byte hash.  Used by the
+/// Proposal::decode reuse case, which parses a RawProposal directly.
+bytes makeRawProposalBytesWithHashLen(std::size_t hashLen)
+{
+    RawProposal raw;
+    raw.set_index(1);
+    std::string hash(hashLen, '\xab');
+    raw.set_hash(hash.data(), hash.size());
+    std::string serialised = raw.SerializeAsString();
+    return bytes(serialised.begin(), serialised.end());
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB174_MalformedHashReject, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(oversize_hash_rejected_on_decode)
+{
+    // 64-byte hash inside the serialized proposal — decode must throw.
+    auto data = makePBFTProposalBytesWithHashLen(64);
+    bytesConstRef ref(data.data(), data.size());
+    BOOST_CHECK_THROW(PBFTProposal{ref}, bcos::Exception);
+}
+
+BOOST_AUTO_TEST_CASE(undersize_hash_rejected_on_decode)
+{
+    auto data = makePBFTProposalBytesWithHashLen(16);
+    bytesConstRef ref(data.data(), data.size());
+    BOOST_CHECK_THROW(PBFTProposal{ref}, bcos::Exception);
+}
+
+BOOST_AUTO_TEST_CASE(canonical_hash_accepted_on_decode)
+{
+    auto data = makePBFTProposalBytesWithHashLen(HashType::SIZE);
+    bytesConstRef ref(data.data(), data.size());
+    BOOST_CHECK_NO_THROW(PBFTProposal{ref});
+}
+
+/// An empty hash field (size 0) is the not-yet-set state of a freshly
+/// constructed proposal — it must NOT be treated as malformed, otherwise the
+/// normal "construct empty, then setHash()" build path (e.g. a default
+/// PBFTProposal{}) would throw.  The decoded proposal carries a default
+/// (zeroed) hash identity.
+BOOST_AUTO_TEST_CASE(empty_hash_accepted_as_unset)
+{
+    auto data = makeRawProposalBytesWithHashLen(0);
+    Proposal proposal{bytesConstRef(data.data(), data.size())};
+    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+
+    // The default-constructed PBFTProposal (hash never set) must also construct
+    // without throwing.
+    BOOST_CHECK_NO_THROW(PBFTProposal{});
+}
+
+/// FIB-174 core scenario: a Proposal object that has already decoded a valid
+/// proposal hash must NOT retain that hash if it is later reused to decode a
+/// malformed proposal.  The malformed decode throws, and m_hash must not keep
+/// the previous (now stale) identity.
+BOOST_AUTO_TEST_CASE(stale_hash_not_retained_after_malformed_reuse)
+{
+    // First decode: a canonical hash.  Capture the accepted identity.
+    auto goodData = makeRawProposalBytesWithHashLen(HashType::SIZE);
+    Proposal proposal{bytesConstRef(goodData.data(), goodData.size())};
+    std::string goodHashBytes(HashType::SIZE, '\xab');
+    HashType good((byte const*)goodHashBytes.data(), HashType::SIZE);
+    BOOST_CHECK_EQUAL(proposal.hash(), good);
+    BOOST_CHECK(proposal.hash() != HashType{});
+
+    // Second decode on the SAME object with a malformed (oversize) hash must
+    // throw, and must clear the previously accepted identity rather than leave
+    // the stale hash in place.
+    auto badData = makeRawProposalBytesWithHashLen(64);
+    BOOST_CHECK_THROW(
+        proposal.decode(bytesConstRef(badData.data(), badData.size())), bcos::Exception);
+    BOOST_CHECK_EQUAL(proposal.hash(), HashType{});
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-pbft/test/unittests/FIB174_MalformedHashRejectTest.cpp
+++ b/bcos-pbft/test/unittests/FIB174_MalformedHashRejectTest.cpp
@@ -26,7 +26,6 @@
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 
-using namespace bcos;
 using namespace bcos::consensus;
 using namespace bcos::crypto;
 

--- a/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
+++ b/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
@@ -37,7 +37,6 @@
 #include <boost/test/unit_test.hpp>
 #include <atomic>
 
-using namespace bcos;
 using namespace bcos::consensus;
 using namespace bcos::crypto;
 using namespace bcos::front;
@@ -96,17 +95,15 @@ inline PBFTMessageInterface::Ptr makeExceptionPrePrepare(
 class MinimalPBFTConfig : public PBFTConfig
 {
 public:
-    MinimalPBFTConfig(CryptoSuite::Ptr _cryptoSuite, KeyPairInterface::Ptr _keyPair,
-        std::shared_ptr<ValidatorInterface> _validator,
+    MinimalPBFTConfig(boost::asio::io_context& _ioService, CryptoSuite::Ptr _cryptoSuite,
+        KeyPairInterface::Ptr _keyPair, std::shared_ptr<ValidatorInterface> _validator,
         std::shared_ptr<FrontServiceInterface> _frontService, BlockFactory::Ptr _blockFactory)
-      : PBFTConfig(m_ioService, std::move(_cryptoSuite), std::move(_keyPair),
+      : PBFTConfig(_ioService, std::move(_cryptoSuite), std::move(_keyPair),
             std::make_shared<PBFTMessageFactoryImpl>(), nullptr, std::move(_validator),
             std::move(_frontService), nullptr, nullptr, std::move(_blockFactory))
     {}
-
-private:
-    boost::asio::io_context m_ioService;
 };
+
 }  // namespace
 
 BOOST_FIXTURE_TEST_SUITE(FIB181_ResetExceptionCacheAdjacent, TestPromptFixture)
@@ -123,8 +120,9 @@ BOOST_AUTO_TEST_CASE(adjacent_stale_entries_both_reset)
     auto validator = std::make_shared<CountingValidator>(txPool, blockFactory, txResultFactory);
     auto frontService = std::make_shared<FakeFrontService>(keyPair->publicKey());
 
+    boost::asio::io_context ioService;
     auto config = std::make_shared<MinimalPBFTConfig>(
-        cryptoSuite, keyPair, validator, frontService, blockFactory);
+        ioService, cryptoSuite, keyPair, validator, frontService, blockFactory);
 
     auto cache = std::make_shared<PBFTCache>(config, /*index*/ 10);
 

--- a/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
+++ b/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
@@ -99,10 +99,13 @@ public:
     MinimalPBFTConfig(CryptoSuite::Ptr _cryptoSuite, KeyPairInterface::Ptr _keyPair,
         std::shared_ptr<ValidatorInterface> _validator,
         std::shared_ptr<FrontServiceInterface> _frontService, BlockFactory::Ptr _blockFactory)
-      : PBFTConfig(std::move(_cryptoSuite), std::move(_keyPair),
+      : PBFTConfig(m_ioService, std::move(_cryptoSuite), std::move(_keyPair),
             std::make_shared<PBFTMessageFactoryImpl>(), nullptr, std::move(_validator),
             std::move(_frontService), nullptr, nullptr, std::move(_blockFactory))
     {}
+
+private:
+    boost::asio::io_context m_ioService;
 };
 }  // namespace
 

--- a/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
+++ b/bcos-pbft/test/unittests/FIB181_ResetExceptionCacheAdjacentTest.cpp
@@ -1,0 +1,145 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB181_ResetExceptionCacheAdjacentTest.cpp
+ * @brief FIB-181: PBFTCache::resetExceptionCache() must process every stale
+ *        exception pre-prepare entry in a single pass. Pre-fix, erasing a stale
+ *        entry returned an iterator to the next entry but the loop's
+ *        unconditional post-branch ++ then skipped that next entry. With two
+ *        adjacent stale entries the second one missed its
+ *        asyncResetTxsFlag(*block, false) call. See audit/findings/FIB-181.md.
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeBlock.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h"
+#include "bcos-framework/bcos-framework/testutils/faker/FakeTxPool.h"
+#include "bcos-pbft/pbft/cache/PBFTCache.h"
+#include "bcos-pbft/pbft/engine/Validator.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTMessage.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTMessageFactoryImpl.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-protocol/TransactionSubmitResultFactoryImpl.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+
+using namespace bcos;
+using namespace bcos::consensus;
+using namespace bcos::crypto;
+using namespace bcos::front;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+/// Validator that only counts asyncResetTxsFlag(Block, bool, bool) calls. It does
+/// NOT call the base implementation, so the test does not depend on txpool state.
+class CountingValidator : public TxsValidator
+{
+public:
+    using TxsValidator::TxsValidator;
+    void asyncResetTxsFlag(const protocol::Block& /*proposal*/, bool /*flag*/,
+        bool /*emptyTxBatchHash*/ = false) override
+    {
+        ++m_count;
+    }
+    std::atomic<int> m_count{0};
+};
+
+inline CryptoSuite::Ptr makeCryptoSuiteFib181()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signImpl = std::make_shared<Secp256k1Crypto>();
+    return std::make_shared<CryptoSuite>(hashImpl, signImpl, nullptr);
+}
+
+/// Build an exception pre-prepare message carrying a distinct 32-byte hash and a
+/// consensusProposal whose data() is a real encoded empty block, so the
+/// resetExceptionCache else-branch's createBlock(data, false, false) parses.
+inline PBFTMessageInterface::Ptr makeExceptionPrePrepare(
+    CryptoSuite::Ptr const& _cryptoSuite, BlockFactory::Ptr const& _blockFactory, uint8_t _seed)
+{
+    auto block = _blockFactory->createBlock();
+    bytes encoded;
+    block->encode(encoded);
+
+    auto proposal = std::make_shared<PBFTProposal>();
+    proposal->setIndex(10);
+    proposal->setHash(_cryptoSuite->hashImpl()->hash(std::to_string(_seed)));
+    proposal->setData(encoded);
+
+    auto msg = std::make_shared<PBFTMessage>();
+    msg->setIndex(10);
+    msg->setHash(_cryptoSuite->hashImpl()->hash("exception-" + std::to_string(_seed)));
+    msg->setConsensusProposal(proposal);
+    return msg;
+}
+
+/// Minimal PBFTConfig: only blockFactory() and validator() are exercised by
+/// resetExceptionCache(). stateMachine/storage/codec are null and guarded by
+/// PBFTConfig::stop().
+class MinimalPBFTConfig : public PBFTConfig
+{
+public:
+    MinimalPBFTConfig(CryptoSuite::Ptr _cryptoSuite, KeyPairInterface::Ptr _keyPair,
+        std::shared_ptr<ValidatorInterface> _validator,
+        std::shared_ptr<FrontServiceInterface> _frontService, BlockFactory::Ptr _blockFactory)
+      : PBFTConfig(std::move(_cryptoSuite), std::move(_keyPair),
+            std::make_shared<PBFTMessageFactoryImpl>(), nullptr, std::move(_validator),
+            std::move(_frontService), nullptr, nullptr, std::move(_blockFactory))
+    {}
+};
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB181_ResetExceptionCacheAdjacent, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(adjacent_stale_entries_both_reset)
+{
+    auto cryptoSuite = makeCryptoSuiteFib181();
+    // generateKeyPair() returns a unique_ptr; bind to the shared KeyPairInterface::Ptr
+    // expected by PBFTConfig (the converting ctor moves the unique_ptr in).
+    KeyPairInterface::Ptr keyPair = cryptoSuite->signatureImpl()->generateKeyPair();
+    auto blockFactory = createBlockFactory(cryptoSuite);
+    auto txPool = std::make_shared<FakeTxPool>();
+    auto txResultFactory = std::make_shared<TransactionSubmitResultFactoryImpl>();
+    auto validator = std::make_shared<CountingValidator>(txPool, blockFactory, txResultFactory);
+    auto frontService = std::make_shared<FakeFrontService>(keyPair->publicKey());
+
+    auto config = std::make_shared<MinimalPBFTConfig>(
+        cryptoSuite, keyPair, validator, frontService, blockFactory);
+
+    auto cache = std::make_shared<PBFTCache>(config, /*index*/ 10);
+
+    // Two adjacent stale exception pre-prepares with DISTINCT hashes. With
+    // m_prePrepare and m_precommit both null, neither matches a valid/precommit
+    // hash, so both fall into the else-branch that erases and calls
+    // asyncResetTxsFlag(*block, false).
+    cache->addExceptionPrePrepareCache(makeExceptionPrePrepare(cryptoSuite, blockFactory, 1));
+    cache->addExceptionPrePrepareCache(makeExceptionPrePrepare(cryptoSuite, blockFactory, 2));
+
+    cache->resetExceptionCache(/*curView*/ 1);
+
+    // Post-fix: both stale entries are processed in the same pass.
+    // Pre-fix the count was 1 (the second adjacent entry was skipped).
+    BOOST_CHECK_EQUAL(validator->m_count.load(), 2);
+
+    config->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-pbft/test/unittests/pbft/FIB120_PBFTProposalDecodeBoundsTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB120_PBFTProposalDecodeBoundsTest.cpp
@@ -43,9 +43,13 @@ namespace test
 static bytes makePBFTProposalBytes(int sigCount, int nodeCount)
 {
     PBFTRawProposal raw;
-    // fill a minimal inner proposal so decodePBObject succeeds
+    // fill a minimal inner proposal so decodePBObject succeeds. Use a canonical
+    // HashType::SIZE hash so the decode path under test exercises only the
+    // signatureList/nodeList bounds — a non-canonical hash length is now rejected
+    // at decode (FIB-174) and would mask the bounds check.
     raw.mutable_proposal()->set_index(1);
-    raw.mutable_proposal()->set_hash("hash");
+    std::string canonicalHash(bcos::crypto::HashType::SIZE, '\x11');
+    raw.mutable_proposal()->set_hash(canonicalHash.data(), canonicalHash.size());
 
     for (int i = 0; i < sigCount; ++i)
     {
@@ -136,7 +140,10 @@ BOOST_AUTO_TEST_CASE(signatureProof_throws_on_out_of_bounds_FIB120)
 {
     auto raw = std::make_shared<PBFTRawProposal>();
     raw->mutable_proposal()->set_index(1);
-    raw->mutable_proposal()->set_hash("hash");
+    // Canonical hash so the constructor's deserializeObject does not reject the
+    // proposal on hash length (FIB-174) before we reach the signatureProof check.
+    std::string canonicalHash(bcos::crypto::HashType::SIZE, '\x11');
+    raw->mutable_proposal()->set_hash(canonicalHash.data(), canonicalHash.size());
     // signature is set but nodelist is empty — index 0 is OOB on nodelist.
     raw->add_signaturelist("sig");
 

--- a/bcos-pbft/test/unittests/pbft/FIB185_ConsensusRearmWatchdogTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB185_ConsensusRearmWatchdogTest.cpp
@@ -22,7 +22,9 @@
 #include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/asio/post.hpp>
 #include <boost/test/unit_test.hpp>
+#include <future>
 
 using namespace bcos::crypto;
 
@@ -63,6 +65,14 @@ BOOST_AUTO_TEST_CASE(WatchdogRearmsStalledTimer)
 
     fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();
 
+    // flush the io_context so the dispatched timer->start() completes
+    {
+        std::promise<void> flushDone;
+        auto flushFuture = flushDone.get_future();
+        boost::asio::post(fixture->ioContext(), [&flushDone]() { flushDone.set_value(); });
+        flushFuture.wait();
+    }
+
     // the watchdog re-armed the timer
     BOOST_CHECK(config->timer()->running());
 
@@ -97,6 +107,13 @@ BOOST_AUTO_TEST_CASE(WatchdogIsNoopWhenTimerRunning)
 
     config->setTimeoutState(true);
     config->timer()->start();
+    // flush the io_context so the dispatched timer->start() completes
+    {
+        std::promise<void> flushDone;
+        auto flushFuture = flushDone.get_future();
+        boost::asio::post(fixture->ioContext(), [&flushDone]() { flushDone.set_value(); });
+        flushFuture.wait();
+    }
     BOOST_CHECK(config->timer()->running());
 
     fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();

--- a/bcos-pbft/test/unittests/pbft/FIB185_ConsensusRearmWatchdogTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB185_ConsensusRearmWatchdogTest.cpp
@@ -1,0 +1,112 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-185: consensus-timer re-arm watchdog
+ * @file FIB185_ConsensusRearmWatchdogTest.cpp
+ * @date 2026-06-15
+ */
+#include "test/unittests/pbft/PBFTFixture.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos::crypto;
+
+namespace bcos
+{
+namespace test
+{
+BOOST_FIXTURE_TEST_SUITE(FIB185_ConsensusRearmWatchdogTest, TestPromptFixture)
+
+inline PBFTFixture::Ptr makeConsensusFixture()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto fixture = createPBFTFixture(cryptoSuite);
+    // make the node a consensus node so the watchdog's isConsensusNode() guard passes.
+    // Note: intentionally do NOT call init() here. init() starts the engine worker and the
+    // periodic checkpoint timer, which would invoke the watchdog concurrently and race the
+    // deterministic timer/timeout state these tests set. The watchdog only reads config +
+    // m_stopped (default false), so the engine need not be started for the unit under test.
+    fixture->appendConsensusNode(fixture->nodeID());
+    return fixture;
+}
+
+// FIB-185: the wedge signature is a consensus node sitting in the timeout state whose
+// view-change timer is not running. The watchdog must re-arm the timer.
+BOOST_AUTO_TEST_CASE(WatchdogRearmsStalledTimer)
+{
+    auto fixture = makeConsensusFixture();
+    auto config = fixture->pbftConfig();
+    BOOST_CHECK(config->isConsensusNode());
+
+    // simulate the wedge: in timeout state but the consensus timer is stopped
+    config->setTimeoutState(true);
+    config->timer()->stop();
+    BOOST_CHECK(config->timeout());
+    BOOST_CHECK(!config->timer()->running());
+
+    fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();
+
+    // the watchdog re-armed the timer
+    BOOST_CHECK(config->timer()->running());
+
+    config->timer()->stop();
+}
+
+// FIB-185: the watchdog must NOT re-arm the timer when the node is not in the timeout state.
+// Re-arming outside timeout would risk spurious view-change activity.
+BOOST_AUTO_TEST_CASE(WatchdogDoesNotRearmWhenNotInTimeout)
+{
+    auto fixture = makeConsensusFixture();
+    auto config = fixture->pbftConfig();
+    BOOST_CHECK(config->isConsensusNode());
+
+    config->setTimeoutState(false);
+    config->timer()->stop();
+    BOOST_CHECK(!config->timeout());
+    BOOST_CHECK(!config->timer()->running());
+
+    fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();
+
+    // not in timeout: the watchdog leaves the stopped timer alone
+    BOOST_CHECK(!config->timer()->running());
+}
+
+// FIB-185: when the timer is already running the watchdog is a no-op (it does not double-arm).
+BOOST_AUTO_TEST_CASE(WatchdogIsNoopWhenTimerRunning)
+{
+    auto fixture = makeConsensusFixture();
+    auto config = fixture->pbftConfig();
+    BOOST_CHECK(config->isConsensusNode());
+
+    config->setTimeoutState(true);
+    config->timer()->start();
+    BOOST_CHECK(config->timer()->running());
+
+    fixture->pbftEngine()->checkConsensusTimerWatchdogForTest();
+
+    // still running, no crash / no double-arm side effect
+    BOOST_CHECK(config->timer()->running());
+
+    config->timer()->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace test
+}  // namespace bcos

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -215,6 +215,9 @@ public:
     // Test-only: inject a committed-block timestamp so FIB-126 monotonicity tests
     // can exercise the timestamp check without a real ledger.
     void setCommittedBlockTimestampForTest(int64_t _ts) { m_ledgerConfig->setTimestamp(_ts); }
+
+    // FIB-185: expose the consensus-timer watchdog for unit testing.
+    void checkConsensusTimerWatchdogForTest() { PBFTEngine::checkConsensusTimerWatchdog(); }
 };
 
 class FakePBFTImpl : public PBFTImpl

--- a/bcos-sync/bcos-sync/state/DownloadRequestQueue.cpp
+++ b/bcos-sync/bcos-sync/state/DownloadRequestQueue.cpp
@@ -137,17 +137,39 @@ std::set<DownloadRequestQueue::BlockRequest> DownloadRequestQueue::mergeAndPop()
     UpgradeGuard ulock(lock);
     std::set<DownloadRequestQueue::BlockRequest> fetchSet{};
 
-    while (!m_reqQueue.empty())
+    // FIB-19: hard cap on the number of generated block requests. A malicious peer can request a
+    // range spanning billions of blocks; without this cap mergeAndPop() expands it into an
+    // unbounded fetchSet and the caller (maintainBlockRequest) issues one ledger read + outbound
+    // message per entry. Stop once the cap is reached and drop the remaining queue; the requester
+    // retries for anything beyond the cap.
+    bool capped = false;
+    while (!m_reqQueue.empty() && !capped)
     {
         auto topReq = m_reqQueue.top();
         auto interval = (topReq->interval() == 0 ? 1 : topReq->interval());
         for (BlockNumber i = topReq->fromNumber(); i <= topReq->toNumber(); i += interval)
         {
+            if (fetchSet.size() >= MAX_MERGED_REQUEST_BLOCKS_COUNT)
+            {
+                capped = true;
+                break;
+            }
             fetchSet.insert({i, topReq->blockDataFlag() > 0 ?
                                     topReq->blockDataFlag() :
                                     (bcos::ledger::HEADER | bcos::ledger::TRANSACTIONS)});
         }
         m_reqQueue.pop();
+    }
+    if (capped)
+    {
+        BLKSYNC_LOG(WARNING) << LOG_BADGE("Download") << LOG_BADGE("Request")
+                             << LOG_DESC("mergeAndPop hit hard cap, dropping remaining requests")
+                             << LOG_KV("cap", MAX_MERGED_REQUEST_BLOCKS_COUNT)
+                             << LOG_KV("fetchSetSize", fetchSet.size())
+                             << LOG_KV("droppedQueueSize", m_reqQueue.size())
+                             << LOG_KV("peer", m_nodeId->shortHex());
+        RequestQueue empty;
+        m_reqQueue.swap(empty);
     }
     if (c_fileLogLevel == LogLevel::TRACE)
     {

--- a/bcos-sync/bcos-sync/utilities/Common.h
+++ b/bcos-sync/bcos-sync/utilities/Common.h
@@ -29,6 +29,15 @@ static constexpr const size_t MAX_DOWNLOAD_BLOCK_QUEUE_SIZE = 256;
 static constexpr const size_t MAX_DOWNLOAD_REQUEST_QUEUE_SIZE = 1000;
 // the max number of blocks this node can request to
 static constexpr const size_t MAX_REQUEST_BLOCKS_COUNT = 8;
+// Hard cap on the number of block requests a single DownloadRequestQueue::mergeAndPop() may
+// generate (FIB-19). A malicious peer can craft a request whose [fromNumber, toNumber] range
+// spans billions of blocks; without a cap, mergeAndPop() expands it into an unbounded fetchSet
+// and maintainBlockRequest() issues one ledger read + outbound message per entry, exhausting
+// CPU/memory/network. The cap equals the worst-case legitimate volume (a full request queue of
+// MAX_DOWNLOAD_REQUEST_QUEUE_SIZE entries, each requesting MAX_REQUEST_BLOCKS_COUNT blocks), so
+// it never truncates honest traffic. The requester retries for any blocks beyond the cap.
+static constexpr const size_t MAX_MERGED_REQUEST_BLOCKS_COUNT =
+    MAX_DOWNLOAD_REQUEST_QUEUE_SIZE * MAX_REQUEST_BLOCKS_COUNT;
 static constexpr const size_t DOWNLOAD_TIMEOUT_TTL = 200;
 enum BlockSyncPacketType : int32_t
 {

--- a/bcos-sync/test/unittests/sync/FIB19_MergeAndPopHardCapTest.cpp
+++ b/bcos-sync/test/unittests/sync/FIB19_MergeAndPopHardCapTest.cpp
@@ -1,0 +1,78 @@
+/**
+ *  Copyright (C) 2021 bcos-sync.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief regression test for FIB-19: DownloadRequestQueue::mergeAndPop() must cap the number of
+ *        generated block requests so a malicious peer cannot trigger unbounded iteration.
+ * @file FIB19_MergeAndPopHardCapTest.cpp
+ */
+
+#include "SyncFixture.h"
+#include "bcos-sync/state/DownloadRequestQueue.h"
+#include "bcos-sync/utilities/Common.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::sync;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+BOOST_FIXTURE_TEST_SUITE(FIB19MergeAndPopHardCapTest, TestPromptFixture)
+
+static DownloadRequestQueue::Ptr makeQueue()
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto gateWay = std::make_shared<FakeGateWay>();
+    auto peer = std::make_shared<SyncFixture>(cryptoSuite, gateWay, 1);
+    return std::make_shared<DownloadRequestQueue>(peer->syncConfig(), peer->syncConfig()->nodeID());
+}
+
+// A single request whose range dwarfs the legitimate maximum must be capped, not fully expanded.
+BOOST_AUTO_TEST_CASE(mergeAndPopEnforcesHardCap)
+{
+    auto queue = makeQueue();
+
+    // size is far above MAX_MERGED_REQUEST_BLOCKS_COUNT but small enough that the pre-fix code
+    // still completes quickly, so the cap is demonstrated deterministically (not via OOM).
+    constexpr size_t kMaliciousSize = MAX_MERGED_REQUEST_BLOCKS_COUNT * 4;
+    queue->push(/*fromNumber*/ 1, /*size*/ kMaliciousSize, /*interval*/ 1);
+
+    auto fetchSet = queue->mergeAndPop();
+    // Without the cap this set would hold kMaliciousSize entries.
+    BOOST_CHECK_EQUAL(fetchSet.size(), MAX_MERGED_REQUEST_BLOCKS_COUNT);
+    // The queue is fully drained once the cap is hit.
+    BOOST_CHECK(queue->empty());
+}
+
+// A legitimate, below-cap merge is returned unchanged.
+BOOST_AUTO_TEST_CASE(mergeAndPopBelowCapUnchanged)
+{
+    auto queue = makeQueue();
+
+    queue->push(/*fromNumber*/ 1, /*size*/ 5, /*interval*/ 1);   // blocks 1..5
+    queue->push(/*fromNumber*/ 10, /*size*/ 3, /*interval*/ 1);  // blocks 10..12
+
+    auto fetchSet = queue->mergeAndPop();
+    BOOST_CHECK_EQUAL(fetchSet.size(), 8);
+    BOOST_CHECK(queue->empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/fisco-bcos-air/main.cpp
+++ b/fisco-bcos-air/main.cpp
@@ -38,6 +38,14 @@ int main(int argc, const char* argv[])
 {
     /// set LC_ALL
     setDefaultOrCLocale();
+    // TODO(FIB-184): this terminate handler is the abort amplifier for the log-sink half of
+    // FIB-184. Under TLS connect/close churn an exception is rethrown inside the boost
+    // asynchronous_sink (BoostLogInitializer::sink_t) on the dedicated log thread; being
+    // uncaught there it reaches std::terminate -> abort() here and crashes the node. The real
+    // fix wraps the async sink's formatter/consumer in bcos-utilities/BoostLogInitializer.cpp so
+    // it can never propagate an uncaught exception. That file is outside this change's scope
+    // (gateway/pbft/air only); do NOT "fix" this by swallowing exceptions in the terminate
+    // handler, which would hide unrelated crashes. Tracked for a follow-up bcos-utilities PR.
     std::set_terminate([]() {
         std::cerr << "terminate handler called, print stacks" << std::endl;
         void* trace_elems[50];

--- a/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
+++ b/transaction-executor/bcos-transaction-executor/EVMCResult.cpp
@@ -40,6 +40,8 @@ bcos::executor_v1::EVMCResult::EVMCResult(EVMCResult&& from) noexcept
 bcos::executor_v1::EVMCResult& bcos::executor_v1::EVMCResult::operator=(EVMCResult&& from) noexcept
 {
     evmc_result::operator=(from);
+    // FIB-179: keep cached TransactionStatus in sync with the moved-from result
+    status = from.status;
     cleanEVMCResult(from);
     return *this;
 }

--- a/transaction-executor/tests/FIB179_180_EVMCResultTest.cpp
+++ b/transaction-executor/tests/FIB179_180_EVMCResultTest.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FIB179_180_EVMCResultTest.cpp
+ * @date 2026
+ */
+
+#include "../bcos-transaction-executor/EVMCResult.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-protocol/TransactionStatus.h"
+#include <evmc/evmc.h>
+#include <boost/test/unit_test.hpp>
+#include <utility>
+using namespace bcos;
+using namespace bcos::executor_v1;
+using namespace bcos::protocol;
+
+BOOST_AUTO_TEST_SUITE(FIB179_180_EVMCResultTest)
+
+BOOST_AUTO_TEST_CASE(moveAssign_updatesCachedStatus)
+{
+    evmc_result dstResult = {};
+    dstResult.status_code = EVMC_SUCCESS;
+    dstResult.release = nullptr;
+    evmc_result srcResult = {};
+    srcResult.status_code = EVMC_REVERT;
+    srcResult.release = nullptr;
+
+    EVMCResult dst(dstResult);
+    EVMCResult src(srcResult);
+    dst = std::move(src);
+    BOOST_CHECK_EQUAL(dst.status_code, EVMC_REVERT);
+    BOOST_CHECK_EQUAL(dst.status, TransactionStatus::RevertInstruction);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
从 release-3.17.0 同步以下修复到 release-3.18.0：

- **fix(sync)**: 限制 mergeAndPop 生成区块请求数量 (FIB-19) (#5277)
- **fix(leader-election)**: keepalive/campaign/lease/watcher 恢复与校验修复 (FIB-173, FIB-175, FIB-176, FIB-177, FIB-178, FIB-182) (#5265)
- **fix(pbft)**: 拒绝畸形 proposal hash + 修复异常缓存清理 (FIB-174, FIB-181) (#5264)
- **fix(gateway/pbft)**: P2P 解码边界检查、会话资源上限、共识重新启用 (FIB-183, FIB-184, FIB-185) (#5266)
- **fix(executor)**: EVMCResult 移动赋值时同步缓存的 TransactionStatus (FIB-179) (#5263)

共涉及 32 个文件，+1360/-32 行变更。