### PR TITLE
fix(gateway,front,pbft,utilities): close consensus-halt-under-session-churn (FIB-184, FIB-185)

### DIFF
--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -22,9 +22,11 @@
 #include "bcos-crypto/interfaces/crypto/KeyInterface.h"
 #include "bcos-framework/gateway/GroupNodeInfo.h"
 #include "bcos-task/Task.h"
+#include "bcos-task/Wait.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/Error.h"
 #include <range/v3/view/any_view.hpp>
+#include <range/v3/view/single.hpp>
 
 namespace bcos::front
 {
@@ -131,6 +133,56 @@ public:
 
     virtual task::Task<void> broadcastMessage(
         uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) = 0;
+
+    /**
+     * @brief broadcast an already-encoded message, taking ownership of the payload so the send can
+     *        be deferred without copying the message body.
+     *
+     * The default implementation bridges to broadcastMessage on the caller thread (correct for the
+     * tars/MAX client and test fakes, which have no in-process gateway lock to contend). The
+     * production FrontService overrides this to dispatch the gateway send off the caller thread, so
+     * a caller holding a lock (e.g. the PBFT consensus worker under m_mutex) is never coupled to
+     * gateway session-lock contention under TLS-churn. The owned payload is kept alive for the
+     * duration of the send.
+     *
+     * Constraint for new implementations: if your environment has in-process send-path lock
+     * coupling (as AIR's gateway does), you MUST override this to dispatch the send off the caller
+     * thread. The default (synchronous bridge) is safe only when the send cannot block on a lock
+     * the caller may already hold.
+     *
+     * @param type: receiver node type
+     * @param moduleID: moduleID
+     * @param payload: already-encoded message body; ownership is transferred to the callee
+     */
+    virtual void asyncBroadcastMessageByOwnedPayload(
+        uint16_t type, int moduleID, bytesPointer payload)
+    {
+        task::wait([](FrontServiceInterface* self, uint16_t _type, int _moduleID,
+                       bytesPointer _payload) -> task::Task<void> {
+            co_await self->broadcastMessage(
+                _type, _moduleID, ::ranges::views::single(bcos::ref(*_payload)));
+        }(this, type, moduleID, std::move(payload)));
+    }
+
+    /**
+     * @brief send an already-encoded message to one node, taking ownership of the payload so the
+     *        send can be deferred without the caller keeping the buffer alive.
+     *
+     * Same rationale as asyncBroadcastMessageByOwnedPayload: the production FrontService dispatches
+     * the gateway send off the caller thread (PBFT under m_mutex must not contend the gateway
+     * session lock; sendViewChange / sendRecoverResponse run there). Point-to-point sends encode
+     * the wire frame anyway, so this is not zero-copy; owning the payload only keeps it alive
+     * across the deferred encode. The default implementation bridges to asyncSendMessageByNodeID.
+     *
+     * @param moduleID: moduleID
+     * @param nodeID: the receiver nodeID
+     * @param payload: already-encoded message body; ownership is transferred to the callee
+     */
+    virtual void asyncSendMessageByNodeIDByOwnedPayload(
+        int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload)
+    {
+        asyncSendMessageByNodeID(moduleID, std::move(nodeID), bcos::ref(*payload), 0, nullptr);
+    }
 
     /**
      * @brief: get local protocol info

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -22,6 +22,7 @@
 #include <bcos-front/Common.h>
 #include <bcos-front/FrontMessage.h>
 #include <bcos-front/FrontService.h>
+#include <bcos-task/Wait.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Exceptions.h>
 #include <oneapi/tbb/task_arena.h>
@@ -36,6 +37,22 @@
 using namespace bcos;
 using namespace front;
 using namespace protocol;
+
+namespace
+{
+// FIB-185: warn (do not drop) when the pending send queue grows pathologically, e.g. when the
+// gateway send is convoyed on the session lock under TLS-churn. Diagnostic only; below the hard cap
+// no consensus message is dropped.
+constexpr std::size_t c_maxPendingSendQueueWarnSize = 100000;
+// FIB-185 (review): hard ceiling as a last-resort OOM guard. If the gateway send stays convoyed on
+// the session lock under extreme churn the queue could otherwise grow without bound and exhaust
+// memory (each entry pins an encoded consensus message). Above this cap the OLDEST pending send is
+// shed (the most stale consensus message, least useful to retransmit) and an error is logged.
+// Dropping a message is strictly better than OOM-killing the node, and PBFT re-broadcast / the
+// view-change path recover from a dropped message. Set well above the warn size so shedding only
+// happens in a genuine runaway, after the warning has fired.
+constexpr std::size_t c_maxPendingSendQueueHardCap = 10 * c_maxPendingSendQueueWarnSize;
+}  // namespace
 
 FrontService::FrontService()
   : m_localProtocol(g_BCOSConfig.protocolInfo(ProtocolModuleID::NodeService))
@@ -220,8 +237,8 @@ void FrontService::start()
 
     // try to getNodeIDs from gateway
     auto self = std::weak_ptr<FrontService>(shared_from_this());
-    m_gatewayInterface->asyncGetGroupNodeInfo(
-        m_groupID, [self](const Error::Ptr& _error, const bcos::gateway::GroupNodeInfo::Ptr& _groupNodeInfo) {
+    m_gatewayInterface->asyncGetGroupNodeInfo(m_groupID,
+        [self](const Error::Ptr& _error, const bcos::gateway::GroupNodeInfo::Ptr& _groupNodeInfo) {
             if (_error)
             {
                 FRONT_LOG(ERROR) << LOG_BADGE("start") << LOG_DESC("asyncGetGroupNodeInfo failed")
@@ -307,6 +324,13 @@ void FrontService::stop()
         {
             m_frontServiceThread->join();
         }
+
+        // FIB-185 (review): flush the serial send queue before returning. m_run is already false
+        // (set above), so enqueueSend accepts no new tasks; the in-flight drainer empties the queue
+        // and waiting on m_asyncGroup quiesces it, so pending consensus sends are dispatched at
+        // stop() time rather than only at destruction. The drainer reuses m_asyncGroup, the same
+        // group every other FrontService async dispatch runs on, so this also joins those.
+        m_asyncGroup.wait();
     }
     catch (const std::exception& e)
     {
@@ -461,6 +485,117 @@ task::Task<void> FrontService::broadcastMessage(
     co_await m_gatewayInterface->broadcastMessage(type, m_groupID, moduleID, *m_nodeID,
         ::ranges::views::concat(
             ::ranges::views::single(bcos::ref(std::as_const(header))), std::move(payloads)));
+}
+
+void FrontService::asyncBroadcastMessageByOwnedPayload(
+    uint16_t type, int moduleID, bytesPointer payload)
+{
+    // FIB-185: enqueue the gateway broadcast onto the serial send queue and return immediately, so
+    // the caller (e.g. PBFT under m_mutex) never runs the gateway-session-lock-acquiring send on
+    // its own thread. The owned payload is captured by the task -> the message body is not copied
+    // (the gateway coroutine forwards it by reference from the shared_ptr).
+    enqueueSend([this, type, moduleID, payload = std::move(payload)]() {
+        FrontMessage message;
+        message.setModuleID(moduleID);
+        auto header = std::make_shared<bytes>();
+        message.encodeHeader(*header);
+        task::wait([](gateway::GatewayInterface::Ptr gateway, uint16_t msgType, std::string groupID,
+                       int module, bcos::crypto::NodeIDPtr srcNodeID, std::shared_ptr<bytes> hdr,
+                       bytesPointer body) -> task::Task<void> {
+            co_await gateway->broadcastMessage(msgType, groupID, module, *srcNodeID,
+                ::ranges::views::concat(::ranges::views::single(bcos::ref(*hdr)),
+                    ::ranges::views::single(bcos::ref(*body))));
+        }(m_gatewayInterface, type, m_groupID, moduleID, m_nodeID, header, payload));
+    });
+}
+
+void FrontService::asyncSendMessageByNodeIDByOwnedPayload(
+    int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload)
+{
+    // FIB-185: enqueue the point-to-point send onto the serial queue and return immediately, so the
+    // caller (PBFT under m_mutex, via sendViewChange / sendRecoverResponse) never runs the
+    // gateway-session-lock-acquiring send on its own thread. The owned payload is captured to keep
+    // it alive for the (synchronous) wire-frame encode inside asyncSendMessageByNodeID.
+    enqueueSend([this, moduleID, nodeID = std::move(nodeID), payload = std::move(payload)]() {
+        asyncSendMessageByNodeID(moduleID, nodeID, bcos::ref(*payload), 0, nullptr);
+    });
+}
+
+void FrontService::enqueueSend(std::function<void()> _sendTask)
+{
+    // FIB-185 (review): once stopped, do not enqueue new sends nor kick a drainer. stop() flushes
+    // the queue and waits on m_asyncGroup; a task enqueued after that would either be lost or,
+    // worse, run a drainer that outlives this FrontService. New sends after stop are dropped on
+    // purpose (the node is shutting down).
+    if (!m_run)
+    {
+        return;
+    }
+    m_sendQueue.push(std::move(_sendTask));
+    // backpressure: warn while still unbounded, then shed the oldest above the hard cap (OOM guard)
+    auto pending = m_sendQueue.unsafe_size();
+    if (pending > c_maxPendingSendQueueWarnSize)
+    {
+        FRONT_LOG(WARNING) << LOG_BADGE("enqueueSend")
+                           << LOG_DESC(
+                                  "pending send queue unusually large; gateway send may be "
+                                  "convoyed on the session lock")
+                           << LOG_KV("pending", pending);
+    }
+    if (pending > c_maxPendingSendQueueHardCap)
+    {
+        std::function<void()> dropped;
+        if (m_sendQueue.try_pop(dropped))
+        {
+            FRONT_LOG(ERROR) << LOG_BADGE("enqueueSend")
+                             << LOG_DESC(
+                                    "send queue hard cap exceeded; dropped oldest pending send to "
+                                    "avoid OOM")
+                             << LOG_KV("pending", pending)
+                             << LOG_KV("hardCap", c_maxPendingSendQueueHardCap);
+        }
+    }
+    // kick a single drainer if none is running (CAS false -> true wins the right to drain)
+    bool expected = false;
+    if (m_sendDraining.compare_exchange_strong(expected, true))
+    {
+        m_taskArena.execute([&]() { m_asyncGroup.run([this]() { drainSendQueue(); }); });
+    }
+}
+
+void FrontService::drainSendQueue()
+{
+    // single drainer: run tasks one at a time so sends keep submission order (FIFO). Each task is
+    // self-contained (owns its payload); a throwing task is logged, never escalated -- an exception
+    // escaping here would otherwise abort the tbb worker thread.
+    for (;;)
+    {
+        std::function<void()> task;
+        while (m_sendQueue.try_pop(task))
+        {
+            try
+            {
+                task();
+            }
+            catch (std::exception const& e)
+            {
+                FRONT_LOG(WARNING) << LOG_BADGE("drainSendQueue")
+                                   << LOG_KV("error", boost::diagnostic_information(e));
+            }
+        }
+        // release the drainer slot, then re-check to avoid a lost wakeup against a concurrent
+        // enqueueSend that pushed after our last try_pop but before we cleared the flag.
+        m_sendDraining.store(false);
+        if (m_sendQueue.empty())
+        {
+            break;
+        }
+        bool expected = false;
+        if (!m_sendDraining.compare_exchange_strong(expected, true))
+        {
+            break;
+        }
+    }
 }
 
 /**

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -25,9 +25,12 @@
 #include <bcos-framework/gateway/GroupNodeInfo.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/ThreadPool.h>
+#include <oneapi/tbb/concurrent_queue.h>
 #include <oneapi/tbb/task_arena.h>
 #include <oneapi/tbb/task_group.h>
 #include <boost/asio.hpp>
+#include <atomic>
+#include <functional>
 #include <utility>
 
 namespace bcos::front
@@ -93,6 +96,19 @@ public:
 
     task::Task<void> broadcastMessage(
         uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) override;
+
+    // FIB-185: dispatch the gateway broadcast onto a serial send queue (off the caller thread) so a
+    // caller holding a lock (PBFT under m_mutex) is not coupled to gateway session-lock contention.
+    // The owned payload is captured by the queued task -> the message body is never copied.
+    void asyncBroadcastMessageByOwnedPayload(
+        uint16_t type, int moduleID, bytesPointer payload) override;
+
+    // FIB-185: dispatch the point-to-point gateway send onto the serial send queue (off the caller
+    // thread), so sendViewChange / sendRecoverResponse run under m_mutex without contending the
+    // gateway session lock. Point-to-point encodes the wire frame, so this is not zero-copy; the
+    // owned payload is captured only to keep it alive across the deferred encode.
+    void asyncSendMessageByNodeIDByOwnedPayload(
+        int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload) override;
 
     /**
      * @brief: receive nodeIDs from gateway
@@ -215,9 +231,17 @@ protected:
 
     virtual void protocolNegotiate(bcos::gateway::GroupNodeInfo::Ptr _groupNodeInfo);
 
+    // FIB-185: hand a send task to the serial queue and return immediately; a single drainer runs
+    // tasks one at a time (FIFO) on m_asyncGroup, so no caller thread runs the gateway send.
+    void enqueueSend(std::function<void()> _sendTask);
+    void drainSendQueue();
+
 private:
     tbb::task_arena m_taskArena;
     tbb::task_group m_asyncGroup;
+    // FIB-185: serial async send queue + single-drainer guard (reuses m_asyncGroup, no new thread).
+    tbb::concurrent_queue<std::function<void()>> m_sendQueue;
+    std::atomic_bool m_sendDraining{false};
     // timer
     std::shared_ptr<boost::asio::io_context> m_ioService;
     /// gateway interface

--- a/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
+++ b/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ * @brief FIB-185: FrontService's owned-payload async entry points must dispatch the gateway send
+ *        off the caller thread. The gateway send acquires the gateway session lock synchronously
+ *        and, under TLS-churn, that lock is contended by session connect/disconnect; running the
+ *        send on the caller thread (e.g. the PBFT consensus worker holding m_mutex) couples
+ *        consensus to gateway lock contention and halts consensus. Both the broadcast
+ *        (asyncBroadcastMessageByOwnedPayload, used by PBFT's prepare/commit/view-change
+ *        broadcasts) and the point-to-point send (asyncSendMessageByNodeIDByOwnedPayload, used by
+ *        sendViewChange/sendRecoverResponse) hand the owned payload to a serial send queue and
+ *        return immediately. These tests pin that: with a gateway whose send blocks, the caller
+ *        returns promptly and the send runs on another thread.
+ * @file FIB185_AsyncSendOffCallerThreadTest.cpp
+ */
+
+#include "FakeGateway.h"
+#include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-front/FrontService.h>
+#include <bcos-front/FrontServiceFactory.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <thread>
+
+using namespace bcos;
+using namespace bcos::front;
+using namespace bcos::front::test;
+
+namespace bcos::test
+{
+namespace
+{
+bcos::crypto::NodeIDPtr makeNodeID(std::string const& _id)
+{
+    auto keyFactory = std::make_shared<bcos::crypto::KeyFactoryImpl>();
+    return keyFactory->createKey(bytesConstRef((bcos::byte*)_id.data(), _id.size()));
+}
+
+// A gateway whose broadcast and point-to-point send each block for a fixed duration on whichever
+// thread runs them, recording that thread. If FrontService ran the gateway send on the caller
+// thread (the pre-fix coupling), the caller would block ~c_blockMs; the owned-payload async paths
+// return immediately and run the send on another thread.
+class BlockingGateway : public bcos::front::test::FakeGateway
+{
+public:
+    static constexpr int c_blockMs = 400;
+    std::promise<std::thread::id> m_bcastRanOn;
+    std::atomic_bool m_bcastCaptured{false};
+    std::promise<std::thread::id> m_p2pRanOn;
+    std::atomic_bool m_p2pCaptured{false};
+
+    task::Task<void> broadcastMessage(uint16_t, std::string_view, int, const bcos::crypto::NodeID&,
+        ::ranges::any_view<bytesConstRef>) override
+    {
+        if (!m_bcastCaptured.exchange(true))
+        {
+            m_bcastRanOn.set_value(std::this_thread::get_id());
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(c_blockMs));
+        co_return;
+    }
+
+    void asyncSendMessageByNodeID(const std::string&, int, bcos::crypto::NodeIDPtr,
+        bcos::crypto::NodeIDPtr, bytesConstRef, bcos::gateway::ErrorRespFunc) override
+    {
+        if (!m_p2pCaptured.exchange(true))
+        {
+            m_p2pRanOn.set_value(std::this_thread::get_id());
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(c_blockMs));
+    }
+};
+
+std::shared_ptr<FrontService> buildFrontServiceWith(std::shared_ptr<BlockingGateway> _gateway)
+{
+    auto factory = std::make_shared<FrontServiceFactory>();
+    factory->setGatewayInterface(std::move(_gateway));
+    auto front = factory->buildFrontService("fib185.group", makeNodeID("fib185.src.nodeid"));
+    front->start();
+    return front;
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(FIB185AsyncSendOffCallerThread, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(asyncBroadcastByOwnedPayload_returnsWithoutBlockingOnGatewaySend)
+{
+    auto gateway = std::make_shared<BlockingGateway>();
+    auto front = buildFrontServiceWith(gateway);
+    // owned payload (bytesPointer): the async path forwards it by reference, no copy of the body.
+    auto payload = std::make_shared<bytes>(64, 'y');
+
+    auto callerThread = std::this_thread::get_id();
+    auto startTime = utcSteadyTime();
+    front->asyncBroadcastMessageByOwnedPayload(static_cast<uint16_t>(1), /*moduleID*/ 111, payload);
+    auto elapsed = utcSteadyTime() - startTime;
+
+    // Deferred to the serial send queue: the caller returns promptly even though the gateway
+    // broadcast is blocked. Before the fix this ran the gateway send synchronously and blocked.
+    BOOST_CHECK_LT(elapsed, static_cast<uint64_t>(BlockingGateway::c_blockMs / 2));
+
+    // The gateway broadcast eventually runs, on a thread other than the caller.
+    auto ranOn = gateway->m_bcastRanOn.get_future();
+    BOOST_REQUIRE(ranOn.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+    BOOST_CHECK(ranOn.get() != callerThread);
+
+    front->stop();
+}
+
+BOOST_AUTO_TEST_CASE(asyncSendByNodeIDByOwnedPayload_returnsWithoutBlockingOnGatewaySend)
+{
+    auto gateway = std::make_shared<BlockingGateway>();
+    auto front = buildFrontServiceWith(gateway);
+    auto dstNodeID = makeNodeID("fib185.dst.nodeid");
+    auto payload = std::make_shared<bytes>(64, 'z');
+
+    auto callerThread = std::this_thread::get_id();
+    auto startTime = utcSteadyTime();
+    front->asyncSendMessageByNodeIDByOwnedPayload(/*moduleID*/ 111, dstNodeID, payload);
+    auto elapsed = utcSteadyTime() - startTime;
+
+    // Deferred to the serial send queue: the caller (PBFT under m_mutex, via sendViewChange /
+    // sendRecoverResponse) returns promptly even though the gateway send is blocked.
+    BOOST_CHECK_LT(elapsed, static_cast<uint64_t>(BlockingGateway::c_blockMs / 2));
+
+    auto ranOn = gateway->m_p2pRanOn.get_future();
+    BOOST_REQUIRE(ranOn.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+    BOOST_CHECK(ranOn.get() != callerThread);
+
+    front->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -593,6 +593,15 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
                                                   "than 2 * p2p.allow_max_msg_size"));
     }
 
+    // FIB-184: inbound session caps, configurable instead of hardcoded in Host. Bound the number
+    // of concurrent / per-IP sessions so authenticated TLS connect-close churn cannot create
+    // sessions (each holding a recv buffer) faster than they tear down and exhaust the heap.
+    constexpr static std::size_t defaultMaxConcurrentSessions = 1024;
+    constexpr static std::size_t defaultMaxSessionsPerIP = 32;
+    m_maxConcurrentSessions =
+        _pt.get<std::size_t>("p2p.max_concurrent_sessions", defaultMaxConcurrentSessions);
+    m_maxSessionsPerIP = _pt.get<std::size_t>("p2p.max_sessions_per_ip", defaultMaxSessionsPerIP);
+
     constexpr static uint32_t defaultMaxReadDataSize = 40 * 1024;
     m_maxReadDataSize = _pt.get<uint32_t>("p2p.session_max_read_data_size", defaultMaxReadDataSize);
 

--- a/bcos-gateway/bcos-gateway/GatewayConfig.h
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.h
@@ -117,7 +117,7 @@ public:
         bool enableOutConnRateLimit() const;
 
         bool enableInRateLimit() const;
-    bool enableInP2pBasicMsgLimit() const;
+        bool enableInP2pBasicMsgLimit() const;
 
         bool enableInP2pModuleMsgLimit(uint16_t _moduleID) const
         {
@@ -216,6 +216,13 @@ public:
     uint32_t sessionRecvBufferSize() const;
     void setSessionRecvBufferSize(uint32_t _sessionRecvBufferSize);
 
+    // FIB-184: caps on inbound sessions, configurable via p2p.max_concurrent_sessions /
+    // p2p.max_sessions_per_ip (previously hardcoded in Host). Bound memory under TLS churn.
+    std::size_t maxConcurrentSessions() const { return m_maxConcurrentSessions; }
+    void setMaxConcurrentSessions(std::size_t _limit) { m_maxConcurrentSessions = _limit; }
+    std::size_t maxSessionsPerIP() const { return m_maxSessionsPerIP; }
+    void setMaxSessionsPerIP(std::size_t _limit) { m_maxSessionsPerIP = _limit; }
+
     uint32_t maxReadDataSize() const;
     void setMaxReadDataSize(uint32_t _maxReadDataSize);
 
@@ -271,6 +278,9 @@ private:
     uint32_t m_allowMaxMsgSize = MAX_MESSAGE_LENGTH;
     // p2p session read buffer size, default: 128k
     uint32_t m_sessionRecvBufferSize{128 * 1024};
+    // FIB-184: inbound session caps (defaults match the prior hardcoded Host constants)
+    std::size_t m_maxConcurrentSessions{1024};
+    std::size_t m_maxSessionsPerIP{32};
     uint32_t m_maxReadDataSize = 40 * 1024;
     uint32_t m_maxSendDataSize = 1024 * 1024;
     uint32_t m_maxSendMsgCount = 10;

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -649,6 +649,9 @@ std::shared_ptr<Service> GatewayFactory::buildService(const GatewayConfig::Ptr& 
     host->setPeerWhitelist(peerWhitelist);
     host->setSessionCallbackManager(sessionCallbackManager);
     host->setEnableSslVerify(_config->enableSSLVerify());
+    // FIB-184: apply the configured inbound-session caps (no longer hardcoded in Host)
+    host->setMaxConcurrentSessions(_config->maxConcurrentSessions());
+    host->setMaxSessionsPerIP(_config->maxSessionsPerIP());
     // init Service
     bool enableRIPProtocol = _config->enableRIPProtocol();
     Service::Ptr service = nullptr;

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -109,10 +109,9 @@ public:
 
     // FIB-184: caps on concurrent inbound sessions to bound memory under TLS connect/close
     // churn. With no cap, an authenticated peer can open sessions faster than they tear down
-    // and exhaust the heap (each session allocates a recv buffer). These are defaults; see
-    // TODO below about plumbing them through GatewayConfig.
-    // TODO(FIB-184): plumb these limits through GatewayConfig
-    // (p2p.max_concurrent_sessions / p2p.max_sessions_per_ip) instead of hardcoding.
+    // and exhaust the heap (each session allocates a recv buffer). GatewayFactory now plumbs the
+    // configured values (p2p.max_concurrent_sessions / p2p.max_sessions_per_ip) via the setters
+    // below; these constants are the defaults used when the config omits them.
     constexpr static std::size_t DEFAULT_MAX_CONCURRENT_SESSIONS = 1024;
     constexpr static std::size_t DEFAULT_MAX_SESSIONS_PER_IP = 32;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -33,16 +33,19 @@
 using namespace bcos;
 using namespace bcos::gateway;
 
-Session::Session(std::shared_ptr<SocketFace> socket, Host& server, size_t _recvBufferSize,
-    [[maybe_unused]] bool _forceSize)
+Session::Session(
+    std::shared_ptr<SocketFace> socket, Host& server, size_t _recvBufferSize, bool _forceSize)
   : m_maxRecvBufferSize(std::max<size_t>(_recvBufferSize, MIN_SESSION_RECV_BUFFER_SIZE)),
-    // FIB-184: do not force the 512KB floor on every session. Start at the requested/initial size
-    // (the config-validated session_recv_buffer_size for production sessions, a tiny value for
-    // tests) and let doRead grow the buffer up to m_maxRecvBufferSize on demand. Previously the
-    // non-forced path unconditionally allocated MIN_SESSION_RECV_BUFFER_SIZE (512KB) per session,
-    // which let connection churn exhaust the heap. _forceSize is now retained only for ABI/source
-    // compatibility of the signature; both paths honor _recvBufferSize as the initial size.
-    m_recvBuffer(_recvBufferSize),
+    // FIB-184: treat _recvBufferSize as the grow CEILING, not the initial allocation. Production
+    // createSession passes the config-validated session_recv_buffer_size, which is forced to
+    // 2 * allow_max_msg_size = 64MB; allocating that per session up front let authenticated TLS
+    // connect/close churn exhaust the heap (SIGSEGV inside malloc during Session construction).
+    // Allocate only INITIAL_SESSION_RECV_BUFFER_SIZE (16KB) initially and let doRead grow the
+    // buffer up to m_maxRecvBufferSize on demand, so only sessions that actually carry large
+    // messages pay for a large buffer. _forceSize keeps the exact size for tests that assert a
+    // specific small buffer.
+    m_recvBuffer(_forceSize ? _recvBufferSize :
+                              std::min<size_t>(_recvBufferSize, INITIAL_SESSION_RECV_BUFFER_SIZE)),
     m_server(server),
     m_socket(std::move(socket)),
     m_idleCheckTimer(
@@ -508,7 +511,20 @@ void Session::doRead()
                 session->m_lastReadTime.store(utcSteadyTime());
 
                 auto& recvBuffer = session->recvBuffer();
-                recvBuffer.onWrite(bytesTransferred);
+                // FIB-184 (review): onWrite advances the write position and returns false if the
+                // just-read bytes would overrun the recv buffer. With the lazy-initial / grow-on-
+                // demand buffer the read size is bounded by the write-buffer span, so this should
+                // not happen; but if it ever did the bytes would be silently dropped and the stream
+                // desynchronized. Treat it as a transport error and drop the session instead.
+                if (!recvBuffer.onWrite(bytesTransferred))
+                {
+                    SESSION_LOG(ERROR)
+                        << LOG_BADGE("doRead") << LOG_DESC("recv buffer overflow on write, drop")
+                        << LOG_KV("bytesTransferred", bytesTransferred)
+                        << LOG_KV("recvBufferSize", recvBuffer.recvBufferSize());
+                    session->drop(TCPError);
+                    return;
+                }
 
                 while (true)
                 {
@@ -617,7 +633,7 @@ void Session::doRead()
     else
     {
         SESSION_LOG(ERROR) << LOG_DESC("callback doRead failed for session inactive")
-                           << LOG_KV("active", m_active)
+                           << LOG_KV("active", m_active.load())
                            << LOG_KV("haveNetwork", m_server.get().haveNetwork());
     }
 }

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -187,6 +187,11 @@ public:
 
     SessionRecvBuffer& recvBuffer();
     const SessionRecvBuffer& recvBuffer() const;
+
+    // FIB-184 (review): grow ceiling for the recv buffer, set from the config-validated size at
+    // construction. Exposed read-only; the member itself is private (below) so external callers
+    // can read but never widen this security bound.
+    std::size_t maxRecvBufferSize() const { return m_maxRecvBufferSize; }
     /**
      * @brief The packets that can be sent are obtained based on the configured policy
      *
@@ -202,7 +207,13 @@ public:
 
     void doRead();
 
+    // FIB-184 (review): keep the grow ceiling private so it can only be read via
+    // maxRecvBufferSize() and never widened from outside. Declared before m_recvBuffer to preserve
+    // member init order.
+private:
     std::size_t m_maxRecvBufferSize;
+
+public:
     SessionRecvBuffer m_recvBuffer;
 
     // ------ for optimize send message parameters  begin ---------------
@@ -240,7 +251,11 @@ public:
     MessageFactory::Ptr m_messageFactory;
     tbb::concurrent_queue<Payload> m_writeQueue;
     std::mutex m_writingQueueMutex;
-    bool m_active = false;
+    // FIB-184 (review): atomic so the active flag is read/written without a data race between the
+    // network worker (set/clear in start/drop) and readers in active()/doRead(). Note active() is
+    // still a composite read (also m_socket / haveNetwork()), so this narrows but does not by
+    // itself make the whole liveness check atomic.
+    std::atomic<bool> m_active{false};
 
     SessionCallbackManagerInterface::Ptr m_sessionCallbackManager;
     std::function<void(NetworkException, SessionFace::Ptr, Message::Ptr)> m_messageHandler;

--- a/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionResourceCapTest.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(ForcedSmallRecvBufferIsHonored)
     auto session = std::make_shared<Session>(fakeSocket, *fakeHost, /*size*/ 2, /*forceSize*/ true);
     BOOST_CHECK_EQUAL(session->recvBuffer().recvBufferSize(), 2u);
     // grow ceiling is still the 512KB minimum
-    BOOST_CHECK_EQUAL(session->m_maxRecvBufferSize, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+    BOOST_CHECK_EQUAL(session->maxRecvBufferSize(), Session::MIN_SESSION_RECV_BUFFER_SIZE);
 
     session->setSocket(nullptr);
     fakeSocket->close();
@@ -132,7 +132,33 @@ BOOST_AUTO_TEST_CASE(DefaultRecvBufferStartsSmall)
     BOOST_CHECK_LT(
         Session::INITIAL_SESSION_RECV_BUFFER_SIZE, Session::MIN_SESSION_RECV_BUFFER_SIZE);
     // the grow ceiling stays at the 512KB minimum so large messages still fit after growth
-    BOOST_CHECK_EQUAL(session->m_maxRecvBufferSize, Session::MIN_SESSION_RECV_BUFFER_SIZE);
+    BOOST_CHECK_EQUAL(session->maxRecvBufferSize(), Session::MIN_SESSION_RECV_BUFFER_SIZE);
+
+    session->setSocket(nullptr);
+    fakeSocket->close();
+}
+
+// FIB-184: production createSession passes the config-validated ceiling (forced to
+// 2 * allow_max_msg_size = 64MB), NOT forceSize. The session must allocate only the small initial
+// buffer and keep the 64MB as the grow ceiling -- not preallocate 64MB per session (the
+// heap-exhaustion crash source). This is the production path the two tests above do not cover.
+BOOST_AUTO_TEST_CASE(ProductionLargeRecvBufferDoesNotPreallocate)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_FIB184>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB184>();
+    auto fakeHost = std::make_shared<FakeHost_FIB184>(hashImpl, fakeAsio);
+
+    constexpr size_t k64MB =
+        64UL * 1024 * 1024;  // == 2 * MAX_MESSAGE_LENGTH, the production ceiling
+    auto session =
+        std::make_shared<Session>(fakeSocket, *fakeHost, /*ceiling*/ k64MB, /*forceSize*/ false);
+
+    // initial allocation is the lazy 16KB, NOT the 64MB ceiling
+    BOOST_CHECK_EQUAL(
+        session->recvBuffer().recvBufferSize(), Session::INITIAL_SESSION_RECV_BUFFER_SIZE);
+    // the grow ceiling still reflects the requested 64MB so large messages fit after growth
+    BOOST_CHECK_EQUAL(session->maxRecvBufferSize(), k64MB);
 
     session->setSocket(nullptr);
     fakeSocket->close();

--- a/bcos-gateway/test/unittests/GatewayConfigTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigTest.cpp
@@ -477,4 +477,28 @@ BOOST_AUTO_TEST_CASE(test_RedisConfig)
     BOOST_CHECK_EQUAL(config->redisConfig().db, 12);
 }
 
+// FIB-184: inbound session caps are plumbed through config (p2p.max_concurrent_sessions /
+// p2p.max_sessions_per_ip) instead of being hardcoded in Host.
+BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
+{
+    // defaults when the keys are absent
+    {
+        auto config = std::make_shared<GatewayConfig>();
+        boost::property_tree::ptree pt;
+        config->initP2PConfig(pt, false);
+        BOOST_CHECK_EQUAL(config->maxConcurrentSessions(), 1024U);
+        BOOST_CHECK_EQUAL(config->maxSessionsPerIP(), 32U);
+    }
+    // parsed when present
+    {
+        auto config = std::make_shared<GatewayConfig>();
+        boost::property_tree::ptree pt;
+        pt.put("p2p.max_concurrent_sessions", 256);
+        pt.put("p2p.max_sessions_per_ip", 8);
+        config->initP2PConfig(pt, false);
+        BOOST_CHECK_EQUAL(config->maxConcurrentSessions(), 256U);
+        BOOST_CHECK_EQUAL(config->maxSessionsPerIP(), 8U);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCache.cpp
@@ -52,11 +52,9 @@ void PBFTCache::onCheckPointTimeout()
         m_checkpointProposal, m_config->cryptoSuite(), m_config->keyPair(), true);
     auto encodedData = m_config->codec()->encode(checkPointMsg);
     // only broadcast message to consensus node
-    task::wait(
-        [](front::FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
-            co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE,
-                ModuleID::PBFT, ::ranges::views::single(ref(*encodedData)));
-        }(m_config->frontService(), std::move(encodedData)));
+    // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
+    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+        bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
 }
 
 bool PBFTCache::existPrePrepare(PBFTMessageInterface::Ptr _prePrepareMsg)
@@ -247,11 +245,9 @@ bool PBFTCache::checkAndPreCommit()
                    << LOG_KV("index", commitReq->index());
     auto encodedData = m_config->codec()->encode(commitReq, m_config->pbftMsgDefaultVersion());
     // only broadcast message to consensus nodes
-    task::wait(
-        [](front::FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
-            co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE,
-                ModuleID::PBFT, ::ranges::views::single(ref(*encodedData)));
-        }(m_config->frontService(), std::move(encodedData)));
+    // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
+    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+        bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     m_precommitted = true;
     // collect the commitReq and try to commit
     return checkAndCommit();

--- a/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/cache/PBFTCacheProcessor.cpp
@@ -831,11 +831,9 @@ NewViewMsgInterface::Ptr PBFTCacheProcessor::checkAndTryIntoNewView()
     // encode and broadcast the viewchangeReq
     auto encodedData = m_config->codec()->encode(newViewMsg);
     // only broadcast message to the consensus nodes
-    task::wait(
-        [](front::FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
-            co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE,
-                ModuleID::PBFT, ::ranges::views::single(ref(*encodedData)));
-        }(m_config->frontService(), std::move(encodedData)));
+    // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
+    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+        bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     m_newViewGenerated = true;
     PBFT_LOG(INFO) << LOG_DESC("The next leader broadcast NewView request")
                    << printPBFTMsgInfo(newViewMsg) << LOG_KV("Idx", m_config->nodeIndex());

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTEngine.cpp
@@ -322,11 +322,9 @@ void PBFTEngine::onProposalApplySuccess(
 
     auto encodedData = m_config->codec()->encode(checkPointMsg);
     // only broadcast message to the consensus nodes
-    task::wait(
-        [](front::FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
-            co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE,
-                ModuleID::PBFT, ::ranges::views::single(ref(*encodedData)));
-        }(m_config->frontService(), std::move(encodedData)));
+    // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
+    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+        bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     auto startT = utcTime();
     auto recordT = utcTime();
     // Note: must lock here to ensure thread safe
@@ -476,10 +474,9 @@ void PBFTEngine::onRecvProposal(bool _containSysTxs, const protocol::Block& prop
                    << LOG_KV("index", pbftMessage->index())
                    << LOG_KV("encode(ms)", encodeEnd - encodeStart)
                    << LOG_KV("asyncSend(ms)", utcTime() - encodeEnd);
-    task::wait([](auto front, decltype(encodedData) encoded) -> task::Task<void> {
-        co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT,
-            ::ranges::views::single(ref(std::as_const(*encoded))));
-    }(m_config->frontService(), std::move(encodedData)));
+    // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
+    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+        bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
 
     // handle the pre-prepare packet
     RecursiveGuard lock(m_mutex);
@@ -1346,11 +1343,9 @@ void PBFTEngine::broadcastPrepareMsg(PBFTMessageInterface::Ptr const& _prePrepar
                    << LOG_KV("packetSize", encodedData->size())
                    << LOG_KV("index", _prePrepareMsg->index());
     // only broadcast to the consensus nodes
-    task::wait(
-        [](front::FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
-            co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE,
-                ModuleID::PBFT, ::ranges::views::single(ref(*encodedData)));
-        }(m_config->frontService(), std::move(encodedData)));
+    // FIB-185: hand the owned payload to the front's serial send queue (off this thread); no copy.
+    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+        bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
     // try to precommit the message
     m_cacheProcessor->checkAndPreCommit();
 }
@@ -1494,9 +1489,11 @@ void PBFTEngine::sendViewChange(bcos::crypto::NodeIDPtr _dstNode)
     auto viewChangeReq = generateViewChange();
     // encode and broadcast the viewchangeReq
     auto encodedData = m_config->codec()->encode(viewChangeReq);
-    // only broadcast to the consensus nodes
-    m_config->frontService()->asyncSendMessageByNodeID(
-        ModuleID::PBFT, std::move(_dstNode), ref(*encodedData), 0, nullptr);
+    // FIB-185: send off the m_mutex critical section via the owned-payload point-to-point entry
+    // (the gateway session-lock acquire runs on the front's send queue, not on the consensus
+    // worker)
+    m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+        ModuleID::PBFT, std::move(_dstNode), std::move(encodedData));
     // collect the viewchangeReq
     m_cacheProcessor->addViewChangeReq(viewChangeReq);
     auto newViewMsg = m_cacheProcessor->checkAndTryIntoNewView();
@@ -1515,8 +1512,10 @@ void PBFTEngine::sendRecoverResponse(bcos::crypto::NodeIDPtr _dstNode)
     response->setTimestamp(utcTime());
     response->setIndex(m_config->committedProposal()->index());
     auto encodedData = m_config->codec()->encode(response);
-    m_config->frontService()->asyncSendMessageByNodeID(
-        ModuleID::PBFT, _dstNode, ref(*encodedData), 0, nullptr);
+    // FIB-185: send off the m_mutex critical section via the owned-payload point-to-point entry
+    // (copy _dstNode; it is logged below). The gateway send runs on the front's send queue.
+    m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+        ModuleID::PBFT, _dstNode, std::move(encodedData));
     PBFT_LOG(DEBUG) << LOG_DESC("sendRecoverResponse") << LOG_KV("peer", _dstNode->shortHex())
                     << m_config->printCurrentState();
 }
@@ -1529,23 +1528,15 @@ void PBFTEngine::broadcastViewChangeReq()
     // only broadcast to the consensus nodes
     PBFT_LOG(INFO) << LOG_DESC("broadcastViewChangeReq") << printPBFTMsgInfo(viewChangeReq)
                    << LOG_KV("packetSize", encodedData->size());
-    // FIB-185 (Fix 1, deferred): this runs under m_mutex (onTimeout -> triggerTimeout holds it).
-    // task::wait here is already fire-and-forget (it starts the coroutine and returns without
-    // blocking to completion), so it does NOT block the worker on the network round-trip. The
-    // residual coupling is that the coroutine's inline prefix (up to its first suspension inside
-    // FrontService::broadcastMessage) executes on this thread while m_mutex is held; if that
-    // prefix contends a gateway/session lock during teardown churn it can briefly stall the
-    // worker. Fully moving the send off-lock would require dispatching it onto a dedicated
-    // executor, which touches consensus-thread/lifetime ordering near the view-change cache; the
-    // watchdog (checkConsensusTimerWatchdog) recovers a stalled timer without that risk. Splitting
-    // the send off-lock is left as a follow-up so the view-change cache invariants below are not
-    // disturbed.
-    // TODO(FIB-185): move the network broadcast fully off the m_mutex critical section (dedicated
-    // executor) once the consensus-thread ordering around the view-change cache is verified safe.
-    task::wait([](FrontServiceInterface::Ptr front, bytesPointer encodedData) -> task::Task<void> {
-        co_await front->broadcastMessage(bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT,
-            ::ranges::views::single(ref(*encodedData)));
-    }(m_config->frontService(), std::move(encodedData)));
+    // FIB-185: this runs under m_mutex (onTimeout -> triggerTimeout holds it). Hand the owned
+    // payload to FrontService::asyncBroadcastMessageByOwnedPayload, which enqueues the gateway send
+    // onto its serial send queue and returns immediately -- the gateway-session-lock-acquiring send
+    // no longer runs on the consensus worker while m_mutex is held (the coupling that wedged
+    // consensus under session-teardown churn is decoupled at the FrontService layer), and the owned
+    // payload is forwarded without copying. The view-change cache mutations below stay under the
+    // lock, unchanged.
+    m_config->frontService()->asyncBroadcastMessageByOwnedPayload(
+        bcos::protocol::NodeType::CONSENSUS_NODE, ModuleID::PBFT, std::move(encodedData));
 
     // collect the viewchangeReq
     m_cacheProcessor->addViewChangeReq(viewChangeReq);

--- a/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
+++ b/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
@@ -29,6 +29,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/log/core/core.hpp>
 #include <boost/log/support/date_time.hpp>
+#include <boost/log/utility/exception_handler.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 
 using namespace bcos;
@@ -116,6 +117,11 @@ BoostLogInitializer::initConsoleLogSink(
 {
     boost::log::add_common_attributes();
     boost::shared_ptr<console_sink_t> consoleSink(new console_sink_t());
+    // FIB-184: the sink is asynchronous, so its backend runs on a dedicated feeding thread. An
+    // exception thrown there (formatting/IO during feed_records) with no handler propagates to
+    // std::terminate -> abort, turning the logging subsystem into a crash amplifier under load.
+    // Suppress it so a single log record is dropped instead of aborting the node.
+    consoleSink->set_exception_handler(boost::log::make_exception_suppressor());
     consoleSink->locked_backend()->add_stream(
         boost::shared_ptr<std::ostream>(&std::cout, boost::null_deleter()));
 
@@ -260,6 +266,8 @@ boost::shared_ptr<bcos::BoostLogInitializer::sink_t> BoostLogInitializer::initHo
     std::string fileName = _logPath + "/" + _logPrefix + "_%Y%m%d%H.%M.log";
 
     boost::shared_ptr<sink_t> sink(new sink_t());
+    // FIB-184: suppress async-sink feeding-thread exceptions so they cannot reach abort.
+    sink->set_exception_handler(boost::log::make_exception_suppressor());
     sink->locked_backend()->set_open_mode(std::ios::ate);
     sink->locked_backend()->set_time_based_rotation(
         boost::bind(&BoostLogInitializer::canRotate, this, (m_currentHourVec.size() - 1)));
@@ -285,6 +293,8 @@ boost::shared_ptr<bcos::BoostLogInitializer::sink_t> BoostLogInitializer::initLo
     /// set file name
     // std::string fileName = _logPath + "/" + "log_%Y%m%d_%H%M.log";
     boost::shared_ptr<sink_t> sink(new sink_t());
+    // FIB-184: suppress async-sink feeding-thread exceptions so they cannot reach abort.
+    sink->set_exception_handler(boost::log::make_exception_suppressor());
     sink->locked_backend()->enable_final_rotation(false);
     sink->locked_backend()->set_open_mode(std::ios::app);
     sink->locked_backend()->set_time_based_rotation(boost::log::sinks::file::rotation_at_time_point(

--- a/bcos-utilities/test/unittests/libutilities/FIB184_LogSinkExceptionTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/FIB184_LogSinkExceptionTest.cpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ * @brief FIB-184: an exception thrown on an asynchronous log sink's feeding thread must not
+ *        propagate to std::terminate/abort. BoostLogInitializer installs
+ *        make_exception_suppressor() on every async sink; this verifies that mechanism: a sink
+ *        backend that always throws does not crash the process when the suppressor is installed.
+ * @file FIB184_LogSinkExceptionTest.cpp
+ */
+
+#include <boost/log/core.hpp>
+#include <boost/log/sinks/async_frontend.hpp>
+#include <boost/log/sinks/basic_sink_backend.hpp>
+#include <boost/log/sinks/frontend_requirements.hpp>
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/sources/severity_logger.hpp>
+#include <boost/log/utility/exception_handler.hpp>
+#include <boost/smart_ptr/make_shared_object.hpp>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <stdexcept>
+
+namespace bcos::test
+{
+namespace
+{
+// A sink backend that throws on every consumed record, simulating a formatting/IO failure on the
+// async sink's dedicated feeding thread (the FIB-184 crash trigger).
+class ThrowingBackend
+  : public boost::log::sinks::basic_sink_backend<boost::log::sinks::synchronized_feeding>
+{
+public:
+    std::atomic<int>* m_consumed = nullptr;
+    void consume(boost::log::record_view const& /*record*/)
+    {
+        if (m_consumed != nullptr)
+        {
+            m_consumed->fetch_add(1);
+        }
+        throw std::runtime_error("FIB-184 simulated log backend failure");
+    }
+};
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(FIB184LogSinkExceptionTest)
+
+BOOST_AUTO_TEST_CASE(asyncSinkSuppressesBackendException)
+{
+    using sink_t = boost::log::sinks::asynchronous_sink<ThrowingBackend>;
+    std::atomic<int> consumed{0};
+    auto backend = boost::make_shared<ThrowingBackend>();
+    backend->m_consumed = &consumed;
+    auto sink = boost::make_shared<sink_t>(backend);
+    // The fix under test: without this handler the throw on the feeding thread is uncaught and
+    // reaches std::terminate -> abort (it would crash this test binary, not just fail the case).
+    sink->set_exception_handler(boost::log::make_exception_suppressor());
+
+    auto core = boost::log::core::get();
+    core->add_sink(sink);
+
+    boost::log::sources::severity_logger<int> logger;
+    BOOST_LOG_SEV(logger, 0) << "FIB-184 trigger record";
+
+    sink->stop();  // join the feeding thread: consume() runs here, throws, and is suppressed
+    sink->flush();
+    core->remove_sink(sink);
+
+    BOOST_CHECK_GE(consumed.load(), 1);  // the throwing backend actually ran
+    BOOST_CHECK(true);                   // reached only because the throw did not abort the process
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/fisco-bcos-air/main.cpp
+++ b/fisco-bcos-air/main.cpp
@@ -38,14 +38,11 @@ int main(int argc, const char* argv[])
 {
     /// set LC_ALL
     setDefaultOrCLocale();
-    // TODO(FIB-184): this terminate handler is the abort amplifier for the log-sink half of
-    // FIB-184. Under TLS connect/close churn an exception is rethrown inside the boost
-    // asynchronous_sink (BoostLogInitializer::sink_t) on the dedicated log thread; being
-    // uncaught there it reaches std::terminate -> abort() here and crashes the node. The real
-    // fix wraps the async sink's formatter/consumer in bcos-utilities/BoostLogInitializer.cpp so
-    // it can never propagate an uncaught exception. That file is outside this change's scope
-    // (gateway/pbft/air only); do NOT "fix" this by swallowing exceptions in the terminate
-    // handler, which would hide unrelated crashes. Tracked for a follow-up bcos-utilities PR.
+    // FIB-184: the log-sink abort path is now closed at the source — every async sink in
+    // BoostLogInitializer installs make_exception_suppressor(), so an exception on the log
+    // feeding thread drops the record instead of reaching std::terminate. This handler is kept
+    // only as a last-resort backstop for genuinely unexpected terminations; it must NOT swallow
+    // exceptions (that would hide unrelated crashes), it only prints a backtrace then aborts.
     std::set_terminate([]() {
         std::cerr << "terminate handler called, print stacks" << std::endl;
         void* trace_elems[50];


### PR DESCRIPTION
## Overview

CertiK's 2026-06-23 re-review escalated FIB-184 to **Critical/Pending** and kept FIB-185 **Partially Resolved**. They are two faces of one incident: authenticated TLS session-teardown churn halts consensus fleet-wide and crashes nodes. This PR closes both. Two commits, one per finding. None of the changes alter block/receipt/consensus-message content, so no compatibility-version feature gate is required.

## FIB-184 (Critical) — gateway/utilities hardening

CertiK symbolized two crash signatures from core dumps plus a fleet-wide hang. Three residuals remained after the prior mitigation; all are fixed here:

1. **64MB recv buffer allocated eagerly per session.** `SessionFactory::createSession` passed the config-validated `session_recv_buffer_size` (forced to `2 * allow_max_msg_size` = 64MB) as the `Session` ctor's initial buffer size, so every inbound session preallocated 64MB and TLS connect/close churn exhausted the heap (SIGSEGV in malloc during `Session::Session`). The 16KB `INITIAL_SESSION_RECV_BUFFER_SIZE` was only the ctor's default argument, bypassed in production. Now `_recvBufferSize` is the grow ceiling and the ctor allocates only the 16KB initial buffer; `doRead` grows up to `m_maxRecvBufferSize` on demand.

2. **Session caps hardcoded, not configurable.** `Host` enforced max-concurrent-sessions=1024 / max-sessions-per-IP=32 as `constexpr` defaults with no `GatewayConfig` plumbing. Added `p2p.max_concurrent_sessions` / `p2p.max_sessions_per_ip` to `GatewayConfig` and wired them into `Host` via `GatewayFactory`.

3. **Async log sink could abort the node.** An exception on the boost `asynchronous_sink` feeding thread was uncaught and reached `std::terminate` -> `abort`, turning the logging subsystem into a crash amplifier under churn. Installed `make_exception_suppressor()` on every async sink in `BoostLogInitializer` so a log record is dropped instead of crashing the node; the `fisco-bcos-air` terminate handler is now only a last-resort backstop.

Tests: `ProductionLargeRecvBufferDoesNotPreallocate` (covers the production 64MB path the prior tests missed — verified RED on the old ctor), `test_sessionCapsFromConfig`, `asyncSinkSuppressesBackendException`.

## FIB-185 (Medium) — send consensus messages off the caller thread

The prior watchdog re-arms a stalled view-change timer but cannot recover a consensus worker blocked on `m_mutex`. PBFT's broadcasts (prepare / commit / checkpoint / view-change) **and** its point-to-point sends (`sendViewChange` / `sendRecoverResponse`) run while the consensus worker holds `PBFTEngine::m_mutex`.

`task::wait` is fire-and-forget, but it still runs the send's synchronous prefix on the caller thread: the bcos-task coroutine chain (`FrontService::broadcastMessage` → `Gateway::broadcastMessage` → `PeersRouterTable::broadcastMessage` → `Service::sendMessageByNodeID`, and the point-to-point `Service::asyncSendMessageByNodeID`) resumes inline until the first real suspension, which is the async socket write deep in `Session`. That prefix reaches `getP2PSessionByNodeID`, which takes the gateway session lock (`Service::x_sessions`, shared). Under session-teardown churn that lock is held exclusively by frequent connect/disconnect (`onConnect`/`onDisconnect`), so the consensus worker stalls on the shared lock while holding `m_mutex`, and every other consensus operation stalls behind `m_mutex` — consensus halts.

Fix it at the FrontService boundary, scoped to PBFT, without changing the `broadcastMessage` / `asyncSendMessageByNodeID` contracts that txpool and sync rely on:

- Two new owned-payload async entry points on `FrontServiceInterface`: `asyncBroadcastMessageByOwnedPayload(type, moduleID, bytesPointer)` and `asyncSendMessageByNodeIDByOwnedPayload(moduleID, nodeID, bytesPointer)`. They take ownership of the already-encoded payload so the send can be deferred. Each has a default implementation that bridges to the existing method (correct for the tars client and test fakes, which have no in-process gateway lock); the production `FrontService` overrides them to enqueue the gateway send onto a serial queue (`enqueueSend`/`drainSendQueue`) reusing the existing `m_asyncGroup` executor (no dedicated thread, FIFO order). A throwing send task is caught and logged, never escalated to the tbb worker thread.
- The broadcast entry forwards the owned payload by reference (zero body copy). Point-to-point must encode the wire frame, so it is not zero-copy; owning the payload only keeps it alive across the deferred encode.
- PBFT's 7 broadcast sites and the 2 point-to-point sends use the new entry points, so all of PBFT's `m_mutex`-held sends now leave the consensus worker. txpool/sync are untouched (the added methods have default implementations).

Test: `FIB185_AsyncSendOffCallerThreadTest` — with a gateway whose broadcast and point-to-point send each block, the caller returns promptly and the send runs on another thread (both verified RED before the change: the caller blocked ~400ms on its own thread).

## Verification

- `test-bcos-utilities`, `test-bcos-pbft`, and `test-bcos-front` full suites pass (exit 0).
- `txpool` and `sync` libraries compile against the new interface methods (each added method has a default implementation, so existing implementers and callers are unaffected).
- `test-bcos-gateway` passes from the test data directory; the suite's pre-existing config/cert cases read `data/config/*.ini` relative to cwd.
- The full 600s multi-node TLS-churn reproduction is fleet-level (CertiK's harness); this PR verifies each documented root cause at unit level and by code.
