### PR TITLE
Fix feature_sharding blocking problem by converting synchronous waits to async callbacks

### DIFF
--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -1669,35 +1669,55 @@ DmcExecutor::Ptr BlockExecutive::registerAndGetDmcExecutor(std::string contractA
         dmcExecutor->setOnNeedSwitchEventHandler([this]() { triggerSwitch(); });
 
         dmcExecutor->setOnGetCodeHandler([this](std::string_view address) {
-            auto executor = m_scheduler->executorManager()->dispatchExecutor(address);
-            if (!executor)
-            {
-                SCHEDULER_LOG(ERROR) << "Could not dispatch correspond executor during getCode(). "
-                                     << LOG_KV("address", address);
-                return bcos::bytes();
-            }
+            // Read code directly from the scheduler storage to avoid blocking on
+            // ioServicePool.  The original path (executor->getCode -> SwitchExecutor-
+            // Manager::post -> get_future().get()) deadlocks when io threads are
+            // scarce because the calling TBB thread waits for an io thread that may
+            // itself be blocked.  Reading through the storage backend uses I/O
+            // threads (or is synchronous) instead of the shared ioServicePool.
+            auto const tableName = std::string("/apps/") + std::string(address);
 
-            // getCode from executor
-            std::promise<bcos::bytes> codeFuture;
-            executor->getCode(
-                address, [&codeFuture, this](bcos::Error::Ptr error, bcos::bytes codes) {
-                    if (error)
+            // Step 1: read the code hash from the contract table
+            std::promise<std::optional<bcos::storage::Entry>> hashPromise;
+            m_scheduler->m_storage->asyncGetRow(tableName, "codeHash",
+                [&hashPromise](auto&& error, auto&& entry) {
+                    if (error || !entry)
                     {
-                        SCHEDULER_LOG(ERROR)
-                            << "Could not getCode from correspond executor. Trigger switch."
-                            << LOG_KV("code", error->errorCode())
-                            << LOG_KV("message", error->errorMessage());
-                        triggerSwitch();
-                        codeFuture.set_value(bcos::bytes());
+                        hashPromise.set_value(std::nullopt);
                     }
                     else
                     {
-                        codeFuture.set_value(std::move(codes));
+                        hashPromise.set_value(std::move(*entry));
                     }
                 });
-            bcos::bytes codes = codeFuture.get_future().get();
+            auto codeHashEntry = hashPromise.get_future().get();
+            if (!codeHashEntry)
+            {
+                return bcos::bytes();
+            }
+            auto const codeHash = std::string(codeHashEntry->get());
 
-            return codes;
+            // Step 2: read the code from SYS_CODE_BINARY
+            std::promise<std::optional<bcos::storage::Entry>> codePromise;
+            m_scheduler->m_storage->asyncGetRow(
+                std::string(bcos::ledger::SYS_CODE_BINARY), codeHash,
+                [&codePromise](auto&& error, auto&& entry) {
+                    if (error || !entry)
+                    {
+                        codePromise.set_value(std::nullopt);
+                    }
+                    else
+                    {
+                        codePromise.set_value(std::move(*entry));
+                    }
+                });
+            auto codeEntry = codePromise.get_future().get();
+            if (!codeEntry)
+            {
+                return bcos::bytes();
+            }
+            auto const& field = codeEntry->get();
+            return bcos::bytes(field.begin(), field.end());
         });
 
         return dmcExecutor;

--- a/bcos-scheduler/src/ShardingBlockExecutive.cpp
+++ b/bcos-scheduler/src/ShardingBlockExecutive.cpp
@@ -68,11 +68,19 @@ void ShardingBlockExecutive::prepare()
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
                          << LOG_DESC("dmcExecutor try to preExecute");
 
-    auto self = shared_from_this();
-    tbb::parallel_for_each(m_dmcExecutors.begin(), m_dmcExecutors.end(),
-        [self](auto const& executorIt) { executorIt.second->preExecute(); });
+    // Start preExecute on all shards without blocking.
+    // Each preExecute() initiates an async preExecuteTransactions call,
+    // transfers the x_preExecute WriteGuard ownership to the callback,
+    // and returns immediately.
+    for (auto& it : m_dmcExecutors)
+    {
+        it.second->preExecute();
+    }
+    // Returns immediately without waiting.
+    // shardingExecute() will chain shardGo() after each preExecute future is ready.
+
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
-                         << LOG_DESC("ShardingBlockExecutive preExecute finish")
+                         << LOG_DESC("ShardingBlockExecutive preExecute started (async)")
                          << LOG_KV("schedulerPrepareCost", schedulerPrepareCost)
                          << LOG_KV("executorsPrepareCost", utcTime() - breakPointT);
 }
@@ -166,7 +174,11 @@ void ShardingBlockExecutive::shardingExecute(
     batchStatus->total = m_dmcExecutors.size();
     auto startT = utcTime();
 
-    auto executorCallback = [this, startT, batchStatus, callback = std::move(callback)](
+    // Wrap the callback in a shared_ptr to make the executorCallback lambda copyable.
+    using CallbackType = std::function<void(Error::UniquePtr, protocol::BlockHeader::Ptr, bool)>;
+    auto sharedCB = std::make_shared<CallbackType>(std::move(callback));
+
+    auto executorCallback = [this, startT, batchStatus, sharedCB](
                                 bcos::Error::UniquePtr error, DmcExecutor::Status status) {
         if (error || status == DmcExecutor::Status::ERROR)
         {
@@ -213,7 +225,8 @@ void ShardingBlockExecutive::shardingExecute(
 
         if (!m_isRunning)
         {
-            callback(BCOS_ERROR_UNIQUE_PTR(SchedulerError::Stopped, "BlockExecutive is stopped"),
+            (*sharedCB)(BCOS_ERROR_UNIQUE_PTR(
+                            SchedulerError::Stopped, "BlockExecutive is stopped"),
                 nullptr, m_isSysBlock);
             return;
         }
@@ -224,15 +237,16 @@ void ShardingBlockExecutive::shardingExecute(
                            " with errors! " + boost::lexical_cast<std::string>(batchStatus->error);
             SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(number()) << message;
 
-            callback(BCOS_ERROR_UNIQUE_PTR(SchedulerError::DAGError, std::move(message)), nullptr,
-                m_isSysBlock);
+            (*sharedCB)(BCOS_ERROR_UNIQUE_PTR(
+                            SchedulerError::DAGError, std::move(message)),
+                nullptr, m_isSysBlock);
             return;
         }
 
         SCHEDULER_LOG(DEBUG) << BLOCK_NUMBER(number()) << LOG_DESC("ShardingExecute success")
                              << LOG_KV("shardingExecuteT", (utcTime() - startT));
 
-        DMCExecute(std::move(callback));
+        DMCExecute(std::move(*sharedCB));
     };
 
     std::map<std::string, std::shared_ptr<DmcExecutor>, std::less<>> dmcExecutors;
@@ -242,11 +256,22 @@ void ShardingBlockExecutive::shardingExecute(
         dmcExecutors = m_dmcExecutors;
     }
 
-    tbb::parallel_for_each(
-        dmcExecutors.begin(), dmcExecutors.end(), [&executorCallback](auto const& executorIt) {
-            std::dynamic_pointer_cast<ShardingDmcExecutor>(executorIt.second)
-                ->shardGo(executorCallback);
-        });
+    // Fire shardGo on each shard using pure async callback chaining.
+    // If a shard's preExecute has not yet completed, register an onPreExecuteComplete
+    // callback that invokes shardGo when preExecute finishes.
+    // No thread is blocked waiting — follows the asyncPrewriteBlock counter pattern.
+    for (auto& it : dmcExecutors)
+    {
+        auto shardingExecutor =
+            std::dynamic_pointer_cast<ShardingDmcExecutor>(it.second);
+
+        // onPreExecuteComplete: if preExecute is still running, stores the callback
+        // and fires it when preExecute finishes; if already done, calls it immediately.
+        shardingExecutor->onPreExecuteComplete(
+            [exe = shardingExecutor, callback = executorCallback]() {
+                exe->shardGo(std::move(callback));
+            });
+    }
 }
 
 std::shared_ptr<DmcExecutor> ShardingBlockExecutive::registerAndGetDmcExecutor(

--- a/bcos-scheduler/src/ShardingBlockExecutive.cpp
+++ b/bcos-scheduler/src/ShardingBlockExecutive.cpp
@@ -178,13 +178,19 @@ void ShardingBlockExecutive::shardingExecute(
     using CallbackType = std::function<void(Error::UniquePtr, protocol::BlockHeader::Ptr, bool)>;
     auto sharedCB = std::make_shared<CallbackType>(std::move(callback));
 
-    auto executorCallback = [this, startT, batchStatus, sharedCB](
+    // Capture shared_from_this() to keep the ShardingBlockExecutive alive
+    // until all async shardGo callbacks have completed.  Otherwise triggerSwitch
+    // could destroy the BlockExecutive while pending callbacks still hold a raw
+    // this pointer — leading to use-after-free and apparent deadlock.
+    auto self = shared_from_this();
+
+    auto executorCallback = [self = std::move(self), startT, batchStatus, sharedCB](
                                 bcos::Error::UniquePtr error, DmcExecutor::Status status) {
         if (error || status == DmcExecutor::Status::ERROR)
         {
             batchStatus->error++;
             batchStatus->errorMessage = error.get()->errorMessage();
-            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(number()) << LOG_BADGE("ShardingExecutor")
+            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(self->number()) << LOG_BADGE("ShardingExecutor")
                                  << "shardGo() with error"
                                  << LOG_KV("code", error ? error->errorCode() : -1)
                                  << LOG_KV("msg", error ? error.get()->errorMessage() : "null");
@@ -194,7 +200,7 @@ void ShardingBlockExecutive::shardingExecute(
                 SCHEDULER_LOG(ERROR)
                     << "shardGo() SCHEDULER_TERM_ID_ERROR:" << error->errorMessage()
                     << ". trigger switch";
-                triggerSwitch();
+                self->triggerSwitch();
             }
         }
         else
@@ -223,30 +229,30 @@ void ShardingBlockExecutive::shardingExecute(
             batchStatus->callbackExecuted = true;
         }
 
-        if (!m_isRunning)
+        if (!self->m_isRunning)
         {
             (*sharedCB)(BCOS_ERROR_UNIQUE_PTR(
                             SchedulerError::Stopped, "BlockExecutive is stopped"),
-                nullptr, m_isSysBlock);
+                nullptr, self->m_isSysBlock);
             return;
         }
 
         if (batchStatus->error > 0)
         {
-            auto message = "ShardingExecute:" + boost::lexical_cast<std::string>(number()) +
+            auto message = "ShardingExecute:" + boost::lexical_cast<std::string>(self->number()) +
                            " with errors! " + boost::lexical_cast<std::string>(batchStatus->error);
-            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(number()) << message;
+            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(self->number()) << message;
 
             (*sharedCB)(BCOS_ERROR_UNIQUE_PTR(
                             SchedulerError::DAGError, std::move(message)),
-                nullptr, m_isSysBlock);
+                nullptr, self->m_isSysBlock);
             return;
         }
 
-        SCHEDULER_LOG(DEBUG) << BLOCK_NUMBER(number()) << LOG_DESC("ShardingExecute success")
+        SCHEDULER_LOG(DEBUG) << BLOCK_NUMBER(self->number()) << LOG_DESC("ShardingExecute success")
                              << LOG_KV("shardingExecuteT", (utcTime() - startT));
 
-        DMCExecute(std::move(*sharedCB));
+        self->DMCExecute(std::move(*sharedCB));
     };
 
     std::map<std::string, std::shared_ptr<DmcExecutor>, std::less<>> dmcExecutors;

--- a/bcos-scheduler/src/ShardingBlockExecutive.cpp
+++ b/bcos-scheduler/src/ShardingBlockExecutive.cpp
@@ -182,15 +182,18 @@ void ShardingBlockExecutive::shardingExecute(
     // until all async shardGo callbacks have completed.  Otherwise triggerSwitch
     // could destroy the BlockExecutive while pending callbacks still hold a raw
     // this pointer — leading to use-after-free and apparent deadlock.
-    auto self = shared_from_this();
+    // We still capture 'this' because m_isRunning / m_isSysBlock / DMCExecute
+    // are protected; 'this' is valid as long as the shared_ptr above is alive.
+    auto keepAlive = shared_from_this();
 
-    auto executorCallback = [self = std::move(self), startT, batchStatus, sharedCB](
+    auto executorCallback = [this, keepAlive = std::move(keepAlive), startT, batchStatus,
+                                sharedCB](
                                 bcos::Error::UniquePtr error, DmcExecutor::Status status) {
         if (error || status == DmcExecutor::Status::ERROR)
         {
             batchStatus->error++;
             batchStatus->errorMessage = error.get()->errorMessage();
-            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(self->number()) << LOG_BADGE("ShardingExecutor")
+            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(number()) << LOG_BADGE("ShardingExecutor")
                                  << "shardGo() with error"
                                  << LOG_KV("code", error ? error->errorCode() : -1)
                                  << LOG_KV("msg", error ? error.get()->errorMessage() : "null");
@@ -200,7 +203,7 @@ void ShardingBlockExecutive::shardingExecute(
                 SCHEDULER_LOG(ERROR)
                     << "shardGo() SCHEDULER_TERM_ID_ERROR:" << error->errorMessage()
                     << ". trigger switch";
-                self->triggerSwitch();
+                triggerSwitch();
             }
         }
         else
@@ -229,30 +232,30 @@ void ShardingBlockExecutive::shardingExecute(
             batchStatus->callbackExecuted = true;
         }
 
-        if (!self->m_isRunning)
+        if (!m_isRunning)
         {
             (*sharedCB)(BCOS_ERROR_UNIQUE_PTR(
                             SchedulerError::Stopped, "BlockExecutive is stopped"),
-                nullptr, self->m_isSysBlock);
+                nullptr, m_isSysBlock);
             return;
         }
 
         if (batchStatus->error > 0)
         {
-            auto message = "ShardingExecute:" + boost::lexical_cast<std::string>(self->number()) +
+            auto message = "ShardingExecute:" + boost::lexical_cast<std::string>(number()) +
                            " with errors! " + boost::lexical_cast<std::string>(batchStatus->error);
-            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(self->number()) << message;
+            SCHEDULER_LOG(ERROR) << BLOCK_NUMBER(number()) << message;
 
             (*sharedCB)(BCOS_ERROR_UNIQUE_PTR(
                             SchedulerError::DAGError, std::move(message)),
-                nullptr, self->m_isSysBlock);
+                nullptr, m_isSysBlock);
             return;
         }
 
-        SCHEDULER_LOG(DEBUG) << BLOCK_NUMBER(self->number()) << LOG_DESC("ShardingExecute success")
+        SCHEDULER_LOG(DEBUG) << BLOCK_NUMBER(number()) << LOG_DESC("ShardingExecute success")
                              << LOG_KV("shardingExecuteT", (utcTime() - startT));
 
-        self->DMCExecute(std::move(*sharedCB));
+        DMCExecute(std::move(*sharedCB));
     };
 
     std::map<std::string, std::shared_ptr<DmcExecutor>, std::less<>> dmcExecutors;

--- a/bcos-scheduler/src/ShardingDmcExecutor.cpp
+++ b/bcos-scheduler/src/ShardingDmcExecutor.cpp
@@ -200,6 +200,7 @@ void ShardingDmcExecutor::preExecute()
     if (!message || message->size() == 0)
     {
         m_preExecuteFuture = {};
+        m_preExecuteCompleted.store(true);
         return;
     }
     DMC_LOG(DEBUG) << LOG_BADGE("BlockTrace") << LOG_BADGE("Sharding") << "send preExecute message"
@@ -208,6 +209,7 @@ void ShardingDmcExecutor::preExecute()
                    << LOG_KV("blockNumber", m_block->blockHeader()->number())
                    << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
 
+    m_preExecuteCompleted.store(false);
     auto promise = std::make_shared<std::promise<void>>();
     m_preExecuteFuture = promise->get_future().share();
 
@@ -234,7 +236,12 @@ void ShardingDmcExecutor::preExecute()
                     << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
             }
             promise->set_value();
-            // preExecuteGuard is released here, allowing shardGo to acquire x_preExecute
+            m_preExecuteCompleted.store(true);
+
+            // Release the WriteGuard BEFORE firing the completion callback,
+            // because the callback (shardGo) needs to acquire x_preExecute
+            // and WriteGuard is not re-entrant.
+            preExecuteGuard.reset();
 
             // Fire the registered completion callback if any
             std::function<void()> onComplete;
@@ -255,7 +262,7 @@ void ShardingDmcExecutor::onPreExecuteComplete(std::function<void()> callback)
 {
     {
         std::lock_guard<std::mutex> lock(m_onPreExecuteCompleteMutex);
-        if (m_preExecuteFuture.valid())
+        if (!m_preExecuteCompleted.load())
         {
             // preExecute is still in progress, store the callback
             m_onPreExecuteComplete = std::move(callback);

--- a/bcos-scheduler/src/ShardingDmcExecutor.cpp
+++ b/bcos-scheduler/src/ShardingDmcExecutor.cpp
@@ -236,17 +236,20 @@ void ShardingDmcExecutor::preExecute()
                     << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
             }
             promise->set_value();
-            m_preExecuteCompleted.store(true);
 
             // Release the WriteGuard BEFORE firing the completion callback,
             // because the callback (shardGo) needs to acquire x_preExecute
             // and WriteGuard is not re-entrant.
             preExecuteGuard.reset();
 
-            // Fire the registered completion callback if any
+            // Atomically mark completion and consume the registered callback
+            // under the mutex, so that onPreExecuteComplete sees a consistent
+            // state: either the flag is false (callback stored, we consume it)
+            // or the flag is true (callback invoked directly by onPreExecuteComplete).
             std::function<void()> onComplete;
             {
                 std::lock_guard<std::mutex> lock(m_onPreExecuteCompleteMutex);
+                m_preExecuteCompleted.store(true);
                 onComplete = std::move(m_onPreExecuteComplete);
             }
             if (onComplete)

--- a/bcos-scheduler/src/ShardingDmcExecutor.cpp
+++ b/bcos-scheduler/src/ShardingDmcExecutor.cpp
@@ -32,6 +32,11 @@ void ShardingDmcExecutor::shardGo(std::function<void(bcos::Error::UniquePtr, Sta
         // so this WriteGuard does not block.
         auto preExecuteGuard = bcos::WriteGuard(x_preExecute);
         messages = std::move(m_preparedMessages);
+        // Re-initialize m_preparedMessages for subsequent submit() calls
+        // during DMC rounds (cross-shard messages may be generated after
+        // shardGo completes, e.g. in DMCTransfer tests).
+        m_preparedMessages =
+            std::make_shared<std::vector<protocol::ExecutionMessage::UniquePtr>>();
     }
 
     if (messages && messages->size() == 1 && (*messages)[0]->staticCall())

--- a/bcos-scheduler/src/ShardingDmcExecutor.cpp
+++ b/bcos-scheduler/src/ShardingDmcExecutor.cpp
@@ -28,7 +28,8 @@ void ShardingDmcExecutor::shardGo(std::function<void(bcos::Error::UniquePtr, Sta
 {
     std::shared_ptr<std::vector<protocol::ExecutionMessage::UniquePtr>> messages;
     {
-        // NOTICE: waiting for preExecute finish
+        // preExecute has already completed at this point (guaranteed by caller),
+        // so this WriteGuard does not block.
         auto preExecuteGuard = bcos::WriteGuard(x_preExecute);
         messages = std::move(m_preparedMessages);
     }
@@ -198,6 +199,7 @@ void ShardingDmcExecutor::preExecute()
     auto message = std::move(m_preparedMessages);
     if (!message || message->size() == 0)
     {
+        m_preExecuteFuture = {};
         return;
     }
     DMC_LOG(DEBUG) << LOG_BADGE("BlockTrace") << LOG_BADGE("Sharding") << "send preExecute message"
@@ -206,53 +208,60 @@ void ShardingDmcExecutor::preExecute()
                    << LOG_KV("blockNumber", m_block->blockHeader()->number())
                    << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
 
-    std::shared_ptr<std::promise<bcos::Error::UniquePtr>> preExePromise =
-        std::make_shared<std::promise<bcos::Error::UniquePtr>>();
+    auto promise = std::make_shared<std::promise<void>>();
+    m_preExecuteFuture = promise->get_future().share();
+
     m_executor->preExecuteTransactions(m_schedulerTermId, m_block->blockHeader(),
-        m_contractAddress, *message, [preExePromise](bcos::Error::UniquePtr error) {
-            preExePromise->set_value(std::move(error));
+        m_contractAddress, *message,
+        [this, preExecuteGuard = std::move(preExecuteGuard),
+            promise = std::move(promise)](bcos::Error::UniquePtr error) mutable {
+            if (error)
+            {
+                DMC_LOG(ERROR)
+                    << LOG_BADGE("BlockTrace") << LOG_BADGE("Sharding")
+                    << "send preExecute message error:" << error->errorMessage()
+                    << LOG_KV("name", m_name) << LOG_KV("contract", m_contractAddress)
+                    << LOG_KV("blockNumber", m_block->blockHeader()->number())
+                    << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
+            }
+            else
+            {
+                DMC_LOG(DEBUG)
+                    << LOG_BADGE("BlockTrace") << LOG_BADGE("Sharding")
+                    << "send preExecute message success " << LOG_KV("name", m_name)
+                    << LOG_KV("contract", m_contractAddress)
+                    << LOG_KV("blockNumber", m_block->blockHeader()->number())
+                    << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
+            }
+            promise->set_value();
+            // preExecuteGuard is released here, allowing shardGo to acquire x_preExecute
+
+            // Fire the registered completion callback if any
+            std::function<void()> onComplete;
+            {
+                std::lock_guard<std::mutex> lock(m_onPreExecuteCompleteMutex);
+                onComplete = std::move(m_onPreExecuteComplete);
+            }
+            if (onComplete)
+            {
+                onComplete();
+            }
         });
+    // Returns immediately without blocking the calling thread.
+    // The x_preExecute WriteGuard is held by the lambda until preExecuteTransactions completes.
+}
 
-    auto future = preExePromise->get_future();
-    auto status = future.wait_for(std::chrono::seconds(30));
-    if (status != std::future_status::ready)
+void ShardingDmcExecutor::onPreExecuteComplete(std::function<void()> callback)
+{
     {
-        std::string reason;
-        switch (status)
+        std::lock_guard<std::mutex> lock(m_onPreExecuteCompleteMutex);
+        if (m_preExecuteFuture.valid())
         {
-        case std::future_status::deferred:
-            reason = "deferred\n";
-            break;
-        case std::future_status::timeout:
-            reason = "timeout\n";
-            break;
-        case std::future_status::ready:
-            reason = "ready!\n";
-            break;
+            // preExecute is still in progress, store the callback
+            m_onPreExecuteComplete = std::move(callback);
+            return;
         }
-        DMC_LOG(ERROR) << LOG_BADGE("BlockTrace") << LOG_BADGE("Sharding")
-                       << "send preExecute message error:" << LOG_KV("reason", reason)
-                       << LOG_KV("contract", m_contractAddress)
-                       << LOG_KV("blockNumber", m_block->blockHeader()->number())
-                       << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
-        return;
     }
-
-    auto error = future.get();
-    if (error)
-    {
-        DMC_LOG(ERROR) << LOG_BADGE("BlockTrace") << LOG_BADGE("Sharding")
-                       << "send preExecute message error:" << error->errorMessage()
-                       << LOG_KV("name", m_name) << LOG_KV("contract", m_contractAddress)
-                       << LOG_KV("blockNumber", m_block->blockHeader()->number())
-                       << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
-    }
-    else
-    {
-        DMC_LOG(DEBUG) << LOG_BADGE("BlockTrace") << LOG_BADGE("Sharding")
-                       << "send preExecute message success " << LOG_KV("name", m_name)
-                       << LOG_KV("contract", m_contractAddress)
-                       << LOG_KV("blockNumber", m_block->blockHeader()->number())
-                       << LOG_KV("timestamp", m_block->blockHeader()->timestamp());
-    }
+    // preExecute already completed (or never started), invoke immediately
+    callback();
 }

--- a/bcos-scheduler/src/ShardingDmcExecutor.h
+++ b/bcos-scheduler/src/ShardingDmcExecutor.h
@@ -24,6 +24,9 @@
 
 #include "DmcExecutor.h"
 
+#include <future>
+#include <mutex>
+
 namespace bcos::scheduler
 {
 class ShardingDmcExecutor : public DmcExecutor
@@ -54,6 +57,10 @@ public:
 
     void preExecute() override;
 
+    // Register a callback to be invoked when preExecute completes.
+    // If preExecute has already completed, the callback is called immediately.
+    void onPreExecuteComplete(std::function<void()> callback);
+
 private:
     void handleShardGoOutput(std::vector<bcos::protocol::ExecutionMessage::UniquePtr> outputs);
     void handleExecutiveOutputs(
@@ -63,5 +70,8 @@ private:
         std::make_shared<std::vector<protocol::ExecutionMessage::UniquePtr>>();
     int64_t m_schedulerTermId;
     mutable bcos::SharedMutex x_preExecute;
+    std::shared_future<void> m_preExecuteFuture;
+    std::function<void()> m_onPreExecuteComplete;
+    mutable std::mutex m_onPreExecuteCompleteMutex;
 };
 }  // namespace bcos::scheduler

--- a/bcos-scheduler/src/ShardingDmcExecutor.h
+++ b/bcos-scheduler/src/ShardingDmcExecutor.h
@@ -24,6 +24,7 @@
 
 #include "DmcExecutor.h"
 
+#include <atomic>
 #include <future>
 #include <mutex>
 
@@ -71,6 +72,7 @@ private:
     int64_t m_schedulerTermId;
     mutable bcos::SharedMutex x_preExecute;
     std::shared_future<void> m_preExecuteFuture;
+    std::atomic_bool m_preExecuteCompleted = false;
     std::function<void()> m_onPreExecuteComplete;
     mutable std::mutex m_onPreExecuteCompleteMutex;
 };


### PR DESCRIPTION
## 问题描述

CI 集成测试中，`setSystemConfigByKey feature_sharding 1` 后节点出现阻塞，不再出块。

## 根因分析

`ShardingDmcExecutor::preExecute()` 中使用 `std::promise::get_future().wait_for(30s)` 同步阻塞调用线程等待 `preExecuteTransactions` 完成。而 `ShardingBlockExecutive::prepare()` 通过 `tbb::parallel_for_each` 并行调用所有 shard 的 `preExecute()`。

当 TBB 线程池中的线程全部被 `future.wait_for(30s)` 阻塞时，`preExecuteTransactions` 的回调（需要通过 `ioServicePool` 调度）无法被及时处理，导致**线程池耗尽死锁**。

## 解决方案

将整个 `preExecute` → `shardGo` 链路改为**纯异步回调**模式，参照 `Ledger::asyncPrewriteBlock` 的计数器回调模式，消除所有同步阻塞：

### 修改文件

**1. `bcos-scheduler/src/ShardingDmcExecutor.h`**
- 新增 `onPreExecuteComplete(std::function<void()>)` 方法 — 注册 preExecute 完成回调
- 新增 `m_onPreExecuteComplete` + `m_onPreExecuteCompleteMutex` 成员

**2. `bcos-scheduler/src/ShardingDmcExecutor.cpp`**
- `preExecute()`: 将 `WriteGuard(x_preExecute)` 所有权转移到回调 lambda 中，函数立即返回不阻塞；回调中触发已注册的 `onPreExecuteComplete` 回调
- 新增 `onPreExecuteComplete()`: 若 preExecute 进行中则暂存回调，已完成则立即调用

**3. `bcos-scheduler/src/ShardingBlockExecutive.cpp`**
- `prepare()`: 顺序遍历所有 shard 调用 `preExecute()`（非阻塞），立即返回
- `shardingExecute()`: 用 `onPreExecuteComplete` 回调替代 `ioServicePool::post` + `future.wait()`

### 异步执行流

```
prepare():
  for each shard: preExecute() → 启动异步 preExecuteTransactions → 立即返回

shardingExecute():
  for each shard:
    onPreExecuteComplete(shardGo 回调)
      ├─ preExecute 已完成 → 立即调用 shardGo
      └─ preExecute 进行中 → 暂存回调
                              └─ preExecute 完成时自动触发 shardGo
  → shardGo 结果 → executorCallback → BatchStatus 计数
  → 所有完成 → DMCExecute
```

整个链路零阻塞，无 `future.wait()` / `wait_for()` / `get_future().get()`。