### PR TITLE
fix(scheduler): consensus-path header stateRoot has been all-zero since #5215 — route execute writes through the layered view

### DIFF
--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -365,8 +365,9 @@ private:
             }
             auto ledgerConfig =
                 co_await ledger::getLedgerConfig(view, blockHeader->number(), m_blockFactory.get());
-            auto receipts = co_await m_schedulerImpl.get().executeBlock(
-                view.backendStorageRef(), m_executor.get(),
+            // Execute writes must land in the view's mutable layer: finishExecute
+            // computes the state root from it and commit merges it into the backend.
+            auto receipts = co_await m_schedulerImpl.get().executeBlock(view, m_executor.get(),
                 *blockHeader, ::ranges::views::indirect(transactions), *ledgerConfig);
 
             auto executedBlockHeader =
@@ -539,8 +540,8 @@ private:
                 {
                     auto message = std::string{"Unexpected empty results!"};
                     BASELINE_SCHEDULER_LOG(INFO) << message;
-                    co_return {BCOS_ERROR_UNIQUE_PTR(
-                                   scheduler::SchedulerError::UnknownError, message),
+                    co_return {
+                        BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::UnknownError, message),
                         nullptr};
                 }
 

--- a/transaction-scheduler/tests/TestExecuteStateRootRegression.cpp
+++ b/transaction-scheduler/tests/TestExecuteStateRootRegression.cpp
@@ -1,0 +1,389 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TestExecuteStateRootRegression.cpp
+ * @author: kyonGuo
+ * @date 2026/7/22
+ */
+
+#include "TrivialCheckpointStorage.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-crypto/interfaces/crypto/CommonType.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
+#include "bcos-framework/txpool/TxPoolInterface.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-protocol/TransactionSubmitResultFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
+#include "bcos-task/AwaitableValue.h"
+#include "bcos-transaction-scheduler/BaselineScheduler.h"
+#include <boost/test/unit_test.hpp>
+#include <array>
+#include <fakeit.hpp>
+
+// Regression test for the zero-stateRoot bug introduced by #5215 (ba902b6bb):
+// BaselineScheduler::coExecuteBlock passed view.backendStorageRef() instead of
+// the layered view to executeBlock, so transaction state writes bypassed the
+// view's mutable layer and landed directly in the backend. finishExecute then
+// XOR-folded an empty mutable layer and every consensus-path header carried
+// stateRoot == 0x0. The stock MockScheduler never writes through its storage
+// argument, so no existing test could see the reroute — the scheduler impl
+// here does write, which is the whole point of this file.
+//
+// Everything lives in an anonymous namespace (unity-build friendly), and the
+// storage stack uses its own backend hasher type so this TU's ViewType — and
+// therefore its getLedgerConfig tag_invoke stub — cannot collide with the
+// stubs in testBaselineScheduler.cpp / FIB101_102_103_104_SchedulerTest.cpp
+// when CMake merges the sources into one unity TU.
+namespace
+{
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::executor_v1;
+using namespace bcos::scheduler_v1;
+
+struct SRBackendHash : std::hash<StateKey>
+{
+};
+
+using SRMutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+using SRBackendStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT), SRBackendHash>;
+using SRCheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, SRBackendStorage>;
+using SRMultiLayerStorage = MultiLayerStorage<SRMutableStorage, void, SRCheckpointBackend>;
+
+struct StateRow
+{
+    std::string_view table;
+    std::string_view key;
+    std::string_view value;
+};
+constexpr std::array<StateRow, 2> stateRows{
+    StateRow{"/apps/aabbccdd00112233", "balance", "1000000"},
+    StateRow{"/apps/eeff445566778899", "code", "0x60806040526004361061"},
+};
+
+struct SRMockExecutor
+{
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(auto& storage,
+        protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
+        int contextID, ledger::LedgerConfig const& ledgerConfig, bool call)
+    {
+        co_return {};
+    }
+
+    template <class Storage>
+    struct ExecuteContext
+    {
+        template <int step>
+        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
+        {
+            co_return {};
+        }
+    };
+
+    auto createExecuteContext(auto& storage, protocol::BlockHeader const& blockHeader,
+        protocol::Transaction const& transaction, int32_t contextID,
+        ledger::LedgerConfig const& ledgerConfig, bool call)
+        -> task::Task<ExecuteContext<std::decay_t<decltype(storage)>>>
+    {
+        co_return {};
+    }
+};
+
+// Unlike the stock MockScheduler, this impl writes state rows through the
+// storage argument BaselineScheduler hands it — exactly what the production
+// SchedulerSerialImpl / SchedulerParallelImpl do. If coExecuteBlock passes the
+// backend instead of the layered view, these rows skip the mutable layer and
+// the stateRoot XOR collapses to zero.
+struct WritingMockScheduler
+{
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(auto& storage,
+        auto& executor, protocol::BlockHeader const& blockHeader,
+        ::ranges::input_range auto const& transactions, ledger::LedgerConfig const& /*unused*/)
+    {
+        for (const auto& row : stateRows)
+        {
+            storage::Entry entry;
+            entry.set(row.value);
+            co_await storage2::writeOne(storage, StateKey{row.table, row.key}, std::move(entry));
+        }
+
+        auto receipts =
+            ::ranges::iota_view<size_t, size_t>(0, ::ranges::size(transactions)) |
+            ::ranges::views::transform([](size_t index) -> protocol::TransactionReceipt::Ptr {
+                auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+                constexpr static std::string_view str = "abc";
+                auto& inner = receipt->inner();
+                inner.dataHash.assign(str.begin(), str.end());
+                inner.data.gasUsed = "100";
+                return receipt;
+            }) |
+            ::ranges::to<std::vector<protocol::TransactionReceipt::Ptr>>();
+
+        co_return receipts;
+    }
+};
+
+// Storage-level getLedgerConfig stub, found via ADL when the BaselineScheduler
+// template is instantiated; [[maybe_unused]] silences clang's -Wunused-function
+// false positive on indirect template use.
+[[maybe_unused]] task::AwaitableValue<void> tag_invoke(
+    ledger::tag_t<bcos::ledger::getLedgerConfig> /*unused*/,
+    SRMultiLayerStorage::ViewType& /*storage*/, bcos::ledger::LedgerConfig& /*ledgerConfig*/,
+    protocol::BlockNumber /*blockNumber*/, protocol::BlockFactory& /*blockFactory*/)
+{
+    return {};
+}
+
+task::Task<std::vector<protocol::Transaction::ConstPtr>> emptyTxsTaskSR()
+{
+    co_return std::vector<protocol::Transaction::ConstPtr>{};
+}
+
+task::Task<ledger::SystemConfigs> emptySystemConfigsTask()
+{
+    co_return ledger::SystemConfigs{};
+}
+
+task::Task<ledger::Features> emptyFeaturesTask()
+{
+    co_return ledger::Features{};
+}
+
+class StateRootRegressionFixture
+{
+public:
+    StateRootRegressionFixture()
+      : checkpointBackend(backendStorage),
+        cryptoSuite(std::make_shared<crypto::CryptoSuite>(
+            std::make_shared<crypto::Keccak256>(), nullptr, nullptr)),
+        blockHeaderFactory(
+            std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite)),
+        transactionFactory(
+            std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite)),
+        receiptFactory(
+            std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)),
+        blockFactory(std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+            cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory)),
+        transactionSubmitResultFactory(
+            std::make_shared<protocol::TransactionSubmitResultFactoryImpl>()),
+        multiLayerStorage(checkpointBackend),
+        baselineScheduler(multiLayerStorage, mockScheduler, mockExecutor, *blockFactory,
+            mockLedger.get(), mockTxPool.get(), *transactionSubmitResultFactory, *hashImpl)
+    {
+        fakeit::When(Method(mockLedger, asyncPrewriteBlock))
+            .AlwaysDo([](storage::StorageInterface::Ptr, protocol::ConstTransactionsPtr,
+                          protocol::Block::ConstPtr,
+                          std::function<void(std::string, Error::Ptr&&)> callback, bool,
+                          std::optional<ledger::Features>) { callback({}, nullptr); });
+
+        using HashView =
+            ::ranges::any_view<h256, ::ranges::category::mask | ::ranges::category::sized>;
+        fakeit::When(Method(mockTxPool, getTransactions)).AlwaysDo([](HashView) {
+            return emptyTxsTaskSR();
+        });
+
+        // The stubs below let coCommitBlock run to completion (its trailing
+        // ledger::getLedgerConfig(m_ledger.get()) touches all of them).
+        fakeit::When(Method(mockLedger, asyncGetBlockNumber))
+            .AlwaysDo([](std::function<void(Error::Ptr, protocol::BlockNumber)> callback) {
+                callback(nullptr, -1);
+            });
+        fakeit::When(Method(mockLedger, asyncGetNodeListByType))
+            .AlwaysDo([](std::string_view const&,
+                          std::function<void(Error::Ptr, consensus::ConsensusNodeList)> callback) {
+                callback(nullptr, {});
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockDataByNumber))
+            .AlwaysDo([](protocol::BlockNumber, int32_t,
+                          std::function<void(Error::Ptr, protocol::Block::Ptr)> callback) {
+                callback(nullptr, nullptr);
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockHashByNumber))
+            .AlwaysDo([](protocol::BlockNumber,
+                          std::function<void(Error::Ptr, crypto::HashType)> callback) {
+                callback(nullptr, crypto::HashType{});
+            });
+        fakeit::When(Method(mockLedger, fetchAllSystemConfigs)).AlwaysDo([](protocol::BlockNumber) {
+            return emptySystemConfigsTask();
+        });
+        fakeit::When(Method(mockLedger, fetchAllFeatures)).AlwaysDo([](protocol::BlockNumber) {
+            return emptyFeaturesTask();
+        });
+
+        // A successful commit invokes both notifiers on m_asyncGroup; leaving
+        // them unset would throw std::bad_function_call inside a TBB task.
+        baselineScheduler.registerBlockNumberNotifier([](protocol::BlockNumber) {});
+        baselineScheduler.registerTransactionNotifier(
+            [](protocol::BlockNumber, protocol::TransactionSubmitResultsPtr,
+                std::function<void(Error::Ptr)> callback) { callback(nullptr); });
+    }
+
+    void writeBlock(const std::shared_ptr<bcostars::protocol::BlockImpl>& block)
+    {
+        auto blockHeader = block->blockHeader();
+        task::syncWait(ledger::prewriteBlock(mockLedger.get(),
+            std::make_shared<protocol::ConstTransactions>(), block, false, backendStorage));
+        bytes headerBuffer;
+        blockHeader->encode(headerBuffer);
+
+        storage::Entry number2HeaderEntry;
+        number2HeaderEntry.set(std::move(headerBuffer));
+        task::syncWait(storage2::writeOne(backendStorage,
+            StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, std::to_string(blockHeader->number())},
+            std::move(number2HeaderEntry)));
+    }
+
+    protocol::BlockHeader::Ptr executeOneBlock(protocol::BlockNumber number)
+    {
+        auto block = std::make_shared<bcostars::protocol::BlockImpl>();
+        auto blockHeader = block->blockHeader();
+        blockHeader->setNumber(number);
+        blockHeader->setVersion(blockVersion);
+        blockHeader->calculateHash(*hashImpl);
+        bytes input;
+        block->appendTransaction(transactionFactory->createTransaction(
+            0, "to", input, std::to_string(number), 100, "chain", "group", 0));
+        writeBlock(block);
+
+        protocol::BlockHeader::Ptr executedHeader;
+        Error::Ptr execError;
+        baselineScheduler.executeBlock(
+            block, false, [&](Error::Ptr error, protocol::BlockHeader::Ptr header, bool) {
+                execError = std::move(error);
+                executedHeader = std::move(header);
+            });
+        BOOST_REQUIRE_MESSAGE(
+            !execError, "executeBlock failed: " + (execError ? execError->errorMessage() : ""));
+        BOOST_REQUIRE(executedHeader);
+        return executedHeader;
+    }
+
+    // Independent oracle: same per-entry hash call shape as calculateStateRoot
+    // (BaselineScheduler.h), XOR-folded over the rows WritingMockScheduler wrote.
+    h256 expectedStateRoot() const
+    {
+        const std::optional<ledger::Features> features{ledger::Features{}};
+        h256 expected;
+        for (const auto& row : stateRows)
+        {
+            storage::Entry entry;
+            entry.set(row.value);
+            expected ^= entry.hash(row.table, row.key, *hashImpl, blockVersion, features);
+        }
+        return expected;
+    }
+
+    static constexpr uint32_t blockVersion = 200;
+
+    SRBackendStorage backendStorage;
+    SRCheckpointBackend checkpointBackend;
+    crypto::CryptoSuite::Ptr cryptoSuite;
+    std::shared_ptr<bcostars::protocol::BlockHeaderFactoryImpl> blockHeaderFactory;
+    std::shared_ptr<bcostars::protocol::TransactionFactoryImpl> transactionFactory;
+    std::shared_ptr<bcostars::protocol::TransactionReceiptFactoryImpl> receiptFactory;
+    std::shared_ptr<bcostars::protocol::BlockFactoryImpl> blockFactory;
+    std::shared_ptr<protocol::TransactionSubmitResultFactoryImpl> transactionSubmitResultFactory;
+
+    crypto::Hash::Ptr hashImpl = std::make_shared<crypto::Keccak256>();
+
+    WritingMockScheduler mockScheduler;
+    fakeit::Mock<ledger::LedgerInterface> mockLedger;
+    fakeit::Mock<txpool::TxPoolInterface> mockTxPool;
+    SRMultiLayerStorage multiLayerStorage;
+    SRMockExecutor mockExecutor;
+    BaselineScheduler<decltype(multiLayerStorage), SRMockExecutor, WritingMockScheduler,
+        ledger::LedgerInterface>
+        baselineScheduler;
+};
+
+BOOST_FIXTURE_TEST_SUITE(TestExecuteStateRootRegression, StateRootRegressionFixture)
+
+// The regression pin: a block whose execution writes state must produce a
+// non-zero header stateRoot, equal to the independently computed XOR oracle.
+// With the #5215 reroute in place this fails with stateRoot == 0x0.
+BOOST_AUTO_TEST_CASE(executedStateRootMatchesXorOracle)
+{
+    auto executedHeader = executeOneBlock(500);
+
+    BOOST_CHECK_NE(executedHeader->stateRoot(), h256{});
+    BOOST_CHECK_EQUAL(executedHeader->stateRoot(), expectedStateRoot());
+}
+
+// The layering pin: execute writes stay in the view's mutable layer until
+// commit merges them into the backend. With the #5215 reroute, the rows are
+// visible in the backend right after execute — i.e. a discarded proposal
+// would already have dirtied the backend.
+BOOST_AUTO_TEST_CASE(executeWritesStayInViewUntilCommit)
+{
+    auto executedHeader = executeOneBlock(600);
+
+    // Before commit: rows are NOT in the backend...
+    for (const auto& row : stateRows)
+    {
+        auto backendValue =
+            task::syncWait(storage2::readOne(backendStorage, StateKey{row.table, row.key}));
+        BOOST_CHECK_MESSAGE(!backendValue,
+            std::string("row leaked into backend before commit: ").append(row.table));
+    }
+    // ...but ARE readable through a fork of the multi-layer storage (they live
+    // in the pushed execution layer).
+    task::syncWait([&]() -> task::Task<void> {
+        auto view = multiLayerStorage.fork();
+        for (const auto& row : stateRows)
+        {
+            auto viewValue = co_await storage2::readOne(view, StateKey{row.table, row.key});
+            BOOST_REQUIRE_MESSAGE(viewValue,
+                std::string("row missing from layered view after execute: ").append(row.table));
+            BOOST_CHECK_EQUAL(std::string(viewValue->get()), std::string(row.value));
+        }
+    }());
+
+    Error::Ptr commitError;
+    ledger::LedgerConfig::Ptr ledgerConfig;
+    baselineScheduler.commitBlock(
+        executedHeader, [&](Error::Ptr error, ledger::LedgerConfig::Ptr config) {
+            commitError = std::move(error);
+            ledgerConfig = std::move(config);
+        });
+    BOOST_REQUIRE_MESSAGE(
+        !commitError, "commitBlock failed: " + (commitError ? commitError->errorMessage() : ""));
+
+    // After commit: the merge moved the rows into the backend.
+    for (const auto& row : stateRows)
+    {
+        auto backendValue =
+            task::syncWait(storage2::readOne(backendStorage, StateKey{row.table, row.key}));
+        BOOST_REQUIRE_MESSAGE(
+            backendValue, std::string("row missing from backend after commit: ").append(row.table));
+        BOOST_CHECK_EQUAL(std::string(backendValue->get()), std::string(row.value));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace


### PR DESCRIPTION
### Failing scenario

Execute any block whose transactions write state, on the consensus path (`BaselineScheduler::executeBlock`):

| Build | Executed header stateRoot |
|---|---|
| release-3.18.0 tip | `0x0000000000000000000000000000000000000000000000000000000000000000` |
| tip + this one-line restore | `0xb2be9d46cc00c2a1...` — byte-identical to an independently computed XOR oracle over the written entries |

Every consensus-path block header has carried an all-zero stateRoot since #5215 (ba902b6bb).

### Root cause

#5215 changed `transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h:368-370` from `executeBlock(view, ...)` to `executeBlock(view.backendStorageRef(), ...)`. The chain from there:

1. `SchedulerImpl::executeBlock` receives the raw backend instead of the layered view, so every transaction state write lands directly in the backend storage, bypassing the view's mutable layer (`View::writeOne` routes to `mutableStorage(view)`; the backend route skips it entirely).
2. `finishExecute(mutableStorage(view), ...)` (BaselineScheduler.h:375) then computes the state root by XOR-folding `calculateStateRoot` over the mutable layer — which is empty. XOR over the empty set is the identity: `stateRoot == h256{}`.
3. The engine path (`engine/bcos-engine/EngineServiceImpl.h:524`) kept passing `view` and is the correct reference shape; this PR makes the consensus path match it.

### Why it was invisible

Every node computes the same zero, so consensus agrees and the header-hash verify at BaselineScheduler.h:379 passes on sync/verify paths — nothing diverges at runtime. On the CI side, the only stateRoot assertion in the repo pins the empty-block root to zero (`testBaselineScheduler.cpp:415`), and the stock `MockScheduler` ignores its storage argument entirely, so no existing test could observe where execute writes land. That is the blind spot this PR's regression test closes.

### What the fix restores beyond the root

Routing execute writes through the view also restores the layering semantics that #5215's reroute broke: execute writes stay in the in-memory mutable layer until `commitBlock` merges them via `mergeBackStorage`. Concretely, a proposal that is executed but never committed (view discarded / rolled back) no longer leaves dirty rows in the backend, and the commit-time merge is meaningful again instead of merging an empty layer over rows that already leaked through.

### Note on #5215's design intent

This partially reverts #5215's write-through routing on the consensus path. #5215 introduced checkpoint-capable backends, and as far as I can tell `createCheckpoint` is currently uncalled in production, so I could not reconstruct whether the `backendStorageRef()` routing was a deliberate step toward a checkpoint-based rollback model (where execute writes go straight to a checkpointed backend) or an accidental reroute. @morebtcg (author of #5215): was there a planned follow-up that would have made the checkpoint path carry the state root, or is this restore in line with the intended design?

### Regression test

`transaction-scheduler/tests/TestExecuteStateRootRegression.cpp` drives the real `BaselineScheduler::executeBlock`/`commitBlock` with a scheduler impl that actually writes two state rows through the storage argument it receives (the whole point — the stock mock never writes). It pins four things: (a) the executed header stateRoot is non-zero; (b) it equals an independently computed oracle that XORs the same `entry.hash(table, key, hashImpl, blockVersion, features)` call shape `calculateStateRoot` uses; (c) before commit the rows are NOT readable from the backend directly, only through the layered view; (d) after `commitBlock` the rows ARE in the backend.

Negative control: with the fix temporarily reverted the test goes red exactly as production does — `stateRoot: 0000...0000`, oracle mismatch, and both rows leak into the backend before commit. With the fix it is green. Full `test-transaction-scheduler` binary: 60/60 test cases, 2783/2783 assertions; `init` (production instantiation) and `test-bcos-ledger` build and pass as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
