### PR TITLE
refactor: change Transaction::value() return type from std::string_view to u256

### DIFF
--- a/bcos-framework/bcos-framework/protocol/Transaction.h
+++ b/bcos-framework/bcos-framework/protocol/Transaction.h
@@ -106,7 +106,7 @@ public:
     virtual std::string_view abi() const = 0;
 
     // balance
-    virtual std::string_view value() const = 0;
+    virtual u256 value() const = 0;
     virtual std::string_view gasPrice() const = 0;
     virtual int64_t gasLimit() const = 0;
     virtual std::string_view maxFeePerGas() const = 0;

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -231,7 +231,7 @@ void bcos::rpc::toJsonResp(Json::Value& jResp, bcos::protocol::Transaction const
     jResp["extraData"] = std::string(transaction.extraData());
     if (transaction.version() >= int32_t(bcos::protocol::TransactionVersion::V1_VERSION))
     {
-        jResp["value"] = boost::lexical_cast<std::string>(transaction.value());
+        jResp["value"] = toQuantity(transaction.value());
         jResp["gasPrice"] = std::string(transaction.gasPrice());
         jResp["gasLimit"] = transaction.gasLimit();
         jResp["maxFeePerGas"] = std::string(transaction.maxFeePerGas());

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -231,7 +231,7 @@ void bcos::rpc::toJsonResp(Json::Value& jResp, bcos::protocol::Transaction const
     jResp["extraData"] = std::string(transaction.extraData());
     if (transaction.version() >= int32_t(bcos::protocol::TransactionVersion::V1_VERSION))
     {
-        jResp["value"] = std::string(transaction.value());
+        jResp["value"] = boost::lexical_cast<std::string>(transaction.value());
         jResp["gasPrice"] = std::string(transaction.gasPrice());
         jResp["gasLimit"] = transaction.gasLimit();
         jResp["maxFeePerGas"] = std::string(transaction.maxFeePerGas());

--- a/bcos-rpc/bcos-rpc/validator/TxValidator.cpp
+++ b/bcos-rpc/bcos-rpc/validator/TxValidator.cpp
@@ -91,7 +91,7 @@ task::Task<protocol::TransactionStatus> TxValidator::checkSenderBalance(
             co_return protocol::TransactionStatus::InsufficientFunds;
         }
 
-        auto txValue = u256(_tx.value());
+        auto txValue = _tx.value();
         auto gasCost = (_tx.gasLimit() > 0) ? u256(_tx.gasLimit()) * txGasPrice : u256(0);
         auto totalRequired = txValue + gasCost;
         if (balanceValue < totalRequired || balanceValue == 0)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -50,7 +50,7 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
         result["type"] = toQuantity(0);
         // web3 tools do not compatible with too long hex
         result["nonce"] = "0x" + std::string(tx.nonce());
-        result["value"] = std::string(tx.value().empty() ? "0x0" : tx.value());
+        result["value"] = toQuantity(tx.value());
         result["maxPriorityFeePerGas"] =
             std::string(tx.maxPriorityFeePerGas().empty() ? "0x0" : tx.maxPriorityFeePerGas());
         result["maxFeePerGas"] = std::string(tx.maxFeePerGas().empty() ? "0x0" : tx.maxFeePerGas());

--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -258,7 +258,7 @@ bcos::protocol::ExecutionMessage::UniquePtr BlockExecutive::buildMessage(
     }
 
     // set value
-    message->setValue(std::string(tx->value()));
+    message->setValue(boost::lexical_cast<std::string>(tx->value()));
     message->setGasLimit(tx->gasLimit());
     message->setGasPrice(m_gasPrice);
     message->setMaxFeePerGas(std::string(tx->maxFeePerGas()));

--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -258,7 +258,7 @@ bcos::protocol::ExecutionMessage::UniquePtr BlockExecutive::buildMessage(
     }
 
     // set value
-    message->setValue(boost::lexical_cast<std::string>(tx->value()));
+    message->setValue(toQuantity(tx->value()));
     message->setGasLimit(tx->gasLimit());
     message->setGasPrice(m_gasPrice);
     message->setMaxFeePerGas(std::string(tx->maxFeePerGas()));

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
@@ -123,9 +123,9 @@ std::string_view bcostars::protocol::TransactionImpl::abi() const
     return m_inner()->data.abi;
 }
 
-std::string_view bcostars::protocol::TransactionImpl::value() const
+bcos::u256 bcostars::protocol::TransactionImpl::value() const
 {
-    return m_inner()->data.value;
+    return bcos::hex2u(m_inner()->data.value);
 }
 
 std::string_view bcostars::protocol::TransactionImpl::gasPrice() const

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.h
@@ -68,7 +68,7 @@ public:
     std::string_view to() const override;
     std::string_view abi() const override;
 
-    std::string_view value() const override;
+    bcos::u256 value() const override;
     std::string_view gasPrice() const override;
     int64_t gasLimit() const override;
     std::string_view maxFeePerGas() const override;

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -142,10 +142,7 @@ bcos::protocol::TransactionStatus TxValidator::checkWeb3Nonce(
 
 TransactionStatus TxValidator::validateTransaction(const bcos::protocol::Transaction& _tx)
 {
-    if (_tx.value().length() > TRANSACTION_VALUE_MAX_LENGTH)
-    {
-        return TransactionStatus::OverFlowValue;
-    }
+
     // EIP-3860: Limit and meter initcode
     if (_tx.type() == TransactionType::Web3Transaction)
     {
@@ -246,7 +243,7 @@ task::Task<TransactionStatus> TxValidator::validateBalance(
             }
         }
 
-        auto txValue = u256(_tx.value());
+        auto txValue = _tx.value();
         if (auto totalRequired = txValue + gasCost;
             balanceValue < totalRequired || balanceValue == 0)
         {

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -498,21 +498,6 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
         BOOST_CHECK(result == TransactionStatus::AlreadyInTxPool);
     }
 
-    // Test 4: Step 3 - OverFlowValue
-    {
-        storageNoSig.clear();
-        auto tx4 = makeWeb3Tx("1235", "0xd485BAEE65E501F1cDa071a5b5c9327C401dcD5a", false);
-        // Set a value that exceeds MAX_LENGTH - need to cast to TransactionImpl
-        auto tx4Impl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx4);
-        if (tx4Impl)
-        {
-            std::string largeValue(TRANSACTION_VALUE_MAX_LENGTH + 1, '1');
-            tx4Impl->mutableInner().data.value.assign(largeValue.begin(), largeValue.end());
-        }
-        auto result = storageNoSig.verifyAndSubmitTransaction(tx4, nullptr, false, false);
-        BOOST_CHECK(result == TransactionStatus::OverFlowValue);
-    }
-
     // Test 5: Step 3 - MaxInitCodeSizeExceeded (for Web3Transaction)
     {
         storageNoSig.clear();

--- a/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.cpp
+++ b/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.cpp
@@ -22,7 +22,7 @@ evmc_message bcos::executor_v1::newEVMCMessage(protocol::BlockNumber blockNumber
         .sender = origin,
         .input_data = transaction.input().data(),
         .input_size = transaction.input().size(),
-        .value = toEvmC(u256(transaction.value())),
+        .value = toEvmC(transaction.value()),
         .create2_salt = {},
         .code_address = recipientAddress,
         .code = nullptr,


### PR DESCRIPTION
## 变更说明

将 `Transaction::value()` 接口的返回值从 `std::string_view` 改为 `u256`，使其语义与数值类型匹配，消除调用方手动 `u256()` 转换的冗余。

## 变更内容

1. **接口层** (`Transaction.h`): `virtual u256 value() const = 0;`
2. **实现层** (`TransactionImpl.h/cpp`): 使用 `bcos::hex2u()` 将 tars 中存储的 hex 字符串转换为 `u256`
3. **调用点适配**:
   - `TxValidator.cpp`（txpool/rpc）: 移除冗余的 `u256(_tx.value())` 包装，移除不再需要的 hex 长度检查（`u256` 天然 256 位有界）
   - `JsonRpcImpl_2_0.cpp`: 使用 `boost::lexical_cast<std::string>()` 转字符串
   - `TransactionResponse.cpp`: 使用 `toQuantity()` 格式化 hex 输出
   - `BlockExecutive.cpp`: 使用 `boost::lexical_cast<std::string>()` 转字符串
   - `TransactionExecutorImpl.cpp`: 移除冗余的 `u256()` 包装

## 测试

- 全量构建通过
- 1427 个测试套件通过（2 个失败为已有 AddressSanitizer 内存泄漏问题，与本次无关）