### PR TITLE
test(mpt): acceptance layer — latency benches, synthetic replay, gate runner, release docs (M10)

### DIFF
--- a/docs/mpt/mpt-deploy-runbook.md
+++ b/docs/mpt/mpt-deploy-runbook.md
@@ -1,0 +1,110 @@
+# Runbook: deploying and operating MPT state storage
+
+Operational entry point for both activation scenarios of the MPT lazy-build
+state root, plus the fault-triage section. Feature background and limitations:
+`docs/mpt/mpt-lazy-build-release-notes.md`.
+
+## Scenario A — hot upgrade of an existing chain
+
+Follow `docs/mpt/mpt-migration-scenario-a.md` (pre-flight checklist, the
+one-way-flag warning, activation, rollback-by-backup). Deployment summary:
+
+1. Roll the new binary across all nodes (rolling restart; the flag is off, so
+   behavior is unchanged).
+2. `setSystemConfigByKey feature_mpt_state_root 1` through governance.
+3. Watch the first two post-activation blocks: block `N` (activation) commits
+   XOR, block `N+1` commits the first MPT root. All nodes must stay in
+   consensus — the pre-flight checklist's binary-version item exists precisely
+   because a node still on an old binary diverges at this point.
+4. Verify with any account written after activation:
+
+   ```bash
+   curl -s http://127.0.0.1:8545 -X POST -H 'Content-Type: application/json' -d \
+     '{"jsonrpc":"2.0","id":1,"method":"eth_getProof","params":["0x<touched-address>",[],"latest"]}'
+   ```
+
+   A dormant (never-touched-since-activation) account instead returns error
+   `-32004` "Account not in trie (dormant in scenario A)" — expected, not a
+   fault.
+
+## Scenario B — new L2 chain from genesis
+
+Node bring-up is the existing L2 runbook:
+`bcos-l2-contracts/docs/runbook-l2-mode.md` (allocs generation, `config.genesis`
+assembly, verification with `cast`, frozen-genesis immutability guards). MPT
+specifics on top of it:
+
+- The genesis header's `stateRoot` is the op-geth-compatible root over the
+  allocs, and the genesis trie nodes are persisted at first init — block 1
+  builds incrementally on them (`Ledger::buildGenesisBlock`,
+  `bcos-ledger/bcos-ledger/Ledger.cpp`).
+- `feature_l2_ethereum_compat` must come from genesis. Writing it mid-chain via
+  governance makes every node refuse to boot at the next restart:
+  "feature_l2_ethereum_compat must be enabled at genesis (activation block 0)"
+  (`validateMPTFlagMatrix`, called from `libinitializer/LedgerInitializer.cpp`).
+- Do not also set `feature_raw_address` — rejected by the same matrix check.
+- All state is in the MPT from block 0: `eth_getProof` has no dormant-account
+  case on an L2 chain. Error `-32004` can still appear with the message "Block
+  stateRoot not in MPT node storage" when the requested block's root cannot be
+  resolved (`EthEndpoint.cpp` distinguishes the two `-32004` causes by
+  message).
+
+## RPC / deployment-shape caveats
+
+- `eth_getProof` needs the MPT node reader wired into the RPC's `NodeService`.
+  Tars/MAX services never wire it (`bcos-rpc/bcos-rpc/groupmgr/NodeService.h`
+  documents the default-unset contract), so under MAX every `eth_getProof`
+  answers `-32603` "MPT not enabled on this node". AIR wiring ships with the
+  reader-injection change; on binaries without it, AIR answers the same
+  `-32603`. Route proof traffic to AIR nodes with the wiring, or treat
+  `-32603` as "this node cannot serve proofs", never as data loss.
+- Disk: `/mpt/` trie-node rows share the state column family and grow without
+  pruning in v1. Budget for monotonic growth proportional to write activity;
+  there is nothing to compact away yet.
+
+## Fault triage: "missing trie node"
+
+Symptom: a node aborts block execution or proof generation with
+`MPTInvariantViolation` — "Trie: missing node hash; storage lacks a referenced
+node" (`bcos-ledger/bcos-ledger/mpt/Trie.h`).
+
+What it is NOT: a crash artifact. A block's header, flat state, trie nodes and
+indices go into **one** RocksDB WriteBatch behind a single `Write()` with WAL —
+all-or-nothing. A kill -9 or power cut cannot leave the trie referencing nodes
+that were never written; the WAL either replays the whole block or none of it.
+There is deliberately no half-commit scanner tool in this release: the crash
+window it would scan for no longer exists, and the guarantee is instead pinned
+in CI by unit tripwires
+(`TestRocksDBStorage2/mergeAppliesSourcesInArgumentOrder`,
+`TestMPTSchedulerWiring/commitAtomicityAndObserverTiming`,
+`TestExecuteStateRootRegression/executeWritesStayInViewUntilCommit` — the
+`§11 #14` row of `tools/mpt_acceptance_gate.sh`).
+
+So a missing node on a live chain means real data loss or a real bug, and the
+node is doing the right thing by failing loudly instead of silently committing
+a wrong root (there is no XOR fallback on the MPT path — pinned by
+`TestMPTSchedulerWiring/buildFailureNoXorFallback`). Triage in order:
+
+1. **Manual interference**: was the datadir copied while the node ran, restored
+   from mismatched partial backups, or edited with RocksDB tools? Restore a
+   consistent full backup or resync the node from peers.
+2. **Disk-level corruption**: check RocksDB's own error log and kernel I/O
+   errors. Same remedy: restore or resync — the chain's other nodes hold the
+   data.
+3. **Neither**: treat as a product bug. Capture the exception text (it carries
+   the missing hash), the block height, and the `/mpt/` row count, and file an
+   issue. Do not attempt to hand-repair the trie.
+
+## Release verification
+
+Before promoting a build that includes these features:
+
+```bash
+# Configure the build dir with -DMPT_ACCEPTANCE_GATES=ON first — the armed full-scale
+# gates are not registered in a default configure (deliberate: keeps per-PR CI un-gated).
+cd build && ctest -L acceptance --output-on-failure   # fine-grained: replay + latency gates
+tools/mpt_acceptance_gate.sh build --strict           # spec §11 table; exit 0 required
+```
+
+`--strict` also fails on spec items whose implementing PR is still in flight —
+drop it only for intermediate progress checks.

--- a/docs/mpt/mpt-lazy-build-release-notes.md
+++ b/docs/mpt/mpt-lazy-build-release-notes.md
@@ -1,0 +1,109 @@
+# MPT Lazy-Build State Storage — v1 Release Notes
+
+FISCO-BCOS can now commit an Ethereum-style Merkle Patricia Trie root as
+`BlockHeader::stateRoot`, feature-flagged and off by default. Two activation
+scenarios exist, selected by two flags in `bcos-framework/bcos-framework/ledger/Features.h`:
+
+| Flag | Scenario | Activation |
+|------|----------|------------|
+| `feature_mpt_state_root` | A — existing chain hot upgrade | mid-chain, via a governance `SystemConfig` write |
+| `feature_l2_ethereum_compat` | B — new L2 chain | genesis only (enforced, see below) |
+
+`shouldBuildMPT` (`transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h`)
+checks the L2 flag first — an L2 chain builds the MPT from block 0 regardless of
+scenario-A activation state. Neither flag set means the legacy XOR state root,
+byte-for-byte unchanged.
+
+## Scenario A: existing chain hot upgrade
+
+- Activation is a plain `SystemConfig` feature row `{value="1", enableNumber=N}`.
+  Block `N` itself still commits the XOR root (strictly-greater transition rule,
+  `shouldBuildMPT`); block `N+1` commits the first MPT root, starting from the
+  **empty trie**.
+- **Lazy build**: an account enters the MPT only when first written after
+  activation. Its first touch commits exactly the rows written in that block —
+  account nonce/balance are read once from flat state, but storage slots written
+  before activation stay outside the storage trie. There is **no bootstrap scan
+  and no preheat tool**: first-touch cost is O(touched rows), independent of how
+  many flat rows the account owns (measured: a 100k-flat-slot account's first
+  touch costs the same sub-millisecond as a fresh account's —
+  `transaction-scheduler/tests/MPTFirstTouchLatencyBench.cpp`).
+- Consequence: the MPT commits to **touched state only**. Dormant accounts and
+  the cold slots of touched accounts are never provable from the root; flat KV
+  remains the source of truth for values.
+
+## Scenario B: new L2 chain
+
+- `feature_l2_ethereum_compat=1` in `config.genesis` `[features]`, plus
+  non-empty `[alloc.N]` / `[alloc.N.storage]` sections (both directions enforced
+  by `NodeConfig::validateL2Invariants`, `bcos-tool/bcos-tool/NodeConfig.cpp`).
+- The genesis header's `stateRoot` is the op-geth-compatible MPT root over the
+  allocs, and every genesis trie node is persisted so block 1 builds
+  incrementally on top of it (`bcos-ledger/bcos-ledger/Ledger.cpp`,
+  `buildGenesisBlock`).
+- 18 FISCO-private precompiles (`0x1000`… range) are hidden in this mode
+  (`bcos-executor/src/precompiled/L2DisabledSet.h`).
+- Genesis-only rule: enabling the L2 flag with a non-zero activation block
+  aborts node boot (`validateMPTFlagMatrix`,
+  `BaselineSchedulerMPTHelpers.h` — "must be enabled at genesis").
+- Node bring-up, predeploy generation and the frozen-genesis guards are covered
+  by `bcos-l2-contracts/docs/runbook-l2-mode.md`.
+
+## eth_getProof
+
+EIP-1186 proofs over the committed MPT (`bcos-rpc/.../EthEndpoint.cpp`):
+
+- `-32004` — the request cannot be proven: dormant account in scenario A
+  ("Account not in trie (dormant in scenario A)"), or the requested block's
+  state root is not in node storage ("Block stateRoot not in MPT node
+  storage").
+- `-32603` — node configuration: the MPT node reader is not wired on this node
+  ("MPT not enabled on this node"). Tars/MAX services never wire the reader, so
+  MAX deployments always answer `-32603`; the AIR wiring ships with the
+  reader-injection change (in flight at this release).
+- A storage slot absent from the trie returns value `0x0` with an exclusion-style
+  proof. Distinguishing "cold slot with a live flat-KV value" (`SlotNotInMPT`)
+  is in flight and not in this release.
+
+## Durability
+
+A block's header, flat state, trie nodes and indices are written in **one**
+RocksDB WriteBatch — a crash cannot leave the trie half-committed, which is why
+this release ships no half-commit scanner (see the triage section of
+`docs/mpt/mpt-deploy-runbook.md`). A trie node missing at read time is treated
+as corruption: `MPTInvariantViolation` ("Trie: missing node hash",
+`bcos-ledger/bcos-ledger/mpt/Trie.h`), fail-loud, no silent XOR fallback.
+
+## Known limitations (v1)
+
+1. **No trie pruning**: obsoleted nodes are tracked per commit but not deleted;
+   `/mpt/` rows grow monotonically. Pruning hooks (`CommitObserver`) are
+   reserved.
+2. **No reorg support** in scenario B; finalized-only sync is assumed.
+3. **The MPT never converges to the full state** in scenario A (by design since
+   the 2026-07-09 slot-level revision): cold slots stay unproven forever unless
+   rewritten.
+4. **Cold-slot proof semantics (`SlotNotInMPT`) and historical `eth_call`** are
+   in flight, not in this release.
+5. `feature_raw_address` is mutually exclusive with both MPT flags
+   (`validateMPTFlagMatrix`).
+
+## Release verification
+
+Two entry points, both required:
+
+```bash
+# The build dir must be configured with -DMPT_ACCEPTANCE_GATES=ON (off by default so the
+# armed full-scale gates never run in per-PR CI).
+cd build && ctest -L acceptance --output-on-failure   # full-scale latency gates + replay
+tools/mpt_acceptance_gate.sh build --strict           # spec §11 cross-reference, exit 0/1
+```
+
+The latency gates: subsequent-touch p99 < 200 ms at the 1000-account-per-block
+scale, and big-account first-touch within the subsequent-touch magnitude
+(`transaction-scheduler/tests/MPTSubsequentTouchP99Gate.cpp`).
+
+## Upgrade paths
+
+- Scenario A migration: `docs/mpt/mpt-migration-scenario-a.md`
+- Deployment (both scenarios): `docs/mpt/mpt-deploy-runbook.md`

--- a/docs/mpt/mpt-migration-scenario-a.md
+++ b/docs/mpt/mpt-migration-scenario-a.md
@@ -1,0 +1,82 @@
+# Scenario A — Enabling the MPT State Root on an Existing Chain
+
+How to switch a running FISCO-BCOS chain's `BlockHeader::stateRoot` from the
+legacy XOR fold to the Ethereum MPT root, and how to roll back. No data
+migration happens at any point: flat KV stays the source of truth, and the trie
+absorbs accounts lazily as they are written after activation.
+
+## Smallest failing scenario this prevents
+
+You enable `feature_mpt_state_root` on 3 of 4 consensus nodes. At the first
+post-activation block the upgraded nodes commit an MPT root, the fourth commits
+the XOR root, consensus on the block header fails and the chain halts. The
+pre-flight checklist below exists to make the activation a single, coordinated,
+block-numbered event.
+
+## Pre-flight checklist
+
+- [ ] Every consensus node runs a binary that knows the flag (the flag is
+      `feature_mpt_state_root` in
+      `bcos-framework/bcos-framework/ledger/Features.h`; a pre-flag binary
+      rejects the governance write as an unknown system key —
+      `SystemConfigPrecompiled` validates keys against `Features::featureKeys()`).
+- [ ] `feature_raw_address` is NOT enabled — the combination aborts node boot
+      (`validateMPTFlagMatrix`,
+      `transaction-scheduler/bcos-transaction-scheduler/BaselineSchedulerMPTHelpers.h`).
+- [ ] Do NOT also enable `feature_l2_ethereum_compat`: it is genesis-only and a
+      mid-chain enable aborts boot with "must be enabled at genesis (activation
+      block 0)" (same file).
+- [ ] `datadir` backups taken on every node — this is the ONLY rollback path
+      (see Rollback below: feature flags cannot be disabled on-chain).
+- [ ] Expect additional disk growth from `/mpt/` trie-node rows — unpruned in
+      v1, they grow monotonically with write activity.
+
+## Activation
+
+1. Through governance, write the feature system config — e.g. from the console:
+
+   ```
+   [group0]: /> setSystemConfigByKey feature_mpt_state_root 1
+   ```
+
+   This creates the `SystemConfig` row `{value="1", enableNumber=N}` the
+   scheduler reads back (`ledger::readFromStorage` turns it into
+   `set(flag)` + `activationBlockOf(flag) == N` for every block ≥ N).
+2. Block `N` still commits the XOR root — the strictly-greater rule in
+   `shouldBuildMPT` keeps the activation block itself as the transition
+   boundary.
+3. Block `N+1` commits the first MPT root, built from the **empty trie**: only
+   accounts written at `N+1` are in it. Every later block extends the trie
+   incrementally from the parent header's root.
+
+## What changes for applications
+
+- `stateRoot` in block headers changes meaning at `N+1`. Anything that compared
+  it across the boundary must treat `N` as an epoch break.
+- `eth_getProof` works for state written after activation. Dormant accounts
+  return JSON-RPC error `-32004` ("Account not in trie (dormant in scenario
+  A)") — a deliberate, explicit answer, not an empty proof
+  (`bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp`). Cold slots of
+  touched accounts are not individually provable in v1 (see release notes,
+  known limitation 3-4).
+- No latency cliff is expected: first touch of an account costs O(rows written
+  this block), regardless of its flat-KV footprint. The acceptance bench pins
+  this (`ctest -L acceptance`, `MPTFirstTouchLatencyBench` /
+  `MPTSubsequentTouchP99Gate`).
+
+## Rollback
+
+**There is no on-chain rollback.** Feature flags are one-way:
+`SystemConfigPrecompiled::validate` rejects any feature value other than `"1"`
+("The value for &lt;key&gt; must be 1.",
+`bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp`), so
+`feature_mpt_state_root` cannot be written back to 0 through governance.
+
+The only way back is off-protocol: stop all nodes and restore every node's
+`datadir` from the pre-activation backup (rewinding the chain to a height
+before block `N`). This discards all blocks committed since the backup — treat
+activation as irreversible in planning, and take the pre-flight backups
+seriously.
+
+Committed `/mpt/` rows never need cleanup in either case: they are inert data
+outside the MPT read path's own epoch.

--- a/tools/mpt_acceptance_gate.sh
+++ b/tools/mpt_acceptance_gate.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# MPT Lazy-Build acceptance gate runner (M10.5).
+#
+# Maps every SURVIVING item of the MPT snapshot-storage design spec's §11 acceptance list
+# (internal design doc "mpt-snapshot-storage-design3", 2026-04-24; the preheat items were
+# replaced by its 2026-07-09 slot-level revision, the half-commit item retired 2026-07-30
+# in favor of single-WriteBatch UT tripwires) to a concrete executable check, runs them
+# one by one, prints a spec-vs-check table and exits 0/1.
+#
+# The build dir must be configured with -DMPT_ACCEPTANCE_GATES=ON — otherwise the armed
+# full-scale latency gates are not registered and their row fails via --no-tests=error.
+#
+# Two release-readiness entry points (both required before a release):
+#   1. ctest -L acceptance --output-on-failure     # full-scale latency gates, fine-grained
+#   2. tools/mpt_acceptance_gate.sh <build-dir>    # this script: §11 cross-reference + exit code
+#
+# The script is a thin ctest/git-grep orchestrator on purpose: a compiled runner would
+# duplicate ctest's test selection and add a build target for zero extra checking power.
+#
+# Usage: tools/mpt_acceptance_gate.sh [build-dir]   (default: ./build)
+#   --strict     count PENDING items (spec items whose implementing PR is still in flight)
+#                as failures — use for the actual release decision.
+set -u
+
+BUILD_DIR="build"
+STRICT=0
+for arg in "$@"; do
+    case "$arg" in
+        --strict) STRICT=1 ;;
+        *) BUILD_DIR="$arg" ;;
+    esac
+done
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 2
+if [ ! -f "$BUILD_DIR/CTestTestfile.cmake" ]; then
+    echo "error: '$BUILD_DIR' is not a CTest build directory (run from repo root or pass the build dir)" >&2
+    exit 2
+fi
+
+LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mpt-acceptance-gate.XXXXXX")"
+PASS=0; FAIL=0; PENDING=0; SKIP=0
+declare -a TABLE
+
+# run_ctest <spec-ref> <description> <ctest-regex>
+# --no-tests=error turns "0 tests matched" into FAIL — a renamed suite can never
+# silently turn its §11 row green.
+run_ctest() {
+    local ref="$1" desc="$2" regex="$3"
+    local log="$LOG_DIR/$(echo "$ref" | tr ' #/' '__-').log"
+    echo "--- [$ref] ctest -R '$regex'"
+    if ctest --test-dir "$BUILD_DIR" -R "$regex" --no-tests=error --output-on-failure \
+        >"$log" 2>&1; then
+        PASS=$((PASS + 1)); TABLE+=("$ref|GATE|$desc|PASS")
+    else
+        FAIL=$((FAIL + 1)); TABLE+=("$ref|GATE|$desc|FAIL")
+        echo "    FAILED — log: $log"; tail -20 "$log" | sed 's/^/    /'
+    fi
+}
+
+# mark <spec-ref> <mode: PENDING|SKIP> <description> <note>
+mark() {
+    local ref="$1" mode="$2" desc="$3"
+    case "$mode" in
+        PENDING) PENDING=$((PENDING + 1)) ;;
+        SKIP) SKIP=$((SKIP + 1)) ;;
+    esac
+    TABLE+=("$ref|$mode|$desc|$mode")
+}
+
+# ---- §11 items, in spec order --------------------------------------------------------------
+
+# #1 scenario B 100-block replay. Degraded form: synthetic deterministic 100-block replay
+# with per-block from-scratch oracle (MPTSyntheticReplayTest.cpp documents why real mainnet
+# blocks are not replayable offline). Real-vector fidelity: op-geth-anchored genesis tests.
+run_ctest "§11 #1" "scenario B 100-block replay, per-block root == from-scratch oracle (synthetic)" \
+    "MPTSyntheticReplaySuite"
+
+# #2 scenario B eth_getProof independently verified.
+run_ctest "§11 #2" "scenario B eth_getProof verifies against independent verifier" \
+    "EthGetProofIntegrationSuite/ScenarioB_AllAllocAccountsProve"
+
+# #3 scenario A activation: stateRoot vs independent oracle, first-touch transition.
+# (Single-process oracle equivalence; a true multi-node consistency run is a deployment test.)
+run_ctest "§11 #3" "scenario A activation transition + oracle-equal stateRoot" \
+    "BaselineSchedulerMPTL1UpgradeSuite"
+
+# #4 dormant account -> AccountNotInMPT (-32004). Two independent rows on purpose: an
+# alternation regex would stay green if one of the two tests were renamed away.
+run_ctest "§11 #4a" "eth_getProof(dormant) -32004 — integration (real ledger + verifier)" \
+    "EthGetProofIntegrationSuite/ScenarioA_ActiveProofVerifies_DormantReturns32004"
+run_ctest "§11 #4b" "eth_getProof(dormant) -32004 — RPC endpoint unit" \
+    "EthGetProofRpcTest/DormantAccountReturns32004"
+
+# #5 cold slot of a touched account -> SlotNotInMPT with flat-KV value.
+mark "§11 #5" "PENDING" "eth_getProof(touched account, cold slot) -> SlotNotInMPT (in-flight branch feat/mpt-proof-slot-not-in-mpt; current code returns a 0x0 exclusion-style value)"
+
+# #6 first-touch storageRoot commits only the touched slots.
+run_ctest "§11 #6" "first-touch storageRoot covers ONLY slots written this block" \
+    "BaselineSchedulerMPTL1UpgradeSuite/DormantAccountFirstTouchCommitsTouchedRowsOnly"
+
+# #7 + #8 latency gates: big-account first-touch within subsequent-touch magnitude, and
+# subsequent-touch p99 < 200ms at the 1000-account scale. One armed acceptance run covers both
+# (MPTSubsequentTouchP99Gate.cpp).
+run_ctest "§11 #7+#8" "latency gates: subsequent-touch p99 < 200ms; big first-touch <= magnitude" \
+    "acceptance/MPTSubsequentTouchP99Gate"
+
+# #9 legacy chain (flags off) unaffected. Representative tripwires here; the FULL suite runs
+# in every per-PR CI (plain ctest), which is the real coverage for this item.
+run_ctest "§11 #9" "legacy XOR chain unaffected (representative; full suite = per-PR CI)" \
+    "FullChainFixtureSmokeSuite/XorChainOneBlockRoundTrip|TestExecuteStateRootRegression"
+
+# #10 commitTrie purity: 1000 repeats byte-identical.
+run_ctest "§11 #10" "commitTrie 1000x repeat byte-identical" "HashBuilderPuritySuite"
+
+# #11 zero AccountDelta materialization ("git grep AccountDelta" — comment mentions that
+# describe the DELETED design are tolerated; any code identifier is a failure).
+echo "--- [§11 #11] git grep AccountDelta (non-comment hits)"
+HITS="$(git grep -n "AccountDelta" -- '*.cpp' '*.h' | grep -vE ':[0-9]+: *(//|\*|/\*)' || true)"
+if [ -z "$HITS" ]; then
+    PASS=$((PASS + 1)); TABLE+=("§11 #11|GATE|no AccountDelta materialization in code|PASS")
+else
+    FAIL=$((FAIL + 1)); TABLE+=("§11 #11|GATE|no AccountDelta materialization in code|FAIL")
+    echo "$HITS" | sed 's/^/    /'
+fi
+
+# #12 sizeof(TrieNode) <= 64 — compile-time static_assert; verify the assert exists (it fails
+# the build itself if violated, so presence == enforcement).
+echo "--- [§11 #12] static_assert(sizeof(TrieNode) <= 64) present"
+if git grep -q "static_assert(sizeof(TrieNode) <= 64" -- '*.cpp' '*.h'; then
+    PASS=$((PASS + 1)); TABLE+=("§11 #12|GATE|static_assert(sizeof(TrieNode) <= 64) enforced at build|PASS")
+else
+    FAIL=$((FAIL + 1)); TABLE+=("§11 #12|GATE|static_assert(sizeof(TrieNode) <= 64) enforced at build|FAIL")
+fi
+
+# #13 scenario B historical eth_call vs MPTReadView oracle.
+mark "§11 #13" "PENDING" "eth_call with historical block tag (in-flight branch feat/mpt-eth-call-blocktag; MPTAccount M13.1 is merged, the RPC->scheduler path is not)"
+
+# #14 half-commit detection — RETIRED 2026-07-30: the single-WriteBatch commit made the
+# crash window structurally impossible (see the durability section of
+# docs/mpt/mpt-deploy-runbook.md). The surviving enforcement is the tripwire suite below.
+run_ctest "§11 #14" "RETIRED half-commit item -> single-WriteBatch tripwires" \
+    "TestRocksDBStorage2/mergeAppliesSourcesInArgumentOrder|TestMPTSchedulerWiring/commitAtomicityAndObserverTiming|TestExecuteStateRootRegression/executeWritesStayInViewUntilCommit"
+
+# #15 PR file/line constraints — enforced by the pre-commit hook on every PR, not runnable here.
+mark "§11 #15" "SKIP" "PR file/line constraints (pre-commit hook enforces per PR)"
+
+# ---- report --------------------------------------------------------------------------------
+LINE="$(printf '%.0s=' {1..118})"
+echo
+echo "$LINE"
+printf '%-10s %-8s %-85s %s\n' "spec" "mode" "check" "result"
+printf '%.0s-' {1..118}; echo
+for row in "${TABLE[@]}"; do
+    IFS='|' read -r ref mode desc result <<<"$row"
+    printf '%-10s %-8s %-85.85s %s\n' "$ref" "$mode" "$desc" "$result"
+done
+echo "$LINE"
+echo "Acceptance summary: $PASS passed, $FAIL failed, $PENDING pending, $SKIP skipped (manual)"
+echo "Logs: $LOG_DIR"
+
+EXIT=0
+if [ "$FAIL" -gt 0 ]; then
+    echo "*** GATE FAILED — DO NOT RELEASE ***"
+    EXIT=1
+elif [ "$PENDING" -gt 0 ]; then
+    if [ "$STRICT" -eq 1 ]; then
+        echo "*** GATE INCOMPLETE (--strict): $PENDING spec item(s) still pending — DO NOT RELEASE ***"
+        EXIT=1
+    else
+        echo "*** GATES PASSED, but $PENDING spec item(s) pending in-flight PRs (use --strict for the release decision) ***"
+    fi
+else
+    echo "*** GATE PASSED — release readiness confirmed ***"
+fi
+exit $EXIT

--- a/tools/mpt_acceptance_gate.sh
+++ b/tools/mpt_acceptance_gate.sh
@@ -91,8 +91,12 @@ run_ctest "§11 #4a" "eth_getProof(dormant) -32004 — integration (real ledger 
 run_ctest "§11 #4b" "eth_getProof(dormant) -32004 — RPC endpoint unit" \
     "EthGetProofRpcTest/DormantAccountReturns32004"
 
-# #5 cold slot of a touched account -> SlotNotInMPT with flat-KV value.
-mark "§11 #5" "PENDING" "eth_getProof(touched account, cold slot) -> SlotNotInMPT (in-flight branch feat/mpt-proof-slot-not-in-mpt; current code returns a 0x0 exclusion-style value)"
+# #5 cold slot of a touched account -> SlotNotInMPT with flat-KV value (#5332, merged).
+# Two independent rows on purpose, same rationale as #4a/#4b.
+run_ctest "§11 #5a" "eth_getProof(touched account, cold slot) SlotNotInMPT — generator/verifier" \
+    "ProofSlotNotInMPTSuite"
+run_ctest "§11 #5b" "eth_getProof(touched account, cold slot) SlotNotInMPT — RPC endpoint" \
+    "EthGetProofSlotNotInMPTTest"
 
 # #6 first-touch storageRoot commits only the touched slots.
 run_ctest "§11 #6" "first-touch storageRoot covers ONLY slots written this block" \

--- a/transaction-scheduler/tests/CMakeLists.txt
+++ b/transaction-scheduler/tests/CMakeLists.txt
@@ -20,6 +20,27 @@ set_source_files_properties("main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 # using-directives other unity-merged TUs carry; compile its users standalone.
 set_source_files_properties(
     "FullChainFixtureSmokeTest.cpp" "BaselineSchedulerMPTL1UpgradeTest.cpp"
-    "BaselineSchedulerMPTGenesisTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+    "BaselineSchedulerMPTGenesisTest.cpp" "MPTFirstTouchLatencyBench.cpp"
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(test-transaction-scheduler PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" "test-transaction-scheduler" "" "")
+
+# Acceptance entries (ctest -L acceptance): the same Boost suites at FULL scale with
+# MPT_ACCEPTANCE=1 in the environment. The per-case registrations config_test_cases made
+# above stay default-runnable REDUCED-scale measurement passes (no env var -> no hard
+# latency assertion), so the per-PR CI ctest run is never gated on wall-clock numbers.
+#
+# OFF by default ON PURPOSE: a plain `ctest` run executes every registered test regardless
+# of labels, so registering these unconditionally would put the armed full-scale gates into
+# every per-PR CI matrix job (including slow shared runners) — exactly the flaky-red this
+# split exists to prevent. Release-verification build dirs configure with
+# -DMPT_ACCEPTANCE_GATES=ON; tools/mpt_acceptance_gate.sh fails loudly (ctest
+# --no-tests=error) when pointed at a build dir configured without it.
+option(MPT_ACCEPTANCE_GATES
+    "Register the full-scale MPT acceptance latency gates as ctest entries" OFF)
+if(MPT_ACCEPTANCE_GATES)
+    add_test(NAME acceptance/MPTFirstTouchLatencyBench WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND test-transaction-scheduler -t MPTFirstTouchLatencyBenchSuite)
+    set_tests_properties(acceptance/MPTFirstTouchLatencyBench PROPERTIES
+        LABELS "acceptance;benchmark" ENVIRONMENT "MPT_ACCEPTANCE=1" TIMEOUT 3600)
+endif()

--- a/transaction-scheduler/tests/CMakeLists.txt
+++ b/transaction-scheduler/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set_source_files_properties("main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties(
     "FullChainFixtureSmokeTest.cpp" "BaselineSchedulerMPTL1UpgradeTest.cpp"
     "BaselineSchedulerMPTGenesisTest.cpp" "MPTFirstTouchLatencyBench.cpp"
+    "MPTSubsequentTouchP99Gate.cpp"
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(test-transaction-scheduler PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" "test-transaction-scheduler" "" "")
@@ -43,4 +44,8 @@ if(MPT_ACCEPTANCE_GATES)
         COMMAND test-transaction-scheduler -t MPTFirstTouchLatencyBenchSuite)
     set_tests_properties(acceptance/MPTFirstTouchLatencyBench PROPERTIES
         LABELS "acceptance;benchmark" ENVIRONMENT "MPT_ACCEPTANCE=1" TIMEOUT 3600)
+    add_test(NAME acceptance/MPTSubsequentTouchP99Gate WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        COMMAND test-transaction-scheduler -t MPTSubsequentTouchP99GateSuite)
+    set_tests_properties(acceptance/MPTSubsequentTouchP99Gate PROPERTIES
+        LABELS "acceptance;gate" ENVIRONMENT "MPT_ACCEPTANCE=1" TIMEOUT 3600)
 endif()

--- a/transaction-scheduler/tests/CMakeLists.txt
+++ b/transaction-scheduler/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ set_source_files_properties("main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_source_files_properties(
     "FullChainFixtureSmokeTest.cpp" "BaselineSchedulerMPTL1UpgradeTest.cpp"
     "BaselineSchedulerMPTGenesisTest.cpp" "MPTFirstTouchLatencyBench.cpp"
-    "MPTSubsequentTouchP99Gate.cpp"
+    "MPTSubsequentTouchP99Gate.cpp" "MPTSyntheticReplayTest.cpp"
     PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(test-transaction-scheduler PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" "test-transaction-scheduler" "" "")
@@ -48,4 +48,12 @@ if(MPT_ACCEPTANCE_GATES)
         COMMAND test-transaction-scheduler -t MPTSubsequentTouchP99GateSuite)
     set_tests_properties(acceptance/MPTSubsequentTouchP99Gate PROPERTIES
         LABELS "acceptance;gate" ENVIRONMENT "MPT_ACCEPTANCE=1" TIMEOUT 3600)
+endif()
+# The synthetic replay is a fast correctness test (no env scaling): label the per-case
+# registration itself so ctest -L acceptance picks it up alongside the default run.
+# (if(TEST) guard: under FASTCTEST config_test_cases registers per-suite names instead.)
+if(TEST "MPTSyntheticReplaySuite/HundredBlockReplayIncrementalMatchesFromScratchOracle")
+    set_tests_properties(
+        "MPTSyntheticReplaySuite/HundredBlockReplayIncrementalMatchesFromScratchOracle"
+        PROPERTIES LABELS "acceptance" TIMEOUT 1800)
 endif()

--- a/transaction-scheduler/tests/MPTFirstTouchLatencyBench.cpp
+++ b/transaction-scheduler/tests/MPTFirstTouchLatencyBench.cpp
@@ -1,0 +1,216 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MPTFirstTouchLatencyBench.cpp
+ * @brief Scenario-A first-touch latency distribution (M10.2, spec design3 §7.3): a chain
+ *        pre-filled with dormant accounts under the XOR era activates feature_mpt_state_root;
+ *        every measured block then first-touches accounts never seen by the MPT. Since the
+ *        2026-07-09 revision first-touch reads O(touched rows) — no prefix-scan bootstrap —
+ *        so the latency must not grow with the dormant flat footprint; a "big" dormant
+ *        account (BIG_ACCOUNT_SLOTS pre-existing flat slots, one slot written on touch) is
+ *        included to spotlight exactly that.
+ *
+ *        MEASUREMENT ONLY — no latency assertion here (the hard gate lives in
+ *        MPTSubsequentTouchP99Gate.cpp). The p50/p95/p99/max numbers print to stdout for
+ *        reviewer judgment. Env MPT_ACCEPTANCE=1 (set by the ctest "acceptance" label
+ *        registrations in tests/CMakeLists.txt) switches to the full-scale workload; the
+ *        default scale keeps the per-PR CI run short.
+ */
+#include "FullChainFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::test::fullchain;
+
+constexpr std::string_view c_mptFlagName = "feature_mpt_state_root";
+
+bool acceptanceScale()
+{
+    char const* env = std::getenv("MPT_ACCEPTANCE");
+    return env != nullptr && env[0] == '1';
+}
+
+/// Distinct 20-byte addresses beyond makeAddress's 256-value range.
+Address benchAddress(uint32_t index)
+{
+    Address address{};
+    address.data()[0] = static_cast<uint8_t>(index >> 24U);
+    address.data()[1] = static_cast<uint8_t>(index >> 16U);
+    address.data()[2] = static_cast<uint8_t>(index >> 8U);
+    address.data()[3] = static_cast<uint8_t>(index);
+    address.data()[19] = 0xB1;  // disjoint from other suites' address spaces
+    return address;
+}
+
+h256 benchH256(uint64_t value)
+{
+    h256 out{};
+    for (size_t i = 0; i < sizeof(value); ++i)
+    {
+        out.data()[31 - i] = static_cast<uint8_t>(value >> (8U * i));
+    }
+    return out;
+}
+
+struct LatencyStats
+{
+    double p50Ms{};
+    double p95Ms{};
+    double p99Ms{};
+    double maxMs{};
+};
+
+LatencyStats computeStats(std::vector<double> latenciesMs)
+{
+    std::sort(latenciesMs.begin(), latenciesMs.end());
+    auto at = [&](size_t index) { return latenciesMs[std::min(index, latenciesMs.size() - 1)]; };
+    return {.p50Ms = at(latenciesMs.size() / 2),
+        .p95Ms = at(latenciesMs.size() * 95 / 100),
+        .p99Ms = at(latenciesMs.size() * 99 / 100),
+        .maxMs = latenciesMs.back()};
+}
+
+BOOST_AUTO_TEST_SUITE(MPTFirstTouchLatencyBenchSuite)
+
+BOOST_AUTO_TEST_CASE(FirstTouchLatencyDistribution)
+{
+    bool const fullScale = acceptanceScale();
+    // Full scale (ctest -L acceptance): 200 measured blocks x 2 fresh dormant accounts,
+    // 100k-slot big account. Default: sized for the per-PR CI ctest run.
+    size_t const measureBlocks = fullScale ? 200 : 30;
+    size_t const touchesPerBlock = 2;
+    size_t const dormantSlotsEach = fullScale ? 100 : 20;  // flat slots per dormant account
+    size_t const bigAccountSlots = fullScale ? 100'000 : 5'000;
+    size_t const prefillRowsPerBlock = 10'000;
+
+    size_t const dormantAccounts = measureBlocks * touchesPerBlock;
+
+    FullChainFixture fixture{"first_touch_bench"};
+    fixture.buildGenesis(FullChainFixture::baseGenesis());
+
+    // --- Phase 1 (XOR era): pre-fill dormant accounts + the big account -------------------
+    auto const bigAccount = benchAddress(0xFFFFFF00U);
+    std::vector<FCRowOp> pending;
+    pending.reserve(prefillRowsPerBlock + dormantSlotsEach + 2);
+    protocol::BlockNumber nextBlock = 1;
+    auto flushPending = [&] {
+        if (pending.empty())
+        {
+            return;
+        }
+        fixture.planBlock(nextBlock, std::move(pending));
+        fixture.runBlock(nextBlock);
+        ++nextBlock;
+        pending.clear();
+    };
+    for (size_t account = 0; account < dormantAccounts; ++account)
+    {
+        auto address = benchAddress(static_cast<uint32_t>(account));
+        pending.push_back(FullChainFixture::balanceRow(address, "1000"));
+        pending.push_back(FullChainFixture::nonceRow(address, "1"));
+        for (size_t slot = 0; slot < dormantSlotsEach; ++slot)
+        {
+            pending.push_back(
+                FullChainFixture::slotRow(address, benchH256(slot), benchH256(slot + 1)));
+        }
+        if (pending.size() >= prefillRowsPerBlock)
+        {
+            flushPending();
+        }
+    }
+    pending.push_back(FullChainFixture::balanceRow(bigAccount, "7777"));
+    for (size_t slot = 0; slot < bigAccountSlots; ++slot)
+    {
+        pending.push_back(FullChainFixture::slotRow(bigAccount, benchH256(slot), benchH256(1)));
+        if (pending.size() >= prefillRowsPerBlock)
+        {
+            flushPending();
+        }
+    }
+    flushPending();
+
+    // --- Phase 2: activate scenario A after the pre-fill ----------------------------------
+    auto const activationBlock = nextBlock;
+    fixture.enableFeatureFromBlock(c_mptFlagName, activationBlock);
+    fixture.planBlock(activationBlock,
+        {FullChainFixture::balanceRow(benchAddress(0xFFFFFF01U), "1")});  // still XOR
+    fixture.runBlock(activationBlock);
+    BOOST_REQUIRE(
+        fixture.featuresAt(activationBlock).get(ledger::Features::Flag::feature_mpt_state_root));
+    BOOST_REQUIRE_EQUAL(fixture.backendNodeCount(), 0);  // MPT starts strictly after activation
+
+    // --- Phase 3: measured first-touch blocks ---------------------------------------------
+    std::vector<double> latenciesMs;
+    latenciesMs.reserve(measureBlocks);
+    size_t nextAccount = 0;
+    for (size_t measured = 0; measured < measureBlocks; ++measured)
+    {
+        auto blockNumber = activationBlock + 1 + static_cast<protocol::BlockNumber>(measured);
+        std::vector<FCRowOp> rows;
+        rows.reserve(touchesPerBlock * 2);
+        for (size_t touch = 0; touch < touchesPerBlock; ++touch)
+        {
+            auto address = benchAddress(static_cast<uint32_t>(nextAccount++));
+            // First touch: balance update + ONE new slot (the pre-activation slots stay
+            // dormant — no bootstrap since the 2026-07-09 revision).
+            rows.push_back(FullChainFixture::balanceRow(address, "2000"));
+            rows.push_back(FullChainFixture::slotRow(
+                address, benchH256(0xF000 + measured), benchH256(measured + 1)));
+        }
+        fixture.planBlock(blockNumber, std::move(rows));
+        auto start = std::chrono::steady_clock::now();
+        fixture.runBlock(blockNumber);
+        latenciesMs.push_back(
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start)
+                .count());
+    }
+    BOOST_REQUIRE_GT(fixture.backendNodeCount(), 0);  // the MPT path really ran
+
+    // --- Phase 4: the big dormant account's first touch (one slot) ------------------------
+    auto bigBlock = activationBlock + 1 + static_cast<protocol::BlockNumber>(measureBlocks);
+    fixture.planBlock(
+        bigBlock, {FullChainFixture::balanceRow(bigAccount, "8888"),
+                      FullChainFixture::slotRow(bigAccount, benchH256(0xF17570CB), benchH256(1))});
+    auto bigStart = std::chrono::steady_clock::now();
+    fixture.runBlock(bigBlock);
+    double const bigTouchMs =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - bigStart)
+            .count();
+
+    auto stats = computeStats(latenciesMs);
+    std::cout << "[MPTFirstTouchLatencyBench] scale=" << (fullScale ? "acceptance" : "default")
+              << " samples=" << latenciesMs.size() << " touchesPerBlock=" << touchesPerBlock
+              << " dormantSlotsEach=" << dormantSlotsEach << "\n"
+              << "[MPTFirstTouchLatencyBench] first-touch block latency: p50=" << stats.p50Ms
+              << "ms p95=" << stats.p95Ms << "ms p99=" << stats.p99Ms << "ms max=" << stats.maxMs
+              << "ms\n"
+              << "[MPTFirstTouchLatencyBench] big-account (" << bigAccountSlots
+              << " pre-existing flat slots) single first-touch: " << bigTouchMs << "ms"
+              << std::endl;
+
+    // Measurement only: no latency assertion (see MPTSubsequentTouchP99Gate for the hard
+    // gates). The REQUIREs above already pin that the numbers came from the MPT path.
+    BOOST_CHECK_GE(latenciesMs.size(), measureBlocks);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace

--- a/transaction-scheduler/tests/MPTSubsequentTouchP99Gate.cpp
+++ b/transaction-scheduler/tests/MPTSubsequentTouchP99Gate.cpp
@@ -1,0 +1,211 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MPTSubsequentTouchP99Gate.cpp
+ * @brief Release-blocker latency gates (M10.3, spec design3 §11):
+ *          - "单块 commit 关键路径延迟 p99 < 200ms（1000 账户改动规模、subsequent-touch 路径）"
+ *          - "first-touch 大账户（本块写 1 slot）的 commit 延迟 p99 ≤ subsequent-touch 量级"
+ *        One scenario-A chain: a big dormant account is pre-filled under XOR, the flag
+ *        activates, GATE_ACCOUNTS accounts warm into the MPT, then every measured block
+ *        rewrites one storage slot on each of them (subsequent-touch). The final block
+ *        first-touches the big dormant account with a single slot write.
+ *
+ *        The HARD assertions arm ONLY under MPT_ACCEPTANCE=1 — the environment the ctest
+ *        "acceptance"-labeled registration sets (tests/CMakeLists.txt). The per-PR CI run
+ *        (plain ctest) executes a reduced-scale measurement pass that reports the same
+ *        numbers without failing, so a slow shared runner cannot turn this into flaky CI.
+ *        Distribution measurement (no gate) lives in MPTFirstTouchLatencyBench.cpp.
+ */
+#include "FullChainFixture.h"
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <random>
+#include <vector>
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::test::fullchain;
+
+constexpr std::string_view c_mptFlagName = "feature_mpt_state_root";
+constexpr double c_subsequentTouchP99GateMs = 200.0;  // spec §11: p99 < 200ms
+// "First-touch ≤ subsequent-touch 量级" (same order of magnitude): 10x the measured
+// subsequent-touch p99, with an absolute floor so a very fast subsequent-touch baseline
+// does not turn scheduling jitter into a false red.
+constexpr double c_firstTouchMagnitudeFactor = 10.0;
+constexpr double c_firstTouchFloorMs = 50.0;
+
+bool gateArmed()
+{
+    char const* env = std::getenv("MPT_ACCEPTANCE");
+    return env != nullptr && env[0] == '1';
+}
+
+Address gateAddress(uint32_t index)
+{
+    Address address{};
+    address.data()[0] = static_cast<uint8_t>(index >> 24U);
+    address.data()[1] = static_cast<uint8_t>(index >> 16U);
+    address.data()[2] = static_cast<uint8_t>(index >> 8U);
+    address.data()[3] = static_cast<uint8_t>(index);
+    address.data()[19] = 0x99;  // disjoint from other suites' address spaces
+    return address;
+}
+
+h256 gateH256(uint64_t value)
+{
+    h256 out{};
+    for (size_t i = 0; i < sizeof(value); ++i)
+    {
+        out.data()[31 - i] = static_cast<uint8_t>(value >> (8U * i));
+    }
+    return out;
+}
+
+BOOST_AUTO_TEST_SUITE(MPTSubsequentTouchP99GateSuite)
+
+BOOST_AUTO_TEST_CASE(SubsequentTouchP99AndBigFirstTouchGates)
+{
+    bool const armed = gateArmed();
+    // Armed (ctest -L acceptance): spec scale — 1000-account change set per block, 100
+    // measured blocks, 100k-flat-slot big account. Default: reduced measurement pass.
+    size_t const accounts = armed ? 1'000 : 250;
+    size_t const measureBlocks = armed ? 100 : 20;
+    size_t const bigAccountSlots = armed ? 100'000 : 5'000;
+    size_t const prefillRowsPerBlock = 10'000;
+    constexpr size_t warmupBlocks = 2;
+
+    FullChainFixture fixture{"subsequent_touch_gate"};
+    fixture.buildGenesis(FullChainFixture::baseGenesis());
+
+    // --- XOR-era pre-fill: the big dormant account ----------------------------------------
+    auto const bigAccount = gateAddress(0xFFFFFF00U);
+    protocol::BlockNumber nextBlock = 1;
+    {
+        std::vector<FCRowOp> pending;
+        pending.reserve(prefillRowsPerBlock + 1);
+        pending.push_back(FullChainFixture::balanceRow(bigAccount, "7777"));
+        for (size_t slot = 0; slot < bigAccountSlots; ++slot)
+        {
+            pending.push_back(FullChainFixture::slotRow(bigAccount, gateH256(slot), gateH256(1)));
+            if (pending.size() >= prefillRowsPerBlock)
+            {
+                fixture.planBlock(nextBlock, std::move(pending));
+                fixture.runBlock(nextBlock);
+                ++nextBlock;
+                pending.clear();
+            }
+        }
+        if (!pending.empty())
+        {
+            fixture.planBlock(nextBlock, std::move(pending));
+            fixture.runBlock(nextBlock);
+            ++nextBlock;
+        }
+    }
+
+    // --- Activation + warmup: all measured accounts enter the MPT -------------------------
+    auto const activationBlock = nextBlock;
+    fixture.enableFeatureFromBlock(c_mptFlagName, activationBlock);
+    fixture.planBlock(activationBlock, {FullChainFixture::balanceRow(gateAddress(1), "1")});
+    fixture.runBlock(activationBlock);  // activation block itself: still XOR
+    BOOST_REQUIRE(
+        fixture.featuresAt(activationBlock).get(ledger::Features::Flag::feature_mpt_state_root));
+
+    nextBlock = activationBlock + 1;
+    for (size_t warmup = 0; warmup < warmupBlocks; ++warmup)
+    {
+        std::vector<FCRowOp> rows;
+        rows.reserve(accounts);
+        for (size_t account = 0; account < accounts; ++account)
+        {
+            rows.push_back(FullChainFixture::balanceRow(
+                gateAddress(static_cast<uint32_t>(account)), std::to_string(1000 + warmup)));
+        }
+        fixture.planBlock(nextBlock, std::move(rows));
+        fixture.runBlock(nextBlock);
+        ++nextBlock;
+    }
+    BOOST_REQUIRE_GT(fixture.backendNodeCount(), 0);  // warmed accounts really are in the MPT
+
+    // --- Measured subsequent-touch blocks: one slot rewrite per account per block ---------
+    std::vector<double> latenciesMs;
+    latenciesMs.reserve(measureBlocks);
+    std::mt19937_64 rng{12345};
+    for (size_t measured = 0; measured < measureBlocks; ++measured)
+    {
+        std::vector<FCRowOp> rows;
+        rows.reserve(accounts);
+        for (size_t account = 0; account < accounts; ++account)
+        {
+            rows.push_back(FullChainFixture::slotRow(gateAddress(static_cast<uint32_t>(account)),
+                gateH256(rng() % 64), gateH256((rng() % 255) + 1)));
+        }
+        fixture.planBlock(nextBlock, std::move(rows));
+        auto start = std::chrono::steady_clock::now();
+        fixture.runBlock(nextBlock);
+        latenciesMs.push_back(
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start)
+                .count());
+        ++nextBlock;
+    }
+
+    // --- Big dormant account: single first-touch block ------------------------------------
+    fixture.planBlock(
+        nextBlock, {FullChainFixture::balanceRow(bigAccount, "8888"),
+                       FullChainFixture::slotRow(bigAccount, gateH256(0xF17570CB), gateH256(1))});
+    auto bigStart = std::chrono::steady_clock::now();
+    fixture.runBlock(nextBlock);
+    double const bigTouchMs =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - bigStart)
+            .count();
+
+    std::sort(latenciesMs.begin(), latenciesMs.end());
+    auto percentile = [&](size_t numerator) {
+        return latenciesMs[std::min(latenciesMs.size() * numerator / 100, latenciesMs.size() - 1)];
+    };
+    double const p50 = percentile(50);
+    double const p99 = percentile(99);
+    double const maxMs = latenciesMs.back();
+    double const firstTouchCeilingMs =
+        std::max(c_firstTouchMagnitudeFactor * p99, c_firstTouchFloorMs);
+
+    std::cout << "[MPTSubsequentTouchP99Gate] mode=" << (armed ? "GATE (armed)" : "report-only")
+              << " accounts/block=" << accounts << " samples=" << latenciesMs.size() << "\n"
+              << "[MPTSubsequentTouchP99Gate] subsequent-touch: p50=" << p50 << "ms p99=" << p99
+              << "ms max=" << maxMs << "ms (gate: p99 < " << c_subsequentTouchP99GateMs << "ms)\n"
+              << "[MPTSubsequentTouchP99Gate] big-account (" << bigAccountSlots
+              << " flat slots) first-touch: " << bigTouchMs
+              << "ms (gate: <= " << firstTouchCeilingMs << "ms)" << std::endl;
+
+    if (armed)
+    {
+        // spec §11: subsequent-touch p99 < 200ms at the 1000-account change scale.
+        BOOST_CHECK_LT(p99, c_subsequentTouchP99GateMs);
+        // spec §11: big-account first-touch stays within the subsequent-touch magnitude —
+        // pins the absence of any prefix-scan bootstrap over the 100k dormant flat slots.
+        BOOST_CHECK_LE(bigTouchMs, firstTouchCeilingMs);
+    }
+    else
+    {
+        BOOST_TEST_MESSAGE("MPT_ACCEPTANCE not set: measurement pass only, gates not armed");
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace

--- a/transaction-scheduler/tests/MPTSyntheticReplayTest.cpp
+++ b/transaction-scheduler/tests/MPTSyntheticReplayTest.cpp
@@ -1,0 +1,233 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MPTSyntheticReplayTest.cpp
+ * @brief Scenario-B 100-block deterministic replay (M10.1, degraded form of spec §11 #1):
+ *        an L2 chain genesis'd from allocs runs 100 blocks of seeded pseudo-random state
+ *        deltas — account creation, balance/nonce updates, slot writes, slot overwrites and
+ *        slot DELETIONS — and after EVERY block the incrementally-built committed stateRoot
+ *        must equal an independent from-scratch trie build over the full expected state.
+ *        A single divergence stops the replay at that block (REQUIRE), exactly the
+ *        chain-break semantics the mainnet-replay card specified: any node-encoding / RLP /
+ *        keccak-padding bug surfaces as the first mismatching block.
+ *
+ *        Degraded from "100 real Ethereum mainnet blocks" deliberately: replaying real
+ *        mainnet blocks needs (a) per-block state diffs only an archive node's
+ *        debug_traceBlock can provide (eth_getBlockByNumber carries none), and (b) a
+ *        mainnet-equivalent EVM including withdrawal processing — while this fixture
+ *        replaces the EVM with a delta-replaying scheduler by design. What the card is
+ *        actually after — long-chain incremental-vs-from-scratch equivalence over a rich op
+ *        mix — is exactly what this test pins. Real-vector fidelity against op-geth is
+ *        separately pinned by test_GenesisStateRoot / BaselineSchedulerMPTGenesisTest.
+ */
+#include "FullChainFixture.h"
+#include "bcos-ledger/mpt/Account.h"
+#include <boost/algorithm/hex.hpp>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <map>
+#include <random>
+#include <vector>
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::test::fullchain;
+namespace mpt = bcos::ledger::mpt;
+
+constexpr std::string_view c_replayEoa1 = "1100000000000000000000000000000000000011";
+constexpr std::string_view c_replayEoa2 = "2200000000000000000000000000000000000022";
+constexpr size_t c_replayBlocks = 100;
+
+Address replayHexAddress(std::string_view hex)
+{
+    Address address;
+    boost::algorithm::unhex(hex.begin(), hex.end(), address.data());
+    return address;
+}
+
+Address replayAddress(uint32_t index)
+{
+    Address address{};
+    address.data()[0] = static_cast<uint8_t>(index >> 24U);
+    address.data()[1] = static_cast<uint8_t>(index >> 16U);
+    address.data()[2] = static_cast<uint8_t>(index >> 8U);
+    address.data()[3] = static_cast<uint8_t>(index);
+    address.data()[19] = 0x34;  // disjoint from other suites' address spaces
+    return address;
+}
+
+h256 replayH256(uint64_t value)
+{
+    h256 out{};
+    for (size_t i = 0; i < sizeof(value); ++i)
+    {
+        out.data()[31 - i] = static_cast<uint8_t>(value >> (8U * i));
+    }
+    return out;
+}
+
+/// Test-side model of one account's expected state (EOA-shaped: no code).
+struct ReplayAccount
+{
+    u256 balance;
+    uint64_t nonce{};
+    std::map<h256, h256> slots;
+};
+
+BOOST_AUTO_TEST_SUITE(MPTSyntheticReplaySuite)
+
+BOOST_AUTO_TEST_CASE(HundredBlockReplayIncrementalMatchesFromScratchOracle)
+{
+    FullChainFixture fixture{"synthetic_replay"};
+    auto genesis = FullChainFixture::baseGenesis();
+    genesis.m_features.push_back(
+        ledger::FeatureSet{ledger::Features::Flag::feature_l2_ethereum_compat, 1});
+    genesis.m_allocs.push_back(ledger::Alloc{.address = std::string(c_replayEoa1),
+        .balance = u256(1000),
+        .nonce = "0",
+        .code = "",
+        .storage = {}});
+    genesis.m_allocs.push_back(ledger::Alloc{.address = std::string(c_replayEoa2),
+        .balance = u256(2000),
+        .nonce = "0",
+        .code = "",
+        .storage = {}});
+    fixture.buildGenesis(genesis);
+
+    // Expected-state model, seeded with the genesis allocs.
+    std::map<Address, ReplayAccount> expected;
+    expected[replayHexAddress(c_replayEoa1)] = {.balance = u256(1000), .slots = {}};
+    expected[replayHexAddress(c_replayEoa2)] = {.balance = u256(2000), .slots = {}};
+    std::vector<Address> known{replayHexAddress(c_replayEoa1), replayHexAddress(c_replayEoa2)};
+
+    // Genesis stateRoot must already match the from-scratch oracle over the allocs.
+    auto oracleRoot = [&] {
+        std::map<Address, mpt::Account> accounts;
+        for (auto const& [address, model] : expected)
+        {
+            mpt::Account account;
+            account.balance = model.balance;
+            account.nonce = model.nonce;
+            if (!model.slots.empty())
+            {
+                std::map<h256, bytes> slots;
+                for (auto const& [slot, value] : model.slots)
+                {
+                    slots[slot] = bytes(value.begin(), value.end());
+                }
+                account.storageRoot = FullChainFixture::storageTrieOracle(slots);
+            }
+            accounts[address] = account;
+        }
+        return FullChainFixture::mptOracle(accounts);
+    };
+    BOOST_REQUIRE_EQUAL(fixture.headerOnChain(0)->stateRoot().hex(), oracleRoot().hex());
+
+    std::mt19937_64 rng{0x5EED2026};
+    uint32_t nextNewAccount = 0;
+    size_t slotDeletes = 0;
+    size_t slotWrites = 0;
+
+    for (size_t blockIndex = 1; blockIndex <= c_replayBlocks; ++blockIndex)
+    {
+        std::vector<FCRowOp> rows;
+        size_t const ops = 1 + rng() % 4;
+        for (size_t op = 0; op < ops; ++op)
+        {
+            auto action = rng() % 100;
+            if (action < 25)
+            {
+                // Create a brand-new account: balance + nonce + one storage slot.
+                auto address = replayAddress(nextNewAccount++);
+                auto slot = replayH256(rng() % 16);
+                auto value = replayH256((rng() % 255) + 1);
+                rows.push_back(FullChainFixture::balanceRow(address, "500"));
+                rows.push_back(FullChainFixture::nonceRow(address, "1"));
+                rows.push_back(FullChainFixture::slotRow(address, slot, value));
+                expected[address] = {.balance = u256(500), .nonce = 1, .slots = {{slot, value}}};
+                known.push_back(address);
+                ++slotWrites;
+            }
+            else if (action < 50)
+            {
+                // Balance update on a known account.
+                auto const& address = known[rng() % known.size()];
+                auto balance = 1 + rng() % 1'000'000;
+                rows.push_back(FullChainFixture::balanceRow(address, std::to_string(balance)));
+                expected[address].balance = u256(balance);
+            }
+            else if (action < 85)
+            {
+                // Slot write / overwrite on a known account (small slot space on purpose:
+                // repeated keys force overwrites and shared trie paths).
+                auto const& address = known[rng() % known.size()];
+                auto slot = replayH256(rng() % 16);
+                auto value = replayH256((rng() % 255) + 1);
+                rows.push_back(FullChainFixture::slotRow(address, slot, value));
+                expected[address].slots[slot] = value;
+                ++slotWrites;
+            }
+            else
+            {
+                // Slot DELETE: drop one existing slot from a random account holding any
+                // (logical deletion row -> trie node removal on the incremental path).
+                auto start = rng() % known.size();
+                for (size_t probe = 0; probe < known.size(); ++probe)
+                {
+                    auto const& address = known[(start + probe) % known.size()];
+                    auto& slots = expected[address].slots;
+                    if (slots.empty())
+                    {
+                        continue;
+                    }
+                    auto victim = slots.begin();
+                    std::advance(victim, rng() % slots.size());
+                    rows.push_back({bcos::ledger::mpt::accountTableName(address),
+                        std::string(
+                            reinterpret_cast<char const*>(victim->first.data()), h256::SIZE),
+                        std::nullopt});
+                    slots.erase(victim);
+                    ++slotDeletes;
+                    break;
+                }
+            }
+        }
+        // Deduplicate conflicting writes within the block is unnecessary: later rows win in
+        // both the storage layer and the expected model (map assignment order == row order).
+        auto blockNumber = static_cast<protocol::BlockNumber>(blockIndex);
+        fixture.planBlock(blockNumber, std::move(rows));
+        auto header = fixture.runBlock(blockNumber);
+
+        // Chain-break semantics: the FIRST diverging block stops the replay (REQUIRE), so a
+        // real encoding bug reports its exact block instead of 99 cascading mismatches.
+        BOOST_REQUIRE_MESSAGE(header->stateRoot().hex() == oracleRoot().hex(),
+            "block " + std::to_string(blockIndex) + " stateRoot mismatch: committed=" +
+                header->stateRoot().hex() + " oracle=" + oracleRoot().hex());
+    }
+
+    // Anti-false-green: the op mix really exercised every path.
+    BOOST_REQUIRE_GE(slotDeletes, 5);
+    BOOST_REQUIRE_GE(slotWrites, 30);
+    BOOST_REQUIRE_GE(known.size(), 10);
+    BOOST_REQUIRE_GT(fixture.backendNodeCount(), 0);
+    BOOST_CHECK_EQUAL(fixture.headerOnChain(c_replayBlocks)->stateRoot().hex(), oracleRoot().hex());
+    std::cout << "[MPTSyntheticReplay] " << c_replayBlocks << "/" << c_replayBlocks
+              << " blocks matched; accounts=" << known.size() << " slotWrites=" << slotWrites
+              << " slotDeletes=" << slotDeletes << std::endl;
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace


### PR DESCRIPTION
> Rebased onto the current `release-3.18.0` tip after #5374 and #5332 merged — the diff is now exactly the five commits below plus one follow-up flipping the gate table's SlotNotInMPT rows (spec §11 #5a/#5b) from PENDING to live ctest gates now that #5332 is in. Current gate tally: **14 PASS / 1 PENDING (historical eth_call, #5382) / 1 SKIP**.

## What this delivers

The MPT acceptance layer (M10), sized to what remains after the half-commit-detection retirement: latency evidence for both build paths, a deterministic scenario-B replay, a release-gate runner over the spec's acceptance checklist, and the release documentation.

- `f72338f78` — **first-touch latency distribution bench**: measures p50/p95/p99 over scenario-A first-touches through the real RocksDB + Ledger + BaselineScheduler stack. Reduced scale by default (report-only, no assertions — CI-safe); full scale under the acceptance option. Measured here (RelWithDebInfo, arm64): p99 = 0.60 ms, and a 100k-slot account's first touch is 0.62 ms — same order as a fresh account, the first measured proof that the slot-level design has no prefix scan.
- `96ec27e59` — **subsequent-touch p99 gate**: hard assertion p99 < 200 ms (spec §11), armed only in acceptance builds. Measured p99 = 44–51 ms at 1000 accounts/block × 100 blocks (~4× headroom).
- `4715b785a` — **scenario-B synthetic 100-block replay**: fixed-seed deterministic replay (create/update/overwrite/delete mix), asserting each block's incrementally committed root equals an independent from-scratch `commitTrie` oracle, failing on the first divergent block. This is the feasible core of the "mainnet replay" card: a true 100-block mainnet replay needs per-block state diffs from an archive node (`debug_traceBlock`) — not fetchable in CI and too large to vendor — and the fixture intentionally replaces the EVM with delta replay, so mainnet stateRoot alignment lacks its premise. Real-vector spot checks already exist (`test_GenesisStateRoot`, the genesis integration test); the mainnet-data portion stays on its card.
- `a433562a8` — **acceptance gate runner** (`tools/mpt_acceptance_gate.sh`): maps the surviving spec §11 items to concrete ctest invocations, prints a per-item table, exit 0/1; `--strict` counts pending items as failures (the release-decision mode). Current tally: 12 PASS, 2 PENDING (SlotNotInMPT → #5332; historical eth_call → the M13.2 PR), 1 SKIP.
- `3cf162294` — **release docs** (`docs/mpt/`): release notes, scenario-A migration guide, deploy runbook. Anchored to current code, including one correction of tribal knowledge: feature flags are one-way (`SystemConfigPrecompiled::validate` rejects any value but "1"), so a scenario-A activation cannot be rolled back on-chain — the runbook makes a pre-activation datadir backup a hard step.

## CI isolation for the hard gates

All per-PR CI pipelines invoke bare `ctest -j3`, so ctest labels alone cannot keep a perf gate out of CI. The armed gates are therefore registered only under `option(MPT_ACCEPTANCE_GATES OFF)`: default builds carry report-only reduced runs, and a release-acceptance build opts in with `-DMPT_ACCEPTANCE_GATES=ON` (the gate script fails loudly via `--no-tests=error` when pointed at a build without it).

## Tests

`test-transaction-scheduler` full suite: 95/95 cases, 3621/3621 assertions. `ctest -L acceptance`: 3/3 in an ON build; an OFF build registers zero acceptance entries. Negative controls: gate thresholds tightened to 0.001 ms trip both assertions; a perturbed replay oracle fails at block 1; `--strict` exits 1 while the default exits 0; an OFF build dir fails the gate rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

