### PR TITLE
feat(scheduler): shouldBuildMPT helper + MPT flag-matrix startup guard (M6.2+M7.3)

### DIFF
--- a/libinitializer/LedgerInitializer.cpp
+++ b/libinitializer/LedgerInitializer.cpp
@@ -1,7 +1,11 @@
 #include "LedgerInitializer.h"
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-task/Wait.h>
+#include <bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h>
 #include <legacy/bcos-ledger/LedgerImpl.h>
 #include <legacy/bcos-storage/StorageWrapperImpl.h>
-#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <future>
+#include <tuple>
 
 std::shared_ptr<bcos::ledger::Ledger> bcos::initializer::LedgerInitializer::build(
     bcos::protocol::BlockFactory::Ptr blockFactory, bcos::storage::StorageInterface::Ptr storage,
@@ -26,5 +30,23 @@ std::shared_ptr<bcos::ledger::Ledger> bcos::initializer::LedgerInitializer::buil
     }
 
     ledger->buildGenesisBlock(nodeConfig->genesisConfig(), *nodeConfig->ledgerConfig());
+
+    // Startup MPT flag-matrix guard (spec 5.10 scenario B, M7.3): refuse to boot when
+    // feature_l2_ethereum_compat carries a non-genesis activation block — enabling it
+    // mid-chain would switch the state-root scheme with no transition rule and fork any
+    // node replaying the pre-flag blocks. Validated against the feature set the NEXT
+    // block runs with (head + 1), the same height convention as the commit path.
+    std::promise<std::tuple<bcos::Error::Ptr, bcos::protocol::BlockNumber>> blockNumberPromise;
+    ledger->asyncGetBlockNumber([&](bcos::Error::Ptr error, bcos::protocol::BlockNumber number) {
+        blockNumberPromise.set_value(std::make_tuple(std::move(error), number));
+    });
+    auto [error, blockNumber] = blockNumberPromise.get_future().get();
+    if (error)
+    {
+        BOOST_THROW_EXCEPTION(*error);
+    }
+    bcos::scheduler_v1::validateMPTFlagMatrix(
+        bcos::task::syncWait(ledger->fetchAllFeatures(blockNumber + 1)));
+
     return ledger;
 }

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/protocol/ProtocolTypeDef.h"
+
+namespace bcos::scheduler_v1
+{
+
+// Decide whether block @p blockNumber commits with an Ethereum MPT state root instead of
+// the legacy XOR root (spec 5.6 / 5.10). Pure function; wired into coCommitBlock by PR-19.
+inline bool shouldBuildMPT(
+    bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber) noexcept
+{
+    // Scenario B: L2 Ethereum-compat chains build the MPT from genesis on. Checked FIRST:
+    // at block 0 feature_mpt_state_root is not yet active, so consulting scenario A first
+    // would send an L2 chain down the XOR path.
+    if (features.get(ledger::Features::Flag::feature_l2_ethereum_compat))
+    {
+        return true;
+    }
+
+    // Scenario A: MPT enabled mid-chain by feature_mpt_state_root. Strictly-greater keeps
+    // the activation block N itself on XOR as the transition boundary (spec 5.10). The
+    // >= 0 guard rejects activationBlockOf == -1 — a flag set() without a storage load —
+    // which would otherwise silently enable MPT since blockNumber > -1 is always true.
+    if (features.get(ledger::Features::Flag::feature_mpt_state_root))
+    {
+        auto activationBlock =
+            features.activationBlockOf(ledger::Features::Flag::feature_mpt_state_root);
+        return activationBlock >= 0 && blockNumber > activationBlock;
+    }
+
+    // Neither flag: legacy XOR state root.
+    return false;
+}
+
+}  // namespace bcos::scheduler_v1

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
@@ -2,14 +2,19 @@
 
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
+#include <bcos-utilities/Exceptions.h>
+#include <boost/throw_exception.hpp>
 
 namespace bcos::scheduler_v1
 {
 
+DERIVE_BCOS_EXCEPTION(InvalidMPTFlagMatrix);
+
 // Decide whether block @p blockNumber commits with an Ethereum MPT state root instead of
-// the legacy XOR root (spec 5.6 / 5.10). Pure function; wired into coCommitBlock by PR-19.
+// the legacy XOR root (spec 5.6 / 5.10). Pure function; the commit path (coCommitBlock)
+// consults it once per block when the MPT branch is wired in.
 inline bool shouldBuildMPT(
-    bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber) noexcept
+    bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber)
 {
     // Scenario B: L2 Ethereum-compat chains build the MPT from genesis on. Checked FIRST:
     // at block 0 feature_mpt_state_root is not yet active, so consulting scenario A first
@@ -32,6 +37,40 @@ inline bool shouldBuildMPT(
 
     // Neither flag: legacy XOR state root.
     return false;
+}
+
+// Startup-time guard for the flag matrix shouldBuildMPT relies on (spec 5.10, M7.3).
+//
+// Scenario B has no transition rule: shouldBuildMPT returns true for EVERY block once
+// feature_l2_ethereum_compat is set, because the flag is assumed enabled at genesis
+// (activation block 0) — the chain never has XOR history to transition from. A mid-chain
+// enable would silently flip the state-root scheme with no boundary, forking any node
+// that replays the pre-flag blocks. Refuse to start instead.
+//
+// Call this with a Features loaded via readFromStorage so activation blocks are
+// populated; a bare set() leaves activationBlockOf at -1, which this guard rejects for
+// the same reason (an unverifiable activation must not pass a consistency check).
+//
+// @throws InvalidMPTFlagMatrix when feature_l2_ethereum_compat is set with a non-zero
+//         (or unknown) activation block. A features object without the flag always passes.
+inline void validateMPTFlagMatrix(bcos::ledger::Features const& features)
+{
+    using Flag = bcos::ledger::Features::Flag;
+    if (!features.get(Flag::feature_l2_ethereum_compat))
+    {
+        return;
+    }
+    auto activationBlock = features.activationBlockOf(Flag::feature_l2_ethereum_compat);
+    if (activationBlock != 0)
+    {
+        BOOST_THROW_EXCEPTION(
+            InvalidMPTFlagMatrix{} << bcos::errinfo_comment(
+                "feature_l2_ethereum_compat must be enabled at genesis (activation block 0), "
+                "but its activation block is " +
+                std::to_string(activationBlock) +
+                "; enabling it mid-chain would switch the state-root scheme with no "
+                "transition rule (spec 5.10 scenario B)"));
+    }
 }
 
 }  // namespace bcos::scheduler_v1

--- a/transaction-scheduler/tests/BaselineSchedulerMPTHelpersTest.cpp
+++ b/transaction-scheduler/tests/BaselineSchedulerMPTHelpersTest.cpp
@@ -1,0 +1,66 @@
+#include "bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h"
+#include "bcos-framework/ledger/Features.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::scheduler_v1;
+
+BOOST_AUTO_TEST_SUITE(BaselineSchedulerMPTHelpersSuite)
+
+BOOST_AUTO_TEST_CASE(BothFlagsOff_AlwaysXOR)
+{
+    ledger::Features features;
+    BOOST_CHECK(!shouldBuildMPT(features, 0));
+    BOOST_CHECK(!shouldBuildMPT(features, 1000));
+}
+
+BOOST_AUTO_TEST_CASE(ScenarioA_StrictlyGreaterThanActivation)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+
+    BOOST_CHECK(!shouldBuildMPT(features, 99));
+    // The activation block N itself stays on XOR: strict-greater is the transition boundary
+    BOOST_CHECK(!shouldBuildMPT(features, 100));
+    BOOST_CHECK(shouldBuildMPT(features, 101));
+    BOOST_CHECK(shouldBuildMPT(features, 1000));
+}
+
+BOOST_AUTO_TEST_CASE(ScenarioB_FromGenesis)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    // No activation block recorded: scenario B does not need one
+
+    BOOST_CHECK(shouldBuildMPT(features, 0));
+    BOOST_CHECK(shouldBuildMPT(features, 1));
+    BOOST_CHECK(shouldBuildMPT(features, 1000));
+}
+
+BOOST_AUTO_TEST_CASE(ScenarioBPriorityOverScenarioA)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+
+    // Scenario B wins regardless of the scenario-A activation boundary; a branch
+    // reordering that consulted feature_mpt_state_root first would fail at 99/100
+    BOOST_CHECK(shouldBuildMPT(features, 99));
+    BOOST_CHECK(shouldBuildMPT(features, 100));
+    BOOST_CHECK(shouldBuildMPT(features, 101));
+}
+
+BOOST_AUTO_TEST_CASE(ScenarioA_FlagSetButActivationUnknown_DoesNotBuild)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    // No setActivationBlock: activationBlockOf reports -1 (bare set(), no storage load).
+    // Without the >= 0 guard, blockNumber > -1 would silently enable MPT everywhere.
+
+    BOOST_CHECK(!shouldBuildMPT(features, 0));
+    BOOST_CHECK(!shouldBuildMPT(features, 1000));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/BaselineSchedulerMPTHelpersTest.cpp
+++ b/transaction-scheduler/tests/BaselineSchedulerMPTHelpersTest.cpp
@@ -63,4 +63,41 @@ BOOST_AUTO_TEST_CASE(ScenarioA_FlagSetButActivationUnknown_DoesNotBuild)
     BOOST_CHECK(!shouldBuildMPT(features, 1000));
 }
 
+BOOST_AUTO_TEST_CASE(FlagMatrix_NoL2FlagAlwaysPasses)
+{
+    ledger::Features features;
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(features));
+
+    // Scenario A alone is a legal matrix regardless of its activation block: the
+    // guard only polices scenario B's genesis-only assumption.
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 500);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(features));
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_L2AtGenesisPasses)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    features.setActivationBlock(ledger::Features::Flag::feature_l2_ethereum_compat, 0);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(features));
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_L2MidChainThrows)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    features.setActivationBlock(ledger::Features::Flag::feature_l2_ethereum_compat, 42);
+    BOOST_CHECK_THROW(validateMPTFlagMatrix(features), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_L2ActivationUnknownThrows)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    // Bare set() without a storage load: activationBlockOf is -1. An unverifiable
+    // activation must not pass a consistency check.
+    BOOST_CHECK_THROW(validateMPTFlagMatrix(features), InvalidMPTFlagMatrix);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

Distills the spec §5.6 MPT-vs-XOR commit-path decision into one pure free function, `bcos::scheduler_v1::shouldBuildMPT(features, blockNumber)` (new header BaselineSchedulerMPTHelpers.h), and adds the M7.3 flag-matrix consistency guard — predicate plus its node-startup wiring. No BaselineScheduler change in this PR — the helper gets wired into `coCommitBlock` in PR-19, on top of the activation-block data path from #5314.

### shouldBuildMPT priority order (commit 1, review-fixed in commit 2)

1. `feature_l2_ethereum_compat` set → always MPT, including genesis. Checked first: at block 0 `feature_mpt_state_root` is not yet active, so consulting rule 2 first would send an L2 chain down the XOR path.
2. `feature_mpt_state_root` set AND its activation block is known (`activationBlockOf >= 0`) AND `blockNumber` is strictly greater → MPT. Strictly-greater keeps the activation block N itself on XOR as a clean transition boundary (spec §5.10). The `>= 0` guard rejects a flag that was `set()` without a storage load.
3. Otherwise XOR.

Review fixes in commit 2: `noexcept` dropped (`Features::get` has a throw path — `noexcept` would turn a future violation into `std::terminate` on the commit path); comment references the intended caller instead of a PR number.

### Flag-matrix guard (commits 2–3, M7.3)

`validateMPTFlagMatrix(features)`: `feature_l2_ethereum_compat` must have activation block exactly 0 (genesis). Scenario B has no transition rule — a mid-chain enable would silently switch the state-root scheme and fork replaying nodes; an unknown activation (-1, bare `set()` without a storage load) is rejected for the same reason. Violations throw `InvalidMPTFlagMatrix`.

Commit 3 wires it into node startup: `LedgerInitializer::build` validates right after `buildGenesisBlock`, against the feature set the next block runs with (head + 1, the commit path's height convention, loaded via `fetchAllFeatures` → `readFromStorage` so activation blocks are populated). A violation propagates out of `build()` and aborts boot.

## Tests

`BaselineSchedulerMPTHelpersSuite` (9 cases): both flags off; scenario A strict-greater matrix (99/100/101/1000 around activation 100); scenario B from genesis; scenario B priority over scenario A's activation-block rule (guards against branch reordering); flag set with unknown activation never builds MPT; legal matrices (no L2 flag / scenario A alone / L2 at genesis); mid-chain L2 enable throws; unknown L2 activation throws.

Full `test-transaction-scheduler` green locally; `init` target builds clean with the wiring and the modified TU passes a standalone `-fsyntax-only` compile (unity-build leak guard).

Refs: spec §5.6, §5.10