### PR TITLE
fix(ledger): empty-alloc L2 genesis publishes emptyRootHash; hoist duplicated trie test helpers

### DIFF
--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -36,6 +36,7 @@
 #include "bcos-tool/NodeConfig.h"
 #include "bcos-tool/VersionConverter.h"
 #include "bcos-utilities/Common.h"
+#include "mpt/Constants.h"
 #include <bcos-codec/scale/Scale.h>
 #include <bcos-concepts/Basic.h>
 #include <bcos-concepts/ByteBuffer.h>
@@ -1894,10 +1895,11 @@ bool Ledger::buildGenesisBlock(
         auto genesisBlockHash = co_await ledger::getBlockHash(*m_stateStorage, 0, fromStorage);
         auto genesisData = generateGenesisData(genesis, ledgerConfig);
         // op-geth-compatible Ethereum state trie over the allocs: the root is
-        // empty (zero) for pbft chains with no allocs, set as the L2 genesis
-        // block's stateRoot below, and re-derived on restart to guard alloc
-        // immutability; the produced nodes are persisted further below on
-        // first init of an L2 chain. computeGenesisStateTrie only reads
+        // empty (zero) for pbft chains with no allocs (an empty-alloc L2 chain
+        // instead publishes mpt::emptyRootHash(), see the header-building branch
+        // below), set as the L2 genesis block's stateRoot below, and re-derived
+        // on restart to guard alloc immutability; the produced nodes are
+        // persisted further below on first init of an L2 chain. computeGenesisStateTrie only reads
         // genesis.m_allocs, so it does not depend on the genesis state being
         // written first.
         GenesisStateTrie ethStateTrie;
@@ -2064,9 +2066,25 @@ bool Ledger::buildGenesisBlock(
         // — the FISCO-BCOS native stateRoot for blocks >= 1 is an XOR of
         // per-block state-change hashes, a different domain from this MPT root,
         // so only the (previously empty) genesis block carries it.
+        bool const l2EthereumCompat = std::any_of(genesis.m_features.begin(),
+            genesis.m_features.end(), [](ledger::FeatureSet const& featureSet) {
+                return featureSet.flag == Features::Flag::feature_l2_ethereum_compat &&
+                       featureSet.enable > 0;
+            });
         if (!genesis.m_allocs.empty())
         {
             header->setStateRoot(ethStateTrie.root);
+        }
+        else if (l2EthereumCompat)
+        {
+            // Empty-alloc L2 genesis: NodeConfig::validateL2Invariants rejects this
+            // combination, but buildGenesisBlock is callable directly. Publish the
+            // canonical empty-trie root instead of a zero h256 — commitTrie()
+            // recognizes only emptyRootHash() as the from-empty marker
+            // (mpt/HashBuilder.h), so a zero parent root would send block 1's
+            // incremental MPT build down the node-reading merge path and abort on
+            // the nonexistent zero-hash node.
+            header->setStateRoot(mpt::emptyRootHash());
         }
         header->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
 
@@ -2154,11 +2172,7 @@ bool Ledger::buildGenesisBlock(
         // (MPTInvariantViolation). Non-MPT chains never read these rows and get none; scenario
         // A (feature_mpt_state_root activated mid-chain) starts its first MPT block from
         // emptyRootHash() and needs no genesis nodes either.
-        if (std::any_of(genesis.m_features.begin(), genesis.m_features.end(),
-                [](ledger::FeatureSet const& featureSet) {
-                    return featureSet.flag == Features::Flag::feature_l2_ethereum_compat &&
-                           featureSet.enable > 0;
-                }))
+        if (l2EthereumCompat)
         {
             for (auto& [nodeHash, nodeRlp] : ethStateTrie.nodes)
             {

--- a/bcos-ledger/test/unittests/ledger/test_GenesisEmptyAllocL2.cpp
+++ b/bcos-ledger/test/unittests/ledger/test_GenesisEmptyAllocL2.cpp
@@ -1,0 +1,127 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file test_GenesisEmptyAllocL2.cpp
+ * @brief Empty-alloc L2 genesis must publish mpt::emptyRootHash() as the genesis
+ *        stateRoot, not a zero h256. The combination (feature_l2_ethereum_compat
+ *        + no allocs) is rejected by NodeConfig::validateL2Invariants, but
+ *        buildGenesisBlock is callable directly, and commitTrie() recognizes
+ *        only emptyRootHash() as the from-empty marker — a zero parent root
+ *        would send block 1's incremental build down the node-reading merge
+ *        path and abort on the nonexistent zero-hash node.
+ */
+#include "L2GenesisTestStorage.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/GenesisConfig.h"
+#include "bcos-ledger/Ledger.h"
+#include "bcos-ledger/LedgerMethods.h"
+#include "bcos-ledger/mpt/Constants.h"
+#include "bcos-ledger/mpt/HashBuilder.h"
+#include "bcos-task/Wait.h"
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/testutils/faker/FakeBlock.h>
+#include <boost/test/unit_test.hpp>
+#include <map>
+#include <memory>
+#include <optional>
+
+using namespace bcos;
+using namespace bcos::ledger;
+using namespace bcos::protocol;
+
+namespace bcos::test
+{
+namespace
+{
+struct GenesisEmptyAllocL2Fixture
+{
+    GenesisEmptyAllocL2Fixture() { m_blockFactory = createBlockFactory(createNormalCryptoSuite()); }
+
+    // l2 flag on, allocs empty — constructed directly, bypassing
+    // NodeConfig::validateL2Invariants (which forbids this combination).
+    static GenesisConfig makeEmptyAllocL2Genesis()
+    {
+        GenesisConfig genesisConfig;
+        genesisConfig.m_txGasLimit = 3000000000;
+        genesisConfig.m_compatibilityVersion =
+            static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_6_VERSION);
+        genesisConfig.m_features.push_back(
+            FeatureSet{Features::Flag::feature_l2_ethereum_compat, 1});
+        genesisConfig.m_chainID = "901";
+        genesisConfig.m_groupID = "group0";
+        return genesisConfig;
+    }
+
+    task::Task<bcos::h256> buildAndReadGenesisStateRoot()
+    {
+        auto storage = makeL2GenesisTestStorage();
+        auto ledger = std::make_shared<Ledger>(m_blockFactory, storage, 1);
+
+        LedgerConfig param;
+        param.setBlockNumber(0);
+        param.setHash(HashType(""));
+        param.setBlockTxCountLimit(0);
+
+        auto ok = co_await ledger::buildGenesisBlock(*ledger, makeEmptyAllocL2Genesis(), param);
+        BOOST_REQUIRE(ok);
+
+        auto block = co_await ledger::getBlockData(*ledger, 0, HEADER);
+        BOOST_REQUIRE(block);
+        co_return bcos::h256(block->blockHeader()->stateRoot());
+    }
+
+    BlockFactory::Ptr m_blockFactory;
+};
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(GenesisEmptyAllocL2Test, GenesisEmptyAllocL2Fixture)
+
+// The genesis header must carry the canonical empty-trie root (keccak(rlp(""))),
+// not a default-constructed zero h256.
+BOOST_AUTO_TEST_CASE(EmptyAllocL2GenesisPublishesEmptyRootHash)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        auto stateRoot = co_await buildAndReadGenesisStateRoot();
+        BOOST_CHECK_EQUAL(stateRoot, mpt::emptyRootHash());
+        BOOST_CHECK_NE(stateRoot, bcos::h256{});
+    }());
+}
+
+// Closing the gap end to end: block 1 hands the genesis stateRoot to commitTrie()
+// as the parent root. With emptyRootHash() it takes the from-empty build (no node
+// reads); a zero root would go down the incremental merge path and throw
+// MPTInvariantViolation on the missing zero-hash node.
+BOOST_AUTO_TEST_CASE(GenesisRootIsUsableAsCommitTrieParent)
+{
+    task::syncWait([this]() -> task::Task<void> {
+        auto priorRoot = co_await buildAndReadGenesisStateRoot();
+
+        // Empty node storage: exactly what a fresh empty-alloc chain has.
+        bcos::storage2::memory_storage::MemoryStorage<bcos::h256, bcos::bytes> nodeStorage;
+        std::map<bcos::h256, std::optional<bcos::bytes>> changes;
+        bcos::h256 key{};
+        key.data()[0] = 0xab;
+        changes[key] = bcos::bytes{0x42};
+
+        auto result = co_await mpt::commitTrie(nodeStorage, priorRoot, changes);
+
+        // Same root the stateless from-empty core derives for this single entry.
+        std::map<bcos::h256, bcos::bytes> entries{{key, bcos::bytes{0x42}}};
+        BOOST_CHECK_EQUAL(result.root, mpt::computeTrieRoot(entries).root);
+    }());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofGenerateTest.cpp
@@ -163,18 +163,6 @@ ChainCheck verifyProofChain(
     }
 }
 
-/// Build a state trie holding @p accounts into @p storage; returns the state root.
-bcos::h256 buildStateTrie(
-    MemStorage& storage, std::vector<std::pair<bcos::Address, Account>> const& accounts)
-{
-    std::map<bcos::h256, bcos::bytes> entries;
-    for (auto const& [addr, account] : accounts)
-    {
-        entries[accountKeyHash(addr)] = account.encode();
-    }
-    return seedTrieFlushed(storage, emptyRootHash(), entries).root;
-}
-
 }  // namespace
 
 BOOST_AUTO_TEST_SUITE(ProofGenerateSuite)
@@ -188,7 +176,7 @@ BOOST_AUTO_TEST_CASE(SingleAccountProofSelfVerifies)
     Account account;
     account.nonce = 1;
     account.balance = 100;
-    auto const stateRoot = buildStateTrie(storage, {{addr, account}});
+    auto const stateRoot = seedStateTrieFlushed(storage, {{addr, account}});
 
     auto result = bcos::task::syncWait(
         generateProof(storage, stateRoot, addr, std::span<bcos::h256 const>{}));
@@ -229,7 +217,7 @@ BOOST_AUTO_TEST_CASE(MultiAccountProofsSelfVerify)
         account.balance = 1000 + i;
         accounts.emplace_back(makeAddress(i), account);
     }
-    auto const stateRoot = buildStateTrie(storage, accounts);
+    auto const stateRoot = seedStateTrieFlushed(storage, accounts);
 
     for (uint8_t i : {uint8_t{1}, uint8_t{7}, uint8_t{20}})
     {
@@ -266,17 +254,17 @@ BOOST_AUTO_TEST_CASE(StorageSlotProofsIncludingExclusion)
     bcos::bytes const valueB{0x82, 0x13, 0x37};  // RLP(0x1337): 2-byte string
 
     // Build the storage trie into the SAME node storage; its root becomes account.storageRoot.
-    auto const storageRoot =
-        seedTrieFlushed(storage, emptyRootHash(),
-            {{slotKeyHash(slotA), valueA}, {slotKeyHash(slotB), valueB}})
-            .root;
+    auto const storageRoot = seedTrieFlushed(storage, emptyRootHash(),
+        {{slotKeyHash(slotA), valueA},
+            {slotKeyHash(slotB),
+                valueB}}).root;
 
     bcos::Address const addr = makeAddress(0xab);
     Account account;
     account.nonce = 5;
     account.balance = 777;
     account.storageRoot = storageRoot;
-    auto const stateRoot = buildStateTrie(storage, {{addr, account}});
+    auto const stateRoot = seedStateTrieFlushed(storage, {{addr, account}});
 
     std::vector<bcos::h256> const slots{slotA, slotB, slotMissing};
     auto result = bcos::task::syncWait(generateProof(storage, stateRoot, addr, slots));
@@ -318,7 +306,7 @@ BOOST_AUTO_TEST_CASE(AccountNotInMPTErrors)
     bcos::Address const known = makeAddress(0xab);
     Account account;
     account.nonce = 1;
-    auto const stateRoot = buildStateTrie(storage, {{known, account}});
+    auto const stateRoot = seedStateTrieFlushed(storage, {{known, account}});
 
     bcos::Address const unknown = makeAddress(0xcd);
     auto missing = bcos::task::syncWait(
@@ -375,7 +363,7 @@ BOOST_AUTO_TEST_CASE(DeterministicOutput)
         }
         accounts.emplace_back(makeAddress(i), account);
     }
-    auto const stateRoot = buildStateTrie(storage, accounts);
+    auto const stateRoot = seedStateTrieFlushed(storage, accounts);
 
     bcos::Address const addr = makeAddress(3);
     std::vector<bcos::h256> const slots{slot, makeHash(0x02)};

--- a/bcos-ledger/test/unittests/mpt/ProofVerifyTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/ProofVerifyTest.cpp
@@ -48,18 +48,6 @@ using VerifyMemStorage = bcos::storage2::memory_storage::MemoryStorage<bcos::h25
 namespace
 {
 
-/// Build a state trie holding @p accounts into @p storage; returns the state root.
-bcos::h256 buildVerifyStateTrie(
-    VerifyMemStorage& storage, std::vector<std::pair<bcos::Address, Account>> const& accounts)
-{
-    std::map<bcos::h256, bcos::bytes> entries;
-    for (auto const& [addr, account] : accounts)
-    {
-        entries[accountKeyHash(addr)] = account.encode();
-    }
-    return seedTrieFlushed(storage, emptyRootHash(), entries).root;
-}
-
 /// A generated proof plus the state root it was generated against.
 struct ProofSetup
 {
@@ -86,7 +74,7 @@ ProofSetup makeAccountWithSlots(std::vector<std::pair<bcos::h256, bcos::bytes>> 
         }
         account.storageRoot = seedTrieFlushed(storage, emptyRootHash(), slotEntries).root;
     }
-    auto const stateRoot = buildVerifyStateTrie(storage, {{addr, account}});
+    auto const stateRoot = seedStateTrieFlushed(storage, {{addr, account}});
 
     auto result = bcos::task::syncWait(
         generateProof(storage, stateRoot, addr, std::span<bcos::h256 const>(requestSlots)));
@@ -222,7 +210,7 @@ BOOST_AUTO_TEST_CASE(ExclusionAtGenerateLevel)
     VerifyMemStorage storage;
     Account account;
     account.nonce = 1;
-    auto const stateRoot = buildVerifyStateTrie(storage, {{makeAddress(0xab), account}});
+    auto const stateRoot = seedStateTrieFlushed(storage, {{makeAddress(0xab), account}});
 
     auto missing = bcos::task::syncWait(
         generateProof(storage, stateRoot, makeAddress(0xcd), std::span<bcos::h256 const>{}));

--- a/bcos-ledger/test/unittests/mpt/TestHelpers.h
+++ b/bcos-ledger/test/unittests/mpt/TestHelpers.h
@@ -25,9 +25,11 @@
 #include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <bcos-framework/storage2/Storage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/mpt/Account.h>
 #include <bcos-ledger/mpt/Classify.h>
 #include <bcos-ledger/mpt/Constants.h>
 #include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-ledger/mpt/MPTReadView.h>
 #include <bcos-ledger/mpt/Nibble.h>
 #include <bcos-ledger/mpt/NodeEncoder.h>
 #include <bcos-ledger/mpt/TrieNode.h>
@@ -106,6 +108,20 @@ inline bcos::storage::Entry makeEntry(std::string_view value)
     bcos::storage::Entry entry;
     entry.set(std::string(value));
     return entry;
+}
+
+/// Build a state trie holding @p accounts into @p storage; returns the state root.
+/// (Hoisted from the per-file copies in ProofGenerateTest.cpp / ProofVerifyTest.cpp.)
+template <typename Storage>
+bcos::h256 seedStateTrieFlushed(
+    Storage& storage, std::vector<std::pair<bcos::Address, Account>> const& accounts)
+{
+    std::map<bcos::h256, bcos::bytes> entries;
+    for (auto const& [addr, account] : accounts)
+    {
+        entries[accountKeyHash(addr)] = account.encode();
+    }
+    return seedTrieFlushed(storage, emptyRootHash(), entries).root;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Failing scenario (commit 1)

An L2 genesis with `feature_l2_ethereum_compat` and **empty** allocs leaves the genesis header's stateRoot as zero-h256: `buildGenesisBlock` sets the eth state root only when allocs are non-empty (Ledger.cpp). But the incremental build treats only `emptyRootHash()` (= keccak(rlp(""))) as the from-empty marker — `commitTrie` (HashBuilder.h) sees any other prior root as a real parent and tries to read its node, so block 1 on such a chain fails with `MPTInvariantViolation: missing node hash` (TrieMerge.h, reproduced by the red test). The combination is currently unreachable through `NodeConfig` (`validateL2Invariants` enforces flag ⟺ non-empty allocs), so this is a defensive fix at the `buildGenesisBlock` layer, which can be called directly.

**Fix**: hoist the existing l2-flag check into a local `l2EthereumCompat` (shared with the genesis node-persistence branch) and publish `mpt::emptyRootHash()` as the genesis stateRoot when the flag is set and allocs are empty. Existing chains restart through the genesis-exists early-return and never re-enter this path — no hidden hardfork.

New `test_GenesisEmptyAllocL2.cpp`: header stateRoot equals `emptyRootHash()` (red before the fix: zero), and that root is usable as a `commitTrie` parent for a block-1-style incremental build (red before: the exact missing-node failure). Negative control: disabling the guard re-produces both failures.

## Commit 2: hoist duplicated trie test helpers

`buildStateTrie` (ProofGenerateTest.cpp) and `buildVerifyStateTrie` (ProofVerifyTest.cpp) were verbatim copies (renamed only to dodge unity-build ODR). Hoisted into `TestHelpers.h` as the template `seedStateTrieFlushed<Storage>`; both files drop their local copies, seven call sites renamed, zero assertion changes. Test-only; settles the helper-dedup follow-up deferred from #5315's review round.

Full `test-bcos-ledger` passes on each commit and on the combined branch (`*** No errors detected`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
