### PR TITLE
refactor(mpt): slim TrieNode — fixed-size NodeRef + vector branch children, variant 1056B to 56B (M12)

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/HashBuilder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/HashBuilder.cpp
@@ -53,9 +53,9 @@ struct HBContext
 NodeRef hbEmit(HBContext& ctx, TrieNode const& node)
 {
     auto [raw, ref] = NodeEncoder<>::encodeAndRef(node, ctx.hasher);
-    if (ref.kind == NodeRef::Kind::Hash)
+    if (ref.kind() == NodeRef::Kind::Hash)
     {
-        ctx.newNodes.emplace(ref.hash, std::move(raw));
+        ctx.newNodes.emplace(ref.hash(), std::move(raw));
     }
     return ref;
 }
@@ -64,14 +64,14 @@ NodeRef hbEmit(HBContext& ctx, TrieNode const& node)
 // 33-byte RLP byte-string 0xa0 + hash.
 bcos::bytes hbRefToRaw(NodeRef const& ref)
 {
-    if (ref.kind == NodeRef::Kind::Inline)
+    if (ref.kind() == NodeRef::Kind::Inline)
     {
-        return ref.inlineBytes;
+        return ref.inlineRef().toBytes();
     }
     bcos::bytes out;
     out.reserve(HASH_REF_ENCODED_SIZE);
     out.push_back(RLP_HASH_REF_PREFIX);
-    out.insert(out.end(), ref.hash.begin(), ref.hash.end());
+    out.insert(out.end(), ref.payload.begin(), ref.payload.end());
     return out;
 }
 
@@ -164,14 +164,14 @@ TrieBuildResult computeTrieRootImpl(
 
     // A trie root is ALWAYS a 32-byte hash, even when the top node encodes to < 32 bytes.
     bcos::h256 root;
-    if (rootRef.kind == NodeRef::Kind::Hash)
+    if (rootRef.kind() == NodeRef::Kind::Hash)
     {
-        root = rootRef.hash;
+        root = rootRef.hash();
     }
     else
     {
-        bcos::crypto::hasher::hash(hasher, bcos::ref(rootRef.inlineBytes), root);
-        newNodes.emplace(root, rootRef.inlineBytes);
+        bcos::crypto::hasher::hash(hasher, rootRef.inlineRef(), root);
+        newNodes.emplace(root, rootRef.inlineRef().toBytes());
     }
 
     return TrieBuildResult{.root = root, .newNodes = std::move(newNodes)};

--- a/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeDecoder.cpp
@@ -126,13 +126,18 @@ TrieNode decodeNode(bcos::bytesConstRef rawInput)
             }
             else if (!child.isList && child.content.size() == bcos::h256::SIZE)  // 0xa0 + 32 bytes
             {
-                branch.children[i].kind = NodeRef::Kind::Hash;
-                branch.children[i].hash = bcos::h256{child.content.data(), child.content.size()};
+                branch.children[i].setHash(bcos::h256{child.content.data(), child.content.size()});
             }
-            else  // inline subtree (a list) → keep the raw span
+            else  // inline subtree (a list) → keep the raw bytes
             {
-                branch.children[i].kind = NodeRef::Kind::Inline;
-                branch.children[i].inlineBytes = toBytes(child.raw);
+                // Yellow Paper §D 32-byte rule: an embedded (inline) node's RLP is < 32 bytes;
+                // anything larger must be hash-referenced, so reject it as malformed.
+                if (child.raw.size() >= bcos::h256::SIZE)
+                {
+                    BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                              "branch child embeds an inline node of >= 32 bytes"));
+                }
+                branch.children[i].setInline(child.raw);
             }
         }
         branch.value = toBytes(items[NIBBLE_RANGE].content);

--- a/bcos-ledger/bcos-ledger/mpt/NodeEncoder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeEncoder.cpp
@@ -33,26 +33,27 @@ namespace bcos::ledger::mpt
 // ---------------------------------------------------------------------------
 
 // Appends the RLP encoding of a NodeRef child into dst.
-// - Default (Inline + empty bytes) → RLP empty string 0x80 (absent child)
-// - Inline non-empty              → splice the raw bytes as-is (already a complete RLP item)
-// - Hash                          → encode the 32-byte hash as an RLP byte-string (33 bytes)
+// - Absent (len == 0)   → RLP empty string 0x80
+// - Inline (len 1..31)  → splice the raw bytes as-is (already a complete RLP item)
+// - Hash   (len == 32)  → encode the 32-byte hash as an RLP byte-string (33 bytes)
 static void appendChildRef(bcos::bytes& dst, NodeRef const& ref)
 {
-    if (ref.kind == NodeRef::Kind::Inline)
+    if (ref.kind() == NodeRef::Kind::Inline)
     {
-        if (ref.inlineBytes.empty())
+        if (ref.isAbsent())
         {
             dst.push_back(RLP_EMPTY_STRING);  // absent child
         }
         else
         {
-            dst.insert(dst.end(), ref.inlineBytes.begin(), ref.inlineBytes.end());
+            auto const raw = ref.inlineRef();
+            dst.insert(dst.end(), raw.begin(), raw.end());
         }
     }
     else
     {
         // Hash kind: emit as 33-byte RLP byte-string [0xa0, hash[0..31]]
-        bcos::codec::rlp::encode(dst, ref.hash);
+        bcos::codec::rlp::encode(dst, ref.hash());
     }
 }
 

--- a/bcos-ledger/bcos-ledger/mpt/NodeEncoder.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/NodeEncoder.cpp
@@ -19,6 +19,7 @@
 
 #include "NodeEncoder.h"
 #include "Constants.h"
+#include "Errors.h"
 #include "HexPrefix.h"
 #include "bcos-utilities/Overloaded.h"
 #include <bcos-codec/rlp/Common.h>
@@ -89,6 +90,15 @@ static void encodeExtension(ExtensionNode const& node, bcos::bytes& out)
 static void encodeBranch(BranchNode const& node, bcos::bytes& out)
 {
     using namespace bcos::codec::rlp;
+
+    // children is a vector, so the 16-slot invariant is convention (default member initializer
+    // in TrieNode.h) rather than type-enforced — a malformed size must fail loudly here instead
+    // of silently mis-encoding a list with the wrong item count.
+    if (node.children.size() != NIBBLE_RANGE)
+    {
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
+                                  "BranchNode.children must hold exactly NIBBLE_RANGE entries"));
+    }
 
     // RLP list header needs payload length up front, so the 17-item payload is built into a
     // local buffer first. Once sealed, the payload is spliced into `out` — caller pays one

--- a/bcos-ledger/bcos-ledger/mpt/NodeEncoder.h
+++ b/bcos-ledger/bcos-ledger/mpt/NodeEncoder.h
@@ -72,16 +72,15 @@ public:
         NodeRef ref;
         if (raw.size() < bcos::h256::SIZE)
         {
-            ref.kind = NodeRef::Kind::Inline;
-            ref.inlineBytes = raw;
+            ref.setInline(bcos::bytesConstRef(raw.data(), raw.size()));
         }
         else
         {
-            ref.kind = NodeRef::Kind::Hash;
-            bcos::crypto::hasher::hash(
-                hasher, bcos::bytesConstRef(raw.data(), raw.size()), ref.hash);
+            bcos::h256 digest;
+            bcos::crypto::hasher::hash(hasher, bcos::bytesConstRef(raw.data(), raw.size()), digest);
+            ref.setHash(digest);
         }
-        return {std::move(raw), std::move(ref)};
+        return {std::move(raw), ref};
     }
 
     /// Convenience overload: constructs a fresh HasherT per call. Use only for one-off or

--- a/bcos-ledger/bcos-ledger/mpt/Proof.h
+++ b/bcos-ledger/bcos-ledger/mpt/Proof.h
@@ -199,9 +199,9 @@ bcos::task::Task<ProofWalk> proofWalk(Storage& storage, bcos::h256 root, bcos::b
         }
         NodeRef const& child = branch.children.at(path.at(pos));
         ++pos;
-        if (child.kind == NodeRef::Kind::Hash)
+        if (child.kind() == NodeRef::Kind::Hash)
         {
-            bcos::h256 const childHash = child.hash;
+            bcos::h256 const childHash = child.hash();
             auto childRaw = co_await bcos::storage2::readOne(storage, childHash);
             if (!childRaw)
             {
@@ -212,14 +212,14 @@ bcos::task::Task<ProofWalk> proofWalk(Storage& storage, bcos::h256 root, bcos::b
             TrieNode next = decodeNode(bcos::ref(out.nodes.back()));
             node = std::move(next);
         }
-        else if (child.inlineBytes.empty())
+        else if (child.isAbsent())
         {
             co_return out;  // absent child: dead end
         }
         else
         {
             // Inline child: embedded in this branch's encoding, not a separate proof item.
-            TrieNode next = decodeNode(bcos::ref(child.inlineBytes));
+            TrieNode next = decodeNode(child.inlineRef());
             node = std::move(next);
         }
     }

--- a/bcos-ledger/bcos-ledger/mpt/Trie.h
+++ b/bcos-ledger/bcos-ledger/mpt/Trie.h
@@ -55,12 +55,12 @@ bcos::task::Task<TrieNode> trieLoadByHash(Storage& storage, bcos::h256 const& ha
 template <bcos::storage2::ReadableStorage<bcos::h256> Storage>
 bcos::task::Task<TrieNode> trieLoadFromRef(Storage& storage, NodeRef const& ref)
 {
-    if (ref.kind == NodeRef::Kind::Hash)
+    if (ref.kind() == NodeRef::Kind::Hash)
     {
-        co_return co_await trieLoadByHash(storage, ref.hash);
+        co_return co_await trieLoadByHash(storage, ref.hash());
     }
     // Inline (non-empty): the child's complete RLP encoding is stored directly.
-    co_return decodeNode(bcos::ref(ref.inlineBytes));
+    co_return decodeNode(ref.inlineRef());
 }
 
 /// Resolve an ExtensionNode.child, which is kept as a raw RLP child reference: EITHER the 33-byte
@@ -148,8 +148,7 @@ public:
             }
             bcos::byte const nib = path.at(pos);
             NodeRef const& child = children.at(nib);
-            // Absent child == Inline with empty inlineBytes.
-            if (child.kind == NodeRef::Kind::Inline && child.inlineBytes.empty())
+            if (child.isAbsent())
             {
                 co_return std::nullopt;
             }

--- a/bcos-ledger/bcos-ledger/mpt/TrieMerge.h
+++ b/bcos-ledger/bcos-ledger/mpt/TrieMerge.h
@@ -116,32 +116,32 @@ struct MutableNode
 // complete RLP) into a NodeRef. Inverse of refToRawBytes below.
 inline NodeRef refFromRawBytes(bcos::bytes const& raw)
 {
-    NodeRef ref;
     if (raw.size() == HASH_REF_ENCODED_SIZE && raw[0] == RLP_HASH_REF_PREFIX)
     {
-        ref.kind = NodeRef::Kind::Hash;
-        ref.hash = bcos::h256(bcos::bytesConstRef(raw.data() + 1, bcos::h256::SIZE));
+        return NodeRef::fromHash(bcos::h256(bcos::bytesConstRef(raw.data() + 1, bcos::h256::SIZE)));
     }
-    else
+    // Yellow Paper §D 32-byte rule: an inline child ref's RLP is < 32 bytes; anything else
+    // here means the stored trie is malformed.
+    if (raw.size() >= bcos::h256::SIZE)
     {
-        ref.kind = NodeRef::Kind::Inline;
-        ref.inlineBytes = raw;
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
+                                  "refFromRawBytes: inline child ref of >= 32 bytes"));
     }
-    return ref;
+    return NodeRef::fromInline(bcos::bytesConstRef(raw.data(), raw.size()));
 }
 
 // Turn a NodeRef into the bytes an ExtensionNode.child expects. Mirrors the file-local helper in
 // HashBuilder.cpp (thin glue over the shared NodeEncoder rules; kept local to each TU).
 inline bcos::bytes refToRawBytes(NodeRef const& ref)
 {
-    if (ref.kind == NodeRef::Kind::Inline)
+    if (ref.kind() == NodeRef::Kind::Inline)
     {
-        return ref.inlineBytes;
+        return ref.inlineRef().toBytes();
     }
     bcos::bytes out;
     out.reserve(HASH_REF_ENCODED_SIZE);
     out.push_back(RLP_HASH_REF_PREFIX);
-    out.insert(out.end(), ref.hash.begin(), ref.hash.end());
+    out.insert(out.end(), ref.payload.begin(), ref.payload.end());
     return out;
 }
 
@@ -173,8 +173,7 @@ inline std::unique_ptr<MutableNode> liftNode(TrieNode decoded, std::optional<bco
         MutableBranch mut;
         for (size_t i = 0; i < NIBBLE_RANGE; ++i)
         {
-            if (auto& child = branch->children[i];
-                child.kind == NodeRef::Kind::Inline && child.inlineBytes.empty())
+            if (auto& child = branch->children[i]; child.isAbsent())
             {
                 mut.children[i] = std::monostate{};
             }
@@ -222,22 +221,23 @@ bcos::task::Task<MutableNode*> mergeResolve(MergeContext<Storage>& ctx, MutableC
     auto const& ref = std::get<NodeRef>(slot);
     std::optional<bcos::h256> origin;
     TrieNode decoded;
-    if (ref.kind == NodeRef::Kind::Hash)
+    if (ref.kind() == NodeRef::Kind::Hash)
     {
-        auto raw = co_await bcos::storage2::readOne(ctx.storage.get(), ref.hash);
+        bcos::h256 const refHash = ref.hash();
+        auto raw = co_await bcos::storage2::readOne(ctx.storage.get(), refHash);
         if (!raw)
         {
             BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
                                       "mergeTrie: missing node hash; storage lacks a referenced "
                                       "node"));
         }
-        ctx.resolvedHashes.insert(ref.hash);
-        origin = ref.hash;
+        ctx.resolvedHashes.insert(refHash);
+        origin = refHash;
         decoded = decodeNode(bcos::ref(*raw));
     }
     else
     {
-        decoded = decodeNode(bcos::ref(ref.inlineBytes));
+        decoded = decodeNode(ref.inlineRef());
     }
     slot = liftNode(std::move(decoded), origin);
     co_return std::get<std::unique_ptr<MutableNode>>(slot).get();
@@ -469,9 +469,7 @@ bcos::task::Task<void> mergeNormalize(MergeContext<Storage>& ctx, MutableNode& n
             // Resolved only to learn its shape, never modified: its prior encoding stays live
             // under the new extension. Un-account the resolve and keep the hash reference.
             ctx.resolvedHashes.erase(*boxed->originHash);
-            NodeRef keep;
-            keep.kind = NodeRef::Kind::Hash;
-            keep.hash = *boxed->originHash;
+            NodeRef const keep = NodeRef::fromHash(*boxed->originHash);
             node.node = MutableExtension{.shared = bcos::bytes{static_cast<bcos::byte>(lastNibble)},
                 .child = MutableChild{keep}};
         }
@@ -574,9 +572,9 @@ struct EmitContext
     NodeRef emit(TrieNode const& node)
     {
         auto [raw, ref] = NodeEncoder<HasherT>::encodeAndRef(node, hasher);
-        if (ref.kind == NodeRef::Kind::Hash)
+        if (ref.kind() == NodeRef::Kind::Hash)
         {
-            newNodes.emplace(ref.hash, std::move(raw));
+            newNodes.emplace(ref.hash(), std::move(raw));
         }
         return ref;
     }
@@ -645,8 +643,7 @@ bcos::task::Task<TrieMergeResult> mergeTrie(Storage& storage, bcos::h256 priorRo
     detail::MergeContext<Storage> ctx{.storage = storage, .resolvedHashes = {}};
 
     // The overlay root starts as a clean reference to the prior root node; nothing is read yet.
-    detail::MutableChild root{
-        NodeRef{.kind = NodeRef::Kind::Hash, .inlineBytes = {}, .hash = priorRoot}};
+    detail::MutableChild root{NodeRef::fromHash(priorRoot)};
 
     // Phase 1 — apply. std::map iteration = h256 lexicographic = 64-nibble path order, so keys
     // sharing a prefix arrive consecutively and hit the overlay's memoized nodes.
@@ -690,14 +687,14 @@ bcos::task::Task<TrieMergeResult> mergeTrie(Storage& storage, bcos::h256 priorRo
             detail::emitNode(emitCtx, *std::get<std::unique_ptr<detail::MutableNode>>(root));
         // A trie root is ALWAYS addressed by a 32-byte hash, even when the top node encodes
         // to fewer than 32 bytes (same rule as computeTrieRoot).
-        if (rootRef.kind == NodeRef::Kind::Hash)
+        if (rootRef.kind() == NodeRef::Kind::Hash)
         {
-            result.root = rootRef.hash;
+            result.root = rootRef.hash();
         }
         else
         {
-            bcos::crypto::hasher::hash(emitCtx.hasher, bcos::ref(rootRef.inlineBytes), result.root);
-            emitCtx.newNodes.emplace(result.root, rootRef.inlineBytes);
+            bcos::crypto::hasher::hash(emitCtx.hasher, rootRef.inlineRef(), result.root);
+            emitCtx.newNodes.emplace(result.root, rootRef.inlineRef().toBytes());
         }
         result.newNodes = std::move(emitCtx.newNodes);
     }

--- a/bcos-ledger/bcos-ledger/mpt/TrieNode.h
+++ b/bcos-ledger/bcos-ledger/mpt/TrieNode.h
@@ -124,10 +124,17 @@ struct NodeRef
 };
 
 /// A branch node: 16 child references (one per hex nibble) plus an optional value.
+///
+/// children is a vector (one heap block of 16 x 33B) rather than std::array so the TrieNode
+/// variant itself stays small — every LeafNode/ExtensionNode instance, by-value TrieNode move
+/// and Task<TrieNode> coroutine frame would otherwise pay BranchNode's full inline footprint.
+/// The "exactly NIBBLE_RANGE slots" invariant moves from the type to convention: the default
+/// member initializer below makes every default-constructed branch 16-wide (each slot the
+/// absent-child sentinel), and NodeEncoder rejects any other size before encoding.
 struct BranchNode
 {
-    /// Default-constructed = absent child (len == 0)
-    std::array<NodeRef, NIBBLE_RANGE> children;
+    /// Always NIBBLE_RANGE entries; default-constructed entries = absent child (len == 0)
+    std::vector<NodeRef> children = std::vector<NodeRef>(NIBBLE_RANGE);
     ///< Typically empty for internal branch nodes
     bcos::bytes value;
 };

--- a/bcos-ledger/bcos-ledger/mpt/TrieNode.h
+++ b/bcos-ledger/bcos-ledger/mpt/TrieNode.h
@@ -21,7 +21,9 @@
 #include "Nibble.h"
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <algorithm>
 #include <array>
+#include <cassert>
 #include <variant>
 #include <vector>
 
@@ -52,9 +54,13 @@ struct ExtensionNode
 };
 
 /// A node reference used inside BranchNode children.
-/// - Inline: the referenced subtree's complete RLP encoding is short (<32 bytes) and is stored
-///   directly; inlineBytes may be empty, which represents an absent child (treated as empty).
-/// - Hash:   the referenced subtree is ≥32 bytes; only the 32-byte keccak256 digest is stored.
+/// - Inline: the referenced subtree's complete RLP encoding is short (< 32 bytes by the Yellow
+///   Paper §D 32-byte rule) and is stored directly; a zero-length inline ref encodes as RLP-empty
+///   (0x80) and represents an absent branch child.
+/// - Hash:   the referenced subtree's RLP is ≥ 32 bytes; only the 32-byte digest is stored.
+///
+/// Both forms fit one fixed 32-byte buffer, so NodeRef is 33 bytes flat (no heap allocation) —
+/// `len` alone discriminates: 0 = absent, 1..31 = inline RLP of that length, 32 = hash.
 struct NodeRef
 {
     enum class Kind : uint8_t
@@ -63,22 +69,64 @@ struct NodeRef
         Hash
     };
 
-    Kind kind{Kind::Inline};
-    /// Valid when kind == Inline. An empty inlineBytes with kind == Inline encodes as RLP-empty
-    /// (0x80) and represents an absent branch child.
-    [[no_unique_address]] bcos::bytes inlineBytes;
-    /// Valid when kind == Hash; keccak256(child RLP)
-    [[no_unique_address]] bcos::h256 hash;
+    /// Inline: the first `len` bytes are the child's complete RLP; the tail is zero.
+    /// Hash: all 32 bytes are the digest of the child's RLP.
+    std::array<bcos::byte, bcos::h256::SIZE> payload{};
+    /// 0 = absent child; 1..31 = inline RLP length; 32 = hash.
+    uint8_t len = 0;
 
-    /// Explicit factory for the absent-child sentinel (Inline + empty inlineBytes).
-    /// Identical to default-construction; named for self-documenting call sites.
-    static NodeRef absent() { return NodeRef{}; }
+    [[nodiscard]] Kind kind() const noexcept
+    {
+        return len == bcos::h256::SIZE ? Kind::Hash : Kind::Inline;
+    }
+    /// Absent child sentinel (inline, zero length); encodes as RLP-empty (0x80).
+    [[nodiscard]] bool isAbsent() const noexcept { return len == 0; }
+
+    /// Valid when kind() == Inline: view of the child's complete RLP encoding.
+    [[nodiscard]] bcos::bytesConstRef inlineRef() const noexcept { return {payload.data(), len}; }
+    /// Valid when kind() == Hash: the 32-byte digest, copied out.
+    [[nodiscard]] bcos::h256 hash() const noexcept
+    {
+        return bcos::h256{payload.data(), payload.size()};
+    }
+
+    /// Caller guarantees raw.size() < 32 (Yellow Paper rule; untrusted inputs are rejected
+    /// upstream in NodeDecoder / refFromRawBytes before reaching here).
+    void setInline(bcos::bytesConstRef raw) noexcept
+    {
+        assert(raw.size() < bcos::h256::SIZE);
+        std::copy(raw.begin(), raw.end(), payload.begin());
+        std::fill(payload.begin() + raw.size(), payload.end(), bcos::byte{0});
+        len = static_cast<uint8_t>(raw.size());
+    }
+    void setHash(bcos::h256 const& digest) noexcept
+    {
+        std::copy(digest.begin(), digest.end(), payload.begin());
+        len = static_cast<uint8_t>(bcos::h256::SIZE);
+    }
+
+    static NodeRef fromInline(bcos::bytesConstRef raw) noexcept
+    {
+        NodeRef ref;
+        ref.setInline(raw);
+        return ref;
+    }
+    static NodeRef fromHash(bcos::h256 const& digest) noexcept
+    {
+        NodeRef ref;
+        ref.setHash(digest);
+        return ref;
+    }
+
+    /// Explicit factory for the absent-child sentinel. Identical to default-construction;
+    /// named for self-documenting call sites.
+    static NodeRef absent() noexcept { return NodeRef{}; }
 };
 
 /// A branch node: 16 child references (one per hex nibble) plus an optional value.
 struct BranchNode
 {
-    /// Default-constructed = Inline + empty (absent child)
+    /// Default-constructed = absent child (len == 0)
     std::array<NodeRef, NIBBLE_RANGE> children;
     ///< Typically empty for internal branch nodes
     bcos::bytes value;

--- a/bcos-ledger/test/unittests/mpt/HashBuilderIncrementalTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/HashBuilderIncrementalTest.cpp
@@ -151,9 +151,9 @@ std::unordered_set<bcos::h256> reachableHashes(NodeStorage& storage, bcos::h256 
         {
             for (auto const& child : branch->children)
             {
-                if (child.kind == NodeRef::Kind::Hash)
+                if (child.kind() == NodeRef::Kind::Hash)
                 {
-                    queue.push_back(child.hash);
+                    queue.push_back(child.hash());
                 }
             }
         }
@@ -352,8 +352,8 @@ BOOST_AUTO_TEST_CASE(BranchCollapseKeepsUntouchedBranchUnrebuilt)
     BOOST_REQUIRE(rootRaw.has_value());
     auto const rootNode = decodeNode(bcos::ref(*rootRaw));
     auto const& rootBranch = std::get<BranchNode>(rootNode);
-    BOOST_REQUIRE(rootBranch.children[1].kind == NodeRef::Kind::Hash);
-    auto const untouchedChild = rootBranch.children[1].hash;
+    BOOST_REQUIRE(rootBranch.children[1].kind() == NodeRef::Kind::Hash);
+    auto const untouchedChild = rootBranch.children[1].hash();
 
     std::unordered_map<bcos::h256, bcos::bytes> newNodes;
     std::unordered_set<bcos::h256> obsoleted;

--- a/bcos-ledger/test/unittests/mpt/NodeDecoderTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/NodeDecoderTest.cpp
@@ -129,11 +129,9 @@ BOOST_AUTO_TEST_CASE(RoundTripBranchMixedChildren)
 
     BranchNode branch;
     // children[0] absent (default)
-    branch.children[3].kind = NodeRef::Kind::Hash;
-    branch.children[3].hash =
-        bcos::h256("0x2222222222222222222222222222222222222222222222222222222222222222");
-    branch.children[10].kind = NodeRef::Kind::Inline;
-    branch.children[10].inlineBytes = tinyRaw;
+    branch.children[3].setHash(
+        bcos::h256("0x2222222222222222222222222222222222222222222222222222222222222222"));
+    branch.children[10].setInline(bcos::ref(tinyRaw));
     // value left empty
 
     bcos::bytes raw = encodeRaw(TrieNode{branch});
@@ -142,14 +140,14 @@ BOOST_AUTO_TEST_CASE(RoundTripBranchMixedChildren)
     BOOST_REQUIRE(std::holds_alternative<BranchNode>(decoded));
     auto const& got = std::get<BranchNode>(decoded);
     // child 0 absent
-    BOOST_CHECK(got.children[0].kind == NodeRef::Kind::Inline);
-    BOOST_CHECK(got.children[0].inlineBytes.empty());
+    BOOST_CHECK(got.children[0].kind() == NodeRef::Kind::Inline);
+    BOOST_CHECK(got.children[0].isAbsent());
     // child 3 hash
-    BOOST_CHECK(got.children[3].kind == NodeRef::Kind::Hash);
-    BOOST_CHECK(got.children[3].hash == branch.children[3].hash);
+    BOOST_CHECK(got.children[3].kind() == NodeRef::Kind::Hash);
+    BOOST_CHECK(got.children[3].hash() == branch.children[3].hash());
     // child 10 inline
-    BOOST_CHECK(got.children[10].kind == NodeRef::Kind::Inline);
-    BOOST_CHECK(got.children[10].inlineBytes == tinyRaw);
+    BOOST_CHECK(got.children[10].kind() == NodeRef::Kind::Inline);
+    BOOST_CHECK(got.children[10].inlineRef().toBytes() == tinyRaw);
     BOOST_CHECK(got.value.empty());
     BOOST_CHECK(encodeRaw(decoded) == raw);
 }

--- a/bcos-ledger/test/unittests/mpt/NodeEncoderTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/NodeEncoderTest.cpp
@@ -47,8 +47,8 @@ BOOST_AUTO_TEST_CASE(EncodeLeafShort)
 
     BOOST_CHECK(!raw.empty());
     BOOST_CHECK(raw.size() < 32);
-    BOOST_CHECK(ref.kind == NodeRef::Kind::Inline);
-    BOOST_CHECK(ref.inlineBytes == raw);
+    BOOST_CHECK(ref.kind() == NodeRef::Kind::Inline);
+    BOOST_CHECK(ref.inlineRef().toBytes() == raw);
 }
 
 // ---------------------------------------------------------------------------
@@ -65,17 +65,16 @@ BOOST_AUTO_TEST_CASE(EncodeBranchHashedWhenLarge)
 
     BranchNode branch;
     // Set children[0] to a Hash-kind ref with a dummy 32-byte hash
-    branch.children[0].kind = NodeRef::Kind::Hash;
-    branch.children[0].hash =
-        bcos::h256("0x1111111111111111111111111111111111111111111111111111111111111111");
+    branch.children[0].setHash(
+        bcos::h256("0x1111111111111111111111111111111111111111111111111111111111111111"));
 
     auto [raw, ref] = NodeEncoder<>::encodeAndRef(TrieNode{branch});
 
     // 33 (hash child) + 15 × 1 (absent children) + 1 (empty value) = 49 payload → 50 total
     BOOST_CHECK(raw.size() >= 32);
-    BOOST_CHECK(ref.kind == NodeRef::Kind::Hash);
+    BOOST_CHECK(ref.kind() == NodeRef::Kind::Hash);
     // Hash must be exactly 32 bytes
-    BOOST_CHECK_EQUAL(ref.hash.size(), 32u);
+    BOOST_CHECK_EQUAL(ref.hash().size(), 32u);
 }
 
 // ---------------------------------------------------------------------------
@@ -122,8 +121,8 @@ BOOST_AUTO_TEST_CASE(InlineThresholdAt31Bytes)
 
         auto [raw, ref] = NodeEncoder<>::encodeAndRef(TrieNode{leaf});
         BOOST_CHECK_EQUAL(raw.size(), 31u);
-        BOOST_CHECK(ref.kind == NodeRef::Kind::Inline);
-        BOOST_CHECK(ref.inlineBytes == raw);
+        BOOST_CHECK(ref.kind() == NodeRef::Kind::Inline);
+        BOOST_CHECK(ref.inlineRef().toBytes() == raw);
     }
 
     // 32-byte encoding → Hash
@@ -134,9 +133,9 @@ BOOST_AUTO_TEST_CASE(InlineThresholdAt31Bytes)
 
         auto [raw, ref] = NodeEncoder<>::encodeAndRef(TrieNode{leaf});
         BOOST_CHECK_EQUAL(raw.size(), 32u);
-        BOOST_CHECK(ref.kind == NodeRef::Kind::Hash);
-        BOOST_CHECK_EQUAL(ref.hash.size(), 32u);
-        BOOST_CHECK(ref.inlineBytes.empty());
+        BOOST_CHECK(ref.kind() == NodeRef::Kind::Hash);
+        BOOST_CHECK_EQUAL(ref.hash().size(), 32u);
+        BOOST_CHECK(!ref.isAbsent());
     }
 }
 

--- a/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
@@ -144,18 +144,18 @@ ChainCheck verifyProofChain(
             }
             NodeRef const& child = branch.children.at(path.at(pos));
             ++pos;
-            if (child.kind == NodeRef::Kind::Hash)
+            if (child.kind() == NodeRef::Kind::Hash)
             {
-                expected = child.hash;
+                expected = child.hash();
                 needNextItem = true;
             }
-            else if (child.inlineBytes.empty())
+            else if (child.isAbsent())
             {
                 return finish();  // absent child: dead end
             }
             else
             {
-                TrieNode next = decodeNode(bcos::ref(child.inlineBytes));
+                TrieNode next = decodeNode(child.inlineRef());
                 node = std::move(next);
             }
         }

--- a/bcos-ledger/test/unittests/mpt/TestHelpers.h
+++ b/bcos-ledger/test/unittests/mpt/TestHelpers.h
@@ -259,14 +259,14 @@ inline NodeRef refEncode(
     {
         NodeRef const childRef = refEncode(node->extChild, hasher);
         bcos::bytes childRaw;
-        if (childRef.kind == NodeRef::Kind::Inline)
+        if (childRef.kind() == NodeRef::Kind::Inline)
         {
-            childRaw = childRef.inlineBytes;
+            childRaw = childRef.inlineRef().toBytes();
         }
         else
         {
             childRaw.push_back(0xa0);
-            childRaw.insert(childRaw.end(), childRef.hash.begin(), childRef.hash.end());
+            childRaw.insert(childRaw.end(), childRef.payload.begin(), childRef.payload.end());
         }
         ExtensionNode ext;
         ext.sharedNibbles = node->path;
@@ -302,13 +302,13 @@ inline bcos::h256 referenceRoot(std::vector<std::pair<bcos::h256, bcos::bytes>> 
     bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
     NodeRef const rootRef = reftrie::refEncode(rootNode, hasher);
     bcos::h256 root;
-    if (rootRef.kind == NodeRef::Kind::Hash)
+    if (rootRef.kind() == NodeRef::Kind::Hash)
     {
-        root = rootRef.hash;
+        root = rootRef.hash();
     }
     else
     {
-        bcos::crypto::hasher::hash(hasher, bcos::ref(rootRef.inlineBytes), root);
+        bcos::crypto::hasher::hash(hasher, rootRef.inlineRef(), root);
     }
     return root;
 }

--- a/bcos-ledger/test/unittests/mpt/TrieNodeSizeTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/TrieNodeSizeTest.cpp
@@ -1,0 +1,130 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TrieNodeSizeTest.cpp
+ * @brief Fixed-size NodeRef: sizeof budget + inline/hash/absent round-trips (spec §5.5, M12)
+ */
+
+#include <bcos-ledger/mpt/NodeDecoder.h>
+#include <bcos-ledger/mpt/NodeEncoder.h>
+#include <bcos-ledger/mpt/TrieMerge.h>
+#include <bcos-ledger/mpt/TrieNode.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::ledger::mpt::test
+{
+
+// The point of the fixed-size NodeRef: payload(32) + len(1) = 33 bytes flat, no heap. The old
+// representation held bytes(24) + h256(32) + kind side by side → 64 bytes and one heap
+// allocation per inline child; BranchNode carried 16 of them.
+static_assert(sizeof(NodeRef) <= 40, "NodeRef must stay pointer-free and ~33 bytes");
+static_assert(sizeof(BranchNode) <= 576, "BranchNode = 16 x NodeRef + value bytes");
+static_assert(sizeof(TrieNode) <= 640, "TrieNode variant is bounded by BranchNode");
+
+BOOST_AUTO_TEST_SUITE(TrieNodeSizeSuite)
+
+// Default construction is the absent-child sentinel and encodes as RLP-empty (0x80).
+BOOST_AUTO_TEST_CASE(AbsentChildSemantics)
+{
+    NodeRef const ref = NodeRef::absent();
+    BOOST_CHECK(ref.isAbsent());
+    BOOST_CHECK(ref.kind() == NodeRef::Kind::Inline);
+    BOOST_CHECK_EQUAL(ref.inlineRef().size(), 0U);
+
+    // A branch of 16 absent children + empty value encodes as 17 x 0x80 behind the list header.
+    bcos::bytes const raw = encodeRaw(TrieNode{BranchNode{}});
+    BOOST_REQUIRE_EQUAL(raw.size(), 18U);
+    for (size_t i = 1; i < raw.size(); ++i)
+    {
+        BOOST_CHECK_EQUAL(raw[i], 0x80);
+    }
+
+    // ... and decodes back to 16 absent children.
+    TrieNode const decoded = decodeNode(bcos::ref(raw));
+    for (auto const& child : std::get<BranchNode>(decoded).children)
+    {
+        BOOST_CHECK(child.isAbsent());
+    }
+}
+
+// Inline form survives encoder → decoder: a tiny leaf child comes back byte-identical.
+BOOST_AUTO_TEST_CASE(InlineFormRoundTrip)
+{
+    LeafNode tiny;
+    tiny.keyNibbles = {0xa};
+    tiny.value = bcos::bytes{0x2a};
+    bcos::bytes const tinyRaw = encodeRaw(TrieNode{tiny});
+    BOOST_REQUIRE(tinyRaw.size() < bcos::h256::SIZE);
+
+    auto const [raw, ref] = NodeEncoder<>::encodeAndRef(TrieNode{tiny});
+    BOOST_CHECK(ref.kind() == NodeRef::Kind::Inline);
+    BOOST_CHECK(!ref.isAbsent());
+    BOOST_CHECK(ref.inlineRef().toBytes() == tinyRaw);
+
+    BranchNode branch;
+    branch.children[5] = ref;
+    TrieNode const decoded = decodeNode(bcos::ref(encodeRaw(TrieNode{branch})));
+    auto const& got = std::get<BranchNode>(decoded);
+    BOOST_CHECK(got.children[5].kind() == NodeRef::Kind::Inline);
+    BOOST_CHECK(got.children[5].inlineRef().toBytes() == tinyRaw);
+}
+
+// Hash form survives encoder → decoder: a >= 32-byte leaf child comes back as the same digest.
+BOOST_AUTO_TEST_CASE(HashFormRoundTrip)
+{
+    LeafNode big;
+    big.keyNibbles = {1, 2, 3, 4};
+    big.value = bcos::bytes(40, 0xee);
+
+    auto const [raw, ref] = NodeEncoder<>::encodeAndRef(TrieNode{big});
+    BOOST_REQUIRE(raw.size() >= bcos::h256::SIZE);
+    BOOST_CHECK(ref.kind() == NodeRef::Kind::Hash);
+    BOOST_CHECK(!ref.isAbsent());
+    BOOST_CHECK(ref.hash() != bcos::h256{});
+
+    BranchNode branch;
+    branch.children[9] = ref;
+    TrieNode const decoded = decodeNode(bcos::ref(encodeRaw(TrieNode{branch})));
+    auto const& got = std::get<BranchNode>(decoded);
+    BOOST_CHECK(got.children[9].kind() == NodeRef::Kind::Hash);
+    BOOST_CHECK(got.children[9].hash() == ref.hash());
+}
+
+// refToRawBytes / refFromRawBytes (ExtensionNode.child glue) invert each other in both forms.
+BOOST_AUTO_TEST_CASE(RawBytesGlueRoundTrip)
+{
+    NodeRef const hashRef = NodeRef::fromHash(
+        bcos::h256("0x3333333333333333333333333333333333333333333333333333333333333333"));
+    bcos::bytes const hashRaw = detail::refToRawBytes(hashRef);
+    BOOST_REQUIRE_EQUAL(hashRaw.size(), 33U);
+    BOOST_CHECK_EQUAL(hashRaw[0], 0xa0);
+    NodeRef const hashBack = detail::refFromRawBytes(hashRaw);
+    BOOST_CHECK(hashBack.kind() == NodeRef::Kind::Hash);
+    BOOST_CHECK(hashBack.hash() == hashRef.hash());
+
+    bcos::bytes const tinyRaw = encodeRaw(TrieNode{LeafNode{.keyNibbles = {7}, .value = {0x01}}});
+    NodeRef const inlineRef = NodeRef::fromInline(bcos::ref(tinyRaw));
+    bcos::bytes const inlineRaw = detail::refToRawBytes(inlineRef);
+    BOOST_CHECK(inlineRaw == tinyRaw);
+    NodeRef const inlineBack = detail::refFromRawBytes(inlineRaw);
+    BOOST_CHECK(inlineBack.kind() == NodeRef::Kind::Inline);
+    BOOST_CHECK(inlineBack.inlineRef().toBytes() == tinyRaw);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/TrieNodeSizeTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/TrieNodeSizeTest.cpp
@@ -17,6 +17,7 @@
  * @brief Fixed-size NodeRef: sizeof budget + inline/hash/absent round-trips (spec §5.5, M12)
  */
 
+#include <bcos-ledger/mpt/Errors.h>
 #include <bcos-ledger/mpt/NodeDecoder.h>
 #include <bcos-ledger/mpt/NodeEncoder.h>
 #include <bcos-ledger/mpt/TrieMerge.h>
@@ -32,8 +33,10 @@ namespace bcos::ledger::mpt::test
 // representation held bytes(24) + h256(32) + kind side by side → 64 bytes and one heap
 // allocation per inline child; BranchNode carried 16 of them.
 static_assert(sizeof(NodeRef) <= 40, "NodeRef must stay pointer-free and ~33 bytes");
-static_assert(sizeof(BranchNode) <= 576, "BranchNode = 16 x NodeRef + value bytes");
-static_assert(sizeof(TrieNode) <= 640, "TrieNode variant is bounded by BranchNode");
+// With children moved behind a vector (one 16 x 33B heap block), the BranchNode struct is just
+// vector + bytes, and the TrieNode variant no longer pays BranchNode's inline footprint.
+static_assert(sizeof(BranchNode) <= 56, "BranchNode struct = children vector + value bytes");
+static_assert(sizeof(TrieNode) <= 64, "TrieNode variant must stay small (~56 bytes)");
 
 BOOST_AUTO_TEST_SUITE(TrieNodeSizeSuite)
 
@@ -53,12 +56,25 @@ BOOST_AUTO_TEST_CASE(AbsentChildSemantics)
         BOOST_CHECK_EQUAL(raw[i], 0x80);
     }
 
-    // ... and decodes back to 16 absent children.
+    // ... and decodes back to exactly 16 absent children (the invariant every consumer relies
+    // on now that children is a vector).
     TrieNode const decoded = decodeNode(bcos::ref(raw));
+    BOOST_REQUIRE_EQUAL(std::get<BranchNode>(decoded).children.size(), NIBBLE_RANGE);
     for (auto const& child : std::get<BranchNode>(decoded).children)
     {
         BOOST_CHECK(child.isAbsent());
     }
+}
+
+// The 16-slot invariant is convention now: default construction yields 16 slots, and the
+// encoder must reject any other width instead of silently emitting a wrong-arity list.
+BOOST_AUTO_TEST_CASE(BranchChildrenWidthInvariant)
+{
+    BOOST_CHECK_EQUAL(BranchNode{}.children.size(), NIBBLE_RANGE);
+
+    BranchNode malformed;
+    malformed.children.pop_back();
+    BOOST_CHECK_THROW(encodeRaw(TrieNode{std::move(malformed)}), MPTInvariantViolation);
 }
 
 // Inline form survives encoder → decoder: a tiny leaf child comes back byte-identical.


### PR DESCRIPTION
## What

Two composed commits that slim the MPT node representation.

**Commit 1 — fixed-size NodeRef.** `NodeRef` carried a `bytes` vector (24B) and an `h256` (32B) side by side even though only one payload is ever live, so each ref was 64B plus a heap allocation for every inline child, and `BranchNode` (16 refs + value) bloated the `TrieNode` variant to ~1056B while Leaf/Extension are 48B. The Yellow Paper §D 32-byte rule guarantees an inline ref's RLP is strictly < 32 bytes and a hash ref is exactly 32 bytes (`NodeEncoder` already branches on `raw.size() < h256::SIZE`), so both forms now share one fixed 32-byte buffer discriminated by a single length field: `len == 0` = absent child, `1..31` = inline RLP of that length, `32` = keccak hash. No heap allocation, no separate `Kind` storage.

**Commit 2 — BranchNode children behind a vector.** Even at 33B per ref, 16 inline refs kept `BranchNode` at 552B, and `std::variant` sizes to its largest alternative — every `LeafNode`/`ExtensionNode` instance, by-value `TrieNode` move and `Task<TrieNode>` coroutine frame paid BranchNode's footprint. `children` is now `std::vector<NodeRef>` (one 16 × 33B = 528B heap block), dropping the variant to 56B. `MutableBranch`/`MutableChild` in TrieMerge.h stay array-based — they are already heap-allocated behind `unique_ptr<MutableNode>`.

## Size accounting

| type | before | after |
|---|---|---|
| `NodeRef` | 64B (+ heap for inline) | 33B flat |
| `BranchNode` | 1048B | 48B struct + 528B heap children block |
| `TrieNode` variant | ~1056B | 56B |
| `MutableChild` (TrieMerge overlay) | 72B | 48B |
| `MutableBranch` | 1152B | 768B |
| `MutableNode` | ~1208B | 824B |

## Tradeoff

Each decoded branch now costs ~40B net more (48B struct + 528B block vs 552B inline) plus one heap allocation, while every leaf/extension instance shrinks 560B → 56B and by-value `TrieNode` moves / coroutine frames shrink accordingly. The "exactly 16 slots" invariant degrades from type-level to convention, enforced twice: a default member initializer makes every default-constructed `BranchNode` NIBBLE_RANGE-wide (all construction sites use default init), and `encodeBranch` throws `MPTInvariantViolation` on any other width instead of silently emitting a wrong-arity RLP list.

## API compatibility

The `Kind` enum is kept and derived from `len`; accessors (`kind()`, `hash()`, `inlineRef()`, `isAbsent()`, `setInline()`, `setHash()`, `fromHash()`, `fromInline()`, `absent()`) keep every call site source-compatible in shape, so the in-flight #5316 (Proof code consuming NodeRef) only needs the mechanical field→accessor spelling, not a semantic rework. All `children` consumers index or iterate (`[i]`, `.at()`, range-for, structured binding), so the array→vector switch changes no call-site spelling. `ExtensionNode::child` (raw-RLP bytes) is deliberately out of scope.

Tightened validation as a side effect of the fixed buffer: `NodeDecoder` and `TrieMerge::refFromRawBytes` now reject inline child refs of >= 32 bytes (malformed by the 32-byte rule; previously accepted silently).

## Tests

- New `TrieNodeSizeTest.cpp`: `static_assert(sizeof(TrieNode) <= 64)` (and NodeRef/BranchNode budgets), absent-child semantics (default ref encodes as RLP-empty 0x80, decoded branch has exactly 16 children), inline-form and hash-form round-trips through encoder/decoder, `refToRawBytes`/`refFromRawBytes` inversion, and a `BranchChildrenWidthInvariant` case: default construction yields 16 slots and encoding a 15-wide branch throws `MPTInvariantViolation`.
- Full `test-bcos-ledger` binary green locally (`*** No errors detected`), including all 88 mpt suite cases (ComputeTrieRoot / HashBuilder / HashBuilderIncremental / NodeEncoder / NodeDecoder / ProofGenerate / MPTReadView / MPTBuilder / Trie).
- Test file additionally compiled standalone with `-fsyntax-only` from the target's flags.make (unity-build include-leak guard), with a negative control.
