### PR TITLE
Fix cross-thread use-after-free in task::syncWait (heap-owned state + self-destroying AsyncTask)

### DIFF
--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -51,13 +51,22 @@ constexpr inline struct SyncWait
         using ReturnVariant = std::conditional_t<std::is_void_v<ReturnType>,
             std::variant<std::monostate, std::exception_ptr>,
             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
-        ReturnVariant result;
-        boost::atomic_flag finished;
-        boost::atomic_flag waitFlag;
+        // The task may complete on another thread. Everything that thread touches after
+        // completion must be heap-owned (shared_ptr held by the detached coroutine below),
+        // never on this waiter's stack: the waiter may wake, return and have its stack
+        // unmapped while the completing thread is still executing the coroutine tail
+        // (FIB-48 crash on macOS: "memory access violation ... no mapping at fault address").
+        struct State
+        {
+            ReturnVariant m_result;
+            boost::atomic_flag m_finished;
+        };
+        auto state = std::make_shared<State>();
 
-        auto handle = [](Task&& task, decltype(result)& result, boost::atomic_flag& finished,
-                          boost::atomic_flag& waitFlag,
-                          auto&&... args) -> task::Task<void> {
+        // AsyncTask self-destroys at final_suspend on whichever thread completes it, so the
+        // waiter never destroys a coroutine frame the completer may still be executing in.
+        auto executeTask = [](Task&& task, std::shared_ptr<State> state,
+                               auto&&... args) -> AsyncTask {
             try
             {
                 if constexpr (std::is_void_v<ReturnType>)
@@ -69,39 +78,27 @@ constexpr inline struct SyncWait
                     if constexpr (std::is_reference_v<ReturnType>)
                     {
                         decltype(auto) ref = co_await task;
-                        result = std::addressof(ref);
+                        state->m_result = std::addressof(ref);
                     }
                     else
                     {
-                        result.template emplace<ReturnType>(co_await std::forward<Task>(task));
+                        state->m_result.template emplace<ReturnType>(
+                            co_await std::forward<Task>(task));
                     }
                 }
             }
             catch (...)
             {
-                result.template emplace<std::exception_ptr>(std::current_exception());
+                state->m_result.template emplace<std::exception_ptr>(std::current_exception());
             }
 
-            if (finished.test_and_set())
-            {
-                // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
-                // If true is returned here, the external finish is set first, and the external
-                // execution needs to be notified
-                waitFlag.test_and_set();
-                waitFlag.notify_one();
-            }
-        }(std::forward<Task>(task), result, finished, waitFlag,
-                                              std::forward<decltype(args)>(args)...);
-        handle.start();
+            state->m_finished.test_and_set();
+            state->m_finished.notify_one();
+        };
+        executeTask(std::forward<Task>(task), state, std::forward<decltype(args)>(args)...).start();
 
-        if (!finished.test_and_set())
-        {
-            // 此处返回false说明task还在执行中，需要等待task完成
-            // If false is returned, the task is still being executed and you need to wait for the
-            // task to complete
-            waitFlag.wait(false);
-        }
-        if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
+        state->m_finished.wait(false);
+        if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(state->m_result)))
         {
             std::rethrow_exception(*exception);
         }
@@ -110,11 +107,11 @@ constexpr inline struct SyncWait
         {
             if constexpr (std::is_reference_v<ReturnType>)
             {
-                return *(std::get<ReturnTypeWrap>(result));
+                return *(std::get<ReturnTypeWrap>(state->m_result));
             }
             else
             {
-                return std::move(std::get<ReturnTypeWrap>(result));
+                return std::move(std::get<ReturnTypeWrap>(state->m_result));
             }
         }
     }

--- a/libtask/tests/TestTask.cpp
+++ b/libtask/tests/TestTask.cpp
@@ -13,12 +13,15 @@
 #include <boost/multiprecision/fwd.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/throw_exception.hpp>
+#include <atomic>
 #include <chrono>
+#include <coroutine>
 #include <future>
 #include <iostream>
 #include <memory_resource>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 using namespace bcos::task;
 
@@ -288,6 +291,62 @@ BOOST_AUTO_TEST_CASE(u256)
     handle.start();
     // auto sum = syncWait(testU256());
     // BOOST_CHECK_GE(sum, 3000);
+}
+
+Task<int> crossThreadTask(std::atomic_int& activeResumers)
+{
+    struct CrossThreadAwaitable
+    {
+        std::atomic_int& active;
+        bool await_ready() const noexcept { return false; }
+        void await_suspend(std::coroutine_handle<> handle)
+        {
+            active.fetch_add(1, std::memory_order_relaxed);
+            // Bind the counter directly, not through the awaitable: the awaitable lives in
+            // the coroutine frame, which is destroyed during resume()
+            std::thread([handle, &active = active]() mutable {
+                handle.resume();
+                active.fetch_sub(1, std::memory_order_release);
+            }).detach();
+        }
+        int await_resume() const noexcept { return 42; }
+    };
+    co_return co_await CrossThreadAwaitable{.active = activeResumers};
+}
+
+BOOST_AUTO_TEST_CASE(syncWaitCrossThreadTeardown)
+{
+    // Regression test: syncWait used to keep the result and wake flags on the waiter's
+    // stack and let the waiter destroy the coroutine frame. When the task completed on
+    // another thread, that thread kept touching the waiter's stack and the frame after
+    // the waiter could wake and return (use-after-free, SIGSEGV in the resumer thread).
+    constexpr int WAITERS = 8;
+    constexpr int ITERATIONS = 1000;
+    std::atomic_int activeResumers{0};
+    std::atomic_int successCount{0};
+    std::vector<std::thread> waiters;
+    waiters.reserve(WAITERS);
+    for (int i = 0; i < WAITERS; ++i)
+    {
+        waiters.emplace_back([&]() {
+            for (int j = 0; j < ITERATIONS; ++j)
+            {
+                if (syncWait(crossThreadTask(activeResumers)) == 42)
+                {
+                    successCount.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& thread : waiters)
+    {
+        thread.join();
+    }
+    while (activeResumers.load(std::memory_order_acquire) != 0)
+    {
+        std::this_thread::yield();
+    }
+    BOOST_CHECK_EQUAL(successCount.load(), WAITERS * ITERATIONS);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Problem

`task::syncWait` (`libtask/bcos-task/Wait.h`) has a use-after-free when the awaited task completes on another thread. There are two independent race paths:

**Path 1 — stack-owned flags.** `result`, `finished` and `waitFlag` live on the waiter's stack and are handed by reference into a detached coroutine. The completing thread still touches them after the point where the waiter can wake up. Note that `boost::atomic_flag::wait` internally re-loads until the value differs (see `boost/atomic/detail/wait_ops_darwin_ulock.hpp`, same loop for the futex backends), so the waiter can legitimately return as soon as `waitFlag.test_and_set()` publishes the new value — before the completing thread executes `waitFlag.notify_one()`. The waiter then returns, its stack is torn down (or the whole thread exits and its stack is unmapped), and `notify_one()` lands on freed memory.

**Path 2 — waiter-owned coroutine frame.** The detached coroutine is a `task::Task<void>` whose frame is destroyed by the waiter (`~Task` calls `m_handle.destroy()`, `Task.h:163`), while `task::Task`'s `FinalAwaitable` suspends at `final_suspend`. So the waiter may destroy a frame that the completing thread is still executing in (everything between the flag publish and reaching the final suspend point).

This is the cause of the FIB48 crash on the macos-15-intel runner ("memory access violation ... no mapping at fault address", fault address inside an unmapped thread stack).

## Fix

1. Move the shared state (`result` + `finished`) into a heap `State` co-owned via `shared_ptr` by the waiter and by the coroutine (by-value parameter). Whatever the completing thread touches after publishing completion is heap memory kept alive by the coroutine's own reference.
2. Run the detached coroutine as an `AsyncTask`, which self-destroys at `final_suspend` (`AsyncTask.h`: `await_suspend` calls `handle.destroy()`). Frame destruction is owned by the completing thread; the waiter no longer destroys anything the completer may still be executing in.

A regression test (`syncWaitCrossThreadTeardown`) hammers the cross-thread slow path from 8 waiter threads. On the pre-fix code it crashes deterministically; with the fix it passes.

## Verification

- `./build/libtask/tests/test-task`: all cases green, including the new regression test.
- Red-green check: rebuilding the test against the base `Wait.h` makes `syncWaitCrossThreadTeardown` crash (Boost.Test exit 201); restoring this fix turns it green.
- A standalone differential stress harness (8 threads x 20k cross-thread completions, only `Wait.h` varying) on macOS arm64: base `release-3.18.0` crashes 5/5 (SIGSEGV), this fix passes 6/6.

## Relation to #5378 / #5380

Both PRs address Path 1 only and keep the `task::Task<void>` + waiter-side frame destruction structure, so Path 2 remains. Under the same stress harness the #5378 variant crashes (SIGSEGV, PC=0x0 in the resumer thread: after `wf->test_and_set()` the waiter can wake, return and destroy the coroutine frame while the completer still executes `wf->notify_one()` and the frame teardown — the copied `shared_ptr` itself lives in the frame). Details posted on the respective PRs.

## Known follow-up (out of scope)

`TBBWait.h` has the same shape (stack-owned `result`/`finished`/`suspendPoint`, waiter-destroyed `Task<void>` frame, completion via `tbb::task::resume` from another thread) and is on the block-execution path (BaselineScheduler / SchedulerSerialImpl / SchedulerParallelImpl / MultiLayerStorage). It needs the same treatment in a follow-up PR.
