### PR TITLE
refactor(mpt): stateless computeTrieRoot core + module cleanups

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/Constants.h
+++ b/bcos-ledger/bcos-ledger/mpt/Constants.h
@@ -32,6 +32,13 @@ namespace bcos::ledger::mpt
 ///   - an absent-child placeholder inside a BranchNode payload
 inline constexpr bcos::byte RLP_EMPTY_STRING = 0x80;
 
+/// RLP header byte for a 32-byte string (RLP_EMPTY_STRING | 32 == 0xa0): the one-byte prefix that
+/// precedes a node's keccak256 digest when a hash node-reference is spliced into a parent payload.
+inline constexpr bcos::byte RLP_HASH_REF_PREFIX = 0xa0;
+
+/// Encoded size of a hash node-reference: the 1-byte RLP_HASH_REF_PREFIX plus the 32-byte digest.
+inline constexpr size_t HASH_REF_ENCODED_SIZE = 1 + bcos::h256::SIZE;
+
 /// Hex string for keccak256(RLP("")) = the empty trie root hash
 inline constexpr std::string_view EMPTY_ROOT_HASH_HEX =
     "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421";

--- a/bcos-ledger/bcos-ledger/mpt/HashBuilder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/HashBuilder.cpp
@@ -23,8 +23,10 @@
 #include "Nibble.h"
 #include "NodeEncoder.h"
 #include <bcos-crypto/hasher/AnyHasher.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
 #include <span>
 #include <utility>
+#include <vector>
 
 namespace bcos::ledger::mpt
 {
@@ -67,8 +69,8 @@ bcos::bytes hbRefToRaw(NodeRef const& ref)
         return ref.inlineBytes;
     }
     bcos::bytes out;
-    out.reserve(1 + bcos::h256::SIZE);
-    out.push_back(0xa0);
+    out.reserve(HASH_REF_ENCODED_SIZE);
+    out.push_back(RLP_HASH_REF_PREFIX);
     out.insert(out.end(), ref.hash.begin(), ref.hash.end());
     return out;
 }
@@ -101,11 +103,11 @@ NodeRef hbBuild(HBContext& ctx, std::span<HBEntry const> entries, size_t depth)
 {
     if (entries.size() == 1)
     {
-        HBEntry const& only = entries.front();
+        const auto& [nibbles, value] = entries.front();
         LeafNode leaf;
         // keyNibbles is the SUFFIX from `depth` to the end (64), not the full key.
-        leaf.keyNibbles.assign(only.nibbles.begin() + depth, only.nibbles.end());
-        leaf.value = only.value;
+        leaf.keyNibbles.assign(nibbles.begin() + depth, nibbles.end());
+        leaf.value = value;
         return hbEmit(ctx, TrieNode{std::move(leaf)});
     }
 
@@ -114,9 +116,8 @@ NodeRef hbBuild(HBContext& ctx, std::span<HBEntry const> entries, size_t depth)
         entries.front().nibbles.data() + depth, entries.front().nibbles.size() - depth);
     bcos::bytesConstRef const lastSuffix(
         entries.back().nibbles.data() + depth, entries.back().nibbles.size() - depth);
-    size_t const cpl = commonPrefixLen(firstSuffix, lastSuffix);
 
-    if (cpl > 0)
+    if (size_t const cpl = commonPrefixLen(firstSuffix, lastSuffix); cpl > 0)
     {
         // Shared prefix → extension over [depth, depth+cpl) pointing at a branch below it.
         NodeRef const childRef = hbBuildBranch(ctx, entries, depth + cpl);
@@ -131,6 +132,62 @@ NodeRef hbBuild(HBContext& ctx, std::span<HBEntry const> entries, size_t depth)
 }
 
 }  // namespace
+
+namespace
+{
+// File-local core: build over already-normalised, sorted, unique (keyHash, value-view) entries.
+// Stateless and reentrant (owns its hasher, touches no shared state) → independent inputs may be
+// built concurrently.
+TrieBuildResult computeTrieRootImpl(
+    std::span<std::pair<bcos::h256, bcos::bytesConstRef> const> sortedEntries)
+{
+    if (sortedEntries.empty())
+    {
+        return TrieBuildResult{.root = emptyRootHash(), .newNodes = {}};
+    }
+
+    std::vector<HBEntry> entries;
+    entries.reserve(sortedEntries.size());
+    for (auto const& [keyHash, value] : sortedEntries)
+    {
+        entries.push_back(
+            HBEntry{.nibbles = bytesToNibbles(keyHash.ref()), .value = value.toBytes()});
+    }
+
+    // Own hasher + own newNodes → no shared state: many computeTrieRootImpl calls may run
+    // concurrently for independent inputs (coarse-grained parallelism across tries).
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    std::unordered_map<bcos::h256, bcos::bytes> newNodes;
+    HBContext ctx{.hasher = hasher, .newNodes = newNodes};
+    NodeRef const rootRef =
+        hbBuild(ctx, std::span<HBEntry const>{entries.data(), entries.size()}, /*depth=*/0);
+
+    // A trie root is ALWAYS a 32-byte hash, even when the top node encodes to < 32 bytes.
+    bcos::h256 root;
+    if (rootRef.kind == NodeRef::Kind::Hash)
+    {
+        root = rootRef.hash;
+    }
+    else
+    {
+        bcos::crypto::hasher::hash(hasher, bcos::ref(rootRef.inlineBytes), root);
+        newNodes.emplace(root, rootRef.inlineBytes);
+    }
+
+    return TrieBuildResult{.root = root, .newNodes = std::move(newNodes)};
+}
+}  // namespace
+
+TrieBuildResult computeTrieRoot(std::map<bcos::h256, bcos::bytes> const& entries)
+{
+    std::vector<std::pair<bcos::h256, bcos::bytesConstRef>> normalized;
+    normalized.reserve(entries.size());
+    for (auto const& [key, value] : entries)
+    {
+        normalized.emplace_back(key, bcos::ref(value));
+    }
+    return computeTrieRootImpl(normalized);
+}
 
 HashBuilder::HashBuilder(NodeCache& cache, bcos::h256 priorRoot)
   : m_cache(cache), m_priorRoot(priorRoot)
@@ -157,45 +214,28 @@ bcos::task::Task<bcos::h256> HashBuilder::commit()
                 "HashBuilder incremental rebuild on non-empty root is implemented in M4 (PR-10)"));
     }
 
-    // 1) Drop deletes (no-op from empty); collect survivors in sorted order (map is sorted).
-    std::vector<HBEntry> entries;
-    entries.reserve(m_changes.size());
+    // Resolve deletes (no-op from an empty trie); m_changes is sorted, so survivors stay sorted.
+    std::vector<std::pair<bcos::h256, bcos::bytesConstRef>> survivors;
+    survivors.reserve(m_changes.size());
     for (auto const& [key, maybeValue] : m_changes)
     {
         if (maybeValue.has_value())
         {
-            entries.push_back(HBEntry{bytesToNibbles(key.ref()), *maybeValue});
+            survivors.emplace_back(key, bcos::ref(*maybeValue));
         }
     }
-    if (entries.empty())
-    {
-        co_return emptyRootHash();
-    }
 
-    // 2) Build the canonical node tree synchronously, recording hash-kind nodes.
-    HBContext ctx{m_hasher, m_newNodes};
-    NodeRef const rootRef =
-        hbBuild(ctx, std::span<HBEntry const>{entries.data(), entries.size()}, /*depth=*/0);
+    // Build the trie through the stateless core, then take ownership of the produced nodes.
+    TrieBuildResult result = computeTrieRootImpl(survivors);
+    m_newNodes = std::move(result.newNodes);
 
-    // 3) A trie root is ALWAYS a 32-byte hash, even when the top node encodes to < 32 bytes.
-    bcos::h256 root;
-    if (rootRef.kind == NodeRef::Kind::Hash)
-    {
-        root = rootRef.hash;
-    }
-    else
-    {
-        bcos::crypto::hasher::hash(m_hasher, bcos::ref(rootRef.inlineBytes), root);
-        m_newNodes.emplace(root, rootRef.inlineBytes);
-    }
-
-    // 4) Flush every new node into the cache in one pass.
+    // Flush every new node into the cache in one pass.
     for (auto const& [hash, raw] : m_newNodes)
     {
-        co_await m_cache.put(hash, raw);
+        co_await m_cache.get().put(hash, raw);
     }
 
-    co_return root;
+    co_return result.root;
 }
 
 std::unordered_map<bcos::h256, bcos::bytes> HashBuilder::drainNewNodes()

--- a/bcos-ledger/bcos-ledger/mpt/HashBuilder.h
+++ b/bcos-ledger/bcos-ledger/mpt/HashBuilder.h
@@ -47,6 +47,7 @@ struct TrieBuildResult
 /// (not a multimap). So there is no sort, no is_sorted check, no dup handling — just one O(n) walk.
 /// Touches no object state and no NodeCache, so independent inputs may be built concurrently
 /// (coarse-grained parallelism across tries). Internally single-threaded.
+/// @note Synchronous (returns a value, not a Task), unlike HashBuilder::commit().
 TrieBuildResult computeTrieRoot(std::map<bcos::h256, bcos::bytes> const& entries);
 
 /// Accumulates put/remove operations keyed by a 32-byte keccak path, then builds the canonical

--- a/bcos-ledger/bcos-ledger/mpt/HashBuilder.h
+++ b/bcos-ledger/bcos-ledger/mpt/HashBuilder.h
@@ -20,10 +20,10 @@
 
 #include "NodeCache.h"
 #include "TrieNode.h"
-#include <bcos-crypto/hasher/OpenSSLHasher.h>
 #include <bcos-task/Task.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <functional>
 #include <map>
 #include <optional>
 #include <unordered_map>
@@ -31,6 +31,23 @@
 
 namespace bcos::ledger::mpt
 {
+
+/// Result of a stateless trie build: the 32-byte root plus the hash-keyed RLP encodings of every
+/// node that must be persisted (the hash-kind nodes produced during the build).
+struct TrieBuildResult
+{
+    bcos::h256 root;
+    std::unordered_map<bcos::h256, bcos::bytes> newNodes;
+};
+
+/// Stateless, reentrant entry point: build one canonical MPT from an ordered keyHash -> value map
+/// and return {root, newNodes}. The input is std::map specifically: its type already pins down
+/// everything the build relies on — ascending iteration (red-black invariant), the canonical order
+/// (default std::less<h256> == 32-byte lexicographic == 64-nibble path order), and key uniqueness
+/// (not a multimap). So there is no sort, no is_sorted check, no dup handling — just one O(n) walk.
+/// Touches no object state and no NodeCache, so independent inputs may be built concurrently
+/// (coarse-grained parallelism across tries). Internally single-threaded.
+TrieBuildResult computeTrieRoot(std::map<bcos::h256, bcos::bytes> const& entries);
 
 /// Accumulates put/remove operations keyed by a 32-byte keccak path, then builds the canonical
 /// Ethereum MPT and returns its 32-byte root.
@@ -64,14 +81,12 @@ public:
     std::unordered_set<bcos::h256> drainObsoletedNodes();
 
 private:
-    NodeCache& m_cache;
+    std::reference_wrapper<NodeCache> m_cache;
     bcos::h256 m_priorRoot;
     /// key → value, or nullopt for a recorded delete. Sorted by 32-byte key == 64-nibble path.
     std::map<bcos::h256, std::optional<bcos::bytes>> m_changes;
     std::unordered_map<bcos::h256, bcos::bytes> m_newNodes;
     std::unordered_set<bcos::h256> m_obsoleted;
-    /// Reused across encodeAndRef calls to amortise EVP_MD_CTX allocation.
-    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher m_hasher;
 };
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/HexPrefix.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/HexPrefix.cpp
@@ -19,6 +19,8 @@
 
 #include "HexPrefix.h"
 #include "Errors.h"
+#include "Nibble.h"
+#include "TrieNode.h"
 #include <boost/throw_exception.hpp>
 #include <cassert>
 
@@ -26,30 +28,30 @@ namespace bcos::ledger::mpt
 {
 
 // Header byte bit layout (Yellow Paper Appendix C):
-//   bit 5 = leaf flag (1 = leaf / terminator, 0 = extension)
-//   bit 4 = odd flag  (1 = odd nibble count, first nibble packed into low 4 bits)
+//   bit 5      = leaf flag (1 = leaf / terminator, 0 = extension)
+//   bit 4      = odd flag  (1 = odd nibble count, first nibble packed into low 4 bits)
+//   bits [3:0] = first nibble (selected with LOW_NIBBLE_MASK from Nibble.h)
 inline constexpr uint8_t HP_LEAF_FLAG = 0b0010'0000U;
 inline constexpr uint8_t HP_ODD_FLAG = 0b0001'0000U;
-inline constexpr uint8_t HP_NIBBLE_MASK = 0b0000'1111U;
 
 bcos::bytes hexPrefixEncode(bcos::bytesConstRef nibbles, bool isLeaf)
 {
     bcos::bytes out;
-    bool const odd = (nibbles.size() % 2 == 1);
+    bool const odd = (nibbles.size() % NIBBLES_PER_BYTE == 1);
     assert(nibbles.empty() == false && "nibbles cannot be empty");
     uint8_t firstByte = (isLeaf ? HP_LEAF_FLAG : 0U) | (odd ? HP_ODD_FLAG : 0U);
     if (odd)
     {
-        assert(nibbles[0] < 16 && "nibble out of range");
-        firstByte |= (nibbles[0] & HP_NIBBLE_MASK);
+        assert(nibbles[0] < NIBBLE_RANGE && "nibble out of range");
+        firstByte |= (nibbles[0] & LOW_NIBBLE_MASK);
     }
     out.push_back(firstByte);
     size_t const start = odd ? 1U : 0U;
-    for (size_t i = start; i + 1 < nibbles.size(); i += 2)
+    for (size_t i = start; i + 1 < nibbles.size(); i += NIBBLES_PER_BYTE)
     {
-        assert(nibbles[i] < 16 && nibbles[i + 1] < 16 && "nibble out of range");
-        out.push_back(
-            static_cast<bcos::byte>(((nibbles[i] & 0x0fU) << 4U) | (nibbles[i + 1] & 0x0fU)));
+        assert(nibbles[i] < NIBBLE_RANGE && nibbles[i + 1] < NIBBLE_RANGE && "nibble out of range");
+        out.push_back(static_cast<bcos::byte>(
+            ((nibbles[i] & LOW_NIBBLE_MASK) << NIBBLE_BITS) | (nibbles[i + 1] & LOW_NIBBLE_MASK)));
     }
     return out;
 }
@@ -66,16 +68,16 @@ std::pair<bcos::bytes, bool> hexPrefixDecode(bcos::bytesConstRef encoded)
     bool const odd = ((first & HP_ODD_FLAG) != 0U);
 
     bcos::bytes nibbles;
-    nibbles.reserve(((encoded.size() - 1) * 2) + (odd ? 1U : 0U));
+    nibbles.reserve(((encoded.size() - 1) * NIBBLES_PER_BYTE) + (odd ? 1U : 0U));
 
     if (odd)
     {
-        nibbles.push_back(first & HP_NIBBLE_MASK);
+        nibbles.push_back(first & LOW_NIBBLE_MASK);
     }
     for (size_t i = 1; i < encoded.size(); ++i)
     {
-        nibbles.push_back(static_cast<uint8_t>((encoded[i] >> 4U) & 0x0fU));
-        nibbles.push_back(static_cast<uint8_t>(encoded[i] & 0x0fU));
+        nibbles.push_back(static_cast<uint8_t>((encoded[i] >> NIBBLE_BITS) & LOW_NIBBLE_MASK));
+        nibbles.push_back(static_cast<uint8_t>(encoded[i] & LOW_NIBBLE_MASK));
     }
     return {std::move(nibbles), isLeaf};
 }

--- a/bcos-ledger/bcos-ledger/mpt/HexPrefix.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/HexPrefix.cpp
@@ -20,7 +20,6 @@
 #include "HexPrefix.h"
 #include "Errors.h"
 #include "Nibble.h"
-#include "TrieNode.h"
 #include <boost/throw_exception.hpp>
 #include <cassert>
 

--- a/bcos-ledger/bcos-ledger/mpt/Nibble.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Nibble.cpp
@@ -28,36 +28,36 @@ namespace bcos::ledger::mpt
 bcos::bytes bytesToNibbles(bcos::bytesConstRef bytes)
 {
     bcos::bytes out;
-    out.reserve(bytes.size() * 2);
-    for (bcos::byte b : bytes)
+    out.reserve(bytes.size() * NIBBLES_PER_BYTE);
+    for (auto const _byte : bytes)
     {
-        out.push_back(static_cast<uint8_t>((b >> 4) & 0x0f));
-        out.push_back(static_cast<uint8_t>(b & 0x0f));
+        out.push_back(static_cast<uint8_t>((_byte >> NIBBLE_BITS) & LOW_NIBBLE_MASK));
+        out.push_back(static_cast<uint8_t>(_byte & LOW_NIBBLE_MASK));
     }
     return out;
 }
 
 bcos::bytes nibblesToBytes(bcos::bytesConstRef nibbles)
 {
-    if (nibbles.size() % 2 != 0)
+    if (nibbles.size() % NIBBLES_PER_BYTE != 0)
     {
         BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
                                   "nibblesToBytes requires even nibble count"));
     }
     bcos::bytes out;
-    out.reserve(nibbles.size() / 2);
-    for (size_t i = 0; i < nibbles.size(); i += 2)
+    out.reserve(nibbles.size() / NIBBLES_PER_BYTE);
+    for (size_t i = 0; i < nibbles.size(); i += NIBBLES_PER_BYTE)
     {
         // Strict invariant: each nibble must fit in 4 bits.
-        if ((nibbles[i] | nibbles[i + 1]) > 0x0fu)
+        if ((nibbles[i] | nibbles[i + 1]) > LOW_NIBBLE_MASK)
         {
             BOOST_THROW_EXCEPTION(
                 MPTInvariantViolation{} << bcos::errinfo_comment(
                     "nibblesToBytes: nibble value out of range [0, 15] at index " +
                     std::to_string(i) + " or " + std::to_string(i + 1)));
         }
-        out.push_back(
-            static_cast<bcos::byte>(((nibbles[i] & 0x0fu) << 4) | (nibbles[i + 1] & 0x0fu)));
+        out.push_back(static_cast<bcos::byte>(
+            ((nibbles[i] & LOW_NIBBLE_MASK) << NIBBLE_BITS) | (nibbles[i + 1] & LOW_NIBBLE_MASK)));
     }
     return out;
 }

--- a/bcos-ledger/bcos-ledger/mpt/Nibble.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Nibble.cpp
@@ -29,10 +29,10 @@ bcos::bytes bytesToNibbles(bcos::bytesConstRef bytes)
 {
     bcos::bytes out;
     out.reserve(bytes.size() * NIBBLES_PER_BYTE);
-    for (auto const _byte : bytes)
+    for (auto const byteValue : bytes)
     {
-        out.push_back(static_cast<uint8_t>((_byte >> NIBBLE_BITS) & LOW_NIBBLE_MASK));
-        out.push_back(static_cast<uint8_t>(_byte & LOW_NIBBLE_MASK));
+        out.push_back(static_cast<uint8_t>((byteValue >> NIBBLE_BITS) & LOW_NIBBLE_MASK));
+        out.push_back(static_cast<uint8_t>(byteValue & LOW_NIBBLE_MASK));
     }
     return out;
 }

--- a/bcos-ledger/bcos-ledger/mpt/Nibble.h
+++ b/bcos-ledger/bcos-ledger/mpt/Nibble.h
@@ -20,9 +20,13 @@
 
 #include <bcos-utilities/Common.h>
 #include <cstddef>
+#include <cstdint>
 
 namespace bcos::ledger::mpt
 {
+
+/// The number of distinct nibble values (0..15): a hex digit's range, and a branch node's fan-out.
+inline constexpr std::uint8_t NIBBLE_RANGE = 16;
 
 /// Bits per nibble: a nibble is one hex digit = 4 bits.
 inline constexpr unsigned NIBBLE_BITS = 4;

--- a/bcos-ledger/bcos-ledger/mpt/Nibble.h
+++ b/bcos-ledger/bcos-ledger/mpt/Nibble.h
@@ -24,6 +24,15 @@
 namespace bcos::ledger::mpt
 {
 
+/// Bits per nibble: a nibble is one hex digit = 4 bits.
+inline constexpr unsigned NIBBLE_BITS = 4;
+
+/// A byte holds two nibbles (high nibble first).
+inline constexpr size_t NIBBLES_PER_BYTE = 2;
+
+/// Mask selecting the low nibble (low 4 bits) of a byte.
+inline constexpr bcos::byte LOW_NIBBLE_MASK = 0x0F;
+
 /// Splits each byte into two nibbles (high nibble first).
 /// Example: {0xab, 0xcd} -> {0x0a, 0x0b, 0x0c, 0x0d}
 bcos::bytes bytesToNibbles(bcos::bytesConstRef bytes);

--- a/bcos-ledger/bcos-ledger/mpt/NodeCache.h
+++ b/bcos-ledger/bcos-ledger/mpt/NodeCache.h
@@ -27,6 +27,9 @@
 
 namespace bcos::ledger::mpt
 {
+/// Default LRU byte budget (64 KiB) for a NodeCache when no capacity is supplied.
+inline constexpr size_t DEFAULT_CACHE_CAPACITY_BYTES = size_t{64} * 1024;
+
 /// Bounded cache for decoded/encoded MPT nodes. Keys are 32-byte node hashes,
 /// values are the RLP encoding of the node. Wraps bcos-framework MemoryStorage
 /// with CONCURRENT (thread-safe sharded buckets) and LRU (capacity-bounded)
@@ -35,7 +38,7 @@ class NodeCache
 {
 public:
     /// @param capacity LRU byte budget (sum of key+value sizes) before eviction.
-    explicit NodeCache(size_t capacity = 64 * 1024);
+    explicit NodeCache(size_t capacity = DEFAULT_CACHE_CAPACITY_BYTES);
 
     /// Returns the cached RLP encoding for @p key, or nullopt on a miss.
     bcos::task::Task<std::optional<bcos::bytes>> get(bcos::h256 const& key);

--- a/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
@@ -30,6 +30,9 @@ namespace bcos::ledger::mpt
 namespace
 {
 
+// A Leaf or Extension node is a 2-item RLP list; a Branch is NIBBLE_RANGE + 1 items.
+constexpr size_t LEAF_OR_EXTENSION_ITEM_COUNT = 2;
+
 // One RLP item read out of a buffer: its full raw span (header + payload), its string content span
 // (payload only; for a single byte < 0x80 the lone byte itself), and whether the item is a list.
 // MPT keeps branch/extension child references RLP-encoded, so we must track the raw span — the
@@ -99,7 +102,7 @@ TrieNode decodeNode(bcos::bytesConstRef rawInput)
     }
 
     // 3) Two items → Leaf or Extension, distinguished by the HP terminator flag.
-    if (items.size() == 2)
+    if (items.size() == LEAF_OR_EXTENSION_ITEM_COUNT)
     {
         auto [nibbles, isLeaf] = hexPrefixDecode(items[0].content);
         if (isLeaf)

--- a/bcos-ledger/bcos-ledger/mpt/Trie.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/Trie.cpp
@@ -59,9 +59,9 @@ bcos::task::Task<TrieNode> trieLoadFromRef(NodeCache& cache, NodeRef const& ref)
 /// hash string (0xa0 followed by the 32-byte digest) OR the inline node's complete RLP encoding.
 bcos::task::Task<TrieNode> trieLoadFromRawRef(NodeCache& cache, bcos::bytes const& childRaw)
 {
-    if (childRaw.size() == 33 && childRaw[0] == 0xa0)
+    if (childRaw.size() == HASH_REF_ENCODED_SIZE && childRaw[0] == RLP_HASH_REF_PREFIX)
     {
-        bcos::h256 const childHash(childRaw.data() + 1, 32);
+        bcos::h256 const childHash(childRaw.data() + 1, bcos::h256::SIZE);
         co_return co_await trieLoadByHash(cache, childHash);
     }
     co_return decodeNode(bcos::ref(childRaw));
@@ -80,7 +80,7 @@ bcos::task::Task<std::optional<bcos::bytes>> Trie::get(bcos::h256 const& keyHash
     bcos::bytes const path = bytesToNibbles(keyHash.ref());  // 64 nibbles
     size_t pos = 0;                                          // nibbles consumed so far
 
-    TrieNode node = co_await trieLoadByHash(m_cache, m_root);
+    TrieNode node = co_await trieLoadByHash(m_cache.get(), m_root);
     while (true)
     {
         if (std::holds_alternative<EmptyNode>(node))
@@ -91,8 +91,7 @@ bcos::task::Task<std::optional<bcos::bytes>> Trie::get(bcos::h256 const& keyHash
         if (auto const* leaf = std::get_if<LeafNode>(&node))
         {
             // The remaining path is path[pos..end]; it must equal the leaf suffix exactly.
-            size_t const remaining = path.size() - pos;
-            if (remaining != leaf->keyNibbles.size())
+            if (size_t const remaining = path.size() - pos; remaining != leaf->keyNibbles.size())
             {
                 co_return std::nullopt;
             }
@@ -106,8 +105,7 @@ bcos::task::Task<std::optional<bcos::bytes>> Trie::get(bcos::h256 const& keyHash
         if (auto const* ext = std::get_if<ExtensionNode>(&node))
         {
             // The remaining path must start with the shared nibbles.
-            size_t const remaining = path.size() - pos;
-            if (remaining < ext->sharedNibbles.size())
+            if (size_t const remaining = path.size() - pos; remaining < ext->sharedNibbles.size())
             {
                 co_return std::nullopt;
             }
@@ -117,26 +115,26 @@ bcos::task::Task<std::optional<bcos::bytes>> Trie::get(bcos::h256 const& keyHash
                 co_return std::nullopt;
             }
             pos += ext->sharedNibbles.size();
-            node = co_await trieLoadFromRawRef(m_cache, ext->child);
+            node = co_await trieLoadFromRawRef(m_cache.get(), ext->child);
             continue;
         }
 
         // BranchNode
-        auto const& br = std::get<BranchNode>(node);
+        const auto& [children, value] = std::get<BranchNode>(node);
         if (pos == path.size())
         {
             // All nibbles consumed at a branch: the value (if any) belongs to this key.
-            co_return br.value.empty() ? std::nullopt : std::optional<bcos::bytes>{br.value};
+            co_return value.empty() ? std::nullopt : std::optional<bcos::bytes>{value};
         }
-        bcos::byte const nib = path[pos];
-        NodeRef const& child = br.children[nib];
+        bcos::byte const nib = path.at(pos);
+        NodeRef const& child = children.at(nib);
         // Absent child == Inline with empty inlineBytes.
         if (child.kind == NodeRef::Kind::Inline && child.inlineBytes.empty())
         {
             co_return std::nullopt;
         }
         pos += 1;
-        node = co_await trieLoadFromRef(m_cache, child);
+        node = co_await trieLoadFromRef(m_cache.get(), child);
     }
 }
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/Trie.h
+++ b/bcos-ledger/bcos-ledger/mpt/Trie.h
@@ -21,6 +21,7 @@
 #include <bcos-task/Task.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <functional>
 #include <optional>
 
 namespace bcos::ledger::mpt
@@ -36,7 +37,7 @@ public:
     bcos::h256 root() const noexcept { return m_root; }
 
 private:
-    NodeCache& m_cache;
+    std::reference_wrapper<NodeCache> m_cache;
     bcos::h256 m_root;
 };
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/TrieNode.h
+++ b/bcos-ledger/bcos-ledger/mpt/TrieNode.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include "Nibble.h"
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <array>
@@ -26,8 +27,6 @@
 
 namespace bcos::ledger::mpt
 {
-
-inline constexpr std::uint8_t NIBBLE_RANGE = 16;
 
 /// The empty trie node — its RLP encoding is the single byte 0x80 (RLP empty string).
 struct EmptyNode

--- a/bcos-ledger/test/unittests/mpt/ComputeTrieRootTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ComputeTrieRootTest.cpp
@@ -1,0 +1,148 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ComputeTrieRootTest.cpp
+ * @brief Tests for the stateless computeTrieRoot core: equals the reference oracle and the stateful
+ *        HashBuilder, and is reentrant (safe to run concurrently for independent inputs).
+ */
+
+#include "TestHelpers.h"
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/NodeCache.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <map>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(ComputeTrieRootSuite)
+
+namespace
+{
+// Distinct random h256 keys + small random values. Unique `ctr*` names avoid an anonymous-namespace
+// ODR clash with the other mpt test files under UNITY_BUILD.
+std::vector<std::pair<bcos::h256, bcos::bytes>> ctrRandomKvs(size_t count, uint32_t seed)
+{
+    auto rng = seededRng(seed);
+    std::vector<std::pair<bcos::h256, bcos::bytes>> kvs;
+    kvs.reserve(count);
+    for (size_t i = 0; i < count; ++i)
+    {
+        bcos::h256 key{};
+        for (size_t j = 0; j < bcos::h256::SIZE; ++j)
+        {
+            key.data()[j] = static_cast<bcos::byte>(rng());
+        }
+        bcos::bytes value{static_cast<bcos::byte>(rng()), static_cast<bcos::byte>(rng()),
+            static_cast<bcos::byte>(rng())};
+        kvs.emplace_back(key, std::move(value));
+    }
+    return kvs;
+}
+
+// Collect kvs into a std::map: an ascending-by-keyHash range satisfying TrieEntryRange.
+std::map<bcos::h256, bcos::bytes> ctrSortedMap(
+    std::vector<std::pair<bcos::h256, bcos::bytes>> const& kvs)
+{
+    std::map<bcos::h256, bcos::bytes> sorted;
+    for (auto const& [key, value] : kvs)
+    {
+        sorted[key] = value;
+    }
+    return sorted;
+}
+}  // namespace
+
+// The stateless core must agree with the independent reference oracle AND with the stateful
+// HashBuilder — same root and a byte-identical produced node set — across several batch sizes.
+BOOST_AUTO_TEST_CASE(MatchesReferenceAndStatefulCommit)
+{
+    for (size_t size : {size_t{1}, size_t{2}, size_t{5}, size_t{20}, size_t{100}})
+    {
+        auto const kvs = ctrRandomKvs(size, /*seed=*/0xABC + static_cast<uint32_t>(size));
+        bcos::h256 const expected = referenceRoot(kvs);
+
+        auto const sorted = ctrSortedMap(kvs);
+        TrieBuildResult const result = computeTrieRoot(sorted);
+        BOOST_CHECK_EQUAL(result.root, expected);
+
+        NodeCache cache;
+        HashBuilder builder(cache, emptyRootHash());
+        for (auto const& [key, value] : kvs)
+        {
+            bcos::task::syncWait(builder.put(key, value));
+        }
+        bcos::h256 const commitRoot = bcos::task::syncWait(builder.commit());
+        BOOST_CHECK_EQUAL(result.root, commitRoot);
+        // unordered_map operator== is content-based: this is a byte-identical node-set check.
+        BOOST_CHECK(result.newNodes == builder.drainNewNodes());
+    }
+}
+
+// An empty input commits to the canonical empty-trie root and produces no nodes.
+BOOST_AUTO_TEST_CASE(EmptyInputIsEmptyRoot)
+{
+    std::map<bcos::h256, bcos::bytes> const empty;
+    TrieBuildResult const result = computeTrieRoot(empty);
+    BOOST_CHECK_EQUAL(result.root, emptyRootHash());
+    BOOST_CHECK(result.newNodes.empty());
+}
+
+// computeTrieRoot owns no shared state, so building many independent tries concurrently must yield
+// exactly the roots produced serially — the safety property coarse-grained parallelism relies on.
+BOOST_AUTO_TEST_CASE(ConcurrentBuildsAreReentrant)
+{
+    constexpr size_t taskCount = 16;
+    std::vector<std::map<bcos::h256, bcos::bytes>> inputs;
+    std::vector<bcos::h256> expected;
+    inputs.reserve(taskCount);
+    expected.reserve(taskCount);
+    for (size_t idx = 0; idx < taskCount; ++idx)
+    {
+        auto const kvs = ctrRandomKvs(50, /*seed=*/0xBEEF + static_cast<uint32_t>(idx));
+        expected.push_back(referenceRoot(kvs));
+        inputs.push_back(ctrSortedMap(kvs));
+    }
+
+    std::vector<bcos::h256> roots(taskCount);
+    std::vector<std::thread> threads;
+    threads.reserve(taskCount);
+    for (size_t idx = 0; idx < taskCount; ++idx)
+    {
+        threads.emplace_back(
+            [&inputs, &roots, idx]() { roots[idx] = computeTrieRoot(inputs[idx]).root; });
+    }
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    for (size_t idx = 0; idx < taskCount; ++idx)
+    {
+        BOOST_CHECK_EQUAL(roots[idx], expected[idx]);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/ports/group-sig/portfile.cmake
+++ b/ports/group-sig/portfile.cmake
@@ -15,13 +15,18 @@ vcpkg_execute_build_process(
     LOGNAME "patch-${TARGET_TRIPLET}"
 )
 
-# ProjectPbc.cmake uses PREFIX ${CMAKE_SOURCE_DIR}/deps, so CMake 3.30's
-# ExternalProject configure_file writes to deps/tmp/ before it exists.
-# Pre-create it so both parallel debug/release configure passes succeed.
+# ProjectPbc.cmake/ProjectPbcSig.cmake use PREFIX ${CMAKE_SOURCE_DIR}/deps (an
+# absolute path in the shared source tree). CMake 3.30's ExternalProject writes
+# deps/tmp/<name>-mkdirs.cmake before that dir exists, so pre-create it.
 file(MAKE_DIRECTORY "${SOURCE_PATH}/deps/tmp")
 
+# DISABLE_PARALLEL_CONFIGURE: debug and release configures share that same
+# absolute deps/ PREFIX. Running them in parallel (vcpkg's default) races on the
+# shared tree and intermittently fails in ExternalProject _ep_set_directories
+# ("configure_file: No such file or directory"). Configure them sequentially.
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_PARALLEL_CONFIGURE
     OPTIONS
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
 )


### PR DESCRIPTION
## What

Extracts a stateless build core from `HashBuilder` and tidies the MPT module. Existing APIs keep their behaviour — `HashBuilder::commit` is refactored to delegate to the new core and stays byte-identical (the §5.6 1000-run determinism test still passes).

- **`computeTrieRoot(std::map<h256, bytes>) -> {root, newNodes}`** — a pure, reentrant builder that `HashBuilder::commit` now delegates to. It owns its hasher and touches no shared state or `NodeCache`, so independent tries can be built concurrently (coarse-grained parallelism across tries). Taking `std::map` as the input type pins ordering, ascending direction and key uniqueness at compile time, so the build needs no sort or `is_sorted` pass.
- **const-correctness** — `Trie::m_cache` and `HashBuilder::m_cache` become `std::reference_wrapper<NodeCache>` to satisfy `cppcoreguidelines-avoid-const-or-ref-data-members`, matching the existing house idiom (`EVMAccount`, `MemoryStorage`, ...).
- **named constants** — magic numbers across the module are consolidated into `RLP_HASH_REF_PREFIX`, `HASH_REF_ENCODED_SIZE`, `NIBBLE_BITS`, `NIBBLES_PER_BYTE`, `LOW_NIBBLE_MASK`, `DEFAULT_CACHE_CAPACITY_BYTES`, `LEAF_OR_EXTENSION_ITEM_COUNT`, reusing the existing `NIBBLE_RANGE` and `h256::SIZE`.
- **`ports/group-sig`** — `DISABLE_PARALLEL_CONFIGURE` fixes an intermittent macOS vcpkg build race where the debug/release configures share one absolute ExternalProject `deps/` PREFIX and clobber each other.

## Tests

New `ComputeTrieRootTest` (3 cases): the stateless core matches the independent reference oracle and the stateful `commit()` (root + byte-identical node set) across batch sizes {1,2,5,20,100}; empty input → empty root; 16 threads building independent tries concurrently all match their serial results. Verified locally (macOS, Debug): `test-bcos-ledger` → 33 cases, `*** No errors detected`.
