### PR TITLE
fix(gateway): isolate session teardown to stop FIB-186 bulk-disconnect consensus halt (vector D)

### DIFF
--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -788,17 +788,35 @@ std::shared_ptr<Gateway> GatewayFactory::buildGateway(GatewayConfig::Ptr _config
         auto gatewayNodeManagerWeakPtr = std::weak_ptr<GatewayNodeManager>(gatewayNodeManager);
         // register disconnect handler
         service->registerDisconnectHandler(
-            [gatewayNodeManagerWeakPtr](NetworkException e, P2PSession::Ptr p2pSession) {
+            [gatewayNodeManagerWeakPtr, serviceWeakPtr = std::weak_ptr<Service>(service)](
+                NetworkException e, P2PSession::Ptr p2pSession) {
                 if (e.errorCode() == P2PExceptionType::DuplicateSession ||
                     e.errorCode() == P2PExceptionType::Success)
                 {
                     return;
                 }
                 auto gatewayNodeManager = gatewayNodeManagerWeakPtr.lock();
-                if (gatewayNodeManager && p2pSession)
+                if (!gatewayNodeManager || !p2pSession)
                 {
-                    gatewayNodeManager->onRemoveNodeIDs(p2pSession->p2pID());
+                    return;
                 }
+                // FIB-186 (vector D): the teardown notification that drives this handler can be
+                // delayed on the dedicated teardown executor while the SAME peer reconnects -- a
+                // new session for the same p2pID is inserted and its status re-populates the
+                // routing table. removeP2PID keys only on p2pID, so a stale teardown would erase
+                // the new session's routing entries and blank the unicast route until the next
+                // status broadcast. Only remove when this dropped session is still the session of
+                // record for its p2pID (or none is): if a different, current session already owns
+                // the p2pID the peer has reconnected and its entries must be kept.
+                if (auto service = serviceWeakPtr.lock())
+                {
+                    auto current = service->getP2PSessionByNodeId(p2pSession->p2pID());
+                    if (current && current != p2pSession)
+                    {
+                        return;
+                    }
+                }
+                gatewayNodeManager->onRemoveNodeIDs(p2pSession->p2pID());
             });
 
         service->registerUnreachableHandler(

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -99,7 +99,21 @@ GatewayNodeManager::GatewayNodeManager(std::string const& _uuid, P2pID const& _n
     m_timer->registerTimeoutHandler([this]() {
         if (m_nodeIDListDirty.exchange(false, std::memory_order_acq_rel))
         {
-            syncLatestNodeIDList();
+            // FIB-186 (vector D): syncLatestNodeIDList runs on the timer thread, before
+            // broadcastStatusSeq() re-arms the timer (m_timer->restart() is its first line).
+            // Timer's async_wait handler only logs a throwing timeout handler and does NOT
+            // reschedule, so an exception escaping here would leave the timer un-rearmed and the
+            // seqSync timer would die permanently (all status-seq broadcasts and node-list syncs
+            // would stop). Contain it so broadcastStatusSeq() always runs and re-arms the timer.
+            try
+            {
+                syncLatestNodeIDList();
+            }
+            catch (std::exception const& e)
+            {
+                NODE_MANAGER_LOG(WARNING)
+                    << LOG_DESC("syncLatestNodeIDList exception") << LOG_KV("error", e.what());
+            }
         }
         broadcastStatusSeq();
     });
@@ -320,11 +334,28 @@ void GatewayNodeManager::onRemoveNodeIDs(const P2pID& _p2pID)
         m_p2pID2Seq.erase(_p2pID);
     }
     m_peersRouterTable->removeP2PID(_p2pID);
-    // FIB-186 (vector D): mark the node list dirty instead of syncing inline. A persistent
-    // bulk-disconnect would otherwise drive one full syncLatestNodeIDList (a node-list broadcast to
-    // every front) per dropped session on the teardown executor; the seqSync timer coalesces the
-    // burst into at most one sync per SEQ_SYNC_PERIOD.
-    m_nodeIDListDirty.store(true, std::memory_order_relaxed);
+    // FIB-186 (vector D): notify the local front promptly without re-introducing the per-disconnect
+    // sync flood. removeP2PID above updates the gateway's own routing table immediately; the
+    // front's cached node-list is refreshed by syncLatestNodeIDList. Sync inline only on the first
+    // drop of a burst (the clean->dirty transition); further drops within the window leave the flag
+    // dirty and are coalesced by the seqSync timer (at most one inline sync per SEQ_SYNC_PERIOD, so
+    // a persistent bulk-disconnect cannot flood the front). Without the inline sync the front would
+    // keep a stale node-list for up to a full period, issuing messages to the departed node that
+    // the gateway then drops. This runs on the teardown executor inside Service::onMessage's
+    // try/catch, but wrap it so a throw cannot skip the rest of onDisconnect (other disconnect
+    // handlers, session erase).
+    if (!m_nodeIDListDirty.exchange(true, std::memory_order_acq_rel))
+    {
+        try
+        {
+            syncLatestNodeIDList();
+        }
+        catch (std::exception const& e)
+        {
+            NODE_MANAGER_LOG(WARNING)
+                << LOG_DESC("onRemoveNodeIDs inline sync exception") << LOG_KV("error", e.what());
+        }
+    }
 }
 
 

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -94,8 +94,15 @@ GatewayNodeManager::GatewayNodeManager(std::string const& _uuid, P2pID const& _n
         boost::bind(&GatewayNodeManager::onReceiveNodeStatus, this, boost::placeholders::_1,
             boost::placeholders::_2, boost::placeholders::_3));
     m_timer = std::make_shared<Timer>(SEQ_SYNC_PERIOD, "seqSync");
-    // broadcast seq periodically
-    m_timer->registerTimeoutHandler([this]() { broadcastStatusSeq(); });
+    // broadcast seq periodically; also flush a coalesced node-list sync if peers dropped since the
+    // last tick (FIB-186 vector D: one sync per period instead of one per dropped session)
+    m_timer->registerTimeoutHandler([this]() {
+        if (m_nodeIDListDirty.exchange(false, std::memory_order_acq_rel))
+        {
+            syncLatestNodeIDList();
+        }
+        broadcastStatusSeq();
+    });
 }
 
 void GatewayNodeManager::stop()
@@ -313,8 +320,11 @@ void GatewayNodeManager::onRemoveNodeIDs(const P2pID& _p2pID)
         m_p2pID2Seq.erase(_p2pID);
     }
     m_peersRouterTable->removeP2PID(_p2pID);
-    // notify nodeIDs to front service
-    syncLatestNodeIDList();
+    // FIB-186 (vector D): mark the node list dirty instead of syncing inline. A persistent
+    // bulk-disconnect would otherwise drive one full syncLatestNodeIDList (a node-list broadcast to
+    // every front) per dropped session on the teardown executor; the seqSync timer coalesces the
+    // burst into at most one sync per SEQ_SYNC_PERIOD.
+    m_nodeIDListDirty.store(true, std::memory_order_relaxed);
 }
 
 

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.h
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.h
@@ -97,10 +97,11 @@ protected:
 
     unsigned const SEQ_SYNC_PERIOD = 1000;
     std::shared_ptr<Timer> m_timer;
-    // FIB-186 (vector D): coalesce disconnect-driven node-list syncs. onRemoveNodeIDs sets this
-    // instead of calling syncLatestNodeIDList() inline; the seqSync timer flushes it at most once
-    // per SEQ_SYNC_PERIOD. Without this a persistent bulk-disconnect drives one full node-list
-    // broadcast to every front per dropped session, piling work onto the teardown executor.
+    // FIB-186 (vector D): coalesce disconnect-driven node-list syncs. onRemoveNodeIDs syncs inline
+    // only on the first drop of a burst (the clean->dirty transition) and otherwise sets this flag;
+    // the seqSync timer flushes it at most once per SEQ_SYNC_PERIOD. So the front is refreshed
+    // promptly on the first drop, while a persistent bulk-disconnect is bounded to ~one sync per
+    // period instead of one full node-list broadcast to every front per dropped session.
     std::atomic_bool m_nodeIDListDirty{false};
 
     GatewayNodeStatusFactory::Ptr m_gatewayNodeStatusFactory;

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.h
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.h
@@ -97,6 +97,11 @@ protected:
 
     unsigned const SEQ_SYNC_PERIOD = 1000;
     std::shared_ptr<Timer> m_timer;
+    // FIB-186 (vector D): coalesce disconnect-driven node-list syncs. onRemoveNodeIDs sets this
+    // instead of calling syncLatestNodeIDList() inline; the seqSync timer flushes it at most once
+    // per SEQ_SYNC_PERIOD. Without this a persistent bulk-disconnect drives one full node-list
+    // broadcast to every front per dropped session, piling work onto the teardown executor.
+    std::atomic_bool m_nodeIDListDirty{false};
 
     GatewayNodeStatusFactory::Ptr m_gatewayNodeStatusFactory;
 };

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
@@ -105,14 +105,15 @@ void PeersRouterTable::batchInsertNodeList(
         int64_t i = 0;
         for (auto const& nodeID : nodeIDList)
         {
-            if (!m_groupNodeList.count(groupID) || !m_groupNodeList.at(groupID).count(nodeID))
-            {
-                m_groupNodeList[groupID][nodeID] = std::set<P2pID>();
-            }
-            m_groupNodeList[groupID][nodeID].insert(_p2pNodeID);
+            // Capture the map iterators so the reverse index can alias the stable key strings owned
+            // by these nodes (try_emplace leaves an existing entry untouched, inserts otherwise).
+            auto groupIt = m_groupNodeList.try_emplace(groupID).first;
+            auto nodeIt = groupIt->second.try_emplace(nodeID).first;
+            nodeIt->second.insert(_p2pNodeID);
             // FIB-186 (vector D): mirror the insert into the reverse index so the matching removal
-            // is O(K) instead of a full-map scan. std::set dedups repeated (groupID, nodeID) pairs.
-            m_p2pID2GroupNodes[_p2pNodeID].emplace(groupID, nodeID);
+            // is O(K) instead of a full-map scan. Store pointers to the key strings (not copies);
+            // see the lifetime invariant on m_p2pID2GroupNodes. std::set dedups repeated pairs.
+            m_p2pID2GroupNodes[_p2pNodeID].emplace(&groupIt->first, &nodeIt->first);
             if (it->protocol(i))
             {
                 m_nodeProtocolInfo[nodeID] = it->protocol(i);
@@ -151,14 +152,14 @@ void PeersRouterTable::removeP2PIDFromGroupNodeList(const P2pID& _p2pID)
     {
         return;
     }
-    for (auto const& [groupID, nodeID] : revIt->second)
+    for (auto const& [groupIDPtr, nodeIDPtr] : revIt->second)
     {
-        auto groupIt = m_groupNodeList.find(groupID);
+        auto groupIt = m_groupNodeList.find(*groupIDPtr);
         if (groupIt == m_groupNodeList.end())
         {
             continue;
         }
-        auto nodeIt = groupIt->second.find(nodeID);
+        auto nodeIt = groupIt->second.find(*nodeIDPtr);
         if (nodeIt == groupIt->second.end())
         {
             continue;

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
@@ -110,6 +110,9 @@ void PeersRouterTable::batchInsertNodeList(
                 m_groupNodeList[groupID][nodeID] = std::set<P2pID>();
             }
             m_groupNodeList[groupID][nodeID].insert(_p2pNodeID);
+            // FIB-186 (vector D): mirror the insert into the reverse index so the matching removal
+            // is O(K) instead of a full-map scan. std::set dedups repeated (groupID, nodeID) pairs.
+            m_p2pID2GroupNodes[_p2pNodeID].emplace(groupID, nodeID);
             if (it->protocol(i))
             {
                 m_nodeProtocolInfo[nodeID] = it->protocol(i);
@@ -137,42 +140,40 @@ void PeersRouterTable::removeP2PID(const P2pID& _p2pID)
 void PeersRouterTable::removeP2PIDFromGroupNodeList(const P2pID& _p2pID)
 {
     WriteGuard l(x_groupNodeList);
-    // remove all nodeIDs info belong to p2pID
-    for (auto it = m_groupNodeList.begin(); it != m_groupNodeList.end();)
+    // FIB-186 (vector D): remove only the entries this p2pID actually holds, looked up via the
+    // reverse index, instead of scanning the whole forward map. This bounds the WriteLock hold time
+    // to O(K) (K = entries the peer holds), so a persistent bulk-disconnect on the teardown thread
+    // cannot stall queryP2pIDs (the ReadLock on the unicast routing hot path). Pruning of emptied
+    // node/group entries stays identical to the old full scan: only a set that contained _p2pID can
+    // shrink, so a set the peer never joined is never visited and never pruned.
+    auto revIt = m_p2pID2GroupNodes.find(_p2pID);
+    if (revIt == m_p2pID2GroupNodes.end())
     {
-        for (auto innerIt = it->second.begin(); innerIt != it->second.end();)
+        return;
+    }
+    for (auto const& [groupID, nodeID] : revIt->second)
+    {
+        auto groupIt = m_groupNodeList.find(groupID);
+        if (groupIt == m_groupNodeList.end())
         {
-            for (auto innerIt2 = innerIt->second.begin(); innerIt2 != innerIt->second.end();)
-            {
-                if (*innerIt2 == _p2pID)
-                {
-                    innerIt2 = innerIt->second.erase(innerIt2);
-                }
-                else
-                {
-                    ++innerIt2;
-                }
-            }
-
-            if (innerIt->second.empty())
-            {
-                innerIt = it->second.erase(innerIt);
-            }
-            else
-            {
-                ++innerIt;
-            }
+            continue;
         }
-
-        if (it->second.empty())
+        auto nodeIt = groupIt->second.find(nodeID);
+        if (nodeIt == groupIt->second.end())
         {
-            it = m_groupNodeList.erase(it);
+            continue;
         }
-        else
+        nodeIt->second.erase(_p2pID);
+        if (nodeIt->second.empty())
         {
-            ++it;
+            groupIt->second.erase(nodeIt);
+            if (groupIt->second.empty())
+            {
+                m_groupNodeList.erase(groupIt);
+            }
         }
     }
+    m_p2pID2GroupNodes.erase(revIt);
 }
 
 void PeersRouterTable::updatePeerNodeList(P2pID const& _p2pNodeID, GatewayNodeStatus::Ptr _status)

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
@@ -82,6 +82,15 @@ private:
     // groupID => NodeID => set<P2pID>
     std::map<std::string, std::map<std::string, std::set<P2pID>, std::less<>>, std::less<>>
         m_groupNodeList;
+    // FIB-186 (vector D): reverse index p2pID => the (groupID, nodeID) entries that p2pID appears
+    // under in m_groupNodeList. removeP2PIDFromGroupNodeList used to scan the whole forward map
+    // (O(groups x nodes x p2pIDs)) under x_groupNodeList's WriteLock; under a persistent
+    // bulk-disconnect the teardown thread reacquires that WriteLock once per dropped peer and
+    // blocks queryP2pIDs -- the ReadLock on the unicast routing hot path
+    // (Gateway::asyncSendMessageByNodeID). This index lets removal touch only the entries a peer
+    // actually holds, bounding the WriteLock hold time to O(K). Maintained under x_groupNodeList
+    // together with m_groupNodeList (same lock, so the two are always consistent).
+    std::map<P2pID, std::set<std::pair<std::string, std::string>>> m_p2pID2GroupNodes;
     std::map<std::string, bcos::protocol::ProtocolInfo::ConstPtr> m_nodeProtocolInfo;
     mutable SharedMutex x_groupNodeList;
 

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
@@ -90,7 +90,16 @@ private:
     // (Gateway::asyncSendMessageByNodeID). This index lets removal touch only the entries a peer
     // actually holds, bounding the WriteLock hold time to O(K). Maintained under x_groupNodeList
     // together with m_groupNodeList (same lock, so the two are always consistent).
-    std::map<P2pID, std::set<std::pair<std::string, std::string>>> m_p2pID2GroupNodes;
+    //
+    // Each entry stores POINTERS to the (groupID, nodeID) key strings owned by m_groupNodeList's
+    // nodes, not copies, to avoid duplicating every groupID/nodeID string.
+    // Lifetime invariant: std::map/std::set keep a node's key object at a stable address until that
+    // element is erased, and removeP2PIDFromGroupNodeList erases a (group)/(node) element only when
+    // its p2pID set empties -- i.e. when no peer (including this one) still references it -- so a
+    // pointer stored here always outlives the reverse entry holding it. This REQUIRES
+    // m_groupNodeList to remain a node-based container: do NOT switch it to a flat/vector-backed
+    // map whose keys move on insert/rehash, or these pointers dangle.
+    std::map<P2pID, std::set<std::pair<const std::string*, const std::string*>>> m_p2pID2GroupNodes;
     std::map<std::string, bcos::protocol::ProtocolInfo::ConstPtr> m_nodeProtocolInfo;
     mutable SharedMutex x_groupNodeList;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -20,6 +20,7 @@
 #include "bcos-gateway/libnetwork/Common.h"
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
+#include "bcos-utilities/ThreadPool.h"
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -800,6 +801,12 @@ void Host::stop()
         m_asioInterface->stop();
     }
     m_asyncGroup.wait();
+    // FIB-186 (vector D): drain the dedicated teardown executor after the network is down, so no
+    // teardown notification outlives the Host.
+    if (m_teardownPool)
+    {
+        m_teardownPool->stop();
+    }
 }
 bcos::gateway::Host::Host(bcos::crypto::Hash::Ptr _hash,
     std::shared_ptr<ASIOInterface> _asioInterface, std::shared_ptr<SessionFactory> _sessionFactory,
@@ -807,7 +814,17 @@ bcos::gateway::Host::Host(bcos::crypto::Hash::Ptr _hash,
   : m_hashImpl(std::move(_hash)),
     m_asioInterface(std::move(_asioInterface)),
     m_sessionFactory(std::move(_sessionFactory)),
-    m_messageFactory(std::move(_messageFactory)) {};
+    m_messageFactory(std::move(_messageFactory))
+{
+    // FIB-186 (vector D): a single dedicated thread for session-teardown notifications, off the
+    // shared m_asyncGroup that carries inbound-message delivery. See postTeardown / Host.h.
+    m_teardownPool = std::make_shared<ThreadPool>("p2pTeardown", 1);
+}
+
+void bcos::gateway::Host::postTeardown(std::function<void()> f)
+{
+    m_teardownPool->enqueue(std::move(f));
+}
 bcos::gateway::Host::~Host()
 {
     stop();

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -807,6 +807,10 @@ void Host::stop()
     {
         m_teardownPool->stop();
     }
+    // A teardown notification that was still running on the pool when it stopped could have posted
+    // follow-up work onto m_asyncGroup after the wait() above returned; drain m_asyncGroup once
+    // more so no such task outlives Host::stop(). wait() on an already-idle group is a cheap no-op.
+    m_asyncGroup.wait();
 }
 bcos::gateway::Host::Host(bcos::crypto::Hash::Ptr _hash,
     std::shared_ptr<ASIOInterface> _asioInterface, std::shared_ptr<SessionFactory> _sessionFactory,

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.h
@@ -106,6 +106,16 @@ public:
         m_asyncGroup.run(std::move(f));
     }
 
+    // FIB-186 (vector D): run a session-teardown notification on the dedicated teardown executor
+    // instead of m_asyncGroup. Teardown of established sessions (Service::onMessage's error path ->
+    // onDisconnect -> onRemoveNodeIDs -> syncLatestNodeIDList) and inbound P2P message delivery
+    // both ran on the shared m_asyncGroup, so a persistent bulk-disconnect flooded that reactor and
+    // starved inter-validator consensus-message delivery -- consensus halted and never recovered
+    // (CertiK FIB-186 vector D). Keeping teardown on its own single-threaded executor keeps it off
+    // the delivery reactor; the single thread also bounds teardown concurrency so a disconnect
+    // flood cannot itself swamp the node.
+    void postTeardown(std::function<void()> f);
+
     void setEnableSslVerify(bool _enableSSLVerify);
 
     // FIB-184: caps on concurrent inbound sessions to bound memory under TLS connect/close
@@ -241,6 +251,10 @@ protected:
 
     tbb::task_arena m_taskArena;
     tbb::task_group m_asyncGroup;
+    // FIB-186 (vector D): dedicated single-thread executor for session-teardown notifications, kept
+    // separate from m_asyncGroup so a bulk-disconnect flood cannot starve inbound-message delivery.
+    // See postTeardown.
+    std::shared_ptr<ThreadPool> m_teardownPool;
     std::shared_ptr<SessionCallbackManagerInterface> m_sessionCallbackManager;
 
     bcos::crypto::Hash::Ptr m_hashImpl;

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -369,23 +369,37 @@ void Session::drop(DisconnectReason _reason)
 
     if (m_messageHandler)
     {
-        // FIB-186 (vector D): post the teardown notification onto the dedicated teardown executor,
-        // NOT m_asyncGroup. This handler drives Service::onMessage's error path -> onDisconnect ->
+        // FIB-186 (vector D): run the teardown notification on the dedicated teardown executor, NOT
+        // m_asyncGroup. This handler drives Service::onMessage's error path -> onDisconnect ->
         // onRemoveNodeIDs -> syncLatestNodeIDList; running it on the shared m_asyncGroup let a
         // persistent bulk-disconnect flood starve inter-validator message delivery (which also runs
         // on m_asyncGroup) and permanently halt consensus. postTeardown keeps it off the delivery
         // reactor. Ordering vs message delivery is unchanged: onDisconnect already ran
         // asynchronously and unordered relative to delivery.
-        m_server.get().postTeardown(
-            [self = weak_from_this(), errorCode, errorMsg = std::move(errorMsg)]() {
-                auto session = self.lock();
-                if (!session)
-                {
-                    return;
-                }
-                session->m_messageHandler(
-                    NetworkException(errorCode, errorMsg), session, Message::Ptr());
-            });
+        auto notifyDisconnect = [self = weak_from_this(), errorCode,
+                                    errorMsg = std::move(errorMsg)]() {
+            auto session = self.lock();
+            if (!session)
+            {
+                return;
+            }
+            session->m_messageHandler(
+                NetworkException(errorCode, errorMsg), session, Message::Ptr());
+        };
+        // FIB-186 (vector D): on shutdown Host::stop() has already stopped the teardown executor
+        // (its io_context is stopped and the worker joined), so a postTeardown() here would enqueue
+        // onto a dead pool and the disconnect notification would be silently dropped. Run it inline
+        // instead, mirroring the socket-teardown path below which also switches to inline on
+        // shutdown. haveNetwork() (== Host::m_run) is cleared at the very start of Host::stop(),
+        // before the pool is stopped, so this branch is taken for every drop during shutdown.
+        if (m_server.get().haveNetwork())
+        {
+            m_server.get().postTeardown(std::move(notifyDisconnect));
+        }
+        else
+        {
+            notifyDisconnect();
+        }
     }
 
     // FIB-184: serialize the SSL/socket teardown onto the socket's own (single-threaded)

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -369,7 +369,14 @@ void Session::drop(DisconnectReason _reason)
 
     if (m_messageHandler)
     {
-        m_server.get().asyncTo(
+        // FIB-186 (vector D): post the teardown notification onto the dedicated teardown executor,
+        // NOT m_asyncGroup. This handler drives Service::onMessage's error path -> onDisconnect ->
+        // onRemoveNodeIDs -> syncLatestNodeIDList; running it on the shared m_asyncGroup let a
+        // persistent bulk-disconnect flood starve inter-validator message delivery (which also runs
+        // on m_asyncGroup) and permanently halt consensus. postTeardown keeps it off the delivery
+        // reactor. Ordering vs message delivery is unchanged: onDisconnect already ran
+        // asynchronously and unordered relative to delivery.
+        m_server.get().postTeardown(
             [self = weak_from_this(), errorCode, errorMsg = std::move(errorMsg)]() {
                 auto session = self.lock();
                 if (!session)

--- a/bcos-gateway/test/unittests/FIB186_BulkDisconnectReactorTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_BulkDisconnectReactorTest.cpp
@@ -1,0 +1,218 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Mechanism confirmation for FIB-186 vector D (persistent bulk-disconnect halts consensus,
+ *        never recovers). CertiK re-test of the merged admission-control fix (18f48cc7) found A/B
+ *        (connect-close churn) fixed but D still permanently halts consensus.
+ * @file FIB186_BulkDisconnectReactorTest.cpp
+ * @date 2026-07-14
+ *
+ * Root cause (from code): every inbound P2P message delivery is
+ *   Session::doRead -> Session::onMessage -> Host::asyncTo(...)   (Session.cpp: onMessage, ~L694)
+ * and every session teardown notification is
+ *   Session::drop -> Host::asyncTo(...)                           (Session.cpp: drop, ~L372)
+ * Host::asyncTo is `m_asyncGroup.run(...)` (Host.h) -- a single unbounded TBB task_group on the
+ * process-global pool. So message delivery and teardown share ONE reactor. A bulk-disconnect of a
+ * large established session pool floods that reactor with teardown work (each drop drives
+ * onDisconnect -> onRemoveNodeIDs -> syncLatestNodeIDList), so validator PBFT messages are read off
+ * the socket but their delivery task is starved behind teardown -- "validators miss each other's
+ * messages", the halt CertiK observed. The accept-side admission control cannot touch this: it
+ * gates NEW connections before the handshake, whereas D tears down ALREADY-established sessions.
+ *
+ * This is a RED (failing) test on the current merged code: it drives a real Session::drop() flood
+ * whose teardown work occupies the shared reactor, then submits a validator-delivery task through
+ * the same reactor and asserts it is NOT starved. It fails today (delivery cannot run while
+ * teardown occupies the reactor) and is the invariant a fix must satisfy: teardown must not be able
+ * to starve consensus-message delivery. Because it drives the real drop() path, a fix that moves
+ * teardown off m_asyncGroup (a dedicated executor) turns it green, while leaving delivery where it
+ * is; a fix that merely throttles teardown on the same reactor does not.
+ */
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
+#include "bcos-gateway/libnetwork/Host.h"
+#include "bcos-gateway/libnetwork/Session.h"
+#include "bcos-gateway/libnetwork/Socket.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <oneapi/tbb/global_control.h>
+#include <boost/asio/error.hpp>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+using namespace bcos::crypto;
+
+namespace ba = boost::asio;
+namespace bi = boost::asio::ip;
+
+BOOST_FIXTURE_TEST_SUITE(FIB186_BulkDisconnectReactorTest, TestPromptFixture)
+
+namespace
+{
+// Minimal ASIO fake: the teardown flood never runs a socket read, so no handler is needed.
+class FakeASIO_Reactor : public bcos::gateway::ASIOInterface
+{
+public:
+    ~FakeASIO_Reactor() noexcept override = default;
+    void asyncReadSome(
+        const std::shared_ptr<SocketFace>&, ba::mutable_buffer, ReadWriteHandler) override
+    {}
+    void strandPost(Base_Handler) override {}
+    void stop() override {}
+};
+
+// Host subclass that exposes the real Host::asyncTo (== m_asyncGroup.run) with the network marked
+// up, so Session::drop() takes the "post the teardown notification onto m_asyncGroup" path.
+class FakeHost_Reactor : public bcos::gateway::Host
+{
+public:
+    FakeHost_Reactor(bcos::crypto::Hash::Ptr hash, std::shared_ptr<ASIOInterface> asioInterface,
+        MessageFactory::Ptr messageFactory)
+      : Host(std::move(hash), std::move(asioInterface), nullptr, std::move(messageFactory))
+    {
+        m_run = true;
+    }
+};
+
+// Socket fake backed by a real SSL stream so drop()/closeSocket() can call sslref(); starts
+// disconnected so closeSocket() early-returns (this test exercises only the m_asyncGroup path).
+class FakeSocket_Reactor : public SocketFace
+{
+public:
+    FakeSocket_Reactor()
+      : m_ioContext(std::make_shared<ba::io_context>()),
+        m_sslContext(ba::ssl::context::tlsv12),
+        m_sslSocket(std::make_shared<ba::ssl::stream<bi::tcp::socket>>(*m_ioContext, m_sslContext))
+    {}
+    bool isConnected() const override { return m_connected; }
+    void close() override { m_connected = false; }
+    bi::tcp::endpoint remoteEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::endpoint localEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::socket& ref() override { return m_sslSocket->next_layer(); }
+    ba::ssl::stream<bi::tcp::socket>& sslref() override { return *m_sslSocket; }
+    const NodeIPEndpoint& nodeIPEndpoint() const override { return m_nodeIPEndpoint; }
+    void setNodeIPEndpoint(NodeIPEndpoint) override {}
+    ba::io_context& ioService() override { return *m_ioContext; }
+
+    bool m_connected{false};
+
+private:
+    std::shared_ptr<ba::io_context> m_ioContext;
+    ba::ssl::context m_sslContext;
+    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
+    NodeIPEndpoint m_nodeIPEndpoint;
+};
+
+// Shared state, held by shared_ptr so a task that outlives the test body never dangles.
+struct ReactorProbe
+{
+    std::atomic<int> teardownRunning{0};  // teardown tasks currently occupying a reactor worker
+    std::atomic<bool> release{false};     // gate that frees the occupying teardown tasks
+    std::atomic<bool> delivered{false};   // set when the validator-delivery task runs
+    std::atomic<int> done{0};             // total tasks completed (drain barrier)
+};
+}  // namespace
+
+// Vector D as a shared-reactor starvation: teardown of established sessions and PBFT message
+// delivery both run on Host::m_asyncGroup, so a teardown flood starves delivery.
+BOOST_AUTO_TEST_CASE(TeardownFloodMustNotStarveMessageDelivery)
+{
+    // Pin the shared TBB pool to a small, known width so "every reactor worker is occupied by
+    // teardown" is deterministic instead of depending on the host core count.
+    tbb::global_control gc(tbb::global_control::max_allowed_parallelism, 2);
+
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto messageFactory = std::make_shared<P2PMessageFactory>();
+    auto fakeAsio = std::make_shared<FakeASIO_Reactor>();
+    auto fakeHost = std::make_shared<FakeHost_Reactor>(hashImpl, fakeAsio, messageFactory);
+
+    auto probe = std::make_shared<ReactorProbe>();
+
+    // Each dropped session's teardown notification models the per-disconnect work a real
+    // bulk-disconnect produces (onDisconnect -> onRemoveNodeIDs -> syncLatestNodeIDList): it
+    // occupies a reactor worker until released. More sessions than possible workers guarantees
+    // every worker ends up in teardown.
+    constexpr int floodCount = 8;
+    std::vector<Session::Ptr> sessions;
+    sessions.reserve(floodCount);
+    for (int i = 0; i < floodCount; ++i)
+    {
+        auto socket = std::make_shared<FakeSocket_Reactor>();
+        auto session = std::make_shared<Session>(socket, *fakeHost, 1024, true);
+        session->setMessageFactory(messageFactory);
+        session->setMessageHandler([probe](NetworkException, SessionFace::Ptr, Message::Ptr) {
+            probe->teardownRunning.fetch_add(1);
+            while (!probe->release.load())
+            {  // hold the reactor worker, as a batch of real teardowns would
+            }
+            probe->done.fetch_add(1);
+        });
+        sessions.push_back(std::move(session));
+    }
+
+    // Bulk-disconnect: each drop() posts its teardown notification onto m_asyncGroup (Session.cpp
+    // drop, ~L372) -- the same reactor message delivery uses.
+    for (auto& session : sessions)
+    {
+        session->drop(DisconnectReason::TCPError);
+    }
+
+    // Wait until teardown occupies the reactor, then let any second worker also pick up a teardown
+    // task (there are more teardown tasks than workers), so no worker is left idle.
+    while (probe->teardownRunning.load() < 1)
+    {
+        std::this_thread::yield();
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // A validator PBFT message delivery goes through the same reactor (Session.cpp onMessage,
+    // ~L694). Submit it now, with teardown occupying the reactor.
+    fakeHost->asyncTo([probe]() {
+        probe->delivered.store(true);
+        probe->done.fetch_add(1);
+    });
+
+    // Grace window: a healthy node must deliver consensus messages far inside a PBFT round. If the
+    // reactor is shared, teardown holds every worker and delivery cannot run within the window.
+    for (int i = 0; i < 50 && !probe->delivered.load(); ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    bool deliveredDuringFlood = probe->delivered.load();
+
+    // Release the flood and drain every task so no lambda outlives this scope.
+    probe->release.store(true);
+    for (int i = 0; i < 5000 && probe->done.load() < floodCount + 1; ++i)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    BOOST_CHECK_MESSAGE(deliveredDuringFlood,
+        "FIB-186 vector D: a PBFT message delivery submitted during a session-teardown flood must "
+        "not be starved. It is today because Session::drop() and Session::onMessage() share the "
+        "unbounded m_asyncGroup reactor -- teardown occupies every worker and delivery never runs, "
+        "halting consensus. A fix must route teardown off the delivery reactor.");
+    BOOST_CHECK_EQUAL(probe->done.load(), floodCount + 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/PeersRouterTableReverseIndexTest.cpp
+++ b/bcos-gateway/test/unittests/PeersRouterTableReverseIndexTest.cpp
@@ -1,0 +1,145 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Equivalence test for the FIB-186 (vector D) reverse-index optimisation of
+ *        PeersRouterTable::removeP2PIDFromGroupNodeList. The removal was changed from an
+ *        O(groups x nodes x p2pIDs) scan of the whole forward map to an O(K) targeted removal
+ * driven by a reverse index (p2pID -> its (groupID, nodeID) entries), to shorten the
+ * x_groupNodeList WriteLock hold time so a bulk-disconnect flood on the teardown thread cannot
+ * stall queryP2pIDs on the routing hot path. This test pins that the targeted removal produces the
+ *        same observable routing table as the old full scan: the removed peer disappears from every
+ *        (group, node) it held, other peers are untouched, emptied node/group entries are pruned,
+ *        the reverse index is cleared so a re-insert + remove stays correct, and removing an
+ * unknown peer is a no-op.
+ * @file PeersRouterTableReverseIndexTest.cpp
+ * @date 2026-07-16
+ */
+
+#include "bcos-framework/protocol/ProtocolInfo.h"
+#include "bcos-gateway/gateway/PeersRouterTable.h"
+#include "bcos-gateway/protocol/GatewayNodeStatus.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::protocol;
+using namespace bcos::test;
+
+BOOST_FIXTURE_TEST_SUITE(PeersRouterTableReverseIndexTest, TestPromptFixture)
+
+namespace
+{
+// Promote the two protected mutators so the test can drive the forward map and its reverse index in
+// isolation, without the peer-status / gateway-info bookkeeping of the public updatePeerStatus.
+class ExposedPeersRouterTable : public PeersRouterTable
+{
+public:
+    ExposedPeersRouterTable() : PeersRouterTable("", nullptr, nullptr) {}
+    using PeersRouterTable::batchInsertNodeList;
+    using PeersRouterTable::removeP2PIDFromGroupNodeList;
+};
+
+GroupNodeInfo::Ptr makeGroupNodeInfo(std::string const& _group, std::vector<std::string> _nodes)
+{
+    auto info = std::make_shared<bcostars::protocol::GroupNodeInfoImpl>();
+    info->setGroupID(_group);
+    // batchInsertNodeList reads protocol(i) for each node index, so append one protocol per node.
+    for (std::size_t i = 0; i < _nodes.size(); ++i)
+    {
+        info->appendProtocol(std::make_shared<ProtocolInfo>(
+            ProtocolModuleID::NodeService, ProtocolVersion::V1, ProtocolVersion::V1));
+    }
+    info->setNodeIDList(std::move(_nodes));
+    return info;
+}
+
+std::set<P2pID> S(std::initializer_list<std::string> _l)
+{
+    return std::set<P2pID>(_l.begin(), _l.end());
+}
+}  // namespace
+
+// The removed peer disappears from every (group, node) it held; co-located peers are untouched; a
+// (group, node) whose only holder was the removed peer is pruned to empty.
+BOOST_AUTO_TEST_CASE(TargetedRemovalMatchesFullScan)
+{
+    ExposedPeersRouterTable table;
+
+    // p2pA holds group1{n1,n2}, group2{n3}
+    table.batchInsertNodeList(
+        "A", {makeGroupNodeInfo("group1", {"n1", "n2"}), makeGroupNodeInfo("group2", {"n3"})});
+    // p2pB holds group1{n1}, group2{n3,n4}
+    table.batchInsertNodeList(
+        "B", {makeGroupNodeInfo("group1", {"n1"}), makeGroupNodeInfo("group2", {"n3", "n4"})});
+    // p2pC holds group1{n2}
+    table.batchInsertNodeList("C", {makeGroupNodeInfo("group1", {"n2"})});
+    // p2pD is the sole holder of group3{n9} -- removing D must prune the node and the whole group.
+    table.batchInsertNodeList("D", {makeGroupNodeInfo("group3", {"n9"})});
+
+    // Pre-removal routing view.
+    BOOST_CHECK(table.queryP2pIDs("group1", "n1") == S({"A", "B"}));
+    BOOST_CHECK(table.queryP2pIDs("group1", "n2") == S({"A", "C"}));
+    BOOST_CHECK(table.queryP2pIDs("group2", "n3") == S({"A", "B"}));
+    BOOST_CHECK(table.queryP2pIDs("group2", "n4") == S({"B"}));
+    BOOST_CHECK(table.queryP2pIDsByGroupID("group3") == S({"D"}));
+
+    table.removeP2PIDFromGroupNodeList("A");
+
+    // A is gone from every entry it held; B and C are untouched; no entry A did not hold changed.
+    BOOST_CHECK(table.queryP2pIDs("group1", "n1") == S({"B"}));
+    BOOST_CHECK(table.queryP2pIDs("group1", "n2") == S({"C"}));
+    BOOST_CHECK(table.queryP2pIDs("group2", "n3") == S({"B"}));
+    BOOST_CHECK(table.queryP2pIDs("group2", "n4") == S({"B"}));
+
+    table.removeP2PIDFromGroupNodeList("D");
+
+    // D was the sole holder of group3{n9}: the node set empties and the group is pruned away.
+    BOOST_CHECK(table.queryP2pIDs("group3", "n9").empty());
+    BOOST_CHECK(table.queryP2pIDsByGroupID("group3").empty());
+}
+
+// The reverse index is cleared when a peer is removed, so a later re-insert (the remove-then-insert
+// shape of updatePeerStatus) and a second removal only affect the peer's new entries.
+BOOST_AUTO_TEST_CASE(ReverseIndexClearedOnRemovalAndIdempotent)
+{
+    ExposedPeersRouterTable table;
+
+    table.batchInsertNodeList("A", {makeGroupNodeInfo("group1", {"n1"})});
+    table.batchInsertNodeList("B", {makeGroupNodeInfo("group1", {"n1"})});
+    BOOST_CHECK(table.queryP2pIDs("group1", "n1") == S({"A", "B"}));
+
+    // Remove A, then re-insert it under a fresh (group1, n5) only.
+    table.removeP2PIDFromGroupNodeList("A");
+    BOOST_CHECK(table.queryP2pIDs("group1", "n1") == S({"B"}));
+    table.batchInsertNodeList("A", {makeGroupNodeInfo("group1", {"n5"})});
+    BOOST_CHECK(table.queryP2pIDs("group1", "n5") == S({"A"}));
+
+    // Second removal must clear only the new entry (proves the first removal cleared A's old
+    // reverse entries -- a stale (group1, n1) reverse entry would have wrongly evicted B here).
+    table.removeP2PIDFromGroupNodeList("A");
+    BOOST_CHECK(table.queryP2pIDs("group1", "n5").empty());
+    BOOST_CHECK(table.queryP2pIDs("group1", "n1") == S({"B"}));
+
+    // Removing a never-seen peer, and removing A a third time, are no-ops (no crash, B intact).
+    table.removeP2PIDFromGroupNodeList("A");
+    table.removeP2PIDFromGroupNodeList("unknown-p2p");
+    BOOST_CHECK(table.queryP2pIDs("group1", "n1") == S({"B"}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/PeersRouterTableReverseIndexTest.cpp
+++ b/bcos-gateway/test/unittests/PeersRouterTableReverseIndexTest.cpp
@@ -142,4 +142,39 @@ BOOST_AUTO_TEST_CASE(ReverseIndexClearedOnRemovalAndIdempotent)
     BOOST_CHECK(table.queryP2pIDs("group1", "n1") == S({"B"}));
 }
 
+// The reverse index aliases m_groupNodeList's key strings by pointer. A group/node fully erased and
+// later recreated must not corrupt routing: the recreated node owns fresh key objects, and no stale
+// reverse entry may reference the freed ones. (Without ASan this is a probabilistic stress of the
+// lifetime invariant, not a proof; the invariant itself is argued on m_p2pID2GroupNodes.)
+BOOST_AUTO_TEST_CASE(GroupErasedAndRecreatedKeepsRoutingCorrect)
+{
+    ExposedPeersRouterTable table;
+
+    // P is the sole holder of group9{n1,n2}; removing P erases both nodes and the whole group.
+    table.batchInsertNodeList("P", {makeGroupNodeInfo("group9", {"n1", "n2"})});
+    BOOST_CHECK(table.queryP2pIDs("group9", "n1") == S({"P"}));
+    table.removeP2PIDFromGroupNodeList("P");
+    BOOST_CHECK(table.queryP2pIDsByGroupID("group9").empty());
+
+    // Churn many unrelated groups so the allocator is likely to reuse the memory the erased group9
+    // key strings occupied.
+    for (int i = 0; i < 64; ++i)
+    {
+        table.batchInsertNodeList(
+            "X", {makeGroupNodeInfo("churn" + std::to_string(i), {"a", "b"})});
+    }
+
+    // Recreate group9 through a different peer Q; its keys are fresh objects at (possibly) reused
+    // addresses.
+    table.batchInsertNodeList("Q", {makeGroupNodeInfo("group9", {"n1"})});
+    BOOST_CHECK(table.queryP2pIDs("group9", "n1") == S({"Q"}));
+
+    // Removing X keys off X's own churn entries only; Q's recreated group9 entry is untouched.
+    table.removeP2PIDFromGroupNodeList("X");
+    BOOST_CHECK(table.queryP2pIDs("churn0", "a").empty());
+    BOOST_CHECK(table.queryP2pIDs("group9", "n1") == S({"Q"}));
+    table.removeP2PIDFromGroupNodeList("Q");
+    BOOST_CHECK(table.queryP2pIDsByGroupID("group9").empty());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Background

CertiK's re-test of the merged FIB-186 admission-control fix (#5320, commit 18f48cc7) confirmed the connect-close churn vectors (A/B) are fixed, but a persistent bulk-disconnect of already-established sessions (vector D) still halts consensus permanently and never recovers, with no node crashing: the chain finalizes for a few minutes, then freezes mid-fault; validators miss each other's messages, hit consensus timeouts, and the view climbs without bound while the 2f+1 quorum never re-forms.

## Failing scenario

An attacker builds a pool of established sessions, then tears them all down at once and keeps doing so. The teardown notification (`Session::drop`) and every inbound P2P message delivery (`Session::onMessage`) are both posted onto the same unbounded TBB reactor (`Host::asyncTo` / `m_asyncGroup`). The teardown handler drives `Service::onMessage`'s error path -> `onDisconnect` -> `onRemoveNodeIDs` -> `syncLatestNodeIDList`. Under a bulk-disconnect flood this teardown work occupies the reactor, so inter-validator PBFT messages are read off the socket but their delivery task is starved behind teardown — the halt CertiK observed. The accept-side admission control from #5320 cannot touch this: it gates new connections before the handshake, whereas vector D tears down already-established sessions.

## Fix

Route teardown notifications to a dedicated single-thread executor (`Host::postTeardown`, backed by `m_teardownPool`) instead of `m_asyncGroup`. Message delivery stays on `m_asyncGroup` and is no longer starved by teardown; the single dedicated thread also bounds teardown concurrency so a disconnect flood cannot itself swamp the node. No new concurrency is introduced — `onDisconnect` already ran asynchronously and unordered relative to delivery.

## Test

`FIB186_BulkDisconnectReactorTest` drives a real `Session::drop()` flood, pins the shared TBB pool to a known width, and asserts that a delivery task submitted through the reactor is not starved by the teardown flood. It fails on the pre-fix code (delivery starved) and passes with this change. Full `test-bcos-gateway` suite: 102/102 cases, 4689/4689 assertions.
