### PR TITLE
sync code: bcos-evm eth base layer - EthTransition over inlined evmone state (release-3.18.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ if(FULLNODE)
     find_package(paillier CONFIG REQUIRED)
     find_package(blst CONFIG REQUIRED)
 
+    add_subdirectory(bcos-evm)
     add_subdirectory(bcos-sealer)
     add_subdirectory(bcos-security)
     add_subdirectory(bcos-scheduler)

--- a/bcos-evm/CMakeLists.txt
+++ b/bcos-evm/CMakeLists.txt
@@ -1,0 +1,52 @@
+cmake_minimum_required(VERSION 3.25)
+
+if(NOT DEFINED PROJECT_NAME)
+    set(BCOS_EVM_STANDALONE ON)
+else()
+    set(BCOS_EVM_STANDALONE OFF)
+endif()
+
+project(bcos-evm LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(evmone CONFIG REQUIRED)
+
+add_library(bcos-evm-eth STATIC
+    bcos-evm/eth/EthTransition.cpp
+    bcos-evm/eth/state/block.cpp
+    bcos-evm/eth/state/bloom_filter.cpp
+    bcos-evm/eth/state/host.cpp
+    bcos-evm/eth/state/precompiles.cpp
+    bcos-evm/eth/state/requests.cpp
+    bcos-evm/eth/state/state.cpp
+    bcos-evm/eth/state/system_contracts.cpp)
+add_library(bcosevm::eth ALIAS bcos-evm-eth)
+target_include_directories(bcos-evm-eth PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(bcos-evm-eth PUBLIC evmone::evmone evmone::precompiles intx::intx)
+
+# 移植文件按上游原样编译；并入本仓后会继承全局 -Werror -Wall -Wextra -pedantic
+# （cmake/CompilerSettings.cmake），AppleClang 对上游代码报 missing-field-initializers。
+# vendored 代码不受本仓告警策略约束——抑制仅限移植源文件，FISCO 自有代码保持全 -Werror。
+set_source_files_properties(
+    bcos-evm/eth/state/block.cpp
+    bcos-evm/eth/state/bloom_filter.cpp
+    bcos-evm/eth/state/host.cpp
+    bcos-evm/eth/state/precompiles.cpp
+    bcos-evm/eth/state/requests.cpp
+    bcos-evm/eth/state/state.cpp
+    bcos-evm/eth/state/system_contracts.cpp
+    PROPERTIES COMPILE_OPTIONS "-Wno-missing-field-initializers")
+
+# 集成构建（主工程 add_subdirectory）下跟随主工程的 TESTS 开关，独立构建恒默认 ON；
+# 否则整树 TESTS=ON 构建/CI 也不会编译 bcos-evm-eth-tests，回归无从暴露。
+if(BCOS_EVM_STANDALONE OR TESTS)
+    set(BCOS_EVM_TESTS_DEFAULT ON)
+else()
+    set(BCOS_EVM_TESTS_DEFAULT OFF)
+endif()
+option(BCOS_EVM_TESTS "Build bcos-evm tests" ${BCOS_EVM_TESTS_DEFAULT})
+if(BCOS_EVM_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/bcos-evm/bcos-evm/adapter/StateViewAdapter.h
+++ b/bcos-evm/bcos-evm/adapter/StateViewAdapter.h
@@ -1,0 +1,19 @@
+// bcos-evm/bcos-evm/adapter/StateViewAdapter.h
+#pragma once
+
+#include <bcos-evm/eth/state/state_view.hpp>
+
+namespace bcos::evmref
+{
+/// v1 placeholder (spec §3.1/§4.1, BlockHashesAdapter is merged in here, see the "declaration
+/// deviation" section):
+/// the test backend uses evmone::test::TestState directly.
+/// When bridging a real ledger, implement the three read-only methods of evmone::state::StateView
+/// here;
+/// note that StateView is a synchronous noexcept interface and get_account_code returns the entire
+/// code by value,
+/// see spec §7.2 for the performance evaluation of bridging a coroutine-based ledger (M3.5 spike,
+/// go/no-go).
+using StateView = evmone::state::StateView;
+using BlockHashes = evmone::state::BlockHashes;
+}  // namespace bcos::evmref

--- a/bcos-evm/bcos-evm/eth/EthTransition.cpp
+++ b/bcos-evm/bcos-evm/eth/EthTransition.cpp
@@ -1,0 +1,24 @@
+#include <bcos-evm/eth/EthTransition.h>
+
+namespace bcos::evmref::eth
+{
+Result runTransaction(const evmone::state::StateView& view, const evmone::state::BlockInfo& block,
+    const evmone::state::BlockHashes& hashes, const evmone::state::Transaction& tx,
+    evmc_revision rev, evmc::VM& vm, int64_t blockGasLeft, int64_t blobGasLeft)
+{
+    const auto validated =
+        evmone::state::validate_transaction(view, block, tx, rev, blockGasLeft, blobGasLeft);
+    if (const auto* err = std::get_if<std::error_code>(&validated))
+        return *err;
+    return evmone::state::transition(view, block, hashes, tx, rev, vm,
+        std::get<evmone::state::TransactionProperties>(validated));
+}
+
+evmone::state::StateDiff runBlockFinalize(const evmone::state::StateView& view, evmc_revision rev,
+    const evmc::address& coinbase, std::optional<uint64_t> blockReward,
+    std::span<const evmone::state::Ommer> ommers,
+    std::span<const evmone::state::Withdrawal> withdrawals)
+{
+    return evmone::state::finalize(view, rev, coinbase, blockReward, ommers, withdrawals);
+}
+}  // namespace bcos::evmref::eth

--- a/bcos-evm/bcos-evm/eth/EthTransition.h
+++ b/bcos-evm/bcos-evm/eth/EthTransition.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <bcos-evm/eth/state/state.hpp>
+#include <evmc/evmc.hpp>
+#include <optional>
+#include <span>
+#include <system_error>
+#include <variant>
+
+namespace bcos::evmref::eth
+{
+/// Result of executing a single transaction: a receipt on success, or an
+/// error_code when validation fails (spec §4.2).
+using Result = std::variant<evmone::state::TransactionReceipt, std::error_code>;
+
+/// Execute a single transaction: validate -> transition (spec §4.2).
+/// The zero-fee logic reuses evmone entirely.
+///
+/// This function does NOT write back to state; the caller persists the changes
+/// via applyStateDiff(receipt.state_diff). blobGasLeft and BlockInfo.blob_base_fee
+/// are pre-computed by the caller from BlobParams (spec §2).
+///
+/// @param view          Read-only pre-state view; the source for account/storage reads.
+/// @param block         Block-level environment (coinbase, timestamp, gas limit,
+///                      base_fee, blob_base_fee, prev_randao, ...) consumed by
+///                      opcodes such as COINBASE/TIMESTAMP/BASEFEE and by gas metering.
+/// @param hashes        Provider of historical block hashes for the BLOCKHASH opcode.
+/// @param tx            The transaction to execute (from/to/value/data/gas/nonce/
+///                      access list/blob hashes, ...).
+/// @param rev           Target EVM revision (fork), selecting which EIP semantics
+///                      and gas rules apply.
+/// @param vm            The EVM instance (evmone) that runs the bytecode.
+/// @param blockGasLeft  Gas remaining in the block (block gas limit minus already
+///                      consumed); used to check the tx gas limit against the block.
+/// @param blobGasLeft   Blob gas remaining in the block; EIP-4844 blob-tx budget check.
+/// @return              A TransactionReceipt on success, or an error_code on
+///                      validation failure.
+[[nodiscard]] Result runTransaction(const evmone::state::StateView& view,
+    const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
+    const evmone::state::Transaction& tx, evmc_revision rev, evmc::VM& vm, int64_t blockGasLeft,
+    int64_t blobGasLeft);
+
+/// Block-level finalization: settle withdrawals and ommer/block rewards after all
+/// transactions in the block have executed. Pure computation — returns the diff to
+/// be written back; the caller is responsible for persisting it.
+///
+/// @param view         Read-only pre-state view.
+/// @param rev          Target EVM revision, selecting the settlement rules
+///                     (e.g. withdrawals only exist from Shanghai onwards).
+/// @param coinbase     Block producer address; recipient of block/ommer rewards.
+/// @param blockReward  Base block reward; std::nullopt means no reward
+///                     (e.g. zero post-merge). Used by the PoW reward model.
+/// @param ommers       Ommer (uncle) blocks, for computing ommer rewards (pre-merge PoW).
+/// @param withdrawals  EIP-4895 withdrawals (Shanghai+), credited to the target accounts.
+/// @return             The StateDiff to write back.
+[[nodiscard]] evmone::state::StateDiff runBlockFinalize(const evmone::state::StateView& view,
+    evmc_revision rev, const evmc::address& coinbase, std::optional<uint64_t> blockReward,
+    std::span<const evmone::state::Ommer> ommers,
+    std::span<const evmone::state::Withdrawal> withdrawals);
+}  // namespace bcos::evmref::eth

--- a/bcos-evm/bcos-evm/eth/state/account.hpp
+++ b/bcos-evm/bcos-evm/eth/state/account.hpp
@@ -1,0 +1,86 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2021 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+#include <unordered_map>
+
+namespace evmone::state
+{
+using evmc::address;
+using evmc::bytes;
+using evmc::bytes32;
+using namespace evmc::literals;
+
+/// The representation of the account storage value.
+struct StorageValue
+{
+    /// The current value.
+    bytes32 current;
+
+    /// The original value.
+    bytes32 original;
+
+    evmc_access_status access_status = EVMC_ACCESS_COLD;
+};
+
+/// The state account.
+struct Account
+{
+    /// The maximum allowed nonce value.
+    static constexpr auto NonceMax = std::numeric_limits<uint64_t>::max();
+
+    /// The keccak256 hash of the empty input. Used to identify empty account's code.
+    static constexpr auto EMPTY_CODE_HASH =
+        0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470_bytes32;
+
+    /// The account nonce.
+    uint64_t nonce = 0;
+
+    /// The account balance.
+    intx::uint256 balance;
+
+    bytes32 code_hash = EMPTY_CODE_HASH;
+
+    /// If the account has non-empty initial storage (when accessing the cold account).
+    bool has_initial_storage = false;
+
+    /// The cached and modified account storage entries.
+    std::unordered_map<bytes32, StorageValue> storage;
+
+    /// The EIP-1153 transient (transaction-level lifetime) storage.
+    std::unordered_map<bytes32, bytes32> transient_storage;
+
+    /// The cache of the account code.
+    ///
+    /// Check code_hash to know if an account code is empty.
+    /// Empty here only means it has not been loaded from the initial storage.
+    bytes code;
+
+    /// The account has been destructed and should be erased at the end of a transaction.
+    bool destructed = false;
+
+    /// The account should be erased if it is empty at the end of a transaction.
+    /// This flag means the account has been "touched" as defined in EIP-161,
+    /// or it is a newly created temporary account.
+    ///
+    /// Yellow Paper uses term "delete" but it is a keyword in C++ while
+    /// the term "erase" is used for deleting objects from C++ collections.
+    bool erase_if_empty = false;
+
+    /// The account has been created in the current transaction.
+    bool just_created = false;
+
+    // This account's code has been modified.
+    bool code_changed = false;
+
+    evmc_access_status access_status = EVMC_ACCESS_COLD;
+
+    [[nodiscard]] bool is_empty() const noexcept
+    {
+        return nonce == 0 && balance == 0 && code_hash == EMPTY_CODE_HASH;
+    }
+};
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/blob_params.hpp
+++ b/bcos-evm/bcos-evm/eth/state/blob_params.hpp
@@ -1,0 +1,23 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2025 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+
+namespace evmone::state
+{
+/// The cost of a single blob in gas units (EIP-4844).
+constexpr auto GAS_PER_BLOB = 0x20000;  // 2**17
+
+/// The maximum number of blobs that can be included in a transaction (EIP-7594).
+constexpr auto MAX_TX_BLOB_COUNT = 6;
+
+/// The blob schedule entry for an EVM revision (EIP-7840).
+struct BlobParams
+{
+    uint16_t target = 0;
+    uint16_t max = 0;
+    uint32_t base_fee_update_fraction = 0;
+};
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/block.cpp
+++ b/bcos-evm/bcos-evm/eth/state/block.cpp
@@ -1,0 +1,94 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "block.hpp"
+#include "transaction.hpp"
+
+namespace evmone::state
+{
+static constexpr auto GAS_LIMIT_ELASTICITY_MULTIPLIER = 2;
+static constexpr auto BASE_FEE_MAX_CHANGE_DENOMINATOR = 8;
+
+uint64_t calc_base_fee(
+    int64_t parent_gas_limit, int64_t parent_gas_used, uint64_t parent_base_fee) noexcept
+{
+    auto parent_gas_target = parent_gas_limit / GAS_LIMIT_ELASTICITY_MULTIPLIER;
+
+    // Special logic for block activating EIP-1559 is not implemented, because test don't cover it.
+    if (parent_gas_used == parent_gas_target)
+    {
+        return parent_base_fee;
+    }
+    else if (parent_gas_used > parent_gas_target)
+    {
+        const auto gas_used_delta = parent_gas_used - parent_gas_target;
+        const auto base_fee_delta =
+            std::max(intx::uint256{parent_base_fee} * gas_used_delta / parent_gas_target /
+                         BASE_FEE_MAX_CHANGE_DENOMINATOR,
+                intx::uint256{1});
+        return parent_base_fee + static_cast<uint64_t>(base_fee_delta);
+    }
+    else
+    {
+        const auto gas_used_delta = parent_gas_target - parent_gas_used;
+        const auto base_fee_delta = intx::uint256{parent_base_fee} * gas_used_delta /
+                                    parent_gas_target / BASE_FEE_MAX_CHANGE_DENOMINATOR;
+        return parent_base_fee - static_cast<uint64_t>(base_fee_delta);
+    }
+}
+
+uint64_t max_blob_gas_per_block(const BlobParams& blob_params) noexcept
+{
+    return blob_params.max * GAS_PER_BLOB;
+}
+
+
+intx::uint256 compute_blob_gas_price(
+    const BlobParams& blob_params, uint64_t excess_blob_gas) noexcept
+{
+    /// A helper function approximating `factor * e ** (numerator / denominator)`.
+    /// https://eips.ethereum.org/EIPS/eip-4844#helpers
+    static constexpr auto fake_exponential = [](uint64_t factor, uint64_t numerator,
+                                                 uint64_t denominator) noexcept {
+        intx::uint256 i = 1;
+        intx::uint256 output = 0;
+        intx::uint256 numerator_accum = factor * denominator;
+        const intx::uint256 numerator256 = numerator;
+        while (numerator_accum > 0)
+        {
+            output += numerator_accum;
+            // Ensure the multiplication won't overflow 256 bits.
+            if (const auto p = intx::umul(numerator_accum, numerator256);
+                p <= std::numeric_limits<intx::uint256>::max())
+                numerator_accum = intx::uint256(p) / (denominator * i);
+            else
+                return std::numeric_limits<intx::uint256>::max();
+            i += 1;
+        }
+        return output / denominator;
+    };
+
+    static constexpr auto MIN_BLOB_GASPRICE = 1;
+    const auto fraction = blob_params.base_fee_update_fraction;
+    return fake_exponential(MIN_BLOB_GASPRICE, excess_blob_gas, fraction);
+}
+
+uint64_t calc_excess_blob_gas(evmc_revision rev, const BlobParams& blob_params,
+    uint64_t parent_blob_gas_used, uint64_t parent_excess_blob_gas, uint64_t parent_base_fee,
+    const intx::uint256& parent_blob_base_fee) noexcept
+{
+    /// The base cost of a blob (EIP-7918).
+    constexpr auto BLOB_BASE_COST = 0x2000;
+
+    const auto target_blob_gas_per_block = uint64_t{blob_params.target} * GAS_PER_BLOB;
+    if (parent_excess_blob_gas + parent_blob_gas_used < target_blob_gas_per_block)
+        return 0;
+
+    if (rev >= EVMC_OSAKA && BLOB_BASE_COST * parent_base_fee > GAS_PER_BLOB * parent_blob_base_fee)
+        return parent_excess_blob_gas +
+               parent_blob_gas_used * (blob_params.max - blob_params.target) / blob_params.max;
+
+    return parent_excess_blob_gas + parent_blob_gas_used - target_blob_gas_per_block;
+}
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/block.hpp
+++ b/bcos-evm/bcos-evm/eth/state/block.hpp
@@ -1,0 +1,83 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "blob_params.hpp"
+#include "hash_utils.hpp"
+#include <intx/intx.hpp>
+#include <vector>
+
+namespace evmone::state
+{
+struct Ommer
+{
+    address beneficiary;  ///< Ommer block beneficiary address.
+    uint32_t delta = 0;   ///< Difference between current and ommer block number.
+};
+
+struct Withdrawal
+{
+    uint64_t index = 0;
+    uint64_t validator_index = 0;
+    address recipient;
+    uint64_t amount_in_gwei = 0;  ///< The amount is denominated in gwei.
+
+    /// Returns withdrawal amount in wei.
+    [[nodiscard]] intx::uint256 get_amount() const noexcept
+    {
+        return intx::uint256{amount_in_gwei} * 1'000'000'000;
+    }
+};
+
+struct BlockInfo
+{
+    int64_t number = 0;
+    int64_t timestamp = 0;
+    hash256 hash;
+    hash256 parent_hash;
+    int64_t parent_timestamp = 0;
+    int64_t gas_limit = 0;
+    int64_t gas_used = 0;
+    address coinbase;
+    int64_t difficulty = 0;
+    int64_t parent_difficulty = 0;
+    bytes extra_data;
+    hash256 parent_ommers_hash;
+    bytes32 prev_randao;
+    hash256 parent_beacon_block_root;
+
+    /// The EIP-1559 base fee, since London.
+    uint64_t base_fee = 0;
+
+    /// The "blob gas used" parameter from EIP-4844
+    std::optional<uint64_t> blob_gas_used;
+
+    /// The "excess blob gas" parameter from EIP-4844
+    /// for computing the blob gas price in the current block.
+    std::optional<uint64_t> excess_blob_gas;
+
+    /// Blob gas price from EIP-4844, computed from excess_blob_gas.
+    std::optional<intx::uint256> blob_base_fee;
+
+    std::vector<Ommer> ommers;
+    std::vector<Withdrawal> withdrawals;
+};
+
+/// Base fee per gas for the block.
+uint64_t calc_base_fee(
+    int64_t parent_gas_limit, int64_t parent_gas_used, uint64_t parent_base_fee) noexcept;
+
+/// Max amount of blob gas allowed in block.
+uint64_t max_blob_gas_per_block(const BlobParams& blob_params) noexcept;
+
+/// Computes the current blob gas price based on the excess blob gas.
+intx::uint256 compute_blob_gas_price(
+    const BlobParams& blob_params, uint64_t excess_blob_gas) noexcept;
+
+/// Computes the current excess blob gas based on parameters of the parent block.
+uint64_t calc_excess_blob_gas(evmc_revision rev, const BlobParams& blob_params,
+    uint64_t parent_blob_gas_used, uint64_t parent_excess_blob_gas, uint64_t parent_base_fee,
+    const intx::uint256& parent_blob_base_fee) noexcept;
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/bloom_filter.cpp
+++ b/bcos-evm/bcos-evm/eth/state/bloom_filter.cpp
@@ -1,0 +1,65 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "bloom_filter.hpp"
+#include "transaction.hpp"
+
+namespace evmone::state
+{
+
+namespace
+{
+/// Adds an entry to the bloom filter.
+/// based on
+/// https://ethereum.github.io/execution-specs/autoapi/ethereum/shanghai/bloom/index.html#add-to-bloom
+inline void add_to(BloomFilter& bf, const bytes_view& entry)
+{
+    const auto hash = keccak256(entry);
+
+    // take the least significant 11-bits of the first three 16-bit values
+    for (const auto i : {0, 2, 4})
+    {
+        const auto bit_to_set = ((hash.bytes[i] & 0x07) << 8) | hash.bytes[i + 1];
+        const auto bit_index = 0x07FF - bit_to_set;
+        const auto byte_index = bit_index / 8;
+        const auto bit_pos = static_cast<uint8_t>(1 << (7 - (bit_index % 8)));
+        bf.bytes[byte_index] |= bit_pos;
+    }
+}
+
+}  // namespace
+
+BloomFilter compute_bloom_filter(std::span<const Log> logs) noexcept
+{
+    BloomFilter res;
+    for (const auto& log : logs)
+    {
+        add_to(res, log.addr);
+        for (const auto& topic : log.topics)
+            add_to(res, topic);
+    }
+
+    return res;
+}
+
+BloomFilter compute_bloom_filter(std::span<const TransactionReceipt> receipts) noexcept
+{
+    BloomFilter res;
+
+    for (const auto& r : receipts)
+        std::transform(
+            res.bytes, std::end(res.bytes), r.logs_bloom_filter.bytes, res.bytes, std::bit_or<>());
+
+    return res;
+}
+
+BloomFilter bloom_filter_from_bytes(const bytes_view& data) noexcept
+{
+    assert(data.size() == 256);
+    BloomFilter res;
+    std::ranges::copy(data, res.bytes);
+    return res;
+}
+
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/bloom_filter.hpp
+++ b/bcos-evm/bcos-evm/eth/state/bloom_filter.hpp
@@ -1,0 +1,36 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include "hash_utils.hpp"
+#include <span>
+
+namespace evmone::state
+{
+struct Log;
+struct TransactionReceipt;
+
+/// The 2048-bit hash suitable for keeping an Ethereum bloom filter of transactions logs.
+struct BloomFilter
+{
+    //// The 256 bytes of the bloom filter value.
+    uint8_t bytes[256] = {};
+
+    /// Implicit operator converting to bytes_view.
+    constexpr operator bytes_view() const noexcept { return {bytes, sizeof(bytes)}; }
+};
+
+/// Computes combined bloom fitter for set of logs.
+/// It's used to compute bloom filter for single transaction.
+[[nodiscard]] BloomFilter compute_bloom_filter(std::span<const Log> logs) noexcept;
+
+/// Computes combined bloom fitter for set of TransactionReceipts
+/// It's used to compute bloom filter for a block.
+[[nodiscard]] BloomFilter compute_bloom_filter(
+    std::span<const TransactionReceipt> receipts) noexcept;
+
+/// Loads BloomFilter from bytes_view
+BloomFilter bloom_filter_from_bytes(const bytes_view& data) noexcept;
+
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/errors.hpp
+++ b/bcos-evm/bcos-evm/eth/state/errors.hpp
@@ -1,0 +1,110 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cassert>
+#include <system_error>
+
+namespace evmone::state
+{
+
+enum ErrorCode : int  // NOLINT(*-use-enum-class)
+{
+    SUCCESS = 0,
+    INTRINSIC_GAS_TOO_LOW,
+    TX_TYPE_NOT_SUPPORTED,
+    INSUFFICIENT_FUNDS,
+    NONCE_HAS_MAX_VALUE,
+    NONCE_TOO_HIGH,
+    NONCE_TOO_LOW,
+    TIP_GT_FEE_CAP,
+    FEE_CAP_LESS_THAN_BLOCKS,
+    BLOB_FEE_CAP_LESS_THAN_BLOCKS,
+    GAS_LIMIT_REACHED,
+    SENDER_NOT_EOA,
+    INIT_CODE_SIZE_LIMIT_EXCEEDED,
+    CREATE_BLOB_TX,
+    EMPTY_BLOB_HASHES_LIST,
+    INVALID_BLOB_HASH_VERSION,
+    BLOB_GAS_LIMIT_EXCEEDED,
+    CREATE_SET_CODE_TX,
+    EMPTY_AUTHORIZATION_LIST,
+    MAX_GAS_LIMIT_EXCEEDED,
+    UNKNOWN_ERROR,
+};
+
+/// Obtains a reference to the static error category object for evmone errors.
+inline const std::error_category& evmone_category() noexcept
+{
+    struct Category : std::error_category
+    {
+        [[nodiscard]] const char* name() const noexcept final { return "evmone"; }
+
+        [[nodiscard]] std::string message(int ev) const noexcept final
+        {
+            switch (ev)
+            {
+            case SUCCESS:
+                return "";
+            case INTRINSIC_GAS_TOO_LOW:
+                return "intrinsic gas too low";
+            case TX_TYPE_NOT_SUPPORTED:
+                return "transaction type not supported";
+            case INSUFFICIENT_FUNDS:
+                return "insufficient funds for gas * price + value";
+            case NONCE_HAS_MAX_VALUE:
+                return "nonce has max value:";
+            case NONCE_TOO_HIGH:
+                return "nonce too high";
+            case NONCE_TOO_LOW:
+                return "nonce too low";
+            case TIP_GT_FEE_CAP:
+                return "max priority fee per gas higher than max fee per gas";
+            case FEE_CAP_LESS_THAN_BLOCKS:
+                return "max fee per gas less than block base fee";
+            case BLOB_FEE_CAP_LESS_THAN_BLOCKS:
+                return "max blob fee per gas less than block base fee";
+            case GAS_LIMIT_REACHED:
+                return "gas limit reached";
+            case SENDER_NOT_EOA:
+                return "sender not an eoa:";
+            case INIT_CODE_SIZE_LIMIT_EXCEEDED:
+                return "max initcode size exceeded";
+            case CREATE_BLOB_TX:
+                return "blob transaction must not be a create transaction";
+            case EMPTY_BLOB_HASHES_LIST:
+                return "empty blob hashes list";
+            case INVALID_BLOB_HASH_VERSION:
+                return "invalid blob hash version";
+            case BLOB_GAS_LIMIT_EXCEEDED:
+                return "blob gas limit exceeded";
+            case CREATE_SET_CODE_TX:
+                return "set code transaction must not be a create transaction";
+            case EMPTY_AUTHORIZATION_LIST:
+                return "empty authorization list";
+            case MAX_GAS_LIMIT_EXCEEDED:
+                return "max gas limit exceeded";
+            case UNKNOWN_ERROR:
+                return "Unknown error";
+            default:
+                assert(false);
+                return "Wrong error code";
+            }
+        }
+    };
+
+    static const Category category_instance;
+    return category_instance;
+}
+
+/// Creates error_code object out of an evmone error code value.
+/// This is used by std::error_code to implement implicit conversion
+/// evmone::ErrorCode -> std::error_code, therefore the definition is
+/// in the global namespace to match the definition of ethash_errc.
+inline std::error_code make_error_code(ErrorCode errc) noexcept
+{
+    return {errc, evmone_category()};
+}
+
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/hash_utils.hpp
+++ b/bcos-evm/bcos-evm/eth/state/hash_utils.hpp
@@ -1,0 +1,34 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <evmc/hex.hpp>
+#include <evmone_precompiles/keccak.hpp>
+#include <bit>
+
+namespace evmone
+{
+using evmc::address;
+using evmc::bytes;
+using evmc::bytes32;
+using evmc::bytes_view;
+using namespace evmc::literals;
+
+/// Default type for 256-bit hash.
+///
+/// Better than ethash::hash256 because has some additional handy constructors.
+using hash256 = bytes32;
+
+/// The hash of the empty RLP list, i.e. keccak256({0xc0}).
+static constexpr auto EmptyListHash =
+    0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347_bytes32;
+
+/// Computes Keccak hash out of input bytes (wrapper of ethash::keccak256).
+inline hash256 keccak256(bytes_view data) noexcept
+{
+    return std::bit_cast<hash256>(ethash::keccak256(data.data(), data.size()));
+}
+}  // namespace evmone

--- a/bcos-evm/bcos-evm/eth/state/host.cpp
+++ b/bcos-evm/bcos-evm/eth/state/host.cpp
@@ -1,0 +1,478 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "host.hpp"
+#include "precompiles.hpp"
+#include <evmone/constants.hpp>
+
+namespace evmone::state
+{
+bool Host::account_exists(const address& addr) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    return acc != nullptr && (m_rev < EVMC_SPURIOUS_DRAGON || !acc->is_empty());
+}
+
+bytes32 Host::get_storage(const address& addr, const bytes32& key) const noexcept
+{
+    return m_state.get_storage(addr, key).current;
+}
+
+evmc_storage_status Host::set_storage(
+    const address& addr, const bytes32& key, const bytes32& value) noexcept
+{
+    // Follow EVMC documentation https://evmc.ethereum.org/storagestatus.html#autotoc_md3
+    // and EIP-2200 specification https://eips.ethereum.org/EIPS/eip-2200.
+
+    auto& storage_slot = m_state.get_storage(addr, key);
+    const auto& [current, original, _] = storage_slot;
+
+    const auto dirty = original != current;
+    const auto restored = original == value;
+    const auto current_is_zero = is_zero(current);
+    const auto value_is_zero = is_zero(value);
+
+    auto status = EVMC_STORAGE_ASSIGNED;  // All other cases.
+    if (!dirty && !restored)
+    {
+        if (current_is_zero)
+            status = EVMC_STORAGE_ADDED;  // 0 → 0 → Z
+        else if (value_is_zero)
+            status = EVMC_STORAGE_DELETED;  // X → X → 0
+        else
+            status = EVMC_STORAGE_MODIFIED;  // X → X → Z
+    }
+    else if (dirty && !restored)
+    {
+        if (current_is_zero && !value_is_zero)
+            status = EVMC_STORAGE_DELETED_ADDED;  // X → 0 → Z
+        else if (!current_is_zero && value_is_zero)
+            status = EVMC_STORAGE_MODIFIED_DELETED;  // X → Y → 0
+    }
+    else if (dirty)
+    {
+        assert(restored);  // Always true.
+        if (current_is_zero)
+            status = EVMC_STORAGE_DELETED_RESTORED;  // X → 0 → X
+        else if (value_is_zero)
+            status = EVMC_STORAGE_ADDED_DELETED;  // 0 → Y → 0
+        else
+            status = EVMC_STORAGE_MODIFIED_RESTORED;  // X → Y → X
+    }
+
+    // In Berlin this is handled in access_storage().
+    if (m_rev < EVMC_BERLIN)
+        m_state.journal_storage_change(addr, key, storage_slot);
+    storage_slot.current = value;  // Update current value.
+    return status;
+}
+
+uint256be Host::get_balance(const address& addr) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    return (acc != nullptr) ? intx::be::store<uint256be>(acc->balance) : uint256be{};
+}
+
+namespace
+{
+/// Check if an existing account is the "create collision"
+/// as defined in the [EIP-7610](https://eips.ethereum.org/EIPS/eip-7610).
+[[nodiscard]] bool is_create_collision(const Account& acc) noexcept
+{
+    // TODO: This requires much more testing:
+    // - what if an account had storage but is destructed?
+    // - what if an account had cold storage but it was emptied?
+    // - what if an account without cold storage gain one?
+    if (acc.nonce != 0)
+        return true;
+    if (acc.code_hash != Account::EMPTY_CODE_HASH)
+        return true;
+    if (acc.has_initial_storage)
+        return true;
+
+    // The hot storage is ignored because it can contain elements from access list.
+    // TODO: Is this correct for destructed accounts?
+    assert(!acc.destructed && "untested");
+    return false;
+}
+}  // namespace
+
+size_t Host::get_code_size(const address& addr) const noexcept
+{
+    const auto raw_code = m_state.get_code(addr);
+    return raw_code.size();
+}
+
+bytes32 Host::get_code_hash(const address& addr) const noexcept
+{
+    const auto* const acc = m_state.find(addr);
+    if (acc == nullptr || acc->is_empty())
+        return {};
+
+    return acc->code_hash;
+}
+
+size_t Host::copy_code(const address& addr, size_t code_offset, uint8_t* buffer_data,
+    size_t buffer_size) const noexcept
+{
+    const auto code = m_state.get_code(addr);
+    const auto code_slice = code.substr(std::min(code_offset, code.size()));
+    const auto num_bytes = std::min(buffer_size, code_slice.size());
+    std::copy_n(code_slice.begin(), num_bytes, buffer_data);
+    return num_bytes;
+}
+
+bool Host::selfdestruct(const address& addr, const address& beneficiary) noexcept
+{
+    if (m_state.find(beneficiary) == nullptr)
+        m_state.journal_create(beneficiary, false);
+    auto& acc = m_state.get(addr);
+    const auto balance = acc.balance;
+    auto& beneficiary_acc = m_state.touch(beneficiary);
+
+    m_state.journal_balance_change(beneficiary, beneficiary_acc.balance);
+    m_state.journal_balance_change(addr, balance);
+
+    if (m_rev >= EVMC_CANCUN && !acc.just_created)
+    {
+        // EIP-6780:
+        // "SELFDESTRUCT is executed in a transaction that is not the same
+        // as the contract invoking SELFDESTRUCT was created"
+        acc.balance = 0;
+        beneficiary_acc.balance += balance;  // Keep balance if acc is the beneficiary.
+
+        // Return "selfdestruct not registered".
+        // In practice this affects only refunds before Cancun.
+        return false;
+    }
+
+    // Transfer may happen multiple times per single account as account's balance
+    // can be increased with a call following previous selfdestruct.
+    beneficiary_acc.balance += balance;
+    acc.balance = 0;  // Zero balance if acc is the beneficiary.
+
+    // Mark the destruction if not done already.
+    if (!acc.destructed)
+    {
+        m_state.journal_destruct(addr);
+        acc.destructed = true;
+        return true;
+    }
+    return false;
+}
+
+address compute_create_address(const address& sender, uint64_t sender_nonce) noexcept
+{
+    static constexpr auto RLP_STR_BASE = 0x80;
+    static constexpr auto RLP_LIST_BASE = 0xc0;
+    static constexpr auto ADDRESS_SIZE = sizeof(sender);
+    static constexpr std::ptrdiff_t MAX_NONCE_SIZE = sizeof(sender_nonce);
+
+    uint8_t buffer[ADDRESS_SIZE + MAX_NONCE_SIZE + 3];  // 3 for RLP prefix bytes.
+    auto p = &buffer[1];                                // Skip RLP list prefix for now.
+    *p++ = RLP_STR_BASE + ADDRESS_SIZE;                 // Set RLP string prefix for address.
+    p = std::copy_n(sender.bytes, ADDRESS_SIZE, p);
+
+    if (sender_nonce < RLP_STR_BASE)  // Short integer encoding including 0 as empty string (0x80).
+    {
+        *p++ = sender_nonce != 0 ? static_cast<uint8_t>(sender_nonce) : RLP_STR_BASE;
+    }
+    else  // Prefixed integer encoding.
+    {
+        // TODO: bit_width returns int after [LWG 3656](https://cplusplus.github.io/LWG/issue3656).
+        // NOLINTNEXTLINE(readability-redundant-casting)
+        const auto num_nonzero_bytes = static_cast<int>((std::bit_width(sender_nonce) + 7) / 8);
+        *p++ = static_cast<uint8_t>(RLP_STR_BASE + num_nonzero_bytes);
+        intx::be::unsafe::store(p, sender_nonce);
+        p = std::shift_left(p, p + MAX_NONCE_SIZE, MAX_NONCE_SIZE - num_nonzero_bytes);
+    }
+
+    const auto total_size = static_cast<size_t>(p - buffer);
+    buffer[0] = static_cast<uint8_t>(RLP_LIST_BASE + (total_size - 1));  // Set the RLP list prefix.
+
+    const auto base_hash = keccak256({buffer, total_size});
+    address addr;
+    std::copy_n(&base_hash.bytes[sizeof(base_hash) - ADDRESS_SIZE], ADDRESS_SIZE, addr.bytes);
+    return addr;
+}
+
+address compute_create2_address(
+    const address& sender, const bytes32& salt, bytes_view init_code) noexcept
+{
+    const auto init_code_hash = keccak256(init_code);
+    uint8_t buffer[1 + sizeof(sender) + sizeof(salt) + sizeof(init_code_hash)];
+    static_assert(std::size(buffer) == 85);
+    auto it = std::begin(buffer);
+    *it++ = 0xff;
+    it = std::copy_n(sender.bytes, sizeof(sender), it);
+    it = std::copy_n(salt.bytes, sizeof(salt), it);
+    std::copy_n(init_code_hash.bytes, sizeof(init_code_hash), it);
+    const auto base_hash = keccak256({buffer, std::size(buffer)});
+    address addr;
+    std::copy_n(&base_hash.bytes[sizeof(base_hash) - sizeof(addr)], sizeof(addr), addr.bytes);
+    return addr;
+}
+
+std::optional<evmc_message> Host::prepare_message(evmc_message msg) noexcept
+{
+    assert(msg.kind != EVMC_EOFCREATE);
+    if (msg.depth == 0 || msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+    {
+        auto& sender_acc = m_state.get(msg.sender);
+
+        // EIP-2681 (already checked for depth 0 during transaction validation).
+        if (sender_acc.nonce == Account::NonceMax)
+            return {};  // Light early exception.
+
+        if (msg.depth != 0)
+        {
+            m_state.journal_bump_nonce(msg.sender);
+            ++sender_acc.nonce;  // Bump sender nonce.
+        }
+
+        if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+        {
+            // Compute and set the address of the account being created.
+            assert(msg.recipient == address{});
+            assert(msg.code_address == address{});
+            // Nonce was already incremented, but creation calculation needs non-incremented value
+            assert(sender_acc.nonce != 0);
+            const auto creation_sender_nonce = sender_acc.nonce - 1;
+            if (msg.kind == EVMC_CREATE)
+                msg.recipient = compute_create_address(msg.sender, creation_sender_nonce);
+            else
+            {
+                assert(msg.kind == EVMC_CREATE2);
+                msg.recipient = compute_create2_address(
+                    msg.sender, msg.create2_salt, {msg.input_data, msg.input_size});
+            }
+
+            // By EIP-2929, the access to new created address is never reverted.
+            access_account(msg.recipient);
+        }
+    }
+
+    return msg;
+}
+
+evmc::Result Host::create(const evmc_message& msg) noexcept
+{
+    assert(msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2);
+
+    auto* new_acc = m_state.find(msg.recipient);
+    const bool new_acc_exists = new_acc != nullptr;
+    if (!new_acc_exists)
+        new_acc = &m_state.insert(msg.recipient);
+    else if (is_create_collision(*new_acc))
+        return evmc::Result{EVMC_FAILURE};  // TODO: Add EVMC errors for creation failures.
+    m_state.journal_create(msg.recipient, new_acc_exists);
+
+    assert(new_acc != nullptr);
+    assert(new_acc->nonce == 0);
+
+    if (m_rev >= EVMC_SPURIOUS_DRAGON)
+        new_acc->nonce = 1;  // No need to journal: create revert will 0 the nonce.
+
+    new_acc->just_created = true;
+
+    auto& sender_acc = m_state.get(msg.sender);  // TODO: Duplicated account lookup.
+    const auto value = intx::be::load<intx::uint256>(msg.value);
+    assert(sender_acc.balance >= value && "EVM must guarantee balance");
+    m_state.journal_balance_change(msg.sender, sender_acc.balance);
+    m_state.journal_balance_change(msg.recipient, new_acc->balance);
+    sender_acc.balance -= value;
+    new_acc->balance += value;  // The new account may be prefunded.
+
+    auto create_msg = msg;
+    create_msg.input_data = nullptr;
+    create_msg.input_size = 0;
+    const bytes_view initcode{msg.input_data, msg.input_size};
+    auto result = m_vm.execute(*this, m_rev, create_msg, initcode.data(), initcode.size());
+    if (result.status_code != EVMC_SUCCESS)
+    {
+        result.create_address = msg.recipient;
+        return result;
+    }
+
+    auto gas_left = result.gas_left;
+    assert(gas_left >= 0);
+
+    const bytes_view code{result.output_data, result.output_size};
+
+    if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > MAX_CODE_SIZE)
+        return evmc::Result{EVMC_FAILURE};
+
+    // Code deployment cost.
+    const auto cost = std::ssize(code) * 200;
+    gas_left -= cost;
+    if (gas_left < 0)
+    {
+        return (m_rev == EVMC_FRONTIER) ?
+                   evmc::Result{EVMC_SUCCESS, result.gas_left, result.gas_refund, msg.recipient} :
+                   evmc::Result{EVMC_FAILURE};
+    }
+
+    if (!code.empty())
+    {
+        // EIP-3541: Reject new contract code starting with the 0xEF byte.
+        if (m_rev >= EVMC_LONDON && code[0] == 0xEF)
+            return evmc::Result{EVMC_CONTRACT_VALIDATION_FAILURE};
+
+        new_acc->code_hash = keccak256(code);
+        new_acc->code = code;
+        new_acc->code_changed = true;
+    }
+
+    return evmc::Result{result.status_code, gas_left, result.gas_refund, msg.recipient};
+}
+
+evmc::Result Host::execute_message(const evmc_message& msg) noexcept
+{
+    assert(msg.kind != EVMC_EOFCREATE);
+    if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+        return create(msg);
+
+    if (msg.kind == EVMC_CALL)
+    {
+        const auto exists = m_state.find(msg.recipient) != nullptr;
+        if (!exists)
+            m_state.journal_create(msg.recipient, exists);
+    }
+
+    if (msg.kind == EVMC_CALL)
+    {
+        if (evmc::is_zero(msg.value))
+            m_state.touch(msg.recipient);
+        else
+        {
+            // We skip touching if we send value, because account cannot end up empty.
+            // It will either have value, or code that transfers this value out, or will be
+            // selfdestructed anyway.
+            auto& dst_acc = m_state.get_or_insert(msg.recipient);
+
+            // Transfer value: sender → recipient.
+            // The sender's balance is already checked therefore the sender account must exist.
+            const auto value = intx::be::load<intx::uint256>(msg.value);
+            assert(m_state.get(msg.sender).balance >= value);
+            m_state.journal_balance_change(msg.sender, m_state.get(msg.sender).balance);
+            m_state.journal_balance_change(msg.recipient, dst_acc.balance);
+            m_state.get(msg.sender).balance -= value;
+            dst_acc.balance += value;
+        }
+    }
+
+    // Calls to precompile address via EIP-7702 delegation execute empty code instead of precompile.
+    if ((msg.flags & EVMC_DELEGATED) == 0 && is_precompile(m_rev, msg.code_address))
+        return call_precompile(m_rev, msg);
+
+    // TODO: get_code() performs the account lookup. Add a way to get an account with code?
+    const auto code = m_state.get_code(msg.code_address);
+    if (code.empty())
+        return evmc::Result{EVMC_SUCCESS, msg.gas};  // Skip trivial execution.
+
+    return m_vm.execute(*this, m_rev, msg, code.data(), code.size());
+}
+
+evmc::Result Host::call(const evmc_message& orig_msg) noexcept
+{
+    const auto msg = prepare_message(orig_msg);
+    if (!msg.has_value())
+        return evmc::Result{EVMC_FAILURE, orig_msg.gas};  // Light exception.
+
+    const auto logs_checkpoint = m_logs.size();
+    const auto state_checkpoint = m_state.checkpoint();
+
+    auto result = execute_message(*msg);
+
+    if (result.status_code != EVMC_SUCCESS)
+    {
+        static constexpr auto addr_03 = 0x03_address;
+        auto* const acc_03 = m_state.find(addr_03);
+        const auto is_03_touched = acc_03 != nullptr && acc_03->erase_if_empty;
+
+        // Revert.
+        m_state.rollback(state_checkpoint);
+        m_logs.resize(logs_checkpoint);
+
+        // The 0x03 quirk: the touch on this address is never reverted.
+        if (is_03_touched && m_rev >= EVMC_SPURIOUS_DRAGON)
+            m_state.touch(addr_03);
+    }
+    return result;
+}
+
+evmc_tx_context Host::get_tx_context() const noexcept
+{
+    // TODO: The effective gas price is already computed in transaction validation.
+    // TODO: The effective gas price calculation is broken for system calls (gas price 0).
+    assert(m_tx.max_gas_price >= m_block.base_fee || m_tx.max_gas_price == 0);
+    const auto priority_gas_price =
+        std::min(m_tx.max_priority_gas_price, m_tx.max_gas_price - m_block.base_fee);
+    const auto effective_gas_price = m_block.base_fee + priority_gas_price;
+
+    return evmc_tx_context{
+        intx::be::store<uint256be>(effective_gas_price),  // By EIP-1559.
+        m_tx.sender,
+        m_block.coinbase,
+        m_block.number,
+        m_block.timestamp,
+        m_block.gas_limit,
+        m_block.prev_randao,
+        0x01_bytes32,  // Chain ID is expected to be 1.
+        uint256be{m_block.base_fee},
+        intx::be::store<uint256be>(m_block.blob_base_fee.value_or(0)),
+        m_tx.blob_hashes.data(),
+        m_tx.blob_hashes.size(),
+    };
+}
+
+bytes32 Host::get_block_hash(int64_t block_number) const noexcept
+{
+    return m_block_hashes.get_block_hash(block_number);
+}
+
+void Host::emit_log(const address& addr, const uint8_t* data, size_t data_size,
+    const bytes32 topics[], size_t topics_count) noexcept
+{
+    m_logs.push_back({addr, {data, data_size}, {topics, topics + topics_count}});
+}
+
+evmc_access_status Host::access_account(const address& addr) noexcept
+{
+    if (m_rev < EVMC_BERLIN)
+        return EVMC_ACCESS_COLD;  // Ignore before Berlin.
+
+    auto& acc = m_state.get_or_insert(addr, {.erase_if_empty = true});
+
+    if (acc.access_status == EVMC_ACCESS_WARM || is_precompile(m_rev, addr))
+        return EVMC_ACCESS_WARM;
+
+    m_state.journal_access_account(addr);
+    acc.access_status = EVMC_ACCESS_WARM;
+    return EVMC_ACCESS_COLD;
+}
+
+evmc_access_status Host::access_storage(const address& addr, const bytes32& key) noexcept
+{
+    auto& storage_slot = m_state.get_storage(addr, key);
+    m_state.journal_storage_change(addr, key, storage_slot);
+    return std::exchange(storage_slot.access_status, EVMC_ACCESS_WARM);
+}
+
+
+evmc::bytes32 Host::get_transient_storage(const address& addr, const bytes32& key) const noexcept
+{
+    const auto& acc = m_state.get(addr);
+    const auto it = acc.transient_storage.find(key);
+    return it != acc.transient_storage.end() ? it->second : bytes32{};
+}
+
+void Host::set_transient_storage(
+    const address& addr, const bytes32& key, const bytes32& value) noexcept
+{
+    auto& slot = m_state.get(addr).transient_storage[key];
+    m_state.journal_transient_storage_change(addr, key, slot);
+    slot = value;
+}
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/host.hpp
+++ b/bcos-evm/bcos-evm/eth/state/host.hpp
@@ -1,0 +1,108 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "state.hpp"
+#include "state_view.hpp"
+#include <optional>
+
+namespace evmone::state
+{
+using evmc::uint256be;
+
+/// Computes the address of to-be-created contract with the CREATE scheme.
+///
+/// Computes the new account address for the contract creation context of the CREATE instruction
+/// or a create transaction.
+/// This is defined by 𝐀𝐃𝐃𝐑 in Yellow Paper, 7. Contract Creation, (88-90), the case for ζ = ∅.
+///
+/// @param sender        The address of the message sender. YP: 𝑠.
+/// @param sender_nonce  The sender's nonce before the increase. YP: 𝑛.
+/// @return              The address computed with the CREATE scheme.
+[[nodiscard]] address compute_create_address(const address& sender, uint64_t sender_nonce) noexcept;
+
+/// Computes the address of to-be-created contract with the CREATE2 scheme.
+///
+/// Computes the new account address for the contract creation context of the CREATE2 instruction.
+///
+/// @param sender        The address of the message sender.
+/// @param salt          The salt.
+/// @param init_code     The init_code to hash (initcode or initcontainer).
+/// @return              The address computed with the scheme.
+[[nodiscard]] address compute_create2_address(
+    const address& sender, const bytes32& salt, bytes_view init_code) noexcept;
+
+class Host : public evmc::Host
+{
+    evmc_revision m_rev;
+    evmc::VM& m_vm;
+    State& m_state;
+    const BlockInfo& m_block;
+    const BlockHashes& m_block_hashes;
+    const Transaction& m_tx;
+    std::vector<Log> m_logs;
+
+public:
+    Host(evmc_revision rev, evmc::VM& vm, State& state, const BlockInfo& block,
+        const BlockHashes& block_hashes, const Transaction& tx) noexcept
+      : m_rev{rev}, m_vm{vm}, m_state{state}, m_block{block}, m_block_hashes{block_hashes}, m_tx{tx}
+    {}
+
+    [[nodiscard]] std::vector<Log>&& take_logs() noexcept { return std::move(m_logs); }
+
+    evmc::Result call(const evmc_message& msg) noexcept override;
+
+private:
+    [[nodiscard]] bool account_exists(const address& addr) const noexcept override;
+
+    [[nodiscard]] bytes32 get_storage(
+        const address& addr, const bytes32& key) const noexcept override;
+
+    evmc_storage_status set_storage(
+        const address& addr, const bytes32& key, const bytes32& value) noexcept override;
+
+    [[nodiscard]] evmc::bytes32 get_transient_storage(
+        const address& addr, const bytes32& key) const noexcept override;
+
+    void set_transient_storage(
+        const address& addr, const bytes32& key, const bytes32& value) noexcept override;
+
+    [[nodiscard]] uint256be get_balance(const address& addr) const noexcept override;
+
+    [[nodiscard]] size_t get_code_size(const address& addr) const noexcept override;
+
+    [[nodiscard]] bytes32 get_code_hash(const address& addr) const noexcept override;
+
+    size_t copy_code(const address& addr, size_t code_offset, uint8_t* buffer_data,
+        size_t buffer_size) const noexcept override;
+
+    bool selfdestruct(const address& addr, const address& beneficiary) noexcept override;
+
+    evmc::Result create(const evmc_message& msg) noexcept;
+
+    [[nodiscard]] evmc_tx_context get_tx_context() const noexcept override;
+
+    [[nodiscard]] bytes32 get_block_hash(int64_t block_number) const noexcept override;
+
+    void emit_log(const address& addr, const uint8_t* data, size_t data_size,
+        const bytes32 topics[], size_t topics_count) noexcept override;
+
+public:
+    evmc_access_status access_account(const address& addr) noexcept override;
+
+private:
+    evmc_access_status access_storage(const address& addr, const bytes32& key) noexcept override;
+
+    /// Prepares message for execution.
+    ///
+    /// This contains mostly checks and logic related to the sender
+    /// which may finally be moved to EVM.
+    /// Any state modification is not reverted.
+    /// @return Modified message or std::nullopt in case of EVM exception.
+    std::optional<evmc_message> prepare_message(evmc_message msg) noexcept;
+
+    evmc::Result execute_message(const evmc_message& msg) noexcept;
+};
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/precompiles.cpp
+++ b/bcos-evm/bcos-evm/eth/state/precompiles.cpp
@@ -1,0 +1,875 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "precompiles.hpp"
+#include "../utils/stdx/utility.hpp"
+#include "evmone_precompiles/secp256r1.hpp"
+#include "precompiles_internal.hpp"
+#include <evmone_precompiles/blake2b.hpp>
+#include <evmone_precompiles/bls.hpp>
+#include <evmone_precompiles/bn254.hpp>
+#include <evmone_precompiles/kzg.hpp>
+#include <evmone_precompiles/modexp.hpp>
+#include <evmone_precompiles/ripemd160.hpp>
+#include <evmone_precompiles/secp256k1.hpp>
+#include <evmone_precompiles/sha256.hpp>
+#include <intx/intx.hpp>
+#include <array>
+#include <bit>
+#include <cassert>
+#include <limits>
+#include <span>
+
+#ifdef EVMONE_PRECOMPILES_LIBSECP256K1
+#include "precompiles_libsecp256k1.hpp"
+#endif
+
+#ifdef EVMONE_PRECOMPILES_GMP
+#include "precompiles_gmp.hpp"
+#endif
+
+namespace evmone::state
+{
+using evmc::bytes;
+using evmc::bytes_view;
+using namespace evmc::literals;
+
+namespace
+{
+constexpr auto GasCostMax = std::numeric_limits<int64_t>::max();
+
+constexpr auto MODEXP_LEN_LIMIT_EIP7823 = 1024;
+
+constexpr auto BLS12_SCALAR_SIZE = 32;
+constexpr auto BLS12_FIELD_ELEMENT_SIZE = 64;
+constexpr auto BLS12_G1_POINT_SIZE = 2 * BLS12_FIELD_ELEMENT_SIZE;
+constexpr auto BLS12_G2_POINT_SIZE = 4 * BLS12_FIELD_ELEMENT_SIZE;
+constexpr auto BLS12_G1_MUL_INPUT_SIZE = BLS12_G1_POINT_SIZE + BLS12_SCALAR_SIZE;
+constexpr auto BLS12_G2_MUL_INPUT_SIZE = BLS12_G2_POINT_SIZE + BLS12_SCALAR_SIZE;
+
+constexpr int64_t num_words(size_t size_in_bytes) noexcept
+{
+    return static_cast<int64_t>((size_in_bytes + 31) / 32);
+}
+
+template <int BaseCost, int WordCost>
+constexpr int64_t cost_per_input_word(size_t input_size) noexcept
+{
+    return BaseCost + WordCost * num_words(input_size);
+}
+}  // namespace
+
+PrecompileAnalysis ecrecover_analyze(bytes_view /*input*/, evmc_revision /*rev*/) noexcept
+{
+    return {3000, 32};
+}
+
+PrecompileAnalysis sha256_analyze(bytes_view input, evmc_revision /*rev*/) noexcept
+{
+    return {cost_per_input_word<60, 12>(input.size()), 32};
+}
+
+PrecompileAnalysis ripemd160_analyze(bytes_view input, evmc_revision /*rev*/) noexcept
+{
+    return {cost_per_input_word<600, 120>(input.size()), 32};
+}
+
+PrecompileAnalysis identity_analyze(bytes_view input, evmc_revision /*rev*/) noexcept
+{
+    return {cost_per_input_word<15, 3>(input.size()), input.size()};
+}
+
+PrecompileAnalysis ecadd_analyze(bytes_view /*input*/, evmc_revision rev) noexcept
+{
+    return {rev >= EVMC_ISTANBUL ? 150 : 500, 64};
+}
+
+PrecompileAnalysis ecmul_analyze(bytes_view /*input*/, evmc_revision rev) noexcept
+{
+    return {rev >= EVMC_ISTANBUL ? 6000 : 40000, 64};
+}
+
+PrecompileAnalysis ecpairing_analyze(bytes_view input, evmc_revision rev) noexcept
+{
+    const auto base_cost = (rev >= EVMC_ISTANBUL) ? 45000 : 100000;
+    const auto element_cost = (rev >= EVMC_ISTANBUL) ? 34000 : 80000;
+    const auto num_elements = static_cast<int64_t>(input.size() / 192);
+    return {base_cost + num_elements * element_cost, 32};
+}
+
+PrecompileAnalysis blake2bf_analyze(bytes_view input, evmc_revision) noexcept
+{
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
+    return {input.size() == 213 ? intx::be::unsafe::load<uint32_t>(input.data()) : GasCostMax, 64};
+}
+
+PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
+{
+    using namespace intx;
+
+    const auto calc_adjusted_exp_len = [input, rev](size_t offset, uint32_t len) noexcept {
+        const auto head_len = std::min(size_t{len}, size_t{32});
+        const auto head_explicit_bytes =
+            offset < input.size() ?
+                input.substr(offset, std::min(head_len, input.size() - offset)) :
+                bytes_view{};
+
+        const auto top_byte_index = head_explicit_bytes.find_first_not_of(uint8_t{0});
+        const auto exp_bit_width =
+            (top_byte_index != bytes_view::npos) ?
+                8 * (head_len - top_byte_index - 1) +
+                    static_cast<unsigned>(std::bit_width(head_explicit_bytes[top_byte_index])) :
+                0;
+
+        const auto tail_len = len - head_len;
+        const auto head_bits = std::max(exp_bit_width, size_t{1}) - 1;
+        const uint64_t factor = rev < EVMC_OSAKA ? 8 : 16;
+        return std::max(factor * uint64_t{tail_len} + uint64_t{head_bits}, uint64_t{1});
+    };
+
+    static constexpr auto calc_mult_complexity_eip7883 = [](uint32_t max_len) noexcept {
+        // With EIP-7823 the computation never overflows.
+        assert(max_len <= MODEXP_LEN_LIMIT_EIP7823);
+        const auto num_words = (max_len + 7) / 8;
+        const auto mult_complexity = max_len <= 32 ? 16 : num_words * num_words * 2;
+        return uint64_t{mult_complexity};
+    };
+    static constexpr auto calc_mult_complexity_eip2565 = [](uint32_t max_len) noexcept {
+        const auto num_words = (uint64_t{max_len} + 7) / 8;
+        return num_words * num_words;  // max value: 0x04000000'00000000
+    };
+    static constexpr auto calc_mult_complexity_eip198 = [](uint32_t max_len) noexcept {
+        const auto max_len_squared = uint64_t{max_len} * max_len;
+        if (max_len <= 64)
+            return max_len_squared;
+        if (max_len <= 1024)
+            return max_len_squared / 4 + 96 * max_len - 3072;
+        // max value: 0x100001df'dffcf220
+        return max_len_squared / 16 + 480 * uint64_t{max_len} - 199680;
+    };
+
+    struct Params
+    {
+        int64_t min_gas;
+        unsigned final_divisor;
+        uint64_t (*calc_mult_complexity)(uint32_t max_len) noexcept;
+    };
+    const auto& [min_gas, final_divisor, calc_mult_complexity] = [rev]() noexcept -> Params {
+        if (rev >= EVMC_OSAKA)
+            return {500, 1, calc_mult_complexity_eip7883};
+        else if (rev >= EVMC_BERLIN)
+            return {200, 3, calc_mult_complexity_eip2565};
+        else  // Byzantium
+            return {0, 20, calc_mult_complexity_eip198};
+    }();
+
+    static constexpr size_t INPUT_HEADER_REQUIRED_SIZE = 3 * sizeof(uint256);
+    uint8_t input_header[INPUT_HEADER_REQUIRED_SIZE]{};
+    // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
+    std::copy_n(input.data(), std::min(input.size(), INPUT_HEADER_REQUIRED_SIZE), input_header);
+
+    const auto base_len256 = be::unsafe::load<uint256>(&input_header[0]);
+    const auto exp_len256 = be::unsafe::load<uint256>(&input_header[32]);
+    const auto mod_len256 = be::unsafe::load<uint256>(&input_header[64]);
+
+    // Check the declared input lengths against the practical (2**32)
+    // or specified (EIP-7823: 2**10) limits.
+    const auto len_limit =
+        rev < EVMC_OSAKA ? std::numeric_limits<uint32_t>::max() : MODEXP_LEN_LIMIT_EIP7823;
+    if (base_len256 > len_limit || mod_len256 > len_limit)
+        return {GasCostMax, 0};
+
+    if (exp_len256 > len_limit)
+    {
+        // Before EIP-7823, the big exponent may be canceled with zero multiplication complexity.
+        if (rev < EVMC_OSAKA && base_len256 == 0 && mod_len256 == 0)
+            return {min_gas, 0};
+        return {GasCostMax, 0};
+    }
+
+    const auto base_len = static_cast<uint32_t>(base_len256);
+    const auto exp_len = static_cast<uint32_t>(exp_len256);
+    const auto mod_len = static_cast<uint32_t>(mod_len256);
+
+    const auto adjusted_exp_len = calc_adjusted_exp_len(sizeof(input_header) + base_len, exp_len);
+    const auto max_len = std::max(mod_len, base_len);
+    const auto gas = umul(calc_mult_complexity(max_len), adjusted_exp_len) / final_divisor;
+    const auto gas_clamped = std::clamp<uint128>(gas, min_gas, GasCostMax);
+    return {static_cast<int64_t>(gas_clamped), mod_len};
+}
+
+PrecompileAnalysis point_evaluation_analyze(bytes_view, evmc_revision) noexcept
+{
+    static constexpr auto POINT_EVALUATION_PRECOMPILE_GAS = 50000;
+    return {POINT_EVALUATION_PRECOMPILE_GAS, 64};
+}
+
+PrecompileAnalysis bls12_g1add_analyze(bytes_view, evmc_revision) noexcept
+{
+    static constexpr auto BLS12_G1ADD_PRECOMPILE_GAS = 375;
+    return {BLS12_G1ADD_PRECOMPILE_GAS, BLS12_G1_POINT_SIZE};
+}
+
+PrecompileAnalysis bls12_g1msm_analyze(bytes_view input, evmc_revision) noexcept
+{
+    static constexpr auto G1MUL_GAS_COST = 12000;
+    static constexpr uint16_t DISCOUNTS[] = {1000, 949, 848, 797, 764, 750, 738, 728, 719, 712, 705,
+        698, 692, 687, 682, 677, 673, 669, 665, 661, 658, 654, 651, 648, 645, 642, 640, 637, 635,
+        632, 630, 627, 625, 623, 621, 619, 617, 615, 613, 611, 609, 608, 606, 604, 603, 601, 599,
+        598, 596, 595, 593, 592, 591, 589, 588, 586, 585, 584, 582, 581, 580, 579, 577, 576, 575,
+        574, 573, 572, 570, 569, 568, 567, 566, 565, 564, 563, 562, 561, 560, 559, 558, 557, 556,
+        555, 554, 553, 552, 551, 550, 549, 548, 547, 547, 546, 545, 544, 543, 542, 541, 540, 540,
+        539, 538, 537, 536, 536, 535, 534, 533, 532, 532, 531, 530, 529, 528, 528, 527, 526, 525,
+        525, 524, 523, 522, 522, 521, 520, 520, 519};
+
+    if (input.empty() || input.size() % BLS12_G1_MUL_INPUT_SIZE != 0)
+        return {GasCostMax, 0};
+
+    const auto k = input.size() / BLS12_G1_MUL_INPUT_SIZE;
+    assert(k > 0);
+    const auto discount = DISCOUNTS[std::min(k, std::size(DISCOUNTS)) - 1];
+    const auto cost = (G1MUL_GAS_COST * discount * static_cast<int64_t>(k)) / 1000;
+    return {cost, BLS12_G1_POINT_SIZE};
+}
+
+PrecompileAnalysis bls12_g2add_analyze(bytes_view, evmc_revision) noexcept
+{
+    static constexpr auto BLS12_G2ADD_PRECOMPILE_GAS = 600;
+    return {BLS12_G2ADD_PRECOMPILE_GAS, BLS12_G2_POINT_SIZE};
+}
+
+PrecompileAnalysis bls12_g2msm_analyze(bytes_view input, evmc_revision) noexcept
+{
+    static constexpr auto G2MUL_GAS_COST = 22500;
+    static constexpr uint16_t DISCOUNTS[] = {1000, 1000, 923, 884, 855, 832, 812, 796, 782, 770,
+        759, 749, 740, 732, 724, 717, 711, 704, 699, 693, 688, 683, 679, 674, 670, 666, 663, 659,
+        655, 652, 649, 646, 643, 640, 637, 634, 632, 629, 627, 624, 622, 620, 618, 615, 613, 611,
+        609, 607, 606, 604, 602, 600, 598, 597, 595, 593, 592, 590, 589, 587, 586, 584, 583, 582,
+        580, 579, 578, 576, 575, 574, 573, 571, 570, 569, 568, 567, 566, 565, 563, 562, 561, 560,
+        559, 558, 557, 556, 555, 554, 553, 552, 552, 551, 550, 549, 548, 547, 546, 545, 545, 544,
+        543, 542, 541, 541, 540, 539, 538, 537, 537, 536, 535, 535, 534, 533, 532, 532, 531, 530,
+        530, 529, 528, 528, 527, 526, 526, 525, 524, 524};
+
+    if (input.empty() || input.size() % BLS12_G2_MUL_INPUT_SIZE != 0)
+        return {GasCostMax, 0};
+
+    const auto k = input.size() / BLS12_G2_MUL_INPUT_SIZE;
+    assert(k > 0);
+    const auto discount = DISCOUNTS[std::min(k, std::size(DISCOUNTS)) - 1];
+    const auto cost = (G2MUL_GAS_COST * discount * static_cast<int64_t>(k)) / 1000;
+    return {cost, BLS12_G2_POINT_SIZE};
+}
+
+PrecompileAnalysis bls12_pairing_check_analyze(bytes_view input, evmc_revision) noexcept
+{
+    static constexpr auto PAIR_SIZE = BLS12_G1_POINT_SIZE + BLS12_G2_POINT_SIZE;
+
+    if (input.empty() || input.size() % PAIR_SIZE != 0)
+        return {GasCostMax, 0};
+
+    const auto npairs = static_cast<int64_t>(input.size()) / PAIR_SIZE;
+
+    static constexpr auto BLS12_PAIRING_CHECK_BASE_FEE_PRECOMPILE_GAS = 37700;
+    static constexpr auto BLS12_PAIRING_CHECK_FEE_PRECOMPILE_GAS = 32600;
+    return {BLS12_PAIRING_CHECK_BASE_FEE_PRECOMPILE_GAS +
+                BLS12_PAIRING_CHECK_FEE_PRECOMPILE_GAS * npairs,
+        32};
+}
+
+PrecompileAnalysis bls12_map_fp_to_g1_analyze(bytes_view, evmc_revision) noexcept
+{
+    static constexpr auto BLS12_MAP_FP_TO_G1_PRECOMPILE_GAS = 5500;
+    return {BLS12_MAP_FP_TO_G1_PRECOMPILE_GAS, BLS12_G1_POINT_SIZE};
+}
+
+PrecompileAnalysis bls12_map_fp2_to_g2_analyze(bytes_view, evmc_revision) noexcept
+{
+    static constexpr auto BLS12_MAP_FP2_TO_G2_PRECOMPILE_GAS = 23800;
+    return {BLS12_MAP_FP2_TO_G2_PRECOMPILE_GAS, BLS12_G2_POINT_SIZE};
+}
+
+PrecompileAnalysis p256verify_analyze(bytes_view, evmc_revision) noexcept
+{
+    return {6900, 32};
+}
+
+namespace
+{
+class EcrecoverInput
+{
+    uint8_t buffer_[128]{};
+
+public:
+    explicit EcrecoverInput(std::span<const uint8_t> input) noexcept
+    {
+        std::copy_n(input.data(), std::min(input.size(), std::size(buffer_)), buffer_);
+    }
+
+    std::optional<std::tuple<std::span<const uint8_t, 32>, std::span<const uint8_t, 64>, bool>>
+    parse() const noexcept
+    {
+        const auto hash = std::span{buffer_}.subspan<0, 32>();
+        const auto v_bytes = std::span{buffer_}.subspan<32, 32>();
+        const auto sig_bytes = std::span{buffer_}.subspan<64, 64>();
+
+        const auto v = intx::be::unsafe::load<intx::uint256>(v_bytes.data());
+        if (v != 27 && v != 28)
+            return std::nullopt;
+        const bool parity = v == 28;
+
+        return std::tuple{hash, sig_bytes, parity};
+    }
+};
+
+}  // namespace
+
+ExecutionResult ecrecover_execute_evmone(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    const EcrecoverInput input_buffer{std::span{input, input_size}};
+    const auto o = input_buffer.parse();
+    if (!o)
+        return {EVMC_SUCCESS, 0};
+    const auto& [hash, sig_bytes, parity] = *o;
+
+    const auto res = evmmax::secp256k1::ecrecover(
+        hash, sig_bytes.subspan<0, 32>(), sig_bytes.subspan<32, 32>(), parity);
+    if (!res)
+        return {EVMC_SUCCESS, 0};
+
+    const auto it = std::fill_n(output, 32 - sizeof(*res), 0);
+    std::copy_n(res->bytes, sizeof(*res), it);
+    return {EVMC_SUCCESS, 32};
+}
+
+#ifdef EVMONE_PRECOMPILES_LIBSECP256K1
+ExecutionResult ecrecover_execute_libsecp256k1(const uint8_t* input, size_t input_size,
+    uint8_t* output, [[maybe_unused]] size_t output_size) noexcept
+{
+    const EcrecoverInput input_buffer{std::span{input, input_size}};
+    const auto o = input_buffer.parse();
+    if (!o)
+        return {EVMC_SUCCESS, 0};
+    const auto& [hash, sig_bytes, parity] = *o;
+
+    uint8_t pubkey[64];
+    if (!ecrecover_libsecp256k1(pubkey, hash, sig_bytes, parity))
+        return {EVMC_SUCCESS, 0};
+
+    const auto addr = evmmax::secp256k1::to_address(pubkey);
+    const auto it = std::fill_n(output, 32 - sizeof(addr), 0);
+    std::copy_n(addr.bytes, sizeof(addr), it);
+    return {EVMC_SUCCESS, 32};
+}
+#endif
+
+ExecutionResult ecrecover_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept
+{
+    assert(output_size >= 32);
+// Select better implementation.
+#ifdef EVMONE_PRECOMPILES_LIBSECP256K1
+    return ecrecover_execute_libsecp256k1(input, input_size, output, output_size);
+#else
+    return ecrecover_execute_evmone(input, input_size, output, output_size);
+#endif
+}
+
+ExecutionResult sha256_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    assert(output_size >= 32);
+    crypto::sha256(reinterpret_cast<std::byte*>(output), reinterpret_cast<const std::byte*>(input),
+        input_size);
+    return {EVMC_SUCCESS, 32};
+}
+
+ExecutionResult ripemd160_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    assert(output_size >= 32);
+    output = std::fill_n(output, 12, std::uint8_t{0});
+    crypto::ripemd160(reinterpret_cast<std::byte*>(output),
+        reinterpret_cast<const std::byte*>(input), input_size);
+    return {EVMC_SUCCESS, 32};
+}
+
+static std::tuple<std::span<const uint8_t>, std::span<const uint8_t>, std::span<const uint8_t>>
+expmod_parse_input(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept
+{
+    static constexpr auto LEN_SIZE = sizeof(intx::uint256);
+    static constexpr auto HEADER_SIZE = 3 * LEN_SIZE;
+    static constexpr auto LEN32_OFF = LEN_SIZE - sizeof(uint32_t);
+
+    // The output size equal to the modulus size.
+    const auto mod_len = output_size;
+
+    // Handle short incomplete input up front. The answer is 0 of the length of the modulus.
+    if (input_size <= HEADER_SIZE) [[unlikely]]
+    {
+        std::fill_n(output, output_size, 0);
+        return {};
+    }
+
+    const auto base_len = intx::be::unsafe::load<uint32_t>(&input[LEN32_OFF]);
+    const auto exp_len = intx::be::unsafe::load<uint32_t>(&input[LEN_SIZE + LEN32_OFF]);
+    assert(intx::be::unsafe::load<uint32_t>(&input[2 * LEN_SIZE + LEN32_OFF]) == mod_len);
+
+    const size_t mod_off = base_len + exp_len;  // Cannot overflow if gas cost computed before.
+    const size_t payload_max_size = mod_off + mod_len;  // Input may contain extra bytes.
+    const std::span payload{
+        input + HEADER_SIZE, std::min(input_size - HEADER_SIZE, payload_max_size)};
+    const auto mod_explicit = payload.subspan(std::min(mod_off, payload.size()));
+
+    // Handle the mod being zero early.
+    // This serves two purposes:
+    // - bigint libraries don't like such a modulus because division by 0 is not well-defined,
+    // - having non-zero modulus guarantees that base and exp aren't out-of-bounds.
+    if (std::ranges::all_of(mod_explicit, [](uint8_t b) { return b == 0; })) [[unlikely]]
+    {
+        // The modulus is zero, so the result is zero.
+        std::fill_n(output, output_size, 0);
+        return {};
+    }
+
+    const auto mod_requires_padding = mod_explicit.size() != mod_len;
+    if (mod_requires_padding) [[unlikely]]
+    {
+        // The modulus is the last argument, and some of its bytes may be missing and be implicitly
+        // zero. In this case, copy the explicit modulus bytes to the output buffer and pad the rest
+        // with zeroes. The output buffer is guaranteed to have exactly the modulus size.
+        const auto [_, output_p] = std::ranges::copy(mod_explicit, output);
+        std::fill(output_p, output + output_size, 0);
+    }
+
+    const auto base = payload.subspan(0, base_len);
+    const auto exp = payload.subspan(base_len, exp_len);
+    const auto mod = mod_requires_padding ? std::span{output, mod_len} : mod_explicit;
+
+    return {base, exp, mod};
+}
+
+ExecutionResult expmod_execute_evmone(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept
+{
+    const auto [base, exp, mod] = expmod_parse_input(input, input_size, output, output_size);
+    if (mod.empty())
+        return {EVMC_SUCCESS, output_size};
+
+    crypto::modexp(base, exp, mod, output);
+    return {EVMC_SUCCESS, output_size};
+}
+
+#ifdef EVMONE_PRECOMPILES_GMP
+ExecutionResult expmod_execute_gmp(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept
+{
+    const auto [base, exp, mod] = expmod_parse_input(input, input_size, output, output_size);
+    if (mod.empty())
+        return {EVMC_SUCCESS, output_size};
+
+    expmod_gmp(base, exp, mod, output);
+    return {EVMC_SUCCESS, output_size};
+}
+#endif
+
+ExecutionResult expmod_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept
+{
+#ifdef EVMONE_PRECOMPILES_GMP
+    return expmod_execute_gmp(input, input_size, output, output_size);
+#else
+    return expmod_execute_evmone(input, input_size, output, output_size);
+#endif
+}
+
+ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    assert(output_size >= 64);
+
+    uint8_t input_buffer[128]{};
+    if (input_size != 0)
+        std::memcpy(input_buffer, input, std::min(input_size, std::size(input_buffer)));
+
+    const auto input_span = std::span{input_buffer};
+
+    using namespace evmmax::bn254;
+
+    const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
+    const auto q = AffinePoint::from_bytes(input_span.subspan<64, 64>());
+    if (!p.has_value() || !q.has_value()) [[unlikely]]
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+    if (!validate(*p) || !validate(*q)) [[unlikely]]
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    const auto res = evmmax::ecc::add_affine(*p, *q);
+    const std::span<uint8_t, 64> output_span{output, 64};
+    res.to_bytes(output_span);
+    return {EVMC_SUCCESS, output_span.size()};
+}
+
+ExecutionResult ecmul_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    assert(output_size >= 64);
+
+    uint8_t input_buffer[96]{};
+    if (input_size != 0)
+        std::memcpy(input_buffer, input, std::min(input_size, std::size(input_buffer)));
+
+    const auto input_span = std::span{input_buffer};
+
+    using namespace evmmax::bn254;
+
+    const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
+    if (!p.has_value() || !validate(*p)) [[unlikely]]
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    const auto c = intx::be::unsafe::load<uint256>(input_buffer + 64);
+
+    const auto res = evmmax::bn254::mul(*p, c);
+    const std::span<uint8_t, 64> output_span{output, 64};
+    res.to_bytes(output_span);
+    return {EVMC_SUCCESS, output_span.size()};
+}
+
+ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    static constexpr auto OUTPUT_SIZE = 32;
+    static constexpr size_t PAIR_SIZE = 192;
+    assert(output_size >= OUTPUT_SIZE);
+
+    if (input_size % PAIR_SIZE != 0)
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    std::vector<std::pair<evmmax::bn254::Point, evmmax::bn254::ExtPoint>> pairs;
+    pairs.reserve(input_size / PAIR_SIZE);  // TODO: may throw std::bad_alloc.
+    for (auto input_ptr = input; input_ptr != input + input_size; input_ptr += PAIR_SIZE)
+    {
+        const evmmax::bn254::Point p{
+            intx::be::unsafe::load<intx::uint256>(input_ptr),
+            intx::be::unsafe::load<intx::uint256>(input_ptr + 32),
+        };
+        const evmmax::bn254::ExtPoint q{
+            {intx::be::unsafe::load<intx::uint256>(input_ptr + 96),
+                intx::be::unsafe::load<intx::uint256>(input_ptr + 64)},
+            {intx::be::unsafe::load<intx::uint256>(input_ptr + 160),
+                intx::be::unsafe::load<intx::uint256>(input_ptr + 128)},
+        };
+        pairs.emplace_back(p, q);
+    }
+
+    const auto res = evmmax::bn254::pairing_check(pairs);
+    if (!res.has_value())
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    std::fill_n(output, OUTPUT_SIZE, 0);
+    output[OUTPUT_SIZE - 1] = *res ? 1 : 0;
+    return {EVMC_SUCCESS, OUTPUT_SIZE};
+}
+
+ExecutionResult identity_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    assert(output_size >= input_size);
+    std::copy_n(input, input_size, output);
+    return {EVMC_SUCCESS, input_size};
+}
+
+ExecutionResult blake2bf_execute(const uint8_t* input, [[maybe_unused]] size_t input_size,
+    uint8_t* output, [[maybe_unused]] size_t output_size) noexcept
+{
+    static_assert(std::endian::native == std::endian::little,
+        "blake2bf only works correctly on little-endian architectures");
+    assert(input_size >= 213);
+    assert(output_size >= 64);
+
+    const auto rounds = intx::be::unsafe::load<uint32_t>(input);
+    input += sizeof(rounds);
+
+    uint64_t h[8];
+    std::memcpy(h, input, sizeof(h));
+    input += sizeof(h);
+
+    uint64_t m[16];
+    std::memcpy(m, input, sizeof(m));
+    input += sizeof(m);
+
+    uint64_t t[2];
+    std::memcpy(t, input, sizeof(t));
+    input += sizeof(t);
+
+    const auto f = *input;
+    if (f != 0 && f != 1) [[unlikely]]
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    crypto::blake2b_compress(rounds, h, m, t, f != 0);
+    std::memcpy(output, h, sizeof(h));
+    return {EVMC_SUCCESS, sizeof(h)};
+}
+
+ExecutionResult point_evaluation_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    assert(output_size >= 64);
+    if (input_size != 192)
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    const auto r = crypto::kzg_verify_proof(reinterpret_cast<const std::byte*>(&input[0]),
+        reinterpret_cast<const std::byte*>(&input[32]),
+        reinterpret_cast<const std::byte*>(&input[64]),
+        reinterpret_cast<const std::byte*>(&input[96]),
+        reinterpret_cast<const std::byte*>(&input[96 + 48]));
+
+    if (!r)
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    // Return FIELD_ELEMENTS_PER_BLOB and BLS_MODULUS as padded 32 byte big endian values
+    // as required by the EIP-4844.
+    intx::be::unsafe::store(output, crypto::FIELD_ELEMENTS_PER_BLOB);
+    intx::be::unsafe::store(output + 32, crypto::BLS_MODULUS);
+    return {EVMC_SUCCESS, 64};
+}
+
+ExecutionResult bls12_g1add_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    if (input_size != 2 * BLS12_G1_POINT_SIZE)
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    assert(output_size == BLS12_G1_POINT_SIZE);
+
+    if (!crypto::bls::g1_add(output, &output[64], input, &input[64], &input[128], &input[192]))
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    return {EVMC_SUCCESS, BLS12_G1_POINT_SIZE};
+}
+
+ExecutionResult bls12_g1msm_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    // Checked in `_analyze` function which must be called before.
+    assert(input_size % BLS12_G1_MUL_INPUT_SIZE == 0);
+    assert(output_size == BLS12_G1_POINT_SIZE);
+
+    if (input_size == BLS12_G1_MUL_INPUT_SIZE)
+    {
+        // Optimize single multiplication case.
+        if (!crypto::bls::g1_mul(output, &output[64], input, &input[64], &input[128]))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
+    else
+    {
+        // TODO: g1_msm() may throw std::bad_alloc.
+        if (!crypto::bls::g1_msm(output, &output[64], input, input_size))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
+
+    return {EVMC_SUCCESS, BLS12_G1_POINT_SIZE};
+}
+
+ExecutionResult bls12_g2add_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    if (input_size != 2 * BLS12_G2_POINT_SIZE)
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    assert(output_size == BLS12_G2_POINT_SIZE);
+
+    if (!crypto::bls::g2_add(output, &output[128], input, &input[128], &input[256], &input[384]))
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    return {EVMC_SUCCESS, BLS12_G2_POINT_SIZE};
+}
+
+ExecutionResult bls12_g2msm_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    // Checked in `_analyze` function which must be called before.
+    assert(input_size % BLS12_G2_MUL_INPUT_SIZE == 0);
+    assert(output_size == BLS12_G2_POINT_SIZE);
+
+    if (input_size == BLS12_G2_MUL_INPUT_SIZE)
+    {
+        // Optimize single multiplication case.
+        if (!crypto::bls::g2_mul(output, &output[128], input, &input[128], &input[256]))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
+    else
+    {
+        // TODO: g2_msm() may throw std::bad_alloc.
+        if (!crypto::bls::g2_msm(output, &output[128], input, input_size))
+            return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
+
+    return {EVMC_SUCCESS, BLS12_G2_POINT_SIZE};
+}
+
+ExecutionResult bls12_pairing_check_execute(const uint8_t* input, size_t input_size,
+    uint8_t* output, [[maybe_unused]] size_t output_size) noexcept
+{
+    // Checked in `_analyze` function which must be called before.
+    assert(input_size % (BLS12_G1_POINT_SIZE + BLS12_G2_POINT_SIZE) == 0);
+    assert(output_size == 32);
+
+    if (!crypto::bls::pairing_check(output, input, input_size))
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    return {EVMC_SUCCESS, 32};
+}
+
+ExecutionResult bls12_map_fp_to_g1_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    if (input_size != BLS12_FIELD_ELEMENT_SIZE)
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    assert(output_size == BLS12_G1_POINT_SIZE);
+
+    if (!crypto::bls::map_fp_to_g1(output, &output[64], input))
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    return {EVMC_SUCCESS, BLS12_G1_POINT_SIZE};
+}
+
+ExecutionResult bls12_map_fp2_to_g2_execute(const uint8_t* input, size_t input_size,
+    uint8_t* output, [[maybe_unused]] size_t output_size) noexcept
+{
+    if (input_size != 2 * BLS12_FIELD_ELEMENT_SIZE)
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    assert(output_size == BLS12_G2_POINT_SIZE);
+
+    if (!crypto::bls::map_fp2_to_g2(output, &output[128], input))
+        return {EVMC_PRECOMPILE_FAILURE, 0};
+
+    return {EVMC_SUCCESS, BLS12_G2_POINT_SIZE};
+}
+
+ExecutionResult p256verify_execute(const uint8_t* input, size_t input_size, uint8_t* output,
+    [[maybe_unused]] size_t output_size) noexcept
+{
+    assert(output_size >= 32);
+
+    if (input_size != 160)
+        return {EVMC_SUCCESS, 0};
+
+    ethash::hash256 h{};
+    std::copy_n(input, sizeof(h), h.bytes);
+    const auto r = intx::be::unsafe::load<intx::uint256>(input + 32);
+    const auto s = intx::be::unsafe::load<intx::uint256>(input + 64);
+    const auto qx = intx::be::unsafe::load<intx::uint256>(input + 96);
+    const auto qy = intx::be::unsafe::load<intx::uint256>(input + 128);
+
+    if (!evmmax::secp256r1::verify(h, r, s, qx, qy))
+        return {EVMC_SUCCESS, 0};  // In case of invalid signature, return empty output.
+
+    // Return 1_u256.
+    std::fill_n(output, 31, 0);
+    output[31] = 1;
+    return {EVMC_SUCCESS, 32};
+}
+
+namespace
+{
+using PrecompileLookupIndex = uint16_t;
+
+struct PrecompileTraits
+{
+    PrecompileLookupIndex address = 0;
+    evmc_revision since = EVMC_FRONTIER;
+    decltype(identity_analyze)* analyze = nullptr;
+    decltype(identity_execute)* execute = nullptr;
+};
+
+inline constexpr std::array<PrecompileTraits, 18> traits{{
+    {0x0001, EVMC_FRONTIER, ecrecover_analyze, ecrecover_execute},
+    {0x0002, EVMC_FRONTIER, sha256_analyze, sha256_execute},
+    {0x0003, EVMC_FRONTIER, ripemd160_analyze, ripemd160_execute},
+    {0x0004, EVMC_FRONTIER, identity_analyze, identity_execute},
+    {0x0005, EVMC_BYZANTIUM, expmod_analyze, expmod_execute},
+    {0x0006, EVMC_BYZANTIUM, ecadd_analyze, ecadd_execute},
+    {0x0007, EVMC_BYZANTIUM, ecmul_analyze, ecmul_execute},
+    {0x0008, EVMC_BYZANTIUM, ecpairing_analyze, ecpairing_execute},
+    {0x0009, EVMC_ISTANBUL, blake2bf_analyze, blake2bf_execute},
+    {0x000a, EVMC_CANCUN, point_evaluation_analyze, point_evaluation_execute},
+    {0x000b, EVMC_PRAGUE, bls12_g1add_analyze, bls12_g1add_execute},
+    {0x000c, EVMC_PRAGUE, bls12_g1msm_analyze, bls12_g1msm_execute},
+    {0x000d, EVMC_PRAGUE, bls12_g2add_analyze, bls12_g2add_execute},
+    {0x000e, EVMC_PRAGUE, bls12_g2msm_analyze, bls12_g2msm_execute},
+    {0x000f, EVMC_PRAGUE, bls12_pairing_check_analyze, bls12_pairing_check_execute},
+    {0x0010, EVMC_PRAGUE, bls12_map_fp_to_g1_analyze, bls12_map_fp_to_g1_execute},
+    {0x0011, EVMC_PRAGUE, bls12_map_fp2_to_g2_analyze, bls12_map_fp2_to_g2_execute},
+    {0x0100, EVMC_OSAKA, p256verify_analyze, p256verify_execute},
+}};
+
+constexpr auto LOOKUP_TABLE_SIZE = [] {
+    PrecompileLookupIndex max_idx = 0;
+    for (const auto& trait : traits)
+        max_idx = std::max(max_idx, trait.address);
+    return max_idx + 1;
+}();
+
+PrecompileLookupIndex to_lookup_index(const evmc::address& addr) noexcept
+{
+    static constexpr auto ADDRESS_SIZE = sizeof(addr.bytes);
+    return static_cast<PrecompileLookupIndex>(
+        (addr.bytes[ADDRESS_SIZE - 2] << 8) | addr.bytes[ADDRESS_SIZE - 1]);
+}
+}  // namespace
+
+bool is_precompile(evmc_revision rev, const evmc::address& addr) noexcept
+{
+    static constexpr auto AVAILABILITY_LOOKUP_TABLE = [] {
+        using Entry = std::underlying_type_t<evmc_revision>;
+        std::array<Entry, LOOKUP_TABLE_SIZE> table{};
+        std::ranges::fill(table, std::numeric_limits<Entry>::max());
+        for (const auto& trait : traits)
+            table[trait.address] = stdx::to_underlying(trait.since);
+        return table;
+    }();
+
+    if (addr >= evmc::address{AVAILABILITY_LOOKUP_TABLE.size()})
+        return false;
+    return AVAILABILITY_LOOKUP_TABLE[to_lookup_index(addr)] <= stdx::to_underlying(rev);
+}
+
+evmc::Result call_precompile(evmc_revision rev, const evmc_message& msg) noexcept
+{
+    static constexpr auto EXECUTION_LOOKUP_TABLE = [] {
+        struct Entry
+        {
+            decltype(PrecompileTraits::analyze) analyze = nullptr;
+            decltype(PrecompileTraits::execute) execute = nullptr;
+        };
+        std::array<Entry, LOOKUP_TABLE_SIZE> table{};
+        for (const auto& trait : traits)
+            table[trait.address] = {trait.analyze, trait.execute};
+        return table;
+    }();
+
+    assert(msg.gas >= 0);
+
+    const auto [analyze, execute] = EXECUTION_LOOKUP_TABLE[to_lookup_index(msg.code_address)];
+
+    const bytes_view input{msg.input_data, msg.input_size};
+    const auto [gas_cost, max_output_size] = analyze(input, rev);
+    const auto gas_left = msg.gas - gas_cost;
+    if (gas_left < 0)
+        return evmc::Result{EVMC_OUT_OF_GAS};
+
+    // Allocate buffer for the precompile's output and pass its ownership to evmc::Result.
+    // TODO: This can be done more elegantly by providing constructor evmc::Result(std::unique_ptr).
+    const auto output_data = new (std::nothrow) uint8_t[max_output_size];  // TODO: handle nullptr.
+    const auto [status_code, output_size] =
+        execute(msg.input_data, msg.input_size, output_data, max_output_size);
+    const evmc_result result{status_code, status_code == EVMC_SUCCESS ? gas_left : 0, 0,
+        output_data, output_size,
+        [](const evmc_result* res) noexcept { delete[] res->output_data; }};
+    return evmc::Result{result};
+}
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/precompiles.hpp
+++ b/bcos-evm/bcos-evm/eth/state/precompiles.hpp
@@ -1,0 +1,38 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+
+namespace evmone::state
+{
+/// The precompile identifiers.
+enum class PrecompileId : uint8_t
+{
+    ecrecover,
+    sha256,
+    ripemd160,
+    identity,
+    expmod,
+    ecadd,
+    ecmul,
+    ecpairing,
+    blake2bf,
+    point_evaluation,
+    bls12_g1add,
+    bls12_g1msm,
+    bls12_g2add,
+    bls12_g2msm,
+    bls12_pairing_check,
+    bls12_map_fp_to_g1,
+    bls12_map_fp2_to_g2,
+    p256verify,
+};
+
+/// Checks if the address @p addr is considered a precompiled contract in the revision @p rev.
+bool is_precompile(evmc_revision rev, const evmc::address& addr) noexcept;
+
+/// Executes the message to a precompiled contract (msg.code_address must be a precompile).
+evmc::Result call_precompile(evmc_revision rev, const evmc_message& msg) noexcept;
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/precompiles_internal.hpp
+++ b/bcos-evm/bcos-evm/eth/state/precompiles_internal.hpp
@@ -1,0 +1,81 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2024 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+
+namespace evmone::state
+{
+struct ExecutionResult
+{
+    evmc_status_code status_code;
+    size_t output_size;
+};
+
+struct PrecompileAnalysis
+{
+    int64_t gas_cost;
+    size_t max_output_size;
+};
+
+PrecompileAnalysis ecrecover_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis sha256_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis ripemd160_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis identity_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis expmod_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis ecadd_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis ecmul_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis ecpairing_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis blake2bf_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis point_evaluation_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis bls12_g1add_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis bls12_g1msm_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis bls12_g2add_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis bls12_g2msm_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis bls12_pairing_check_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis bls12_map_fp_to_g1_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis bls12_map_fp2_to_g2_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+PrecompileAnalysis p256verify_analyze(evmc::bytes_view input, evmc_revision rev) noexcept;
+
+ExecutionResult ecrecover_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult ecrecover_execute_evmone(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult sha256_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult ripemd160_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult identity_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult expmod_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult expmod_execute_evmone(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult ecadd_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult ecmul_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult blake2bf_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult ecpairing_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult point_evaluation_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult bls12_g1add_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult bls12_g1msm_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult bls12_g2add_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult bls12_g2msm_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult bls12_pairing_check_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult bls12_map_fp_to_g1_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult bls12_map_fp2_to_g2_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+ExecutionResult p256verify_execute(
+    const uint8_t* input, size_t input_size, uint8_t* output, size_t output_size) noexcept;
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/requests.cpp
+++ b/bcos-evm/bcos-evm/eth/state/requests.cpp
@@ -1,0 +1,151 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2024 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "requests.hpp"
+#include <evmone_precompiles/sha256.hpp>
+
+namespace evmone::state
+{
+namespace
+{
+consteval uint32_t pad_to_words(uint32_t size) noexcept
+{
+    return ((size + 31) / 32) * 32;
+}
+}  // namespace
+
+hash256 calculate_requests_hash(std::span<const Requests> block_requests_list)
+{
+    bytes requests_hash_list;
+    requests_hash_list.reserve(sizeof(hash256) * block_requests_list.size());
+
+    for (const auto& requests : block_requests_list)
+    {
+        if (requests.data().empty())
+            continue;  // Skip empty requests.
+
+        hash256 requests_hash;
+        crypto::sha256(reinterpret_cast<std::byte*>(requests_hash.bytes),
+            reinterpret_cast<const std::byte*>(requests.raw_data.data()), requests.raw_data.size());
+        requests_hash_list += requests_hash;
+    }
+
+    hash256 block_requests_hash;
+    crypto::sha256(reinterpret_cast<std::byte*>(block_requests_hash.bytes),
+        reinterpret_cast<const std::byte*>(requests_hash_list.data()), requests_hash_list.size());
+    return block_requests_hash;
+}
+
+std::optional<Requests> collect_deposit_requests(std::span<const TransactionReceipt> receipts)
+{
+    // Browse all logs from all transactions.
+    Requests requests(Requests::Type::deposit);
+    for (const auto& receipt : receipts)
+    {
+        for (const auto& log : receipt.logs)
+        {
+            // Follow the EIP-6110 pseudocode for block validity.
+            // https://eips.ethereum.org/EIPS/eip-6110#block-validity
+
+            // Filter out logs by the contact address and the log first topic.
+            if (log.addr != DEPOSIT_CONTRACT_ADDRESS)
+                continue;
+            if (log.topics.empty() || log.topics[0] != DEPOSIT_EVENT_SIGNATURE_HASH)
+                continue;
+
+            // Validate the layout of the log. If it doesn't match the EIP spec,
+            // the requests' collection is failed.
+            if (log.data.size() != 576)
+                return std::nullopt;
+
+            // Deposit log definition
+            // https://github.com/ethereum/consensus-specs/blob/dev/solidity_deposit_contract/deposit_contract.sol
+            // event DepositEvent(
+            //     bytes pubkey,
+            //     bytes withdrawal_credentials,
+            //     bytes amount,
+            //     bytes signature,
+            //     bytes index
+            // );
+            //
+            // In ABI a word with its size prepends every bytes array.
+            // Skip over the first 5 words (offsets of the values) and the pubkey size.
+            // Read and validate the ABI offsets and lengths for the dynamic fields
+            // according to EIP-6110. If any check fails, collection is considered failed.
+
+            const auto read_word_as_size = [&](size_t pos) -> std::optional<uint32_t> {
+                assert(log.data.size() >= pos + 32);
+                const auto v = intx::be::unsafe::load<uint256>(&log.data[pos]);
+                // Ensure the encoded bytes fit into uint32_t.
+                if (v > std::numeric_limits<uint32_t>::max())
+                    return std::nullopt;
+                return static_cast<uint32_t>(v);
+            };
+
+            static constexpr uint32_t WORD = 32;
+            assert(log.data.size() >= WORD * 5);
+
+            // Read the 5 offsets from the head (first 5 words).
+            std::array<uint32_t, 5> offsets = {};
+            for (size_t i = 0; i < offsets.size(); ++i)
+            {
+                const auto w = read_word_as_size(i * WORD);
+                if (!w)
+                    return std::nullopt;
+                offsets[i] = *w;
+            }
+
+            // Compute expected offsets and lengths (hard-coded from the deposit ABI layout).
+            static constexpr uint32_t DATA_SECTION =
+                WORD * 5;  // where the dynamic data area starts
+            static constexpr uint32_t PUBKEY_OFFSET = DATA_SECTION;
+            static constexpr uint32_t PUBKEY_SIZE = 48;
+            static constexpr uint32_t WITHDRAWAL_OFFSET =
+                PUBKEY_OFFSET + WORD + pad_to_words(PUBKEY_SIZE);
+            static constexpr uint32_t WITHDRAWAL_SIZE = 32;
+            static constexpr uint32_t AMOUNT_OFFSET =
+                WITHDRAWAL_OFFSET + WORD + pad_to_words(WITHDRAWAL_SIZE);
+            static constexpr uint32_t AMOUNT_SIZE = 8;
+            static constexpr uint32_t SIGNATURE_OFFSET =
+                AMOUNT_OFFSET + WORD + pad_to_words(AMOUNT_SIZE);
+            static constexpr uint32_t SIGNATURE_SIZE = 96;
+            static constexpr uint32_t INDEX_OFFSET =
+                SIGNATURE_OFFSET + WORD + pad_to_words(SIGNATURE_SIZE);
+            static constexpr uint32_t INDEX_SIZE = 8;
+
+            // Offsets in the head point to the length-word of each dynamic field.
+            static constexpr std::array EXPECTED_OFFSETS{
+                PUBKEY_OFFSET, WITHDRAWAL_OFFSET, AMOUNT_OFFSET, SIGNATURE_OFFSET, INDEX_OFFSET};
+
+            if (offsets != EXPECTED_OFFSETS)
+                return std::nullopt;  // layout does not match expected EIP-6110 deposit layout
+
+            // Validate sizes of each field encoded in the log.
+            const auto validate_size_at = [&](uint32_t offset, uint32_t expected_size) -> bool {
+                const auto size = read_word_as_size(offset);
+                return size.has_value() && (*size == expected_size);
+            };
+            if (!validate_size_at(PUBKEY_OFFSET, PUBKEY_SIZE) ||
+                !validate_size_at(WITHDRAWAL_OFFSET, WITHDRAWAL_SIZE) ||
+                !validate_size_at(AMOUNT_OFFSET, AMOUNT_SIZE) ||
+                !validate_size_at(SIGNATURE_OFFSET, SIGNATURE_SIZE) ||
+                !validate_size_at(INDEX_OFFSET, INDEX_SIZE))
+            {
+                // field size does not match expected EIP-6110 deposit layout
+                return std::nullopt;
+            }
+
+            // Index is padded to the word boundary, so takes 32 bytes.
+            assert(log.data.size() == INDEX_OFFSET + WORD + pad_to_words(INDEX_SIZE));
+
+            requests.append({&log.data[PUBKEY_OFFSET + WORD], PUBKEY_SIZE});
+            requests.append({&log.data[WITHDRAWAL_OFFSET + WORD], WITHDRAWAL_SIZE});
+            requests.append({&log.data[AMOUNT_OFFSET + WORD], AMOUNT_SIZE});
+            requests.append({&log.data[SIGNATURE_OFFSET + WORD], SIGNATURE_SIZE});
+            requests.append({&log.data[INDEX_OFFSET + WORD], INDEX_SIZE});
+        }
+    }
+    return requests;
+}
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/requests.hpp
+++ b/bcos-evm/bcos-evm/eth/state/requests.hpp
@@ -1,0 +1,72 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2024 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "hash_utils.hpp"
+#include "transaction.hpp"
+#include <evmc/evmc.hpp>
+#include <span>
+
+namespace evmone::state
+{
+/// The address of the deposit contract.
+///
+/// TODO: This address differs in different chains, so it should be configurable.
+constexpr auto DEPOSIT_CONTRACT_ADDRESS = 0x00000000219ab540356cBB839Cbe05303d7705Fa_address;
+
+/// The topic of deposit log of the deposit contract.
+constexpr auto DEPOSIT_EVENT_SIGNATURE_HASH =
+    0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5_bytes32;
+
+/// `requests` object.
+///
+/// Defined by EIP-7685: General purpose execution layer requests.
+/// https://eips.ethereum.org/EIPS/eip-7685.
+struct Requests
+{
+    /// The type of the requests.
+    enum class Type : uint8_t
+    {
+        /// Deposit requests.
+        /// Introduced by EIP-6110 https://eips.ethereum.org/EIPS/eip-6110.
+        deposit = 0,
+
+        /// Withdrawal requests.
+        /// Introduced by EIP-7002 https://eips.ethereum.org/EIPS/eip-7002.
+        withdrawal = 1,
+
+        /// Consolidation requests.
+        /// Introduced by EIP-7251 https://eips.ethereum.org/EIPS/eip-7251.
+        consolidation = 2,
+    };
+
+    /// Raw encoded data of requests object: first byte is type, the rest is request objects.
+    bytes raw_data;
+
+    explicit Requests(Type _type, bytes_view data = {})
+    {
+        raw_data.reserve(1 + data.size());
+        raw_data += static_cast<uint8_t>(_type);
+        raw_data += data;
+    }
+
+    /// Requests type.
+    Type type() const noexcept { return static_cast<Type>(raw_data[0]); }
+
+    /// Requests data - an opaque byte array, contains zero or more encoded request objects.
+    bytes_view data() const noexcept { return {raw_data.data() + 1, raw_data.size() - 1}; }
+
+    /// Append data to requests object byte array.
+    void append(bytes_view data) { raw_data.append(data); }
+};
+
+/// Calculate commitment value of block requests list
+hash256 calculate_requests_hash(std::span<const Requests> requests_list);
+
+/// Construct a requests object from logs of the deposit contract.
+///
+/// @return The collected deposit requests or std::nullopt if the collection has failed.
+std::optional<Requests> collect_deposit_requests(std::span<const TransactionReceipt> receipts);
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/state.cpp
+++ b/bcos-evm/bcos-evm/eth/state/state.cpp
@@ -1,0 +1,650 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "state.hpp"
+#include "../utils/stdx/utility.hpp"
+#include "host.hpp"
+#include "state_view.hpp"
+#include <evmone/constants.hpp>
+#include <evmone/delegation.hpp>
+#include <evmone_precompiles/secp256k1.hpp>
+#include <algorithm>
+
+using namespace intx;
+
+namespace evmone::state
+{
+namespace
+{
+/// Secp256k1's N/2 is the upper bound of the signature's s value.
+constexpr auto SECP256K1N_OVER_2 = evmmax::secp256k1::Curve::ORDER / 2;
+/// EIP-7702: The cost of authorization that sets delegation to an account that didn't exist before.
+constexpr auto AUTHORIZATION_EMPTY_ACCOUNT_COST = 25000;
+/// EIP-7702: The cost of authorization that sets delegation to an account that already exists.
+constexpr auto AUTHORIZATION_BASE_COST = 12500;
+
+constexpr int64_t num_words(size_t size_in_bytes) noexcept
+{
+    return static_cast<int64_t>((size_in_bytes + 31) / 32);
+}
+
+size_t compute_tx_data_tokens(evmc_revision rev, bytes_view data) noexcept
+{
+    const auto num_zero_bytes = static_cast<size_t>(std::ranges::count(data, 0));
+    const auto num_nonzero_bytes = data.size() - num_zero_bytes;
+
+    const size_t nonzero_byte_multiplier = rev >= EVMC_ISTANBUL ? 4 : 17;
+    return (nonzero_byte_multiplier * num_nonzero_bytes) + num_zero_bytes;
+}
+
+int64_t compute_access_list_cost(const AccessList& access_list) noexcept
+{
+    static constexpr auto ADDRESS_COST = 2400;
+    static constexpr auto STORAGE_KEY_COST = 1900;
+
+    int64_t cost = 0;
+    for (const auto& [_, keys] : access_list)
+        cost += ADDRESS_COST + static_cast<int64_t>(keys.size()) * STORAGE_KEY_COST;
+    return cost;
+}
+
+struct TransactionCost
+{
+    int64_t intrinsic = 0;
+    int64_t min = 0;
+};
+
+/// Compute the transaction intrinsic gas 𝑔₀ (Yellow Paper, 6.2) and minimal gas (EIP-7623).
+TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, const Transaction& tx) noexcept
+{
+    static constexpr auto TX_BASE_COST = 21000;
+    static constexpr auto TX_CREATE_COST = 32000;
+    static constexpr auto DATA_TOKEN_COST = 4;
+    static constexpr auto INITCODE_WORD_COST = 2;
+    static constexpr auto TOTAL_COST_FLOOR_PER_TOKEN = 10;
+
+    const auto is_create = !tx.to.has_value();
+
+    const auto create_cost = (is_create && rev >= EVMC_HOMESTEAD) ? TX_CREATE_COST : 0;
+
+    const auto num_tokens = static_cast<int64_t>(compute_tx_data_tokens(rev, tx.data));
+    const auto data_cost = num_tokens * DATA_TOKEN_COST;
+
+    const auto access_list_cost = compute_access_list_cost(tx.access_list);
+
+    const auto auth_list_cost =
+        static_cast<int64_t>(tx.authorization_list.size()) * AUTHORIZATION_EMPTY_ACCOUNT_COST;
+
+    const auto initcode_cost =
+        (is_create && rev >= EVMC_SHANGHAI) ? INITCODE_WORD_COST * num_words(tx.data.size()) : 0;
+
+    const auto intrinsic_cost =
+        TX_BASE_COST + create_cost + data_cost + access_list_cost + auth_list_cost + initcode_cost;
+
+    // EIP-7623: Compute the minimum cost for the transaction by. If disabled, just use 0.
+    const auto min_cost =
+        rev >= EVMC_PRAGUE ? TX_BASE_COST + num_tokens * TOTAL_COST_FLOOR_PER_TOKEN : 0;
+
+    return {intrinsic_cost, min_cost};
+}
+
+int64_t process_authorization_list(
+    State& state, uint64_t chain_id, const AuthorizationList& authorization_list)
+{
+    int64_t delegation_refund = 0;
+    for (const auto& auth : authorization_list)
+    {
+        // 1. Verify the chain id is either 0 or the chain’s current ID.
+        if (auth.chain_id != 0 && auth.chain_id != chain_id)
+            continue;
+
+        // 2. Verify the nonce is less than 2**64 - 1.
+        if (auth.nonce == Account::NonceMax)
+            continue;
+
+        // 3. Verify if the signer has been successfully recovered from the signature.
+        //    authority = ecrecover(...)
+        // y_parity must be 0 or 1 for EIP-7702/2930 signatures.
+        if (auth.v > 1)
+            continue;
+        // TODO: We actually only do "partial" verification by assuming the signature is valid
+        //   when the test has the signer specified.
+        if (!auth.signer.has_value())
+            continue;
+
+        // s value must be less than or equal to secp256k1n/2, as specified in EIP-2.
+        if (auth.s > SECP256K1N_OVER_2)
+            continue;
+
+        // Get or create the authority account.
+        // It is still empty at this point until nonce bump following successful authorization.
+        auto& authority = state.get_or_insert(*auth.signer, {.erase_if_empty = true});
+
+        // 4. Add authority to accessed_addresses (as defined in EIP-2929.)
+        authority.access_status = EVMC_ACCESS_WARM;
+
+        // 5. Verify the code of authority is either empty or already delegated.
+        if (authority.code_hash != Account::EMPTY_CODE_HASH &&
+            !is_code_delegated(state.get_code(*auth.signer)))
+            continue;
+
+        // 6. Verify the nonce of authority is equal to nonce.
+        // In case authority does not exist in the trie, verify that nonce is equal to 0.
+        if (auth.nonce != authority.nonce)
+            continue;
+
+        // 7. Add PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST gas to the global refund counter
+        // if authority exists in the trie.
+        // Successful authorization validation makes an account non-empty.
+        // We apply the refund only if the account has existed before.
+        // We detect "exists in the trie" by inspecting _empty_ property (EIP-161) because _empty_
+        // implies an account doesn't exist in the state (EIP-7523).
+        if (!authority.is_empty())
+        {
+            static constexpr auto EXISTING_AUTHORITY_REFUND =
+                AUTHORIZATION_EMPTY_ACCOUNT_COST - AUTHORIZATION_BASE_COST;
+            delegation_refund += EXISTING_AUTHORITY_REFUND;
+        }
+
+        // As a special case, if address is 0 do not write the designation.
+        // Clear the account’s code and reset the account’s code hash to the empty hash.
+        if (is_zero(auth.addr))
+        {
+            if (authority.code_hash != Account::EMPTY_CODE_HASH)
+            {
+                authority.code_changed = true;
+                authority.code.clear();
+                authority.code_hash = Account::EMPTY_CODE_HASH;
+            }
+        }
+        // 8. Set the code of authority to be 0xef0100 || address. This is a delegation designation.
+        else
+        {
+            auto new_code = bytes(DELEGATION_MAGIC) + bytes(auth.addr);
+            if (authority.code != new_code)
+            {
+                // We are doing this only if the code is different to make the state diff precise.
+                authority.code_changed = true;
+                authority.code = std::move(new_code);
+                authority.code_hash = keccak256(authority.code);
+            }
+        }
+
+        // 9. Increase the nonce of authority by one.
+        ++authority.nonce;
+    }
+    return delegation_refund;
+}
+
+evmc_message build_message(const Transaction& tx, int64_t execution_gas_limit) noexcept
+{
+    const auto recipient = tx.to.has_value() ? *tx.to : evmc::address{};
+
+    return {
+        .kind = tx.to.has_value() ? EVMC_CALL : EVMC_CREATE,
+        .flags = 0,
+        .depth = 0,
+        .gas = execution_gas_limit,
+        .recipient = recipient,
+        .sender = tx.sender,
+        .input_data = tx.data.data(),
+        .input_size = tx.data.size(),
+        .value = intx::be::store<evmc::uint256be>(tx.value),
+        .create2_salt = {},
+        .code_address = recipient,
+        .code = nullptr,
+        .code_size = 0,
+    };
+}
+}  // namespace
+
+StateDiff State::build_diff(evmc_revision rev) const
+{
+    StateDiff diff;
+    for (const auto& [addr, m] : m_modified)
+    {
+        if (m.destructed)
+        {
+            // TODO: This must be done even for just_created
+            //   because destructed may pre-date just_created. Add test to evmone (EEST has it).
+            diff.deleted_accounts.emplace_back(addr);
+            continue;
+        }
+        if (m.erase_if_empty && rev >= EVMC_SPURIOUS_DRAGON && m.is_empty())
+        {
+            if (!m.just_created)  // Don't report just created accounts
+                diff.deleted_accounts.emplace_back(addr);
+            continue;
+        }
+
+        // Unconditionally report nonce and balance as modified.
+        // TODO: We don't have information if the balance/nonce has actually changed.
+        //   One option is to just keep the original values. This may be handy for RPC.
+        // TODO(clang): In AppleClang 15 emplace_back without StateDiff::Entry doesn't compile.
+        //   NOLINTNEXTLINE(modernize-use-emplace)
+        auto& a = diff.modified_accounts.emplace_back(StateDiff::Entry{addr, m.nonce, m.balance});
+
+        // Output only the new code.
+        // TODO: Output also the code hash. It will be needed for DB update and MPT hash.
+        if (m.code_changed)
+            a.code = m.code;
+
+        for (const auto& [k, v] : m.storage)
+        {
+            if (v.current != v.original)
+                a.modified_storage.emplace_back(k, v.current);
+        }
+    }
+    return diff;
+}
+
+Account& State::insert(const address& addr, Account account)
+{
+    const auto r = m_modified.insert({addr, std::move(account)});
+    assert(r.second);
+    return r.first->second;
+}
+
+Account* State::find(const address& addr) noexcept
+{
+    // TODO: Avoid double lookup (find+insert) and not cached initial state lookup for non-existent
+    //   accounts. If we want to cache non-existent account we need a proper flag for it.
+    if (const auto it = m_modified.find(addr); it != m_modified.end())
+        return &it->second;
+    if (const auto cacc = m_initial.get_account(addr); cacc)
+        return &insert(addr, {.nonce = cacc->nonce,
+                                 .balance = cacc->balance,
+                                 .code_hash = cacc->code_hash,
+                                 .has_initial_storage = cacc->has_storage});
+    return nullptr;
+}
+
+Account& State::get(const address& addr) noexcept
+{
+    auto acc = find(addr);
+    assert(acc != nullptr);
+    return *acc;
+}
+
+Account& State::get_or_insert(const address& addr, Account account)
+{
+    if (const auto acc = find(addr); acc != nullptr)
+        return *acc;
+    return insert(addr, std::move(account));
+}
+
+bytes_view State::get_code(const address& addr)
+{
+    auto* a = find(addr);
+    if (a == nullptr)
+        return {};
+    if (a->code_hash == Account::EMPTY_CODE_HASH)
+        return {};
+    if (a->code.empty())
+        a->code = m_initial.get_account_code(addr);
+    return a->code;
+}
+
+Account& State::touch(const address& addr)
+{
+    auto& acc = get_or_insert(addr, {.erase_if_empty = true});
+    if (!acc.erase_if_empty && acc.is_empty())
+    {
+        acc.erase_if_empty = true;
+        m_journal.emplace_back(JournalTouched{addr});
+    }
+    return acc;
+}
+
+StorageValue& State::get_storage(const address& addr, const bytes32& key)
+{
+    // TODO: Avoid account lookup by giving the reference to the account's storage to Host.
+    auto& acc = get(addr);
+    const auto [it, missing] = acc.storage.try_emplace(key);
+    if (missing)
+    {
+        const auto initial_value = m_initial.get_storage(addr, key);
+        it->second = {initial_value, initial_value};
+    }
+    return it->second;
+}
+
+void State::journal_balance_change(const address& addr, const intx::uint256& prev_balance)
+{
+    m_journal.emplace_back(JournalBalanceChange{{addr}, prev_balance});
+}
+
+void State::journal_storage_change(
+    const address& addr, const bytes32& key, const StorageValue& value)
+{
+    m_journal.emplace_back(JournalStorageChange{{addr}, key, value.current, value.access_status});
+}
+
+void State::journal_transient_storage_change(
+    const address& addr, const bytes32& key, const bytes32& value)
+{
+    m_journal.emplace_back(JournalTransientStorageChange{{addr}, key, value});
+}
+
+void State::journal_bump_nonce(const address& addr)
+{
+    m_journal.emplace_back(JournalNonceBump{addr});
+}
+
+void State::journal_create(const address& addr, bool existed)
+{
+    m_journal.emplace_back(JournalCreate{{addr}, existed});
+}
+
+void State::journal_destruct(const address& addr)
+{
+    m_journal.emplace_back(JournalDestruct{addr});
+}
+
+void State::journal_access_account(const address& addr)
+{
+    m_journal.emplace_back(JournalAccessAccount{addr});
+}
+
+void State::rollback(size_t checkpoint)
+{
+    while (m_journal.size() != checkpoint)
+    {
+        std::visit(
+            [this](const auto& e) {
+                using T = std::decay_t<decltype(e)>;
+                if constexpr (std::is_same_v<T, JournalNonceBump>)
+                {
+                    get(e.addr).nonce -= 1;
+                }
+                else if constexpr (std::is_same_v<T, JournalTouched>)
+                {
+                    get(e.addr).erase_if_empty = false;
+                }
+                else if constexpr (std::is_same_v<T, JournalDestruct>)
+                {
+                    get(e.addr).destructed = false;
+                }
+                else if constexpr (std::is_same_v<T, JournalAccessAccount>)
+                {
+                    get(e.addr).access_status = EVMC_ACCESS_COLD;
+                }
+                else if constexpr (std::is_same_v<T, JournalCreate>)
+                {
+                    if (e.existed)
+                    {
+                        // This account is not always "touched". TODO: Why?
+                        auto& a = get(e.addr);
+                        a.nonce = 0;
+                        a.code_hash = Account::EMPTY_CODE_HASH;
+                        a.code.clear();
+                    }
+                    else
+                    {
+                        // TODO: Before Spurious Dragon we don't clear empty accounts ("erasable")
+                        //       so we need to delete them here explicitly.
+                        //       This should be changed by tuning "erasable" flag
+                        //       and clear in all revisions.
+                        m_modified.erase(e.addr);
+                    }
+                }
+                else if constexpr (std::is_same_v<T, JournalStorageChange>)
+                {
+                    auto& s = get(e.addr).storage.find(e.key)->second;
+                    s.current = e.prev_value;
+                    s.access_status = e.prev_access_status;
+                }
+                else if constexpr (std::is_same_v<T, JournalTransientStorageChange>)
+                {
+                    auto& s = get(e.addr).transient_storage.find(e.key)->second;
+                    s = e.prev_value;
+                }
+                else if constexpr (std::is_same_v<T, JournalBalanceChange>)
+                {
+                    get(e.addr).balance = e.prev_balance;
+                }
+                else
+                {
+                    // TODO(C++23): Change condition to `false` once CWG2518 is in.
+                    static_assert(std::is_void_v<T>, "unhandled journal entry type");
+                }
+            },
+            m_journal.back());
+        m_journal.pop_back();
+    }
+}
+
+/// Validates transaction and computes its execution gas limit (the amount of gas provided to EVM).
+/// @return  Execution gas limit or transaction validation error.
+std::variant<TransactionProperties, std::error_code> validate_transaction(
+    const StateView& state_view, const BlockInfo& block, const Transaction& tx, evmc_revision rev,
+    int64_t block_gas_left, int64_t blob_gas_left) noexcept
+{
+    switch (tx.type)  // Validate "special" transaction types.
+    {
+    case Transaction::Type::blob:
+        if (rev < EVMC_CANCUN)
+            return make_error_code(TX_TYPE_NOT_SUPPORTED);
+        if (!tx.to.has_value())
+            return make_error_code(CREATE_BLOB_TX);
+        if (tx.blob_hashes.empty())
+            return make_error_code(EMPTY_BLOB_HASHES_LIST);
+        if (rev >= EVMC_OSAKA && tx.blob_hashes.size() > MAX_TX_BLOB_COUNT)
+            return make_error_code(BLOB_GAS_LIMIT_EXCEEDED);
+
+        assert(block.blob_base_fee.has_value());
+        if (tx.max_blob_gas_price < *block.blob_base_fee)
+            return make_error_code(BLOB_FEE_CAP_LESS_THAN_BLOCKS);
+
+        if (std::ranges::any_of(tx.blob_hashes, [](const auto& h) { return h.bytes[0] != 0x01; }))
+            return make_error_code(INVALID_BLOB_HASH_VERSION);
+        if (std::cmp_greater(tx.blob_gas_used(), blob_gas_left))
+            return make_error_code(BLOB_GAS_LIMIT_EXCEEDED);
+        break;
+
+    case Transaction::Type::set_code:
+        if (rev < EVMC_PRAGUE)
+            return make_error_code(TX_TYPE_NOT_SUPPORTED);
+        if (!tx.to.has_value())
+            return make_error_code(CREATE_SET_CODE_TX);
+        if (tx.authorization_list.empty())
+            return make_error_code(EMPTY_AUTHORIZATION_LIST);
+        break;
+
+    default:;
+    }
+
+    switch (tx.type)  // Validate the "regular" transaction type hierarchy.
+    {
+    case Transaction::Type::set_code:
+    case Transaction::Type::blob:
+    case Transaction::Type::eip1559:
+        if (rev < EVMC_LONDON)
+            return make_error_code(TX_TYPE_NOT_SUPPORTED);
+
+        if (tx.max_priority_gas_price > tx.max_gas_price)
+            return make_error_code(TIP_GT_FEE_CAP);  // Priority gas price is too high.
+        [[fallthrough]];
+
+    case Transaction::Type::access_list:
+        if (rev < EVMC_BERLIN)
+            return make_error_code(TX_TYPE_NOT_SUPPORTED);
+        [[fallthrough]];
+
+    case Transaction::Type::legacy:;
+    }
+
+    assert(tx.max_priority_gas_price <= tx.max_gas_price);
+
+    if (rev >= EVMC_OSAKA && tx.gas_limit > MAX_TX_GAS_LIMIT)
+        return make_error_code(MAX_GAS_LIMIT_EXCEEDED);
+
+    if (tx.gas_limit > block_gas_left)
+        return make_error_code(GAS_LIMIT_REACHED);
+
+    if (tx.max_gas_price < block.base_fee)
+        return make_error_code(FEE_CAP_LESS_THAN_BLOCKS);
+
+    // We need some information about the sender so lookup the account in the state.
+    // TODO: During transaction execution this account will be also needed, so we may pass it along.
+    const auto sender_acc = state_view.get_account(tx.sender).value_or(
+        StateView::Account{.code_hash = Account::EMPTY_CODE_HASH});
+
+    if (sender_acc.code_hash != Account::EMPTY_CODE_HASH &&
+        !is_code_delegated(state_view.get_account_code(tx.sender)))
+        return make_error_code(SENDER_NOT_EOA);  // Origin must not be a contract (EIP-3607).
+
+    if (sender_acc.nonce == Account::NonceMax)  // Nonce value limit (EIP-2681).
+        return make_error_code(NONCE_HAS_MAX_VALUE);
+
+    if (sender_acc.nonce < tx.nonce)
+        return make_error_code(NONCE_TOO_HIGH);
+
+    if (sender_acc.nonce > tx.nonce)
+        return make_error_code(NONCE_TOO_LOW);
+
+    // initcode size is limited by EIP-3860.
+    if (rev >= EVMC_SHANGHAI && !tx.to.has_value() && tx.data.size() > MAX_INITCODE_SIZE)
+        return make_error_code(INIT_CODE_SIZE_LIMIT_EXCEEDED);
+
+    // Compute and check if sender has enough balance for the theoretical maximum transaction cost.
+    // Note this is different from tx_max_cost computed with effective gas price later.
+    // The computation cannot overflow if done with 512-bit precision.
+    auto max_total_fee = umul(uint256{tx.gas_limit}, tx.max_gas_price);
+    max_total_fee += tx.value;
+
+    if (tx.type == Transaction::Type::blob)
+    {
+        const auto total_blob_gas = tx.blob_gas_used();
+        // FIXME: Can overflow uint256.
+        max_total_fee += total_blob_gas * tx.max_blob_gas_price;
+    }
+    if (sender_acc.balance < max_total_fee)
+        return make_error_code(INSUFFICIENT_FUNDS);
+
+    const auto [intrinsic_cost, min_cost] = compute_tx_intrinsic_cost(rev, tx);
+    if (tx.gas_limit < std::max(intrinsic_cost, min_cost))
+        return make_error_code(INTRINSIC_GAS_TOO_LOW);
+
+    const auto execution_gas_limit = tx.gas_limit - intrinsic_cost;
+    return TransactionProperties{execution_gas_limit, min_cost};
+}
+
+StateDiff finalize(const StateView& state_view, evmc_revision rev, const address& coinbase,
+    std::optional<uint64_t> block_reward, std::span<const Ommer> ommers,
+    std::span<const Withdrawal> withdrawals)
+{
+    State state{state_view};
+    // TODO: The block reward can be represented as a withdrawal.
+    if (block_reward.has_value())
+    {
+        const auto reward = *block_reward;
+        assert(reward % 32 == 0);  // Assume block reward is divisible by 32.
+        const auto reward_by_32 = reward / 32;
+        const auto reward_by_8 = reward / 8;
+
+        state.touch(coinbase).balance += reward + reward_by_32 * ommers.size();
+        for (const auto& ommer : ommers)
+        {
+            assert(ommer.delta > 0 && ommer.delta < 8);
+            state.touch(ommer.beneficiary).balance += reward_by_8 * (8 - ommer.delta);
+        }
+    }
+
+    for (const auto& withdrawal : withdrawals)
+        state.touch(withdrawal.recipient).balance += withdrawal.get_amount();
+
+    return state.build_diff(rev);
+}
+
+TransactionReceipt transition(const StateView& state_view, const BlockInfo& block,
+    const BlockHashes& block_hashes, const Transaction& tx, evmc_revision rev, evmc::VM& vm,
+    const TransactionProperties& tx_props)
+{
+    State state{state_view};
+
+    auto& sender_acc = state.get_or_insert(tx.sender);
+    assert(sender_acc.nonce < Account::NonceMax);  // Required for valid tx.
+    ++sender_acc.nonce;                            // Bump sender nonce.
+
+    const auto delegation_refund =
+        process_authorization_list(state, tx.chain_id, tx.authorization_list);
+
+    const auto base_fee = (rev >= EVMC_LONDON) ? block.base_fee : 0;
+    assert(tx.max_gas_price >= base_fee);                   // Required for valid tx.
+    assert(tx.max_gas_price >= tx.max_priority_gas_price);  // Required for valid tx.
+    const auto priority_gas_price =
+        std::min(tx.max_priority_gas_price, tx.max_gas_price - base_fee);
+    const auto effective_gas_price = base_fee + priority_gas_price;
+
+    assert(effective_gas_price <= tx.max_gas_price);  // Required for valid tx.
+    const auto tx_max_cost = tx.gas_limit * effective_gas_price;
+
+    sender_acc.balance -= tx_max_cost;  // Modify sender balance after all checks.
+
+    if (tx.type == Transaction::Type::blob)
+    {
+        // This uint64 * uint256 cannot overflow, because tx.blob_gas_used has limits enforced
+        // before this stage.
+        assert(block.blob_base_fee.has_value());
+        const auto blob_fee = intx::umul(intx::uint256(tx.blob_gas_used()), *block.blob_base_fee);
+        assert(blob_fee <= std::numeric_limits<intx::uint256>::max());
+        assert(sender_acc.balance >= blob_fee);  // Required for valid tx.
+        sender_acc.balance -= intx::uint256(blob_fee);
+    }
+
+    Host host{rev, vm, state, block, block_hashes, tx};
+
+    sender_acc.access_status = EVMC_ACCESS_WARM;  // Tx sender is always warm.
+    if (tx.to.has_value())
+        host.access_account(*tx.to);
+    for (const auto& [a, storage_keys] : tx.access_list)
+    {
+        host.access_account(a);
+        for (const auto& key : storage_keys)
+            state.get_storage(a, key).access_status = EVMC_ACCESS_WARM;
+    }
+    // EIP-3651: Warm COINBASE.
+    // This may create an empty coinbase account. The account cannot be created unconditionally
+    // because this breaks old revisions.
+    if (rev >= EVMC_SHANGHAI)
+        host.access_account(block.coinbase);
+
+    auto message = build_message(tx, tx_props.execution_gas_limit);
+    if (tx.to.has_value())
+    {
+        if (const auto delegate = get_delegate_address(host, *tx.to))
+        {
+            message.code_address = *delegate;
+            message.flags |= EVMC_DELEGATED;
+            host.access_account(message.code_address);
+        }
+    }
+
+    const auto result = host.call(message);
+
+    auto gas_used = tx.gas_limit - result.gas_left;
+
+    const auto max_refund_quotient = rev >= EVMC_LONDON ? 5 : 2;
+    const auto refund_limit = gas_used / max_refund_quotient;
+    const auto refund = std::min(delegation_refund + result.gas_refund, refund_limit);
+    gas_used -= refund;
+    assert(gas_used > 0);
+
+    // EIP-7623: The gas used by the transaction must be at least the min_gas_cost.
+    gas_used = std::max(gas_used, tx_props.min_gas_cost);
+
+    sender_acc.balance += tx_max_cost - gas_used * effective_gas_price;
+    state.touch(block.coinbase).balance += gas_used * priority_gas_price;
+
+    // Cumulative gas used is unknown in this scope.
+    TransactionReceipt receipt{
+        tx.type, result.status_code, gas_used, {}, host.take_logs(), {}, state.build_diff(rev)};
+
+    // Cannot put it into constructor call because logs are std::moved from host instance.
+    receipt.logs_bloom_filter = compute_bloom_filter(receipt.logs);
+
+    return receipt;
+}
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/state.hpp
+++ b/bcos-evm/bcos-evm/eth/state/state.hpp
@@ -1,0 +1,153 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "account.hpp"
+#include "block.hpp"
+#include "bloom_filter.hpp"
+#include "errors.hpp"
+#include "hash_utils.hpp"
+#include "state_diff.hpp"
+#include "state_view.hpp"
+#include "transaction.hpp"
+#include <variant>
+
+namespace evmone::state
+{
+/// The Ethereum State: the collection of accounts mapped by their addresses.
+class State
+{
+    struct JournalBase
+    {
+        address addr;
+    };
+
+    struct JournalBalanceChange : JournalBase
+    {
+        intx::uint256 prev_balance;
+    };
+
+    struct JournalTouched : JournalBase
+    {};
+
+    struct JournalStorageChange : JournalBase
+    {
+        bytes32 key;
+        bytes32 prev_value;
+        evmc_access_status prev_access_status;
+    };
+
+    struct JournalTransientStorageChange : JournalBase
+    {
+        bytes32 key;
+        bytes32 prev_value;
+    };
+
+    struct JournalNonceBump : JournalBase
+    {};
+
+    struct JournalCreate : JournalBase
+    {
+        bool existed;
+    };
+
+    struct JournalDestruct : JournalBase
+    {};
+
+    struct JournalAccessAccount : JournalBase
+    {};
+
+    using JournalEntry =
+        std::variant<JournalBalanceChange, JournalTouched, JournalStorageChange, JournalNonceBump,
+            JournalCreate, JournalTransientStorageChange, JournalDestruct, JournalAccessAccount>;
+
+    /// The read-only view of the initial (cold) state.
+    const StateView& m_initial;
+
+    /// The accounts loaded from the initial state and potentially modified.
+    std::unordered_map<address, Account> m_modified;
+
+    /// The state journal: the list of changes made to the state
+    /// with information how to revert them.
+    std::vector<JournalEntry> m_journal;
+
+public:
+    explicit State(const StateView& state_view) noexcept : m_initial{state_view} {}
+    State(const State&) = delete;
+    State(State&&) = delete;
+    State& operator=(State&&) = delete;
+
+    /// Inserts the new account at the address.
+    /// There must not exist any account under this address before.
+    Account& insert(const address& addr, Account account = {});
+
+    /// Returns the pointer to the account at the address if the account exists. Null otherwise.
+    Account* find(const address& addr) noexcept;
+
+    /// Gets the account at the address (the account must exist).
+    Account& get(const address& addr) noexcept;
+
+    /// Gets an existing account or inserts new account.
+    Account& get_or_insert(const address& addr, Account account = {});
+
+    bytes_view get_code(const address& addr);
+
+    StorageValue& get_storage(const address& addr, const bytes32& key);
+
+    StateDiff build_diff(evmc_revision rev) const;
+
+    /// Returns the state journal checkpoint. It can be later used to in rollback()
+    /// to revert changes newer than the checkpoint.
+    [[nodiscard]] size_t checkpoint() const noexcept { return m_journal.size(); }
+
+    /// Reverts state changes made after the checkpoint.
+    void rollback(size_t checkpoint);
+
+    /// Methods performing changes to the state which can be reverted by rollback().
+    /// @{
+
+    /// Touches (as in EIP-161) an existing account or inserts new erasable account.
+    Account& touch(const address& addr);
+
+    void journal_balance_change(const address& addr, const intx::uint256& prev_balance);
+
+    void journal_storage_change(const address& addr, const bytes32& key, const StorageValue& value);
+
+    void journal_transient_storage_change(
+        const address& addr, const bytes32& key, const bytes32& value);
+
+    void journal_bump_nonce(const address& addr);
+
+    void journal_create(const address& addr, bool existed);
+
+    void journal_destruct(const address& addr);
+
+    void journal_access_account(const address& addr);
+
+    /// @}
+};
+
+/// Finalize state after applying a "block" of transactions.
+///
+/// Applies block reward to coinbase, withdrawals (post Shanghai) and deletes empty touched accounts
+/// (post Spurious Dragon).
+[[nodiscard]] StateDiff finalize(const StateView& state_view, evmc_revision rev,
+    const address& coinbase, std::optional<uint64_t> block_reward, std::span<const Ommer> ommers,
+    std::span<const Withdrawal> withdrawals);
+
+/// Executes a valid transaction.
+///
+/// @return Transaction receipt with state diff.
+TransactionReceipt transition(const StateView& state, const BlockInfo& block,
+    const BlockHashes& block_hashes, const Transaction& tx, evmc_revision rev, evmc::VM& vm,
+    const TransactionProperties& tx_props);
+
+/// Validate a transaction.
+///
+/// @return Computed execution gas limit or validation error.
+[[nodiscard]] std::variant<TransactionProperties, std::error_code> validate_transaction(
+    const StateView& state_view, const BlockInfo& block, const Transaction& tx, evmc_revision rev,
+    int64_t block_gas_left, int64_t blob_gas_left) noexcept;
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/state_diff.hpp
+++ b/bcos-evm/bcos-evm/eth/state/state_diff.hpp
@@ -1,0 +1,51 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2024 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+#include <vector>
+
+namespace evmone::state
+{
+using evmc::address;
+using evmc::bytes;
+using evmc::bytes32;
+using intx::uint256;
+
+/// Collection of changes to the State
+struct StateDiff
+{
+    struct Entry
+    {
+        /// Address of the modified account.
+        address addr;
+
+        /// New nonce value.
+        /// TODO: Currently it is not guaranteed the value is different from the initial one.
+        uint64_t nonce;
+
+        /// New balance value.
+        /// TODO: Currently it is not guaranteed the value is different from the initial one.
+        uint256 balance;
+
+        /// New or modified account code. If bytes are empty, it means the code has been cleared.
+        std::optional<bytes> code;
+
+        /// The list of the account's storage modifications: key => new value.
+        /// The value 0 means the storage entry is deleted.
+        std::vector<std::pair<bytes32, bytes32>> modified_storage;
+    };
+
+    /// List of modified or created accounts.
+    std::vector<Entry> modified_accounts;
+
+    /// List of deleted accounts.
+    ///
+    /// This list doesn't have common addresses with modified_accounts.
+    /// Note that from the Cancun revision (because of the modification to the SELFDESTRUCT)
+    /// accounts cannot be deleted and this list is always empty.
+    std::vector<address> deleted_accounts;
+};
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/state_view.hpp
+++ b/bcos-evm/bcos-evm/eth/state/state_view.hpp
@@ -1,0 +1,44 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2024 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+#include <optional>
+
+namespace evmone::state
+{
+using evmc::address;
+using evmc::bytes;
+using evmc::bytes32;
+using intx::uint256;
+
+class StateView
+{
+public:
+    struct Account
+    {
+        uint64_t nonce = 0;
+        uint256 balance;
+        bytes32 code_hash;
+        bool has_storage = false;
+    };
+
+    virtual ~StateView() = default;
+    virtual std::optional<Account> get_account(const address& addr) const noexcept = 0;
+    virtual bytes get_account_code(const address& addr) const noexcept = 0;
+    virtual bytes32 get_storage(const address& addr, const bytes32& key) const noexcept = 0;
+};
+
+
+/// Interface to access hashes of known block headers.
+class BlockHashes
+{
+public:
+    virtual ~BlockHashes() = default;
+
+    /// Returns the hash of the block header of the given block number.
+    virtual bytes32 get_block_hash(int64_t block_number) const noexcept = 0;
+};
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/system_contracts.cpp
+++ b/bcos-evm/bcos-evm/eth/state/system_contracts.cpp
@@ -1,0 +1,131 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "system_contracts.hpp"
+#include "host.hpp"
+#include "state_view.hpp"
+
+namespace evmone::state
+{
+namespace
+{
+/// Information about a registered "storage" system contract. They are executed at the block start
+/// to store additional information in the State.
+struct StorageSystemContract
+{
+    using GetInputFn = bytes32(const BlockInfo&, const BlockHashes&) noexcept;
+
+    evmc_revision since = EVMC_MAX_REVISION;  ///< EVM revision in which added.
+    address addr;                             ///< Address of the system contract.
+    GetInputFn* get_input = nullptr;          ///< How to get the input for the system call.
+};
+
+/// Information about a registered "requests" system contract. They are executed at the block end
+/// and produce requests: typed sequence of bytes.
+struct RequestsSystemContract
+{
+    evmc_revision since = EVMC_MAX_REVISION;                ///< EVM revision in which added.
+    address addr;                                           ///< Address of the system contract.
+    Requests::Type request_type = Requests::Type::deposit;  ///< Type of requests produced.
+};
+
+/// Registered "storage" system contracts.
+constexpr std::array STORAGE_SYSTEM_CONTRACTS{
+    StorageSystemContract{EVMC_CANCUN, BEACON_ROOTS_ADDRESS,
+        [](const BlockInfo& block, const BlockHashes&) noexcept {
+            return block.parent_beacon_block_root;
+        }},
+    StorageSystemContract{EVMC_PRAGUE, HISTORY_STORAGE_ADDRESS,
+        [](const BlockInfo& block, const BlockHashes& block_hashes) noexcept {
+            return block_hashes.get_block_hash(block.number - 1);
+        }},
+};
+
+/// Registered "requests" system contracts.
+constexpr std::array REQUESTS_SYSTEM_CONTRACTS{
+    RequestsSystemContract{
+        EVMC_PRAGUE,
+        WITHDRAWAL_REQUEST_ADDRESS,
+        Requests::Type::withdrawal,
+    },
+    RequestsSystemContract{
+        EVMC_PRAGUE,
+        CONSOLIDATION_REQUEST_ADDRESS,
+        Requests::Type::consolidation,
+    },
+};
+
+constexpr auto by_rev = [](const auto& a, const auto& b) noexcept { return a.since < b.since; };
+static_assert(std::ranges::is_sorted(STORAGE_SYSTEM_CONTRACTS, by_rev),
+    "system contract entries must be ordered by revision");
+static_assert(std::ranges::is_sorted(REQUESTS_SYSTEM_CONTRACTS, by_rev),
+    "system contract entries must be ordered by revision");
+
+
+evmc::Result execute_system_call(State& state, const BlockInfo& block,
+    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm, const address& addr,
+    bytes_view code, bytes_view input)
+{
+    const evmc_message msg{
+        .kind = EVMC_CALL,
+        .gas = 30'000'000,
+        .recipient = addr,
+        .sender = SYSTEM_ADDRESS,
+        .input_data = input.data(),
+        .input_size = input.size(),
+    };
+
+    const Transaction empty_tx{};
+    Host host{rev, vm, state, block, block_hashes, empty_tx};
+    return vm.execute(host, rev, msg, code.data(), code.size());
+}
+}  // namespace
+
+StateDiff system_call_block_start(const StateView& state_view, const BlockInfo& block,
+    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
+{
+    State state{state_view};
+    for (const auto& [since, addr, get_input] : STORAGE_SYSTEM_CONTRACTS)
+    {
+        if (rev < since)
+            break;  // Because entries are ordered, there are no other contracts for this revision.
+
+        // Skip the call if the target account doesn't exist. This is by EIP-4788 spec.
+        // > if no code exists at [address], the call must fail silently.
+        const auto code = state_view.get_account_code(addr);
+        if (code.empty())
+            continue;
+
+        const auto input32 = get_input(block, block_hashes);
+        const auto res =
+            execute_system_call(state, block, block_hashes, rev, vm, addr, code, input32);
+        assert(res.status_code == EVMC_SUCCESS);
+    }
+    // TODO: Should we return empty diff if no system contracts?
+    return state.build_diff(rev);
+}
+
+std::optional<RequestsResult> system_call_block_end(const StateView& state_view,
+    const BlockInfo& block, const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm)
+{
+    State state{state_view};
+    std::vector<Requests> requests;
+    for (const auto& [since, addr, request_type] : REQUESTS_SYSTEM_CONTRACTS)
+    {
+        if (rev < since)
+            break;  // Because entries are ordered, there are no other contracts for this revision.
+
+        // Fail if the target account doesn't exist. This is by EIP-7002 and EIP-7251 spec.
+        const auto code = state_view.get_account_code(addr);
+        if (code.empty())
+            return std::nullopt;
+
+        const auto res = execute_system_call(state, block, block_hashes, rev, vm, addr, code, {});
+        if (res.status_code != EVMC_SUCCESS)
+            return std::nullopt;
+        requests.emplace_back(request_type, bytes_view{res.output_data, res.output_size});
+    }
+    return RequestsResult{state.build_diff(rev), requests};
+}
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/system_contracts.hpp
+++ b/bcos-evm/bcos-evm/eth/state/system_contracts.hpp
@@ -1,0 +1,55 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "requests.hpp"
+#include <evmc/evmc.hpp>
+
+namespace evmone::state
+{
+using namespace evmc::literals;
+
+/// The address of the sender of the system calls (EIP-4788).
+constexpr auto SYSTEM_ADDRESS = 0xfffffffffffffffffffffffffffffffffffffffe_address;
+
+/// The address of the system contract storing the root hashes of beacon chain blocks (EIP-4788).
+constexpr auto BEACON_ROOTS_ADDRESS = 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02_address;
+
+/// The address of the system contract storing historical block hashes (EIP-2935).
+constexpr auto HISTORY_STORAGE_ADDRESS = 0x0000F90827F1C53A10CB7A02335B175320002935_address;
+
+/// The address of the system contract processing EL-triggerable withdrawals (EIP-7002).
+constexpr auto WITHDRAWAL_REQUEST_ADDRESS = 0x00000961EF480EB55E80D19AD83579A64C007002_address;
+
+/// The address of the system contract processing consolidations (EIP-7251).
+constexpr auto CONSOLIDATION_REQUEST_ADDRESS = 0x0000BBDDC7CE488642FB579F8B00F3A590007251_address;
+
+struct BlockInfo;
+struct StateDiff;
+class BlockHashes;
+class StateView;
+
+/// Performs the system call: invokes system contracts that have to be executed
+/// at the start of the block.
+///
+/// Executes code of pre-defined accounts via pseudo-transaction from the system sender (0xff...fe).
+/// The sender's nonce is not increased.
+[[nodiscard]] StateDiff system_call_block_start(const StateView& state_view, const BlockInfo& block,
+    const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
+
+struct RequestsResult
+{
+    StateDiff state_diff;            ///< State diff of the system contracts execution.
+    std::vector<Requests> requests;  ///< Collected requests.
+};
+
+/// Performs the system call: invokes system contracts that have to be executed
+/// at the end of the block.
+///
+/// Executes code of pre-defined accounts via pseudo-transaction from the system sender (0xff...fe).
+/// The sender's nonce is not increased.
+/// @return The collected requests and state diff or std::nullopt if the execution has failed.
+[[nodiscard]] std::optional<RequestsResult> system_call_block_end(const StateView& state_view,
+    const BlockInfo& block, const BlockHashes& block_hashes, evmc_revision rev, evmc::VM& vm);
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/state/transaction.hpp
+++ b/bcos-evm/bcos-evm/eth/state/transaction.hpp
@@ -1,0 +1,129 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2022 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "blob_params.hpp"
+#include "bloom_filter.hpp"
+#include "state_diff.hpp"
+#include <intx/intx.hpp>
+#include <optional>
+#include <vector>
+
+namespace evmone::state
+{
+/// The maximum allowed gas limit for a transaction (EIP-7825).
+constexpr auto MAX_TX_GAS_LIMIT = 0x1000000;  // 2**24
+
+using AccessList = std::vector<std::pair<address, std::vector<bytes32>>>;
+
+struct Authorization
+{
+    intx::uint256 chain_id;
+    address addr;
+    uint64_t nonce = 0;
+    /// Signer is empty if it cannot be ecrecovered from r, s, v.
+    std::optional<address> signer;
+    intx::uint256 r;
+    intx::uint256 s;
+    intx::uint256 v;
+};
+
+using AuthorizationList = std::vector<Authorization>;
+
+struct Transaction
+{
+    /// The type of the transaction.
+    ///
+    /// The format is defined by EIP-2718: Typed Transaction Envelope.
+    /// https://eips.ethereum.org/EIPS/eip-2718.
+    enum class Type : uint8_t
+    {
+        /// The legacy RLP-encoded transaction without leading "type" byte.
+        legacy = 0,
+
+        /// The typed transaction with optional account/storage access list.
+        /// Introduced by EIP-2930 https://eips.ethereum.org/EIPS/eip-2930.
+        access_list = 1,
+
+        /// The typed transaction with priority gas price.
+        /// Introduced by EIP-1559 https://eips.ethereum.org/EIPS/eip-1559.
+        eip1559 = 2,
+
+        /// The typed blob transaction (with array of blob hashes).
+        /// Introduced by EIP-4844 https://eips.ethereum.org/EIPS/eip-4844.
+        blob = 3,
+
+        /// The typed set code transaction (with authorization list).
+        /// Introduced by EIP-7702 https://eips.ethereum.org/EIPS/eip-7702.
+        set_code = 4,
+    };
+
+    /// Returns amount of blob gas used by this transaction
+    [[nodiscard]] uint64_t blob_gas_used() const { return GAS_PER_BLOB * blob_hashes.size(); }
+
+    Type type = Type::legacy;
+    bytes data;
+    int64_t gas_limit = 0;
+    intx::uint256 max_gas_price;
+    intx::uint256 max_priority_gas_price;
+    intx::uint256 max_blob_gas_price;
+    address sender;
+    std::optional<address> to;
+    intx::uint256 value;
+    AccessList access_list;
+    std::vector<bytes32> blob_hashes;
+    uint64_t chain_id = 0;
+    uint64_t nonce = 0;
+    intx::uint256 r;
+    intx::uint256 s;
+    uint8_t v = 0;
+    AuthorizationList authorization_list;
+};
+
+/// Transaction properties computed during the validation needed for the execution.
+struct TransactionProperties
+{
+    /// The amount of gas provided to the EVM for the transaction execution.
+    int64_t execution_gas_limit = 0;
+
+    /// The minimal amount of gas the transaction must use.
+    int64_t min_gas_cost = 0;
+};
+
+struct Log
+{
+    address addr;
+    bytes data;
+    std::vector<bytes32> topics;
+};
+
+/// Transaction Receipt
+///
+/// This struct is used in two contexts:
+/// 1. As the formally specified, RLP-encode transaction receipt included in the Ethereum blocks.
+/// 2. As the internal representation of the transaction execution result.
+/// These both roles share most, but not all the information. There are some fields that cannot be
+/// assigned in the single transaction execution context. There are also fields that are not a part
+/// of the RLP-encoded transaction receipts.
+/// TODO: Consider splitting the struct into two based on the duality explained above.
+struct TransactionReceipt
+{
+    Transaction::Type type = Transaction::Type::legacy;
+    evmc_status_code status = EVMC_INTERNAL_ERROR;
+
+    /// Amount of gas used by this transaction.
+    int64_t gas_used = 0;
+
+    /// Amount of gas used by this and previous transactions in the block.
+    int64_t cumulative_gas_used = 0;
+    std::vector<Log> logs;
+    BloomFilter logs_bloom_filter;
+    StateDiff state_diff;
+
+    /// Root hash of the state after this transaction. Used only in old pre-Byzantium transactions.
+    std::optional<bytes32> post_state;
+};
+
+}  // namespace evmone::state

--- a/bcos-evm/bcos-evm/eth/utils/stdx/utility.hpp
+++ b/bcos-evm/bcos-evm/eth/utils/stdx/utility.hpp
@@ -1,0 +1,14 @@
+// evmone: Fast Ethereum Virtual Machine implementation
+// Copyright 2023 The evmone Authors.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include <type_traits>
+
+namespace stdx
+{
+template <typename EnumT>
+constexpr auto to_underlying(EnumT e) noexcept
+{
+    return static_cast<std::underlying_type_t<EnumT>>(e);
+}
+}  // namespace stdx

--- a/bcos-evm/test/CMakeLists.txt
+++ b/bcos-evm/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(Boost REQUIRED unit_test_framework)
+
+add_executable(bcos-evm-eth-tests
+    eth/EthTransitionTest.cpp
+)
+target_link_libraries(bcos-evm-eth-tests PRIVATE
+    bcosevm::eth
+    Boost::unit_test_framework
+)
+add_test(NAME BcosEvmEthTests COMMAND bcos-evm-eth-tests)

--- a/bcos-evm/test/eth/EthTransitionTest.cpp
+++ b/bcos-evm/test/eth/EthTransitionTest.cpp
@@ -1,0 +1,202 @@
+#define BOOST_TEST_MODULE BcosEvmEthTests
+#include <bcos-evm/eth/EthTransition.h>
+#include <evmone/evmone.h>
+#include <boost/test/unit_test.hpp>
+#include <bcos-evm/eth/state/hash_utils.hpp>  // keccak256（Stub 的 code_hash 计算）
+#include <map>
+
+using namespace evmone;
+using namespace evmc::literals;
+using intx::operator""_u256;
+
+namespace
+{
+// NOTE: 原始数字分隔符写法 1'000'...'_u256 在本仓库 vcpkg 锁定的 intx 0.15.0 下编译失败：
+// intx::from_string 的 from_dec_digit 不识别 '\'' 分隔符（consteval 求值直接抛错，
+// 见 intx.hpp from_dec_digit/from_string）。数值不变，仅去除分隔符使其可编译。
+constexpr auto kFunding = 1000000000000000000_u256;  // 1 ETH in wei
+constexpr auto kWithdrawalWei = 5000000000_u256;     // 5 gwei = 5e9 wei
+
+// 最小内存 StateView 桩：三个只读方法与真实实现语义对齐（code_hash = keccak256(code)，
+// has_storage = 存储非空）。内存后端与 StateDiff 回写缝属后续 PR；本文件的断言直接
+// 检查 receipt.state_diff / finalize 返回的 diff，不做写回。
+struct StubAccount
+{
+    uint64_t nonce = 0;
+    intx::uint256 balance;
+    std::map<evmc::bytes32, evmc::bytes32> storage;
+    evmc::bytes code;
+};
+
+class StubState : public state::StateView
+{
+public:
+    std::map<evmc::address, StubAccount> accounts;
+
+    std::optional<Account> get_account(const evmc::address& addr) const noexcept override
+    {
+        const auto it = accounts.find(addr);
+        if (it == accounts.end())
+            return std::nullopt;
+        const auto& acc = it->second;
+        return Account{acc.nonce, acc.balance, keccak256(acc.code), !acc.storage.empty()};
+    }
+
+    evmc::bytes get_account_code(const evmc::address& addr) const noexcept override
+    {
+        const auto it = accounts.find(addr);
+        return it != accounts.end() ? it->second.code : evmc::bytes{};
+    }
+
+    evmc::bytes32 get_storage(
+        const evmc::address& addr, const evmc::bytes32& key) const noexcept override
+    {
+        const auto it = accounts.find(addr);
+        if (it == accounts.end())
+            return {};
+        const auto sit = it->second.storage.find(key);
+        return sit != it->second.storage.end() ? sit->second : evmc::bytes32{};
+    }
+};
+
+class StubBlockHashes : public state::BlockHashes
+{
+public:
+    evmc::bytes32 get_block_hash(int64_t /*block_number*/) const noexcept override { return {}; }
+};
+
+// 在 diff 的 modified_accounts 中查找账户条目；找不到返回 nullptr。
+const state::StateDiff::Entry* findModified(const state::StateDiff& diff, const evmc::address& addr)
+{
+    for (const auto& m : diff.modified_accounts)
+        if (m.addr == addr)
+            return &m;
+    return nullptr;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(EthTransitionTest)
+
+BOOST_AUTO_TEST_CASE(SimpleTransfer21000)
+{
+    const auto sender = 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address;
+    const auto receiver = 0x0000000000000000000000000000000000001234_address;
+
+    StubState state;
+    state.accounts[sender].balance = kFunding;  // nonce 缺省 0
+
+    state::BlockInfo block;
+    block.number = 1;
+    block.gas_limit = 30'000'000;
+    block.base_fee = 7;
+    block.coinbase = 0x00000000000000000000000000000000c014ba5e_address;
+
+    state::Transaction tx;
+    tx.type = state::Transaction::Type::eip1559;
+    tx.sender = sender;
+    tx.to = receiver;
+    tx.value = 1000;
+    tx.gas_limit = 100'000;
+    tx.max_gas_price = 1000;
+    tx.max_priority_gas_price = 10;
+    tx.nonce = 0;
+
+    evmc::VM vm{evmc_create_evmone()};
+    StubBlockHashes hashes;
+    const auto res = bcos::evmref::eth::runTransaction(
+        state, block, hashes, tx, EVMC_CANCUN, vm, block.gas_limit, 786432);
+
+    if (const auto* err = std::get_if<std::error_code>(&res))
+        BOOST_FAIL("runTransaction: " + err->message());
+    const auto& receipt = std::get<state::TransactionReceipt>(res);
+    BOOST_CHECK(receipt.status == EVMC_SUCCESS);
+    BOOST_CHECK_EQUAL(receipt.gas_used, 21000);
+
+    // 包装不写回：结果只体现在 receipt.state_diff 中
+    const auto* entry = findModified(receipt.state_diff, receiver);
+    BOOST_REQUIRE(entry != nullptr);
+    BOOST_CHECK(entry->balance == 1000);
+}
+
+BOOST_AUTO_TEST_CASE(InvalidTxRejectedWithoutSideEffect)
+{
+    const auto sender = 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address;
+    StubState state;
+    state.accounts[sender].balance = 1_u256;  // 付不起 gas；nonce 缺省 0
+
+    state::BlockInfo block;
+    block.number = 1;
+    block.gas_limit = 30'000'000;
+    block.base_fee = 7;
+
+    state::Transaction tx;
+    tx.type = state::Transaction::Type::eip1559;
+    tx.sender = sender;
+    tx.to = sender;
+    tx.gas_limit = 100'000;
+    tx.max_gas_price = 1000;
+    tx.max_priority_gas_price = 10;
+    tx.nonce = 0;
+
+    evmc::VM vm{evmc_create_evmone()};
+    StubBlockHashes hashes;
+    const auto res = bcos::evmref::eth::runTransaction(
+        state, block, hashes, tx, EVMC_CANCUN, vm, block.gas_limit, 786432);
+
+    BOOST_REQUIRE(std::holds_alternative<std::error_code>(res));
+    BOOST_CHECK(std::get<std::error_code>(res) ==
+                state::make_error_code(state::INSUFFICIENT_FUNDS));  // 钉住拒因，防其他校验失败假绿
+}
+
+// 钉死 blockGasLeft/blobGasLeft 两个相邻 int64_t 形参不被换序：
+// blobGasLeft=0 时 type-3 blob tx 必须被拒（换序后 786432 会放行它）。
+BOOST_AUTO_TEST_CASE(BlobTxRejectedWhenNoBlobGasLeft)
+{
+    const auto sender = 0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b_address;
+    StubState state;
+    state.accounts[sender].balance = kFunding;  // nonce 缺省 0
+
+    state::BlockInfo block;
+    block.number = 1;
+    block.gas_limit = 30'000'000;
+    block.base_fee = 7;
+    block.blob_base_fee = 1;
+
+    state::Transaction tx;
+    tx.type = state::Transaction::Type::blob;
+    tx.sender = sender;
+    tx.to = 0x0000000000000000000000000000000000001234_address;  // blob tx 必须有 to
+    tx.gas_limit = 100'000;
+    tx.max_gas_price = 1000;
+    tx.max_priority_gas_price = 10;
+    tx.max_blob_gas_price = 1;
+    tx.blob_hashes = {0x0100000000000000000000000000000000000000000000000000000000000001_bytes32};
+    tx.nonce = 0;
+
+    evmc::VM vm{evmc_create_evmone()};
+    StubBlockHashes hashes;
+    const auto res = bcos::evmref::eth::runTransaction(
+        state, block, hashes, tx, EVMC_CANCUN, vm, block.gas_limit, /*blobGasLeft=*/0);
+
+    BOOST_REQUIRE(std::holds_alternative<std::error_code>(res));
+    BOOST_CHECK(std::get<std::error_code>(res) ==
+                state::make_error_code(state::BLOB_GAS_LIMIT_EXCEEDED));  // 拒因必须是 blob 预算
+}
+
+// runBlockFinalize 的 withdrawals 路径：金额按 gwei 计，diff 中须为 ×1e9 换算后的 wei。
+BOOST_AUTO_TEST_CASE(FinalizeAppliesWithdrawalGweiToWei)
+{
+    const auto payee = 0x0000000000000000000000000000000000005e11_address;
+    StubState state;
+
+    const state::Withdrawal w{
+        .index = 0, .validator_index = 0, .recipient = payee, .amount_in_gwei = 5};
+    const auto diff = bcos::evmref::eth::runBlockFinalize(state, EVMC_CANCUN,
+        0x00000000000000000000000000000000c014ba5e_address, std::nullopt, {}, std::span{&w, 1});
+
+    const auto* entry = findModified(diff, payee);
+    BOOST_REQUIRE(entry != nullptr);
+    BOOST_CHECK(entry->balance == kWithdrawalWei);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/ports/evmone/portfile.cmake
+++ b/ports/evmone/portfile.cmake
@@ -78,6 +78,8 @@ file(INSTALL
     "${SOURCE_PATH}/lib/evmone/vm.hpp"
     "${SOURCE_PATH}/lib/evmone/execution_state.hpp"
     "${SOURCE_PATH}/lib/evmone/tracing.hpp"
+    "${SOURCE_PATH}/lib/evmone/constants.hpp"
+    "${SOURCE_PATH}/lib/evmone/delegation.hpp"
     DESTINATION "${CURRENT_PACKAGES_DIR}/include/evmone")
 
 # 4c. Install phase-1 precompile crypto headers used directly by FISCO-BCOS.
@@ -89,6 +91,9 @@ file(INSTALL
     "${SOURCE_PATH}/lib/evmone_precompiles/bn254.hpp"
     "${SOURCE_PATH}/lib/evmone_precompiles/ecc.hpp"
     "${SOURCE_PATH}/lib/evmone_precompiles/hash_types.h"
+    "${SOURCE_PATH}/lib/evmone_precompiles/keccak.h"
+    "${SOURCE_PATH}/lib/evmone_precompiles/keccak.hpp"
+    "${SOURCE_PATH}/lib/evmone_precompiles/secp256k1.hpp"
     "${SOURCE_PATH}/lib/evmone_precompiles/mulmod.hpp"
     "${SOURCE_PATH}/lib/evmone_precompiles/secp256r1.hpp"
     "${SOURCE_PATH}/lib/evmone_precompiles/modexp.hpp"
@@ -136,6 +141,7 @@ if(NOT TARGET evmone::evmone)
             "${CMAKE_CURRENT_LIST_DIR}/../../lib/${_evmone_lib_prefix}evmone_precompiles${_evmone_lib_suffix}"
         INTERFACE_LINK_LIBRARIES "blst"
     )
+
 endif()
 ]=])
 

--- a/ports/evmone/vcpkg.json
+++ b/ports/evmone/vcpkg.json
@@ -1,6 +1,7 @@
 {
     "name": "evmone",
     "version-string": "0.21.0",
+    "port-version": 2,
     "homepage": "https://github.com/ipsilon/evmone",
     "description": "Fast Ethereum Virtual Machine implementation (EVMC merged)",
     "dependencies": [


### PR DESCRIPTION
## What

PR 1/N of the bcos-evm reference execution module (stacked series; PR 2 adds
the in-memory state backend + StateDiff writeback seam, later PRs add the
opstack layer).

- `eth/EthTransition`: validate -> transition wrapper for single-tx execution,
  reusing evmone's state transition end to end (zero-fee logic included)
- 23 files verbatim-inlined from evmone `test/state` (+ `stdx/utility.hpp`):
  FISCO needs to modify the state layer, and depending on an external
  library's test/ directory cannot support that
- `ports/evmone` stays a pure upstream dependency: no test/-related patches,
  no nlohmann-json (port-version 2)
- Tests: `EthTransitionTest` (Boost.Test) with an in-test StateView stub;
  pins rejection error codes (INSUFFICIENT_FUNDS / BLOB_GAS_LIMIT_EXCEEDED)
  and the blockGasLeft/blobGasLeft parameter order

## Upstream baseline (vendored-code provenance)

| | |
|---|---|
| release | https://github.com/ipsilon/evmone/releases/tag/v0.21.0 |
| commit | `35b7e1eecd25ec9564f7c010d9ed97062b020fe8` (tag `v0.21.0`) |
| license | Apache-2.0 (original copyright headers preserved) |

The files are byte-identical in the mirror the vcpkg overlay port builds from
(`ywy2090/evmone@3585c2cb`, branch `v0.21.0`, an EVMC-merged repackaging that
leaves `test/state` and `test/utils/stdx` untouched) - verified against both.

Mapping (byte-identical, zero content modifications):

- `test/state/` (22 files) -> `bcos-evm/bcos-evm/eth/state/`
- `test/utils/stdx/utility.hpp` -> `bcos-evm/bcos-evm/eth/utils/stdx/utility.hpp`

Excluded besides the upstream-optional gmp/libsecp256k1 pairs:
`ethash_difficulty.*` (dead code here - no consumer in the ported closure;
pre-merge PoW difficulty is not applicable), mpt/rlp (ported when
state/receipts root computation lands), JSON test loaders,
`test_state.{hpp,cpp}` (in-memory backend - follow-up PR).

Verify:

```bash
diff -r -x CMakeLists.txt -x 'precompiles_gmp.*' -x 'precompiles_libsecp256k1.*' \
    -x 'ethash_difficulty.*' \
    <upstream>/test/state bcos-evm/bcos-evm/eth/state
diff -r <upstream>/test/utils/stdx bcos-evm/bcos-evm/eth/utils/stdx
```

Both must produce empty output. As verbatim-vendored code, these files carry
a file-scoped `-Wno-missing-field-initializers` (they inherit the repo-wide
`-Werror`; AppleClang promotes upstream's aggregate-init warnings to errors)
and are exempt from local formatting policy.

Regression on this branch: full ctest 1484/1485 passed; `BcosEvmEthTests`
green.
