### PR TITLE
fix(gateway): fix TLS session-teardown use-after-free via shared ownership (FIB-184)

### DIFF
--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -312,9 +312,10 @@ void Session::write()
         m_server.get().asioInterface()->asyncWrite(m_socket, m_writings->buffers,
             // FIB-184: hold a strong reference to the session for the duration of the async write.
             // async_write operates on this->m_socket and reads from buffers owned via m_writings;
-            // a strong ref keeps the socket/SSL stream alive until the write completes, so a
-            // concurrent teardown on another thread cannot free the stream mid-write.
-            [session = shared_from_this(), writings = m_writings, m_lock = std::move(lock)](
+            // a strong ref keeps the socket/SSL stream (and m_writings, which backs the buffers
+            // asyncWrite captures by reference) alive until the write completes, so a concurrent
+            // teardown on another thread cannot free them mid-write.
+            [session = shared_from_this(), m_lock = std::move(lock)](
                 const boost::system::error_code _error, std::size_t _size) mutable {
                 {
                     session->m_writings->buffers.clear();
@@ -388,10 +389,24 @@ void Session::drop(DisconnectReason _reason)
     // makes it run on the same single thread that services every read/write for this session —
     // i.e. a per-session strand — so socket operations never overlap. The strong self capture keeps
     // the session (and its socket) alive until the teardown runs.
+    //
+    // Shutdown path exception: Service::stop() calls Host::stop() (which stops and joins the
+    // io_context threads via IOServicePool::stop()) BEFORE dropping sessions, so once the network
+    // is down a posted handler would never run — the socket would never be closed and the posted
+    // task would pin this session in a dead io_context queue. With the io_context threads joined
+    // there are no read/write handlers left to race, so close inline instead (matching the old
+    // synchronous teardown behaviour on shutdown).
     if (m_socket)
     {
-        boost::asio::post(m_socket->ioService(),
-            [self = shared_from_this(), _reason]() { self->closeSocket(_reason); });
+        if (m_server.get().haveNetwork())
+        {
+            boost::asio::post(m_socket->ioService(),
+                [self = shared_from_this(), _reason]() { self->closeSocket(_reason); });
+        }
+        else
+        {
+            closeSocket(_reason);
+        }
     }
 }
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -17,6 +17,7 @@
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Overloaded.h"
 #include <boost/asio/buffer.hpp>
+#include <boost/asio/post.hpp>
 #include <boost/container/container_fwd.hpp>
 #include <boost/throw_exception.hpp>
 #include <algorithm>
@@ -309,10 +310,12 @@ void Session::write()
             payload.toConstBuffer(outputIt);
         }
         m_server.get().asioInterface()->asyncWrite(m_socket, m_writings->buffers,
-            [self = std::weak_ptr<Session>(shared_from_this()), writings = m_writings,
-                m_lock = std::move(lock)](
+            // FIB-184: hold a strong reference to the session for the duration of the async write.
+            // async_write operates on this->m_socket and reads from buffers owned via m_writings;
+            // a strong ref keeps the socket/SSL stream alive until the write completes, so a
+            // concurrent teardown on another thread cannot free the stream mid-write.
+            [session = shared_from_this(), writings = m_writings, m_lock = std::move(lock)](
                 const boost::system::error_code _error, std::size_t _size) mutable {
-                if (auto session = self.lock())
                 {
                     session->m_writings->buffers.clear();
                     for (auto& payload : session->m_writings->payloads)
@@ -377,81 +380,99 @@ void Session::drop(DisconnectReason _reason)
             });
     }
 
-    if (m_socket->isConnected())
+    // FIB-184: serialize the SSL/socket teardown onto the socket's own (single-threaded)
+    // io_context. drop() can be invoked from a TBB worker (Service-layer teardown, duplicate-peer
+    // handling) while an async_read_some/async_write is still in flight on the socket's io_context
+    // thread. Running close()/async_shutdown inline on the caller thread would then touch the same
+    // ssl::stream concurrently with those handlers. Posting the teardown to the socket's io_context
+    // makes it run on the same single thread that services every read/write for this session —
+    // i.e. a per-session strand — so socket operations never overlap. The strong self capture keeps
+    // the session (and its socket) alive until the teardown runs.
+    if (m_socket)
     {
-        try
-        {
-            if (_reason == DisconnectRequested || _reason == DuplicatePeer ||
-                _reason == ClientQuit || _reason == UserReason)
-            {
-                SESSION_LOG(DEBUG) << "[drop] closing remote " << m_socket->remoteEndpoint()
-                                   << LOG_KV("reason", reasonOf(_reason))
-                                   << LOG_KV("endpoint", m_socket->nodeIPEndpoint());
-            }
-            else
-            {
-                SESSION_LOG(INFO) << "[drop] closing remote " << m_socket->remoteEndpoint()
-                                  << LOG_KV("reason", reasonOf(_reason))
-                                  << LOG_KV("endpoint", m_socket->nodeIPEndpoint());
-            }
+        boost::asio::post(m_socket->ioService(),
+            [self = shared_from_this(), _reason]() { self->closeSocket(_reason); });
+    }
+}
 
-            /// if get Host object failed, close the socket directly
-            auto socket = m_socket;
-            if (socket->isConnected())
+void Session::closeSocket(DisconnectReason _reason)
+{
+    if (!m_socket || !m_socket->isConnected())
+    {
+        return;
+    }
+    try
+    {
+        if (_reason == DisconnectRequested || _reason == DuplicatePeer || _reason == ClientQuit ||
+            _reason == UserReason)
+        {
+            SESSION_LOG(DEBUG) << "[drop] closing remote " << m_socket->remoteEndpoint()
+                               << LOG_KV("reason", reasonOf(_reason))
+                               << LOG_KV("endpoint", m_socket->nodeIPEndpoint());
+        }
+        else
+        {
+            SESSION_LOG(INFO) << "[drop] closing remote " << m_socket->remoteEndpoint()
+                              << LOG_KV("reason", reasonOf(_reason))
+                              << LOG_KV("endpoint", m_socket->nodeIPEndpoint());
+        }
+
+        /// if get Host object failed, close the socket directly
+        auto socket = m_socket;
+        if (socket->isConnected())
+        {
+            socket->close();
+        }
+        auto shutdown_timer = std::make_shared<boost::asio::deadline_timer>(
+            socket->ioService(), boost::posix_time::milliseconds(m_shutDownTimeThres));
+        /// async wait for shutdown
+        shutdown_timer->async_wait([socket](const boost::system::error_code& error) {
+            /// drop operation has been aborted
+            if (error == boost::asio::error::operation_aborted)
             {
+                SESSION_LOG(DEBUG)
+                    << "[drop] operation aborted  by async_shutdown"
+                    << LOG_KV("value", error.value()) << LOG_KV("message", error.message());
+                return;
+            }
+            /// shutdown timer error
+            if (error && error != boost::asio::error::operation_aborted)
+            {
+                SESSION_LOG(WARNING)
+                    << "[drop] shutdown timer failed" << LOG_KV("failedValue", error.value())
+                    << LOG_KV("message", error.message());
+            }
+            /// force to shutdown when timeout
+            if (socket->ref().is_open())
+            {
+                SESSION_LOG(WARNING) << "[drop] timeout, force close the socket"
+                                     << LOG_KV("remote endpoint", socket->nodeIPEndpoint());
                 socket->close();
             }
-            auto shutdown_timer = std::make_shared<boost::asio::deadline_timer>(
-                socket->ioService(), boost::posix_time::milliseconds(m_shutDownTimeThres));
-            /// async wait for shutdown
-            shutdown_timer->async_wait([socket](const boost::system::error_code& error) {
-                /// drop operation has been aborted
-                if (error == boost::asio::error::operation_aborted)
+        });
+
+        /// async shutdown normally
+        socket->sslref().async_shutdown(
+            [socket, shutdown_timer](const boost::system::error_code& error) {
+                shutdown_timer->cancel();
+                if (error)
                 {
-                    SESSION_LOG(DEBUG)
-                        << "[drop] operation aborted  by async_shutdown"
-                        << LOG_KV("value", error.value()) << LOG_KV("message", error.message());
-                    return;
-                }
-                /// shutdown timer error
-                if (error && error != boost::asio::error::operation_aborted)
-                {
-                    SESSION_LOG(WARNING)
-                        << "[drop] shutdown timer failed" << LOG_KV("failedValue", error.value())
+                    SESSION_LOG(INFO)
+                        << "[drop] shutdown failed " << LOG_KV("failedValue", error.value())
                         << LOG_KV("message", error.message());
                 }
-                /// force to shutdown when timeout
+                /// force to close the socket
                 if (socket->ref().is_open())
                 {
-                    SESSION_LOG(WARNING) << "[drop] timeout, force close the socket"
-                                         << LOG_KV("remote endpoint", socket->nodeIPEndpoint());
+                    SESSION_LOG(WARNING) << LOG_DESC("force to shutdown session")
+                                         << LOG_KV("endpoint", socket->nodeIPEndpoint());
                     socket->close();
                 }
             });
-
-            /// async shutdown normally
-            socket->sslref().async_shutdown(
-                [socket, shutdown_timer](const boost::system::error_code& error) {
-                    shutdown_timer->cancel();
-                    if (error)
-                    {
-                        SESSION_LOG(INFO)
-                            << "[drop] shutdown failed " << LOG_KV("failedValue", error.value())
-                            << LOG_KV("message", error.message());
-                    }
-                    /// force to close the socket
-                    if (socket->ref().is_open())
-                    {
-                        SESSION_LOG(WARNING) << LOG_DESC("force to shutdown session")
-                                             << LOG_KV("endpoint", socket->nodeIPEndpoint());
-                        socket->close();
-                    }
-                });
-        }
-        catch (...)
-        {
-            SESSION_LOG(ERROR) << LOG_DESC("drop error") << LOG_KV("endpoint", nodeIPEndpoint());
-        }
+    }
+    catch (...)
+    {
+        SESSION_LOG(ERROR) << LOG_DESC("drop error") << LOG_KV("endpoint", nodeIPEndpoint());
     }
 }
 
@@ -489,15 +510,15 @@ void Session::doRead()
 {
     if (m_active && m_server.get().haveNetwork())
     {
-        // NOTE: Capture m_socket as a shared_ptr to keep the SSL context alive for the duration
-        // of this async read. The handler never references `socket` directly — it touches
-        // the socket only via the Session recovered from `self.lock()` — but removing this
-        // capture re-introduces the FIB-97 use-after-free: a concurrent drop() can free
-        // the SSL stream while this read is still in flight.
-        auto asyncRead = [self = std::weak_ptr<Session>(shared_from_this()), socket = m_socket](
+        // FIB-184: capture a strong reference (shared_from_this) instead of a weak_ptr. The
+        // buffer handed to asyncReadSome below points into this->m_recvBuffer and the stream is
+        // this->m_socket — both owned by the session. Holding a strong ref keeps the session, and
+        // therefore the recv buffer and the socket, alive until this handler completes, so a
+        // concurrent teardown on another thread can free them only after the read finishes. This
+        // supersedes the FIB-97 socket-only capture, which kept the SSL stream alive but not the
+        // recv buffer that async_read_some writes into — the actual use-after-free.
+        auto asyncRead = [session = shared_from_this()](
                              const boost::system::error_code& ec, std::size_t bytesTransferred) {
-            std::ignore = socket;
-            if (const auto session = self.lock())
             {
                 if (ec)
                 {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -232,11 +232,16 @@ public:
     /// Drop the connection for the reason @a _reason.
     void drop(DisconnectReason _reason);
 
-    // FIB-184: perform the actual SSL/socket teardown (close + graceful async_shutdown). drop()
-    // posts this onto the socket's own single-threaded io_context so it never runs concurrently
-    // with an in-flight async_read_some/async_write on the same ssl::stream (see Session.cpp).
+private:
+    // FIB-184: perform the actual SSL/socket teardown (close + graceful async_shutdown). It has a
+    // strict threading contract — it must run on the socket's io_context (or, on the shutdown path,
+    // with the io_context threads already joined) so it never touches the ssl::stream concurrently
+    // with an in-flight async_read_some/async_write. It is therefore private and reachable only via
+    // drop(), which enforces that contract (post to the io_context, or inline once the network is
+    // down); calling it directly from an arbitrary thread would reintroduce the original race.
     void closeSocket(DisconnectReason _reason);
 
+public:
     /// Check error code after reading and drop peer if error code.
     bool checkRead(boost::system::error_code _ec);
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -232,6 +232,11 @@ public:
     /// Drop the connection for the reason @a _reason.
     void drop(DisconnectReason _reason);
 
+    // FIB-184: perform the actual SSL/socket teardown (close + graceful async_shutdown). drop()
+    // posts this onto the socket's own single-threaded io_context so it never runs concurrently
+    // with an in-flight async_read_some/async_write on the same ssl::stream (see Session.cpp).
+    void closeSocket(DisconnectReason _reason);
+
     /// Check error code after reading and drop peer if error code.
     bool checkRead(boost::system::error_code _ec);
 

--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -106,6 +106,11 @@ public:
     {
         m_run = true;
     }
+
+    // Simulate Host::stop() having already run (IOServicePool::stop() joins the io_context
+    // threads), so haveNetwork() returns false and no io_context is left to service posted
+    // handlers.
+    void stopNetwork() { m_run = false; }
 };
 
 // A socket backed by a real SSL stream so drop()/closeSocket() can call sslref() safely; close()
@@ -181,6 +186,41 @@ BOOST_AUTO_TEST_CASE(InFlightReadKeepsSessionAlive)
     BOOST_CHECK_MESSAGE(weakSession.lock() == nullptr,
         "FIB-184: once the outstanding read and the deferred teardown complete, the Session must "
         "be released (no leak / self-reference cycle)");
+}
+
+// Shutdown-path regression: Service::stop() calls Host::stop() -- which stops and JOINS the
+// io_context threads via IOServicePool::stop() -- BEFORE dropping sessions. A drop() that posts its
+// teardown to the now-dead io_context would never close the socket and would pin the session in a
+// dead queue. When the network is already down, drop() must close the socket inline instead. This
+// test deliberately never runs the socket's io_context, mirroring the joined-thread state.
+BOOST_AUTO_TEST_CASE(DropClosesSocketInlineWhenNetworkDown)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_Lifetime>();
+    auto messageFactory = std::make_shared<P2PMessageFactory>();
+    auto fakeAsio = std::make_shared<FakeASIO_Lifetime>();
+    auto fakeHost =
+        std::make_shared<FakeHost_Lifetime>(hashImpl, fakeAsio, nullptr, messageFactory);
+
+    auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 1024, true);
+    session->setMessageFactory(messageFactory);
+    session->setMessageHandler([](NetworkException, SessionFace::Ptr, Message::Ptr) {});
+    BOOST_REQUIRE(fakeSocket->isConnected());
+
+    // Host::stop() has already joined the io_context threads: the socket's io_context will never
+    // run again, so a posted teardown would be dead code.
+    fakeHost->stopNetwork();
+
+    // The socket's io_context is deliberately never run in this test.
+    session->drop(DisconnectReason::ClientQuit);
+
+    BOOST_CHECK_MESSAGE(!fakeSocket->isConnected(),
+        "FIB-184: with the network down (io_context threads joined), drop() must close the socket "
+        "inline; a teardown posted to the dead io_context would never run");
+
+    // Drain the shutdown handlers closeSocket() queued (they hold the socket, not the session) so
+    // the fake io_context tears down cleanly.
+    fakeSocket->ioService().poll();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -1,0 +1,186 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-184: async read/write handlers must own the session
+ * @file FIB184_SessionAsyncLifetimeTest.cpp
+ * @date 2026-07-03
+ *
+ * CertiK re-review of commit 00ec1c8b1 found the earlier hardening (session caps, lazy recv
+ * buffer, log-sink suppression) did not address the underlying use-after-free: the async read
+ * handler captured only a weak_ptr<Session>, yet the buffer handed to async_read_some points into
+ * Session::m_recvBuffer and the stream is Session::m_socket. A concurrent teardown on another
+ * thread could destroy the Session — freeing the recv buffer — while the read was still in flight,
+ * so ASIO wrote decrypted bytes into freed memory (SIGSEGV). The fix captures shared_from_this()
+ * so an outstanding operation keeps the Session (and its buffer/socket) alive until it completes.
+ *
+ * This test drives a Session to the point where exactly one async read is in flight, drops every
+ * external strong reference, and asserts the Session is still alive — i.e. the in-flight read owns
+ * it. With the pre-fix weak_ptr capture the Session would already be destroyed here.
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/Socket.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/asio/error.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+using namespace bcos::crypto;
+
+namespace ba = boost::asio;
+namespace bi = boost::asio::ip;
+
+BOOST_FIXTURE_TEST_SUITE(FIB184_SessionAsyncLifetimeTest, TestPromptFixture)
+
+// A fake ASIO that captures — but does not invoke — the async read handler and the strandPost
+// callback, so a test can hold a read "in flight" and fire it deterministically.
+class FakeASIO_Lifetime : public bcos::gateway::ASIOInterface
+{
+public:
+    FakeASIO_Lifetime() = default;
+    ~FakeASIO_Lifetime() noexcept override = default;
+
+    void asyncReadSome(
+        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler handler) override
+    {
+        m_readHandler = std::move(handler);
+    }
+
+    void strandPost(Base_Handler handler) override { m_strandHandler = std::move(handler); }
+    void stop() override {}
+
+    // Run the deferred first-doRead posted by Session::start(). Moving the boost::function out
+    // leaves m_strandHandler empty, so a re-entrant doRead re-arms into a fresh slot.
+    void runStrandPost()
+    {
+        auto handler = std::move(m_strandHandler);
+        if (handler)
+        {
+            handler();
+        }
+    }
+
+    bool hasReadHandler() const { return static_cast<bool>(m_readHandler); }
+
+    // Complete the outstanding read, releasing the reference it holds on the session. Moving the
+    // handler out empties m_readHandler first, so a re-armed read lands in the fresh slot.
+    void fireReadHandler(boost::system::error_code error, std::size_t bytes)
+    {
+        auto handler = std::move(m_readHandler);
+        if (handler)
+        {
+            handler(error, bytes);
+        }
+    }
+
+private:
+    ReadWriteHandler m_readHandler;
+    Base_Handler m_strandHandler;
+};
+
+class FakeHost_Lifetime : public bcos::gateway::Host
+{
+public:
+    FakeHost_Lifetime(bcos::crypto::Hash::Ptr hash, std::shared_ptr<ASIOInterface> asioInterface,
+        std::shared_ptr<SessionFactory> sessionFactory, MessageFactory::Ptr messageFactory)
+      : Host(std::move(hash), std::move(asioInterface), std::move(sessionFactory),
+            std::move(messageFactory))
+    {
+        m_run = true;
+    }
+};
+
+// A socket backed by a real SSL stream so drop()/closeSocket() can call sslref() safely; close()
+// only flips the connected flag (the underlying TCP socket is never opened).
+class FakeSocket_Lifetime : public SocketFace
+{
+public:
+    FakeSocket_Lifetime()
+      : m_ioContext(std::make_shared<ba::io_context>()),
+        m_sslContext(ba::ssl::context::tlsv12),
+        m_sslSocket(std::make_shared<ba::ssl::stream<bi::tcp::socket>>(*m_ioContext, m_sslContext))
+    {}
+    ~FakeSocket_Lifetime() override = default;
+
+    bool isConnected() const override { return m_connected; }
+    void close() override { m_connected = false; }
+    bi::tcp::endpoint remoteEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::endpoint localEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::socket& ref() override { return m_sslSocket->next_layer(); }
+    ba::ssl::stream<bi::tcp::socket>& sslref() override { return *m_sslSocket; }
+    const NodeIPEndpoint& nodeIPEndpoint() const override { return m_nodeIPEndpoint; }
+    void setNodeIPEndpoint(NodeIPEndpoint) override {}
+    ba::io_context& ioService() override { return *m_ioContext; }
+
+    bool m_connected{true};
+
+private:
+    std::shared_ptr<ba::io_context> m_ioContext;
+    ba::ssl::context m_sslContext;
+    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
+    NodeIPEndpoint m_nodeIPEndpoint;
+};
+
+// The regression: an in-flight async read must keep the Session alive after every external strong
+// reference is dropped. Pre-fix (weak_ptr capture) the Session would be destroyed here, leaving
+// async_read_some writing into a freed recv buffer.
+BOOST_AUTO_TEST_CASE(InFlightReadKeepsSessionAlive)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket_Lifetime>();
+    auto messageFactory = std::make_shared<P2PMessageFactory>();
+    auto fakeAsio = std::make_shared<FakeASIO_Lifetime>();
+    auto fakeHost =
+        std::make_shared<FakeHost_Lifetime>(hashImpl, fakeAsio, nullptr, messageFactory);
+
+    std::weak_ptr<Session> weakSession;
+    {
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 1024, true);
+        session->setMessageFactory(messageFactory);
+        session->setMessageHandler([](NetworkException, SessionFace::Ptr, Message::Ptr) {});
+        weakSession = session;
+
+        session->start();           // posts the first doRead via strandPost
+        fakeAsio->runStrandPost();  // runs doRead -> asyncReadSome captures the read handler
+
+        BOOST_REQUIRE_MESSAGE(fakeAsio->hasReadHandler(),
+            "Session::start()/doRead() must arm exactly one async read");
+        // `session` goes out of scope here: the in-flight read is now the only owner.
+    }
+
+    BOOST_CHECK_MESSAGE(weakSession.lock() != nullptr,
+        "FIB-184: an in-flight async read must keep the Session (and its recv buffer/socket) "
+        "alive; pre-fix weak_ptr capture would have destroyed it here");
+
+    // Completing the read with EOF drives drop(): no re-arm, so the read handler releases its
+    // reference. drop() defers the socket teardown onto the socket's io_context; mark the socket
+    // disconnected first so closeSocket() early-returns (no real SSL shutdown in the test), then
+    // drain that io_context so the deferred handler releases its reference too.
+    fakeSocket->m_connected = false;
+    fakeAsio->fireReadHandler(boost::asio::error::eof, 0);
+    fakeSocket->ioService().poll();
+
+    BOOST_CHECK_MESSAGE(weakSession.lock() == nullptr,
+        "FIB-184: once the outstanding read and the deferred teardown complete, the Session must "
+        "be released (no leak / self-reference cycle)");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
+++ b/bcos-gateway/test/unittests/FIB97_new_SessionDropIdempotencyTest.cpp
@@ -154,20 +154,21 @@ BOOST_AUTO_TEST_CASE(drop_twice_sequential_no_double_teardown)
     BOOST_REQUIRE(bundle.session);
     BOOST_REQUIRE(bundle.socket);
 
-    // First drop: should perform the full teardown.
+    // First drop: wins the m_dropped CAS and posts the (single) socket teardown.
     bundle.session->drop(DisconnectReason::TCPError);
-    // Second drop: must be a no-op (not re-enter teardown).
+    // Second drop: must be a no-op (CAS fails), so it posts no second teardown.
     bundle.session->drop(DisconnectReason::TCPError);
 
-    // The socket must have been closed exactly once — a second drop re-invoking
-    // socket close is a sign of double-teardown.
-    // NOTE: close() in FakeSocket sets m_connected = false and increments m_closeCount.
-    // After the first drop the socket is already disconnected, so the second drop's
-    // `if (m_socket->isConnected())` guard may also prevent re-entry even without the
-    // new m_dropped guard — but the isConnected() check is not thread-safe and a race
-    // between two concurrent callers can slip through.  The atomic CAS fix is the
-    // correct guard.  The sequential check here still demonstrates the invariant.
+    // drop() marks the session inactive synchronously.
     BOOST_CHECK(!bundle.session->active());
+
+    // FIB-184: the actual socket close/shutdown is deferred onto the socket's own io_context so it
+    // can never race an in-flight async_read_some/async_write. Drain that io_context to run the
+    // deferred teardown; only the CAS winner posted one, so close() must run exactly once.
+    bundle.socket->ioService().poll();
+
+    // The socket must have been closed exactly once — a second drop re-invoking socket close is a
+    // sign of double-teardown. close() in FakeSocket increments m_closeCount.
     BOOST_CHECK_EQUAL(bundle.socket->m_closeCount.load(), 1);
 }
 
@@ -186,7 +187,9 @@ BOOST_AUTO_TEST_CASE(drop_concurrent_two_threads_no_race)
 
     // No crash, no UAF, no TSan report.
     BOOST_CHECK(!bundle.session->active());
-    BOOST_CHECK_LE(bundle.socket->m_closeCount.load(), 1);
+    // FIB-184: run the deferred teardown posted by the single CAS winner (see sequential case).
+    bundle.socket->ioService().poll();
+    BOOST_CHECK_EQUAL(bundle.socket->m_closeCount.load(), 1);
 }
 
 // FIB-97-new: Eight threads all calling drop() concurrently — stress the CAS path.
@@ -208,7 +211,9 @@ BOOST_AUTO_TEST_CASE(drop_many_threads_stress)
     }
 
     BOOST_CHECK(!bundle.session->active());
-    BOOST_CHECK_LE(bundle.socket->m_closeCount.load(), 1);
+    // FIB-184: run the deferred teardown posted by the single CAS winner (see sequential case).
+    bundle.socket->ioService().poll();
+    BOOST_CHECK_EQUAL(bundle.socket->m_closeCount.load(), 1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## FIB-184 — durable fix for the TLS session-teardown use-after-free

CertiK's re-review of the previous FIB-184 fix (#5294) judged it **ineffective**: under the connection-storm and persistent bulk-disconnect campaigns the fleet still crashes with SIGSEGV and consensus halts. The added session caps, deferred receive-buffer allocation, and log-sink exception suppression are hardening / rate-limiting that never touched the underlying use-after-free.

### Root cause

The async **read** (`doRead`) and **write** (`write`) completion handlers captured only `weak_ptr<Session>`. But the buffer handed to `async_read_some` is a raw pointer into `Session::m_recvBuffer`, and the stream is `Session::m_socket` — both owned by the Session. A concurrent teardown running on a TBB worker thread (`Host::asyncTo` → `Service::onMessage`/`onDisconnect` → `m_sessions.erase`, or the duplicate-peer map overwrite `m_sessions[p2pID] = newSession`) destroys the Session — freeing its recv buffer and socket — while the operation is still in flight on the socket's io_context thread. ASIO then writes decrypted bytes into freed heap → SIGSEGV. The FIB-97 `socket = m_socket` capture kept the SSL stream alive but not the recv buffer, so it was an incomplete fix.

### The fix

Implements exactly CertiK's prescribed remediation — shared ownership so memory is released only after the last outstanding handler completes, with teardown serialized on a per-session strand:

- **`doRead` and `write` completion handlers now capture `shared_from_this()`** (strong) instead of `weak_ptr`. An outstanding operation keeps the Session — and therefore its recv buffer, its socket, and the write-queue mutex held via `m_lock` — alive until the handler runs. The write path matters too: with the old weak capture, when `lock()` returned null the write callback (`payload.m_callback`) was silently dropped (message sent, caller never notified); the strong reference guarantees the callback still fires. This is the canonical ASIO "the completion handler owns the object" idiom and supersedes the FIB-97 socket-only capture.
- **`drop()` no longer closes the socket inline.** During normal operation it posts the SSL teardown (`Session::closeSocket()`) onto the socket's own single-threaded io_context via `boost::asio::post(m_socket->ioService(), ...)`. Since `IOServicePool` runs one thread per io_context, posting teardown there is a per-session strand: `close()` / `async_shutdown()` never run concurrently with an in-flight `async_read_some` / `async_write` on the same `ssl::stream`. `closeSocket()` is private and reachable only via `drop()`, which enforces this contract.
  - **Shutdown path:** `Service::stop()` calls `Host::stop()` — which stops and joins the io_context threads via `IOServicePool::stop()` — *before* dropping sessions, so a teardown posted after that point would never run (dead-code graceful shutdown; the posted task would pin the Session in a dead queue). When `haveNetwork()` is false, `drop()` closes the socket inline instead: the threads are already joined, so nothing can race, and this restores the pre-existing synchronous shutdown behaviour.

**Contract note:** deferring the close introduces a short window where `active() == false` but `isConnected() == true` (the posted `closeSocket()` runs slightly later on the io_context). This converges and is not a runtime-correctness bug, but callers that assumed "socket is closed immediately after `drop()`" should be aware.

The #5294 caps / lazy buffer / log-sink suppressor are left in place — they still bound resource usage; this PR fixes the UAF underneath them. No memory-leak risk is introduced: the strong reference lives in ASIO's pending-operation slot (not inside the Session, so no cycle), and outstanding I/O is always terminated by the idle-check timer and by socket close on drop, so the Session's release is merely deferred until the last handler completes, never prevented.

### Testing

- New `FIB184_SessionAsyncLifetimeTest`:
  - `InFlightReadKeepsSessionAlive` pins the core invariant — drive a Session to exactly one in-flight read, drop every external strong reference, assert the Session is still alive (the in-flight read owns it), then complete the read and assert release. **Fails on the pre-fix weak capture, passes on the fix.**
  - `DropClosesSocketInlineWhenNetworkDown` covers the shutdown path — with the io_context stopped, `drop()` must close the socket inline; fails without the inline-close fallback.
- `FIB97_new_SessionDropIdempotencyTest` adapted to drain the socket io_context (`ioService().poll()`) before asserting the close count, since teardown is now deferred there.
- **All 101 bcos-gateway unit tests pass** (ctest).
- The live churn attack (mTLS injector, Scenario A storm + Scenario D persistent bulk-disconnect) was reproduced against a local AIR cluster; it drives the vulnerable teardown path at scale (10k+ session creates, ~9.8k drops/node) and the fixed build sustains it with no crash / deadlock / consensus halt. The deterministic baseline-crash-vs-fixed-clean ASan differential should be run on Linux/CI — AddressSanitizer is currently unusable on the local macOS toolchain (it hangs at startup).
