### PR TITLE
feat(scheduler): historical eth_call via MPT state at blockTag (M13.2)

### DIFF
--- a/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
+++ b/bcos-framework/bcos-framework/dispatcher/SchedulerInterface.h
@@ -56,6 +56,21 @@ public:
     virtual void call(protocol::Transaction::Ptr tx,
         std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr)>) = 0;
 
+    // by rpc: eth_call pinned at a block height (M13.2). The default implementation ignores
+    // the height and serves the latest state — byte-for-byte the pre-existing behaviour of
+    // every implementation with no historical state to offer (tars SchedulerService, fakes),
+    // which is why this is a defaulted method and not a pure one (same pattern as
+    // FrontInterface::asyncBroadcastMessageByOwnedPayload). BaselineScheduler overrides it
+    // with a real execution against the MPT state committed at that block. A distinct name
+    // rather than a call() overload: -Woverloaded-virtual (in -Wall, promoted by -Werror)
+    // would otherwise fire in every subclass that overrides only the latest-state call().
+    virtual void callAtBlock(protocol::Transaction::Ptr tx,
+        bcos::protocol::BlockNumber /*blockNumber*/,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr)> callback)
+    {
+        call(std::move(tx), std::move(callback));
+    }
+
     // clear all status
     virtual void reset(std::function<void(Error::Ptr)> callback) = 0;
     virtual void getCode(

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -507,7 +507,7 @@ task::Task<void> EthEndpoint::call(
         BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid call request!"));
     }
     auto const blockTag = toView(request[1U]);
-    auto [blockNumber, _] = co_await getBlockNumberByTag(blockTag);
+    auto [blockNumber, isLatest] = co_await getBlockNumberByTag(blockTag);
     if (c_fileLogLevel == TRACE)
     {
         WEB3_LOG(TRACE) << LOG_DESC("eth_call") << LOG_KV("call", call)
@@ -519,6 +519,9 @@ task::Task<void> EthEndpoint::call(
     {
         bcos::scheduler::SchedulerInterface& m_scheduler;
         bcos::protocol::Transaction::Ptr& m_tx;
+        // Engaged for a non-latest tag: route through callAtBlock (M13.2) so the scheduler
+        // executes against that block's state; disengaged keeps the latest-state call().
+        std::optional<protocol::BlockNumber> m_historicalBlock;
         Error::Ptr m_error;
         Json::Value& m_response;
         u256* m_gasUsed;
@@ -526,7 +529,7 @@ task::Task<void> EthEndpoint::call(
         constexpr static bool await_ready() noexcept { return false; }
         void await_suspend(std::coroutine_handle<> handle)
         {
-            m_scheduler.call(m_tx, [this, handle](Error::Ptr&& error, auto&& result) {
+            auto callback = [this, handle](Error::Ptr&& error, auto&& result) {
                 if (error)
                 {
                     m_error = std::move(error);
@@ -557,7 +560,15 @@ task::Task<void> EthEndpoint::call(
                 }
 
                 handle.resume();
-            });
+            };
+            if (m_historicalBlock)
+            {
+                m_scheduler.callAtBlock(m_tx, *m_historicalBlock, std::move(callback));
+            }
+            else
+            {
+                m_scheduler.call(m_tx, std::move(callback));
+            }
         }
         void await_resume()
         {
@@ -568,6 +579,7 @@ task::Task<void> EthEndpoint::call(
         }
     } awaitable{.m_scheduler = *scheduler,
         .m_tx = tx,
+        .m_historicalBlock = isLatest ? std::nullopt : std::make_optional(blockNumber),
         .m_error = {},
         .m_response = response,
         .m_gasUsed = gasUsed};

--- a/bcos-rpc/test/unittests/rpc/Web3EthCallBlockTagTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthCallBlockTagTest.cpp
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * @file Web3EthCallBlockTagTest.cpp
+ * @brief eth_call blockTag routing (M13.2): latest-family tags stay on
+ *        SchedulerInterface::call, historical tags go through callAtBlock with the resolved
+ *        height, and the callAtBlock default implementation keeps schedulers that only
+ *        implement call() working.
+ */
+
+#include "../common/RPCFixture.h"
+#include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
+#include <boost/test/unit_test.hpp>
+#include <future>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+
+/// Records which SchedulerInterface entry point eth_call lands on, and with what height.
+class RecordingScheduler : public FakeScheduler
+{
+public:
+    using FakeScheduler::FakeScheduler;
+    using Ptr = std::shared_ptr<RecordingScheduler>;
+
+    int m_latestCalls{0};
+    std::vector<protocol::BlockNumber> m_historicalCalls;
+
+    void call(protocol::Transaction::Ptr,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr)> callback) noexcept
+        override
+    {
+        ++m_latestCalls;
+        callback({}, std::make_shared<bcostars::protocol::TransactionReceiptImpl>());
+    }
+    void callAtBlock(protocol::Transaction::Ptr, protocol::BlockNumber blockNumber,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr)> callback) override
+    {
+        m_historicalCalls.push_back(blockNumber);
+        callback({}, std::make_shared<bcostars::protocol::TransactionReceiptImpl>());
+    }
+};
+
+class Web3EthCallBlockTagFixture : public RPCFixture
+{
+public:
+    Web3JsonRpcImpl::Ptr buildWeb3Rpc(std::shared_ptr<bcos::scheduler::SchedulerInterface> sched)
+    {
+        auto service = std::make_shared<rpc::NodeService>(
+            m_ledger, std::move(sched), txPool, nullptr, nullptr, m_blockFactory, nullptr);
+        rpc = factory->buildLocalRpc(groupInfo, service);
+        auto web3 = rpc->web3JsonRpc();
+        BOOST_REQUIRE(web3 != nullptr);
+        return web3;
+    }
+
+    static Json::Value request(Web3JsonRpcImpl::Ptr const& web3, std::string_view blockTag)
+    {
+        auto payload =
+            std::string(
+                R"({"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"to":"0x1234567890123456789012345678901234567890","data":"0x"},)") +
+            std::string(blockTag) + "]}";
+        std::promise<bcos::bytes> promise;
+        web3->onRPCRequest(
+            payload, [&promise](bcos::bytes resp) { promise.set_value(std::move(resp)); });
+        auto jsonBytes = promise.get_future().get();
+        Json::Value value;
+        Json::Reader reader;
+        std::string_view json((char*)jsonBytes.data(), jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    }
+
+    Rpc::Ptr rpc;
+};
+
+BOOST_FIXTURE_TEST_SUITE(Web3EthCallBlockTagTest, Web3EthCallBlockTagFixture)
+
+BOOST_AUTO_TEST_CASE(latestFamilyTagsStayOnTheLatestCall)
+{
+    auto recording = std::make_shared<RecordingScheduler>(m_ledger, m_blockFactory);
+    auto web3 = buildWeb3Rpc(recording);
+
+    for (auto tag : {R"("latest")", R"("pending")", R"("safe")", R"("finalized")"})
+    {
+        auto resp = request(web3, tag);
+        BOOST_CHECK_MESSAGE(resp.isMember("result"), "tag " + std::string(tag));
+    }
+    BOOST_CHECK_EQUAL(recording->m_latestCalls, 4);
+    BOOST_CHECK(recording->m_historicalCalls.empty());
+}
+
+BOOST_AUTO_TEST_CASE(historicalTagsRouteThroughCallAtBlock)
+{
+    auto recording = std::make_shared<RecordingScheduler>(m_ledger, m_blockFactory);
+    auto web3 = buildWeb3Rpc(recording);
+
+    auto resp = request(web3, R"("0x1")");
+    BOOST_CHECK(resp.isMember("result"));
+    auto respEarliest = request(web3, R"("earliest")");
+    BOOST_CHECK(respEarliest.isMember("result"));
+
+    BOOST_CHECK_EQUAL(recording->m_latestCalls, 0);
+    BOOST_REQUIRE_EQUAL(recording->m_historicalCalls.size(), 2U);
+    BOOST_CHECK_EQUAL(recording->m_historicalCalls[0], 1);
+    BOOST_CHECK_EQUAL(recording->m_historicalCalls[1], 0);
+}
+
+BOOST_AUTO_TEST_CASE(numericTagAtTheTipIsLatest)
+{
+    auto recording = std::make_shared<RecordingScheduler>(m_ledger, m_blockFactory);
+    auto web3 = buildWeb3Rpc(recording);
+
+    // The fake ledger's current height, given as an explicit number, is the latest state.
+    protocol::BlockNumber latest = -1;
+    m_ledger->asyncGetBlockNumber(
+        [&latest](Error::Ptr, protocol::BlockNumber number) { latest = number; });
+    BOOST_REQUIRE_GE(latest, 0);
+
+    std::ostringstream quantity;
+    quantity << "\"0x" << std::hex << latest << "\"";
+    auto resp = request(web3, quantity.str());
+    BOOST_CHECK(resp.isMember("result"));
+    BOOST_CHECK_EQUAL(recording->m_latestCalls, 1);
+    BOOST_CHECK(recording->m_historicalCalls.empty());
+}
+
+// A scheduler that never heard of callAtBlock (overrides only call) still serves a
+// historical tag through the interface's forwarding default implementation.
+BOOST_AUTO_TEST_CASE(defaultImplementationKeepsLegacySchedulersWorking)
+{
+    auto web3 = buildWeb3Rpc(std::make_shared<FakeScheduler2>(m_ledger, m_blockFactory));
+
+    auto resp = request(web3, R"("0x1")");
+    BOOST_CHECK(resp.isMember("result"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
+++ b/transaction-executor/bcos-transaction-executor/RollbackableStorage.h
@@ -26,6 +26,9 @@ class Rollbackable
 public:
     using Key = typename Storage::Key;
     using Value = typename Storage::Value;
+    /// The wrapped storage type, so type-level traits can see through the wrapper
+    /// (hostcontext::isHistoricalStorage walks it).
+    using StorageType = Storage;
     using Savepoint = int64_t;
 
     Rollbackable(Storage& storage) : m_storage(storage) {}

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -99,6 +99,37 @@ struct Executable
 template <class Storage>
 using Account = ledger::account::EVMAccount<Storage>;
 
+/// True when @p Storage is (or wraps) a historical state stack — a storage pinned to a past
+/// block's state, marked by a `isHistoricalStateStorage` member (HistoricalCallStorage.h).
+/// The walk sees through the two wrappers a storage reaches getExecutable in: Rollbackable
+/// (via its StorageType alias) and storage2::View (via its BackendStorage alias).
+///
+/// getExecutable consults it because the global executable cache is keyed by address alone
+/// and shared with the latest-state paths, so historical execution must bypass it both
+/// ways: a hit would execute the code the address holds TODAY (possibly deployed after the
+/// pinned block), and a fill would poison latest-path lookups with the pinned block's code.
+template <class Storage>
+consteval bool isHistoricalStorage()
+{
+    using StorageType = std::decay_t<Storage>;
+    if constexpr (requires { StorageType::isHistoricalStateStorage; })
+    {
+        return true;
+    }
+    else if constexpr (requires { typename StorageType::StorageType; })
+    {
+        return isHistoricalStorage<typename StorageType::StorageType>();
+    }
+    else if constexpr (requires { typename StorageType::BackendStorage; })
+    {
+        return isHistoricalStorage<typename StorageType::BackendStorage>();
+    }
+    else
+    {
+        return false;
+    }
+}
+
 using CacheExecutables =
     storage2::memory_storage::MemoryStorage<evmc_address, std::shared_ptr<Executable>,
         storage2::memory_storage::Attribute(
@@ -109,16 +140,23 @@ CacheExecutables& getCacheExecutables();
 task::Task<std::shared_ptr<Executable>> getExecutable(
     auto& storage, const evmc_address& address, const evmc_revision& revision, bool binaryAddress)
 {
-    if (auto executable = co_await storage2::readOne(getCacheExecutables(), address))
+    constexpr bool useGlobalCache = !isHistoricalStorage<decltype(storage)>();
+    if constexpr (useGlobalCache)
     {
-        co_return std::move(*executable);
+        if (auto executable = co_await storage2::readOne(getCacheExecutables(), address))
+        {
+            co_return std::move(*executable);
+        }
     }
 
     if (Account<std::decay_t<decltype(storage)>> account(storage, address, binaryAddress);
         auto codeEntry = co_await account.code())
     {
         auto executable = std::make_shared<Executable>(std::move(*codeEntry));
-        co_await storage2::writeOne(getCacheExecutables(), address, executable);
+        if constexpr (useGlobalCache)
+        {
+            co_await storage2::writeOne(getCacheExecutables(), address, executable);
+        }
         co_return executable;
     }
     co_return {};

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "BaselineSchedulerMPTHelpers.h"
+#include "HistoricalCallStorage.h"
 #include "MPTNodeStorage.h"
 #include "bcos-crypto/interfaces/crypto/Hash.h"
 #include "bcos-crypto/merkle/Merkle.h"
@@ -20,6 +21,7 @@
 #include "bcos-framework/protocol/Transaction.h"
 #include "bcos-framework/protocol/TransactionReceipt.h"
 #include "bcos-framework/protocol/TransactionSubmitResultFactory.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
@@ -902,18 +904,109 @@ public:
     {
         task::wait([](decltype(this) self, protocol::Transaction::Ptr transaction,
                        decltype(callback) callback) -> task::Task<void> {
-            auto view = self->m_multiLayerStorage.get().fork();
-            view.newMutable();
-            auto blockNumber = co_await ledger::getCurrentBlockNumber(view, ledger::fromStorage);
-            auto ledgerConfig =
-                co_await ledger::getLedgerConfig(view, blockNumber, self->m_blockFactory.get());
-            auto block = co_await ledger::getBlockData(
-                view, blockNumber, ledger::HEADER, self->m_blockFactory.get());
-            auto receipt = co_await self->m_executor.get().executeTransaction(
-                view, *block->blockHeader(), *transaction, 0, *ledgerConfig, true);
-
-            callback(nullptr, std::move(receipt));
+            callback(nullptr, co_await self->coCallLatest(std::move(transaction)));
         }(this, std::move(transaction), std::move(callback)));
+    }
+
+    /// The pre-existing latest-state call, verbatim: fork the live view and execute on top
+    /// of it. Shared by call() and by callAtBlock() when the requested height IS the latest.
+    task::Task<protocol::TransactionReceipt::Ptr> coCallLatest(
+        protocol::Transaction::Ptr transaction)
+    {
+        auto view = m_multiLayerStorage.get().fork();
+        view.newMutable();
+        auto blockNumber = co_await ledger::getCurrentBlockNumber(view, ledger::fromStorage);
+        auto ledgerConfig =
+            co_await ledger::getLedgerConfig(view, blockNumber, m_blockFactory.get());
+        auto block =
+            co_await ledger::getBlockData(view, blockNumber, ledger::HEADER, m_blockFactory.get());
+        co_return co_await m_executor.get().executeTransaction(
+            view, *block->blockHeader(), *transaction, 0, *ledgerConfig, true);
+    }
+
+    /// eth_call pinned at @p blockNumber (M13.2, spec §5.13): execute against the state
+    /// block N committed — the MPT at block N's header stateRoot — with the call's own
+    /// writes landing in a fresh mutable layer stacked on a HistoricalStateBackend
+    /// (read-your-writes inside the call, nothing persisted; HistoricalCallStorage.h).
+    ///
+    /// Gated to scenario B (feature_l2_ethereum_compat): only there is the trie the
+    /// COMPLETE state at the root. A scenario-A trie excludes every account dormant since
+    /// activation, so a historical call could silently execute against a state where such
+    /// accounts read as absent — refused loudly instead (OQ6 resolution, MPTAccount.h:83-85).
+    /// Blocks above the latest height and blocks whose header records no state root
+    /// (a scenario-B genesis) are refused with explicit errors. Trie-read failures
+    /// (MPTMissingNode / MPTDecodeError / MPTInvariantViolation) surface as Error results,
+    /// never as swallowed wrong answers.
+    void callAtBlock(protocol::Transaction::Ptr transaction, protocol::BlockNumber blockNumber,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr)> callback) override
+    {
+        task::wait([](decltype(this) self, protocol::Transaction::Ptr transaction,
+                       protocol::BlockNumber blockNumber,
+                       decltype(callback) callback) -> task::Task<void> {
+            try
+            {
+                auto latestView = self->m_multiLayerStorage.get().fork();
+                auto latestNumber =
+                    co_await ledger::getCurrentBlockNumber(latestView, ledger::fromStorage);
+                if (blockNumber > latestNumber)
+                {
+                    callback(BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidBlockNumber,
+                                 fmt::format("eth_call: block {} does not exist (latest: {})",
+                                     blockNumber, latestNumber)),
+                        nullptr);
+                    co_return;
+                }
+                if (blockNumber == latestNumber)
+                {
+                    callback(nullptr, co_await self->coCallLatest(std::move(transaction)));
+                    co_return;
+                }
+                auto ledgerConfig = co_await ledger::getLedgerConfig(
+                    latestView, blockNumber, self->m_blockFactory.get());
+                if (!ledgerConfig->features().get(
+                        ledger::Features::Flag::feature_l2_ethereum_compat))
+                {
+                    callback(BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidStatus,
+                                 fmt::format(
+                                     "eth_call: historical call at block {} requires the "
+                                     "full-fidelity MPT of an L2 Ethereum-compat chain "
+                                     "(feature_l2_ethereum_compat, scenario B); this chain's state "
+                                     "at that block is not completely committed to an MPT",
+                                     blockNumber)),
+                        nullptr);
+                    co_return;
+                }
+                auto block = co_await ledger::getBlockData(
+                    latestView, blockNumber, ledger::HEADER, self->m_blockFactory.get());
+                auto stateRoot = block->blockHeader()->stateRoot();
+                if (stateRoot == crypto::HashType{})
+                {
+                    callback(BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::InvalidStatus,
+                                 fmt::format("eth_call: no MPT state root recorded in block {}'s "
+                                             "header",
+                                     blockNumber)),
+                        nullptr);
+                    co_return;
+                }
+
+                HistoricalStateBackend<typename MultiLayerStorage::ViewType> historicalBackend(
+                    latestView, stateRoot);
+                storage2::View<typename MultiLayerStorage::MutableStorage, void,
+                    HistoricalStateBackend<typename MultiLayerStorage::ViewType>>
+                    historicalView(std::addressof(historicalBackend));
+                historicalView.newMutable();
+                auto receipt = co_await self->m_executor.get().executeTransaction(
+                    historicalView, *block->blockHeader(), *transaction, 0, *ledgerConfig, true);
+                callback(nullptr, std::move(receipt));
+            }
+            catch (std::exception const& e)
+            {
+                callback(BCOS_ERROR_UNIQUE_PTR(scheduler::SchedulerError::UnknownError,
+                             fmt::format("eth_call at block {} failed: {}", blockNumber,
+                                 boost::diagnostic_information(e))),
+                    nullptr);
+            }
+        }(this, std::move(transaction), blockNumber, std::move(callback)));
     }
 
     void reset([[maybe_unused]] std::function<void(Error::Ptr)> callback) override

--- a/transaction-scheduler/bcos-transaction-scheduler/HistoricalCallStorage.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/HistoricalCallStorage.h
@@ -1,0 +1,286 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HistoricalCallStorage.h
+ * @brief HistoricalStateBackend — the read-through layer of a historical eth_call's storage
+ *        stack: flat-state reads answered from the MPT at a past block's state root (M13.2,
+ *        spec §5.13)
+ */
+#pragma once
+
+#include "MPTNodeStorage.h"
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Classify.h>
+#include <bcos-ledger/mpt/MPTAccount.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <concepts>
+#include <map>
+#include <memory>
+#include <optional>
+#include <range/v3/range/concepts.hpp>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace bcos::scheduler_v1
+{
+
+/// The backend of a historical eth_call view (spec §5.13): BaselineScheduler::callAtBlock
+/// stacks `storage2::View<MutableStorage, void, HistoricalStateBackend>` — a fresh writable
+/// layer over this read-through layer — so the call's own writes land in the mutable layer
+/// and read back (read-your-writes, the PR #5324 review blocker), while every MISS resolves
+/// here against the state block N committed:
+///
+///  - account-table rows ("/apps/<40-hex>": nonce / balance / codeHash / 32-byte slots)
+///    answer from the block's MPT via MPTAccount's rooted reads, re-encoded in the exact
+///    flat representations EVMAccount reads (decimal strings for nonce and balance, raw
+///    32 bytes for codeHash and slot values). An account or slot with no leaf at that root
+///    reads as absent — Ethereum semantics, exact for scenario B where the trie is the
+///    complete state (gating to scenario B is the caller's job, per OQ6);
+///  - the SYS_TABLES row of an account table answers leaf presence, so exists() means what
+///    an Ethereum client means by it (MPTAccount.h's documented divergence, resolved the
+///    Ethereum way);
+///  - the flat CODE field reads as absent: at blockVersion >= 3.1 code lives in
+///    s_code_binary under the leaf's codeHash (see MPTAccount::code()'s shape inventory),
+///    and s_code_binary passes through below;
+///  - everything else passes through to the LATEST view — deliberately. s_code_binary and
+///    s_number_2_hash are content-addressed / append-only, so their rows are valid at any
+///    height; abi and the other KNOWN_BCOS_EXTENSION_FIELDS are BCOS metadata outside the
+///    committed 4-tuple, deliberately not historicised (PR #5324); system tables (/sys/,
+///    config, auth) have no per-block commitment to answer from, so latest is the only
+///    answer there is — a documented v1 limitation, not an accident.
+///
+/// Read-only by construction: this class exposes no write surface, and the View above it
+/// sends every write to its own mutable layer. Trie reads can throw (MPTMissingNode /
+/// MPTDecodeError / MPTInvariantViolation on a corrupt store); callAtBlock catches them at
+/// the scheduler boundary and turns them into an Error the RPC can report.
+///
+/// NOT thread-safe: one instance serves one call coroutine (the per-address MPTAccount
+/// cache and its per-root leaf cache are unsynchronised, exactly like MPTAccount itself).
+///
+/// @tparam LatestView a full fork() of the node's MultiLayerStorage. It serves two roles:
+///         trie-NODE resolution (ViewNodeStorage reads "/mpt/" rows through it — correct for
+///         ANY root because nodes are content-addressed, so pending layers can only add,
+///         never change them) and the pass-through plane described above.
+template <class LatestView>
+class HistoricalStateBackend
+{
+public:
+    using Key = executor_v1::StateKey;
+    using Value = executor_v1::StateValue;
+    using AccountType =
+        ledger::mpt::MPTAccount<LatestView, ViewNodeStorage<LatestView>, LatestView>;
+
+    /// Marker consumed by executor_v1::hostcontext::isHistoricalStorage(): storages carrying
+    /// it must bypass the global address-keyed executable cache (HostContext.h::getExecutable).
+    constexpr static bool isHistoricalStateStorage = true;
+
+    /// @param stateRoot the MPT state root block N committed — its header's stateRoot.
+    HistoricalStateBackend(LatestView& latestView, h256 stateRoot)
+      : m_latestView(std::addressof(latestView)), m_nodeStorage(latestView), m_stateRoot(stateRoot)
+    {}
+    // Not movable either: cached MPTAccounts hold reference_wrappers into this object's
+    // m_nodeStorage member, which a defaulted move would leave dangling. The one consumer
+    // (callAtBlock) hands the View a pointer, so nothing needs to move it.
+    HistoricalStateBackend(const HistoricalStateBackend&) = delete;
+    HistoricalStateBackend& operator=(const HistoricalStateBackend&) = delete;
+    HistoricalStateBackend(HistoricalStateBackend&&) noexcept = delete;
+    HistoricalStateBackend& operator=(HistoricalStateBackend&&) noexcept = delete;
+    ~HistoricalStateBackend() noexcept = default;
+
+    task::Task<storage2::StorageValueType<Value>> readOneRaw(auto const& key)
+    {
+        auto const keyView = asStateKeyView(key);
+        // Account-table rows: the block's MPT is the source of truth.
+        if (auto address = ledger::mpt::parseAccountTable(keyView.m_table))
+        {
+            co_return co_await resolveAccountRow(*address, keyView);
+        }
+        // The SYS_TABLES row of an account table: existence == leaf presence at the root.
+        if (keyView.m_table == ledger::SYS_TABLES)
+        {
+            if (auto address = ledger::mpt::parseAccountTable(keyView.m_key))
+            {
+                if (co_await accountAt(*address).exists(m_stateRoot))
+                {
+                    co_return storage::Entry{std::string_view{"value"}};
+                }
+                co_return storage2::NOT_EXISTS_TYPE{};
+            }
+        }
+        // Everything else: pass through to the latest view (see class comment).
+        co_return co_await m_latestView->readOneRaw(keyView);
+    }
+
+    task::Task<std::vector<storage2::StorageValueType<Value>>> readSomeRaw(
+        ::ranges::input_range auto keys)
+    {
+        std::vector<storage2::StorageValueType<Value>> values;
+        if constexpr (::ranges::sized_range<decltype(keys)>)
+        {
+            values.reserve(::ranges::size(keys));
+        }
+        for (auto const& key : keys)
+        {
+            values.emplace_back(co_await readOneRaw(key));
+        }
+        co_return values;
+    }
+
+    task::Task<std::optional<Value>> readOne(auto const& key)
+    {
+        auto value = co_await readOneRaw(key);
+        if (auto* entry = std::get_if<Value>(std::addressof(value)))
+        {
+            co_return std::move(*entry);
+        }
+        co_return std::nullopt;
+    }
+
+    task::Task<std::vector<std::optional<Value>>> readSome(::ranges::input_range auto keys)
+    {
+        std::vector<std::optional<Value>> values;
+        if constexpr (::ranges::sized_range<decltype(keys)>)
+        {
+            values.reserve(::ranges::size(keys));
+        }
+        for (auto const& key : keys)
+        {
+            values.emplace_back(co_await readOne(key));
+        }
+        co_return values;
+    }
+
+    /// Ordered iteration cannot be answered from an MPT — slot keys are hashed into the
+    /// trie, so enumerating flat keys would need the whole preimage set — and the execute
+    /// path never range-scans ACCOUNT state (HostContext reads point keys only). What does
+    /// range during a call is the legacy precompiled table plane (LegacyStorageWrapper over
+    /// /sys/ and BFS tables), which is pass-through territory here; serve it from the
+    /// latest view like every other pass-through read.
+    auto range(auto&&... args) -> task::Task<
+        storage2::ReturnType<std::invoke_result_t<storage2::Range, LatestView&, decltype(args)...>>>
+    {
+        co_return co_await storage2::range(*m_latestView, std::forward<decltype(args)>(args)...);
+    }
+
+private:
+    static executor_v1::StateKeyView asStateKeyView(auto const& key)
+    {
+        using KeyType = std::decay_t<decltype(key)>;
+        if constexpr (std::same_as<KeyType, executor_v1::StateKeyView>)
+        {
+            return key;
+        }
+        else if constexpr (std::same_as<KeyType, executor_v1::StateKey>)
+        {
+            return executor_v1::StateKeyView{key};
+        }
+        else
+        {
+            // std::reference_wrapper (fillMissingValues batches keys this way).
+            return asStateKeyView(key.get());
+        }
+    }
+
+    /// One MPTAccount per address, kept for the whole call: the account leaf is decoded once
+    /// per address (MPTAccount caches it per root) no matter how many field and slot reads
+    /// the call performs.
+    AccountType& accountAt(Address const& address)
+    {
+        auto it = m_accounts.find(address);
+        if (it == m_accounts.end())
+        {
+            // binaryAddress is false by construction: feature_raw_address is mutually
+            // exclusive with both MPT flags for the life of a chain
+            // (BaselineSchedulerMPTHelpers.h::validateMPTFlagMatrix), and callAtBlock only
+            // builds this backend for MPT blocks.
+            it = m_accounts
+                     .try_emplace(address, *m_latestView, m_nodeStorage, *m_latestView, address,
+                         /*binaryAddress*/ false)
+                     .first;
+        }
+        return it->second;
+    }
+
+    task::Task<storage2::StorageValueType<Value>> resolveAccountRow(
+        Address const& address, executor_v1::StateKeyView const& keyView)
+    {
+        using ledger::mpt::RowKind;
+        auto& account = accountAt(address);
+        switch (ledger::mpt::classifyRowKey(keyView.m_key))
+        {
+        case RowKind::StorageSlot:
+        {
+            if (auto entry = co_await account.storageEntry(keyView.m_key, m_stateRoot))
+            {
+                co_return std::move(*entry);
+            }
+            co_return storage2::NOT_EXISTS_TYPE{};
+        }
+        case RowKind::Balance:
+        {
+            if (!co_await account.exists(m_stateRoot))
+            {
+                co_return storage2::NOT_EXISTS_TYPE{};
+            }
+            auto balance = co_await account.balance(m_stateRoot);
+            // The flat representation EVMAccount::balance() lexical_casts back.
+            co_return storage::Entry{balance.str({}, {})};
+        }
+        case RowKind::Nonce:
+        {
+            if (auto nonce = co_await account.nonce(m_stateRoot))
+            {
+                co_return storage::Entry{*nonce};
+            }
+            co_return storage2::NOT_EXISTS_TYPE{};
+        }
+        case RowKind::CodeHash:
+        {
+            if (!co_await account.exists(m_stateRoot))
+            {
+                co_return storage2::NOT_EXISTS_TYPE{};
+            }
+            auto codeHash = co_await account.codeHash(m_stateRoot);
+            // Raw 32 bytes, exactly as EVMAccount::setCode writes the row.
+            co_return storage::Entry{concepts::bytebuffer::toView(codeHash)};
+        }
+        case RowKind::Code:
+            // Modern (>= 3.1) code lives in s_code_binary under the leaf's codeHash; the
+            // flat CODE probe EVMAccount::code() falls back to must miss (class comment).
+            co_return storage2::NOT_EXISTS_TYPE{};
+        case RowKind::BcosExtension:
+        case RowKind::UnknownField:
+            // abi and friends: BCOS metadata outside the committed 4-tuple, deliberately
+            // not historicised (PR #5324). Unclassified fields cannot be IN the trie at all
+            // (MPTBuilder throws on them at build time), so latest is the only answer.
+            co_return co_await m_latestView->readOneRaw(keyView);
+        }
+        // Unreachable: classifyRowKey covers every enumerator.
+        co_return storage2::NOT_EXISTS_TYPE{};
+    }
+
+    LatestView* m_latestView;
+    ViewNodeStorage<LatestView> m_nodeStorage;
+    h256 m_stateRoot;
+    std::map<Address, AccountType> m_accounts;
+};
+
+}  // namespace bcos::scheduler_v1

--- a/transaction-scheduler/tests/TestEthCallHistory.cpp
+++ b/transaction-scheduler/tests/TestEthCallHistory.cpp
@@ -1,0 +1,706 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TestEthCallHistory.cpp
+ * @brief Historical eth_call through the scheduler (M13.2): HistoricalStateBackend resolves
+ *        flat-state reads from a past block's MPT root; the View stacked on it gives the
+ *        call read-your-writes; BaselineScheduler::callAtBlock wires blockNumber -> header
+ *        stateRoot -> historical stack -> executor, with explicit refusals for beyond-latest
+ *        blocks and non-scenario-B chains; getExecutable bypasses the global executable
+ *        cache for historical storages.
+ */
+
+#include "TrivialCheckpointStorage.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/storage2/MemoryStorage.h"
+#include "bcos-framework/storage2/MultiLayerStorage.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-protocol/TransactionSubmitResultFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/BlockImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptImpl.h"
+#include "bcos-task/AwaitableValue.h"
+#include "bcos-transaction-executor/RollbackableStorage.h"
+#include "bcos-transaction-executor/vm/HostContext.h"
+#include "bcos-transaction-scheduler/BaselineScheduler.h"
+#include "bcos-transaction-scheduler/HistoricalCallStorage.h"
+#include <boost/test/unit_test.hpp>
+#include <fakeit.hpp>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Anonymous namespace + HC prefix: this TU is unity-merged with the other scheduler test
+// TUs, and the getLedgerConfig tag_invoke stub below is found by ADL through the ViewType's
+// template arguments — the storage types must be anchored here (same pattern as
+// TestMPTSchedulerWiring.cpp).
+namespace
+{
+using namespace bcos;
+using namespace bcos::storage2;
+using namespace bcos::executor_v1;
+using namespace bcos::scheduler_v1;
+
+using HCMutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+struct HCBackendStorage
+  : memory_storage::MemoryStorage<StateKey, StateValue,
+        memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+        std::hash<StateKey>>
+{
+};
+using HCCheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, HCBackendStorage>;
+using HCMultiLayerStorage = MultiLayerStorage<HCMutableStorage, void, HCCheckpointBackend>;
+using HCViewType = HCMultiLayerStorage::ViewType;
+using HCHistoricalBackend = HistoricalStateBackend<HCViewType>;
+using HCHistoricalView = View<HCMutableStorage, void, HCHistoricalBackend>;
+
+/// The Features the getLedgerConfig stub hands out — set per test.
+ledger::Features g_hcFeatures{};
+
+[[maybe_unused]] task::AwaitableValue<void> tag_invoke(
+    ledger::tag_t<bcos::ledger::getLedgerConfig> /*unused*/, HCViewType& /*storage*/,
+    bcos::ledger::LedgerConfig& ledgerConfig, protocol::BlockNumber /*blockNumber*/,
+    protocol::BlockFactory& /*blockFactory*/)
+{
+    ledgerConfig.setFeatures(g_hcFeatures);
+    return {};
+}
+
+task::Task<std::vector<protocol::Transaction::ConstPtr>> hcEmptyTxsTask()
+{
+    co_return std::vector<protocol::Transaction::ConstPtr>{};
+}
+task::Task<ledger::SystemConfigs> hcEmptySystemConfigsTask()
+{
+    co_return ledger::SystemConfigs{};
+}
+task::Task<ledger::Features> hcEmptyFeaturesTask()
+{
+    co_return ledger::Features{};
+}
+
+// --- the probed account -----------------------------------------------------------------
+
+Address hcAddress()
+{
+    Address address{};
+    address.data()[0] = 0xAA;
+    return address;
+}
+
+evmc_address hcEvmcAddress()
+{
+    evmc_address address{};
+    address.bytes[0] = 0xAA;
+    return address;
+}
+
+h256 hcSlot()
+{
+    h256 slot{};
+    slot.data()[31] = 0x01;
+    return slot;
+}
+
+std::string hcSlotRowKey()
+{
+    auto slot = hcSlot();
+    return {reinterpret_cast<char const*>(slot.data()), h256::SIZE};
+}
+
+std::string hcRawValue(uint8_t lastByte)
+{
+    std::string raw(32, '\0');
+    raw[31] = static_cast<char>(lastByte);
+    return raw;
+}
+
+evmc_bytes32 hcEvmcValue(uint8_t lastByte)
+{
+    evmc_bytes32 value{};
+    value.bytes[31] = lastByte;
+    return value;
+}
+
+bytes outputOf(protocol::TransactionReceipt::Ptr const& receipt)
+{
+    auto view = receipt->output();
+    return {view.begin(), view.end()};
+}
+
+bytes toBytes(evmc_bytes32 const& value)
+{
+    return {value.bytes, value.bytes + sizeof(value.bytes)};
+}
+
+// --- block-driving mocks (same shapes as TestMPTSchedulerWiring) ------------------------
+
+struct HCRowOp
+{
+    std::string table;
+    std::string key;
+    std::string value;
+};
+
+struct HCWritingScheduler
+{
+    std::map<protocol::BlockNumber, std::vector<HCRowOp>> const* m_plan{};
+
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(auto& storage,
+        auto& /*executor*/, protocol::BlockHeader const& blockHeader,
+        ::ranges::input_range auto const& transactions, ledger::LedgerConfig const& /*unused*/)
+    {
+        if (auto it = m_plan->find(blockHeader.number()); it != m_plan->end())
+        {
+            for (auto const& row : it->second)
+            {
+                storage::Entry entry;
+                entry.set(row.value);
+                co_await storage2::writeOne(
+                    storage, StateKey{row.table, row.key}, std::move(entry));
+            }
+        }
+        auto receipts = ::ranges::iota_view<size_t, size_t>(0, ::ranges::size(transactions)) |
+                        ::ranges::views::transform([](size_t) -> protocol::TransactionReceipt::Ptr {
+                            auto receipt =
+                                std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+                            constexpr static std::string_view str = "abc";
+                            auto& inner = receipt->inner();
+                            inner.dataHash.assign(str.begin(), str.end());
+                            inner.data.gasUsed = "100";
+                            return receipt;
+                        }) |
+                        ::ranges::to<std::vector<protocol::TransactionReceipt::Ptr>>();
+        co_return receipts;
+    }
+};
+
+/// The "EVM" of these tests: reads the probed account's slot through whatever storage the
+/// scheduler hands it — EVMAccount over the historical stack, exactly the account type the
+/// production HostContext uses — and returns the 32-byte value as the receipt output.
+/// WriteThenReadSlot first SSTOREs m_writeValue, so the output proves (or disproves)
+/// read-your-writes on the stack.
+struct HCProbeExecutor
+{
+    enum class Mode : uint8_t
+    {
+        ReadSlot,
+        WriteThenReadSlot,
+    };
+    Mode m_mode{Mode::ReadSlot};
+    evmc_bytes32 m_writeValue{};
+    protocol::BlockNumber m_lastExecutedHeaderNumber{-1};
+
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(auto& storage,
+        protocol::BlockHeader const& blockHeader, protocol::Transaction const& /*transaction*/,
+        int /*contextID*/, ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+    {
+        m_lastExecutedHeaderNumber = blockHeader.number();
+        ledger::account::EVMAccount account(storage, hcEvmcAddress(), false);
+        if (m_mode == Mode::WriteThenReadSlot)
+        {
+            co_await account.setStorage(ledger::account::toEvmcBytes32(hcSlot()), m_writeValue);
+        }
+        auto value = co_await account.storage(ledger::account::toEvmcBytes32(hcSlot()));
+        auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+        auto& inner = receipt->inner();
+        inner.data.output.assign(value.bytes, value.bytes + sizeof(value.bytes));
+        co_return receipt;
+    }
+
+    template <class Storage>
+    struct ExecuteContext
+    {
+        task::Task<void> prepare() { co_return; }
+        task::Task<void> execute() { co_return; }
+        task::Task<protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
+    };
+    auto createExecuteContext(auto& storage, protocol::BlockHeader const& /*blockHeader*/,
+        protocol::Transaction const& /*transaction*/, int32_t /*contextID*/,
+        ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+        -> task::Task<ExecuteContext<std::decay_t<decltype(storage)>>>
+    {
+        co_return {};
+    }
+};
+
+class EthCallHistoryFixture
+{
+public:
+    EthCallHistoryFixture()
+      : checkpointBackend(backendStorage),
+        cryptoSuite(std::make_shared<crypto::CryptoSuite>(
+            std::make_shared<crypto::Keccak256>(), nullptr, nullptr)),
+        blockHeaderFactory(
+            std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite)),
+        transactionFactory(
+            std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite)),
+        receiptFactory(
+            std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)),
+        blockFactory(std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+            cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory)),
+        transactionSubmitResultFactory(
+            std::make_shared<protocol::TransactionSubmitResultFactoryImpl>()),
+        multiLayerStorage(checkpointBackend),
+        baselineScheduler(multiLayerStorage, mockScheduler, probeExecutor, *blockFactory,
+            mockLedger.get(), mockTxPool.get(), *transactionSubmitResultFactory, *hashImpl)
+    {
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+        g_hcFeatures = features;
+        mockScheduler.m_plan = &plan;
+
+        fakeit::When(Method(mockLedger, asyncPrewriteBlock))
+            .AlwaysDo([](storage::StorageInterface::Ptr, protocol::ConstTransactionsPtr,
+                          protocol::Block::ConstPtr,
+                          std::function<void(std::string, Error::Ptr&&)> callback, bool,
+                          std::optional<ledger::Features>) { callback({}, nullptr); });
+        using HashView =
+            ::ranges::any_view<h256, ::ranges::category::mask | ::ranges::category::sized>;
+        fakeit::When(Method(mockTxPool, getTransactions)).AlwaysDo([](HashView) {
+            return hcEmptyTxsTask();
+        });
+        fakeit::When(Method(mockLedger, asyncGetBlockNumber))
+            .AlwaysDo([](std::function<void(Error::Ptr, protocol::BlockNumber)> callback) {
+                callback(nullptr, -1);
+            });
+        fakeit::When(Method(mockLedger, asyncGetNodeListByType))
+            .AlwaysDo([](std::string_view const&,
+                          std::function<void(Error::Ptr, consensus::ConsensusNodeList)> callback) {
+                callback(nullptr, {});
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockDataByNumber))
+            .AlwaysDo([](protocol::BlockNumber, int32_t,
+                          std::function<void(Error::Ptr, protocol::Block::Ptr)> callback) {
+                callback(nullptr, nullptr);
+            });
+        fakeit::When(Method(mockLedger, asyncGetBlockHashByNumber))
+            .AlwaysDo([](protocol::BlockNumber,
+                          std::function<void(Error::Ptr, crypto::HashType)> callback) {
+                callback(nullptr, crypto::HashType{});
+            });
+        fakeit::When(Method(mockLedger, fetchAllSystemConfigs)).AlwaysDo([](protocol::BlockNumber) {
+            return hcEmptySystemConfigsTask();
+        });
+        fakeit::When(Method(mockLedger, fetchAllFeatures)).AlwaysDo([](protocol::BlockNumber) {
+            return hcEmptyFeaturesTask();
+        });
+
+        baselineScheduler.registerBlockNumberNotifier([](protocol::BlockNumber) {});
+        baselineScheduler.registerTransactionNotifier(
+            [](protocol::BlockNumber, protocol::TransactionSubmitResultsPtr,
+                std::function<void(Error::Ptr)> callback) { callback(nullptr); });
+    }
+
+    protocol::BlockHeader::Ptr executeOneBlock(protocol::BlockNumber number)
+    {
+        auto block = std::make_shared<bcostars::protocol::BlockImpl>();
+        auto blockHeader = block->blockHeader();
+        blockHeader->setNumber(number);
+        blockHeader->setVersion(blockVersion);
+        blockHeader->calculateHash(*hashImpl);
+        bytes input;
+        block->appendTransaction(transactionFactory->createTransaction(
+            0, "to", input, std::to_string(number), 100, "chain", "group", 0));
+
+        Error::Ptr execError;
+        protocol::BlockHeader::Ptr executedHeader;
+        baselineScheduler.executeBlock(
+            block, false, [&](Error::Ptr error, protocol::BlockHeader::Ptr header, bool) {
+                execError = std::move(error);
+                executedHeader = std::move(header);
+            });
+        BOOST_REQUIRE_MESSAGE(
+            !execError, "executeBlock failed: " + (execError ? execError->errorMessage() : ""));
+        BOOST_REQUIRE(executedHeader);
+        return executedHeader;
+    }
+
+    void commitOneBlock(protocol::BlockHeader::Ptr const& header)
+    {
+        Error::Ptr commitError;
+        baselineScheduler.commitBlock(header,
+            [&](Error::Ptr error, ledger::LedgerConfig::Ptr) { commitError = std::move(error); });
+        BOOST_REQUIRE_MESSAGE(!commitError,
+            "commitBlock failed: " + (commitError ? commitError->errorMessage() : ""));
+        // Mirror production: the ledger persists the signed header row (the mock only
+        // invokes the callback).
+        writeHeaderToBackend(header);
+    }
+
+    void writeHeaderToBackend(protocol::BlockHeader::Ptr const& header)
+    {
+        bytes headerBuffer;
+        header->encode(headerBuffer);
+        storage::Entry entry;
+        entry.set(std::move(headerBuffer));
+        task::syncWait(storage2::writeOne(backendStorage,
+            StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER, std::to_string(header->number())},
+            std::move(entry)));
+    }
+
+    protocol::BlockHeader::Ptr makeHeader(protocol::BlockNumber number, h256 stateRoot)
+    {
+        auto header = blockHeaderFactory->createBlockHeader();
+        header->setNumber(number);
+        header->setVersion(blockVersion);
+        header->setStateRoot(stateRoot);
+        header->calculateHash(*hashImpl);
+        return header;
+    }
+
+    void writeCurrentNumberToBackend(protocol::BlockNumber number)
+    {
+        storage::Entry entry;
+        entry.set(std::to_string(number));
+        task::syncWait(storage2::writeOne(backendStorage,
+            StateKey{ledger::SYS_CURRENT_STATE, ledger::SYS_KEY_CURRENT_NUMBER}, std::move(entry)));
+    }
+
+    /// Run the canonical 3-block chain: slot=0x01 at block 1, slot=0x02 at block 2,
+    /// balance bump (slot untouched) at block 3. Returns the three executed headers.
+    std::vector<protocol::BlockHeader::Ptr> runCanonicalChain()
+    {
+        // Seed the genesis header (Ledger::buildGenesisBlock's job in production): scenario-B
+        // block 1 resolves its parent root from it, and an empty-alloc L2 genesis commits the
+        // empty trie.
+        writeHeaderToBackend(makeHeader(0, ledger::mpt::emptyRootHash()));
+
+        auto const table = ledger::mpt::accountTableName(hcAddress());
+        plan[1] = {{table, "balance", "1000"}, {table, "nonce", "5"},
+            {table, hcSlotRowKey(), hcRawValue(0x01)}};
+        plan[2] = {{table, hcSlotRowKey(), hcRawValue(0x02)}};
+        plan[3] = {{table, "balance", "2000"}};
+
+        std::vector<protocol::BlockHeader::Ptr> headers;
+        for (protocol::BlockNumber number = 1; number <= 3; ++number)
+        {
+            auto header = executeOneBlock(number);
+            commitOneBlock(header);
+            headers.push_back(std::move(header));
+        }
+        writeCurrentNumberToBackend(3);
+        return headers;
+    }
+
+    std::tuple<Error::Ptr, protocol::TransactionReceipt::Ptr> callAt(protocol::BlockNumber number)
+    {
+        auto transaction = transactionFactory->createTransaction(
+            0, "to", bytes{}, "callNonce", 100, "chain", "group", 0);
+        Error::Ptr callError;
+        protocol::TransactionReceipt::Ptr receipt;
+        baselineScheduler.callAtBlock(std::move(transaction), number,
+            [&](Error::Ptr error, protocol::TransactionReceipt::Ptr result) {
+                callError = std::move(error);
+                receipt = std::move(result);
+            });
+        return {std::move(callError), std::move(receipt)};
+    }
+
+    static constexpr uint32_t blockVersion = 200;
+
+    HCBackendStorage backendStorage;
+    HCCheckpointBackend checkpointBackend;
+    crypto::CryptoSuite::Ptr cryptoSuite;
+    std::shared_ptr<bcostars::protocol::BlockHeaderFactoryImpl> blockHeaderFactory;
+    std::shared_ptr<bcostars::protocol::TransactionFactoryImpl> transactionFactory;
+    std::shared_ptr<bcostars::protocol::TransactionReceiptFactoryImpl> receiptFactory;
+    std::shared_ptr<bcostars::protocol::BlockFactoryImpl> blockFactory;
+    std::shared_ptr<protocol::TransactionSubmitResultFactoryImpl> transactionSubmitResultFactory;
+
+    crypto::Hash::Ptr hashImpl = std::make_shared<crypto::Keccak256>();
+
+    std::map<protocol::BlockNumber, std::vector<HCRowOp>> plan;
+    HCWritingScheduler mockScheduler;
+    fakeit::Mock<ledger::LedgerInterface> mockLedger;
+    fakeit::Mock<txpool::TxPoolInterface> mockTxPool;
+    HCMultiLayerStorage multiLayerStorage;
+    HCProbeExecutor probeExecutor;
+    BaselineScheduler<decltype(multiLayerStorage), HCProbeExecutor, HCWritingScheduler,
+        ledger::LedgerInterface>
+        baselineScheduler;
+};
+
+// The trait getExecutable consults: the marker propagates through View and Rollbackable,
+// and plain storages stay non-historical (negative control).
+static_assert(hostcontext::isHistoricalStorage<HCHistoricalBackend>());
+static_assert(hostcontext::isHistoricalStorage<HCHistoricalView>());
+static_assert(hostcontext::isHistoricalStorage<Rollbackable<HCHistoricalView>>());
+static_assert(!hostcontext::isHistoricalStorage<HCViewType>());
+static_assert(!hostcontext::isHistoricalStorage<Rollbackable<HCViewType>>());
+static_assert(!hostcontext::isHistoricalStorage<HCMutableStorage>());
+
+BOOST_FIXTURE_TEST_SUITE(TestEthCallHistory, EthCallHistoryFixture)
+
+// Storage-level: HistoricalStateBackend answers account rows from the MPT at the pinned
+// root — the block-1 root serves block-1 values after later blocks overwrote them — and
+// absent accounts/slots read as absent. Pass-through rows (the header table) stay readable.
+BOOST_AUTO_TEST_CASE(historicalBackendResolvesAccountRows)
+{
+    auto headers = runCanonicalChain();
+    auto const table = ledger::mpt::accountTableName(hcAddress());
+
+    auto latestView = multiLayerStorage.fork();
+    HCHistoricalBackend backendAt1(latestView, headers[0]->stateRoot());
+
+    // Slot: the block-1 value, not the block-2 overwrite.
+    auto slotEntry =
+        task::syncWait(storage2::readOne(backendAt1, StateKeyView{table, hcSlotRowKey()}));
+    BOOST_REQUIRE(slotEntry);
+    BOOST_CHECK(slotEntry->get() == hcRawValue(0x01));
+
+    // Balance and nonce in the exact flat representations EVMAccount reads.
+    auto balanceEntry =
+        task::syncWait(storage2::readOne(backendAt1, StateKeyView{table, "balance"}));
+    BOOST_REQUIRE(balanceEntry);
+    BOOST_CHECK_EQUAL(balanceEntry->get(), "1000");
+    auto nonceEntry = task::syncWait(storage2::readOne(backendAt1, StateKeyView{table, "nonce"}));
+    BOOST_REQUIRE(nonceEntry);
+    BOOST_CHECK_EQUAL(nonceEntry->get(), "5");
+
+    // SYS_TABLES row of the account table: leaf presence.
+    auto existsEntry =
+        task::syncWait(storage2::readOne(backendAt1, StateKeyView{ledger::SYS_TABLES, table}));
+    BOOST_CHECK(existsEntry.has_value());
+
+    // A root later in the chain serves the overwrite and the balance bump.
+    HCHistoricalBackend backendAt3(latestView, headers[2]->stateRoot());
+    auto slotAt3 =
+        task::syncWait(storage2::readOne(backendAt3, StateKeyView{table, hcSlotRowKey()}));
+    BOOST_REQUIRE(slotAt3);
+    BOOST_CHECK(slotAt3->get() == hcRawValue(0x02));
+    auto balanceAt3 = task::syncWait(storage2::readOne(backendAt3, StateKeyView{table, "balance"}));
+    BOOST_REQUIRE(balanceAt3);
+    BOOST_CHECK_EQUAL(balanceAt3->get(), "2000");
+
+    // An account with no leaf at the root reads as absent, all four row kinds.
+    Address stranger{};
+    stranger.data()[0] = 0xBB;
+    auto strangerTable = ledger::mpt::accountTableName(stranger);
+    BOOST_CHECK(
+        !task::syncWait(storage2::readOne(backendAt1, StateKeyView{strangerTable, "balance"})));
+    BOOST_CHECK(!task::syncWait(
+        storage2::readOne(backendAt1, StateKeyView{strangerTable, hcSlotRowKey()})));
+    BOOST_CHECK(!task::syncWait(
+        storage2::readOne(backendAt1, StateKeyView{ledger::SYS_TABLES, strangerTable})));
+
+    // Pass-through: a header row read through the historical backend is served verbatim
+    // from the latest view.
+    auto headerRow = task::syncWait(
+        storage2::readOne(backendAt1, StateKeyView{ledger::SYS_NUMBER_2_BLOCK_HEADER, "2"}));
+    BOOST_CHECK(headerRow.has_value());
+}
+
+// Stack-level: a mutable layer over the historical backend gives read-your-writes without
+// disturbing the committed state.
+BOOST_AUTO_TEST_CASE(historicalViewReadYourWrites)
+{
+    auto headers = runCanonicalChain();
+    auto const table = ledger::mpt::accountTableName(hcAddress());
+
+    auto latestView = multiLayerStorage.fork();
+    HCHistoricalBackend historicalBackend(latestView, headers[0]->stateRoot());
+    HCHistoricalView historicalView(std::addressof(historicalBackend));
+    historicalView.newMutable();
+
+    // Miss resolves historically...
+    auto before =
+        task::syncWait(storage2::readOne(historicalView, StateKeyView{table, hcSlotRowKey()}));
+    BOOST_REQUIRE(before);
+    BOOST_CHECK(before->get() == hcRawValue(0x01));
+
+    // ...a write lands in the mutable layer and reads back...
+    storage::Entry updated;
+    updated.set(hcRawValue(0x99));
+    task::syncWait(
+        storage2::writeOne(historicalView, StateKey{table, hcSlotRowKey()}, std::move(updated)));
+    auto after =
+        task::syncWait(storage2::readOne(historicalView, StateKeyView{table, hcSlotRowKey()}));
+    BOOST_REQUIRE(after);
+    BOOST_CHECK(after->get() == hcRawValue(0x99));
+
+    // ...and the backend below never saw it.
+    auto backendValue =
+        task::syncWait(storage2::readOne(historicalBackend, StateKeyView{table, hcSlotRowKey()}));
+    BOOST_REQUIRE(backendValue);
+    BOOST_CHECK(backendValue->get() == hcRawValue(0x01));
+}
+
+// Scheduler-level: callAtBlock(N) executes against block N's state — each height serves its
+// own slot value, the executor sees block N's header, and the latest heights keep working
+// through both entry points.
+BOOST_AUTO_TEST_CASE(callAtBlockServesEachHeight)
+{
+    runCanonicalChain();
+
+    auto [error1, receipt1] = callAt(1);
+    BOOST_REQUIRE_MESSAGE(!error1, (error1 ? error1->errorMessage() : std::string{}));
+    BOOST_REQUIRE(receipt1);
+    BOOST_CHECK(outputOf(receipt1) == toBytes(hcEvmcValue(0x01)));
+    BOOST_CHECK_EQUAL(probeExecutor.m_lastExecutedHeaderNumber, 1);
+
+    auto [error2, receipt2] = callAt(2);
+    BOOST_REQUIRE_MESSAGE(!error2, (error2 ? error2->errorMessage() : std::string{}));
+    BOOST_CHECK(outputOf(receipt2) == toBytes(hcEvmcValue(0x02)));
+    BOOST_CHECK_EQUAL(probeExecutor.m_lastExecutedHeaderNumber, 2);
+
+    // Block 3 IS the latest: callAtBlock delegates to the latest path, which reads the
+    // same (unchanged since block 2) slot.
+    auto [error3, receipt3] = callAt(3);
+    BOOST_REQUIRE_MESSAGE(!error3, (error3 ? error3->errorMessage() : std::string{}));
+    BOOST_CHECK(outputOf(receipt3) == toBytes(hcEvmcValue(0x02)));
+    BOOST_CHECK_EQUAL(probeExecutor.m_lastExecutedHeaderNumber, 3);
+
+    // The plain latest-state call() still works.
+    auto transaction = transactionFactory->createTransaction(
+        0, "to", bytes{}, "latestNonce", 100, "chain", "group", 0);
+    Error::Ptr latestError;
+    protocol::TransactionReceipt::Ptr latestReceipt;
+    baselineScheduler.call(
+        std::move(transaction), [&](Error::Ptr error, protocol::TransactionReceipt::Ptr result) {
+            latestError = std::move(error);
+            latestReceipt = std::move(result);
+        });
+    BOOST_REQUIRE_MESSAGE(
+        !latestError, (latestError ? latestError->errorMessage() : std::string{}));
+    BOOST_CHECK(outputOf(latestReceipt) == toBytes(hcEvmcValue(0x02)));
+}
+
+// The PR #5324 review blocker, pinned green on the real stack: an SSTORE inside a
+// historical call reads back within that call, leaks into no other call and never reaches
+// the committed state.
+BOOST_AUTO_TEST_CASE(writeThenReadInsideHistoricalCall)
+{
+    runCanonicalChain();
+
+    probeExecutor.m_mode = HCProbeExecutor::Mode::WriteThenReadSlot;
+    probeExecutor.m_writeValue = hcEvmcValue(0x99);
+    auto [writeError, writeReceipt] = callAt(1);
+    BOOST_REQUIRE_MESSAGE(!writeError, (writeError ? writeError->errorMessage() : std::string{}));
+    BOOST_CHECK(outputOf(writeReceipt) == toBytes(hcEvmcValue(0x99)));
+
+    // A fresh call at the same height starts from the committed state again.
+    probeExecutor.m_mode = HCProbeExecutor::Mode::ReadSlot;
+    auto [readError, readReceipt] = callAt(1);
+    BOOST_REQUIRE_MESSAGE(!readError, (readError ? readError->errorMessage() : std::string{}));
+    BOOST_CHECK(outputOf(readReceipt) == toBytes(hcEvmcValue(0x01)));
+
+    // And the live chain state is untouched.
+    auto latestView = multiLayerStorage.fork();
+    auto liveValue = task::syncWait(storage2::readOne(
+        latestView, StateKeyView{ledger::mpt::accountTableName(hcAddress()), hcSlotRowKey()}));
+    BOOST_REQUIRE(liveValue);
+    BOOST_CHECK(liveValue->get() == hcRawValue(0x02));
+}
+
+// The refusals: a block beyond the latest height, a chain without scenario-B MPT, and a
+// block whose header is unreachable all answer with explicit errors, never a latest-state
+// result dressed up as a historical one.
+BOOST_AUTO_TEST_CASE(callAtBlockRefusalPaths)
+{
+    runCanonicalChain();
+
+    auto [beyondError, beyondReceipt] = callAt(99);
+    BOOST_REQUIRE(beyondError);
+    BOOST_CHECK(beyondError->errorMessage().find("does not exist") != std::string::npos);
+    BOOST_CHECK(!beyondReceipt);
+
+    // Scenario A (mid-chain MPT activation) is refused: the trie there is not the complete
+    // state, so a historical call could silently mis-read dormant accounts.
+    ledger::Features scenarioA;
+    scenarioA.set(ledger::Features::Flag::feature_mpt_state_root);
+    scenarioA.setActivationBlock(ledger::Features::Flag::feature_mpt_state_root, 0);
+    g_hcFeatures = scenarioA;
+    auto [scenarioAError, scenarioAReceipt] = callAt(1);
+    BOOST_REQUIRE(scenarioAError);
+    BOOST_CHECK(
+        scenarioAError->errorMessage().find("feature_l2_ethereum_compat") != std::string::npos);
+    BOOST_CHECK(!scenarioAReceipt);
+
+    // Back to scenario B: the empty-root genesis header serves an EMPTY state — the slot
+    // reads as zero, which is Ethereum's answer for "before anything was written".
+    ledger::Features scenarioB;
+    scenarioB.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+    g_hcFeatures = scenarioB;
+    auto [genesisError, genesisReceipt] = callAt(0);
+    BOOST_REQUIRE_MESSAGE(
+        !genesisError, (genesisError ? genesisError->errorMessage() : std::string{}));
+    BOOST_CHECK(outputOf(genesisReceipt) == toBytes(hcEvmcValue(0x00)));
+
+    // A header that records NO state root at all (h256{} zero) is refused loudly rather
+    // than misread as a real root.
+    writeHeaderToBackend(makeHeader(0, h256{}));
+    auto [zeroRootError, zeroRootReceipt] = callAt(0);
+    BOOST_REQUIRE(zeroRootError);
+    BOOST_CHECK(zeroRootError->errorMessage().find("no MPT state root") != std::string::npos);
+    BOOST_CHECK(!zeroRootReceipt);
+}
+
+// getExecutable must not serve a historical call from the global address-keyed executable
+// cache, nor fill that cache from one: the cache is shared with latest-state execution and
+// code at an address can differ between the pinned block and today.
+BOOST_AUTO_TEST_CASE(executableCacheBypassForHistoricalStorage)
+{
+    auto headers = runCanonicalChain();
+
+    // A unique address so this test owns its global-cache entry.
+    evmc_address cachedAddress{};
+    cachedAddress.bytes[0] = 0xCE;
+    cachedAddress.bytes[19] = 0x01;
+
+    // Poison the global cache with an executable for that address.
+    bytes fakeCode{0x60, 0x00, 0x60, 0x00, 0xF3};  // trivial EVM bytes
+    auto poisoned =
+        std::make_shared<hostcontext::Executable>(bytesConstRef{fakeCode.data(), fakeCode.size()});
+    task::syncWait(storage2::writeOne(hostcontext::getCacheExecutables(), cachedAddress, poisoned));
+
+    auto latestView = multiLayerStorage.fork();
+    HCHistoricalBackend historicalBackend(latestView, headers[0]->stateRoot());
+    HCHistoricalView historicalView(std::addressof(historicalBackend));
+    historicalView.newMutable();
+    Rollbackable<HCHistoricalView> rollbackable(historicalView);
+
+    // Historical storage: the poisoned cache entry must NOT be served. The address has no
+    // leaf at the block-1 root, so its code resolves to nothing — "no executable".
+    auto historicalResult = task::syncWait(hostcontext::getExecutable(
+        rollbackable, cachedAddress, EVMC_CANCUN, /*binaryAddress*/ false));
+    BOOST_CHECK(!historicalResult);
+
+    // Positive control: a latest-state storage IS served from the cache for the same
+    // address, proving the bypass above is what made the difference.
+    auto plainView = multiLayerStorage.fork();
+    plainView.newMutable();
+    Rollbackable<decltype(plainView)> plainRollbackable(plainView);
+    auto latestResult = task::syncWait(hostcontext::getExecutable(
+        plainRollbackable, cachedAddress, EVMC_CANCUN, /*binaryAddress*/ false));
+    BOOST_CHECK_EQUAL(latestResult.get(), poisoned.get());
+
+    // Clean up the global cache so no other test sees this entry.
+    task::syncWait(storage2::removeOne(hostcontext::getCacheExecutables(), cachedAddress));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace


### PR DESCRIPTION
## Failing scenario

`eth_call` / `eth_estimateGas` with a historical blockTag silently execute against the **latest** state: `EthEndpoint::call` parses the tag but only logs it, and `SchedulerInterface::call` has no block-height parameter. A caller asking "what would this view function have returned at block N" gets an answer computed from today's state, with no error. With MPTAccount (#5324) merged, the chain now retains everything needed to answer correctly on L2 chains — this PR wires it through.

## Fix

- `HistoricalCallStorage.h` (new): `HistoricalStateBackend<LatestView>` — the read-through layer #5324's PR body prescribed for this follow-up. Account-table rows (nonce/balance/codeHash/32-byte slots) that miss are resolved through `MPTAccount`'s per-read rooted lookups against block N's state root and re-encoded in `EVMAccount`'s flat representation; `SYS_TABLES` presence mirrors leaf existence; everything else passes through to the latest view (`s_code_binary` and `s_number_2_hash` are content-addressed / append-only, so pass-through is exact).
- `BaselineScheduler.h`: the existing `call()` body moves verbatim into `coCallLatest()`; new `callAtBlock(tx, number, cb)` refuses heights above the tip (`InvalidBlockNumber`, matching geth's "header not found" instead of the old silent-latest), routes `number == tip` to the latest path, and otherwise executes over `View<MutableStorage, void, HistoricalStateBackend>` — so a call's own writes are visible to its subsequent reads (SSTORE then SLOAD returns the new value), nothing persists, and nothing leaks across calls. The parent root comes from block N's header via the latest view; a zero state root or a scenario-A chain is refused outright (a scenario-A trie omits dormant accounts, so historical reads there would be silently wrong — per MPTAccount's documented caller obligation).
- `SchedulerInterface.h`: `callAtBlock` is a new virtual with a default implementation delegating to `call()` — tars/mock/DMC implementations compile unchanged and keep their current behavior. A same-name `call` overload is not possible: `-Woverloaded-virtual` + `-Werror` would break every subclass overriding only the one-argument `call`.
- `HostContext.h`: the global per-address executable cache is bypassed in both directions for historical storage (a hit would run today's code at block N; a fill would poison latest execution) via a `consteval` storage trait.
- `EthEndpoint.cpp`: historical tags route to `callAtBlock`; the latest family (`latest`/`pending`/`safe`/`finalized`/empty) is byte-for-byte unaffected. `eth_estimateGas` reuses the same path.

## Behavior changes and v1 boundaries

- blockTag above the tip now returns an error instead of silently executing latest (aligned with geth).
- Real historical execution is served by AIR/BaselineScheduler; MAX/tars and the legacy DMC scheduler fall back to the default implementation (latest, the pre-PR behavior).
- `/sys/` rows and system-config reads pass through to latest: sys-config stores only the newest `(value, enableNumber)` pair, so a config changed after block N is not reconstructible without replay. Documented in the header.
- A full-chain e2e test rides on #5374's `FullChainFixture` and follows once that PR lands.

## Tests

`TestEthCallHistory.cpp` (6 cases + 6 static_asserts): rooted account-row resolution; read-your-writes inside a historical call on the real stack; per-height answers across three block heights; refusal paths (above-tip, zero root, scenario A; genesis empty-trie reads correctly); executable-cache bypass proven by pre-poisoning the cache (with a positive control). `Web3EthCallBlockTagTest.cpp` (4 cases): tag routing, `number == tip` collapsing to latest, and a `call()`-only scheduler still served via the default delegation. Negative controls: making account rows pass through to latest trips 8 assertions; forcing the global cache trips the bypass test; reverting the endpoint routing trips the routing tests. Full `test-transaction-scheduler` and `test-bcos-rpc` suites pass; the `fisco-bcos` production target compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
