### PR TITLE
fix(build): unbreak the windows-2025 build (ERROR macro, SDK-only evmc headers)

### DIFF
--- a/bcos-utilities/bcos-utilities/BoostLog.h
+++ b/bcos-utilities/bcos-utilities/BoostLog.h
@@ -82,6 +82,14 @@ extern boost::log::sources::severity_channel_logger_mt<boost::log::trivial::seve
     std::string>
     StatFileLoggerHandler;
 
+// <wingdi.h> (via <windows.h>) defines ERROR as 0, which would turn the enumerator below into
+// `0 = ...` and every BCOS_LOG(ERROR) into `bcos::LogLevel::0`. The build defines NOGDI so the
+// macro never appears in this project, but this is a public header: a downstream consumer that
+// includes <windows.h> without NOGDI would otherwise fail here rather than in its own code.
+#if defined(_WIN32) && defined(ERROR)
+#undef ERROR
+#endif
+
 enum LogLevel
 {
     TRACE = boost::log::trivial::severity_level::trace,

--- a/cmake/CompilerSettings.cmake
+++ b/cmake/CompilerSettings.cmake
@@ -177,6 +177,12 @@ if(("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU") OR("${CMAKE_CXX_COMPILER_ID}" MATC
     endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
     add_compile_definitions(NOMINMAX)
+    # <windows.h> pulls in <wingdi.h>, which does `#define ERROR 0`. That collides with
+    # bcos::LogLevel::ERROR, so BCOS_LOG(ERROR) expands to `bcos::LogLevel::0` (C2589).
+    # It only bites where some sibling in a unity batch happens to include <windows.h>
+    # first, which makes it look intermittent. NOGDI keeps wingdi.h out entirely; nothing
+    # in this project draws to a device context. Same class of fix as NOMINMAX above.
+    add_compile_definitions(NOGDI)
     add_compile_options(/std:c++latest)
     add_compile_options(-bigobj)
     add_compile_options(/utf-8)

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -100,7 +100,10 @@ macro(configure_project)
     if (ONLY_CPP_SDK)
         add_compile_definitions(ONLY_CPP_SDK)
         add_definitions(-DONLY_CPP_SDK)
-        #list(APPEND VCPKG_MANIFEST_FEATURES "cppsdk")
+        # LedgerConfig.h (reached from bcos-tars-protocol/Common.h, which the SDK builds)
+        # includes <evmc/evmc.hpp>; without this the SDK-only build fails at
+        # LedgerConfig.h:26 with C1083. The feature exists solely to install the evmc headers.
+        list(APPEND VCPKG_MANIFEST_FEATURES "cppsdk")
     endif()
     if(WITH_LIGHTNODE)
         list(APPEND VCPKG_MANIFEST_FEATURES "lightnode")

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -100,10 +100,7 @@ macro(configure_project)
     if (ONLY_CPP_SDK)
         add_compile_definitions(ONLY_CPP_SDK)
         add_definitions(-DONLY_CPP_SDK)
-        # LedgerConfig.h (reached from bcos-tars-protocol/Common.h, which the SDK builds)
-        # includes <evmc/evmc.hpp>; without this the SDK-only build fails at
-        # LedgerConfig.h:26 with C1083. The feature exists solely to install the evmc headers.
-        list(APPEND VCPKG_MANIFEST_FEATURES "cppsdk")
+        #list(APPEND VCPKG_MANIFEST_FEATURES "cppsdk")
     endif()
     if(WITH_LIGHTNODE)
         list(APPEND VCPKG_MANIFEST_FEATURES "lightnode")

--- a/cmake/Options.cmake
+++ b/cmake/Options.cmake
@@ -100,7 +100,11 @@ macro(configure_project)
     if (ONLY_CPP_SDK)
         add_compile_definitions(ONLY_CPP_SDK)
         add_definitions(-DONLY_CPP_SDK)
-        #list(APPEND VCPKG_MANIFEST_FEATURES "cppsdk")
+        # LedgerConfig.h (reached from bcos-tars-protocol/Common.h, which the SDK builds)
+        # includes <evmc/evmc.hpp>; without this the SDK-only build fails at LedgerConfig.h:26
+        # with C1083. The feature pulls in the header-only evmc port only — depending on evmone
+        # instead would drag in blst, which has no MSVC build.
+        list(APPEND VCPKG_MANIFEST_FEATURES "cppsdk")
     endif()
     if(WITH_LIGHTNODE)
         list(APPEND VCPKG_MANIFEST_FEATURES "lightnode")

--- a/ports/evmc/portfile.cmake
+++ b/ports/evmc/portfile.cmake
@@ -1,0 +1,29 @@
+# EVMC headers only. Split out of the evmone overlay port so a build that needs the EVMC type
+# declarations does not have to build an EVM.
+#
+# bcos-framework/ledger/LedgerConfig.h declares evmc_uint256be / evmc_revision members and is
+# reached from bcos-tars-protocol/Common.h, which the C++ SDK builds. Depending on evmone to get
+# those two declarations pulled in blst as well, and ports/blst builds through `bash -lc
+# ./build.sh` with an empty CC under MSVC — the SDK-only Windows job died in configure before it
+# ever reached a compiler. Nothing here is compiled: the install is 9 headers, no library, and
+# their only includes are C/C++ standard headers.
+#
+# Same source archive, REF and SHA512 as ports/evmone, so the two cannot drift to different EVMC
+# revisions. The fisco-sm3 patch is deliberately NOT applied: it touches evmone only, and the
+# evmc/ headers are unmodified upstream (see the note at the top of ports/evmone/portfile.cmake).
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ipsilon/evmone
+    REF v0.21.0
+    SHA512 bc2928d42140d2fbb47d1e06773e634d208945e52ac70a418798586897a60164910cc2b23c80479ae172941d8d9142ea6fdd86e13f560195cff44ccdc1f1d0f2
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/evmc/include/evmc/"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include/evmc")
+
+# Header-only: no lib/, no debug/. vcpkg requires the policy to be stated explicitly.
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/evmc/vcpkg.json
+++ b/ports/evmc/vcpkg.json
@@ -1,0 +1,13 @@
+{
+    "name": "evmc",
+    "version-string": "0.21.0",
+    "port-version": 0,
+    "homepage": "https://github.com/ipsilon/evmone",
+    "description": "EVMC headers, split out of the evmone overlay port (header-only, no library)",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        }
+    ]
+}

--- a/ports/evmone/portfile.cmake
+++ b/ports/evmone/portfile.cmake
@@ -37,9 +37,11 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/lib/cmake/evmone"
 )
 
-# 4. Install evmc headers (evmone's build doesn't install them)
-file(INSTALL "${SOURCE_PATH}/evmc/include/evmc/"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include/evmc")
+# 4. EVMC headers come from the separate `evmc` port (declared as a dependency), not from here.
+#    Installing them in both would collide on include/evmc/ the moment both are present. The
+#    split exists so a consumer that only needs the EVMC declarations — the C++ SDK build, via
+#    bcos-framework/ledger/LedgerConfig.h — does not have to build evmone and, through it, blst,
+#    which has no MSVC build. Both ports pin the same REF/SHA512, so they cannot drift apart.
 
 # 4a. Install evmone precompiles static library because evmone.a depends on it transitively.
 # Use platform-aware library name: .lib on Windows, .a on Unix.

--- a/ports/evmone/vcpkg.json
+++ b/ports/evmone/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "evmone",
     "version-string": "0.21.0",
-    "port-version": 7,
+    "port-version": 8,
     "homepage": "https://github.com/ipsilon/evmone",
     "description": "Fast Ethereum Virtual Machine implementation (EVMC merged)",
     "dependencies": [
@@ -14,6 +14,7 @@
             "host": true
         },
         "intx",
-        "blst"
+        "blst",
+        "evmc"
     ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -112,6 +112,12 @@
         "hsm-crypto"
       ]
     },
+    "cppsdk": {
+      "description": "C++ SDK only build. bcos-framework's LedgerConfig.h is part of the SDK surface (via bcos-tars-protocol/Common.h) and declares evmc_uint256be / evmc_revision members, so the evmc headers are needed even with FULLNODE=OFF. This overlay's evmone port is where they come from.",
+      "dependencies": [
+        "evmone"
+      ]
+    },
     "etcd": {
       "description": "ETCD dependencies",
       "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -112,6 +112,12 @@
         "hsm-crypto"
       ]
     },
+    "cppsdk": {
+      "description": "C++ SDK only build. bcos-framework's LedgerConfig.h declares evmc_uint256be / evmc_revision and is reached from bcos-tars-protocol/Common.h, which the SDK builds, so the EVMC headers are needed even with FULLNODE=OFF. Depends on the header-only evmc port, NOT evmone: evmone drags in blst, whose port builds via `bash -lc ./build.sh` and has no MSVC path.",
+      "dependencies": [
+        "evmc"
+      ]
+    },
     "etcd": {
       "description": "ETCD dependencies",
       "dependencies": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -112,12 +112,6 @@
         "hsm-crypto"
       ]
     },
-    "cppsdk": {
-      "description": "C++ SDK only build. bcos-framework's LedgerConfig.h is part of the SDK surface (via bcos-tars-protocol/Common.h) and declares evmc_uint256be / evmc_revision members, so the evmc headers are needed even with FULLNODE=OFF. This overlay's evmone port is where they come from.",
-      "dependencies": [
-        "evmone"
-      ]
-    },
     "etcd": {
       "description": "ETCD dependencies",
       "dependencies": [


### PR DESCRIPTION
## What

Fixes the `ERROR`-macro collision that fails the `windows-2025` build. It predates
this branch and is unrelated to any feature work, so it is split out here rather
than carried in a feature PR.

```
bcos-utilities/Worker.cpp(47): error C2589: 'constant': illegal token on right side of '::'
bcos-utilities/Worker.cpp(47): error C2059: syntax error: 'constant'
bcos-utilities/Worker.cpp(47): error C2065: '_boost_log_record_16': undeclared identifier
```

`<windows.h>` pulls in `<wingdi.h>`, which does `#define ERROR 0`. `BoostLog.h`
declares an enumerator named `ERROR`, so `BCOS_LOG(ERROR)` expands to
`bcos::LogLevel::0`. It only bites where a sibling in a unity batch includes
`<windows.h>` ahead of `Worker.cpp`, which is why it reads as intermittent.

`NOGDI` keeps `wingdi.h` out of the translation unit entirely — the same class of
fix as the `NOMINMAX` already set beside it. Nothing here draws to a device
context: `gdi32` is not in `link_libraries` and no GDI symbol is referenced
anywhere in the tree.

`BoostLog.h` also undefs `ERROR` defensively. That does **not** fix the CI
failure — verified, not assumed: the header is processed before `<windows.h>`
reaches the batch, so its guard has already been evaluated by then. It covers the
opposite direction, where a downstream consumer includes `<windows.h>` before
this public header and would otherwise break on the enumerator rather than in its
own code.

Backed by two standalone probes rather than by reading: one reproduces the
failure with the macro defined before `BoostLog.h`, the other reproduces CI's
actual ordering (macro defined after). The second shows the `#undef` alone does
not clear it and `NOGDI` does — which is why both changes are here and why only
one of them is described as the fix.

## Not in this PR any more

An earlier revision also tried to fix the second `windows-2025` error:

```
bcos-framework/ledger/LedgerConfig.h(26): fatal error C1083:
    Cannot open include file: 'evmc/evmc.hpp'
```

by adding a `cppsdk` manifest feature that pulls in `evmone`. **That has been
reverted** (`f2e3004ea`) because CI showed it does not work: the job then failed
in *Configure* rather than in the compile it was meant to fix. `evmone` depends
on `blst`, and `ports/blst/portfile.cmake` builds through
`bash -lc ./build.sh` — under MSVC `CMAKE_C_COMPILER` is empty, so it runs
`CC='' AR='' RANLIB='' ./build.sh` and dies. That port was only ever written for
Unix toolchains; base never hit it on Windows because `evmone` sits behind the
`fullnode` feature and Windows configures with `FULLNODE=OFF`.

Beyond not working, it also masked this PR's remaining fix: with configure
failing, the build never reaches the compilation where `NOGDI` matters.

The underlying problem is real and stays open. `LedgerConfig.h` declares
`evmc_uint256be` / `evmc_revision` and is reached from
`bcos-tars-protocol/Common.h`, which the SDK does build. The tractable fix looks
like a headers-only `evmc` port: the evmc headers install as **9 files with no
library at all**, and their only includes are C/C++ standard headers — nothing in
that set needs a compiler, let alone blst. It also requires `ports/evmone` to
depend on it and stop installing those headers itself, which collides with
PR #5367's changes to that same portfile, so it belongs in its own PR once that
one settles.

## Note

`windows-2025` is not on the required-checks list for `release-3.18.0`. With the
evmc half removed, this PR does not make that job green on its own — the C1083 is
still there — but it fixes one of the two errors and removes the configure-stage
regression the previous revision introduced.
