### PR TITLE
Fix compilation errors in verifyProofChain: use member function calls instead of field access

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/Proof.h
+++ b/bcos-ledger/bcos-ledger/mpt/Proof.h
@@ -402,17 +402,17 @@ std::optional<bcos::bytes> verifyProofChain(bcos::h256 const& expectedRoot,
         }
         NodeRef const& child = branch.children.at(path.at(pos));
         ++pos;
-        if (child.kind == NodeRef::Kind::Hash)
+        if (child.kind() == NodeRef::Kind::Hash)
         {
-            node = takeNode(child.hash);
+            node = takeNode(child.hash());
         }
-        else if (child.inlineBytes.empty())
+        else if (child.inlineRef().empty())
         {
             return finish({});  // absent child: exclusion
         }
         else
         {
-            node = decodeChecked(bcos::ref(child.inlineBytes));
+            node = decodeChecked(child.inlineRef());
         }
     }
     return std::nullopt;  // hash mismatch, malformed node, or dangling ref


### PR DESCRIPTION
## 修复内容

修复 `bcos-ledger/bcos-ledger/mpt/Proof.h` 中 `verifyProofChain` 函数的编译错误。

### 问题描述

`NodeRef` 结构体中的 `kind()`、`hash()`、`inlineRef()` 均为**成员函数**，而非数据成员。原代码错误地将其作为字段直接访问，导致编译失败。

### 具体修改

`Proof.h` 第 405-415 行，共 4 处修正：

| 原代码 | 修正后 | 说明 |
|--------|--------|------|
| `child.kind` | `child.kind()` | `kind` 是成员函数 |
| `child.hash` | `child.hash()` | `hash` 是成员函数 |
| `child.inlineBytes` | `child.inlineRef()` | 成员名是 `inlineRef`（也是函数） |
| `bcos::ref(child.inlineBytes)` | `child.inlineRef()` | `inlineRef()` 返回的就是 `bytesConstRef`，无需额外包装 |

### 验证

全量编译已通过，66/66 目标全部构建成功。