### PR TITLE
Fix deadlock and exception swallowing in MessagePromiseSwapper

### DIFF
--- a/bcos-executor/src/executive/PromiseTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/PromiseTransactionExecutive.cpp
@@ -46,17 +46,27 @@ void MessagePromiseSwapper::spawnAndCall(std::function<CallParameters::UniquePtr
     // A std::async future would join on destruction and deadlock waiting
     // for the still-blocked thread — the nested promise is only fulfilled
     // by a future resume() that requires this spawnAndCall to return first.
-    std::thread([this, lastPromise, currentPromise,
+    // The lambda MUST read m_currentPromise (the member) at completion
+    // time, NOT a frozen snapshot.  Under the serialized ping-pong
+    // protocol the member has been advanced by nested spawnAndCall /
+    // resume() calls while execute() was in-flight, and the last
+    // completer must deliver to the latest promise.
+    //
+    // Data-race safety: every m_currentPromise write in a subsequent
+    // spawnAndCall happens-before this thread's wake-up via the
+    // thread-creation + promise set_value/get chain; the scheduler is
+    // always blocked in get() when this thread's completion runs.
+    std::thread([this, lastPromise,
                     spawnCall = std::move(spawnCall)]() mutable {
         try
         {
             auto message = spawnCall();
-            auto promise = lastPromise ? lastPromise : currentPromise;
+            auto promise = lastPromise ? lastPromise : m_currentPromise;
             promise->set_value(std::move(message));
         }
         catch (...)
         {
-            auto promise = lastPromise ? lastPromise : currentPromise;
+            auto promise = lastPromise ? lastPromise : m_currentPromise;
             promise->set_exception(std::current_exception());
         }
     }).detach();

--- a/bcos-executor/src/executive/PromiseTransactionExecutive.cpp
+++ b/bcos-executor/src/executive/PromiseTransactionExecutive.cpp
@@ -1,6 +1,7 @@
 #include "PromiseTransactionExecutive.h"
 #include "bcos-framework/executor/ExecuteError.h"
 #include <future>
+#include <thread>
 
 using namespace bcos::executor;
 
@@ -12,11 +13,18 @@ using namespace bcos::executor;
 // (e.g. inside tbb::flow::graph::wait_for_all or during DMC-resume
 // processing), the posted work could never be picked up → deadlock.
 //
-// We use std::async(std::launch::async, ...) to launch a dedicated thread
-// on demand.  Threads are created only when PromiseTransactionExecutive is
-// actually invoked (infrequent — TiKV storage + sharding path only), and
-// they exit immediately after the task completes, avoiding persistent
-// resource consumption.
+// We use std::thread(...).detach() to launch a dedicated on-demand thread
+// in fire-and-forget fashion.  std::async is deliberately NOT used here
+// because its returned std::future joins on destruction, which would
+// deadlock when spawnCall internally blocks on a nested spawnAndCall
+// (cross-shard DMC externalCall) — the inner promise is only fulfilled by
+// a later resume(), which cannot happen until the outer spawnAndCall
+// returns, but the outer future's destructor would be waiting to join the
+// still-blocked worker thread.
+//
+// Threads are created only when PromiseTransactionExecutive is actually
+// invoked (TiKV storage + sharding path only) and exit after the task
+// completes, avoiding persistent resource consumption.
 // ---------------------------------------------------------------------------
 
 MessagePromiseSwapper::MessagePromiseSwapper(IOServicePool::Ptr /*_pool*/) {}
@@ -26,23 +34,35 @@ void MessagePromiseSwapper::spawnAndCall(std::function<CallParameters::UniquePtr
 {
     auto lastPromise = m_currentPromise;
     m_currentPromise = std::make_shared<std::promise<CallParameters::UniquePtr>>();
+    auto currentPromise = m_currentPromise;
 
     // Launch work on a DEDICATED on-demand thread, never on the main
     // IOServicePool.  This breaks the cross-dependency that would otherwise
     // deadlock on low-core-count systems.
-    // The returned future is stored so that its destructor (which joins the
-    // thread) runs after the promise below has been fulfilled, ensuring the
-    // async thread is always joined before spawnAndCall returns.
-    auto asyncFuture = std::async(std::launch::async, [this, lastPromise,
-                                     spawnCall = std::move(spawnCall)]() mutable {
-        auto message = spawnCall();
-        auto promise = lastPromise ? lastPromise : m_currentPromise;
-        promise->set_value(std::move(message));
-    });
+    //
+    // IMPORTANT: std::thread(...).detach() is used instead of std::async
+    // because the spawned task may internally call spawnAndCall again
+    // (cross-shard DMC externalCall) and block on the nested promise.
+    // A std::async future would join on destruction and deadlock waiting
+    // for the still-blocked thread — the nested promise is only fulfilled
+    // by a future resume() that requires this spawnAndCall to return first.
+    std::thread([this, lastPromise, currentPromise,
+                    spawnCall = std::move(spawnCall)]() mutable {
+        try
+        {
+            auto message = spawnCall();
+            auto promise = lastPromise ? lastPromise : currentPromise;
+            promise->set_value(std::move(message));
+        }
+        catch (...)
+        {
+            auto promise = lastPromise ? lastPromise : currentPromise;
+            promise->set_exception(std::current_exception());
+        }
+    }).detach();
 
-    auto message = m_currentPromise->get_future().get();
+    auto message = currentPromise->get_future().get();
     waitAndDo(std::move(message));
-    // asyncFuture destructor joins the async thread here (already finished)
 }
 
 PromiseTransactionExecutive::PromiseTransactionExecutive(IOServicePool::Ptr pool,

--- a/bcos-executor/src/executive/PromiseTransactionExecutive.h
+++ b/bcos-executor/src/executive/PromiseTransactionExecutive.h
@@ -53,7 +53,6 @@ public:
         std::function<void(CallParameters::UniquePtr)> waitAndDo);
 
 private:
-    std::shared_ptr<std::promise<CallParameters::UniquePtr>> m_lastPromise;
     std::shared_ptr<std::promise<CallParameters::UniquePtr>> m_currentPromise;
 };
 

--- a/bcos-executor/src/executive/PromiseTransactionExecutive.h
+++ b/bcos-executor/src/executive/PromiseTransactionExecutive.h
@@ -24,17 +24,13 @@
 #include "CoroutineTransactionExecutive.h"
 #include "SyncStorageWrapper.h"
 #include "TransactionExecutive.h"
+#include "bcos-utilities/IOServicePool.h"
 #include <boost/coroutine2/coroutine.hpp>
 #include <memory>
 #include <thread>
 
 namespace bcos
 {
-// Forward declaration — the actual header (bcos-utilities/IOServicePool.h) is
-// only needed in the .cpp file.  The constructor parameter is kept for
-// backward compatibility but is no longer used (the swapper now owns its
-// dedicated background thread pool).
-class IOServicePool;
 
 namespace executor
 {
@@ -44,12 +40,13 @@ public:
     using Ptr = std::shared_ptr<MessagePromiseSwapper>;
 
     /// Construct a MessagePromiseSwapper.
-    /// @param _pool  DEPRECATED — no longer used.  The swapper now uses its own
-    ///               dedicated background thread pool, independent of the main
-    ///               IOServicePool, to avoid thread-pool exhaustion deadlocks
-    ///               on low-core-count systems (≤ 3 cores) where the DAG
-    ///               wait_for_all and DMC resume paths could otherwise starve
-    ///               the shared pool.
+    /// @param _pool  DEPRECATED — no longer used.  The swapper now spawns
+    ///               dedicated fire-and-forget threads on demand (via
+    ///               std::thread::detach) instead of posting work to the
+    ///               shared IOServicePool, to avoid thread-pool exhaustion
+    ///               deadlocks on low-core-count systems (≤ 3 cores) where
+    ///               the DAG wait_for_all and DMC resume paths could
+    ///               otherwise starve the shared pool.
     MessagePromiseSwapper(IOServicePool::Ptr _pool = nullptr);
 
     void spawnAndCall(std::function<CallParameters::UniquePtr()> spawnCall,


### PR DESCRIPTION
## 概述

修复 commit `7ef47bbc`（"Fix dag and shared blocking"）中引入的三个问题。

## 问题与修复

### 🚨 Critical: `std::async` 析构 join 导致协议死锁

`MessagePromiseSwapper::spawnAndCall()` 中 `std::async(std::launch::async)` 返回的 `std::future` 在析构时会阻塞 join worker 线程。跨分片 DMC `externalCall` 场景下：

1. `start()` → 外层 `spawnAndCall` → worker 线程 T1 运行 `execute()` → 内层 `externalCall()` → 内层 `spawnAndCall` → T1 阻塞在嵌套 promise 上等待 `resume()`
2. 内层 async lambda（T2）履行的却是**外层**的 promise，外层 `spawnAndCall` 的 `get()` 返回
3. 外层 `asyncFuture` 析构尝试 join T1，但 T1 仍阻塞在只有后续 `resume()` 才能履行的嵌套 promise 上
4. `resume()` 需要 `start()` 先返回 → **永久死锁**

**修复**: 将 `std::async` 替换为 `std::thread(...).detach()`，恢复发后即忘语义（与旧 `m_pool->post` 行为一致）。

### 🚨 Medium: 异常被静默吞没

若 `spawnCall()`（即 `execute()`）在 `promise->set_value` 前抛出异常，promise 永不兑现，异常被存入无人读取的 discarded future，父线程在 `get()` 上无限静默阻塞。

**修复**: worker lambda 中添加 `try/catch(...)`，通过 `promise->set_exception(std::current_exception())` 传播异常。

### 📝 Low: 注释与头文件问题

- 注释写"专用后台线程池"但实际上每次调用创建一根新线程（`detach`），已修正为准确描述
- 头文件中用前置声明 `class IOServicePool;` 替代 `#include`（实际可达性依赖传递 include 链），已恢复为可靠的 `#include "bcos-utilities/IOServicePool.h"`

## 修改文件

- `bcos-executor/src/executive/PromiseTransactionExecutive.h` — 恢复头文件 include，修正注释
- `bcos-executor/src/executive/PromiseTransactionExecutive.cpp` — `std::async` → `std::thread::detach`，添加异常处理