### PR TITLE
Fix use-after-destroy bug in SyncWait

### DIFF
--- a/libtask/bcos-task/AsyncTask.h
+++ b/libtask/bcos-task/AsyncTask.h
@@ -16,7 +16,9 @@
 
 #pragma once
 #include <coroutine>
+#include <cstdint>
 #include <exception>
+#include <atomic>
 
 namespace bcos::task
 {
@@ -55,8 +57,71 @@ public:
     AsyncTask(AsyncTask&& task) noexcept = delete;
     AsyncTask& operator=(const AsyncTask&) = delete;
     AsyncTask& operator=(AsyncTask&& task) = delete;
-    ~AsyncTask() noexcept = default;
+    ~AsyncTask() noexcept  = default;
     void start() { m_handle.resume(); }
+
+private:
+    std::coroutine_handle<promise_type> m_handle;
+};
+
+enum class waitStatus: uint8_t {
+    INIT,
+    WAITING,
+    FINISHED,
+};
+
+class [[nodiscard]] SyncTask
+{
+public:
+    struct promise_type
+    {
+        // 持有handle的计数器
+        std::atomic<uint8_t> m_count{2};
+        // 用于记录任务的等待状态以及获取状态的引用
+        std::atomic<waitStatus> m_status{waitStatus::INIT};
+
+        static constexpr std::suspend_always initial_suspend() noexcept { return {}; }
+        static constexpr auto final_suspend() noexcept
+        {
+            struct FinalAwaitable
+            {
+                static constexpr bool await_ready() noexcept { return false; }
+                static void await_suspend(std::coroutine_handle<promise_type> handle) noexcept
+                {
+                    if (handle.promise().m_count.fetch_sub(1) == 1)
+                    {
+                        handle.destroy();
+                    }
+                }
+                constexpr void await_resume() noexcept {}
+            };
+            return FinalAwaitable{};
+        }
+        SyncTask get_return_object()
+        {
+            auto handle = std::coroutine_handle<promise_type>::from_promise(
+                *static_cast<promise_type*>(this));
+            return SyncTask{handle};
+        }
+        static void unhandled_exception() { std::rethrow_exception(std::current_exception()); }
+        constexpr static void return_void() noexcept {}
+    };
+
+    explicit SyncTask(std::coroutine_handle<promise_type> handle) : m_handle(handle) {}
+    SyncTask(const SyncTask&) = delete;
+    SyncTask(SyncTask&& task) noexcept = delete;
+    SyncTask& operator=(const SyncTask&) = delete;
+    SyncTask& operator=(SyncTask&& task) = delete;
+    ~SyncTask() noexcept 
+    {
+        if (m_handle.promise().m_count.fetch_sub(1) == 1)
+        {
+            m_handle.destroy();
+        }
+    }
+    void start() { m_handle.resume(); }
+
+    std::atomic<waitStatus>& getStatus() { return m_handle.promise().m_status; }
 
 private:
     std::coroutine_handle<promise_type> m_handle;

--- a/libtask/bcos-task/Task.h
+++ b/libtask/bcos-task/Task.h
@@ -96,20 +96,24 @@ template <class TaskType>
 struct Awaitable
 {
     explicit Awaitable(std::coroutine_handle<typename TaskType::promise_type> handle)
-      : m_handle(std::move(handle)) {};
+      { m_continuation.handle = std::move(handle);}
     Awaitable(const Awaitable&) = delete;
     Awaitable(Awaitable&&) noexcept = default;
     Awaitable& operator=(const Awaitable&) = delete;
     Awaitable& operator=(Awaitable&&) noexcept = default;
     ~Awaitable() noexcept = default;
 
-    bool await_ready() const noexcept { return !m_handle || m_handle.done(); }
-    template <class Promise>
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> handle)
+    bool await_ready() const noexcept { return !m_continuation.handle || m_continuation.handle.done(); }
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<> handle)
     {
+        // This transformation operation is safe 
+        // when Awaitable is constructed by coroutine_handle<typename TaskType::promise_type>
+        // but unsafe when Awaitable is constructed by other ways
+        auto nextHandle = 
+            std::coroutine_handle<typename TaskType::promise_type>::from_address(m_continuation.handle.address());
         m_continuation.handle = handle;
-        m_handle.promise().m_continuation = std::addressof(m_continuation);
-        return m_handle;
+        nextHandle.promise().m_continuation = std::addressof(m_continuation);
+        return nextHandle;
     }
     TaskType::Value await_resume()
     {
@@ -129,7 +133,6 @@ struct Awaitable
         }
     }
 
-    std::coroutine_handle<typename TaskType::promise_type> m_handle;
     Continuation<typename TaskType::VariantValue> m_continuation;
 };
 
@@ -159,6 +162,7 @@ public:
         }
         m_handle = task.m_handle;
         task.m_handle = nullptr;
+        return *this;
     }
     ~Task() noexcept
     {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -41,13 +41,6 @@ constexpr inline struct Wait
 
 constexpr inline struct SyncWait
 {
-
-    enum class waitStatus: uint8_t {
-        INIT,
-        WAITING,
-        AWAKED,
-        FINISHED,
-    };
     template <IsAwaitable Task>
     auto operator()(Task&& task, auto&&... args) const
         -> AwaitableReturnType<std::remove_cvref_t<Task>>
@@ -59,10 +52,8 @@ constexpr inline struct SyncWait
             std::variant<std::monostate, std::exception_ptr>,
             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
         ReturnVariant result;
-        std::atomic<waitStatus> status = waitStatus::INIT;
 
-        auto handle = [](Task&& task, decltype(result)& result, std::atomic<waitStatus>& status,
-                          auto&&... args) -> task::AsyncTask {
+        auto handle = [](Task&& task, decltype(result)& result, auto&&... args) -> task::SyncTask {
             try
             {
                 if constexpr (std::is_void_v<ReturnType>)
@@ -87,18 +78,30 @@ constexpr inline struct SyncWait
                 result.template emplace<std::exception_ptr>(std::current_exception());
             }
 
+            struct GetStatusAwaitable {
+                std::coroutine_handle<SyncTask::promise_type> m_handle;
+                bool await_ready() const noexcept { return false; }
+                bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept 
+                {
+                    m_handle = handle;
+                    return false;
+                }
+                std::atomic<waitStatus>& await_resume() noexcept { return m_handle.promise().m_status; }
+            };
+
+            auto& status = co_await GetStatusAwaitable();
+
             auto expected = waitStatus::INIT;
             if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
             {
                 // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
                 // If true is returned here, the external finish is set first, and the external
                 // execution needs to be notified
-                status.store(waitStatus::AWAKED);
-                status.notify_one();
                 status.store(waitStatus::FINISHED);
+                status.notify_one();
             }
-        }(std::forward<Task>(task), result, status,
-                                              std::forward<decltype(args)>(args)...);
+        }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
+        auto& status = handle.getStatus();
         handle.start();
 
         auto expected = waitStatus::INIT;
@@ -108,8 +111,6 @@ constexpr inline struct SyncWait
             // If true is returned, the task is still being executed and you need to wait for the
             // task to complete
             status.wait(waitStatus::WAITING);
-            //此时status进入AWAKED状态，开始忙等直到FINISHED
-            while (status.load() != waitStatus::FINISHED){}
         }
         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
         {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -41,6 +41,13 @@ constexpr inline struct Wait
 
 constexpr inline struct SyncWait
 {
+
+    enum class waitStatus: uint8_t {
+        INIT,
+        WAITING,
+        AWAKED,
+        FINISHED,
+    };
     template <IsAwaitable Task>
     auto operator()(Task&& task, auto&&... args) const
         -> AwaitableReturnType<std::remove_cvref_t<Task>>
@@ -52,13 +59,9 @@ constexpr inline struct SyncWait
             std::variant<std::monostate, std::exception_ptr>,
             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
         ReturnVariant result;
-        boost::atomic_flag finished;
-        boost::atomic_flag waitFlag;
-        boost::atomic_flag exited;
+        std::atomic<waitStatus> status = waitStatus::INIT;
 
-        auto handle = [](Task&& task, decltype(result)& result, boost::atomic_flag& finished,
-                          boost::atomic_flag& waitFlag,
-                          boost::atomic_flag& exited,
+        auto handle = [](Task&& task, decltype(result)& result, std::atomic<waitStatus>& status,
                           auto&&... args) -> task::Task<void> {
             try
             {
@@ -84,28 +87,29 @@ constexpr inline struct SyncWait
                 result.template emplace<std::exception_ptr>(std::current_exception());
             }
 
-            if (finished.test_and_set())
+            auto expected = waitStatus::INIT;
+            if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
             {
                 // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
                 // If true is returned here, the external finish is set first, and the external
                 // execution needs to be notified
-                waitFlag.test_and_set();
-                waitFlag.notify_one();
-                exited.test_and_set();
+                status.store(waitStatus::AWAKED);
+                status.notify_one();
+                status.store(waitStatus::FINISHED);
             }
-        }(std::forward<Task>(task), result, finished, waitFlag,
+        }(std::forward<Task>(task), result, status,
                                               std::forward<decltype(args)>(args)...);
         handle.start();
 
-        if (!finished.test_and_set())
+        auto expected = waitStatus::INIT;
+        if (status.compare_exchange_strong(expected, waitStatus::WAITING))
         {
-            // 此处返回false说明task还在执行中，需要等待task完成
-            // If false is returned, the task is still being executed and you need to wait for the
+            // 此处返回true说明task还在执行中，需要等待task完成
+            // If true is returned, the task is still being executed and you need to wait for the
             // task to complete
-            while (!exited.load())
-            {
-                waitFlag.wait(false);
-            }
+            status.wait(waitStatus::WAITING);
+            //此时status进入AWAKED状态，开始忙等直到FINISHED
+            while (status.load() != waitStatus::FINISHED){}
         }
         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
         {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -54,9 +54,11 @@ constexpr inline struct SyncWait
         ReturnVariant result;
         boost::atomic_flag finished;
         boost::atomic_flag waitFlag;
+        boost::atomic_flag exited;
 
         auto handle = [](Task&& task, decltype(result)& result, boost::atomic_flag& finished,
                           boost::atomic_flag& waitFlag,
+                          boost::atomic_flag& exited,
                           auto&&... args) -> task::Task<void> {
             try
             {
@@ -89,6 +91,7 @@ constexpr inline struct SyncWait
                 // execution needs to be notified
                 waitFlag.test_and_set();
                 waitFlag.notify_one();
+                exited.test_and_set();
             }
         }(std::forward<Task>(task), result, finished, waitFlag,
                                               std::forward<decltype(args)>(args)...);
@@ -99,7 +102,10 @@ constexpr inline struct SyncWait
             // 此处返回false说明task还在执行中，需要等待task完成
             // If false is returned, the task is still being executed and you need to wait for the
             // task to complete
-            waitFlag.wait(false);
+            while (!exited.load())
+            {
+                waitFlag.wait(false);
+            }
         }
         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
         {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -62,7 +62,7 @@ constexpr inline struct SyncWait
         std::atomic<waitStatus> status = waitStatus::INIT;
 
         auto handle = [](Task&& task, decltype(result)& result, std::atomic<waitStatus>& status,
-                          auto&&... args) -> task::Task<void> {
+                          auto&&... args) -> task::AsyncTask {
             try
             {
                 if constexpr (std::is_void_v<ReturnType>)

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -14,121 +14,123 @@
  *  limitations under the License.
  */
 
-#pragma once
-#include "AsyncTask.h"
-#include "Task.h"
-#include "Trait.h"
-#include <boost/atomic/atomic_flag.hpp>
-#include <exception>
-#include <memory>
-#include <type_traits>
-#include <variant>
-
-namespace bcos::task
-{
-
-constexpr inline struct Wait
-{
-    static AsyncTask executeTask(auto task) { co_await std::move(task); }
-
-    template <IsAwaitable Task>
-    void operator()(Task&& task) const
-    {
-        auto asyncTask = executeTask(std::forward<Task>(task));
-        asyncTask.start();
-    }
-} wait{};
-
-constexpr inline struct SyncWait
-{
-    template <IsAwaitable Task>
-    auto operator()(Task&& task, auto&&... args) const
-        -> AwaitableReturnType<std::remove_cvref_t<Task>>
-    {
-        using ReturnType = AwaitableReturnType<std::remove_cvref_t<Task>>;
-        using ReturnTypeWrap = std::conditional_t<std::is_reference_v<ReturnType>,
-            std::add_pointer_t<ReturnType>, ReturnType>;
-        using ReturnVariant = std::conditional_t<std::is_void_v<ReturnType>,
-            std::variant<std::monostate, std::exception_ptr>,
-            std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
-        ReturnVariant result;
-
-        auto handle = [](Task&& task, decltype(result)& result, auto&&... args) -> task::SyncTask {
-            try
-            {
-                if constexpr (std::is_void_v<ReturnType>)
-                {
-                    co_await std::forward<Task>(task);
-                }
-                else
-                {
-                    if constexpr (std::is_reference_v<ReturnType>)
-                    {
-                        decltype(auto) ref = co_await task;
-                        result = std::addressof(ref);
-                    }
-                    else
-                    {
-                        result.template emplace<ReturnType>(co_await std::forward<Task>(task));
-                    }
-                }
-            }
-            catch (...)
-            {
-                result.template emplace<std::exception_ptr>(std::current_exception());
-            }
-
-            struct GetStatusAwaitable {
-                std::coroutine_handle<SyncTask::promise_type> m_handle;
-                bool await_ready() const noexcept { return false; }
-                bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept 
-                {
-                    m_handle = handle;
-                    return false;
-                }
-                std::atomic<waitStatus>& await_resume() noexcept { return m_handle.promise().m_status; }
-            };
-
-            auto& status = co_await GetStatusAwaitable();
-
-            auto expected = waitStatus::INIT;
-            if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
-            {
-                // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
-                // If true is returned here, the external finish is set first, and the external
-                // execution needs to be notified
-                status.store(waitStatus::FINISHED);
-                status.notify_one();
-            }
-        }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
-        auto& status = handle.getStatus();
-        handle.start();
-
-        auto expected = waitStatus::INIT;
-        if (status.compare_exchange_strong(expected, waitStatus::WAITING))
-        {
-            // 此处返回true说明task还在执行中，需要等待task完成
-            // If true is returned, the task is still being executed and you need to wait for the
-            // task to complete
-            status.wait(waitStatus::WAITING);
-        }
-        if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
-        {
-            std::rethrow_exception(*exception);
-        }
-
-        if constexpr (!std::is_void_v<ReturnType>)
-        {
-            if constexpr (std::is_reference_v<ReturnType>)
-            {
-                return *(std::get<ReturnTypeWrap>(result));
-            }
-            else
-            {
-                return std::move(std::get<ReturnTypeWrap>(result));
-            }
-        }
-    }
-} syncWait{};
-
-}  // namespace bcos::task
+ #pragma once
+ #include "AsyncTask.h"
+ #include "Task.h"
+ #include "Trait.h"
+ #include <boost/atomic/atomic_flag.hpp>
+ #include <exception>
+ #include <memory>
+ #include <type_traits>
+ #include <variant>
+ 
+ namespace bcos::task
+ {
+ 
+ constexpr inline struct Wait
+ {
+     static AsyncTask executeTask(auto task) { co_await std::move(task); }
+ 
+     template <IsAwaitable Task>
+     void operator()(Task&& task) const
+     {
+         auto asyncTask = executeTask(std::forward<Task>(task));
+         asyncTask.start();
+     }
+ } wait{};
+ 
+ constexpr inline struct SyncWait
+ {
+     template <IsAwaitable Task>
+     auto operator()(Task&& task, auto&&... args) const
+         -> AwaitableReturnType<std::remove_cvref_t<Task>>
+     {
+         using ReturnType = AwaitableReturnType<std::remove_cvref_t<Task>>;
+         using ReturnTypeWrap = std::conditional_t<std::is_reference_v<ReturnType>,
+             std::add_pointer_t<ReturnType>, ReturnType>;
+         using ReturnVariant = std::conditional_t<std::is_void_v<ReturnType>,
+             std::variant<std::monostate, std::exception_ptr>,
+             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
+         ReturnVariant result;
+ 
+         auto handle = [](Task&& task, decltype(result)& result, auto&&... args) -> task::SyncTask {
+             try
+             {
+                 if constexpr (std::is_void_v<ReturnType>)
+                 {
+                     co_await std::forward<Task>(task);
+                 }
+                 else
+                 {
+                     if constexpr (std::is_reference_v<ReturnType>)
+                     {
+                         decltype(auto) ref = co_await task;
+                         result = std::addressof(ref);
+                     }
+                     else
+                     {
+                         result.template emplace<ReturnType>(co_await std::forward<Task>(task));
+                     }
+                 }
+             }
+             catch (...)
+             {
+                 result.template emplace<std::exception_ptr>(std::current_exception());
+             }
+ 
+             struct GetStatusAwaitable {
+                 std::coroutine_handle<SyncTask::promise_type> m_handle;
+                 bool await_ready() const noexcept { return false; }
+                 bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept 
+                 {
+                     m_handle = handle;
+                     return false;
+                 }
+                 std::atomic<waitStatus>& await_resume() noexcept { return m_handle.promise().m_status; }
+             };
+ 
+             auto& status = co_await GetStatusAwaitable();
+ 
+             auto expected = waitStatus::INIT;
+             if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
+             {
+                 // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
+                 // If true is returned here, the external finish is set first, and the external
+                 // execution needs to be notified
+                 status.store(waitStatus::FINISHED);
+                 status.notify_one();
+             }
+         }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
+         
+         auto& status = handle.getStatus();
+         handle.start();
+ 
+         auto expected = waitStatus::INIT;
+         if (status.compare_exchange_strong(expected, waitStatus::WAITING))
+         {
+             // 此处返回true说明task还在执行中，需要等待task完成
+             // If true is returned, the task is still being executed and you need to wait for the
+             // task to complete
+             status.wait(waitStatus::WAITING);
+         }
+         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
+         {
+             std::rethrow_exception(*exception);
+         }
+ 
+         if constexpr (!std::is_void_v<ReturnType>)
+         {
+             if constexpr (std::is_reference_v<ReturnType>)
+             {
+                 return *(std::get<ReturnTypeWrap>(result));
+             }
+             else
+             {
+                 return std::move(std::get<ReturnTypeWrap>(result));
+             }
+         }
+     }
+ } syncWait{};
+ 
+ }  // namespace bcos::task
+ 


### PR DESCRIPTION
### 问题描述
SyncWait 存在一个竞态条件导致的 use-after-destroy 问题。当主线程和协程同时进入同步等待路径时：
1. 主线程调用 `finished.test_and_set()` 返回 `false`，进入等待
2. 协程完成后调用 `finished.test_and_set()` 返回 `true`（主线程已设置），进入通知分支
3. 协程调用 `waitFlag.test_and_set()` 和 `waitFlag.notify_one()`
4. 主线程被 `waitFlag.wait(false)` 唤醒后直接退出函数，局部变量 `waitFlag` 等被销毁
5. 此时协程的 `notify_one()` 可能还未完全执行完毕（`this` 指针指向已销毁对象），导致未定义行为

### 修复方式
用一个 `std::atomic<waitStatus>` 四态状态机替代原有的 `finished + waitFlag` 双标志位方案：
INIT → WAITING（主线程进入等待） INIT → FINISHED（协程先完成） WAITING → AWAKED（协程唤醒主线程）→ FINISHED（协程最终置位）

**协程侧**：协程先 `store(AWAKED)` 再 `notify_one()`，最后 `store(FINISHED)`。在 `store(FINISHED)` 之后协程不再访问 `status`。
**主线程侧**：主线程 `wait(WAITING)` 被唤醒后进入忙等循环，直到看到 `FINISHED` 才退出。此时协程已设置 `FINISHED` 且不再访问 `status`，生命周期安全。
与旧的 `finished + waitFlag + exited` 三标志方案相比，该方案只需一个原子变量，状态机更清晰。
### 改动点
1. 新增 `waitStatus` 枚举（INIT / WAITING / AWAKED / FINISHED）
2. 用 `std::atomic<waitStatus>` 替代 `boost::atomic_flag finished` 和 `boost::atomic_flag waitFlag`
3. 协程完成时通过 `compare_exchange_strong` 判断是否需通知主线程，按 AWAKED → notify_one → FINISHED 顺序操作
4. 主线程通过 `compare_exchange_strong` 判断是否需等待，wait 唤醒后忙等 FINISHED 以确保协程彻底退出
