### PR TITLE
feat(features): activation-block data path + feature_mpt_state_root (M6.1)

### DIFF
--- a/bcos-framework/bcos-framework/ledger/Features.h
+++ b/bcos-framework/bcos-framework/ledger/Features.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../protocol/Protocol.h"
+#include "../protocol/ProtocolTypeDef.h"
 #include "../storage2/Storage.h"
 #include "bcos-task/Task.h"
 #include <bcos-utilities/Common.h>
@@ -7,6 +8,7 @@
 #include <array>
 #include <bitset>
 #include <magic_enum/magic_enum.hpp>
+#include <map>
 #include <ostream>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/iota.hpp>
@@ -113,6 +115,9 @@ public:
         feature_balance_policy2 = 56,     // 转账白名单 Transfer whitelist
         feature_l2_ethereum_compat = 57,  // OP-Stack L2 mode: Ethereum-compatible
                                           // genesis/predeploys
+        feature_mpt_state_root = 58,      // MPT lazy-build: block stateRoot switches to the
+                                          // Ethereum MPT root from this flag's activation
+                                          // block on (spec 2026-04-24 design3 4.3)
     };
 
     // feature_flags bit = enum value; magic_enum's default reflection range is
@@ -125,6 +130,11 @@ public:
 
 private:
     std::bitset<magic_enum::enum_count<Flag>()> m_flags;
+    // Activation block per flag, recorded only by the readFromStorage paths (spec 5.6):
+    // the shouldBuildMPT decision (PR-17) needs the block a flag activated AT, which the
+    // bitset alone cannot answer. A flag enabled via bare set() has no activation context
+    // and is deliberately absent here.
+    std::map<Flag, protocol::BlockNumber> m_activationBlocks;
 
 public:
     static Flag string2Flag(std::string_view str);
@@ -145,6 +155,23 @@ public:
     void set(Flag flag);
 
     void set(std::string_view flag) { set(string2Flag(flag)); }
+
+    // The block number @p flag activated at, or -1 when unknown — i.e. the flag was never
+    // loaded through a readFromStorage path (bare set() records nothing). Callers deciding
+    // on activation-block semantics must check get(flag) first: an enabled-but-unrecorded
+    // flag also reports -1.
+    protocol::BlockNumber activationBlockOf(Flag flag) const noexcept
+    {
+        auto it = m_activationBlocks.find(flag);
+        return it == m_activationBlocks.end() ? -1 : it->second;
+    }
+
+    // Record @p flag's activation block. Public so the free-function readFromStorage
+    // overload (FeaturesStorage.h) can write it without friendship.
+    void setActivationBlock(Flag flag, protocol::BlockNumber enableNumber)
+    {
+        m_activationBlocks[flag] = enableNumber;
+    }
 
 
     void setToShardingDefault(protocol::BlockVersion version);

--- a/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
+++ b/bcos-framework/bcos-framework/ledger/FeaturesStorage.h
@@ -6,6 +6,7 @@
 #include "Features.h"
 #include "bcos-task/Task.h"
 #include <boost/lexical_cast.hpp>
+#include <range/v3/range/conversion.hpp>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/transform.hpp>
 #include <range/v3/view/zip.hpp>
@@ -25,6 +26,7 @@ inline task::Task<void> Features::readFromStorage(
             if (blockNumber >= enableNumber)
             {
                 set(key);
+                setActivationBlock(string2Flag(key), enableNumber);
             }
         }
     }
@@ -52,10 +54,13 @@ inline task::Task<void> readFromStorage(Features& features,
     storage2::ReadableStorage<executor_v1::StateKey> auto& storage, long blockNumber)
 {
     decltype(auto) keys = bcos::ledger::Features::featureKeys();
-    auto entries = co_await storage2::readSome(std::forward<decltype(storage)>(storage),
-        keys | ::ranges::views::transform([](std::string_view key) {
-            return executor_v1::StateKeyView(ledger::SYS_CONFIG, key);
-        }));
+    // Materialize the key views: a lazy range-v3 pipeline reports its size as
+    // ranges::detail::diffmax_t, which storages like MemoryStorage cannot narrow to
+    // size_t in readSome's reserve; a vector is a plain sized range for any storage.
+    auto keyViews = keys | ::ranges::views::transform([](std::string_view key) {
+        return executor_v1::StateKeyView(ledger::SYS_CONFIG, key);
+    }) | ::ranges::to<std::vector>();
+    auto entries = co_await storage2::readSome(std::forward<decltype(storage)>(storage), keyViews);
     for (auto&& [key, entry] : ::ranges::views::zip(keys, entries))
     {
         if (entry)
@@ -64,6 +69,7 @@ inline task::Task<void> readFromStorage(Features& features,
             if (blockNumber >= enableNumber)
             {
                 features.set(key);
+                features.setActivationBlock(Features::string2Flag(key), enableNumber);
             }
         }
     }

--- a/bcos-framework/test/CMakeLists.txt
+++ b/bcos-framework/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(SOURCES unittests/storage2/TestMemoryStorage.cpp
     unittests/storage/TestCondition.cpp
     unittests/main/main.cpp
     unittests/interfaces/ExecutorTest.cpp
+    unittests/interfaces/FeaturesActivationBlockTest.cpp
     unittests/interfaces/FeaturesTest.cpp
     unittests/interfaces/TestTransactionExecutor.cpp
     unittests/mempool/TestAnyMemPool.cpp

--- a/bcos-framework/test/unittests/interfaces/FeaturesActivationBlockTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesActivationBlockTest.cpp
@@ -1,0 +1,115 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FeaturesActivationBlockTest.cpp
+ * @brief Features activation-block data path + feature_mpt_state_root flag (spec §4.3, §5.6)
+ */
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/FeaturesStorage.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Wait.h"
+// Entry::setObject/getObject serialize through boost archives; Entry.h only pulls the
+// basic_archive types, the concrete archives are the consumer's include.
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/test/unit_test.hpp>
+#include <magic_enum/magic_enum.hpp>
+
+using namespace bcos;
+using namespace bcos::ledger;
+
+namespace
+{
+using ConfigStorage = storage2::memory_storage::MemoryStorage<executor_v1::StateKey,
+    executor_v1::StateValue, storage2::memory_storage::ORDERED>;
+
+task::Task<void> writeFlagAt(
+    ConfigStorage& storage, std::string_view flagName, protocol::BlockNumber enableNumber)
+{
+    storage::Entry entry;
+    entry.setObject(SystemConfigEntry{std::string{"1"}, enableNumber});
+    co_await storage2::writeOne(
+        storage, executor_v1::StateKey(SYS_CONFIG, flagName), std::move(entry));
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(FeaturesActivationBlockSuite)
+
+BOOST_AUTO_TEST_CASE(MptStateRootFlagExistsWithPermanentValue)
+{
+    BOOST_CHECK(Features::contains("feature_mpt_state_root"));
+    // The explicit enum value is persisted on-chain via feature_flags (Features.h "PERMANENT"
+    // rule) — pin it so a reorder/renumber cannot slip through review.
+    BOOST_CHECK_EQUAL(magic_enum::enum_integer(Features::Flag::feature_mpt_state_root), 58);
+}
+
+BOOST_AUTO_TEST_CASE(ActivationBlockReturnsMinusOneWhenUnset)
+{
+    Features features;
+    BOOST_CHECK_EQUAL(features.activationBlockOf(Features::Flag::feature_mpt_state_root), -1);
+}
+
+BOOST_AUTO_TEST_CASE(MemberReadFromStorageRecordsEnableNumber)
+{
+    ConfigStorage storage;
+    task::syncWait(writeFlagAt(storage, "feature_mpt_state_root", 100));
+
+    Features features;
+    task::syncWait(features.readFromStorage(storage, /*blockNumber*/ 200));
+
+    BOOST_CHECK(features.get(Features::Flag::feature_mpt_state_root));
+    BOOST_CHECK_EQUAL(features.activationBlockOf(Features::Flag::feature_mpt_state_root), 100);
+}
+
+BOOST_AUTO_TEST_CASE(FreeFunctionReadFromStorageRecordsEnableNumber)
+{
+    ConfigStorage storage;
+    task::syncWait(writeFlagAt(storage, "feature_mpt_state_root", 77));
+
+    Features features;
+    task::syncWait(readFromStorage(features, storage, /*blockNumber*/ 200));
+
+    BOOST_CHECK(features.get(Features::Flag::feature_mpt_state_root));
+    BOOST_CHECK_EQUAL(features.activationBlockOf(Features::Flag::feature_mpt_state_root), 77);
+}
+
+BOOST_AUTO_TEST_CASE(ActivationBlockNotRecordedBelowEnableNumber)
+{
+    ConfigStorage storage;
+    task::syncWait(writeFlagAt(storage, "feature_mpt_state_root", 100));
+
+    Features features;
+    task::syncWait(features.readFromStorage(storage, /*blockNumber*/ 50));
+
+    // blockNumber < enableNumber: the flag is not enabled, and no activation block either.
+    BOOST_CHECK(!features.get(Features::Flag::feature_mpt_state_root));
+    BOOST_CHECK_EQUAL(features.activationBlockOf(Features::Flag::feature_mpt_state_root), -1);
+}
+
+BOOST_AUTO_TEST_CASE(BareSetStillReportsMinusOne)
+{
+    Features features;
+    features.set(Features::Flag::feature_mpt_state_root);
+
+    BOOST_CHECK(features.get(Features::Flag::feature_mpt_state_root));
+    // set() carries no enableNumber context — by convention activationBlockOf stays -1;
+    // callers (shouldBuildMPT, PR-17) must check get(flag) before trusting the number.
+    BOOST_CHECK_EQUAL(features.activationBlockOf(Features::Flag::feature_mpt_state_root), -1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesTest.cpp
@@ -205,6 +205,7 @@ BOOST_AUTO_TEST_CASE(feature)
         "feature_rpbft_vrf_type_secp256k1",
         "feature_balance_policy2",
         "feature_l2_ethereum_compat",
+        "feature_mpt_state_root",
     };
     // clang-format on
     BOOST_CHECK_EQUAL(keys.size(), compareKeys.size());


### PR DESCRIPTION
## What

Two small, coupled additions to `Features` (spec §4.3, §5.6, §5.10):

1. **`feature_mpt_state_root = 58`** — the MPT lazy-build activation flag: from its activation block on, block stateRoot switches to the Ethereum MPT root. The value is explicit and permanent per the Flag-numbering rule in Features.h; `feature_l2_ethereum_compat = 57` already landed with A6, so this is the only new flag. A unit test pins the integer value so a renumber cannot slip through review.

2. **Activation-block data path** — `readFromStorage` currently reads each flag's `SystemConfigEntry`, compares `enableNumber`, calls `set(key)` and discards the number. The upcoming `shouldBuildMPT` helper (PR-17) needs the block a flag activated AT (the scenario-A transition uses a strict-greater-than check on it), which the bitset cannot answer. This PR adds a `std::map<Flag, BlockNumber> m_activationBlocks` populated by both `readFromStorage` paths (member template and free function), an `activationBlockOf(Flag)` accessor returning -1 for never-loaded flags, and a public `setActivationBlock()` so the free function needs no friendship. Bare `set()` deliberately records nothing — callers must check `get(flag)` before trusting the number, and the accessor's doc comment says so.

No change to `m_flags`, `set()`, `get()`, `toFlagsNumber()`, or any persisted encoding — fully backward compatible; `git revert` restores the exact prior behavior.

## Drive-by fix

The free-function `readFromStorage` fed a lazy range-v3 `StateKeyView` pipeline straight into `storage2::readSome`. Such a pipeline reports its size as `ranges::detail::diffmax_t`, which `MemoryStorage::readSome`'s `reserve` cannot narrow to `size_t` — the new unit test is the first code to instantiate that combination and it fails to compile. Materializing the keys into a `std::vector` fixes it for any storage type; existing callers see identical values.

## Tests

`FeaturesActivationBlockSuite` (6 cases): flag existence + pinned enum value, -1 when unset, both `readFromStorage` variants record `enableNumber`, nothing recorded when `blockNumber < enableNumber`, and the bare-`set()` convention. `FeaturesTest`'s exhaustive `compareKeys` list extended with the new flag. Verified locally: full `test-bcos-framework` run → No errors detected; full-tree build exit 0; standalone `-fsyntax-only` compile of the new test TU (unity-build leak guard) → exit 0. (The framework test CMakeLists uses an explicit source list, so the new test file is registered there — no GLOB in this module.)

Refs: spec §4.3, §5.6, §5.10; phase-b M6.1; unblocks PR-17 (shouldBuildMPT helper). Runs in parallel with #5310/#5311 — zero file overlap.