### PR TITLE
Fix use-after-destroy bug in SyncWait

### DIFF
--- a/libtask/bcos-task/AsyncTask.h
+++ b/libtask/bcos-task/AsyncTask.h
@@ -16,7 +16,9 @@
 
 #pragma once
 #include <coroutine>
+#include <cstdint>
 #include <exception>
+#include <atomic>
 
 namespace bcos::task
 {
@@ -55,8 +57,71 @@ public:
     AsyncTask(AsyncTask&& task) noexcept = delete;
     AsyncTask& operator=(const AsyncTask&) = delete;
     AsyncTask& operator=(AsyncTask&& task) = delete;
-    ~AsyncTask() noexcept = default;
+    ~AsyncTask() noexcept  = default;
     void start() { m_handle.resume(); }
+
+private:
+    std::coroutine_handle<promise_type> m_handle;
+};
+
+enum class waitStatus: uint8_t {
+    INIT,
+    WAITING,
+    FINISHED,
+};
+
+class [[nodiscard]] SyncTask
+{
+public:
+    struct promise_type
+    {
+        // 持有handle的计数器
+        std::atomic<uint8_t> m_count{2};
+        // 用于记录任务的等待状态以及获取状态的引用
+        std::atomic<waitStatus> m_status{waitStatus::INIT};
+
+        static constexpr std::suspend_always initial_suspend() noexcept { return {}; }
+        static constexpr auto final_suspend() noexcept
+        {
+            struct FinalAwaitable
+            {
+                static constexpr bool await_ready() noexcept { return false; }
+                static void await_suspend(std::coroutine_handle<promise_type> handle) noexcept
+                {
+                    if (handle.promise().m_count.fetch_sub(1) == 1)
+                    {
+                        handle.destroy();
+                    }
+                }
+                constexpr void await_resume() noexcept {}
+            };
+            return FinalAwaitable{};
+        }
+        SyncTask get_return_object()
+        {
+            auto handle = std::coroutine_handle<promise_type>::from_promise(
+                *static_cast<promise_type*>(this));
+            return SyncTask{handle};
+        }
+        static void unhandled_exception() { std::rethrow_exception(std::current_exception()); }
+        constexpr static void return_void() noexcept {}
+    };
+
+    explicit SyncTask(std::coroutine_handle<promise_type> handle) : m_handle(handle) {}
+    SyncTask(const SyncTask&) = delete;
+    SyncTask(SyncTask&& task) noexcept = delete;
+    SyncTask& operator=(const SyncTask&) = delete;
+    SyncTask& operator=(SyncTask&& task) = delete;
+    ~SyncTask() noexcept 
+    {
+        if (m_handle.promise().m_count.fetch_sub(1) == 1)
+        {
+            m_handle.destroy();
+        }
+    }
+    void start() { m_handle.resume(); }
+
+    std::atomic<waitStatus>& getStatus() { return m_handle.promise().m_status; }
 
 private:
     std::coroutine_handle<promise_type> m_handle;

--- a/libtask/bcos-task/AsyncTask.h
+++ b/libtask/bcos-task/AsyncTask.h
@@ -15,10 +15,10 @@
  */
 
 #pragma once
+#include <atomic>
 #include <coroutine>
 #include <cstdint>
 #include <exception>
-#include <atomic>
 
 namespace bcos::task
 {
@@ -57,28 +57,55 @@ public:
     AsyncTask(AsyncTask&& task) noexcept = delete;
     AsyncTask& operator=(const AsyncTask&) = delete;
     AsyncTask& operator=(AsyncTask&& task) = delete;
-    ~AsyncTask() noexcept  = default;
+    ~AsyncTask() noexcept = default;
     void start() { m_handle.resume(); }
 
 private:
     std::coroutine_handle<promise_type> m_handle;
 };
 
-enum class waitStatus: uint8_t {
+enum class WaitStatus : uint8_t
+{
     INIT,
     WAITING,
     FINISHED,
 };
 
+/*
+ * SyncTask ties the lifetime of the synchronization state to the coroutine frame.
+ *
+ * The synchronization state (m_status) and a reference counter (m_count) live inside
+ * the coroutine frame (promise_type), so their lifetime equals the frame lifetime.
+ *
+ * Lifetime protocol (reference counting):
+ *   - m_count starts at 1, owned by the SyncTask handle.
+ *   - start() increments it to 2 before resuming the coroutine.
+ *   - The coroutine's FinalAwaitable::await_suspend decrements it at final_suspend,
+ *     i.e. after the coroutine has executed every byte of its frame (program order)
+ *     and will not touch the frame afterwards.
+ *   - ~SyncTask() decrements it.
+ *   - The side that brings the counter to zero destroys the frame.
+ *
+ * Why this closes the use-after-destroy races:
+ *   - The completing coroutine can safely call notify_one() on m_status: it holds its
+ *     own reference until final_suspend, so the frame (and m_status) cannot be
+ *     destroyed by the waiter while notify_one() runs.
+ *   - The waiter (SyncTask handle) never destroys a frame that the completer may
+ *     still be executing in, because destruction requires the completer to have
+ *     already decremented the counter at final_suspend.
+ *   - If start() is never called the counter stays at 1, so ~SyncTask() destroys the
+ *     frame and a never-started task does not leak.
+ */
 class [[nodiscard]] SyncTask
 {
 public:
     struct promise_type
     {
-        // 持有handle的计数器
-        std::atomic<uint8_t> m_count{2};
-        // 用于记录任务的等待状态以及获取状态的引用
-        std::atomic<waitStatus> m_status{waitStatus::INIT};
+        // Reference counter guarding the frame lifetime, see the comment above.
+        // Starts at 1 (owned by the SyncTask handle); start() raises it to 2.
+        std::atomic<uint8_t> m_count{1};
+        // Synchronization state shared between the waiter and the coroutine.
+        std::atomic<WaitStatus> m_status{WaitStatus::INIT};
 
         static constexpr std::suspend_always initial_suspend() noexcept { return {}; }
         static constexpr auto final_suspend() noexcept
@@ -103,7 +130,21 @@ public:
                 *static_cast<promise_type*>(this));
             return SyncTask{handle};
         }
-        static void unhandled_exception() { std::rethrow_exception(std::current_exception()); }
+        void unhandled_exception()
+        {
+            // Abnormal termination: the coroutine body threw an uncaught exception,
+            // so control never reaches final_suspend and the reference added by
+            // start() would never be released there. Release it here. If this was
+            // the last reference, the frame must be destroyed now; otherwise the
+            // SyncTask handle's destructor will destroy it. The exception object
+            // lives in thread-local storage, so rethrowing after destroy() is safe.
+            auto handle = std::coroutine_handle<promise_type>::from_promise(*this);
+            if (m_count.fetch_sub(1) == 1)
+            {
+                handle.destroy();
+            }
+            std::rethrow_exception(std::current_exception());
+        }
         constexpr static void return_void() noexcept {}
     };
 
@@ -112,16 +153,23 @@ public:
     SyncTask(SyncTask&& task) noexcept = delete;
     SyncTask& operator=(const SyncTask&) = delete;
     SyncTask& operator=(SyncTask&& task) = delete;
-    ~SyncTask() noexcept 
+    ~SyncTask() noexcept
     {
         if (m_handle.promise().m_count.fetch_sub(1) == 1)
         {
             m_handle.destroy();
         }
     }
-    void start() { m_handle.resume(); }
+    void start()
+    {
+        // Increment the reference count BEFORE resuming: resume() may drive the
+        // coroutine all the way to final_suspend, which would otherwise drop the
+        // counter to zero and destroy the frame while start() is still using it.
+        m_handle.promise().m_count.fetch_add(1);
+        m_handle.resume();
+    }
 
-    std::atomic<waitStatus>& getStatus() { return m_handle.promise().m_status; }
+    std::atomic<WaitStatus>& getStatus() { return m_handle.promise().m_status; }
 
 private:
     std::coroutine_handle<promise_type> m_handle;

--- a/libtask/bcos-task/Task.h
+++ b/libtask/bcos-task/Task.h
@@ -96,20 +96,24 @@ template <class TaskType>
 struct Awaitable
 {
     explicit Awaitable(std::coroutine_handle<typename TaskType::promise_type> handle)
-      : m_handle(std::move(handle)) {};
+      { m_continuation.handle = std::move(handle);}
     Awaitable(const Awaitable&) = delete;
     Awaitable(Awaitable&&) noexcept = default;
     Awaitable& operator=(const Awaitable&) = delete;
     Awaitable& operator=(Awaitable&&) noexcept = default;
     ~Awaitable() noexcept = default;
 
-    bool await_ready() const noexcept { return !m_handle || m_handle.done(); }
-    template <class Promise>
-    std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> handle)
+    bool await_ready() const noexcept { return !m_continuation.handle || m_continuation.handle.done(); }
+    std::coroutine_handle<> await_suspend(std::coroutine_handle<> handle)
     {
+        // This transformation operation is safe 
+        // when Awaitable is constructed by coroutine_handle<typename TaskType::promise_type>
+        // but unsafe when Awaitable is constructed by other ways
+        auto nextHandle = 
+            std::coroutine_handle<typename TaskType::promise_type>::from_address(m_continuation.handle.address());
         m_continuation.handle = handle;
-        m_handle.promise().m_continuation = std::addressof(m_continuation);
-        return m_handle;
+        nextHandle.promise().m_continuation = std::addressof(m_continuation);
+        return nextHandle;
     }
     TaskType::Value await_resume()
     {
@@ -129,7 +133,6 @@ struct Awaitable
         }
     }
 
-    std::coroutine_handle<typename TaskType::promise_type> m_handle;
     Continuation<typename TaskType::VariantValue> m_continuation;
 };
 
@@ -159,6 +162,7 @@ public:
         }
         m_handle = task.m_handle;
         task.m_handle = nullptr;
+        return *this;
     }
     ~Task() noexcept
     {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -41,13 +41,6 @@ constexpr inline struct Wait
 
 constexpr inline struct SyncWait
 {
-
-    enum class waitStatus: uint8_t {
-        INIT,
-        WAITING,
-        AWAKED,
-        FINISHED,
-    };
     template <IsAwaitable Task>
     auto operator()(Task&& task, auto&&... args) const
         -> AwaitableReturnType<std::remove_cvref_t<Task>>
@@ -59,10 +52,8 @@ constexpr inline struct SyncWait
             std::variant<std::monostate, std::exception_ptr>,
             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
         ReturnVariant result;
-        std::atomic<waitStatus> status = waitStatus::INIT;
 
-        auto handle = [](Task&& task, decltype(result)& result, std::atomic<waitStatus>& status,
-                          auto&&... args) -> task::AsyncTask {
+        auto handle = [](Task&& task, decltype(result)& result, auto&&... args) -> task::SyncTask {
             try
             {
                 if constexpr (std::is_void_v<ReturnType>)
@@ -87,18 +78,30 @@ constexpr inline struct SyncWait
                 result.template emplace<std::exception_ptr>(std::current_exception());
             }
 
+            struct GetStatusAwaitable {
+                std::coroutine_handle<SyncTask::promise_type> m_handle;
+                bool await_ready() const noexcept { return false; }
+                bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept 
+                {
+                    m_handle = handle;
+                    return false;
+                }
+                std::atomic<waitStatus>& await_resume() noexcept { return m_handle.promise().m_status; }
+            };
+
+            auto& status = co_await GetStatusAwaitable();
+
             auto expected = waitStatus::INIT;
             if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
             {
                 // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
                 // If true is returned here, the external finish is set first, and the external
                 // execution needs to be notified
-                status.store(waitStatus::AWAKED);
-                status.notify_one();
                 status.store(waitStatus::FINISHED);
+                status.notify_one();
             }
-        }(std::forward<Task>(task), result, status,
-                                              std::forward<decltype(args)>(args)...);
+        }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
+        auto& status = handle.getStatus();
         handle.start();
 
         auto expected = waitStatus::INIT;
@@ -108,8 +111,6 @@ constexpr inline struct SyncWait
             // If true is returned, the task is still being executed and you need to wait for the
             // task to complete
             status.wait(waitStatus::WAITING);
-            //此时status进入AWAKED状态，开始忙等直到FINISHED
-            while (status.load() != waitStatus::FINISHED){}
         }
         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
         {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -41,6 +41,13 @@ constexpr inline struct Wait
 
 constexpr inline struct SyncWait
 {
+
+    enum class waitStatus: uint8_t {
+        INIT,
+        WAITING,
+        AWAKED,
+        FINISHED,
+    };
     template <IsAwaitable Task>
     auto operator()(Task&& task, auto&&... args) const
         -> AwaitableReturnType<std::remove_cvref_t<Task>>
@@ -52,13 +59,9 @@ constexpr inline struct SyncWait
             std::variant<std::monostate, std::exception_ptr>,
             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
         ReturnVariant result;
-        boost::atomic_flag finished;
-        boost::atomic_flag waitFlag;
-        boost::atomic_flag exited;
+        std::atomic<waitStatus> status = waitStatus::INIT;
 
-        auto handle = [](Task&& task, decltype(result)& result, boost::atomic_flag& finished,
-                          boost::atomic_flag& waitFlag,
-                          boost::atomic_flag& exited,
+        auto handle = [](Task&& task, decltype(result)& result, std::atomic<waitStatus>& status,
                           auto&&... args) -> task::Task<void> {
             try
             {
@@ -84,28 +87,29 @@ constexpr inline struct SyncWait
                 result.template emplace<std::exception_ptr>(std::current_exception());
             }
 
-            if (finished.test_and_set())
+            auto expected = waitStatus::INIT;
+            if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
             {
                 // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
                 // If true is returned here, the external finish is set first, and the external
                 // execution needs to be notified
-                waitFlag.test_and_set();
-                waitFlag.notify_one();
-                exited.test_and_set();
+                status.store(waitStatus::AWAKED);
+                status.notify_one();
+                status.store(waitStatus::FINISHED);
             }
-        }(std::forward<Task>(task), result, finished, waitFlag,
+        }(std::forward<Task>(task), result, status,
                                               std::forward<decltype(args)>(args)...);
         handle.start();
 
-        if (!finished.test_and_set())
+        auto expected = waitStatus::INIT;
+        if (status.compare_exchange_strong(expected, waitStatus::WAITING))
         {
-            // 此处返回false说明task还在执行中，需要等待task完成
-            // If false is returned, the task is still being executed and you need to wait for the
+            // 此处返回true说明task还在执行中，需要等待task完成
+            // If true is returned, the task is still being executed and you need to wait for the
             // task to complete
-            while (!exited.load())
-            {
-                waitFlag.wait(false);
-            }
+            status.wait(waitStatus::WAITING);
+            //此时status进入AWAKED状态，开始忙等直到FINISHED
+            while (status.load() != waitStatus::FINISHED){}
         }
         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
         {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -54,9 +54,11 @@ constexpr inline struct SyncWait
         ReturnVariant result;
         boost::atomic_flag finished;
         boost::atomic_flag waitFlag;
+        boost::atomic_flag exited;
 
         auto handle = [](Task&& task, decltype(result)& result, boost::atomic_flag& finished,
                           boost::atomic_flag& waitFlag,
+                          boost::atomic_flag& exited,
                           auto&&... args) -> task::Task<void> {
             try
             {
@@ -89,6 +91,7 @@ constexpr inline struct SyncWait
                 // execution needs to be notified
                 waitFlag.test_and_set();
                 waitFlag.notify_one();
+                exited.test_and_set();
             }
         }(std::forward<Task>(task), result, finished, waitFlag,
                                               std::forward<decltype(args)>(args)...);
@@ -99,7 +102,10 @@ constexpr inline struct SyncWait
             // 此处返回false说明task还在执行中，需要等待task完成
             // If false is returned, the task is still being executed and you need to wait for the
             // task to complete
-            waitFlag.wait(false);
+            while (!exited.load())
+            {
+                waitFlag.wait(false);
+            }
         }
         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
         {

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -62,7 +62,7 @@ constexpr inline struct SyncWait
         std::atomic<waitStatus> status = waitStatus::INIT;
 
         auto handle = [](Task&& task, decltype(result)& result, std::atomic<waitStatus>& status,
-                          auto&&... args) -> task::Task<void> {
+                          auto&&... args) -> task::AsyncTask {
             try
             {
                 if constexpr (std::is_void_v<ReturnType>)

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -14,123 +14,131 @@
  *  limitations under the License.
  */
 
- #pragma once
- #include "AsyncTask.h"
- #include "Task.h"
- #include "Trait.h"
- #include <boost/atomic/atomic_flag.hpp>
- #include <exception>
- #include <memory>
- #include <type_traits>
- #include <variant>
- 
- namespace bcos::task
- {
- 
- constexpr inline struct Wait
- {
-     static AsyncTask executeTask(auto task) { co_await std::move(task); }
- 
-     template <IsAwaitable Task>
-     void operator()(Task&& task) const
-     {
-         auto asyncTask = executeTask(std::forward<Task>(task));
-         asyncTask.start();
-     }
- } wait{};
- 
- constexpr inline struct SyncWait
- {
-     template <IsAwaitable Task>
-     auto operator()(Task&& task, auto&&... args) const
-         -> AwaitableReturnType<std::remove_cvref_t<Task>>
-     {
-         using ReturnType = AwaitableReturnType<std::remove_cvref_t<Task>>;
-         using ReturnTypeWrap = std::conditional_t<std::is_reference_v<ReturnType>,
-             std::add_pointer_t<ReturnType>, ReturnType>;
-         using ReturnVariant = std::conditional_t<std::is_void_v<ReturnType>,
-             std::variant<std::monostate, std::exception_ptr>,
-             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
-         ReturnVariant result;
- 
-         auto handle = [](Task&& task, decltype(result)& result, auto&&... args) -> task::SyncTask {
-             try
-             {
-                 if constexpr (std::is_void_v<ReturnType>)
-                 {
-                     co_await std::forward<Task>(task);
-                 }
-                 else
-                 {
-                     if constexpr (std::is_reference_v<ReturnType>)
-                     {
-                         decltype(auto) ref = co_await task;
-                         result = std::addressof(ref);
-                     }
-                     else
-                     {
-                         result.template emplace<ReturnType>(co_await std::forward<Task>(task));
-                     }
-                 }
-             }
-             catch (...)
-             {
-                 result.template emplace<std::exception_ptr>(std::current_exception());
-             }
- 
-             struct GetStatusAwaitable {
-                 std::coroutine_handle<SyncTask::promise_type> m_handle;
-                 bool await_ready() const noexcept { return false; }
-                 bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept 
-                 {
-                     m_handle = handle;
-                     return false;
-                 }
-                 std::atomic<waitStatus>& await_resume() noexcept { return m_handle.promise().m_status; }
-             };
- 
-             auto& status = co_await GetStatusAwaitable();
- 
-             auto expected = waitStatus::INIT;
-             if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
-             {
-                 // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
-                 // If true is returned here, the external finish is set first, and the external
-                 // execution needs to be notified
-                 status.store(waitStatus::FINISHED);
-                 status.notify_one();
-             }
-         }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
-         
-         auto& status = handle.getStatus();
-         handle.start();
- 
-         auto expected = waitStatus::INIT;
-         if (status.compare_exchange_strong(expected, waitStatus::WAITING))
-         {
-             // 此处返回true说明task还在执行中，需要等待task完成
-             // If true is returned, the task is still being executed and you need to wait for the
-             // task to complete
-             status.wait(waitStatus::WAITING);
-         }
-         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
-         {
-             std::rethrow_exception(*exception);
-         }
- 
-         if constexpr (!std::is_void_v<ReturnType>)
-         {
-             if constexpr (std::is_reference_v<ReturnType>)
-             {
-                 return *(std::get<ReturnTypeWrap>(result));
-             }
-             else
-             {
-                 return std::move(std::get<ReturnTypeWrap>(result));
-             }
-         }
-     }
- } syncWait{};
- 
- }  // namespace bcos::task
- 
+#pragma once
+#include "AsyncTask.h"
+#include "Task.h"
+#include "Trait.h"
+#include <exception>
+#include <memory>
+#include <type_traits>
+#include <variant>
+
+namespace bcos::task
+{
+
+constexpr inline struct Wait
+{
+    static AsyncTask executeTask(auto task) { co_await std::move(task); }
+
+    template <IsAwaitable Task>
+    void operator()(Task&& task) const
+    {
+        auto asyncTask = executeTask(std::forward<Task>(task));
+        asyncTask.start();
+    }
+} wait{};
+
+constexpr inline struct SyncWait
+{
+    template <IsAwaitable Task>
+    auto operator()(Task&& task, auto&&... args) const
+        -> AwaitableReturnType<std::remove_cvref_t<Task>>
+    {
+        using ReturnType = AwaitableReturnType<std::remove_cvref_t<Task>>;
+        using ReturnTypeWrap = std::conditional_t<std::is_reference_v<ReturnType>,
+            std::add_pointer_t<ReturnType>, ReturnType>;
+        using ReturnVariant = std::conditional_t<std::is_void_v<ReturnType>,
+            std::variant<std::monostate, std::exception_ptr>,
+            std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
+        ReturnVariant result;
+
+        auto handle = [](Task&& task, decltype(result)& result,
+                          auto&&... args) -> task::SyncTask {
+            try
+            {
+                if constexpr (std::is_void_v<ReturnType>)
+                {
+                    co_await std::forward<Task>(task);
+                }
+                else
+                {
+                    if constexpr (std::is_reference_v<ReturnType>)
+                    {
+                        decltype(auto) ref = co_await task;
+                        result = std::addressof(ref);
+                    }
+                    else
+                    {
+                        result.template emplace<ReturnType>(co_await std::forward<Task>(task));
+                    }
+                }
+            }
+            catch (...)
+            {
+                result.template emplace<std::exception_ptr>(std::current_exception());
+            }
+
+            // A coroutine body cannot access its own coroutine_handle directly.
+            // GetStatusAwaitable uses co_await only to capture the enclosing
+            // coroutine's handle in await_suspend and hand back a reference to the
+            // promise's m_status. await_suspend returns false, so the coroutine is
+            // resumed immediately and this is effectively a non-suspending call.
+            // The returned reference is the same object the waiter accesses through
+            // SyncTask::getStatus().
+            struct GetStatusAwaitable
+            {
+                std::coroutine_handle<SyncTask::promise_type> m_handle;
+                bool await_ready() const noexcept { return false; }
+                bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept
+                {
+                    m_handle = handle;
+                    return false;
+                }
+                std::atomic<WaitStatus>& await_resume() noexcept
+                {
+                    return m_handle.promise().m_status;
+                }
+            };
+
+            auto& status = co_await GetStatusAwaitable();
+
+            auto expected = WaitStatus::INIT;
+            if (!status.compare_exchange_strong(expected, WaitStatus::FINISHED))
+            {
+                // CAS failed: the waiter has already set the status to WAITING
+                // (slow path). Set FINISHED and wake the waiter up.
+                status.store(WaitStatus::FINISHED);
+                status.notify_one();
+            }
+        }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
+
+        auto& status = handle.getStatus();
+        handle.start();
+
+        auto expected = WaitStatus::INIT;
+        if (status.compare_exchange_strong(expected, WaitStatus::WAITING))
+        {
+            // CAS succeeded: the coroutine has not finished yet. Wait until it
+            // publishes FINISHED.
+            status.wait(WaitStatus::WAITING);
+        }
+        if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
+        {
+            std::rethrow_exception(*exception);
+        }
+
+        if constexpr (!std::is_void_v<ReturnType>)
+        {
+            if constexpr (std::is_reference_v<ReturnType>)
+            {
+                return *(std::get<ReturnTypeWrap>(result));
+            }
+            else
+            {
+                return std::move(std::get<ReturnTypeWrap>(result));
+            }
+        }
+    }
+} syncWait{};
+
+}  // namespace bcos::task

--- a/libtask/bcos-task/Wait.h
+++ b/libtask/bcos-task/Wait.h
@@ -14,121 +14,123 @@
  *  limitations under the License.
  */
 
-#pragma once
-#include "AsyncTask.h"
-#include "Task.h"
-#include "Trait.h"
-#include <boost/atomic/atomic_flag.hpp>
-#include <exception>
-#include <memory>
-#include <type_traits>
-#include <variant>
-
-namespace bcos::task
-{
-
-constexpr inline struct Wait
-{
-    static AsyncTask executeTask(auto task) { co_await std::move(task); }
-
-    template <IsAwaitable Task>
-    void operator()(Task&& task) const
-    {
-        auto asyncTask = executeTask(std::forward<Task>(task));
-        asyncTask.start();
-    }
-} wait{};
-
-constexpr inline struct SyncWait
-{
-    template <IsAwaitable Task>
-    auto operator()(Task&& task, auto&&... args) const
-        -> AwaitableReturnType<std::remove_cvref_t<Task>>
-    {
-        using ReturnType = AwaitableReturnType<std::remove_cvref_t<Task>>;
-        using ReturnTypeWrap = std::conditional_t<std::is_reference_v<ReturnType>,
-            std::add_pointer_t<ReturnType>, ReturnType>;
-        using ReturnVariant = std::conditional_t<std::is_void_v<ReturnType>,
-            std::variant<std::monostate, std::exception_ptr>,
-            std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
-        ReturnVariant result;
-
-        auto handle = [](Task&& task, decltype(result)& result, auto&&... args) -> task::SyncTask {
-            try
-            {
-                if constexpr (std::is_void_v<ReturnType>)
-                {
-                    co_await std::forward<Task>(task);
-                }
-                else
-                {
-                    if constexpr (std::is_reference_v<ReturnType>)
-                    {
-                        decltype(auto) ref = co_await task;
-                        result = std::addressof(ref);
-                    }
-                    else
-                    {
-                        result.template emplace<ReturnType>(co_await std::forward<Task>(task));
-                    }
-                }
-            }
-            catch (...)
-            {
-                result.template emplace<std::exception_ptr>(std::current_exception());
-            }
-
-            struct GetStatusAwaitable {
-                std::coroutine_handle<SyncTask::promise_type> m_handle;
-                bool await_ready() const noexcept { return false; }
-                bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept 
-                {
-                    m_handle = handle;
-                    return false;
-                }
-                std::atomic<waitStatus>& await_resume() noexcept { return m_handle.promise().m_status; }
-            };
-
-            auto& status = co_await GetStatusAwaitable();
-
-            auto expected = waitStatus::INIT;
-            if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
-            {
-                // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
-                // If true is returned here, the external finish is set first, and the external
-                // execution needs to be notified
-                status.store(waitStatus::FINISHED);
-                status.notify_one();
-            }
-        }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
-        auto& status = handle.getStatus();
-        handle.start();
-
-        auto expected = waitStatus::INIT;
-        if (status.compare_exchange_strong(expected, waitStatus::WAITING))
-        {
-            // 此处返回true说明task还在执行中，需要等待task完成
-            // If true is returned, the task is still being executed and you need to wait for the
-            // task to complete
-            status.wait(waitStatus::WAITING);
-        }
-        if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
-        {
-            std::rethrow_exception(*exception);
-        }
-
-        if constexpr (!std::is_void_v<ReturnType>)
-        {
-            if constexpr (std::is_reference_v<ReturnType>)
-            {
-                return *(std::get<ReturnTypeWrap>(result));
-            }
-            else
-            {
-                return std::move(std::get<ReturnTypeWrap>(result));
-            }
-        }
-    }
-} syncWait{};
-
-}  // namespace bcos::task
+ #pragma once
+ #include "AsyncTask.h"
+ #include "Task.h"
+ #include "Trait.h"
+ #include <boost/atomic/atomic_flag.hpp>
+ #include <exception>
+ #include <memory>
+ #include <type_traits>
+ #include <variant>
+ 
+ namespace bcos::task
+ {
+ 
+ constexpr inline struct Wait
+ {
+     static AsyncTask executeTask(auto task) { co_await std::move(task); }
+ 
+     template <IsAwaitable Task>
+     void operator()(Task&& task) const
+     {
+         auto asyncTask = executeTask(std::forward<Task>(task));
+         asyncTask.start();
+     }
+ } wait{};
+ 
+ constexpr inline struct SyncWait
+ {
+     template <IsAwaitable Task>
+     auto operator()(Task&& task, auto&&... args) const
+         -> AwaitableReturnType<std::remove_cvref_t<Task>>
+     {
+         using ReturnType = AwaitableReturnType<std::remove_cvref_t<Task>>;
+         using ReturnTypeWrap = std::conditional_t<std::is_reference_v<ReturnType>,
+             std::add_pointer_t<ReturnType>, ReturnType>;
+         using ReturnVariant = std::conditional_t<std::is_void_v<ReturnType>,
+             std::variant<std::monostate, std::exception_ptr>,
+             std::variant<std::monostate, ReturnTypeWrap, std::exception_ptr>>;
+         ReturnVariant result;
+ 
+         auto handle = [](Task&& task, decltype(result)& result, auto&&... args) -> task::SyncTask {
+             try
+             {
+                 if constexpr (std::is_void_v<ReturnType>)
+                 {
+                     co_await std::forward<Task>(task);
+                 }
+                 else
+                 {
+                     if constexpr (std::is_reference_v<ReturnType>)
+                     {
+                         decltype(auto) ref = co_await task;
+                         result = std::addressof(ref);
+                     }
+                     else
+                     {
+                         result.template emplace<ReturnType>(co_await std::forward<Task>(task));
+                     }
+                 }
+             }
+             catch (...)
+             {
+                 result.template emplace<std::exception_ptr>(std::current_exception());
+             }
+ 
+             struct GetStatusAwaitable {
+                 std::coroutine_handle<SyncTask::promise_type> m_handle;
+                 bool await_ready() const noexcept { return false; }
+                 bool await_suspend(std::coroutine_handle<SyncTask::promise_type> handle) noexcept 
+                 {
+                     m_handle = handle;
+                     return false;
+                 }
+                 std::atomic<waitStatus>& await_resume() noexcept { return m_handle.promise().m_status; }
+             };
+ 
+             auto& status = co_await GetStatusAwaitable();
+ 
+             auto expected = waitStatus::INIT;
+             if (!status.compare_exchange_strong(expected, waitStatus::FINISHED))
+             {
+                 // 此处返回true说明外部首先设置了finished，那么需要通知外部已经执行完成了
+                 // If true is returned here, the external finish is set first, and the external
+                 // execution needs to be notified
+                 status.store(waitStatus::FINISHED);
+                 status.notify_one();
+             }
+         }(std::forward<Task>(task), result, std::forward<decltype(args)>(args)...);
+         
+         auto& status = handle.getStatus();
+         handle.start();
+ 
+         auto expected = waitStatus::INIT;
+         if (status.compare_exchange_strong(expected, waitStatus::WAITING))
+         {
+             // 此处返回true说明task还在执行中，需要等待task完成
+             // If true is returned, the task is still being executed and you need to wait for the
+             // task to complete
+             status.wait(waitStatus::WAITING);
+         }
+         if (auto* exception = std::get_if<std::exception_ptr>(std::addressof(result)))
+         {
+             std::rethrow_exception(*exception);
+         }
+ 
+         if constexpr (!std::is_void_v<ReturnType>)
+         {
+             if constexpr (std::is_reference_v<ReturnType>)
+             {
+                 return *(std::get<ReturnTypeWrap>(result));
+             }
+             else
+             {
+                 return std::move(std::get<ReturnTypeWrap>(result));
+             }
+         }
+     }
+ } syncWait{};
+ 
+ }  // namespace bcos::task
+ 

--- a/libtask/tests/TestTask.cpp
+++ b/libtask/tests/TestTask.cpp
@@ -13,12 +13,14 @@
 #include <boost/multiprecision/fwd.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/throw_exception.hpp>
+#include <atomic>
 #include <chrono>
 #include <future>
 #include <iostream>
 #include <memory_resource>
 #include <stdexcept>
 #include <thread>
+#include <vector>
 
 using namespace bcos::task;
 
@@ -288,6 +290,113 @@ BOOST_AUTO_TEST_CASE(u256)
     handle.start();
     // auto sum = syncWait(testU256());
     // BOOST_CHECK_GE(sum, 3000);
+}
+
+Task<int> crossThreadTask(std::atomic_int& activeResumers)
+{
+    struct CrossThreadAwaitable
+    {
+        std::atomic_int& active;
+        bool await_ready() const noexcept { return false; }
+        void await_suspend(std::coroutine_handle<> handle)
+        {
+            active.fetch_add(1, std::memory_order_relaxed);
+            // Bind the counter directly, not through the awaitable: the awaitable lives in
+            // the coroutine frame, which is destroyed during resume()
+            std::thread([handle, &active = active]() mutable {
+                handle.resume();
+                active.fetch_sub(1, std::memory_order_release);
+            }).detach();
+        }
+        int await_resume() const noexcept { return 42; }
+    };
+    co_return co_await CrossThreadAwaitable{.active = activeResumers};
+}
+
+BOOST_AUTO_TEST_CASE(syncWaitFastPath)
+{
+    // Fast path: the coroutine completes inline before the waiter reaches the wait,
+    // the waiter should skip waiting entirely and get the value back.
+    auto value = bcos::task::syncWait([]() -> Task<int> { co_return 42; }());
+    BOOST_CHECK_EQUAL(value, 42);
+
+    bcos::task::syncWait([]() -> Task<void> { co_return; }());
+}
+
+BOOST_AUTO_TEST_CASE(syncWaitSlowPath)
+{
+    // Slow path: the coroutine completes on another thread after the waiter has
+    // started waiting. Verifies the cross-thread notify/wake-up works and the
+    // coroutine frame stays alive through both destruction orders.
+    std::atomic_int activeResumers{0};
+    auto value = syncWait(crossThreadTask(activeResumers));
+    BOOST_CHECK_EQUAL(value, 42);
+    while (activeResumers.load(std::memory_order_acquire) != 0)
+    {
+        std::this_thread::yield();
+    }
+}
+
+BOOST_AUTO_TEST_CASE(syncWaitException)
+{
+    // The exception thrown inside the coroutine is rethrown by syncWait.
+    BOOST_CHECK_THROW(bcos::task::syncWait([]() -> Task<int> {
+        BOOST_THROW_EXCEPTION(std::runtime_error("syncWait error"));
+        co_return 0;
+    }()),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(syncTaskUnhandledException)
+{
+    // Directly exercise SyncTask's unhandled_exception path: the coroutine body
+    // throws without being caught, so control never reaches final_suspend and the
+    // reference added by start() must be released inside unhandled_exception.
+    // Otherwise the frame leaks when the SyncTask handle is destroyed.
+    for (int i = 0; i < 100; ++i)
+    {
+        auto syncTask = []() -> SyncTask {
+            BOOST_THROW_EXCEPTION(std::runtime_error("unhandled sync task error"));
+            co_return;
+        }();
+        BOOST_CHECK_THROW(syncTask.start(), std::runtime_error);
+        // ~SyncTask releases the remaining reference and destroys the frame.
+    }
+}
+
+BOOST_AUTO_TEST_CASE(syncWaitCrossThreadTeardown)
+{
+    // Regression test: syncWait used to keep the result and wake flags on the waiter's
+    // stack and let the waiter destroy the coroutine frame. When the task completed on
+    // another thread, that thread kept touching the waiter's stack and the frame after
+    // the waiter could wake and return (use-after-free, SIGSEGV in the resumer thread).
+    constexpr int WAITERS = 8;
+    constexpr int ITERATIONS = 1000;
+    std::atomic_int activeResumers{0};
+    std::atomic_int successCount{0};
+    std::vector<std::thread> waiters;
+    waiters.reserve(WAITERS);
+    for (int i = 0; i < WAITERS; ++i)
+    {
+        waiters.emplace_back([&]() {
+            for (int j = 0; j < ITERATIONS; ++j)
+            {
+                if (syncWait(crossThreadTask(activeResumers)) == 42)
+                {
+                    successCount.fetch_add(1, std::memory_order_relaxed);
+                }
+            }
+        });
+    }
+    for (auto& thread : waiters)
+    {
+        thread.join();
+    }
+    while (activeResumers.load(std::memory_order_acquire) != 0)
+    {
+        std::this_thread::yield();
+    }
+    BOOST_CHECK_EQUAL(successCount.load(), WAITERS * ITERATIONS);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Fix use-after-destroy bug in SyncWait via coroutine-frame reference counting
### 问题描述
原始 `SyncWait` 存在竞态条件导致的 use-after-destroy 问题：
1. 主线程调用 `finished.test_and_set()` 返回 `false`，进入等待
2. 协程完成后调用 `finished.test_and_set()` 返回 `true`（主线程已设置），进入通知分支
3. 协程调用 `waitFlag.test_and_set()` 和 `waitFlag.notify_one()`
4. 主线程被唤醒后直接退出函数，栈上局部变量 `waitFlag` 等被销毁
5. 协程的 `notify_one()` 内部可能还在访问 `this`，此时对象已被销毁 → UB
根因是 `finished` 和 `waitFlag` 作为栈上局部变量，其生命周期与主线程栈帧绑定，无法保证协程退出时它们仍然存活。
### 修复方案
#### 核心思路
将同步状态变量和协程帧的生命周期管理合二为一，放入协程帧内部的 promise 中，通过引用计数保证帧在双方都完成前不被释放。
#### 新增 `SyncTask` 类型（`AsyncTask.h`）
SyncTask::promise_type: m_count{2} // 引用计数，初始为 2（主线程 + 协程各持 1） m_status{waitStatus::INIT} // 三态同步变量：INIT → WAITING → FINISHED

引用计数释放时机：
- **主线程**：`~SyncTask()` 中 `m_count.fetch_sub(1)`，若 ==1 则 `handle.destroy()`
- **协程**：`final_suspend` 中 `m_count.fetch_sub(1)`，若 ==1 则 `handle.destroy()`
只有双方都递减后，最后一次递减者才销毁协程帧。在此之前的 `notify_one()` 执行期间，`m_status` 始终存活。
#### `SyncWait` 状态机（`Wait.h`）
协程侧（通过 GetStatusAwaitable 获取 promise 内的 m_status 引用）： CAS(INIT → FINISHED) - 成功：协程先完成，主线程不需要等待 - 失败：主线程已进入 WAITING，store(FINISHED) + notify_one()

主线程侧（通过 handle.getStatus() 获取引用）： CAS(INIT → WAITING) - 成功：进入慢路径，wait(WAITING) 直到被协程唤醒 - 失败：协程已完成（status == FINISHED），跳过等待


`m_status` 位于协程帧内，受 `m_count` 引用计数保护，notify_one() 执行期间不会发生 UAF。
### 方案优势
- **零额外堆分配**：`m_status` 和 `m_count` 都在协程帧中（栈上分配），无需 `shared_ptr` 的额外 `make_shared`
- **无忙等**：慢路径使用 `std::atomic::wait/notify_one` 进行 futex 同步
- **快路径零开销**：协程先完成时，主线程仅两次 CAS 即可返回
- **生命周期安全**：引用计数从根本保证 `m_status` 在双方完成前不被释放
### 改动点
**`AsyncTask.h`**：
- 新增 `waitStatus` 枚举（INIT / WAITING / FINISHED）
- 新增 `SyncTask` 类，promise 中包含 `m_count` 引用计数和 `m_status` 状态变量
- `final_suspend` 和 `~SyncTask()` 中通过引用计数管理帧生命周期
**`Wait.h`**：
- 移除栈上的 `finished` 和 `waitFlag` 两个 `boost::atomic_flag`
- lambda 返回类型从 `task::Task<void>` 改为 `task::SyncTask`
- 新增 `GetStatusAwaitable`，协程体通过 `co_await` 获取 promise 内 `m_status` 引用
- 状态机从双标志 test_and_set 改为单原子 CAS 三态切换

### Awaitable 重构说明
**原因与目的**
Awaitable 是 Task<T> 的 co_await 实现载体。每次协程内 co_await 一个 Task<T> 时，都会构造一个 Awaitable，且它作为局部对象存放在协程帧中——因此其大小直接影响协程帧的占用。

重构前 Awaitable 持有两个指针字段：

std::coroutine_handle<typename TaskType::promise_type> m_handle;  // 被 await 的任务 handle
Continuation<typename TaskType::VariantValue> m_continuation;     // 内含 handle + value
但这两个字段在时间上是互斥使用的：

await 之前：只需要"被 await 任务"的 handle（await_ready 判断是否已完成、await_suspend 返回给调度器）
await_suspend 之后：只需要"调用方协程"的 handle 和值传递槽（Continuation）
两个字段同时存活是空间浪费。重构将两者合并为一个 m_continuation：它的 handle 字段在挂起前存放被 await 任务的 handle，挂起时通过 from_address 恢复出真实类型后覆写为调用方 handle。每个挂起点节省 8 字节（一个指针）的协程帧空间，且不改变任何外部语义。

**安全性分析**
from_address 从地址重建类型化的 coroutine_handle，其正确性依赖一个不变量：

m_continuation.handle 的初始值必然是被 await 任务的 coroutine_handle<typename TaskType::promise_type>。

该不变量由唯一的构造路径保证：Awaitable 只能通过 Task::operator co_await() && 构造，即 Awaitable<Task>(m_handle)——传入的必然是本任务自身的 handle。await_suspend 的执行序列为：
 
// 恢复被 await 任务
auto nextHandle = coroutine_handle<TaskType::promise_type>::from_address(m_continuation.handle.address());
 // 覆写为调用方 handle
m_continuation.handle = handle;                                          
 // 建立续接关系
nextHandle.promise().m_continuation = std::addressof(m_continuation);    
 // 恢复被 await 任务
return nextHandle; 
                                                       
await_ready 检查的仍是 m_continuation.handle（即被 await 任务）是否已完成，语义不变
挂起返回后，m_continuation.handle 已被覆写为调用方 handle，final_suspend 通过它续接回调用方，语义不变
前提条件已用代码注释显式标注（"safe when constructed by coroutine_handleTaskType::promise_type, unsafe otherwise"）——若用户绕过 operator co_await 直接构造 Awaitable，则该不变量被破坏，from_address 不适用。这是所有场景中均不会发生的路径。
测试保障
重构波及所有 co_await Task<T> 路径，通过以下测试验证正确性：

多层嵌套 await（level1 → level2 → level3）覆盖连续挂起/续接
跨线程 resume（asyncLevel1/asyncLevel2，TBB 调度）覆盖非对称转移
异常传播（taskException、memoryLeak）覆盖异常经由 Continuation.value 传递
本次新增的 syncWaitFastPath / syncWaitSlowPath / syncWaitCrossThreadTeardown 同样经由重构后的 Awaitable 路径（syncWait 协程内 co_await task）
全部用例通过：./build/libtask/tests/test-task → *** No errors detected。