### PR TITLE
fix(gateway): bound TLS handshake admission to stop consensus halt under connection churn (FIB-186)

### DIFF
--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -602,6 +602,25 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
         _pt.get<std::size_t>("p2p.max_concurrent_sessions", defaultMaxConcurrentSessions);
     m_maxSessionsPerIP = _pt.get<std::size_t>("p2p.max_sessions_per_ip", defaultMaxSessionsPerIP);
 
+    // FIB-186: cap concurrent in-flight TLS handshakes. Unlike the session caps above (enforced
+    // only after the handshake), this bounds accept/handshake work so connection churn cannot
+    // saturate the shared I/O pool and starve consensus message delivery. Global only (a per-IP cap
+    // is trivially bypassed by source-IP rotation; see Host.h).
+    constexpr static std::size_t defaultMaxPendingHandshakes = 64;
+    m_maxPendingHandshakes =
+        _pt.get<std::size_t>("p2p.max_pending_handshakes", defaultMaxPendingHandshakes);
+    // FIB-186: bound how long a single in-flight handshake may run before its admission slot is
+    // reclaimed, so a stalled / slow-loris handshake cannot hold a slot (and keep Host alive)
+    // indefinitely.
+    constexpr static int defaultHandshakeTimeoutMs = 10000;
+    m_handshakeTimeout = _pt.get<int>("p2p.handshake_timeout_ms", defaultHandshakeTimeoutMs);
+
+    // FIB-186: bound the RATE of accepted new connections so a churn flood cannot consume unbounded
+    // handshake CPU (asymmetric crypto). 0 = unlimited.
+    constexpr static uint32_t defaultMaxConnectionsPerSecond = 100;
+    m_maxConnectionsPerSecond =
+        _pt.get<uint32_t>("p2p.max_connections_per_second", defaultMaxConnectionsPerSecond);
+
     constexpr static uint32_t defaultMaxReadDataSize = 40 * 1024;
     m_maxReadDataSize = _pt.get<uint32_t>("p2p.session_max_read_data_size", defaultMaxReadDataSize);
 
@@ -628,6 +647,8 @@ void GatewayConfig::initP2PConfig(const boost::property_tree::ptree& _pt, bool _
                              << LOG_KV("p2p.session_max_send_data_size", m_maxSendDataSize)
                              << LOG_KV("p2p.session_max_send_msg_count", m_maxSendMsgCount)
                              << LOG_KV("p2p.thread_count", m_threadPoolSize)
+                             << LOG_KV("p2p.max_pending_handshakes", m_maxPendingHandshakes)
+                             << LOG_KV("p2p.max_connections_per_second", m_maxConnectionsPerSecond)
                              << LOG_KV("p2p.nodes_path", m_nodePath)
                              << LOG_KV("p2p.nodes_file", m_nodeFileName)
                              << LOG_KV("p2p.readonly", m_readonly)

--- a/bcos-gateway/bcos-gateway/GatewayConfig.h
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.h
@@ -223,6 +223,21 @@ public:
     std::size_t maxSessionsPerIP() const { return m_maxSessionsPerIP; }
     void setMaxSessionsPerIP(std::size_t _limit) { m_maxSessionsPerIP = _limit; }
 
+    // FIB-186: cap on concurrent in-flight TLS handshakes, configurable via
+    // p2p.max_pending_handshakes. Bounds accept/handshake work so connection churn cannot starve
+    // the shared I/O pool that also delivers consensus messages. Global only (no per-IP: see
+    // Host.h).
+    std::size_t maxPendingHandshakes() const { return m_maxPendingHandshakes; }
+    void setMaxPendingHandshakes(std::size_t _limit) { m_maxPendingHandshakes = _limit; }
+    // FIB-186: per-handshake timeout (ms), configurable via p2p.handshake_timeout_ms. Reclaims the
+    // admission slot of a stalled / slow-loris handshake instead of letting it hold forever.
+    int handshakeTimeout() const { return m_handshakeTimeout; }
+    void setHandshakeTimeout(int _timeoutMs) { m_handshakeTimeout = _timeoutMs; }
+    // FIB-186: max accepted new connections per second, configurable via
+    // p2p.max_connections_per_second. Bounds handshake CPU under connection churn (0 = unlimited).
+    uint32_t maxConnectionsPerSecond() const { return m_maxConnectionsPerSecond; }
+    void setMaxConnectionsPerSecond(uint32_t _limit) { m_maxConnectionsPerSecond = _limit; }
+
     uint32_t maxReadDataSize() const;
     void setMaxReadDataSize(uint32_t _maxReadDataSize);
 
@@ -281,6 +296,13 @@ private:
     // FIB-184: inbound session caps (defaults match the prior hardcoded Host constants)
     std::size_t m_maxConcurrentSessions{1024};
     std::size_t m_maxSessionsPerIP{32};
+    // FIB-186: in-flight TLS handshake cap (default matches Host::DEFAULT_MAX_PENDING_HANDSHAKES)
+    std::size_t m_maxPendingHandshakes{64};
+    // FIB-186: per-handshake timeout in ms (default matches Host::DEFAULT_HANDSHAKE_TIMEOUT_MS)
+    int m_handshakeTimeout{10000};
+    // FIB-186: accepted new-connection rate cap (default matches
+    // Host::DEFAULT_MAX_CONNECTIONS_PER_SECOND)
+    uint32_t m_maxConnectionsPerSecond{100};
     uint32_t m_maxReadDataSize = 40 * 1024;
     uint32_t m_maxSendDataSize = 1024 * 1024;
     uint32_t m_maxSendMsgCount = 10;

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -613,7 +613,27 @@ std::shared_ptr<Service> GatewayFactory::buildService(const GatewayConfig::Ptr& 
 
     // init ASIOInterface
     auto asioInterface = std::make_shared<ASIOInterface>();
-    auto ioServicePool = std::make_shared<IOServicePool>();
+    // FIB-186: size the P2P I/O pool from p2p.thread_count (previously ignored: IOServicePool() was
+    // built with no args, always defaulting to hardware_concurrency()+1). A single shared pool
+    // carries the acceptor, inbound + outbound sessions, TLS handshakes and timers.
+    //
+    // We deliberately do NOT add a second, acceptor-only pool to isolate inbound churn. A
+    // boost::asio SSL stream is welded to its io_context for life, so a connection's handshake and
+    // the reads of the session that follows run on the same pool; and an inbound churn connection
+    // is indistinguishable from an inbound validator connection at accept time (identity is known
+    // only after the handshake). So no pool assignment can separate attacker handshakes from
+    // validator consensus reads -- both always land on the same pool. A pool split would only move
+    // which thread the handshake CPU lands on, not off a thread that also carries consensus reads:
+    // thread isolation is not CPU isolation, and once that thread saturates consensus halts anyway
+    // (a split merely delays the onset). What actually prevents the halt is keeping the expensive
+    // handshake from running at all -- rejecting churn cheaply BEFORE the handshake via the
+    // accept-rate limit and the in-flight-handshake cap (Host), tuned small enough that admitted
+    // handshake CPU cannot saturate the pool. This was validated on a 3-node churn harness: with
+    // those caps on, a dedicated acceptor pool made no measurable difference; with them off, both
+    // the single-pool and the split-pool builds halted. See
+    // Host::DEFAULT_MAX_CONNECTIONS_PER_SECOND.
+    auto ioServicePool =
+        std::make_shared<IOServicePool>(std::max<uint32_t>(1U, _config->threadPoolSize()));
     asioInterface->setIOServicePool(ioServicePool);
     asioInterface->setSrvContext(srvCtx);
     asioInterface->setClientContext(clientCtx);
@@ -652,6 +672,10 @@ std::shared_ptr<Service> GatewayFactory::buildService(const GatewayConfig::Ptr& 
     // FIB-184: apply the configured inbound-session caps (no longer hardcoded in Host)
     host->setMaxConcurrentSessions(_config->maxConcurrentSessions());
     host->setMaxSessionsPerIP(_config->maxSessionsPerIP());
+    // FIB-186: bound in-flight TLS handshakes so connection churn cannot starve consensus reads.
+    host->setMaxPendingHandshakes(_config->maxPendingHandshakes());
+    host->setHandshakeTimeout(_config->handshakeTimeout());
+    host->setMaxConnectionsPerSecond(_config->maxConnectionsPerSecond());
     // init Service
     bool enableRIPProtocol = _config->enableRIPProtocol();
     Service::Ptr service = nullptr;

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -23,6 +23,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <set>
@@ -32,6 +33,28 @@
 using namespace bcos;
 using namespace bcos::gateway;
 using namespace bcos::crypto;
+
+namespace
+{
+// FIB-186: RAII guard bound to an in-flight TLS handshake. Constructed after a handshake slot is
+// acquired and moved into the handshake completion handler; its destructor releases the slot when
+// the handler runs (success / failure / abort) or is destroyed on shutdown. Held via weak_ptr so a
+// Host torn down before the handshake completes does not crash the guard.
+struct HandshakeSlotGuard
+{
+    std::weak_ptr<Host> host;
+    explicit HandshakeSlotGuard(std::weak_ptr<Host> _host) : host(std::move(_host)) {}
+    HandshakeSlotGuard(const HandshakeSlotGuard&) = delete;
+    HandshakeSlotGuard& operator=(const HandshakeSlotGuard&) = delete;
+    ~HandshakeSlotGuard()
+    {
+        if (auto h = host.lock())
+        {
+            h->releaseHandshakeSlot();
+        }
+    }
+};
+}  // namespace
 
 /**
  * @brief: accept connection requests, maily include procedures:
@@ -73,13 +96,76 @@ void Host::startAccept(boost::system::error_code boost_error)
 
                 /// if the connected peer over the limitation, drop socket
                 socket->setNodeIPEndpoint(endpoint);
-                HOST_LOG(INFO) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
+                // FIB-186: DEBUG, not INFO — under connection churn this fires on every accept and
+                // would flood the log, letting a low-trust peer fill the disk.
+                HOST_LOG(DEBUG) << LOG_DESC("P2P Recv Connect, From=") << endpoint;
+                // FIB-186: bound concurrent in-flight TLS handshakes (global cap) BEFORE starting
+                // the handshake. The FIB-184 session caps apply only after the handshake completes,
+                // so connection churn from a low-trust peer would otherwise flood the shared I/O
+                // thread-pool with accept / handshake / teardown work and starve inter-validator
+                // PBFT reads, halting consensus. Over the cap, drop the socket and re-arm accept
+                // without running the (CPU-heavy) TLS handshake.
+                std::string remoteAddress = socket->nodeIPEndpoint().address();
+                // FIB-186: rate-limit accepted connections before anything else, so a churn flood
+                // is dropped cheaply (accept + close) instead of paying the CPU-heavy TLS
+                // handshake. This bounds handshake CPU per unit time, which the concurrency caps
+                // below do not.
+                if (!tryAcquireConnectionToken())
+                {
+                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
+                                    << LOG_DESC("connection accept-rate limit reached, reject")
+                                    << LOG_KV("address", remoteAddress)
+                                    << LOG_KV("maxConnectionsPerSecond", m_maxConnectionsPerSecond);
+                    socket->close();
+                    startAccept();
+                    return;
+                }
+                if (!tryAcquireHandshakeSlot())
+                {
+                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
+                                    << LOG_DESC("pending-handshake cap reached, reject connection")
+                                    << LOG_KV("address", remoteAddress)
+                                    << LOG_KV("pendingHandshakes", m_pendingHandshakes.load())
+                                    << LOG_KV("maxPendingHandshakes", m_maxPendingHandshakes);
+                    socket->close();
+                    startAccept();
+                    return;
+                }
+                // Release the slot exactly once when the handshake completes (success, failure, or
+                // abort): the guard rides the completion handler and is destroyed with it.
+                auto handshakeGuard = std::make_shared<HandshakeSlotGuard>(weak_from_this());
+                // FIB-186: bound the handshake's lifetime. A stalled / slow TLS handshake would
+                // otherwise never complete, so its admission slot (above) would never be released
+                // and this Host (kept alive by the completion handler's shared_from_this) could
+                // never be destroyed. On timeout close the socket; that completes async_handshake
+                // with an error, so the completion handler runs, the guard is destroyed and the
+                // slot released. The timer and the handshake completion run on the socket's single
+                // io_context thread, so they are serialised (no race on close/cancel). Same pattern
+                // as the outbound connectTimer.
+                auto handshakeTimer = std::make_shared<boost::asio::deadline_timer>(
+                    socket->ioService(), boost::posix_time::milliseconds(m_handshakeTimeout));
+                handshakeTimer->async_wait([socket](const boost::system::error_code& timerError) {
+                    if (timerError == boost::asio::error::operation_aborted)
+                    {
+                        return;
+                    }
+                    if (socket->isConnected())
+                    {
+                        HOST_LOG(WARNING) << LOG_BADGE("startAccept")
+                                          << LOG_DESC("in-flight handshake timed out, close socket")
+                                          << LOG_KV("endpoint", socket->nodeIPEndpoint());
+                        socket->close();
+                    }
+                });
                 /// register ssl callback to get the NodeID of peers
                 std::shared_ptr<std::string> endpointPublicKey = std::make_shared<std::string>();
                 m_asioInterface->setVerifyCallback(socket, newVerifyCallback(endpointPublicKey));
                 m_asioInterface->asyncHandshake(socket, ba::ssl::stream_base::server,
-                    boost::bind(&Host::handshakeServer, shared_from_this(), ba::placeholders::error,
-                        endpointPublicKey, socket));
+                    [self = shared_from_this(), endpointPublicKey, socket, handshakeGuard,
+                        handshakeTimer](const boost::system::error_code& handshakeError) {
+                        handshakeTimer->cancel();
+                        self->handshakeServer(handshakeError, endpointPublicKey, socket);
+                    });
 
                 startAccept();
             },
@@ -411,6 +497,56 @@ void Host::releaseSessionSlot(std::string const& _address)
     {
         m_sessionCount.fetch_sub(1, std::memory_order_relaxed);
     }
+}
+
+// FIB-186: reserve an in-flight-handshake slot under the global cap. Returns false when the cap is
+// reached; the caller must then close the socket and re-arm accept without starting the (CPU-heavy)
+// TLS handshake. Uses a dedicated mutex so it does not contend with the session-cap path. Global
+// count only -- a per-IP cap is trivially bypassed by source-IP rotation (see Host.h).
+bool Host::tryAcquireHandshakeSlot()
+{
+    std::lock_guard<std::mutex> lock(x_pendingHandshakes);
+    if (m_pendingHandshakes.load(std::memory_order_relaxed) >= m_maxPendingHandshakes)
+    {
+        return false;
+    }
+    m_pendingHandshakes.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+// FIB-186: release a previously reserved handshake slot. Runs from the HandshakeSlotGuard bound to
+// the handshake completion handler, i.e. exactly once when the handshake finishes or is aborted.
+void Host::releaseHandshakeSlot()
+{
+    std::lock_guard<std::mutex> lock(x_pendingHandshakes);
+    if (m_pendingHandshakes.load(std::memory_order_relaxed) > 0)
+    {
+        m_pendingHandshakes.fetch_sub(1, std::memory_order_relaxed);
+    }
+}
+
+// FIB-186: token-bucket rate limiter for accepted new connections. Refills at
+// m_maxConnectionsPerSecond (also the burst cap), consumes one token per accepted connection, and
+// returns false once the bucket is empty so the caller drops the connection before the TLS
+// handshake. 0 = unlimited. Bounds handshake CPU per unit time (the concurrency caps do not).
+bool Host::tryAcquireConnectionToken()
+{
+    if (m_maxConnectionsPerSecond == 0)
+    {
+        return true;
+    }
+    std::lock_guard<std::mutex> lock(x_connectionRate);
+    auto now = std::chrono::steady_clock::now();
+    double elapsed = std::chrono::duration<double>(now - m_lastTokenRefill).count();
+    m_lastTokenRefill = now;
+    m_connectionTokens = std::min<double>(
+        m_maxConnectionsPerSecond, m_connectionTokens + elapsed * m_maxConnectionsPerSecond);
+    if (m_connectionTokens >= 1.0)
+    {
+        m_connectionTokens -= 1.0;
+        return true;
+    }
+    return false;
 }
 
 namespace

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -106,27 +106,38 @@ void Host::startAccept(boost::system::error_code boost_error)
                 // PBFT reads, halting consensus. Over the cap, drop the socket and re-arm accept
                 // without running the (CPU-heavy) TLS handshake.
                 std::string remoteAddress = socket->nodeIPEndpoint().address();
-                // FIB-186: rate-limit accepted connections before anything else, so a churn flood
-                // is dropped cheaply (accept + close) instead of paying the CPU-heavy TLS
-                // handshake. This bounds handshake CPU per unit time, which the concurrency caps
-                // below do not.
-                if (!tryAcquireConnectionToken())
-                {
-                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
-                                    << LOG_DESC("connection accept-rate limit reached, reject")
-                                    << LOG_KV("address", remoteAddress)
-                                    << LOG_KV("maxConnectionsPerSecond", m_maxConnectionsPerSecond);
-                    socket->close();
-                    startAccept();
-                    return;
-                }
+                // FIB-186: bound admission of new connections BEFORE the CPU-heavy TLS handshake,
+                // so connection churn from a low-trust peer cannot flood the shared I/O pool with
+                // accept / handshake / teardown work and starve inter-validator PBFT reads (the
+                // FIB-184 session caps apply only AFTER the handshake completes). Reserve the
+                // in-flight-handshake slot first because it is the refundable check: if the
+                // accept-rate limiter below then rejects, we release the slot and no rate token is
+                // spent. Checking the rate token first would instead waste a token whenever the
+                // handshake cap is already saturated, needlessly lowering the effective accept rate
+                // for legitimate peers arriving in that window.
                 if (!tryAcquireHandshakeSlot())
                 {
                     HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
                                     << LOG_DESC("pending-handshake cap reached, reject connection")
                                     << LOG_KV("address", remoteAddress)
-                                    << LOG_KV("pendingHandshakes", m_pendingHandshakes.load())
+                                    << LOG_KV("pendingHandshakes", currentPendingHandshakes())
                                     << LOG_KV("maxPendingHandshakes", m_maxPendingHandshakes);
+                    socket->close();
+                    startAccept();
+                    return;
+                }
+                // Accept-rate token bucket: drops a churn flood cheaply (accept + close) before
+                // paying handshake CPU, which the concurrency cap alone does not. On rejection the
+                // handshake slot reserved just above must be released so it is not leaked -- the
+                // HandshakeSlotGuard that normally releases it is only created once both checks
+                // pass.
+                if (!tryAcquireConnectionToken())
+                {
+                    releaseHandshakeSlot();
+                    HOST_LOG(DEBUG) << LOG_BADGE("startAccept")
+                                    << LOG_DESC("connection accept-rate limit reached, reject")
+                                    << LOG_KV("address", remoteAddress)
+                                    << LOG_KV("maxConnectionsPerSecond", m_maxConnectionsPerSecond);
                     socket->close();
                     startAccept();
                     return;
@@ -506,11 +517,11 @@ void Host::releaseSessionSlot(std::string const& _address)
 bool Host::tryAcquireHandshakeSlot()
 {
     std::lock_guard<std::mutex> lock(x_pendingHandshakes);
-    if (m_pendingHandshakes.load(std::memory_order_relaxed) >= m_maxPendingHandshakes)
+    if (m_pendingHandshakes >= m_maxPendingHandshakes)
     {
         return false;
     }
-    m_pendingHandshakes.fetch_add(1, std::memory_order_relaxed);
+    ++m_pendingHandshakes;
     return true;
 }
 
@@ -519,9 +530,9 @@ bool Host::tryAcquireHandshakeSlot()
 void Host::releaseHandshakeSlot()
 {
     std::lock_guard<std::mutex> lock(x_pendingHandshakes);
-    if (m_pendingHandshakes.load(std::memory_order_relaxed) > 0)
+    if (m_pendingHandshakes > 0)
     {
-        m_pendingHandshakes.fetch_sub(1, std::memory_order_relaxed);
+        --m_pendingHandshakes;
     }
 }
 
@@ -531,6 +542,8 @@ void Host::releaseHandshakeSlot()
 // handshake. 0 = unlimited. Bounds handshake CPU per unit time (the concurrency caps do not).
 bool Host::tryAcquireConnectionToken()
 {
+    // Lock-free read: m_maxConnectionsPerSecond is set once by GatewayFactory before start() (see
+    // setMaxConnectionsPerSecond), so no writer races with this fast-path check.
     if (m_maxConnectionsPerSecond == 0)
     {
         return true;

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -18,6 +18,7 @@
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/system/error_code.hpp>
 #include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -129,6 +130,65 @@ public:
     bool tryAcquireSessionSlot(std::string const& _address);
     void releaseSessionSlot(std::string const& _address);
 
+    // FIB-186: cap concurrent in-flight TLS handshakes (global). The FIB-184 session caps above
+    // apply only AFTER the handshake completes, so they do not bound accept / handshake / teardown
+    // work. Connection churn from a low-trust peer floods the shared I/O thread-pool with that work
+    // and starves inter-validator PBFT reads, halting consensus without any node crash. Bounding
+    // in-flight handshakes keeps the shared pool from saturating so consensus reads are not
+    // starved. GatewayFactory plumbs the configured value (p2p.max_pending_handshakes); this
+    // constant is the default when the config omits it.
+    //
+    // This is a GLOBAL cap, not per-IP: a per-IP cap only raises the bar from one source IP to a
+    // handful (any real churn attacker rotates source addresses), while risking false rejections of
+    // legitimate peers behind a shared egress IP (NAT / same datacenter). The global cap bounds the
+    // aggregate handshake work regardless of how the attacker spreads it across source IPs.
+    constexpr static std::size_t DEFAULT_MAX_PENDING_HANDSHAKES = 64;
+    // FIB-186: default inbound TLS handshake timeout (ms). Without a timeout a stalled / slow
+    // handshake never completes, so its admission slot is never released and (because the
+    // completion handler holds shared_from_this) this Host can never be destroyed. Bounding it lets
+    // a slow-loris peer hold at most this long before its slot is reclaimed. GatewayFactory plumbs
+    // the configured value (p2p.handshake_timeout_ms); this constant is the default when the config
+    // omits it.
+    constexpr static int DEFAULT_HANDSHAKE_TIMEOUT_MS = 10000;
+
+    std::size_t maxPendingHandshakes() const { return m_maxPendingHandshakes; }
+    void setMaxPendingHandshakes(std::size_t _limit) { m_maxPendingHandshakes = _limit; }
+    std::size_t currentPendingHandshakes() const { return m_pendingHandshakes.load(); }
+    int handshakeTimeout() const { return m_handshakeTimeout; }
+    void setHandshakeTimeout(int _timeoutMs) { m_handshakeTimeout = _timeoutMs; }
+
+    // FIB-186: reserve / release an in-flight-handshake slot. tryAcquire returns false (caller must
+    // close the socket and re-arm accept) when the global cap is reached. release runs from the
+    // HandshakeSlotGuard bound to the handshake completion handler, i.e. exactly once when the
+    // handshake finishes (success, failure, or abort).
+    bool tryAcquireHandshakeSlot();
+    void releaseHandshakeSlot();
+
+    // FIB-186: rate-limit accepted new connections (not just their concurrency). The pending-
+    // handshake cap above bounds how many handshakes run at once, but on a fast link a churn flood
+    // still cycles through the slots and consumes unbounded handshake CPU (asymmetric crypto). A
+    // token bucket refilled at m_maxConnectionsPerSecond bounds the accept RATE: over the limit the
+    // connection is dropped before the (CPU-heavy) TLS handshake. 0 = unlimited.
+    //
+    // Why the rate + concurrency caps are the fix, and NOT a dedicated acceptor thread-pool: a
+    // boost::asio SSL stream is welded to its io_context for life, so a connection's TLS handshake
+    // and the reads of the session that follows run on the SAME pool. An inbound churn connection
+    // and an inbound validator connection are indistinguishable at accept time (identity is only
+    // known after the handshake), so no pool assignment can separate "attacker handshake" from
+    // "validator consensus reads" -- they always land on the same pool. Splitting the acceptor onto
+    // its own pool only moves WHICH thread the handshake CPU lands on; it does not remove it from a
+    // thread that also carries consensus reads. Thread isolation is not CPU isolation: once that
+    // thread is saturated by handshake crypto the consensus reads sharing it are starved and
+    // consensus halts anyway -- a pool split merely delays the onset. The only effective lever is
+    // to stop the expensive handshake from running at all: reject churn cheaply BEFORE the
+    // handshake. Keeping this rate cap (and the concurrency cap) small enough that the admitted
+    // handshake CPU cannot saturate the pool is what actually prevents the halt; an acceptor pool
+    // would add code and config for no measurable protection (validated on a 3-node churn harness).
+    constexpr static uint32_t DEFAULT_MAX_CONNECTIONS_PER_SECOND = 100;
+    uint32_t maxConnectionsPerSecond() const { return m_maxConnectionsPerSecond; }
+    void setMaxConnectionsPerSecond(uint32_t _limit) { m_maxConnectionsPerSecond = _limit; }
+    bool tryAcquireConnectionToken();
+
 protected:
     /// obtain the common name from the subject:
     /// the subject format is: /CN=xx/O=xxx/OU=xxx/ commonly
@@ -205,6 +265,21 @@ protected:
     std::atomic<std::size_t> m_sessionCount{0};
     std::map<std::string, std::size_t> m_sessionCountPerIP;
     std::mutex x_sessionCountPerIP;
+
+    // FIB-186: in-flight-handshake accounting (dedicated mutex, separate from the session-cap
+    // path). Global count only -- see the comment on DEFAULT_MAX_PENDING_HANDSHAKES for why there
+    // is no per-IP cap.
+    std::size_t m_maxPendingHandshakes{DEFAULT_MAX_PENDING_HANDSHAKES};
+    std::atomic<std::size_t> m_pendingHandshakes{0};
+    std::mutex x_pendingHandshakes;
+    int m_handshakeTimeout{DEFAULT_HANDSHAKE_TIMEOUT_MS};
+
+    // FIB-186: token bucket for the new-connection accept rate (dedicated mutex). Starts full so a
+    // freshly-started node accepts an initial burst rather than rejecting the first connections.
+    uint32_t m_maxConnectionsPerSecond{DEFAULT_MAX_CONNECTIONS_PER_SECOND};
+    double m_connectionTokens{static_cast<double>(DEFAULT_MAX_CONNECTIONS_PER_SECOND)};
+    std::chrono::steady_clock::time_point m_lastTokenRefill{std::chrono::steady_clock::now()};
+    std::mutex x_connectionRate;
 };
 }  // namespace gateway
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -153,7 +153,11 @@ public:
 
     std::size_t maxPendingHandshakes() const { return m_maxPendingHandshakes; }
     void setMaxPendingHandshakes(std::size_t _limit) { m_maxPendingHandshakes = _limit; }
-    std::size_t currentPendingHandshakes() const { return m_pendingHandshakes.load(); }
+    std::size_t currentPendingHandshakes() const
+    {
+        std::lock_guard<std::mutex> lock(x_pendingHandshakes);
+        return m_pendingHandshakes;
+    }
     int handshakeTimeout() const { return m_handshakeTimeout; }
     void setHandshakeTimeout(int _timeoutMs) { m_handshakeTimeout = _timeoutMs; }
 
@@ -186,7 +190,17 @@ public:
     // would add code and config for no measurable protection (validated on a 3-node churn harness).
     constexpr static uint32_t DEFAULT_MAX_CONNECTIONS_PER_SECOND = 100;
     uint32_t maxConnectionsPerSecond() const { return m_maxConnectionsPerSecond; }
-    void setMaxConnectionsPerSecond(uint32_t _limit) { m_maxConnectionsPerSecond = _limit; }
+    // NOTE: this and the other cap setters are called by GatewayFactory during construction, before
+    // Host::start(), so they need no locking and tryAcquireConnectionToken()'s lock-free read of
+    // m_maxConnectionsPerSecond is race-free.
+    void setMaxConnectionsPerSecond(uint32_t _limit)
+    {
+        m_maxConnectionsPerSecond = _limit;
+        // Keep the token bucket consistent with the configured rate: m_connectionTokens is default-
+        // initialized to the compile-time default, so without this a non-default rate would start
+        // with the wrong burst capacity until the first refill (~1s).
+        m_connectionTokens = static_cast<double>(_limit);
+    }
     bool tryAcquireConnectionToken();
 
 protected:
@@ -270,8 +284,10 @@ protected:
     // path). Global count only -- see the comment on DEFAULT_MAX_PENDING_HANDSHAKES for why there
     // is no per-IP cap.
     std::size_t m_maxPendingHandshakes{DEFAULT_MAX_PENDING_HANDSHAKES};
-    std::atomic<std::size_t> m_pendingHandshakes{0};
-    std::mutex x_pendingHandshakes;
+    // Plain counter, not atomic: every access is under x_pendingHandshakes (the diagnostic getter
+    // currentPendingHandshakes() takes the mutex too), so an atomic would be redundant.
+    std::size_t m_pendingHandshakes{0};
+    mutable std::mutex x_pendingHandshakes;
     int m_handshakeTimeout{DEFAULT_HANDSHAKE_TIMEOUT_MS};
 
     // FIB-186: token bucket for the new-connection accept rate (dedicated mutex). Starts full so a

--- a/bcos-gateway/test/unittests/FIB186_HandshakeAdmissionTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_HandshakeAdmissionTest.cpp
@@ -1,0 +1,170 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression tests for FIB-186: cap concurrent in-flight TLS handshakes so connection churn
+ *        cannot starve the shared I/O pool that also delivers consensus messages.
+ * @file FIB186_HandshakeAdmissionTest.cpp
+ * @date 2026-07-07
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/SocketFace.h"
+#include "bcos-utilities/ThreadPool.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+using namespace bcos::crypto;
+
+namespace ba = boost::asio;
+
+BOOST_FIXTURE_TEST_SUITE(FIB186_HandshakeAdmissionTest, TestPromptFixture)
+
+class FakeASIO_FIB186 : public bcos::gateway::ASIOInterface
+{
+public:
+    FakeASIO_FIB186() : m_threadPool(std::make_shared<bcos::ThreadPool>("FakeASIO_FIB186", 1)) {}
+    ~FakeASIO_FIB186() noexcept override {}
+    void asyncReadSome(
+        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
+    {}
+    void strandPost(Base_Handler handler) override { m_handler = std::move(handler); }
+    void stop() override { m_threadPool->stop(); }
+
+protected:
+    Base_Handler m_handler;
+    bcos::ThreadPool::Ptr m_threadPool;
+};
+
+// Exposes the protected handshake-admission helpers for direct testing, mirroring the FIB-184
+// session-cap test harness.
+class FakeHost_FIB186 : public bcos::gateway::Host
+{
+public:
+    FakeHost_FIB186(bcos::crypto::Hash::Ptr _hash, std::shared_ptr<ASIOInterface> _asioInterface)
+      : Host(_hash, _asioInterface, nullptr, nullptr)
+    {
+        m_run = true;
+    }
+    bool callTryAcquireHandshakeSlot() { return tryAcquireHandshakeSlot(); }
+    void callReleaseHandshakeSlot() { releaseHandshakeSlot(); }
+};
+
+// FIB-186: the global concurrent-handshake cap rejects once the total limit is hit. It is global,
+// not per-IP: a churn attacker rotates source addresses, so a per-IP cap only raises the bar from
+// one IP to a handful while risking false rejections of legitimate peers behind a shared egress IP.
+BOOST_AUTO_TEST_CASE(GlobalHandshakeCapIsEnforced)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB186>();
+    auto fakeHost = std::make_shared<FakeHost_FIB186>(hashImpl, fakeAsio);
+
+    fakeHost->setMaxPendingHandshakes(2);
+
+    BOOST_CHECK(fakeHost->callTryAcquireHandshakeSlot());
+    BOOST_CHECK(fakeHost->callTryAcquireHandshakeSlot());
+    // global cap reached, the next handshake is rejected
+    BOOST_CHECK(!fakeHost->callTryAcquireHandshakeSlot());
+    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 2u);
+
+    fakeHost->callReleaseHandshakeSlot();
+    BOOST_CHECK(fakeHost->callTryAcquireHandshakeSlot());
+    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 2u);
+}
+
+// FIB-186: the RAII HandshakeSlotGuard pattern releases the slot exactly once when the handshake
+// completion handler is destroyed (success, failure, or abort). Mirrors how startAccept binds the
+// guard into the asyncHandshake completion handler.
+BOOST_AUTO_TEST_CASE(GuardReleasesSlotExactlyOnce)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB186>();
+    auto fakeHost = std::make_shared<FakeHost_FIB186>(hashImpl, fakeAsio);
+
+    BOOST_CHECK(fakeHost->callTryAcquireHandshakeSlot());
+    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 1u);
+
+    {
+        // A shared_ptr with a release-on-destroy deleter models the HandshakeSlotGuard riding the
+        // completion handler; when the last copy is destroyed the slot is released once.
+        std::weak_ptr<Host> weakHost = fakeHost;
+        auto guard = std::shared_ptr<void>(nullptr, [weakHost](void*) {
+            if (auto h = weakHost.lock())
+            {
+                std::static_pointer_cast<FakeHost_FIB186>(h)->callReleaseHandshakeSlot();
+            }
+        });
+        // Copying the handler (as asio may) must not double-release: release happens on final
+        // destruction of the shared guard, not per copy.
+        auto guardCopy = guard;
+        BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 1u);
+    }
+    // After the guard (and its copy) is destroyed, the slot is released exactly once.
+    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 0u);
+}
+
+// FIB-186: releasing an unknown / already-drained address never underflows the global counter.
+BOOST_AUTO_TEST_CASE(ReleaseNeverUnderflows)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB186>();
+    auto fakeHost = std::make_shared<FakeHost_FIB186>(hashImpl, fakeAsio);
+
+    fakeHost->callReleaseHandshakeSlot();  // release with no slot held
+    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 0u);
+
+    BOOST_CHECK(fakeHost->callTryAcquireHandshakeSlot());
+    fakeHost->callReleaseHandshakeSlot();
+    fakeHost->callReleaseHandshakeSlot();  // spurious extra release
+    BOOST_CHECK_EQUAL(fakeHost->currentPendingHandshakes(), 0u);
+}
+
+// FIB-186: the connection accept-rate token bucket bounds accepted connections per second. With a
+// rate cap, a tight burst of accepts is throttled once the bucket drains; with the cap disabled
+// (0) every accept passes. This bounds handshake CPU under churn, which the concurrency caps do
+// not.
+BOOST_AUTO_TEST_CASE(ConnectionRateLimitBoundsAcceptBurst)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO_FIB186>();
+    auto fakeHost = std::make_shared<FakeHost_FIB186>(hashImpl, fakeAsio);
+
+    // unlimited: every accept passes
+    fakeHost->setMaxConnectionsPerSecond(0);
+    for (int i = 0; i < 1000; ++i)
+    {
+        BOOST_CHECK(fakeHost->tryAcquireConnectionToken());
+    }
+
+    // bounded: a tight burst of 1000 accepts is throttled to roughly the bucket capacity, so far
+    // fewer than 1000 succeed (loose bounds keep this independent of wall-clock timing).
+    fakeHost->setMaxConnectionsPerSecond(10);
+    int granted = 0;
+    for (int i = 0; i < 1000; ++i)
+    {
+        if (fakeHost->tryAcquireConnectionToken())
+        {
+            ++granted;
+        }
+    }
+    BOOST_CHECK_GE(granted, 1);
+    BOOST_CHECK_LT(granted, 1000);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/GatewayConfigTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigTest.cpp
@@ -488,9 +488,11 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
         config->initP2PConfig(pt, false);
         BOOST_CHECK_EQUAL(config->maxConcurrentSessions(), 1024U);
         BOOST_CHECK_EQUAL(config->maxSessionsPerIP(), 32U);
-        // FIB-186: handshake admission cap + timeout defaults (global cap only, no per-IP)
+        // FIB-186: handshake admission cap + timeout + accept-rate defaults (global cap only, no
+        // per-IP)
         BOOST_CHECK_EQUAL(config->maxPendingHandshakes(), 64U);
         BOOST_CHECK_EQUAL(config->handshakeTimeout(), 10000);
+        BOOST_CHECK_EQUAL(config->maxConnectionsPerSecond(), 100U);
     }
     // parsed when present
     {
@@ -498,14 +500,25 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
         boost::property_tree::ptree pt;
         pt.put("p2p.max_concurrent_sessions", 256);
         pt.put("p2p.max_sessions_per_ip", 8);
-        // FIB-186: handshake admission cap + timeout are read from [p2p], not hardcoded
+        // FIB-186: handshake admission cap + timeout + accept rate are read from [p2p], not
+        // hardcoded
         pt.put("p2p.max_pending_handshakes", 16);
         pt.put("p2p.handshake_timeout_ms", 3000);
+        pt.put("p2p.max_connections_per_second", 50);
         config->initP2PConfig(pt, false);
         BOOST_CHECK_EQUAL(config->maxConcurrentSessions(), 256U);
         BOOST_CHECK_EQUAL(config->maxSessionsPerIP(), 8U);
         BOOST_CHECK_EQUAL(config->maxPendingHandshakes(), 16U);
         BOOST_CHECK_EQUAL(config->handshakeTimeout(), 3000);
+        BOOST_CHECK_EQUAL(config->maxConnectionsPerSecond(), 50U);
+    }
+    // FIB-186: 0 disables the accept-rate limiter (unlimited)
+    {
+        auto config = std::make_shared<GatewayConfig>();
+        boost::property_tree::ptree pt;
+        pt.put("p2p.max_connections_per_second", 0);
+        config->initP2PConfig(pt, false);
+        BOOST_CHECK_EQUAL(config->maxConnectionsPerSecond(), 0U);
     }
 }
 

--- a/bcos-gateway/test/unittests/GatewayConfigTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayConfigTest.cpp
@@ -488,6 +488,9 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
         config->initP2PConfig(pt, false);
         BOOST_CHECK_EQUAL(config->maxConcurrentSessions(), 1024U);
         BOOST_CHECK_EQUAL(config->maxSessionsPerIP(), 32U);
+        // FIB-186: handshake admission cap + timeout defaults (global cap only, no per-IP)
+        BOOST_CHECK_EQUAL(config->maxPendingHandshakes(), 64U);
+        BOOST_CHECK_EQUAL(config->handshakeTimeout(), 10000);
     }
     // parsed when present
     {
@@ -495,9 +498,14 @@ BOOST_AUTO_TEST_CASE(test_sessionCapsFromConfig)
         boost::property_tree::ptree pt;
         pt.put("p2p.max_concurrent_sessions", 256);
         pt.put("p2p.max_sessions_per_ip", 8);
+        // FIB-186: handshake admission cap + timeout are read from [p2p], not hardcoded
+        pt.put("p2p.max_pending_handshakes", 16);
+        pt.put("p2p.handshake_timeout_ms", 3000);
         config->initP2PConfig(pt, false);
         BOOST_CHECK_EQUAL(config->maxConcurrentSessions(), 256U);
         BOOST_CHECK_EQUAL(config->maxSessionsPerIP(), 8U);
+        BOOST_CHECK_EQUAL(config->maxPendingHandshakes(), 16U);
+        BOOST_CHECK_EQUAL(config->handshakeTimeout(), 3000);
     }
 }
 

--- a/tools/BcosBuilder/src/tpl/config.ini.gateway
+++ b/tools/BcosBuilder/src/tpl/config.ini.gateway
@@ -7,6 +7,16 @@
     nodes_file=nodes.json
     ; enable p2p ssl verify, default is true
     ; enable_ssl_verify = true
+    ; FIB-186: bound concurrent in-flight TLS handshakes (global) so connection churn from a low-trust
+    ; peer cannot saturate the shared I/O pool and starve consensus message delivery. Defaults shown.
+    ; max_pending_handshakes = 64
+    ; reclaim a stalled / slow handshake's admission slot after this many ms, default 10000
+    ; handshake_timeout_ms = 10000
+    ; FIB-186: cap accepted new connections per second to bound handshake CPU under connection
+    ; churn (0 = unlimited), default 100
+    ; max_connections_per_second = 100
+    ; threads for the P2P I/O pool, default 8
+    ; thread_count = 8
 
 [certificate_blacklist]
     ; crl.0 should be nodeid, nodeid's length is 512


### PR DESCRIPTION
## What

Connection churn from a low-trust peer opens and drops TLS connections faster than they complete, flooding the gateway's shared I/O thread-pool with accept / handshake / teardown work. That starves inter-validator PBFT reads on the same pool and halts consensus with no node crash and no recovery (CertiK FIB-186 — the residual of FIB-184 after #5313 fixed only the crash).

## Fix — handshake admission control

Bound the admission of new connections **before** the CPU-heavy TLS handshake runs, all configurable via `[p2p]` with safe defaults:

- **Global** concurrent in-flight handshake cap — `p2p.max_pending_handshakes` (64). Checked in `Host::startAccept` right after accept and before `asyncHandshake`; over the cap the socket is closed and accept is re-armed without running the handshake. A RAII `HandshakeSlotGuard` rides the handshake completion handler and releases the slot exactly once (success / failure / abort).
- **Accept-rate** token bucket — `p2p.max_connections_per_second` (100, 0 = unlimited). Rejects a churn flood cheaply (accept + close) before paying handshake CPU, which the concurrency cap alone does not.
- **Handshake timeout** — `p2p.handshake_timeout_ms` (10000). A `deadline_timer` on the socket's io_context closes a stalled / slow-loris handshake so its admission slot (and the Host kept alive by the completion handler) is reclaimed.

Also sizes the P2P I/O pool from `p2p.thread_count` (previously ignored — the pool was constructed with no args, always `hardware_concurrency()+1`).

## Why not I/O-plane isolation, and why the cap is global not per-IP

Earlier iterations of this PR split the acceptor onto a dedicated I/O pool and added a per-IP handshake cap. Both were **removed** after a 3-node churn harness disproved them:

- A `boost::asio` SSL stream is welded to its `io_context` for life, so a connection's handshake and the reads of the session that follows run on the same pool; and an inbound churn connection is indistinguishable from an inbound validator connection at accept time (identity is only known after the handshake). No pool assignment can separate attacker handshakes from validator consensus reads — a pool split only moves which thread the handshake CPU saturates. Thread isolation is not CPU isolation: once that thread saturates, consensus halts anyway (a split merely delays the onset). In the harness, with the admission caps on a dedicated acceptor pool made no measurable difference; with the caps off both the single-pool and the split-pool builds halted. The admission caps are what actually prevent the halt.
- A per-IP cap is trivially bypassed by source-IP rotation (it only raises the bar from one source IP to a handful) while risking false rejection of legitimate peers behind a shared egress IP (NAT / same datacenter). The global cap bounds aggregate handshake work regardless of how the attacker spreads it across source IPs.

## Testing

`ctest` on the gateway module: 62/62 green, including `FIB186_HandshakeAdmissionTest` (4 cases: global cap enforced, guard releases exactly once, release never underflows, accept-rate token bucket).
