### PR TITLE
Disable feature_sharding integration test in CI

### DIFF
--- a/tools/.ci/java_sdk_demo_ci_test.sh
+++ b/tools/.ci/java_sdk_demo_ci_test.sh
@@ -247,9 +247,10 @@ contract_test()
     bash console.sh setSystemConfigByKey feature_dmc2serial 1
     check_all_contract
 
-    LOG_INFO "\n=====> Test sharding: set feature_sharding"
-    bash console.sh setSystemConfigByKey feature_sharding 1
-    check_all_contract
+    # feature_sharding is deprecated, skip sharding test
+    # LOG_INFO "\n=====> Test sharding: set feature_sharding"
+    # bash console.sh setSystemConfigByKey feature_sharding 1
+    # check_all_contract
 }
 
 


### PR DESCRIPTION
## 变更说明

在 `ci_check_air` 集成测试中注释掉 `feature_sharding` 相关的测试用例。

### 背景

`feature_sharding` 功能即将废弃，不需要再在 CI 中运行相关集成测试。

### 变更内容

- `tools/.ci/java_sdk_demo_ci_test.sh`：注释掉 `contract_test()` 中开启 `feature_sharding` 并执行 `check_all_contract` 的 3 行代码

### 影响范围

- 仅影响 CI 集成测试流程，不影响生产代码
- CI 中 non-sm、sm、baseline 三个阶段均不再执行 sharding 模式下的合约测试
- Default 模式和 Serial 模式测试不受影响