### PR TITLE
feat(ledger): persist genesis trie nodes for L2 chains (M6 follow-up)

### DIFF
--- a/bcos-ledger/CMakeLists.txt
+++ b/bcos-ledger/CMakeLists.txt
@@ -25,6 +25,10 @@ target_include_directories(ledger PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-ledger>)
 target_link_libraries(ledger PUBLIC tool protocol-tars codec table bcos-concepts bcos-crypto Boost::serialization)
+# bcos-storage/KeyPrefixes.h (the "/mpt/" node-row key layout) is header-only; a full
+# `storage` link would pull RocksDB into the exported ledger target, so only the include
+# directory is added (build tree only, not exported).
+target_include_directories(ledger PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../bcos-storage)
 set_target_properties(ledger PROPERTIES UNITY_BUILD "ON")
 
 # test related

--- a/bcos-ledger/bcos-ledger/GenesisStateRoot.cpp
+++ b/bcos-ledger/bcos-ledger/GenesisStateRoot.cpp
@@ -42,7 +42,7 @@ bcos::h256 keccak(bcos::bytesConstRef data)
 // Zero-valued slots are skipped (no-op in Ethereum state). Empty -> emptyRoot.
 // The slot keccak stays over the raw configured bytes (not mpt::slotKeyHash, which
 // right-aligns into a fixed 32 bytes) to keep genesis hashing byte-identical.
-bcos::task::Task<bcos::h256> storageRootOf(std::vector<Alloc::State> const& storage)
+bcos::task::Task<mpt::TrieBuildResult> storageTrieOf(std::vector<Alloc::State> const& storage)
 {
     std::map<bcos::h256, bcos::bytes> entries;
     for (auto const& [slotHex, valueHex] : storage)
@@ -59,21 +59,30 @@ bcos::task::Task<bcos::h256> storageRootOf(std::vector<Alloc::State> const& stor
     }
     if (entries.empty())
     {
-        co_return mpt::emptyRootHash();
+        co_return mpt::TrieBuildResult{.root = mpt::emptyRootHash(), .newNodes = {}};
     }
-    // From-empty build through the stateless core; the produced nodes are not persisted — only
-    // the root goes into the genesis header.
-    co_return mpt::computeTrieRoot(entries).root;
+    // From-empty build through the stateless core: root + every produced node.
+    co_return mpt::computeTrieRoot(entries);
 }
 }  // namespace
 
 bcos::task::Task<bcos::h256> bcos::ledger::computeGenesisStateRoot(GenesisConfig const& genesis)
 {
+    auto trie = co_await computeGenesisStateTrie(genesis);
+    co_return trie.root;
+}
+
+bcos::task::Task<bcos::ledger::GenesisStateTrie> bcos::ledger::computeGenesisStateTrie(
+    GenesisConfig const& genesis)
+{
     std::map<bcos::h256, bcos::bytes> stateEntries;
+    std::unordered_map<bcos::h256, bcos::bytes> nodes;
 
     for (auto const& alloc : genesis.m_allocs)
     {
-        auto storageRoot = co_await storageRootOf(alloc.storage);
+        auto storageTrie = co_await storageTrieOf(alloc.storage);
+        auto storageRoot = storageTrie.root;
+        nodes.merge(storageTrie.newNodes);
 
         auto codeBytes = bcos::fromHex(alloc.code);
         bcos::h256 codeHash = codeBytes.empty() ?
@@ -94,5 +103,7 @@ bcos::task::Task<bcos::h256> bcos::ledger::computeGenesisStateRoot(GenesisConfig
         stateEntries[addrKeyHash] = std::move(accountRlp);
     }
 
-    co_return mpt::computeTrieRoot(stateEntries).root;
+    auto accountTrie = mpt::computeTrieRoot(stateEntries);
+    nodes.merge(accountTrie.newNodes);
+    co_return GenesisStateTrie{.root = accountTrie.root, .nodes = std::move(nodes)};
 }

--- a/bcos-ledger/bcos-ledger/GenesisStateRoot.h
+++ b/bcos-ledger/bcos-ledger/GenesisStateRoot.h
@@ -19,7 +19,9 @@
 #pragma once
 #include <bcos-framework/ledger/GenesisConfig.h>
 #include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
 #include <bcos-utilities/FixedBytes.h>
+#include <unordered_map>
 
 namespace bcos::ledger
 {
@@ -46,4 +48,19 @@ namespace bcos::ledger
 // go-ethereum vectors), so given correct per-account encoding the returned root
 // is op-geth-compatible by construction.
 bcos::task::Task<bcos::h256> computeGenesisStateRoot(GenesisConfig const& genesis);
+
+/// The genesis state trie in full: the op-geth-compatible root plus EVERY node the build
+/// produced — account trie and each account's storage sub-trie — as hash-keyed raw RLP.
+/// Identical encodings across sub-tries hash identically and dedupe in the map.
+struct GenesisStateTrie
+{
+    bcos::h256 root;
+    std::unordered_map<bcos::h256, bcos::bytes> nodes;
+};
+
+// computeGenesisStateRoot plus the produced nodes. Scenario B (L2, Ethereum-compatible)
+// chains need the nodes persisted as "/mpt/" state rows at genesis: block 1's incremental
+// MPT build (buildAndCollect with the genesis root as parent) reads parent-version nodes
+// through storage, and a missing node aborts execution loudly (MPTInvariantViolation).
+bcos::task::Task<GenesisStateTrie> computeGenesisStateTrie(GenesisConfig const& genesis);
 }  // namespace bcos::ledger

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -32,6 +32,7 @@
 #include "bcos-framework/storage/LegacyStorageMethods.h"
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-storage/KeyPrefixes.h"
 #include "bcos-tool/NodeConfig.h"
 #include "bcos-tool/VersionConverter.h"
 #include "bcos-utilities/Common.h"
@@ -1892,15 +1893,17 @@ bool Ledger::buildGenesisBlock(
         }
         auto genesisBlockHash = co_await ledger::getBlockHash(*m_stateStorage, 0, fromStorage);
         auto genesisData = generateGenesisData(genesis, ledgerConfig);
-        // op-geth-compatible Ethereum state root over the allocs. Empty (zero)
-        // for pbft chains with no allocs. Set as the L2 genesis block's
-        // stateRoot below, and re-derived on restart to guard alloc
-        // immutability. computeGenesisStateRoot only reads genesis.m_allocs, so
-        // it does not depend on the genesis state being written first.
-        bcos::h256 ethStateRoot;
+        // op-geth-compatible Ethereum state trie over the allocs: the root is
+        // empty (zero) for pbft chains with no allocs, set as the L2 genesis
+        // block's stateRoot below, and re-derived on restart to guard alloc
+        // immutability; the produced nodes are persisted further below on
+        // first init of an L2 chain. computeGenesisStateTrie only reads
+        // genesis.m_allocs, so it does not depend on the genesis state being
+        // written first.
+        GenesisStateTrie ethStateTrie;
         if (!genesis.m_allocs.empty())
         {
-            ethStateRoot = co_await computeGenesisStateRoot(genesis);
+            ethStateTrie = co_await computeGenesisStateTrie(genesis);
         }
         if (genesisBlockHash)
         {
@@ -1918,18 +1921,19 @@ bool Ledger::buildGenesisBlock(
             // config change to any alloc changes that root, so compare the
             // stored header's stateRoot against the freshly derived one.
             if (existsGenesisData == genesisData && !genesis.m_allocs.empty() &&
-                genesisBlockHeader->stateRoot() != ethStateRoot)
+                genesisBlockHeader->stateRoot() != ethStateTrie.root)
             {
                 LEDGER_LOG(FATAL) << LOG_BADGE("buildGenesisBlock")
                                   << LOG_DESC("genesis allocs changed since first init")
                                   << LOG_KV(
                                          "storedStateRoot", genesisBlockHeader->stateRoot().hex())
-                                  << LOG_KV("computedStateRoot", ethStateRoot.hex());
+                                  << LOG_KV("computedStateRoot", ethStateTrie.root.hex());
                 BOOST_THROW_EXCEPTION(
                     bcos::tool::InvalidConfig() << errinfo_comment(
                         "genesis allocs changed since first init (op-geth state root mismatch); "
                         "refuse to start. stored=" +
-                        genesisBlockHeader->stateRoot().hex() + " computed=" + ethStateRoot.hex()));
+                        genesisBlockHeader->stateRoot().hex() +
+                        " computed=" + ethStateTrie.root.hex()));
             }
 
             if (existsGenesisData == genesisData)
@@ -2062,7 +2066,7 @@ bool Ledger::buildGenesisBlock(
         // so only the (previously empty) genesis block carries it.
         if (!genesis.m_allocs.empty())
         {
-            header->setStateRoot(ethStateRoot);
+            header->setStateRoot(ethStateTrie.root);
         }
         header->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
 
@@ -2141,6 +2145,29 @@ bool Ledger::buildGenesisBlock(
         co_await setGenesisFeatures(genesis.m_features, features, *m_stateStorage);
         co_await importGenesisState(
             genesis.m_allocs, *m_stateStorage, *m_blockFactory->cryptoSuite()->hashImpl());
+
+        // Scenario B (L2): block 1 builds the MPT incrementally on top of the genesis state
+        // root (buildAndCollect with the genesis root as parent) and reads the parent trie
+        // through "/mpt/" state rows, so every genesis trie node — account trie plus each
+        // account's storage sub-trie — must be persisted here, on the same storage the alloc
+        // flat rows above just went to. A missing node aborts block-1 execution loudly
+        // (MPTInvariantViolation). Non-MPT chains never read these rows and get none; scenario
+        // A (feature_mpt_state_root activated mid-chain) starts its first MPT block from
+        // emptyRootHash() and needs no genesis nodes either.
+        if (std::any_of(genesis.m_features.begin(), genesis.m_features.end(),
+                [](ledger::FeatureSet const& featureSet) {
+                    return featureSet.flag == Features::Flag::feature_l2_ethereum_compat &&
+                           featureSet.enable > 0;
+                }))
+        {
+            for (auto& [nodeHash, nodeRlp] : ethStateTrie.nodes)
+            {
+                Entry nodeEntry;
+                nodeEntry.set(std::move(nodeRlp));
+                co_await storage2::writeOne(
+                    *m_stateStorage, storage2::mptNodeStateKey(nodeHash), std::move(nodeEntry));
+            }
+        }
 
         // consensus leader period
         Entry leaderPeriodEntry;

--- a/bcos-ledger/test/CMakeLists.txt
+++ b/bcos-ledger/test/CMakeLists.txt
@@ -24,6 +24,8 @@ set(TEST_BINARY_NAME test-bcos-ledger)
 add_executable(${TEST_BINARY_NAME} ${SOURCES})
 target_include_directories(${TEST_BINARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
 target_include_directories(${TEST_BINARY_NAME} PRIVATE ${CMAKE_BINARY_DIR}/bcos-framework)
+# header-only bcos-storage/KeyPrefixes.h ("/mpt/" node-row keys), same as the ledger target
+target_include_directories(${TEST_BINARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/bcos-storage)
 
 find_package(Boost REQUIRED unit_test_framework)
 

--- a/bcos-ledger/test/unittests/ledger/test_GenesisNodePersistence.cpp
+++ b/bcos-ledger/test/unittests/ledger/test_GenesisNodePersistence.cpp
@@ -1,0 +1,438 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file test_GenesisNodePersistence.cpp
+ * @brief L2 (scenario B) genesis trie-node persistence: buildGenesisBlock must write every
+ *        account-trie and storage-sub-trie node as a "/mpt/" state row, so the block-1
+ *        incremental MPT build (buildAndCollect over the genesis root) can read its parents.
+ */
+#include "../mpt/TestHelpers.h"
+#include "L2GenesisTestStorage.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/GenesisConfig.h"
+#include "bcos-framework/storage/LegacyStorageMethods.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-ledger/GenesisStateRoot.h"
+#include "bcos-ledger/Ledger.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-ledger/mpt/Account.h"
+#include "bcos-ledger/mpt/Classify.h"
+#include "bcos-ledger/mpt/Constants.h"
+#include "bcos-ledger/mpt/HashBuilder.h"
+#include "bcos-ledger/mpt/MPTBuilder.h"
+#include "bcos-ledger/mpt/NodeDecoder.h"
+#include "bcos-ledger/mpt/StorageValueCodec.h"
+#include "bcos-ledger/mpt/TrieNode.h"
+#include "bcos-task/Wait.h"
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/testutils/faker/FakeBlock.h>
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-table/src/StateStorage.h>
+#include <boost/algorithm/hex.hpp>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <set>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::ledger;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+
+struct GenesisNodeFixture
+{
+    GenesisNodeFixture() { m_blockFactory = createBlockFactory(createNormalCryptoSuite()); }
+
+    static LedgerConfig makeParam()
+    {
+        LedgerConfig param;
+        param.setBlockNumber(0);
+        param.setHash(crypto::HashType(""));
+        param.setBlockTxCountLimit(0);
+        return param;
+    }
+
+    static GenesisConfig baseConfig()
+    {
+        GenesisConfig genesis;
+        genesis.m_txGasLimit = 3000000000;
+        genesis.m_compatibilityVersion =
+            static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_6_VERSION);
+        genesis.m_chainID = "901";
+        genesis.m_groupID = "group0";
+        return genesis;
+    }
+
+    BlockFactory::Ptr m_blockFactory;
+};
+
+// Contract account: code + two storage slots (the storage sub-trie has real nodes).
+constexpr std::string_view c_contractAddress = "42000000000000000000000000000000000000c0";
+constexpr std::string_view c_contractCode = "6080604052";
+// EOA account: balance only.
+constexpr std::string_view c_eoaAddress = "1100000000000000000000000000000000000011";
+
+std::string slotHex(char lastNibble)
+{
+    return std::string(63, '0') + lastNibble;
+}
+
+Alloc contractAlloc()
+{
+    return Alloc{.address = std::string(c_contractAddress),
+        .balance = u256(500),
+        .nonce = "1",
+        .code = std::string(c_contractCode),
+        .storage = {{slotHex('0'), std::string(60, '0') + "0385"},
+            {slotHex('2'), std::string(62, '0') + "77"}}};
+}
+
+Alloc eoaAlloc()
+{
+    return Alloc{.address = std::string(c_eoaAddress),
+        .balance = u256(1000),
+        .nonce = "0",
+        .code = "",
+        .storage = {}};
+}
+
+// Count the persisted "/mpt/" rows in the test storage.
+size_t countMPTRows(storage::StateStorage& storage)
+{
+    size_t count = 0;
+    storage.parallelTraverse(false, [&](std::string_view table, std::string_view, auto const&) {
+        if (table == storage2::kMPTTable)
+        {
+            ++count;
+        }
+        return true;
+    });
+    return count;
+}
+
+// Read one persisted trie-node row; REQUIRE it exists and its content hashes back to @p hash.
+task::Task<bcos::bytes> readNodeRowChecked(storage::StorageInterface& storage, h256 hash)
+{
+    auto entry = co_await storage2::readOne(storage, storage2::mptNodeStateKey(hash));
+    BOOST_REQUIRE_MESSAGE(
+        entry.has_value(), "missing genesis trie node row for hash " + hash.hex());
+    auto raw = entry->get();
+    bcos::bytes rlp(raw.begin(), raw.end());
+    BOOST_CHECK_EQUAL(crypto::keccak256Hash(bcos::ref(rlp)).hex(), hash.hex());
+    co_return rlp;
+}
+
+task::Task<void> walkNodeHash(storage::StorageInterface& storage, h256 hash, bool accountTrie,
+    std::set<h256>& visited, size_t& storageTrieNodes);
+
+// Walk one decoded node's children (inline children recurse in-memory; hash children go
+// back through the stored rows).
+task::Task<void> walkDecoded(storage::StorageInterface& storage, ledger::mpt::TrieNode const& node,
+    bool accountTrie, std::set<h256>& visited, size_t& storageTrieNodes)
+{
+    namespace mpt = ledger::mpt;
+    if (auto const* leaf = std::get_if<mpt::LeafNode>(&node))
+    {
+        if (accountTrie)
+        {
+            auto account = mpt::Account::decode(bcos::ref(leaf->value));
+            if (account.storageRoot != mpt::emptyRootHash())
+            {
+                co_await walkNodeHash(
+                    storage, account.storageRoot, false, visited, storageTrieNodes);
+            }
+        }
+        co_return;
+    }
+    if (auto const* ext = std::get_if<mpt::ExtensionNode>(&node))
+    {
+        if (ext->child.size() == mpt::HASH_REF_ENCODED_SIZE &&
+            ext->child.front() == mpt::RLP_HASH_REF_PREFIX)
+        {
+            auto childHash = h256(bcos::bytesConstRef(ext->child.data() + 1, h256::SIZE));
+            co_await walkNodeHash(storage, childHash, accountTrie, visited, storageTrieNodes);
+        }
+        else
+        {
+            auto child = mpt::decodeNode(bcos::ref(ext->child));
+            co_await walkDecoded(storage, child, accountTrie, visited, storageTrieNodes);
+        }
+        co_return;
+    }
+    if (auto const* branch = std::get_if<mpt::BranchNode>(&node))
+    {
+        for (auto const& ref : branch->children)
+        {
+            if (ref.isAbsent())
+            {
+                continue;
+            }
+            if (ref.kind() == mpt::NodeRef::Kind::Hash)
+            {
+                co_await walkNodeHash(storage, ref.hash(), accountTrie, visited, storageTrieNodes);
+            }
+            else
+            {
+                auto child = mpt::decodeNode(ref.inlineRef());
+                co_await walkDecoded(storage, child, accountTrie, visited, storageTrieNodes);
+            }
+        }
+    }
+    co_return;
+}
+
+task::Task<void> walkNodeHash(storage::StorageInterface& storage, h256 hash, bool accountTrie,
+    std::set<h256>& visited, size_t& storageTrieNodes)
+{
+    if (!visited.insert(hash).second)
+    {
+        co_return;
+    }
+    if (!accountTrie)
+    {
+        ++storageTrieNodes;
+    }
+    auto rlp = co_await readNodeRowChecked(storage, hash);
+    auto node = ledger::mpt::decodeNode(bcos::ref(rlp));
+    co_await walkDecoded(storage, node, accountTrie, visited, storageTrieNodes);
+}
+
+// storage2 node-storage adapter over the ledger's StorageInterface: the same "/mpt/" rows
+// ViewNodeStorage (transaction-scheduler) reads at block 1, expressed over the test storage.
+class LedgerNodeStorage
+{
+public:
+    using Key = h256;
+    using Value = bcos::bytes;
+
+    explicit LedgerNodeStorage(storage::StorageInterface& backend) : m_backend(&backend) {}
+
+    task::Task<std::optional<bcos::bytes>> readOne(h256 key)
+    {
+        auto entry = co_await storage2::readOne(*m_backend, storage2::mptNodeStateKey(key));
+        if (!entry)
+        {
+            co_return std::nullopt;
+        }
+        auto raw = entry->get();
+        co_return bcos::bytes(raw.begin(), raw.end());
+    }
+
+    task::Task<std::vector<std::optional<bcos::bytes>>> readSome(::ranges::input_range auto keys)
+    {
+        std::vector<std::optional<bcos::bytes>> values;
+        for (auto const& key : keys)
+        {
+            values.emplace_back(co_await readOne(key));
+        }
+        co_return values;
+    }
+
+    task::Task<void> writeOne(h256 key, bcos::bytes value)
+    {
+        storage::Entry entry;
+        entry.set(std::move(value));
+        co_await storage2::writeOne(*m_backend, storage2::mptNodeStateKey(key), std::move(entry));
+    }
+
+    task::Task<void> writeSome(::ranges::input_range auto keyValues)
+    {
+        for (auto&& keyValue : keyValues)
+        {
+            auto const& [key, value] = keyValue;
+            co_await writeOne(key, bcos::bytes(value.begin(), value.end()));
+        }
+    }
+
+private:
+    storage::StorageInterface* m_backend;
+};
+
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(GenesisNodePersistenceTest, GenesisNodeFixture)
+
+// (a) L2 genesis with non-empty allocs: every node reachable from the genesis state root —
+// account trie AND per-account storage sub-tries — exists as a "/mpt/" row whose content
+// hashes back to its key, and no unreachable garbage rows are written.
+BOOST_AUTO_TEST_CASE(L2GenesisPersistsAllTrieNodes)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        auto storage = makeL2GenesisTestStorage();
+        auto ledger = std::make_shared<Ledger>(m_blockFactory, storage, 1);
+
+        auto genesisConfig = baseConfig();
+        genesisConfig.m_features.push_back(
+            FeatureSet{Features::Flag::feature_l2_ethereum_compat, 1});
+        genesisConfig.m_allocs.push_back(contractAlloc());
+        genesisConfig.m_allocs.push_back(eoaAlloc());
+
+        auto ok = co_await ledger::buildGenesisBlock(*ledger, genesisConfig, makeParam());
+        BOOST_REQUIRE(ok);
+
+        auto block = co_await ledger::getBlockData(*ledger, 0, HEADER);
+        BOOST_REQUIRE(block);
+        h256 root = block->blockHeader()->stateRoot();
+        BOOST_REQUIRE_NE(root, h256{});
+        BOOST_REQUIRE_NE(root, ledger::mpt::emptyRootHash());
+
+        std::set<h256> visited;
+        size_t storageTrieNodes = 0;
+        co_await walkNodeHash(*storage, root, true, visited, storageTrieNodes);
+
+        // The contract's storage sub-trie must be persisted too: block 1 reads its parent
+        // nodes when the account's slots change.
+        BOOST_CHECK_GE(storageTrieNodes, 1);
+        // Exactly the reachable nodes are stored: no missing rows (walk REQUIREs each), and
+        // no unreachable extras.
+        BOOST_CHECK_EQUAL(countMPTRows(*storage), visited.size());
+    }());
+}
+
+// (b) L2 flag with an empty alloc set (root = empty-trie root): nothing to persist.
+BOOST_AUTO_TEST_CASE(EmptyAllocsWriteNoNodeRows)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        auto storage = makeL2GenesisTestStorage();
+        auto ledger = std::make_shared<Ledger>(m_blockFactory, storage, 1);
+
+        auto genesisConfig = baseConfig();
+        genesisConfig.m_features.push_back(
+            FeatureSet{Features::Flag::feature_l2_ethereum_compat, 1});
+
+        auto ok = co_await ledger::buildGenesisBlock(*ledger, genesisConfig, makeParam());
+        BOOST_REQUIRE(ok);
+        BOOST_CHECK_EQUAL(countMPTRows(*storage), 0);
+    }());
+}
+
+// (c) Non-MPT chains write no node rows: neither a plain pbft genesis nor an alloc-carrying
+// genesis without feature_l2_ethereum_compat (the header still pins the alloc root, but no
+// block will ever build an MPT on top of it).
+BOOST_AUTO_TEST_CASE(NonL2ChainsWriteNoNodeRows)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        {
+            auto storage = makeL2GenesisTestStorage();
+            auto ledger = std::make_shared<Ledger>(m_blockFactory, storage, 1);
+            auto ok = co_await ledger::buildGenesisBlock(*ledger, baseConfig(), makeParam());
+            BOOST_REQUIRE(ok);
+            BOOST_CHECK_EQUAL(countMPTRows(*storage), 0);
+        }
+        {
+            auto storage = makeL2GenesisTestStorage();
+            auto ledger = std::make_shared<Ledger>(m_blockFactory, storage, 1);
+            auto genesisConfig = baseConfig();
+            genesisConfig.m_allocs.push_back(contractAlloc());
+            auto ok = co_await ledger::buildGenesisBlock(*ledger, genesisConfig, makeParam());
+            BOOST_REQUIRE(ok);
+            BOOST_CHECK_EQUAL(countMPTRows(*storage), 0);
+        }
+    }());
+}
+
+// (d) End-to-end block-1 shape: an incremental buildAndCollect with the genesis root as
+// parent must succeed (it reads the persisted genesis nodes) and produce the same root as a
+// from-scratch build over the expected post-block state.
+BOOST_AUTO_TEST_CASE(BlockOneIncrementalBuildOverGenesisRoot)
+{
+    namespace mpt = ledger::mpt;
+    namespace mpttest = ledger::mpt::test;
+    task::syncWait([this]() -> task::Task<void> {
+        auto storage = makeL2GenesisTestStorage();
+        auto ledger = std::make_shared<Ledger>(m_blockFactory, storage, 1);
+
+        auto genesisConfig = baseConfig();
+        genesisConfig.m_features.push_back(
+            FeatureSet{Features::Flag::feature_l2_ethereum_compat, 1});
+        genesisConfig.m_allocs.push_back(contractAlloc());
+        genesisConfig.m_allocs.push_back(eoaAlloc());
+
+        auto ok = co_await ledger::buildGenesisBlock(*ledger, genesisConfig, makeParam());
+        BOOST_REQUIRE(ok);
+
+        auto block = co_await ledger::getBlockData(*ledger, 0, HEADER);
+        BOOST_REQUIRE(block);
+        h256 genesisRoot = block->blockHeader()->stateRoot();
+
+        // Block-1 delta: subsequent-touch of the contract account — balance update + one NEW
+        // storage slot. The build must read the genesis account-trie nodes (parent leaf) and
+        // the genesis storage-sub-trie nodes (slot merge) through the persisted rows.
+        bcos::Address contractAddr;
+        boost::algorithm::unhex(
+            c_contractAddress.begin(), c_contractAddress.end(), contractAddr.data());
+
+        h256 newSlot{};
+        newSlot.data()[31] = 0x05;
+        bcos::bytes newSlotValue(32, 0);
+        newSlotValue[31] = 0x99;
+
+        mpttest::FlatBackendStorage flatBackend;
+        auto view = mpttest::makeFlatView(flatBackend);
+        mpttest::writeFlatRow(view, mpttest::accountFieldKey(contractAddr, mpt::ROW_BALANCE),
+            mpttest::makeEntry("777"));
+        mpttest::writeFlatRow(view, mpttest::accountSlotKey(contractAddr, newSlot),
+            mpttest::makeEntry(std::string_view{
+                reinterpret_cast<char const*>(newSlotValue.data()), newSlotValue.size()}));
+
+        LedgerNodeStorage nodeStorage(*storage);
+        auto output =
+            co_await mpt::buildAndCollect(nodeStorage, genesisRoot, view, /*l2Mode=*/true);
+
+        // Oracle: from-scratch trie over the expected post-block state.
+        auto keccak = [](bcos::bytes const& data) {
+            return crypto::keccak256Hash(bcos::ref(data));
+        };
+
+        std::map<h256, bcos::bytes> storageEntries;
+        for (auto const& [slotHexKey, valueHex] : contractAlloc().storage)
+        {
+            auto slotBytes = bcos::fromHex(slotHexKey);
+            auto valueBytes = bcos::fromHex(valueHex);
+            storageEntries[keccak(slotBytes)] = mpt::encodeStorageValue(bcos::ref(valueBytes));
+        }
+        auto newSlotBytes = bcos::bytes(newSlot.begin(), newSlot.end());
+        storageEntries[keccak(newSlotBytes)] = mpt::encodeStorageValue(bcos::ref(newSlotValue));
+        auto expectedStorageRoot = mpt::computeTrieRoot(storageEntries).root;
+
+        auto codeBytes = bcos::fromHex(std::string(c_contractCode));
+        std::map<h256, bcos::bytes> accountEntries;
+        {
+            bcos::bytes rlp;
+            codec::rlp::encode(rlp, uint64_t(1), u256(777), expectedStorageRoot, keccak(codeBytes));
+            auto addrBytes = bcos::fromHex(std::string(c_contractAddress));
+            accountEntries[keccak(addrBytes)] = std::move(rlp);
+        }
+        {
+            bcos::bytes rlp;
+            codec::rlp::encode(
+                rlp, uint64_t(0), u256(1000), mpt::emptyRootHash(), mpt::emptyCodeHash());
+            auto addrBytes = bcos::fromHex(std::string(c_eoaAddress));
+            accountEntries[keccak(addrBytes)] = std::move(rlp);
+        }
+        auto expectedRoot = mpt::computeTrieRoot(accountEntries).root;
+
+        BOOST_CHECK_EQUAL(output.stateRoot.hex(), expectedRoot.hex());
+        BOOST_CHECK_NE(output.stateRoot, genesisRoot);
+    }());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/CMakeLists.txt
+++ b/bcos-rpc/test/CMakeLists.txt
@@ -26,9 +26,21 @@ add_executable(${TEST_BINARY_NAME} ${SOURCES})
 target_include_directories(${TEST_BINARY_NAME} PRIVATE .)
 target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wno-unused-variable)
 
-target_link_libraries(${TEST_BINARY_NAME} txpool ledger rpc tool Boost::unit_test_framework)
+# transaction-scheduler: EthGetProofIntegrationTest.cpp drives the FullChainFixture
+# end-to-end harness (transaction-scheduler/tests/FullChainFixture.h); it brings
+# ledger/storage (RocksDB) transitively. Deliberately NOT linking `executor` here even
+# though the BaselineScheduler instantiation references bcos::unhexAddress: executor
+# PUBLIC-links wedprcrypto's Rust static libraries, whose bundled runtime breaks libc++
+# exception catching binary-wide (testCallRequest/decode_invalid_gas_string starts
+# reporting "unknown type" for a plain std::invalid_argument). The test file carries a
+# linkage-only definition of unhexAddress instead.
+target_link_libraries(${TEST_BINARY_NAME} txpool ledger rpc tool transaction-scheduler Boost::unit_test_framework)
 set_source_files_properties("unittests/main/main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties("unittests/rpc/RpcReadHandlersTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+# FullChainFixture.h pulls RocksDB and testutils headers whose names collide with the
+# using-directives other unity-merged TUs carry; compile its user standalone.
+set_source_files_properties(
+    "unittests/rpc/EthGetProofIntegrationTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 #add_test(NAME ${TEST_BINARY_NAME} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${TEST_BINARY_NAME})
 config_test_cases("" "${SOURCES}" ${TEST_BINARY_NAME} "" "")

--- a/bcos-rpc/test/unittests/rpc/EthGetProofIntegrationTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetProofIntegrationTest.cpp
@@ -1,0 +1,323 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EthGetProofIntegrationTest.cpp
+ * @brief eth_getProof end-to-end integration (M8.4): the chain state comes from the REAL
+ *        stack — FullChainFixture's real Ledger genesis + real BaselineScheduler blocks on
+ *        real RocksDB — and EthEndpoint::getProof proves accounts against the trie nodes
+ *        those commits actually persisted as "/mpt/" rows. Covers scenario A active
+ *        (proof + independent verifyProof), scenario A dormant (-32004 "Account not in
+ *        trie", EthEndpoint.cpp's EthGetProofUnavailable), and scenario B where every
+ *        genesis-alloc account proves, storage slots included.
+ *
+ *        The node reader is a test-local snapshot: the committed "/mpt/" rows are copied
+ *        from the RocksDB backend into a MemoryStorage<h256, bytes> and wrapped in the
+ *        production AnyStorage type NodeService::setMPTNodeReader takes. The production
+ *        reader wiring is a separate (open) PR; this test deliberately does not depend
+ *        on it.
+ */
+#include "transaction-scheduler/tests/FullChainFixture.h"
+#include <bcos-framework/storage2/AnyStorage.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/Proof.h>
+#include <bcos-rpc/groupmgr/NodeService.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/algorithm/hex.hpp>
+#include <boost/test/unit_test.hpp>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bcos
+{
+// Linkage-only definition. The BaselineScheduler instantiation inside FullChainFixture
+// references bcos::unhexAddress (declared in bcos-executor/src/Common.h, pulled in by
+// BaselineScheduler.h) from its getABI/getCode members — which this test never calls.
+// The producing library (`executor`) is deliberately NOT linked into test-bcos-rpc:
+// it PUBLIC-links wedprcrypto's Rust static libraries, whose bundled runtime breaks
+// libc++ exception catching binary-wide (see bcos-rpc/test/CMakeLists.txt). This is a
+// verbatim copy of bcos-executor/src/Common.cpp's definition; the linker guarantees it
+// is the only one in this binary.
+evmc_address unhexAddress(std::string_view view)
+{
+    if (view.empty())
+    {
+        return {};
+    }
+    if (view.starts_with("0x") || view.starts_with("0X"))
+    {
+        view = view.substr(2);
+    }
+    if (view.size() != sizeof(evmc_address) * 2) [[unlikely]]
+    {
+        return {};
+    }
+    evmc_address address;
+    boost::algorithm::unhex(view, address.bytes);
+    return address;
+}
+}  // namespace bcos
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::test::fullchain;
+namespace mpt = bcos::ledger::mpt;
+
+using EpiNodeStorage = storage2::memory_storage::MemoryStorage<h256, bytes>;
+
+/// Snapshot every committed "/mpt/" row from the fixture's RocksDB backend into @p nodes —
+/// the read surface a production node reader serves, minus the wiring.
+void epiLoadNodes(FullChainFixture& fixture, EpiNodeStorage& nodes)
+{
+    task::syncWait([&]() -> task::Task<void> {
+        auto iterator = co_await storage2::range(fixture.m_multiLayerStorage.latestBackend());
+        while (auto keyValue = co_await iterator.next())
+        {
+            auto&& [key, value] = *keyValue;
+            auto view = executor_v1::StateKeyView{key};
+            if (view.m_table == storage2::kMPTTable)
+            {
+                BOOST_REQUIRE_EQUAL(view.m_key.size(), h256::SIZE);
+                h256 hash{bcos::bytesConstRef(
+                    reinterpret_cast<bcos::byte const*>(view.m_key.data()), h256::SIZE)};
+                auto const* entry = std::get_if<storage::Entry>(std::addressof(value));
+                BOOST_REQUIRE(entry != nullptr);
+                auto raw = entry->get();
+                co_await storage2::writeOne(nodes, hash, bytes(raw.begin(), raw.end()));
+            }
+        }
+    }());
+}
+
+/// EthEndpoint over the fixture's REAL ledger: "latest" resolves through the real
+/// getCurrentBlockNumber, the proof anchors at the real committed header's stateRoot.
+struct EpiEndpointHarness
+{
+    rpc::NodeService::Ptr m_nodeService;
+    std::unique_ptr<rpc::EthEndpoint> m_endpoint;
+
+    EpiEndpointHarness(FullChainFixture& fixture, EpiNodeStorage& nodes)
+    {
+        m_nodeService = std::make_shared<rpc::NodeService>(fixture.m_ledger, nullptr,
+            fixture.m_txpool, nullptr, nullptr, fixture.m_blockFactory, nullptr);
+        m_nodeService->setMPTNodeReader(std::make_shared<rpc::NodeService::MPTNodeReader>(nodes));
+        m_endpoint = std::make_unique<rpc::EthEndpoint>(m_nodeService, nullptr, false);
+    }
+
+    /// Direct endpoint call with EIP-1186 params; returns the result object.
+    /// JsonRpcException escapes to the caller for the error-path cases.
+    Json::Value getProof(
+        std::string const& addressHex, std::vector<std::string> const& keys, std::string tag)
+    {
+        Json::Value params(Json::arrayValue);
+        params.append(addressHex);
+        Json::Value keysJson(Json::arrayValue);
+        for (auto const& key : keys)
+        {
+            keysJson.append(key);
+        }
+        params.append(keysJson);
+        params.append(std::move(tag));
+        Json::Value response;
+        task::syncWait(m_endpoint->getProof(params, response));
+        return response["result"];
+    }
+};
+
+/// A JSON quantity ("0x2a") back to trimmed big-endian bytes; "0x0" -> empty.
+bytes epiQuantityToBytes(std::string const& quantity)
+{
+    std::string hex = quantity;
+    if (hex.starts_with("0x") || hex.starts_with("0X"))
+    {
+        hex = hex.substr(2);
+    }
+    if (hex.empty() || hex == "0")
+    {
+        return {};
+    }
+    if (hex.size() % 2 != 0)
+    {
+        hex.insert(0, "0");
+    }
+    return fromHex(hex);
+}
+
+/// Rebuild the binary EIP1186Proof from the endpoint's JSON (same shape as
+/// EthGetProofRpcTest's proofFromJson): hex fields back to bytes, slot values back to the
+/// trie's RLP leaf encoding — verifyProof compares raw leaf bytes.
+mpt::EIP1186Proof epiProofFromJson(Json::Value const& result)
+{
+    mpt::EIP1186Proof out;
+    out.address = Address(result["address"].asString(), Address::FromHex);
+    out.balance = fromBigQuantity(result["balance"].asString());
+    out.nonce = fromBigQuantity(result["nonce"].asString());
+    out.codeHash = h256(result["codeHash"].asString(), h256::FromHex);
+    out.storageHash = h256(result["storageHash"].asString(), h256::FromHex);
+    for (auto const& node : result["accountProof"])
+    {
+        out.accountProof.push_back(fromHexWithPrefix(node.asString()));
+    }
+    for (auto const& entryJson : result["storageProof"])
+    {
+        mpt::StorageProof entry;
+        entry.key = h256(entryJson["key"].asString(), h256::FromHex);
+        auto raw = epiQuantityToBytes(entryJson["value"].asString());
+        entry.value = mpt::encodeStorageValue(bcos::ref(raw));
+        for (auto const& node : entryJson["proof"])
+        {
+            entry.proof.push_back(fromHexWithPrefix(node.asString()));
+        }
+        out.storageProof.push_back(std::move(entry));
+    }
+    return out;
+}
+
+constexpr std::string_view c_epiContractAddress = "42000000000000000000000000000000000000c0";
+constexpr std::string_view c_epiContractCode = "6080604052";
+constexpr std::string_view c_epiEoaAddress = "1100000000000000000000000000000000000011";
+
+std::string epiSlotHexPrefixed(char lastNibble)
+{
+    return "0x" + std::string(63, '0') + lastNibble;
+}
+
+BOOST_AUTO_TEST_SUITE(EthGetProofIntegrationSuite)
+
+// Scenario A over the real chain: activation at block 2; the dormant account was written in
+// the XOR era (block 1), the active account entered the MPT at block 3 (N+1).
+// eth_getProof(active) returns an EIP-1186 proof the independent verifier accepts against
+// the block-3 header root — and rejects against any other root. eth_getProof(dormant)
+// throws the -32004 "Account not in trie" JsonRpcException.
+BOOST_AUTO_TEST_CASE(ScenarioA_ActiveProofVerifies_DormantReturns32004)
+{
+    FullChainFixture fixture{"epi_scenario_a"};
+    fixture.buildGenesis(FullChainFixture::baseGenesis());
+    fixture.enableFeatureFromBlock("feature_mpt_state_root", 2);
+
+    auto const dormant = FullChainFixture::makeAddress(0xDF);
+    auto const filler = FullChainFixture::makeAddress(0xF1);
+    auto const active = FullChainFixture::makeAddress(0xAC);
+
+    fixture.planBlock(1, {FullChainFixture::balanceRow(dormant, "1000000")});  // XOR era
+    fixture.planBlock(2, {FullChainFixture::balanceRow(filler, "1")});  // activation block, XOR
+    fixture.planBlock(3, {FullChainFixture::balanceRow(active, "2000000"),
+                             FullChainFixture::nonceRow(active, "1")});  // first MPT block
+    fixture.runBlock(1);
+    fixture.runBlock(2);
+    auto header3 = fixture.runBlock(3);
+
+    EpiNodeStorage nodes;
+    epiLoadNodes(fixture, nodes);
+    EpiEndpointHarness harness{fixture, nodes};
+
+    // (i) Active account: proof comes back and round-trips through the independent verifier.
+    auto result = harness.getProof(active.hexPrefixed(), {}, "latest");
+    BOOST_REQUIRE(!result.isNull());
+    BOOST_CHECK_EQUAL(result["balance"].asString(), "0x1e8480");  // 2000000
+    BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x1");
+    auto proof = epiProofFromJson(result);
+    auto verify = mpt::verifyProof(header3->stateRoot(), proof);
+    BOOST_CHECK(verify.accountValid);
+
+    // Control: the same proof must NOT verify against a different root (block 2's XOR root).
+    auto wrongRoot = fixture.headerOnChain(2)->stateRoot();
+    BOOST_REQUIRE_NE(wrongRoot, header3->stateRoot());
+    BOOST_CHECK(!mpt::verifyProof(wrongRoot, proof).accountValid);
+
+    // (ii) Dormant account: explicit -32004, never an empty proof.
+    try
+    {
+        harness.getProof(dormant.hexPrefixed(), {}, "latest");
+        BOOST_FAIL("eth_getProof(dormant) must throw");
+    }
+    catch (rpc::JsonRpcException const& e)
+    {
+        BOOST_CHECK_EQUAL(e.code(), -32004);
+        BOOST_CHECK(std::string(e.msg()).find("not in trie") != std::string::npos);
+    }
+}
+
+// Scenario B over the real chain: every genesis-alloc account proves at the current head.
+// Block 1 touches only the EOA, so the contract's proof walk crosses block-1 account-trie
+// nodes AND untouched genesis storage-sub-trie nodes — both served from the committed
+// "/mpt/" rows. Slot proofs recover the alloc values; an absent slot yields a valid
+// exclusion proof.
+BOOST_AUTO_TEST_CASE(ScenarioB_AllAllocAccountsProve)
+{
+    FullChainFixture fixture{"epi_scenario_b"};
+    auto genesis = FullChainFixture::baseGenesis();
+    genesis.m_features.push_back(
+        ledger::FeatureSet{ledger::Features::Flag::feature_l2_ethereum_compat, 1});
+    genesis.m_allocs.push_back(ledger::Alloc{.address = std::string(c_epiContractAddress),
+        .balance = u256(500),
+        .nonce = "1",
+        .code = std::string(c_epiContractCode),
+        .storage = {{std::string(63, '0') + "0", std::string(60, '0') + "0385"},
+            {std::string(63, '0') + "2", std::string(62, '0') + "77"}}});
+    genesis.m_allocs.push_back(ledger::Alloc{.address = std::string(c_epiEoaAddress),
+        .balance = u256(1000),
+        .nonce = "0",
+        .code = "",
+        .storage = {}});
+    fixture.buildGenesis(genesis);
+
+    Address eoa;
+    boost::algorithm::unhex(c_epiEoaAddress.begin(), c_epiEoaAddress.end(), eoa.data());
+    fixture.planBlock(1, {FullChainFixture::balanceRow(eoa, "2000")});
+    auto header1 = fixture.runBlock(1);
+
+    EpiNodeStorage nodes;
+    epiLoadNodes(fixture, nodes);
+    EpiEndpointHarness harness{fixture, nodes};
+
+    // EOA (touched at block 1): balance updated, proof verifies at the head root.
+    {
+        auto result = harness.getProof("0x" + std::string(c_epiEoaAddress), {}, "latest");
+        BOOST_REQUIRE(!result.isNull());
+        BOOST_CHECK_EQUAL(result["balance"].asString(), "0x7d0");  // 2000
+        auto verify = mpt::verifyProof(header1->stateRoot(), epiProofFromJson(result));
+        BOOST_CHECK(verify.accountValid);
+    }
+
+    // Contract (untouched since genesis): account + both alloc slots + one absent slot.
+    {
+        auto result = harness.getProof("0x" + std::string(c_epiContractAddress),
+            {epiSlotHexPrefixed('0'), epiSlotHexPrefixed('2'), epiSlotHexPrefixed('9')}, "latest");
+        BOOST_REQUIRE(!result.isNull());
+        BOOST_CHECK_EQUAL(result["balance"].asString(), "0x1f4");  // 500
+        BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x1");
+        BOOST_REQUIRE_EQUAL(result["storageProof"].size(), 3U);
+        BOOST_CHECK_EQUAL(result["storageProof"][0U]["value"].asString(), "0x385");
+        BOOST_CHECK_EQUAL(result["storageProof"][1U]["value"].asString(), "0x77");
+        BOOST_CHECK_EQUAL(result["storageProof"][2U]["value"].asString(), "0x0");  // absent
+
+        auto verify = mpt::verifyProof(header1->stateRoot(), epiProofFromJson(result));
+        BOOST_CHECK(verify.accountValid);
+        BOOST_REQUIRE_EQUAL(verify.storageValid.size(), 3U);
+        BOOST_CHECK(verify.storageValid[0]);
+        BOOST_CHECK(verify.storageValid[1]);
+        BOOST_CHECK(verify.storageValid[2]);  // valid EXCLUSION proof
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -342,8 +342,9 @@ private:
      * before MPT. Scenario B (L2 from genesis) is the full-state case: every account enters
      * the trie when it is created.
      *
-     * Scenario-B limitation unchanged: a non-empty-alloc L2 genesis persists its header but
-     * no trie NODES, so only empty-alloc genesis chains block 1 today.
+     * Scenario-B genesis nodes: Ledger::buildGenesisBlock persists every genesis trie node
+     * (account trie + storage sub-tries, computeGenesisStateTrie) as "/mpt/" state rows on
+     * first init of an L2 chain, so block 1's incremental build reads its parents here.
      */
     task::Task<ledger::mpt::MPTDeltaLayer> buildMPTStateRoot(
         typename MultiLayerStorage::ViewType& view, protocol::BlockHeader const& blockHeader,

--- a/transaction-scheduler/tests/BaselineSchedulerMPTGenesisTest.cpp
+++ b/transaction-scheduler/tests/BaselineSchedulerMPTGenesisTest.cpp
@@ -1,0 +1,235 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file BaselineSchedulerMPTGenesisTest.cpp
+ * @brief Scenario-B (L2) genesis, end to end over the real stack (M6.5): the real Ledger
+ *        genesis on real RocksDB pins the op-geth-compatible alloc root into the genesis
+ *        header and persists the genesis trie nodes (cc51df624); block 1 then builds the
+ *        MPT INCREMENTALLY on top of that root through the real BaselineScheduler — the
+ *        first full-stack verification that the persisted genesis nodes actually feed the
+ *        block-1 build. Scenario-B semantics take priority over scenario A's activation
+ *        rule (l2 flag checked first in shouldBuildMPT).
+ */
+#include "FullChainFixture.h"
+#include "bcos-ledger/mpt/Account.h"
+#include "bcos-ledger/mpt/Constants.h"
+#include "bcos-ledger/mpt/HashBuilder.h"
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <boost/algorithm/hex.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::test::fullchain;
+namespace mpt = bcos::ledger::mpt;
+
+constexpr std::string_view c_genContractAddress = "42000000000000000000000000000000000000c0";
+constexpr std::string_view c_genContractCode = "6080604052";
+constexpr std::string_view c_genEoaAddress = "1100000000000000000000000000000000000011";
+
+std::string genSlotHex(char lastNibble)
+{
+    return std::string(63, '0') + lastNibble;
+}
+
+ledger::Alloc genContractAlloc()
+{
+    return ledger::Alloc{.address = std::string(c_genContractAddress),
+        .balance = u256(500),
+        .nonce = "1",
+        .code = std::string(c_genContractCode),
+        .storage = {{genSlotHex('0'), std::string(60, '0') + "0385"},
+            {genSlotHex('2'), std::string(62, '0') + "77"}}};
+}
+
+ledger::Alloc genEoaAlloc()
+{
+    return ledger::Alloc{.address = std::string(c_genEoaAddress),
+        .balance = u256(1000),
+        .nonce = "0",
+        .code = "",
+        .storage = {}};
+}
+
+ledger::GenesisConfig genL2Genesis()
+{
+    auto genesis = FullChainFixture::baseGenesis();
+    genesis.m_features.push_back(
+        ledger::FeatureSet{ledger::Features::Flag::feature_l2_ethereum_compat, 1});
+    genesis.m_allocs.push_back(genContractAlloc());
+    genesis.m_allocs.push_back(genEoaAlloc());
+    return genesis;
+}
+
+h256 genKeccak(bytes const& data)
+{
+    return crypto::keccak256Hash(bcos::ref(data));
+}
+
+Address genAddress(std::string_view hex)
+{
+    Address address;
+    boost::algorithm::unhex(hex.begin(), hex.end(), address.data());
+    return address;
+}
+
+/// The contract's storage-trie root over the genesis allocs plus @p extraSlots
+/// (slot32 -> raw 32-byte value), via the independent computeTrieRoot core.
+h256 genContractStorageRoot(std::map<h256, bytes> const& extraSlots = {})
+{
+    std::map<h256, bytes> entries;
+    for (auto const& [slotHexKey, valueHex] : genContractAlloc().storage)
+    {
+        auto slotBytes = bcos::fromHex(slotHexKey);
+        auto valueBytes = bcos::fromHex(valueHex);
+        entries[genKeccak(slotBytes)] = mpt::encodeStorageValue(bcos::ref(valueBytes));
+    }
+    for (auto const& [slot, rawValue] : extraSlots)
+    {
+        auto slotBytes = bytes(slot.begin(), slot.end());
+        entries[genKeccak(slotBytes)] =
+            mpt::encodeStorageValue(bytesConstRef(rawValue.data(), rawValue.size()));
+    }
+    return mpt::computeTrieRoot(entries).root;
+}
+
+/// From-scratch state-trie oracle over explicit Ethereum account leaves:
+/// (address, nonce, balance, storageRoot, codeHash).
+struct GenAccountLeaf
+{
+    std::string_view addressHex;
+    uint64_t nonce{};
+    u256 balance;
+    h256 storageRoot;
+    h256 codeHash;
+};
+
+h256 genStateRootOracle(std::vector<GenAccountLeaf> const& leaves)
+{
+    std::map<h256, bytes> accountEntries;
+    for (auto const& leaf : leaves)
+    {
+        bytes rlp;
+        codec::rlp::encode(rlp, leaf.nonce, leaf.balance, leaf.storageRoot, leaf.codeHash);
+        auto addrBytes = bcos::fromHex(std::string(leaf.addressHex));
+        accountEntries[genKeccak(addrBytes)] = std::move(rlp);
+    }
+    return mpt::computeTrieRoot(accountEntries).root;
+}
+
+h256 genContractCodeHash()
+{
+    return genKeccak(bcos::fromHex(std::string(c_genContractCode)));
+}
+
+BOOST_AUTO_TEST_SUITE(BaselineSchedulerMPTGenesisSuite)
+
+// The genesis header's stateRoot equals the op-geth-compatible root over the allocs,
+// computed here by an independent from-scratch oracle (secure tries, RLP account leaves) —
+// and the trie nodes behind it are committed "/mpt/" rows in the RocksDB backend.
+BOOST_AUTO_TEST_CASE(GenesisRootMatchesOpGethOracle)
+{
+    FullChainFixture fixture{"gen_root_oracle"};
+    fixture.buildGenesis(genL2Genesis());
+
+    auto expectedRoot = genStateRootOracle({
+        {c_genContractAddress, 1, u256(500), genContractStorageRoot(), genContractCodeHash()},
+        {c_genEoaAddress, 0, u256(1000), mpt::emptyRootHash(), mpt::emptyCodeHash()},
+    });
+
+    auto genesisHeader = fixture.headerOnChain(0);
+    BOOST_CHECK_EQUAL(genesisHeader->stateRoot().hex(), expectedRoot.hex());
+    BOOST_CHECK_NE(genesisHeader->stateRoot(), mpt::emptyRootHash());
+    BOOST_CHECK_GT(fixture.backendNodeCount(), 0);
+}
+
+// Block 1 builds INCREMENTALLY on the genesis root through the real scheduler: the build
+// reads the persisted genesis nodes (account leaf + storage sub-trie) to merge a balance
+// update and a NEW storage slot into the existing tries, and the result matches the
+// from-scratch oracle over the expected post-block state. Block 2 keeps chaining. This is
+// the full-stack closure of the cc51df624 genesis-node persistence.
+BOOST_AUTO_TEST_CASE(BlockOneIncrementalBuildOverGenesisRoot)
+{
+    FullChainFixture fixture{"gen_block1_incremental"};
+    fixture.buildGenesis(genL2Genesis());
+    auto genesisRoot = fixture.headerOnChain(0)->stateRoot();
+    auto genesisNodeCount = fixture.backendNodeCount();
+    BOOST_REQUIRE_GT(genesisNodeCount, 0);
+
+    auto const contract = genAddress(c_genContractAddress);
+    auto const eoa = genAddress(c_genEoaAddress);
+    h256 newSlot{};
+    newSlot.data()[31] = 0x05;
+    h256 newValue{};
+    newValue.data()[31] = 0x99;
+
+    // Block 1: subsequent-touch of the contract — balance update + one NEW slot. The merge
+    // must resolve the genesis account leaf AND the genesis storage sub-trie nodes through
+    // the persisted "/mpt/" rows; a missing node would abort the execute loudly.
+    fixture.planBlock(1, {FullChainFixture::balanceRow(contract, "777"),
+                             FullChainFixture::slotRow(contract, newSlot, newValue)});
+    auto header1 = fixture.runBlock(1);
+
+    auto expectedRoot1 = genStateRootOracle({
+        {c_genContractAddress, 1, u256(777),
+            genContractStorageRoot({{newSlot, bytes(newValue.begin(), newValue.end())}}),
+            genContractCodeHash()},
+        {c_genEoaAddress, 0, u256(1000), mpt::emptyRootHash(), mpt::emptyCodeHash()},
+    });
+    BOOST_CHECK_EQUAL(header1->stateRoot().hex(), expectedRoot1.hex());
+    BOOST_CHECK_NE(header1->stateRoot(), genesisRoot);
+    BOOST_CHECK_GT(fixture.backendNodeCount(), genesisNodeCount);
+
+    // Block 2: the chain keeps extending incrementally (parent root from block 1's header).
+    fixture.planBlock(2, {FullChainFixture::balanceRow(eoa, "2000")});
+    auto header2 = fixture.runBlock(2);
+    auto expectedRoot2 = genStateRootOracle({
+        {c_genContractAddress, 1, u256(777),
+            genContractStorageRoot({{newSlot, bytes(newValue.begin(), newValue.end())}}),
+            genContractCodeHash()},
+        {c_genEoaAddress, 0, u256(2000), mpt::emptyRootHash(), mpt::emptyCodeHash()},
+    });
+    BOOST_CHECK_EQUAL(header2->stateRoot().hex(), expectedRoot2.hex());
+    BOOST_CHECK_EQUAL(fixture.headerOnChain(2)->stateRoot(), header2->stateRoot());
+}
+
+// Scenario-B priority over scenario A: even with a feature_mpt_state_root activation row
+// pointing far in the future (block 100), the l2 flag — checked FIRST in shouldBuildMPT —
+// keeps every block on the MPT path. Block 1 commits an MPT root, not an XOR root.
+BOOST_AUTO_TEST_CASE(L2PriorityOverScenarioAActivation)
+{
+    FullChainFixture fixture{"gen_l2_priority"};
+    fixture.buildGenesis(genL2Genesis());
+    fixture.enableFeatureFromBlock("feature_mpt_state_root", 100);
+
+    auto const eoa = genAddress(c_genEoaAddress);
+    std::vector<FCRowOp> rows{FullChainFixture::balanceRow(eoa, "4242")};
+    fixture.planBlock(1, rows);
+    auto header1 = fixture.runBlock(1);
+
+    // At block 1 the scenario-A flag is NOT yet visible (enableNumber 100)…
+    BOOST_CHECK(!fixture.featuresAt(1).get(ledger::Features::Flag::feature_mpt_state_root));
+    // …but the block still commits the MPT root (and NOT the XOR fold of its delta).
+    auto expectedRoot = genStateRootOracle({
+        {c_genContractAddress, 1, u256(500), genContractStorageRoot(), genContractCodeHash()},
+        {c_genEoaAddress, 0, u256(4242), mpt::emptyRootHash(), mpt::emptyCodeHash()},
+    });
+    BOOST_CHECK_EQUAL(header1->stateRoot().hex(), expectedRoot.hex());
+    BOOST_CHECK_NE(header1->stateRoot(), fixture.xorOracle(rows, fixture.featuresAt(1)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace

--- a/transaction-scheduler/tests/BaselineSchedulerMPTL1UpgradeTest.cpp
+++ b/transaction-scheduler/tests/BaselineSchedulerMPTL1UpgradeTest.cpp
@@ -1,0 +1,191 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file BaselineSchedulerMPTL1UpgradeTest.cpp
+ * @brief Scenario-A activation transition, end to end over the real stack (M6.5): a chain
+ *        genesis'd by the real Ledger on real RocksDB activates feature_mpt_state_root
+ *        mid-chain through a real SYS_CONFIG {value, enableNumber} row — no feature
+ *        injection hook anywhere. Blocks up to and INCLUDING the activation block N stay on
+ *        the legacy XOR root; block N+1 starts the MPT from the EMPTY trie (the activation
+ *        boundary — pre-activation accounts stay dormant); N+2 extends it incrementally via
+ *        the parent header. First-touch of a dormant account commits its touched rows only:
+ *        account metadata is read from flat state, but slots written before activation stay
+ *        outside the storage trie (spec design3 — the 2026-07-09 revision removed the
+ *        first-touch prefix-scan bootstrap deliberately).
+ */
+#include "FullChainFixture.h"
+#include "bcos-ledger/mpt/Account.h"
+#include <boost/test/unit_test.hpp>
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::test::fullchain;
+namespace mpt = bcos::ledger::mpt;
+
+constexpr std::string_view c_mptFlagName = "feature_mpt_state_root";
+
+h256 l1uSlot(uint8_t lastByte)
+{
+    h256 slot{};
+    slot.data()[31] = lastByte;
+    return slot;
+}
+
+h256 l1uValue(uint8_t lastByte)
+{
+    h256 value{};
+    value.data()[31] = lastByte;
+    return value;
+}
+
+BOOST_AUTO_TEST_SUITE(BaselineSchedulerMPTL1UpgradeSuite)
+
+// Activation at N=3. Blocks 1..2 (pre-activation) and block 3 (the activation block itself,
+// strictly-greater rule) commit XOR roots and write zero "/mpt/" rows. Block 4 commits an
+// MPT root that equals a from-scratch build over ONLY the accounts written at block 4 —
+// proving the parent root was emptyRootHash() and pre-activation accounts stayed out. Block
+// 5 extends the trie incrementally (parent root from block 4's committed header).
+BOOST_AUTO_TEST_CASE(ActivationBlockKeepsXorNextBlockStartsMPT)
+{
+    FullChainFixture fixture{"l1u_transition"};
+    fixture.buildGenesis(FullChainFixture::baseGenesis());
+    fixture.enableFeatureFromBlock(c_mptFlagName, 3);
+
+    auto const addressA = FullChainFixture::makeAddress(0xAA);  // XOR-era only
+    auto const addressB = FullChainFixture::makeAddress(0xBB);  // first MPT block
+    auto const addressC = FullChainFixture::makeAddress(0xCC);  // second MPT block
+
+    std::vector<FCRowOp> rows1{
+        FullChainFixture::balanceRow(addressA, "1000"), FullChainFixture::nonceRow(addressA, "1")};
+    std::vector<FCRowOp> rows2{FullChainFixture::balanceRow(addressA, "2000")};
+    std::vector<FCRowOp> rows3{FullChainFixture::nonceRow(addressA, "2")};
+    std::vector<FCRowOp> rows4{
+        FullChainFixture::balanceRow(addressB, "7"), FullChainFixture::nonceRow(addressB, "3")};
+    std::vector<FCRowOp> rows5{FullChainFixture::balanceRow(addressC, "13")};
+    fixture.planBlock(1, rows1);
+    fixture.planBlock(2, rows2);
+    fixture.planBlock(3, rows3);
+    fixture.planBlock(4, rows4);
+    fixture.planBlock(5, rows5);
+
+    // Blocks 1-2: the flag row's enableNumber=3 is invisible below 3 — pure XOR era.
+    auto header1 = fixture.runBlock(1);
+    BOOST_CHECK(!fixture.featuresAt(1).get(ledger::Features::Flag::feature_mpt_state_root));
+    BOOST_CHECK_EQUAL(header1->stateRoot(), fixture.xorOracle(rows1, fixture.featuresAt(1)));
+    auto header2 = fixture.runBlock(2);
+    BOOST_CHECK_EQUAL(header2->stateRoot(), fixture.xorOracle(rows2, fixture.featuresAt(2)));
+    BOOST_CHECK_EQUAL(fixture.backendNodeCount(), 0);
+
+    // Block 3 = activation block N: the flag IS active (activationBlockOf == 3), but the
+    // strictly-greater rule keeps this block on XOR; still no "/mpt/" row anywhere.
+    auto features3 = fixture.featuresAt(3);
+    BOOST_REQUIRE(features3.get(ledger::Features::Flag::feature_mpt_state_root));
+    BOOST_CHECK_EQUAL(
+        features3.activationBlockOf(ledger::Features::Flag::feature_mpt_state_root), 3);
+    auto header3 = fixture.runBlock(3);
+    BOOST_CHECK_EQUAL(header3->stateRoot(), fixture.xorOracle(rows3, features3));
+    BOOST_CHECK_EQUAL(fixture.backendNodeCount(), 0);
+
+    // Block 4 = N+1: first MPT root. Equals the from-scratch oracle over {B} ALONE — the
+    // parent root was the empty trie and XOR-era account A did not enter.
+    auto header4 = fixture.runBlock(4);
+    mpt::Account accountB;
+    accountB.balance = 7;
+    accountB.nonce = 3;
+    BOOST_CHECK_EQUAL(header4->stateRoot(), FullChainFixture::mptOracle({{addressB, accountB}}));
+    BOOST_CHECK_GT(fixture.backendNodeCount(), 0);
+    // Discriminating control: a trie that DID absorb the pre-activation account would have a
+    // different root.
+    mpt::Account accountA;
+    accountA.balance = 2000;
+    accountA.nonce = 2;
+    BOOST_CHECK_NE(header4->stateRoot(),
+        FullChainFixture::mptOracle({{addressA, accountA}, {addressB, accountB}}));
+
+    // Block 5 = N+2: incremental chain — parent root resolves from block 4's committed
+    // header, trie now covers {B, C}.
+    auto header5 = fixture.runBlock(5);
+    mpt::Account accountC;
+    accountC.balance = 13;
+    BOOST_CHECK_EQUAL(header5->stateRoot(),
+        FullChainFixture::mptOracle({{addressB, accountB}, {addressC, accountC}}));
+
+    // The committed chain agrees with the executed headers.
+    BOOST_CHECK_EQUAL(fixture.headerOnChain(3)->stateRoot(), header3->stateRoot());
+    BOOST_CHECK_EQUAL(fixture.headerOnChain(5)->stateRoot(), header5->stateRoot());
+}
+
+// A dormant account (created with a storage slot BEFORE activation) is first touched after
+// the transition: the touch commits the touched rows — balance from the delta, nonce
+// inherited from flat state — and the storage trie covers ONLY the newly-touched slot. The
+// pre-activation slot stays outside (no first-touch bootstrap scan), pinned by a
+// discriminating negative oracle.
+BOOST_AUTO_TEST_CASE(DormantAccountFirstTouchCommitsTouchedRowsOnly)
+{
+    FullChainFixture fixture{"l1u_dormant_first_touch"};
+    fixture.buildGenesis(FullChainFixture::baseGenesis());
+    fixture.enableFeatureFromBlock(c_mptFlagName, 2);
+
+    auto const dormant = FullChainFixture::makeAddress(0xDD);
+    auto const active = FullChainFixture::makeAddress(0xEE);
+    auto const oldSlot = l1uSlot(0x01);
+    auto const oldValue = l1uValue(0x2A);
+    auto const newSlot = l1uSlot(0x05);
+    auto const newValue = l1uValue(0x63);
+
+    // Block 1 (XOR era): dormant account gets balance, nonce and one storage slot.
+    std::vector<FCRowOp> rows1{FullChainFixture::balanceRow(dormant, "77"),
+        FullChainFixture::nonceRow(dormant, "5"),
+        FullChainFixture::slotRow(dormant, oldSlot, oldValue)};
+    fixture.planBlock(1, rows1);
+    // Block 2 (activation block, XOR): unrelated account.
+    std::vector<FCRowOp> rows2{FullChainFixture::balanceRow(active, "1")};
+    fixture.planBlock(2, rows2);
+    // Block 3 (first MPT block): only the unrelated account — dormant stays out.
+    fixture.planBlock(3, {FullChainFixture::balanceRow(active, "2")});
+    // Block 4: first touch of the dormant account — balance update + one NEW slot.
+    fixture.planBlock(4, {FullChainFixture::balanceRow(dormant, "88"),
+                             FullChainFixture::slotRow(dormant, newSlot, newValue)});
+
+    fixture.runBlock(1);
+    fixture.runBlock(2);
+
+    auto header3 = fixture.runBlock(3);
+    mpt::Account accountActive;
+    accountActive.balance = 2;
+    BOOST_CHECK_EQUAL(header3->stateRoot(), FullChainFixture::mptOracle({{active, accountActive}}));
+
+    auto header4 = fixture.runBlock(4);
+    mpt::Account accountDormant;
+    accountDormant.balance = 88;  // from the block-4 delta
+    accountDormant.nonce = 5;     // first-touch metadata read from the flat rows of block 1
+    accountDormant.storageRoot =
+        FullChainFixture::storageTrieOracle({{newSlot, bytes(newValue.begin(), newValue.end())}});
+    BOOST_CHECK_EQUAL(header4->stateRoot(),
+        FullChainFixture::mptOracle({{active, accountActive}, {dormant, accountDormant}}));
+
+    // Discriminating control: had the pre-activation slot been bootstrapped into the storage
+    // trie, the root would differ.
+    mpt::Account accountBootstrapped = accountDormant;
+    accountBootstrapped.storageRoot =
+        FullChainFixture::storageTrieOracle({{oldSlot, bytes(oldValue.begin(), oldValue.end())},
+            {newSlot, bytes(newValue.begin(), newValue.end())}});
+    BOOST_CHECK_NE(header4->stateRoot(),
+        FullChainFixture::mptOracle({{active, accountActive}, {dormant, accountBootstrapped}}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace

--- a/transaction-scheduler/tests/CMakeLists.txt
+++ b/transaction-scheduler/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set_source_files_properties("main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 # FullChainFixture.h pulls RocksDB and testutils headers whose names collide with the
 # using-directives other unity-merged TUs carry; compile its users standalone.
 set_source_files_properties(
-    "FullChainFixtureSmokeTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    "FullChainFixtureSmokeTest.cpp" "BaselineSchedulerMPTL1UpgradeTest.cpp"
+    "BaselineSchedulerMPTGenesisTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(test-transaction-scheduler PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" "test-transaction-scheduler" "" "")

--- a/transaction-scheduler/tests/CMakeLists.txt
+++ b/transaction-scheduler/tests/CMakeLists.txt
@@ -16,5 +16,9 @@ target_link_libraries(test-transaction-scheduler
 	FakeIt::FakeIt-boost
 )
 set_source_files_properties("main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+# FullChainFixture.h pulls RocksDB and testutils headers whose names collide with the
+# using-directives other unity-merged TUs carry; compile its users standalone.
+set_source_files_properties(
+    "FullChainFixtureSmokeTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(test-transaction-scheduler PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" "test-transaction-scheduler" "" "")

--- a/transaction-scheduler/tests/FullChainFixture.h
+++ b/transaction-scheduler/tests/FullChainFixture.h
@@ -1,0 +1,482 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FullChainFixture.h
+ * @brief End-to-end chain fixture over the PRODUCTION persistence stack: a real
+ *        CheckpointRocksDBStorage backend in a tmpdir (the exact storage
+ *        GlobalStateStorageInitializer builds for a node), a real Ledger sharing the same
+ *        ::rocksdb::DB through the legacy RocksDBStorage adapter (the Initializer.cpp
+ *        arrangement), real Ledger::buildGenesisBlock — including the L2 genesis trie-node
+ *        persistence — and the real BaselineScheduler execute/commit path on top.
+ *
+ *        Two deliberate substitutions, both OUTSIDE the code under test:
+ *        - block deltas are injected through a plan-replaying scheduler impl instead of the
+ *          EVM executor (the MPT build consumes the view's mutable layer either way);
+ *        - the txpool is FakeTxPool: every test block carries its transactions inline, so
+ *          getTransactions never consults the pool.
+ *
+ *        Features are NOT injected through any test hook: scenario flags activate through
+ *        real SYS_CONFIG rows (genesis features via buildGenesisBlock, mid-chain activation
+ *        via the same {value, enableNumber} row a governance action writes), and the
+ *        scheduler reads them back through the production getLedgerConfig(view, ...) path.
+ *
+ *        Shared by FullChainFixtureSmokeTest / BaselineSchedulerMPTL1UpgradeTest /
+ *        BaselineSchedulerMPTGenesisTest (test-transaction-scheduler) and
+ *        EthGetProofIntegrationTest (test-bcos-rpc).
+ */
+#pragma once
+
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/GenesisConfig.h"
+#include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage/Serialize.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
+#include "bcos-framework/testutils/faker/FakeTxPool.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-ledger/Ledger.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-ledger/mpt/Classify.h"
+#include "bcos-ledger/mpt/MPTBuilder.h"
+#include "bcos-ledger/mpt/StorageValueCodec.h"
+#include "bcos-protocol/TransactionSubmitResultFactoryImpl.h"
+#include "bcos-storage/CheckpointRocksDBStorage.h"
+#include "bcos-storage/KeyPrefixes.h"
+#include "bcos-storage/RocksDBStorage.h"
+#include "bcos-storage/StateKVResolver.h"
+#include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
+#include "bcos-transaction-scheduler/BaselineScheduler.h"
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bcos::test::fullchain
+{
+
+// The production state-storage stack, mirroring libinitializer/GlobalStateStorageInitializer.h
+// (not included: its constructor lives in the init library, which tests do not link). The LRU
+// cache layer is omitted (void): it is a read-through cache with no behavior of its own that
+// these correctness tests could observe.
+using FCMutableStorage =
+    storage2::memory_storage::MemoryStorage<executor_v1::StateKey, executor_v1::StateValue,
+        storage2::memory_storage::Attribute(
+            storage2::memory_storage::ORDERED | storage2::memory_storage::LOGICAL_DELETION)>;
+using FCCheckpointStorage =
+    storage2::rocksdb::CheckpointRocksDBStorage<executor_v1::StateKey, executor_v1::StateValue,
+        storage2::rocksdb::StateKeyResolver, storage2::rocksdb::StateValueResolver>;
+using FCMultiLayerStorage =
+    storage2::MultiLayerStorage<FCMutableStorage, void, FCCheckpointStorage>;
+
+/// One flat-state row the plan-replaying scheduler writes for a block.
+/// value == nullopt performs a storage-level logical deletion.
+struct FCRowOp
+{
+    std::string table;
+    std::string key;
+    std::optional<std::string> value;
+};
+
+/// Scheduler impl replaying a per-block row plan into the storage BaselineScheduler hands it
+/// (the execute view's mutable layer) — the production write path minus the EVM.
+struct FCWritingScheduler
+{
+    std::map<protocol::BlockNumber, std::vector<FCRowOp>> const* m_plan{};
+
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(auto& storage,
+        auto& /*executor*/, protocol::BlockHeader const& blockHeader,
+        ::ranges::input_range auto const& transactions, ledger::LedgerConfig const& /*unused*/)
+    {
+        if (auto it = m_plan->find(blockHeader.number()); it != m_plan->end())
+        {
+            for (auto const& row : it->second)
+            {
+                if (row.value)
+                {
+                    storage::Entry entry;
+                    entry.set(*row.value);
+                    co_await storage2::writeOne(
+                        storage, executor_v1::StateKey{row.table, row.key}, std::move(entry));
+                }
+                else
+                {
+                    co_await storage2::removeOne(
+                        storage, executor_v1::StateKey{row.table, row.key});
+                }
+            }
+        }
+        auto receipts = ::ranges::iota_view<size_t, size_t>(0, ::ranges::size(transactions)) |
+                        ::ranges::views::transform([](size_t) -> protocol::TransactionReceipt::Ptr {
+                            auto receipt =
+                                std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+                            constexpr static std::string_view str = "abc";
+                            auto& inner = receipt->inner();
+                            inner.dataHash.assign(str.begin(), str.end());
+                            inner.data.gasUsed = "100";
+                            return receipt;
+                        }) |
+                        ::ranges::to<std::vector>();
+        co_return receipts;
+    }
+};
+
+/// No-op executor satisfying BaselineScheduler's TransactionExecutor concept; never invoked
+/// because FCWritingScheduler does not delegate per-transaction execution.
+struct FCExecutor
+{
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(auto& /*storage*/,
+        protocol::BlockHeader const& /*blockHeader*/, protocol::Transaction const& /*transaction*/,
+        int /*contextID*/, ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+    {
+        co_return {};
+    }
+    template <class Storage>
+    struct ExecuteContext
+    {
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
+    };
+    auto createExecuteContext(auto& storage, protocol::BlockHeader const& /*blockHeader*/,
+        protocol::Transaction const& /*transaction*/, int32_t /*contextID*/,
+        ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+        -> task::Task<ExecuteContext<std::decay_t<decltype(storage)>>>
+    {
+        co_return {};
+    }
+};
+
+class FullChainFixture
+{
+    /// Declared FIRST so its destructor runs LAST — after the RocksDB handles have closed.
+    struct TmpDirGuard
+    {
+        std::filesystem::path m_path;
+        explicit TmpDirGuard(std::string const& testName)
+        {
+            static std::atomic<uint64_t> counter{0};
+            m_path = std::filesystem::temp_directory_path() /
+                     ("fullchain-" + testName + "-" + std::to_string(counter.fetch_add(1)) + "-" +
+                         std::to_string(static_cast<uint64_t>(
+                             std::chrono::steady_clock::now().time_since_epoch().count())));
+            std::filesystem::remove_all(m_path);
+            std::filesystem::create_directories(m_path);
+        }
+        ~TmpDirGuard() noexcept
+        {
+            std::error_code ec;
+            std::filesystem::remove_all(m_path, ec);
+        }
+        TmpDirGuard(TmpDirGuard const&) = delete;
+        TmpDirGuard& operator=(TmpDirGuard const&) = delete;
+    };
+
+public:
+    explicit FullChainFixture(std::string testName)
+      : m_tmpdir(testName),
+        m_checkpointStorage(m_tmpdir.m_path.string()),
+        m_multiLayerStorage(m_checkpointStorage),
+        // The legacy StorageInterface shares CheckpointRocksDBStorage's ::rocksdb::DB with a
+        // no-op deleter — byte-for-byte the Initializer.cpp wiring. Legacy keys ("table:key")
+        // and StateKeyResolver encodings agree, so the Ledger and the scheduler stack
+        // read/write the same physical rows.
+        m_legacyStorage(std::make_shared<storage::RocksDBStorage>(
+            std::unique_ptr<::rocksdb::DB, std::function<void(::rocksdb::DB*)>>(
+                &m_multiLayerStorage.latestBackend().rocksDB(), [](::rocksdb::DB*) {}),
+            nullptr)),
+        m_cryptoSuite(std::make_shared<crypto::CryptoSuite>(
+            std::make_shared<crypto::Keccak256>(), nullptr, nullptr)),
+        m_blockHeaderFactory(
+            std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(m_cryptoSuite)),
+        m_transactionFactory(
+            std::make_shared<bcostars::protocol::TransactionFactoryImpl>(m_cryptoSuite)),
+        m_receiptFactory(
+            std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(m_cryptoSuite)),
+        m_blockFactory(std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+            m_cryptoSuite, m_blockHeaderFactory, m_transactionFactory, m_receiptFactory)),
+        m_ledger(std::make_shared<bcos::ledger::Ledger>(m_blockFactory, m_legacyStorage, 1)),
+        m_txpool(std::make_shared<bcos::test::FakeTxPool>()),
+        m_transactionSubmitResultFactory(
+            std::make_shared<protocol::TransactionSubmitResultFactoryImpl>()),
+        m_baselineScheduler(m_multiLayerStorage, m_schedulerImpl, m_executor, *m_blockFactory,
+            *m_ledger, *m_txpool, *m_transactionSubmitResultFactory, *m_hashImpl)
+    {
+        m_schedulerImpl.m_plan = &m_plan;
+        m_baselineScheduler.registerBlockNumberNotifier([](protocol::BlockNumber) {});
+        m_baselineScheduler.registerTransactionNotifier(
+            [](protocol::BlockNumber, protocol::TransactionSubmitResultsPtr,
+                std::function<void(Error::Ptr)> callback) { callback(nullptr); });
+    }
+
+    // --- genesis ---------------------------------------------------------------------------
+
+    /// Minimal viable genesis (same shape as test_GenesisNodePersistence's baseConfig).
+    /// Auth check off: initSysContract's block-0 deploy is EVM work outside this fixture.
+    static ledger::GenesisConfig baseGenesis()
+    {
+        ledger::GenesisConfig genesis;
+        genesis.m_txGasLimit = 3000000000;
+        genesis.m_compatibilityVersion =
+            static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_6_VERSION);
+        genesis.m_chainID = "901";
+        genesis.m_groupID = "group0";
+        genesis.m_isAuthCheck = false;
+        return genesis;
+    }
+
+    /// Real chain init: Ledger::buildGenesisBlock over the shared RocksDB — writes the genesis
+    /// header, SYS_CONFIG rows (features included) and, for L2 genesis configs, every genesis
+    /// trie node as a "/mpt/" state row (cc51df624).
+    void buildGenesis(ledger::GenesisConfig const& genesis)
+    {
+        ledger::LedgerConfig param;
+        param.setBlockNumber(0);
+        param.setHash(crypto::HashType(""));
+        param.setBlockTxCountLimit(0);
+        bool ok = task::syncWait(ledger::buildGenesisBlock(*m_ledger, genesis, param));
+        BOOST_REQUIRE_MESSAGE(ok, "buildGenesisBlock failed");
+    }
+
+    /// Scenario-A style mid-chain activation: write the SYS_CONFIG feature row exactly as a
+    /// governance action would — {value="1", enableNumber}. getLedgerConfig's readFromStorage
+    /// turns it into set(flag) + activationBlock == enableNumber for every block >=
+    /// enableNumber; blocks below never see the flag.
+    void enableFeatureFromBlock(std::string_view flagName, protocol::BlockNumber enableNumber)
+    {
+        storage::Entry entry;
+        entry.set(storage::serialize::encode(ledger::SystemConfigEntry{"1", enableNumber}));
+        task::syncWait(storage2::writeOne(m_multiLayerStorage.latestBackend(),
+            executor_v1::StateKey{ledger::SYS_CONFIG, flagName}, std::move(entry)));
+    }
+
+    // --- running blocks --------------------------------------------------------------------
+
+    void planBlock(protocol::BlockNumber number, std::vector<FCRowOp> rows)
+    {
+        m_plan[number] = std::move(rows);
+    }
+
+    static FCRowOp balanceRow(Address const& addr, std::string value)
+    {
+        return {bcos::ledger::mpt::accountTableName(addr),
+            std::string(bcos::ledger::mpt::ROW_BALANCE), std::move(value)};
+    }
+    static FCRowOp nonceRow(Address const& addr, std::string value)
+    {
+        return {bcos::ledger::mpt::accountTableName(addr),
+            std::string(bcos::ledger::mpt::ROW_NONCE), std::move(value)};
+    }
+    /// A storage slot row: 32-raw-byte slot key, 32-raw-byte value.
+    static FCRowOp slotRow(Address const& addr, h256 const& slot, h256 const& value)
+    {
+        return {bcos::ledger::mpt::accountTableName(addr),
+            std::string(reinterpret_cast<char const*>(slot.data()), h256::SIZE),
+            std::string(reinterpret_cast<char const*>(value.data()), h256::SIZE)};
+    }
+
+    std::tuple<Error::Ptr, protocol::BlockHeader::Ptr> executeBlockRaw(protocol::BlockNumber number)
+    {
+        auto block = std::make_shared<bcostars::protocol::BlockImpl>();
+        auto blockHeader = block->blockHeader();
+        blockHeader->setNumber(number);
+        blockHeader->setVersion(static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_6_VERSION));
+        blockHeader->calculateHash(*m_hashImpl);
+        // One inline transaction: getTransactions serves the block's own transactions, so the
+        // FakeTxPool is never consulted, and the real Ledger prewrite has something to store.
+        bytes input;
+        block->appendTransaction(m_transactionFactory->createTransaction(
+            0, "to", input, std::to_string(number), 100, "chain", "group", 0));
+
+        Error::Ptr execError;
+        protocol::BlockHeader::Ptr executedHeader;
+        m_baselineScheduler.executeBlock(
+            block, false, [&](Error::Ptr error, protocol::BlockHeader::Ptr header, bool) {
+                execError = std::move(error);
+                executedHeader = std::move(header);
+            });
+        return {std::move(execError), std::move(executedHeader)};
+    }
+
+    protocol::BlockHeader::Ptr executeOneBlock(protocol::BlockNumber number)
+    {
+        auto [error, header] = executeBlockRaw(number);
+        BOOST_REQUIRE_MESSAGE(
+            !error, "executeBlock failed: " + (error ? error->errorMessage() : ""));
+        BOOST_REQUIRE(header);
+        return header;
+    }
+
+    void commitOneBlock(protocol::BlockHeader::Ptr const& header)
+    {
+        Error::Ptr commitError;
+        m_baselineScheduler.commitBlock(header,
+            [&](Error::Ptr error, ledger::LedgerConfig::Ptr) { commitError = std::move(error); });
+        BOOST_REQUIRE_MESSAGE(!commitError,
+            "commitBlock failed: " + (commitError ? commitError->errorMessage() : ""));
+    }
+
+    /// Execute + commit one block; returns the executed header (stateRoot readable).
+    protocol::BlockHeader::Ptr runBlock(protocol::BlockNumber number)
+    {
+        auto header = executeOneBlock(number);
+        commitOneBlock(header);
+        return header;
+    }
+
+    // --- assertion helpers -----------------------------------------------------------------
+
+    /// The block header as COMMITTED on chain, read back through the real Ledger.
+    protocol::BlockHeader::Ptr headerOnChain(protocol::BlockNumber number)
+    {
+        auto block = task::syncWait(ledger::getBlockData(*m_ledger, number, ledger::HEADER));
+        BOOST_REQUIRE_MESSAGE(block && block->blockHeader(),
+            "no block header on chain for " + std::to_string(number));
+        return block->blockHeader();
+    }
+
+    /// One trie-node row from the RocksDB backend under its ordinary "/mpt/" StateKey.
+    std::optional<bytes> backendNode(h256 const& hash)
+    {
+        auto entry = task::syncWait(storage2::readOne(
+            m_multiLayerStorage.latestBackend(), storage2::mptNodeStateKey(hash)));
+        if (!entry)
+        {
+            return std::nullopt;
+        }
+        auto raw = entry->get();
+        return bytes(raw.begin(), raw.end());
+    }
+
+    /// Count of committed "/mpt/" rows in the RocksDB backend.
+    size_t backendNodeCount()
+    {
+        return task::syncWait([this]() -> task::Task<size_t> {
+            size_t count = 0;
+            auto iterator = co_await storage2::range(m_multiLayerStorage.latestBackend());
+            while (auto keyValue = co_await iterator.next())
+            {
+                auto&& [key, value] = *keyValue;
+                if (executor_v1::StateKeyView{key}.m_table == storage2::kMPTTable)
+                {
+                    ++count;
+                }
+            }
+            co_return count;
+        }());
+    }
+
+    // --- oracles (independent of the scheduler's build) --------------------------------------
+
+    /// Legacy XOR oracle over a block's row plan (same per-entry hash shape as
+    /// calculateStateRoot). @p features must be the features ACTIVE at that block.
+    h256 xorOracle(std::vector<FCRowOp> const& rows, ledger::Features const& active) const
+    {
+        const std::optional<ledger::Features> features{active};
+        h256 expected;
+        for (auto const& row : rows)
+        {
+            BOOST_REQUIRE(row.value);
+            storage::Entry entry;
+            entry.set(*row.value);
+            expected ^= entry.hash(row.table, row.key, *m_hashImpl,
+                static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_6_VERSION), features);
+        }
+        return expected;
+    }
+
+    /// The features the production read path yields at @p blockNumber — read from the same
+    /// committed SYS_CONFIG rows the scheduler reads, activation blocks included.
+    ledger::Features featuresAt(protocol::BlockNumber blockNumber)
+    {
+        ledger::Features features;
+        task::syncWait(
+            ledger::readFromStorage(features, m_multiLayerStorage.latestBackend(), blockNumber));
+        return features;
+    }
+
+    /// Independent MPT oracle: one from-scratch commitTrie build over the expected FINAL
+    /// account set (tries are history-independent).
+    static h256 mptOracle(std::map<Address, bcos::ledger::mpt::Account> const& accounts)
+    {
+        namespace mpt = bcos::ledger::mpt;
+        std::map<h256, std::optional<bytes>> accountChanges;
+        for (auto const& [address, account] : accounts)
+        {
+            accountChanges[mpt::accountKeyHash(address)] = account.encode();
+        }
+        storage2::memory_storage::MemoryStorage<h256, bytes, storage2::memory_storage::ORDERED>
+            scratch;
+        auto merged =
+            task::syncWait(mpt::commitTrie(scratch, mpt::emptyRootHash(), accountChanges));
+        return merged.root;
+    }
+
+    /// Storage-trie oracle over (slot -> 32-byte raw value).
+    static h256 storageTrieOracle(std::map<h256, bytes> const& slots)
+    {
+        namespace mpt = bcos::ledger::mpt;
+        std::map<h256, std::optional<bytes>> changes;
+        for (auto const& [slot, rawValue] : slots)
+        {
+            changes[mpt::slotKeyHash(slot)] =
+                mpt::encodeStorageValue(bytesConstRef(rawValue.data(), rawValue.size()));
+        }
+        storage2::memory_storage::MemoryStorage<h256, bytes, storage2::memory_storage::ORDERED>
+            scratch;
+        auto merged = task::syncWait(mpt::commitTrie(scratch, mpt::emptyRootHash(), changes));
+        return merged.root;
+    }
+
+    static Address makeAddress(uint8_t firstByte)
+    {
+        Address address{};
+        address.data()[0] = firstByte;
+        return address;
+    }
+
+    TmpDirGuard m_tmpdir;
+    FCCheckpointStorage m_checkpointStorage;
+    FCMultiLayerStorage m_multiLayerStorage;
+    storage::StorageInterface::Ptr m_legacyStorage;
+    crypto::CryptoSuite::Ptr m_cryptoSuite;
+    std::shared_ptr<bcostars::protocol::BlockHeaderFactoryImpl> m_blockHeaderFactory;
+    std::shared_ptr<bcostars::protocol::TransactionFactoryImpl> m_transactionFactory;
+    std::shared_ptr<bcostars::protocol::TransactionReceiptFactoryImpl> m_receiptFactory;
+    std::shared_ptr<bcostars::protocol::BlockFactoryImpl> m_blockFactory;
+    std::shared_ptr<bcos::ledger::Ledger> m_ledger;
+    std::shared_ptr<bcos::test::FakeTxPool> m_txpool;
+    std::shared_ptr<protocol::TransactionSubmitResultFactoryImpl> m_transactionSubmitResultFactory;
+    crypto::Hash::Ptr m_hashImpl = std::make_shared<crypto::Keccak256>();
+    std::map<protocol::BlockNumber, std::vector<FCRowOp>> m_plan;
+    FCWritingScheduler m_schedulerImpl;
+    FCExecutor m_executor;
+    scheduler_v1::BaselineScheduler<FCMultiLayerStorage, FCExecutor, FCWritingScheduler,
+        bcos::ledger::Ledger>
+        m_baselineScheduler;
+};
+
+}  // namespace bcos::test::fullchain

--- a/transaction-scheduler/tests/FullChainFixtureSmokeTest.cpp
+++ b/transaction-scheduler/tests/FullChainFixtureSmokeTest.cpp
@@ -1,0 +1,84 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file FullChainFixtureSmokeTest.cpp
+ * @brief Self-checks for FullChainFixture (M6.4a): the real-RocksDB + real-Ledger harness
+ *        itself runs a chain — before BaselineSchedulerMPTL1UpgradeTest /
+ *        BaselineSchedulerMPTGenesisTest / EthGetProofIntegrationTest build on it.
+ */
+#include "FullChainFixture.h"
+#include <boost/test/unit_test.hpp>
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::test::fullchain;
+
+BOOST_AUTO_TEST_SUITE(FullChainFixtureSmokeSuite)
+
+// A plain (no MPT flags) chain: genesis over the real Ledger, one block through the real
+// BaselineScheduler execute/commit path. The stateRoot is the legacy XOR root (pinned
+// against the independent oracle), no "/mpt/" row reaches the RocksDB backend, and the
+// committed header reads back through the real Ledger with the same root.
+BOOST_AUTO_TEST_CASE(XorChainOneBlockRoundTrip)
+{
+    FullChainFixture fixture{"smoke_xor_one_block"};
+    fixture.buildGenesis(FullChainFixture::baseGenesis());
+
+    auto const address = FullChainFixture::makeAddress(0xAA);
+    std::vector<FCRowOp> rows{
+        FullChainFixture::balanceRow(address, "1000"), FullChainFixture::nonceRow(address, "1")};
+    fixture.planBlock(1, rows);
+
+    auto header = fixture.runBlock(1);
+    BOOST_CHECK_NE(header->stateRoot(), h256{});
+    BOOST_CHECK_EQUAL(header->stateRoot(), fixture.xorOracle(rows, fixture.featuresAt(1)));
+    BOOST_CHECK_EQUAL(fixture.backendNodeCount(), 0);
+
+    auto onChain = fixture.headerOnChain(1);
+    BOOST_CHECK_EQUAL(onChain->number(), 1);
+    BOOST_CHECK_EQUAL(onChain->stateRoot(), header->stateRoot());
+}
+
+// The fixture's L2 genesis path really reaches RocksDB: an alloc-carrying genesis with
+// feature_l2_ethereum_compat persists a non-zero op-geth-compatible stateRoot in the genesis
+// header AND its trie nodes as committed "/mpt/" rows (cc51df624), readable back through the
+// storage2 backend — the wiring PR-20's scenario-B suite depends on.
+BOOST_AUTO_TEST_CASE(L2GenesisNodesReachBackend)
+{
+    FullChainFixture fixture{"smoke_l2_genesis"};
+    auto genesis = FullChainFixture::baseGenesis();
+    genesis.m_features.push_back(
+        ledger::FeatureSet{ledger::Features::Flag::feature_l2_ethereum_compat, 1});
+    genesis.m_allocs.push_back(ledger::Alloc{.address = "1100000000000000000000000000000000000011",
+        .balance = u256(1000),
+        .nonce = "0",
+        .code = "",
+        .storage = {}});
+    fixture.buildGenesis(genesis);
+
+    auto genesisHeader = fixture.headerOnChain(0);
+    BOOST_CHECK_NE(genesisHeader->stateRoot(), h256{});
+    BOOST_CHECK_GT(fixture.backendNodeCount(), 0);
+
+    // The genesis root's own node row is present and hashes back to the root.
+    auto rootNode = fixture.backendNode(genesisHeader->stateRoot());
+    BOOST_REQUIRE(rootNode.has_value());
+    BOOST_CHECK_EQUAL(
+        crypto::keccak256Hash(bcos::ref(*rootNode)).hex(), genesisHeader->stateRoot().hex());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace


### PR DESCRIPTION
## Failing scenario

An L2 (scenario-B) chain with non-empty genesis allocs: `Ledger::buildGenesisBlock` computes the op-geth-compatible state root over the allocs (`computeGenesisStateRoot`, Ledger.cpp) and seals it into the genesis header — but only the root. The produced trie nodes are discarded (`GenesisStateRoot.cpp` said so explicitly: *"the produced nodes are not persisted — only the root goes into the genesis header"*). Block 1's execute-time incremental MPT build (#5345) then takes the genesis root as parent and must read the parent trie's nodes; none exist, so block 1 fails with `MPTInvariantViolation: Trie: missing node hash`. This was a declared scope cut in #5345; this PR closes it.

## Fix

- `GenesisStateRoot.h/.cpp`: new `GenesisStateTrie{root, nodes}` + `computeGenesisStateTrie()`. `computeTrieRoot` already returns `TrieBuildResult{root, newNodes}`, so no trie API changes — the account trie's nodes and every per-account storage sub-trie's nodes are merged into one hash-keyed map. `computeGenesisStateRoot` keeps its signature and delegates.
- `Ledger.cpp` (`buildGenesisBlock`, fresh-init path only): right after `importGenesisState`, write every node as an ordinary state row `StateKey{"/mpt/", digest}` via `storage2::writeOne(*m_stateStorage, mptNodeStateKey(h), Entry(rlp))` — the identical write path the alloc flat rows use, so node rows share the genesis batch's fate. Gated on `feature_l2_ethereum_compat` in the genesis features (the same predicate as `NodeConfig::validateL2Invariants` and `shouldBuildMPT`'s scenario-B branch).

Behavior notes: the exists-genesis restart path returns before the write loop, so restarts never re-execute it. Scenario A (upgrade activation) is unaffected — its first MPT block starts from `emptyRootHash()` and needs no genesis nodes. Non-MPT chains and allocs-without-flag chains write zero rows.

Build note: linking the `storage` target into bcos-ledger breaks the `install(EXPORT fiscobcosTargets)` set (storage is not exported), so the dependency is an include-dir only (`KeyPrefixes.h` is header-only), PRIVATE and build-tree only.

## Tests

New `test_GenesisNodePersistence.cpp`, 4 cases:

- (a) walk the trie from the genesis header stateRoot via NodeDecoder over the stored rows, checking each node's content hash and descending into storage sub-tries via the decoded account's storageRoot; also asserts stored-row-count == visited-set (no garbage rows);
- (b) empty allocs → zero node rows;
- (c) pbft chain and allocs-without-flag → zero node rows;
- (d) end-to-end: `buildAndCollect` with the genesis root as parent and a block-1-style delta (balance update + new storage slot, subsequent-touch) succeeds, and the resulting root equals an independent from-scratch `computeTrieRoot` oracle.

Red before the fix — cases (a) and (d) fail, (d) with the exact `MPTInvariantViolation: Trie: missing node hash` from the failing scenario. Green after. Negative control: disabling the gate re-produces both failures. Full `test-bcos-ledger` and `test-transaction-scheduler` (comment-only change there) both pass with `*** No errors detected`.

## Known limitation (pre-existing, not introduced here)

A hypothetical empty-alloc L2 genesis would leave the header stateRoot as zero-h256 while `commitTrie` treats only `emptyRootHash()` as from-empty, so block 1 would still fail on such a chain. Currently unreachable: `validateL2Invariants` requires non-empty allocs together with the flag. Left for a follow-up note rather than widening this PR.

## Appended: end-to-end integration tests (M6.4a + M6.5 + M8.4)

Three test-only commits stacked on top (zero production-code changes):

- `d4179c3aa` — `FullChainFixture`: a reusable end-to-end harness over a real `CheckpointRocksDBStorage` (the production four-parameter type), real `Ledger::buildGenesisBlock` (so this PR's genesis node persistence is exercised naturally) and the real `BaselineScheduler` execute/commit path including `prewriteBlockToBuffer`. Feature activation is driven by writing real SYS_CONFIG rows (`{value="1", enableNumber=N}`, the same shape governance writes) read back through `Features::readFromStorage` — no test-only injection hooks.
- `8fa21a816` — activation-transition tests: scenario A (block N still XOR → N+1 switches to MPT with an empty-trie parent, matching a from-scratch oracle → N+2 continues incrementally; dormant-account first-touch commits only touched rows, pinned by a negative oracle) and scenario B (genesis root equals an independent RLP+`computeTrieRoot` oracle; block 1 builds incrementally on the persisted genesis nodes — the first full-stack verification of this PR's fix; L2 takes priority over a scenario-A activation setting).
- `2c8c9572a` — eth_getProof end-to-end: active account → proof verifies; dormant scenario-A account → `-32004` per `EthEndpoint.cpp`; scenario B allocs all prove and verify; a proof checked against a wrong root must be rejected.

Both `test-transaction-scheduler` and `test-bcos-rpc` full suites pass. One note for future work: linking `executor` into `test-bcos-rpc` breaks exception catching binary-wide (its PUBLIC `wedprcrypto` Rust static library ships a conflicting runtime — a libc++ `std::invalid_argument` thrown by `stoull` becomes uncatchable). The tests therefore provide a linkage-only copy of `unhexAddress` instead of linking `executor`; a future duplicate symbol would fail loudly at link time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

