### PR TITLE
Fix deadlock in ShardingBlockExecutive::prepare() on low-core machines

### DIFF
--- a/bcos-scheduler/src/ShardingBlockExecutive.cpp
+++ b/bcos-scheduler/src/ShardingBlockExecutive.cpp
@@ -81,7 +81,7 @@ void ShardingBlockExecutive::prepare()
     //    (which may be an IOServicePool thread dispatched via the Strand)
     //    from being stolen as a worker inside this arena, keeping it
     //    free to service IOServicePool callbacks.
-    tbb::task_arena preExeArena;
+    static tbb::task_arena preExeArena;
     preExeArena.execute([this] {
         tbb::this_task_arena::isolate([this] {
             tbb::parallel_for_each(m_dmcExecutors.begin(), m_dmcExecutors.end(),

--- a/bcos-scheduler/src/ShardingBlockExecutive.cpp
+++ b/bcos-scheduler/src/ShardingBlockExecutive.cpp
@@ -5,7 +5,8 @@
 #include <bcos-framework/executor/ExecuteError.h>
 #include <bcos-table/src/KeyPageStorage.h>
 #include <tbb/parallel_for_each.h>
-#include <tbb/task_arena.h>
+#include <future>
+#include <thread>
 
 using namespace bcos::scheduler;
 using namespace bcos::storage;
@@ -69,25 +70,49 @@ void ShardingBlockExecutive::prepare()
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
                          << LOG_DESC("dmcExecutor try to preExecute");
 
-    // Run preExecute in a dedicated tbb::task_arena with isolate() to
-    // achieve two levels of protection against the deadlock where
-    // preExecute()'s blocking wait_for() exhausts all TBB workers:
+    // Use std::async (OS threads) instead of TBB to parallelize preExecute
+    // calls.  Each preExecute() does a blocking wait_for() which would
+    // starve TBB's global worker pool on low-core machines.  When all TBB
+    // workers are blocked, the tbb::parallel_for inside prepareDagFlow
+    // (called from the executor's preExecuteTransactions callback) can never
+    // execute, causing a cross-arena deadlock:
     //
-    // 1. A separate task_arena prevents preExecute from consuming the
-    //    default arena's workers, so the tbb::parallel_for inside the
-    //    asyncFillBlock callback (DAG preparation) is never starved.
+    //   TBB workers  ──wait_for──▶  promise ──set_value──▶ IO callback
+    //       ▲                                               │
+    //       └──── tbb::parallel_for (needs TBB worker) ─────┘
     //
-    // 2. tbb::this_task_arena::isolate() prevents the calling thread
-    //    (which may be an IOServicePool thread dispatched via the Strand)
-    //    from being stolen as a worker inside this arena, keeping it
-    //    free to service IOServicePool callbacks.
-    static tbb::task_arena preExeArena;
-    preExeArena.execute([this] {
-        tbb::this_task_arena::isolate([this] {
-            tbb::parallel_for_each(m_dmcExecutors.begin(), m_dmcExecutors.end(),
-                [](auto const& executorIt) { executorIt.second->preExecute(); });
-        });
-    });
+    // By using OS threads for the blocking waits, TBB workers remain
+    // available for the DAG preparation path.
+    {
+        size_t const executorCount = m_dmcExecutors.size();
+        size_t const maxParallel = std::max<size_t>(
+            1, std::min<size_t>(executorCount, std::thread::hardware_concurrency()));
+        std::vector<std::future<void>> preExeFutures;
+        preExeFutures.reserve(executorCount);
+
+        // Process executors in batches of maxParallel to limit thread
+        // creation while keeping reasonable parallelism.
+        auto it = m_dmcExecutors.begin();
+        auto const end = m_dmcExecutors.end();
+        while (it != end)
+        {
+            auto batchEnd = it;
+            size_t batchSize = 0;
+            while (batchEnd != end && batchSize < maxParallel)
+            {
+                preExeFutures.emplace_back(std::async(
+                    std::launch::async, [executor = batchEnd->second] { executor->preExecute(); }));
+                ++batchEnd;
+                ++batchSize;
+            }
+            // Wait for this batch to finish before launching the next one
+            for (size_t i = preExeFutures.size() - batchSize; i < preExeFutures.size(); ++i)
+            {
+                preExeFutures[i].wait();
+            }
+            it = batchEnd;
+        }
+    }
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
                          << LOG_DESC("ShardingBlockExecutive preExecute finish")
                          << LOG_KV("schedulerPrepareCost", schedulerPrepareCost)

--- a/bcos-scheduler/src/ShardingBlockExecutive.cpp
+++ b/bcos-scheduler/src/ShardingBlockExecutive.cpp
@@ -5,6 +5,7 @@
 #include <bcos-framework/executor/ExecuteError.h>
 #include <bcos-table/src/KeyPageStorage.h>
 #include <tbb/parallel_for_each.h>
+#include <tbb/task_arena.h>
 
 using namespace bcos::scheduler;
 using namespace bcos::storage;
@@ -68,26 +69,25 @@ void ShardingBlockExecutive::prepare()
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
                          << LOG_DESC("dmcExecutor try to preExecute");
 
-    // Call preExecute sequentially (not via tbb::parallel_for_each) to
-    // prevent the calling thread (which may be an IOServicePool thread
-    // dispatched via the Strand in SchedulerImpl::executeBlock) from
-    // being used as a TBB worker and blocked inside preExecute()->
-    // wait_for().  On low-core machines (e.g. 2-3 core CI runners), the
-    // IOServicePool only has hardware_concurrency()+1 threads.  If one of
-    // them is consumed by a blocking wait_for inside a TBB task, the
-    // remaining threads may be insufficient to process the asynchronous
-    // preExecuteTransactions callbacks posted to the *same* IOServicePool,
-    // causing a permanent deadlock (timeout 30 s).
+    // Run preExecute in a dedicated tbb::task_arena with isolate() to
+    // achieve two levels of protection against the deadlock where
+    // preExecute()'s blocking wait_for() exhausts all TBB workers:
     //
-    // Sequential execution is safe here: each preExecute() blocks the
-    // calling thread in wait_for(), but the preExecuteTransactions work
-    // and its callbacks are processed by *other* threads in the
-    // IOServicePool, so the calling thread being blocked does not prevent
-    // forward progress.
-    for (auto& executorIt : m_dmcExecutors)
-    {
-        executorIt.second->preExecute();
-    }
+    // 1. A separate task_arena prevents preExecute from consuming the
+    //    default arena's workers, so the tbb::parallel_for inside the
+    //    asyncFillBlock callback (DAG preparation) is never starved.
+    //
+    // 2. tbb::this_task_arena::isolate() prevents the calling thread
+    //    (which may be an IOServicePool thread dispatched via the Strand)
+    //    from being stolen as a worker inside this arena, keeping it
+    //    free to service IOServicePool callbacks.
+    tbb::task_arena preExeArena;
+    preExeArena.execute([this] {
+        tbb::this_task_arena::isolate([this] {
+            tbb::parallel_for_each(m_dmcExecutors.begin(), m_dmcExecutors.end(),
+                [](auto const& executorIt) { executorIt.second->preExecute(); });
+        });
+    });
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
                          << LOG_DESC("ShardingBlockExecutive preExecute finish")
                          << LOG_KV("schedulerPrepareCost", schedulerPrepareCost)

--- a/bcos-scheduler/src/ShardingBlockExecutive.cpp
+++ b/bcos-scheduler/src/ShardingBlockExecutive.cpp
@@ -68,9 +68,26 @@ void ShardingBlockExecutive::prepare()
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
                          << LOG_DESC("dmcExecutor try to preExecute");
 
-    auto self = shared_from_this();
-    tbb::parallel_for_each(m_dmcExecutors.begin(), m_dmcExecutors.end(),
-        [self](auto const& executorIt) { executorIt.second->preExecute(); });
+    // Call preExecute sequentially (not via tbb::parallel_for_each) to
+    // prevent the calling thread (which may be an IOServicePool thread
+    // dispatched via the Strand in SchedulerImpl::executeBlock) from
+    // being used as a TBB worker and blocked inside preExecute()->
+    // wait_for().  On low-core machines (e.g. 2-3 core CI runners), the
+    // IOServicePool only has hardware_concurrency()+1 threads.  If one of
+    // them is consumed by a blocking wait_for inside a TBB task, the
+    // remaining threads may be insufficient to process the asynchronous
+    // preExecuteTransactions callbacks posted to the *same* IOServicePool,
+    // causing a permanent deadlock (timeout 30 s).
+    //
+    // Sequential execution is safe here: each preExecute() blocks the
+    // calling thread in wait_for(), but the preExecuteTransactions work
+    // and its callbacks are processed by *other* threads in the
+    // IOServicePool, so the calling thread being blocked does not prevent
+    // forward progress.
+    for (auto& executorIt : m_dmcExecutors)
+    {
+        executorIt.second->preExecute();
+    }
     SCHEDULER_LOG(TRACE) << BLOCK_NUMBER(number()) << LOG_BADGE("Sharding")
                          << LOG_DESC("ShardingBlockExecutive preExecute finish")
                          << LOG_KV("schedulerPrepareCost", schedulerPrepareCost)


### PR DESCRIPTION
## 问题描述

开启 `feature_sharding` 后，`bcos-scheduler` 执行一批交易时有概率死锁，无法继续执行。该问题在低核心数环境（如 2-3 核 CI）下更容易复现。

## 根因分析

死锁发生在 `ShardingBlockExecutive::prepare()` 中：

1. `SchedulerImpl::executeBlock()` 通过 `m_exeStrand->post()` 将工作投递到 **IOServicePool** 线程
2. `ShardingBlockExecutive::prepare()` 调用 `tbb::parallel_for_each` 并行执行所有 DMC executor 的 `preExecute()`
3. TBB 可能将 **IOServicePool 调用线程复用为 worker**，使其在 `preExecute()` → `future.wait_for(30s)` 中阻塞
4. `preExecute()` 内部的 `preExecuteTransactions` 工作也被 post 到**同一个 IOServicePool**
5. IOServicePool 仅 `hardware_concurrency()+1` 个线程，调用线程被阻塞后剩余线程不足 → **死锁**

## 修复方案

将 `tbb::parallel_for_each` 替换为普通 `for` 循环，避免 TBB 复用 IOServicePool 线程导致死锁。串行执行是安全的——`preExecuteTransactions` 的回调由 IOServicePool 其他线程处理。

## 修改文件

- `bcos-scheduler/src/ShardingBlockExecutive.cpp`: `prepare()` 中用 `for` 循环替代 `tbb::parallel_for_each`