### PR TITLE
feat(mpt): MPTAccount — EVMAccount with an opt-in historical read path (M13.1)

### DIFF
--- a/bcos-framework/bcos-framework/ledger/Account.h
+++ b/bcos-framework/bcos-framework/ledger/Account.h
@@ -1,10 +1,29 @@
 #pragma once
 #include "../storage/Entry.h"
 #include "bcos-task/Trait.h"
+#include <bcos-utilities/FixedBytes.h>
 #include <evmc/evmc.h>
+#include <algorithm>
+#include <iterator>
 
 namespace bcos::ledger::account
 {
+
+/// The Account interface speaks evmc_bytes32 while storage and crypto speak h256, so every
+/// implementation converts between the two. Shared here rather than re-privatised per class:
+/// bcos-executor has its own toEvmC/fromEvmC (executor-private Common.h, and fromEvmC yields
+/// u256 rather than h256), which layers below the executor cannot include.
+inline h256 toH256(const evmc_bytes32& value)
+{
+    return h256{bytesConstRef{value.bytes, sizeof(value.bytes)}};
+}
+
+inline evmc_bytes32 toEvmcBytes32(h256 const& value)
+{
+    evmc_bytes32 out{};
+    std::copy(value.begin(), value.end(), std::begin(out.bytes));
+    return out;
+}
 template <class AccountType>
 concept Account = requires(AccountType account) {
     { account.exists() } -> task::IsAwaitableReturnValue<bool>;

--- a/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  * @file MPTAccount.h
- * @brief EVMAccount subclass whose reads walk the MPT at a fixed root, for historical calls
+ * @brief EVMAccount plus opt-in historical reads through the MPT at a caller-supplied root
  * (spec §5.13)
  */
 #pragma once
@@ -25,8 +25,8 @@
 #include "MPTReadView.h"
 #include "StorageValueCodec.h"
 #include "Trie.h"
-#include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-concepts/ByteBuffer.h>
+#include <bcos-framework/ledger/Account.h>
 #include <bcos-framework/ledger/EVMAccount.h>
 #include <bcos-framework/ledger/LedgerTypeDef.h>
 #include <bcos-framework/storage/Entry.h>
@@ -36,8 +36,7 @@
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <evmc/evmc.h>
-#include <boost/throw_exception.hpp>
-#include <algorithm>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -45,52 +44,55 @@
 namespace bcos::ledger::mpt
 {
 
-/// A Storage that carries the MPT read context, so MPTAccount stays constructible with
-/// HostContext's fixed (storage, address, binaryAddress) shape (HostContext.h getAccount /
-/// executeCreate): the historical storage stack PR-43 builds exposes these three getters and
-/// MPTAccount pulls its trie context out of them at construction.
+/// A Storage that carries the MPT node/backend handles, letting MPTAccount keep EVMAccount's
+/// fixed (storage, address, binaryAddress) construction shape — the one HostContext uses.
+///
+/// Reserved for PR-43; nothing outside the tests satisfies it yet. It exists so a historical
+/// storage stack can hand HostContext an Account type without widening HostContext's three
+/// construction sites, and it constrains that swap to storages that actually carry MPT handles.
 template <class Storage>
 concept HistoricalStorageContext = requires(Storage& storage) {
     { storage.mptNodeStorage() };
     { storage.mptBackendStorage() };
-    { storage.mptStateRoot() } -> std::convertible_to<bcos::h256>;
 };
 
-/// EVMAccount subclass for historical calls (spec §5.13): an eth_call against block N swaps this
-/// class in for EVMAccount (HostContext is coded against the Account concept, statically
-/// dispatched, so the shadowed methods below win) and executes on block N's trie.
+/// EVMAccount with an opt-in historical read path (spec §5.13).
 ///
-/// READS are pure MPT walks at the fixed @p stateRoot, never layered over anything:
-/// balance()/nonce()/codeHash() come from the account leaf 4-tuple (MPTReadView::readAccount);
-/// storage(key) takes the leaf's storageRoot and descends the storage trie along
-/// slotKeyHash(key); code()/abi() resolve the leaf's codeHash through the flat
-/// s_code_binary / s_contract_abi tables — hash-addressed and append-only, so their rows are
-/// valid for ANY historical block (spec §4.5).
+/// Every read takes an OPTIONAL state root, empty by default:
+///   - empty (the default, and what HostContext's no-argument calls produce) → the inherited
+///     EVMAccount behaviour, unchanged: flat KV reads and writes against @p Storage. Reads see
+///     this call's own writes, so read-your-writes, nonce advance and CREATE all behave exactly
+///     as they do on the latest state.
+///   - a value → a historical read at that root: the account leaf 4-tuple through
+///     MPTReadView::readAccount, storage slots through the leaf's storageRoot along
+///     slotKeyHash(key), code through the leaf's codeHash. Nothing is written; the MPT is only
+///     ever read.
 ///
-/// WRITES are inherited from EVMAccount verbatim (create/setCode/setBalance/setNonce/setStorage)
-/// and land as flat rows in @p Storage. They exist so a simulated call can execute, but block N
-/// is immutable and reads never consult @p Storage: a write in a historical call is NOT visible
-/// to a subsequent read of the same field/slot (SSTORE then SLOAD returns the historical value).
-/// Historical calls target view-style execution; this boundary is deliberate (spec §5.13).
-/// Nothing ever writes the node storage — MPTAccount only reads it.
+/// The historical path is a point-query facility (eth_getBalance / eth_getStorageAt / eth_getCode
+/// at block N, and the state source a historical-call storage stack resolves misses from), NOT a
+/// mode the object is locked into: a caller that never passes a root cannot tell this class from
+/// EVMAccount.
 ///
-/// Absence semantics are Ethereum semantics, NOT errors: an account missing from the trie reads
-/// as exists()==false / balance 0 / nonce nullopt / zero codeHash; a slot missing from the
-/// storage trie reads as the zero value. This class targets scenario B (genesis-enabled MPT,
-/// spec §4.4), where the trie is the COMPLETE state and exclusion genuinely means zero/empty.
-/// Scenario-A cold data makes exclusion ambiguous — gating historical calls to scenario B is the
-/// eth_call plumbing layer's job (PR-43, per OQ6 resolution (c)+(a)), not this class's.
+/// Absence at a given root is Ethereum semantics, not an error: an account with no leaf reads as
+/// exists()==false / balance 0 / nonce nullopt / zero codeHash, and a slot with no leaf reads as
+/// zero. That is exact for scenario B (genesis-enabled MPT, spec §4.4), where the trie is the
+/// complete state. Scenario-A cold data makes exclusion ambiguous, so gating historical queries
+/// to scenario B is the caller's job (PR-43, per OQ6 resolution (c)+(a)).
 ///
-/// Like MPTReadView, each read walks from the root with a fresh Trie: the object holds no
-/// mutable state (node-level caching is the Storage layer's concern), so HostContext's
-/// construct-per-use pattern is loss-free. The account+storage tries are keccak paths end-to-end
-/// (accountKeyHash / slotKeyHash defaults), matching what MPTBuilder committed.
+/// abi() and increaseNonce() are inherited unchanged. abi is BCOS metadata outside the committed
+/// 4-tuple and is deliberately not historicised — a historical query returns the CURRENT abi,
+/// because the base resolves it through today's flat codeHash. increaseNonce() is a write helper
+/// that reads the base's flat nonce, which is what the default (latest) path wants.
 ///
-/// @tparam Storage        where the inherited EVMAccount writes land (and the table name comes
-///                        from); never consulted by reads.
-/// @tparam NodeStorage    resolves trie node hashes (same concept MPTReadView eats).
-/// @tparam BackendStorage flat store holding s_code_binary / s_contract_abi (hash-addressed,
-///                        history-invariant), read by executor_v1::StateKeyView.
+/// The object caches the leaf it last decoded, keyed by root, so K reads of one historical query
+/// cost one trie descent. That makes it stateful, unlike EVMAccount: one instance must not be
+/// shared across concurrent coroutines. HostContext's construct-per-use pattern (HostContext.h:117
+/// /271/363) keeps that trivially true, and the cache costs nothing there because it is per-object.
+///
+/// @tparam Storage        the flat KV the inherited EVMAccount behaviour reads and writes.
+/// @tparam NodeStorage    resolves trie node hashes (the concept MPTReadView eats).
+/// @tparam BackendStorage flat store holding s_code_binary (hash-addressed, so its rows are
+///                        valid for any historical block, spec §4.5).
 template <class Storage, bcos::storage2::ReadableStorage<bcos::h256> NodeStorage,
     class BackendStorage>
 class MPTAccount : public bcos::ledger::account::EVMAccount<Storage>
@@ -99,26 +101,35 @@ private:
     using Base = bcos::ledger::account::EVMAccount<Storage>;
 
 public:
-    /// Direct construction (tests, callers that already hold the trie context).
-    /// @param storage   write target for the inherited EVMAccount write methods.
-    /// @param stateRoot block N's state root; emptyRootHash() means "no accounts".
+    /// Direct construction, for callers that already hold the trie handles (tests, tooling).
+    /// @param binaryAddress the caller's feature_raw_address setting, exactly as EVMAccount
+    /// takes it — deliberately without a default: it decides the flat table name every
+    /// no-root read and every inherited write uses, and guessing it wrong makes those reads
+    /// silently miss on a raw-address chain.
     MPTAccount(Storage& storage, NodeStorage& nodeStorage, BackendStorage& backendStorage,
-        bcos::h256 stateRoot, bcos::Address address)
-      : Base(storage, address, /*binaryAddress*/ false),
+        bcos::Address address, bool binaryAddress)
+      : Base(storage, address, binaryAddress),
+        m_storage(storage),
         m_nodeStorage(nodeStorage),
         m_backendStorage(backendStorage),
-        m_stateRoot(stateRoot),
         m_address(address)
     {}
 
-    /// HostContext-shaped construction: same (storage, address, binaryAddress) signature as
-    /// EVMAccount, with the trie context riding on the storage type (PR-43's historical stack).
+    /// EVMAccount's construction shape, for the historical storage stack PR-43 builds: the trie
+    /// handles ride on the storage type instead of being extra arguments. No production caller
+    /// yet — HostContext still names EVMAccount at HostContext.h:100.
+    ///
+    /// Swapping this class in there does NOT by itself make a call historical: HostContext passes
+    /// no root, so every read lands on the inherited path and behaves byte-for-byte like
+    /// EVMAccount. Historical base state comes from the storage stack PR-43 builds (a writable
+    /// layer over a read-through layer that resolves misses through the rooted reads below), not
+    /// from the account type.
     MPTAccount(Storage& storage, const evmc_address& address, bool binaryAddress)
         requires HistoricalStorageContext<Storage>
       : Base(storage, address, binaryAddress),
+        m_storage(storage),
         m_nodeStorage(storage.mptNodeStorage()),
         m_backendStorage(storage.mptBackendStorage()),
-        m_stateRoot(storage.mptStateRoot()),
         m_address(bcos::bytesConstRef{address.bytes, sizeof(address.bytes)})
     {}
 
@@ -128,46 +139,70 @@ public:
     MPTAccount& operator=(MPTAccount&&) noexcept = default;
     ~MPTAccount() noexcept = default;
 
-    /// True when the account has a leaf in block N's trie. A create() in this call writes the
-    /// s_tables row into Storage (inherited) but does not change what block N contains.
-    bcos::task::Task<bool> exists()
+    /// Whether the account exists — in the flat state, or (with a root) in that block's trie.
+    bcos::task::Task<bool> exists(std::optional<bcos::h256> stateRoot = {})
     {
-        auto const account = co_await readLeaf();
+        if (!stateRoot)
+        {
+            co_return co_await Base::exists();
+        }
+        auto const account = co_await readLeaf(*stateRoot);
         co_return account.has_value();
     }
 
-    /// The code bytes at block N: the leaf's codeHash resolved through s_code_binary. An absent
-    /// account or an EOA (emptyCodeHash) has no code. A leaf that commits a non-empty codeHash
-    /// with NO matching s_code_binary row is a corrupted backend or a mis-wired code write path,
-    /// not an EOA — silently returning nullopt would downgrade the account and execute the call
-    /// wrong, so it throws instead (the append-only, hash-addressed code table makes the row's
-    /// existence an invariant; EIP-7702 delegation designators are ordinary hash-addressed code
-    /// and are covered by the same invariant).
-    bcos::task::Task<std::optional<bcos::storage::Entry>> code()
+    /// The code bytes. With a root: the leaf's codeHash resolved through s_code_binary, falling
+    /// back to the account table's code field when that row is missing — EVMAccount's own last
+    /// resort, and where contracts deployed by old versions and internal precompiled keep their
+    /// code. The fallback reads ONLY that field, never the full base resolution: the base
+    /// starts from today's flat codeHash, which for an address whose code changed since would
+    /// return bytes hashing to something other than the codeHash this very object reports.
+    /// An account absent from the trie has no code and does NOT fall back at all — it did not
+    /// exist at that block, and the flat tables only hold today's value.
+    ///
+    /// Neither source holding the code is an invariant violation, not an absence: a leaf that
+    /// commits a non-empty codeHash asserts the code existed at that block, so failing to find it
+    /// means the store is corrupt or pruned. Reporting nullopt there would make the EVM read the
+    /// contract as an EOA and answer a call to it with success and empty output — a wrong result
+    /// the caller cannot distinguish from a right one. Throwing is loud instead; the historical
+    /// call path (PR-43) must catch it at the RPC boundary, as it must MPTDecodeError.
+    bcos::task::Task<std::optional<bcos::storage::Entry>> code(
+        std::optional<bcos::h256> stateRoot = {})
     {
-        auto const account = co_await readLeaf();
+        if (!stateRoot)
+        {
+            co_return co_await Base::code();
+        }
+        auto const account = co_await readLeaf(*stateRoot);
         if (!account || account->codeHash == emptyCodeHash())
         {
             co_return std::nullopt;
         }
-        auto codeEntry = co_await bcos::storage2::readOne(
-            m_backendStorage.get(), bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
-                                        bcos::concepts::bytebuffer::toView(account->codeHash)});
-        if (!codeEntry)
+        if (auto codeEntry = co_await bcos::storage2::readOne(m_backendStorage.get(),
+                bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
+                    bcos::concepts::bytebuffer::toView(account->codeHash)}))
         {
-            BOOST_THROW_EXCEPTION(
-                MPTInvariantViolation{} << bcos::errinfo_comment(
-                    "historical code(): account leaf commits codeHash " + account->codeHash.hex() +
-                    " but s_code_binary has no such row"));
+            co_return codeEntry;
         }
-        co_return codeEntry;
+        if (auto codeEntry = co_await bcos::storage2::readOne(
+                m_storage.get(), bcos::executor_v1::StateKeyView{
+                                     this->address(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE}))
+        {
+            co_return codeEntry;
+        }
+        BOOST_THROW_EXCEPTION(
+            MPTInvariantViolation{} << bcos::errinfo_comment(
+                "historical code(): account leaf commits codeHash " + account->codeHash.hex() +
+                " but neither s_code_binary nor the account table holds the code"));
     }
 
-    /// The leaf's codeHash; zero for an absent account (mirrors EVMAccount's missing-field
-    /// default).
-    bcos::task::Task<bcos::h256> codeHash()
+    /// The code hash: the leaf's, or (no root) the flat account row's.
+    bcos::task::Task<bcos::h256> codeHash(std::optional<bcos::h256> stateRoot = {})
     {
-        auto const account = co_await readLeaf();
+        if (!stateRoot)
+        {
+            co_return co_await Base::codeHash();
+        }
+        auto const account = co_await readLeaf(*stateRoot);
         if (!account)
         {
             co_return bcos::h256{};
@@ -175,26 +210,14 @@ public:
         co_return account->codeHash;
     }
 
-    /// The contract abi at block N: the leaf's codeHash resolved through s_contract_abi — like
-    /// s_code_binary it is hash-addressed and append-only, so the flat row is history-valid.
-    /// Unlike code(), a missing row is NOT an invariant violation: abi is BCOS metadata outside
-    /// the committed 4-tuple, so absence simply reads as nullopt.
-    bcos::task::Task<std::optional<bcos::storage::Entry>> abi()
+    /// The balance: the leaf's, or (no root) the flat account row's. Absent reads as 0.
+    bcos::task::Task<bcos::u256> balance(std::optional<bcos::h256> stateRoot = {})
     {
-        auto const account = co_await readLeaf();
-        if (!account || account->codeHash == emptyCodeHash())
+        if (!stateRoot)
         {
-            co_return std::nullopt;
+            co_return co_await Base::balance();
         }
-        co_return co_await bcos::storage2::readOne(
-            m_backendStorage.get(), bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CONTRACT_ABI,
-                                        bcos::concepts::bytebuffer::toView(account->codeHash)});
-    }
-
-    /// The leaf's balance; 0 for an absent account.
-    bcos::task::Task<bcos::u256> balance()
-    {
-        auto const account = co_await readLeaf();
+        auto const account = co_await readLeaf(*stateRoot);
         if (!account)
         {
             co_return bcos::u256{};
@@ -202,11 +225,15 @@ public:
         co_return account->balance;
     }
 
-    /// The leaf's nonce as a decimal string (EVMAccount's representation); nullopt for an absent
-    /// account.
-    bcos::task::Task<std::optional<std::string>> nonce()
+    /// The nonce as a decimal string (EVMAccount's representation): the leaf's, or (no root) the
+    /// flat account row's. Absent reads as nullopt.
+    bcos::task::Task<std::optional<std::string>> nonce(std::optional<bcos::h256> stateRoot = {})
     {
-        auto const account = co_await readLeaf();
+        if (!stateRoot)
+        {
+            co_return co_await Base::nonce();
+        }
+        auto const account = co_await readLeaf(*stateRoot);
         if (!account)
         {
             co_return std::nullopt;
@@ -214,56 +241,68 @@ public:
         co_return account->nonce.template convert_to<std::string>();
     }
 
-    /// Trie nonce + 1 written through the inherited setNonce (simulation only, like every
-    /// write); throws account::NonceNotInitialized for an absent account — same contract as
-    /// EVMAccount. Shadowed because the base version reads the flat nonce row, which historical
-    /// reads must not consult.
-    bcos::task::Task<void> increaseNonce()
-    {
-        auto const account = co_await readLeaf();
-        if (!account)
-        {
-            BOOST_THROW_EXCEPTION(bcos::ledger::account::NonceNotInitialized{});
-        }
-        auto const newNonce = account->nonce + 1;
-        co_await Base::setNonce(newNonce.template convert_to<std::string>());
-    }
+    // The inherited flat reads, including the tag-forwarding overload HostContext calls with
+    // BYPASS_READ_SET / BYPASS_MULTILAYER. Re-exported because the historical overload below
+    // would otherwise hide the whole storage() overload set.
+    using Base::storage;
 
-    /// SLOAD at block N: the leaf's storageRoot, then the storage trie along slotKeyHash(key).
-    /// Absent account, empty storage trie, or absent slot all read as the zero value.
-    bcos::task::Task<evmc_bytes32> storage(const evmc_bytes32& key)
+    /// SLOAD at @p stateRoot: the leaf's storageRoot, then the storage trie along
+    /// slotKeyHash(key). Absent account, empty storage trie, or absent slot all read as zero.
+    /// An empty root means the flat read, identical to the inherited storage(key).
+    bcos::task::Task<evmc_bytes32> storage(
+        const evmc_bytes32& key, std::optional<bcos::h256> stateRoot)
     {
-        auto const value = co_await readTrieSlot(toSlot(key));
+        if (!stateRoot)
+        {
+            co_return co_await Base::storage(key);
+        }
+        auto const value = co_await readTrieSlot(*stateRoot, bcos::ledger::account::toH256(key));
         if (!value)
         {
             co_return evmc_bytes32{};
         }
-        co_return toEvmcBytes(bcos::h256{*value});
+        co_return bcos::ledger::account::toEvmcBytes32(bcos::h256{*value});
     }
 
-    /// Tag-taking variant (see EVMAccount's tag-forwarding overload): HostContext passes
-    /// composable tags like BYPASS_READ_SET / BYPASS_MULTILAYER for metadata reads. MPTAccount
-    /// tracks no read set and has no layers, so every tag is a no-op and this is exactly
-    /// storage(key). (Both overloads are shadowed together — shadowing one would hide the
-    /// base's other overload.)
-    bcos::task::Task<evmc_bytes32> storage(const evmc_bytes32& key, auto... /*tags*/)
+    /// Same read for a plain root. This overload is REQUIRED, not sugar: without it a bare
+    /// h256 is an exact match for the inherited tag pack and only a conversion away from the
+    /// optional above, so storage(key, root) would silently resolve to the flat tag-forwarding
+    /// read and return today's value for a historical query.
+    bcos::task::Task<evmc_bytes32> storage(const evmc_bytes32& key, bcos::h256 const& stateRoot)
     {
-        co_return co_await storage(key);
+        co_return co_await storage(key, std::optional<bcos::h256>{stateRoot});
     }
 
-    /// The raw 32-byte slot value as a storage Entry (the shape BaselineScheduler's
-    /// getPendingStorageAt reads), or nullopt when the slot is absent. @p key is the raw 32-byte
-    /// slot key exactly as the flat KV stores it; only 32-byte keys can exist in a storage trie,
-    /// so any other length is absent by construction.
-    bcos::task::Task<std::optional<bcos::storage::Entry>> storageEntry(const std::string_view& key)
+    /// Likewise for a literal nullopt, which would otherwise be deduced as a tag and forwarded
+    /// into readOneRaw (harmless there, but by accident rather than by design).
+    bcos::task::Task<evmc_bytes32> storage(const evmc_bytes32& key, std::nullopt_t /*latest*/)
     {
+        co_return co_await Base::storage(key);
+    }
+
+    /// A root and storage tags CANNOT be combined: storage(key, root, BYPASS_READ_SET) matches
+    /// none of the overloads above on arity and lands on the inherited tag pack, which forwards
+    /// the root as if it were a tag and reads today's flat value. Read the historical slot and
+    /// the tagged flat slot as two separate calls.
+
+    /// The raw 32-byte slot value as a storage Entry, or nullopt when the slot is absent. With a
+    /// root, @p key must be a 32-byte slot key — nothing else can exist in a storage trie — so
+    /// any other length is absent by construction; the flat path keeps the base's behaviour of
+    /// reading any account-table field name.
+    bcos::task::Task<std::optional<bcos::storage::Entry>> storageEntry(
+        const std::string_view& key, std::optional<bcos::h256> stateRoot = {})
+    {
+        if (!stateRoot)
+        {
+            co_return co_await Base::storageEntry(key);
+        }
         if (key.size() != bcos::h256::SIZE)
         {
             co_return std::nullopt;
         }
         bcos::h256 const slot{
             bcos::bytesConstRef{reinterpret_cast<const bcos::byte*>(key.data()), key.size()}};
-        auto const value = co_await readTrieSlot(slot);
+        auto const value = co_await readTrieSlot(*stateRoot, slot);
         if (!value)
         {
             co_return std::nullopt;
@@ -272,27 +311,29 @@ public:
         co_return bcos::storage::Entry{bcos::concepts::bytebuffer::toView(padded)};
     }
 
-    // path() / address() are inherited: both return the EVMAccount table name ("/apps/<hex>",
-    // or the binary/system variants), so historical and latest accounts key transient storage
-    // and logs identically.
-
-    /// The state root this account reads against.
-    bcos::h256 root() const noexcept { return m_stateRoot; }
-
 private:
-    /// The account leaf 4-tuple at m_stateRoot, or nullopt when absent. Fresh walk per call.
-    bcos::task::Task<std::optional<Account>> readLeaf() const
+    /// The account leaf 4-tuple at @p stateRoot, or nullopt when absent. Cached per root: the
+    /// trie at a fixed root is immutable and reads never change it, so one walk serves every
+    /// field read and every slot read of the same historical query.
+    bcos::task::Task<std::optional<Account>> readLeaf(bcos::h256 const& stateRoot)
     {
-        MPTReadView<NodeStorage> const view{m_nodeStorage.get(), m_stateRoot};
-        co_return co_await view.readAccount(m_address);
+        if (m_cachedLeafRoot == stateRoot)
+        {
+            co_return m_cachedLeaf;
+        }
+        MPTReadView<NodeStorage> const view{m_nodeStorage.get(), stateRoot};
+        auto account = co_await view.readAccount(m_address);
+        m_cachedLeafRoot = stateRoot;
+        m_cachedLeaf = account;
+        co_return account;
     }
 
-    /// The slot value from the account's storage trie, decoded from its RLP leaf (the
-    /// big-endian-trimmed integer encodeStorageValue produced). nullopt when the account is
-    /// absent, its storage trie is empty, or the slot has no leaf.
-    bcos::task::Task<std::optional<bcos::u256>> readTrieSlot(bcos::h256 const& slot) const
+    /// The slot value from the account's storage trie at @p stateRoot. nullopt when the account
+    /// is absent, its storage trie is empty, or the slot has no leaf.
+    bcos::task::Task<std::optional<bcos::u256>> readTrieSlot(
+        bcos::h256 const& stateRoot, bcos::h256 const& slot)
     {
-        auto const account = co_await readLeaf();
+        auto const account = co_await readLeaf(stateRoot);
         if (!account || account->storageRoot == emptyRootHash())
         {
             co_return std::nullopt;
@@ -303,44 +344,18 @@ private:
         {
             co_return std::nullopt;
         }
-        co_return decodeStorageLeaf(*leaf);
+        co_return decodeStorageValue(bcos::ref(*leaf));
     }
 
-    /// Inverse of encodeStorageValue (StorageValueCodec): one RLP string holding the
-    /// big-endian-trimmed slot value. @throws MPTDecodeError on malformed input.
-    static bcos::u256 decodeStorageLeaf(bcos::bytes const& leaf)
-    {
-        bcos::bytesRef cursor{const_cast<bcos::byte*>(leaf.data()), leaf.size()};
-        bcos::u256 value;
-        if (auto error = bcos::codec::rlp::decode(cursor, value); error)
-        {
-            BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
-                                      "storage leaf: bad RLP value: " + error->errorMessage()));
-        }
-        if (!cursor.empty())
-        {
-            BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
-                                      "storage leaf: trailing bytes after the RLP value"));
-        }
-        return value;
-    }
-
-    static bcos::h256 toSlot(const evmc_bytes32& key)
-    {
-        return bcos::h256{bcos::bytesConstRef{key.bytes, sizeof(key.bytes)}};
-    }
-
-    static evmc_bytes32 toEvmcBytes(bcos::h256 const& value)
-    {
-        evmc_bytes32 out{};
-        std::copy(value.begin(), value.end(), out.bytes);
-        return out;
-    }
-
+    // The base holds this privately; the historical code() fallback needs it to read the
+    // account table's code field directly.
+    std::reference_wrapper<Storage> m_storage;
     std::reference_wrapper<NodeStorage> m_nodeStorage;
     std::reference_wrapper<BackendStorage> m_backendStorage;
-    bcos::h256 m_stateRoot;
     bcos::Address m_address;
+
+    std::optional<bcos::h256> m_cachedLeafRoot;
+    std::optional<Account> m_cachedLeaf;
 };
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
@@ -14,7 +14,8 @@
  *  limitations under the License.
  *
  * @file MPTAccount.h
- * @brief Account-concept reader over MPT state at a fixed root, for historical calls (spec §5.13)
+ * @brief EVMAccount subclass whose reads walk the MPT at a fixed root, for historical calls
+ * (spec §5.13)
  */
 #pragma once
 
@@ -26,8 +27,6 @@
 #include "Trie.h"
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-concepts/ByteBuffer.h>
-// EVMAccount.h supplies bcos::ledger::account::NonceNotInitialized; increaseNonce() throws the
-// SAME exception type as EVMAccount so callers need not distinguish the two implementations.
 #include <bcos-framework/ledger/EVMAccount.h>
 #include <bcos-framework/ledger/LedgerTypeDef.h>
 #include <bcos-framework/storage/Entry.h>
@@ -42,61 +41,85 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
-#include <utility>
 
 namespace bcos::ledger::mpt
 {
 
-/// Account-concept implementation that reads state through the MPT at a FIXED stateRoot — the
-/// historical-call counterpart of ledger::account::EVMAccount (spec §5.13). HostContext is coded
-/// against the Account concept (bcos-framework/ledger/Account.h), so an eth_call against block N
-/// swaps this in for EVMAccount and executes on block N's trie instead of the latest flat KV.
+/// A Storage that carries the MPT read context, so MPTAccount stays constructible with
+/// HostContext's fixed (storage, address, binaryAddress) shape (HostContext.h getAccount /
+/// executeCreate): the historical storage stack PR-43 builds exposes these three getters and
+/// MPTAccount pulls its trie context out of them at construction.
+template <class Storage>
+concept HistoricalStorageContext = requires(Storage& storage) {
+    { storage.mptNodeStorage() };
+    { storage.mptBackendStorage() };
+    { storage.mptStateRoot() } -> std::convertible_to<bcos::h256>;
+};
+
+/// EVMAccount subclass for historical calls (spec §5.13): an eth_call against block N swaps this
+/// class in for EVMAccount (HostContext is coded against the Account concept, statically
+/// dispatched, so the shadowed methods below win) and executes on block N's trie.
 ///
-/// Reads walk the trie: balance()/nonce()/codeHash() come from the account leaf 4-tuple
-/// (MPTReadView::readAccount); storage(key) descends the account's storage trie along
-/// slotKeyHash(key); code() resolves the leaf's codeHash through the flat s_code_binary table —
-/// hash-addressed and append-only, so its rows are valid for ANY historical block (spec §4.5).
+/// READS are pure MPT walks at the fixed @p stateRoot, never layered over anything:
+/// balance()/nonce()/codeHash() come from the account leaf 4-tuple (MPTReadView::readAccount);
+/// storage(key) takes the leaf's storageRoot and descends the storage trie along
+/// slotKeyHash(key); code()/abi() resolve the leaf's codeHash through the flat
+/// s_code_binary / s_contract_abi tables — hash-addressed and append-only, so their rows are
+/// valid for ANY historical block (spec §4.5).
+///
+/// WRITES are inherited from EVMAccount verbatim (create/setCode/setBalance/setNonce/setStorage)
+/// and land as flat rows in @p Storage. They exist so a simulated call can execute, but block N
+/// is immutable and reads never consult @p Storage: a write in a historical call is NOT visible
+/// to a subsequent read of the same field/slot (SSTORE then SLOAD returns the historical value).
+/// Historical calls target view-style execution; this boundary is deliberate (spec §5.13).
+/// Nothing ever writes the node storage — MPTAccount only reads it.
 ///
 /// Absence semantics are Ethereum semantics, NOT errors: an account missing from the trie reads
 /// as exists()==false / balance 0 / nonce nullopt / zero codeHash; a slot missing from the
 /// storage trie reads as the zero value. This class targets scenario B (genesis-enabled MPT,
 /// spec §4.4), where the trie is the COMPLETE state and exclusion genuinely means zero/empty.
-/// Scenario-A cold data (dormant accounts, cold slots of touched accounts) makes exclusion
-/// ambiguous — gating historical calls to scenario B is the eth_call plumbing layer's job
-/// (PR-43, per OQ6 resolution (c)+(a)), not this class's.
+/// Scenario-A cold data makes exclusion ambiguous — gating historical calls to scenario B is the
+/// eth_call plumbing layer's job (PR-43, per OQ6 resolution (c)+(a)), not this class's.
 ///
-/// Writes are simulation-only: a historical call may SSTORE / set balances, but block N is
-/// immutable, so create/setCode/setBalance/setNonce/setStorage land in an internal in-memory
-/// overlay that reads consult before the trie. Nothing ever touches the node storage — MPTAccount
-/// only reads it. The overlay dies with the account object (== with the call).
+/// Like MPTReadView, each read walks from the root with a fresh Trie: the object holds no
+/// mutable state (node-level caching is the Storage layer's concern), so HostContext's
+/// construct-per-use pattern is loss-free. The account+storage tries are keccak paths end-to-end
+/// (accountKeyHash / slotKeyHash defaults), matching what MPTBuilder committed.
 ///
-/// Like MPTReadView, each read walks from the root with a fresh Trie: no trie state is cached
-/// (node-level caching is the Storage layer's concern). The account+storage tries are keccak
-/// paths end-to-end (accountKeyHash / slotKeyHash defaults), matching what MPTBuilder committed.
-///
-/// The interface is the de-facto superset of the Account concept that HostContext and
-/// BaselineScheduler actually call (spec §5.13): concept methods plus storage(key, DIRECT_TYPE),
-/// storageEntry(), increaseNonce().
-///
-/// @tparam NodeStorage resolves trie node hashes (same concept MPTReadView eats).
-/// @tparam CodeStorage resolves s_code_binary rows by executor_v1::StateKeyView — the flat KV
-/// store (or any layer over it).
-template <bcos::storage2::ReadableStorage<bcos::h256> NodeStorage, class CodeStorage>
-class MPTAccount
+/// @tparam Storage        where the inherited EVMAccount writes land (and the table name comes
+///                        from); never consulted by reads.
+/// @tparam NodeStorage    resolves trie node hashes (same concept MPTReadView eats).
+/// @tparam BackendStorage flat store holding s_code_binary / s_contract_abi (hash-addressed,
+///                        history-invariant), read by executor_v1::StateKeyView.
+template <class Storage, bcos::storage2::ReadableStorage<bcos::h256> NodeStorage,
+    class BackendStorage>
+class MPTAccount : public bcos::ledger::account::EVMAccount<Storage>
 {
+private:
+    using Base = bcos::ledger::account::EVMAccount<Storage>;
+
 public:
-    /// @param nodeStorage trie node store the walks read against.
-    /// @param codeStorage flat store holding s_code_binary (code bytes by code hash).
-    /// @param stateRoot   block N's state root; emptyRootHash() means "no accounts".
-    /// @param address     the 20-byte account address.
-    MPTAccount(NodeStorage& nodeStorage, CodeStorage& codeStorage, bcos::h256 stateRoot,
-        bcos::Address address)
-      : m_nodeStorage(nodeStorage),
-        m_codeStorage(codeStorage),
+    /// Direct construction (tests, callers that already hold the trie context).
+    /// @param storage   write target for the inherited EVMAccount write methods.
+    /// @param stateRoot block N's state root; emptyRootHash() means "no accounts".
+    MPTAccount(Storage& storage, NodeStorage& nodeStorage, BackendStorage& backendStorage,
+        bcos::h256 stateRoot, bcos::Address address)
+      : Base(storage, address, /*binaryAddress*/ false),
+        m_nodeStorage(nodeStorage),
+        m_backendStorage(backendStorage),
         m_stateRoot(stateRoot),
-        m_address(address),
-        m_addressHex(address.hex())
+        m_address(address)
+    {}
+
+    /// HostContext-shaped construction: same (storage, address, binaryAddress) signature as
+    /// EVMAccount, with the trie context riding on the storage type (PR-43's historical stack).
+    MPTAccount(Storage& storage, const evmc_address& address, bool binaryAddress)
+        requires HistoricalStorageContext<Storage>
+      : Base(storage, address, binaryAddress),
+        m_nodeStorage(storage.mptNodeStorage()),
+        m_backendStorage(storage.mptBackendStorage()),
+        m_stateRoot(storage.mptStateRoot()),
+        m_address(bcos::bytesConstRef{address.bytes, sizeof(address.bytes)})
     {}
 
     MPTAccount(const MPTAccount&) = delete;
@@ -105,59 +128,32 @@ public:
     MPTAccount& operator=(MPTAccount&&) noexcept = default;
     ~MPTAccount() noexcept = default;
 
-    /// True when the account has a leaf in the trie, or create() was called on this object.
-    /// Mirrors EVMAccount: value writes (setBalance etc.) alone do not create the account.
+    /// True when the account has a leaf in block N's trie. A create() in this call writes the
+    /// s_tables row into Storage (inherited) but does not change what block N contains.
     bcos::task::Task<bool> exists()
     {
-        if (m_created)
-        {
-            co_return true;
-        }
         auto const account = co_await readLeaf();
         co_return account.has_value();
     }
 
-    /// Simulation-only: marks the account created in the overlay. The trie is never written.
-    bcos::task::Task<void> create()
-    {
-        m_created = true;
-        co_return;
-    }
-
-    /// The code bytes: overlay first (a simulated setCode), then the trie leaf's codeHash
-    /// resolved through s_code_binary. An absent account or an EOA (emptyCodeHash) has no code.
+    /// The code bytes at block N: the leaf's codeHash resolved through s_code_binary. An absent
+    /// account or an EOA (emptyCodeHash) has no code.
     bcos::task::Task<std::optional<bcos::storage::Entry>> code()
     {
-        if (m_codeOverlay)
-        {
-            co_return bcos::storage::Entry{m_codeOverlay->code};
-        }
         auto const account = co_await readLeaf();
         if (!account || account->codeHash == emptyCodeHash())
         {
             co_return std::nullopt;
         }
         co_return co_await bcos::storage2::readOne(
-            m_codeStorage.get(), bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
-                                     bcos::concepts::bytebuffer::toView(account->codeHash)});
+            m_backendStorage.get(), bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
+                                        bcos::concepts::bytebuffer::toView(account->codeHash)});
     }
 
-    /// Simulation-only: the code/abi/hash land in the overlay; s_code_binary is never written.
-    bcos::task::Task<void> setCode(
-        bcos::bytes code, std::string abi, const bcos::crypto::HashType& codeHash)
-    {
-        m_codeOverlay = CodeOverlay{std::move(code), std::move(abi), codeHash};
-        co_return;
-    }
-
-    /// Overlay codeHash (after a simulated setCode), else the leaf's codeHash. Zero for an
-    /// absent account (mirrors EVMAccount's missing-field default).
+    /// The leaf's codeHash; zero for an absent account (mirrors EVMAccount's missing-field
+    /// default).
     bcos::task::Task<bcos::h256> codeHash()
     {
-        if (m_codeOverlay)
-        {
-            co_return m_codeOverlay->codeHash;
-        }
         auto const account = co_await readLeaf();
         if (!account)
         {
@@ -166,24 +162,23 @@ public:
         co_return account->codeHash;
     }
 
-    /// The Ethereum account 4-tuple has no abi field — abi is a BCOS extension excluded from the
-    /// MPT (spec §5.13). Only a simulated setCode's abi is visible; historical reads are empty.
+    /// The contract abi at block N: the leaf's codeHash resolved through s_contract_abi — like
+    /// s_code_binary it is hash-addressed and append-only, so the flat row is history-valid.
     bcos::task::Task<std::optional<bcos::storage::Entry>> abi()
     {
-        if (m_codeOverlay && !m_codeOverlay->abi.empty())
+        auto const account = co_await readLeaf();
+        if (!account || account->codeHash == emptyCodeHash())
         {
-            co_return bcos::storage::Entry{m_codeOverlay->abi};
+            co_return std::nullopt;
         }
-        co_return std::nullopt;
+        co_return co_await bcos::storage2::readOne(
+            m_backendStorage.get(), bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CONTRACT_ABI,
+                                        bcos::concepts::bytebuffer::toView(account->codeHash)});
     }
 
-    /// Overlay balance, else the leaf's balance, else 0 for an absent account.
+    /// The leaf's balance; 0 for an absent account.
     bcos::task::Task<bcos::u256> balance()
     {
-        if (m_balanceOverlay)
-        {
-            co_return *m_balanceOverlay;
-        }
         auto const account = co_await readLeaf();
         if (!account)
         {
@@ -192,21 +187,10 @@ public:
         co_return account->balance;
     }
 
-    /// Simulation-only: lands in the overlay.
-    bcos::task::Task<void> setBalance(const bcos::u256& balance)
-    {
-        m_balanceOverlay = balance;
-        co_return;
-    }
-
-    /// Overlay nonce, else the leaf's nonce as a decimal string (EVMAccount's representation),
-    /// else nullopt for an absent account.
+    /// The leaf's nonce as a decimal string (EVMAccount's representation); nullopt for an absent
+    /// account.
     bcos::task::Task<std::optional<std::string>> nonce()
     {
-        if (m_nonceOverlay)
-        {
-            co_return *m_nonceOverlay;
-        }
         auto const account = co_await readLeaf();
         if (!account)
         {
@@ -215,38 +199,26 @@ public:
         co_return account->nonce.template convert_to<std::string>();
     }
 
-    /// Simulation-only: lands in the overlay.
-    bcos::task::Task<void> setNonce(std::string nonce)
-    {
-        m_nonceOverlay = std::move(nonce);
-        co_return;
-    }
-
-    /// nonce()+1 into the overlay; throws account::NonceNotInitialized when the account has no
-    /// nonce (absent from the trie and never setNonce'd) — same contract as EVMAccount.
+    /// Trie nonce + 1 written through the inherited setNonce (simulation only, like every
+    /// write); throws account::NonceNotInitialized for an absent account — same contract as
+    /// EVMAccount. Shadowed because the base version reads the flat nonce row, which historical
+    /// reads must not consult.
     bcos::task::Task<void> increaseNonce()
     {
-        if (auto currentNonce = co_await nonce())
-        {
-            const auto newNonce = bcos::u256(currentNonce.value()) + 1;
-            co_await setNonce(newNonce.convert_to<std::string>());
-        }
-        else
+        auto const account = co_await readLeaf();
+        if (!account)
         {
             BOOST_THROW_EXCEPTION(bcos::ledger::account::NonceNotInitialized{});
         }
+        auto const newNonce = account->nonce + 1;
+        co_await Base::setNonce(newNonce.template convert_to<std::string>());
     }
 
-    /// SLOAD at block N: overlay first, then the account's storage trie along slotKeyHash(key).
+    /// SLOAD at block N: the leaf's storageRoot, then the storage trie along slotKeyHash(key).
     /// Absent account, empty storage trie, or absent slot all read as the zero value.
     bcos::task::Task<evmc_bytes32> storage(const evmc_bytes32& key)
     {
-        auto const slot = toSlot(key);
-        if (auto const it = m_storageOverlay.find(slot); it != m_storageOverlay.end())
-        {
-            co_return it->second;
-        }
-        auto const value = co_await readTrieSlot(slot);
+        auto const value = co_await readTrieSlot(toSlot(key));
         if (!value)
         {
             co_return evmc_bytes32{};
@@ -254,19 +226,14 @@ public:
         co_return toEvmcBytes(bcos::h256{*value});
     }
 
-    /// DIRECT-tagged variant (see EVMAccount): metadata-only reads that must bypass read-set
-    /// tracking. MPTAccount tracks no read set, so it is exactly storage(key).
-    bcos::task::Task<evmc_bytes32> storage(
-        const evmc_bytes32& key, storage2::DIRECT_TYPE /*direct*/)
+    /// Tag-taking variant (see EVMAccount's tag-forwarding overload): HostContext passes
+    /// composable tags like BYPASS_READ_SET / BYPASS_MULTILAYER for metadata reads. MPTAccount
+    /// tracks no read set and has no layers, so every tag is a no-op and this is exactly
+    /// storage(key). (Both overloads are shadowed together — shadowing one would hide the
+    /// base's other overload.)
+    bcos::task::Task<evmc_bytes32> storage(const evmc_bytes32& key, auto... /*tags*/)
     {
         co_return co_await storage(key);
-    }
-
-    /// Simulation-only: lands in the overlay; the storage trie is never written.
-    bcos::task::Task<void> setStorage(const evmc_bytes32& key, const evmc_bytes32& value)
-    {
-        m_storageOverlay[toSlot(key)] = value;
-        co_return;
     }
 
     /// The raw 32-byte slot value as a storage Entry (the shape BaselineScheduler's
@@ -281,11 +248,6 @@ public:
         }
         bcos::h256 const slot{
             bcos::bytesConstRef{reinterpret_cast<const bcos::byte*>(key.data()), key.size()}};
-        if (auto const it = m_storageOverlay.find(slot); it != m_storageOverlay.end())
-        {
-            co_return bcos::storage::Entry{std::string_view{
-                reinterpret_cast<const char*>(it->second.bytes), sizeof(it->second.bytes)}};
-        }
         auto const value = co_await readTrieSlot(slot);
         if (!value)
         {
@@ -295,23 +257,14 @@ public:
         co_return bcos::storage::Entry{bcos::concepts::bytebuffer::toView(padded)};
     }
 
-    /// The lowercase-hex address (no 0x). MPTAccount has no flat table, so unlike EVMAccount
-    /// there is no /apps/ table-name prefix to return.
-    bcos::task::Task<std::string_view> path() { co_return std::string_view{m_addressHex}; }
-
-    std::string_view address() const { return m_addressHex; }
+    // path() / address() are inherited: both return the EVMAccount table name ("/apps/<hex>",
+    // or the binary/system variants), so historical and latest accounts key transient storage
+    // and logs identically.
 
     /// The state root this account reads against.
     bcos::h256 root() const noexcept { return m_stateRoot; }
 
 private:
-    struct CodeOverlay
-    {
-        bcos::bytes code;
-        std::string abi;
-        bcos::h256 codeHash;
-    };
-
     /// The account leaf 4-tuple at m_stateRoot, or nullopt when absent. Fresh walk per call.
     bcos::task::Task<std::optional<Account>> readLeaf() const
     {
@@ -370,17 +323,9 @@ private:
     }
 
     std::reference_wrapper<NodeStorage> m_nodeStorage;
-    std::reference_wrapper<CodeStorage> m_codeStorage;
+    std::reference_wrapper<BackendStorage> m_backendStorage;
     bcos::h256 m_stateRoot;
     bcos::Address m_address;
-    std::string m_addressHex;
-
-    // Simulation overlay: writes land here, reads consult it before the trie. Never persisted.
-    bool m_created{false};
-    std::optional<bcos::u256> m_balanceOverlay;
-    std::optional<std::string> m_nonceOverlay;
-    std::optional<CodeOverlay> m_codeOverlay;
-    std::unordered_map<bcos::h256, evmc_bytes32> m_storageOverlay;
 };
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
@@ -137,7 +137,12 @@ public:
     }
 
     /// The code bytes at block N: the leaf's codeHash resolved through s_code_binary. An absent
-    /// account or an EOA (emptyCodeHash) has no code.
+    /// account or an EOA (emptyCodeHash) has no code. A leaf that commits a non-empty codeHash
+    /// with NO matching s_code_binary row is a corrupted backend or a mis-wired code write path,
+    /// not an EOA — silently returning nullopt would downgrade the account and execute the call
+    /// wrong, so it throws instead (the append-only, hash-addressed code table makes the row's
+    /// existence an invariant; EIP-7702 delegation designators are ordinary hash-addressed code
+    /// and are covered by the same invariant).
     bcos::task::Task<std::optional<bcos::storage::Entry>> code()
     {
         auto const account = co_await readLeaf();
@@ -145,9 +150,17 @@ public:
         {
             co_return std::nullopt;
         }
-        co_return co_await bcos::storage2::readOne(
+        auto codeEntry = co_await bcos::storage2::readOne(
             m_backendStorage.get(), bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
                                         bcos::concepts::bytebuffer::toView(account->codeHash)});
+        if (!codeEntry)
+        {
+            BOOST_THROW_EXCEPTION(
+                MPTInvariantViolation{} << bcos::errinfo_comment(
+                    "historical code(): account leaf commits codeHash " + account->codeHash.hex() +
+                    " but s_code_binary has no such row"));
+        }
+        co_return codeEntry;
     }
 
     /// The leaf's codeHash; zero for an absent account (mirrors EVMAccount's missing-field
@@ -164,6 +177,8 @@ public:
 
     /// The contract abi at block N: the leaf's codeHash resolved through s_contract_abi — like
     /// s_code_binary it is hash-addressed and append-only, so the flat row is history-valid.
+    /// Unlike code(), a missing row is NOT an invariant violation: abi is BCOS metadata outside
+    /// the committed 4-tuple, so absence simply reads as nullopt.
     bcos::task::Task<std::optional<bcos::storage::Entry>> abi()
     {
         auto const account = co_await readLeaf();

--- a/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
@@ -26,6 +26,7 @@
 #include "StorageValueCodec.h"
 #include "Trie.h"
 #include <bcos-concepts/ByteBuffer.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
 #include <bcos-framework/ledger/Account.h>
 #include <bcos-framework/ledger/EVMAccount.h>
 #include <bcos-framework/ledger/LedgerTypeDef.h>
@@ -73,11 +74,23 @@ concept HistoricalStorageContext = requires(Storage& storage) {
 /// mode the object is locked into: a caller that never passes a root cannot tell this class from
 /// EVMAccount.
 ///
-/// Absence at a given root is Ethereum semantics, not an error: an account with no leaf reads as
-/// exists()==false / balance 0 / nonce nullopt / zero codeHash, and a slot with no leaf reads as
-/// zero. That is exact for scenario B (genesis-enabled MPT, spec §4.4), where the trie is the
-/// complete state. Scenario-A cold data makes exclusion ambiguous, so gating historical queries
-/// to scenario B is the caller's job (PR-43, per OQ6 resolution (c)+(a)).
+/// A rooted read answers from the MPT and from nothing else. What the trie does not hold at that
+/// root does not exist as far as this path is concerned — the flat tables are never consulted to
+/// paper over a gap, because they hold TODAY's values and cannot answer a question about block N.
+///
+/// Absence at a given root is therefore Ethereum semantics, not an error: an account with no leaf
+/// reads as exists()==false / balance 0 / nonce nullopt / zero codeHash, and a slot with no leaf
+/// reads as zero. That is exact for scenario B (genesis-enabled MPT, spec §4.4), where the trie is
+/// the complete state. Scenario-A cold data makes exclusion ambiguous, so gating historical
+/// queries to scenario B is the caller's job (PR-43, per OQ6 resolution (c)+(a)).
+///
+/// One consequence to know about: exists() means different things on the two paths, and the rooted
+/// one is the Ethereum meaning. With a root it is leaf presence, exactly as an Ethereum client
+/// answers "does this account exist". The inherited flat exists() (EVMAccount.h:27-31) tests for a
+/// SYS_TABLES row, a BCOS notion with no Ethereum counterpart, and the two can disagree: an
+/// account touched only by rows carrying no Ethereum state never produces a leaf (MPTBuilder.h:
+/// 92-97, 215-227 keep that one member of the EIP-161 empty-account class out of the trie), so it
+/// reads as absent historically and present flatly. Ethereum agrees with the historical answer.
 ///
 /// abi() and increaseNonce() are inherited unchanged. abi is BCOS metadata outside the committed
 /// 4-tuple and is deliberately not historicised — a historical query returns the CURRENT abi,
@@ -109,7 +122,6 @@ public:
     MPTAccount(Storage& storage, NodeStorage& nodeStorage, BackendStorage& backendStorage,
         bcos::Address address, bool binaryAddress)
       : Base(storage, address, binaryAddress),
-        m_storage(storage),
         m_nodeStorage(nodeStorage),
         m_backendStorage(backendStorage),
         m_address(address)
@@ -127,7 +139,6 @@ public:
     MPTAccount(Storage& storage, const evmc_address& address, bool binaryAddress)
         requires HistoricalStorageContext<Storage>
       : Base(storage, address, binaryAddress),
-        m_storage(storage),
         m_nodeStorage(storage.mptNodeStorage()),
         m_backendStorage(storage.mptBackendStorage()),
         m_address(bcos::bytesConstRef{address.bytes, sizeof(address.bytes)})
@@ -150,21 +161,26 @@ public:
         co_return account.has_value();
     }
 
-    /// The code bytes. With a root: the leaf's codeHash resolved through s_code_binary, falling
-    /// back to the account table's code field when that row is missing — EVMAccount's own last
-    /// resort, and where contracts deployed by old versions and internal precompiled keep their
-    /// code. The fallback reads ONLY that field, never the full base resolution: the base
-    /// starts from today's flat codeHash, which for an address whose code changed since would
-    /// return bytes hashing to something other than the codeHash this very object reports.
-    /// An account absent from the trie has no code and does NOT fall back at all — it did not
-    /// exist at that block, and the flat tables only hold today's value.
+    /// The code bytes, resolved exactly as Ethereum resolves them: `codeHash == keccak256("")`
+    /// means the account has no code, and otherwise the code is whatever the one content-addressed
+    /// store holds under that hash. There is no second place to look and no fallback.
     ///
-    /// Neither source holding the code is an invariant violation, not an absence: a leaf that
-    /// commits a non-empty codeHash asserts the code existed at that block, so failing to find it
-    /// means the store is corrupt or pruned. Reporting nullopt there would make the EVM read the
-    /// contract as an EOA and answer a call to it with success and empty output — a wrong result
-    /// the caller cannot distinguish from a right one. Throwing is loud instead; the historical
-    /// call path (PR-43) must catch it at the RPC boundary, as it must MPTDecodeError.
+    /// That is a deliberate narrowing of what the flat path does. `EVMAccount::code()` also probes
+    /// the account table's CODE field, because two pre-3.18 shapes put code there: the old-logic
+    /// deploy (HostContext.cpp:483-495, blockVersion < 3.1) and internal create with
+    /// bugfix_internal_create_redundant_storage off (TransactionExecutive.cpp:963-967, which
+    /// writes CODE and no CODE_HASH at all, so FlatToMPT commits emptyCodeHash for an account
+    /// that does have code). Neither shape is producible at 3.18.0 — `EVMAccount::setCode`
+    /// (EVMAccount.h:65-88) always writes s_code_binary — and a future fork that changes code
+    /// storage again gets its own feature flag. Serving them here would mean reading TODAY's flat
+    /// tables to answer a question about block N, which cannot be right in general.
+    ///
+    /// A missing blob under a non-empty codeHash is an invariant violation, not an absence: the
+    /// leaf asserts the code existed at that block, so failing to find it means the store is
+    /// corrupt or pruned. Returning nullopt would run the contract as an EOA and answer calls to
+    /// it with success and empty output — a wrong result the caller cannot distinguish from a
+    /// right one, and geth likewise fails block processing rather than degrading. The historical
+    /// call path (PR-43) must catch this at the RPC boundary, as it must MPTDecodeError.
     bcos::task::Task<std::optional<bcos::storage::Entry>> code(
         std::optional<bcos::h256> stateRoot = {})
     {
@@ -183,16 +199,9 @@ public:
         {
             co_return codeEntry;
         }
-        if (auto codeEntry = co_await bcos::storage2::readOne(
-                m_storage.get(), bcos::executor_v1::StateKeyView{
-                                     this->address(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE}))
-        {
-            co_return codeEntry;
-        }
-        BOOST_THROW_EXCEPTION(
-            MPTInvariantViolation{} << bcos::errinfo_comment(
-                "historical code(): account leaf commits codeHash " + account->codeHash.hex() +
-                " but neither s_code_binary nor the account table holds the code"));
+        BOOST_THROW_EXCEPTION(MPTInvariantViolation{} << bcos::errinfo_comment(
+                                  "historical code(): account leaf commits codeHash " +
+                                  account->codeHash.hex() + " but s_code_binary has no such row"));
     }
 
     /// The code hash: the leaf's, or (no root) the flat account row's.
@@ -280,10 +289,18 @@ public:
         co_return co_await Base::storage(key);
     }
 
-    /// A root and storage tags CANNOT be combined: storage(key, root, BYPASS_READ_SET) matches
-    /// none of the overloads above on arity and lands on the inherited tag pack, which forwards
-    /// the root as if it were a tag and reads today's flat value. Read the historical slot and
-    /// the tagged flat slot as two separate calls.
+    /// A root and storage tags CANNOT be combined. Without the deletion below,
+    /// storage(key, root, BYPASS_READ_SET) matches none of the overloads above on arity, lands on
+    /// the inherited tag pack, forwards the root as if it were a tag and reads today's flat value
+    /// — the same silent latest-for-historical failure the plain-root overload exists to prevent,
+    /// one arity up. Deleting it makes the call a compile error instead. Read the historical slot
+    /// and the tagged flat slot as two separate calls.
+    template <class... Tags>
+    bcos::task::Task<evmc_bytes32> storage(
+        const evmc_bytes32&, bcos::h256 const&, Tags&&...) = delete;
+    template <class... Tags>
+    bcos::task::Task<evmc_bytes32> storage(
+        const evmc_bytes32&, std::optional<bcos::h256> const&, Tags&&...) = delete;
 
     /// The raw 32-byte slot value as a storage Entry, or nullopt when the slot is absent. With a
     /// root, @p key must be a 32-byte slot key — nothing else can exist in a storage trie — so
@@ -339,7 +356,15 @@ private:
             co_return std::nullopt;
         }
         Trie<NodeStorage> const trie{m_nodeStorage.get(), account->storageRoot};
-        auto const leaf = co_await trie.get(slotKeyHash(slot));
+        // The hasher-injection form, per StorageValueCodec.h's hot-path convention: this is the
+        // per-SLOAD path of a historical call, and the convenience overload builds a fresh
+        // OpenSSL context every time. Constructed on first use rather than held by value, so the
+        // default (flat) path keeps EVMAccount's allocation-free, non-throwing construction.
+        if (!m_hasher)
+        {
+            m_hasher.emplace();
+        }
+        auto const leaf = co_await trie.get(slotKeyHash(slot, *m_hasher));
         if (!leaf)
         {
             co_return std::nullopt;
@@ -347,15 +372,14 @@ private:
         co_return decodeStorageValue(bcos::ref(*leaf));
     }
 
-    // The base holds this privately; the historical code() fallback needs it to read the
-    // account table's code field directly.
-    std::reference_wrapper<Storage> m_storage;
     std::reference_wrapper<NodeStorage> m_nodeStorage;
     std::reference_wrapper<BackendStorage> m_backendStorage;
     bcos::Address m_address;
 
     std::optional<bcos::h256> m_cachedLeafRoot;
     std::optional<Account> m_cachedLeaf;
+    /// Reused slot-key hash context, built on the first rooted slot read (see readTrieSlot).
+    std::optional<bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher> m_hasher;
 };
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTAccount.h
@@ -1,0 +1,386 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MPTAccount.h
+ * @brief Account-concept reader over MPT state at a fixed root, for historical calls (spec §5.13)
+ */
+#pragma once
+
+#include "Account.h"
+#include "Constants.h"
+#include "Errors.h"
+#include "MPTReadView.h"
+#include "StorageValueCodec.h"
+#include "Trie.h"
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-concepts/ByteBuffer.h>
+// EVMAccount.h supplies bcos::ledger::account::NonceNotInitialized; increaseNonce() throws the
+// SAME exception type as EVMAccount so callers need not distinguish the two implementations.
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <evmc/evmc.h>
+#include <boost/throw_exception.hpp>
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+namespace bcos::ledger::mpt
+{
+
+/// Account-concept implementation that reads state through the MPT at a FIXED stateRoot — the
+/// historical-call counterpart of ledger::account::EVMAccount (spec §5.13). HostContext is coded
+/// against the Account concept (bcos-framework/ledger/Account.h), so an eth_call against block N
+/// swaps this in for EVMAccount and executes on block N's trie instead of the latest flat KV.
+///
+/// Reads walk the trie: balance()/nonce()/codeHash() come from the account leaf 4-tuple
+/// (MPTReadView::readAccount); storage(key) descends the account's storage trie along
+/// slotKeyHash(key); code() resolves the leaf's codeHash through the flat s_code_binary table —
+/// hash-addressed and append-only, so its rows are valid for ANY historical block (spec §4.5).
+///
+/// Absence semantics are Ethereum semantics, NOT errors: an account missing from the trie reads
+/// as exists()==false / balance 0 / nonce nullopt / zero codeHash; a slot missing from the
+/// storage trie reads as the zero value. This class targets scenario B (genesis-enabled MPT,
+/// spec §4.4), where the trie is the COMPLETE state and exclusion genuinely means zero/empty.
+/// Scenario-A cold data (dormant accounts, cold slots of touched accounts) makes exclusion
+/// ambiguous — gating historical calls to scenario B is the eth_call plumbing layer's job
+/// (PR-43, per OQ6 resolution (c)+(a)), not this class's.
+///
+/// Writes are simulation-only: a historical call may SSTORE / set balances, but block N is
+/// immutable, so create/setCode/setBalance/setNonce/setStorage land in an internal in-memory
+/// overlay that reads consult before the trie. Nothing ever touches the node storage — MPTAccount
+/// only reads it. The overlay dies with the account object (== with the call).
+///
+/// Like MPTReadView, each read walks from the root with a fresh Trie: no trie state is cached
+/// (node-level caching is the Storage layer's concern). The account+storage tries are keccak
+/// paths end-to-end (accountKeyHash / slotKeyHash defaults), matching what MPTBuilder committed.
+///
+/// The interface is the de-facto superset of the Account concept that HostContext and
+/// BaselineScheduler actually call (spec §5.13): concept methods plus storage(key, DIRECT_TYPE),
+/// storageEntry(), increaseNonce().
+///
+/// @tparam NodeStorage resolves trie node hashes (same concept MPTReadView eats).
+/// @tparam CodeStorage resolves s_code_binary rows by executor_v1::StateKeyView — the flat KV
+/// store (or any layer over it).
+template <bcos::storage2::ReadableStorage<bcos::h256> NodeStorage, class CodeStorage>
+class MPTAccount
+{
+public:
+    /// @param nodeStorage trie node store the walks read against.
+    /// @param codeStorage flat store holding s_code_binary (code bytes by code hash).
+    /// @param stateRoot   block N's state root; emptyRootHash() means "no accounts".
+    /// @param address     the 20-byte account address.
+    MPTAccount(NodeStorage& nodeStorage, CodeStorage& codeStorage, bcos::h256 stateRoot,
+        bcos::Address address)
+      : m_nodeStorage(nodeStorage),
+        m_codeStorage(codeStorage),
+        m_stateRoot(stateRoot),
+        m_address(address),
+        m_addressHex(address.hex())
+    {}
+
+    MPTAccount(const MPTAccount&) = delete;
+    MPTAccount(MPTAccount&&) noexcept = default;
+    MPTAccount& operator=(const MPTAccount&) = delete;
+    MPTAccount& operator=(MPTAccount&&) noexcept = default;
+    ~MPTAccount() noexcept = default;
+
+    /// True when the account has a leaf in the trie, or create() was called on this object.
+    /// Mirrors EVMAccount: value writes (setBalance etc.) alone do not create the account.
+    bcos::task::Task<bool> exists()
+    {
+        if (m_created)
+        {
+            co_return true;
+        }
+        auto const account = co_await readLeaf();
+        co_return account.has_value();
+    }
+
+    /// Simulation-only: marks the account created in the overlay. The trie is never written.
+    bcos::task::Task<void> create()
+    {
+        m_created = true;
+        co_return;
+    }
+
+    /// The code bytes: overlay first (a simulated setCode), then the trie leaf's codeHash
+    /// resolved through s_code_binary. An absent account or an EOA (emptyCodeHash) has no code.
+    bcos::task::Task<std::optional<bcos::storage::Entry>> code()
+    {
+        if (m_codeOverlay)
+        {
+            co_return bcos::storage::Entry{m_codeOverlay->code};
+        }
+        auto const account = co_await readLeaf();
+        if (!account || account->codeHash == emptyCodeHash())
+        {
+            co_return std::nullopt;
+        }
+        co_return co_await bcos::storage2::readOne(
+            m_codeStorage.get(), bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
+                                     bcos::concepts::bytebuffer::toView(account->codeHash)});
+    }
+
+    /// Simulation-only: the code/abi/hash land in the overlay; s_code_binary is never written.
+    bcos::task::Task<void> setCode(
+        bcos::bytes code, std::string abi, const bcos::crypto::HashType& codeHash)
+    {
+        m_codeOverlay = CodeOverlay{std::move(code), std::move(abi), codeHash};
+        co_return;
+    }
+
+    /// Overlay codeHash (after a simulated setCode), else the leaf's codeHash. Zero for an
+    /// absent account (mirrors EVMAccount's missing-field default).
+    bcos::task::Task<bcos::h256> codeHash()
+    {
+        if (m_codeOverlay)
+        {
+            co_return m_codeOverlay->codeHash;
+        }
+        auto const account = co_await readLeaf();
+        if (!account)
+        {
+            co_return bcos::h256{};
+        }
+        co_return account->codeHash;
+    }
+
+    /// The Ethereum account 4-tuple has no abi field — abi is a BCOS extension excluded from the
+    /// MPT (spec §5.13). Only a simulated setCode's abi is visible; historical reads are empty.
+    bcos::task::Task<std::optional<bcos::storage::Entry>> abi()
+    {
+        if (m_codeOverlay && !m_codeOverlay->abi.empty())
+        {
+            co_return bcos::storage::Entry{m_codeOverlay->abi};
+        }
+        co_return std::nullopt;
+    }
+
+    /// Overlay balance, else the leaf's balance, else 0 for an absent account.
+    bcos::task::Task<bcos::u256> balance()
+    {
+        if (m_balanceOverlay)
+        {
+            co_return *m_balanceOverlay;
+        }
+        auto const account = co_await readLeaf();
+        if (!account)
+        {
+            co_return bcos::u256{};
+        }
+        co_return account->balance;
+    }
+
+    /// Simulation-only: lands in the overlay.
+    bcos::task::Task<void> setBalance(const bcos::u256& balance)
+    {
+        m_balanceOverlay = balance;
+        co_return;
+    }
+
+    /// Overlay nonce, else the leaf's nonce as a decimal string (EVMAccount's representation),
+    /// else nullopt for an absent account.
+    bcos::task::Task<std::optional<std::string>> nonce()
+    {
+        if (m_nonceOverlay)
+        {
+            co_return *m_nonceOverlay;
+        }
+        auto const account = co_await readLeaf();
+        if (!account)
+        {
+            co_return std::nullopt;
+        }
+        co_return account->nonce.template convert_to<std::string>();
+    }
+
+    /// Simulation-only: lands in the overlay.
+    bcos::task::Task<void> setNonce(std::string nonce)
+    {
+        m_nonceOverlay = std::move(nonce);
+        co_return;
+    }
+
+    /// nonce()+1 into the overlay; throws account::NonceNotInitialized when the account has no
+    /// nonce (absent from the trie and never setNonce'd) — same contract as EVMAccount.
+    bcos::task::Task<void> increaseNonce()
+    {
+        if (auto currentNonce = co_await nonce())
+        {
+            const auto newNonce = bcos::u256(currentNonce.value()) + 1;
+            co_await setNonce(newNonce.convert_to<std::string>());
+        }
+        else
+        {
+            BOOST_THROW_EXCEPTION(bcos::ledger::account::NonceNotInitialized{});
+        }
+    }
+
+    /// SLOAD at block N: overlay first, then the account's storage trie along slotKeyHash(key).
+    /// Absent account, empty storage trie, or absent slot all read as the zero value.
+    bcos::task::Task<evmc_bytes32> storage(const evmc_bytes32& key)
+    {
+        auto const slot = toSlot(key);
+        if (auto const it = m_storageOverlay.find(slot); it != m_storageOverlay.end())
+        {
+            co_return it->second;
+        }
+        auto const value = co_await readTrieSlot(slot);
+        if (!value)
+        {
+            co_return evmc_bytes32{};
+        }
+        co_return toEvmcBytes(bcos::h256{*value});
+    }
+
+    /// DIRECT-tagged variant (see EVMAccount): metadata-only reads that must bypass read-set
+    /// tracking. MPTAccount tracks no read set, so it is exactly storage(key).
+    bcos::task::Task<evmc_bytes32> storage(
+        const evmc_bytes32& key, storage2::DIRECT_TYPE /*direct*/)
+    {
+        co_return co_await storage(key);
+    }
+
+    /// Simulation-only: lands in the overlay; the storage trie is never written.
+    bcos::task::Task<void> setStorage(const evmc_bytes32& key, const evmc_bytes32& value)
+    {
+        m_storageOverlay[toSlot(key)] = value;
+        co_return;
+    }
+
+    /// The raw 32-byte slot value as a storage Entry (the shape BaselineScheduler's
+    /// getPendingStorageAt reads), or nullopt when the slot is absent. @p key is the raw 32-byte
+    /// slot key exactly as the flat KV stores it; only 32-byte keys can exist in a storage trie,
+    /// so any other length is absent by construction.
+    bcos::task::Task<std::optional<bcos::storage::Entry>> storageEntry(const std::string_view& key)
+    {
+        if (key.size() != bcos::h256::SIZE)
+        {
+            co_return std::nullopt;
+        }
+        bcos::h256 const slot{
+            bcos::bytesConstRef{reinterpret_cast<const bcos::byte*>(key.data()), key.size()}};
+        if (auto const it = m_storageOverlay.find(slot); it != m_storageOverlay.end())
+        {
+            co_return bcos::storage::Entry{std::string_view{
+                reinterpret_cast<const char*>(it->second.bytes), sizeof(it->second.bytes)}};
+        }
+        auto const value = co_await readTrieSlot(slot);
+        if (!value)
+        {
+            co_return std::nullopt;
+        }
+        bcos::h256 const padded{*value};
+        co_return bcos::storage::Entry{bcos::concepts::bytebuffer::toView(padded)};
+    }
+
+    /// The lowercase-hex address (no 0x). MPTAccount has no flat table, so unlike EVMAccount
+    /// there is no /apps/ table-name prefix to return.
+    bcos::task::Task<std::string_view> path() { co_return std::string_view{m_addressHex}; }
+
+    std::string_view address() const { return m_addressHex; }
+
+    /// The state root this account reads against.
+    bcos::h256 root() const noexcept { return m_stateRoot; }
+
+private:
+    struct CodeOverlay
+    {
+        bcos::bytes code;
+        std::string abi;
+        bcos::h256 codeHash;
+    };
+
+    /// The account leaf 4-tuple at m_stateRoot, or nullopt when absent. Fresh walk per call.
+    bcos::task::Task<std::optional<Account>> readLeaf() const
+    {
+        MPTReadView<NodeStorage> const view{m_nodeStorage.get(), m_stateRoot};
+        co_return co_await view.readAccount(m_address);
+    }
+
+    /// The slot value from the account's storage trie, decoded from its RLP leaf (the
+    /// big-endian-trimmed integer encodeStorageValue produced). nullopt when the account is
+    /// absent, its storage trie is empty, or the slot has no leaf.
+    bcos::task::Task<std::optional<bcos::u256>> readTrieSlot(bcos::h256 const& slot) const
+    {
+        auto const account = co_await readLeaf();
+        if (!account || account->storageRoot == emptyRootHash())
+        {
+            co_return std::nullopt;
+        }
+        Trie<NodeStorage> const trie{m_nodeStorage.get(), account->storageRoot};
+        auto const leaf = co_await trie.get(slotKeyHash(slot));
+        if (!leaf)
+        {
+            co_return std::nullopt;
+        }
+        co_return decodeStorageLeaf(*leaf);
+    }
+
+    /// Inverse of encodeStorageValue (StorageValueCodec): one RLP string holding the
+    /// big-endian-trimmed slot value. @throws MPTDecodeError on malformed input.
+    static bcos::u256 decodeStorageLeaf(bcos::bytes const& leaf)
+    {
+        bcos::bytesRef cursor{const_cast<bcos::byte*>(leaf.data()), leaf.size()};
+        bcos::u256 value;
+        if (auto error = bcos::codec::rlp::decode(cursor, value); error)
+        {
+            BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                      "storage leaf: bad RLP value: " + error->errorMessage()));
+        }
+        if (!cursor.empty())
+        {
+            BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                      "storage leaf: trailing bytes after the RLP value"));
+        }
+        return value;
+    }
+
+    static bcos::h256 toSlot(const evmc_bytes32& key)
+    {
+        return bcos::h256{bcos::bytesConstRef{key.bytes, sizeof(key.bytes)}};
+    }
+
+    static evmc_bytes32 toEvmcBytes(bcos::h256 const& value)
+    {
+        evmc_bytes32 out{};
+        std::copy(value.begin(), value.end(), out.bytes);
+        return out;
+    }
+
+    std::reference_wrapper<NodeStorage> m_nodeStorage;
+    std::reference_wrapper<CodeStorage> m_codeStorage;
+    bcos::h256 m_stateRoot;
+    bcos::Address m_address;
+    std::string m_addressHex;
+
+    // Simulation overlay: writes land here, reads consult it before the trie. Never persisted.
+    bool m_created{false};
+    std::optional<bcos::u256> m_balanceOverlay;
+    std::optional<std::string> m_nonceOverlay;
+    std::optional<CodeOverlay> m_codeOverlay;
+    std::unordered_map<bcos::h256, evmc_bytes32> m_storageOverlay;
+};
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.cpp
@@ -25,6 +25,7 @@
 // leaks in), so keep both explicit.
 #include <bcos-crypto/hasher/AnyHasher.h>
 #include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-utilities/DataConvertUtility.h>  // fromBigEndian
 
 namespace bcos::ledger::mpt
 {
@@ -56,8 +57,14 @@ bcos::u256 decodeStorageValue(bcos::bytesConstRef leaf)
     // The RLP cursor API advances a mutable ref; decode only reads, so the cast is safe (same
     // shape as NodeDecoder.cpp / Account.cpp).
     bcos::bytesRef cursor{const_cast<bcos::byte*>(leaf.data()), leaf.size()};
-    bcos::u256 value;
-    if (auto error = bcos::codec::rlp::decode(cursor, value); error)
+    // Decode to a byte string first, NOT straight to u256: rlp::decode(cursor, u256) feeds the
+    // payload to fromBigEndian (DataConvertUtility.h:279-285), a `ret = (ret << 8) | b` loop over
+    // a fixed-width unchecked u256. A 33-byte payload would shift its high byte out and yield a
+    // plausible wrong slot value mod 2^256 instead of an error, and a leading-zero payload would
+    // decode as if canonical. Ethereum's storage values are minimal big-endian byte strings of at
+    // most 32 bytes; anything else is a corrupt leaf.
+    bcos::bytes payload;
+    if (auto error = bcos::codec::rlp::decode(cursor, payload); error)
     {
         BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
                                   "storage leaf: bad RLP value: " + error->errorMessage()));
@@ -67,7 +74,19 @@ bcos::u256 decodeStorageValue(bcos::bytesConstRef leaf)
         BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
                                   "storage leaf: trailing bytes after the RLP value"));
     }
-    return value;
+    if (payload.size() > static_cast<size_t>(bcos::h256::SIZE))
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "storage leaf: value payload is " +
+                                  std::to_string(payload.size()) + " bytes, over the 32-byte max"));
+    }
+    if (!payload.empty() && payload.front() == 0)
+    {
+        BOOST_THROW_EXCEPTION(
+            MPTDecodeError{} << bcos::errinfo_comment(
+                "storage leaf: value payload has a leading zero byte (not minimal big-endian)"));
+    }
+    return bcos::fromBigEndian<bcos::u256>(payload);
 }
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.cpp
+++ b/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.cpp
@@ -17,6 +17,8 @@
  * @brief Storage-slot key transform and value encoding for the secure trie (spec §5.3)
  */
 #include "StorageValueCodec.h"
+#include "Errors.h"
+#include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-codec/rlp/RLPEncode.h>
 // AnyHasher.h defines the free bcos::crypto::hasher::hash(); OpenSSLHasher.h only defines the
 // hasher type. A unity build can mask a missing include of the former (a sibling TU's include
@@ -47,6 +49,25 @@ bcos::bytes encodeStorageValue(bcos::bytesConstRef value)
     bcos::bytes out;
     codec::rlp::encode(out, value.getCroppedData(offset));
     return out;
+}
+
+bcos::u256 decodeStorageValue(bcos::bytesConstRef leaf)
+{
+    // The RLP cursor API advances a mutable ref; decode only reads, so the cast is safe (same
+    // shape as NodeDecoder.cpp / Account.cpp).
+    bcos::bytesRef cursor{const_cast<bcos::byte*>(leaf.data()), leaf.size()};
+    bcos::u256 value;
+    if (auto error = bcos::codec::rlp::decode(cursor, value); error)
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "storage leaf: bad RLP value: " + error->errorMessage()));
+    }
+    if (!cursor.empty())
+    {
+        BOOST_THROW_EXCEPTION(MPTDecodeError{} << bcos::errinfo_comment(
+                                  "storage leaf: trailing bytes after the RLP value"));
+    }
+    return value;
 }
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.h
+++ b/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.h
@@ -53,4 +53,10 @@ bcos::h256 slotKeyHash(bcos::h256 const& slot);
 /// so the empty return is unambiguous.)
 bcos::bytes encodeStorageValue(bcos::bytesConstRef value);
 
+/// The inverse of encodeStorageValue: decode one storage-trie leaf back into the slot value.
+/// Kept next to the encoder so a change to one is impossible to miss in the other (proof
+/// generation and historical reads both decode; only MPTBuilder encodes).
+/// @throws MPTDecodeError on malformed RLP or on trailing bytes after the value.
+bcos::u256 decodeStorageValue(bcos::bytesConstRef leaf);
+
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.h
+++ b/bcos-ledger/bcos-ledger/mpt/StorageValueCodec.h
@@ -56,7 +56,9 @@ bcos::bytes encodeStorageValue(bcos::bytesConstRef value);
 /// The inverse of encodeStorageValue: decode one storage-trie leaf back into the slot value.
 /// Kept next to the encoder so a change to one is impossible to miss in the other (proof
 /// generation and historical reads both decode; only MPTBuilder encodes).
-/// @throws MPTDecodeError on malformed RLP or on trailing bytes after the value.
+/// @throws MPTDecodeError on malformed RLP, on trailing bytes after the value, or when the value
+/// is not a minimal big-endian byte string of at most 32 bytes (over-long or leading-zero
+/// payloads decode into a plausible wrong value rather than an error if left unchecked).
 bcos::u256 decodeStorageValue(bcos::bytesConstRef leaf);
 
 }  // namespace bcos::ledger::mpt

--- a/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  * @file MPTAccountTest.cpp
- * @brief Unit tests for MPTAccount, the EVMAccount subclass reading MPT state (spec §5.13)
+ * @brief Unit tests for MPTAccount: EVMAccount by default, MPT reads when given a root (§5.13)
  */
 
 #include "TestHelpers.h"
@@ -28,7 +28,6 @@
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <bcos-ledger/mpt/Account.h>
 #include <bcos-ledger/mpt/Constants.h>
-#include <bcos-ledger/mpt/HashBuilder.h>
 #include <bcos-ledger/mpt/MPTAccount.h>
 #include <bcos-ledger/mpt/MPTReadView.h>
 #include <bcos-ledger/mpt/StorageValueCodec.h>
@@ -51,8 +50,8 @@ using FlatStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor
     bcos::storage::Entry, bcos::storage2::memory_storage::ORDERED>;
 using TestMPTAccount = MPTAccount<FlatStorage, NodeStorage, FlatStorage>;
 
-// The whole point of MPTAccount: it satisfies the Account concept HostContext is coded against
-// (mirrors TestTransactionExecutive.cpp's static_assert for EVMAccount).
+// MPTAccount stays a drop-in for EVMAccount: every read has a default argument, so the concept
+// HostContext is coded against is satisfied by the no-argument calls.
 static_assert(bcos::ledger::account::Account<TestMPTAccount>);
 
 namespace
@@ -60,14 +59,12 @@ namespace
 
 bcos::h256 fromEvmc(const evmc_bytes32& value)
 {
-    return bcos::h256{bcos::bytesConstRef{value.bytes, sizeof(value.bytes)}};
+    return bcos::ledger::account::toH256(value);
 }
 
 evmc_bytes32 toEvmc(bcos::h256 const& value)
 {
-    evmc_bytes32 out{};
-    std::copy(value.begin(), value.end(), out.bytes);
-    return out;
+    return bcos::ledger::account::toEvmcBytes32(value);
 }
 
 /// Number of keys currently in @p storage (full bucket scan).
@@ -85,26 +82,13 @@ size_t storageKeyCount(Storage& storage)
     }(storage));
 }
 
-/// The flat row an inherited EVMAccount write left in @p storage, as a string; nullopt if none.
-std::optional<std::string> flatRow(
-    FlatStorage& storage, std::string_view table, std::string_view row)
-{
-    auto entry = bcos::task::syncWait(
-        bcos::storage2::readOne(storage, bcos::executor_v1::StateKeyView{table, row}));
-    if (!entry)
-    {
-        return std::nullopt;
-    }
-    return std::string{entry->get()};
-}
-
-/// A seeded historical world: one account with two storage slots, code, and abi committed into
-/// nodeStorage / backendStorage; plus an empty execStorage where inherited writes land.
+/// A seeded historical world: a contract with two storage slots and code committed into the
+/// trie, its code row in backendStorage, plus an execStorage standing in for the live flat KV.
 struct SeededState
 {
     NodeStorage nodeStorage;
-    FlatStorage backendStorage;  // s_code_binary + s_contract_abi, hash-addressed
-    FlatStorage execStorage;     // write target of the inherited EVMAccount methods
+    FlatStorage backendStorage;  // s_code_binary, hash-addressed
+    FlatStorage execStorage;     // the flat KV the inherited EVMAccount behaviour uses
 
     bcos::Address addr = makeAddress(0xab);
     bcos::Address eoaAddr = makeAddress(0xee);
@@ -114,7 +98,6 @@ struct SeededState
     bcos::u256 val1{0x1234};
     bcos::u256 val2{0xdeadbeef};
     bcos::bytes code{0x60, 0x80, 0x60, 0x40, 0x52};
-    std::string abi{R"([{"type":"function","name":"f"}])"};
     bcos::h256 codeHash;
     Account seeded;  // the committed 4-tuple
     bcos::h256 stateRoot;
@@ -127,20 +110,15 @@ struct SeededState
                 {slotKeyHash(slot2), encodeStorageValue(bcos::h256(val2).ref())}})
                                      .root;
 
-        // Code + abi: hash-addressed rows keyed by the raw 32 hash bytes.
         bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
         bcos::crypto::hasher::hash(hasher, bcos::ref(code), codeHash);
         bcos::task::syncWait(bcos::storage2::writeOne(backendStorage,
             bcos::executor_v1::StateKey{
                 bcos::ledger::SYS_CODE_BINARY, bcos::concepts::bytebuffer::toView(codeHash)},
             bcos::storage::Entry{code}));
-        bcos::task::syncWait(bcos::storage2::writeOne(backendStorage,
-            bcos::executor_v1::StateKey{
-                bcos::ledger::SYS_CONTRACT_ABI, bcos::concepts::bytebuffer::toView(codeHash)},
-            bcos::storage::Entry{abi}));
 
-        // Account trie: the contract's 4-tuple leaf at accountKeyHash(addr), plus a second
-        // EOA leaf — no code (emptyCodeHash) and no storage (emptyRootHash).
+        // Account trie: the contract's 4-tuple leaf, plus an EOA leaf — no code
+        // (emptyCodeHash) and no storage (emptyRootHash).
         seeded.nonce = 7;
         seeded.balance = 1000;
         seeded.storageRoot = storageRoot;
@@ -155,204 +133,305 @@ struct SeededState
                         .root;
     }
 
-    TestMPTAccount account() { return {execStorage, nodeStorage, backendStorage, stateRoot, addr}; }
+    TestMPTAccount account()
+    {
+        return {execStorage, nodeStorage, backendStorage, addr, /*binaryAddress*/ false};
+    }
     TestMPTAccount accountAt(bcos::Address const& address)
     {
-        return {execStorage, nodeStorage, backendStorage, stateRoot, address};
+        return {execStorage, nodeStorage, backendStorage, address, /*binaryAddress*/ false};
     }
     std::string tableName() const { return "/apps/" + addr.hex(); }
+    /// The historical root, in the optional form every read takes.
+    std::optional<bcos::h256> at() const { return stateRoot; }
 };
 
 }  // namespace
 
 BOOST_AUTO_TEST_SUITE(MPTAccountSuite)
 
-// The 4-tuple reads (balance/nonce/codeHash) and storage(key) match the seeded values; the
-// MPTReadView 4-tuple is the oracle.
-BOOST_AUTO_TEST_CASE(ReadsMatchSeededState)
+// Reads given a root walk the trie: the 4-tuple and both slots match what was committed, with
+// MPTReadView as the oracle.
+BOOST_AUTO_TEST_CASE(HistoricalReadsMatchSeededState)
 {
     SeededState state;
     auto account = state.account();
 
-    BOOST_CHECK(bcos::task::syncWait(account.exists()));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
-    auto const nonce = bcos::task::syncWait(account.nonce());
+    BOOST_CHECK(bcos::task::syncWait(account.exists(state.at())));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance(state.at())), 1000);
+    auto const nonce = bcos::task::syncWait(account.nonce(state.at()));
     BOOST_REQUIRE(nonce.has_value());
     BOOST_CHECK_EQUAL(*nonce, "7");
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), state.codeHash);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(state.at())), state.codeHash);
 
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1), state.at()))),
         bcos::h256(state.val1));
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot2)))),
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot2), state.at()))),
         bcos::h256(state.val2));
+    // A plain root must resolve to the historical overload, not to the inherited tag-forwarding
+    // flat read (a bare h256 is an exact match for the tag pack — see MPTAccount::storage).
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1), state.stateRoot))),
+        bcos::h256(state.val1));
+    // The mirror case: a literal nullopt must mean "latest", i.e. the flat read (empty here),
+    // not be swallowed as a storage tag.
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1), std::nullopt))),
+        bcos::h256{});
+
+    auto const code = bcos::task::syncWait(account.code(state.at()));
+    BOOST_REQUIRE(code.has_value());
+    auto const codeView = code->get();
+    BOOST_CHECK(bcos::bytes(codeView.begin(), codeView.end()) == state.code);
 
     // Oracle: the same leaf through MPTReadView.
     MPTReadView view(state.nodeStorage, state.stateRoot);
     auto const oracle = bcos::task::syncWait(view.readAccount(state.addr));
     BOOST_REQUIRE(oracle.has_value());
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), oracle->balance);
-    BOOST_CHECK_EQUAL(bcos::u256(*bcos::task::syncWait(account.nonce())), oracle->nonce);
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), oracle->codeHash);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance(state.at())), oracle->balance);
+    BOOST_CHECK_EQUAL(bcos::u256(*bcos::task::syncWait(account.nonce(state.at()))), oracle->nonce);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(state.at())), oracle->codeHash);
 
-    // address()/path() are INHERITED from EVMAccount: the "/apps/<hex>" table name, so
-    // historical and latest accounts key transient storage and logs identically.
+    // address()/path() are inherited: the real table name, identical to EVMAccount's.
     BOOST_CHECK_EQUAL(account.address(), state.tableName());
     BOOST_CHECK_EQUAL(bcos::task::syncWait(account.path()), state.tableName());
-    BOOST_CHECK_EQUAL(account.root(), state.stateRoot);
 }
 
-// code()/abi() resolve the leaf's codeHash through the hash-addressed backend tables and return
-// the exact deployed bytes.
-BOOST_AUTO_TEST_CASE(CodeAndAbiRoundTrip)
+// Without a root MPTAccount IS EVMAccount: reads go to the flat KV and see this object's own
+// writes. Read-your-writes, nonce advance and create() all behave as on the latest state — the
+// historical trie is not consulted at all (it holds different values for every field here).
+BOOST_AUTO_TEST_CASE(DefaultReadsAreFlatWithReadYourWrites)
 {
     SeededState state;
     auto account = state.account();
 
-    auto const code = bcos::task::syncWait(account.code());
-    BOOST_REQUIRE(code.has_value());
-    auto const view = code->get();
-    bcos::bytes const got{view.begin(), view.end()};
-    BOOST_CHECK(got == state.code);
-
-    auto const abi = bcos::task::syncWait(account.abi());
-    BOOST_REQUIRE(abi.has_value());
-    BOOST_CHECK_EQUAL(abi->get(), state.abi);
-}
-
-// Absence is Ethereum semantics, not an error: an account missing from the trie reads as
-// exists false / balance 0 / nonce unset / zero codeHash / no code; a missing slot reads zero.
-BOOST_AUTO_TEST_CASE(AbsentAccountAndSlotReadZero)
-{
-    SeededState state;
-
-    auto absent = state.accountAt(makeAddress(0xcd));
-    BOOST_CHECK(!bcos::task::syncWait(absent.exists()));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(absent.balance()), 0);
-    BOOST_CHECK(!bcos::task::syncWait(absent.nonce()).has_value());
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(absent.codeHash()), bcos::h256{});
-    BOOST_CHECK(!bcos::task::syncWait(absent.code()).has_value());
-    BOOST_CHECK(!bcos::task::syncWait(absent.abi()).has_value());
+    // Nothing written yet: the flat KV is empty, and the trie's values do NOT leak through.
+    BOOST_CHECK(!bcos::task::syncWait(account.exists()));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 0);
+    BOOST_CHECK(!bcos::task::syncWait(account.nonce()).has_value());
     BOOST_CHECK_EQUAL(
-        fromEvmc(bcos::task::syncWait(absent.storage(toEvmc(state.slot1)))), bcos::h256{});
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))), bcos::h256{});
 
-    // An existing account's absent slot also reads zero; its storageEntry is nullopt.
-    auto account = state.account();
-    BOOST_CHECK_EQUAL(
-        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slotAbsent)))), bcos::h256{});
-    BOOST_CHECK(!bcos::task::syncWait(
-        account.storageEntry(bcos::concepts::bytebuffer::toView(state.slotAbsent)))
-            .has_value());
+    // create() then exists(); setBalance/setNonce/setStorage then read them back.
+    bcos::task::syncWait(account.create());
+    BOOST_CHECK(bcos::task::syncWait(account.exists()));
 
-    // increaseNonce on an absent account throws, like EVMAccount.
-    BOOST_CHECK_THROW(
-        bcos::task::syncWait(absent.increaseNonce()), bcos::ledger::account::NonceNotInitialized);
-
-    // An empty root has no accounts at all.
-    auto emptyRootAccount = TestMPTAccount{
-        state.execStorage, state.nodeStorage, state.backendStorage, emptyRootHash(), state.addr};
-    BOOST_CHECK(!bcos::task::syncWait(emptyRootAccount.exists()));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(emptyRootAccount.balance()), 0);
-}
-
-// Writes are the INHERITED EVMAccount methods: they land as flat rows in execStorage (in
-// EVMAccount's own representation) and reads keep returning the historical trie values — a
-// write in a historical call is never read back (spec §5.13 boundary). The trie/node storage
-// and the backend tables never gain, lose, or change a key.
-BOOST_AUTO_TEST_CASE(WritesAreSimulationOnlyAndNeverReadBack)
-{
-    SeededState state;
-    size_t const nodeKeysBefore = storageKeyCount(state.nodeStorage);
-    size_t const backendKeysBefore = storageKeyCount(state.backendStorage);
-    BOOST_REQUIRE_GT(nodeKeysBefore, 0);
-    BOOST_REQUIRE_EQUAL(storageKeyCount(state.execStorage), 0);
-
-    auto account = state.account();
-    auto const table = state.tableName();
-
-    // setBalance: the flat row is EVMAccount's decimal-string representation; balance() still
-    // reads the trie.
     bcos::task::syncWait(account.setBalance(bcos::u256{555}));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
-    BOOST_CHECK_EQUAL(flatRow(state.execStorage, table, bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE)
-                          .value_or("<missing>"),
-        "555");
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 555);
 
-    // setNonce writes the row; nonce() still reads the trie.
     bcos::task::syncWait(account.setNonce("42"));
-    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "7");
-    BOOST_CHECK_EQUAL(flatRow(state.execStorage, table, bcos::ledger::ACCOUNT_TABLE_FIELDS::NONCE)
-                          .value_or("<missing>"),
-        "42");
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "42");
+    bcos::task::syncWait(account.increaseNonce());  // inherited: reads the flat nonce
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "43");
 
-    // increaseNonce = trie nonce + 1 through the inherited setNonce: overwrites the row with 8
-    // (7+1), NOT 43 — the previous simulated setNonce is not read back either.
-    bcos::task::syncWait(account.increaseNonce());
-    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "7");
-    BOOST_CHECK_EQUAL(flatRow(state.execStorage, table, bcos::ledger::ACCOUNT_TABLE_FIELDS::NONCE)
-                          .value_or("<missing>"),
-        "8");
-
-    // setStorage writes the raw 32-byte row; storage() still reads the trie.
     bcos::h256 const newValue{0xabcdef};
     bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(newValue)));
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
-        bcos::h256(state.val1));
-    auto const slotRow =
-        flatRow(state.execStorage, table, bcos::concepts::bytebuffer::toView(state.slot1));
-    BOOST_REQUIRE(slotRow.has_value());
-    BOOST_CHECK_EQUAL(bcos::h256(bcos::bytesConstRef(
-                          reinterpret_cast<const bcos::byte*>(slotRow->data()), slotRow->size())),
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))), newValue);
+    // The tag-forwarding overload HostContext uses is still the inherited flat read.
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(
+                          account.storage(toEvmc(state.slot1), bcos::storage2::BYPASS_READ_SET))),
         newValue);
 
-    // setCode lands the code row in execStorage's s_code_binary (inherited behavior); the
-    // historical codeHash()/code() are unchanged and backendStorage is untouched.
+    // setCode / abi(): abi is inherited outright, so it round-trips through the flat KV.
     bcos::bytes newCode{0xfe, 0xed};
     bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
     bcos::h256 newCodeHash;
     bcos::crypto::hasher::hash(hasher, bcos::ref(newCode), newCodeHash);
     bcos::task::syncWait(account.setCode(newCode, "the-abi", newCodeHash));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), state.codeHash);
-    auto const stillHistoricalCode = bcos::task::syncWait(account.code());
-    BOOST_REQUIRE(stillHistoricalCode.has_value());
-    auto const stillHistoricalView = stillHistoricalCode->get();
-    BOOST_CHECK(bcos::bytes(stillHistoricalView.begin(), stillHistoricalView.end()) == state.code);
-    BOOST_CHECK(flatRow(state.execStorage, bcos::ledger::SYS_CODE_BINARY,
-        bcos::concepts::bytebuffer::toView(newCodeHash))
-            .has_value());
-
-    // create() on an absent account writes the s_tables row (inherited) but exists() still
-    // answers from the trie.
-    auto created = state.accountAt(makeAddress(0xcd));
-    bcos::task::syncWait(created.create());
-    BOOST_CHECK(!bcos::task::syncWait(created.exists()));
-    BOOST_CHECK(flatRow(state.execStorage, bcos::ledger::SYS_TABLES,
-        std::string{"/apps/"} + makeAddress(0xcd).hex())
-            .has_value());
-
-    // The historical stores are untouched.
-    BOOST_CHECK_EQUAL(storageKeyCount(state.nodeStorage), nodeKeysBefore);
-    BOOST_CHECK_EQUAL(storageKeyCount(state.backendStorage), backendKeysBefore);
-
-    // A fresh MPTAccount still reads the ORIGINAL committed state.
-    auto pristine = state.account();
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(pristine.balance()), 1000);
-    BOOST_CHECK_EQUAL(*bcos::task::syncWait(pristine.nonce()), "7");
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(pristine.codeHash()), state.codeHash);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), newCodeHash);
+    auto const flatCode = bcos::task::syncWait(account.code());
+    BOOST_REQUIRE(flatCode.has_value());
+    auto const flatCodeView = flatCode->get();
+    BOOST_CHECK(bcos::bytes(flatCodeView.begin(), flatCodeView.end()) == newCode);
+    auto const flatAbi = bcos::task::syncWait(account.abi());
+    BOOST_REQUIRE(flatAbi.has_value());
+    BOOST_CHECK_EQUAL(flatAbi->get(), "the-abi");
 }
 
-// The tag-taking read (BYPASS_READ_SET et al. are no-ops here) and storageEntry stay
-// consistent with storage(key) — all pure trie
-// reads, before AND after a simulated write to the same slot.
-BOOST_AUTO_TEST_CASE(DirectAndStorageEntryConsistent)
+// binaryAddress is what makes the no-root path address the right table on a feature_raw_address
+// chain, which is why the constructor takes it without a default. With it set, the inherited
+// reads and writes must use the raw-byte table name, not the hex one.
+BOOST_AUTO_TEST_CASE(BinaryAddressSelectsTheRawTable)
+{
+    SeededState state;
+    TestMPTAccount account{
+        state.execStorage, state.nodeStorage, state.backendStorage, state.addr, true};
+
+    std::string expected{bcos::ledger::SYS_DIRECTORY::USER_APPS};
+    expected.append(reinterpret_cast<const char*>(state.addr.data()), state.addr.size());
+    BOOST_CHECK_EQUAL(account.address(), expected);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.path()), expected);
+    BOOST_CHECK_NE(account.address(), state.tableName());
+
+    // The inherited write lands under that name, and the inherited read finds it there.
+    bcos::task::syncWait(account.setBalance(bcos::u256{99}));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 99);
+    auto const row = bcos::task::syncWait(bcos::storage2::readOne(state.execStorage,
+        bcos::executor_v1::StateKeyView{expected, bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE}));
+    BOOST_REQUIRE(row.has_value());
+
+    // The historical path is address-keyed, not table-keyed, so it is unaffected.
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance(state.at())), 1000);
+}
+
+// The two paths do not contaminate each other: after the flat writes above, reads given a root
+// still return the block's committed values, and the node storage never gains a key.
+BOOST_AUTO_TEST_CASE(HistoricalReadsIgnoreFlatWrites)
+{
+    SeededState state;
+    size_t const nodeKeysBefore = storageKeyCount(state.nodeStorage);
+    BOOST_REQUIRE_GT(nodeKeysBefore, 0);
+
+    auto account = state.account();
+    bcos::task::syncWait(account.setBalance(bcos::u256{555}));
+    bcos::task::syncWait(account.setNonce("42"));
+    bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(bcos::h256{0xabcdef})));
+
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance(state.at())), 1000);
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce(state.at())), "7");
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1), state.at()))),
+        bcos::h256(state.val1));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(state.at())), state.codeHash);
+
+    // The flat writes really did land — the historical path simply does not look at them.
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 555);
+    BOOST_CHECK_EQUAL(storageKeyCount(state.nodeStorage), nodeKeysBefore);
+}
+
+// Absence at a root is Ethereum semantics, not an error.
+BOOST_AUTO_TEST_CASE(AbsentAccountAndSlotReadZero)
+{
+    SeededState state;
+
+    auto absent = state.accountAt(makeAddress(0xcd));
+    BOOST_CHECK(!bcos::task::syncWait(absent.exists(state.at())));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(absent.balance(state.at())), 0);
+    BOOST_CHECK(!bcos::task::syncWait(absent.nonce(state.at())).has_value());
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(absent.codeHash(state.at())), bcos::h256{});
+    BOOST_CHECK(!bcos::task::syncWait(absent.code(state.at())).has_value());
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(absent.storage(toEvmc(state.slot1), state.at()))),
+        bcos::h256{});
+
+    // An existing account's absent slot also reads zero; its storageEntry is nullopt.
+    auto account = state.account();
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slotAbsent), state.at()))),
+        bcos::h256{});
+    BOOST_CHECK(!bcos::task::syncWait(
+        account.storageEntry(bcos::concepts::bytebuffer::toView(state.slotAbsent), state.at()))
+            .has_value());
+
+    // An empty root has no accounts at all.
+    BOOST_CHECK(!bcos::task::syncWait(account.exists(emptyRootHash())));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance(emptyRootHash())), 0);
+}
+
+// An EOA leaf (emptyCodeHash, emptyRootHash storage) exists with its 4-tuple values but has no
+// code, and every slot reads zero through the empty-storage-trie short circuit.
+BOOST_AUTO_TEST_CASE(EOALeafHasNoCodeAndEmptyStorage)
+{
+    SeededState state;
+    auto eoa = state.accountAt(state.eoaAddr);
+
+    BOOST_CHECK(bcos::task::syncWait(eoa.exists(state.at())));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(eoa.balance(state.at())), 5);
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(eoa.nonce(state.at())), "1");
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(eoa.codeHash(state.at())), emptyCodeHash());
+    BOOST_CHECK(!bcos::task::syncWait(eoa.code(state.at())).has_value());
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(eoa.storage(toEvmc(state.slot1), state.at()))), bcos::h256{});
+}
+
+// A leaf whose codeHash has no s_code_binary row falls back to the base resolution, exactly as
+// EVMAccount does — that is where contracts deployed by old versions keep their code. An
+// account absent from the trie does NOT fall back: it did not exist at that block.
+BOOST_AUTO_TEST_CASE(MissingCodeRowFallsBackToAccountTable)
+{
+    SeededState state;
+    Account legacy;
+    legacy.nonce = 1;
+    legacy.balance = 1;
+    legacy.storageRoot = emptyRootHash();
+    legacy.codeHash = makeHash(0x77);  // committed, but no s_code_binary row exists for it
+    auto const legacyAddr = makeAddress(0xba);
+    auto const root = seedTrieFlushed(
+        state.nodeStorage, state.stateRoot, {{accountKeyHash(legacyAddr), legacy.encode()}})
+                          .root;
+
+    bcos::bytes const legacyCode{0x01, 0x02, 0x03};
+    bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
+        bcos::executor_v1::StateKey{
+            "/apps/" + legacyAddr.hex(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE},
+        bcos::storage::Entry{legacyCode}));
+
+    // Today's flat state has this address on a DIFFERENT, hash-addressed code. The fallback must
+    // not go through the base's full resolution, which starts from this flat codeHash and would
+    // return bytes hashing to something other than the codeHash the leaf committed.
+    bcos::bytes const todaysCode{0xaa, 0xbb};
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    bcos::h256 todaysCodeHash;
+    bcos::crypto::hasher::hash(hasher, bcos::ref(todaysCode), todaysCodeHash);
+    bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
+        bcos::executor_v1::StateKey{
+            "/apps/" + legacyAddr.hex(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH},
+        bcos::storage::Entry{bcos::concepts::bytebuffer::toView(todaysCodeHash)}));
+    bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
+        bcos::executor_v1::StateKey{
+            bcos::ledger::SYS_CODE_BINARY, bcos::concepts::bytebuffer::toView(todaysCodeHash)},
+        bcos::storage::Entry{todaysCode}));
+
+    auto account = state.accountAt(legacyAddr);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(root)), makeHash(0x77));
+    auto const code = bcos::task::syncWait(account.code(root));
+    BOOST_REQUIRE(code.has_value());
+    auto const view = code->get();
+    BOOST_CHECK(bcos::bytes(view.begin(), view.end()) == legacyCode);
+    BOOST_CHECK(bcos::bytes(view.begin(), view.end()) != todaysCode);
+
+    // Absent from the trie: no code and no fallback, even though the flat row is right there.
+    auto absent = state.accountAt(makeAddress(0xcd));
+    bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
+        bcos::executor_v1::StateKey{
+            "/apps/" + makeAddress(0xcd).hex(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE},
+        bcos::storage::Entry{legacyCode}));
+    BOOST_CHECK(!bcos::task::syncWait(absent.code(root)).has_value());
+}
+
+// A committed non-empty codeHash asserts the code existed; neither store holding it is corruption,
+// not absence. Reporting nullopt would run the contract as an EOA and answer calls to it with
+// success and empty output, which the caller cannot tell from a correct answer.
+BOOST_AUTO_TEST_CASE(CodeMissingFromBothStoresThrows)
+{
+    SeededState state;
+    Account corrupt;
+    corrupt.nonce = 1;
+    corrupt.balance = 1;
+    corrupt.storageRoot = emptyRootHash();
+    corrupt.codeHash = makeHash(0x99);  // no s_code_binary row, and no account-table CODE row
+    auto const corruptAddr = makeAddress(0xde);
+    auto const root = seedTrieFlushed(
+        state.nodeStorage, state.stateRoot, {{accountKeyHash(corruptAddr), corrupt.encode()}})
+                          .root;
+
+    auto account = state.accountAt(corruptAddr);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(root)), makeHash(0x99));
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(account.code(root)), bcos::ledger::mpt::MPTInvariantViolation);
+}
+
+// storageEntry: the 32-byte slot value at a root, or the base's any-field-name read without one.
+BOOST_AUTO_TEST_CASE(StorageEntryHistoricalAndFlat)
 {
     SeededState state;
     auto account = state.account();
 
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(
-                          account.storage(toEvmc(state.slot1), bcos::storage2::BYPASS_READ_SET))),
-        bcos::h256(state.val1));
-    auto entry =
-        bcos::task::syncWait(account.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)));
+    auto entry = bcos::task::syncWait(
+        account.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1), state.at()));
     BOOST_REQUIRE(entry.has_value());
     auto entryView = entry->get();
     BOOST_REQUIRE_EQUAL(entryView.size(), bcos::h256::SIZE);
@@ -360,118 +439,75 @@ BOOST_AUTO_TEST_CASE(DirectAndStorageEntryConsistent)
                           reinterpret_cast<const bcos::byte*>(entryView.data()), entryView.size())),
         bcos::h256(state.val1));
 
-    // After a simulated setStorage, all three paths STILL return the trie value.
-    bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(bcos::h256{0x99})));
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
-        bcos::h256(state.val1));
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(
-                          account.storage(toEvmc(state.slot1), bcos::storage2::BYPASS_READ_SET))),
-        bcos::h256(state.val1));
-    auto afterWrite =
-        bcos::task::syncWait(account.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)));
-    BOOST_REQUIRE(afterWrite.has_value());
-    auto afterWriteView = afterWrite->get();
+    // Only 32-byte keys can exist in a storage trie: anything else is absent by construction.
+    BOOST_CHECK(!bcos::task::syncWait(account.storageEntry("short-key", state.at())).has_value());
+
+    // A full-width slot value survives the trie's trimmed encoding and the u256 → h256 widening
+    // (the seeded slots are small enough to leave the top bytes zero).
+    bcos::u256 const wide{"0xff02030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"};
+    auto const wideRoot = seedTrieFlushed(state.nodeStorage, state.seeded.storageRoot,
+        {{slotKeyHash(state.slotAbsent), encodeStorageValue(bcos::h256(wide).ref())}})
+                              .root;
+    Account widened = state.seeded;
+    widened.storageRoot = wideRoot;
+    auto const rootWithWideSlot = seedTrieFlushed(state.nodeStorage, state.stateRoot,
+        {{accountKeyHash(state.addr),
+            widened.encode()}}).root;
     BOOST_CHECK_EQUAL(
-        bcos::h256(bcos::bytesConstRef(
-            reinterpret_cast<const bcos::byte*>(afterWriteView.data()), afterWriteView.size())),
-        bcos::h256(state.val1));
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slotAbsent), rootWithWideSlot))),
+        bcos::h256(wide));
 
-    // A non-32-byte key cannot exist in a storage trie: absent by construction.
-    BOOST_CHECK(!bcos::task::syncWait(account.storageEntry("short-key")).has_value());
-}
-
-// An EOA leaf (emptyCodeHash, emptyRootHash storage): exists() with its 4-tuple values, but has
-// no code/abi (the emptyCodeHash branch) and every slot reads zero through the
-// empty-storage-trie short circuit — no trie descent is even attempted.
-BOOST_AUTO_TEST_CASE(EOALeafHasNoCodeAndEmptyStorage)
-{
-    SeededState state;
-    auto eoa = state.accountAt(state.eoaAddr);
-
-    BOOST_CHECK(bcos::task::syncWait(eoa.exists()));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(eoa.balance()), 5);
-    BOOST_CHECK_EQUAL(*bcos::task::syncWait(eoa.nonce()), "1");
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(eoa.codeHash()), emptyCodeHash());
-    BOOST_CHECK(!bcos::task::syncWait(eoa.code()).has_value());
-    BOOST_CHECK(!bcos::task::syncWait(eoa.abi()).has_value());
-    BOOST_CHECK_EQUAL(
-        fromEvmc(bcos::task::syncWait(eoa.storage(toEvmc(state.slot1)))), bcos::h256{});
-    BOOST_CHECK(
-        !bcos::task::syncWait(eoa.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)))
-            .has_value());
-}
-
-// A leaf that commits a non-empty codeHash with no matching s_code_binary row is a corrupted
-// backend, not an EOA: code() throws instead of silently downgrading the account. abi() stays
-// nullopt — the abi table is BCOS metadata outside the committed 4-tuple.
-BOOST_AUTO_TEST_CASE(MissingCodeRowIsInvariantViolation)
-{
-    SeededState state;
-    Account broken;
-    broken.nonce = 1;
-    broken.balance = 1;
-    broken.storageRoot = emptyRootHash();
-    broken.codeHash = makeHash(0x77);  // no s_code_binary row exists for this hash
-    auto const brokenAddr = makeAddress(0xba);
-    auto const root = seedTrieFlushed(
-        state.nodeStorage, state.stateRoot, {{accountKeyHash(brokenAddr), broken.encode()}})
-                          .root;
-
-    TestMPTAccount account{
-        state.execStorage, state.nodeStorage, state.backendStorage, root, brokenAddr};
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), makeHash(0x77));
-    BOOST_CHECK_THROW(bcos::task::syncWait(account.code()), MPTInvariantViolation);
-    BOOST_CHECK(!bcos::task::syncWait(account.abi()).has_value());
+    // Without a root the base reads any account-table field name, short keys included.
+    bcos::task::syncWait(account.setBalance(bcos::u256{7}));
+    auto const flatField =
+        bcos::task::syncWait(account.storageEntry(bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE));
+    BOOST_REQUIRE(flatField.has_value());
+    BOOST_CHECK_EQUAL(flatField->get(), "7");
 }
 
 namespace
 {
 
-/// PR-43's historical storage stack, shrunk to what MPTAccount's HostContext-shaped constructor
-/// needs: a Storage carrying the MPT read context via the three getters.
+/// PR-43's historical storage stack, shrunk to what MPTAccount's EVMAccount-shaped constructor
+/// needs: a Storage that also hands out the MPT node and backend handles.
 struct StubHistoricalStorage : FlatStorage
 {
     NodeStorage* nodes{};
     FlatStorage* backend{};
-    bcos::h256 root;
 
     NodeStorage& mptNodeStorage() { return *nodes; }
     FlatStorage& mptBackendStorage() { return *backend; }
-    bcos::h256 mptStateRoot() const { return root; }
 };
 static_assert(HistoricalStorageContext<StubHistoricalStorage>);
 static_assert(!HistoricalStorageContext<FlatStorage>);
 
 }  // namespace
 
-// The (storage, address, binaryAddress) constructor — HostContext's fixed construction shape
-// (getAccount / executeCreate build accounts with exactly these three arguments) — pulls the
-// trie context off the storage type and reads the same historical state.
+// The (storage, address, binaryAddress) constructor — HostContext's fixed construction shape —
+// pulls the trie handles off the storage type and reads the same state both ways.
 BOOST_AUTO_TEST_CASE(HostContextConstructionShape)
 {
     SeededState state;
     StubHistoricalStorage stub;
     stub.nodes = &state.nodeStorage;
     stub.backend = &state.backendStorage;
-    stub.root = state.stateRoot;
 
     evmc_address evmcAddr{};
-    std::copy(state.addr.begin(), state.addr.end(), evmcAddr.bytes);
+    std::copy(state.addr.begin(), state.addr.end(), std::begin(evmcAddr.bytes));
 
     MPTAccount<StubHistoricalStorage, NodeStorage, FlatStorage> account{
         stub, evmcAddr, /*binaryAddress*/ false};
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
-    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "7");
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance(state.stateRoot)), 1000);
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce(state.stateRoot)), "7");
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1), state.stateRoot))),
         bcos::h256(state.val1));
     BOOST_CHECK_EQUAL(account.address(), state.tableName());
-    BOOST_CHECK_EQUAL(account.root(), state.stateRoot);
 
-    // Writes go through the inherited EVMAccount methods into the stub itself.
+    // Writes and default reads use the stub itself, unchanged EVMAccount behaviour.
     bcos::task::syncWait(account.setBalance(bcos::u256{1}));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
-    BOOST_CHECK(
-        flatRow(stub, state.tableName(), bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE).has_value());
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance(state.stateRoot)), 1000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
@@ -38,6 +38,7 @@
 #include <bcos-utilities/FixedBytes.h>
 #include <evmc/evmc.h>
 #include <boost/test/unit_test.hpp>
+#include <algorithm>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -398,6 +399,29 @@ BOOST_AUTO_TEST_CASE(EOALeafHasNoCodeAndEmptyStorage)
     BOOST_CHECK(
         !bcos::task::syncWait(eoa.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)))
             .has_value());
+}
+
+// A leaf that commits a non-empty codeHash with no matching s_code_binary row is a corrupted
+// backend, not an EOA: code() throws instead of silently downgrading the account. abi() stays
+// nullopt — the abi table is BCOS metadata outside the committed 4-tuple.
+BOOST_AUTO_TEST_CASE(MissingCodeRowIsInvariantViolation)
+{
+    SeededState state;
+    Account broken;
+    broken.nonce = 1;
+    broken.balance = 1;
+    broken.storageRoot = emptyRootHash();
+    broken.codeHash = makeHash(0x77);  // no s_code_binary row exists for this hash
+    auto const brokenAddr = makeAddress(0xba);
+    auto const root = seedTrieFlushed(
+        state.nodeStorage, state.stateRoot, {{accountKeyHash(brokenAddr), broken.encode()}})
+                          .root;
+
+    TestMPTAccount account{
+        state.execStorage, state.nodeStorage, state.backendStorage, root, brokenAddr};
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), makeHash(0x77));
+    BOOST_CHECK_THROW(bcos::task::syncWait(account.code()), MPTInvariantViolation);
+    BOOST_CHECK(!bcos::task::syncWait(account.abi()).has_value());
 }
 
 namespace

--- a/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
@@ -54,6 +54,38 @@ using TestMPTAccount = MPTAccount<FlatStorage, NodeStorage, FlatStorage>;
 // HostContext is coded against is satisfied by the no-argument calls.
 static_assert(bcos::ledger::account::Account<TestMPTAccount>);
 
+// A root and a storage tag cannot be combined. Without the deleted overload this compiles and
+// resolves to the inherited tag pack, forwarding the root as a tag and reading today's flat value.
+// The concepts are templates on purpose: a requires-expression over concrete types is checked
+// eagerly, so selecting the deleted overload would be a hard error rather than an unmet
+// requirement.
+template <class AccountType>
+concept CombinesRootAndTag = requires(AccountType& account, evmc_bytes32 key, bcos::h256 root) {
+    account.storage(key, root, bcos::storage2::BYPASS_READ_SET);
+};
+static_assert(!CombinesRootAndTag<TestMPTAccount>);
+
+// Same for the optional form. Deleting only the plain-root arity would leave this one resolving to
+// the inherited tag pack, where MemoryStorage::readOneRaw discards every extra argument — the root
+// vanishes and the call reads today's flat value.
+template <class AccountType>
+concept CombinesOptionalRootAndTag =
+    requires(AccountType& account, evmc_bytes32 key, std::optional<bcos::h256> root) {
+        account.storage(key, root, bcos::storage2::BYPASS_READ_SET);
+    };
+static_assert(!CombinesOptionalRootAndTag<TestMPTAccount>);
+
+// The forms that must keep working, so the deletion cannot silently swallow them.
+template <class AccountType>
+concept HasEveryStorageForm = requires(AccountType& account, evmc_bytes32 key, bcos::h256 root) {
+    account.storage(key, root);
+    account.storage(key, std::optional<bcos::h256>{root});
+    account.storage(key, std::nullopt);
+    account.storage(key);
+    account.storage(key, bcos::storage2::BYPASS_READ_SET);
+};
+static_assert(HasEveryStorageForm<TestMPTAccount>);
+
 namespace
 {
 
@@ -347,10 +379,90 @@ BOOST_AUTO_TEST_CASE(EOALeafHasNoCodeAndEmptyStorage)
         fromEvmc(bcos::task::syncWait(eoa.storage(toEvmc(state.slot1), state.at()))), bcos::h256{});
 }
 
-// A leaf whose codeHash has no s_code_binary row falls back to the base resolution, exactly as
-// EVMAccount does — that is where contracts deployed by old versions keep their code. An
-// account absent from the trie does NOT fall back: it did not exist at that block.
-BOOST_AUTO_TEST_CASE(MissingCodeRowFallsBackToAccountTable)
+// A rooted read answers from the MPT alone. A leaf committing emptyCodeHash means the account had
+// no code at that block, full stop — bytes sitting in today's account-table CODE field do not
+// change that answer, even though the inherited flat path serves them. This pins the scope
+// decision: the two pre-3.18 shapes that put code in the account table (old-logic deploy, and
+// internal create with bugfix_internal_create_redundant_storage off, which writes CODE and no
+// CODE_HASH so FlatToMPT commits emptyCodeHash) are not producible at 3.18.0, and answering a
+// block-N question out of today's flat tables cannot be right in general.
+BOOST_AUTO_TEST_CASE(EmptyCodeHashLeafIsCodelessEvenWithFlatCodeBytes)
+{
+    SeededState state;
+    Account codeless;
+    codeless.nonce = 1;
+    codeless.balance = 1;
+    codeless.storageRoot = emptyRootHash();
+    codeless.codeHash = emptyCodeHash();
+    auto const addr = makeAddress(0xc0);
+    auto const root = seedTrieFlushed(
+        state.nodeStorage, state.stateRoot, {{accountKeyHash(addr), codeless.encode()}})
+                          .root;
+
+    bcos::bytes const flatCode{0x0a, 0x0b};
+    bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
+        bcos::executor_v1::StateKey{
+            "/apps/" + addr.hex(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE},
+        bcos::storage::Entry{flatCode}));
+
+    auto account = state.accountAt(addr);
+    BOOST_CHECK(bcos::task::syncWait(account.exists(root)));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(root)), emptyCodeHash());
+    BOOST_CHECK(!bcos::task::syncWait(account.code(root)).has_value());
+    // The flat path does serve those bytes; the divergence is deliberate, not an oversight.
+    auto const flat = bcos::task::syncWait(account.code());
+    BOOST_REQUIRE(flat.has_value());
+    auto const flatView = flat->get();
+    BOOST_CHECK(bcos::bytes(flatView.begin(), flatView.end()) == flatCode);
+}
+
+// exists() means leaf presence with a root — the Ethereum meaning — and a SYS_TABLES row without
+// one. They disagree for an account that has a table row but never produced a leaf, and Ethereum
+// agrees with the historical answer: it keeps no EIP-161 empty account in state.
+BOOST_AUTO_TEST_CASE(ExistsMeansLeafPresenceHistoricallyAndTableRowFlatly)
+{
+    SeededState state;
+    auto account = state.accountAt(makeAddress(0xf1));
+
+    // create() writes the SYS_TABLES row the flat exists() tests for, and nothing else.
+    bcos::task::syncWait(account.create());
+    BOOST_CHECK(bcos::task::syncWait(account.exists()));
+    BOOST_CHECK(!bcos::task::syncWait(account.exists(state.at())));
+
+    // The seeded contract is the converse control: present on both paths.
+    auto seeded = state.account();
+    BOOST_CHECK(bcos::task::syncWait(seeded.exists(state.at())));
+}
+
+// abi() is the one read with no root parameter: it is BCOS metadata outside the committed 4-tuple,
+// so a historical snapshot pairs block-N code/codeHash with the CURRENT abi. Pinned so the
+// asymmetry is a decision on record rather than something a reader has to infer.
+BOOST_AUTO_TEST_CASE(AbiIsNotHistoricised)
+{
+    SeededState state;
+    auto account = state.account();
+
+    // Deploy different code, and thus a different abi, "today".
+    bcos::bytes newCode{0xfe, 0xed};
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    bcos::h256 newCodeHash;
+    bcos::crypto::hasher::hash(hasher, bcos::ref(newCode), newCodeHash);
+    bcos::task::syncWait(account.setCode(newCode, "todays-abi", newCodeHash));
+
+    // The rooted reads still answer for block N...
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(state.at())), state.codeHash);
+    // ...while abi() has no rooted form at all and answers with today's.
+    auto const abi = bcos::task::syncWait(account.abi());
+    BOOST_REQUIRE(abi.has_value());
+    BOOST_CHECK_EQUAL(abi->get(), "todays-abi");
+}
+
+// Ethereum resolves code through exactly one store, so a leaf whose codeHash has no s_code_binary
+// row is corruption, not an EOA: returning nullopt would run the contract as an EOA and answer
+// calls to it with success and empty output. The account table's CODE field is deliberately NOT
+// consulted — the two pre-3.18 shapes that put code there cannot be produced at this blockVersion,
+// and reading today's flat tables to answer a question about block N cannot be right in general.
+BOOST_AUTO_TEST_CASE(MissingCodeRowThrowsAndNeverFallsBackToFlat)
 {
     SeededState state;
     Account legacy;
@@ -363,66 +475,45 @@ BOOST_AUTO_TEST_CASE(MissingCodeRowFallsBackToAccountTable)
         state.nodeStorage, state.stateRoot, {{accountKeyHash(legacyAddr), legacy.encode()}})
                           .root;
 
-    bcos::bytes const legacyCode{0x01, 0x02, 0x03};
+    // Flat state holds code for this address under both pre-3.18 shapes. Neither may rescue the
+    // historical read: the CODE field's bytes hash to nothing the leaf committed, and the flat
+    // CODE_HASH is today's, not block N's.
+    bcos::bytes const flatCode{0x01, 0x02, 0x03};
     bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
         bcos::executor_v1::StateKey{
             "/apps/" + legacyAddr.hex(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE},
-        bcos::storage::Entry{legacyCode}));
-
-    // Today's flat state has this address on a DIFFERENT, hash-addressed code. The fallback must
-    // not go through the base's full resolution, which starts from this flat codeHash and would
-    // return bytes hashing to something other than the codeHash the leaf committed.
-    bcos::bytes const todaysCode{0xaa, 0xbb};
+        bcos::storage::Entry{flatCode}));
     bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
-    bcos::h256 todaysCodeHash;
-    bcos::crypto::hasher::hash(hasher, bcos::ref(todaysCode), todaysCodeHash);
+    bcos::h256 flatCodeHash;
+    bcos::crypto::hasher::hash(hasher, bcos::ref(flatCode), flatCodeHash);
     bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
         bcos::executor_v1::StateKey{
             "/apps/" + legacyAddr.hex(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH},
-        bcos::storage::Entry{bcos::concepts::bytebuffer::toView(todaysCodeHash)}));
+        bcos::storage::Entry{bcos::concepts::bytebuffer::toView(flatCodeHash)}));
     bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
         bcos::executor_v1::StateKey{
-            bcos::ledger::SYS_CODE_BINARY, bcos::concepts::bytebuffer::toView(todaysCodeHash)},
-        bcos::storage::Entry{todaysCode}));
+            bcos::ledger::SYS_CODE_BINARY, bcos::concepts::bytebuffer::toView(flatCodeHash)},
+        bcos::storage::Entry{flatCode}));
 
     auto account = state.accountAt(legacyAddr);
     BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(root)), makeHash(0x77));
-    auto const code = bcos::task::syncWait(account.code(root));
-    BOOST_REQUIRE(code.has_value());
-    auto const view = code->get();
-    BOOST_CHECK(bcos::bytes(view.begin(), view.end()) == legacyCode);
-    BOOST_CHECK(bcos::bytes(view.begin(), view.end()) != todaysCode);
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(account.code(root)), bcos::ledger::mpt::MPTInvariantViolation);
+    // The flat path still serves those bytes; only the historical path refuses them.
+    auto const flat = bcos::task::syncWait(account.code());
+    BOOST_REQUIRE(flat.has_value());
+    auto const flatView = flat->get();
+    BOOST_CHECK(bcos::bytes(flatView.begin(), flatView.end()) == flatCode);
 
-    // Absent from the trie: no code and no fallback, even though the flat row is right there.
+    // Absent from the trie: no code, and no exception either — it did not exist at that block.
     auto absent = state.accountAt(makeAddress(0xcd));
     bcos::task::syncWait(bcos::storage2::writeOne(state.execStorage,
         bcos::executor_v1::StateKey{
             "/apps/" + makeAddress(0xcd).hex(), bcos::ledger::ACCOUNT_TABLE_FIELDS::CODE},
-        bcos::storage::Entry{legacyCode}));
+        bcos::storage::Entry{flatCode}));
     BOOST_CHECK(!bcos::task::syncWait(absent.code(root)).has_value());
 }
 
-// A committed non-empty codeHash asserts the code existed; neither store holding it is corruption,
-// not absence. Reporting nullopt would run the contract as an EOA and answer calls to it with
-// success and empty output, which the caller cannot tell from a correct answer.
-BOOST_AUTO_TEST_CASE(CodeMissingFromBothStoresThrows)
-{
-    SeededState state;
-    Account corrupt;
-    corrupt.nonce = 1;
-    corrupt.balance = 1;
-    corrupt.storageRoot = emptyRootHash();
-    corrupt.codeHash = makeHash(0x99);  // no s_code_binary row, and no account-table CODE row
-    auto const corruptAddr = makeAddress(0xde);
-    auto const root = seedTrieFlushed(
-        state.nodeStorage, state.stateRoot, {{accountKeyHash(corruptAddr), corrupt.encode()}})
-                          .root;
-
-    auto account = state.accountAt(corruptAddr);
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash(root)), makeHash(0x99));
-    BOOST_CHECK_THROW(
-        bcos::task::syncWait(account.code(root)), bcos::ledger::mpt::MPTInvariantViolation);
-}
 
 // storageEntry: the 32-byte slot value at a root, or the base's any-field-name read without one.
 BOOST_AUTO_TEST_CASE(StorageEntryHistoricalAndFlat)

--- a/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  * @file MPTAccountTest.cpp
- * @brief Unit tests for MPTAccount, the Account-concept reader over MPT state (spec §5.13)
+ * @brief Unit tests for MPTAccount, the EVMAccount subclass reading MPT state (spec §5.13)
  */
 
 #include "TestHelpers.h"
@@ -46,9 +46,9 @@ namespace bcos::ledger::mpt::test
 {
 
 using NodeStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
-using CodeStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+using FlatStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
     bcos::storage::Entry, bcos::storage2::memory_storage::ORDERED>;
-using TestMPTAccount = MPTAccount<NodeStorage, CodeStorage>;
+using TestMPTAccount = MPTAccount<FlatStorage, NodeStorage, FlatStorage>;
 
 // The whole point of MPTAccount: it satisfies the Account concept HostContext is coded against
 // (mirrors TestTransactionExecutive.cpp's static_assert for EVMAccount).
@@ -84,20 +84,36 @@ size_t storageKeyCount(Storage& storage)
     }(storage));
 }
 
-/// A seeded historical world: one account with two storage slots and code, committed into
-/// nodeStorage; the code bytes in codeStorage under s_code_binary[codeHash].
+/// The flat row an inherited EVMAccount write left in @p storage, as a string; nullopt if none.
+std::optional<std::string> flatRow(
+    FlatStorage& storage, std::string_view table, std::string_view row)
+{
+    auto entry = bcos::task::syncWait(
+        bcos::storage2::readOne(storage, bcos::executor_v1::StateKeyView{table, row}));
+    if (!entry)
+    {
+        return std::nullopt;
+    }
+    return std::string{entry->get()};
+}
+
+/// A seeded historical world: one account with two storage slots, code, and abi committed into
+/// nodeStorage / backendStorage; plus an empty execStorage where inherited writes land.
 struct SeededState
 {
     NodeStorage nodeStorage;
-    CodeStorage codeStorage;
+    FlatStorage backendStorage;  // s_code_binary + s_contract_abi, hash-addressed
+    FlatStorage execStorage;     // write target of the inherited EVMAccount methods
 
     bcos::Address addr = makeAddress(0xab);
+    bcos::Address eoaAddr = makeAddress(0xee);
     bcos::h256 slot1 = makeHash(0x01);
     bcos::h256 slot2 = makeHash(0x02);
     bcos::h256 slotAbsent = makeHash(0x7f);
     bcos::u256 val1{0x1234};
     bcos::u256 val2{0xdeadbeef};
     bcos::bytes code{0x60, 0x80, 0x60, 0x40, 0x52};
+    std::string abi{R"([{"type":"function","name":"f"}])"};
     bcos::h256 codeHash;
     Account seeded;  // the committed 4-tuple
     bcos::h256 stateRoot;
@@ -105,36 +121,45 @@ struct SeededState
     SeededState()
     {
         // Storage trie: two slots, values RLP-trimmed exactly as MPTBuilder writes them.
-        HashBuilder storageTrie(nodeStorage, emptyRootHash());
-        bcos::task::syncWait(
-            storageTrie.put(slotKeyHash(slot1), encodeStorageValue(bcos::h256(val1).ref())));
-        bcos::task::syncWait(
-            storageTrie.put(slotKeyHash(slot2), encodeStorageValue(bcos::h256(val2).ref())));
-        auto const storageRoot = bcos::task::syncWait(storageTrie.commit());
+        auto const storageRoot = seedTrieFlushed(nodeStorage, emptyRootHash(),
+            {{slotKeyHash(slot1), encodeStorageValue(bcos::h256(val1).ref())},
+                {slotKeyHash(slot2), encodeStorageValue(bcos::h256(val2).ref())}})
+                                     .root;
 
-        // Code: hash-addressed row in s_code_binary, keyed by the raw 32 hash bytes.
+        // Code + abi: hash-addressed rows keyed by the raw 32 hash bytes.
         bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
         bcos::crypto::hasher::hash(hasher, bcos::ref(code), codeHash);
-        bcos::task::syncWait(bcos::storage2::writeOne(codeStorage,
+        bcos::task::syncWait(bcos::storage2::writeOne(backendStorage,
             bcos::executor_v1::StateKey{
                 bcos::ledger::SYS_CODE_BINARY, bcos::concepts::bytebuffer::toView(codeHash)},
             bcos::storage::Entry{code}));
+        bcos::task::syncWait(bcos::storage2::writeOne(backendStorage,
+            bcos::executor_v1::StateKey{
+                bcos::ledger::SYS_CONTRACT_ABI, bcos::concepts::bytebuffer::toView(codeHash)},
+            bcos::storage::Entry{abi}));
 
-        // Account trie: the 4-tuple leaf at accountKeyHash(addr).
+        // Account trie: the contract's 4-tuple leaf at accountKeyHash(addr), plus a second
+        // EOA leaf — no code (emptyCodeHash) and no storage (emptyRootHash).
         seeded.nonce = 7;
         seeded.balance = 1000;
         seeded.storageRoot = storageRoot;
         seeded.codeHash = codeHash;
-        HashBuilder accountTrie(nodeStorage, emptyRootHash());
-        bcos::task::syncWait(accountTrie.put(accountKeyHash(addr), seeded.encode()));
-        stateRoot = bcos::task::syncWait(accountTrie.commit());
+        Account eoa;
+        eoa.nonce = 1;
+        eoa.balance = 5;
+        eoa.storageRoot = emptyRootHash();
+        eoa.codeHash = emptyCodeHash();
+        stateRoot = seedTrieFlushed(nodeStorage, emptyRootHash(),
+            {{accountKeyHash(addr), seeded.encode()}, {accountKeyHash(eoaAddr), eoa.encode()}})
+                        .root;
     }
 
-    TestMPTAccount account() { return {nodeStorage, codeStorage, stateRoot, addr}; }
+    TestMPTAccount account() { return {execStorage, nodeStorage, backendStorage, stateRoot, addr}; }
     TestMPTAccount accountAt(bcos::Address const& address)
     {
-        return {nodeStorage, codeStorage, stateRoot, address};
+        return {execStorage, nodeStorage, backendStorage, stateRoot, address};
     }
+    std::string tableName() const { return "/apps/" + addr.hex(); }
 };
 
 }  // namespace
@@ -168,15 +193,16 @@ BOOST_AUTO_TEST_CASE(ReadsMatchSeededState)
     BOOST_CHECK_EQUAL(bcos::u256(*bcos::task::syncWait(account.nonce())), oracle->nonce);
     BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), oracle->codeHash);
 
-    // address()/path() are the lowercase-hex address.
-    BOOST_CHECK_EQUAL(account.address(), state.addr.hex());
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.path()), state.addr.hex());
+    // address()/path() are INHERITED from EVMAccount: the "/apps/<hex>" table name, so
+    // historical and latest accounts key transient storage and logs identically.
+    BOOST_CHECK_EQUAL(account.address(), state.tableName());
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.path()), state.tableName());
     BOOST_CHECK_EQUAL(account.root(), state.stateRoot);
 }
 
-// code() resolves the leaf's codeHash through the s_code_binary handle and returns the exact
-// deployed bytes; abi() is empty (the Ethereum 4-tuple has no abi field).
-BOOST_AUTO_TEST_CASE(CodeRoundTrip)
+// code()/abi() resolve the leaf's codeHash through the hash-addressed backend tables and return
+// the exact deployed bytes.
+BOOST_AUTO_TEST_CASE(CodeAndAbiRoundTrip)
 {
     SeededState state;
     auto account = state.account();
@@ -187,7 +213,9 @@ BOOST_AUTO_TEST_CASE(CodeRoundTrip)
     bcos::bytes const got{view.begin(), view.end()};
     BOOST_CHECK(got == state.code);
 
-    BOOST_CHECK(!bcos::task::syncWait(account.abi()).has_value());
+    auto const abi = bcos::task::syncWait(account.abi());
+    BOOST_REQUIRE(abi.has_value());
+    BOOST_CHECK_EQUAL(abi->get(), state.abi);
 }
 
 // Absence is Ethereum semantics, not an error: an account missing from the trie reads as
@@ -202,6 +230,7 @@ BOOST_AUTO_TEST_CASE(AbsentAccountAndSlotReadZero)
     BOOST_CHECK(!bcos::task::syncWait(absent.nonce()).has_value());
     BOOST_CHECK_EQUAL(bcos::task::syncWait(absent.codeHash()), bcos::h256{});
     BOOST_CHECK(!bcos::task::syncWait(absent.code()).has_value());
+    BOOST_CHECK(!bcos::task::syncWait(absent.abi()).has_value());
     BOOST_CHECK_EQUAL(
         fromEvmc(bcos::task::syncWait(absent.storage(toEvmc(state.slot1)))), bcos::h256{});
 
@@ -213,88 +242,113 @@ BOOST_AUTO_TEST_CASE(AbsentAccountAndSlotReadZero)
         account.storageEntry(bcos::concepts::bytebuffer::toView(state.slotAbsent)))
             .has_value());
 
-    // increaseNonce on an account with no nonce throws, like EVMAccount.
+    // increaseNonce on an absent account throws, like EVMAccount.
     BOOST_CHECK_THROW(
         bcos::task::syncWait(absent.increaseNonce()), bcos::ledger::account::NonceNotInitialized);
 
     // An empty root has no accounts at all.
-    auto emptyRootAccount =
-        TestMPTAccount{state.nodeStorage, state.codeStorage, emptyRootHash(), state.addr};
+    auto emptyRootAccount = TestMPTAccount{
+        state.execStorage, state.nodeStorage, state.backendStorage, emptyRootHash(), state.addr};
     BOOST_CHECK(!bcos::task::syncWait(emptyRootAccount.exists()));
     BOOST_CHECK_EQUAL(bcos::task::syncWait(emptyRootAccount.balance()), 0);
 }
 
-// Writes are simulation-only: they land in the overlay (subsequent reads see them) and neither
-// nodeStorage nor codeStorage gains, loses, or changes a single key.
-BOOST_AUTO_TEST_CASE(WritesLandInOverlayOnly)
+// Writes are the INHERITED EVMAccount methods: they land as flat rows in execStorage (in
+// EVMAccount's own representation) and reads keep returning the historical trie values — a
+// write in a historical call is never read back (spec §5.13 boundary). The trie/node storage
+// and the backend tables never gain, lose, or change a key.
+BOOST_AUTO_TEST_CASE(WritesAreSimulationOnlyAndNeverReadBack)
 {
     SeededState state;
     size_t const nodeKeysBefore = storageKeyCount(state.nodeStorage);
-    size_t const codeKeysBefore = storageKeyCount(state.codeStorage);
+    size_t const backendKeysBefore = storageKeyCount(state.backendStorage);
     BOOST_REQUIRE_GT(nodeKeysBefore, 0);
+    BOOST_REQUIRE_EQUAL(storageKeyCount(state.execStorage), 0);
 
     auto account = state.account();
+    auto const table = state.tableName();
 
+    // setBalance: the flat row is EVMAccount's decimal-string representation; balance() still
+    // reads the trie.
     bcos::task::syncWait(account.setBalance(bcos::u256{555}));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 555);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
+    BOOST_CHECK_EQUAL(flatRow(state.execStorage, table, bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE)
+                          .value_or("<missing>"),
+        "555");
 
+    // setNonce writes the row; nonce() still reads the trie.
     bcos::task::syncWait(account.setNonce("42"));
-    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "42");
-    bcos::task::syncWait(account.increaseNonce());
-    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "43");
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "7");
+    BOOST_CHECK_EQUAL(flatRow(state.execStorage, table, bcos::ledger::ACCOUNT_TABLE_FIELDS::NONCE)
+                          .value_or("<missing>"),
+        "42");
 
+    // increaseNonce = trie nonce + 1 through the inherited setNonce: overwrites the row with 8
+    // (7+1), NOT 43 — the previous simulated setNonce is not read back either.
+    bcos::task::syncWait(account.increaseNonce());
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "7");
+    BOOST_CHECK_EQUAL(flatRow(state.execStorage, table, bcos::ledger::ACCOUNT_TABLE_FIELDS::NONCE)
+                          .value_or("<missing>"),
+        "8");
+
+    // setStorage writes the raw 32-byte row; storage() still reads the trie.
     bcos::h256 const newValue{0xabcdef};
     bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(newValue)));
-    BOOST_CHECK_EQUAL(
-        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))), newValue);
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
+        bcos::h256(state.val1));
+    auto const slotRow =
+        flatRow(state.execStorage, table, bcos::concepts::bytebuffer::toView(state.slot1));
+    BOOST_REQUIRE(slotRow.has_value());
+    BOOST_CHECK_EQUAL(bcos::h256(bcos::bytesConstRef(
+                          reinterpret_cast<const bcos::byte*>(slotRow->data()), slotRow->size())),
+        newValue);
 
+    // setCode lands the code row in execStorage's s_code_binary (inherited behavior); the
+    // historical codeHash()/code() are unchanged and backendStorage is untouched.
     bcos::bytes newCode{0xfe, 0xed};
     bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
     bcos::h256 newCodeHash;
     bcos::crypto::hasher::hash(hasher, bcos::ref(newCode), newCodeHash);
     bcos::task::syncWait(account.setCode(newCode, "the-abi", newCodeHash));
-    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), newCodeHash);
-    auto const overlayCode = bcos::task::syncWait(account.code());
-    BOOST_REQUIRE(overlayCode.has_value());
-    auto const overlayView = overlayCode->get();
-    BOOST_CHECK(bcos::bytes(overlayView.begin(), overlayView.end()) == newCode);
-    auto const overlayAbi = bcos::task::syncWait(account.abi());
-    BOOST_REQUIRE(overlayAbi.has_value());
-    BOOST_CHECK_EQUAL(overlayAbi->get(), "the-abi");
-
-    // create() on an absent account flips exists() without touching storage.
-    auto created = state.accountAt(makeAddress(0xcd));
-    bcos::task::syncWait(created.create());
-    BOOST_CHECK(bcos::task::syncWait(created.exists()));
-
-    // Storage untouched: same key counts, and the simulated code row never reached codeStorage.
-    BOOST_CHECK_EQUAL(storageKeyCount(state.nodeStorage), nodeKeysBefore);
-    BOOST_CHECK_EQUAL(storageKeyCount(state.codeStorage), codeKeysBefore);
-    BOOST_CHECK(
-        !bcos::task::syncWait(bcos::storage2::readOne(state.codeStorage,
-                                  bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
-                                      bcos::concepts::bytebuffer::toView(newCodeHash)}))
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), state.codeHash);
+    auto const stillHistoricalCode = bcos::task::syncWait(account.code());
+    BOOST_REQUIRE(stillHistoricalCode.has_value());
+    auto const stillHistoricalView = stillHistoricalCode->get();
+    BOOST_CHECK(bcos::bytes(stillHistoricalView.begin(), stillHistoricalView.end()) == state.code);
+    BOOST_CHECK(flatRow(state.execStorage, bcos::ledger::SYS_CODE_BINARY,
+        bcos::concepts::bytebuffer::toView(newCodeHash))
             .has_value());
 
-    // A fresh MPTAccount over the same storages still reads the ORIGINAL committed state.
+    // create() on an absent account writes the s_tables row (inherited) but exists() still
+    // answers from the trie.
+    auto created = state.accountAt(makeAddress(0xcd));
+    bcos::task::syncWait(created.create());
+    BOOST_CHECK(!bcos::task::syncWait(created.exists()));
+    BOOST_CHECK(flatRow(state.execStorage, bcos::ledger::SYS_TABLES,
+        std::string{"/apps/"} + makeAddress(0xcd).hex())
+            .has_value());
+
+    // The historical stores are untouched.
+    BOOST_CHECK_EQUAL(storageKeyCount(state.nodeStorage), nodeKeysBefore);
+    BOOST_CHECK_EQUAL(storageKeyCount(state.backendStorage), backendKeysBefore);
+
+    // A fresh MPTAccount still reads the ORIGINAL committed state.
     auto pristine = state.account();
     BOOST_CHECK_EQUAL(bcos::task::syncWait(pristine.balance()), 1000);
     BOOST_CHECK_EQUAL(*bcos::task::syncWait(pristine.nonce()), "7");
     BOOST_CHECK_EQUAL(bcos::task::syncWait(pristine.codeHash()), state.codeHash);
-    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(pristine.storage(toEvmc(state.slot1)))),
-        bcos::h256(state.val1));
 }
 
-// The DIRECT-tagged read and storageEntry stay consistent with storage(key), both against the
-// trie and against the overlay.
+// The tag-taking read (BYPASS_READ_SET et al. are no-ops here) and storageEntry stay
+// consistent with storage(key) — all pure trie
+// reads, before AND after a simulated write to the same slot.
 BOOST_AUTO_TEST_CASE(DirectAndStorageEntryConsistent)
 {
     SeededState state;
     auto account = state.account();
 
-    // Trie-backed: all three read paths agree on the committed value.
     BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(
-                          account.storage(toEvmc(state.slot1), bcos::storage2::DIRECT))),
+                          account.storage(toEvmc(state.slot1), bcos::storage2::BYPASS_READ_SET))),
         bcos::h256(state.val1));
     auto entry =
         bcos::task::syncWait(account.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)));
@@ -305,26 +359,95 @@ BOOST_AUTO_TEST_CASE(DirectAndStorageEntryConsistent)
                           reinterpret_cast<const bcos::byte*>(entryView.data()), entryView.size())),
         bcos::h256(state.val1));
 
-    // Overlay-backed: after setStorage, all three see the overlay value.
-    bcos::h256 const newValue{0x99};
-    bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(newValue)));
-    BOOST_CHECK_EQUAL(
-        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))), newValue);
+    // After a simulated setStorage, all three paths STILL return the trie value.
+    bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(bcos::h256{0x99})));
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
+        bcos::h256(state.val1));
     BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(
-                          account.storage(toEvmc(state.slot1), bcos::storage2::DIRECT))),
-        newValue);
-    auto overlayEntry =
+                          account.storage(toEvmc(state.slot1), bcos::storage2::BYPASS_READ_SET))),
+        bcos::h256(state.val1));
+    auto afterWrite =
         bcos::task::syncWait(account.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)));
-    BOOST_REQUIRE(overlayEntry.has_value());
-    auto overlayEntryView = overlayEntry->get();
-    BOOST_REQUIRE_EQUAL(overlayEntryView.size(), bcos::h256::SIZE);
+    BOOST_REQUIRE(afterWrite.has_value());
+    auto afterWriteView = afterWrite->get();
     BOOST_CHECK_EQUAL(
         bcos::h256(bcos::bytesConstRef(
-            reinterpret_cast<const bcos::byte*>(overlayEntryView.data()), overlayEntryView.size())),
-        newValue);
+            reinterpret_cast<const bcos::byte*>(afterWriteView.data()), afterWriteView.size())),
+        bcos::h256(state.val1));
 
     // A non-32-byte key cannot exist in a storage trie: absent by construction.
     BOOST_CHECK(!bcos::task::syncWait(account.storageEntry("short-key")).has_value());
+}
+
+// An EOA leaf (emptyCodeHash, emptyRootHash storage): exists() with its 4-tuple values, but has
+// no code/abi (the emptyCodeHash branch) and every slot reads zero through the
+// empty-storage-trie short circuit — no trie descent is even attempted.
+BOOST_AUTO_TEST_CASE(EOALeafHasNoCodeAndEmptyStorage)
+{
+    SeededState state;
+    auto eoa = state.accountAt(state.eoaAddr);
+
+    BOOST_CHECK(bcos::task::syncWait(eoa.exists()));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(eoa.balance()), 5);
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(eoa.nonce()), "1");
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(eoa.codeHash()), emptyCodeHash());
+    BOOST_CHECK(!bcos::task::syncWait(eoa.code()).has_value());
+    BOOST_CHECK(!bcos::task::syncWait(eoa.abi()).has_value());
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(eoa.storage(toEvmc(state.slot1)))), bcos::h256{});
+    BOOST_CHECK(
+        !bcos::task::syncWait(eoa.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)))
+            .has_value());
+}
+
+namespace
+{
+
+/// PR-43's historical storage stack, shrunk to what MPTAccount's HostContext-shaped constructor
+/// needs: a Storage carrying the MPT read context via the three getters.
+struct StubHistoricalStorage : FlatStorage
+{
+    NodeStorage* nodes{};
+    FlatStorage* backend{};
+    bcos::h256 root;
+
+    NodeStorage& mptNodeStorage() { return *nodes; }
+    FlatStorage& mptBackendStorage() { return *backend; }
+    bcos::h256 mptStateRoot() const { return root; }
+};
+static_assert(HistoricalStorageContext<StubHistoricalStorage>);
+static_assert(!HistoricalStorageContext<FlatStorage>);
+
+}  // namespace
+
+// The (storage, address, binaryAddress) constructor — HostContext's fixed construction shape
+// (getAccount / executeCreate build accounts with exactly these three arguments) — pulls the
+// trie context off the storage type and reads the same historical state.
+BOOST_AUTO_TEST_CASE(HostContextConstructionShape)
+{
+    SeededState state;
+    StubHistoricalStorage stub;
+    stub.nodes = &state.nodeStorage;
+    stub.backend = &state.backendStorage;
+    stub.root = state.stateRoot;
+
+    evmc_address evmcAddr{};
+    std::copy(state.addr.begin(), state.addr.end(), evmcAddr.bytes);
+
+    MPTAccount<StubHistoricalStorage, NodeStorage, FlatStorage> account{
+        stub, evmcAddr, /*binaryAddress*/ false};
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "7");
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
+        bcos::h256(state.val1));
+    BOOST_CHECK_EQUAL(account.address(), state.tableName());
+    BOOST_CHECK_EQUAL(account.root(), state.stateRoot);
+
+    // Writes go through the inherited EVMAccount methods into the stub itself.
+    bcos::task::syncWait(account.setBalance(bcos::u256{1}));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
+    BOOST_CHECK(
+        flatRow(stub, state.tableName(), bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE).has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTAccountTest.cpp
@@ -1,0 +1,332 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MPTAccountTest.cpp
+ * @brief Unit tests for MPTAccount, the Account-concept reader over MPT state (spec §5.13)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-crypto/hasher/AnyHasher.h>
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-framework/ledger/Account.h>
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/MPTAccount.h>
+#include <bcos-ledger/mpt/MPTReadView.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-task/Task.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <evmc/evmc.h>
+#include <boost/test/unit_test.hpp>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace bcos::ledger::mpt::test
+{
+
+using NodeStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
+using CodeStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+    bcos::storage::Entry, bcos::storage2::memory_storage::ORDERED>;
+using TestMPTAccount = MPTAccount<NodeStorage, CodeStorage>;
+
+// The whole point of MPTAccount: it satisfies the Account concept HostContext is coded against
+// (mirrors TestTransactionExecutive.cpp's static_assert for EVMAccount).
+static_assert(bcos::ledger::account::Account<TestMPTAccount>);
+
+namespace
+{
+
+bcos::h256 fromEvmc(const evmc_bytes32& value)
+{
+    return bcos::h256{bcos::bytesConstRef{value.bytes, sizeof(value.bytes)}};
+}
+
+evmc_bytes32 toEvmc(bcos::h256 const& value)
+{
+    evmc_bytes32 out{};
+    std::copy(value.begin(), value.end(), out.bytes);
+    return out;
+}
+
+/// Number of keys currently in @p storage (full bucket scan).
+template <class Storage>
+size_t storageKeyCount(Storage& storage)
+{
+    return bcos::task::syncWait([](Storage& storage) -> bcos::task::Task<size_t> {
+        auto range = co_await bcos::storage2::range(storage);
+        size_t count = 0;
+        while (co_await range.next())
+        {
+            ++count;
+        }
+        co_return count;
+    }(storage));
+}
+
+/// A seeded historical world: one account with two storage slots and code, committed into
+/// nodeStorage; the code bytes in codeStorage under s_code_binary[codeHash].
+struct SeededState
+{
+    NodeStorage nodeStorage;
+    CodeStorage codeStorage;
+
+    bcos::Address addr = makeAddress(0xab);
+    bcos::h256 slot1 = makeHash(0x01);
+    bcos::h256 slot2 = makeHash(0x02);
+    bcos::h256 slotAbsent = makeHash(0x7f);
+    bcos::u256 val1{0x1234};
+    bcos::u256 val2{0xdeadbeef};
+    bcos::bytes code{0x60, 0x80, 0x60, 0x40, 0x52};
+    bcos::h256 codeHash;
+    Account seeded;  // the committed 4-tuple
+    bcos::h256 stateRoot;
+
+    SeededState()
+    {
+        // Storage trie: two slots, values RLP-trimmed exactly as MPTBuilder writes them.
+        HashBuilder storageTrie(nodeStorage, emptyRootHash());
+        bcos::task::syncWait(
+            storageTrie.put(slotKeyHash(slot1), encodeStorageValue(bcos::h256(val1).ref())));
+        bcos::task::syncWait(
+            storageTrie.put(slotKeyHash(slot2), encodeStorageValue(bcos::h256(val2).ref())));
+        auto const storageRoot = bcos::task::syncWait(storageTrie.commit());
+
+        // Code: hash-addressed row in s_code_binary, keyed by the raw 32 hash bytes.
+        bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+        bcos::crypto::hasher::hash(hasher, bcos::ref(code), codeHash);
+        bcos::task::syncWait(bcos::storage2::writeOne(codeStorage,
+            bcos::executor_v1::StateKey{
+                bcos::ledger::SYS_CODE_BINARY, bcos::concepts::bytebuffer::toView(codeHash)},
+            bcos::storage::Entry{code}));
+
+        // Account trie: the 4-tuple leaf at accountKeyHash(addr).
+        seeded.nonce = 7;
+        seeded.balance = 1000;
+        seeded.storageRoot = storageRoot;
+        seeded.codeHash = codeHash;
+        HashBuilder accountTrie(nodeStorage, emptyRootHash());
+        bcos::task::syncWait(accountTrie.put(accountKeyHash(addr), seeded.encode()));
+        stateRoot = bcos::task::syncWait(accountTrie.commit());
+    }
+
+    TestMPTAccount account() { return {nodeStorage, codeStorage, stateRoot, addr}; }
+    TestMPTAccount accountAt(bcos::Address const& address)
+    {
+        return {nodeStorage, codeStorage, stateRoot, address};
+    }
+};
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(MPTAccountSuite)
+
+// The 4-tuple reads (balance/nonce/codeHash) and storage(key) match the seeded values; the
+// MPTReadView 4-tuple is the oracle.
+BOOST_AUTO_TEST_CASE(ReadsMatchSeededState)
+{
+    SeededState state;
+    auto account = state.account();
+
+    BOOST_CHECK(bcos::task::syncWait(account.exists()));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 1000);
+    auto const nonce = bcos::task::syncWait(account.nonce());
+    BOOST_REQUIRE(nonce.has_value());
+    BOOST_CHECK_EQUAL(*nonce, "7");
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), state.codeHash);
+
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))),
+        bcos::h256(state.val1));
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot2)))),
+        bcos::h256(state.val2));
+
+    // Oracle: the same leaf through MPTReadView.
+    MPTReadView view(state.nodeStorage, state.stateRoot);
+    auto const oracle = bcos::task::syncWait(view.readAccount(state.addr));
+    BOOST_REQUIRE(oracle.has_value());
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), oracle->balance);
+    BOOST_CHECK_EQUAL(bcos::u256(*bcos::task::syncWait(account.nonce())), oracle->nonce);
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), oracle->codeHash);
+
+    // address()/path() are the lowercase-hex address.
+    BOOST_CHECK_EQUAL(account.address(), state.addr.hex());
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.path()), state.addr.hex());
+    BOOST_CHECK_EQUAL(account.root(), state.stateRoot);
+}
+
+// code() resolves the leaf's codeHash through the s_code_binary handle and returns the exact
+// deployed bytes; abi() is empty (the Ethereum 4-tuple has no abi field).
+BOOST_AUTO_TEST_CASE(CodeRoundTrip)
+{
+    SeededState state;
+    auto account = state.account();
+
+    auto const code = bcos::task::syncWait(account.code());
+    BOOST_REQUIRE(code.has_value());
+    auto const view = code->get();
+    bcos::bytes const got{view.begin(), view.end()};
+    BOOST_CHECK(got == state.code);
+
+    BOOST_CHECK(!bcos::task::syncWait(account.abi()).has_value());
+}
+
+// Absence is Ethereum semantics, not an error: an account missing from the trie reads as
+// exists false / balance 0 / nonce unset / zero codeHash / no code; a missing slot reads zero.
+BOOST_AUTO_TEST_CASE(AbsentAccountAndSlotReadZero)
+{
+    SeededState state;
+
+    auto absent = state.accountAt(makeAddress(0xcd));
+    BOOST_CHECK(!bcos::task::syncWait(absent.exists()));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(absent.balance()), 0);
+    BOOST_CHECK(!bcos::task::syncWait(absent.nonce()).has_value());
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(absent.codeHash()), bcos::h256{});
+    BOOST_CHECK(!bcos::task::syncWait(absent.code()).has_value());
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(absent.storage(toEvmc(state.slot1)))), bcos::h256{});
+
+    // An existing account's absent slot also reads zero; its storageEntry is nullopt.
+    auto account = state.account();
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slotAbsent)))), bcos::h256{});
+    BOOST_CHECK(!bcos::task::syncWait(
+        account.storageEntry(bcos::concepts::bytebuffer::toView(state.slotAbsent)))
+            .has_value());
+
+    // increaseNonce on an account with no nonce throws, like EVMAccount.
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(absent.increaseNonce()), bcos::ledger::account::NonceNotInitialized);
+
+    // An empty root has no accounts at all.
+    auto emptyRootAccount =
+        TestMPTAccount{state.nodeStorage, state.codeStorage, emptyRootHash(), state.addr};
+    BOOST_CHECK(!bcos::task::syncWait(emptyRootAccount.exists()));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(emptyRootAccount.balance()), 0);
+}
+
+// Writes are simulation-only: they land in the overlay (subsequent reads see them) and neither
+// nodeStorage nor codeStorage gains, loses, or changes a single key.
+BOOST_AUTO_TEST_CASE(WritesLandInOverlayOnly)
+{
+    SeededState state;
+    size_t const nodeKeysBefore = storageKeyCount(state.nodeStorage);
+    size_t const codeKeysBefore = storageKeyCount(state.codeStorage);
+    BOOST_REQUIRE_GT(nodeKeysBefore, 0);
+
+    auto account = state.account();
+
+    bcos::task::syncWait(account.setBalance(bcos::u256{555}));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.balance()), 555);
+
+    bcos::task::syncWait(account.setNonce("42"));
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "42");
+    bcos::task::syncWait(account.increaseNonce());
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(account.nonce()), "43");
+
+    bcos::h256 const newValue{0xabcdef};
+    bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(newValue)));
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))), newValue);
+
+    bcos::bytes newCode{0xfe, 0xed};
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    bcos::h256 newCodeHash;
+    bcos::crypto::hasher::hash(hasher, bcos::ref(newCode), newCodeHash);
+    bcos::task::syncWait(account.setCode(newCode, "the-abi", newCodeHash));
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(account.codeHash()), newCodeHash);
+    auto const overlayCode = bcos::task::syncWait(account.code());
+    BOOST_REQUIRE(overlayCode.has_value());
+    auto const overlayView = overlayCode->get();
+    BOOST_CHECK(bcos::bytes(overlayView.begin(), overlayView.end()) == newCode);
+    auto const overlayAbi = bcos::task::syncWait(account.abi());
+    BOOST_REQUIRE(overlayAbi.has_value());
+    BOOST_CHECK_EQUAL(overlayAbi->get(), "the-abi");
+
+    // create() on an absent account flips exists() without touching storage.
+    auto created = state.accountAt(makeAddress(0xcd));
+    bcos::task::syncWait(created.create());
+    BOOST_CHECK(bcos::task::syncWait(created.exists()));
+
+    // Storage untouched: same key counts, and the simulated code row never reached codeStorage.
+    BOOST_CHECK_EQUAL(storageKeyCount(state.nodeStorage), nodeKeysBefore);
+    BOOST_CHECK_EQUAL(storageKeyCount(state.codeStorage), codeKeysBefore);
+    BOOST_CHECK(
+        !bcos::task::syncWait(bcos::storage2::readOne(state.codeStorage,
+                                  bcos::executor_v1::StateKeyView{bcos::ledger::SYS_CODE_BINARY,
+                                      bcos::concepts::bytebuffer::toView(newCodeHash)}))
+            .has_value());
+
+    // A fresh MPTAccount over the same storages still reads the ORIGINAL committed state.
+    auto pristine = state.account();
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(pristine.balance()), 1000);
+    BOOST_CHECK_EQUAL(*bcos::task::syncWait(pristine.nonce()), "7");
+    BOOST_CHECK_EQUAL(bcos::task::syncWait(pristine.codeHash()), state.codeHash);
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(pristine.storage(toEvmc(state.slot1)))),
+        bcos::h256(state.val1));
+}
+
+// The DIRECT-tagged read and storageEntry stay consistent with storage(key), both against the
+// trie and against the overlay.
+BOOST_AUTO_TEST_CASE(DirectAndStorageEntryConsistent)
+{
+    SeededState state;
+    auto account = state.account();
+
+    // Trie-backed: all three read paths agree on the committed value.
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(
+                          account.storage(toEvmc(state.slot1), bcos::storage2::DIRECT))),
+        bcos::h256(state.val1));
+    auto entry =
+        bcos::task::syncWait(account.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)));
+    BOOST_REQUIRE(entry.has_value());
+    auto entryView = entry->get();
+    BOOST_REQUIRE_EQUAL(entryView.size(), bcos::h256::SIZE);
+    BOOST_CHECK_EQUAL(bcos::h256(bcos::bytesConstRef(
+                          reinterpret_cast<const bcos::byte*>(entryView.data()), entryView.size())),
+        bcos::h256(state.val1));
+
+    // Overlay-backed: after setStorage, all three see the overlay value.
+    bcos::h256 const newValue{0x99};
+    bcos::task::syncWait(account.setStorage(toEvmc(state.slot1), toEvmc(newValue)));
+    BOOST_CHECK_EQUAL(
+        fromEvmc(bcos::task::syncWait(account.storage(toEvmc(state.slot1)))), newValue);
+    BOOST_CHECK_EQUAL(fromEvmc(bcos::task::syncWait(
+                          account.storage(toEvmc(state.slot1), bcos::storage2::DIRECT))),
+        newValue);
+    auto overlayEntry =
+        bcos::task::syncWait(account.storageEntry(bcos::concepts::bytebuffer::toView(state.slot1)));
+    BOOST_REQUIRE(overlayEntry.has_value());
+    auto overlayEntryView = overlayEntry->get();
+    BOOST_REQUIRE_EQUAL(overlayEntryView.size(), bcos::h256::SIZE);
+    BOOST_CHECK_EQUAL(
+        bcos::h256(bcos::bytesConstRef(
+            reinterpret_cast<const bcos::byte*>(overlayEntryView.data()), overlayEntryView.size())),
+        newValue);
+
+    // A non-32-byte key cannot exist in a storage trie: absent by construction.
+    BOOST_CHECK(!bcos::task::syncWait(account.storageEntry("short-key")).has_value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/StorageValueCodecTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/StorageValueCodecTest.cpp
@@ -71,6 +71,43 @@ BOOST_AUTO_TEST_CASE(MalformedLeavesThrow)
     BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(list)), MPTDecodeError);
 }
 
+// Ethereum storage values are minimal big-endian byte strings of at most 32 bytes. Decoding
+// straight to u256 would accept both of these: fromBigEndian shifts an over-long payload's high
+// bytes out and hands back a plausible wrong value mod 2^256, and a leading zero decodes as if
+// it were canonical.
+BOOST_AUTO_TEST_CASE(NonCanonicalPayloadsThrow)
+{
+    // 33-byte payload, short-string form (0x80 + 33). Its first byte would be shifted out
+    // entirely. It must be 0xa1 and not 0xb8|33: the long-string form requires a payload of at
+    // least 56 bytes (RLPDecode.h:65-84), so 0xb8|33 is rejected by the header parser before the
+    // length check below ever runs.
+    bcos::bytes overlong{0xa1};
+    overlong.push_back(0xff);
+    overlong.insert(overlong.end(), 32, 0x11);
+    BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(overlong)), MPTDecodeError);
+
+    // The long-string form itself, canonically encoded: 0xb8 + length 56 + 56 bytes.
+    bcos::bytes longForm{0xb8, 56};
+    longForm.insert(longForm.end(), 56, 0x11);
+    BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(longForm)), MPTDecodeError);
+
+    // Exactly 32 bytes is the boundary and must still decode.
+    bcos::bytes maxWidth{0xa0};
+    maxWidth.insert(maxWidth.end(), 32, 0x11);
+    BOOST_CHECK_NO_THROW(decodeStorageValue(bcos::ref(maxWidth)));
+
+    // Leading zero: 0x82 0x00 0x01 encodes the same value as 0x01, non-minimally.
+    bcos::bytes const leadingZero{0x82, 0x00, 0x01};
+    BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(leadingZero)), MPTDecodeError);
+
+    // The encoder never produces either form, so nothing valid is rejected.
+    BOOST_CHECK_EQUAL(decodeStorageValue(bcos::ref(encodeStorageValue(
+                          bcos::h256(bcos::u256{"0x00ff00000000000000000000000000000000000000000000"
+                                                "0000000000000001"})
+                              .ref()))),
+        bcos::u256{"0x00ff000000000000000000000000000000000000000000000000000000000001"});
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace bcos::ledger::mpt::test

--- a/bcos-ledger/test/unittests/mpt/StorageValueCodecTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/StorageValueCodecTest.cpp
@@ -1,0 +1,76 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file StorageValueCodecTest.cpp
+ * @brief Round-trip and malformed-input tests for the storage-slot value codec (spec §5.3)
+ */
+
+#include <bcos-ledger/mpt/Errors.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(StorageValueCodecSuite)
+
+// encode then decode returns the original value, across the byte-length boundaries RLP treats
+// differently (single small byte, one byte >= 0x80, multi-byte, full 32 bytes).
+BOOST_AUTO_TEST_CASE(RoundTrip)
+{
+    for (auto const& value : {bcos::u256{1}, bcos::u256{0x7f}, bcos::u256{0x80}, bcos::u256{0x1234},
+             bcos::u256{0xdeadbeef},
+             bcos::u256{"0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"}})
+    {
+        auto const encoded = encodeStorageValue(bcos::h256(value).ref());
+        BOOST_REQUIRE(!encoded.empty());
+        BOOST_CHECK_EQUAL(decodeStorageValue(bcos::ref(encoded)), value);
+    }
+}
+
+// A zero value is not part of the storage trie: the encoder returns an empty buffer, which is
+// the caller's signal to delete the slot rather than write a leaf.
+BOOST_AUTO_TEST_CASE(ZeroEncodesToEmpty)
+{
+    BOOST_CHECK(encodeStorageValue(bcos::h256{}.ref()).empty());
+}
+
+// Malformed leaves are rejected, not silently truncated into a plausible value.
+BOOST_AUTO_TEST_CASE(MalformedLeavesThrow)
+{
+    // Truncated: a 4-byte string header with only 2 bytes of payload.
+    bcos::bytes const truncated{0x84, 0x01, 0x02};
+    BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(truncated)), MPTDecodeError);
+
+    // Empty input: no RLP item at all.
+    bcos::bytes const empty;
+    BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(empty)), MPTDecodeError);
+
+    // Trailing bytes after a well-formed value — a corrupted leaf that would otherwise decode
+    // to the first item and silently drop the rest.
+    auto trailing = encodeStorageValue(bcos::h256(bcos::u256{0x1234}).ref());
+    trailing.push_back(0x01);
+    BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(trailing)), MPTDecodeError);
+
+    // A list where a string is expected.
+    bcos::bytes const list{0xc2, 0x01, 0x02};
+    BOOST_CHECK_THROW(decodeStorageValue(bcos::ref(list)), MPTDecodeError);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test


### PR DESCRIPTION
### What this adds

`MPTAccount` (`bcos-ledger/bcos-ledger/mpt/MPTAccount.h`), an `EVMAccount` with an opt-in historical read path, per spec §5.13. It is the state source PR-43 will resolve historical `eth_call` / `eth_getBalance` / `eth_getStorageAt` / `eth_getCode` from. **There is no production caller yet** — `HostContext.h:100` still names `EVMAccount`, and that fact should scale every severity judgement here.

### Shape

The class publicly inherits `EVMAccount<Storage>`, and every read takes an optional state root that defaults to empty:

- **empty** — which is what the `Account` concept requires and what HostContext's no-argument calls produce — delegates to `Base::xxx()`. The behaviour is byte-for-byte EVMAccount: flat KV reads and writes, reads see this call's own writes, nonce advances, CREATE derives distinct addresses.
- **a value** makes that one read a point query at that root: the account leaf 4-tuple through `MPTReadView::readAccount`, storage slots through the leaf's `storageRoot` along `slotKeyHash(key)`, code through the leaf's `codeHash`. Nothing is ever written; the MPT is only read.

`abi()` and `increaseNonce()` are inherited outright. An abi cannot change under a fixed codeHash, and `increaseNonce()` is a write helper over the flat nonce. `path()` and `address()` are inherited too, so table naming and the auth-table prefix are unchanged.

Absence at a root is Ethereum semantics rather than an error: an account with no leaf reads as `exists() == false` / balance 0 / nonce nullopt / zero codeHash, and a slot with no leaf reads as zero. That is exact for scenario B, where the trie is the complete state. Scenario-A cold data makes exclusion ambiguous, so gating historical queries to scenario B is the caller's job (PR-43, per OQ6 (c)+(a)).

### Why not a root frozen at construction

The first two revisions of this PR fixed the root in the constructor and made every read pure MPT while the inherited writes landed in flat storage. Review proved that breaks EVM semantics inside a single call, and the proof holds: `HostContext::get`/`set` (`HostContext.h:283/288`) forward straight to the account with nothing in between, so SSTORE followed by SLOAD returned the historical value; a transfer that debits and credits the same balance read the pre-call figure twice; and `nonce()` stayed pinned, so `externalCall` (`HostContext.h:604-617`) derived the same contract address for every CREATE in one call. Taking the root per read removes the whole class of problem, because the default path is not a historical path at all.

### Why not flat-first with a trie fallback

The alternative suggested in review — read the flat row first, fall back to the trie on a miss — is silently wrong on a normal storage stack. `BaselineScheduler.h:737-738` builds the call's view with `fork()` then `newMutable()`: a fresh writable layer over layers that read through to the **latest** state. So a flat-first read is not "what this call wrote", it is today's value, and any slot touched in a later block would shadow the historical one with no error anywhere. That shape is only correct when the caller happens to have built a stack whose lower layers are empty, and the account object has no way to check that it was handed one.

Composing "historical base state" with "reads see this call's writes" therefore belongs in the storage stack (PR-43): a writable `MutableStorage` over a read-through layer that resolves misses through the rooted reads here. The layering is then explicit and testable, instead of being an unverifiable assumption inside the account type.

### code() resolution

Exactly as Ethereum resolves it: an absent account or a leaf committing `keccak256("")` has no code, otherwise the code is whatever the one content-addressed store holds under that hash, and a miss throws `MPTInvariantViolation` rather than reading as an EOA — returning nullopt would answer calls to a contract with success and empty output, a wrong result indistinguishable from a right one, and geth likewise fails block processing rather than degrading.

**A rooted read answers from the MPT and from nothing else.** Earlier revisions of this PR grew a fallback to the account table's CODE field, which meant answering a question about block N out of today's flat tables. That fallback is gone. FISCO has four shapes that can hold a contract's code — modern (`EVMAccount.h:65-88`, hash-addressed), old-logic deploy (`HostContext.cpp:483-495`, blockVersion < 3.1), internal create with `bugfix_internal_create_redundant_storage` off (`TransactionExecutive.cpp:963-967`, which writes CODE and *no* CODE_HASH, so `FlatToMPT` commits emptyCodeHash for an account that does have code), and selfdestruct (`BlockContext.cpp:223-231`). Only the first is producible at blockVersion 3.18.0, and a future fork that changes code storage again gets its own feature flag.

`MPTInvariantViolation` and `MPTDecodeError` must be caught at the RPC boundary by PR-43. PR-43 also owns the scenario gate: a chain that enables MPT mid-flight can hold the pre-3.18 shapes, and historical queries there must be refused rather than answered from the trie alone.

### exists() and abi()

`exists()` means different things on the two paths, and the rooted one is the Ethereum meaning: leaf presence, exactly as an Ethereum client answers "does this account exist". The inherited flat `exists()` (`EVMAccount.h:27-31`) tests for a SYS_TABLES row, a BCOS notion with no Ethereum counterpart, and the two disagree for an account that never produced a leaf. Ethereum agrees with the historical answer. `abi()` is BCOS metadata outside the committed 4-tuple and has no rooted form at all, so a historical snapshot pairs block-N code with the current abi. Both are documented and pinned by tests rather than changed.

### Storage values are canonical or rejected

`decodeStorageValue` decodes to a byte string first and rejects payloads over 32 bytes or with a leading zero byte. Feeding the payload straight to `fromBigEndian` (`DataConvertUtility.h:279-285`, a shift-accumulate loop over an unchecked fixed-width u256) let a 33-byte payload shift its high byte out and yield a plausible wrong slot value mod 2^256. `encodeStorageValue` emits minimal big-endian, so nothing valid is rejected.

### An overload trap worth knowing about

`storage(key, root)` needs a non-template overload for a bare `h256`. The base's variadic `storage(key, auto... tags)` is an *exact* match for one, while the `std::optional<h256>` overload needs a conversion, so without it a plain root silently resolves to the flat tag-forwarding read — a historical query returning today's value with no error. This was hit for real during development; a test now pins it, along with the `std::nullopt` mirror case.

The same failure exists one arity up, so `storage(key, root, TAG)` is now a **compile error**: both the plain and the optional root arities are deleted. Deleting either one alone leaves the other resolving to the inherited tag pack, where `readOneRaw` discards the extra argument — the root vanishes and the call reads today's value.

### Also in this PR

`decodeStorageValue()` moves next to `encodeStorageValue()` in `StorageValueCodec` — it was hand-written in a private static of an unrelated class, so an encoding change had to be mirrored by hand and `Proof.h` could not reuse it. Shared `toH256`/`toEvmcBytes32` land in `bcos-framework/ledger/Account.h`; layering forbids including bcos-executor from bcos-ledger, and the executor-private `fromEvmC` yields `u256` rather than `h256`.

`HistoricalStorageContext` and the `(storage, address, binaryAddress)` constructor are PR-43 reservations, documented as such. Swapping this class into `HostContext.h:100` does **not** by itself make a call historical, since HostContext passes no root.

`binaryAddress` is a required constructor parameter with no default: now that the no-root path is a real flat read, guessing it wrong computes the wrong table name on a `feature_raw_address` chain and reads nothing.

### Testing

`MPTAccountSuite` (12 cases) and `StorageValueCodecSuite` (4 cases), 112 assertions:

- `HistoricalReadsMatchSeededState` — the 4-tuple and both slots against an `MPTReadView` oracle, plus the plain-root and `std::nullopt` overload assertions.
- `DefaultReadsAreFlatWithReadYourWrites` — the answer to the review blocker: create → exists, setBalance → balance, setNonce → nonce → increaseNonce → nonce, setStorage → storage (including the tag overload HostContext uses), setCode → codeHash/code/abi.
- `BinaryAddressSelectsTheRawTable` — the raw-byte table name is what the inherited reads and writes use.
- `HistoricalReadsIgnoreFlatWrites` — after flat writes, rooted reads still return the committed values and the node storage gains no key.
- `AbsentAccountAndSlotReadZero`, `EOALeafHasNoCodeAndEmptyStorage` — Ethereum absence semantics, empty root and empty codeHash short circuits.
- `EmptyCodeHashLeafIsCodelessEvenWithFlatCodeBytes` — the scope decision made visible: a leaf committing emptyCodeHash reads as codeless even though the flat path serves bytes for the same address.
- `MissingCodeRowThrowsAndNeverFallsBackToFlat` — the invariant violation, with flat code deliberately present and deliberately not used.
- `ExistsMeansLeafPresenceHistoricallyAndTableRowFlatly`, `AbiIsNotHistoricised` — the two documented divergences.
- `StorageEntryHistoricalAndFlat`, `HostContextConstructionShape`.
- `NonCanonicalPayloadsThrow` — over-long (short-string and long-string forms), the 32-byte boundary, leading zero, and an encoder round-trip.
- `static_assert(Account<TestMPTAccount>)` pins the concept; `static_assert(!HistoricalStorageContext<FlatStorage>)` is the negative control; `CombinesRootAndTag` / `CombinesOptionalRootAndTag` pin the deleted overloads and `HasEveryStorageForm` pins that they swallow nothing legitimate.

```
./bcos-ledger/test/test-bcos-ledger --run_test='MPTAccountSuite,StorageValueCodecSuite'
  16 test cases, 112 assertions, all passed
./bcos-ledger/test/test-bcos-ledger
  *** No errors detected
```
