### PR TITLE
refactor(storage2): replace ambiguous DIRECT tag with semantic-specific tags

### DIFF
--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -192,13 +192,15 @@ public:
         }
     }
 
-    // DIRECT-tagged storage read: bypasses any read-set tracking on the storage
+    // untracked-read-tagged storage read: bypasses any read-set tracking on the storage
     // wrapper. Use for metadata-only reads (e.g. computing evmc_storage_status)
     // that must not register as a semantic read for parallel conflict detection.
-    task::Task<evmc_bytes32> storage(const evmc_bytes32& key, storage2::DIRECT_TYPE direct)
+    task::Task<evmc_bytes32> storage(
+        const evmc_bytes32& key, storage2::untracked_read_t untracked)
     {
         auto rawValue = co_await m_storage.get().readOneRaw(
-            executor_v1::StateKey{m_tableName, concepts::bytebuffer::toView(key.bytes)}, direct);
+            executor_v1::StateKey{m_tableName, concepts::bytebuffer::toView(key.bytes)},
+            untracked);
         evmc_bytes32 value{};
         if (auto* entry = std::get_if<storage::Entry>(std::addressof(rawValue)))
         {

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -192,15 +192,15 @@ public:
         }
     }
 
-    // bypass-read-set-tagged storage read: bypasses any read-set tracking on the storage
-    // wrapper. Use for metadata-only reads (e.g. computing evmc_storage_status)
-    // that must not register as a semantic read for parallel conflict detection.
-    task::Task<evmc_bytes32> storage(
-        const evmc_bytes32& key, storage2::BYPASS_READ_SET_TYPE untracked)
+    // Tag-forwarding storage read: passes all tags through to the underlying
+    // readOneRaw call. Callers compose the exact set of tags they need
+    // (e.g. BYPASS_READ_SET | BYPASS_MULTILAYER for metadata reads that
+    // must skip both conflict tracking and layer resolution).
+    task::Task<evmc_bytes32> storage(const evmc_bytes32& key, auto... tags)
     {
         auto rawValue = co_await m_storage.get().readOneRaw(
             executor_v1::StateKey{m_tableName, concepts::bytebuffer::toView(key.bytes)},
-            untracked);
+            tags...);
         evmc_bytes32 value{};
         if (auto* entry = std::get_if<storage::Entry>(std::addressof(rawValue)))
         {

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -192,11 +192,11 @@ public:
         }
     }
 
-    // untracked-read-tagged storage read: bypasses any read-set tracking on the storage
+    // bypass-read-set-tagged storage read: bypasses any read-set tracking on the storage
     // wrapper. Use for metadata-only reads (e.g. computing evmc_storage_status)
     // that must not register as a semantic read for parallel conflict detection.
     task::Task<evmc_bytes32> storage(
-        const evmc_bytes32& key, storage2::UNTRACKED_READ_TYPE untracked)
+        const evmc_bytes32& key, storage2::BYPASS_READ_SET_TYPE untracked)
     {
         auto rawValue = co_await m_storage.get().readOneRaw(
             executor_v1::StateKey{m_tableName, concepts::bytebuffer::toView(key.bytes)},

--- a/bcos-framework/bcos-framework/ledger/EVMAccount.h
+++ b/bcos-framework/bcos-framework/ledger/EVMAccount.h
@@ -196,7 +196,7 @@ public:
     // wrapper. Use for metadata-only reads (e.g. computing evmc_storage_status)
     // that must not register as a semantic read for parallel conflict detection.
     task::Task<evmc_bytes32> storage(
-        const evmc_bytes32& key, storage2::untracked_read_t untracked)
+        const evmc_bytes32& key, storage2::UNTRACKED_READ_TYPE untracked)
     {
         auto rawValue = co_await m_storage.get().readOneRaw(
             executor_v1::StateKey{m_tableName, concepts::bytebuffer::toView(key.bytes)},

--- a/bcos-framework/bcos-framework/storage2/AnyStorage.h
+++ b/bcos-framework/bcos-framework/storage2/AnyStorage.h
@@ -33,7 +33,7 @@ namespace bcos::storage2
 // 说明
 // - 批量 API 接受通用 range；AnyStorage 在内部使用 any_view 别名进行适配
 // - merge(to, from) 会遍历来源的 range，并以通用方式对目标执行写入/删除
-// - 使用 DIRECT 进行删除时，如果底层存储支持，将绕过“逻辑删除”
+// - 使用 bypass_logical_delete 进行删除时，如果底层存储支持，将绕过“逻辑删除”
 //
 // 通过将 Key/Value 作为模板参数保留，在擦除具体存储实现的同时保持强类型。
 
@@ -57,7 +57,7 @@ namespace bcos::storage2
 // Notes
 // - Bulk APIs accept generic ranges; AnyStorage adapts them internally using any_view aliases
 // - merge(to, from) iterates source's range and applies writes/removes to destination generically
-// - Removing with DIRECT will bypass logical-deletion if the underlying storage supports it
+// - Removing with bypass_logical_delete will bypass logical-deletion if the underlying storage supports it
 //
 // Keep Key/Value as template parameters to preserve strong types while
 // erasing the concrete storage implementation.
@@ -108,11 +108,11 @@ private:
         virtual ~StorageConcept() = default;
         virtual task::Task<std::vector<std::optional<ValueType>>> readSome(AnyKeyView keys) = 0;
         virtual task::Task<void> writeSome(AnyKeyValueView keyValues) = 0;
-        virtual task::Task<void> removeSome(AnyKeyView keys, bool direct) = 0;
+        virtual task::Task<void> removeSome(AnyKeyView keys, bool physical) = 0;
 
         virtual task::Task<std::optional<ValueType>> readOne(Key key) = 0;
         virtual task::Task<void> writeOne(Key key, ValueType value) = 0;
-        virtual task::Task<void> removeOne(Key key, bool direct) = 0;
+        virtual task::Task<void> removeOne(Key key, bool physical) = 0;
 
         virtual task::Task<std::unique_ptr<IteratorConcept>> rangeBegin() = 0;
         virtual task::Task<std::unique_ptr<IteratorConcept>> rangeSeekBegin(const Key& key) = 0;
@@ -177,11 +177,12 @@ private:
             co_await m_storage->writeSome(::ranges::views::all(keyValues));
         }
 
-        task::Task<void> removeSome(AnyKeyView keys, bool direct) override
+        task::Task<void> removeSome(AnyKeyView keys, bool physical) override
         {
-            if (direct)
+            if (physical)
             {
-                co_await m_storage->removeSome(::ranges::views::all(keys), DIRECT);
+                co_await m_storage->removeSome(
+                    ::ranges::views::all(keys), bypass_logical_delete);
             }
             else
             {
@@ -199,11 +200,11 @@ private:
             co_await m_storage->writeOne(std::move(key), std::move(value));
         }
 
-        task::Task<void> removeOne(Key key, bool direct) override
+        task::Task<void> removeOne(Key key, bool physical) override
         {
-            if (direct)
+            if (physical)
             {
-                co_await m_storage->removeOne(std::move(key), DIRECT);
+                co_await m_storage->removeOne(std::move(key), bypass_logical_delete);
             }
             else
             {
@@ -298,9 +299,11 @@ public:
         co_await m_self->removeSome(::ranges::views::all(keys), false);
     }
 
-    auto removeSome(::ranges::input_range auto keys, DIRECT_TYPE /*unused*/) -> task::Task<void>
+    auto removeSome(::ranges::input_range auto keys, auto... tags) -> task::Task<void>
     {
-        co_await m_self->removeSome(::ranges::views::all(keys), true);
+        constexpr bool physical =
+            contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+        co_await m_self->removeSome(::ranges::views::all(keys), physical);
     }
 
     auto readOne(auto key) -> task::Task<std::optional<Value>>
@@ -318,9 +321,11 @@ public:
         co_await m_self->removeOne(std::move(key), false);
     }
 
-    auto removeOne(auto key, DIRECT_TYPE /*unused*/) -> task::Task<void>
+    auto removeOne(auto key, auto... tags) -> task::Task<void>
     {
-        co_await m_self->removeOne(std::move(key), true);
+        constexpr bool physical =
+            contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+        co_await m_self->removeOne(std::move(key), physical);
     }
 
     auto range() -> task::Task<typename AnyStorage::Iterator>

--- a/bcos-framework/bcos-framework/storage2/AnyStorage.h
+++ b/bcos-framework/bcos-framework/storage2/AnyStorage.h
@@ -33,7 +33,7 @@ namespace bcos::storage2
 // 说明
 // - 批量 API 接受通用 range；AnyStorage 在内部使用 any_view 别名进行适配
 // - merge(to, from) 会遍历来源的 range，并以通用方式对目标执行写入/删除
-// - 使用 bypass_logical_delete 进行删除时，如果底层存储支持，将绕过“逻辑删除”
+// - 使用 BYPASS_LOGICAL_DELETE 进行删除时，如果底层存储支持，将绕过“逻辑删除”
 //
 // 通过将 Key/Value 作为模板参数保留，在擦除具体存储实现的同时保持强类型。
 
@@ -57,7 +57,7 @@ namespace bcos::storage2
 // Notes
 // - Bulk APIs accept generic ranges; AnyStorage adapts them internally using any_view aliases
 // - merge(to, from) iterates source's range and applies writes/removes to destination generically
-// - Removing with bypass_logical_delete will bypass logical-deletion if the underlying storage supports it
+// - Removing with BYPASS_LOGICAL_DELETE will bypass logical-deletion if the underlying storage supports it
 //
 // Keep Key/Value as template parameters to preserve strong types while
 // erasing the concrete storage implementation.
@@ -182,7 +182,7 @@ private:
             if (physical)
             {
                 co_await m_storage->removeSome(
-                    ::ranges::views::all(keys), bypass_logical_delete);
+                    ::ranges::views::all(keys), BYPASS_LOGICAL_DELETE);
             }
             else
             {
@@ -204,7 +204,7 @@ private:
         {
             if (physical)
             {
-                co_await m_storage->removeOne(std::move(key), bypass_logical_delete);
+                co_await m_storage->removeOne(std::move(key), BYPASS_LOGICAL_DELETE);
             }
             else
             {
@@ -302,7 +302,7 @@ public:
     auto removeSome(::ranges::input_range auto keys, auto... tags) -> task::Task<void>
     {
         constexpr bool physical =
-            contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+            contains_tag_v<BYPASS_LOGICAL_DELETE_TYPE, decltype(tags)...>;
         co_await m_self->removeSome(::ranges::views::all(keys), physical);
     }
 
@@ -324,7 +324,7 @@ public:
     auto removeOne(auto key, auto... tags) -> task::Task<void>
     {
         constexpr bool physical =
-            contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+            contains_tag_v<BYPASS_LOGICAL_DELETE_TYPE, decltype(tags)...>;
         co_await m_self->removeOne(std::move(key), physical);
     }
 

--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -443,7 +443,7 @@ public:
 
     task::AwaitableValue<void> removeOne(auto key, auto... tags)
     {
-        constexpr bool physical = contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+        constexpr bool physical = contains_tag_v<BYPASS_LOGICAL_DELETE_TYPE, decltype(tags)...>;
         removeSome(::ranges::views::single(std::move(key)), physical);
         return {};
     }
@@ -456,7 +456,7 @@ public:
 
     task::Task<void> removeSome(::ranges::input_range auto keys, auto... tags)
     {
-        constexpr bool physical = contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+        constexpr bool physical = contains_tag_v<BYPASS_LOGICAL_DELETE_TYPE, decltype(tags)...>;
         removeSome(std::move(keys), physical);
         co_return;
     }

--- a/bcos-framework/bcos-framework/storage2/MemoryStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MemoryStorage.h
@@ -441,9 +441,10 @@ public:
         return {true};
     }
 
-    task::AwaitableValue<void> removeOne(auto key, DIRECT_TYPE /*unused*/)
+    task::AwaitableValue<void> removeOne(auto key, auto... tags)
     {
-        removeSome(::ranges::views::single(std::move(key)), true);
+        constexpr bool physical = contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+        removeSome(::ranges::views::single(std::move(key)), physical);
         return {};
     }
 
@@ -453,9 +454,10 @@ public:
         co_return;
     }
 
-    task::Task<void> removeSome(::ranges::input_range auto keys, DIRECT_TYPE /*unused*/)
+    task::Task<void> removeSome(::ranges::input_range auto keys, auto... tags)
     {
-        removeSome(std::move(keys), true);
+        constexpr bool physical = contains_tag_v<bypass_logical_delete_t, decltype(tags)...>;
+        removeSome(std::move(keys), physical);
         co_return;
     }
 

--- a/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
@@ -198,8 +198,8 @@ public:
         -> task::Task<std::vector<storage2::StorageValueType<Value>>>
         requires ::ranges::sized_range<Keys>
     {
-        constexpr bool untracked = contains_tag_v<UNTRACKED_READ_TYPE, decltype(tags)...>;
-        if constexpr (untracked)
+        constexpr bool bypassMultiLayer = contains_tag_v<BYPASS_MULTILAYER_TYPE, decltype(tags)...>;
+        if constexpr (bypassMultiLayer)
         {
             if (m_mutableStorage)
             {
@@ -258,8 +258,8 @@ public:
 
     auto readOneRaw(const auto& key, auto... tags) -> task::Task<storage2::StorageValueType<Value>>
     {
-        constexpr bool untracked = contains_tag_v<UNTRACKED_READ_TYPE, decltype(tags)...>;
-        if constexpr (untracked)
+        constexpr bool bypassMultiLayer = contains_tag_v<BYPASS_MULTILAYER_TYPE, decltype(tags)...>;
+        if constexpr (bypassMultiLayer)
         {
             if (m_mutableStorage)
             {

--- a/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
@@ -194,26 +194,34 @@ public:
     }
 
     template <::ranges::input_range Keys>
-    auto readSomeRaw(Keys keys, storage2::DIRECT_TYPE /*unused*/)
+    auto readSomeRaw(Keys keys, auto... tags)
         -> task::Task<std::vector<storage2::StorageValueType<Value>>>
         requires ::ranges::sized_range<Keys>
     {
-        if (m_mutableStorage)
+        constexpr bool untracked = contains_tag_v<untracked_read_t, decltype(tags)...>;
+        if constexpr (untracked)
         {
-            co_return co_await m_mutableStorage->readSomeRaw(std::move(keys));
-        }
+            if (m_mutableStorage)
+            {
+                co_return co_await m_mutableStorage->readSomeRaw(std::move(keys));
+            }
 
-        for (auto& immutableStorage : m_immutableStorages)
+            for (auto& immutableStorage : m_immutableStorages)
+            {
+                co_return co_await immutableStorage->readSomeRaw(std::move(keys));
+            }
+
+            if constexpr (withCacheStorage)
+            {
+                co_return co_await m_cacheStorage.get().readSomeRaw(std::move(keys));
+            }
+
+            co_return co_await backendStorageRef().readSomeRaw(std::move(keys));
+        }
+        else
         {
-            co_return co_await immutableStorage->readSomeRaw(std::move(keys));
+            co_return co_await readSomeRaw(std::move(keys));
         }
-
-        if constexpr (withCacheStorage)
-        {
-            co_return co_await m_cacheStorage.get().readSomeRaw(std::move(keys));
-        }
-
-        co_return co_await backendStorageRef().readSomeRaw(std::move(keys));
     }
 
     auto readOneRaw(const auto& key) -> task::Task<storage2::StorageValueType<Value>>
@@ -248,25 +256,32 @@ public:
         co_return co_await backendStorageRef().readOneRaw(key);
     }
 
-    auto readOneRaw(const auto& key, storage2::DIRECT_TYPE /*unused*/)
-        -> task::Task<storage2::StorageValueType<Value>>
+    auto readOneRaw(const auto& key, auto... tags) -> task::Task<storage2::StorageValueType<Value>>
     {
-        if (m_mutableStorage)
+        constexpr bool untracked = contains_tag_v<untracked_read_t, decltype(tags)...>;
+        if constexpr (untracked)
         {
-            co_return co_await m_mutableStorage->readOneRaw(key);
-        }
+            if (m_mutableStorage)
+            {
+                co_return co_await m_mutableStorage->readOneRaw(key);
+            }
 
-        for (auto& immutableStorage : m_immutableStorages)
+            for (auto& immutableStorage : m_immutableStorages)
+            {
+                co_return co_await immutableStorage->readOneRaw(key);
+            }
+
+            if constexpr (withCacheStorage)
+            {
+                co_return co_await m_cacheStorage.get().readOneRaw(key);
+            }
+
+            co_return co_await backendStorageRef().readOneRaw(key);
+        }
+        else
         {
-            co_return co_await immutableStorage->readOneRaw(key);
+            co_return co_await readOneRaw(key);
         }
-
-        if constexpr (withCacheStorage)
-        {
-            co_return co_await m_cacheStorage.get().readOneRaw(key);
-        }
-
-        co_return co_await backendStorageRef().readOneRaw(key);
     }
 
     template <::ranges::input_range Keys>
@@ -465,10 +480,9 @@ public:
     constexpr static bool withCacheStorage = !std::is_void_v<CachedStorage>;
     using KeyType = std::remove_cvref_t<typename MutableStorageType::Key>;
     using ValueType = std::remove_cvref_t<typename MutableStorageType::Value>;
-    using OpenedStorage =
-        decltype(std::declval<std::remove_reference_t<BackendStorage>&>().open());
-    using ViewType = View<MutableStorageType, CachedStorage,
-        std::remove_reference_t<OpenedStorage>>;
+    using OpenedStorage = decltype(std::declval<std::remove_reference_t<BackendStorage>&>().open());
+    using ViewType =
+        View<MutableStorageType, CachedStorage, std::remove_reference_t<OpenedStorage>>;
     using CheckpointName = typename std::remove_reference_t<BackendStorage>::CheckpointName;
 
     std::deque<std::shared_ptr<MutableStorageType>> m_storages;

--- a/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
@@ -198,7 +198,7 @@ public:
         -> task::Task<std::vector<storage2::StorageValueType<Value>>>
         requires ::ranges::sized_range<Keys>
     {
-        constexpr bool untracked = contains_tag_v<untracked_read_t, decltype(tags)...>;
+        constexpr bool untracked = contains_tag_v<UNTRACKED_READ_TYPE, decltype(tags)...>;
         if constexpr (untracked)
         {
             if (m_mutableStorage)
@@ -258,7 +258,7 @@ public:
 
     auto readOneRaw(const auto& key, auto... tags) -> task::Task<storage2::StorageValueType<Value>>
     {
-        constexpr bool untracked = contains_tag_v<untracked_read_t, decltype(tags)...>;
+        constexpr bool untracked = contains_tag_v<UNTRACKED_READ_TYPE, decltype(tags)...>;
         if constexpr (untracked)
         {
             if (m_mutableStorage)

--- a/bcos-framework/bcos-framework/storage2/Storage.h
+++ b/bcos-framework/bcos-framework/storage2/Storage.h
@@ -15,9 +15,24 @@
 namespace bcos::storage2
 {
 
-inline constexpr struct DIRECT_TYPE
+// Helper: check if a tag type is present in a parameter pack.
+// Usage: if constexpr (contains_tag_v<untracked_read_t, decltype(tags)...>) { ... }
+template <class Tag, class... Tags>
+inline constexpr bool contains_tag_v = (std::same_as<std::decay_t<Tags>, Tag> || ...);
+
+// Bypass logical deletion: physically erase the entry instead of marking a
+// deleteItem sentinel. Used by MemoryStorage (removeOne/removeSome) and
+// RollbackableStorage (rollback).
+inline constexpr struct bypass_logical_delete_t
 {
-} DIRECT;
+} bypass_logical_delete;
+
+// Bypass read-set tracking: do not register the read in the parallel
+// scheduler's conflict set. Used by ReadWriteSetStorage (readOne/readSome),
+// EVM metadata reads (SSTORE status), and Rollbackable pre-image capture.
+inline constexpr struct untracked_read_t
+{
+} untracked_read;
 
 inline constexpr struct RANGE_SEEK_TYPE
 {

--- a/bcos-framework/bcos-framework/storage2/Storage.h
+++ b/bcos-framework/bcos-framework/storage2/Storage.h
@@ -16,7 +16,7 @@ namespace bcos::storage2
 {
 
 // Helper: check if a tag type is present in a parameter pack.
-// Usage: if constexpr (contains_tag_v<UNTRACKED_READ_TYPE, decltype(tags)...>) { ... }
+// Usage: if constexpr (contains_tag_v<BYPASS_READ_SET_TYPE, decltype(tags)...>) { ... }
 template <class Tag, class... Tags>
 inline constexpr bool contains_tag_v = (std::same_as<std::decay_t<Tags>, Tag> || ...);
 
@@ -30,9 +30,17 @@ inline constexpr struct BYPASS_LOGICAL_DELETE_TYPE
 // Bypass read-set tracking: do not register the read in the parallel
 // scheduler's conflict set. Used by ReadWriteSetStorage (readOne/readSome),
 // EVM metadata reads (SSTORE status), and Rollbackable pre-image capture.
-inline constexpr struct UNTRACKED_READ_TYPE
+inline constexpr struct BYPASS_READ_SET_TYPE
 {
-} UNTRACKED_READ;
+} BYPASS_READ_SET;
+
+// Bypass MultiLayerStorage layer resolution: read from the most recent layer
+// directly instead of walking the full mutable→immutable→cache→backend chain.
+// Used when the caller already knows which layer to target (e.g. pre-image
+// capture, metadata queries that only need the latest value).
+inline constexpr struct BYPASS_MULTILAYER_TYPE
+{
+} BYPASS_MULTILAYER;
 
 inline constexpr struct RANGE_SEEK_TYPE
 {

--- a/bcos-framework/bcos-framework/storage2/Storage.h
+++ b/bcos-framework/bcos-framework/storage2/Storage.h
@@ -16,23 +16,23 @@ namespace bcos::storage2
 {
 
 // Helper: check if a tag type is present in a parameter pack.
-// Usage: if constexpr (contains_tag_v<untracked_read_t, decltype(tags)...>) { ... }
+// Usage: if constexpr (contains_tag_v<UNTRACKED_READ_TYPE, decltype(tags)...>) { ... }
 template <class Tag, class... Tags>
 inline constexpr bool contains_tag_v = (std::same_as<std::decay_t<Tags>, Tag> || ...);
 
 // Bypass logical deletion: physically erase the entry instead of marking a
 // deleteItem sentinel. Used by MemoryStorage (removeOne/removeSome) and
 // RollbackableStorage (rollback).
-inline constexpr struct bypass_logical_delete_t
+inline constexpr struct BYPASS_LOGICAL_DELETE_TYPE
 {
-} bypass_logical_delete;
+} BYPASS_LOGICAL_DELETE;
 
 // Bypass read-set tracking: do not register the read in the parallel
 // scheduler's conflict set. Used by ReadWriteSetStorage (readOne/readSome),
 // EVM metadata reads (SSTORE status), and Rollbackable pre-image capture.
-inline constexpr struct untracked_read_t
+inline constexpr struct UNTRACKED_READ_TYPE
 {
-} untracked_read;
+} UNTRACKED_READ;
 
 inline constexpr struct RANGE_SEEK_TYPE
 {

--- a/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(directDelete)
         }
         BOOST_CHECK_EQUAL(count1, 10);
 
-        co_await storage2::removeOne(storage, 6, bcos::storage2::DIRECT);
+        co_await storage2::removeOne(storage, 6, bcos::storage2::bypass_logical_delete);
         auto range2 = co_await storage2::range(storage);
         int count2 = 0;
         while (co_await range2.next())

--- a/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
+++ b/bcos-framework/test/unittests/storage2/TestMemoryStorage.cpp
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(directDelete)
         }
         BOOST_CHECK_EQUAL(count1, 10);
 
-        co_await storage2::removeOne(storage, 6, bcos::storage2::bypass_logical_delete);
+        co_await storage2::removeOne(storage, 6, bcos::storage2::BYPASS_LOGICAL_DELETE);
         auto range2 = co_await storage2::range(storage);
         int count2 = 0;
         while (co_await range2.next())

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -87,7 +87,8 @@ private:
                        ::ranges::to<std::vector<Key>>;
             }
         }();
-        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::BYPASS_READ_SET);
+        auto oldValues = co_await storage.readSomeRaw(
+            keyList, storage2::BYPASS_READ_SET, storage2::BYPASS_MULTILAYER);
 
         m_records.reserve(m_records.size() + keyList.size());
         for (auto&& [key, oldValue] : ::ranges::views::zip(keyList, oldValues))
@@ -133,16 +134,15 @@ public:
         co_return co_await storage2::readOne(m_storage.get(), std::move(key));
     }
 
-    // Bypass read-set tracking for pre-image capture: read the raw value
-    // without registering in any tracking wrapper (e.g. RW-set or rollback
-    // record). Used by callers that read a value for internal metadata only
-    // (e.g. computing evmc_storage_status) and must not participate in
-    // parallel conflict detection.
-    auto readOneRaw(auto key, storage2::BYPASS_READ_SET_TYPE untracked) -> task::Task<
-        task::AwaitableReturnType<decltype(m_storage.get().readOneRaw(std::move(key), untracked))>>
+    // Raw read that forwards tags to the underlying storage without imposing
+    // any interpretation. Callers compose the exact set of tags they need
+    // (e.g. BYPASS_READ_SET | BYPASS_MULTILAYER for pre-image capture) and
+    // this passthrough forwards them unchanged.
+    auto readOneRaw(auto key, auto... tags) -> task::Task<
+        task::AwaitableReturnType<decltype(m_storage.get().readOneRaw(std::move(key), tags...))>>
         requires HasReadOneRaw<Storage>
     {
-        co_return co_await m_storage.get().readOneRaw(std::move(key), untracked);
+        co_return co_await m_storage.get().readOneRaw(std::move(key), tags...);
     }
 
     auto existsOne(auto key) -> task::Task<task::AwaitableReturnType<
@@ -158,7 +158,8 @@ public:
         auto& record = m_records.emplace_back();
         record.key = key;
         auto& storage = m_storage.get();
-        record.oldValue = co_await storage.readOneRaw(key, storage2::BYPASS_READ_SET);
+        record.oldValue = co_await storage.readOneRaw(
+            key, storage2::BYPASS_READ_SET, storage2::BYPASS_MULTILAYER);
         co_await storage2::writeOne(m_storage.get(), std::move(key), std::move(value));
     }
 

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -11,12 +11,13 @@ namespace bcos::executor_v1
 
 template <class Storage>
 concept HasReadOneRaw = requires(Storage& storage) {
-    storage.readOneRaw(std::declval<typename Storage::Key>(), storage2::DIRECT);
+    storage.readOneRaw(std::declval<typename Storage::Key>(), storage2::untracked_read);
 };
 
 template <class Storage>
 concept HasReadSomeRaw = requires(Storage& storage) {
-    storage.readSomeRaw(std::declval<std::vector<typename Storage::Key>>(), storage2::DIRECT);
+    storage.readSomeRaw(
+        std::declval<std::vector<typename Storage::Key>>(), storage2::untracked_read);
 };
 
 template <class Storage>
@@ -44,8 +45,8 @@ public:
 
             co_await std::visit(
                 bcos::overloaded{[&](storage2::NOT_EXISTS_TYPE) -> task::Task<void> {
-                                     co_await storage2::removeOne(
-                                         m_storage.get(), std::move(record.key), storage2::DIRECT);
+                                     co_await storage2::removeOne(m_storage.get(),
+                                         std::move(record.key), storage2::bypass_logical_delete);
                                  },
                     [&](storage2::DELETED_TYPE) -> task::Task<void> {
                         co_await storage2::writeOne(
@@ -86,7 +87,7 @@ private:
                        ::ranges::to<std::vector<Key>>;
             }
         }();
-        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::DIRECT);
+        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::untracked_read);
 
         m_records.reserve(m_records.size() + keyList.size());
         for (auto&& [key, oldValue] : ::ranges::views::zip(keyList, oldValues))
@@ -132,15 +133,15 @@ public:
         co_return co_await storage2::readOne(m_storage.get(), std::move(key));
     }
 
-    // DIRECT-tagged raw read that bypasses any tracking wrapper (e.g. RW-set or
+    // untracked-read-tagged raw read that bypasses any tracking wrapper (e.g. RW-set or
     // rollback-record creation). Used by callers that read a value for internal
     // metadata only (e.g. computing evmc_storage_status) and must not participate
     // in parallel conflict detection.
-    auto readOneRaw(auto key, storage2::DIRECT_TYPE direct) -> task::Task<
-        task::AwaitableReturnType<decltype(m_storage.get().readOneRaw(std::move(key), direct))>>
+    auto readOneRaw(auto key, storage2::untracked_read_t untracked) -> task::Task<
+        task::AwaitableReturnType<decltype(m_storage.get().readOneRaw(std::move(key), untracked))>>
         requires HasReadOneRaw<Storage>
     {
-        co_return co_await m_storage.get().readOneRaw(std::move(key), direct);
+        co_return co_await m_storage.get().readOneRaw(std::move(key), untracked);
     }
 
     auto existsOne(auto key) -> task::Task<task::AwaitableReturnType<
@@ -156,7 +157,7 @@ public:
         auto& record = m_records.emplace_back();
         record.key = key;
         auto& storage = m_storage.get();
-        record.oldValue = co_await storage.readOneRaw(key, storage2::DIRECT);
+        record.oldValue = co_await storage.readOneRaw(key, storage2::untracked_read);
         co_await storage2::writeOne(m_storage.get(), std::move(key), std::move(value));
     }
 

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -11,13 +11,13 @@ namespace bcos::executor_v1
 
 template <class Storage>
 concept HasReadOneRaw = requires(Storage& storage) {
-    storage.readOneRaw(std::declval<typename Storage::Key>(), storage2::untracked_read);
+    storage.readOneRaw(std::declval<typename Storage::Key>(), storage2::UNTRACKED_READ);
 };
 
 template <class Storage>
 concept HasReadSomeRaw = requires(Storage& storage) {
     storage.readSomeRaw(
-        std::declval<std::vector<typename Storage::Key>>(), storage2::untracked_read);
+        std::declval<std::vector<typename Storage::Key>>(), storage2::UNTRACKED_READ);
 };
 
 template <class Storage>
@@ -46,7 +46,7 @@ public:
             co_await std::visit(
                 bcos::overloaded{[&](storage2::NOT_EXISTS_TYPE) -> task::Task<void> {
                                      co_await storage2::removeOne(m_storage.get(),
-                                         std::move(record.key), storage2::bypass_logical_delete);
+                                         std::move(record.key), storage2::BYPASS_LOGICAL_DELETE);
                                  },
                     [&](storage2::DELETED_TYPE) -> task::Task<void> {
                         co_await storage2::writeOne(
@@ -87,7 +87,7 @@ private:
                        ::ranges::to<std::vector<Key>>;
             }
         }();
-        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::untracked_read);
+        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::UNTRACKED_READ);
 
         m_records.reserve(m_records.size() + keyList.size());
         for (auto&& [key, oldValue] : ::ranges::views::zip(keyList, oldValues))
@@ -137,7 +137,7 @@ public:
     // rollback-record creation). Used by callers that read a value for internal
     // metadata only (e.g. computing evmc_storage_status) and must not participate
     // in parallel conflict detection.
-    auto readOneRaw(auto key, storage2::untracked_read_t untracked) -> task::Task<
+    auto readOneRaw(auto key, storage2::UNTRACKED_READ_TYPE untracked) -> task::Task<
         task::AwaitableReturnType<decltype(m_storage.get().readOneRaw(std::move(key), untracked))>>
         requires HasReadOneRaw<Storage>
     {
@@ -157,7 +157,7 @@ public:
         auto& record = m_records.emplace_back();
         record.key = key;
         auto& storage = m_storage.get();
-        record.oldValue = co_await storage.readOneRaw(key, storage2::untracked_read);
+        record.oldValue = co_await storage.readOneRaw(key, storage2::UNTRACKED_READ);
         co_await storage2::writeOne(m_storage.get(), std::move(key), std::move(value));
     }
 

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -11,13 +11,13 @@ namespace bcos::executor_v1
 
 template <class Storage>
 concept HasReadOneRaw = requires(Storage& storage) {
-    storage.readOneRaw(std::declval<typename Storage::Key>(), storage2::UNTRACKED_READ);
+    storage.readOneRaw(std::declval<typename Storage::Key>(), storage2::BYPASS_READ_SET);
 };
 
 template <class Storage>
 concept HasReadSomeRaw = requires(Storage& storage) {
     storage.readSomeRaw(
-        std::declval<std::vector<typename Storage::Key>>(), storage2::UNTRACKED_READ);
+        std::declval<std::vector<typename Storage::Key>>(), storage2::BYPASS_READ_SET);
 };
 
 template <class Storage>
@@ -87,7 +87,7 @@ private:
                        ::ranges::to<std::vector<Key>>;
             }
         }();
-        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::UNTRACKED_READ);
+        auto oldValues = co_await storage.readSomeRaw(keyList, storage2::BYPASS_READ_SET);
 
         m_records.reserve(m_records.size() + keyList.size());
         for (auto&& [key, oldValue] : ::ranges::views::zip(keyList, oldValues))
@@ -133,11 +133,12 @@ public:
         co_return co_await storage2::readOne(m_storage.get(), std::move(key));
     }
 
-    // untracked-read-tagged raw read that bypasses any tracking wrapper (e.g. RW-set or
-    // rollback-record creation). Used by callers that read a value for internal
-    // metadata only (e.g. computing evmc_storage_status) and must not participate
-    // in parallel conflict detection.
-    auto readOneRaw(auto key, storage2::UNTRACKED_READ_TYPE untracked) -> task::Task<
+    // Bypass read-set tracking for pre-image capture: read the raw value
+    // without registering in any tracking wrapper (e.g. RW-set or rollback
+    // record). Used by callers that read a value for internal metadata only
+    // (e.g. computing evmc_storage_status) and must not participate in
+    // parallel conflict detection.
+    auto readOneRaw(auto key, storage2::BYPASS_READ_SET_TYPE untracked) -> task::Task<
         task::AwaitableReturnType<decltype(m_storage.get().readOneRaw(std::move(key), untracked))>>
         requires HasReadOneRaw<Storage>
     {
@@ -157,7 +158,7 @@ public:
         auto& record = m_records.emplace_back();
         record.key = key;
         auto& storage = m_storage.get();
-        record.oldValue = co_await storage.readOneRaw(key, storage2::UNTRACKED_READ);
+        record.oldValue = co_await storage.readOneRaw(key, storage2::BYPASS_READ_SET);
         co_await storage2::writeOne(m_storage.get(), std::move(key), std::move(value));
     }
 

--- a/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
+++ b/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
@@ -79,7 +79,7 @@ struct EVMHostInterface
             // registered in the parallel scheduler's read set, otherwise pure SSTORE
             // writes would create false RAW edges against any earlier writer of the
             // same slot.
-            auto existingValue = syncWait(hostContext.get(key, storage2::untracked_read));
+            auto existingValue = syncWait(hostContext.get(key, storage2::UNTRACKED_READ));
             const bool existingIsZero = concepts::bytebuffer::equalTo(
                 existingValue.bytes, executor::EMPTY_EVM_BYTES32.bytes);
             if (newIsZero)

--- a/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
+++ b/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
@@ -75,11 +75,11 @@ struct EVMHostInterface
             // MODIFIED_RESTORED). Requires tracking the transaction-original value
             // per slot to distinguish clean (o == c) from dirty (o != c) writes.
             //
-            // DIRECT read: this lookup is for status metadata only and must not be
+            // untracked read: this lookup is for status metadata only and must not be
             // registered in the parallel scheduler's read set, otherwise pure SSTORE
             // writes would create false RAW edges against any earlier writer of the
             // same slot.
-            auto existingValue = syncWait(hostContext.get(key, storage2::DIRECT));
+            auto existingValue = syncWait(hostContext.get(key, storage2::untracked_read));
             const bool existingIsZero = concepts::bytebuffer::equalTo(
                 existingValue.bytes, executor::EMPTY_EVM_BYTES32.bytes);
             if (newIsZero)

--- a/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
+++ b/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
@@ -79,7 +79,8 @@ struct EVMHostInterface
             // registered in the parallel scheduler's read set, otherwise pure SSTORE
             // writes would create false RAW edges against any earlier writer of the
             // same slot.
-            auto existingValue = syncWait(hostContext.get(key, storage2::BYPASS_READ_SET));
+            auto existingValue = syncWait(hostContext.get(
+                key, storage2::BYPASS_READ_SET, storage2::BYPASS_MULTILAYER));
             const bool existingIsZero = concepts::bytebuffer::equalTo(
                 existingValue.bytes, executor::EMPTY_EVM_BYTES32.bytes);
             if (newIsZero)

--- a/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
+++ b/transaction-executor/bcos-transaction-executor/vm/EVMHostInterface.h
@@ -75,11 +75,11 @@ struct EVMHostInterface
             // MODIFIED_RESTORED). Requires tracking the transaction-original value
             // per slot to distinguish clean (o == c) from dirty (o != c) writes.
             //
-            // untracked read: this lookup is for status metadata only and must not be
+            // bypass-read-set read: this lookup is for status metadata only and must not be
             // registered in the parallel scheduler's read set, otherwise pure SSTORE
             // writes would create false RAW edges against any earlier writer of the
             // same slot.
-            auto existingValue = syncWait(hostContext.get(key, storage2::UNTRACKED_READ));
+            auto existingValue = syncWait(hostContext.get(key, storage2::BYPASS_READ_SET));
             const bool existingIsZero = concepts::bytebuffer::equalTo(
                 existingValue.bytes, executor::EMPTY_EVM_BYTES32.bytes);
             if (newIsZero)

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -273,13 +273,8 @@ public:
                 ledger::Features::Flag::feature_raw_address));
     }
 
-    task::Task<evmc_bytes32> get(const evmc_bytes32* key, auto&&... /*unused*/)
-    {
-        co_return co_await m_recipientAccount.storage(*key);
-    }
-
     // Tag-forwarding variant: passes all tags through to the underlying
-    // storage call chain. Callers compose the exact set of tags they need
+    // EVMAccount::storage call. Callers compose the exact set of tags they need
     // (e.g. BYPASS_READ_SET | BYPASS_MULTILAYER for metadata reads that
     // must skip both conflict tracking and layer resolution).
     task::Task<evmc_bytes32> get(const evmc_bytes32* key, auto... tags)

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -282,7 +282,7 @@ public:
     // ReadWriteSetStorage read set. Use only for internal metadata reads (e.g.
     // SSTORE status determination) that must not influence DAG conflict edges.
     task::Task<evmc_bytes32> get(
-        const evmc_bytes32* key, storage2::untracked_read_t untracked)
+        const evmc_bytes32* key, storage2::UNTRACKED_READ_TYPE untracked)
     {
         co_return co_await m_recipientAccount.storage(*key, untracked);
     }

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -278,12 +278,13 @@ public:
         co_return co_await m_recipientAccount.storage(*key);
     }
 
-    // DIRECT-tagged variant: reads the underlying slot without populating the
+    // untracked-read-tagged variant: reads the underlying slot without populating the
     // ReadWriteSetStorage read set. Use only for internal metadata reads (e.g.
     // SSTORE status determination) that must not influence DAG conflict edges.
-    task::Task<evmc_bytes32> get(const evmc_bytes32* key, storage2::DIRECT_TYPE direct)
+    task::Task<evmc_bytes32> get(
+        const evmc_bytes32* key, storage2::untracked_read_t untracked)
     {
-        co_return co_await m_recipientAccount.storage(*key, direct);
+        co_return co_await m_recipientAccount.storage(*key, untracked);
     }
 
     task::Task<void> set(const evmc_bytes32* key, const evmc_bytes32* value, auto&&... /*unused*/)

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -278,13 +278,13 @@ public:
         co_return co_await m_recipientAccount.storage(*key);
     }
 
-    // bypass-read-set-tagged variant: reads the underlying slot without populating the
-    // ReadWriteSetStorage read set. Use only for internal metadata reads (e.g.
-    // SSTORE status determination) that must not influence DAG conflict edges.
-    task::Task<evmc_bytes32> get(
-        const evmc_bytes32* key, storage2::BYPASS_READ_SET_TYPE untracked)
+    // Tag-forwarding variant: passes all tags through to the underlying
+    // storage call chain. Callers compose the exact set of tags they need
+    // (e.g. BYPASS_READ_SET | BYPASS_MULTILAYER for metadata reads that
+    // must skip both conflict tracking and layer resolution).
+    task::Task<evmc_bytes32> get(const evmc_bytes32* key, auto... tags)
     {
-        co_return co_await m_recipientAccount.storage(*key, untracked);
+        co_return co_await m_recipientAccount.storage(*key, tags...);
     }
 
     task::Task<void> set(const evmc_bytes32* key, const evmc_bytes32* value, auto&&... /*unused*/)

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -278,11 +278,11 @@ public:
         co_return co_await m_recipientAccount.storage(*key);
     }
 
-    // untracked-read-tagged variant: reads the underlying slot without populating the
+    // bypass-read-set-tagged variant: reads the underlying slot without populating the
     // ReadWriteSetStorage read set. Use only for internal metadata reads (e.g.
     // SSTORE status determination) that must not influence DAG conflict edges.
     task::Task<evmc_bytes32> get(
-        const evmc_bytes32* key, storage2::UNTRACKED_READ_TYPE untracked)
+        const evmc_bytes32* key, storage2::BYPASS_READ_SET_TYPE untracked)
     {
         co_return co_await m_recipientAccount.storage(*key, untracked);
     }

--- a/transaction-executor/tests/TestMemoryStorage.h
+++ b/transaction-executor/tests/TestMemoryStorage.h
@@ -9,14 +9,14 @@ using MutableStorage = storage2::memory_storage::MemoryStorage<StateKey, StateVa
     storage2::memory_storage::ORDERED>;
 
 auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/, MutableStorage& storage,
-    ::ranges::input_range auto&& keys, storage2::DIRECT_TYPE /*unused*/)
+    ::ranges::input_range auto&& keys, storage2::untracked_read_t /*unused*/)
     -> task::Task<task::AwaitableReturnType<decltype(storage2::readSome(storage, keys))>>
 {
     co_return co_await storage2::readSome(storage, std::forward<decltype(keys)>(keys));
 }
 
 auto tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/, MutableStorage& storage,
-    const auto& key, storage2::DIRECT_TYPE /*unused*/)
+    const auto& key, storage2::untracked_read_t /*unused*/)
     -> task::Task<task::AwaitableReturnType<decltype(storage2::readOne(storage, key))>>
 {
     co_return co_await storage2::readOne(storage, key);

--- a/transaction-executor/tests/TestMemoryStorage.h
+++ b/transaction-executor/tests/TestMemoryStorage.h
@@ -9,14 +9,14 @@ using MutableStorage = storage2::memory_storage::MemoryStorage<StateKey, StateVa
     storage2::memory_storage::ORDERED>;
 
 auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/, MutableStorage& storage,
-    ::ranges::input_range auto&& keys, storage2::UNTRACKED_READ_TYPE /*unused*/)
+    ::ranges::input_range auto&& keys, storage2::BYPASS_READ_SET_TYPE /*unused*/)
     -> task::Task<task::AwaitableReturnType<decltype(storage2::readSome(storage, keys))>>
 {
     co_return co_await storage2::readSome(storage, std::forward<decltype(keys)>(keys));
 }
 
 auto tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/, MutableStorage& storage,
-    const auto& key, storage2::UNTRACKED_READ_TYPE /*unused*/)
+    const auto& key, storage2::BYPASS_READ_SET_TYPE /*unused*/)
     -> task::Task<task::AwaitableReturnType<decltype(storage2::readOne(storage, key))>>
 {
     co_return co_await storage2::readOne(storage, key);

--- a/transaction-executor/tests/TestMemoryStorage.h
+++ b/transaction-executor/tests/TestMemoryStorage.h
@@ -9,14 +9,14 @@ using MutableStorage = storage2::memory_storage::MemoryStorage<StateKey, StateVa
     storage2::memory_storage::ORDERED>;
 
 auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/, MutableStorage& storage,
-    ::ranges::input_range auto&& keys, storage2::untracked_read_t /*unused*/)
+    ::ranges::input_range auto&& keys, storage2::UNTRACKED_READ_TYPE /*unused*/)
     -> task::Task<task::AwaitableReturnType<decltype(storage2::readSome(storage, keys))>>
 {
     co_return co_await storage2::readSome(storage, std::forward<decltype(keys)>(keys));
 }
 
 auto tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/, MutableStorage& storage,
-    const auto& key, storage2::untracked_read_t /*unused*/)
+    const auto& key, storage2::UNTRACKED_READ_TYPE /*unused*/)
     -> task::Task<task::AwaitableReturnType<decltype(storage2::readOne(storage, key))>>
 {
     co_return co_await storage2::readOne(storage, key);

--- a/transaction-executor/tests/TestRollbackableStorage.cpp
+++ b/transaction-executor/tests/TestRollbackableStorage.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(addRollback)
         Rollbackable rollbackableStorage(memoryStorage);
 
         auto view = ::ranges::single_view(StateKey{"table1"sv, "Key1"sv});
-        co_await storage2::readSome(memoryStorage, view, storage2::UNTRACKED_READ);
+        co_await storage2::readSome(memoryStorage, view, storage2::BYPASS_READ_SET);
 
         std::string_view tableID = "table1";
         auto point = rollbackableStorage.current();
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(rollbackToLogicalDeletionState)
         auto valueAfterRollback = co_await storage2::readOne(rollbackableStorage, key);
         BOOST_CHECK(!valueAfterRollback);
 
-        auto rawValue = co_await memoryStorage.readOneRaw(key, storage2::UNTRACKED_READ);
+        auto rawValue = co_await memoryStorage.readOneRaw(key, storage2::BYPASS_READ_SET);
         BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(rawValue));
     }());
 }
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE(rollbackRestoresLogicalDeletionForStringValues)
         auto rolledBackValue = co_await storage2::readOne(rollbackableStorage, key);
         BOOST_CHECK(!rolledBackValue);
 
-        auto rawValue = co_await storage.readOneRaw(key, storage2::UNTRACKED_READ);
+        auto rawValue = co_await storage.readOneRaw(key, storage2::BYPASS_READ_SET);
         BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(rawValue));
     }());
 }

--- a/transaction-executor/tests/TestRollbackableStorage.cpp
+++ b/transaction-executor/tests/TestRollbackableStorage.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(addRollback)
         Rollbackable rollbackableStorage(memoryStorage);
 
         auto view = ::ranges::single_view(StateKey{"table1"sv, "Key1"sv});
-        co_await storage2::readSome(memoryStorage, view, storage2::untracked_read);
+        co_await storage2::readSome(memoryStorage, view, storage2::UNTRACKED_READ);
 
         std::string_view tableID = "table1";
         auto point = rollbackableStorage.current();
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(rollbackToLogicalDeletionState)
         auto valueAfterRollback = co_await storage2::readOne(rollbackableStorage, key);
         BOOST_CHECK(!valueAfterRollback);
 
-        auto rawValue = co_await memoryStorage.readOneRaw(key, storage2::untracked_read);
+        auto rawValue = co_await memoryStorage.readOneRaw(key, storage2::UNTRACKED_READ);
         BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(rawValue));
     }());
 }
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE(rollbackRestoresLogicalDeletionForStringValues)
         auto rolledBackValue = co_await storage2::readOne(rollbackableStorage, key);
         BOOST_CHECK(!rolledBackValue);
 
-        auto rawValue = co_await storage.readOneRaw(key, storage2::untracked_read);
+        auto rawValue = co_await storage.readOneRaw(key, storage2::UNTRACKED_READ);
         BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(rawValue));
     }());
 }

--- a/transaction-executor/tests/TestRollbackableStorage.cpp
+++ b/transaction-executor/tests/TestRollbackableStorage.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(addRollback)
         Rollbackable rollbackableStorage(memoryStorage);
 
         auto view = ::ranges::single_view(StateKey{"table1"sv, "Key1"sv});
-        co_await storage2::readSome(memoryStorage, view, storage2::DIRECT);
+        co_await storage2::readSome(memoryStorage, view, storage2::untracked_read);
 
         std::string_view tableID = "table1";
         auto point = rollbackableStorage.current();
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(rollbackToLogicalDeletionState)
         auto valueAfterRollback = co_await storage2::readOne(rollbackableStorage, key);
         BOOST_CHECK(!valueAfterRollback);
 
-        auto rawValue = co_await memoryStorage.readOneRaw(key, storage2::DIRECT);
+        auto rawValue = co_await memoryStorage.readOneRaw(key, storage2::untracked_read);
         BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(rawValue));
     }());
 }
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE(rollbackRestoresLogicalDeletionForStringValues)
         auto rolledBackValue = co_await storage2::readOne(rollbackableStorage, key);
         BOOST_CHECK(!rolledBackValue);
 
-        auto rawValue = co_await storage.readOneRaw(key, storage2::DIRECT);
+        auto rawValue = co_await storage.readOneRaw(key, storage2::untracked_read);
         BOOST_CHECK(std::holds_alternative<storage2::DELETED_TYPE>(rawValue));
     }());
 }

--- a/transaction-executor/tests/TestRollbackableStorage.cpp
+++ b/transaction-executor/tests/TestRollbackableStorage.cpp
@@ -650,4 +650,30 @@ BOOST_AUTO_TEST_CASE(rollbackRestoresLogicalDeletionForStringValues)
     }());
 }
 
+// Variadic tag forwarding: readOneRaw passes all caller-supplied tags
+// through to the underlying storage unchanged.
+BOOST_AUTO_TEST_CASE(variadicTagForwarding)
+{
+    task::syncWait([]() -> task::Task<void> {
+        MutableStorage memoryStorage;
+        Rollbackable rollbackableStorage(memoryStorage);
+
+        std::string_view tableID = "table1";
+        storage::Entry entry;
+        entry.set("hello");
+        co_await storage2::writeOne(
+            rollbackableStorage, StateKey{tableID, "Key1"sv}, entry);
+
+        // Pass multiple tags; MemoryStorage ignores them, but this
+        // verifies the variadic interface compiles and forwards correctly.
+        auto rawValue = co_await rollbackableStorage.readOneRaw(
+            StateKey{tableID, "Key1"sv}, storage2::BYPASS_READ_SET,
+            storage2::BYPASS_MULTILAYER);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(rawValue));
+        BOOST_CHECK_EQUAL(std::get<storage::Entry>(rawValue).get(), "hello"sv);
+
+        co_return;
+    }());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
@@ -82,24 +82,39 @@ public:
         co_return co_await storage2::readOne(m_storage.get(), std::move(key));
     }
 
-    // FIB-100: DIRECT reads are Rollbackable's pre-image snapshots — internal
+    // FIB-100: untracked reads are Rollbackable's pre-image snapshots — internal
     // bookkeeping, not transaction-visible reads. Tracking them would create
     // phantom read dependencies (a chunk that only wrote a key would look
     // like it also read it, triggering false RAW). Rollback correctness is
     // protected instead by WAW detection in hasRAWIntersection: two chunks
     // writing the same key are forced to serialize, so the "read stale
     // pre-image" window cannot open.
-    auto readSome(::ranges::input_range auto keys, storage2::DIRECT_TYPE direct)
-        -> task::Task<task::AwaitableReturnType<std::invoke_result_t<storage2::ReadSome, Storage&,
-            decltype(keys), storage2::DIRECT_TYPE>>>
+    auto readSome(::ranges::input_range auto keys, auto... tags)
+        -> task::Task<task::AwaitableReturnType<
+            std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys), decltype(tags)...>>>
     {
-        co_return co_await storage2::readSome(m_storage.get(), std::move(keys), direct);
+        constexpr bool untracked =
+            storage2::contains_tag_v<storage2::untracked_read_t, decltype(tags)...>;
+        if constexpr (!untracked)
+        {
+            for (auto&& key : keys)
+            {
+                putSet(false, key);
+            }
+        }
+        co_return co_await storage2::readSome(m_storage.get(), std::move(keys), tags...);
     }
 
-    auto readOne(auto key, storage2::DIRECT_TYPE direct) -> task::Task<task::AwaitableReturnType<
-        std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key), storage2::DIRECT_TYPE>>>
+    auto readOne(auto key, auto... tags) -> task::Task<task::AwaitableReturnType<
+        std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key), decltype(tags)...>>>
     {
-        co_return co_await storage2::readOne(m_storage.get(), std::move(key), direct);
+        constexpr bool untracked =
+            storage2::contains_tag_v<storage2::untracked_read_t, decltype(tags)...>;
+        if constexpr (!untracked)
+        {
+            putSet(false, key);
+        }
+        co_return co_await storage2::readOne(m_storage.get(), std::move(key), tags...);
     }
 
     auto existsOne(auto key) -> task::Task<task::AwaitableReturnType<

--- a/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
@@ -94,7 +94,7 @@ public:
             std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys), decltype(tags)...>>>
     {
         constexpr bool untracked =
-            storage2::contains_tag_v<storage2::untracked_read_t, decltype(tags)...>;
+            storage2::contains_tag_v<storage2::UNTRACKED_READ_TYPE, decltype(tags)...>;
         if constexpr (!untracked)
         {
             for (auto&& key : keys)
@@ -109,7 +109,7 @@ public:
         std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key), decltype(tags)...>>>
     {
         constexpr bool untracked =
-            storage2::contains_tag_v<storage2::untracked_read_t, decltype(tags)...>;
+            storage2::contains_tag_v<storage2::UNTRACKED_READ_TYPE, decltype(tags)...>;
         if constexpr (!untracked)
         {
             putSet(false, key);

--- a/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/ReadWriteSetStorage.h
@@ -93,9 +93,9 @@ public:
         -> task::Task<task::AwaitableReturnType<
             std::invoke_result_t<storage2::ReadSome, Storage&, decltype(keys), decltype(tags)...>>>
     {
-        constexpr bool untracked =
-            storage2::contains_tag_v<storage2::UNTRACKED_READ_TYPE, decltype(tags)...>;
-        if constexpr (!untracked)
+        constexpr bool bypassSet =
+            storage2::contains_tag_v<storage2::BYPASS_READ_SET_TYPE, decltype(tags)...>;
+        if constexpr (!bypassSet)
         {
             for (auto&& key : keys)
             {
@@ -108,9 +108,9 @@ public:
     auto readOne(auto key, auto... tags) -> task::Task<task::AwaitableReturnType<
         std::invoke_result_t<storage2::ReadOne, Storage&, decltype(key), decltype(tags)...>>>
     {
-        constexpr bool untracked =
-            storage2::contains_tag_v<storage2::UNTRACKED_READ_TYPE, decltype(tags)...>;
-        if constexpr (!untracked)
+        constexpr bool bypassSet =
+            storage2::contains_tag_v<storage2::BYPASS_READ_SET_TYPE, decltype(tags)...>;
+        if constexpr (!bypassSet)
         {
             putSet(false, key);
         }

--- a/transaction-scheduler/tests/FIB100_FIB106_ReadWriteSetTest.cpp
+++ b/transaction-scheduler/tests/FIB100_FIB106_ReadWriteSetTest.cpp
@@ -28,7 +28,7 @@ using namespace bcos;
 using namespace bcos::storage2;
 using namespace bcos::scheduler_v1;
 
-// ---- Mock storage that supports DIRECT reads (used for FIB-100 tracking tests) ----
+// ---- Mock storage that supports untracked reads (used for FIB-100 tracking tests) ----
 // ReadWriteSetStorage forwards readSomeRaw/readOneRaw via direct member access,
 // so the wrapped backend must expose those (matching MemoryStorage's interface).
 struct DirectMockStorage
@@ -68,7 +68,7 @@ task::Task<std::optional<int>> tag_invoke(
 }
 
 task::Task<std::optional<int>> tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/,
-    DirectMockStorage& /*storage*/, const auto& key, storage2::DIRECT_TYPE /*unused*/)
+    DirectMockStorage& /*storage*/, const auto& key, storage2::untracked_read_t /*unused*/)
 {
     co_return std::make_optional(key * 10);
 }
@@ -87,7 +87,7 @@ task::Task<std::vector<std::optional<int>>> tag_invoke(
 
 task::Task<std::vector<std::optional<int>>> tag_invoke(
     storage2::tag_t<storage2::readSome> /*unused*/, DirectMockStorage& /*storage*/,
-    ::ranges::forward_range auto keys, storage2::DIRECT_TYPE /*unused*/)
+    ::ranges::forward_range auto keys, storage2::untracked_read_t /*unused*/)
 {
     std::vector<std::optional<int>> result;
     for (auto&& key : keys)
@@ -101,35 +101,35 @@ BOOST_AUTO_TEST_SUITE(FIB100_FIB106_ReadWriteSetTest)
 
 // ---- FIB-100 ----
 
-// DIRECT reads are Rollbackable's internal pre-image snapshots. Tracking them
+// untracked reads are Rollbackable's internal pre-image snapshots. Tracking them
 // as transaction-visible reads would create phantom RAW dependencies. The
 // rollback-correctness concern raised by the audit is addressed instead by
 // WAW detection (see wawIntersectionDetected below): two chunks writing the
 // same key are serialized, so Rollbackable never reads a stale pre-image.
-BOOST_AUTO_TEST_CASE(directReadOneDoesNotPolluteReadSet)
+BOOST_AUTO_TEST_CASE(untrackedReadOneDoesNotPolluteReadSet)
 {
     task::syncWait([]() -> task::Task<void> {
         DirectMockStorage backend;
         ReadWriteSetStorage<decltype(backend)> reader(backend);
 
-        auto value = co_await storage2::readOne(reader, 42, storage2::DIRECT);
+        auto value = co_await storage2::readOne(reader, 42, storage2::untracked_read);
         BOOST_REQUIRE(value);
         BOOST_CHECK_EQUAL(*value, 420);
 
-        // Read set must remain empty — DIRECT is infrastructure, not business.
+        // Read set must remain empty — untracked is infrastructure, not business.
         BOOST_CHECK(::ranges::empty(readWriteSet(reader)));
         co_return;
     }());
 }
 
-BOOST_AUTO_TEST_CASE(directReadSomeDoesNotPolluteReadSet)
+BOOST_AUTO_TEST_CASE(untrackedReadSomeDoesNotPolluteReadSet)
 {
     task::syncWait([]() -> task::Task<void> {
         DirectMockStorage backend;
         ReadWriteSetStorage<decltype(backend)> reader(backend);
 
         std::vector<int> keys = {3, 5, 7};
-        auto values = co_await storage2::readSome(reader, keys, storage2::DIRECT);
+        auto values = co_await storage2::readSome(reader, keys, storage2::untracked_read);
         BOOST_REQUIRE_EQUAL(values.size(), 3);
         BOOST_CHECK_EQUAL(*values[0], 30);
         BOOST_CHECK_EQUAL(*values[1], 50);
@@ -140,8 +140,8 @@ BOOST_AUTO_TEST_CASE(directReadSomeDoesNotPolluteReadSet)
     }());
 }
 
-// Rollbackable<ReadWriteSetStorage<...>>.writeOne internally does a
-// DIRECT readOne to capture the pre-image. That read must not appear in the
+// Rollbackable<ReadWriteSetStorage<...>>.writeOne internally does an
+// untracked readOne to capture the pre-image. That read must not appear in the
 // tracked set — only the subsequent write should.
 BOOST_AUTO_TEST_CASE(rollbackablePreImageReadIsNotTracked)
 {
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(rollbackablePreImageReadIsNotTracked)
         co_await storage2::writeOne(rollbackable, 42, 7);
 
         // Exactly one entry, and it is a write (not a read inflated by the
-        // DIRECT pre-image snapshot).
+        // untracked pre-image snapshot).
         auto const& tracked = readWriteSet(rwStorage);
         BOOST_REQUIRE_EQUAL(tracked.size(), 1);
         auto const& flag = tracked.at(std::hash<int>{}(42));

--- a/transaction-scheduler/tests/FIB100_FIB106_ReadWriteSetTest.cpp
+++ b/transaction-scheduler/tests/FIB100_FIB106_ReadWriteSetTest.cpp
@@ -68,7 +68,7 @@ task::Task<std::optional<int>> tag_invoke(
 }
 
 task::Task<std::optional<int>> tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/,
-    DirectMockStorage& /*storage*/, const auto& key, storage2::UNTRACKED_READ_TYPE /*unused*/)
+    DirectMockStorage& /*storage*/, const auto& key, storage2::BYPASS_READ_SET_TYPE /*unused*/)
 {
     co_return std::make_optional(key * 10);
 }
@@ -87,7 +87,7 @@ task::Task<std::vector<std::optional<int>>> tag_invoke(
 
 task::Task<std::vector<std::optional<int>>> tag_invoke(
     storage2::tag_t<storage2::readSome> /*unused*/, DirectMockStorage& /*storage*/,
-    ::ranges::forward_range auto keys, storage2::UNTRACKED_READ_TYPE /*unused*/)
+    ::ranges::forward_range auto keys, storage2::BYPASS_READ_SET_TYPE /*unused*/)
 {
     std::vector<std::optional<int>> result;
     for (auto&& key : keys)
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_SUITE(FIB100_FIB106_ReadWriteSetTest)
 
 // ---- FIB-100 ----
 
-// untracked reads are Rollbackable's internal pre-image snapshots. Tracking them
+// bypass-read-set reads are Rollbackable's internal pre-image snapshots. Tracking them
 // as transaction-visible reads would create phantom RAW dependencies. The
 // rollback-correctness concern raised by the audit is addressed instead by
 // WAW detection (see wawIntersectionDetected below): two chunks writing the
@@ -112,11 +112,11 @@ BOOST_AUTO_TEST_CASE(untrackedReadOneDoesNotPolluteReadSet)
         DirectMockStorage backend;
         ReadWriteSetStorage<decltype(backend)> reader(backend);
 
-        auto value = co_await storage2::readOne(reader, 42, storage2::UNTRACKED_READ);
+        auto value = co_await storage2::readOne(reader, 42, storage2::BYPASS_READ_SET);
         BOOST_REQUIRE(value);
         BOOST_CHECK_EQUAL(*value, 420);
 
-        // Read set must remain empty — untracked is infrastructure, not business.
+        // Read set must remain empty — bypass-read-set is infrastructure, not business.
         BOOST_CHECK(::ranges::empty(readWriteSet(reader)));
         co_return;
     }());
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(untrackedReadSomeDoesNotPolluteReadSet)
         ReadWriteSetStorage<decltype(backend)> reader(backend);
 
         std::vector<int> keys = {3, 5, 7};
-        auto values = co_await storage2::readSome(reader, keys, storage2::UNTRACKED_READ);
+        auto values = co_await storage2::readSome(reader, keys, storage2::BYPASS_READ_SET);
         BOOST_REQUIRE_EQUAL(values.size(), 3);
         BOOST_CHECK_EQUAL(*values[0], 30);
         BOOST_CHECK_EQUAL(*values[1], 50);

--- a/transaction-scheduler/tests/FIB100_FIB106_ReadWriteSetTest.cpp
+++ b/transaction-scheduler/tests/FIB100_FIB106_ReadWriteSetTest.cpp
@@ -68,7 +68,7 @@ task::Task<std::optional<int>> tag_invoke(
 }
 
 task::Task<std::optional<int>> tag_invoke(storage2::tag_t<storage2::readOne> /*unused*/,
-    DirectMockStorage& /*storage*/, const auto& key, storage2::untracked_read_t /*unused*/)
+    DirectMockStorage& /*storage*/, const auto& key, storage2::UNTRACKED_READ_TYPE /*unused*/)
 {
     co_return std::make_optional(key * 10);
 }
@@ -87,7 +87,7 @@ task::Task<std::vector<std::optional<int>>> tag_invoke(
 
 task::Task<std::vector<std::optional<int>>> tag_invoke(
     storage2::tag_t<storage2::readSome> /*unused*/, DirectMockStorage& /*storage*/,
-    ::ranges::forward_range auto keys, storage2::untracked_read_t /*unused*/)
+    ::ranges::forward_range auto keys, storage2::UNTRACKED_READ_TYPE /*unused*/)
 {
     std::vector<std::optional<int>> result;
     for (auto&& key : keys)
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(untrackedReadOneDoesNotPolluteReadSet)
         DirectMockStorage backend;
         ReadWriteSetStorage<decltype(backend)> reader(backend);
 
-        auto value = co_await storage2::readOne(reader, 42, storage2::untracked_read);
+        auto value = co_await storage2::readOne(reader, 42, storage2::UNTRACKED_READ);
         BOOST_REQUIRE(value);
         BOOST_CHECK_EQUAL(*value, 420);
 
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(untrackedReadSomeDoesNotPolluteReadSet)
         ReadWriteSetStorage<decltype(backend)> reader(backend);
 
         std::vector<int> keys = {3, 5, 7};
-        auto values = co_await storage2::readSome(reader, keys, storage2::untracked_read);
+        auto values = co_await storage2::readSome(reader, keys, storage2::UNTRACKED_READ);
         BOOST_REQUIRE_EQUAL(values.size(), 3);
         BOOST_CHECK_EQUAL(*values[0], 30);
         BOOST_CHECK_EQUAL(*values[1], 50);

--- a/transaction-scheduler/tests/testMultiLayerStorage.cpp
+++ b/transaction-scheduler/tests/testMultiLayerStorage.cpp
@@ -233,4 +233,182 @@ BOOST_AUTO_TEST_CASE(deletedEntry)
     }());
 }
 
+// BYPASS_MULTILAYER: readOneRaw stops at the first layer that exists and
+// returns NOT_EXISTS without falling through. The untagged overload walks
+// the full chain (mutable → immutable → cache → backend) and only returns
+// NOT_EXISTS when no layer holds the key.
+BOOST_AUTO_TEST_CASE(bypassMultiLayerReadOneRaw)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        // Pre-populate the backend with a key
+        StateKey backendKey{"test_table"sv, "backend_key"sv};
+        storage::Entry backendEntry;
+        backendEntry.set("backend_value");
+        co_await storage2::writeOne(backendStorage, backendKey, backendEntry);
+
+        // Fork a view with a mutable layer holding a different key
+        auto view = multiLayerStorage.fork();
+        view.newMutable();
+        StateKey mutableKey{"test_table"sv, "mutable_key"sv};
+        storage::Entry mutableEntry;
+        mutableEntry.set("mutable_value");
+        co_await storage2::writeOne(view, mutableKey, mutableEntry);
+
+        // Both paths agree on a key present in the mutable layer
+        auto mutableByBypass =
+            co_await view.readOneRaw(mutableKey, storage2::BYPASS_MULTILAYER);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(mutableByBypass));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(mutableByBypass).get(), "mutable_value"sv);
+
+        auto mutableByNormal = co_await view.readOneRaw(mutableKey);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(mutableByNormal));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(mutableByNormal).get(), "mutable_value"sv);
+
+        // Divergence on a key that only exists in the backend:
+        // BYPASS_MULTILAYER → NOT_EXISTS (stops at mutable, unconditional co_return)
+        auto backendByBypass =
+            co_await view.readOneRaw(backendKey, storage2::BYPASS_MULTILAYER);
+        BOOST_CHECK(std::holds_alternative<storage2::NOT_EXISTS_TYPE>(backendByBypass));
+
+        // No tag → falls through the full chain, reaches backend
+        auto backendByNormal = co_await view.readOneRaw(backendKey);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(backendByNormal));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(backendByNormal).get(), "backend_value"sv);
+
+        co_return;
+    }());
+}
+
+// Same layer-resolution test for the batch path (readSomeRaw).
+BOOST_AUTO_TEST_CASE(bypassMultiLayerReadSomeRaw)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        StateKey backendKey{"test_table"sv, "backend_key"sv};
+        storage::Entry backendEntry;
+        backendEntry.set("backend_value");
+        co_await storage2::writeOne(backendStorage, backendKey, backendEntry);
+
+        auto view = multiLayerStorage.fork();
+        view.newMutable();
+        StateKey mutableKey{"test_table"sv, "mutable_key"sv};
+        storage::Entry mutableEntry;
+        mutableEntry.set("mutable_value");
+        co_await storage2::writeOne(view, mutableKey, mutableEntry);
+
+        // BYPASS_MULTILAYER: backend-only key → NOT_EXISTS
+        auto bypassValues = co_await view.readSomeRaw(
+            std::vector{mutableKey, backendKey}, storage2::BYPASS_MULTILAYER);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(bypassValues[0]));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(bypassValues[0]).get(), "mutable_value"sv);
+        BOOST_CHECK(
+            std::holds_alternative<storage2::NOT_EXISTS_TYPE>(bypassValues[1]));
+
+        // No tag: backend-only key → resolved from backend
+        auto normalValues =
+            co_await view.readSomeRaw(std::vector{mutableKey, backendKey});
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(normalValues[0]));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(normalValues[0]).get(), "mutable_value"sv);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(normalValues[1]));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(normalValues[1]).get(), "backend_value"sv);
+
+        co_return;
+    }());
+}
+
+// BYPASS_READ_SET composed with BYPASS_MULTILAYER: the two tags travel
+// together and each layer picks the one it cares about.
+BOOST_AUTO_TEST_CASE(composedTagsReadOneRaw)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        StateKey backendKey{"test_table"sv, "backend_key"sv};
+        storage::Entry backendEntry;
+        backendEntry.set("backend_value");
+        co_await storage2::writeOne(backendStorage, backendKey, backendEntry);
+
+        auto view = multiLayerStorage.fork();
+        view.newMutable();
+
+        // Both tags together: BYPASS_MULTILAYER determines layer resolution
+        // (topmost-only), BYPASS_READ_SET is irrelevant to this View but
+        // forwarded to lower layers.
+        auto result = co_await view.readOneRaw(
+            backendKey, storage2::BYPASS_READ_SET, storage2::BYPASS_MULTILAYER);
+        BOOST_CHECK(std::holds_alternative<storage2::NOT_EXISTS_TYPE>(result));
+
+        co_return;
+    }());
+}
+
+// Regression: Rollbackable pre-image capture through MultiLayerStorage.
+//
+// Rollbackable::storeOldValues / writeOne capture the pre-image of a key
+// before writing, so rollback can restore the old value.  On base the read
+// used DIRECT (= topmost-layer-only): a key whose value exists only in the
+// backend (from an earlier block) and is first-written inside the current
+// mutable layer captures NOT_EXISTS.  Rollback then erases the key from
+// the mutable layer → the key does NOT appear in the block delta.
+//
+// Without BYPASS_MULTILAYER the pre-image resolves via the full layer
+// chain and captures the backend value.  Rollback writes that value back
+// → a same-value row appears in the block delta → XOR state root changes.
+// The trigger is any tx with a reverted frame touching a pre-existing slot.
+//
+// This test asserts that BYPASS_READ_SET | BYPASS_MULTILAYER delivers
+// NOT_EXISTS (the old DIRECT behaviour), while the untagged overload
+// resolves through the full chain — so the divergence is visible and the
+// tag composition works as designed.
+BOOST_AUTO_TEST_CASE(preImageCaptureBypassMultiLayerRegression)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        // Simulate a key that exists in the backend from a previous block
+        StateKey key{"test_table"sv, "preimage_key"sv};
+        storage::Entry backendEntry;
+        backendEntry.set("value_from_previous_block");
+        co_await storage2::writeOne(backendStorage, key, backendEntry);
+
+        // Fork a new view with a mutable layer (new transaction frame).
+        // The key has NOT been written in this frame yet.
+        auto view = multiLayerStorage.fork();
+        view.newMutable();
+
+        // Pre-image capture with BYPASS_READ_SET | BYPASS_MULTILAYER:
+        // BYPASS_MULTILAYER → stops at mutable layer → NOT_EXISTS.
+        // This is the old DIRECT behaviour and must NOT change.
+        auto bypassResult = co_await view.readOneRaw(
+            key, storage2::BYPASS_READ_SET, storage2::BYPASS_MULTILAYER);
+        BOOST_CHECK(
+            std::holds_alternative<storage2::NOT_EXISTS_TYPE>(bypassResult));
+
+        // Untagged read: walks the full chain → reaches the backend.
+        auto normalResult = co_await view.readOneRaw(key);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(normalResult));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(normalResult).get(),
+            "value_from_previous_block"sv);
+
+        // Verify the batch path as well (storeOldValues uses readSomeRaw)
+        auto bypassBatch = co_await view.readSomeRaw(
+            std::vector{key}, storage2::BYPASS_READ_SET,
+            storage2::BYPASS_MULTILAYER);
+        BOOST_CHECK_EQUAL(bypassBatch.size(), 1u);
+        BOOST_CHECK(std::holds_alternative<storage2::NOT_EXISTS_TYPE>(
+            bypassBatch[0]));
+
+        auto normalBatch = co_await view.readSomeRaw(std::vector{key});
+        BOOST_CHECK_EQUAL(normalBatch.size(), 1u);
+        BOOST_CHECK(std::holds_alternative<storage::Entry>(normalBatch[0]));
+        BOOST_CHECK_EQUAL(
+            std::get<storage::Entry>(normalBatch[0]).get(),
+            "value_from_previous_block"sv);
+
+        co_return;
+    }());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/transaction-scheduler/tests/testReadWriteSetStorage.cpp
+++ b/transaction-scheduler/tests/testReadWriteSetStorage.cpp
@@ -93,19 +93,19 @@ struct MockStorage
         co_return std::nullopt;
     }
 
-    auto readOne(auto&& key, storage2::DIRECT_TYPE direct) -> task::Task<std::optional<int>>
+    auto readOne(auto&& key, storage2::untracked_read_t untracked) -> task::Task<std::optional<int>>
     {
         co_return std::make_optional(100);
     }
 };
 
-BOOST_AUTO_TEST_CASE(directFlag)
+BOOST_AUTO_TEST_CASE(untrackedReadFlag)
 {
     task::syncWait([]() -> task::Task<void> {
         MockStorage lhsStorage;
         ReadWriteSetStorage<decltype(lhsStorage)> firstStorage(lhsStorage);
 
-        auto value = co_await firstStorage.readOneRaw(100, storage2::DIRECT);
+        auto value = co_await firstStorage.readOneRaw(100, storage2::untracked_read);
         BOOST_CHECK_EQUAL(std::get<int>(value), 100);
     }());
 }

--- a/transaction-scheduler/tests/testReadWriteSetStorage.cpp
+++ b/transaction-scheduler/tests/testReadWriteSetStorage.cpp
@@ -93,7 +93,7 @@ struct MockStorage
         co_return std::nullopt;
     }
 
-    auto readOne(auto&& key, storage2::untracked_read_t untracked) -> task::Task<std::optional<int>>
+    auto readOne(auto&& key, storage2::UNTRACKED_READ_TYPE untracked) -> task::Task<std::optional<int>>
     {
         co_return std::make_optional(100);
     }
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(untrackedReadFlag)
         MockStorage lhsStorage;
         ReadWriteSetStorage<decltype(lhsStorage)> firstStorage(lhsStorage);
 
-        auto value = co_await firstStorage.readOneRaw(100, storage2::untracked_read);
+        auto value = co_await firstStorage.readOneRaw(100, storage2::UNTRACKED_READ);
         BOOST_CHECK_EQUAL(std::get<int>(value), 100);
     }());
 }

--- a/transaction-scheduler/tests/testReadWriteSetStorage.cpp
+++ b/transaction-scheduler/tests/testReadWriteSetStorage.cpp
@@ -93,7 +93,7 @@ struct MockStorage
         co_return std::nullopt;
     }
 
-    auto readOne(auto&& key, storage2::UNTRACKED_READ_TYPE untracked) -> task::Task<std::optional<int>>
+    auto readOne(auto&& key, storage2::BYPASS_READ_SET_TYPE untracked) -> task::Task<std::optional<int>>
     {
         co_return std::make_optional(100);
     }
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(untrackedReadFlag)
         MockStorage lhsStorage;
         ReadWriteSetStorage<decltype(lhsStorage)> firstStorage(lhsStorage);
 
-        auto value = co_await firstStorage.readOneRaw(100, storage2::UNTRACKED_READ);
+        auto value = co_await firstStorage.readOneRaw(100, storage2::BYPASS_READ_SET);
         BOOST_CHECK_EQUAL(std::get<int>(value), 100);
     }());
 }


### PR DESCRIPTION
## 概述

将 storage2 接口中语义模糊的单一 `DIRECT` 标签拆分为两个语义明确的行为标签，消除因同一标签在不同存储层含义不同而导致的混淆和误用。

## 问题

`DIRECT` 标签在代码库中承载了三种不同的语义：

| 位置 | 语义 | 
|------|------|
| `MemoryStorage::removeOne/removeSome` | 绕过逻辑删除，物理擦除 |
| `ReadWriteSetStorage::readOne/readSome` | 绕过读集跟踪，避免虚假 DAG 冲突边 |
| `MultiLayerStorage::readOneRaw/readSomeRaw` | 绕过中间缓存层，直读后端 |

同一调用点（如 `RollbackableStorage::storeOldValues()` 的预镜像捕获）同时需要多种语义，但 `DIRECT` 无法区分，各层各自解读，容易出错。

## 方案

替换为两个命名明确的 tag：

- **`BYPASS_LOGICAL_DELETE_TYPE`** / **`BYPASS_LOGICAL_DELETE`** — 物理删除，不保留 `deleteItem` 哨兵
- **`UNTRACKED_READ_TYPE`** / **`UNTRACKED_READ`** — 绕过读集跟踪，不注册到并行调度器的冲突集

### 设计特性

- **多 tag 同时传递**：函数使用 `auto... tags` 参数包，调用方可以同时传入多个 tag
- **顺序无关**：通过 `contains_tag_v<Tag, Tags...>` fold expression 检查，不依赖参数位置
- **按需忽略**：每个函数只 `if constexpr` 检查自己关心的 tag，无关 tag 直接透传到底层

### 使用示例

```cpp
// 回滚时：物理删除
co_await storage2::removeOne(storage, key, storage2::BYPASS_LOGICAL_DELETE);

// 预镜像捕获：不跟踪读集
co_await storage.readSomeRaw(keyList, storage2::UNTRACKED_READ);

// 同时传递两个 tag（顺序无关）：
co_await storage2::readOne(storage, key,
    storage2::UNTRACKED_READ, storage2::BYPASS_LOGICAL_DELETE);
```

## 变更文件

共 14 个文件，151 行新增，96 行删除（净增 55 行，主要来自 `MultiLayerStorage` 的 tag 分支逻辑）。