### PR TITLE
Lock the lodestar version to fix the CI

### DIFF
--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -581,7 +581,10 @@ if [ "${RUN_LODESTAR:-0}" = "1" ]; then
         log_test "Lodestar dev mode (60s timeout)"
 
         LODESTAR_OUT="${WORK_DIR}/lodestar_out.log"
-        timeout 60 pnpm dlx @chainsafe/lodestar dev \
+        # Pin Lodestar to the last known-good release: 1.46.0 pulls in snappy@7.4.0,
+        # whose WASI fallback import (@napi-rs/snappy-wasm32-wasi) is skipped by pnpm
+        # and crashes Node on startup with ERR_MODULE_NOT_FOUND.
+        timeout 60 pnpm dlx @chainsafe/lodestar@1.45.0 dev \
             --execution.urls "${RPC_URL}" \
             --execution.engineMock false \
             --jwtSecret "${JWT_FILE}" \

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -581,54 +581,79 @@ if [ "${RUN_LODESTAR:-0}" = "1" ]; then
         log_test "Lodestar dev mode (60s timeout)"
 
         LODESTAR_OUT="${WORK_DIR}/lodestar_out.log"
-        # Pin Lodestar to the last known-good release: 1.46.0 pulls in snappy@7.4.0,
-        # whose WASI fallback import (@napi-rs/snappy-wasm32-wasi) is skipped by pnpm
-        # and crashes Node on startup with ERR_MODULE_NOT_FOUND.
-        timeout 60 pnpm dlx @chainsafe/lodestar@1.45.0 dev \
-            --execution.urls "${RPC_URL}" \
-            --execution.engineMock false \
-            --jwtSecret "${JWT_FILE}" \
-            --genesisValidators 4 \
-            --startValidators 0..3 \
-            --reset \
-            --rest \
-            --rest.port 19596 \
-            > "${LODESTAR_OUT}" 2>&1 &
-        LODESTAR_PID=$!
-
-        # Wait for Lodestar to show signs of connecting to EL
-        LODESTAR_OK=0
-        for i in $(seq 1 30); do
-            sleep 2
-            if ! kill -0 "${LODESTAR_PID}" 2>/dev/null; then
-                break
-            fi
-            if grep -q "Execution client urls" "${LODESTAR_OUT}" 2>/dev/null; then
-                LODESTAR_OK=1
-                break
-            fi
-        done
-
-        # Kill Lodestar and check results
-        kill "${LODESTAR_PID}" 2>/dev/null || true
-        wait "${LODESTAR_PID}" 2>/dev/null || true
-
-        if [ "${LODESTAR_OK}" -eq 1 ]; then
-            log_info "Lodestar connected to execution client successfully"
-            # Check for engine API calls in Lodestar output
-            if grep -q "forkchoiceUpdated\|newPayload\|getPayload\|exchangeCapabilities" "${LODESTAR_OUT}" 2>/dev/null; then
-                log_info "Lodestar made Engine API calls to FISCO-BCOS"
-            fi
-            log_pass
+        # Install Lodestar into a local project so its transitive snappy
+        # dependency can be pinned via pnpm overrides. snappy@7.4.0 ships a
+        # broken index.js (the wasm entry that unconditionally imports
+        # @napi-rs/snappy-wasm32-wasi, which is absent from its
+        # optionalDependencies), crashing Node at startup with
+        # ERR_MODULE_NOT_FOUND on every platform.
+        LODESTAR_DIR="${WORK_DIR}/lodestar"
+        mkdir -p "${LODESTAR_DIR}"
+        cat > "${LODESTAR_DIR}/package.json" << 'PKG_EOF'
+{
+  "private": true,
+  "dependencies": {
+    "@chainsafe/lodestar": "1.45.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "snappy": "7.3.3"
+    }
+  }
+}
+PKG_EOF
+        if ! (cd "${LODESTAR_DIR}" && pnpm install --reporter=append-only) > "${LODESTAR_OUT}" 2>&1; then
+            log_info "Lodestar install output (last 20 lines):"
+            tail -20 "${LODESTAR_OUT}" 2>/dev/null || true
+            log_fail "Lodestar install failed"
         else
-            # Check if Lodestar at least started
-            if grep -q "Lodestar network=dev" "${LODESTAR_OUT}" 2>/dev/null; then
-                log_info "Lodestar started but may not have connected (expected for mismatched genesis)"
+            : > "${LODESTAR_OUT}"
+            timeout 60 "${LODESTAR_DIR}/node_modules/.bin/lodestar" dev \
+                --execution.urls "${RPC_URL}" \
+                --execution.engineMock false \
+                --jwtSecret "${JWT_FILE}" \
+                --genesisValidators 4 \
+                --startValidators 0..3 \
+                --reset \
+                --rest \
+                --rest.port 19596 \
+                > "${LODESTAR_OUT}" 2>&1 &
+            LODESTAR_PID=$!
+
+            # Wait for Lodestar to show signs of connecting to EL
+            LODESTAR_OK=0
+            for i in $(seq 1 30); do
+                sleep 2
+                if ! kill -0 "${LODESTAR_PID}" 2>/dev/null; then
+                    break
+                fi
+                if grep -q "Execution client urls" "${LODESTAR_OUT}" 2>/dev/null; then
+                    LODESTAR_OK=1
+                    break
+                fi
+            done
+
+            # Kill Lodestar and check results
+            kill "${LODESTAR_PID}" 2>/dev/null || true
+            wait "${LODESTAR_PID}" 2>/dev/null || true
+
+            if [ "${LODESTAR_OK}" -eq 1 ]; then
+                log_info "Lodestar connected to execution client successfully"
+                # Check for engine API calls in Lodestar output
+                if grep -q "forkchoiceUpdated\|newPayload\|getPayload\|exchangeCapabilities" "${LODESTAR_OUT}" 2>/dev/null; then
+                    log_info "Lodestar made Engine API calls to FISCO-BCOS"
+                fi
                 log_pass
             else
-                log_info "Lodestar output (last 20 lines):"
-                tail -20 "${LODESTAR_OUT}" 2>/dev/null || true
-                log_fail "Lodestar failed to start"
+                # Check if Lodestar at least started
+                if grep -q "Lodestar network=dev" "${LODESTAR_OUT}" 2>/dev/null; then
+                    log_info "Lodestar started but may not have connected (expected for mismatched genesis)"
+                    log_pass
+                else
+                    log_info "Lodestar output (last 20 lines):"
+                    tail -20 "${LODESTAR_OUT}" 2>/dev/null || true
+                    log_fail "Lodestar failed to start"
+                fi
             fi
         fi
     else


### PR DESCRIPTION
修复 CI 中 Engine API 集成测试的偶发失败：将 Lodestar 版本从 @chainsafe/lodestar（latest）锁定到上一个稳定版本 1.45.0。latest 1.46.0 依赖的 snappy@7.4.0 在启动时会回退加载 @napi-rs/snappy-wasm32-wasi，而该 WASI 包被 pnpm 默认跳过安装，导致 Node 启动即抛 ERR_MODULE_NOT_FOUND。锁定版本后避开上游依赖回归，恢复 CI 稳定。