### PR TITLE
ci(codecov): upload only the lcov file for base-branch coverage

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -340,6 +340,11 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: build/coverage.info
+          # Upload only the clean lcov file. Without this, codecov-cli also
+          # sweeps the build/ tree and uploads thousands of raw .gcov/.gcda
+          # intermediates whose paths do not map to the repo, which makes
+          # Codecov reject the whole commit as an unusable report.
+          disable_search: true
           flags: unittests
           fail_ci_if_error: false
           verbose: true


### PR DESCRIPTION
## Problem

The base-branch Codecov upload (the `push`-event step that establishes the baseline the PR comment compares against) passes `files: build/coverage.info` but leaves search enabled. codecov-cli therefore also sweeps the `build/` tree and uploads thousands of raw `.gcov`/`.gcda` intermediates alongside the clean lcov file.

Confirmed from the upload log on a base push: `Found 2554 coverage files to report`. Those intermediates carry build-directory paths that do not map to the repository, so Codecov rejects the base commit as an **unusable report** — it shows `state: error, sessions: 0`, `0.00%` — which in turn leaves the PR comment with no usable base to diff against.

## Fix

Add `disable_search: true` so only `build/coverage.info` is uploaded. The network scan (used for path mapping) is independent of search and is unaffected.

## Notes

Companion to the `master` PR that fixes the fork-PR listener upload (which failed with the same "unusable report" symptom for a different reason — no source checkout).
