### PR TITLE
Refactor ExecuteContext: split executeStep template into prepare/execute/finish

### DIFF
--- a/bcos-framework/bcos-framework/transaction-executor/TransactionExecutor.h
+++ b/bcos-framework/bcos-framework/transaction-executor/TransactionExecutor.h
@@ -12,7 +12,8 @@ namespace bcos::executor_v1
 template <class TransactionExecutorType, class Storage>
 concept TransactionExecutor = requires(TransactionExecutorType& executor, Storage& storage,
     const protocol::BlockHeader& blockHeader, const protocol::Transaction& transaction,
-    int contextID, const ledger::LedgerConfig& ledgerConfig, bool call) {
+    int contextID, const ledger::LedgerConfig& ledgerConfig, bool call,
+    typename TransactionExecutorType::template ExecuteContext<Storage>& execCtx) {
     {
         executor.executeTransaction(
             storage, blockHeader, transaction, contextID, ledgerConfig, call)
@@ -27,6 +28,12 @@ concept TransactionExecutor = requires(TransactionExecutorType& executor, Storag
             storage, blockHeader, transaction, contextID, ledgerConfig, call)
     } -> task::IsAwaitableReturnValue<
         typename TransactionExecutorType::template ExecuteContext<Storage>>;
+
+    // ExecuteContext must expose three lifecycle methods: prepare, execute, finish
+    { execCtx.prepare() } -> task::IsAwaitableReturnValue<void>;
+    { execCtx.execute() } -> task::IsAwaitableReturnValue<void>;
+    { execCtx.finish() } -> task::IsAwaitableReturnValue<
+        bcos::protocol::TransactionReceipt::Ptr>;
 };
 
 }  // namespace bcos::executor_v1

--- a/bcos-utilities/bcos-utilities/ITTAPI.h
+++ b/bcos-utilities/bcos-utilities/ITTAPI.h
@@ -111,6 +111,7 @@ struct ITT_DOMAINS
     __itt_string_handle* EXECUTE_CHUNK1 = __itt_string_handle_create("executeChunk1");
     __itt_string_handle* EXECUTE_CHUNK2 = __itt_string_handle_create("executeChunk2");
     __itt_string_handle* EXECUTE_CHUNK3 = __itt_string_handle_create("executeChunk3");
+    __itt_string_handle* EXECUTE_CHUNK4 = __itt_string_handle_create("executeChunk4");
     __itt_string_handle* RELEASE_CONFLICT = __itt_string_handle_create("releaseConflict");
     __itt_string_handle* MERGE_RWSET = __itt_string_handle_create("mergeRWSet");
     __itt_string_handle* MERGE_CHUNK = __itt_string_handle_create("mergeChunk");

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -149,6 +149,9 @@ struct StubExecutor
     template <class Storage>
     struct ExecuteContext
     {
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return nullptr; }
     };
 
     template <class Storage>

--- a/tools/.ci/check-commit.sh
+++ b/tools/.ci/check-commit.sh
@@ -14,7 +14,7 @@ SHELL_FOLDER=$(
 check_script="clang-format"
 commit_limit=1000
 file_limit=35
-insert_limit=600
+insert_limit=300
 license_line=20
 
 skip_check_words="sync code|release"

--- a/tools/.ci/check-commit.sh
+++ b/tools/.ci/check-commit.sh
@@ -14,7 +14,7 @@ SHELL_FOLDER=$(
 check_script="clang-format"
 commit_limit=1000
 file_limit=35
-insert_limit=300
+insert_limit=600
 license_line=20
 
 skip_check_words="sync code|release"

--- a/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
+++ b/transaction-executor/bcos-transaction-executor/TransactionExecutorImpl.h
@@ -128,49 +128,36 @@ public:
                 executor, storage, blockHeader, transaction, contextID, ledgerConfig, call))
         {}
 
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
+        task::Task<void> prepare() { co_await m_data->m_hostContext.prepare(); }
+
+        task::Task<void> execute()
         {
-            if constexpr (step == 0)
+            auto updated = co_await updateNonce();
+            if (updated)
             {
-                co_await m_data->m_hostContext.prepare();
-            }
-            else if constexpr (step == 1)
-            {
-                auto updated = co_await updateNonce();
-                if (updated)
-                {
-                    m_data->m_startSavepoint = m_data->m_rollbackableStorage.current();
-                }
-
-                if (const auto gasPrice =
-                        u256{std::get<0>(m_data->m_ledgerConfig.get().gasPrice())};
-                    m_data->m_transaction.get().type() == 1 &&  // web3Tx
-                    m_data->m_ledgerConfig.get().features().get(
-                        ledger::Features::Flag::bugfix_gas_payment_balance_precheck) &&
-                    gasPrice > 0)
-                {
-                    // FIB-75 geth-style: buy gas (pre-deduct), execute, refund unused gas.
-                    if (!co_await buyGas())
-                    {
-                        co_return {};
-                    }
-                    m_data->m_evmcResult.emplace(co_await m_data->m_hostContext.execute());
-                    co_await refundGas();
-                }
-                else
-                {
-                    // Legacy path
-                    m_data->m_evmcResult.emplace(co_await m_data->m_hostContext.execute());
-                    co_await consumeBalance();
-                }
-            }
-            else if constexpr (step == 2)
-            {
-                co_return co_await finish();
+                m_data->m_startSavepoint = m_data->m_rollbackableStorage.current();
             }
 
-            co_return {};
+            if (const auto gasPrice = u256{std::get<0>(m_data->m_ledgerConfig.get().gasPrice())};
+                m_data->m_transaction.get().type() == 1 &&  // web3Tx
+                m_data->m_ledgerConfig.get().features().get(
+                    ledger::Features::Flag::bugfix_gas_payment_balance_precheck) &&
+                gasPrice > 0)
+            {
+                // FIB-75 geth-style: buy gas (pre-deduct), execute, refund unused gas.
+                if (!co_await buyGas())
+                {
+                    co_return;
+                }
+                m_data->m_evmcResult.emplace(co_await m_data->m_hostContext.execute());
+                co_await refundGas();
+            }
+            else
+            {
+                // Legacy path
+                m_data->m_evmcResult.emplace(co_await m_data->m_hostContext.execute());
+                co_await consumeBalance();
+            }
         }
 
         task::Task<bool> updateNonce()
@@ -453,9 +440,9 @@ public:
         auto executeContext = co_await createExecuteContext(
             storage, blockHeader, transaction, contextID, ledgerConfig, call);
 
-        co_await executeContext.template executeStep<0>();
-        co_await executeContext.template executeStep<1>();
-        co_return co_await executeContext.template executeStep<2>();
+        co_await executeContext.prepare();
+        co_await executeContext.execute();
+        co_return co_await executeContext.finish();
     }
 };
 

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -237,7 +237,7 @@ private:
         m_web3TypedTxKindForAccessList(web3TypedTxKind)
     {
         // W1 warm at top-level construction (sync). Nested HostContext (m_level>0) skips.
-        // prepare() handles prepareCall/Create only; see TransactionExecutorImpl executeStep<0>.
+        // prepare() handles prepareCall/Create only; see TransactionExecutorImpl prepare().
         warmEip2929AtTransactionEntry();
         assert(!executor::eip2929Enabled(m_revision, m_ledgerConfig.get()) || m_eip2929Access);
     }

--- a/transaction-executor/tests/TestTransactionExecutor.cpp
+++ b/transaction-executor/tests/TestTransactionExecutor.cpp
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(revertLogsClearedWithFeature)
         execCtx.m_data->m_evmcResult->status = bcos::protocol::TransactionStatus::RevertInstruction;
 
         // Finish and verify logs cleared
-        auto receipt = co_await execCtx.template executeStep<2>();
+        auto receipt = co_await execCtx.finish();
         BOOST_CHECK_NE(receipt->status(), 0);
         BOOST_CHECK(receipt->logEntries().empty());
     }());
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(revertLogsRemainWithoutFeature)
         execCtx.m_data->m_evmcResult->status = bcos::protocol::TransactionStatus::RevertInstruction;
 
         // Finish and verify logs remain (bugfix is off)
-        auto receipt = co_await execCtx.template executeStep<2>();
+        auto receipt = co_await execCtx.finish();
         BOOST_CHECK_NE(receipt->status(), 0);
         BOOST_CHECK(!receipt->logEntries().empty());
     }());

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -101,11 +101,7 @@ public:
             if (m_hasRAW.get().test())
             {
                 PARALLEL_SCHEDULER_LOG(DEBUG)
-<<<<<<< HEAD
-                    << "Chunk: " << m_chunkIndex << " aborted in createContexts, executed " << index
-=======
                     << "Chunk: " << m_chunkIndex << " aborted in prepare, executed " << index
->>>>>>> bb243a00fa42c0922cee8e17a74717c496784dae
                     << " transactions";
                 break;
             }
@@ -122,11 +118,7 @@ public:
             if (m_hasRAW.get().test())
             {
                 PARALLEL_SCHEDULER_LOG(DEBUG)
-<<<<<<< HEAD
-                    << "Chunk: " << m_chunkIndex << " aborted in prepare, executed " << index
-=======
                     << "Chunk: " << m_chunkIndex << " aborted in execute, executed " << index
->>>>>>> bb243a00fa42c0922cee8e17a74717c496784dae
                     << " transactions";
                 break;
             }

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -74,7 +74,7 @@ public:
     auto& storageView() & { return m_storageView; }
     auto& readWriteSetStorage() & { return m_readWriteSetStorage; }
 
-    task::Task<void> executeStep1(
+    task::Task<void> createContexts(
         const protocol::BlockHeader& blockHeader, const ledger::LedgerConfig& ledgerConfig)
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
@@ -92,7 +92,7 @@ public:
         }
     }
 
-    task::Task<void> executeStep2()
+    task::Task<void> prepare()
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
             ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK1);
@@ -101,7 +101,7 @@ public:
             if (m_hasRAW.get().test())
             {
                 PARALLEL_SCHEDULER_LOG(DEBUG)
-                    << "Chunk: " << m_chunkIndex << " aborted in step1, executed " << index
+                    << "Chunk: " << m_chunkIndex << " aborted in prepare, executed " << index
                     << " transactions";
                 break;
             }
@@ -109,7 +109,7 @@ public:
         }
     }
 
-    task::Task<void> executeStep3()
+    task::Task<void> execute()
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
             ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK2);
@@ -118,7 +118,7 @@ public:
             if (m_hasRAW.get().test())
             {
                 PARALLEL_SCHEDULER_LOG(DEBUG)
-                    << "Chunk: " << m_chunkIndex << " aborted in step2, executed " << index
+                    << "Chunk: " << m_chunkIndex << " aborted in execute, executed " << index
                     << " transactions";
                 break;
             }
@@ -126,7 +126,7 @@ public:
         }
     }
 
-    task::Task<void> executeStep4()
+    task::Task<void> finish()
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
             ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK3);
@@ -214,7 +214,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_2);
                         if (chunk && !hasRAW.test())
                         {
-                            task::tbb::syncWait(chunk->executeStep1(blockHeader, ledgerConfig));
+                            task::tbb::syncWait(chunk->createContexts(blockHeader, ledgerConfig));
                         }
 
                         return chunk;
@@ -226,7 +226,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_3);
                         if (chunk && !hasRAW.test())
                         {
-                            task::tbb::syncWait(chunk->executeStep2());
+                            task::tbb::syncWait(chunk->prepare());
                         }
 
                         return chunk;
@@ -238,7 +238,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_4);
                         if (chunk && !hasRAW.test())
                         {
-                            task::tbb::syncWait(chunk->executeStep3());
+                            task::tbb::syncWait(chunk->execute());
                         }
 
                         return chunk;
@@ -284,7 +284,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_6);
                         if (chunk)
                         {
-                            task::tbb::syncWait(chunk->executeStep4());
+                            task::tbb::syncWait(chunk->finish());
                         }
 
                         return chunk;

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -105,7 +105,7 @@ public:
                     << " transactions";
                 break;
             }
-            co_await executeContext.template executeStep<0>();
+            co_await executeContext.prepare();
         }
     }
 
@@ -122,7 +122,7 @@ public:
                     << " transactions";
                 break;
             }
-            co_await executeContext.template executeStep<1>();
+            co_await executeContext.execute();
         }
     }
 
@@ -132,7 +132,7 @@ public:
             ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK3);
         for (auto&& [context, executeContext] : ::ranges::views::zip(m_contexts, m_executeContexts))
         {
-            *context.receipt = co_await executeContext.template executeStep<2>();
+            *context.receipt = co_await executeContext.finish();
         }
     }
 };

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -74,11 +74,11 @@ public:
     auto& storageView() & { return m_storageView; }
     auto& readWriteSetStorage() & { return m_readWriteSetStorage; }
 
-    task::Task<void> executeStep1(
+    task::Task<void> createContexts(
         const protocol::BlockHeader& blockHeader, const ledger::LedgerConfig& ledgerConfig)
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
-            ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK3);
+            ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK4);
         m_executeContexts.reserve(::ranges::size(m_contexts));
         for (auto& context : m_contexts)
         {
@@ -92,7 +92,7 @@ public:
         }
     }
 
-    task::Task<void> executeStep2()
+    task::Task<void> prepare()
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
             ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK1);
@@ -101,7 +101,7 @@ public:
             if (m_hasRAW.get().test())
             {
                 PARALLEL_SCHEDULER_LOG(DEBUG)
-                    << "Chunk: " << m_chunkIndex << " aborted in step1, executed " << index
+                    << "Chunk: " << m_chunkIndex << " aborted in createContexts, executed " << index
                     << " transactions";
                 break;
             }
@@ -109,7 +109,7 @@ public:
         }
     }
 
-    task::Task<void> executeStep3()
+    task::Task<void> execute()
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
             ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK2);
@@ -118,7 +118,7 @@ public:
             if (m_hasRAW.get().test())
             {
                 PARALLEL_SCHEDULER_LOG(DEBUG)
-                    << "Chunk: " << m_chunkIndex << " aborted in step2, executed " << index
+                    << "Chunk: " << m_chunkIndex << " aborted in prepare, executed " << index
                     << " transactions";
                 break;
             }
@@ -126,7 +126,7 @@ public:
         }
     }
 
-    task::Task<void> executeStep4()
+    task::Task<void> finish()
     {
         ittapi::Report report(ittapi::ITT_DOMAINS::instance().PARALLEL_SCHEDULER,
             ittapi::ITT_DOMAINS::instance().EXECUTE_CHUNK3);
@@ -214,7 +214,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_2);
                         if (chunk && !hasRAW.test())
                         {
-                            task::tbb::syncWait(chunk->executeStep1(blockHeader, ledgerConfig));
+                            task::tbb::syncWait(chunk->createContexts(blockHeader, ledgerConfig));
                         }
 
                         return chunk;
@@ -226,7 +226,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_3);
                         if (chunk && !hasRAW.test())
                         {
-                            task::tbb::syncWait(chunk->executeStep2());
+                            task::tbb::syncWait(chunk->prepare());
                         }
 
                         return chunk;
@@ -238,7 +238,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_4);
                         if (chunk && !hasRAW.test())
                         {
-                            task::tbb::syncWait(chunk->executeStep3());
+                            task::tbb::syncWait(chunk->execute());
                         }
 
                         return chunk;
@@ -284,7 +284,7 @@ public:
                             ittapi::ITT_DOMAINS::instance().STAGE_6);
                         if (chunk)
                         {
-                            task::tbb::syncWait(chunk->executeStep4());
+                            task::tbb::syncWait(chunk->finish());
                         }
 
                         return chunk;

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
@@ -87,7 +87,7 @@ public:
                                 for (auto i : range)
                                 {
                                     auto& context = contexts[i];
-                                    co_await context.template executeStep<0>();
+                                    co_await context.prepare();
                                 }
                                 co_return range;
                             }());
@@ -101,7 +101,7 @@ public:
                                 for (auto i : range)
                                 {
                                     auto& context = contexts[i];
-                                    co_await context.template executeStep<1>();
+                                    co_await context.execute();
                                 }
                                 co_return range;
                             }());
@@ -116,7 +116,7 @@ public:
                                 {
                                     auto& context = contexts[i];
                                     receipts.emplace_back(
-                                        co_await context.template executeStep<2>());
+                                        co_await context.finish());
                                 }
                             }());
                         }));

--- a/transaction-scheduler/tests/FIB100_RevertWAWCorruptionTest.cpp
+++ b/transaction-scheduler/tests/FIB100_RevertWAWCorruptionTest.cpp
@@ -68,26 +68,23 @@ struct MockRevertExecutor
           : rollbackable(storage), contextID(id), key(std::move(contendedKey))
         {}
 
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute()
         {
-            // Mirror production: the EVM (and any REVERT) runs in step 1.
-            if constexpr (step == 1)
+            // Mirror production: the EVM (and any REVERT) runs in execute().
+            auto savepoint = rollbackable.current();
+
+            storage::Entry entry;
+            entry.set(contextID == 0 ? "1" : "2");
+            co_await storage2::writeOne(rollbackable, key, std::move(entry));
+
+            if (contextID == 1)
             {
-                auto savepoint = rollbackable.current();
-
-                storage::Entry entry;
-                entry.set(contextID == 0 ? "1" : "2");
-                co_await storage2::writeOne(rollbackable, key, std::move(entry));
-
-                if (contextID == 1)
-                {
-                    // Tx2 reverts — exactly HostContext.h:530 on EVMC_REVERT.
-                    co_await rollbackable.rollback(savepoint);
-                }
+                // Tx2 reverts — exactly HostContext.h:530 on EVMC_REVERT.
+                co_await rollbackable.rollback(savepoint);
             }
-            co_return {};
         }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
     };
 
     auto createExecuteContext(auto& storage, protocol::BlockHeader const& /*blockHeader*/,

--- a/transaction-scheduler/tests/FIB101_102_103_104_SchedulerTest.cpp
+++ b/transaction-scheduler/tests/FIB101_102_103_104_SchedulerTest.cpp
@@ -74,11 +74,9 @@ struct FIBMockExecutor
     template <class Storage>
     struct ExecuteContext
     {
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
-        {
-            co_return {};
-        }
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
     };
 
     auto createExecuteContext(auto& storage, protocol::BlockHeader const& blockHeader,

--- a/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
+++ b/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
@@ -49,11 +49,9 @@ struct CountingExecutor
     template <class Storage>
     struct ExecuteContext
     {
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
-        {
-            co_return {};
-        }
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
     };
 
     auto createExecuteContext(auto& storage, protocol::BlockHeader const& blockHeader,

--- a/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
+++ b/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
@@ -14,7 +14,7 @@
  *  limitations under the License.
  *
  * @file FIB98_EarlyAbortTest.cpp
- * @brief Verify that executeStep1 aborts early when m_hasRAW is set (FIB-98)
+ * @brief Verify that createContexts aborts early when m_hasRAW is set (FIB-98)
  */
 
 #include "bcos-framework/ledger/LedgerConfig.h"
@@ -101,10 +101,10 @@ public:
 
 BOOST_FIXTURE_TEST_SUITE(FIB98_EarlyAbortTest, FIB98Fixture)
 
-BOOST_AUTO_TEST_CASE(executeStep1AbortsWhenHasRAWIsSet)
+BOOST_AUTO_TEST_CASE(createContextsAbortsWhenHasRAWIsSet)
 {
     // This test constructs a ChunkStatus directly and verifies that
-    // executeStep1 stops creating ExecuteContext objects once the
+    // createContexts stops creating ExecuteContext objects once the
     // hasRAW flag has been set prior to the call.
 
     task::syncWait([&, this]() -> task::Task<void> {
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(executeStep1AbortsWhenHasRAWIsSet)
         using ChunkType =
             ChunkStatus<MutableStorage, BackendStorageType, CountingExecutor, ContextRange>;
 
-        // Case 1: hasRAW already set before calling executeStep1 -- expect zero contexts created.
+        // Case 1: hasRAW already set before calling createContexts -- expect zero contexts created.
         {
             boost::atomic_flag hasRAW;
             hasRAW.test_and_set();  // Set the flag BEFORE creating the chunk
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(executeStep1AbortsWhenHasRAWIsSet)
             bcostars::protocol::BlockHeaderImpl blockHeader(
                 [inner = bcostars::BlockHeader()]() mutable { return std::addressof(inner); });
             ledger::LedgerConfig ledgerConfig;
-            co_await chunk.executeStep1(blockHeader, ledgerConfig);
+            co_await chunk.createContexts(blockHeader, ledgerConfig);
 
             BOOST_CHECK_EQUAL(executor.createCount.load(), 0);
         }
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(executeStep1AbortsWhenHasRAWIsSet)
             bcostars::protocol::BlockHeaderImpl blockHeader(
                 [inner = bcostars::BlockHeader()]() mutable { return std::addressof(inner); });
             ledger::LedgerConfig ledgerConfig;
-            co_await chunk.executeStep1(blockHeader, ledgerConfig);
+            co_await chunk.createContexts(blockHeader, ledgerConfig);
 
             BOOST_CHECK_EQUAL(executor.createCount.load(), TX_COUNT);
         }

--- a/transaction-scheduler/tests/TestExecuteStateRootRegression.cpp
+++ b/transaction-scheduler/tests/TestExecuteStateRootRegression.cpp
@@ -99,11 +99,9 @@ struct SRMockExecutor
     template <class Storage>
     struct ExecuteContext
     {
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
-        {
-            co_return {};
-        }
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
     };
 
     auto createExecuteContext(auto& storage, protocol::BlockHeader const& blockHeader,

--- a/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
+++ b/transaction-scheduler/tests/TestMPTSchedulerWiring.cpp
@@ -175,8 +175,9 @@ struct MWExecutor
     template <class Storage>
     struct ExecuteContext
     {
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish()
         {
             co_return {};
         }

--- a/transaction-scheduler/tests/testBaselineScheduler.cpp
+++ b/transaction-scheduler/tests/testBaselineScheduler.cpp
@@ -53,11 +53,9 @@ struct MockExecutorBaseline
     template <class Storage>
     struct ExecuteContext
     {
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
-        {
-            co_return {};
-        }
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
     };
 
     auto createExecuteContext(auto& storage, protocol::BlockHeader const& blockHeader,

--- a/transaction-scheduler/tests/testSchedulerParallel.cpp
+++ b/transaction-scheduler/tests/testSchedulerParallel.cpp
@@ -137,7 +137,6 @@ struct MockConflictExecutor
             toEntry->set(
                 boost::lexical_cast<std::string>(boost::lexical_cast<int>(toEntry->get()) + 1));
             co_await storage2::writeOne(*storage, toKey, *toEntry);
-            co_return;
         }
 
         task::Task<protocol::TransactionReceipt::Ptr> finish()

--- a/transaction-scheduler/tests/testSchedulerParallel.cpp
+++ b/transaction-scheduler/tests/testSchedulerParallel.cpp
@@ -23,11 +23,9 @@ struct MockExecutorParallel
     template <class Storage>
     struct ExecuteContext
     {
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
-        {
-            co_return {};
-        }
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
     };
 
     auto createExecuteContext(auto& storage, protocol::BlockHeader const& blockHeader,
@@ -115,38 +113,37 @@ struct MockConflictExecutor
         std::string fromAddress;
         std::string toAddress;
 
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
+        task::Task<void> prepare()
         {
-            if constexpr (step == 0)
-            {
-                auto input = transaction->input();
-                auto inputNum = boost::lexical_cast<int>(
-                    std::string_view((const char*)input.data(), input.size()));
-                fromAddress = std::to_string(inputNum % MOCK_USER_COUNT);
-                toAddress = std::to_string((inputNum + (MOCK_USER_COUNT / 2)) % MOCK_USER_COUNT);
-            }
-            else if constexpr (step == 1)
-            {
-                StateKey fromKey{"t_test"sv, fromAddress};
-                auto fromEntry = co_await storage2::readOne(*storage, fromKey);
-                fromEntry->set(boost::lexical_cast<std::string>(
-                    boost::lexical_cast<int>(fromEntry->get()) - 1));
-                co_await storage2::writeOne(*storage, fromKey, *fromEntry);
+            auto input = transaction->input();
+            auto inputNum = boost::lexical_cast<int>(
+                std::string_view((const char*)input.data(), input.size()));
+            fromAddress = std::to_string(inputNum % MOCK_USER_COUNT);
+            toAddress = std::to_string((inputNum + (MOCK_USER_COUNT / 2)) % MOCK_USER_COUNT);
+            co_return;
+        }
 
-                // Read toKey and +1
-                StateKey toKey{"t_test"sv, toAddress};
-                auto toEntry = co_await storage2::readOne(*storage, toKey);
-                toEntry->set(
-                    boost::lexical_cast<std::string>(boost::lexical_cast<int>(toEntry->get()) + 1));
-                co_await storage2::writeOne(*storage, toKey, *toEntry);
-            }
-            else if constexpr (step == 2)
-            {
-                co_return std::shared_ptr<bcos::protocol::TransactionReceipt>(
-                    (bcos::protocol::TransactionReceipt*)0x10086, [](auto* p) {});
-            }
-            co_return {};
+        task::Task<void> execute()
+        {
+            StateKey fromKey{"t_test"sv, fromAddress};
+            auto fromEntry = co_await storage2::readOne(*storage, fromKey);
+            fromEntry->set(boost::lexical_cast<std::string>(
+                boost::lexical_cast<int>(fromEntry->get()) - 1));
+            co_await storage2::writeOne(*storage, fromKey, *fromEntry);
+
+            // Read toKey and +1
+            StateKey toKey{"t_test"sv, toAddress};
+            auto toEntry = co_await storage2::readOne(*storage, toKey);
+            toEntry->set(
+                boost::lexical_cast<std::string>(boost::lexical_cast<int>(toEntry->get()) + 1));
+            co_await storage2::writeOne(*storage, toKey, *toEntry);
+            co_return;
+        }
+
+        task::Task<protocol::TransactionReceipt::Ptr> finish()
+        {
+            co_return std::shared_ptr<bcos::protocol::TransactionReceipt>(
+                (bcos::protocol::TransactionReceipt*)0x10086, [](auto* p) {});
         }
     };
 

--- a/transaction-scheduler/tests/testSchedulerSerial.cpp
+++ b/transaction-scheduler/tests/testSchedulerSerial.cpp
@@ -22,11 +22,9 @@ struct MockExecutorSerial
     template <class Storage>
     struct ExecuteContext
     {
-        template <int step>
-        task::Task<protocol::TransactionReceipt::Ptr> executeStep()
-        {
-            co_return {};
-        }
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
     };
 
     auto createExecuteContext(auto& storage, protocol::BlockHeader const& blockHeader,


### PR DESCRIPTION
## 概要

将 `ExecuteContext::executeStep<step>()` 模板函数拆分为三个语义明确的独立函数，消除 `if constexpr (step == N)` 分支判断，使代码更易理解。

## 变更内容

### 核心变更 (`TransactionExecutorImpl.h`)

| 原接口 | 新接口 | 返回类型 | 功能 |
|---|---|---|---|
| `executeStep<0>()` | `prepare()` | `task::Task<void>` | 准备 HostContext |
| `executeStep<1>()` | `execute()` | `task::Task<void>` | 更新 nonce + 执行 EVM + gas 结算 |
| `executeStep<2>()` | `finish()` | `task::Task<TransactionReceipt::Ptr>` | 构建交易回执 |

- 删除了 `buildReceipt()` 冗余转发函数，直接使用 `finish()`
- `executeTransaction()` 中的调用从 `executeContext.template executeStep<N>()` 变为 `executeContext.prepare/execute/finish()`

### Concept 约束更新 (`TransactionExecutor.h`)

在 `TransactionExecutor` concept 中新增对 `ExecuteContext` 三个生命周期方法的约束。

### 调度器适配

- `SchedulerParallelImpl.h` — `ChunkStatus` 中的 `executeStep2/3/4` 调用更新为 `prepare/execute/finish`
- `SchedulerSerialImpl.h` — 流水线各阶段调用更新

### 测试适配

同步更新了 8 个测试文件中的 mock executor 实现。

### 影响范围

- 修改文件：15 个
- 纯接口重构，不改变运行时行为