### PR TITLE
fix(framework): adapt FeaturesActivationBlockTest to Serialize.h API

### DIFF
--- a/bcos-framework/test/unittests/interfaces/FeaturesActivationBlockTest.cpp
+++ b/bcos-framework/test/unittests/interfaces/FeaturesActivationBlockTest.cpp
@@ -20,13 +20,10 @@
 #include "bcos-framework/ledger/FeaturesStorage.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage/Serialize.h"
 #include "bcos-framework/storage2/MemoryStorage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-task/Wait.h"
-// Entry::setObject/getObject serialize through boost archives; Entry.h only pulls the
-// basic_archive types, the concrete archives are the consumer's include.
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
 #include <boost/test/unit_test.hpp>
 #include <magic_enum/magic_enum.hpp>
 
@@ -42,7 +39,7 @@ task::Task<void> writeFlagAt(
     ConfigStorage& storage, std::string_view flagName, protocol::BlockNumber enableNumber)
 {
     storage::Entry entry;
-    entry.setObject(SystemConfigEntry{std::string{"1"}, enableNumber});
+    entry.set(storage::serialize::encode(SystemConfigEntry{std::string{"1"}, enableNumber}));
     co_await storage2::writeOne(
         storage, executor_v1::StateKey(SYS_CONFIG, flagName), std::move(entry));
 }


### PR DESCRIPTION
## What

Unbreaks release-3.18.0 CI. #5312 replaced `Entry::setObject/getObject` with `storage::serialize::encode/decode` and migrated every call site — but #5314 merged the same day carrying one more `setObject` caller in its new test file. Git merged the two cleanly; compilation of `test-bcos-framework` broke on every platform (`FeaturesActivationBlockTest.cpp:45: 'Entry' has no member named 'setObject'`), so the branch's own post-merge CI and every open PR's CI against it are red (#5315/#5316/#5317 all fail with exactly this error in a file none of them touch).

One-file fix: the test's Entry write becomes `entry.set(storage::serialize::encode(SystemConfigEntry{...}))`, and the now-stale boost archive includes are dropped (Serialize.h owns them). A whole-tree grep for remaining `setObject/getObject` users finds only `benchmark/LegacyEntry.h`, which defines its own legacy copy and does not consume `storage::Entry`.

## Evidence

Full `test-bcos-framework` built and run locally on this commit: "*** No errors detected", exit 0.