### PR TITLE
feat(scheduler): execute-time MPT build + atomic node commit (M5.2b+M6.2+M6.3+M6.4)

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/MPTDeltaLayer.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTDeltaLayer.h
@@ -40,8 +40,10 @@ struct MPTDeltaLayer
     /// The post-block MPT state root.
     bcos::h256 stateRoot;
     /// Every newly produced node (hash → raw RLP), aggregated from every commitTrie() result of
-    /// this block. The commit flow writes these under /mpt/<hash> keys in the SAME WriteBatch as
-    /// the flat state (single db->Write, spec §5.6).
+    /// this block. buildAndCollect's end-of-build flush writes these as ordinary "/mpt/:<hash>"
+    /// state rows into the block's mutable layer, so commit persists them in the SAME WriteBatch
+    /// as the flat state (single db->Write, spec §5.6); this map stays the CommitObserver's
+    /// payload.
     std::unordered_map<bcos::h256, bcos::bytes> newNodes;
     /// Nodes that the tries rebuilt by THIS block no longer reference, disjoint from newNodes.
     ///

--- a/bcos-ledger/bcos-ledger/mpt/MPTDeltaLayer.h
+++ b/bcos-ledger/bcos-ledger/mpt/MPTDeltaLayer.h
@@ -43,7 +43,9 @@ struct MPTDeltaLayer
     /// this block. buildAndCollect's end-of-build flush writes these as ordinary "/mpt/:<hash>"
     /// state rows into the block's mutable layer, so commit persists them in the SAME WriteBatch
     /// as the flat state (single db->Write, spec §5.6); this map stays the CommitObserver's
-    /// payload.
+    /// payload. The flush COPIES each node's RLP into its row's Entry (it takes the map by
+    /// const reference and never moves out of it), so newNodes is still complete when
+    /// CommitObserver::onCommit receives the delta after the WriteBatch lands.
     std::unordered_map<bcos::h256, bcos::bytes> newNodes;
     /// Nodes that the tries rebuilt by THIS block no longer reference, disjoint from newNodes.
     ///

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
@@ -76,9 +76,11 @@ public:
     }
 
     /// Type-erased read handle over the MPT node storage for eth_getProof (M8.3): key = node
-    /// hash, value = the node's raw RLP encoding, physically stored as ordinary state rows
-    /// under the "/mpt/:<hash>" key prefix of the default column family (bcos-storage
-    /// KeyPrefixes.h::mptNodeStateKey / makeMPTNodeKey).
+    /// hash, value = the node's raw RLP encoding, physically stored as ordinary state rows —
+    /// StateKey{"/mpt/", <32 raw digest bytes>}, i.e. "/mpt/:" + digest = 38 bytes in the
+    /// default column family. Build those keys ONLY with bcos-storage
+    /// KeyPrefixes.h::mptNodeStateKey; the physical form is produced and parsed solely by
+    /// StateKeyResolver.
     using MPTNodeReader = bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>;
 
     /// Non-owning: the AnyStorage view holds a raw pointer to the underlying storage, whose

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
@@ -76,8 +76,9 @@ public:
     }
 
     /// Type-erased read handle over the MPT node storage for eth_getProof (M8.3): key = node
-    /// hash, value = the node's raw RLP encoding, physically stored under the /mpt/<hash> key
-    /// prefix of the default column family (bcos-storage KeyPrefixes.h::makeMPTNodeKey).
+    /// hash, value = the node's raw RLP encoding, physically stored as ordinary state rows
+    /// under the "/mpt/:<hash>" key prefix of the default column family (bcos-storage
+    /// KeyPrefixes.h::mptNodeStateKey / makeMPTNodeKey).
     using MPTNodeReader = bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>;
 
     /// Non-owning: the AnyStorage view holds a raw pointer to the underlying storage, whose

--- a/bcos-storage/bcos-storage/KeyPrefixes.h
+++ b/bcos-storage/bcos-storage/KeyPrefixes.h
@@ -13,12 +13,13 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- * @brief MPT key namespace constants and encode/decode helpers (spec §5.1)
+ * @brief MPT node-row key layout: the "/mpt/" state table and its encode/decode helpers
  * @file KeyPrefixes.h
  * @author: kyonRay
  * @date: 2026-05-12
  */
 #pragma once
+#include "bcos-framework/transaction-executor/StateKey.h"
 #include <bcos-utilities/FixedBytes.h>
 #include <cstring>
 #include <optional>
@@ -28,26 +29,45 @@
 namespace bcos::storage2
 {
 
-/// The sole "/mpt/" ASCII prefix for MPT node keys in the default ColumnFamily.
-/// All MPT keys are exactly 37 bytes: kMPTPrefix (5) + raw keccak hash (32).
-/// Do NOT write "/mpt/" literals anywhere else — use makeMPTNodeKey / parseMPTNodeKey.
-inline constexpr std::string_view kMPTPrefix = "/mpt/";
-inline constexpr std::size_t kMPTKeyLength = kMPTPrefix.size() + 32;  // 37
+/// The state TABLE of MPT trie-node rows. A node row is an ordinary state row —
+/// StateKey{"/mpt/", <32 raw digest bytes>} — so its physical key in the default
+/// ColumnFamily is the StateKey serialization "<table>" ':' "<key>":
+///
+///   "/mpt/:" + 32 raw digest bytes = 38 bytes
+///
+/// "/mpt/" itself contains no ':', so the first ':' of every node row's physical key sits
+/// at index 5 and StateKeyResolver::decode's split-at-first-colon reconstruction is exact
+/// for every digest — including digests that happen to contain 0x3A (':') bytes.
+/// Do NOT write "/mpt/" literals anywhere else — use mptNodeStateKey / makeMPTNodeKey /
+/// parseMPTNodeKey.
+inline constexpr std::string_view kMPTTable = "/mpt/";
+inline constexpr std::size_t kMPTKeyLength = kMPTTable.size() + 1 + 32;  // 38
 
-/// Encode a 32-byte keccak hash into a 37-byte RocksDB key with the /mpt/ namespace prefix.
-/// This is the ONLY place that embeds kMPTPrefix into a key.
+/// The StateKey of a trie node's row: table "/mpt/", row key = the 32 raw digest bytes.
+/// This is the form every in-process reader and writer uses — the ordinary state
+/// resolvers and storages handle it with no MPT-specific code.
+inline executor_v1::StateKey mptNodeStateKey(const h256& hash)
+{
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    return {kMPTTable, std::string_view(reinterpret_cast<const char*>(hash.data()), h256::SIZE)};
+}
+
+/// The literal 38-byte physical RocksDB key of a trie node's row — exactly what
+/// StateKeyResolver::encode(mptNodeStateKey(hash)) emits. For raw-DB consumers only
+/// (layout-proof tests, offline tooling); in-process code goes through mptNodeStateKey.
 inline std::string makeMPTNodeKey(const h256& hash)
 {
     std::string key;
-    key.reserve(kMPTPrefix.size() + h256::SIZE);
-    key.append(kMPTPrefix);
+    key.reserve(kMPTKeyLength);
+    key.append(kMPTTable);
+    key.push_back(':');
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     key.append(reinterpret_cast<const char*>(hash.data()), h256::SIZE);
     return key;
 }
 
-/// Decode a raw RocksDB key back to its h256 hash.
-/// Returns std::nullopt if the key is not a valid 37-byte /mpt/-prefixed key.
+/// Decode a physical RocksDB key back to its node digest.
+/// Returns std::nullopt unless the key is exactly the 38-byte "/mpt/:<32 bytes>" form.
 /// Never throws — this is runtime data validation.
 inline std::optional<h256> parseMPTNodeKey(std::string_view key) noexcept
 {
@@ -55,13 +75,12 @@ inline std::optional<h256> parseMPTNodeKey(std::string_view key) noexcept
     {
         return std::nullopt;
     }
-    if (key.substr(0, kMPTPrefix.size()) != kMPTPrefix)
+    if (!key.starts_with(kMPTTable) || key[kMPTTable.size()] != ':')
     {
         return std::nullopt;
     }
     h256 hash;
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    std::memcpy(hash.data(), key.data() + kMPTPrefix.size(), h256::SIZE);
+    std::memcpy(hash.data(), key.data() + kMPTTable.size() + 1, h256::SIZE);
     return hash;
 }
 

--- a/bcos-storage/bcos-storage/KeyPrefixes.h
+++ b/bcos-storage/bcos-storage/KeyPrefixes.h
@@ -40,6 +40,11 @@ namespace bcos::storage2
 inline constexpr std::string_view kMPTTable = "/mpt/";
 inline constexpr std::size_t kMPTKeyLength = kMPTTable.size() + 1 + 32;  // 38
 
+static_assert(kMPTTable.find(':') == std::string_view::npos,
+    "the MPT table name must not contain ':' — StateKeyResolver splits a physical key at its "
+    "FIRST colon, so a colon in the table name would decode node rows to a corrupted "
+    "table/key split");
+
 /// The StateKey of a trie node's row: table "/mpt/", row key = the 32 raw digest bytes.
 /// This is the form every in-process reader and writer uses — the ordinary state
 /// resolvers and storages handle it with no MPT-specific code.

--- a/bcos-storage/bcos-storage/KeyPrefixes.h
+++ b/bcos-storage/bcos-storage/KeyPrefixes.h
@@ -21,9 +21,6 @@
 #pragma once
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include <bcos-utilities/FixedBytes.h>
-#include <cstring>
-#include <optional>
-#include <string>
 #include <string_view>
 
 namespace bcos::storage2
@@ -38,8 +35,8 @@ namespace bcos::storage2
 /// "/mpt/" itself contains no ':', so the first ':' of every node row's physical key sits
 /// at index 5 and StateKeyResolver::decode's split-at-first-colon reconstruction is exact
 /// for every digest — including digests that happen to contain 0x3A (':') bytes.
-/// Do NOT write "/mpt/" literals anywhere else — use mptNodeStateKey / makeMPTNodeKey /
-/// parseMPTNodeKey.
+/// Do NOT write "/mpt/" literals anywhere else — build keys with mptNodeStateKey;
+/// the physical form is produced and parsed solely by StateKeyResolver.
 inline constexpr std::string_view kMPTTable = "/mpt/";
 inline constexpr std::size_t kMPTKeyLength = kMPTTable.size() + 1 + 32;  // 38
 
@@ -50,38 +47,6 @@ inline executor_v1::StateKey mptNodeStateKey(const h256& hash)
 {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
     return {kMPTTable, std::string_view(reinterpret_cast<const char*>(hash.data()), h256::SIZE)};
-}
-
-/// The literal 38-byte physical RocksDB key of a trie node's row — exactly what
-/// StateKeyResolver::encode(mptNodeStateKey(hash)) emits. For raw-DB consumers only
-/// (layout-proof tests, offline tooling); in-process code goes through mptNodeStateKey.
-inline std::string makeMPTNodeKey(const h256& hash)
-{
-    std::string key;
-    key.reserve(kMPTKeyLength);
-    key.append(kMPTTable);
-    key.push_back(':');
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    key.append(reinterpret_cast<const char*>(hash.data()), h256::SIZE);
-    return key;
-}
-
-/// Decode a physical RocksDB key back to its node digest.
-/// Returns std::nullopt unless the key is exactly the 38-byte "/mpt/:<32 bytes>" form.
-/// Never throws — this is runtime data validation.
-inline std::optional<h256> parseMPTNodeKey(std::string_view key) noexcept
-{
-    if (key.size() != kMPTKeyLength)
-    {
-        return std::nullopt;
-    }
-    if (!key.starts_with(kMPTTable) || key[kMPTTable.size()] != ':')
-    {
-        return std::nullopt;
-    }
-    h256 hash;
-    std::memcpy(hash.data(), key.data() + kMPTTable.size() + 1, h256::SIZE);
-    return hash;
 }
 
 }  // namespace bcos::storage2

--- a/bcos-storage/test/unittest/CMakeLists.txt
+++ b/bcos-storage/test/unittest/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "main.cpp")
+list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "TestMPTNodeKey.cpp" "main.cpp")
 # cmake settings
 set(TEST_BINARY_NAME test-storage)
 

--- a/bcos-storage/test/unittest/TestKeyPrefixes.cpp
+++ b/bcos-storage/test/unittest/TestKeyPrefixes.cpp
@@ -13,7 +13,9 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  *
- * @brief Unit tests for KeyPrefixes.h (MPT key namespace utilities)
+ * @brief Unit tests for KeyPrefixes.h: the "/mpt/" node-row key layout, with
+ *        StateKeyResolver as the ONLY physical encode/decode authority (KeyPrefixes.h
+ *        deliberately exports no physical-key helpers of its own).
  * @file TestKeyPrefixes.cpp
  * @author: kyonRay
  * @date: 2026-05-12
@@ -33,9 +35,23 @@ using namespace bcos;
 using namespace bcos::storage2;
 using namespace bcos::storage2::rocksdb;
 
+namespace
+{
+/// The physical bytes StateKeyResolver::encode emits for a StateKey — the single authority
+/// every on-disk key goes through (RocksDBStorage2's write path).
+std::string resolverPhysicalKey(executor_v1::StateKey const& stateKey)
+{
+    std::string out;
+    StateKeyResolver::encode(stateKey, [&](bcos::bytesConstRef view) {
+        out.append(reinterpret_cast<char const*>(view.data()), view.size());
+    });
+    return out;
+}
+}  // namespace
+
 BOOST_AUTO_TEST_SUITE(KeyPrefixesSuite)
 
-BOOST_AUTO_TEST_CASE(MakeMPTNodeKeyFormat)
+BOOST_AUTO_TEST_CASE(NodeRowPhysicalForm)
 {
     h256 hash;
     // Fill with a recognisable pattern
@@ -44,9 +60,10 @@ BOOST_AUTO_TEST_CASE(MakeMPTNodeKeyFormat)
         hash[i] = static_cast<byte>(i + 1);
     }
 
-    std::string key = makeMPTNodeKey(hash);
+    std::string key = resolverPhysicalKey(mptNodeStateKey(hash));
 
     // Must be exactly 38 bytes: 5 (table) + 1 (':') + 32 (hash)
+    BOOST_CHECK_EQUAL(key.size(), kMPTKeyLength);
     BOOST_CHECK_EQUAL(key.size(), 38U);
 
     // Must start with the "/mpt/:" StateKey serialization prefix
@@ -58,52 +75,34 @@ BOOST_AUTO_TEST_CASE(MakeMPTNodeKeyFormat)
         BOOST_CHECK_EQUAL(static_cast<uint8_t>(key[6 + i]), hash[i]);
     }
 
-    // The physical bytes ARE the StateKey serialization of mptNodeStateKey(hash).
+    // The physical bytes ARE the StateKey's own flat buffer — encode adds nothing.
     auto stateKey = mptNodeStateKey(hash);
     BOOST_CHECK_EQUAL(std::string_view(stateKey.data(), stateKey.size()), key);
 }
 
-BOOST_AUTO_TEST_CASE(ParseMPTNodeKeyRoundTrip)
+BOOST_AUTO_TEST_CASE(NodeRowResolverRoundTrip)
 {
     h256 original = h256::generateRandomFixedBytes();
-    std::string encoded = makeMPTNodeKey(original);
-    auto decoded = parseMPTNodeKey(encoded);
+    std::string physical = resolverPhysicalKey(mptNodeStateKey(original));
 
-    BOOST_REQUIRE(decoded.has_value());
-    BOOST_CHECK_EQUAL(decoded.value(), original);
+    // decode is the inverse of encode: same StateKey, table "/mpt/", key = the raw digest.
+    auto decoded = StateKeyResolver::decode(std::string_view(physical));
+    BOOST_CHECK(decoded == mptNodeStateKey(original));
+    executor_v1::StateKeyView const view{decoded};
+    BOOST_CHECK_EQUAL(view.m_table, kMPTTable);
+    BOOST_CHECK_EQUAL(
+        view.m_key, std::string_view(reinterpret_cast<char const*>(original.data()), h256::SIZE));
 }
 
-BOOST_AUTO_TEST_CASE(ParseMPTNodeKeyRejectsBadInputs)
+BOOST_AUTO_TEST_CASE(RetiredColonFreeLayoutIsNotAStateKey)
 {
-    // Empty string
-    BOOST_CHECK(!parseMPTNodeKey("").has_value());
-
-    // Prefix only, no hash bytes
-    BOOST_CHECK(!parseMPTNodeKey("/mpt/").has_value());
-
-    // Prefix + truncated hash (less than 32 bytes)
-    BOOST_CHECK(!parseMPTNodeKey("/mpt/:short").has_value());
-
-    // Wrong prefix: existing /apps/ namespace key
-    BOOST_CHECK(!parseMPTNodeKey("/apps/abc:def").has_value());
-
-    // Wrong prefix: existing s_ namespace key
-    BOOST_CHECK(!parseMPTNodeKey("s_number_2_hash:123").has_value());
-
-    // The RETIRED 37-byte layout ("/mpt/" + raw digest, no ':'): must not parse.
+    // The RETIRED 37-byte layout ("/mpt/" + raw digest, no ':') cannot even be decoded as a
+    // StateKey when the digest contains no 0x3A byte — the reason the layout moved to
+    // "/mpt/:". (A digest WITH a 0x3A would decode, but to a corrupted table/key split.)
     std::string legacy(37, '\0');
     legacy.replace(0, 5, "/mpt/");
-    BOOST_CHECK(!parseMPTNodeKey(legacy).has_value());
-
-    // Exactly 38 bytes but wrong table: "/abc/:" + 32 nul bytes
-    std::string almost(38, '\0');
-    almost.replace(0, 6, "/abc/:");
-    BOOST_CHECK(!parseMPTNodeKey(almost).has_value());
-
-    // Exactly 38 bytes, right table, but the separator byte is not ':'
-    std::string badSeparator = makeMPTNodeKey(h256{});
-    badSeparator[5] = '_';
-    BOOST_CHECK(!parseMPTNodeKey(badSeparator).has_value());
+    BOOST_CHECK_THROW(
+        StateKeyResolver::decode(std::string_view(legacy)), executor_v1::NoTableSpliterError);
 }
 
 BOOST_AUTO_TEST_CASE(RocksDBAccessorExposed)
@@ -134,7 +133,7 @@ BOOST_AUTO_TEST_CASE(RocksDBAccessorExposed)
 
         // Demonstrate writing and reading a "/mpt/:<hash>" key via rocksDB()
         h256 hash = h256::generateRandomFixedBytes();
-        std::string mptKey = makeMPTNodeKey(hash);
+        std::string mptKey = resolverPhysicalKey(mptNodeStateKey(hash));
         std::string mptValue = "mpt_node_data";
 
         ::rocksdb::WriteOptions wo;

--- a/bcos-storage/test/unittest/TestKeyPrefixes.cpp
+++ b/bcos-storage/test/unittest/TestKeyPrefixes.cpp
@@ -46,17 +46,21 @@ BOOST_AUTO_TEST_CASE(MakeMPTNodeKeyFormat)
 
     std::string key = makeMPTNodeKey(hash);
 
-    // Must be exactly 37 bytes: 5 (prefix) + 32 (hash)
-    BOOST_CHECK_EQUAL(key.size(), 37U);
+    // Must be exactly 38 bytes: 5 (table) + 1 (':') + 32 (hash)
+    BOOST_CHECK_EQUAL(key.size(), 38U);
 
-    // Must start with "/mpt/"
-    BOOST_CHECK_EQUAL(key.substr(0, 5), "/mpt/");
+    // Must start with the "/mpt/:" StateKey serialization prefix
+    BOOST_CHECK_EQUAL(key.substr(0, 6), "/mpt/:");
 
     // Last 32 bytes must match the raw hash bytes
     for (unsigned i = 0; i < 32; ++i)
     {
-        BOOST_CHECK_EQUAL(static_cast<uint8_t>(key[5 + i]), hash[i]);
+        BOOST_CHECK_EQUAL(static_cast<uint8_t>(key[6 + i]), hash[i]);
     }
+
+    // The physical bytes ARE the StateKey serialization of mptNodeStateKey(hash).
+    auto stateKey = mptNodeStateKey(hash);
+    BOOST_CHECK_EQUAL(std::string_view(stateKey.data(), stateKey.size()), key);
 }
 
 BOOST_AUTO_TEST_CASE(ParseMPTNodeKeyRoundTrip)
@@ -78,7 +82,7 @@ BOOST_AUTO_TEST_CASE(ParseMPTNodeKeyRejectsBadInputs)
     BOOST_CHECK(!parseMPTNodeKey("/mpt/").has_value());
 
     // Prefix + truncated hash (less than 32 bytes)
-    BOOST_CHECK(!parseMPTNodeKey("/mpt/short").has_value());
+    BOOST_CHECK(!parseMPTNodeKey("/mpt/:short").has_value());
 
     // Wrong prefix: existing /apps/ namespace key
     BOOST_CHECK(!parseMPTNodeKey("/apps/abc:def").has_value());
@@ -86,10 +90,20 @@ BOOST_AUTO_TEST_CASE(ParseMPTNodeKeyRejectsBadInputs)
     // Wrong prefix: existing s_ namespace key
     BOOST_CHECK(!parseMPTNodeKey("s_number_2_hash:123").has_value());
 
-    // Exactly 37 bytes but wrong prefix: "/abc/" + 32 nul bytes (spec example)
-    std::string almost(37, '\0');
-    almost.replace(0, 5, "/abc/");
+    // The RETIRED 37-byte layout ("/mpt/" + raw digest, no ':'): must not parse.
+    std::string legacy(37, '\0');
+    legacy.replace(0, 5, "/mpt/");
+    BOOST_CHECK(!parseMPTNodeKey(legacy).has_value());
+
+    // Exactly 38 bytes but wrong table: "/abc/:" + 32 nul bytes
+    std::string almost(38, '\0');
+    almost.replace(0, 6, "/abc/:");
     BOOST_CHECK(!parseMPTNodeKey(almost).has_value());
+
+    // Exactly 38 bytes, right table, but the separator byte is not ':'
+    std::string badSeparator = makeMPTNodeKey(h256{});
+    badSeparator[5] = '_';
+    BOOST_CHECK(!parseMPTNodeKey(badSeparator).has_value());
 }
 
 BOOST_AUTO_TEST_CASE(RocksDBAccessorExposed)
@@ -118,7 +132,7 @@ BOOST_AUTO_TEST_CASE(RocksDBAccessorExposed)
         // rocksDB() must reference the same underlying DB instance
         BOOST_CHECK_EQUAL(&storage.rocksDB(), rawPtr);
 
-        // Demonstrate writing and reading a /mpt/<hash> key via rocksDB()
+        // Demonstrate writing and reading a "/mpt/:<hash>" key via rocksDB()
         h256 hash = h256::generateRandomFixedBytes();
         std::string mptKey = makeMPTNodeKey(hash);
         std::string mptValue = "mpt_node_data";

--- a/bcos-storage/test/unittest/TestMPTNodeKey.cpp
+++ b/bcos-storage/test/unittest/TestMPTNodeKey.cpp
@@ -16,8 +16,9 @@
  * @brief Physical-layout proof for MPT node rows as ORDINARY state rows: an Entry keyed
  *        mptNodeStateKey(hash) written through a real RocksDBStorage2<StateKey, ...,
  *        StateKeyResolver, ...> lands under the literal 38-byte "/mpt/:<digest>" key
- *        (makeMPTNodeKey), and those physical bytes decode back to the same StateKey via
- *        the resolver's split-at-first-colon reconstruction — the two facts the scheduler's
+ *        (constructed INDEPENDENTLY in this TU — KeyPrefixes.h exports no physical-key
+ *        helper), and those physical bytes decode back to the same StateKey via the
+ *        resolver's split-at-first-colon reconstruction — the two facts the scheduler's
  *        view-riding node plane (ViewNodeStorage) and every raw-DB node reader depend on.
  * @file TestMPTNodeKey.cpp
  */
@@ -59,6 +60,16 @@ bytes sampleNodeRlp()
     // Arbitrary non-empty payload standing in for a node's RLP encoding.
     return bytes{0xC5, 0x84, 0xDE, 0xAD, 0xBE, 0xEF};
 }
+
+// The literal 38-byte physical key, built here by hand ON PURPOSE: the proof compares what
+// the resolver-backed storage stack actually writes against bytes constructed with zero
+// shared code (the production encode authority is StateKeyResolver alone).
+std::string physicalNodeKey(h256 const& hash)
+{
+    std::string key = "/mpt/:";
+    key.append(reinterpret_cast<char const*>(hash.data()), h256::SIZE);
+    return key;
+}
 }  // namespace
 
 struct TestMPTNodeKeyFixture
@@ -88,23 +99,19 @@ BOOST_FIXTURE_TEST_SUITE(TestMPTNodeKey, TestMPTNodeKeyFixture)
 BOOST_AUTO_TEST_CASE(physicalFormIsStateKeyNative)
 {
     auto const hash = colonRiddledHash();
-    auto const physicalKey = storage2::makeMPTNodeKey(hash);
+    auto const physicalKey = physicalNodeKey(hash);
 
     BOOST_CHECK_EQUAL(physicalKey.size(), storage2::kMPTKeyLength);  // 38
     BOOST_CHECK_EQUAL(physicalKey.find(':'), 5U);                    // table separator
 
-    // Split-at-first-colon reconstruction (what StateKeyResolver::decode does).
-    StateKey const decoded{std::string(physicalKey)};
+    // The resolver's decode (single-string StateKey constructor, split at the first colon)
+    // reconstructs table "/mpt/" + the raw digest exactly — colons in the digest and all.
+    auto const decoded = StateKeyResolver::decode(std::string_view(physicalKey));
     StateKeyView const view{decoded};
     BOOST_CHECK_EQUAL(view.m_table, storage2::kMPTTable);
     BOOST_CHECK_EQUAL(
         view.m_key, std::string_view(reinterpret_cast<char const*>(hash.data()), h256::SIZE));
     BOOST_CHECK(decoded == storage2::mptNodeStateKey(hash));
-
-    // parseMPTNodeKey inverts the physical key.
-    auto parsed = storage2::parseMPTNodeKey(physicalKey);
-    BOOST_REQUIRE(parsed.has_value());
-    BOOST_CHECK_EQUAL(*parsed, hash);
 }
 
 // End-to-end physical-key proof over a real RocksDB, through the same code path commit
@@ -139,8 +146,8 @@ BOOST_AUTO_TEST_CASE(mergeLandsUnderPhysicalKey)
         // Raw Get with the literal 38-byte key: proves the on-disk layout, not just the
         // resolver round-trip.
         std::string rawValue;
-        auto status = rocksDB->Get(
-            ::rocksdb::ReadOptions(), storage2::makeMPTNodeKey(hash), std::addressof(rawValue));
+        auto status =
+            rocksDB->Get(::rocksdb::ReadOptions(), physicalNodeKey(hash), std::addressof(rawValue));
         BOOST_REQUIRE(status.ok());
 
         // The value is Entry-encoded like every other value in the CF.

--- a/bcos-storage/test/unittest/TestMPTNodeKey.cpp
+++ b/bcos-storage/test/unittest/TestMPTNodeKey.cpp
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Physical-layout proof for MPT node rows as ORDINARY state rows: an Entry keyed
+ *        mptNodeStateKey(hash) written through a real RocksDBStorage2<StateKey, ...,
+ *        StateKeyResolver, ...> lands under the literal 38-byte "/mpt/:<digest>" key
+ *        (makeMPTNodeKey), and those physical bytes decode back to the same StateKey via
+ *        the resolver's split-at-first-colon reconstruction — the two facts the scheduler's
+ *        view-riding node plane (ViewNodeStorage) and every raw-DB node reader depend on.
+ * @file TestMPTNodeKey.cpp
+ */
+
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/Storage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Wait.h"
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-storage/RocksDBStorage2.h>
+#include <bcos-storage/StateKVResolver.h>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <random>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::storage2::rocksdb;
+using namespace bcos::executor_v1;
+
+namespace
+{
+// A digest deliberately RIDDLED with 0x3A (':') bytes: the layout's decode contract is that
+// the first ':' of the 38-byte physical key always sits at index 5 (the "/mpt/" table has
+// none), so colons inside the digest must not confuse the split.
+h256 colonRiddledHash()
+{
+    h256 hash;
+    for (size_t i = 0; i < h256::SIZE; ++i)
+    {
+        hash.data()[i] = (i % 2 == 0) ? byte{0x3A} : static_cast<byte>(0x11 + i);
+    }
+    return hash;
+}
+
+bytes sampleNodeRlp()
+{
+    // Arbitrary non-empty payload standing in for a node's RLP encoding.
+    return bytes{0xC5, 0x84, 0xDE, 0xAD, 0xBE, 0xEF};
+}
+}  // namespace
+
+struct TestMPTNodeKeyFixture
+{
+    std::string path = "./mptnodekeydb" + std::to_string(std::random_device{}());
+
+    TestMPTNodeKeyFixture()
+    {
+        ::rocksdb::Options options;
+        options.create_if_missing = true;
+
+        ::rocksdb::DB* db = nullptr;
+        auto status = ::rocksdb::DB::Open(options, path, &db);
+        BOOST_REQUIRE(status.ok());
+        rocksDB.reset(db);
+    }
+    ~TestMPTNodeKeyFixture() { boost::filesystem::remove_all(path); }
+
+    std::unique_ptr<::rocksdb::DB> rocksDB;
+};
+
+BOOST_FIXTURE_TEST_SUITE(TestMPTNodeKey, TestMPTNodeKeyFixture)
+
+// The physical form is StateKey-NATIVE: a full-CF scan can hand the raw 38 bytes to the
+// resolver's single-string StateKey constructor and get table "/mpt/" + the raw digest
+// back, because the first ':' is always the table separator at index 5.
+BOOST_AUTO_TEST_CASE(physicalFormIsStateKeyNative)
+{
+    auto const hash = colonRiddledHash();
+    auto const physicalKey = storage2::makeMPTNodeKey(hash);
+
+    BOOST_CHECK_EQUAL(physicalKey.size(), storage2::kMPTKeyLength);  // 38
+    BOOST_CHECK_EQUAL(physicalKey.find(':'), 5U);                    // table separator
+
+    // Split-at-first-colon reconstruction (what StateKeyResolver::decode does).
+    StateKey const decoded{std::string(physicalKey)};
+    StateKeyView const view{decoded};
+    BOOST_CHECK_EQUAL(view.m_table, storage2::kMPTTable);
+    BOOST_CHECK_EQUAL(
+        view.m_key, std::string_view(reinterpret_cast<char const*>(hash.data()), h256::SIZE));
+    BOOST_CHECK(decoded == storage2::mptNodeStateKey(hash));
+
+    // parseMPTNodeKey inverts the physical key.
+    auto parsed = storage2::parseMPTNodeKey(physicalKey);
+    BOOST_REQUIRE(parsed.has_value());
+    BOOST_CHECK_EQUAL(*parsed, hash);
+}
+
+// End-to-end physical-key proof over a real RocksDB, through the same code path commit
+// uses: node rows and flat rows travel in ONE StateKey-keyed source (the shape of a
+// block's mutable layer after the MPT build flushed into it), one RocksDBStorage2::merge,
+// then a raw db Get with the literal 38-byte key.
+BOOST_AUTO_TEST_CASE(mergeLandsUnderPhysicalKey)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver> storage(
+            *rocksDB, StateKeyResolver{}, StateValueResolver{});
+
+        auto const hash = colonRiddledHash();
+        auto const nodeRlp = sampleNodeRlp();
+
+        // One mutable-layer-shaped source carrying BOTH row kinds — no special node source.
+        storage2::memory_storage::MemoryStorage<StateKey, StateValue,
+            storage2::memory_storage::ORDERED>
+            mutableLayer;
+        storage::Entry flatEntry;
+        flatEntry.set("flat-value");
+        co_await storage2::writeOne(
+            mutableLayer, StateKey{"/apps/test", "balance"}, std::move(flatEntry));
+        storage::Entry nodeEntry;
+        nodeEntry.set(bytes(nodeRlp));
+        co_await storage2::writeOne(
+            mutableLayer, storage2::mptNodeStateKey(hash), std::move(nodeEntry));
+
+        // One merge = one WriteBatch = one rocksdb Write (RocksDBStorage2::merge).
+        co_await storage.merge(mutableLayer);
+
+        // Raw Get with the literal 38-byte key: proves the on-disk layout, not just the
+        // resolver round-trip.
+        std::string rawValue;
+        auto status = rocksDB->Get(
+            ::rocksdb::ReadOptions(), storage2::makeMPTNodeKey(hash), std::addressof(rawValue));
+        BOOST_REQUIRE(status.ok());
+
+        // The value is Entry-encoded like every other value in the CF.
+        auto decoded = storage::Entry::decode(
+            bytesConstRef(reinterpret_cast<const byte*>(rawValue.data()), rawValue.size()));
+        auto decodedView = decoded.get();
+        bytes const decodedBytes(decodedView.begin(), decodedView.end());
+        BOOST_CHECK(decodedBytes == nodeRlp);
+
+        // The flat row landed too (same merge, same batch).
+        auto flatBack = co_await storage2::readOne(storage, StateKey{"/apps/test", "balance"});
+        BOOST_REQUIRE(flatBack);
+        BOOST_CHECK_EQUAL(std::string(flatBack->get()), "flat-value");
+
+        // And the ordinary StateKey read path resolves the node row.
+        auto nodeBack = co_await storage2::readOne(storage, storage2::mptNodeStateKey(hash));
+        BOOST_REQUIRE(nodeBack);
+        auto nodeBackView = nodeBack->get();
+        bytes const nodeBackBytes(nodeBackView.begin(), nodeBackView.end());
+        BOOST_CHECK(nodeBackBytes == nodeRlp);
+    }());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
+++ b/bcos-storage/test/unittest/TestRocksDBStorage2.cpp
@@ -2,8 +2,8 @@
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-task/Wait.h"
-#include <bcos-storage/CheckpointRocksDBStorage.h>
 #include <bcos-framework/storage/Entry.h>
+#include <bcos-storage/CheckpointRocksDBStorage.h>
 #include <bcos-storage/RocksDBStorage2.h>
 #include <bcos-storage/StateKVResolver.h>
 #include <fmt/format.h>
@@ -58,8 +58,8 @@ struct TestRocksDBStorage2Fixture
 
         RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver> storage(
             *guard, StateKeyResolver{}, StateValueResolver{});
-        task::syncWait(storage2::writeOne(
-            storage, StateKey{table, key}, storage::Entry(std::string(value))));
+        task::syncWait(
+            storage2::writeOne(storage, StateKey{table, key}, storage::Entry(std::string(value))));
     }
 };
 
@@ -236,13 +236,55 @@ BOOST_AUTO_TEST_CASE(merge)
     }());
 }
 
+// merge() folds its sources into ONE WriteBatch in ARGUMENT ORDER, so when two sources carry
+// the same key the LAST one wins on disk. MultiLayerStorage::mergeBackStorage leans on exactly
+// this: it passes the committing block's own layer first and commit's prewrite storage second,
+// so a row both of them hold — SYS_NUMBER_2_BLOCK_HEADER, written unsigned at execute time and
+// signed at commit time — persists in the prewrite (signed) version. The MultiLayerStorage-level
+// test lives in TestMPTSchedulerWiring; this one pins the property at the physical RocksDB layer.
+BOOST_AUTO_TEST_CASE(mergeAppliesSourcesInArgumentOrder)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver> rocksDB(
+            *originRocksDB, StateKeyResolver{}, StateValueResolver{});
+
+        storage2::memory_storage::MemoryStorage<StateKey, StateValue,
+            storage2::memory_storage::ORDERED>
+            firstSource;
+        storage2::memory_storage::MemoryStorage<StateKey, StateValue,
+            storage2::memory_storage::ORDERED>
+            secondSource;
+
+        StateKey const sharedKey{"s_number_2_header"sv, "7"sv};
+        co_await storage2::writeOne(firstSource, sharedKey, storage::Entry{"executed-unsigned"});
+        co_await storage2::writeOne(secondSource, sharedKey, storage::Entry{"committed-signed"});
+        // A key only the first source holds must survive the merge untouched.
+        StateKey const firstOnlyKey{"s_number_2_hash"sv, "7"sv};
+        co_await storage2::writeOne(firstSource, firstOnlyKey, storage::Entry{"hash-row"});
+
+        co_await storage2::merge(rocksDB, firstSource, secondSource);
+
+        auto shared = co_await storage2::readOne(rocksDB, sharedKey);
+        BOOST_REQUIRE(shared);
+        BOOST_CHECK_EQUAL(shared->get(), "committed-signed");
+
+        auto firstOnly = co_await storage2::readOne(rocksDB, firstOnlyKey);
+        BOOST_REQUIRE(firstOnly);
+        BOOST_CHECK_EQUAL(firstOnly->get(), "hash-row");
+
+        co_return;
+    }());
+}
+
 BOOST_AUTO_TEST_CASE(openLatestOrCheckpointByDirectory)
 {
     auto root = path + "_checkpoint_root";
     TestCheckpointStorage checkpointRocksDBStorage(root, StateKeyResolver{}, StateValueResolver{});
     auto latestPath = checkpointRocksDBStorage.latestPath();
-    auto firstCheckpointName = h256("1111111111111111111111111111111111111111111111111111111111111111");
-    auto secondCheckpointName = h256("2222222222222222222222222222222222222222222222222222222222222222");
+    auto firstCheckpointName =
+        h256("1111111111111111111111111111111111111111111111111111111111111111");
+    auto secondCheckpointName =
+        h256("2222222222222222222222222222222222222222222222222222222222222222");
     auto firstCheckpointPath = checkpointRocksDBStorage.checkpointPath(firstCheckpointName);
     auto secondCheckpointPath = checkpointRocksDBStorage.checkpointPath(secondCheckpointName);
 
@@ -266,8 +308,8 @@ BOOST_AUTO_TEST_CASE(openLatestOrCheckpointByDirectory)
         BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.oldestCheckpointName(), firstCheckpointName);
 
         auto firstCheckpointStorage = checkpointRocksDBStorage.open(firstCheckpointName);
-        auto firstCheckpointValue = co_await storage2::readOne(
-            firstCheckpointStorage, StateKey{"sys"sv, "key"sv});
+        auto firstCheckpointValue =
+            co_await storage2::readOne(firstCheckpointStorage, StateKey{"sys"sv, "key"sv});
         BOOST_REQUIRE(firstCheckpointValue);
         BOOST_CHECK_EQUAL(firstCheckpointValue->get(), "latest-value-1");
         BOOST_CHECK_EQUAL(
@@ -284,8 +326,8 @@ BOOST_AUTO_TEST_CASE(openLatestOrCheckpointByDirectory)
         BOOST_CHECK_EQUAL(*checkpointRocksDBStorage.oldestCheckpointName(), firstCheckpointName);
 
         auto secondCheckpointStorage = checkpointRocksDBStorage.open(secondCheckpointName);
-        auto secondCheckpointValue = co_await storage2::readOne(
-            secondCheckpointStorage, StateKey{"sys"sv, "key"sv});
+        auto secondCheckpointValue =
+            co_await storage2::readOne(secondCheckpointStorage, StateKey{"sys"sv, "key"sv});
         BOOST_REQUIRE(secondCheckpointValue);
         BOOST_CHECK_EQUAL(secondCheckpointValue->get(), "latest-value-2");
         BOOST_CHECK_EQUAL(

--- a/transaction-scheduler/CMakeLists.txt
+++ b/transaction-scheduler/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(transaction-scheduler bcos-transaction-scheduler/BaselineScheduler.c
 target_include_directories(transaction-scheduler PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-transaction-scheduler>)
-target_link_libraries(transaction-scheduler PUBLIC ledger bcos-framework fmt::fmt-header-only)
+target_link_libraries(transaction-scheduler PUBLIC ledger storage bcos-framework fmt::fmt-header-only)
 set_target_properties(transaction-scheduler PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -237,13 +237,26 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
     // view while the parent is still pending. Commit overwrites this row with the
     // consensus-SIGNED encoding in the same WriteBatch — mergeBackStorage merges the
     // block's layer before prewriteStorage, so the signed version wins in the backend.
-    bytes headerBuffer;
-    newBlockHeader.encode(headerBuffer);
-    storage::Entry headerEntry;
-    headerEntry.set(std::move(headerBuffer));
-    co_await storage2::writeOne(storage,
-        executor_v1::StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr},
-        std::move(headerEntry));
+    //
+    // Both conditions are load-bearing:
+    //  - MPT blocks only. buildMPTStateRoot reads a parent header exactly when the parent
+    //    itself built an MPT root, so publishing headers for XOR blocks would buy nothing
+    //    and leave every legacy chain's execute path carrying an extra row;
+    //  - never block 0. Unlike the two hash mappings above, the genesis header row has an
+    //    owner: Ledger::buildGenesisBlock writes it at chain init, and coCommitBlock skips
+    //    prewriteBlockToBuffer for block 0 (isSysContractDeploy), so nothing would overwrite
+    //    an execute-time row — the sys-contract-deploy header (its own gasUsed, hash, empty
+    //    sealer/parentInfo) would replace the chain's genesis header on disk.
+    if (mptStateRoot && newBlockHeader.number() != 0)
+    {
+        bytes headerBuffer;
+        newBlockHeader.encode(headerBuffer);
+        storage::Entry headerEntry;
+        headerEntry.set(std::move(headerBuffer));
+        co_await storage2::writeOne(storage,
+            executor_v1::StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr},
+            std::move(headerEntry));
+    }
 }
 
 template <class MultiLayerStorage,
@@ -309,14 +322,16 @@ private:
      * blocks' not-yet-committed deltas, node rows included — and return the trie-node delta.
      *
      * The parent state root comes from the parent block's HEADER, read through the view.
-     * finishExecute writes every executed header into its block's mutable layer, so ONE
-     * getBlockData arm covers every case: a pending parent resolves from the view's
-     * immutable chain (pipeline), a committed parent — the genesis block included — from
-     * the backend's signed header (restart / sequential). A missing header under an MPT
-     * parent throws NotFoundBlockHeader (getBlockData, LedgerMethods.h) — never a silent
-     * empty-trie rebuild. An XOR parent (scenario-A activation boundary) starts from the
-     * empty trie. Scenario-B limitation unchanged: a non-empty-alloc L2 genesis persists
-     * its header but no trie NODES, so only empty-alloc genesis chains block 1 today.
+     * finishExecute publishes every non-genesis MPT block's executed header into its own
+     * mutable layer, so ONE getBlockData arm covers every case: a pending parent resolves
+     * from the view's immutable chain (pipeline), a committed parent — the genesis block
+     * included — from the backend's signed header (restart / sequential; genesis is the
+     * ledger's own genesis header, which is why finishExecute must not publish one). A
+     * missing header under an MPT parent throws NotFoundBlockHeader (getBlockData,
+     * LedgerMethods.h) — never a silent empty-trie rebuild. An XOR parent (scenario-A
+     * activation boundary) starts from the empty trie, and never has its header read here.
+     * Scenario-B limitation unchanged: a non-empty-alloc L2 genesis persists its header but
+     * no trie NODES, so only empty-alloc genesis chains block 1 today.
      */
     task::Task<ledger::mpt::MPTDeltaLayer> buildMPTStateRoot(
         typename MultiLayerStorage::ViewType& view, protocol::BlockHeader const& blockHeader,

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -471,6 +471,12 @@ private:
             std::optional<h256> mptStateRoot;
             if (shouldBuildMPT(ledgerConfig->features(), blockHeader->number()))
             {
+                // Reaching here means an MPT IS being built, so the flag-matrix rule the
+                // build depends on has to hold. Re-checked per block rather than at startup
+                // only: a mid-chain activation of either flag is invisible to the boot-time
+                // guard (LedgerInitializer). Inside the branch, so shouldBuildMPT stays a
+                // pure predicate AND is evaluated once.
+                rejectRawAddressWithMPT(ledgerConfig->features(), blockHeader->number());
                 try
                 {
                     mptDelta.emplace(co_await buildMPTStateRoot(view, *blockHeader, *ledgerConfig));

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -230,6 +230,20 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
         executor_v1::StateKey{
             ledger::SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(blockHash)},
         hash2NumberEntry);
+
+    // The executed header itself, under the same key commit's prewrite uses — written at
+    // execute time for the same reason as the two hash mappings above: the NEXT block's
+    // execution reads its parent's header (stateRoot for the MPT parent root) through the
+    // view while the parent is still pending. Commit overwrites this row with the
+    // consensus-SIGNED encoding in the same WriteBatch — mergeBackStorage merges the
+    // block's layer before prewriteStorage, so the signed version wins in the backend.
+    bytes headerBuffer;
+    newBlockHeader.encode(headerBuffer);
+    storage::Entry headerEntry;
+    headerEntry.set(std::move(headerBuffer));
+    co_await storage2::writeOne(storage,
+        executor_v1::StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr},
+        std::move(headerEntry));
 }
 
 template <class MultiLayerStorage,
@@ -294,44 +308,29 @@ private:
      * mutable layer is exactly this block's delta and whose immutable layers are the pending
      * blocks' not-yet-committed deltas, node rows included — and return the trie-node delta.
      *
-     * Parent state root resolution, in order:
-     *  1. the newest pending ExecuteResult (block N-1 executed, not yet committed) carries an
-     *     MPT delta — pipeline case, its stateRoot is the parent root; the parent's NODES need
-     *     no bookkeeping, they sit in N-1's layer inside this view's immutable chain;
-     *  2. shouldBuildMPT(features, N-1): block N-1 committed with an MPT root — read it from
-     *     the signed header in the ledger (restart / sequential case);
-     *  3. otherwise (scenario-A activation boundary where N-1 was XOR-rooted, or genesis):
-     *     the empty trie root.
+     * The parent state root comes from the parent block's HEADER, read through the view.
+     * finishExecute writes every executed header into its block's mutable layer, so ONE
+     * getBlockData arm covers every case: a pending parent resolves from the view's
+     * immutable chain (pipeline), a committed parent — the genesis block included — from
+     * the backend's signed header (restart / sequential). A missing header under an MPT
+     * parent throws NotFoundBlockHeader (getBlockData, LedgerMethods.h) — never a silent
+     * empty-trie rebuild. An XOR parent (scenario-A activation boundary) starts from the
+     * empty trie. Scenario-B limitation unchanged: a non-empty-alloc L2 genesis persists
+     * its header but no trie NODES, so only empty-alloc genesis chains block 1 today.
      */
     task::Task<ledger::mpt::MPTDeltaLayer> buildMPTStateRoot(
         typename MultiLayerStorage::ViewType& view, protocol::BlockHeader const& blockHeader,
         ledger::LedgerConfig const& ledgerConfig)
     {
-        h256 parentStateRoot = ledger::mpt::emptyRootHash();
         auto const blockNumber = blockHeader.number();
-        bool parentPending = false;
-        {
-            std::unique_lock resultsLock(m_resultsMutex);
-            if (!m_results.empty() &&
-                m_results.front()->m_executedBlockHeader->number() == blockNumber - 1 &&
-                m_results.front()->m_mptDelta)
-            {
-                parentStateRoot = m_results.front()->m_mptDelta->stateRoot;
-                parentPending = true;
-            }
-        }
-        if (!parentPending && blockNumber > 0 &&
-            shouldBuildMPT(ledgerConfig.features(), blockNumber - 1))
+        h256 parentStateRoot = ledger::mpt::emptyRootHash();
+        if (blockNumber > 0 && shouldBuildMPT(ledgerConfig.features(), blockNumber - 1))
         {
             auto parentBlock = co_await ledger::getBlockData(
                 view, blockNumber - 1, ledger::HEADER, m_blockFactory.get());
             parentStateRoot = parentBlock->blockHeader()->stateRoot();
         }
-        // else: scenario-A activation boundary (parent committed an XOR root) or a scenario-B
-        // genesis execute — the build starts from the empty trie. Scenario-B limitation: a
-        // non-empty-alloc L2 genesis persists its state root (Ledger.cpp genesis build) but
-        // not its trie NODES, so only empty-alloc genesis (root == emptyRootHash()) can chain
-        // block 1 today.
+        // else: scenario-A activation boundary (parent committed an XOR root) — empty trie.
 
         // Node reads resolve through the full view (parent nodes live in the pending layers /
         // backend); node writes land in this block's own mutable layer (MPTNodeStorage.h).

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "BaselineSchedulerMPTHelpers.h"
+#include "MPTNodeStorage.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
 #include "bcos-crypto/merkle/Merkle.h"
 #include "bcos-executor/src/Common.h"
@@ -23,6 +25,8 @@
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-framework/txpool/TxPoolInterface.h"
+#include "bcos-ledger/mpt/CommitObserver.h"
+#include "bcos-ledger/mpt/MPTBuilder.h"
 #include "bcos-task/TBBWait.h"
 #include "bcos-task/Wait.h"
 #include "bcos-utilities/Bloom.h"
@@ -158,7 +162,7 @@ h256 calculateReceiptRoot(
 task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
     protocol::BlockHeader& newBlockHeader, protocol::Block& block,
     ::ranges::input_range auto transactions, bool& sysBlock, crypto::Hash const& hashImpl,
-    ledger::Features const& features)
+    ledger::Features const& features, std::optional<h256> mptStateRoot = {})
 {
     ittapi::Report finishReport(ittapi::ITT_DOMAINS::instance().BASELINE_SCHEDULER,
         ittapi::ITT_DOMAINS::instance().FINISH_EXECUTE);
@@ -169,6 +173,14 @@ task::Task<void> finishExecute(auto& storage, ::ranges::range auto receipts,
 
     tbb::parallel_invoke([&]() { transactionRoot = calculateTransactionRoot(block, hashImpl); },
         [&]() {
+            // When the block was built with an Ethereum MPT root (shouldBuildMPT), the header
+            // commits to it verbatim and the legacy XOR fold is skipped; with no MPT root the
+            // XOR arm below is byte-identical to the pre-MPT behavior.
+            if (mptStateRoot)
+            {
+                stateRoot = *mptStateRoot;
+                return;
+            }
             stateRoot = task::tbb::syncWait(
                 calculateStateRoot(storage, block.blockHeader()->version(), hashImpl, features));
         },
@@ -260,9 +272,74 @@ private:
         protocol::BlockHeader::Ptr m_executedBlockHeader;
         protocol::Block::Ptr m_block;
         bool m_sysBlock{};
+        /// Engaged when the block was executed with an MPT state root (shouldBuildMPT).
+        /// Observer payload and parent-root source ONLY: its stateRoot seeds the NEXT block's
+        /// build while this one awaits commit, and coCommitBlock hands the whole delta to the
+        /// CommitObserver after the merge lands. Node PERSISTENCE never reads it — the node
+        /// rows ride the block's mutable layer into mergeBackStorage as ordinary state rows
+        /// (MPTNodeStorage.h).
+        std::optional<ledger::mpt::MPTDeltaLayer> m_mptDelta;
     };
     std::deque<std::shared_ptr<ExecuteResult>> m_results;
     std::mutex m_resultsMutex;
+
+    /// Post-commit hook over each MPT block's node delta — the pathdb pruning seam
+    /// (CommitObserver.h). Defaults to the no-op observer; replaced via setMPTCommitObserver.
+    /// Written only before block flow starts (wiring time), read on the commit path.
+    std::shared_ptr<ledger::mpt::CommitObserver> m_mptCommitObserver =
+        std::make_shared<ledger::mpt::NoopCommitObserver>();
+
+    /**
+     * Build the block's Ethereum MPT state root over the execute view — the view whose top
+     * mutable layer is exactly this block's delta and whose immutable layers are the pending
+     * blocks' not-yet-committed deltas, node rows included — and return the trie-node delta.
+     *
+     * Parent state root resolution, in order:
+     *  1. the newest pending ExecuteResult (block N-1 executed, not yet committed) carries an
+     *     MPT delta — pipeline case, its stateRoot is the parent root; the parent's NODES need
+     *     no bookkeeping, they sit in N-1's layer inside this view's immutable chain;
+     *  2. shouldBuildMPT(features, N-1): block N-1 committed with an MPT root — read it from
+     *     the signed header in the ledger (restart / sequential case);
+     *  3. otherwise (scenario-A activation boundary where N-1 was XOR-rooted, or genesis):
+     *     the empty trie root.
+     */
+    task::Task<ledger::mpt::MPTDeltaLayer> buildMPTStateRoot(
+        typename MultiLayerStorage::ViewType& view, protocol::BlockHeader const& blockHeader,
+        ledger::LedgerConfig const& ledgerConfig)
+    {
+        h256 parentStateRoot = ledger::mpt::emptyRootHash();
+        auto const blockNumber = blockHeader.number();
+        bool parentPending = false;
+        {
+            std::unique_lock resultsLock(m_resultsMutex);
+            if (!m_results.empty() &&
+                m_results.front()->m_executedBlockHeader->number() == blockNumber - 1 &&
+                m_results.front()->m_mptDelta)
+            {
+                parentStateRoot = m_results.front()->m_mptDelta->stateRoot;
+                parentPending = true;
+            }
+        }
+        if (!parentPending && blockNumber > 0 &&
+            shouldBuildMPT(ledgerConfig.features(), blockNumber - 1))
+        {
+            auto parentBlock = co_await ledger::getBlockData(
+                view, blockNumber - 1, ledger::HEADER, m_blockFactory.get());
+            parentStateRoot = parentBlock->blockHeader()->stateRoot();
+        }
+        // else: scenario-A activation boundary (parent committed an XOR root) or a scenario-B
+        // genesis execute — the build starts from the empty trie. Scenario-B limitation: a
+        // non-empty-alloc L2 genesis persists its state root (Ledger.cpp genesis build) but
+        // not its trie NODES, so only empty-alloc genesis (root == emptyRootHash()) can chain
+        // block 1 today.
+
+        // Node reads resolve through the full view (parent nodes live in the pending layers /
+        // backend); node writes land in this block's own mutable layer (MPTNodeStorage.h).
+        ViewNodeStorage<typename MultiLayerStorage::ViewType> nodeStorage(view);
+        bool const l2Mode =
+            ledgerConfig.features().get(ledger::Features::Flag::feature_l2_ethereum_compat);
+        co_return co_await ledger::mpt::buildAndCollect(nodeStorage, parentStateRoot, view, l2Mode);
+    }
 
     /**
      * Executes a block and returns a tuple containing an error (if any), the block header, and
@@ -370,12 +447,39 @@ private:
             auto receipts = co_await m_schedulerImpl.get().executeBlock(view, m_executor.get(),
                 *blockHeader, ::ranges::views::indirect(transactions), *ledgerConfig);
 
+            // MPT state root (spec §5.6): built at EXECUTE time, not commit time — the block
+            // header's stateRoot is set and hashed in finishExecute below and that hash is what
+            // PBFT signs, so a commit-time build could never reach the header. The trie-node
+            // rows land in this view's mutable layer (persisted by commit's mergeBackStorage
+            // like any state row); the delta rides in ExecuteResult for the CommitObserver and
+            // the next block's parent root.
+            std::optional<ledger::mpt::MPTDeltaLayer> mptDelta;
+            std::optional<h256> mptStateRoot;
+            if (shouldBuildMPT(ledgerConfig->features(), blockHeader->number()))
+            {
+                try
+                {
+                    mptDelta.emplace(co_await buildMPTStateRoot(view, *blockHeader, *ledgerConfig));
+                    mptStateRoot = mptDelta->stateRoot;
+                }
+                catch (std::exception& e)
+                {
+                    // No fallback to the XOR root: a silent state-root scheme switch is a
+                    // fork — a halted chain is diagnosable, a forked one is not. The
+                    // rethrow surfaces through coExecuteBlock's catch as an execute error.
+                    BASELINE_SCHEDULER_LOG(ERROR)
+                        << "MPT state root build failed, refusing XOR fallback, block="
+                        << blockHeader->number() << " | " << boost::diagnostic_information(e);
+                    throw;
+                }
+            }
+
             auto executedBlockHeader =
                 m_blockFactory.get().blockHeaderFactory()->populateBlockHeader(blockHeader);
             bool sysBlock = false;
             co_await finishExecute(mutableStorage(view), ::ranges::views::all(receipts),
                 *executedBlockHeader, *block, ::ranges::views::all(transactions), sysBlock,
-                m_hashImpl.get(), ledgerConfig->features());
+                m_hashImpl.get(), ledgerConfig->features(), mptStateRoot);
 
             if (verify && (executedBlockHeader->hash() != blockHeader->hash()))
             {
@@ -409,7 +513,8 @@ private:
                     .m_receipts = std::move(receipts),
                     .m_executedBlockHeader = executedBlockHeader,
                     .m_block = std::move(block),
-                    .m_sysBlock = sysBlock});
+                    .m_sysBlock = sysBlock,
+                    .m_mptDelta = std::move(mptDelta)});
 
             // FIB-103 / FIB-104: Commit the execution result in a strict order:
             // push the view first (so we have a rollback target), then push the
@@ -602,10 +707,27 @@ private:
             // own mutex, (b) backpressure is only over-conservative by one, and
             // (c) m_results.back() cannot change here — m_commitMutex guarantees
             // a single committer.
+            // MPT node persistence needs no code here: the block's trie-node rows were written
+            // into its mutable layer at execute time as ordinary "/mpt/" state rows
+            // (MPTNodeStorage.h), so the single mergeBackStorage below lands flat state and
+            // trie nodes in one backend merge — one WriteBatch, one Write
+            // (RocksDBStorage2::merge). delta.obsoletedNodes / intraBlockObsoleted are NOT
+            // consumed here: they are candidates for the future pathdb pruning spec only, no
+            // deletes are issued (MPTDeltaLayer.h contract).
             {
                 ittapi::Report mergeReport(ittapi::ITT_DOMAINS::instance().BASE_SCHEDULER,
                     ittapi::ITT_DOMAINS::instance().MERGE_STATE);
                 co_await m_multiLayerStorage.get().mergeBackStorage(prewriteStorage);
+            }
+
+            // CommitObserver timing contract (CommitObserver.h): AFTER the block's WriteBatch
+            // has landed and BEFORE m_lastCommittedBlockNumber advances, so the delta the
+            // observer sees is exactly the persisted state. Only MPT blocks fire it. The
+            // contract requires implementations not to throw and not to block; deliberately
+            // no try/catch here — swallowing an observer bug would hide it forever.
+            if (result->m_mptDelta)
+            {
+                m_mptCommitObserver->onCommit(header->number(), *result->m_mptDelta);
             }
 
             {
@@ -833,6 +955,17 @@ public:
         std::function<void(bcos::protocol::BlockNumber)> blockNumberNotifier)
     {
         m_blockNumberNotifier = std::move(blockNumberNotifier);
+    }
+
+    /// Replace the MPT commit observer (CommitObserver.h). Call at wiring time, before block
+    /// flow starts. A null pointer keeps the current observer — the commit path relies on the
+    /// member never being empty.
+    void setMPTCommitObserver(std::shared_ptr<ledger::mpt::CommitObserver> observer)
+    {
+        if (observer)
+        {
+            m_mptCommitObserver = std::move(observer);
+        }
     }
 
     void setVersion(int version, ledger::LedgerConfig::Ptr ledgerConfig) override {}

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -300,11 +300,12 @@ private:
         protocol::Block::Ptr m_block;
         bool m_sysBlock{};
         /// Engaged when the block was executed with an MPT state root (shouldBuildMPT).
-        /// Observer payload and parent-root source ONLY: its stateRoot seeds the NEXT block's
-        /// build while this one awaits commit, and coCommitBlock hands the whole delta to the
-        /// CommitObserver after the merge lands. Node PERSISTENCE never reads it — the node
-        /// rows ride the block's mutable layer into mergeBackStorage as ordinary state rows
-        /// (MPTNodeStorage.h).
+        /// CommitObserver payload ONLY: coCommitBlock hands the whole delta to the observer
+        /// after the merge lands. Nothing else reads it — node PERSISTENCE goes through the
+        /// block's mutable layer into mergeBackStorage as ordinary state rows
+        /// (MPTNodeStorage.h), and the NEXT block reads its parent root from the published
+        /// header row, not from here (buildMPTStateRoot), so this field is not a channel any
+        /// consensus-path data flows through.
         std::optional<ledger::mpt::MPTDeltaLayer> m_mptDelta;
     };
     std::deque<std::shared_ptr<ExecuteResult>> m_results;
@@ -328,8 +329,19 @@ private:
      * included — from the backend's signed header (restart / sequential; genesis is the
      * ledger's own genesis header, which is why finishExecute must not publish one). A
      * missing header under an MPT parent throws NotFoundBlockHeader (getBlockData,
-     * LedgerMethods.h) — never a silent empty-trie rebuild. An XOR parent (scenario-A
-     * activation boundary) starts from the empty trie, and never has its header read here.
+     * LedgerMethods.h) — never a silent empty-trie rebuild.
+     *
+     * An XOR parent (the scenario-A activation boundary) starts from the EMPTY trie, and
+     * never has its header read here. That is the scenario-A semantics, not an oversight:
+     * activating feature_mpt_state_root mid-chain commits only to state written AFTER
+     * activation — accounts dormant since the flip stay outside the trie and answer
+     * AccountNotInMPT, and the root is deliberately NOT a full-state Ethereum commitment
+     * (spec design3 §1.1.2 / §1.1.4 / §1.1.6; the 2026-07-09 revision removed first-touch
+     * bootstrap and the preheat tooling on purpose — no stop-the-world scan, no migration).
+     * Sync completeness on such a chain comes from replaying the block sequence, as it did
+     * before MPT. Scenario B (L2 from genesis) is the full-state case: every account enters
+     * the trie when it is created.
+     *
      * Scenario-B limitation unchanged: a non-empty-alloc L2 genesis persists its header but
      * no trie NODES, so only empty-alloc genesis chains block 1 today.
      */
@@ -490,6 +502,20 @@ private:
                     BASELINE_SCHEDULER_LOG(ERROR)
                         << "MPT state root build failed, refusing XOR fallback, block="
                         << blockHeader->number() << " | " << boost::diagnostic_information(e);
+                    if (blockHeader->number() == 1)
+                    {
+                        // The known scenario-B gap has exactly this shape, and a bare
+                        // missing-node error from the trie core cannot say so: an L2 genesis
+                        // built from a NON-EMPTY alloc writes the genesis stateRoot but not
+                        // the trie nodes behind it, so block 1's incremental build cannot
+                        // resolve the parent trie. Name it instead of leaving operators to
+                        // guess.
+                        BASELINE_SCHEDULER_LOG(ERROR)
+                            << "Block 1 build failure on an L2 chain: if genesis was created "
+                               "with a non-empty alloc, its trie nodes were never persisted "
+                               "(known limitation) — only empty-alloc genesis chains block 1 "
+                               "today";
+                    }
                     throw;
                 }
             }

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
@@ -11,32 +11,50 @@ namespace bcos::scheduler_v1
 DERIVE_BCOS_EXCEPTION(InvalidMPTFlagMatrix);
 
 // Decide whether block @p blockNumber commits with an Ethereum MPT state root instead of
-// the legacy XOR root (spec 5.6 / 5.10). Pure function; the commit path (coCommitBlock)
-// consults it once per block when the MPT branch is wired in.
+// the legacy XOR root (spec 5.6 / 5.10). The commit path (coCommitBlock) consults it once
+// per block when the MPT branch is wired in.
+//
+// @throws InvalidMPTFlagMatrix when the answer would be true while feature_raw_address is
+//         set. Throwing here is deliberate: flags can activate at block boundaries after
+//         boot, so validateMPTFlagMatrix at startup cannot see a mid-chain activation of
+//         either flag of the pair. Aborting the commit path loudly beats silently building
+//         an MPT that classifies no account table (see validateMPTFlagMatrix for why the
+//         combination is unsupported) — fail-loud over fail-silent.
 inline bool shouldBuildMPT(
     bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber)
 {
+    bool buildMPT = false;
     // Scenario B: L2 Ethereum-compat chains build the MPT from genesis on. Checked FIRST:
     // at block 0 feature_mpt_state_root is not yet active, so consulting scenario A first
     // would send an L2 chain down the XOR path.
     if (features.get(ledger::Features::Flag::feature_l2_ethereum_compat))
     {
-        return true;
+        buildMPT = true;
     }
-
     // Scenario A: MPT enabled mid-chain by feature_mpt_state_root. Strictly-greater keeps
     // the activation block N itself on XOR as the transition boundary (spec 5.10). The
     // >= 0 guard rejects activationBlockOf == -1 — a flag set() without a storage load —
     // which would otherwise silently enable MPT since blockNumber > -1 is always true.
-    if (features.get(ledger::Features::Flag::feature_mpt_state_root))
+    else if (features.get(ledger::Features::Flag::feature_mpt_state_root))
     {
         auto activationBlock =
             features.activationBlockOf(ledger::Features::Flag::feature_mpt_state_root);
-        return activationBlock >= 0 && blockNumber > activationBlock;
+        buildMPT = activationBlock >= 0 && blockNumber > activationBlock;
     }
+    // Neither flag: legacy XOR state root (buildMPT stays false).
 
-    // Neither flag: legacy XOR state root.
-    return false;
+    if (buildMPT && features.get(ledger::Features::Flag::feature_raw_address))
+    {
+        BOOST_THROW_EXCEPTION(InvalidMPTFlagMatrix{} << bcos::errinfo_comment(
+                                  "feature_raw_address is active while the MPT state root is "
+                                  "enabled (block " +
+                                  std::to_string(blockNumber) +
+                                  "); raw_address stores account tables under 20-byte binary "
+                                  "names, which the MPT delta scan cannot classify — every "
+                                  "account would silently drop out of the MPT. Unsupported in "
+                                  "v1; aborting the commit path instead of forking silently"));
+    }
+    return buildMPT;
 }
 
 // Startup-time guard for the flag matrix shouldBuildMPT relies on (spec 5.10, M7.3).
@@ -51,11 +69,35 @@ inline bool shouldBuildMPT(
 // populated; a bare set() leaves activationBlockOf at -1, which this guard rejects for
 // the same reason (an unverifiable activation must not pass a consistency check).
 //
-// @throws InvalidMPTFlagMatrix when feature_l2_ethereum_compat is set with a non-zero
-//         (or unknown) activation block. A features object without the flag always passes.
+// A second invariant guards feature_raw_address: it switches account table names from
+// /apps/<40-hex-address> to 20-byte binary addresses, but the MPT delta scan
+// (parseAccountTable, spec 5.10) only classifies 40-hex account tables. With both active,
+// every account table fails classification and silently drops out of the MPT — the chain
+// keeps committing state roots that cover no account (a silent fork against any honest
+// replica). Binary account tables are unsupported in v1, so refuse the combination with
+// either MPT flag. shouldBuildMPT re-checks this at commit time for activations that
+// happen after boot.
+//
+// @throws InvalidMPTFlagMatrix when feature_raw_address is set together with
+//         feature_mpt_state_root or feature_l2_ethereum_compat, or when
+//         feature_l2_ethereum_compat is set with a non-zero (or unknown) activation
+//         block. A features object with neither MPT flag always passes.
 inline void validateMPTFlagMatrix(bcos::ledger::Features const& features)
 {
     using Flag = bcos::ledger::Features::Flag;
+    if (features.get(Flag::feature_raw_address) &&
+        (features.get(Flag::feature_mpt_state_root) ||
+            features.get(Flag::feature_l2_ethereum_compat)))
+    {
+        BOOST_THROW_EXCEPTION(InvalidMPTFlagMatrix{} << bcos::errinfo_comment(
+                                  "feature_raw_address cannot be combined with "
+                                  "feature_mpt_state_root or feature_l2_ethereum_compat: "
+                                  "raw_address stores account tables under 20-byte binary "
+                                  "names, but the MPT delta scan only classifies 40-hex "
+                                  "/apps/<address> tables, so every account would silently "
+                                  "drop out of the MPT state root (silent fork). Binary "
+                                  "account tables are unsupported in v1 (spec 5.10)"));
+    }
     if (!features.get(Flag::feature_l2_ethereum_compat))
     {
         return;

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
@@ -55,6 +55,14 @@ inline bool shouldBuildMPT(
 //         beats silently building an MPT that classifies no account table (see
 //         validateMPTFlagMatrix for why the combination is unsupported) — fail-loud over
 //         fail-silent. @p blockNumber is diagnostic only.
+//
+// OPERATIONAL CONSEQUENCE, deliberate: on a chain already building an MPT, turning
+// feature_raw_address on mid-chain halts block production from the next block, and there is
+// no in-protocol recovery — the flag cannot be turned off again through consensus once every
+// node refuses to execute. The alternative is worse: an MPT over a key space the delta scan
+// cannot classify commits roots that cover no account at all, which forks the chain against
+// every honest replica silently. feature_raw_address and the MPT state root are mutually
+// exclusive for the life of a chain, not just at boot.
 inline void rejectRawAddressWithMPT(
     bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber)
 {

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h
@@ -11,15 +11,12 @@ namespace bcos::scheduler_v1
 DERIVE_BCOS_EXCEPTION(InvalidMPTFlagMatrix);
 
 // Decide whether block @p blockNumber commits with an Ethereum MPT state root instead of
-// the legacy XOR root (spec 5.6 / 5.10). The commit path (coCommitBlock) consults it once
+// the legacy XOR root (spec 5.6 / 5.10). The execute path (coExecuteBlock) consults it once
 // per block when the MPT branch is wired in.
 //
-// @throws InvalidMPTFlagMatrix when the answer would be true while feature_raw_address is
-//         set. Throwing here is deliberate: flags can activate at block boundaries after
-//         boot, so validateMPTFlagMatrix at startup cannot see a mid-chain activation of
-//         either flag of the pair. Aborting the commit path loudly beats silently building
-//         an MPT that classifies no account table (see validateMPTFlagMatrix for why the
-//         combination is unsupported) — fail-loud over fail-silent.
+// Pure: no throw, no side effect. The flag-matrix rule this decision depends on is enforced
+// by rejectRawAddressWithMPT below, which the execute path calls inside this predicate's
+// branch — one evaluation, and the guard never has to re-ask the question.
 inline bool shouldBuildMPT(
     bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber)
 {
@@ -42,8 +39,26 @@ inline bool shouldBuildMPT(
         buildMPT = activationBlock >= 0 && blockNumber > activationBlock;
     }
     // Neither flag: legacy XOR state root (buildMPT stays false).
+    return buildMPT;
+}
 
-    if (buildMPT && features.get(ledger::Features::Flag::feature_raw_address))
+// Runtime half of the flag-matrix guard. PRECONDITION: call it only where the block is
+// already known to be building an MPT — i.e. inside the shouldBuildMPT branch of the execute
+// path — so the predicate is evaluated once and this function only has to answer "is
+// raw_address in the way?".
+//
+// The startup half (validateMPTFlagMatrix, below) cannot cover this case: flags activate at
+// block boundaries after boot, so a node that started before feature_raw_address — or before
+// either MPT flag — never saw the pair at startup.
+//
+// @throws InvalidMPTFlagMatrix when feature_raw_address is set. Aborting execution loudly
+//         beats silently building an MPT that classifies no account table (see
+//         validateMPTFlagMatrix for why the combination is unsupported) — fail-loud over
+//         fail-silent. @p blockNumber is diagnostic only.
+inline void rejectRawAddressWithMPT(
+    bcos::ledger::Features const& features, bcos::protocol::BlockNumber blockNumber)
+{
+    if (features.get(ledger::Features::Flag::feature_raw_address))
     {
         BOOST_THROW_EXCEPTION(InvalidMPTFlagMatrix{} << bcos::errinfo_comment(
                                   "feature_raw_address is active while the MPT state root is "
@@ -52,9 +67,8 @@ inline bool shouldBuildMPT(
                                   "); raw_address stores account tables under 20-byte binary "
                                   "names, which the MPT delta scan cannot classify — every "
                                   "account would silently drop out of the MPT. Unsupported in "
-                                  "v1; aborting the commit path instead of forking silently"));
+                                  "v1; aborting the execute path instead of forking silently"));
     }
-    return buildMPT;
 }
 
 // Startup-time guard for the flag matrix shouldBuildMPT relies on (spec 5.10, M7.3).
@@ -75,8 +89,8 @@ inline bool shouldBuildMPT(
 // every account table fails classification and silently drops out of the MPT — the chain
 // keeps committing state roots that cover no account (a silent fork against any honest
 // replica). Binary account tables are unsupported in v1, so refuse the combination with
-// either MPT flag. shouldBuildMPT re-checks this at commit time for activations that
-// happen after boot.
+// either MPT flag. rejectRawAddressWithMPT re-checks that half on the blocks that actually
+// build an MPT, for activations that happen after boot.
 //
 // @throws InvalidMPTFlagMatrix when feature_raw_address is set together with
 //         feature_mpt_state_root or feature_l2_ethereum_compat, or when

--- a/transaction-scheduler/bcos-transaction-scheduler/MPTNodeStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/MPTNodeStorage.h
@@ -1,0 +1,116 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MPTNodeStorage.h
+ * @brief ViewNodeStorage — the trie-node plane of the execute view: buildAndCollect's node
+ *        reads and writes expressed as ordinary "/mpt/" state rows on the SAME view
+ *        executeBlock writes into (spec §5.6)
+ */
+#pragma once
+
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace bcos::scheduler_v1
+{
+
+/// The trie-node storage coExecuteBlock hands to buildAndCollect: a thin adapter mapping the
+/// builder's (h256 → RLP bytes) contract onto ordinary state rows of the block's execute view
+/// — StateKey{"/mpt/", digest} → Entry(RLP) (KeyPrefixes.h::mptNodeStateKey).
+///
+///  - node WRITES (buildAndCollect's end-of-build flush) land in the view's TOP mutable
+///    layer, the same layer the block's flat-state delta lives in;
+///  - node READS resolve through the FULL view (mutable → immutable pending layers → cache →
+///    backend), the same mechanism readFlatAccountMeta uses for flat parent reads.
+///
+/// Everything the retired MPTNodeOverlay implemented by hand now falls out of the view's
+/// layering:
+///  - pipeline visibility: block N+1's fork() carries block N's not-yet-committed mutable
+///    layer as an immutable layer, node rows included — no pending-delta snapshot, and the
+///    shared_ptr layer chain keeps a layer readable across a concurrent commit-side pop;
+///  - rollback: dropping a block's layer drops its node rows with it;
+///  - commit atomicity: node rows sit in the back layer, so the existing
+///    mergeBackStorage(prewriteStorage) merges them into the backend with the flat state in
+///    the same single WriteBatch — no extra merge sources, no special casing.
+///
+/// Ordering inside one build is safe by construction: the flush runs after the delta scan
+/// completes, and a stray "/mpt/" row can never be classified as account state because
+/// parseAccountTable() only accepts "/apps/<40-hex>" tables (pinned by the stray-row test in
+/// TestMPTSchedulerWiring.cpp).
+template <class View>
+class ViewNodeStorage
+{
+public:
+    using Key = bcos::h256;
+    using Value = bcos::bytes;
+
+    explicit ViewNodeStorage(View& view) : m_view(std::addressof(view)) {}
+
+    task::Task<std::optional<bcos::bytes>> readOne(bcos::h256 key)
+    {
+        auto entry = co_await storage2::readOne(*m_view, storage2::mptNodeStateKey(key));
+        if (!entry)
+        {
+            co_return std::nullopt;
+        }
+        auto raw = entry->get();
+        co_return bcos::bytes(raw.begin(), raw.end());
+    }
+
+    task::Task<std::vector<std::optional<bcos::bytes>>> readSome(::ranges::input_range auto keys)
+    {
+        std::vector<std::optional<bcos::bytes>> values;
+        if constexpr (::ranges::sized_range<decltype(keys)>)
+        {
+            values.reserve(::ranges::size(keys));
+        }
+        for (auto&& key : keys)
+        {
+            values.emplace_back(co_await readOne(key));
+        }
+        co_return values;
+    }
+
+    task::Task<void> writeOne(bcos::h256 key, bcos::bytes value)
+    {
+        storage::Entry entry;
+        entry.set(std::move(value));
+        co_await storage2::writeOne(
+            mutableStorage(*m_view), storage2::mptNodeStateKey(key), std::move(entry));
+    }
+
+    task::Task<void> writeSome(::ranges::input_range auto keyValues)
+    {
+        for (auto&& [key, value] : keyValues)
+        {
+            // flushTrieNodes hands const references (the delta must stay intact for the
+            // CommitObserver) — copy each node's RLP into its row's Entry.
+            co_await writeOne(key, bcos::bytes(value.begin(), value.end()));
+        }
+    }
+
+private:
+    View* m_view;
+};
+
+}  // namespace bcos::scheduler_v1

--- a/transaction-scheduler/bcos-transaction-scheduler/MPTNodeStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/MPTNodeStorage.h
@@ -28,6 +28,7 @@
 #include <bcos-utilities/FixedBytes.h>
 #include <memory>
 #include <optional>
+#include <range/v3/view/transform.hpp>
 #include <utility>
 #include <vector>
 
@@ -79,14 +80,23 @@ public:
 
     task::Task<std::vector<std::optional<bcos::bytes>>> readSome(::ranges::input_range auto keys)
     {
+        // One batched read through the view rather than a coroutine round-trip per node: a
+        // block's build resolves thousands of parent nodes.
+        auto entries = co_await storage2::readSome(
+            *m_view, keys | ::ranges::views::transform(
+                                [](auto const& key) { return storage2::mptNodeStateKey(key); }));
+
         std::vector<std::optional<bcos::bytes>> values;
-        if constexpr (::ranges::sized_range<decltype(keys)>)
+        values.reserve(entries.size());
+        for (auto const& entry : entries)
         {
-            values.reserve(::ranges::size(keys));
-        }
-        for (auto&& key : keys)
-        {
-            values.emplace_back(co_await readOne(key));
+            if (!entry)
+            {
+                values.emplace_back(std::nullopt);
+                continue;
+            }
+            auto raw = entry->get();
+            values.emplace_back(bcos::bytes(raw.begin(), raw.end()));
         }
         co_return values;
     }
@@ -101,12 +111,16 @@ public:
 
     task::Task<void> writeSome(::ranges::input_range auto keyValues)
     {
-        for (auto&& [key, value] : keyValues)
-        {
-            // flushTrieNodes hands const references (the delta must stay intact for the
-            // CommitObserver) — copy each node's RLP into its row's Entry.
-            co_await writeOne(key, bcos::bytes(value.begin(), value.end()));
-        }
+        // One batched write into the top mutable layer, same reason as readSome above. The
+        // RLP is COPIED into each row's Entry, never moved out: flushTrieNodes hands const
+        // references and MPTDeltaLayer::newNodes must stay intact for the CommitObserver.
+        co_await storage2::writeSome(
+            mutableStorage(*m_view), keyValues | ::ranges::views::transform([](auto&& keyValue) {
+                auto const& [key, value] = keyValue;
+                storage::Entry entry;
+                entry.set(bcos::bytes(value.begin(), value.end()));
+                return std::make_pair(storage2::mptNodeStateKey(key), std::move(entry));
+            }));
     }
 
 private:

--- a/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
+++ b/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
@@ -1,0 +1,782 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TestMPTSchedulerWiring.cpp
+ * @brief End-to-end wiring tests for the execute-time MPT build in BaselineScheduler with
+ *        trie nodes as ordinary "/mpt/" state rows on the execute view: scenario-A activation
+ *        transition, pipeline node visibility through the view's immutable layer chain (with
+ *        a negative control), commit atomicity, CommitObserver timing, parent-root resolution
+ *        via the ledger header, the stray-"/mpt/"-row guard, and the no-XOR-fallback policy.
+ */
+
+#include "TrivialCheckpointStorage.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-ledger/mpt/CommitObserver.h"
+#include "bcos-ledger/mpt/Errors.h"
+#include "bcos-ledger/mpt/MPTBuilder.h"
+#include "bcos-ledger/mpt/StorageValueCodec.h"
+#include "bcos-protocol/TransactionSubmitResultFactoryImpl.h"
+#include "bcos-storage/KeyPrefixes.h"
+#include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
+#include "bcos-task/AwaitableValue.h"
+#include "bcos-transaction-scheduler/BaselineScheduler.h"
+#include <boost/test/unit_test.hpp>
+#include <fakeit.hpp>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Everything in an anonymous namespace (unity-build friendly); all storage-stack types carry
+// the MW prefix and their own backend type, so this TU's ViewType — and its getLedgerConfig
+// tag_invoke stub — cannot collide with the other scheduler test TUs when CMake merges the
+// sources into one unity TU (same pattern as TestExecuteStateRootRegression.cpp).
+namespace
+{
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::executor_v1;
+using namespace bcos::scheduler_v1;
+
+using MWMutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+// The backend is behaviourally a stock flat MemoryStorage: with trie nodes as ordinary
+// "/mpt/" StateKey rows there is nothing MPT-specific left for a backend to implement.
+// Still a DISTINCT type rather than an alias — this TU's getLedgerConfig tag_invoke stub is
+// found by ADL through the ViewType's template arguments, so the backend type must be
+// anchored in this anonymous namespace (the same reasoning as the MW prefix).
+struct MWBackendStorage
+  : memory_storage::MemoryStorage<StateKey, StateValue,
+        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+        std::hash<StateKey>>
+{
+};
+
+using MWCheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, MWBackendStorage>;
+using MWMultiLayerStorage = MultiLayerStorage<MWMutableStorage, void, MWCheckpointBackend>;
+
+/// Read one trie-node row from the backend under its ordinary StateKey.
+std::optional<bytes> backendNode(MWBackendStorage& backend, h256 const& hash)
+{
+    auto entry = task::syncWait(storage2::readOne(backend, storage2::mptNodeStateKey(hash)));
+    if (!entry)
+    {
+        return std::nullopt;
+    }
+    auto raw = entry->get();
+    return bytes(raw.begin(), raw.end());
+}
+
+/// Count the backend rows living in the "/mpt/" table (committed trie nodes).
+size_t backendNodeCount(MWBackendStorage& backend)
+{
+    return task::syncWait([&]() -> task::Task<size_t> {
+        size_t count = 0;
+        auto iterator = co_await storage2::range(backend);
+        while (auto keyValue = co_await iterator.next())
+        {
+            auto&& [key, value] = *keyValue;
+            if (StateKeyView{key}.m_table == storage2::kMPTTable)
+            {
+                ++count;
+            }
+        }
+        co_return count;
+    }());
+}
+
+/// One flat-state row operation the mock scheduler performs for a block.
+/// value == nullopt means storage-level logical deletion (the removeSome path).
+struct MWRowOp
+{
+    std::string table;
+    std::string key;
+    std::optional<std::string> value;
+};
+
+/// Scheduler impl that replays a per-block write plan through the storage argument
+/// BaselineScheduler hands it — the production write path (view mutable layer).
+struct MWWritingScheduler
+{
+    std::map<protocol::BlockNumber, std::vector<MWRowOp>> const* m_plan{};
+
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(auto& storage,
+        auto& /*executor*/, protocol::BlockHeader const& blockHeader,
+        ::ranges::input_range auto const& transactions, ledger::LedgerConfig const& /*unused*/)
+    {
+        if (auto it = m_plan->find(blockHeader.number()); it != m_plan->end())
+        {
+            for (auto const& row : it->second)
+            {
+                if (row.value)
+                {
+                    storage::Entry entry;
+                    entry.set(*row.value);
+                    co_await storage2::writeOne(
+                        storage, StateKey{row.table, row.key}, std::move(entry));
+                }
+                else
+                {
+                    co_await storage2::removeOne(storage, StateKey{row.table, row.key});
+                }
+            }
+        }
+
+        auto receipts = ::ranges::iota_view<size_t, size_t>(0, ::ranges::size(transactions)) |
+                        ::ranges::views::transform([](size_t) -> protocol::TransactionReceipt::Ptr {
+                            auto receipt =
+                                std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+                            constexpr static std::string_view str = "abc";
+                            auto& inner = receipt->inner();
+                            inner.dataHash.assign(str.begin(), str.end());
+                            inner.data.gasUsed = "100";
+                            return receipt;
+                        }) |
+                        ::ranges::to<std::vector<protocol::TransactionReceipt::Ptr>>();
+        co_return receipts;
+    }
+};
+
+struct MWExecutor
+{
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(auto& /*storage*/,
+        protocol::BlockHeader const& /*blockHeader*/, protocol::Transaction const& /*transaction*/,
+        int /*contextID*/, ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+    {
+        co_return {};
+    }
+    template <class Storage>
+    struct ExecuteContext
+    {
+        template <int step>
+        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
+        {
+            co_return {};
+        }
+    };
+    auto createExecuteContext(auto& storage, protocol::BlockHeader const& /*blockHeader*/,
+        protocol::Transaction const& /*transaction*/, int32_t /*contextID*/,
+        ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+        -> task::Task<ExecuteContext<std::decay_t<decltype(storage)>>>
+    {
+        co_return {};
+    }
+};
+
+/// The Features the getLedgerConfig stub hands to every execute — set per test.
+ledger::Features g_mwFeatures{};
+
+[[maybe_unused]] task::AwaitableValue<void> tag_invoke(
+    ledger::tag_t<bcos::ledger::getLedgerConfig> /*unused*/,
+    MWMultiLayerStorage::ViewType& /*storage*/, bcos::ledger::LedgerConfig& ledgerConfig,
+    protocol::BlockNumber /*blockNumber*/, protocol::BlockFactory& /*blockFactory*/)
+{
+    ledgerConfig.setFeatures(g_mwFeatures);
+    return {};
+}
+
+task::Task<std::vector<protocol::Transaction::ConstPtr>> emptyTxsTaskMW()
+{
+    co_return std::vector<protocol::Transaction::ConstPtr>{};
+}
+task::Task<ledger::SystemConfigs> emptySystemConfigsTaskMW()
+{
+    co_return ledger::SystemConfigs{};
+}
+task::Task<ledger::Features> emptyFeaturesTaskMW()
+{
+    co_return ledger::Features{};
+}
+
+/// Probe observer: records the callback's view of the world at onCommit time, including
+/// whether every delta node was already readable from the backend under its ordinary
+/// "/mpt/" StateKey (the timing contract).
+struct MWProbeObserver : public bcos::ledger::mpt::CommitObserver
+{
+    struct Record
+    {
+        protocol::BlockNumber blockNumber{};
+        h256 stateRoot;
+        size_t newNodeCount{};
+        bool allNodesInBackendAtCallback{};
+        bcos::ledger::mpt::MPTDeltaLayer delta;  // copy for post-hoc assertions
+    };
+    MWBackendStorage* m_backend{};
+    std::vector<Record> m_records;
+
+    void onCommit(
+        protocol::BlockNumber blockNumber, bcos::ledger::mpt::MPTDeltaLayer const& delta) override
+    {
+        bool allVisible = true;
+        for (auto const& [hash, rlp] : delta.newNodes)
+        {
+            auto stored = backendNode(*m_backend, hash);
+            if (!stored || *stored != rlp)
+            {
+                allVisible = false;
+                break;
+            }
+        }
+        m_records.push_back({.blockNumber = blockNumber,
+            .stateRoot = delta.stateRoot,
+            .newNodeCount = delta.newNodes.size(),
+            .allNodesInBackendAtCallback = allVisible,
+            .delta = delta});
+    }
+};
+
+class MPTWiringFixture
+{
+public:
+    MPTWiringFixture()
+      : checkpointBackend(backendStorage),
+        cryptoSuite(std::make_shared<crypto::CryptoSuite>(
+            std::make_shared<crypto::Keccak256>(), nullptr, nullptr)),
+        blockHeaderFactory(
+            std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite)),
+        transactionFactory(
+            std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite)),
+        receiptFactory(
+            std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)),
+        blockFactory(std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+            cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory)),
+        transactionSubmitResultFactory(
+            std::make_shared<protocol::TransactionSubmitResultFactoryImpl>()),
+        multiLayerStorage(checkpointBackend),
+        baselineScheduler(multiLayerStorage, mockScheduler, mockExecutor, *blockFactory,
+            mockLedger.get(), mockTxPool.get(), *transactionSubmitResultFactory, *hashImpl)
+    {
+        g_mwFeatures = ledger::Features{};
+        mockScheduler.m_plan = &plan;
+
+        observer = std::make_shared<MWProbeObserver>();
+        observer->m_backend = &backendStorage;
+        baselineScheduler.setMPTCommitObserver(observer);
+
+        fakeit::When(Method(mockLedger, asyncPrewriteBlock))
+            .AlwaysDo([](storage::StorageInterface::Ptr, protocol::ConstTransactionsPtr,
+                          protocol::Block::ConstPtr,
+                          std::function<void(std::string, Error::Ptr&&)> callback, bool,
+                          std::optional<ledger::Features>) { callback({}, nullptr); });
+        using HashView =
+            ::ranges::any_view<h256, ::ranges::category::mask | ::ranges::category::sized>;
+        fakeit::When(Method(mockTxPool, getTransactions)).AlwaysDo([](HashView) {
+            return emptyTxsTaskMW();
+        });
+        fakeit::When(Method(mockLedger, asyncGetBlockNumber))
+            .AlwaysDo([](std::function<void(Error::Ptr, protocol::BlockNumber)> callback) {
+                callback(nullptr, -1);
+            });
+        fakeit::When(Method(mockLedger, asyncGetNodeListByType))
+            .AlwaysDo([](std::string_view const&,
+                          std::function<void(Error::Ptr, consensus::ConsensusNodeList)> callback) {
+                callback(nullptr, {});
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockDataByNumber))
+            .AlwaysDo([](protocol::BlockNumber, int32_t,
+                          std::function<void(Error::Ptr, protocol::Block::Ptr)> callback) {
+                callback(nullptr, nullptr);
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockHashByNumber))
+            .AlwaysDo([](protocol::BlockNumber,
+                          std::function<void(Error::Ptr, crypto::HashType)> callback) {
+                callback(nullptr, crypto::HashType{});
+            });
+        fakeit::When(Method(mockLedger, fetchAllSystemConfigs)).AlwaysDo([](protocol::BlockNumber) {
+            return emptySystemConfigsTaskMW();
+        });
+        fakeit::When(Method(mockLedger, fetchAllFeatures)).AlwaysDo([](protocol::BlockNumber) {
+            return emptyFeaturesTaskMW();
+        });
+
+        baselineScheduler.registerBlockNumberNotifier([](protocol::BlockNumber) {});
+        baselineScheduler.registerTransactionNotifier(
+            [](protocol::BlockNumber, protocol::TransactionSubmitResultsPtr,
+                std::function<void(Error::Ptr)> callback) { callback(nullptr); });
+    }
+
+    static void useScenarioA(protocol::BlockNumber activationBlock)
+    {
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_mpt_state_root);
+        features.setActivationBlock(
+            ledger::Features::Flag::feature_mpt_state_root, activationBlock);
+        g_mwFeatures = features;
+    }
+    static void useScenarioB()
+    {
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+        g_mwFeatures = features;
+    }
+
+    std::tuple<Error::Ptr, protocol::BlockHeader::Ptr> executeBlockRaw(protocol::BlockNumber number)
+    {
+        auto block = std::make_shared<bcostars::protocol::BlockImpl>();
+        auto blockHeader = block->blockHeader();
+        blockHeader->setNumber(number);
+        blockHeader->setVersion(blockVersion);
+        blockHeader->calculateHash(*hashImpl);
+        bytes input;
+        block->appendTransaction(transactionFactory->createTransaction(
+            0, "to", input, std::to_string(number), 100, "chain", "group", 0));
+
+        Error::Ptr execError;
+        protocol::BlockHeader::Ptr executedHeader;
+        baselineScheduler.executeBlock(
+            block, false, [&](Error::Ptr error, protocol::BlockHeader::Ptr header, bool) {
+                execError = std::move(error);
+                executedHeader = std::move(header);
+            });
+        return {std::move(execError), std::move(executedHeader)};
+    }
+
+    protocol::BlockHeader::Ptr executeOneBlock(protocol::BlockNumber number)
+    {
+        auto [error, header] = executeBlockRaw(number);
+        BOOST_REQUIRE_MESSAGE(
+            !error, "executeBlock failed: " + (error ? error->errorMessage() : ""));
+        BOOST_REQUIRE(header);
+        return header;
+    }
+
+    void commitOneBlock(protocol::BlockHeader::Ptr const& header)
+    {
+        Error::Ptr commitError;
+        baselineScheduler.commitBlock(header,
+            [&](Error::Ptr error, ledger::LedgerConfig::Ptr) { commitError = std::move(error); });
+        BOOST_REQUIRE_MESSAGE(!commitError,
+            "commitBlock failed: " + (commitError ? commitError->errorMessage() : ""));
+        // Production persists the consensus-signed header (with its final stateRoot) via
+        // prewriteBlockToBuffer; the ledger mock here only invokes the callback, so mirror
+        // that persistence for the parent-root-from-header resolution path.
+        writeHeaderToBackend(header);
+    }
+
+    void writeHeaderToBackend(protocol::BlockHeader::Ptr const& header)
+    {
+        bytes headerBuffer;
+        header->encode(headerBuffer);
+        storage::Entry entry;
+        entry.set(std::move(headerBuffer));
+        task::syncWait(storage2::writeOne(backendStorage,
+            StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, std::to_string(header->number())},
+            std::move(entry)));
+    }
+
+    protocol::BlockHeader::Ptr makeExecutedShapeHeader(protocol::BlockNumber number, h256 stateRoot)
+    {
+        auto header = blockHeaderFactory->createBlockHeader();
+        header->setNumber(number);
+        header->setVersion(blockVersion);
+        header->setStateRoot(stateRoot);
+        header->calculateHash(*hashImpl);
+        return header;
+    }
+
+    // --- oracles -----------------------------------------------------------
+
+    /// Legacy XOR oracle over a block's row plan (same per-entry hash call shape as
+    /// calculateStateRoot).
+    h256 xorOracle(std::vector<MWRowOp> const& rows) const
+    {
+        const std::optional<ledger::Features> features{g_mwFeatures};
+        h256 expected;
+        for (auto const& row : rows)
+        {
+            BOOST_REQUIRE(row.value);
+            storage::Entry entry;
+            entry.set(*row.value);
+            expected ^= entry.hash(row.table, row.key, *hashImpl, blockVersion, features);
+        }
+        return expected;
+    }
+
+    /// Independent MPT oracle: commitTrie (bcos-ledger's stateless trie build) over explicitly
+    /// constructed account leaves, from the empty root. Tries are history-independent, so the
+    /// expected root of any block equals one from-scratch build over the expected FINAL state
+    /// of every account the MPT has absorbed so far.
+    static h256 mptOracle(std::map<Address, bcos::ledger::mpt::Account> const& accounts)
+    {
+        namespace mpt = bcos::ledger::mpt;
+        std::map<h256, std::optional<bytes>> accountChanges;
+        for (auto const& [address, account] : accounts)
+        {
+            accountChanges[mpt::accountKeyHash(address)] = account.encode();
+        }
+        memory_storage::MemoryStorage<h256, bytes, memory_storage::ORDERED> scratch;
+        auto merged =
+            task::syncWait(mpt::commitTrie(scratch, mpt::emptyRootHash(), accountChanges));
+        return merged.root;
+    }
+
+    static h256 storageTrieOracle(std::map<h256, bytes> const& slots)  // slot -> 32-byte raw value
+    {
+        namespace mpt = bcos::ledger::mpt;
+        std::map<h256, std::optional<bytes>> changes;
+        for (auto const& [slot, rawValue] : slots)
+        {
+            changes[mpt::slotKeyHash(slot)] =
+                mpt::encodeStorageValue(bytesConstRef(rawValue.data(), rawValue.size()));
+        }
+        memory_storage::MemoryStorage<h256, bytes, memory_storage::ORDERED> scratch;
+        auto merged = task::syncWait(mpt::commitTrie(scratch, mpt::emptyRootHash(), changes));
+        return merged.root;
+    }
+
+    static Address makeAddress(uint8_t firstByte)
+    {
+        Address address{};
+        address.data()[0] = firstByte;
+        return address;
+    }
+
+    static constexpr uint32_t blockVersion = 200;
+
+    MWBackendStorage backendStorage;
+    MWCheckpointBackend checkpointBackend;
+    crypto::CryptoSuite::Ptr cryptoSuite;
+    std::shared_ptr<bcostars::protocol::BlockHeaderFactoryImpl> blockHeaderFactory;
+    std::shared_ptr<bcostars::protocol::TransactionFactoryImpl> transactionFactory;
+    std::shared_ptr<bcostars::protocol::TransactionReceiptFactoryImpl> receiptFactory;
+    std::shared_ptr<bcostars::protocol::BlockFactoryImpl> blockFactory;
+    std::shared_ptr<protocol::TransactionSubmitResultFactoryImpl> transactionSubmitResultFactory;
+
+    crypto::Hash::Ptr hashImpl = std::make_shared<crypto::Keccak256>();
+
+    std::map<protocol::BlockNumber, std::vector<MWRowOp>> plan;
+    MWWritingScheduler mockScheduler;
+    fakeit::Mock<ledger::LedgerInterface> mockLedger;
+    fakeit::Mock<txpool::TxPoolInterface> mockTxPool;
+    MWMultiLayerStorage multiLayerStorage;
+    MWExecutor mockExecutor;
+    std::shared_ptr<MWProbeObserver> observer;
+    BaselineScheduler<decltype(multiLayerStorage), MWExecutor, MWWritingScheduler,
+        ledger::LedgerInterface>
+        baselineScheduler;
+};
+
+BOOST_FIXTURE_TEST_SUITE(TestMPTSchedulerWiring, MPTWiringFixture)
+
+// (a) Scenario-A transition: with feature_mpt_state_root activated at block 500, block 500
+// itself still commits the legacy XOR root (strictly-greater boundary), block 501 commits an
+// MPT root pinned against the commitTrie oracle, and block 502 — whose parent root resolves
+// via the committed header in the ledger (the restart path) — extends the trie incrementally,
+// including a storage-slot write that exercises the two-level trie build.
+BOOST_AUTO_TEST_CASE(scenarioATransition)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioA(500);
+
+    auto const addressA = makeAddress(0xAA);
+    auto const addressB = makeAddress(0xBB);
+    auto const tableA = mpt::accountTableName(addressA);
+    auto const tableB = mpt::accountTableName(addressB);
+
+    // Block 500 (activation block, XOR): A gets balance + nonce.
+    plan[500] = {{tableA, "balance", "1000000"}, {tableA, "nonce", "1"}};
+    // Block 501 (first MPT block): B first-touch, balance + nonce.
+    plan[501] = {{tableB, "balance", "7"}, {tableB, "nonce", "3"}};
+    // Block 502: A first-touch in the MPT — balance overwritten, nonce inherited from the
+    // FLAT state (written back in the XOR era), plus one storage slot.
+    h256 slot{};
+    slot.data()[31] = 0x01;
+    std::string slotValueRaw(32, '\0');
+    slotValueRaw[31] = 0x2A;
+    plan[502] = {{tableA, "balance", "42"},
+        {tableA, std::string(reinterpret_cast<char const*>(slot.data()), h256::SIZE),
+            slotValueRaw}};
+
+    // --- block 500: XOR root, no MPT delta, observer silent.
+    auto header500 = executeOneBlock(500);
+    BOOST_CHECK_NE(header500->stateRoot(), h256{});
+    BOOST_CHECK_EQUAL(header500->stateRoot(), xorOracle(plan[500]));
+    commitOneBlock(header500);
+    BOOST_CHECK_EQUAL(backendNodeCount(backendStorage), 0);
+    BOOST_CHECK(observer->m_records.empty());
+
+    // --- block 501: MPT root over {B}.
+    auto header501 = executeOneBlock(501);
+    mpt::Account accountB;
+    accountB.balance = 7;
+    accountB.nonce = 3;
+    BOOST_CHECK_EQUAL(header501->stateRoot(), mptOracle({{addressB, accountB}}));
+    commitOneBlock(header501);
+    BOOST_CHECK_GT(backendNodeCount(backendStorage), 0);
+
+    // --- block 502: parent root read from block 501's committed header (m_results is empty
+    // after the commit, so the pipeline path cannot serve it), trie extended to {A, B}.
+    auto header502 = executeOneBlock(502);
+    mpt::Account accountA;
+    accountA.balance = 42;
+    accountA.nonce = 1;  // from the flat rows block 500 wrote — first-touch metadata read
+    accountA.storageRoot =
+        storageTrieOracle({{slot, bytes(slotValueRaw.begin(), slotValueRaw.end())}});
+    BOOST_CHECK_EQUAL(
+        header502->stateRoot(), mptOracle({{addressA, accountA}, {addressB, accountB}}));
+    commitOneBlock(header502);
+}
+
+// (c) Pipeline visibility: two MPT blocks execute back-to-back with NO commit in between.
+// Block 502's incremental rebuild must resolve block 501's not-yet-committed trie nodes
+// through its forked view's immutable layer chain (fork() carries 501's mutable layer, node
+// rows included) — the backend holds zero node rows throughout.
+BOOST_AUTO_TEST_CASE(pipelineVisibility)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioA(500);
+
+    auto const addressA = makeAddress(0xA1);
+    auto const addressB = makeAddress(0xB2);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "5"}};
+    plan[501] = {{mpt::accountTableName(addressA), "balance", "11"}};
+    plan[502] = {{mpt::accountTableName(addressB), "balance", "13"}};
+
+    auto header500 = executeOneBlock(500);  // XOR
+    commitOneBlock(header500);
+
+    auto header501 = executeOneBlock(501);  // MPT, stays pending
+    auto header502 = executeOneBlock(502);  // MPT, must read 501's pending nodes
+
+    // Nothing committed: 502's reads came from 501's layer in the view chain.
+    BOOST_CHECK_EQUAL(backendNodeCount(backendStorage), 0);
+
+    mpt::Account accountA;
+    accountA.balance = 11;
+    mpt::Account accountB;
+    accountB.balance = 13;
+    BOOST_CHECK_EQUAL(header501->stateRoot(), mptOracle({{addressA, accountA}}));
+    BOOST_CHECK_EQUAL(
+        header502->stateRoot(), mptOracle({{addressA, accountA}, {addressB, accountB}}));
+
+    // Both commit cleanly afterwards.
+    commitOneBlock(header501);
+    commitOneBlock(header502);
+    BOOST_CHECK_GT(backendNodeCount(backendStorage), 0);
+}
+
+// (c) negative control: the SAME build succeeds through a view forked AFTER block 501's
+// pushView (its immutable chain carries 501's node rows) and fails loudly with the
+// missing-node invariant through a view forked BEFORE it (no immutable chain to resolve the
+// parent trie from) — proving the pipeline visibility above really comes from the view's
+// layer chain, not from some other channel.
+BOOST_AUTO_TEST_CASE(pipelineVisibilityNegativeControl)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioA(500);
+
+    auto const addressA = makeAddress(0xA7);
+    auto const addressB = makeAddress(0xB8);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "5"}};
+    plan[501] = {{mpt::accountTableName(addressA), "balance", "11"}};
+
+    auto header500 = executeOneBlock(500);  // XOR
+    commitOneBlock(header500);
+
+    // Forked BEFORE block 501 executes: fork() snapshots the layer list at call time, so
+    // this view will never see 501's mutable layer.
+    auto staleView = multiLayerStorage.fork();
+    staleView.newMutable();
+
+    auto header501 = executeOneBlock(501);  // MPT, stays pending — nodes only in its layer
+    BOOST_CHECK_EQUAL(backendNodeCount(backendStorage), 0);
+
+    // Forked AFTER pushView: carries 501's layer.
+    auto freshView = multiLayerStorage.fork();
+    freshView.newMutable();
+
+    // The candidate next-block delta, written identically into both views' mutable layers.
+    auto writeDelta = [&](auto& view) {
+        storage::Entry entry;
+        entry.set("13");
+        task::syncWait(storage2::writeOne(mutableStorage(view),
+            StateKey{mpt::accountTableName(addressB), "balance"}, std::move(entry)));
+    };
+    writeDelta(freshView);
+    writeDelta(staleView);
+
+    auto const parentRoot = header501->stateRoot();
+
+    // GREEN: the view whose immutable chain carries 501's node rows resolves the parent trie.
+    {
+        ViewNodeStorage<MWMultiLayerStorage::ViewType> nodeStorage(freshView);
+        auto delta =
+            task::syncWait(mpt::buildAndCollect(nodeStorage, parentRoot, freshView, false));
+        mpt::Account accountA;
+        accountA.balance = 11;
+        mpt::Account accountB;
+        accountB.balance = 13;
+        BOOST_CHECK_EQUAL(delta.stateRoot, mptOracle({{addressA, accountA}, {addressB, accountB}}));
+    }
+
+    // RED: the same build over the stale view — 501's nodes are unreachable, so the trie
+    // walk must fail with the missing-node invariant, never silently rebuild from empty.
+    {
+        ViewNodeStorage<MWMultiLayerStorage::ViewType> nodeStorage(staleView);
+        BOOST_CHECK_THROW(
+            task::syncWait(mpt::buildAndCollect(nodeStorage, parentRoot, staleView, false)),
+            mpt::MPTInvariantViolation);
+    }
+}
+
+// (b) + (e) Commit atomicity and observer timing: after commit, every delta node is readable
+// from the backend under its ordinary "/mpt/" StateKey byte-for-byte (asserted twice: inside
+// the observer AT callback time — the timing contract — and post-hoc); before commit, nothing
+// reaches the backend. XOR blocks never fire the observer.
+BOOST_AUTO_TEST_CASE(commitAtomicityAndObserverTiming)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioA(500);
+
+    auto const addressA = makeAddress(0xC3);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "9"}};
+    plan[501] = {{mpt::accountTableName(addressA), "nonce", "2"}};
+
+    auto header500 = executeOneBlock(500);  // XOR
+    commitOneBlock(header500);
+    BOOST_CHECK(observer->m_records.empty());  // XOR block: observer NOT fired
+
+    auto header501 = executeOneBlock(501);  // MPT
+    // (amended d) Executed but uncommitted: the node rows live only in the block's pending
+    // mutable layer; zero "/mpt/" rows have reached the backend. NOTE: BaselineScheduler
+    // exposes no proposal-drop / view-change clearing of m_results today (reset() is a no-op,
+    // m_results only shrinks via commit-side pop_back), so "rollback" coverage here is
+    // exactly this: nothing reaches disk before commit.
+    BOOST_CHECK_EQUAL(backendNodeCount(backendStorage), 0);
+    BOOST_CHECK(observer->m_records.empty());
+
+    commitOneBlock(header501);
+
+    BOOST_REQUIRE_EQUAL(observer->m_records.size(), 1);
+    auto const& record = observer->m_records.front();
+    BOOST_CHECK_EQUAL(record.blockNumber, 501);
+    BOOST_CHECK_EQUAL(record.stateRoot, header501->stateRoot());
+    BOOST_CHECK_GT(record.newNodeCount, 0);
+    BOOST_CHECK(record.allNodesInBackendAtCallback);  // fired AFTER the nodes landed
+
+    // Post-hoc: every delta node readable from the backend under its digest, bytes equal.
+    for (auto const& [hash, rlp] : record.delta.newNodes)
+    {
+        auto stored = backendNode(backendStorage, hash);
+        BOOST_REQUIRE_MESSAGE(stored.has_value(), "node missing from backend: " + hash.hex());
+        BOOST_CHECK(*stored == rlp);
+    }
+}
+
+// Scenario B (L2): every block is MPT-rooted; the first executed block resolves its parent
+// root from the previous block's SIGNED HEADER in the ledger. Part 1: a parent header carrying
+// emptyRootHash() chains cleanly. Part 2 (separate case below): a parent header carrying a
+// root whose nodes do not exist must fail the execute loudly — proving the header value is
+// actually consumed, not silently defaulted.
+BOOST_AUTO_TEST_CASE(scenarioBParentFromLedgerHeader)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioB();
+
+    writeHeaderToBackend(makeExecutedShapeHeader(499, mpt::emptyRootHash()));
+
+    auto const addressA = makeAddress(0xD4);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "21"}};
+
+    auto header500 = executeOneBlock(500);
+    mpt::Account accountA;
+    accountA.balance = 21;
+    BOOST_CHECK_EQUAL(header500->stateRoot(), mptOracle({{addressA, accountA}}));
+}
+
+BOOST_AUTO_TEST_CASE(scenarioBBogusParentRootFailsLoud)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioB();
+
+    h256 bogusRoot;
+    bogusRoot.data()[0] = 0xDE;
+    bogusRoot.data()[1] = 0xAD;
+    writeHeaderToBackend(makeExecutedShapeHeader(499, bogusRoot));
+
+    auto const addressA = makeAddress(0xE5);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "1"}};
+
+    auto [error, header] = executeBlockRaw(500);
+    BOOST_REQUIRE(error);
+    BOOST_CHECK(!header);
+}
+
+// Guard: a stray row under the reserved "/mpt/" table in the block's TOP delta layer must be
+// skipped by the build's account scan — parseAccountTable only accepts "/apps/<40-hex>"
+// tables — never classified as an account, and must not perturb the state root.
+BOOST_AUTO_TEST_CASE(strayMptRowIsNotAnAccount)
+{
+    namespace mpt = bcos::ledger::mpt;
+    BOOST_CHECK(!mpt::parseAccountTable(storage2::kMPTTable).has_value());
+
+    useScenarioA(500);
+    auto const addressA = makeAddress(0xC9);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "9"}};
+
+    h256 strayHash;
+    strayHash.data()[0] = 0x5A;
+    std::string const strayKey(reinterpret_cast<char const*>(strayHash.data()), h256::SIZE);
+    plan[501] = {{mpt::accountTableName(addressA), "balance", "10"},
+        {std::string(storage2::kMPTTable), strayKey, "not-a-real-node"}};
+
+    auto header500 = executeOneBlock(500);  // XOR
+    commitOneBlock(header500);
+
+    // Must not throw UnknownAccountRowField, and the root reflects ONLY the account row.
+    auto header501 = executeOneBlock(501);
+    mpt::Account accountA;
+    accountA.balance = 10;
+    BOOST_CHECK_EQUAL(header501->stateRoot(), mptOracle({{addressA, accountA}}));
+    commitOneBlock(header501);
+}
+
+// (f) No-fallback policy: a delta shape buildAndCollect rejects (a core-field row logically
+// deleted outside a tombstone) surfaces as an execute ERROR — never as a block that silently
+// fell back to the XOR root.
+BOOST_AUTO_TEST_CASE(buildFailureNoXorFallback)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioA(500);
+
+    auto const addressA = makeAddress(0xF6);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "8"}};
+    // Lone deletion of a core-field row: not a tombstone (nonce/codeHash not deleted).
+    plan[501] = {{mpt::accountTableName(addressA), "balance", std::nullopt}};
+
+    auto header500 = executeOneBlock(500);  // XOR
+    commitOneBlock(header500);
+
+    auto [error, header] = executeBlockRaw(501);
+    BOOST_REQUIRE(error);
+    BOOST_CHECK(!header);  // no header => no XOR-rooted block escaped
+    BOOST_CHECK(error->errorMessage().find("tombstone") != std::string::npos);
+    BOOST_CHECK_EQUAL(backendNodeCount(backendStorage), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace

--- a/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
+++ b/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
@@ -18,7 +18,10 @@
  *        trie nodes as ordinary "/mpt/" state rows on the execute view: scenario-A activation
  *        transition, pipeline node visibility through the view's immutable layer chain (with
  *        a negative control), commit atomicity, CommitObserver timing, parent-root resolution
- *        via the ledger header, the stray-"/mpt/"-row guard, and the no-XOR-fallback policy.
+ *        via the parent block's header (finishExecute writes every executed header into the
+ *        block's layer, so pipeline and restart share one getBlockData arm; with a fail-loud
+ *        missing-header negative), the stray-"/mpt/"-row guard, and the no-XOR-fallback
+ *        policy.
  */
 
 #include "TrivialCheckpointStorage.h"
@@ -371,9 +374,9 @@ public:
             [&](Error::Ptr error, ledger::LedgerConfig::Ptr) { commitError = std::move(error); });
         BOOST_REQUIRE_MESSAGE(!commitError,
             "commitBlock failed: " + (commitError ? commitError->errorMessage() : ""));
-        // Production persists the consensus-signed header (with its final stateRoot) via
-        // prewriteBlockToBuffer; the ledger mock here only invokes the callback, so mirror
-        // that persistence for the parent-root-from-header resolution path.
+        // Production persists the consensus-SIGNED header via prewriteBlockToBuffer,
+        // overwriting the execute-time header row the block's layer already merged; the
+        // ledger mock here only invokes the callback, so mirror that overwrite.
         writeHeaderToBackend(header);
     }
 
@@ -387,6 +390,7 @@ public:
             StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, std::to_string(header->number())},
             std::move(entry)));
     }
+
 
     protocol::BlockHeader::Ptr makeExecutedShapeHeader(protocol::BlockNumber number, h256 stateRoot)
     {
@@ -485,8 +489,8 @@ BOOST_FIXTURE_TEST_SUITE(TestMPTSchedulerWiring, MPTWiringFixture)
 // (a) Scenario-A transition: with feature_mpt_state_root activated at block 500, block 500
 // itself still commits the legacy XOR root (strictly-greater boundary), block 501 commits an
 // MPT root pinned against the commitTrie oracle, and block 502 — whose parent root resolves
-// via the committed header in the ledger (the restart path) — extends the trie incrementally,
-// including a storage-slot write that exercises the two-level trie build.
+// via block 501's committed header in the backend (the restart path) — extends the trie
+// incrementally, including a storage-slot write that exercises the two-level trie build.
 BOOST_AUTO_TEST_CASE(scenarioATransition)
 {
     namespace mpt = bcos::ledger::mpt;
@@ -528,8 +532,8 @@ BOOST_AUTO_TEST_CASE(scenarioATransition)
     commitOneBlock(header501);
     BOOST_CHECK_GT(backendNodeCount(backendStorage), 0);
 
-    // --- block 502: parent root read from block 501's committed header (m_results is empty
-    // after the commit, so the pipeline path cannot serve it), trie extended to {A, B}.
+    // --- block 502: parent root read from block 501's committed header in the backend
+    // (no pending layer can serve it after the commit), trie extended to {A, B}.
     auto header502 = executeOneBlock(502);
     mpt::Account accountA;
     accountA.balance = 42;
@@ -542,9 +546,10 @@ BOOST_AUTO_TEST_CASE(scenarioATransition)
 }
 
 // (c) Pipeline visibility: two MPT blocks execute back-to-back with NO commit in between.
-// Block 502's incremental rebuild must resolve block 501's not-yet-committed trie nodes
-// through its forked view's immutable layer chain (fork() carries 501's mutable layer, node
-// rows included) — the backend holds zero node rows throughout.
+// Block 502's incremental rebuild must resolve block 501's not-yet-committed trie nodes AND
+// its parent root (501's executed header, written by finishExecute) through its forked
+// view's immutable layer chain (fork() carries 501's mutable layer, node and header rows
+// included) — the backend holds zero node rows throughout.
 BOOST_AUTO_TEST_CASE(pipelineVisibility)
 {
     namespace mpt = bcos::ledger::mpt;
@@ -687,11 +692,11 @@ BOOST_AUTO_TEST_CASE(commitAtomicityAndObserverTiming)
     }
 }
 
-// Scenario B (L2): every block is MPT-rooted; the first executed block resolves its parent
-// root from the previous block's SIGNED HEADER in the ledger. Part 1: a parent header carrying
-// emptyRootHash() chains cleanly. Part 2 (separate case below): a parent header carrying a
-// root whose nodes do not exist must fail the execute loudly — proving the header value is
-// actually consumed, not silently defaulted.
+// Scenario B (L2, restart case): every block is MPT-rooted; the first executed block after a
+// restart resolves its parent root from the parent's SIGNED HEADER in the backend — what
+// commit left behind. Part 1: a parent header carrying emptyRootHash() chains cleanly. Part 2
+// (separate case below): a parent header carrying a root whose nodes do not exist must fail
+// the execute loudly — proving the header value is actually consumed, not silently defaulted.
 BOOST_AUTO_TEST_CASE(scenarioBParentFromLedgerHeader)
 {
     namespace mpt = bcos::ledger::mpt;
@@ -724,6 +729,50 @@ BOOST_AUTO_TEST_CASE(scenarioBBogusParentRootFailsLoud)
     auto [error, header] = executeBlockRaw(500);
     BOOST_REQUIRE(error);
     BOOST_CHECK(!header);
+}
+
+// Fail-loud negative: an MPT parent whose header is nowhere (no pending layer, no backend
+// row) must surface getBlockData's NotFoundBlockHeader as an execute error — never a silent
+// rebuild from the empty trie.
+BOOST_AUTO_TEST_CASE(mptParentHeaderMissingFailsLoud)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioB();
+
+    auto const addressA = makeAddress(0xE8);
+    plan[500] = {{mpt::accountTableName(addressA), "balance", "2"}};
+
+    auto [error, header] = executeBlockRaw(500);
+    BOOST_REQUIRE(error);
+    BOOST_CHECK(!header);
+    BOOST_CHECK(error->errorMessage().find("NotFoundBlockHeader") != std::string::npos);
+}
+
+// The execute-time header row (unsigned encoding, written by finishExecute into the block's
+// layer) and commit's prewrite row (signed encoding) share the same key. The backend must end
+// with the prewrite version: mergeBackStorage merges the block's layer BEFORE the extra
+// storages, so within the one WriteBatch the prewrite write wins. This ordering is what lets
+// finishExecute publish headers early without ever leaking an unsigned header to disk.
+BOOST_AUTO_TEST_CASE(commitPrewriteOverwritesExecuteTimeHeaderRow)
+{
+    auto view = multiLayerStorage.fork();
+    view.newMutable();
+    StateKey const key{ledger::SYS_NUMBER_2_BLOCK_HEADER, "7"};
+    storage::Entry executedVersion;
+    executedVersion.set("executed-unsigned");
+    task::syncWait(storage2::writeOne(mutableStorage(view), key, std::move(executedVersion)));
+    multiLayerStorage.pushView(std::move(view));
+
+    MWMutableStorage prewrite;
+    storage::Entry signedVersion;
+    signedVersion.set("committed-signed");
+    task::syncWait(storage2::writeOne(prewrite, key, std::move(signedVersion)));
+
+    task::syncWait(multiLayerStorage.mergeBackStorage(prewrite));
+
+    auto entry = task::syncWait(storage2::readOne(backendStorage, key));
+    BOOST_REQUIRE(entry);
+    BOOST_CHECK_EQUAL(std::string(entry->get()), "committed-signed");
 }
 
 // Guard: a stray row under the reserved "/mpt/" table in the block's TOP delta layer must be

--- a/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
+++ b/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
@@ -18,10 +18,10 @@
  *        trie nodes as ordinary "/mpt/" state rows on the execute view: scenario-A activation
  *        transition, pipeline node visibility through the view's immutable layer chain (with
  *        a negative control), commit atomicity, CommitObserver timing, parent-root resolution
- *        via the parent block's header (finishExecute writes every executed header into the
- *        block's layer, so pipeline and restart share one getBlockData arm; with a fail-loud
- *        missing-header negative), the stray-"/mpt/"-row guard, and the no-XOR-fallback
- *        policy.
+ *        via the parent block's header (finishExecute publishes every non-genesis MPT block's
+ *        executed header into its layer, so pipeline and restart share one getBlockData arm;
+ *        with a fail-loud missing-header negative and the XOR-block / genesis exclusions),
+ *        the stray-"/mpt/"-row guard, and the no-XOR-fallback policy.
  */
 
 #include "TrivialCheckpointStorage.h"
@@ -378,6 +378,16 @@ public:
         // overwriting the execute-time header row the block's layer already merged; the
         // ledger mock here only invokes the callback, so mirror that overwrite.
         writeHeaderToBackend(header);
+    }
+
+    /// The SYS_NUMBER_2_BLOCK_HEADER row for @p number as seen through a view forked NOW —
+    /// i.e. including the pending (executed, not yet committed) layers.
+    std::optional<storage::Entry> headerRowInView(protocol::BlockNumber number)
+    {
+        auto view = multiLayerStorage.fork();
+        view.newMutable();
+        return task::syncWait(storage2::readOne(
+            view, StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, std::to_string(number)}));
     }
 
     void writeHeaderToBackend(protocol::BlockHeader::Ptr const& header)
@@ -773,6 +783,61 @@ BOOST_AUTO_TEST_CASE(commitPrewriteOverwritesExecuteTimeHeaderRow)
     auto entry = task::syncWait(storage2::readOne(backendStorage, key));
     BOOST_REQUIRE(entry);
     BOOST_CHECK_EQUAL(std::string(entry->get()), "committed-signed");
+}
+
+// The execute-time header row exists for ONE reason — letting the next MPT block resolve its
+// parent's stateRoot through the view — so finishExecute publishes it for MPT blocks only. An
+// XOR block's header is never read that way (buildMPTStateRoot takes the empty-trie arm when
+// the parent did not build an MPT), and publishing it would put an extra row in every legacy
+// chain's execute path.
+BOOST_AUTO_TEST_CASE(executeTimeHeaderRowOnlyForMPTBlocks)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioA(500);
+
+    auto const address = makeAddress(0xD4);
+    plan[500] = {{mpt::accountTableName(address), "balance", "3"}};
+    plan[501] = {{mpt::accountTableName(address), "balance", "4"}};
+
+    // Block 500 is the activation block itself: XOR root, so no header row.
+    auto header500 = executeOneBlock(500);
+    BOOST_CHECK(!headerRowInView(500));
+    commitOneBlock(header500);
+
+    // Block 501 builds an MPT: its header must be readable from the pending layer, and it must
+    // be the EXECUTED header (the stateRoot block 502's build will start from).
+    auto header501 = executeOneBlock(501);
+    auto row = headerRowInView(501);
+    BOOST_REQUIRE(row);
+    auto field = row->get();
+    auto decoded = blockHeaderFactory->createBlockHeader(
+        bcos::bytesConstRef(reinterpret_cast<bcos::byte const*>(field.data()), field.size()));
+    BOOST_CHECK_EQUAL(decoded->number(), 501);
+    BOOST_CHECK_EQUAL(decoded->stateRoot(), header501->stateRoot());
+}
+
+// Genesis is the one block whose header row already has an owner: Ledger::buildGenesisBlock
+// writes it at chain init, and coCommitBlock skips prewriteBlockToBuffer for block 0
+// (isSysContractDeploy), so nothing would overwrite an execute-time row — the sys-contract
+// deploy header (its own gasUsed, hash, empty sealer/parentInfo) would REPLACE the chain's
+// genesis header on disk. Scenario B is the case that matters: block 0 does take the MPT arm
+// there, so only the explicit number()!=0 guard keeps the row out.
+BOOST_AUTO_TEST_CASE(genesisBlockPublishesNoExecuteTimeHeader)
+{
+    namespace mpt = bcos::ledger::mpt;
+    useScenarioB();
+
+    auto const address = makeAddress(0xE2);
+    plan[0] = {{mpt::accountTableName(address), "balance", "1"}};
+
+    auto header0 = executeOneBlock(0);
+    // The block really went down the MPT arm (an XOR root here would make the test vacuous).
+    BOOST_CHECK_EQUAL(header0->stateRoot(), mptOracle({{address, [] {
+                                                            mpt::Account account;
+                                                            account.balance = 1;
+                                                            return account;
+                                                        }()}}));
+    BOOST_CHECK(!headerRowInView(0));
 }
 
 // Guard: a stray row under the reserved "/mpt/" table in the block's TOP delta layer must be

--- a/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
+++ b/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
@@ -785,6 +785,48 @@ BOOST_AUTO_TEST_CASE(commitPrewriteOverwritesExecuteTimeHeaderRow)
     BOOST_CHECK_EQUAL(std::string(entry->get()), "committed-signed");
 }
 
+// ViewNodeStorage's batch paths: writeSome lands every node in the top mutable layer and
+// readSome answers in key order with nullopt for absent nodes. flushTrieNodes is the only
+// production caller of writeSome and nothing calls readSome yet (the trie walk resolves nodes
+// one at a time), so pin both here rather than let the batch read ship unexercised.
+BOOST_AUTO_TEST_CASE(viewNodeStorageBatchReadWrite)
+{
+    auto view = multiLayerStorage.fork();
+    view.newMutable();
+    ViewNodeStorage<MWMultiLayerStorage::ViewType> nodeStorage(view);
+
+    h256 hashA;
+    hashA[0] = 0xA1;
+    h256 hashB;
+    hashB[0] = 0xB2;
+    h256 absent;
+    absent[0] = 0xC3;
+
+    std::vector<std::pair<h256, bytes>> nodes{
+        {hashA, bytes{0x01, 0x02}}, {hashB, bytes{0x03, 0x04, 0x05}}};
+    task::syncWait(nodeStorage.writeSome(nodes));
+
+    // Written through the batch path, readable as ordinary "/mpt/" rows of the mutable layer.
+    auto storedA = task::syncWait(storage2::readOne(view, storage2::mptNodeStateKey(hashA)));
+    BOOST_REQUIRE(storedA);
+    BOOST_CHECK_EQUAL(storedA->get(), std::string("\x01\x02", 2));
+
+    // The source map is untouched — the flush copies, so the delta stays whole for the
+    // CommitObserver.
+    BOOST_CHECK_EQUAL(nodes[0].second.size(), 2U);
+    BOOST_CHECK_EQUAL(nodes[1].second.size(), 3U);
+
+    auto values = task::syncWait(nodeStorage.readSome(std::vector<h256>{hashB, absent, hashA}));
+    BOOST_REQUIRE_EQUAL(values.size(), 3U);
+    BOOST_REQUIRE(values[0]);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        values[0]->begin(), values[0]->end(), nodes[1].second.begin(), nodes[1].second.end());
+    BOOST_CHECK(!values[1]);
+    BOOST_REQUIRE(values[2]);
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+        values[2]->begin(), values[2]->end(), nodes[0].second.begin(), nodes[0].second.end());
+}
+
 // The execute-time header row exists for ONE reason — letting the next MPT block resolve its
 // parent's stateRoot through the view — so finishExecute publishes it for MPT blocks only. An
 // XOR block's header is never read that way (buildMPTStateRoot takes the empty-trie arm when

--- a/transaction-scheduler/tests/TestRawAddressMPTGuard.cpp
+++ b/transaction-scheduler/tests/TestRawAddressMPTGuard.cpp
@@ -48,42 +48,84 @@ BOOST_AUTO_TEST_CASE(FlagMatrix_MPTFlagsWithoutRawAddressStillPass)
     BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(scenarioB));
 }
 
-BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressWithScenarioAThrowsPastActivation)
+// rejectRawAddressWithMPT is called from INSIDE the shouldBuildMPT branch, so its own job is
+// just "is raw_address in the way?" — the block-number question is already answered by the
+// call site. These cases pin the two states, and the gate-composition cases below pin that the
+// pair together reproduces the behavior the old throwing shouldBuildMPT had.
+BOOST_AUTO_TEST_CASE(PerBlockGuard_RawAddressThrows)
 {
     ledger::Features features;
     features.set(ledger::Features::Flag::feature_raw_address);
     features.set(ledger::Features::Flag::feature_mpt_state_root);
     features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
 
-    // At and before the activation block scenario A stays on XOR, so no MPT is built and
-    // the guard must not fire.
-    BOOST_CHECK(!shouldBuildMPT(features, 99));
+    BOOST_CHECK_THROW(rejectRawAddressWithMPT(features, 101), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(PerBlockGuard_WithoutRawAddressPasses)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+
+    BOOST_CHECK_NO_THROW(rejectRawAddressWithMPT(features, 101));
+    BOOST_CHECK(shouldBuildMPT(features, 101));
+}
+
+// Gate composition, scenario A: the guard only runs where the predicate said yes, so at and
+// before the activation block nothing fires (XOR path), and past the boundary it does.
+BOOST_AUTO_TEST_CASE(GateComposition_ScenarioAFiresOnlyPastActivation)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+
+    // Mirrors coExecuteBlock: predicate first, guard only inside the branch.
+    auto executeGate = [&](protocol::BlockNumber blockNumber) {
+        if (shouldBuildMPT(features, blockNumber))
+        {
+            rejectRawAddressWithMPT(features, blockNumber);
+        }
+    };
+
+    BOOST_CHECK_NO_THROW(executeGate(99));
+    BOOST_CHECK_NO_THROW(executeGate(100));
+    BOOST_CHECK_THROW(executeGate(101), InvalidMPTFlagMatrix);
+    BOOST_CHECK_THROW(executeGate(1000), InvalidMPTFlagMatrix);
+
+    // The predicate itself stays PURE — it answers the state-root question and nothing else,
+    // even for the block numbers the gate rejects.
     BOOST_CHECK(!shouldBuildMPT(features, 100));
-    // Past the boundary the MPT would be built: fail loudly instead of silently dropping
-    // every binary-named account table.
-    BOOST_CHECK_THROW(shouldBuildMPT(features, 101), InvalidMPTFlagMatrix);
-    BOOST_CHECK_THROW(shouldBuildMPT(features, 1000), InvalidMPTFlagMatrix);
+    BOOST_CHECK(shouldBuildMPT(features, 101));
+    BOOST_CHECK(shouldBuildMPT(features, 1000));
 }
 
-BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressWithScenarioBThrowsEveryBlock)
+// Gate composition, scenario B: the MPT is built from genesis on, so the gate fires at every
+// block; and raw_address WITHOUT an MPT flag never reaches the guard at all.
+BOOST_AUTO_TEST_CASE(GateComposition_ScenarioBFiresEveryBlockRawAddressAloneNever)
 {
-    ledger::Features features;
-    features.set(ledger::Features::Flag::feature_raw_address);
-    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    auto executeGate = [](ledger::Features const& features, protocol::BlockNumber blockNumber) {
+        if (shouldBuildMPT(features, blockNumber))
+        {
+            rejectRawAddressWithMPT(features, blockNumber);
+        }
+    };
 
-    // Scenario B builds the MPT from genesis on, so the guard fires at every block.
-    BOOST_CHECK_THROW(shouldBuildMPT(features, 0), InvalidMPTFlagMatrix);
-    BOOST_CHECK_THROW(shouldBuildMPT(features, 1000), InvalidMPTFlagMatrix);
-}
+    ledger::Features scenarioB;
+    scenarioB.set(ledger::Features::Flag::feature_raw_address);
+    scenarioB.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    BOOST_CHECK_THROW(executeGate(scenarioB, 0), InvalidMPTFlagMatrix);
+    BOOST_CHECK_THROW(executeGate(scenarioB, 1000), InvalidMPTFlagMatrix);
+    BOOST_CHECK(shouldBuildMPT(scenarioB, 0));
+    BOOST_CHECK(shouldBuildMPT(scenarioB, 1000));
 
-BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressAloneUnchanged)
-{
-    ledger::Features features;
-    features.set(ledger::Features::Flag::feature_raw_address);
-
-    // Without an MPT flag the function keeps its legacy answer: XOR path, no throw.
-    BOOST_CHECK_NO_THROW(BOOST_CHECK(!shouldBuildMPT(features, 0)));
-    BOOST_CHECK_NO_THROW(BOOST_CHECK(!shouldBuildMPT(features, 1000)));
+    ledger::Features rawOnly;
+    rawOnly.set(ledger::Features::Flag::feature_raw_address);
+    BOOST_CHECK_NO_THROW(executeGate(rawOnly, 0));
+    BOOST_CHECK_NO_THROW(executeGate(rawOnly, 1000));
+    BOOST_CHECK(!shouldBuildMPT(rawOnly, 0));
+    BOOST_CHECK(!shouldBuildMPT(rawOnly, 1000));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/TestRawAddressMPTGuard.cpp
+++ b/transaction-scheduler/tests/TestRawAddressMPTGuard.cpp
@@ -1,0 +1,89 @@
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::scheduler_v1;
+
+BOOST_AUTO_TEST_SUITE(RawAddressMPTGuardSuite)
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_RawAddressWithMPTStateRootThrows)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+    BOOST_CHECK_THROW(validateMPTFlagMatrix(features), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_RawAddressWithL2Throws)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    features.setActivationBlock(ledger::Features::Flag::feature_l2_ethereum_compat, 0);
+    // Must throw for the raw_address pairing even though the L2 flag alone (genesis
+    // activation) is a legal matrix.
+    BOOST_CHECK_THROW(validateMPTFlagMatrix(features), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_RawAddressAlonePasses)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(features));
+}
+
+BOOST_AUTO_TEST_CASE(FlagMatrix_MPTFlagsWithoutRawAddressStillPass)
+{
+    // Regression: the raw_address guard must not reject the previously-legal matrices.
+    ledger::Features scenarioA;
+    scenarioA.set(ledger::Features::Flag::feature_mpt_state_root);
+    scenarioA.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 500);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(scenarioA));
+
+    ledger::Features scenarioB;
+    scenarioB.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    scenarioB.setActivationBlock(ledger::Features::Flag::feature_l2_ethereum_compat, 0);
+    BOOST_CHECK_NO_THROW(validateMPTFlagMatrix(scenarioB));
+}
+
+BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressWithScenarioAThrowsPastActivation)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_mpt_state_root);
+    features.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 100);
+
+    // At and before the activation block scenario A stays on XOR, so no MPT is built and
+    // the guard must not fire.
+    BOOST_CHECK(!shouldBuildMPT(features, 99));
+    BOOST_CHECK(!shouldBuildMPT(features, 100));
+    // Past the boundary the MPT would be built: fail loudly instead of silently dropping
+    // every binary-named account table.
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 101), InvalidMPTFlagMatrix);
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 1000), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressWithScenarioBThrowsEveryBlock)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+    features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+
+    // Scenario B builds the MPT from genesis on, so the guard fires at every block.
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 0), InvalidMPTFlagMatrix);
+    BOOST_CHECK_THROW(shouldBuildMPT(features, 1000), InvalidMPTFlagMatrix);
+}
+
+BOOST_AUTO_TEST_CASE(ShouldBuildMPT_RawAddressAloneUnchanged)
+{
+    ledger::Features features;
+    features.set(ledger::Features::Flag::feature_raw_address);
+
+    // Without an MPT flag the function keeps its legacy answer: XOR path, no throw.
+    BOOST_CHECK_NO_THROW(BOOST_CHECK(!shouldBuildMPT(features, 0)));
+    BOOST_CHECK_NO_THROW(BOOST_CHECK(!shouldBuildMPT(features, 1000)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
# Execute-time MPT build: trie nodes as ordinary state rows on the execution view

This PR wires the MPT state-root build (bcos-ledger `buildAndCollect`) into `BaselineScheduler` at execute time, with one central design decision: **trie-node rows are ordinary state rows riding the same execution view the block's flat state lives in**. This is a rework of this PR's first revision, which routed nodes through a dedicated typed key, a pending-delta overlay and commit-time extra merge sources — all of that is deleted (see "Deleted relative to the first revision" below).

## View-plane rationale

`buildAndCollect` needs two things from its node storage: reads of the parent trie's nodes and a flush of the block's new nodes. Both now go through the SAME view `executeBlock` writes into, via a small `ViewNodeStorage` adapter (`transaction-scheduler/bcos-transaction-scheduler/MPTNodeStorage.h`):

- node **writes** land in the block's top mutable layer — `storage2::writeOne(mutableStorage(view), StateKey{"/mpt/", hash}, Entry(rlp))` — the layer the block's flat delta lives in;
- node **reads** resolve through the full view (mutable → pending immutable layers → cache → backend), the exact mechanism `readFlatAccountMeta` already uses for flat parent reads.

The view's layering then provides, with no dedicated code:

- **pipeline visibility**: block N+1's `fork()` snapshots block N's not-yet-committed mutable layer as an immutable layer, node rows included, so N+1's incremental build resolves N's pending nodes exactly like it resolves N's pending flat rows. The shared_ptr layer chain also keeps a layer readable across a concurrent commit-side pop;
- **rollback**: dropping a block's layer drops its node rows with it;
- **commit atomicity**: node rows sit in the back mutable layer, so the existing `mergeBackStorage(prewriteStorage)` persists flat state, ledger data and trie nodes in one `RocksDBStorage2::merge` — one WriteBatch, one Write. No extra arguments, no special casing.

## The "/mpt/:" StateKey-native physical layout (bcos-storage commit)

A node row is `StateKey{"/mpt/", <32 raw digest bytes>}`, so its physical RocksDB key is the StateKey serialization `"/mpt/:" + raw32` — 38 bytes, first `':'` always at index 5 (the `/mpt/` table name contains no colon). That makes the layout decode-native: `StateKeyResolver::decode`'s single-string `StateKey` constructor splits at the first colon and reconstructs table `"/mpt/"` + the raw digest exactly, even for digests containing 0x3A bytes. The first revision's 37-byte colon-free layout could not be decoded as a StateKey at all, which forced a typed `MPTNodeKey`, a resolver encode overload and a "full-CF decode misparses /mpt/ rows" caveat — the new layout removes the problem instead of routing around it. `KeyPrefixes.h` exports the `mptNodeStateKey(h256)` factory and layout constants only — **no physical-key encode/decode helpers**: `StateKeyResolver::encode`/`decode` is the single physical-layout authority (review round; `makeMPTNodeKey`/`parseMPTNodeKey` deleted, the layout-proof tests construct the literal 38-byte form locally and decode through the resolver itself).

## Deleted relative to the first revision (net simpler)

- `MPTNodeKey` typed key + comparison/hash support, the `StateKeyResolver::encode(MPTNodeKey)` overload, and the `RocksDBStorage2::mptNodeCapable` marker — `bcos-storage` is back to its upstream shape except for the layout constants;
- `MPTNodeOverlay` and its pending-delta snapshot machinery in `buildMPTStateRoot` (the view already layers pending blocks);
- the commit-side extra node storage and the `mergeBackStorage(prewriteStorage, extraNodes)` special case — back to plain `mergeBackStorage(prewriteStorage)`;
- `MultiLayerStorage::mergeSameKeyed` cache-arm filter — reverted entirely, the cache arm is plain `storage2::merge` again;
- the `isMPTNodeCapableBackend` compile-time gate and `MPTUnsupportedBackendError` — every backend stores node rows because they are ordinary rows.

`ExecuteResult::m_mptDelta` stays, but as the CommitObserver's payload only: node persistence never reads it, and since the review round below the next block's parent root comes from the published header row rather than from this field.

## Cache-sharing tradeoff

With `mergeSameKeyed` gone, committed node rows merge into the production LRU cache like any state row. That is free node caching for the incremental build's parent reads, at the cost of trie nodes and flat state sharing the same LRU capacity. Accepted: the cache is a strict subset with backend fallthrough, so the worst case is eviction pressure, never wrong reads.

## Carried over unchanged from the first revision

- `shouldBuildMPT` execute-branch gating (scenario A strictly-greater activation boundary, scenario B from genesis);
- `finishExecute`'s optional `mptStateRoot` — the XOR path is byte-identical when unset;
- fail-loud, no-XOR-fallback policy: a build failure surfaces as an execute error, never a silently XOR-rooted block;
- `CommitObserver` wiring: fires with the block's delta AFTER merge success and BEFORE `m_lastCommittedBlockNumber` advances; `setMPTCommitObserver` for the future pathdb pruning seam.

## Review round: parent root from the parent HEADER, read through the view

`buildMPTStateRoot` originally resolved the parent state root through a two-arm chain: the newest pending `ExecuteResult` under `m_resultsMutex` (pipeline case) or a `getBlockData` header read (restart case). Per review, the header IS the canonical carrier of the state root, so the resolution is now **one `getBlockData(view, N-1, HEADER)` arm for every case** — enabled by `finishExecute` writing each executed MPT block's header into its own mutable layer (see "Review round 2" below for the exclusions), right beside the two execute-time hash-mapping rows (`SYS_NUMBER_2_HASH` / `SYS_HASH_2_NUMBER`) it already writes for the same reason: the next block needs the data before commit persists the canonical version. A pending parent thus resolves from the view's immutable chain (pipeline), a committed parent — the genesis block included — from the backend's signed header (restart / sequential). A missing header under an MPT parent throws `NotFoundBlockHeader`, never a silent empty-trie rebuild. Commit overwrites the execute-time row with the consensus-signed encoding in the same WriteBatch — `mergeBackStorage` merges the block's layer before `prewriteStorage`, an ordering now pinned by `commitPrewriteOverwritesExecuteTimeHeaderRow` — so the backend only ever holds signed headers. The header row shares the block layer's lifecycle exactly like the trie-node rows (crash drops them together, commit lands them atomically), so no pipeline failure mode can separate the two.

## Review round 2: the header row is published for non-genesis MPT blocks only

The first cut of the section above published the executed header for EVERY block, and CI caught what that costs at block 0: `coCommitBlock` skips `prewriteBlockToBuffer` for the genesis block (`isSysContractDeploy`), so no signed version overwrites the execute-time row, and `mergeBackStorage` merged the sys-contract-deploy header over the one `Ledger::buildGenesisBlock` wrote at chain init — `getBlockByNumber(0)` then reports the deploy block's `gasUsed` (656887) instead of 0, and the genesis header's hash / sealer / parentInfo are replaced too. Three platforms failed the RPC-API assertion; the same jobs are green on the base commit and on the revision before the header write, which pins the cause to this PR.

`finishExecute` now publishes the row only when the block actually built an MPT root AND its number is not 0. Both exclusions are load-bearing rather than defensive: `buildMPTStateRoot` reads a parent header exactly when that parent built an MPT itself, so an XOR block's header is never read that way, and genesis' header row already has an owner. `executeTimeHeaderRowOnlyForMPTBlocks` and `genesisBlockPublishesNoExecuteTimeHeader` pin both — each verified red against a build with the guard removed.

The same round takes the remaining review suggestions: `shouldBuildMPT` is a pure predicate again — the `feature_raw_address` rejection moved to `rejectRawAddressWithMPT`, which `coExecuteBlock` calls *inside* the `shouldBuildMPT` branch, so the predicate is evaluated once and the guard only answers "is raw_address in the way?" instead of re-deriving whether this block builds an MPT; the runtime check itself stays, because the startup guard cannot see a flag pair that activates at a block boundary after boot; a `static_assert` pins that the `"/mpt/"` table name carries no `':'`, the premise `StateKeyResolver`'s split-at-first-colon decode depends on; `MPTDeltaLayer` documents that the node flush copies each RLP out of `newNodes`, so the map is still complete when `CommitObserver::onCommit` receives it; and `TestRocksDBStorage2::mergeAppliesSourcesInArgumentOrder` pins merge's argument-order semantics at the physical layer — two sources carrying one key land in the batch in order, last write wins — which is what lets commit's signed header overwrite the execute-time one inside a single `WriteBatch`.

## Folded in: feature_raw_address × MPT guard (was PR #5342, M6.2 follow-up)

The `feature_raw_address` rejection guard now ships in this PR as its own commit (cherry-picked verbatim from #5342, which is closed in favor of this PR). `validateMPTFlagMatrix` in `BaselineSchedulerMPTHelpers.h` (throwing `InvalidMPTFlagMatrix`) rejects `feature_raw_address` combined with either MPT state-root flag, and `shouldBuildMPT` enforces the same rule at its gate: raw-address mode keys accounts by 20-byte raw address, while the MPT build assumes `/apps/<40-hex>` tables, so the combination would silently build a trie over a key space the spec never defined. `TestRawAddressMPTGuard.cpp` pins the full flag matrix (raw_address alone passes, either MPT flag alone passes, each combination throws, both scenario-A past-activation and scenario-B from-genesis arms).

## What the root commits to (scenario A vs scenario B)

Worth stating explicitly, because the code alone reads like an oversight: on a **scenario-A** chain (`feature_mpt_state_root` flipped mid-life), the first MPT block starts from the EMPTY trie, and the committed root covers only state written after activation. Accounts dormant since the flip stay outside the trie and answer `AccountNotInMPT`; the root is deliberately **not** a full-state Ethereum commitment, and a full-state MPT implementation computing over the whole account set will get a different root. That is the design (spec design3 §1.1.2 / §1.1.4 / §1.1.6): the 2026-07-09 revision dropped first-touch bootstrap and the preheat tooling on purpose, so activation costs no stop-the-world scan and no migration. Sync completeness on such a chain comes from replaying the block sequence, exactly as it did before MPT. **Scenario B** (L2, flag on at genesis) is the full-state case — every account enters the trie when it is created, and the root is the Ethereum-verifiable one.

One operational constraint follows from the same place: `feature_raw_address` and the MPT state root are mutually exclusive for the life of a chain, not just at boot. Turning `feature_raw_address` on mid-chain halts an MPT chain from the next block with no in-protocol recovery (`rejectRawAddressWithMPT`). The alternative would be committing roots that classify no account at all — a silent fork — so the halt is the deliberate trade.

## Scope cuts (unchanged)

- L2 non-empty-alloc genesis: the genesis build persists the state root but not its trie nodes, so only empty-alloc genesis chains block 1 today. A block-1 build failure now says so in the log instead of surfacing a bare missing-node error from the trie core;
- RPC `NodeService::setMPTNodeReader` wiring (eth_getProof reader) arrives with the injection PR;
- pruning: `obsoletedNodes`/`intraBlockObsoleted` are recorded, never consumed — no deletes are issued.

## Test evidence

All run locally on macOS arm64 (RelWithDebInfo, TESTS=ON):

- `test-storage` green (19 cases), including the rewritten `TestMPTNodeKey` physical-layout proof: an Entry keyed `mptNodeStateKey(hash)` written through a real `RocksDBStorage2<StateKey, ..., StateKeyResolver, ...>` merge is readable via raw `db->Get` with the literal 38-byte key constructed independently in the test TU, and those physical bytes decode back to the same StateKey (colon-riddled digest) through `StateKeyResolver::decode`; the rewritten `KeyPrefixesSuite` pins the resolver round-trip and the retired colon-free layout's rejection;
- `test-transaction-scheduler` green (85 cases, including the new `RawAddressMPTGuardSuite`), `TestMPTSchedulerWiring` covering: scenario-A transition pinned against an independent commitTrie oracle (XOR at activation block, MPT after, parent resolution from the committed header across a commit, two-level storage-trie build); pipeline visibility with zero backend nodes — now covering the parent HEADER as well (block 502 resolves 501's executed header from the pending layer); **a negative control** — the same `buildAndCollect` goes green through a view forked after block N's `pushView` and red (`MPTInvariantViolation`, missing node) through a view forked before it, proving visibility really comes from the view's layer chain; commit atomicity + observer timing (all delta nodes byte-identical in the backend at callback time, nothing on disk before commit); scenario-B restart both directions off a seeded parent header plus the fail-loud missing-header negative (`NotFoundBlockHeader`); the merge-order pins `commitPrewriteOverwritesExecuteTimeHeaderRow` (storage-stack level) and `TestRocksDBStorage2::mergeAppliesSourcesInArgumentOrder` (physical WriteBatch level); the two header-publication exclusions `executeTimeHeaderRowOnlyForMPTBlocks` / `genesisBlockPublishesNoExecuteTimeHeader`, both verified red against a build with the guard removed; **a stray-row guard** — a `"/mpt/"`-table row in the top delta layer is skipped by the account scan (`parseAccountTable`), never misclassified; build failure surfaces as an execute error with no XOR fallback;
- `test-bcos-ledger` green (154 cases), `test-bcos-framework` green (67 cases);
- production `fisco-bcos` target compiles — with same-keyed node rows the production cache+RocksDB instantiation no longer needs any merge special-casing;
- per-file standalone `-fsyntax-only` compiles for the new/rewritten TUs with a negative control (stripping a load-bearing include fails as expected), guarding against unity-build include leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

