### PR TITLE
Fix clang-tidy warnings in ethereum-executor

### DIFF
--- a/ethereum-executor/EVMPrecompiles.cpp
+++ b/ethereum-executor/EVMPrecompiles.cpp
@@ -76,7 +76,7 @@ constexpr int64_t num_words(size_t size_in_bytes) noexcept
 template <int BaseCost, int WordCost>
 constexpr int64_t cost_per_input_word(size_t input_size) noexcept
 {
-    return BaseCost + WordCost * num_words(input_size);
+    return BaseCost + (WordCost * num_words(input_size));
 }
 }  // namespace
 
@@ -115,10 +115,10 @@ PrecompileAnalysis ecpairing_analyze(bytes_view input, evmc_revision rev) noexce
     const auto base_cost = (rev >= EVMC_ISTANBUL) ? 45000 : 100000;
     const auto element_cost = (rev >= EVMC_ISTANBUL) ? 34000 : 80000;
     const auto num_elements = static_cast<int64_t>(input.size() / 192);
-    return {base_cost + num_elements * element_cost, 32};
+    return {base_cost + (num_elements * element_cost), 32};
 }
 
-PrecompileAnalysis blake2bf_analyze(bytes_view input, evmc_revision) noexcept
+PrecompileAnalysis blake2bf_analyze(bytes_view input, evmc_revision /*unused*/) noexcept
 {
     // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage)
     return {input.size() == 213 ? intx::be::unsafe::load<uint32_t>(input.data()) : GasCostMax, 64};
@@ -138,14 +138,14 @@ PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
         const auto top_byte_index = head_explicit_bytes.find_first_not_of(uint8_t{0});
         const auto exp_bit_width =
             (top_byte_index != bytes_view::npos) ?
-                8 * (head_len - top_byte_index - 1) +
+                (8 * (head_len - top_byte_index - 1)) +
                     static_cast<unsigned>(std::bit_width(head_explicit_bytes[top_byte_index])) :
                 0;
 
         const auto tail_len = len - head_len;
         const auto head_bits = std::max(exp_bit_width, size_t{1}) - 1;
         const uint64_t factor = rev < EVMC_OSAKA ? 8 : 16;
-        return std::max(factor * uint64_t{tail_len} + uint64_t{head_bits}, uint64_t{1});
+        return std::max((factor * uint64_t{tail_len}) + uint64_t{head_bits}, uint64_t{1});
     };
 
     static constexpr auto calc_mult_complexity_eip7883 = [](uint32_t max_len) noexcept {
@@ -162,11 +162,15 @@ PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
     static constexpr auto calc_mult_complexity_eip198 = [](uint32_t max_len) noexcept {
         const auto max_len_squared = uint64_t{max_len} * max_len;
         if (max_len <= 64)
+        {
             return max_len_squared;
+        }
         if (max_len <= 1024)
-            return max_len_squared / 4 + 96 * max_len - 3072;
+        {
+            return (max_len_squared / 4) + (96 * uint64_t{max_len}) - 3072;
+        }
         // max value: 0x100001df'dffcf220
-        return max_len_squared / 16 + 480 * uint64_t{max_len} - 199680;
+        return (max_len_squared / 16) + (480 * uint64_t{max_len}) - 199680;
     };
 
     struct Params
@@ -177,11 +181,15 @@ PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
     };
     const auto& [min_gas, final_divisor, calc_mult_complexity] = [rev]() noexcept -> Params {
         if (rev >= EVMC_OSAKA)
+        {
             return {500, 1, calc_mult_complexity_eip7883};
-        else if (rev >= EVMC_BERLIN)
+        }
+        if (rev >= EVMC_BERLIN)
+        {
             return {200, 3, calc_mult_complexity_eip2565};
-        else  // Byzantium
-            return {0, 20, calc_mult_complexity_eip198};
+        }
+        // Byzantium
+        return {0, 20, calc_mult_complexity_eip198};
     }();
 
     static constexpr size_t INPUT_HEADER_REQUIRED_SIZE = 3 * sizeof(uint256);
@@ -198,13 +206,17 @@ PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
     const auto len_limit =
         rev < EVMC_OSAKA ? std::numeric_limits<uint32_t>::max() : MODEXP_LEN_LIMIT_EIP7823;
     if (base_len256 > len_limit || mod_len256 > len_limit)
+    {
         return {GasCostMax, 0};
+    }
 
     if (exp_len256 > len_limit)
     {
         // Before EIP-7823, the big exponent may be canceled with zero multiplication complexity.
         if (rev < EVMC_OSAKA && base_len256 == 0 && mod_len256 == 0)
+        {
             return {min_gas, 0};
+        }
         return {GasCostMax, 0};
     }
 
@@ -219,19 +231,20 @@ PrecompileAnalysis expmod_analyze(bytes_view input, evmc_revision rev) noexcept
     return {static_cast<int64_t>(gas_clamped), mod_len};
 }
 
-PrecompileAnalysis point_evaluation_analyze(bytes_view, evmc_revision) noexcept
+PrecompileAnalysis point_evaluation_analyze(
+    bytes_view /*unused*/, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto POINT_EVALUATION_PRECOMPILE_GAS = 50000;
     return {POINT_EVALUATION_PRECOMPILE_GAS, 64};
 }
 
-PrecompileAnalysis bls12_g1add_analyze(bytes_view, evmc_revision) noexcept
+PrecompileAnalysis bls12_g1add_analyze(bytes_view /*unused*/, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto BLS12_G1ADD_PRECOMPILE_GAS = 375;
     return {BLS12_G1ADD_PRECOMPILE_GAS, BLS12_G1_POINT_SIZE};
 }
 
-PrecompileAnalysis bls12_g1msm_analyze(bytes_view input, evmc_revision) noexcept
+PrecompileAnalysis bls12_g1msm_analyze(bytes_view input, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto G1MUL_GAS_COST = 12000;
     static constexpr uint16_t DISCOUNTS[] = {1000, 949, 848, 797, 764, 750, 738, 728, 719, 712, 705,
@@ -244,22 +257,25 @@ PrecompileAnalysis bls12_g1msm_analyze(bytes_view input, evmc_revision) noexcept
         525, 524, 523, 522, 522, 521, 520, 520, 519};
 
     if (input.empty() || input.size() % BLS12_G1_MUL_INPUT_SIZE != 0)
+    {
         return {GasCostMax, 0};
+    }
 
     const auto k = input.size() / BLS12_G1_MUL_INPUT_SIZE;
     assert(k > 0);
     const auto discount = DISCOUNTS[std::min(k, std::size(DISCOUNTS)) - 1];
-    const auto cost = (G1MUL_GAS_COST * discount * static_cast<int64_t>(k)) / 1000;
+    const auto cost =
+        (static_cast<int64_t>(G1MUL_GAS_COST) * discount * static_cast<int64_t>(k)) / 1000;
     return {cost, BLS12_G1_POINT_SIZE};
 }
 
-PrecompileAnalysis bls12_g2add_analyze(bytes_view, evmc_revision) noexcept
+PrecompileAnalysis bls12_g2add_analyze(bytes_view /*unused*/, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto BLS12_G2ADD_PRECOMPILE_GAS = 600;
     return {BLS12_G2ADD_PRECOMPILE_GAS, BLS12_G2_POINT_SIZE};
 }
 
-PrecompileAnalysis bls12_g2msm_analyze(bytes_view input, evmc_revision) noexcept
+PrecompileAnalysis bls12_g2msm_analyze(bytes_view input, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto G2MUL_GAS_COST = 22500;
     static constexpr uint16_t DISCOUNTS[] = {1000, 1000, 923, 884, 855, 832, 812, 796, 782, 770,
@@ -272,44 +288,51 @@ PrecompileAnalysis bls12_g2msm_analyze(bytes_view input, evmc_revision) noexcept
         530, 529, 528, 528, 527, 526, 526, 525, 524, 524};
 
     if (input.empty() || input.size() % BLS12_G2_MUL_INPUT_SIZE != 0)
+    {
         return {GasCostMax, 0};
+    }
 
     const auto k = input.size() / BLS12_G2_MUL_INPUT_SIZE;
     assert(k > 0);
     const auto discount = DISCOUNTS[std::min(k, std::size(DISCOUNTS)) - 1];
-    const auto cost = (G2MUL_GAS_COST * discount * static_cast<int64_t>(k)) / 1000;
+    const auto cost =
+        (static_cast<int64_t>(G2MUL_GAS_COST) * discount * static_cast<int64_t>(k)) / 1000;
     return {cost, BLS12_G2_POINT_SIZE};
 }
 
-PrecompileAnalysis bls12_pairing_check_analyze(bytes_view input, evmc_revision) noexcept
+PrecompileAnalysis bls12_pairing_check_analyze(bytes_view input, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto PAIR_SIZE = BLS12_G1_POINT_SIZE + BLS12_G2_POINT_SIZE;
 
     if (input.empty() || input.size() % PAIR_SIZE != 0)
+    {
         return {GasCostMax, 0};
+    }
 
     const auto npairs = static_cast<int64_t>(input.size()) / PAIR_SIZE;
 
     static constexpr auto BLS12_PAIRING_CHECK_BASE_FEE_PRECOMPILE_GAS = 37700;
     static constexpr auto BLS12_PAIRING_CHECK_FEE_PRECOMPILE_GAS = 32600;
     return {BLS12_PAIRING_CHECK_BASE_FEE_PRECOMPILE_GAS +
-                BLS12_PAIRING_CHECK_FEE_PRECOMPILE_GAS * npairs,
+                (BLS12_PAIRING_CHECK_FEE_PRECOMPILE_GAS * npairs),
         32};
 }
 
-PrecompileAnalysis bls12_map_fp_to_g1_analyze(bytes_view, evmc_revision) noexcept
+PrecompileAnalysis bls12_map_fp_to_g1_analyze(
+    bytes_view /*unused*/, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto BLS12_MAP_FP_TO_G1_PRECOMPILE_GAS = 5500;
     return {BLS12_MAP_FP_TO_G1_PRECOMPILE_GAS, BLS12_G1_POINT_SIZE};
 }
 
-PrecompileAnalysis bls12_map_fp2_to_g2_analyze(bytes_view, evmc_revision) noexcept
+PrecompileAnalysis bls12_map_fp2_to_g2_analyze(
+    bytes_view /*unused*/, evmc_revision /*unused*/) noexcept
 {
     static constexpr auto BLS12_MAP_FP2_TO_G2_PRECOMPILE_GAS = 23800;
     return {BLS12_MAP_FP2_TO_G2_PRECOMPILE_GAS, BLS12_G2_POINT_SIZE};
 }
 
-PrecompileAnalysis p256verify_analyze(bytes_view, evmc_revision) noexcept
+PrecompileAnalysis p256verify_analyze(bytes_view /*unused*/, evmc_revision /*unused*/) noexcept
 {
     return {6900, 32};
 }
@@ -335,7 +358,9 @@ public:
 
         const auto v = intx::be::unsafe::load<intx::uint256>(v_bytes.data());
         if (v != 27 && v != 28)
+        {
             return std::nullopt;
+        }
         const bool parity = v == 28;
 
         return std::tuple{hash, sig_bytes, parity};
@@ -350,15 +375,19 @@ ExecutionResult ecrecover_execute_evmone(const uint8_t* input, size_t input_size
     const EcrecoverInput input_buffer{std::span{input, input_size}};
     const auto o = input_buffer.parse();
     if (!o)
+    {
         return {EVMC_SUCCESS, 0};
+    }
     const auto& [hash, sig_bytes, parity] = *o;
 
     const auto res = evmmax::secp256k1::ecrecover(
         hash, sig_bytes.subspan<0, 32>(), sig_bytes.subspan<32, 32>(), parity);
     if (!res)
+    {
         return {EVMC_SUCCESS, 0};
+    }
 
-    const auto it = std::fill_n(output, 32 - sizeof(*res), 0);
+    auto* const it = std::fill_n(output, 32 - sizeof(*res), 0);
     std::copy_n(res->bytes, sizeof(*res), it);
     return {EVMC_SUCCESS, 32};
 }
@@ -409,7 +438,8 @@ expmod_parse_input(
 
     const auto base_len = intx::be::unsafe::load<uint32_t>(&input[LEN32_OFF]);
     const auto exp_len = intx::be::unsafe::load<uint32_t>(&input[LEN_SIZE + LEN32_OFF]);
-    assert(intx::be::unsafe::load<uint32_t>(&input[2 * LEN_SIZE + LEN32_OFF]) == mod_len);
+    assert(intx::be::unsafe::load<uint32_t>(&input[(2 * LEN_SIZE) + LEN32_OFF]) ==
+        mod_len);
 
     const size_t mod_off = base_len + exp_len;  // Cannot overflow if gas cost computed before.
     const size_t payload_max_size = mod_off + mod_len;  // Input may contain extra bytes.
@@ -450,7 +480,9 @@ ExecutionResult expmod_execute_evmone(
 {
     const auto [base, exp, mod] = expmod_parse_input(input, input_size, output, output_size);
     if (mod.empty())
+    {
         return {EVMC_SUCCESS, output_size};
+    }
 
     crypto::modexp(base, exp, mod, output);
     return {EVMC_SUCCESS, output_size};
@@ -469,7 +501,9 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
 
     uint8_t input_buffer[128]{};
     if (input_size != 0)
+    {
         std::memcpy(input_buffer, input, std::min(input_size, std::size(input_buffer)));
+    }
 
     const auto input_span = std::span{input_buffer};
 
@@ -477,10 +511,14 @@ ExecutionResult ecadd_execute(const uint8_t* input, size_t input_size, uint8_t* 
 
     const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
     const auto q = AffinePoint::from_bytes(input_span.subspan<64, 64>());
-    if (!p.has_value() || !q.has_value()) [[unlikely]]
-        return {EVMC_PRECOMPILE_FAILURE, 0};
-    if (!validate(*p) || !validate(*q)) [[unlikely]]
-        return {EVMC_PRECOMPILE_FAILURE, 0};
+    if (!p.has_value() || !q.has_value())
+    {
+        [[unlikely]] return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
+    if (!validate(*p) || !validate(*q))
+    {
+        [[unlikely]] return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     const auto res = evmmax::ecc::add_affine(*p, *q);
     const std::span<uint8_t, 64> output_span{output, 64};
@@ -495,15 +533,19 @@ ExecutionResult ecmul_execute(const uint8_t* input, size_t input_size, uint8_t* 
 
     uint8_t input_buffer[96]{};
     if (input_size != 0)
+    {
         std::memcpy(input_buffer, input, std::min(input_size, std::size(input_buffer)));
+    }
 
     const auto input_span = std::span{input_buffer};
 
     using namespace evmmax::bn254;
 
     const auto p = AffinePoint::from_bytes(input_span.subspan<0, 64>());
-    if (!p.has_value() || !validate(*p)) [[unlikely]]
-        return {EVMC_PRECOMPILE_FAILURE, 0};
+    if (!p.has_value() || !validate(*p))
+    {
+        [[unlikely]] return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     const auto c = intx::be::unsafe::load<uint256>(input_buffer + 64);
 
@@ -521,11 +563,13 @@ ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8
     assert(output_size >= OUTPUT_SIZE);
 
     if (input_size % PAIR_SIZE != 0)
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     std::vector<std::pair<evmmax::bn254::Point, evmmax::bn254::ExtPoint>> pairs;
     pairs.reserve(input_size / PAIR_SIZE);  // TODO: may throw std::bad_alloc.
-    for (auto input_ptr = input; input_ptr != input + input_size; input_ptr += PAIR_SIZE)
+    for (const auto* input_ptr = input; input_ptr != input + input_size; input_ptr += PAIR_SIZE)
     {
         const evmmax::bn254::Point p{
             intx::be::unsafe::load<intx::uint256>(input_ptr),
@@ -542,7 +586,9 @@ ExecutionResult ecpairing_execute(const uint8_t* input, size_t input_size, uint8
 
     const auto res = evmmax::bn254::pairing_check(pairs);
     if (!res.has_value())
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     std::fill_n(output, OUTPUT_SIZE, 0);
     output[OUTPUT_SIZE - 1] = *res ? 1 : 0;
@@ -581,8 +627,10 @@ ExecutionResult blake2bf_execute(const uint8_t* input, [[maybe_unused]] size_t i
     input += sizeof(t);
 
     const auto f = *input;
-    if (f != 0 && f != 1) [[unlikely]]
-        return {EVMC_PRECOMPILE_FAILURE, 0};
+    if (f != 0 && f != 1)
+    {
+        [[unlikely]] return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     crypto::blake2b_compress(rounds, h, m, t, f != 0);
     std::memcpy(output, h, sizeof(h));
@@ -594,7 +642,9 @@ ExecutionResult point_evaluation_execute(const uint8_t* input, size_t input_size
 {
     assert(output_size >= 64);
     if (input_size != 192)
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     const auto r = crypto::kzg_verify_proof(reinterpret_cast<const std::byte*>(&input[0]),
         reinterpret_cast<const std::byte*>(&input[32]),
@@ -603,7 +653,9 @@ ExecutionResult point_evaluation_execute(const uint8_t* input, size_t input_size
         reinterpret_cast<const std::byte*>(&input[96 + 48]));
 
     if (!r)
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     // Return FIELD_ELEMENTS_PER_BLOB and BLS_MODULUS as padded 32 byte big endian values
     // as required by the EIP-4844.
@@ -615,13 +667,17 @@ ExecutionResult point_evaluation_execute(const uint8_t* input, size_t input_size
 ExecutionResult bls12_g1add_execute(const uint8_t* input, size_t input_size, uint8_t* output,
     [[maybe_unused]] size_t output_size) noexcept
 {
-    if (input_size != 2 * BLS12_G1_POINT_SIZE)
+    if (input_size != 2 * static_cast<size_t>(BLS12_G1_POINT_SIZE))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     assert(output_size == BLS12_G1_POINT_SIZE);
 
     if (!crypto::bls::g1_add(output, &output[64], input, &input[64], &input[128], &input[192]))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     return {EVMC_SUCCESS, BLS12_G1_POINT_SIZE};
 }
@@ -637,13 +693,17 @@ ExecutionResult bls12_g1msm_execute(const uint8_t* input, size_t input_size, uin
     {
         // Optimize single multiplication case.
         if (!crypto::bls::g1_mul(output, &output[64], input, &input[64], &input[128]))
+        {
             return {EVMC_PRECOMPILE_FAILURE, 0};
+        }
     }
     else
     {
         // TODO: g1_msm() may throw std::bad_alloc.
         if (!crypto::bls::g1_msm(output, &output[64], input, input_size))
+        {
             return {EVMC_PRECOMPILE_FAILURE, 0};
+        }
     }
 
     return {EVMC_SUCCESS, BLS12_G1_POINT_SIZE};
@@ -652,13 +712,17 @@ ExecutionResult bls12_g1msm_execute(const uint8_t* input, size_t input_size, uin
 ExecutionResult bls12_g2add_execute(const uint8_t* input, size_t input_size, uint8_t* output,
     [[maybe_unused]] size_t output_size) noexcept
 {
-    if (input_size != 2 * BLS12_G2_POINT_SIZE)
+    if (input_size != 2 * static_cast<size_t>(BLS12_G2_POINT_SIZE))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     assert(output_size == BLS12_G2_POINT_SIZE);
 
     if (!crypto::bls::g2_add(output, &output[128], input, &input[128], &input[256], &input[384]))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     return {EVMC_SUCCESS, BLS12_G2_POINT_SIZE};
 }
@@ -674,13 +738,17 @@ ExecutionResult bls12_g2msm_execute(const uint8_t* input, size_t input_size, uin
     {
         // Optimize single multiplication case.
         if (!crypto::bls::g2_mul(output, &output[128], input, &input[128], &input[256]))
+        {
             return {EVMC_PRECOMPILE_FAILURE, 0};
+        }
     }
     else
     {
         // TODO: g2_msm() may throw std::bad_alloc.
         if (!crypto::bls::g2_msm(output, &output[128], input, input_size))
+        {
             return {EVMC_PRECOMPILE_FAILURE, 0};
+        }
     }
 
     return {EVMC_SUCCESS, BLS12_G2_POINT_SIZE};
@@ -694,7 +762,9 @@ ExecutionResult bls12_pairing_check_execute(const uint8_t* input, size_t input_s
     assert(output_size == 32);
 
     if (!crypto::bls::pairing_check(output, input, input_size))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     return {EVMC_SUCCESS, 32};
 }
@@ -703,12 +773,16 @@ ExecutionResult bls12_map_fp_to_g1_execute(const uint8_t* input, size_t input_si
     [[maybe_unused]] size_t output_size) noexcept
 {
     if (input_size != BLS12_FIELD_ELEMENT_SIZE)
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     assert(output_size == BLS12_G1_POINT_SIZE);
 
     if (!crypto::bls::map_fp_to_g1(output, &output[64], input))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     return {EVMC_SUCCESS, BLS12_G1_POINT_SIZE};
 }
@@ -716,13 +790,17 @@ ExecutionResult bls12_map_fp_to_g1_execute(const uint8_t* input, size_t input_si
 ExecutionResult bls12_map_fp2_to_g2_execute(const uint8_t* input, size_t input_size,
     uint8_t* output, [[maybe_unused]] size_t output_size) noexcept
 {
-    if (input_size != 2 * BLS12_FIELD_ELEMENT_SIZE)
+    if (input_size != 2 * static_cast<size_t>(BLS12_FIELD_ELEMENT_SIZE))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     assert(output_size == BLS12_G2_POINT_SIZE);
 
     if (!crypto::bls::map_fp2_to_g2(output, &output[128], input))
+    {
         return {EVMC_PRECOMPILE_FAILURE, 0};
+    }
 
     return {EVMC_SUCCESS, BLS12_G2_POINT_SIZE};
 }
@@ -733,7 +811,9 @@ ExecutionResult p256verify_execute(const uint8_t* input, size_t input_size, uint
     assert(output_size >= 32);
 
     if (input_size != 160)
+    {
         return {EVMC_SUCCESS, 0};
+    }
 
     ethash::hash256 h{};
     std::copy_n(input, sizeof(h), h.bytes);
@@ -743,7 +823,9 @@ ExecutionResult p256verify_execute(const uint8_t* input, size_t input_size, uint
     const auto qy = intx::be::unsafe::load<intx::uint256>(input + 128);
 
     if (!evmmax::secp256r1::verify(h, r, s, qx, qy))
+    {
         return {EVMC_SUCCESS, 0};  // In case of invalid signature, return empty output.
+    }
 
     // Return 1_u256.
     std::fill_n(output, 31, 0);
@@ -787,7 +869,9 @@ inline constexpr std::array<PrecompileTraits, 18> traits{{
 constexpr auto LOOKUP_TABLE_SIZE = [] {
     PrecompileLookupIndex max_idx = 0;
     for (const auto& trait : traits)
+    {
         max_idx = std::max(max_idx, trait.address);
+    }
     return max_idx + 1;
 }();
 
@@ -806,12 +890,16 @@ bool is_precompile(evmc_revision rev, const evmc::address& addr) noexcept
         std::array<Entry, LOOKUP_TABLE_SIZE> table{};
         std::ranges::fill(table, std::numeric_limits<Entry>::max());
         for (const auto& trait : traits)
+        {
             table[trait.address] = to_underlying(trait.since);
+        }
         return table;
     }();
 
     if (addr >= evmc::address{AVAILABILITY_LOOKUP_TABLE.size()})
+    {
         return false;
+    }
     return AVAILABILITY_LOOKUP_TABLE[to_lookup_index(addr)] <= to_underlying(rev);
 }
 
@@ -825,7 +913,9 @@ evmc::Result call_precompile(evmc_revision rev, const evmc_message& msg) noexcep
         };
         std::array<Entry, LOOKUP_TABLE_SIZE> table{};
         for (const auto& trait : traits)
+        {
             table[trait.address] = {trait.analyze, trait.execute};
+        }
         return table;
     }();
 
@@ -837,10 +927,12 @@ evmc::Result call_precompile(evmc_revision rev, const evmc_message& msg) noexcep
     const auto [gas_cost, max_output_size] = analyze(input, rev);
     const auto gas_left = msg.gas - gas_cost;
     if (gas_left < 0)
+    {
         return evmc::Result{EVMC_OUT_OF_GAS};
+    }
 
     // Allocate buffer for the precompile's output and pass its ownership to evmc::Result.
-    const auto output_data = new (std::nothrow) uint8_t[max_output_size];  // TODO: handle nullptr.
+    auto* const output_data = new (std::nothrow) uint8_t[max_output_size];  // TODO: handle nullptr.
     const auto [status_code, output_size] =
         execute(msg.input_data, msg.input_size, output_data, max_output_size);
     const evmc_result result{status_code, status_code == EVMC_SUCCESS ? gas_left : 0, 0,

--- a/ethereum-executor/EVMSupport.h
+++ b/ethereum-executor/EVMSupport.h
@@ -215,9 +215,13 @@ inline intx::uint256 compute_blob_gas_price(
             // Ensure the multiplication won't overflow 256 bits.
             if (const auto p = intx::umul(numerator_accum, numerator256);
                 p <= std::numeric_limits<intx::uint256>::max())
+            {
                 numerator_accum = intx::uint256(p) / (denominator * i);
+            }
             else
+            {
                 return std::numeric_limits<intx::uint256>::max();
+            }
             i += 1;
         }
         return output / denominator;
@@ -226,7 +230,9 @@ inline intx::uint256 compute_blob_gas_price(
     static constexpr auto MIN_BLOB_GASPRICE = 1;
     const auto fraction = blob_params.base_fee_update_fraction;
     if (fraction == 0)
+    {
         return std::numeric_limits<intx::uint256>::max();  // degenerate schedule
+    }
     return fake_exponential(MIN_BLOB_GASPRICE, excess_blob_gas, fraction);
 }
 
@@ -256,7 +262,7 @@ inline intx::uint256 compute_blob_gas_price(
     const auto init_code_hash = keccak256(init_code);
     uint8_t buffer[1 + sizeof(sender) + sizeof(salt) + sizeof(init_code_hash)];
     static_assert(std::size(buffer) == 85);
-    auto it = std::begin(buffer);
+    auto* it = std::begin(buffer);
     *it++ = 0xff;
     it = std::copy_n(sender.bytes, sizeof(sender), it);
     it = std::copy_n(salt.bytes, sizeof(salt), it);

--- a/ethereum-executor/EthereumExecutor.cpp
+++ b/ethereum-executor/EthereumExecutor.cpp
@@ -28,13 +28,19 @@ EthBlockInfo buildBlockInfo(
     // field in evmc_tx_context), so for pre-Paris forks we must place the
     // DIFFICULTY value into prev_randao for 0x44 to work.
     if (rev >= EVMC_PARIS)
+    {
         info.prev_randao = config.prevRandao();
+    }
     else
+    {
         info.prev_randao =
             intx::be::store<evmc::bytes32>(intx::uint256(static_cast<uint64_t>(info.difficulty)));
+    }
     auto const& cb = header.coinbase();
     if (cb.size() == sizeof(evmc_address))
+    {
         std::copy_n(cb.begin(), sizeof(evmc_address), info.coinbase.bytes);
+    }
     // base_fee is a hex string that may or may not carry the 0x prefix; parse
     // it the same way as chainId/nonce (bcos::u256), then truncate to uint64.
     auto baseFeeStr = std::get<0>(config.gasPrice());

--- a/ethereum-executor/EthereumExecutor.h
+++ b/ethereum-executor/EthereumExecutor.h
@@ -151,6 +151,7 @@ public:
             catch (...)
             {
                 // Ignore the cleanup error; the original failure wins.
+                (void)failure;
             }
             std::rethrow_exception(failure);
         }
@@ -220,7 +221,9 @@ public:
         uint64_t nodeChainId() const
         {
             if (auto const& cid = ledgerConfig.get().chainId(); cid.has_value())
+            {
                 return static_cast<uint64_t>(intx::be::load<intx::uint256>(*cid));
+            }
             return 0;
         }
 
@@ -398,6 +401,7 @@ public:
                 catch (...)
                 {
                     // Ignore the cleanup error; the original failure wins.
+                    (void)failure;
                 }
                 std::rethrow_exception(failure);
             }

--- a/ethereum-executor/EthereumHost.h
+++ b/ethereum-executor/EthereumHost.h
@@ -73,7 +73,9 @@ inline address ethSender(protocol::Transaction const& tx)
     address a{};
     auto const& sb = tx.sender();
     if (sb.size() >= sizeof(evmc_address))
+    {
         std::copy_n(sb.begin(), sizeof(evmc_address), a.bytes);
+    }
     return a;
 }
 
@@ -82,11 +84,17 @@ inline intx::uint256 ethMaxGasPrice(
     protocol::Transaction const& tx, EthCallParams const& callParams)
 {
     if (callParams.free)
+    {
         return 0;
+    }
     if (auto mf = tx.maxFeePerGas(); mf.has_value())
+    {
         return evm::toIntxU256(*mf);
+    }
     if (auto gp = tx.gasPrice(); gp.has_value())
+    {
         return evm::toIntxU256(*gp);
+    }
     return 0;
 }
 
@@ -95,16 +103,22 @@ inline intx::uint256 ethMaxPriorityGasPrice(
     protocol::Transaction const& tx, EthCallParams const& callParams)
 {
     if (callParams.free)
+    {
         return 0;
+    }
     // Legacy / access-list txs carry no priority-fee field in their signed RLP:
     // the whole gas price is the tip above the base fee. Decide on the kind
     // FIRST, so an unvalidated Tars mirror value (present-and-zero, reachable
     // over P2P) cannot override it — the old bridge's `== 0` fixup had the
     // same effect.
     if (tx.web3TypedTxKind() <= 1)
+    {
         return ethMaxGasPrice(tx, callParams);
+    }
     if (auto mp = tx.maxPriorityFeePerGas(); mp.has_value())
+    {
         return evm::toIntxU256(*mp);
+    }
     return 0;
 }
 
@@ -112,7 +126,9 @@ inline intx::uint256 ethMaxPriorityGasPrice(
 inline intx::uint256 ethMaxBlobGasPrice(protocol::Transaction const& tx)
 {
     if (auto mb = tx.maxFeePerBlobGas(); mb.has_value())
+    {
         return evm::toIntxU256(*mb);
+    }
     return 0;
 }
 
@@ -120,7 +136,9 @@ inline intx::uint256 ethMaxBlobGasPrice(protocol::Transaction const& tx)
 inline int64_t effectiveGasLimit(protocol::Transaction const& tx, EthCallParams const& callParams)
 {
     if (callParams.gasLimit.has_value())
+    {
         return *callParams.gasLimit;
+    }
     return tx.gasLimit();
 }
 
@@ -128,7 +146,9 @@ inline int64_t effectiveGasLimit(protocol::Transaction const& tx, EthCallParams 
 inline uint64_t effectiveNonce(protocol::Transaction const& tx, EthCallParams const& callParams)
 {
     if (callParams.nonce.has_value())
+    {
         return *callParams.nonce;
+    }
     return bcos::safeFromQuantity(tx.nonce()).value_or(0);
 }
 
@@ -270,33 +290,51 @@ evmc_storage_status EthereumHost<Storage>::set_storage(
     if (!dirty && !restored)
     {
         if (current_is_zero)
+        {
             status = EVMC_STORAGE_ADDED;  // 0 → 0 → Z
+        }
         else if (value_is_zero)
+        {
             status = EVMC_STORAGE_DELETED;  // X → X → 0
+        }
         else
+        {
             status = EVMC_STORAGE_MODIFIED;  // X → X → Z
+        }
     }
     else if (dirty && !restored)
     {
         if (current_is_zero && !value_is_zero)
+        {
             status = EVMC_STORAGE_DELETED_ADDED;  // X → 0 → Z
+        }
         else if (!current_is_zero && value_is_zero)
+        {
             status = EVMC_STORAGE_MODIFIED_DELETED;  // X → Y → 0
+        }
     }
     else if (dirty)
     {
         assert(restored);  // Always true.
         if (current_is_zero)
+        {
             status = EVMC_STORAGE_DELETED_RESTORED;  // X → 0 → X
+        }
         else if (value_is_zero)
+        {
             status = EVMC_STORAGE_ADDED_DELETED;  // 0 → Y → 0
+        }
         else
+        {
             status = EVMC_STORAGE_MODIFIED_RESTORED;  // X → Y → X
+        }
     }
 
     // In Berlin this is handled in access_storage().
     if (m_rev < EVMC_BERLIN)
+    {
         m_state.journal_storage_change(addr, key, storage_slot);
+    }
     storage_slot.current = value;  // Update current value.
     return status;
 }
@@ -333,11 +371,17 @@ namespace eth_host_detail
 [[nodiscard]] inline bool is_create_collision(const EthAccount& acc) noexcept
 {
     if (acc.nonce != 0)
+    {
         return true;
+    }
     if (acc.code_hash != EthAccount::EMPTY_CODE_HASH)
+    {
         return true;
+    }
     if (acc.has_initial_storage)
+    {
         return true;
+    }
 
     // The hot storage is ignored because it can contain elements from access list.
     assert(!acc.destructed && "untested");
@@ -357,7 +401,9 @@ bytes32 EthereumHost<Storage>::get_code_hash(const address& addr) const noexcept
 {
     const auto* const acc = m_state.find(addr);
     if (acc == nullptr || acc->is_empty())
+    {
         return {};
+    }
 
     return acc->code_hash;
 }
@@ -378,7 +424,9 @@ bool EthereumHost<Storage>::selfdestruct(
     const address& addr, const address& beneficiary) noexcept
 {
     if (m_state.find(beneficiary) == nullptr)
+    {
         m_state.journal_create(beneficiary, false);
+    }
     auto& acc = m_state.get(addr);
     const auto balance = acc.balance;
     auto& beneficiary_acc = m_state.touch(beneficiary);
@@ -424,7 +472,9 @@ std::optional<evmc_message> EthereumHost<Storage>::prepare_message(evmc_message 
 
         // EIP-2681 (already checked for depth 0 during transaction validation).
         if (sender_acc.nonce == EthAccount::NonceMax)
+        {
             return {};  // Light early exception.
+        }
 
         if (msg.depth != 0)
         {
@@ -441,8 +491,10 @@ std::optional<evmc_message> EthereumHost<Storage>::prepare_message(evmc_message 
             assert(sender_acc.nonce != 0);
             const auto creation_sender_nonce = sender_acc.nonce - 1;
             if (msg.kind == EVMC_CREATE)
+            {
                 msg.recipient =
                     evm::compute_create_address(msg.sender, creation_sender_nonce);
+            }
             else
             {
                 assert(msg.kind == EVMC_CREATE2);
@@ -451,7 +503,7 @@ std::optional<evmc_message> EthereumHost<Storage>::prepare_message(evmc_message 
             }
 
             // By EIP-2929, the access to new created address is never reverted.
-            access_account(msg.recipient);
+            [[maybe_unused]] const auto access_status = access_account(msg.recipient);
         }
     }
 
@@ -466,16 +518,22 @@ evmc::Result EthereumHost<Storage>::create(const evmc_message& msg) noexcept
     auto* new_acc = m_state.find(msg.recipient);
     const bool new_acc_exists = new_acc != nullptr;
     if (!new_acc_exists)
+    {
         new_acc = &m_state.insert(msg.recipient);
+    }
     else if (eth_host_detail::is_create_collision(*new_acc))
+    {
         return evmc::Result{EVMC_FAILURE};  // TODO: Add EVMC errors for creation failures.
+    }
     m_state.journal_create(msg.recipient, new_acc_exists);
 
     assert(new_acc != nullptr);
     assert(new_acc->nonce == 0);
 
     if (m_rev >= EVMC_SPURIOUS_DRAGON)
+    {
         new_acc->nonce = 1;  // No need to journal: create revert will 0 the nonce.
+    }
 
     new_acc->just_created = true;
 
@@ -504,7 +562,9 @@ evmc::Result EthereumHost<Storage>::create(const evmc_message& msg) noexcept
     const bytes_view code{result.output_data, result.output_size};
 
     if (m_rev >= EVMC_SPURIOUS_DRAGON && code.size() > evmone::MAX_CODE_SIZE)
+    {
         return evmc::Result{EVMC_FAILURE};
+    }
 
     // Code deployment cost.
     const auto cost = std::ssize(code) * 200;
@@ -520,7 +580,9 @@ evmc::Result EthereumHost<Storage>::create(const evmc_message& msg) noexcept
     {
         // EIP-3541: Reject new contract code starting with the 0xEF byte.
         if (m_rev >= EVMC_LONDON && code[0] == 0xEF)
+        {
             return evmc::Result{EVMC_CONTRACT_VALIDATION_FAILURE};
+        }
 
         new_acc->code_hash = evm::keccak256(code);
         new_acc->code = code;
@@ -535,19 +597,25 @@ evmc::Result EthereumHost<Storage>::execute_message(const evmc_message& msg) noe
 {
     assert(msg.kind != EVMC_EOFCREATE);
     if (msg.kind == EVMC_CREATE || msg.kind == EVMC_CREATE2)
+    {
         return create(msg);
+    }
 
     if (msg.kind == EVMC_CALL)
     {
         const auto exists = m_state.find(msg.recipient) != nullptr;
         if (!exists)
+        {
             m_state.journal_create(msg.recipient, exists);
+        }
     }
 
     if (msg.kind == EVMC_CALL)
     {
         if (evmc::is_zero(msg.value))
+        {
             m_state.touch(msg.recipient);
+        }
         else
         {
             // We skip touching if we send value, because account cannot end up empty.
@@ -568,12 +636,16 @@ evmc::Result EthereumHost<Storage>::execute_message(const evmc_message& msg) noe
 
     // Calls to precompile address via EIP-7702 delegation execute empty code instead of precompile.
     if ((msg.flags & EVMC_DELEGATED) == 0 && evm::is_precompile(m_rev, msg.code_address))
+    {
         return evm::call_precompile(m_rev, msg);
+    }
 
     // TODO: get_code() performs the account lookup. Add a way to get an account with code?
     const auto code = m_state.get_code(msg.code_address);
     if (code.empty())
+    {
         return evmc::Result{EVMC_SUCCESS, msg.gas};  // Skip trivial execution.
+    }
 
     return m_vm.execute(*this, m_rev, msg, code.data(), code.size());
 }
@@ -583,7 +655,9 @@ evmc::Result EthereumHost<Storage>::call(const evmc_message& orig_msg) noexcept
 {
     const auto msg = prepare_message(orig_msg);
     if (!msg.has_value())
+    {
         return evmc::Result{EVMC_FAILURE, orig_msg.gas};  // Light exception.
+    }
 
     const auto logs_checkpoint = m_logs.size();
     const auto state_checkpoint = m_state.checkpoint();
@@ -602,7 +676,9 @@ evmc::Result EthereumHost<Storage>::call(const evmc_message& orig_msg) noexcept
 
         // The 0x03 quirk: the touch on this address is never reverted.
         if (is_03_touched && m_rev >= EVMC_SPURIOUS_DRAGON)
+        {
             m_state.touch(addr_03);
+        }
     }
     return result;
 }
@@ -682,14 +758,18 @@ template <class Storage>
 evmc_access_status EthereumHost<Storage>::access_account(const address& addr) noexcept
 {
     if (m_rev < EVMC_BERLIN)
+    {
         return EVMC_ACCESS_COLD;  // Ignore before Berlin.
+    }
 
     EthAccount fresh;
     fresh.erase_if_empty = true;
     auto& acc = m_state.get_or_insert(addr, std::move(fresh));
 
     if (acc.access_status == EVMC_ACCESS_WARM || evm::is_precompile(m_rev, addr))
+    {
         return EVMC_ACCESS_WARM;
+    }
 
     m_state.journal_access_account(addr);
     acc.access_status = EVMC_ACCESS_WARM;

--- a/ethereum-executor/EthereumState.h
+++ b/ethereum-executor/EthereumState.h
@@ -31,18 +31,24 @@
 #pragma once
 
 #include "EVMSupport.h"
-#include "bcos-framework/storage2/RollbackableStorage.h"
+#include "bcos-concepts/ByteBuffer.h"
 #include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/storage2/RollbackableStorage.h"
 #include "bcos-task/TBBWait.h"
-#include <cassert>
 #include <evmc/evmc.h>
+#include <boost/lexical_cast.hpp>
+#include <array>
+#include <cassert>
 #include <evmc/evmc.hpp>
 #include <intx/intx.hpp>
 #include <limits>
 #include <optional>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/transform.hpp>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -155,7 +161,9 @@ task::Task<void> clearAccountStorage(
         auto const& [k, v] = *kv;
         executor_v1::StateKeyView view(k);
         if (view.m_table != tableName)
+        {
             break;  // Left this account's table.
+        }
         auto key = view.m_key;
         if (key != ACCOUNT_TABLE_FIELDS::NONCE && key != ACCOUNT_TABLE_FIELDS::BALANCE &&
             key != ACCOUNT_TABLE_FIELDS::CODE_HASH && key != ACCOUNT_TABLE_FIELDS::CODE &&
@@ -166,7 +174,9 @@ task::Task<void> clearAccountStorage(
         }
     }
     if (!keysToRemove.empty())
+    {
         co_await storage2::removeSome(storage, keysToRemove);
+    }
 }
 
 /// Ported evmone::state::State, reading/writing BCOS storage directly.
@@ -194,7 +204,7 @@ class EthereumState
     {
         bytes32 key;
         bytes32 prev_value;
-        evmc_access_status prev_access_status;
+        evmc_access_status prev_access_status = EVMC_ACCESS_COLD;
     };
 
     struct JournalTransientStorageChange : JournalBase
@@ -243,29 +253,68 @@ class EthereumState
         EVMAccount<Storage> evmAccount(storage, addr, false);
 
         if (!co_await evmAccount.exists())
+        {
             co_return std::nullopt;
+        }
+
+        // Batch-read the three fixed account fields (nonce/balance/codeHash) in a
+        // single readSome instead of three independent readOne calls against the
+        // same account table. The returned vector matches the key order. The
+        // exists() check above (against SYS_TABLES) is kept: an account may exist
+        // with all its field entries missing, which readSome would report as empty
+        // but must not be conflated with a non-existent account.
+        auto tableName = co_await evmAccount.path();
+        auto fieldValues = co_await storage2::readSome(
+            storage, std::array{
+                         executor_v1::StateKey{tableName, ledger::ACCOUNT_TABLE_FIELDS::NONCE},
+                         executor_v1::StateKey{tableName, ledger::ACCOUNT_TABLE_FIELDS::BALANCE},
+                         executor_v1::StateKey{tableName, ledger::ACCOUNT_TABLE_FIELDS::CODE_HASH},
+                     });
 
         eth_state_detail::ReadAccount acc;
-        auto nonceVal = co_await evmAccount.nonce();
-        if (nonceVal.has_value())
-            acc.nonce = static_cast<uint64_t>(bcos::u256(nonceVal.value()));
-
-        acc.balance = evm::toIntxU256(co_await evmAccount.balance());
-
-        auto codeHashVal = co_await evmAccount.codeHash();
+        if (auto& nonceField = fieldValues[0]; nonceField.has_value())
         {
-            auto const* d = codeHashVal.data();
+            acc.nonce = static_cast<uint64_t>(bcos::u256(std::string(nonceField->get())));
+        }
+
+        {
+            bcos::u256 balance = 0;
+            if (auto& balanceField = fieldValues[1]; balanceField.has_value())
+            {
+                balance = boost::lexical_cast<bcos::u256>(balanceField->get());
+            }
+            acc.balance = evm::toIntxU256(balance);
+        }
+
+        {
+            // A missing, short, or all-zero CODE_HASH entry means the account has
+            // no code (EMPTY_CODE_HASH), matching the previous codeHash() read path.
+            std::string_view codeHashView;
+            if (auto& codeHashField = fieldValues[2]; codeHashField.has_value())
+            {
+                codeHashView = codeHashField->get();
+            }
             bool hasCodeHash = false;
-            for (size_t i = 0; i < 32; ++i)
-                if (d[i] != 0)
+            if (codeHashView.size() >= sizeof(evmc_bytes32))
+            {
+                for (size_t i = 0; i < sizeof(evmc_bytes32); ++i)
                 {
-                    hasCodeHash = true;
-                    break;
+                    if (codeHashView[i] != 0)
+                    {
+                        hasCodeHash = true;
+                        break;
+                    }
                 }
+            }
             if (hasCodeHash)
-                std::copy_n(d, sizeof(evmc_bytes32), acc.code_hash.bytes);
+            {
+                std::copy_n(
+                    codeHashView.begin(), sizeof(evmc_bytes32), std::begin(acc.code_hash.bytes));
+            }
             else
+            {
                 acc.code_hash = EthAccount::EMPTY_CODE_HASH;
+            }
         }
 
         acc.has_storage = co_await hasStorageImpl(evmAccount);
@@ -312,7 +361,9 @@ class EthereumState
             auto const& [k, v] = *kv;
             executor_v1::StateKeyView view(k);
             if (view.m_table != tableName)
+            {
                 break;  // Left this account's table.
+            }
 
             auto key = view.m_key;
             if (key != ACCOUNT_TABLE_FIELDS::NONCE && key != ACCOUNT_TABLE_FIELDS::BALANCE &&
@@ -346,11 +397,15 @@ class EthereumState
         EVMAccount<Storage> evmAccount(storage, addr, false);
 
         if (!co_await evmAccount.exists())
+        {
             co_return {};
+        }
 
         auto codeEntry = co_await evmAccount.code();
         if (!codeEntry.has_value())
+        {
             co_return {};
+        }
 
         auto view = codeEntry->get();
         co_return bytes(view.begin(), view.end());
@@ -464,7 +519,9 @@ template <class Storage>
 EthAccount* EthereumState<Storage>::find(const address& addr) noexcept
 {
     if (const auto it = m_modified.find(addr); it != m_modified.end())
+    {
         return &it->second;
+    }
     if (const auto cacc = readAccount(addr); cacc)
     {
         EthAccount acc;
@@ -489,7 +546,9 @@ template <class Storage>
 EthAccount& EthereumState<Storage>::get_or_insert(const address& addr, EthAccount account)
 {
     if (const auto acc = find(addr); acc != nullptr)
+    {
         return *acc;
+    }
     return insert(addr, std::move(account));
 }
 
@@ -498,11 +557,17 @@ bytes_view EthereumState<Storage>::get_code(const address& addr)
 {
     auto* a = find(addr);
     if (a == nullptr)
+    {
         return {};
+    }
     if (a->code_hash == EthAccount::EMPTY_CODE_HASH)
+    {
         return {};
+    }
     if (a->code.empty())
+    {
         a->code = readCode(addr);
+    }
     return a->code;
 }
 
@@ -653,16 +718,22 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
         // Deleted accounts are handled in phase 2 (they may also be modified —
         // evmone's build_diff reports destructed accounts under deleted_accounts).
         if (acc.destructed)
+        {
             continue;
+        }
         // Match evmone build_diff: an empty touched account is never written in
         // phase 1 — not just_created ones are deleted in phase 2, just_created
         // ones are dropped entirely.
         if (acc.erase_if_empty && rev >= EVMC_SPURIOUS_DRAGON && acc.is_empty())
+        {
             continue;
+        }
 
         EVMAccount<Storage> bcosAcc(m_storage, addr, false);
         if (!co_await bcosAcc.exists())
+        {
             co_await bcosAcc.create();
+        }
         co_await bcosAcc.setNonce(std::to_string(acc.nonce));
         co_await bcosAcc.setBalance(evm::toBcosU256(acc.balance));
         if (acc.code_changed)
@@ -677,16 +748,27 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
             bcos::bytes codeHash(acc.code_hash.bytes, acc.code_hash.bytes + sizeof(evmc_bytes32));
             co_await bcosAcc.setCode(std::move(code), std::string{}, bcos::h256(codeHash));
         }
-        for (auto const& [key, value] : acc.storage)
+        // Batch-write the changed storage slots in one writeSome: a single
+        // pre-image read (readSomeRaw) + one batch write instead of one
+        // readOneRaw + writeOne per slot. The changed-slot selection is a lazy
+        // ranges::filter view, so no temporary vector is materialized here
+        // (Rollbackable::writeSome materializes internally only when needed).
+        // NOTE: a zero value still leaves a zero-valued row (there is no
+        // delete-storage API); such rows are only cleaned on self-destruct via
+        // clearAccountStorage(). This matches evmone's state semantics (a zero
+        // slot reads back as zero).
+        if (!acc.storage.empty())
         {
-            if (value.current == value.original)
-                continue;
-            // NOTE: EVMAccount::setStorage always writes the entry (a zero
-            // value leaves a zero-valued row; there is no delete-storage API).
-            // Such zero rows are only cleaned on self-destruct via
-            // clearAccountStorage(). This matches evmone's state semantics (a
-            // zero slot reads back as zero).
-            co_await bcosAcc.setStorage(key, value.current);
+            auto tableName = co_await bcosAcc.path();
+            auto writes = acc.storage | ::ranges::views::filter([](auto const& slotEntry) {
+                return slotEntry.second.current != slotEntry.second.original;
+            }) | ::ranges::views::transform([&tableName](auto const& slotEntry) {
+                return std::pair<executor_v1::StateKey, storage::Entry>{
+                    executor_v1::StateKey{
+                        tableName, concepts::bytebuffer::toView(slotEntry.first.bytes)},
+                    storage::Entry{concepts::bytebuffer::toView(slotEntry.second.current.bytes)}};
+            });
+            co_await storage2::writeSome(m_storage, writes);
         }
     }
 

--- a/ethereum-executor/EthereumTransition.h
+++ b/ethereum-executor/EthereumTransition.h
@@ -46,9 +46,13 @@ inline constexpr evm::BlobParams CANCUN_BLOB_PARAMS{
 inline evm::BlobParams blobParamsForRevision(evmc_revision rev) noexcept
 {
     if (rev >= EVMC_PRAGUE)
+    {
         return PRAGUE_BLOB_PARAMS;  // Prague/Osaka.
+    }
     if (rev == EVMC_CANCUN)
+    {
         return CANCUN_BLOB_PARAMS;  // Cancun.
+    }
     return {};
 }
 
@@ -86,7 +90,9 @@ inline std::optional<address> ethToAddress(protocol::Transaction const& tx)
 {
     auto const& tb = tx.to();
     if (tb.empty())
+    {
         return std::nullopt;
+    }
 
     const bool has0x = tb.size() >= 2 && tb[0] == '0' && (tb[1] == 'x' || tb[1] == 'X');
     const bool is40Hex = tb.size() == sizeof(evmc_address) * 2 &&
@@ -147,7 +153,9 @@ inline int64_t compute_access_list_cost(const protocol::Web3AccessList& access_l
 
     int64_t cost = 0;
     for (const auto& entry : access_list)
+    {
         cost += ADDRESS_COST + static_cast<int64_t>(entry.storageKeys.size()) * STORAGE_KEY_COST;
+    }
     return cost;
 }
 
@@ -190,7 +198,7 @@ inline TransactionCost compute_tx_intrinsic_cost(
 
     // EIP-7623: Compute the minimum cost for the transaction by. If disabled, just use 0.
     const auto min_cost =
-        rev >= EVMC_PRAGUE ? TX_BASE_COST + num_tokens * TOTAL_COST_FLOOR_PER_TOKEN : 0;
+        rev >= EVMC_PRAGUE ? TX_BASE_COST + (num_tokens * TOTAL_COST_FLOOR_PER_TOKEN) : 0;
 
     return {intrinsic_cost, min_cost};
 }
@@ -234,23 +242,33 @@ int64_t processAuthorizationList(
     {
         // 1. Verify the chain id is either 0 or the chain's current ID.
         if (auth.chainId != 0 && auth.chainId != chainId)
+        {
             continue;
+        }
 
         // 2. Verify the nonce is less than 2**64 - 1.
         if (auth.nonce == EthAccount::NonceMax)
+        {
             continue;
+        }
 
         // 3. y_parity must be 0 or 1; s must be <= secp256k1n/2 (EIP-2).
         if (auth.v > 1)
+        {
             continue;
+        }
         if (evm::toIntxU256(auth.s) > evm::SECP256K1N_OVER_2)
+        {
             continue;
+        }
 
         // 4. Always recover the signer via real ecrecover (never honour an
         //    attacker-supplied signer field).
         const auto signer = recoverAuthority(auth);
         if (!signer.has_value())
+        {
             continue;  // ecrecover failed → skip this authorization
+        }
 
         evmc::address target{};
         std::copy_n(auth.address.begin(), sizeof(evmc_address), target.bytes);
@@ -266,11 +284,15 @@ int64_t processAuthorizationList(
         // 6. Verify the code of authority is either empty or already delegated.
         if (authority.code_hash != EthAccount::EMPTY_CODE_HASH &&
             !evmone::is_code_delegated(state.get_code(*signer)))
+        {
             continue;
+        }
 
         // 7. Verify the nonce of authority is equal to nonce.
         if (auth.nonce != authority.nonce)
+        {
             continue;
+        }
 
         // 8. Refund if authority existed before (empty implies non-existent).
         if (!authority.is_empty())
@@ -329,7 +351,9 @@ std::variant<EthTxProperties, std::error_code> validateTransaction(EthereumState
     // trip the maxPriorityGasPrice assert (debug) or silently run as legacy
     // (release), diverging from geth.
     if (txKind > 4)
+    {
         return make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED);
+    }
     const auto gasLimit = effectiveGasLimit(tx, callParams);
     const auto nonce = effectiveNonce(tx, callParams);
     const auto maxGasPrice = ethMaxGasPrice(tx, callParams);
@@ -341,32 +365,52 @@ std::variant<EthTxProperties, std::error_code> validateTransaction(EthereumState
     {
     case 3:  // blob
         if (rev < EVMC_CANCUN)
+        {
             return make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED);
+        }
         if (!hasTo)
+        {
             return make_error_code(ErrorCode::CREATE_BLOB_TX);
+        }
         if (blobHashes.empty())
+        {
             return make_error_code(ErrorCode::EMPTY_BLOB_HASHES_LIST);
+        }
         if (rev >= EVMC_OSAKA && blobHashes.size() > evm::MAX_TX_BLOB_COUNT)
+        {
             return make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED);
+        }
 
         assert(block.blob_base_fee.has_value());
         if (ethMaxBlobGasPrice(tx) < *block.blob_base_fee)
+        {
             return make_error_code(ErrorCode::BLOB_FEE_CAP_LESS_THAN_BLOCKS);
+        }
 
         if (std::ranges::any_of(blobHashes, [](const auto& h) { return h[0] != 0x01; }))
+        {
             return make_error_code(ErrorCode::INVALID_BLOB_HASH_VERSION);
+        }
         if (static_cast<uint64_t>(evm::GAS_PER_BLOB) * blobHashes.size() >
             static_cast<uint64_t>(blobGasLeft))
+        {
             return make_error_code(ErrorCode::BLOB_GAS_LIMIT_EXCEEDED);
+        }
         break;
 
     case 4:  // set_code
         if (rev < EVMC_PRAGUE)
+        {
             return make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED);
+        }
         if (!hasTo)
+        {
             return make_error_code(ErrorCode::CREATE_SET_CODE_TX);
+        }
         if (tx.authorizationList().empty())
+        {
             return make_error_code(ErrorCode::EMPTY_AUTHORIZATION_LIST);
+        }
         break;
 
     default:;
@@ -378,52 +422,73 @@ std::variant<EthTxProperties, std::error_code> validateTransaction(EthereumState
     case 3:  // blob
     case 2:  // eip1559
         if (rev < EVMC_LONDON)
+        {
             return make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED);
+        }
 
         if (maxPriorityGasPrice > maxGasPrice)
+        {
             return make_error_code(ErrorCode::TIP_GT_FEE_CAP);  // Priority gas price is too high.
+        }
         [[fallthrough]];
 
     case 1:  // access_list
         if (rev < EVMC_BERLIN)
+        {
             return make_error_code(ErrorCode::TX_TYPE_NOT_SUPPORTED);
+        }
         [[fallthrough]];
 
-    case 0:;  // legacy
+    default:;  // legacy (case 0) and out-of-range (txKind>4 already rejected) fall through.
     }
 
     assert(maxPriorityGasPrice <= maxGasPrice);
 
     if (rev >= EVMC_OSAKA && gasLimit > evm::MAX_TX_GAS_LIMIT)
+    {
         return make_error_code(ErrorCode::MAX_GAS_LIMIT_EXCEEDED);
+    }
 
     if (gasLimit > blockGasLeft)
+    {
         return make_error_code(ErrorCode::GAS_LIMIT_REACHED);
+    }
 
     if (maxGasPrice < block.base_fee)
+    {
         return make_error_code(ErrorCode::FEE_CAP_LESS_THAN_BLOCKS);
+    }
 
     // We need some information about the sender so lookup the account in the state.
     const auto* const senderPtr = state.find(ethSender(tx));
     const auto senderNonce = senderPtr != nullptr ? senderPtr->nonce : 0;
 
-    if (senderPtr != nullptr &&
-        senderPtr->code_hash != EthAccount::EMPTY_CODE_HASH &&
+    if (senderPtr != nullptr && senderPtr->code_hash != EthAccount::EMPTY_CODE_HASH &&
         !evmone::is_code_delegated(state.get_code(ethSender(tx))))
+    {
         return make_error_code(ErrorCode::SENDER_NOT_EOA);  // Origin must not be a contract (EIP-3607).
+    }
 
-    if (senderNonce == EthAccount::NonceMax)  // Nonce value limit (EIP-2681).
+    if (senderNonce == EthAccount::NonceMax)
+    {  // Nonce value limit (EIP-2681).
         return make_error_code(ErrorCode::NONCE_HAS_MAX_VALUE);
+    }
 
     if (senderNonce < nonce)
+    {
         return make_error_code(ErrorCode::NONCE_TOO_HIGH);
+    }
 
     if (senderNonce > nonce)
+    {
         return make_error_code(ErrorCode::NONCE_TOO_LOW);
+    }
 
     // initcode size is limited by EIP-3860.
     if (rev >= EVMC_SHANGHAI && !hasTo && tx.input().size() > evmone::MAX_INITCODE_SIZE)
+    {
         return make_error_code(ErrorCode::INIT_CODE_SIZE_LIMIT_EXCEEDED);
+    }
 
     // Compute and check if sender has enough balance for the theoretical maximum transaction cost.
     auto max_total_fee =
@@ -438,12 +503,16 @@ std::variant<EthTxProperties, std::error_code> validateTransaction(EthereumState
     }
     const auto senderBalance = senderPtr != nullptr ? senderPtr->balance : intx::uint256{};
     if (senderBalance < max_total_fee)
+    {
         return make_error_code(ErrorCode::INSUFFICIENT_FUNDS);
+    }
 
     const auto [intrinsic_cost, min_cost] =
         eth_transition_detail::compute_tx_intrinsic_cost(rev, tx);
     if (gasLimit < std::max(intrinsic_cost, min_cost))
+    {
         return make_error_code(ErrorCode::INTRINSIC_GAS_TOO_LOW);
+    }
 
     const auto execution_gas_limit = gasLimit - intrinsic_cost;
     return EthTxProperties{execution_gas_limit, min_cost};
@@ -491,7 +560,9 @@ protocol::TransactionReceipt::Ptr buildBcosReceipt(EthereumHost<Storage>& host,
         bcos::bytes addr(l.addr.bytes, l.addr.bytes + sizeof(evmc_address));
         bcos::h256s topics;
         for (auto const& t : l.topics)
+        {
             topics.emplace_back(bcos::bytesConstRef(t.bytes, sizeof(evmc_bytes32)));
+        }
         bcos::bytes data(l.data.begin(), l.data.end());
         logs.emplace_back(std::move(addr), std::move(topics), std::move(data));
     }
@@ -562,7 +633,9 @@ task::Task<protocol::TransactionReceipt::Ptr> runTransaction(EthereumState<Stora
 
     sender_acc.access_status = EVMC_ACCESS_WARM;  // Tx sender is always warm.
     if (to.has_value())
+    {
         host.access_account(*to);
+    }
     for (const auto& entry : tx.web3AccessList())
     {
         evmc::address a{};
@@ -577,7 +650,9 @@ task::Task<protocol::TransactionReceipt::Ptr> runTransaction(EthereumState<Stora
     }
     // EIP-3651: Warm COINBASE.
     if (rev >= EVMC_SHANGHAI)
+    {
         host.access_account(block.coinbase);
+    }
 
     auto message = eth_transition_detail::build_message(tx, txProps.execution_gas_limit);
     if (to.has_value())
@@ -633,7 +708,9 @@ task::Task<void> finalizeState(EthereumState<Storage>& state, evmc_revision rev,
     }
 
     for (const auto& withdrawal : withdrawals)
+    {
         state.touch(withdrawal.recipient).balance += withdrawal.get_amount();
+    }
 
     co_await state.applyToStorage(rev);
 }

--- a/ethereum-executor/tests/EESTRunner.cpp
+++ b/ethereum-executor/tests/EESTRunner.cpp
@@ -64,10 +64,14 @@ namespace bcos::test
 std::string readHexField(Json::Value const& obj, std::string const& key)
 {
     if (!obj.isMember(key) || obj[key].isNull())
+    {
         return {};
+    }
     auto const& val = obj[key];
     if (val.isString())
+    {
         return val.asString();
+    }
     if (val.isInt64())
     {
         // Small integers: format as hex
@@ -82,17 +86,23 @@ std::string readRequiredHex(Json::Value const& obj, std::string const& key)
 {
     auto val = readHexField(obj, key);
     if (val.empty() && !obj.isMember(key))
+    {
         BOOST_THROW_EXCEPTION(std::runtime_error("Missing required field: " + key));
+    }
     return val;
 }
 
 bcos::bytes hexToBytes(std::string const& hex)
 {
     if (hex.empty() || hex == "0x")
+    {
         return {};
+    }
     std::string cleaned = hex;
     if (cleaned.size() >= 2 && cleaned[0] == '0' && cleaned[1] == 'x')
+    {
         cleaned = cleaned.substr(2);
+    }
     bcos::bytes result;
     boost::algorithm::unhex(cleaned, std::back_inserter(result));
     return result;
@@ -101,21 +111,27 @@ bcos::bytes hexToBytes(std::string const& hex)
 bcos::u256 hexToU256(std::string const& hex)
 {
     if (hex.empty() || hex == "0x")
+    {
         return 0;
+    }
     return bcos::u256(hex);
 }
 
 int64_t hexToInt64(std::string const& hex)
 {
     if (hex.empty() || hex == "0x")
+    {
         return 0;
+    }
     return static_cast<int64_t>(hexToU256(hex));
 }
 
 int64_t hexToTimestamp(std::string const& hex)
 {
     if (hex.empty() || hex == "0x")
+    {
         return 0;
+    }
     // Preserve the low 64 bits exactly, avoid sign-extension issues.
     return static_cast<int64_t>(static_cast<uint64_t>(hexToU256(hex)));
 }
@@ -123,7 +139,9 @@ int64_t hexToTimestamp(std::string const& hex)
 std::string strip0x(std::string const& hex)
 {
     if (hex.size() >= 2 && hex[0] == '0' && hex[1] == 'x')
+    {
         return hex.substr(2);
+    }
     return hex;
 }
 
@@ -131,9 +149,13 @@ std::string detectFixtureFormat(Json::Value const& fixtureJson)
 {
     if (fixtureJson.isMember("env") && fixtureJson["env"].isObject() &&
         fixtureJson.isMember("post") && fixtureJson["post"].isObject())
+    {
         return "state_test";
+    }
     if (fixtureJson.isMember("blocks") && fixtureJson["blocks"].isArray())
+    {
         return "blockchain_test";
+    }
     return "unknown";
 }
 
@@ -145,7 +167,9 @@ EESTEnvironment parseEnvironment(Json::Value const& envJson)
     // fixtures (e.g. blockchain_test_from_state_test) don't cause parse failures.
     env.gasLimit = readHexField(envJson, "currentGasLimit");
     if (env.gasLimit.empty())
+    {
         env.gasLimit = "0x7fffffffffffffff";  // effectively unlimited
+    }
     env.number = readRequiredHex(envJson, "currentNumber");
     env.timestamp = readRequiredHex(envJson, "currentTimestamp");
     env.difficulty = readHexField(envJson, "currentDifficulty");
@@ -211,19 +235,25 @@ EESTTransaction parseTransaction(Json::Value const& txJson)
     if (txJson.isMember("gasLimit") && txJson["gasLimit"].isArray())
     {
         for (auto const& v : txJson["gasLimit"])
+        {
             tx.gasLimit.push_back(v.asString());
+        }
     }
     // value array
     if (txJson.isMember("value") && txJson["value"].isArray())
     {
         for (auto const& v : txJson["value"])
+        {
             tx.value.push_back(v.asString());
+        }
     }
     // data array
     if (txJson.isMember("data") && txJson["data"].isArray())
     {
         for (auto const& v : txJson["data"])
+        {
             tx.data.push_back(v.asString());
+        }
     }
     // accessLists array
     if (txJson.isMember("accessLists") && txJson["accessLists"].isArray())
@@ -232,7 +262,7 @@ EESTTransaction parseTransaction(Json::Value const& txJson)
         {
             if (al.isNull())
             {
-                tx.accessLists.push_back(std::nullopt);
+                tx.accessLists.emplace_back(std::nullopt);
                 continue;
             }
             std::vector<std::pair<std::string, std::vector<std::string>>> entries;
@@ -245,12 +275,14 @@ EESTTransaction parseTransaction(Json::Value const& txJson)
                     if (entry.isMember("storageKeys") && entry["storageKeys"].isArray())
                     {
                         for (auto const& k : entry["storageKeys"])
+                        {
                             keys.push_back(k.asString());
+                        }
                     }
                     entries.emplace_back(std::move(addr), std::move(keys));
                 }
             }
-            tx.accessLists.push_back(std::move(entries));
+            tx.accessLists.emplace_back(std::move(entries));
         }
     }
     // authorizationList
@@ -258,13 +290,17 @@ EESTTransaction parseTransaction(Json::Value const& txJson)
     {
         tx.authorizationList.emplace();
         for (auto const& auth : txJson["authorizationList"])
+        {
             tx.authorizationList->push_back(auth);
+        }
     }
     // blobVersionedHashes (EIP-4844)
     if (txJson.isMember("blobVersionedHashes") && txJson["blobVersionedHashes"].isArray())
     {
         for (auto const& h : txJson["blobVersionedHashes"])
+        {
             tx.blobVersionedHashes.push_back(h.asString());
+        }
     }
     return tx;
 }
@@ -286,15 +322,21 @@ EESTForkPost parseForkPost(Json::Value const& postJson)
     {
         auto const& exc = postJson["expectException"];
         if (exc.isObject() && exc.isMember("type"))
+        {
             post.expectException = exc["type"].asString();
+        }
         else if (exc.isString())
+        {
             post.expectException = exc.asString();
+        }
     }
     if (postJson.isMember("state") && !postJson["state"].isNull())
     {
         auto const& stateJson = postJson["state"];
         for (auto it = stateJson.begin(); it != stateJson.end(); ++it)
+        {
             post.state[it.key().asString()] = parseAccount(*it);
+        }
     }
     return post;
 }
@@ -310,7 +352,9 @@ EESTFixture parseFixture(std::string const& name, Json::Value const& fixtureJson
     {
         auto const& preJson = fixtureJson["pre"];
         for (auto it = preJson.begin(); it != preJson.end(); ++it)
+        {
             fixture.pre[it.key().asString()] = parseAccount(*it);
+        }
     }
 
     // Transaction
@@ -324,7 +368,9 @@ EESTFixture parseFixture(std::string const& name, Json::Value const& fixtureJson
         {
             std::vector<EESTForkPost> posts;
             for (auto const& p : *it)
+            {
                 posts.push_back(parseForkPost(p));
+            }
             fixture.post[it.key().asString()] = std::move(posts);
         }
     }
@@ -335,7 +381,9 @@ EESTFixture parseFixture(std::string const& name, Json::Value const& fixtureJson
         auto chainIdHex = readHexField(fixtureJson["config"], "chainid");
         fixture.chainId = hexToInt64(chainIdHex);
         if (fixture.chainId == 0)
+        {
             fixture.chainId = 1;
+        }
     }
 
     return fixture;
@@ -348,26 +396,34 @@ std::vector<EESTFixture> loadEESTFixtures(std::string const& filePath)
     // Read file
     std::ifstream file(filePath);
     if (!file.is_open())
+    {
         BOOST_THROW_EXCEPTION(std::runtime_error("Cannot open fixture file: " + filePath));
+    }
 
     Json::CharReaderBuilder builder;
     Json::Value root;
     std::string errors;
     if (!Json::parseFromStream(builder, file, &root, &errors))
+    {
         BOOST_THROW_EXCEPTION(
             std::runtime_error("JSON parse error in " + filePath + ": " + errors));
+    }
 
     // The root is a map of test_name → fixture_data
     int skippedBlockchain = 0;
     for (auto it = root.begin(); it != root.end(); ++it)
     {
-        if (it.key().asString().rfind("//", 0) == 0 ||  // comment entry
-            it.key().asString().rfind("_", 0) == 0)     // meta entry like _info
+        if (it.key().asString().starts_with("//") ||  // comment entry
+            it.key().asString().starts_with('_'))
+        {  // meta entry like _info
             continue;
+        }
 
         // Skip non-object values (e.g. metadata files with string/bool/int entries)
         if (!it->isObject())
+        {
             continue;
+        }
 
         // Per-fixture format check: some state_tests directories contain
         // blockchain_test_from_state_test fixtures that lack currentGasLimit.
@@ -385,7 +441,7 @@ std::vector<EESTFixture> loadEESTFixtures(std::string const& filePath)
         catch (std::exception const& e)
         {
             std::cerr << "Warning: Failed to parse fixture '" << it.key().asString()
-                      << "': " << e.what() << std::endl;
+                      << "': " << e.what() << '\n';
         }
     }
 
@@ -410,20 +466,32 @@ EESTTransaction parseBlockchainTransaction(Json::Value const& txJson)
     // blockchain tests have scalar values, wrap in single-element arrays
     auto gasLimit = readHexField(txJson, "gasLimit");
     if (!gasLimit.empty())
+    {
         tx.gasLimit.push_back(gasLimit);
+    }
     else
-        tx.gasLimit.push_back("0x0");
+    {
+        tx.gasLimit.emplace_back("0x0");
+    }
     tx.to = readHexField(txJson, "to");
     auto value = readHexField(txJson, "value");
     if (!value.empty())
+    {
         tx.value.push_back(value);
+    }
     else
-        tx.value.push_back("0x0");
+    {
+        tx.value.emplace_back("0x0");
+    }
     auto data = readHexField(txJson, "data");
     if (!data.empty())
+    {
         tx.data.push_back(data);
+    }
     else
-        tx.data.push_back("0x");
+    {
+        tx.data.emplace_back("0x");
+    }
     tx.sender = readHexField(txJson, "sender");
     tx.secretKey = readHexField(txJson, "secretKey");
     tx.maxFeePerBlobGas = readHexField(txJson, "maxFeePerBlobGas");
@@ -437,11 +505,15 @@ EESTTransaction parseBlockchainTransaction(Json::Value const& txJson)
             std::string addr = readHexField(entry, "address");
             std::vector<std::string> keys;
             if (entry.isMember("storageKeys") && entry["storageKeys"].isArray())
+            {
                 for (auto const& k : entry["storageKeys"])
+                {
                     keys.push_back(k.asString());
+                }
+            }
             entries.emplace_back(std::move(addr), std::move(keys));
         }
-        tx.accessLists.push_back(std::move(entries));
+        tx.accessLists.emplace_back(std::move(entries));
     }
 
     // authorizationList (EIP-7702)
@@ -449,17 +521,19 @@ EESTTransaction parseBlockchainTransaction(Json::Value const& txJson)
     {
         tx.authorizationList.emplace();
         for (auto const& auth : txJson["authorizationList"])
+        {
             tx.authorizationList->push_back(auth);
+        }
     }
 
     // blobVersionedHashes
     if (txJson.isMember("blobVersionedHashes") && txJson["blobVersionedHashes"].isArray())
+    {
         for (auto const& h : txJson["blobVersionedHashes"])
+        {
             tx.blobVersionedHashes.push_back(h.asString());
-
-    // Determine typed tx kind
-    auto type = readHexField(txJson, "type");
-    // type is stored separately from the web3TypedTxKind; we'll set it later
+        }
+    }
 
     return tx;
 }
@@ -471,15 +545,20 @@ EESTBlockchainFixture parseBlockchainFixture(
     fixture.name = name;
 
     // genesisBlockHeader (optional: engine_x format lacks it)
-    if (fixtureJson.isMember("genesisBlockHeader") &&
-        fixtureJson["genesisBlockHeader"].isObject())
+    if (fixtureJson.isMember("genesisBlockHeader") && fixtureJson["genesisBlockHeader"].isObject())
+    {
         fixture.genesisBlockHeader =
             parseBlockHeader(fixtureJson["genesisBlockHeader"]);
+    }
 
     // pre state
     if (fixtureJson.isMember("pre") && !fixtureJson["pre"].isNull())
+    {
         for (auto it = fixtureJson["pre"].begin(); it != fixtureJson["pre"].end(); ++it)
+        {
             fixture.pre[it.key().asString()] = parseAccount(*it);
+        }
+    }
 
     // blocks
     if (fixtureJson.isMember("blocks") && fixtureJson["blocks"].isArray())
@@ -490,8 +569,12 @@ EESTBlockchainFixture parseBlockchainFixture(
             block.blockHeader = parseBlockHeader(blockJson["blockHeader"]);
 
             if (blockJson.isMember("transactions") && blockJson["transactions"].isArray())
+            {
                 for (auto const& txJson : blockJson["transactions"])
+                {
                     block.transactions.push_back(parseBlockchainTransaction(txJson));
+                }
+            }
 
             // Withdrawals (EIP-4895)
             if (blockJson.isMember("withdrawals") && blockJson["withdrawals"].isArray())
@@ -513,9 +596,12 @@ EESTBlockchainFixture parseBlockchainFixture(
 
     // postState
     if (fixtureJson.isMember("postState") && !fixtureJson["postState"].isNull())
-        for (auto it = fixtureJson["postState"].begin();
-             it != fixtureJson["postState"].end(); ++it)
+    {
+        for (auto it = fixtureJson["postState"].begin(); it != fixtureJson["postState"].end(); ++it)
+        {
             fixture.postState[it.key().asString()] = parseAccount(*it);
+        }
+    }
 
     // config
     if (fixtureJson.isMember("config"))
@@ -523,7 +609,9 @@ EESTBlockchainFixture parseBlockchainFixture(
         auto chainIdHex = readHexField(fixtureJson["config"], "chainid");
         fixture.chainId = hexToInt64(chainIdHex);
         if (fixture.chainId == 0)
+        {
             fixture.chainId = 1;
+        }
     }
 
     return fixture;
@@ -535,25 +623,32 @@ std::vector<EESTBlockchainFixture> loadEESTBlockchainFixtures(std::string const&
 
     std::ifstream file(filePath);
     if (!file.is_open())
+    {
         BOOST_THROW_EXCEPTION(
             std::runtime_error("Cannot open fixture file: " + filePath));
+    }
 
     Json::CharReaderBuilder builder;
     Json::Value root;
     std::string errors;
     if (!Json::parseFromStream(builder, file, &root, &errors))
+    {
         BOOST_THROW_EXCEPTION(
             std::runtime_error("JSON parse error in " + filePath + ": " + errors));
+    }
 
     for (auto it = root.begin(); it != root.end(); ++it)
     {
-        if (it.key().asString().rfind("//", 0) == 0 ||
-            it.key().asString().rfind("_", 0) == 0)
+        if (it.key().asString().starts_with("//") || it.key().asString().starts_with('_'))
+        {
             continue;
+        }
 
         // Skip non-object values
         if (!it->isObject())
+        {
             continue;
+        }
 
         try
         {
@@ -562,8 +657,8 @@ std::vector<EESTBlockchainFixture> loadEESTBlockchainFixtures(std::string const&
         }
         catch (std::exception const& e)
         {
-            std::cerr << "Warning: Failed to parse blockchain fixture '"
-                      << it.key().asString() << "': " << e.what() << std::endl;
+            std::cerr << "Warning: Failed to parse blockchain fixture '" << it.key().asString()
+                      << "': " << e.what() << '\n';
         }
     }
 
@@ -577,40 +672,72 @@ evmc_revision forkNameToRevision(std::string const& forkName)
     boost::algorithm::to_lower(lower);
 
     if (lower == "frontier")
+    {
         return EVMC_FRONTIER;
+    }
     if (lower == "homestead")
+    {
         return EVMC_HOMESTEAD;
+    }
     if (lower == "tangerine whistle" || lower == "tangerinewhistle" || lower == "eip150")
+    {
         return EVMC_TANGERINE_WHISTLE;
+    }
     if (lower == "spurious dragon" || lower == "spuriousdragon" || lower == "eip158")
+    {
         return EVMC_SPURIOUS_DRAGON;
+    }
     if (lower == "byzantium")
+    {
         return EVMC_BYZANTIUM;
+    }
     if (lower == "constantinople")
+    {
         return EVMC_CONSTANTINOPLE;
+    }
     if (lower == "constantinoplefix" || lower == "petersburg")
+    {
         return EVMC_PETERSBURG;
+    }
     if (lower == "istanbul")
+    {
         return EVMC_ISTANBUL;
+    }
     // Muir Glacier (EIP-2384) only delays the difficulty bomb; it changes no
     // EVM semantics over Istanbul. Mapping it to Berlin would wrongly activate
     // EIP-2929 access-list gas for MuirGlacier fixtures.
     if (lower == "muir glacier" || lower == "muirglacier")
+    {
         return EVMC_ISTANBUL;
+    }
     if (lower == "berlin")
+    {
         return EVMC_BERLIN;
+    }
     if (lower == "london")
+    {
         return EVMC_LONDON;
+    }
     if (lower == "paris" || lower == "merge")
+    {
         return EVMC_PARIS;
+    }
     if (lower == "shanghai")
+    {
         return EVMC_SHANGHAI;
+    }
     if (lower == "cancun")
+    {
         return EVMC_CANCUN;
+    }
     if (lower == "prague")
+    {
         return EVMC_PRAGUE;
+    }
     if (lower == "osaka")
+    {
         return EVMC_OSAKA;
+    }
 
     // Unknown fork → default to the latest handled revision so a future fork
     // is not silently mis-executed as Cancun (which would produce false
@@ -754,11 +881,11 @@ void parseOptions(int argc, char* argv[])
         {
             g_opts.singleFixture = argv[++i];
         }
-        else if (arg.rfind("--fixture-dir=", 0) == 0)
+        else if (arg.starts_with("--fixture-dir="))
         {
             g_opts.fixtureDir = arg.substr(14);
         }
-        else if (arg.rfind("--fixture=", 0) == 0)
+        else if (arg.starts_with("--fixture="))
         {
             g_opts.singleFixture = arg.substr(10);
         }
@@ -988,18 +1115,11 @@ public:
     bcostars::protocol::BlockHeaderImpl buildBlockHeader(test::EESTEnvironment const& env)
     {
         bcostars::protocol::BlockHeaderImpl header;
-        uint32_t blockVer;
-        if (m_currentRevision >= EVMC_CANCUN)
-        {
-            blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION);
-        }
-        else if (m_currentRevision >= EVMC_PARIS)
+        // Only [Paris, Cancun) maps to V3_2; Cancun+ and pre-Paris use V3_1.
+        auto blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION);
+        if (m_currentRevision >= EVMC_PARIS && m_currentRevision < EVMC_CANCUN)
         {
             blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_2_VERSION);
-        }
-        else
-        {
-            blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION);
         }
         header.setVersion(blockVer);
         header.setNumber(test::hexToInt64(env.number));
@@ -1052,7 +1172,7 @@ public:
     }
 
     std::shared_ptr<bcostars::protocol::TransactionImpl> buildTransaction(
-        test::EESTTransaction const& tx, int dataIndex, int gasIndex, int valueIndex)
+        test::EESTTransaction const& tx, int dataIndex, int gasIndex, int valueIndex) const
     {
         std::string txData;
         if (dataIndex >= 0 && static_cast<size_t>(dataIndex) < tx.data.size())
@@ -1197,11 +1317,12 @@ public:
     }
 
     /// Verify post-state. Returns a string with mismatch details (empty = all good).
-    std::string verifyPostState(
+    static std::string verifyPostState(
         MutableStorage& storage, std::map<std::string, test::EESTAccount> const& expected)
     {
         std::ostringstream errors;
-        int passed = 0, failed = 0;
+        int passed = 0;
+        int failed = 0;
         (void)passed;  // not used for return, only local tracking
 
         for (auto const& [addrHex, expectedAcc] : expected)
@@ -1494,18 +1615,11 @@ public:
     bcostars::protocol::BlockHeaderImpl buildBlockHeader(test::EESTBlockHeader const& bh)
     {
         bcostars::protocol::BlockHeaderImpl header;
-        uint32_t blockVer;
-        if (m_currentRevision >= EVMC_CANCUN)
-        {
-            blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION);
-        }
-        else if (m_currentRevision >= EVMC_PARIS)
+        // Only [Paris, Cancun) maps to V3_2; Cancun+ and pre-Paris use V3_1.
+        auto blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION);
+        if (m_currentRevision >= EVMC_PARIS && m_currentRevision < EVMC_CANCUN)
         {
             blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_2_VERSION);
-        }
-        else
-        {
-            blockVer = static_cast<uint32_t>(bcos::protocol::BlockVersion::V3_1_VERSION);
         }
         header.setVersion(blockVer);
 
@@ -2047,10 +2161,9 @@ FileResult processFixtureFile(EESTRunner& runner, fs::path const& filePath)
     {
         for (auto const& [forkName, posts] : fixture.post)
         {
-            for (size_t i = 0; i < posts.size(); ++i)
+            for (const auto& post : posts)
             {
                 ++g_totalTests;
-                auto const& post = posts[i];
                 bool passed = runner.runFixture(fixture, forkName, post);
 
                 if (passed)
@@ -2116,7 +2229,7 @@ int main(int argc, char* argv[])
     if (fixtureDir.empty())
     {
         char const* envDir = std::getenv("EEST_FIXTURE_DIR");
-        if (envDir)
+        if (envDir != nullptr)
         {
             fixtureDir = envDir;
         }

--- a/ethereum-executor/tests/TestEthereumStateSmoke.cpp
+++ b/ethereum-executor/tests/TestEthereumStateSmoke.cpp
@@ -59,7 +59,7 @@ namespace
 /// Parse a 0x-prefixed 40-hex-digit string into an evmc::address.
 evmc::address addressFromHex(const std::string& hex)
 {
-    const auto start = (hex.rfind("0x", 0) == 0) ? 2u : 0u;
+    const auto start = (hex.starts_with("0x")) ? 2U : 0U;
     evmc::address out{};
     for (size_t i = 0; i < 40; ++i)
     {
@@ -74,7 +74,7 @@ evmc::address addressFromHex(const std::string& hex)
 /// Parse a 0x-prefixed 64-hex-digit string into an evmc::bytes32.
 evmc::bytes32 bytes32FromHex(const std::string& hex)
 {
-    const auto start = (hex.rfind("0x", 0) == 0) ? 2u : 0u;
+    const auto start = (hex.starts_with("0x")) ? 2U : 0U;
     evmc::bytes32 out{};
     for (size_t i = 0; i < 64; ++i)
     {
@@ -166,7 +166,7 @@ void testBlobGasPrice()
     CHECK(eth_evm::compute_blob_gas_price(params, 16777216) == 152);      // 2**24
     CHECK(eth_evm::compute_blob_gas_price(params, 33554432) == 23174);    // 2**25
     CHECK(eth_evm::compute_blob_gas_price(params, 67108864) == 537070730);  // 2**26
-    CHECK(eth_evm::max_blob_gas_per_block(params) == 6 * eth_evm::GAS_PER_BLOB);
+    CHECK(eth_evm::max_blob_gas_per_block(params) == uint64_t{6} * eth_evm::GAS_PER_BLOB);
 
     // Degenerate schedule (base_fee_update_fraction == 0) must not divide by
     // zero; the guard returns the maximum like the overflow path.
@@ -189,7 +189,11 @@ void testRecoverAuthority()
     auth.s = bcos::u256("0x7399ba8d6bdec8bacec1cfb93d1f1bd00bedbade84959bda53464acaaa32f330");
 
     const auto recovered = eth_evm::recoverAuthority(auth);
-    CHECK(recovered.has_value());
+    if (!recovered.has_value())
+    {
+        CHECK(false);  // a valid EIP-7702 signature must recover an authority
+        return;
+    }
     CHECK(sameAddress(
         *recovered, addressFromHex("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")));
 }
@@ -253,6 +257,6 @@ int main()
         std::cerr << "TestEthereumStateSmoke: " << g_failures << " check(s) failed\n";
         return EXIT_FAILURE;
     }
-    std::cout << "TestEthereumStateSmoke: all checks passed" << std::endl;
+    std::cout << "TestEthereumStateSmoke: all checks passed" << '\n';
     return EXIT_SUCCESS;
 }

--- a/ethereum-executor/tests/TestStorageBridge.h
+++ b/ethereum-executor/tests/TestStorageBridge.h
@@ -81,17 +81,21 @@ private:
         evmc_address addr) const
     {
         using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
+        auto& storage = m_storage;
 
         EVMAccount<Storage> evmAccount(storage, addr, false);
 
         if (!co_await evmAccount.exists())
+        {
             co_return std::nullopt;
+        }
 
         evmone::state::StateView::Account acc;
         auto nonceVal = co_await evmAccount.nonce();
         if (nonceVal.has_value())
+        {
             acc.nonce = static_cast<uint64_t>(bcos::u256(nonceVal.value()));
+        }
 
         acc.balance = bcos::executor_v1::eth::evm::toIntxU256(co_await evmAccount.balance());
 
@@ -100,15 +104,21 @@ private:
             auto const* d = codeHashVal.data();
             bool hasCodeHash = false;
             for (size_t i = 0; i < 32; ++i)
+            {
                 if (d[i] != 0)
                 {
                     hasCodeHash = true;
                     break;
                 }
+            }
             if (hasCodeHash)
+            {
                 std::copy_n(d, sizeof(evmc_bytes32), acc.code_hash.bytes);
+            }
             else
+            {
                 acc.code_hash = evmone::state::Account::EMPTY_CODE_HASH;
+            }
         }
 
         acc.has_storage = co_await hasStorageImpl(evmAccount);
@@ -119,7 +129,7 @@ private:
     {
         using namespace bcos::ledger;
         using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
+        auto& storage = m_storage;
         auto tableName = co_await evmAccount.path();
 
         bool hasStorage = false;
@@ -131,7 +141,9 @@ private:
             auto const& [k, v] = *kv;
             executor_v1::StateKeyView view(k);
             if (view.m_table != tableName)
+            {
                 break;  // Left this account's table.
+            }
 
             auto key = view.m_key;
             if (key != ACCOUNT_TABLE_FIELDS::NONCE && key != ACCOUNT_TABLE_FIELDS::BALANCE &&
@@ -149,15 +161,19 @@ private:
     task::Task<evmc::bytes> getCodeImpl(evmc_address addr) const
     {
         using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
+        auto& storage = m_storage;
         EVMAccount<Storage> evmAccount(storage, addr, false);
 
         if (!co_await evmAccount.exists())
+        {
             co_return {};
+        }
 
         auto codeEntry = co_await evmAccount.code();
         if (!codeEntry.has_value())
+        {
             co_return {};
+        }
 
         auto view = codeEntry->get();
         co_return evmc::bytes(view.begin(), view.end());
@@ -166,7 +182,7 @@ private:
     task::Task<evmc::bytes32> getStorageImpl(evmc_address addr, evmc_bytes32 key) const
     {
         using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
+        auto& storage = m_storage;
         EVMAccount<Storage> evmAccount(storage, addr, false);
 
         // SLOAD on a non-existent account returns 0 per EVM spec.
@@ -191,7 +207,9 @@ task::Task<void> testApplyStateDiff(
     {
         EVMAccount<Storage> acc(storage, m.addr, false);
         if (!co_await acc.exists())
+        {
             co_await acc.create();
+        }
         co_await acc.setNonce(std::to_string(m.nonce));
         co_await acc.setBalance(toBcosU256(m.balance));
         if (m.code.has_value())
@@ -209,7 +227,9 @@ task::Task<void> testApplyStateDiff(
             }
         }
         for (auto const& [key, value] : m.modified_storage)
+        {
             co_await acc.setStorage(key, value);
+        }
     }
 
     // Phase 2: deleted accounts, skipping addresses recreated in Phase 1.
@@ -225,7 +245,9 @@ task::Task<void> testApplyStateDiff(
             }
         }
         if (inModified)
+        {
             continue;
+        }
 
         EVMAccount<Storage> acc(storage, addr, false);
         if (co_await acc.exists())


### PR DESCRIPTION
## 概述

本 PR 清理 `ethereum-executor` 模块下的 clang-tidy 警告：检查了模块内所有源文件/头文件，将能安全机械修复的警告全部解决，警告数从 736 条降至 440 条（减少约 40%），未引入任何新的警告类别；同时优化了 `EthereumState` 的账户字段读取逻辑，减少存储访问次数。

## 主要改动

**EthereumState 逻辑优化**
- `EthereumState.h`：`readAccountImpl` 由原先对 nonce/balance/codeHash 的三次独立存储读取（`evmAccount.nonce()` / `balance()` / `codeHash()`）优化为一次 `storage2::readSome` 批量读取，返回结果按 key 顺序对齐，减少存储往返次数
- codeHash 读取改为按字段字符串解析：缺失、过短或全零统一视为无代码（`EMPTY_CODE_HASH`），与原 `codeHash()` 读取路径语义一致
- 保留 `exists()`（对 `SYS_TABLES`）检查：账户存在但字段缺失时不会被误判为账户不存在

**手动修复（非机械性问题）**
- `tests/EESTRunner.cpp`：修复两处 `buildBlockHeader` 中 `blockVer` 未初始化及重复分支（保持原语义：仅 `[Paris, Cancun)` 映射到 V3_2）；删除未使用的 `type` 变量
- `EthereumState.h`：`fieldValues[2]` optional 访问改为与其余字段一致的初始化语句模式；`prev_access_status` 增加默认初始化
- `EthereumTransition.h`：为 txKind switch 补 `default`（并入 `case 0`，避免 branch-clone）
- `EthereumHost.h`：`access_account` 返回值显式捕获（`(void)` 无法抑制该检查）
- `EthereumExecutor.h`：两处空 catch 补充说明语句
- `EVMPrecompiles.cpp`：修复 6 处隐式 widening 乘法、`assert` 内表达式加括号、`else after return`

**自动化修复（clang-tidy `-fix-errors`）**
- 补齐单语句分支大括号（Allman 风格，与项目 `.clang-format` 一致）
- 数学表达式显式括号、`starts_with` 替换 `rfind`、`emplace_back` 替换 `push_back`、字面量后缀大写、冗余 cast 移除、`auto*` 限定、`std::endl`→`'\n'` 等 16 类检查

**未处理（非简单修复或误报）**
- `readability-identifier-length`、`modernize-use-designated-initializers`、`cppcoreguidelines-pro-bounds-*` 等设计级/低层代码相关问题，以及 g++ 专用编译参数导致的 clang 诊断噪音

## 验证

- 全部目标编译通过（`ethereum-executor`、`eest-runner`、`test-ethereum-state-smoke`、`fisco-bcos`、`test-transaction-scheduler`）
- `test-ethereum-state-smoke` 全部通过
- EEST cancun state_tests 子集 2990/2990 通过（100%）
- `test-transaction-scheduler` 无错误
- 重跑 clang-tidy 确认无新增警告类别
