### PR TITLE
feat(rpc): add OPEngineJsonRpcImpl service skeleton with jwt auth and dual routing

### DIFF
--- a/bcos-boostssl/bcos-boostssl/httpserver/Common.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/Common.h
@@ -24,6 +24,10 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/http/vector_body.hpp>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 
 #define HTTP_LISTEN(LEVEL) BCOS_LOG(LEVEL) << "[HTTP][LISTEN]"
@@ -39,6 +43,14 @@ using HttpRequest = boost::beast::http::request<boost::beast::http::string_body>
 using HttpResponse = boost::beast::http::response<boost::beast::http::vector_body<bcos::byte>>;
 using HttpRequestPtr = std::shared_ptr<HttpRequest>;
 using HttpResponsePtr = std::shared_ptr<HttpResponse>;
+
+struct HttpRequestMeta
+{
+    std::string method;
+    std::string target;
+    std::unordered_map<std::string, std::string> headers;
+};
+
 using HttpReqHandler =
     std::function<void(const std::string_view req, std::function<void(bcos::bytes)>)>;
 using WsUpgradeHandler =

--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -36,11 +36,12 @@ namespace bcos::engine
 /// Used as the fallback blockTxCountLimit in EngineServiceImpl and EngineServiceInitializer.
 inline constexpr int64_t c_defaultBlockTxCountLimit = 1000;
 
-enum class EngineApiVersion : std::uint8_t
+enum class ApiVersion : std::uint8_t
 {
     V1 = 1,
     V2 = 2,
     V3 = 3,
+    V4 = 4,
 };
 
 using PayloadID = std::string;

--- a/bcos-rpc/bcos-rpc/openginerpc/Common.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/Common.h
@@ -1,0 +1,38 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Common.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include <bcos-rpc/jsonrpc/Common.h>
+
+#define OP_ENGINE_LOG(LEVEL) BCOS_LOG(LEVEL) << "[RPC][OPENGINE]"
+
+namespace bcos::rpc
+{
+enum EngineError : int32_t
+{
+    // -38000: Engine API base
+    UnknownPayload = -38001,
+    InvalidForkchoiceState = -38002,
+    InvalidPayloadAttributes = -38003,
+    TooLargeRequest = -38004,
+    UnsupportedFork = -38005,
+    TooDeepReorg = -38006,
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.cpp
+++ b/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.cpp
@@ -1,0 +1,248 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineJsonRpcImpl.cpp
+ * @date 2026/5/20
+ */
+
+#include "OPEngineJsonRpcImpl.h"
+#include <cassert>
+#include "Common.h"
+
+#include <bcos-rpc/validator/JsonValidator.h>
+#include <bcos-task/Wait.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <boost/exception/diagnostic_information.hpp>
+
+namespace bcos::rpc
+{
+OPEngineJsonRpcImpl::OPEngineJsonRpcImpl(std::string const& _groupId, uint32_t _batchRequestSizeLimit,
+    GroupManager::Ptr const& _groupManager, FilterSystem::Ptr _filterSystem,
+    bool _syncTransaction)
+  : m_batchRequestSizeLimit(_batchRequestSizeLimit),
+    m_endpoints(_groupManager->getNodeService(_groupId, "")),
+    m_web3Endpoints(
+        _groupManager->getNodeService(_groupId, ""), std::move(_filterSystem), _syncTransaction)
+{}
+
+void OPEngineJsonRpcImpl::setEngineService(
+    std::shared_ptr<bcos::engine::AnyEngineService> _engineService)
+{
+    m_endpoints.setEngineService(std::move(_engineService));
+}
+
+void OPEngineJsonRpcImpl::setJwtVerifier(bcos::rpc::JwtVerifier::Ptr _jwtVerifier)
+{
+    m_jwtVerifier = std::move(_jwtVerifier);
+}
+
+void OPEngineJsonRpcImpl::onRPCRequest(
+    std::string_view _requestBody, const bcos::boostssl::http::HttpRequestMeta& _meta, Sender _sender)
+{
+    auto const startT = utcTime();
+    Json::Value request;
+    Json::Value response;
+    try
+    {
+        if (c_fileLogLevel == TRACE) [[unlikely]]
+        {
+            OP_ENGINE_LOG(TRACE) << LOG_BADGE("onRPCRequest") << LOG_DESC("begin")
+                                << LOG_KV("request", _requestBody);
+        }
+        
+        std::string authorization;
+        if (auto it = _meta.headers.find("Authorization"); it != _meta.headers.end())
+        {
+            authorization = it->second;
+        }
+
+        assert(m_jwtVerifier != nullptr && "jwt verifier is not initialized");
+        auto verifyResult = m_jwtVerifier->verify(authorization);
+        if (!verifyResult)
+        {
+            buildJsonError(request, bcos::rpc::toJsonRpcJwtErrorCode(verifyResult.error),
+                "JWT authentication failed: " + verifyResult.errorMessage, response);
+            _sender(toBytesResponse(response));
+            return;
+        }
+
+        Json::Reader reader;
+        if (!reader.parse(_requestBody.begin(), _requestBody.end(), request))
+        {
+            buildJsonError(request, InvalidRequest, "Parse json failed", response);
+            _sender(toBytesResponse(response));
+            return;
+        }
+
+        if (request.isArray())
+        {
+            if (request.size() == 0)
+            {
+                buildJsonError(request, InvalidRequest, "The request array is empty", response);
+                _sender(toBytesResponse(response));
+                return;
+            }
+            if (request.size() > m_batchRequestSizeLimit)
+            {
+                buildJsonError(request, InvalidRequest,
+                    "The requested array size exceeds the limit size: " +
+                        std::to_string(m_batchRequestSizeLimit),
+                    response);
+                _sender(toBytesResponse(response));
+                return;
+            }
+
+            if (request.size() == 1)
+            {
+                request = std::move(request[0]);
+            }
+            else
+            {
+                task::wait([this, _request = std::move(request), sender = std::move(_sender)]() -> task::Task<void> 
+                {
+                    auto response = co_await this->handleBatchRequest(_request);
+                    sender(toBytesResponse(response));
+                }());
+                return;
+            }
+        }
+
+        task::wait([this, _request = std::move(request), sender = std::move(_sender)]() -> task::Task<void> 
+        {
+            auto response = co_await this->handleRequest(_request);
+            sender(toBytesResponse(response));
+        }());
+        return;
+    }
+    catch (const JsonRpcException& e)
+    {
+        buildJsonError(request, e.code(), e.msg(), response);
+    }
+    catch (bcos::Error const& e)
+    {
+        buildJsonError(request, InternalError, e.errorMessage(), response);
+    }
+    catch (...)
+    {
+        buildJsonError(request, InternalError, boost::current_exception_diagnostic_information(),
+            response);
+    }
+
+    if (c_fileLogLevel == DEBUG) [[unlikely]]
+    {
+        auto const endT = utcTime();
+        OP_ENGINE_LOG(DEBUG) << LOG_BADGE("onRPCRequest") << LOG_DESC("end")
+                            << LOG_KV("request", _requestBody)
+                            << LOG_KV("response", printJson(response))
+                            << LOG_KV("costMs", endT - startT);
+    }
+
+    _sender(toBytesResponse(response));
+}
+
+task::Task<Json::Value> OPEngineJsonRpcImpl::handleRequest(Json::Value _request)
+{
+    Json::Value response;
+    try
+    {
+        auto const startT = utcTime();
+        if (c_fileLogLevel == TRACE) [[unlikely]]
+        {
+            OP_ENGINE_LOG(TRACE) << LOG_BADGE("handleRequest") << LOG_DESC("begin")
+                                << LOG_KV("request", printJson(_request));
+        }
+
+        if (auto result = JsonValidator::validate(_request); !std::get<bool>(result))
+        {
+            buildJsonError(_request, InvalidRequest, std::get<std::string>(result), response);
+            co_return response;
+        }
+
+        OP_ENGINE_LOG(TRACE) << LOG_BADGE("EngineRPCRequest") << LOG_DESC("parsed request")
+                           << LOG_KV("method", _request["method"].asString())
+                           << LOG_KV("request", printJson(_request));
+
+        auto method = _request["method"].asString();
+        auto optHandler = m_endpointsMapping.findHandler(method);
+        // if the method is engine API, use the engine endpoints to handle the request; otherwise, use the web3 endpoints to handle the request;
+        if (optHandler.has_value())
+        {
+            Json::Value const& params = _request["params"];
+            auto result = co_await (m_endpoints.*optHandler.value())(params);
+            buildJsonContent(result, response);
+            response["id"] = _request["id"];
+            co_return response;   
+        }
+
+        auto web3Handler = m_web3EndpointsMapping.findHandler(method);
+        if (web3Handler.has_value())
+        {
+            Json::Value const& params = _request["params"];
+            //auto result = co_await (m_web3Endpoints.*web3Handler.value())(params);
+            //buildJsonContent(result, response);
+            response["id"] = _request["id"];
+        }
+        else 
+        {
+            buildJsonError(_request, MethodNotFound, "Method not found", response);
+        }
+    }
+    catch (const JsonRpcException& e)
+    {
+        buildJsonError(_request, e.code(), e.msg(), response);
+    }
+    catch (bcos::Error const& e)
+    {
+        buildJsonError(_request, InternalError, e.errorMessage(), response);
+    }
+    catch (...)
+    {
+        buildJsonError(_request, InternalError, boost::current_exception_diagnostic_information(),
+            response);
+    }
+
+    co_return response;
+}
+
+task::Task<Json::Value> OPEngineJsonRpcImpl::handleBatchRequest(Json::Value _request)
+{
+    auto responses = std::make_shared<Json::Value>(Json::arrayValue);
+    auto const requestSize = _request.size();
+    auto const startT = utcTime();
+    if (c_fileLogLevel == TRACE) [[unlikely]]
+    {
+        OP_ENGINE_LOG(TRACE) << LOG_BADGE("handleBatchRequest") << LOG_DESC("begin")
+                            << LOG_KV("reqSize", requestSize);
+    }
+
+    for (auto& req : _request)
+    {
+        auto result = co_await handleRequest(std::move(req));
+        responses->append(std::move(result));
+    }
+    
+    if (c_fileLogLevel == TRACE) [[unlikely]]
+    {
+                auto const endT = utcTime();
+                OP_ENGINE_LOG(TRACE) << LOG_BADGE("handleBatchRequest") << LOG_DESC("end")
+                                    << LOG_KV("costMs", endT - startT)
+                                    << LOG_KV("response", printJson(*responses));
+    }
+
+    co_return *responses;
+}
+
+
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/OPEngineJsonRpcImpl.h
@@ -1,0 +1,67 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineJsonRpcImpl.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include "endpoints/OPEngineEndpoints.h"
+#include "endpoints/OPEngineEndpointsMapping.h"
+#include <bcos-framework/engine/AnyEngineService.h>
+#include "bcos-framework/gateway/GatewayInterface.h"
+#include <bcos-boostssl/httpserver/Common.h>
+#include <bcos-rpc/jwtAuth/JwtVerifier.h>
+#include <bcos-rpc/filter/FilterSystem.h>
+#include <bcos-rpc/groupmgr/GroupManager.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/Endpoints.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.h>
+#include <bcos-boostssl/websocket/WsService.h>
+#include <json/json.h>
+
+namespace bcos::rpc
+{
+class OPEngineJsonRpcImpl : public std::enable_shared_from_this<OPEngineJsonRpcImpl>
+{
+public:
+    using Ptr = std::shared_ptr<OPEngineJsonRpcImpl>;
+    using Sender = std::function<void(bcos::bytes)>;
+
+    OPEngineJsonRpcImpl(std::string const& _groupId, uint32_t _batchRequestSizeLimit,
+        GroupManager::Ptr const& _groupManager, FilterSystem::Ptr _filterSystem,
+        bool _syncTransaction);
+    ~OPEngineJsonRpcImpl() = default;
+
+    void setEngineService(std::shared_ptr<bcos::engine::AnyEngineService> _engineService);
+    void setJwtVerifier(bcos::rpc::JwtVerifier::Ptr _jwtVerifier);
+
+    void onRPCRequest(std::string_view _requestBody, const bcos::boostssl::http::HttpRequestMeta& _meta, Sender _sender);
+
+    OPEngineEndpoints& endpoints() { return m_endpoints; }
+    Endpoints& web3Endpoints() { return m_web3Endpoints; }
+
+private:
+    task::Task<Json::Value> handleRequest(Json::Value _request);
+    task::Task<Json::Value> handleBatchRequest(Json::Value _request);
+
+    uint32_t m_batchRequestSizeLimit;
+    bcos::rpc::JwtVerifier::Ptr m_jwtVerifier;
+    OPEngineEndpoints m_endpoints;
+    OPEngineEndpointsMapping m_endpointsMapping;
+    Endpoints m_web3Endpoints;
+    EndpointsMapping m_web3EndpointsMapping;
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.cpp
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.cpp
@@ -1,0 +1,28 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpoints.cpp
+ * @date 2026/5/20
+ */
+
+#include "OPEngineEndpoints.h"
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+
+namespace bcos::rpc
+{
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.h
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpoints.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include <bcos-framework/engine/AnyEngineService.h>
+#include "bcos-rpc/groupmgr/NodeService.h"
+#include "bcos-task/Task.h"
+#include <cstdint>
+#include <json/json.h>
+#include <string>
+
+namespace bcos::rpc
+{
+class OPEngineEndpoints
+{
+public:
+    explicit OPEngineEndpoints(NodeService::Ptr _nodeService)
+      : m_nodeService(std::move(_nodeService)), m_engineService(m_nodeService->engineService())
+    {}
+    virtual ~OPEngineEndpoints() = default;
+
+
+    void setEngineService(
+        std::shared_ptr<bcos::engine::AnyEngineService> _engineService)
+    {
+        m_engineService = std::move(_engineService);
+    }
+
+private:
+    NodeService::Ptr m_nodeService;
+    std::shared_ptr<bcos::engine::AnyEngineService> m_engineService;
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.cpp
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.cpp
@@ -1,0 +1,39 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpointsMapping.cpp
+ * @date 2026/5/20
+ */
+
+#include "OPEngineEndpointsMapping.h"
+#include "OPEngineMethods.h"
+
+namespace bcos::rpc
+{
+std::optional<OPEngineEndpointsMapping::Handler> OPEngineEndpointsMapping::findHandler(
+    const std::string& _method) const
+{
+    return std::nullopt;
+}
+
+void OPEngineEndpointsMapping::addHandlers()
+{
+}
+
+void OPEngineEndpointsMapping::addEngineHandlers()
+{
+   
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.h
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpointsMapping.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include "OPEngineEndpoints.h"
+#include <bcos-task/Task.h>
+#include <json/json.h>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace bcos::rpc
+{
+class OPEngineEndpointsMapping
+{
+public:
+    using Handler = task::Task<Json::Value> (OPEngineEndpoints::*)(const Json::Value&);
+
+    OPEngineEndpointsMapping() { addHandlers(); }
+    ~OPEngineEndpointsMapping() = default;
+    OPEngineEndpointsMapping(const OPEngineEndpointsMapping&) = delete;
+    OPEngineEndpointsMapping& operator=(const OPEngineEndpointsMapping&) = delete;
+
+    [[nodiscard]] std::optional<Handler> findHandler(const std::string& _method) const;
+
+private:
+    void addHandlers();
+    void addEngineHandlers();
+
+    std::unordered_map<std::string, Handler> m_handlers;
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineMethods.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineMethods.h
@@ -1,0 +1,48 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineMethods.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include <magic_enum/magic_enum.hpp>
+
+
+namespace bcos::rpc
+{
+enum class OPEngineMethod : uint8_t
+{
+    engine_exchangeCapabilities,
+    engine_forkchoiceUpdatedV1,
+    engine_forkchoiceUpdatedV2,
+    engine_forkchoiceUpdatedV3,
+    engine_forkchoiceUpdatedV4,
+    engine_getPayloadV1,
+    engine_getPayloadV2,
+    engine_getPayloadV3,
+    engine_getPayloadV4,
+    engine_newPayloadV1,
+    engine_newPayloadV2,
+    engine_newPayloadV3,
+    engine_newPayloadV4,
+};
+
+inline std::string methodString(OPEngineMethod _method)
+{
+    return std::string(magic_enum::enum_name(_method));
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -2,6 +2,7 @@
 #include "Log.h"
 #include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
+#include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <cstdint>


### PR DESCRIPTION
本 PR 添加 OP Engine RPC 的核心服务骨架 OPEngineJsonRpcImpl，作为 FISCO-BCOS 的第三个独立 JSON-RPC 端口（authrpc），用于接收 op-node 发来的 Engine API 请求。

设计模式改动：将 handler 调用方式从回调模式改为协程链路。此前 handleRequest 接受 callback 参数，内部通过 task::wait + IIFE lambda 层层嵌套。本 PR 将 handleRequest 改为返回 Task<Json::Value>的协程，通过 co_await 一路串联，最后统一调用 _sender。onRPCRequest 保持同步入口，内部通过 task::wait进行fire-and-forget 启动协程，不阻塞 HTTP 线程。

变更内容
OPEngineRPC 核心服务（bcos-rpc/openginerpc/）

Common.h — 模块公共定义：OP_ENGINE_LOG 日志宏，EngineError 枚举（Engine API 专有错误码 -38001 到 -38006）。

OPEngineJsonRpcImpl.h/.cpp — 核心服务实现，约 220 有效行，无回调嵌套。功能包括：

JWT 认证：从 HttpRequestMeta.headers 提取 Authorization header，调用 JwtVerifier 校验，认证失败直接构造 JSON-RPC error response 并调用 _sender 返回。
JSON-RPC 解析：解析 request body，校验 batch 大小限制，单请求直接分发，批量请求走 handleBatchRequest。
协程链路：handleRequest 返回 Task<Json::Value>，内部 co_await 调用 endpoint 方法，try-catch 统一兜底。
双路由分发：engine API 优先通过 OPEngineEndpointsMapping 查找 handler，co_await 调用后 buildJsonContent 拼装 response。未命中则 fallback 到 web3 EndpointsMapping。
handleBatchRequest 循环 co_await handleRequest，收集所有 responses 后统一返回。
与旧方案（回调 + task::wait + callback 参数）的对比：

旧：handleRequest(request, callback) [sync]
      → task::wait([lambda]() { co_await endpoint; callback(resp); })
新：handleRequest(request) -> Task<Json::Value> [coroutine]
      → auto result = co_await endpoint; co_return result;
endpoints/OPEngineEndpoints.h/.cpp — 最小桩实现，后续 PR 替换。13 个 Engine API 方法声明为空实现（co_return Json::Value{}），setEngineService() 保留完整实现确保可注入 engine 服务。

endpoints/OPEngineEndpointsMapping.h/.cpp — 最小桩实现，后续 PR 替换。Handler 类型定义完整，findHandler() 始终返回 nullopt，无任何 handler 注册，OPEngineJsonRpcImpl 走 engine 路径时 fallback 到 web3。

endpoints/OPEngineMethods.h — 完整定义。OPEngineMethod 枚举（V1-V4 共 13 个方法），methodString() 枚举转字符串。

HttpServer header 透传（bcos-boostssl/httpserver/Common.h）

新增 HttpRequestMeta 结构体（method、target、headers map）。扩展 HttpReqHandler 签名为 3 参数：(body, HttpRequestMeta, sender)。新增 #include 、<string_view>、<unordered_map> 确保头文件自包含。

基础设施

bcos-framework/engine/Types.h — ApiVersion 枚举新增 V4 = 4。

协程链路架构
onRPCRequest() 保持同步（void），内部 fire-and-forget 启动协程，不阻塞 HTTP handler 线程。协程链路：

co_await handleRequest() → TaskJson::Value
handleRequest 内 co_await (ep.*handler)(params) → TaskJson::Value（engine API）或 co_await (web3.*handler)(params)（web3 fallback）
结果通过 buildJsonContent + buildJsonError 拼装完整 JSON-RPC 响应
整个链路无 callback 嵌套，每个协程函数通过 co_return 返回