### PR TITLE
feat(evm): 引入 OP 执行器头（OpstackExecutor + 适配层接口）

### DIFF
--- a/ethereum-executor/BCOS2Evmone.h
+++ b/ethereum-executor/BCOS2Evmone.h
@@ -1,0 +1,143 @@
+/// @file BCOS2Evmone.h
+/// @brief Type converters between BCOS protocol types and evmone state types.
+#pragma once
+
+#include "EthereumState.h"  // clearAccountStorage (release authority; shared with applyStateDiff below)
+#include "StorageStateView.h"
+#include "bcos-evm/eth/state/state.hpp"
+#include "bcos-evm/eth/state/transaction.hpp"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
+#include "bcos-framework/protocol/BlockHeader.h"
+#include "bcos-framework/protocol/LogEntry.h"
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-framework/protocol/TransactionReceipt.h"
+#include "bcos-framework/protocol/TransactionReceiptFactory.h"
+#include "bcos-task/TBBWait.h"
+#include <evmone/evmone.h>
+#include <string>
+#include <system_error>
+
+namespace bcos::executor_v1::eth
+{
+
+using ::bcos::executor_v1::eth::toIntxU256;
+
+// EIP-7840 blob schedule constants and blobParamsForRevision() live in
+// EthereumTransition.h (release authority). blockHeaderToBlockInfo in
+// BCOS2Evmone.cpp calls blobParamsForRevision from there.
+
+// Non-template converters — defined in BCOS2Evmone.cpp.
+evmone::state::BlockInfo blockHeaderToBlockInfo(
+    protocol::BlockHeader const& header, ledger::LedgerConfig const& config, evmc_revision rev);
+
+evmone::state::Transaction bcosTransactionToEvmone(protocol::Transaction const& tx);
+
+// validationErrorReceipt is provided by EthereumExecutor.h/.cpp (release
+// authority) — removed here to avoid a link-time duplicate definition.
+
+// Defined in BCOS2Evmone.cpp; declared here because the template applyStateDiff
+// below (in this header) calls it.
+bcos::u256 toBcosU256(intx::uint256 const& val);
+
+// clearAccountStorage is provided by EthereumState.h (release authority; same
+// implementation as the version this header previously carried). It is included
+// at the top so the applyStateDiff template below can see it.
+
+template <class Storage>
+task::Task<void> applyStateDiff(Storage& storage, evmone::state::StateDiff const& diff,
+    evmc_revision, crypto::Hash const& hashImpl)
+{
+    using namespace bcos::ledger::account;
+
+    // Phase 1: Process modified_accounts FIRST.
+    // This ensures created accounts exist before we potentially delete them.
+    for (auto const& m : diff.modified_accounts)
+    {
+        EVMAccount<Storage> acc(storage, m.addr, false);
+        if (!co_await acc.exists())
+            co_await acc.create();
+        co_await acc.setNonce(std::to_string(m.nonce));
+        co_await acc.setBalance(toBcosU256(m.balance));
+        if (m.code.has_value())
+        {
+            auto const& c = *m.code;
+            if (c.empty())
+            {
+                co_await acc.setCode(bcos::bytes{}, std::string{}, bcos::h256{});
+            }
+            else
+            {
+                bcos::bytes code(c.begin(), c.end());
+                auto ch = hashImpl.hash(bcos::bytesConstRef(code.data(), code.size()));
+                co_await acc.setCode(std::move(code), std::string{}, ch);
+            }
+        }
+        for (auto const& [key, value] : m.modified_storage)
+        {
+            // NOTE: EVMAccount::setStorage always writes the entry (a zero
+            // value leaves a zero-valued row; there is no delete-storage API).
+            // Known limitation: such zero rows are only cleaned on self-destruct
+            // via clearAccountStorage(). This matches evmone's state semantics
+            // (a zero slot reads back as zero) and the sibling zero check in
+            // evmoneReceiptToBcos is not required here.
+            co_await acc.setStorage(key, value);
+        }
+    }
+
+    // Phase 2: Process deleted_accounts, but skip addresses that were just
+    // created/modified in Phase 1 (recreated accounts).
+    // Also track which addresses we processed as deleted.
+    for (auto const& addr : diff.deleted_accounts)
+    {
+        // Check if this address was already handled by modified_accounts above.
+        // If so, the account was destructed and recreated in the same tx —
+        // the modified state already reflects the recreation, so skip deletion.
+        bool inModified = false;
+        for (auto const& m : diff.modified_accounts)
+        {
+            if (memcmp(m.addr.bytes, addr.bytes, sizeof(evmc_address)) == 0)
+            {
+                inModified = true;
+                break;
+            }
+        }
+        if (inModified)
+            continue;  // Already handled by modified_accounts processing
+
+        // Genuine deletion: clear account state (including storage, so that a
+        // later CREATE/CREATE2 at this address is not an EIP-7610 collision).
+        EVMAccount<Storage> acc(storage, addr, false);
+        if (co_await acc.exists())
+        {
+            co_await acc.setBalance(0);
+            co_await acc.setNonce("0");
+            co_await acc.setCode(bcos::bytes{}, std::string{}, bcos::h256{});
+            co_await clearAccountStorage(storage, acc);
+            // B4 (Task 6.1): drop the SYS_TABLES marker too, so the touch-deleted
+            // account is fully gone — not a lingering EIP-161 ghost empty account
+            // (marker row survives while every field reads zero). acc.path() is the
+            // same tableName key space Storage2State::applyDeletedEntry removes
+            // (Storage2State.h:427-428); the exists() guard above keeps this shared
+            // function quiet when the account is already missing — no strict ghost-delete
+            // tripwire (unlike applyDeletedEntry), so the non-OP path cannot hard-error.
+            co_await storage2::removeOne(
+                storage, executor_v1::StateKeyView(bcos::ledger::SYS_TABLES, co_await acc.path()));
+        }
+    }
+
+    // NOTE: evmone's State::build_diff() may not include recreated accounts
+    // (destructed + recreated via CREATE2 in the same tx) in modified_accounts.
+    // This is a known limitation — without modifying bcos-evm, we cannot
+    // recover the lost nonce/balance/code for these accounts.
+}
+
+protocol::TransactionReceipt::Ptr evmoneReceiptToBcos(evmone::state::TransactionReceipt const& er,
+    protocol::TransactionReceiptFactory const& rf, int64_t blockNumber);
+
+struct ZeroBlockHashes : evmone::state::BlockHashes
+{
+    evmc::bytes32 get_block_hash(int64_t) const noexcept override { return {}; }
+};
+
+}  // namespace bcos::executor_v1::eth

--- a/ethereum-executor/StorageStateView.h
+++ b/ethereum-executor/StorageStateView.h
@@ -1,0 +1,211 @@
+/// @file StorageStateView.h
+/// @brief An evmone::state::StateView adapter that reads from BCOS MutableStorage
+///        via EVMAccount (synchronous bridge using TBB syncWait).
+///
+/// This adapter allows bcos-evm's transition() engine to read pre-state from
+/// the BCOS storage layer without modification.  After execution, the returned
+/// StateDiff is written back by the caller.
+
+#pragma once
+
+#include "bcos-evm/eth/state/state.hpp"
+#include "bcos-evm/eth/state/state_view.hpp"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-task/TBBWait.h"
+#include <evmc/evmc.h>
+#include <optional>
+
+namespace bcos::executor_v1::eth
+{
+
+/// Helper: convert bcos::u256 to intx::uint256.
+/// Defined here to avoid circular dependency with BCOS2Evmone.h.
+inline intx::uint256 toIntxU256(bcos::u256 const& val)
+{
+    auto hexStr = "0x" + val.str(0, std::ios_base::hex);
+    return intx::from_string<intx::uint256>(hexStr);
+}
+
+/// A read-only StateView backed by BCOS MutableStorage and EVMAccount.
+///
+/// All three virtual methods are synchronous (required by evmone::state::StateView),
+/// so they internally use task::tbb::syncWait to bridge from the async BCOS
+/// storage layer. Each override guards the syncWait call in try/catch: the
+/// interface is noexcept and syncWait rethrows, so an unguarded exception would
+/// terminate the process. A failed read is reported as "absent / empty".
+template <class Storage>
+class StorageStateView : public evmone::state::StateView
+{
+public:
+    StorageStateView(Storage& storage) : m_storage(storage)
+    {
+        // Pre-load code cache for precompiled / known addresses?
+        // For now, keep it simple — all reads go through EVMAccount.
+    }
+
+    std::optional<evmone::state::StateView::Account> get_account(
+        const evmc::address& addr) const noexcept override
+    {
+        // evmone's interface requires noexcept, but the underlying storage
+        // reads (via TBB syncWait) can throw (e.g. a malformed nonce/balance
+        // entry or a storage backend IO error). syncWait rethrows, so without
+        // this guard an exception would cross the noexcept boundary and call
+        // std::terminate. Present a failed read as "absent" instead.
+        try
+        {
+            return task::tbb::syncWait(getAccountImpl(addr));
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
+    }
+
+    evmc::bytes get_account_code(const evmc::address& addr) const noexcept override
+    {
+        try
+        {
+            return task::tbb::syncWait(getCodeImpl(addr));
+        }
+        catch (...)
+        {
+            return {};
+        }
+    }
+
+    evmc::bytes32 get_storage(
+        const evmc::address& addr, const evmc::bytes32& key) const noexcept override
+    {
+        try
+        {
+            return task::tbb::syncWait(getStorageImpl(addr, key));
+        }
+        catch (...)
+        {
+            return {};
+        }
+    }
+
+private:
+    Storage& m_storage;
+
+    task::Task<std::optional<evmone::state::StateView::Account>> getAccountImpl(
+        evmc_address addr) const
+    {
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+
+        EVMAccount<Storage> evmAccount(storage, addr, false);
+
+        if (!co_await evmAccount.exists())
+            co_return std::nullopt;
+
+        evmone::state::StateView::Account acc;
+        auto nonceVal = co_await evmAccount.nonce();
+        if (nonceVal.has_value())
+            acc.nonce = static_cast<uint64_t>(bcos::u256(nonceVal.value()));
+
+        acc.balance = toIntxU256(co_await evmAccount.balance());
+
+        auto codeHashVal = co_await evmAccount.codeHash();
+        {
+            auto const* d = codeHashVal.data();
+            bool hasCodeHash = false;
+            for (size_t i = 0; i < 32; ++i)
+                if (d[i] != 0) { hasCodeHash = true; break; }
+            if (hasCodeHash)
+                std::copy_n(d, sizeof(evmc_bytes32), acc.code_hash.bytes);
+            else
+                acc.code_hash = evmone::state::Account::EMPTY_CODE_HASH;
+        }
+
+        // Determine whether the account has any non-field storage slots.
+        // evmone uses has_storage for EIP-7610 CREATE collision detection and
+        // account emptiness. Reporting "true" unconditionally would make every
+        // balance-only pre-funded account look like a CREATE collision, which
+        // breaks contracts created at pre-funded addresses (EIP-6780 etc.).
+        acc.has_storage = co_await hasStorageImpl(evmAccount);
+        co_return acc;
+    }
+
+    /// Check whether the account table contains any storage slot (a key that
+    /// is not one of the fixed account field names).
+    ///
+    /// NOTE (read-write-set tracking): this probe scans the account table with
+    /// storage2::range(), and ReadWriteSetStorage::range() does not record
+    /// reads (its keys are unknown until the lazy iterator is consumed). Under
+    /// SchedulerParallelImpl a chunk that only writes a storage slot of
+    /// account X is therefore not flagged as conflicting with another chunk
+    /// that reads X's has_storage here, so the reader may observe stale data.
+    /// The main-field reads (exists/nonce/balance/codeHash) above ARE tracked,
+    /// so this only bites when the two chunks touch *storage slots* of the
+    /// same account. Not exercised by the current EEST/scheduler tests (they
+    /// do not write contract storage); tracked as a known limitation.
+    task::Task<bool> hasStorageImpl(bcos::ledger::account::EVMAccount<Storage>& evmAccount) const
+    {
+        using namespace bcos::ledger;
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+        auto tableName = co_await evmAccount.path();
+
+        bool hasStorage = false;
+        // Seek to the first key of this account's table (empty key sorts first).
+        auto it = co_await storage2::range(storage, storage2::RANGE_SEEK,
+            executor_v1::StateKey{tableName, std::string_view{}});
+
+        while (auto kv = co_await it.next())
+        {
+            auto const& [k, v] = *kv;
+            executor_v1::StateKeyView view(k);
+            if (view.m_table != tableName)
+                break;  // Left this account's table.
+
+            auto key = view.m_key;
+            if (key != ACCOUNT_TABLE_FIELDS::NONCE &&
+                key != ACCOUNT_TABLE_FIELDS::BALANCE &&
+                key != ACCOUNT_TABLE_FIELDS::CODE_HASH &&
+                key != ACCOUNT_TABLE_FIELDS::CODE &&
+                key != ACCOUNT_TABLE_FIELDS::ABI &&
+                key != ACCOUNT_TABLE_FIELDS::ALIVE &&
+                key != ACCOUNT_TABLE_FIELDS::FROZEN &&
+                key != ACCOUNT_TABLE_FIELDS::SHARD)
+            {
+                hasStorage = true;
+                break;
+            }
+        }
+        co_return hasStorage;
+    }
+
+    task::Task<evmc::bytes> getCodeImpl(evmc_address addr) const
+    {
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+        EVMAccount<Storage> evmAccount(storage, addr, false);
+
+        if (!co_await evmAccount.exists())
+            co_return {};
+
+        auto codeEntry = co_await evmAccount.code();
+        if (!codeEntry.has_value())
+            co_return {};
+
+        auto view = codeEntry->get();
+        co_return evmc::bytes(view.begin(), view.end());
+    }
+
+    task::Task<evmc::bytes32> getStorageImpl(evmc_address addr, evmc_bytes32 key) const
+    {
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+        EVMAccount<Storage> evmAccount(storage, addr, false);
+
+        // SLOAD on a non-existent account returns 0 per EVM spec.
+        // EVMAccount::storage() already returns empty bytes32 for missing
+        // accounts/keys, so we can omit the redundant exists() check here
+        // and save one storage round-trip per SLOAD.
+        co_return co_await evmAccount.storage(key);
+    }
+};
+
+}  // namespace bcos::executor_v1::eth

--- a/opstack-executor/OpCommon.h
+++ b/opstack-executor/OpCommon.h
@@ -1,0 +1,148 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+// Shared error types + the block-execution result for the OP scheduler, plus the block-context
+// conversion helpers (bcos<->evmc fixed-size conversions / bounds-checked narrowing / FISCO-header
+// -> evmone BlockInfo build). Split out of OpSchedulerSeam.h so dependent layers can throw without
+// depending on the class template. OpBlockSeal lives here too (not in OpBlockExecute.h):
+// OpExecuteBlockResult carries it by value.
+//
+// The six-way commitment comparison surface (OpBlockCommitments / commitmentsOf /
+// payloadBloomToH2048 / mismatchedFieldOf / detail::toBcosH256 / toBcosBloom) lives in
+// OpCommitments.h — this header is deliberately types + conversions, no commitment logic.
+
+#include <bcos-framework/protocol/BlockHeader.h>
+#include <bcos-framework/protocol/TransactionReceipt.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <bcos-evm/eth/state/block.hpp>
+#include <bcos-evm/eth/state/bloom_filter.hpp>
+#include <cstdint>
+#include <cstring>
+#include <evmc/evmc.hpp>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bcos::evm::opstack
+{
+/// Block-header commitment fields. Jovian BlobGasUsed (the DA footprint header field) was
+/// reclaimed into this struct.
+struct OpBlockSeal
+{
+    evmone::hash256 receiptsRoot;
+    evmone::state::BloomFilter logsBloom;
+    evmone::hash256 withdrawalsRoot;
+    std::optional<evmone::hash256> requestsHash;  // Isthmus+ has a value; CANCUN-family fork
+                                                  // headers lack this field
+    /// Jovian block-header BlobGasUsed reuse slot = DA footprint (only non-deposit txs accumulate,
+    /// each tx = EstimatedDASize × scalar). Implemented as Σ of the meta.da_footprint over
+    /// receipts; a deposits-only block sums no terms and is always 0 ≡ op-geth's first-Jovian-block
+    /// special case. When has_da_footprint is false there is always no value.
+    std::optional<uint64_t> blobGasUsed;
+};
+}  // namespace bcos::evm::opstack
+
+namespace bcos::evm::engine
+{
+/// Thrown for anything OP block execution classifies as a consensus-level rejection (error
+/// table): malformed/undecodable raw tx bytes, processOpBlock's own semantic throws
+/// (empty block, first tx not the L1 attributes deposit, gas-pool overrun, ...). Maps to INVALID
+/// on the caller side, never -32603.
+struct OpConsensusError : std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
+/// Thrown when the ledger bridge's poison flag is set (a storage2-layer failure, not a consensus
+/// violation — Storage2State.h's poison-flag error channel contract). Maps to JSON-RPC -32603
+/// internal error on the caller side, never INVALID.
+struct OpStorageError : std::runtime_error
+{
+    using std::runtime_error::runtime_error;
+};
+
+/// Six-way comparison surface for an executed OP block: `seal`'s
+/// receiptsRoot/logsBloom/withdrawalsRoot (bcos::evm::opstack::OpBlockSeal, unchanged structure)
+/// plus three members below (stateRoot/gasUsed/txRoot) that are deliberately NOT folded into
+/// OpBlockSeal.
+struct OpExecuteBlockResult
+{
+    std::vector<bcos::protocol::TransactionReceipt::Ptr> receipts;
+    bcos::evm::opstack::OpBlockSeal seal;
+    bcos::h256 stateRoot;
+    uint64_t gasUsed;
+    bcos::h256 txRoot;
+};
+
+/// Table holding each accepted OP block's transactions as their raw EIP-2718 envelopes, keyed by
+/// keccak(envelope). Deliberately not the generic SYS_HASH_2_TX (which holds tars Transaction
+/// objects — an Ethereum envelope would decode into a plausible-looking but hash-mismatched tx).
+inline constexpr std::string_view SYS_ETH_HASH_2_RAWTX{"s_eth_hash_2_rawtx"};
+
+namespace detail
+{
+// ---- bcos:: <-> evmc:: fixed-size conversions ----
+
+inline evmc::address toEvmcAddress(const bcos::Address& a) noexcept
+{
+    evmc::address out{};
+    std::memcpy(out.bytes, a.data(), sizeof(out.bytes));
+    return out;
+}
+
+inline evmc::bytes32 toEvmcBytes32(const bcos::h256& h) noexcept
+{
+    evmc::bytes32 out{};
+    std::memcpy(out.bytes, h.data(), sizeof(out.bytes));
+    return out;
+}
+
+// `toBcosH256` (evmc::bytes32 -> bcos::h256) lives in OpCommitments.h (two identical inline
+// definitions of one name in the same namespace would be a redefinition error).
+
+/// Bounds-checked u256→u64 narrowing — explicit > max check, never raw static_cast
+/// (silent-truncation guard).
+inline uint64_t narrowU256ToU64(const bcos::u256& v, const char* fieldName)
+{
+    static const bcos::u256 kMaxU64(std::numeric_limits<uint64_t>::max());
+    if (v > kMaxU64)
+        throw OpConsensusError(
+            std::string("OpSchedulerSeam: field exceeds uint64_t range: ") + fieldName);
+    return static_cast<uint64_t>(v);
+}
+
+/// Build the OP block context from a FISCO header. `gasLimitOverride` injects the head block's
+/// gasLimit as blockGasLeft (a minimal test header may leave gasLimit==0); `lenientOptionals`
+/// tolerates unset optional header fields as 0 (eth_call path), while block execution uses
+/// `.value()` and throws on an unset field.
+inline evmone::state::BlockInfo toBlockInfo(const bcos::protocol::BlockHeader& env,
+    std::optional<uint64_t> gasLimitOverride = std::nullopt, bool lenientOptionals = false)
+{
+    evmone::state::BlockInfo blk;
+    blk.number = static_cast<int64_t>(env.number());
+    // FISCO tars store milliseconds; evmone wants seconds.
+    blk.timestamp = static_cast<uint64_t>(env.timestamp()) / 1000;
+    blk.gas_limit = gasLimitOverride.has_value() ?
+                        static_cast<int64_t>(*gasLimitOverride) :
+                        narrowU256ToU64(env.gasLimit(), "BlockInfo::gasLimit");
+    blk.base_fee = narrowU256ToU64(
+        lenientOptionals ? env.baseFee().value_or(bcos::u256{0}) : env.baseFee().value(),
+        "BlockInfo::baseFee");
+    blk.coinbase = toEvmcAddress(env.coinbase());
+    blk.prev_randao = toEvmcBytes32(env.prevRandao());
+    blk.parent_beacon_block_root =
+        toEvmcBytes32(lenientOptionals ? env.parentBeaconBlockRoot().value_or(bcos::h256{}) :
+                                         env.parentBeaconBlockRoot().value());
+    blk.extra_data = evmc::bytes(env.extraData().begin(), env.extraData().end());
+    blk.blob_gas_used = narrowU256ToU64(
+        lenientOptionals ? env.blobGasUsed().value_or(bcos::u256{0}) : env.blobGasUsed().value(),
+        "BlockInfo::blobGasUsed");
+    return blk;
+}
+}  // namespace detail
+}  // namespace bcos::evm::engine

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -1,0 +1,354 @@
+/// @file OpstackExecutor.h
+/// @brief OP Stack (Optimism L2) transaction executor based on bcos-evm/opstack.
+///
+/// Implements the bcos::executor_v1::TransactionExecutor concept (ExecuteContext with
+/// prepare/execute/finish): opValidate + opTransition for NORMAL transactions, runDeposit for
+/// 0x7E deposits, finalizeOpBlock for block finalize. The caller passes an already-decoded
+/// DepositTx. Storage-backed StateView and state-diff writeback are shared with EthereumExecutor
+/// via ethereum-executor.
+
+#pragma once
+
+#include "bcos-evm/opstack/OpFeeParams.h"
+#include "bcos-evm/opstack/OpForkSchedule.h"
+#include "bcos-evm/opstack/OpTransition.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
+#include "bcos-framework/protocol/BlockHeader.h"
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-framework/protocol/TransactionReceipt.h"
+#include "bcos-framework/protocol/TransactionReceiptFactory.h"
+#include "bcos-framework/transaction-executor/TransactionExecutor.h"
+#include "bcos-task/TBBWait.h"
+#include "ethereum-executor/BCOS2Evmone.h"
+#include "ethereum-executor/StorageStateView.h"
+#include "opstack-executor/OpCommon.h"  // detail::narrowU256ToU64 / toEvmcAddress / toEvmcBytes32
+#include <bcos-utilities/Exceptions.h>
+#include <evmone/evmone.h>
+#include <evmc/evmc.hpp>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace bcos::evm::opstack
+{
+// Defined in OpBlockExecute.cpp — forward-declared here to avoid including OpBlockExecute.h
+// (which includes this header).
+evmone::state::StateDiff finalizeOpBlock(
+    const evmone::state::StateView& view, const OpForkConfig& cfg, const evmc::address& coinbase);
+}  // namespace bcos::evm::opstack
+
+namespace bcos::executor_v1::opstack
+{
+
+DERIVE_BCOS_EXCEPTION(EvmcRevisionNotConfigured);
+DERIVE_BCOS_EXCEPTION(OpForkRevisionMismatch);
+DERIVE_BCOS_EXCEPTION(OpTxValidationFailed);
+
+class OpstackExecutor
+{
+public:
+    OpstackExecutor(protocol::TransactionReceiptFactory::Ptr receiptFactory,
+        crypto::Hash::Ptr hashImpl,
+        bcos::evm::opstack::OpForkConfig const& forkConfig = bcos::evm::opstack::jovianConfig())
+      : m_receiptFactory(std::move(receiptFactory)),
+        m_hashImpl(std::move(hashImpl)),
+        m_forkConfig(forkConfig),
+        m_vm(evmc_create_evmone())
+    {}
+
+    /// Access the EVM instance (needed for system_call functions).
+    evmc::VM& vm() { return m_vm; }
+
+    /// eth_call block context, mirroring detail::toBlockInfo: lenient optionals (unset header
+    /// fields read as 0 rather than throwing), gasLimit injected as blockGasLeft.
+    static evmone::state::BlockInfo buildBlockInfo(
+        protocol::BlockHeader const& header, uint64_t gasLimit)
+    {
+        return bcos::evm::engine::detail::toBlockInfo(header, gasLimit, /*lenientOptionals=*/true);
+    }
+
+    /// Real header gasLimit, falling back to the caller's blockGasLeft when the header leaves it
+    /// unset (==0, e.g. minimal test headers).
+    static uint64_t opBlockGasLimit(protocol::BlockHeader const& header, uint64_t fallback)
+    {
+        namespace detail = bcos::evm::engine::detail;
+        auto const gl = header.gasLimit();  // non-optional u256 (BlockHeader.h:156)
+        return (gl == 0) ? fallback : detail::narrowU256ToU64(gl, "BlockInfo::gasLimit");
+    }
+
+    // ---- TransactionExecutor concept: ExecuteContext with prepare/execute/finish ----
+    template <class Storage>
+    struct ExecuteContext
+    {
+        OpstackExecutor& executor;
+        Storage& storage;
+        protocol::BlockHeader const& blockHeader;
+        protocol::Transaction const& transaction;
+        int contextID;
+        ledger::LedgerConfig const& ledgerConfig;
+        bool call;
+
+        // Per-transaction state threaded across the concept lifecycle.
+        bcos::evm::opstack::OpTxProperties m_props;   // set by prepare()
+        protocol::TransactionReceipt::Ptr m_receipt;  // set by execute()
+        evmone::state::StateDiff m_diff;              // writeback deferred to finish()
+
+        ExecuteContext(OpstackExecutor& exec, Storage& st, protocol::BlockHeader const& bh,
+            protocol::Transaction const& tx, int cid, ledger::LedgerConfig const& cfg, bool c)
+          : executor(exec),
+            storage(st),
+            blockHeader(bh),
+            transaction(tx),
+            contextID(cid),
+            ledgerConfig(cfg),
+            call(c),
+            m_props{},
+            m_receipt{},
+            m_diff{}
+        {}
+
+        // concept lifecycle: prepare (validate) -> execute (transition) -> finish (writeback)
+        task::Task<void> prepare()
+        {
+            m_props = co_await executor.m_prepare(storage, blockHeader, transaction, ledgerConfig);
+        }
+        task::Task<void> execute()
+        {
+            m_receipt = co_await executor.m_execute(
+                storage, blockHeader, transaction, ledgerConfig, m_props, m_diff);
+        }
+        task::Task<protocol::TransactionReceipt::Ptr> finish()
+        {
+            co_return co_await executor.m_finish(
+                storage, blockHeader, ledgerConfig, m_receipt, m_diff);
+        }
+    };
+
+    template <class Storage>
+    task::Task<ExecuteContext<Storage>> createExecuteContext(Storage& storage,
+        protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
+        int contextID, ledger::LedgerConfig const& ledgerConfig, bool call)
+    {
+        co_return ExecuteContext<Storage>{
+            *this, storage, blockHeader, transaction, contextID, ledgerConfig, call};
+    }
+
+    /// Execute a single OP normal transaction (injection-style, mirroring processOpBlock).
+    /// Orchestrator supplies fee, decrementing blockGasLeft, chainId, and real block hashes.
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(Storage& storage,
+        protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
+        int contextID, ledger::LedgerConfig const& ledgerConfig, bool call,
+        bcos::evm::opstack::OpFeeParams const& fee = {}, int64_t blockGasLeft = 0,
+        uint64_t chainId = 0, evmone::state::BlockHashes const* blockHashes = nullptr)
+    {
+        (void)contextID;
+
+        if (transaction.isDepositTx())
+        {
+            auto dep = depositFromTransaction(transaction);
+            co_return co_await executeDeposit(
+                storage, blockHeader, dep, chainId, blockGasLeft, ledgerConfig, blockHashes);
+        }
+
+        auto props = co_await m_prepare(
+            storage, blockHeader, transaction, ledgerConfig, fee, blockGasLeft);
+        evmone::state::StateDiff diff;
+        auto receipt = co_await m_execute(storage, blockHeader, transaction, ledgerConfig, props,
+            diff, chainId, blockGasLeft, blockHashes);
+        co_return co_await m_finish(storage, blockHeader, ledgerConfig, receipt, diff);
+    }
+
+    /// Execute a single OP 0x7E deposit transaction (reuses runDeposit).
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeDeposit(Storage& storage,
+        protocol::BlockHeader const& blockHeader, bcos::evm::opstack::DepositTx const& dep,
+        uint64_t chainId, int64_t blockGasLeft, ledger::LedgerConfig const& ledgerConfig,
+        evmone::state::BlockHashes const* blockHashes = nullptr)
+    {
+        namespace op = bcos::evm::opstack;
+        namespace eth = bcos::executor_v1::eth;
+
+        auto revOpt = ledgerConfig.evmcRevision();
+        if (!revOpt.has_value())
+            BOOST_THROW_EXCEPTION(EvmcRevisionNotConfigured{}
+                                  << bcos::errinfo_comment("evmcRevision not configured"));
+        auto rev = *revOpt;
+        if (m_forkConfig.rev != rev)
+            BOOST_THROW_EXCEPTION(OpForkRevisionMismatch{} << bcos::errinfo_comment(
+                                      "OP fork revision does not match ledger evmcRevision"));
+
+        auto blockInfo = buildBlockInfo(
+            blockHeader, opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
+        eth::StorageStateView<Storage> stateView(storage);
+        eth::ZeroBlockHashes zeroBlockHashes;
+        auto const& bh = (blockHashes != nullptr) ? *blockHashes : zeroBlockHashes;
+
+        evmone::state::StateDiff diff;
+        auto receipt = op::runDeposit(stateView, blockInfo, bh, dep, m_forkConfig, m_vm, chainId,
+            blockGasLeft, m_receiptFactory, diff);
+        co_await eth::applyStateDiff(storage, diff, rev, *m_hashImpl);
+        co_return receipt;
+    }
+
+    /// OP block-level finalize (no block reward, via finalizeOpBlock).
+    template <class Storage>
+    task::Task<void> finalizeBlock(Storage& storage, protocol::BlockHeader const& blockHeader,
+        ledger::LedgerConfig const& ledgerConfig)
+    {
+        namespace op = bcos::evm::opstack;
+        namespace eth = bcos::executor_v1::eth;
+
+        auto revOpt = ledgerConfig.evmcRevision();
+        if (!revOpt.has_value())
+            BOOST_THROW_EXCEPTION(EvmcRevisionNotConfigured{}
+                                  << bcos::errinfo_comment("evmcRevision not configured"));
+        auto rev = *revOpt;
+        if (m_forkConfig.rev != rev)
+            BOOST_THROW_EXCEPTION(OpForkRevisionMismatch{} << bcos::errinfo_comment(
+                                      "OP fork revision does not match ledger evmcRevision"));
+
+        eth::StorageStateView<Storage> stateView(storage);
+        evmc_address coinbase{};
+        auto const& cb = blockHeader.coinbase();
+        if (cb.size() == sizeof(evmc_address))
+            std::copy_n(cb.begin(), sizeof(evmc_address), coinbase.bytes);
+
+        auto diff = op::finalizeOpBlock(stateView, m_forkConfig, coinbase);
+        co_await eth::applyStateDiff(storage, diff, rev, *m_hashImpl);
+    }
+
+private:
+    // ---- Shared normal-tx pipeline: three stages (prepare/execute/finish). ----
+    // Stage 1 — validate: fork/evmc revision check, block info + evmone tx + signed envelope, then
+    // injection-style opValidate (props.fee snapshotted for the transition stage).
+    template <class Storage>
+    task::Task<bcos::evm::opstack::OpTxProperties> m_prepare(Storage& storage,
+        protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
+        ledger::LedgerConfig const& ledgerConfig, bcos::evm::opstack::OpFeeParams const& fee = {},
+        int64_t blockGasLeft = 0)
+    {
+        namespace op = bcos::evm::opstack;
+        namespace eth = bcos::executor_v1::eth;
+
+        auto revOpt = ledgerConfig.evmcRevision();
+        if (!revOpt.has_value())
+            BOOST_THROW_EXCEPTION(EvmcRevisionNotConfigured{}
+                                  << bcos::errinfo_comment("evmcRevision not configured"));
+        auto rev = *revOpt;
+        if (m_forkConfig.rev != rev)
+            BOOST_THROW_EXCEPTION(OpForkRevisionMismatch{} << bcos::errinfo_comment(
+                                      "OP fork revision does not match ledger evmcRevision"));
+
+        auto blockInfo = buildBlockInfo(
+            blockHeader, opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
+        auto evmTx = eth::bcosTransactionToEvmone(transaction);
+        eth::StorageStateView<Storage> stateView(storage);
+        auto envRef = transaction.extraTransactionBytes();
+        evmc::bytes_view env{envRef.data(), envRef.size()};
+
+        auto validated =
+            op::opValidate(stateView, blockInfo, evmTx, env, m_forkConfig, fee, blockGasLeft);
+        if (auto const* err = std::get_if<std::error_code>(&validated))
+            BOOST_THROW_EXCEPTION(OpTxValidationFailed{} << bcos::errinfo_comment(err->message()));
+        co_return std::get<op::OpTxProperties>(validated);
+    }
+
+    // Stage 2 — execute: injection-style opTransition reusing props.fee (the validate-time
+    // snapshot), so the pair can never be fed different OpFeeParams.
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> m_execute(Storage& storage,
+        protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
+        ledger::LedgerConfig const& ledgerConfig, bcos::evm::opstack::OpTxProperties const& props,
+        evmone::state::StateDiff& diff, uint64_t chainId = 0, int64_t blockGasLeft = 0,
+        evmone::state::BlockHashes const* blockHashes = nullptr)
+    {
+        namespace op = bcos::evm::opstack;
+        namespace eth = bcos::executor_v1::eth;
+
+        (void)ledgerConfig;
+        auto blockInfo = buildBlockInfo(
+            blockHeader, opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
+        auto evmTx = eth::bcosTransactionToEvmone(transaction);
+        eth::StorageStateView<Storage> stateView(storage);
+
+        eth::ZeroBlockHashes zeroBlockHashes;
+        auto const& bh = (blockHashes != nullptr) ? *blockHashes : zeroBlockHashes;
+        co_return op::opTransition(stateView, blockInfo, bh, evmTx, m_forkConfig, m_vm, props,
+            chainId, m_receiptFactory, diff);
+    }
+
+    // Stage 3 — writeback: apply the transition's state diff to storage, return the final receipt.
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> m_finish(Storage& storage,
+        protocol::BlockHeader const& blockHeader, ledger::LedgerConfig const& ledgerConfig,
+        protocol::TransactionReceipt::Ptr receipt, evmone::state::StateDiff const& diff)
+    {
+        namespace eth = bcos::executor_v1::eth;
+
+        auto revOpt = ledgerConfig.evmcRevision();
+        if (!revOpt.has_value())
+            BOOST_THROW_EXCEPTION(EvmcRevisionNotConfigured{}
+                                  << bcos::errinfo_comment("evmcRevision not configured"));
+        auto rev = *revOpt;
+
+        co_await eth::applyStateDiff(storage, diff, rev, *m_hashImpl);
+        co_return std::move(receipt);
+    }
+
+    /// Build a DepositTx from a protocol::Transaction whose isDepositTx() is true, reading the
+    /// deposit-only mirrors (sourceHash/mint/isSystemTransaction) from the object. No raw-envelope
+    /// RLP re-parse (buildOpBlock decoded it via opEnvelopeToTars); the width checks below
+    /// (sourceHash 32-byte / sender 20-byte / to 20-byte) reject malformed fields. mint is always
+    /// Some(value) (0 == no mint).
+public:
+    static bcos::evm::opstack::DepositTx depositFromTransaction(protocol::Transaction const& tx)
+    {
+        namespace op = bcos::evm::opstack;
+        op::DepositTx dep;
+
+        // source_hash: unprefixed hex string_view -> evmc::bytes32 (fail loud on malformed input)
+        auto sh = bcos::safeFromHex(tx.sourceHash());
+        if (!sh || sh->size() != sizeof(evmc::bytes32))
+            BOOST_THROW_EXCEPTION(OpTxValidationFailed{} << bcos::errinfo_comment(
+                                      "deposit sourceHash is not a 32-byte hex string"));
+        std::copy(sh->begin(), sh->end(), dep.source_hash.bytes);
+
+        // from: 20-byte raw string_view -> evmc::address (deposit has no signature; from == sender)
+        auto const& sb = tx.sender();
+        if (sb.size() != sizeof(evmc::address))
+            BOOST_THROW_EXCEPTION(OpTxValidationFailed{} << bcos::errinfo_comment(
+                                      "deposit sender is not a 20-byte address"));
+        std::copy_n(sb.begin(), sizeof(evmc::address), dep.from.bytes);
+
+        // to: hex string_view -> optional<evmc::address> (empty = contract creation)
+        auto const& tb = tx.to();
+        if (!tb.empty())
+        {
+            auto dec = bcos::safeFromHex(tb);
+            if (!dec || dec->size() != sizeof(evmc::address))
+                BOOST_THROW_EXCEPTION(OpTxValidationFailed{} << bcos::errinfo_comment(
+                                          "deposit to is not a 20-byte address"));
+            evmc::address ta{};
+            std::copy(dec->begin(), dec->end(), ta.bytes);
+            dep.to = ta;
+        }
+
+        dep.mint = bcos::executor_v1::eth::evm::toIntxU256(tx.mint());
+        dep.value = bcos::executor_v1::eth::evm::toIntxU256(tx.value());
+        dep.gas_limit = tx.gasLimit();
+        dep.is_system_tx = tx.depositIsSystemTransaction();
+        auto const& input = tx.input();
+        dep.data = evmc::bytes(input.begin(), input.end());
+        return dep;
+    }
+
+private:
+    protocol::TransactionReceiptFactory::Ptr m_receiptFactory;
+    crypto::Hash::Ptr m_hashImpl;
+    bcos::evm::opstack::OpForkConfig const& m_forkConfig;
+    evmc::VM m_vm;
+};
+
+}  // namespace bcos::executor_v1::opstack


### PR DESCRIPTION
## 概述

PR #5424 拆分的第一个 PR：引入 OP 执行器的**头依赖层**（4 个文件，856 行，valid_insertions 347）。

## 包含文件

| 文件 | 行数 | 说明 |
|---|---|---|
| `opstack-executor/OpstackExecutor.h` | 354 | OP 执行器门面：`executeTransaction`/`executeDeposit`/`finalizeBlock`（header-only template） |
| `ethereum-executor/StorageStateView.h` | 211 | `StorageStateView<Storage>`：FISCO storage → evmone state view 适配 |
| `opstack-executor/OpCommon.h` | 148 | detail 工具函数（`narrowU256ToU64`/`toEvmcAddress`/`toEvmcBytes32`） |
| `ethereum-executor/BCOS2Evmone.h` | 143 | `bcosTransactionToEvmone`/`applyStateDiff`/`toIntxU256` 适配声明 |

## 依赖说明

这些头的底层依赖（`bcos-evm/opstack`、vendored evmone state、`EthereumState.h`、`EVMSupport.h`）**已在 release-3.18.0 中**（#5416/#5418 合入），因此本 PR 是收敛的最小头依赖层，不重复引入底层。

## 说明

- 纯头 PR，不含 `.cpp` 实现（后续拆分 PR 补齐）
- 不修改任何现有代码/CMake，不影响 release-3.18.0 现有编译
