### PR TITLE
refactor: 将 ThreadPool(1) 替换为共享 IOServicePool + Strand 串行调度

### DIFF
--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -1009,7 +1009,7 @@ bcos::amop::AMOPImpl::Ptr GatewayFactory::buildAMOP(
     registerAMOPHandlers(service, topicManager);
 
     return std::make_shared<AMOPImpl>(topicManager, amopMessageFactory, requestFactory, _network,
-        _p2pNodeID, *m_ioServicePool->getIOService());
+        _p2pNodeID, *m_ioServicePool->getIOService(), m_ioServicePool);
 }
 
 bcos::amop::AMOPImpl::Ptr GatewayFactory::buildLocalAMOP(
@@ -1024,7 +1024,7 @@ bcos::amop::AMOPImpl::Ptr GatewayFactory::buildLocalAMOP(
     registerAMOPHandlers(service, topicManager);
 
     return std::make_shared<AMOPImpl>(topicManager, amopMessageFactory, requestFactory, _network,
-        _p2pNodeID, *m_ioServicePool->getIOService());
+        _p2pNodeID, *m_ioServicePool->getIOService(), m_ioServicePool);
 }
 
 void GatewayFactory::registerAMOPHandlers(

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -40,14 +40,15 @@ TopicManager::Ptr AMOPImpl::topicManager()
 AMOPImpl::AMOPImpl(TopicManager::Ptr _topicManager,
     bcos::amop::AMOPMessageFactory::Ptr _messageFactory, AMOPRequestFactory::Ptr _requestFactory,
     P2PInterface::Ptr _network, P2pID const& _p2pNodeID,
-    boost::asio::io_context& _ioContext)
+    boost::asio::io_context& _ioContext,
+    bcos::IOServicePool::Ptr _ioServicePool)
   : m_topicManager(_topicManager),
     m_messageFactory(_messageFactory),
     m_requestFactory(_requestFactory),
     m_network(_network),
-    m_p2pNodeID(_p2pNodeID)
+    m_p2pNodeID(_p2pNodeID),
+    m_ioServicePool(std::move(_ioServicePool))
 {
-    m_threadPool = std::make_shared<ThreadPool>("amopDispatcher", 1);
     m_timer = std::make_shared<Timer>(_ioContext, TOPIC_SYNC_PERIOD, "topicSync");
     m_timer->registerTimeoutHandler([this]() { broadcastTopicSeq(); });
 
@@ -216,7 +217,7 @@ void AMOPImpl::onReceiveAMOPMessage(P2pID const& _nodeID, std::string const& _to
         std::string errorMessage = "NotFoundClientByTopicDispatchMsg";
         amopMsg->setData(bytesConstRef((bcos::byte*)errorMessage.c_str(), errorMessage.size()));
         amopMsg->encode(*buffer);
-        m_threadPool->enqueue([buffer, _responseCallback]() {
+        m_ioServicePool->strand([buffer, _responseCallback]() {
             _responseCallback(buffer, GatewayMessageType::AMOPMessageType);
         });
         AMOP_LOG(WARNING) << LOG_BADGE("onRecvAMOPMessage")
@@ -487,7 +488,7 @@ void AMOPImpl::onAMOPMessage(
     NetworkException const& _e, P2PSession::Ptr _session, std::shared_ptr<P2PMessage> _message)
 {
     auto self = std::weak_ptr<AMOPImpl>(shared_from_this());
-    m_threadPool->enqueue([self, _e, _session, _message]() {
+    m_ioServicePool->strand([self, _e, _session, _message]() {
         auto amop = self.lock();
         if (!amop)
         {

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -47,7 +47,7 @@ AMOPImpl::AMOPImpl(TopicManager::Ptr _topicManager,
     m_requestFactory(_requestFactory),
     m_network(_network),
     m_p2pNodeID(_p2pNodeID),
-    m_ioServicePool(std::move(_ioServicePool))
+    m_strand(std::make_shared<Strand>(std::move(_ioServicePool)))
 {
     m_timer = std::make_shared<Timer>(_ioContext, TOPIC_SYNC_PERIOD, "topicSync");
     m_timer->registerTimeoutHandler([this]() { broadcastTopicSeq(); });
@@ -217,7 +217,7 @@ void AMOPImpl::onReceiveAMOPMessage(P2pID const& _nodeID, std::string const& _to
         std::string errorMessage = "NotFoundClientByTopicDispatchMsg";
         amopMsg->setData(bytesConstRef((bcos::byte*)errorMessage.c_str(), errorMessage.size()));
         amopMsg->encode(*buffer);
-        m_ioServicePool->strand([buffer, _responseCallback]() {
+        m_strand->post([buffer, _responseCallback]() {
             _responseCallback(buffer, GatewayMessageType::AMOPMessageType);
         });
         AMOP_LOG(WARNING) << LOG_BADGE("onRecvAMOPMessage")
@@ -488,7 +488,7 @@ void AMOPImpl::onAMOPMessage(
     NetworkException const& _e, P2PSession::Ptr _session, std::shared_ptr<P2PMessage> _message)
 {
     auto self = std::weak_ptr<AMOPImpl>(shared_from_this());
-    m_ioServicePool->strand([self, _e, _session, _message]() {
+    m_strand->post([self, _e, _session, _message]() {
         auto amop = self.lock();
         if (!amop)
         {

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
@@ -24,7 +24,7 @@
 #include "bcos-gateway/libp2p/P2PInterface.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-gateway/libp2p/P2PSession.h"
-#include "bcos-utilities/ThreadPool.h"
+#include "bcos-utilities/IOServicePool.h"
 #include "bcos-utilities/Timer.h"
 #include <boost/asio/io_context.hpp>
 namespace bcos
@@ -38,7 +38,8 @@ public:
     AMOPImpl(TopicManager::Ptr _topicManager, AMOPMessageFactory::Ptr _messageFactory,
         bcos::protocol::AMOPRequestFactory::Ptr _requestFactory,
         bcos::gateway::P2PInterface::Ptr _network, bcos::gateway::P2pID const& _p2pNodeID,
-        boost::asio::io_context& _ioContext);
+        boost::asio::io_context& _ioContext,
+        bcos::IOServicePool::Ptr _ioServicePool);
     virtual ~AMOPImpl();
 
     virtual void start();
@@ -148,7 +149,7 @@ private:
     std::shared_ptr<Timer> m_timer;
     bcos::gateway::P2PInterface::Ptr m_network;
     bcos::gateway::P2pID m_p2pNodeID;
-    ThreadPool::Ptr m_threadPool;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 
     unsigned const TOPIC_SYNC_PERIOD = 2000;
 };

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.h
@@ -149,7 +149,7 @@ private:
     std::shared_ptr<Timer> m_timer;
     bcos::gateway::P2PInterface::Ptr m_network;
     bcos::gateway::P2pID m_p2pNodeID;
-    bcos::IOServicePool::Ptr m_ioServicePool;
+    bcos::Strand::Ptr m_strand;
 
     unsigned const TOPIC_SYNC_PERIOD = 2000;
 };

--- a/bcos-pbft/bcos-pbft/core/StateMachine.cpp
+++ b/bcos-pbft/bcos-pbft/core/StateMachine.cpp
@@ -32,7 +32,7 @@ void StateMachine::asyncApply(ssize_t _timeout, ProposalInterface::ConstPtr _las
 {
     auto self = weak_from_this();
     // Note: async here to increase performance
-    m_worker->enqueue(
+    m_ioServicePool->strand(
         [self, _timeout, _lastAppliedProposal, _proposal, _executedProposal, _onExecuteFinished]() {
             auto stateMachine = self.lock();
             if (!stateMachine)

--- a/bcos-pbft/bcos-pbft/core/StateMachine.cpp
+++ b/bcos-pbft/bcos-pbft/core/StateMachine.cpp
@@ -32,7 +32,7 @@ void StateMachine::asyncApply(ssize_t _timeout, ProposalInterface::ConstPtr _las
 {
     auto self = weak_from_this();
     // Note: async here to increase performance
-    m_ioServicePool->strand(
+    m_strand->post(
         [self, _timeout, _lastAppliedProposal, _proposal, _executedProposal, _onExecuteFinished]() {
             auto stateMachine = self.lock();
             if (!stateMachine)

--- a/bcos-pbft/bcos-pbft/core/StateMachine.h
+++ b/bcos-pbft/bcos-pbft/core/StateMachine.h
@@ -22,7 +22,7 @@
 #include "bcos-framework/consensus/StateMachineInterface.h"
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
 #include <bcos-framework/protocol/BlockFactory.h>
-#include <bcos-utilities/ThreadPool.h>
+#include <bcos-utilities/IOServicePool.h>
 
 #include <utility>
 namespace bcos
@@ -33,22 +33,11 @@ class StateMachine : public StateMachineInterface, public std::enable_shared_fro
 {
 public:
     StateMachine(bcos::scheduler::SchedulerInterface::Ptr _scheduler,
-        bcos::protocol::BlockFactory::Ptr _blockFactory)
-      : m_scheduler(std::move(_scheduler)), m_blockFactory(std::move(_blockFactory))
-    {
-        // since execute block is serial, only use one thread to decrease the timecost
-        m_worker = std::make_shared<ThreadPool>("stateMachine", 1);
-    }
-
-    ~StateMachine() override { stop(); }
-
-    void stop() override
-    {
-        if (m_worker)
-        {
-            m_worker->stop();
-        }
-    }
+        bcos::protocol::BlockFactory::Ptr _blockFactory,
+        bcos::IOServicePool::Ptr _ioServicePool)
+      : m_scheduler(std::move(_scheduler)), m_blockFactory(std::move(_blockFactory)),
+        m_ioServicePool(std::move(_ioServicePool))
+    {}
 
     void asyncApply(ssize_t _execTimeout, ProposalInterface::ConstPtr _lastAppliedProposal,
         ProposalInterface::Ptr _proposal, ProposalInterface::Ptr _executedProposal,
@@ -67,7 +56,7 @@ private:
 protected:
     bcos::scheduler::SchedulerInterface::Ptr m_scheduler;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
-    bcos::ThreadPool::Ptr m_worker;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace consensus
 }  // namespace bcos

--- a/bcos-pbft/bcos-pbft/core/StateMachine.h
+++ b/bcos-pbft/bcos-pbft/core/StateMachine.h
@@ -36,7 +36,7 @@ public:
         bcos::protocol::BlockFactory::Ptr _blockFactory,
         bcos::IOServicePool::Ptr _ioServicePool)
       : m_scheduler(std::move(_scheduler)), m_blockFactory(std::move(_blockFactory)),
-        m_ioServicePool(std::move(_ioServicePool))
+        m_strand(std::make_shared<Strand>(std::move(_ioServicePool)))
     {}
 
     void asyncApply(ssize_t _execTimeout, ProposalInterface::ConstPtr _lastAppliedProposal,
@@ -56,7 +56,7 @@ private:
 protected:
     bcos::scheduler::SchedulerInterface::Ptr m_scheduler;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
-    bcos::IOServicePool::Ptr m_ioServicePool;
+    bcos::Strand::Ptr m_strand;
 };
 }  // namespace consensus
 }  // namespace bcos

--- a/bcos-pbft/bcos-pbft/pbft/PBFTFactory.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/PBFTFactory.cpp
@@ -39,7 +39,8 @@ PBFTFactory::PBFTFactory(boost::asio::io_context& _ioService,
     std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
     bcos::scheduler::SchedulerInterface::Ptr _scheduler, bcos::txpool::TxPoolInterface::Ptr _txpool,
     bcos::protocol::BlockFactory::Ptr _blockFactory,
-    bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory)
+    bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+    bcos::IOServicePool::Ptr _ioServicePool)
   : m_ioService(_ioService),
     m_cryptoSuite(std::move(_cryptoSuite)),
     m_keyPair(std::move(_keyPair)),
@@ -49,7 +50,8 @@ PBFTFactory::PBFTFactory(boost::asio::io_context& _ioService,
     m_scheduler(std::move(_scheduler)),
     m_txpool(std::move(_txpool)),
     m_blockFactory(std::move(_blockFactory)),
-    m_txResultFactory(std::move(_txResultFactory))
+    m_txResultFactory(std::move(_txResultFactory)),
+    m_ioServicePool(std::move(_ioServicePool))
 {}
 
 PBFTImpl::Ptr PBFTFactory::createPBFT()
@@ -62,11 +64,11 @@ PBFTImpl::Ptr PBFTFactory::createPBFT()
     auto validator = std::make_shared<TxsValidator>(m_txpool, m_blockFactory, m_txResultFactory);
 
     PBFT_LOG(DEBUG) << LOG_DESC("create StateMachine");
-    auto stateMachine = std::make_shared<StateMachine>(m_scheduler, m_blockFactory);
+    auto stateMachine = std::make_shared<StateMachine>(m_scheduler, m_blockFactory, m_ioServicePool);
 
     PBFT_LOG(INFO) << LOG_DESC("create pbftStorage");
     auto pbftStorage =
-        std::make_shared<LedgerStorage>(m_scheduler, m_storage, m_blockFactory, pbftMessageFactory);
+        std::make_shared<LedgerStorage>(m_scheduler, m_storage, m_blockFactory, pbftMessageFactory, m_ioServicePool);
 
     PBFT_LOG(INFO) << LOG_DESC("create pbftConfig");
     PBFTConfig::Ptr pbftConfig =
@@ -74,10 +76,10 @@ PBFTImpl::Ptr PBFTFactory::createPBFT()
             pbftCodec, validator, m_frontService, stateMachine, pbftStorage, m_blockFactory);
 
     PBFT_LOG(INFO) << LOG_DESC("create PBFTEngine");
-    auto pbftEngine = std::make_shared<PBFTEngine>(pbftConfig, m_ioService);
+    auto pbftEngine = std::make_shared<PBFTEngine>(pbftConfig, m_ioService, m_ioServicePool);
 
     PBFT_LOG(INFO) << LOG_DESC("create PBFT");
-    auto pbft = std::make_shared<PBFTImpl>(pbftEngine);
+    auto pbft = std::make_shared<PBFTImpl>(pbftEngine, m_ioServicePool);
     pbft->setLedger(m_ledger);
     return pbft;
 }

--- a/bcos-pbft/bcos-pbft/pbft/PBFTFactory.h
+++ b/bcos-pbft/bcos-pbft/pbft/PBFTFactory.h
@@ -24,6 +24,7 @@
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
 #include <bcos-framework/storage/KVStorageHelper.h>
 #include <bcos-framework/sync/BlockSyncInterface.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <functional>
 
 namespace bcos::consensus
@@ -40,7 +41,8 @@ public:
         std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
         bcos::scheduler::SchedulerInterface::Ptr _scheduler,
         bcos::txpool::TxPoolInterface::Ptr _txpool, bcos::protocol::BlockFactory::Ptr _blockFactory,
-        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory);
+        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+        bcos::IOServicePool::Ptr _ioServicePool);
 
     virtual ~PBFTFactory() = default;
     virtual PBFTImpl::Ptr createPBFT();
@@ -56,5 +58,6 @@ protected:
     bcos::txpool::TxPoolInterface::Ptr m_txpool;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
     bcos::protocol::TransactionSubmitResultFactory::Ptr m_txResultFactory;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace bcos::consensus

--- a/bcos-pbft/bcos-pbft/pbft/PBFTImpl.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/PBFTImpl.cpp
@@ -43,7 +43,6 @@ void PBFTImpl::stop()
         PBFT_LOG(INFO) << LOG_DESC("The PBFT module has already been stopped!");
         return;
     }
-    m_blockValidator->stop();
     m_pbftEngine->stop();
     m_running = false;
     PBFT_LOG(INFO) << LOG_DESC("Stop the PBFT module.");

--- a/bcos-pbft/bcos-pbft/pbft/PBFTImpl.h
+++ b/bcos-pbft/bcos-pbft/pbft/PBFTImpl.h
@@ -30,9 +30,11 @@ class PBFTImpl : public ConsensusInterface
 {
 public:
     using Ptr = std::shared_ptr<PBFTImpl>;
-    explicit PBFTImpl(PBFTEngine::Ptr _pbftEngine) : m_pbftEngine(std::move(_pbftEngine))
+    explicit PBFTImpl(PBFTEngine::Ptr _pbftEngine, bcos::IOServicePool::Ptr _ioServicePool)
+      : m_pbftEngine(std::move(_pbftEngine))
     {
-        m_blockValidator = std::make_shared<BlockValidator>(m_pbftEngine->pbftConfig());
+        m_blockValidator = std::make_shared<BlockValidator>(
+            m_pbftEngine->pbftConfig(), std::move(_ioServicePool));
     }
     ~PBFTImpl() override { stop(); }
 

--- a/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.cpp
@@ -29,7 +29,7 @@ void BlockValidator::asyncCheckBlock(
     Block::Ptr _block, std::function<void(Error::Ptr, bool)> _onVerifyFinish)
 {
     auto self = weak_from_this();
-    m_taskPool->enqueue([self, _block, _onVerifyFinish]() {
+    m_ioServicePool->strand([self, _block, _onVerifyFinish]() {
         auto blockHeader = _block->blockHeader();
 
         // Separate result computation from callback delivery (FIB-139):

--- a/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.cpp
@@ -29,7 +29,7 @@ void BlockValidator::asyncCheckBlock(
     Block::Ptr _block, std::function<void(Error::Ptr, bool)> _onVerifyFinish)
 {
     auto self = weak_from_this();
-    m_ioServicePool->strand([self, _block, _onVerifyFinish]() {
+    m_strand->post([self, _block, _onVerifyFinish]() {
         auto blockHeader = _block->blockHeader();
 
         // Separate result computation from callback delivery (FIB-139):

--- a/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.h
@@ -21,7 +21,7 @@
 #pragma once
 #include "../config/PBFTConfig.h"
 #include <bcos-framework/protocol/Block.h>
-#include <bcos-utilities/ThreadPool.h>
+#include <bcos-utilities/IOServicePool.h>
 namespace bcos
 {
 namespace consensus
@@ -30,21 +30,13 @@ class BlockValidator : public std::enable_shared_from_this<BlockValidator>
 {
 public:
     using Ptr = std::shared_ptr<BlockValidator>;
-    explicit BlockValidator(PBFTConfig::Ptr _config)
-      : m_config(std::move(_config)), m_taskPool(std::make_shared<ThreadPool>("blockValidator", 1))
+    explicit BlockValidator(PBFTConfig::Ptr _config, bcos::IOServicePool::Ptr _ioServicePool)
+      : m_config(std::move(_config)), m_ioServicePool(std::move(_ioServicePool))
     {}
     virtual ~BlockValidator() = default;
 
     virtual void asyncCheckBlock(
         bcos::protocol::Block::Ptr _block, std::function<void(Error::Ptr, bool)> _onVerifyFinish);
-
-    virtual void stop()
-    {
-        if (m_taskPool)
-        {
-            m_taskPool->stop();
-        }
-    }
 
 protected:
     virtual bool checkSealerListAndWeightList(bcos::protocol::Block::Ptr _block);
@@ -52,7 +44,7 @@ protected:
 
 private:
     PBFTConfig::Ptr m_config;
-    ThreadPool::Ptr m_taskPool;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace consensus
 }  // namespace bcos

--- a/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/BlockValidator.h
@@ -31,7 +31,7 @@ class BlockValidator : public std::enable_shared_from_this<BlockValidator>
 public:
     using Ptr = std::shared_ptr<BlockValidator>;
     explicit BlockValidator(PBFTConfig::Ptr _config, bcos::IOServicePool::Ptr _ioServicePool)
-      : m_config(std::move(_config)), m_ioServicePool(std::move(_ioServicePool))
+      : m_config(std::move(_config)), m_strand(std::make_shared<Strand>(std::move(_ioServicePool)))
     {}
     virtual ~BlockValidator() = default;
 
@@ -44,7 +44,7 @@ protected:
 
 private:
     PBFTConfig::Ptr m_config;
-    bcos::IOServicePool::Ptr m_ioServicePool;
+    bcos::Strand::Ptr m_strand;
 };
 }  // namespace consensus
 }  // namespace bcos

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -42,14 +42,15 @@ using namespace bcos::front;
 using namespace bcos::crypto;
 using namespace bcos::protocol;
 
-PBFTEngine::PBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& _ioContext)
+PBFTEngine::PBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& _ioContext,
+    bcos::IOServicePool::Ptr _ioServicePool)
   : ConsensusEngine(_ioContext, "pbft", 20),
     m_config(_config),
     m_ledgerConfig(std::make_shared<LedgerConfig>())
 {
     auto cacheFactory = std::make_shared<PBFTCacheFactory>();
     m_cacheProcessor = std::make_shared<PBFTCacheProcessor>(cacheFactory, _config);
-    m_logSync = std::make_shared<PBFTLogSync>(m_config, m_cacheProcessor);
+    m_logSync = std::make_shared<PBFTLogSync>(m_config, m_cacheProcessor, std::move(_ioServicePool));
     // register the timeout function
     m_config->timer()->registerTimeoutHandler([this]() { onTimeout(); });
     m_config->storage()->registerFinalizeHandler(

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.h
@@ -24,6 +24,7 @@
 #include "bcos-pbft/core/ConsensusEngine.h"
 #include "bcos-pbft/pbft/utilities/PBFTPipeline.h"
 #include <bcos-utilities/Error.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/Timer.h>
 #include <oneapi/tbb/concurrent_queue.h>
 #include <unordered_map>
@@ -58,7 +59,8 @@ public:
     using Ptr = std::shared_ptr<PBFTEngine>;
     using SendResponseCallback = std::function<void(bytesConstRef)>;
     explicit PBFTEngine(std::shared_ptr<PBFTConfig> _config,
-        boost::asio::io_context& _ioContext);
+        boost::asio::io_context& _ioContext,
+        bcos::IOServicePool::Ptr _ioServicePool);
     ~PBFTEngine() override { stop(); }
 
     void start() override;

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
@@ -28,10 +28,11 @@ using namespace bcos::protocol;
 using namespace bcos::crypto;
 using namespace bcos::consensus;
 
-PBFTLogSync::PBFTLogSync(PBFTConfig::Ptr _config, PBFTCacheProcessor::Ptr _pbftCache)
+PBFTLogSync::PBFTLogSync(PBFTConfig::Ptr _config, PBFTCacheProcessor::Ptr _pbftCache,
+    bcos::IOServicePool::Ptr _ioServicePool)
   : m_config(std::move(_config)),
     m_pbftCache(std::move(_pbftCache)),
-    m_requestThread(std::make_shared<ThreadPool>("pbftLogSync", 1))
+    m_ioServicePool(std::move(_ioServicePool))
 {}
 
 void PBFTLogSync::requestCommittedProposals(
@@ -82,7 +83,7 @@ void PBFTLogSync::requestPBFTData(
     PublicPtr _from, PBFTRequestInterface::Ptr _pbftRequest, CallbackFunc _callback)
 {
     auto self = weak_from_this();
-    m_requestThread->enqueue([self, _from, _pbftRequest, _callback]() {
+    m_ioServicePool->strand([self, _from, _pbftRequest, _callback]() {
         try
         {
             auto pbftLogSync = self.lock();

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
@@ -32,7 +32,7 @@ PBFTLogSync::PBFTLogSync(PBFTConfig::Ptr _config, PBFTCacheProcessor::Ptr _pbftC
     bcos::IOServicePool::Ptr _ioServicePool)
   : m_config(std::move(_config)),
     m_pbftCache(std::move(_pbftCache)),
-    m_ioServicePool(std::move(_ioServicePool))
+    m_strand(std::make_shared<Strand>(std::move(_ioServicePool)))
 {}
 
 void PBFTLogSync::requestCommittedProposals(
@@ -83,7 +83,7 @@ void PBFTLogSync::requestPBFTData(
     PublicPtr _from, PBFTRequestInterface::Ptr _pbftRequest, CallbackFunc _callback)
 {
     auto self = weak_from_this();
-    m_ioServicePool->strand([self, _from, _pbftRequest, _callback]() {
+    m_strand->post([self, _from, _pbftRequest, _callback]() {
         try
         {
             auto pbftLogSync = self.lock();

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.h
@@ -72,6 +72,6 @@ protected:
 private:
     PBFTConfig::Ptr m_config;
     PBFTCacheProcessor::Ptr m_pbftCache;
-    bcos::IOServicePool::Ptr m_ioServicePool;
+    bcos::Strand::Ptr m_strand;
 };
 }  // namespace bcos::consensus

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.h
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.h
@@ -22,14 +22,15 @@
 #include "../cache/PBFTCacheProcessor.h"
 #include "../config/PBFTConfig.h"
 #include <bcos-crypto/interfaces/crypto/KeyInterface.h>
-#include <bcos-utilities/ThreadPool.h>
+#include <bcos-utilities/IOServicePool.h>
 namespace bcos::consensus
 {
 class PBFTLogSync : public std::enable_shared_from_this<PBFTLogSync>
 {
 public:
     using Ptr = std::shared_ptr<PBFTLogSync>;
-    PBFTLogSync(PBFTConfig::Ptr _config, PBFTCacheProcessor::Ptr _pbftCache);
+    PBFTLogSync(PBFTConfig::Ptr _config, PBFTCacheProcessor::Ptr _pbftCache,
+        bcos::IOServicePool::Ptr _ioServicePool);
     virtual ~PBFTLogSync() = default;
     using SendResponseCallback = std::function<void(bytesConstRef _respData)>;
     using HandlePrePrepareCallback = std::function<void(PBFTMessageInterface::Ptr)>;
@@ -53,7 +54,7 @@ public:
     virtual void requestPrecommitData(bcos::crypto::PublicPtr _from,
         PBFTMessageInterface::Ptr _prePrepareMsg, HandlePrePrepareCallback _prePrepareCallback);
 
-    virtual void stop() { m_requestThread->stop(); }
+    virtual void stop() {}
 
 protected:
     virtual void onRecvCommittedProposalsResponse(bcos::Error::Ptr _error,
@@ -71,6 +72,6 @@ protected:
 private:
     PBFTConfig::Ptr m_config;
     PBFTCacheProcessor::Ptr m_pbftCache;
-    std::shared_ptr<ThreadPool> m_requestThread;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace bcos::consensus

--- a/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
@@ -320,7 +320,7 @@ void LedgerStorage::asyncCommitStableCheckPoint(PBFTProposalInterface::Ptr _stab
                    << LOG_KV("blockProofSize", blockSignatureList.size());
     // Note: enqueue here to increase the performance since commitBlock is a sync implementation
     auto self = weak_from_this();
-    m_commitBlockWorker->enqueue([self, blockHeader, _stableProposal]() {
+    m_ioServicePool->strand([self, blockHeader, _stableProposal]() {
         auto storage = self.lock();
         if (!storage)
         {
@@ -397,7 +397,7 @@ void LedgerStorage::commitStableCheckPoint(PBFTProposalInterface::Ptr _stablePro
             // Note:Here the thread pool is used to asynchronize the operation of PBFT finalize to
             // prevent the commitBlock from calling the callback synchronously and affecting the
             // performance.
-            ledgerStorage->m_commitBlockWorker->enqueue(
+            ledgerStorage->m_ioServicePool->strand(
                 [self, txsSize, _blockHeader, _ledgerConfig]() {
                     auto storage = self.lock();
                     if (!storage)

--- a/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.cpp
@@ -320,7 +320,7 @@ void LedgerStorage::asyncCommitStableCheckPoint(PBFTProposalInterface::Ptr _stab
                    << LOG_KV("blockProofSize", blockSignatureList.size());
     // Note: enqueue here to increase the performance since commitBlock is a sync implementation
     auto self = weak_from_this();
-    m_ioServicePool->strand([self, blockHeader, _stableProposal]() {
+    m_strand->post([self, blockHeader, _stableProposal]() {
         auto storage = self.lock();
         if (!storage)
         {
@@ -397,7 +397,7 @@ void LedgerStorage::commitStableCheckPoint(PBFTProposalInterface::Ptr _stablePro
             // Note:Here the thread pool is used to asynchronize the operation of PBFT finalize to
             // prevent the commitBlock from calling the callback synchronously and affecting the
             // performance.
-            ledgerStorage->m_ioServicePool->strand(
+            ledgerStorage->m_strand->post(
                 [self, txsSize, _blockHeader, _ledgerConfig]() {
                     auto storage = self.lock();
                     if (!storage)

--- a/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.h
+++ b/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.h
@@ -42,7 +42,7 @@ public:
         m_storage(std::move(_storage)),
         m_blockFactory(std::move(_blockFactory)),
         m_messageFactory(std::move(_messageFactory)),
-        m_ioServicePool(std::move(_ioServicePool))
+        m_strand(std::make_shared<Strand>(std::move(_ioServicePool)))
     {
         createKVTable(m_pbftCommitDB);
     }
@@ -112,6 +112,6 @@ protected:
     std::function<void(bcos::ledger::LedgerConfig::Ptr, bool _syncBlock)> m_finalizeHandler;
     std::function<void(bcos::Error::Ptr&&, PBFTProposalInterface::Ptr)>
         m_onStableCheckPointCommitFailed;
-    bcos::IOServicePool::Ptr m_ioServicePool;
+    bcos::Strand::Ptr m_strand;
 };
 }  // namespace bcos::consensus

--- a/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.h
+++ b/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.h
@@ -24,7 +24,7 @@
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
 #include <bcos-framework/protocol/BlockFactory.h>
 #include <bcos-framework/storage/KVStorageHelper.h>
-#include <bcos-utilities/ThreadPool.h>
+#include <bcos-utilities/IOServicePool.h>
 
 #include <utility>
 
@@ -36,23 +36,18 @@ public:
     using Ptr = std::shared_ptr<LedgerStorage>;
     LedgerStorage(bcos::scheduler::SchedulerInterface::Ptr _scheduler,
         std::shared_ptr<bcos::storage::KVStorageHelper> _storage,
-        bcos::protocol::BlockFactory::Ptr _blockFactory, PBFTMessageFactory::Ptr _messageFactory)
+        bcos::protocol::BlockFactory::Ptr _blockFactory, PBFTMessageFactory::Ptr _messageFactory,
+        bcos::IOServicePool::Ptr _ioServicePool)
       : m_scheduler(std::move(_scheduler)),
         m_storage(std::move(_storage)),
         m_blockFactory(std::move(_blockFactory)),
-        m_messageFactory(std::move(_messageFactory))
+        m_messageFactory(std::move(_messageFactory)),
+        m_ioServicePool(std::move(_ioServicePool))
     {
         createKVTable(m_pbftCommitDB);
-        m_commitBlockWorker = std::make_shared<ThreadPool>("blockSubmit", 1);
     }
-    ~LedgerStorage() override { stop(); }
-    void stop() override
-    {
-        if (m_commitBlockWorker)
-        {
-            m_commitBlockWorker->stop();
-        }
-    }
+    ~LedgerStorage() override = default;
+
     void createKVTable(std::string const& _dbName);
     PBFTProposalListPtr loadState(bcos::protocol::BlockNumber _stabledIndex) override;
 
@@ -117,6 +112,6 @@ protected:
     std::function<void(bcos::ledger::LedgerConfig::Ptr, bool _syncBlock)> m_finalizeHandler;
     std::function<void(bcos::Error::Ptr&&, PBFTProposalInterface::Ptr)>
         m_onStableCheckPointCommitFailed;
-    std::shared_ptr<ThreadPool> m_commitBlockWorker;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace bcos::consensus

--- a/bcos-pbft/test/unittests/pbft/FIB112_OnExecuteFinishedRestoreTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB112_OnExecuteFinishedRestoreTest.cpp
@@ -111,7 +111,8 @@ BOOST_AUTO_TEST_CASE(callback_called_on_block_number_mismatch)
         cryptoSuite, headerFactory, txFactory, receiptFactory);
 
     auto scheduler = std::make_shared<MismatchedNumberScheduler>(blockFactory);
-    auto stateMachine = std::make_shared<StateMachine>(scheduler, blockFactory);
+    auto ioPool = std::make_shared<IOServicePool>(1, "fib112");
+    auto stateMachine = std::make_shared<StateMachine>(scheduler, blockFactory, ioPool);
 
     // lastApplied at index 1
     auto lastApplied = std::make_shared<Proposal>();

--- a/bcos-pbft/test/unittests/pbft/FIB124_NewViewPrePrepareCrosscheckTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB124_NewViewPrePrepareCrosscheckTest.cpp
@@ -46,8 +46,9 @@ class TestPBFTEngine : public FakePBFTEngine
 {
 public:
     using Ptr = std::shared_ptr<TestPBFTEngine>;
-    explicit TestPBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& io)
-      : FakePBFTEngine(_config, io)
+    explicit TestPBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& io,
+        bcos::IOServicePool::Ptr pool)
+      : FakePBFTEngine(_config, io, std::move(pool))
     {}
     bool testIsValidNewViewMsg(std::shared_ptr<NewViewMsgInterface> _msg)
     {
@@ -76,7 +77,8 @@ BOOST_AUTO_TEST_CASE(testRejectNewViewWithTamperedPrePrepareHash)
     auto verifierConfig = verifierFaker->pbftConfig();
 
     // Build a TestPBFTEngine backed by the verifier's config.
-    auto testEngine = std::make_shared<TestPBFTEngine>(verifierConfig, verifierFaker->ioContext());
+    auto ioPool = std::make_shared<IOServicePool>(1, "fib124");
+    auto testEngine = std::make_shared<TestPBFTEngine>(verifierConfig, verifierFaker->ioContext(), ioPool);
 
     // Advance to a higher view so that isValidNewViewMsg passes the view check.
     ViewType targetView = 1;

--- a/bcos-pbft/test/unittests/pbft/FIB127_LogRecoverySigCheckTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB127_LogRecoverySigCheckTest.cpp
@@ -45,8 +45,9 @@ class TestPBFTLogSync : public PBFTLogSync
 {
 public:
     using Ptr = std::shared_ptr<TestPBFTLogSync>;
-    TestPBFTLogSync(PBFTConfig::Ptr _config, PBFTCacheProcessor::Ptr _cache)
-      : PBFTLogSync(_config, _cache)
+    TestPBFTLogSync(PBFTConfig::Ptr _config, PBFTCacheProcessor::Ptr _cache,
+        bcos::IOServicePool::Ptr _pool)
+      : PBFTLogSync(_config, _cache, std::move(_pool))
     {}
     void testOnRecvCommittedProposalsResponse(bcos::Error::Ptr _error,
         bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data,
@@ -90,7 +91,8 @@ BOOST_AUTO_TEST_CASE(testDropProposalWithNoSigProofs)
     // Use the codec to produce the full PBFT packet format that decode() expects.
     auto encodedData = config->codec()->encode(responseMsg, config->pbftMsgDefaultVersion());
 
-    auto logSync = std::make_shared<TestPBFTLogSync>(config, cacheProcessor);
+    auto ioPool = std::make_shared<IOServicePool>(1, "fib127");
+    auto logSync = std::make_shared<TestPBFTLogSync>(config, cacheProcessor, ioPool);
 
     // Before: cache has no entry for blockNumber + 1.
     auto beforeSize = cacheProcessor->caches().size();
@@ -134,7 +136,8 @@ BOOST_AUTO_TEST_CASE(testDropProposalWithInsufficientWeight)
     responseMsg->setProposals({proposal});
     auto encodedData = config->codec()->encode(responseMsg, config->pbftMsgDefaultVersion());
 
-    auto logSync = std::make_shared<TestPBFTLogSync>(config, cacheProcessor);
+    auto ioPool2 = std::make_shared<IOServicePool>(1, "fib127b");
+    auto logSync = std::make_shared<TestPBFTLogSync>(config, cacheProcessor, ioPool2);
 
     auto beforeSize = cacheProcessor->caches().size();
     auto sender = cryptoSuite->signatureImpl()->generateKeyPair()->publicKey();
@@ -189,7 +192,8 @@ BOOST_AUTO_TEST_CASE(testDropProposalWithDuplicateSealerProofs)
     responseMsg->setProposals({proposal});
     auto encodedData = config->codec()->encode(responseMsg, config->pbftMsgDefaultVersion());
 
-    auto logSync = std::make_shared<TestPBFTLogSync>(config, cacheProcessor);
+    auto ioPool3 = std::make_shared<IOServicePool>(1, "fib127c");
+    auto logSync = std::make_shared<TestPBFTLogSync>(config, cacheProcessor, ioPool3);
 
     auto beforeSize = cacheProcessor->caches().size();
     auto sender = cryptoSuite->signatureImpl()->generateKeyPair()->publicKey();

--- a/bcos-pbft/test/unittests/pbft/FIB132_InFlightProposalDedupTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB132_InFlightProposalDedupTest.cpp
@@ -97,7 +97,8 @@ BOOST_AUTO_TEST_CASE(inflight_key_uniqueness_and_dedup)
     msg2->setConsensusProposal(pbftProposal2);
 
     // Create an InspectablePBFTEngine backed by leaderFaker's config
-    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext());
+    auto ioPool = std::make_shared<IOServicePool>(1, "fib132");
+    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext(), ioPool);
 
     auto key1 = engine->testInFlightKey(msg1);
     auto key1b = engine->testInFlightKey(msg1);
@@ -156,7 +157,8 @@ BOOST_AUTO_TEST_CASE(inflight_set_capped_under_flood)
     BlockNumber currentBlockNumber = 10;
     auto fakerMap = createFakers(cryptoSuite, 4, currentBlockNumber, 4);
     auto leaderFaker = fakerMap[0];
-    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext());
+    auto ioPool2 = std::make_shared<IOServicePool>(1, "fib132cap");
+    auto engine = std::make_shared<InspectablePBFTEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext(), ioPool2);
 
     // The cap constant must exist and equal 1024.
     BOOST_CHECK_EQUAL(PBFTEngine::c_maxInFlightProposals, 1024U);

--- a/bcos-pbft/test/unittests/pbft/FIB136_CheckSignatureNoExceptionTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB136_CheckSignatureNoExceptionTest.cpp
@@ -119,7 +119,8 @@ BOOST_AUTO_TEST_CASE(throwing_signature_backend_returns_invalid)
     auto leaderFaker = fakerMap[leaderIndex];
 
     // Build an engine with the leader's config
-    auto engine = std::make_shared<CheckSignatureEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext());
+    auto ioPool = std::make_shared<IOServicePool>(1, "fib136");
+    auto engine = std::make_shared<CheckSignatureEngine>(leaderFaker->pbftConfig(), leaderFaker->ioContext(), ioPool);
 
     // Create a ThrowingPBFTMessage whose verifySignature() throws.
     // Set generatedFrom=0 so that the leader node is found in the consensus node list.

--- a/bcos-pbft/test/unittests/pbft/FIB138_PromotionGateTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB138_PromotionGateTest.cpp
@@ -73,7 +73,7 @@ inline std::shared_ptr<FibPromotionPBFTImpl> makePromotionPBFTFib138(
     PBFTFixture::Ptr const& fixture)
 {
     auto pbftEngine = fixture->pbftEngine();
-    auto fakedPbft = std::make_shared<FibPromotionPBFTImpl>(pbftEngine);
+    auto fakedPbft = std::make_shared<FibPromotionPBFTImpl>(pbftEngine, fixture->ioServicePool());
     fakedPbft->setLedger(fixture->ledger());
     return fakedPbft;
 }

--- a/bcos-pbft/test/unittests/pbft/FIB139_AsyncCheckBlockSingleFireTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB139_AsyncCheckBlockSingleFireTest.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(CallbackFiredExactlyOnce_NormalPath)
     faker->init();
 
     auto config = faker->pbftConfig();
-    auto blockValidator = std::make_shared<BlockValidator>(config);
+    auto blockValidator = std::make_shared<BlockValidator>(config, faker->ioServicePool());
 
     // Genesis block (number == 0) fires the callback immediately with (nullptr, true).
     std::atomic<int> callCount{0};
@@ -68,7 +68,6 @@ BOOST_AUTO_TEST_CASE(CallbackFiredExactlyOnce_NormalPath)
     // Give the thread pool time to complete.
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     BOOST_CHECK_EQUAL(callCount.load(), 1);
-    blockValidator->stop();
 }
 
 // Test: callback is invoked exactly once when the callback itself throws.
@@ -84,7 +83,7 @@ BOOST_AUTO_TEST_CASE(CallbackFiredExactlyOnce_CallbackThrows)
     faker->init();
 
     auto config = faker->pbftConfig();
-    auto blockValidator = std::make_shared<BlockValidator>(config);
+    auto blockValidator = std::make_shared<BlockValidator>(config, faker->ioServicePool());
 
     // Genesis block fires immediately with true, then the callback throws.
     // Before the fix: outer catch catches that throw and calls the callback again → count == 2.
@@ -98,7 +97,6 @@ BOOST_AUTO_TEST_CASE(CallbackFiredExactlyOnce_CallbackThrows)
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     // Must be exactly 1 even though the callback threw.
     BOOST_CHECK_EQUAL(callCount.load(), 1);
-    blockValidator->stop();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-pbft/test/unittests/pbft/FIB140_PreparedProposalResponseSizeTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/FIB140_PreparedProposalResponseSizeTest.cpp
@@ -153,7 +153,8 @@ struct FIB140Fixture : public TestPromptFixture
         pbftFixture->init();
         auto config = pbftFixture->pbftConfig();
         auto cacheProcessor = pbftFixture->pbftEngine()->cacheProcessor();
-        logSync = std::make_shared<FakePBFTLogSync>(config, cacheProcessor);
+        logSync = std::make_shared<FakePBFTLogSync>(config, cacheProcessor,
+            std::make_shared<IOServicePool>(1, "fib140"));
         nodeID = cryptoSuite->signatureImpl()->generateKeyPair()->publicKey();
     }
 

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -165,7 +165,7 @@ public:
     using Ptr = std::shared_ptr<FakePBFTEngine>;
     explicit FakePBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& _ioContext,
         bcos::IOServicePool::Ptr _ioServicePool)
-      : PBFTEngine(_config, _ioContext, std::move(_ioServicePool))
+      : PBFTEngine(_config, _ioContext, _ioServicePool)
     {
         auto cacheFactory = std::make_shared<FakePBFTCacheFactory>();
         m_cacheProcessor = std::make_shared<FakeCacheProcessor>(cacheFactory, _config);

--- a/bcos-pbft/test/unittests/pbft/PBFTFixture.h
+++ b/bcos-pbft/test/unittests/pbft/PBFTFixture.h
@@ -163,12 +163,13 @@ class FakePBFTEngine : public PBFTEngine
 {
 public:
     using Ptr = std::shared_ptr<FakePBFTEngine>;
-    explicit FakePBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& _ioContext)
-      : PBFTEngine(_config, _ioContext)
+    explicit FakePBFTEngine(PBFTConfig::Ptr _config, boost::asio::io_context& _ioContext,
+        bcos::IOServicePool::Ptr _ioServicePool)
+      : PBFTEngine(_config, _ioContext, std::move(_ioServicePool))
     {
         auto cacheFactory = std::make_shared<FakePBFTCacheFactory>();
         m_cacheProcessor = std::make_shared<FakeCacheProcessor>(cacheFactory, _config);
-        m_logSync = std::make_shared<PBFTLogSync>(_config, m_cacheProcessor);
+        m_logSync = std::make_shared<PBFTLogSync>(_config, m_cacheProcessor, _ioServicePool);
         m_cacheProcessor->registerProposalAppliedHandler(
             [this](int64_t _errorCode, PBFTProposalInterface::Ptr _proposal,
                 PBFTProposalInterface::Ptr _executedProposal) {
@@ -225,7 +226,9 @@ public:
 class FakePBFTImpl : public PBFTImpl
 {
 public:
-    explicit FakePBFTImpl(PBFTEngine::Ptr _pbftEngine) : PBFTImpl(_pbftEngine)
+    explicit FakePBFTImpl(PBFTEngine::Ptr _pbftEngine,
+        bcos::IOServicePool::Ptr _ioServicePool)
+      : PBFTImpl(_pbftEngine, std::move(_ioServicePool))
     {
         m_running = true;
         m_masterNode.store(true);
@@ -250,29 +253,30 @@ public:
         std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
         bcos::scheduler::SchedulerInterface::Ptr _scheduler,
         bcos::txpool::TxPoolInterface::Ptr _txpool, bcos::protocol::BlockFactory::Ptr _blockFactory,
-        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory)
+        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+        bcos::IOServicePool::Ptr _ioServicePool)
       : PBFTFactory(_ioService, _cryptoSuite, _keyPair, _frontService, _storage, _ledger,
-            _scheduler, _txpool, _blockFactory, _txResultFactory)
+            _scheduler, _txpool, _blockFactory, _txResultFactory, std::move(_ioServicePool))
     {}
 
     PBFTImpl::Ptr createPBFT() override
     {
         auto pbft = PBFTFactory::createPBFT();
         auto orgPBFTConfig = pbft->pbftEngine()->pbftConfig();
-        auto stateMachine = std::make_shared<StateMachine>(m_scheduler, m_blockFactory);
+        auto stateMachine = std::make_shared<StateMachine>(m_scheduler, m_blockFactory, m_ioServicePool);
 
         PBFT_LOG(DEBUG) << LOG_DESC("create pbftStorage");
         auto pbftStorage = std::make_shared<LedgerStorage>(
-            m_scheduler, m_storage, m_blockFactory, orgPBFTConfig->pbftMessageFactory());
+            m_scheduler, m_storage, m_blockFactory, orgPBFTConfig->pbftMessageFactory(), m_ioServicePool);
 
         auto pbftConfig = std::make_shared<FakePBFTConfig>(m_ioService, m_cryptoSuite, m_keyPair,
             orgPBFTConfig->pbftMessageFactory(), orgPBFTConfig->codec(), orgPBFTConfig->validator(),
             orgPBFTConfig->frontService(), stateMachine, pbftStorage, m_blockFactory);
         PBFT_LOG(DEBUG) << LOG_DESC("create PBFTEngine");
-        auto pbftEngine = std::make_shared<FakePBFTEngine>(pbftConfig, m_ioService);
+        auto pbftEngine = std::make_shared<FakePBFTEngine>(pbftConfig, m_ioService, m_ioServicePool);
 
         PBFT_LOG(INFO) << LOG_DESC("create PBFT");
-        auto fakedPBFT = std::make_shared<FakePBFTImpl>(pbftEngine);
+        auto fakedPBFT = std::make_shared<FakePBFTImpl>(pbftEngine, m_ioServicePool);
         fakedPBFT->setLedger(m_ledger);
         pbftConfig->setTimeoutState(false);
         pbftConfig->timer()->stop();
@@ -323,7 +327,7 @@ public:
 
         auto pbftFactory = std::make_shared<FakePBFTFactory>(*m_ioServicePool->getIOService(),
             _cryptoSuite, _keyPair, m_frontService, m_storage, m_ledger, m_scheduler, m_txpool,
-            m_blockFactory, txResultFactory);
+            m_blockFactory, txResultFactory, m_ioServicePool);
         m_pbft = pbftFactory->createPBFT();
         m_pbftEngine = std::dynamic_pointer_cast<FakePBFTEngine>(m_pbft->pbftEngine());
         m_pbft->registerFaultyDiscriminator([](bcos::crypto::NodeIDPtr) { return false; });
@@ -403,6 +407,7 @@ public:
 
     BlockFactory::Ptr blockFactory() { return m_blockFactory; }
     boost::asio::io_context& ioContext() { return *m_ioServicePool->getIOService(); }
+    bcos::IOServicePool::Ptr ioServicePool() { return m_ioServicePool; }
 
 private:
     // Must be declared first so io_context outlives all Workers using it

--- a/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.cpp
+++ b/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.cpp
@@ -41,11 +41,11 @@ PBFTImpl::Ptr RPBFTFactory::createRPBFT()
     auto validator = std::make_shared<TxsValidator>(m_txpool, m_blockFactory, m_txResultFactory);
 
     PBFT_LOG(DEBUG) << LOG_DESC("create StateMachine");
-    auto stateMachine = std::make_shared<StateMachine>(m_scheduler, m_blockFactory);
+    auto stateMachine = std::make_shared<StateMachine>(m_scheduler, m_blockFactory, m_ioServicePool);
 
     PBFT_LOG(INFO) << LOG_DESC("create pbftStorage");
     auto pbftStorage =
-        std::make_shared<LedgerStorage>(m_scheduler, m_storage, m_blockFactory, pbftMessageFactory);
+        std::make_shared<LedgerStorage>(m_scheduler, m_storage, m_blockFactory, pbftMessageFactory, m_ioServicePool);
 
     PBFT_LOG(INFO) << LOG_DESC("create rPBFTConfig");
     PBFTConfig::Ptr rpbftConfig =
@@ -53,10 +53,10 @@ PBFTImpl::Ptr RPBFTFactory::createRPBFT()
             validator, m_frontService, stateMachine, pbftStorage, m_blockFactory);
 
     PBFT_LOG(INFO) << LOG_DESC("create rPBFTEngine");
-    auto pbftEngine = std::make_shared<PBFTEngine>(rpbftConfig, m_ioService);
+    auto pbftEngine = std::make_shared<PBFTEngine>(rpbftConfig, m_ioService, m_ioServicePool);
 
     PBFT_LOG(INFO) << LOG_DESC("create rPBFT");
-    auto pbft = std::make_shared<PBFTImpl>(pbftEngine);
+    auto pbft = std::make_shared<PBFTImpl>(pbftEngine, m_ioServicePool);
     pbft->setLedger(m_ledger);
     return pbft;
 }

--- a/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.h
+++ b/bcos-rpbft/bcos-rpbft/rpbft/utilities/RPBFTFactory.h
@@ -41,11 +41,12 @@ public:
         std::shared_ptr<bcos::ledger::LedgerInterface> _ledger,
         bcos::scheduler::SchedulerInterface::Ptr _scheduler,
         bcos::txpool::TxPoolInterface::Ptr _txpool, bcos::protocol::BlockFactory::Ptr _blockFactory,
-        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory)
+        bcos::protocol::TransactionSubmitResultFactory::Ptr _txResultFactory,
+        bcos::IOServicePool::Ptr _ioServicePool)
       : PBFTFactory(_ioService, std::move(_cryptoSuite), std::move(_keyPair),
             std::move(_frontService), std::move(_storage), std::move(_ledger),
             std::move(_scheduler), std::move(_txpool), std::move(_blockFactory),
-            std::move(_txResultFactory))
+            std::move(_txResultFactory), std::move(_ioServicePool))
     {}
     RPBFTFactory& operator=(const RPBFTFactory&) = delete;
     RPBFTFactory(const RPBFTFactory&) = delete;

--- a/bcos-rpbft/test/unittests/config/RPBFTConfigTest.cpp
+++ b/bcos-rpbft/test/unittests/config/RPBFTConfigTest.cpp
@@ -73,7 +73,7 @@ public:
 
         auto rpbftFactory = std::make_shared<RPBFTFactory>(*m_ioServicePool->getIOService(),
             m_cryptoSuite, m_keyPair, m_frontService, m_storage, m_ledger, m_scheduler, m_txpool,
-            m_blockFactory, txResultFactory);
+            m_blockFactory, txResultFactory, m_ioServicePool);
         m_rpbft = rpbftFactory->createRPBFT();
         m_rpbftConfig = std::dynamic_pointer_cast<RPBFTConfig>(m_rpbft->pbftEngine()->pbftConfig());
     }

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -39,14 +39,14 @@ using namespace bcos::ledger;
 using namespace bcos::tool;
 
 BlockSync::BlockSync(
-    BlockSyncConfig::Ptr _config, boost::asio::io_context& _ioContext, unsigned _idleWaitMs)
+    BlockSyncConfig::Ptr _config, boost::asio::io_context& _ioContext,
+    bcos::IOServicePool::Ptr _ioServicePool, unsigned _idleWaitMs)
   : Worker(_ioContext, "syncWorker", _idleWaitMs),
     m_config(_config),
     m_syncStatus(std::make_shared<SyncPeerStatus>(_config)),
-    m_downloadingQueue(std::make_shared<DownloadingQueue>(_config))
+    m_downloadingQueue(std::make_shared<DownloadingQueue>(_config)),
+    m_ioServicePool(std::move(_ioServicePool))
 {
-    m_downloadBlockProcessor = std::make_shared<bcos::ThreadPool>("Download", 1);
-    m_sendBlockProcessor = std::make_shared<bcos::ThreadPool>("SyncSend", 1);
     m_downloadingTimer =
         std::make_shared<Timer>(_ioContext, m_config->downloadTimeout(), "downloadTimer");
 
@@ -162,14 +162,6 @@ void BlockSync::stop()
         return;
     }
     BLKSYNC_LOG(INFO) << LOG_DESC("Stop BlockSync");
-    if (m_downloadBlockProcessor)
-    {
-        m_downloadBlockProcessor->stop();
-    }
-    if (m_sendBlockProcessor)
-    {
-        m_sendBlockProcessor->stop();
-    }
     if (m_downloadingTimer)
     {
         m_downloadingTimer->destroy();
@@ -220,7 +212,7 @@ void BlockSync::executeWorker()
     }
     // maintain the connections between observers/sealers
     maintainPeersConnection();
-    m_downloadBlockProcessor->enqueue([this]() {
+    m_ioServicePool->strand([this]() {
         try
         {
             // flush downloaded buffer into downloading queue
@@ -249,7 +241,7 @@ void BlockSync::executeWorker()
         }
     });
     // send block to other nodes
-    m_sendBlockProcessor->enqueue([this]() {
+    m_ioServicePool->strand([this]() {
         try
         {
             maintainBlockRequest();

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -212,25 +212,31 @@ void BlockSync::executeWorker()
     }
     // maintain the connections between observers/sealers
     maintainPeersConnection();
-    m_strand->post([this]() {
+    auto self = weak_from_this();
+    m_strand->post([self]() {
+        auto sync = self.lock();
+        if (!sync)
+        {
+            return;
+        }
         try
         {
             // flush downloaded buffer into downloading queue
-            maintainDownloadingBuffer();
-            maintainDownloadingQueue();
+            sync->maintainDownloadingBuffer();
+            sync->maintainDownloadingQueue();
 
             // send block-download-request to peers if this node is behind others
-            tryToRequestBlocks();
+            sync->tryToRequestBlocks();
 
-            if (m_config->syncArchivedBlockBody())
+            if (sync->m_config->syncArchivedBlockBody())
             {
-                auto archivedBlockNumber = m_config->archiveBlockNumber();
+                auto archivedBlockNumber = sync->m_config->archiveBlockNumber();
                 if (archivedBlockNumber == 0)
                 {
                     return;
                 }
-                syncArchivedBlockBody(archivedBlockNumber);
-                verifyAndCommitArchivedBlock(archivedBlockNumber);
+                sync->syncArchivedBlockBody(archivedBlockNumber);
+                sync->verifyAndCommitArchivedBlock(archivedBlockNumber);
             }
         }
         catch (std::exception const& e)
@@ -241,10 +247,15 @@ void BlockSync::executeWorker()
         }
     });
     // send block to other nodes
-    m_strand->post([this]() {
+    m_strand->post([self]() {
+        auto sync = self.lock();
+        if (!sync)
+        {
+            return;
+        }
         try
         {
-            maintainBlockRequest();
+            sync->maintainBlockRequest();
         }
         catch (std::exception const& e)
         {

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -45,7 +45,7 @@ BlockSync::BlockSync(
     m_config(_config),
     m_syncStatus(std::make_shared<SyncPeerStatus>(_config)),
     m_downloadingQueue(std::make_shared<DownloadingQueue>(_config)),
-    m_ioServicePool(std::move(_ioServicePool))
+    m_strand(std::make_shared<Strand>(std::move(_ioServicePool)))
 {
     m_downloadingTimer =
         std::make_shared<Timer>(_ioContext, m_config->downloadTimeout(), "downloadTimer");
@@ -212,7 +212,7 @@ void BlockSync::executeWorker()
     }
     // maintain the connections between observers/sealers
     maintainPeersConnection();
-    m_ioServicePool->strand([this]() {
+    m_strand->post([this]() {
         try
         {
             // flush downloaded buffer into downloading queue
@@ -241,7 +241,7 @@ void BlockSync::executeWorker()
         }
     });
     // send block to other nodes
-    m_ioServicePool->strand([this]() {
+    m_strand->post([this]() {
         try
         {
             maintainBlockRequest();

--- a/bcos-sync/bcos-sync/BlockSync.h
+++ b/bcos-sync/bcos-sync/BlockSync.h
@@ -26,7 +26,7 @@
 #include "bcos-sync/utilities/SyncTreeTopology.h"
 #include "bcos-tool/NodeTimeMaintenance.h"
 #include <bcos-framework/sync/BlockSyncInterface.h>
-#include <bcos-utilities/ThreadPool.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/Timer.h>
 #include <bcos-utilities/Worker.h>
 namespace bcos::sync
@@ -39,7 +39,7 @@ public:
     using Ptr = std::shared_ptr<BlockSync>;
     // FIXME: make idle configable
     BlockSync(BlockSyncConfig::Ptr _config, boost::asio::io_context& _ioContext,
-        unsigned _idleWaitMs = 200);
+        bcos::IOServicePool::Ptr _ioServicePool, unsigned _idleWaitMs = 200);
     ~BlockSync() override = default;
 
     void start() override;
@@ -151,8 +151,7 @@ protected:
     std::function<void(std::string const&, int, bcos::crypto::NodeIDPtr, bytesConstRef)>
         m_sendResponseHandler;
 
-    bcos::ThreadPool::Ptr m_downloadBlockProcessor = nullptr;
-    bcos::ThreadPool::Ptr m_sendBlockProcessor = nullptr;
+    bcos::IOServicePool::Ptr m_ioServicePool = nullptr;
     std::shared_ptr<Timer> m_downloadingTimer;
 
     std::atomic_bool m_running = {false};

--- a/bcos-sync/bcos-sync/BlockSync.h
+++ b/bcos-sync/bcos-sync/BlockSync.h
@@ -151,7 +151,7 @@ protected:
     std::function<void(std::string const&, int, bcos::crypto::NodeIDPtr, bytesConstRef)>
         m_sendResponseHandler;
 
-    bcos::IOServicePool::Ptr m_ioServicePool = nullptr;
+    bcos::Strand::Ptr m_strand = nullptr;
     std::shared_ptr<Timer> m_downloadingTimer;
 
     std::atomic_bool m_running = {false};

--- a/bcos-sync/bcos-sync/BlockSyncFactory.cpp
+++ b/bcos-sync/bcos-sync/BlockSyncFactory.cpp
@@ -47,12 +47,13 @@ BlockSyncFactory::BlockSyncFactory(bcos::crypto::PublicPtr _nodeId,
     m_syncArchivedBlockBody(_syncArchivedBlockBody)
 {}
 
-BlockSync::Ptr BlockSyncFactory::createBlockSync(boost::asio::io_context& _ioContext)
+BlockSync::Ptr BlockSyncFactory::createBlockSync(boost::asio::io_context& _ioContext,
+    bcos::IOServicePool::Ptr _ioServicePool)
 {
     auto msgFactory = std::make_shared<BlockSyncMsgFactoryImpl>();
     auto syncConfig = std::make_shared<BlockSyncConfig>(m_nodeId, m_ledger, m_txpool,
         m_blockFactory, m_txResultFactory, m_frontService, m_scheduler, m_consensus, msgFactory,
         m_nodeTimeMaintenance, m_enableSendBlockStatusByTree, m_syncTreeWidth,
         m_syncArchivedBlockBody);
-    return std::make_shared<BlockSync>(syncConfig, _ioContext);
+    return std::make_shared<BlockSync>(syncConfig, _ioContext, std::move(_ioServicePool));
 }

--- a/bcos-sync/bcos-sync/BlockSyncFactory.h
+++ b/bcos-sync/bcos-sync/BlockSyncFactory.h
@@ -41,7 +41,8 @@ public:
         bool _syncArchivedBlockBody = false);
     virtual ~BlockSyncFactory() = default;
 
-    virtual BlockSync::Ptr createBlockSync(boost::asio::io_context& _ioContext);
+    virtual BlockSync::Ptr createBlockSync(boost::asio::io_context& _ioContext,
+        bcos::IOServicePool::Ptr _ioServicePool);
 
 private:
     bcos::crypto::PublicPtr m_nodeId;

--- a/bcos-sync/test/unittests/sync/SyncFixture.h
+++ b/bcos-sync/test/unittests/sync/SyncFixture.h
@@ -47,8 +47,8 @@ class FakeBlockSync : public BlockSync
 public:
     using Ptr = std::shared_ptr<FakeBlockSync>;
     FakeBlockSync(BlockSyncConfig::Ptr _config, boost::asio::io_context& _ioContext,
-        unsigned _idleWaitMs = 200)
-      : BlockSync(_config, _ioContext, _idleWaitMs)
+        bcos::IOServicePool::Ptr _ioServicePool, unsigned _idleWaitMs = 200)
+      : BlockSync(_config, _ioContext, std::move(_ioServicePool), _idleWaitMs)
     {
         m_running = true;
         enableAsMaster(true);
@@ -90,10 +90,13 @@ public:
             _nodeTimeMaintenance)
     {}
 
-    BlockSync::Ptr createBlockSync(boost::asio::io_context& _ioContext) override
+    BlockSync::Ptr createBlockSync(boost::asio::io_context& _ioContext,
+        bcos::IOServicePool::Ptr _ioServicePool) override
     {
-        auto sync = BlockSyncFactory::createBlockSync(_ioContext);
-        return std::make_shared<FakeBlockSync>(sync->config(), _ioContext);
+        auto pool = _ioServicePool;  // keep a copy before move
+        auto sync = BlockSyncFactory::createBlockSync(_ioContext, std::move(_ioServicePool));
+        return std::make_shared<FakeBlockSync>(
+            sync->config(), _ioContext, std::move(pool));
     }
 };
 
@@ -123,7 +126,7 @@ public:
             std::make_shared<FakeBlockSyncFactory>(m_keyPair->publicKey(), m_blockFactory, m_ledger,
                 m_frontService, m_scheduler, m_consensus, m_nodeTimeMaintenance);
         m_sync = std::dynamic_pointer_cast<FakeBlockSync>(
-            blockSyncFactory->createBlockSync(*m_ioServicePool->getIOService()));
+            blockSyncFactory->createBlockSync(*m_ioServicePool->getIOService(), m_ioServicePool));
         if (_fakeGateWay)
         {
             _fakeGateWay->addSync(m_keyPair->publicKey(), m_sync);

--- a/bcos-utilities/bcos-utilities/IOServicePool.cpp
+++ b/bcos-utilities/bcos-utilities/IOServicePool.cpp
@@ -37,6 +37,13 @@ IOServicePool::IOServicePool(size_t _workerNum, std::string_view _threadName)
 
 IOServicePool::~IOServicePool()
 {
+    // Stop accepting new strand tasks and drain the pending queue so that
+    // no drain handler accesses members after they are destroyed.
+    {
+        std::lock_guard<std::mutex> lock(m_strandMutex);
+        m_strandQueue.clear();
+        m_strandBusy = false;
+    }
     for (auto& ctx : m_contexts)
     {
         ctx.ioService->stop();
@@ -84,6 +91,11 @@ void IOServicePool::drainStrand()
     bool hasMore = false;
     {
         std::lock_guard<std::mutex> lock(m_strandMutex);
+        if (m_strandQueue.empty())
+        {
+            m_strandBusy = false;
+            return;
+        }
         task = std::move(m_strandQueue.front());
         m_strandQueue.pop_front();
         hasMore = !m_strandQueue.empty();

--- a/bcos-utilities/bcos-utilities/IOServicePool.cpp
+++ b/bcos-utilities/bcos-utilities/IOServicePool.cpp
@@ -78,13 +78,13 @@ void Strand::Impl::kick()
     auto self = pool.lock();
     if (!self)
     {
-        // Pool is gone — clear queue and bail out.
+        // Pool is gone — clear queue and reset count.
         std::lock_guard<std::mutex> lock(mutex);
         queue.clear();
-        busy = false;
+        count_.store(0, std::memory_order_release);
         return;
     }
-    // Capture a shared_ptr to Impl so that the queue / mutex / busy stay
+    // Capture a shared_ptr to Impl so that the queue / mutex / count_ stay
     // alive even if the owning Strand is destroyed before this handler runs.
     std::shared_ptr<Impl> impl = shared_from_this();
     self->post([impl]() { impl->drain(); });
@@ -95,26 +95,32 @@ void Strand::Impl::drain()
     std::function<void()> task;
     {
         std::lock_guard<std::mutex> lock(mutex);
-        if (queue.empty())
-        {
-            busy = false;
-            return;
-        }
+        // count_ > 0 guarantees the queue is non-empty (post() enqueues
+        // before fetch_add), so this pop is always safe.
         task = std::move(queue.front());
         queue.pop_front();
     }
-    task();
-    // Re-check queue AFTER task completes.  If a new task was enqueued while
-    // we were executing task(), the queue is non-empty and we kick the next
-    // drain.  Only set busy=false when the queue is truly empty — this
-    // closes the race where busy was cleared before task() finished.
+    IOServicePool::safeExecute(std::move(task));
+
+    // Atomically release our "running" slot.  fetch_sub returns the value
+    // *before* subtraction.
+    if (auto prev = count_.fetch_sub(1, std::memory_order_acq_rel); prev == 1)
     {
+        // Only our running slot existed — no new tasks were posted during
+        // execution.  Verify under lock to close a narrow race: a post()
+        // between our fetch_sub and the lock below.
         std::lock_guard<std::mutex> lock(mutex);
         if (queue.empty())
         {
-            busy = false;
-            return;
+            return;  // Truly done.
         }
+        // A post() snuck in and already called kick() for us (it saw
+        // count_ go from 0 to 1).  Restore the running count so the
+        // already-posted drain can proceed, and return without kicking.
+        count_.fetch_add(1, std::memory_order_relaxed);
+        return;
     }
+    // prev > 1: more tasks were definitely enqueued during our execution.
+    // No lock needed here — just kick the next drain.
     kick();
 }

--- a/bcos-utilities/bcos-utilities/IOServicePool.cpp
+++ b/bcos-utilities/bcos-utilities/IOServicePool.cpp
@@ -37,13 +37,6 @@ IOServicePool::IOServicePool(size_t _workerNum, std::string_view _threadName)
 
 IOServicePool::~IOServicePool()
 {
-    // Stop accepting new strand tasks and drain the pending queue so that
-    // no drain handler accesses members after they are destroyed.
-    {
-        std::lock_guard<std::mutex> lock(m_strandMutex);
-        m_strandQueue.clear();
-        m_strandBusy = false;
-    }
     for (auto& ctx : m_contexts)
     {
         ctx.ioService->stop();
@@ -80,33 +73,48 @@ bcos::IOServicePool::IOServiceContext::IOServiceContext(std::shared_ptr<IOServic
   : ioService(std::move(_ioService)), work(this->ioService->get_executor())
 {}
 
-void IOServicePool::kickStrand()
+void Strand::Impl::kick()
 {
-    post([this]() { drainStrand(); });
+    auto self = pool.lock();
+    if (!self)
+    {
+        // Pool is gone — clear queue and bail out.
+        std::lock_guard<std::mutex> lock(mutex);
+        queue.clear();
+        busy = false;
+        return;
+    }
+    // Capture a shared_ptr to Impl so that the queue / mutex / busy stay
+    // alive even if the owning Strand is destroyed before this handler runs.
+    std::shared_ptr<Impl> impl = shared_from_this();
+    self->post([impl]() { impl->drain(); });
 }
 
-void IOServicePool::drainStrand()
+void Strand::Impl::drain()
 {
     std::function<void()> task;
-    bool hasMore = false;
     {
-        std::lock_guard<std::mutex> lock(m_strandMutex);
-        if (m_strandQueue.empty())
+        std::lock_guard<std::mutex> lock(mutex);
+        if (queue.empty())
         {
-            m_strandBusy = false;
+            busy = false;
             return;
         }
-        task = std::move(m_strandQueue.front());
-        m_strandQueue.pop_front();
-        hasMore = !m_strandQueue.empty();
-        if (!hasMore)
-        {
-            m_strandBusy = false;
-        }
+        task = std::move(queue.front());
+        queue.pop_front();
     }
     task();
-    if (hasMore)
+    // Re-check queue AFTER task completes.  If a new task was enqueued while
+    // we were executing task(), the queue is non-empty and we kick the next
+    // drain.  Only set busy=false when the queue is truly empty — this
+    // closes the race where busy was cleared before task() finished.
     {
-        kickStrand();
+        std::lock_guard<std::mutex> lock(mutex);
+        if (queue.empty())
+        {
+            busy = false;
+            return;
+        }
     }
+    kick();
 }

--- a/bcos-utilities/bcos-utilities/IOServicePool.cpp
+++ b/bcos-utilities/bcos-utilities/IOServicePool.cpp
@@ -72,3 +72,29 @@ std::shared_ptr<IOServicePool::IOService>& IOServicePool::getIOService()
 bcos::IOServicePool::IOServiceContext::IOServiceContext(std::shared_ptr<IOService> _ioService)
   : ioService(std::move(_ioService)), work(this->ioService->get_executor())
 {}
+
+void IOServicePool::kickStrand()
+{
+    post([this]() { drainStrand(); });
+}
+
+void IOServicePool::drainStrand()
+{
+    std::function<void()> task;
+    bool hasMore = false;
+    {
+        std::lock_guard<std::mutex> lock(m_strandMutex);
+        task = std::move(m_strandQueue.front());
+        m_strandQueue.pop_front();
+        hasMore = !m_strandQueue.empty();
+        if (!hasMore)
+        {
+            m_strandBusy = false;
+        }
+    }
+    task();
+    if (hasMore)
+    {
+        kickStrand();
+    }
+}

--- a/bcos-utilities/bcos-utilities/IOServicePool.h
+++ b/bcos-utilities/bcos-utilities/IOServicePool.h
@@ -29,6 +29,74 @@
 #include <thread>
 namespace bcos
 {
+class IOServicePool;
+
+// Standalone serial task dispatcher that wraps an IOServicePool.
+// Tasks submitted via post() are guaranteed to execute in FIFO order
+// and never concurrently, while still being round-robin dispatched
+// across the pool's io_contexts.  Multiple Strand instances can coexist
+// independently — each serializes its own tasks without blocking others.
+//
+// Lifetime: the Strand can be safely destroyed even when drain handlers
+// are still queued in the pool — the inner Impl struct is kept alive by
+// the posted handlers until the queue is fully drained.
+class Strand
+{
+    struct Impl : public std::enable_shared_from_this<Impl>
+    {
+        std::weak_ptr<IOServicePool> pool;
+        std::deque<std::function<void()>> queue;
+        std::mutex mutex;
+        bool busy{false};
+
+        void kick();
+        void drain();
+    };
+
+public:
+    using Ptr = std::shared_ptr<Strand>;
+
+    explicit Strand(const std::shared_ptr<IOServicePool>& pool)
+    {
+        m_impl = std::make_shared<Impl>();
+        m_impl->pool = pool;
+    }
+
+    ~Strand()
+    {
+        std::lock_guard<std::mutex> lock(m_impl->mutex);
+        m_impl->queue.clear();
+        m_impl->busy = false;
+    }
+
+    Strand(const Strand&) = delete;
+    Strand& operator=(const Strand&) = delete;
+    Strand(Strand&&) = delete;
+    Strand& operator=(Strand&&) = delete;
+
+    template <class Task>
+    void post(Task&& task)
+    {
+        bool needKick = false;
+        {
+            std::lock_guard<std::mutex> lock(m_impl->mutex);
+            m_impl->queue.emplace_back(std::forward<Task>(task));
+            needKick = !m_impl->busy;
+            if (needKick)
+            {
+                m_impl->busy = true;
+            }
+        }
+        if (needKick)
+        {
+            m_impl->kick();
+        }
+    }
+
+private:
+    std::shared_ptr<Impl> m_impl;
+};
+
 class IOServicePool
 {
 public:
@@ -69,31 +137,6 @@ public:
         }
     }
 
-    // Submit a task that is guaranteed to execute serially with respect to
-    // other tasks submitted via strand() (FIFO order).  Unlike
-    // boost::asio::strand which binds to a single executor, this
-    // implementation round-robins each task across the pool's io_contexts
-    // so that strand work is spread over all threads while never executing
-    // two strand tasks concurrently.
-    template <class Task>
-    void strand(Task&& task)
-    {
-        bool needKick = false;
-        {
-            std::lock_guard<std::mutex> lock(m_strandMutex);
-            m_strandQueue.emplace_back(std::forward<Task>(task));
-            needKick = !m_strandBusy;
-            if (needKick)
-            {
-                m_strandBusy = true;
-            }
-        }
-        if (needKick)
-        {
-            kickStrand();
-        }
-    }
-
 private:
     struct IOServiceContext
     {
@@ -103,18 +146,10 @@ private:
 
         explicit IOServiceContext(std::shared_ptr<IOService> _ioService);
     };
-    void kickStrand();
-    void drainStrand();
 
     std::vector<IOServiceContext> m_contexts;
     std::vector<std::thread::id> m_threadIds;
     std::string m_threadName;
     std::atomic_size_t m_nextIOService = 0;
-
-    // Custom strand: deque-based serial task queue with round-robin dispatch
-    // across all pool io_contexts.  Only one task is in-flight at a time.
-    std::deque<std::function<void()>> m_strandQueue;
-    std::mutex m_strandMutex;
-    bool m_strandBusy{false};
 };
 }  // namespace bcos

--- a/bcos-utilities/bcos-utilities/IOServicePool.h
+++ b/bcos-utilities/bcos-utilities/IOServicePool.h
@@ -19,7 +19,10 @@
 
 #pragma once
 #include <boost/asio.hpp>
+#include <deque>
+#include <functional>
 #include <memory>
+#include <mutex>
 #include <range/v3/algorithm/binary_search.hpp>
 #include <string>
 #include <string_view>
@@ -66,6 +69,31 @@ public:
         }
     }
 
+    // Submit a task that is guaranteed to execute serially with respect to
+    // other tasks submitted via strand() (FIFO order).  Unlike
+    // boost::asio::strand which binds to a single executor, this
+    // implementation round-robins each task across the pool's io_contexts
+    // so that strand work is spread over all threads while never executing
+    // two strand tasks concurrently.
+    template <class Task>
+    void strand(Task&& task)
+    {
+        bool needKick = false;
+        {
+            std::lock_guard<std::mutex> lock(m_strandMutex);
+            m_strandQueue.emplace_back(std::forward<Task>(task));
+            needKick = !m_strandBusy;
+            if (needKick)
+            {
+                m_strandBusy = true;
+            }
+        }
+        if (needKick)
+        {
+            kickStrand();
+        }
+    }
+
 private:
     struct IOServiceContext
     {
@@ -75,9 +103,18 @@ private:
 
         explicit IOServiceContext(std::shared_ptr<IOService> _ioService);
     };
+    void kickStrand();
+    void drainStrand();
+
     std::vector<IOServiceContext> m_contexts;
     std::vector<std::thread::id> m_threadIds;
     std::string m_threadName;
     std::atomic_size_t m_nextIOService = 0;
+
+    // Custom strand: deque-based serial task queue with round-robin dispatch
+    // across all pool io_contexts.  Only one task is in-flight at a time.
+    std::deque<std::function<void()>> m_strandQueue;
+    std::mutex m_strandMutex;
+    bool m_strandBusy{false};
 };
 }  // namespace bcos

--- a/bcos-utilities/bcos-utilities/IOServicePool.h
+++ b/bcos-utilities/bcos-utilities/IOServicePool.h
@@ -18,7 +18,10 @@
  */
 
 #pragma once
+#include "BoostLog.h"
 #include <boost/asio.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+#include <atomic>
 #include <deque>
 #include <functional>
 #include <memory>
@@ -47,7 +50,11 @@ class Strand
         std::weak_ptr<IOServicePool> pool;
         std::deque<std::function<void()>> queue;
         std::mutex mutex;
-        bool busy{false};
+        // 0 = idle, 1 = a drain is running (no waiting tasks),
+        // >1 = drain running + (count_-1) waiting tasks.
+        // Managed with atomic CAS to reduce mutex contention between
+        // post() and drain(), following boost::asio::strand's pattern.
+        std::atomic<int> count_{0};
 
         void kick();
         void drain();
@@ -66,7 +73,7 @@ public:
     {
         std::lock_guard<std::mutex> lock(m_impl->mutex);
         m_impl->queue.clear();
-        m_impl->busy = false;
+        m_impl->count_.store(0, std::memory_order_release);
     }
 
     Strand(const Strand&) = delete;
@@ -77,17 +84,14 @@ public:
     template <class Task>
     void post(Task&& task)
     {
-        bool needKick = false;
         {
             std::lock_guard<std::mutex> lock(m_impl->mutex);
             m_impl->queue.emplace_back(std::forward<Task>(task));
-            needKick = !m_impl->busy;
-            if (needKick)
-            {
-                m_impl->busy = true;
-            }
         }
-        if (needKick)
+        // Atomically claim a slot.  If count was 0 (idle), we must kick.
+        // acq_rel: acquire to see prior drain completion, release so that
+        // drain()'s fetch_sub sees our increment.
+        if (m_impl->count_.fetch_add(1, std::memory_order_acq_rel) == 0)
         {
             m_impl->kick();
         }
@@ -120,7 +124,9 @@ public:
     void post(Task&& task)
     {
         auto& ioService = getIOService();
-        boost::asio::post(ioService->get_executor(), std::forward<Task>(task));
+        boost::asio::post(ioService->get_executor(), [task = std::forward<Task>(task)]() mutable {
+            IOServicePool::safeExecute(std::move(task));
+        });
     }
 
     template <class Task>
@@ -129,11 +135,34 @@ public:
         auto id = std::this_thread::get_id();
         if (::ranges::binary_search(m_threadIds, id))
         {
-            task();
+            IOServicePool::safeExecute(std::forward<Task>(task));
         }
         else
         {
             post(std::forward<Task>(task));
+        }
+    }
+
+    // Shared exception guard: wraps a task so that a throw inside it
+    // does not kill the pool thread or strand.  Used by both
+    // IOServicePool::post/dispatch and Strand::Impl::drain.
+    template <class Task>
+    static void safeExecute(Task task)
+    {
+        try
+        {
+            task();
+        }
+        catch (std::exception const& e)
+        {
+            BCOS_LOG(WARNING) << LOG_DESC("Exception in IOServicePool task")
+                              << LOG_KV("message", boost::diagnostic_information(e));
+        }
+        catch (...)
+        {
+            BCOS_LOG(WARNING) << LOG_DESC("Unknown exception in IOServicePool task")
+                              << LOG_KV(
+                                     "message", boost::current_exception_diagnostic_information());
         }
     }
 

--- a/bcos-utilities/test/CMakeLists.txt
+++ b/bcos-utilities/test/CMakeLists.txt
@@ -30,5 +30,6 @@ target_link_libraries(${TEST_BINARY_NAME} PRIVATE bcos-utilities bcos-crypto Boo
 set_source_files_properties("unittests/main/main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties("unittests/libutilities/TestBoostLog.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties("unittests/libutilities/TestFixedBytes.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+set_source_files_properties("unittests/libutilities/IOServicePoolTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" ${TEST_BINARY_NAME} "" "")

--- a/bcos-utilities/test/unittests/libutilities/IOServicePoolTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/IOServicePoolTest.cpp
@@ -1,0 +1,220 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief unit tests for IOServicePool strand()
+ *
+ * @file IOServicePoolTest.cpp
+ */
+
+#include "bcos-utilities/IOServicePool.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace bcos;
+using namespace std;
+
+namespace bcos::test
+{
+BOOST_FIXTURE_TEST_SUITE(IOServicePoolTest, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(strandRunsSerially)
+{
+    auto pool = std::make_shared<IOServicePool>(4, "strandSerial");
+
+    std::vector<int> order;
+    std::atomic<int> inFlight{0};
+    std::atomic<bool> concurrent{false};
+
+    constexpr int N = 100;
+    for (int i = 0; i < N; ++i)
+    {
+        pool->strand([&order, &inFlight, &concurrent, i]() {
+            // If another strand task is already running, we have a concurrency bug.
+            if (inFlight.fetch_add(1) > 0)
+            {
+                concurrent.store(true);
+            }
+            order.push_back(i);
+            inFlight.fetch_sub(1);
+        });
+    }
+
+    // Let the strand drain.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    pool.reset();  // stop and join
+
+    BOOST_CHECK(!concurrent.load());
+    BOOST_CHECK_EQUAL(order.size(), (size_t)N);
+    // Verify FIFO order.
+    for (int i = 0; i < N; ++i)
+    {
+        BOOST_CHECK_EQUAL(order[(size_t)i], i);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(strandSpreadsAcrossThreads)
+{
+    constexpr size_t kThreads = 4;
+    auto pool = std::make_shared<IOServicePool>(kThreads, "strandSpread");
+
+    std::vector<std::thread::id> threadIds;
+    std::mutex mutex;
+    std::atomic<int> done{0};
+
+    constexpr int N = 20;
+    for (int i = 0; i < N; ++i)
+    {
+        pool->strand([&threadIds, &mutex, &done]() {
+            {
+                std::lock_guard<std::mutex> lock(mutex);
+                threadIds.push_back(std::this_thread::get_id());
+            }
+            // Simulate some work so tasks spread across scheduling quanta.
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            done.fetch_add(1);
+        });
+    }
+
+    // Wait for all strand tasks.
+    for (int timeout = 0; timeout < 100 && done.load() < N; ++timeout)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    pool.reset();
+    BOOST_CHECK_EQUAL(done.load(), N);
+    // Count unique thread IDs to verify round-robin distribution.
+    std::sort(threadIds.begin(), threadIds.end());
+    auto uniqueCount = (size_t)std::distance(
+        threadIds.begin(), std::unique(threadIds.begin(), threadIds.end()));
+    // With >1 io_context and round-robin, we should have used more than 1 thread.
+    BOOST_CHECK_GT(uniqueCount, 1U);
+}
+
+BOOST_AUTO_TEST_CASE(strandAndPostAreIndependent)
+{
+    auto pool = std::make_shared<IOServicePool>(4, "strandPost");
+
+    std::atomic<int> strandInFlight{0};
+    std::atomic<bool> strandConcurrent{false};
+    std::atomic<int> strandOrder{0};
+    std::atomic<int> strandDone{0};
+
+    std::atomic<int> postInFlight{0};
+    std::atomic<int> postMaxConcurrency{0};
+    std::atomic<int> postDone{0};
+
+    constexpr int N = 30;
+    for (int i = 0; i < N; ++i)
+    {
+        // Strand tasks must be serial.
+        pool->strand([&strandInFlight, &strandConcurrent, &strandOrder, &strandDone, i]() {
+            if (strandInFlight.fetch_add(1) > 0)
+            {
+                strandConcurrent.store(true);
+            }
+            // Busy-wait a tiny bit to increase chance of catching concurrency bugs.
+            auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(1);
+            while (std::chrono::steady_clock::now() < deadline)
+                ;
+            strandOrder.store(strandOrder.load() + 1);
+            strandInFlight.fetch_sub(1);
+            strandDone.fetch_add(1);
+        });
+
+        // Post tasks may run concurrently with strand and with each other.
+        pool->post([&postInFlight, &postMaxConcurrency, &postDone]() {
+            int current = postInFlight.fetch_add(1) + 1;
+            // Track the maximum observed concurrency among post tasks.
+            int prev;
+            do
+            {
+                prev = postMaxConcurrency.load();
+                if (current <= prev) break;
+            } while (!postMaxConcurrency.compare_exchange_weak(prev, current));
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            postInFlight.fetch_sub(1);
+            postDone.fetch_add(1);
+        });
+    }
+
+    // Wait for completion.
+    for (int timeout = 0; timeout < 100 && (strandDone.load() < N || postDone.load() < N);
+         ++timeout)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    pool.reset();
+
+    BOOST_CHECK(!strandConcurrent.load());
+    BOOST_CHECK_EQUAL(strandDone.load(), N);
+    BOOST_CHECK_EQUAL(postDone.load(), N);
+    // Post tasks should have observed some concurrency (with 4 threads).
+    // It's theoretically possible they all serialized, but extremely unlikely.
+    BOOST_WARN_GT(postMaxConcurrency.load(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(strandOrderWithMixedSubmission)
+{
+    auto pool = std::make_shared<IOServicePool>(2, "strandMixed");
+
+    std::vector<int> strandOrder;
+    std::mutex orderMutex;
+
+    // Submit strand tasks interleaved with post tasks.
+    pool->strand([&strandOrder, &orderMutex]() {
+        std::lock_guard lock(orderMutex);
+        strandOrder.push_back(0);
+    });
+    pool->post([]() {
+        // no-op, just to interleave
+    });
+    pool->strand([&strandOrder, &orderMutex]() {
+        std::lock_guard lock(orderMutex);
+        strandOrder.push_back(1);
+    });
+    pool->strand([&strandOrder, &orderMutex]() {
+        std::lock_guard lock(orderMutex);
+        strandOrder.push_back(2);
+    });
+    pool->post([]() {
+        // no-op
+    });
+    pool->strand([&strandOrder, &orderMutex]() {
+        std::lock_guard lock(orderMutex);
+        strandOrder.push_back(3);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    pool.reset();
+
+    BOOST_CHECK_EQUAL(strandOrder.size(), 4U);
+    // Strand tasks must execute in submission order regardless of interleaved posts.
+    for (size_t i = 0; i < strandOrder.size(); ++i)
+    {
+        BOOST_CHECK_EQUAL(strandOrder[i], (int)i);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/bcos-utilities/test/unittests/libutilities/IOServicePoolTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/IOServicePoolTest.cpp
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(strandAndPostAreIndependent)
     for (int i = 0; i < N; ++i)
     {
         // Strand tasks must be serial.
-        pool->strand([&strandInFlight, &strandConcurrent, &strandOrder, &strandDone, i]() {
+        pool->strand([&strandInFlight, &strandConcurrent, &strandOrder, &strandDone]() {
             if (strandInFlight.fetch_add(1) > 0)
             {
                 strandConcurrent.store(true);

--- a/bcos-utilities/test/unittests/libutilities/IOServicePoolTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/IOServicePoolTest.cpp
@@ -37,6 +37,7 @@ BOOST_FIXTURE_TEST_SUITE(IOServicePoolTest, TestPromptFixture)
 BOOST_AUTO_TEST_CASE(strandRunsSerially)
 {
     auto pool = std::make_shared<IOServicePool>(4, "strandSerial");
+    auto strand = std::make_shared<Strand>(pool);
 
     std::vector<int> order;
     std::atomic<int> inFlight{0};
@@ -45,7 +46,7 @@ BOOST_AUTO_TEST_CASE(strandRunsSerially)
     constexpr int N = 100;
     for (int i = 0; i < N; ++i)
     {
-        pool->strand([&order, &inFlight, &concurrent, i]() {
+        strand->post([&order, &inFlight, &concurrent, i]() {
             // If another strand task is already running, we have a concurrency bug.
             if (inFlight.fetch_add(1) > 0)
             {
@@ -73,6 +74,7 @@ BOOST_AUTO_TEST_CASE(strandSpreadsAcrossThreads)
 {
     constexpr size_t kThreads = 4;
     auto pool = std::make_shared<IOServicePool>(kThreads, "strandSpread");
+    auto strand = std::make_shared<Strand>(pool);
 
     std::vector<std::thread::id> threadIds;
     std::mutex mutex;
@@ -81,7 +83,7 @@ BOOST_AUTO_TEST_CASE(strandSpreadsAcrossThreads)
     constexpr int N = 20;
     for (int i = 0; i < N; ++i)
     {
-        pool->strand([&threadIds, &mutex, &done]() {
+        strand->post([&threadIds, &mutex, &done]() {
             {
                 std::lock_guard<std::mutex> lock(mutex);
                 threadIds.push_back(std::this_thread::get_id());
@@ -111,6 +113,7 @@ BOOST_AUTO_TEST_CASE(strandSpreadsAcrossThreads)
 BOOST_AUTO_TEST_CASE(strandAndPostAreIndependent)
 {
     auto pool = std::make_shared<IOServicePool>(4, "strandPost");
+    auto strand = std::make_shared<Strand>(pool);
 
     std::atomic<int> strandInFlight{0};
     std::atomic<bool> strandConcurrent{false};
@@ -125,7 +128,7 @@ BOOST_AUTO_TEST_CASE(strandAndPostAreIndependent)
     for (int i = 0; i < N; ++i)
     {
         // Strand tasks must be serial.
-        pool->strand([&strandInFlight, &strandConcurrent, &strandOrder, &strandDone]() {
+        strand->post([&strandInFlight, &strandConcurrent, &strandOrder, &strandDone]() {
             if (strandInFlight.fetch_add(1) > 0)
             {
                 strandConcurrent.store(true);
@@ -176,30 +179,31 @@ BOOST_AUTO_TEST_CASE(strandAndPostAreIndependent)
 BOOST_AUTO_TEST_CASE(strandOrderWithMixedSubmission)
 {
     auto pool = std::make_shared<IOServicePool>(2, "strandMixed");
+    auto strand = std::make_shared<Strand>(pool);
 
     std::vector<int> strandOrder;
     std::mutex orderMutex;
 
     // Submit strand tasks interleaved with post tasks.
-    pool->strand([&strandOrder, &orderMutex]() {
+    strand->post([&strandOrder, &orderMutex]() {
         std::lock_guard lock(orderMutex);
         strandOrder.push_back(0);
     });
     pool->post([]() {
         // no-op, just to interleave
     });
-    pool->strand([&strandOrder, &orderMutex]() {
+    strand->post([&strandOrder, &orderMutex]() {
         std::lock_guard lock(orderMutex);
         strandOrder.push_back(1);
     });
-    pool->strand([&strandOrder, &orderMutex]() {
+    strand->post([&strandOrder, &orderMutex]() {
         std::lock_guard lock(orderMutex);
         strandOrder.push_back(2);
     });
     pool->post([]() {
         // no-op
     });
-    pool->strand([&strandOrder, &orderMutex]() {
+    strand->post([&strandOrder, &orderMutex]() {
         std::lock_guard lock(orderMutex);
         strandOrder.push_back(3);
     });

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -428,7 +428,7 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
         m_pbftInitializer = std::make_shared<PBFTInitializer>(_nodeArchType, m_nodeConfig,
             m_protocolInitializer, m_txpoolInitializer->txpool(), ledger, m_scheduler,
             consensusStorage, m_frontServiceInitializer->front(), nodeTimeMaintenance,
-            *m_ioServicePool->getIOService());
+            m_ioServicePool);
         auto nodeID = m_protocolInitializer->keyPair()->publicKey();
         auto frontService = m_frontServiceInitializer->front();
         auto groupID = m_nodeConfig->groupId();
@@ -455,7 +455,7 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
         m_pbftInitializer = std::make_shared<ProPBFTInitializer>(_nodeArchType, m_nodeConfig,
             m_protocolInitializer, m_txpoolInitializer->txpool(), ledger, m_scheduler,
             consensusStorage, m_frontServiceInitializer->front(), nodeTimeMaintenance,
-            *m_ioServicePool->getIOService());
+            m_ioServicePool);
     }
     if (_nodeArchType == bcos::protocol::NodeArchitectureType::MAX)
     {

--- a/libinitializer/PBFTInitializer.cpp
+++ b/libinitializer/PBFTInitializer.cpp
@@ -64,7 +64,7 @@ PBFTInitializer::PBFTInitializer(bcos::protocol::NodeArchitectureType _nodeArchT
     bcos::storage::StorageInterface::Ptr _storage,
     std::shared_ptr<bcos::front::FrontServiceInterface> _frontService,
     bcos::tool::NodeTimeMaintenance::Ptr _nodeTimeMaintenance,
-    boost::asio::io_context& _ioContext)
+    bcos::IOServicePool::Ptr _ioServicePool)
   : m_nodeArchType(_nodeArchType),
     m_nodeConfig(std::move(_nodeConfig)),
     m_protocolInitializer(std::move(_protocolInitializer)),
@@ -74,7 +74,7 @@ PBFTInitializer::PBFTInitializer(bcos::protocol::NodeArchitectureType _nodeArchT
     m_storage(std::move(_storage)),
     m_frontService(std::move(_frontService)),
     m_nodeTimeMaintenance(std::move(_nodeTimeMaintenance)),
-    m_ioContext(&_ioContext)
+    m_ioServicePool(std::move(_ioServicePool))
 {
     m_groupInfoCodec = std::make_shared<bcostars::protocol::GroupInfoCodecImpl>();
     g_BCOSConfig.setIsWasm(m_nodeConfig->isWasm());
@@ -427,7 +427,8 @@ void PBFTInitializer::createSealer()
 {
     // create sealer
     auto sealerFactory = SealerFactory(m_nodeConfig, m_protocolInitializer->blockFactory(),
-        m_txpool, m_nodeTimeMaintenance, m_protocolInitializer->keyPair(), *m_ioContext);
+        m_txpool, m_nodeTimeMaintenance, m_protocolInitializer->keyPair(),
+        *m_ioServicePool->getIOService());
     // if rpbft sealer, register the sealer to the pbft
     if (m_nodeConfig->consensusType() == ledger::RPBFT_CONSENSUS_TYPE) [[unlikely]]
     {
@@ -445,20 +446,20 @@ void PBFTInitializer::createPBFT()
     auto kvStorage = std::make_shared<bcos::storage::KVStorageHelper>(m_storage);
     if (m_nodeConfig->consensusType() == ledger::PBFT_CONSENSUS_TYPE)
     {
-        auto pbftFactory = std::make_shared<PBFTFactory>(*m_ioContext,
+        auto pbftFactory = std::make_shared<PBFTFactory>(*m_ioServicePool->getIOService(),
             m_protocolInitializer->cryptoSuite(),
             m_protocolInitializer->keyPair(), m_frontService, kvStorage, m_ledger, m_scheduler,
             m_txpool, m_protocolInitializer->blockFactory(),
-            m_protocolInitializer->txResultFactory());
+            m_protocolInitializer->txResultFactory(), m_ioServicePool);
         m_pbft = pbftFactory->createPBFT();
     }
     else if (m_nodeConfig->consensusType() == ledger::RPBFT_CONSENSUS_TYPE)
     {
-        auto rpbftFactory = std::make_shared<RPBFTFactory>(*m_ioContext,
+        auto rpbftFactory = std::make_shared<RPBFTFactory>(*m_ioServicePool->getIOService(),
             m_protocolInitializer->cryptoSuite(),
             m_protocolInitializer->keyPair(), m_frontService, kvStorage, m_ledger, m_scheduler,
             m_txpool, m_protocolInitializer->blockFactory(),
-            m_protocolInitializer->txResultFactory());
+            m_protocolInitializer->txResultFactory(), m_ioServicePool);
         m_pbft = rpbftFactory->createRPBFT();
     }
 
@@ -505,7 +506,7 @@ void PBFTInitializer::createSync()
         m_txpool, m_frontService, m_scheduler, m_pbft, m_nodeTimeMaintenance,
         m_nodeConfig->enableSendBlockStatusByTree(), m_nodeConfig->treeWidth(),
         m_nodeConfig->syncArchivedBlocks());
-    m_blockSync = blockSyncFactory->createBlockSync(*m_ioContext);
+    m_blockSync = blockSyncFactory->createBlockSync(*m_ioServicePool->getIOService(), m_ioServicePool);
     m_blockSync->setFaultyNodeBlockDelta(m_nodeConfig->pipelineSize());
     m_blockSync->setAllowFreeNodeSync(m_nodeConfig->allowFreeNodeSync());
 }
@@ -616,7 +617,7 @@ void PBFTInitializer::initConsensusFailOver(KeyInterface::Ptr _nodeID)
     m_leaderElection = leaderElectionFactory->createLeaderElection(m_nodeConfig->memberID(),
         nodeConfig, m_nodeConfig->failOverClusterUrl(), leaderKey, "consensus_fault_tolerance",
         m_nodeConfig->leaseTTL(), m_nodeConfig->pdCaPath(), m_nodeConfig->pdCertPath(),
-        m_nodeConfig->pdKeyPath(), *m_ioContext);
+        m_nodeConfig->pdKeyPath(), *m_ioServicePool->getIOService());
 
     // register the handler
     m_leaderElection->registerOnCampaignHandler(

--- a/libinitializer/PBFTInitializer.h
+++ b/libinitializer/PBFTInitializer.h
@@ -21,7 +21,7 @@
 #pragma once
 #include "bcos-framework/rpc/RPCInterface.h"
 #include "libinitializer/ProtocolInitializer.h"
-#include <boost/asio/io_context.hpp>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-framework/consensus/ConsensusInterface.h>
 #include <bcos-framework/dispatcher/SchedulerInterface.h>
 #include <bcos-framework/election/LeaderElectionInterface.h>
@@ -71,7 +71,7 @@ public:
         bcos::storage::StorageInterface::Ptr _storage,
         bcos::front::FrontServiceInterface::Ptr _frontService,
         bcos::tool::NodeTimeMaintenance::Ptr _nodeTimeMaintenance,
-        boost::asio::io_context& _ioContext);
+        bcos::IOServicePool::Ptr _ioServicePool);
 
     virtual ~PBFTInitializer() { stop(); }
 
@@ -131,7 +131,7 @@ protected:
     bcos::protocol::MemberFactoryInterface::Ptr m_memberFactory;
     bcos::election::LeaderElectionInterface::Ptr m_leaderElection;
     bcos::tool::NodeTimeMaintenance::Ptr m_nodeTimeMaintenance;
-    boost::asio::io_context* m_ioContext;
+    bcos::IOServicePool::Ptr m_ioServicePool;
 };
 }  // namespace initializer
 }  // namespace bcos

--- a/libinitializer/ProPBFTInitializer.cpp
+++ b/libinitializer/ProPBFTInitializer.cpp
@@ -44,11 +44,11 @@ ProPBFTInitializer::ProPBFTInitializer(bcos::protocol::NodeArchitectureType _nod
     bcos::storage::StorageInterface::Ptr _storage,
     std::shared_ptr<bcos::front::FrontServiceInterface> _frontService,
     bcos::tool::NodeTimeMaintenance::Ptr _nodeTimeMaintenance,
-    boost::asio::io_context& _ioContext)
+    bcos::IOServicePool::Ptr _ioServicePool)
   : PBFTInitializer(_nodeArchType, _nodeConfig, _protocolInitializer, _txpool, _ledger, _scheduler,
-        _storage, _frontService, _nodeTimeMaintenance, _ioContext)
+        _storage, _frontService, _nodeTimeMaintenance, _ioServicePool)
 {
-    m_timer = std::make_shared<Timer>(_ioContext, m_timerSchedulerInterval, "node info report");
+    m_timer = std::make_shared<Timer>(*_ioServicePool->getIOService(), m_timerSchedulerInterval, "node info report");
 
     std::vector<tars::TC_Endpoint> endPoints;
     auto withoutTarsFramework = m_nodeConfig->withoutTarsFramework();

--- a/libinitializer/ProPBFTInitializer.h
+++ b/libinitializer/ProPBFTInitializer.h
@@ -24,8 +24,8 @@
 #include <bcos-framework/gateway/GatewayInterface.h>
 #include <bcos-framework/rpc/RPCInterface.h>
 #include <bcos-tool/NodeTimeMaintenance.h>
+#include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/Timer.h>
-#include <boost/asio/io_context.hpp>
 #include <fisco-bcos-tars-service/Common/TarsUtils.h>
 
 namespace bcos
@@ -43,7 +43,7 @@ public:
         bcos::storage::StorageInterface::Ptr _storage,
         std::shared_ptr<bcos::front::FrontServiceInterface> _frontService,
         bcos::tool::NodeTimeMaintenance::Ptr _nodeTimeMaintenance,
-        boost::asio::io_context& _ioContext);
+        bcos::IOServicePool::Ptr _ioServicePool);
 
     virtual ~ProPBFTInitializer() { stop(); }
 


### PR DESCRIPTION
## 概述

将各个模块中独立的单线程 `ThreadPool(1)` 全部替换为复用 Initializer 的统一共享 `IOServicePool`，同时新增独立的 `Strand` 类来保证任务的串行 FIFO 执行顺序。每个模块持有自己的 `Strand` 实例，`Strand` 内部通过 round-robin 将任务分发到共享线程池的多个 `io_context` 上执行，在保证串行性的前提下充分利用多核。

## 主要变更

### 新增 Strand 类（`bcos-utilities/IOServicePool.h`）

- 独立的串行任务调度器，基于 `std::deque` + `std::mutex` + `std::atomic<int> count_` 实现
- 参考 `boost::asio::strand` 的原子 CAS 模式：用 `count_`（0=空闲, 1=运行中, >1=运行中+排队任务）替代 `bool busy`，`post()` 通过 `fetch_add` 无锁判断是否需要 kick，`drain()` 通过 `fetch_sub` 省去第二次加锁
- **锁竞争优化**：`post()` 锁内仅做队列 push（不再读写 busy），`drain()` 在高并发有新任务入队时（`count_ > 1`）跳过第二次锁直接 kick，减少 mutex 竞争
- `drain()` 通过 `IOServicePool::safeExecute()` 统一包裹 try/catch（`std::exception&` + `...`），异常被捕获并记日志，strand 不会卡死
- 通过 `weak_ptr<IOServicePool>` 避免循环引用，`Impl::shared_from_this()` 保证队列排空前对象不被销毁
- 多个 `Strand` 实例可独立共存，各自串行化自身任务，互不阻塞

### ThreadPool(1) → Strand（共 7 个模块）

| 模块 | 原成员 | 新成员 |
|------|--------|--------|
| **StateMachine** | `ThreadPool m_worker` | `Strand m_strand` |
| **PBFTLogSync** | `ThreadPool m_requestThread` | `Strand m_strand` |
| **BlockValidator** | `ThreadPool m_taskPool` | `Strand m_strand` |
| **LedgerStorage** | `ThreadPool m_commitBlockWorker` | `Strand m_strand` |
| **BlockSync** | `ThreadPool m_downloadBlockProcessor` + `m_sendBlockProcessor` | `Strand m_strand`（合并为一个） |
| **AMOPImpl** | `ThreadPool m_threadPool` | `Strand m_strand` |

- 原 `enqueue()` 调用全部替换为 `m_strand->post()`
- 回调统一使用 `weak_from_this()` 模式避免循环引用
- 移除了所有 `stop()` / `~Destructor()` 中的 ThreadPool 生命周期管理代码

### 工厂链路传递 IOServicePool

- **PBFTFactory** / **RPBFTFactory**：构造函数新增 `IOServicePool::Ptr` 参数，传递给 StateMachine、LedgerStorage、PBFTEngine
- **PBFTEngine**：新增 `IOServicePool::Ptr` 参数，传递给 PBFTLogSync
- **PBFTImpl**：新增 `IOServicePool::Ptr` 参数，传递给 BlockValidator
- **BlockSyncFactory**：`createBlockSync()` 新增 `IOServicePool::Ptr` 参数
- **GatewayFactory**：`buildAMOP()` / `buildLocalAMOP()` 传入 `IOServicePool`
- **PBFTInitializer** / **ProPBFTInitializer**：将原来的 `io_context&` 替换为 `IOServicePool::Ptr`，通过工厂链路向下传递

### 单元测试

新增 `IOServicePoolTest.cpp`（4 个测试用例）：
- `strandRunsSerially`：验证 100 个任务严格串行、无并发
- `strandSpreadsAcrossThreads`：验证任务跨多个线程分布（round-robin）
- `strandAndPostAreIndependent`：验证 Strand 串行与 pool->post() 并发互不干扰
- `strandOrderWithMixedSubmission`：验证穿插提交时任务严格按顺序执行

适配了所有受影响的测试文件（约 15 个），为测试夹具传入 `IOServicePool` 实例。

## 效果

- **线程数减少**：从 7 个独立线程降至共享池的 `hardware_concurrency + 1` 个线程
- **资源利用率提升**：多个串行任务共享同一线程池，避免线程闲置
- **生命周期简化**：`IOServicePool` 由 Initializer 统一管理，各模块无需关心线程启停