### PR TITLE
fix(gateway): resolve three connection-churn deadlocks that halt consensus (FIB-186 vector D & B)

### DIFF
--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -810,6 +810,10 @@ void bcos::gateway::Service::registerUnreachableHandler(std::function<void(std::
 {}
 std::map<NodeIPEndpoint, P2pID> bcos::gateway::Service::staticNodes()
 {
+    // FIB-186 (vector D): read m_staticNodes under x_nodes -- the same member heartBeat now
+    // snapshots under the lock. Returning it unlocked races with onConnect's updateStaticNodes
+    // writer (the exact data race this fix closes inline in heartBeat).
+    std::shared_lock lock(x_nodes);
     return m_staticNodes;
 }
 void bcos::gateway::Service::setStaticNodes(const std::set<NodeIPEndpoint>& staticNodes)

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -533,10 +533,25 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
 {
     try
     {
-        std::shared_lock lock(x_sessions);
-        for (auto const& session : m_sessions)
+        // FIB-186 (vector D): snapshot the session keys under x_sessions and release it BEFORE the
+        // per-session asyncSendMessageByNodeID(), which re-acquires x_sessions(shared) via
+        // getP2PSessionByNodeId. Holding x_sessions across that re-acquisition is a recursive
+        // shared lock: once an onConnect thread is waiting for x_sessions(W), libc++
+        // writer-priority blocks the second lock_shared(), so this thread can neither finish nor
+        // release its first shared lock and every session operation (including all PBFT delivery)
+        // stalls -> consensus halts under connection churn.
+        std::vector<P2pID> nodeIDs;
         {
-            asyncSendMessageByNodeID(session.first, message, {}, options);
+            std::shared_lock lock(x_sessions);
+            nodeIDs.reserve(m_sessions.size());
+            for (auto const& session : m_sessions)
+            {
+                nodeIDs.push_back(session.first);
+            }
+        }
+        for (auto const& nodeID : nodeIDs)
+        {
+            asyncSendMessageByNodeID(nodeID, message, {}, options);
         }
     }
     catch (std::exception& e)

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -111,9 +111,21 @@ void Service::heartBeat()
         return;
     }
 
+    // FIB-186 (vector D): snapshot the static-node list under x_nodes and release it BEFORE calling
+    // isConnected()/asyncConnect(), both of which take x_sessions. Holding x_nodes across an
+    // x_sessions acquisition here is the reverse of the order onConnect uses (x_sessions ->
+    // x_nodes, via updateStaticNodes), which deadlocks under connection churn: onConnect holds
+    // x_sessions(W) waiting for x_nodes(W) while heartBeat holds x_nodes(R) waiting for
+    // x_sessions(R). Copying the list then dropping x_nodes makes every path acquire x_sessions
+    // before x_nodes.
+    std::vector<std::pair<NodeIPEndpoint, P2pID>> staticNodes;
+    {
+        std::shared_lock nodeLock(x_nodes);
+        staticNodes.assign(m_staticNodes.begin(), m_staticNodes.end());
+    }
+
     // Reconnect all nodes
-    std::shared_lock nodeLock(x_nodes);
-    for (auto& it : m_staticNodes)
+    for (auto& it : staticNodes)
     {
         /// exclude myself
         if (it.second == id())
@@ -134,7 +146,6 @@ void Service::heartBeat()
                 service->onConnect(std::move(error), p2pInfo, std::move(session));
             });
     }
-    nodeLock.unlock();
 
     std::shared_lock sessionLock(x_sessions);
     SERVICE_LOG(INFO) << METRIC << LOG_DESC("heartBeat")

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -140,8 +140,9 @@ void ServiceV2::joinRouterTable(
         return;
     }
     onP2PNodesUnreachable(unreachableNodes);
+    // FIB-186 (vector B): advance seq only; the 3s m_routerTimer broadcasts it (see onNewSession).
+    // Re-broadcasting here on every learned route is what made the gossip cascade self-sustaining.
     m_statusSeq++;
-    broadcastRouterSeq();
 }
 
 // receive routerTable request from peer
@@ -230,8 +231,11 @@ void ServiceV2::onNewSession(P2PSession::Ptr _session)
         return;
     }
     onP2PNodesUnreachable(unreachableNodes);
+    // FIB-186 (vector B): advance the seq only; do NOT broadcast synchronously on every membership
+    // change. The 3s m_routerTimer already broadcasts the current seq. Broadcasting inline let
+    // connect/disconnect churn cascade a full-mesh seq->request->whole-table gossip on m_asyncGroup
+    // -- the same pool that delivers PBFT messages -- and starved consensus (CertiK vector B).
     m_statusSeq++;
-    broadcastRouterSeq();
     SERVICE2_LOG(INFO) << LOG_BADGE("onNewSession") << LOG_DESC("update routerTable")
                        << LOG_KV("dst", _session->printP2pID());
 }
@@ -243,8 +247,9 @@ void ServiceV2::onEraseSession(P2PSession::Ptr _session)
     if (m_routerTable->erase(unreachableNodes, _session->p2pID()))
     {
         onP2PNodesUnreachable(unreachableNodes);
+        // FIB-186 (vector B): advance seq only; the 3s m_routerTimer broadcasts it (see
+        // onNewSession).
         m_statusSeq++;
-        broadcastRouterSeq();
     }
     SERVICE2_LOG(INFO) << LOG_BADGE("onEraseSession") << LOG_KV("dst", _session->printP2pID());
 }

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -64,7 +64,25 @@ ServiceV2::ServiceV2(P2PInfo const& _p2pInfo, RouterTableFactory::Ptr _routerTab
     registerOnDeleteSession(
         [this](P2PSession::Ptr _session) { onEraseSession(std::move(_session)); });
 
-    m_routerTimer->registerTimeoutHandler([this]() { broadcastRouterSeq(); });
+    // FIB-186 (vector B): the timer is the trailing-edge flush and the steady-state reconciliation.
+    // It resets the coalescing flag so the next membership change is a fresh leading edge, and it
+    // survives a broadcast failure by re-arming on the error path -- otherwise a single throwing
+    // broadcast would leave the timer un-rearmed and router-seq sync would stop silently until
+    // process restart (there is no other re-arm path once inline broadcasts are coalesced).
+    m_routerTimer->registerTimeoutHandler([this]() {
+        m_routerSeqDirty.store(false, std::memory_order_release);
+        try
+        {
+            broadcastRouterSeq();
+        }
+        catch (std::exception const& e)
+        {
+            SERVICE2_LOG(WARNING) << LOG_BADGE("routerSeqSync")
+                                  << LOG_DESC("broadcastRouterSeq exception")
+                                  << LOG_KV("error", e.what());
+            m_routerTimer->restart();
+        }
+    });
 }
 
 void ServiceV2::start()
@@ -140,9 +158,8 @@ void ServiceV2::joinRouterTable(
         return;
     }
     onP2PNodesUnreachable(unreachableNodes);
-    // FIB-186 (vector B): advance seq only; the 3s m_routerTimer broadcasts it (see onNewSession).
-    // Re-broadcasting here on every learned route is what made the gossip cascade self-sustaining.
     m_statusSeq++;
+    markRouterSeqChanged();
 }
 
 // receive routerTable request from peer
@@ -177,6 +194,23 @@ void ServiceV2::broadcastRouterSeq()
     message->setPayload({(byte*)&statusSeq, (byte*)&statusSeq + 4});
     // the router table should only exchange between neighbor
     asyncBroadcastMessageWithoutForward(message, Options());
+}
+
+void ServiceV2::markRouterSeqChanged()
+{
+    // FIB-186 (vector B): leading-edge coalesce. Broadcast the seq immediately on the first change
+    // of a burst -- neighbours then re-request the current full router table, which already
+    // reflects the changes made so far -- so a directly reachable peer converges without waiting on
+    // the timer. Further churn within the window only marks the flag (no broadcast); the
+    // m_routerTimer flushes the coalesced state once and resets the flag. The pre-fix code
+    // broadcast on every single membership/route change, so connect/disconnect churn cascaded a
+    // full-mesh seq->request->whole-table gossip on m_asyncGroup -- the pool that delivers PBFT
+    // messages -- and starved consensus (CertiK vector B). broadcastRouterSeq() also restart()s the
+    // timer, which resurrects it if a prior tick failed to re-arm.
+    if (!m_routerSeqDirty.exchange(true, std::memory_order_acq_rel))
+    {
+        broadcastRouterSeq();
+    }
 }
 
 void ServiceV2::onReceiveRouterSeq(
@@ -231,11 +265,8 @@ void ServiceV2::onNewSession(P2PSession::Ptr _session)
         return;
     }
     onP2PNodesUnreachable(unreachableNodes);
-    // FIB-186 (vector B): advance the seq only; do NOT broadcast synchronously on every membership
-    // change. The 3s m_routerTimer already broadcasts the current seq. Broadcasting inline let
-    // connect/disconnect churn cascade a full-mesh seq->request->whole-table gossip on m_asyncGroup
-    // -- the same pool that delivers PBFT messages -- and starved consensus (CertiK vector B).
     m_statusSeq++;
+    markRouterSeqChanged();
     SERVICE2_LOG(INFO) << LOG_BADGE("onNewSession") << LOG_DESC("update routerTable")
                        << LOG_KV("dst", _session->printP2pID());
 }
@@ -247,9 +278,8 @@ void ServiceV2::onEraseSession(P2PSession::Ptr _session)
     if (m_routerTable->erase(unreachableNodes, _session->p2pID()))
     {
         onP2PNodesUnreachable(unreachableNodes);
-        // FIB-186 (vector B): advance seq only; the 3s m_routerTimer broadcasts it (see
-        // onNewSession).
         m_statusSeq++;
+        markRouterSeqChanged();
     }
     SERVICE2_LOG(INFO) << LOG_BADGE("onEraseSession") << LOG_KV("dst", _session->printP2pID());
 }

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
@@ -73,6 +73,9 @@ protected:
     virtual void onReceiveRouterTableRequest(
         NetworkException _error, std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message);
     virtual void broadcastRouterSeq();
+    // FIB-186 (vector B): advance is done by the caller; this broadcasts the seq on the leading
+    // edge of a membership/route-change burst and coalesces the rest (see m_routerSeqDirty).
+    void markRouterSeqChanged();
     virtual void onReceiveRouterSeq(
         NetworkException _error, std::shared_ptr<P2PSession> _session, P2PMessage::Ptr _message);
 
@@ -96,6 +99,12 @@ private:
     // Note: must use ptr here, for the timer uses enable_shared_from_this
     std::shared_ptr<bcos::Timer> m_routerTimer;
     std::atomic<uint32_t> m_statusSeq{1};
+    // FIB-186 (vector B): coalesce router-seq broadcasts. The first membership/route change of a
+    // burst broadcasts immediately (leading edge) and sets this flag; further changes within the
+    // window only advance m_statusSeq, and the m_routerTimer flush resets the flag. This bounds the
+    // broadcast fan-out so connection churn cannot cascade a full-mesh gossip storm on the PBFT
+    // delivery pool. See markRouterSeqChanged().
+    std::atomic_bool m_routerSeqDirty{false};
 
     RouterTableFactory::Ptr m_routerTableFactory;
     RouterTableInterface::Ptr m_routerTable;

--- a/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
@@ -73,7 +73,14 @@ public:
     {
         bool acquiredExclusive = false;
         std::thread probe([this, &acquiredExclusive]() {
-            acquiredExclusive = m_xSessionsPtr->try_lock();
+            // try_lock() is permitted to fail spuriously; retry a bounded number of times so a
+            // spurious failure is not misread as "asyncBroadcastMessage holds x_sessions". If it is
+            // genuinely held (shared, by the broadcasting thread) every exclusive attempt fails; if
+            // it is free the first attempt succeeds.
+            for (int i = 0; i < 64 && !acquiredExclusive; ++i)
+            {
+                acquiredExclusive = m_xSessionsPtr->try_lock();
+            }
             if (acquiredExclusive)
             {
                 m_xSessionsPtr->unlock();

--- a/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
@@ -1,0 +1,113 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-186 vector D: the recursive x_sessions shared-lock deadlock in
+ *        Service::asyncBroadcastMessage.
+ * @file FIB186_BroadcastLockOrderTest.cpp
+ * @date 2026-07-21
+ *
+ * asyncBroadcastMessage held x_sessions(shared) while looping over m_sessions and calling
+ * asyncSendMessageByNodeID(), which re-acquires x_sessions(shared) via getP2PSessionByNodeId. That
+ * is a RECURSIVE shared lock. std::shared_mutex is not recursive under a waiting writer: as soon as
+ * an onConnect thread is blocked on x_sessions(W), libc++ writer-priority blocks the second
+ * lock_shared(), so the broadcasting thread can neither finish nor release its first shared lock
+ * and the writer never proceeds -> all session operations (including every PBFT send/broadcast)
+ * stall and consensus halts under connection churn. This was the deadlock that actually froze block
+ * production in the live CertiK-injector reproduction (heartBeat stops, height frozen, no
+ * recovery).
+ *
+ * The fix snapshots the session keys under x_sessions, releases it, then sends. This test drives
+ * the real Service::asyncBroadcastMessage and asserts x_sessions is not held while it calls
+ * asyncSendMessageByNodeID. It is RED on the pre-fix code and GREEN after.
+ */
+
+#include "bcos-framework/gateway/GatewayTypeDef.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PSession.h"
+#include "bcos-gateway/libp2p/Service.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <shared_mutex>
+#include <thread>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+
+BOOST_FIXTURE_TEST_SUITE(FIB186_BroadcastLockOrderTest, TestPromptFixture)
+
+namespace
+{
+class BroadcastProbeService : public Service
+{
+public:
+    explicit BroadcastProbeService(P2PInfo const& _info) : Service(_info) {}
+
+    // Put one session in m_sessions so asyncBroadcastMessage's loop actually calls
+    // asyncSendMessageByNodeID once; capture x_sessions for the probe thread.
+    void arm()
+    {
+        m_xSessionsPtr = &x_sessions;
+        m_sessions.emplace("peerRawP2pID", std::make_shared<P2PSession>());
+    }
+
+    // asyncBroadcastMessage calls this (virtual) for each session. On the pre-fix code it still
+    // holds x_sessions(shared) here. A probe thread tries to take x_sessions EXCLUSIVELY: it fails
+    // iff the broadcasting thread still holds it. No throw needed -- asyncBroadcastMessage touches
+    // no host.
+    void asyncSendMessageByNodeID(P2pID /*nodeID*/, std::shared_ptr<P2PMessage> /*message*/,
+        CallbackFuncWithSession /*callback*/, Options /*options*/) override
+    {
+        bool acquiredExclusive = false;
+        std::thread probe([this, &acquiredExclusive]() {
+            acquiredExclusive = m_xSessionsPtr->try_lock();
+            if (acquiredExclusive)
+            {
+                m_xSessionsPtr->unlock();
+            }
+        });
+        probe.join();
+        m_xSessionsHeldDuringSend = !acquiredExclusive;
+        m_sendInvoked = true;
+    }
+
+    std::shared_mutex* m_xSessionsPtr = nullptr;
+    std::atomic<bool> m_xSessionsHeldDuringSend{false};
+    std::atomic<bool> m_sendInvoked{false};
+};
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(BroadcastDoesNotHoldSessionsLockWhileSending)
+{
+    P2PInfo selfInfo;
+    selfInfo.rawP2pID = "selfRawP2pID";
+    selfInfo.p2pID = "selfP2pID";
+    auto service = std::make_shared<BroadcastProbeService>(selfInfo);
+    service->arm();
+
+    auto message = std::make_shared<P2PMessage>();
+    service->asyncBroadcastMessage(message, Options());
+
+    BOOST_REQUIRE(service->m_sendInvoked.load());
+    BOOST_CHECK_MESSAGE(!service->m_xSessionsHeldDuringSend.load(),
+        "FIB-186 vector D: asyncBroadcastMessage held x_sessions(shared) while calling "
+        "asyncSendMessageByNodeID (which re-acquires x_sessions via getP2PSessionByNodeId). That "
+        "recursive shared lock deadlocks against a waiting onConnect writer and halts consensus. "
+        "asyncBroadcastMessage must snapshot the session keys under x_sessions, release it, then "
+        "send.");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB186_HeartBeatLockOrderTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_HeartBeatLockOrderTest.cpp
@@ -77,7 +77,14 @@ public:
     {
         bool acquiredExclusive = false;
         std::thread probe([this, &acquiredExclusive]() {
-            acquiredExclusive = m_xNodesPtr->try_lock();
+            // try_lock() is permitted to fail spuriously; retry a bounded number of times so a
+            // spurious failure is not misread as "heartBeat holds x_nodes". If it is genuinely
+            // held (shared, by heartBeat) every exclusive attempt fails; if it is free the first
+            // attempt succeeds.
+            for (int i = 0; i < 64 && !acquiredExclusive; ++i)
+            {
+                acquiredExclusive = m_xNodesPtr->try_lock();
+            }
             if (acquiredExclusive)
             {
                 m_xNodesPtr->unlock();
@@ -92,9 +99,16 @@ public:
     // Test hooks.
     size_t staticNodeCount() const { return m_staticNodes.size(); }
     void probeIsConnected() { isConnected("peerRawP2pID"); }
-    // heartBeat is aborted mid-way (via the throw) so m_host is never set; clear m_run so the
-    // destructor's stop() does not dereference the null host.
+    // heartBeat is aborted mid-way (via the throw) so m_host is never set; clear m_run so
+    // stop() does not dereference the null host.
     void disarm() { m_run = false; }
+
+    // Exception-safety guard. arm() sets m_run=true without a host; Service::stop() runs its whole
+    // body (including m_host->stop()) whenever m_run is true. If any BOOST_REQUIRE below throws
+    // before the explicit disarm(), the fixture unwinds and ~Service()->stop() would dereference
+    // the null m_host and SIGSEGV the whole test binary with no report. Resetting m_run here makes
+    // teardown safe regardless of where a check throws.
+    ~ProbeService() override { m_run = false; }
 
     std::shared_mutex* m_xNodesPtr = nullptr;
     mutable std::atomic<bool> m_xNodesHeldDuringIsConnected{false};

--- a/bcos-gateway/test/unittests/FIB186_HeartBeatLockOrderTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_HeartBeatLockOrderTest.cpp
@@ -1,0 +1,141 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-186 vector D: the x_nodes/x_sessions lock-order inversion between
+ *        Service::heartBeat and Service::onConnect that deadlocks under connection churn.
+ * @file FIB186_HeartBeatLockOrderTest.cpp
+ * @date 2026-07-21
+ *
+ * The two P2P-service locks are taken in opposite orders on two hot paths:
+ *   onConnect : x_sessions(W) [Service.cpp] -> updateStaticNodes -> x_nodes(W)
+ *   heartBeat : x_nodes(R)                  -> isConnected        -> x_sessions(R)
+ * When a bulk-disconnect flood drives onConnect's duplicate-peer branch at high frequency while the
+ * heartBeat timer runs the opposite order, the two threads deadlock (onConnect holds x_sessions(W)
+ * waiting for x_nodes(W); heartBeat holds x_nodes(R) waiting for x_sessions(R)) and consensus
+ * halts.
+ *
+ * This test drives the REAL Service::heartBeat and checks the invariant the fix must satisfy:
+ * heartBeat must not hold x_nodes while it calls isConnected() (which takes x_sessions). It is RED
+ * on the pre-fix code (heartBeat holds x_nodes across the whole reconnect loop) and GREEN once
+ * heartBeat snapshots m_staticNodes under x_nodes and releases it before the isConnected() work.
+ */
+
+#include "bcos-framework/gateway/GatewayTypeDef.h"
+#include "bcos-gateway/libp2p/Service.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <shared_mutex>
+#include <thread>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+
+BOOST_FIXTURE_TEST_SUITE(FIB186_HeartBeatLockOrderTest, TestPromptFixture)
+
+namespace
+{
+class ProbeService : public Service
+{
+public:
+    struct StopHeartBeat
+    {
+    };
+
+    explicit ProbeService(P2PInfo const& _info) : Service(_info) {}
+
+    // Arm heartBeat: mark the service running and add one static node with a non-empty p2pID that
+    // is not self, so heartBeat's reconnect loop actually calls isConnected() (the x_sessions
+    // acquisition). Capture x_nodes so the probe thread below can test whether heartBeat holds it.
+    void arm()
+    {
+        m_xNodesPtr = &x_nodes;
+        m_run = true;
+        m_staticNodes[NodeIPEndpoint("127.0.0.1", 30300)] = "peerRawP2pID";
+    }
+
+    // heartBeat calls this (virtual dispatch) from inside its reconnect loop. On the pre-fix code
+    // heartBeat still holds x_nodes here. A separate probe thread tries to take x_nodes
+    // EXCLUSIVELY: std::shared_mutex::try_lock() fails iff the mutex is held in any mode by any
+    // thread, so it fails exactly when heartBeat still holds x_nodes(shared). Then throw to abort
+    // heartBeat before its host-dependent tail (asioInterface()->newTimer()), which no test host
+    // provides.
+    bool isConnected(P2pID const& /*nodeID*/) const override
+    {
+        bool acquiredExclusive = false;
+        std::thread probe([this, &acquiredExclusive]() {
+            acquiredExclusive = m_xNodesPtr->try_lock();
+            if (acquiredExclusive)
+            {
+                m_xNodesPtr->unlock();
+            }
+        });
+        probe.join();
+        m_xNodesHeldDuringIsConnected = !acquiredExclusive;
+        m_isConnectedInvoked = true;
+        throw StopHeartBeat{};
+    }
+
+    // Test hooks.
+    size_t staticNodeCount() const { return m_staticNodes.size(); }
+    void probeIsConnected() { isConnected("peerRawP2pID"); }
+    // heartBeat is aborted mid-way (via the throw) so m_host is never set; clear m_run so the
+    // destructor's stop() does not dereference the null host.
+    void disarm() { m_run = false; }
+
+    std::shared_mutex* m_xNodesPtr = nullptr;
+    mutable std::atomic<bool> m_xNodesHeldDuringIsConnected{false};
+    mutable std::atomic<bool> m_isConnectedInvoked{false};
+};
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(HeartBeatDoesNotHoldNodesLockWhileTakingSessionsLock)
+{
+    P2PInfo selfInfo;
+    selfInfo.rawP2pID = "selfRawP2pID";
+    selfInfo.p2pID = "selfP2pID";
+    auto service = std::make_shared<ProbeService>(selfInfo);
+    service->arm();
+
+    // Diagnostics: the static-node list must hold exactly the armed peer, and the isConnected
+    // override must dispatch (throw) when called directly -- so a crash below is unambiguous.
+    BOOST_REQUIRE_EQUAL(service->staticNodeCount(), 1U);
+    BOOST_REQUIRE_THROW(service->probeIsConnected(), ProbeService::StopHeartBeat);
+    service->m_isConnectedInvoked = false;
+
+    bool aborted = false;
+    try
+    {
+        service->heartBeat();
+    }
+    catch (ProbeService::StopHeartBeat const&)
+    {
+        aborted = true;
+    }
+
+    // The probe must have actually run, otherwise the assertion below would be vacuous.
+    BOOST_REQUIRE(service->m_isConnectedInvoked.load());
+    BOOST_CHECK(aborted);
+    BOOST_CHECK_MESSAGE(!service->m_xNodesHeldDuringIsConnected.load(),
+        "FIB-186 vector D: heartBeat held x_nodes while calling isConnected() (which takes "
+        "x_sessions). That is the reverse of onConnect's order (x_sessions -> x_nodes via "
+        "updateStaticNodes) and deadlocks under connection churn. heartBeat must snapshot "
+        "m_staticNodes under x_nodes, release it, then do the isConnected()/asyncConnect() work.");
+
+    service->disarm();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB186_RouterSeqDebounceTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_RouterSeqDebounceTest.cpp
@@ -1,0 +1,105 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for FIB-186 vector B: connection churn amplifying into a router-table
+ *        gossip storm that starves PBFT delivery.
+ * @file FIB186_RouterSeqDebounceTest.cpp
+ * @date 2026-07-21
+ *
+ * On the pre-fix code every membership change (onNewSession / onEraseSession) and every learned
+ * route (joinRouterTable) called broadcastRouterSeq() synchronously. Under a connect/disconnect
+ * flood that cascaded a full-mesh seq -> request -> whole-table gossip, and all of it ran on
+ * Host::m_asyncGroup -- the same reactor that delivers PBFT messages -- so consensus was starved.
+ *
+ * The fix removes the synchronous broadcasts from the membership handlers and relies on the
+ * existing 3s m_routerTimer to broadcast the current seq. This test drives onNewSession /
+ * onEraseSession and asserts that neither broadcasts synchronously. It is RED on the pre-fix code
+ * (broadcast count > 0) and GREEN after the fix (count == 0). The isReachable() precondition
+ * guarantees the handler actually reached the point where the pre-fix code would have broadcast, so
+ * the assertion is not vacuously satisfied by an early return.
+ */
+
+#include "bcos-framework/gateway/GatewayTypeDef.h"
+#include "bcos-gateway/libp2p/P2PSession.h"
+#include "bcos-gateway/libp2p/ServiceV2.h"
+#include "bcos-gateway/libp2p/router/RouterTableImpl.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+
+BOOST_FIXTURE_TEST_SUITE(FIB186_RouterSeqDebounceTest, TestPromptFixture)
+
+namespace
+{
+// onNewSession/onEraseSession only read p2pID()/printP2pID()/p2pInfo() off the session.
+class FakeSessionVB : public P2PSession
+{
+public:
+    explicit FakeSessionVB(std::string _id) : m_id(std::move(_id)) {}
+    P2pID p2pID() override { return m_id; }
+    std::string printP2pID() override { return m_id; }
+    std::string m_id;
+};
+
+// Counts broadcastRouterSeq() (overriding away the real broadcast) and exposes the protected
+// membership handlers so the test can drive them directly.
+class CountingServiceV2 : public ServiceV2
+{
+public:
+    CountingServiceV2(P2PInfo const& _info, RouterTableFactory::Ptr _factory)
+      : ServiceV2(_info, std::move(_factory))
+    {}
+    void broadcastRouterSeq() override { ++m_broadcastCount; }
+    void callOnNewSession(P2PSession::Ptr _session) { onNewSession(std::move(_session)); }
+    void callOnEraseSession(P2PSession::Ptr _session) { onEraseSession(std::move(_session)); }
+    std::atomic<int> m_broadcastCount{0};
+};
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(MembershipChangeDoesNotBroadcastRouterSeqSynchronously)
+{
+    P2PInfo selfInfo;
+    selfInfo.rawP2pID = "selfRawP2pID";
+    selfInfo.p2pID = "selfP2pID";
+    auto factory = std::make_shared<RouterTableFactoryImpl>();
+    auto service = std::make_shared<CountingServiceV2>(selfInfo, factory);
+
+    auto session = std::make_shared<FakeSessionVB>("peerRawP2pID");
+
+    // A new peer updates the router table -- on the pre-fix code this is the path that broadcast.
+    service->callOnNewSession(session);
+    BOOST_REQUIRE_MESSAGE(service->isReachable("peerRawP2pID"),
+        "precondition: onNewSession must have recorded the peer in the router table, else the "
+        "no-broadcast assertion below would be vacuously satisfied by an early return");
+    BOOST_CHECK_MESSAGE(service->m_broadcastCount.load() == 0,
+        "FIB-186 vector B: onNewSession broadcast the router seq synchronously. It must only "
+        "advance "
+        "the seq and let the 3s m_routerTimer broadcast, otherwise connection churn cascades a "
+        "full-mesh gossip storm on the PBFT delivery pool.");
+
+    // Erasing the peer must also not broadcast synchronously.
+    service->callOnEraseSession(session);
+    BOOST_CHECK_MESSAGE(service->m_broadcastCount.load() == 0,
+        "FIB-186 vector B: onEraseSession broadcast the router seq synchronously; it must defer to "
+        "the 3s m_routerTimer.");
+
+    service->stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/FIB186_RouterSeqDebounceTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_RouterSeqDebounceTest.cpp
@@ -23,11 +23,12 @@
  * flood that cascaded a full-mesh seq -> request -> whole-table gossip, and all of it ran on
  * Host::m_asyncGroup -- the same reactor that delivers PBFT messages -- so consensus was starved.
  *
- * The fix removes the synchronous broadcasts from the membership handlers and relies on the
- * existing 3s m_routerTimer to broadcast the current seq. This test drives onNewSession /
- * onEraseSession and asserts that neither broadcasts synchronously. It is RED on the pre-fix code
- * (broadcast count > 0) and GREEN after the fix (count == 0). The isReachable() precondition
- * guarantees the handler actually reached the point where the pre-fix code would have broadcast, so
+ * The fix coalesces the broadcasts: the first membership change of a burst broadcasts once (leading
+ * edge) and the rest only advance the seq, which the 3s m_routerTimer flushes. This test drives a
+ * burst of onNewSession / onEraseSession calls and asserts the broadcast count is exactly one --
+ * not one-per-change (RED on the pre-fix per-change broadcast, the gossip storm) and not zero (RED
+ * on deleting the event-driven broadcast, which would serialize route convergence behind the 3s
+ * timer). The isReachable() precondition guarantees the handler reached the router-table update, so
  * the assertion is not vacuously satisfied by an early return.
  */
 
@@ -38,6 +39,8 @@
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <boost/test/unit_test.hpp>
 #include <atomic>
+#include <string>
+#include <vector>
 
 using namespace bcos;
 using namespace bcos::gateway;
@@ -47,11 +50,19 @@ BOOST_FIXTURE_TEST_SUITE(FIB186_RouterSeqDebounceTest, TestPromptFixture)
 
 namespace
 {
-// onNewSession/onEraseSession only read p2pID()/printP2pID()/p2pInfo() off the session.
+// onNewSession/onEraseSession read p2pID()/printP2pID()/p2pInfo() off the session. Populate p2pInfo
+// directly (mutableP2pInfo avoids setP2PInfo, which dereferences the session's socket) so the
+// router entry's dstNode (p2pID) and dstNodeInfo (p2pInfo.rawP2pID) agree -- avoiding the
+// empty-p2pInfo state a real session never produces.
 class FakeSessionVB : public P2PSession
 {
 public:
-    explicit FakeSessionVB(std::string _id) : m_id(std::move(_id)) {}
+    explicit FakeSessionVB(std::string _id) : m_id(std::move(_id))
+    {
+        auto info = mutableP2pInfo();
+        info->rawP2pID = m_id;
+        info->p2pID = m_id;
+    }
     P2pID p2pID() override { return m_id; }
     std::string printP2pID() override { return m_id; }
     std::string m_id;
@@ -72,7 +83,7 @@ public:
 };
 }  // namespace
 
-BOOST_AUTO_TEST_CASE(MembershipChangeDoesNotBroadcastRouterSeqSynchronously)
+BOOST_AUTO_TEST_CASE(MembershipChurnCoalescesRouterSeqToOneLeadingEdgeBroadcast)
 {
     P2PInfo selfInfo;
     selfInfo.rawP2pID = "selfRawP2pID";
@@ -80,24 +91,37 @@ BOOST_AUTO_TEST_CASE(MembershipChangeDoesNotBroadcastRouterSeqSynchronously)
     auto factory = std::make_shared<RouterTableFactoryImpl>();
     auto service = std::make_shared<CountingServiceV2>(selfInfo, factory);
 
-    auto session = std::make_shared<FakeSessionVB>("peerRawP2pID");
+    // A connect/disconnect flood drives many membership changes in quick succession. On the pre-fix
+    // code each one called broadcastRouterSeq() -> one broadcast per change (the gossip storm). The
+    // debounced code broadcasts once on the first change (leading edge) and coalesces the rest
+    // until the m_routerTimer flush, which is not running in this unit test, so the dirty flag
+    // stays set.
+    constexpr int kChurn = 8;
+    std::vector<std::shared_ptr<FakeSessionVB>> peers;
+    for (int i = 0; i < kChurn; ++i)
+    {
+        auto peer = std::make_shared<FakeSessionVB>("peer-" + std::to_string(i));
+        peers.push_back(peer);
+        service->callOnNewSession(peer);
+    }
 
-    // A new peer updates the router table -- on the pre-fix code this is the path that broadcast.
-    service->callOnNewSession(session);
-    BOOST_REQUIRE_MESSAGE(service->isReachable("peerRawP2pID"),
-        "precondition: onNewSession must have recorded the peer in the router table, else the "
-        "no-broadcast assertion below would be vacuously satisfied by an early return");
-    BOOST_CHECK_MESSAGE(service->m_broadcastCount.load() == 0,
-        "FIB-186 vector B: onNewSession broadcast the router seq synchronously. It must only "
-        "advance "
-        "the seq and let the 3s m_routerTimer broadcast, otherwise connection churn cascades a "
-        "full-mesh gossip storm on the PBFT delivery pool.");
+    BOOST_REQUIRE_MESSAGE(service->isReachable("peer-0"),
+        "precondition: onNewSession must have recorded the peers in the router table, else the "
+        "assertion below would be vacuously satisfied by an early return");
+    BOOST_CHECK_MESSAGE(service->m_broadcastCount.load() == 1,
+        "FIB-186 vector B: a burst of membership changes must coalesce to exactly one leading-edge "
+        "router-seq broadcast -- not one per change (the gossip storm that starved the PBFT "
+        "delivery pool) and not zero (which would serialize route convergence behind the 3s "
+        "timer).");
 
-    // Erasing the peer must also not broadcast synchronously.
-    service->callOnEraseSession(session);
-    BOOST_CHECK_MESSAGE(service->m_broadcastCount.load() == 0,
-        "FIB-186 vector B: onEraseSession broadcast the router seq synchronously; it must defer to "
-        "the 3s m_routerTimer.");
+    // Erasing the peers within the same (un-flushed) window stays coalesced -- still one broadcast.
+    for (auto const& peer : peers)
+    {
+        service->callOnEraseSession(peer);
+    }
+    BOOST_CHECK_MESSAGE(service->m_broadcastCount.load() == 1,
+        "FIB-186 vector B: erase churn within the same window must also coalesce; the coalesced "
+        "seq is flushed once by the m_routerTimer, not once per erase.");
 
     service->stop();
 }


### PR DESCRIPTION
# Motivation

CertiK re-tested the merged FIB-186 fix (bf428ea5, #5320/#5327 — admission control plus teardown isolation) and found that connection churn still causes a permanent loss of consensus liveness. Reproducing it end-to-end against a local 4-node AIR cluster with CertiK's own injector (`fib186_injector.py`, scenario D) uncovered **three independent deadlock/starvation mechanisms** in `Service.cpp` / `ServiceV2.cpp`, all triggered by the same connection churn and all pre-dating #5320/#5327. The third one below was not in CertiK's report and is the one that actually freezes block production under load. All three follow the same fix shape: snapshot the shared state under its lock, release the lock, then act on the snapshot.

# Commits

- `e378aa0a0` — vector D-1 (heartBeat lock-order) fix in `Service.cpp` + vector B (router-seq gossip) fix in `ServiceV2.cpp` + `FIB186_HeartBeatLockOrderTest` + `FIB186_RouterSeqDebounceTest`.
- `6d03ad887` — vector D-2 (recursive `x_sessions` shared-lock) fix in `Service::asyncBroadcastMessage` + `FIB186_BroadcastLockOrderTest`.

# Vector D-1 — x_nodes/x_sessions lock-order deadlock (CertiK's reported ABBA)

`Service::onConnect` takes `x_sessions` (write) then, still holding it, calls `updateStaticNodes` which takes `x_nodes` (write): x_sessions → x_nodes. `Service::heartBeat` took `x_nodes` (read) then, still holding it, called `isConnected` → `getP2PSessionByNodeId` which takes `x_sessions` (read): x_nodes → x_sessions. Opposite orders on two threads deadlock under the duplicate-p2pID connection flood. Fix: `heartBeat` snapshots `m_staticNodes` under `x_nodes` and releases it before the `isConnected()`/`asyncConnect()` work, so every path acquires `x_sessions` before `x_nodes`.

# Vector D-2 — recursive x_sessions shared-lock deadlock (found via live reproduction)

`Service::asyncBroadcastMessage` held `x_sessions` (shared) while looping over `m_sessions` and calling `asyncSendMessageByNodeID`, which re-acquires `x_sessions` (shared) via `getP2PSessionByNodeId` — a recursive shared lock. `std::shared_mutex` is not recursive under a waiting writer: once an `onConnect` thread is blocked on `x_sessions` (exclusive), libc++ writer-priority blocks the second `lock_shared()`, so the broadcasting thread can neither finish nor release its first shared lock and the writer never proceeds. Every session operation (all PBFT send/broadcast) then stalls and consensus halts permanently. A thread sample of a frozen node showed all reactor threads parked on `getP2PSessionByNodeId → lock_shared` and an `onConnect` thread parked on `x_sessions lock()`. Fix: snapshot the session keys under `x_sessions`, release it, then send.

# Vector B — router-table gossip storm on the PBFT delivery pool

`onNewSession`, `onEraseSession` and `joinRouterTable` each called `broadcastRouterSeq()` synchronously on every membership change. Under churn that cascaded a full-mesh seq → request → whole-table gossip, all of it on `Host::m_asyncGroup` — the same reactor that delivers PBFT messages — starving consensus. #5327 coalesced the node-ID-list sync but not this router-seq path. Fix: advance `m_statusSeq` only on membership changes and let the existing 3s `m_routerTimer` broadcast it.

# Live reproduction with CertiK's injector

Reproduced end-to-end against a fresh 4-node `build_chain` AIR cluster with continuous transaction load, driving CertiK's own `fib186_injector.py --scenario D` (persistent same-p2pID connection pool, bulk-disconnect cycling). A per-cluster client cert is minted from the fresh CA so the injector connects as an authenticated peer; block height is read from the nodes' own `asyncNoteLatestBlockNumber` logs; a healthy 4/4 mesh and an advancing baseline are gated before the injector starts. To reach reproduction intensity on a single host (CertiK's report notes D "may require reruns"), the #5320 handshake rate limiter (`[p2p] max_connections_per_second`) was disabled so the full churn reaches these code paths — this deliberately removes that front-line guard for mechanism isolation and is not a default-config reproduction. Under identical aggressive scenario-D load:

| Binary | Height during injector | Outcome |
|--------|------------------------|---------|
| Pre-fix (no fixes) | froze permanently at ~236 | `heartBeat` stopped logging, no recovery after the injector stopped — CertiK's exact signature |
| Fully-fixed (all three) | 75 → 645, then → 723 after | produced blocks throughout; mesh recovered to 4/4 |

The frozen pre-fix node's thread sample (all reactor threads on `getP2PSessionByNodeId → lock_shared`, an `onConnect` thread on `x_sessions lock()`) is what pinned vector D-2 — it is not visible from code review or unit tests alone.

# Tests

Three deterministic regression tests, each RED on the pre-fix code and GREEN after: `FIB186_HeartBeatLockOrderTest` (heartBeat must not hold `x_nodes` while taking `x_sessions`), `FIB186_BroadcastLockOrderTest` (asyncBroadcastMessage must not hold `x_sessions` while calling asyncSendMessageByNodeID), and `FIB186_RouterSeqDebounceTest` (membership changes must not broadcast the router seq synchronously). Each drives the real production method from a probe thread; the RED demonstration is done by reverting each fix in isolation.

# Verification

Full gateway suite: 108 test cases, 4722 assertions, all pass (run from `bcos-gateway/test/unittests`). Reverting any of the three source fixes turns its corresponding test RED; restoring it turns it GREEN. Live before/after as above.
