### PR TITLE
Change gasPrice/maxFeePerGas/maxPriorityFeePerGas return type to std::optional<u256>

### DIFF
--- a/bcos-framework/bcos-framework/protocol/Transaction.cpp
+++ b/bcos-framework/bcos-framework/protocol/Transaction.cpp
@@ -131,10 +131,10 @@ std::ostream& operator<<(std::ostream& stream, const Transaction& transaction)
            << "to=" << transaction.to() << ", "
            << "abi=" << transaction.abi() << ", "
            << "value=" << transaction.value() << ", "
-           << "gasPrice=" << transaction.gasPrice() << ", "
+           << "gasPrice=" << transaction.gasPrice().value_or(0) << ", "
            << "gasLimit=" << transaction.gasLimit() << ", "
-           << "maxFeePerGas=" << transaction.maxFeePerGas() << ", "
-           << "maxPriorityFeePerGas=" << transaction.maxPriorityFeePerGas() << ", "
+           << "maxFeePerGas=" << transaction.maxFeePerGas().value_or(0) << ", "
+           << "maxPriorityFeePerGas=" << transaction.maxPriorityFeePerGas().value_or(0) << ", "
            << "extension=" << toHex(transaction.extension()) << ", "
            << "extraData=" << transaction.extraData() << ", "
            << "sender=" <<
@@ -153,22 +153,10 @@ std::ostream& operator<<(std::ostream& stream, const Transaction& transaction)
 
 u256 effectiveGasPrice(Transaction const& tx)
 {
-    try
+    if (auto price = tx.gasPrice(); price.has_value() && *price > 0)
     {
-        if (const auto price = tx.gasPrice(); !price.empty())
-        {
-            if (auto value = u256(price); value > 0)
-            {
-                return value;
-            }
-        }
-        if (const auto mfg = tx.maxFeePerGas(); !mfg.empty())
-        {
-            return u256(mfg);
-        }
+        return *price;
     }
-    catch (...)
-    {}
-    return {0};
+    return tx.maxFeePerGas().value_or(0);
 }
 }  // namespace bcos::protocol

--- a/bcos-framework/bcos-framework/protocol/Transaction.h
+++ b/bcos-framework/bcos-framework/protocol/Transaction.h
@@ -107,10 +107,10 @@ public:
 
     // balance
     virtual u256 value() const = 0;
-    virtual std::string_view gasPrice() const = 0;
+    virtual std::optional<u256> gasPrice() const = 0;
     virtual int64_t gasLimit() const = 0;
-    virtual std::string_view maxFeePerGas() const = 0;
-    virtual std::string_view maxPriorityFeePerGas() const = 0;
+    virtual std::optional<u256> maxFeePerGas() const = 0;
+    virtual std::optional<u256> maxPriorityFeePerGas() const = 0;
 
     // v2
     virtual bcos::bytesConstRef extension() const = 0;

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -232,10 +232,11 @@ void bcos::rpc::toJsonResp(Json::Value& jResp, bcos::protocol::Transaction const
     if (transaction.version() >= int32_t(bcos::protocol::TransactionVersion::V1_VERSION))
     {
         jResp["value"] = toQuantity(transaction.value());
-        jResp["gasPrice"] = std::string(transaction.gasPrice());
+        // match tars hash: nullopt → "", otherwise hex quantity
+        jResp["gasPrice"] = transaction.gasPrice() ? toQuantity(*transaction.gasPrice()) : "";
         jResp["gasLimit"] = transaction.gasLimit();
-        jResp["maxFeePerGas"] = std::string(transaction.maxFeePerGas());
-        jResp["maxPriorityFeePerGas"] = std::string(transaction.maxPriorityFeePerGas());
+        jResp["maxFeePerGas"] = transaction.maxFeePerGas() ? toQuantity(*transaction.maxFeePerGas()) : "";
+        jResp["maxPriorityFeePerGas"] = transaction.maxPriorityFeePerGas() ? toQuantity(*transaction.maxPriorityFeePerGas()) : "";
     }
     if (transaction.version() >= (int32_t)bcos::protocol::TransactionVersion::V2_VERSION)
     {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -39,9 +39,7 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
     }
     result["gas"] = toQuantity(tx.gasLimit());
     auto gasPrice = tx.gasPrice();
-
-    // FIXME)): return will case coredump in executor
-    result["gasPrice"] = std::string(gasPrice.empty() ? "0x0" : gasPrice);
+    result["gasPrice"] = toQuantity(gasPrice.value_or(0));
     result["hash"] = tx.hash().hexPrefixed();
     result["input"] = toHexStringWithPrefix(tx.input());
 
@@ -51,9 +49,8 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
         // web3 tools do not compatible with too long hex
         result["nonce"] = "0x" + std::string(tx.nonce());
         result["value"] = toQuantity(tx.value());
-        result["maxPriorityFeePerGas"] =
-            std::string(tx.maxPriorityFeePerGas().empty() ? "0x0" : tx.maxPriorityFeePerGas());
-        result["maxFeePerGas"] = std::string(tx.maxFeePerGas().empty() ? "0x0" : tx.maxFeePerGas());
+        result["maxPriorityFeePerGas"] = toQuantity(tx.maxPriorityFeePerGas().value_or(0));
+        result["maxFeePerGas"] = toQuantity(tx.maxFeePerGas().value_or(0));
         result["chainId"] = "0x0";
     }
     else [[likely]]

--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -261,8 +261,8 @@ bcos::protocol::ExecutionMessage::UniquePtr BlockExecutive::buildMessage(
     message->setValue(toQuantity(tx->value()));
     message->setGasLimit(tx->gasLimit());
     message->setGasPrice(m_gasPrice);
-    message->setMaxFeePerGas(std::string(tx->maxFeePerGas()));
-    message->setMaxPriorityFeePerGas(std::string(tx->maxPriorityFeePerGas()));
+    message->setMaxFeePerGas(toQuantity(tx->maxFeePerGas().value_or(0)));
+    message->setMaxPriorityFeePerGas(toQuantity(tx->maxPriorityFeePerGas().value_or(0)));
     message->setEffectiveGasPrice(m_gasPrice);
 
     return message;

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
@@ -128,9 +128,13 @@ bcos::u256 bcostars::protocol::TransactionImpl::value() const
     return bcos::hex2u(m_inner()->data.value);
 }
 
-std::string_view bcostars::protocol::TransactionImpl::gasPrice() const
+std::optional<bcos::u256> bcostars::protocol::TransactionImpl::gasPrice() const
 {
-    return m_inner()->data.gasPrice;
+    if (m_inner()->data.gasPrice.empty())
+    {
+        return std::nullopt;
+    }
+    return bcos::hex2u(m_inner()->data.gasPrice);
 }
 
 int64_t bcostars::protocol::TransactionImpl::gasLimit() const
@@ -138,14 +142,22 @@ int64_t bcostars::protocol::TransactionImpl::gasLimit() const
     return m_inner()->data.gasLimit;
 }
 
-std::string_view bcostars::protocol::TransactionImpl::maxFeePerGas() const
+std::optional<bcos::u256> bcostars::protocol::TransactionImpl::maxFeePerGas() const
 {
-    return m_inner()->data.maxFeePerGas;
+    if (m_inner()->data.maxFeePerGas.empty())
+    {
+        return std::nullopt;
+    }
+    return bcos::hex2u(m_inner()->data.maxFeePerGas);
 }
 
-std::string_view bcostars::protocol::TransactionImpl::maxPriorityFeePerGas() const
+std::optional<bcos::u256> bcostars::protocol::TransactionImpl::maxPriorityFeePerGas() const
 {
-    return m_inner()->data.maxPriorityFeePerGas;
+    if (m_inner()->data.maxPriorityFeePerGas.empty())
+    {
+        return std::nullopt;
+    }
+    return bcos::hex2u(m_inner()->data.maxPriorityFeePerGas);
 }
 
 bcos::bytesConstRef bcostars::protocol::TransactionImpl::extension() const

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.h
@@ -69,10 +69,10 @@ public:
     std::string_view abi() const override;
 
     bcos::u256 value() const override;
-    std::string_view gasPrice() const override;
+    std::optional<bcos::u256> gasPrice() const override;
     int64_t gasLimit() const override;
-    std::string_view maxFeePerGas() const override;
-    std::string_view maxPriorityFeePerGas() const override;
+    std::optional<bcos::u256> maxFeePerGas() const override;
+    std::optional<bcos::u256> maxPriorityFeePerGas() const override;
     bcos::bytesConstRef extension() const override;
 
     bcos::bytesConstRef input() const override;


### PR DESCRIPTION
## 摘要

将 `Transaction` 接口层的 `gasPrice()`、`maxFeePerGas()`、`maxPriorityFeePerGas()` 返回值从 `std::string_view` 改为 `std::optional<u256>`，与之前 `value()` 的改造方向保持一致。

## 背景

原接口返回 `std::string_view` 指向 tars 内部的 hex 字符串，调用方需要手动 `u256(str)` 转换，且无法区分"字段不存在"（空串）与"字段值为 0"（`"0x0"`）。

## 方案

使用 `std::optional<u256>` 作为返回类型：

- **`nullopt`** — tars 字段为空，字段不存在
- **`u256(0)`** — tars 字段明确为 `"0x0"`
- **`u256(N)`** — 正常数值

无需新增任何虚函数，只改 3 个已有方法的返回类型。

## 改动文件（7 个）

| 文件 | 改动 |
|---|---|
| `Transaction.h` | 接口返回类型改为 `std::optional<u256>` |
| `TransactionImpl.h/.cpp` | 空串 → `nullopt`，有值 → `hex2u(tars_string)` |
| `Transaction.cpp` | `effectiveGasPrice` 用 `.has_value()` 简化；`operator<<` 用 `.value_or(0)` |
| `JsonRpcImpl_2_0.cpp` | FISCO RPC：`nullopt` → 输出 `""`（匹配 tars hash 原文），有值 → `toQuantity()` |
| `TransactionResponse.cpp` | Web3 RPC：`.value_or(0)` 保持旧行为（空值输出 `"0x0"`） |
| `BlockExecutive.cpp` | `.value_or(0)` 适配 ExecutionMessage 路径 |

## 测试

`ci_check_air.sh` 全部通过（non-SM / SM 国密 / baseline 三个阶段，含 `HashCalculatorTest`）。