### PR TITLE
feat(rpc): wire the MPT node reader into NodeService for eth_getProof (M8.3 follow-up)

### DIFF
--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.h
@@ -83,10 +83,11 @@ public:
     /// StateKeyResolver.
     using MPTNodeReader = bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>;
 
-    /// Non-owning: the AnyStorage view holds a raw pointer to the underlying storage, whose
-    /// ownership stays with the Initializer; that storage must outlive this NodeService.
-    /// Default unset — the production wiring arrives with the scheduler-injection PR (PR-18);
-    /// until then nothing sets it and eth_getProof answers "MPT not enabled on this node".
+    /// The handle owns its key-translating adapter (storage2::makeMPTNodeReader), but the
+    /// storage underneath it is borrowed — owned by the Initializer, which must outlive this
+    /// NodeService. AIR wires it in AirNodeInitializer (Initializer::mptNodeReader over the
+    /// committed state backend); a tars-built NodeService has no local storage, leaves it
+    /// unset, and eth_getProof answers "MPT not enabled on this node".
     /// shared_ptr because AnyStorage itself is move-only and not default-constructible.
     void setMPTNodeReader(std::shared_ptr<MPTNodeReader> _reader) noexcept
     {
@@ -112,7 +113,8 @@ private:
 
     std::shared_ptr<bcos::engine::AnyEngineService> m_engineService;
 
-    /// Non-owning MPT node reader; see setMPTNodeReader() for the lifetime contract.
+    /// MPT node reader handle (owns its adapter, borrows the underlying storage); see
+    /// setMPTNodeReader() for the lifetime contract.
     std::shared_ptr<MPTNodeReader> m_mptNodeReader;
 
     bcostars::LedgerServicePrx m_ledgerPrx;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -924,8 +924,9 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
     }
     auto const stateRoot = block->blockHeader()->stateRoot();
 
-    // The MPT node reader is wired by the initializer (PR-18); unset means the node does not
-    // maintain an MPT state root — a configuration matter, hence -32603 rather than -32004.
+    // The MPT node reader is wired by the AIR initializer (AirNodeInitializer); unset means
+    // this node has no local path to MPT node rows (e.g. a tars-built NodeService) — a
+    // deployment matter, hence -32603 rather than -32004.
     auto const mptReader = m_nodeService->mptNodeReader();
     if (!mptReader) [[unlikely]]
     {

--- a/bcos-rpc/test/CMakeLists.txt
+++ b/bcos-rpc/test/CMakeLists.txt
@@ -34,7 +34,7 @@ target_compile_options(${TEST_BINARY_NAME} PRIVATE -Wno-unused-variable)
 # exception catching binary-wide (testCallRequest/decode_invalid_gas_string starts
 # reporting "unknown type" for a plain std::invalid_argument). The test file carries a
 # linkage-only definition of unhexAddress instead.
-target_link_libraries(${TEST_BINARY_NAME} txpool ledger rpc tool transaction-scheduler Boost::unit_test_framework)
+target_link_libraries(${TEST_BINARY_NAME} txpool ledger rpc tool transaction-scheduler storage Boost::unit_test_framework)
 set_source_files_properties("unittests/main/main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties("unittests/rpc/RpcReadHandlersTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 # FullChainFixture.h pulls RocksDB and testutils headers whose names collide with the

--- a/bcos-rpc/test/unittests/rpc/EthGetProofReaderWiringTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetProofReaderWiringTest.cpp
@@ -1,0 +1,204 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief eth_getProof over the PRODUCTION reader shape (M8.3 wiring): trie nodes stored as
+ *        ordinary StateKey rows ("/mpt/" plane), read back through
+ *        makeMPTNodeReader(stateRowStorage) — the same adapter chain the AIR initializer
+ *        injects into NodeService — instead of EthGetProofRpcTest's direct h256->bytes map.
+ * @file EthGetProofReaderWiringTest.cpp
+ */
+
+#include "../common/RPCFixture.h"
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Account.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/MPTReadView.h>
+#include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-storage/MPTNodeReadStorage.h>
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <map>
+#include <optional>
+#include <string>
+
+namespace bcos::test
+{
+namespace mpt = bcos::ledger::mpt;
+
+class EthGetProofWiringFixture : public RPCFixture
+{
+public:
+    /// The state-row plane standing in for the committed backend
+    /// (GlobalStateStorage::latestBackend() in production): StateKey -> Entry, no MPT types.
+    using StateRowStorage =
+        bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
+            bcos::executor_v1::StateValue, bcos::storage2::memory_storage::ORDERED>;
+
+    EthGetProofWiringFixture()
+    {
+        rpc = factory->buildLocalRpc(groupInfo, nodeService);
+        web3JsonRpc = rpc->web3JsonRpc();
+        BOOST_TEST(web3JsonRpc != nullptr);
+    }
+
+    /// Commit @p entries into the trie whose nodes live as "/mpt/" STATE ROWS: parent nodes
+    /// are read through the very adapter under test, and the produced nodes are flushed back
+    /// through the ordinary state write path (Entry keyed mptNodeStateKey) — write side and
+    /// read side meet only at the row layout, exactly like scheduler-commit vs rpc-read.
+    bcos::h256 commitIntoStateRows(std::map<bcos::h256, bcos::bytes> const& entries)
+    {
+        std::map<bcos::h256, std::optional<bcos::bytes>> changes;
+        for (auto const& [key, value] : entries)
+        {
+            changes[key] = value;
+        }
+        return task::syncWait([&]() -> task::Task<bcos::h256> {
+            storage2::MPTNodeReadStorage reader(m_stateRows);
+            auto result = co_await mpt::commitTrie(reader, mpt::emptyRootHash(), changes);
+            for (auto const& [hash, rlp] : result.newNodes)
+            {
+                storage::Entry entry;
+                entry.set(bcos::bytes(rlp));
+                co_await storage2::writeOne(
+                    m_stateRows, storage2::mptNodeStateKey(hash), std::move(entry));
+            }
+            co_return result.root;
+        }());
+    }
+
+    void buildTrie()
+    {
+        auto const storageRoot = commitIntoStateRows(
+            {{mpt::slotKeyHash(slotA), valueA}, {mpt::slotKeyHash(slotB), valueB}});
+
+        mpt::Account account;
+        account.nonce = 7;
+        account.balance = 1000;
+        account.storageRoot = storageRoot;
+        stateRoot = commitIntoStateRows({{mpt::accountKeyHash(address), account.encode()}});
+
+        m_ledger->ledgerData().back()->blockHeader()->setStateRoot(stateRoot);
+    }
+
+    /// The production wiring shape (AirNodeInitializer): the AnyStorage handle owns its
+    /// adapter; only m_stateRows (the Initializer-owned backend stand-in) is borrowed.
+    void wireReader() { nodeService->setMPTNodeReader(storage2::makeMPTNodeReader(m_stateRows)); }
+
+    Json::Value request(std::string const& req)
+    {
+        Json::Value value;
+        Json::Reader reader;
+        std::promise<bcos::bytes> promise;
+        web3JsonRpc->onRPCRequest(
+            req, [&promise](bcos::bytes resp) { promise.set_value(std::move(resp)); });
+        auto jsonBytes = promise.get_future().get();
+        std::string_view json((char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    }
+
+    Json::Value getProof(
+        std::string const& addressHex, std::vector<std::string> const& keys, std::string const& tag)
+    {
+        Json::Value req;
+        req["jsonrpc"] = "2.0";
+        req["id"] = 1;
+        req["method"] = "eth_getProof";
+        Json::Value params(Json::arrayValue);
+        params.append(addressHex);
+        Json::Value keysJson(Json::arrayValue);
+        for (auto const& key : keys)
+        {
+            keysJson.append(key);
+        }
+        params.append(keysJson);
+        params.append(tag);
+        req["params"] = params;
+        return request(printJson(req));
+    }
+
+    Rpc::Ptr rpc;
+    Web3JsonRpcImpl::Ptr web3JsonRpc;
+
+    StateRowStorage m_stateRows;
+    bcos::Address address{std::string("0x00000000000000000000000000000000000000ab")};
+    h256 slotA{1U};
+    h256 slotB{2U};
+    bytes valueA{0x2a};              // RLP(42)
+    bytes valueB{0x82, 0x13, 0x37};  // RLP(0x1337)
+    h256 stateRoot;
+};
+
+BOOST_FIXTURE_TEST_SUITE(EthGetProofReaderWiringTest, EthGetProofWiringFixture)
+
+// Happy path through the full production reader chain: state rows -> MPTNodeReadStorage ->
+// AnyStorage -> NodeService -> generateProof.
+BOOST_AUTO_TEST_CASE(WiredReaderServesProofFromStateRows)
+{
+    buildTrie();
+    wireReader();
+
+    auto resp =
+        getProof(address.hexPrefixed(), {slotA.hexPrefixed(), slotB.hexPrefixed()}, "latest");
+    BOOST_TEST(!resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    auto const& result = resp["result"];
+    BOOST_TEST(result["address"].asString() == address.hexPrefixed());
+    BOOST_TEST(result["balance"].asString() == "0x3e8");
+    BOOST_TEST(result["nonce"].asString() == "0x7");
+    BOOST_REQUIRE(result["accountProof"].isArray());
+    BOOST_TEST(result["accountProof"].size() >= 1U);
+    BOOST_REQUIRE_EQUAL(result["storageProof"].size(), 2U);
+    BOOST_TEST(result["storageProof"][0U]["value"].asString() == "0x2a");
+    BOOST_TEST(result["storageProof"][1U]["value"].asString() == "0x1337");
+}
+
+// Negative control for the wiring itself: the SAME trie sits in the state rows, but with no
+// setMPTNodeReader call the endpoint must still answer -32603 — proving the happy path above
+// passes because of the injected reader, not some other route to the rows.
+BOOST_AUTO_TEST_CASE(UnwiredReaderStillReturns32603)
+{
+    buildTrie();
+    // no wireReader()
+
+    auto resp = getProof(address.hexPrefixed(), {}, "latest");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32603);
+    BOOST_CHECK(resp["error"]["message"].asString().find("MPT not enabled") != std::string::npos);
+}
+
+// A header stateRoot with no node row behind it must surface as -32004 through the adapter:
+// the adapter's nullopt-on-miss is what generateProof turns into BlockNotCommitted.
+BOOST_AUTO_TEST_CASE(MissingRootThroughAdapterReturns32004)
+{
+    buildTrie();
+    wireReader();
+    m_ledger->ledgerData().back()->blockHeader()->setStateRoot(h256{0x1234U});
+
+    auto resp = getProof(address.hexPrefixed(), {}, "latest");
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), -32004);
+    BOOST_CHECK(
+        resp["error"]["message"].asString().find("not in MPT node storage") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/EthGetProofRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthGetProofRpcTest.cpp
@@ -274,7 +274,7 @@ BOOST_AUTO_TEST_CASE(UnknownStateRootReturns32004)
         resp["error"]["message"].asString().find("not in MPT node storage") != std::string::npos);
 }
 
-// No MPT node reader wired (production state until PR-18) -> -32603 "MPT not enabled".
+// No MPT node reader wired (production: a tars-built NodeService) -> -32603 "MPT not enabled".
 BOOST_AUTO_TEST_CASE(ReaderUnsetReturns32603)
 {
     buildTrie();  // trie + stateRoot exist, but the reader stays unset

--- a/bcos-storage/bcos-storage/MPTNodeReadStorage.h
+++ b/bcos-storage/bcos-storage/MPTNodeReadStorage.h
@@ -1,0 +1,167 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MPTNodeReadStorage.h
+ * @brief MPTNodeReadStorage — the eth_getProof node reader (M8.3 wiring): a read-only
+ *        (h256 -> raw RLP bytes) facade over the ordinary "/mpt/" state rows of a committed
+ *        state storage, plus makeMPTNodeReader() producing the owning AnyStorage handle
+ *        NodeService::setMPTNodeReader expects
+ */
+#pragma once
+
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/AnyStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/throw_exception.hpp>
+#include <memory>
+#include <optional>
+#include <range/v3/view/transform.hpp>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace bcos::storage2
+{
+
+/// The read-side sibling of the scheduler's ViewNodeStorage (MPTNodeStorage.h): where that
+/// adapter rides a block's execute view so the builder sees pending layers, this one wraps a
+/// COMMITTED storage — production wires it over GlobalStateStorage::latestBackend(), the
+/// plane every committed block's node rows were merged into — because eth_getProof answers
+/// for committed headers only and must never see an in-flight block's rows.
+///
+/// Reads translate h256 -> StateKey{"/mpt/", digest} (KeyPrefixes.h::mptNodeStateKey) and
+/// unwrap the Entry value to its raw bytes; a missing row is std::nullopt, the miss shape
+/// generateProof's proofWalk maps to its rootMissing / BlockNotCommitted handling.
+///
+/// AnyStorage's type-erasure model instantiates the FULL storage surface (its StorageModel
+/// virtuals are not SFINAE-guarded), so the mutating and scanning entry points exist here
+/// only to satisfy that instantiation — each throws std::logic_error: the proof path is
+/// strictly read-only and nothing may write state through an RPC-held handle.
+template <class Storage>
+class MPTNodeReadStorage
+{
+public:
+    using Key = bcos::h256;
+    using Value = bcos::bytes;
+
+    explicit MPTNodeReadStorage(Storage& storage) : m_storage(std::addressof(storage)) {}
+
+    task::Task<std::optional<bcos::bytes>> readOne(bcos::h256 key)
+    {
+        auto entry = co_await storage2::readOne(*m_storage, storage2::mptNodeStateKey(key));
+        if (!entry)
+        {
+            co_return std::nullopt;
+        }
+        auto raw = entry->get();
+        co_return bcos::bytes(raw.begin(), raw.end());
+    }
+
+    task::Task<std::vector<std::optional<bcos::bytes>>> readSome(::ranges::input_range auto keys)
+    {
+        // One batched read: a proof walk resolves whole node paths at a time.
+        auto entries = co_await storage2::readSome(
+            *m_storage, keys | ::ranges::views::transform(
+                                   [](auto const& key) { return storage2::mptNodeStateKey(key); }));
+
+        std::vector<std::optional<bcos::bytes>> values;
+        values.reserve(entries.size());
+        for (auto const& entry : entries)
+        {
+            if (!entry)
+            {
+                values.emplace_back(std::nullopt);
+                continue;
+            }
+            auto raw = entry->get();
+            values.emplace_back(bcos::bytes(raw.begin(), raw.end()));
+        }
+        co_return values;
+    }
+
+    // --- read-only guard rail: everything below throws, see the class comment ---
+
+    /// The iterator type range() nominally yields; never actually produced. The unreachable
+    /// co_returns below keep each guard a coroutine, so the throw surfaces at co_await like
+    /// every other storage error.
+    struct NoIterator
+    {
+        task::Task<std::optional<std::pair<bcos::h256, StorageValueType<bcos::bytes>>>> next()
+        {
+            throwReadOnly();
+            co_return std::nullopt;
+        }
+    };
+
+    task::Task<void> writeOne(bcos::h256 /*key*/, bcos::bytes /*value*/)
+    {
+        throwReadOnly();
+        co_return;
+    }
+    task::Task<void> writeSome(::ranges::input_range auto /*keyValues*/)
+    {
+        throwReadOnly();
+        co_return;
+    }
+    task::Task<void> removeOne(bcos::h256 /*key*/, auto&&... /*tags*/)
+    {
+        throwReadOnly();
+        co_return;
+    }
+    task::Task<void> removeSome(::ranges::input_range auto /*keys*/, auto&&... /*tags*/)
+    {
+        throwReadOnly();
+        co_return;
+    }
+    task::Task<NoIterator> range(auto&&... /*args*/)
+    {
+        throwReadOnly();
+        co_return NoIterator{};
+    }
+
+private:
+    [[noreturn]] static void throwReadOnly()
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error(
+            "MPTNodeReadStorage is a read-only view over committed MPT node rows"));
+    }
+
+    Storage* m_storage;
+};
+
+/// Build the handle NodeService::setMPTNodeReader takes: an AnyStorage<h256, bytes> that
+/// OWNS its MPTNodeReadStorage adapter via an aliasing shared_ptr, so callers manage exactly
+/// one lifetime. The only borrowed piece is @p storage itself (production: the state
+/// backend, owned by the Initializer), which must outlive the returned handle.
+template <class Storage>
+[[nodiscard]] std::shared_ptr<AnyStorage<bcos::h256, bcos::bytes>> makeMPTNodeReader(
+    Storage& storage)
+{
+    struct OwningReader
+    {
+        MPTNodeReadStorage<Storage> adapter;
+        std::optional<AnyStorage<bcos::h256, bcos::bytes>> erased;
+
+        explicit OwningReader(Storage& storage) : adapter(storage) { erased.emplace(adapter); }
+    };
+    auto owner = std::make_shared<OwningReader>(storage);
+    return {owner, std::addressof(*owner->erased)};
+}
+
+}  // namespace bcos::storage2

--- a/bcos-storage/test/unittest/CMakeLists.txt
+++ b/bcos-storage/test/unittest/CMakeLists.txt
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "TestMPTNodeKey.cpp" "main.cpp")
+list(APPEND SOURCES "TestRocksDBStorage.cpp" "TestRocksDBStorage2.cpp" "TestKeyPrefixes.cpp" "TestMPTNodeKey.cpp" "TestMPTNodeReadStorage.cpp" "main.cpp")
 # cmake settings
 set(TEST_BINARY_NAME test-storage)
 

--- a/bcos-storage/test/unittest/TestMPTNodeReadStorage.cpp
+++ b/bcos-storage/test/unittest/TestMPTNodeReadStorage.cpp
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief MPTNodeReadStorage — the eth_getProof node reader adapter (M8.3 wiring): node rows
+ *        written through the ORDINARY state write path (Entry keyed mptNodeStateKey(hash)
+ *        into a real RocksDBStorage2<StateKey, ..., StateKeyResolver, ...>) read back by raw
+ *        h256 through the adapter, both directly and through the type-erased
+ *        AnyStorage<h256, bytes> handle makeMPTNodeReader() hands to NodeService.
+ * @file TestMPTNodeReadStorage.cpp
+ */
+
+#include "bcos-framework/storage2/AnyStorage.h"
+#include "bcos-framework/storage2/Storage.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-task/Wait.h"
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-storage/KeyPrefixes.h>
+#include <bcos-storage/MPTNodeReadStorage.h>
+#include <bcos-storage/RocksDBStorage2.h>
+#include <bcos-storage/StateKVResolver.h>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+#include <optional>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::storage2::rocksdb;
+using namespace bcos::executor_v1;
+
+namespace
+{
+using StateRocksDB = RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver>;
+
+bytes nodeRlpA()
+{
+    return bytes{0xC5, 0x84, 0xDE, 0xAD, 0xBE, 0xEF};
+}
+bytes nodeRlpB()
+{
+    return bytes{0xC3, 0x82, 0x13, 0x37};
+}
+
+/// Write a node row exactly the way production does: an Entry under mptNodeStateKey(hash)
+/// through the ordinary storage2 write path — no adapter involved on the write side.
+task::Task<void> writeNodeRow(auto& storage, h256 const& hash, bytes rlp)
+{
+    storage::Entry entry;
+    entry.set(std::move(rlp));
+    co_await storage2::writeOne(storage, storage2::mptNodeStateKey(hash), std::move(entry));
+}
+}  // namespace
+
+struct TestMPTNodeReadStorageFixture
+{
+    std::string path = "./mptnodereaderdb" + std::to_string(std::random_device{}());
+
+    TestMPTNodeReadStorageFixture()
+    {
+        ::rocksdb::Options options;
+        options.create_if_missing = true;
+
+        ::rocksdb::DB* db = nullptr;
+        auto status = ::rocksdb::DB::Open(options, path, &db);
+        BOOST_REQUIRE(status.ok());
+        rocksDB.reset(db);
+    }
+    ~TestMPTNodeReadStorageFixture() { boost::filesystem::remove_all(path); }
+
+    std::unique_ptr<::rocksdb::DB> rocksDB;
+    h256 hashA{1U};
+    h256 hashB{2U};
+    h256 hashMissing{3U};
+};
+
+BOOST_FIXTURE_TEST_SUITE(TestMPTNodeReadStorage, TestMPTNodeReadStorageFixture)
+
+// Ordinary state write path in, adapter read by raw h256 out; a hash never written reads
+// back as nullopt — the exact miss shape generateProof's proofWalk keys its rootMissing /
+// broken-chain handling on.
+BOOST_AUTO_TEST_CASE(readOneRoundTripAndMiss)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        StateRocksDB storage(*rocksDB, StateKeyResolver{}, StateValueResolver{});
+        co_await writeNodeRow(storage, hashA, nodeRlpA());
+        co_await writeNodeRow(storage, hashB, nodeRlpB());
+
+        storage2::MPTNodeReadStorage reader(storage);
+        auto valueA = co_await reader.readOne(hashA);
+        BOOST_REQUIRE(valueA.has_value());
+        BOOST_CHECK(*valueA == nodeRlpA());
+
+        // Negative control: a different hash yields DIFFERENT bytes (the adapter keys reads
+        // by hash, it does not replay a constant), and an absent hash yields nullopt.
+        auto valueB = co_await reader.readOne(hashB);
+        BOOST_REQUIRE(valueB.has_value());
+        BOOST_CHECK(*valueB != *valueA);
+        BOOST_CHECK(*valueB == nodeRlpB());
+        auto miss = co_await reader.readOne(hashMissing);
+        BOOST_CHECK(!miss.has_value());
+    }());
+}
+
+// readSome preserves request order and represents per-key misses as gaps, matching the
+// batched-read contract the storage2 free functions dispatch to.
+BOOST_AUTO_TEST_CASE(readSomeKeepsOrderAndGaps)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        StateRocksDB storage(*rocksDB, StateKeyResolver{}, StateValueResolver{});
+        co_await writeNodeRow(storage, hashA, nodeRlpA());
+        co_await writeNodeRow(storage, hashB, nodeRlpB());
+
+        storage2::MPTNodeReadStorage reader(storage);
+        std::vector<h256> keys{hashA, hashMissing, hashB};
+        auto values = co_await storage2::readSome(reader, keys);
+        BOOST_REQUIRE_EQUAL(values.size(), 3U);
+        BOOST_REQUIRE(values[0].has_value());
+        BOOST_CHECK(*values[0] == nodeRlpA());
+        BOOST_CHECK(!values[1].has_value());  // negative control: the gap stays a gap
+        BOOST_REQUIRE(values[2].has_value());
+        BOOST_CHECK(*values[2] == nodeRlpB());
+    }());
+}
+
+// The production shape: makeMPTNodeReader() returns an AnyStorage<h256, bytes> handle that
+// OWNS its adapter (aliasing shared_ptr), so the handle stays valid with no other reference
+// to the adapter — only the backend row storage must outlive it.
+BOOST_AUTO_TEST_CASE(anyStorageHandleOwnsItsAdapter)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        StateRocksDB storage(*rocksDB, StateKeyResolver{}, StateValueResolver{});
+        co_await writeNodeRow(storage, hashA, nodeRlpA());
+
+        auto reader = storage2::makeMPTNodeReader(storage);
+        BOOST_REQUIRE(reader != nullptr);
+        auto value = co_await reader->readOne(hashA);
+        BOOST_REQUIRE(value.has_value());
+        BOOST_CHECK(*value == nodeRlpA());
+        auto miss = co_await reader->readOne(hashMissing);
+        BOOST_CHECK(!miss.has_value());  // negative control through the erased handle too
+    }());
+}
+
+// The adapter is a read-only view: every mutating entry point AnyStorage's type-erasure
+// forces onto it throws instead of touching the backend; reads on the same handle keep
+// working afterwards (negative control that the throw is per-operation, not poisoning).
+BOOST_AUTO_TEST_CASE(mutationsThrowReadsSurvive)
+{
+    StateRocksDB storage(*rocksDB, StateKeyResolver{}, StateValueResolver{});
+    task::syncWait(writeNodeRow(storage, hashA, nodeRlpA()));
+
+    auto reader = storage2::makeMPTNodeReader(storage);
+    BOOST_CHECK_THROW(task::syncWait(reader->writeOne(hashB, nodeRlpB())), std::logic_error);
+    BOOST_CHECK_THROW(task::syncWait(reader->removeOne(hashA)), std::logic_error);
+    BOOST_CHECK_THROW(task::syncWait(reader->range()), std::logic_error);
+
+    // The rejected write really did not land, and reads still work.
+    auto valueA = task::syncWait(reader->readOne(hashA));
+    BOOST_REQUIRE(valueA.has_value());
+    BOOST_CHECK(*valueA == nodeRlpA());
+    BOOST_CHECK(!task::syncWait(reader->readOne(hashB)).has_value());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -61,8 +61,7 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
     m_nodeInitializer = std::make_shared<bcos::initializer::Initializer>();
     m_nodeInitializer->initConfig(_configFilePath, _genesisFile, "", true);
 
-    auto ioServicePool =
-        std::make_shared<bcos::IOServicePool>(nodeConfig->ioThreadCount(), "io");
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(nodeConfig->ioThreadCount(), "io");
     m_nodeInitializer->setIOServicePool(ioServicePool);
 
     // create gateway
@@ -86,6 +85,14 @@ void AirNodeInitializer::init(std::string const& _configFilePath, std::string co
             m_nodeInitializer->txPoolInitializer()->txpool(), pbftInitializer->pbft(),
             pbftInitializer->blockSync(), m_nodeInitializer->protocolInitializer()->blockFactory(),
             m_nodeInitializer->engineService());
+    // eth_getProof node reader (M8.3): committed MPT node rows straight from the state
+    // backend. Set unconditionally — feature_mpt_state_root can activate at runtime, and a
+    // pre-MPT header's stateRoot simply misses in the node rows (-32004); -32603 stays
+    // reserved for nodes that structurally cannot serve proofs (tars-built NodeService).
+    // Lifetime: the handle owns its adapter; the borrowed backend lives in m_nodeInitializer,
+    // declared before m_rpc / m_tarsApplication (the NodeService holders), so it is
+    // destroyed after them.
+    nodeService->setMPTNodeReader(m_nodeInitializer->mptNodeReader());
 
     // create rpc
     RpcFactory rpcFactory(nodeConfig->chainId(), m_gateway, keyFactory,

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -39,6 +39,7 @@
 #include "bcos-framework/storage/StorageInterface.h"
 #include "bcos-ledger/LedgerMethods.h"
 #include "bcos-scheduler/src/TarsExecutorManager.h"
+#include "bcos-storage/MPTNodeReadStorage.h"
 #include "bcos-storage/RocksDBStorage.h"
 #include "bcos-task/Wait.h"
 #include "bcos-utilities/Error.h"
@@ -1349,6 +1350,20 @@ std::string Initializer::getBlockDBPath(bool _airVersion) const
     // if the stateDBPath is absolute path, the result stateDBPath will deep
     return tars::ServerConfig::BasePath + ".." + c_fileSeparator + m_nodeConfig->groupId() +
            c_fileSeparator + blockDBPath;
+}
+
+std::shared_ptr<bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>> Initializer::mptNodeReader()
+{
+    if (!m_globalStateStorageInitializer)
+    {
+        return nullptr;
+    }
+    // The committed plane only: block commit merges each block's node rows (with its flat
+    // state, one WriteBatch) into latestBackend(), and eth_getProof targets committed
+    // headers — the pending layers of the MultiLayerStorage belong to in-flight blocks and
+    // must stay invisible to proofs.
+    return bcos::storage2::makeMPTNodeReader(
+        m_globalStateStorageInitializer->storage().latestBackend());
 }
 
 std::string Initializer::getConsensusStorageDBPath(bool _airVersion) const

--- a/libinitializer/Initializer.h
+++ b/libinitializer/Initializer.h
@@ -34,9 +34,9 @@
 #include <bcos-scheduler/src/SchedulerManager.h>
 #include <bcos-utilities/BoostLogInitializer.h>
 #include <bcos-utilities/IOServicePool.h>
+#include <oneapi/tbb/global_control.h>
 #include <memory>
 #include <optional>
-#include <oneapi/tbb/global_control.h>
 #ifdef WITH_LIGHTNODE
 #include "LightNodeInitializer.h"
 #endif
@@ -59,6 +59,11 @@ class SchedulerInterface;
 namespace engine
 {
 class AnyEngineService;
+}
+namespace storage2
+{
+template <class Key, class ValueT>
+class AnyStorage;
 }
 namespace initializer
 {
@@ -117,6 +122,14 @@ public:
     /// NOTE: this should be last called
     void initSysContract();
     bcos::storage::TransactionalStorageInterface::Ptr storage() { return m_storage; }
+
+    /// Type-erased read handle over the committed MPT node rows for eth_getProof (M8.3
+    /// wiring): each call builds a fresh AnyStorage view over GlobalStateStorage's backend
+    /// (the committed plane node rows merge into at block commit) — the handle owns its
+    /// key-translating adapter, but the backend stays owned by this Initializer's
+    /// GlobalStateStorageInitializer, so the handle must not outlive this Initializer.
+    /// nullptr before initNode() built the global state storage (e.g. config-only usage).
+    std::shared_ptr<bcos::storage2::AnyStorage<bcos::h256, bcos::bytes>> mptNodeReader();
     bcos::Error::Ptr generateSnapshot(const std::string& snapshotPath, bool withTxAndReceipts,
         const tool::NodeConfig::Ptr& nodeConfig);
     bcos::Error::Ptr importSnapshot(


### PR DESCRIPTION
## Failing scenario

The eth_getProof pipeline is fully merged — proof generator (#5311/#5316), `EthEndpoint::getProof` (#5316), execute-time node persistence (#5345) — but nothing ever calls `NodeService::setMPTNodeReader`. Production nodes therefore answer `-32603 "MPT not enabled on this node"` for every eth_getProof request, even with the MPT feature active. `NodeService.h` said the wiring would arrive with the scheduler-injection PR; #5345 explicitly cut it. This PR closes that last mile.

## Fix

- `bcos-storage/MPTNodeReadStorage.h` (new): `MPTNodeReadStorage<Storage>` adapter satisfying `storage2::ReadableStorage<h256>` — translates each `h256` to `mptNodeStateKey(hash)`, reads the underlying state storage, unwraps the Entry into raw node bytes; miss stays `nullopt` as the proof walk expects. Write/remove/range members are throwing stubs: `AnyStorage`'s `StorageModel` instantiates every virtual unconditionally, so the wrapped type must compile the full set. `makeMPTNodeReader()` returns an aliasing `shared_ptr<AnyStorage<h256, bytes>>` that owns the adapter.
- `libinitializer/Initializer.h/.cpp`: `Initializer::mptNodeReader()` wraps `MultiLayerStorage::latestBackend()` — the committed layer that #5345's single-WriteBatch commit merges node rows into. Pending layers belong to in-flight blocks and are deliberately not consulted: proofs are for committed blocks; an uncommitted block's root simply misses and maps to `-32004` (retryable), keeping `-32603` for nodes with no local storage path at all.
- `fisco-bcos-air/AirNodeInitializer.cpp`: the production wiring — `setMPTNodeReader` right after NodeService construction. Set unconditionally: `feature_mpt_state_root` can be activated at runtime through governance, and feature-gating at init would require a node restart after activation. Lifetime: the handle owns the adapter and borrows the backend, whose owner (`m_nodeInitializer`) is declared before both NodeService holders and thus destructs after them; the legacy `m_storage` already borrows the same RocksDB with a no-op deleter, so no new lifetime category is introduced.

Scope cut: MAX/tars mode is not wired. A tars-built NodeService is assembled from service proxies and the RPC process has no local state storage, so the slot is structurally unreachable there and stays unset (`-32603`); `NodeService.h` now documents the AIR-wired / tars-unset split.

## Tests

- `TestMPTNodeReadStorage.cpp` (new, 4 cases): node rows written through the ordinary state write path into a real `RocksDBStorage2<StateKey, StateValue, StateKeyResolver, StateValueResolver>` read back by hash; missing hash → `nullopt`; the same through the type-erased `AnyStorage` handle; write/remove/range throw and do not poison subsequent reads.
- `EthGetProofReaderWiringTest.cpp` (new, 3 cases): trie nodes stored as `StateKey{"/mpt/", digest}` rows, reader injected via `makeMPTNodeReader`, full getProof round-trip verifies against the trie; unwired NodeService → `-32603` (negative control); root row absent → `-32004`.
- `test-storage` and `test-bcos-rpc` full suites pass (`*** No errors detected`); the `fisco-bcos` production target (libinitializer + AirNodeInitializer instantiation) compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
