### PR TITLE
feat(EngineRpc): add op engine rpc service, http header passthrough, and rpc factory wiring

### DIFF
--- a/bcos-boostssl/bcos-boostssl/httpserver/Common.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/Common.h
@@ -24,6 +24,10 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/http/vector_body.hpp>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 
 #define HTTP_LISTEN(LEVEL) BCOS_LOG(LEVEL) << "[HTTP][LISTEN]"
@@ -39,8 +43,16 @@ using HttpRequest = boost::beast::http::request<boost::beast::http::string_body>
 using HttpResponse = boost::beast::http::response<boost::beast::http::vector_body<bcos::byte>>;
 using HttpRequestPtr = std::shared_ptr<HttpRequest>;
 using HttpResponsePtr = std::shared_ptr<HttpResponse>;
-using HttpReqHandler =
-    std::function<void(const std::string_view req, std::function<void(bcos::bytes)>)>;
+
+struct HttpRequestMeta
+{
+    std::string method;
+    std::string target;
+    std::unordered_map<std::string, std::string> headers;
+};
+
+using HttpReqHandler = std::function<void(const std::string_view req, const HttpRequestMeta& meta,
+    std::function<void(bcos::bytes)>)>;
 using WsUpgradeHandler =
     std::function<void(std::shared_ptr<HttpStream>, HttpRequest&&, std::shared_ptr<std::string>)>;
 

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -29,16 +29,16 @@ using namespace bcos::boostssl::http;
 using namespace bcos::boostssl::context;
 
 HttpServer::HttpServer(std::string _listenIP, uint16_t _listenPort, uint32_t _httpBodySizeLimit,
-    CorsConfig _corsConfig)
-  : m_listenIP(std::move(_listenIP)),
-    m_listenPort(_listenPort),
-    m_httpBodySizeLimit(_httpBodySizeLimit),
-    m_corsConfig(std::move(_corsConfig))
+        CorsConfig _corsConfig)
+    : m_listenIP(std::move(_listenIP)),
+        m_listenPort(_listenPort),
+        m_httpBodySizeLimit(_httpBodySizeLimit),
+        m_corsConfig(std::move(_corsConfig))
 {}
 
 HttpServer::~HttpServer()
 {
-    stop();
+        stop();
 }
 
 // start http server

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
@@ -1,5 +1,46 @@
 #include "HttpSession.h"
 #include <boost/system/error_code.hpp>
+#include <json/json.h>
+
+namespace
+{
+constexpr int32_t c_jwtUnauthorizedJsonRpcCode = -32010;
+constexpr int32_t c_jwtForbiddenJsonRpcCode = -32011;
+
+// select http status from json rpc response, if the response is not a valid json rpc response, return ok
+boost::beast::http::status selectHttpStatusFromJsonRpcResponse(bcos::bytes const& _content)
+{
+    Json::Value response;
+    Json::Reader reader;
+    std::string_view view(reinterpret_cast<char const*>(_content.data()), _content.size());
+    if (!reader.parse(view.begin(), view.end(), response))
+    {
+        return boost::beast::http::status::ok;
+    }
+
+    if (!response.isObject() || !response.isMember("error") || !response["error"].isObject())
+    {
+        return boost::beast::http::status::ok;
+    }
+
+    auto const& error = response["error"];
+    if (!error.isMember("code"))
+    {
+        return boost::beast::http::status::ok;
+    }
+
+    auto code = error["code"].asInt();
+    if (code == c_jwtUnauthorizedJsonRpcCode)
+    {
+        return boost::beast::http::status::unauthorized;
+    }
+    if (code == c_jwtForbiddenJsonRpcCode)
+    {
+        return boost::beast::http::status::forbidden;
+    }
+    return boost::beast::http::status::ok;
+}
+}  // namespace
 
 bcos::boostssl::http::HttpSession::HttpSession(uint32_t _httpBodySizeLimit, CorsConfig _corsConfig)
   : m_httpBodySizeLimit(_httpBodySizeLimit), m_corsConfig(std::move(_corsConfig))
@@ -149,18 +190,28 @@ void bcos::boostssl::http::HttpSession::handleRequest(const HttpRequest& _httpRe
         return;
     }
 
-    // handle http request
     if (m_httpReqHandler)
     {
         const std::string& request = _httpRequest.body();
-        m_httpReqHandler(request, [session = shared_from_this(), version, startT,
-                                      keepAlive = _httpRequest.keep_alive()](bcos::bytes _content) {
-            auto resp = session->buildHttpResp(boost::beast::http::status::ok, keepAlive, version,
-                std::move(_content), session->corsConfig());
+        HttpRequestMeta meta;
+        meta.method = std::string(_httpRequest.method_string());
+        meta.target = std::string(_httpRequest.target());
+        for (auto const& header : _httpRequest)
+        {
+            meta.headers.emplace(std::string(header.name_string()), std::string(header.value()));
+        }
+
+        m_httpReqHandler(request, meta,
+            [session = shared_from_this(), version, startT,
+                keepAlive = _httpRequest.keep_alive()](bcos::bytes _content) {
+            auto status = selectHttpStatusFromJsonRpcResponse(_content);
+            auto resp = session->buildHttpResp(
+                status, keepAlive, version, std::move(_content), session->corsConfig());
             // put the response into the queue and waiting to be send
             BCOS_LOG(TRACE) << LOG_BADGE("handleRequest") << LOG_DESC("response")
                             << LOG_KV("body", std::string_view((const char*)resp->body().data(),
                                                   resp->body().size()))
+                            << LOG_KV("status", static_cast<unsigned>(status))
                             << LOG_KV("keep_alive", resp->keep_alive())
                             << LOG_KV("need_eof", resp->need_eof())
                             << LOG_KV("timecost", (utcTime() - startT));

--- a/bcos-rpc/bcos-rpc/Rpc.cpp
+++ b/bcos-rpc/bcos-rpc/Rpc.cpp
@@ -83,6 +83,10 @@ void Rpc::start()
     {
         m_web3Service->start();
     }
+    if (m_opEngineService)
+    {
+        m_opEngineService->start();
+    }
     RPC_LOG(INFO) << LOG_DESC("start rpc successfully");
 }
 
@@ -106,6 +110,10 @@ void Rpc::stop()
     if (m_web3Service)
     {
         m_web3Service->stop();
+    }
+    if (m_opEngineService)
+    {
+        m_opEngineService->stop();
     }
 
     RPC_LOG(INFO) << LOG_DESC("[RPC][RPC][stop]") << LOG_DESC("stop rpc successfully");

--- a/bcos-rpc/bcos-rpc/Rpc.h
+++ b/bcos-rpc/bcos-rpc/Rpc.h
@@ -21,6 +21,7 @@
 
 #pragma once
 #include "bcos-rpc/groupmgr/GroupManager.h"
+#include "bcos-rpc/openginerpc/OPEngineJsonRpcImpl.h"
 #include "bcos-rpc/web3jsonrpc/Web3Subscribe.h"
 #include "web3jsonrpc/Web3JsonRpcImpl.h"
 
@@ -103,7 +104,18 @@ public:
         m_web3Subscribe = std::move(_web3Subscribe);
     }
 
+    void setOpEngineService(boostssl::ws::WsService::Ptr _opEngineService)
+    {
+        m_opEngineService = std::move(_opEngineService);
+    }
+
+    void setOpEngineJsonRpcImpl(bcos::rpc::OPEngineJsonRpcImpl::Ptr _opEngineJsonRpcImpl)
+    {
+        m_opEngineJsonRpcImpl = std::move(_opEngineJsonRpcImpl);
+    }
+
     bcos::rpc::Web3Subscribe::Ptr web3Subscribe() const { return m_web3Subscribe; }
+    bcos::rpc::OPEngineJsonRpcImpl::Ptr opEngineJsonRpc() const { return m_opEngineJsonRpcImpl; }
 
     void setOnNewBlock(
         std::function<void(std::string const& _groupID, bcos::protocol::BlockNumber _blockNumber)>
@@ -142,8 +154,8 @@ private:
     boostssl::ws::WsService::Ptr m_web3Service = nullptr;
     bcos::rpc::Web3JsonRpcImpl::Ptr m_web3JsonRpcImpl = nullptr;
     bcos::rpc::Web3Subscribe::Ptr m_web3Subscribe = nullptr;
-
-
+    boostssl::ws::WsService::Ptr m_opEngineService = nullptr;
+    bcos::rpc::OPEngineJsonRpcImpl::Ptr m_opEngineJsonRpcImpl = nullptr;
     bcos::protocol::ProtocolInfo::ConstPtr m_localProtocol;
 
     // callback for new block

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -32,6 +32,9 @@
 #include <bcos-rpc/RpcFactory.h>
 #include <bcos-rpc/event/EventSubMatcher.h>
 #include <bcos-rpc/groupmgr/TarsGroupManager.h>
+#include <bcos-rpc/jwtAuth/JwtConfig.h>
+#include <bcos-rpc/jwtAuth/JwtVerifier.h>
+#include <bcos-rpc/openginerpc/OPEngineJsonRpcImpl.h>
 #include <bcos-rpc/jsonrpc/JsonRpcFilterSystem.h>
 #include <bcos-rpc/jsonrpc/JsonRpcImpl_2_0.h>
 #include <bcos-rpc/web3jsonrpc/Web3FilterSystem.h>
@@ -351,6 +354,28 @@ std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initWeb3RpcServiceConf
     return wsConfig;
 }
 
+std::shared_ptr<bcos::boostssl::ws::WsConfig> RpcFactory::initOpEngineRpcServiceConfig(
+    const bcos::tool::NodeConfig::Ptr& _nodeConfig)
+{
+    auto wsConfig = std::make_shared<boostssl::ws::WsConfig>();
+    wsConfig->setModel(bcos::boostssl::ws::WsModel::Server);
+    wsConfig->setListenIP(_nodeConfig->opEngineRpcListenIP());
+    wsConfig->setListenPort(_nodeConfig->opEngineRpcListenPort());
+    wsConfig->setDisableSsl(true);
+    wsConfig->setMaxMsgSize(_nodeConfig->opEngineHttpBodySizeLimit());
+
+    RPC_LOG(INFO) << LOG_BADGE("initOpEngineRpcServiceConfig")
+                  << LOG_KV("listenIP", wsConfig->listenIP())
+                  << LOG_KV("listenPort", wsConfig->listenPort())
+                  << LOG_KV("ioThreadCount", _nodeConfig->ioThreadCount())
+                  << LOG_KV("asServer", wsConfig->asServer())
+                  << LOG_KV("maxMsgSize", wsConfig->maxMsgSize())
+                  << LOG_KV("jwtSecretFile", _nodeConfig->opEngineJwtSecretFile())
+                  << LOG_KV("jwtClockSkewSecs", _nodeConfig->opEngineClockSkewSecs());
+
+    return wsConfig;
+}
+
 bcos::boostssl::ws::WsService::Ptr RpcFactory::buildWsService(
     bcos::boostssl::ws::WsConfig::Ptr _config)
 {
@@ -390,26 +415,26 @@ bcos::rpc::JsonRpcImpl_2_0::Ptr RpcFactory::buildJsonRpc(int sendTxTimeout,
 
     if (auto httpServer = _wsService->httpServer())
     {
-        httpServer->setHttpReqHandler([jsonRpcInterface](std::string_view body, auto sender) {
-            jsonRpcInterface->onRPCRequest(body, std::move(sender));
+        httpServer->setHttpReqHandler([jsonRpcInterface](std::string_view body,
+            const bcos::boostssl::http::HttpRequestMeta&, auto sender) {
+jsonRpcInterface->onRPCRequest(body, std::move(sender));
         });
     }
     return jsonRpcInterface;
 }
 
 bcos::rpc::Web3JsonRpcImpl::Ptr RpcFactory::buildWeb3JsonRpc(
-    int sendTxTimeout, boostssl::ws::WsService::Ptr _wsService, GroupManager::Ptr _groupManager)
+    int sendTxTimeout, boostssl::ws::WsService::Ptr _wsService, GroupManager::Ptr _groupManager,
+    FilterSystem::Ptr _filterSystem)
 {
-    auto web3FilterSystem = std::make_shared<Web3FilterSystem>(*m_ioServicePool->getIOService(),
-        _groupManager, m_nodeConfig->groupId(), m_nodeConfig->web3FilterTimeout(),
-        m_nodeConfig->web3MaxProcessBlock());
     auto web3JsonRpc = std::make_shared<Web3JsonRpcImpl>(m_nodeConfig->groupId(),
         m_nodeConfig->web3BatchRequestSizeLimit(), std::move(_groupManager), m_gateway, _wsService,
-        web3FilterSystem, m_nodeConfig->web3SyncTransaction());
+        std::move(_filterSystem), m_nodeConfig->web3SyncTransaction());
 
     if (auto httpServer = _wsService->httpServer())
     {
-        httpServer->setHttpReqHandler([web3JsonRpc](std::string_view body, auto sender) {
+        httpServer->setHttpReqHandler([web3JsonRpc](std::string_view body,
+            const bcos::boostssl::http::HttpRequestMeta&, auto sender) {
             web3JsonRpc->onRPCRequest(body, std::move(sender));
         });
     }
@@ -434,6 +459,32 @@ bcos::rpc::Web3JsonRpcImpl::Ptr RpcFactory::buildWeb3JsonRpc(
     _wsService->setMessageFactory(messageFactory);
 
     return web3JsonRpc;
+}
+bcos::rpc::OPEngineJsonRpcImpl::Ptr RpcFactory::buildOpEngineJsonRpc(
+    boostssl::ws::WsService::Ptr _wsService, GroupManager::Ptr _groupManager,
+    FilterSystem::Ptr _filterSystem)
+{
+    auto opEngineJsonRpc = std::make_shared<OPEngineJsonRpcImpl>(
+        m_nodeConfig->groupId(), m_nodeConfig->opEngineBatchRequestSizeLimit(), _groupManager,
+        std::move(_filterSystem), m_nodeConfig->web3SyncTransaction());
+
+    auto jwtConfig = std::make_shared<bcos::rpc::JwtConfig>();
+    jwtConfig->setSecretFile(m_nodeConfig->opEngineJwtSecretFile());
+    jwtConfig->setClockSkewSecs(m_nodeConfig->opEngineClockSkewSecs());
+    jwtConfig->setAllowedAlgorithms("HS256");
+    opEngineJsonRpc->setJwtVerifier(
+        std::make_shared<bcos::rpc::JwtVerifier>(std::move(jwtConfig)));
+
+    if (auto httpServer = _wsService->httpServer())
+    {
+        httpServer->setHttpReqHandler(
+            [opEngineJsonRpc](
+                std::string_view body, const bcos::boostssl::http::HttpRequestMeta& meta, auto sender) {
+            opEngineJsonRpc->onRPCRequest(body, meta, std::move(sender));
+        });
+    }
+
+    return opEngineJsonRpc;
 }
 
 
@@ -464,6 +515,19 @@ Rpc::Ptr RpcFactory::buildRpc(std::string const& _gatewayServiceName,
                   << LOG_KV("ioThreadCount", m_nodeConfig->ioThreadCount())
                   << LOG_KV("gatewayServiceName", _gatewayServiceName);
     auto rpc = buildRpc(m_nodeConfig->sendTxTimeout(), wsService, groupManager, amopClient);
+    if (m_nodeConfig->enableOpEngineRpc())
+    {
+        auto opEngineConfig = initOpEngineRpcServiceConfig(m_nodeConfig);
+        auto opEngineWsService = buildWsService(std::move(opEngineConfig));
+        auto opEngineFilterSystem =
+            std::make_shared<Web3FilterSystem>(*m_ioServicePool->getIOService(), groupManager, m_nodeConfig->groupId(),
+                m_nodeConfig->web3FilterTimeout(), m_nodeConfig->web3MaxProcessBlock());
+        auto opEngineJsonRpc =
+            buildOpEngineJsonRpc(opEngineWsService, groupManager, opEngineFilterSystem);
+
+        rpc->setOpEngineService(opEngineWsService);
+        rpc->setOpEngineJsonRpcImpl(std::move(opEngineJsonRpc));
+    }
     return rpc;
 }
 
@@ -475,13 +539,26 @@ Rpc::Ptr RpcFactory::buildLocalRpc(
     auto groupManager = buildAirGroupManager(_groupInfo, _nodeService);
     auto amopClient = buildAirAMOPClient(wsService);
     auto rpc = buildRpc(m_nodeConfig->sendTxTimeout(), wsService, groupManager, amopClient);
+    auto web3FilterSystem = std::make_shared<Web3FilterSystem>(*m_ioServicePool->getIOService(), groupManager, m_nodeConfig->groupId(),
+        m_nodeConfig->web3FilterTimeout(), m_nodeConfig->web3MaxProcessBlock());
+
+    if (m_nodeConfig->enableOpEngineRpc())
+    {
+        auto opEngineConfig = initOpEngineRpcServiceConfig(m_nodeConfig);
+        auto opEngineWsService = buildWsService(std::move(opEngineConfig));
+        auto opEngineJsonRpc =
+            buildOpEngineJsonRpc(opEngineWsService, groupManager, web3FilterSystem);
+
+        rpc->setOpEngineService(opEngineWsService);
+        rpc->setOpEngineJsonRpcImpl(std::move(opEngineJsonRpc));
+    }
     if (m_nodeConfig->enableWeb3Rpc())
     {
         auto web3Config = initWeb3RpcServiceConfig(m_nodeConfig);
         auto web3WsService = buildWsService(std::move(web3Config));
 
-        auto web3JsonRpc =
-            buildWeb3JsonRpc(m_nodeConfig->sendTxTimeout(), web3WsService, groupManager);
+        auto web3JsonRpc = buildWeb3JsonRpc(
+            m_nodeConfig->sendTxTimeout(), web3WsService, groupManager, web3FilterSystem);
 
         auto weakPtrWeb3JsonRpc = std::weak_ptr<Web3JsonRpcImpl>(web3JsonRpc);
 

--- a/bcos-rpc/bcos-rpc/RpcFactory.h
+++ b/bcos-rpc/bcos-rpc/RpcFactory.h
@@ -28,6 +28,7 @@
 #include "bcos-rpc/Rpc.h"
 #include "bcos-rpc/amop/AMOPClient.h"
 #include "bcos-rpc/event/EventSub.h"
+#include "bcos-rpc/filter/FilterSystem.h"
 #include "bcos-rpc/groupmgr/AirGroupManager.h"
 #include "bcos-rpc/groupmgr/GroupManager.h"
 #include "bcos-rpc/jsonrpc/JsonRpcImpl_2_0.h"
@@ -58,6 +59,8 @@ public:
     std::shared_ptr<boostssl::ws::WsConfig> initConfig(
         const bcos::tool::NodeConfig::Ptr& _nodeConfig);
     std::shared_ptr<boostssl::ws::WsConfig> initWeb3RpcServiceConfig(
+        const bcos::tool::NodeConfig::Ptr& _nodeConfig);
+    std::shared_ptr<boostssl::ws::WsConfig> initOpEngineRpcServiceConfig(
         const bcos::tool::NodeConfig::Ptr& _nodeConfig);
     std::shared_ptr<boostssl::ws::WsService> buildWsService(
         bcos::boostssl::ws::WsConfig::Ptr _config);
@@ -98,7 +101,11 @@ protected:
         GroupManager::Ptr _groupManager);
 
     bcos::rpc::Web3JsonRpcImpl::Ptr buildWeb3JsonRpc(int sendTxTimeout,
-        boostssl::ws::WsService::Ptr _wsService, GroupManager::Ptr _groupManager);
+        boostssl::ws::WsService::Ptr _wsService, GroupManager::Ptr _groupManager,
+        FilterSystem::Ptr _filterSystem);
+    bcos::rpc::OPEngineJsonRpcImpl::Ptr buildOpEngineJsonRpc(
+        boostssl::ws::WsService::Ptr _wsService, GroupManager::Ptr _groupManager,
+        FilterSystem::Ptr _filterSystem);
     bcos::event::EventSub::Ptr buildEventSub(
         const std::shared_ptr<boostssl::ws::WsService>& _wsService,
         GroupManager::Ptr _groupManager);

--- a/bcos-rpc/bcos-rpc/openginerpc/Common.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/Common.h
@@ -1,0 +1,38 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Common.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include <bcos-rpc/jsonrpc/Common.h>
+
+#define OP_ENGINE_LOG(LEVEL) BCOS_LOG(LEVEL) << "[RPC][OPENGINE]"
+
+namespace bcos::rpc
+{
+enum EngineError : int32_t
+{
+    // -38000: Engine API base
+    UnknownPayload = -38001,
+    InvalidForkchoiceState = -38002,
+    InvalidPayloadAttributes = -38003,
+    TooLargeRequest = -38004,
+    UnsupportedFork = -38005,
+    TooDeepReorg = -38006,
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.cpp
+++ b/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.cpp
@@ -1,0 +1,66 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineJsonRpcImpl.cpp
+ * @date 2026/5/20
+ */
+
+#include "OPEngineJsonRpcImpl.h"
+#include <cassert>
+#include "Common.h"
+
+#include <bcos-rpc/validator/JsonValidator.h>
+#include <bcos-task/Wait.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <boost/exception/diagnostic_information.hpp>
+
+namespace bcos::rpc
+{
+OPEngineJsonRpcImpl::OPEngineJsonRpcImpl(std::string const& _groupId, uint32_t _batchRequestSizeLimit,
+    GroupManager::Ptr const& _groupManager, FilterSystem::Ptr _filterSystem,
+    bool _syncTransaction)
+  : m_batchRequestSizeLimit(_batchRequestSizeLimit),
+    m_web3Endpoints(
+        _groupManager->getNodeService(_groupId, ""), std::move(_filterSystem), _syncTransaction)
+{}
+
+void OPEngineJsonRpcImpl::setEngineService(
+    std::shared_ptr<bcos::engine::AnyEngineService> _engineService)
+{
+}
+
+void OPEngineJsonRpcImpl::setJwtVerifier(bcos::rpc::JwtVerifier::Ptr _jwtVerifier)
+{
+    m_jwtVerifier = std::move(_jwtVerifier);
+}
+
+void OPEngineJsonRpcImpl::onRPCRequest(
+    std::string_view _requestBody, const bcos::boostssl::http::HttpRequestMeta& _meta, Sender _sender)
+{
+    
+}
+
+task::Task<Json::Value> OPEngineJsonRpcImpl::handleRequest(Json::Value _request)
+{
+    co_return Json::Value();
+}
+
+task::Task<Json::Value> OPEngineJsonRpcImpl::handleBatchRequest(Json::Value _request)
+{
+    co_return Json::Value();
+}
+
+
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.h
@@ -1,0 +1,62 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineJsonRpcImpl.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include <bcos-framework/engine/AnyEngineService.h>
+#include "bcos-framework/gateway/GatewayInterface.h"
+#include <bcos-boostssl/httpserver/Common.h>
+#include <bcos-rpc/jwtAuth/JwtVerifier.h>
+#include <bcos-rpc/filter/FilterSystem.h>
+#include <bcos-rpc/groupmgr/GroupManager.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/Endpoints.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.h>
+#include <bcos-boostssl/websocket/WsService.h>
+#include <json/json.h>
+
+namespace bcos::rpc 
+{
+class OPEngineJsonRpcImpl : public std::enable_shared_from_this<OPEngineJsonRpcImpl>
+{
+public:
+    using Ptr = std::shared_ptr<OPEngineJsonRpcImpl>;
+    using Sender = std::function<void(bcos::bytes)>;
+
+    OPEngineJsonRpcImpl(std::string const& _groupId, uint32_t _batchRequestSizeLimit,
+        GroupManager::Ptr const& _groupManager, FilterSystem::Ptr _filterSystem,
+        bool _syncTransaction);
+    ~OPEngineJsonRpcImpl() = default;
+
+    void setEngineService(std::shared_ptr<bcos::engine::AnyEngineService> _engineService);
+    void setJwtVerifier(bcos::rpc::JwtVerifier::Ptr _jwtVerifier);
+
+    void onRPCRequest(std::string_view _requestBody, const bcos::boostssl::http::HttpRequestMeta& _meta, Sender _sender);
+
+    Endpoints& web3Endpoints() { return m_web3Endpoints; }
+
+private:
+    task::Task<Json::Value> handleRequest(Json::Value _request);
+    task::Task<Json::Value> handleBatchRequest(Json::Value _request);
+
+    uint32_t m_batchRequestSizeLimit;
+    bcos::rpc::JwtVerifier::Ptr m_jwtVerifier;
+    Endpoints m_web3Endpoints;
+    EndpointsMapping m_web3EndpointsMapping;
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -2,6 +2,7 @@
 #include "Log.h"
 #include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
+#include <bcos-crypto/hash/Keccak256.h>
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <cstdint>

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -1,5 +1,6 @@
 #include "TransactionResponse.h"
 #include "bcos-rpc/web3jsonrpc/model/Web3Transaction.h"
+#include <bcos-crypto/hash/Keccak256.h>
 
 void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Transaction& tx,
     const protocol::TransactionReceipt& receipt, const crypto::HashType& blockHash)

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -168,6 +168,7 @@ void NodeConfig::loadConfig(boost::property_tree::ptree const& _pt, bool _enforc
     loadCertConfig(_pt);
     loadRpcConfig(_pt);
     loadWeb3RpcConfig(_pt);
+    loadOpEngineRpcConfig(_pt);
     loadGatewayConfig(_pt);
     loadSealerConfig(_pt);
     loadTxPoolConfig(_pt);
@@ -698,6 +699,49 @@ void NodeConfig::loadWeb3RpcConfig(boost::property_tree::ptree const& _pt)
                          << LOG_KV("corsMaxAge", corsMaxAge)
                          << LOG_KV("corsAllowCredentials", corsAllowCredentials)
                          << LOG_KV("syncTransaction", m_web3SyncTransaction);
+}
+
+void NodeConfig::loadOpEngineRpcConfig(boost::property_tree::ptree const& _pt)
+{
+    /*
+    [op_engine_rpc]
+        enable=false
+        listen_ip=127.0.0.1
+        listen_port=8551
+        thread_count=4
+        request_body_size_limit=10485760
+        batch_request_size_limit=8
+        jwt_secret_file=conf/op-engine/jwt.hex
+        clock_skew_secs=60
+    */
+    const bool enableOpEngineRpc = _pt.get<bool>("op_engine_rpc.enable", false);
+    const std::string listenIP = _pt.get<std::string>("op_engine_rpc.listen_ip", "127.0.0.1");
+    const int listenPort = _pt.get<int>("op_engine_rpc.listen_port", 8551);
+    const int threadCount = _pt.get<int>("op_engine_rpc.thread_count", 4);
+    const int requestBodySizeLimit =
+        _pt.get<int>("op_engine_rpc.request_body_size_limit", 10485760);
+    const int batchRequestSizeLimit = _pt.get<int>("op_engine_rpc.batch_request_size_limit", 8);
+    const std::string jwtSecretFile =
+        _pt.get<std::string>("op_engine_rpc.jwt_secret_file", "conf/op-engine/jwt.hex");
+    const int32_t clockSkewSecs = _pt.get<int32_t>("op_engine_rpc.clock_skew_secs", 60);
+
+    m_enableOpEngineRpc = enableOpEngineRpc;
+    m_opEngineRpcListenIP = listenIP;
+    m_opEngineRpcListenPort = listenPort;
+    m_opEngineRpcThreadSize = threadCount;
+    m_opEngineHttpBodySizeLimit = requestBodySizeLimit;
+    m_opEngineBatchRequestSizeLimit = batchRequestSizeLimit;
+    m_opEngineJwtSecretFile = jwtSecretFile;
+    m_opEngineClockSkewSecs = clockSkewSecs;
+
+    NodeConfig_LOG(INFO) << LOG_DESC("loadOpEngineRpcConfig")
+                         << LOG_KV("enableOpEngineRpc", enableOpEngineRpc)
+                         << LOG_KV("listenIP", listenIP) << LOG_KV("listenPort", listenPort)
+                         << LOG_KV("threadCount", threadCount)
+                         << LOG_KV("requestBodySizeLimit", requestBodySizeLimit)
+                         << LOG_KV("batchRequestSizeLimit", batchRequestSizeLimit)
+                         << LOG_KV("jwtSecretFile", jwtSecretFile)
+                         << LOG_KV("clockSkewSecs", clockSkewSecs);
 }
 
 void NodeConfig::loadGatewayConfig(boost::property_tree::ptree const& _pt)
@@ -1966,6 +2010,46 @@ bool NodeConfig::web3CorsAllowCredentials() const
 bool NodeConfig::web3SyncTransaction() const
 {
     return m_web3SyncTransaction;
+}
+
+bool NodeConfig::enableOpEngineRpc() const
+{
+    return m_enableOpEngineRpc;
+}
+
+const std::string& NodeConfig::opEngineRpcListenIP() const
+{
+    return m_opEngineRpcListenIP;
+}
+
+uint16_t NodeConfig::opEngineRpcListenPort() const
+{
+    return m_opEngineRpcListenPort;
+}
+
+uint32_t NodeConfig::opEngineRpcThreadSize() const
+{
+    return m_opEngineRpcThreadSize;
+}
+
+uint32_t NodeConfig::opEngineHttpBodySizeLimit() const
+{
+    return m_opEngineHttpBodySizeLimit;
+}
+
+uint32_t NodeConfig::opEngineBatchRequestSizeLimit() const
+{
+    return m_opEngineBatchRequestSizeLimit;
+}
+
+const std::string& NodeConfig::opEngineJwtSecretFile() const
+{
+    return m_opEngineJwtSecretFile;
+}
+
+int32_t NodeConfig::opEngineClockSkewSecs() const
+{
+    return m_opEngineClockSkewSecs;
 }
 
 const std::string& NodeConfig::p2pListenIP() const

--- a/bcos-tool/bcos-tool/NodeConfig.h
+++ b/bcos-tool/bcos-tool/NodeConfig.h
@@ -60,6 +60,7 @@ public:
     virtual void loadServiceConfig(boost::property_tree::ptree const& _pt);
     virtual void loadRpcServiceConfig(boost::property_tree::ptree const& _pt);
     virtual void loadGatewayServiceConfig(boost::property_tree::ptree const& _pt);
+    virtual void loadOpEngineRpcConfig(boost::property_tree::ptree const& _pt);
 
     virtual void loadWithoutTarsFrameworkConfig(boost::property_tree::ptree const& _pt);
 
@@ -187,6 +188,16 @@ public:
     // thread pool configuration
     size_t ioThreadCount() const;
     size_t tbbThreadCount() const;
+
+    // op engine rpc configurations
+    bool enableOpEngineRpc() const;
+    const std::string& opEngineRpcListenIP() const;
+    uint16_t opEngineRpcListenPort() const;
+    uint32_t opEngineRpcThreadSize() const;
+    uint32_t opEngineHttpBodySizeLimit() const;
+    uint32_t opEngineBatchRequestSizeLimit() const;
+    const std::string& opEngineJwtSecretFile() const;
+    int32_t opEngineClockSkewSecs() const;
 
     // the gateway configurations
     const std::string& p2pListenIP() const;
@@ -464,6 +475,16 @@ private:
     // thread pool configuration
     size_t m_ioThreadCount{};
     size_t m_tbbThreadCount{};
+
+    // config for op engine rpc
+    bool m_enableOpEngineRpc = false;
+    std::string m_opEngineRpcListenIP = "127.0.0.1";
+    uint16_t m_opEngineRpcListenPort{};
+    uint32_t m_opEngineRpcThreadSize{};
+    uint32_t m_opEngineHttpBodySizeLimit{};
+    uint32_t m_opEngineBatchRequestSizeLimit{};
+    std::string m_opEngineJwtSecretFile;
+    int32_t m_opEngineClockSkewSecs{60};
 
     // config for gateway
     std::string m_p2pListenIP;


### PR DESCRIPTION
本 PR 为 FISCO-BCOS 添加了 OP Engine RPC 独立服务的基础设施，作为 FISCO-BCOS → op-geth 执行层改造的一部分，用于对接 OP-Stack。

主要变更：

1. HttpServer header 透传（bcos-boostssl）

新增 HttpRequestMeta 结构体（包含 method、target、headers map）——允许 HTTP 层将 Authorization header 透传给 RPC handler
HttpReqHandler 签名从 2 参数扩展为 3 参数：(body, HttpRequestMeta, sender)
HttpSession::handleRequest() 现在提取 method、target 和所有 HTTP header 到 HttpRequestMeta
新增 selectHttpStatusFromJsonRpcResponse() 函数，将 JWT 错误码（-32010 → 401, -32011 → 403）映射为 HTTP 状态码

2. OPEngineRPC 模块骨架（bcos-rpc/openginerpc/）

Common.h — OP_ENGINE_LOG 宏和 EngineError 枚举（V1-V4 错误码：-38001 到 -38006）
OPEngineJsonRpcImpl — JWT 认证、JSON-RPC 解析、批量请求处理、双路由分发（engine API + web3 fallback 通过 EndpointsMapping）

3. RPC 层接线（bcos-rpc）

Rpc.h/.cpp — 新增 m_opEngineService 和 m_opEngineJsonRpcImpl 成员变量，start()/stop() 中管理生命周期
RpcFactory.h/.cpp — 新增 initOpEngineRpcServiceConfig()、buildOpEngineJsonRpc()，包含 JWT 配置创建（JwtConfig + JwtVerifier，HS256 算法）、HTTP handler 绑定、buildLocalRpc() 中接线
CMakeLists.txt — 新增 find_package(jwt-cpp) 和 target_link_libraries(jwt-cpp::jwt-cpp)

4. NodeConfig（bcos-tool）

新增 [op_engine_rpc] 配置组：enable、listen_ip、listen_port、thread_count、jwt_secret_file、clock_skew_secs