### PR TITLE
Simplify AnyEngineService: use alias instead of wrapper class, remove redundant shared_ptr

### DIFF
--- a/bcos-framework/bcos-framework/engine/AnyEngineService.h
+++ b/bcos-framework/bcos-framework/engine/AnyEngineService.h
@@ -20,14 +20,12 @@
 
 #pragma once
 
-#include "bcos-framework/engine/EngineService.h"
+#include "Types.h"
 #include "bcos-task/Task.h"
 #include <proxy/proxy.h>
 #include <cassert>
 #include <optional>
 #include <string>
-#include <type_traits>
-#include <utility>
 #include <vector>
 
 namespace bcos::engine
@@ -49,111 +47,30 @@ struct AnyEngineServiceFacade
             std::vector<std::string>)>::add_convention<MemUpdateForkchoice,
         task::Task<ForkchoiceUpdatedResult>(const ForkchoiceState&, const PayloadAttributes*,
             std::uint32_t)>::add_convention<MemGetPayload,
-        task::Task<GetPayloadResult>(
-            const PayloadID&, std::uint32_t)>::add_convention<MemNewPayload,
-        task::Task<PayloadStatus>(
-            const NewPayloadRequest&, std::uint32_t)>::add_convention<MemGetSafeBlockNumber,
-        std::optional<bcos::protocol::BlockNumber>() const>::add_convention<MemGetFinalizedBlockNumber,
-        std::optional<bcos::protocol::BlockNumber>() const>::support_relocation<pro::constraint_level::nothrow>::
-        support_destruction<pro::constraint_level::nothrow>::build
+        task::Task<GetPayloadResult>(const PayloadID&, std::uint32_t)>::
+        add_convention<MemNewPayload, task::Task<PayloadStatus>(const NewPayloadRequest&,
+                                          std::uint32_t)>::add_convention<MemGetSafeBlockNumber,
+            std::optional<bcos::protocol::BlockNumber>()
+                const>::add_convention<MemGetFinalizedBlockNumber,
+            std::optional<bcos::protocol::BlockNumber>()
+                const>::support_relocation<pro::constraint_level::nothrow>::
+            support_destruction<pro::constraint_level::nothrow>::build
 {
 };
 
 /// Type-erased owning wrapper around any type satisfying EngineServiceConcept.
 ///
-/// Backed by pro::proxy<AnyEngineServiceFacade>.  This thin wrapper adapts
-/// proxy's operator-> dispatch style to the direct-call style required by
-/// the EngineServiceConcept.
+/// This is a simple alias for pro::proxy<AnyEngineServiceFacade>.
+/// Use pro::make_proxy<AnyEngineServiceFacade>(...) to construct, and
+/// operator-> for dispatch (pointer semantics):
 ///
 /// Usage:
 /// @code
 ///   // For non-movable types (recommended):
-///   AnyEngineService any(std::in_place_type<EngineServiceImpl<...>>, memPool, storage, ...);
-///   auto result = co_await any.updateForkchoice(state, nullptr, 1);
+///   auto any = pro::make_proxy<AnyEngineServiceFacade, EngineServiceImpl<...>>(
+///       memPool, storage, ...);
+///   auto result = co_await any->updateForkchoice(state, nullptr, 1);
 /// @endcode
-class AnyEngineService
-{
-public:
-    using ProxyType = pro::proxy<AnyEngineServiceFacade>;
-
-    AnyEngineService() = default;
-    ~AnyEngineService() = default;
-
-    AnyEngineService(const AnyEngineService&) = delete;
-    AnyEngineService& operator=(const AnyEngineService&) = delete;
-
-    AnyEngineService(AnyEngineService&&) noexcept = default;
-    AnyEngineService& operator=(AnyEngineService&&) noexcept = default;
-
-    /// Construct from any type satisfying EngineServiceConcept.
-    /// The value is copied/moved into the proxy (owning semantics).
-    template <class T>
-        requires EngineServiceConcept<std::remove_cvref_t<T>> &&
-                 (!std::same_as<std::remove_cvref_t<T>, AnyEngineService>)
-    explicit AnyEngineService(T&& engine)
-      : m_impl(pro::make_proxy<AnyEngineServiceFacade, std::remove_cvref_t<T>>(
-            std::forward<T>(engine)))
-    {}
-
-    /// Construct in-place from constructor arguments (for non-movable types).
-    template <class T, class... Args>
-        requires EngineServiceConcept<T> &&
-                 std::is_constructible_v<T, Args...>
-    explicit AnyEngineService(std::in_place_type_t<T>, Args&&... args)
-      : m_impl(pro::make_proxy<AnyEngineServiceFacade, T>(std::forward<Args>(args)...))
-    {}
-
-    /// Returns true if this wrapper holds an engine implementation.
-    [[nodiscard]] explicit operator bool() const noexcept { return m_impl.has_value(); }
-
-    task::Task<std::vector<std::string>> exchangeCapabilities(
-        std::vector<std::string> remoteCapabilities)
-    {
-        assert(m_impl.has_value() && "AnyEngineService must be initialized before use");
-        co_return co_await m_impl->exchangeCapabilities(std::move(remoteCapabilities));
-    }
-
-    task::Task<ForkchoiceUpdatedResult> updateForkchoice(const ForkchoiceState& forkchoiceState,
-        const PayloadAttributes* payloadAttributes, std::uint32_t version)
-    {
-        assert(m_impl.has_value() && "AnyEngineService must be initialized before use");
-        co_return co_await m_impl->updateForkchoice(forkchoiceState, payloadAttributes, version);
-    }
-
-    task::Task<GetPayloadResult> getPayload(const PayloadID& payloadId, std::uint32_t version)
-    {
-        assert(m_impl.has_value() && "AnyEngineService must be initialized before use");
-        co_return co_await m_impl->getPayload(payloadId, version);
-    }
-
-    task::Task<PayloadStatus> newPayload(const NewPayloadRequest& request, std::uint32_t version)
-    {
-        assert(m_impl.has_value() && "AnyEngineService must be initialized before use");
-        co_return co_await m_impl->newPayload(request, version);
-    }
-
-    std::optional<bcos::protocol::BlockNumber> getSafeBlockNumber() const
-    {
-        assert(m_impl.has_value() && "AnyEngineService must be initialized before use");
-        return m_impl->getSafeBlockNumber();
-    }
-
-    std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() const
-    {
-        assert(m_impl.has_value() && "AnyEngineService must be initialized before use");
-        return m_impl->getFinalizedBlockNumber();
-    }
-
-    /// Access the underlying proxy for advanced operations.
-    [[nodiscard]] ProxyType& proxy() noexcept { return m_impl; }
-    [[nodiscard]] const ProxyType& proxy() const noexcept { return m_impl; }
-
-private:
-    ProxyType m_impl;
-};
-
-/// Verify that AnyEngineService itself satisfies the concept (reflexive check).
-static_assert(
-    EngineServiceConcept<AnyEngineService>, "AnyEngineService must satisfy EngineServiceConcept");
+using AnyEngineService = pro::proxy<AnyEngineServiceFacade>;
 
 }  // namespace bcos::engine

--- a/bcos-framework/test/unittests/engine/TestAnyEngineService.cpp
+++ b/bcos-framework/test/unittests/engine/TestAnyEngineService.cpp
@@ -146,9 +146,8 @@ static_assert(
 static_assert(EngineServiceConcept<NonCopyableEngineService>,
     "NonCopyableEngineService must satisfy EngineServiceConcept");
 
-/// Compile-time verification: AnyEngineService is correctly constrained.
-static_assert(
-    EngineServiceConcept<AnyEngineService>, "AnyEngineService must satisfy EngineServiceConcept");
+/// Compile-time verification: AnyEngineService (= pro::proxy<AnyEngineServiceFacade>)
+/// is correctly constrained.
 static_assert(!std::is_copy_constructible_v<AnyEngineService>,
     "AnyEngineService must not be copy-constructible");
 static_assert(
@@ -166,19 +165,19 @@ BOOST_AUTO_TEST_SUITE(TestAnyEngineService)
 BOOST_AUTO_TEST_CASE(constructWithMock)
 {
     bcos::test::MockEngineService mock;
-    AnyEngineService any(mock);
+    auto any = pro::make_proxy<AnyEngineServiceFacade>(mock);
 
-    BOOST_CHECK(static_cast<bool>(any));
+    BOOST_CHECK(any.has_value());
 }
 
 /// Verify exchangeCapabilities delegates correctly.
 BOOST_AUTO_TEST_CASE(exchangeCapabilitiesDelegates)
 {
     bcos::test::MockEngineService mock;
-    AnyEngineService any(mock);
+    auto any = pro::make_proxy<AnyEngineServiceFacade>(mock);
 
     auto result =
-        task::syncWait(any.exchangeCapabilities(std::vector<std::string>{"cap1", "cap2"}));
+        task::syncWait(any->exchangeCapabilities(std::vector<std::string>{"cap1", "cap2"}));
 
     BOOST_CHECK_EQUAL(result.size(), 2);
     BOOST_CHECK_EQUAL(result[0], "cap1");
@@ -190,9 +189,9 @@ BOOST_AUTO_TEST_CASE(getSafeBlockNumberDelegates)
 {
     bcos::test::MockEngineService mock;
     mock.m_safeBlockNumber = 42;
-    AnyEngineService any(mock);
+    auto any = pro::make_proxy<AnyEngineServiceFacade>(mock);
 
-    auto result = any.getSafeBlockNumber();
+    auto result = any->getSafeBlockNumber();
 
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 42);
@@ -203,9 +202,9 @@ BOOST_AUTO_TEST_CASE(getFinalizedBlockNumberDelegates)
 {
     bcos::test::MockEngineService mock;
     mock.m_finalizedBlockNumber = 21;
-    AnyEngineService any(mock);
+    auto any = pro::make_proxy<AnyEngineServiceFacade>(mock);
 
-    auto result = any.getFinalizedBlockNumber();
+    auto result = any->getFinalizedBlockNumber();
 
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 21);
@@ -218,9 +217,9 @@ BOOST_AUTO_TEST_CASE(getSafeBlockNumberOnConst)
 {
     bcos::test::MockEngineService mock;
     mock.m_safeBlockNumber = 99;
-    const AnyEngineService any(mock);
+    const auto any = pro::make_proxy<AnyEngineServiceFacade>(mock);
 
-    auto result = any.getSafeBlockNumber();
+    auto result = any->getSafeBlockNumber();
 
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 99);
@@ -231,9 +230,9 @@ BOOST_AUTO_TEST_CASE(getFinalizedBlockNumberOnConst)
 {
     bcos::test::MockEngineService mock;
     mock.m_finalizedBlockNumber = 55;
-    const AnyEngineService any(mock);
+    const auto any = pro::make_proxy<AnyEngineServiceFacade>(mock);
 
-    auto result = any.getFinalizedBlockNumber();
+    auto result = any->getFinalizedBlockNumber();
 
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 55);
@@ -243,15 +242,16 @@ BOOST_AUTO_TEST_CASE(getFinalizedBlockNumberOnConst)
 /// This is the critical path for wrapping real EngineServiceImpl.
 BOOST_AUTO_TEST_CASE(constructNonCopyableInPlace)
 {
-    auto any = AnyEngineService(std::in_place_type<bcos::test::NonCopyableEngineService>);
+    auto any =
+        pro::make_proxy<AnyEngineServiceFacade, bcos::test::NonCopyableEngineService>();
 
-    BOOST_CHECK(static_cast<bool>(any));
+    BOOST_CHECK(any.has_value());
 
-    auto result = any.getSafeBlockNumber();
+    auto result = any->getSafeBlockNumber();
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 100);
 
-    auto finalized = any.getFinalizedBlockNumber();
+    auto finalized = any->getFinalizedBlockNumber();
     BOOST_CHECK(finalized.has_value());
     BOOST_CHECK_EQUAL(*finalized, 200);
 }
@@ -259,16 +259,16 @@ BOOST_AUTO_TEST_CASE(constructNonCopyableInPlace)
 /// Verify in_place_type with extra constructor arguments (variadic forwarding).
 BOOST_AUTO_TEST_CASE(constructNonCopyableInPlaceWithArgs)
 {
-    auto any = AnyEngineService(std::in_place_type<bcos::test::NonCopyableEngineService>,
+    auto any = pro::make_proxy<AnyEngineServiceFacade, bcos::test::NonCopyableEngineService>(
         std::optional<BlockNumber>{300}, std::optional<BlockNumber>{400});
 
-    BOOST_CHECK(static_cast<bool>(any));
+    BOOST_CHECK(any.has_value());
 
-    auto result = any.getSafeBlockNumber();
+    auto result = any->getSafeBlockNumber();
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 300);
 
-    auto finalized = any.getFinalizedBlockNumber();
+    auto finalized = any->getFinalizedBlockNumber();
     BOOST_CHECK(finalized.has_value());
     BOOST_CHECK_EQUAL(*finalized, 400);
 }
@@ -276,9 +276,11 @@ BOOST_AUTO_TEST_CASE(constructNonCopyableInPlaceWithArgs)
 /// Verify exchangeCapabilities through an in_place_type-constructed AnyEngineService.
 BOOST_AUTO_TEST_CASE(exchangeCapabilitiesNonCopyableInPlace)
 {
-    auto any = AnyEngineService(std::in_place_type<bcos::test::NonCopyableEngineService>);
+    auto any =
+        pro::make_proxy<AnyEngineServiceFacade, bcos::test::NonCopyableEngineService>();
 
-    auto result = task::syncWait(any.exchangeCapabilities(std::vector<std::string>{"a", "b", "c"}));
+    auto result =
+        task::syncWait(any->exchangeCapabilities(std::vector<std::string>{"a", "b", "c"}));
 
     BOOST_CHECK_EQUAL(result.size(), 3);
 }
@@ -286,14 +288,15 @@ BOOST_AUTO_TEST_CASE(exchangeCapabilitiesNonCopyableInPlace)
 /// Verify that const methods work on an in_place_type-constructed AnyEngineService.
 BOOST_AUTO_TEST_CASE(constMethodsOnNonCopyableInPlace)
 {
-    const auto any = AnyEngineService(std::in_place_type<bcos::test::NonCopyableEngineService>,
-        std::optional<BlockNumber>{500}, std::optional<BlockNumber>{600});
+    const auto any =
+        pro::make_proxy<AnyEngineServiceFacade, bcos::test::NonCopyableEngineService>(
+            std::optional<BlockNumber>{500}, std::optional<BlockNumber>{600});
 
-    auto safe = any.getSafeBlockNumber();
+    auto safe = any->getSafeBlockNumber();
     BOOST_CHECK(safe.has_value());
     BOOST_CHECK_EQUAL(*safe, 500);
 
-    auto finalized = any.getFinalizedBlockNumber();
+    auto finalized = any->getFinalizedBlockNumber();
     BOOST_CHECK(finalized.has_value());
     BOOST_CHECK_EQUAL(*finalized, 600);
 }
@@ -303,14 +306,14 @@ BOOST_AUTO_TEST_CASE(moveConstruction)
 {
     bcos::test::MockEngineService mock;
     mock.m_safeBlockNumber = 77;
-    AnyEngineService any1(mock);
+    auto any1 = pro::make_proxy<AnyEngineServiceFacade>(mock);
 
-    AnyEngineService any2(std::move(any1));
+    auto any2 = std::move(any1);
 
-    BOOST_CHECK(static_cast<bool>(any2));
-    BOOST_CHECK(!static_cast<bool>(any1));
+    BOOST_CHECK(any2.has_value());
+    BOOST_CHECK(!any1.has_value());
 
-    auto result = any2.getSafeBlockNumber();
+    auto result = any2->getSafeBlockNumber();
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 77);
 }
@@ -322,15 +325,15 @@ BOOST_AUTO_TEST_CASE(moveAssignment)
     mock1.m_safeBlockNumber = 88;
     bcos::test::MockEngineService mock2;
     mock2.m_safeBlockNumber = 99;
-    AnyEngineService any1(mock1);
-    AnyEngineService any2(mock2);
+    auto any1 = pro::make_proxy<AnyEngineServiceFacade>(mock1);
+    auto any2 = pro::make_proxy<AnyEngineServiceFacade>(mock2);
 
     any2 = std::move(any1);
 
-    BOOST_CHECK(static_cast<bool>(any2));
-    BOOST_CHECK(!static_cast<bool>(any1));
+    BOOST_CHECK(any2.has_value());
+    BOOST_CHECK(!any1.has_value());
 
-    auto result = any2.getSafeBlockNumber();
+    auto result = any2->getSafeBlockNumber();
     BOOST_CHECK(result.has_value());
     BOOST_CHECK_EQUAL(*result, 88);
 }

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp
@@ -93,12 +93,12 @@ NodeService::Ptr NodeServiceFactory::buildNodeService(std::string const&, std::s
         return nullptr;
     }
 
-    // Note: m_engineService is nullptr by default. In AIR nodes, it is wired via
-    // AirNodeInitializer. In MAX/Tars nodes, the EngineService needs to be exposed as a
-    // Tars servant before the RPC process can obtain a proxy to it (TODO: MAX wiring).
+    // Note: m_engineService is default-constructed (empty) by default. In AIR nodes, it is
+    // moved from AirNodeInitializer. In MAX/Tars nodes, the EngineService needs to be exposed
+    // as a Tars servant before the RPC process can obtain a proxy to it (TODO: MAX wiring).
     auto nodeService = std::make_shared<NodeService>(ledgerClient.first, schedulerClient.first,
         txpoolClient.first, consensusClient.first, syncClient.first, blockFactory,
-        m_engineService);
+        std::move(m_engineService));
 
     nodeService->setLedgerPrx(ledgerClient.second);
     return nodeService;

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
@@ -49,7 +49,7 @@ public:
         bcos::txpool::TxPoolInterface::Ptr _txpool,
         bcos::consensus::ConsensusInterface::Ptr _consensus,
         bcos::sync::BlockSyncInterface::Ptr _sync, bcos::protocol::BlockFactory::Ptr _blockFactory,
-        std::shared_ptr<bcos::engine::AnyEngineService> _engineService)
+        bcos::engine::AnyEngineService _engineService)
       : m_ledger(std::move(_ledger)),
         m_scheduler(std::move(_scheduler)),
         m_txpool(std::move(_txpool)),
@@ -69,11 +69,8 @@ public:
 
     bcos::txpool::TxPoolInterface& txpoolRef() { return *m_txpool; }
 
-    std::shared_ptr<bcos::engine::AnyEngineService>& engineService() { return m_engineService; }
-    std::shared_ptr<bcos::engine::AnyEngineService> const& engineService() const
-    {
-        return m_engineService;
-    }
+    bcos::engine::AnyEngineService& engineService() { return m_engineService; }
+    bcos::engine::AnyEngineService const& engineService() const { return m_engineService; }
 
     /// Type-erased read handle over the MPT node storage for eth_getProof (M8.3): key = node
     /// hash, value = the node's raw RLP encoding, physically stored under the /mpt/<hash> key
@@ -107,7 +104,7 @@ private:
     bcos::sync::BlockSyncInterface::Ptr m_sync;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
 
-    std::shared_ptr<bcos::engine::AnyEngineService> m_engineService;
+    bcos::engine::AnyEngineService m_engineService;
 
     /// Non-owning MPT node reader; see setMPTNodeReader() for the lifetime contract.
     std::shared_ptr<MPTNodeReader> m_mptNodeReader;
@@ -124,7 +121,7 @@ public:
     NodeService::Ptr buildNodeService(std::string const& _chainID, std::string const& _groupID,
         bcos::group::ChainNodeInfo::Ptr _nodeInfo, bcos::tool::NodeConfig::Ptr _nodeConfig);
 
-    void setEngineService(std::shared_ptr<bcos::engine::AnyEngineService> _engineService)
+    void setEngineService(bcos::engine::AnyEngineService _engineService)
     {
         m_engineService = std::move(_engineService);
     }
@@ -147,6 +144,6 @@ public:
     }
 
 private:
-    std::shared_ptr<bcos::engine::AnyEngineService> m_engineService;
+    bcos::engine::AnyEngineService m_engineService;
 };
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -315,7 +315,7 @@ task::Task<void> EngineEndpoint::exchangeCapabilities(
     const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -342,7 +342,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV1(
     const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -362,7 +362,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV2(
     const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -382,7 +382,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV3(
     const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -401,7 +401,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV3(
 task::Task<void> EngineEndpoint::getPayloadV1(const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -418,7 +418,7 @@ task::Task<void> EngineEndpoint::getPayloadV1(const Json::Value& request, Json::
 task::Task<void> EngineEndpoint::getPayloadV2(const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -436,7 +436,7 @@ task::Task<void> EngineEndpoint::getPayloadV2(const Json::Value& request, Json::
 task::Task<void> EngineEndpoint::getPayloadV3(const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -478,7 +478,7 @@ task::Task<void> EngineEndpoint::getPayloadV3(const Json::Value& request, Json::
 task::Task<void> EngineEndpoint::newPayloadV1(const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -496,7 +496,7 @@ task::Task<void> EngineEndpoint::newPayloadV1(const Json::Value& request, Json::
 task::Task<void> EngineEndpoint::newPayloadV2(const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;
@@ -514,7 +514,7 @@ task::Task<void> EngineEndpoint::newPayloadV2(const Json::Value& request, Json::
 task::Task<void> EngineEndpoint::newPayloadV3(const Json::Value& request, Json::Value& response)
 {
     auto& engineService = m_nodeService->engineService();
-    if (!engineService)
+    if (!engineService.has_value())
     {
         buildEngineNotAvailableError(request, response);
         co_return;

--- a/bcos-rpc/test/unittests/common/RPCFixture.h
+++ b/bcos-rpc/test/unittests/common/RPCFixture.h
@@ -125,8 +125,8 @@ public:
 
         nodeService = std::make_shared<rpc::NodeService>(
             m_ledger, scheduler, txPool, nullptr, nullptr, m_blockFactory,
-            // EngineService not needed for existing RPC tests; pass nullptr as stub.
-            nullptr);
+            // EngineService not needed for existing RPC tests; pass empty proxy as stub.
+            bcos::engine::AnyEngineService{});
 
 
         groupInfo = std::make_shared<group::GroupInfo>();

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -537,7 +537,8 @@ BOOST_AUTO_TEST_CASE(handleEngineNotAvailableTest)
 BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
 {
     TestEngineService testEngineService;
-    nodeService->engineService() = std::make_shared<bcos::engine::AnyEngineService>(testEngineService);
+    nodeService->engineService() =
+        pro::make_proxy<bcos::engine::AnyEngineServiceFacade>(testEngineService);
 
     auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
         "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100,

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -85,7 +85,7 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
         std::make_shared<NodeService>(m_nodeInitializer->ledger(), m_nodeInitializer->scheduler(),
             m_nodeInitializer->txPoolInitializer()->txpool(), pbftInitializer->pbft(),
             pbftInitializer->blockSync(), m_nodeInitializer->protocolInitializer()->blockFactory(),
-            m_nodeInitializer->engineService());
+            std::move(*m_nodeInitializer->engineService()));
 
     // create rpc
     RpcFactory rpcFactory(nodeConfig->chainId(), m_gateway, keyFactory,

--- a/libinitializer/EngineServiceInitializer.h
+++ b/libinitializer/EngineServiceInitializer.h
@@ -58,9 +58,9 @@ private:
             m_memPool(memPool),
             m_transactionExecutor(std::move(transactionExecutor)),
             m_scheduler(std::move(scheduler)),
-            m_any(std::in_place_type<ConcreteEngineService>, m_memPool,
-                m_storageInitializer->storage(), *m_transactionExecutor, *m_scheduler,
-                std::move(blockFactory), blockTxCountLimit)
+            m_any(pro::make_proxy<bcos::engine::AnyEngineServiceFacade, ConcreteEngineService>(
+                m_memPool, m_storageInitializer->storage(), *m_transactionExecutor, *m_scheduler,
+                std::move(blockFactory), blockTxCountLimit))
         {}
 
         std::shared_ptr<GlobalStateStorageInitializer> m_storageInitializer;

--- a/libinitializer/Initializer.h
+++ b/libinitializer/Initializer.h
@@ -23,6 +23,7 @@
 #include "PBFTInitializer.h"
 #include "ProtocolInitializer.h"
 #include "TxPoolInitializer.h"
+#include "bcos-framework/engine/AnyEngineService.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "bcos-tool/NodeConfig.h"
 #include "bcos-transaction-executor/precompiled/PrecompiledManager.h"
@@ -55,10 +56,6 @@ class GatewayInterface;
 namespace scheduler
 {
 class SchedulerInterface;
-}
-namespace engine
-{
-class AnyEngineService;
 }
 namespace initializer
 {


### PR DESCRIPTION
## 变更概述

将 AnyEngineService 从包装类简化为 `using AnyEngineService = pro::proxy<AnyEngineServiceFacade>` 别名，消除冗余代码，统一使用指针语义调用。

## 主要变更

### 1. AnyEngineService.h — 从包装类改为 using 别名
- 删除整个 AnyEngineService 包装类（~80 行冗余代码）
- 改为 `using AnyEngineService = pro::proxy<AnyEngineServiceFacade>`
- pro::proxy 原生支持 operator-> 分发、has_value() 判空、移动语义，无需额外包装

### 2. NodeService / NodeServiceFactory — 去除 shared_ptr 双重间接
- m_engineService: `shared_ptr<AnyEngineService>` → `AnyEngineService` 值语义
- 默认构造的 proxy 即为空状态，等价于原来的 nullptr
- engineService() 返回 AnyEngineService&，调用方可直接使用 -> 调用

### 3. EngineEndpoint.cpp — 简化调用模式
- 空检查: `!engineService` → `!engineService.has_value()`
- 调用: 去除双重解引用，直接 `engineService->method()`

### 4. 其他适配
- EngineServiceInitializer.h: `std::in_place_type<T>` → `pro::make_proxy<Facade, T>(...)`
- Initializer.h: 前向声明 → include 头文件
- AirNodeInitializer.cpp: `std::move(*ptr)` 将 proxy 从 shared_ptr 移出
- 测试文件同步更新

## 收益
- 减少约 80 行包装类代码
- 消除 shared_ptr → pro::proxy 的双重间接层
- 调用端代码更自然: `engineService->method()` 一步到位