### PR TITLE
feat(mpt): SlotNotInMPT — honest proofs for scenario-A cold slots (M8 follow-up)

### DIFF
--- a/bcos-framework/bcos-framework/testutils/faker/FakeLedger.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeLedger.h
@@ -19,6 +19,7 @@
  * @date 2021-05-25
  */
 #pragma once
+#include "../../ledger/Features.h"
 #include "../../ledger/LedgerConfig.h"
 #include "../../ledger/LedgerInterface.h"
 #include "../../protocol/Block.h"
@@ -149,10 +150,7 @@ public:
         std::map<HashType, bytesConstPtr> emptyTxsData;
         m_txsHashToData.swap(emptyTxsData);
     }
-    void stop()
-    {
-        m_worker.reset();
-    }
+    void stop() { m_worker.reset(); }
 
     FakeLedger(
         BlockFactory::Ptr _blockFactory, size_t _blockNumber, size_t _txsSize, size_t _receiptsSize)
@@ -544,6 +542,13 @@ public:
         fakeStorageEntryMaps[tableName][_key] = std::move(_data);
     }
 
+    void setFeatures(bcos::ledger::Features _features) { m_features = _features; }
+
+    task::Task<bcos::ledger::Features> fetchAllFeatures(protocol::BlockNumber) override
+    {
+        co_return m_features;
+    }
+
     task::Task<std::optional<storage::Entry>> getStorageAt(std::string_view _address,
         std::string_view _key, protocol::BlockNumber _blockNumber) override
     {
@@ -586,6 +591,8 @@ private:
     std::shared_ptr<FakeStorage> m_fakeStorage;
     std::map<std::string, std::map<std::string, std::optional<storage::Entry>>>
         fakeStorageEntryMaps;
+    // Empty by default, matching LedgerInterface's default fetchAllFeatures.
+    bcos::ledger::Features m_features;
 };
 }  // namespace test
 }  // namespace bcos

--- a/bcos-ledger/bcos-ledger/mpt/Proof.h
+++ b/bcos-ledger/bcos-ledger/mpt/Proof.h
@@ -44,8 +44,9 @@
 namespace bcos::ledger::mpt
 {
 
-/// Proof for one storage slot (spec §5.9). For an absent slot, EIP-1186 semantics apply: value is
-/// empty (JSON 0x0) and proof holds the nodes visited until the walk dead-ended (exclusion proof).
+/// Proof for one storage slot (spec §5.9). For an absent slot under a COMPLETE storage trie
+/// (fullTrie mode), EIP-1186 semantics apply: value is empty (JSON 0x0) and proof holds the nodes
+/// visited until the walk dead-ended (exclusion proof).
 struct StorageProof
 {
     bcos::h256 key;  ///< the raw 32-byte slot key as requested (NOT keccak-transformed)
@@ -53,6 +54,12 @@ struct StorageProof
     /// slot value, matching go-ethereum. Empty when the slot is absent.
     bcos::bytes value;
     std::vector<bcos::bytes> proof;  ///< raw RLP node encodings, storage root first
+    /// False = SlotNotInMPT (spec §5.9, scenario A): the account has a leaf, but this slot was
+    /// never written after MPT activation, so the (incomplete) storage trie excludes it. The
+    /// exclusion walk proves nothing about the slot's flat-KV value — generateProof leaves value
+    /// and proof EMPTY here, and the RPC layer fills value with the authoritative flat-KV truth.
+    /// Only generateProof(fullTrie=false) produces false.
+    bool inMPT = true;
 };
 
 /// EIP-1186 result: the account fields plus the Merkle paths proving them (spec §5.9).
@@ -210,8 +217,20 @@ bcos::task::Task<ProofWalk> proofWalk(Storage& storage, bcos::h256 root, bcos::b
 ///   - stateRoot absent from storage        → ProofErrorCode::BlockNotCommitted
 ///   - stateRoot == emptyRootHash(), or the account walk dead-ends
 ///                                           → ProofErrorCode::AccountNotInMPT
-///   - a requested slot is absent            → StorageProof with empty value and the dead-end
+///   - a requested slot is absent, fullTrie  → StorageProof with empty value and the dead-end
 ///                                             prefix as exclusion proof (EIP-1186 value 0x0)
+///   - a requested slot is absent, !fullTrie → StorageProof with inMPT=false, empty value, empty
+///                                             proof (SlotNotInMPT, see @p fullTrie below)
+///
+/// @param fullTrie asserts the storage tries are COMPLETE (scenario B, feature_l2_ethereum_compat:
+/// every live slot has a trie leaf), so an exclusion walk IS a provable zero. Under scenario A
+/// (slot-level weakening, spec §4.4) the trie only commits slots written after MPT activation; an
+/// exclusion walk there looks IDENTICAL to scenario B's but proves nothing about the slot's
+/// flat-KV value, which may be non-zero — the entry is marked inMPT=false with value and proof
+/// left empty instead of lying with a value-0 exclusion proof. The distinction is mode-driven and
+/// cannot be inferred from the trie shape, hence this explicit parameter; the default keeps the
+/// complete-trie semantics of existing callers. This layer stays storage-pure: reading the
+/// Features flag and filling the flat-KV value are the RPC layer's job.
 ///
 /// Proof generation is a read-only cold path: instantiate over a Storage without an extra cache
 /// layer (e.g. the RocksDB-backed store directly) to avoid polluting the commit path's cache.
@@ -227,7 +246,8 @@ bcos::task::Task<ProofWalk> proofWalk(Storage& storage, bcos::h256 root, bcos::b
 template <bcos::storage2::ReadableStorage<bcos::h256> Storage,
     bcos::crypto::hasher::Hasher HasherT = bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher>
 bcos::task::Task<std::variant<EIP1186Proof, ProofErrorCode>> generateProof(Storage& storage,
-    bcos::h256 stateRoot, bcos::Address address, std::span<bcos::h256 const> slots)
+    bcos::h256 stateRoot, bcos::Address address, std::span<bcos::h256 const> slots,
+    bool fullTrie = true)
 {
     if (stateRoot == emptyRootHash())
     {
@@ -274,17 +294,42 @@ bcos::task::Task<std::variant<EIP1186Proof, ProofErrorCode>> generateProof(Stora
                     MPTInvariantViolation{} << bcos::errinfo_comment(
                         "generateProof: account references a storage root absent from storage"));
             }
-            entry.proof = std::move(slotWalk.nodes);
             if (slotWalk.value)
             {
+                entry.proof = std::move(slotWalk.nodes);
                 entry.value = std::move(*slotWalk.value);
             }
+            else if (fullTrie)
+            {
+                entry.proof = std::move(slotWalk.nodes);  // exclusion proof: a provable zero
+            }
+            else
+            {
+                // Scenario A cold slot: the exclusion walk proves nothing about the flat-KV
+                // value — discard it and mark the entry SlotNotInMPT (spec §5.9).
+                entry.inMPT = false;
+            }
         }
-        // else: empty storage trie — every slot is absent; empty value, empty proof.
+        else if (!fullTrie)
+        {
+            entry.inMPT = false;  // scenario A, empty storage trie: every slot is cold
+        }
+        // else: fullTrie, empty storage trie — every slot provably zero; empty value+proof.
         out.storageProof.push_back(std::move(entry));
     }
     co_return out;
 }
+
+/// Per-slot verification outcome (spec §5.9). Verified/Invalid mirror the storageValid bool; the
+/// third state exists because a SlotNotInMPT entry (inMPT=false) is neither: its value is a
+/// flat-KV assertion with no Merkle backing, so the verifier must not accept it as proven — and
+/// must not fail the response over it either, the honest generator emits exactly this shape.
+enum class SlotProofStatus : uint8_t
+{
+    Verified,      ///< hash chain verified and the recovered value equals the claimed value
+    Invalid,       ///< broken/padded chain, value mismatch, or inMPT=false smuggling proof bytes
+    Unverifiable,  ///< inMPT=false with an empty proof: cryptographically unproven, not disproven
+};
 
 /// Result of independently verifying an EIP1186Proof against a claimed state root (spec §7.1).
 /// The recovered* fields are what the proof bytes actually commit to; they are only filled when
@@ -296,7 +341,10 @@ struct VerifyResult
     bcos::u256 recoveredNonce{};
     bcos::h256 recoveredCodeHash{};
     bcos::h256 recoveredStorageRoot{};
-    std::vector<bool> storageValid;  ///< parallel to proof.storageProof
+    /// Parallel to proof.storageProof; true iff storageStatus[i] == Verified.
+    std::vector<bool> storageValid;
+    /// Parallel to proof.storageProof; the tri-state behind storageValid (spec §5.9).
+    std::vector<SlotProofStatus> storageStatus;
     /// Raw leaf value bytes recovered from each slot's chain (empty = proven absent). Filled only
     /// for slots whose hash chain verified.
     std::vector<bcos::bytes> recoveredStorageValues;
@@ -428,19 +476,24 @@ std::optional<bcos::bytes> verifyProofChain(bcos::h256 const& expectedRoot,
 /// account leaf, the leaf decodes, and the decoded fields EQUAL the proof's claimed
 /// nonce/balance/codeHash/storageHash. Malformed leaf bytes yield accountValid=false, never an
 /// exception. On any account-side failure the function returns immediately with every
-/// storageValid false — slot chains hang off proof.storageHash, which an invalid account side
-/// has not established.
+/// storageValid false and every storageStatus Invalid (including inMPT=false entries: an
+/// unestablished account leaf makes even "unverifiable" too generous) — slot chains hang off
+/// proof.storageHash, which an invalid account side has not established.
 ///
-/// Per slot i: against an empty storage root, valid iff value and proof are both empty (matching
-/// generateProof's empty-trie output); otherwise the slot chain must verify against
-/// proof.storageHash and its recovered value must equal storageProof[i].value (empty = proven
-/// absence).
+/// Per slot i, an inMPT=false entry (SlotNotInMPT, spec §5.9) is judged first: it is Unverifiable
+/// when its proof is empty — the value is flat-KV-asserted, deliberately NOT counted as verified
+/// and NOT treated as a response-level failure — and Invalid when it carries proof bytes (a
+/// malformed mix: an unverifiable claim must not dress up as a proof). Otherwise (inMPT=true):
+/// against an empty storage root, valid iff value and proof are both empty (matching
+/// generateProof's empty-trie output); else the slot chain must verify against proof.storageHash
+/// and its recovered value must equal storageProof[i].value (empty = proven absence).
 template <
     bcos::crypto::hasher::Hasher HasherT = bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher>
 VerifyResult verifyProof(bcos::h256 claimedRoot, EIP1186Proof const& proof)
 {
     VerifyResult out;
     out.storageValid.assign(proof.storageProof.size(), false);
+    out.storageStatus.assign(proof.storageProof.size(), SlotProofStatus::Invalid);
     out.recoveredStorageValues.assign(proof.storageProof.size(), bcos::bytes{});
 
     HasherT hasher;  // one hash context, reused for the account chain and every slot
@@ -477,10 +530,21 @@ VerifyResult verifyProof(bcos::h256 claimedRoot, EIP1186Proof const& proof)
     for (size_t i = 0; i < proof.storageProof.size(); ++i)
     {
         auto const& entry = proof.storageProof[i];
+        if (!entry.inMPT)
+        {
+            // SlotNotInMPT (spec §5.9): the value is a flat-KV assertion — Unverifiable, never
+            // Verified. An inMPT=false entry carrying proof bytes is malformed: whatever those
+            // bytes prove, the generator's contract says no proof exists for this slot.
+            out.storageStatus[i] =
+                entry.proof.empty() ? SlotProofStatus::Unverifiable : SlotProofStatus::Invalid;
+            continue;  // storageValid[i] stays false either way
+        }
         if (proof.storageHash == emptyRootHash<HasherT>())
         {
             // Empty storage trie: generateProof emits empty value + empty proof for every slot.
             out.storageValid[i] = entry.value.empty() && entry.proof.empty();
+            out.storageStatus[i] =
+                out.storageValid[i] ? SlotProofStatus::Verified : SlotProofStatus::Invalid;
             continue;
         }
         auto const slotPath = bytesToNibbles(slotKeyHash(entry.key, hasher).ref());
@@ -488,10 +552,12 @@ VerifyResult verifyProof(bcos::h256 claimedRoot, EIP1186Proof const& proof)
             proof.storageHash, std::span<bcos::bytes const>(entry.proof), slotPath, hasher);
         if (!recovered)
         {
-            continue;  // invalid slot chain: storageValid[i] stays false
+            continue;  // invalid slot chain: storageValid[i] false, storageStatus[i] Invalid
         }
         out.recoveredStorageValues[i] = std::move(*recovered);
         out.storageValid[i] = (out.recoveredStorageValues[i] == entry.value);
+        out.storageStatus[i] =
+            out.storageValid[i] ? SlotProofStatus::Verified : SlotProofStatus::Invalid;
     }
     return out;
 }

--- a/bcos-ledger/test/unittests/mpt/ProofSlotNotInMPTTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofSlotNotInMPTTest.cpp
@@ -1,0 +1,243 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file ProofSlotNotInMPTTest.cpp
+ * @brief SlotNotInMPT: honest proofs for scenario-A cold slots (spec §5.9 / §4.4)
+ */
+
+#include "TestHelpers.h"
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/Proof.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-task/Task.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <map>
+#include <span>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace bcos::ledger::mpt::test
+{
+
+// Helper names carry a ColdSlot prefix: the unity build can merge this file with the other
+// Proof*Test.cpp files into one TU, fusing their unnamed namespaces.
+using ColdSlotMemStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
+
+namespace
+{
+
+/// One account (nonce 7, balance 4242) whose storage trie holds @p slotValues; generates the
+/// EIP-1186 proof for @p requestSlots under the given trie-completeness mode.
+std::pair<bcos::h256, EIP1186Proof> makeColdSlotProof(
+    std::vector<std::pair<bcos::h256, bcos::bytes>> const& slotValues,
+    std::vector<bcos::h256> const& requestSlots, bool fullTrie)
+{
+    ColdSlotMemStorage storage;
+    bcos::Address const addr = makeAddress(0xab);
+    Account account;
+    account.nonce = 7;
+    account.balance = 4242;
+    if (!slotValues.empty())
+    {
+        std::map<bcos::h256, bcos::bytes> slotEntries;
+        for (auto const& [slot, value] : slotValues)
+        {
+            slotEntries[slotKeyHash(slot)] = value;
+        }
+        account.storageRoot = seedTrieFlushed(storage, emptyRootHash(), slotEntries).root;
+    }
+    auto const stateRoot =
+        seedTrieFlushed(storage, emptyRootHash(), {{accountKeyHash(addr), account.encode()}}).root;
+
+    auto result = bcos::task::syncWait(generateProof(
+        storage, stateRoot, addr, std::span<bcos::h256 const>(requestSlots), fullTrie));
+    BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(result));
+    return {stateRoot, std::get<EIP1186Proof>(std::move(result))};
+}
+
+bcos::h256 const coldSlotHot = makeHash(0x01);
+bcos::h256 const coldSlotCold = makeHash(0x03);
+bcos::bytes const coldSlotHotValue{0x2a};  // RLP(42): single byte < 0x80
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(ProofSlotNotInMPTSuite)
+
+// Scenario A (fullTrie=false): the hot slot (in the trie) proves normally; the cold slot (absent
+// from the trie) is marked inMPT=false with value AND proof empty — the flat-fill contract: the
+// mpt layer asserts nothing about the value, the RPC layer supplies the flat-KV truth.
+BOOST_AUTO_TEST_CASE(ScenarioAColdSlotMarkedNotInMPT)
+{
+    auto const proof = makeColdSlotProof(
+        {{coldSlotHot, coldSlotHotValue}}, {coldSlotHot, coldSlotCold}, /*fullTrie=*/false)
+                           .second;
+
+    BOOST_REQUIRE_EQUAL(proof.storageProof.size(), 2);
+    auto const& hot = proof.storageProof.at(0);
+    BOOST_CHECK(hot.inMPT);
+    BOOST_CHECK(hot.value == coldSlotHotValue);
+    BOOST_CHECK(!hot.proof.empty());
+
+    auto const& cold = proof.storageProof.at(1);
+    BOOST_CHECK(!cold.inMPT);
+    BOOST_CHECK(cold.value.empty());
+    BOOST_CHECK(cold.proof.empty());
+}
+
+// Scenario A with an EMPTY storage trie: every requested slot is cold — inMPT=false, empty
+// value, empty proof (under fullTrie=true the same shape means "provably zero", see below).
+BOOST_AUTO_TEST_CASE(ScenarioAEmptyStorageTrieAllSlotsCold)
+{
+    auto const proof =
+        makeColdSlotProof({}, {coldSlotHot, coldSlotCold}, /*fullTrie=*/false).second;
+
+    BOOST_REQUIRE_EQUAL(proof.storageProof.size(), 2);
+    for (auto const& entry : proof.storageProof)
+    {
+        BOOST_CHECK(!entry.inMPT);
+        BOOST_CHECK(entry.value.empty());
+        BOOST_CHECK(entry.proof.empty());
+    }
+}
+
+// Scenario B (fullTrie=true): behavior unchanged — an absent slot yields a non-empty exclusion
+// proof with inMPT=true (the complete trie makes the exclusion a provable zero), and the
+// defaulted-argument call produces the identical result.
+BOOST_AUTO_TEST_CASE(ScenarioBExclusionProofUnchanged)
+{
+    auto const proof = makeColdSlotProof(
+        {{coldSlotHot, coldSlotHotValue}}, {coldSlotHot, coldSlotCold}, /*fullTrie=*/true)
+                           .second;
+
+    BOOST_REQUIRE_EQUAL(proof.storageProof.size(), 2);
+    auto const& absent = proof.storageProof.at(1);
+    BOOST_CHECK(absent.inMPT);
+    BOOST_CHECK(absent.value.empty());
+    BOOST_CHECK(!absent.proof.empty());
+
+    // The defaulted call is scenario B: byte-identical storageProof entries.
+    ColdSlotMemStorage storage;  // re-generate via the default argument on a fresh build
+    {
+        Account account;
+        account.nonce = 7;
+        account.balance = 4242;
+        std::map<bcos::h256, bcos::bytes> const slotEntries{
+            {slotKeyHash(coldSlotHot), coldSlotHotValue}};
+        account.storageRoot = seedTrieFlushed(storage, emptyRootHash(), slotEntries).root;
+        std::map<bcos::h256, bcos::bytes> const accountEntries{
+            {accountKeyHash(makeAddress(0xab)), account.encode()}};
+        auto const root = seedTrieFlushed(storage, emptyRootHash(), accountEntries).root;
+        std::vector<bcos::h256> const slots{coldSlotHot, coldSlotCold};
+        auto result = bcos::task::syncWait(
+            generateProof(storage, root, makeAddress(0xab), std::span<bcos::h256 const>(slots)));
+        BOOST_REQUIRE(std::holds_alternative<EIP1186Proof>(result));
+        auto const& viaDefault = std::get<EIP1186Proof>(result);
+        BOOST_REQUIRE_EQUAL(viaDefault.storageProof.size(), 2);
+        for (size_t i = 0; i < 2; ++i)
+        {
+            BOOST_CHECK(viaDefault.storageProof.at(i).inMPT == proof.storageProof.at(i).inMPT);
+            BOOST_CHECK(viaDefault.storageProof.at(i).value == proof.storageProof.at(i).value);
+            BOOST_CHECK(viaDefault.storageProof.at(i).proof == proof.storageProof.at(i).proof);
+        }
+    }
+}
+
+// The verifier treats an inMPT=false entry as UNVERIFIABLE: not accepted as proven
+// (storageValid=false) and not a response-level failure (accountValid and the other slots
+// still verify). The RPC layer fills the value from flat KV, so a non-empty value with an
+// empty proof is the expected honest shape.
+BOOST_AUTO_TEST_CASE(VerifierTreatsSlotNotInMPTAsUnverifiable)
+{
+    auto [stateRoot, proof] = makeColdSlotProof(
+        {{coldSlotHot, coldSlotHotValue}}, {coldSlotHot, coldSlotCold}, /*fullTrie=*/false);
+
+    // Simulate the RPC layer's flat fill: an authoritative non-zero value without a proof.
+    proof.storageProof.at(1).value = bcos::bytes{0x13, 0x37};
+
+    auto const res = verifyProof(stateRoot, proof);
+    BOOST_CHECK(res.accountValid);
+    BOOST_REQUIRE_EQUAL(res.storageValid.size(), 2);
+    BOOST_REQUIRE_EQUAL(res.storageStatus.size(), 2);
+
+    BOOST_CHECK(res.storageValid.at(0));
+    BOOST_CHECK(res.storageStatus.at(0) == SlotProofStatus::Verified);
+
+    BOOST_CHECK(!res.storageValid.at(1));
+    BOOST_CHECK(res.storageStatus.at(1) == SlotProofStatus::Unverifiable);
+    BOOST_CHECK(res.recoveredStorageValues.at(1).empty());
+}
+
+// An inMPT=false entry carrying proof bytes is malformed — whatever those bytes prove, the
+// generator's contract says no proof exists for the slot. The verifier rejects it as Invalid
+// (not Unverifiable), even when the smuggled bytes are a genuine exclusion chain.
+BOOST_AUTO_TEST_CASE(VerifierRejectsNotInMPTWithProofBytes)
+{
+    // Generate the genuine exclusion chain for the cold slot under scenario B...
+    auto [stateRoot, proofB] =
+        makeColdSlotProof({{coldSlotHot, coldSlotHotValue}}, {coldSlotCold}, /*fullTrie=*/true);
+    BOOST_REQUIRE(!proofB.storageProof.at(0).proof.empty());
+
+    // ...then claim inMPT=false while keeping those proof bytes attached.
+    proofB.storageProof.at(0).inMPT = false;
+
+    auto const res = verifyProof(stateRoot, proofB);
+    BOOST_CHECK(res.accountValid);
+    BOOST_REQUIRE_EQUAL(res.storageStatus.size(), 1);
+    BOOST_CHECK(!res.storageValid.at(0));
+    BOOST_CHECK(res.storageStatus.at(0) == SlotProofStatus::Invalid);
+}
+
+// storageStatus mirrors storageValid for inMPT=true entries: Verified for a good chain,
+// Invalid for a tampered value — the tri-state adds Unverifiable without disturbing the
+// existing bool contract.
+BOOST_AUTO_TEST_CASE(StatusMirrorsBoolForInMPTEntries)
+{
+    auto [stateRoot, proof] =
+        makeColdSlotProof({{coldSlotHot, coldSlotHotValue}}, {coldSlotHot}, /*fullTrie=*/true);
+
+    auto const good = verifyProof(stateRoot, proof);
+    BOOST_CHECK(good.storageValid.at(0));
+    BOOST_CHECK(good.storageStatus.at(0) == SlotProofStatus::Verified);
+
+    proof.storageProof.at(0).value = bcos::bytes{0x2b};  // claim a different value
+    auto const bad = verifyProof(stateRoot, proof);
+    BOOST_CHECK(!bad.storageValid.at(0));
+    BOOST_CHECK(bad.storageStatus.at(0) == SlotProofStatus::Invalid);
+}
+
+// Account-side failure short-circuits every slot to Invalid, including inMPT=false entries:
+// with no established account leaf, even "unverifiable" would be too generous.
+BOOST_AUTO_TEST_CASE(AccountFailureLeavesColdSlotsInvalid)
+{
+    auto [stateRoot, proof] = makeColdSlotProof(
+        {{coldSlotHot, coldSlotHotValue}}, {coldSlotHot, coldSlotCold}, /*fullTrie=*/false);
+
+    auto const res = verifyProof(makeHash(0x99), proof);  // wrong root: account chain fails
+    BOOST_CHECK(!res.accountValid);
+    BOOST_REQUIRE_EQUAL(res.storageStatus.size(), 2);
+    BOOST_CHECK(res.storageStatus.at(0) == SlotProofStatus::Invalid);
+    BOOST_CHECK(res.storageStatus.at(1) == SlotProofStatus::Invalid);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "EthEndpoint.h"
+#include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-protocol/TransactionStatus.h"
@@ -931,8 +932,17 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
         BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
     }
 
+    // The exclusion-vs-cold-slot distinction is mode-driven (spec §5.9): only under
+    // feature_l2_ethereum_compat (scenario B) are the storage tries complete, making an
+    // exclusion walk a provable zero. Otherwise (scenario A) the trie omits slots never
+    // written after MPT activation, and generateProof marks such slots inMPT=false instead
+    // of emitting a lying value-0 exclusion proof. getFeatures degrades to an empty set on
+    // fetch failure, i.e. to the honest scenario-A behavior.
+    auto const features = co_await ledger::getFeatures(*ledger);
+    bool const fullTrie = features.get(ledger::Features::Flag::feature_l2_ethereum_compat);
+
     auto result = co_await ledger::mpt::generateProof(
-        *mptReader, stateRoot, address, std::span<h256 const>(slots));
+        *mptReader, stateRoot, address, std::span<h256 const>(slots), fullTrie);
     if (auto const* errorCode = std::get_if<ledger::mpt::ProofErrorCode>(&result))
     {
         auto const* message = (*errorCode == ledger::mpt::ProofErrorCode::AccountNotInMPT) ?
@@ -955,10 +965,34 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
     }
     output["accountProof"] = std::move(accountProof);
     Json::Value storageProof = Json::arrayValue;
+    auto const addressHex = address.hex();  // ledger::getStorageAt's shape: lowercase, unprefixed
     for (auto& entry : proof.storageProof)
     {
         Json::Value entryJson = Json::objectValue;
         entryJson["key"] = entry.key.hexPrefixed();
+        if (!entry.inMPT)
+        {
+            // SlotNotInMPT (spec §5.9): the slot is absent from the scenario-A storage trie, so
+            // no Merkle proof exists — "value" is the authoritative flat-KV truth, "proof" the
+            // empty array. Forward the resolved blockNumber (not a hardcoded 0 like the other
+            // Web3 flat reads): unlike them, this endpoint's Merkle half DOES honor blockTag —
+            // it proves against the requested block's stateRoot — so the flat half must target
+            // the same block. Ledger::getStorageAt ignores the argument today and serves
+            // latest-committed state; passing it keeps this call site correct once historical
+            // flat reads land, instead of silently staying latest-only. Unset slot reads as zero.
+            std::string quantity = "0x0";
+            if (auto const flat = co_await ledger::getStorageAt(
+                    *ledger, addressHex, entry.key.toRawString(), blockNumber);
+                flat.has_value())
+            {
+                quantity = toQuantity(flat.value().get());
+            }
+            entryJson["value"] = std::move(quantity);
+            entryJson["proof"] = Json::arrayValue;
+            entryJson["inMPT"] = false;
+            storageProof.append(std::move(entryJson));
+            continue;
+        }
         // The trie leaf stores RLP(big-endian-trimmed slot value); EIP-1186 "value" is the
         // slot's QUANTITY. Strip the RLP string header to recover the payload bytes and render
         // them as a quantity — 0x0 when the slot is absent (empty leaf value).
@@ -979,6 +1013,7 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
             proofJson.append(toHexStringWithPrefix(node));
         }
         entryJson["proof"] = std::move(proofJson);
+        entryJson["inMPT"] = true;
         storageProof.append(std::move(entryJson));
     }
     output["storageProof"] = std::move(storageProof);

--- a/bcos-rpc/test/unittests/rpc/EthGetProofRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetProofRpcTest.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-framework/ledger/Features.h>
 #include <bcos-framework/storage2/AnyStorage.h>
 #include <bcos-framework/storage2/MemoryStorage.h>
 #include <bcos-ledger/mpt/Account.h>
@@ -49,6 +50,12 @@ public:
         rpc = factory->buildLocalRpc(groupInfo, nodeService);
         web3JsonRpc = rpc->web3JsonRpc();
         BOOST_TEST(web3JsonRpc != nullptr);
+        // These cases assert scenario-B semantics (feature_l2_ethereum_compat: complete storage
+        // tries, exclusion = provable zero). The scenario-A SlotNotInMPT behavior is covered by
+        // EthGetProofSlotNotInMPTTest.cpp.
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+        m_ledger->setFeatures(features);
     }
 
     /// Commit @p entries into a fresh trie in @p storage and flush the produced nodes, returning

--- a/bcos-rpc/test/unittests/rpc/EthGetProofSlotNotInMPTTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetProofSlotNotInMPTTest.cpp
@@ -1,0 +1,270 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthGetProofSlotNotInMPTTest.cpp
+ * @brief eth_getProof SlotNotInMPT JSON shape under scenario A (spec §5.9 / §4.4)
+ */
+
+#include "../common/RPCFixture.h"
+#include <bcos-framework/ledger/Features.h>
+#include <bcos-framework/storage2/AnyStorage.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/Proof.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bcos::test
+{
+namespace mpt = bcos::ledger::mpt;
+
+// FakeLedger's default (empty) feature set leaves feature_l2_ethereum_compat OFF, so every case
+// here runs under scenario A unless it opts in to scenario B explicitly.
+class EthGetProofSlotNotInMPTFixture : public RPCFixture
+{
+public:
+    using MPTNodeStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes>;
+
+    EthGetProofSlotNotInMPTFixture()
+    {
+        rpc = factory->buildLocalRpc(groupInfo, nodeService);
+        web3JsonRpc = rpc->web3JsonRpc();
+        BOOST_TEST(web3JsonRpc != nullptr);
+        buildTrie();
+        nodeService->setMPTNodeReader(
+            std::make_shared<bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>>(m_mptNodes));
+    }
+
+    /// Commit @p entries into a fresh trie in @p storage and flush the produced nodes, returning
+    /// the root. commitTrie only computes; persistence is the caller's job (HashBuilder.h).
+    static bcos::h256 commitInto(
+        MPTNodeStorage& storage, std::map<bcos::h256, bcos::bytes> const& entries)
+    {
+        std::map<bcos::h256, std::optional<bcos::bytes>> changes;
+        for (auto const& [key, value] : entries)
+        {
+            changes[key] = value;
+        }
+        auto result = task::syncWait(mpt::commitTrie(storage, mpt::emptyRootHash(), changes));
+        task::syncWait(mpt::flushTrieNodes(storage, result.newNodes));
+        return result.root;
+    }
+
+    /// One account whose storage trie holds ONLY slotHot; slotCold stays out of the trie —
+    /// under scenario A that makes it a cold slot, not a provable zero.
+    void buildTrie()
+    {
+        auto const storageRoot = commitInto(m_mptNodes, {{mpt::slotKeyHash(slotHot), hotValue}});
+
+        mpt::Account account;
+        account.nonce = 7;
+        account.balance = 1000;
+        account.storageRoot = storageRoot;
+        stateRoot = commitInto(m_mptNodes, {{mpt::accountKeyHash(address), account.encode()}});
+
+        m_ledger->ledgerData().back()->blockHeader()->setStateRoot(stateRoot);
+    }
+
+    void enableL2Mode()
+    {
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+        m_ledger->setFeatures(features);
+    }
+
+    /// A JSON quantity ("0x2a") back to trimmed big-endian bytes; "0x0" -> empty.
+    static bytes quantityToBytes(std::string const& quantity)
+    {
+        std::string hex = quantity;
+        if (hex.starts_with("0x") || hex.starts_with("0X"))
+        {
+            hex = hex.substr(2);
+        }
+        if (hex.empty() || hex == "0")
+        {
+            return {};
+        }
+        if (hex.size() % 2 != 0)
+        {
+            hex.insert(0, "0");
+        }
+        return fromHex(hex);
+    }
+
+    /// Store a 32-byte big-endian flat value for @p slot the way the endpoint reads it back:
+    /// ledger::getStorageAt with the lowercase unprefixed address and the raw 32-byte key.
+    void setFlatValue(h256 const& slot, h256 const& value)
+    {
+        storage::Entry entry;
+        entry.set(value.toRawString());
+        m_ledger->setStorageAt(address.hex(), slot.toRawString(), std::move(entry));
+    }
+
+    Json::Value request(std::string const& req)
+    {
+        Json::Value value;
+        Json::Reader reader;
+        std::promise<bcos::bytes> promise;
+        web3JsonRpc->onRPCRequest(
+            req, [&promise](bcos::bytes resp) { promise.set_value(std::move(resp)); });
+        auto jsonBytes = promise.get_future().get();
+        std::string_view json((char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    }
+
+    Json::Value getProof(std::vector<std::string> const& keys)
+    {
+        Json::Value req;
+        req["jsonrpc"] = "2.0";
+        req["id"] = 1;
+        req["method"] = "eth_getProof";
+        Json::Value params(Json::arrayValue);
+        params.append(address.hexPrefixed());
+        Json::Value keysJson(Json::arrayValue);
+        for (auto const& key : keys)
+        {
+            keysJson.append(key);
+        }
+        params.append(keysJson);
+        params.append("latest");
+        req["params"] = params;
+        return request(printJson(req));
+    }
+
+    Rpc::Ptr rpc;
+    Web3JsonRpcImpl::Ptr web3JsonRpc;
+
+    MPTNodeStorage m_mptNodes;
+    bcos::Address address{std::string("0x00000000000000000000000000000000000000ab")};
+    h256 slotHot{1U};
+    h256 slotCold{3U};
+    bytes hotValue{0x2a};  // RLP(42): single byte < 0x80
+    h256 stateRoot;
+};
+
+BOOST_FIXTURE_TEST_SUITE(EthGetProofSlotNotInMPTTest, EthGetProofSlotNotInMPTFixture)
+
+// Scenario A, cold slot with a non-zero flat value: "value" is the authoritative flat-KV truth,
+// "proof" the empty array, "inMPT" false — NOT a value-0 exclusion proof, which would lie about
+// a slot whose flat value is non-zero. The hot slot proves normally alongside it.
+BOOST_AUTO_TEST_CASE(ColdSlotFlatValueNoProof)
+{
+    setFlatValue(slotCold, h256{0x1337U});  // 32-byte padded: exercises quantity trimming too
+
+    auto resp = getProof({slotHot.hexPrefixed(), slotCold.hexPrefixed()});
+    BOOST_TEST(!resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+    BOOST_REQUIRE_EQUAL(result["storageProof"].size(), 2U);
+
+    auto const& hot = result["storageProof"][0U];
+    BOOST_TEST(hot["key"].asString() == slotHot.hexPrefixed());
+    BOOST_TEST(hot["value"].asString() == "0x2a");
+    BOOST_TEST(hot["proof"].size() >= 1U);
+    BOOST_TEST(hot["inMPT"].asBool());
+
+    auto const& cold = result["storageProof"][1U];
+    BOOST_TEST(cold["key"].asString() == slotCold.hexPrefixed());
+    BOOST_TEST(cold["value"].asString() == "0x1337");
+    BOOST_REQUIRE(cold["proof"].isArray());
+    BOOST_TEST(cold["proof"].size() == 0U);
+    BOOST_TEST(!cold["inMPT"].asBool());
+}
+
+// Scenario A, cold slot with NO flat entry: the authoritative value is zero — still no proof.
+BOOST_AUTO_TEST_CASE(ColdSlotWithoutFlatValueReadsZero)
+{
+    auto resp = getProof({slotCold.hexPrefixed()});
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& cold = resp["result"]["storageProof"][0U];
+    BOOST_TEST(cold["value"].asString() == "0x0");
+    BOOST_TEST(cold["proof"].size() == 0U);
+    BOOST_TEST(!cold["inMPT"].asBool());
+}
+
+// Scenario B (feature_l2_ethereum_compat): the same absent slot yields the unchanged EIP-1186
+// exclusion proof — value 0x0, non-empty proof, inMPT true — because the complete trie makes
+// the exclusion a provable zero. The flat value must NOT leak into the response.
+BOOST_AUTO_TEST_CASE(ScenarioBKeepsExclusionProof)
+{
+    enableL2Mode();
+    setFlatValue(slotCold, h256{0x1337U});  // present in flat KV, must be ignored
+
+    auto resp = getProof({slotCold.hexPrefixed()});
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& cold = resp["result"]["storageProof"][0U];
+    BOOST_TEST(cold["value"].asString() == "0x0");
+    BOOST_TEST(cold["proof"].size() >= 1U);
+    BOOST_TEST(cold["inMPT"].asBool());
+}
+
+// The scenario-A response round-trips into the verifier contract: the hot slot verifies, the
+// cold slot is Unverifiable (not Verified, not a response-level failure).
+BOOST_AUTO_TEST_CASE(ColdSlotRoundTripUnverifiable)
+{
+    setFlatValue(slotCold, h256{0x1337U});
+
+    auto resp = getProof({slotHot.hexPrefixed(), slotCold.hexPrefixed()});
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+
+    mpt::EIP1186Proof reconstructed;
+    reconstructed.address = Address(result["address"].asString(), Address::FromHex);
+    reconstructed.balance = fromBigQuantity(result["balance"].asString());
+    reconstructed.nonce = fromBigQuantity(result["nonce"].asString());
+    reconstructed.codeHash = h256(result["codeHash"].asString(), h256::FromHex);
+    reconstructed.storageHash = h256(result["storageHash"].asString(), h256::FromHex);
+    for (auto const& node : result["accountProof"])
+    {
+        reconstructed.accountProof.push_back(fromHexWithPrefix(node.asString()));
+    }
+    for (auto const& entryJson : result["storageProof"])
+    {
+        mpt::StorageProof entry;
+        entry.key = h256(entryJson["key"].asString(), h256::FromHex);
+        entry.inMPT = entryJson["inMPT"].asBool();
+        auto raw = quantityToBytes(entryJson["value"].asString());
+        // In-trie values compare against the RLP leaf encoding; a flat-KV assertion
+        // (inMPT=false) is carried as-is — the verifier ignores it either way.
+        entry.value = entry.inMPT ? mpt::encodeStorageValue(bcos::ref(raw)) : raw;
+        for (auto const& node : entryJson["proof"])
+        {
+            entry.proof.push_back(fromHexWithPrefix(node.asString()));
+        }
+        reconstructed.storageProof.push_back(std::move(entry));
+    }
+
+    auto const verify = mpt::verifyProof(stateRoot, reconstructed);
+    BOOST_TEST(verify.accountValid);
+    BOOST_REQUIRE_EQUAL(verify.storageStatus.size(), 2U);
+    BOOST_TEST(verify.storageValid[0]);
+    BOOST_CHECK(verify.storageStatus[0] == mpt::SlotProofStatus::Verified);
+    BOOST_TEST(!verify.storageValid[1]);
+    BOOST_CHECK(verify.storageStatus[1] == mpt::SlotProofStatus::Unverifiable);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/transaction-scheduler/tests/TestCommitSingleBatch.cpp
+++ b/transaction-scheduler/tests/TestCommitSingleBatch.cpp
@@ -1,0 +1,535 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TestCommitSingleBatch.cpp
+ * @brief Tripwire for the single-WriteBatch commit invariant.
+ *
+ * BaselineScheduler::coCommitBlock funnels EVERYTHING a block commit persists
+ * through exactly one backend merge: prewriteBlockToBuffer collects the ledger
+ * rows (header, hash mappings, nonces, tx metadata) into prewriteStorage, and
+ * mergeBackStorage(prewriteStorage) (BaselineScheduler.h) folds the block's
+ * mutable layer PLUS that buffer into the backend via a single
+ * storage2::merge(m_latestBackend, backStorage, extraStorages...)
+ * (MultiLayerStorage.h, non-cache arm). MPT trie-node rows need no extra path:
+ * they were written into the same mutable layer at execute time as ordinary
+ * "/mpt/" state rows (MPTNodeStorage.h).
+ *
+ * Transitive closure with the physical layer: TestRocksDBStorage2 (bcos-storage,
+ * cases `merge` / `mergeAppliesSourcesInArgumentOrder`) pins that one
+ * RocksDBStorage2::merge call = one rocksdb::WriteBatch handed to a single
+ * rocksdb::DB::Write (RocksDBStorage2.h). This file pins the logical layer:
+ * one commit = exactly one backend merge whose key set is complete (header row,
+ * number<->hash index rows, transaction-touched state rows, and — under
+ * feature_mpt_state_root — the "/mpt/" trie-node rows). Together: one commit,
+ * one WriteBatch, one Write. If a refactor ever splits the commit into several
+ * backend writes (reintroducing the half-commit window the retired checker
+ * #5333 hunted for), the exactly-once assertions here go red.
+ *
+ * The counting backend intercepts the merge by shadowing MemoryStorage's
+ * variadic `merge` member — storage2::merge is a member-function-first CPO
+ * (Storage.h `Merge`), so the derived overload is what mergeBackStorage hits.
+ *
+ * Everything lives in an anonymous namespace with SB-prefixed storage types so
+ * this TU's getLedgerConfig tag_invoke stub cannot collide with the other
+ * scheduler test TUs under a unity build (same pattern as
+ * TestExecuteStateRootRegression.cpp / TestMPTSchedulerWiring.cpp).
+ */
+
+#include "TrivialCheckpointStorage.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
+#include "bcos-framework/txpool/TxPoolInterface.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-ledger/mpt/Classify.h"
+#include "bcos-protocol/TransactionSubmitResultFactoryImpl.h"
+#include "bcos-storage/KeyPrefixes.h"
+#include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
+#include "bcos-task/AwaitableValue.h"
+#include "bcos-transaction-scheduler/BaselineScheduler.h"
+#include <boost/lexical_cast.hpp>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <fakeit.hpp>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::executor_v1;
+using namespace bcos::scheduler_v1;
+
+using SBMutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+
+/// Backend that counts merge calls and records, per call, every key the merge
+/// lands — the block's mutable layer and all extra storages (prewriteStorage).
+/// storage2::merge dispatches to the member function (Storage.h `Merge` CPO), so
+/// shadowing MemoryStorage's variadic merge intercepts exactly the call
+/// MultiLayerStorage::mergeBackStorage makes on m_latestBackend; all other
+/// storage2 CPOs keep hitting the inherited MemoryStorage members. A distinct
+/// type (not an alias) also anchors this TU's getLedgerConfig tag_invoke stub
+/// for ADL through the ViewType — same reasoning as TestMPTSchedulerWiring.
+struct SBCountingBackend
+  : memory_storage::MemoryStorage<StateKey, StateValue,
+        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+        std::hash<StateKey>>
+{
+    using Base = memory_storage::MemoryStorage<StateKey, StateValue,
+        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+        std::hash<StateKey>>;
+
+    size_t m_mergeCalls = 0;
+    std::vector<std::vector<StateKey>> m_mergedKeySets;  // one key list per merge call
+
+    template <class... FromStorages>
+    task::AwaitableValue<void> merge(FromStorages&... fromStorages)
+    {
+        std::vector<StateKey> keys;
+        (collectKeys(fromStorages, keys), ...);
+        ++m_mergeCalls;
+        m_mergedKeySets.push_back(std::move(keys));
+        return Base::merge(fromStorages...);
+    }
+
+private:
+    static void collectKeys(auto& fromStorage, std::vector<StateKey>& out)
+    {
+        task::syncWait([&]() -> task::Task<void> {
+            auto iterator = co_await storage2::range(fromStorage);
+            while (auto keyValue = co_await iterator.next())
+            {
+                auto&& [key, value] = *keyValue;
+                out.emplace_back(key);
+            }
+        }());
+    }
+};
+
+using SBCheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, SBCountingBackend>;
+using SBMultiLayerStorage = MultiLayerStorage<SBMutableStorage, void, SBCheckpointBackend>;
+
+bool keySetContains(std::vector<StateKey> const& keys, std::string_view table, std::string_view key)
+{
+    return std::ranges::any_of(keys, [&](StateKey const& stateKey) {
+        return StateKeyView{stateKey}.get() == std::tuple{table, key};
+    });
+}
+
+size_t mptKeyCount(std::vector<StateKey> const& keys)
+{
+    return static_cast<size_t>(std::ranges::count_if(keys, [](StateKey const& stateKey) {
+        return StateKeyView{stateKey}.m_table == storage2::kMPTTable;
+    }));
+}
+
+/// One flat-state row the mock scheduler writes for a block.
+struct SBRow
+{
+    std::string table;
+    std::string key;
+    std::string value;
+};
+
+/// Scheduler impl that replays a per-block write plan through the storage
+/// argument BaselineScheduler hands it — the production write path (the view's
+/// mutable layer), which commit later merges into the backend.
+struct SBWritingScheduler
+{
+    std::map<protocol::BlockNumber, std::vector<SBRow>> const* m_plan{};
+
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(auto& storage,
+        auto& /*executor*/, protocol::BlockHeader const& blockHeader,
+        ::ranges::input_range auto const& transactions, ledger::LedgerConfig const& /*unused*/)
+    {
+        if (auto it = m_plan->find(blockHeader.number()); it != m_plan->end())
+        {
+            for (auto const& row : it->second)
+            {
+                storage::Entry entry;
+                entry.set(row.value);
+                co_await storage2::writeOne(
+                    storage, StateKey{row.table, row.key}, std::move(entry));
+            }
+        }
+
+        auto receipts = ::ranges::iota_view<size_t, size_t>(0, ::ranges::size(transactions)) |
+                        ::ranges::views::transform([](size_t) -> protocol::TransactionReceipt::Ptr {
+                            auto receipt =
+                                std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+                            constexpr static std::string_view str = "abc";
+                            auto& inner = receipt->inner();
+                            inner.dataHash.assign(str.begin(), str.end());
+                            inner.data.gasUsed = "100";
+                            return receipt;
+                        }) |
+                        ::ranges::to<std::vector<protocol::TransactionReceipt::Ptr>>();
+        co_return receipts;
+    }
+};
+
+struct SBExecutor
+{
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(auto& /*storage*/,
+        protocol::BlockHeader const& /*blockHeader*/, protocol::Transaction const& /*transaction*/,
+        int /*contextID*/, ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+    {
+        co_return {};
+    }
+    template <class Storage>
+    struct ExecuteContext
+    {
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
+    };
+    auto createExecuteContext(auto& storage, protocol::BlockHeader const& /*blockHeader*/,
+        protocol::Transaction const& /*transaction*/, int32_t /*contextID*/,
+        ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+        -> task::Task<ExecuteContext<std::decay_t<decltype(storage)>>>
+    {
+        co_return {};
+    }
+};
+
+/// The Features the getLedgerConfig stub hands to every execute — set per test.
+ledger::Features g_sbFeatures{};
+
+[[maybe_unused]] task::AwaitableValue<void> tag_invoke(
+    ledger::tag_t<bcos::ledger::getLedgerConfig> /*unused*/,
+    SBMultiLayerStorage::ViewType& /*storage*/, bcos::ledger::LedgerConfig& ledgerConfig,
+    protocol::BlockNumber /*blockNumber*/, protocol::BlockFactory& /*blockFactory*/)
+{
+    ledgerConfig.setFeatures(g_sbFeatures);
+    return {};
+}
+
+task::Task<std::vector<protocol::Transaction::ConstPtr>> emptyTxsTaskSB()
+{
+    co_return std::vector<protocol::Transaction::ConstPtr>{};
+}
+task::Task<ledger::SystemConfigs> emptySystemConfigsTaskSB()
+{
+    co_return ledger::SystemConfigs{};
+}
+task::Task<ledger::Features> emptyFeaturesTaskSB()
+{
+    co_return ledger::Features{};
+}
+
+class CommitSingleBatchFixture
+{
+public:
+    CommitSingleBatchFixture()
+      : checkpointBackend(backendStorage),
+        cryptoSuite(std::make_shared<crypto::CryptoSuite>(
+            std::make_shared<crypto::Keccak256>(), nullptr, nullptr)),
+        blockHeaderFactory(
+            std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite)),
+        transactionFactory(
+            std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite)),
+        receiptFactory(
+            std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)),
+        blockFactory(std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+            cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory)),
+        transactionSubmitResultFactory(
+            std::make_shared<protocol::TransactionSubmitResultFactoryImpl>()),
+        multiLayerStorage(checkpointBackend),
+        baselineScheduler(multiLayerStorage, mockScheduler, mockExecutor, *blockFactory,
+            mockLedger.get(), mockTxPool.get(), *transactionSubmitResultFactory, *hashImpl)
+    {
+        g_sbFeatures = ledger::Features{};
+        mockScheduler.m_plan = &plan;
+
+        // Unlike the no-op stubs in the sibling fixtures, this asyncPrewriteBlock
+        // writes the same three ledger index rows the production LedgerImpl
+        // writes (Ledger.cpp asyncPrewriteBlock: number->hash, hash->number,
+        // number->header) through the storage it is handed. coCommitBlock hands
+        // it prewriteStorage (via prewriteBlockToBuffer's LegacyStorageWrapper),
+        // so these rows MUST travel in the same single backend merge as the
+        // block's state rows — which is exactly what the key-set assertions pin.
+        fakeit::When(Method(mockLedger, asyncPrewriteBlock))
+            .AlwaysDo([](storage::StorageInterface::Ptr storage, protocol::ConstTransactionsPtr,
+                          protocol::Block::ConstPtr block,
+                          std::function<void(std::string, Error::Ptr&&)> callback, bool,
+                          std::optional<ledger::Features>) {
+                auto header = block->blockHeader();
+                auto blockNumberStr = boost::lexical_cast<std::string>(header->number());
+                auto hash = header->hash();
+                auto hashView =
+                    std::string_view(reinterpret_cast<const char*>(hash.data()), hash.SIZE);
+
+                storage::Entry hashEntry;
+                hashEntry.set(hash.asBytes());
+                storage->asyncSetRow(ledger::SYS_NUMBER_2_HASH, blockNumberStr,
+                    std::move(hashEntry), [](Error::UniquePtr) {});
+
+                storage::Entry hash2NumberEntry;
+                hash2NumberEntry.set(blockNumberStr);
+                storage->asyncSetRow(ledger::SYS_HASH_2_NUMBER, hashView,
+                    std::move(hash2NumberEntry), [](Error::UniquePtr) {});
+
+                bytes headerBuffer;
+                header->encode(headerBuffer);
+                storage::Entry number2HeaderEntry;
+                number2HeaderEntry.set(std::move(headerBuffer));
+                storage->asyncSetRow(ledger::SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr,
+                    std::move(number2HeaderEntry), [](Error::UniquePtr) {});
+
+                callback({}, nullptr);
+            });
+        using HashView =
+            ::ranges::any_view<h256, ::ranges::category::mask | ::ranges::category::sized>;
+        fakeit::When(Method(mockTxPool, getTransactions)).AlwaysDo([](HashView) {
+            return emptyTxsTaskSB();
+        });
+        fakeit::When(Method(mockLedger, asyncGetBlockNumber))
+            .AlwaysDo([](std::function<void(Error::Ptr, protocol::BlockNumber)> callback) {
+                callback(nullptr, -1);
+            });
+        fakeit::When(Method(mockLedger, asyncGetNodeListByType))
+            .AlwaysDo([](std::string_view const&,
+                          std::function<void(Error::Ptr, consensus::ConsensusNodeList)> callback) {
+                callback(nullptr, {});
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockDataByNumber))
+            .AlwaysDo([](protocol::BlockNumber, int32_t,
+                          std::function<void(Error::Ptr, protocol::Block::Ptr)> callback) {
+                callback(nullptr, nullptr);
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockHashByNumber))
+            .AlwaysDo([](protocol::BlockNumber,
+                          std::function<void(Error::Ptr, crypto::HashType)> callback) {
+                callback(nullptr, crypto::HashType{});
+            });
+        fakeit::When(Method(mockLedger, fetchAllSystemConfigs)).AlwaysDo([](protocol::BlockNumber) {
+            return emptySystemConfigsTaskSB();
+        });
+        fakeit::When(Method(mockLedger, fetchAllFeatures)).AlwaysDo([](protocol::BlockNumber) {
+            return emptyFeaturesTaskSB();
+        });
+
+        baselineScheduler.registerBlockNumberNotifier([](protocol::BlockNumber) {});
+        baselineScheduler.registerTransactionNotifier(
+            [](protocol::BlockNumber, protocol::TransactionSubmitResultsPtr,
+                std::function<void(Error::Ptr)> callback) { callback(nullptr); });
+    }
+
+    static void useScenarioA(protocol::BlockNumber activationBlock)
+    {
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_mpt_state_root);
+        features.setActivationBlock(
+            ledger::Features::Flag::feature_mpt_state_root, activationBlock);
+        g_sbFeatures = features;
+    }
+
+    protocol::BlockHeader::Ptr executeOneBlock(protocol::BlockNumber number)
+    {
+        auto block = std::make_shared<bcostars::protocol::BlockImpl>();
+        auto blockHeader = block->blockHeader();
+        blockHeader->setNumber(number);
+        blockHeader->setVersion(blockVersion);
+        blockHeader->calculateHash(*hashImpl);
+        bytes input;
+        block->appendTransaction(transactionFactory->createTransaction(
+            0, "to", input, std::to_string(number), 100, "chain", "group", 0));
+
+        Error::Ptr execError;
+        protocol::BlockHeader::Ptr executedHeader;
+        baselineScheduler.executeBlock(
+            block, false, [&](Error::Ptr error, protocol::BlockHeader::Ptr header, bool) {
+                execError = std::move(error);
+                executedHeader = std::move(header);
+            });
+        BOOST_REQUIRE_MESSAGE(
+            !execError, "executeBlock failed: " + (execError ? execError->errorMessage() : ""));
+        BOOST_REQUIRE(executedHeader);
+        return executedHeader;
+    }
+
+    void commitOneBlock(protocol::BlockHeader::Ptr const& header)
+    {
+        Error::Ptr commitError;
+        baselineScheduler.commitBlock(header,
+            [&](Error::Ptr error, ledger::LedgerConfig::Ptr) { commitError = std::move(error); });
+        BOOST_REQUIRE_MESSAGE(!commitError,
+            "commitBlock failed: " + (commitError ? commitError->errorMessage() : ""));
+    }
+
+    std::optional<storage::Entry> backendRow(std::string_view table, std::string_view key)
+    {
+        return task::syncWait(storage2::readOne(backendStorage, StateKey{table, key}));
+    }
+
+    /// Assert the invariant contract for one committed block against merge call
+    /// @p mergeIndex : the block's header / number->hash / hash->number rows and
+    /// every planned state row all travelled in that single merge.
+    void checkCommitKeySet(size_t mergeIndex, protocol::BlockHeader::Ptr const& header)
+    {
+        BOOST_REQUIRE_GT(backendStorage.m_mergedKeySets.size(), mergeIndex);
+        auto const& keys = backendStorage.m_mergedKeySets[mergeIndex];
+        auto blockNumberStr = boost::lexical_cast<std::string>(header->number());
+        auto hash = header->hash();
+        auto hashView = std::string_view(reinterpret_cast<const char*>(hash.data()), hash.SIZE);
+
+        BOOST_CHECK_MESSAGE(keySetContains(keys, ledger::SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr),
+            "header row missing from the commit merge for block " + blockNumberStr);
+        BOOST_CHECK_MESSAGE(keySetContains(keys, ledger::SYS_NUMBER_2_HASH, blockNumberStr),
+            "number->hash row missing from the commit merge for block " + blockNumberStr);
+        BOOST_CHECK_MESSAGE(keySetContains(keys, ledger::SYS_HASH_2_NUMBER, hashView),
+            "hash->number row missing from the commit merge for block " + blockNumberStr);
+        for (auto const& row : plan.at(header->number()))
+        {
+            BOOST_CHECK_MESSAGE(keySetContains(keys, row.table, row.key),
+                "state row missing from the commit merge: " + row.table + ":" + row.key);
+        }
+    }
+
+    static constexpr uint32_t blockVersion = 200;
+
+    SBCountingBackend backendStorage;
+    SBCheckpointBackend checkpointBackend;
+    crypto::CryptoSuite::Ptr cryptoSuite;
+    std::shared_ptr<bcostars::protocol::BlockHeaderFactoryImpl> blockHeaderFactory;
+    std::shared_ptr<bcostars::protocol::TransactionFactoryImpl> transactionFactory;
+    std::shared_ptr<bcostars::protocol::TransactionReceiptFactoryImpl> receiptFactory;
+    std::shared_ptr<bcostars::protocol::BlockFactoryImpl> blockFactory;
+    std::shared_ptr<protocol::TransactionSubmitResultFactoryImpl> transactionSubmitResultFactory;
+
+    crypto::Hash::Ptr hashImpl = std::make_shared<crypto::Keccak256>();
+
+    std::map<protocol::BlockNumber, std::vector<SBRow>> plan;
+    SBWritingScheduler mockScheduler;
+    fakeit::Mock<ledger::LedgerInterface> mockLedger;
+    fakeit::Mock<txpool::TxPoolInterface> mockTxPool;
+    SBMultiLayerStorage multiLayerStorage;
+    SBExecutor mockExecutor;
+    BaselineScheduler<decltype(multiLayerStorage), SBExecutor, SBWritingScheduler,
+        ledger::LedgerInterface>
+        baselineScheduler;
+};
+
+BOOST_FIXTURE_TEST_SUITE(TestCommitSingleBatch, CommitSingleBatchFixture)
+
+// (a)+(b)+(d) Flat (XOR-era) block: commit lands the header row, both hash index
+// rows, and every transaction-touched state row through EXACTLY ONE backend
+// merge; before the commit the backend has seen zero merges and none of those
+// rows. A second block's commit drives the counter to exactly 2 — proving the
+// counter is live (the exactly-once assertion is not vacuously green) and that
+// the invariant is per-commit. Negative controls: a never-written row is absent
+// from the recorded key set, and a flat commit carries no "/mpt/" keys.
+BOOST_AUTO_TEST_CASE(flatCommitIsExactlyOneMergeWithFullKeySet)
+{
+    plan[100] = {{"/apps/aabbccdd00112233", "balance", "1000000"},
+        {"/apps/eeff445566778899", "code", "0x60806040526004361061"}};
+    plan[101] = {{"/apps/aabbccdd00112233", "balance", "999999"}};
+
+    auto header100 = executeOneBlock(100);
+
+    // (d) Executed but not committed: zero merges, zero rows in the backend.
+    BOOST_CHECK_EQUAL(backendStorage.m_mergeCalls, 0);
+    BOOST_CHECK(!backendRow("/apps/aabbccdd00112233", "balance"));
+    BOOST_CHECK(!backendRow(ledger::SYS_NUMBER_2_BLOCK_HEADER, "100"));
+
+    commitOneBlock(header100);
+
+    // (a) Exactly one backend merge for the whole commit.
+    BOOST_REQUIRE_EQUAL(backendStorage.m_mergeCalls, 1);
+    // (b) ...and that one merge carried the complete key set.
+    checkCommitKeySet(0, header100);
+    // Negative control for (b): the recorded key set is discriminating.
+    BOOST_CHECK(!keySetContains(
+        backendStorage.m_mergedKeySets[0], "/apps/aabbccdd00112233", "never_written"));
+    // Negative control for the MPT case below: no trie-node rows in a flat commit.
+    BOOST_CHECK_EQUAL(mptKeyCount(backendStorage.m_mergedKeySets[0]), 0);
+
+    // The merged rows are really in the backend now (the wrapper forwarded).
+    auto balance = backendRow("/apps/aabbccdd00112233", "balance");
+    BOOST_REQUIRE(balance);
+    BOOST_CHECK_EQUAL(std::string(balance->get()), "1000000");
+    BOOST_CHECK(backendRow(ledger::SYS_NUMBER_2_BLOCK_HEADER, "100"));
+
+    // Counter sensitivity: the next commit is again exactly one merge.
+    auto header101 = executeOneBlock(101);
+    BOOST_CHECK_EQUAL(backendStorage.m_mergeCalls, 1);
+    commitOneBlock(header101);
+    BOOST_REQUIRE_EQUAL(backendStorage.m_mergeCalls, 2);
+    checkCommitKeySet(1, header101);
+}
+
+// (c) MPT block (feature_mpt_state_root active): the execute-time trie build
+// writes its node rows into the block's mutable layer as ordinary "/mpt/" state
+// keys (MPTNodeStorage.h), so the SAME single commit merge must carry them
+// alongside the flat state rows and the ledger index rows. Before the commit no
+// "/mpt/" row exists in the backend; the activation-block (XOR) commit right
+// before is the in-test negative control (merge #0 carries none).
+BOOST_AUTO_TEST_CASE(mptCommitSingleMergeIncludesTrieNodeRows)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioA(500);
+
+    auto address = Address{};
+    address.data()[0] = 0xAB;
+    auto const table = mpt::accountTableName(address);
+    plan[500] = {{table, "balance", "1000000"}};  // activation block: still XOR
+    plan[501] = {{table, "balance", "42"}};       // first MPT block
+
+    auto header500 = executeOneBlock(500);
+    commitOneBlock(header500);
+    BOOST_REQUIRE_EQUAL(backendStorage.m_mergeCalls, 1);
+    checkCommitKeySet(0, header500);
+    BOOST_CHECK_EQUAL(mptKeyCount(backendStorage.m_mergedKeySets[0]), 0);  // XOR: no nodes
+
+    auto header501 = executeOneBlock(501);
+    // (d) MPT nodes built at execute time stay in the pending layer: still only
+    // the one merge from block 500, and no "/mpt/" row reached the backend.
+    BOOST_CHECK_EQUAL(backendStorage.m_mergeCalls, 1);
+
+    commitOneBlock(header501);
+
+    // (a) The MPT block's commit is still exactly one backend merge...
+    BOOST_REQUIRE_EQUAL(backendStorage.m_mergeCalls, 2);
+    // (b) ...with the full flat/ledger key set...
+    checkCommitKeySet(1, header501);
+    // (c) ...AND the trie-node rows riding in the same merge.
+    auto const mptRows = mptKeyCount(backendStorage.m_mergedKeySets[1]);
+    BOOST_CHECK_GT(mptRows, 0);
+
+    // The node rows really landed (spot-check one recorded "/mpt/" key).
+    auto const& keys = backendStorage.m_mergedKeySets[1];
+    auto nodeKey = std::ranges::find_if(keys, [](StateKey const& stateKey) {
+        return StateKeyView{stateKey}.m_table == storage2::kMPTTable;
+    });
+    BOOST_REQUIRE(nodeKey != keys.end());
+    auto nodeView = StateKeyView{*nodeKey};
+    BOOST_CHECK(backendRow(nodeView.m_table, nodeView.m_key));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace


### PR DESCRIPTION
## What

Implements the SlotNotInMPT proof boundary from spec design3 §5.9 / §4.4 (Revision 2026-07-09): when an account has an MPT leaf but a requested slot was never written after MPT activation (a cold slot under scenario A), `eth_getProof` no longer returns a value-0 exclusion proof for it. The slot entry now carries the authoritative flat-KV value, an empty `proof` array, and `inMPT: false`.

## Why the mode flag

An exclusion walk in the storage trie looks byte-identical in two situations with opposite meanings:

- **Scenario B** (`feature_l2_ethereum_compat` on): storage tries are complete, so an exclusion IS a provable zero — behavior unchanged: value 0x0, real exclusion proof, `inMPT: true`.
- **Scenario A** (slot-level weakening, §4.4): the trie only commits slots written after activation, so the same exclusion proves nothing about the slot's flat-KV value, which may be non-zero. Returning a value-0 exclusion proof would be a cryptographically well-formed lie.

The distinction cannot be inferred from the trie shape, so `generateProof` takes an explicit `fullTrie` parameter (default `true` keeps existing complete-trie callers' semantics). The mode is read from `feature_l2_ethereum_compat`, the same flag `scheduler_v1::shouldBuildMPT` checks first for its scenario-B arm, and `validateMPTFlagMatrix` refuses to boot unless that flag activated at block 0 — so it is a chain-lifetime invariant and reading features at latest is sound regardless of blockTag.

The mpt layer stays storage-pure: `EthEndpoint::getProof` picks the mode and fills the cold slot's value from flat state via `ledger::getStorageAt`, forwarding the blockTag-resolved `blockNumber` rather than the hardcoded 0 the other Web3 flat reads pass. Unlike those endpoints, this one's Merkle half does honor blockTag — it proves against the requested block's stateRoot — so its flat half must target the same block. `Ledger::getStorageAt` ignores the argument today and serves latest-committed state (the same committed state the stateRoot targets; the racing-commit window is identical to `eth_getStorageAt`'s), so this is behavior-neutral now and already correct once historical flat reads land. `getFeatures` degrades to an empty feature set on fetch failure, i.e. to the honest scenario-A behavior.

## Verifier contract

`verifyProof` gains a per-slot tri-state `SlotProofStatus` alongside the existing `storageValid` bools (which keep their exact semantics: true iff Verified):

- `inMPT=false` with empty proof → **Unverifiable**: the value is a flat-KV assertion with no Merkle backing — never accepted as proven, and never a response-level failure (the account side and sibling slots still verify).
- `inMPT=false` carrying proof bytes → **Invalid**: malformed — an unverifiable claim must not dress up as a proof, even if the smuggled bytes are a genuine exclusion chain.
- `inMPT=true` → existing Verified/Invalid logic, unchanged.

On an account-side failure every slot reports Invalid, including `inMPT=false` entries: with no established account leaf, even "unverifiable" would be too generous.

## Note on the JSON shape

`inMPT` is an extension field beyond EIP-1186, and a cold slot returns an empty `proof: []` against a non-empty `storageHash`, which is outside the EIP-1186 shape. A standard verifier rejects such a response rather than being deceived by it — honesty over shape is the deliberate tradeoff here, and the alternative (a well-formed value-0 exclusion proof) is exactly what this PR exists to remove.

## Also in this PR

`FakeLedger` gains `setFeatures` + a `fetchAllFeatures` override (empty by default, matching the interface default, so tests that do not call `setFeatures` are unaffected) so endpoint tests can toggle modes. `EthGetProofRpcTest` is pinned to scenario B in its fixture — its assertions encode complete-trie exclusion semantics.

## Tests

- `ProofSlotNotInMPTTest.cpp` (new): scenario-A cold slot → `inMPT=false` + empty value/proof (flat-fill contract); empty storage trie under scenario A; scenario-B exclusion unchanged (including via the defaulted argument); verifier Unverifiable / Invalid-on-smuggled-proof / status-mirrors-bool / account-failure cases.
- `EthGetProofSlotNotInMPTTest.cpp` (new): JSON shape for cold slots (flat value, empty proof array, `inMPT` false), zero when no flat entry, scenario-B flag restores the exclusion proof and ignores flat KV, and a JSON round-trip into `verifyProof` ending Unverifiable.
- Rebased onto the `release-3.18.0` tip (`1e8471199`). Both new tests build their tries through the post-#5315 free-function API — `seedTrieFlushed` from `TestHelpers.h` on the ledger side, a local `commitTrie` + `flushTrieNodes` helper on the rpc side, mirroring `EthGetProofRpcTest`.
- On that rebased tree: `test-bcos-ledger` and `test-bcos-rpc` both build clean and pass in full (`*** No errors detected`). `ProofSlotNotInMPTSuite` is 7 cases / 54 assertions; `EthGetProofSlotNotInMPTTest` + `EthGetProofRpcTest` are 9 cases / 68 assertions.

