### PR TITLE
ci(codecov): check out base sources so PR coverage reports are usable

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -10,9 +10,12 @@ name: Coverage comment
 # after the build finishes, so it gets the token and write permission even for
 # fork PRs. workflow_run only triggers from the file on the default branch.
 #
-# Security: this job never checks out PR code. It consumes the coverage-data
-# artifact produced by the build and passes only a digits-validated PR number
-# to Codecov, avoiding the workflow_run "pwn request" pitfall.
+# Security: this job never checks out fork PR code. It consumes only the
+# coverage-data artifact and a digits-validated PR number from the untrusted
+# build, and the sources it checks out are the PR's BASE branch (an existing,
+# trusted branch of this repo) purely so Codecov can map report paths to real
+# files. Nothing from the fork is ever executed, so the workflow_run "pwn
+# request" pitfall is avoided.
 
 on:
   workflow_run:
@@ -39,24 +42,52 @@ jobs:
           name: coverage-data
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: cov
-      - name: Validate PR number
+          # Land the artifact OUTSIDE the workspace so the base-branch checkout
+          # below does not clobber it.
+          path: ${{ runner.temp }}/cov
+      - name: Validate PR number and resolve base branch
         id: pr
         if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          num="$(cat cov/pr-number.txt)"
+          num="$(cat "${RUNNER_TEMP}/cov/pr-number.txt")"
           # cov/* originates from the untrusted fork run: accept digits only.
           if ! printf '%s' "$num" | grep -Eq '^[0-9]+$'; then
             echo "Refusing non-numeric PR number: '$num'" >&2
             exit 1
           fi
+          # base.ref is the PR's target branch. A PR can only target a real branch
+          # of this repo, so it is trusted; still constrain it to a plain ref name.
+          base="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${num}" --jq '.base.ref')"
+          if ! printf '%s' "$base" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "Unexpected base ref: '$base'" >&2
+            exit 1
+          fi
           echo "number=$num" >> "$GITHUB_OUTPUT"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+      - name: Check out base-branch sources for path mapping
+        # Codecov builds a "network" (the repo's file list) to map each report
+        # path onto a real file; with no checkout it finds nothing to match and
+        # discards the whole report as "unusable" (0.00%). Check out the PR's BASE
+        # branch -- trusted upstream code, never executed here -- so the network is
+        # complete. NOT the fork head, keeping this a safe workflow_run job.
+        if: steps.pr.outputs.number != ''
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ steps.pr.outputs.base }}
+          persist-credentials: false
       - name: Upload to Codecov
         if: steps.pr.outputs.number != ''
         uses: codecov/codecov-action@v5
         with:
-          files: cov/coverage.info
+          files: ${{ runner.temp }}/cov/coverage.info
+          # We hand Codecov exactly one lcov file; do not let the CLI also sweep
+          # the checked-out tree for stray coverage files. (This does not affect
+          # the network scan, which is what makes path mapping work.)
+          disable_search: true
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
           # workflow_run runs on the default branch, so point Codecov back at the


### PR DESCRIPTION
## Problem

Fork-PR coverage comments have been stuck at `0.00%`. The `coverage-comment.yml` `workflow_run` listener uploads the report without checking out the repository, so codecov-cli builds its file "network" (the list of repo files it uses to map each report path onto a real file) from an empty workspace — only ~5 files (the downloaded artifact folder). Codecov then cannot match any of the report's ~800 `SF:` source paths to real files and discards the whole report as an **unusable report**, so every fork PR shows `0.00%`.

Confirmed from the upload log: `Found 1 coverage files to report` / `Found 5 network files to report`; the upload returns HTTP 200 but the commit ends in `state: error, sessions: 0` on Codecov.

## Fix

Check out the PR's base branch before the upload so codecov-cli has the real file tree and path mapping works. The base branch is an existing, trusted branch of this repo (a PR can only target a real base branch); it is only read for the file listing and is never executed, so this remains a safe `workflow_run` job — no fork code is checked out or run. The artifact now lands in `RUNNER_TEMP` so the checkout does not clobber it, and `disable_search: true` keeps the upload limited to the single lcov file (the network scan is independent of search).

## Notes

`workflow_run` only runs from the copy on the default branch, so this must land on `master` to take effect. A companion PR fixes a related "unusable report" cause in the base-branch upload on `release-3.17.0`.
