### PR TITLE
feat(rpc): eth_getProof EIP-1186 endpoint (M8.3)

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/Proof.h
+++ b/bcos-ledger/bcos-ledger/mpt/Proof.h
@@ -322,20 +322,25 @@ template <bcos::crypto::hasher::Hasher HasherT>
 std::optional<bcos::bytes> verifyProofChain(bcos::h256 const& expectedRoot,
     std::span<bcos::bytes const> proofNodes, bcos::bytes const& path, HasherT& hasher)
 {
-    if (proofNodes.empty())
-    {
-        return std::nullopt;  // proving anything needs at least the root node
-    }
-    bcos::h256 expected = expectedRoot;
-    size_t idx = 0;                        // next proof item to consume
-    size_t pos = 0;                        // nibbles consumed so far
-    std::optional<bcos::bytes> concluded;  // set once the walk terminates
+    size_t idx = 0;  // next proof item to consume
+    size_t pos = 0;  // nibbles consumed so far
 
-    while (!concluded)
-    {
+    // A malformed node makes the chain invalid — never an escaping exception.
+    auto decodeChecked = [](bcos::bytesConstRef raw) -> std::optional<TrieNode> {
+        try
+        {
+            return decodeNode(raw);
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
+    };
+    // Consume the next proof item; it must hash to the pending reference.
+    auto takeNode = [&](bcos::h256 const& expected) -> std::optional<TrieNode> {
         if (idx >= proofNodes.size())
         {
-            return std::nullopt;  // a hash ref is pending but the proof ran out of items
+            return std::nullopt;  // dangling ref: the proof ran out of items
         }
         bcos::h256 got;
         bcos::crypto::hasher::hash(hasher, bcos::ref(proofNodes[idx]), got);
@@ -343,110 +348,74 @@ std::optional<bcos::bytes> verifyProofChain(bcos::h256 const& expectedRoot,
         {
             return std::nullopt;  // broken hash link
         }
-        TrieNode node;
-        try
+        return decodeChecked(bcos::ref(proofNodes[idx++]));
+    };
+    // Every terminal exit: the result only stands if the proof was consumed exactly
+    // (trailing items = padded proof, rejected).
+    auto finish = [&](bcos::bytes value) -> std::optional<bcos::bytes> {
+        if (idx != proofNodes.size())
         {
-            node = decodeNode(bcos::ref(proofNodes[idx]));
+            return std::nullopt;
         }
-        catch (...)
-        {
-            return std::nullopt;  // malformed node: invalid, never an escaping exception
-        }
-        ++idx;
+        return value;
+    };
 
-        // Descend through this proof item, expanding inline children embedded in it, until the
-        // walk terminates or reaches the next hash-referenced node.
-        bool needNextItem = false;
-        while (!needNextItem && !concluded)
-        {
-            if (std::holds_alternative<EmptyNode>(node))
-            {
-                concluded.emplace();  // dead end: exclusion
-                break;
-            }
-            if (auto const* leaf = std::get_if<LeafNode>(&node))
-            {
-                if (path.size() - pos == leaf->keyNibbles.size() &&
-                    std::equal(
-                        leaf->keyNibbles.begin(), leaf->keyNibbles.end(), path.begin() + pos))
-                {
-                    concluded = leaf->value;
-                }
-                else
-                {
-                    concluded.emplace();  // diverging leaf: exclusion
-                }
-                break;
-            }
-            if (auto const* ext = std::get_if<ExtensionNode>(&node))
-            {
-                if (path.size() - pos < ext->sharedNibbles.size() ||
-                    !std::equal(
-                        ext->sharedNibbles.begin(), ext->sharedNibbles.end(), path.begin() + pos))
-                {
-                    concluded.emplace();  // path diverges inside the extension: exclusion
-                    break;
-                }
-                pos += ext->sharedNibbles.size();
-                if (ext->child.size() == HASH_REF_ENCODED_SIZE &&
-                    ext->child[0] == RLP_HASH_REF_PREFIX)
-                {
-                    expected = bcos::h256(ext->child.data() + 1, bcos::h256::SIZE);
-                    needNextItem = true;
-                }
-                else
-                {
-                    TrieNode next;
-                    try
-                    {
-                        next = decodeNode(bcos::ref(ext->child));
-                    }
-                    catch (...)
-                    {
-                        return std::nullopt;
-                    }
-                    node = std::move(next);
-                }
-                continue;
-            }
-            auto const& branch = std::get<BranchNode>(node);
-            if (pos == path.size())
-            {
-                concluded = branch.value;  // empty branch value = exclusion
-                break;
-            }
-            NodeRef const& child = branch.children.at(path.at(pos));
-            ++pos;
-            if (child.kind == NodeRef::Kind::Hash)
-            {
-                expected = child.hash;
-                needNextItem = true;
-            }
-            else if (child.inlineBytes.empty())
-            {
-                concluded.emplace();  // absent child: exclusion
-            }
-            else
-            {
-                TrieNode next;
-                try
-                {
-                    next = decodeNode(bcos::ref(child.inlineBytes));
-                }
-                catch (...)
-                {
-                    return std::nullopt;
-                }
-                node = std::move(next);
-            }
-        }
-    }
-
-    if (idx != proofNodes.size())
+    // One loop over a single "current node" state; the loop body only answers "where does
+    // the next node come from" — a hash ref advances via takeNode (consumes a proof item),
+    // an inline child via decodeChecked on the bytes embedded in the current item. Any
+    // failure empties node and the loop exits. Lambda return values materialize before the
+    // assignment overwrites node, so decoding an inline child that lives inside the current
+    // variant is safe by construction (proofWalk needs a comment to enforce the same).
+    auto node = takeNode(expectedRoot);
+    while (node)
     {
-        return std::nullopt;  // trailing unused items: reject padded proofs
+        if (std::holds_alternative<EmptyNode>(*node))
+        {
+            return finish({});  // dead end: exclusion
+        }
+        if (auto const* leaf = std::get_if<LeafNode>(&*node))
+        {
+            bool const match =
+                path.size() - pos == leaf->keyNibbles.size() &&
+                std::equal(leaf->keyNibbles.begin(), leaf->keyNibbles.end(), path.begin() + pos);
+            return finish(match ? leaf->value : bcos::bytes{});  // value, or a diverging leaf
+        }
+        if (auto const* ext = std::get_if<ExtensionNode>(&*node))
+        {
+            if (path.size() - pos < ext->sharedNibbles.size() ||
+                !std::equal(
+                    ext->sharedNibbles.begin(), ext->sharedNibbles.end(), path.begin() + pos))
+            {
+                return finish({});  // path diverges inside the extension: exclusion
+            }
+            pos += ext->sharedNibbles.size();
+            node = (ext->child.size() == HASH_REF_ENCODED_SIZE &&
+                       ext->child[0] == RLP_HASH_REF_PREFIX) ?
+                       takeNode(bcos::h256(ext->child.data() + 1, bcos::h256::SIZE)) :
+                       decodeChecked(bcos::ref(ext->child));  // inline child: same proof item
+            continue;
+        }
+        auto const& branch = std::get<BranchNode>(*node);
+        if (pos == path.size())
+        {
+            return finish(branch.value);  // path exhausted at a branch (empty = exclusion)
+        }
+        NodeRef const& child = branch.children.at(path.at(pos));
+        ++pos;
+        if (child.kind == NodeRef::Kind::Hash)
+        {
+            node = takeNode(child.hash);
+        }
+        else if (child.inlineBytes.empty())
+        {
+            return finish({});  // absent child: exclusion
+        }
+        else
+        {
+            node = decodeChecked(bcos::ref(child.inlineBytes));
+        }
     }
-    return concluded;
+    return std::nullopt;  // hash mismatch, malformed node, or dangling ref
 }
 }  // namespace detail
 

--- a/bcos-ledger/bcos-ledger/mpt/Proof.h
+++ b/bcos-ledger/bcos-ledger/mpt/Proof.h
@@ -24,6 +24,7 @@
 #include "MPTReadView.h"
 #include "Nibble.h"
 #include "NodeDecoder.h"
+#include "StorageValueCodec.h"
 #include "TrieNode.h"
 // AnyHasher.h defines the free bcos::crypto::hasher::hash(); OpenSSLHasher.h only defines the
 // hasher type. A unity build can mask a missing include of the former, so keep both explicit.
@@ -42,32 +43,6 @@
 
 namespace bcos::ledger::mpt
 {
-namespace detail
-{
-/// The "secure trie" key transform for storage slots: hash of the raw 32-byte slot key
-/// (keccak256 on Ethereum-compatible chains, SM3 on guomi ones — whatever @p hasher computes).
-/// Mirrors accountKeyHash (MPTReadView.h) for the account trie (spec §5.9).
-/// Kept in detail with the SAME signature as #5310's shared mpt::slotKeyHash
-/// (StorageValueCodec.h) — once both land, this duplicate folds into it mechanically.
-/// detail scoping avoids an ODR clash meanwhile.
-///
-/// Hasher-injection form: the caller owns @p hasher and reuses it across calls
-/// (generateProof hashes one slot key per requested slot).
-template <bcos::crypto::hasher::Hasher HasherT>
-bcos::h256 slotKeyHash(bcos::h256 const& slot, HasherT& hasher)
-{
-    bcos::h256 out;
-    bcos::crypto::hasher::hash(hasher, slot.ref(), out);
-    return out;
-}
-
-/// Convenience overload constructing a fresh keccak256 hasher per call (tests, one-off use).
-inline bcos::h256 slotKeyHash(bcos::h256 const& slot)
-{
-    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
-    return slotKeyHash(slot, hasher);
-}
-}  // namespace detail
 
 /// Proof for one storage slot (spec §5.9). For an absent slot, EIP-1186 semantics apply: value is
 /// empty (JSON 0x0) and proof holds the nodes visited until the walk dead-ended (exclusion proof).
@@ -288,7 +263,7 @@ bcos::task::Task<std::variant<EIP1186Proof, ProofErrorCode>> generateProof(Stora
         entry.key = slot;
         if (account.storageRoot != emptyRootHash())
         {
-            auto const slotHash = detail::slotKeyHash(slot, hasher);
+            auto const slotHash = slotKeyHash(slot, hasher);
             auto slotWalk = co_await detail::proofWalk(
                 storage, account.storageRoot, bytesToNibbles(slotHash.ref()));
             if (slotWalk.rootMissing)
@@ -309,6 +284,247 @@ bcos::task::Task<std::variant<EIP1186Proof, ProofErrorCode>> generateProof(Stora
         out.storageProof.push_back(std::move(entry));
     }
     co_return out;
+}
+
+/// Result of independently verifying an EIP1186Proof against a claimed state root (spec §7.1).
+/// The recovered* fields are what the proof bytes actually commit to; they are only filled when
+/// the account chain verified AND matched the proof's claimed top-level fields.
+struct VerifyResult
+{
+    bool accountValid = false;
+    bcos::u256 recoveredBalance{};
+    bcos::u256 recoveredNonce{};
+    bcos::h256 recoveredCodeHash{};
+    bcos::h256 recoveredStorageRoot{};
+    std::vector<bool> storageValid;  ///< parallel to proof.storageProof
+    /// Raw leaf value bytes recovered from each slot's chain (empty = proven absent). Filled only
+    /// for slots whose hash chain verified.
+    std::vector<bcos::bytes> recoveredStorageValues;
+};
+
+namespace detail
+{
+/// Verify one root→leaf hash chain using ONLY @p proofNodes — no storage access. Re-derives every
+/// hash link: proofNodes[0] must hash to @p expectedRoot, and each hash reference encountered
+/// along @p path must match the hash of the next consumed proof item. Inline children are decoded
+/// in place without consuming an item, mirroring how generateProof embeds them.
+///
+/// This walk is deliberately independent of proofWalk (spec §7.1 cross-validation): the two share
+/// only the low-level decode helpers (decodeNode, nibble utils), so a traversal bug in one cannot
+/// hide in the other.
+///
+/// @param path the full nibble path of the key being proven (64 nibbles for 32-byte key hashes)
+/// @return nullopt   → the chain is INVALID (hash mismatch, malformed node, dangling hash ref,
+///                     or trailing unused proof items — padded proofs are rejected)
+///         empty     → valid EXCLUSION proof: the walk dead-ends, the key is absent
+///         non-empty → the proven leaf/branch value
+template <bcos::crypto::hasher::Hasher HasherT>
+std::optional<bcos::bytes> verifyProofChain(bcos::h256 const& expectedRoot,
+    std::span<bcos::bytes const> proofNodes, bcos::bytes const& path, HasherT& hasher)
+{
+    if (proofNodes.empty())
+    {
+        return std::nullopt;  // proving anything needs at least the root node
+    }
+    bcos::h256 expected = expectedRoot;
+    size_t idx = 0;                        // next proof item to consume
+    size_t pos = 0;                        // nibbles consumed so far
+    std::optional<bcos::bytes> concluded;  // set once the walk terminates
+
+    while (!concluded)
+    {
+        if (idx >= proofNodes.size())
+        {
+            return std::nullopt;  // a hash ref is pending but the proof ran out of items
+        }
+        bcos::h256 got;
+        bcos::crypto::hasher::hash(hasher, bcos::ref(proofNodes[idx]), got);
+        if (got != expected)
+        {
+            return std::nullopt;  // broken hash link
+        }
+        TrieNode node;
+        try
+        {
+            node = decodeNode(bcos::ref(proofNodes[idx]));
+        }
+        catch (...)
+        {
+            return std::nullopt;  // malformed node: invalid, never an escaping exception
+        }
+        ++idx;
+
+        // Descend through this proof item, expanding inline children embedded in it, until the
+        // walk terminates or reaches the next hash-referenced node.
+        bool needNextItem = false;
+        while (!needNextItem && !concluded)
+        {
+            if (std::holds_alternative<EmptyNode>(node))
+            {
+                concluded.emplace();  // dead end: exclusion
+                break;
+            }
+            if (auto const* leaf = std::get_if<LeafNode>(&node))
+            {
+                if (path.size() - pos == leaf->keyNibbles.size() &&
+                    std::equal(
+                        leaf->keyNibbles.begin(), leaf->keyNibbles.end(), path.begin() + pos))
+                {
+                    concluded = leaf->value;
+                }
+                else
+                {
+                    concluded.emplace();  // diverging leaf: exclusion
+                }
+                break;
+            }
+            if (auto const* ext = std::get_if<ExtensionNode>(&node))
+            {
+                if (path.size() - pos < ext->sharedNibbles.size() ||
+                    !std::equal(
+                        ext->sharedNibbles.begin(), ext->sharedNibbles.end(), path.begin() + pos))
+                {
+                    concluded.emplace();  // path diverges inside the extension: exclusion
+                    break;
+                }
+                pos += ext->sharedNibbles.size();
+                if (ext->child.size() == HASH_REF_ENCODED_SIZE &&
+                    ext->child[0] == RLP_HASH_REF_PREFIX)
+                {
+                    expected = bcos::h256(ext->child.data() + 1, bcos::h256::SIZE);
+                    needNextItem = true;
+                }
+                else
+                {
+                    TrieNode next;
+                    try
+                    {
+                        next = decodeNode(bcos::ref(ext->child));
+                    }
+                    catch (...)
+                    {
+                        return std::nullopt;
+                    }
+                    node = std::move(next);
+                }
+                continue;
+            }
+            auto const& branch = std::get<BranchNode>(node);
+            if (pos == path.size())
+            {
+                concluded = branch.value;  // empty branch value = exclusion
+                break;
+            }
+            NodeRef const& child = branch.children.at(path.at(pos));
+            ++pos;
+            if (child.kind == NodeRef::Kind::Hash)
+            {
+                expected = child.hash;
+                needNextItem = true;
+            }
+            else if (child.inlineBytes.empty())
+            {
+                concluded.emplace();  // absent child: exclusion
+            }
+            else
+            {
+                TrieNode next;
+                try
+                {
+                    next = decodeNode(bcos::ref(child.inlineBytes));
+                }
+                catch (...)
+                {
+                    return std::nullopt;
+                }
+                node = std::move(next);
+            }
+        }
+    }
+
+    if (idx != proofNodes.size())
+    {
+        return std::nullopt;  // trailing unused items: reject padded proofs
+    }
+    return concluded;
+}
+}  // namespace detail
+
+/// Independently verify an EIP-1186 proof against @p claimedRoot (spec §7.1). Pure and
+/// synchronous: consumes ONLY the proof byte arrays — never storage — and re-derives every hash
+/// link via detail::verifyProofChain, the deliberate second implementation cross-validating
+/// generateProof's proofWalk.
+///
+/// accountValid requires all of: the account chain anchors at @p claimedRoot, ends at a present
+/// account leaf, the leaf decodes, and the decoded fields EQUAL the proof's claimed
+/// nonce/balance/codeHash/storageHash. Malformed leaf bytes yield accountValid=false, never an
+/// exception. On any account-side failure the function returns immediately with every
+/// storageValid false — slot chains hang off proof.storageHash, which an invalid account side
+/// has not established.
+///
+/// Per slot i: against an empty storage root, valid iff value and proof are both empty (matching
+/// generateProof's empty-trie output); otherwise the slot chain must verify against
+/// proof.storageHash and its recovered value must equal storageProof[i].value (empty = proven
+/// absence).
+template <
+    bcos::crypto::hasher::Hasher HasherT = bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher>
+VerifyResult verifyProof(bcos::h256 claimedRoot, EIP1186Proof const& proof)
+{
+    VerifyResult out;
+    out.storageValid.assign(proof.storageProof.size(), false);
+    out.recoveredStorageValues.assign(proof.storageProof.size(), bcos::bytes{});
+
+    HasherT hasher;  // one hash context, reused for the account chain and every slot
+    auto const accountPath = bytesToNibbles(accountKeyHash(proof.address).ref());
+    auto const accountLeaf = detail::verifyProofChain(
+        claimedRoot, std::span<bcos::bytes const>(proof.accountProof), accountPath, hasher);
+    if (!accountLeaf || accountLeaf->empty())
+    {
+        // Invalid chain, or an exclusion: an EIP-1186 proof for a present account must contain
+        // the account leaf.
+        return out;
+    }
+
+    Account decoded;
+    try
+    {
+        decoded = Account::decode(bcos::ref(*accountLeaf));
+    }
+    catch (...)
+    {
+        return out;  // malformed account leaf: invalid, never an escaping exception
+    }
+    if (decoded.nonce != proof.nonce || decoded.balance != proof.balance ||
+        decoded.codeHash != proof.codeHash || decoded.storageRoot != proof.storageHash)
+    {
+        return out;  // the chain proves a DIFFERENT account state than the proof claims
+    }
+    out.accountValid = true;
+    out.recoveredNonce = decoded.nonce;
+    out.recoveredBalance = decoded.balance;
+    out.recoveredCodeHash = decoded.codeHash;
+    out.recoveredStorageRoot = decoded.storageRoot;
+
+    for (size_t i = 0; i < proof.storageProof.size(); ++i)
+    {
+        auto const& entry = proof.storageProof[i];
+        if (proof.storageHash == emptyRootHash<HasherT>())
+        {
+            // Empty storage trie: generateProof emits empty value + empty proof for every slot.
+            out.storageValid[i] = entry.value.empty() && entry.proof.empty();
+            continue;
+        }
+        auto const slotPath = bytesToNibbles(slotKeyHash(entry.key, hasher).ref());
+        auto recovered = detail::verifyProofChain(
+            proof.storageHash, std::span<bcos::bytes const>(entry.proof), slotPath, hasher);
+        if (!recovered)
+        {
+            continue;  // invalid slot chain: storageValid[i] stays false
+        }
+        out.recoveredStorageValues[i] = std::move(*recovered);
+        out.storageValid[i] = (out.recoveredStorageValues[i] == entry.value);
+    }
+    return out;
 }
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
@@ -26,6 +26,7 @@
 #include <bcos-ledger/mpt/MPTReadView.h>
 #include <bcos-ledger/mpt/NodeDecoder.h>
 #include <bcos-ledger/mpt/Proof.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
 #include <bcos-task/Task.h>
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/Common.h>
@@ -266,8 +267,8 @@ BOOST_AUTO_TEST_CASE(StorageSlotProofsIncludingExclusion)
 
     // Build the storage trie into the SAME node storage; its root becomes account.storageRoot.
     HashBuilder storageTrieBuilder(storage, emptyRootHash());
-    bcos::task::syncWait(storageTrieBuilder.put(detail::slotKeyHash(slotA), valueA));
-    bcos::task::syncWait(storageTrieBuilder.put(detail::slotKeyHash(slotB), valueB));
+    bcos::task::syncWait(storageTrieBuilder.put(slotKeyHash(slotA), valueA));
+    bcos::task::syncWait(storageTrieBuilder.put(slotKeyHash(slotB), valueB));
     auto const storageRoot = bcos::task::syncWait(storageTrieBuilder.commit());
 
     bcos::Address const addr = makeAddress(0xab);
@@ -291,8 +292,7 @@ BOOST_AUTO_TEST_CASE(StorageSlotProofsIncludingExclusion)
         auto const& entry = proof.storageProof.at(i);
         BOOST_CHECK_EQUAL(entry.key, slots.at(i));
         BOOST_CHECK(entry.value == (i == 0 ? valueA : valueB));
-        auto const check =
-            verifyProofChain(entry.proof, storageRoot, detail::slotKeyHash(entry.key));
+        auto const check = verifyProofChain(entry.proof, storageRoot, slotKeyHash(entry.key));
         BOOST_CHECK(check.hashChainOk);
         BOOST_CHECK(check.allNodesUsed);
         BOOST_REQUIRE(check.value.has_value());
@@ -304,8 +304,7 @@ BOOST_AUTO_TEST_CASE(StorageSlotProofsIncludingExclusion)
     BOOST_CHECK_EQUAL(absent.key, slotMissing);
     BOOST_CHECK(absent.value.empty());
     BOOST_CHECK(!absent.proof.empty());
-    auto const check =
-        verifyProofChain(absent.proof, storageRoot, detail::slotKeyHash(slotMissing));
+    auto const check = verifyProofChain(absent.proof, storageRoot, slotKeyHash(slotMissing));
     BOOST_CHECK(check.hashChainOk);
     BOOST_CHECK(check.allNodesUsed);
     BOOST_CHECK(!check.value.has_value());
@@ -348,11 +347,11 @@ BOOST_AUTO_TEST_CASE(HasherParameterizationKeepsSm3Possible)
 
     bcos::h256 const slot = makeHash(0x01);
     bcos::crypto::hasher::openssl::OpenSSL_SM3_Hasher sm3;
-    auto const sm3Key = detail::slotKeyHash(slot, sm3);
-    BOOST_CHECK(sm3Key != detail::slotKeyHash(slot));  // keccak default != SM3 injection
+    auto const sm3Key = slotKeyHash(slot, sm3);
+    BOOST_CHECK(sm3Key != slotKeyHash(slot));  // keccak default != SM3 injection
 
     bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher keccakHasher;
-    BOOST_CHECK(detail::slotKeyHash(slot, keccakHasher) == detail::slotKeyHash(slot));
+    BOOST_CHECK(slotKeyHash(slot, keccakHasher) == slotKeyHash(slot));
 }
 
 // Generating the same proof twice yields byte-identical output.
@@ -363,7 +362,7 @@ BOOST_AUTO_TEST_CASE(DeterministicOutput)
     bcos::bytes const slotValue{0x2a};
 
     HashBuilder storageTrieBuilder(storage, emptyRootHash());
-    bcos::task::syncWait(storageTrieBuilder.put(detail::slotKeyHash(slot), slotValue));
+    bcos::task::syncWait(storageTrieBuilder.put(slotKeyHash(slot), slotValue));
     auto const storageRoot = bcos::task::syncWait(storageTrieBuilder.commit());
 
     std::vector<std::pair<bcos::Address, Account>> accounts;

--- a/bcos-ledger/test/unittests/mpt/ProofVerifyTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofVerifyTest.cpp
@@ -1,0 +1,251 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ProofVerifyTest.cpp
+ * @brief Cross-validation of generateProof against the independent verifyProof
+ *        (spec §5.9, §7.1)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/MPTReadView.h>
+#include <bcos-ledger/mpt/Proof.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-task/Task.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <span>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+// Helper names carry a Verify prefix/suffix: the unity build can merge this file and
+// ProofGenerateTest.cpp into one TU, fusing their unnamed namespaces.
+using VerifyMemStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
+
+namespace
+{
+
+/// Build a state trie holding @p accounts into @p storage; returns the state root.
+bcos::h256 buildVerifyStateTrie(
+    VerifyMemStorage& storage, std::vector<std::pair<bcos::Address, Account>> const& accounts)
+{
+    HashBuilder builder(storage, emptyRootHash());
+    for (auto const& [addr, account] : accounts)
+    {
+        bcos::task::syncWait(builder.put(accountKeyHash(addr), account.encode()));
+    }
+    return bcos::task::syncWait(builder.commit());
+}
+
+/// A generated proof plus the state root it was generated against.
+struct ProofSetup
+{
+    bcos::h256 stateRoot;
+    EIP1186Proof proof;
+};
+
+/// One account (nonce 7, balance 4242) whose storage trie holds @p slotValues; generates the
+/// EIP-1186 proof for the account and @p requestSlots.
+ProofSetup makeAccountWithSlots(std::vector<std::pair<bcos::h256, bcos::bytes>> const& slotValues,
+    std::vector<bcos::h256> const& requestSlots)
+{
+    VerifyMemStorage storage;
+    bcos::Address const addr = makeAddress(0xab);
+    Account account;
+    account.nonce = 7;
+    account.balance = 4242;
+    if (!slotValues.empty())
+    {
+        HashBuilder storageTrieBuilder(storage, emptyRootHash());
+        for (auto const& [slot, value] : slotValues)
+        {
+            bcos::task::syncWait(storageTrieBuilder.put(slotKeyHash(slot), value));
+        }
+        account.storageRoot = bcos::task::syncWait(storageTrieBuilder.commit());
+    }
+    auto const stateRoot = buildVerifyStateTrie(storage, {{addr, account}});
+
+    auto result = bcos::task::syncWait(
+        generateProof(storage, stateRoot, addr, std::span<bcos::h256 const>(requestSlots)));
+    BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(result));
+    return ProofSetup{stateRoot, std::get<EIP1186Proof>(std::move(result))};
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(ProofVerifySuite)
+
+// The generate → verify round trip through two independent implementations: verifyProof reads
+// only the proof byte arrays (never storage) and must accept what generateProof emitted.
+BOOST_AUTO_TEST_CASE(GeneratedProofPassesIndependentVerifier)
+{
+    bcos::h256 const slot = makeHash(0x01);
+    auto const setup = makeAccountWithSlots({{slot, bcos::bytes{0x2a}}}, {slot});
+
+    auto const res = verifyProof(setup.stateRoot, setup.proof);
+    BOOST_CHECK(res.accountValid);
+    BOOST_CHECK_EQUAL(res.recoveredNonce, setup.proof.nonce);
+    BOOST_CHECK_EQUAL(res.recoveredBalance, setup.proof.balance);
+    BOOST_CHECK_EQUAL(res.recoveredCodeHash, setup.proof.codeHash);
+    BOOST_CHECK_EQUAL(res.recoveredStorageRoot, setup.proof.storageHash);
+    BOOST_REQUIRE_EQUAL(res.storageValid.size(), 1);
+    BOOST_CHECK(res.storageValid.at(0));
+    BOOST_REQUIRE_EQUAL(res.recoveredStorageValues.size(), 1);
+    BOOST_CHECK(res.recoveredStorageValues.at(0) == setup.proof.storageProof.at(0).value);
+}
+
+// One flipped byte anywhere in a proof node breaks its hash link. Account-side tampering kills
+// accountValid; storage-side tampering kills only that slot while the account side stays valid.
+BOOST_AUTO_TEST_CASE(TamperedProofFailsVerification)
+{
+    bcos::h256 const slot = makeHash(0x01);
+    auto const setup = makeAccountWithSlots({{slot, bcos::bytes{0x2a}}}, {slot});
+
+    {
+        auto tampered = setup.proof;
+        BOOST_REQUIRE(!tampered.accountProof.empty());
+        tampered.accountProof.at(0).at(5) ^= 0x01;
+        auto const res = verifyProof(setup.stateRoot, tampered);
+        BOOST_CHECK(!res.accountValid);
+    }
+    {
+        auto tampered = setup.proof;
+        BOOST_REQUIRE(!tampered.storageProof.at(0).proof.empty());
+        tampered.storageProof.at(0).proof.at(0).at(5) ^= 0x01;
+        auto const res = verifyProof(setup.stateRoot, tampered);
+        BOOST_CHECK(res.accountValid);
+        BOOST_REQUIRE_EQUAL(res.storageValid.size(), 1);
+        BOOST_CHECK(!res.storageValid.at(0));
+    }
+}
+
+// An untampered proof presented against a different root cannot anchor its first node.
+BOOST_AUTO_TEST_CASE(WrongStateRootFailsVerification)
+{
+    auto const setup = makeAccountWithSlots({}, {});
+    auto const res = verifyProof(makeHash(0x99), setup.proof);
+    BOOST_CHECK(!res.accountValid);
+}
+
+// Proof bytes intact, but the claimed top-level field disagrees with the account leaf the chain
+// actually proves: the field-consistency check must reject it.
+BOOST_AUTO_TEST_CASE(TamperedFieldFailsVerification)
+{
+    auto const setup = makeAccountWithSlots({}, {});
+    auto tampered = setup.proof;
+    tampered.balance += 1;
+    auto const res = verifyProof(setup.stateRoot, tampered);
+    BOOST_CHECK(!res.accountValid);
+
+    // Sanity: the unmodified proof passes.
+    BOOST_CHECK(verifyProof(setup.stateRoot, setup.proof).accountValid);
+}
+
+// Ten present slots all verify with non-empty recovered values; a requested ABSENT slot yields a
+// verifying exclusion (storageValid true, recovered value empty).
+BOOST_AUTO_TEST_CASE(MultiSlotProofAllVerify)
+{
+    std::vector<std::pair<bcos::h256, bcos::bytes>> slotValues;
+    std::vector<bcos::h256> request;
+    for (uint8_t i = 1; i <= 10; ++i)
+    {
+        // Single bytes < 0x80: each is its own one-byte RLP encoding, like the stored leaf form.
+        slotValues.emplace_back(makeHash(i), bcos::bytes{static_cast<bcos::byte>(0x20 + i)});
+        request.push_back(makeHash(i));
+    }
+    bcos::h256 const absentSlot = makeHash(0x77);
+    request.push_back(absentSlot);
+
+    auto const setup = makeAccountWithSlots(slotValues, request);
+    auto const res = verifyProof(setup.stateRoot, setup.proof);
+    BOOST_CHECK(res.accountValid);
+    BOOST_REQUIRE_EQUAL(res.storageValid.size(), 11);
+    BOOST_REQUIRE_EQUAL(res.recoveredStorageValues.size(), 11);
+    for (size_t i = 0; i < 10; ++i)
+    {
+        BOOST_CHECK(res.storageValid.at(i));
+        BOOST_CHECK(!res.recoveredStorageValues.at(i).empty());
+        BOOST_CHECK(res.recoveredStorageValues.at(i) == setup.proof.storageProof.at(i).value);
+    }
+    BOOST_CHECK(res.storageValid.at(10));
+    BOOST_CHECK(res.recoveredStorageValues.at(10).empty());
+}
+
+// A slot requested on an account whose storage trie is EMPTY: generateProof emits empty value +
+// empty proof, and the verifier accepts exactly that shape (and only that shape).
+BOOST_AUTO_TEST_CASE(EmptyStorageTrieSlotVerifies)
+{
+    auto const setup = makeAccountWithSlots({}, {makeHash(0x05)});
+    BOOST_REQUIRE_EQUAL(setup.proof.storageProof.size(), 1);
+    BOOST_CHECK(setup.proof.storageProof.at(0).value.empty());
+    BOOST_CHECK(setup.proof.storageProof.at(0).proof.empty());
+
+    auto const res = verifyProof(setup.stateRoot, setup.proof);
+    BOOST_CHECK(res.accountValid);
+    BOOST_REQUIRE_EQUAL(res.storageValid.size(), 1);
+    BOOST_CHECK(res.storageValid.at(0));
+    BOOST_CHECK(res.recoveredStorageValues.at(0).empty());
+
+    // A claimed value against the empty storage root is unprovable and must be rejected.
+    auto tampered = setup.proof;
+    tampered.storageProof.at(0).value = bcos::bytes{0x2a};
+    BOOST_CHECK(!verifyProof(setup.stateRoot, tampered).storageValid.at(0));
+}
+
+// A dormant (never-written) account has no leaf to prove: the boundary is documented at the
+// generate level — generateProof refuses with AccountNotInMPT, so no proof reaches the verifier.
+BOOST_AUTO_TEST_CASE(ExclusionAtGenerateLevel)
+{
+    VerifyMemStorage storage;
+    Account account;
+    account.nonce = 1;
+    auto const stateRoot = buildVerifyStateTrie(storage, {{makeAddress(0xab), account}});
+
+    auto missing = bcos::task::syncWait(
+        generateProof(storage, stateRoot, makeAddress(0xcd), std::span<bcos::h256 const>{}));
+    BOOST_REQUIRE(std::holds_alternative<ProofErrorCode>(missing));
+    BOOST_CHECK(std::get<ProofErrorCode>(missing) == ProofErrorCode::AccountNotInMPT);
+}
+
+// Extra trailing nodes after the walk concluded must be rejected: a padded proof is not the
+// minimal chain the root committed to.
+BOOST_AUTO_TEST_CASE(PaddedProofRejected)
+{
+    auto const setup = makeAccountWithSlots({}, {});
+    BOOST_CHECK(verifyProof(setup.stateRoot, setup.proof).accountValid);
+
+    auto padded = setup.proof;
+    padded.accountProof.push_back(bcos::bytes{0x01, 0x02, 0x03});
+    BOOST_CHECK(!verifyProof(setup.stateRoot, padded).accountValid);
+
+    // Padding with a copy of a legitimate node is no better than junk.
+    auto duplicated = setup.proof;
+    duplicated.accountProof.push_back(duplicated.accountProof.front());
+    BOOST_CHECK(!verifyProof(setup.stateRoot, duplicated).accountValid);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
@@ -29,9 +29,12 @@
 #include <bcos-framework/multigroup/GroupInfo.h>
 #include <bcos-framework/protocol/BlockFactory.h>
 #include <bcos-framework/protocol/ServiceDesc.h>
+#include <bcos-framework/storage2/AnyStorage.h>
 #include <bcos-framework/sync/BlockSyncInterface.h>
 #include <bcos-framework/txpool/TxPoolInterface.h>
 #include <bcos-tars-protocol/client/LedgerServiceClient.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
 #include <servant/Application.h>
 #include <utility>
 
@@ -72,6 +75,22 @@ public:
         return m_engineService;
     }
 
+    /// Type-erased read handle over the MPT node storage for eth_getProof (M8.3): key = node
+    /// hash, value = the node's raw RLP encoding, physically stored under the /mpt/<hash> key
+    /// prefix of the default column family (bcos-storage KeyPrefixes.h::makeMPTNodeKey).
+    using MPTNodeReader = bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>;
+
+    /// Non-owning: the AnyStorage view holds a raw pointer to the underlying storage, whose
+    /// ownership stays with the Initializer; that storage must outlive this NodeService.
+    /// Default unset — the production wiring arrives with the scheduler-injection PR (PR-18);
+    /// until then nothing sets it and eth_getProof answers "MPT not enabled on this node".
+    /// shared_ptr because AnyStorage itself is move-only and not default-constructible.
+    void setMPTNodeReader(std::shared_ptr<MPTNodeReader> _reader) noexcept
+    {
+        m_mptNodeReader = std::move(_reader);
+    }
+    std::shared_ptr<MPTNodeReader> mptNodeReader() const noexcept { return m_mptNodeReader; }
+
     void setLedgerPrx(bcostars::LedgerServicePrx const& _ledgerPrx) { m_ledgerPrx = _ledgerPrx; }
 
     bool unreachable()
@@ -89,6 +108,9 @@ private:
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
 
     std::shared_ptr<bcos::engine::AnyEngineService> m_engineService;
+
+    /// Non-owning MPT node reader; see setMPTNodeReader() for the lifetime contract.
+    std::shared_ptr<MPTNodeReader> m_mptNodeReader;
 
     bcostars::LedgerServicePrx m_ledgerPrx;
 };

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
@@ -108,6 +108,7 @@ void EndpointsMapping::addEthHandlers()
     m_handlers[methodString(EthMethod::eth_getFilterLogs)] = &Endpoints::getFilterLogs;
     m_handlers[methodString(EthMethod::eth_getLogs)] = &Endpoints::getLogs;
     m_handlers[methodString(EthMethod::eth_maxPriorityFeePerGas)] = &Endpoints::maxPriorityFeePerGas;
+    m_handlers[methodString(EthMethod::eth_getProof)] = &Endpoints::getProof;
     // clang-format on
 }
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -26,6 +26,7 @@
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-executor/src/Common.h>
+#include <bcos-ledger/mpt/Proof.h>
 #include <bcos-rpc/Common.h>
 #include <bcos-rpc/util.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
@@ -40,7 +41,10 @@
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <boost/throw_exception.hpp>
 #include <cstdint>
+#include <span>
 #include <string>
+#include <variant>
+#include <vector>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -865,6 +869,122 @@ task::Task<void> EthEndpoint::maxPriorityFeePerGas(
     buildJsonContent(result, response);
     co_return;
 }
+
+/// eth_getProof custom error code (spec §5.9): both request-level proof failures — dormant
+/// account and unknown/uncommitted state root — map to -32004; the message distinguishes them.
+constexpr int32_t EthGetProofUnavailable = -32004;
+
+task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& response)
+{
+    // params: address(DATA 20B), storageKeys(DATA[] of 32B), blockNumber(QTY|TAG)  (EIP-1186)
+    // result: {address, balance, nonce, codeHash, storageHash, accountProof[], storageProof[]}
+    Address address;
+    try
+    {
+        address = Address(toView(request[0U]), Address::FromHex, Address::AlignRight);
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid address"));
+    }
+    auto const& keysJson = request[1U];
+    if (!keysJson.isNull() && !keysJson.isArray())
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "storageKeys must be an array"));
+    }
+    std::vector<h256> slots;
+    slots.reserve(keysJson.size());
+    for (auto const& key : keysJson)
+    {
+        try
+        {
+            slots.emplace_back(toView(key), h256::FromHex, h256::AlignRight);
+        }
+        catch (...)
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid storage key"));
+        }
+    }
+    auto const blockTag = toView(request[2U]);
+    auto [blockNumber, _] = co_await getBlockNumberByTag(blockTag);
+    if (c_fileLogLevel == TRACE)
+    {
+        WEB3_LOG(TRACE) << "eth_getProof" << LOG_KV("address", address.hexPrefixed())
+                        << LOG_KV("slotCount", slots.size()) << LOG_KV("blockTag", blockTag)
+                        << LOG_KV("blockNumber", blockNumber);
+    }
+
+    // Resolve the block's stateRoot from its header.
+    auto const ledger = m_nodeService->ledger();
+    auto const block = co_await ledger::getBlockData(*ledger, blockNumber, bcos::ledger::HEADER);
+    if (!block || !block->blockHeader()) [[unlikely]]
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Block not found"));
+    }
+    auto const stateRoot = block->blockHeader()->stateRoot();
+
+    // The MPT node reader is wired by the initializer (PR-18); unset means the node does not
+    // maintain an MPT state root — a configuration matter, hence -32603 rather than -32004.
+    auto const mptReader = m_nodeService->mptNodeReader();
+    if (!mptReader) [[unlikely]]
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
+    }
+
+    auto result = co_await ledger::mpt::generateProof(
+        *mptReader, stateRoot, address, std::span<h256 const>(slots));
+    if (auto const* errorCode = std::get_if<ledger::mpt::ProofErrorCode>(&result))
+    {
+        auto const* message = (*errorCode == ledger::mpt::ProofErrorCode::AccountNotInMPT) ?
+                                  "Account not in trie (dormant in scenario A)" :
+                                  "Block stateRoot not in MPT node storage";
+        BOOST_THROW_EXCEPTION(JsonRpcException(EthGetProofUnavailable, message));
+    }
+    auto& proof = std::get<ledger::mpt::EIP1186Proof>(result);
+
+    Json::Value output = Json::objectValue;
+    output["address"] = address.hexPrefixed();
+    output["balance"] = toQuantity(proof.balance);
+    output["nonce"] = toQuantity(proof.nonce);
+    output["codeHash"] = proof.codeHash.hexPrefixed();
+    output["storageHash"] = proof.storageHash.hexPrefixed();
+    Json::Value accountProof = Json::arrayValue;
+    for (auto const& node : proof.accountProof)
+    {
+        accountProof.append(toHexStringWithPrefix(node));
+    }
+    output["accountProof"] = std::move(accountProof);
+    Json::Value storageProof = Json::arrayValue;
+    for (auto& entry : proof.storageProof)
+    {
+        Json::Value entryJson = Json::objectValue;
+        entryJson["key"] = entry.key.hexPrefixed();
+        // The trie leaf stores RLP(big-endian-trimmed slot value); EIP-1186 "value" is the
+        // slot's QUANTITY. Strip the RLP string header to recover the payload bytes and render
+        // them as a quantity — 0x0 when the slot is absent (empty leaf value).
+        bcos::bytes payload;
+        if (!entry.value.empty())
+        {
+            auto valueRef = bcos::ref(entry.value);
+            if (auto error = codec::rlp::decode(valueRef, payload); error != nullptr) [[unlikely]]
+            {
+                BOOST_THROW_EXCEPTION(
+                    JsonRpcException(InternalError, "Malformed storage leaf RLP"));
+            }
+        }
+        entryJson["value"] = toQuantity(payload);
+        Json::Value proofJson = Json::arrayValue;
+        for (auto const& node : entry.proof)
+        {
+            proofJson.append(toHexStringWithPrefix(node));
+        }
+        entryJson["proof"] = std::move(proofJson);
+        storageProof.append(std::move(entryJson));
+    }
+    output["storageProof"] = std::move(storageProof);
+    buildJsonContent(output, response);
+}
+
 bcos::rpc::EthEndpoint::EthEndpoint(
     NodeService::Ptr nodeService, FilterSystem::Ptr filterSystem, bool syncTransaction)
   : m_nodeService(std::move(nodeService)),

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
@@ -78,6 +78,7 @@ public:
     task::Task<std::tuple<protocol::BlockNumber, bool>> getBlockNumberByTag(
         std::string_view blockTag);
     task::Task<void> maxPriorityFeePerGas(const Json::Value&, Json::Value&);
+    task::Task<void> getProof(const Json::Value&, Json::Value&);
 
 private:
     NodeService::Ptr m_nodeService;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
@@ -79,7 +79,8 @@ enum class EthMethod
     eth_getFilterChanges,
     eth_getFilterLogs,
     eth_getLogs,
-    eth_maxPriorityFeePerGas
+    eth_maxPriorityFeePerGas,
+    eth_getProof
 };
 
 [[maybe_unused]] static std::string methodString(EthMethod _method)

--- a/bcos-rpc/test/unittests/rpc/EthGetProofRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetProofRpcTest.cpp
@@ -1,0 +1,270 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthGetProofRpcTest.cpp
+ * @brief eth_getProof EIP-1186 JSON-RPC endpoint tests (M8.3, spec §5.9 / §6.2)
+ */
+
+#include "../common/RPCFixture.h"
+#include <bcos-framework/storage2/AnyStorage.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/Proof.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <string>
+#include <vector>
+
+namespace bcos::test
+{
+namespace mpt = bcos::ledger::mpt;
+
+class EthGetProofFixture : public RPCFixture
+{
+public:
+    using MPTNodeStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
+
+    EthGetProofFixture()
+    {
+        rpc = factory->buildLocalRpc(groupInfo, nodeService);
+        web3JsonRpc = rpc->web3JsonRpc();
+        BOOST_TEST(web3JsonRpc != nullptr);
+    }
+
+    /// Build one account owning a two-slot storage trie into m_mptNodes and stamp the resulting
+    /// state root onto the latest fake block header ("latest" resolves to it). Reader wiring is a
+    /// separate step so the unset-reader case can reuse the same trie setup.
+    void buildTrie()
+    {
+        mpt::HashBuilder storageTrie(m_mptNodes, mpt::emptyRootHash());
+        task::syncWait(storageTrie.put(mpt::slotKeyHash(slotA), valueA));
+        task::syncWait(storageTrie.put(mpt::slotKeyHash(slotB), valueB));
+        auto const storageRoot = task::syncWait(storageTrie.commit());
+
+        mpt::Account account;
+        account.nonce = 7;
+        account.balance = 1000;
+        account.storageRoot = storageRoot;
+        mpt::HashBuilder stateTrie(m_mptNodes, mpt::emptyRootHash());
+        task::syncWait(stateTrie.put(mpt::accountKeyHash(address), account.encode()));
+        stateRoot = task::syncWait(stateTrie.commit());
+
+        m_ledger->ledgerData().back()->blockHeader()->setStateRoot(stateRoot);
+    }
+
+    /// Inject the type-erased MPT node reader; the AnyStorage view is non-owning, m_mptNodes
+    /// (a fixture member) plays the Initializer's ownership role and outlives the NodeService.
+    void wireReader()
+    {
+        nodeService->setMPTNodeReader(
+            std::make_shared<bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>>(m_mptNodes));
+    }
+
+    Json::Value request(std::string const& req)
+    {
+        Json::Value value;
+        Json::Reader reader;
+        std::promise<bcos::bytes> promise;
+        web3JsonRpc->onRPCRequest(
+            req, [&promise](bcos::bytes resp) { promise.set_value(std::move(resp)); });
+        auto jsonBytes = promise.get_future().get();
+        std::string_view json((char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    }
+
+    Json::Value getProof(
+        std::string const& addressHex, std::vector<std::string> const& keys, std::string const& tag)
+    {
+        Json::Value req;
+        req["jsonrpc"] = "2.0";
+        req["id"] = 1;
+        req["method"] = "eth_getProof";
+        Json::Value params(Json::arrayValue);
+        params.append(addressHex);
+        Json::Value keysJson(Json::arrayValue);
+        for (auto const& key : keys)
+        {
+            keysJson.append(key);
+        }
+        params.append(keysJson);
+        params.append(tag);
+        req["params"] = params;
+        return request(printJson(req));
+    }
+
+    /// A JSON quantity ("0x2a") back to trimmed big-endian bytes; "0x0" -> empty.
+    static bytes quantityToBytes(std::string const& quantity)
+    {
+        std::string hex = quantity;
+        if (hex.starts_with("0x") || hex.starts_with("0X"))
+        {
+            hex = hex.substr(2);
+        }
+        if (hex.empty() || hex == "0")
+        {
+            return {};
+        }
+        if (hex.size() % 2 != 0)
+        {
+            hex.insert(0, "0");
+        }
+        return fromHex(hex);
+    }
+
+    /// Rebuild the binary EIP1186Proof from the endpoint's JSON: hex fields back to bytes, and
+    /// each slot "value" (a QUANTITY per EIP-1186) back to the trie's RLP leaf encoding via
+    /// encodeStorageValue — verifyProof compares against the raw leaf bytes.
+    static mpt::EIP1186Proof proofFromJson(Json::Value const& result)
+    {
+        mpt::EIP1186Proof out;
+        out.address = Address(result["address"].asString(), Address::FromHex);
+        out.balance = fromBigQuantity(result["balance"].asString());
+        out.nonce = fromBigQuantity(result["nonce"].asString());
+        out.codeHash = h256(result["codeHash"].asString(), h256::FromHex);
+        out.storageHash = h256(result["storageHash"].asString(), h256::FromHex);
+        for (auto const& node : result["accountProof"])
+        {
+            out.accountProof.push_back(fromHexWithPrefix(node.asString()));
+        }
+        for (auto const& entryJson : result["storageProof"])
+        {
+            mpt::StorageProof entry;
+            entry.key = h256(entryJson["key"].asString(), h256::FromHex);
+            auto raw = quantityToBytes(entryJson["value"].asString());
+            entry.value = mpt::encodeStorageValue(bcos::ref(raw));
+            for (auto const& node : entryJson["proof"])
+            {
+                entry.proof.push_back(fromHexWithPrefix(node.asString()));
+            }
+            out.storageProof.push_back(std::move(entry));
+        }
+        return out;
+    }
+
+    Rpc::Ptr rpc;
+    Web3JsonRpcImpl::Ptr web3JsonRpc;
+
+    MPTNodeStorage m_mptNodes;
+    bcos::Address address{std::string("0x00000000000000000000000000000000000000ab")};
+    bcos::Address dormant{std::string("0x00000000000000000000000000000000000000cd")};
+    h256 slotA{1U};
+    h256 slotB{2U};
+    h256 slotMissing{3U};
+    bytes valueA{0x2a};              // RLP(42): single byte < 0x80
+    bytes valueB{0x82, 0x13, 0x37};  // RLP(0x1337): 2-byte string
+    h256 stateRoot;
+};
+
+BOOST_FIXTURE_TEST_SUITE(EthGetProofRpcTest, EthGetProofFixture)
+
+// eth_getProof must be registered in EndpointsMapping (method-name lookup succeeds).
+BOOST_AUTO_TEST_CASE(MethodRegistered)
+{
+    EndpointsMapping const mapping;
+    BOOST_CHECK(mapping.findHandler("eth_getProof").has_value());
+    BOOST_CHECK(!mapping.findHandler("eth_getProofX").has_value());
+}
+
+// Happy path: full EIP-1186 shape over a real one-account/two-slot trie, plus a round trip — the
+// JSON-serialized proof fed back through verifyProof must still verify, proving the RPC layer
+// does not corrupt the proof bytes.
+BOOST_AUTO_TEST_CASE(HappyPathShapeAndRoundTrip)
+{
+    buildTrie();
+    wireReader();
+
+    auto resp = getProof(address.hexPrefixed(),
+        {slotA.hexPrefixed(), slotB.hexPrefixed(), slotMissing.hexPrefixed()}, "latest");
+    BOOST_TEST(!resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+
+    BOOST_TEST(result["address"].asString() == address.hexPrefixed());
+    BOOST_TEST(result["balance"].asString() == "0x3e8");
+    BOOST_TEST(result["nonce"].asString() == "0x7");
+    BOOST_TEST(result["codeHash"].asString() == mpt::emptyCodeHash().hexPrefixed());
+    BOOST_REQUIRE(result["accountProof"].isArray());
+    BOOST_TEST(result["accountProof"].size() >= 1U);
+
+    BOOST_REQUIRE(result["storageProof"].isArray());
+    BOOST_REQUIRE_EQUAL(result["storageProof"].size(), 3U);
+    auto const& proofA = result["storageProof"][0U];
+    auto const& proofB = result["storageProof"][1U];
+    auto const& proofMissing = result["storageProof"][2U];
+    BOOST_TEST(proofA["key"].asString() == slotA.hexPrefixed());
+    // The trie leaf stores RLP(0x2a); EIP-1186 "value" is the decoded QUANTITY.
+    BOOST_TEST(proofA["value"].asString() == "0x2a");
+    BOOST_TEST(proofA["proof"].size() >= 1U);
+    BOOST_TEST(proofB["value"].asString() == "0x1337");
+    // Absent slot: zero value with a non-empty exclusion proof.
+    BOOST_TEST(proofMissing["value"].asString() == "0x0");
+    BOOST_TEST(proofMissing["proof"].size() >= 1U);
+
+    auto const reconstructed = proofFromJson(result);
+    auto const verify = mpt::verifyProof(stateRoot, reconstructed);
+    BOOST_TEST(verify.accountValid);
+    BOOST_REQUIRE_EQUAL(verify.storageValid.size(), 3U);
+    BOOST_TEST(verify.storageValid[0]);
+    BOOST_TEST(verify.storageValid[1]);
+    BOOST_TEST(verify.storageValid[2]);
+}
+
+// Dormant account (present state root, address not in the trie) -> -32004 "not in trie".
+BOOST_AUTO_TEST_CASE(DormantAccountReturns32004)
+{
+    buildTrie();
+    wireReader();
+
+    auto resp = getProof(dormant.hexPrefixed(), {}, "latest");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32004);
+    BOOST_CHECK(resp["error"]["message"].asString().find("not in trie") != std::string::npos);
+}
+
+// Header stateRoot absent from the MPT node storage -> -32004 "not in MPT node storage".
+BOOST_AUTO_TEST_CASE(UnknownStateRootReturns32004)
+{
+    buildTrie();
+    wireReader();
+    m_ledger->ledgerData().back()->blockHeader()->setStateRoot(h256{0x1234U});
+
+    auto resp = getProof(address.hexPrefixed(), {}, "latest");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32004);
+    BOOST_CHECK(
+        resp["error"]["message"].asString().find("not in MPT node storage") != std::string::npos);
+}
+
+// No MPT node reader wired (production state until PR-18) -> -32603 "MPT not enabled".
+BOOST_AUTO_TEST_CASE(ReaderUnsetReturns32603)
+{
+    buildTrie();  // trie + stateRoot exist, but the reader stays unset
+
+    auto resp = getProof(address.hexPrefixed(), {slotA.hexPrefixed()}, "latest");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32603);
+    BOOST_CHECK(resp["error"]["message"].asString().find("MPT not enabled") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
## What

**Stacked on #5316 (M8.2)** — this branch contains #5316's verifier commits; review only the last commit (`bf2d79616`). Wires the proof library (#5311 generator + #5316 verifier) into the Web3 JSON-RPC layer as the standard EIP-1186 `eth_getProof` method.

- `EthMethod`/`EndpointsMapping`: register `eth_getProof`.
- `EthEndpoint::getProof`: parses `(address, storageKeys[], blockTag)` with the file's sibling-method conventions (bad input → InvalidParams), resolves the block header's stateRoot via the ledger, reads MPT nodes through the NodeService handle below, calls `ledger::mpt::generateProof`, and serializes the EIP-1186 result. Slot `value` is RLP-decoded back to a QUANTITY (the trie leaf stores the RLP of the trimmed big-endian value; 0x0 for absent slots).
- Error mapping: `AccountNotInMPT` → `-32004` "Account not in trie (dormant in scenario A)"; `BlockNotCommitted` → `-32004` "Block stateRoot not in MPT node storage"; MPT reader unset → `-32603` "MPT not enabled on this node" (a configuration matter, not a data one). All raised as `JsonRpcException`, the file's dominant convention.
- `NodeService`: a non-owning, type-erased MPT node reader slot — `storage2::AnyStorage<h256, bytes>` held via `shared_ptr` (AnyStorage is AnyHolder-based: move-only and not default-constructible, so a bare member does not fit). Ownership of the real storage stays with the Initializer; the slot stays unset until the scheduler-injection wiring (PR-18) lands, so live nodes answer "MPT not enabled" until then.

## Tests

`EthGetProofRpcTest` (5 cases, driven black-box through `onRPCRequest` on the existing RPCFixture): method registration; happy path over a real in-memory MPT (2 present slots + 1 absent slot's exclusion proof) asserting the full EIP-1186 JSON shape **and feeding the RPC-serialized proof back through `verifyProof` (#5316) to prove the endpoint does not corrupt proof bytes**; dormant account → -32004; unknown stateRoot → -32004; reader unset → -32603.

Full `test-bcos-rpc`: 85/85 cases, 987/987 assertions, exit 0. Full `test-bcos-ledger` re-run green on this branch. New/modified TUs pass standalone `-fsyntax-only` compiles (unity-build leak guard).

Refs: spec §5.9, §6.2 modification list