### PR TITLE
Refactor thread pool configuration: consolidate to TBB and shared IOServicePool settings

### DIFF
--- a/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsService.cpp
@@ -182,10 +182,10 @@ void WsService::start()
     }
     m_running = true;
 
-    // init m_timerFactory if it is not not initialized
+    // init m_timerFactory if it is not initialized
     if (!m_timerFactory)
     {
-        m_timerFactory = std::make_shared<timer::TimerFactory>();
+        m_timerFactory = std::make_shared<timer::TimerFactory>(m_timerIoc);
     }
 
     // start as server

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -123,11 +123,6 @@ uint16_t GatewayConfig::listenPort() const
     return m_listenPort;
 }
 
-uint32_t GatewayConfig::threadPoolSize() const
-{
-    return m_threadPoolSize;
-}
-
 bool GatewayConfig::smSSL() const
 {
     return m_smSSL;
@@ -602,9 +597,6 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
     constexpr static uint32_t defaultMaxSendMsgCount = 10;
     m_maxSendMsgCount = _pt.get<uint32_t>("p2p.session_max_send_msg_count", defaultMaxSendMsgCount);
 
-    constexpr static uint32_t defaultThreadPoolSize = 8;
-    m_threadPoolSize = _pt.get<uint32_t>("p2p.thread_count", defaultThreadPoolSize);
-
     m_smSSL = smSSL;
     m_listenIP = listenIP;
     m_listenPort = (uint16_t)listenPort;
@@ -618,7 +610,6 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
                              << LOG_KV("p2p.session_max_read_data_size", m_maxReadDataSize)
                              << LOG_KV("p2p.session_max_send_data_size", m_maxSendDataSize)
                              << LOG_KV("p2p.session_max_send_msg_count", m_maxSendMsgCount)
-                             << LOG_KV("p2p.thread_count", m_threadPoolSize)
                              << LOG_KV("p2p.nodes_path", m_nodePath)
                              << LOG_KV("p2p.nodes_file", m_nodeFileName)
                              << LOG_KV("p2p.readonly", m_readonly)

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -572,6 +572,14 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
 
     m_enableCompress = _pt.get<bool>("p2p.enable_compression", true);
 
+    // Deprecation warning for removed p2p.thread_count
+    if (_pt.get_optional<uint32_t>("p2p.thread_count"))
+    {
+        GATEWAY_CONFIG_LOG(WARNING)
+            << LOG_DESC("initP2PConfig: p2p.thread_count is deprecated, "
+                        "use thread_pool.io_thread_count instead");
+    }
+
     constexpr static uint32_t defaultAllowMaxMsgSize = MAX_MESSAGE_LENGTH;
     m_allowMaxMsgSize = _pt.get<uint32_t>("p2p.allow_max_msg_size", defaultAllowMaxMsgSize);
 

--- a/bcos-gateway/bcos-gateway/GatewayConfig.h
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.h
@@ -179,7 +179,6 @@ public:
 
     std::string listenIP() const;
     uint16_t listenPort() const;
-    uint32_t threadPoolSize() const;
     bool smSSL() const;
     uint8_t sslClientMode() const;
     uint8_t sslServerMode() const;
@@ -290,8 +289,6 @@ private:
     std::string m_listenIP;
     // p2p network listen Port
     uint16_t m_listenPort;
-    // threadPool size
-    uint32_t m_threadPoolSize{8};
     // p2p connected nodes host list
     std::set<NodeIPEndpoint> m_connectedNodes;
     // peer black list

--- a/bcos-gateway/test/unittests/GatewayConfigTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigTest.cpp
@@ -149,7 +149,6 @@ BOOST_AUTO_TEST_CASE(test_nodesJsonParser)
         std::set<NodeIPEndpoint> nodeIPEndpointSet;
         config->parseConnectedJson(json, nodeIPEndpointSet);
         BOOST_CHECK_EQUAL(nodeIPEndpointSet.size(), 3);
-        BOOST_CHECK_EQUAL(config->threadPoolSize(), 8);
     }
 
     {
@@ -158,7 +157,6 @@ BOOST_AUTO_TEST_CASE(test_nodesJsonParser)
         std::set<NodeIPEndpoint> nodeIPEndpointSet;
         config->parseConnectedJson(json, nodeIPEndpointSet);
         BOOST_CHECK_EQUAL(nodeIPEndpointSet.size(), 0);
-        BOOST_CHECK_EQUAL(config->threadPoolSize(), 8);
     }
 
     {
@@ -170,7 +168,6 @@ BOOST_AUTO_TEST_CASE(test_nodesJsonParser)
         std::set<NodeIPEndpoint> nodeIPEndpointSet;
         config->parseConnectedJson(json, nodeIPEndpointSet);
         BOOST_CHECK_EQUAL(nodeIPEndpointSet.size(), 2);
-        BOOST_CHECK_EQUAL(config->threadPoolSize(), 8);
     }
 }
 

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -39,6 +39,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/FileUtility.h>
+#include <bcos-utilities/NewTimer.h>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -73,14 +74,13 @@ std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initConfig(
 
     wsConfig->setListenIP(_nodeConfig->rpcListenIP());
     wsConfig->setListenPort(_nodeConfig->rpcListenPort());
-    wsConfig->setThreadPoolSize(_nodeConfig->rpcThreadPoolSize());
     wsConfig->setDisableSsl(_nodeConfig->rpcDisableSsl());
     if (_nodeConfig->rpcDisableSsl())
     {
         RPC_LOG(INFO) << LOG_BADGE("initConfig") << LOG_DESC("rpc work in disable ssl model")
                       << LOG_KV("listenIP", wsConfig->listenIP())
                       << LOG_KV("listenPort", wsConfig->listenPort())
-                      << LOG_KV("threadCount", wsConfig->threadPoolSize())
+                      << LOG_KV("ioThreadCount", _nodeConfig->ioThreadCount())
                       << LOG_KV("asServer", wsConfig->asServer());
         return wsConfig;
     }
@@ -170,7 +170,7 @@ std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initConfig(
         RPC_LOG(INFO) << LOG_DESC("rpc work in ssl model")
                       << LOG_KV("listenIP", wsConfig->listenIP())
                       << LOG_KV("listenPort", wsConfig->listenPort())
-                      << LOG_KV("threadCount", wsConfig->threadPoolSize())
+                      << LOG_KV("ioThreadCount", _nodeConfig->ioThreadCount())
                       << LOG_KV("asServer", wsConfig->asServer())
                       << LOG_KV("caCert", _nodeConfig->caCert())
                       << LOG_KV("nodeCert", _nodeConfig->nodeCert())
@@ -308,7 +308,7 @@ std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initConfig(
         RPC_LOG(INFO) << LOG_DESC("rpc work in sm ssl model")
                       << LOG_KV("listenIP", wsConfig->listenIP())
                       << LOG_KV("listenPort", wsConfig->listenPort())
-                      << LOG_KV("threadCount", wsConfig->threadPoolSize())
+                      << LOG_KV("ioThreadCount", _nodeConfig->ioThreadCount())
                       << LOG_KV("asServer", wsConfig->asServer())
                       << LOG_KV("caCert", _nodeConfig->smCaCert())
                       << LOG_KV("nodeCert", _nodeConfig->smNodeCert())
@@ -330,7 +330,6 @@ std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initWeb3RpcServiceConf
 
     wsConfig->setListenIP(_nodeConfig->web3RpcListenIP());
     wsConfig->setListenPort(_nodeConfig->web3RpcListenPort());
-    wsConfig->setThreadPoolSize(_nodeConfig->web3RpcThreadSize());
     wsConfig->setDisableSsl(true);
     wsConfig->setMaxMsgSize(_nodeConfig->web3HttpBodySizeLimit());
     wsConfig->setCorsConfig(
@@ -344,7 +343,7 @@ std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initWeb3RpcServiceConf
     RPC_LOG(INFO) << LOG_BADGE("initWeb3RpcServiceConfig")
                   << LOG_KV("listenIP", wsConfig->listenIP())
                   << LOG_KV("listenPort", wsConfig->listenPort())
-                  << LOG_KV("threadCount", wsConfig->threadPoolSize())
+                  << LOG_KV("ioThreadCount", _nodeConfig->ioThreadCount())
                   << LOG_KV("asServer", wsConfig->asServer())
                   << LOG_KV("maxMsgSize", wsConfig->maxMsgSize())
                   << LOG_KV("corsConfig", wsConfig->corsConfig().toString());
@@ -358,30 +357,22 @@ bcos::boostssl::ws::WsService::Ptr RpcFactory::buildWsService(
     auto wsService = std::make_shared<bcos::boostssl::ws::WsService>();
     auto initializer = std::make_shared<bcos::boostssl::ws::WsInitializer>();
 
-    // Check threadPoolSize configuration (read before moving _config)
-    size_t threadPoolSize = _config ? _config->threadPoolSize() : 0;
-
     initializer->setConfig(std::move(_config));
 
-    if (threadPoolSize > 0)
+    if (!m_ioServicePool)
     {
-        // Use a dedicated thread pool for RPC
-        auto rpcIOServicePool = std::make_shared<bcos::IOServicePool>(threadPoolSize, "rpc");
-        initializer->setIOServicePool(rpcIOServicePool);
+        BOOST_THROW_EXCEPTION(
+            InvalidParameter() << errinfo_comment("No shared IOServicePool available for RPC!"));
     }
-    else if (m_ioServicePool)
-    {
-        // Use the shared external IOServicePool
-        initializer->setIOServicePool(m_ioServicePool);
-    }
-    else
-    {
-        // No external pool and no threadPoolSize configured, throw exception
-        BOOST_THROW_EXCEPTION(InvalidParameter() << errinfo_comment(
-                                  "No IOServicePool available for RPC: please configure "
-                                  "threadPoolSize or set shared IOServicePool!"));
-    }
+    // Use the shared external IOServicePool
+    initializer->setIOServicePool(m_ioServicePool);
     initializer->initWsService(wsService);
+
+    // Use shared IOServicePool's io_context for TimerFactory to avoid
+    // creating dedicated "timerFactory" threads
+    auto timerFactory =
+        std::make_shared<timer::TimerFactory>(m_ioServicePool->getIOService());
+    wsService->setTimerFactory(std::move(timerFactory));
 
     return wsService;
 }
@@ -390,9 +381,9 @@ bcos::rpc::JsonRpcImpl_2_0::Ptr RpcFactory::buildJsonRpc(int sendTxTimeout,
     const std::shared_ptr<boostssl::ws::WsService>& _wsService, GroupManager::Ptr _groupManager)
 {
     // JsonRpcImpl_2_0
-    auto filterSystem = std::make_shared<JsonRpcFilterSystem>(
-        *m_ioServicePool->getIOService(), _groupManager, m_nodeConfig->groupId(),
-            m_nodeConfig->rpcFilterTimeout(), m_nodeConfig->rpcMaxProcessBlock());
+    auto filterSystem = std::make_shared<JsonRpcFilterSystem>(*m_ioServicePool->getIOService(),
+        _groupManager, m_nodeConfig->groupId(), m_nodeConfig->rpcFilterTimeout(),
+        m_nodeConfig->rpcMaxProcessBlock());
     auto jsonRpcInterface = std::make_shared<bcos::rpc::JsonRpcImpl_2_0>(
         _groupManager, m_gateway, _wsService, filterSystem, m_nodeConfig->forceSender());
     jsonRpcInterface->setSendTxTimeout(sendTxTimeout);
@@ -409,9 +400,9 @@ bcos::rpc::JsonRpcImpl_2_0::Ptr RpcFactory::buildJsonRpc(int sendTxTimeout,
 bcos::rpc::Web3JsonRpcImpl::Ptr RpcFactory::buildWeb3JsonRpc(
     int sendTxTimeout, boostssl::ws::WsService::Ptr _wsService, GroupManager::Ptr _groupManager)
 {
-    auto web3FilterSystem = std::make_shared<Web3FilterSystem>(
-        *m_ioServicePool->getIOService(), _groupManager, m_nodeConfig->groupId(),
-            m_nodeConfig->web3FilterTimeout(), m_nodeConfig->web3MaxProcessBlock());
+    auto web3FilterSystem = std::make_shared<Web3FilterSystem>(*m_ioServicePool->getIOService(),
+        _groupManager, m_nodeConfig->groupId(), m_nodeConfig->web3FilterTimeout(),
+        m_nodeConfig->web3MaxProcessBlock());
     auto web3JsonRpc = std::make_shared<Web3JsonRpcImpl>(m_nodeConfig->groupId(),
         m_nodeConfig->web3BatchRequestSizeLimit(), std::move(_groupManager), m_gateway, _wsService,
         web3FilterSystem, m_nodeConfig->web3SyncTransaction());
@@ -470,7 +461,7 @@ Rpc::Ptr RpcFactory::buildRpc(std::string const& _gatewayServiceName,
 
     RPC_LOG(INFO) << LOG_KV("listenIP", config->listenIP())
                   << LOG_KV("listenPort", config->listenPort())
-                  << LOG_KV("threadCount", config->threadPoolSize())
+                  << LOG_KV("ioThreadCount", m_nodeConfig->ioThreadCount())
                   << LOG_KV("gatewayServiceName", _gatewayServiceName);
     auto rpc = buildRpc(m_nodeConfig->sendTxTimeout(), wsService, groupManager, amopClient);
     return rpc;
@@ -562,8 +553,8 @@ GroupManager::Ptr RpcFactory::buildGroupManager(
     if (!_entryPoint)
     {
         RPC_LOG(INFO) << LOG_DESC("buildGroupManager: using tars to manager the node info");
-        return std::make_shared<TarsGroupManager>(*m_ioServicePool->getIOService(),
-            _rpcServiceName, m_chainID, nodeServiceFactory, m_nodeConfig);
+        return std::make_shared<TarsGroupManager>(*m_ioServicePool->getIOService(), _rpcServiceName,
+            m_chainID, nodeServiceFactory, m_nodeConfig);
     }
     RPC_LOG(INFO) << LOG_DESC("buildGroupManager with leaderEntryPoint to manager the node info");
     auto groupManager = std::make_shared<GroupManager>(
@@ -606,8 +597,8 @@ AMOPClient::Ptr RpcFactory::buildAMOPClient(
 {
     auto wsFactory = std::make_shared<WsMessageFactory>();
     auto requestFactory = std::make_shared<AMOPRequestFactory>();
-    return std::make_shared<AMOPClient>(*m_ioServicePool->getIOService(),
-        _wsService, wsFactory, requestFactory, m_gateway, _gatewayServiceName);
+    return std::make_shared<AMOPClient>(*m_ioServicePool->getIOService(), _wsService, wsFactory,
+        requestFactory, m_gateway, _gatewayServiceName);
 }
 
 AMOPClient::Ptr RpcFactory::buildAirAMOPClient(std::shared_ptr<boostssl::ws::WsService> _wsService)

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -562,7 +562,6 @@ void NodeConfig::loadRpcConfig(boost::property_tree::ptree const& _pt)
     */
     std::string listenIP = _pt.get<std::string>("rpc.listen_ip", "0.0.0.0");
     int listenPort = _pt.get<int>("rpc.listen_port", 20200);
-    int threadCount = _pt.get<int>("rpc.thread_count", 8);
     int filterTimeout = _pt.get<int>("rpc.filter_timeout", 300);
     int maxProcessBlock = _pt.get<int>("rpc.filter_max_process_block", 10);
     bool smSsl = _pt.get<bool>("rpc.sm_ssl", false);
@@ -576,7 +575,6 @@ void NodeConfig::loadRpcConfig(boost::property_tree::ptree const& _pt)
 
     m_rpcListenIP = listenIP;
     m_rpcListenPort = listenPort;
-    m_rpcThreadPoolSize = threadCount;
     m_rpcDisableSsl = disableSsl;
     m_rpcSmSsl = smSsl;
     m_rpcFilterTimeout = filterTimeout * 1000;  // to milliseconds
@@ -614,7 +612,6 @@ void NodeConfig::loadWeb3RpcConfig(boost::property_tree::ptree const& _pt)
     */
     const std::string listenIP = _pt.get<std::string>("web3_rpc.listen_ip", "127.0.0.1");
     const int listenPort = _pt.get<int>("web3_rpc.listen_port", 8545);
-    const int threadCount = _pt.get<int>("web3_rpc.thread_count", 8);
     const int filterTimeout = _pt.get<int>("web3_rpc.filter_timeout", 300);
     const int maxProcessBlock = _pt.get<int>("web3_rpc.filter_max_process_block", 10);
     const bool enableWeb3Rpc = _pt.get<bool>("web3_rpc.enable", false);
@@ -632,7 +629,6 @@ void NodeConfig::loadWeb3RpcConfig(boost::property_tree::ptree const& _pt)
 
     m_web3RpcListenIP = listenIP;
     m_web3RpcListenPort = listenPort;
-    m_web3RpcThreadSize = threadCount;
     m_enableWeb3Rpc = enableWeb3Rpc;
     m_web3FilterTimeout = filterTimeout * 1000;  // to milliseconds
     m_web3MaxProcessBlock = maxProcessBlock;
@@ -648,7 +644,6 @@ void NodeConfig::loadWeb3RpcConfig(boost::property_tree::ptree const& _pt)
 
     NodeConfig_LOG(INFO) << LOG_DESC("loadWeb3RpcConfig") << LOG_KV("enableWeb3Rpc", enableWeb3Rpc)
                          << LOG_KV("listenIP", listenIP) << LOG_KV("listenPort", listenPort)
-                         << LOG_KV("listenPort", listenPort) << LOG_KV("threadCount", threadCount)
                          << LOG_KV("filterTimeout", filterTimeout)
                          << LOG_KV("maxProcessBlock", maxProcessBlock)
                          << LOG_KV("batchRequestSizeLimit", batchRequestSizeLimit)
@@ -768,19 +763,6 @@ void NodeConfig::loadTxPoolConfig(boost::property_tree::ptree const& _pt)
         BOOST_THROW_EXCEPTION(
             InvalidConfig() << errinfo_comment("Please set txpool.limit to positive !"));
     }
-    m_notifyWorkerNum = checkAndGetValue(_pt, "txpool.notify_worker_num", "2");
-    if (m_notifyWorkerNum <= 0)
-    {
-        BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
-                                  "Please set txpool.notify_worker_num to positive !"));
-    }
-    m_verifierWorkerNum = checkAndGetValue(_pt, "txpool.verify_worker_num",
-        std::to_string(std::min(8U, std::thread::hardware_concurrency() + 1)));
-    if (m_verifierWorkerNum <= 0)
-    {
-        BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
-                                  "Please set txpool.verify_worker_num to positive !"));
-    }
     // the txs expiration time, in second
     auto txsExpirationTime = checkAndGetValue(_pt, "txpool.txs_expiration_time", "600");
     if (txsExpirationTime * 1000 <= DEFAULT_MIN_CONSENSUS_TIME_MS) [[unlikely]]
@@ -808,8 +790,6 @@ void NodeConfig::loadTxPoolConfig(boost::property_tree::ptree const& _pt)
     }
     m_preStoreMaxInflight = static_cast<size_t>(preStoreCap);
     NodeConfig_LOG(INFO) << LOG_DESC("loadTxPoolConfig") << LOG_KV("txpoolLimit", m_txpoolLimit)
-                         << LOG_KV("notifierWorkers", m_notifyWorkerNum)
-                         << LOG_KV("verifierWorkers", m_verifierWorkerNum)
                          << LOG_KV("checkBlockLimit", m_checkBlockLimit)
                          << LOG_KV("txsExpirationTime(ms)", m_txsExpirationTime)
                          << LOG_KV("enableTxsFromFreeNode", m_enableTxsFromFreeNode)
@@ -1181,13 +1161,16 @@ void NodeConfig::loadOthersConfig(boost::property_tree::ptree const& _pt)
     m_vmCacheSize = _pt.get<int>("executor.vm_cache_size", 1024);
     m_baselineSchedulerConfig.grainSize =
         _pt.get<int>("executor.baseline_scheduler_chunksize", 100);
-    m_baselineSchedulerConfig.maxThread = _pt.get<int>("executor.baseline_scheduler_maxthread", 16);
     m_baselineSchedulerConfig.parallel =
         _pt.get<bool>("executor.baseline_scheduler_parallel", false);
 
+    m_ioThreadCount = checkAndGetValue(_pt, "executor.io_thread_count",
+        std::to_string(std::thread::hardware_concurrency() + 1));
+    m_tbbThreadCount = checkAndGetValue(_pt, "executor.tbb_thread_count",
+        std::to_string(std::thread::hardware_concurrency()));
+
     m_tarsRPCConfig.host = _pt.get<std::string>("rpc.tars_rpc_host", "127.0.0.1");
     m_tarsRPCConfig.port = _pt.get<int>("rpc.tars_rpc_port", 0);
-    m_tarsRPCConfig.threadCount = _pt.get<int>("rpc.tars_rpc_thread_count", 8);
 
     m_checkTransactionSignature = _pt.get<bool>("experimental.check_transaction_signature", true);
     m_checkParallelConflict = _pt.get<bool>("experimental.check_parallel_conflict", true);
@@ -1200,6 +1183,8 @@ void NodeConfig::loadOthersConfig(boost::property_tree::ptree const& _pt)
 
     NodeConfig_LOG(INFO) << LOG_DESC("loadOthersConfig") << LOG_KV("sendTxTimeout", m_sendTxTimeout)
                          << LOG_KV("vmCacheSize", m_vmCacheSize)
+                         << LOG_KV("ioThreadCount", m_ioThreadCount)
+                         << LOG_KV("tbbThreadCount", m_tbbThreadCount)
                          << LOG_KV("checkTransactionSignature", m_checkTransactionSignature)
                          << LOG_KV("checkParallelConflict", m_checkParallelConflict)
                          << LOG_KV("singlePointConsensus", m_singlePointConsensus)
@@ -1532,16 +1517,6 @@ size_t NodeConfig::txpoolLimit() const
     return m_txpoolLimit;
 }
 
-size_t NodeConfig::notifyWorkerNum() const
-{
-    return m_notifyWorkerNum;
-}
-
-size_t NodeConfig::verifierWorkerNum() const
-{
-    return m_verifierWorkerNum;
-}
-
 int64_t NodeConfig::txsExpirationTime() const
 {
     return m_txsExpirationTime;
@@ -1832,11 +1807,6 @@ uint16_t NodeConfig::rpcListenPort() const
     return m_rpcListenPort;
 }
 
-uint32_t NodeConfig::rpcThreadPoolSize() const
-{
-    return m_rpcThreadPoolSize;
-}
-
 uint32_t NodeConfig::rpcFilterTimeout() const
 {
     return m_rpcFilterTimeout;
@@ -1870,11 +1840,6 @@ const std::string& NodeConfig::web3RpcListenIP() const
 uint16_t NodeConfig::web3RpcListenPort() const
 {
     return m_web3RpcListenPort;
-}
-
-uint32_t NodeConfig::web3RpcThreadSize() const
-{
-    return m_web3RpcThreadSize;
 }
 
 uint32_t NodeConfig::web3FilterTimeout() const
@@ -2182,6 +2147,16 @@ bool NodeConfig::preStoreBackpressureEnabled() const
 size_t NodeConfig::preStoreMaxInflight() const
 {
     return m_preStoreMaxInflight;
+}
+
+size_t NodeConfig::ioThreadCount() const
+{
+    return m_ioThreadCount;
+}
+
+size_t NodeConfig::tbbThreadCount() const
+{
+    return m_tbbThreadCount;
 }
 
 void NodeConfig::loadAlloc(boost::property_tree::ptree const& ptree)

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -573,6 +573,14 @@ void NodeConfig::loadRpcConfig(boost::property_tree::ptree const& _pt)
     }
     bool needRetInput = _pt.get<bool>("rpc.return_input_params", true);
 
+    // Deprecation warning for removed rpc.thread_count
+    if (_pt.get_optional<int>("rpc.thread_count"))
+    {
+        NodeConfig_LOG(WARNING)
+            << LOG_DESC("loadRpcConfig: rpc.thread_count is deprecated, "
+                        "use thread_pool.io_thread_count instead");
+    }
+
     m_rpcListenIP = listenIP;
     m_rpcListenPort = listenPort;
     m_rpcDisableSsl = disableSsl;
@@ -626,6 +634,14 @@ void NodeConfig::loadWeb3RpcConfig(boost::property_tree::ptree const& _pt)
     const std::string corsAllowedHeaders = _pt.get<std::string>(
         "web3_rpc.cors_allowed_headers", "Content-Type, Authorization, X-Requested-With");
     const int32_t corsMaxAge = _pt.get<int32_t>("web3_rpc.cors_max_age", 86400);
+
+    // Deprecation warning for removed web3_rpc.thread_count
+    if (_pt.get_optional<int>("web3_rpc.thread_count"))
+    {
+        NodeConfig_LOG(WARNING)
+            << LOG_DESC("loadWeb3RpcConfig: web3_rpc.thread_count is deprecated, "
+                        "use thread_pool.io_thread_count instead");
+    }
 
     m_web3RpcListenIP = listenIP;
     m_web3RpcListenPort = listenPort;
@@ -757,6 +773,20 @@ void NodeConfig::loadCertConfig(boost::property_tree::ptree const& _pt)
 // load the txpool related params
 void NodeConfig::loadTxPoolConfig(boost::property_tree::ptree const& _pt)
 {
+    // Deprecation warnings for removed txpool thread config keys
+    if (_pt.get_optional<std::string>("txpool.notify_worker_num"))
+    {
+        NodeConfig_LOG(WARNING)
+            << LOG_DESC("loadTxPoolConfig: txpool.notify_worker_num is deprecated, "
+                        "use thread_pool.io_thread_count instead");
+    }
+    if (_pt.get_optional<std::string>("txpool.verify_worker_num"))
+    {
+        NodeConfig_LOG(WARNING)
+            << LOG_DESC("loadTxPoolConfig: txpool.verify_worker_num is deprecated, "
+                        "use thread_pool.io_thread_count instead");
+    }
+
     m_txpoolLimit = checkAndGetValue(_pt, "txpool.limit", "15000");
     if (m_txpoolLimit <= 0)
     {
@@ -1164,9 +1194,23 @@ void NodeConfig::loadOthersConfig(boost::property_tree::ptree const& _pt)
     m_baselineSchedulerConfig.parallel =
         _pt.get<bool>("executor.baseline_scheduler_parallel", false);
 
-    m_ioThreadCount = checkAndGetValue(_pt, "executor.io_thread_count",
+    // Deprecation warning for removed config keys
+    if (_pt.get_optional<std::string>("executor.baseline_scheduler_maxthread"))
+    {
+        NodeConfig_LOG(WARNING)
+            << LOG_DESC("loadOthersConfig: executor.baseline_scheduler_maxthread is deprecated, "
+                        "use thread_pool.tbb_thread_count instead");
+    }
+    if (_pt.get_optional<std::string>("rpc.tars_rpc_thread_count"))
+    {
+        NodeConfig_LOG(WARNING)
+            << LOG_DESC("loadOthersConfig: rpc.tars_rpc_thread_count is deprecated, "
+                        "use thread_pool.io_thread_count instead");
+    }
+
+    m_ioThreadCount = checkAndGetValue(_pt, "thread_pool.io_thread_count",
         std::to_string(std::thread::hardware_concurrency() + 1));
-    m_tbbThreadCount = checkAndGetValue(_pt, "executor.tbb_thread_count", "0");
+    m_tbbThreadCount = checkAndGetValue(_pt, "thread_pool.tbb_thread_count", "0");
 
     m_tarsRPCConfig.host = _pt.get<std::string>("rpc.tars_rpc_host", "127.0.0.1");
     m_tarsRPCConfig.port = _pt.get<int>("rpc.tars_rpc_port", 0);

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -1166,8 +1166,7 @@ void NodeConfig::loadOthersConfig(boost::property_tree::ptree const& _pt)
 
     m_ioThreadCount = checkAndGetValue(_pt, "executor.io_thread_count",
         std::to_string(std::thread::hardware_concurrency() + 1));
-    m_tbbThreadCount = checkAndGetValue(_pt, "executor.tbb_thread_count",
-        std::to_string(std::thread::hardware_concurrency()));
+    m_tbbThreadCount = checkAndGetValue(_pt, "executor.tbb_thread_count", "0");
 
     m_tarsRPCConfig.host = _pt.get<std::string>("rpc.tars_rpc_host", "127.0.0.1");
     m_tarsRPCConfig.port = _pt.get<int>("rpc.tars_rpc_port", 0);

--- a/bcos-tool/bcos-tool/NodeConfig.h
+++ b/bcos-tool/bcos-tool/NodeConfig.h
@@ -83,8 +83,6 @@ public:
 
     // the txpool configurations
     size_t txpoolLimit() const;
-    size_t notifyWorkerNum() const;
-    size_t verifierWorkerNum() const;
     int64_t txsExpirationTime() const;
     bool checkBlockLimit() const;
 
@@ -165,7 +163,6 @@ public:
     // the rpc configurations
     const std::string& rpcListenIP() const;
     uint16_t rpcListenPort() const;
-    uint32_t rpcThreadPoolSize() const;
     uint32_t rpcFilterTimeout() const;
     uint32_t rpcMaxProcessBlock() const;
     bool rpcSmSsl() const;
@@ -175,7 +172,6 @@ public:
     bool enableWeb3Rpc() const;
     const std::string& web3RpcListenIP() const;
     uint16_t web3RpcListenPort() const;
-    uint32_t web3RpcThreadSize() const;
     uint32_t web3FilterTimeout() const;
     uint32_t web3MaxProcessBlock() const;
     uint32_t web3BatchRequestSizeLimit() const;
@@ -187,6 +183,10 @@ public:
     int32_t web3CorsMaxAge() const;
     bool web3CorsAllowCredentials() const;
     bool web3SyncTransaction() const;
+
+    // thread pool configuration
+    size_t ioThreadCount() const;
+    size_t tbbThreadCount() const;
 
     // the gateway configurations
     const std::string& p2pListenIP() const;
@@ -259,7 +259,6 @@ public:
     {
         bool parallel = false;
         int grainSize = 0;
-        int maxThread = 0;
     };
     BaselineSchedulerConfig const& baselineSchedulerConfig() const;
 
@@ -267,7 +266,6 @@ public:
     {
         std::string host;
         uint16_t port = 0;
-        uint32_t threadCount = 0;
     };
     TarsRPCConfig const& tarsRPCConfig() const;
 
@@ -337,8 +335,6 @@ private:
     bcos::crypto::KeyFactory::Ptr m_keyFactory;
     // txpool related configuration
     size_t m_txpoolLimit{};
-    size_t m_notifyWorkerNum{};
-    size_t m_verifierWorkerNum{};
     int64_t m_txsExpirationTime{};
     bool m_checkBlockLimit = true;
     // permit txs from free node or not
@@ -443,7 +439,6 @@ private:
     // config for rpc
     std::string m_rpcListenIP;
     uint16_t m_rpcListenPort{};
-    uint32_t m_rpcThreadPoolSize{};
     uint32_t m_rpcFilterTimeout{};
     uint32_t m_rpcMaxProcessBlock{};
     bool m_rpcSmSsl{};
@@ -453,7 +448,6 @@ private:
     bool m_enableWeb3Rpc = false;
     std::string m_web3RpcListenIP;
     uint16_t m_web3RpcListenPort{};
-    uint32_t m_web3RpcThreadSize{};
     uint32_t m_web3FilterTimeout{};
     uint32_t m_web3MaxProcessBlock{};
     uint32_t m_web3BatchRequestSizeLimit{};
@@ -466,6 +460,10 @@ private:
     int32_t m_web3CorsMaxAge = 86400;
     bool m_web3CorsAllowCredentials = true;
     bool m_web3SyncTransaction = false;
+
+    // thread pool configuration
+    size_t m_ioThreadCount{};
+    size_t m_tbbThreadCount{};
 
     // config for gateway
     std::string m_p2pListenIP;

--- a/bcos-utilities/bcos-utilities/NewTimer.cpp
+++ b/bcos-utilities/bcos-utilities/NewTimer.cpp
@@ -77,12 +77,12 @@ void bcos::timer::Timer::stop()
             return;
         }
 
-        if (self->m_delayHandler)
+        if (self->m_delayHandler.has_value())
         {
             self->m_delayHandler->cancel();
         }
 
-        if (self->m_timerHandler)
+        if (self->m_timerHandler.has_value())
         {
             self->m_timerHandler->cancel();
         }
@@ -90,7 +90,7 @@ void bcos::timer::Timer::stop()
 }
 void bcos::timer::Timer::startDelayTask()
 {
-    m_delayHandler = std::make_shared<boost::asio::steady_timer>(*(m_ioService));
+    m_delayHandler.emplace(*m_ioService);
 
     auto self = weak_from_this();
     m_delayHandler->expires_after(std::chrono::milliseconds(m_delayMS));
@@ -119,7 +119,7 @@ void bcos::timer::Timer::startDelayTask()
 }
 void bcos::timer::Timer::startPeriodTask()
 {
-    m_timerHandler = std::make_shared<boost::asio::steady_timer>(*m_ioService);
+    m_timerHandler.emplace(*m_ioService);
     auto self = weak_from_this();
     m_timerHandler->expires_after(std::chrono::milliseconds(m_periodMS));
     m_timerHandler->async_wait([self](const boost::system::error_code& error) {
@@ -162,75 +162,9 @@ void bcos::timer::Timer::executeTask()
 bcos::timer::TimerFactory::TimerFactory(std::shared_ptr<boost::asio::io_context> _ioService)
   : m_ioService(std::move(_ioService))
 {}
-bcos::timer::TimerFactory::TimerFactory() : m_ioService(std::make_shared<boost::asio::io_context>())
-{
-    // No io_service object is provided, create io_service and the worker thread
-    startThread();
-}
-bcos::timer::TimerFactory::~TimerFactory()
-{
-    stopThread();
-}
 bcos::timer::Timer::Ptr bcos::timer::TimerFactory::createTimer(
     TimerTask&& _task, int _periodMS, int _delayMS)  // NOLINT
 {
     auto timer = std::make_shared<Timer>(m_ioService, std::move(_task), _periodMS, _delayMS);
     return timer;
-}
-void bcos::timer::TimerFactory::startThread()
-{
-    if (m_worker)
-    {
-        return;
-    }
-    m_running = true;
-
-    BCOS_LOG(INFO) << LOG_BADGE("startThread") << LOG_DESC("start the timer thread");
-
-    m_worker = std::make_unique<std::thread>([this]() {
-        bcos::pthread_setThreadName(m_threadName);
-        BCOS_LOG(INFO) << LOG_BADGE("startThread") << LOG_DESC("the timer thread start")
-                       << LOG_KV("threadName", m_threadName);
-        while (m_running)
-        {
-            try
-            {
-                auto work = boost::asio::make_work_guard(*m_ioService);
-                m_ioService->run();
-                if (!m_running)
-                {
-                    break;
-                }
-            }
-            catch (std::exception const& e)
-            {
-                BCOS_LOG(WARNING) << LOG_BADGE("startThread")
-                                  << LOG_DESC("Exception in Worker Thread of timer")
-                                  << LOG_KV("message", boost::diagnostic_information(e));
-            }
-            m_ioService->stop();
-        }
-
-        BCOS_LOG(INFO) << LOG_BADGE("startThread") << LOG_DESC("the timer thread stop");
-    });
-}
-void bcos::timer::TimerFactory::stopThread()
-{
-    if (!m_worker)
-    {
-        return;
-    }
-    m_running = false;
-    BCOS_LOG(INFO) << LOG_BADGE("stopThread") << LOG_DESC("stop the timer thread");
-
-    m_ioService->stop();
-    if (m_worker->get_id() != std::this_thread::get_id())
-    {
-        m_worker->join();
-        m_worker.reset();
-    }
-    else
-    {
-        m_worker->detach();
-    }
 }

--- a/bcos-utilities/bcos-utilities/NewTimer.h
+++ b/bcos-utilities/bcos-utilities/NewTimer.h
@@ -25,6 +25,7 @@
 #include <boost/asio/steady_timer.hpp>
 #include <atomic>
 #include <memory>
+#include <optional>
 
 namespace bcos::timer
 {
@@ -63,8 +64,8 @@ private:
     TimerTask m_timerTask;
     int m_delayMS;
     int m_periodMS;
-    std::shared_ptr<boost::asio::steady_timer> m_delayHandler;
-    std::shared_ptr<boost::asio::steady_timer> m_timerHandler;
+    std::optional<boost::asio::steady_timer> m_delayHandler;
+    std::optional<boost::asio::steady_timer> m_timerHandler;
 };
 class TimerFactory
 {
@@ -72,13 +73,12 @@ public:
     using Ptr = std::shared_ptr<TimerFactory>;
     using ConstPtr = std::shared_ptr<TimerFactory>;
 
-    TimerFactory(std::shared_ptr<boost::asio::io_context> _ioService);
-    TimerFactory();
+    explicit TimerFactory(std::shared_ptr<boost::asio::io_context> _ioService);
     TimerFactory(const TimerFactory&) = delete;
     TimerFactory(TimerFactory&&) = delete;
     TimerFactory& operator=(const TimerFactory&) = delete;
     TimerFactory& operator=(TimerFactory&&) = delete;
-    ~TimerFactory();
+    ~TimerFactory() = default;
 
     /**
      * @brief
@@ -92,12 +92,6 @@ public:
         ;
 
 private:
-    void startThread();
-    void stopThread();
-
-    std::atomic_bool m_running = {false};
-    std::string m_threadName = "timerFactory";
-    std::unique_ptr<std::thread> m_worker;
     std::shared_ptr<boost::asio::io_context> m_ioService;
 };
 

--- a/bcos-utilities/test/unittests/libutilities/NewTimerTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/NewTimerTest.cpp
@@ -31,7 +31,10 @@ BOOST_FIXTURE_TEST_SUITE(TimerTest, TestPromptFixture)
 
 BOOST_AUTO_TEST_CASE(testTimer)
 {
-    timer::TimerFactory timerFactory;
+    auto ioContext = std::make_shared<boost::asio::io_context>();
+    auto workGuard = boost::asio::make_work_guard(*ioContext);
+    std::thread ioThread([&ioContext] { ioContext->run(); });
+    timer::TimerFactory timerFactory(ioContext);
 
     {
         auto timer = timerFactory.createTimer([] {}, 0, 0);
@@ -80,6 +83,10 @@ BOOST_AUTO_TEST_CASE(testTimer)
         BOOST_CHECK_GE(count, 1);
         timer->stop();
     }
+
+    workGuard.reset();
+    ioContext->stop();
+    ioThread.join();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -62,7 +62,7 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
     m_nodeInitializer->initConfig(_configFilePath, _genesisFile, "", true);
 
     auto ioServicePool =
-        std::make_shared<bcos::IOServicePool>(std::thread::hardware_concurrency() + 1, "io");
+        std::make_shared<bcos::IOServicePool>(nodeConfig->ioThreadCount(), "io");
     m_nodeInitializer->setIOServicePool(ioServicePool);
 
     // create gateway
@@ -107,11 +107,11 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
 
     // tars rpc
     if (!nodeConfig->tarsRPCConfig().host.empty() && nodeConfig->tarsRPCConfig().port > 0 &&
-        nodeConfig->tarsRPCConfig().threadCount > 0)
+        nodeConfig->ioThreadCount() > 0)
     {
         m_tarsApplication.emplace(nodeService);
         m_tarsConfig.emplace(RPCApplication::generateTarsConfig(nodeConfig->tarsRPCConfig().host,
-            nodeConfig->tarsRPCConfig().port, nodeConfig->tarsRPCConfig().threadCount));
+            nodeConfig->tarsRPCConfig().port, nodeConfig->ioThreadCount()));
     }
 }
 

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -300,7 +300,7 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
             std::make_shared<scheduler_v1::SchedulerParallelImpl<GlobalStateMutableStorage>>(
                 m_ioServicePool);
         parallelScheduler->m_grainSize = baselineSchedulerConfig.grainSize;
-        parallelScheduler->m_maxConcurrency = baselineSchedulerConfig.maxThread;
+        parallelScheduler->m_maxConcurrency = m_nodeConfig->tbbThreadCount();
         std::tie(m_baselineSchedulerHolder, m_setBaselineSchedulerBlockNumberNotifier) =
             scheduler_v1::BaselineSchedulerInitializer::build(m_globalStateStorageInitializer,
                 m_protocolInitializer->blockFactory(), parallelScheduler,

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -170,6 +170,16 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     std::string const& _configFilePath, std::string const& _genesisFile,
     bcos::gateway::GatewayInterface::Ptr _gateway, bool _airVersion, const std::string& _logPath)
 {
+    // TBB global thread control
+    auto tbbThreadCount = m_nodeConfig->tbbThreadCount();
+    if (tbbThreadCount > 0)
+    {
+        m_tbbGlobalControl.emplace(
+            oneapi::tbb::global_control::max_allowed_parallelism, tbbThreadCount);
+        INITIALIZER_LOG(INFO) << LOG_DESC("TBB global_control set")
+                              << LOG_KV("maxAllowedParallelism", tbbThreadCount);
+    }
+
     // build the front service
     m_frontServiceInitializer = std::make_shared<FrontServiceInitializer>(
         m_nodeConfig, m_protocolInitializer, _gateway, m_ioServicePool);
@@ -248,8 +258,8 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     }
 
     // build ledger
-    auto ledger = LedgerInitializer::build(
-        m_protocolInitializer->blockFactory(), m_storage, m_nodeConfig, m_blockStorage, m_ioServicePool);
+    auto ledger = LedgerInitializer::build(m_protocolInitializer->blockFactory(), m_storage,
+        m_nodeConfig, m_blockStorage, m_ioServicePool);
     ledger->setKeyPageSize(m_nodeConfig->keyPageSize());
     m_ledger = ledger;
 
@@ -270,9 +280,9 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
         std::make_shared<protocol::TransactionSubmitResultFactoryImpl>();
 
     // init the txpool
-    m_txpoolInitializer = std::make_shared<TxPoolInitializer>(
-        m_nodeConfig, m_protocolInitializer, m_frontServiceInitializer->front(), ledger,
-        *m_ioServicePool->getIOService(), m_ioServicePool);
+    m_txpoolInitializer = std::make_shared<TxPoolInitializer>(m_nodeConfig, m_protocolInitializer,
+        m_frontServiceInitializer->front(), ledger, *m_ioServicePool->getIOService(),
+        m_ioServicePool);
     m_memPoolInitializer = MemPoolInitializer::build();
 
     std::shared_ptr<bcos::scheduler::TarsExecutorManager> executorManager;
@@ -300,30 +310,30 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
             std::make_shared<scheduler_v1::SchedulerParallelImpl<GlobalStateMutableStorage>>(
                 m_ioServicePool);
         parallelScheduler->m_grainSize = baselineSchedulerConfig.grainSize;
-        parallelScheduler->m_maxConcurrency = m_nodeConfig->tbbThreadCount();
+        if (tbbThreadCount > 0)
+        {
+            parallelScheduler->m_maxConcurrency = tbbThreadCount;
+        }
         std::tie(m_baselineSchedulerHolder, m_setBaselineSchedulerBlockNumberNotifier) =
             scheduler_v1::BaselineSchedulerInitializer::build(m_globalStateStorageInitializer,
                 m_protocolInitializer->blockFactory(), parallelScheduler,
                 m_txpoolInitializer->txpool(), transactionSubmitResultFactory, ledger,
                 transactionExecutor);
-        m_engineServiceInitializer =
-            EngineServiceInitializer::build(m_globalStateStorageInitializer,
-                m_protocolInitializer->blockFactory(), parallelScheduler,
-                transactionExecutor, m_memPoolInitializer->memPool());
+        m_engineServiceInitializer = EngineServiceInitializer::build(
+            m_globalStateStorageInitializer, m_protocolInitializer->blockFactory(),
+            parallelScheduler, transactionExecutor, m_memPoolInitializer->memPool());
     }
     else
     {
-        auto serialScheduler =
-            std::make_shared<scheduler_v1::SchedulerSerialImpl>(m_ioServicePool);
+        auto serialScheduler = std::make_shared<scheduler_v1::SchedulerSerialImpl>(m_ioServicePool);
         std::tie(m_baselineSchedulerHolder, m_setBaselineSchedulerBlockNumberNotifier) =
             scheduler_v1::BaselineSchedulerInitializer::build(m_globalStateStorageInitializer,
                 m_protocolInitializer->blockFactory(), serialScheduler,
                 m_txpoolInitializer->txpool(), transactionSubmitResultFactory, ledger,
                 transactionExecutor);
-        m_engineServiceInitializer =
-            EngineServiceInitializer::build(m_globalStateStorageInitializer,
-                m_protocolInitializer->blockFactory(), serialScheduler,
-                transactionExecutor, m_memPoolInitializer->memPool());
+        m_engineServiceInitializer = EngineServiceInitializer::build(
+            m_globalStateStorageInitializer, m_protocolInitializer->blockFactory(), serialScheduler,
+            transactionExecutor, m_memPoolInitializer->memPool());
     }
 
     executorManager = std::make_shared<bcos::scheduler::TarsExecutorManager>(
@@ -414,8 +424,8 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
             m_protocolInitializer->cryptoSuite()->hashImpl(), m_nodeConfig->isWasm(),
             m_nodeConfig->vmCacheSize(), m_nodeConfig->isAuthCheck(), executorName,
             m_ioServicePool);
-        auto switchExecutorManager =
-            std::make_shared<bcos::executor::SwitchExecutorManager>(executorFactory, m_ioServicePool);
+        auto switchExecutorManager = std::make_shared<bcos::executor::SwitchExecutorManager>(
+            executorFactory, m_ioServicePool);
         executorManager->addExecutor(executorName, switchExecutorManager);
         m_switchExecutorManager = switchExecutorManager;
     }
@@ -426,10 +436,10 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     // build and init the pbft related modules
     if (_nodeArchType == protocol::NodeArchitectureType::AIR)
     {
-        m_pbftInitializer = std::make_shared<PBFTInitializer>(_nodeArchType, m_nodeConfig,
-            m_protocolInitializer, m_txpoolInitializer->txpool(), ledger, m_scheduler,
-            consensusStorage, m_frontServiceInitializer->front(), nodeTimeMaintenance,
-            m_ioServicePool);
+        m_pbftInitializer =
+            std::make_shared<PBFTInitializer>(_nodeArchType, m_nodeConfig, m_protocolInitializer,
+                m_txpoolInitializer->txpool(), ledger, m_scheduler, consensusStorage,
+                m_frontServiceInitializer->front(), nodeTimeMaintenance, m_ioServicePool);
         auto nodeID = m_protocolInitializer->keyPair()->publicKey();
         auto frontService = m_frontServiceInitializer->front();
         auto groupID = m_nodeConfig->groupId();
@@ -453,10 +463,10 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     }
     else
     {
-        m_pbftInitializer = std::make_shared<ProPBFTInitializer>(_nodeArchType, m_nodeConfig,
-            m_protocolInitializer, m_txpoolInitializer->txpool(), ledger, m_scheduler,
-            consensusStorage, m_frontServiceInitializer->front(), nodeTimeMaintenance,
-            m_ioServicePool);
+        m_pbftInitializer =
+            std::make_shared<ProPBFTInitializer>(_nodeArchType, m_nodeConfig, m_protocolInitializer,
+                m_txpoolInitializer->txpool(), ledger, m_scheduler, consensusStorage,
+                m_frontServiceInitializer->front(), nodeTimeMaintenance, m_ioServicePool);
     }
     if (_nodeArchType == bcos::protocol::NodeArchitectureType::MAX)
     {

--- a/libinitializer/Initializer.h
+++ b/libinitializer/Initializer.h
@@ -35,6 +35,8 @@
 #include <bcos-utilities/BoostLogInitializer.h>
 #include <bcos-utilities/IOServicePool.h>
 #include <memory>
+#include <optional>
+#include <oneapi/tbb/global_control.h>
 #ifdef WITH_LIGHTNODE
 #include "LightNodeInitializer.h"
 #endif
@@ -153,6 +155,7 @@ private:
     // if enable SeparateBlockAndState,txs and receipts will be stored in m_blockStorage
     bcos::storage::TransactionalStorageInterface::Ptr m_blockStorage = nullptr;
     std::shared_ptr<MemPoolInitializer> m_memPoolInitializer;
+    std::optional<oneapi::tbb::global_control> m_tbbGlobalControl;
 
     std::function<std::shared_ptr<scheduler::SchedulerInterface>()> m_baselineSchedulerHolder;
     std::function<void(std::function<void(protocol::BlockNumber)>)>

--- a/libinitializer/TxPoolInitializer.cpp
+++ b/libinitializer/TxPoolInitializer.cpp
@@ -48,8 +48,9 @@ TxPoolInitializer::TxPoolInitializer(bcos::tool::NodeConfig::Ptr _nodeConfig,
         m_nodeConfig->blockLimit(), m_nodeConfig->txpoolLimit(),
         m_nodeConfig->checkTransactionSignature());
 
+    auto ioThreadCount = m_nodeConfig->ioThreadCount();
     m_txpool = m_txpoolFactory->createTxPool(_ioContext, m_ioServicePool,
-        m_nodeConfig->notifyWorkerNum(), m_nodeConfig->verifierWorkerNum(), m_nodeConfig->txsExpirationTime());
+        ioThreadCount, ioThreadCount, m_nodeConfig->txsExpirationTime());
     m_txpool->setCheckBlockLimit(m_nodeConfig->checkBlockLimit());
     m_txpool->setPreStoreBackpressureEnabled(m_nodeConfig->preStoreBackpressureEnabled());
     m_txpool->setPreStoreMaxInflight(m_nodeConfig->preStoreMaxInflight());

--- a/tools/BcosAirBuilder/build_chain.sh
+++ b/tools/BcosAirBuilder/build_chain.sh
@@ -1376,7 +1376,6 @@ generate_config_ini() {
 [rpc]
     listen_ip=${rpc_listen_ip}
     listen_port=${rpc_listen_port}
-    thread_count=4
     ; ssl or sm ssl
     sm_ssl=false
     ; ssl connection switch, if you wan to disable the ssl connection, turn it to false, default: true
@@ -1389,7 +1388,6 @@ generate_config_ini() {
     enable=${enable_web3_rpc}
     listen_ip=0.0.0.0
     listen_port=8545
-    thread_count=8
     request_body_size_limit=10240000
     ; cors config for web3 rpc
     enable_cors=true
@@ -1465,10 +1463,6 @@ generate_common_ini() {
 [txpool]
     ; size of the txpool, default is 15000
     limit=15000
-    ; txs notification threads num, default is 2
-    notify_worker_num=2
-    ; txs verification threads num, default is the number of CPU cores
-    ;verify_worker_num=2
     ; txs expiration time, in seconds, default is 10 minutes
     txs_expiration_time = 600
     ; permit txs from free node or not, default is false
@@ -1608,7 +1602,6 @@ generate_sm_config_ini() {
 [rpc]
     listen_ip=${rpc_listen_ip}
     listen_port=${rpc_listen_port}
-    thread_count=4
     ; ssl or sm ssl
     sm_ssl=true
     ; ssl connection switch, if you wan to disable the ssl connection, turn it to false, default: true
@@ -1620,7 +1613,6 @@ generate_sm_config_ini() {
     enable=false
     listen_ip=0.0.0.0
     listen_port=8545
-    thread_count=8
     http_body_size_limit=10240000
     ; cors config for web3 rpc
     enable_cors=true
@@ -2563,7 +2555,6 @@ enable_storage_security = false
     listen_ip="0.0.0.0"
     # rpc listen port
     listen_port=${rpc_listen_port}
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port

--- a/tools/BcosBuilder/max/conf/config-build-example.toml
+++ b/tools/BcosBuilder/max/conf/config-build-example.toml
@@ -51,7 +51,6 @@ enable_storage_security = false
     deploy_ip=["127.0.0.1"]
     listen_ip="0.0.0.0"
     listen_port=20200
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port
@@ -101,7 +100,6 @@ enable_storage_security = false
     deploy_ip=["127.0.0.1"]
     listen_ip="0.0.0.0"
     listen_port=20220
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port
@@ -150,7 +148,6 @@ enable_storage_security = false
     deploy_ip=["127.0.0.1"]
     listen_ip="0.0.0.0"
     listen_port=20240
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port
@@ -198,7 +195,6 @@ enable_storage_security = false
     deploy_ip=["127.0.0.1"]
     listen_ip="0.0.0.0"
     listen_port=20260
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port

--- a/tools/BcosBuilder/max/conf/config-deploy-example.toml
+++ b/tools/BcosBuilder/max/conf/config-deploy-example.toml
@@ -51,7 +51,6 @@ enable_storage_security = false
     deploy_ip=["172.25.0.3"]
     listen_ip="0.0.0.0"
     listen_port=20200
-    thread_count=4
 
     [agency.gateway]
     deploy_ip=["172.25.0.3"]

--- a/tools/BcosBuilder/max/conf/config-service-expand-example.toml
+++ b/tools/BcosBuilder/max/conf/config-service-expand-example.toml
@@ -27,7 +27,6 @@ enable_storage_security = false
     deploy_ip=["172.25.0.5"]
     listen_ip="0.0.0.0"
     listen_port=10200
-    thread_count=4
 
     [agency.gateway]
     deploy_ip=["172.25.0.5"]

--- a/tools/BcosBuilder/pro/conf/config-build-example.toml
+++ b/tools/BcosBuilder/pro/conf/config-build-example.toml
@@ -50,7 +50,6 @@ enable_storage_security = false
     listen_ip="0.0.0.0"
     # rpc listen port
     listen_port=20200
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port
@@ -102,7 +101,6 @@ enable_storage_security = false
     listen_ip="0.0.0.0"
     # rpc listen port
     listen_port=20201
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port
@@ -155,7 +153,6 @@ enable_storage_security = false
     listen_ip="0.0.0.0"
     # rpc listen port
     listen_port=20202
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port
@@ -208,7 +205,6 @@ enable_storage_security = false
     listen_ip="0.0.0.0"
     # rpc listen port
     listen_port=20203
-    thread_count=4
     # rpc tars server listen ip
     tars_listen_ip="0.0.0.0"
     # rpc tars server listen port

--- a/tools/BcosBuilder/pro/conf/config-deploy-example.toml
+++ b/tools/BcosBuilder/pro/conf/config-deploy-example.toml
@@ -50,7 +50,6 @@ enable_storage_security = false
     deploy_ip=["172.25.0.3"]
     listen_ip="0.0.0.0"
     listen_port=20200
-    thread_count=4
 
     [agency.gateway]
     deploy_ip=["172.25.0.3"]
@@ -89,7 +88,6 @@ enable_storage_security = false
     deploy_ip=["172.25.0.3"]
     listen_ip="0.0.0.0"
     listen_port=20201
-    thread_count=4
 
     [agency.gateway]
     deploy_ip=["172.25.0.3"]

--- a/tools/BcosBuilder/pro/conf/config-service-expand-example.toml
+++ b/tools/BcosBuilder/pro/conf/config-service-expand-example.toml
@@ -26,7 +26,6 @@ enable_storage_security = false
     deploy_ip=["172.25.0.5"]
     listen_ip="0.0.0.0"
     listen_port=10200
-    thread_count=4
 
     [agency.gateway]
     deploy_ip=["172.25.0.5"]

--- a/tools/BcosBuilder/src/config/chain_config.py
+++ b/tools/BcosBuilder/src/config/chain_config.py
@@ -110,8 +110,6 @@ class ServiceInfoConfig:
             self.config, "listen_ip", ServiceInfo.default_listen_ip, False, self.desc)
         self.listen_port = utilities.get_item_value(
             self.config, "listen_port", 20200, False, self.desc)
-        self.thread_count = utilities.get_item_value(
-            self.config, "thread_count", 4, False, self.desc)
         # peers info
         self.peers = utilities.get_item_value(
             self.config, "peers", [], False, self.desc)

--- a/tools/BcosBuilder/src/config/service_config_generator.py
+++ b/tools/BcosBuilder/src/config/service_config_generator.py
@@ -178,8 +178,6 @@ class ServiceConfigGenerator:
         ini_config[section]['listen_port'] = str(service_config.listen_port)
         ini_config[section]['sm_ssl'] = utilities.convert_bool_to_str(
             service_config.sm_ssl)
-        ini_config[section]['thread_count'] = str(
-            service_config.thread_count)
         ini_config["service"]['gateway'] = service_config.agency_config.chain_id + \
             "." + service_config.agency_config.gateway_service_name
         ini_config["service"]['rpc'] = service_config.agency_config.chain_id + \

--- a/tools/BcosBuilder/src/tpl/config.ini.node
+++ b/tools/BcosBuilder/src/tpl/config.ini.node
@@ -28,9 +28,18 @@
 
 [executor]
     enable_dag=true
-    ; TBB thread pool size, default is 0 (no limit), >0 will use tbb::global_control to limit threads
+
+[thread_pool]
+    ; TBB global thread count for CPU-intensive tasks (e.g. parallel scheduler).
+    ; Default 0 means no global_control — TBB uses all available cores.
+    ; Set >0 to limit with tbb::global_control::max_allowed_parallelism.
+    ; Replaces the old executor.baseline_scheduler_maxthread (removed).
     ;tbb_thread_count=
-    ; shared IOServicePool thread count, default is CPU cores + 1
+    ; Shared IOServicePool thread count for IO-intensive tasks across all modules
+    ; (gateway, rpc, front, sync, pbft, txpool, scheduler, executor).
+    ; Default: hardware_concurrency() + 1.
+    ; Replaces old per-module thread configs (rpc.thread_count, web3_rpc.thread_count,
+    ; p2p.thread_count, txpool.notify_worker_num, txpool.verify_worker_num).
     ;io_thread_count=
 
 [storage]

--- a/tools/BcosBuilder/src/tpl/config.ini.node
+++ b/tools/BcosBuilder/src/tpl/config.ini.node
@@ -28,6 +28,10 @@
 
 [executor]
     enable_dag=true
+    ; TBB thread pool size, default is the number of CPU cores
+    ;tbb_thread_count=
+    ; shared IOServicePool thread count, default is CPU cores + 1
+    ;io_thread_count=
 
 [storage]
     data_path=data
@@ -39,10 +43,6 @@
 [txpool]
     ; size of the txpool, default is 15000
     limit=15000
-    ; txs notification threads num, default is 2
-    notify_worker_num=2
-    ; txs verification threads num, default is the number of CPU cores
-    ;verify_worker_num=2
     ; txs expiration time, in seconds, default is 10 minutes
     txs_expiration_time = 600
     ; permit txs from free node or not, default is false

--- a/tools/BcosBuilder/src/tpl/config.ini.node
+++ b/tools/BcosBuilder/src/tpl/config.ini.node
@@ -28,7 +28,7 @@
 
 [executor]
     enable_dag=true
-    ; TBB thread pool size, default is the number of CPU cores
+    ; TBB thread pool size, default is 0 (no limit), >0 will use tbb::global_control to limit threads
     ;tbb_thread_count=
     ; shared IOServicePool thread count, default is CPU cores + 1
     ;io_thread_count=

--- a/tools/BcosBuilder/src/tpl/config.ini.rpc
+++ b/tools/BcosBuilder/src/tpl/config.ini.rpc
@@ -1,7 +1,6 @@
 [rpc]
     listen_ip=0.0.0.0
     listen_port=20200
-    thread_count=4
     sm_ssl=false
     ; ssl connection switch, if disable the ssl connection, default: false
     enable_ssl=true

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -161,7 +161,6 @@ node.0=9418c37b060ecc49dc558d858a3e313a45e504ee7601034f657ed23ec8cce2aa2ef93c55e
 [rpc]
 listen_ip=0.0.0.0
 listen_port=21200
-thread_count=2
 disable_ssl=true
 sm_ssl=false
 
@@ -169,7 +168,6 @@ sm_ssl=false
 enable=true
 listen_ip=0.0.0.0
 listen_port=${RPC_PORT}
-thread_count=2
 
 [p2p]
 listen_ip=0.0.0.0


### PR DESCRIPTION
## 变更摘要

将节点配置（config.ini）中分散的各个模块线程数参数统一为两个线程池配置，简化节点运维。

### 移除的旧配置项

| 旧配置项 | 默认值 | 所属模块 |
|---|---|---|
| `rpc.thread_count` | 8 | RPC WebSocket 服务器 |
| `web3_rpc.thread_count` | 8 | Web3 HTTP 服务器 |
| `p2p.thread_count` | 8 | P2P 网关 |
| `txpool.notify_worker_num` | 2 | 交易通知分发 |
| `txpool.verify_worker_num` | min(8, CPU核数+1) | 交易验证提交 |
| `rpc.tars_rpc_thread_count` | 8 | TARS RPC 服务器 |
| `executor.baseline_scheduler_maxthread` | 16 | 并行调度器最大并发 |

### 新增的配置项

| 新配置项 | 默认值 | 说明 |
|---|---|---|
| `executor.io_thread_count` | CPU核数 + 1 | 共用 IOServicePool 线程数（统一管理所有 IO 密集型线程） |
| `executor.tbb_thread_count` | 0（不限制） | TBB 全局线程数（>0 时通过 `tbb::global_control` 限制 CPU 密集型并行度） |

### 设计思路

- **IO 密集型**：RPC、P2P 网关、交易池的通知/验证等网络 IO 操作统一使用共享的 `IOServicePool`，由 `executor.io_thread_count` 控制线程数
- **CPU 密集型**：并行调度器等计算密集型任务通过 TBB `global_control` 限制最大并行度，由 `executor.tbb_thread_count` 控制。默认值为 0 表示不做全局限制

### 修改文件（26 个）

- 配置层：`NodeConfig.h/cpp`、`GatewayConfig.h/cpp`
- 消费层：`RpcFactory.cpp`、`TxPoolInitializer.cpp`、`AirNodeInitializer.cpp`、`Initializer.cpp/h`
- 模板/脚本：`config.ini.*` 模板、`build_chain.sh`、BcosBuilder Python 配置
- 测试：`GatewayConfigTest.cpp`