### PR TITLE
feat(mpt): EIP-1186 account + storage proof generation (M8.1)

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/Proof.h
+++ b/bcos-ledger/bcos-ledger/mpt/Proof.h
@@ -44,16 +44,28 @@ namespace bcos::ledger::mpt
 {
 namespace detail
 {
-/// The "secure trie" key transform for storage slots: the trie path is keccak256 of the raw
-/// 32-byte slot key. Mirrors accountKeyHash (MPTReadView.h) for the account trie (spec §5.9).
-/// Kept in detail: #5310 introduces the shared mpt::slotKeyHash (StorageValueCodec.h) — once
-/// both land, this duplicate folds into it. detail scoping avoids an ODR clash meanwhile.
-inline bcos::h256 slotKeyHash(bcos::h256 const& slot)
+/// The "secure trie" key transform for storage slots: hash of the raw 32-byte slot key
+/// (keccak256 on Ethereum-compatible chains, SM3 on guomi ones — whatever @p hasher computes).
+/// Mirrors accountKeyHash (MPTReadView.h) for the account trie (spec §5.9).
+/// Kept in detail with the SAME signature as #5310's shared mpt::slotKeyHash
+/// (StorageValueCodec.h) — once both land, this duplicate folds into it mechanically.
+/// detail scoping avoids an ODR clash meanwhile.
+///
+/// Hasher-injection form: the caller owns @p hasher and reuses it across calls
+/// (generateProof hashes one slot key per requested slot).
+template <bcos::crypto::hasher::Hasher HasherT>
+bcos::h256 slotKeyHash(bcos::h256 const& slot, HasherT& hasher)
 {
-    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
     bcos::h256 out;
     bcos::crypto::hasher::hash(hasher, slot.ref(), out);
     return out;
+}
+
+/// Convenience overload constructing a fresh keccak256 hasher per call (tests, one-off use).
+inline bcos::h256 slotKeyHash(bcos::h256 const& slot)
+{
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    return slotKeyHash(slot, hasher);
 }
 }  // namespace detail
 
@@ -231,7 +243,14 @@ bcos::task::Task<ProofWalk> proofWalk(Storage& storage, bcos::h256 root, bcos::b
 /// @throws MPTInvariantViolation on storage inconsistency (a committed root referencing a missing
 /// node), MPTDecodeError on a malformed account leaf — programming/data errors, not request
 /// errors.
-template <bcos::storage2::ReadableStorage<bcos::h256> Storage>
+///
+/// @tparam HasherT the slot-key hash function (Hasher concept), owned here and reused across the
+/// requested slots; keccak256 by default, SM3 for guomi deployments (same end-to-end caveat as
+/// the builders: accountKeyHash and the trie the proof reads were produced with the chain's
+/// hasher — parameterizing this function alone does not make an SM3 chain, it keeps the door
+/// open for one).
+template <bcos::storage2::ReadableStorage<bcos::h256> Storage,
+    bcos::crypto::hasher::Hasher HasherT = bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher>
 bcos::task::Task<std::variant<EIP1186Proof, ProofErrorCode>> generateProof(Storage& storage,
     bcos::h256 stateRoot, bcos::Address address, std::span<bcos::h256 const> slots)
 {
@@ -262,13 +281,14 @@ bcos::task::Task<std::variant<EIP1186Proof, ProofErrorCode>> generateProof(Stora
     out.accountProof = std::move(accountWalk.nodes);
 
     out.storageProof.reserve(slots.size());
+    HasherT hasher;  // one hash context, reused for every requested slot's key transform
     for (auto const& slot : slots)
     {
         StorageProof entry;
         entry.key = slot;
         if (account.storageRoot != emptyRootHash())
         {
-            auto const slotHash = detail::slotKeyHash(slot);
+            auto const slotHash = detail::slotKeyHash(slot, hasher);
             auto slotWalk = co_await detail::proofWalk(
                 storage, account.storageRoot, bytesToNibbles(slotHash.ref()));
             if (slotWalk.rootMissing)

--- a/bcos-ledger/bcos-ledger/mpt/Proof.h
+++ b/bcos-ledger/bcos-ledger/mpt/Proof.h
@@ -1,0 +1,294 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Proof.h
+ * @brief EIP-1186 account + storage proof generation over an MPT state root (spec §5.9)
+ */
+#pragma once
+
+#include "Account.h"
+#include "Constants.h"
+#include "Errors.h"
+#include "MPTReadView.h"
+#include "Nibble.h"
+#include "NodeDecoder.h"
+#include "TrieNode.h"
+// AnyHasher.h defines the free bcos::crypto::hasher::hash(); OpenSSLHasher.h only defines the
+// hasher type. A unity build can mask a missing include of the former, so keep both explicit.
+#include <bcos-crypto/hasher/AnyHasher.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/throw_exception.hpp>
+#include <algorithm>
+#include <optional>
+#include <span>
+#include <variant>
+#include <vector>
+
+namespace bcos::ledger::mpt
+{
+namespace detail
+{
+/// The "secure trie" key transform for storage slots: the trie path is keccak256 of the raw
+/// 32-byte slot key. Mirrors accountKeyHash (MPTReadView.h) for the account trie (spec §5.9).
+/// Kept in detail: #5310 introduces the shared mpt::slotKeyHash (StorageValueCodec.h) — once
+/// both land, this duplicate folds into it. detail scoping avoids an ODR clash meanwhile.
+inline bcos::h256 slotKeyHash(bcos::h256 const& slot)
+{
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    bcos::h256 out;
+    bcos::crypto::hasher::hash(hasher, slot.ref(), out);
+    return out;
+}
+}  // namespace detail
+
+/// Proof for one storage slot (spec §5.9). For an absent slot, EIP-1186 semantics apply: value is
+/// empty (JSON 0x0) and proof holds the nodes visited until the walk dead-ended (exclusion proof).
+struct StorageProof
+{
+    bcos::h256 key;  ///< the raw 32-byte slot key as requested (NOT keccak-transformed)
+    /// The leaf value exactly as stored in the trie — the RLP encoding of the big-endian-trimmed
+    /// slot value, matching go-ethereum. Empty when the slot is absent.
+    bcos::bytes value;
+    std::vector<bcos::bytes> proof;  ///< raw RLP node encodings, storage root first
+};
+
+/// EIP-1186 result: the account fields plus the Merkle paths proving them (spec §5.9).
+struct EIP1186Proof
+{
+    bcos::Address address;
+    bcos::u256 balance;
+    bcos::u256 nonce;
+    bcos::h256 codeHash;
+    bcos::h256 storageHash;  ///< the account's storage trie root
+    /// Raw RLP node encodings from the state root down to the account leaf. Only hash-referenced
+    /// nodes appear; inline children are embedded in their parent's encoding (go-ethereum
+    /// semantics).
+    std::vector<bcos::bytes> accountProof;
+    std::vector<StorageProof> storageProof;  ///< one entry per requested slot, in request order
+};
+
+/// Error outcomes of generateProof (spec §5.9). Returned as a variant alternative rather than
+/// thrown: both cases are expected request-level outcomes (a dormant account under scenario A, an
+/// unknown/uncommitted root), not programming errors — the RPC layer maps them to JSON-RPC error
+/// codes. Genuine storage inconsistencies still throw MPTInvariantViolation, like Trie does.
+enum class ProofErrorCode : uint8_t
+{
+    AccountNotInMPT,    ///< the walk from stateRoot dead-ends before an account leaf
+    BlockNotCommitted,  ///< stateRoot itself is absent from node storage (unknown/uncommitted)
+};
+
+namespace detail
+{
+/// Outcome of one root→leaf proof walk (shared by the account and storage trie passes).
+struct ProofWalk
+{
+    /// Raw RLP encoding of every hash-referenced node visited, root first. Inline children are
+    /// NOT separate items — their bytes are embedded in the parent's encoding.
+    std::vector<bcos::bytes> nodes;
+    std::optional<bcos::bytes> value;  ///< the leaf/branch value when the key is present
+    bool rootMissing{false};           ///< the root hash itself is absent from storage
+};
+
+/// Walk from @p root along @p path (nibble sequence), collecting each hash-referenced node's raw
+/// RLP. Stops at the leaf holding the key, or at the node where the path dead-ends (exclusion
+/// proof — the collected prefix is still returned). This descent intentionally does not reuse
+/// Trie::get(): the proof needs every visited node's raw encoding, which Trie discards.
+/// @throws MPTInvariantViolation when a non-root referenced node is missing from storage.
+template <bcos::storage2::ReadableStorage<bcos::h256> Storage>
+bcos::task::Task<ProofWalk> proofWalk(Storage& storage, bcos::h256 root, bcos::bytes path)
+{
+    ProofWalk out;
+    auto rootRaw = co_await bcos::storage2::readOne(storage, root);
+    if (!rootRaw)
+    {
+        out.rootMissing = true;
+        co_return out;
+    }
+    out.nodes.push_back(std::move(*rootRaw));
+    // decodeNode deep-copies into the TrieNode, so later push_back reallocations are harmless.
+    TrieNode node = decodeNode(bcos::ref(out.nodes.back()));
+    size_t pos = 0;  // nibbles consumed so far
+
+    while (true)
+    {
+        if (std::holds_alternative<EmptyNode>(node))
+        {
+            co_return out;  // dead end
+        }
+        if (auto const* leaf = std::get_if<LeafNode>(&node))
+        {
+            if (path.size() - pos == leaf->keyNibbles.size() &&
+                std::equal(leaf->keyNibbles.begin(), leaf->keyNibbles.end(), path.begin() + pos))
+            {
+                out.value = leaf->value;
+            }
+            co_return out;  // key found, or a diverging leaf: either way the walk stops here
+        }
+        if (auto const* ext = std::get_if<ExtensionNode>(&node))
+        {
+            if (path.size() - pos < ext->sharedNibbles.size() ||
+                !std::equal(
+                    ext->sharedNibbles.begin(), ext->sharedNibbles.end(), path.begin() + pos))
+            {
+                co_return out;  // path diverges inside the extension: dead end
+            }
+            pos += ext->sharedNibbles.size();
+            // The child is a raw RLP ref: EITHER the 33-byte hash string (0xa0 + digest) OR the
+            // inline child's complete RLP encoding (already part of this node's proof item).
+            if (ext->child.size() == HASH_REF_ENCODED_SIZE && ext->child[0] == RLP_HASH_REF_PREFIX)
+            {
+                bcos::h256 const childHash(ext->child.data() + 1, bcos::h256::SIZE);
+                auto childRaw = co_await bcos::storage2::readOne(storage, childHash);
+                if (!childRaw)
+                {
+                    BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
+                                              "proofWalk: storage lacks a referenced trie node"));
+                }
+                out.nodes.push_back(std::move(*childRaw));
+                TrieNode next = decodeNode(bcos::ref(out.nodes.back()));
+                node = std::move(next);
+            }
+            else
+            {
+                // Decode fully into a temporary BEFORE overwriting node: ext->child lives inside
+                // the current alternative.
+                TrieNode next = decodeNode(bcos::ref(ext->child));
+                node = std::move(next);
+            }
+            continue;
+        }
+        // BranchNode
+        auto const& branch = std::get<BranchNode>(node);
+        if (pos == path.size())
+        {
+            // All nibbles consumed at a branch (cannot happen for fixed 64-nibble keccak paths,
+            // handled for shape-completeness like Trie::get).
+            if (!branch.value.empty())
+            {
+                out.value = branch.value;
+            }
+            co_return out;
+        }
+        NodeRef const& child = branch.children.at(path.at(pos));
+        ++pos;
+        if (child.kind == NodeRef::Kind::Hash)
+        {
+            bcos::h256 const childHash = child.hash;
+            auto childRaw = co_await bcos::storage2::readOne(storage, childHash);
+            if (!childRaw)
+            {
+                BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
+                                          "proofWalk: storage lacks a referenced trie node"));
+            }
+            out.nodes.push_back(std::move(*childRaw));
+            TrieNode next = decodeNode(bcos::ref(out.nodes.back()));
+            node = std::move(next);
+        }
+        else if (child.inlineBytes.empty())
+        {
+            co_return out;  // absent child: dead end
+        }
+        else
+        {
+            // Inline child: embedded in this branch's encoding, not a separate proof item.
+            TrieNode next = decodeNode(bcos::ref(child.inlineBytes));
+            node = std::move(next);
+        }
+    }
+}
+}  // namespace detail
+
+/// Generate an EIP-1186 proof for @p address (and @p slots) against @p stateRoot (spec §5.9).
+/// Walks the state trie from stateRoot along accountKeyHash(address) collecting every
+/// hash-referenced node's raw RLP; decodes the account leaf; then walks the account's storage
+/// trie from Account::storageRoot along slotKeyHash(slot) for each requested slot the same way.
+///
+/// Outcomes:
+///   - stateRoot absent from storage        → ProofErrorCode::BlockNotCommitted
+///   - stateRoot == emptyRootHash(), or the account walk dead-ends
+///                                           → ProofErrorCode::AccountNotInMPT
+///   - a requested slot is absent            → StorageProof with empty value and the dead-end
+///                                             prefix as exclusion proof (EIP-1186 value 0x0)
+///
+/// Proof generation is a read-only cold path: instantiate over a Storage without an extra cache
+/// layer (e.g. the RocksDB-backed store directly) to avoid polluting the commit path's cache.
+/// @throws MPTInvariantViolation on storage inconsistency (a committed root referencing a missing
+/// node), MPTDecodeError on a malformed account leaf — programming/data errors, not request
+/// errors.
+template <bcos::storage2::ReadableStorage<bcos::h256> Storage>
+bcos::task::Task<std::variant<EIP1186Proof, ProofErrorCode>> generateProof(Storage& storage,
+    bcos::h256 stateRoot, bcos::Address address, std::span<bcos::h256 const> slots)
+{
+    if (stateRoot == emptyRootHash())
+    {
+        co_return ProofErrorCode::AccountNotInMPT;  // empty trie holds no accounts
+    }
+
+    auto const addressKeyHash = accountKeyHash(address);
+    auto accountWalk =
+        co_await detail::proofWalk(storage, stateRoot, bytesToNibbles(addressKeyHash.ref()));
+    if (accountWalk.rootMissing)
+    {
+        co_return ProofErrorCode::BlockNotCommitted;
+    }
+    if (!accountWalk.value)
+    {
+        co_return ProofErrorCode::AccountNotInMPT;
+    }
+    auto const account = Account::decode(bcos::ref(*accountWalk.value));
+
+    EIP1186Proof out;
+    out.address = address;
+    out.balance = account.balance;
+    out.nonce = account.nonce;
+    out.codeHash = account.codeHash;
+    out.storageHash = account.storageRoot;
+    out.accountProof = std::move(accountWalk.nodes);
+
+    out.storageProof.reserve(slots.size());
+    for (auto const& slot : slots)
+    {
+        StorageProof entry;
+        entry.key = slot;
+        if (account.storageRoot != emptyRootHash())
+        {
+            auto const slotHash = detail::slotKeyHash(slot);
+            auto slotWalk = co_await detail::proofWalk(
+                storage, account.storageRoot, bytesToNibbles(slotHash.ref()));
+            if (slotWalk.rootMissing)
+            {
+                // A committed account leaf references this root; its absence is corruption, not a
+                // request-level outcome.
+                BOOST_THROW_EXCEPTION(
+                    MPTInvariantViolation{} << bcos::errinfo_comment(
+                        "generateProof: account references a storage root absent from storage"));
+            }
+            entry.proof = std::move(slotWalk.nodes);
+            if (slotWalk.value)
+            {
+                entry.value = std::move(*slotWalk.value);
+            }
+        }
+        // else: empty storage trie — every slot is absent; empty value, empty proof.
+        out.storageProof.push_back(std::move(entry));
+    }
+    co_return out;
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
@@ -338,6 +338,23 @@ BOOST_AUTO_TEST_CASE(AccountNotInMPTErrors)
     BOOST_CHECK(std::get<ProofErrorCode>(unknownRoot) == ProofErrorCode::BlockNotCommitted);
 }
 
+// The hasher is a template parameter with a keccak256 default; the guomi door stays open:
+// the SM3 instantiation is well-formed and the injection form actually uses the injected hasher.
+BOOST_AUTO_TEST_CASE(HasherParameterizationKeepsSm3Possible)
+{
+    // Compile-time coverage: taking the address forces full instantiation with SM3.
+    [[maybe_unused]] auto* sm3Instantiation =
+        &generateProof<MemStorage, bcos::crypto::hasher::openssl::OpenSSL_SM3_Hasher>;
+
+    bcos::h256 const slot = makeHash(0x01);
+    bcos::crypto::hasher::openssl::OpenSSL_SM3_Hasher sm3;
+    auto const sm3Key = detail::slotKeyHash(slot, sm3);
+    BOOST_CHECK(sm3Key != detail::slotKeyHash(slot));  // keccak default != SM3 injection
+
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher keccakHasher;
+    BOOST_CHECK(detail::slotKeyHash(slot, keccakHasher) == detail::slotKeyHash(slot));
+}
+
 // Generating the same proof twice yields byte-identical output.
 BOOST_AUTO_TEST_CASE(DeterministicOutput)
 {

--- a/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
@@ -1,0 +1,386 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ProofGenerateTest.cpp
+ * @brief Unit tests for EIP-1186 proof generation (spec §5.9)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/MPTReadView.h>
+#include <bcos-ledger/mpt/NodeDecoder.h>
+#include <bcos-ledger/mpt/Proof.h>
+#include <bcos-task/Task.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <optional>
+#include <variant>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+using MemStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
+
+namespace
+{
+
+bcos::h256 keccak(bcos::bytes const& data)
+{
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    bcos::h256 out;
+    bcos::crypto::hasher::hash(hasher, bcos::ref(data), out);
+    return out;
+}
+
+/// Result of the in-test structural proof verifier (the oracle).
+struct ChainCheck
+{
+    bool hashChainOk{false};   ///< every proof item's keccak matched the hash that referenced it
+    bool allNodesUsed{false};  ///< the walk consumed exactly the whole proof vector (no siblings)
+    std::optional<bcos::bytes> value;  ///< the value found at the end of the walk, if present
+};
+
+/// Independent re-walk of a proof: recompute each node's keccak, check it matches the reference
+/// from the previous node (proof[0] must hash to @p root), descend along keccak-path @p keyHash
+/// through hash refs AND inline children, and record the terminal value. This is a different
+/// algorithm from Proof.h's storage-backed walk — it reads only the proof vector — so it acts as
+/// a self-verification oracle against the root.
+ChainCheck verifyProofChain(
+    std::vector<bcos::bytes> const& proof, bcos::h256 const& root, bcos::h256 const& keyHash)
+{
+    ChainCheck res;
+    if (proof.empty())
+    {
+        return res;
+    }
+    auto const path = bytesToNibbles(keyHash.ref());
+    size_t pos = 0;
+    size_t idx = 0;
+    bcos::h256 expected = root;
+
+    auto finish = [&]() {
+        res.hashChainOk = true;
+        res.allNodesUsed = (idx == proof.size());
+        return res;
+    };
+
+    while (true)
+    {
+        if (idx >= proof.size() || keccak(proof.at(idx)) != expected)
+        {
+            return res;  // chain runs past the end, or a hash mismatch: not a valid proof
+        }
+        TrieNode node = decodeNode(bcos::ref(proof.at(idx)));
+        ++idx;
+
+        // Descend through this proof item, expanding any inline children embedded in it, until
+        // the walk terminates or reaches the next hash-referenced node.
+        bool needNextItem = false;
+        while (!needNextItem)
+        {
+            if (std::holds_alternative<EmptyNode>(node))
+            {
+                return finish();  // dead end
+            }
+            if (auto const* leaf = std::get_if<LeafNode>(&node))
+            {
+                if (path.size() - pos == leaf->keyNibbles.size() &&
+                    std::equal(
+                        leaf->keyNibbles.begin(), leaf->keyNibbles.end(), path.begin() + pos))
+                {
+                    res.value = leaf->value;
+                }
+                return finish();
+            }
+            if (auto const* ext = std::get_if<ExtensionNode>(&node))
+            {
+                if (path.size() - pos < ext->sharedNibbles.size() ||
+                    !std::equal(
+                        ext->sharedNibbles.begin(), ext->sharedNibbles.end(), path.begin() + pos))
+                {
+                    return finish();  // dead end inside the extension
+                }
+                pos += ext->sharedNibbles.size();
+                if (ext->child.size() == HASH_REF_ENCODED_SIZE &&
+                    ext->child[0] == RLP_HASH_REF_PREFIX)
+                {
+                    expected = bcos::h256(ext->child.data() + 1, bcos::h256::SIZE);
+                    needNextItem = true;
+                }
+                else
+                {
+                    TrieNode next = decodeNode(bcos::ref(ext->child));
+                    node = std::move(next);
+                }
+                continue;
+            }
+            auto const& branch = std::get<BranchNode>(node);
+            if (pos == path.size())
+            {
+                if (!branch.value.empty())
+                {
+                    res.value = branch.value;
+                }
+                return finish();
+            }
+            NodeRef const& child = branch.children.at(path.at(pos));
+            ++pos;
+            if (child.kind == NodeRef::Kind::Hash)
+            {
+                expected = child.hash;
+                needNextItem = true;
+            }
+            else if (child.inlineBytes.empty())
+            {
+                return finish();  // absent child: dead end
+            }
+            else
+            {
+                TrieNode next = decodeNode(bcos::ref(child.inlineBytes));
+                node = std::move(next);
+            }
+        }
+    }
+}
+
+/// Build a state trie holding @p accounts into @p storage; returns the state root.
+bcos::h256 buildStateTrie(
+    MemStorage& storage, std::vector<std::pair<bcos::Address, Account>> const& accounts)
+{
+    HashBuilder builder(storage, emptyRootHash());
+    for (auto const& [addr, account] : accounts)
+    {
+        bcos::task::syncWait(builder.put(accountKeyHash(addr), account.encode()));
+    }
+    return bcos::task::syncWait(builder.commit());
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(ProofGenerateSuite)
+
+// A single-account trie: the proof is a chain whose first node keccaks to the state root and
+// whose last node is the account leaf. The structural verifier is the oracle.
+BOOST_AUTO_TEST_CASE(SingleAccountProofSelfVerifies)
+{
+    MemStorage storage;
+    bcos::Address const addr = makeAddress(0xab);
+    Account account;
+    account.nonce = 1;
+    account.balance = 100;
+    auto const stateRoot = buildStateTrie(storage, {{addr, account}});
+
+    auto result = bcos::task::syncWait(
+        generateProof(storage, stateRoot, addr, std::span<bcos::h256 const>{}));
+    BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(result));
+    auto const& proof = std::get<EIP1186Proof>(result);
+
+    BOOST_CHECK_EQUAL(proof.address, addr);
+    BOOST_CHECK_EQUAL(proof.balance, 100);
+    BOOST_CHECK_EQUAL(proof.nonce, 1);
+    BOOST_CHECK_EQUAL(proof.codeHash, emptyCodeHash());
+    BOOST_CHECK_EQUAL(proof.storageHash, emptyRootHash());
+    BOOST_CHECK(proof.storageProof.empty());
+
+    // Single account → the trie is exactly one leaf node, and it hashes to the root.
+    BOOST_REQUIRE_EQUAL(proof.accountProof.size(), 1);
+    BOOST_CHECK_EQUAL(keccak(proof.accountProof.front()), stateRoot);
+
+    auto const check = verifyProofChain(proof.accountProof, stateRoot, accountKeyHash(addr));
+    BOOST_CHECK(check.hashChainOk);
+    BOOST_CHECK(check.allNodesUsed);
+    BOOST_REQUIRE(check.value.has_value());
+    BOOST_CHECK(*check.value == account.encode());
+    auto const decoded = Account::decode(bcos::ref(*check.value));
+    BOOST_CHECK_EQUAL(decoded.nonce, 1);
+    BOOST_CHECK_EQUAL(decoded.balance, 100);
+}
+
+// ≥17 accounts force branch nodes. Proofs for three different accounts each self-verify, and the
+// allNodesUsed check proves sibling data does not leak into the proof beyond the walked path.
+BOOST_AUTO_TEST_CASE(MultiAccountProofsSelfVerify)
+{
+    MemStorage storage;
+    std::vector<std::pair<bcos::Address, Account>> accounts;
+    for (uint8_t i = 1; i <= 20; ++i)
+    {
+        Account account;
+        account.nonce = i;
+        account.balance = 1000 + i;
+        accounts.emplace_back(makeAddress(i), account);
+    }
+    auto const stateRoot = buildStateTrie(storage, accounts);
+
+    for (uint8_t i : {uint8_t{1}, uint8_t{7}, uint8_t{20}})
+    {
+        bcos::Address const addr = makeAddress(i);
+        auto result = bcos::task::syncWait(
+            generateProof(storage, stateRoot, addr, std::span<bcos::h256 const>{}));
+        BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(result));
+        auto const& proof = std::get<EIP1186Proof>(result);
+
+        BOOST_CHECK_EQUAL(proof.nonce, i);
+        BOOST_CHECK_EQUAL(proof.balance, 1000 + i);
+        // 20 accounts cannot fit a single node: at least a root branch plus a leaf.
+        BOOST_CHECK_GE(proof.accountProof.size(), 2);
+
+        auto const check = verifyProofChain(proof.accountProof, stateRoot, accountKeyHash(addr));
+        BOOST_CHECK(check.hashChainOk);
+        BOOST_CHECK(check.allNodesUsed);
+        BOOST_REQUIRE(check.value.has_value());
+        auto const decoded = Account::decode(bcos::ref(*check.value));
+        BOOST_CHECK_EQUAL(decoded.nonce, i);
+        BOOST_CHECK_EQUAL(decoded.balance, 1000 + i);
+    }
+}
+
+// An account with a storage trie: two present slots self-verify and yield the stored RLP values;
+// an absent slot yields an empty (zero) value plus a non-empty dead-end (exclusion) proof.
+BOOST_AUTO_TEST_CASE(StorageSlotProofsIncludingExclusion)
+{
+    MemStorage storage;
+    bcos::h256 const slotA = makeHash(0x01);
+    bcos::h256 const slotB = makeHash(0x02);
+    bcos::h256 const slotMissing = makeHash(0x03);
+    bcos::bytes const valueA{0x2a};              // RLP(42): single byte < 0x80
+    bcos::bytes const valueB{0x82, 0x13, 0x37};  // RLP(0x1337): 2-byte string
+
+    // Build the storage trie into the SAME node storage; its root becomes account.storageRoot.
+    HashBuilder storageTrieBuilder(storage, emptyRootHash());
+    bcos::task::syncWait(storageTrieBuilder.put(detail::slotKeyHash(slotA), valueA));
+    bcos::task::syncWait(storageTrieBuilder.put(detail::slotKeyHash(slotB), valueB));
+    auto const storageRoot = bcos::task::syncWait(storageTrieBuilder.commit());
+
+    bcos::Address const addr = makeAddress(0xab);
+    Account account;
+    account.nonce = 5;
+    account.balance = 777;
+    account.storageRoot = storageRoot;
+    auto const stateRoot = buildStateTrie(storage, {{addr, account}});
+
+    std::vector<bcos::h256> const slots{slotA, slotB, slotMissing};
+    auto result = bcos::task::syncWait(generateProof(storage, stateRoot, addr, slots));
+    BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(result));
+    auto const& proof = std::get<EIP1186Proof>(result);
+
+    BOOST_CHECK_EQUAL(proof.storageHash, storageRoot);
+    BOOST_REQUIRE_EQUAL(proof.storageProof.size(), 3);
+
+    // Present slots: values match what was stored, and each proof self-verifies.
+    for (size_t i : {size_t{0}, size_t{1}})
+    {
+        auto const& entry = proof.storageProof.at(i);
+        BOOST_CHECK_EQUAL(entry.key, slots.at(i));
+        BOOST_CHECK(entry.value == (i == 0 ? valueA : valueB));
+        auto const check =
+            verifyProofChain(entry.proof, storageRoot, detail::slotKeyHash(entry.key));
+        BOOST_CHECK(check.hashChainOk);
+        BOOST_CHECK(check.allNodesUsed);
+        BOOST_REQUIRE(check.value.has_value());
+        BOOST_CHECK(*check.value == entry.value);
+    }
+
+    // Absent slot: empty (zero) value, non-empty exclusion proof that dead-ends cleanly.
+    auto const& absent = proof.storageProof.at(2);
+    BOOST_CHECK_EQUAL(absent.key, slotMissing);
+    BOOST_CHECK(absent.value.empty());
+    BOOST_CHECK(!absent.proof.empty());
+    auto const check =
+        verifyProofChain(absent.proof, storageRoot, detail::slotKeyHash(slotMissing));
+    BOOST_CHECK(check.hashChainOk);
+    BOOST_CHECK(check.allNodesUsed);
+    BOOST_CHECK(!check.value.has_value());
+}
+
+// An unknown address on a populated trie, and any address on the empty root, both yield
+// AccountNotInMPT. A root absent from storage yields BlockNotCommitted.
+BOOST_AUTO_TEST_CASE(AccountNotInMPTErrors)
+{
+    MemStorage storage;
+    bcos::Address const known = makeAddress(0xab);
+    Account account;
+    account.nonce = 1;
+    auto const stateRoot = buildStateTrie(storage, {{known, account}});
+
+    bcos::Address const unknown = makeAddress(0xcd);
+    auto missing = bcos::task::syncWait(
+        generateProof(storage, stateRoot, unknown, std::span<bcos::h256 const>{}));
+    BOOST_REQUIRE(std::holds_alternative<ProofErrorCode>(missing));
+    BOOST_CHECK(std::get<ProofErrorCode>(missing) == ProofErrorCode::AccountNotInMPT);
+
+    auto emptyRoot = bcos::task::syncWait(
+        generateProof(storage, emptyRootHash(), known, std::span<bcos::h256 const>{}));
+    BOOST_REQUIRE(std::holds_alternative<ProofErrorCode>(emptyRoot));
+    BOOST_CHECK(std::get<ProofErrorCode>(emptyRoot) == ProofErrorCode::AccountNotInMPT);
+
+    auto unknownRoot = bcos::task::syncWait(
+        generateProof(storage, makeHash(0x99), known, std::span<bcos::h256 const>{}));
+    BOOST_REQUIRE(std::holds_alternative<ProofErrorCode>(unknownRoot));
+    BOOST_CHECK(std::get<ProofErrorCode>(unknownRoot) == ProofErrorCode::BlockNotCommitted);
+}
+
+// Generating the same proof twice yields byte-identical output.
+BOOST_AUTO_TEST_CASE(DeterministicOutput)
+{
+    MemStorage storage;
+    bcos::h256 const slot = makeHash(0x01);
+    bcos::bytes const slotValue{0x2a};
+
+    HashBuilder storageTrieBuilder(storage, emptyRootHash());
+    bcos::task::syncWait(storageTrieBuilder.put(detail::slotKeyHash(slot), slotValue));
+    auto const storageRoot = bcos::task::syncWait(storageTrieBuilder.commit());
+
+    std::vector<std::pair<bcos::Address, Account>> accounts;
+    for (uint8_t i = 1; i <= 20; ++i)
+    {
+        Account account;
+        account.nonce = i;
+        if (i == 3)
+        {
+            account.storageRoot = storageRoot;
+        }
+        accounts.emplace_back(makeAddress(i), account);
+    }
+    auto const stateRoot = buildStateTrie(storage, accounts);
+
+    bcos::Address const addr = makeAddress(3);
+    std::vector<bcos::h256> const slots{slot, makeHash(0x02)};
+    auto first = bcos::task::syncWait(generateProof(storage, stateRoot, addr, slots));
+    auto second = bcos::task::syncWait(generateProof(storage, stateRoot, addr, slots));
+    BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(first));
+    BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(second));
+    auto const& lhs = std::get<EIP1186Proof>(first);
+    auto const& rhs = std::get<EIP1186Proof>(second);
+
+    BOOST_CHECK(lhs.accountProof == rhs.accountProof);
+    BOOST_REQUIRE_EQUAL(lhs.storageProof.size(), rhs.storageProof.size());
+    for (size_t i = 0; i < lhs.storageProof.size(); ++i)
+    {
+        BOOST_CHECK(lhs.storageProof.at(i).key == rhs.storageProof.at(i).key);
+        BOOST_CHECK(lhs.storageProof.at(i).value == rhs.storageProof.at(i).value);
+        BOOST_CHECK(lhs.storageProof.at(i).proof == rhs.storageProof.at(i).proof);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test


### PR DESCRIPTION
## What

Adds `Proof.h` — EIP-1186 proof generation over an MPT state root (spec §5.9). `generateProof(storage, stateRoot, address, slots)` walks the state trie along `accountKeyHash(address)` collecting every hash-referenced node's raw RLP encoding, decodes the account leaf, then walks the account's storage trie along `keccak256(slot)` for each requested slot the same way. Header-only template over `storage2::ReadableStorage<h256>`, the same shape as `Trie`.

Semantics match go-ethereum's `eth_getProof`: inline children stay embedded in their parent's proof item rather than appearing separately; an absent slot returns an empty value with the dead-end node prefix as its exclusion proof. Expected request-level outcomes come back as `variant<EIP1186Proof, ProofErrorCode>` (`AccountNotInMPT` for a dormant/unknown account or an empty root, `BlockNotCommitted` for a state root absent from node storage); genuine storage inconsistencies throw `MPTInvariantViolation` like `Trie` does.

Proof generation is a cold read-only path: instantiate it over a storage without an extra cache layer to keep the commit path's cache unpolluted — with the storage2-concept design that is just a choice of template argument, no bypass mechanism needed.

## Independence

Only new files (`Proof.h` + test); no existing file is touched, so this lands in parallel with the M4.3 builder work (#5310). The one deliberate overlap: `detail::slotKeyHash` duplicates the slot key transform that #5310 introduces as the shared `mpt::slotKeyHash` (StorageValueCodec.h) — it is detail-scoped here to avoid an ODR clash whichever PR merges first, and folds into the shared helper once both land. The walk intentionally does not reuse `Trie::get()` (which discards the visited nodes' raw encodings that a proof consists of).

## Tests

`ProofGenerateSuite` (5 cases). The oracle is an in-test structural verifier that re-walks each returned proof using only the proof bytes: it recomputes every node's keccak against the hash that referenced it (first node against the root), descends through hash refs and inline children, and asserts every proof item is consumed (catching sibling leakage). Cases: single-account trie, 20-account trie forcing branch nodes (3 addresses proven), storage proofs with 2 present + 1 absent slot (exclusion proof dead-ends cleanly), both error codes, and byte-identical determinism across repeated generation.

Verified locally: `test-bcos-ledger` full run → No errors detected (all existing mpt + genesis suites green); standalone `-fsyntax-only` compile of the new test TU against the target's real flags (unity-build leak guard) → exit 0.

Refs: spec §5.9; phase-b M8.1; unblocks PR-25 (proof verifier).