### PR TITLE
feat(ledger/tools): half-commit detection library + offline CLI (M9.1+M9.4)

### DIFF
--- a/bcos-ledger/CMakeLists.txt
+++ b/bcos-ledger/CMakeLists.txt
@@ -18,14 +18,26 @@
 
 
 find_package(Boost REQUIRED serialization)
+find_package(RocksDB REQUIRED)
 
 file(GLOB_RECURSE SRCS bcos-ledger/*.cpp)
+# halfcommit/ builds as its own lean static lib (framework + RocksDB, no ledger)
+# so node startup (PR-29) and the offline CLI (tools/half-commit-check) can link
+# the scanner without dragging in the full ledger target
+file(GLOB_RECURSE HALFCOMMIT_SRCS bcos-ledger/halfcommit/*.cpp)
+list(REMOVE_ITEM SRCS ${HALFCOMMIT_SRCS})
 add_library(ledger ${SRCS})
 target_include_directories(ledger PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-ledger>)
 target_link_libraries(ledger PUBLIC tool protocol-tars codec table bcos-concepts bcos-crypto Boost::serialization)
 set_target_properties(ledger PROPERTIES UNITY_BUILD "ON")
+
+add_library(halfcommit-checker ${HALFCOMMIT_SRCS})
+target_include_directories(halfcommit-checker PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/bcos-ledger>)
+target_link_libraries(halfcommit-checker PUBLIC bcos-framework bcos-crypto RocksDB::rocksdb)
 
 # test related
 if (TESTS)
@@ -35,5 +47,5 @@ if (TESTS)
 endif()
 
 include(GNUInstallDirs)
-install(TARGETS ledger EXPORT fiscobcosTargets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+install(TARGETS ledger halfcommit-checker EXPORT fiscobcosTargets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 install(DIRECTORY "bcos-ledger" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}" FILES_MATCHING PATTERN "*.h")

--- a/bcos-ledger/bcos-ledger/halfcommit/HalfCommitChecker.cpp
+++ b/bcos-ledger/bcos-ledger/halfcommit/HalfCommitChecker.cpp
@@ -1,0 +1,183 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HalfCommitChecker.cpp
+ * @brief Half-commit (orphan block) detection over a node state database (spec §5.12)
+ */
+#include "HalfCommitChecker.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Common.h"
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <boost/lexical_cast.hpp>
+#include <optional>
+#include <ostream>
+#include <set>
+
+namespace bcos::ledger::halfcommit
+{
+
+namespace
+{
+
+std::optional<protocol::BlockNumber> readCurrentNumber(::rocksdb::DB& db)
+{
+    std::string value;
+    auto status = db.Get(::rocksdb::ReadOptions{},
+        storage::toDBKey(SYS_CURRENT_STATE, SYS_KEY_CURRENT_NUMBER), &value);
+    if (!status.ok())
+    {
+        return std::nullopt;
+    }
+    try
+    {
+        return boost::lexical_cast<protocol::BlockNumber>(value);
+    }
+    catch (boost::bad_lexical_cast const&)
+    {
+        return std::nullopt;
+    }
+}
+
+// Block numbers of all rows in `table` above `threshold`. Row keys are the
+// decimal block number (Ledger::asyncPrewriteBlock uses
+// boost::lexical_cast<std::string>(header->number())), stored under the
+// physical key `<table>:<key>` (storage::toDBKey).
+std::set<protocol::BlockNumber> rowsAbove(
+    ::rocksdb::DB& db, std::string_view table, protocol::BlockNumber threshold)
+{
+    std::set<protocol::BlockNumber> result;
+    auto prefix = storage::toDBKey(table, {});
+    std::unique_ptr<::rocksdb::Iterator> iterator{db.NewIterator(::rocksdb::ReadOptions{})};
+    for (iterator->Seek(prefix); iterator->Valid() && iterator->key().starts_with(prefix);
+        iterator->Next())
+    {
+        auto rowKey = iterator->key().ToStringView().substr(prefix.size());
+        protocol::BlockNumber blockNumber{};
+        try
+        {
+            blockNumber = boost::lexical_cast<protocol::BlockNumber>(rowKey);
+        }
+        catch (boost::bad_lexical_cast const&)
+        {
+            continue;  // not a ledger-written row; ledger only writes numeric keys here
+        }
+        if (blockNumber > threshold)
+        {
+            result.insert(blockNumber);
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
+ScanReport scan(::rocksdb::DB& db, protocol::BlockFactory& blockFactory)
+{
+    ScanReport report;
+    auto currentNumber = readCurrentNumber(db);
+    if (!currentNumber)
+    {
+        report.dbCorrupted = true;
+        report.corruptionReason =
+            fmt::format("missing or non-numeric {}:{} row — not a node state database?",
+                SYS_CURRENT_STATE, SYS_KEY_CURRENT_NUMBER);
+        return report;
+    }
+    report.currentNumber = *currentNumber;
+
+    auto txOrphans = rowsAbove(db, SYS_NUMBER_2_TXS, report.currentNumber);
+    auto nonceOrphans = rowsAbove(db, SYS_BLOCK_NUMBER_2_NONCES, report.currentNumber);
+    if (txOrphans != nonceOrphans)
+    {
+        report.dbCorrupted = true;
+        report.corruptionReason = fmt::format(
+            "inconsistent indexes above current_number={}: {} has blocks [{}] but {} has blocks "
+            "[{}]",
+            report.currentNumber, SYS_NUMBER_2_TXS, fmt::join(txOrphans, ", "),
+            SYS_BLOCK_NUMBER_2_NONCES, fmt::join(nonceOrphans, ", "));
+        return report;
+    }
+
+    report.orphans.reserve(txOrphans.size());
+    for (auto blockNumber : txOrphans)
+    {
+        std::string value;
+        auto status = db.Get(::rocksdb::ReadOptions{},
+            storage::toDBKey(SYS_NUMBER_2_TXS, boost::lexical_cast<std::string>(blockNumber)),
+            &value);
+        if (!status.ok())
+        {
+            report.dbCorrupted = true;
+            report.corruptionReason = fmt::format("failed to re-read {} row of block {}: {}",
+                SYS_NUMBER_2_TXS, blockNumber, status.ToString());
+            return report;
+        }
+
+        OrphanBlock orphan{.blockNumber = blockNumber, .txHashes = {}};
+        try
+        {
+            auto block = blockFactory.createBlock(
+                bytesConstRef(reinterpret_cast<const byte*>(value.data()), value.size()),
+                /*calculateHash*/ false, /*checkSig*/ false);
+            orphan.txHashes.reserve(block->transactionsMetaDataSize());
+            for (uint64_t i = 0; i < block->transactionsMetaDataSize(); ++i)
+            {
+                orphan.txHashes.emplace_back(block->transactionHash(i));
+            }
+        }
+        catch (std::exception const& e)
+        {
+            report.dbCorrupted = true;
+            report.corruptionReason = fmt::format(
+                "undecodable {} row of block {}: {}", SYS_NUMBER_2_TXS, blockNumber, e.what());
+            return report;
+        }
+        report.orphans.push_back(std::move(orphan));
+    }
+    return report;
+}
+
+std::string formatReport(ScanReport const& report)
+{
+    if (report.dbCorrupted)
+    {
+        return fmt::format(
+            "*** DB CORRUPTION DETECTED ***\n  reason: {}\n  currentNumber: {}\n"
+            "  Operator should investigate before restarting the node.\n",
+            report.corruptionReason, report.currentNumber);
+    }
+
+    auto out = fmt::format(
+        "currentNumber: {}\norphans: {}\n", report.currentNumber, report.orphans.size());
+    for (auto const& orphan : report.orphans)
+    {
+        out += fmt::format("  block {}, tx_count={}\n", orphan.blockNumber, orphan.txHashes.size());
+    }
+    return out;
+}
+
+void dumpOrphans(ScanReport const& report, std::ostream& out)
+{
+    for (auto const& orphan : report.orphans)
+    {
+        for (auto const& hash : orphan.txHashes)
+        {
+            out << orphan.blockNumber << " " << hash.hexPrefixed() << "\n";
+        }
+    }
+}
+
+}  // namespace bcos::ledger::halfcommit

--- a/bcos-ledger/bcos-ledger/halfcommit/HalfCommitChecker.h
+++ b/bcos-ledger/bcos-ledger/halfcommit/HalfCommitChecker.h
@@ -1,0 +1,69 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HalfCommitChecker.h
+ * @brief Half-commit (orphan block) detection over a node state database (spec §5.12)
+ */
+#pragma once
+
+#include "bcos-framework/protocol/BlockFactory.h"
+#include "bcos-framework/protocol/ProtocolTypeDef.h"
+#include <rocksdb/db.h>
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+namespace bcos::ledger::halfcommit
+{
+
+// A block whose tx-index rows exist above current_number: the crash happened
+// after the block data was stored but before the state commit advanced
+// current_number.
+struct OrphanBlock
+{
+    protocol::BlockNumber blockNumber{};
+    // Decoded from the SYS_NUMBER_2_TXS row (a BlockFactory-encoded block
+    // carrying transaction metadata only; see Ledger::asyncPrewriteBlock).
+    std::vector<crypto::HashType> txHashes;
+};
+
+struct ScanReport
+{
+    protocol::BlockNumber currentNumber{-1};
+    std::vector<OrphanBlock> orphans;  // ascending blockNumber
+    bool dbCorrupted{false};
+    std::string corruptionReason;
+};
+
+// Read-only scan shared by node startup (PR-29) and the offline CLI:
+// 1. read SYS_CURRENT_STATE.current_number = M
+// 2. collect rows of SYS_NUMBER_2_TXS with blockNumber > M (orphans)
+// 3. cross-check against SYS_BLOCK_NUMBER_2_NONCES — the two index tables are
+//    written together (Ledger::asyncPrewriteBlock), so the block-number sets
+//    above M must be identical; a mismatch is reported as dbCorrupted (caller
+//    should abort and involve ops, never self-heal)
+//
+// Never modifies the database. Values are read as ledger wrote them; a
+// database with storage_security (disk encryption) enabled is not supported.
+ScanReport scan(::rocksdb::DB& db, protocol::BlockFactory& blockFactory);
+
+// Human-readable diagnostic, one line per orphan block.
+std::string formatReport(ScanReport const& report);
+
+// One "<blockNumber> <0xTxHash>" per line; format is grep/awk-friendly and
+// consumed by ops runbooks — keep it stable.
+void dumpOrphans(ScanReport const& report, std::ostream& out);
+
+}  // namespace bcos::ledger::halfcommit

--- a/bcos-ledger/test/CMakeLists.txt
+++ b/bcos-ledger/test/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(${TEST_BINARY_NAME} PRIVATE ${CMAKE_BINARY_DIR}/bcos-
 
 find_package(Boost REQUIRED unit_test_framework)
 
-target_link_libraries(${TEST_BINARY_NAME} PRIVATE ledger bcos-crypto protocol-tars Boost::unit_test_framework)
+target_link_libraries(${TEST_BINARY_NAME} PRIVATE ledger halfcommit-checker bcos-crypto protocol-tars Boost::unit_test_framework)
 target_compile_definitions(${TEST_BINARY_NAME} PUBLIC _TESTS_)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 # add_test(NAME test-ledger WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${TEST_BINARY_NAME})

--- a/bcos-ledger/test/unittests/HalfCommitCheckerTest.cpp
+++ b/bcos-ledger/test/unittests/HalfCommitCheckerTest.cpp
@@ -1,0 +1,246 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HalfCommitCheckerTest.cpp
+ * @brief spec §7.2 half-commit detection: scan over a DB crafted like a
+ *        crash between block-data store and state commit (spec §5.12)
+ */
+#include "bcos-ledger/halfcommit/HalfCommitChecker.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Common.h"
+#include "bcos-framework/testutils/faker/FakeBlock.h"
+#include <rocksdb/db.h>
+#include <boost/test/unit_test.hpp>
+#include <filesystem>
+#include <sstream>
+
+using namespace bcos;
+using namespace bcos::ledger;
+
+namespace
+{
+
+struct HalfCommitCheckerFixture
+{
+    HalfCommitCheckerFixture()
+    {
+        m_blockFactory = bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+        m_path = std::filesystem::temp_directory_path() /
+                 (std::string("bcos_halfcommit_test_") +
+                     boost::unit_test::framework::current_test_case().p_name.get());
+        std::filesystem::remove_all(m_path);
+
+        ::rocksdb::Options options;
+        options.create_if_missing = true;
+        ::rocksdb::DB* db = nullptr;
+        auto status = ::rocksdb::DB::Open(options, m_path.string(), &db);
+        BOOST_REQUIRE_MESSAGE(status.ok(), status.ToString());
+        m_db.reset(db);
+    }
+    ~HalfCommitCheckerFixture()
+    {
+        m_db.reset();
+        std::filesystem::remove_all(m_path);
+    }
+
+    void put(std::string_view table, std::string_view key, std::string_view value)
+    {
+        auto status = m_db->Put(::rocksdb::WriteOptions{}, storage::toDBKey(table, key),
+            ::rocksdb::Slice(value.data(), value.size()));
+        BOOST_REQUIRE(status.ok());
+    }
+
+    void writeCurrentNumber(protocol::BlockNumber number)
+    {
+        // mirrors Ledger::asyncPrewriteBlock "current number":
+        // ASCII decimal via boost::lexical_cast<std::string>
+        put(SYS_CURRENT_STATE, SYS_KEY_CURRENT_NUMBER, std::to_string(number));
+    }
+
+    // mirrors Ledger::asyncPrewriteBlock "number 2 transactions": a
+    // BlockFactory-encoded block carrying transaction metadata (hash + to) only
+    void writeTxsRow(protocol::BlockNumber number, std::vector<crypto::HashType> const& txHashes)
+    {
+        auto block = m_blockFactory->createBlock();
+        for (auto const& hash : txHashes)
+        {
+            block->appendTransactionMetaData(m_blockFactory->createTransactionMetaData(
+                hash, "0x0000000000000000000000000000000000001001"));
+        }
+        bytes buffer;
+        block->encode(buffer);
+        put(SYS_NUMBER_2_TXS, std::to_string(number),
+            std::string_view(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    }
+
+    // mirrors Ledger::asyncPrewriteBlock "number 2 nonce": a BlockFactory-encoded
+    // block carrying the nonce list only
+    void writeNoncesRow(protocol::BlockNumber number, size_t nonceCount)
+    {
+        auto block = m_blockFactory->createBlock();
+        std::vector<std::string> nonces;
+        nonces.reserve(nonceCount);
+        for (size_t i = 0; i < nonceCount; ++i)
+        {
+            nonces.push_back(std::to_string(10000 + i));
+        }
+        block->setNonceList(::ranges::any_view<std::string>(nonces));
+        bytes buffer;
+        block->encode(buffer);
+        put(SYS_BLOCK_NUMBER_2_NONCES, std::to_string(number),
+            std::string_view(reinterpret_cast<const char*>(buffer.data()), buffer.size()));
+    }
+
+    // a fully committed block: both index rows present and current_number covers it
+    void writeCommittedBlock(
+        protocol::BlockNumber number, std::vector<crypto::HashType> const& txHashes)
+    {
+        writeTxsRow(number, txHashes);
+        writeNoncesRow(number, txHashes.size());
+    }
+
+    std::vector<crypto::HashType> makeHashes(size_t count, unsigned seed)
+    {
+        std::vector<crypto::HashType> hashes;
+        hashes.reserve(count);
+        for (size_t i = 0; i < count; ++i)
+        {
+            hashes.emplace_back(crypto::HashType(seed * 1000 + i));
+        }
+        return hashes;
+    }
+
+    protocol::BlockFactory::Ptr m_blockFactory;
+    std::filesystem::path m_path;
+    std::unique_ptr<::rocksdb::DB> m_db;
+};
+
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(HalfCommitCheckerSuite, HalfCommitCheckerFixture)
+
+BOOST_AUTO_TEST_CASE(HealthyDBReportsNoOrphan)
+{
+    writeCurrentNumber(100);
+    writeCommittedBlock(99, makeHashes(2, 99));
+    writeCommittedBlock(100, makeHashes(3, 100));
+
+    auto report = halfcommit::scan(*m_db, *m_blockFactory);
+
+    BOOST_CHECK_EQUAL(report.currentNumber, 100);
+    BOOST_CHECK(report.orphans.empty());
+    BOOST_CHECK_EQUAL(report.dbCorrupted, false);
+
+    auto text = halfcommit::formatReport(report);
+    BOOST_CHECK(text.find("currentNumber: 100") != std::string::npos);
+    BOOST_CHECK(text.find("orphans: 0") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(CrashAfterBlockDataStoreReportsOrphans)
+{
+    // crash simulation: blocks 101..103 got their tx/nonce index rows written,
+    // but the state commit never advanced current_number past 100
+    writeCurrentNumber(100);
+    writeCommittedBlock(100, makeHashes(2, 100));
+    auto orphanHashes101 = makeHashes(2, 101);
+    auto orphanHashes102 = makeHashes(0, 102);  // empty block
+    auto orphanHashes103 = makeHashes(3, 103);
+    writeCommittedBlock(101, orphanHashes101);
+    writeCommittedBlock(102, orphanHashes102);
+    writeCommittedBlock(103, orphanHashes103);
+
+    auto report = halfcommit::scan(*m_db, *m_blockFactory);
+
+    BOOST_CHECK_EQUAL(report.dbCorrupted, false);
+    BOOST_CHECK_EQUAL(report.currentNumber, 100);
+    BOOST_REQUIRE_EQUAL(report.orphans.size(), 3);
+    BOOST_CHECK_EQUAL(report.orphans[0].blockNumber, 101);
+    BOOST_CHECK_EQUAL(report.orphans[1].blockNumber, 102);
+    BOOST_CHECK_EQUAL(report.orphans[2].blockNumber, 103);
+    BOOST_CHECK(report.orphans[0].txHashes == orphanHashes101);
+    BOOST_CHECK(report.orphans[1].txHashes.empty());
+    BOOST_CHECK(report.orphans[2].txHashes == orphanHashes103);
+
+    auto text = halfcommit::formatReport(report);
+    BOOST_CHECK(text.find("orphans: 3") != std::string::npos);
+    BOOST_CHECK(text.find("block 101, tx_count=2") != std::string::npos);
+    BOOST_CHECK(text.find("block 103, tx_count=3") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(IndexMismatchReportsCorruption)
+{
+    // txs row for 101 exists but the nonces row does not — the two indexes are
+    // written together, so this is not a plain half-commit but corruption
+    writeCurrentNumber(100);
+    writeTxsRow(101, makeHashes(2, 101));
+
+    auto report = halfcommit::scan(*m_db, *m_blockFactory);
+
+    BOOST_CHECK_EQUAL(report.dbCorrupted, true);
+    BOOST_CHECK(report.corruptionReason.find("s_number_2_txs") != std::string::npos);
+    BOOST_CHECK(report.corruptionReason.find("s_block_number_2_nonces") != std::string::npos);
+    BOOST_CHECK(report.orphans.empty());
+
+    auto text = halfcommit::formatReport(report);
+    BOOST_CHECK(text.find("CORRUPTION") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(NonceRowWithoutTxsRowAlsoReportsCorruption)
+{
+    writeCurrentNumber(100);
+    writeNoncesRow(101, 2);
+
+    auto report = halfcommit::scan(*m_db, *m_blockFactory);
+    BOOST_CHECK_EQUAL(report.dbCorrupted, true);
+}
+
+BOOST_AUTO_TEST_CASE(MissingCurrentNumberReportsCorruption)
+{
+    auto report = halfcommit::scan(*m_db, *m_blockFactory);
+
+    BOOST_CHECK_EQUAL(report.dbCorrupted, true);
+    BOOST_CHECK(report.corruptionReason.find("current_number") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(UndecodableTxsRowReportsCorruption)
+{
+    writeCurrentNumber(100);
+    put(SYS_NUMBER_2_TXS, "101", "definitely-not-a-tars-encoded-block");
+    writeNoncesRow(101, 1);
+
+    auto report = halfcommit::scan(*m_db, *m_blockFactory);
+
+    BOOST_CHECK_EQUAL(report.dbCorrupted, true);
+    BOOST_CHECK(report.corruptionReason.find("101") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(DumpOrphansWritesOneLinePerTxHash)
+{
+    writeCurrentNumber(100);
+    auto orphanHashes = makeHashes(2, 101);
+    writeCommittedBlock(101, orphanHashes);
+
+    auto report = halfcommit::scan(*m_db, *m_blockFactory);
+    BOOST_REQUIRE_EQUAL(report.orphans.size(), 1);
+
+    std::ostringstream out;
+    halfcommit::dumpOrphans(report, out);
+
+    std::string expected =
+        "101 " + orphanHashes[0].hexPrefixed() + "\n101 " + orphanHashes[1].hexPrefixed() + "\n";
+    BOOST_CHECK_EQUAL(out.str(), expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 if(TOOLS)
   add_subdirectory(archive-tool)
+  add_subdirectory(half-commit-check)
   add_subdirectory(storage-tool)
   add_subdirectory(hsm-tool)
   add_subdirectory(kms-tool)

--- a/tools/half-commit-check/CMakeLists.txt
+++ b/tools/half-commit-check/CMakeLists.txt
@@ -1,0 +1,8 @@
+find_package(Boost REQUIRED program_options)
+find_package(RocksDB REQUIRED)
+
+add_executable(half-commit-check main.cpp)
+target_link_libraries(
+    half-commit-check halfcommit-checker protocol-tars bcos-crypto Boost::program_options
+    RocksDB::rocksdb)
+target_include_directories(half-commit-check PRIVATE ${CMAKE_SOURCE_DIR})

--- a/tools/half-commit-check/main.cpp
+++ b/tools/half-commit-check/main.cpp
@@ -1,0 +1,144 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file main.cpp
+ * @brief offline half-commit diagnostic CLI (spec §5.12) — thin shell over the
+ *        halfcommit-checker library; node must be stopped before running
+ */
+#include "bcos-ledger/halfcommit/HalfCommitChecker.h"
+#include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <rocksdb/db.h>
+#include <boost/program_options.hpp>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+namespace
+{
+
+// Exit codes (consumed by ops runbooks — keep stable):
+// 0 = scan OK (orphans, if any, are listed in the report)
+// 1 = DB corruption detected
+// 2 = CLI argument error
+// 3 = failed to open RocksDB
+// 4 = failed to open the --dump-orphans output file
+enum ExitCode : int
+{
+    EXIT_SCAN_OK = 0,
+    EXIT_DB_CORRUPTED = 1,
+    EXIT_BAD_ARGUMENTS = 2,
+    EXIT_DB_OPEN_FAILED = 3,
+    EXIT_DUMP_FILE_FAILED = 4,
+};
+
+bcos::protocol::BlockFactory::Ptr buildBlockFactory()
+{
+    // Only used to decode transaction-metadata blocks (stored hashes are read
+    // verbatim, nothing is re-hashed), so the concrete hash/signature scheme
+    // of the chain does not matter here.
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    auto blockHeaderFactory =
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite);
+    auto transactionFactory =
+        std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    auto receiptFactory =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite);
+    return std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+        cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[])
+{
+    namespace po = boost::program_options;
+    po::options_description description(
+        "half-commit-check — offline scan for blocks whose tx/nonce index rows were persisted "
+        "but whose state commit never advanced current_number (spec §5.12).\n"
+        "The node must be STOPPED; the database is opened read-only.\n\nOptions");
+    description.add_options()("help,h", "print this help")("datadir,d", po::value<std::string>(),
+        "node state RocksDB directory (data/group0... in AIR)")("report-only", po::bool_switch(),
+        "print the diagnostic report only (default behavior)")("dump-orphans",
+        po::value<std::string>(),
+        "additionally write orphan tx hashes to <file>, one '<blockNumber> <txHash>' per line");
+
+    po::variables_map variables;
+    try
+    {
+        po::store(po::parse_command_line(argc, argv, description), variables);
+        po::notify(variables);
+    }
+    catch (std::exception const& e)
+    {
+        std::cout << "Error: " << e.what() << "\n" << description << "\n";
+        return EXIT_BAD_ARGUMENTS;
+    }
+    if (variables.count("help") != 0)
+    {
+        std::cout << description << "\n";
+        return EXIT_SCAN_OK;
+    }
+    if (variables.count("datadir") == 0)
+    {
+        std::cout << "Error: --datadir is required\n" << description << "\n";
+        return EXIT_BAD_ARGUMENTS;
+    }
+    if (variables["report-only"].as<bool>() && variables.count("dump-orphans") != 0)
+    {
+        std::cout << "Error: --report-only and --dump-orphans are mutually exclusive\n";
+        return EXIT_BAD_ARGUMENTS;
+    }
+
+    auto datadir = variables["datadir"].as<std::string>();
+    ::rocksdb::Options options;
+    options.create_if_missing = false;
+    ::rocksdb::DB* rawDB = nullptr;
+    auto status = ::rocksdb::DB::OpenForReadOnly(options, datadir, &rawDB);
+    if (!status.ok())
+    {
+        std::cout << "Error: failed to open RocksDB at " << datadir
+                  << " read-only: " << status.ToString() << "\n";
+        return EXIT_DB_OPEN_FAILED;
+    }
+    std::unique_ptr<::rocksdb::DB> database(rawDB);
+
+    auto blockFactory = buildBlockFactory();
+    auto report = bcos::ledger::halfcommit::scan(*database, *blockFactory);
+    std::cout << bcos::ledger::halfcommit::formatReport(report);
+    if (report.dbCorrupted)
+    {
+        return EXIT_DB_CORRUPTED;
+    }
+
+    if (variables.count("dump-orphans") != 0)
+    {
+        auto dumpPath = variables["dump-orphans"].as<std::string>();
+        std::ofstream dumpFile(dumpPath, std::ios::trunc);
+        if (!dumpFile)
+        {
+            std::cout << "Error: failed to open dump file " << dumpPath << "\n";
+            return EXIT_DUMP_FILE_FAILED;
+        }
+        bcos::ledger::halfcommit::dumpOrphans(report, dumpFile);
+        std::cout << "Dumped " << report.orphans.size() << " orphan blocks' tx hashes to "
+                  << dumpPath << "\n";
+    }
+    return EXIT_SCAN_OK;
+}


### PR DESCRIPTION
### What

Implements spec §5.12 (Half-commit Detection & Replay) detection plane: a read-only orphan-block scan library plus an offline diagnostic CLI. Two commits: the library (M9.1), then the CLI (M9.4).

A crash between storing a block's data and the state commit leaves the database with block N's tx/nonce index rows while `s_current_state.current_number` is still N-1. Today that state is invisible to ops. This PR makes it visible; it does not change any commit path.

### Library — `halfcommit-checker` (bcos-ledger/bcos-ledger/halfcommit/)

`scan(rocksdb::DB&, protocol::BlockFactory&) -> ScanReport`:

1. reads `s_current_state:current_number = M` (physical key layout `table:key` per `storage::toDBKey`, decimal row keys as written by `Ledger::asyncPrewriteBlock`)
2. collects `s_number_2_txs` rows with blockNumber > M and decodes each row's transaction-metadata block into the orphan tx-hash list
3. cross-checks against `s_block_number_2_nonces`: both indexes are written together in `Ledger::asyncPrewriteBlock`, so their block-number sets above M must agree. A mismatch — likewise an undecodable row or a missing `current_number` — is reported as `dbCorrupted` with a human-readable reason (distinct status, no throw); callers abort and involve ops, never self-heal.

Pure read-only, synchronous, no dependency on BaselineScheduler or Initializer. Built as a lean static lib (bcos-framework + RocksDB only) so both the future startup path and the tool link it without the full `ledger` target. `formatReport` / `dumpOrphans` helpers keep the CLI thin.

### CLI — `half-commit-check` (tools/half-commit-check/, gated by `TOOLS=ON`)

```
half-commit-check --datadir <path> [--report-only | --dump-orphans <file>]
```

Opens the datadir with `DB::OpenForReadOnly` (node must be stopped), runs the same scan, prints the report. `--dump-orphans` writes one `<blockNumber> <0xTxHash>` per line. Exit codes: 0 scan ok / 1 corruption / 2 argument error / 3 cannot open DB / 4 cannot open dump file.

Verified against crafted datadirs (healthy / orphaned / corrupted); sample orphan run:

```
currentNumber: 100
orphans: 2
  block 101, tx_count=2
  block 102, tx_count=3
```

### Tests

`bcos-ledger/test/unittests/HalfCommitCheckerTest.cpp` (7 cases, all green): healthy DB; crash-after-block-store with 3 orphans (tx hashes verified exactly, including an empty block); txs-without-nonces and nonces-without-txs mismatches; missing current_number; undecodable row; dump format. Fixtures write rows exactly as `Ledger::asyncPrewriteBlock` does (`toDBKey` keys, BlockFactory-encoded metadata/nonce blocks).

### Out of scope (follow-up PRs)

Startup integration (`BaselineSchedulerInitializer` calling the scan, PR-29), the coCommitBlock reconcile step (PR-30), and Prometheus metrics (PR-33) are follow-ups; this PR only provides the scan API they will call.

### Note on base branch state

`test-bcos-ledger` does not compile at the current release-3.18.0 tip independent of this PR: `bcos-ledger/bcos-ledger/mpt/Proof.h:405-415` still uses the pre-#5323 NodeRef field API (`child.kind` / `child.hash` / `child.inlineBytes`) after #5323 turned those into methods. This PR's tests were run with a local 3-line adaptation of Proof.h to the new API (not included here, to keep scope clean). CI on this PR will hit that pre-existing failure until it is fixed on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
