### PR TITLE
feat(EngineRpc): add engine api parsing and serialization helper functions

### DIFF
--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -36,11 +36,12 @@ namespace bcos::engine
 /// Used as the fallback blockTxCountLimit in EngineServiceImpl and EngineServiceInitializer.
 inline constexpr int64_t c_defaultBlockTxCountLimit = 1000;
 
-enum class EngineApiVersion : std::uint8_t
+enum class ApiVersion : std::uint8_t
 {
     V1 = 1,
     V2 = 2,
     V3 = 3,
+    V4 = 4,
 };
 
 using PayloadID = std::string;

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/ForkchoiceUpdated.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/ForkchoiceUpdated.h
@@ -1,0 +1,88 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ForkchoiceUpdated.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include "NewPayload.h"
+#include "Helper.h"
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
+
+namespace bcos::rpc
+{
+inline std::optional<bcos::engine::PayloadAttributes> parsePayloadAttributes(
+    Json::Value const& params, engine::ApiVersion version)
+{
+    if (params.size() < 2 || params[1].isNull())
+    {
+        return std::nullopt;
+    }
+    auto const& pa = params[1];
+    bcos::engine::PayloadAttributes attrs{
+        .timestamp = fromQuantity(std::string(pa["timestamp"].asString())),
+        .prevRandao = parseH256(pa["prevRandao"].asString()),
+        .suggestedFeeRecipient = parseAddress(pa["suggestedFeeRecipient"].asString()),
+        .withdrawals = std::nullopt,
+        .parentBeaconBlockRoot = std::nullopt,
+        .slotNumber = std::nullopt,
+        .targetGasLimit = std::nullopt,
+    };
+    if (pa.isMember("withdrawals") && !pa["withdrawals"].isNull())
+    {
+        std::vector<bcos::engine::WithdrawalV1> withdrawals;
+        for (auto const& w : pa["withdrawals"])
+        {
+            withdrawals.push_back(bcos::engine::WithdrawalV1{
+                .index = fromBigQuantity(w["index"].asString()),
+                .validatorIndex = fromBigQuantity(w["validatorIndex"].asString()),
+                .address = parseAddress(w["address"].asString()),
+                .amount = fromBigQuantity(w["amount"].asString()),
+            });
+        }
+        attrs.withdrawals = std::move(withdrawals);
+    }
+    if (pa.isMember("parentBeaconBlockRoot") && !pa["parentBeaconBlockRoot"].isNull())
+    {
+        attrs.parentBeaconBlockRoot = parseH256(pa["parentBeaconBlockRoot"].asString());
+    }
+    return attrs;
+}
+
+inline bcos::engine::ForkchoiceState parseForkchoiceState(Json::Value const& params)
+{
+    auto const& fc = params[0u];
+    return bcos::engine::ForkchoiceState{
+        .headBlockHash = parseH256(fc["headBlockHash"].asString()),
+        .safeBlockHash = parseH256(fc["safeBlockHash"].asString()),
+        .finalizedBlockHash = parseH256(fc["finalizedBlockHash"].asString()),
+    };
+}
+
+inline Json::Value combineForkchoiceUpdatedResult(
+    bcos::engine::ForkchoiceUpdatedResult const& result, engine::ApiVersion version)
+{
+    Json::Value jsonResult(Json::objectValue);
+    jsonResult["payloadStatus"] = serializePayloadStatus(result.payloadStatus, version);
+    if (result.payloadId.has_value())
+    {
+        jsonResult["payloadId"] = *result.payloadId;
+    }
+    return jsonResult;
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/GetPayload.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/GetPayload.h
@@ -1,0 +1,130 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file GetPayload.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include "Helper.h"
+#include <bcos-rpc/openginerpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+
+
+namespace bcos::rpc
+{
+inline Json::Value serializeExecutionPayload(
+    bcos::engine::ExecutionPayload const& payload, engine::ApiVersion version)
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = payload.parentHash.hexPrefixed();
+    ep["feeRecipient"] = payload.feeRecipient.hexPrefixed();
+    ep["stateRoot"] = payload.stateRoot.hexPrefixed();
+    ep["receiptsRoot"] = payload.receiptsRoot.hexPrefixed();
+    ep["logsBloom"] = toPaddingHexStringWithPrefix(BloomBytesSize, payload.logsBloom);
+    ep["prevRandao"] = payload.prevRandao.hexPrefixed();
+    ep["blockNumber"] = toQuantity(payload.blockNumber);
+    ep["gasLimit"] = toQuantity(payload.gasLimit);
+    ep["gasUsed"] = toQuantity(payload.gasUsed);
+    ep["timestamp"] = toQuantity(payload.timestamp);
+    ep["extraData"] = toHexStringWithPrefix(payload.extraData);
+    ep["baseFeePerGas"] = toQuantity(payload.baseFeePerGas);
+    ep["blockHash"] = payload.blockHash.hexPrefixed();
+
+    Json::Value transactions(Json::arrayValue);
+    for (auto const& transaction : payload.transactions)
+    {
+        bytes encoded;
+        transaction->encode(encoded);
+        transactions.append(toHexStringWithPrefix(encoded));
+    }
+    ep["transactions"] = std::move(transactions);
+
+    if (payload.withdrawals.has_value())
+    {
+        Json::Value withdrawals(Json::arrayValue);
+        for (auto const& w : *payload.withdrawals)
+        {
+            Json::Value item(Json::objectValue);
+            item["index"] = toQuantity(w.index);
+            item["validatorIndex"] = toQuantity(w.validatorIndex);
+            item["address"] = w.address.hexPrefixed();
+            item["amount"] = toQuantity(w.amount);
+            withdrawals.append(std::move(item));
+        }
+        ep["withdrawals"] = std::move(withdrawals);
+    }
+    if (payload.blobGasUsed.has_value())
+    {
+        ep["blobGasUsed"] = toQuantity(*payload.blobGasUsed);
+    }
+    if (payload.excessBlobGas.has_value())
+    {
+        ep["excessBlobGas"] = toQuantity(*payload.excessBlobGas);
+    }
+    return ep;
+}
+
+inline void combineGetPayloadResponse(
+    Json::Value& _result, bcos::engine::GetPayloadResult const& _response,
+    engine::ApiVersion version)
+{
+    if (version == engine::ApiVersion::V1)
+    {
+        _result = serializeExecutionPayload(_response.executionPayload, version);
+        return;
+    }
+
+    _result["executionPayload"] = serializeExecutionPayload(_response.executionPayload, version);
+    _result["blockValue"] = toQuantity(_response.blockValue);
+
+    if (version == engine::ApiVersion::V2)
+    {
+        return;
+    }
+
+    // V3+: blobsBundle and shouldOverrideBuilder
+    Json::Value blobsBundle(Json::objectValue);
+    blobsBundle["commitments"] = Json::Value(Json::arrayValue);
+    blobsBundle["proofs"] = Json::Value(Json::arrayValue);
+    blobsBundle["blobs"] = Json::Value(Json::arrayValue);
+    if (_response.blobsBundle.has_value())
+    {
+        Json::Value commitments(Json::arrayValue);
+        for (auto const& commitment : _response.blobsBundle->commitments)
+        {
+            commitments.append(toHexStringWithPrefix(commitment));
+        }
+        blobsBundle["commitments"] = std::move(commitments);
+
+        Json::Value proofs(Json::arrayValue);
+        for (auto const& proof : _response.blobsBundle->proofs)
+        {
+            proofs.append(toHexStringWithPrefix(proof));
+        }
+        blobsBundle["proofs"] = std::move(proofs);
+
+        Json::Value blobs(Json::arrayValue);
+        for (auto const& blob : _response.blobsBundle->blobs)
+        {
+            blobs.append(toHexStringWithPrefix(blob));
+        }
+        blobsBundle["blobs"] = std::move(blobs);
+    }
+    _result["blobsBundle"] = std::move(blobsBundle);
+    _result["shouldOverrideBuilder"] = _response.shouldOverrideBuilder;
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/Helper.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/Helper.h
@@ -1,0 +1,69 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Helper.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <bcos-framework/engine/Types.h>
+#include <bcos-framework/protocol/TransactionFactory.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-utilities/Common.h>
+#include <json/json.h>
+#include <string>
+
+
+namespace bcos::rpc
+{
+[[noreturn]] inline void throwMissingRequiredField(
+    std::string_view context, std::string_view fieldName)
+{
+    // TODO: return the engine-method-specific error code for missing required fields.
+    BOOST_THROW_EXCEPTION(JsonRpcException(
+        InvalidParams, "Missing required field \"" + std::string(fieldName) + "\" in " +
+                           std::string(context)));
+}
+
+inline bcos::h256 parseH256(std::string_view hex)
+{
+    auto bytes = fromHex(hex);
+    if (bytes.size() != 32)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "Expected 32-byte hex string for h256, got " +
+                               std::to_string(bytes.size()) + " bytes"));
+    }
+    h256 result;
+    std::ranges::copy(bytes.begin(), bytes.end(), result.begin());
+    return result;
+}
+
+inline bcos::Address parseAddress(std::string_view hex)
+{
+    auto bytes = fromHex(hex);
+    if (bytes.size() != 20)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "Expected 20-byte hex string for address, got " +
+                               std::to_string(bytes.size()) + " bytes"));
+    }
+    Address result;
+    std::ranges::copy(bytes.begin(), bytes.end(), result.begin());
+    return result;
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/openginerpc/helper/NewPayload.h
+++ b/bcos-rpc/bcos-rpc/openginerpc/helper/NewPayload.h
@@ -1,0 +1,167 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NewPayload.h
+ * @date 2026/5/21
+ */
+
+#pragma once
+
+#include <bcos-rpc/openginerpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include "Helper.h"
+
+
+namespace bcos::rpc
+{
+inline bcos::engine::NewPayloadRequest parseNewPayloadRequest(
+    Json::Value const& params, bcos::protocol::TransactionFactory& transactionFactory,
+    engine::ApiVersion version)
+{
+    auto const& ep = params[0u];
+    bcos::engine::ExecutionPayload payload{
+        .parentHash = parseH256(ep["parentHash"].asString()),
+        .feeRecipient = parseAddress(ep["feeRecipient"].asString()),
+        .stateRoot = parseH256(ep["stateRoot"].asString()),
+        .receiptsRoot = parseH256(ep["receiptsRoot"].asString()),
+        .logsBloom = {},
+        .prevRandao = parseH256(ep["prevRandao"].asString()),
+        .blockNumber = static_cast<bcos::protocol::BlockNumber>(
+            fromQuantity(std::string(ep["blockNumber"].asString()))),
+        .gasLimit = fromBigQuantity(ep["gasLimit"].asString()),
+        .gasUsed = fromBigQuantity(ep["gasUsed"].asString()),
+        .timestamp = fromQuantity(std::string(ep["timestamp"].asString())),
+        .extraData = {},
+        .baseFeePerGas = fromBigQuantity(ep["baseFeePerGas"].asString()),
+        .blockHash = parseH256(ep["blockHash"].asString()),
+        .transactions = {},
+        .withdrawals = std::nullopt,
+        .blobGasUsed = std::nullopt,
+        .excessBlobGas = std::nullopt,
+        .blockAccessList = std::nullopt,
+        .slotNumber = std::nullopt,
+    };
+    if (ep.isMember("extraData"))
+    {
+        payload.extraData = fromHex(ep["extraData"].asString());
+    }
+    if (ep.isMember("logsBloom"))
+    {
+        auto bloomBytes = fromHex(ep["logsBloom"].asString());
+        if (bloomBytes.size() != BloomBytesSize)
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "Expected 256-byte hex string for logsBloom, got " +
+                                   std::to_string(bloomBytes.size()) + " bytes"));
+        }
+        std::copy(bloomBytes.begin(), bloomBytes.end(), payload.logsBloom.begin());
+    }
+    if (ep.isMember("transactions") && !ep["transactions"].isNull())
+    {
+        payload.transactions.reserve(ep["transactions"].size());
+        for (auto const& tx : ep["transactions"])
+        {
+            auto txData = fromHex(tx.asString());
+            payload.transactions.push_back(transactionFactory.decodeTransaction(ref(txData)));
+        }
+    }
+    if (ep.isMember("withdrawals") && !ep["withdrawals"].isNull())
+    {
+        std::vector<bcos::engine::WithdrawalV1> withdrawals;
+        for (auto const& w : ep["withdrawals"])
+        {
+            withdrawals.push_back(bcos::engine::WithdrawalV1{
+                .index = fromBigQuantity(w["index"].asString()),
+                .validatorIndex = fromBigQuantity(w["validatorIndex"].asString()),
+                .address = parseAddress(w["address"].asString()),
+                .amount = fromBigQuantity(w["amount"].asString()),
+            });
+        }
+        payload.withdrawals = std::move(withdrawals);
+    }
+    if (ep.isMember("blobGasUsed"))
+    {
+        payload.blobGasUsed = fromBigQuantity(ep["blobGasUsed"].asString());
+    }
+    if (ep.isMember("excessBlobGas"))
+    {
+        payload.excessBlobGas = fromBigQuantity(ep["excessBlobGas"].asString());
+    }
+
+    bcos::engine::NewPayloadRequest request{
+        .executionPayload = std::move(payload),
+        .expectedBlobVersionedHashes = {},
+        .parentBeaconBlockRoot = std::nullopt,
+        .executionRequests = std::nullopt,
+    };
+    if (version >= engine::ApiVersion::V3 &&
+        params.size() >= 2 && params[1].isArray())
+    {
+        for (auto const& h : params[1])
+        {
+            request.expectedBlobVersionedHashes.push_back(parseH256(h.asString()));
+        }
+    }
+    if (version >= engine::ApiVersion::V3 &&
+        params.size() >= 3 && !params[2].isNull())
+    {
+        request.parentBeaconBlockRoot = parseH256(params[2].asString());
+    }
+    return request;
+}
+
+inline Json::Value serializePayloadStatus(
+    bcos::engine::PayloadStatus const& status, engine::ApiVersion version)
+{
+    Json::Value result(Json::objectValue);
+    switch (status.status)
+    {
+    case bcos::engine::PayloadValidationStatus::Valid:
+        result["status"] = "VALID";
+        break;
+    case bcos::engine::PayloadValidationStatus::Invalid:
+        result["status"] = "INVALID";
+        break;
+    case bcos::engine::PayloadValidationStatus::Syncing:
+        result["status"] = "SYNCING";
+        break;
+    case bcos::engine::PayloadValidationStatus::Accepted:
+        result["status"] = "ACCEPTED";
+        break;
+    case bcos::engine::PayloadValidationStatus::InvalidBlockHash:
+        result["status"] =
+            (version >= engine::ApiVersion::V3) ?
+                "INVALID" :
+                "INVALID_BLOCK_HASH";
+        break;
+    }
+    if (status.latestValidHash.has_value())
+    {
+        result["latestValidHash"] = status.latestValidHash->hexPrefixed();
+    }
+    if (status.validationError.has_value())
+    {
+        result["validationError"] = *status.validationError;
+    }
+    return result;
+}
+
+inline void combineNewPayloadResponse(
+    Json::Value& _result, bcos::engine::PayloadStatus const& _response, engine::ApiVersion version)
+{
+    _result = serializePayloadStatus(_response, version);
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -2,6 +2,7 @@
 #include "Log.h"
 #include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
+#include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <cstdint>


### PR DESCRIPTION
本 PR 是 OP Engine RPC 的第三层——在 PR-3 的 OPEngineEndpoints 完整实现之上，补齐 Engine API 请求解析和响应组装的 helper 函数。替换 PR-3 中的桩实现为完整代码。

变更内容
Helper 函数——完整实现（bcos-rpc/openginerpc/helper/，4 个文件，共 454 行）

Helper.h — 基础字段解析工具（69 行）：

parseH256(string_view)：将 hex 字符串解析为 h256（32 字节）。校验长度是否为 32 字节，不合法时抛出 -32602 Invalid params 错误。
parseAddress(string_view)：将 hex 字符串解析为 Address（20 字节）。校验长度是否为 20 字节，不合法时抛出 -32602 Invalid params。
ForkchoiceUpdated.h — forkchoiceUpdated 相关解析与组装（88 行）：

parsePayloadAttributes(params, version)：从 params[1] 解析 PayloadAttributes。解析 timestamp、prevRandao、suggestedFeeRecipient 三个必填字段；optional 处理 withdrawals（WithdrawalV1 数组，包含 index、validatorIndex、address、amount）和 parentBeaconBlockRoot。params 中若不含 payloadAttributes 则返回 nullopt。
parseForkchoiceState(params)：从 params[0] 解析 ForkchoiceState。三个 hash 字段：headBlockHash、safeBlockHash、finalizedBlockHash。
combineForkchoiceUpdatedResult(result, version)：将 ForkchoiceUpdatedResult 组装为 JSON 对象。包含 payloadStatus（调用 serializePayloadStatus）和可选的 payloadId。
GetPayload.h — getPayload 相关序列化（130 行）：

serializeExecutionPayload(payload, version)：将 ExecutionPayload 序列化为 JSON。包含 parentHash、feeRecipient、stateRoot、receiptsRoot、logsBloom、prevRandao、blockNumber、gasLimit、gasUsed、timestamp、extraData、baseFeePerGas、blockHash、transactions（hex 编码数组）。withdrawals 和 blobGasUsed/excessBlobGas 按 optional 状态输出。
combineGetPayloadResponse(result, response, version)：组装 getPayload 完整响应。V1 直接返回 serialized payload；V2 返回 executionPayload + blockValue；V3 额外添加 blobsBundle（commitments/proofs/blobs 数组）和 shouldOverrideBuilder 布尔值。
NewPayload.h — newPayload 相关解析与序列化（167 行）：

parseNewPayloadRequest(params, txFactory, version)：从 params[0] 解析 NewPayloadRequest。解析完整的 ExecutionPayload（含 extraData、logsBloom 校验、transactions 解码）。V3 以上从 params[1] 解析 expectedBlobVersionedHashes，从 params[2] 解析 parentBeaconBlockRoot（均通过 version >= V3 判断）。
serializePayloadStatus(status, version)：将 PayloadStatus 序列化为 JSON。VALID/INVALID/SYNCING/ACCEPTED/INVALID_BLOCK_HASH 状态字符串映射。V3 以上 INVALID_BLOCK_HASH 改为 INVALID。
combineNewPayloadResponse：将 PayloadStatus 写入 JSON result。