### PR TITLE
fix: resolve CMake 4.x compatibility issue on macos-15 by unlinking Homebrew cmake

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -106,19 +106,15 @@ jobs:
           cd build
           CC=gcc-14 CXX=g++-14 cmake -G Ninja -DCMAKE_BUILD_TYPE=MinSizeRel -DLINKER=mold -DTESTS=ON -DCOVERAGE=OFF -DWITH_LIGHTNODE=ON -DWITH_CPPSDK=ON -DWITH_TIKV=OFF -DWITH_WASM=OFF -DWITH_TARS_SERVICES=OFF -DTOOL=OFF -DVCPKG_TARGET_TRIPLET=arm64-linux-release ${EXTRA_FLAGS} ..
       - name: Configure for macOS
-        if: matrix.os == 'macos-15'
+        if: matrix.os == 'macos-15' || matrix.os == 'macos-15-intel'
         run: |
+          brew unlink cmake 2>/dev/null || true
+          cmake --version
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           mkdir -p build
           cd build
-          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=MinSizeRel -DTESTS=ON -DCOVERAGE=OFF -DWITH_LIGHTNODE=ON -DWITH_CPPSDK=ON -DWITH_TIKV=OFF -DWITH_WASM=OFF -DWITH_TARS_SERVICES=OFF -DTOOL=OFF -DVCPKG_TARGET_TRIPLET=arm64-osx-release ${EXTRA_FLAGS} ..
-      - name: Configure for macOS (Intel)
-        if: matrix.os == 'macos-15-intel'
-        run: |
-          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-          mkdir -p build
-          cd build
-          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=MinSizeRel -DTESTS=ON -DCOVERAGE=OFF -DWITH_LIGHTNODE=ON -DWITH_CPPSDK=ON -DWITH_TIKV=OFF -DWITH_WASM=OFF -DWITH_TARS_SERVICES=OFF -DTOOL=OFF -DVCPKG_TARGET_TRIPLET=x64-osx-release ${EXTRA_FLAGS} ..
+          ARCH=$(echo "${{ runner.arch }}" | tr '[:upper:]' '[:lower:]')
+          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=MinSizeRel -DTESTS=ON -DCOVERAGE=OFF -DWITH_LIGHTNODE=ON -DWITH_CPPSDK=ON -DWITH_TIKV=OFF -DWITH_WASM=OFF -DWITH_TARS_SERVICES=OFF -DTOOL=OFF -DVCPKG_TARGET_TRIPLET=${ARCH}-osx-release ${EXTRA_FLAGS} ..
       - name: Configure for windows
         if: matrix.os == 'windows-2025'
         run: |


### PR DESCRIPTION
## 问题

macos-15 上 CI 编译失败，错误为：

```
CMake Error: The warning category "old-style-cast" is not known.
```

**根因**：macos-15 自带的 Homebrew CMake 为 4.x 版本，该版本移除了 `old-style-cast` deprecation warning 类别。而 vcpkg 在构建 port（如 benchmark）时，会通过 triplet/toolchain 传递 `-Werror=old-style-cast` 给 cmake，导致 cmake 4.x 直接报错退出。

虽然 workflow 已通过 `lukka/get-cmake@latest` 安装 CMake 3.28.3，但 Homebrew 的 cmake 在 PATH 中的优先级更高，vcpkg 实际调用的是 `/opt/homebrew/bin/cmake`（4.x）。

## 修复

在两处 macOS configure 步骤中，前置 `brew unlink cmake`，确保 vcpkg 使用 `lukka/get-cmake` 安装的 CMake 3.28.3。

同时将 `macos-15` 和 `macos-15-intel` 的 configure 步骤合并为一个，二者仅 `VCPKG_TARGET_TRIPLET` 不同（arm64 vs x64），通过 `runner.arch` 转小写动态拼接。