### PR TITLE
Disable DMC transfer tests in CI check air script

### DIFF
--- a/tools/.ci/ci_check_air.sh
+++ b/tools/.ci/ci_check_air.sh
@@ -289,9 +289,9 @@ fi
 # ============ 阶段1：预构建所有依赖（仅一次）============
 prebuild_deps
 
-# ============ 阶段2：non-sm 测试（含扩容 + DMC）============
+# ============ 阶段2：non-sm 测试（含扩容）============
 LOG_INFO "======== check non-sm case ========"
-export RUN_DMC="true"
+export RUN_DMC="false"
 init ""
 expand_node ""
 check_consensus


### PR DESCRIPTION
## 变更说明

屏蔽 `ci_check_air.sh` 中 DMC 转账测试。

在 non-sm 测试阶段将 `RUN_DMC` 环境变量从 `true` 改为 `false`，与其他阶段（sm、baseline）保持一致，不再运行 DMC 转账测试。

## 变更内容

- `tools/.ci/ci_check_air.sh`: 阶段2 non-sm 测试中 `export RUN_DMC="true"` → `export RUN_DMC="false"`