### PR TITLE
feat(EngineRpc): add OPEngineEndpoints full implementation with engine method dispatch and parsing helpers

### DIFF
--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -36,11 +36,12 @@ namespace bcos::engine
 /// Used as the fallback blockTxCountLimit in EngineServiceImpl and EngineServiceInitializer.
 inline constexpr int64_t c_defaultBlockTxCountLimit = 1000;
 
-enum class EngineApiVersion : std::uint8_t
+enum class ApiVersion : std::uint8_t
 {
     V1 = 1,
     V2 = 2,
     V3 = 3,
+    V4 = 4,
 };
 
 using PayloadID = std::string;

--- a/bcos-rpc/bcos-rpc/openginerpc/Common.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/Common.h
@@ -1,0 +1,38 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Common.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include <bcos-rpc/jsonrpc/Common.h>
+
+#define OP_ENGINE_LOG(LEVEL) BCOS_LOG(LEVEL) << "[RPC][OPENGINE]"
+
+namespace bcos::rpc
+{
+enum EngineError : int32_t
+{
+    // -38000: Engine API base
+    UnknownPayload = -38001,
+    InvalidForkchoiceState = -38002,
+    InvalidPayloadAttributes = -38003,
+    TooLargeRequest = -38004,
+    UnsupportedFork = -38005,
+    TooDeepReorg = -38006,
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.cpp
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.cpp
@@ -1,0 +1,200 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpoints.cpp
+ * @date 2026/5/20
+ */
+
+#include "OPEngineEndpoints.h"
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace
+{
+constexpr int32_t kEngineNotAvailable = -32000;
+
+void buildEngineNotAvailableError()
+{
+    BOOST_THROW_EXCEPTION(
+        JsonRpcException(kEngineNotAvailable, "Engine service is not available on this node"));
+}
+}  // namespace
+
+namespace bcos::rpc
+{
+task::Task<Json::Value> OPEngineEndpoints::exchangeCapabilities(const Json::Value& _request)
+{
+    if (!m_engineService)
+    {
+        buildEngineNotAvailableError();
+    }
+
+    std::vector<std::string> remoteCaps;
+    remoteCaps.reserve(_request.size());
+    for (auto const& cap : _request)
+    {
+        if (!cap.isString())
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "engine_exchangeCapabilities expects string capability items"));
+        }
+        remoteCaps.emplace_back(cap.asString());
+    }
+
+    auto caps = co_await m_engineService->exchangeCapabilities(std::move(remoteCaps));
+    Json::Value result(Json::arrayValue);
+    for (auto const& cap : caps)
+    {
+        result.append(cap);
+    }
+    co_return result;
+}
+
+task::Task<Json::Value> OPEngineEndpoints::forkchoiceUpdatedV1(const Json::Value& _request)
+{
+    co_return co_await handleForkchoiceUpdated(engine::ApiVersion::V1, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::forkchoiceUpdatedV2(const Json::Value& _request)
+{
+    co_return co_await handleForkchoiceUpdated(engine::ApiVersion::V2, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::forkchoiceUpdatedV3(const Json::Value& _request)
+{
+    co_return co_await handleForkchoiceUpdated(engine::ApiVersion::V3, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::forkchoiceUpdatedV4(const Json::Value& _request)
+{
+    // V4 not yet implemented (Prague fork)
+    BOOST_THROW_EXCEPTION(
+        JsonRpcException(EngineError::UnsupportedFork, "engine_forkchoiceUpdatedV4 is not yet supported"));
+    co_return {};
+}
+
+task::Task<Json::Value> OPEngineEndpoints::getPayloadV1(const Json::Value& _request)
+{
+    co_return co_await handleGetPayload(engine::ApiVersion::V1, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::getPayloadV2(const Json::Value& _request)
+{
+    co_return co_await handleGetPayload(engine::ApiVersion::V2, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::getPayloadV3(const Json::Value& _request)
+{
+    co_return co_await handleGetPayload(engine::ApiVersion::V3, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::getPayloadV4(const Json::Value& _request)
+{
+    // V4 not yet implemented (Prague fork)
+    BOOST_THROW_EXCEPTION(
+        JsonRpcException(EngineError::UnsupportedFork, "engine_getPayloadV4 is not yet supported"));
+    co_return {};
+}
+
+task::Task<Json::Value> OPEngineEndpoints::newPayloadV1(const Json::Value& _request)
+{
+    co_return co_await handleNewPayload(engine::ApiVersion::V1, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::newPayloadV2(const Json::Value& _request)
+{
+    co_return co_await handleNewPayload(engine::ApiVersion::V2, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::newPayloadV3(const Json::Value& _request)
+{
+    co_return co_await handleNewPayload(engine::ApiVersion::V3, _request);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::newPayloadV4(const Json::Value& _request)
+{
+    // V4 not yet implemented (Prague fork)
+    BOOST_THROW_EXCEPTION(
+        JsonRpcException(EngineError::UnsupportedFork, "engine_newPayloadV4 is not yet supported"));
+    co_return {};
+}
+
+task::Task<Json::Value> OPEngineEndpoints::handleForkchoiceUpdated(engine::ApiVersion version, const Json::Value& _request)
+{
+    if (!m_engineService)
+    {
+        buildEngineNotAvailableError();
+    }
+
+    auto forkchoiceState = parseForkchoiceState(_request);
+    auto payloadAttrs = parsePayloadAttributes(_request, version);
+    // TODO: engineService->updateForkchoice() MUST throw JsonRpcException in these cases:
+    //   -38002 InvalidForkchoiceState: headBlockHash is VALID but finalizedBlockHash/safeBlockHash not in chain
+    //   -38003 InvalidPayloadAttributes: payloadAttributes.timestamp <= headBlockHash.timestamp
+    //   -38005 UnsupportedFork: timestamp out of fork window (V2/V3 specific)
+    //   -38006 TooDeepReorg: reorg depth exceeds limitation
+    auto engineResult = co_await m_engineService->updateForkchoice(
+        forkchoiceState, payloadAttrs.has_value() ? &*payloadAttrs : nullptr,
+        toServiceVersion(version));
+
+    co_return combineForkchoiceUpdatedResult(engineResult, version);
+}
+
+task::Task<Json::Value> OPEngineEndpoints::handleGetPayload(engine::ApiVersion version, const Json::Value& _request)
+{
+    if (!m_engineService)
+    {
+        buildEngineNotAvailableError();
+    }
+    if (!_request.isArray() || _request.size() != 1 || !_request[0u].isString())
+    {
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "Invalid params for engine_getPayload"));
+    }
+
+    auto engineResult =
+        co_await m_engineService->getPayload(_request[0u].asString(), toServiceVersion(version));
+    // TODO: engineService->getPayload() MUST throw JsonRpcException in these cases:
+    //   -38001 UnknownPayload: build process identified by payloadId does not exist
+    //   -38005 UnsupportedFork: timestamp of built payload out of fork window (V2/V3)
+
+    Json::Value result(Json::objectValue);
+    combineGetPayloadResponse(result, engineResult, version);
+    co_return result;
+}
+
+task::Task<Json::Value> OPEngineEndpoints::handleNewPayload(engine::ApiVersion version, const Json::Value& _request)
+{
+    if (!m_engineService)
+    {
+        buildEngineNotAvailableError();
+    }
+
+    auto engineRequest =
+        parseNewPayloadRequest(_request, *m_nodeService->blockFactory()->transactionFactory(), version);
+    // TODO: engineService->newPayload() MUST throw JsonRpcException in these cases:
+    //   -32602 InvalidParams: wrong version of ExecutionPayload structure (V2)
+    //   -38005 UnsupportedFork: timestamp out of fork window (V2/V3)
+    auto engineResult =
+        co_await m_engineService->newPayload(engineRequest, toServiceVersion(version));
+    co_return serializePayloadStatus(engineResult, version);
+}
+
+std::uint32_t OPEngineEndpoints::toServiceVersion(engine::ApiVersion version)
+{
+    return static_cast<uint32_t>(version);
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpoints.h
@@ -1,0 +1,72 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpoints.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include "../helper/ForkchoiceUpdated.h"
+#include "../helper/GetPayload.h"
+#include "../helper/NewPayload.h"
+#include <bcos-framework/engine/AnyEngineService.h>
+#include <bcos-rpc/openginerpc/Common.h>
+#include "bcos-rpc/groupmgr/NodeService.h"
+#include "bcos-task/Task.h"
+#include <cstdint>
+#include <json/json.h>
+#include <string>
+
+namespace bcos::rpc
+{
+class OPEngineEndpoints
+{
+public:
+    explicit OPEngineEndpoints(NodeService::Ptr _nodeService)
+      : m_nodeService(std::move(_nodeService)), m_engineService(m_nodeService->engineService())
+    {}
+    virtual ~OPEngineEndpoints() = default;
+
+    task::Task<Json::Value> exchangeCapabilities(const Json::Value&);
+    task::Task<Json::Value> forkchoiceUpdatedV1(const Json::Value&);
+    task::Task<Json::Value> forkchoiceUpdatedV2(const Json::Value&);
+    task::Task<Json::Value> forkchoiceUpdatedV3(const Json::Value&);
+    task::Task<Json::Value> forkchoiceUpdatedV4(const Json::Value&);
+    task::Task<Json::Value> getPayloadV1(const Json::Value&);
+    task::Task<Json::Value> getPayloadV2(const Json::Value&);
+    task::Task<Json::Value> getPayloadV3(const Json::Value&);
+    task::Task<Json::Value> getPayloadV4(const Json::Value&);
+    task::Task<Json::Value> newPayloadV1(const Json::Value&);
+    task::Task<Json::Value> newPayloadV2(const Json::Value&);
+    task::Task<Json::Value> newPayloadV3(const Json::Value&);
+    task::Task<Json::Value> newPayloadV4(const Json::Value&);
+
+    void setEngineService(
+        std::shared_ptr<bcos::engine::AnyEngineService> _engineService)
+    {
+        m_engineService = std::move(_engineService);
+    }
+
+private:
+    task::Task<Json::Value> handleForkchoiceUpdated(engine::ApiVersion version, const Json::Value& _request);
+    task::Task<Json::Value> handleGetPayload(engine::ApiVersion version, const Json::Value& _request);
+    task::Task<Json::Value> handleNewPayload(engine::ApiVersion version, const Json::Value& _request);
+    static std::uint32_t toServiceVersion(engine::ApiVersion version);
+
+    NodeService::Ptr m_nodeService;
+    std::shared_ptr<bcos::engine::AnyEngineService> m_engineService;
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.cpp
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.cpp
@@ -1,0 +1,70 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpointsMapping.cpp
+ * @date 2026/5/20
+ */
+
+#include "OPEngineEndpointsMapping.h"
+#include "OPEngineMethods.h"
+
+namespace bcos::rpc
+{
+std::optional<OPEngineEndpointsMapping::Handler> OPEngineEndpointsMapping::findHandler(
+    const std::string& _method) const
+{
+    auto it = m_handlers.find(_method);
+    if (it == m_handlers.end())
+    {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+void OPEngineEndpointsMapping::addHandlers()
+{
+    addEngineHandlers();
+}
+
+void OPEngineEndpointsMapping::addEngineHandlers()
+{
+    m_handlers[methodString(OPEngineMethod::engine_exchangeCapabilities)] =
+        &OPEngineEndpoints::exchangeCapabilities;
+    m_handlers[methodString(OPEngineMethod::engine_forkchoiceUpdatedV1)] =
+        &OPEngineEndpoints::forkchoiceUpdatedV1;
+    m_handlers[methodString(OPEngineMethod::engine_forkchoiceUpdatedV2)] =
+        &OPEngineEndpoints::forkchoiceUpdatedV2;
+    m_handlers[methodString(OPEngineMethod::engine_forkchoiceUpdatedV3)] =
+        &OPEngineEndpoints::forkchoiceUpdatedV3;
+    m_handlers[methodString(OPEngineMethod::engine_forkchoiceUpdatedV4)] =
+        &OPEngineEndpoints::forkchoiceUpdatedV4;
+    m_handlers[methodString(OPEngineMethod::engine_getPayloadV1)] =
+        &OPEngineEndpoints::getPayloadV1;
+    m_handlers[methodString(OPEngineMethod::engine_getPayloadV2)] =
+        &OPEngineEndpoints::getPayloadV2;
+    m_handlers[methodString(OPEngineMethod::engine_getPayloadV3)] =
+        &OPEngineEndpoints::getPayloadV3;
+    m_handlers[methodString(OPEngineMethod::engine_getPayloadV4)] =
+        &OPEngineEndpoints::getPayloadV4;
+    m_handlers[methodString(OPEngineMethod::engine_newPayloadV1)] =
+        &OPEngineEndpoints::newPayloadV1;
+    m_handlers[methodString(OPEngineMethod::engine_newPayloadV2)] =
+        &OPEngineEndpoints::newPayloadV2;
+    m_handlers[methodString(OPEngineMethod::engine_newPayloadV3)] =
+        &OPEngineEndpoints::newPayloadV3;
+    m_handlers[methodString(OPEngineMethod::engine_newPayloadV4)] =
+        &OPEngineEndpoints::newPayloadV4;
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineEndpointsMapping.h
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineEndpointsMapping.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include "OPEngineEndpoints.h"
+#include <bcos-task/Task.h>
+#include <json/json.h>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace bcos::rpc
+{
+class OPEngineEndpointsMapping
+{
+public:
+    using Handler = task::Task<Json::Value> (OPEngineEndpoints::*)(const Json::Value&);
+
+    OPEngineEndpointsMapping() { addHandlers(); }
+    ~OPEngineEndpointsMapping() = default;
+    OPEngineEndpointsMapping(const OPEngineEndpointsMapping&) = delete;
+    OPEngineEndpointsMapping& operator=(const OPEngineEndpointsMapping&) = delete;
+
+    [[nodiscard]] std::optional<Handler> findHandler(const std::string& _method) const;
+
+private:
+    void addHandlers();
+    void addEngineHandlers();
+
+    std::unordered_map<std::string, Handler> m_handlers;
+};
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineMethods.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/endpoints/OPEngineMethods.h
@@ -1,0 +1,48 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file OPEngineMethods.h
+ * @date 2026/5/20
+ */
+
+#pragma once
+
+#include <magic_enum/magic_enum.hpp>
+
+
+namespace bcos::rpc
+{
+enum class OPEngineMethod : uint8_t
+{
+    engine_exchangeCapabilities,
+    engine_forkchoiceUpdatedV1,
+    engine_forkchoiceUpdatedV2,
+    engine_forkchoiceUpdatedV3,
+    engine_forkchoiceUpdatedV4,
+    engine_getPayloadV1,
+    engine_getPayloadV2,
+    engine_getPayloadV3,
+    engine_getPayloadV4,
+    engine_newPayloadV1,
+    engine_newPayloadV2,
+    engine_newPayloadV3,
+    engine_newPayloadV4,
+};
+
+inline std::string methodString(OPEngineMethod _method)
+{
+    return std::string(magic_enum::enum_name(_method));
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/ForkchoiceUpdated.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/ForkchoiceUpdated.h
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ForkchoiceUpdated.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include "NewPayload.h"
+#include "Helper.h"
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
+
+namespace bcos::rpc
+{
+inline std::optional<bcos::engine::PayloadAttributes> parsePayloadAttributes(
+    Json::Value const& params, engine::ApiVersion version)
+{
+    return {};
+}
+
+inline bcos::engine::ForkchoiceState parseForkchoiceState(Json::Value const& params)
+{
+    return {};
+}
+
+inline Json::Value combineForkchoiceUpdatedResult(
+    bcos::engine::ForkchoiceUpdatedResult const& result, engine::ApiVersion version)
+{
+    return {};
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/GetPayload.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/GetPayload.h
@@ -1,0 +1,40 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file GetPayload.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include "Helper.h"
+#include <bcos-rpc/openginerpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+
+
+namespace bcos::rpc
+{
+inline Json::Value serializeExecutionPayload(
+    bcos::engine::ExecutionPayload const& payload, engine::ApiVersion version)
+{
+    return {};
+}
+
+inline void combineGetPayloadResponse(
+    Json::Value& _result, bcos::engine::GetPayloadResult const& _response,
+    engine::ApiVersion version)
+{
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/Helper.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/Helper.h
@@ -1,0 +1,42 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Helper.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <bcos-framework/engine/Types.h>
+#include <bcos-framework/protocol/TransactionFactory.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-utilities/Common.h>
+#include <json/json.h>
+#include <string>
+
+
+namespace bcos::rpc
+{
+inline bcos::h256 parseH256(std::string_view hex)
+{
+    return {};
+}
+
+inline bcos::Address parseAddress(std::string_view hex)
+{
+    return {};
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/NewPayload.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/NewPayload.h
@@ -1,0 +1,47 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NewPayload.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include <bcos-rpc/openginerpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include "Helper.h"
+
+
+namespace bcos::rpc
+{
+inline bcos::engine::NewPayloadRequest parseNewPayloadRequest(
+    Json::Value const& params, bcos::protocol::TransactionFactory& transactionFactory,
+    engine::ApiVersion version)
+{
+    return {};
+}
+
+inline Json::Value serializePayloadStatus(
+    bcos::engine::PayloadStatus const& status, engine::ApiVersion version)
+{
+    return {};
+}
+
+inline void combineNewPayloadResponse(
+    Json::Value& _result, bcos::engine::PayloadStatus const& _response, engine::ApiVersion version)
+{
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -2,6 +2,7 @@
 #include "Log.h"
 #include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
+#include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <cstdint>


### PR DESCRIPTION
本 PR 是 OP Engine RPC 的第二层——在 PR-2 的 OPEngineJsonRpcImpl 骨架之上，补齐 Engine API 的方法映射、请求解析和响应组装能力。替换 PR-2 中的桩实现为完整代码。

变更内容
OPEngineEndpoints 完整实现（endpoints/OPEngineEndpoints.h/.cpp）

13 个 Engine API 方法的桩替换为完整的 coroutine 实现。每个方法接收 const Json::Value&（已剥离 JSON-RPC envelope 的 params），返回 Task<Json::Value>。所有方法通过三个底层 handler 统一处理：

exchangeCapabilities：遍历 params 数组提取 capability 字符串列表，调用 engineService->exchangeCapabilities()，返回 JSON 数组。
handleForkchoiceUpdated：调用 helper 解析 forkchoiceState 和 payloadAttributes，调用 engineService->updateForkchoice()，通过 combineForkchoiceUpdatedResult 组装响应。
handleGetPayload：验证 params 格式（必须为单元素 string 数组），调用 engineService->getPayload()，通过 combineGetPayloadResponse 组装响应。
handleNewPayload：调用 helper 解析 NewPayloadRequest，调用 engineService->newPayload()，返回 PayloadStatus。
每个 handler 入口检查 m_engineService 是否可用，不可用时抛出 -32000 Engine service not available 错误。已标注 TODO 说明各 engineService 调用预期产生的 Engine API 专有错误码（-38001 到 -38006）。

OPEngineEndpointsMapping 完整实现（endpoints/OPEngineEndpointsMapping.h/.cpp）

桩替换为完整的 method → handler 映射表。Handler 类型为 task::Task<Json::Value> (OPEngineEndpoints::*)(const Json::Value&) 成员函数指针。映射表包含全部 13 个方法（V1-V4 各三个）：exchangeCapabilities、forkchoiceUpdatedV1-V4、getPayloadV1-V4、newPayloadV1-V4。

V4 方法在 mapper 的 lambda 中直接抛出 -38005 UnsupportedFork 错误。

OPEngineMethods（endpoints/OPEngineMethods.h）

OPEngineMethod 枚举完整定义（V1-V4 共 13 个枚举值）。methodString() 通过 magic_enum 将枚举值转为对应的 engine_* 方法名字符串。

Helper 函数——桩实现（helper/ 目录，4 个文件）

辅助函数均为空实现（co_return {}），后续 PR 替换。包括：

Helper.h：parseH256、parseAddress
ForkchoiceUpdated.h：parseForkchoiceState、parsePayloadAttributes、combineForkchoiceUpdatedResult
GetPayload.h：serializeExecutionPayload、combineGetPayloadResponse
NewPayload.h：parseNewPayloadRequest、serializePayloadStatus
这些 helper 在 PR-2 的 OPEngineEndpoints 桩中并未使用（桩方法直接 co_return {}），在本 PR 的完整实现中已全部接入，但功能实现留待后续 PR 补充。

架构
OPEngineEndpoints (完整实现)
  forkchoiceUpdatedV1-V4 → handleForkchoiceUpdated(version)
    → parseForkchoiceState() + parsePayloadAttributes() [helper stub]
    → engineService->updateForkchoice()
    → combineForkchoiceUpdatedResult() [helper stub]
  getPayloadV1-V4 → handleGetPayload(version)
    → engineService->getPayload()
    → combineGetPayloadResponse() [helper stub]
  newPayloadV1-V4 → handleNewPayload(version)
    → parseNewPayloadRequest() [helper stub]
    → engineService->newPayload()
    → serializePayloadStatus() [helper stub]
  exchangeCapabilities
    → engineService->exchangeCapabilities()
