### PR TITLE
fix(ci,utilities,build): make windows-2025 and macos-15-intel CI jobs pass on release-3.17.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -75,9 +75,16 @@ jobs:
       - name: Install macOS dependencies
         if: matrix.os == 'macos-15' || matrix.os == 'macos-15-intel'
         run: brew install libomp autoconf automake libtool
-      - name: Add MSbuild to PATH
+      - name: Set up MSVC environment
+        # The windows-2025 image ships Visual Studio 18 (2026), which the pinned
+        # CMake 3.28 cannot recognize as a generator: generator auto-detection
+        # falls back to "NMake Makefiles" and fails with "'nmake' '-?' failed"
+        # because nothing put the VC tools on PATH. Use the Ninja generator with
+        # cl.exe from the developer environment instead (version-agnostic).
         if: matrix.os == 'windows-2025'
-        uses: microsoft/setup-msbuild@v1.1
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
       - uses: actions-rs/toolchain@v1
         if: matrix.os != 'windows-2025'
         with:
@@ -123,7 +130,7 @@ jobs:
         run: |
           mkdir build -Force
           cd build
-          cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DALLOCATOR=default -DTESTS=OFF -DFULLNODE=OFF -DWITH_LIGHTNODE=OFF -DWITH_TARS_SERVICES=OFF -DWITH_CPPSDK=ON -DWITH_WASM=OFF -DWITH_TIKV=OFF -DTOOL=OFF -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ..
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=MinSizeRel -DALLOCATOR=default -DTESTS=OFF -DFULLNODE=OFF -DWITH_LIGHTNODE=OFF -DWITH_TARS_SERVICES=OFF -DWITH_CPPSDK=ON -DWITH_WASM=OFF -DWITH_TIKV=OFF -DTOOL=OFF -DVCPKG_TARGET_TRIPLET=x64-windows-static-release ..
       - name: Build
         run: |
           cd build

--- a/bcos-boostssl/bcos-boostssl/context/NodeInfoTools.cpp
+++ b/bcos-boostssl/bcos-boostssl/context/NodeInfoTools.cpp
@@ -20,6 +20,7 @@
 
 #include <bcos-boostssl/context/Common.h>
 #include <bcos-boostssl/context/NodeInfoTools.h>
+#include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FileUtility.h>
 #include <boost/algorithm/string/classification.hpp>

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpServer.cpp
@@ -20,6 +20,7 @@
 
 #include <bcos-boostssl/context/NodeInfoTools.h>
 #include <bcos-boostssl/httpserver/HttpServer.h>
+#include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/ThreadPool.h>
 #include <memory>
 #include <utility>
@@ -30,16 +31,16 @@ using namespace bcos::boostssl::http;
 using namespace bcos::boostssl::context;
 
 HttpServer::HttpServer(std::string _listenIP, uint16_t _listenPort, uint32_t _httpBodySizeLimit,
-        CorsConfig _corsConfig)
-    : m_listenIP(std::move(_listenIP)),
-        m_listenPort(_listenPort),
-        m_httpBodySizeLimit(_httpBodySizeLimit),
-        m_corsConfig(std::move(_corsConfig))
+    CorsConfig _corsConfig)
+  : m_listenIP(std::move(_listenIP)),
+    m_listenPort(_listenPort),
+    m_httpBodySizeLimit(_httpBodySizeLimit),
+    m_corsConfig(std::move(_corsConfig))
 {}
 
 HttpServer::~HttpServer()
 {
-        stop();
+    stop();
 }
 
 // start http server

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpSession.cpp
@@ -1,4 +1,5 @@
 #include "HttpSession.h"
+#include <bcos-utilities/BoostLog.h>
 #include <boost/system/error_code.hpp>
 
 bcos::boostssl::http::HttpSession::HttpSession(uint32_t _httpBodySizeLimit, CorsConfig _corsConfig)

--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpStream.cpp
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpStream.cpp
@@ -1,4 +1,5 @@
 #include "HttpStream.h"
+#include <bcos-utilities/BoostLog.h>
 
 std::string bcos::boostssl::http::HttpStream::localEndpoint()
 {

--- a/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/RawWsMessage.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <bcos-boostssl/websocket/RawWsMessage.h>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos::boostssl::ws;
 
@@ -40,16 +41,14 @@ uint16_t RawWsMessage::version() const
     return 0;
 }
 
-void RawWsMessage::setVersion(uint16_t)
-{}
+void RawWsMessage::setVersion(uint16_t) {}
 
 uint16_t RawWsMessage::packetType() const
 {
     return m_packetType;
 }
 
-void RawWsMessage::setPacketType(uint16_t)
-{}
+void RawWsMessage::setPacketType(uint16_t) {}
 
 std::string const& RawWsMessage::seq() const
 {
@@ -76,8 +75,7 @@ uint16_t RawWsMessage::ext() const
     return 0;
 }
 
-void RawWsMessage::setExt(uint16_t)
-{}
+void RawWsMessage::setExt(uint16_t) {}
 
 bool RawWsMessage::encode(bcos::bytes& _buffer)
 {
@@ -96,8 +94,7 @@ bool RawWsMessage::isRespPacket() const
     return false;
 }
 
-void RawWsMessage::setRespPacket()
-{}
+void RawWsMessage::setRespPacket() {}
 
 uint32_t RawWsMessage::length() const
 {

--- a/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsConnector.cpp
@@ -22,6 +22,7 @@
 #include <bcos-boostssl/websocket/Common.h>
 #include <bcos-boostssl/websocket/WsConnector.h>
 #include <bcos-boostssl/websocket/WsTools.h>
+#include <bcos-utilities/BoostLog.h>
 #include <boost/asio/error.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/beast/websocket/stream_base.hpp>

--- a/bcos-boostssl/bcos-boostssl/websocket/WsMessage.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsMessage.cpp
@@ -19,6 +19,7 @@
  */
 #include <bcos-boostssl/websocket/Common.h>
 #include <bcos-boostssl/websocket/WsMessage.h>
+#include <bcos-utilities/BoostLog.h>
 #include <boost/asio/detail/socket_ops.hpp>
 #include <iterator>
 
@@ -60,8 +61,7 @@ uint16_t WsMessage::version() const
     return m_version;
 }
 
-void WsMessage::setVersion(uint16_t)
-{}
+void WsMessage::setVersion(uint16_t) {}
 
 uint16_t WsMessage::packetType() const
 {

--- a/bcos-boostssl/bcos-boostssl/websocket/WsTools.cpp
+++ b/bcos-boostssl/bcos-boostssl/websocket/WsTools.cpp
@@ -20,6 +20,7 @@
 #include <bcos-boostssl/websocket/Common.h>
 #include <bcos-boostssl/websocket/WsConfig.h>
 #include <bcos-boostssl/websocket/WsTools.h>
+#include <bcos-utilities/BoostLog.h>
 #include <boost/algorithm/string.hpp>
 
 using namespace bcos;

--- a/bcos-crypto/bcos-crypto/hasher/AnyHasher.h
+++ b/bcos-crypto/bcos-crypto/hasher/AnyHasher.h
@@ -2,6 +2,8 @@
 #include "Hasher.h"
 #include "bcos-crypto/TrivialObject.h"
 #include <memory>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/primitives.hpp>
 #include <span>
 
 namespace bcos::crypto::hasher
@@ -73,9 +75,9 @@ public:
 
     void final(auto& output)
     {
-        if constexpr (
-            requires { output.resize(size_t{}); }) {
-                output.resize(hashSize());
+        if constexpr (requires { output.resize(size_t{}); })
+        {
+            output.resize(hashSize());
         }
 
         m_anyHasher->final(

--- a/bcos-framework/bcos-framework/ledger/LedgerTypeDef.h
+++ b/bcos-framework/bcos-framework/ledger/LedgerTypeDef.h
@@ -29,6 +29,8 @@
 #include <oneapi/tbb/concurrent_unordered_map.h>
 #include <boost/archive/binary_iarchive.hpp>
 #include <magic_enum/magic_enum.hpp>
+#include <range/v3/view/transform.hpp>
+#include <range/v3/view/zip.hpp>
 
 namespace bcos::ledger
 {

--- a/bcos-framework/bcos-framework/protocol/BlockHeader.h
+++ b/bcos-framework/bcos-framework/protocol/BlockHeader.h
@@ -27,6 +27,7 @@
 #include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <gsl/span>
+#include <range/v3/view/any_view.hpp>
 
 namespace bcos::protocol
 {
@@ -76,8 +77,8 @@ public:
         if (signatures.size() < sealers.size())
         {
             throwTrace(InvalidBlockHeader()
-                           << errinfo_comment("Invalid blockHeader for the size of sealerList "
-                                              "is smaller than the size of signatureList"));
+                       << errinfo_comment("Invalid blockHeader for the size of sealerList "
+                                          "is smaller than the size of signatureList"));
         }
         for (const auto& signature : signatures)
         {
@@ -88,8 +89,8 @@ public:
                     hash(), bytesConstRef(signatureData.data(), signatureData.size())))
             {
                 throwTrace(InvalidSignatureList() << errinfo_comment(
-                                   "Invalid signatureList for verify failed, signatureData:" +
-                                   toHex(signatureData)));
+                               "Invalid signatureList for verify failed, signatureData:" +
+                               toHex(signatureData)));
             }
         }
     }

--- a/bcos-framework/bcos-framework/storage/LegacyStorageMethods.h
+++ b/bcos-framework/bcos-framework/storage/LegacyStorageMethods.h
@@ -5,6 +5,8 @@
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-task/Task.h"
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/primitives.hpp>
 
 namespace bcos::storage
 {
@@ -77,8 +79,7 @@ task::Task<std::vector<std::optional<Entry>>> tag_invoke(
     }
     for (auto&& key : keys)
     {
-        values.emplace_back(
-            co_await storage2::readOne(storage, std::forward<decltype(key)>(key)));
+        values.emplace_back(co_await storage2::readOne(storage, std::forward<decltype(key)>(key)));
     }
 
     co_return values;
@@ -94,8 +95,8 @@ inline task::Task<void> tag_invoke(storage2::tag_t<storage2::writeSome> /*unused
     }
 }
 
-inline task::Task<void> tag_invoke(
-    storage2::tag_t<storage2::writeOne> /*unused*/, StorageInterface& storage, auto stateKey, Entry entry)
+inline task::Task<void> tag_invoke(storage2::tag_t<storage2::writeOne> /*unused*/,
+    StorageInterface& storage, auto stateKey, Entry entry)
 {
     struct Awaitable
     {

--- a/bcos-framework/bcos-framework/transaction-scheduler/TransactionScheduler.h
+++ b/bcos-framework/bcos-framework/transaction-scheduler/TransactionScheduler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-task/Trait.h"
+#include <range/v3/range/concepts.hpp>
 
 namespace bcos::scheduler_v1
 {

--- a/bcos-framework/bcos-framework/txpool/TxPoolInterface.h
+++ b/bcos-framework/bcos-framework/txpool/TxPoolInterface.h
@@ -25,6 +25,7 @@
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Error.h"
 #include <boost/throw_exception.hpp>
+#include <range/v3/view/any_view.hpp>
 #include <stdexcept>
 
 namespace bcos::txpool

--- a/bcos-sdk/bcos-cpp-sdk/amop/Common.h
+++ b/bcos-sdk/bcos-cpp-sdk/amop/Common.h
@@ -18,6 +18,7 @@
  * @date 2021-08-25
  */
 #pragma once
+#include <bcos-utilities/BoostLog.h>
 
 #define AMOP_CLIENT(LEVEL) BCOS_LOG(LEVEL) << "[AMOP][CLIENT]"
 #define AMOP_TOPIC_MANAGER(LEVEL) BCOS_LOG(LEVEL) << "[AMOP][TOPICMANAGER]"

--- a/bcos-sdk/bcos-cpp-sdk/event/EventSub.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/event/EventSub.cpp
@@ -26,6 +26,7 @@
 #include <bcos-cpp-sdk/event/EventSubRequest.h>
 #include <bcos-cpp-sdk/event/EventSubResponse.h>
 #include <bcos-cpp-sdk/event/EventSubStatus.h>
+#include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/Common.h>
 #include <json/reader.h>
 #include <boost/thread/thread.hpp>

--- a/bcos-sdk/bcos-cpp-sdk/event/EventSub.h
+++ b/bcos-sdk/bcos-cpp-sdk/event/EventSub.h
@@ -24,6 +24,7 @@
 #include <bcos-cpp-sdk/event/EventSubInterface.h>
 #include <bcos-cpp-sdk/event/EventSubTask.h>
 #include <bcos-cpp-sdk/ws/Service.h>
+#include <bcos-utilities/BoostLog.h>
 #include <boost/thread/thread.hpp>
 #include <atomic>
 #include <memory>

--- a/bcos-sdk/bcos-cpp-sdk/event/EventSubParams.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/event/EventSubParams.cpp
@@ -20,6 +20,7 @@
 
 #include <bcos-cpp-sdk/event/EventSubParams.h>
 #include <bcos-cpp-sdk/utilities/abi/ContractABIEventTopic.h>
+#include <bcos-utilities/BoostLog.h>
 #include <json/json.h>
 #include <exception>
 
@@ -129,7 +130,7 @@ void EventSubParams::fromJson(const Json::Value& jParams)
             if (jIndex.isArray())
             {  // array topics
                 for (Json::Value::ArrayIndex innerIndex = 0; innerIndex < jIndex.size();
-                     ++innerIndex)
+                    ++innerIndex)
                 {
                     addTopic(index, jIndex[innerIndex].asString());
                 }

--- a/bcos-sdk/bcos-cpp-sdk/event/EventSubRequest.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/event/EventSubRequest.cpp
@@ -20,6 +20,7 @@
 
 #include <bcos-cpp-sdk/event/Common.h>
 #include <bcos-cpp-sdk/event/EventSubRequest.h>
+#include <bcos-utilities/BoostLog.h>
 
 #include <json/json.h>
 #include <exception>
@@ -246,7 +247,7 @@ bool EventSubSubRequest::fromJson(const std::string& _request)
                     if (jIndex.isArray())
                     {  // array topics
                         for (Json::Value::ArrayIndex innerIndex = 0; innerIndex < jIndex.size();
-                             ++innerIndex)
+                            ++innerIndex)
                         {
                             params->addTopic(index, jIndex[innerIndex].asString());
                         }

--- a/bcos-sdk/bcos-cpp-sdk/event/EventSubResponse.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/event/EventSubResponse.cpp
@@ -19,6 +19,7 @@
  */
 #include <bcos-cpp-sdk/event/Common.h>
 #include <bcos-cpp-sdk/event/EventSubResponse.h>
+#include <bcos-utilities/BoostLog.h>
 #include <json/json.h>
 #include <boost/exception/diagnostic_information.hpp>
 

--- a/bcos-sdk/bcos-cpp-sdk/event/EventSubTask.h
+++ b/bcos-sdk/bcos-cpp-sdk/event/EventSubTask.h
@@ -23,6 +23,7 @@
 #include <bcos-cpp-sdk/event/Common.h>
 #include <bcos-cpp-sdk/event/EventSubInterface.h>
 #include <bcos-cpp-sdk/event/EventSubParams.h>
+#include <bcos-utilities/BoostLog.h>
 #include <atomic>
 #include <utility>
 

--- a/bcos-sdk/bcos-cpp-sdk/rpc/Common.h
+++ b/bcos-sdk/bcos-cpp-sdk/rpc/Common.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/Common.h>
 #include <json/json.h>
 #include <json/value.h>

--- a/bcos-sdk/bcos-cpp-sdk/rpc/JsonRpcImpl.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/rpc/JsonRpcImpl.cpp
@@ -21,6 +21,7 @@
 #include <bcos-boostssl/websocket/WsError.h>
 #include <bcos-cpp-sdk/rpc/Common.h>
 #include <bcos-cpp-sdk/rpc/JsonRpcImpl.h>
+#include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <json/value.h>

--- a/bcos-sdk/bcos-cpp-sdk/rpc/JsonRpcImpl.h
+++ b/bcos-sdk/bcos-cpp-sdk/rpc/JsonRpcImpl.h
@@ -23,6 +23,7 @@
 #include <bcos-cpp-sdk/rpc/JsonRpcRequest.h>
 #include <bcos-cpp-sdk/ws/Service.h>
 #include <bcos-framework/multigroup/GroupInfoCodec.h>
+#include <bcos-utilities/BoostLog.h>
 #include <functional>
 #include <utility>
 

--- a/bcos-sdk/bcos-cpp-sdk/utilities/Common.h
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/Common.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include <bcos-cpp-sdk/utilities/logger/LogInitializer.h>
+#include <bcos-utilities/BoostLog.h>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 

--- a/bcos-sdk/bcos-cpp-sdk/ws/Common.h
+++ b/bcos-sdk/bcos-cpp-sdk/ws/Common.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include <bcos-utilities/BoostLog.h>
 #include <bcos-utilities/Common.h>
 
 #define RPC_WS_LOG(LEVEL) BCOS_LOG(LEVEL) << "[RPCWS][SERVICE]"

--- a/bcos-sdk/bcos-cpp-sdk/ws/HandshakeResponse.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/ws/HandshakeResponse.cpp
@@ -20,6 +20,7 @@
 
 #include <bcos-cpp-sdk/ws/Common.h>
 #include <bcos-cpp-sdk/ws/HandshakeResponse.h>
+#include <bcos-utilities/BoostLog.h>
 #include <json/json.h>
 #include <json/value.h>
 

--- a/bcos-tars-protocol/CMakeLists.txt
+++ b/bcos-tars-protocol/CMakeLists.txt
@@ -29,6 +29,13 @@ file(GLOB_RECURSE SRC_LIST bcos-tars-protocol/*.cpp)
 file(GLOB_RECURSE CLIENT_SRC bcos-tars-protocol/client/*.cpp)
 if (ONLY_CPP_SDK AND (NOT WITH_SWIG_SDK))
     list(REMOVE_ITEM SRC_LIST ${CLIENT_SRC})
+    # GroupInfoCodecImpl.cpp implements group-info codec on top of the
+    # toBcosGroupInfo/toTarsGroupInfo helpers that Common.h compiles out under
+    # ONLY_CPP_SDK (#if !ONLY_CPP_SDK). All of its users (bcos-rpc,
+    # bcos-gateway, libinitializer) are full-node components, so drop it from
+    # SDK-only builds like the service clients above.
+    list(REMOVE_ITEM SRC_LIST
+        ${CMAKE_CURRENT_SOURCE_DIR}/bcos-tars-protocol/protocol/GroupInfoCodecImpl.cpp)
 endif ()
 find_package(tarscpp REQUIRED)
 find_package(TBB REQUIRED)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -1,5 +1,6 @@
 #include "FrontServiceClient.h"
 #include "bcos-tars-protocol/ErrorConverter.h"
+#include <range/v3/view/any_view.hpp>
 
 void bcostars::FrontServiceClient::start() {}
 void bcostars::FrontServiceClient::stop() {}

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
@@ -6,6 +6,7 @@
 #include <bcos-tars-protocol/protocol/GroupNodeInfoImpl.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/RefDataContainer.h>
+#include <range/v3/view/any_view.hpp>
 
 namespace bcostars
 {

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -23,6 +23,7 @@
 #include "bcos-tars-protocol/tars/GatewayService.h"
 #include <bcos-crypto/interfaces/crypto/KeyFactory.h>
 #include <bcos-framework/gateway/GatewayInterface.h>
+#include <range/v3/view/any_view.hpp>
 #include <string>
 
 #define GATEWAYCLIENT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[GATEWAYCLIENT][INITIALIZER]"

--- a/bcos-tars-protocol/bcos-tars-protocol/client/TxPoolServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/TxPoolServiceClient.cpp
@@ -1,6 +1,8 @@
 #include "TxPoolServiceClient.h"
 
 #include <memory>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/transform.hpp>
 #include <utility>
 
 bcostars::TxPoolServiceClient::TxPoolServiceClient(bcostars::TxPoolServicePrx _proxy,

--- a/bcos-tars-protocol/bcos-tars-protocol/impl/TarsSerializable.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/impl/TarsSerializable.h
@@ -3,6 +3,8 @@
 #include "TarsStruct.h"
 #include <bcos-concepts/Basic.h>
 #include <bcos-concepts/ByteBuffer.h>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/primitives.hpp>
 
 namespace bcostars
 {

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
@@ -26,6 +26,8 @@
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/Exceptions.h"
 #include <boost/endian/conversion.hpp>
+#include <range/v3/view/any_view.hpp>
+#include <range/v3/view/transform.hpp>
 
 DERIVE_BCOS_EXCEPTION(EmptyBlockHeaderHash);
 
@@ -70,7 +72,8 @@ void bcostars::protocol::BlockHeaderImpl::clear()
     m_inner()->resetDefautlt();
 }
 
-::ranges::any_view<bcos::protocol::ParentInfo, ::ranges::category::input | ::ranges::category::sized>
+::ranges::any_view<bcos::protocol::ParentInfo,
+    ::ranges::category::input | ::ranges::category::sized>
 bcostars::protocol::BlockHeaderImpl::parentInfo() const
 {
     return m_inner()->data.parentInfo |

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.h
@@ -30,6 +30,7 @@
 #include <bcos-framework/protocol/BlockHeader.h>
 #include <bcos-framework/protocol/ProtocolTypeDef.h>
 #include <gsl/span>
+#include <range/v3/view/any_view.hpp>
 
 namespace bcostars::protocol
 {

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.cpp
@@ -19,9 +19,15 @@
  * @date 2021-04-20
  */
 
-#include "BlockImpl.h"
+// On Windows tup/Tars.h must be parsed before the generated tars headers,
+// otherwise the tars namespace is broken for them (same workaround as
+// bcos-tars-protocol/Common.h).
+#ifdef _WIN32
+#include <tup/Tars.h>
+#endif
 #include "../impl/TarsHashable.h"
 #include "../impl/TarsSerializable.h"
+#include "BlockImpl.h"
 #include "bcos-concepts/Serialize.h"
 #include "bcos-framework/protocol/TransactionReceipt.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockImpl.h
@@ -33,6 +33,7 @@
 #include <bcos-framework/protocol/BlockHeader.h>
 #include <gsl/span>
 #include <memory>
+#include <range/v3/view/any_view.hpp>
 
 namespace bcostars::protocol
 {

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/GroupNodeInfoImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/GroupNodeInfoImpl.h
@@ -21,6 +21,12 @@
 
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+// On Windows tup/Tars.h must be parsed before the generated tars headers,
+// otherwise the tars namespace is broken for them (same workaround as
+// bcos-tars-protocol/Common.h).
+#ifdef _WIN32
+#include <tup/Tars.h>
+#endif
 #include <bcos-framework/gateway/GroupNodeInfo.h>
 #include <bcos-framework/protocol/ProtocolInfo.h>
 #include <bcos-tars-protocol/tars/GatewayInfo.h>

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/MemberImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/MemberImpl.h
@@ -22,6 +22,12 @@
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
+// On Windows tup/Tars.h must be parsed before the generated tars headers,
+// otherwise the tars namespace is broken for them (same workaround as
+// bcos-tars-protocol/Common.h).
+#ifdef _WIN32
+#include <tup/Tars.h>
+#endif
 #include "bcos-tars-protocol/tars/Member.h"
 #include <bcos-framework/protocol/MemberInterface.h>
 namespace bcostars

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionMetaDataImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionMetaDataImpl.h
@@ -20,6 +20,12 @@
  */
 #pragma once
 
+// On Windows tup/Tars.h must be parsed before the generated tars headers,
+// otherwise the tars namespace is broken for them (same workaround as
+// bcos-tars-protocol/Common.h).
+#ifdef _WIN32
+#include <tup/Tars.h>
+#endif
 #include "bcos-framework/protocol/TransactionMetaData.h"
 #include "bcos-tars-protocol/tars/TransactionMetaData.h"
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionSubmitResultImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionSubmitResultImpl.h
@@ -21,6 +21,12 @@
 
 #pragma once
 
+// On Windows tup/Tars.h must be parsed before the generated tars headers,
+// otherwise the tars namespace is broken for them (same workaround as
+// bcos-tars-protocol/Common.h).
+#ifdef _WIN32
+#include <tup/Tars.h>
+#endif
 #include "bcos-tars-protocol/tars/TransactionSubmitResult.h"
 #include <bcos-crypto/interfaces/crypto/CommonType.h>
 #include <bcos-crypto/interfaces/crypto/CryptoSuite.h>

--- a/bcos-utilities/bcos-utilities/Base64.cpp
+++ b/bcos-utilities/bcos-utilities/Base64.cpp
@@ -23,6 +23,7 @@
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
 #include <boost/iostreams/copy.hpp>
+#include <range/v3/range/access.hpp>
 
 using namespace boost::archive::iterators;
 

--- a/bcos-utilities/bcos-utilities/Bloom.h
+++ b/bcos-utilities/bcos-utilities/Bloom.h
@@ -22,6 +22,8 @@
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-framework/protocol/LogEntry.h"
 #include "bcos-utilities/Common.h"
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/traits.hpp>
 
 namespace bcos
 {

--- a/bcos-utilities/bcos-utilities/Timer.cpp
+++ b/bcos-utilities/bcos-utilities/Timer.cpp
@@ -48,6 +48,15 @@ bcos::Timer::Timer(int64_t _timeout, std::string _threadName)
             if (ioContext.stopped())
             {
                 ioContext.restart();
+                // destroy() publishes m_working=false before calling ioService().stop().
+                // If that stop() landed between the stopped() check and restart(), the
+                // restart() above just erased it; without this re-check the loop would
+                // enter run() under a fresh work guard and block forever, deadlocking
+                // destroy() in m_worker->join() (FIB135 test hang on CI).
+                if (!m_working)
+                {
+                    break;
+                }
             }
             try
             {

--- a/concepts/bcos-concepts/ByteBuffer.h
+++ b/concepts/bcos-concepts/ByteBuffer.h
@@ -3,6 +3,10 @@
 #include "Basic.h"
 #include <boost/throw_exception.hpp>
 #include <algorithm>
+#include <range/v3/range/access.hpp>
+#include <range/v3/range/concepts.hpp>
+#include <range/v3/range/primitives.hpp>
+#include <range/v3/range/traits.hpp>
 
 namespace bcos::concepts::bytebuffer
 {

--- a/ports/benchmark/portfile.cmake
+++ b/ports/benchmark/portfile.cmake
@@ -1,0 +1,28 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/benchmark
+    REF "v${VERSION}"
+    SHA512 f9031f144a7deeed151d22676b50384c03e5bbd19b68dac9471e91e49c408b770158c5c325f58e6ac07437955fdab3f08aeee76ba7ca5f97d2b51f14f6782416
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+    OPTIONS
+        -DBENCHMARK_ENABLE_TESTING=OFF
+        -DBENCHMARK_INSTALL_DOCS=OFF
+        -DBENCHMARK_ENABLE_WERROR=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/benchmark)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/benchmark/vcpkg.json
+++ b/ports/benchmark/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "$comment": "https://github.com/google/benchmark/issues/661 describes the missing UWP support upstream",
+  "name": "benchmark",
+  "version-semver": "1.9.4",
+  "description": "A library to benchmark code snippets, similar to unit tests.",
+  "homepage": "https://github.com/google/benchmark",
+  "license": "Apache-2.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -19,6 +19,7 @@
     "./ports/boost-context",
     "./ports/tarscpp",
     "./ports/rapidhash",
-    "./ports/openssl"
+    "./ports/openssl",
+    "./ports/benchmark"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -43,6 +43,7 @@
     },
     "fmt",
     "secp256k1",
+    "evmc",
     {
       "name": "aws-sdk-cpp",
       "features": [
@@ -63,7 +64,6 @@
       "description": "Full node dependencies",
       "dependencies": [
         "evmone",
-        "evmc",
         "boost-coroutine2",
         {
           "name": "rocksdb",


### PR DESCRIPTION
# Motivation

The `windows-2025` and `macos-15-intel` jobs of the Github runner workflow have failed on every push to `release-3.17.0` (runs 28000244044, 28347199573, 28488927147). Four independent root causes; the last fully-green run was 25547976790 (2026-05-08):

**1. windows-2025: CMake cannot detect Visual Studio 2026 (deterministic, fails at configure)**

The runner image now ships only Visual Studio 18 (2026) (`C:\Program Files\Microsoft Visual Studio\18\Enterprise`, MSVC 14.44). The workflow pins CMake 3.28.3 via `lukka/get-cmake`, which predates the `Visual Studio 18 2026` generator, so generator auto-detection finds no usable VS instance, silently falls back to `NMake Makefiles`, and fails at `CMakeLists.txt:32 (project)` with `Running 'nmake' '-?' failed` — `setup-msbuild` only puts `msbuild` on PATH, not the VC tools. vcpkg still built all dependencies because it locates `cl.exe` through its own vswhere logic, which is why the job died only after the 55-minute vcpkg install.

**1b. windows-2025: missing evmc header in the cpp-sdk dependency set (deterministic, fails at build; masked by 1.)**

Once configure is fixed, the build fails with `ChecksumAddress.h(25): fatal error C1083: Cannot open include file: 'evmc/evmc.h'`. `bcos-crypto` exposes `evmc_address` in its public API and compiles `ChecksumAddress.cpp` unconditionally since the header-to-source refactor, but `evmc` lived only in the `fullnode` vcpkg feature, which the windows `WITH_CPPSDK`-only build disables. This exact error is what first broke `Build (windows-2025)` in mid-May (run 26744054510, 2026-06-01, same C1083 under the old VS generator) — the VS2026 image update later moved the failure to configure and hid it. `bcos-framework` ledger headers (`Account.h`/`EVMAccount.h`/`LedgerConfig.h`) also use evmc types. Fix: move `evmc` (headers + small static libs) into the base dependencies; `evmone`, the heavy dependency, stays in `fullnode`.

**2. macos-15-intel: `TxpoolMemoryStorageTest/FIB48_SubmitTransactionResumesOnce` segfault (runs of 06-23 and 06-29)**

`memory access violation at address: 0x7000...: no mapping at fault address` — a freed thread stack. `task::syncWait` (`libtask/bcos-task/Wait.h`) keeps the result variant and the `finished`/`waitFlag` handshake flags on the waiter's stack and hands references into a detached coroutine. When the awaited task completes on a *different* thread (here: the test's main thread firing the tx-submit callback from `batchRemoveSealedTxs`), the completing thread still touches that stack (result emplace, `waitFlag.test_and_set()/notify_one()`) and the inner coroutine frame (its `final_suspend` reads `promise().m_continuation`) after the point where the waiter is allowed to wake. The waiter can then return from `syncWait`, run `~Task` (`m_handle.destroy()` on the frame the completer is still executing in), and exit its thread — unmapping the stack the completer is about to dereference.

*Update 2026-07-21: the `Wait.h` fix for this root cause has been extracted from this PR to a separate branch (`fix/syncwait-teardown-race`) for separate review. The analysis above still stands, but this PR no longer changes `Wait.h`, so FIB48 is not addressed here.*

**3. macos-15-intel: `FIB135Test/view_change_backoff_is_bounded` 1500 s ctest timeout (run of 07-01)**

`Timer::destroy()` (`bcos-utilities/Timer.cpp`) publishes `m_working = false`, then calls `stop()` and `ioService().stop()`, then joins the worker. If the worker thread is between its `while (m_working)` check and the `ioContext.stopped()` check at that moment, it observes `stopped() == true`, calls `ioContext.restart()` — erasing the stop `destroy()` just issued — grabs a fresh work guard and blocks in `ioContext.run()` forever. `destroy()` then deadlocks in `m_worker->join()`. The FIB135 test constructs and destroys a `PBFTTimer` within microseconds of thread spawn, which maximizes exposure to this window.

# Changes

- `bcos-utilities/bcos-utilities/Timer.cpp`: the worker loop re-checks `m_working` immediately after `ioContext.restart()`. `destroy()` orders `m_working = false` before `ioService().stop()`, so any `restart()` that erased destroy's stop is followed by a `m_working` load that observes `false` and exits the loop.
- `.github/workflows/workflow.yml`: replace `microsoft/setup-msbuild` with `ilammy/msvc-dev-cmd@v1` (arch x64) and configure with `-G Ninja` (ninja 1.12.1 is already installed by `get-cmake`), so CMake never needs to recognize the VS instance version.
- `vcpkg.json`: move `evmc` from the `fullnode` feature into the base dependencies. Note this changes the vcpkg cache key, so every job rebuilds its dependency cache once on this PR.
- `ports/benchmark/`, `vcpkg-configuration.json`: add a benchmark overlay port that drops the `-Werror=old-style-cast` line the upstream vcpkg portfile passes as a CMake command-line option. CMake's `-Werror=` only accepts the `dev`/`deprecated` categories; CMake 3 silently ignores the unknown category, CMake 4 fails configure with `The warning category "old-style-cast" is not known.` The line is dead anyway — the port already sets `-DBENCHMARK_ENABLE_WERROR=OFF` — so behavior is identical under CMake 3 and 4, and the overlay can be dropped once the vcpkg submodule is bumped past the upstream fix.

# Testing

- Local (macOS arm64, Debug): full `test-bcos-txpool`, `test-bcos-pbft`, `test-bcos-utilities`, `test-task` suites — no errors detected.
- Stress: `TxpoolMemoryStorageTest/FIB48_SubmitTransactionResumesOnce` x300 and `FIB135Test` x300 — 0 failures.
- Full repo build (every `Wait.h` includer recompiled, `fisco-bcos` linked) + full ctest suite: 100% tests passed, 0 tests failed out of 999.
- Final CI (run 28614352063, head 4f793cb31): **all six jobs green** — Build (windows-2025), Build (macos-15-intel), Build (ubuntu-24.04), Build (ubuntu-24.04-arm), Build (macos-15), Coverage. macos-15-intel also passed its full Test step on round 1 (d80e86eff), confirming the syncWait/Timer fixes on the previously-failing runner.
- *Update 2026-07-21:* the all-green run above was on a head whose history still contained the `Wait.h` fix. The current head (32e22bdf4) has that fix extracted and adds the benchmark overlay, so the fresh CI run on this head is the authoritative result; without the `Wait.h` change the FIB48 segfault on macos-15-intel may reappear.
- The windows build surfaced three further MSVC-only latent breakages beyond the four root causes above, fixed iteratively (the SDK-scope code had not compiled under MSVC since the late-April header-to-source refactors): missing direct range-v3 includes (2fe2efbfb, 17 files), GroupInfoCodecImpl.cpp compiling an API that Common.h compiles out under ONLY_CPP_SDK (b34385e33), tup/Tars.h ordering for generated tars headers (4e86ef32d, the Common.h workaround applied to 5 unprotected files), and missing BoostLog.h includes in bcos-sdk/bcos-boostssl (4f793cb31, 21 files).

