### PR TITLE
[bcos-evm][PR-0/6] Bootstrap three-library layout (no TE integration)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ if(FULLNODE)
     find_package(paillier CONFIG REQUIRED)
     find_package(blst CONFIG REQUIRED)
 
+    add_subdirectory(bcos-evm)
     add_subdirectory(bcos-sealer)
     add_subdirectory(bcos-security)
     add_subdirectory(bcos-scheduler)

--- a/bcos-evm/CMakeLists.txt
+++ b/bcos-evm/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.28)
+
+find_package(evmone CONFIG REQUIRED)
+include(GNUInstallDirs)
+
+file(GLOB_RECURSE BCOS_EVM_ETH_SOURCES CONFIGURE_DEPENDS eth/*.cpp)
+file(GLOB_RECURSE BCOS_EVM_BCOS_SOURCES CONFIGURE_DEPENDS bcos/*.cpp)
+file(GLOB_RECURSE BCOS_EVM_OP_SOURCES CONFIGURE_DEPENDS opstack/*.cpp)
+
+add_library(bcos-evm-eth STATIC ${BCOS_EVM_ETH_SOURCES})
+add_library(bcos-evm-bcos STATIC ${BCOS_EVM_BCOS_SOURCES})
+add_library(bcos-evm-op STATIC ${BCOS_EVM_OP_SOURCES})
+add_library(bcos-evm ALIAS bcos-evm-bcos)
+
+target_include_directories(bcos-evm-eth PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_include_directories(bcos-evm-bcos PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_include_directories(bcos-evm-op PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(bcos-evm-eth PUBLIC
+    evmone::evmone
+    bcos-task
+    bcos-framework
+    ledger
+    bcos-protocol
+    bcos-utilities
+    bcos-crypto
+    codec
+)
+
+target_link_libraries(bcos-evm-bcos PUBLIC
+    bcos-evm-eth
+)
+
+target_link_libraries(bcos-evm-op PUBLIC
+    bcos-evm-eth
+)
+
+install(TARGETS bcos-evm-eth bcos-evm-bcos bcos-evm-op EXPORT fiscobcosTargets
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(DIRECTORY "include/bcos-evm" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
+
+option(BCOS_EVM_SPECS_TESTS "Build EVM reference test runners" OFF)
+
+if(TESTS)
+    include(CTest)
+    add_subdirectory(test)
+    if(BCOS_EVM_SPECS_TESTS)
+        add_subdirectory(test/eth-eest-test)
+    endif()
+endif()

--- a/bcos-evm/bcos/Placeholder.cpp
+++ b/bcos-evm/bcos/Placeholder.cpp
@@ -1,0 +1,8 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+namespace bcos::evm::bcos
+{
+void fiscoOrchestrationPlaceholder() {}
+}  // namespace bcos::evm::bcos

--- a/bcos-evm/eth/EVMCResult.cpp
+++ b/bcos-evm/eth/EVMCResult.cpp
@@ -1,0 +1,242 @@
+#include <range/v3/algorithm/binary_search.hpp>
+#include <range/v3/algorithm/copy.hpp>
+#include <range/v3/algorithm/lower_bound.hpp>
+#include <range/v3/algorithm/partition_point.hpp>
+
+#include "EVMCResult.h"
+#include "bcos-codec/abi/ContractABICodec.h"
+#include "bcos-protocol/TransactionStatus.h"
+#include "bcos-utilities/Common.h"
+#include "bcos-utilities/Exceptions.h"
+#include <evmc/evmc.h>
+#include <boost/throw_exception.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <gsl/pointers>
+
+DERIVE_BCOS_EXCEPTION(UnknownEVMCStatus);
+
+static void cleanEVMCResult(evmc_result& from)
+{
+    from.release = nullptr;
+    from.output_data = nullptr;
+    from.output_size = 0;
+}
+
+bcos::evm::EVMCResult::EVMCResult(evmc_result from)
+  : evmc_result(from), status{evmcStatusToTransactionStatus(from.status_code)}
+{}
+
+bcos::evm::EVMCResult::EVMCResult(evmc_result from, protocol::TransactionStatus statusCode)
+  : evmc_result(from), status(statusCode)
+{}
+
+bcos::evm::EVMCResult::EVMCResult(EVMCResult&& from) noexcept
+  : evmc_result(from), status{from.status}
+{
+    cleanEVMCResult(from);
+}
+
+bcos::evm::EVMCResult& bcos::evm::EVMCResult::operator=(EVMCResult&& from) noexcept
+{
+    evmc_result::operator=(from);
+    status = from.status;
+    cleanEVMCResult(from);
+    return *this;
+}
+
+bcos::evm::EVMCResult::~EVMCResult() noexcept
+{
+    if (release != nullptr)
+    {
+        release(static_cast<evmc_result*>(this));
+        release = nullptr;
+        output_data = nullptr;
+        output_size = 0;
+    }
+}
+
+bcos::bytes bcos::evm::writeErrInfoToOutput(
+    const crypto::Hash& hashImpl, std::string const& errInfo)
+{
+    bcos::codec::abi::ContractABICodec abi(hashImpl);
+    return abi.abiIn("Error(string)", errInfo);
+}
+
+std::tuple<gsl::owner<uint8_t*>, size_t, decltype(evmc_result::release)>
+bcos::evm::fillErrorOutputInPlace(
+    const crypto::Hash& hashImpl, evmc_status_code status, const std::string& errorInfo)
+{
+    bytes errorBytes;
+    if (!errorInfo.empty())
+    {
+        errorBytes = writeErrInfoToOutput(hashImpl, errorInfo);
+    }
+    else
+    {
+        auto [ignoredStatus, errorMessage] = evmcStatusToErrorMessage(hashImpl, status);
+        (void)ignoredStatus;
+        errorBytes.swap(errorMessage);
+    }
+
+    if (errorBytes.empty())
+    {
+        return {nullptr, 0, nullptr};
+    }
+
+    auto* output = new uint8_t[errorBytes.size()];  // NOLINT
+    ::ranges::copy(errorBytes, output);
+    constexpr static auto* release = +[](const struct evmc_result* result) {
+        gsl::owner<decltype(result->output_data)> ptr{result->output_data};
+        delete[] ptr;
+    };
+
+    return {output, errorBytes.size(), release};
+}
+
+bcos::protocol::TransactionStatus bcos::evm::evmcStatusToTransactionStatus(evmc_status_code status)
+{
+    switch (status)
+    {
+    case EVMC_SUCCESS:
+        return protocol::TransactionStatus::None;
+    case EVMC_REVERT:
+        return protocol::TransactionStatus::RevertInstruction;
+    case EVMC_OUT_OF_GAS:
+        return protocol::TransactionStatus::OutOfGas;
+    case EVMC_INSUFFICIENT_BALANCE:
+        return protocol::TransactionStatus::NotEnoughCash;
+    case EVMC_STACK_OVERFLOW:
+        return protocol::TransactionStatus::OutOfStack;
+    case EVMC_STACK_UNDERFLOW:
+        return protocol::TransactionStatus::StackUnderflow;
+    case EVMC_INVALID_INSTRUCTION:
+    case EVMC_UNDEFINED_INSTRUCTION:
+        return protocol::TransactionStatus::BadInstruction;
+    default:
+        BOOST_THROW_EXCEPTION(UnknownEVMCStatus{});
+    }
+}
+
+std::tuple<bcos::protocol::TransactionStatus, bcos::bytes> bcos::evm::evmcStatusToErrorMessage(
+    const bcos::crypto::Hash& hashImpl, evmc_status_code status)
+{
+    using namespace std::string_literals;
+    bcos::bytes output;
+
+    switch (status)
+    {
+    case EVMC_SUCCESS:
+        return {bcos::protocol::TransactionStatus::None, {}};
+    case EVMC_REVERT:
+        return {bcos::protocol::TransactionStatus::RevertInstruction, {}};
+    case EVMC_OUT_OF_GAS:
+        return {bcos::protocol::TransactionStatus::OutOfGas,
+            bcos::evm::writeErrInfoToOutput(hashImpl, "Execution out of gas."s)};
+    case EVMC_INSUFFICIENT_BALANCE:
+        return {bcos::protocol::TransactionStatus::NotEnoughCash, {}};
+    case EVMC_STACK_OVERFLOW:
+        return {bcos::protocol::TransactionStatus::OutOfStack,
+            bcos::evm::writeErrInfoToOutput(hashImpl, "Execution stack overflow."s)};
+    case EVMC_STACK_UNDERFLOW:
+        return {bcos::protocol::TransactionStatus::StackUnderflow,
+            bcos::evm::writeErrInfoToOutput(hashImpl, "Execution needs more items on EVM stack."s)};
+    case EVMC_INVALID_INSTRUCTION:
+    case EVMC_UNDEFINED_INSTRUCTION:
+        return {bcos::protocol::TransactionStatus::BadInstruction,
+            bcos::evm::writeErrInfoToOutput(hashImpl, "Execution invalid/undefined opcode."s)};
+    case EVMC_BAD_JUMP_DESTINATION:
+        return {bcos::protocol::TransactionStatus::BadJumpDestination,
+            bcos::evm::writeErrInfoToOutput(
+                hashImpl, "Execution has violated the jump destination restrictions."s)};
+    case EVMC_INVALID_MEMORY_ACCESS:
+        return {bcos::protocol::TransactionStatus::StackUnderflow,
+            bcos::evm::writeErrInfoToOutput(
+                hashImpl, "Execution tried to read outside memory bounds."s)};
+    case EVMC_STATIC_MODE_VIOLATION:
+        return {bcos::protocol::TransactionStatus::Unknown,
+            bcos::evm::writeErrInfoToOutput(hashImpl,
+                "Execution tried to execute an operation which is restricted in static mode."s)};
+    case EVMC_INTERNAL_ERROR:
+    default:
+        return {bcos::protocol::TransactionStatus::Unknown, {}};
+    }
+}
+
+bcos::evm::EVMCResult bcos::evm::makeErrorEVMCResult(crypto::Hash const& hashImpl,
+    protocol::TransactionStatus status, evmc_status_code evmStatus, int64_t gas,
+    const std::string& errorInfo, bool clampGasLeft)
+{
+    // FIB-78: when bugfix_v1_error_handling is active, force gas_left to 0 for
+    // fatal EVM error statuses so downstream gasUsed computations cannot under-charge,
+    // and clamp any negative value to prevent signed-overflow in (gasLimit - gas_left).
+    // Gated by a feature flag to preserve consensus with pre-fix nodes.
+    int64_t gasLeft = gas;
+    if (clampGasLeft)
+    {
+        switch (evmStatus)
+        {
+        case EVMC_OUT_OF_GAS:
+        case EVMC_INTERNAL_ERROR:
+        case EVMC_STACK_OVERFLOW:
+        case EVMC_STACK_UNDERFLOW:
+        case EVMC_INVALID_INSTRUCTION:
+        case EVMC_UNDEFINED_INSTRUCTION:
+        case EVMC_BAD_JUMP_DESTINATION:
+        case EVMC_INVALID_MEMORY_ACCESS:
+            gasLeft = 0;
+            break;
+        default:
+            break;
+        }
+        gasLeft = std::max<int64_t>(gasLeft, 0);
+    }
+
+    auto [outputData, outputSize, release] = fillErrorOutputInPlace(hashImpl, evmStatus, errorInfo);
+    EVMCResult result{evmc_result{.status_code = evmStatus,
+                          .gas_left = gasLeft,
+                          .gas_refund = 0,
+                          .output_data = outputData,
+                          .output_size = outputSize,
+                          .release = release,
+                          .create_address = {},
+                          .padding = {}},
+        status};
+
+    return result;
+}
+
+std::ostream& operator<<(std::ostream& output, const evmc_message& message)
+{
+    output << "evmc_message{";
+    output << "kind: " << message.kind << ", ";
+    output << "flags: " << message.flags << ", ";
+    output << "depth: " << message.depth << ", ";
+    output << "gas: " << message.gas << ", ";
+    output << "recipient: " << bcos::bytesConstRef(message.recipient.bytes) << ", ";
+    output << "sender: " << bcos::bytesConstRef(message.sender.bytes) << ", ";
+    output << "input_data: " << bcos::bytesConstRef(message.input_data, message.input_size) << ", ";
+    output << "value: " << bcos::bytesConstRef(message.value.bytes) << ", ";
+    output << "create2_salt: " << bcos::bytesConstRef(message.create2_salt.bytes) << ", ";
+    output << "code_address: " << bcos::bytesConstRef(message.code_address.bytes) << "}";
+    return output;
+}
+
+std::ostream& operator<<(std::ostream& output, const evmc_result& result)
+{
+    output << "evmc_result{";
+    output << "status_code: " << result.status_code << ", ";
+    output << "gas_left: " << result.gas_left << ", ";
+    output << "gas_refund: " << result.gas_refund << ", ";
+    output << "output_data: " << bcos::bytesConstRef(result.output_data, result.output_size)
+           << ", ";
+    output << "release: " << (result.release != nullptr) << ", ";
+    output << "create_address: " << bcos::bytesConstRef(result.create_address.bytes) << "}";
+    return output;
+}
+
+std::ostream& operator<<(std::ostream& output, const evmc_address& address)
+{
+    output << bcos::bytesConstRef(address.bytes);
+    return output;
+}

--- a/bcos-evm/eth/EVMCResult.h
+++ b/bcos-evm/eth/EVMCResult.h
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Common.h
+ * @author: ancelmo
+ * @date: 2021-10-08
+ */
+
+#pragma once
+#include "bcos-crypto/interfaces/crypto/Hash.h"
+#include "bcos-protocol/TransactionStatus.h"
+#include <evmc/evmc.h>
+#include <gsl/pointers>
+#include <tuple>
+
+namespace bcos::evm
+{
+class EVMCResult : public evmc_result
+{
+public:
+    explicit EVMCResult(evmc_result from);
+    EVMCResult(evmc_result from, protocol::TransactionStatus statusCode);
+    EVMCResult(const EVMCResult&) = delete;
+    EVMCResult(EVMCResult&& from) noexcept;
+    EVMCResult& operator=(const EVMCResult&) = delete;
+    EVMCResult& operator=(EVMCResult&& from) noexcept;
+    ~EVMCResult() noexcept;
+
+    protocol::TransactionStatus status;
+};
+
+bytes writeErrInfoToOutput(const crypto::Hash& hashImpl, std::string const& errInfo);
+
+std::tuple<gsl::owner<uint8_t*>, size_t, decltype(evmc_result::release)> fillErrorOutputInPlace(
+    const crypto::Hash& hashImpl, evmc_status_code status, const std::string& errorInfo = "");
+
+protocol::TransactionStatus evmcStatusToTransactionStatus(evmc_status_code status);
+std::tuple<bcos::protocol::TransactionStatus, bcos::bytes> evmcStatusToErrorMessage(
+    const bcos::crypto::Hash& hashImpl, evmc_status_code status);
+
+EVMCResult makeErrorEVMCResult(crypto::Hash const& hashImpl, protocol::TransactionStatus status,
+    evmc_status_code evmStatus, int64_t gas, const std::string& errorInfo,
+    bool clampGasLeft = false);
+
+}  // namespace bcos::evm
+
+std::ostream& operator<<(std::ostream& output, const evmc_message& message);
+std::ostream& operator<<(std::ostream& output, const evmc_result& result);
+std::ostream& operator<<(std::ostream& output, const evmc_address& address);

--- a/bcos-evm/eth/ExecuteMessage.h
+++ b/bcos-evm/eth/ExecuteMessage.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Top-level message execution over eth::state::EthHost.
+ * @file ExecuteMessage.h
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/AccessList.h"
+#include "bcos-evm/eth/Eip7702.h"
+#include "bcos-evm/eth/RevisionConfig.h"
+#include "bcos-evm/eth/state/BlockInfo.hpp"
+#include "bcos-evm/eth/state/State.hpp"
+#include "bcos-evm/eth/state/Transaction.hpp"
+#include "bcos-evm/eth/state/VmHostPolicy.h"
+#include <bcos-utilities/Common.h>
+#include <evmc/evmc.hpp>
+#include <vector>
+
+namespace bcos::evm
+{
+struct ChainCallTargetPort;
+using LogEntry = state::LogEntry;
+
+struct ExecuteMessageInput
+{
+    /// Mutable execution journal; pipeline passes &TxPipelineContext::state (ADR-019 Q14).
+    state::State* state{nullptr};
+    evmc::VM* vm{nullptr};
+    evmc_message message{};
+    bcos::u256 gasPrice{0};
+    state::BlockInfo blockInfo{};
+    state::BlockHashes blockHashes{};
+    bcos::evm_standard::RevisionConfig revisionConfig{};
+    state::TransactionProperties txProps{};
+    const Eip2930AccessList* accessList{nullptr};
+    bool authorizationListPresent{false};
+    std::vector<SetCodeAuthorization> authorizations;
+    uint8_t web3TypedTxKind{0};
+    state::VmHostPolicy* extension{nullptr};
+    ChainCallTargetPort* chainPort{nullptr};
+    bool fixStorageStatus{true};
+    bool fixNonceInit{false};
+    /// When true, orchestration (e.g. OpStack deposit finalizeDeposit) owns sender nonce bump.
+    bool skipTopLevelSenderNonceBump{false};
+    std::optional<bcos::h256> txHash;
+};
+
+struct ExecuteMessageOutput
+{
+    evmc::Result result{evmc_result{}};
+    state::StateDiff stateDiff;
+    std::vector<LogEntry> logs;
+    int64_t gasRefund{0};
+};
+
+ExecuteMessageOutput executeMessage(ExecuteMessageInput input);
+
+}  // namespace bcos::evm

--- a/bcos-evm/eth/RevisionConfig.h
+++ b/bcos-evm/eth/RevisionConfig.h
@@ -1,0 +1,113 @@
+#pragma once
+#include <evmc/evmc.h>
+#include <cstddef>
+#include <cstdint>
+
+namespace bcos::evm_standard
+{
+
+struct RevisionConfig
+{
+    evmc_revision revision = EVMC_CANCUN;
+
+    // A. Feature-gated EIPs (require explicit flag ON in FISCO)
+    bool warm_access : 1 = false;
+    bool eip2537 : 1 = false;
+    bool eip7212 : 1 = false;
+    bool eip7623 : 1 = false;
+    bool eip7823 : 1 = false;
+
+    // B. Revision-only EIPs (derived from evmc_revision)
+    bool eip1153 : 1 = false;
+    bool eip4844 : 1 = false;
+    bool eip5656 : 1 = false;
+    bool eip6780 : 1 = false;
+    bool eip1559 : 1 = false;
+    bool eip3651 : 1 = false;
+    bool eip7702 : 1 = false;
+
+    // C. Fork-dependent parameters
+    uint8_t calldata_floor_per_token = 10;
+};
+
+// Enumerate bool EIP/profile flags for profile tests and drift detection (design §5.6).
+#define REVISION_CONFIG_BOOL_FIELDS(X) \
+    X(warm_access)                     \
+    X(eip2537)                         \
+    X(eip7212)                         \
+    X(eip7623)                         \
+    X(eip7823)                         \
+    X(eip1153)                         \
+    X(eip4844)                         \
+    X(eip5656)                         \
+    X(eip6780)                         \
+    X(eip1559)                         \
+    X(eip3651)                         \
+    X(eip7702)
+
+inline constexpr std::size_t revisionConfigBoolFieldCount() noexcept
+{
+    std::size_t n = 0;
+#define REVISION_CONFIG_COUNT_FIELD(name) ++n;
+    REVISION_CONFIG_BOOL_FIELDS(REVISION_CONFIG_COUNT_FIELD)
+#undef REVISION_CONFIG_COUNT_FIELD
+    return n;
+}
+
+static_assert(revisionConfigBoolFieldCount() == 12,
+    "Keep REVISION_CONFIG_BOOL_FIELDS in sync with RevisionConfig bool bitfields");
+
+// A-class feature-gated fields (FISCO requires an explicit flag ON for each).
+#define REVISION_CONFIG_GATED_FIELDS(X) \
+    X(warm_access)                      \
+    X(eip2537)                          \
+    X(eip7212)                          \
+    X(eip7623)                          \
+    X(eip7823)                          \
+    X(eip7702)
+
+inline constexpr std::size_t revisionConfigGatedFieldCount() noexcept
+{
+    std::size_t n = 0;
+#define REVISION_CONFIG_GATED_COUNT(name) ++n;
+    REVISION_CONFIG_GATED_FIELDS(REVISION_CONFIG_GATED_COUNT)
+#undef REVISION_CONFIG_GATED_COUNT
+    return n;
+}
+
+static_assert(revisionConfigGatedFieldCount() == 6,
+    "Keep REVISION_CONFIG_GATED_FIELDS in sync with the A-class field set");
+
+// Single source of truth: EIP gating for a given revision. Canonical (maximal) config.
+// Chains translate blockNum/features -> revision elsewhere (EthPolicy/FiscoPolicy), then
+// optionally mask A-class fields. Never read `revision >= EVMC_xxx` for a gated EIP outside here.
+inline RevisionConfig revisionConfigFromRevision(evmc_revision revision)
+{
+    RevisionConfig cfg;
+    cfg.revision = revision;
+    cfg.warm_access = revision >= EVMC_BERLIN;
+    cfg.eip1559 = revision >= EVMC_LONDON;
+    cfg.eip3651 = revision >= EVMC_SHANGHAI;
+    cfg.eip1153 = revision >= EVMC_CANCUN;
+    cfg.eip4844 = revision >= EVMC_CANCUN;
+    cfg.eip5656 = revision >= EVMC_CANCUN;
+    cfg.eip6780 = revision >= EVMC_CANCUN;
+    cfg.eip2537 = revision >= EVMC_PRAGUE;
+    cfg.eip7623 = revision >= EVMC_PRAGUE;
+    cfg.eip7702 = revision >= EVMC_PRAGUE;
+    cfg.eip7212 = revision >= EVMC_OSAKA;
+    cfg.eip7823 = revision >= EVMC_OSAKA;
+    cfg.calldata_floor_per_token = cfg.eip7623 ? 10 : 0;
+    return cfg;
+}
+
+// Isthmus binds to Prague EVM revision at tx granularity. Block-level Prague
+// postExecution (EIP-6110/7002/7251) is out of scope — op-geth skips it when
+// IsIsthmus (state_processor.go:141). Guarded by IsthmusPostExecutionPolicyTest
+// and check-opstack-no-prague-post-execution.sh.
+inline RevisionConfig makeIsthmusRevisionConfig()
+{
+    return revisionConfigFromRevision(EVMC_PRAGUE);
+}
+
+}  // namespace bcos::evm_standard

--- a/bcos-evm/eth/Transfer.h
+++ b/bcos-evm/eth/Transfer.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "bcos-evm/eth/state/State.hpp"
+
+namespace bcos::evm
+{
+inline bool canTransfer(
+    state::EvmStateReader const& state, evmc_address const& from, bcos::u256 const& value)
+{
+    return state.get_balance(from) >= value;
+}
+
+inline void transfer(
+    state::State& state, evmc_address const& from, evmc_address const& to, bcos::u256 const& value)
+{
+    if (value == 0)
+    {
+        return;
+    }
+    state.set_balance(from, state.get_balance(from) - value);
+    state.set_balance(to, state.get_balance(to) + value);
+}
+}  // namespace bcos::evm

--- a/bcos-evm/eth/execution/CallTargetResolver.cpp
+++ b/bcos-evm/eth/execution/CallTargetResolver.cpp
@@ -1,0 +1,117 @@
+#include "bcos-evm/eth/execution/CallTargetResolver.h"
+#include "bcos-evm/eth/Eip7702.h"
+#include "bcos-evm/eth/execution/CreateContract.h"
+#include "bcos-evm/eth/execution/FrameTargetResolver.h"
+#include "bcos-evm/eth/ports/ChainCallTargetPort.h"
+#include "bcos-evm/eth/precompiled/PrecompileActive.h"
+#include "bcos-evm/eth/state/State.hpp"
+
+namespace bcos::evm::execution
+{
+namespace
+{
+bool is7702DelegationDesignator(
+    bcos::evm_standard::RevisionConfig const& revision, bcos::bytes const& code)
+{
+    return revision.eip7702 &&
+           parseDelegationTarget(bcos::bytesConstRef{code.data(), code.size()}).has_value();
+}
+
+bool isActiveEmptyPrecompileTarget(state::State const& state,
+    bcos::evm_standard::RevisionConfig const& revision, evmc_address const& target,
+    evmc_message const& message)
+{
+    if (state::isZeroAddress(target))
+    {
+        return false;
+    }
+    auto const code = state.get_code(target);
+    if (!code.empty())
+    {
+        return false;
+    }
+    return precompiled::isActivePrecompile(revision, target);
+}
+}  // namespace
+
+CallTargetDescriptor resolveCallTarget(state::State& state,
+    bcos::evm_standard::RevisionConfig const& revision, evmc_message msg, FrameScope scope,
+    ChainCallTargetPort* chainPort, state::VmHostPolicy* extension)
+{
+    if (isCreateKind(msg.kind))
+    {
+        return CallTargetDescriptor{
+            .kind = CallTargetKind::EvmContract, .warmPolicy = WarmPolicy::Never, .routed = msg};
+    }
+
+    auto const frameTarget = resolveFrameTarget(state, revision, msg, scope);
+    auto const& executionAddress = frameTarget.executionAddress;
+    auto const& routed = frameTarget.routed;
+
+    auto const code = state.get_code(executionAddress);
+    bool const emptyCode = code.empty();
+
+    if (!emptyCode && is7702DelegationDesignator(revision, code))
+    {
+        return CallTargetDescriptor{.kind = CallTargetKind::EvmContract,
+            .dispatchAddress = executionAddress,
+            .warmPolicy = WarmPolicy::Never,
+            .routed = routed};
+    }
+
+    if (msg.kind == EVMC_DELEGATECALL && extension != nullptr &&
+        !extension->allowDelegateCallToPrecompile() &&
+        isActiveEmptyPrecompileTarget(state, revision, executionAddress, routed))
+    {
+        return CallTargetDescriptor{.kind = CallTargetKind::PolicyRejected,
+            .dispatchAddress = executionAddress,
+            .warmPolicy = WarmPolicy::Never,
+            .routed = routed};
+    }
+
+    bool const tryChainHook = emptyCode || scope == FrameScope::Nested;
+    if (tryChainHook && chainPort != nullptr)
+    {
+        if (auto chainDesc = chainPort->classifyTarget(state, executionAddress, routed, scope))
+        {
+            chainDesc->routed = routed;
+            return *chainDesc;
+        }
+    }
+
+    if (emptyCode && precompiled::isActivePrecompile(revision, executionAddress))
+    {
+        return CallTargetDescriptor{.kind = CallTargetKind::BuiltinPrecompile,
+            .dispatchAddress = executionAddress,
+            .warmPolicy = WarmPolicy::TxEntryAlways,
+            .routed = routed};
+    }
+
+    if (emptyCode)
+    {
+        return CallTargetDescriptor{.kind = CallTargetKind::EmptyAccount,
+            .dispatchAddress = executionAddress,
+            .warmPolicy = WarmPolicy::Never,
+            .routed = routed};
+    }
+
+    return CallTargetDescriptor{.kind = CallTargetKind::EvmContract,
+        .dispatchAddress = executionAddress,
+        .warmPolicy = WarmPolicy::Never,
+        .routed = routed};
+}
+
+void enumerateTxEntryWarmTargets(bcos::evm_standard::RevisionConfig const& cfg,
+    ChainCallTargetPort const* chainPort, std::function<void(evmc_address const&)> const& consume)
+{
+    // Builtin precompiles: resolveCallTarget assigns WarmPolicy::TxEntryAlways (PrecompileActive
+    // single source).
+    precompiled::forEachActivePrecompile(cfg, [&](evmc_address const& a) { consume(a); });
+    // Chain static targets: adapter forEachStaticWarmTarget emits only isTxEntryWarm entries (PR5).
+    if (chainPort != nullptr)
+    {
+        chainPort->forEachStaticWarmTarget(consume);
+    }
+}
+
+}  // namespace bcos::evm::execution

--- a/bcos-evm/eth/execution/CallTargetResolver.h
+++ b/bcos-evm/eth/execution/CallTargetResolver.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "bcos-evm/eth/RevisionConfig.h"
+#include "bcos-evm/eth/execution/FrameScope.h"
+#include "bcos-evm/eth/state/VmHostPolicy.h"
+#include <evmc/evmc.h>
+#include <functional>
+
+namespace bcos::evm
+{
+struct ChainCallTargetPort;
+}
+
+namespace bcos::evm::state
+{
+class State;
+}
+
+namespace bcos::evm::execution
+{
+
+enum class CallTargetKind
+{
+    EvmContract,
+    BuiltinPrecompile,
+    ChainPrecompile,
+    EmptyAccount,
+    PolicyRejected,
+};
+
+enum class WarmPolicy
+{
+    Never,
+    TxEntryAlways,
+    TxEntryIfStatic,
+    FrameEntryOnly,  // CREATE warm-pin; set by resolveFrameTarget, not consumed by enumerate
+};
+
+/// Tx-entry warm set includes TxEntryAlways (builtin) and TxEntryIfStatic (fixed predeploys).
+inline constexpr bool isTxEntryWarm(WarmPolicy policy) noexcept
+{
+    return policy == WarmPolicy::TxEntryAlways || policy == WarmPolicy::TxEntryIfStatic;
+}
+
+struct CallTargetDescriptor
+{
+    CallTargetKind kind{CallTargetKind::EvmContract};
+    evmc_address dispatchAddress{};
+    WarmPolicy warmPolicy{WarmPolicy::Never};
+    evmc_message routed{};
+};
+
+CallTargetDescriptor resolveCallTarget(state::State& state,
+    bcos::evm_standard::RevisionConfig const& revision, evmc_message msg, FrameScope scope,
+    ChainCallTargetPort* chainPort, state::VmHostPolicy* extension);
+
+void enumerateTxEntryWarmTargets(bcos::evm_standard::RevisionConfig const& cfg,
+    ChainCallTargetPort const* chainPort, std::function<void(evmc_address const&)> const& consume);
+
+}  // namespace bcos::evm::execution

--- a/bcos-evm/eth/execution/ExecutionFrame.h
+++ b/bcos-evm/eth/execution/ExecutionFrame.h
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Unified execution frame entry (top-level and nested).
+ * @file ExecutionFrame.h
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/RevisionConfig.h"
+#include "bcos-evm/eth/execution/FrameScope.h"
+#include "bcos-evm/eth/state/VmHostPolicy.h"
+#include <evmc/evmc.hpp>
+
+namespace bcos::evm
+{
+struct ChainCallTargetPort;
+}
+
+namespace bcos::evm::state
+{
+class State;
+class EthHost;
+}  // namespace bcos::evm::state
+
+namespace bcos::evm::execution
+{
+
+struct FrameContext
+{
+    state::State& state;
+    evmc::VM& vm;
+    bcos::evm_standard::RevisionConfig const& revisionConfig;
+    state::VmHostPolicy* extension{nullptr};
+    ChainCallTargetPort* chainPort{nullptr};
+    evmc_address txOrigin{};
+    evmc_address& executionAddress;
+    bool fixNonceInit{false};
+
+    FrameContext(state::State& state_, evmc::VM& vm_,
+        bcos::evm_standard::RevisionConfig const& revisionConfig_, state::VmHostPolicy* extension_,
+        evmc_address txOrigin_, evmc_address& executionAddress_, bool fixNonceInit_ = false,
+        ChainCallTargetPort* chainPort_ = nullptr) noexcept
+      : state(state_),
+        vm(vm_),
+        revisionConfig(revisionConfig_),
+        extension(extension_),
+        chainPort(chainPort_),
+        txOrigin(txOrigin_),
+        executionAddress(executionAddress_),
+        fixNonceInit(fixNonceInit_)
+    {}
+};
+
+struct FrameResult
+{
+    evmc::Result result{evmc_result{}};
+    int64_t gasRefund{0};
+    bool precompileHit{false};
+};
+
+FrameResult runExecutionFrame(
+    FrameContext& ctx, evmc_message message, FrameScope scope, state::EthHost& host);
+
+}  // namespace bcos::evm::execution

--- a/bcos-evm/eth/execution/FrameScope.h
+++ b/bcos-evm/eth/execution/FrameScope.h
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief TopLevel vs Nested execution frame scope.
+ * @file FrameScope.h
+ */
+
+#pragma once
+
+namespace bcos::evm::execution
+{
+enum class FrameScope
+{
+    TopLevel,
+    Nested,
+};
+}  // namespace bcos::evm::execution

--- a/bcos-evm/eth/gas/ProtocolGas.h
+++ b/bcos-evm/eth/gas/ProtocolGas.h
@@ -1,0 +1,23 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ * @brief Canonical Ethereum protocol gas constants (geth params.go aligned).
+ * @file ProtocolGas.h
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace bcos::evm::gas
+{
+
+inline constexpr int64_t TX_BASE_GAS = 21'000;
+inline constexpr int64_t CREATE_BASE_GAS = 32'000;
+inline constexpr int64_t INITCODE_WORD_GAS = 2;
+inline constexpr int64_t ACCESS_LIST_ADDRESS_COST = 2'400;
+inline constexpr int64_t ACCESS_LIST_STORAGE_KEY_COST = 1'900;
+inline constexpr int64_t ZERO_BYTE_INTRINSIC_COST = 4;
+inline constexpr int64_t NONZERO_BYTE_INTRINSIC_COST = 16;
+
+}  // namespace bcos::evm::gas

--- a/bcos-evm/eth/gas/TxIntrinsicGas.h
+++ b/bcos-evm/eth/gas/TxIntrinsicGas.h
@@ -1,0 +1,161 @@
+/*
+ * Transaction intrinsic gas and top-level settlement (EIP-7623 + EIP-3529).
+ *
+ * Lean model (geth/op-geth aligned): full intrinsic pre-debit before EVM, then
+ *   gasUsed = gasLimit - min(gasLimit, gasLeft + cappedRefund), EIP-7623 floor uplift.
+ *
+ * @file TxIntrinsicGas.h
+ */
+#pragma once
+
+#include "bcos-evm/eth/AccessList.h"
+#include "bcos-evm/eth/Eip7702.h"
+#include "bcos-evm/eth/gas/Eip7623.h"
+#include "bcos-evm/eth/gas/ProtocolGas.h"
+#include <evmc/evmc.h>
+#include <algorithm>
+
+namespace bcos::evm
+{
+namespace gas
+{
+
+struct TxIntrinsicGas
+{
+    int64_t txBase = TX_BASE_GAS;
+    int64_t normalCalldata = 0;
+    int64_t accessListCost = 0;
+    int64_t createIntrinsic = 0;
+    int64_t floorReserve = 0;
+
+    int64_t fixedCost() const { return txBase + accessListCost; }
+
+    int64_t preExecutionDebit() const { return fixedCost() + normalCalldata + createIntrinsic; }
+
+    /// EIP-7623: max(21000 + floor, intrinsic) where intrinsic includes access list + CREATE.
+    int64_t gasLimitMinimum() const
+    {
+        int64_t const intrinsic = preExecutionDebit();
+        int64_t const floorTotal = txBase + floorReserve;
+        return std::max(intrinsic, floorTotal);
+    }
+
+    /// EIP-7623 + EIP-7702: auth intrinsic is part of the intrinsic side of the minimum, not
+    /// additive.
+    int64_t gasLimitMinimumWithAuth(int64_t authCost) const
+    {
+        int64_t const intrinsic = preExecutionDebit() + authCost;
+        int64_t const floorTotal = txBase + floorReserve;
+        return std::max(intrinsic, floorTotal);
+    }
+};
+
+/// Post-execution inputs for Lean settlement (full intrinsic already debited from message.gas).
+struct TxGasSettlementSnapshot
+{
+    int64_t gasLimit = 0;
+    Eip7623Components calldata{};
+    int64_t evmGasRefund = 0;
+};
+
+using TxGasSettlementContext = TxGasSettlementSnapshot;
+
+inline int64_t calcAccessListCost(Eip2930AccessList const* accessList) noexcept
+{
+    if (accessList == nullptr)
+    {
+        return 0;
+    }
+    int64_t cost = 0;
+    for (auto const& entry : *accessList)
+    {
+        cost += ACCESS_LIST_ADDRESS_COST;
+        cost += static_cast<int64_t>(entry.second.size()) * ACCESS_LIST_STORAGE_KEY_COST;
+    }
+    return cost;
+}
+
+inline int64_t calcAuthTupleIntrinsicGas(uint64_t authTupleCount) noexcept
+{
+    return static_cast<int64_t>(authTupleCount) * static_cast<int64_t>(PER_EMPTY_ACCOUNT_COST);
+}
+
+inline int64_t calcCreateIntrinsic(evmc_message const& message) noexcept
+{
+    if (message.kind != EVMC_CREATE && message.kind != EVMC_CREATE2)
+    {
+        return 0;
+    }
+    auto const inputSize = static_cast<int64_t>(message.input_size);
+    auto const words = (inputSize + 31) / 32;
+    return CREATE_BASE_GAS + INITCODE_WORD_GAS * words;
+}
+
+inline TxIntrinsicGas computeTxIntrinsicGas(
+    evmc_message const& message, Eip2930AccessList const* accessList, uint8_t web3TypedTxKind)
+{
+    (void)web3TypedTxKind;
+    TxIntrinsicGas intrinsic;
+    auto const components =
+        gas::calcEip7623Components(bcos::bytesConstRef(message.input_data, message.input_size));
+    intrinsic.normalCalldata = components.normalCost;
+    intrinsic.floorReserve = components.floorCost;
+
+    if (accessList != nullptr && !accessList->empty())
+    {
+        intrinsic.accessListCost = calcAccessListCost(accessList);
+    }
+
+    intrinsic.createIntrinsic = calcCreateIntrinsic(message);
+    return intrinsic;
+}
+
+inline int64_t effectiveRefundEip3529(int64_t evmGasRefund, int64_t gasUsedBeforeRefund) noexcept
+{
+    if (gasUsedBeforeRefund <= 0)
+    {
+        return 0;
+    }
+    return std::min(evmGasRefund, gasUsedBeforeRefund / 5);
+}
+
+inline int64_t calcFloorDataGas(
+    uint8_t calldataFloorPerToken, Eip7623Components const& calldata) noexcept
+{
+    return TX_BASE_GAS + calldata.tokenCount * calldataFloorPerToken;
+}
+
+/// geth state_transition settlement: peakGasUsed from gasLimit/gasLeft, EIP-3529 refund cap,
+/// EIP-7623 floor uplift. Authoritative refund counter is host state.get_refund().
+inline int64_t settleTopLevelTransactionGas(
+    int64_t gasLimit, int64_t evmGasLeft, int64_t stateRefund, int64_t floorDataGas) noexcept
+{
+    int64_t const gasLeft =
+        std::min(std::max<int64_t>(0, evmGasLeft), std::max<int64_t>(0, gasLimit));
+    int64_t const peakGasUsed = std::max<int64_t>(0, gasLimit) - gasLeft;
+    int64_t const effectiveRefund = effectiveRefundEip3529(stateRefund, peakGasUsed);
+    int64_t const gasRemaining =
+        std::min(std::max<int64_t>(0, gasLimit), gasLeft + effectiveRefund);
+    int64_t gasUsed = std::max<int64_t>(0, gasLimit) - gasRemaining;
+    if (floorDataGas > 0 && gasUsed < floorDataGas)
+    {
+        gasUsed = std::min(floorDataGas, std::max<int64_t>(0, gasLimit));
+    }
+    return gasUsed;
+}
+
+inline int64_t settleTopLevelTransactionGas(int64_t gasLimit, int64_t evmGasLeft,
+    int64_t stateRefund, uint8_t calldataFloorPerToken, Eip7623Components const& calldata) noexcept
+{
+    return settleTopLevelTransactionGas(
+        gasLimit, evmGasLeft, stateRefund, calcFloorDataGas(calldataFloorPerToken, calldata));
+}
+
+}  // namespace gas
+}  // namespace bcos::evm
+
+namespace bcos::executor_v1::gas
+{
+using bcos::evm::gas::computeTxIntrinsicGas;
+using bcos::evm::gas::TxIntrinsicGas;
+}  // namespace bcos::executor_v1::gas

--- a/bcos-evm/eth/pipeline/ExecutionSession.h
+++ b/bcos-evm/eth/pipeline/ExecutionSession.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "bcos-evm/eth/ExecuteMessage.h"
+#include "bcos-evm/eth/pipeline/TxPipelineContext.h"
+#include "bcos-evm/eth/ports/ChainCallTargetPort.h"
+#include "bcos-evm/eth/state/VmHostPolicy.h"
+#include <cassert>
+#include <stdexcept>
+
+namespace bcos::evm
+{
+
+/// Kernel view of per-tx execution environment (ADR-027 Tier 1+2). Chain Bundles own adapters.
+struct ExecutionSession
+{
+    ChainCallTargetPort* chainPort{nullptr};
+    state::VmHostPolicy* extension{nullptr};
+    evmc::VM* vm{nullptr};
+    state::BlockHashes blockHashes{};
+    bool fixStorageStatus{true};
+    bool fixNonceInit{false};
+
+    void wire(TxPipelineContext& ctx) const
+    {
+        if (vm == nullptr)
+        {
+            throw std::invalid_argument("ExecutionSession::wire requires vm");
+        }
+
+        ctx.extension = extension;
+        ctx.chainPort = chainPort;
+        ctx.inputs.vm = vm;
+        ctx.session = this;
+
+#ifndef NDEBUG
+        assert(ctx.extension == extension);
+        assert(ctx.chainPort == chainPort);
+        assert(ctx.inputs.vm == vm);
+#endif
+    }
+
+    ExecuteMessageInput toExecuteMessageInput(TxPipelineContext const& ctx) const
+    {
+        ExecuteMessageInput input;
+        input.state = const_cast<state::State*>(&ctx.state);
+        input.vm = vm;
+        input.message = ctx.message;
+        input.gasPrice = ctx.gasPrice;
+        input.blockInfo = ctx.inputs.blockInfo;
+        input.blockHashes = blockHashes;
+        input.revisionConfig = ctx.revisionConfig;
+        input.txProps = ctx.txProps;
+        input.accessList = ctx.inputs.accessList;
+        input.authorizationListPresent = ctx.inputs.authorizationListPresent;
+        input.authorizations = ctx.inputs.authorizations;
+        input.web3TypedTxKind = ctx.inputs.web3TypedTxKind;
+        input.extension = extension;
+        input.chainPort = chainPort;
+        input.fixStorageStatus = fixStorageStatus;
+        input.fixNonceInit = fixNonceInit;
+        return input;
+    }
+};
+
+}  // namespace bcos::evm

--- a/bcos-evm/eth/pipeline/TxPipelineContext.h
+++ b/bcos-evm/eth/pipeline/TxPipelineContext.h
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "bcos-evm/eth/AccessList.h"
+#include "bcos-evm/eth/EVMCResult.h"
+#include "bcos-evm/eth/Eip7702.h"
+#include "bcos-evm/eth/ExecuteMessage.h"
+#include "bcos-evm/eth/RevisionConfig.h"
+#include "bcos-evm/eth/execution/TxFeaturePrepare.h"
+#include "bcos-evm/eth/gas/TxIntrinsicGas.h"
+#include "bcos-evm/eth/pipeline/DebitIntrinsicGas.h"
+#include "bcos-evm/eth/state/State.hpp"
+#include "bcos-evm/eth/state/VmHostPolicy.h"
+#include "bcos-utilities/DataConvertUtility.h"
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+
+namespace bcos::crypto
+{
+class Hash;
+}
+
+namespace bcos::evm
+{
+
+struct ChainCallTargetPort;
+struct ExecutionSession;
+
+enum class TxPipelineExitKind
+{
+    None,
+    RulesRejected,
+    GasAffordRejected,
+    IntrinsicRejected,
+    Completed,
+    ExceptionHandled
+};
+
+struct TxPipelineInputs
+{
+    evmc::VM* vm{nullptr};
+    bcos::crypto::Hash const* hashImpl{nullptr};
+    state::BlockInfo blockInfo{};
+    state::BlockHashes blockHashes{};
+    Eip2930AccessList const* accessList{nullptr};
+    bool authorizationListPresent{false};
+    std::vector<SetCodeAuthorization> authorizations;
+    uint8_t web3TypedTxKind{0};
+};
+
+class TxPipelineContext
+{
+public:
+    TxPipelineContext(state::EvmStateReader const& stateView, evmc_message inputMessage,
+        bcos::evm_standard::RevisionConfig inputRevisionConfig, intx::uint256 inputGasPrice)
+      : message(inputMessage),
+        originalGasLimit(inputMessage.gas),
+        state(stateView),
+        gasPrice(intxToU256(inputGasPrice)),
+        revisionConfig(inputRevisionConfig)
+    {
+        execution::setWarmDestinationFromKind(txProps, message.kind);
+    }
+
+    TxPipelineContext(state::EvmStateReader const& stateView, evmc_message inputMessage,
+        bcos::evm_standard::RevisionConfig inputRevisionConfig, bcos::u256 inputGasPrice)
+      : message(inputMessage),
+        originalGasLimit(inputMessage.gas),
+        state(stateView),
+        gasPrice(inputGasPrice),
+        revisionConfig(inputRevisionConfig)
+    {
+        execution::setWarmDestinationFromKind(txProps, message.kind);
+    }
+
+    TxPipelineContext(TxPipelineContext const&) = delete;
+    TxPipelineContext& operator=(TxPipelineContext const&) = delete;
+    TxPipelineContext(TxPipelineContext&&) = delete;
+    TxPipelineContext& operator=(TxPipelineContext&&) = delete;
+
+    TxPipelineInputs inputs;
+    evmc_message message{};
+    int64_t originalGasLimit{0};
+    state::State state;
+    bcos::u256 gasPrice{0};
+    state::VmHostPolicy* extension{nullptr};
+    ChainCallTargetPort* chainPort{nullptr};
+    ExecutionSession const* session{nullptr};
+    state::TransactionProperties txProps{};
+    bcos::evm_standard::RevisionConfig revisionConfig{};
+    gas::TxGasSettlementSnapshot snapshot{};
+    ExecuteMessageOutput kernelOutput{};
+    EVMCResult evmcResult{evmc_result{}};
+    bool earlyExit{false};
+    TxPipelineExitKind exitKind{TxPipelineExitKind::None};
+    IntrinsicDebitMode intrinsicDebitMode{IntrinsicDebitMode::None};
+    /// Eth-only: set by EthOrchestrationErrorPolicy when top-level vmerr is included in block.
+    bool topLevelIncludedTxVmError{false};
+
+private:
+    static bcos::u256 intxToU256(intx::uint256 const& value)
+    {
+        evmc_bytes32 bytes{};
+        intx::be::store(bytes.bytes, value);
+        return fromBigEndian<bcos::u256>(bytes.bytes);
+    }
+};
+
+}  // namespace bcos::evm

--- a/bcos-evm/eth/ports/ChainCallTargetPort.h
+++ b/bcos-evm/eth/ports/ChainCallTargetPort.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "bcos-evm/eth/execution/CallTargetResolver.h"
+#include "bcos-evm/eth/execution/FrameScope.h"
+#include "bcos-evm/eth/state/State.hpp"
+#include <evmc/evmc.h>
+#include <functional>
+#include <optional>
+
+namespace bcos::evm
+{
+
+struct ChainCallTargetPort
+{
+    virtual ~ChainCallTargetPort() = default;
+
+    virtual std::optional<execution::CallTargetDescriptor> classifyTarget(state::State& state,
+        evmc_address const& executionAddress, evmc_message const& msg,
+        execution::FrameScope scope) = 0;
+
+    virtual std::optional<evmc_result> dispatch(evmc_revision rev, evmc_message const& msg) = 0;
+
+    virtual void forEachStaticWarmTarget(
+        std::function<void(evmc_address const&)> const& consume) const = 0;
+};
+
+}  // namespace bcos::evm

--- a/bcos-evm/eth/reference/EthOrchestrationProfile.cpp
+++ b/bcos-evm/eth/reference/EthOrchestrationProfile.cpp
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthOrchestrationProfile.cpp
+ */
+
+#include "bcos-evm/eth/reference/EthOrchestrationProfile.h"
+
+namespace bcos::evm
+{
+
+EthPrecheckPolicy EthOrchestrationProfile::buildPrecheckPolicy(BindingsContext& bindingsCtx)
+{
+    return EthPrecheckPolicy{bindingsCtx.input};
+}
+
+EthOrchestrationErrorPolicy EthOrchestrationProfile::buildErrorPolicy(
+    BindingsContext const& /*bindingsCtx*/)
+{
+    return EthOrchestrationErrorPolicy{};
+}
+
+EthOrchestrationProfile::Bindings EthOrchestrationProfile::bind(BindingsContext& bindingsCtx)
+{
+    return Bindings{buildPrecheckPolicy(bindingsCtx), buildErrorPolicy(bindingsCtx)};
+}
+
+}  // namespace bcos::evm

--- a/bcos-evm/eth/reference/EthOrchestrationProfile.h
+++ b/bcos-evm/eth/reference/EthOrchestrationProfile.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthOrchestrationProfile.h
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/reference/EthOrchestrationErrorPolicy.h"
+#include "bcos-evm/eth/reference/EthPrecheckPolicy.h"
+#include "bcos-evm/eth/reference/EthReferenceBridge.h"
+
+namespace bcos::evm
+{
+
+struct EthOrchestrationProfile
+{
+    /// Orchestration policy bind input (not kernel ExecutionSession; ADR-027 naming follow-up).
+    struct BindingsContext
+    {
+        EthReferenceRequest const& input;
+        EthReferenceResult& output;
+    };
+
+    struct Bindings
+    {
+        EthPrecheckPolicy precheckPolicy;
+        EthOrchestrationErrorPolicy errorPolicy;
+    };
+
+    static EthPrecheckPolicy buildPrecheckPolicy(BindingsContext& bindingsCtx);
+    static EthOrchestrationErrorPolicy buildErrorPolicy(BindingsContext const& bindingsCtx);
+    static Bindings bind(BindingsContext& bindingsCtx);
+};
+
+}  // namespace bcos::evm

--- a/bcos-evm/eth/state/Account.hpp
+++ b/bcos-evm/eth/state/Account.hpp
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief In-memory account model for execution-time State journal.
+ * @file Account.hpp
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/state/HashUtils.hpp"
+#include <unordered_map>
+
+namespace bcos::evm::state
+{
+using StorageMap = std::unordered_map<evmc_bytes32, evmc_bytes32, Bytes32Hash, Bytes32Equal>;
+
+struct Account
+{
+    bcos::u256 balance{0};
+    uint64_t nonce{0};
+    bcos::bytes code;
+    evmc_bytes32 codeHash{};
+    StorageMap storage;
+    StorageMap transientStorage;
+    bool balanceDirty{false};
+    bool nonceDirty{false};
+    bool codeDirty{false};
+    bool selfDestructed{false};
+};
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/BlockInfo.hpp
+++ b/bcos-evm/eth/state/BlockInfo.hpp
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Block context used by eth transition().
+ * @file BlockInfo.hpp
+ */
+
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <evmc/evmc.h>
+#include <functional>
+
+namespace bcos::evm::state
+{
+using BlockHashes = std::function<evmc_bytes32(int64_t)>;
+
+struct BlockInfo
+{
+    int64_t number{0};
+    int64_t timestamp{0};
+    int64_t gasLimit{0};
+    evmc_address coinbase{};
+    evmc_bytes32 prevRandao{};
+    bcos::u256 baseFee{0};
+    bcos::u256 chainId{0};
+    bcos::u256 blobBaseFee{0};
+};
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/EthHost.cpp
+++ b/bcos-evm/eth/state/EthHost.cpp
@@ -1,0 +1,406 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthHost.cpp
+ */
+
+#include "bcos-evm/eth/state/EthHost.hpp"
+#include "bcos-evm/eth/Transfer.h"
+#include "bcos-evm/eth/execution/Eip2929Access.h"
+#include "bcos-evm/eth/execution/ExecutionFrame.h"
+#include "bcos-evm/eth/gas/Eip2929StorageGas.h"
+#include "bcos-evm/eth/state/HashUtils.hpp"
+#include "bcos-evm/eth/trace/EvmTrace.h"
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+namespace bcos::evm::state
+{
+namespace
+{
+using bcos::evm::gas::COLD_SLOAD_COST_EIP2929;
+using bcos::evm::gas::SSTORE_CLEARS_SCHEDULE_REFUND_EIP3529;
+using bcos::evm::gas::SSTORE_RESET_GAS_EIP2200;
+using bcos::evm::gas::SSTORE_SET_GAS_EIP2200;
+using bcos::evm::gas::WARM_STORAGE_READ_COST_EIP2929;
+
+void applySstoreRefundEip3529(State& state, const evmc_bytes32& current,
+    const evmc_bytes32& original, const evmc_bytes32& value) noexcept
+{
+    if (Bytes32Equal{}(current, value))
+    {
+        return;
+    }
+    if (Bytes32Equal{}(original, current))
+    {
+        if (isZeroBytes32(original))
+        {
+            return;
+        }
+        if (isZeroBytes32(value))
+        {
+            state.add_refund(SSTORE_CLEARS_SCHEDULE_REFUND_EIP3529);
+        }
+        return;
+    }
+    if (!isZeroBytes32(original))
+    {
+        if (isZeroBytes32(current))
+        {
+            state.sub_refund(SSTORE_CLEARS_SCHEDULE_REFUND_EIP3529);
+        }
+        else if (isZeroBytes32(value))
+        {
+            state.add_refund(SSTORE_CLEARS_SCHEDULE_REFUND_EIP3529);
+        }
+    }
+    if (Bytes32Equal{}(original, value))
+    {
+        if (isZeroBytes32(original))
+        {
+            state.add_refund(SSTORE_SET_GAS_EIP2200 - WARM_STORAGE_READ_COST_EIP2929);
+        }
+        else
+        {
+            state.add_refund((SSTORE_RESET_GAS_EIP2200 - COLD_SLOAD_COST_EIP2929) -
+                             WARM_STORAGE_READ_COST_EIP2929);
+        }
+    }
+}
+
+}  // namespace
+
+EthHost::EthHost(State& state, evmc_tx_context txContext,
+    bcos::evm_standard::RevisionConfig revisionConfig, evmc::VM& vm, BlockHashes blockHashes,
+    VmHostPolicy* extension, bool fixStorageStatus, ChainCallTargetPort* chainPort)
+  : m_state(state),
+    m_txContext(txContext),
+    m_revisionConfig(revisionConfig),
+    m_vm(vm),
+    m_blockHashes(std::move(blockHashes)),
+    m_extension(extension),
+    m_chainPort(chainPort),
+    m_fixStorageStatus(fixStorageStatus)
+{}
+
+bool EthHost::account_exists(const address& addr) const noexcept
+{
+    return m_state.get_account(addr).has_value();
+}
+
+EthHost::bytes32 EthHost::get_storage(const address& addr, const bytes32& key) const noexcept
+{
+    return m_state.get_storage(addr, key);
+}
+
+evmc_storage_status EthHost::set_storage(
+    const address& addr, const bytes32& key, const bytes32& value) noexcept
+{
+    auto const slot = std::make_pair(addr, key);
+    auto [it, inserted] = m_storageOriginalValues.try_emplace(slot, evmc_bytes32{});
+    if (inserted)
+    {
+        // FISCO sstoreStatus reads committed storage directly for status classification.
+        it->second = m_state.get_storage(addr, key);
+    }
+
+    auto const& original = it->second;
+    auto const current = m_state.get_storage(addr, key);
+    if (Bytes32Equal{}(current, value))
+    {
+        // Unchanged slot: evmone keeps ASSIGNED (100 gas) even when original was zero.
+        return EVMC_STORAGE_ASSIGNED;
+    }
+    if (m_fixStorageStatus)
+    {
+        applySstoreRefundEip3529(m_state, current, original, value);
+    }
+
+    m_state.set_storage(addr, key, value);
+    auto const status = classifyStorageStatus(original, current, value, m_fixStorageStatus);
+    if (!m_fixStorageStatus && status == EVMC_STORAGE_DELETED)
+    {
+        m_state.add_refund(SSTORE_CLEARS_SCHEDULE_REFUND_EIP3529);
+    }
+    return status;
+}
+
+EthHost::uint256be EthHost::get_balance(const address& addr) const noexcept
+{
+    return toEvmC(m_state.get_balance(addr));
+}
+
+size_t EthHost::get_code_size(const address& addr) const noexcept
+{
+    return m_state.get_code(addr).size();
+}
+
+EthHost::bytes32 EthHost::get_code_hash(const address& addr) const noexcept
+{
+    return m_state.get_code_hash(addr);
+}
+
+size_t EthHost::copy_code(const address& addr, size_t code_offset, uint8_t* buffer_data,
+    size_t buffer_size) const noexcept
+{
+    auto const code = m_state.get_code(addr);
+    if (code_offset >= code.size() || buffer_size == 0)
+    {
+        return 0;
+    }
+    auto const count = std::min(buffer_size, code.size() - code_offset);
+    std::copy_n(code.data() + code_offset, count, buffer_data);
+    return count;
+}
+
+void EthHost::markCreatedInTx(evmc_address const& addr) noexcept
+{
+    if (!isZeroAddress(addr))
+    {
+        m_createdInTx.insert(addr);
+    }
+}
+
+bool EthHost::wasCreatedInTx(evmc_address const& addr) const noexcept
+{
+    return m_createdInTx.contains(addr);
+}
+
+void EthHost::destroyContractState(evmc_address const& addr) noexcept
+{
+    m_state.set_code(addr, {}, {});
+    m_state.clear_storage(addr);
+}
+
+bool EthHost::selfdestruct(const address& addr, const address& beneficiary) noexcept
+{
+    if (m_extension != nullptr)
+    {
+        auto const account = m_state.find(addr).value_or(Account{});
+        if (!m_extension->allowSelfdestruct(account))
+        {
+            return false;
+        }
+    }
+
+    auto const balance = m_state.get_balance(addr);
+    auto const selfBeneficiary =
+        std::memcmp(addr.bytes, beneficiary.bytes, sizeof(addr.bytes)) == 0;
+
+    if (m_revisionConfig.eip6780 && !wasCreatedInTx(addr))
+    {
+        // EIP-6780: pre-existing accounts are not destroyable; move balance only.
+        // evmone: acc.balance = 0; beneficiary += balance (net unchanged when self-beneficiary).
+        if (balance != 0)
+        {
+            m_state.set_balance(addr, 0);
+            if (selfBeneficiary)
+            {
+                m_state.set_balance(addr, balance);
+            }
+            else
+            {
+                m_state.set_balance(beneficiary, m_state.get_balance(beneficiary) + balance);
+            }
+        }
+        return false;
+    }
+
+    if (balance != 0)
+    {
+        if (!selfBeneficiary)
+        {
+            bcos::evm::transfer(m_state, addr, beneficiary, balance);
+        }
+        else
+        {
+            m_state.set_balance(addr, 0);
+        }
+    }
+
+    if (m_revisionConfig.eip6780)
+    {
+        m_state.mark_self_destructed(addr);
+        return true;
+    }
+
+    destroyContractState(addr);
+    return true;
+}
+
+EthHost::Result EthHost::call(const evmc_message& msg) noexcept
+{
+    if (msg.depth > 0)
+    {
+        EVM_LOG(TRACE) << LOG_DESC("EthHost::call") << LOG_KV("kind", trace::callKind(msg.kind))
+                       << LOG_KV("depth", msg.depth) << LOG_KV("gas", msg.gas)
+                       << LOG_KV("sender", trace::evmcAddress(msg.sender))
+                       << LOG_KV("target", trace::evmcAddress(msg.recipient));
+    }
+
+    struct ExecutionAddressGuard
+    {
+        evmc_address& address;
+        evmc_address saved;
+        explicit ExecutionAddressGuard(evmc_address& address_) : address(address_), saved(address_)
+        {}
+        ~ExecutionAddressGuard() { address = saved; }
+    };
+    ExecutionAddressGuard guard{m_executionAddress};
+
+    execution::FrameContext frameCtx{m_state, m_vm, m_revisionConfig, m_extension,
+        m_txContext.tx_origin, m_executionAddress, false, m_chainPort};
+    auto fr = execution::runExecutionFrame(frameCtx, msg, execution::FrameScope::Nested, *this);
+    return Result(std::move(fr.result));
+}
+
+evmc_tx_context EthHost::get_tx_context() const noexcept
+{
+    return m_txContext;
+}
+
+EthHost::bytes32 EthHost::get_block_hash(int64_t number) const noexcept
+{
+    if (!m_blockHashes)
+    {
+        return {};
+    }
+    return m_blockHashes(number);
+}
+
+void EthHost::emit_log(const address& addr, const uint8_t* data, size_t data_size,
+    const bytes32 topics[], size_t num_topics) noexcept
+{
+    LogEntry entry;
+    entry.address = addr;
+    if (data != nullptr && data_size > 0)
+    {
+        entry.data.assign(data, data + data_size);
+    }
+    entry.topics.reserve(num_topics);
+    for (size_t i = 0; i < num_topics; ++i)
+    {
+        entry.topics.push_back(topics[i]);
+    }
+    m_logs.push_back(std::move(entry));
+}
+
+evmc_access_status EthHost::access_account(const address& addr) noexcept
+{
+    if (!execution::isEip2929Enabled(m_revisionConfig))
+    {
+        return EVMC_ACCESS_COLD;
+    }
+    return m_state.warm_up_address(addr) ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
+}
+
+evmc_access_status EthHost::access_storage(const address& addr, const bytes32& key) noexcept
+{
+    if (!execution::isEip2929Enabled(m_revisionConfig))
+    {
+        return EVMC_ACCESS_COLD;
+    }
+    return m_state.warm_up_storage(addr, key) ? EVMC_ACCESS_COLD : EVMC_ACCESS_WARM;
+}
+
+EthHost::bytes32 EthHost::get_transient_storage(
+    const address& addr, const bytes32& key) const noexcept
+{
+    auto const account = m_state.find(addr);
+    if (!account.has_value())
+    {
+        return {};
+    }
+    auto it = account->transientStorage.find(key);
+    if (it == account->transientStorage.end())
+    {
+        return {};
+    }
+    return it->second;
+}
+
+void EthHost::set_transient_storage(
+    const address& addr, const bytes32& key, const bytes32& value) noexcept
+{
+    m_state.set_transient_storage(addr, key, value);
+}
+
+std::vector<LogEntry> EthHost::take_logs()
+{
+    return std::exchange(m_logs, {});
+}
+
+evmc_storage_status EthHost::classifyStorageStatus(const evmc_bytes32& oldValue,
+    const evmc_bytes32& currentValue, const evmc_bytes32& newValue, bool fixStorageStatus) noexcept
+{
+    if (!fixStorageStatus)
+    {
+        return isZeroBytes32(newValue) ? EVMC_STORAGE_DELETED : EVMC_STORAGE_MODIFIED;
+    }
+
+    // evmone test/state/host.cpp set_storage (EIP-2200 / EIP-3529 status mapping).
+    auto const dirty = !Bytes32Equal{}(oldValue, currentValue);
+    auto const restored = Bytes32Equal{}(oldValue, newValue);
+    auto const currentIsZero = isZeroBytes32(currentValue);
+    auto const valueIsZero = isZeroBytes32(newValue);
+
+    auto status = EVMC_STORAGE_ASSIGNED;
+    if (!dirty && !restored)
+    {
+        if (currentIsZero)
+        {
+            status = EVMC_STORAGE_ADDED;
+        }
+        else if (valueIsZero)
+        {
+            status = EVMC_STORAGE_DELETED;
+        }
+        else
+        {
+            status = EVMC_STORAGE_MODIFIED;
+        }
+    }
+    else if (dirty && !restored)
+    {
+        if (currentIsZero && !valueIsZero)
+        {
+            status = EVMC_STORAGE_DELETED_ADDED;
+        }
+        else if (!currentIsZero && valueIsZero)
+        {
+            status = EVMC_STORAGE_MODIFIED_DELETED;
+        }
+    }
+    else if (dirty && restored)
+    {
+        if (currentIsZero)
+        {
+            status = EVMC_STORAGE_DELETED_RESTORED;
+        }
+        else if (valueIsZero)
+        {
+            status = EVMC_STORAGE_ADDED_DELETED;
+        }
+        else
+        {
+            status = EVMC_STORAGE_MODIFIED_RESTORED;
+        }
+    }
+    return status;
+}
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/EthHost.hpp
+++ b/bcos-evm/eth/state/EthHost.hpp
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Lightweight evmc host over eth::state with extension hooks.
+ * @file EthHost.hpp
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/RevisionConfig.h"
+#include "bcos-evm/eth/state/BlockInfo.hpp"
+#include "bcos-evm/eth/state/State.hpp"
+#include "bcos-evm/eth/state/Transaction.hpp"
+#include "bcos-evm/eth/state/VmHostPolicy.h"
+#include <evmc/evmc.hpp>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace bcos::evm
+{
+struct ChainCallTargetPort;
+}
+
+namespace bcos::evm::state
+{
+class EthHost : public evmc::Host
+{
+public:
+    using address = evmc::address;
+    using bytes32 = evmc::bytes32;
+    using uint256be = evmc::uint256be;
+    using Result = evmc::Result;
+
+    EthHost(State& state, evmc_tx_context txContext,
+        bcos::evm_standard::RevisionConfig revisionConfig, evmc::VM& vm, BlockHashes blockHashes,
+        VmHostPolicy* extension = nullptr, bool fixStorageStatus = true,
+        ChainCallTargetPort* chainPort = nullptr);
+
+    bool account_exists(const address& addr) const noexcept final;
+    bytes32 get_storage(const address& addr, const bytes32& key) const noexcept final;
+    evmc_storage_status set_storage(
+        const address& addr, const bytes32& key, const bytes32& value) noexcept final;
+    uint256be get_balance(const address& addr) const noexcept final;
+    size_t get_code_size(const address& addr) const noexcept final;
+    bytes32 get_code_hash(const address& addr) const noexcept final;
+    size_t copy_code(const address& addr, size_t code_offset, uint8_t* buffer_data,
+        size_t buffer_size) const noexcept final;
+    bool selfdestruct(const address& addr, const address& beneficiary) noexcept final;
+    Result call(const evmc_message& msg) noexcept final;
+    evmc_tx_context get_tx_context() const noexcept final;
+    bytes32 get_block_hash(int64_t number) const noexcept final;
+    void emit_log(const address& addr, const uint8_t* data, size_t data_size,
+        const bytes32 topics[], size_t num_topics) noexcept final;
+    evmc_access_status access_account(const address& addr) noexcept final;
+    evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept final;
+    bytes32 get_transient_storage(const address& addr, const bytes32& key) const noexcept final;
+    void set_transient_storage(
+        const address& addr, const bytes32& key, const bytes32& value) noexcept final;
+    void set_execution_address(const evmc_address& address) noexcept
+    {
+        m_executionAddress = address;
+    }
+    evmc_address& execution_address_ref() noexcept { return m_executionAddress; }
+    void markCreatedInTx(evmc_address const& addr) noexcept;
+    [[nodiscard]] bool wasCreatedInTx(evmc_address const& addr) const noexcept;
+    std::vector<LogEntry> take_logs();
+
+private:
+    static evmc_storage_status classifyStorageStatus(const evmc_bytes32& oldValue,
+        const evmc_bytes32& currentValue, const evmc_bytes32& newValue,
+        bool fixStorageStatus) noexcept;
+
+    void destroyContractState(evmc_address const& addr) noexcept;
+
+private:
+    State& m_state;
+    evmc_tx_context m_txContext{};
+    bcos::evm_standard::RevisionConfig m_revisionConfig{};
+    evmc::VM& m_vm;
+    BlockHashes m_blockHashes;
+    VmHostPolicy* m_extension{nullptr};
+    ChainCallTargetPort* m_chainPort{nullptr};
+    std::unordered_map<std::pair<address, bytes32>, bytes32, WarmStorageKeyHash,
+        WarmStorageKeyEqual>
+        m_storageOriginalValues;
+    bool m_fixStorageStatus{true};
+    std::vector<LogEntry> m_logs;
+    evmc_address m_executionAddress{};
+    std::unordered_set<evmc_address, AddressHash, AddressEqual> m_createdInTx;
+};
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/EvmStateReader.hpp
+++ b/bcos-evm/eth/state/EvmStateReader.hpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Cold-state read abstraction consumed by execution State.
+ * @file EvmStateReader.hpp
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/state/Account.hpp"
+#include <optional>
+
+namespace bcos::evm::state
+{
+class EvmStateReader
+{
+public:
+    virtual ~EvmStateReader() = default;
+
+    virtual std::optional<Account> get_account(const evmc_address& address) const = 0;
+
+    [[nodiscard]] virtual bcos::u256 get_balance(const evmc_address& address) const
+    {
+        auto const account = get_account(address);
+        return account.has_value() ? account->balance : bcos::u256{0};
+    }
+
+    [[nodiscard]] virtual uint64_t get_nonce(const evmc_address& address) const
+    {
+        auto const account = get_account(address);
+        return account.has_value() ? account->nonce : 0;
+    }
+
+    [[nodiscard]] virtual bcos::bytes get_code(const evmc_address& address) const
+    {
+        auto const account = get_account(address);
+        return account.has_value() ? account->code : bcos::bytes{};
+    }
+
+    [[nodiscard]] virtual evmc_bytes32 get_code_hash(const evmc_address& address) const
+    {
+        auto const account = get_account(address);
+        return account.has_value() ? account->codeHash : evmc_bytes32{};
+    }
+
+    [[nodiscard]] virtual evmc_bytes32 get_storage(
+        const evmc_address& address, const evmc_bytes32& key) const
+    {
+        auto const account = get_account(address);
+        if (!account.has_value())
+        {
+            return {};
+        }
+        auto const it = account->storage.find(key);
+        if (it == account->storage.end())
+        {
+            return {};
+        }
+        return it->second;
+    }
+};
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/HashUtils.hpp
+++ b/bcos-evm/eth/state/HashUtils.hpp
@@ -1,0 +1,225 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Hash and conversion helpers for evmc address/bytes32 keys.
+ * @file HashUtils.hpp
+ */
+
+#pragma once
+
+#include "bcos-crypto/interfaces/crypto/CommonType.h"
+#include "bcos-utilities/DataConvertUtility.h"
+#include <evmc/evmc.h>
+#include <boost/container_hash/hash.hpp>
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <evmone_precompiles/keccak.hpp>
+#include <string_view>
+
+namespace bcos::evm::state
+{
+struct AddressHash
+{
+    size_t operator()(evmc_address const& address) const noexcept
+    {
+        return boost::hash_range(address.bytes, address.bytes + sizeof(address.bytes));
+    }
+};
+
+struct AddressEqual
+{
+    bool operator()(evmc_address const& lhs, evmc_address const& rhs) const noexcept
+    {
+        return std::memcmp(lhs.bytes, rhs.bytes, sizeof(lhs.bytes)) == 0;
+    }
+};
+
+struct Bytes32Hash
+{
+    size_t operator()(evmc_bytes32 const& value) const noexcept
+    {
+        return boost::hash_range(value.bytes, value.bytes + sizeof(value.bytes));
+    }
+};
+
+struct Bytes32Equal
+{
+    bool operator()(evmc_bytes32 const& lhs, evmc_bytes32 const& rhs) const noexcept
+    {
+        return std::memcmp(lhs.bytes, rhs.bytes, sizeof(lhs.bytes)) == 0;
+    }
+};
+
+inline bool isZeroAddress(const evmc_address& address) noexcept
+{
+    return std::all_of(std::begin(address.bytes), std::end(address.bytes),
+        [](uint8_t value) { return value == 0; });
+}
+
+inline bool isZeroBytes32(const evmc_bytes32& value) noexcept
+{
+    return std::all_of(
+        std::begin(value.bytes), std::end(value.bytes), [](uint8_t item) { return item == 0; });
+}
+
+inline evmc_bytes32 emptyCodeHash() noexcept
+{
+    evmc_bytes32 out{};
+    out.bytes[0] = 0xc5;
+    out.bytes[1] = 0xd2;
+    out.bytes[2] = 0x46;
+    out.bytes[3] = 0x01;
+    out.bytes[4] = 0x86;
+    out.bytes[5] = 0xf7;
+    out.bytes[6] = 0x23;
+    out.bytes[7] = 0x3c;
+    out.bytes[8] = 0x92;
+    out.bytes[9] = 0x7e;
+    out.bytes[10] = 0x7d;
+    out.bytes[11] = 0xb2;
+    out.bytes[12] = 0xdc;
+    out.bytes[13] = 0xc7;
+    out.bytes[14] = 0x03;
+    out.bytes[15] = 0xc0;
+    out.bytes[16] = 0xe5;
+    out.bytes[17] = 0x00;
+    out.bytes[18] = 0xb6;
+    out.bytes[19] = 0x53;
+    out.bytes[20] = 0xca;
+    out.bytes[21] = 0x82;
+    out.bytes[22] = 0x27;
+    out.bytes[23] = 0x3b;
+    out.bytes[24] = 0x7b;
+    out.bytes[25] = 0xfa;
+    out.bytes[26] = 0xd8;
+    out.bytes[27] = 0x04;
+    out.bytes[28] = 0x5d;
+    out.bytes[29] = 0x85;
+    out.bytes[30] = 0xa4;
+    out.bytes[31] = 0x70;
+    return out;
+}
+
+inline evmc_bytes32 keccak256Code(bcos::bytesConstRef code)
+{
+    if (code.empty())
+    {
+        return emptyCodeHash();
+    }
+    auto const hash = ethash::keccak256(code.data(), code.size());
+    evmc_bytes32 out{};
+    std::memcpy(out.bytes, hash.bytes, sizeof(out.bytes));
+    return out;
+}
+
+inline bcos::u256 fromEvmC(const evmc_bytes32& value)
+{
+    return fromBigEndian<bcos::u256>(value.bytes);
+}
+
+inline evmc_bytes32 toEvmC(const bcos::u256& value)
+{
+    evmc_bytes32 out{};
+    auto encoded = toBigEndian(value);
+    std::copy(encoded.begin(), encoded.end(), out.bytes);
+    return out;
+}
+
+inline evmc_bytes32 toEvmC(const bcos::crypto::HashType& value)
+{
+    evmc_bytes32 out{};
+    std::copy(value.begin(), value.end(), out.bytes);
+    return out;
+}
+
+inline uint8_t fromHexNibble(char value) noexcept
+{
+    auto lower = static_cast<char>(std::tolower(static_cast<unsigned char>(value)));
+    if (lower >= '0' && lower <= '9')
+    {
+        return static_cast<uint8_t>(lower - '0');
+    }
+    if (lower >= 'a' && lower <= 'f')
+    {
+        return static_cast<uint8_t>(10 + lower - 'a');
+    }
+    return 0xff;
+}
+
+inline evmc_address parseHexAddress(std::string_view value) noexcept
+{
+    if (value.starts_with("0x") || value.starts_with("0X"))
+    {
+        value.remove_prefix(2);
+    }
+    if (value.size() != sizeof(evmc_address) * 2)
+    {
+        return {};
+    }
+
+    evmc_address address{};
+    for (size_t index = 0; index < sizeof(evmc_address); ++index)
+    {
+        auto high = fromHexNibble(value[index * 2]);
+        auto low = fromHexNibble(value[index * 2 + 1]);
+        if (high == 0xff || low == 0xff)
+        {
+            return {};
+        }
+        address.bytes[index] = static_cast<uint8_t>((high << 4) | low);
+    }
+    return address;
+}
+
+inline void appendRlpUint64(bcos::bytes& out, uint64_t value)
+{
+    if (value == 0)
+    {
+        out.push_back(0x80);
+        return;
+    }
+    bcos::bytes encoded;
+    while (value > 0)
+    {
+        encoded.insert(encoded.begin(), static_cast<uint8_t>(value & 0xff));
+        value >>= 8;
+    }
+    if (encoded.size() == 1 && encoded[0] < 0x80)
+    {
+        out.push_back(encoded[0]);
+        return;
+    }
+    out.push_back(static_cast<uint8_t>(0x80 + encoded.size()));
+    out.insert(out.end(), encoded.begin(), encoded.end());
+}
+
+inline evmc_address predictLegacyCreateAddress(evmc_address const& sender, uint64_t nonce) noexcept
+{
+    bcos::bytes payload;
+    payload.push_back(0x94);
+    payload.insert(payload.end(), sender.bytes, sender.bytes + sizeof(sender.bytes));
+    appendRlpUint64(payload, nonce);
+
+    bcos::bytes rlp;
+    rlp.push_back(static_cast<uint8_t>(0xc0 + payload.size()));
+    rlp.insert(rlp.end(), payload.begin(), payload.end());
+
+    auto const hash = ethash::keccak256(rlp.data(), rlp.size());
+    evmc_address out{};
+    std::memcpy(out.bytes, hash.bytes + 12, sizeof(out.bytes));
+    return out;
+}
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/State.cpp
+++ b/bcos-evm/eth/state/State.cpp
@@ -1,0 +1,393 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file State.cpp
+ */
+
+#include "bcos-evm/eth/state/State.hpp"
+#include "bcos-evm/eth/state/HashUtils.hpp"
+
+namespace bcos::evm::state
+{
+State::State(EvmStateReader const& baseEvmStateReader) : m_baseStateView(&baseEvmStateReader) {}
+
+std::optional<Account> State::find(const evmc_address& address) const
+{
+    if (auto it = m_accounts.find(address); it != m_accounts.end())
+    {
+        return it->second;
+    }
+    return m_baseStateView->get_account(address);
+}
+
+std::optional<Account> State::get_account(const evmc_address& address) const
+{
+    return find(address);
+}
+
+bcos::u256 State::get_balance(const evmc_address& address) const
+{
+    auto const account = find(address);
+    return account.has_value() ? account->balance : bcos::u256{0};
+}
+
+uint64_t State::get_nonce(const evmc_address& address) const
+{
+    auto const account = find(address);
+    return account.has_value() ? account->nonce : 0;
+}
+
+bcos::bytes State::get_code(const evmc_address& address) const
+{
+    auto const account = find(address);
+    return account.has_value() ? account->code : bcos::bytes{};
+}
+
+evmc_bytes32 State::get_code_hash(const evmc_address& address) const
+{
+    auto const account = find(address);
+    if (!account.has_value())
+    {
+        return {};
+    }
+    if (account->code.empty())
+    {
+        return emptyCodeHash();
+    }
+    if (!isZeroBytes32(account->codeHash))
+    {
+        return account->codeHash;
+    }
+    return keccak256Code(bcos::bytesConstRef{account->code.data(), account->code.size()});
+}
+
+evmc_bytes32 State::get_storage(const evmc_address& address, const evmc_bytes32& key) const
+{
+    if (auto it = m_accounts.find(address); it != m_accounts.end())
+    {
+        if (auto storageIt = it->second.storage.find(key); storageIt != it->second.storage.end())
+        {
+            return storageIt->second;
+        }
+    }
+    return m_baseStateView->get_storage(address, key);
+}
+
+bool State::has_checkpoint() const noexcept
+{
+    return !m_checkpoints.empty();
+}
+
+void State::checkpoint()
+{
+    m_checkpoints.push_back({m_journal.size(), m_gasRefund, {}});
+}
+
+void State::commit()
+{
+    if (m_checkpoints.empty())
+    {
+        return;
+    }
+
+    if (m_checkpoints.size() >= 2)
+    {
+        auto top = std::move(m_checkpoints.back());
+        m_checkpoints.pop_back();
+        auto& parent = m_checkpoints.back();
+        for (auto const& address : top.touchedAccounts)
+        {
+            parent.touchedAccounts.insert(address);
+        }
+        return;
+    }
+
+    m_checkpoints.pop_back();
+}
+
+void State::revert()
+{
+    if (m_checkpoints.empty())
+    {
+        return;
+    }
+
+    auto const checkpoint = std::move(m_checkpoints.back());
+    m_checkpoints.pop_back();
+
+    while (m_journal.size() > checkpoint.journalSize)
+    {
+        auto const entry = std::move(m_journal.back());
+        m_journal.pop_back();
+        switch (entry.type)
+        {
+        case JournalType::AccountSnapshot:
+            if (entry.previousAccount.has_value())
+            {
+                m_accounts[entry.address] = *entry.previousAccount;
+            }
+            else
+            {
+                m_accounts.erase(entry.address);
+            }
+            break;
+        case JournalType::WarmAddressInsert:
+            if (!m_pinnedWarmAccounts.contains(entry.address))
+            {
+                m_warmAccounts.erase(entry.address);
+            }
+            break;
+        case JournalType::WarmStorageInsert:
+            m_warmStorage.erase({entry.address, entry.key});
+            break;
+        case JournalType::CreateWarmPinInsert:
+            m_pinnedWarmAccounts.erase(entry.address);
+            if (entry.pinInsertedWarm)
+            {
+                m_warmAccounts.erase(entry.address);
+            }
+            break;
+        }
+    }
+
+    m_gasRefund = checkpoint.gasRefund;
+}
+
+Account& State::mutable_account(const evmc_address& address)
+{
+    if (auto it = m_accounts.find(address); it != m_accounts.end())
+    {
+        return it->second;
+    }
+
+    auto account = m_baseStateView->get_account(address);
+    auto [it, _] = m_accounts.emplace(address, account.value_or(Account{}));
+    return it->second;
+}
+
+void State::push_journal_account(const evmc_address& address, std::optional<Account> previous)
+{
+    m_journal.push_back(
+        JournalEntry{JournalType::AccountSnapshot, address, evmc_bytes32{}, std::move(previous)});
+}
+
+void State::push_journal_warm_address(const evmc_address& address)
+{
+    m_journal.push_back(
+        JournalEntry{JournalType::WarmAddressInsert, address, evmc_bytes32{}, std::nullopt});
+}
+
+void State::push_journal_warm_storage(const evmc_address& address, const evmc_bytes32& key)
+{
+    m_journal.push_back(JournalEntry{JournalType::WarmStorageInsert, address, key, std::nullopt});
+}
+
+void State::push_journal_create_warm_pin(const evmc_address& address, bool insertedWarm)
+{
+    JournalEntry entry{};
+    entry.type = JournalType::CreateWarmPinInsert;
+    entry.address = address;
+    entry.pinInsertedWarm = insertedWarm;
+    m_journal.push_back(std::move(entry));
+}
+
+void State::journal_account_once(const evmc_address& address)
+{
+    if (m_checkpoints.empty())
+    {
+        return;
+    }
+
+    auto& checkpoint = m_checkpoints.back();
+    if (!checkpoint.touchedAccounts.insert(address).second)
+    {
+        return;
+    }
+
+    push_journal_account(address, find(address));
+}
+
+void State::set_balance(const evmc_address& address, const bcos::u256& balance)
+{
+    journal_account_once(address);
+    auto& account = mutable_account(address);
+    account.balance = balance;
+    account.balanceDirty = true;
+}
+
+void State::set_nonce(const evmc_address& address, uint64_t nonce)
+{
+    journal_account_once(address);
+    auto& account = mutable_account(address);
+    account.nonce = nonce;
+    account.nonceDirty = true;
+}
+
+void State::set_code(const evmc_address& address, bcos::bytes code, evmc_bytes32 codeHash)
+{
+    journal_account_once(address);
+    auto& account = mutable_account(address);
+    account.code = std::move(code);
+    account.codeHash = codeHash;
+    account.codeDirty = true;
+}
+
+void State::set_storage(
+    const evmc_address& address, const evmc_bytes32& key, const evmc_bytes32& value)
+{
+    auto const prior = get_storage(address, key);
+    if (Bytes32Equal{}(prior, value))
+    {
+        return;
+    }
+
+    journal_account_once(address);
+    mutable_account(address).storage[key] = value;
+}
+
+void State::clear_storage(const evmc_address& address)
+{
+    journal_account_once(address);
+    mutable_account(address).storage.clear();
+}
+
+void State::set_transient_storage(
+    const evmc_address& address, const evmc_bytes32& key, const evmc_bytes32& value)
+{
+    journal_account_once(address);
+    mutable_account(address).transientStorage[key] = value;
+}
+
+void State::clearAllTransientStorage()
+{
+    for (auto& [address, account] : m_accounts)
+    {
+        (void)address;
+        account.transientStorage.clear();
+    }
+}
+
+bool State::warm_up_address(const evmc_address& address)
+{
+    auto const inserted = m_warmAccounts.insert(address).second;
+    if (inserted && has_checkpoint())
+    {
+        push_journal_warm_address(address);
+    }
+    return inserted;
+}
+
+bool State::warm_up_storage(const evmc_address& address, const evmc_bytes32& key)
+{
+    auto const inserted = m_warmStorage.insert({address, key}).second;
+    if (inserted && has_checkpoint())
+    {
+        push_journal_warm_storage(address, key);
+    }
+    return inserted;
+}
+
+bool State::warm_up_address_no_journal(const evmc_address& address)
+{
+    return m_warmAccounts.insert(address).second;
+}
+
+bool State::warm_up_storage_no_journal(const evmc_address& address, const evmc_bytes32& key)
+{
+    return m_warmStorage.insert({address, key}).second;
+}
+
+void State::pin_warm_create_address(const evmc_address& address)
+{
+    bool const insertedWarm = m_warmAccounts.insert(address).second;
+    m_pinnedWarmAccounts.insert(address);
+    if (has_checkpoint())
+    {
+        push_journal_create_warm_pin(address, insertedWarm);
+    }
+}
+
+bool State::is_address_warm(const evmc_address& address) const
+{
+    return m_warmAccounts.contains(address);
+}
+
+bool State::is_storage_warm(const evmc_address& address, const evmc_bytes32& key) const
+{
+    return m_warmStorage.contains({address, key});
+}
+
+StateDiff State::build_diff() const
+{
+    StateDiff diff;
+    diff.accounts.reserve(m_accounts.size());
+    for (auto const& [address, account] : m_accounts)
+    {
+        Account persisted = account;
+        persisted.transientStorage.clear();
+        diff.accounts.emplace(address, std::move(persisted));
+    }
+    return diff;
+}
+
+void State::mark_self_destructed(const evmc_address& address)
+{
+    journal_account_once(address);
+    mutable_account(address).selfDestructed = true;
+}
+
+bool State::has_self_destructed(const evmc_address& address) const
+{
+    auto const account = find(address);
+    return account.has_value() && account->selfDestructed;
+}
+
+void State::finalize_self_destructs()
+{
+    for (auto& [address, account] : m_accounts)
+    {
+        if (!account.selfDestructed)
+        {
+            continue;
+        }
+        account.code.clear();
+        account.codeHash = {};
+        account.storage.clear();
+        account.balance = 0;
+        account.nonce = 0;
+        account.selfDestructed = false;
+    }
+}
+
+void State::add_refund(uint64_t amount)
+{
+    m_gasRefund += amount;
+}
+
+void State::sub_refund(uint64_t amount)
+{
+    m_gasRefund = (m_gasRefund >= amount) ? (m_gasRefund - amount) : 0;
+}
+
+uint64_t State::get_refund() const noexcept
+{
+    return m_gasRefund;
+}
+
+void State::clear_refund() noexcept
+{
+    m_gasRefund = 0;
+}
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/State.hpp
+++ b/bcos-evm/eth/state/State.hpp
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Execution-state journal with checkpoint/revert and EIP-2929 access tracking.
+ * @file State.hpp
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/state/EvmStateReader.hpp"
+#include "bcos-evm/eth/state/StateDiff.hpp"
+#include <optional>
+#include <unordered_set>
+#include <vector>
+
+namespace bcos::evm::state
+{
+struct WarmStorageKeyHash
+{
+    size_t operator()(std::pair<evmc_address, evmc_bytes32> const& value) const noexcept
+    {
+        size_t hash = AddressHash{}(value.first);
+        boost::hash_combine(hash, Bytes32Hash{}(value.second));
+        return hash;
+    }
+};
+
+struct WarmStorageKeyEqual
+{
+    bool operator()(std::pair<evmc_address, evmc_bytes32> const& lhs,
+        std::pair<evmc_address, evmc_bytes32> const& rhs) const noexcept
+    {
+        return AddressEqual{}(lhs.first, rhs.first) && Bytes32Equal{}(lhs.second, rhs.second);
+    }
+};
+
+class State : public EvmStateReader
+{
+public:
+    explicit State(EvmStateReader const& baseEvmStateReader);
+
+    [[nodiscard]] std::optional<Account> get_account(const evmc_address& address) const override;
+    [[nodiscard]] bcos::u256 get_balance(const evmc_address& address) const override;
+    [[nodiscard]] uint64_t get_nonce(const evmc_address& address) const override;
+    [[nodiscard]] bcos::bytes get_code(const evmc_address& address) const override;
+    [[nodiscard]] evmc_bytes32 get_code_hash(const evmc_address& address) const override;
+    [[nodiscard]] evmc_bytes32 get_storage(
+        const evmc_address& address, const evmc_bytes32& key) const override;
+    [[nodiscard]] std::optional<Account> find(const evmc_address& address) const;
+
+    void checkpoint();
+    void revert();
+    void commit();
+    [[nodiscard]] bool has_checkpoint() const noexcept;
+
+    void set_balance(const evmc_address& address, const bcos::u256& balance);
+    void set_nonce(const evmc_address& address, uint64_t nonce);
+    void set_code(const evmc_address& address, bcos::bytes code, evmc_bytes32 codeHash);
+    void set_storage(
+        const evmc_address& address, const evmc_bytes32& key, const evmc_bytes32& value);
+    void clear_storage(const evmc_address& address);
+    void set_transient_storage(
+        const evmc_address& address, const evmc_bytes32& key, const evmc_bytes32& value);
+    /// Clears in-memory transient slots for all overlay accounts (geth Prepare parity).
+    void clearAllTransientStorage();
+
+    [[nodiscard]] bool warm_up_address(const evmc_address& address);
+    [[nodiscard]] bool warm_up_storage(const evmc_address& address, const evmc_bytes32& key);
+    [[nodiscard]] bool warm_up_address_no_journal(const evmc_address& address);
+    [[nodiscard]] bool warm_up_storage_no_journal(
+        const evmc_address& address, const evmc_bytes32& key);
+    void pin_warm_create_address(const evmc_address& address);
+    [[nodiscard]] bool is_address_warm(const evmc_address& address) const;
+    [[nodiscard]] bool is_storage_warm(const evmc_address& address, const evmc_bytes32& key) const;
+
+    [[nodiscard]] StateDiff build_diff() const;
+
+    void mark_self_destructed(const evmc_address& address);
+    [[nodiscard]] bool has_self_destructed(const evmc_address& address) const;
+    void finalize_self_destructs();
+
+    void add_refund(uint64_t amount);
+    void sub_refund(uint64_t amount);
+    [[nodiscard]] uint64_t get_refund() const noexcept;
+    void clear_refund() noexcept;
+
+private:
+    enum class JournalType : uint8_t
+    {
+        AccountSnapshot,
+        WarmAddressInsert,
+        WarmStorageInsert,
+        CreateWarmPinInsert,
+    };
+
+    struct JournalEntry
+    {
+        JournalType type{JournalType::AccountSnapshot};
+        evmc_address address{};
+        evmc_bytes32 key{};
+        std::optional<Account> previousAccount;
+        /// True when pin_warm_create_address inserted into m_warmAccounts.
+        bool pinInsertedWarm{false};
+    };
+
+    struct Checkpoint
+    {
+        size_t journalSize{0};
+        uint64_t gasRefund{0};
+        std::unordered_set<evmc_address, AddressHash, AddressEqual> touchedAccounts;
+    };
+
+    Account& mutable_account(const evmc_address& address);
+    void journal_account_once(const evmc_address& address);
+    void push_journal_account(const evmc_address& address, std::optional<Account> previous);
+    void push_journal_warm_address(const evmc_address& address);
+    void push_journal_warm_storage(const evmc_address& address, const evmc_bytes32& key);
+    void push_journal_create_warm_pin(const evmc_address& address, bool insertedWarm);
+
+private:
+    EvmStateReader const* m_baseStateView;
+    std::unordered_map<evmc_address, Account, AddressHash, AddressEqual> m_accounts;
+    std::unordered_set<evmc_address, AddressHash, AddressEqual> m_warmAccounts;
+    std::unordered_set<evmc_address, AddressHash, AddressEqual> m_pinnedWarmAccounts;
+    std::unordered_set<std::pair<evmc_address, evmc_bytes32>, WarmStorageKeyHash,
+        WarmStorageKeyEqual>
+        m_warmStorage;
+    std::vector<JournalEntry> m_journal;
+    std::vector<Checkpoint> m_checkpoints;
+    uint64_t m_gasRefund{0};
+};
+
+inline void installCreatedContractCode(
+    State& state, const evmc_message& message, const evmc_result& result)
+{
+    if (result.status_code != EVMC_SUCCESS || result.output_size == 0 ||
+        result.output_data == nullptr)
+    {
+        return;
+    }
+    if (message.kind != EVMC_CREATE && message.kind != EVMC_CREATE2)
+    {
+        return;
+    }
+
+    auto createAddr = message.recipient;
+    if (isZeroAddress(createAddr))
+    {
+        createAddr = message.code_address;
+    }
+    if (isZeroAddress(createAddr))
+    {
+        createAddr = result.create_address;
+    }
+    if (isZeroAddress(createAddr))
+    {
+        return;
+    }
+
+    bcos::bytes code(result.output_data, result.output_data + result.output_size);
+    state.set_code(createAddr, std::move(code), {});
+}
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/StateDiff.hpp
+++ b/bcos-evm/eth/state/StateDiff.hpp
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief State mutation set to be applied after successful execution.
+ * @file StateDiff.hpp
+ */
+
+#pragma once
+
+#include "bcos-evm/eth/state/Account.hpp"
+#include <unordered_map>
+
+namespace bcos::evm::state
+{
+struct StateDiff
+{
+    std::unordered_map<evmc_address, Account, AddressHash, AddressEqual> accounts;
+
+    [[nodiscard]] bool empty() const noexcept { return accounts.empty(); }
+};
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/Transaction.hpp
+++ b/bcos-evm/eth/state/Transaction.hpp
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Lightweight transaction/request model for execution entry points.
+ * @file Transaction.hpp
+ */
+
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <evmc/evmc.h>
+#include <optional>
+#include <vector>
+
+namespace bcos::evm::state
+{
+struct Transaction
+{
+    evmc_address from{};
+    std::optional<evmc_address> to;
+    bcos::bytes data;
+    bcos::u256 value{0};
+    bcos::u256 gasPrice{0};
+    int64_t gasLimit{0};
+    uint64_t nonce{0};
+};
+
+struct TransactionProperties
+{
+    bool isStatic{false};
+    bool warmCoinbase{true};
+    bool warmDestination{true};
+};
+
+struct LogEntry
+{
+    evmc_address address{};
+    bcos::bytes data;
+    std::vector<evmc_bytes32> topics;
+};
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/state/VmHostPolicy.h
+++ b/bcos-evm/eth/state/VmHostPolicy.h
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief EthHost policy hooks for FISCO vs eth vector execution (spec §5.3, §7.1)
+ * @file VmHostPolicy.h
+ */
+
+#pragma once
+
+#include <evmc/evmc.h>
+
+namespace bcos::evm::state
+{
+struct Account;
+
+/// Injectable policy for EthHost extension points (Hook#3–6, #8 via FiscoVmHostPolicy).
+/// Chain precompile dispatch is via `ChainCallTargetPort` on FrameContext (ADR-024).
+struct VmHostPolicy
+{
+    virtual ~VmHostPolicy() = default;
+
+    virtual bool allowSelfdestruct(const Account& acc) { return true; }
+    virtual bool allowDelegateCallToPrecompile() { return true; }
+    virtual bool skipHostValueTransfer() { return false; }
+
+    virtual void prepareMessage(evmc_revision rev, evmc_message& msg)
+    {
+        (void)rev;
+        (void)msg;
+    }
+
+    virtual void setCallerAddress(const evmc_address& caller) { (void)caller; }
+
+    virtual void bumpContractCreateNonce(const evmc_address& contractAddress)
+    {
+        (void)contractAddress;
+    }
+};
+}  // namespace bcos::evm::state

--- a/bcos-evm/eth/vm/VMFactory.h
+++ b/bcos-evm/eth/vm/VMFactory.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief factory of vm
+ * @file VMFactory.h
+ * @author: ancelmo
+ * @date: 2022-12-15
+ */
+
+#pragma once
+#include "VMInstance.h"
+#include "bcos-utilities/BoostLog.h"
+#include "bcos-utilities/Error.h"
+#include "bcos-utilities/Exceptions.h"
+#include <evmone/evmone.h>
+#include <boost/throw_exception.hpp>
+#include <memory>
+
+namespace bcos::evm
+{
+enum class VMKind
+{
+    evmone,
+};
+
+DERIVE_BCOS_EXCEPTION(UnknownVMError);
+
+class VMFactory
+{
+public:
+    static VMInstance create(VMKind kind, bytesConstRef code)
+    {
+        switch (kind)
+        {
+        case VMKind::evmone:
+        {
+            // FIB-95: wrap analyze() in try/catch to prevent unhandled exceptions
+            try
+            {
+                return VMInstance{std::make_shared<EvmoneCodeAnalysis>(evmone::baseline::analyze(
+                    evmone::bytes_view((const uint8_t*)code.data(), code.size())))};
+            }
+            catch (const std::exception& e)
+            {
+                BCOS_LOG(ERROR) << LOG_BADGE("VM") << "Failed to analyze bytecode: " << e.what();
+                BOOST_THROW_EXCEPTION(UnknownVMError{});
+            }
+        }
+        default:
+            BOOST_THROW_EXCEPTION(UnknownVMError{});
+        }
+    }
+};
+}  // namespace bcos::evm

--- a/bcos-evm/eth/vm/VMInstance.cpp
+++ b/bcos-evm/eth/vm/VMInstance.cpp
@@ -1,0 +1,43 @@
+#include "VMInstance.h"
+#include <evmone/evmone.h>
+#include <evmone/vm.hpp>
+
+bcos::evm::VMInstance::VMInstance(std::shared_ptr<EvmoneCodeAnalysis const> analysis) noexcept
+  : m_analysis(std::move(analysis))
+{
+    assert(m_analysis != nullptr);
+}
+
+bcos::evm::EVMCResult bcos::evm::VMInstance::execute(const struct evmc_host_interface* host,
+    struct evmc_host_context* context, evmc_revision rev, const evmc_message* msg,
+    const uint8_t* code, size_t codeSize)
+{
+    (void)code;  // execute uses pre-analyzed m_analysis
+    (void)codeSize;
+    // Reuse thread_local VM: evmone 0.21 ExecutionState::reset() clears all critical fields
+    // (gas_refund, memory, msg, host, rev, return_data, status). The 0.11-era dirty-stack bug
+    // (EVMC_BAD_JUMP_DESTINATION) was fixed in 0.21. Internal ExecutionState pool grows to max
+    // nesting depth then stops allocating — eliminating per-call malloc/free.
+    thread_local evmc::VM t_vm{evmc_create_evmone()};
+    return EVMCResult(evmone::baseline::execute(
+        *static_cast<evmone::VM*>(t_vm.get_raw_pointer()), *host, context, rev, *msg, *m_analysis));
+}
+
+std::strong_ordering operator<=>(const evmc_address& lhs, const evmc_address& rhs) noexcept
+{
+    return std::memcmp(lhs.bytes, rhs.bytes, sizeof(evmc_address)) <=> 0;
+}
+bool operator==(const evmc_address& lhs, const evmc_address& rhs) noexcept
+{
+    return std::is_eq(lhs <=> rhs);
+}
+bool std::equal_to<evmc_address>::operator()(
+    const evmc_address& lhs, const evmc_address& rhs) const noexcept
+{
+    return lhs == rhs;
+}
+size_t std::hash<evmc_address>::operator()(const evmc_address& address) const noexcept
+{
+    std::span view(address.bytes);
+    return boost::hash_range(view.begin(), view.end());
+}

--- a/bcos-evm/eth/vm/VMInstance.h
+++ b/bcos-evm/eth/vm/VMInstance.h
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief c++ wrapper of vm
+ * @file VMInstance.h
+ * @author: xingqiangbai
+ * @date: 2021-05-24
+ * @author: ancelmo
+ * @date: 2023-3-3
+ */
+
+#pragma once
+#include "bcos-evm/eth/EVMCResult.h"
+#include <bcos-utilities/Common.h>
+#include <compare>
+#include <evmc/evmc.hpp>
+#include <evmone/baseline.hpp>
+#include <memory>
+
+namespace bcos::evm
+{
+
+using EvmoneCodeAnalysis = evmone::baseline::CodeAnalysis;
+
+/// RAII wrapper: cached baseline analysis + fresh evmc::VM per execute (see VMInstance.cpp).
+class VMInstance
+{
+public:
+    explicit VMInstance(std::shared_ptr<EvmoneCodeAnalysis const> analysis) noexcept;
+    ~VMInstance() noexcept = default;
+
+    VMInstance(VMInstance const&) = delete;
+    VMInstance(VMInstance&&) noexcept = default;
+    VMInstance& operator=(VMInstance const&) = delete;
+    VMInstance& operator=(VMInstance&&) noexcept = default;
+
+    EVMCResult execute(const struct evmc_host_interface* host, struct evmc_host_context* context,
+        evmc_revision rev, const evmc_message* msg, const uint8_t* code, size_t codeSize);
+
+private:
+    std::shared_ptr<EvmoneCodeAnalysis const> m_analysis;
+};
+
+}  // namespace bcos::evm
+
+std::strong_ordering operator<=>(const evmc_address& lhs, const evmc_address& rhs) noexcept;
+bool operator==(const evmc_address& lhs, const evmc_address& rhs) noexcept;
+template <>
+struct std::equal_to<evmc_address>
+{
+    bool operator()(const evmc_address& lhs, const evmc_address& rhs) const noexcept;
+};
+template <>
+struct std::hash<evmc_address>
+{
+    size_t operator()(const evmc_address& address) const noexcept;
+};

--- a/bcos-evm/opstack/OpStackOrchestrationProfile.cpp
+++ b/bcos-evm/opstack/OpStackOrchestrationProfile.cpp
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OpStackOrchestrationProfile.cpp
+ */
+
+#include "bcos-evm/opstack/OpStackOrchestrationProfile.h"
+
+namespace bcos::evm
+{
+
+OpStackPrecheckPolicy OpStackOrchestrationProfile::buildPrecheckPolicy(BindingsContext& bindingsCtx)
+{
+    return OpStackPrecheckPolicy{bindingsCtx.view};
+}
+
+OpStackOrchestrationErrorPolicy OpStackOrchestrationProfile::buildErrorPolicy(
+    BindingsContext const& /*bindingsCtx*/)
+{
+    return OpStackOrchestrationErrorPolicy{};
+}
+
+OpStackOrchestrationProfile::Bindings OpStackOrchestrationProfile::bind(
+    BindingsContext& bindingsCtx)
+{
+    return Bindings{buildPrecheckPolicy(bindingsCtx), buildErrorPolicy(bindingsCtx)};
+}
+
+}  // namespace bcos::evm

--- a/bcos-evm/opstack/OpStackOrchestrationProfile.h
+++ b/bcos-evm/opstack/OpStackOrchestrationProfile.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OpStackOrchestrationProfile.h
+ */
+
+#pragma once
+
+#include "bcos-evm/opstack/OpStackExecutionBridge.h"
+#include "bcos-evm/opstack/OpStackOrchestrationErrorPolicy.h"
+#include "bcos-evm/opstack/OpStackPrecheckPolicy.h"
+#include "bcos-evm/opstack/OpStackSettlementView.h"
+
+namespace bcos::evm
+{
+
+struct OpStackOrchestrationProfile
+{
+    /// Orchestration policy bind input (not kernel ExecutionSession; ADR-027 naming follow-up).
+    struct BindingsContext
+    {
+        OpStackExecutionRequest const& input;
+        OpStackSettlementView view;
+    };
+
+    struct Bindings
+    {
+        OpStackPrecheckPolicy precheckPolicy;
+        OpStackOrchestrationErrorPolicy errorPolicy;
+    };
+
+    static OpStackPrecheckPolicy buildPrecheckPolicy(BindingsContext& bindingsCtx);
+    static OpStackOrchestrationErrorPolicy buildErrorPolicy(BindingsContext const& bindingsCtx);
+    static Bindings bind(BindingsContext& bindingsCtx);
+};
+
+}  // namespace bcos::evm

--- a/bcos-evm/opstack/Placeholder.cpp
+++ b/bcos-evm/opstack/Placeholder.cpp
@@ -1,0 +1,8 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+namespace bcos::evm::opstack
+{
+void opStackOrchestrationPlaceholder() {}
+}  // namespace bcos::evm::opstack


### PR DESCRIPTION
# bcos-evm 模块设计文档

**版本：** 2026-07-08 · **分支：** `feat-evm-refactor`

> 本文档描述 `bcos-evm` 目标架构。本 PR（PR-0/6）仅落地三库 CMake 骨架与 Port/Profile 头文件契约，完整实现见后续 PR-1~6 及 feat 分支。

**一句话：** 将 FISCO-BCOS 的 EVM 执行从 executor 耦合代码中抽离为独立模块；**共享内核**（`bcos-evm-eth`）统一提供 `stateTransitionExecute` 8 步交易管线、`innerExecute`/`runCallFrame` 帧执行、evmone Host、`RevisionConfig` EIP 开关与 `PrecompileRouter` 标准预编译路由，三链（FISCO / ETH 参考 / OP Stack）仅在外壳层注入 Hooks 与 Port。

**不在范围内：** 区块调度、共识、TxPool、legacy `bcos-executor`/DAG/`HostContext`、JSON-RPC receipt 暴露；这些由 TE/scheduler 负责，`bcos-evm` 只处理单笔交易的 EVM 执行与链编排。

---

## 1. 为何构建这个模块

重构前，EVM 执行逻辑散落在 `bcos-executor`、`transaction-executor` 和各类 Host 适配里，带来四个根本问题：

1. **标准语义与链定制纠缠** — FISCO 权限表、精编译、21000 gas 等与标准 EVM opcode 语义混在同一调用栈。
2. **编译期强耦合** — 执行层直接 `#include` executor 精编译，无法独立测试与合规回归。
3. **多链需求缺乏边界** — 同一仓库要跑 FISCO、ETH 参考、OP Stack，但没有清晰的「共享什么、定制什么」契约。
4. **EIP 开关难以审计** — revision 和 feature flag 在多处重复推导，旧链向前兼容无法系统化证明。

`bcos-evm` 的解法：**抽出一个与链无关的标准 EVM 内核，把三条链的差异放到可注入的外壳里**。

---

## 2. 核心设计原理

**硬规则：** `eth/` 永远不能 `#include` `bcos/` 或 `opstack/`。链差异只能**注入**，不能**渗透**进内核。

### 2.1 一个内核，三套外壳

内核（`eth/` 中 L1–L3 部分）负责 evmc 语义下的状态变更；链外壳（L4：`eth/apply/` ETH 参考、`bcos/`、`opstack/`）负责预检、扣费、receipt 与链专属 CALL 目标。详见 §3.1。

### 2.2 四类扩展点

| 扩展点 | 触发时机 | 典型用途 |
| --- | --- | --- |
| `StateTransitionHooks` | pipeline 第 1–5 步（EVM 入口前） | message 规范化、规则校验、intrinsic 策略、余额/转账 precheck |
| `StateTransitionErrorPolicy` | intrinsic 失败、异常 catch、EVM 返回后、pipeline 出口 | 异常 → `EVMCResult` 映射、included-vmerr 归一化、链特有 receipt 语义 |
| `EvmHostHooks` | evmone 调用树内部（`runCallFrame`） | selfdestruct、value transfer、SSTORE refund、CREATE nonce |
| `ChainCallTargetPort` | CALL 分类与 dispatch | FISCO 精编译、OP L1Block 等链专属目标 |

`StateTransitionHooks` 决定「能不能跑、怎么跑」；`StateTransitionErrorPolicy` 决定「失败了怎么对外呈现」（`TransactionStatus`、`gas_left`、revert logs、state revert）。二者成对经 `*StateTransitionBindings::bind()` 注入；详见 §3.8。

链外壳通过 `*StateTransitionBindings::bind()` 填充 hooks/errorPolicy；Host 通过 `FiscoEvmHostHooks` 等子类或 `nullptr`（OP）注入。

### 2.3 Port 依赖倒置

`bcos-evm` 只定义纯虚接口 **`AuthPort`**、**`ChainCallTargetPort`**。FISCO 精编译 dispatch 由 TE 的 `ExecutorPrecompileAdapter` 实现并注入；`FiscoChainCallTargetAdapter` 负责 classify 与路由。`eth/` 内核零 executor include；`bcos/` 策略层仍有少量 TE 头文件依赖待清理。

### 2.4 EIP 开关单一推导

`RevisionConfig`（14 bool + fork 参数）由 `revisionConfigFromRevision(rev)` 唯一推导；FISCO 对 A 类 EIP 再用 `Features::Flag` 掩码。预编译 warm 与 dispatch 共用 `PrecompileActive.h`。

### 2.5 深 module

- **`stateTransitionExecute`** — 8 步 canonical pipeline（normalize → rules → gasAffordable → intrinsic → canTransfer → invoke → adopt → finalizeGasUsed；RAII `onComplete`）
- **`innerExecute`** — tx 级 warm、7702 授权、nonce bump；`depth==0` 时进入 TopLevel 帧
- **`runCallFrame`** — 帧语义由显式 `FrameScope`（TopLevel/Nested）驱动，不隐式依赖 depth

`ctx.message` 是 intrinsic gas 扣减的**唯一可变 owner**。

---

## 3. 分层模型

### 3.1 总览与 CMake 对应

概念分层与物理库对照：

| 概念层 | 目录 / 目标 | 说明 |
| --- | --- | --- |
| L4 链外壳 | `bcos/` → `bcos-evm-bcos` | FISCO 生产（`bcos-evm` 默认 alias） |
| L4 链外壳 | `opstack/` → `bcos-evm-op` | OP Stack |
| L4 链外壳 | `eth/apply/` + `eth/settlement/` | ETH 参考路径（与内核**同库** `bcos-evm-eth`） |
| L3 共享编排 | `eth/kernel/state-transition/` | `stateTransitionExecute` |
| L2 执行内核 | `eth/kernel/execution/` + `eth/host/` + `eth/vm/` | `innerExecute` / `runCallFrame` / evmone |
| L1 协议状态 | `eth/eip/` · `eth/gas/` · `eth/precompiled/` · `eth/state/` | EIP、gas、预编译、Journal State |
| L0 基础设施 | evmone · `bcos-framework` · `bcos-evm-storage` | storage 库仅 FISCO 链链接 |

```text
┌─────────────────────────────────────────────────────────────────────────────┐
│ L4  链编排外壳                                                               │
│     bcos/  FISCO ── bcos-evm-bcos                                           │
│     opstack/  OP Stack ── bcos-evm-op                                       │
│     eth/apply/ + eth/settlement/  ETH 参考 ── 同库 bcos-evm-eth              │
├─────────────────────────────────────────────────────────────────────────────┤
│ L3  stateTransitionExecute（8 步管线）← StateTransitionHooks / ErrorPolicy  │
├─────────────────────────────────────────────────────────────────────────────┤
│ L2  innerExecute → runCallFrame → evmone                                    │
│     ← EvmHostHooks + ChainCallTargetPort                                    │
├─────────────────────────────────────────────────────────────────────────────┤
│ L1  RevisionConfig · EIP · gas · PrecompileRouter · State/Journal            │
├─────────────────────────────────────────────────────────────────────────────┤
│ L0  evmone · bcos-framework · bcos-evm-storage (LedgerStateView)            │
└─────────────────────────────────────────────────────────────────────────────┘
         ▲                    ▲                         ▲
         │ AuthPort           │ EthEvmHostHooks           │ OpStackChainCallTargetAdapter
         │ ChainCallTargetPort│ callTargetPort=null       │ extension=nullptr
         └──── transaction-executor 适配层（运行期注入）────────────────────────┘
```

### 3.2 L1 — 协议与状态层

| 子层 | 能力 |
| --- | --- |
| `RevisionConfig` | 14 EIP bool；A 类 7 字段 FISCO feature 掩码，B 类 fork 推导，C 类 fork 参数 |
| `eth/eip/` | 1559、2929、4844、7623、7702 等单 EIP 实现 |
| `eth/gas/` | intrinsic、refund cap、fee projection（State-free 算术） |
| `eth/precompiled/` | `PrecompileActive` warm+dispatch 单源；`PrecompileRouter` envelope |
| `eth/state/` | `StateView`（冷读）→ `State`（Journal overlay）→ `StateDiff`（输出 TE） |

### 3.3 L2 — 执行内核

| 组件 | 能力 |
| --- | --- |
| `innerExecute` | tx-entry warm、7702 auth、nonce bump、selfdestruct 收尾 |
| `runCallFrame` | TopLevel/Nested；routing → bytecode → value → CREATE → evmone |
| `EthHost` | evmc host：storage/balance/call/log/selfdestruct |
| `CallTargetResolver` | EOA / 合约 / builtin precompile / chain precompile |

**注入 seam（完整虚表见 `StateTransitionHooks.h` / `EvmHostHooks.h`）：**

```text
StateTransitionHooks          StateTransitionErrorPolicy   EvmHostHooks
· getIntrinsicGasParams       · onIntrinsicGasFailure      · allowSelfdestruct
· onNormalizeMessage          · onException                · skipHostValueTransfer
· onPreCheckRules             · onFinalizeGasUsed          · prepareMessage
· onPreCheckGasAffordable     · onComplete                 · applySstoreRefund / …
· onPreCheckCanTransfer                                    ChainCallTargetPort
· onTuneInnerExecuteInput                                  · classifyTarget / dispatch
· onInvokeInnerExecute
```

### 3.4 L4 — ETH 参考路径（`eth/apply/`）

| 组件 | 能力 |
| --- | --- |
| `applyEthMessage` | buyGas（pipeline 外）→ bind → `stateTransitionExecute` → refund |
| `EthStateTransitionHooks` | 1559 cap、7702/4844 规则；7623 经 `IntrinsicGasMode::FloorDataGas` |
| `EthEvmHostHooks` | 空子类，基类默认 = 标准以太坊 |
| `ChainCallTargetPort` | **nullptr** |

### 3.5 L4 — FISCO 外壳（`bcos/`）

**编排层：**

| 能力 | 机制 |
| --- | --- |
| 权限检查 | `FiscoStateTransitionHooks::onPreCheckRules` → `AuthPort::checkAuth`（需 `enable_auth_check`） |
| 21000 gas | **非 7623 路径**：`onPreCheckCanTransfer` 扣 `BALANCE_TRANSFER_GAS`；7623 启用走 intrinsic floor |
| CREATE 地址 | 顶层 `onNormalizeMessage`；嵌套 `FiscoEvmHostHooks::prepareMessage` |
| 费用 / 错误 | `FiscoTxFeeSettlement`；`FiscoStateTransitionErrorPolicy`（`fix_error_handling` 等） |

**Host 层（`FiscoEvmHostHooks`，多数覆写受 bugfix flag 门控）：**

| 覆写 | 行为 |
| --- | --- |
| `allowSelfdestruct` / `allowDelegateCallToPrecompile` | 恒 `false` |
| `skipHostValueTransfer` | `enable_balance_transfer` 时 true |
| `onCreateTargetInitialized` | `AuthPort::createAuthTable` |
| `applySstoreRefund` / `classifyStorageStatus` | `fix_storage_status` ON → 标准 EIP-3529；OFF → legacy |
| `bumpContractCreateNonce` / `finalizeTopLevelCreateNonce` | web3Tx 或 `fix_nonce_init` 等条件下持久化 |

**Call target：**

| 机制 | 能力 |
| --- | --- |
| `FiscoChainCallTargetAdapter` | classify `0x1000+` / `[PRECOMPILED]` |
| TE `ExecutorPrecompileAdapter` | `ChainCallTargetPort` dispatch（运行期注入） |

**`FiscoRevisionConfig` overlay：** 8 个 bugfix bool（`fix_storage_status` … `fix_precompiled_feature_gate`）+ 5 个链行为 bool（`enable_balance_transfer`、`use_raw_address` 等），包裹内嵌 `RevisionConfig ethConfig`。

```text
applyFiscoMessage
  ├─ FiscoExecutionBundle
  │    ├─ FiscoEvmHostHooks
  │    ├─ FiscoChainCallTargetAdapter
  │    └─ AuthPort* / ChainCallTargetPort*（TE 注入）
  └─ FiscoStateTransitionBindings::bind() → stateTransitionExecute → …
```

### 3.6 L4 — OP Stack 外壳（`opstack/`）

Lifecycle **内联在 `applyOpStackMessage`**（无独立 `runOpStackTxLifecycle` 符号）：

```text
applyOpStackMessage
  ├─ bind(ctx) + lifecycleCheckEntryRules   ← pipeline 外；失败则 earlyExit，不进 stateTransitionExecute
  ├─ acquireGasPool
  └─ deposit: mint → checkpoint → stateTransitionExecute → settleDeposit
     normal:  buyGas → checkpoint → stateTransitionExecute → completeAfterPipeline
```

| 能力 | 机制 |
| --- | --- |
| Blob precheck | `lifecycleCheckEntryRules` 内 `OpStackBlobTxChecks` |
| Floor gas | pipeline 内 `onPreCheckGasAffordable` + `OpStackFloorGas` |
| L1 cost / operator fee | `RollupCost`、`OpStackFeeSettlement` |
| Call target | `OpStackChainCallTargetAdapter`（L1Block、GasPriceOracle） |
| Host | **`extension = nullptr`**（内核 null-check 走标准以太坊语义；与 ETH 的实例接线不同） |
| Revision | TE：`makeOpStackRevisionConfigFromBlock(header, features)`；无块上下文时默认 `makeIsthmusRevisionConfig()`（= `revisionConfigFromRevision(EVMC_PRAGUE)`） |

### 3.7 三链扩展对照

| 扩展 seam | ETH 参考 | FISCO | OP Stack |
| --- | --- | --- | --- |
| `StateTransitionHooks` | 1559/7702/4844 `onPreCheckRules`；7623 intrinsic；余额检查 | CREATE normalize；Auth `onPreCheckRules`；21000/7623 `onPreCheckCanTransfer` | **`lifecycleCheckEntryRules`**（pipeline 外）；floor `onPreCheckGasAffordable` |
| `StateTransitionErrorPolicy` | ADR-015 included-vmerr；EIP-7702 set-code 特殊 | `fix_error_handling` 双轨；`NotFoundCodeError` | deposit/REVERT 特殊；其余 vmerr 部分 ADR-015 |
| `EvmHostHooks` | `EthEvmHostHooks` 实例（基类默认） | `FiscoEvmHostHooks`（bugfix 门控覆写） | **`nullptr`** |
| `ChainCallTargetPort` | null | `FiscoChainCallTargetAdapter` + TE `ExecutorPrecompileAdapter` | `OpStackChainCallTargetAdapter` |
| `AuthPort` | 无 | TE 注入 | 无 |
| Lifecycle 外圈 | buyGas 在 `applyEthMessage` 内 | buyGas/refund 在 **TE Execute**（`fix_gas_precheck` 时；非 apply 内） | **`applyOpStackMessage` 内联**（gasPool + settlement） |
| `RevisionConfig` | 块高 → 主网 fork | derive + A 类 flag 掩码（revision 下限 CANCUN） | Isthmus = Prague dense |

**重要：** ETH 参考路径测通 ≠ FISCO/OP 生产路径测通。

### 3.8 错误处理设计（`StateTransitionErrorPolicy`）

#### 3.8.1 要解决的问题

ADR-019 将三链收敛到共享 `stateTransitionExecute` 后，仍有一块**链相关**逻辑不能写进内核：

- intrinsic gas 扣费失败 → 填什么 `EVMCResult` / `TransactionStatus` / `gas_left`
- precheck 或 pipeline 内抛出的 C++ 异常 → 映射成什么 EVM status、是否 revert state
- EVM 执行完成后 → included-vmerr 是否归一化、CREATE 地址如何回填、revert logs 是否清理

重构前这些规则散落在各链 `apply*Message` wrapper 的 `mapIntrinsicFailure` / `mapException` lambda 中。`StateTransitionErrorPolicy` 将这条 **错误映射 seam** 抽为可注入、可单测的虚接口，使 `StateTransitionExecute.cpp` 保持链无关。

实现文件：

| 层级 | 文件 |
| --- | --- |
| 基类 | `eth/kernel/state-transition/StateTransitionErrorPolicy.h` |
| ETH 参考 | `eth/apply/EthStateTransitionErrorPolicy.h` |
| FISCO | `bcos/FiscoStateTransitionErrorPolicy.h` |
| OP Stack | `opstack/apply/OpStackStateTransitionErrorPolicy.h` |
| ADR-015 共享 helper | `eth/kernel/state-transition/IncludedTxVmerrNormalize.h` |

#### 3.8.2 在 pipeline 中的调用点

```text
stateTransitionExecute(ctx, hooks, errorPolicy)
  │
  ├─ [try] hooks.onNormalizeMessage … onInvokeInnerExecute
  │     ├─ deductIntrinsicGas 失败 → errorPolicy.onIntrinsicGasFailure
  │     └─ innerExecute 成功     → errorPolicy.onFinalizeGasUsed
  │
  ├─ [catch] errorPolicy.onException
  │
  └─ [RAII] errorPolicy.onComplete   ← 所有出口（early-exit / 成功 / 异常）均执行
```

| 方法 | 触发条件 | 职责 |
| --- | --- | --- |
| `onIntrinsicGasFailure` | `deductIntrinsicGas` 返回失败 | 将 intrinsic OOG 映射为可结算的 `ctx.evmcResult` |
| `onException` | pipeline `try` 块内未捕获异常 | 按异常类型映射 status；通常 `ctx.state.revert()` |
| `onFinalizeGasUsed` | `innerExecute` 返回后（含 SUCCESS / REVERT / OOG 等） | post-EVM 结果归一化（ADR-015、CREATE 地址、logs 清理） |
| `onComplete` | pipeline 任意出口（RAII guard） | 兜底修正（如负 `gas_left`） |

**注意：** gas buy/refund、L1 cost、block gas pool 等**费用落账**在 TE / `apply*Message` / `*FeeSettlement` 层，不属于 `StateTransitionErrorPolicy`；ErrorPolicy 只负责 **`ctx.evmcResult` 语义**及其对 receipt 字段的影响。

#### 3.8.3 与 `StateTransitionHooks` 的分工

| 维度 | `StateTransitionHooks` | `StateTransitionErrorPolicy` |
| --- | --- | --- |
| 时机 | EVM 入口前（第 1–5 步） | intrinsic 失败、异常、EVM 返回后、出口 |
| 典型动作 | auth 检查、余额 precheck、抛 `NotFoundCodeError` | 捕获异常并填 `evmcResult`、ADR-015 归一化 |
| earlyExit | 可设 `ctx.earlyExit = true` 阻止进 EVM | 在已失败或已执行后**规范化结果** |
| 链差异示例 | FISCO `onNormalizeMessage`；OP `lifecycleCheckEntryRules`（pipeline 外） | FISCO `fixErrorHandling`；Eth ADR-015；OP deposit/REVERT 特殊 |

部分 precheck 失败在 Hooks 层直接写入 `ctx.evmcResult` 并 `earlyExit`（如 Eth malformed tx、FISCO auth 拒绝），**不经过** `onIntrinsicGasFailure` / `onException`；但 RAII `onComplete` 仍会执行。只有 pipeline `try/catch` 包裹范围内的异常与 intrinsic 失败才由 ErrorPolicy 的 `onIntrinsicGasFailure` / `onException` 映射。

#### 3.8.4 三链 ErrorPolicy 差异

**对齐目标：** Eth → geth；FISCO → 历史链行为 + `bugfix_*` 开关；OP Stack → op-geth。

##### intrinsic gas 失败（`onIntrinsicGasFailure`）

| | ETH | FISCO | OP Stack |
| --- | --- | --- | --- |
| `TransactionStatus` | `OutOfGasLimit` | `OutOfGas` | `OutOfGasLimit` |
| `gas_left` | 0 | **双轨**：`fix_error_handling` 关 → 保留 `message.gas`；开 → 0 | 0 |
| 错误 reason | 无 | 有（EIP-7623/7702 分类字符串，ABI 编码进 output） | 无 |
| 构造 helper | `makeEvmcResult` | `makeErrorEVMCResult(hashImpl, …, clampGasLeft)` | `makeOutOfGasLimitResult` |

##### 异常映射（`onException`）

| 异常 / 场景 | ETH | FISCO | OP Stack |
| --- | --- | --- | --- |
| `OutOfGas` | `OutOfGasLimit` | `OutOfGas`，`gas_left=0` | 一律 `INTERNAL_ERROR` + `Unknown` |
| `NotEnoughCashError` | 多在 Hooks precheck，不经 ErrorPolicy | `NotEnoughCash`，gas 受 `fixErrorHandling` 影响 | 一律 internal error |
| `NotFoundCodeError` | 无（FISCO 独有 precheck） | STATIC/DELEGATECALL → `SUCCESS`；普通 CALL → `REVERT` + `"Call address error."` | 一律 internal error |
| 其他 `std::exception` | `Unknown` + `INTERNAL_ERROR` | legacy → `OutOfGas`；`fix_error_handling` 开 → `Unknown` | 一律 internal error |
| state revert | checkpoint 存在则 `revert()` | 同左 | 同左 |

FISCO `NotFoundCodeError` 由 `FiscoStateTransitionHooks::onPreCheckCanTransfer` 在「目标无 code 且有 calldata」时抛出，是 FISCO 历史「调不存在合约」语义，非标准 geth 行为。

##### EVM 返回后归一化（`onFinalizeGasUsed`，在 `innerExecute` 返回后调用，不仅限于 SUCCESS）

| 能力 | ETH | FISCO | OP Stack |
| --- | --- | --- | --- |
| ADR-015 included-vmerr | **完整**：顶层 vmerr → `status_code=SUCCESS`，receipt `TransactionStatus` 保留失败 | **不做** | **部分**：非 REVERT 的顶层 vmerr 走 ADR-015 |
| EIP-7702 set-code REVERT | `normalizeSetCodeTransactionVmerr` | 无 | 无 |
| 顶层 `REVERT` | 走 ADR-015 归一化 | receipt 直接反映失败 | **保持原始 REVERT**（op-geth D3） |
| Deposit 交易 | 走正常规则 | 走正常规则 | **跳过** finalize 归一化 |
| CREATE `create_address` 回填 | 内核帧内处理 | 成功且空 → 从 `message.recipient` 拷贝 | 标准 Eth 路径 |
| `eth_call` | `isCall` 时跳过 finalize | — | — |
| revert logs 清理 | — | `fix_revert_logs` 开启时清空失败交易 logs | — |

ADR-015（`IncludedTxVmerrNormalize.h`）核心语义：顶层 OOG/REVERT 等 vmerr 交易**仍进块、仍收 gas**；结算侧将 `status_code` 归一化为 `SUCCESS`，receipt 的 `TransactionStatus` 保留失败（Gap 40 geth receiptsRoot 对齐）。

##### 出口兜底（`onComplete`）

仅 FISCO 覆写：检测到 `gas_left < 0` 时强制映射为 OOG，防止 `gasLimit - gas_left` 有符号溢出。Eth / OP 使用基类默认 no-op。

#### 3.8.5 配置与装配

| Policy 字段 | 来源 | 链 |
| --- | --- | --- |
| `isCall` | `EthStateTransitionBindings` | ETH（`eth_call` 跳过 ADR-015 finalize） |
| `hashImpl` | `FiscoStateTransitionBindings` | FISCO（`makeErrorEVMCResult` 编码 error output） |
| `fixErrorHandling` | `FiscoRevisionConfig.fix_error_handling`（`bugfix_v1_error_handling`） | FISCO |
| `fixRevertLogs` | `FiscoRevisionConfig.fix_revert_logs` | FISCO |

装配路径：各链 `*StateTransitionBindings::buildErrorPolicy(ctx)` → `stateTransitionExecute` 第三个参数。

#### 3.8.6 测试

| 测试 | 覆盖 |
| --- | --- |
| `test/eth/EthStateTransitionErrorPolicyTest.cpp` | ADR-015、7702 set-code、intrinsic failure |
| `test/bcos/FiscoStateTransitionErrorPolicyTest.cpp` | `fixErrorHandling` 双轨、`NotFoundCodeError`、负 gas_left |
| `test/opstack/OpStackStateTransitionErrorPolicyTest.cpp` | deposit 跳过、REVERT 不归一化、included vmerr |

设计来源：仓库根 `docs/superpowers/specs/2026-06-24-orchestration-error-policy-design.md`（原名 OrchestrationErrorPolicy，落地为 StateTransitionErrorPolicy）；ADR-015 included-vmerr；ADR-022 FISCO CREATE 地址回填。

---

## 4. 执行流程

### 4.1 节点中的位置

```text
共识 → Baseline Scheduler → transaction-executor (TE) → bcos-evm
              Prepare → Execute → Finalize（TE 三阶段；Execute 调 apply*Message）
```

| `executionPath` | TE | bcos-evm 入口 |
| --- | --- | --- |
| Fisco（默认） | `TransactionExecutorImpl` | `applyFiscoMessage` |
| Eth | `EthTransactionExecutorImpl` | `applyEthMessage` |
| OpStack | `OpStackTransactionExecutorImpl` | `applyOpStackMessage` |

### 4.2 共享 pipeline（`stateTransitionExecute`）

```text
normalizeMessage → preCheckRules → preCheckGasAffordable → deductIntrinsicGas
  → [onIntrinsicGasFailure] preCheckCanTransfer → tuneInput + onInvokeInnerExecute (innerExecute)
  → adoptEvmcResult + settlementSnapshot → [onFinalizeGasUsed]
  → [catch: onException] → [RAII: onComplete]
```

（方括号内为 `StateTransitionErrorPolicy` 回调；详见 §3.8。）

`innerExecute` 内：`prepareState` → `runCallFrame(TopLevel)` → evmone → `EthHost::call` → `runCallFrame(Nested)` → PrecompileRouter envelope。

ETH normal：`applyEthMessage` 先 **buyGas**，再进 pipeline，最后 refund。OP normal/deposit：lifecycle 外圈处理 gasPool 与 settlement 后再/再进 pipeline。

---

## 5. 关键数据结构

**`StateTransitionContext`** — 单笔交易编排上下文（message、state、revision、earlyExit、fee 侧车）；经 `wireExecutionEnvironment(vm, extension, callTargetPort)` 注入执行环境。

**`RevisionConfig`** — 14 EIP bool + calldata floor；全模块唯一开关来源。

**`State` + Journal** — checkpoint/revert；precompile envelope（checkpoint → transfer → dispatch）依赖 journal 原子回滚。

**结算分层：** `eth/gas/` 做 State-free 算术；`eth/settlement/`、`bcos/`、`opstack/settlement/` 做 State-based 落账（buyGas/refund/L1 cost）。

---

## 6. 当前状态（2026-07-08）

### 已完成

- 四静态库 + alias（eth / storage / bcos / op）+ `eth/` 单向依赖
- 三链共享 `stateTransitionExecute` + 统一 `runCallFrame`
- Port 依赖倒置（`AuthPort` + `ChainCallTargetPort`）
- EEST（ETH 参考路径，基准 `build-bcos-evm-check` @ `eest-integration-matrix.md`）：
  - curated manifest Shanghai–Osaka **4140/4140**
  - transaction tests **106/106**
  - granular full-tree **2722/2722** file-clean（`160604Z`）
  - static GST **2445/2445**（`015708Z`）
  - blockchain：Cancun **2181/2181**；Prague **2302/2302**；Osaka **1321/1321**；M4 Berlin/London/Paris/Shanghai；static **40855/40855**

### 待做

| 项 | 说明 |
| --- | --- |
| 入口失败 reject（ADR-028） | geth 不收录 intrinsic/buyGas 失败；TE Finalize 仍 always `makeReceipt`，待 TE/共识层闭合 |
| TE/共识对齐 | finalize/receipt inclusion 语义与 geth 仍有差距（parity audit / Gap 39） |
| Blockchain engine/sync | `blockchain_tests_engine*` / sync 格式与 CL payload 解码 intentionally deferred |

---

## 7. 总结

`bcos-evm` = **可独立演进的标准内核**（L1–L3，`bcos-evm-eth`）+ **三链可注入外壳**（L4）。差异通过 Hooks（交易级/帧级）与 Port（Auth、链 CALL 目标）注入；**错误语义**通过 `StateTransitionErrorPolicy` 与 Hooks 分工注入（§3.8）；EIP 开关集中在 `RevisionConfig`。架构骨架与 EEST 参考路径回归已闭合，剩余主要是 ADR-028 入口失败 reject 与 TE/共识层 inclusion 语义对齐。