### PR TITLE
fix(pbft): tie PBFT submessage lifetime to parent via aliasing shared_ptr (FIB-121)

### DIFF
--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTMessage.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTMessage.cpp
@@ -61,14 +61,16 @@ void PBFTMessage::deserializeToObject()
     m_proposals->clear();
     if (m_pbftRawMessage->has_consensusproposal())
     {
-        auto* consensusProposal = m_pbftRawMessage->mutable_consensusproposal();
-        std::shared_ptr<PBFTRawProposal> rawConsensusProposal(consensusProposal);
-        m_consensusProposal = std::make_shared<PBFTProposal>(rawConsensusProposal);
+        // FIB-121: aliasing shared_ptr shares m_pbftRawMessage's control block, so the
+        // child wrapper keeps the parent protobuf alive and never deletes the submessage
+        // itself -- no dual-ownership, no destructor release dance.
+        m_consensusProposal = std::make_shared<PBFTProposal>(std::shared_ptr<PBFTRawProposal>(
+            m_pbftRawMessage, m_pbftRawMessage->mutable_consensusproposal()));
     }
     for (int i = 0; i < m_pbftRawMessage->proposals_size(); i++)
     {
-        std::shared_ptr<PBFTRawProposal> rawProposal(m_pbftRawMessage->mutable_proposals(i));
-        m_proposals->push_back(std::make_shared<PBFTProposal>(rawProposal));
+        m_proposals->push_back(std::make_shared<PBFTProposal>(std::shared_ptr<PBFTRawProposal>(
+            m_pbftRawMessage, m_pbftRawMessage->mutable_proposals(i))));
     }
 }
 
@@ -80,15 +82,14 @@ void PBFTMessage::decodeAndSetSignature(CryptoSuite::Ptr _cryptoSuite, bytesCons
 
 void PBFTMessage::setConsensusProposal(PBFTProposalInterface::Ptr _consensusProposal)
 {
-    m_consensusProposal = _consensusProposal;
     auto pbftProposal = std::dynamic_pointer_cast<PBFTProposal>(_consensusProposal);
-    // set committed proposal
-    if (m_pbftRawMessage->has_consensusproposal())
-    {
-        m_pbftRawMessage->unsafe_arena_release_consensusproposal();
-    }
-    m_pbftRawMessage->unsafe_arena_set_allocated_consensusproposal(
-        pbftProposal->pbftRawProposal().get());
+    // FIB-121: deep-copy the caller's proposal into our own protobuf, then expose an
+    // aliasing wrapper over that copy. Nothing is shared with the caller, and proofs
+    // later appended via consensusProposal() (e.g. PBFTCache::intoPrecommit ->
+    // setSignatureList) write through to m_pbftRawMessage and survive encode().
+    m_pbftRawMessage->mutable_consensusproposal()->CopyFrom(*pbftProposal->pbftRawProposal());
+    m_consensusProposal = std::make_shared<PBFTProposal>(std::shared_ptr<PBFTRawProposal>(
+        m_pbftRawMessage, m_pbftRawMessage->mutable_consensusproposal()));
 }
 
 HashType PBFTMessage::getHashFieldsDataHash(CryptoSuite::Ptr _cryptoSuite) const
@@ -112,14 +113,17 @@ void PBFTMessage::generateAndSetSignatureData(
 
 void PBFTMessage::setProposals(PBFTProposalList const& _proposals)
 {
+    // FIB-121: keep the caller's wrappers in the member list (identity + in-memory fields
+    // preserved, exactly as before) and deep-copy each into our protobuf for encode. The
+    // protobuf owns its copies normally, so there is no borrowed raw pointer to release in
+    // the destructor (was UnsafeArenaAddAllocated borrow + ~PBFTMessage release).
     *m_proposals = _proposals;
     m_pbftRawMessage->clear_proposals();
     for (const auto& proposal : _proposals)
     {
         auto proposalImpl = std::dynamic_pointer_cast<PBFTProposal>(proposal);
         assert(proposalImpl);
-        m_pbftRawMessage->mutable_proposals()->UnsafeArenaAddAllocated(
-            proposalImpl->pbftRawProposal().get());
+        m_pbftRawMessage->add_proposals()->CopyFrom(*proposalImpl->pbftRawProposal());
     }
 }
 

--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTMessage.h
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTMessage.h
@@ -50,20 +50,10 @@ public:
         decodeAndSetSignature(std::move(_cryptoSuite), _data);
     }
 
-    ~PBFTMessage() override
-    {
-        // return back the ownership to m_consensusProposal
-        if (m_pbftRawMessage->has_consensusproposal())
-        {
-            m_pbftRawMessage->unsafe_arena_release_consensusproposal();
-        }
-        // return the ownership of rawProposal to the passed-in proposal
-        auto allocatedProposalSize = m_pbftRawMessage->proposals_size();
-        for (int i = 0; i < allocatedProposalSize; i++)
-        {
-            m_pbftRawMessage->mutable_proposals()->UnsafeArenaReleaseLast();
-        }
-    }
+    // FIB-121: consensusProposal / proposals wrappers hold aliasing shared_ptrs that
+    // share this message's control block; they never own the submessages, so there is
+    // no ownership to release here (was a fragile unsafe_arena_release dance).
+    ~PBFTMessage() override = default;
 
     std::shared_ptr<PBFTRawMessage> pbftRawMessage() { return m_pbftRawMessage; }
     bytesPointer encode(bcos::crypto::CryptoSuite::Ptr _cryptoSuite,

--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTNewViewMsg.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTNewViewMsg.cpp
@@ -36,46 +36,60 @@ bytesPointer PBFTNewViewMsg::encode(CryptoSuite::Ptr, KeyPairInterface::Ptr) con
 void PBFTNewViewMsg::decode(bytesConstRef _data)
 {
     decodePBObject(m_rawNewView, _data);
-    setBaseMessage(std::shared_ptr<BaseMessage>(m_rawNewView->mutable_message()));
+    setBaseMessage(std::shared_ptr<BaseMessage>(m_rawNewView, m_rawNewView->mutable_message()));
     PBFTNewViewMsg::deserializeToObject();
 }
 
 void PBFTNewViewMsg::deserializeToObject()
 {
     PBFTBaseMessage::deserializeToObject();
-    // decode into m_viewChangeList
+    // FIB-121: clear before repopulating so a re-decode does not accumulate duplicate
+    // aliasing wrappers (matches PBFTMessage / PBFTViewChangeMsg::deserializeToObject).
+    m_viewChangeList->clear();
+    m_prePrepareList->clear();
+    // aliasing shared_ptrs share m_rawNewView's control block, so every nested
+    // viewChange / prePrepare wrapper keeps the NewView protobuf alive and owns nothing.
     for (int i = 0; i < m_rawNewView->viewchangemsglist_size(); i++)
     {
-        std::shared_ptr<RawViewChangeMessage> pbRawViewChange(
-            m_rawNewView->mutable_viewchangemsglist(i));
-        m_viewChangeList->push_back(std::make_shared<PBFTViewChangeMsg>(pbRawViewChange));
+        m_viewChangeList->push_back(
+            std::make_shared<PBFTViewChangeMsg>(std::shared_ptr<RawViewChangeMessage>(
+                m_rawNewView, m_rawNewView->mutable_viewchangemsglist(i))));
     }
-    // decode into m_prePrepareList
     for (int i = 0; i < m_rawNewView->prepreparelist_size(); i++)
     {
-        std::shared_ptr<PBFTRawMessage> pbftRawMessage(m_rawNewView->mutable_prepreparelist(i));
-        m_prePrepareList->push_back(std::make_shared<PBFTMessage>(pbftRawMessage));
+        m_prePrepareList->push_back(std::make_shared<PBFTMessage>(std::shared_ptr<PBFTRawMessage>(
+            m_rawNewView, m_rawNewView->mutable_prepreparelist(i))));
     }
 }
 
 void PBFTNewViewMsg::setViewChangeMsgList(ViewChangeMsgList const& _viewChangeMsgList)
 {
+    // FIB-121: keep the caller's viewChange wrappers in the member list (identity +
+    // in-memory fields preserved, as before) and deep-copy each into our protobuf for encode
+    // (was AddAllocated borrow + destructor release). The in-memory FIB-124 cross-check reads
+    // the originals, so their nested preparedProposals stay intact without a hashfieldsdata
+    // round-trip.
     *m_viewChangeList = _viewChangeMsgList;
-    for (auto viewChangeMsg : _viewChangeMsgList)
+    m_rawNewView->clear_viewchangemsglist();
+    for (auto const& viewChangeMsg : _viewChangeMsgList)
     {
         auto pbViewChangeMsg = std::dynamic_pointer_cast<PBFTViewChangeMsg>(viewChangeMsg);
-        m_rawNewView->mutable_viewchangemsglist()->AddAllocated(
-            pbViewChangeMsg->rawViewChange().get());
+        m_rawNewView->add_viewchangemsglist()->CopyFrom(*pbViewChangeMsg->rawViewChange());
     }
 }
 
 void PBFTNewViewMsg::setPrePrepareList(PBFTMessageList const& _prePrepareList)
 {
+    // FIB-121: keep the caller's prePrepare wrappers in the member list and deep-copy each
+    // into our protobuf for encode (was AddAllocated borrow + destructor release).
     *m_prePrepareList = _prePrepareList;
-    for (auto prePrepare : _prePrepareList)
+    m_rawNewView->clear_prepreparelist();
+    for (auto const& prePrepare : _prePrepareList)
     {
         auto pbPrePrepare = std::dynamic_pointer_cast<PBFTMessage>(prePrepare);
+        // flush the inner base header into hashfieldsdata before copying (the prePrepare's
+        // base message is serialized into bytes, not embedded as a nested message field).
         pbPrePrepare->encodeHashFields();
-        m_rawNewView->mutable_prepreparelist()->AddAllocated(pbPrePrepare->pbftRawMessage().get());
+        m_rawNewView->add_prepreparelist()->CopyFrom(*pbPrePrepare->pbftRawMessage());
     }
 }

--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTNewViewMsg.h
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTNewViewMsg.h
@@ -34,7 +34,9 @@ public:
     PBFTNewViewMsg() : PBFTBaseMessage()
     {
         m_rawNewView = std::make_shared<RawNewViewMessage>();
-        m_rawNewView->set_allocated_message(PBFTBaseMessage::baseMessage().get());
+        // FIB-121: alias the base header onto the protobuf's `message` field (was
+        // set_allocated_message + destructor release).
+        setBaseMessage(std::shared_ptr<BaseMessage>(m_rawNewView, m_rawNewView->mutable_message()));
         m_viewChangeList = std::make_shared<ViewChangeMsgList>();
         m_prePrepareList = std::make_shared<PBFTMessageList>();
         m_packetType = PacketType::NewViewPacket;
@@ -48,22 +50,9 @@ public:
         decode(_data);
     }
 
-    ~PBFTNewViewMsg() override
-    {
-        // return back the ownership of message to the PBFTBaseMessage
-        m_rawNewView->unsafe_arena_release_message();
-        // return back the ownership to m_viewChangeList
-        auto viewChangeSize = m_rawNewView->viewchangemsglist_size();
-        for (auto i = 0; i < viewChangeSize; i++)
-        {
-            m_rawNewView->mutable_viewchangemsglist()->UnsafeArenaReleaseLast();
-        }
-        auto preprepareSize = m_rawNewView->prepreparelist_size();
-        for (auto i = 0; i < preprepareSize; i++)
-        {
-            m_rawNewView->mutable_prepreparelist()->UnsafeArenaReleaseLast();
-        }
-    }
+    // FIB-121: base header / viewChangeMsgList / prePrepareList wrappers hold aliasing
+    // shared_ptrs that share this object's control block; nothing to release here.
+    ~PBFTNewViewMsg() override = default;
 
     bytesPointer encode(bcos::crypto::CryptoSuite::Ptr _cryptoSuite,
         bcos::crypto::KeyPairInterface::Ptr _keyPair) const override;

--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTRequest.h
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTRequest.h
@@ -19,8 +19,8 @@
  * @date 2021-04-28
  */
 #pragma once
-#include "bcos-pbft/pbft/interfaces/PBFTRequestInterface.h"
 #include "PBFTBaseMessage.h"
+#include "bcos-pbft/pbft/interfaces/PBFTRequestInterface.h"
 #include "bcos-pbft/pbft/protocol/proto/PBFT.pb.h"
 #include <bcos-protocol/Common.h>
 
@@ -34,7 +34,9 @@ public:
     PBFTRequest() : PBFTBaseMessage()
     {
         m_pbRequest = std::make_shared<ProposalRequest>();
-        m_pbRequest->set_allocated_message(PBFTBaseMessage::baseMessage().get());
+        // FIB-121: alias the base header onto the protobuf's `message` field (was
+        // set_allocated_message + destructor release).
+        setBaseMessage(std::shared_ptr<BaseMessage>(m_pbRequest, m_pbRequest->mutable_message()));
     }
     explicit PBFTRequest(bytesConstRef _data) : PBFTBaseMessage()
     {
@@ -42,7 +44,8 @@ public:
         decode(_data);
     }
 
-    ~PBFTRequest() override { m_pbRequest->unsafe_arena_release_message(); }
+    // FIB-121: the base header wrapper aliases m_pbRequest's control block; nothing to release.
+    ~PBFTRequest() override = default;
 
     void setSize(int64_t _size) override { m_pbRequest->set_size(_size); }
     int64_t size() const override { return m_pbRequest->size(); }
@@ -56,7 +59,7 @@ public:
     void decode(bytesConstRef _data) override
     {
         bcos::protocol::decodePBObject(m_pbRequest, _data);
-        setBaseMessage(std::shared_ptr<BaseMessage>(m_pbRequest->mutable_message()));
+        setBaseMessage(std::shared_ptr<BaseMessage>(m_pbRequest, m_pbRequest->mutable_message()));
         PBFTBaseMessage::deserializeToObject();
     }
 

--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTViewChangeMsg.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTViewChangeMsg.cpp
@@ -29,7 +29,9 @@ using namespace bcos::consensus;
 using namespace bcos::protocol;
 using namespace bcos::crypto;
 PBFTViewChangeMsg::PBFTViewChangeMsg(std::shared_ptr<RawViewChangeMessage> _rawViewChange)
-  : PBFTBaseMessage(std::shared_ptr<BaseMessage>(_rawViewChange->mutable_message()))
+  // FIB-121: alias the base header onto the viewed protobuf's `message` field so the
+  // base wrapper shares _rawViewChange's control block (no owning-over-borrowed pointer).
+  : PBFTBaseMessage(std::shared_ptr<BaseMessage>(_rawViewChange, _rawViewChange->mutable_message()))
 {
     m_packetType = PacketType::ViewChangePacket;
     m_preparedProposalList = std::make_shared<PBFTMessageList>();
@@ -45,32 +47,34 @@ bytesPointer PBFTViewChangeMsg::encode(CryptoSuite::Ptr, KeyPairInterface::Ptr) 
 void PBFTViewChangeMsg::decode(bytesConstRef _data)
 {
     decodePBObject(m_rawViewChange, _data);
-    setBaseMessage(std::shared_ptr<BaseMessage>(m_rawViewChange->mutable_message()));
+    setBaseMessage(
+        std::shared_ptr<BaseMessage>(m_rawViewChange, m_rawViewChange->mutable_message()));
     PBFTViewChangeMsg::deserializeToObject();
     m_packetType = PacketType::ViewChangePacket;
 }
 
 void PBFTViewChangeMsg::setCommittedProposal(PBFTProposalInterface::Ptr _proposal)
 {
-    m_committedProposal = _proposal;
     auto pbftProposal = std::dynamic_pointer_cast<PBFTProposal>(_proposal);
-    // set committed proposal
-    if (m_rawViewChange->has_committedproposal())
-    {
-        m_rawViewChange->unsafe_arena_release_committedproposal();
-    }
-    m_rawViewChange->unsafe_arena_set_allocated_committedproposal(
-        pbftProposal->pbftRawProposal().get());
+    // FIB-121: deep-copy into our protobuf, then alias a wrapper over our own copy.
+    m_rawViewChange->mutable_committedproposal()->CopyFrom(*pbftProposal->pbftRawProposal());
+    m_committedProposal = std::make_shared<PBFTProposal>(std::shared_ptr<PBFTRawProposal>(
+        m_rawViewChange, m_rawViewChange->mutable_committedproposal()));
 }
 
 void PBFTViewChangeMsg::setPreparedProposals(PBFTMessageList const& _preparedProposals)
 {
+    // FIB-121: keep the caller's prePrepare wrappers in the member list (identity +
+    // in-memory base fields preserved, as before) and deep-copy each into our protobuf for
+    // encode (was AddAllocated borrow + destructor release). A PBFTMessage's base fields
+    // round-trip through hashfieldsdata, so rebuilding wrappers from the copy would lose any
+    // fields the caller had not yet flushed -- keeping the originals avoids that.
     *m_preparedProposalList = _preparedProposals;
-    for (auto proposal : *m_preparedProposalList)
+    m_rawViewChange->clear_preparedproposals();
+    for (auto const& proposal : _preparedProposals)
     {
         auto pbftMessage = std::dynamic_pointer_cast<PBFTMessage>(proposal);
-        m_rawViewChange->mutable_preparedproposals()->AddAllocated(
-            pbftMessage->pbftRawMessage().get());
+        m_rawViewChange->add_preparedproposals()->CopyFrom(*pbftMessage->pbftRawMessage());
     }
 }
 
@@ -80,28 +84,24 @@ void PBFTViewChangeMsg::deserializeToObject()
     m_preparedProposalList->clear();
     // FIB-121 / Issue #3 (DoS mitigation): reject oversized preparedProposals
     // before allocating any wrappers, preventing memory-exhaustion attacks from
-    // malicious peers and shrinking the bad_alloc surface that Issue #1
-    // (partial-construct exception unwinding) depends on.
+    // malicious peers.
     //
-    // A full structural fix for Issue #1 (release-then-wrap, or aliasing
-    // shared_ptrs throughout) requires consistently restructuring the encode
-    // path (setCommittedProposal / setPreparedProposals / PBFTNewViewMsg's
-    // viewchangemsglist AddAllocated) and the destructors of PBFTViewChangeMsg
-    // / PBFTNewViewMsg / PBFTMessage, all of which currently rely on a fragile
-    // dual-ownership + destructor-release protocol.  That refactor is deferred
-    // because (a) it crosses several files with subtle invariants, and (b) the
-    // size cap below reduces the bad_alloc trigger surface to near-zero for the
-    // realistic threat model (an attacker sending an oversized message — the
-    // primary CertiK concern in Issue #3).
+    // FIB-121 / Issue #1 structural fix (applied): committedProposal /
+    // preparedProposals wrappers below, and the encode-path setters
+    // (setCommittedProposal / setPreparedProposals / PBFTNewViewMsg's list setters),
+    // now use aliasing shared_ptrs that share m_rawViewChange's control block instead
+    // of the old dual-ownership + destructor-release protocol. Every wrapper keeps the
+    // owning protobuf alive and deletes nothing, so partial-construct exception
+    // unwinding can no longer double-free or leak.
     validateRepeatedSize(
         m_rawViewChange->preparedproposals(), MAX_PBFT_REPEATED_FIELD_SIZE, "preparedProposals");
 
-    std::shared_ptr<PBFTRawProposal> rawCommittedProposal(
-        m_rawViewChange->mutable_committedproposal());
-    m_committedProposal = std::make_shared<PBFTProposal>(rawCommittedProposal);
+    m_committedProposal = std::make_shared<PBFTProposal>(std::shared_ptr<PBFTRawProposal>(
+        m_rawViewChange, m_rawViewChange->mutable_committedproposal()));
     for (int i = 0; i < m_rawViewChange->preparedproposals_size(); i++)
     {
-        std::shared_ptr<PBFTRawMessage> preparedMsg(m_rawViewChange->mutable_preparedproposals(i));
-        m_preparedProposalList->push_back(std::make_shared<PBFTMessage>(preparedMsg));
+        m_preparedProposalList->push_back(
+            std::make_shared<PBFTMessage>(std::shared_ptr<PBFTRawMessage>(
+                m_rawViewChange, m_rawViewChange->mutable_preparedproposals(i))));
     }
 }

--- a/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTViewChangeMsg.h
+++ b/bcos-pbft/bcos-pbft/pbft/protocol/PB/PBFTViewChangeMsg.h
@@ -31,7 +31,11 @@ public:
     {
         m_preparedProposalList = std::make_shared<PBFTMessageList>();
         m_rawViewChange = std::make_shared<RawViewChangeMessage>();
-        m_rawViewChange->set_allocated_message(PBFTBaseMessage::baseMessage().get());
+        // FIB-121: alias the base header onto the protobuf's `message` field instead of
+        // set_allocated_message + destructor release. Base setters then write through to
+        // m_rawViewChange, so encode() is self-contained with no ownership juggling.
+        setBaseMessage(
+            std::shared_ptr<BaseMessage>(m_rawViewChange, m_rawViewChange->mutable_message()));
         m_packetType = PacketType::ViewChangePacket;
     }
 
@@ -43,22 +47,9 @@ public:
         decode(_data);
     }
 
-    ~PBFTViewChangeMsg() override
-    {
-        // return back the ownership of message to PBFTBaseMessage
-        m_rawViewChange->unsafe_arena_release_message();
-        // return back the ownership to m_committedProposal
-        if (m_rawViewChange->has_committedproposal())
-        {
-            m_rawViewChange->unsafe_arena_release_committedproposal();
-        }
-        // return back the ownership to m_preparedProposalList
-        auto preparedProposalSize = m_rawViewChange->preparedproposals_size();
-        for (auto i = 0; i < preparedProposalSize; i++)
-        {
-            m_rawViewChange->mutable_preparedproposals()->UnsafeArenaReleaseLast();
-        }
-    }
+    // FIB-121: base header / committedProposal / preparedProposals wrappers hold aliasing
+    // shared_ptrs that share this object's control block; nothing to release here.
+    ~PBFTViewChangeMsg() override = default;
 
     std::shared_ptr<RawViewChangeMessage> rawViewChange() { return m_rawViewChange; }
 

--- a/bcos-pbft/test/unittests/protocol/FIB121_ProofSurvivalTest.cpp
+++ b/bcos-pbft/test/unittests/protocol/FIB121_ProofSurvivalTest.cpp
@@ -1,0 +1,147 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief FIB-121 characterization net: signature proofs appended to a
+ *        consensusProposal AFTER it is set into a message must survive encode.
+ *        The aliasing-shared_ptr ownership fix exposes consensusProposal() as a
+ *        write-through view of the message's own protobuf, so the
+ *        PBFTCache::intoPrecommit -> setSignatureList pattern (PBFTCache.cpp:172)
+ *        keeps working. A copy-at-set design that snapshotted the proposal would
+ *        silently drop later proofs; this test is the regression guard.
+ * @file FIB121_ProofSurvivalTest.cpp
+ * @date 2026-06-26
+ */
+#include "bcos-pbft/pbft/protocol/PB/PBFTMessage.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTProposal.h"
+#include "bcos-pbft/pbft/protocol/PB/PBFTViewChangeMsg.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::crypto;
+using namespace bcos::consensus;
+using namespace bcos::protocol;
+using namespace std::string_view_literals;
+
+namespace bcos::test
+{
+BOOST_FIXTURE_TEST_SUITE(FIB121ProofSurvivalTest, TestPromptFixture)
+
+static CryptoSuite::Ptr makeSuite()
+{
+    return std::make_shared<CryptoSuite>(
+        std::make_shared<Keccak256>(), std::make_shared<Secp256k1Crypto>(), nullptr);
+}
+
+// A consensus proposal carrying block data but NO signature proofs yet.
+static PBFTProposal::Ptr makeBareProposal(
+    CryptoSuite::Ptr const& _suite, BlockNumber _index, bytes const& _data)
+{
+    auto proposal = std::make_shared<PBFTProposal>();
+    proposal->setIndex(_index);
+    proposal->setHash(_suite->hashImpl()->hash("proposal"sv));
+    proposal->setData(_data);
+    return proposal;
+}
+
+// Direct: append proofs AFTER setConsensusProposal, then encode the message
+// itself. The proofs must be present in the re-decoded message.
+BOOST_AUTO_TEST_CASE(mutateAfterSetReflectedAtEncode)
+{
+    auto suite = makeSuite();
+    KeyPairInterface::Ptr keyPair = suite->signatureImpl()->generateKeyPair();
+    bytes data{'b', 'l', 'o', 'c', 'k', 'd', 'a', 't', 'a'};
+
+    auto proposal = makeBareProposal(suite, 100, data);
+    BOOST_CHECK(proposal->signatureProofSize() == 0);
+
+    auto prePrepare = std::make_shared<PBFTMessage>();
+    prePrepare->setPacketType(PacketType::PrePreparePacket);
+    prePrepare->setVersion(1);
+    prePrepare->setView(1);
+    prePrepare->setIndex(100);
+    prePrepare->setHash(proposal->hash());
+    prePrepare->setConsensusProposal(proposal);
+
+    // mutate AFTER set (the intoPrecommit / setSignatureList pattern)
+    bytes sig0{'s', '0'};
+    bytes sig1{'s', '1'};
+    prePrepare->consensusProposal()->appendSignatureProof(7, ref(sig0));
+    prePrepare->consensusProposal()->appendSignatureProof(9, ref(sig1));
+    BOOST_CHECK(prePrepare->consensusProposal()->signatureProofSize() == 2);
+
+    auto encoded = prePrepare->encode(suite, keyPair);
+    auto decoded = std::make_shared<PBFTMessage>(suite, ref(*encoded));
+
+    BOOST_REQUIRE(decoded->consensusProposal() != nullptr);
+    BOOST_CHECK_EQUAL(decoded->consensusProposal()->signatureProofSize(), 2U);
+    BOOST_CHECK_EQUAL(decoded->consensusProposal()->signatureProof(0).first, 7);
+    BOOST_CHECK_EQUAL(decoded->consensusProposal()->signatureProof(1).first, 9);
+    BOOST_CHECK(decoded->consensusProposal()->signatureProof(0).second.toBytes() == sig0);
+    BOOST_CHECK(decoded->consensusProposal()->signatureProof(1).second.toBytes() == sig1);
+    BOOST_CHECK(decoded->consensusProposal()->data().toBytes() == data);
+}
+
+// Embedded: the prePrepare whose proposal was mutated-after-set is embedded into
+// a ViewChange and encoded. The proofs must survive the nested round-trip — the
+// path that would fail under a copy-at-set design.
+BOOST_AUTO_TEST_CASE(proofSurvivesViewChangeEmbedding)
+{
+    auto suite = makeSuite();
+    bytes data{'p', 'a', 'y', 'l', 'o', 'a', 'd'};
+
+    auto proposal = makeBareProposal(suite, 200, data);
+    auto prePrepare = std::make_shared<PBFTMessage>();
+    prePrepare->setPacketType(PacketType::PrePreparePacket);
+    prePrepare->setVersion(1);
+    prePrepare->setView(2);
+    prePrepare->setIndex(200);
+    prePrepare->setHash(proposal->hash());
+    prePrepare->setConsensusProposal(proposal);
+
+    // mutate after set
+    bytes sig{'z', 'z'};
+    prePrepare->consensusProposal()->appendSignatureProof(3, ref(sig));
+    BOOST_CHECK(prePrepare->consensusProposal()->signatureProofSize() == 1);
+
+    auto committed = makeBareProposal(suite, 199, bytes{});
+
+    auto viewChange = std::make_shared<PBFTViewChangeMsg>();
+    viewChange->setPacketType(PacketType::ViewChangePacket);
+    viewChange->setVersion(1);
+    viewChange->setView(2);
+    viewChange->setIndex(200);
+    viewChange->setHash(proposal->hash());
+    viewChange->setCommittedProposal(committed);
+    PBFTMessageList prepared{prePrepare};
+    viewChange->setPreparedProposals(prepared);
+
+    auto encoded = viewChange->encode(nullptr, nullptr);
+    auto decodedViewChange = std::make_shared<PBFTViewChangeMsg>(ref(*encoded));
+
+    BOOST_REQUIRE_EQUAL(decodedViewChange->preparedProposals().size(), 1U);
+    auto const& decodedPrePrepare = decodedViewChange->preparedProposals()[0];
+    BOOST_REQUIRE(decodedPrePrepare->consensusProposal() != nullptr);
+    BOOST_CHECK_EQUAL(decodedPrePrepare->consensusProposal()->signatureProofSize(), 1U);
+    BOOST_CHECK_EQUAL(decodedPrePrepare->consensusProposal()->signatureProof(0).first, 3);
+    BOOST_CHECK(decodedPrePrepare->consensusProposal()->signatureProof(0).second.toBytes() == sig);
+    BOOST_CHECK(decodedPrePrepare->consensusProposal()->data().toBytes() == data);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
### What

CertiK FIB-121. Fixes the fragile borrow-and-release ownership of PBFT protobuf submessages by tying each submessage wrapper's lifetime to its parent message via a `shared_ptr` **aliasing constructor**.

This is a smaller-footprint alternative to #5287 (the value + non-owning-view rewrite): it keeps the existing class hierarchy, interfaces, and every getter signature, so no callers are touched. The diff is 96 insertions / 109 deletions across the PB message types (vs ~1200/1100 over 53 files in #5287).

### Problem

`PBFTMessage` / `PBFTViewChangeMsg` / `PBFTNewViewMsg` / `PBFTRequest` borrowed their protobuf submessages (`consensusProposal`, `proposals`, `committedProposal`, `preparedProposals`, `viewChangeMsgList`, `prePrepareList`, and the base `message`) by wrapping `mutable_*()` raw pointers in **owning** `shared_ptr`s, then balanced them with manual `unsafe_arena_release_*` / `UnsafeArenaReleaseLast` in destructors and `unsafe_arena_set_allocated_*` / `AddAllocated` on the set paths. This is only balanced when every take is matched by exactly one release on every path (including exception paths); any imbalance is a double-free or a leak.

### Fix

`PBFTProposal` already used this pattern internally for FIB-122 — an aliasing `shared_ptr` that ties `Proposal::m_rawProposal` to the owning `PBFTRawProposal`. This PR extends the same pattern to every parent→child submessage relationship:

- getters / decode build each child wrapper with `std::shared_ptr<Child>(owningParentShared, parent->mutable_child())` — the wrapper shares the parent protobuf's control block, so a live child keeps its parent alive and the wrapper deletes nothing;
- the base header is aliased onto the protobuf's `message` field instead of `set_allocated_message`, so base setters write straight through;
- set paths deep-copy the input into the owning protobuf (`CopyFrom`, which the protobuf then owns normally) and keep the caller's wrappers in the member list — no borrowed raw pointer escapes;
- every destructor becomes `= default`; the arena-release dance is gone.

`consensusProposal()` / `committedProposal()` are rebuilt as aliasing views of the owning protobuf so a proof appended after `setConsensusProposal` (the `PBFTCache::intoPrecommit` → `setSignatureList` path) still writes through and survives encode.

### Testing

- New `FIB121_ProofSurvivalTest` pins the mutate-after-set proof-survival behaviour (direct, and embedded into a ViewChange).
- `test-bcos-pbft` (143 cases) and `test-bcos-rpbft` pass; `test-sealer` builds.
- Static check: zero `unsafe_arena` / `set_allocated_message` / `AddAllocated` borrows remain in `bcos-pbft/.../protocol/PB/`.

### Notes

Alternative to #5287; both target FIB-121 (#5278). This branch is intentionally minimal and keeps the public API stable.
