### PR TITLE
Entry: Add typed storage API with atomic lazy decode and extract serialization to Serialize.h

### DIFF
--- a/bcos-executor/src/executive/BlockContext.cpp
+++ b/bcos-executor/src/executive/BlockContext.cpp
@@ -25,6 +25,7 @@
 #include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/storage/StorageInterface.h"
 #include "bcos-framework/storage/Table.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-task/Wait.h"
 #include <boost/core/ignore_unused.hpp>
 #include <boost/lexical_cast.hpp>
@@ -91,7 +92,7 @@ BlockContext::BlockContext(std::shared_ptr<storage::StateStorageInterface> stora
             auto entry = table->getRow(key);
             if (entry)
             {
-                auto [value, enableNumber] = entry->getObject<ledger::SystemConfigEntry>();
+                auto [value, enableNumber] = bcos::storage::serialize::decode<ledger::SystemConfigEntry>(entry->get());
                 if (current.number() >= enableNumber)
                 {
                     m_features.set(key);

--- a/bcos-executor/src/executive/ExecutiveDagFlow.cpp
+++ b/bcos-executor/src/executive/ExecutiveDagFlow.cpp
@@ -347,7 +347,7 @@ critical::CriticalFieldsInterface::Ptr ExecutiveDagFlow::generateDagCriticals(
                                         continue;
                                     }
 
-                                    auto codeHash = entry->getField(0);
+                                    auto codeHash = entry->get();
 
                                     // get abi according to codeHash
                                     auto abiTable =
@@ -367,14 +367,14 @@ critical::CriticalFieldsInterface::Ptr ExecutiveDagFlow::generateDagCriticals(
                                         }
                                     }
                                     tmpEntry = std::move(*abiEntry);
-                                    abiStr = tmpEntry.getField(0);
+                                    abiStr = tmpEntry.get();
                                 }
                                 else
                                 {
                                     // old logic
                                     auto entry = table->getRow(ACCOUNT_ABI);
                                     tmpEntry = std::move(*entry);
-                                    abiStr = tmpEntry.getField(0);
+                                    abiStr = tmpEntry.get();
                                 }
                                 bool isSmCrypto = blockContext.hashHandler()->getHashImplType() ==
                                                   crypto::HashImplType::Sm3Hash;

--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -494,7 +494,7 @@ crypto::HashType TransactionExecutive::getCodeHash(const std::string_view& contr
     auto entry = storage().getRow(contractTableName, ACCOUNT_CODE_HASH);
     if (entry)
     {
-        auto code = entry->getField(0);
+        auto code = entry->get();
         return crypto::HashType(code, crypto::HashType::StringDataType::FromBinary);
     }
 

--- a/bcos-executor/src/executor/TransactionExecutor.cpp
+++ b/bcos-executor/src/executor/TransactionExecutor.cpp
@@ -1743,7 +1743,7 @@ void TransactionExecutor::dagExecuteTransactionsInternal(
                                         continue;
                                     }
 
-                                    auto codeHash = entry->getField(0);
+                                    auto codeHash = entry->get();
 
                                     // get abi according to codeHash
                                     auto abiTable =
@@ -1765,14 +1765,14 @@ void TransactionExecutor::dagExecuteTransactionsInternal(
                                         }
                                     }
                                     tmpEntry = std::move(*abiEntry);
-                                    abiStr = tmpEntry.getField(0);
+                                    abiStr = tmpEntry.get();
                                 }
                                 else
                                 {
                                     // old logic
                                     auto entry = table->getRow(ACCOUNT_ABI);
                                     tmpEntry = std::move(*entry);
-                                    abiStr = tmpEntry.getField(0);
+                                    abiStr = tmpEntry.get();
                                 }
                                 bool isSmCrypto =
                                     m_hashImpl->getHashImplType() == crypto::HashImplType::Sm3Hash;
@@ -2152,7 +2152,7 @@ void TransactionExecutor::getCode(
                     return;
                 }
 
-                auto code = entry->getField(0);
+                auto code = entry->get();
                 EXECUTOR_NAME_LOG(INFO) << "Get code success" << LOG_KV("code size", code.size());
 
                 auto codeBytes = bcos::bytes(code.begin(), code.end());
@@ -2195,7 +2195,7 @@ void TransactionExecutor::getCode(
                     return;
                 }
 
-                auto code = entry->getField(0);
+                auto code = entry->get();
                 if ((features.get(ledger::Features::Flag::bugfix_eoa_as_contract) &&
                         bcos::precompiled::isDynamicPrecompiledAccountCode(code)) ||
                     (features.get(ledger::Features::Flag::bugfix_eoa_match_failed) &&
@@ -2281,7 +2281,7 @@ void TransactionExecutor::getABI(
                     callback(nullptr, std::string());
                     return;
                 }
-                auto abi = entry->getField(0);
+                auto abi = entry->get();
                 EXECUTOR_NAME_LOG(INFO) << "Get ABI success" << LOG_KV("ABI size", abi.size());
                 callback(nullptr, std::string(abi));
             });
@@ -2323,7 +2323,7 @@ void TransactionExecutor::getABI(
                     return;
                 }
 
-                auto abi = entry->getField(0);
+                auto abi = entry->get();
                 EXECUTOR_NAME_LOG(INFO) << "Get ABI success" << LOG_KV("ABI size", abi.size());
                 callback(nullptr, std::string(abi));
             });
@@ -3068,7 +3068,7 @@ std::string TransactionExecutor::getCodeHash(
                 codeHashPromise.set_value(std::string());
                 return;
             }
-            auto codeHash = std::string(entry->getField(0));
+            auto codeHash = std::string(entry->get());
             codeHashPromise.set_value(std::move(codeHash));
         });
     return codeHashPromise.get_future().get();

--- a/bcos-executor/src/precompiled/BFSPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/BFSPrecompiled.cpp
@@ -26,6 +26,7 @@
 #include "bcos-framework/executor/PrecompiledTypeDef.h"
 #include "bcos-framework/protocol/Protocol.h"
 #include "bcos-framework/storage/StorageInterface.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-tool/BfsFileFactory.h"
 #include <boost/algorithm/string/split.hpp>
 #include <boost/archive/binary_iarchive.hpp>
@@ -353,7 +354,7 @@ void BFSPrecompiled::listDir(const std::shared_ptr<executor::TransactionExecutiv
                 _callParameters->setExecResult(codec.encode(int32_t(CODE_FILE_NOT_EXIST), files));
                 return;
             }
-            auto baseFields = baseNameEntry->getObject<std::vector<std::string>>();
+            auto baseFields = bcos::storage::serialize::decode<std::vector<std::string>>(baseNameEntry->get());
             if (baseFields[0] == tool::FS_TYPE_DIR)
             {
                 // if type is dir, then return sub resource
@@ -364,7 +365,7 @@ void BFSPrecompiled::listDir(const std::shared_ptr<executor::TransactionExecutiv
                 for (const auto& key : keys | ::ranges::views::all)
                 {
                     auto entry = _executive->storage().getRow(absolutePath, key);
-                    auto fields = entry->getObject<std::vector<std::string>>();
+                    auto fields = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
                     files.emplace_back(
                         key, fields[0], std::vector<std::string>{fields.begin() + 1, fields.end()});
                 }
@@ -490,7 +491,7 @@ void BFSPrecompiled::listDirPage(const std::shared_ptr<executor::TransactionExec
         _callParameters->setExecResult(codec.encode(s256((int)CODE_FILE_NOT_EXIST), files));
         return;
     }
-    auto baseFields = baseNameEntry->getObject<std::vector<std::string>>();
+    auto baseFields = bcos::storage::serialize::decode<std::vector<std::string>>(baseNameEntry->get());
     if (baseFields[0] == tool::FS_TYPE_DIR)
     {
         // if type is dir, then return sub resource
@@ -501,7 +502,7 @@ void BFSPrecompiled::listDirPage(const std::shared_ptr<executor::TransactionExec
         for (const auto& key : keys | ::ranges::views::all)
         {
             auto entry = _executive->storage().getRow(absolutePath, key);
-            auto fields = entry->getObject<std::vector<std::string>>();
+            auto fields = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
             files.emplace_back(
                 key, fields[0], std::vector<std::string>{fields.begin() + 1, fields.end()});
         }
@@ -1092,14 +1093,14 @@ void BFSPrecompiled::rebuildBfs310(
         auto extraEntry = _executive->storage().getRow(rebuildPath, tool::FS_KEY_EXTRA);
         // root has no parent
         Entry newFormEntry;
-        newFormEntry.setObject(std::vector<std::string>{
+        newFormEntry.set(bcos::storage::serialize::encode(std::vector<std::string>{
             std::string(typeEntry->get()),
             std::string("0"),
             std::string(aclTypeEntry->get()),
             std::string(aclWhiteEntry->get()),
             std::string(aclBlackEntry->get()),
             std::string(extraEntry->get()),
-        });
+        }));
         typeEntry->setStatus(Entry::Status::DELETED);
         aclTypeEntry->setStatus(Entry::Status::DELETED);
         aclWhiteEntry->setStatus(Entry::Status::DELETED);
@@ -1208,7 +1209,7 @@ bool BFSPrecompiled::recursiveBuildDir(
             }
             else
             {
-                auto dirFields = dirEntry->getObject<std::vector<std::string>>();
+                auto dirFields = bcos::storage::serialize::decode<std::vector<std::string>>(dirEntry->get());
                 if (dirFields[0] == tool::FS_TYPE_DIR)
                 {
                     // if dir is directory, continue

--- a/bcos-executor/src/precompiled/BFSPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/BFSPrecompiled.cpp
@@ -375,8 +375,8 @@ void BFSPrecompiled::listDir(const std::shared_ptr<executor::TransactionExecutiv
                 // if type is link, then return link address
                 auto addressEntry = _executive->storage().getRow(absolutePath, FS_LINK_ADDRESS);
                 auto abiEntry = _executive->storage().getRow(absolutePath, FS_LINK_ABI);
-                std::vector<std::string> ext = {std::string(addressEntry->getField(0)),
-                    abiEntry.has_value() ? std::string(abiEntry->getField(0)) : ""};
+                std::vector<std::string> ext = {std::string(addressEntry->get()),
+                    abiEntry.has_value() ? std::string(abiEntry->get()) : ""};
                 BfsTuple link =
                     std::make_tuple(baseName, std::string(FS_TYPE_LINK), std::move(ext));
                 files.emplace_back(std::move(link));
@@ -397,11 +397,11 @@ void BFSPrecompiled::listDir(const std::shared_ptr<executor::TransactionExecutiv
         {
             // get type success, this is dir or link
             // if dir
-            if (typeEntry->getField(0) == FS_TYPE_DIR)
+            if (typeEntry->get() == FS_TYPE_DIR)
             {
                 auto subEntry = _executive->storage().getRow(absolutePath, FS_KEY_SUB);
                 std::map<std::string, std::string> bfsInfo;
-                auto&& out = asBytes(std::string(subEntry->getField(0)));
+                auto&& out = asBytes(std::string(subEntry->get()));
                 codec::scale::decode(bfsInfo, gsl::make_span(out));
                 files.reserve(bfsInfo.size());
                 for (const auto& bfs : bfsInfo)
@@ -411,13 +411,13 @@ void BFSPrecompiled::listDir(const std::shared_ptr<executor::TransactionExecutiv
                     files.emplace_back(std::move(file));
                 }
             }
-            else if (typeEntry->getField(0) == FS_TYPE_LINK)
+            else if (typeEntry->get() == FS_TYPE_LINK)
             {
                 // if link
                 auto addressEntry = _executive->storage().getRow(absolutePath, FS_LINK_ADDRESS);
                 auto abiEntry = _executive->storage().getRow(absolutePath, FS_LINK_ABI);
-                std::vector<std::string> ext = {std::string(addressEntry->getField(0)),
-                    abiEntry.has_value() ? std::string(abiEntry->getField(0)) : ""};
+                std::vector<std::string> ext = {std::string(addressEntry->get()),
+                    abiEntry.has_value() ? std::string(abiEntry->get()) : ""};
                 BfsTuple link =
                     std::make_tuple(baseName, std::string(FS_TYPE_LINK), std::move(ext));
                 files.emplace_back(std::move(link));
@@ -535,8 +535,8 @@ void BFSPrecompiled::listDirPage(const std::shared_ptr<executor::TransactionExec
         // if type is link, then return link address
         auto addressEntry = _executive->storage().getRow(absolutePath, FS_LINK_ADDRESS);
         auto abiEntry = _executive->storage().getRow(absolutePath, FS_LINK_ABI);
-        std::vector<std::string> ext = {std::string(addressEntry->getField(0)),
-            abiEntry.has_value() ? std::string(abiEntry->getField(0)) : ""};
+        std::vector<std::string> ext = {std::string(addressEntry->get()),
+            abiEntry.has_value() ? std::string(abiEntry->get()) : ""};
         BfsTuple link = std::make_tuple(baseName, std::string(FS_TYPE_LINK), std::move(ext));
         files.emplace_back(std::move(link));
     }
@@ -614,7 +614,7 @@ void BFSPrecompiled::linkImpl(const std::string& _absolutePath, const std::strin
     {
         // table exist, check this resource is a link
         auto typeEntry = _executive->storage().getRow(linkTableName, FS_KEY_TYPE);
-        if (typeEntry && typeEntry->getField(0) == FS_TYPE_LINK)
+        if (typeEntry && typeEntry->get() == FS_TYPE_LINK)
         {
             // contract name and version exist, overwrite address and abi
             tool::BfsFileFactory::buildLink(
@@ -689,7 +689,7 @@ void BFSPrecompiled::linkAdaptCNS(const std::shared_ptr<executor::TransactionExe
     {
         // table exist, check this resource is a link
         auto typeEntry = _executive->storage().getRow(linkTableName, FS_KEY_TYPE);
-        if (typeEntry && typeEntry->getField(0) == FS_TYPE_LINK)
+        if (typeEntry && typeEntry->get() == FS_TYPE_LINK)
         {
             // contract name and version exist, overwrite address and abi
             auto addressEntry = linkTable->newEntry();
@@ -748,11 +748,11 @@ void BFSPrecompiled::readLink(const std::shared_ptr<executor::TransactionExecuti
     {
         // file exists, try to get type
         auto typeEntry = _executive->storage().getRow(absolutePath, FS_KEY_TYPE);
-        if (typeEntry && typeEntry->getField(0) == FS_TYPE_LINK)
+        if (typeEntry && typeEntry->get() == FS_TYPE_LINK)
         {
             // if link
             auto addressEntry = _executive->storage().getRow(absolutePath, FS_LINK_ADDRESS);
-            auto contractAddress = std::string(addressEntry->getField(0));
+            auto contractAddress = std::string(addressEntry->get());
             auto codecAddress = blockContext.isWasm() ? codec.encode(contractAddress) :
                                                         codec.encode(Address(contractAddress));
             _callParameters->setExecResult(codecAddress);
@@ -869,10 +869,10 @@ void BFSPrecompiled::touch(const std::shared_ptr<executor::TransactionExecutive>
     {
         std::map<std::string, std::string> bfsInfo;
         auto subEntry = _executive->storage().getRow(parentDir, FS_KEY_SUB);
-        auto&& out = asBytes(std::string(subEntry->getField(0)));
+        auto&& out = asBytes(std::string(subEntry->get()));
         codec::scale::decode(bfsInfo, gsl::make_span(out));
         bfsInfo.insert(std::make_pair(baseName, type));
-        subEntry->setField(0, asString(codec::scale::encode(bfsInfo)));
+        subEntry->set(asString(codec::scale::encode(bfsInfo)));
         _executive->storage().setRow(parentDir, FS_KEY_SUB, std::move(subEntry.value()));
 
         _callParameters->setExecResult(codec.encode(int32_t(CODE_SUCCESS)));
@@ -1236,7 +1236,7 @@ bool BFSPrecompiled::recursiveBuildDir(
             {
                 // root + dir table exist, try to get type entry
                 auto tryGetTypeEntry = _executive->storage().getRow(newTableName, FS_KEY_TYPE);
-                if (tryGetTypeEntry.has_value() && tryGetTypeEntry->getField(0) == FS_TYPE_DIR)
+                if (tryGetTypeEntry.has_value() && tryGetTypeEntry->get() == FS_TYPE_DIR)
                 {
                     // if success and dir is directory, continue
                     root = newTableName;
@@ -1252,7 +1252,7 @@ bool BFSPrecompiled::recursiveBuildDir(
 
             // root + dir not exist, create root + dir and build bfs info in root table
             auto subEntry = _executive->storage().getRow(root, FS_KEY_SUB);
-            auto&& out = asBytes(std::string(subEntry->getField(0)));
+            auto&& out = asBytes(std::string(subEntry->get()));
             // codec to map
             std::map<std::string, std::string> bfsInfo;
             codec::scale::decode(bfsInfo, gsl::make_span(out));
@@ -1276,7 +1276,7 @@ bool BFSPrecompiled::recursiveBuildDir(
             _executive->storage().setRow(newTableName, FS_KEY_EXTRA, std::move(extraEntry));
 
             // set metadata in parent dir
-            subEntry->setField(0, asString(codec::scale::encode(bfsInfo)));
+            subEntry->set(asString(codec::scale::encode(bfsInfo)));
             _executive->storage().setRow(root, FS_KEY_SUB, std::move(subEntry.value()));
             root = newTableName;
         }

--- a/bcos-executor/src/precompiled/ConsensusPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/ConsensusPrecompiled.cpp
@@ -22,6 +22,7 @@
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/protocol/Protocol.h"
 #include "bcos-framework/sealer/VrfCurveType.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "common/PrecompiledResult.h"
 #include "common/Utilities.h"
 #include "common/WorkingSealerManagerImpl.h"
@@ -227,7 +228,7 @@ static int removeNode(const std::shared_ptr<executor::TransactionExecutive>& _ex
     auto entry = storage.getRow(SYS_CONSENSUS, "key");
     if (entry)
     {
-        consensusList = entry->getObject<ConsensusNodeList>();
+        consensusList = bcos::storage::serialize::decode<ConsensusNodeList>(entry->get());
     }
     else
     {
@@ -253,7 +254,7 @@ static int removeNode(const std::shared_ptr<executor::TransactionExecutive>& _ex
         return CODE_LAST_SEALER;
     }
 
-    entry->setObject(consensusList);
+    entry->set(bcos::storage::serialize::encode(consensusList));
     storage.setRow(SYS_CONSENSUS, "key", std::move(*entry));
 
     return 0;

--- a/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
@@ -27,6 +27,7 @@
 #include "bcos-framework/ledger/SystemConfigs.h"
 #include "bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-framework/protocol/Protocol.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-task/Wait.h"
 #include "bcos-tool/VersionConverter.h"
 #include <boost/archive/binary_iarchive.hpp>
@@ -227,7 +228,7 @@ std::shared_ptr<PrecompiledExecResult> SystemConfigPrecompiled::call(
 
             auto entry = table->newEntry();
             auto systemConfigEntry = SystemConfigEntry{configValue, blockContext.number() + 1};
-            entry.setObject(systemConfigEntry);
+            entry.set(bcos::storage::serialize::encode(systemConfigEntry));
 
             table->setRow(configKey, std::move(entry));
 
@@ -368,7 +369,7 @@ std::pair<std::string, protocol::BlockNumber> SystemConfigPrecompiled::getSysCon
         auto entry = table->getRow(_key);
         if (entry) [[likely]]
         {
-            auto [value, enableNumber] = entry->getObject<SystemConfigEntry>();
+            auto [value, enableNumber] = bcos::storage::serialize::decode<SystemConfigEntry>(entry->get());
             return {value, enableNumber};
         }
 

--- a/bcos-executor/src/precompiled/TableManagerPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/TableManagerPrecompiled.cpp
@@ -305,7 +305,7 @@ void TableManagerPrecompiled::openTable(
     {
         // file exists, try to get type
         auto typeEntry = _executive->storage().getRow(absolutePath, FS_KEY_TYPE);
-        if (typeEntry && typeEntry->getField(0) == FS_TYPE_LINK)
+        if (typeEntry && typeEntry->get() == FS_TYPE_LINK)
         {
             // if link
             auto addressEntry = _executive->storage().getRow(absolutePath, FS_LINK_ADDRESS);

--- a/bcos-executor/src/precompiled/TablePrecompiled.cpp
+++ b/bcos-executor/src/precompiled/TablePrecompiled.cpp
@@ -132,11 +132,11 @@ static size_t selectByValueCond(const std::shared_ptr<executor::TransactionExecu
         if (toLexicographic)
         {
             entryTuple = {
-                toLexicographicOrder(key), tableEntry->getObject<std::vector<std::string>>()};
+                toLexicographicOrder(key), bcos::storage::serialize::decode<std::vector<std::string>>(tableEntry->get())};
         }
         else
         {
-            entryTuple = {key, tableEntry->getObject<std::vector<std::string>>()};
+            entryTuple = {key, bcos::storage::serialize::decode<std::vector<std::string>>(tableEntry->get())};
         }
 
         if (valueCondition->isValid(std::get<1>(entryTuple)))
@@ -454,7 +454,7 @@ void TablePrecompiled::selectByKey(const std::string& tableName,
         _callParameters->setExecResult(codec.encode(std::move(emptyEntry)));
         return;
     }
-    auto values = entry->getObject<std::vector<std::string>>();
+    auto values = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
 
     // update the memory gas and the computation gas
     gasPricer->updateMemUsed(values.size());
@@ -500,7 +500,7 @@ void TablePrecompiled::selectByCondition(const std::string& tableName,
     for (auto& key : tableKeyList)
     {
         auto tableEntry = _executive->storage().getRow(tableName, key);
-        EntryTuple entryTuple = {key, tableEntry->getObject<std::vector<std::string>>()};
+        EntryTuple entryTuple = {key, bcos::storage::serialize::decode<std::vector<std::string>>(tableEntry->get())};
         entries.emplace_back(std::move(entryTuple));
     }
 
@@ -570,11 +570,11 @@ void TablePrecompiled::selectByConditionV32(const std::string& tableName,
                 if (_isNumericalOrder)
                 {
                     entryTuple = {toLexicographicOrder(key),
-                        tableEntry->getObject<std::vector<std::string>>()};
+                        bcos::storage::serialize::decode<std::vector<std::string>>(tableEntry->get())};
                 }
                 else
                 {
-                    entryTuple = {key, tableEntry->getObject<std::vector<std::string>>()};
+                    entryTuple = {key, bcos::storage::serialize::decode<std::vector<std::string>>(tableEntry->get())};
                 }
                 entries.emplace_back(std::move(entryTuple));
             }
@@ -757,7 +757,7 @@ void TablePrecompiled::insert(const std::string& tableName,
     }
 
     Entry entry;
-    entry.setObject(std::move(values));
+    entry.set(bcos::storage::serialize::encode(std::move(values)));
 
     gasPricer->appendOperation(InterfaceOpcode::Insert);
     gasPricer->updateMemUsed(entry.size());
@@ -814,7 +814,7 @@ void TablePrecompiled::updateByKey(const std::string& tableName,
         return;
     }
 
-    auto values = existEntry->getObject<std::vector<std::string>>();
+    auto values = bcos::storage::serialize::decode<std::vector<std::string>>(existEntry->get());
     for (const auto& kv : updateFields)
     {
         auto& field = std::get<0>(kv);
@@ -841,7 +841,7 @@ void TablePrecompiled::updateByKey(const std::string& tableName,
         values[index] = value;
     }
     Entry updateEntry;
-    updateEntry.setObject(std::move(values));
+    updateEntry.set(bcos::storage::serialize::encode(std::move(values)));
     _executive->storage().setRow(tableName, key, std::move(updateEntry));
 
     gasPricer->appendOperation(InterfaceOpcode::Update);
@@ -916,12 +916,12 @@ void TablePrecompiled::updateByCondition(const std::string& tableName,
     for (size_t i = 0; i < entries.size(); ++i)
     {
         auto&& entry = entries[i];
-        auto values = entry->getObject<std::vector<std::string>>();
+        auto values = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
         for (auto& kv : updateValue)
         {
             values[kv.first] = kv.second;
         }
-        entry->setObject(std::move(values));
+        entry->set(bcos::storage::serialize::encode(std::move(values)));
         _executive->storage().setRow(tableName, tableKeyList[i], std::move(entry.value()));
     }
     PRECOMPILED_LOG(DEBUG) << LOG_BADGE("TablePrecompiled") << LOG_BADGE("UPDATE")
@@ -1017,7 +1017,7 @@ void TablePrecompiled::updateByConditionV32(const std::string& tableName,
                         values[kv.first] = kv.second;
                     }
                     storage::Entry entry;
-                    entry.setObject(values);
+                    entry.set(bcos::storage::serialize::encode(values));
                     _executive->storage().setRow(
                         tableName, std::get<0>(entryTuple), std::move(entry));
                 }
@@ -1034,12 +1034,12 @@ void TablePrecompiled::updateByConditionV32(const std::string& tableName,
             for (size_t i = 0; i < entries.size(); ++i)
             {
                 auto&& entry = entries[i];
-                auto values = entry->getObject<std::vector<std::string>>();
+                auto values = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
                 for (auto& kv : updateValue)
                 {
                     values[kv.first] = kv.second;
                 }
-                entry->setObject(std::move(values));
+                entry->set(bcos::storage::serialize::encode(std::move(values)));
                 _executive->storage().setRow(tableName, tableKeyList[i], std::move(entry.value()));
             }
             affectedRows = tableKeyList.size();

--- a/bcos-executor/src/precompiled/common/Utilities.cpp
+++ b/bcos-executor/src/precompiled/common/Utilities.cpp
@@ -262,7 +262,7 @@ bcos::precompiled::ContractStatus bcos::precompiled::getContractStatus(
         // this may happen when register link in contract constructor
         return ContractStatus::Available;
     }
-    auto codeHashStr = codeHashEntry->getField(0);
+    auto codeHashStr = codeHashEntry->get();
     auto codeHash = HashType(codeHashStr, FixedBytes<32>::FromBinary);
 
     if (codeHash == HashType())

--- a/bcos-executor/src/precompiled/common/WorkingSealerManagerImpl.cpp
+++ b/bcos-executor/src/precompiled/common/WorkingSealerManagerImpl.cpp
@@ -278,7 +278,7 @@ bool WorkingSealerManagerImpl::shouldRotate(const executor::TransactionExecutive
     if (auto featureSwitch =
             _executive->storage().getRow(ledger::SYS_CONFIG, ledger::SYSTEM_KEY_RPBFT_SWITCH))
     {
-        auto featureInfo = featureSwitch->getObject<ledger::SystemConfigEntry>();
+        auto featureInfo = bcos::storage::serialize::decode<ledger::SystemConfigEntry>(featureSwitch->get());
         if (std::get<1>(featureInfo) == blockContext.number())
         {
             PRECOMPILED_LOG(DEBUG) << LOG_DESC("shouldRotate: enable feature_rpbft last block")
@@ -290,7 +290,7 @@ bool WorkingSealerManagerImpl::shouldRotate(const executor::TransactionExecutive
     if (auto epochEntry = _executive->storage().getRow(
             ledger::SYS_CONFIG, ledger::SYSTEM_KEY_RPBFT_EPOCH_SEALER_NUM))
     {
-        auto epochInfo = epochEntry->getObject<ledger::SystemConfigEntry>();
+        auto epochInfo = bcos::storage::serialize::decode<ledger::SystemConfigEntry>(epochEntry->get());
         PRECOMPILED_LOG(DEBUG) << LOG_DESC("shouldRotate: get epoch_sealer_num")
                                << LOG_KV("value", std::get<0>(epochInfo))
                                << LOG_KV("enableBlk", std::get<1>(epochInfo));
@@ -318,7 +318,7 @@ bool WorkingSealerManagerImpl::shouldRotate(const executor::TransactionExecutive
         return false;
     }
 
-    auto epochBlockNumEntry = epochBlockInfo->getObject<ledger::SystemConfigEntry>();
+    auto epochBlockNumEntry = bcos::storage::serialize::decode<ledger::SystemConfigEntry>(epochBlockInfo->get());
     auto epochBlockNum = boost::lexical_cast<uint32_t>(std::get<0>(epochBlockNumEntry));
     if ((blockContext.number() - std::get<1>(epochBlockNumEntry)) % epochBlockNum == 0)
     {
@@ -384,8 +384,8 @@ void WorkingSealerManagerImpl::setNotifyRotateFlag(
 {
     auto const& blockContext = executive->blockContext();
     storage::Entry rotateEntry;
-    rotateEntry.setObject(
-        SystemConfigEntry{boost::lexical_cast<std::string>(flag), blockContext.number() + 1});
+    rotateEntry.set(bcos::storage::serialize::encode(
+        SystemConfigEntry{boost::lexical_cast<std::string>(flag), blockContext.number() + 1}));
     executive->storage().setRow(
         SYS_CONFIG, ledger::INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE, std::move(rotateEntry));
 }
@@ -396,7 +396,7 @@ bool WorkingSealerManagerImpl::getNotifyRotateFlag(
     auto const& blockContext = executive->blockContext();
     if (auto entry = executive->storage().getRow(SYS_CONFIG, INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE))
     {
-        auto config = entry->getObject<ledger::SystemConfigEntry>();
+        auto config = bcos::storage::serialize::decode<ledger::SystemConfigEntry>(entry->get());
         if (!std::get<0>(config).empty() && blockContext.number() >= std::get<1>(config))
         {
             return boost::lexical_cast<bool>(std::get<0>(config));

--- a/bcos-executor/src/precompiled/extension/AuthManagerPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/AuthManagerPrecompiled.cpp
@@ -550,7 +550,7 @@ u256 AuthManagerPrecompiled::getDeployAuthType(
                 << LOG_BADGE("AuthManagerPrecompiled") << LOG_DESC("apps not exist");
             return {};
         }
-        auto fields = entry->getObject<std::vector<std::string>>();
+        auto fields = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
         typeStr.assign(fields[2]);
     }
     else
@@ -576,7 +576,7 @@ u256 AuthManagerPrecompiled::getDeployAuthType(
                     << LOG_BADGE("AuthManagerPrecompiled") << LOG_DESC("apps not exist");
                 return {};
             }
-            auto fields = entry->getObject<std::vector<std::string>>();
+            auto fields = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
             typeStr.assign(fields[2]);
         }
     }
@@ -640,9 +640,9 @@ void AuthManagerPrecompiled::setDeployType(
             PRECOMPILED_LOG(FATAL)
                 << LOG_BADGE("AuthManagerPrecompiled") << LOG_DESC("apps not exist");
         }
-        auto fields = entry->getObject<std::vector<std::string>>();
+        auto fields = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
         fields[2] = boost::lexical_cast<std::string>(type);
-        entry->setObject(fields);
+        entry->set(bcos::storage::serialize::encode(fields));
         _executive->storage().setRow(
             tool::FS_ROOT, tool::FS_APPS.substr(1), std::move(entry.value()));
         getErrorCodeOut(_callParameters->mutableExecResult(), CODE_SUCCESS, codec);
@@ -695,7 +695,7 @@ void AuthManagerPrecompiled::setDeployAuth(
             PRECOMPILED_LOG(FATAL)
                 << LOG_BADGE("AuthManagerPrecompiled") << LOG_DESC("apps not exist");
         }
-        auto fields = entry->getObject<std::vector<std::string>>();
+        auto fields = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
 
         const auto insertIndex = (type == (int)AuthType::WHITE_LIST_MODE) ? 3 : 4;
 
@@ -708,7 +708,7 @@ void AuthManagerPrecompiled::setDeployAuth(
         // covered writing
         aclMap[account] = access;
         fields[insertIndex] = asString(codec::scale::encode(aclMap));
-        entry->setObject(fields);
+        entry->set(bcos::storage::serialize::encode(fields));
 
         _executive->storage().setRow(
             tool::FS_ROOT, tool::FS_APPS.substr(1), std::move(entry.value()));
@@ -776,7 +776,7 @@ bool AuthManagerPrecompiled::checkDeployAuth(
             PRECOMPILED_LOG(FATAL)
                 << LOG_BADGE("AuthManagerPrecompiled") << LOG_DESC("apps not exist");
         }
-        auto fields = entry->getObject<std::vector<std::string>>();
+        auto fields = bcos::storage::serialize::decode<std::vector<std::string>>(entry->get());
         auto getAclIndex = (type == (int)AuthType::WHITE_LIST_MODE) ? 3 : 4;
         aclMapStr.assign(fields.at(getAclIndex));
     }

--- a/bcos-executor/src/precompiled/extension/AuthManagerPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/AuthManagerPrecompiled.cpp
@@ -719,7 +719,7 @@ void AuthManagerPrecompiled::setDeployAuth(
     auto getAclStr =
         (type == (int)AuthType::BLACK_LIST_MODE) ? tool::FS_ACL_BLACK : tool::FS_ACL_WHITE;
     auto entry = _executive->storage().getRow(tool::FS_APPS, getAclStr);
-    auto mapStr = std::string(entry->getField(0));
+    auto mapStr = std::string(entry->get());
     if (!mapStr.empty())
     {
         auto&& out = asBytes(mapStr);
@@ -727,7 +727,7 @@ void AuthManagerPrecompiled::setDeployAuth(
     }
     // covered writing
     aclMap[account] = access;
-    entry->setField(0, asString(codec::scale::encode(aclMap)));
+    entry->set(asString(codec::scale::encode(aclMap)));
     _executive->storage().setRow(tool::FS_APPS, getAclStr, std::move(entry.value()));
 
     getErrorCodeOut(_callParameters->mutableExecResult(), CODE_SUCCESS, codec);

--- a/bcos-executor/src/precompiled/extension/ContractAuthMgrPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/ContractAuthMgrPrecompiled.cpp
@@ -229,7 +229,7 @@ void ContractAuthMgrPrecompiled::getAdmin(
                                << LOG_KV("path", path);
         BOOST_THROW_EXCEPTION(protocol::PrecompiledError{} << errinfo_comment("Contract Admin row not found."));
     }
-    std::string adminStr = std::string(entry->getField(0));
+    std::string adminStr = std::string(entry->get());
     PRECOMPILED_LOG(TRACE) << LOG_BADGE("ContractAuthMgrPrecompiled")
                            << LOG_DESC("getAdmin success") << LOG_KV("admin", adminStr);
     _callParameters->setExecResult(codec.encode(adminStr));
@@ -287,7 +287,7 @@ void ContractAuthMgrPrecompiled::resetAdmin(
         }
     }
     auto newEntry = table->newEntry();
-    newEntry.setField(SYS_VALUE, admin);
+    newEntry.set(admin);
     table->setRow(ADMIN_FIELD, std::move(newEntry));
     getErrorCodeOut(_callParameters->mutableExecResult(), CODE_SUCCESS, codec);
 }
@@ -341,7 +341,7 @@ void ContractAuthMgrPrecompiled::setMethodAuthType(
         return;
     }
 
-    std::string authTypeStr = std::string(entry->getField(SYS_VALUE));
+    std::string authTypeStr = std::string(entry->get());
     std::map<bytes, uint8_t> methAuthTypeMap;
     if (!authTypeStr.empty())
     {
@@ -350,7 +350,7 @@ void ContractAuthMgrPrecompiled::setMethodAuthType(
     }
     // covered writing
     methAuthTypeMap[func] = type;
-    entry->setField(SYS_VALUE, asString(codec::scale::encode(methAuthTypeMap)));
+    entry->set(asString(codec::scale::encode(methAuthTypeMap)));
     table->setRow(METHOD_AUTH_TYPE, std::move(entry.value()));
 
     getErrorCodeOut(_callParameters->mutableExecResult(), CODE_SUCCESS, codec);
@@ -573,7 +573,7 @@ void ContractAuthMgrPrecompiled::setMethodAuth(
                                << LOG_DESC("auth row not found, try to set new one")
                                << LOG_KV("path", path) << LOG_KV("Type", getTypeStr);
         entry = table->newEntry();
-        entry->setField(SYS_VALUE, "");
+        entry->set("");
     }
 
     bool access = _isClose ? (authType == (int)AuthType::BLACK_LIST_MODE) :
@@ -582,7 +582,7 @@ void ContractAuthMgrPrecompiled::setMethodAuth(
     auto userAuth = std::make_pair(account, access);
 
     MethodAuthMap authMap;
-    if (entry->getField(SYS_VALUE).empty())
+    if (entry->get().empty())
     {
         // first insert func
         authMap.insert({func, {std::move(userAuth)}});
@@ -591,7 +591,7 @@ void ContractAuthMgrPrecompiled::setMethodAuth(
     {
         try
         {
-            auto&& out = asBytes(std::string(entry->getField(SYS_VALUE)));
+            auto&& out = asBytes(std::string(entry->get()));
             codec::scale::decode(authMap, gsl::make_span(out));
             if (authMap.find(func) != authMap.end())
             {
@@ -611,7 +611,7 @@ void ContractAuthMgrPrecompiled::setMethodAuth(
             return;
         }
     }
-    entry->setField(SYS_VALUE, asString(codec::scale::encode(authMap)));
+    entry->set(asString(codec::scale::encode(authMap)));
     table->setRow(getTypeStr, std::move(entry.value()));
     getErrorCodeOut(_callParameters->mutableExecResult(), CODE_SUCCESS, codec);
 }
@@ -622,7 +622,7 @@ int32_t ContractAuthMgrPrecompiled::getMethodAuthType(
 {
     auto table = _executive->storage().openTable(_path);
     if (!table || !table->getRow(METHOD_AUTH_TYPE) ||
-        table->getRow(METHOD_AUTH_TYPE)->getField(SYS_VALUE).empty()) [[unlikely]]
+        table->getRow(METHOD_AUTH_TYPE)->get().empty()) [[unlikely]]
     {
         PRECOMPILED_LOG(TRACE)
             << LOG_BADGE("ContractAuthMgrPrecompiled")
@@ -630,7 +630,7 @@ int32_t ContractAuthMgrPrecompiled::getMethodAuthType(
         return (int)CODE_TABLE_AUTH_TYPE_NOT_EXIST;
     }
     auto entry = table->getRow(METHOD_AUTH_TYPE);
-    std::string authTypeStr = std::string(entry->getField(SYS_VALUE));
+    std::string authTypeStr = std::string(entry->get());
     std::map<bytes, uint8_t> authTypeMap;
     try
     {
@@ -668,14 +668,14 @@ MethodAuthMap ContractAuthMgrPrecompiled::getMethodAuth(
 
     auto entry = table->getRow(getTypeStr);
     MethodAuthMap authMap = {};
-    if (!entry || entry->getField(SYS_VALUE).empty())
+    if (!entry || entry->get().empty())
     {
         PRECOMPILED_LOG(TRACE) << LOG_BADGE("ContractAuthMgrPrecompiled")
                                << LOG_DESC("auth row not found, no method set acl")
                                << LOG_KV("path", path) << LOG_KV("authType", getTypeStr);
         return authMap;
     }
-    bytes&& out = asBytes(std::string(entry->getField(SYS_VALUE)));
+    bytes&& out = asBytes(std::string(entry->get()));
     codec::scale::decode(authMap, gsl::make_span(out));
     return authMap;
 }

--- a/bcos-executor/src/precompiled/extension/DagTransferPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/DagTransferPrecompiled.cpp
@@ -210,7 +210,7 @@ void DagTransferPrecompiled::userAddCall(std::shared_ptr<executor::TransactionEx
 
         // user not exist, insert user into it.
         auto newEntry = table->newEntry();
-        newEntry.setField(DAG_TRANSFER_FIELD_BALANCE, amount.str());
+        newEntry.set(amount.str());
         table->setRow(user, newEntry);
         ret = 0;
     } while (false);
@@ -267,12 +267,12 @@ void DagTransferPrecompiled::userSaveCall(
             // If user is not exist, insert it. With this strategy, we can also add user by save
             // operation.
             auto newEntry = table->newEntry();
-            newEntry.setField(DAG_TRANSFER_FIELD_BALANCE, amount.str());
+            newEntry.set(amount.str());
             table->setRow(user, newEntry);
         }
         else
         {
-            balance = u256(entry->getField(DAG_TRANSFER_FIELD_BALANCE));
+            balance = u256(entry->get());
 
             // if overflow
             auto new_balance = balance + amount;
@@ -284,7 +284,7 @@ void DagTransferPrecompiled::userSaveCall(
             }
 
             auto updateEntry = table->newEntry();
-            updateEntry.setField(DAG_TRANSFER_FIELD_BALANCE, new_balance.str());
+            updateEntry.set(new_balance.str());
             table->setRow(user, updateEntry);
         }
 
@@ -342,7 +342,7 @@ void DagTransferPrecompiled::userDrawCall(
         }
 
         // only one record for every user
-        balance = u256(entry->getField(DAG_TRANSFER_FIELD_BALANCE));
+        balance = u256(entry->get());
         if (balance < amount)
         {
             strErrorMsg = "insufficient balance";
@@ -352,7 +352,7 @@ void DagTransferPrecompiled::userDrawCall(
 
         auto new_balance = balance - amount;
         auto newEntry = table->newEntry();
-        newEntry.setField(DAG_TRANSFER_FIELD_BALANCE, new_balance.str());
+        newEntry.set(new_balance.str());
         table->setRow(user, newEntry);
         ret = 0;
     } while (false);
@@ -402,7 +402,7 @@ void DagTransferPrecompiled::userBalanceCall(
         }
 
         // only one record for every user
-        balance = u256(entry->getField(DAG_TRANSFER_FIELD_BALANCE));
+        balance = u256(entry->get());
         ret = 0;
     } while (false);
     if (!strErrorMsg.empty())
@@ -465,7 +465,7 @@ void DagTransferPrecompiled::userTransferCall(
             break;
         }
 
-        fromUserBalance = u256(entry->getField(DAG_TRANSFER_FIELD_BALANCE));
+        fromUserBalance = u256(entry->get());
         if (fromUserBalance < amount)
         {
             strErrorMsg = "from user insufficient balance";
@@ -478,13 +478,13 @@ void DagTransferPrecompiled::userTransferCall(
         {
             // If to user not exist, add it first.
             auto newEntry = table->newEntry();
-            newEntry.setField(DAG_TRANSFER_FIELD_BALANCE, u256(0).str());
+            newEntry.set(u256(0).str());
             table->setRow(toUser, newEntry);
             toUserBalance = 0;
         }
         else
         {
-            toUserBalance = u256(entry->getField(DAG_TRANSFER_FIELD_BALANCE));
+            toUserBalance = u256(entry->get());
         }
 
         // overflow check
@@ -500,12 +500,12 @@ void DagTransferPrecompiled::userTransferCall(
 
         // update fromUser balance info.
         entry = table->newEntry();
-        entry->setField(DAG_TRANSFER_FIELD_BALANCE, newFromUserBalance.str());
+        entry->set(newFromUserBalance.str());
         table->setRow(fromUser, *entry);
 
         // update toUser balance info.
         entry = table->newEntry();
-        entry->setField(DAG_TRANSFER_FIELD_BALANCE, newToUserBalance.str());
+        entry->set(newToUserBalance.str());
         table->setRow(toUser, *entry);
         // end with success
         ret = 0;

--- a/bcos-executor/src/precompiled/extension/HelloWorldPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/HelloWorldPrecompiled.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<PrecompiledExecResult> HelloWorldPrecompiled::call(
             gasPricer->updateMemUsed(entry->size());
             gasPricer->appendOperation(InterfaceOpcode::Select, 1);
 
-            retValue = entry->getField(0);
+            retValue = entry->get();
             PRECOMPILED_LOG(DEBUG) << LOG_BADGE("HelloWorldPrecompiled") << LOG_DESC("get")
                                    << LOG_KV("value", retValue);
         }
@@ -113,7 +113,7 @@ std::shared_ptr<PrecompiledExecResult> HelloWorldPrecompiled::call(
         auto entry = table->getRow(HELLO_WORLD_KEY_FIELD_NAME);
         gasPricer->updateMemUsed(entry->size());
         gasPricer->appendOperation(InterfaceOpcode::Select, 1);
-        entry->setField(0, strValue);
+        entry->set(strValue);
 
         table->setRow(HELLO_WORLD_KEY_FIELD_NAME, *entry);
         gasPricer->appendOperation(InterfaceOpcode::Update, 1);

--- a/bcos-executor/src/precompiled/extension/SmallBankPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/extension/SmallBankPrecompiled.cpp
@@ -170,7 +170,7 @@ void SmallBankPrecompiled::updateBalanceCall(
 
         // user not exist, insert user into it.
         auto newEntry = table->newEntry();
-        newEntry.setField(SMALLBANK_TRANSFER_FIELD_BALANCE, amount.str());
+        newEntry.set(amount.str());
         // std::cout << "SmallBank  ---------- user message has insert tableName: " << m_tableName
         // << ", userName is" << user << ", balance is " << amount.str() << std::endl;
         table->setRow(user, newEntry);
@@ -238,7 +238,7 @@ void SmallBankPrecompiled::sendPaymentCall(
             break;
         }
 
-        fromUserBalance = u256(entry->getField(SMALLBANK_TRANSFER_FIELD_BALANCE));
+        fromUserBalance = u256(entry->get());
         if (fromUserBalance < amount)
         {
             strErrorMsg = "from user insufficient balance";
@@ -251,13 +251,13 @@ void SmallBankPrecompiled::sendPaymentCall(
         {
             // If to user not exist, add it first.
             auto newEntry = table->newEntry();
-            newEntry.setField(SMALLBANK_TRANSFER_FIELD_BALANCE, u256(0).str());
+            newEntry.set(u256(0).str());
             table->setRow(toUser, newEntry);
             toUserBalance = 0;
         }
         else
         {
-            toUserBalance = u256(entry->getField(SMALLBANK_TRANSFER_FIELD_BALANCE));
+            toUserBalance = u256(entry->get());
         }
 
         // overflow check
@@ -277,12 +277,12 @@ void SmallBankPrecompiled::sendPaymentCall(
         // toUserBalance is" << toUserBalance << ", newToUserBalance is "<< newToUserBalance <<
         // std::endl; update fromUser balance info.
         entry = table->newEntry();
-        entry->setField(SMALLBANK_TRANSFER_FIELD_BALANCE, newFromUserBalance.str());
+        entry->set(newFromUserBalance.str());
         table->setRow(fromUser, *entry);
 
         // update toUser balance info.
         entry = table->newEntry();
-        entry->setField(SMALLBANK_TRANSFER_FIELD_BALANCE, newToUserBalance.str());
+        entry->set(newToUserBalance.str());
         table->setRow(toUser, *entry);
         // end with success
         ret = 0;

--- a/bcos-executor/src/vm/HostContext.cpp
+++ b/bcos-executor/src/vm/HostContext.cpp
@@ -93,7 +93,7 @@ std::string HostContext::get(const std::string_view& _key)
     auto entry = m_executive->storage().getRow(m_tableName, _key);
     if (entry)
     {
-        return std::string(entry->getField(0));
+        return std::string(entry->get());
     }
     return {};
 }
@@ -534,7 +534,7 @@ void HostContext::setCodeAndAbi(bytes code, string abi)
         {
             // set abi in abi table
             auto codeEntry = m_executive->storage().getRow(m_tableName, ACCOUNT_CODE_HASH);
-            auto codeHash = codeEntry->getField(0);
+            auto codeHash = codeEntry->get();
 
             if (c_fileLogLevel <= TRACE) [[unlikely]]
             {
@@ -660,7 +660,7 @@ evmc_bytes32 HostContext::store(const evmc_bytes32* key)
     auto entry = m_executive->storage().getRow(m_tableName, keyView);
     if (entry)
     {
-        auto field = entry->getField(0);
+        auto field = entry->get();
         std::uninitialized_copy_n(field.data(), sizeof(result), result.bytes);
     }
     else
@@ -690,7 +690,7 @@ evmc_bytes32 HostContext::getTransientStorage(const evmc_bytes32* key)
     auto entry = readAccessor.value()->getRow(m_tableName, keyView);
     if (!entry.first && entry.second.has_value())
     {
-        auto field = entry.second->getField(0);
+        auto field = entry.second->get();
         std::uninitialized_copy_n(field.data(), sizeof(result), result.bytes);
     }
     else

--- a/bcos-executor/test/unittest/fixture/TransactionFixture.h
+++ b/bcos-executor/test/unittest/fixture/TransactionFixture.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "bcos-codec/scale/Scale.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-codec/wrapper/CodecWrapper.h"
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/hash/SM3.h"
@@ -99,7 +100,7 @@ public:
         ledger->setBlockNumber(header->number() - 1);
         std::promise<bool> p;
         Entry authEntry;
-        authEntry.setObject(SystemConfigEntry(_isCheckAuth ? "1" : "0", 0));
+        authEntry.set(bcos::storage::serialize::encode(SystemConfigEntry(_isCheckAuth ? "1" : "0", 0)));
         storage->asyncSetRow(ledger::SYS_CONFIG, ledger::SYSTEM_KEY_AUTH_CHECK_STATUS,
             std::move(authEntry), [&p](auto&& e) { p.set_value(true); });
         p.get_future().get();
@@ -210,14 +211,14 @@ private:
                 });
             auto table = promise1.get_future().get();
             auto entry = table->newEntry();
-            entry.setObject(SystemConfigEntry{"3000000", 0});
+            entry.set(bcos::storage::serialize::encode(SystemConfigEntry{"3000000", 0}));
             table->setRow(SYSTEM_KEY_TX_GAS_LIMIT, std::move(entry));
 
             // for each feature
             for (auto& feature : features)
             {
                 Entry featureEntry;
-                featureEntry.setObject(SystemConfigEntry{"1", 0});
+                featureEntry.set(bcos::storage::serialize::encode(SystemConfigEntry{"1", 0}));
                 table->setRow(feature, std::move(featureEntry));
             }
         }

--- a/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
@@ -338,11 +338,11 @@ BOOST_AUTO_TEST_CASE(callWasmConcurrentlyTransfer)
 
     auto entry = table.getRow("code");
     BOOST_CHECK(entry);
-    BOOST_CHECK_GT(entry->getField(0).size(), 0);
+    BOOST_CHECK_GT(entry->get().size(), 0);
 
     entry = table.getRow("abi");
     BOOST_CHECK(entry);
-    BOOST_CHECK_GT(entry->getField(0).size(), 0);
+    BOOST_CHECK_GT(entry->get().size(), 0);
 
     std::vector<ExecutionMessage::UniquePtr> requests;
     auto cases = vector<tuple<string, string, uint32_t>>();
@@ -590,11 +590,11 @@ BOOST_AUTO_TEST_CASE(callWasmConcurrentlyHelloWorld)
 
     auto entry = table.getRow("code");
     BOOST_CHECK(entry);
-    BOOST_CHECK_GT(entry->getField(0).size(), 0);
+    BOOST_CHECK_GT(entry->get().size(), 0);
 
     entry = table.getRow("abi");
     BOOST_CHECK(entry);
-    BOOST_CHECK_GT(entry->getField(0).size(), 0);
+    BOOST_CHECK_GT(entry->get().size(), 0);
 
     std::vector<ExecutionMessage::UniquePtr> requests;
     auto cases = vector<string>();

--- a/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(deployAndCall)
 
     auto entry = table.getRow("code");
     BOOST_CHECK(entry);
-    BOOST_CHECK_GT(entry->getField(0).size(), 0);
+    BOOST_CHECK_GT(entry->get().size(), 0);
 
     // start new block
     auto blockHeader2 = std::make_shared<bcostars::protocol::BlockHeaderImpl>(

--- a/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "../mock/MockLedger.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "../mock/MockTransactionalStorage.h"
 #include "../mock/MockTxPool.h"
 #include "bcos-codec/wrapper/CodecWrapper.h"
@@ -369,7 +370,7 @@ BOOST_AUTO_TEST_CASE(externalCall)
 
     ledger::SystemConfigEntry se = {"1", 0};
     storage::Entry entry;
-    entry.setObject(se);
+    entry.set(bcos::storage::serialize::encode(se));
     backend->setRow(ledger::SYS_CONFIG, "feature_evm_address", entry);
     std::string ABin =
         "608060405234801561001057600080fd5b5061037f806100206000396000f3fe60806040523480156100105760"
@@ -1944,8 +1945,8 @@ BOOST_AUTO_TEST_CASE(transientStorageTest2)
         std::make_shared<MockTransactionalStorage>(hashImpl);
     Entry entry;
     bcos::protocol::BlockNumber blockNumber = 0;
-    entry.setObject(
-        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber});
+    entry.set(bcos::storage::serialize::encode(
+        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber}));
     newStorage->asyncSetRow(ledger::SYS_CONFIG, "feature_evm_cancun", entry,
         [](Error::UniquePtr error) { BOOST_CHECK_EQUAL(error.get(), nullptr); });
     // check feature_evm_cancun whether is on
@@ -2167,8 +2168,8 @@ BOOST_AUTO_TEST_CASE(mcopy_opcode_test_1)
         std::make_shared<MockTransactionalStorage>(hashImpl);
     Entry entry;
     bcos::protocol::BlockNumber blockNumber = 0;
-    entry.setObject(
-        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber});
+    entry.set(bcos::storage::serialize::encode(
+        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber}));
     newStorage->asyncSetRow(ledger::SYS_CONFIG, "feature_evm_cancun", entry,
         [](Error::UniquePtr error) { BOOST_CHECK_EQUAL(error.get(), nullptr); });
     // check feature_evm_cancun whether is on
@@ -2275,8 +2276,8 @@ BOOST_AUTO_TEST_CASE(blobBaseFee_test)
         std::make_shared<MockTransactionalStorage>(hashImpl);
     Entry entry;
     bcos::protocol::BlockNumber blockNumber = 0;
-    entry.setObject(
-        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber});
+    entry.set(bcos::storage::serialize::encode(
+        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber}));
     newStorage->asyncSetRow(ledger::SYS_CONFIG, "feature_evm_cancun", entry,
         [](Error::UniquePtr error) { BOOST_CHECK_EQUAL(error.get(), nullptr); });
     // check feature_evm_cancun whether is on
@@ -2377,8 +2378,8 @@ BOOST_AUTO_TEST_CASE(blobHash_test)
         std::make_shared<MockTransactionalStorage>(hashImpl);
     Entry entry;
     bcos::protocol::BlockNumber blockNumber = 0;
-    entry.setObject(
-        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber});
+    entry.set(bcos::storage::serialize::encode(
+        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber}));
     newStorage->asyncSetRow(ledger::SYS_CONFIG, "feature_evm_cancun", entry,
         [](Error::UniquePtr error) { BOOST_CHECK_EQUAL(error.get(), nullptr); });
     // check feature_evm_cancun whether is on
@@ -2467,8 +2468,8 @@ BOOST_AUTO_TEST_CASE(getTransientStorageTest)
         std::make_shared<MockTransactionalStorage>(hashImpl);
     Entry entry;
     bcos::protocol::BlockNumber blockNumber = 0;
-    entry.setObject(
-        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber});
+    entry.set(bcos::storage::serialize::encode(
+        ledger::SystemConfigEntry{boost::lexical_cast<std::string>((int)1), blockNumber}));
     newStorage->asyncSetRow(ledger::SYS_CONFIG, "feature_evm_cancun", entry,
         [](Error::UniquePtr error) { BOOST_CHECK_EQUAL(error.get(), nullptr); });
     // check feature_evm_cancun whether is on
@@ -2610,7 +2611,7 @@ contract HelloFactory {
 
     ledger::SystemConfigEntry se = {"1", 0};
     storage::Entry entry;
-    entry.setObject(se);
+    entry.set(bcos::storage::serialize::encode(se));
     backend->setRow(ledger::SYS_CONFIG, "feature_evm_address", entry);
     bytes input;
     boost::algorithm::unhex(helloFactory, std::back_inserter(input));

--- a/bcos-executor/test/unittest/libexecutor/TestWasmExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestWasmExecutor.cpp
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(deployAndCall)
 
     auto entry = table.getRow("code");
     BOOST_CHECK(entry);
-    BOOST_CHECK_GT(entry->getField(0).size(), 0);
+    BOOST_CHECK_GT(entry->get().size(), 0);
 
     // start new block
     auto blockHeader2 = std::make_shared<bcostars::protocol::BlockHeaderImpl>(
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE(deployError)
 
         auto entry = table.getRow("code");
         BOOST_CHECK(entry);
-        BOOST_CHECK_GT(entry->getField(0).size(), 0);
+        BOOST_CHECK_GT(entry->get().size(), 0);
     }
 
     string errorAddress = "usr/alice/hello_world/hello_world";
@@ -761,7 +761,7 @@ BOOST_AUTO_TEST_CASE(deployAndCall_100)
 
     auto entry = table.getRow("code");
     BOOST_CHECK(entry);
-    BOOST_CHECK_GT(entry->getField(0).size(), 0);
+    BOOST_CHECK_GT(entry->get().size(), 0);
 
     // start new block
     auto blockHeader2 = std::make_shared<bcostars::protocol::BlockHeaderImpl>(

--- a/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "bcos-framework/ledger/LedgerTypeDef.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "libprecompiled/PreCompiledFixture.h"
 #include <boost/endian/conversion.hpp>
@@ -316,7 +317,7 @@ public:
             p.set_value(entry.value());
         });
         auto entry = p.get_future().get();
-        auto nodeList = entry.getObject<ledger::ConsensusNodeList>();
+        auto nodeList = bcos::storage::serialize::decode<ledger::ConsensusNodeList>(entry.get());
         return nodeList;
     }
 
@@ -328,7 +329,7 @@ public:
             p.set_value(entry.value());
         });
         auto entry = p.get_future().get();
-        auto systemConfig = entry.getObject<SystemConfigEntry>();
+        auto systemConfig = bcos::storage::serialize::decode<SystemConfigEntry>(entry.get());
         return systemConfig;
     }
 

--- a/bcos-executor/test/unittest/libprecompiled/PreCompiledFixture.h
+++ b/bcos-executor/test/unittest/libprecompiled/PreCompiledFixture.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "bcos-codec/scale/Scale.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/hash/SM3.h"
 #include "bcos-crypto/interfaces/crypto/CommonType.h"
@@ -110,7 +111,7 @@ public:
         ledger->setBlockNumber(header->number() - 1);
         std::promise<bool> p;
         Entry authEntry;
-        authEntry.setObject(SystemConfigEntry(_isCheckAuth ? "1" : "0", 0));
+        authEntry.set(bcos::storage::serialize::encode(SystemConfigEntry(_isCheckAuth ? "1" : "0", 0)));
         storage->asyncSetRow(ledger::SYS_CONFIG, ledger::SYSTEM_KEY_AUTH_CHECK_STATUS,
             std::move(authEntry), [&p](auto&& e) { p.set_value(true); });
         p.get_future().get();
@@ -158,14 +159,14 @@ public:
                 });
             auto table = promise1.get_future().get();
             auto entry = table->newEntry();
-            entry.setObject(SystemConfigEntry{"3000000", 0});
+            entry.set(bcos::storage::serialize::encode(SystemConfigEntry{"3000000", 0}));
             table->setRow(SYSTEM_KEY_TX_GAS_LIMIT, std::move(entry));
 
             // for each feature
             for (auto& feature : features)
             {
                 Entry featureEntry;
-                featureEntry.setObject(SystemConfigEntry{"1", 0});
+                featureEntry.set(bcos::storage::serialize::encode(SystemConfigEntry{"1", 0}));
                 table->setRow(feature, std::move(featureEntry));
             }
         }

--- a/bcos-executor/test/unittest/libprecompiled/WorkingSealerManagerTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/WorkingSealerManagerTest.cpp
@@ -1,4 +1,5 @@
 #include "bcos-crypto/interfaces/crypto/Hash.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-crypto/signature/key/KeyImpl.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage2/MemoryStorage.h"
@@ -65,7 +66,7 @@ BOOST_AUTO_TEST_CASE(testRotate)
         // Should rotate
         storage::Entry notifyRotateEntry;
         ledger::SystemConfigEntry systemConfigEntry{"1", 0};
-        notifyRotateEntry.setObject(systemConfigEntry);
+        notifyRotateEntry.set(bcos::storage::serialize::encode(systemConfigEntry));
         co_await storage2::writeOne(storage,
             executor_v1::StateKey{
                 ledger::SYS_CONFIG, ledger::INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE},

--- a/bcos-executor/test/unittest/mock/MockLedger.h
+++ b/bcos-executor/test/unittest/mock/MockLedger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MockBlock.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-framework/ledger/LedgerInterface.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/StorageInterface.h"
@@ -162,7 +163,8 @@ public:
                     [&promise](auto&& e, std::optional<storage::Entry> entry) {
                         promise.set_value(entry.value());
                     });
-                auto entry = promise.get_future().get().getObject<ledger::SystemConfigEntry>();
+                auto rawEntry = promise.get_future().get();
+                auto entry = bcos::storage::serialize::decode<ledger::SystemConfigEntry>(rawEntry.get());
                 _onGetConfig(nullptr, std::get<0>(entry), std::get<1>(entry));
                 return;
             }

--- a/bcos-executor/test/unittest/test_L2ConfigLoader.cpp
+++ b/bcos-executor/test/unittest/test_L2ConfigLoader.cpp
@@ -100,7 +100,7 @@ void putSlot(FakeSlotStorage& storage, std::string_view configKey,
     std::copy(low192.begin(), low192.end(), packed.begin() + 8);
 
     bcos::storage::Entry entry;
-    entry.setField(0, std::string(reinterpret_cast<char const*>(packed.data()), packed.size()));
+    entry.set(std::string(reinterpret_cast<char const*>(packed.data()), packed.size()));
 
     StateKey stateKey(systemConfigTable(),
         std::string_view(reinterpret_cast<char const*>(slot.data()), slot.size()));

--- a/bcos-framework/CMakeLists.txt
+++ b/bcos-framework/CMakeLists.txt
@@ -44,6 +44,9 @@ target_link_libraries(bcos-framework PUBLIC
     fmt::fmt
     TBB::tbb)
 set_target_properties(bcos-framework PROPERTIES UNITY_BUILD "ON")
+# Entry.cpp uses namespace bcos::storage which conflicts with unity build
+# namespace stacking from other translation units in the same batch.
+set_source_files_properties(bcos-framework/storage/Entry.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 
 if (TESTS)
     enable_testing()

--- a/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
+++ b/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "../ledger/LedgerTypeDef.h"
 #include "../storage/Entry.h"
+#include "../storage/Serialize.h"
 #include "../storage2/Storage.h"
 #include "../transaction-executor/StateKey.h"
 #include "Features.h"
@@ -21,7 +22,8 @@ inline task::Task<void> Features::readFromStorage(
             co_await storage2::readOne(storage, executor_v1::StateKeyView(ledger::SYS_CONFIG, key));
         if (entry)
         {
-            auto [value, enableNumber] = entry->template getObject<ledger::SystemConfigEntry>();
+            auto [value, enableNumber] =
+                storage::serialize::decode<ledger::SystemConfigEntry>(entry->get());
             if (blockNumber >= enableNumber)
             {
                 set(key);
@@ -40,8 +42,8 @@ inline task::Task<void> Features::writeToStorage(
                                               executor_v1::StateKeyView(ledger::SYS_CONFIG, name))))
         {
             storage::Entry entry;
-            entry.setObject(
-                SystemConfigEntry{boost::lexical_cast<std::string>((int)value), blockNumber});
+            entry.set(storage::serialize::encode(
+                SystemConfigEntry{boost::lexical_cast<std::string>((int)value), blockNumber}));
             co_await storage2::writeOne(
                 storage, executor_v1::StateKey(ledger::SYS_CONFIG, name), std::move(entry));
         }
@@ -60,7 +62,8 @@ inline task::Task<void> readFromStorage(Features& features,
     {
         if (entry)
         {
-            auto [value, enableNumber] = entry->template getObject<ledger::SystemConfigEntry>();
+            auto [value, enableNumber] =
+                storage::serialize::decode<ledger::SystemConfigEntry>(entry->get());
             if (blockNumber >= enableNumber)
             {
                 features.set(key);
@@ -78,8 +81,8 @@ inline task::Task<void> writeToStorage(Features const& features,
     co_await storage2::writeSome(std::forward<decltype(storage)>(storage),
         ::ranges::views::transform(flags, [&](auto&& tuple) {
             storage::Entry entry;
-            entry.setObject(SystemConfigEntry{
-                boost::lexical_cast<std::string>((int)std::get<2>(tuple)), blockNumber});
+            entry.set(storage::serialize::encode(SystemConfigEntry{
+                boost::lexical_cast<std::string>((int)std::get<2>(tuple)), blockNumber}));
             return std::make_tuple(
                 executor_v1::StateKey(ledger::SYS_CONFIG, std::get<1>(tuple)), std::move(entry));
         }));

--- a/bcos-framework/bcos-framework/ledger/LedgerTypeDef.h
+++ b/bcos-framework/bcos-framework/ledger/LedgerTypeDef.h
@@ -22,12 +22,12 @@
 #include "../consensus/ConsensusNode.h"
 #include "../protocol/ProtocolTypeDef.h"
 #include "SystemConfigs.h"
+#include "bcos-framework/storage/Serialize.h"
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-task/Task.h"
 #include <bcos-utilities/Common.h>
 #include <oneapi/tbb/concurrent_unordered_map.h>
-#include <boost/archive/binary_iarchive.hpp>
 #include <magic_enum/magic_enum.hpp>
 
 namespace bcos::ledger
@@ -176,7 +176,8 @@ inline task::Task<void> readFromStorage(
     {
         if (entry)
         {
-            auto [value, enableNumber] = entry->template getObject<ledger::SystemConfigEntry>();
+            auto [value, enableNumber] =
+                storage::serialize::decode<ledger::SystemConfigEntry>(entry->get());
             if (blockNumber >= enableNumber)
             {
                 configs.set(key, value, enableNumber);

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -5,16 +5,6 @@
 
 namespace bcos::storage
 {
-Entry::Entry(const Entry& other) = default;
-
-bcos::storage::Entry& Entry::operator=(const Entry& other)
-{
-    if (this != &other)
-    {
-        m_buffer = other.m_buffer;
-    }
-    return *this;
-}
 
 std::string_view Entry::get() const&
 {
@@ -43,7 +33,6 @@ std::string_view Entry::getField(size_t index) const&
             BCOS_ERROR(-1, "Get field index: " + boost::lexical_cast<std::string>(index) +
                                " failed, index out of range"));
     }
-
     return get();
 }
 
@@ -62,8 +51,7 @@ void Entry::setStatus(Status status)
 
     if (status == DELETED)
     {
-        // Encode DELETED purely as a type tag — no data stored.
-        m_buffer = pro::make_proxy_inplace<AnyBufferFacade>(DeletedModel{});
+        m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(DeletedModel{});
     }
     else if (status == EMPTY)
     {
@@ -71,7 +59,7 @@ void Entry::setStatus(Status status)
     }
     else
     {
-        // NORMAL or MODIFIED: preserve existing data, change status tag.
+        // NORMAL or MODIFIED: preserve data, change status tag.
         if (m_buffer.has_value())
         {
             auto view = get();
@@ -89,7 +77,6 @@ bool Entry::dirty() const
     if (!m_buffer.has_value()) [[unlikely]]
         return false;
     auto s = m_buffer->status();
-
     return s == ENTRY_MODIFIED || s == ENTRY_DELETED;
 }
 
@@ -103,12 +90,11 @@ bool Entry::valid() const
 void Entry::setImplCopy(const char* data, size_t sz)
 {
     if (sz <= SMALL_SIZE)
-        m_buffer = pro::make_proxy_inplace<AnyBufferFacade>(SmallBuffer<ENTRY_MODIFIED>{data, sz});
+        m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(SmallBuffer<ENTRY_MODIFIED>{data, sz});
     else if (sz == static_cast<size_t>(SMALL_SIZE + 1))
-        m_buffer =
-            pro::make_proxy_inplace<AnyBufferFacade>(Fixed32Buffer<ENTRY_MODIFIED>{data, sz});
+        m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(Fixed32Buffer<ENTRY_MODIFIED>{data, sz});
     else
-        m_buffer = pro::make_proxy_inplace<AnyBufferFacade>(
+        m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
             BufferModel<std::string, ENTRY_MODIFIED>{std::string(data, sz)});
 }
 
@@ -123,6 +109,20 @@ Entry::Holder Entry::makeBuffer(EntryStatus es, const char* data, size_t sz)
     default:
         return Holder{};
     }
+}
+
+std::string Entry::encodeToBytes() const
+{
+    if (!m_buffer.has_value())
+        return {};
+    return m_buffer->encodeTo();
+}
+
+/* static */ Entry Entry::decodeFromBytes(std::string_view bytes)
+{
+    Entry entry;
+    entry.set(bytes);
+    return entry;
 }
 
 crypto::HashType Entry::hash(std::string_view table, std::string_view key,

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -6,6 +6,7 @@
 namespace bcos::storage
 {
 DERIVE_BCOS_EXCEPTION(TypedEntryStatusChange);
+DERIVE_BCOS_EXCEPTION(TypedEntryHashCall);
 
 std::string_view Entry::get() const&
 {
@@ -129,6 +130,11 @@ crypto::HashType Entry::hash(std::string_view table, std::string_view key,
     const bcos::crypto::Hash& hashImpl, uint32_t blockVersion,
     std::optional<bcos::ledger::Features> const& features) const
 {
+    if (m_buffer.has_value() && m_buffer->getTypedPtr() != nullptr)
+    {
+        BOOST_THROW_EXCEPTION(TypedEntryHashCall{});
+    }
+
     const bool enableHashCollisionFix =
         features.has_value() &&
         features->get(bcos::ledger::Features::Flag::bugfix_statestorage_hash_v3_17);

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -113,8 +113,8 @@ std::string Entry::encodeToBytes() const
     if (!m_buffer.has_value())
         return {};
     std::string result;
-    m_buffer->encode([&result](const uint8_t* data, size_t size) {
-        result.append(reinterpret_cast<const char*>(data), size);
+    m_buffer->encode([&result](bytesConstRef data) {
+        result.append(reinterpret_cast<const char*>(data.data()), data.size());
     });
     return result;
 }

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -5,6 +5,7 @@
 
 namespace bcos::storage
 {
+DERIVE_BCOS_EXCEPTION(TypedEntryStatusChange);
 
 std::string_view Entry::get() const&
 {
@@ -25,17 +26,6 @@ int32_t Entry::size() const
     return m_buffer.has_value() ? static_cast<int32_t>(m_buffer->size()) : 0;
 }
 
-std::string_view Entry::getField(size_t index) const&
-{
-    if (index > 0)
-    {
-        BOOST_THROW_EXCEPTION(
-            BCOS_ERROR(-1, "Get field index: " + boost::lexical_cast<std::string>(index) +
-                               " failed, index out of range"));
-    }
-    return get();
-}
-
 Entry::Status Entry::status() const
 {
     if (!m_buffer.has_value()) [[unlikely]]
@@ -45,6 +35,12 @@ Entry::Status Entry::status() const
 
 void Entry::setStatus(Status status)
 {
+    // Typed entries are immutable — refuse status mutation.
+    if (m_buffer.has_value() && m_buffer->getTypedPtr() != nullptr)
+    {
+        BOOST_THROW_EXCEPTION(TypedEntryStatusChange{});
+    }
+
     auto cur = this->status();
     if (cur == status)
         return;

--- a/bcos-framework/bcos-framework/storage/Entry.cpp
+++ b/bcos-framework/bcos-framework/storage/Entry.cpp
@@ -115,7 +115,11 @@ std::string Entry::encodeToBytes() const
 {
     if (!m_buffer.has_value())
         return {};
-    return m_buffer->encodeTo();
+    std::string result;
+    m_buffer->encode([&result](const uint8_t* data, size_t size) {
+        result.append(reinterpret_cast<const char*>(data), size);
+    });
+    return result;
 }
 
 /* static */ Entry Entry::decodeFromBytes(std::string_view bytes)

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -22,6 +22,7 @@
 #include <range/v3/range/concepts.hpp>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <type_traits>
 #include <typeindex>
 
@@ -76,7 +77,7 @@ struct AnyEntryFacade
         MemSize, size_t() const noexcept>::add_convention<MemStatus,
         EntryStatus() const noexcept>::add_convention<MemEncode,
         void(std::function<void(const uint8_t*, size_t)>) const>::add_convention<MemGetTypedPtr,
-        void*() const noexcept>::add_convention<MemTypeIndex,
+        const void*() const noexcept>::add_convention<MemTypeIndex,
         std::type_index() const noexcept>::support_copy<pro::constraint_level::nontrivial>::
         support_relocation<pro::constraint_level::nothrow>::support_destruction<
             pro::constraint_level::nothrow>::restrict_layout<MAX_PROXY_BUFFER_SIZE, 8>::build
@@ -114,7 +115,7 @@ public:
     }
 
     [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
+    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Stores exactly 32 bytes inline.
@@ -137,7 +138,7 @@ public:
     }
 
     [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
+    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Adapts any ByteBuffer-conforming type T.
@@ -162,7 +163,7 @@ public:
     }
 
     [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
+    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Adapts a shared_ptr-wrapped ByteBuffer type.
@@ -186,7 +187,7 @@ public:
     }
 
     [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
+    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Deleted sentinel model.
@@ -204,17 +205,47 @@ public:
     void encode(std::function<void(const uint8_t*, size_t)>) const {}
 
     [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
+    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
+// ─── tag_invoke infrastructure ─────────────────────────────────────
+// ADL anchor declared in bcos::storage.  Users must overload tag_invoke
+// in their own namespaces to provide encode/decode for their types.
+void tag_invoke();  // not defined — poison pill to prevent unqualified calls
+
+// ─── Encode customization point object ────────────────────────────
+// Requires: tag_invoke(encode_t, const T&, std::function<void(const uint8_t*, size_t)>)
+// to be defined in T's associated namespace.
+struct encode_t
+{
+    template <typename T>
+    void operator()(const T& v, std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        tag_invoke(*this, v, std::move(sink));
+    }
+};
+inline constexpr encode_t encode{};
+
+// ─── Decode customization point object ────────────────────────────
+// Requires: tag_invoke(decode_t, std::type_identity<T>, const uint8_t*, size_t)
+// to be defined in T's associated namespace.
+struct decode_t
+{
+    template <typename T>
+    T operator()(std::type_identity<T>, const uint8_t* data, size_t size) const
+    {
+        return tag_invoke(*this, std::type_identity<T>{}, data, size);
+    }
+};
+inline constexpr decode_t decode{};
+
 // ─── Encodable concept ─────────────────────────────────────────────
-// T must provide:
-//   void encode(std::function<void(const uint8_t*, size_t)> sink) const
-//   T(const uint8_t* data, size_t size)  // decode constructor
+// Satisfied when tag_invoke(encode_t, v, sink) and
+// tag_invoke(decode_t, type_identity<T>{}, data, size) are well-formed.
 template <typename T>
 concept Encodable = requires(const T& v, const uint8_t* data, size_t size) {
-    { v.encode(std::declval<std::function<void(const uint8_t*, size_t)>>()) } -> std::same_as<void>;
-    T{data, size};
+    { encode(v, std::declval<std::function<void(const uint8_t*, size_t)>>()) } -> std::same_as<void>;
+    { decode(std::type_identity<T>{}, data, size) } -> std::same_as<T>;
 };
 
 // ─── Typed holder model ────────────────────────────────────────────
@@ -233,9 +264,9 @@ public:
 
     void encode(std::function<void(const uint8_t*, size_t)> sink) const
     {
-        m_value.encode(std::move(sink));
+        bcos::storage::encode(m_value, std::move(sink));
     }
-    [[nodiscard]] void* getTypedPtr() const noexcept { return const_cast<T*>(&m_value); }
+    [[nodiscard]] const void* getTypedPtr() const noexcept { return &m_value; }
     [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(T); }
 };
 
@@ -278,25 +309,10 @@ public:
     // ── Accessors ──────────────────────────────────────────────────
 
     std::string_view get() const&;
-
-    std::string_view getField(size_t index) const&;
-
     const char* data() const&;
     int32_t size() const;
 
     // ── Mutators ───────────────────────────────────────────────────
-
-    template <typename T>
-    void setField(size_t index, T&& input)
-    {
-        if (index > 0)
-        {
-            BOOST_THROW_EXCEPTION(
-                BCOS_ERROR(-1, "Set field index: " + boost::lexical_cast<std::string>(index) +
-                                   " failed, index out of range"));
-        }
-        set(std::forward<T>(input));
-    }
 
     void set(ByteBuffer auto value)
     {
@@ -307,13 +323,13 @@ public:
         }
         else
         {
-            auto sz = value.size();
-            if (sz <= SMALL_SIZE)
-                m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
-                    SmallBuffer<ENTRY_MODIFIED>{reinterpret_cast<const char*>(value.data()), sz});
-            else if (sz == static_cast<decltype(sz)>(SMALL_SIZE + 1))
-                m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
-                    Fixed32Buffer<ENTRY_MODIFIED>{reinterpret_cast<const char*>(value.data()), sz});
+            auto valueSize = value.size();
+            if (valueSize <= SMALL_SIZE)
+                m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(SmallBuffer<ENTRY_MODIFIED>{
+                    reinterpret_cast<const char*>(value.data()), valueSize});
+            else if (valueSize == static_cast<decltype(valueSize)>(SMALL_SIZE + 1))
+                m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(Fixed32Buffer<ENTRY_MODIFIED>{
+                    reinterpret_cast<const char*>(value.data()), valueSize});
             else
                 m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
                     BufferModel<RawType, ENTRY_MODIFIED>{std::forward<decltype(value)>(value)});
@@ -339,7 +355,7 @@ public:
     void setTyped(T value);
 
     template <Encodable T>
-    T* getTyped() const;
+    const T* getTyped() const;
 
     template <Encodable T>
     bool holdsType() const noexcept;
@@ -362,7 +378,7 @@ public:
             BOOST_THROW_EXCEPTION(
                 BCOS_ERROR(StorageError::UnknownEntryType, "Import fields not equal to 1"));
         }
-        setField(0, std::move(*values.begin()));
+        set(std::move(*values.begin()));
     }
 
     bool valid() const;
@@ -394,7 +410,7 @@ private:
                 BufferModel<std::string, S>{std::string(data, sz)});
     }
 
-    Holder m_buffer;
+    mutable Holder m_buffer;
 
     // ── Decode synchronization ────────────────────────────────────
     // Protects the lazy-decode transition in getTyped<T>().
@@ -416,52 +432,63 @@ void Entry::setTyped(T value)
 }
 
 template <Encodable T>
-T* Entry::getTyped() const
+const T* Entry::getTyped() const
 {
     if (!m_buffer.has_value())
         return nullptr;
 
     // ── Fast path: already typed, no lock ─────────────────────────
+    // Acquire fence pairs with m_decodeLock.clear(release) in the
+    // slow path to ensure visibility of TypedHolderModel<T> inline
+    // data on weakly-ordered architectures (ARM, Power).
+    std::atomic_thread_fence(std::memory_order_acquire);
     auto* ptr = m_buffer->getTypedPtr();
     if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
-        return static_cast<T*>(ptr);
+        return static_cast<const T*>(ptr);
 
     // Typed model with a different type — refuse (type is immutable).
     if (ptr != nullptr)
         return nullptr;
 
     // ── Slow path: byte-buffer → typed, needs synchronization ─────
-    // Spin until we acquire the lock.
+    // Spin until we acquire the lock, with backoff after 64 spins
+    // to avoid burning CPU if the decoding thread is preempted.
+    int spins = 0;
     while (m_decodeLock.test_and_set(std::memory_order_acquire))
-        ;
+    {
+        if (++spins > 64)
+        {
+            spins = 0;
+            std::this_thread::yield();
+        }
+    }
+
+    // RAII spinlock guard: releases m_decodeLock on scope exit,
+    // preventing lock leaks from early returns or exceptions.
+    struct DecodeLockGuard
+    {
+        std::atomic_flag* lock;
+        ~DecodeLockGuard() { lock->clear(std::memory_order_release); }
+    } guard{std::addressof(m_decodeLock)};
 
     // Double-check: another thread may have decoded while we waited.
     ptr = m_buffer->getTypedPtr();
     if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
-    {
-        m_decodeLock.clear(std::memory_order_release);
-        return static_cast<T*>(ptr);
-    }
+        return static_cast<const T*>(ptr);
+
+    // Typed model with a different type — refuse (type is immutable).
     if (ptr != nullptr)
-    {
-        m_decodeLock.clear(std::memory_order_release);
         return nullptr;
-    }
 
     // Still byte-buffer — perform the decode.
     auto view = get();
     if (view.empty())
-    {
-        m_decodeLock.clear(std::memory_order_release);
         return nullptr;
-    }
 
-    T obj(reinterpret_cast<const uint8_t*>(view.data()), view.size());
-    auto* self = const_cast<Entry*>(this);
-    self->m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(obj)});
-    auto* result = static_cast<T*>(self->m_buffer->getTypedPtr());
-    m_decodeLock.clear(std::memory_order_release);
-    return result;
+    auto obj = decode(std::type_identity<T>{},
+        reinterpret_cast<const uint8_t*>(view.data()), view.size());
+    m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(obj)});
+    return static_cast<const T*>(m_buffer->getTypedPtr());
 }
 
 template <Encodable T>

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -7,9 +7,6 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Error.h>
 #include <proxy/proxy.h>
-#include <boost/archive/basic_archive.hpp>
-#include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/iostreams/stream.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
@@ -20,8 +17,11 @@
 #include <initializer_list>
 #include <memory>
 #include <optional>
-#include <type_traits>
 #include <range/v3/range/concepts.hpp>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <typeindex>
 
 namespace bcos::storage
 {
@@ -40,9 +40,6 @@ concept ByteBuffer = requires(const T& t) {
 template <typename T>
 constexpr bool IsByteBufferViewV = ::ranges::view_<std::remove_cvref_t<T>>;
 
-constexpr static int32_t ARCHIVE_FLAG =
-    boost::archive::no_header | boost::archive::no_codecvt | boost::archive::no_tracking;
-
 // ─── Status enum at namespace scope ────────────────────────────────
 // Defined before buffer models and facade so they can use it as a
 // non-type template parameter and convention return type.  Values MUST
@@ -56,41 +53,39 @@ enum EntryStatus : int8_t
     ENTRY_MODIFIED = 3,  // dirty() can use status
 };
 
-// ─── Proxy-based type-erased byte-buffer facade ────────────────────
-// Replaces the previous AnyHolder + AnyBufferVTableExt hand-rolled vtable
-// with proxy's facade-builder, which achieves the same zero-virtual-overhead
-// dispatch (data/size/status) through its own vtable mechanism.
+// ─── Proxy-based type-erased entry facade ──────────────────────────
+// Unified facade for both byte-buffer and typed models.
+// Byte-buffer models: data/size/status return buffer content; encodeTo
+//   returns a copy of raw bytes; getTypedPtr returns nullptr.
+// Typed models: data returns nullptr; encodeTo calls T::encode();
+//   getTypedPtr returns the concrete object pointer.
 
-// Maximum inline buffer size for the proxy's small-buffer optimization.
-// Must accommodate the largest buffer model (currently BufferModel<T> / SmallBuffer etc.).
 inline constexpr size_t MAX_PROXY_BUFFER_SIZE = 32;
 
 PRO_DEF_MEM_DISPATCH(MemData, data);
 PRO_DEF_MEM_DISPATCH(MemSize, size);
 PRO_DEF_MEM_DISPATCH(MemStatus, status);
+PRO_DEF_MEM_DISPATCH(MemEncodeTo, encodeTo);
+PRO_DEF_MEM_DISPATCH(MemGetTypedPtr, getTypedPtr);
 
-struct AnyBufferFacade
+struct AnyEntryFacade
   : pro::facade_builder ::add_convention<MemData, const char*() const noexcept>::add_convention<
-        MemSize, size_t() const noexcept>::add_convention<MemStatus,
-        EntryStatus() const noexcept>::support_copy<pro::constraint_level::nontrivial>::
-        support_relocation<pro::constraint_level::nothrow>::support_destruction<
-            pro::constraint_level::nothrow>::restrict_layout<MAX_PROXY_BUFFER_SIZE, 8>::build
+        MemSize, size_t() const noexcept>::add_convention<MemStatus, EntryStatus() const noexcept>::
+        add_convention<MemEncodeTo, std::string() const>::add_convention<MemGetTypedPtr,
+            void*() const noexcept>::support_copy<pro::constraint_level::nontrivial>::
+            support_relocation<pro::constraint_level::nothrow>::support_destruction<
+                pro::constraint_level::nothrow>::restrict_layout<MAX_PROXY_BUFFER_SIZE, 8>::build
 {
 };
 
-// Buffer models no longer need a common base class — proxy dispatches
-// through the facade conventions above. Each model only needs data(),
-// size() and status() member functions with the signatures declared in
-// AnyBufferFacade.
-//
-// Every buffer model is templated on EntryStatus so the status is
-// encoded in the *type* rather than stored as a runtime field.  This
-// removes the 8-byte m_status member from Entry (reducing sizeof(Entry)
-// from 48 → 40).  Status transitions reconstruct the proxy with a
-// different template argument.
+// ─── Buffer models ─────────────────────────────────────────────────
+// Every model implements the full AnyEntryFacade convention set.
+// Byte-buffer models: data/size/status work as before; encodeTo returns
+//   a copy of the raw bytes; typeTag returns RAW_BYTES; getTypedPtr returns nullptr.
+// Typed models: data returns nullptr; encodeTo calls T::encode();
+//   typeTag returns the tag for T; getTypedPtr returns the concrete object.
 
-// Stores ≤31 bytes inline.  Repurposes 1 byte for the length so the
-// total data-member footprint stays at 32 bytes (saving 8 B vs size_t).
+// Stores ≤31 bytes inline.
 template <EntryStatus S>
 class SmallBuffer
 {
@@ -107,9 +102,11 @@ public:
     [[nodiscard]] const char* data() const noexcept { return m_buffer.data(); }
     [[nodiscard]] size_t size() const noexcept { return m_size; }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
-// Stores exactly 32 bytes inline — no size field needed.
+// Stores exactly 32 bytes inline.
 template <EntryStatus S>
 class Fixed32Buffer
 {
@@ -122,10 +119,11 @@ public:
     [[nodiscard]] const char* data() const noexcept { return m_buffer.data(); }
     [[nodiscard]] size_t size() const noexcept { return CAPACITY; }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
-// Adapts any ByteBuffer-conforming type T (std::string, std::vector<char>,
-// std::array<char,N>, etc.). Owns the value by move/copy.
+// Adapts any ByteBuffer-conforming type T.
 template <ByteBuffer T, EntryStatus S>
     requires(sizeof(T) <= MAX_PROXY_BUFFER_SIZE)
 class BufferModel
@@ -140,10 +138,11 @@ public:
     }
     [[nodiscard]] size_t size() const noexcept { return m_value.size(); }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
-// Adapts a shared_ptr-wrapped ByteBuffer type. Shares ownership of the
-// underlying buffer — no copy on clone().
+// Adapts a shared_ptr-wrapped ByteBuffer type.
 template <ByteBuffer T, EntryStatus S>
 class SharedBufferModel
 {
@@ -157,14 +156,11 @@ public:
     }
     [[nodiscard]] size_t size() const noexcept { return m_ptr->size(); }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
-// ─── Deleted sentinel model ────────────────────────────────────────
-// Encodes the DELETED status purely as a type tag — no data is stored.
-// This avoids the value copy/move that the old setStatus(DELETED) path
-// incurred.  The proxy still satisfies has_value()==true, but data()
-// returns a pointer to an empty string and size() returns 0, so the
-// observable behaviour is identical to the previous DELETED state.
+// Deleted sentinel model.
 class DeletedModel
 {
 public:
@@ -175,6 +171,27 @@ public:
     }
     [[nodiscard]] size_t size() const noexcept { return 0; }
     [[nodiscard]] EntryStatus status() const noexcept { return ENTRY_DELETED; }
+    [[nodiscard]] std::string encodeTo() const { return {}; }
+    [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
+};
+
+// ─── Typed holder model ────────────────────────────────────────────
+// Stores a typed shared_ptr<void> (16 bytes) + encode function pointer
+// (8 bytes) = 24 bytes inline.  Fits in 32-byte proxy SBO.
+class TypedHolderModel
+{
+    std::shared_ptr<void> m_ptr;
+    std::string (*m_encodeFn)(const void*);
+
+public:
+    TypedHolderModel(std::shared_ptr<void> ptr, std::string (*encodeFn)(const void*))
+      : m_ptr(std::move(ptr)), m_encodeFn(encodeFn)
+    {}
+    [[nodiscard]] const char* data() const noexcept { return nullptr; }
+    [[nodiscard]] size_t size() const noexcept { return 0; }
+    [[nodiscard]] EntryStatus status() const noexcept { return ENTRY_MODIFIED; }
+    [[nodiscard]] std::string encodeTo() const { return m_encodeFn(m_ptr.get()); }
+    [[nodiscard]] void* getTypedPtr() const noexcept { return m_ptr.get(); }
 };
 
 class Entry
@@ -192,49 +209,16 @@ public:
     constexpr static int32_t SMALL_SIZE = 31;
     static constexpr size_t INLINE_BUFFER_SIZE = 40;
 
-    using Holder = pro::proxy<AnyBufferFacade>;
+    using Holder = pro::proxy<AnyEntryFacade>;
 
     Entry() = default;
     explicit Entry(auto input) { set(std::move(input)); }
 
-    Entry(const Entry& other);
+    Entry(const Entry& other) = default;
     Entry(Entry&&) noexcept = default;
-    bcos::storage::Entry& operator=(const Entry& other);
+    bcos::storage::Entry& operator=(const Entry& other) = default;
     bcos::storage::Entry& operator=(Entry&&) noexcept = default;
     ~Entry() noexcept = default;
-
-    template <typename Out, typename InputArchive = boost::archive::binary_iarchive,
-        int flag = ARCHIVE_FLAG>
-    void getObject(Out& out) const
-    {
-        auto view = get();
-        boost::iostreams::stream<boost::iostreams::array_source> inputStream(
-            view.data(), view.size());
-        InputArchive archive(inputStream, flag);
-        archive >> out;
-    }
-
-    template <typename Out, typename InputArchive = boost::archive::binary_iarchive,
-        int flag = ARCHIVE_FLAG>
-    Out getObject() const
-    {
-        Out out;
-        getObject<Out, InputArchive, flag>(out);
-        return out;
-    }
-
-    template <typename In, typename OutputArchive = boost::archive::binary_oarchive,
-        int flag = ARCHIVE_FLAG>
-    void setObject(const In& input)
-    {
-        std::string value;
-        boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>> outputStream(
-            value);
-        OutputArchive archive(outputStream, flag);
-        archive << input;
-        outputStream.flush();
-        setField(0, std::move(value));
-    }
 
     // ── Accessors ──────────────────────────────────────────────────
 
@@ -264,21 +248,19 @@ public:
         using RawType = std::remove_cvref_t<decltype(value)>;
         if constexpr (IsByteBufferViewV<RawType>)
         {
-            // Non-owning views (string_view, span, etc.): deep-copy the content
             setImplCopy(reinterpret_cast<const char*>(value.data()), value.size());
         }
         else
         {
-            // Owning types (string, vector, etc.): store the value directly
             auto sz = value.size();
             if (sz <= SMALL_SIZE)
-                m_buffer = pro::make_proxy_inplace<AnyBufferFacade>(
+                m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
                     SmallBuffer<ENTRY_MODIFIED>{reinterpret_cast<const char*>(value.data()), sz});
             else if (sz == static_cast<decltype(sz)>(SMALL_SIZE + 1))
-                m_buffer = pro::make_proxy_inplace<AnyBufferFacade>(
+                m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
                     Fixed32Buffer<ENTRY_MODIFIED>{reinterpret_cast<const char*>(value.data()), sz});
             else
-                m_buffer = pro::make_proxy_inplace<AnyBufferFacade>(
+                m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
                     BufferModel<RawType, ENTRY_MODIFIED>{std::forward<decltype(value)>(value)});
         }
     }
@@ -293,9 +275,22 @@ public:
     template <ByteBuffer T>
     void set(std::shared_ptr<T> value)
     {
-        m_buffer = pro::make_proxy_inplace<AnyBufferFacade>(
+        m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
             SharedBufferModel<T, ENTRY_MODIFIED>{std::move(value)});
     }
+
+    // ── Typed storage API ──────────────────────────────────────────
+    template <typename T>
+    void setTyped(std::shared_ptr<T> ptr);
+
+    template <typename T>
+    T* getTyped() const;
+
+    template <typename T>
+    bool holdsType() const noexcept;
+
+    // Encode for persistence via the facade's encodeTo convention.
+    std::string encodeToBytes() const;
 
     // ── Status ─────────────────────────────────────────────────────
 
@@ -329,36 +324,74 @@ public:
 private:
     void setImplCopy(const char* data, size_t sz);
 
-    // Helper: construct a buffer with the given status, preserving data.
-    // Used by setStatus() for NORMAL ↔ MODIFIED transitions.
     static Holder makeBuffer(EntryStatus es, const char* data, size_t sz);
 
     template <EntryStatus S>
     static Holder makeBufferImpl(const char* data, size_t sz)
     {
         if (sz <= SMALL_SIZE)
-            return pro::make_proxy_inplace<AnyBufferFacade>(SmallBuffer<S>{data, sz});
+            return pro::make_proxy_inplace<AnyEntryFacade>(SmallBuffer<S>{data, sz});
         else if (sz == static_cast<size_t>(SMALL_SIZE + 1))
-            return pro::make_proxy_inplace<AnyBufferFacade>(Fixed32Buffer<S>{data, sz});
+            return pro::make_proxy_inplace<AnyEntryFacade>(Fixed32Buffer<S>{data, sz});
         else
-            return pro::make_proxy_inplace<AnyBufferFacade>(
+            return pro::make_proxy_inplace<AnyEntryFacade>(
                 BufferModel<std::string, S>{std::string(data, sz)});
     }
 
     Holder m_buffer;
 
-    // Unit-test accessor: exposes the internal proxy holder for inspection
-    // (buffer model type can be verified via decltype and size checks).
+    // Unit-test accessor.
     friend const Holder& entryTestHolder(const Entry& e) noexcept { return e.m_buffer; }
 };
 
-}  // namespace bcos::storage
+// ─── Template implementations ──────────────────────────────────────
 
-namespace boost::serialization
+template <typename T>
+void Entry::setTyped(std::shared_ptr<T> ptr)
 {
-template <typename Archive, typename... Types>
-void serialize(Archive& ar, std::tuple<Types...>& t, const unsigned int)
-{
-    std::apply([&](auto&... element) { ((ar & element), ...); }, t);
+    auto encodeFn = +[](const void* p) -> std::string {
+        std::string out;
+        static_cast<const T*>(p)->encode(out);
+        return out;
+    };
+    m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel{std::move(ptr), encodeFn});
 }
-}  // namespace boost::serialization
+
+template <typename T>
+T* Entry::getTyped() const
+{
+    if (!m_buffer.has_value())
+        return nullptr;
+
+    // If already a typed model, return the stored pointer.
+    auto* ptr = m_buffer->getTypedPtr();
+    if (ptr != nullptr)
+        return static_cast<T*>(ptr);
+
+    // Byte-buffer mode: lazy decode.
+    auto view = get();
+    if (view.empty())
+        return nullptr;
+
+    auto obj = std::make_shared<T>();
+    obj->decode(bcos::bytesConstRef(reinterpret_cast<const bcos::byte*>(view.data()), view.size()));
+
+    // Replace byte-buffer model with a typed model.
+    auto encodeFn = +[](const void* p) -> std::string {
+        std::string out;
+        static_cast<const T*>(p)->encode(out);
+        return out;
+    };
+    auto* self = const_cast<Entry*>(this);
+    self->m_buffer =
+        pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel{std::move(obj), encodeFn});
+    return static_cast<T*>(self->m_buffer->getTypedPtr());
+}
+
+template <typename T>
+bool Entry::holdsType() const noexcept
+{
+    if (!m_buffer.has_value())
+        return false;
+    return m_buffer->getTypedPtr() != nullptr;
+}

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -287,7 +287,7 @@ public:
 
     Entry(const Entry& other)
       : m_buffer(other.m_buffer)
-    {}  // m_decodeLock default-initialized (cleared) — new object, independent state
+    {}  // m_decodeState default-initialized (0) — new object, independent state
     Entry(Entry&& other) noexcept : m_buffer(std::move(other.m_buffer)) {}
     bcos::storage::Entry& operator=(const Entry& other)
     {
@@ -417,11 +417,42 @@ private:
     mutable Holder m_buffer;
 
     // ── Decode synchronization ────────────────────────────────────
-    // Protects the lazy-decode transition in getTyped<T>().
-    // Spinlock (atomic_flag): only 1-2 bytes overhead, and the
-    // critical section is a single decode + proxy assignment —
-    // spinning is cheaper than a futex wakeup.
-    mutable std::atomic_flag m_decodeLock = ATOMIC_FLAG_INIT;
+    // Tri-state atomic for lazy-decode in getTyped<T>().
+    //
+    // acquire-release ordering: store(DECODE_TYPED, release) pairs with
+    // load(acquire)==DECODE_TYPED in the fast path, guaranteeing visibility
+    // of m_buffer writes on weakly-ordered architectures.
+    static constexpr int DECODE_BYTE = 0;    // m_buffer holds a byte model (unlocked)
+    static constexpr int DECODE_LOCKED = 1;  // decode in progress — m_buffer being written
+    static constexpr int DECODE_TYPED =
+        2;  // m_buffer holds TypedHolderModel<T> (stable, immutable)
+    mutable std::atomic<int> m_decodeState{DECODE_BYTE};
+
+    // CAS-spin to acquire exclusive access to m_buffer.
+    // Returns the state that was replaced: DECODE_BYTE or DECODE_TYPED.
+    // Spins with backoff if another thread holds DECODE_LOCKED.
+    int acquireDecodeLock() const
+    {
+        int spins = 0;
+        while (true)
+        {
+            int expected = m_decodeState.load(std::memory_order_relaxed);
+            if (expected != DECODE_LOCKED)
+            {
+                if (m_decodeState.compare_exchange_weak(expected, DECODE_LOCKED,
+                        std::memory_order_acquire, std::memory_order_relaxed))
+                {
+                    return expected;
+                }
+                continue;
+            }
+            if (++spins > 64)
+            {
+                spins = 0;
+                std::this_thread::yield();
+            }
+        }
+    }
 
     // Unit-test accessor.
     friend const Holder& entryTestHolder(const Entry& e) noexcept { return e.m_buffer; }
@@ -432,7 +463,9 @@ private:
 template <Encodable T>
 void Entry::setTyped(T value)
 {
+    acquireDecodeLock();  // CAS BYTE→LOCKED or TYPED→LOCKED; spin-waits if LOCKED
     m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(value)});
+    m_decodeState.store(DECODE_TYPED, std::memory_order_release);
 }
 
 template <Encodable T>
@@ -443,67 +476,75 @@ const T* Entry::getTyped() const
         return nullptr;
     }
 
-    // ── Fast path: already typed, no lock ─────────────────────────
-    // Acquire fence pairs with m_decodeLock.clear(release) in the
-    // slow path to ensure visibility of TypedHolderModel<T> inline
-    // data on weakly-ordered architectures (ARM, Power).
-    std::atomic_thread_fence(std::memory_order_acquire);
-    auto* ptr = m_buffer->getTypedPtr();
-    if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
+    // ── Fast path: already typed, lock-free ───────────────────────
+    // DECODE_TYPED: m_buffer is typed AND immutable (no concurrent
+    // writer will ever modify it).  acquire-load synchronizes with the
+    // release-store in setTyped() or the slow-path decode completion,
+    // guaranteeing full visibility of the TypedHolderModel<T> inline data.
+    if (m_decodeState.load(std::memory_order_acquire) == DECODE_TYPED)
     {
-        return static_cast<const T*>(ptr);
-    }
-
-    // Typed model with a different type — refuse (type is immutable).
-    if (ptr != nullptr)
-    {
-        return nullptr;
-    }
-
-    // ── Slow path: byte-buffer → typed, needs synchronization ─────
-    // Spin until we acquire the lock, with backoff after 64 spins
-    // to avoid burning CPU if the decoding thread is preempted.
-    int spins = 0;
-    while (m_decodeLock.test_and_set(std::memory_order_acquire))
-    {
-        if (++spins > 64)
+        auto* ptr = m_buffer->getTypedPtr();
+        if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
         {
-            spins = 0;
-            std::this_thread::yield();
+            return static_cast<const T*>(ptr);
         }
+        // Rare edge case: DECODE_TYPED but getTypedPtr() is null.
+        // Can happen if set() overwrites a previously-typed entry
+        // (m_buffer now holds bytes, state is stale).  Fall through
+        // to the CAS loop which resets state→DECODE_BYTE and retries.
     }
 
-    // RAII spinlock guard: releases m_decodeLock on scope exit,
-    // preventing lock leaks from early returns or exceptions.
-    struct DecodeLockGuard
-    {
-        std::atomic_flag* lock;
-        ~DecodeLockGuard() { lock->clear(std::memory_order_release); }
-    } guard{std::addressof(m_decodeLock)};
+    // ── Slow path: CAS-based synchronization ──────────────────────
+    int prevState = acquireDecodeLock();
 
-    // Double-check: another thread may have decoded while we waited.
-    ptr = m_buffer->getTypedPtr();
-    if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
+    // RAII guard: on exception (e.g. T ctor throws on corrupt data),
+    // reset state to DECODE_BYTE so future callers can retry.
+    struct StateGuard
     {
-        return static_cast<const T*>(ptr);
+        std::atomic<int>* state;
+        bool dismissed = false;
+        ~StateGuard()
+        {
+            if (!dismissed) [[unlikely]]
+                state->store(DECODE_BYTE, std::memory_order_release);
+        }
+    } guard{std::addressof(m_decodeState)};
+
+    if (prevState == DECODE_TYPED)
+    {
+        // Another thread finished decoding while we waited for the lock.
+        auto* ptr = m_buffer->getTypedPtr();
+        if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
+        {
+            guard.dismissed = true;
+            m_decodeState.store(DECODE_TYPED, std::memory_order_release);
+            return static_cast<const T*>(ptr);
+        }
+        if (ptr != nullptr)
+        {
+            guard.dismissed = true;
+            m_decodeState.store(DECODE_TYPED, std::memory_order_release);
+            return nullptr;  // typed, but wrong type
+        }
+        // TYPED but null ptr — set() overwrote a typed entry.
+        // Fall through to decode from the byte buffer.
     }
 
-    // Typed model with a different type — refuse (type is immutable).
-    if (ptr != nullptr)
-    {
-        return nullptr;
-    }
-
-    // Still byte-buffer — perform the decode.
+    // prevState == DECODE_BYTE: perform the lazy decode.
     auto view = get();
     if (view.empty())
     {
+        guard.dismissed = true;
+        m_decodeState.store(DECODE_BYTE, std::memory_order_release);
         return nullptr;
     }
 
     auto obj = decode(std::type_identity<T>{},
         bytesConstRef(reinterpret_cast<const bcos::byte*>(view.data()), view.size()));
     m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(obj)});
+
+    guard.dismissed = true;
+    m_decodeState.store(DECODE_TYPED, std::memory_order_release);
     return static_cast<const T*>(m_buffer->getTypedPtr());
 }
 

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -76,7 +76,7 @@ struct AnyEntryFacade
   : pro::facade_builder ::add_convention<MemData, const char*() const noexcept>::add_convention<
         MemSize, size_t() const noexcept>::add_convention<MemStatus,
         EntryStatus() const noexcept>::add_convention<MemEncode,
-        void(std::function<void(const uint8_t*, size_t)>) const>::add_convention<MemGetTypedPtr,
+        void(std::function<void(bytesConstRef)>) const>::add_convention<MemGetTypedPtr,
         const void*() const noexcept>::add_convention<MemTypeIndex,
         std::type_index() const noexcept>::support_copy<pro::constraint_level::nontrivial>::
         support_relocation<pro::constraint_level::nothrow>::support_destruction<
@@ -109,9 +109,9 @@ public:
     size_t size() const noexcept { return m_size; }
     EntryStatus status() const noexcept { return S; }
 
-    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    void encode(std::function<void(bytesConstRef)> sink) const
     {
-        sink(reinterpret_cast<const uint8_t*>(data()), size());
+        sink(bytesConstRef(reinterpret_cast<const bcos::byte*>(data()), size()));
     }
 
     std::type_index typeIndex() const noexcept { return typeid(void); }
@@ -132,9 +132,9 @@ public:
     size_t size() const noexcept { return CAPACITY; }
     EntryStatus status() const noexcept { return S; }
 
-    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    void encode(std::function<void(bytesConstRef)> sink) const
     {
-        sink(reinterpret_cast<const uint8_t*>(data()), size());
+        sink(bytesConstRef(reinterpret_cast<const bcos::byte*>(data()), size()));
     }
 
     std::type_index typeIndex() const noexcept { return typeid(void); }
@@ -154,9 +154,9 @@ public:
     size_t size() const noexcept { return m_value.size(); }
     EntryStatus status() const noexcept { return S; }
 
-    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    void encode(std::function<void(bytesConstRef)> sink) const
     {
-        sink(reinterpret_cast<const uint8_t*>(data()), size());
+        sink(bytesConstRef(reinterpret_cast<const bcos::byte*>(data()), size()));
     }
 
     std::type_index typeIndex() const noexcept { return typeid(void); }
@@ -175,9 +175,9 @@ public:
     size_t size() const noexcept { return m_ptr->size(); }
     EntryStatus status() const noexcept { return S; }
 
-    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    void encode(std::function<void(bytesConstRef)> sink) const
     {
-        sink(reinterpret_cast<const uint8_t*>(data()), size());
+        sink(bytesConstRef(reinterpret_cast<const bcos::byte*>(data()), size()));
     }
 
     std::type_index typeIndex() const noexcept { return typeid(void); }
@@ -196,7 +196,7 @@ public:
     size_t size() const noexcept { return 0; }
     EntryStatus status() const noexcept { return ENTRY_DELETED; }
 
-    void encode(std::function<void(const uint8_t*, size_t)>) const {}
+    void encode(std::function<void(bytesConstRef)>) const {}
 
     std::type_index typeIndex() const noexcept { return typeid(void); }
     const void* getTypedPtr() const noexcept { return nullptr; }
@@ -208,40 +208,40 @@ public:
 void tag_invoke();  // not defined — poison pill to prevent unqualified calls
 
 // ─── Encode customization point object ────────────────────────────
-// Requires: tag_invoke(encode_t, const T&, std::function<void(const uint8_t*, size_t)>)
-// to be defined in T's associated namespace.
+// Requires: tag_invoke(encode_t, const T&, Sink) where Sink is callable
+// with bytesConstRef, to be defined in T's associated namespace.
 struct encode_t
 {
-    template <typename T>
-    void operator()(const T& v, std::function<void(const uint8_t*, size_t)> sink) const
+    template <typename T, typename Sink>
+    void operator()(const T& v, Sink&& sink) const
     {
-        tag_invoke(*this, v, std::move(sink));
+        tag_invoke(*this, v, std::forward<Sink>(sink));
     }
 };
 inline constexpr encode_t encode{};
 
 // ─── Decode customization point object ────────────────────────────
-// Requires: tag_invoke(decode_t, std::type_identity<T>, const uint8_t*, size_t)
+// Requires: tag_invoke(decode_t, std::type_identity<T>, bytesConstRef)
 // to be defined in T's associated namespace.
 struct decode_t
 {
     template <typename T>
-    T operator()(std::type_identity<T>, const uint8_t* data, size_t size) const
+    T operator()(std::type_identity<T>, bytesConstRef data) const
     {
-        return tag_invoke(*this, std::type_identity<T>{}, data, size);
+        return tag_invoke(*this, std::type_identity<T>{}, data);
     }
 };
 inline constexpr decode_t decode{};
 
 // ─── Encodable concept ─────────────────────────────────────────────
 // Satisfied when tag_invoke(encode_t, v, sink) and
-// tag_invoke(decode_t, type_identity<T>{}, data, size) are well-formed.
+// tag_invoke(decode_t, type_identity<T>{}, bytes) are well-formed.
 template <typename T>
-concept Encodable = requires(const T& v, const uint8_t* data, size_t size) {
+concept Encodable = requires(const T& v, bytesConstRef bytes) {
     {
-        encode(v, std::declval<std::function<void(const uint8_t*, size_t)>>())
+        encode(v, [](bytesConstRef) {})
     } -> std::same_as<void>;
-    { decode(std::type_identity<T>{}, data, size) } -> std::same_as<T>;
+    { decode(std::type_identity<T>{}, bytes) } -> std::same_as<T>;
 };
 
 // ─── Typed holder model ────────────────────────────────────────────
@@ -258,7 +258,7 @@ public:
     size_t size() const noexcept { return 0; }
     EntryStatus status() const noexcept { return ENTRY_MODIFIED; }
 
-    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    void encode(std::function<void(bytesConstRef)> sink) const
     {
         bcos::storage::encode(m_value, std::move(sink));
     }
@@ -501,8 +501,8 @@ const T* Entry::getTyped() const
         return nullptr;
     }
 
-    auto obj =
-        decode(std::type_identity<T>{}, reinterpret_cast<const uint8_t*>(view.data()), view.size());
+    auto obj = decode(std::type_identity<T>{},
+        bytesConstRef(reinterpret_cast<const bcos::byte*>(view.data()), view.size()));
     m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(obj)});
     return static_cast<const T*>(m_buffer->getTypedPtr());
 }

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -293,23 +293,42 @@ public:
     Entry() = default;
     explicit Entry(auto input) { set(std::move(input)); }
 
-    Entry(const Entry& other)
-      : m_buffer(other.m_buffer)
-    {}  // m_decodeState default-initialized (0) — new object, independent state
-    Entry(Entry&& other) noexcept : m_buffer(std::move(other.m_buffer)) {}
+    Entry(const Entry& other) : m_buffer(other.m_buffer)
+    {
+        // Propagate TYPED state so copies of typed entries hit the fast path.
+        // LOCKED state is not copied — the source must not be under concurrent
+        // mutation during copy (that would be UB regardless).
+        if (other.m_decodeState.load(std::memory_order_acquire) == DECODE_TYPED)
+            m_decodeState.store(DECODE_TYPED, std::memory_order_relaxed);
+    }
+    Entry(Entry&& other) noexcept : m_buffer(std::move(other.m_buffer))
+    {
+        if (other.m_decodeState.load(std::memory_order_acquire) == DECODE_TYPED)
+            m_decodeState.store(DECODE_TYPED, std::memory_order_relaxed);
+    }
     bcos::storage::Entry& operator=(const Entry& other)
     {
         m_buffer = other.m_buffer;
+        // Propagate TYPED state; if other is BYTE we keep current state.
+        if (other.m_decodeState.load(std::memory_order_acquire) == DECODE_TYPED)
+            m_decodeState.store(DECODE_TYPED, std::memory_order_relaxed);
         return *this;
     }
     bcos::storage::Entry& operator=(Entry&& other) noexcept
     {
         m_buffer = std::move(other.m_buffer);
+        if (other.m_decodeState.load(std::memory_order_acquire) == DECODE_TYPED)
+            m_decodeState.store(DECODE_TYPED, std::memory_order_relaxed);
         return *this;
     }
     ~Entry() noexcept = default;
 
     // ── Accessors ──────────────────────────────────────────────────
+    // NOTE: get()/data()/size() do not participate in the decode state
+    // machine.  They read m_buffer directly without acquiring DECODE_LOCKED.
+    // Concurrent get() + getTyped() (slow path) on the same Entry is a data
+    // race — callers must ensure external synchronization or use getTyped()
+    // exclusively once typed access begins.
 
     std::string_view get() const&;
     const char* data() const&;
@@ -522,27 +541,25 @@ const T* Entry::getTyped() const
         }
     } guard{std::addressof(m_decodeState)};
 
-    if (prevState == DECODE_TYPED)
+    // Double-check m_buffer regardless of prevState.  Handles:
+    // - Another thread finished decoding while we waited (prevState==TYPED).
+    // - Copy/move of a typed entry where state is stale BYTE (prevState==BYTE
+    //   but m_buffer already holds TypedHolderModel).
+    if (const auto* ptr = m_buffer->getTypedPtr(); ptr != nullptr)
     {
-        // Another thread finished decoding while we waited for the lock.
-        auto* ptr = m_buffer->getTypedPtr();
-        if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
+        if (m_buffer->typeIndex() == std::type_index(typeid(T)))
         {
             guard.dismissed = true;
             m_decodeState.store(DECODE_TYPED, std::memory_order_release);
             return static_cast<const T*>(ptr);
         }
-        if (ptr != nullptr)
-        {
-            guard.dismissed = true;
-            m_decodeState.store(DECODE_TYPED, std::memory_order_release);
-            return nullptr;  // typed, but wrong type
-        }
-        // TYPED but null ptr — set() overwrote a typed entry.
-        // Fall through to decode from the byte buffer.
+        // Typed, but wrong type — immutable.
+        guard.dismissed = true;
+        m_decodeState.store(DECODE_TYPED, std::memory_order_release);
+        return nullptr;
     }
 
-    // prevState == DECODE_BYTE: perform the lazy decode.
+    // Not typed — must be byte-buffer.  Perform the lazy decode.
     auto view = get();
     if (view.empty())
     {

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -279,7 +279,6 @@ public:
     };
 
     constexpr static int32_t SMALL_SIZE = 31;
-    static constexpr size_t INLINE_BUFFER_SIZE = 40;
 
     using Holder = pro::proxy<AnyEntryFacade>;
 
@@ -321,14 +320,20 @@ public:
         {
             auto valueSize = value.size();
             if (valueSize <= SMALL_SIZE)
+            {
                 m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(SmallBuffer<ENTRY_MODIFIED>{
                     reinterpret_cast<const char*>(value.data()), valueSize});
+            }
             else if (valueSize == static_cast<decltype(valueSize)>(SMALL_SIZE + 1))
+            {
                 m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(Fixed32Buffer<ENTRY_MODIFIED>{
                     reinterpret_cast<const char*>(value.data()), valueSize});
+            }
             else
+            {
                 m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(
                     BufferModel<RawType, ENTRY_MODIFIED>{std::forward<decltype(value)>(value)});
+            }
         }
     }
 
@@ -398,12 +403,15 @@ private:
     static Holder makeBufferImpl(const char* data, size_t sz)
     {
         if (sz <= SMALL_SIZE)
+        {
             return pro::make_proxy_inplace<AnyEntryFacade>(SmallBuffer<S>{data, sz});
-        else if (sz == static_cast<size_t>(SMALL_SIZE + 1))
+        }
+        if (sz == static_cast<size_t>(SMALL_SIZE + 1))
+        {
             return pro::make_proxy_inplace<AnyEntryFacade>(Fixed32Buffer<S>{data, sz});
-        else
-            return pro::make_proxy_inplace<AnyEntryFacade>(
-                BufferModel<std::string, S>{std::string(data, sz)});
+        }
+        return pro::make_proxy_inplace<AnyEntryFacade>(
+            BufferModel<std::string, S>{std::string(data, sz)});
     }
 
     mutable Holder m_buffer;
@@ -431,7 +439,9 @@ template <Encodable T>
 const T* Entry::getTyped() const
 {
     if (!m_buffer.has_value())
+    {
         return nullptr;
+    }
 
     // ── Fast path: already typed, no lock ─────────────────────────
     // Acquire fence pairs with m_decodeLock.clear(release) in the
@@ -440,11 +450,15 @@ const T* Entry::getTyped() const
     std::atomic_thread_fence(std::memory_order_acquire);
     auto* ptr = m_buffer->getTypedPtr();
     if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
+    {
         return static_cast<const T*>(ptr);
+    }
 
     // Typed model with a different type — refuse (type is immutable).
     if (ptr != nullptr)
+    {
         return nullptr;
+    }
 
     // ── Slow path: byte-buffer → typed, needs synchronization ─────
     // Spin until we acquire the lock, with backoff after 64 spins
@@ -470,16 +484,22 @@ const T* Entry::getTyped() const
     // Double-check: another thread may have decoded while we waited.
     ptr = m_buffer->getTypedPtr();
     if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
+    {
         return static_cast<const T*>(ptr);
+    }
 
     // Typed model with a different type — refuse (type is immutable).
     if (ptr != nullptr)
+    {
         return nullptr;
+    }
 
     // Still byte-buffer — perform the decode.
     auto view = get();
     if (view.empty())
+    {
         return nullptr;
+    }
 
     auto obj =
         decode(std::type_identity<T>{}, reinterpret_cast<const uint8_t*>(view.data()), view.size());
@@ -491,7 +511,9 @@ template <Encodable T>
 bool Entry::holdsType() const noexcept
 {
     if (!m_buffer.has_value())
+    {
         return false;
+    }
     return m_buffer->typeIndex() == std::type_index(typeid(T));
 }
 

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -105,17 +105,17 @@ public:
     {
         std::memcpy(m_buffer.data(), data, size);
     }
-    [[nodiscard]] const char* data() const noexcept { return m_buffer.data(); }
-    [[nodiscard]] size_t size() const noexcept { return m_size; }
-    [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    const char* data() const noexcept { return m_buffer.data(); }
+    size_t size() const noexcept { return m_size; }
+    EntryStatus status() const noexcept { return S; }
 
     void encode(std::function<void(const uint8_t*, size_t)> sink) const
     {
         sink(reinterpret_cast<const uint8_t*>(data()), size());
     }
 
-    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
+    std::type_index typeIndex() const noexcept { return typeid(void); }
+    const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Stores exactly 32 bytes inline.
@@ -128,17 +128,17 @@ class Fixed32Buffer
 public:
     Fixed32Buffer() = default;
     Fixed32Buffer(const char* data, size_t) { std::memcpy(m_buffer.data(), data, CAPACITY); }
-    [[nodiscard]] const char* data() const noexcept { return m_buffer.data(); }
-    [[nodiscard]] size_t size() const noexcept { return CAPACITY; }
-    [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    const char* data() const noexcept { return m_buffer.data(); }
+    size_t size() const noexcept { return CAPACITY; }
+    EntryStatus status() const noexcept { return S; }
 
     void encode(std::function<void(const uint8_t*, size_t)> sink) const
     {
         sink(reinterpret_cast<const uint8_t*>(data()), size());
     }
 
-    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
+    std::type_index typeIndex() const noexcept { return typeid(void); }
+    const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Adapts any ByteBuffer-conforming type T.
@@ -150,20 +150,17 @@ class BufferModel
 
 public:
     explicit BufferModel(T value) : m_value(std::move(value)) {}
-    [[nodiscard]] const char* data() const noexcept
-    {
-        return reinterpret_cast<const char*>(m_value.data());
-    }
-    [[nodiscard]] size_t size() const noexcept { return m_value.size(); }
-    [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    const char* data() const noexcept { return reinterpret_cast<const char*>(m_value.data()); }
+    size_t size() const noexcept { return m_value.size(); }
+    EntryStatus status() const noexcept { return S; }
 
     void encode(std::function<void(const uint8_t*, size_t)> sink) const
     {
         sink(reinterpret_cast<const uint8_t*>(data()), size());
     }
 
-    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
+    std::type_index typeIndex() const noexcept { return typeid(void); }
+    const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Adapts a shared_ptr-wrapped ByteBuffer type.
@@ -174,38 +171,35 @@ class SharedBufferModel
 
 public:
     explicit SharedBufferModel(std::shared_ptr<T> ptr) : m_ptr(std::move(ptr)) {}
-    [[nodiscard]] const char* data() const noexcept
-    {
-        return reinterpret_cast<const char*>(m_ptr->data());
-    }
-    [[nodiscard]] size_t size() const noexcept { return m_ptr->size(); }
-    [[nodiscard]] EntryStatus status() const noexcept { return S; }
+    const char* data() const noexcept { return reinterpret_cast<const char*>(m_ptr->data()); }
+    size_t size() const noexcept { return m_ptr->size(); }
+    EntryStatus status() const noexcept { return S; }
 
     void encode(std::function<void(const uint8_t*, size_t)> sink) const
     {
         sink(reinterpret_cast<const uint8_t*>(data()), size());
     }
 
-    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
+    std::type_index typeIndex() const noexcept { return typeid(void); }
+    const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // Deleted sentinel model.
 class DeletedModel
 {
 public:
-    [[nodiscard]] const char* data() const noexcept
+    const char* data() const noexcept
     {
         static constexpr const char* empty = "";
         return empty;
     }
-    [[nodiscard]] size_t size() const noexcept { return 0; }
-    [[nodiscard]] EntryStatus status() const noexcept { return ENTRY_DELETED; }
+    size_t size() const noexcept { return 0; }
+    EntryStatus status() const noexcept { return ENTRY_DELETED; }
 
     void encode(std::function<void(const uint8_t*, size_t)>) const {}
 
-    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
-    [[nodiscard]] const void* getTypedPtr() const noexcept { return nullptr; }
+    std::type_index typeIndex() const noexcept { return typeid(void); }
+    const void* getTypedPtr() const noexcept { return nullptr; }
 };
 
 // ─── tag_invoke infrastructure ─────────────────────────────────────
@@ -244,7 +238,9 @@ inline constexpr decode_t decode{};
 // tag_invoke(decode_t, type_identity<T>{}, data, size) are well-formed.
 template <typename T>
 concept Encodable = requires(const T& v, const uint8_t* data, size_t size) {
-    { encode(v, std::declval<std::function<void(const uint8_t*, size_t)>>()) } -> std::same_as<void>;
+    {
+        encode(v, std::declval<std::function<void(const uint8_t*, size_t)>>())
+    } -> std::same_as<void>;
     { decode(std::type_identity<T>{}, data, size) } -> std::same_as<T>;
 };
 
@@ -258,16 +254,16 @@ class TypedHolderModel
 
 public:
     explicit TypedHolderModel(T value) : m_value(std::move(value)) {}
-    [[nodiscard]] const char* data() const noexcept { return nullptr; }
-    [[nodiscard]] size_t size() const noexcept { return 0; }
-    [[nodiscard]] EntryStatus status() const noexcept { return ENTRY_MODIFIED; }
+    const char* data() const noexcept { return nullptr; }
+    size_t size() const noexcept { return 0; }
+    EntryStatus status() const noexcept { return ENTRY_MODIFIED; }
 
     void encode(std::function<void(const uint8_t*, size_t)> sink) const
     {
         bcos::storage::encode(m_value, std::move(sink));
     }
-    [[nodiscard]] const void* getTypedPtr() const noexcept { return &m_value; }
-    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(T); }
+    const void* getTypedPtr() const noexcept { return &m_value; }
+    std::type_index typeIndex() const noexcept { return typeid(T); }
 };
 
 class Entry
@@ -485,8 +481,8 @@ const T* Entry::getTyped() const
     if (view.empty())
         return nullptr;
 
-    auto obj = decode(std::type_identity<T>{},
-        reinterpret_cast<const uint8_t*>(view.data()), view.size());
+    auto obj =
+        decode(std::type_identity<T>{}, reinterpret_cast<const uint8_t*>(view.data()), view.size());
     m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(obj)});
     return static_cast<const T*>(m_buffer->getTypedPtr());
 }

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -69,6 +69,10 @@ PRO_DEF_MEM_DISPATCH(MemData, data);
 PRO_DEF_MEM_DISPATCH(MemSize, size);
 PRO_DEF_MEM_DISPATCH(MemStatus, status);
 PRO_DEF_MEM_DISPATCH(MemEncode, encode);
+// TODO(#5312): MemEncode convention is fixed to std::function<void(bytesConstRef)>,
+// so every encodeToBytes() call constructs a std::function temporary.
+// Future work: template the sink to eliminate type-erasure overhead,
+// or add an owning std::string overload to decodeFromBytes for zero-copy.
 PRO_DEF_MEM_DISPATCH(MemGetTypedPtr, getTypedPtr);
 PRO_DEF_MEM_DISPATCH(MemTypeIndex, typeIndex);
 
@@ -256,6 +260,10 @@ public:
     explicit TypedHolderModel(T value) : m_value(std::move(value)) {}
     const char* data() const noexcept { return nullptr; }
     size_t size() const noexcept { return 0; }
+    // TODO(#5312): Typed entries are always MODIFIED→dirty(), which collides
+    // with the commit path's hash-if-dirty logic.  Eventually degrade to byte
+    // semantics: hash() should hash encodeToBytes(), setStatus() should
+    // materialize encoded bytes before changing status.
     EntryStatus status() const noexcept { return ENTRY_MODIFIED; }
 
     void encode(std::function<void(bytesConstRef)> sink) const
@@ -362,6 +370,10 @@ public:
     bool holdsType() const noexcept;
 
     // Encode for persistence via the facade's encodeTo convention.
+    // TODO(#5312): encodeToBytes() materializes a std::string per call.
+    // For the RocksDB hot path this adds one copy vs the old zero-copy
+    // approach.  Future optimization: template the sink, or add a
+    // RocksDB-specific encode that writes directly to a Slice.
     std::string encodeToBytes() const;
     // Reconstruct from raw bytes (no type tag needed — caller knows the type).
     static Entry decodeFromBytes(std::string_view bytes);

--- a/bcos-framework/bcos-framework/storage/Entry.h
+++ b/bcos-framework/bcos-framework/storage/Entry.h
@@ -11,9 +11,11 @@
 #include <boost/throw_exception.hpp>
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <functional>
 #include <initializer_list>
 #include <memory>
 #include <optional>
@@ -65,25 +67,28 @@ inline constexpr size_t MAX_PROXY_BUFFER_SIZE = 32;
 PRO_DEF_MEM_DISPATCH(MemData, data);
 PRO_DEF_MEM_DISPATCH(MemSize, size);
 PRO_DEF_MEM_DISPATCH(MemStatus, status);
-PRO_DEF_MEM_DISPATCH(MemEncodeTo, encodeTo);
+PRO_DEF_MEM_DISPATCH(MemEncode, encode);
 PRO_DEF_MEM_DISPATCH(MemGetTypedPtr, getTypedPtr);
+PRO_DEF_MEM_DISPATCH(MemTypeIndex, typeIndex);
 
 struct AnyEntryFacade
   : pro::facade_builder ::add_convention<MemData, const char*() const noexcept>::add_convention<
-        MemSize, size_t() const noexcept>::add_convention<MemStatus, EntryStatus() const noexcept>::
-        add_convention<MemEncodeTo, std::string() const>::add_convention<MemGetTypedPtr,
-            void*() const noexcept>::support_copy<pro::constraint_level::nontrivial>::
-            support_relocation<pro::constraint_level::nothrow>::support_destruction<
-                pro::constraint_level::nothrow>::restrict_layout<MAX_PROXY_BUFFER_SIZE, 8>::build
+        MemSize, size_t() const noexcept>::add_convention<MemStatus,
+        EntryStatus() const noexcept>::add_convention<MemEncode,
+        void(std::function<void(const uint8_t*, size_t)>) const>::add_convention<MemGetTypedPtr,
+        void*() const noexcept>::add_convention<MemTypeIndex,
+        std::type_index() const noexcept>::support_copy<pro::constraint_level::nontrivial>::
+        support_relocation<pro::constraint_level::nothrow>::support_destruction<
+            pro::constraint_level::nothrow>::restrict_layout<MAX_PROXY_BUFFER_SIZE, 8>::build
 {
 };
 
 // ─── Buffer models ─────────────────────────────────────────────────
 // Every model implements the full AnyEntryFacade convention set.
-// Byte-buffer models: data/size/status work as before; encodeTo returns
-//   a copy of the raw bytes; typeTag returns RAW_BYTES; getTypedPtr returns nullptr.
-// Typed models: data returns nullptr; encodeTo calls T::encode();
-//   typeTag returns the tag for T; getTypedPtr returns the concrete object.
+// Byte-buffer models: data/size/status return buffer content; encode
+//   feeds raw bytes to sink; getTypedPtr returns nullptr.
+// Typed models: data returns nullptr; encode calls T::encode() then
+//   feeds the result to sink; getTypedPtr returns the object pointer.
 
 // Stores ≤31 bytes inline.
 template <EntryStatus S>
@@ -102,7 +107,13 @@ public:
     [[nodiscard]] const char* data() const noexcept { return m_buffer.data(); }
     [[nodiscard]] size_t size() const noexcept { return m_size; }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
-    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+
+    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        sink(reinterpret_cast<const uint8_t*>(data()), size());
+    }
+
+    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
     [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
@@ -119,7 +130,13 @@ public:
     [[nodiscard]] const char* data() const noexcept { return m_buffer.data(); }
     [[nodiscard]] size_t size() const noexcept { return CAPACITY; }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
-    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+
+    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        sink(reinterpret_cast<const uint8_t*>(data()), size());
+    }
+
+    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
     [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
@@ -138,7 +155,13 @@ public:
     }
     [[nodiscard]] size_t size() const noexcept { return m_value.size(); }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
-    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+
+    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        sink(reinterpret_cast<const uint8_t*>(data()), size());
+    }
+
+    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
     [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
@@ -156,7 +179,13 @@ public:
     }
     [[nodiscard]] size_t size() const noexcept { return m_ptr->size(); }
     [[nodiscard]] EntryStatus status() const noexcept { return S; }
-    [[nodiscard]] std::string encodeTo() const { return {data(), size()}; }
+
+    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        sink(reinterpret_cast<const uint8_t*>(data()), size());
+    }
+
+    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
     [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
@@ -171,27 +200,43 @@ public:
     }
     [[nodiscard]] size_t size() const noexcept { return 0; }
     [[nodiscard]] EntryStatus status() const noexcept { return ENTRY_DELETED; }
-    [[nodiscard]] std::string encodeTo() const { return {}; }
+
+    void encode(std::function<void(const uint8_t*, size_t)>) const {}
+
+    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(void); }
     [[nodiscard]] void* getTypedPtr() const noexcept { return nullptr; }
 };
 
+// ─── Encodable concept ─────────────────────────────────────────────
+// T must provide:
+//   void encode(std::function<void(const uint8_t*, size_t)> sink) const
+//   T(const uint8_t* data, size_t size)  // decode constructor
+template <typename T>
+concept Encodable = requires(const T& v, const uint8_t* data, size_t size) {
+    { v.encode(std::declval<std::function<void(const uint8_t*, size_t)>>()) } -> std::same_as<void>;
+    T{data, size};
+};
+
 // ─── Typed holder model ────────────────────────────────────────────
-// Stores a typed shared_ptr<void> (16 bytes) + encode function pointer
-// (8 bytes) = 24 bytes inline.  Fits in 32-byte proxy SBO.
+// Stores T directly by value.  If sizeof(T) ≤ 32, the proxy keeps it
+// inline (SBO); larger types are heap-allocated transparently.
+template <Encodable T>
 class TypedHolderModel
 {
-    std::shared_ptr<void> m_ptr;
-    std::string (*m_encodeFn)(const void*);
+    T m_value;
 
 public:
-    TypedHolderModel(std::shared_ptr<void> ptr, std::string (*encodeFn)(const void*))
-      : m_ptr(std::move(ptr)), m_encodeFn(encodeFn)
-    {}
+    explicit TypedHolderModel(T value) : m_value(std::move(value)) {}
     [[nodiscard]] const char* data() const noexcept { return nullptr; }
     [[nodiscard]] size_t size() const noexcept { return 0; }
     [[nodiscard]] EntryStatus status() const noexcept { return ENTRY_MODIFIED; }
-    [[nodiscard]] std::string encodeTo() const { return m_encodeFn(m_ptr.get()); }
-    [[nodiscard]] void* getTypedPtr() const noexcept { return m_ptr.get(); }
+
+    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        m_value.encode(std::move(sink));
+    }
+    [[nodiscard]] void* getTypedPtr() const noexcept { return const_cast<T*>(&m_value); }
+    [[nodiscard]] std::type_index typeIndex() const noexcept { return typeid(T); }
 };
 
 class Entry
@@ -214,10 +259,20 @@ public:
     Entry() = default;
     explicit Entry(auto input) { set(std::move(input)); }
 
-    Entry(const Entry& other) = default;
-    Entry(Entry&&) noexcept = default;
-    bcos::storage::Entry& operator=(const Entry& other) = default;
-    bcos::storage::Entry& operator=(Entry&&) noexcept = default;
+    Entry(const Entry& other)
+      : m_buffer(other.m_buffer)
+    {}  // m_decodeLock default-initialized (cleared) — new object, independent state
+    Entry(Entry&& other) noexcept : m_buffer(std::move(other.m_buffer)) {}
+    bcos::storage::Entry& operator=(const Entry& other)
+    {
+        m_buffer = other.m_buffer;
+        return *this;
+    }
+    bcos::storage::Entry& operator=(Entry&& other) noexcept
+    {
+        m_buffer = std::move(other.m_buffer);
+        return *this;
+    }
     ~Entry() noexcept = default;
 
     // ── Accessors ──────────────────────────────────────────────────
@@ -280,18 +335,19 @@ public:
     }
 
     // ── Typed storage API ──────────────────────────────────────────
-    template <typename T>
-    void setTyped(std::shared_ptr<T> ptr);
+    template <Encodable T>
+    void setTyped(T value);
 
-    template <typename T>
+    template <Encodable T>
     T* getTyped() const;
 
-    template <typename T>
+    template <Encodable T>
     bool holdsType() const noexcept;
 
     // Encode for persistence via the facade's encodeTo convention.
     std::string encodeToBytes() const;
-
+    // Reconstruct from raw bytes (no type tag needed — caller knows the type).
+    static Entry decodeFromBytes(std::string_view bytes);
     // ── Status ─────────────────────────────────────────────────────
 
     Status status() const;
@@ -340,58 +396,80 @@ private:
 
     Holder m_buffer;
 
+    // ── Decode synchronization ────────────────────────────────────
+    // Protects the lazy-decode transition in getTyped<T>().
+    // Spinlock (atomic_flag): only 1-2 bytes overhead, and the
+    // critical section is a single decode + proxy assignment —
+    // spinning is cheaper than a futex wakeup.
+    mutable std::atomic_flag m_decodeLock = ATOMIC_FLAG_INIT;
+
     // Unit-test accessor.
     friend const Holder& entryTestHolder(const Entry& e) noexcept { return e.m_buffer; }
 };
 
 // ─── Template implementations ──────────────────────────────────────
 
-template <typename T>
-void Entry::setTyped(std::shared_ptr<T> ptr)
+template <Encodable T>
+void Entry::setTyped(T value)
 {
-    auto encodeFn = +[](const void* p) -> std::string {
-        std::string out;
-        static_cast<const T*>(p)->encode(out);
-        return out;
-    };
-    m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel{std::move(ptr), encodeFn});
+    m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(value)});
 }
 
-template <typename T>
+template <Encodable T>
 T* Entry::getTyped() const
 {
     if (!m_buffer.has_value())
         return nullptr;
 
-    // If already a typed model, return the stored pointer.
+    // ── Fast path: already typed, no lock ─────────────────────────
     auto* ptr = m_buffer->getTypedPtr();
-    if (ptr != nullptr)
+    if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
         return static_cast<T*>(ptr);
 
-    // Byte-buffer mode: lazy decode.
-    auto view = get();
-    if (view.empty())
+    // Typed model with a different type — refuse (type is immutable).
+    if (ptr != nullptr)
         return nullptr;
 
-    auto obj = std::make_shared<T>();
-    obj->decode(bcos::bytesConstRef(reinterpret_cast<const bcos::byte*>(view.data()), view.size()));
+    // ── Slow path: byte-buffer → typed, needs synchronization ─────
+    // Spin until we acquire the lock.
+    while (m_decodeLock.test_and_set(std::memory_order_acquire))
+        ;
 
-    // Replace byte-buffer model with a typed model.
-    auto encodeFn = +[](const void* p) -> std::string {
-        std::string out;
-        static_cast<const T*>(p)->encode(out);
-        return out;
-    };
+    // Double-check: another thread may have decoded while we waited.
+    ptr = m_buffer->getTypedPtr();
+    if (ptr != nullptr && m_buffer->typeIndex() == std::type_index(typeid(T)))
+    {
+        m_decodeLock.clear(std::memory_order_release);
+        return static_cast<T*>(ptr);
+    }
+    if (ptr != nullptr)
+    {
+        m_decodeLock.clear(std::memory_order_release);
+        return nullptr;
+    }
+
+    // Still byte-buffer — perform the decode.
+    auto view = get();
+    if (view.empty())
+    {
+        m_decodeLock.clear(std::memory_order_release);
+        return nullptr;
+    }
+
+    T obj(reinterpret_cast<const uint8_t*>(view.data()), view.size());
     auto* self = const_cast<Entry*>(this);
-    self->m_buffer =
-        pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel{std::move(obj), encodeFn});
-    return static_cast<T*>(self->m_buffer->getTypedPtr());
+    self->m_buffer = pro::make_proxy_inplace<AnyEntryFacade>(TypedHolderModel<T>{std::move(obj)});
+    auto* result = static_cast<T*>(self->m_buffer->getTypedPtr());
+    m_decodeLock.clear(std::memory_order_release);
+    return result;
 }
 
-template <typename T>
+template <Encodable T>
 bool Entry::holdsType() const noexcept
 {
     if (!m_buffer.has_value())
         return false;
-    return m_buffer->getTypedPtr() != nullptr;
+    return m_buffer->typeIndex() == std::type_index(typeid(T));
 }
+
+}  // namespace bcos::storage

--- a/bcos-framework/bcos-framework/storage/KVStorageHelper.h
+++ b/bcos-framework/bcos-framework/storage/KVStorageHelper.h
@@ -24,7 +24,7 @@ public:
 
                 if (entry)
                 {
-                    callback(nullptr, entry->getField(0));
+                    callback(nullptr, entry->get());
                 }
                 else
                 {
@@ -51,7 +51,7 @@ public:
                 {
                     if (it)
                     {
-                        values->emplace_back(std::string(it->getField(0)));
+                        values->emplace_back(std::string(it->get()));
                     }
                     else
                     {

--- a/bcos-framework/bcos-framework/storage/Serialize.h
+++ b/bcos-framework/bcos-framework/storage/Serialize.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <boost/archive/basic_archive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/iostreams/device/array.hpp>
+#include <boost/iostreams/device/back_inserter.hpp>
+#include <boost/iostreams/stream.hpp>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+namespace bcos::storage::serialize
+{
+
+// ─── Archive flags (moved from Entry.h) ────────────────────────────
+// no_header | no_codecvt | no_tracking for minimal binary output.
+constexpr static int32_t ARCHIVE_FLAG =
+    boost::archive::no_header | boost::archive::no_codecvt | boost::archive::no_tracking;
+
+// ─── boost::archive-based encode/decode ────────────────────────────
+// Replaces Entry::setObject() / Entry::getObject().
+// Used for types like SystemConfigEntry, ConsensusNodeList, std::vector<std::string>, etc.
+// Caller: entry.set(serialize::encode(value));
+//         auto val = serialize::decode<T>(entry.get());
+
+template <typename T, typename OutputArchive = boost::archive::binary_oarchive,
+    int flag = ARCHIVE_FLAG>
+std::string encode(const T& input)
+{
+    std::string value;
+    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>> outputStream(
+        value);
+    OutputArchive archive(outputStream, flag);
+    archive << input;
+    outputStream.flush();
+    return value;
+}
+
+template <typename T, typename InputArchive = boost::archive::binary_iarchive,
+    int flag = ARCHIVE_FLAG>
+T decode(std::string_view view)
+{
+    T out;
+    boost::iostreams::stream<boost::iostreams::array_source> inputStream(view.data(), view.size());
+    InputArchive archive(inputStream, flag);
+    archive >> out;
+    return out;
+}
+
+// ─── Typed encode/decode (for types with encode()/decode() members) ─
+// Used for Transaction, TransactionReceipt, and similar.
+// Caller: entry.set(serialize::typedEncode(tx));
+//         auto tx = serialize::typedDecode<Transaction>(entry.get());
+
+template <typename T>
+    requires requires(const T& obj, std::string& out) { obj.encode(out); }
+std::string typedEncode(const T& obj)
+{
+    std::string out;
+    obj.encode(out);
+    return out;
+}
+
+template <typename T>
+    requires requires(T& obj, std::string_view in) { obj.decode(in); }
+T typedDecode(std::string_view view)
+{
+    T obj;
+    obj.decode(view);
+    return obj;
+}
+
+}  // namespace bcos::storage::serialize
+
+// ─── boost::serialization support for std::tuple ───────────────────
+// Required by SystemConfigEntry = std::tuple<std::string, BlockNumber>
+// and other tuple-based types stored via boost::archive.
+// Moved from Entry.h.
+namespace boost::serialization
+{
+template <typename Archive, typename... Types>
+void serialize(Archive& ar, std::tuple<Types...>& t, const unsigned int)
+{
+    std::apply([&](auto&... element) { ((ar & element), ...); }, t);
+}
+}  // namespace boost::serialization

--- a/bcos-framework/bcos-framework/storage/Serialize.h
+++ b/bcos-framework/bcos-framework/storage/Serialize.h
@@ -10,7 +10,6 @@
 #include <string>
 #include <string_view>
 #include <tuple>
-#include <type_traits>
 
 namespace bcos::storage::serialize
 {
@@ -31,8 +30,7 @@ template <typename T, typename OutputArchive = boost::archive::binary_oarchive,
 std::string encode(const T& input)
 {
     std::string value;
-    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>> outputStream(
-        value);
+    boost::iostreams::stream<boost::iostreams::back_insert_device<std::string>> outputStream(value);
     OutputArchive archive(outputStream, flag);
     archive << input;
     outputStream.flush();
@@ -48,29 +46,6 @@ T decode(std::string_view view)
     InputArchive archive(inputStream, flag);
     archive >> out;
     return out;
-}
-
-// ─── Typed encode/decode (for types with encode()/decode() members) ─
-// Used for Transaction, TransactionReceipt, and similar.
-// Caller: entry.set(serialize::typedEncode(tx));
-//         auto tx = serialize::typedDecode<Transaction>(entry.get());
-
-template <typename T>
-    requires requires(const T& obj, std::string& out) { obj.encode(out); }
-std::string typedEncode(const T& obj)
-{
-    std::string out;
-    obj.encode(out);
-    return out;
-}
-
-template <typename T>
-    requires requires(T& obj, std::string_view in) { obj.decode(in); }
-T typedDecode(std::string_view view)
-{
-    T obj;
-    obj.decode(view);
-    return obj;
 }
 
 }  // namespace bcos::storage::serialize

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -754,13 +754,13 @@ void Ledger::asyncGetBlockNumber(
             bcos::protocol::BlockNumber blockNumber = -1;
             try
             {
-                blockNumber = boost::lexical_cast<bcos::protocol::BlockNumber>(entry->getField(0));
+                blockNumber = boost::lexical_cast<bcos::protocol::BlockNumber>(entry->get());
             }
             catch (boost::bad_lexical_cast& e)
             {
                 // Ignore the exception
                 LEDGER_LOG(INFO) << "Cast blockNumber failed, may be empty, set to default value -1"
-                                 << LOG_KV("blockNumber str", entry->getField(0));
+                                 << LOG_KV("blockNumber str", entry->get());
             }
 
             LEDGER_LOG(TRACE) << "GetBlockNumber success" << LOG_KV("blockNumber", blockNumber);
@@ -796,7 +796,7 @@ void Ledger::asyncGetBlockHashByNumber(bcos::protocol::BlockNumber _blockNumber,
                     return;
                 }
 
-                auto hashStr = entry->getField(0);
+                auto hashStr = entry->get();
                 bcos::crypto::HashType hash(
                     std::string(hashStr), bcos::crypto::HashType::FromBinary);
 
@@ -836,14 +836,14 @@ void Ledger::asyncGetBlockNumberByHash(const crypto::HashType& _blockHash,
                 try
                 {
                     blockNumber =
-                        boost::lexical_cast<bcos::protocol::BlockNumber>(entry->getField(0));
+                        boost::lexical_cast<bcos::protocol::BlockNumber>(entry->get());
                 }
                 catch (boost::bad_lexical_cast& e)
                 {
                     // Ignore the exception
                     LEDGER_LOG(INFO)
                         << "Cast blockNumber failed, may be empty, set to default value -1"
-                        << LOG_KV("blockNumber str", entry->getField(0));
+                        << LOG_KV("blockNumber str", entry->get());
                 }
                 callback(nullptr, blockNumber);
             }
@@ -966,7 +966,7 @@ void Ledger::asyncGetTransactionReceiptByHash(bcos::crypto::HashType const& _txH
                 return;
             }
 
-            auto value = entry->getField(0);
+            auto value = entry->get();
             auto receipt = m_blockFactory->receiptFactory()->createReceipt(
                 bcos::bytesConstRef((bcos::byte*)value.data(), value.size()));
 
@@ -1039,7 +1039,7 @@ void Ledger::asyncGetTotalTransactionCount(
                     {
                         try
                         {
-                            value = boost::lexical_cast<int64_t>(entry->getField(0));
+                            value = boost::lexical_cast<int64_t>(entry->get());
                         }
                         catch (boost::bad_lexical_cast& e)
                         {
@@ -1198,7 +1198,7 @@ void Ledger::asyncGetNonceList(bcos::protocol::BlockNumber _startNumber, int64_t
                                 continue;
                             }
 
-                            auto value = entry->getField(0);
+                            auto value = entry->get();
                             auto block = m_blockFactory->createBlock(
                                 bcos::bytesConstRef((bcos::byte*)value.data(), value.size()), false,
                                 false);
@@ -1354,7 +1354,7 @@ void Ledger::asyncGetBlockHeader(bcos::protocol::Block::Ptr block,
                         return;
                     }
 
-                    auto field = entry->getField(0);
+                    auto field = entry->get();
                     auto headerPtr = m_blockFactory->blockHeaderFactory()->createBlockHeader(
                         bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
 
@@ -1386,7 +1386,7 @@ void Ledger::asyncGetBlockTransactionHashes(bcos::protocol::BlockNumber blockNum
                         return;
                     }
 
-                    auto txs = entry->getField(0);
+                    auto txs = entry->get();
                     auto blockWithTxs = m_blockFactory->createBlock(
                         bcos::bytesConstRef((bcos::byte*)txs.data(), txs.size()));
 
@@ -1437,7 +1437,7 @@ void Ledger::asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>>
                 }
                 else
                 {
-                    auto field = entry->getField(0);
+                    auto field = entry->get();
                     auto transaction = m_blockFactory->transactionFactory()->createTransaction(
                         bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false, false,
                         false);
@@ -1505,7 +1505,7 @@ void Ledger::asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>>
                     }
                     else
                     {
-                        auto field = entry->getField(0);
+                        auto field = entry->get();
                         auto transaction = m_blockFactory->transactionFactory()->createTransaction(
                             bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false,
                             false, false);
@@ -1565,7 +1565,7 @@ void Ledger::asyncBatchGetReceipts(std::shared_ptr<std::vector<std::string>> has
                     return;
                 }
 
-                auto field = entry->getField(0);
+                auto field = entry->get();
                 auto receipt = m_blockFactory->receiptFactory()->createReceipt(
                     bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
                 receipts.push_back(std::move(receipt));

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -1111,7 +1111,7 @@ void Ledger::asyncGetSystemConfigByKey(const std::string_view& _key,
 
                     LEDGER_LOG(TRACE) << "Entry value: " << toHex(entry->get());
 
-                    auto [value, number] = entry->getObject<SystemConfigEntry>();
+                    auto [value, number] = bcos::storage::serialize::decode<SystemConfigEntry>(entry->get());
 
                     // The param was reset at height getLatestBlockNumber(), and takes effect in
                     // next block. So we query the status of getLatestBlockNumber() + 1.
@@ -1955,7 +1955,7 @@ bool Ledger::buildGenesisBlock(
                     executor_v1::StateKeyView(SYS_CURRENT_STATE, SYS_KEY_CURRENT_NUMBER));
                 if (versionEntry && blockNumberEntry)
                 {
-                    auto [versionStr, _] = versionEntry->getObject<SystemConfigEntry>();
+                    auto [versionStr, _] = bcos::storage::serialize::decode<SystemConfigEntry>(versionEntry->get());
                     auto storageVersion = tool::toVersionNumber(versionStr);
 
                     // 设置sharding default，相关的bugfix也要设置上，否则会不一致
@@ -2098,21 +2098,21 @@ bool Ledger::buildGenesisBlock(
 
         // tx count limit
         Entry txLimitEntry;
-        txLimitEntry.setObject(
-            SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_txCountLimit), 0});
+        txLimitEntry.set(bcos::storage::serialize::encode(
+            SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_txCountLimit), 0}));
         sysTable->setRow(SYSTEM_KEY_TX_COUNT_LIMIT, std::move(txLimitEntry));
 
         // tx gas limit
         Entry gasLimitEntry;
-        gasLimitEntry.setObject(
-            SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_txGasLimit), 0});
+        gasLimitEntry.set(bcos::storage::serialize::encode(
+            SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_txGasLimit), 0}));
         sysTable->setRow(SYSTEM_KEY_TX_GAS_LIMIT, std::move(gasLimitEntry));
 
         // tx gas price
         if (versionCompareTo(versionNumber, BlockVersion::V3_6_VERSION) >= 0)
         {
             Entry gasPriceEntry;
-            gasPriceEntry.setObject(SystemConfigEntry("0x0", 0));
+            gasPriceEntry.set(bcos::storage::serialize::encode(SystemConfigEntry("0x0", 0)));
             sysTable->setRow(SYSTEM_KEY_TX_GAS_PRICE, std::move(gasPriceEntry));
         }
 
@@ -2123,17 +2123,17 @@ bool Ledger::buildGenesisBlock(
             features.set(ledger::Features::Flag::feature_rpbft);
 
             Entry epochSealerNumEntry;
-            epochSealerNumEntry.setObject(
-                SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_epochSealerNum), 0});
+            epochSealerNumEntry.set(bcos::storage::serialize::encode(
+                SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_epochSealerNum), 0}));
             sysTable->setRow(SYSTEM_KEY_RPBFT_EPOCH_SEALER_NUM, std::move(epochSealerNumEntry));
 
             Entry epochBlockNumEntry;
-            epochBlockNumEntry.setObject(
-                SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_epochBlockNum), 0});
+            epochBlockNumEntry.set(bcos::storage::serialize::encode(
+                SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_epochBlockNum), 0}));
             sysTable->setRow(SYSTEM_KEY_RPBFT_EPOCH_BLOCK_NUM, std::move(epochBlockNumEntry));
 
             Entry notifyRotateEntry;
-            notifyRotateEntry.setObject(SystemConfigEntry("0", 0));
+            notifyRotateEntry.set(bcos::storage::serialize::encode(SystemConfigEntry("0", 0)));
             sysTable->setRow(INTERNAL_SYSTEM_KEY_NOTIFY_ROTATE, std::move(notifyRotateEntry));
         }
 
@@ -2143,25 +2143,25 @@ bool Ledger::buildGenesisBlock(
 
         // consensus leader period
         Entry leaderPeriodEntry;
-        leaderPeriodEntry.setObject(
-            SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_leaderSwitchPeriod), 0});
+        leaderPeriodEntry.set(bcos::storage::serialize::encode(
+            SystemConfigEntry{boost::lexical_cast<std::string>(genesis.m_leaderSwitchPeriod), 0}));
         sysTable->setRow(SYSTEM_KEY_CONSENSUS_LEADER_PERIOD, std::move(leaderPeriodEntry));
 
         LEDGER_LOG(INFO) << LOG_DESC("init the compatibilityVersion")
                          << LOG_KV("versionNumber", versionNumber);
         // write compatibility version
         Entry compatibilityVersionEntry;
-        compatibilityVersionEntry.setObject(
+        compatibilityVersionEntry.set(bcos::storage::serialize::encode(
             SystemConfigEntry{tool::fromVersionNumber(static_cast<protocol::BlockVersion>(
                                   genesis.m_compatibilityVersion)),
-                0});
+                0}));
         sysTable->setRow(SYSTEM_KEY_COMPATIBILITY_VERSION, std::move(compatibilityVersionEntry));
 
         if (versionCompareTo(versionNumber, BlockVersion::V3_3_VERSION) >= 0)
         {
             // write auth check status
             Entry authCheckStatusEntry;
-            authCheckStatusEntry.setObject(SystemConfigEntry{genesis.m_isAuthCheck ? "1" : "0", 0});
+            authCheckStatusEntry.set(bcos::storage::serialize::encode(SystemConfigEntry{genesis.m_isAuthCheck ? "1" : "0", 0}));
             sysTable->setRow(SYSTEM_KEY_AUTH_CHECK_STATUS, std::move(authCheckStatusEntry));
         }
 
@@ -2169,7 +2169,7 @@ bool Ledger::buildGenesisBlock(
         {
             // write web3 chain id
             Entry chainIdEntry;
-            chainIdEntry.setObject(SystemConfigEntry{genesis.m_web3ChainID, 0});
+            chainIdEntry.set(bcos::storage::serialize::encode(SystemConfigEntry{genesis.m_web3ChainID, 0}));
             sysTable->setRow(SYSTEM_KEY_WEB3_CHAIN_ID, std::move(chainIdEntry));
         }
 
@@ -2177,8 +2177,8 @@ bool Ledger::buildGenesisBlock(
         if (versionNumber >= BlockVersion::V3_15_0_VERSION && genesis.m_executorVersion > 0)
         {
             Entry executorVersion;
-            executorVersion.setObject(
-                SystemConfigEntry{std::to_string(genesis.m_executorVersion), 0});
+            executorVersion.set(bcos::storage::serialize::encode(
+                SystemConfigEntry{std::to_string(genesis.m_executorVersion), 0}));
             co_await storage2::writeOne(*m_stateStorage,
                 executor_v1::StateKey(
                     SYS_CONFIG, magic_enum::enum_name(ledger::SystemConfig::executor_version)),
@@ -2187,7 +2187,7 @@ bool Ledger::buildGenesisBlock(
             // 按会议结论，executor v1默认打开balance_transfer
             // According to the meeting conclusion, executor v1 defaults to open balance_transfer
             Entry balanceTransfer;
-            balanceTransfer.setObject(SystemConfigEntry{"1", 0});
+            balanceTransfer.set(bcos::storage::serialize::encode(SystemConfigEntry{"1", 0}));
             co_await storage2::writeOne(*m_stateStorage,
                 executor_v1::StateKey(
                     SYS_CONFIG, magic_enum::enum_name(ledger::SystemConfig::balance_transfer)),
@@ -2456,7 +2456,7 @@ task::Task<bcos::ledger::SystemConfigs> Ledger::fetchAllSystemConfigs(
     {
         if (entry)
         {
-            auto [value, enableNumber] = entry->getObject<SystemConfigEntry>();
+            auto [value, enableNumber] = bcos::storage::serialize::decode<SystemConfigEntry>(entry->get());
             if (enableNumber <= _blockNumber)
             {
                 configs.set(key, value, enableNumber);
@@ -2487,7 +2487,7 @@ bcos::storage::StorageInterface::Ptr bcos::ledger::Ledger::getStateStorage()
         {
             BOOST_THROW_EXCEPTION(BCOS_ERROR(GetStorageError, "Not found compatibilityVersion."));
         }
-        auto [compatibilityVersionStr, _] = entry->template getObject<SystemConfigEntry>();
+        auto [compatibilityVersionStr, _] = bcos::storage::serialize::decode<SystemConfigEntry>(entry->get());
         auto const version = bcos::tool::toVersionNumber(compatibilityVersionStr);
         auto stateStorage = stateStorageFactory.createStateStorage(
             m_stateStorage, version, true, false, keyPageIgnoreTables);

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -201,7 +201,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
         if (auto entry = co_await storage2::readOne(
                 storage, executor_v1::StateKeyView{SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr}))
         {
-            auto field = entry->getField(0);
+            auto field = entry->get();
             auto headerPtr = blockFactory.blockHeaderFactory()->createBlockHeader(
                 bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
             block->setBlockHeader(std::move(headerPtr));
@@ -217,7 +217,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
         if (auto txsEntry = co_await storage2::readOne(
                 storage, executor_v1::StateKeyView{SYS_NUMBER_2_TXS, blockNumberStr}))
         {
-            auto txs = txsEntry->getField(0);
+            auto txs = txsEntry->get();
             auto blockWithTxs =
                 blockFactory.createBlock(bcos::bytesConstRef((bcos::byte*)txs.data(), txs.size()));
             auto hashes = blockWithTxs->transactionHashes() | ::ranges::to<std::vector>();
@@ -232,7 +232,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
                     }));
                 for (auto& txEntry : transactions)
                 {
-                    auto field = txEntry->getField(0);
+                    auto field = txEntry->get();
                     auto transaction = blockFactory.transactionFactory()->createTransaction(
                         bcos::bytesConstRef((bcos::byte*)field.data(), field.size()), false, false,
                         false);
@@ -249,7 +249,7 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
                     }));
                 for (auto& receiptEntry : receipts)
                 {
-                    auto field = receiptEntry->getField(0);
+                    auto field = receiptEntry->get();
                     auto receipt = blockFactory.receiptFactory()->createReceipt(
                         bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
                     block->appendReceipt(std::move(receipt));
@@ -329,7 +329,7 @@ task::Task<void> tag_invoke(ledger::tag_t<getLedgerConfig> /*unused*/, auto& sto
     if (auto entry = co_await storage2::readOne(
             storage, executor_v1::StateKeyView{SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr}))
     {
-        auto field = entry->getField(0);
+        auto field = entry->get();
         auto headerPtr = blockFactory.blockHeaderFactory()->createBlockHeader(
             bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));
         ledgerConfig.setTimestamp(headerPtr->timestamp());
@@ -418,7 +418,7 @@ task::Task<std::optional<crypto::HashType>> tag_invoke(ledger::tag_t<getBlockHas
     if (auto entry = co_await storage2::readOne(
             storage, executor_v1::StateKeyView{SYS_NUMBER_2_HASH, blockNumberString}))
     {
-        auto hashStr = entry->getField(0);
+        auto hashStr = entry->get();
         bcos::crypto::HashType hash(hashStr, bcos::crypto::HashType::FromBinary);
 
         co_return std::make_optional(hash);
@@ -435,7 +435,7 @@ task::Task<std::optional<protocol::BlockNumber>> tag_invoke(
     if (auto entry = co_await storage2::readOne(storage,
             executor_v1::StateKeyView{SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(hash)}))
     {
-        auto blockNumberStr = entry->getField(0);
+        auto blockNumberStr = entry->get();
         auto blockNumber = boost::lexical_cast<protocol::BlockNumber>(blockNumberStr);
 
         co_return std::make_optional(blockNumber);
@@ -453,13 +453,13 @@ task::Task<protocol::BlockNumber> tag_invoke(ledger::tag_t<getCurrentBlockNumber
         try
         {
             blockNumber =
-                boost::lexical_cast<bcos::protocol::BlockNumber>(blockNumberEntry->getField(0));
+                boost::lexical_cast<bcos::protocol::BlockNumber>(blockNumberEntry->get());
         }
         catch (boost::bad_lexical_cast& e)
         {
             // Ignore the exception
             LEDGER_LOG(INFO) << "Cast blockNumber failed, may be empty, set to default value -1"
-                             << LOG_KV("blockNumber str", blockNumberEntry->getField(0));
+                             << LOG_KV("blockNumber str", blockNumberEntry->get());
         }
         LEDGER_LOG(TRACE) << "GetBlockNumber success" << LOG_KV("blockNumber", blockNumber);
         co_return blockNumber;
@@ -478,7 +478,7 @@ task::Task<consensus::ConsensusNodeList> tag_invoke(ledger::tag_t<getNodeList> /
         co_return consensus::ConsensusNodeList{};
     }
 
-    auto ledgerConsensusNodeList = decodeConsensusList(nodeListEntry->getField(0));
+    auto ledgerConsensusNodeList = decodeConsensusList(nodeListEntry->get());
     consensus::ConsensusNodeList nodes =
         ledgerConsensusNodeList | ::ranges::views::transform([](auto const& node) {
             auto nodeIDBin = fromHex(node.nodeID);

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -564,7 +564,7 @@ task::Task<std::optional<SystemConfigEntry>> tag_invoke(ledger::tag_t<getSystemC
     if (auto entry =
             co_await storage2::readOne(storage, executor_v1::StateKeyView(SYS_CONFIG, key)))
     {
-        co_return entry->template getObject<SystemConfigEntry>();
+        co_return bcos::storage::serialize::decode<SystemConfigEntry>(entry->get());
     }
     co_return {};
 }

--- a/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(test_3_0_FixtureLedger)
     m_storage->asyncGetRow(
         tool::FS_ROOT, tool::FS_KEY_SUB, [&](Error::UniquePtr, std::optional<Entry> _entry) {
             std::map<std::string, std::string> bfsInfos;
-            auto&& out = asBytes(std::string(_entry->getField(0)));
+            auto&& out = asBytes(std::string(_entry->get()));
             codec::scale::decode(bfsInfos, gsl::make_span(out));
             for (const auto& item : v)
             {
@@ -708,7 +708,7 @@ BOOST_AUTO_TEST_CASE(getBlockNumberByHash)
             BOOST_CHECK(!error);
             BOOST_CHECK(hashEntry);
             auto hash = bcos::crypto::HashType(
-                std::string(hashEntry->getField(0)), bcos::crypto::HashType::FromBinary);
+                std::string(hashEntry->get()), bcos::crypto::HashType::FromBinary);
 
             Entry numberEntry;
             m_storage->asyncSetRow(SYS_HASH_2_NUMBER,

--- a/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
+++ b/bcos-ledger/test/unittests/ledger/LedgerTest.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "bcos-ledger/Ledger.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "../../mock/MockKeyFactor.h"
 #include "bcos-crypto/hasher/OpenSSLHasher.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
@@ -1341,12 +1342,12 @@ BOOST_AUTO_TEST_CASE(getSystemConfig)
     auto table = tablePromise.get_future().get();
 
     auto oldEntry = table.getRow(SYSTEM_KEY_TX_COUNT_LIMIT);
-    auto [txCountLimit, enableNum] = oldEntry->getObject<SystemConfigEntry>();
+    auto [txCountLimit, enableNum] = bcos::storage::serialize::decode<SystemConfigEntry>(oldEntry->get());
     BOOST_CHECK_EQUAL(txCountLimit, "1000");
     BOOST_CHECK_EQUAL(enableNum, 0);
 
     Entry newEntry = table.newEntry();
-    newEntry.setObject(SystemConfigEntry{"2000", 5});
+    newEntry.set(bcos::storage::serialize::encode(SystemConfigEntry{"2000", 5}));
 
     table.setRow(SYSTEM_KEY_TX_COUNT_LIMIT, newEntry);
 
@@ -1440,22 +1441,22 @@ BOOST_AUTO_TEST_CASE(getLedgerConfig)
         SystemConfigEntry config;
 
         config = {"12", 0};
-        value.setObject(config);
+        value.set(bcos::storage::serialize::encode(config));
         co_await storage2::writeOne(
             *m_storage, KeyType{SYS_CONFIG, SYSTEM_KEY_TX_COUNT_LIMIT}, value);
 
         config = {"100", 0};
-        value.setObject(config);
+        value.set(bcos::storage::serialize::encode(config));
         co_await storage2::writeOne(
             *m_storage, KeyType{SYS_CONFIG, SYSTEM_KEY_CONSENSUS_LEADER_PERIOD}, value);
 
         config = {"200", 0};
-        value.setObject(config);
+        value.set(bcos::storage::serialize::encode(config));
         co_await storage2::writeOne(
             *m_storage, KeyType{SYS_CONFIG, SYSTEM_KEY_TX_GAS_LIMIT}, value);
 
         config = {"3.8.1", 0};
-        value.setObject(config);
+        value.set(bcos::storage::serialize::encode(config));
         co_await storage2::writeOne(
             *m_storage, KeyType{SYS_CONFIG, SYSTEM_KEY_COMPATIBILITY_VERSION}, value);
 
@@ -1468,12 +1469,12 @@ BOOST_AUTO_TEST_CASE(getLedgerConfig)
         // co_await storage2::writeOne(*m_storage, KeyType{SYS_NUMBER_2_HASH, "10086"}, value);
 
         config = {"1", 0};
-        value.setObject(config);
+        value.set(bcos::storage::serialize::encode(config));
         co_await storage2::writeOne(
             *m_storage, KeyType{SYS_CONFIG, SYSTEM_KEY_RPBFT_SWITCH}, value);
 
         config = {"12345", 0};
-        value.setObject(config);
+        value.set(bcos::storage::serialize::encode(config));
         co_await storage2::writeOne(
             *m_storage, KeyType{SYS_CONFIG, SYSTEM_KEY_RPBFT_EPOCH_SEALER_NUM}, value);
 
@@ -1645,8 +1646,7 @@ BOOST_AUTO_TEST_CASE(genesisExecutorVersion)
                           magic_enum::enum_name(ledger::SystemConfig::executor_version)));
         BOOST_REQUIRE(value);
 
-        ledger::SystemConfigEntry entry;
-        value->getObject(entry);
+        auto entry = bcos::storage::serialize::decode<ledger::SystemConfigEntry>(value->get());
         using namespace std::string_view_literals;
         BOOST_CHECK_EQUAL(std::get<0>(entry), "10086"sv);
     }());

--- a/bcos-scheduler/test/testCommitBlock.cpp
+++ b/bcos-scheduler/test/testCommitBlock.cpp
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(commitBlock)
     auto table = prom.get_future().get();
     auto entry = table.getRow(SYS_KEY_CURRENT_NUMBER);
     BOOST_CHECK_EQUAL(entry.has_value(), true);
-    auto blockNumber = entry->getField("value");
+    auto blockNumber = entry->get();
     BOOST_CHECK_EQUAL(blockNumber, "100");
 }
 

--- a/bcos-storage/bcos-storage/StateKVResolver.h
+++ b/bcos-storage/bcos-storage/StateKVResolver.h
@@ -14,19 +14,21 @@ struct InvalidStateKey : public Error
 
 struct StateValueResolver
 {
-    static auto encode(const storage::Entry& entry) { return entry; }
-    static auto encode(storage::Entry&& entry) { return std::move(entry); }
+    static auto encode(const storage::Entry& entry) -> std::string
+    {
+        return entry.encodeToBytes();
+    }
+    static auto encode(storage::Entry&& entry) -> std::string
+    {
+        return entry.encodeToBytes();
+    }
     static storage::Entry decode(std::string_view view)
     {
-        storage::Entry entry;
-        entry.set(view);
-        return entry;
+        return storage::Entry::decodeFromBytes(view);
     }
     static storage::Entry decode(std::string buffer)
     {
-        storage::Entry entry;
-        entry.set(std::move(buffer));
-        return entry;
+        return storage::Entry::decodeFromBytes(buffer);
     }
 };
 

--- a/bcos-storage/test/unittest/TestRocksDBStorage.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage.cpp
@@ -163,7 +163,7 @@ struct TestRocksDBStorageFixture
                         BOOST_CHECK_EQUAL(entries.size(), tableEntries);
                         for (size_t i = 0; i < tableEntries; ++i)
                         {
-                            BOOST_CHECK_EQUAL(entries[i]->getField(0), "value_delete");
+                            BOOST_CHECK_EQUAL(entries[i]->get(), "value_delete");
                         }
                     });
             });
@@ -424,13 +424,13 @@ BOOST_AUTO_TEST_CASE(asyncPrepare)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
 
         auto entry2 = table2->newEntry();
         auto key2 = "key" + boost::lexical_cast<std::string>(i);
-        entry2.setField(0, "hello world!abc" + boost::lexical_cast<std::string>(i));
+        entry2.set("hello world!abc" + boost::lexical_cast<std::string>(i));
         table2->setRow(key2, entry2);
         table2Keys.push_back(key2);
     }
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(asyncPrepare)
 
                     for (size_t i = 0; i < 10; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table1Keys[i][3]);
                     }
                 });
@@ -489,7 +489,7 @@ BOOST_AUTO_TEST_CASE(asyncPrepare)
 
                     for (size_t i = 0; i < 10; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!abc") + table2Keys[i][3]);
                     }
                 });
@@ -647,7 +647,7 @@ BOOST_AUTO_TEST_CASE(commitAndCheck)
             state->asyncGetRow(
                 "test_table1", key, [&num](Error::UniquePtr error, std::optional<Entry> entry) {
                     BOOST_CHECK(!error);
-                    num = boost::lexical_cast<size_t>(entry->getField(0));
+                    num = boost::lexical_cast<size_t>(entry->get());
                 });
 
             BOOST_CHECK_EQUAL(num, i);
@@ -671,7 +671,7 @@ BOOST_AUTO_TEST_CASE(commitAndCheck)
                 auto [it, inserted] = keySet->emplace(key);
                 boost::ignore_unused(it);
                 BOOST_CHECK(inserted);
-                auto num = boost::lexical_cast<size_t>(entry.getField(0));
+                auto num = boost::lexical_cast<size_t>(entry.get());
                 BOOST_CHECK_EQUAL(i + 100, num);
             });
             return true;

--- a/bcos-storage/test/unittest/TestTiKVStorage.cpp
+++ b/bcos-storage/test/unittest/TestTiKVStorage.cpp
@@ -139,9 +139,9 @@ struct TestTiKVStorageFixture
                         BOOST_CHECK_EQUAL(entries.size(), tableEntries);
                         for (size_t i = 0; i < tableEntries; ++i)
                         {
-                            // BOOST_CHECK_EQUAL(entries[i]->getField(0), std::string("value3"));
+                            // BOOST_CHECK_EQUAL(entries[i]->get(), std::string("value3"));
                             BOOST_CHECK_EQUAL(
-                                entries[i]->getField(0), std::string("value_") + keys[i].substr(3));
+                                entries[i]->get(), std::string("value_") + keys[i].substr(3));
                         }
                     });
             });
@@ -404,13 +404,13 @@ BOOST_AUTO_TEST_CASE(asyncPrepare)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
 
         auto entry2 = table2->newEntry();
         auto key2 = "key" + boost::lexical_cast<std::string>(i);
-        entry2.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry2.set("hello world!" + boost::lexical_cast<std::string>(i));
         table2->setRow(key2, entry2);
         table2Keys.push_back(key2);
     }
@@ -440,7 +440,7 @@ BOOST_AUTO_TEST_CASE(asyncPrepare)
 
                     for (size_t i = 0; i < 10; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table1Keys[i][3]);
                     }
                 });
@@ -463,7 +463,7 @@ BOOST_AUTO_TEST_CASE(asyncPrepare)
 
                     for (size_t i = 0; i < 10; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table2Keys[i][3]);
                     }
                 });
@@ -508,13 +508,13 @@ BOOST_AUTO_TEST_CASE(asyncPrepareTimeout)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
 
         auto entry2 = table2->newEntry();
         auto key2 = "key" + boost::lexical_cast<std::string>(i);
-        entry2.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry2.set("hello world!" + boost::lexical_cast<std::string>(i));
         table2->setRow(key2, entry2);
         table2Keys.push_back(key2);
     }
@@ -575,13 +575,13 @@ BOOST_AUTO_TEST_CASE(multiStorageCommit)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
 
         auto entry2 = table2->newEntry();
         auto key2 = "key" + boost::lexical_cast<std::string>(i);
-        entry2.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry2.set("hello world!" + boost::lexical_cast<std::string>(i));
         table2->setRow(key2, entry2);
         table2Keys.push_back(key2);
     }
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(multiStorageCommit)
 
                     for (size_t i = 0; i < tableEntries; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table1Keys[i].substr(3));
                     }
                 });
@@ -660,7 +660,7 @@ BOOST_AUTO_TEST_CASE(multiStorageCommit)
 
                     for (size_t i = 0; i < tableEntries; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table2Keys[i].substr(3));
                     }
                 });
@@ -723,7 +723,7 @@ BOOST_AUTO_TEST_CASE(singleStorageRollback)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
     }
     auto params1 = bcos::protocol::TwoPCParams();
@@ -783,13 +783,13 @@ BOOST_AUTO_TEST_CASE(multiStorageRollback)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
 
         auto entry2 = table2->newEntry();
         auto key2 = "key" + boost::lexical_cast<std::string>(i);
-        entry2.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry2.set("hello world!" + boost::lexical_cast<std::string>(i));
         table2->setRow(key2, entry2);
         table2Keys.push_back(key2);
     }
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE(secondaryRollbackAndPrimaryCommit)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
     }
@@ -949,13 +949,13 @@ BOOST_AUTO_TEST_CASE(multiStorageScondaryCrash)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
 
         auto entry2 = table2->newEntry();
         auto key2 = "key" + boost::lexical_cast<std::string>(i);
-        entry2.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry2.set("hello world!" + boost::lexical_cast<std::string>(i));
         table2->setRow(key2, entry2);
         table2Keys.push_back(key2);
     }
@@ -1050,7 +1050,7 @@ BOOST_AUTO_TEST_CASE(multiStorageScondaryCrash)
 
                     for (size_t i = 0; i < tableEntries; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table1Keys[i].substr(3));
                     }
                 });
@@ -1073,7 +1073,7 @@ BOOST_AUTO_TEST_CASE(multiStorageScondaryCrash)
 
                     for (size_t i = 0; i < tableEntries; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table2Keys[i].substr(3));
                     }
                 });
@@ -1091,7 +1091,7 @@ BOOST_AUTO_TEST_CASE(multiStorageScondaryCrash)
                     for (size_t i = 0; i < total; ++i)
                     {
                         auto value = "value_" + keys[i].substr(3);
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0), value);
+                        BOOST_CHECK_EQUAL(entries[i]->get(), value);
                     }
                 });
         });
@@ -1174,13 +1174,13 @@ BOOST_AUTO_TEST_CASE(multiStoragePrimaryCrash)
     {
         auto entry = table1->newEntry();
         auto key1 = "key" + boost::lexical_cast<std::string>(i);
-        entry.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry.set("hello world!" + boost::lexical_cast<std::string>(i));
         table1->setRow(key1, entry);
         table1Keys.push_back(key1);
 
         auto entry2 = table2->newEntry();
         auto key2 = "key" + boost::lexical_cast<std::string>(i);
-        entry2.setField(0, "hello world!" + boost::lexical_cast<std::string>(i));
+        entry2.set("hello world!" + boost::lexical_cast<std::string>(i));
         table2->setRow(key2, entry2);
         table2Keys.push_back(key2);
     }
@@ -1262,7 +1262,7 @@ BOOST_AUTO_TEST_CASE(multiStoragePrimaryCrash)
 
                     for (size_t i = 0; i < tableEntries; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table1Keys[i].substr(3));
                     }
                 });
@@ -1285,7 +1285,7 @@ BOOST_AUTO_TEST_CASE(multiStoragePrimaryCrash)
 
                     for (size_t i = 0; i < tableEntries; ++i)
                     {
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0),
+                        BOOST_CHECK_EQUAL(entries[i]->get(),
                             std::string("hello world!") + table2Keys[i].substr(3));
                     }
                 });
@@ -1302,7 +1302,7 @@ BOOST_AUTO_TEST_CASE(multiStoragePrimaryCrash)
                     for (size_t i = 0; i < total; ++i)
                     {
                         auto value = "value_" + keys[i].substr(3);
-                        BOOST_CHECK_EQUAL(entries[i]->getField(0), value);
+                        BOOST_CHECK_EQUAL(entries[i]->get(), value);
                     }
                 });
         });
@@ -1353,7 +1353,7 @@ BOOST_AUTO_TEST_CASE(multiStoragePrimaryCrash)
                     // for (size_t i = 0; i < tableEntries; ++i)
                     // {
                     //     BOOST_CHECK_EQUAL(keys[i], "");
-                    //     BOOST_CHECK_EQUAL(entries[i]->getField(0), "");
+                    //     BOOST_CHECK_EQUAL(entries[i]->get(), "");
                     // }
                 });
         });

--- a/bcos-table/src/ContractShardUtils.cpp
+++ b/bcos-table/src/ContractShardUtils.cpp
@@ -25,7 +25,7 @@ using namespace bcos::storage;
 
 bool ContractShardUtils::isInherent(std::optional<bcos::storage::Entry> entry)
 {
-    return entry && entry->getField(0).starts_with(INHERENT_PREFIX);
+    return entry && entry->get().starts_with(INHERENT_PREFIX);
 }
 
 void ContractShardUtils::setContractShard(bcos::storage::StorageWrapper& storage,
@@ -96,7 +96,7 @@ std::string ContractShardUtils::getContractShard(
     {
         if (entry)
         {
-            tableName = entry->getField(0);
+            tableName = entry->get();
             tableName.remove_prefix(INHERENT_PREFIX.length());
         }
         entry = getShard(storage, tableName);
@@ -105,7 +105,7 @@ std::string ContractShardUtils::getContractShard(
 
     if (entry)
     {
-        auto shardName = entry->getField(0);
+        auto shardName = entry->get();
         shardName.remove_prefix(SHARD_ROOT_PREFIX.length());
         return std::string(shardName);
     }

--- a/bcos-table/src/KeyPageStorage.cpp
+++ b/bcos-table/src/KeyPageStorage.cpp
@@ -285,7 +285,7 @@ void KeyPageStorage::parallelTraverse(bool onlyDirty,
                         {
                             auto* meta = it.second->getTableMeta();
                             Entry entry;
-                            entry.setObject(*meta);
+                            entry.set(bcos::storage::serialize::encode(*meta));
                             m_size += entry.size();
                             if (!m_readOnly)
                             {
@@ -329,7 +329,7 @@ void KeyPageStorage::parallelTraverse(bool onlyDirty,
                             }
                             else
                             {
-                                entry.setObject(*page);
+                                entry.set(bcos::storage::serialize::encode(*page));
                                 m_size += entry.size();
                                 entry.setStatus(it.second->entry.status());
                                 if (!m_readOnly)
@@ -735,7 +735,7 @@ auto KeyPageStorage::getEntryFromPage(std::string_view table, std::string_view k
             if (data.value()->entry.dirty())
             {
                 Entry entry;
-                entry.setObject(*meta);
+                entry.set(bcos::storage::serialize::encode(*meta));
                 entry.setStatus(data.value()->entry.status());
                 return std::make_pair(nullptr, std::move(entry));
             }
@@ -808,7 +808,7 @@ auto KeyPageStorage::getEntryFromPage(std::string_view table, std::string_view k
                         << LOG_KV("dirty", data.value()->entry.dirty());
                 }
                 Entry entry;
-                entry.setObject(*page);
+                entry.set(bcos::storage::serialize::encode(*page));
                 entry.setStatus(pageData->entry.status());
                 return std::make_pair(nullptr, std::move(entry));
             }

--- a/bcos-table/src/KeyPageStorage.h
+++ b/bcos-table/src/KeyPageStorage.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "StateStorageInterface.h"
+#include <bcos-framework/storage/Serialize.h>
 #include <fmt/format.h>
 #include <boost/archive/basic_archive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
@@ -245,7 +246,7 @@ public:
             }
             boost::iostreams::stream<boost::iostreams::array_source> inputStream(
                 value.data(), value.size());
-            boost::archive::binary_iarchive archive(inputStream, ARCHIVE_FLAG);
+            boost::archive::binary_iarchive archive(inputStream, bcos::storage::serialize::ARCHIVE_FLAG);
             archive >> *this;
         }
         TableMeta(const TableMeta& meta)
@@ -554,7 +555,7 @@ public:
             }
             boost::iostreams::stream<boost::iostreams::array_source> inputStream(
                 value.data(), value.size());
-            boost::archive::binary_iarchive archive(inputStream, ARCHIVE_FLAG);
+            boost::archive::binary_iarchive archive(inputStream, bcos::storage::serialize::ARCHIVE_FLAG);
             archive >> *this;
             if (pageKey != entries.rbegin()->first)
             {

--- a/bcos-table/src/LegacyStorageWrapper.h
+++ b/bcos-table/src/LegacyStorageWrapper.h
@@ -163,7 +163,7 @@ public:
                             ::ranges::views::transform([&](auto tuple) {
                                 auto& [key, value] = tuple;
                                 storage::Entry entry;
-                                entry.setField(0, value);
+                                entry.set(value);
                                 return std::make_pair(
                                     executor_v1::StateKey{tableName, key}, std::move(entry));
                             }));

--- a/bcos-table/src/StorageInterface.cpp
+++ b/bcos-table/src/StorageInterface.cpp
@@ -58,7 +58,7 @@ void StorageInterface::asyncCreateTable(std::string _tableName, std::string _val
                     }
 
                     auto tableEntry = sysTable->newEntry();
-                    tableEntry.setField(0, std::string(valueFields));
+                    tableEntry.set(std::string(valueFields));
 
                     sysTable->asyncSetRow(tableName, tableEntry,
                         [this, callback, tableName, valueFields = std::move(valueFields)](
@@ -150,7 +150,7 @@ void StorageInterface::asyncGetTableInfo(
                         }
 
                         std::vector<std::string> fields;
-                        boost::split(fields, entry->getField(0), boost::is_any_of(","));
+                        boost::split(fields, entry->get(), boost::is_any_of(","));
 
                         auto tableInfo = std::make_shared<storage::TableInfo>(
                             std::move(tableName), std::move(fields));

--- a/bcos-table/test/unittests/libtable/Entry.cpp
+++ b/bcos-table/test/unittests/libtable/Entry.cpp
@@ -615,23 +615,23 @@ struct TestValueA
         nameLen = static_cast<int32_t>(std::min(n.size(), nameBuf.size()));
         std::memcpy(nameBuf.data(), n.data(), nameLen);
     }
-    TestValueA(const uint8_t* data, size_t size)
+    TestValueA(bytesConstRef data)
     {
-        if (size < 8)
+        if (data.size() < 8)
             return;
-        std::memcpy(&id, data, 4);
-        std::memcpy(&nameLen, data + 4, 4);
+        std::memcpy(&id, data.data(), 4);
+        std::memcpy(&nameLen, data.data() + 4, 4);
         auto actualLen = std::min(static_cast<size_t>(nameLen), nameBuf.size());
-        if (size >= 8 + actualLen)
-            std::memcpy(nameBuf.data(), data + 8, actualLen);
+        if (data.size() >= 8 + actualLen)
+            std::memcpy(nameBuf.data(), data.data() + 8, actualLen);
     }
-    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    void encode(auto&& sink) const
     {
         uint8_t buf[32];
         std::memcpy(buf, &id, 4);
         std::memcpy(buf + 4, &nameLen, 4);
         std::memcpy(buf + 8, nameBuf.data(), nameLen);
-        sink(buf, 8 + static_cast<size_t>(nameLen));
+        sink(bytesConstRef(buf, 8 + static_cast<size_t>(nameLen)));
     }
     std::string nameStr() const { return std::string(nameBuf.data(), nameLen); }
     bool operator==(const TestValueA& o) const
@@ -648,14 +648,14 @@ struct TestValueB
 
     TestValueB() = default;
     explicit TestValueB(int64_t v) : value(v) {}
-    TestValueB(const uint8_t* data, size_t size)
+    TestValueB(bytesConstRef data)
     {
-        if (size >= 8)
-            std::memcpy(&value, data, 8);
+        if (data.size() >= 8)
+            std::memcpy(&value, data.data(), 8);
     }
-    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    void encode(auto&& sink) const
     {
-        sink(reinterpret_cast<const uint8_t*>(&value), 8);
+        sink(bytesConstRef(reinterpret_cast<const bcos::byte*>(&value), 8));
     }
     bool operator==(const TestValueB& o) const { return value == o.value; }
 };
@@ -663,26 +663,26 @@ static_assert(sizeof(TestValueB) <= 32);
 
 // ─── tag_invoke overloads for Encodable test types ────────────────
 
-void tag_invoke(
-    bcos::storage::encode_t, const TestValueA& v, std::function<void(const uint8_t*, size_t)> sink)
+template <typename Sink>
+void tag_invoke(bcos::storage::encode_t, const TestValueA& v, Sink&& sink)
 {
-    v.encode(std::move(sink));
+    v.encode(std::forward<Sink>(sink));
 }
 TestValueA tag_invoke(
-    bcos::storage::decode_t, std::type_identity<TestValueA>, const uint8_t* data, size_t size)
+    bcos::storage::decode_t, std::type_identity<TestValueA>, bytesConstRef data)
 {
-    return TestValueA{data, size};
+    return TestValueA{data};
 }
 
-void tag_invoke(
-    bcos::storage::encode_t, const TestValueB& v, std::function<void(const uint8_t*, size_t)> sink)
+template <typename Sink>
+void tag_invoke(bcos::storage::encode_t, const TestValueB& v, Sink&& sink)
 {
-    v.encode(std::move(sink));
+    v.encode(std::forward<Sink>(sink));
 }
 TestValueB tag_invoke(
-    bcos::storage::decode_t, std::type_identity<TestValueB>, const uint8_t* data, size_t size)
+    bcos::storage::decode_t, std::type_identity<TestValueB>, bytesConstRef data)
 {
-    return TestValueB{data, size};
+    return TestValueB{data};
 }
 
 // ─── Typed Entry tests ─────────────────────────────────────────────
@@ -729,8 +729,8 @@ BOOST_AUTO_TEST_CASE(lazyDecodeFromByteMode)
     Entry entry;
     TestValueA original{99, "lazy"};
     std::string encoded;
-    encode(original, [&encoded](const uint8_t* d, size_t s) {
-        encoded.append(reinterpret_cast<const char*>(d), s);
+    encode(original, [&encoded](bytesConstRef d) {
+        encoded.append(reinterpret_cast<const char*>(d.data()), d.size());
     });
     entry.set(encoded);
 
@@ -763,8 +763,8 @@ BOOST_AUTO_TEST_CASE(encodeToBytesAfterSetTyped)
     auto bytes = entry.encodeToBytes();
     TestValueA expected{55, "world"};
     std::string expectedBytes;
-    encode(expected, [&expectedBytes](const uint8_t* d, size_t s) {
-        expectedBytes.append(reinterpret_cast<const char*>(d), s);
+    encode(expected, [&expectedBytes](bytesConstRef d) {
+        expectedBytes.append(reinterpret_cast<const char*>(d.data()), d.size());
     });
     BOOST_CHECK_EQUAL(bytes, expectedBytes);
 }

--- a/bcos-table/test/unittests/libtable/Entry.cpp
+++ b/bcos-table/test/unittests/libtable/Entry.cpp
@@ -600,6 +600,171 @@ BOOST_AUTO_TEST_CASE(viewDeepCopy_constructFromView)
     BOOST_TEST(entryTestHolder(entry).has_value());
 }
 
+// ─── Encodable test types for typed Entry tests ────────────────────
+// Must be ≤ 32 bytes to satisfy proxy's restrict_layout<SBO=32, align=8>.
+
+struct TestValueA
+{
+    int32_t id = 0;
+    int32_t nameLen = 0;
+    std::array<char, 24> nameBuf{};
+
+    TestValueA() = default;
+    TestValueA(int32_t i, std::string_view n) : id(i)
+    {
+        nameLen = static_cast<int32_t>(std::min(n.size(), nameBuf.size()));
+        std::memcpy(nameBuf.data(), n.data(), nameLen);
+    }
+    TestValueA(const uint8_t* data, size_t size)
+    {
+        if (size < 8) return;
+        std::memcpy(&id, data, 4);
+        std::memcpy(&nameLen, data + 4, 4);
+        auto actualLen = std::min(static_cast<size_t>(nameLen), nameBuf.size());
+        if (size >= 8 + actualLen)
+            std::memcpy(nameBuf.data(), data + 8, actualLen);
+    }
+    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        uint8_t buf[32];
+        std::memcpy(buf, &id, 4);
+        std::memcpy(buf + 4, &nameLen, 4);
+        std::memcpy(buf + 8, nameBuf.data(), nameLen);
+        sink(buf, 8 + static_cast<size_t>(nameLen));
+    }
+    std::string nameStr() const { return std::string(nameBuf.data(), nameLen); }
+    bool operator==(const TestValueA& o) const
+    {
+        return id == o.id && nameLen == o.nameLen &&
+               std::memcmp(nameBuf.data(), o.nameBuf.data(), nameLen) == 0;
+    }
+};
+static_assert(sizeof(TestValueA) <= 32);
+
+struct TestValueB
+{
+    int64_t value = 0;
+
+    TestValueB() = default;
+    explicit TestValueB(int64_t v) : value(v) {}
+    TestValueB(const uint8_t* data, size_t size)
+    {
+        if (size >= 8) std::memcpy(&value, data, 8);
+    }
+    void encode(std::function<void(const uint8_t*, size_t)> sink) const
+    {
+        sink(reinterpret_cast<const uint8_t*>(&value), 8);
+    }
+    bool operator==(const TestValueB& o) const { return value == o.value; }
+};
+static_assert(sizeof(TestValueB) <= 32);
+
+// ─── Typed Entry tests ─────────────────────────────────────────────
+
+BOOST_AUTO_TEST_CASE(setTypedGetTypedSameType)
+{
+    Entry entry;
+    TestValueA original{42, "hello"};
+    entry.setTyped(original);
+
+    // getTyped should return a valid pointer with matching data
+    auto* ptr = entry.getTyped<TestValueA>();
+    BOOST_REQUIRE(ptr != nullptr);
+    BOOST_CHECK_EQUAL(ptr->id, 42);
+    BOOST_CHECK_EQUAL(ptr->nameStr(), "hello");
+
+    // holdsType should be correct
+    BOOST_TEST(entry.holdsType<TestValueA>());
+    BOOST_TEST(!entry.holdsType<TestValueB>());
+}
+
+BOOST_AUTO_TEST_CASE(setTypedGetTypedDifferentType)
+{
+    Entry entry;
+    entry.setTyped(TestValueA{7, "test"});
+
+    // getTyped<TestValueB> on an Entry holding TestValueA should fail
+    auto* ptr = entry.getTyped<TestValueB>();
+    BOOST_TEST(ptr == nullptr);
+
+    // But getTyped<TestValueA> still works
+    auto* ptrA = entry.getTyped<TestValueA>();
+    BOOST_REQUIRE(ptrA != nullptr);
+    BOOST_CHECK_EQUAL(ptrA->id, 7);
+
+    // holdsType should distinguish
+    BOOST_TEST(entry.holdsType<TestValueA>());
+    BOOST_TEST(!entry.holdsType<TestValueB>());
+}
+
+BOOST_AUTO_TEST_CASE(lazyDecodeFromByteMode)
+{
+    // Start with a byte-mode Entry (simulating data from RocksDB)
+    Entry entry;
+    TestValueA original{99, "lazy"};
+    std::string encoded;
+    original.encode([&encoded](const uint8_t* d, size_t s) {
+        encoded.append(reinterpret_cast<const char*>(d), s);
+    });
+    entry.set(encoded);
+
+    // Entry is in byte-mode; holdsType should be false for any type
+    BOOST_TEST(!entry.holdsType<TestValueA>());
+    BOOST_TEST(!entry.holdsType<TestValueB>());
+
+    // First getTyped triggers lazy decode
+    auto* ptr = entry.getTyped<TestValueA>();
+    BOOST_REQUIRE(ptr != nullptr);
+    BOOST_CHECK_EQUAL(ptr->id, 99);
+    BOOST_CHECK_EQUAL(ptr->nameStr(), "lazy");
+
+    // After lazy decode, entry holds the typed model
+    BOOST_TEST(entry.holdsType<TestValueA>());
+    BOOST_TEST(!entry.holdsType<TestValueB>());
+
+    // Second getTyped is O(1) — no re-decode
+    auto* ptr2 = entry.getTyped<TestValueA>();
+    BOOST_REQUIRE(ptr2 != nullptr);
+    BOOST_CHECK(ptr == ptr2);  // Same pointer, same TypedHolderModel instance
+}
+
+BOOST_AUTO_TEST_CASE(encodeToBytesAfterSetTyped)
+{
+    Entry entry;
+    entry.setTyped(TestValueA{55, "world"});
+
+    // Encode to bytes — should match what TestValueA::encode produces
+    auto bytes = entry.encodeToBytes();
+    TestValueA expected{55, "world"};
+    std::string expectedBytes;
+    expected.encode([&expectedBytes](const uint8_t* d, size_t s) {
+        expectedBytes.append(reinterpret_cast<const char*>(d), s);
+    });
+    BOOST_CHECK_EQUAL(bytes, expectedBytes);
+}
+
+BOOST_AUTO_TEST_CASE(setTypedMoveSemantics)
+{
+    Entry entry;
+    TestValueA original{1, "move-test-name"};
+    auto originalName = original.nameStr();
+
+    entry.setTyped(std::move(original));
+
+    auto* ptr = entry.getTyped<TestValueA>();
+    BOOST_REQUIRE(ptr != nullptr);
+    BOOST_CHECK_EQUAL(ptr->id, 1);
+    BOOST_CHECK_EQUAL(ptr->nameStr(), originalName);
+}
+
+BOOST_AUTO_TEST_CASE(emptyEntryGetTyped)
+{
+    Entry entry;
+    auto* ptr = entry.getTyped<TestValueA>();
+    BOOST_TEST(ptr == nullptr);
+    BOOST_TEST(!entry.holdsType<TestValueA>());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace test
 }  // namespace bcos

--- a/bcos-table/test/unittests/libtable/Entry.cpp
+++ b/bcos-table/test/unittests/libtable/Entry.cpp
@@ -20,10 +20,10 @@
 // Allow unit tests to inspect private members for buffer-model verification
 
 #include "bcos-framework/protocol/Protocol.h"
-#include <bcos-framework/storage/Serialize.h>
 #include "bcos-framework/storage/Table.h"
 #include "bcos-table/src/StateStorage.h"
 #include <bcos-crypto/hash/SM3.h>
+#include <bcos-framework/storage/Serialize.h>
 #include <bcos-utilities/Error.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/archive/binary_iarchive.hpp>
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(copyFrom)
     auto entry1 = std::make_shared<Entry>();
     auto entry2 = std::make_shared<Entry>();
     BOOST_CHECK_EQUAL(entry1->dirty(), false);
-    entry1->setField(0, "value");
+    entry1->set("value");
     BOOST_TEST(entry1->dirty() == true);
     BOOST_TEST(entry1->size() == 5);
 
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(copyFrom)
     {
         auto entry3 = Entry(*entry1);
 
-        entry3.setField(0, "i am key2");
+        entry3.set("i am key2");
 
         auto entry4(std::move(entry3));
 
@@ -88,27 +88,27 @@ BOOST_AUTO_TEST_CASE(copyFrom)
         auto entry6(std::move(entry5));
     }
 
-    BOOST_CHECK_EQUAL(entry2->getField(0), "value"sv);
+    BOOST_CHECK_EQUAL(entry2->get(), "value"sv);
 
-    entry2->setField(0, "value2");
+    entry2->set("value2");
 
-    BOOST_CHECK_EQUAL(entry2->getField(0), "value2");
-    BOOST_CHECK_EQUAL(entry1->getField(0), "value");
+    BOOST_CHECK_EQUAL(entry2->get(), "value2");
+    BOOST_CHECK_EQUAL(entry1->get(), "value");
 
-    entry2->setField(0, "value3");
+    entry2->set("value3");
     BOOST_TEST(entry2->size() == 6);
-    BOOST_TEST(entry2->getField(0) == "value3");
+    BOOST_TEST(entry2->get() == "value3");
     *entry2 = *entry2;
     BOOST_TEST(entry2->dirty() == true);
     // entry2->setDirty(false);
     entry2->setStatus(Entry::Status::NORMAL);
     BOOST_TEST(entry2->dirty() == false);
     // test setField lValue and rValue
-    entry2->setField(0, string("value2"));
+    entry2->set(string("value2"));
     BOOST_TEST(entry2->dirty() == true);
     BOOST_TEST(entry2->size() == 6);
     auto value2 = "value2";
-    entry2->setField(0, value2);
+    entry2->set(value2);
 }
 
 BOOST_AUTO_TEST_CASE(functions)
@@ -131,12 +131,12 @@ BOOST_AUTO_TEST_CASE(BytesField)
 
     entry.importFields({std::string(value)});
 
-    BOOST_CHECK_EQUAL(entry.getField(0), value);
+    BOOST_CHECK_EQUAL(entry.get(), value);
 
     Entry entry2;
     entry2.importFields({data});
 
-    BOOST_CHECK_EQUAL(entry2.getField(0), value);
+    BOOST_CHECK_EQUAL(entry2.get(), value);
 }
 
 BOOST_AUTO_TEST_CASE(capacity)
@@ -145,8 +145,7 @@ BOOST_AUTO_TEST_CASE(capacity)
 
     entry.importFields({std::string("abc")});
 
-    entry.setField(
-        0, std::string("abdflsakdjflkasjdfoiqwueroi!!!!sdlkfjsldfbclsadflaksjdfpqweioruaaa"));
+    entry.set(std::string("abdflsakdjflkasjdfoiqwueroi!!!!sdlkfjsldfbclsadflaksjdfpqweioruaaa"));
 
     BOOST_CHECK_LT(entry.size(), 100);
     BOOST_CHECK_GT(entry.size(), 0);
@@ -159,7 +158,8 @@ BOOST_AUTO_TEST_CASE(object)
     Entry entry;
     entry.set(bcos::storage::serialize::encode(value));
 
-    auto out = bcos::storage::serialize::decode<std::tuple<int, std::string, std::string>>(entry.get());
+    auto out =
+        bcos::storage::serialize::decode<std::tuple<int, std::string, std::string>>(entry.get());
 
     BOOST_CHECK(out == value);
 }
@@ -167,9 +167,9 @@ BOOST_AUTO_TEST_CASE(object)
 BOOST_AUTO_TEST_CASE(largeObject)
 {
     Entry entry;
-    entry.setField(0, std::string(1024, 'a'));
+    entry.set(std::string(1024, 'a'));
 
-    BOOST_CHECK_EQUAL(entry.getField(0), std::string(1024, 'a'));
+    BOOST_CHECK_EQUAL(entry.get(), std::string(1024, 'a'));
 }
 
 BOOST_AUTO_TEST_CASE(stringView)
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(entryHash)
 
     Entry entry;
     entry.setStatus(Entry::MODIFIED);
-    entry.setField(0, data);
+    entry.set(data);
 
     auto sm3 = std::make_shared<bcos::crypto::SM3>();
     auto oldHash = entry.hash(table, key, *sm3, 0);
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(entryHash)
     BOOST_CHECK_EQUAL(deletedHash, deletedExpect);
 
     entry.setStatus(Entry::MODIFIED);
-    entry.setField(0, data);
+    entry.set(data);
     auto modifyHash =
         entry.hash(table, key, *sm3, (uint32_t)bcos::protocol::BlockVersion::V3_1_VERSION);
     hasher = sm3->hasher();
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(smallBuffer_stdString)
     entry.set(value);
     BOOST_CHECK_EQUAL(entry.get(), value);
     BOOST_CHECK_EQUAL(entry.size(), 5);
-    BOOST_CHECK_EQUAL(entry.getField(0), value);
+    BOOST_CHECK_EQUAL(entry.get(), value);
     BOOST_CHECK_EQUAL(entry.status(), Entry::MODIFIED);
     // Verify holder has a value and data is inline (modifying source doesn't affect entry)
     BOOST_TEST(entryTestHolder(entry).has_value());
@@ -522,15 +522,16 @@ BOOST_AUTO_TEST_CASE(viewDeepCopy_stringView)
     original.clear();
     original.shrink_to_fit();
 
-    BOOST_CHECK_EQUAL(entry.get(), "string_view deep copy - entry owns its data after source destroyed");
+    BOOST_CHECK_EQUAL(
+        entry.get(), "string_view deep copy - entry owns its data after source destroyed");
     BOOST_CHECK_EQUAL(entry.size(), 66);
     BOOST_TEST(entryTestHolder(entry).has_value());
 }
 
 BOOST_AUTO_TEST_CASE(viewDeepCopy_spanConstChar)
 {
-    std::vector<char> original = {'s', 'p', 'a', 'n', '_', 'd', 'e', 'e', 'p', '_',
-                                  'c', 'o', 'p', 'y', '_', 't', 'e', 's', 't'};
+    std::vector<char> original = {'s', 'p', 'a', 'n', '_', 'd', 'e', 'e', 'p', '_', 'c', 'o', 'p',
+        'y', '_', 't', 'e', 's', 't'};
     std::span<const char> sp(original.data(), original.size());
 
     Entry entry;
@@ -568,8 +569,7 @@ BOOST_AUTO_TEST_CASE(viewDeepCopy_spanChar)
 BOOST_AUTO_TEST_CASE(viewDeepCopy_bytesConstRef)
 {
     std::string original = "bytesConstRef deep copy test";
-    auto ref =
-        bytesConstRef(reinterpret_cast<const bcos::byte*>(original.data()), original.size());
+    auto ref = bytesConstRef(reinterpret_cast<const bcos::byte*>(original.data()), original.size());
 
     Entry entry;
     entry.set(ref);
@@ -617,7 +617,8 @@ struct TestValueA
     }
     TestValueA(const uint8_t* data, size_t size)
     {
-        if (size < 8) return;
+        if (size < 8)
+            return;
         std::memcpy(&id, data, 4);
         std::memcpy(&nameLen, data + 4, 4);
         auto actualLen = std::min(static_cast<size_t>(nameLen), nameBuf.size());
@@ -649,7 +650,8 @@ struct TestValueB
     explicit TestValueB(int64_t v) : value(v) {}
     TestValueB(const uint8_t* data, size_t size)
     {
-        if (size >= 8) std::memcpy(&value, data, 8);
+        if (size >= 8)
+            std::memcpy(&value, data, 8);
     }
     void encode(std::function<void(const uint8_t*, size_t)> sink) const
     {
@@ -658,6 +660,30 @@ struct TestValueB
     bool operator==(const TestValueB& o) const { return value == o.value; }
 };
 static_assert(sizeof(TestValueB) <= 32);
+
+// ─── tag_invoke overloads for Encodable test types ────────────────
+
+void tag_invoke(
+    bcos::storage::encode_t, const TestValueA& v, std::function<void(const uint8_t*, size_t)> sink)
+{
+    v.encode(std::move(sink));
+}
+TestValueA tag_invoke(
+    bcos::storage::decode_t, std::type_identity<TestValueA>, const uint8_t* data, size_t size)
+{
+    return TestValueA{data, size};
+}
+
+void tag_invoke(
+    bcos::storage::encode_t, const TestValueB& v, std::function<void(const uint8_t*, size_t)> sink)
+{
+    v.encode(std::move(sink));
+}
+TestValueB tag_invoke(
+    bcos::storage::decode_t, std::type_identity<TestValueB>, const uint8_t* data, size_t size)
+{
+    return TestValueB{data, size};
+}
 
 // ─── Typed Entry tests ─────────────────────────────────────────────
 
@@ -703,7 +729,7 @@ BOOST_AUTO_TEST_CASE(lazyDecodeFromByteMode)
     Entry entry;
     TestValueA original{99, "lazy"};
     std::string encoded;
-    original.encode([&encoded](const uint8_t* d, size_t s) {
+    encode(original, [&encoded](const uint8_t* d, size_t s) {
         encoded.append(reinterpret_cast<const char*>(d), s);
     });
     entry.set(encoded);
@@ -737,7 +763,7 @@ BOOST_AUTO_TEST_CASE(encodeToBytesAfterSetTyped)
     auto bytes = entry.encodeToBytes();
     TestValueA expected{55, "world"};
     std::string expectedBytes;
-    expected.encode([&expectedBytes](const uint8_t* d, size_t s) {
+    encode(expected, [&expectedBytes](const uint8_t* d, size_t s) {
         expectedBytes.append(reinterpret_cast<const char*>(d), s);
     });
     BOOST_CHECK_EQUAL(bytes, expectedBytes);

--- a/bcos-table/test/unittests/libtable/Entry.cpp
+++ b/bcos-table/test/unittests/libtable/Entry.cpp
@@ -20,6 +20,7 @@
 // Allow unit tests to inspect private members for buffer-model verification
 
 #include "bcos-framework/protocol/Protocol.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-framework/storage/Table.h"
 #include "bcos-table/src/StateStorage.h"
 #include <bcos-crypto/hash/SM3.h>
@@ -156,9 +157,9 @@ BOOST_AUTO_TEST_CASE(object)
     std::tuple<int, std::string, std::string> value = std::make_tuple(100, "hello", "world");
 
     Entry entry;
-    entry.setObject(value);
+    entry.set(bcos::storage::serialize::encode(value));
 
-    auto out = entry.getObject<std::tuple<int, std::string, std::string>>();
+    auto out = bcos::storage::serialize::decode<std::tuple<int, std::string, std::string>>(entry.get());
 
     BOOST_CHECK(out == value);
 }

--- a/bcos-table/test/unittests/libtable/Table.cpp
+++ b/bcos-table/test/unittests/libtable/Table.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(dump_hash)
     // BOOST_TEST(table->dirty() == false);
     auto entry = std::make_optional(table->newEntry());
     // entry->setField("key", "name");
-    entry->setField(0, "Lili");
+    entry->set("Lili");
     table->setRow("name", *entry);
     auto tableinfo = table->tableInfo();
     BOOST_CHECK_EQUAL(tableinfo->name(), tableName);
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(dump_hash)
     // BOOST_TEST(data->size() == 1);
     entry = table->newEntry();
     // entry->setField("key", "name2");
-    entry->setField(0, "WW");
+    entry->set("WW");
     BOOST_CHECK_NO_THROW(table->setRow("name2", *entry));
 
     // data = table->dump(m_blockNumber);
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(setRow)
     // BOOST_TEST(table->tableInfo()->key == keyField);
     auto entry = std::make_optional(table->newEntry());
     // entry->setField("key", "name");
-    // BOOST_CHECK_THROW(entry->setField(0, "Lili"), bcos::Error);
+    // BOOST_CHECK_THROW(entry->set("Lili"), bcos::Error);
     BOOST_CHECK_NO_THROW(table->setRow("name", *entry));
 
     // check fields order of SYS_TABLE
@@ -196,8 +196,8 @@ BOOST_AUTO_TEST_CASE(removeFromCache)
     // BOOST_TEST(table->tableInfo()->key == keyField);
     auto entry = std::make_optional(table->newEntry());
     // entry->setField("key", "name");
-    entry->setField(0, "hello world!");
-    // BOOST_CHECK_THROW(entry->setField(0, "Lili"), bcos::Error);
+    entry->set("hello world!");
+    // BOOST_CHECK_THROW(entry->set("Lili"), bcos::Error);
     BOOST_CHECK_NO_THROW(table->setRow("name", *entry));
 
     auto deleteEntry = std::make_optional(table->newEntry());

--- a/bcos-table/test/unittests/libtable/TablePerf.cpp
+++ b/bcos-table/test/unittests/libtable/TablePerf.cpp
@@ -28,7 +28,7 @@ struct TablePerfFixture
         for (size_t i = 0; i < count; ++i)
         {
             auto entry = table.newEntry();
-            entry.setField(0, "value1");
+            entry.set("value1");
 
             entries.emplace_back("key_" + boost::lexical_cast<std::string>(i), std::move(entry));
         }
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(syncGet)
         std::string key = "key_" + boost::lexical_cast<std::string>(i);
         auto entry = table->getRow(key);
 
-        BOOST_CHECK_EQUAL(entry->getField(0), "value1");
+        BOOST_CHECK_EQUAL(entry->get(), "value1");
     }
 
     std::cout << "sync cost: " << bcos::utcSteadyTime() - now << "\n";
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(asyncGet)
     {
         std::string key = "key_" + boost::lexical_cast<std::string>(i);
         table->asyncGetRow(key, [&total, &finished, &done](auto&&, auto&& entry) {
-            BOOST_CHECK_EQUAL(entry->getField(0), "value1");
+            BOOST_CHECK_EQUAL(entry->get(), "value1");
 
             auto current = done.fetch_add(1);
             if (current + 1 >= total)
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(asyncToSyncGet)
         std::string key = "key_" + boost::lexical_cast<std::string>(i);
         std::promise<bool> finished;
         table->asyncGetRow(key, [&finished](auto&&, auto&& entry) {
-            BOOST_CHECK_EQUAL(entry->getField(0), "value1");
+            BOOST_CHECK_EQUAL(entry->get(), "value1");
             finished.set_value(true);
         });
         finished.get_future().get();

--- a/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(rollback)
         crypto::HashType("ab98649ca506b076000000000000000000000000000000000000000000000001").hex());
 #endif
     auto entry = std::make_optional(table->newEntry());
-    BOOST_REQUIRE_NO_THROW(entry->setField(0, "Lili"));
+    BOOST_REQUIRE_NO_THROW(entry->set("Lili"));
     BOOST_REQUIRE_NO_THROW(table->setRow("name", *entry));
 
     countRet = tableFactory->count(testTableName);
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(rollback)
     entry = table->getRow("name");
     BOOST_REQUIRE(entry.has_value());
     BOOST_REQUIRE(entry->dirty() == true);
-    BOOST_REQUIRE(entry->getField(0) == "Lili");
+    BOOST_REQUIRE(entry->get() == "Lili");
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
     BOOST_CHECK_EQUAL(hash.hex(),
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE(rollback)
     tableFactory->setRecoder(savePoint);
 
     entry = table->newEntry();
-    entry->setField(0, "12345");
+    entry->set("12345");
     table->setRow("id", *entry);
     countRet = tableFactory->count(testTableName);
     BOOST_REQUIRE_EQUAL(countRet.first, 2);
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(rollback)
     tableFactory->setRecoder(savePoint1);
 
     entry = table->newEntry();
-    entry->setField(0, "500");
+    entry->set("500");
     table->setRow("balance", *entry);
     countRet = tableFactory->count(testTableName);
     BOOST_REQUIRE_EQUAL(countRet.first, 3);
@@ -312,7 +312,7 @@ BOOST_AUTO_TEST_CASE(rollback)
 
     // insert without version
     entry = table->newEntry();
-    entry->setField(0, "new record");
+    entry->set("new record");
     BOOST_REQUIRE_NO_THROW(table->setRow("id", *entry));
     countRet = tableFactory->count(testTableName);
     BOOST_REQUIRE_EQUAL(countRet.first, 2);
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(rollback2)
 #endif
     auto entry = std::make_optional(table->newEntry());
     // entry->setField("key", "name");
-    entry->setField(0, "Lili");
+    entry->set("Lili");
     table->setRow("name", *entry);
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
@@ -371,14 +371,14 @@ BOOST_AUTO_TEST_CASE(rollback2)
 #endif
     // BOOST_REQUIRE(table->dirty() == true);
     BOOST_REQUIRE(entry->dirty() == true);
-    BOOST_REQUIRE(entry->getField(0) == "Lili");
+    BOOST_REQUIRE(entry->get() == "Lili");
     // auto savePoint = tableFactory->savepoint();
     auto savePoint = std::make_shared<Recoder>();
     tableFactory->setRecoder(savePoint);
 
     entry = table->newEntry();
     // entry->setField("key", "id");
-    entry->setField(0, "12345");
+    entry->set("12345");
     table->setRow("id", *entry);
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(hash)
     auto table = tableFactory->openTable(testTableName);
     auto entry = std::make_optional(table->newEntry());
     // entry->setField("key", "name");
-    entry->setField(0, "Lili");
+    entry->set("Lili");
     BOOST_REQUIRE_NO_THROW(table->setRow("name", *entry));
     entry = table->getRow("name");
     BOOST_REQUIRE(entry.has_value());
@@ -505,7 +505,7 @@ BOOST_AUTO_TEST_CASE(hash)
 
     entry = std::make_optional(table->newEntry());
     // entry->setField("key", "id");
-    entry->setField(0, "12345");
+    entry->set("12345");
     BOOST_REQUIRE_NO_THROW(table->setRow("id", *entry));
     entry = table->getRow("id");
     BOOST_REQUIRE(entry.has_value());
@@ -542,14 +542,14 @@ BOOST_AUTO_TEST_CASE(hash)
     // getPrimaryKeys and getRows
     entry = table->newEntry();
     // entry->setField("key", "id");
-    entry->setField(0, "12345");
+    entry->set("12345");
     BOOST_REQUIRE_NO_THROW(table->setRow("id", *entry));
     entry = table->getRow("name");
-    entry->setField(0, "Wang");
+    entry->set("Wang");
     BOOST_REQUIRE_NO_THROW(table->setRow("name", *entry));
     entry = table->newEntry();
     // entry->setField("key", "balance");
-    entry->setField(0, "12345");
+    entry->set("12345");
     BOOST_REQUIRE_NO_THROW(table->setRow("balance", *entry));
     BOOST_REQUIRE(entry.has_value());
     keys = table->getPrimaryKeys({c});
@@ -610,13 +610,13 @@ BOOST_AUTO_TEST_CASE(hash_V3_1_0)
         auto table = tableFactory1->openTable(tableName);
 
         auto entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
 
         std::promise<bool> getRow;
         table->asyncGetRow(key, [&](auto&& error, auto&& result) {
             BOOST_REQUIRE(!error);
-            BOOST_REQUIRE_EQUAL(result->getField(0), "hello world!");
+            BOOST_REQUIRE_EQUAL(result->get(), "hello world!");
 
             getRow.set_value(true);
         });
@@ -634,13 +634,13 @@ BOOST_AUTO_TEST_CASE(hash_V3_1_0)
         auto table = tableFactory2->openTable(tableName);
 
         auto entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
 
         std::promise<bool> getRow;
         table->asyncGetRow(key, [&](auto&& error, auto&& result) {
             BOOST_REQUIRE(!error);
-            BOOST_REQUIRE_EQUAL(result->getField(0), "hello world!");
+            BOOST_REQUIRE_EQUAL(result->get(), "hello world!");
 
             getRow.set_value(true);
         });
@@ -672,14 +672,14 @@ BOOST_AUTO_TEST_CASE(hash_different_table_same_data)
         tableFactory->createTable(tableName, "value");
         auto table = tableFactory->openTable(tableName);
         auto entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
         tableName = "testTable2";
         tableFactory->createTable(tableName, "value");
         key = "testKey2";
         table = tableFactory->openTable(tableName);
         entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
     };
     auto setData2 = [&](auto&& tableFactory) {
@@ -688,14 +688,14 @@ BOOST_AUTO_TEST_CASE(hash_different_table_same_data)
         tableFactory->createTable(tableName, "value");
         auto table = tableFactory->openTable(tableName);
         auto entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
         tableName = "testTable1";
         tableFactory->createTable(tableName, "value");
         key = "testKey2";
         table = tableFactory->openTable(tableName);
         entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
     };
     setData1(tableFactory1);
@@ -738,13 +738,13 @@ BOOST_AUTO_TEST_CASE(openAndCommit)
         auto table = tableFactory2->openTable(tableName);
 
         auto entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
 
         std::promise<bool> getRow;
         table->asyncGetRow(key, [&](auto&& error, auto&& result) {
             BOOST_REQUIRE(!error);
-            BOOST_REQUIRE_EQUAL(result->getField(0), "hello world!");
+            BOOST_REQUIRE_EQUAL(result->get(), "hello world!");
 
             getRow.set_value(true);
         });
@@ -767,7 +767,7 @@ BOOST_AUTO_TEST_CASE(checkInvalidKeys)
     {
         auto key = "testKey" + boost::lexical_cast<std::string>(i);
         auto entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
     }
     std::atomic<size_t> invalid = 0;
@@ -787,7 +787,7 @@ BOOST_AUTO_TEST_CASE(checkInvalidKeys)
     table = tableFactory3->openTable(tableName);
     key = "testKey" + boost::lexical_cast<std::string>(8);
     entry = table->newEntry();
-    entry.setField(0, "hello world!sss");
+    entry.set("hello world!sss");
     table->setRow(key, entry);
     invalid = 0;
     tableFactory3->parallelTraverse(false, [&](auto&, auto&, auto& entry) {
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE(chainLink)
                 auto entry = std::make_optional(table->newEntry());
                 auto key =
                     boost::lexical_cast<std::string>(i) + boost::lexical_cast<std::string>(k);
-                entry->setField(0, boost::lexical_cast<std::string>(i));
+                entry->set(boost::lexical_cast<std::string>(i));
                 BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
             }
         }
@@ -918,7 +918,7 @@ BOOST_AUTO_TEST_CASE(chainLink)
                 // BOOST_REQUIRE_NE(tableInfo, nullptr);
                 if (table != "s_tables" && !key.empty() && entry.status() != Entry::Status::DELETED)
                 {
-                    auto l = entry.getField(0).size();
+                    auto l = entry.get().size();
                     BOOST_REQUIRE_GE(l, 10);
                 }
             });
@@ -941,7 +941,7 @@ BOOST_AUTO_TEST_CASE(chainLink)
                 // BOOST_REQUIRE_NE(tableInfo, nullptr);
                 if (table != "s_tables" && !key.empty() && entry.status() != Entry::Status::DELETED)
                 {
-                    auto l = entry.getField(0).size();
+                    auto l = entry.get().size();
                     BOOST_REQUIRE_GE(l, 10);
                     BOOST_REQUIRE_EQUAL(entry.dirty(), true);
                 }
@@ -1089,7 +1089,7 @@ BOOST_AUTO_TEST_CASE(getRows)
     for (auto& it : values3)
     {
         BOOST_REQUIRE(it);
-        BOOST_REQUIRE_EQUAL(it->getField(0), "ddd1");
+        BOOST_REQUIRE_EQUAL(it->get(), "ddd1");
         BOOST_REQUIRE_EQUAL(it->dirty(), true);
     }
 
@@ -1100,7 +1100,7 @@ BOOST_AUTO_TEST_CASE(getRows)
     for (auto& it : values4)
     {
         BOOST_REQUIRE(it);
-        BOOST_REQUIRE_EQUAL(it->getField(0), "data" + boost::lexical_cast<std::string>(count));
+        BOOST_REQUIRE_EQUAL(it->get(), "data" + boost::lexical_cast<std::string>(count));
         BOOST_REQUIRE_EQUAL(it->dirty(), false);
         ++count;
     }
@@ -1169,12 +1169,12 @@ BOOST_AUTO_TEST_CASE(readPageWithInvalidKeyAndModifyNotChangePageKey)
     // write a page but the pageKey k0 is deleted, suppose the real pageKey is k1
     auto table = tableFactory->openTable(testTableName);
     auto entry = std::make_optional(table->newEntry());
-    entry->setField(0, "fruit999");
+    entry->set("fruit999");
     BOOST_REQUIRE_NO_THROW(table->setRow("999", *entry));
     entry = table->getRow("999");
     BOOST_REQUIRE(entry.has_value());
     entry = std::make_optional(table->newEntry());
-    entry->setField(0, "fruit99");
+    entry->set("fruit99");
     BOOST_REQUIRE_NO_THROW(table->setRow("99", *entry));
     entry = table->getRow("99");
     BOOST_REQUIRE(entry.has_value());
@@ -1193,10 +1193,10 @@ BOOST_AUTO_TEST_CASE(readPageWithInvalidKeyAndModifyNotChangePageKey)
     entry = std::make_optional(table->newDeletedEntry());
     BOOST_REQUIRE_NO_THROW(table->setRow("99", *entry));
     entry = std::make_optional(table->newEntry());
-    entry->setField(0, "fruit98");
+    entry->set("fruit98");
     BOOST_REQUIRE_NO_THROW(table->setRow("98", *entry));
     entry = std::make_optional(table->newEntry());
-    entry->setField(0, "fruit97");
+    entry->set("fruit97");
     BOOST_REQUIRE_NO_THROW(table->setRow("97", *entry));
 
     // commit the page, if has bug it will commit the page use invalid pageKey k0, otherwise it
@@ -1220,12 +1220,12 @@ BOOST_AUTO_TEST_CASE(readPageWithInvalidKeyAndDeleteNotChangePageKey)
     // write a page but the pageKey k0 is deleted, suppose the real pageKey is k1
     auto table = tableFactory->openTable(testTableName);
     auto entry = std::make_optional(table->newEntry());
-    entry->setField(0, "fruit999");
+    entry->set("fruit999");
     BOOST_REQUIRE_NO_THROW(table->setRow("999", *entry));
     entry = table->getRow("999");
     BOOST_REQUIRE(entry.has_value());
     entry = std::make_optional(table->newEntry());
-    entry->setField(0, "fruit99");
+    entry->set("fruit99");
     BOOST_REQUIRE_NO_THROW(table->setRow("99", *entry));
     entry = table->getRow("99");
     BOOST_REQUIRE(entry.has_value());
@@ -1356,7 +1356,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRow)
     storage2->asyncGetRow("table", "key1", [](Error::UniquePtr error, std::optional<Entry> entry) {
         BOOST_REQUIRE(!error);
         BOOST_REQUIRE(entry.has_value());
-        BOOST_REQUIRE_EQUAL(entry->getField(0), "value2");
+        BOOST_REQUIRE_EQUAL(entry->get(), "value2");
     });
 
     storage2->rollback(*recoder);
@@ -1364,7 +1364,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRow)
     storage2->asyncGetRow("table", "key1", [](Error::UniquePtr error, std::optional<Entry> entry) {
         BOOST_REQUIRE(!error);
         BOOST_REQUIRE(entry.has_value());
-        BOOST_REQUIRE_EQUAL(entry->getField(0), "value1");
+        BOOST_REQUIRE_EQUAL(entry->get(), "value1");
     });
 }
 
@@ -1399,7 +1399,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRows)
         "table", keys, [](Error::UniquePtr error, std::vector<std::optional<Entry>> entry) {
             BOOST_REQUIRE(!error);
             BOOST_REQUIRE_EQUAL(entry.size(), 1);
-            BOOST_REQUIRE_EQUAL(entry[0].value().getField(0), "value2");
+            BOOST_REQUIRE_EQUAL(entry[0].value().get(), "value2");
         });
 
     storage2->rollback(*recoder);
@@ -1408,7 +1408,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRows)
         "table", keys, [](Error::UniquePtr error, std::vector<std::optional<Entry>> entry) {
             BOOST_REQUIRE(!error);
             BOOST_REQUIRE_EQUAL(entry.size(), 1);
-            BOOST_REQUIRE_EQUAL(entry[0].value().getField(0), "value1");
+            BOOST_REQUIRE_EQUAL(entry[0].value().get(), "value1");
         });
 }
 
@@ -1595,7 +1595,7 @@ BOOST_AUTO_TEST_CASE(pageMerge)
             auto entry = std::make_optional(table->newEntry());
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -1675,7 +1675,7 @@ BOOST_AUTO_TEST_CASE(pageMergeRandom)
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
 
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             table->setRow(key, *entry);
             // BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
             // try
@@ -1788,7 +1788,7 @@ BOOST_AUTO_TEST_CASE(pageMergeParallelRandom)
             auto entry = std::make_optional(table->newEntry());
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -1873,7 +1873,7 @@ BOOST_AUTO_TEST_CASE(parallelMix)
             auto entry = std::make_optional(table->newEntry());
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -1893,7 +1893,7 @@ BOOST_AUTO_TEST_CASE(parallelMix)
                 auto entry = std::make_optional(table->newEntry());
                 auto key =
                     boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-                entry->setField(0, boost::lexical_cast<std::string>(k + 1));
+                entry->set(boost::lexical_cast<std::string>(k + 1));
                 BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
             }
             else
@@ -1967,7 +1967,7 @@ BOOST_AUTO_TEST_CASE(pageSplit)
             auto entry = std::make_optional(table->newEntry());
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -2020,7 +2020,7 @@ BOOST_AUTO_TEST_CASE(pageSplitRandom)
             auto entry = std::make_optional(table->newEntry());
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -2077,7 +2077,7 @@ BOOST_AUTO_TEST_CASE(pageSplitParallelRandom)
             auto entry = std::make_optional(table->newEntry());
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -2129,7 +2129,7 @@ BOOST_AUTO_TEST_CASE(asyncGetPrimaryKeys)
         {
             auto entry = std::make_optional(table->newEntry());
             auto key = boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -2205,7 +2205,7 @@ BOOST_AUTO_TEST_CASE(asyncGetPrimaryKeys)
     BOOST_REQUIRE(table);
     auto entry = std::make_optional(table->newEntry());
     auto key = "fruit";
-    entry->setField(0, "a");
+    entry->set("a");
     BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
     Condition c6;
     c6.limit(0, 0);
@@ -2258,11 +2258,11 @@ BOOST_AUTO_TEST_CASE(BigTableAdd)
             auto value =
                 boost::lexical_cast<std::string>(i) + "_" + boost::lexical_cast<std::string>(v);
             auto entry0 = std::make_optional(table0->newEntry());
-            entry0->setField(0, value);
+            entry0->set(value);
             BOOST_REQUIRE_NO_THROW(table0->setRow(key, *entry0));
 
             auto entry1 = std::make_optional(table1->newEntry());
-            entry1->setField(0, value);
+            entry1->set(value);
             BOOST_REQUIRE_NO_THROW(table1->setRow(key, *entry1));
         }
         auto hash0 = tableStorage0->hash(hashImpl, features);
@@ -2332,11 +2332,11 @@ BOOST_AUTO_TEST_CASE(BigTableAddSerialize)
             auto value =
                 boost::lexical_cast<std::string>(i) + "_" + boost::lexical_cast<std::string>(v);
             auto entry0 = std::make_optional(table0->newEntry());
-            entry0->setField(0, value);
+            entry0->set(value);
             BOOST_REQUIRE_NO_THROW(table0->setRow(key, *entry0));
 
             auto entry1 = std::make_optional(table1->newEntry());
-            entry1->setField(0, value);
+            entry1->set(value);
             BOOST_REQUIRE_NO_THROW(table1->setRow(key, *entry1));
         }
         auto hash0 = tableStorage0->hash(hashImpl, features);
@@ -2418,21 +2418,21 @@ BOOST_AUTO_TEST_CASE(mockCommitProcess)
                 boost::lexical_cast<std::string>(i) + "_" + boost::lexical_cast<std::string>(v);
             auto getKey = boost::lexical_cast<std::string>(index + k);
             auto entry0 = std::make_optional(table0->newEntry());
-            entry0->setField(0, value);
+            entry0->set(value);
             BOOST_REQUIRE_NO_THROW(table0->setRow(key, *entry0));
             entry0 = table0->getRow(key);
             BOOST_REQUIRE(entry0);
             entry0 = table0->getRow(getKey);
 
             auto entry1 = std::make_optional(table1->newEntry());
-            entry1->setField(0, value);
+            entry1->set(value);
             BOOST_REQUIRE_NO_THROW(table1->setRow(key, *entry1));
             entry1 = table1->getRow(key);
             BOOST_REQUIRE(entry1);
             entry1 = table1->getRow(getKey);
 
             auto entry2 = std::make_optional(table2->newEntry());
-            entry2->setField(0, value);
+            entry2->set(value);
             BOOST_REQUIRE_NO_THROW(table2->setRow(key, *entry2));
             entry2 = table2->getRow(key);
             BOOST_REQUIRE(entry2);
@@ -2536,21 +2536,21 @@ BOOST_AUTO_TEST_CASE(mockCommitProcessParallel)
                 boost::lexical_cast<std::string>(i) + "_" + boost::lexical_cast<std::string>(v);
             auto getKey = boost::lexical_cast<std::string>(index + k);
             auto entry0 = std::make_optional(table0->newEntry());
-            entry0->setField(0, value);
+            entry0->set(value);
             BOOST_REQUIRE_NO_THROW(table0->setRow(key, *entry0));
             entry0 = table0->getRow(key);
             BOOST_REQUIRE(entry0);
             entry0 = table0->getRow(getKey);
 
             auto entry1 = std::make_optional(table1->newEntry());
-            entry1->setField(0, value);
+            entry1->set(value);
             BOOST_REQUIRE_NO_THROW(table1->setRow(key, *entry1));
             entry1 = table1->getRow(key);
             BOOST_REQUIRE(entry1);
             entry1 = table1->getRow(getKey);
 
             auto entry2 = std::make_optional(table2->newEntry());
-            entry2->setField(0, value);
+            entry2->set(value);
             BOOST_REQUIRE_NO_THROW(table2->setRow(key, *entry2));
             entry2 = table2->getRow(key);
             BOOST_REQUIRE(entry2);
@@ -2629,7 +2629,7 @@ BOOST_AUTO_TEST_CASE(pageMergeBig)
             auto entry = std::make_optional(table->newEntry());
             auto key =
                 boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-            entry->setField(0, boost::lexical_cast<std::string>(k));
+            entry->set(boost::lexical_cast<std::string>(k));
             BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
         }
     }
@@ -2664,7 +2664,7 @@ BOOST_AUTO_TEST_CASE(pageMergeBig)
                 auto entry = std::make_optional(table->newEntry());
                 auto key =
                     boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-                entry->setField(0, boost::lexical_cast<std::string>(k));
+                entry->set(boost::lexical_cast<std::string>(k));
                 BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
             }
         }
@@ -2677,7 +2677,7 @@ BOOST_AUTO_TEST_CASE(pageMergeBig)
                 auto entry = std::make_optional(table->newEntry());
                 auto key =
                     boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-                entry->setField(0, boost::lexical_cast<std::string>(k));
+                entry->set(boost::lexical_cast<std::string>(k));
                 BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
             }
         }
@@ -2704,7 +2704,7 @@ BOOST_AUTO_TEST_CASE(pageMergeBig)
                 auto entry = std::make_optional(table->newEntry());
                 auto key =
                     boost::lexical_cast<std::string>(j) + "_" + boost::lexical_cast<std::string>(k);
-                entry->setField(0, boost::lexical_cast<std::string>(k));
+                entry->set(boost::lexical_cast<std::string>(k));
                 BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
             }
         }
@@ -2780,7 +2780,7 @@ BOOST_AUTO_TEST_CASE(insertAndDelete)
             auto value =
                 boost::lexical_cast<std::string>(i) + "_" + boost::lexical_cast<std::string>(v);
             auto entry0 = std::make_optional(table0->newEntry());
-            entry0->setField(0, value);
+            entry0->set(value);
             BOOST_REQUIRE_NO_THROW(table0->setRow(key, *entry0));
         }
 
@@ -2846,7 +2846,7 @@ BOOST_AUTO_TEST_CASE(invalidPageKeyToValid)
     {
         auto entry = std::make_optional(table->newEntry());
         auto key = "key1234567890123456789" + boost::lexical_cast<std::string>(k);
-        entry->setField(0, key);
+        entry->set(key);
         // 64B every entry
         BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
     }
@@ -2854,7 +2854,7 @@ BOOST_AUTO_TEST_CASE(invalidPageKeyToValid)
     {
         auto entry = std::make_optional(table->newEntry());
         auto key = "key1234567890123456789" + boost::lexical_cast<std::string>(k);
-        entry->setField(0, key);
+        entry->set(key);
         // 64B every entry
         BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
     }
@@ -2893,7 +2893,7 @@ BOOST_AUTO_TEST_CASE(invalidPageKeyToValid)
     {
         auto entry = table->newEntry();
         auto key = "key1234567890123456789" + boost::lexical_cast<std::string>(k);
-        entry.setField(0, key);
+        entry.set(key);
         tableStorage2->asyncSetRow(
             tableName, key, entry, [](Error::UniquePtr e) { BOOST_REQUIRE(!e); });
     }
@@ -2933,7 +2933,7 @@ BOOST_AUTO_TEST_CASE(DeleteTableToEmpty_InsertInvalidPageKey)
     {
         auto entry = std::make_optional(table->newEntry());
         auto key = "key1234567890123456789" + boost::lexical_cast<std::string>(k);
-        entry->setField(0, key);
+        entry->set(key);
         // 64B every entry
         BOOST_REQUIRE_NO_THROW(table->setRow(key, *entry));
     }
@@ -2949,7 +2949,7 @@ BOOST_AUTO_TEST_CASE(DeleteTableToEmpty_InsertInvalidPageKey)
         size_t keyVal = 1000002035;
         auto entry = table->newEntry();
         auto key = "key1234567890123456789" + boost::lexical_cast<std::string>(keyVal);
-        entry.setField(0, key);
+        entry.set(key);
         tableStorage2->asyncSetRow(
             tableName, key, entry, [](Error::UniquePtr e) { BOOST_REQUIRE(!e); });
     }
@@ -2959,7 +2959,7 @@ BOOST_AUTO_TEST_CASE(DeleteTableToEmpty_InsertInvalidPageKey)
     {
         auto entry = table->newDeletedEntry();
         auto key = "key1234567890123456789" + boost::lexical_cast<std::string>(k);
-        // entry.setField(0, key);
+        // entry.set(key);
         tableStorage3->asyncSetRow(
             tableName, key, entry, [](Error::UniquePtr e) { BOOST_REQUIRE(!e); });
     }
@@ -2968,13 +2968,13 @@ BOOST_AUTO_TEST_CASE(DeleteTableToEmpty_InsertInvalidPageKey)
     size_t keyVal = 1000002034;
     auto key = "key1234567890123456789" + boost::lexical_cast<std::string>(keyVal);
     auto entry = table->newEntry();
-    entry.setField(0, "ss");
+    entry.set("ss");
     tableStorage4->asyncSetRow(
         tableName, key, entry, [](Error::UniquePtr e) { BOOST_REQUIRE(!e); });
     keyVal = 1000002035;
     key = "key1234567890123456789" + boost::lexical_cast<std::string>(keyVal);
     entry = table->newEntry();
-    entry.setField(0, "ss");
+    entry.set("ss");
     tableStorage4->asyncSetRow(
         tableName, key, entry, [](Error::UniquePtr e) { BOOST_REQUIRE(!e); });
     std::atomic<size_t> valid = 0;
@@ -3046,10 +3046,10 @@ BOOST_AUTO_TEST_CASE(bugfix_keypage_system_entry_hash)
         auto key = "1";
         auto value = "value";
         auto entry0 = std::make_optional(table0->newEntry());
-        entry0->setField(0, value);
+        entry0->set(value);
         BOOST_REQUIRE_NO_THROW(table0->setRow(key, *entry0));
         auto entry = std::make_optional(table0->newEntry());
-        entry->setField(0, value);
+        entry->set(value);
         storage->asyncSetRow(StorageInterface::SYS_TABLES, "1", *entry, [](Error::UniquePtr) {});
         return storage->hash(hashImpl, f);
     };

--- a/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "Hash.h"
+#include <bcos-framework/storage/Serialize.h>
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/storage/StorageInterface.h"
@@ -2999,7 +3000,7 @@ BOOST_AUTO_TEST_CASE(TableMeta_read_write_mutex)
     threadPool->post([&]() {
         std::cout << "==================== parallelTraverse" << std::endl;
         Entry entry;
-        entry.setObject(*meta);
+        entry.set(bcos::storage::serialize::encode(*meta));
         std::cout << meta->size() << std::endl;
         promise->set_value();
     });

--- a/bcos-table/test/unittests/libtable/TestStateStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestStateStorage.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(rollback)
         crypto::HashType("ab98649ca506b076000000000000000000000000000000000000000000000001").hex());
 #endif
     auto entry = std::make_optional(table->newEntry());
-    BOOST_REQUIRE_NO_THROW(entry->setField(0, "Lili"));
+    BOOST_REQUIRE_NO_THROW(entry->set("Lili"));
     BOOST_REQUIRE_NO_THROW(table->setRow("name", *entry));
 
     hash = tableFactory->hash(hashImpl, features);
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(rollback)
     entry = table->getRow("name");
     BOOST_REQUIRE(entry.has_value());
     BOOST_REQUIRE(entry->dirty() == true);
-    BOOST_REQUIRE(entry->getField(0) == "Lili");
+    BOOST_REQUIRE(entry->get() == "Lili");
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
     BOOST_CHECK_EQUAL(hash.hex(),
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(rollback)
     tableFactory->setRecoder(savePoint);
 
     entry = table->newEntry();
-    entry->setField(0, "12345");
+    entry->set("12345");
     table->setRow("id", *entry);
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(rollback)
     tableFactory->setRecoder(savePoint1);
 
     entry = table->newEntry();
-    entry->setField(0, "500");
+    entry->set("500");
     table->setRow("balance", *entry);
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(rollback)
 
     // insert without version
     entry = table->newEntry();
-    entry->setField(0, "new record");
+    entry->set("new record");
     BOOST_REQUIRE_NO_THROW(table->setRow("id", *entry));
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE(rollback2)
 #endif
     auto entry = std::make_optional(table->newEntry());
     // entry->setField("key", "name");
-    entry->setField(0, "Lili");
+    entry->set("Lili");
     table->setRow("name", *entry);
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
@@ -319,14 +319,14 @@ BOOST_AUTO_TEST_CASE(rollback2)
 #endif
     // BOOST_REQUIRE(table->dirty() == true);
     BOOST_REQUIRE(entry->dirty() == true);
-    BOOST_REQUIRE(entry->getField(0) == "Lili");
+    BOOST_REQUIRE(entry->get() == "Lili");
     // auto savePoint = tableFactory->savepoint();
     auto savePoint = std::make_shared<Recoder>();
     tableFactory->setRecoder(savePoint);
 
     entry = table->newEntry();
     // entry->setField("key", "id");
-    entry->setField(0, "12345");
+    entry->set("12345");
     table->setRow("id", *entry);
     hash = tableFactory->hash(hashImpl, features);
 #if defined(__APPLE__)
@@ -404,14 +404,14 @@ BOOST_AUTO_TEST_CASE(hash)
     auto table = tableFactory->openTable(testTableName);
     auto entry = std::make_optional(table->newEntry());
     // entry->setField("key", "name");
-    entry->setField(0, "Lili");
+    entry->set("Lili");
     BOOST_CHECK_NO_THROW(table->setRow("name", *entry));
     entry = table->getRow("name");
     BOOST_TEST(entry);
 
     entry = std::make_optional(table->newEntry());
     // entry->setField("key", "id");
-    entry->setField(0, "12345");
+    entry->set("12345");
     BOOST_CHECK_NO_THROW(table->setRow("id", *entry));
     entry = table->getRow("id");
     BOOST_TEST(entry);
@@ -448,14 +448,14 @@ BOOST_AUTO_TEST_CASE(hash)
     // getPrimaryKeys and getRows
     entry = table->newEntry();
     // entry->setField("key", "id");
-    entry->setField(0, "12345");
+    entry->set("12345");
     BOOST_CHECK_NO_THROW(table->setRow("id", *entry));
     entry = table->getRow("name");
-    entry->setField(0, "Wang");
+    entry->set("Wang");
     BOOST_CHECK_NO_THROW(table->setRow("name", *entry));
     entry = table->newEntry();
     // entry->setField("key", "balance");
-    entry->setField(0, "12345");
+    entry->set("12345");
     BOOST_CHECK_NO_THROW(table->setRow("balance", *entry));
     BOOST_TEST(entry);
     keys = table->getPrimaryKeys({});
@@ -518,13 +518,13 @@ BOOST_AUTO_TEST_CASE(openAndCommit)
         auto table = tableFactory2->openTable(tableName);
 
         auto entry = std::make_optional(table->newEntry());
-        entry->setField(0, "hello world!");
+        entry->set("hello world!");
         table->setRow(key, *entry);
 
         std::promise<bool> getRow;
         table->asyncGetRow(key, [&](auto&& error, auto&& result) {
             BOOST_CHECK(!error);
-            BOOST_CHECK_EQUAL(result->getField(0), "hello world!");
+            BOOST_CHECK_EQUAL(result->get(), "hello world!");
 
             getRow.set_value(true);
         });
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(chainLink)
                 auto entry = std::make_optional(table->newEntry());
                 auto key =
                     boost::lexical_cast<std::string>(i) + boost::lexical_cast<std::string>(k);
-                entry->setField(0, boost::lexical_cast<std::string>(i));
+                entry->set(boost::lexical_cast<std::string>(i));
                 BOOST_CHECK_NO_THROW(table->setRow(key, *entry));
             }
         }
@@ -627,7 +627,7 @@ BOOST_AUTO_TEST_CASE(chainLink)
                                 BOOST_CHECK_EQUAL(entry->dirty(), false);
                             }
                             BOOST_CHECK_EQUAL(
-                                entry->getField(0), boost::lexical_cast<std::string>(i));
+                                entry->get(), boost::lexical_cast<std::string>(i));
                         }
                     }
                 }
@@ -643,7 +643,7 @@ BOOST_AUTO_TEST_CASE(chainLink)
                 // BOOST_CHECK_NE(tableInfo, nullptr);
                 if (table != "s_tables")
                 {
-                    auto i = boost::lexical_cast<int>(entry.getField(0));
+                    auto i = boost::lexical_cast<int>(entry.get());
 
                     BOOST_CHECK_LE(i, index);
                 }
@@ -667,7 +667,7 @@ BOOST_AUTO_TEST_CASE(chainLink)
                 // BOOST_CHECK_NE(tableInfo, nullptr);
                 if (table != "s_tables")
                 {
-                    auto i = boost::lexical_cast<int>(entry.getField(0));
+                    auto i = boost::lexical_cast<int>(entry.get());
 
                     if (i == index)
                     {
@@ -822,7 +822,7 @@ BOOST_AUTO_TEST_CASE(getRows)
     for (auto& it : values3)
     {
         BOOST_CHECK(it);
-        BOOST_CHECK_EQUAL(it->getField(0), "ddd1");
+        BOOST_CHECK_EQUAL(it->get(), "ddd1");
         BOOST_CHECK_EQUAL(it->dirty(), true);
     }
 
@@ -833,7 +833,7 @@ BOOST_AUTO_TEST_CASE(getRows)
     for (auto& it : values4)
     {
         BOOST_CHECK(it);
-        BOOST_CHECK_EQUAL(it->getField(0), "data" + boost::lexical_cast<std::string>(count));
+        BOOST_CHECK_EQUAL(it->get(), "data" + boost::lexical_cast<std::string>(count));
         BOOST_CHECK_EQUAL(it->dirty(), false);
         ++count;
     }
@@ -983,7 +983,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRow)
     storage2->asyncGetRow("table", "key1", [](Error::UniquePtr error, std::optional<Entry> entry) {
         BOOST_CHECK(!error);
         BOOST_CHECK(entry);
-        BOOST_CHECK_EQUAL(entry->getField(0), "value2");
+        BOOST_CHECK_EQUAL(entry->get(), "value2");
     });
 
     storage2->rollback(*recoder);
@@ -991,7 +991,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRow)
     storage2->asyncGetRow("table", "key1", [](Error::UniquePtr error, std::optional<Entry> entry) {
         BOOST_CHECK(!error);
         BOOST_CHECK(entry);
-        BOOST_CHECK_EQUAL(entry->getField(0), "value1");
+        BOOST_CHECK_EQUAL(entry->get(), "value1");
     });
 }
 
@@ -1024,7 +1024,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRows)
         "table", keys, [](Error::UniquePtr error, std::vector<std::optional<Entry>> entry) {
             BOOST_CHECK(!error);
             BOOST_CHECK_EQUAL(entry.size(), 1);
-            BOOST_CHECK_EQUAL(entry[0].value().getField(0), "value2");
+            BOOST_CHECK_EQUAL(entry[0].value().get(), "value2");
         });
 
     storage2->rollback(*recoder);
@@ -1033,7 +1033,7 @@ BOOST_AUTO_TEST_CASE(rollbackAndGetRows)
         "table", keys, [](Error::UniquePtr error, std::vector<std::optional<Entry>> entry) {
             BOOST_CHECK(!error);
             BOOST_CHECK_EQUAL(entry.size(), 1);
-            BOOST_CHECK_EQUAL(entry[0].value().getField(0), "value1");
+            BOOST_CHECK_EQUAL(entry[0].value().get(), "value1");
         });
 }
 

--- a/bcos-tool/bcos-tool/BfsFileFactory.cpp
+++ b/bcos-tool/bcos-tool/BfsFileFactory.cpp
@@ -1,3 +1,4 @@
+#include <bcos-framework/storage/Serialize.h>
 /**
  *  Copyright (C) 2022 FISCO BCOS.
  *  SPDX-License-Identifier: Apache-2.0
@@ -72,7 +73,7 @@ void BfsFileFactory::buildDirEntry(
             }
         },
         fileType);
-    _mutableEntry.setObject<std::vector<std::string>>({type.data(), "0", "0", "", "", ""});
+    _mutableEntry.set(bcos::storage::serialize::encode<std::vector<std::string>>({type.data(), "0", "0", "", "", ""}));
 }
 
 bool BfsFileFactory::buildLink(Table& _table, const std::string& _address, const std::string& _abi,

--- a/legacy/bcos-ledger/LedgerImpl.h
+++ b/legacy/bcos-ledger/LedgerImpl.h
@@ -100,13 +100,13 @@ protected:
 
         try
         {
-            number = boost::lexical_cast<bcos::protocol::BlockNumber>(entry->getField(0));
+            number = boost::lexical_cast<bcos::protocol::BlockNumber>(entry->get());
         }
         catch (boost::bad_lexical_cast& e)
         {
             // Ignore the exception
             LEDGER_LOG(INFO) << "Cast blockNumber failed, may be empty, set to default value -1"
-                             << LOG_KV("blockNumber str", entry->getField(0));
+                             << LOG_KV("blockNumber str", entry->get());
             number = -1;
         }
     }
@@ -124,7 +124,7 @@ protected:
             co_return;
         }
 
-        auto hashStr = entry->getField(0);
+        auto hashStr = entry->get();
         bcos::concepts::bytebuffer::assignTo(hashStr, hash);
     }
 
@@ -166,7 +166,7 @@ protected:
             LEDGER_LOG(WARNING) << "Not found codeHash contractAddress:" << _contractAddress;
             BOOST_THROW_EXCEPTION(GetABIError{} << errinfo_comment{"Get CodeHash not found"});
         }
-        auto codeHash = codeHashEntry.second->getField(0);
+        auto codeHash = codeHashEntry.second->get();
 
         // according to codeHash get abi
         auto entry = stateStorage->getRow(SYS_CONTRACT_ABI, codeHash);
@@ -176,7 +176,7 @@ protected:
             BOOST_THROW_EXCEPTION(GetABIError{} << errinfo_comment{"Get Abi not found"});
         }
 
-        std::string abiStr = std::string(entry.second->getField(0));
+        std::string abiStr = std::string(entry.second->get());
         LEDGER_LOG(TRACE) << "contractAddress is " << _contractAddress
                           << "ledger impl get abi is: " << abiStr;
         co_return abiStr;
@@ -204,7 +204,7 @@ protected:
                             NotFoundTransaction{} << errinfo_comment{"Get transaction not found"});
                     }
 
-                    auto field = entries[index]->getField(0);
+                    auto field = entries[index]->get();
                     auto bytesRef =
                         bcos::bytesConstRef((const bcos::byte*)field.data(), field.size());
                     bcos::concepts::serialize::decode(bytesRef, out[index]);
@@ -229,7 +229,7 @@ protected:
             int64_t value = 0;
             if (entry)
             {
-                [[likely]] value = boost::lexical_cast<int64_t>(entry->getField(0));
+                [[likely]] value = boost::lexical_cast<int64_t>(entry->get());
             }
 
             switch (i)
@@ -269,7 +269,7 @@ protected:
                 NotFoundBlockHeader{} << errinfo_comment{"Not found block header!"});
         }
 
-        auto field = entry->getField(0);
+        auto field = entry->get();
         bcos::concepts::serialize::decode(field, block.blockHeader);
 
         co_return;
@@ -288,7 +288,7 @@ protected:
             co_return;
         }
 
-        auto field = entry->getField(0);
+        auto field = entry->get();
         std::remove_reference_t<decltype(block)> metadataBlock;
         bcos::concepts::serialize::decode(field, metadataBlock);
         block.transactionsMetaData = std::move(metadataBlock.transactionsMetaData);
@@ -343,7 +343,7 @@ protected:
         }
 
         std::remove_reference_t<decltype(block)> nonceBlock;
-        auto field = entry->getField(0);
+        auto field = entry->get();
         bcos::concepts::serialize::decode(field, nonceBlock);
         block.nonceList = std::move(nonceBlock.nonceList);
     }

--- a/legacy/bcos-ledger/LedgerImpl.h
+++ b/legacy/bcos-ledger/LedgerImpl.h
@@ -135,7 +135,7 @@ protected:
         auto versionEntry =
             storage().getRow(ledger::SYS_CONFIG, ledger::SYSTEM_KEY_COMPATIBILITY_VERSION);
         auto [compatibilityVersionStr, number] =
-            versionEntry->template getObject<SystemConfigEntry>();
+            bcos::storage::serialize::decode<SystemConfigEntry>(versionEntry->get());
         if (!versionEntry)
         {
             LEDGER_LOG(WARNING) << "Not found compatibilityVersion: ";

--- a/legacy/bcos-ledger/test/LedgerImplTest.cpp
+++ b/legacy/bcos-ledger/test/LedgerImplTest.cpp
@@ -123,7 +123,7 @@ struct LedgerImplFixture
         bcos::storage::Entry headerEntry;
         std::vector<bcos::byte> headerBuffer;
         bcos::concepts::serialize::encode(header, headerBuffer);
-        headerEntry.setField(0, std::move(headerBuffer));
+        headerEntry.set(std::move(headerBuffer));
         data.emplace(std::tuple{SYS_NUMBER_2_BLOCK_HEADER, "10086"}, std::move(headerEntry));
 
         bcostars::Block transactionsBlock;
@@ -142,7 +142,7 @@ struct LedgerImplFixture
             std::vector<bcos::byte> txBuffer;
             bcos::concepts::serialize::encode(transaction, txBuffer);
             bcos::storage::Entry txEntry;
-            txEntry.setField(0, std::move(txBuffer));
+            txEntry.set(std::move(txBuffer));
 
             data.emplace(std::tuple{SYS_HASH_2_TX, hashStr}, std::move(txEntry));
 
@@ -154,14 +154,14 @@ struct LedgerImplFixture
             std::vector<bcos::byte> receiptBuffer;
             bcos::concepts::serialize::encode(receipt, receiptBuffer);
             bcos::storage::Entry receiptEntry;
-            receiptEntry.setField(0, std::move(receiptBuffer));
+            receiptEntry.set(std::move(receiptBuffer));
             data.emplace(std::tuple{SYS_HASH_2_RECEIPT, hashStr}, std::move(receiptEntry));
         }
 
         std::vector<bcos::byte> txsBuffer;
         bcos::concepts::serialize::encode(transactionsBlock, txsBuffer);
         bcos::storage::Entry txsEntry;
-        txsEntry.setField(0, std::move(txsBuffer));
+        txsEntry.set(std::move(txsBuffer));
         data.emplace(std::tuple{SYS_NUMBER_2_TXS, "10086"}, std::move(txsEntry));
 
         bcostars::Block nonceBlock;
@@ -170,7 +170,7 @@ struct LedgerImplFixture
         std::vector<bcos::byte> nonceBuffer;
         bcos::concepts::serialize::encode(nonceBlock, nonceBuffer);
         bcos::storage::Entry nonceEntry;
-        nonceEntry.setField(0, std::move(nonceBuffer));
+        nonceEntry.set(std::move(nonceBuffer));
         data.emplace(std::tuple{SYS_BLOCK_NUMBER_2_NONCES, "10086"}, std::move(nonceEntry));
     }
 

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -729,7 +729,7 @@ protocol::BlockNumber Initializer::getCurrentBlockNumber(
                 try
                 {
                     auto blockNumber =
-                        boost::lexical_cast<bcos::protocol::BlockNumber>(entry->getField(0));
+                        boost::lexical_cast<bcos::protocol::BlockNumber>(entry->get());
                     blockNumberFuture.set_value(blockNumber);
                 }
                 catch (boost::bad_lexical_cast& e)
@@ -737,7 +737,7 @@ protocol::BlockNumber Initializer::getCurrentBlockNumber(
                     // Ignore the exception
                     LEDGER_LOG(INFO)
                         << "Cast blockNumber failed, may be empty, set to default value 0"
-                        << LOG_KV("blockNumber str", entry->getField(0));
+                        << LOG_KV("blockNumber str", entry->get());
                     blockNumberFuture.set_value(0);
                 }
             }


### PR DESCRIPTION
## 改动概述

本 PR 对 `Entry` 存储层进行了架构级重构，将单一的 `std::string` 字节存储升级为 **proxy facade + SBO 多态类型擦除架构**，同时保持完全向后兼容。7 个提交覆盖 54 个文件（+1026/-585 行）。

```
提交链（从底到顶）:
  45610f722  Enable Entry to support typed
  c1212f311  Add atomic lazy decode
  d825adf08  Remove unused typed serialize
  a2425f61f  Use tag_invoke encode and decode for Entry
  3b15f8755  Remove [[discard]]
  053c87d13  Fix clang-tidy warning
  e07d53beb  Update encode() to template sink
```

---

### 1. Proxy Facade 类型擦除架构（全新）

Entry 内部不再持有单一 `std::string`，而是使用 `pro::proxy<AnyEntryFacade>` 实现类型擦除，通过 6 个 dispatch 约定覆盖所有操作：

- `MemData` / `MemSize` / `MemStatus` — 数据指针、大小、状态
- `MemEncode` — 序列化（模板 sink，无 std::function 开销）
- `MemGetTypedPtr` / `MemTypeIndex` — typed 指针 + 类型反射
- `restrict_layout<32, 8>` — 32 字节 inline SBO + 8 字节对齐

**6 种 Buffer 模型**覆盖所有使用场景：

| 模型 | 容量 | 存储方式 | 分配 |
|------|------|----------|------|
| SmallBuffer | ≤31 字节 | inline array + 1B size | 0 |
| Fixed32Buffer | =32 字节 | inline array (无 size 字段) | 0 |
| BufferModel | >32 字节 (sizeof(T)≤32) | 内联 T（如 std::string） | 0 (move) |
| SharedBufferModel | 任意 | shared_ptr | 0 (共享) |
| DeletedModel | 0 | 哨兵（无数据） | 0 |
| TypedHolderModel | 任意 | 内联或堆分配（proxy 决定） | 由 proxy 管理 |

**设计要点：**
- Fixed32Buffer 零 size 开销（恒 32 字节，适用于地址/哈希场景）
- SmallBuffer 阈值 31 确保 + 1B size = 32B = proxy inline 容量极限
- BufferModel 的 `requires(sizeof(T) <= 32)` 确保类型自身适合 proxy inline 存储

---

### 2. tag_invoke 定制化点（CPO）设计

引入 C++20 风格的 **Customization Point Object** 作为 Entry typed 存储的扩展机制：

- **encode CPO** — `bcos::storage::encode(v, sink)` → ADL 分发到 `tag_invoke(encode_t, ...)`
- **decode CPO** — `bcos::storage::decode<T>(data)` → ADL 分发到 `tag_invoke(decode_t, ...)`
- **std::type_identity** 阻止 decode 模板参数推导，强制调用方显式指定类型
- **Encodable concept** 编译期校验 encode + decode 双向约束
- **Poison pill** — `void tag_invoke()` 未定义声明阻止无限定调用
- **encode() 模板 sink** — 消除 `std::function` 类型擦除开销

---

### 3. 序列化分离 (Serialize.h)

将原来耦合在 Entry.h 中的 boost::archive 序列化逻辑抽取到独立 `bcos-framework/storage/Serialize.h`：

- `serialize::encode<T>(value)` / `serialize::decode<T>(view)` 模板函数
- ARCHIVE_FLAG（no_header | no_codecvt | no_tracking）迁移
- std::tuple 的 boost::serialization 支持随迁
- 迁移规模：getField(0) → get() 142 处、setObject/getObject → serialize::encode/decode 95 处
- StateValueResolver 同步重构：Entry → std::string 序列化

---

### 4. Atomic Lazy Decode（原子化延迟解码）

引入 `getTyped<T>()` 实现**线程安全的延迟类型解码**：

**数据流：**
RocksDB 读取 → Entry(byte-buffer) → getTyped<T>() 首次调用 → spinlock-protected decode → TypedHolderModel<T> 替换 m_buffer → 后续调用 O(1) 返回指针（无锁快路径）

**线程安全实现（Double-Check Locking + RAII Spinlock）：**
- 快路径：atomic_thread_fence(acquire) → getTypedPtr() → 已 typed 则直接返回（无锁）
- 慢路径：test_and_set 自旋获取锁（64 次后 yield backoff）
- DecodeLockGuard RAII — 任何退出路径（含异常）自动 clear(release)
- Double-check — 另一线程可能已完成解码
- acquire/release 内存序保证 ARM/Power 弱内存序可见性
- 类型不可变性：typed 数据后 setStatus() 抛 TypedEntryStatusChange、hash() 抛 TypedEntryHashCall

---

### 5. StateValueResolver 重构

存储层编码器从直接传递 Entry 对象改为**扁平的字节序列**：

```cpp
// 旧：Entry 直接作为存储值
static auto encode(const Entry& entry) { return entry; }

// 新：Entry → std::string
static auto encode(const Entry& entry) -> std::string { return entry.encodeToBytes(); }
static Entry decode(std::string_view view) { return Entry::decodeFromBytes(view); }
```

---

### 6. 性能特征

| 数据大小 | 模型 | 内存开销 | 堆分配 |
|----------|------|----------|--------|
| 0-31 字节 | SmallBuffer | 32B | 0 |
| 32 字节 | Fixed32Buffer | 32B | 0 |
| 33+ 字节 (view) | setImplCopy | inline string(32B) + heap | 1 |
| 33+ 字节 (owning) | BufferModel | inline string(32B) | 0 (move) |

绝大多数区块链存储场景（哈希、配置值）走零分配路径。

---

### 7. API 兼容性

| 旧 API | 新 API | 状态 |
|--------|--------|------|
| entry.getField(0) | entry.get() | 全局迁移 |
| entry.setObject(v) | entry.set(serialize::encode(v)) | 全局迁移 |
| entry.getObject<T>() | serialize::decode<T>(entry.get()) | 全局迁移 |
| entry.set(v) | 不变 | 兼容 |
| — | entry.setTyped<T>(v) | 新增 |
| — | entry.getTyped<T>() | 新增 |
| — | entry.encodeToBytes() | 新增 |
