### PR TITLE
ci: increase commit check insert limit from 300 to 600

### DIFF
--- a/tools/.ci/check-commit.sh
+++ b/tools/.ci/check-commit.sh
@@ -14,7 +14,7 @@ SHELL_FOLDER=$(
 check_script="clang-format"
 commit_limit=1000
 file_limit=35
-insert_limit=300
+insert_limit=600
 license_line=20
 
 skip_check_words="sync code|release"


### PR DESCRIPTION
## 变更说明

将 `tools/.ci/check-commit.sh` 中提交检查的 `insert_limit`（单次提交允许插入的代码行数上限）从 300 提高到 600。

## 背景

部分合法的大规模提交（如自动生成的代码、批量重构等）会超过原有的 300 行插入上限，导致 CI 提交检查误报失败。本次调整放宽该限制，避免正常提交被误拦截。

## 变更内容

- `tools/.ci/check-commit.sh`：`insert_limit` 由 `300` 调整为 `600`。

## 测试

该修改仅涉及 CI 脚本参数，不影响编译与运行逻辑。