### PR TITLE
fix(txpool): reject transaction with malformed 'to' at admission time (#5318)

### DIFF
--- a/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/storage/MemoryStorage.cpp
@@ -23,6 +23,7 @@
 #include "bcos-framework/protocol/Transaction.h"
 #include "bcos-protocol/TransactionSubmitResultImpl.h"
 #include "bcos-task/Wait.h"
+#include "bcos-txpool/txpool/validator/TxValidator.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/ITTAPI.h"
 #include <oneapi/tbb/blocked_range.h>
@@ -36,8 +37,8 @@
 #include <memory>
 #include <range/v3/algorithm/all_of.hpp>
 #include <range/v3/algorithm/remove_if.hpp>
-#include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/concat.hpp>
+#include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/transform.hpp>
 #include <variant>
@@ -137,7 +138,7 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
             // This lambda may outlive the Awaitable (e.g. stored in a Transaction callback),
             // so it must NOT capture 'this'.
             auto completeOnce = [state = m_state, handle](Error::Ptr error,
-                                     bcos::protocol::TransactionSubmitResult::Ptr result) mutable {
+                                    bcos::protocol::TransactionSubmitResult::Ptr result) mutable {
                 bool expected = false;
                 if (!state->m_resumed.compare_exchange_strong(
                         expected, true, std::memory_order_acq_rel, std::memory_order_acquire))
@@ -161,8 +162,8 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
 
             try
             {
-                auto result = m_self->verifyAndSubmitTransaction(
-                    m_transaction, completeOnce, true, true);
+                auto result =
+                    m_self->verifyAndSubmitTransaction(m_transaction, completeOnce, true, true);
 
                 if (result != TransactionStatus::None)
                 {
@@ -171,8 +172,7 @@ task::Task<protocol::TransactionSubmitResult::Ptr> MemoryStorage::submitTransact
                         << LOG_KV("TxHash", m_transaction ? m_transaction->hash().hex() : "")
                         << LOG_KV("result", result);
                     completeOnce(
-                        BCOS_ERROR_PTR((int32_t)result, bcos::protocol::toString(result)),
-                        nullptr);
+                        BCOS_ERROR_PTR((int32_t)result, bcos::protocol::toString(result)), nullptr);
                 }
             }
             catch (std::exception& e)
@@ -274,6 +274,19 @@ TransactionStatus MemoryStorage::txpoolStorageCheck(
 TransactionStatus MemoryStorage::enforceSubmitTransaction(Transaction::Ptr _tx)
 {
     auto txHash = _tx->hash();
+    // Issue #5318: transactions on this path come from another node's proposal and bypass
+    // validateTransaction(), so re-check `to` here — otherwise a proposal carrying a
+    // malformed `to` is imported, passes verification and deterministically fails
+    // execution, halting consensus. Rejecting it fails the proposal verification instead,
+    // and PBFT view-changes to a leader with a clean proposal.
+    if (!isValidToField(_tx->to()))
+    {
+        TXPOOL_LOG(WARNING) << LOG_DESC("enforce to seal failed for malformed to field")
+                            << LOG_KV("to", _tx->to()) << LOG_KV("importTxHash", txHash.abridged())
+                            << LOG_KV("importBatchId", _tx->batchId())
+                            << LOG_KV("importBatchHash", _tx->batchHash().abridged());
+        return TransactionStatus::Malformed;
+    }
     // the transaction has already onChain, reject it
     // check ledger tx
     // check web3 tx

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -36,14 +36,12 @@ using namespace bcos;
 using namespace bcos::protocol;
 using namespace bcos::txpool;
 
-namespace
+bool bcos::txpool::isValidToField(std::string_view toField)
 {
-// Issue #5318: `to` must be empty (deployment) or a 20-byte hex address with an optional
-// 0x/0X prefix. Anything else used to pass admission, get packed into a block and
-// deterministically fail execution (BASELINE_SCHEDULER throws while hex-decoding `to`),
-// which PBFT re-proposes forever — halting the whole chain.
-bool isValidToAddress(std::string_view toField)
-{
+    if (toField.empty() || g_BCOSConfig.isWasm())
+    {
+        return true;
+    }
     if (toField.starts_with("0x") || toField.starts_with("0X"))
     {
         toField.remove_prefix(2);
@@ -53,7 +51,6 @@ bool isValidToAddress(std::string_view toField)
            std::ranges::all_of(
                toField, [](unsigned char character) { return std::isxdigit(character) != 0; });
 }
-}  // namespace
 
 TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
 {
@@ -164,8 +161,7 @@ bcos::protocol::TransactionStatus TxValidator::checkWeb3Nonce(
 TransactionStatus TxValidator::validateTransaction(const bcos::protocol::Transaction& _tx)
 {
     // Issue #5318: reject a malformed `to` at admission time so it can never reach a block.
-    // WASM chains are exempt: their `to` is a BFS path (e.g. /apps/HelloWorld), not an address.
-    if (!_tx.to().empty() && !g_BCOSConfig.isWasm() && !isValidToAddress(_tx.to()))
+    if (!isValidToField(_tx.to()))
     {
         TX_VALIDATOR_CHECKER_LOG(WARNING)
             << LOG_BADGE("ValidateTransaction") << LOG_DESC("RejectTransactionWithInvalidTo")

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -22,6 +22,7 @@
 #include "bcos-framework/bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-framework/txpool/Constant.h"
 #include "bcos-ledger/LedgerMethods.h"
@@ -29,10 +30,30 @@
 #include "bcos-utilities/DataConvertUtility.h"
 
 #include <bcos-rpc/jsonrpc/Common.h>
+#include <cctype>
 
 using namespace bcos;
 using namespace bcos::protocol;
 using namespace bcos::txpool;
+
+namespace
+{
+// Issue #5318: `to` must be empty (deployment) or a 20-byte hex address with an optional
+// 0x/0X prefix. Anything else used to pass admission, get packed into a block and
+// deterministically fail execution (BASELINE_SCHEDULER throws while hex-decoding `to`),
+// which PBFT re-proposes forever — halting the whole chain.
+bool isValidToAddress(std::string_view toField)
+{
+    if (toField.starts_with("0x") || toField.starts_with("0X"))
+    {
+        toField.remove_prefix(2);
+    }
+    constexpr size_t addressHexLength = 40;
+    return toField.size() == addressHexLength &&
+           std::ranges::all_of(
+               toField, [](unsigned char character) { return std::isxdigit(character) != 0; });
+}
+}  // namespace
 
 TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
 {
@@ -142,6 +163,15 @@ bcos::protocol::TransactionStatus TxValidator::checkWeb3Nonce(
 
 TransactionStatus TxValidator::validateTransaction(const bcos::protocol::Transaction& _tx)
 {
+    // Issue #5318: reject a malformed `to` at admission time so it can never reach a block.
+    // WASM chains are exempt: their `to` is a BFS path (e.g. /apps/HelloWorld), not an address.
+    if (!_tx.to().empty() && !g_BCOSConfig.isWasm() && !isValidToAddress(_tx.to()))
+    {
+        TX_VALIDATOR_CHECKER_LOG(WARNING)
+            << LOG_BADGE("ValidateTransaction") << LOG_DESC("RejectTransactionWithInvalidTo")
+            << LOG_KV("to", _tx.to()) << LOG_KV("hash", _tx.hash().abridged());
+        return TransactionStatus::Malformed;
+    }
     if (_tx.value().length() > TRANSACTION_VALUE_MAX_LENGTH)
     {
         return TransactionStatus::OverFlowValue;

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
@@ -32,6 +32,12 @@
 
 namespace bcos::txpool
 {
+// Issue #5318: a valid `to` is empty (deployment) or a 20-byte hex address with an optional
+// 0x/0X prefix; WASM chains are exempt because their `to` carries a BFS path. Anything else
+// used to get packed into a block and deterministically fail execution (BASELINE_SCHEDULER
+// throws while hex-decoding `to`), which PBFT re-proposes forever — halting the whole chain.
+bool isValidToField(std::string_view toField);
+
 class TxValidator : public TxValidatorInterface
 {
 public:

--- a/bcos-txpool/test/unittests/txpool/Issue5318InvalidToTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Issue5318InvalidToTest.cpp
@@ -23,6 +23,10 @@
 #include "bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-protocol/TransactionStatus.h"
 #include "bcos-txpool/txpool/validator/TxValidator.h"
+#include "test/unittests/txpool/TxPoolFixture.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
@@ -97,6 +101,41 @@ BOOST_AUTO_TEST_CASE(acceptValidTo)
     // web3 transaction with prefixed address
     BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("0x" + std::string(40, 'b'),
                     protocol::TransactionType::Web3Transaction)) == TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(enforceImportRejectsInvalidTo)
+{
+    // proposal verification path: a transaction missing from the local pool is imported
+    // via MemoryStorage::enforceSubmitTransaction, which bypasses validateTransaction() —
+    // a malicious/unfixed leader could otherwise smuggle a malformed `to` into a block
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    bcos::crypto::KeyPairInterface::Ptr keyPair = signatureImpl->generateKeyPair();
+    auto fakeGateWay = std::make_shared<FakeGateWay>();
+    auto faker = std::make_shared<TxPoolFixture>(keyPair->publicKey(), cryptoSuite,
+        "group_test_for_txpool", "chain_test_for_txpool", 10, fakeGateWay, false, false);
+    faker->init();
+    auto txpoolStorage = faker->txpool()->txpoolStorage();
+
+    // build transactions that pass the ledger nonce / blockLimit checks of the enforce
+    // path, so a rejection can only come from the `to` validation under test
+    auto blockLimit = faker->ledger()->blockNumber() + 5;
+    auto makeEnforceTx = [&](std::string_view toField, const std::string& nonce) {
+        return fakeTransaction(cryptoSuite, keyPair, toField, asBytes("issue5318"), nonce,
+            blockLimit, "chain_test_for_txpool", "group_test_for_txpool");
+    };
+
+    // positive control: a valid `to` is imported through the same path
+    auto validTxs = std::make_shared<protocol::Transactions>();
+    validTxs->emplace_back(makeEnforceTx(std::string(40, 'a'), "10086100861"));
+    BOOST_CHECK(txpoolStorage->batchVerifyAndSubmitTransaction(nullptr, validTxs));
+
+    auto poisonTxs = std::make_shared<protocol::Transactions>();
+    poisonTxs->emplace_back(makeEnforceTx("HelloWorld", "10086100862"));
+    BOOST_CHECK(!txpoolStorage->batchVerifyAndSubmitTransaction(nullptr, poisonTxs));
+
+    txpoolStorage->clear();
 }
 
 BOOST_AUTO_TEST_CASE(wasmChainSkipsAddressCheck)

--- a/bcos-txpool/test/unittests/txpool/Issue5318InvalidToTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/Issue5318InvalidToTest.cpp
@@ -1,0 +1,116 @@
+/**
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief regression test for issue #5318: a transaction with a non-hex `to` must be
+ *        rejected at txpool admission time, instead of being packed into a block and
+ *        deterministically failing execution (which PBFT re-proposes forever,
+ *        halting consensus)
+ * @file Issue5318InvalidToTest.cpp
+ */
+#include "bcos-framework/bcos-framework/testutils/faker/FakeTransaction.h"
+#include "bcos-framework/protocol/GlobalConfig.h"
+#include "bcos-protocol/TransactionStatus.h"
+#include "bcos-txpool/txpool/validator/TxValidator.h"
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::txpool;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+protocol::Transaction::Ptr makeTxWithTo(std::string toField,
+    protocol::TransactionType type = protocol::TransactionType::BCOSTransaction)
+{
+    auto tx = fakeInvalidateTransacton("issue5318", 0);
+    auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+    txImpl->mutableInner().data.to = std::move(toField);
+    txImpl->mutableInner().type = static_cast<tars::Char>(type);
+    return tx;
+}
+
+TxValidator::Ptr makeValidator()
+{
+    return std::make_shared<TxValidator>(nullptr, nullptr, nullptr, "group0", "chain0");
+}
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(Issue5318InvalidToTest, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(rejectNonHexTo)
+{
+    auto validator = makeValidator();
+
+    // the exact repro of issue #5318: java-sdk copied a BFS `path` argument verbatim
+    // into `to` on a Solidity chain
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("HelloWorld")) ==
+                TransactionStatus::Malformed);
+    // correct length (40) but non-hex characters — would throw inside
+    // boost::algorithm::unhex during execution
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo(std::string(40, 'z'))) ==
+                TransactionStatus::Malformed);
+    // hex but wrong length
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo(std::string(39, 'a'))) ==
+                TransactionStatus::Malformed);
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo(std::string(41, 'a'))) ==
+                TransactionStatus::Malformed);
+    // 0x prefix alone is not a deployment marker (deployment uses an empty `to`)
+    BOOST_CHECK(
+        validator->validateTransaction(*makeTxWithTo("0x")) == TransactionStatus::Malformed);
+    // valid hex address hidden behind an invalid prefix
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("xx" + std::string(40, 'a'))) ==
+                TransactionStatus::Malformed);
+}
+
+BOOST_AUTO_TEST_CASE(acceptValidTo)
+{
+    auto validator = makeValidator();
+
+    // deployment: empty `to`
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("")) == TransactionStatus::None);
+    // unprefixed 20-byte hex address (BCOS SDK form)
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo(std::string(40, 'a'))) ==
+                TransactionStatus::None);
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo(
+                    "0123456789abcdefABCDEF0123456789abcdefAB")) == TransactionStatus::None);
+    // 0x-prefixed (Web3Transaction::takeToTarsTransaction writes hexPrefixed())
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("0x" + std::string(40, 'a'))) ==
+                TransactionStatus::None);
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("0X" + std::string(40, 'A'))) ==
+                TransactionStatus::None);
+    // web3 transaction with prefixed address
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("0x" + std::string(40, 'b'),
+                    protocol::TransactionType::Web3Transaction)) == TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(wasmChainSkipsAddressCheck)
+{
+    auto validator = makeValidator();
+
+    // on a WASM chain `to` is a BFS path, not a hex address — the check must not apply
+    g_BCOSConfig.setIsWasm(true);
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("/apps/HelloWorld")) ==
+                TransactionStatus::None);
+    g_BCOSConfig.setIsWasm(false);
+    BOOST_CHECK(validator->validateTransaction(*makeTxWithTo("/apps/HelloWorld")) ==
+                TransactionStatus::Malformed);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test


### PR DESCRIPTION
**Motivation**

Fixes #5318. A single transaction whose `to` field is not a valid hex address permanently halts consensus on v3.16.x: it passes txpool verification, gets packed into a block, then `BASELINE_SCHEDULER` throws inside `boost::algorithm::unhex` while decoding `to` (`unhexAddress`, called from `newEVMCMessage`). The scheduler maps the exception to `SchedulerError::UnknownError`, and PBFT treats the deterministic failure as transient, re-proposing the same block forever. Block height stops advancing on every node and the chain never recovers.

**Solution**

Validate the `to` field at txpool admission time: it must be empty (deployment) or a 20-byte hex address with an optional `0x`/`0X` prefix (`isValidToField()`). The check is enforced on both paths a transaction can enter the pool through:

1. `TxValidator::validateTransaction()` — client submission via RPC and p2p tx sync is rejected with `TransactionStatus::Malformed`, so a malformed `to` can never be sealed by an honest node.
2. `MemoryStorage::enforceSubmitTransaction()` — transactions missing from the local pool during proposal verification are imported through this path, which bypasses `validateTransaction()`. Re-checking here makes a proposal that carries a malformed `to` (from a malicious or unfixed leader) fail verification, so PBFT view-changes to a leader with a clean proposal instead of executing the poisoned block.

WASM chains are exempt (`g_BCOSConfig.isWasm()`) because their `to` carries a BFS path (e.g. `/apps/HelloWorld`) instead of an address. Web3 transactions are unaffected: their `to` is always written as `hexPrefixed()` of a 20-byte RLP address. Admission-level rejection changes no execution semantics for any transaction already accepted on-chain, so there is no hardfork risk.

Regression test `Issue5318InvalidToTest.cpp` covers the original repro (`"HelloWorld"` as `to`), 40-char non-hex, wrong lengths, prefix edge cases, valid address forms, the web3 type, the WASM exemption, and the enforce-import path (positive control: a valid transaction imports through the same path; poison transaction is rejected).