### PR TITLE
feat(scheduler): reject feature_raw_address with MPT state-root flags (M6.2 follow-up)

### DIFF
--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
@@ -11,32 +11,50 @@ namespace bcos::scheduler_v1
 DERIVE_BCOS_EXCEPTION(InvalidMPTFlagMatrix);
 
 // Decide whether block @p blockNumber commits with an Ethereum MPT state root instead of
-// the legacy XOR root (spec 5.6 / 5.10). Pure function; the commit path (coCommitBlock)
-// consults it once per block when the MPT branch is wired in.
+// the legacy XOR root (spec 5.6 / 5.10). The commit path (coCommitBlock) consults it once
+// per block when the MPT branch is wired in.
+//
+// @throws InvalidMPTFlagMatrix when the answer would be true while feature_raw_address is
+//         set. Throwing here is deliberate: flags can activate at block boundaries after
+//         boot, so validateMPTFlagMatrix at startup cannot see a mid-chain activation of
+//         either flag of the pair. Aborting the commit path loudly beats silently building
+//         an MPT that classifies no account table (see validateMPTFlagMatrix for why the
+//         combination is unsupported) — fail-loud over fail-silent.
 inline bool shouldBuildMPT(
     bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber)
 {
+    bool buildMPT = false;
     // Scenario B: L2 Ethereum-compat chains build the MPT from genesis on. Checked FIRST:
     // at block 0 feature_mpt_state_root is not yet active, so consulting scenario A first
     // would send an L2 chain down the XOR path.
     if (features.get(ledger::Features::Flag::feature_l2_ethereum_compat))
     {
-        return true;
+        buildMPT = true;
     }
-
     // Scenario A: MPT enabled mid-chain by feature_mpt_state_root. Strictly-greater keeps
     // the activation block N itself on XOR as the transition boundary (spec 5.10). The
     // >= 0 guard rejects activationBlockOf == -1 — a flag set() without a storage load —
     // which would otherwise silently enable MPT since blockNumber > -1 is always true.
-    if (features.get(ledger::Features::Flag::feature_mpt_state_root))
+    else if (features.get(ledger::Features::Flag::feature_mpt_state_root))
     {
         auto activationBlock =
             features.activationBlockOf(ledger::Features::Flag::feature_mpt_state_root);
-        return activationBlock >= 0 && blockNumber > activationBlock;
+        buildMPT = activationBlock >= 0 && blockNumber > activationBlock;
     }
+    // Neither flag: legacy XOR state root (buildMPT stays false).
 
-    // Neither flag: legacy XOR state root.
-    return false;
+    if (buildMPT && features.get(ledger::Features::Flag::feature_raw_address))
+    {
+        BOOST_THROW_EXCEPTION(InvalidMPTFlagMatrix{} << bcos::errinfo_comment(
+                                  "feature_raw_address is active while the MPT state root is "
+                                  "enabled (block " +
+                                  std::to_string(blockNumber) +
+                                  "); raw_address stores account tables under 20-byte binary "
+                                  "names, which the MPT delta scan cannot classify — every "
+                                  "account would silently drop out of the MPT. Unsupported in "
+                                  "v1; aborting the commit path instead of forking silently"));
+    }
+    return buildMPT;
 }
 
 // Startup-time guard for the flag matrix shouldBuildMPT relies on (spec 5.10, M7.3).
@@ -51,11 +69,35 @@ inline bool shouldBuildMPT(
 // populated; a bare set() leaves activationBlockOf at -1, which this guard rejects for
 // the same reason (an unverifiable activation must not pass a consistency check).
 //
-// @throws InvalidMPTFlagMatrix when feature_l2_ethereum_compat is set with a non-zero
-//         (or unknown) activation block. A features object without the flag always passes.
+// A second invariant guards feature_raw_address: it switches account table names from
+// /apps/<40-hex-address> to 20-byte binary addresses, but the MPT delta scan
+// (parseAccountTable, spec 5.10) only classifies 40-hex account tables. With both active,
+// every account table fails classification and silently drops out of the MPT — the chain
+// keeps committing state roots that cover no account (a silent fork against any honest
+// replica). Binary account tables are unsupported in v1, so refuse the combination with
+// either MPT flag. shouldBuildMPT re-checks this at commit time for activations that
+// happen after boot.
+//
+// @throws InvalidMPTFlagMatrix when feature_raw_address is set together with
+//         feature_mpt_state_root or feature_l2_ethereum_compat, or when
+//         feature_l2_ethereum_compat is set with a non-zero (or unknown) activation
+//         block. A features object with neither MPT flag always passes.
 inline void validateMPTFlagMatrix(bcos::ledger::Features const& features)
 {
     using Flag = bcos::ledger::Features::Flag;
+    if (features.get(Flag::feature_raw_address) &&
+        (features.get(Flag::feature_mpt_state_root) ||
+            features.get(Flag::feature_l2_ethereum_compat)))
+    {
+        BOOST_THROW_EXCEPTION(InvalidMPTFlagMatrix{} << bcos::errinfo_comment(
+                                  "feature_raw_address cannot be combined with "
+                                  "feature_mpt_state_root or feature_l2_ethereum_compat: "
+                                  "raw_address stores account tables under 20-byte binary "
+                                  "names, but the MPT delta scan only classifies 40-hex "
+                                  "/apps/<address> tables, so every account would silently "
+                                  "drop out of the MPT state root (silent fork). Binary "
+                                  "account tables are unsupported in v1 (spec 5.10)"));
+    }
     if (!features.get(Flag::feature_l2_ethereum_compat))
     {
         return;

--- a/transaction-scheduler/tests/TestRawAddressMPTGuard.cpp
+++ b/transaction-scheduler/tests/TestRawAddressMPTGuard.cpp
@@ -1,0 +1,89 @@
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::scheduler_v1;
+
+BOOST_AUTO_TEST_SUITE(RawAddressMPTGuardSuite)
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_RawAddressWithMPTStateRootThrows)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+    BOOST_CHECK_THROW(validateMPTFlagMatrix(features), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_RawAddressWithL2Throws)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    features.setActivationBlock(ledger::Features::Flag::feature_l2_ethereum_compat, 0);
+    // Must throw for the raw_address pairing even though the L2 flag alone (genesis
+    // activation) is a legal matrix.
+    BOOST_CHECK_THROW(validateMPTFlagMatrix(features), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_RawAddressAlonePasses)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(features));
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_MPTFlagsWithoutRawAddressStillPass)
+{
+    // Regression: the raw_address guard must not reject the previously-legal matrices.
+    ledger::Features scenarioA;
+    scenarioA.set(ledger::Features::Flag::feature_mpt_state_root);
+    scenarioA.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 500);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(scenarioA));
+
+    ledger::Features scenarioB;
+    scenarioB.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    scenarioB.setActivationBlock(ledger::Features::Flag::feature_l2_ethereum_compat, 0);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(scenarioB));
+}
+
+BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressWithScenarioAThrowsPastActivation)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+
+    // At and before the activation block scenario A stays on XOR, so no MPT is built and
+    // the guard must not fire.
+    BOOST_CHECK(!shouldBuildMPT(features, 99));
+    BOOST_CHECK(!shouldBuildMPT(features, 100));
+    // Past the boundary the MPT would be built: fail loudly instead of silently dropping
+    // every binary-named account table.
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 101), InvalidMPTFlagMatrix);
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 1000), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressWithScenarioBThrowsEveryBlock)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+
+    // Scenario B builds the MPT from genesis on, so the guard fires at every block.
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 0), InvalidMPTFlagMatrix);
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 1000), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressAloneUnchanged)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+
+    // Without an MPT flag the function keeps its legacy answer: XOR path, no throw.
+    BOOST_CHECK_NO_THROW(BOOST_CHECK(!shouldBuildMPT(features, 0)));
+    BOOST_CHECK_NO_THROW(BOOST_CHECK(!shouldBuildMPT(features, 1000)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Scenario

`feature_raw_address` (flag 54) switches account table names from `/apps/<40-hex-address>` to 20-byte binary addresses. The MPT build path merged in #5315 (`parseAccountTable` in `bcos-ledger/bcos-ledger/mpt/Classify.h`) only classifies 40-hex account tables. If a chain enables `feature_raw_address` together with `feature_mpt_state_root` or `feature_l2_ethereum_compat`, every account table fails classification and silently drops out of the MPT delta scan: the chain keeps committing state roots that cover no account — a silent state-root fork with no error anywhere. There was previously no mutual-exclusion check for this combination.

Binary account tables are out of scope for MPT v1, so this PR refuses the combination loudly instead of supporting it.

# Changes

`transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h`:

- `validateMPTFlagMatrix` now throws `InvalidMPTFlagMatrix` at startup when `feature_raw_address` is set together with either `feature_mpt_state_root` or `feature_l2_ethereum_compat`. The existing scenario-B genesis-activation check is unchanged.
- `shouldBuildMPT` now throws `InvalidMPTFlagMatrix` at commit time whenever it would answer true (either scenario) while `feature_raw_address` is set. This is the runtime belt for a mid-chain flag activation that startup validation cannot see — flags can activate at block boundaries after boot. Aborting the commit path loudly beats a silent fork. When no MPT flag is active the function's behavior is byte-for-byte unchanged.

# Tests

New suite `RawAddressMPTGuardSuite` (`transaction-scheduler/tests/TestRawAddressMPTGuard.cpp`, 7 cases / 15 assertions):

- `validateMPTFlagMatrix` throws on raw_address + mpt_state_root and on raw_address + l2_ethereum_compat; passes with raw_address alone and with the previously-legal MPT matrices (regression).
- `shouldBuildMPT` throws past the scenario-A activation boundary (but not at/before it, where XOR still applies) and at every block under scenario B; with raw_address alone it still returns false without throwing.

Evidence: `test-transaction-scheduler` full binary 65/65 test cases, 2781/2781 assertions passed locally (macOS arm64, RelWithDebInfo). Pre-existing `BaselineSchedulerMPTHelpersSuite` 9/9 green. The new TU also passes a standalone `-fsyntax-only` compile with the target's exact flags (unity-build include-leak guard, with negative control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
