### PR TITLE
Engine API: OP Stack protocol structures and raw EIP-2718 transaction wire codec

### DIFF
--- a/bcos-framework/bcos-framework/engine/RawTransactionDispatch.h
+++ b/bcos-framework/bcos-framework/engine/RawTransactionDispatch.h
@@ -1,0 +1,79 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file RawTransactionDispatch.h
+ * @brief First-byte dispatch table for raw EIP-2718 transaction envelopes
+ */
+
+#pragma once
+
+#include "bcos-utilities/Common.h"
+#include <cstdint>
+
+namespace bcos::engine
+{
+
+/// Category of a raw EIP-2718 transaction envelope, decided by its first byte.
+enum class RawTransactionKind : std::uint8_t
+{
+    Legacy,       ///< first byte >= 0xc0 (RLP list header)
+    AccessList,   ///< 0x01 (EIP-2930)
+    DynamicFee,   ///< 0x02 (EIP-1559)
+    Blob,         ///< 0x03 (EIP-4844) — parseable but always rejected on L2
+    SetCode,      ///< 0x04 (EIP-7702)
+    Deposit,      ///< 0x7e (OP Stack deposit)
+    Unsupported,  ///< everything else, including 0x00 and empty input
+};
+
+/// The single authoritative dispatch table for raw transaction bytes. Every entry point
+/// that admits raw transactions (eth_sendRawTransaction, the in-process mempool, Engine
+/// forkchoiceUpdated attributes.transactions and newPayload payload.transactions) must
+/// classify through this function rather than re-implementing first-byte checks.
+///
+/// Note: 0x00 is NOT a valid EIP-2718 type. Bytes in [0x05, 0x7d] and [0x7f, 0xbf] are
+/// reserved/unknown and classify as Unsupported.
+inline RawTransactionKind dispatchRawTransaction(bcos::bytesConstRef raw)
+{
+    if (raw.empty())
+    {
+        return RawTransactionKind::Unsupported;
+    }
+    switch (raw[0])
+    {
+    case 0x01:
+        return RawTransactionKind::AccessList;
+    case 0x02:
+        return RawTransactionKind::DynamicFee;
+    case 0x03:
+        return RawTransactionKind::Blob;
+    case 0x04:
+        return RawTransactionKind::SetCode;
+    case 0x7e:
+        return RawTransactionKind::Deposit;
+    default:
+        // 0xc0..0xff: RLP list header => legacy transaction.
+        return raw[0] >= 0xc0 ? RawTransactionKind::Legacy : RawTransactionKind::Unsupported;
+    }
+}
+
+/// Whether a transaction of this kind may appear inside an Engine execution payload.
+/// L2 forbids blob transactions entirely (OP Stack, Ecotone onwards) — a single blob or
+/// unsupported transaction invalidates the whole payload, it is not dropped individually.
+inline bool isRawTransactionPayloadAdmissible(RawTransactionKind kind)
+{
+    return kind != RawTransactionKind::Blob && kind != RawTransactionKind::Unsupported;
+}
+
+}  // namespace bcos::engine

--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -81,9 +81,19 @@ struct PayloadAttributes
     // Required by PayloadAttributesV3/V4.
     std::optional<h256> parentBeaconBlockRoot;
 
-    // Required by PayloadAttributesV4.
-    std::optional<std::uint64_t> slotNumber;
-    std::optional<std::uint64_t> targetGasLimit;
+    // OP Stack payload attributes (optimism/specs engine.md). All optional so that
+    // vanilla Ethereum attributes keep their current behavior when absent.
+    // EIP-2718 raw transaction hex strings, passed through verbatim without decoding;
+    // decoding/dispatch belongs to the raw-bytes carrier and type-dispatch work.
+    std::optional<std::vector<std::string>> transactions;
+    // When true the payload must not include transactions picked from the mempool.
+    std::optional<bool> noTxPool;
+    // Block gas limit dictated by the L1 SystemConfig via the CL.
+    std::optional<std::uint64_t> gasLimit;
+    // Holocene: 8 bytes = 4-byte EIP-1559 denominator followed by 4-byte elasticity.
+    std::optional<bytes> eip1559Params;
+    // Jovian: minimum base fee, in wei.
+    std::optional<std::uint64_t> minBaseFee;
 };
 
 struct ExecutionPayload
@@ -111,9 +121,10 @@ struct ExecutionPayload
     std::optional<u256> blobGasUsed;
     std::optional<u256> excessBlobGas;
 
-    // Required by ExecutionPayloadV4.
-    std::optional<bytes> blockAccessList;
-    std::optional<std::uint64_t> slotNumber;
+    // Required by ExecutionPayloadV4/V5 (OP Stack, Isthmus onwards): storage root of
+    // the L2ToL1MessagePasser predeploy. May carry a placeholder until real-value
+    // header wiring lands.
+    std::optional<h256> withdrawalsRoot;
 };
 
 struct NewPayloadRequest
@@ -167,6 +178,10 @@ struct GetPayloadData
 
     // Required by engine_getPayloadV4/V6.
     std::optional<std::vector<bytes>> executionRequests;
+
+    // OP Stack getPayload response extension: the beacon root the payload was built
+    // with, echoed back to newPayload by the CL.
+    std::optional<h256> parentBeaconBlockRoot;
 };
 
 using GetPayloadResult = std::unique_ptr<GetPayloadData>;

--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -96,6 +96,18 @@ struct PayloadAttributes
     std::optional<std::uint64_t> minBaseFee;
 };
 
+/// One Engine-API transaction. The raw EIP-2718 bytes are the canonical wire form and
+/// are preserved byte-for-byte through parse -> payload cache -> serialization (getPayload
+/// must return exactly what newPayload received). The decoded form is the executable
+/// representation where one exists: locally built payloads carry the mempool transaction
+/// here; externally received payloads and deposits carry raw bytes only until execution
+/// wiring decodes them.
+struct EngineTransaction
+{
+    bytes raw;
+    protocol::Transaction::Ptr decoded;
+};
+
 struct ExecutionPayload
 {
     // Required by ExecutionPayloadV1/V2/V3/V4.
@@ -108,7 +120,7 @@ struct ExecutionPayload
     u256 gasUsed = 0;
     u256 baseFeePerGas = 0;
     h256 blockHash;
-    bcos::protocol::Transactions transactions;
+    std::vector<EngineTransaction> transactions;
     bytes extraData;
     Address feeRecipient;
     std::uint64_t timestamp = 0;

--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -88,11 +88,19 @@ struct PayloadAttributes
     std::optional<std::vector<std::string>> transactions;
     // When true the payload must not include transactions picked from the mempool.
     std::optional<bool> noTxPool;
-    // Block gas limit dictated by the L1 SystemConfig via the CL.
+    // Block gas limit dictated by the L1 SystemConfig via the CL. 64-bit by protocol:
+    // op-node serializes it as a Uint64Quantity (op-service/eth/types.go,
+    // PayloadAttributes.GasLimit *Uint64Quantity).
     std::optional<std::uint64_t> gasLimit;
-    // Holocene: 8 bytes = 4-byte EIP-1559 denominator followed by 4-byte elasticity.
+    // Holocene: 8 bytes = 4-byte EIP-1559 denominator followed by 4-byte elasticity
+    // (op-node: EIP1559Params *Bytes8).
     std::optional<bytes> eip1559Params;
-    // Jovian: minimum base fee, in wei.
+    // Jovian: minimum base fee, in wei. 64-bit by protocol: op-node declares it as
+    // MinBaseFee *uint64 (op-service/eth/types.go) and the Jovian block-header
+    // extraData packs it as a big-endian u64 at bytes [9, 17)
+    // (specs.optimism.io jovian/exec-engine); the spec's bare "QUANTITY" wording does
+    // not widen it. Values beyond uint64 are rejected at JSON parse (strict
+    // fromQuantity), matching what the extraData encoding could never carry.
     std::optional<std::uint64_t> minBaseFee;
 };
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -20,8 +20,8 @@
 
 #include "EngineEndpoint.h"
 #include <bcos-rpc/jsonrpc/Common.h>
-#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 #include <bcos-utilities/DataConvertUtility.h>
 
@@ -88,8 +88,7 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV3(
     co_await handleForkchoiceUpdated(engine::ApiVersion::V3, request, response);
 }
 
-task::Task<void> EngineEndpoint::forkchoiceUpdatedV4(
-    const Json::Value&, Json::Value& response)
+task::Task<void> EngineEndpoint::forkchoiceUpdatedV4(const Json::Value&, Json::Value& response)
 {
     // V4 not yet implemented (Prague fork)
     Json::Value request;
@@ -111,37 +110,32 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
     auto forkchoiceState = parseForkchoiceState(request);
     auto payloadAttrs = parsePayloadAttributes(request, version);
     // TODO: engineService->updateForkchoice() MUST throw JsonRpcException in these cases:
-    //   -38002 InvalidForkchoiceState: headBlockHash is VALID but finalizedBlockHash/safeBlockHash not in chain
-    //   -38003 InvalidPayloadAttributes: payloadAttributes.timestamp <= headBlockHash.timestamp
-    //   -38005 UnsupportedFork: timestamp out of fork window (V2/V3 specific)
-    //   -38006 TooDeepReorg: reorg depth exceeds limitation
-    auto engineResult = co_await engineService->updateForkchoice(
-        forkchoiceState, payloadAttrs.has_value() ? &*payloadAttrs : nullptr,
-        static_cast<uint32_t>(version));
+    //   -38002 InvalidForkchoiceState: headBlockHash is VALID but finalizedBlockHash/safeBlockHash
+    //   not in chain -38003 InvalidPayloadAttributes: payloadAttributes.timestamp <=
+    //   headBlockHash.timestamp -38005 UnsupportedFork: timestamp out of fork window (V2/V3
+    //   specific) -38006 TooDeepReorg: reorg depth exceeds limitation
+    auto engineResult = co_await engineService->updateForkchoice(forkchoiceState,
+        payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
     auto jsonResult = combineForkchoiceUpdatedResult(engineResult, version);
     buildJsonContent(jsonResult, response);
 }
 
-task::Task<void> EngineEndpoint::getPayloadV1(
-    const Json::Value& request, Json::Value& response)
+task::Task<void> EngineEndpoint::getPayloadV1(const Json::Value& request, Json::Value& response)
 {
     co_await handleGetPayload(engine::ApiVersion::V1, request, response);
 }
 
-task::Task<void> EngineEndpoint::getPayloadV2(
-    const Json::Value& request, Json::Value& response)
+task::Task<void> EngineEndpoint::getPayloadV2(const Json::Value& request, Json::Value& response)
 {
     co_await handleGetPayload(engine::ApiVersion::V2, request, response);
 }
 
-task::Task<void> EngineEndpoint::getPayloadV3(
-    const Json::Value& request, Json::Value& response)
+task::Task<void> EngineEndpoint::getPayloadV3(const Json::Value& request, Json::Value& response)
 {
     co_await handleGetPayload(engine::ApiVersion::V3, request, response);
 }
 
-task::Task<void> EngineEndpoint::getPayloadV4(
-    const Json::Value&, Json::Value& response)
+task::Task<void> EngineEndpoint::getPayloadV4(const Json::Value&, Json::Value& response)
 {
     // V4 not yet implemented (Prague fork)
     Json::Value request;
@@ -161,8 +155,8 @@ task::Task<void> EngineEndpoint::handleGetPayload(
     }
 
     engine::PayloadID payloadId = request[0u].asString();
-    auto engineResult = co_await engineService->getPayload(
-        payloadId, static_cast<uint32_t>(version));
+    auto engineResult =
+        co_await engineService->getPayload(payloadId, static_cast<uint32_t>(version));
     if (!engineResult)
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnknownPayload,
@@ -174,26 +168,22 @@ task::Task<void> EngineEndpoint::handleGetPayload(
     buildJsonContent(result, response);
 }
 
-task::Task<void> EngineEndpoint::newPayloadV1(
-    const Json::Value& request, Json::Value& response)
+task::Task<void> EngineEndpoint::newPayloadV1(const Json::Value& request, Json::Value& response)
 {
     co_await handleNewPayload(engine::ApiVersion::V1, request, response);
 }
 
-task::Task<void> EngineEndpoint::newPayloadV2(
-    const Json::Value& request, Json::Value& response)
+task::Task<void> EngineEndpoint::newPayloadV2(const Json::Value& request, Json::Value& response)
 {
     co_await handleNewPayload(engine::ApiVersion::V2, request, response);
 }
 
-task::Task<void> EngineEndpoint::newPayloadV3(
-    const Json::Value& request, Json::Value& response)
+task::Task<void> EngineEndpoint::newPayloadV3(const Json::Value& request, Json::Value& response)
 {
     co_await handleNewPayload(engine::ApiVersion::V3, request, response);
 }
 
-task::Task<void> EngineEndpoint::newPayloadV4(
-    const Json::Value&, Json::Value& response)
+task::Task<void> EngineEndpoint::newPayloadV4(const Json::Value&, Json::Value& response)
 {
     // V4 not yet implemented (Prague fork)
     Json::Value request;
@@ -212,13 +202,12 @@ task::Task<void> EngineEndpoint::handleNewPayload(
         co_return;
     }
 
-    auto newPayloadReq =
-        parseNewPayloadRequest(request, *m_nodeService->blockFactory()->transactionFactory(), version);
+    auto newPayloadReq = parseNewPayloadRequest(request, version);
     // TODO: engineService->newPayload() MUST throw JsonRpcException in these cases:
     //   -32602 InvalidParams: wrong version of ExecutionPayload structure (V2)
     //   -38005 UnsupportedFork: timestamp out of fork window (V2/V3)
-    auto engineResult = co_await engineService->newPayload(
-        newPayloadReq, static_cast<uint32_t>(version));
+    auto engineResult =
+        co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
     auto result = serializePayloadStatus(engineResult, version);
     buildJsonContent(result, response);
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -19,11 +19,12 @@
  */
 
 #include "EthEndpoint.h"
+#include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/Ledger.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-ledger/LedgerMethods.h"
 #include "bcos-mempool/MemPoolImpl.h"
-#include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-protocol/TransactionStatus.h"
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPDecode.h>
@@ -425,6 +426,20 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     auto rawTx = toView(request[0U]);
     auto rawTxBytes = fromHexWithPrefix(rawTx);
     auto bytesRef = bcos::ref(rawTxBytes);
+    // Authoritative first-byte dispatch (RawTransactionDispatch.h). L2 never admits blob
+    // (type-3) transactions, and deposits (0x7e) can only be injected by the consensus
+    // layer through the Engine API, never through the public transaction pool.
+    switch (engine::dispatchRawTransaction(bytesRef))
+    {
+    case engine::RawTransactionKind::Blob:
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "blob transactions are not supported"));
+    case engine::RawTransactionKind::Deposit:
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "deposit transactions cannot be submitted via eth_sendRawTransaction"));
+    default:
+        break;
+    }
     Web3Transaction web3Tx;
     if (auto const error = codec::rlp::decode(bytesRef, web3Tx); error != nullptr) [[unlikely]]
     {
@@ -494,8 +509,7 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
         {
             WEB3_LOG(WARNING) << LOG_DESC("sendRawTransaction mempool verify failed")
                               << LOG_KV("reason", boost::diagnostic_information(e));
-            BOOST_THROW_EXCEPTION(
-                JsonRpcException(InvalidParams, "invalid transaction signature"));
+            BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "invalid transaction signature"));
         }
         std::vector<protocol::Transaction::Ptr> txs;
         txs.push_back(std::move(tx));

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.cpp
@@ -1,0 +1,154 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file DepositTransaction.cpp
+ * @brief OP Stack 0x7E deposit transaction: raw-bytes decoding and geth-shaped JSON
+ */
+
+#include "DepositTransaction.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-crypto/ChecksumAddress.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-rpc/web3jsonrpc/utils/util.h>
+
+using namespace bcos;
+using namespace bcos::codec::rlp;
+
+bcos::Error::UniquePtr bcos::rpc::decodeDepositTransaction(
+    bcos::bytesRef& in, DepositTransaction& out) noexcept
+{
+    if (in.empty() || in[0] != c_depositTxType)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(
+            UnexpectedEip2718Serialization, "Not a 0x7e deposit transaction envelope");
+    }
+    in = in.getCroppedData(1);
+    auto&& [error, header] = decodeHeader(in);
+    if (error != nullptr)
+    {
+        return std::move(error);
+    }
+    if (!header.isList)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(UnexpectedString, "Deposit transaction body must be a list");
+    }
+    if (header.payloadLength > in.size())
+    {
+        return BCOS_ERROR_UNIQUE_PTR(InputTooShort, "Deposit transaction body too short");
+    }
+    bytesRef body(in.data(), header.payloadLength);
+
+    if (auto fieldError = decodeItems(body, out.sourceHash, out.from); fieldError != nullptr)
+    {
+        return fieldError;
+    }
+    // `to`: empty RLP item = contract creation (same convention as every Ethereum tx type).
+    if (body.empty())
+    {
+        return BCOS_ERROR_UNIQUE_PTR(InputTooShort, "Deposit transaction missing to field");
+    }
+    if (body[0] == BYTES_HEAD_BASE)
+    {
+        out.to = std::nullopt;
+        body = body.getCroppedData(1);
+    }
+    else
+    {
+        Address to{};
+        if (auto fieldError = decode(body, to); fieldError != nullptr)
+        {
+            return fieldError;
+        }
+        out.to.emplace(to);
+    }
+    // `mint`: empty RLP item = no mint. op-geth encodes a nil *big.Int as the empty item
+    // and decodes the empty item back to nil — on the wire nil and zero are the same
+    // (both encode to 0x80), so nullopt here matches op-geth's decode-side behavior.
+    if (body.empty())
+    {
+        return BCOS_ERROR_UNIQUE_PTR(InputTooShort, "Deposit transaction missing mint field");
+    }
+    if (body[0] == BYTES_HEAD_BASE)
+    {
+        out.mint = std::nullopt;
+        body = body.getCroppedData(1);
+    }
+    else
+    {
+        u256 mint{0};
+        if (auto fieldError = decode(body, mint); fieldError != nullptr)
+        {
+            return fieldError;
+        }
+        out.mint.emplace(mint);
+    }
+    // isSystemTx decodes as an integer: RLP-canonical false is the EMPTY item (0x80,
+    // zero-length payload — op-geth encodes Go bools that way), which the shared
+    // decode(bool&) rejects because it requires exactly one payload byte.
+    uint64_t isSystemTxValue = 0;
+    if (auto fieldError = decodeItems(body, out.value, out.gas, isSystemTxValue, out.input);
+        fieldError != nullptr)
+    {
+        return fieldError;
+    }
+    out.isSystemTx = isSystemTxValue != 0;
+    if (!body.empty())
+    {
+        return BCOS_ERROR_UNIQUE_PTR(
+            UnexpectedListElements, "Trailing bytes in deposit transaction body");
+    }
+    in = in.getCroppedData(header.payloadLength);
+    return nullptr;
+}
+
+void bcos::rpc::combineDepositTxResponse(Json::Value& result, const DepositTransaction& deposit)
+{
+    result["type"] = toQuantity(static_cast<uint64_t>(c_depositTxType));
+    result["sourceHash"] = deposit.sourceHash.hexPrefixed();
+    auto from = deposit.from.hex();
+    toChecksumAddress(from, bcos::crypto::keccak256Hash(bcos::bytesConstRef(from)).hex());
+    result["from"] = "0x" + std::move(from);
+    if (deposit.to.has_value())
+    {
+        auto to = deposit.to->hex();
+        toChecksumAddress(to, bcos::crypto::keccak256Hash(bcos::bytesConstRef(to)).hex());
+        result["to"] = "0x" + std::move(to);
+    }
+    else
+    {
+        result["to"] = Json::nullValue;
+    }
+    result["gas"] = toQuantity(deposit.gas);
+    result["value"] = toQuantity(deposit.value);
+    result["input"] = toHexStringWithPrefix(deposit.input);
+    if (deposit.mint.has_value())
+    {
+        // op-geth omits mint when nil and emits it when present (json:"mint,omitempty").
+        result["mint"] = toQuantity(*deposit.mint);
+    }
+    if (deposit.isSystemTx)
+    {
+        // op-geth emits isSystemTx only when true.
+        result["isSystemTx"] = true;
+    }
+    // Deposits carry no nonce (the deposit nonce lives in the receipt), no gas price and
+    // no signature; op-geth emits zero quantities for these.
+    result["nonce"] = "0x0";
+    result["gasPrice"] = "0x0";
+    result["v"] = "0x0";
+    result["r"] = "0x0";
+    result["s"] = "0x0";
+}

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.h
@@ -1,0 +1,69 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file DepositTransaction.h
+ * @brief OP Stack 0x7E deposit transaction: raw-bytes decoding and geth-shaped JSON
+ */
+
+#pragma once
+
+#include <bcos-crypto/interfaces/crypto/CommonType.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/Error.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <json/json.h>
+#include <optional>
+
+namespace bcos::rpc
+{
+
+/// EIP-2718 type byte of an OP Stack deposit transaction.
+inline constexpr uint8_t c_depositTxType = 0x7e;
+
+/// Decoded form of an OP Stack deposit transaction (0x7E). Field set and semantics follow
+/// op-geth core/types.DepositTx and the executor-side DepositTx in
+/// bcos-evm/bcos-evm/opstack/OpTransition.h. This is the wire-decoding twin used by the
+/// RPC layer; execution wiring converts it to the evmone-facing representation.
+struct DepositTransaction
+{
+    crypto::HashType sourceHash;
+    Address from;
+    std::optional<Address> to;  ///< nullopt = contract creation
+    std::optional<u256> mint;   ///< nullopt = no mint (RLP empty item, op-geth *big.Int nil)
+    u256 value{0};
+    uint64_t gas{0};
+    bool isSystemTx{false};
+    bytes input;
+};
+
+/// Decode `0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data])` from
+/// the full raw envelope (type byte included). Consumes the decoded bytes from `in`;
+/// trailing bytes inside the RLP list are an error. Returns nullptr on success.
+///
+/// Display-grade, not consensus-grade: bytes after the RLP list are not rejected,
+/// non-canonical integer encodings are accepted, and over-long uint64 payloads truncate.
+/// Execution wiring must NOT reuse this decoder for consensus-side validation.
+bcos::Error::UniquePtr decodeDepositTransaction(
+    bcos::bytesRef& in, DepositTransaction& out) noexcept;
+
+/// Fill `result` with the deposit-specific JSON fields in op-geth's RPC shape
+/// (internal/ethapi RPCTransaction): type 0x7e, sourceHash, from, to (null for creation),
+/// gas, value, input, mint (only when present), isSystemTx (only when true). Fields
+/// without deposit semantics follow op-geth: nonce/gasPrice/v/r/s are 0x0 (the deposit
+/// nonce lives in the receipt and is filled by the receipt path once available), and no
+/// chainId is emitted.
+void combineDepositTxResponse(Json::Value& result, const DepositTransaction& deposit);
+
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -1,4 +1,5 @@
 #include "TransactionResponse.h"
+#include "bcos-rpc/web3jsonrpc/model/DepositTransaction.h"
 #include "bcos-rpc/web3jsonrpc/model/Web3Transaction.h"
 #include <bcos-crypto/hash/Keccak256.h>
 
@@ -43,6 +44,33 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
     result["gasPrice"] = toQuantity(gasPrice.value_or(0));
     result["hash"] = tx.hash().hexPrefixed();
     result["input"] = toHexStringWithPrefix(tx.input());
+
+    // OP Stack deposit (0x7e): extraTransactionBytes carries the full raw envelope, and
+    // the geth-shaped deposit fields (sourceHash/mint/isSystemTx, zero nonce/gasPrice and
+    // zero v/r/s — deposits are unsigned) come from decoding it. Return early: the
+    // signature-derived fields below have no deposit semantics.
+    if (auto extraBytes = tx.extraTransactionBytes();
+        !extraBytes.empty() && extraBytes[0] == c_depositTxType)
+    {
+        DepositTransaction deposit;
+        auto rawCursor = bcos::bytesRef(const_cast<byte*>(extraBytes.data()), extraBytes.size());
+        if (auto error = decodeDepositTransaction(rawCursor, deposit); error == nullptr)
+        {
+            combineDepositTxResponse(result, deposit);
+        }
+        else
+        {
+            // Undecodable deposit bytes: keep the generic fields already filled and mark
+            // the type; never fall through to the Web3 payload decoder (wrong format) or
+            // to the signature fields (deposits carry none).
+            result["type"] = toQuantity(static_cast<uint64_t>(c_depositTxType));
+            result["nonce"] = "0x0";
+            result["v"] = "0x0";
+            result["r"] = "0x0";
+            result["s"] = "0x0";
+        }
+        return;
+    }
 
     if (tx.type() == bcos::protocol::TransactionType::BCOSTransaction) [[unlikely]]
     {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "EngineHelper.h"
-#include <bcos-framework/protocol/TransactionFactory.h>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -29,8 +28,8 @@ namespace
 constexpr std::size_t c_eip1559ParamsBytes = 8;
 }  // namespace
 
-bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(Json::Value const& params,
-    bcos::protocol::TransactionFactory& transactionFactory, engine::ApiVersion version)
+bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
+    Json::Value const& params, engine::ApiVersion version)
 {
     auto const& ep = params[0u];
     bcos::engine::ExecutionPayload payload{
@@ -71,11 +70,22 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(Json::Value co
     }
     if (ep.isMember("transactions") && !ep["transactions"].isNull())
     {
+        // Raw EIP-2718 bytes, hex-decoded verbatim. No transaction decoding happens
+        // here — getPayload must later return exactly these bytes.
         payload.transactions.reserve(ep["transactions"].size());
-        for (auto const& tx : ep["transactions"])
+        for (auto const& transaction : ep["transactions"])
         {
-            auto txData = fromHex(tx.asString());
-            payload.transactions.push_back(transactionFactory.decodeTransaction(ref(txData)));
+            bcos::engine::EngineTransaction engineTx;
+            try
+            {
+                engineTx.raw = fromHex(transaction.asString());
+            }
+            catch (std::exception const&)
+            {
+                BOOST_THROW_EXCEPTION(JsonRpcException(
+                    InvalidParams, "Expected hex string entries in executionPayload.transactions"));
+            }
+            payload.transactions.push_back(std::move(engineTx));
         }
     }
     if (ep.isMember("withdrawals") && !ep["withdrawals"].isNull())
@@ -339,9 +349,9 @@ Json::Value bcos::rpc::serializeExecutionPayload(
     Json::Value transactions(Json::arrayValue);
     for (auto const& transaction : payload.transactions)
     {
-        bytes encoded;
-        transaction->encode(encoded);
-        transactions.append(toHexStringWithPrefix(encoded));
+        // Raw EIP-2718 bytes out, exactly as carried — byte-for-byte what newPayload
+        // received or what buildPayload reassembled.
+        transactions.append(toHexStringWithPrefix(transaction.raw));
     }
     ep["transactions"] = std::move(transactions);
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -274,13 +274,34 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
         }
         attrs.noTxPool = pa["noTxPool"].asBool();
     }
+    // The three fields below wrap their conversions: fromQuantity / fromHex throw plain
+    // std::exception subclasses (malformed input, uint64 overflow), which the RPC entry
+    // point would surface as InternalError — a client input error must map to
+    // InvalidParams naming the field instead.
     if (pa.isMember("gasLimit") && !pa["gasLimit"].isNull())
     {
-        attrs.gasLimit = fromQuantity(std::string(pa["gasLimit"].asString()));
+        try
+        {
+            attrs.gasLimit = fromQuantity(std::string(pa["gasLimit"].asString()));
+        }
+        catch (std::exception const&)
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "Expected uint64 quantity for payloadAttributes.gasLimit"));
+        }
     }
     if (pa.isMember("eip1559Params") && !pa["eip1559Params"].isNull())
     {
-        auto paramsBytes = fromHex(pa["eip1559Params"].asString());
+        bytes paramsBytes;
+        try
+        {
+            paramsBytes = fromHex(pa["eip1559Params"].asString());
+        }
+        catch (std::exception const&)
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "Expected hex string for payloadAttributes.eip1559Params"));
+        }
         if (paramsBytes.size() != c_eip1559ParamsBytes)
         {
             BOOST_THROW_EXCEPTION(JsonRpcException(
@@ -291,7 +312,15 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
     }
     if (pa.isMember("minBaseFee") && !pa["minBaseFee"].isNull())
     {
-        attrs.minBaseFee = fromQuantity(std::string(pa["minBaseFee"].asString()));
+        try
+        {
+            attrs.minBaseFee = fromQuantity(std::string(pa["minBaseFee"].asString()));
+        }
+        catch (std::exception const&)
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "Expected uint64 quantity for payloadAttributes.minBaseFee"));
+        }
     }
     return attrs;
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -26,6 +26,40 @@ namespace
 {
 /// Holocene eip1559Params: 4-byte denominator followed by 4-byte elasticity.
 constexpr std::size_t c_eip1559ParamsBytes = 8;
+
+/// Validate and decode one element of a JSON `transactions` array. The element must be
+/// a string, "0x"-prefixed and valid hex. Shared by the payloadAttributes and the
+/// executionPayload parse paths so both reject malformed entries with the same
+/// InvalidParams shape, naming the offending index.
+bcos::bytes parseRawTransactionElement(
+    Json::Value const& element, char const* container, Json::ArrayIndex index)
+{
+    auto reject = [&]() -> bcos::bytes {
+        BOOST_THROW_EXCEPTION(bcos::rpc::JsonRpcException(bcos::rpc::InvalidParams,
+            std::string(container) + ".transactions[" + std::to_string(index) +
+                "] must be a 0x-prefixed hex string"));
+    };
+    if (!element.isString())
+    {
+        return reject();
+    }
+    auto const hex = element.asString();
+    // <= 2 also rejects a bare "0x" (empty transaction); the odd-length check matters
+    // because bcos::fromHex silently left-pads odd-length input with a '0' nibble,
+    // which would break the "hex-decoded verbatim" byte-fidelity contract.
+    if (hex.size() <= 2 || hex.size() % 2 != 0 || hex[0] != '0' || (hex[1] != 'x' && hex[1] != 'X'))
+    {
+        return reject();
+    }
+    try
+    {
+        return bcos::fromHex(hex);
+    }
+    catch (std::exception const&)
+    {
+        return reject();
+    }
+}
 }  // namespace
 
 bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
@@ -70,22 +104,20 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
     }
     if (ep.isMember("transactions") && !ep["transactions"].isNull())
     {
+        if (!ep["transactions"].isArray())
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "Expected array of hex strings for executionPayload.transactions"));
+        }
         // Raw EIP-2718 bytes, hex-decoded verbatim. No transaction decoding happens
         // here — getPayload must later return exactly these bytes.
         payload.transactions.reserve(ep["transactions"].size());
-        for (auto const& transaction : ep["transactions"])
+        for (Json::ArrayIndex i = 0; i < ep["transactions"].size(); ++i)
         {
-            bcos::engine::EngineTransaction engineTx;
-            try
-            {
-                engineTx.raw = fromHex(transaction.asString());
-            }
-            catch (std::exception const&)
-            {
-                BOOST_THROW_EXCEPTION(JsonRpcException(
-                    InvalidParams, "Expected hex string entries in executionPayload.transactions"));
-            }
-            payload.transactions.push_back(std::move(engineTx));
+            payload.transactions.push_back(bcos::engine::EngineTransaction{
+                .raw = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i),
+                .decoded = nullptr,
+            });
         }
     }
     if (ep.isMember("withdrawals") && !ep["withdrawals"].isNull())
@@ -222,14 +254,24 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
         }
         std::vector<std::string> transactions;
         transactions.reserve(pa["transactions"].size());
-        for (auto const& transaction : pa["transactions"])
+        for (Json::ArrayIndex i = 0; i < pa["transactions"].size(); ++i)
         {
-            transactions.push_back(transaction.asString());
+            // Validate shape and hex, but keep the original string verbatim — the
+            // forced-transaction list must pass through byte-identical.
+            parseRawTransactionElement(pa["transactions"][i], "payloadAttributes", i);
+            transactions.push_back(pa["transactions"][i].asString());
         }
         attrs.transactions = std::move(transactions);
     }
     if (pa.isMember("noTxPool") && !pa["noTxPool"].isNull())
     {
+        // Strict: jsoncpp asBool() silently converts numbers/strings, so gate on the
+        // JSON type (op-node serializes NoTxPool as a JSON bool).
+        if (!pa["noTxPool"].isBool())
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "Expected boolean for payloadAttributes.noTxPool"));
+        }
         attrs.noTxPool = pa["noTxPool"].asBool();
     }
     if (pa.isMember("gasLimit") && !pa["gasLimit"].isNull())

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -100,7 +100,12 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(Json::Value co
     {
         payload.excessBlobGas = fromBigQuantity(ep["excessBlobGas"].asString());
     }
-    if (ep.isMember("withdrawalsRoot") && !ep["withdrawalsRoot"].isNull())
+    // withdrawalsRoot is an ExecutionPayloadV4+ field (Isthmus). For V1-V3 requests it
+    // is ignored rather than rejected: the Isthmus spec leaves pre-V4 handling
+    // unspecified and op-geth's NewPayloadV3 (eth/catalyst/api.go) performs no
+    // withdrawalsRoot validation, so rejecting here would diverge from op-geth.
+    if (version >= engine::ApiVersion::V4 && ep.isMember("withdrawalsRoot") &&
+        !ep["withdrawalsRoot"].isNull())
     {
         payload.withdrawalsRoot = parseH256(ep["withdrawalsRoot"].asString());
     }
@@ -362,7 +367,8 @@ Json::Value bcos::rpc::serializeExecutionPayload(
     {
         ep["excessBlobGas"] = toQuantity(*payload.excessBlobGas);
     }
-    if (payload.withdrawalsRoot.has_value())
+    // V4+ only (Isthmus): never emitted in V1-V3 payload shapes.
+    if (version >= engine::ApiVersion::V4 && payload.withdrawalsRoot.has_value())
     {
         ep["withdrawalsRoot"] = payload.withdrawalsRoot->hexPrefixed();
     }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -23,9 +23,14 @@
 using namespace bcos;
 using namespace bcos::rpc;
 
-bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
-    Json::Value const& params, bcos::protocol::TransactionFactory& transactionFactory,
-    engine::ApiVersion version)
+namespace
+{
+/// Holocene eip1559Params: 4-byte denominator followed by 4-byte elasticity.
+constexpr std::size_t c_eip1559ParamsBytes = 8;
+}  // namespace
+
+bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(Json::Value const& params,
+    bcos::protocol::TransactionFactory& transactionFactory, engine::ApiVersion version)
 {
     auto const& ep = params[0u];
     bcos::engine::ExecutionPayload payload{
@@ -42,13 +47,12 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .extraData = {},
         .feeRecipient = parseAddress(ep["feeRecipient"].asString()),
         .timestamp = fromQuantity(std::string(ep["timestamp"].asString())),
-        .blockNumber = static_cast<bcos::protocol::BlockNumber>(
-            fromQuantity(ep["blockNumber"].asString())),
+        .blockNumber =
+            static_cast<bcos::protocol::BlockNumber>(fromQuantity(ep["blockNumber"].asString())),
         .withdrawals = std::nullopt,
         .blobGasUsed = std::nullopt,
         .excessBlobGas = std::nullopt,
-        .blockAccessList = std::nullopt,
-        .slotNumber = std::nullopt,
+        .withdrawalsRoot = std::nullopt,
     };
     if (ep.isMember("extraData"))
     {
@@ -59,9 +63,9 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         auto bloomBytes = fromHex(ep["logsBloom"].asString());
         if (bloomBytes.size() != BloomBytesSize)
         {
-            BOOST_THROW_EXCEPTION(JsonRpcException(
-                InvalidParams, "Expected 256-byte hex string for logsBloom, got " +
-                                   std::to_string(bloomBytes.size()) + " bytes"));
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "Expected 256-byte hex string for logsBloom, got " +
+                                                    std::to_string(bloomBytes.size()) + " bytes"));
         }
         std::copy(bloomBytes.begin(), bloomBytes.end(), payload.logsBloom.begin());
     }
@@ -96,6 +100,10 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
     {
         payload.excessBlobGas = fromBigQuantity(ep["excessBlobGas"].asString());
     }
+    if (ep.isMember("withdrawalsRoot") && !ep["withdrawalsRoot"].isNull())
+    {
+        payload.withdrawalsRoot = parseH256(ep["withdrawalsRoot"].asString());
+    }
 
     bcos::engine::NewPayloadRequest request{
         .executionPayload = std::move(payload),
@@ -103,16 +111,14 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .parentBeaconBlockRoot = std::nullopt,
         .executionRequests = std::nullopt,
     };
-    if (version >= engine::ApiVersion::V3 &&
-        params.size() >= 2 && params[1].isArray())
+    if (version >= engine::ApiVersion::V3 && params.size() >= 2 && params[1].isArray())
     {
         for (auto const& h : params[1])
         {
             request.expectedBlobVersionedHashes.push_back(parseH256(h.asString()));
         }
     }
-    if (version >= engine::ApiVersion::V3 &&
-        params.size() >= 3 && !params[2].isNull())
+    if (version >= engine::ApiVersion::V3 && params.size() >= 3 && !params[2].isNull())
     {
         request.parentBeaconBlockRoot = parseH256(params[2].asString());
     }
@@ -138,10 +144,7 @@ Json::Value bcos::rpc::serializePayloadStatus(
         result["status"] = "ACCEPTED";
         break;
     case bcos::engine::PayloadValidationStatus::InvalidBlockHash:
-        result["status"] =
-            (version >= engine::ApiVersion::V3) ?
-                "INVALID" :
-                "INVALID_BLOCK_HASH";
+        result["status"] = (version >= engine::ApiVersion::V3) ? "INVALID" : "INVALID_BLOCK_HASH";
         break;
     }
     if (status.latestValidHash.has_value())
@@ -169,8 +172,11 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
         .timestamp = fromQuantity(std::string(pa["timestamp"].asString())),
         .withdrawals = std::nullopt,
         .parentBeaconBlockRoot = std::nullopt,
-        .slotNumber = std::nullopt,
-        .targetGasLimit = std::nullopt,
+        .transactions = std::nullopt,
+        .noTxPool = std::nullopt,
+        .gasLimit = std::nullopt,
+        .eip1559Params = std::nullopt,
+        .minBaseFee = std::nullopt,
     };
     if (pa.isMember("withdrawals") && !pa["withdrawals"].isNull())
     {
@@ -190,7 +196,99 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
     {
         attrs.parentBeaconBlockRoot = parseH256(pa["parentBeaconBlockRoot"].asString());
     }
+    // OP Stack attributes. Raw transaction hex strings are stored verbatim without
+    // decoding — the Engine transaction codec consumes them downstream.
+    if (pa.isMember("transactions") && !pa["transactions"].isNull())
+    {
+        if (!pa["transactions"].isArray())
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "Expected array of hex strings for payloadAttributes.transactions"));
+        }
+        std::vector<std::string> transactions;
+        transactions.reserve(pa["transactions"].size());
+        for (auto const& transaction : pa["transactions"])
+        {
+            transactions.push_back(transaction.asString());
+        }
+        attrs.transactions = std::move(transactions);
+    }
+    if (pa.isMember("noTxPool") && !pa["noTxPool"].isNull())
+    {
+        attrs.noTxPool = pa["noTxPool"].asBool();
+    }
+    if (pa.isMember("gasLimit") && !pa["gasLimit"].isNull())
+    {
+        attrs.gasLimit = fromQuantity(std::string(pa["gasLimit"].asString()));
+    }
+    if (pa.isMember("eip1559Params") && !pa["eip1559Params"].isNull())
+    {
+        auto paramsBytes = fromHex(pa["eip1559Params"].asString());
+        if (paramsBytes.size() != c_eip1559ParamsBytes)
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                InvalidParams, "Expected 8-byte hex string for eip1559Params, got " +
+                                   std::to_string(paramsBytes.size()) + " bytes"));
+        }
+        attrs.eip1559Params = std::move(paramsBytes);
+    }
+    if (pa.isMember("minBaseFee") && !pa["minBaseFee"].isNull())
+    {
+        attrs.minBaseFee = fromQuantity(std::string(pa["minBaseFee"].asString()));
+    }
     return attrs;
+}
+
+Json::Value bcos::rpc::serializePayloadAttributes(bcos::engine::PayloadAttributes const& attrs)
+{
+    Json::Value pa(Json::objectValue);
+    pa["timestamp"] = toQuantity(attrs.timestamp);
+    pa["prevRandao"] = attrs.prevRandao.hexPrefixed();
+    pa["suggestedFeeRecipient"] = attrs.suggestedFeeRecipient.hexPrefixed();
+    if (attrs.withdrawals.has_value())
+    {
+        Json::Value withdrawals(Json::arrayValue);
+        for (auto const& w : *attrs.withdrawals)
+        {
+            Json::Value item(Json::objectValue);
+            item["index"] = toQuantity(w.index);
+            item["validatorIndex"] = toQuantity(w.validatorIndex);
+            item["address"] = w.address.hexPrefixed();
+            item["amount"] = toQuantity(w.amount);
+            withdrawals.append(std::move(item));
+        }
+        pa["withdrawals"] = std::move(withdrawals);
+    }
+    if (attrs.parentBeaconBlockRoot.has_value())
+    {
+        pa["parentBeaconBlockRoot"] = attrs.parentBeaconBlockRoot->hexPrefixed();
+    }
+    if (attrs.transactions.has_value())
+    {
+        Json::Value transactions(Json::arrayValue);
+        for (auto const& transaction : *attrs.transactions)
+        {
+            transactions.append(transaction);
+        }
+        pa["transactions"] = std::move(transactions);
+    }
+    if (attrs.noTxPool.has_value())
+    {
+        pa["noTxPool"] = *attrs.noTxPool;
+    }
+    if (attrs.gasLimit.has_value())
+    {
+        pa["gasLimit"] = toQuantity(*attrs.gasLimit);
+    }
+    if (attrs.eip1559Params.has_value())
+    {
+        pa["eip1559Params"] = toHexStringWithPrefix(*attrs.eip1559Params);
+    }
+    if (attrs.minBaseFee.has_value())
+    {
+        pa["minBaseFee"] = toQuantity(*attrs.minBaseFee);
+    }
+    return pa;
 }
 
 bcos::engine::ForkchoiceState bcos::rpc::parseForkchoiceState(Json::Value const& params)
@@ -264,12 +362,15 @@ Json::Value bcos::rpc::serializeExecutionPayload(
     {
         ep["excessBlobGas"] = toQuantity(*payload.excessBlobGas);
     }
+    if (payload.withdrawalsRoot.has_value())
+    {
+        ep["withdrawalsRoot"] = payload.withdrawalsRoot->hexPrefixed();
+    }
     return ep;
 }
 
-void bcos::rpc::combineGetPayloadResponse(
-    Json::Value& _result, bcos::engine::GetPayloadResult const& _response,
-    engine::ApiVersion version)
+void bcos::rpc::combineGetPayloadResponse(Json::Value& _result,
+    bcos::engine::GetPayloadResult const& _response, engine::ApiVersion version)
 {
     if (version == engine::ApiVersion::V1)
     {
@@ -315,4 +416,8 @@ void bcos::rpc::combineGetPayloadResponse(
     }
     _result["blobsBundle"] = std::move(blobsBundle);
     _result["shouldOverrideBuilder"] = _response->shouldOverrideBuilder;
+    if (_response->parentBeaconBlockRoot.has_value())
+    {
+        _result["parentBeaconBlockRoot"] = _response->parentBeaconBlockRoot->hexPrefixed();
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.h
@@ -27,11 +27,6 @@
 #include <algorithm>
 #include <string>
 
-namespace bcos::protocol
-{
-class TransactionFactory;
-}  // namespace bcos::protocol
-
 namespace bcos::rpc
 {
 /// @brief Parse a hex-encoded 32-byte h256 value.
@@ -67,11 +62,14 @@ inline bcos::Address parseAddress(std::string_view hex)
 }
 
 // The functions below are defined in EngineHelper.cpp to avoid pulling
-// ~300 lines of serialization code and <TransactionFactory.h> into every
-// translation unit that transitively includes this header.
+// ~300 lines of serialization code into every translation unit that
+// transitively includes this header.
 
-bcos::engine::NewPayloadRequest parseNewPayloadRequest(Json::Value const& params,
-    bcos::protocol::TransactionFactory& transactionFactory, engine::ApiVersion version);
+// Transactions are carried as raw EIP-2718 bytes: parsing and serialization only do
+// hex <-> bytes, byte-preserving in both directions. Classification/decoding of the
+// raw bytes is the dispatch table's job (bcos-framework/engine/RawTransactionDispatch.h).
+bcos::engine::NewPayloadRequest parseNewPayloadRequest(
+    Json::Value const& params, engine::ApiVersion version);
 
 Json::Value serializePayloadStatus(
     bcos::engine::PayloadStatus const& status, engine::ApiVersion version);

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.h
@@ -19,13 +19,18 @@
 
 #pragma once
 
-#include <algorithm>
 #include <bcos-framework/engine/Types.h>
 #include <bcos-rpc/jsonrpc/Common.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <json/json.h>
+#include <algorithm>
 #include <string>
+
+namespace bcos::protocol
+{
+class TransactionFactory;
+}  // namespace bcos::protocol
 
 namespace bcos::rpc
 {
@@ -36,9 +41,9 @@ inline bcos::h256 parseH256(std::string_view hex)
     auto bytes = fromHex(hex);
     if (bytes.size() != 32)
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(
-            InvalidParams, "Expected 32-byte hex string for h256, got " +
-                               std::to_string(bytes.size()) + " bytes"));
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "Expected 32-byte hex string for h256, got " +
+                                                std::to_string(bytes.size()) + " bytes"));
     }
     h256 result;
     std::ranges::copy(bytes.begin(), bytes.end(), result.begin());
@@ -52,9 +57,9 @@ inline bcos::Address parseAddress(std::string_view hex)
     auto bytes = fromHex(hex);
     if (bytes.size() != 20)
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(
-            InvalidParams, "Expected 20-byte hex string for address, got " +
-                               std::to_string(bytes.size()) + " bytes"));
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "Expected 20-byte hex string for address, got " +
+                                                std::to_string(bytes.size()) + " bytes"));
     }
     Address result;
     std::ranges::copy(bytes.begin(), bytes.end(), result.begin());
@@ -65,15 +70,16 @@ inline bcos::Address parseAddress(std::string_view hex)
 // ~300 lines of serialization code and <TransactionFactory.h> into every
 // translation unit that transitively includes this header.
 
-bcos::engine::NewPayloadRequest parseNewPayloadRequest(
-    Json::Value const& params, bcos::protocol::TransactionFactory& transactionFactory,
-    engine::ApiVersion version);
+bcos::engine::NewPayloadRequest parseNewPayloadRequest(Json::Value const& params,
+    bcos::protocol::TransactionFactory& transactionFactory, engine::ApiVersion version);
 
 Json::Value serializePayloadStatus(
     bcos::engine::PayloadStatus const& status, engine::ApiVersion version);
 
 std::optional<bcos::engine::PayloadAttributes> parsePayloadAttributes(
     Json::Value const& params, engine::ApiVersion version);
+
+Json::Value serializePayloadAttributes(bcos::engine::PayloadAttributes const& attrs);
 
 bcos::engine::ForkchoiceState parseForkchoiceState(Json::Value const& params);
 

--- a/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
@@ -18,10 +18,7 @@
  *        ExecutionPayload.withdrawalsRoot and GetPayloadData.parentBeaconBlockRoot.
  */
 
-#include <bcos-crypto/hash/Keccak256.h>
-#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
-#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
 #include <json/json.h>
 #include <boost/test/unit_test.hpp>
 #include <memory>
@@ -32,14 +29,6 @@ using namespace bcos::rpc;
 
 namespace
 {
-bcos::protocol::TransactionFactory::Ptr makeTransactionFactory()
-{
-    auto hashImpl = std::make_shared<crypto::Keccak256>();
-    auto sign = std::make_shared<crypto::Secp256k1Crypto>();
-    auto cryptoSuite = std::make_shared<crypto::CryptoSuite>(hashImpl, sign, nullptr);
-    return std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
-}
-
 Json::Value makeBaseAttributes()
 {
     Json::Value attrs(Json::objectValue);
@@ -174,7 +163,6 @@ BOOST_AUTO_TEST_CASE(payloadAttributesTransactionsMustBeArray)
 
 BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootRoundTrip)
 {
-    auto factory = makeTransactionFactory();
     auto const withdrawalsRootHex =
         std::string("0x9999999999999999999999999999999999999999999999999999999999999999");
 
@@ -184,7 +172,7 @@ BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootRoundTrip)
     params.append(ep);
 
     // withdrawalsRoot is a V4+ (Isthmus) payload field, so the round trip runs at V4.
-    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V4);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
     BOOST_REQUIRE(request.executionPayload.withdrawalsRoot.has_value());
     BOOST_CHECK_EQUAL(request.executionPayload.withdrawalsRoot->hexPrefixed(), withdrawalsRootHex);
 
@@ -195,14 +183,13 @@ BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootRoundTrip)
     // Parse the serialized payload again: the field survives a full round trip.
     Json::Value reparseParams(Json::arrayValue);
     reparseParams.append(serialized);
-    auto reparsed = parseNewPayloadRequest(reparseParams, *factory, engine::ApiVersion::V4);
+    auto reparsed = parseNewPayloadRequest(reparseParams, engine::ApiVersion::V4);
     BOOST_CHECK(
         reparsed.executionPayload.withdrawalsRoot == request.executionPayload.withdrawalsRoot);
 }
 
 BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootIgnoredBeforeV4)
 {
-    auto factory = makeTransactionFactory();
     auto ep = makeBaseExecutionPayload();
     ep["withdrawalsRoot"] = "0x9999999999999999999999999999999999999999999999999999999999999999";
     Json::Value params(Json::arrayValue);
@@ -210,7 +197,7 @@ BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootIgnoredBeforeV4)
 
     // V1-V3: the field is ignored (matches op-geth NewPayloadV3, which performs no
     // withdrawalsRoot validation; the Isthmus spec leaves pre-V4 handling unspecified).
-    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V3);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V3);
     BOOST_CHECK(!request.executionPayload.withdrawalsRoot.has_value());
 
     // Even with the struct field set, V1-V3 serialization never emits it.
@@ -222,11 +209,10 @@ BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootIgnoredBeforeV4)
 
 BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootAbsentByDefault)
 {
-    auto factory = makeTransactionFactory();
     Json::Value params(Json::arrayValue);
     params.append(makeBaseExecutionPayload());
 
-    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V1);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V1);
     BOOST_CHECK(!request.executionPayload.withdrawalsRoot.has_value());
 
     auto serialized = serializeExecutionPayload(request.executionPayload, engine::ApiVersion::V1);

--- a/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
@@ -183,20 +183,41 @@ BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootRoundTrip)
     Json::Value params(Json::arrayValue);
     params.append(ep);
 
-    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V3);
+    // withdrawalsRoot is a V4+ (Isthmus) payload field, so the round trip runs at V4.
+    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V4);
     BOOST_REQUIRE(request.executionPayload.withdrawalsRoot.has_value());
     BOOST_CHECK_EQUAL(request.executionPayload.withdrawalsRoot->hexPrefixed(), withdrawalsRootHex);
 
-    auto serialized = serializeExecutionPayload(request.executionPayload, engine::ApiVersion::V3);
+    auto serialized = serializeExecutionPayload(request.executionPayload, engine::ApiVersion::V4);
     BOOST_REQUIRE(serialized.isMember("withdrawalsRoot"));
     BOOST_CHECK_EQUAL(serialized["withdrawalsRoot"].asString(), withdrawalsRootHex);
 
     // Parse the serialized payload again: the field survives a full round trip.
     Json::Value reparseParams(Json::arrayValue);
     reparseParams.append(serialized);
-    auto reparsed = parseNewPayloadRequest(reparseParams, *factory, engine::ApiVersion::V3);
+    auto reparsed = parseNewPayloadRequest(reparseParams, *factory, engine::ApiVersion::V4);
     BOOST_CHECK(
         reparsed.executionPayload.withdrawalsRoot == request.executionPayload.withdrawalsRoot);
+}
+
+BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootIgnoredBeforeV4)
+{
+    auto factory = makeTransactionFactory();
+    auto ep = makeBaseExecutionPayload();
+    ep["withdrawalsRoot"] = "0x9999999999999999999999999999999999999999999999999999999999999999";
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+
+    // V1-V3: the field is ignored (matches op-geth NewPayloadV3, which performs no
+    // withdrawalsRoot validation; the Isthmus spec leaves pre-V4 handling unspecified).
+    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V3);
+    BOOST_CHECK(!request.executionPayload.withdrawalsRoot.has_value());
+
+    // Even with the struct field set, V1-V3 serialization never emits it.
+    request.executionPayload.withdrawalsRoot =
+        parseH256("0x9999999999999999999999999999999999999999999999999999999999999999");
+    auto serialized = serializeExecutionPayload(request.executionPayload, engine::ApiVersion::V3);
+    BOOST_CHECK(!serialized.isMember("withdrawalsRoot"));
 }
 
 BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootAbsentByDefault)

--- a/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
@@ -1,0 +1,234 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EngineProtoAlignB1Test.cpp
+ * @brief Engine protocol structure alignment tests: OP payload-attributes fields,
+ *        ExecutionPayload.withdrawalsRoot and GetPayloadData.parentBeaconBlockRoot.
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace
+{
+bcos::protocol::TransactionFactory::Ptr makeTransactionFactory()
+{
+    auto hashImpl = std::make_shared<crypto::Keccak256>();
+    auto sign = std::make_shared<crypto::Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<crypto::CryptoSuite>(hashImpl, sign, nullptr);
+    return std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+}
+
+Json::Value makeBaseAttributes()
+{
+    Json::Value attrs(Json::objectValue);
+    attrs["timestamp"] = "0x64";
+    attrs["prevRandao"] = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    attrs["suggestedFeeRecipient"] = "0x2222222222222222222222222222222222222222";
+    return attrs;
+}
+
+Json::Value makeAttributesParams(Json::Value attrs)
+{
+    Json::Value params(Json::arrayValue);
+    Json::Value forkchoice(Json::objectValue);
+    forkchoice["headBlockHash"] =
+        "0x3333333333333333333333333333333333333333333333333333333333333333";
+    forkchoice["safeBlockHash"] =
+        "0x3333333333333333333333333333333333333333333333333333333333333333";
+    forkchoice["finalizedBlockHash"] =
+        "0x3333333333333333333333333333333333333333333333333333333333333333";
+    params.append(std::move(forkchoice));
+    params.append(std::move(attrs));
+    return params;
+}
+
+Json::Value makeBaseExecutionPayload()
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    ep["feeRecipient"] = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    ep["stateRoot"] = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    ep["receiptsRoot"] = "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    ep["logsBloom"] = "0x" + std::string(512, '0');
+    ep["prevRandao"] = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    ep["blockNumber"] = "0x1";
+    ep["gasLimit"] = "0x5208";
+    ep["gasUsed"] = "0x0";
+    ep["timestamp"] = "0x1";
+    ep["extraData"] = "0x1234";
+    ep["baseFeePerGas"] = "0x1";
+    ep["blockHash"] = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    ep["transactions"] = Json::Value(Json::arrayValue);
+    return ep;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(EngineProtoAlignB1Test)
+
+BOOST_AUTO_TEST_CASE(payloadAttributesOpFieldsParseAndSerialize)
+{
+    auto attrs = makeBaseAttributes();
+    Json::Value transactions(Json::arrayValue);
+    // Raw EIP-2718 hex strings: a deposit (0x7e) and a type-2 transaction, opaque here.
+    transactions.append("0x7e01020304");
+    transactions.append("0x02f8720102");
+    attrs["transactions"] = transactions;
+    attrs["noTxPool"] = true;
+    attrs["gasLimit"] = "0x1c9c380";
+    attrs["eip1559Params"] = "0x0000000800000002";
+    attrs["minBaseFee"] = "0x3b9aca00";
+
+    auto parsed = parsePayloadAttributes(makeAttributesParams(attrs), engine::ApiVersion::V3);
+    BOOST_REQUIRE(parsed.has_value());
+    BOOST_REQUIRE(parsed->transactions.has_value());
+    BOOST_REQUIRE_EQUAL(parsed->transactions->size(), 2);
+    BOOST_CHECK_EQUAL(parsed->transactions->at(0), "0x7e01020304");
+    BOOST_CHECK_EQUAL(parsed->transactions->at(1), "0x02f8720102");
+    BOOST_REQUIRE(parsed->noTxPool.has_value());
+    BOOST_CHECK_EQUAL(*parsed->noTxPool, true);
+    BOOST_REQUIRE(parsed->gasLimit.has_value());
+    BOOST_CHECK_EQUAL(*parsed->gasLimit, 30000000ULL);
+    BOOST_REQUIRE(parsed->eip1559Params.has_value());
+    BOOST_CHECK_EQUAL(parsed->eip1559Params->size(), 8);
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(*parsed->eip1559Params), "0x0000000800000002");
+    BOOST_REQUIRE(parsed->minBaseFee.has_value());
+    BOOST_CHECK_EQUAL(*parsed->minBaseFee, 1000000000ULL);
+
+    // Serialization round-trip: serialize the parsed struct and parse it again.
+    auto serialized = serializePayloadAttributes(*parsed);
+    BOOST_CHECK_EQUAL(serialized["noTxPool"].asBool(), true);
+    BOOST_CHECK_EQUAL(serialized["gasLimit"].asString(), "0x1c9c380");
+    BOOST_CHECK_EQUAL(serialized["eip1559Params"].asString(), "0x0000000800000002");
+    BOOST_CHECK_EQUAL(serialized["minBaseFee"].asString(), "0x3b9aca00");
+    BOOST_REQUIRE_EQUAL(serialized["transactions"].size(), 2);
+    BOOST_CHECK_EQUAL(serialized["transactions"][0u].asString(), "0x7e01020304");
+
+    auto reparsed =
+        parsePayloadAttributes(makeAttributesParams(serialized), engine::ApiVersion::V3);
+    BOOST_REQUIRE(reparsed.has_value());
+    BOOST_CHECK(reparsed->transactions == parsed->transactions);
+    BOOST_CHECK(reparsed->noTxPool == parsed->noTxPool);
+    BOOST_CHECK(reparsed->gasLimit == parsed->gasLimit);
+    BOOST_CHECK(reparsed->eip1559Params == parsed->eip1559Params);
+    BOOST_CHECK(reparsed->minBaseFee == parsed->minBaseFee);
+}
+
+BOOST_AUTO_TEST_CASE(payloadAttributesOpFieldsDefaultToAbsent)
+{
+    // No OP fields in the JSON: parsing keeps them unset (current behavior preserved),
+    // and serialization does not invent them.
+    auto parsed =
+        parsePayloadAttributes(makeAttributesParams(makeBaseAttributes()), engine::ApiVersion::V3);
+    BOOST_REQUIRE(parsed.has_value());
+    BOOST_CHECK(!parsed->transactions.has_value());
+    BOOST_CHECK(!parsed->noTxPool.has_value());
+    BOOST_CHECK(!parsed->gasLimit.has_value());
+    BOOST_CHECK(!parsed->eip1559Params.has_value());
+    BOOST_CHECK(!parsed->minBaseFee.has_value());
+
+    auto serialized = serializePayloadAttributes(*parsed);
+    BOOST_CHECK(!serialized.isMember("transactions"));
+    BOOST_CHECK(!serialized.isMember("noTxPool"));
+    BOOST_CHECK(!serialized.isMember("gasLimit"));
+    BOOST_CHECK(!serialized.isMember("eip1559Params"));
+    BOOST_CHECK(!serialized.isMember("minBaseFee"));
+}
+
+BOOST_AUTO_TEST_CASE(payloadAttributesEip1559ParamsLengthRejected)
+{
+    auto attrs = makeBaseAttributes();
+    attrs["eip1559Params"] = "0x00000008";  // 4 bytes, must be 8
+    BOOST_CHECK_THROW(parsePayloadAttributes(makeAttributesParams(attrs), engine::ApiVersion::V3),
+        JsonRpcException);
+}
+
+BOOST_AUTO_TEST_CASE(payloadAttributesTransactionsMustBeArray)
+{
+    auto attrs = makeBaseAttributes();
+    attrs["transactions"] = "0x7e01020304";  // scalar instead of array
+    BOOST_CHECK_THROW(parsePayloadAttributes(makeAttributesParams(attrs), engine::ApiVersion::V3),
+        JsonRpcException);
+}
+
+BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootRoundTrip)
+{
+    auto factory = makeTransactionFactory();
+    auto const withdrawalsRootHex =
+        std::string("0x9999999999999999999999999999999999999999999999999999999999999999");
+
+    auto ep = makeBaseExecutionPayload();
+    ep["withdrawalsRoot"] = withdrawalsRootHex;
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+
+    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V3);
+    BOOST_REQUIRE(request.executionPayload.withdrawalsRoot.has_value());
+    BOOST_CHECK_EQUAL(request.executionPayload.withdrawalsRoot->hexPrefixed(), withdrawalsRootHex);
+
+    auto serialized = serializeExecutionPayload(request.executionPayload, engine::ApiVersion::V3);
+    BOOST_REQUIRE(serialized.isMember("withdrawalsRoot"));
+    BOOST_CHECK_EQUAL(serialized["withdrawalsRoot"].asString(), withdrawalsRootHex);
+
+    // Parse the serialized payload again: the field survives a full round trip.
+    Json::Value reparseParams(Json::arrayValue);
+    reparseParams.append(serialized);
+    auto reparsed = parseNewPayloadRequest(reparseParams, *factory, engine::ApiVersion::V3);
+    BOOST_CHECK(
+        reparsed.executionPayload.withdrawalsRoot == request.executionPayload.withdrawalsRoot);
+}
+
+BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootAbsentByDefault)
+{
+    auto factory = makeTransactionFactory();
+    Json::Value params(Json::arrayValue);
+    params.append(makeBaseExecutionPayload());
+
+    auto request = parseNewPayloadRequest(params, *factory, engine::ApiVersion::V1);
+    BOOST_CHECK(!request.executionPayload.withdrawalsRoot.has_value());
+
+    auto serialized = serializeExecutionPayload(request.executionPayload, engine::ApiVersion::V1);
+    BOOST_CHECK(!serialized.isMember("withdrawalsRoot"));
+}
+
+BOOST_AUTO_TEST_CASE(getPayloadResponseCarriesParentBeaconBlockRoot)
+{
+    auto const beaconRootHex =
+        std::string("0x8888888888888888888888888888888888888888888888888888888888888888");
+    auto data = std::make_unique<engine::GetPayloadData>();
+    data->parentBeaconBlockRoot = parseH256(beaconRootHex);
+
+    Json::Value result;
+    combineGetPayloadResponse(result, data, engine::ApiVersion::V3);
+    BOOST_REQUIRE(result.isMember("parentBeaconBlockRoot"));
+    BOOST_CHECK_EQUAL(result["parentBeaconBlockRoot"].asString(), beaconRootHex);
+
+    // Absent beacon root: the member is not emitted (V1-V3 responses unchanged).
+    auto emptyData = std::make_unique<engine::GetPayloadData>();
+    Json::Value emptyResult;
+    combineGetPayloadResponse(emptyResult, emptyData, engine::ApiVersion::V3);
+    BOOST_CHECK(!emptyResult.isMember("parentBeaconBlockRoot"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
@@ -161,6 +161,70 @@ BOOST_AUTO_TEST_CASE(payloadAttributesTransactionsMustBeArray)
         JsonRpcException);
 }
 
+BOOST_AUTO_TEST_CASE(payloadAttributesTransactionsElementsMustBePrefixedHexStrings)
+{
+    // Non-string element.
+    auto attrs = makeBaseAttributes();
+    Json::Value transactions(Json::arrayValue);
+    transactions.append(Json::Value(123));
+    attrs["transactions"] = transactions;
+    BOOST_CHECK_THROW(parsePayloadAttributes(makeAttributesParams(attrs), engine::ApiVersion::V3),
+        JsonRpcException);
+
+    // Invalid hex characters.
+    auto badHexAttrs = makeBaseAttributes();
+    Json::Value badHexTxs(Json::arrayValue);
+    badHexTxs.append("0xzz");
+    badHexAttrs["transactions"] = badHexTxs;
+    BOOST_CHECK_THROW(
+        parsePayloadAttributes(makeAttributesParams(badHexAttrs), engine::ApiVersion::V3),
+        JsonRpcException);
+
+    // Missing 0x prefix.
+    auto noPrefixAttrs = makeBaseAttributes();
+    Json::Value noPrefixTxs(Json::arrayValue);
+    noPrefixTxs.append("7e01020304");
+    noPrefixAttrs["transactions"] = noPrefixTxs;
+    BOOST_CHECK_THROW(
+        parsePayloadAttributes(makeAttributesParams(noPrefixAttrs), engine::ApiVersion::V3),
+        JsonRpcException);
+
+    // Odd-length hex (fromHex would silently left-pad a '0' nibble — must reject).
+    auto oddAttrs = makeBaseAttributes();
+    Json::Value oddTxs(Json::arrayValue);
+    oddTxs.append("0x123");
+    oddAttrs["transactions"] = oddTxs;
+    BOOST_CHECK_THROW(
+        parsePayloadAttributes(makeAttributesParams(oddAttrs), engine::ApiVersion::V3),
+        JsonRpcException);
+
+    // Bare "0x" (empty transaction).
+    auto emptyAttrs = makeBaseAttributes();
+    Json::Value emptyTxs(Json::arrayValue);
+    emptyTxs.append("0x");
+    emptyAttrs["transactions"] = emptyTxs;
+    BOOST_CHECK_THROW(
+        parsePayloadAttributes(makeAttributesParams(emptyAttrs), engine::ApiVersion::V3),
+        JsonRpcException);
+}
+
+BOOST_AUTO_TEST_CASE(payloadAttributesNoTxPoolMustBeBoolean)
+{
+    // jsoncpp asBool() silently converts numbers and strings; the parser must gate on
+    // the JSON type instead.
+    auto stringAttrs = makeBaseAttributes();
+    stringAttrs["noTxPool"] = "true";
+    BOOST_CHECK_THROW(
+        parsePayloadAttributes(makeAttributesParams(stringAttrs), engine::ApiVersion::V3),
+        JsonRpcException);
+
+    auto numberAttrs = makeBaseAttributes();
+    numberAttrs["noTxPool"] = 1;
+    BOOST_CHECK_THROW(
+        parsePayloadAttributes(makeAttributesParams(numberAttrs), engine::ApiVersion::V3),
+        JsonRpcException);
+}
+
 BOOST_AUTO_TEST_CASE(executionPayloadWithdrawalsRootRoundTrip)
 {
     auto const withdrawalsRootHex =

--- a/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
@@ -153,6 +153,39 @@ BOOST_AUTO_TEST_CASE(payloadAttributesEip1559ParamsLengthRejected)
         JsonRpcException);
 }
 
+BOOST_AUTO_TEST_CASE(payloadAttributesMalformedQuantitiesMapToInvalidParams)
+{
+    // Malformed / overflowing gasLimit, minBaseFee and non-hex eip1559Params must
+    // surface as InvalidParams (a plain std::exception from the converters would be
+    // mapped to InternalError by the RPC entry point).
+    auto expectInvalidParams = [](Json::Value attrs) {
+        BOOST_CHECK_EXCEPTION(
+            parsePayloadAttributes(makeAttributesParams(std::move(attrs)), engine::ApiVersion::V3),
+            JsonRpcException,
+            [](JsonRpcException const& error) { return error.code() == InvalidParams; });
+    };
+
+    auto malformedGasLimit = makeBaseAttributes();
+    malformedGasLimit["gasLimit"] = "0xzz";
+    expectInvalidParams(malformedGasLimit);
+
+    auto overflowGasLimit = makeBaseAttributes();
+    overflowGasLimit["gasLimit"] = "0x10000000000000000";  // 2^64, exceeds uint64
+    expectInvalidParams(overflowGasLimit);
+
+    auto malformedMinBaseFee = makeBaseAttributes();
+    malformedMinBaseFee["minBaseFee"] = "not-a-quantity";
+    expectInvalidParams(malformedMinBaseFee);
+
+    auto overflowMinBaseFee = makeBaseAttributes();
+    overflowMinBaseFee["minBaseFee"] = "0x10000000000000000";
+    expectInvalidParams(overflowMinBaseFee);
+
+    auto malformedEip1559 = makeBaseAttributes();
+    malformedEip1559["eip1559Params"] = "0xzzzzzzzzzzzzzzzz";  // 8 bytes long, invalid hex
+    expectInvalidParams(malformedEip1559);
+}
+
 BOOST_AUTO_TEST_CASE(payloadAttributesTransactionsMustBeArray)
 {
     auto attrs = makeBaseAttributes();

--- a/bcos-rpc/test/unittests/rpc/EngineRawTxB2B3Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRawTxB2B3Test.cpp
@@ -1,0 +1,303 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EngineRawTxB2B3Test.cpp
+ * @brief Engine raw transaction carrier (B2) and type dispatch / deposit decode (B3)
+ */
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-framework/engine/RawTransactionDispatch.h>
+#include <bcos-rpc/web3jsonrpc/model/DepositTransaction.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::rpc;
+using namespace bcos::engine;
+
+namespace
+{
+Json::Value makeExecutionPayloadJson(std::vector<std::string> const& transactionsHex)
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    ep["feeRecipient"] = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    ep["stateRoot"] = "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    ep["receiptsRoot"] = "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
+    ep["logsBloom"] = "0x" + std::string(512, '0');
+    ep["prevRandao"] = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    ep["blockNumber"] = "0x1";
+    ep["gasLimit"] = "0x5208";
+    ep["gasUsed"] = "0x0";
+    ep["timestamp"] = "0x1";
+    ep["extraData"] = "0x1234";
+    ep["baseFeePerGas"] = "0x1";
+    ep["blockHash"] = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    Json::Value transactions(Json::arrayValue);
+    for (auto const& hex : transactionsHex)
+    {
+        transactions.append(hex);
+    }
+    ep["transactions"] = std::move(transactions);
+    return ep;
+}
+
+struct DepositFixtureFields
+{
+    crypto::HashType sourceHash{"1111111111111111111111111111111111111111111111111111111111111111"};
+    Address from{"2222222222222222222222222222222222222222"};
+    std::optional<Address> to{Address{"3333333333333333333333333333333333333333"}};
+    std::optional<u256> mint{u256(1000)};
+    u256 value{7};
+    uint64_t gas{21000};
+    bool isSystemTx{false};
+    bytes input{0xde, 0xad, 0xbe, 0xef};
+};
+
+/// Encode `0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data])`.
+bytes buildDepositRaw(DepositFixtureFields const& fields)
+{
+    bytes body;
+    codec::rlp::encode(body, fields.sourceHash);
+    codec::rlp::encode(body, fields.from);
+    if (fields.to.has_value())
+    {
+        codec::rlp::encode(body, *fields.to);
+    }
+    else
+    {
+        body.push_back(codec::rlp::BYTES_HEAD_BASE);
+    }
+    if (fields.mint.has_value())
+    {
+        codec::rlp::encode(body, *fields.mint);
+    }
+    else
+    {
+        body.push_back(codec::rlp::BYTES_HEAD_BASE);
+    }
+    codec::rlp::encode(body, fields.value);
+    codec::rlp::encode(body, fields.gas);
+    codec::rlp::encode(body, static_cast<uint64_t>(fields.isSystemTx));
+    codec::rlp::encode(body, fields.input);
+
+    bytes raw;
+    raw.push_back(c_depositTxType);
+    codec::rlp::encodeHeader(raw, codec::rlp::Header{.isList = true, .payloadLength = body.size()});
+    raw.insert(raw.end(), body.begin(), body.end());
+    return raw;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(EngineRawTxB2B3Test)
+
+BOOST_AUTO_TEST_CASE(dispatchTableIsAuthoritative)
+{
+    auto kindOf = [](bytes raw) { return dispatchRawTransaction(bcos::ref(raw)); };
+    BOOST_CHECK(kindOf({0x01, 0xaa}) == RawTransactionKind::AccessList);
+    BOOST_CHECK(kindOf({0x02, 0xaa}) == RawTransactionKind::DynamicFee);
+    BOOST_CHECK(kindOf({0x04, 0xaa}) == RawTransactionKind::SetCode);
+    BOOST_CHECK(kindOf({0x7e, 0xaa}) == RawTransactionKind::Deposit);
+    // RLP list header range => legacy.
+    BOOST_CHECK(kindOf({0xc0}) == RawTransactionKind::Legacy);
+    BOOST_CHECK(kindOf({0xf8, 0x01}) == RawTransactionKind::Legacy);
+    BOOST_CHECK(kindOf({0xff}) == RawTransactionKind::Legacy);
+    // Blob: parseable as a category, but never admissible.
+    BOOST_CHECK(kindOf({0x03, 0xaa}) == RawTransactionKind::Blob);
+    BOOST_CHECK(!isRawTransactionPayloadAdmissible(RawTransactionKind::Blob));
+    // 0x00 is not a valid EIP-2718 type; reserved/unknown bytes are unsupported.
+    BOOST_CHECK(kindOf({0x00, 0xaa}) == RawTransactionKind::Unsupported);
+    BOOST_CHECK(kindOf({0x05, 0xaa}) == RawTransactionKind::Unsupported);
+    BOOST_CHECK(kindOf({0x7f, 0xaa}) == RawTransactionKind::Unsupported);
+    BOOST_CHECK(kindOf({0xbf, 0xaa}) == RawTransactionKind::Unsupported);
+    BOOST_CHECK(kindOf({}) == RawTransactionKind::Unsupported);
+    BOOST_CHECK(!isRawTransactionPayloadAdmissible(RawTransactionKind::Unsupported));
+    BOOST_CHECK(isRawTransactionPayloadAdmissible(RawTransactionKind::Legacy));
+    BOOST_CHECK(isRawTransactionPayloadAdmissible(RawTransactionKind::Deposit));
+}
+
+BOOST_AUTO_TEST_CASE(rawTransactionBytesSurviveParseSerializeRoundTrip)
+{
+    // dep-1 as raw hex plus a legacy and a typed transaction: the parser does hex->bytes
+    // only, and serialization returns the exact same hex — the three-point byte equality
+    // the Engine codec must guarantee (attributes leg asserted below).
+    auto const dep1Hex = toHexStringWithPrefix(buildDepositRaw(DepositFixtureFields{}));
+    auto const legacyHex = std::string("0xc9808080808080808080");
+    auto const typedHex = std::string("0x02f8010203");
+
+    Json::Value params(Json::arrayValue);
+    params.append(makeExecutionPayloadJson({dep1Hex, legacyHex, typedHex}));
+
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V1);
+    BOOST_REQUIRE_EQUAL(request.executionPayload.transactions.size(), 3);
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(request.executionPayload.transactions[0].raw), dep1Hex);
+    BOOST_CHECK_EQUAL(
+        toHexStringWithPrefix(request.executionPayload.transactions[1].raw), legacyHex);
+    BOOST_CHECK_EQUAL(
+        toHexStringWithPrefix(request.executionPayload.transactions[2].raw), typedHex);
+    // No decoding at the parse boundary.
+    BOOST_CHECK(request.executionPayload.transactions[0].decoded == nullptr);
+
+    auto serialized = serializeExecutionPayload(request.executionPayload, engine::ApiVersion::V1);
+    BOOST_REQUIRE_EQUAL(serialized["transactions"].size(), 3);
+    BOOST_CHECK_EQUAL(serialized["transactions"][0U].asString(), dep1Hex);
+    BOOST_CHECK_EQUAL(serialized["transactions"][1U].asString(), legacyHex);
+    BOOST_CHECK_EQUAL(serialized["transactions"][2U].asString(), typedHex);
+
+    // Attributes leg: the forced-transaction list keeps dep-1 verbatim as well.
+    Json::Value attrsParams(Json::arrayValue);
+    Json::Value forkchoice(Json::objectValue);
+    forkchoice["headBlockHash"] =
+        "0x3333333333333333333333333333333333333333333333333333333333333333";
+    forkchoice["safeBlockHash"] =
+        "0x3333333333333333333333333333333333333333333333333333333333333333";
+    forkchoice["finalizedBlockHash"] =
+        "0x3333333333333333333333333333333333333333333333333333333333333333";
+    attrsParams.append(std::move(forkchoice));
+    Json::Value attrs(Json::objectValue);
+    attrs["timestamp"] = "0x64";
+    attrs["prevRandao"] = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    attrs["suggestedFeeRecipient"] = "0x2222222222222222222222222222222222222222";
+    Json::Value attrsTxs(Json::arrayValue);
+    attrsTxs.append(dep1Hex);
+    attrs["transactions"] = std::move(attrsTxs);
+    attrsParams.append(std::move(attrs));
+    auto parsedAttrs = parsePayloadAttributes(attrsParams, engine::ApiVersion::V3);
+    BOOST_REQUIRE(parsedAttrs.has_value());
+    BOOST_REQUIRE(parsedAttrs->transactions.has_value());
+    BOOST_CHECK_EQUAL(parsedAttrs->transactions->at(0), dep1Hex);
+}
+
+BOOST_AUTO_TEST_CASE(parseNewPayloadRejectsNonHexTransactionEntries)
+{
+    Json::Value params(Json::arrayValue);
+    params.append(makeExecutionPayloadJson({"0xzz"}));
+    BOOST_CHECK_THROW(parseNewPayloadRequest(params, engine::ApiVersion::V1), JsonRpcException);
+}
+
+BOOST_AUTO_TEST_CASE(depositDecodeFullFields)
+{
+    DepositFixtureFields fields;
+    fields.isSystemTx = true;
+    auto raw = buildDepositRaw(fields);
+    auto cursor = bcos::ref(raw);
+
+    DepositTransaction deposit;
+    auto error = decodeDepositTransaction(cursor, deposit);
+    BOOST_REQUIRE(error == nullptr);
+    BOOST_CHECK_EQUAL(deposit.sourceHash, fields.sourceHash);
+    BOOST_CHECK_EQUAL(deposit.from, fields.from);
+    BOOST_REQUIRE(deposit.to.has_value());
+    BOOST_CHECK_EQUAL(*deposit.to, *fields.to);
+    BOOST_REQUIRE(deposit.mint.has_value());
+    BOOST_CHECK_EQUAL(*deposit.mint, *fields.mint);
+    BOOST_CHECK_EQUAL(deposit.value, fields.value);
+    BOOST_CHECK_EQUAL(deposit.gas, fields.gas);
+    BOOST_CHECK_EQUAL(deposit.isSystemTx, true);
+    BOOST_CHECK(deposit.input == fields.input);
+    BOOST_CHECK(cursor.empty());
+}
+
+BOOST_AUTO_TEST_CASE(depositDecodeCreationAndNilMint)
+{
+    DepositFixtureFields fields;
+    fields.to = std::nullopt;    // contract creation: empty RLP item
+    fields.mint = std::nullopt;  // nil mint: empty RLP item (op-geth *big.Int nil)
+    auto raw = buildDepositRaw(fields);
+    auto cursor = bcos::ref(raw);
+
+    DepositTransaction deposit;
+    auto error = decodeDepositTransaction(cursor, deposit);
+    BOOST_REQUIRE(error == nullptr);
+    BOOST_CHECK(!deposit.to.has_value());
+    BOOST_CHECK(!deposit.mint.has_value());
+}
+
+BOOST_AUTO_TEST_CASE(depositDecodeRejectsMalformedInput)
+{
+    // Wrong type byte.
+    bytes notDeposit{0x02, 0xc0};
+    auto cursor = bcos::ref(notDeposit);
+    DepositTransaction deposit;
+    BOOST_CHECK(decodeDepositTransaction(cursor, deposit) != nullptr);
+
+    // Truncated body.
+    auto raw = buildDepositRaw(DepositFixtureFields{});
+    raw.resize(raw.size() - 3);
+    auto truncatedCursor = bcos::ref(raw);
+    BOOST_CHECK(decodeDepositTransaction(truncatedCursor, deposit) != nullptr);
+
+    // Trailing bytes inside the list.
+    auto goodRaw = buildDepositRaw(DepositFixtureFields{});
+    bytes body(goodRaw.begin() + 1 + 2, goodRaw.end());  // strip type byte + list header
+    body.push_back(0x01);                                // extra trailing item
+    bytes tampered;
+    tampered.push_back(c_depositTxType);
+    codec::rlp::encodeHeader(
+        tampered, codec::rlp::Header{.isList = true, .payloadLength = body.size()});
+    tampered.insert(tampered.end(), body.begin(), body.end());
+    auto tamperedCursor = bcos::ref(tampered);
+    BOOST_CHECK(decodeDepositTransaction(tamperedCursor, deposit) != nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(depositJsonMatchesGethShape)
+{
+    DepositFixtureFields fields;
+    auto raw = buildDepositRaw(fields);
+    auto cursor = bcos::ref(raw);
+    DepositTransaction deposit;
+    BOOST_REQUIRE(decodeDepositTransaction(cursor, deposit) == nullptr);
+
+    Json::Value result(Json::objectValue);
+    combineDepositTxResponse(result, deposit);
+
+    BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    BOOST_CHECK_EQUAL(result["sourceHash"].asString(), fields.sourceHash.hexPrefixed());
+    BOOST_CHECK_EQUAL(result["gas"].asString(), "0x5208");
+    BOOST_CHECK_EQUAL(result["value"].asString(), "0x7");
+    BOOST_CHECK_EQUAL(result["input"].asString(), "0xdeadbeef");
+    BOOST_CHECK_EQUAL(result["mint"].asString(), "0x3e8");
+    // op-geth omits isSystemTx when false and emits it only when true.
+    BOOST_CHECK(!result.isMember("isSystemTx"));
+    // Deposits are unsigned and carry no nonce of their own (the deposit nonce lives in
+    // the receipt); op-geth emits zero quantities.
+    BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["gasPrice"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["v"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["r"].asString(), "0x0");
+    BOOST_CHECK_EQUAL(result["s"].asString(), "0x0");
+    BOOST_CHECK(!result.isMember("chainId"));
+
+    // isSystemTx=true is emitted; a creation deposit reports "to": null.
+    DepositFixtureFields systemFields;
+    systemFields.isSystemTx = true;
+    systemFields.to = std::nullopt;
+    systemFields.mint = std::nullopt;
+    auto systemRaw = buildDepositRaw(systemFields);
+    auto systemCursor = bcos::ref(systemRaw);
+    DepositTransaction systemDeposit;
+    BOOST_REQUIRE(decodeDepositTransaction(systemCursor, systemDeposit) == nullptr);
+    Json::Value systemResult(Json::objectValue);
+    combineDepositTxResponse(systemResult, systemDeposit);
+    BOOST_CHECK_EQUAL(systemResult["isSystemTx"].asBool(), true);
+    BOOST_CHECK(systemResult["to"].isNull());
+    BOOST_CHECK(!systemResult.isMember("mint"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/EngineRawTxB2B3Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRawTxB2B3Test.cpp
@@ -186,9 +186,44 @@ BOOST_AUTO_TEST_CASE(rawTransactionBytesSurviveParseSerializeRoundTrip)
 
 BOOST_AUTO_TEST_CASE(parseNewPayloadRejectsNonHexTransactionEntries)
 {
+    // Invalid hex characters.
     Json::Value params(Json::arrayValue);
     params.append(makeExecutionPayloadJson({"0xzz"}));
     BOOST_CHECK_THROW(parseNewPayloadRequest(params, engine::ApiVersion::V1), JsonRpcException);
+
+    // Missing 0x prefix.
+    Json::Value noPrefixParams(Json::arrayValue);
+    noPrefixParams.append(makeExecutionPayloadJson({"7e01020304"}));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(noPrefixParams, engine::ApiVersion::V1), JsonRpcException);
+
+    // Non-string element.
+    auto nonStringPayload = makeExecutionPayloadJson({});
+    nonStringPayload["transactions"].append(Json::Value(123));
+    Json::Value nonStringParams(Json::arrayValue);
+    nonStringParams.append(nonStringPayload);
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(nonStringParams, engine::ApiVersion::V1), JsonRpcException);
+
+    // Odd-length hex (fromHex would silently left-pad a '0' nibble — must reject to
+    // keep the byte-fidelity contract).
+    Json::Value oddParams(Json::arrayValue);
+    oddParams.append(makeExecutionPayloadJson({"0x123"}));
+    BOOST_CHECK_THROW(parseNewPayloadRequest(oddParams, engine::ApiVersion::V1), JsonRpcException);
+
+    // Bare "0x" (empty transaction).
+    Json::Value emptyParams(Json::arrayValue);
+    emptyParams.append(makeExecutionPayloadJson({"0x"}));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(emptyParams, engine::ApiVersion::V1), JsonRpcException);
+
+    // transactions must be an array.
+    auto scalarPayload = makeExecutionPayloadJson({});
+    scalarPayload["transactions"] = "0x7e01020304";
+    Json::Value scalarParams(Json::arrayValue);
+    scalarParams.append(scalarPayload);
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(scalarParams, engine::ApiVersion::V1), JsonRpcException);
 }
 
 BOOST_AUTO_TEST_CASE(depositDecodeFullFields)

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -18,12 +18,12 @@
  */
 
 #include "../common/RPCFixture.h"
-#include <bcos-framework/engine/AnyEngineService.h>
-#include <bcos-rpc/web3jsonrpc/utils/Common.h>
-#include <bcos-rpc/web3jsonrpc/endpoints/Endpoints.h>
 #include <bcos-codec/wrapper/CodecWrapper.h>
-#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-framework/engine/AnyEngineService.h>
+#include <bcos-rpc/web3jsonrpc/endpoints/Endpoints.h>
+#include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
 #include <json/json.h>
 #include <memory>
 
@@ -67,8 +67,8 @@ public:
     }
 
     task::Task<engine::ForkchoiceUpdatedResult> updateForkchoice(
-        const engine::ForkchoiceState& forkchoiceState,
-        const engine::PayloadAttributes*, std::uint32_t version)
+        const engine::ForkchoiceState& forkchoiceState, const engine::PayloadAttributes*,
+        std::uint32_t version)
     {
         m_state->capturedForkchoiceState = forkchoiceState;
         m_state->capturedForkchoiceVersion = static_cast<int>(version);
@@ -92,7 +92,10 @@ public:
     }
 
     std::optional<bcos::protocol::BlockNumber> getSafeBlockNumber() const { return std::nullopt; }
-    std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() const { return std::nullopt; }
+    std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() const
+    {
+        return std::nullopt;
+    }
 };
 
 class EngineRpcTestFixture : public RPCFixture
@@ -102,8 +105,7 @@ public:
     {
         nodeService->engineService() =
             std::make_shared<bcos::engine::AnyEngineService>(mockService);
-        endpoints = std::make_unique<Endpoints>(
-            nodeService, nullptr, false);
+        endpoints = std::make_unique<Endpoints>(nodeService, nullptr, false);
     }
 
     std::unique_ptr<Endpoints> endpoints;
@@ -111,9 +113,9 @@ public:
 };
 
 // Helper macro: call an EngineEndpoint method through Endpoints
-#define CALL_ENGINE(method, params, response) \
+#define CALL_ENGINE(method, params, response)                                          \
     task::wait([&](Endpoints* ep, Json::Value p, Json::Value& r) -> task::Task<void> { \
-        co_await ep->method(p, r); \
+        co_await ep->method(p, r);                                                     \
     }(endpoints.get(), params, response))
 
 BOOST_FIXTURE_TEST_SUITE(EngineRpcTest, EngineRpcTestFixture)
@@ -148,8 +150,7 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV1)
     BOOST_CHECK(!response["result"].isMember("payloadId"));
 
     BOOST_REQUIRE(mockService.m_state->capturedForkchoiceState.has_value());
-    BOOST_CHECK_EQUAL(
-        mockService.m_state->capturedForkchoiceState->headBlockHash.hex(),
+    BOOST_CHECK_EQUAL(mockService.m_state->capturedForkchoiceState->headBlockHash.hex(),
         "1111111111111111111111111111111111111111111111111111111111111111");
     BOOST_REQUIRE(mockService.m_state->capturedForkchoiceVersion.has_value());
     BOOST_CHECK_EQUAL(*mockService.m_state->capturedForkchoiceVersion, 1);
@@ -191,7 +192,8 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV3)
     attrs["timestamp"] = "0x1";
     attrs["prevRandao"] = "0x4444444444444444444444444444444444444444444444444444444444444444";
     attrs["suggestedFeeRecipient"] = "0x5555555555555555555555555555555555555555";
-    attrs["parentBeaconBlockRoot"] = "0x6666666666666666666666666666666666666666666666666666666666666666";
+    attrs["parentBeaconBlockRoot"] =
+        "0x6666666666666666666666666666666666666666666666666666666666666666";
     params.append(attrs);
 
     Json::Value response;
@@ -307,9 +309,9 @@ BOOST_AUTO_TEST_CASE(newPayloadV1)
 
 BOOST_AUTO_TEST_CASE(newPayloadV2)
 {
-    auto tx = m_blockFactory->transactionFactory()->createTransaction(
-        0, "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100,
-        chainId, groupId, static_cast<int64_t>(utcTime()));
+    auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
+        "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100, chainId,
+        groupId, static_cast<int64_t>(utcTime()));
     bytes encodedTx;
     tx->encode(encodedTx);
     auto encodedTxHex = toHexStringWithPrefix(encodedTx);
@@ -353,8 +355,8 @@ BOOST_AUTO_TEST_CASE(newPayloadV2)
     auto& capturedReq = *mockService.m_state->capturedNewPayloadRequest;
     BOOST_CHECK_EQUAL(capturedReq.executionPayload.transactions.size(), 1);
     BOOST_REQUIRE(capturedReq.executionPayload.withdrawals.has_value());
-    BOOST_CHECK_EQUAL(capturedReq.executionPayload.withdrawals->front().amount,
-        fromBigQuantity(largeQuantity));
+    BOOST_CHECK_EQUAL(
+        capturedReq.executionPayload.withdrawals->front().amount, fromBigQuantity(largeQuantity));
     BOOST_REQUIRE(capturedReq.executionPayload.blobGasUsed.has_value());
     BOOST_CHECK_EQUAL(*capturedReq.executionPayload.blobGasUsed, fromBigQuantity(largeQuantity));
     BOOST_REQUIRE(capturedReq.executionPayload.excessBlobGas.has_value());
@@ -365,9 +367,9 @@ BOOST_AUTO_TEST_CASE(newPayloadV2)
 
 BOOST_AUTO_TEST_CASE(newPayloadV3)
 {
-    auto tx = m_blockFactory->transactionFactory()->createTransaction(
-        0, "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100,
-        chainId, groupId, static_cast<int64_t>(utcTime()));
+    auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
+        "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100, chainId,
+        groupId, static_cast<int64_t>(utcTime()));
     bytes encodedTx;
     tx->encode(encodedTx);
     auto encodedTxHex = toHexStringWithPrefix(encodedTx);
@@ -421,8 +423,8 @@ BOOST_AUTO_TEST_CASE(newPayloadV4)
 BOOST_AUTO_TEST_CASE(newPayloadAndGetPayloadRoundTrip)
 {
     auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
-        "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100,
-        chainId, groupId, static_cast<int64_t>(utcTime()));
+        "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100, chainId,
+        groupId, static_cast<int64_t>(utcTime()));
     bytes encodedTx;
     tx->encode(encodedTx);
     auto encodedTxHex = toHexStringWithPrefix(encodedTx);
@@ -472,12 +474,12 @@ BOOST_AUTO_TEST_CASE(newPayloadAndGetPayloadRoundTrip)
     BOOST_REQUIRE(
         mockService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals.has_value());
     BOOST_CHECK_EQUAL(
-        mockService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals->front().amount,
+        mockService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals->front()
+            .amount,
         expectedLargeValue);
     BOOST_REQUIRE(
         mockService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed.has_value());
-    BOOST_CHECK_EQUAL(
-        *mockService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed,
+    BOOST_CHECK_EQUAL(*mockService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed,
         expectedLargeValue);
     BOOST_REQUIRE(
         mockService.m_state->capturedNewPayloadRequest->executionPayload.excessBlobGas.has_value());
@@ -485,10 +487,12 @@ BOOST_AUTO_TEST_CASE(newPayloadAndGetPayloadRoundTrip)
         *mockService.m_state->capturedNewPayloadRequest->executionPayload.excessBlobGas,
         expectedLargeValue);
 
-    bytes decodedEncodedTx;
-    mockService.m_state->capturedNewPayloadRequest->executionPayload.transactions.front()->encode(
-        decodedEncodedTx);
-    BOOST_CHECK_EQUAL(toHexStringWithPrefix(decodedEncodedTx), encodedTxHex);
+    // Raw-bytes carrier: newPayload preserves the wire bytes verbatim (no decoding).
+    BOOST_CHECK_EQUAL(
+        toHexStringWithPrefix(
+            mockService.m_state->capturedNewPayloadRequest->executionPayload.transactions.front()
+                .raw),
+        encodedTxHex);
 
     // --- engine_getPayloadV2 ---
     mockService.m_state->getPayloadResult->executionPayload =
@@ -508,14 +512,15 @@ BOOST_AUTO_TEST_CASE(newPayloadAndGetPayloadRoundTrip)
     BOOST_CHECK(getPayloadResponse["result"].isMember("executionPayload"));
     BOOST_CHECK_EQUAL(getPayloadResponse["result"]["executionPayload"]["transactions"].size(), 1);
     BOOST_CHECK_EQUAL(
-        getPayloadResponse["result"]["executionPayload"]["transactions"][0u].asString(), encodedTxHex);
+        getPayloadResponse["result"]["executionPayload"]["transactions"][0u].asString(),
+        encodedTxHex);
     BOOST_CHECK_EQUAL(
         getPayloadResponse["result"]["executionPayload"]["withdrawals"][0u]["amount"].asString(),
         largeQuantity);
     BOOST_CHECK_EQUAL(
         getPayloadResponse["result"]["executionPayload"]["blobGasUsed"].asString(), largeQuantity);
-    BOOST_CHECK_EQUAL(
-        getPayloadResponse["result"]["executionPayload"]["excessBlobGas"].asString(), largeQuantity);
+    BOOST_CHECK_EQUAL(getPayloadResponse["result"]["executionPayload"]["excessBlobGas"].asString(),
+        largeQuantity);
     BOOST_CHECK_EQUAL(getPayloadResponse["result"]["blockValue"].asString(), largeQuantity);
 }
 

--- a/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
@@ -38,7 +38,9 @@ public:
     {
         std::promise<bcos::bytes> promise;
         web3JsonRpc->onRPCRequest(
-            request, [&promise](bcos::bytes resp, boost::beast::http::status) { promise.set_value(std::move(resp)); });
+            request, [&promise](bcos::bytes resp, boost::beast::http::status) {
+                promise.set_value(std::move(resp));
+            });
         auto jsonBytes = promise.get_future().get();
         Json::Value value;
         Json::Reader reader;
@@ -201,6 +203,22 @@ BOOST_AUTO_TEST_CASE(getFilterChangesUnknownId)
 {
     auto resp = call(req("eth_getFilterChanges", R"(["0x999"])"));
     BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+}
+
+BOOST_AUTO_TEST_CASE(sendRawTransactionRejectsBlobTransaction)
+{
+    // L2 never admits blob (type-3) transactions; rejected before RLP decoding.
+    auto resp = call(req("eth_sendRawTransaction", R"(["0x03deadbeef"])"));
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_NE(resp["error"]["message"].asString().find("blob"), std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(sendRawTransactionRejectsDepositTransaction)
+{
+    // Deposits (0x7e) are CL-injected via the Engine API only, never via the tx pool.
+    auto resp = call(req("eth_sendRawTransaction", R"(["0x7edeadbeef"])"));
+    BOOST_REQUIRE(resp.isMember("error"));
+    BOOST_CHECK_NE(resp["error"]["message"].asString().find("deposit"), std::string::npos);
 }
 
 BOOST_AUTO_TEST_CASE(sendRawTransactionGarbageReportsError)

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -21,11 +21,11 @@
 
 #include "../common/RPCFixture.h"
 #include "bcos-utilities/DataConvertUtility.h"
-#include <bcos-framework/engine/AnyEngineService.h>
 #include <bcos-codec/wrapper/CodecWrapper.h>
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/hash/SM3.h>
 #include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-framework/engine/AnyEngineService.h>
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
 #include <bcos-framework/testutils/faker/FakeFrontService.h>
 #include <bcos-framework/testutils/faker/FakeLedger.h>
@@ -40,11 +40,11 @@
 #include <bcos-task/Task.h>
 #include <bcos-utilities/Exceptions.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
-#include <memory>
-#include <ostream>
 #include <atomic>
 #include <chrono>
 #include <filesystem>
+#include <memory>
+#include <ostream>
 #include <string_view>
 
 using namespace bcos;
@@ -61,8 +61,7 @@ public:
     /// inside AnyEngineService's proxy share the same state via this pointer.
     struct State
     {
-        engine::PayloadStatus payloadStatusResult{
-            .latestValidHash = std::nullopt,
+        engine::PayloadStatus payloadStatusResult{.latestValidHash = std::nullopt,
             .validationError = std::nullopt,
             .status = engine::PayloadValidationStatus::Valid};
         engine::GetPayloadResult getPayloadResult = std::make_unique<engine::GetPayloadData>();
@@ -103,7 +102,10 @@ public:
     }
 
     std::optional<bcos::protocol::BlockNumber> getSafeBlockNumber() const { return std::nullopt; }
-    std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() const { return std::nullopt; }
+    std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() const
+    {
+        return std::nullopt;
+    }
 };
 
 class Web3TestFixture : public RPCFixture
@@ -123,7 +125,9 @@ public:
         {
             std::promise<bcos::bytes> promise;
             web3JsonRpc->onRPCRequest(
-                request, [&promise](bcos::bytes resp, boost::beast::http::status) { promise.set_value(std::move(resp)); });
+                request, [&promise](bcos::bytes resp, boost::beast::http::status) {
+                    promise.set_value(std::move(resp));
+                });
             auto jsonBytes = promise.get_future().get();
             std::string_view json(
                 (char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
@@ -468,63 +472,35 @@ BOOST_AUTO_TEST_CASE(handleEIP1559TxTest)
 
 BOOST_AUTO_TEST_CASE(handleEIP4844TxTest)
 {
-    // method eth_sendRawTransaction
-    auto testEIP4844Tx = [&](std::string const& rawTx, std::string const& expectHash) {
-        // clang-format off
-        const std::string request = R"({"jsonrpc":"2.0","id":1132123, "method":"eth_sendRawTransaction","params":[")" + rawTx + R"("]})";
-        // clang-format on
-        auto rawTxBytes = fromHexWithPrefix(rawTx);
-        auto rawTxBytesRef = bcos::ref(rawTxBytes);
-        Web3Transaction rawWeb3Tx;
-        codec::rlp::decode(rawTxBytesRef, rawWeb3Tx);
-        onRPCRequestWrapper(request, [](auto&&, auto&&) {});
-        // validRespCheck(response);
-        // BOOST_TEST(response["id"].asInt64() == 1132123);
-        // BOOST_TEST(response["result"].asString() == expectHash);
-        std::vector<crypto::HashType> hashes = {HashType(expectHash)};
-        task::wait([&rawWeb3Tx](
-                       Web3TestFixture* self, decltype(hashes) m_hashes) -> task::Task<void> {
-            auto txs = co_await self->txPool->getTransactions(m_hashes);
-            BOOST_TEST(txs.size() == 1);
-            BOOST_TEST(txs[0]->hash() == m_hashes[0]);
-            BOOST_TEST(txs[0]->type() == 1);
-            BOOST_TEST(!txs[0]->extraTransactionBytes().empty());
-            auto ref = bytesRef(const_cast<unsigned char*>(txs[0]->extraTransactionBytes().data()),
-                txs[0]->extraTransactionBytes().size());
-            Web3Transaction tx;
-            bcos::codec::rlp::decode(ref, tx);
-            BOOST_TEST(tx.type == rawWeb3Tx.type);
-            BOOST_TEST(tx.data == rawWeb3Tx.data);
-            BOOST_TEST(tx.nonce == rawWeb3Tx.nonce);
-            BOOST_CHECK(tx.to == rawWeb3Tx.to);
-            BOOST_TEST(tx.value == rawWeb3Tx.value);
-            BOOST_TEST(tx.maxFeePerGas == rawWeb3Tx.maxFeePerGas);
-            BOOST_TEST(tx.maxPriorityFeePerGas == rawWeb3Tx.maxPriorityFeePerGas);
-            BOOST_TEST(tx.gasLimit == rawWeb3Tx.gasLimit);
-            BOOST_TEST(tx.accessList == rawWeb3Tx.accessList);
-            BOOST_CHECK(tx.chainId == rawWeb3Tx.chainId);
-            BOOST_TEST(tx.maxFeePerBlobGas == rawWeb3Tx.maxFeePerBlobGas);
-            BOOST_TEST(tx.blobVersionedHashes == rawWeb3Tx.blobVersionedHashes);
-        }(this, std::move(hashes)));
-        return rawWeb3Tx;
-    };
-
+    // L2 (OP Stack, Ecotone onwards) never admits blob transactions:
+    // eth_sendRawTransaction rejects type-3 envelopes before RLP decoding, and the
+    // transaction must not enter the pool. (These three mainnet blob transactions were
+    // previously asserted to be accepted — that acceptance was vestigial: FISCO carries
+    // no KZG/blob-sidecar support.)
     m_ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, std::to_string(1));
-    std::optional<storage::Entry> balanceOp = storage::Entry();
-    balanceOp->set(asBytes("123456700000000000"));
+    auto testRejectedEIP4844Tx = [&](std::string const& rawTx, std::string const& txHash) {
+        const std::string request =
+            R"({"jsonrpc":"2.0","id":1132123, "method":"eth_sendRawTransaction","params":[")" +
+            rawTx + R"("]})";
+        auto response = onRPCRequestWrapper(request);
+        BOOST_REQUIRE(response.isMember("error"));
+        BOOST_CHECK_NE(response["error"]["message"].asString().find("blob"), std::string::npos);
+        std::vector<crypto::HashType> hashes = {HashType(txHash)};
+        task::wait([](Web3TestFixture* self, decltype(hashes) m_hashes) -> task::Task<void> {
+            auto txs = co_await self->txPool->getTransactions(m_hashes);
+            BOOST_REQUIRE_EQUAL(txs.size(), 1);
+            BOOST_CHECK(!txs[0]);  // rejected transactions never reach the pool
+        }(this, std::move(hashes)));
+    };
     // clang-format off
-    // https://etherscan.io/tx/0x637b7e88d7a0992b62a973acd41736ee2b63be1c86d0ffeb683747964daea892
-    m_ledger->setStorageAt("2c169dfe5fbba12957bdd0ba47d9cedbfe260ca7", std::string(bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE), balanceOp);
-    testEIP4844Tx(
+    testRejectedEIP4844Tx(
         "0x03f902fd018309a7ee8405f5e1008522ecb25c008353ec6094c662c410c0ecf747543f5ba90660f6abebd9c8c480b90264b72d42a100000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000d06ad5334c4498113f3cc1548635e7c32bb72562421fddef1e60d165d8035ebe2031fe8a2addb2bec3c5c43b6168e3dac21f84cddbfae7d9e24977fbee8038772000000000000000000000000000000000000000000000000000000000009a7ed04ef432aa69fe0dd81c5d5d07464120008bbaede9cf73c4ca149f0be56acfbf605ba2078240f1585f96424c2d1ee48211da3b3f9177bf2b9880b4fc91d59e9a200000000000000000000000000000000000000000000000000000000000000010000000000000000df5459e0fefcbcfb5585179c4dfde48bc334f5836ad2821f0000000000000000883e48453eb072b0e184b27522f52d8324ee5d6ee778b05002c8df8c56bb3f47ab53b12be77ca1192abf4821a3e2b32c24d34af793fbcdca00000000000000000000000000000000cf420df13fc18924e41f7b0bd34de6a6000000000000000000000000000000000f389c6a65227d0e916c9670e8398e0d00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003088cf8a7c3410fc132c573b94603dd2cf6e25555808a487c925ae595f6e2d1907907ba57a3fb42729eb1de453ebeda6bc00000000000000000000000000000000c08522ecb25c00e1a00131e940049304bb30d0da71fcccc542712238c5e2aa6ad96cf7eb5fa8ef974880a0f9ea6a59f3f160f36e1e2248085ec9d3bc3797462b4e5fd2c53f6753ddc88cc3a06e0aa62f613475a881564eb9269762b466560d4870835a198e12f6d5e05a9eaa",
         "0x637b7e88d7a0992b62a973acd41736ee2b63be1c86d0ffeb683747964daea892");
-    // https://etherscan.io/tx/0x82d366c93c5fb2cbe8f1b6f0f19c260d11a958875560a398d75784ce9f4d6adf
-    m_ledger->setStorageAt("6887246668a3b87f54deb3b94ba47a6f63f32985", std::string(bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE), balanceOp);
-    testEIP4844Tx("0x03f9013b018310fcdb847735940085041e2a063282520894ff000000000000000000000000000000000000108080c0843b9aca00f8c6a001a74d77682287763fc9a460f1c0a2f686daa8bdbb8757564c0fc05f54bbd6d5a0015d0db22bb787710c9d112373a0a49132646f0813c478d15ed247c148982172a00185ece9183ab795a0bfd3326d5b64848d9839992ac3f3ce4a55afb6e7ba4520a0013d1e438e3fb85830cb49bad9598a1ac720b778796c67a00ed8e20eebde05c5a001ff9dae3fb9320795caa1b474a9f667f2022e0e3d8a678ebfe163d7801908c1a001622f10864730dcd603857f00824ad18e070c64b57f9878738db1f85cfad33880a04539a1636f5c431241be963c898bc59491ed7c01853b75ed9e9e9bc47d0aa9ada031880afe746833518e6ea271ecd6a3943fa6da09ba1f889531729a1c8270e7cc",
+    testRejectedEIP4844Tx(
+        "0x03f9013b018310fcdb847735940085041e2a063282520894ff000000000000000000000000000000000000108080c0843b9aca00f8c6a001a74d77682287763fc9a460f1c0a2f686daa8bdbb8757564c0fc05f54bbd6d5a0015d0db22bb787710c9d112373a0a49132646f0813c478d15ed247c148982172a00185ece9183ab795a0bfd3326d5b64848d9839992ac3f3ce4a55afb6e7ba4520a0013d1e438e3fb85830cb49bad9598a1ac720b778796c67a00ed8e20eebde05c5a001ff9dae3fb9320795caa1b474a9f667f2022e0e3d8a678ebfe163d7801908c1a001622f10864730dcd603857f00824ad18e070c64b57f9878738db1f85cfad33880a04539a1636f5c431241be963c898bc59491ed7c01853b75ed9e9e9bc47d0aa9ada031880afe746833518e6ea271ecd6a3943fa6da09ba1f889531729a1c8270e7cc",
         "0x82d366c93c5fb2cbe8f1b6f0f19c260d11a958875560a398d75784ce9f4d6adf");
-    // https://etherscan.io/tx/0xa8fd95a70b4f2b6cea8c52bcb782b5c3f806a0d5250cf75a1d97a6e899f09979
-    m_ledger->setStorageAt("625726c858dbf78c0125436c943bf4b4be9d9033", std::string(bcos::ledger::ACCOUNT_TABLE_FIELDS::BALANCE), balanceOp);
-    testEIP4844Tx("0x03f9013a0182a8f98477359400850432ec4812825208946f54ca6f6ede96662024ffd61bfd18f3f4e34dff8080c0843b9aca00f8c6a001fb60d5b0abeff9e3d47099386a31eed62cd55d54aa146b42d10eb81b0a9b2aa00156b2193030eb7c9496d8586492934a57a5ebd0fac816ef1ea01dc4d09498c5a001bd78704a4b015adec86a654a123045312b083641ababec0e60ef17be4453e7a001b59b9a8b8d35bd6afcff91c6afc56ebcaf4a62f6e83f5e57aac4484f022cc4a00110aac506aff4957e40d4640f0763015b84bbb8c23f50f1b13d501067bea878a001f100a97a70563cd623e588c976155ffe5999d1e9258302d969964d7524bd0280a08c1cff27365c5fe0a6ebfe5e010b3460747489302547f3ba5b181390fad485ada02af2f430e0dfad48ba78853b59486ea7425835c3a7034bb22702234f8994288f",
+    testRejectedEIP4844Tx(
+        "0x03f9013a0182a8f98477359400850432ec4812825208946f54ca6f6ede96662024ffd61bfd18f3f4e34dff8080c0843b9aca00f8c6a001fb60d5b0abeff9e3d47099386a31eed62cd55d54aa146b42d10eb81b0a9b2aa00156b2193030eb7c9496d8586492934a57a5ebd0fac816ef1ea01dc4d09498c5a001bd78704a4b015adec86a654a123045312b083641ababec0e60ef17be4453e7a001b59b9a8b8d35bd6afcff91c6afc56ebcaf4a62f6e83f5e57aac4484f022cc4a00110aac506aff4957e40d4640f0763015b84bbb8c23f50f1b13d501067bea878a001f100a97a70563cd623e588c976155ffe5999d1e9258302d969964d7524bd0280a08c1cff27365c5fe0a6ebfe5e010b3460747489302547f3ba5b181390fad485ada02af2f430e0dfad48ba78853b59486ea7425835c3a7034bb22702234f8994288f",
         "0xa8fd95a70b4f2b6cea8c52bcb782b5c3f806a0d5250cf75a1d97a6e899f09979");
     // clang-format on
 }
@@ -536,25 +512,24 @@ BOOST_AUTO_TEST_CASE(handleEngineNotAvailableTest)
     auto response = onRPCRequestWrapper(request);
     BOOST_TEST(response.isMember("error"));
     BOOST_TEST(response["error"]["code"].asInt() == MethodNotFound);
-    BOOST_TEST(
-        response["error"]["message"].asString() == "Method not found");
+    BOOST_TEST(response["error"]["message"].asString() == "Method not found");
 }
 
 BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
 {
     TestEngineService testEngineService;
-    nodeService->engineService() = std::make_shared<bcos::engine::AnyEngineService>(testEngineService);
+    nodeService->engineService() =
+        std::make_shared<bcos::engine::AnyEngineService>(testEngineService);
 
     // Create a separate Web3JsonRpcImpl with OP Engine enabled for engine API tests
-    auto engineRpc = std::make_shared<Web3JsonRpcImpl>(
-        groupId, 8, rpc->groupManager(), nullptr, false, true);
+    auto engineRpc =
+        std::make_shared<Web3JsonRpcImpl>(groupId, 8, rpc->groupManager(), nullptr, false, true);
 
     auto engineRequest = [&](std::string_view req) -> Json::Value {
         std::promise<bcos::bytes> promise;
-        engineRpc->onRPCRequest(req,
-            [&promise](bcos::bytes resp, boost::beast::http::status) {
-                promise.set_value(std::move(resp));
-            });
+        engineRpc->onRPCRequest(req, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
         auto jsonBytes = promise.get_future().get();
         Json::Value val;
         Json::Reader reader;
@@ -563,8 +538,8 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
     };
 
     auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
-        "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100,
-        chainId, groupId, static_cast<int64_t>(utcTime()));
+        "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd", bytes{0x12, 0x34}, "nonce-1", 100, chainId,
+        groupId, static_cast<int64_t>(utcTime()));
     bytes encodedTx;
     tx->encode(encodedTx);
     auto encodedTxHex = toHexStringWithPrefix(encodedTx);
@@ -594,21 +569,28 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest.has_value());
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadVersion.has_value());
     BOOST_TEST(*testEngineService.m_state->capturedNewPayloadVersion == 2);
-    BOOST_TEST(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.transactions.size() == 1);
-    BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals.has_value());
-    BOOST_TEST(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals->front().amount ==
-               expectedLargeValue);
-    BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed.has_value());
-    BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.excessBlobGas.has_value());
-    BOOST_TEST(*testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed ==
-               expectedLargeValue);
-    BOOST_TEST(*testEngineService.m_state->capturedNewPayloadRequest->executionPayload.excessBlobGas ==
-               expectedLargeValue);
+    BOOST_TEST(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.transactions
+                   .size() == 1);
+    BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals
+            .has_value());
+    BOOST_TEST(
+        testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals->front()
+            .amount == expectedLargeValue);
+    BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed
+            .has_value());
+    BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload
+            .excessBlobGas.has_value());
+    BOOST_TEST(
+        *testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed ==
+        expectedLargeValue);
+    BOOST_TEST(
+        *testEngineService.m_state->capturedNewPayloadRequest->executionPayload.excessBlobGas ==
+        expectedLargeValue);
 
-    bytes decodedEncodedTx;
-    testEngineService.m_state->capturedNewPayloadRequest->executionPayload.transactions.front()->encode(
-        decodedEncodedTx);
-    BOOST_TEST(toHexStringWithPrefix(decodedEncodedTx) == encodedTxHex);
+    // Raw-bytes carrier: newPayload preserves the wire bytes verbatim (no decoding).
+    BOOST_TEST(toHexStringWithPrefix(testEngineService.m_state->capturedNewPayloadRequest
+                       ->executionPayload.transactions.front()
+                       .raw) == encodedTxHex);
 
     testEngineService.m_state->getPayloadResult->executionPayload =
         testEngineService.m_state->capturedNewPayloadRequest->executionPayload;
@@ -623,9 +605,11 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
     BOOST_TEST(*testEngineService.m_state->capturedPayloadId == "payload-id-1");
     BOOST_TEST(*testEngineService.m_state->capturedGetPayloadVersion == 2);
     BOOST_TEST(getPayloadResponse["result"]["executionPayload"]["transactions"].size() == 1);
-    BOOST_TEST(getPayloadResponse["result"]["executionPayload"]["transactions"][0].asString() == encodedTxHex);
-    BOOST_TEST(getPayloadResponse["result"]["executionPayload"]["withdrawals"][0]["amount"].asString() ==
-               largeQuantity);
+    BOOST_TEST(getPayloadResponse["result"]["executionPayload"]["transactions"][0].asString() ==
+               encodedTxHex);
+    BOOST_TEST(
+        getPayloadResponse["result"]["executionPayload"]["withdrawals"][0]["amount"].asString() ==
+        largeQuantity);
     BOOST_TEST(getPayloadResponse["result"]["blockValue"].asString() == largeQuantity);
 }
 
@@ -895,9 +879,8 @@ BOOST_AUTO_TEST_CASE(jwtHttpRequestAuthTest)
     auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::steady_clock::now().time_since_epoch())
                   .count();
-    auto secretFile = tempDir /
-                      ("fisco-bcos-jwt-rpc-test-" + std::to_string(ns) + "-" +
-                          std::to_string(counter.fetch_add(1)) + ".hex");
+    auto secretFile = tempDir / ("fisco-bcos-jwt-rpc-test-" + std::to_string(ns) + "-" +
+                                    std::to_string(counter.fetch_add(1)) + ".hex");
     {
         std::ofstream ofs(secretFile);
         ofs << secretHex;
@@ -908,8 +891,8 @@ BOOST_AUTO_TEST_CASE(jwtHttpRequestAuthTest)
     config->setClockSkewSecs(60);
     config->setAllowedAlgorithms("HS256");
 
-    auto engineRpc = std::make_shared<Web3JsonRpcImpl>(
-        groupId, 8, rpc->groupManager(), nullptr, false, true);
+    auto engineRpc =
+        std::make_shared<Web3JsonRpcImpl>(groupId, 8, rpc->groupManager(), nullptr, false, true);
     engineRpc->setJwtVerifier(std::make_shared<JwtVerifier>(config));
 
     auto secretBytes = fromHex(secretHex);
@@ -931,8 +914,8 @@ BOOST_AUTO_TEST_CASE(jwtHttpRequestAuthTest)
         request.body() = R"({"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]})";
         request.prepare_payload();
 
-        engineRpc->onRPCRequest(request,
-            [&promise](bcos::bytes resp, boost::beast::http::status status) {
+        engineRpc->onRPCRequest(
+            request, [&promise](bcos::bytes resp, boost::beast::http::status status) {
                 promise.set_value({std::move(resp), status});
             });
         auto [resp, status] = promise.get_future().get();
@@ -955,8 +938,8 @@ BOOST_AUTO_TEST_CASE(jwtHttpRequestAuthTest)
         request.body() = R"({"jsonrpc":"2.0","id":2,"method":"eth_chainId","params":[]})";
         request.prepare_payload();
 
-        engineRpc->onRPCRequest(request,
-            [&promise](bcos::bytes resp, boost::beast::http::status status) {
+        engineRpc->onRPCRequest(
+            request, [&promise](bcos::bytes resp, boost::beast::http::status status) {
                 promise.set_value({std::move(resp), status});
             });
         auto [resp, status] = promise.get_future().get();
@@ -974,8 +957,8 @@ BOOST_AUTO_TEST_CASE(jwtHttpRequestAuthTest)
         request.body() = R"({"jsonrpc":"2.0","id":3,"method":"eth_chainId","params":[]})";
         request.prepare_payload();
 
-        engineRpc->onRPCRequest(request,
-            [&promise](bcos::bytes resp, boost::beast::http::status status) {
+        engineRpc->onRPCRequest(
+            request, [&promise](bcos::bytes resp, boost::beast::http::status status) {
                 promise.set_value({std::move(resp), status});
             });
         auto [resp, status] = promise.get_future().get();

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
@@ -22,6 +22,7 @@
 #include "TransactionImpl.h"
 #include "../impl/TarsHashable.h"
 #include "../impl/TarsSerializable.h"
+#include "Web3RawTransaction.h"
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-codec/rlp/RLPEncode.h>
@@ -84,7 +85,7 @@ bcos::crypto::HashType bcostars::protocol::TransactionImpl::hash() const
     return hashResult;
 }
 
-static bcos::crypto::HashType recomputeWeb3CanonicalHash(
+bcos::bytes bcostars::protocol::reassembleWeb3RawTransaction(
     bcos::bytesConstRef payload, bcos::bytesConstRef signature)
 {
     // The byte-splice logic mirrors Web3Transaction::encode() / txHash() in
@@ -115,10 +116,10 @@ static bcos::crypto::HashType recomputeWeb3CanonicalHash(
     auto const yParity = static_cast<uint64_t>(signature[64]);
 
     auto throwDecode = [](std::string_view stage) {
-        BCOS_LOG(INFO) << LOG_DESC("recompute canonical Web3 txHash: decode failed")
+        BCOS_LOG(INFO) << LOG_DESC("reassemble raw Web3 transaction: decode failed")
                        << LOG_KV("stage", stage);
         BOOST_THROW_EXCEPTION(std::invalid_argument(
-            std::string("recompute canonical Web3 txHash: decode failed at ").append(stage)));
+            std::string("reassemble raw Web3 transaction: decode failed at ").append(stage)));
     };
     if (payload.empty()) [[unlikely]]
     {
@@ -234,7 +235,7 @@ static bcos::crypto::HashType recomputeWeb3CanonicalHash(
         full.insert(full.end(), fields.begin(), fields.end());
         full.insert(full.end(), sig.begin(), sig.end());
     }
-    return bcos::crypto::keccak256Hash(bcos::ref(full));
+    return full;
 }
 
 void bcostars::protocol::TransactionImpl::calculateHash(const bcos::crypto::Hash& hashImpl)
@@ -247,8 +248,8 @@ void bcostars::protocol::TransactionImpl::calculateHash(const bcos::crypto::Hash
     // The recompute is a byte splice plus one keccak, cheap enough to always run.
     if (type() == static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction))
     {
-        auto const canonicalTxHash =
-            recomputeWeb3CanonicalHash(extraTransactionBytes(), signatureData());
+        auto const canonicalTxHash = bcos::crypto::keccak256Hash(
+            bcos::ref(reassembleWeb3RawTransaction(extraTransactionBytes(), signatureData())));
         m_inner()->extraTransactionHash.assign(canonicalTxHash.begin(), canonicalTxHash.end());
         return;
     }

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3RawTransaction.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3RawTransaction.h
@@ -1,0 +1,40 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Web3RawTransaction.h
+ * @brief Reassembly of full signed raw Ethereum transaction bytes
+ */
+
+#pragma once
+
+#include <bcos-utilities/Common.h>
+
+namespace bcostars::protocol
+{
+
+/// Reassemble the full signed raw transaction bytes (EIP-2718 typed envelope or legacy
+/// RLP list) from the signing payload (Transaction::extraTransactionBytes()) and the
+/// 65-byte r||s||yParity signature (Transaction::signatureData()).
+///
+/// This is the byte-splice introduced for the canonical Web3 txHash recompute (FIB-New1);
+/// keccak256 of the returned bytes is that canonical hash. The Engine API getPayload path
+/// uses the returned bytes directly as the transaction wire form.
+///
+/// Throws std::invalid_argument when the payload is not a decodable Web3 signing payload
+/// or the signature is not 65 bytes.
+bcos::bytes reassembleWeb3RawTransaction(
+    bcos::bytesConstRef payload, bcos::bytesConstRef signature);
+
+}  // namespace bcostars::protocol

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "EngineServiceImpl.h"
+#include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
 
 namespace
@@ -69,9 +70,51 @@ bool bcos::engine::detail::isGetPayloadVersionCompatible(
     return false;
 }
 
+namespace
+{
+/// Shared over the two transaction carriers (attributes hex strings and payload raw
+/// bytes): a blob (type-3) or unsupported/unknown-type transaction invalidates the whole
+/// carrier — it is never dropped individually (L2 forbids blob transactions entirely).
+std::optional<std::string> validateRawTransactionKind(
+    bcos::engine::RawTransactionKind kind, std::size_t index)
+{
+    using bcos::engine::RawTransactionKind;
+    if (kind == RawTransactionKind::Blob)
+    {
+        return "blob transactions are not allowed (transaction index " + std::to_string(index) +
+               ")";
+    }
+    if (kind == RawTransactionKind::Unsupported)
+    {
+        return "unsupported transaction type (transaction index " + std::to_string(index) + ")";
+    }
+    return std::nullopt;
+}
+}  // namespace
+
 std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     const PayloadAttributes& payloadAttributes, std::uint32_t version)
 {
+    if (payloadAttributes.transactions.has_value())
+    {
+        for (std::size_t i = 0; i < payloadAttributes.transactions->size(); ++i)
+        {
+            bcos::bytes raw;
+            try
+            {
+                raw = bcos::fromHex((*payloadAttributes.transactions)[i]);
+            }
+            catch (std::exception const&)
+            {
+                return "payloadAttributes.transactions[" + std::to_string(i) +
+                       "] is not a hex string";
+            }
+            if (auto error = validateRawTransactionKind(dispatchRawTransaction(bcos::ref(raw)), i))
+            {
+                return error;
+            }
+        }
+    }
     if (version == 1 && payloadAttributes.withdrawals.has_value())
     {
         return std::string("withdrawals are not part of PayloadAttributesV1");
@@ -94,11 +137,16 @@ std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
 std::optional<std::string> bcos::engine::detail::validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version)
 {
-    for (auto const& transaction : executionPayload.transactions)
+    for (std::size_t i = 0; i < executionPayload.transactions.size(); ++i)
     {
-        if (!transaction)
+        auto const& raw = executionPayload.transactions[i].raw;
+        if (raw.empty())
         {
-            return std::string("executionPayload.transactions entries must not be null");
+            return "executionPayload.transactions[" + std::to_string(i) + "] is empty";
+        }
+        if (auto error = validateRawTransactionKind(dispatchRawTransaction(bcos::ref(raw)), i))
+        {
+            return error;
         }
     }
     if (version == 1 && executionPayload.withdrawals.has_value())

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/merkle/Merkle.h"
 #include "bcos-framework/engine/EngineService.h"
 #include "bcos-framework/engine/Types.h"
@@ -34,6 +35,7 @@
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Common.h"
+#include "bcos-utilities/DataConvertUtility.h"
 #include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
 #include <bcos-tars-protocol/protocol/Web3RawTransaction.h>
@@ -43,6 +45,9 @@
 #include <mutex>
 #include <optional>
 #include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/indirect.hpp>
+#include <range/v3/view/transform.hpp>
 #include <shared_mutex>
 #include <string>
 #include <string_view>
@@ -245,8 +250,15 @@ public:
         // state nonce here is still the committed one.
         std::vector<protocol::Transaction::Ptr> sealedTxs;
         view.newMutable();
-        m_memPool.get().remove(view);
-        m_memPool.get().seal(m_blockTxCountLimit, view, std::back_inserter(sealedTxs));
+        // noTxPool=true (OP Stack): the payload must not take any transaction from the
+        // pool — it contains exactly the forced transaction list (possibly none). Skip
+        // both pool hygiene and sealing; forced transactions are prepended in
+        // buildPayload.
+        if (!payloadAttributes->noTxPool.value_or(false))
+        {
+            m_memPool.get().remove(view);
+            m_memPool.get().seal(m_blockTxCountLimit, view, std::back_inserter(sealedTxs));
+        }
 
         // Step 3: Build the payload on the executed view (already mutable above).
         auto payloadId = nextPayloadID();
@@ -493,9 +505,16 @@ private:
                 // this restores parity with that path (eth_getLogs uses it as a filter).
                 auto const& bloom = it->second.executionPayload.logsBloom;
                 block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+                // Raw-only entries (forced transactions) carry no decoded form and are
+                // not modeled as ledger transactions until execution wiring lands; the
+                // persisted transaction list therefore matches the receipts list, which
+                // also only covers the executed (decoded) subset.
                 for (auto const& tx : it->second.executionPayload.transactions)
                 {
-                    block->appendTransaction(tx.decoded);
+                    if (tx.decoded)
+                    {
+                        block->appendTransaction(tx.decoded);
+                    }
                 }
                 for (auto const& receipt : it->second.receipts)
                 {
@@ -503,6 +522,7 @@ private:
                 }
                 auto blockTxs = std::make_shared<protocol::ConstTransactions>(
                     it->second.executionPayload.transactions |
+                    ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
                     ::ranges::views::transform([](auto const& tx) {
                         return protocol::Transaction::ConstPtr(tx.decoded);
                     }) |
@@ -566,7 +586,28 @@ private:
         // eth_sendRawTransaction, which admits Web3 transactions exclusively, so the
         // exclusion only ever triggers for in-process callers.
         std::vector<EngineTransaction> engineTransactions;
-        engineTransactions.reserve(sealedTxs.size());
+        engineTransactions.reserve(
+            payloadAttributes.transactions.value_or(std::vector<std::string>{}).size() +
+            sealedTxs.size());
+        // Forced transactions (OP attributes.transactions) come FIRST, in the order the
+        // CL gave them — this is the only OP-sanctioned path for deposits. Their raw
+        // EIP-2718 bytes are carried byte-for-byte (hex validity and dispatch
+        // admissibility were already enforced by validatePayloadAttributes, which runs
+        // before buildPayload). They carry no decoded executable form yet: 0x7E deposit
+        // execution (runDeposit) and raw->executable decoding for typed/legacy forced
+        // transactions belong to the execution-lane wiring, so raw-only entries are
+        // placed in the payload, participate in the transactions root via their
+        // canonical keccak256(raw) hash, but are not executed and do not advance state.
+        if (payloadAttributes.transactions.has_value())
+        {
+            for (auto const& forcedHex : *payloadAttributes.transactions)
+            {
+                engineTransactions.push_back(EngineTransaction{
+                    .raw = fromHex(forcedHex),
+                    .decoded = nullptr,
+                });
+            }
+        }
         for (auto& sealedTx : sealedTxs)
         {
             if (sealedTx->type() !=
@@ -669,15 +710,19 @@ private:
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
 
         // Step 2c: Execute transactions via the scheduler, over the decoded executable
-        // forms (locally sealed transactions always carry one).
-        auto receipts =
-            co_await m_scheduler.get().executeBlock(view, m_executor.get(), *blockHeader,
-                executionPayload.transactions |
-                    ::ranges::views::transform(
-                        [](auto const& transaction) -> bcos::protocol::Transaction const& {
-                            return *transaction.decoded;
-                        }),
-                ledgerConfig);
+        // forms. Raw-only entries (forced transactions from the OP attributes list) have
+        // no executable form yet and are skipped — see the forced-transaction comment
+        // above. Materialized into a vector because scheduler implementations require a
+        // sized range (a lazy filter view is not sized).
+        auto executableTransactions =
+            executionPayload.transactions | ::ranges::views::filter([](auto const& transaction) {
+                return transaction.decoded != nullptr;
+            }) |
+            ::ranges::views::transform(
+                [](auto const& transaction) { return transaction.decoded; }) |
+            ::ranges::to<std::vector>();
+        auto receipts = co_await m_scheduler.get().executeBlock(view, m_executor.get(),
+            *blockHeader, executableTransactions | ::ranges::views::indirect, ledgerConfig);
 
         // Step 2d: Compute transaction root (Merkle over tx hashes)
         // TODO: Use scheduler_v1::calculateTransactionRoot from BaselineScheduler.h
@@ -692,8 +737,13 @@ private:
             if (!executionPayload.transactions.empty())
             {
                 auto txHashes =
-                    executionPayload.transactions |
-                    ::ranges::views::transform([](auto& tx) { return tx.decoded->hash(); });
+                    executionPayload.transactions | ::ranges::views::transform([](auto& tx) {
+                        // Canonical txHash: decoded transactions expose it directly;
+                        // raw-only (forced) entries hash their EIP-2718 bytes, which is
+                        // the canonical hash for every raw transaction kind.
+                        return tx.decoded ? tx.decoded->hash() :
+                                            bcos::crypto::keccak256Hash(bcos::ref(tx.raw));
+                    });
                 std::vector<h256> merkleTrie;
                 merkle.generateMerkle(txHashes, merkleTrie);
                 if (!merkleTrie.empty())

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -32,6 +32,7 @@
 #include "bcos-ledger/LedgerMethods.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
+#include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
@@ -552,32 +553,38 @@ private:
     {
         // Dual carrier: every sealed transaction is stored with both its raw EIP-2718
         // bytes (the wire form getPayload returns) and the decoded executable form (used
-        // for execution and ledger persistence). Web3 transactions reassemble their exact
-        // signed raw bytes from the signing payload + signature — the same splice that
-        // produces the canonical txHash. Native Tars transactions have no EIP-2718 form
-        // and keep the legacy Tars encoding as a fallback. NOTE: a Tars-encoded wire form
-        // does NOT pass this service's own newPayload validation (its first byte
-        // dispatches as Unsupported), so a payload built from a native transaction only
-        // serves flows that stop at getPayload. In production the mempool's sole ingress
-        // is eth_sendRawTransaction, which admits Web3 transactions exclusively, so this
-        // branch is unreachable there; it exists for legacy test fixtures.
+        // for execution and ledger persistence). Web3 transactions reassemble their
+        // exact signed raw bytes from the signing payload + signature — the same splice
+        // that produces the canonical txHash.
+        //
+        // Only transactions with a genuine EIP-2718 wire form enter the OP payload. A
+        // native Tars transaction has no such form — any bytes emitted for it would be
+        // rejected by this service's own newPayload dispatch, so sealing one would make
+        // the service build a payload it then judges INVALID (an FCU -> getPayload ->
+        // newPayload livelock). Such transactions are excluded from the payload with a
+        // warning and remain in the mempool. In production the mempool's sole ingress is
+        // eth_sendRawTransaction, which admits Web3 transactions exclusively, so the
+        // exclusion only ever triggers for in-process callers.
         std::vector<EngineTransaction> engineTransactions;
         engineTransactions.reserve(sealedTxs.size());
         for (auto& sealedTx : sealedTxs)
         {
-            bytes raw;
-            if (sealedTx->type() ==
+            if (sealedTx->type() !=
                 static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction))
             {
-                raw = bcostars::protocol::reassembleWeb3RawTransaction(
-                    sealedTx->extraTransactionBytes(), sealedTx->signatureData());
+                BCOS_LOG(WARNING) << LOG_BADGE("EngineService")
+                                  << LOG_DESC(
+                                         "buildPayload: excluding transaction without an EIP-2718 "
+                                         "wire form from the OP payload")
+                                  << LOG_KV("hash", sealedTx->hash().hex())
+                                  << LOG_KV("type", static_cast<int>(sealedTx->type()));
+                continue;
             }
-            else
-            {
-                sealedTx->encode(raw);
-            }
-            engineTransactions.push_back(
-                EngineTransaction{.raw = std::move(raw), .decoded = std::move(sealedTx)});
+            engineTransactions.push_back(EngineTransaction{
+                .raw = bcostars::protocol::reassembleWeb3RawTransaction(
+                    sealedTx->extraTransactionBytes(), sealedTx->signatureData()),
+                .decoded = std::move(sealedTx),
+            });
         }
 
         ExecutionPayload executionPayload{

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -35,6 +35,7 @@
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
+#include <bcos-tars-protocol/protocol/Web3RawTransaction.h>
 #include <cstdint>
 #include <deque>
 #include <functional>
@@ -493,7 +494,7 @@ private:
                 block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
                 for (auto const& tx : it->second.executionPayload.transactions)
                 {
-                    block->appendTransaction(tx);
+                    block->appendTransaction(tx.decoded);
                 }
                 for (auto const& receipt : it->second.receipts)
                 {
@@ -501,8 +502,9 @@ private:
                 }
                 auto blockTxs = std::make_shared<protocol::ConstTransactions>(
                     it->second.executionPayload.transactions |
-                    ::ranges::views::transform(
-                        [](auto const& tx) { return protocol::Transaction::ConstPtr(tx); }) |
+                    ::ranges::views::transform([](auto const& tx) {
+                        return protocol::Transaction::ConstPtr(tx.decoded);
+                    }) |
                     ::ranges::to<std::vector>());
                 co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
                 co_await m_globalStateStorage.get().mergeBackStorage(prewriteStorage);
@@ -548,6 +550,36 @@ private:
         std::uint32_t version, bcos::protocol::BlockNumber nextBlockNumber,
         std::vector<protocol::Transaction::Ptr> sealedTxs, ViewType& view) const
     {
+        // Dual carrier: every sealed transaction is stored with both its raw EIP-2718
+        // bytes (the wire form getPayload returns) and the decoded executable form (used
+        // for execution and ledger persistence). Web3 transactions reassemble their exact
+        // signed raw bytes from the signing payload + signature — the same splice that
+        // produces the canonical txHash. Native Tars transactions have no EIP-2718 form
+        // and keep the legacy Tars encoding as a fallback. NOTE: a Tars-encoded wire form
+        // does NOT pass this service's own newPayload validation (its first byte
+        // dispatches as Unsupported), so a payload built from a native transaction only
+        // serves flows that stop at getPayload. In production the mempool's sole ingress
+        // is eth_sendRawTransaction, which admits Web3 transactions exclusively, so this
+        // branch is unreachable there; it exists for legacy test fixtures.
+        std::vector<EngineTransaction> engineTransactions;
+        engineTransactions.reserve(sealedTxs.size());
+        for (auto& sealedTx : sealedTxs)
+        {
+            bytes raw;
+            if (sealedTx->type() ==
+                static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction))
+            {
+                raw = bcostars::protocol::reassembleWeb3RawTransaction(
+                    sealedTx->extraTransactionBytes(), sealedTx->signatureData());
+            }
+            else
+            {
+                sealedTx->encode(raw);
+            }
+            engineTransactions.push_back(
+                EngineTransaction{.raw = std::move(raw), .decoded = std::move(sealedTx)});
+        }
+
         ExecutionPayload executionPayload{
             .logsBloom = Bloom{},
             .parentHash = forkchoiceState.headBlockHash,
@@ -558,7 +590,7 @@ private:
             .gasUsed = 0,
             .baseFeePerGas = 0,
             .blockHash = detail::syntheticHash(payloadId),
-            .transactions = std::move(sealedTxs),
+            .transactions = std::move(engineTransactions),
             .extraData = {},
             .feeRecipient = payloadAttributes.suggestedFeeRecipient,
             .timestamp = payloadAttributes.timestamp,
@@ -629,10 +661,16 @@ private:
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
 
-        // Step 2c: Execute transactions via the scheduler
-        // Use views::indirect to dereference shared_ptr<Transaction> -> const Transaction&
-        auto receipts = co_await m_scheduler.get().executeBlock(view, m_executor.get(),
-            *blockHeader, executionPayload.transactions | ::ranges::views::indirect, ledgerConfig);
+        // Step 2c: Execute transactions via the scheduler, over the decoded executable
+        // forms (locally sealed transactions always carry one).
+        auto receipts =
+            co_await m_scheduler.get().executeBlock(view, m_executor.get(), *blockHeader,
+                executionPayload.transactions |
+                    ::ranges::views::transform(
+                        [](auto const& transaction) -> bcos::protocol::Transaction const& {
+                            return *transaction.decoded;
+                        }),
+                ledgerConfig);
 
         // Step 2d: Compute transaction root (Merkle over tx hashes)
         // TODO: Use scheduler_v1::calculateTransactionRoot from BaselineScheduler.h
@@ -646,8 +684,9 @@ private:
                 hasher.clone());
             if (!executionPayload.transactions.empty())
             {
-                auto txHashes = executionPayload.transactions |
-                                ::ranges::views::transform([](auto& tx) { return tx->hash(); });
+                auto txHashes =
+                    executionPayload.transactions |
+                    ::ranges::views::transform([](auto& tx) { return tx.decoded->hash(); });
                 std::vector<h256> merkleTrie;
                 merkle.generateMerkle(txHashes, merkleTrie);
                 if (!merkleTrie.empty())

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -20,8 +20,8 @@
 #pragma once
 
 #include "bcos-crypto/merkle/Merkle.h"
-#include "bcos-framework/engine/Types.h"
 #include "bcos-framework/engine/EngineService.h"
+#include "bcos-framework/engine/Types.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/protocol/BlockFactory.h"
@@ -36,6 +36,7 @@
 #include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -43,7 +44,6 @@
 #include <shared_mutex>
 #include <string>
 #include <string_view>
-#include <deque>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -257,6 +257,7 @@ public:
             .blockValue = 0,
             .blobsBundle = std::nullopt,
             .shouldOverrideBuilder = false,
+            .parentBeaconBlockRoot = payloadAttributes->parentBeaconBlockRoot,
             .view = std::make_shared<ViewType>(std::move(view)),
             .header = std::move(built.header),
             .receipts = std::move(built.receipts),
@@ -284,8 +285,8 @@ public:
                 auto const evictedId = m_payloadOrder.front();
                 m_payloadOrder.pop_front();
                 m_payloadCache.erase(evictedId);
-                std::erase_if(m_blockHashToPayloadId,
-                    [&](auto const& kv) { return kv.second == evictedId; });
+                std::erase_if(
+                    m_blockHashToPayloadId, [&](auto const& kv) { return kv.second == evictedId; });
             }
         }
         result.payloadId = payloadId;
@@ -329,6 +330,9 @@ private:
         u256 blockValue = 0;
         std::optional<BlobsBundleV1> blobsBundle;
         bool shouldOverrideBuilder = false;
+        /// Beacon root the payload was built with (from PayloadAttributes) or received
+        /// with (from NewPayloadRequest); echoed in the getPayload response (OP Stack).
+        std::optional<h256> parentBeaconBlockRoot;
         std::shared_ptr<ViewType> view;
         /// Built-block artifacts kept so newPayload() can persist the ledger block tables
         /// (SYS_NUMBER_2_HASH / SYS_HASH_2_NUMBER / SYS_NUMBER_2_BLOCK_HEADER /
@@ -384,6 +388,7 @@ private:
             .blobsBundle = it->second.blobsBundle,
             .shouldOverrideBuilder = it->second.shouldOverrideBuilder,
             .executionRequests = std::nullopt,
+            .parentBeaconBlockRoot = it->second.parentBeaconBlockRoot,
         });
     }
 
@@ -450,6 +455,7 @@ private:
             .blockValue = 0,
             .blobsBundle = std::nullopt,
             .shouldOverrideBuilder = false,
+            .parentBeaconBlockRoot = request.parentBeaconBlockRoot,
             .view = nullptr,
             .header = nullptr,
             .receipts = {},
@@ -498,8 +504,7 @@ private:
                     ::ranges::views::transform(
                         [](auto const& tx) { return protocol::Transaction::ConstPtr(tx); }) |
                     ::ranges::to<std::vector>());
-                co_await ledger::prewriteBlockToBuffer(
-                    *m_ledger, blockTxs, block, prewriteStorage);
+                co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
                 co_await m_globalStateStorage.get().mergeBackStorage(prewriteStorage);
             }
             else
@@ -518,9 +523,8 @@ private:
         // executed (unbounded memory over time). Keep only the just-committed block; the
         // newPayload() parent check accepts the head hash directly, so dropping older
         // blockHash rows is safe.
-        std::erase_if(m_blockHashToPayloadId, [&](auto const& kv) {
-            return kv.first != request.executionPayload.blockHash;
-        });
+        std::erase_if(m_blockHashToPayloadId,
+            [&](auto const& kv) { return kv.first != request.executionPayload.blockHash; });
         std::erase_if(m_payloadCache, [&](auto const& kv) { return kv.first != payloadId; });
 
         co_return makeStatus(
@@ -562,8 +566,7 @@ private:
             .withdrawals = std::nullopt,
             .blobGasUsed = std::nullopt,
             .excessBlobGas = std::nullopt,
-            .blockAccessList = std::nullopt,
-            .slotNumber = std::nullopt,
+            .withdrawalsRoot = std::nullopt,
         };
 
         if (version >= static_cast<std::uint32_t>(ApiVersion::V2))

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -5,8 +5,11 @@
 
 #include "engine/bcos-engine/EngineServiceImpl.h"
 
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-concepts/ByteBuffer.h>
 #include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/engine/RawTransactionDispatch.h>
 #include <bcos-framework/ledger/EVMAccount.h>
 #include <bcos-framework/ledger/LedgerTypeDef.h>
 #include <bcos-framework/storage/Entry.h>
@@ -67,6 +70,46 @@ static protocol::Transaction::Ptr makeTx(std::string_view senderBytes, int64_t n
     tx->calculateHash(hasher);
     tx->markClean();
     tx->setImportTime(nonce);
+    return tx;
+}
+
+/// A Web3-typed transaction with a real EIP-1559 signing payload and a 65-byte
+/// signature, shaped exactly like the eth_sendRawTransaction ingress produces:
+/// type=Web3Transaction, extraTransactionBytes = 0x02 || rlp(unsigned fields),
+/// signature = r(32) || s(32) || yParity(1). calculateHash() runs the same raw-bytes
+/// splice buildPayload uses, so constructing one also validates the payload shape.
+static protocol::Transaction::Ptr makeWeb3Tx(std::string_view senderBytes, uint64_t nonce)
+{
+    bytes body;
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));  // chainId
+    bcos::codec::rlp::encode(body, nonce);
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));      // maxPriorityFeePerGas
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));      // maxFeePerGas
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(21000));  // gasLimit
+    bcos::codec::rlp::encode(body, Address("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"));
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(0));  // value
+    bcos::codec::rlp::encode(body, bytes{});                   // data
+    body.push_back(bcos::codec::rlp::LIST_HEAD_BASE);          // empty accessList
+    bytes payload;
+    payload.push_back(0x02);
+    bcos::codec::rlp::encodeHeader(
+        payload, bcos::codec::rlp::Header{.isList = true, .payloadLength = body.size()});
+    payload.insert(payload.end(), body.begin(), body.end());
+
+    auto tx = std::make_shared<TestTransactionImpl>();
+    tx->mutableInner().type = static_cast<int>(bcos::protocol::TransactionType::Web3Transaction);
+    tx->mutableInner().extraTransactionBytes.assign(payload.begin(), payload.end());
+    bytes signature(65, 0);
+    signature[31] = 0x12;  // r != 0
+    signature[63] = 0x34;  // s != 0
+    signature[64] = 0x01;  // yParity
+    tx->mutableInner().signature.assign(signature.begin(), signature.end());
+    tx->setNonce("0x" + std::to_string(nonce));
+    tx->forceSender(toBytes(senderBytes));
+    Keccak256 hasher;
+    tx->calculateHash(hasher);
+    tx->markClean();
+    tx->setImportTime(static_cast<int64_t>(nonce));
     return tx;
 }
 
@@ -582,6 +625,168 @@ BOOST_AUTO_TEST_CASE(payload_carries_parent_beacon_block_root_and_withdrawals_ro
     BOOST_CHECK_EQUAL(*committed->parentBeaconBlockRoot, *request.parentBeaconBlockRoot);
     BOOST_REQUIRE(committed->executionPayload.withdrawalsRoot.has_value());
     BOOST_CHECK_EQUAL(*committed->executionPayload.withdrawalsRoot, withdrawalsRoot);
+}
+
+BOOST_AUTO_TEST_CASE(build_payload_reassembles_web3_raw_bytes)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("dddddddddddddddddddd", 20);
+    auto tx = makeWeb3Tx(sender, 0);
+    memPool.add(std::vector{tx});
+    globalStateStorageFixture.setNonce(sender, "0");
+    auto payloadAttributes = makePayloadAttributesV2();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 2));
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 1);
+    auto const& engineTx = payload->executionPayload.transactions.front();
+
+    // The wire form is the reassembled signed EIP-2718 raw envelope, not Tars encoding.
+    BOOST_CHECK(bcos::engine::dispatchRawTransaction(bcos::ref(engineTx.raw)) ==
+                bcos::engine::RawTransactionKind::DynamicFee);
+    // keccak256(raw) is the canonical txHash — the exact equality op-node depends on
+    // when it recomputes transaction hashes from getPayload's raw bytes.
+    BOOST_CHECK_EQUAL(bcos::crypto::keccak256Hash(bcos::ref(engineTx.raw)), tx->hash());
+    // Dual model: the decoded executable form is the sealed mempool transaction itself.
+    BOOST_CHECK(engineTx.decoded == tx);
+
+    // A native Tars encoding, by contrast, dispatches as Unsupported — pinning why the
+    // buildPayload Tars fallback wire form cannot pass newPayload validation and is
+    // reserved for flows that stop at getPayload.
+    bytes tarsEncoded;
+    makeTx(sender, 1)->encode(tarsEncoded);
+    BOOST_CHECK(bcos::engine::dispatchRawTransaction(bcos::ref(tarsEncoded)) ==
+                bcos::engine::RawTransactionKind::Unsupported);
+}
+
+BOOST_AUTO_TEST_CASE(new_payload_round_trips_deposit_raw_bytes)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+
+    // dep-1: raw 0x7E deposit bytes. Only the first byte matters to the dispatch table;
+    // byte fidelity is asserted on the full vector.
+    bytes const depositRaw{0x7e, 0x01, 0x02, 0x03, 0x04, 0x05};
+    bytes const legacyRaw{0xc9, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80};
+    bytes const typedRaw{0x02, 0xf8, 0x01, 0x02};
+
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    request.executionPayload.transactions.push_back({.raw = depositRaw, .decoded = nullptr});
+    request.executionPayload.transactions.push_back({.raw = legacyRaw, .decoded = nullptr});
+    request.executionPayload.transactions.push_back({.raw = typedRaw, .decoded = nullptr});
+
+    // Deposit / legacy / typed all dispatch as admissible payload transactions.
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
+
+    // getPayload returns exactly the bytes newPayload received (dep-1 byte-for-byte).
+    auto committed = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE_EQUAL(committed->executionPayload.transactions.size(), 3);
+    BOOST_CHECK(committed->executionPayload.transactions[0].raw == depositRaw);
+    BOOST_CHECK(committed->executionPayload.transactions[1].raw == legacyRaw);
+    BOOST_CHECK(committed->executionPayload.transactions[2].raw == typedRaw);
+}
+
+BOOST_AUTO_TEST_CASE(new_payload_rejects_blob_and_unknown_transaction_types)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    // A single blob transaction invalidates the whole payload, even next to a valid one.
+    NewPayloadRequest blobRequest;
+    blobRequest.executionPayload.transactions.push_back(
+        {.raw = bytes{0xc9, 0x80, 0x80}, .decoded = nullptr});
+    blobRequest.executionPayload.transactions.push_back(
+        {.raw = bytes{0x03, 0xaa, 0xbb}, .decoded = nullptr});
+    auto blobStatus = task::syncWait(engineService.newPayload(blobRequest, 1));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(blobStatus.status), static_cast<int>(PayloadValidationStatus::Invalid));
+    BOOST_REQUIRE(blobStatus.validationError.has_value());
+    BOOST_CHECK_NE(blobStatus.validationError->find("blob"), std::string::npos);
+
+    // 0x00 is not a valid EIP-2718 type.
+    NewPayloadRequest zeroRequest;
+    zeroRequest.executionPayload.transactions.push_back(
+        {.raw = bytes{0x00, 0x01}, .decoded = nullptr});
+    auto zeroStatus = task::syncWait(engineService.newPayload(zeroRequest, 1));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(zeroStatus.status), static_cast<int>(PayloadValidationStatus::Invalid));
+    BOOST_REQUIRE(zeroStatus.validationError.has_value());
+    BOOST_CHECK_NE(zeroStatus.validationError->find("unsupported"), std::string::npos);
+
+    // Unknown reserved type byte.
+    NewPayloadRequest unknownRequest;
+    unknownRequest.executionPayload.transactions.push_back(
+        {.raw = bytes{0x05, 0x01}, .decoded = nullptr});
+    auto unknownStatus = task::syncWait(engineService.newPayload(unknownRequest, 1));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(unknownStatus.status), static_cast<int>(PayloadValidationStatus::Invalid));
+
+    // Empty raw bytes.
+    NewPayloadRequest emptyRequest;
+    emptyRequest.executionPayload.transactions.push_back({.raw = bytes{}, .decoded = nullptr});
+    auto emptyStatus = task::syncWait(engineService.newPayload(emptyRequest, 1));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(emptyStatus.status), static_cast<int>(PayloadValidationStatus::Invalid));
+}
+
+BOOST_AUTO_TEST_CASE(forkchoice_attributes_reject_blob_forced_transactions)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    // A blob transaction in the forced transaction list invalidates the whole FCU.
+    auto blobAttributes = makePayloadAttributesV3();
+    blobAttributes.transactions = std::vector<std::string>{"0x03aabb"};
+    auto blobResult =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &blobAttributes, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(blobResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Invalid));
+    BOOST_REQUIRE(blobResult.payloadStatus.validationError.has_value());
+    BOOST_CHECK_NE(blobResult.payloadStatus.validationError->find("blob"), std::string::npos);
+    BOOST_CHECK(!blobResult.payloadId.has_value());
+
+    // Non-hex entries are rejected, not decoded.
+    auto badHexAttributes = makePayloadAttributesV3();
+    badHexAttributes.transactions = std::vector<std::string>{"0xzz"};
+    auto badHexResult =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &badHexAttributes, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(badHexResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Invalid));
+
+    // A deposit in the forced transaction list is admissible (dep-1 arrives this way).
+    auto depositAttributes = makePayloadAttributesV3();
+    depositAttributes.transactions = std::vector<std::string>{"0x7e010203"};
+    auto depositResult =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &depositAttributes, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(depositResult.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Valid));
+    BOOST_CHECK(depositResult.payloadId.has_value());
 }
 
 BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -97,8 +97,8 @@ struct TrivialCheckpointStorage
     std::optional<CheckpointName> oldestCheckpointName() const { return std::nullopt; }
 };
 
-using RealGlobalCheckpointBackend = TrivialCheckpointStorage<
-    bcos::executor_v1::StateKey, bcos::executor_v1::StateValue, RealGlobalStateBackendStorage>;
+using RealGlobalCheckpointBackend = TrivialCheckpointStorage<bcos::executor_v1::StateKey,
+    bcos::executor_v1::StateValue, RealGlobalStateBackendStorage>;
 using RealGlobalStateStorage = bcos::storage2::MultiLayerStorage<RealGlobalStateMutableStorage,
     void, RealGlobalCheckpointBackend>;
 
@@ -168,9 +168,8 @@ struct StubExecutor
     }
 
     template <class Storage>
-    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&,
-        const protocol::BlockHeader&, const protocol::Transaction&, int,
-        const ledger::LedgerConfig&, bool)
+    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&, const protocol::BlockHeader&,
+        const protocol::Transaction&, int, const ledger::LedgerConfig&, bool)
     {
         co_return ExecuteContext<Storage>{};
     }
@@ -180,8 +179,7 @@ struct StubScheduler
 {
     template <class Storage, class Executor>
     task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
-        const protocol::BlockHeader&, ::ranges::input_range auto&&,
-        const ledger::LedgerConfig&)
+        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
     {
         co_return {};
     }
@@ -191,8 +189,7 @@ struct BloomScheduler
 {
     template <class Storage, class Executor>
     task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
-        const protocol::BlockHeader&, ::ranges::input_range auto&&,
-        const ledger::LedgerConfig&)
+        const protocol::BlockHeader&, ::ranges::input_range auto&&, const ledger::LedgerConfig&)
     {
         Bloom bloom1{};
         bloom1[255] = static_cast<bcos::byte>(0x01);
@@ -226,8 +223,7 @@ BloomEngineServiceImpl makeBloomEngineServiceImpl(
 using TestEngineServiceImpl =
     EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, StubScheduler>;
 
-TestEngineServiceImpl makeEngineServiceImpl(
-    MemPoolImpl& memPool, RealGlobalStateStorage& storage)
+TestEngineServiceImpl makeEngineServiceImpl(MemPoolImpl& memPool, RealGlobalStateStorage& storage)
 {
     StubExecutor executor;
     StubScheduler scheduler;
@@ -546,6 +542,45 @@ BOOST_AUTO_TEST_CASE(forkchoice_ignores_stale_update_after_newer_head_wins)
         static_cast<int>(PayloadValidationStatus::Valid));
 }
 
+BOOST_AUTO_TEST_CASE(payload_carries_parent_beacon_block_root_and_withdrawals_root)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+
+    // buildPayload stored the attributes' beacon root in the payload cache; getPayload
+    // must return it. withdrawalsRoot stays unset until real-value header wiring lands.
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(payload->parentBeaconBlockRoot.has_value());
+    BOOST_CHECK_EQUAL(*payload->parentBeaconBlockRoot, *payloadAttributes.parentBeaconBlockRoot);
+    BOOST_CHECK(!payload->executionPayload.withdrawalsRoot.has_value());
+
+    // newPayload carries both fields back in; the committed cache entry keeps them.
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    auto const withdrawalsRoot =
+        h256("4444444444444444444444444444444444444444444444444444444444444444");
+    request.executionPayload.withdrawalsRoot = withdrawalsRoot;
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
+
+    auto committed = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(committed->parentBeaconBlockRoot.has_value());
+    BOOST_CHECK_EQUAL(*committed->parentBeaconBlockRoot, *request.parentBeaconBlockRoot);
+    BOOST_REQUIRE(committed->executionPayload.withdrawalsRoot.has_value());
+    BOOST_CHECK_EQUAL(*committed->executionPayload.withdrawalsRoot, withdrawalsRoot);
+}
+
 BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
 {
     MemPoolImpl memPool;
@@ -560,8 +595,8 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
     auto payloadAttributes = makePayloadAttributesV2();
 
     BloomScheduler bloomScheduler;
-    auto engineService = makeBloomEngineServiceImpl(
-        memPool, globalStateStorageFixture.storage, bloomScheduler);
+    auto engineService =
+        makeBloomEngineServiceImpl(memPool, globalStateStorageFixture.storage, bloomScheduler);
 
     auto result =
         task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -312,8 +312,11 @@ NewPayloadRequest makeNewPayloadRequestV3(const ExecutionPayload& executionPaylo
     request.executionPayload = executionPayload;
     request.expectedBlobVersionedHashes = {
         h256("3333333333333333333333333333333333333333333333333333333333333333")};
+    // Deliberately different from makePayloadAttributesV3()'s beacon root (0x2222...):
+    // tests must be able to tell whether newPayload really overwrites the cached value
+    // with the request's, not just re-reads what the attributes stored.
     request.parentBeaconBlockRoot =
-        h256("2222222222222222222222222222222222222222222222222222222222222222");
+        h256("5555555555555555555555555555555555555555555555555555555555555555");
     return request;
 }
 }  // namespace
@@ -622,6 +625,9 @@ BOOST_AUTO_TEST_CASE(payload_carries_parent_beacon_block_root_and_withdrawals_ro
 
     auto committed = task::syncWait(engineService.getPayload(*result.payloadId, 3));
     BOOST_REQUIRE(committed->parentBeaconBlockRoot.has_value());
+    // The request carries a beacon root different from the attributes' — the cache must
+    // now hold the request's value, proving newPayload overwrites rather than re-reads.
+    BOOST_CHECK_NE(*request.parentBeaconBlockRoot, *payloadAttributes.parentBeaconBlockRoot);
     BOOST_CHECK_EQUAL(*committed->parentBeaconBlockRoot, *request.parentBeaconBlockRoot);
     BOOST_REQUIRE(committed->executionPayload.withdrawalsRoot.has_value());
     BOOST_CHECK_EQUAL(*committed->executionPayload.withdrawalsRoot, withdrawalsRoot);

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -663,13 +663,54 @@ BOOST_AUTO_TEST_CASE(build_payload_reassembles_web3_raw_bytes)
     // Dual model: the decoded executable form is the sealed mempool transaction itself.
     BOOST_CHECK(engineTx.decoded == tx);
 
-    // A native Tars encoding, by contrast, dispatches as Unsupported — pinning why the
-    // buildPayload Tars fallback wire form cannot pass newPayload validation and is
-    // reserved for flows that stop at getPayload.
+    // A native Tars encoding, by contrast, dispatches as Unsupported — pinning why
+    // buildPayload excludes native transactions instead of emitting their Tars bytes
+    // (such a wire form could never pass newPayload validation).
     bytes tarsEncoded;
     makeTx(sender, 1)->encode(tarsEncoded);
     BOOST_CHECK(bcos::engine::dispatchRawTransaction(bcos::ref(tarsEncoded)) ==
                 bcos::engine::RawTransactionKind::Unsupported);
+}
+
+BOOST_AUTO_TEST_CASE(build_payload_excludes_native_transactions_full_loop)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    // One native Tars transaction and one Web3 transaction, both sealable.
+    std::string nativeSender("eeeeeeeeeeeeeeeeeeee", 20);
+    std::string web3Sender("ffffffffffffffffffff", 20);
+    auto nativeTx = makeTx(nativeSender, 0);
+    auto web3Tx = makeWeb3Tx(web3Sender, 0);
+    memPool.add(std::vector{nativeTx, web3Tx});
+    globalStateStorageFixture.setNonce(nativeSender, "0");
+    globalStateStorageFixture.setNonce(web3Sender, "0");
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+
+    // The native transaction is excluded from the OP payload (no EIP-2718 wire form);
+    // only the Web3 transaction remains, carried as its genuine raw envelope.
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 1);
+    BOOST_CHECK(payload->executionPayload.transactions.front().decoded == web3Tx);
+    BOOST_CHECK(bcos::engine::dispatchRawTransaction(
+                    bcos::ref(payload->executionPayload.transactions.front().raw)) ==
+                bcos::engine::RawTransactionKind::DynamicFee);
+
+    // The full loop closes: the payload this service built passes its own newPayload
+    // validation (the seal/validate asymmetry the exclusion removes).
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
 }
 
 BOOST_AUTO_TEST_CASE(new_payload_round_trips_deposit_raw_bytes)
@@ -803,7 +844,8 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
         c_initialBlockNumber, c_initialBlockNumber);
     std::string sender("cccccccccccccccccccc", 20);
-    auto tx = makeTx(sender, 0);
+    // Web3-shaped: only transactions with an EIP-2718 wire form enter OP payloads.
+    auto tx = makeWeb3Tx(sender, 0);
     memPool.add(std::vector{tx});
     globalStateStorageFixture.setNonce(sender, "0");
     auto payloadAttributes = makePayloadAttributesV2();

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -564,6 +564,9 @@ BOOST_AUTO_TEST_CASE(payload_carries_parent_beacon_block_root_and_withdrawals_ro
     BOOST_CHECK(!payload->executionPayload.withdrawalsRoot.has_value());
 
     // newPayload carries both fields back in; the committed cache entry keeps them.
+    // This exercises the structure layer only: withdrawalsRoot is set directly on the
+    // struct, deliberately bypassing the JSON parser, whose V1-V3 dialect ignores the
+    // field (it is an ExecutionPayloadV4+/Isthmus field — see EngineProtoAlignB1Test).
     globalStateStorageFixture.setBlockNumber(
         payload->executionPayload.blockHash, c_initialBlockNumber + 1);
     auto request = makeNewPayloadRequestV3(payload->executionPayload);

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -826,14 +826,88 @@ BOOST_AUTO_TEST_CASE(forkchoice_attributes_reject_blob_forced_transactions)
     BOOST_CHECK_EQUAL(static_cast<int>(badHexResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Invalid));
 
-    // A deposit in the forced transaction list is admissible (dep-1 arrives this way).
+    // A deposit in the forced transaction list is admissible (dep-1 arrives this way)
+    // AND actually lands in the built payload, byte-for-byte.
     auto depositAttributes = makePayloadAttributesV3();
     depositAttributes.transactions = std::vector<std::string>{"0x7e010203"};
     auto depositResult =
         task::syncWait(engineService.updateForkchoice(forkchoiceState, &depositAttributes, 3));
     BOOST_CHECK_EQUAL(static_cast<int>(depositResult.payloadStatus.status),
         static_cast<int>(PayloadValidationStatus::Valid));
-    BOOST_CHECK(depositResult.payloadId.has_value());
+    BOOST_REQUIRE(depositResult.payloadId.has_value());
+    auto depositPayload = task::syncWait(engineService.getPayload(*depositResult.payloadId, 3));
+    BOOST_REQUIRE_EQUAL(depositPayload->executionPayload.transactions.size(), 1);
+    BOOST_CHECK(depositPayload->executionPayload.transactions.front().raw ==
+                (bytes{0x7e, 0x01, 0x02, 0x03}));
+}
+
+BOOST_AUTO_TEST_CASE(forced_transactions_enter_payload_first)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("abababababababababab", 20);
+    auto poolTx = makeWeb3Tx(sender, 0);
+    memPool.add(std::vector{poolTx});
+    globalStateStorageFixture.setNonce(sender, "0");
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    // Two forced transactions (dep-1 first) plus one mempool transaction:
+    // payload order = forced list order, then pool transactions.
+    auto attributes = makePayloadAttributesV3();
+    attributes.transactions = std::vector<std::string>{"0x7e0102030405", "0x02f8aabb"};
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 3);
+    // Forced first, in the order the attributes gave them, byte-for-byte.
+    BOOST_CHECK(payload->executionPayload.transactions[0].raw ==
+                (bytes{0x7e, 0x01, 0x02, 0x03, 0x04, 0x05}));
+    BOOST_CHECK(payload->executionPayload.transactions[0].decoded == nullptr);
+    BOOST_CHECK(payload->executionPayload.transactions[1].raw == (bytes{0x02, 0xf8, 0xaa, 0xbb}));
+    // The mempool transaction follows the forced list.
+    BOOST_CHECK(payload->executionPayload.transactions[2].decoded == poolTx);
+}
+
+BOOST_AUTO_TEST_CASE(no_tx_pool_true_excludes_mempool_transactions)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("cdcdcdcdcdcdcdcdcdcd", 20);
+    auto poolTx = makeWeb3Tx(sender, 0);
+    memPool.add(std::vector{poolTx});
+    globalStateStorageFixture.setNonce(sender, "0");
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    // noTxPool=true with a forced deposit: the payload contains exactly the forced
+    // list; the sealable mempool transaction must not appear and stays in the pool.
+    auto attributes = makePayloadAttributesV3();
+    attributes.noTxPool = true;
+    attributes.transactions = std::vector<std::string>{"0x7e010203"};
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 1);
+    BOOST_CHECK(
+        payload->executionPayload.transactions.front().raw == (bytes{0x7e, 0x01, 0x02, 0x03}));
+    auto retained = memPool.get(std::vector{poolTx->hash()});
+    BOOST_REQUIRE_EQUAL(retained.size(), 1);
+    BOOST_CHECK(retained[0]);
+
+    // noTxPool=true with no forced transactions: an empty payload.
+    auto emptyAttributes = makePayloadAttributesV3();
+    emptyAttributes.noTxPool = true;
+    auto emptyResult =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &emptyAttributes, 3));
+    BOOST_REQUIRE(emptyResult.payloadId.has_value());
+    auto emptyPayload = task::syncWait(engineService.getPayload(*emptyResult.payloadId, 3));
+    BOOST_CHECK(emptyPayload->executionPayload.transactions.empty());
 }
 
 BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)

--- a/mempool/bcos-mempool/MemPoolImpl.cpp
+++ b/mempool/bcos-mempool/MemPoolImpl.cpp
@@ -1,4 +1,5 @@
 #include "MemPoolImpl.h"
+#include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Exceptions.h"
 #include <boost/exception/diagnostic_information.hpp>
@@ -52,6 +53,18 @@ void bcos::txpool::MemPoolImpl::add(protocol::Transaction::Ptr transaction)
     if (transaction->tainted()) [[unlikely]]
     {
         bcos::throwTrace(InvalidTaintedTransaction{});
+    }
+
+    // L2 never admits blob (type-3) transactions (OP Stack, Ecotone onwards). The RPC
+    // entry rejects them before decoding; this is the second gate for in-process callers.
+    // For Web3 transactions the signing payload (extraTransactionBytes) starts with the
+    // same EIP-2718 type byte as the raw envelope, so the shared dispatch table applies.
+    if (transaction->type() ==
+            static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction) &&
+        bcos::engine::dispatchRawTransaction(transaction->extraTransactionBytes()) ==
+            bcos::engine::RawTransactionKind::Blob) [[unlikely]]
+    {
+        bcos::throwTrace(InvalidBlobTransaction{});
     }
 
     auto& nonceIndex = m_transactions.get<0>();

--- a/mempool/bcos-mempool/MemPoolImpl.h
+++ b/mempool/bcos-mempool/MemPoolImpl.h
@@ -23,6 +23,7 @@ namespace bcos::txpool
 
 DERIVE_BCOS_EXCEPTION(InvalidNonce);
 DERIVE_BCOS_EXCEPTION(InvalidTaintedTransaction);
+DERIVE_BCOS_EXCEPTION(InvalidBlobTransaction);
 
 struct TransactionData
 {
@@ -294,7 +295,6 @@ public:
         }
         return transactions;
     }
-
 };
 
 }  // namespace bcos::txpool

--- a/mempool/test/unittests/mempool/MemPoolImplTest.cpp
+++ b/mempool/test/unittests/mempool/MemPoolImplTest.cpp
@@ -158,6 +158,21 @@ static void setNonce(MapStateStorage& s, std::string_view sender, std::string no
 
 BOOST_AUTO_TEST_SUITE(MemPoolImplTest)
 
+BOOST_AUTO_TEST_CASE(add_rejects_blob_web3_transaction)
+{
+    // Second type-3 gate behind the RPC entry: a Web3 transaction whose signing payload
+    // carries the EIP-4844 type byte is rejected by the mempool itself.
+    MemPoolImpl pool;
+    auto tx = std::make_shared<TestTransactionImpl>();
+    tx->mutableInner().type = static_cast<int>(bcos::protocol::TransactionType::Web3Transaction);
+    bcos::bytes const blobPayload{0x03, 0x01, 0x02};
+    tx->mutableInner().extraTransactionBytes.assign(blobPayload.begin(), blobPayload.end());
+    tx->markClean();
+
+    BOOST_CHECK_THROW(
+        pool.add(std::vector{protocol::Transaction::Ptr(tx)}), InvalidBlobTransaction);
+}
+
 BOOST_AUTO_TEST_CASE(seal_single_sender_contiguous)
 {
     MemPoolImpl pool;

--- a/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
+++ b/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
@@ -27,6 +27,8 @@
  */
 
 #include "TrivialCheckpointStorage.h"
+#include "bcos-codec/rlp/Common.h"
+#include "bcos-codec/rlp/RLPEncode.h"
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
@@ -37,11 +39,11 @@
 #include "bcos-framework/testutils/faker/FakeBlock.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
+#include "bcos-ledger/LedgerMethods.h"
 #include "bcos-mempool/MemPoolImpl.h"
 #include "bcos-protocol/TransactionStatus.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
-#include "bcos-ledger/LedgerMethods.h"
 #include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
 #include "bcos-task/Wait.h"
 #include "bcos-transaction-scheduler/SchedulerParallelImpl.h"
@@ -124,11 +126,11 @@ std::shared_ptr<bcostars::protocol::TransactionImpl> EEMakeTransferTx(
     std::shared_ptr<bcos::crypto::CryptoSuite> const& cryptoSuite, evmc_address const& from,
     evmc_address const& to, uint64_t value, std::string const& nonce)
 {
-    auto toHexStr = bcos::toHexStringWithPrefix(
-        bcos::bytes(std::begin(to.bytes), std::end(to.bytes)));
-    auto tx = factory.createTransaction(1 /* V1 */, toHexStr, {}, nonce,
-        1000 /* blockLimit */, "0x1" /* chainId */, "" /* groupId */, 0 /* importTime */,
-        {} /* abi */, EEQuantity(value) /* value */, "0x0" /* gasPrice */, 21000 /* gasLimit */);
+    auto toHexStr =
+        bcos::toHexStringWithPrefix(bcos::bytes(std::begin(to.bytes), std::end(to.bytes)));
+    auto tx = factory.createTransaction(1 /* V1 */, toHexStr, {}, nonce, 1000 /* blockLimit */,
+        "0x1" /* chainId */, "" /* groupId */, 0 /* importTime */, {} /* abi */,
+        EEQuantity(value) /* value */, "0x0" /* gasPrice */, 21000 /* gasLimit */);
     tx->forceSender(bcos::bytes(std::begin(from.bytes), std::end(from.bytes)));
     tx->calculateHash(*cryptoSuite->hashImpl());
     return std::static_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
@@ -161,8 +163,8 @@ task::Task<void> EEWriteBlockHash(
 {
     storage::Entry entry;
     entry.set(hash.asBytes());
-    co_await storage2::writeOne(storage,
-        StateKey{ledger::SYS_NUMBER_2_HASH, std::to_string(number)}, std::move(entry));
+    co_await storage2::writeOne(
+        storage, StateKey{ledger::SYS_NUMBER_2_HASH, std::to_string(number)}, std::move(entry));
 }
 
 /// Persist the committed current block height into SYS_CURRENT_STATE/current_number —
@@ -178,9 +180,8 @@ task::Task<void> EEWriteCurrentNumber(EEBackendStorage& storage, int64_t number)
 class TestEthereumExecutorSchedulerFixture
 {
 public:
-    bcos::crypto::CryptoSuite::Ptr cryptoSuite =
-        std::make_shared<bcos::crypto::CryptoSuite>(
-            std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    bcos::crypto::CryptoSuite::Ptr cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
     bcostars::protocol::TransactionFactoryImpl transactionFactory{cryptoSuite};
     bcostars::protocol::TransactionReceiptFactoryImpl receiptFactory{cryptoSuite};
     EEBackendStorage backendStorage;
@@ -237,11 +238,10 @@ task::Task<void> EERunTransfers(Scheduler& scheduler, EthereumExecutor& executor
     auto view = multiLayerStorage.fork();
     view.newMutable();
 
-    auto transactions =
-        txs | ::ranges::views::transform([](auto& ptr) -> auto& { return *ptr; });
+    auto transactions = txs | ::ranges::views::transform([](auto& ptr) -> auto& { return *ptr; });
 
-    auto receipts = co_await scheduler.executeBlock(
-        view, executor, blockHeader, transactions, ledgerConfig);
+    auto receipts =
+        co_await scheduler.executeBlock(view, executor, blockHeader, transactions, ledgerConfig);
 
     BOOST_CHECK_EQUAL(receipts.size(), txs.size());
     for (size_t i = 0; i < receipts.size(); ++i)
@@ -254,8 +254,8 @@ task::Task<void> EERunTransfers(Scheduler& scheduler, EthereumExecutor& executor
     for (auto const& [addr, expected] : expectedBalances)
     {
         auto actual = co_await EEReadBalance(view, addr);
-        BOOST_CHECK_MESSAGE(actual == expected,
-            "balance mismatch: expected " << expected << " got " << actual);
+        BOOST_CHECK_MESSAGE(
+            actual == expected, "balance mismatch: expected " << expected << " got " << actual);
     }
 }
 
@@ -278,8 +278,10 @@ BOOST_AUTO_TEST_CASE(serialExecuteBlock)
         co_await EEFundAccount(backendStorage, recipient1, 0);
 
         std::vector<protocol::Transaction::Ptr> txs;
-        txs.emplace_back(EEMakeTransferTx(transactionFactory, cryptoSuite, sender0, recipient0, 100, "0"));
-        txs.emplace_back(EEMakeTransferTx(transactionFactory, cryptoSuite, sender1, recipient1, 200, "0"));
+        txs.emplace_back(
+            EEMakeTransferTx(transactionFactory, cryptoSuite, sender0, recipient0, 100, "0"));
+        txs.emplace_back(
+            EEMakeTransferTx(transactionFactory, cryptoSuite, sender1, recipient1, 200, "0"));
 
         co_await EERunTransfers(scheduler, *executor, multiLayerStorage, backendStorage,
             cryptoSuite, txs,
@@ -327,8 +329,7 @@ BOOST_AUTO_TEST_CASE(serialExecuteBlockWithHexTo)
             EEMakeTransferTx(transactionFactory, cryptoSuite, sender, recipient1, 200, "1"));
 
         co_await EERunTransfers(scheduler, *executor, multiLayerStorage, backendStorage,
-            cryptoSuite, txs,
-            {{sender, EEFunding - 300}, {recipient0, 100}, {recipient1, 200}});
+            cryptoSuite, txs, {{sender, EEFunding - 300}, {recipient0, 100}, {recipient1, 200}});
     }());
 }
 
@@ -352,8 +353,8 @@ BOOST_AUTO_TEST_CASE(parallelExecuteBlock)
             transfers.emplace_back(sender, recipient);
             co_await EEFundAccount(backendStorage, sender, EEFunding);
             co_await EEFundAccount(backendStorage, recipient, 0);
-            txs.emplace_back(EEMakeTransferTx(
-                transactionFactory, cryptoSuite, sender, recipient, 10 + i, "0"));
+            txs.emplace_back(
+                EEMakeTransferTx(transactionFactory, cryptoSuite, sender, recipient, 10 + i, "0"));
             expected.emplace_back(sender, EEFunding - (10 + i));
             expected.emplace_back(recipient, 10 + i);
         }
@@ -392,15 +393,15 @@ BOOST_AUTO_TEST_CASE(serialSameSenderSequentialNonces)
             EEMakeTransferTx(transactionFactory, cryptoSuite, sender, recipient1, 200, "1"));
 
         co_await EERunTransfers(scheduler, *executor, multiLayerStorage, backendStorage,
-            cryptoSuite, txs,
-            {{sender, EEFunding - 300}, {recipient0, 100}, {recipient1, 200}});
+            cryptoSuite, txs, {{sender, EEFunding - 300}, {recipient0, 100}, {recipient1, 200}});
     }());
 }
 
 BOOST_AUTO_TEST_CASE(parallelSameSenderSequentialNonces)
 {
     task::syncWait([&, this]() -> task::Task<void> {
-        auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "testEthParallelSameSenderGC");
+        auto ioServicePool =
+            std::make_shared<bcos::IOServicePool>(1, "testEthParallelSameSenderGC");
         SchedulerParallelImpl<EEMutableStorage> scheduler(ioServicePool);
 
         auto sender = EEMakeAddress(23);
@@ -418,8 +419,7 @@ BOOST_AUTO_TEST_CASE(parallelSameSenderSequentialNonces)
             EEMakeTransferTx(transactionFactory, cryptoSuite, sender, recipient1, 200, "1"));
 
         co_await EERunTransfers(scheduler, *executor, multiLayerStorage, backendStorage,
-            cryptoSuite, txs,
-            {{sender, EEFunding - 300}, {recipient0, 100}, {recipient1, 200}});
+            cryptoSuite, txs, {{sender, EEFunding - 300}, {recipient0, 100}, {recipient1, 200}});
     }());
 }
 
@@ -452,7 +452,8 @@ BOOST_AUTO_TEST_CASE(serialSharedRecipient)
 BOOST_AUTO_TEST_CASE(parallelSharedRecipient)
 {
     task::syncWait([&, this]() -> task::Task<void> {
-        auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "testEthParallelSharedRecipGC");
+        auto ioServicePool =
+            std::make_shared<bcos::IOServicePool>(1, "testEthParallelSharedRecipGC");
         SchedulerParallelImpl<EEMutableStorage> scheduler(ioServicePool);
 
         auto sender0 = EEMakeAddress(43);
@@ -606,8 +607,7 @@ BOOST_AUTO_TEST_CASE(serialSameNonceSecondRejected)
 BOOST_AUTO_TEST_CASE(parallelSameNonceSecondRejected)
 {
     task::syncWait([&, this]() -> task::Task<void> {
-        auto ioServicePool =
-            std::make_shared<bcos::IOServicePool>(1, "testEthParallelSameNonceGC");
+        auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "testEthParallelSameNonceGC");
         SchedulerParallelImpl<EEMutableStorage> scheduler(ioServicePool);
 
         auto sender = EEMakeAddress(82);
@@ -648,7 +648,7 @@ BOOST_AUTO_TEST_CASE(parallelSameNonceSecondRejected)
 
         BOOST_CHECK_EQUAL(receipts.size(), 2u);
         BOOST_CHECK_EQUAL(receipts[0]->status(), 0);  // first nonce-"0" tx succeeds
-        BOOST_CHECK(receipts[1]->status() != 0);  // second same-nonce tx rejected
+        BOOST_CHECK(receipts[1]->status() != 0);      // second same-nonce tx rejected
 
         auto senderBalance = co_await EEReadBalance(view, sender);
         BOOST_CHECK(senderBalance == EEFunding - 100);
@@ -884,10 +884,9 @@ BOOST_AUTO_TEST_CASE(callDryRunSkipsNonceAndGasValidation)
         // CallRequest::takeToTransaction produces for an eth_call that omits them.
         auto toHexStr = bcos::toHexStringWithPrefix(
             bcos::bytes(std::begin(recipient.bytes), std::end(recipient.bytes)));
-        auto tx = transactionFactory.createTransaction(1 /* V1 */, toHexStr, {},
-            "" /*nonce*/, 1000 /*blockLimit*/, "0x1" /*chainId*/, "" /*groupId*/,
-            0 /*importTime*/, {} /*abi*/, EEQuantity(100) /*value*/, "0x0" /*gasPrice*/,
-            0 /*gasLimit*/);
+        auto tx = transactionFactory.createTransaction(1 /* V1 */, toHexStr, {}, "" /*nonce*/,
+            1000 /*blockLimit*/, "0x1" /*chainId*/, "" /*groupId*/, 0 /*importTime*/, {} /*abi*/,
+            EEQuantity(100) /*value*/, "0x0" /*gasPrice*/, 0 /*gasLimit*/);
         tx->forceSender(bcos::bytes(std::begin(sender.bytes), std::end(sender.bytes)));
         tx->calculateHash(*cryptoSuite->hashImpl());
 
@@ -917,8 +916,8 @@ BOOST_AUTO_TEST_CASE(toDecodingOnlyWellFormedAddresses)
             bcos::bytes(std::begin(recipient.bytes), std::end(recipient.bytes)));
 
         auto mkTx = [&](std::string const& toField) {
-            auto tx = transactionFactory.createTransaction(1 /* V1 */, toField, {}, "0", 1000,
-                "0x1", "", 0, {}, EEQuantity(1), "0x0", 21000);
+            auto tx = transactionFactory.createTransaction(
+                1 /* V1 */, toField, {}, "0", 1000, "0x1", "", 0, {}, EEQuantity(1), "0x0", 21000);
             tx->forceSender(bcos::bytes(20, 0));
             tx->calculateHash(*cryptoSuite->hashImpl());
             return tx;
@@ -992,8 +991,8 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
             storage::Entry entry;
             entry.set("0");
             co_await storage2::writeOne(backendStorage,
-                executor_v1::StateKey{ledger::SYS_HASH_2_NUMBER,
-                    bcos::concepts::bytebuffer::toView(genesisHash)},
+                executor_v1::StateKey{
+                    ledger::SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(genesisHash)},
                 std::move(entry));
         }
         co_await EEWriteCurrentNumber(backendStorage, 0);
@@ -1002,8 +1001,8 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
         // A block gas limit so the transfer (gas 21000) fits in the block.
         {
             storage::Entry entry;
-            entry.set(bcos::storage::serialize::encode(ledger::SystemConfigEntry{
-                std::to_string(ledger::ETHEREUM_EXECUTOR_VERSION), 0}));
+            entry.set(bcos::storage::serialize::encode(
+                ledger::SystemConfigEntry{std::to_string(ledger::ETHEREUM_EXECUTOR_VERSION), 0}));
             co_await storage2::writeOne(backendStorage,
                 executor_v1::StateKey{ledger::SYS_CONFIG,
                     std::string(magic_enum::enum_name(ledger::SystemConfig::executor_version))},
@@ -1026,7 +1025,13 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
 
         // Submit a real value-transfer tx (nonce 0, matching the sender's state nonce).
         // Built directly as EETestTransactionImpl (the factory returns a base TransactionImpl
-        // which cannot be markClean()'d) with the same inner encoding the factory produces.
+        // which cannot be markClean()'d). Web3-shaped: only transactions with a genuine
+        // EIP-2718 wire form enter OP payloads (buildPayload excludes native Tars
+        // transactions), so the tx carries type=Web3Transaction, an EIP-1559 signing
+        // payload mirroring the transfer fields and a 65-byte signature — the same shape
+        // the eth_sendRawTransaction ingress produces. Execution still reads the inner
+        // interface fields (EthereumTransition converts via tx.web3TypedTxKind() and the
+        // Transaction accessors), so the transfer semantics are unchanged.
         auto tx = std::make_shared<EETestTransactionImpl>();
         {
             auto& inner = tx->mutableInner();
@@ -1041,6 +1046,34 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
             inner.data.gasLimit = 100000;
             inner.data.maxFeePerGas = "0x0";
             inner.data.maxPriorityFeePerGas = "0x0";
+            inner.type = static_cast<int>(bcos::protocol::TransactionType::Web3Transaction);
+            inner.web3TypedTxKind = 2;  // EIP-1559 (matches the 0x02 signing payload below)
+
+            // Signing payload: 0x02 || rlp([chainId, nonce, maxPriorityFeePerGas,
+            // maxFeePerGas, gasLimit, to, value, data, accessList]), mirroring the
+            // transfer fields above.
+            bcos::bytes body;
+            bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));       // chainId
+            bcos::codec::rlp::encode(body, static_cast<uint64_t>(0));       // nonce
+            bcos::codec::rlp::encode(body, static_cast<uint64_t>(0));       // maxPriorityFeePerGas
+            bcos::codec::rlp::encode(body, static_cast<uint64_t>(0));       // maxFeePerGas
+            bcos::codec::rlp::encode(body, static_cast<uint64_t>(100000));  // gasLimit
+            bcos::codec::rlp::encode(
+                body, bcos::Address(bcos::bytesConstRef(recipient.bytes, sizeof(recipient.bytes))));
+            bcos::codec::rlp::encode(body, static_cast<uint64_t>(100));  // value
+            bcos::codec::rlp::encode(body, bcos::bytes{});               // data
+            body.push_back(bcos::codec::rlp::LIST_HEAD_BASE);            // empty accessList
+            bcos::bytes payloadBytes;
+            payloadBytes.push_back(0x02);
+            bcos::codec::rlp::encodeHeader(payloadBytes,
+                bcos::codec::rlp::Header{.isList = true, .payloadLength = body.size()});
+            payloadBytes.insert(payloadBytes.end(), body.begin(), body.end());
+            inner.extraTransactionBytes.assign(payloadBytes.begin(), payloadBytes.end());
+            bcos::bytes signature(65, 0);
+            signature[31] = 0x12;  // r != 0
+            signature[63] = 0x34;  // s != 0
+            signature[64] = 0x01;  // yParity
+            inner.signature.assign(signature.begin(), signature.end());
         }
         tx->forceSender(bcos::bytes(std::begin(sender.bytes), std::end(sender.bytes)));
         tx->calculateHash(*cryptoSuite->hashImpl());
@@ -1072,7 +1105,8 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
         // The committed state must show the transfer executed successfully (not
         // NONCE_TOO_LOW — the seal's nonce advance must not leak into execution) and be
         // visible in the backend after newPayload's pushView + mergeBackStorage.
-        auto recipientBalance = co_await EEReadBalance(multiLayerStorage.latestBackend(), recipient);
+        auto recipientBalance =
+            co_await EEReadBalance(multiLayerStorage.latestBackend(), recipient);
         BOOST_CHECK_EQUAL(recipientBalance, u256(100));
         auto senderBalance = co_await EEReadBalance(multiLayerStorage.latestBackend(), sender);
         BOOST_CHECK_EQUAL(senderBalance, EEFunding - 100);
@@ -1088,8 +1122,7 @@ BOOST_AUTO_TEST_CASE(viewCommitMechanism)
         view.newMutable();
         storage::Entry entry;
         entry.set("42");
-        co_await storage2::writeOne(
-            view, executor_v1::StateKey{"t", "k"}, std::move(entry));
+        co_await storage2::writeOne(view, executor_v1::StateKey{"t", "k"}, std::move(entry));
         multiLayerStorage.pushView(std::move(view));
         co_await multiLayerStorage.mergeBackStorage();
         auto read = co_await storage2::readOne(


### PR DESCRIPTION
## What

Lane-B PR of the OP Stack integration series, covering the Engine protocol/codec surface: structure alignment with the OP Stack (Isthmus/Jovian-era) spec, the raw EIP-2718 transaction carrier, and the transaction-type dispatch table with deposit decoding. The Engine method surface (getPayloadV5/newPayloadV4, capability narrowing) and execution wiring remain out of scope for this PR.

### Protocol structure alignment

- **PayloadAttributes**: adds the OP fields `transactions` (array of raw tx hex strings, passed through untouched — not decoded), `noTxPool`, `gasLimit`, `eip1559Params` (strict 8-byte validation) and `minBaseFee` (u64). All `std::optional`; absent fields keep current behavior, and the single-node consensus path is unaffected.
- **ExecutionPayload**: adds `withdrawalsRoot` (mandatory in V4/V5 payloads since Isthmus; a placeholder value is allowed until the header PR provides the real one) and removes the non-spec leftovers `blockAccessList`/`slotNumber`, plus the dead `slotNumber`/`targetGasLimit` in PayloadAttributes. Per review, `withdrawalsRoot` is gated behind payload version V4: V1-V3 requests ignore it (matching op-geth's NewPayloadV3, which performs no withdrawalsRoot validation) and V1-V3 responses never emit it.
- **parentBeaconBlockRoot**: threaded end-to-end — payload attributes → payload cache → getPayload response (same envelope key as op-geth) → newPayload parse-back — with round-trip UTs.

### Raw EIP-2718 transaction carrier

- `ExecutionPayload.transactions` now carries `EngineTransaction{raw, decoded}`: the raw EIP-2718 bytes are the canonical wire form, byte-preserved through parse → payload cache → getPayload serialization (previously the Engine wire path decoded/encoded Tars bytes, which op-node cannot read). The decoded executable form is filled for locally built payloads.
- `parseNewPayloadRequest`/`serializeExecutionPayload` only do hex ↔ bytes; the `TransactionFactory` parameter is gone.
- `buildPayload` reassembles the exact signed raw bytes of Web3 transactions via `bcostars::protocol::reassembleWeb3RawTransaction`, factored out of the canonical-txHash byte splice (the hash recompute now keccaks its output — byte-identical behavior). Native Tars transactions keep the legacy Tars encoding as their wire form (pre-existing single-node flows only; an external CL never consumes such payloads).

### Transaction-type dispatch and deposit decode

- `bcos-framework/engine/RawTransactionDispatch.h` is the single authoritative first-byte dispatch: `0x01`/`0x02`/`0x04` typed, `>= 0xc0` legacy, `0x7e` deposit, `0x03` blob (parseable but always rejected), everything else including `0x00` unsupported.
- Blob (type-3) transactions are rejected at all three entry points: `eth_sendRawTransaction` (which also rejects `0x7e` — deposits are CL-injected via the Engine API only), `MemPoolImpl::add` (`InvalidBlobTransaction`), and the Engine validators — a single blob/unsupported transaction turns the whole payload / whole FCU INVALID rather than being dropped individually.
- `DepositTransaction` decodes `0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data])` with op-geth semantics (empty RLP item ⇒ `to` = contract creation / `mint` = nil; `isSystemTx` decoded as an integer because canonical RLP `false` is the empty item), and deposits serialize in op-geth's RPC JSON shape (`sourceHash`; `mint`/`isSystemTx` omitted when nil/false; zero nonce/gasPrice/v/r/s; no chainId). `combineTxResponse` routes `0x7e` transactions to that shape and skips the signature-derived fields (deposits are unsigned).

### Behavior change

`eth_sendRawTransaction` no longer accepts type-3 envelopes (L2 forbids blob transactions from Ecotone on). `handleEIP4844TxTest` now asserts rejection — the previous acceptance was vestigial, as no KZG/blob-sidecar support exists.

## Verification

- `ctest -R "EngineServiceTest|EngineRpcTest|EngineProtoAlignB1Test|EngineRawTxB2B3Test|AnyEngineService|MemPoolImplTest"`: 71/71 passed.
- Full `test-bcos-rpc`, `test-bcos-engine`, `test-bcos-framework`, `test-bcos-mempool` binaries: no errors detected; consumer target `single-consensus` builds clean.
- dep-1 byte fidelity is asserted at three points: the FCU attributes list keeps the raw hex verbatim, and newPayload → payload cache → getPayload returns byte-identical raw bytes (both service-level and JSON-level tests).
- All changed TUs pass standalone `-fsyntax-only` compilation.

## Notes

- Deposit decoding stops at the internal representation; `runDeposit` execution wiring belongs to the execution lane.
- Forced-transaction inclusion (`noTxPool`, attributes-first gasLimit) and the V5/V4 method surface + capability narrowing are the next PR in this lane; the new OP attribute fields and `serializePayloadAttributes` get their production consumers there.
