### PR TITLE
Per-transaction Karst execution: real karstConfig, 0x7E deposit lane, opTransition dispatch

### DIFF
--- a/bcos-evm/bcos-evm/opstack/OpForkSchedule.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpForkSchedule.cpp
@@ -85,16 +85,19 @@ const OpForkConfig& jovianConfig() noexcept
     return cfg;
 }
 
-// Karst is NOT independently adapted yet: its execution/receipt behavior is temporarily an alias
-// of Jovian (placeholder). Do not treat karstConfig() as a real Karst adaptation. Derived from
-// jovianConfig, changing only the fork tag, the same pattern as granite/holocene deriving from
-// fjord -- future Jovian changes are automatically carried into Karst, avoiding parallel-literal
-// drift.
+// Karst on top of Jovian: the EVM revision moves to Osaka (EIP-7825 tx gas cap — normal
+// transactions only, deposits stay exempt, see runDeposit —, EIP-7823/7883 MODEXP limits,
+// EIP-7939 CLZ, EIP-7951 P256 all gate on EVMC_OSAKA in the vendored state layer) and
+// bn256Pairing's input limit tightens to 57600 (karstPrecompileOverrides, which also stops
+// overriding P256 so EIP-7951 pricing applies). Fee/receipt semantics (operator fee, DA
+// footprint) carry over from Jovian unchanged.
 const OpForkConfig& karstConfig() noexcept
 {
     static const OpForkConfig cfg = [] {
         OpForkConfig c = jovianConfig();
         c.fork = OpFork::Karst;
+        c.rev = EVMC_OSAKA;
+        c.precompiles = &karstPrecompileOverrides();
         return c;
     }();
     return cfg;

--- a/bcos-evm/bcos-evm/opstack/OpHost.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpHost.cpp
@@ -96,7 +96,11 @@ evmc_tx_context OpHost::get_tx_context() const noexcept
         m_block.prev_randao,
         intx::be::store<evmc::uint256be>(intx::uint256{m_chain_id}),
         intx::be::store<evmc::uint256be>(intx::uint256{m_block.base_fee}),
-        intx::be::store<evmc::uint256be>(m_block.blob_base_fee.value_or(0)),
+        // OP L2 semantics: excessBlobGas is fixed at 0, so a caller that fills
+        // block.blob_base_fee computes fake_exponential(1, 0, ...) == 1 and that value is
+        // used as-is. The DEFAULT for an unfilled field is 1, not 0 (the EIP-4844
+        // minimum): a 0 would misprice any contract reading BLOBBASEFEE.
+        intx::be::store<evmc::uint256be>(m_block.blob_base_fee.value_or(1)),
         m_tx.blob_hashes.data(),
         m_tx.blob_hashes.size(),
         nullptr,

--- a/bcos-evm/bcos-evm/opstack/OpPrecompiles.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpPrecompiles.cpp
@@ -40,6 +40,19 @@ constexpr PrecompileOverrides::Entry kJovianEntries[] = {
     {.addr = evmc::address{0x0f}, .gas_cost_override = -1, .max_input_size = 156672},
 };
 
+// Karst re-tightens only bn256Pairing (81984 -> 57600); the BLS MSM/pairing limits carry
+// over from Jovian unchanged. P256Verify deliberately has NO Karst entry: Karst adopts
+// EIP-7951 (P256VERIFY at gas 6900), and karstConfig().rev is EVMC_OSAKA, so with no
+// override OpHost::call falls through to the vendored Osaka-gated p256verify with exactly
+// the EIP-7951 pricing — the pre-Karst 3450 (RIP-7212 P256VerifyGasFjord) entries stop at
+// Jovian.
+constexpr PrecompileOverrides::Entry kKarstEntries[] = {
+    {.addr = evmc::address{0x08}, .gas_cost_override = -1, .max_input_size = 57600},
+    {.addr = evmc::address{0x0c}, .gas_cost_override = -1, .max_input_size = 288960},
+    {.addr = evmc::address{0x0e}, .gas_cost_override = -1, .max_input_size = 278784},
+    {.addr = evmc::address{0x0f}, .gas_cost_override = -1, .max_input_size = 156672},
+};
+
 // Fjord: only P256Verify. No bn256 limit yet (that arrives with Granite) and no BLS at all
 // (CANCUN). Citations as above.
 constexpr PrecompileOverrides::Entry kFjordEntries[] = {
@@ -61,6 +74,12 @@ const PrecompileOverrides& isthmusPrecompileOverrides() noexcept
 const PrecompileOverrides& jovianPrecompileOverrides() noexcept
 {
     static const PrecompileOverrides overrides{.entries = kJovianEntries};
+    return overrides;
+}
+
+const PrecompileOverrides& karstPrecompileOverrides() noexcept
+{
+    static const PrecompileOverrides overrides{.entries = kKarstEntries};
     return overrides;
 }
 

--- a/bcos-evm/bcos-evm/opstack/OpPrecompiles.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpPrecompiles.cpp
@@ -40,8 +40,13 @@ constexpr PrecompileOverrides::Entry kJovianEntries[] = {
     {.addr = evmc::address{0x0f}, .gas_cost_override = -1, .max_input_size = 156672},
 };
 
-// Karst re-tightens only bn256Pairing (81984 -> 57600); the BLS MSM/pairing limits carry
-// over from Jovian unchanged. P256Verify deliberately has NO Karst entry: Karst adopts
+// Karst re-tightens only bn256Pairing, and what it tightens is the INPUT SIZE, not the
+// gas cost: 81984 -> 57600 BYTES of calldata. bn256 pairing consumes 192 bytes per pair,
+// so those are Jovian's 427 pairs and Karst's 300 (81984/192 = 427, 57600/192 = 300) —
+// matching Optimism Upgrade 19's "from 427 pairs (81,984 bytes) to 300 pairs (57,600
+// bytes)". Pricing is untouched (gas_cost_override = -1 => no override); the per-pair gas
+// stays whatever the vendored precompile charges. The BLS MSM/pairing limits carry over
+// from Jovian unchanged. P256Verify deliberately has NO Karst entry: Karst adopts
 // EIP-7951 (P256VERIFY at gas 6900), and karstConfig().rev is EVMC_OSAKA, so with no
 // override OpHost::call falls through to the vendored Osaka-gated p256verify with exactly
 // the EIP-7951 pricing — the pre-Karst 3450 (RIP-7212 P256VerifyGasFjord) entries stop at

--- a/bcos-evm/bcos-evm/opstack/OpPrecompiles.h
+++ b/bcos-evm/bcos-evm/opstack/OpPrecompiles.h
@@ -43,6 +43,7 @@ struct PrecompileOverrides
 
 const PrecompileOverrides& isthmusPrecompileOverrides() noexcept;
 const PrecompileOverrides& jovianPrecompileOverrides() noexcept;
+const PrecompileOverrides& karstPrecompileOverrides() noexcept;
 const PrecompileOverrides& fjordPrecompileOverrides() noexcept;
 const PrecompileOverrides& granitePrecompileOverrides() noexcept;
 }  // namespace bcos::evm::opstack

--- a/bcos-evm/bcos-evm/opstack/OpTransition.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.cpp
@@ -325,11 +325,20 @@ OpDepositReceipt runDeposit(const evmone::state::StateView& view,
 
     // Deposit skips the fee cap validation; validate is used only to compute intrinsic gas / the
     // EIP-7623 floor.
+    //
+    // The revision is clamped to Prague for this call ONLY: Karst does not enable the
+    // EIP-7825 per-tx gas cap for deposits (they are metered on L1 — the OptimismPortal
+    // caps deposits at 20M gas total per L1 block; the L2 EL performs no deposit gas
+    // check of its own), yet validate_transaction enforces the cap at Osaka+ (the
+    // MAX_TX_GAS_LIMIT check in the vendored state.cpp). The only other Osaka-gated
+    // validate rule is the blob count (MAX_TX_BLOB_COUNT, same function), and a deposit
+    // carries no blobs; compute_tx_intrinsic_cost has no Osaka-gated terms. Execution
+    // below still runs at the real cfg.rev.
     evmone::state::BlockInfo validateBlock = block;
     validateBlock.base_fee = 0;
     const DepositValidationView maskedView{view, dep.from};
     const auto props = evmone::state::validate_transaction(
-        maskedView, validateBlock, tx, cfg.rev, blockGasLeft, 0);
+        maskedView, validateBlock, tx, std::min(cfg.rev, EVMC_PRAGUE), blockGasLeft, 0);
 
     evmone::state::TransactionReceipt receipt;
     receipt.type = kDepositTxType;

--- a/bcos-evm/bcos-evm/opstack/OpTransition.h
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.h
@@ -114,6 +114,9 @@ constexpr auto kDepositTxType = static_cast<evmone::state::Transaction::Type>(0x
 /// intrinsic + the EIP-7623 floor; both failure paths retain the mint and force-increment the
 /// nonce; is_system_tx==true throws std::runtime_error (block-level error). gas_limit exceeding
 /// blockGasLeft throws std::runtime_error (op-geth ErrGasLimitReached, block-level error).
+/// Deposits are exempt from the EIP-7825 per-tx cap (Karst meters deposit gas on L1 — the
+/// OptimismPortal caps deposits at 20M gas total per L1 block; the EL performs no deposit
+/// gas check of its own).
 OpDepositReceipt runDeposit(const evmone::state::StateView& view,
     const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
     const DepositTx& dep, const OpForkConfig& cfg, evmc::VM& vm, uint64_t chainId,

--- a/bcos-evm/test/CMakeLists.txt
+++ b/bcos-evm/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(bcos-evm-opstack-tests
     opstack/OpValidateTest.cpp
     opstack/OpTransitionTest.cpp
     opstack/OpDepositTest.cpp
+    opstack/OpDepositGasCapTest.cpp
     opstack/OpZeroDiffTest.cpp
     opstack/OpReceiptMetaTest.cpp
     opstack/Op7702Test.cpp

--- a/bcos-evm/test/opstack/OpDepositGasCapTest.cpp
+++ b/bcos-evm/test/opstack/OpDepositGasCapTest.cpp
@@ -1,0 +1,93 @@
+// Karst deposit gas semantics: deposits are exempt from the EIP-7825 per-tx cap
+// (2^24 = 16,777,216) that Karst's EVMC_OSAKA revision enforces for normal
+// transactions. Deposit gas is metered on L1 (the OptimismPortal caps deposits at
+// 20M gas total per L1 block); the L2 EL performs no deposit gas check of its own,
+// bounded only by blockGasLeft. Every vector here sits above 2^24, pinning the
+// exemption — without the validate-revision clamp in runDeposit they would come
+// back as MAX_GAS_LIMIT_EXCEEDED failure receipts.
+#include "StateDiffWriteback.h"
+#include "TestPrinters.h"
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <evmone/evmone.h>
+#include <boost/test/unit_test.hpp>
+#include <bcos-evm/eth/state/state.hpp>
+#include <test/utils/test_state.hpp>
+
+using namespace bcos::evm::opstack;
+using namespace evmone;
+using namespace evmc::literals;
+
+namespace
+{
+constexpr auto kFrom = 0x00000000000000000000000000000000000000cc_address;
+constexpr int64_t kBlockGasLeft = 30000000;
+
+state::BlockInfo blk()
+{
+    state::BlockInfo b;
+    b.number = 1;
+    b.gas_limit = kBlockGasLeft;
+    b.base_fee = 7;
+    return b;
+}
+
+DepositTx depositWithGasLimit(int64_t gasLimit)
+{
+    return DepositTx{.source_hash = 0x01_bytes32,
+        .from = kFrom,
+        .to = kFrom,
+        .mint = intx::uint256{100},
+        .value = intx::uint256{0},
+        .gas_limit = gasLimit,
+        .is_system_tx = false,
+        .data = {}};
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpDepositGasCapSuite)
+
+BOOST_AUTO_TEST_CASE(Above7825CapExecutes)
+{
+    auto vm = evmc::VM{evmc_create_evmone()};
+    test::TestState ts;
+    ts[kFrom] = {.nonce = 5, .balance = intx::uint256{0}, .storage = {}, .code = {}};
+    test::TestBlockHashes hashes;
+
+    const auto r = runDeposit(
+        ts, blk(), hashes, depositWithGasLimit(19'999'999), karstConfig(), vm, 1234, kBlockGasLeft);
+    BOOST_CHECK_EQUAL(r.receipt.status, EVMC_SUCCESS);
+    BOOST_CHECK_LT(r.receipt.gas_used, 19'999'999);
+}
+
+BOOST_AUTO_TEST_CASE(TwentyMillionGasExecutes)
+{
+    auto vm = evmc::VM{evmc_create_evmone()};
+    test::TestState ts;
+    ts[kFrom] = {.nonce = 5, .balance = intx::uint256{0}, .storage = {}, .code = {}};
+    test::TestBlockHashes hashes;
+
+    const auto r = runDeposit(
+        ts, blk(), hashes, depositWithGasLimit(20'000'000), karstConfig(), vm, 1234, kBlockGasLeft);
+    bcos::evm::applyStateDiffStrict(ts, r.receipt.state_diff);
+    BOOST_CHECK_EQUAL(r.receipt.status, EVMC_SUCCESS);
+    BOOST_CHECK_EQUAL(ts.at(kFrom).nonce, 6u);
+    BOOST_CHECK_EQUAL(ts.at(kFrom).balance, intx::uint256{100});
+}
+
+// The EL enforces no 20M cutoff of its own (rejecting a deposit the L1 accepted could
+// strand the minted ETH): 20,000,001 still executes under Karst, bounded only by
+// blockGasLeft.
+BOOST_AUTO_TEST_CASE(AboveTwentyMillionStillExecutesUnderKarst)
+{
+    auto vm = evmc::VM{evmc_create_evmone()};
+    test::TestState ts;
+    ts[kFrom] = {.nonce = 5, .balance = intx::uint256{0}, .storage = {}, .code = {}};
+    test::TestBlockHashes hashes;
+
+    const auto r = runDeposit(
+        ts, blk(), hashes, depositWithGasLimit(20'000'001), karstConfig(), vm, 1234, kBlockGasLeft);
+    BOOST_CHECK_EQUAL(r.receipt.status, EVMC_SUCCESS);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-evm/test/opstack/OpForkScheduleTest.cpp
+++ b/bcos-evm/test/opstack/OpForkScheduleTest.cpp
@@ -27,13 +27,16 @@ BOOST_AUTO_TEST_CASE(JovianAndKarstConfigs)
     BOOST_CHECK(j.disable_prague_requests);
     BOOST_CHECK((j.precompiles) != nullptr);
 
+    // Karst is a real adaptation, no longer a Jovian alias: Osaka revision and its own
+    // precompile table. Fee/receipt flags still carry over from Jovian.
     const auto& k = karstConfig();
     BOOST_CHECK_EQUAL(k.fork, OpFork::Karst);
-    BOOST_CHECK_EQUAL(k.rev, j.rev);
+    BOOST_CHECK_EQUAL(k.rev, EVMC_OSAKA);
+    BOOST_CHECK_EQUAL(k.precompiles, &karstPrecompileOverrides());
     BOOST_CHECK_EQUAL(k.has_operator_fee, j.has_operator_fee);
     BOOST_CHECK_EQUAL(k.has_jovian_operator_formula, j.has_jovian_operator_formula);
     BOOST_CHECK_EQUAL(k.has_da_footprint, j.has_da_footprint);
-    BOOST_CHECK_EQUAL(k.precompiles, j.precompiles);
+    BOOST_CHECK_EQUAL(k.disable_prague_requests, j.disable_prague_requests);
 }
 
 BOOST_AUTO_TEST_CASE(IsthmusDisablesJovianFlags)

--- a/bcos-evm/test/opstack/OpHostTest.cpp
+++ b/bcos-evm/test/opstack/OpHostTest.cpp
@@ -42,6 +42,32 @@ BOOST_AUTO_TEST_CASE(GetTxContextUsesConfiguredChainId)
     BOOST_CHECK_EQUAL(intx::be::load<intx::uint256>(ctx.chain_id), intx::uint256{1234});
 }
 
+// BLOBBASEFEE: a filled block.blob_base_fee is used as-is (an OP block computes
+// fake_exponential over excessBlobGas == 0, which yields 1); an UNFILLED field defaults
+// to the EIP-4844 minimum of 1, never 0 (the old value_or(0) default mispriced any
+// contract reading BLOBBASEFEE when the executor left the field unset).
+BOOST_AUTO_TEST_CASE(GetTxContextBlobBaseFeeDefaultsToOneAndKeepsInput)
+{
+    auto vm = evmc::VM{evmc_create_evmone()};
+    test::TestState ts;
+    state::State st{ts};
+    test::TestBlockHashes hashes;
+    state::Transaction tx;
+    tx.sender = 0x00000000000000000000000000000000000000aa_address;
+
+    auto block = makeBlock();
+    BOOST_REQUIRE(!block.blob_base_fee.has_value());
+    OpHost host{EVMC_PRAGUE, vm, st, block, hashes, tx, 1234, &isthmusPrecompileOverrides()};
+    BOOST_CHECK_EQUAL(
+        intx::be::load<intx::uint256>(host.get_tx_context().blob_base_fee), intx::uint256{1});
+
+    // Filled field is passed through, not overridden.
+    block.blob_base_fee = intx::uint256{5};
+    OpHost hostFilled{EVMC_PRAGUE, vm, st, block, hashes, tx, 1234, nullptr};
+    BOOST_CHECK_EQUAL(
+        intx::be::load<intx::uint256>(hostFilled.get_tx_context().blob_base_fee), intx::uint256{5});
+}
+
 BOOST_AUTO_TEST_CASE(GetTxContextGasPriceZeroForSystemCall)
 {
     auto vm = evmc::VM{evmc_create_evmone()};

--- a/bcos-evm/test/opstack/OpPrecompilesTest.cpp
+++ b/bcos-evm/test/opstack/OpPrecompilesTest.cpp
@@ -76,7 +76,36 @@ BOOST_AUTO_TEST_CASE(JovianLimitsStricterThanIsthmus)
     BOOST_CHECK_EQUAL(
         jovianPrecompileOverrides().find(evmc::address{0x0f})->max_input_size, 156672u);
     BOOST_CHECK_EQUAL(jovianConfig().precompiles, &jovianPrecompileOverrides());
-    BOOST_CHECK_EQUAL(karstConfig().precompiles, &jovianPrecompileOverrides());
+}
+
+// Karst re-tightens only bn256Pairing (81984 -> 57600); P256Verify and the BLS
+// MSM/pairing limits carry over from Jovian unchanged.
+BOOST_AUTO_TEST_CASE(KarstTightensBn256OnlyOverJovian)
+{
+    const auto& karst = karstPrecompileOverrides();
+    const auto& jovian = jovianPrecompileOverrides();
+
+    const auto* k08 = karst.find(evmc::address{0x08});
+    BOOST_REQUIRE((k08) != nullptr);
+    BOOST_CHECK_EQUAL(k08->max_input_size, 57600u);
+    BOOST_CHECK_LT(k08->max_input_size, jovian.find(evmc::address{0x08})->max_input_size);
+    BOOST_CHECK_LT(k08->gas_cost_override, 0);
+
+    for (const auto& addr : {evmc::address{0x0c}, evmc::address{0x0e}, evmc::address{0x0f}})
+    {
+        const auto* k = karst.find(addr);
+        const auto* j = jovian.find(addr);
+        BOOST_REQUIRE((k) != nullptr);
+        BOOST_REQUIRE((j) != nullptr);
+        BOOST_CHECK_EQUAL(k->max_input_size, j->max_input_size);
+        BOOST_CHECK_EQUAL(k->gas_cost_override, j->gas_cost_override);
+    }
+    // Karst does NOT override P256Verify: EIP-7951 (gas 6900) applies via the vendored
+    // Osaka-gated precompile, so 0x100 must be absent from the Karst table (an entry
+    // would pin the pre-Karst RIP-7212 gas 3450). Jovian still carries it.
+    BOOST_CHECK(!karst.contains(evmc::address{0x100}));
+    BOOST_CHECK(jovian.contains(evmc::address{0x100}));
+    BOOST_CHECK_EQUAL(karstConfig().precompiles, &karst);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -66,6 +66,7 @@ DERIVE_BCOS_EXCEPTION(UnknownForkchoiceHeadBlock);
 DERIVE_BCOS_EXCEPTION(InvalidForkchoiceState);
 DERIVE_BCOS_EXCEPTION(UnknownPayload);
 DERIVE_BCOS_EXCEPTION(IncompatiblePayloadVersion);
+DERIVE_BCOS_EXCEPTION(BlockGasLimitExceeded);
 
 namespace detail
 {
@@ -290,7 +291,7 @@ public:
             .parentBeaconBlockRoot = payloadAttributes->parentBeaconBlockRoot,
             .view = std::make_shared<ViewType>(std::move(view)),
             .header = std::move(built.header),
-            .receipts = std::move(built.receipts),
+            .persistedReceipts = std::move(built.persistedReceipts),
         };
         if (version == static_cast<std::uint32_t>(ApiVersion::V3))
         {
@@ -370,7 +371,11 @@ private:
         /// SYS_HASH_2_RECEIPT / SYS_HASH_2_TX) via ledger::prewriteBlockToBuffer. Externally
         /// received payloads leave these null/empty.
         bcos::protocol::BlockHeader::Ptr header;
-        std::vector<protocol::TransactionReceipt::Ptr> receipts;
+        /// Receipts of the DECODED transactions only, aligned index-by-index with the
+        /// decoded subset of executionPayload.transactions. Deliberately not the set the
+        /// header's receiptsRoot / gasUsed / logsBloom were computed over (that one also
+        /// covers deposits) — see BuildPayloadResult::persistedReceipts.
+        std::vector<protocol::TransactionReceipt::Ptr> persistedReceipts;
     };
 
     static bool isVersionSupported(std::uint32_t version)
@@ -488,7 +493,7 @@ private:
             .parentBeaconBlockRoot = request.parentBeaconBlockRoot,
             .view = nullptr,
             .header = nullptr,
-            .receipts = {},
+            .persistedReceipts = {},
         };
         if (version == static_cast<std::uint32_t>(ApiVersion::V3))
         {
@@ -535,7 +540,7 @@ private:
                         block->appendTransaction(tx.decoded);
                     }
                 }
-                for (auto const& receipt : it->second.receipts)
+                for (auto const& receipt : it->second.persistedReceipts)
                 {
                     block->appendReceipt(receipt);
                 }
@@ -582,7 +587,12 @@ private:
     {
         ExecutionPayload executionPayload;
         bcos::protocol::BlockHeader::Ptr header;
-        std::vector<protocol::TransactionReceipt::Ptr> receipts;
+        /// The receipts that get PERSISTED, which is NOT the set the header's totals were
+        /// computed over. Named so at the type level because the two differ: the header's
+        /// receiptsRoot / gasUsed / logsBloom cover deposits too, while this list only
+        /// covers the decoded (scheduler) transactions, index-by-index with the persisted
+        /// transaction list. See Step 2c's comment for why, and for when the two converge.
+        std::vector<protocol::TransactionReceipt::Ptr> persistedReceipts;
     };
 
     bcos::task::Task<BuildPayloadResult> buildPayload(const ForkchoiceState& forkchoiceState,
@@ -684,10 +694,11 @@ private:
         ledger::LedgerConfig ledgerConfig;
         co_await ledger::getLedgerConfig(view, ledgerConfig, nextBlockNumber - 1, *m_blockFactory);
         auto blockVersion = ledgerConfig.compatibilityVersion();
+        auto const blockGasLimit = std::get<0>(ledgerConfig.gasLimit());
 
         // Fill gasLimit from ledger config (FISCO-BCOS does not use EIP-1559 baseFeePerGas,
         // and logsBloom is not part of BlockHeader hash computation in FISCO-BCOS).
-        executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
+        executionPayload.gasLimit = blockGasLimit;
 
         // Real EVM execution: execute transactions and compute real hashes.
         if (executionPayload.transactions.empty())
@@ -701,7 +712,7 @@ private:
             emptyHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
-            emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
+            emptyHeader->setGasLimit(u256(blockGasLimit));
             emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
             emptyHeader->setReceiptsRoot(h256{});
             emptyHeader->setTxsRoot(h256{});
@@ -713,7 +724,7 @@ private:
             executionPayload.blockHash = emptyHeader->hash();
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
                 .header = std::move(emptyHeader),
-                .receipts = {}};
+                .persistedReceipts = {}};
         }
 
         // Step 2b: Create BlockHeader for the new block
@@ -726,7 +737,7 @@ private:
         blockHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
         blockHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
-        blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
+        blockHeader->setGasLimit(u256(blockGasLimit));
 
         // Step 2c-0: Execute 0x7E deposits (raw-only forced entries) FIRST, before the
         // scheduler runs the decoded transactions — deposits lead the OP payload and the
@@ -764,8 +775,9 @@ private:
             *blockHeader, executableTransactions | ::ranges::views::indirect, ledgerConfig);
         // Deposit receipts lead, matching payload order (forced entries come first) — but
         // ONLY for the block totals below (receiptsRoot / gasUsed / logsBloom).
-        // BuildPayloadResult.receipts stays the scheduler subset: newPayload persistence
-        // pairs receipts with the persisted (decoded) transaction list index-by-index
+        // BuildPayloadResult.persistedReceipts stays the scheduler subset (hence the name —
+        // the two sets are NOT interchangeable): newPayload persistence pairs receipts with
+        // the persisted (decoded) transaction list index-by-index
         // (prewriteBlockToBuffer keys SYS_HASH_2_RECEIPT by blockTxs[i]->hash()), and a
         // deposit has no ledger transaction to pair with until deposits are modeled as
         // ledger transactions. Merging them into the persisted list would mis-key the
@@ -849,6 +861,90 @@ private:
                 orBloom(logsBloom, receipt->logsBloom());
             }
         }
+        // No pool bounds the block's gas here. op-geth runs ONE GasPool per block
+        // (core/state_processor.go:70, `gp = NewGasPool(block.GasLimit())`) that every
+        // transaction draws its own gasLimit from before executing — deposits included
+        // (core/state_transition.go:360, `return st.gp.SubGas(st.msg.GasLimit) // gas used
+        // by deposits may not be used by other txs`) — with the unused remainder returned
+        // afterwards (:669-672). This lane has none: EthereumExecutor passes the FULL block
+        // gas limit as every transaction's blockGasLeft, so each deposit and each scheduler
+        // transaction believes it owns the whole budget and the sum above can land past it.
+        //
+        // Only the deposits are a hard failure, and ONLY they may be. Which half overran
+        // decides whether failing the payload is a fix or a weapon:
+        //
+        //   * Deposits are consensus-injected by the CL, so an over-budget deposit set is a
+        //     malformed payload request and refusing it is the correct verdict — the same
+        //     one op-geth reaches, since SubGas's ErrGasLimitReached is excluded from the
+        //     failed-deposit salvage branch (core/state_transition.go:486) and propagates as
+        //     a block error rather than a failure receipt. Retrying is futile until the CL
+        //     sends different attributes, so there is nothing to stall.
+        //
+        //   * The scheduler's half arrives from eth_sendRawTransaction, and throwing on it
+        //     would hand any caller a permanent production halt. The throw escapes
+        //     updateForkchoice, so the block is abandoned and nothing commits; the mempool
+        //     is untouched (remove()/seal() already ran, and MemPoolImpl::remove(state)
+        //     prunes strictly by nonce with no TTL, while these transactions never executed
+        //     so no nonce moved); the next forkchoice update seals the identical batch off
+        //     the identical state and throws again. The node would never produce another
+        //     block. It is also cheap to trigger: base_fee defaults to 0 (EthereumHost.h:46)
+        //     so a zero-balance sender passes the fee checks, and gasUsed is driven by
+        //     calldata intrinsic cost rather than real computation. Log it instead — loudly,
+        //     because it means the C3 accounting below is overdue.
+        //
+        // Nothing on this lane consumes the check either way today: handleNewPayload only
+        // commits payloads this node built (it re-executes nothing when view == nullptr), so
+        // no peer validates the totals.
+        //
+        // Only the check, not the accounting: a real pool has to be threaded through
+        // scheduler_v1::TransactionScheduler::executeBlock — a bcos-framework concept shared
+        // by the serial, parallel and baseline schedulers — AND needs each transaction's
+        // actual gasUsed fed back so the unspent remainder returns to the pool. That is the
+        // block-lifecycle layer's job (C3).
+        //
+        // Approximating it here by reserving each sealed transaction's DECLARED gasLimit up
+        // front, without the refund half, was tried and rejected: it starves the chain.
+        // op-geth can reserve safely because its txpool refuses a transaction whose gas
+        // exceeds the block limit at admission (core/txpool/validation.go:135, ErrGasLimit).
+        // FISCO's ingress has no such check — EthEndpoint's mempool branch validates
+        // signature and chainId only, MemPoolImpl::add hash and nonce parseability — while
+        // the executor rejects an over-cap transaction (EIP-7825, Osaka) WITHOUT executing
+        // it, so it burns no gas, never advances its sender's nonce, and
+        // MemPoolImpl::remove(state), which prunes strictly by nonce, can never evict it.
+        // A single free eth_sendRawTransaction declaring gas == the block limit would then
+        // reserve the entire budget of every future block forever. Reserving correctly
+        // needs the executor's per-revision gas cap, which the engine deliberately does not
+        // link (engine/CMakeLists.txt: bcos-framework, bcos-task, bcos-utilities, ledger).
+        //
+        // A zero limit means UNCONFIGURED, not "this block may burn no gas": getLedgerConfig
+        // reads tx_gas_limit with getOrDefault(..., "0") (LedgerMethods.h), so a chain
+        // without that SYS_CONFIG row lands here with 0 and must not be judged against it.
+        if (blockGasLimit > 0)
+        {
+            u256 depositGasUsed;
+            for (auto const& depositReceipt : depositReceipts)
+            {
+                depositGasUsed += depositReceipt->gasUsed();
+            }
+            if (depositGasUsed > u256(blockGasLimit))
+            {
+                BOOST_THROW_EXCEPTION(
+                    BlockGasLimitExceeded{} << bcos::errinfo_comment{
+                        "Forced deposits consume more gas than the block gas limit allows"});
+            }
+            if (totalGasUsed > u256(blockGasLimit))
+            {
+                BCOS_LOG(ERROR) << LOG_BADGE("EngineService")
+                                << LOG_DESC(
+                                       "buildPayload: block gas used exceeds the block gas "
+                                       "limit; the scheduler has no cross-transaction gas "
+                                       "accounting yet")
+                                << LOG_KV("blockNumber", nextBlockNumber)
+                                << LOG_KV("gasUsed", totalGasUsed)
+                                << LOG_KV("gasLimit", blockGasLimit)
+                                << LOG_KV("depositGasUsed", depositGasUsed);
+            }
+        }
 
         // Step 2g: Compute state root (MPT over state storage)
         h256 stateRoot = co_await calculateStateRoot(view, blockHeader->version());
@@ -865,12 +961,12 @@ private:
         executionPayload.receiptsRoot = receiptRoot;
         executionPayload.gasUsed = totalGasUsed;
         executionPayload.blockHash = blockHeader->hash();
-        executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
+        executionPayload.gasLimit = blockGasLimit;
         executionPayload.logsBloom = logsBloom;
 
         co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
             .header = std::move(blockHeader),
-            .receipts = std::move(receipts)};
+            .persistedReceipts = std::move(receipts)};
     }
 
     /// Compute state root by iterating over storage and XOR-ing entry hashes.

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -22,6 +22,7 @@
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/merkle/Merkle.h"
 #include "bcos-framework/engine/EngineService.h"
+#include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-framework/engine/Types.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
@@ -39,12 +40,14 @@
 #include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
 #include <bcos-tars-protocol/protocol/Web3RawTransaction.h>
+#include <concepts>
 #include <cstdint>
 #include <deque>
 #include <functional>
 #include <mutex>
 #include <optional>
 #include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/view/concat.hpp>
 #include <range/v3/view/filter.hpp>
 #include <range/v3/view/indirect.hpp>
 #include <range/v3/view/transform.hpp>
@@ -80,6 +83,19 @@ std::optional<std::string> validatePayloadAttributes(
 std::optional<std::string> validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version);
 }  // namespace detail
+
+/// The OP deposit execution entry an executor may provide (see buildPayload Step 2c-0).
+/// Named so the gate below and the hard conformance check on the REAL executor share one
+/// definition: a signature drift on EthereumExecutor::executeDeposit must fail the
+/// static_assert next to its scheduler wiring (TestEthereumExecutorScheduler.cpp), not
+/// silently turn this `if constexpr` off and stop executing deposits.
+template <class Executor, class Storage>
+concept ExecutesDeposits = requires(Executor& executor, Storage& storage,
+    protocol::BlockHeader const& blockHeader, ledger::LedgerConfig const& ledgerConfig) {
+    {
+        executor.executeDeposit(storage, blockHeader, bcos::bytesConstRef{}, ledgerConfig)
+    } -> std::same_as<task::Task<protocol::TransactionReceipt::Ptr>>;
+};
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
     requires executor_v1::TransactionExecutor<ExecutorType,
@@ -506,9 +522,12 @@ private:
                 auto const& bloom = it->second.executionPayload.logsBloom;
                 block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
                 // Raw-only entries (forced transactions) carry no decoded form and are
-                // not modeled as ledger transactions until execution wiring lands; the
-                // persisted transaction list therefore matches the receipts list, which
-                // also only covers the executed (decoded) subset.
+                // not modeled as ledger transactions; the persisted transaction list
+                // therefore matches the receipts list, which also only covers the
+                // decoded subset — prewriteBlockToBuffer pairs them index-by-index, so
+                // the two MUST stay aligned. Deposits DO execute (Step 2c-0) and enter
+                // the block totals, but their receipts are not persisted until deposits
+                // are modeled as ledger transactions.
                 for (auto const& tx : it->second.executionPayload.transactions)
                 {
                     if (tx.decoded)
@@ -593,11 +612,11 @@ private:
         // CL gave them — this is the only OP-sanctioned path for deposits. Their raw
         // EIP-2718 bytes are carried byte-for-byte (hex validity and dispatch
         // admissibility were already enforced by validatePayloadAttributes, which runs
-        // before buildPayload). They carry no decoded executable form yet: 0x7E deposit
-        // execution (runDeposit) and raw->executable decoding for typed/legacy forced
-        // transactions belong to the execution-lane wiring, so raw-only entries are
-        // placed in the payload, participate in the transactions root via their
-        // canonical keccak256(raw) hash, but are not executed and do not advance state.
+        // before buildPayload). They carry no decoded executable form: 0x7E deposits
+        // execute through the executor's deposit entry (Step 2c-0 below, executor
+        // permitting); raw->executable decoding for typed/legacy forced transactions is
+        // still unwired, so those raw-only entries participate in the transactions root
+        // via their canonical keccak256(raw) hash but are not executed.
         if (payloadAttributes.transactions.has_value())
         {
             for (auto const& forcedHex : *payloadAttributes.transactions)
@@ -709,9 +728,29 @@ private:
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
 
+        // Step 2c-0: Execute 0x7E deposits (raw-only forced entries) FIRST, before the
+        // scheduler runs the decoded transactions — deposits lead the OP payload and the
+        // scheduler's transactions must see their state. Executed directly through the
+        // executor's deposit entry (deposits never exist as protocol::Transaction), gated
+        // on the executor providing one so stub executors keep their behavior. An invalid
+        // deposit throws out of buildPayload — it is a block-level error.
+        std::vector<protocol::TransactionReceipt::Ptr> depositReceipts;
+        if constexpr (ExecutesDeposits<ExecutorType, ViewType>)
+        {
+            for (auto const& engineTx : executionPayload.transactions)
+            {
+                if (engineTx.decoded == nullptr &&
+                    dispatchRawTransaction(bcos::ref(engineTx.raw)) == RawTransactionKind::Deposit)
+                {
+                    depositReceipts.push_back(co_await m_executor.get().executeDeposit(
+                        view, *blockHeader, bcos::ref(engineTx.raw), ledgerConfig));
+                }
+            }
+        }
+
         // Step 2c: Execute transactions via the scheduler, over the decoded executable
-        // forms. Raw-only entries (forced transactions from the OP attributes list) have
-        // no executable form yet and are skipped — see the forced-transaction comment
+        // forms. Raw-only non-deposit entries (forced typed/legacy transactions) have no
+        // executable form yet and are skipped — see the forced-transaction comment
         // above. Materialized into a vector because scheduler implementations require a
         // sized range (a lazy filter view is not sized).
         auto executableTransactions =
@@ -723,6 +762,19 @@ private:
             ::ranges::to<std::vector>();
         auto receipts = co_await m_scheduler.get().executeBlock(view, m_executor.get(),
             *blockHeader, executableTransactions | ::ranges::views::indirect, ledgerConfig);
+        // Deposit receipts lead, matching payload order (forced entries come first) — but
+        // ONLY for the block totals below (receiptsRoot / gasUsed / logsBloom).
+        // BuildPayloadResult.receipts stays the scheduler subset: newPayload persistence
+        // pairs receipts with the persisted (decoded) transaction list index-by-index
+        // (prewriteBlockToBuffer keys SYS_HASH_2_RECEIPT by blockTxs[i]->hash()), and a
+        // deposit has no ledger transaction to pair with until deposits are modeled as
+        // ledger transactions. Merging them into the persisted list would mis-key the
+        // first decoded receipt and overrun blockTxs on a mixed block. Until that later
+        // PR, a deposit's receipt affects the block totals but is not retrievable via
+        // eth_getTransactionReceipt — KNOWN INVARIANT BREAK: the header commits to a
+        // receiptsRoot the stored receipts cannot reproduce until C3 models deposits as
+        // ledger transactions.
+        auto allReceipts = ::ranges::views::concat(depositReceipts, receipts);
 
         // Step 2d: Compute transaction root (Merkle over tx hashes)
         // TODO: Use scheduler_v1::calculateTransactionRoot from BaselineScheduler.h
@@ -753,11 +805,11 @@ private:
             }
         }
 
-        // Step 2e: Compute receipt root (Merkle over receipt hashes)
+        // Step 2e: Compute receipt root (Merkle over receipt hashes, deposits included)
         h256 receiptRoot;
         {
             // Validate receipts are non-null before computing hashes
-            if (::ranges::any_of(receipts, [](auto& r) { return !r; }))
+            if (::ranges::any_of(allReceipts, [](auto& r) { return !r; }))
             {
                 BOOST_THROW_EXCEPTION(std::runtime_error{"Null receipt returned by scheduler"});
             }
@@ -765,10 +817,10 @@ private:
             auto hasher = hashImpl.hasher();
             crypto::merkle::Merkle<std::remove_reference_t<decltype(hasher)>> merkle(
                 hasher.clone());
-            if (!receipts.empty())
+            if (!::ranges::empty(allReceipts))
             {
                 auto receiptHashes =
-                    receipts | ::ranges::views::transform([](auto& r) { return r->hash(); });
+                    allReceipts | ::ranges::views::transform([](auto& r) { return r->hash(); });
                 std::vector<h256> merkleTrie;
                 merkle.generateMerkle(receiptHashes, merkleTrie);
                 if (!merkleTrie.empty())
@@ -778,10 +830,11 @@ private:
             }
         }
 
-        // Step 2f: Compute gas used and block-level logsBloom from receipts.
+        // Step 2f: Compute gas used and block-level logsBloom from receipts
+        // (deposits included).
         u256 totalGasUsed;
         Bloom logsBloom{};
-        for (auto& receipt : receipts)
+        for (auto& receipt : allReceipts)
         {
             if (!receipt)
             {

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -78,14 +78,15 @@ static protocol::Transaction::Ptr makeTx(std::string_view senderBytes, int64_t n
 /// type=Web3Transaction, extraTransactionBytes = 0x02 || rlp(unsigned fields),
 /// signature = r(32) || s(32) || yParity(1). calculateHash() runs the same raw-bytes
 /// splice buildPayload uses, so constructing one also validates the payload shape.
-static protocol::Transaction::Ptr makeWeb3Tx(std::string_view senderBytes, uint64_t nonce)
+static protocol::Transaction::Ptr makeWeb3Tx(
+    std::string_view senderBytes, uint64_t nonce, uint64_t gasLimit = 21000)
 {
     bytes body;
     bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));  // chainId
     bcos::codec::rlp::encode(body, nonce);
-    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));      // maxPriorityFeePerGas
-    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));      // maxFeePerGas
-    bcos::codec::rlp::encode(body, static_cast<uint64_t>(21000));  // gasLimit
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));  // maxPriorityFeePerGas
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(1));  // maxFeePerGas
+    bcos::codec::rlp::encode(body, gasLimit);
     bcos::codec::rlp::encode(body, Address("abcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"));
     bcos::codec::rlp::encode(body, static_cast<uint64_t>(0));  // value
     bcos::codec::rlp::encode(body, bytes{});                   // data
@@ -99,6 +100,9 @@ static protocol::Transaction::Ptr makeWeb3Tx(std::string_view senderBytes, uint6
     auto tx = std::make_shared<TestTransactionImpl>();
     tx->mutableInner().type = static_cast<int>(bcos::protocol::TransactionType::Web3Transaction);
     tx->mutableInner().extraTransactionBytes.assign(payload.begin(), payload.end());
+    // Transaction::gasLimit() reads the Tars field, not the signing payload — the
+    // eth_sendRawTransaction ingress fills both, so keep them in step here too.
+    tx->mutableInner().data.gasLimit = static_cast<int64_t>(gasLimit);
     bytes signature(65, 0);
     signature[31] = 0x12;  // r != 0
     signature[63] = 0x34;  // s != 0
@@ -165,6 +169,19 @@ struct RealGlobalStateStorageFixture
     void setBlockNumber(const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
     {
         task::syncWait(writeBlockNumberToStorage(backendStorage, blockHash, blockNumber));
+    }
+
+    /// Seed the SYS_CONFIG tx_gas_limit row getLedgerConfig reads. Without it that read
+    /// falls back to "0" (LedgerMethods.h getOrDefault) and buildPayload treats the block
+    /// gas budget as unconfigured.
+    void setGasLimit(uint64_t gasLimit)
+    {
+        storage::Entry entry;
+        entry.set(bcos::storage::serialize::encode(
+            ledger::SystemConfigEntry{std::to_string(gasLimit), 0}));
+        task::syncWait(storage2::writeOne(backendStorage,
+            bcos::executor_v1::StateKey{ledger::SYS_CONFIG, ledger::SYSTEM_KEY_TX_GAS_LIMIT},
+            std::move(entry)));
     }
 
     void setNonce(std::string_view sender, std::string nonce)
@@ -953,6 +970,9 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
 struct DepositRecordingExecutor : StubExecutor
 {
     std::vector<bytes> executedDeposits;
+    /// gasUsed each executed deposit reports. Raised by the gas-budget tests so the
+    /// deposits consume (or overrun) the whole block gas limit.
+    u256 depositGasUsed{21000};
 
     template <class Storage>
     task::Task<protocol::TransactionReceipt::Ptr> executeDeposit(Storage& /*storage*/,
@@ -961,7 +981,7 @@ struct DepositRecordingExecutor : StubExecutor
     {
         executedDeposits.emplace_back(rawDeposit.begin(), rawDeposit.end());
         auto inner = std::make_shared<bcostars::TransactionReceipt>();
-        inner->data.gasUsed = "21000";
+        inner->data.gasUsed = depositGasUsed.str();
         auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>(
             [inner]() mutable { return inner.get(); });
         Keccak256 hasher;
@@ -1005,6 +1025,136 @@ BOOST_AUTO_TEST_CASE(build_payload_executes_forced_deposits)
     BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 2);
     BOOST_CHECK(payload->executionPayload.transactions[0].raw ==
                 (bytes{0x7e, 0x01, 0x02, 0x03, 0x04, 0x05}));
+}
+
+/// Mixed block: a deposit that consumes most of the block gas limit and a pool
+/// transaction coexist. The deposit's gas enters the block totals (Step 2f sums over
+/// deposits AND scheduler receipts), the block stays inside its own limit, and nothing is
+/// dropped -- the guard judges the total, it does not ration admission.
+BOOST_AUTO_TEST_CASE(build_payload_counts_deposit_gas_in_the_block_totals)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    constexpr uint64_t c_blockGasLimit = ledger::DEFAULT_GAS_LIMIT;
+    globalStateStorageFixture.setGasLimit(c_blockGasLimit);
+    std::string sender("9999999999aaaaaaaaaa", 20);
+    auto poolTx = makeWeb3Tx(sender, 0, /*gasLimit=*/21000);
+    memPool.add(std::vector{poolTx});
+    globalStateStorageFixture.setNonce(sender, "0");
+
+    auto attributes = makePayloadAttributesV3();
+    attributes.transactions = std::vector<std::string>{"0x7e0102030405"};
+
+    DepositRecordingExecutor executor;
+    executor.depositGasUsed = u256(c_blockGasLimit - 1000);
+    StubScheduler scheduler;
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, DepositRecordingExecutor, StubScheduler>
+        engineService(
+            memPool, globalStateStorageFixture.storage, executor, scheduler, blockFactory);
+
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+
+    // Both entries ride the payload: the forced deposit and the sealed transaction.
+    BOOST_REQUIRE_EQUAL(executor.executedDeposits.size(), 1);
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 2);
+    BOOST_CHECK(payload->executionPayload.transactions[0].decoded == nullptr);
+    BOOST_CHECK(payload->executionPayload.transactions[1].decoded == poolTx);
+    // The deposit's gas is in the block totals, and the block stays legal.
+    BOOST_CHECK_EQUAL(payload->executionPayload.gasLimit, c_blockGasLimit);
+    BOOST_CHECK_EQUAL(payload->executionPayload.gasUsed, u256(c_blockGasLimit - 1000));
+    BOOST_CHECK(payload->executionPayload.gasUsed <= payload->executionPayload.gasLimit);
+}
+
+/// Anti-starvation regression. A transaction declaring the ENTIRE block gas limit must not
+/// cost any other transaction its slot. This is why buildPayload only judges the block's
+/// total and never reserves a transaction's declared gasLimit up front: nothing bounds a
+/// declared gasLimit on the way in (EthEndpoint checks signature and chainId, MemPoolImpl
+/// hash and nonce), and such a transaction is rejected WITHOUT executing, so its nonce
+/// never advances and MemPoolImpl::remove — which prunes strictly by nonce — can never
+/// evict it. A reserve-up-front scheme would let one free eth_sendRawTransaction consume
+/// the budget of every future block forever.
+BOOST_AUTO_TEST_CASE(build_payload_does_not_let_one_huge_gaslimit_starve_other_senders)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    globalStateStorageFixture.setGasLimit(ledger::DEFAULT_GAS_LIMIT);
+
+    // The hog declares the entire block gas limit; the ordinary transaction is a plain
+    // 21000-gas transfer from a DIFFERENT sender.
+    std::string hogSender("11111111111111111111", 20);
+    std::string plainSender("22222222222222222222", 20);
+    auto hogTx = makeWeb3Tx(hogSender, 0, /*gasLimit=*/ledger::DEFAULT_GAS_LIMIT);
+    auto plainTx = makeWeb3Tx(plainSender, 0, /*gasLimit=*/21000);
+    memPool.add(std::vector{hogTx, plainTx});
+    globalStateStorageFixture.setNonce(hogSender, "0");
+    globalStateStorageFixture.setNonce(plainSender, "0");
+
+    auto attributes = makePayloadAttributesV3();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+
+    // BOTH transactions ride the payload. The hog's declared 3e9 gas costs the other
+    // sender nothing, because no budget is reserved from a declaration — only the
+    // resulting total is judged. seal() visits senders through a hashed index, so the
+    // order is not fixed; assert membership rather than position.
+    auto const& transactions = payload->executionPayload.transactions;
+    BOOST_REQUIRE_EQUAL(transactions.size(), 2);
+    bool hogPresent = false;
+    bool plainPresent = false;
+    for (auto const& engineTx : transactions)
+    {
+        hogPresent = hogPresent || engineTx.decoded == hogTx;
+        plainPresent = plainPresent || engineTx.decoded == plainTx;
+    }
+    BOOST_CHECK(hogPresent);
+    BOOST_CHECK(plainPresent);
+    // And the block still respects its own limit.
+    BOOST_CHECK(payload->executionPayload.gasUsed <= payload->executionPayload.gasLimit);
+}
+
+/// Forced deposits that alone overrun the block gas limit are a block-level error: the
+/// builder refuses the payload instead of emitting a block whose gasUsed exceeds its own
+/// gasLimit. op-geth reaches the same verdict — SubGas's ErrGasLimitReached is excluded
+/// from the failed-deposit salvage branch (core/state_transition.go:486).
+BOOST_AUTO_TEST_CASE(build_payload_rejects_deposits_over_the_block_gas_limit)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    globalStateStorageFixture.setGasLimit(ledger::DEFAULT_GAS_LIMIT);
+    auto attributes = makePayloadAttributesV3();
+    // Two deposits, each reporting two thirds of the block gas limit.
+    attributes.transactions = std::vector<std::string>{"0x7e0102030405", "0x7e0607080910"};
+
+    DepositRecordingExecutor executor;
+    executor.depositGasUsed = u256(ledger::DEFAULT_GAS_LIMIT / 3 * 2);
+    StubScheduler scheduler;
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, DepositRecordingExecutor, StubScheduler>
+        engineService(
+            memPool, globalStateStorageFixture.storage, executor, scheduler, blockFactory);
+
+    BOOST_CHECK_THROW(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3)),
+        bcos::engine::BlockGasLimitExceeded);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -946,4 +946,65 @@ BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
     }
 }
 
+/// A stub executor that additionally provides the OP deposit entry: buildPayload's
+/// Step 2c-0 gate (if constexpr requires executeDeposit) compiles the deposit lane
+/// in, must call it for raw-only 0x7e entries — and only those — and prepends the
+/// returned receipt.
+struct DepositRecordingExecutor : StubExecutor
+{
+    std::vector<bytes> executedDeposits;
+
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeDeposit(Storage& /*storage*/,
+        const protocol::BlockHeader& /*blockHeader*/, bcos::bytesConstRef rawDeposit,
+        const ledger::LedgerConfig& /*ledgerConfig*/)
+    {
+        executedDeposits.emplace_back(rawDeposit.begin(), rawDeposit.end());
+        auto inner = std::make_shared<bcostars::TransactionReceipt>();
+        inner->data.gasUsed = "21000";
+        auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>(
+            [inner]() mutable { return inner.get(); });
+        Keccak256 hasher;
+        receipt->calculateHash(hasher);
+        co_return receipt;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(build_payload_executes_forced_deposits)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+
+    // One forced deposit and one forced non-deposit (typed raw): only the deposit
+    // reaches executeDeposit; the typed raw entry still has no execution wiring.
+    auto attributes = makePayloadAttributesV3();
+    attributes.transactions = std::vector<std::string>{"0x7e0102030405", "0x02f8aabb"};
+
+    DepositRecordingExecutor executor;
+    StubScheduler scheduler;
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, DepositRecordingExecutor, StubScheduler>
+        engineService(
+            memPool, globalStateStorageFixture.storage, executor, scheduler, blockFactory);
+
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+
+    // Exactly the deposit's raw bytes were executed.
+    BOOST_REQUIRE_EQUAL(executor.executedDeposits.size(), 1);
+    BOOST_CHECK(executor.executedDeposits[0] == (bytes{0x7e, 0x01, 0x02, 0x03, 0x04, 0x05}));
+    // The deposit receipt participates in the block totals (StubScheduler
+    // contributes no receipts, so the gas total is the deposit's alone).
+    BOOST_CHECK_EQUAL(payload->executionPayload.gasUsed, u256(21000));
+    // Both forced entries still ride the payload raw, byte-for-byte.
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 2);
+    BOOST_CHECK(payload->executionPayload.transactions[0].raw ==
+                (bytes{0x7e, 0x01, 0x02, 0x03, 0x04, 0x05}));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/ethereum-executor/CMakeLists.txt
+++ b/ethereum-executor/CMakeLists.txt
@@ -7,12 +7,17 @@ find_package(TBB CONFIG REQUIRED)
 add_library(ethereum-executor
     EthereumExecutor.cpp
     EVMPrecompiles.cpp
+    OpStackTransition.cpp
 )
 target_include_directories(ethereum-executor PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/ethereum-executor>)
+# bcosevm::opstack: the OP Stack lane calls bcos-evm's opTransition/runDeposit
+# directly (single consensus implementation, see OpStackTransition.h).
+# protocol-tars: reassembleWeb3RawTransaction (the signed envelope the L1 data
+# fee is priced over). codec: the RLP primitives of the 0x7E deposit decoder.
 target_link_libraries(ethereum-executor PUBLIC
-    bcos-framework bcos-protocol
+    bcos-framework bcos-protocol bcosevm::opstack codec protocol-tars
     evmone::evmone evmone::precompiles intx::intx TBB::tbb)
 set_target_properties(ethereum-executor PROPERTIES UNITY_BUILD OFF)
 

--- a/ethereum-executor/EthereumExecutor.h
+++ b/ethereum-executor/EthereumExecutor.h
@@ -27,12 +27,14 @@
 #pragma once
 
 #include "EthereumTransition.h"
-#include "bcos-framework/storage2/RollbackableStorage.h"
+#include "OpStackTransition.h"
+#include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
 #include "bcos-framework/protocol/BlockHeader.h"
 #include "bcos-framework/protocol/Transaction.h"
 #include "bcos-framework/protocol/TransactionReceipt.h"
 #include "bcos-framework/protocol/TransactionReceiptFactory.h"
+#include "bcos-framework/storage2/RollbackableStorage.h"
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-task/TBBWait.h"
 #include <bcos-utilities/Exceptions.h>
@@ -154,6 +156,59 @@ public:
             }
             std::rethrow_exception(failure);
         }
+    }
+
+    /// Execute one OP Stack 0x7E deposit from its raw EIP-2718 envelope
+    /// (OP Stack lane; deposits are consensus-injected via the Engine payload
+    /// attributes and never exist as protocol::Transaction). Throws on a
+    /// malformed envelope or a block-level deposit rejection (is_system_tx,
+    /// 20M gas cap, block gas) — an invalid deposit invalidates the payload.
+    /// Same all-or-nothing storage guarantee as execute(): the journal rolls
+    /// every write back before the exception propagates.
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeDeposit(Storage& storage,
+        protocol::BlockHeader const& blockHeader, bcos::bytesConstRef rawDeposit,
+        ledger::LedgerConfig const& ledgerConfig)
+    {
+        auto revOpt = ledgerConfig.evmcRevisionForBlock(blockHeader.number());
+        if (!revOpt.has_value())
+        {
+            BOOST_THROW_EXCEPTION(
+                EvmcRevisionNotConfigured() << errinfo_comment("evmcRevision not configured"));
+        }
+        auto blockInfo = buildBlockInfo(blockHeader, ledgerConfig, *revOpt);
+        uint64_t chainId = 0;
+        if (auto const& cid = ledgerConfig.chainId(); cid.has_value())
+        {
+            chainId = static_cast<uint64_t>(intx::be::load<intx::uint256>(*cid));
+        }
+
+        Rollbackable<Storage> rollable(storage);
+        const auto savepoint = rollable.current();
+        std::exception_ptr failure;
+        protocol::TransactionReceipt::Ptr receipt;
+        try
+        {
+            receipt = co_await executeOpStackDeposit(rollable, blockInfo, m_blockHashLookup,
+                rawDeposit, m_vm, chainId, m_receiptFactory, blockHeader.number());
+        }
+        catch (...)
+        {
+            failure = std::current_exception();
+        }
+        if (failure)
+        {
+            try
+            {
+                co_await rollable.rollback(savepoint);
+            }
+            catch (...)
+            {
+                // Ignore the cleanup error; the original failure wins.
+            }
+            std::rethrow_exception(failure);
+        }
+        co_return receipt;
     }
 
     // TransactionExecutor concept support: ExecuteContext
@@ -283,7 +338,8 @@ public:
                 //   state read, so it is resolved in execute() (the only
                 //   phase allowed to touch state).
             }
-            m_blobGasLeft = static_cast<int64_t>(evm::max_blob_gas_per_block(blobParamsForRevision(m_rev)));
+            m_blobGasLeft =
+                static_cast<int64_t>(evm::max_blob_gas_per_block(blobParamsForRevision(m_rev)));
             co_return;
         }
 
@@ -343,39 +399,55 @@ public:
 
             try
             {
-                if (call && transaction.get().nonce().empty())
+                // OP Stack lane (feature_l2_ethereum_compat): real execution runs
+                // under Karst semantics — L1 data fee, operator fee, fee vault
+                // routing, precompile overrides — through bcos-evm's opTransition
+                // (see OpStackTransition.h). The eth_call dry-run (call == true)
+                // stays on the pure-Ethereum lane: a dry run is never charged, so
+                // the OP fee assembly has nothing to price (geth's eth_call skips
+                // the L1 fee the same way).
+                if (!call && ledgerConfig.get().features().get(
+                                 ledger::Features::Flag::feature_l2_ethereum_compat))
                 {
-                    // Resolve the sender's current nonce for the eth_call shape
-                    // (0 would fail NONCE_TOO_LOW for a sender past its first tx).
-                    auto senderAcc = state.find(ethSender(transaction.get()));
-                    m_callParams.nonce = senderAcc ? senderAcc->nonce : 0;
-                }
-
-                auto validationResult = validateTransaction(state, m_blockInfo, transaction.get(),
-                    m_rev, m_blockInfo.gas_limit /*block_gas_left*/,
-                    m_blobGasLeft /*blob_gas_left*/, m_callParams);
-                if (auto* props = std::get_if<EthTxProperties>(&validationResult))
-                {
-                    // Valid against the current state — use the computed properties.
-                    // NOTE: we do not special-case SENDER_NOT_EOA here. EIP-3607
-                    // requires rejecting transactions whose sender has non-delegating
-                    // code; only accounts with empty code or a 0xef0100 delegation
-                    // designator may be senders, which validate_transaction already
-                    // accepts.
-                    m_receipt = co_await runTransaction(state, m_blockInfo,
-                        executor.get().m_blockHashLookup, transaction.get(), m_rev,
-                        executor.get().m_vm, *props, nodeChainId(), m_callParams,
-                        executor.get().m_receiptFactory, blockHeader.get().number());
+                    m_receipt = co_await executeOpStackTransaction(rollable, m_blockInfo,
+                        executor.get().m_blockHashLookup, transaction.get(), executor.get().m_vm,
+                        nodeChainId(), executor.get().m_receiptFactory, blockHeader.get().number());
                 }
                 else
                 {
-                    // Genuinely invalid — skip execution; finish() produces a
-                    // failure receipt and nothing is written for this transaction.
-                    m_validationError = std::get<std::error_code>(validationResult);
-                    BCOS_LOG(INFO) << LOG_BADGE("EXECUTE")
-                                   << LOG_DESC("tx validation failed")
-                                   << LOG_KV("error", m_validationError.value().message())
-                                   << LOG_KV("code", m_validationError.value().value());
+                    if (call && transaction.get().nonce().empty())
+                    {
+                        // Resolve the sender's current nonce for the eth_call shape
+                        // (0 would fail NONCE_TOO_LOW for a sender past its first tx).
+                        auto senderAcc = state.find(ethSender(transaction.get()));
+                        m_callParams.nonce = senderAcc ? senderAcc->nonce : 0;
+                    }
+
+                    auto validationResult = validateTransaction(state, m_blockInfo,
+                        transaction.get(), m_rev, m_blockInfo.gas_limit /*block_gas_left*/,
+                        m_blobGasLeft /*blob_gas_left*/, m_callParams);
+                    if (auto* props = std::get_if<EthTxProperties>(&validationResult))
+                    {
+                        // Valid against the current state — use the computed properties.
+                        // NOTE: we do not special-case SENDER_NOT_EOA here. EIP-3607
+                        // requires rejecting transactions whose sender has non-delegating
+                        // code; only accounts with empty code or a 0xef0100 delegation
+                        // designator may be senders, which validate_transaction already
+                        // accepts.
+                        m_receipt = co_await runTransaction(state, m_blockInfo,
+                            executor.get().m_blockHashLookup, transaction.get(), m_rev,
+                            executor.get().m_vm, *props, nodeChainId(), m_callParams,
+                            executor.get().m_receiptFactory, blockHeader.get().number());
+                    }
+                    else
+                    {
+                        // Genuinely invalid — skip execution; finish() produces a
+                        // failure receipt and nothing is written for this transaction.
+                        m_validationError = std::get<std::error_code>(validationResult);
+                        BCOS_LOG(INFO) << LOG_BADGE("EXECUTE") << LOG_DESC("tx validation failed")
+                                       << LOG_KV("error", m_validationError.value().message())
+                                       << LOG_KV("code", m_validationError.value().value());
+                    }
                 }
             }
             catch (...)

--- a/ethereum-executor/OpStackBridge.h
+++ b/ethereum-executor/OpStackBridge.h
@@ -1,0 +1,292 @@
+/// @file OpStackBridge.h
+/// @brief Bridge between BCOS storage and bcos-evm's evmone::state::StateView /
+///        BlockHashes / StateDiff interfaces, for the OP Stack execution lane.
+///
+/// The pure-Ethereum lane executes natively against BCOS storage
+/// (EthereumState / EthereumTransition — no StateView involved). The OP lane
+/// deliberately does NOT re-port the OP transition semantics: opValidate /
+/// opTransition / runDeposit in bcos-evm/opstack are the single consensus
+/// implementation (fee vault routing, deposit failure semantics, operator-fee
+/// conservation), and re-porting them here would create a second copy to keep
+/// in sync. Instead this header bridges the executor's coroutine storage to
+/// the synchronous StateView those functions consume (reads via
+/// task::tbb::syncWait, fail-safe: a failed read reports "absent / empty"),
+/// and applies the resulting StateDiff back to BCOS storage.
+///
+/// Promoted from the EEST runner's test-only bridge (tests/TestStorageBridge.h
+/// now forwards here): the OP lane made it production code.
+
+#pragma once
+
+#include "EthereumHost.h"   // BlockHashLookup / EthBlockInfo
+#include "EthereumState.h"  // evm::toBcosU256 / evm::keccak256 / eth::clearAccountStorage
+#include "bcos-evm/eth/state/state_diff.hpp"
+#include "bcos-evm/eth/state/state_view.hpp"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-task/TBBWait.h"
+#include <evmc/evmc.h>
+#include <atomic>
+#include <functional>
+#include <optional>
+
+namespace bcos::executor_v1::eth
+{
+
+/// A read-only evmone::state::StateView backed by BCOS storage + EVMAccount.
+/// Synchronous (required by the StateView interface), bridged with
+/// task::tbb::syncWait.
+///
+/// The noexcept StateView interface cannot propagate a storage failure, so a
+/// throwing read answers "absent / empty" to keep execution moving AND latches
+/// readFailed() — the executed result was computed against fabricated state.
+/// Callers MUST check readFailed() before applying the resulting StateDiff and
+/// discard the execution when it is set; treating an I/O failure as "account
+/// does not exist / slot is zero" would otherwise persist a wrong receipt and
+/// state.
+template <class Storage>
+class StorageStateView : public evmone::state::StateView
+{
+public:
+    StorageStateView(Storage& storage) : m_storage(storage) {}
+
+    std::optional<evmone::state::StateView::Account> get_account(
+        const evmc::address& addr) const noexcept override
+    {
+        try
+        {
+            return task::tbb::syncWait(getAccountImpl(addr));
+        }
+        catch (...)
+        {
+            m_readFailed.store(true, std::memory_order_relaxed);
+            return std::nullopt;
+        }
+    }
+
+    evmc::bytes get_account_code(const evmc::address& addr) const noexcept override
+    {
+        try
+        {
+            return task::tbb::syncWait(getCodeImpl(addr));
+        }
+        catch (...)
+        {
+            m_readFailed.store(true, std::memory_order_relaxed);
+            return {};
+        }
+    }
+
+    evmc::bytes32 get_storage(
+        const evmc::address& addr, const evmc::bytes32& key) const noexcept override
+    {
+        try
+        {
+            return task::tbb::syncWait(getStorageImpl(addr, key));
+        }
+        catch (...)
+        {
+            m_readFailed.store(true, std::memory_order_relaxed);
+            return {};
+        }
+    }
+
+    /// True when any read above swallowed a storage failure — the answers given
+    /// since then are not the committed state.
+    [[nodiscard]] bool readFailed() const noexcept
+    {
+        return m_readFailed.load(std::memory_order_relaxed);
+    }
+
+private:
+    Storage& m_storage;
+    mutable std::atomic_bool m_readFailed{false};
+
+    task::Task<std::optional<evmone::state::StateView::Account>> getAccountImpl(
+        evmc_address addr) const
+    {
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+
+        EVMAccount<Storage> evmAccount(storage, addr, false);
+
+        if (!co_await evmAccount.exists())
+            co_return std::nullopt;
+
+        evmone::state::StateView::Account acc;
+        auto nonceVal = co_await evmAccount.nonce();
+        if (nonceVal.has_value())
+            acc.nonce = static_cast<uint64_t>(bcos::u256(nonceVal.value()));
+
+        acc.balance = evm::toIntxU256(co_await evmAccount.balance());
+
+        auto codeHashVal = co_await evmAccount.codeHash();
+        {
+            auto const* d = codeHashVal.data();
+            bool hasCodeHash = false;
+            for (size_t i = 0; i < 32; ++i)
+                if (d[i] != 0)
+                {
+                    hasCodeHash = true;
+                    break;
+                }
+            if (hasCodeHash)
+                std::copy_n(d, sizeof(evmc_bytes32), acc.code_hash.bytes);
+            else
+                acc.code_hash = EthAccount::EMPTY_CODE_HASH;
+        }
+
+        acc.has_storage = co_await hasStorageImpl(evmAccount);
+        co_return acc;
+    }
+
+    task::Task<bool> hasStorageImpl(bcos::ledger::account::EVMAccount<Storage>& evmAccount) const
+    {
+        using namespace bcos::ledger;
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+        auto tableName = co_await evmAccount.path();
+
+        bool hasStorage = false;
+        auto it = co_await storage2::range(
+            storage, storage2::RANGE_SEEK, executor_v1::StateKey{tableName, std::string_view{}});
+
+        while (auto kv = co_await it.next())
+        {
+            auto const& [k, v] = *kv;
+            executor_v1::StateKeyView view(k);
+            if (view.m_table != tableName)
+                break;  // Left this account's table.
+
+            auto key = view.m_key;
+            if (key != ACCOUNT_TABLE_FIELDS::NONCE && key != ACCOUNT_TABLE_FIELDS::BALANCE &&
+                key != ACCOUNT_TABLE_FIELDS::CODE_HASH && key != ACCOUNT_TABLE_FIELDS::CODE &&
+                key != ACCOUNT_TABLE_FIELDS::ABI && key != ACCOUNT_TABLE_FIELDS::ALIVE &&
+                key != ACCOUNT_TABLE_FIELDS::FROZEN && key != ACCOUNT_TABLE_FIELDS::SHARD)
+            {
+                hasStorage = true;
+                break;
+            }
+        }
+        co_return hasStorage;
+    }
+
+    task::Task<evmc::bytes> getCodeImpl(evmc_address addr) const
+    {
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+        EVMAccount<Storage> evmAccount(storage, addr, false);
+
+        if (!co_await evmAccount.exists())
+            co_return {};
+
+        auto codeEntry = co_await evmAccount.code();
+        if (!codeEntry.has_value())
+            co_return {};
+
+        auto view = codeEntry->get();
+        co_return evmc::bytes(view.begin(), view.end());
+    }
+
+    task::Task<evmc::bytes32> getStorageImpl(evmc_address addr, evmc_bytes32 key) const
+    {
+        using namespace bcos::ledger::account;
+        auto& storage = const_cast<Storage&>(m_storage);
+        EVMAccount<Storage> evmAccount(storage, addr, false);
+
+        // SLOAD on a non-existent account returns 0 per EVM spec.
+        co_return co_await evmAccount.storage(key);
+    }
+};
+
+/// evmone::state::BlockHashes over the executor's injected BlockHashLookup
+/// (BLOCKHASH opcode). An absent lookup — or one that throws — reports the
+/// zero hash ("unknown block"), matching the pure-Ethereum lane's fail-safe.
+class LookupBlockHashes final : public evmone::state::BlockHashes
+{
+public:
+    LookupBlockHashes(BlockHashLookup const& lookup, int64_t currentHeight) noexcept
+      : m_lookup(lookup), m_currentHeight(currentHeight)
+    {}
+
+    evmc::bytes32 get_block_hash(int64_t blockNumber) const noexcept override
+    {
+        if (!m_lookup)
+            return {};
+        try
+        {
+            return m_lookup(blockNumber, m_currentHeight);
+        }
+        catch (...)
+        {
+            return {};
+        }
+    }
+
+private:
+    BlockHashLookup const& m_lookup;
+    int64_t m_currentHeight;
+};
+
+/// Write a bcos-evm StateDiff back to BCOS storage. Code hashing is
+/// keccak256 (Ethereum consensus hashing), same as EthereumState's
+/// applyToStorage — see the "code hash algorithm" note there.
+template <class Storage>
+task::Task<void> applyEvmoneStateDiff(Storage& storage, evmone::state::StateDiff const& diff)
+{
+    using namespace bcos::ledger::account;
+
+    // Phase 1: Process modified_accounts FIRST so created accounts exist.
+    for (auto const& m : diff.modified_accounts)
+    {
+        EVMAccount<Storage> acc(storage, m.addr, false);
+        if (!co_await acc.exists())
+            co_await acc.create();
+        co_await acc.setNonce(std::to_string(m.nonce));
+        co_await acc.setBalance(evm::toBcosU256(m.balance));
+        if (m.code.has_value())
+        {
+            auto const& c = *m.code;
+            if (c.empty())
+            {
+                co_await acc.setCode(bcos::bytes{}, std::string{}, bcos::h256{});
+            }
+            else
+            {
+                bcos::bytes code(c.begin(), c.end());
+                const auto ch = evm::keccak256({code.data(), code.size()});
+                co_await acc.setCode(std::move(code), std::string{},
+                    bcos::h256{bcos::bytesConstRef(ch.bytes, sizeof(ch.bytes))});
+            }
+        }
+        for (auto const& [key, value] : m.modified_storage)
+            co_await acc.setStorage(key, value);
+    }
+
+    // Phase 2: deleted accounts, skipping addresses recreated in Phase 1.
+    for (auto const& addr : diff.deleted_accounts)
+    {
+        bool inModified = false;
+        for (auto const& m : diff.modified_accounts)
+        {
+            if (memcmp(m.addr.bytes, addr.bytes, sizeof(evmc_address)) == 0)
+            {
+                inModified = true;
+                break;
+            }
+        }
+        if (inModified)
+            continue;
+
+        EVMAccount<Storage> acc(storage, addr, false);
+        if (co_await acc.exists())
+        {
+            co_await acc.setBalance(0);
+            co_await acc.setNonce("0");
+            co_await acc.setCode(bcos::bytes{}, std::string{}, bcos::h256{});
+            co_await clearAccountStorage(storage, acc);
+        }
+    }
+}
+
+}  // namespace bcos::executor_v1::eth

--- a/ethereum-executor/OpStackTransition.cpp
+++ b/ethereum-executor/OpStackTransition.cpp
@@ -20,6 +20,48 @@
 namespace bcos::executor_v1::eth
 {
 
+const std::error_category& depositDecodeCategory() noexcept
+{
+    struct Category : std::error_category
+    {
+        [[nodiscard]] const char* name() const noexcept final { return "op-deposit-decode"; }
+
+        [[nodiscard]] std::string message(int ev) const noexcept final
+        {
+            switch (static_cast<DepositDecodeError>(ev))
+            {
+            case DepositDecodeError::WrongTypeByte:
+                return "not a 0x7e deposit envelope";
+            case DepositDecodeError::MalformedEnvelope:
+                return "malformed RLP envelope header (not a list)";
+            case DepositDecodeError::TrailingBytes:
+                return "trailing bytes after the deposit field list";
+            case DepositDecodeError::TruncatedBody:
+                return "truncated deposit field list";
+            case DepositDecodeError::MalformedField:
+                return "malformed deposit field (hash / address / data / integer)";
+            case DepositDecodeError::NonCanonicalInteger:
+                return "non-canonical integer (leading zero bytes)";
+            case DepositDecodeError::IntegerTooWide:
+                return "integer wider than the field allows";
+            case DepositDecodeError::NonCanonicalBool:
+                return "non-canonical bool for isSystemTx";
+            case DepositDecodeError::GasLimitOutOfRange:
+                return "gas does not fit int64";
+            }
+            return "unknown deposit decode error";
+        }
+    };
+
+    static const Category categoryInstance;
+    return categoryInstance;
+}
+
+std::error_code make_error_code(DepositDecodeError error) noexcept
+{
+    return {static_cast<int>(error), depositDecodeCategory()};
+}
+
 namespace
 {
 /// Strict RLP unsigned-integer read for the consensus-grade deposit decoder. decodeHeader
@@ -28,20 +70,31 @@ namespace
 /// @p maxBytes — the shared decode(UnsignedIntegral) silently wraps/truncates an over-long
 /// value — and must not start with a zero byte (canonical zero is the EMPTY payload, so an
 /// inline 0x00 is equally non-canonical: "rlp: non-canonical integer (leading zero bytes)").
-bool decodeStrictUint(bcos::bytesRef& from, size_t maxBytes, bcos::u256& out)
+/// Returns a default-constructed (success) error_code on acceptance.
+std::error_code decodeStrictUint(bcos::bytesRef& from, size_t maxBytes, bcos::u256& out)
 {
     using namespace bcos::codec::rlp;
     auto&& [error, header] = decodeHeader(from);
-    if (error != nullptr || header.isList || header.payloadLength > maxBytes)
+    if (error != nullptr || header.isList)
     {
-        return false;
+        // MalformedField, not MalformedEnvelope: this is an integer FIELD inside the list
+        // (mint / value / gas / isSystemTx), so reporting the outer envelope's code would
+        // point an operator at the wrong place.
+        return make_error_code(DepositDecodeError::MalformedField);
     }
+    if (header.payloadLength > maxBytes)
+    {
+        return make_error_code(DepositDecodeError::IntegerTooWide);
+    }
+    // The direct from[i] indexing below is in bounds: decodeHeader's last act is to reject
+    // a header announcing more payload than remains (RLPDecode.h, InputTooShort), which
+    // the MalformedField branch above already returned on.
     // For an inline single byte (< 0x80) decodeHeader leaves the byte in place as the
     // payload; for prefixed forms it has already consumed the header — either way the
     // payload starts at from[0].
     if (header.payloadLength >= 1 && from[0] == 0x00)
     {
-        return false;
+        return make_error_code(DepositDecodeError::NonCanonicalInteger);
     }
     out = 0;
     for (size_t i = 0; i < header.payloadLength; ++i)
@@ -49,7 +102,7 @@ bool decodeStrictUint(bcos::bytesRef& from, size_t maxBytes, bcos::u256& out)
         out = (out << 8) | from[i];
     }
     from = from.getCroppedData(header.payloadLength);
-    return true;
+    return {};
 }
 }  // namespace
 
@@ -57,11 +110,10 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     bcos::bytesConstRef rawDeposit)
 {
     using namespace bcos::codec::rlp;
-    const auto decodeError = std::make_error_code(std::errc::invalid_argument);
 
     if (rawDeposit.empty() || rawDeposit[0] != 0x7e)
     {
-        return decodeError;
+        return make_error_code(DepositDecodeError::WrongTypeByte);
     }
     // The bcos-codec rlp decode API only offers mutable-ref entry points (it re-slices the
     // ref as it consumes; it never writes through it, but the type demands a writable
@@ -71,13 +123,18 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     bcos::bytes buffer(rawDeposit.begin() + 1, rawDeposit.end());
     bcos::bytesRef in(buffer.data(), buffer.size());
 
+    // Consensus-grade: the envelope is exactly the type byte + one RLP list — trailing
+    // bytes after the list are rejected (the display decoder tolerates them).
     auto&& [headerError, header] = decodeHeader(in);
-    if (headerError != nullptr || !header.isList || header.payloadLength != in.size())
+    if (headerError != nullptr || !header.isList)
     {
-        // Consensus-grade: the envelope is exactly the type byte + one RLP list —
-        // trailing bytes after the list are rejected (the display decoder tolerates
-        // them).
-        return decodeError;
+        return make_error_code(DepositDecodeError::MalformedEnvelope);
+    }
+    // decodeHeader already rejected a list announcing more than remains, so a mismatch
+    // here can only be leftover bytes past the list's end.
+    if (header.payloadLength != in.size())
+    {
+        return make_error_code(DepositDecodeError::TrailingBytes);
     }
     bcos::bytesRef body(in.data(), header.payloadLength);
 
@@ -85,7 +142,7 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     bcos::Address from;
     if (decodeItems(body, sourceHash, from) != nullptr)
     {
-        return decodeError;
+        return make_error_code(DepositDecodeError::MalformedField);
     }
 
     bcos::evm::opstack::DepositTx deposit{};
@@ -96,7 +153,7 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     // Ethereum tx type).
     if (body.empty())
     {
-        return decodeError;
+        return make_error_code(DepositDecodeError::TruncatedBody);
     }
     if (body[0] == BYTES_HEAD_BASE)
     {
@@ -108,7 +165,7 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
         bcos::Address to;
         if (decode(body, to) != nullptr)
         {
-            return decodeError;
+            return make_error_code(DepositDecodeError::MalformedField);
         }
         evmc::address toAddr{};
         std::copy_n(to.data(), sizeof(evmc_address), toAddr.bytes);
@@ -118,7 +175,7 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     // `mint`: the empty RLP item = no mint (op-geth encodes a nil *big.Int that way).
     if (body.empty())
     {
-        return decodeError;
+        return make_error_code(DepositDecodeError::TruncatedBody);
     }
     if (body[0] == BYTES_HEAD_BASE)
     {
@@ -128,9 +185,9 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     else
     {
         bcos::u256 mint{0};
-        if (!decodeStrictUint(body, sizeof(evmc_bytes32), mint))
+        if (auto error = decodeStrictUint(body, sizeof(evmc_bytes32), mint))
         {
-            return decodeError;
+            return error;
         }
         deposit.mint = evm::toIntxU256(mint);
     }
@@ -142,20 +199,34 @@ std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     bcos::u256 gas{0};
     bcos::u256 isSystemTx{0};
     bcos::bytes input;
-    if (!decodeStrictUint(body, sizeof(evmc_bytes32), value) ||
-        !decodeStrictUint(body, sizeof(uint64_t), gas) || !decodeStrictUint(body, 1, isSystemTx) ||
-        isSystemTx > 1)
+    if (auto error = decodeStrictUint(body, sizeof(evmc_bytes32), value))
     {
-        return decodeError;
+        return error;
     }
-    if (decode(body, input) != nullptr || !body.empty())
+    if (auto error = decodeStrictUint(body, sizeof(uint64_t), gas))
     {
-        return decodeError;
+        return error;
+    }
+    if (auto error = decodeStrictUint(body, 1, isSystemTx))
+    {
+        return error;
+    }
+    if (isSystemTx > 1)
+    {
+        return make_error_code(DepositDecodeError::NonCanonicalBool);
+    }
+    if (decode(body, input) != nullptr)
+    {
+        return make_error_code(DepositDecodeError::MalformedField);
+    }
+    if (!body.empty())
+    {
+        return make_error_code(DepositDecodeError::TrailingBytes);
     }
     // Consensus-grade: gas must additionally fit an int64 (the executable gas_limit).
     if (gas > bcos::u256(std::numeric_limits<int64_t>::max()))
     {
-        return decodeError;
+        return make_error_code(DepositDecodeError::GasLimitOutOfRange);
     }
     deposit.value = evm::toIntxU256(value);
     deposit.gas_limit = static_cast<int64_t>(gas);

--- a/ethereum-executor/OpStackTransition.cpp
+++ b/ethereum-executor/OpStackTransition.cpp
@@ -1,0 +1,316 @@
+/// @file OpStackTransition.cpp
+/// @brief Out-of-line pieces of the OP Stack execution lane: the consensus-grade
+///        0x7E deposit decoder and the BCOS <-> evmone converters. The converter
+///        bodies follow the pre-split BCOS2Evmone.cpp (dropped by the pure-
+///        Ethereum split 4/4) — the OP lane re-needs them because it feeds
+///        bcos-evm's opTransition/runDeposit, which consume the evmone types.
+
+#include "OpStackTransition.h"
+
+#include "EthereumTransition.h"  // mapEvmcStatusToBcosStatus / safeFromHex helpers
+#include "bcos-framework/protocol/LogEntry.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-tars-protocol/protocol/Web3RawTransaction.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+
+namespace bcos::executor_v1::eth
+{
+
+namespace
+{
+/// Strict RLP unsigned-integer read for the consensus-grade deposit decoder. decodeHeader
+/// already enforces the canonical-size rules (0x81-prefixed single byte < 0x80, long-form
+/// length < 56); this adds op-geth's integer rules on top: the payload is at most
+/// @p maxBytes — the shared decode(UnsignedIntegral) silently wraps/truncates an over-long
+/// value — and must not start with a zero byte (canonical zero is the EMPTY payload, so an
+/// inline 0x00 is equally non-canonical: "rlp: non-canonical integer (leading zero bytes)").
+bool decodeStrictUint(bcos::bytesRef& from, size_t maxBytes, bcos::u256& out)
+{
+    using namespace bcos::codec::rlp;
+    auto&& [error, header] = decodeHeader(from);
+    if (error != nullptr || header.isList || header.payloadLength > maxBytes)
+    {
+        return false;
+    }
+    // For an inline single byte (< 0x80) decodeHeader leaves the byte in place as the
+    // payload; for prefixed forms it has already consumed the header — either way the
+    // payload starts at from[0].
+    if (header.payloadLength >= 1 && from[0] == 0x00)
+    {
+        return false;
+    }
+    out = 0;
+    for (size_t i = 0; i < header.payloadLength; ++i)
+    {
+        out = (out << 8) | from[i];
+    }
+    from = from.getCroppedData(header.payloadLength);
+    return true;
+}
+}  // namespace
+
+std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
+    bcos::bytesConstRef rawDeposit)
+{
+    using namespace bcos::codec::rlp;
+    const auto decodeError = std::make_error_code(std::errc::invalid_argument);
+
+    if (rawDeposit.empty() || rawDeposit[0] != 0x7e)
+    {
+        return decodeError;
+    }
+    // The bcos-codec rlp decode API only offers mutable-ref entry points (it re-slices the
+    // ref as it consumes; it never writes through it, but the type demands a writable
+    // span). Rather than const_cast the caller's buffer into one, decode from a local
+    // copy — deposit envelopes are small (bounded by OP payload attributes), so the copy
+    // is a few hundred bytes per deposit.
+    bcos::bytes buffer(rawDeposit.begin() + 1, rawDeposit.end());
+    bcos::bytesRef in(buffer.data(), buffer.size());
+
+    auto&& [headerError, header] = decodeHeader(in);
+    if (headerError != nullptr || !header.isList || header.payloadLength != in.size())
+    {
+        // Consensus-grade: the envelope is exactly the type byte + one RLP list —
+        // trailing bytes after the list are rejected (the display decoder tolerates
+        // them).
+        return decodeError;
+    }
+    bcos::bytesRef body(in.data(), header.payloadLength);
+
+    bcos::h256 sourceHash;
+    bcos::Address from;
+    if (decodeItems(body, sourceHash, from) != nullptr)
+    {
+        return decodeError;
+    }
+
+    bcos::evm::opstack::DepositTx deposit{};
+    std::copy_n(sourceHash.data(), sizeof(evmc_bytes32), deposit.source_hash.bytes);
+    std::copy_n(from.data(), sizeof(evmc_address), deposit.from.bytes);
+
+    // `to`: the empty RLP item = contract creation (same convention as every
+    // Ethereum tx type).
+    if (body.empty())
+    {
+        return decodeError;
+    }
+    if (body[0] == BYTES_HEAD_BASE)
+    {
+        deposit.to = std::nullopt;
+        body = body.getCroppedData(1);
+    }
+    else
+    {
+        bcos::Address to;
+        if (decode(body, to) != nullptr)
+        {
+            return decodeError;
+        }
+        evmc::address toAddr{};
+        std::copy_n(to.data(), sizeof(evmc_address), toAddr.bytes);
+        deposit.to = toAddr;
+    }
+
+    // `mint`: the empty RLP item = no mint (op-geth encodes a nil *big.Int that way).
+    if (body.empty())
+    {
+        return decodeError;
+    }
+    if (body[0] == BYTES_HEAD_BASE)
+    {
+        deposit.mint = std::nullopt;
+        body = body.getCroppedData(1);
+    }
+    else
+    {
+        bcos::u256 mint{0};
+        if (!decodeStrictUint(body, sizeof(evmc_bytes32), mint))
+        {
+            return decodeError;
+        }
+        deposit.mint = evm::toIntxU256(mint);
+    }
+
+    // Integer bounds mirror op-geth's DepositTx field types: mint/value are 256-bit
+    // (32 bytes), gas is a uint64 (8 bytes), isSystemTx is a bool whose only canonical
+    // encodings are the empty payload (false) and 0x01 (true).
+    bcos::u256 value{0};
+    bcos::u256 gas{0};
+    bcos::u256 isSystemTx{0};
+    bcos::bytes input;
+    if (!decodeStrictUint(body, sizeof(evmc_bytes32), value) ||
+        !decodeStrictUint(body, sizeof(uint64_t), gas) || !decodeStrictUint(body, 1, isSystemTx) ||
+        isSystemTx > 1)
+    {
+        return decodeError;
+    }
+    if (decode(body, input) != nullptr || !body.empty())
+    {
+        return decodeError;
+    }
+    // Consensus-grade: gas must additionally fit an int64 (the executable gas_limit).
+    if (gas > bcos::u256(std::numeric_limits<int64_t>::max()))
+    {
+        return decodeError;
+    }
+    deposit.value = evm::toIntxU256(value);
+    deposit.gas_limit = static_cast<int64_t>(gas);
+    deposit.is_system_tx = isSystemTx != 0;
+    deposit.data = evmc::bytes(input.begin(), input.end());
+    return deposit;
+}
+
+evmone::state::BlockInfo toEvmoneBlockInfo(EthBlockInfo const& blockInfo)
+{
+    evmone::state::BlockInfo info{};
+    info.number = blockInfo.number;
+    info.timestamp = blockInfo.timestamp;
+    info.gas_limit = blockInfo.gas_limit;
+    info.coinbase = blockInfo.coinbase;
+    info.difficulty = blockInfo.difficulty;
+    info.prev_randao = blockInfo.prev_randao;
+    info.base_fee = blockInfo.base_fee;
+    info.blob_gas_used = blockInfo.blob_gas_used;
+    info.excess_blob_gas = blockInfo.excess_blob_gas;
+    info.blob_base_fee = blockInfo.blob_base_fee;
+    return info;
+}
+
+evmone::state::Transaction toEvmoneTransaction(protocol::Transaction const& tx)
+{
+    evmone::state::Transaction evmTx{};
+    switch (tx.web3TypedTxKind())
+    {
+    case 0:
+        evmTx.type = evmone::state::Transaction::Type::legacy;
+        break;
+    case 1:
+        evmTx.type = evmone::state::Transaction::Type::access_list;
+        break;
+    case 2:
+        evmTx.type = evmone::state::Transaction::Type::eip1559;
+        break;
+    case 3:
+        evmTx.type = evmone::state::Transaction::Type::blob;
+        break;
+    case 4:
+        evmTx.type = evmone::state::Transaction::Type::set_code;
+        break;
+    default:
+        // Out-of-enum kinds keep the raw byte so opValidate's whitelist rejects
+        // them (its type check runs before anything else).
+        evmTx.type = static_cast<evmone::state::Transaction::Type>(tx.web3TypedTxKind());
+        break;
+    }
+    auto const& input = tx.input();
+    evmTx.data = evmc::bytes(input.begin(), input.end());
+    evmTx.gas_limit = tx.gasLimit();
+    if (auto gp = tx.gasPrice(); gp.has_value())
+        evmTx.max_gas_price = evm::toIntxU256(*gp);
+    if (auto mf = tx.maxFeePerGas(); mf.has_value())
+        evmTx.max_gas_price = evm::toIntxU256(*mf);
+    if (auto mp = tx.maxPriorityFeePerGas(); mp.has_value())
+        evmTx.max_priority_gas_price = evm::toIntxU256(*mp);
+    if (auto mb = tx.maxFeePerBlobGas(); mb.has_value())
+        evmTx.max_blob_gas_price = evm::toIntxU256(*mb);
+
+    // For legacy/access_list txs (no explicit maxPriorityFeePerGas in the signed
+    // RLP) the whole gas price is the tip above the base fee — decided on the
+    // kind, same as ethMaxPriorityGasPrice in the pure-Ethereum lane.
+    if ((evmTx.type == evmone::state::Transaction::Type::legacy ||
+            evmTx.type == evmone::state::Transaction::Type::access_list))
+        evmTx.max_priority_gas_price = evmTx.max_gas_price;
+
+    evmTx.sender = ethSender(tx);
+    evmTx.to = ethToAddress(tx);
+    evmTx.value = evm::toIntxU256(tx.value());
+    for (auto const& entry : tx.web3AccessList())
+    {
+        evmc_address addr{};
+        std::copy_n(entry.account.begin(), sizeof(evmc_address), addr.bytes);
+        std::vector<evmc::bytes32> keys;
+        for (auto const& sk : entry.storageKeys)
+        {
+            evmc_bytes32 key{};
+            std::copy_n(sk.begin(), sizeof(evmc_bytes32), key.bytes);
+            keys.push_back(key);
+        }
+        evmTx.access_list.emplace_back(addr, std::move(keys));
+    }
+    for (auto const& h : tx.blobVersionedHashes())
+    {
+        evmc_bytes32 hash{};
+        std::copy_n(h.begin(), sizeof(evmc_bytes32), hash.bytes);
+        evmTx.blob_hashes.push_back(hash);
+    }
+    // Parsed strictly and non-throwing (see the pure-Ethereum lane's
+    // effectiveNonce): a malformed value falls through to 0, which the signature
+    // check upstream already rejected for signed inputs.
+    evmTx.chain_id = bcos::safeFromQuantity(tx.chainId()).value_or(0);
+    evmTx.nonce = bcos::safeFromQuantity(tx.nonce()).value_or(0);
+    for (auto const& auth : tx.authorizationList())
+    {
+        evmone::state::Authorization ea{};
+        ea.chain_id = evm::toIntxU256(bcos::u256(auth.chainId));
+        std::copy_n(auth.address.begin(), sizeof(evmc_address), ea.addr.bytes);
+        ea.nonce = auth.nonce;
+        if (auth.signer.size() == sizeof(evmc_address))
+        {
+            evmc_address sa{};
+            std::copy_n(auth.signer.begin(), sizeof(evmc_address), sa.bytes);
+            ea.signer = sa;
+        }
+        ea.r = evm::toIntxU256(auth.r);
+        ea.s = evm::toIntxU256(auth.s);
+        ea.v = evm::toIntxU256(bcos::u256(auth.v));
+        evmTx.authorization_list.push_back(std::move(ea));
+    }
+    return evmTx;
+}
+
+protocol::TransactionReceipt::Ptr toBcosReceipt(evmone::state::TransactionReceipt const& receipt,
+    protocol::TransactionReceiptFactory const& receiptFactory, int64_t blockNumber)
+{
+    std::vector<protocol::LogEntry> logs;
+    logs.reserve(receipt.logs.size());
+    for (auto const& l : receipt.logs)
+    {
+        bcos::bytes addr(l.addr.bytes, l.addr.bytes + sizeof(evmc_address));
+        bcos::h256s topics;
+        for (auto const& t : l.topics)
+            topics.emplace_back(bcos::bytesConstRef(t.bytes, sizeof(evmc_bytes32)));
+        bcos::bytes data(l.data.begin(), l.data.end());
+        logs.emplace_back(std::move(addr), std::move(topics), std::move(data));
+    }
+    // evmone's receipt does not carry output data (return data is consumed during
+    // execution), matching the pure-Ethereum lane's documented limitation.
+    bcos::bytes output;
+    return receiptFactory.createReceipt(bcos::u256(static_cast<uint64_t>(receipt.gas_used)),
+        std::string{}, logs, mapEvmcStatusToBcosStatus(receipt.status), bcos::ref(output),
+        blockNumber);
+}
+
+bcos::bytes signedTxEnvelope(protocol::Transaction const& transaction)
+{
+    if (transaction.type() != static_cast<uint8_t>(protocol::TransactionType::Web3Transaction))
+    {
+        return {};
+    }
+    try
+    {
+        return bcostars::protocol::reassembleWeb3RawTransaction(
+            transaction.extraTransactionBytes(), transaction.signatureData());
+    }
+    catch (std::invalid_argument const&)
+    {
+        // No decodable wire form — the empty envelope makes opValidate reject the
+        // transaction instead of pricing its L1 fee over garbage.
+        return {};
+    }
+}
+
+}  // namespace bcos::executor_v1::eth

--- a/ethereum-executor/OpStackTransition.h
+++ b/ethereum-executor/OpStackTransition.h
@@ -45,12 +45,44 @@ DERIVE_BCOS_EXCEPTION(OpStateReadFailed);
 protocol::TransactionReceipt::Ptr validationErrorReceipt(std::error_code const& error,
     protocol::TransactionReceiptFactory const& rf, int64_t blockNumber);
 
+/// Why a 0x7e envelope failed to decode. Every value is a REJECT and which one it is
+/// changes nothing about that verdict — the codes exist purely so the rejection can be
+/// read. Collapsing them all into std::errc::invalid_argument made
+/// InvalidDepositTransaction report "Invalid argument" for a wrong type byte, a
+/// truncated field and a non-canonical integer alike, with nothing in the log to tell an
+/// operator which one stalled the payload.
+enum class DepositDecodeError : int
+{
+    WrongTypeByte = 1,    ///< Empty input, or the first byte is not 0x7e.
+    MalformedEnvelope,    ///< The outer RLP header is undecodable or is not a list.
+    TrailingBytes,        ///< Bytes remain after the RLP list / after the final field.
+    TruncatedBody,        ///< A field is missing: the list ran out mid-way.
+    MalformedField,       ///< An item's RLP is undecodable or the wrong width — a hash,
+                          ///< an address, the data blob, or an integer field whose own
+                          ///< header will not decode.
+    NonCanonicalInteger,  ///< Integer payload starts with a zero byte (canonical zero is
+                          ///< the empty payload).
+    IntegerTooWide,       ///< Integer payload exceeds the field's width (mint/value 32
+                          ///< bytes, gas 8, isSystemTx 1).
+    NonCanonicalBool,     ///< isSystemTx is neither 0x80 (false) nor 0x01 (true).
+    GasLimitOutOfRange,   ///< gas does not fit the executable int64 gas_limit.
+};
+
+/// Category for DepositDecodeError, in the same shape as evm_error_category()
+/// (EVMSupport.h). Defined in OpStackTransition.cpp.
+const std::error_category& depositDecodeCategory() noexcept;
+
+/// Creates an error_code out of a deposit-decode error value.
+std::error_code make_error_code(DepositDecodeError error) noexcept;
+
 /// Decode a raw `0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTx,
 /// data])` envelope into the executable DepositTx. Consensus-grade, unlike the
 /// display decoder in bcos-rpc (DepositTransaction.h): the envelope must be fully
 /// consumed (no trailing bytes after the RLP list), integer fields follow op-geth's
 /// canonical rules (no leading zeros, mint/value <= 32 bytes, gas <= 8 bytes and
-/// int64, isSystemTx only 0x80/0x01). Defined in OpStackTransition.cpp.
+/// int64, isSystemTx only 0x80/0x01). The failure value is a DepositDecodeError-coded
+/// error_code; the set of accepted envelopes does not depend on it. Defined in
+/// OpStackTransition.cpp.
 std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
     bcos::bytesConstRef rawDeposit);
 

--- a/ethereum-executor/OpStackTransition.h
+++ b/ethereum-executor/OpStackTransition.h
@@ -1,0 +1,163 @@
+/// @file OpStackTransition.h
+/// @brief OP Stack (Karst) per-transaction execution lane of the executor.
+///
+/// Normal (non-deposit) transactions run through bcos-evm's opValidate /
+/// opTransition — L1 data fee (FastLZ), operator fee, base/L1/operator fee
+/// vault routing, Karst precompile overrides — and 0x7E deposits run through
+/// runDeposit. Those functions are the single consensus implementation of the
+/// OP semantics (see OpStackBridge.h for why they are bridged rather than
+/// re-ported); this header converts the BCOS-side inputs (protocol::Transaction,
+/// EthBlockInfo) to their evmone-side twins, feeds them through, applies the
+/// resulting StateDiff to BCOS storage and produces the BCOS receipt.
+///
+/// Fee parameters are read from the OP_L1_BLOCK predeploy storage slots
+/// (opValidateFromState -> loadOpFeeParams) through the same StateView the
+/// transaction executes against.
+///
+/// Per-transaction lane ONLY: block-level coordination (EIP-4788/2935 system
+/// calls, block gas accounting across transactions, receipt/DA roots) is the
+/// block-lifecycle layer's job, not this header's.
+
+#pragma once
+
+#include "OpStackBridge.h"
+#include "bcos-evm/opstack/OpForkSchedule.h"
+#include "bcos-evm/opstack/OpTransition.h"
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-framework/protocol/TransactionReceipt.h"
+#include "bcos-framework/protocol/TransactionReceiptFactory.h"
+#include <bcos-utilities/Exceptions.h>
+#include <evmc/evmc.hpp>
+#include <system_error>
+#include <variant>
+
+namespace bcos::executor_v1::eth
+{
+
+DERIVE_BCOS_EXCEPTION(InvalidDepositTransaction);
+/// A StorageStateView read swallowed a storage failure (see readFailed()): the execution
+/// result was computed against fabricated state and is discarded via the caller's
+/// rollback/rethrow path.
+DERIVE_BCOS_EXCEPTION(OpStateReadFailed);
+
+// Declared in EthereumExecutor.h (defined in EthereumExecutor.cpp); redeclared here to
+// avoid a circular include — EthereumExecutor.h includes this header for the dispatch.
+protocol::TransactionReceipt::Ptr validationErrorReceipt(std::error_code const& error,
+    protocol::TransactionReceiptFactory const& rf, int64_t blockNumber);
+
+/// Decode a raw `0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTx,
+/// data])` envelope into the executable DepositTx. Consensus-grade, unlike the
+/// display decoder in bcos-rpc (DepositTransaction.h): the envelope must be fully
+/// consumed (no trailing bytes after the RLP list), integer fields follow op-geth's
+/// canonical rules (no leading zeros, mint/value <= 32 bytes, gas <= 8 bytes and
+/// int64, isSystemTx only 0x80/0x01). Defined in OpStackTransition.cpp.
+std::variant<bcos::evm::opstack::DepositTx, std::error_code> decodeDepositTx(
+    bcos::bytesConstRef rawDeposit);
+
+/// The evmone-side twin of the BCOS transaction (type / fee fields / to / access
+/// list / blob hashes / authorization list). Defined in OpStackTransition.cpp.
+evmone::state::Transaction toEvmoneTransaction(protocol::Transaction const& transaction);
+
+/// The evmone-side twin of the executor's block parameters (field-for-field; the
+/// EthBlockInfo was already derived from the BlockHeader + LedgerConfig by
+/// buildBlockInfo). Defined in OpStackTransition.cpp.
+evmone::state::BlockInfo toEvmoneBlockInfo(EthBlockInfo const& blockInfo);
+
+/// BCOS receipt from an executed evmone receipt (status mapping / log conversion
+/// shared with the pure-Ethereum lane's conventions). Defined in
+/// OpStackTransition.cpp.
+protocol::TransactionReceipt::Ptr toBcosReceipt(evmone::state::TransactionReceipt const& receipt,
+    protocol::TransactionReceiptFactory const& receiptFactory, int64_t blockNumber);
+
+/// The raw signed EIP-2718 envelope of a Web3 transaction (the L1 data fee is
+/// priced over these exact bytes). Empty when the transaction has no wire form —
+/// opValidate then rejects it. Defined in OpStackTransition.cpp.
+bcos::bytes signedTxEnvelope(protocol::Transaction const& transaction);
+
+/// Execute one normal (non-deposit) transaction under OP Karst semantics.
+/// Writes the state diff into @p storage; the caller owns atomicity (wrap in a
+/// Rollbackable and roll back on exception, as ExecuteContext::execute() does).
+template <class Storage>
+task::Task<protocol::TransactionReceipt::Ptr> executeOpStackTransaction(Storage& storage,
+    EthBlockInfo const& blockInfo, BlockHashLookup const& blockHashLookup,
+    protocol::Transaction const& transaction, evmc::VM& vm, uint64_t chainId,
+    protocol::TransactionReceiptFactory const& receiptFactory, int64_t blockNumber)
+{
+    // Karst-only chain: every fork up to Karst is active from genesis
+    // (rollup.json fork times all 0), so the fork config is not block-dependent.
+    const auto& cfg = bcos::evm::opstack::karstConfig();
+    const StorageStateView<Storage> view{storage};
+    const auto evmBlock = toEvmoneBlockInfo(blockInfo);
+    const LookupBlockHashes hashes{blockHashLookup, blockInfo.number};
+    const auto evmTx = toEvmoneTransaction(transaction);
+    const auto envelope = signedTxEnvelope(transaction);
+
+    auto validated = bcos::evm::opstack::opValidateFromState(view, evmBlock, evmTx,
+        evmc::bytes_view{envelope.data(), envelope.size()}, cfg,
+        /*blockGasLeft=*/evmBlock.gas_limit);
+    if (const auto* error = std::get_if<std::error_code>(&validated))
+    {
+        // A "validation failure" derived from fabricated state (a swallowed storage
+        // read failure) must not become a failure receipt.
+        if (view.readFailed())
+        {
+            BOOST_THROW_EXCEPTION(OpStateReadFailed() << errinfo_comment(
+                                      "storage read failed during OP transaction validation"));
+        }
+        co_return validationErrorReceipt(*error, receiptFactory, blockNumber);
+    }
+
+    auto opReceipt = bcos::evm::opstack::opTransition(view, evmBlock, hashes, evmTx, cfg, vm,
+        std::get<bcos::evm::opstack::OpTxProperties>(validated), chainId);
+    // The StateView is noexcept, so a storage failure inside validate/transition was
+    // answered as "absent / empty" and latched instead of thrown. Discard the result
+    // BEFORE it reaches storage — the caller's rollback/rethrow path takes over.
+    if (view.readFailed())
+    {
+        BOOST_THROW_EXCEPTION(OpStateReadFailed() << errinfo_comment(
+                                  "storage read failed during OP transaction execution"));
+    }
+    co_await applyEvmoneStateDiff(storage, opReceipt.receipt.state_diff);
+    co_return toBcosReceipt(opReceipt.receipt, receiptFactory, blockNumber);
+}
+
+/// Execute one 0x7E deposit from its raw envelope. A malformed envelope or a
+/// deposit runDeposit rejects (is_system_tx, block gas) is a BLOCK-level error
+/// and throws — deposits are consensus-injected (OP payload attributes), so an
+/// invalid one invalidates the whole payload rather than producing a failure
+/// receipt. Same atomicity contract as executeOpStackTransaction.
+template <class Storage>
+task::Task<protocol::TransactionReceipt::Ptr> executeOpStackDeposit(Storage& storage,
+    EthBlockInfo const& blockInfo, BlockHashLookup const& blockHashLookup,
+    bcos::bytesConstRef rawDeposit, evmc::VM& vm, uint64_t chainId,
+    protocol::TransactionReceiptFactory const& receiptFactory, int64_t blockNumber)
+{
+    auto decoded = decodeDepositTx(rawDeposit);
+    if (const auto* error = std::get_if<std::error_code>(&decoded))
+    {
+        BOOST_THROW_EXCEPTION(InvalidDepositTransaction() << errinfo_comment(
+                                  "malformed 0x7e deposit envelope: " + error->message()));
+    }
+
+    const auto& cfg = bcos::evm::opstack::karstConfig();
+    const StorageStateView<Storage> view{storage};
+    const auto evmBlock = toEvmoneBlockInfo(blockInfo);
+    const LookupBlockHashes hashes{blockHashLookup, blockInfo.number};
+
+    // runDeposit throws std::runtime_error for its block-level rejections;
+    // propagate.
+    auto depositReceipt = bcos::evm::opstack::runDeposit(view, evmBlock, hashes,
+        std::get<bcos::evm::opstack::DepositTx>(decoded), cfg, vm, chainId,
+        /*blockGasLeft=*/evmBlock.gas_limit);
+    // Same read-failure gate as executeOpStackTransaction: a deposit executed against
+    // fabricated state must not be applied.
+    if (view.readFailed())
+    {
+        BOOST_THROW_EXCEPTION(OpStateReadFailed() << errinfo_comment(
+                                  "storage read failed during OP deposit execution"));
+    }
+    co_await applyEvmoneStateDiff(storage, depositReceipt.receipt.state_diff);
+    co_return toBcosReceipt(depositReceipt.receipt, receiptFactory, blockNumber);
+}
+
+}  // namespace bcos::executor_v1::eth

--- a/ethereum-executor/tests/CMakeLists.txt
+++ b/ethereum-executor/tests/CMakeLists.txt
@@ -23,3 +23,14 @@ set_target_properties(test-ethereum-state-smoke PROPERTIES RUNTIME_OUTPUT_DIRECT
 # SearchTestCases.cmake only discovers BOOST_*TEST_* targets; this standalone
 # target must register itself so ctest actually runs it in CI.
 add_test(NAME test-ethereum-state-smoke COMMAND test-ethereum-state-smoke)
+
+# OP Stack execution lane: 0x7E decoding, executeDeposit, and the
+# feature_l2_ethereum_compat dispatch onto opTransition.
+add_executable(test-opstack-execution TestOpStackExecution.cpp)
+target_link_libraries(test-opstack-execution
+    ethereum-executor protocol-tars bcos-framework bcos-task codec bcos-utilities
+    evmone::evmone intx::intx TBB::tbb)
+set_source_files_properties("TestOpStackExecution.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+set_target_properties(test-opstack-execution PROPERTIES UNITY_BUILD OFF)
+set_target_properties(test-opstack-execution PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+add_test(NAME test-opstack-execution COMMAND test-opstack-execution)

--- a/ethereum-executor/tests/TestOpStackExecution.cpp
+++ b/ethereum-executor/tests/TestOpStackExecution.cpp
@@ -1,0 +1,587 @@
+/// @file TestOpStackExecution.cpp
+/// @brief OP Stack (Karst) execution lane: consensus-grade 0x7E decoding,
+///        deposit execution through EthereumExecutor::executeDeposit, and the
+///        feature_l2_ethereum_compat dispatch of normal transactions onto
+///        opTransition (L1 data fee / fee vault routing), with the pure-Ethereum
+///        lane as differential control.
+///
+/// Standalone CHECK-style runner (same pattern as TestEthereumStateSmoke.cpp):
+/// NDEBUG-independent, registered with add_test().
+
+#include "ethereum-executor/EthereumExecutor.h"
+#include "ethereum-executor/OpStackTransition.h"
+#include "ethereum-executor/tests/TestMemoryStorage.h"
+
+#include "bcos-codec/rlp/Common.h"
+#include "bcos-codec/rlp/RLPEncode.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/ledger/Features.h"
+#include "bcos-framework/ledger/LedgerConfig.h"
+#include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h"
+#include "bcos-task/TBBWait.h"
+#include <bcos-evm/opstack/OpFeeParams.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-evm/opstack/RollupCost.h>
+#include <evmone/evmone.h>
+#include <iostream>
+#include <memory>
+
+namespace
+{
+int g_failures = 0;
+
+void checkImpl(bool ok, const char* expr, const char* file, int line)
+{
+    if (!ok)
+    {
+        std::cerr << file << ':' << line << ": CHECK failed: " << expr << '\n';
+        ++g_failures;
+    }
+}
+}  // namespace
+
+#define CHECK(expr) checkImpl(static_cast<bool>(expr), #expr, __FILE__, __LINE__)
+
+namespace
+{
+using namespace bcos;
+using namespace bcos::executor_v1;
+using namespace bcos::executor_v1::eth;
+namespace opstack = bcos::evm::opstack;
+
+constexpr uint64_t kBaseFee = 7;
+
+evmc_address makeAddress(uint8_t seed)
+{
+    evmc_address addr{};
+    addr.bytes[19] = seed;
+    return addr;
+}
+
+task::Task<void> seedAccount(
+    MutableStorage& storage, evmc_address const& addr, u256 balance, uint64_t nonce)
+{
+    ledger::account::EVMAccount<MutableStorage> acc(storage, addr, false);
+    if (!co_await acc.exists())
+    {
+        co_await acc.create();
+    }
+    co_await acc.setNonce(std::to_string(nonce));
+    co_await acc.setBalance(balance);
+}
+
+/// slot 3 of L1Block.sol: base_fee_scalar packed into bytes [16,20) (BE u32);
+/// blob_base_fee_scalar ([20,24)) left 0.
+evmc::bytes32 packSlot3(uint32_t baseFeeScalar)
+{
+    evmc::bytes32 slot3{};
+    for (int i = 0; i < 4; ++i)
+    {
+        slot3.bytes[16 + i] = static_cast<uint8_t>(baseFeeScalar >> (8 * (3 - i)));
+    }
+    return slot3;
+}
+
+/// Seed the OP_L1_BLOCK fee slots (L1Block.sol layout, slots 1/3/7/8) the fee
+/// assembly reads through loadOpFeeParams.
+task::Task<void> seedOpFeeParams(
+    MutableStorage& storage, uint64_t l1BaseFee, uint32_t baseFeeScalar)
+{
+    ledger::account::EVMAccount<MutableStorage> acc(storage, opstack::OP_L1_BLOCK, false);
+    if (!co_await acc.exists())
+    {
+        co_await acc.create();
+    }
+    auto slotKey = [](uint8_t slot) {
+        evmc::bytes32 key{};
+        key.bytes[31] = slot;
+        return key;
+    };
+    // slot 1: l1_base_fee (whole slot).
+    co_await acc.setStorage(slotKey(1), intx::be::store<evmc::bytes32>(intx::uint256{l1BaseFee}));
+    // slot 3: base_fee_scalar in bytes [16,20), blob_base_fee_scalar in [20,24).
+    co_await acc.setStorage(slotKey(3), packSlot3(baseFeeScalar));
+    // slot 7: blob_base_fee = 1.
+    co_await acc.setStorage(slotKey(7), intx::be::store<evmc::bytes32>(intx::uint256{1}));
+    // slot 8: operator fee scalar/constant and DA footprint scalar all 0.
+    co_await acc.setStorage(slotKey(8), evmc::bytes32{});
+}
+
+task::Task<u256> readBalance(MutableStorage& storage, evmc_address const& addr)
+{
+    ledger::account::EVMAccount<MutableStorage> acc(storage, addr, false);
+    co_return co_await acc.balance();
+}
+
+task::Task<std::string> readNonce(MutableStorage& storage, evmc_address const& addr)
+{
+    ledger::account::EVMAccount<MutableStorage> acc(storage, addr, false);
+    auto nonce = co_await acc.nonce();
+    co_return nonce.value_or("<absent>");
+}
+
+/// Raw 0x7E envelope: 0x7e || rlp([sourceHash, from, to, mint, value, gas,
+/// isSystemTx, data]). `to`/`mint` empty items encode creation / no-mint.
+bcos::bytes buildDepositEnvelope(evmc_address const& from, std::optional<evmc_address> to,
+    std::optional<uint64_t> mint, uint64_t value, uint64_t gas, bool isSystemTx,
+    bcos::bytes const& data)
+{
+    using namespace bcos::codec::rlp;
+    bcos::bytes body;
+    encode(body, h256{});  // sourceHash (all-zero is fine for execution)
+    encode(body, bcos::Address(bcos::bytesConstRef(from.bytes, sizeof(from.bytes))));
+    if (to.has_value())
+    {
+        encode(body, bcos::Address(bcos::bytesConstRef(to->bytes, sizeof(to->bytes))));
+    }
+    else
+    {
+        body.push_back(BYTES_HEAD_BASE);
+    }
+    if (mint.has_value())
+    {
+        encode(body, *mint);
+    }
+    else
+    {
+        body.push_back(BYTES_HEAD_BASE);
+    }
+    encode(body, value);
+    encode(body, gas);
+    encode(body, static_cast<uint64_t>(isSystemTx ? 1 : 0));
+    encode(body, data);
+
+    bcos::bytes envelope;
+    envelope.push_back(0x7e);
+    encodeHeader(envelope, Header{.isList = true, .payloadLength = body.size()});
+    envelope.insert(envelope.end(), body.begin(), body.end());
+    return envelope;
+}
+
+/// A type-2 transfer as the executor sees it: Tars mirror fields (execution
+/// inputs) plus the reassemblable signed envelope (extraTransactionBytes +
+/// 65-byte signature) the L1 data fee is priced over.
+std::shared_ptr<bcostars::protocol::TransactionImpl> makeWeb3TransferTx(evmc_address const& from,
+    evmc_address const& to, uint64_t value, uint64_t gasLimit, uint64_t maxFee,
+    uint64_t maxPriorityFee)
+{
+    using namespace bcos::codec::rlp;
+
+    auto tarsTx = std::make_shared<bcostars::Transaction>();
+    auto& data = tarsTx->data;
+    data.version = 0;
+    data.blockLimit = 0;
+    data.nonce = "0";
+    data.gasLimit = static_cast<int64_t>(gasLimit);
+    data.value = intx::hex(intx::uint256{value});
+    data.maxFeePerGas = intx::hex(intx::uint256{maxFee});
+    data.maxPriorityFeePerGas = intx::hex(intx::uint256{maxPriorityFee});
+    data.chainID = "1";
+    data.to = bcos::toHexStringWithPrefix(bcos::bytes(std::begin(to.bytes), std::end(to.bytes)));
+    tarsTx->type = 1;  // protocol::TransactionType::Web3Transaction
+    tarsTx->web3TypedTxKind = 2;
+    tarsTx->sender.assign(std::begin(from.bytes), std::end(from.bytes));
+
+    // Signed envelope: the 0x02 signing payload + a synthetic 65-byte signature.
+    bcos::bytes body;
+    encode(body, static_cast<uint64_t>(1));  // chainId
+    encode(body, static_cast<uint64_t>(0));  // nonce
+    encode(body, maxPriorityFee);
+    encode(body, maxFee);
+    encode(body, gasLimit);
+    encode(body, bcos::Address(bcos::bytesConstRef(to.bytes, sizeof(to.bytes))));
+    encode(body, value);
+    encode(body, bcos::bytes{});     // data
+    body.push_back(LIST_HEAD_BASE);  // empty accessList
+    bcos::bytes payload;
+    payload.push_back(0x02);
+    encodeHeader(payload, Header{.isList = true, .payloadLength = body.size()});
+    payload.insert(payload.end(), body.begin(), body.end());
+    tarsTx->extraTransactionBytes.assign(payload.begin(), payload.end());
+
+    bcos::bytes signature(65, 0);
+    signature[31] = 0x12;  // r != 0
+    signature[63] = 0x34;  // s != 0
+    signature[64] = 0x01;  // yParity
+    tarsTx->signature.assign(signature.begin(), signature.end());
+
+    return std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tarsTx = std::move(tarsTx)]() mutable { return tarsTx.get(); });
+}
+
+/// Fault-injection wrapper: forwards every storage2 op to the inner MutableStorage,
+/// but once armed the READ entry points throw — simulating a backend I/O failure
+/// underneath the noexcept StateView bridge. Writes keep forwarding so the test
+/// proves the execution is discarded before any write, not that writes failed.
+struct FaultInjectionStorage
+{
+    MutableStorage& inner;
+    bool armed = false;
+
+    // storage2::range is a member-based CPO (Storage.h calls storage.range(...)).
+    auto range(auto&&... args) -> task::Task<task::AwaitableReturnType<decltype(storage2::range(
+        inner, std::forward<decltype(args)>(args)...))>>
+    {
+        if (armed)
+        {
+            throw std::runtime_error("injected storage read failure");
+        }
+        co_return co_await storage2::range(inner, std::forward<decltype(args)>(args)...);
+    }
+};
+
+void throwIfArmed(FaultInjectionStorage& storage)
+{
+    if (storage.armed)
+    {
+        throw std::runtime_error("injected storage read failure");
+    }
+}
+
+auto tag_invoke(storage2::tag_t<storage2::readSome> /*unused*/, FaultInjectionStorage& storage,
+    ::ranges::input_range auto&& keys)
+    -> task::Task<task::AwaitableReturnType<decltype(storage2::readSome(
+        storage.inner, std::forward<decltype(keys)>(keys)))>>
+{
+    throwIfArmed(storage);
+    co_return co_await storage2::readSome(storage.inner, std::forward<decltype(keys)>(keys));
+}
+
+auto tag_invoke(
+    storage2::tag_t<storage2::readOne> /*unused*/, FaultInjectionStorage& storage, auto const& key)
+    -> task::Task<task::AwaitableReturnType<decltype(storage2::readOne(storage.inner, key))>>
+{
+    throwIfArmed(storage);
+    co_return co_await storage2::readOne(storage.inner, key);
+}
+
+auto tag_invoke(storage2::tag_t<storage2::existsOne> /*unused*/, FaultInjectionStorage& storage,
+    auto const& key) -> task::Task<bool>
+{
+    throwIfArmed(storage);
+    co_return co_await storage2::existsOne(storage.inner, key);
+}
+
+auto tag_invoke(storage2::tag_t<storage2::writeSome> /*unused*/, FaultInjectionStorage& storage,
+    auto&& keyValues) -> task::Task<void>
+{
+    co_await storage2::writeSome(storage.inner, std::forward<decltype(keyValues)>(keyValues));
+}
+
+auto tag_invoke(storage2::tag_t<storage2::writeOne> /*unused*/, FaultInjectionStorage& storage,
+    auto key, auto value) -> task::Task<void>
+{
+    co_await storage2::writeOne(storage.inner, std::move(key), std::move(value));
+}
+
+auto tag_invoke(storage2::tag_t<storage2::removeSome> /*unused*/, FaultInjectionStorage& storage,
+    auto&& keys) -> task::Task<void>
+{
+    co_await storage2::removeSome(storage.inner, std::forward<decltype(keys)>(keys));
+}
+
+bcostars::protocol::BlockHeaderImpl makeBlockHeader(bcos::crypto::Hash& hashImpl)
+{
+    bcostars::protocol::BlockHeaderImpl header;
+    header.setNumber(1);
+    header.setTimestamp(1000);
+    header.calculateHash(hashImpl);
+    return header;
+}
+
+ledger::LedgerConfig makeLedgerConfig(bool l2Mode)
+{
+    ledger::LedgerConfig config;
+    config.setEVMCRevision(EVMC_OSAKA);
+    config.setGasLimit({30'000'000, 0});
+    config.setGasPrice({"0x7", 0});  // block base fee = 7
+    if (l2Mode)
+    {
+        ledger::Features features;
+        features.set(ledger::Features::Flag::feature_l2_ethereum_compat);
+        config.setFeatures(features);
+    }
+    return config;
+}
+
+void testDepositDecoder()
+{
+    const auto from = makeAddress(0xcc);
+    const auto to = makeAddress(0xdd);
+
+    // Full envelope roundtrip.
+    auto envelope = buildDepositEnvelope(from, to, 100, 5, 100000, false, {0x01, 0x02});
+    auto decoded = decodeDepositTx(bcos::ref(envelope));
+    CHECK(std::holds_alternative<opstack::DepositTx>(decoded));
+    if (auto* dep = std::get_if<opstack::DepositTx>(&decoded))
+    {
+        CHECK(dep->from == from);
+        CHECK(dep->to.has_value() && *dep->to == to);
+        CHECK(dep->mint.has_value() && *dep->mint == 100);
+        CHECK(dep->value == 5);
+        CHECK(dep->gas_limit == 100000);
+        CHECK(!dep->is_system_tx);
+        CHECK(dep->data.size() == 2);
+    }
+
+    // Creation + no-mint: empty RLP items.
+    auto creation = decodeDepositTx(bcos::ref(
+        envelope = buildDepositEnvelope(from, std::nullopt, std::nullopt, 0, 21000, false, {})));
+    CHECK(std::holds_alternative<opstack::DepositTx>(creation));
+    if (auto* dep = std::get_if<opstack::DepositTx>(&creation))
+    {
+        CHECK(!dep->to.has_value());
+        CHECK(!dep->mint.has_value());
+    }
+
+    // Wrong type byte.
+    auto notDeposit = bcos::bytes{0x02, 0x01};
+    CHECK(std::holds_alternative<std::error_code>(decodeDepositTx(bcos::ref(notDeposit))));
+
+    // Trailing bytes after the RLP list are consensus-rejected.
+    auto trailing = buildDepositEnvelope(from, to, 100, 0, 21000, false, {});
+    trailing.push_back(0x00);
+    CHECK(std::holds_alternative<std::error_code>(decodeDepositTx(bcos::ref(trailing))));
+
+    // Non-canonical integer encodings (op-geth rejects each of these; the shared
+    // lenient decode() would wrap/truncate/accept them). Items are 0-based:
+    // sourceHash, from, to, mint, value, gas, isSystemTx, data.
+    using namespace bcos::codec::rlp;
+    auto canonicalItems = [&]() {
+        std::vector<bcos::bytes> items(8);
+        encode(items[0], h256{});
+        encode(items[1], bcos::Address(bcos::bytesConstRef(from.bytes, sizeof(from.bytes))));
+        encode(items[2], bcos::Address(bcos::bytesConstRef(to.bytes, sizeof(to.bytes))));
+        encode(items[3], static_cast<uint64_t>(100));    // mint
+        encode(items[4], static_cast<uint64_t>(0));      // value (canonical zero = 0x80)
+        encode(items[5], static_cast<uint64_t>(21000));  // gas
+        encode(items[6], static_cast<uint64_t>(0));      // isSystemTx = false
+        encode(items[7], bcos::bytes{});                 // data
+        return items;
+    };
+    auto wrapItems = [](std::vector<bcos::bytes> const& items) {
+        bcos::bytes body;
+        for (auto const& item : items)
+        {
+            body.insert(body.end(), item.begin(), item.end());
+        }
+        bcos::bytes out;
+        out.push_back(0x7e);
+        encodeHeader(out, Header{.isList = true, .payloadLength = body.size()});
+        out.insert(out.end(), body.begin(), body.end());
+        return out;
+    };
+    auto expectReject = [&](size_t index, bcos::bytes rawItem) {
+        auto items = canonicalItems();
+        items[index] = std::move(rawItem);
+        auto bad = wrapItems(items);
+        CHECK(std::holds_alternative<std::error_code>(decodeDepositTx(bcos::ref(bad))));
+    };
+    // Positive control: the canonical items decode.
+    auto good = wrapItems(canonicalItems());
+    CHECK(std::holds_alternative<opstack::DepositTx>(decodeDepositTx(bcos::ref(good))));
+    // gas with a leading zero byte (0x82 0x00 0x52).
+    expectReject(5, {0x82, 0x00, 0x52});
+    // gas payload longer than uint64 (9 bytes).
+    expectReject(5, {0x89, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    // value payload longer than 32 bytes (33 bytes, would wrap mod 2^256).
+    {
+        bcos::bytes wide{0xa1};
+        wide.push_back(0x01);
+        wide.insert(wide.end(), 32, 0x00);
+        expectReject(4, std::move(wide));
+    }
+    // value zero encoded as inline 0x00 (canonical zero is the empty payload 0x80).
+    expectReject(4, {0x00});
+    // isSystemTx = 2 (only 0x80/0x01 are canonical bools).
+    expectReject(6, {0x02});
+}
+
+void testExecuteDeposit()
+{
+    bcos::crypto::Keccak256 keccak;
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    bcostars::protocol::TransactionReceiptFactoryImpl receiptFactory{cryptoSuite};
+    EthereumExecutor executor{receiptFactory};
+
+    MutableStorage storage;
+    const auto from = makeAddress(0xcc);
+    const auto to = makeAddress(0xdd);
+    task::tbb::syncWait(seedAccount(storage, from, 0, 5));
+
+    auto header = makeBlockHeader(keccak);
+    auto ledgerConfig = makeLedgerConfig(true);
+
+    // Mint 1000, transfer 400 of it to `to`.
+    auto envelope = buildDepositEnvelope(from, to, 1000, 400, 100000, false, {});
+    auto receipt = task::tbb::syncWait(
+        executor.executeDeposit(storage, header, bcos::ref(envelope), ledgerConfig));
+    CHECK(receipt != nullptr);
+    CHECK(receipt->status() == 0);
+    CHECK(receipt->gasUsed() == 21000);
+
+    CHECK(task::tbb::syncWait(readBalance(storage, from)) == u256(600));
+    CHECK(task::tbb::syncWait(readBalance(storage, to)) == u256(400));
+    // Deposit force-increments the depositor nonce.
+    CHECK(task::tbb::syncWait(readNonce(storage, from)) == "6");
+
+    // A malformed envelope is a block-level error: it throws and leaves no state.
+    auto malformed = envelope;
+    malformed.push_back(0x00);
+    bool thrown = false;
+    try
+    {
+        task::tbb::syncWait(
+            executor.executeDeposit(storage, header, bcos::ref(malformed), ledgerConfig));
+    }
+    catch (...)
+    {
+        thrown = true;
+    }
+    CHECK(thrown);
+    CHECK(task::tbb::syncWait(readBalance(storage, from)) == u256(600));
+}
+
+/// A storage read failure under the noexcept StateView bridge must NOT persist a
+/// result computed against fabricated ("absent / empty") state: the read-failure
+/// latch turns it into an exception BEFORE the state diff is applied.
+void testReadFailureDiscardsExecution()
+{
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    bcostars::protocol::TransactionReceiptFactoryImpl receiptFactory{cryptoSuite};
+    auto vm = evmc::VM{evmc_create_evmone()};
+
+    const auto from = makeAddress(0xcc);
+    const auto to = makeAddress(0xdd);
+    MutableStorage inner;
+    task::tbb::syncWait(seedAccount(inner, from, 0, 5));
+    FaultInjectionStorage storage{inner};
+
+    EthBlockInfo blockInfo{};
+    blockInfo.number = 1;
+    blockInfo.timestamp = 1;
+    blockInfo.gas_limit = 30'000'000;
+
+    auto envelope = buildDepositEnvelope(from, to, 1000, 400, 100000, false, {});
+
+    // Control: unarmed, the wrapper is transparent and the deposit lands.
+    auto receipt = task::tbb::syncWait(executeOpStackDeposit(storage, blockInfo, BlockHashLookup{},
+        bcos::ref(envelope), vm, /*chainId=*/1234, receiptFactory, 1));
+    CHECK(receipt != nullptr);
+    CHECK(receipt->status() == 0);
+    CHECK(task::tbb::syncWait(readBalance(inner, from)) == u256(600));
+
+    // Armed: every read throws inside the bridge; the execution must be discarded via
+    // an exception, with NO dirty state written.
+    storage.armed = true;
+    bool thrown = false;
+    try
+    {
+        task::tbb::syncWait(executeOpStackDeposit(storage, blockInfo, BlockHashLookup{},
+            bcos::ref(envelope), vm, 1234, receiptFactory, 1));
+    }
+    catch (...)
+    {
+        thrown = true;
+    }
+    CHECK(thrown);
+    storage.armed = false;
+    CHECK(task::tbb::syncWait(readBalance(inner, from)) == u256(600));
+    CHECK(task::tbb::syncWait(readBalance(inner, to)) == u256(400));
+    CHECK(task::tbb::syncWait(readNonce(inner, from)) == "6");
+}
+
+void testOpStackLaneDispatch()
+{
+    bcos::crypto::Keccak256 keccak;
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    bcostars::protocol::TransactionReceiptFactoryImpl receiptFactory{cryptoSuite};
+
+    const auto sender = makeAddress(0xaa);
+    const auto recipient = makeAddress(0xbb);
+    const u256 funding = u256(1'000'000'000'000'000'000ULL);  // 1 ETH
+
+    auto runTransfer = [&](bool l2Mode) {
+        MutableStorage storage;
+        task::tbb::syncWait(seedAccount(storage, sender, funding, 0));
+        task::tbb::syncWait(seedOpFeeParams(storage, /*l1BaseFee=*/1'000'000'000,
+            /*baseFeeScalar=*/1000));
+
+        EthereumExecutor executor{receiptFactory};
+        auto header = makeBlockHeader(keccak);
+        auto ledgerConfig = makeLedgerConfig(l2Mode);
+        auto tx = makeWeb3TransferTx(sender, recipient, /*value=*/12345,
+            /*gasLimit=*/50000, /*maxFee=*/1000, /*maxPriorityFee=*/1);
+        auto receipt = task::tbb::syncWait(
+            executor.executeTransaction(storage, header, *tx, 0, ledgerConfig, /*call=*/false));
+        CHECK(receipt != nullptr);
+        CHECK(receipt->status() == 0);
+        struct Result
+        {
+            u256 recipientBalance;
+            u256 l1FeeVault;
+            u256 baseFeeVault;
+            std::string senderNonce;
+            u256 gasUsed;
+            bcos::bytes envelope;
+        };
+        return Result{
+            .recipientBalance = task::tbb::syncWait(readBalance(storage, recipient)),
+            .l1FeeVault = task::tbb::syncWait(readBalance(storage, opstack::OP_L1_FEE_VAULT)),
+            .baseFeeVault = task::tbb::syncWait(readBalance(storage, opstack::OP_BASE_FEE_VAULT)),
+            .senderNonce = task::tbb::syncWait(readNonce(storage, sender)),
+            .gasUsed = receipt->gasUsed(),
+            .envelope = signedTxEnvelope(*tx),
+        };
+    };
+
+    // OP lane: transfer lands, L1 data fee and base fee are routed to the vaults.
+    auto op = runTransfer(true);
+    CHECK(op.recipientBalance == u256(12345));
+    CHECK(op.senderNonce == "1");
+    CHECK(op.gasUsed == u256(21000));
+    CHECK(!op.envelope.empty());
+    // The L1 fee vault credit equals the Fjord+ FastLZ cost of the signed envelope
+    // under the seeded OP_L1_BLOCK params — pins that the fee assembly read the
+    // seeded slots and routed the exact cost.
+    const auto fee =
+        opstack::unpackOpFeeParams(intx::be::store<evmc::bytes32>(intx::uint256{1'000'000'000}),
+            packSlot3(1000), intx::be::store<evmc::bytes32>(intx::uint256{1}), evmc::bytes32{});
+    const auto expectedL1Cost = opstack::computeL1CostFromFlz(fee,
+        opstack::flzCompressLen(evmc::bytes_view{op.envelope.data(), op.envelope.size()}),
+        opstack::karstConfig());
+    CHECK(expectedL1Cost > 0);
+    CHECK(op.l1FeeVault == eth::evm::toBcosU256(expectedL1Cost));
+    // Base fee vault gets gasUsed * baseFee (OP does not burn the base fee).
+    CHECK(op.baseFeeVault == u256(21000 * kBaseFee));
+
+    // Differential control — same transaction, feature off: the pure-Ethereum
+    // lane charges no L1 fee and credits no vault.
+    auto ethLane = runTransfer(false);
+    CHECK(ethLane.recipientBalance == u256(12345));
+    CHECK(ethLane.l1FeeVault == u256(0));
+    CHECK(ethLane.baseFeeVault == u256(0));
+}
+}  // namespace
+
+int main()
+{
+    testDepositDecoder();
+    testExecuteDeposit();
+    testReadFailureDiscardsExecution();
+    testOpStackLaneDispatch();
+
+    if (g_failures != 0)
+    {
+        std::cerr << g_failures << " check(s) failed\n";
+        return 1;
+    }
+    std::cout << "TestOpStackExecution: all checks passed\n";
+    return 0;
+}

--- a/ethereum-executor/tests/TestOpStackExecution.cpp
+++ b/ethereum-executor/tests/TestOpStackExecution.cpp
@@ -28,6 +28,8 @@
 #include <evmone/evmone.h>
 #include <iostream>
 #include <memory>
+#include <set>
+#include <string>
 
 namespace
 {
@@ -337,14 +339,43 @@ void testDepositDecoder()
         CHECK(!dep->mint.has_value());
     }
 
-    // Wrong type byte.
-    auto notDeposit = bcos::bytes{0x02, 0x01};
-    CHECK(std::holds_alternative<std::error_code>(decodeDepositTx(bcos::ref(notDeposit))));
+    // Every rejection below asserts BOTH halves: that the envelope is still rejected
+    // (the consensus verdict, unchanged by the error-code split) and which
+    // DepositDecodeError it reports (the diagnosability the split buys — previously all
+    // of these surfaced as the single message "Invalid argument").
+    auto expectRejectCode = [](bcos::bytes const& raw, DepositDecodeError expected) {
+        auto decoded = decodeDepositTx(bcos::ref(raw));
+        const auto* error = std::get_if<std::error_code>(&decoded);
+        CHECK(error != nullptr);
+        if (error != nullptr)
+        {
+            if (*error != make_error_code(expected))
+            {
+                std::cerr << "  expected \"" << make_error_code(expected).message() << "\", got \""
+                          << error->message() << "\"\n";
+            }
+            CHECK(*error == make_error_code(expected));
+            CHECK(!error->message().empty());
+        }
+    };
+
+    // Wrong type byte — and the empty envelope reaches the same verdict.
+    expectRejectCode(bcos::bytes{0x02, 0x01}, DepositDecodeError::WrongTypeByte);
+    expectRejectCode(bcos::bytes{}, DepositDecodeError::WrongTypeByte);
 
     // Trailing bytes after the RLP list are consensus-rejected.
     auto trailing = buildDepositEnvelope(from, to, 100, 0, 21000, false, {});
     trailing.push_back(0x00);
-    CHECK(std::holds_alternative<std::error_code>(decodeDepositTx(bcos::ref(trailing))));
+    expectRejectCode(trailing, DepositDecodeError::TrailingBytes);
+
+    // The type byte alone: no RLP header at all.
+    expectRejectCode(bcos::bytes{0x7e}, DepositDecodeError::MalformedEnvelope);
+    // A list header announcing more payload than is present — decodeHeader's own
+    // InputTooShort, surfaced as a malformed envelope.
+    expectRejectCode(bcos::bytes{0x7e, 0xc8, 0x01, 0x02}, DepositDecodeError::MalformedEnvelope);
+    // A non-list (bytes) item where the field list belongs.
+    expectRejectCode(
+        bcos::bytes{0x7e, 0x83, 0x01, 0x02, 0x03}, DepositDecodeError::MalformedEnvelope);
 
     // Non-canonical integer encodings (op-geth rejects each of these; the shared
     // lenient decode() would wrap/truncate/accept them). Items are 0-based:
@@ -374,30 +405,81 @@ void testDepositDecoder()
         out.insert(out.end(), body.begin(), body.end());
         return out;
     };
-    auto expectReject = [&](size_t index, bcos::bytes rawItem) {
+    auto expectReject = [&](size_t index, bcos::bytes rawItem, DepositDecodeError expected) {
         auto items = canonicalItems();
         items[index] = std::move(rawItem);
-        auto bad = wrapItems(items);
-        CHECK(std::holds_alternative<std::error_code>(decodeDepositTx(bcos::ref(bad))));
+        expectRejectCode(wrapItems(items), expected);
     };
     // Positive control: the canonical items decode.
     auto good = wrapItems(canonicalItems());
     CHECK(std::holds_alternative<opstack::DepositTx>(decodeDepositTx(bcos::ref(good))));
     // gas with a leading zero byte (0x82 0x00 0x52).
-    expectReject(5, {0x82, 0x00, 0x52});
+    expectReject(5, {0x82, 0x00, 0x52}, DepositDecodeError::NonCanonicalInteger);
     // gas payload longer than uint64 (9 bytes).
-    expectReject(5, {0x89, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
+    expectReject(5, {0x89, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        DepositDecodeError::IntegerTooWide);
     // value payload longer than 32 bytes (33 bytes, would wrap mod 2^256).
     {
         bcos::bytes wide{0xa1};
         wide.push_back(0x01);
         wide.insert(wide.end(), 32, 0x00);
-        expectReject(4, std::move(wide));
+        expectReject(4, std::move(wide), DepositDecodeError::IntegerTooWide);
     }
     // value zero encoded as inline 0x00 (canonical zero is the empty payload 0x80).
-    expectReject(4, {0x00});
+    expectReject(4, {0x00}, DepositDecodeError::NonCanonicalInteger);
     // isSystemTx = 2 (only 0x80/0x01 are canonical bools).
-    expectReject(6, {0x02});
+    expectReject(6, {0x02}, DepositDecodeError::NonCanonicalBool);
+    // gas = 2^63 (8 bytes, canonical) fits uint64 but not the executable int64 gas_limit.
+    expectReject(5, {0x88, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+        DepositDecodeError::GasLimitOutOfRange);
+    // `to` truncated to 19 bytes — a field that is present but the wrong width.
+    {
+        bcos::bytes shortTo{0x93};
+        shortTo.insert(shortTo.end(), 19, 0xdd);
+        expectReject(2, std::move(shortTo), DepositDecodeError::MalformedField);
+    }
+    // An integer field whose own RLP header is undecodable (gas announces 4 bytes but the
+    // list ends). It is a FIELD failure, not the outer envelope's.
+    {
+        auto items = canonicalItems();
+        items[5] = {0x84};
+        items[6].clear();
+        items[7].clear();
+        expectRejectCode(wrapItems(items), DepositDecodeError::MalformedField);
+    }
+    // An integer field encoded as a list where a scalar belongs — same field-level code.
+    expectReject(4, {0xc1, 0x01}, DepositDecodeError::MalformedField);
+    // Field list that simply stops early: `to` present, nothing after it. The decoder runs
+    // out of items rather than failing to parse one.
+    {
+        auto items = canonicalItems();
+        for (size_t index = 3; index < items.size(); ++index)
+        {
+            items[index].clear();
+        }
+        expectRejectCode(wrapItems(items), DepositDecodeError::TruncatedBody);
+    }
+    // Stopping one item earlier lands on the `to` check, the other TruncatedBody site.
+    {
+        auto items = canonicalItems();
+        for (size_t index = 2; index < items.size(); ++index)
+        {
+            items[index].clear();
+        }
+        expectRejectCode(wrapItems(items), DepositDecodeError::TruncatedBody);
+    }
+    // Every distinct failure reports a distinct message: the whole point of the split.
+    const DepositDecodeError allErrors[] = {DepositDecodeError::WrongTypeByte,
+        DepositDecodeError::MalformedEnvelope, DepositDecodeError::TrailingBytes,
+        DepositDecodeError::TruncatedBody, DepositDecodeError::MalformedField,
+        DepositDecodeError::NonCanonicalInteger, DepositDecodeError::IntegerTooWide,
+        DepositDecodeError::NonCanonicalBool, DepositDecodeError::GasLimitOutOfRange};
+    std::set<std::string> messages;
+    for (auto error : allErrors)
+    {
+        messages.insert(make_error_code(error).message());
+    }
+    CHECK(messages.size() == std::size(allErrors));
 }
 
 void testExecuteDeposit()

--- a/ethereum-executor/tests/TestStorageBridge.h
+++ b/ethereum-executor/tests/TestStorageBridge.h
@@ -1,241 +1,29 @@
 /// @file TestStorageBridge.h
-/// @brief TEST-ONLY bridge between BCOS storage and bcos-evm's
-///        evmone::state::StateView / StateDiff interfaces.
-///
-/// The ethereum-executor LIBRARY no longer ships the StateView / StateDiff
-/// adapter layer (StorageStateView / StorageBlockHashes / applyStateDiff were
-/// removed — the executor reads/writes BCOS storage directly through
-/// EVMAccount / storage2). However the EEST runner also drives bcos-evm's
-/// system contracts (EIP-4788 / EIP-2935 / EIP-7002 / EIP-7251) directly, and
-/// those keep the upstream evmone::state::{StateView, BlockHashes} interface
-/// (bcos-evm is unchanged). This header is the small local bridge the test tool
-/// needs for that path only; it is NOT part of the executor library.
+/// @brief Forwarders kept for the EEST runner: the BCOS-storage <->
+///        evmone::state::StateView / StateDiff bridge that used to live here
+///        test-only was promoted to the executor library when the OP Stack
+///        execution lane made it production code (see
+///        ethereum-executor/OpStackBridge.h). The runner keeps its old names.
 
 #pragma once
 
 #include "bcos-crypto/interfaces/crypto/Hash.h"
-#include "bcos-evm/eth/state/account.hpp"
-#include "bcos-evm/eth/state/state_diff.hpp"
-#include "bcos-evm/eth/state/state_view.hpp"
-#include "bcos-framework/ledger/EVMAccount.h"
-#include "bcos-framework/storage/Entry.h"
-#include "bcos-task/TBBWait.h"
-#include "ethereum-executor/EthereumState.h"  // evm::toIntxU256 / evm::toBcosU256 / eth::clearAccountStorage
-#include <evmc/evmc.h>
-#include <optional>
+#include "ethereum-executor/OpStackBridge.h"
 
 namespace bcos::test
 {
 
-/// A read-only evmone::state::StateView backed by BCOS storage + EVMAccount.
-/// Synchronous (required by the StateView interface), bridged with
-/// task::tbb::syncWait, fail-safe (a failed read reports "absent / empty").
 template <class Storage>
-class TestStorageStateView : public evmone::state::StateView
-{
-public:
-    TestStorageStateView(Storage& storage) : m_storage(storage) {}
+using TestStorageStateView = bcos::executor_v1::eth::StorageStateView<Storage>;
 
-    std::optional<evmone::state::StateView::Account> get_account(
-        const evmc::address& addr) const noexcept override
-    {
-        try
-        {
-            return task::tbb::syncWait(getAccountImpl(addr));
-        }
-        catch (...)
-        {
-            return std::nullopt;
-        }
-    }
-
-    evmc::bytes get_account_code(const evmc::address& addr) const noexcept override
-    {
-        try
-        {
-            return task::tbb::syncWait(getCodeImpl(addr));
-        }
-        catch (...)
-        {
-            return {};
-        }
-    }
-
-    evmc::bytes32 get_storage(
-        const evmc::address& addr, const evmc::bytes32& key) const noexcept override
-    {
-        try
-        {
-            return task::tbb::syncWait(getStorageImpl(addr, key));
-        }
-        catch (...)
-        {
-            return {};
-        }
-    }
-
-private:
-    Storage& m_storage;
-
-    task::Task<std::optional<evmone::state::StateView::Account>> getAccountImpl(
-        evmc_address addr) const
-    {
-        using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
-
-        EVMAccount<Storage> evmAccount(storage, addr, false);
-
-        if (!co_await evmAccount.exists())
-            co_return std::nullopt;
-
-        evmone::state::StateView::Account acc;
-        auto nonceVal = co_await evmAccount.nonce();
-        if (nonceVal.has_value())
-            acc.nonce = static_cast<uint64_t>(bcos::u256(nonceVal.value()));
-
-        acc.balance = bcos::executor_v1::eth::evm::toIntxU256(co_await evmAccount.balance());
-
-        auto codeHashVal = co_await evmAccount.codeHash();
-        {
-            auto const* d = codeHashVal.data();
-            bool hasCodeHash = false;
-            for (size_t i = 0; i < 32; ++i)
-                if (d[i] != 0)
-                {
-                    hasCodeHash = true;
-                    break;
-                }
-            if (hasCodeHash)
-                std::copy_n(d, sizeof(evmc_bytes32), acc.code_hash.bytes);
-            else
-                acc.code_hash = evmone::state::Account::EMPTY_CODE_HASH;
-        }
-
-        acc.has_storage = co_await hasStorageImpl(evmAccount);
-        co_return acc;
-    }
-
-    task::Task<bool> hasStorageImpl(bcos::ledger::account::EVMAccount<Storage>& evmAccount) const
-    {
-        using namespace bcos::ledger;
-        using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
-        auto tableName = co_await evmAccount.path();
-
-        bool hasStorage = false;
-        auto it = co_await storage2::range(storage, storage2::RANGE_SEEK,
-            executor_v1::StateKey{tableName, std::string_view{}});
-
-        while (auto kv = co_await it.next())
-        {
-            auto const& [k, v] = *kv;
-            executor_v1::StateKeyView view(k);
-            if (view.m_table != tableName)
-                break;  // Left this account's table.
-
-            auto key = view.m_key;
-            if (key != ACCOUNT_TABLE_FIELDS::NONCE && key != ACCOUNT_TABLE_FIELDS::BALANCE &&
-                key != ACCOUNT_TABLE_FIELDS::CODE_HASH && key != ACCOUNT_TABLE_FIELDS::CODE &&
-                key != ACCOUNT_TABLE_FIELDS::ABI && key != ACCOUNT_TABLE_FIELDS::ALIVE &&
-                key != ACCOUNT_TABLE_FIELDS::FROZEN && key != ACCOUNT_TABLE_FIELDS::SHARD)
-            {
-                hasStorage = true;
-                break;
-            }
-        }
-        co_return hasStorage;
-    }
-
-    task::Task<evmc::bytes> getCodeImpl(evmc_address addr) const
-    {
-        using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
-        EVMAccount<Storage> evmAccount(storage, addr, false);
-
-        if (!co_await evmAccount.exists())
-            co_return {};
-
-        auto codeEntry = co_await evmAccount.code();
-        if (!codeEntry.has_value())
-            co_return {};
-
-        auto view = codeEntry->get();
-        co_return evmc::bytes(view.begin(), view.end());
-    }
-
-    task::Task<evmc::bytes32> getStorageImpl(evmc_address addr, evmc_bytes32 key) const
-    {
-        using namespace bcos::ledger::account;
-        auto& storage = const_cast<Storage&>(m_storage);
-        EVMAccount<Storage> evmAccount(storage, addr, false);
-
-        // SLOAD on a non-existent account returns 0 per EVM spec.
-        co_return co_await evmAccount.storage(key);
-    }
-};
-
-/// TEST-ONLY: write a bcos-evm StateDiff back to BCOS storage. The executor
-/// library no longer has an applyStateDiff (it writes BCOS storage directly);
-/// this helper exists only so the EEST runner can persist the state diff of
-/// bcos-evm's system_call_block_start/end system contracts.
+/// The hashImpl parameter is retained for signature compatibility but unused:
+/// the production apply hashes code with keccak256 unconditionally (Ethereum
+/// consensus hashing), which is what every EEST call site passed anyway.
 template <class Storage>
 task::Task<void> testApplyStateDiff(
-    Storage& storage, evmone::state::StateDiff const& diff, crypto::Hash const& hashImpl)
+    Storage& storage, evmone::state::StateDiff const& diff, crypto::Hash const& /*hashImpl*/)
 {
-    using namespace bcos::ledger::account;
-    using bcos::executor_v1::eth::evm::toBcosU256;
-    using bcos::executor_v1::eth::clearAccountStorage;
-
-    // Phase 1: Process modified_accounts FIRST so created accounts exist.
-    for (auto const& m : diff.modified_accounts)
-    {
-        EVMAccount<Storage> acc(storage, m.addr, false);
-        if (!co_await acc.exists())
-            co_await acc.create();
-        co_await acc.setNonce(std::to_string(m.nonce));
-        co_await acc.setBalance(toBcosU256(m.balance));
-        if (m.code.has_value())
-        {
-            auto const& c = *m.code;
-            if (c.empty())
-            {
-                co_await acc.setCode(bcos::bytes{}, std::string{}, bcos::h256{});
-            }
-            else
-            {
-                bcos::bytes code(c.begin(), c.end());
-                auto ch = hashImpl.hash(bcos::bytesConstRef(code.data(), code.size()));
-                co_await acc.setCode(std::move(code), std::string{}, ch);
-            }
-        }
-        for (auto const& [key, value] : m.modified_storage)
-            co_await acc.setStorage(key, value);
-    }
-
-    // Phase 2: deleted accounts, skipping addresses recreated in Phase 1.
-    for (auto const& addr : diff.deleted_accounts)
-    {
-        bool inModified = false;
-        for (auto const& m : diff.modified_accounts)
-        {
-            if (memcmp(m.addr.bytes, addr.bytes, sizeof(evmc_address)) == 0)
-            {
-                inModified = true;
-                break;
-            }
-        }
-        if (inModified)
-            continue;
-
-        EVMAccount<Storage> acc(storage, addr, false);
-        if (co_await acc.exists())
-        {
-            co_await acc.setBalance(0);
-            co_await acc.setNonce("0");
-            co_await acc.setCode(bcos::bytes{}, std::string{}, bcos::h256{});
-            co_await clearAccountStorage(storage, acc);
-        }
-    }
+    co_await bcos::executor_v1::eth::applyEvmoneStateDiff(storage, diff);
 }
 
 }  // namespace bcos::test

--- a/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
+++ b/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
@@ -26,6 +26,7 @@
  * ledger::getBlockHash LedgerMethod.
  */
 
+#include "EthereumBlockHashLookup.h"
 #include "TrivialCheckpointStorage.h"
 #include "bcos-codec/rlp/Common.h"
 #include "bcos-codec/rlp/RLPEncode.h"
@@ -51,10 +52,9 @@
 #include "engine/bcos-engine/EngineServiceImpl.h"
 #include "ethereum-executor/EthereumExecutor.h"
 #include "ethereum-executor/EthereumHost.h"
-#include "EthereumBlockHashLookup.h"
+#include <evmone/evmone.h>
 #include <boost/test/unit_test.hpp>
 #include <cstring>
-#include <evmone/evmone.h>
 #include <magic_enum/magic_enum.hpp>
 #include <memory>
 #include <sstream>
@@ -84,6 +84,12 @@ using EEMultiLayerStorage = MultiLayerStorage<EEMutableStorage, void, EECheckpoi
 // driven through the scheduler's createExecuteContext + prepare/execute/finish
 // pipeline.
 static_assert(executor_v1::TransactionExecutor<EthereumExecutor, EEMutableStorage>);
+
+// Hard conformance check for the Engine's deposit lane (buildPayload Step 2c-0): the gate
+// there is `if constexpr (ExecutesDeposits<...>)`, so a signature drift on
+// EthereumExecutor::executeDeposit would otherwise silently stop executing deposits
+// instead of failing the build.
+static_assert(bcos::engine::ExecutesDeposits<EthereumExecutor, EEMutableStorage>);
 
 static const u256 EEFunding = u256(1000000000000000000ULL);  // 1 ETH
 
@@ -201,8 +207,7 @@ public:
         // node wires — not a parallel copy that can drift.
         blockHashLookup = [&backend = backendStorage](
                               int64_t blockNumber, int64_t currentHeight) -> evmc::bytes32 {
-            return initializer::ethBlockHashLookupFromStorage(
-                backend, blockNumber, currentHeight);
+            return initializer::ethBlockHashLookupFromStorage(backend, blockNumber, currentHeight);
         };
         executor = std::make_shared<EthereumExecutor>(receiptFactory, blockHashLookup);
     }
@@ -291,12 +296,10 @@ BOOST_AUTO_TEST_CASE(serialExecuteBlock)
         // The storage-backed block-hash lookup resolves committed hashes via LedgerMethod.
         // The transfers above executed in a block of height 1, which is the current
         // height passed to the provider for the 256-ancestor bound.
-        auto h0 = task::tbb::syncWait(
-            ledger::getBlockHash(backendStorage, 0, ledger::fromStorage));
+        auto h0 = task::tbb::syncWait(ledger::getBlockHash(backendStorage, 0, ledger::fromStorage));
         BOOST_CHECK(h0.has_value());
         auto resolved = blockHashLookup(0, 1);
-        BOOST_CHECK_EQUAL(
-            std::memcmp(resolved.bytes, h0->data(), sizeof(evmc_bytes32)), 0);
+        BOOST_CHECK_EQUAL(std::memcmp(resolved.bytes, h0->data(), sizeof(evmc_bytes32)), 0);
     }());
 }
 
@@ -684,16 +687,14 @@ BOOST_AUTO_TEST_CASE(blockHashLookbackLimit)
             task::tbb::syncWait(ledger::getBlockHash(backendStorage, 50, ledger::fromStorage));
         BOOST_CHECK(h50.has_value());
         auto resolved50 = blockHashLookup(50, 300);
-        BOOST_CHECK_EQUAL(
-            std::memcmp(resolved50.bytes, h50->data(), sizeof(evmc_bytes32)), 0);
+        BOOST_CHECK_EQUAL(std::memcmp(resolved50.bytes, h50->data(), sizeof(evmc_bytes32)), 0);
 
         // The oldest reachable ancestor (current - 256) — must resolve.
         auto h44 =
             task::tbb::syncWait(ledger::getBlockHash(backendStorage, 44, ledger::fromStorage));
         BOOST_CHECK(h44.has_value());
         auto resolved44 = blockHashLookup(44, 300);
-        BOOST_CHECK_EQUAL(
-            std::memcmp(resolved44.bytes, h44->data(), sizeof(evmc_bytes32)), 0);
+        BOOST_CHECK_EQUAL(std::memcmp(resolved44.bytes, h44->data(), sizeof(evmc_bytes32)), 0);
 
         // Older than 256 ancestors — unknown (zero hash), despite the hash being stored.
         evmc::bytes32 zero{};
@@ -762,8 +763,8 @@ BOOST_AUTO_TEST_CASE(blockHashHostNoexceptBoundary)
         eth::BlockHashLookup throwingLookup = [](int64_t, int64_t) -> evmc::bytes32 {
             throw std::runtime_error("simulated storage failure");
         };
-        eth::EthereumHost<EEMutableStorage> host{EVMC_SHANGHAI, vm, state, block,
-            std::move(throwingLookup), *tx, callParams};
+        eth::EthereumHost<EEMutableStorage> host{
+            EVMC_SHANGHAI, vm, state, block, std::move(throwingLookup), *tx, callParams};
         auto result = vm.execute(host, EVMC_SHANGHAI, msg, code, sizeof(code));
         BOOST_CHECK_EQUAL(result.status_code, EVMC_SUCCESS);
     }
@@ -774,8 +775,8 @@ BOOST_AUTO_TEST_CASE(blockHashHostNoexceptBoundary)
         eth::BlockHashLookup zeroLookup = [](int64_t, int64_t) -> evmc::bytes32 {
             return evmc::bytes32{};
         };
-        eth::EthereumHost<EEMutableStorage> host{EVMC_SHANGHAI, vm, state, block,
-            std::move(zeroLookup), *tx, callParams};
+        eth::EthereumHost<EEMutableStorage> host{
+            EVMC_SHANGHAI, vm, state, block, std::move(zeroLookup), *tx, callParams};
         auto result = vm.execute(host, EVMC_SHANGHAI, msg, code, sizeof(code));
         BOOST_CHECK_EQUAL(result.status_code, EVMC_SUCCESS);
     }
@@ -927,8 +928,7 @@ BOOST_AUTO_TEST_CASE(toDecodingOnlyWellFormedAddresses)
         {
             auto to = ethToAddress(*mkTx(toHexStr));
             BOOST_REQUIRE(to.has_value());
-            BOOST_CHECK_EQUAL(
-                std::memcmp(to->bytes, recipient.bytes, sizeof(evmc_address)), 0);
+            BOOST_CHECK_EQUAL(std::memcmp(to->bytes, recipient.bytes, sizeof(evmc_address)), 0);
         }
 
         // Raw 20 bytes (defensive fallback branch) -> the exact recipient address.
@@ -936,8 +936,7 @@ BOOST_AUTO_TEST_CASE(toDecodingOnlyWellFormedAddresses)
             bcos::bytes raw(std::begin(recipient.bytes), std::end(recipient.bytes));
             auto to = ethToAddress(*mkTx(std::string(raw.begin(), raw.end())));
             BOOST_REQUIRE(to.has_value());
-            BOOST_CHECK_EQUAL(
-                std::memcmp(to->bytes, recipient.bytes, sizeof(evmc_address)), 0);
+            BOOST_CHECK_EQUAL(std::memcmp(to->bytes, recipient.bytes, sizeof(evmc_address)), 0);
         }
 
         // Short hex "0x1234" -> unset (contract creation), never 0x1234000...0.


### PR DESCRIPTION
Wave-2 PR of the op-node integration plan (C1). Builds on #5420 (fee parameter source in genesis state) and #5421 (raw tx type dispatch), both merged; rebased onto #5419. This is the "per-transaction" half of the execution story — block-level coordination (EIP-4788/2935 system calls) is deliberately out of scope and comes next as C2.

## What this PR does

**1. `karstConfig()` becomes real** (`bcos-evm/opstack/`)

- `OpForkSchedule.cpp`: Karst is no longer a Jovian alias — `EVMC_OSAKA` revision and its own fork table.
- `OpPrecompiles.cpp`: Karst precompile table with bn256 pairing (`0x08`) capped at 57,600 **bytes** of input (300 pairs × 192 B, down from Jovian's 81,984 B / 427 pairs) — an input-size limit, not a repricing; `gas_cost_override` stays `-1`. BLS entries carried over from Jovian. **P256VERIFY (`0x100`) is deliberately absent from the Karst table**: Karst activates EIP-7951, which reprices it to 6,900 gas — with no override, `OpHost::call` falls through to the vendored evmone dispatcher whose Osaka-gated `p256verify` charges exactly that, so the price tracks the spec instead of a hand-maintained constant. Jovian keeps its 3,450 (RIP-7212) override; a test pins both facts.
- `NodeConfig` needed no change: `osaka` is already an accepted `evm_revision` (only `experimental` is rejected), with existing UT coverage.

**2. Deposit (0x7E) execution lane** (`ethereum-executor/`)

- New `OpStackTransition.{h,cpp}`: a consensus-grade strict deposit decoder (integers must be canonical — no leading zeros; `value` ≤ 32 bytes, `gas` ≤ 8 bytes and int64, `isSystemTx` only `0x80`/`0x01`) feeding bcos-evm's existing `runDeposit()`. The executor bridges to bcos-evm's single consensus implementation instead of re-implementing it; the former test-only storage bridge is promoted to a production `OpStackBridge.h` (the test header now just forwards).
- **Storage-read failures are a hard stop, not a default value**: the `StateView` interface is `noexcept` with no error channel, so `OpStackBridge` records any read failure in an atomic flag and both execution entry points check it before `applyEvmoneStateDiff` — a failed read aborts the transaction through the existing rollback path instead of being silently interpreted as "account absent / slot zero / no code". A fault-injection storage stub pins this: injected read failure → exception propagates, zero dirty state committed.
- **Deposit gas: EIP-7825 exemption, no EL-side cap.** Karst enables the EIP-7825 per-tx gas cap (2^24) for normal transactions; deposits are exempt — deposit gas is metered on L1 (the OptimismPortal caps deposits at 20M gas total per L1 block) and the L2 EL performs no deposit gas check of its own (rejecting a deposit the L1 accepted could strand minted ETH). `runDeposit` implements the exemption by clamping only its `validate_transaction` call to Prague; execution runs at the real revision. Vectors at 19,999,999 / 20,000,000 / 20,000,001 gas all execute under Karst — all above 2^24, pinning both the exemption and the absence of an EL cutoff.
- `EngineServiceImpl.h` buildPayload: forced deposits from payload attributes are now actually executed before the scheduler runs (Step 2c-0) — closing the "lands in the block but does not execute" boundary documented in #5421. The gate is a named concept (`ExecutesDeposits`) with a `static_assert` at the real-executor wiring, so an `executeDeposit` signature drift becomes a compile error rather than a silently disabled deposit lane. Deposit receipts feed the block-level totals (receiptsRoot/gasUsed/bloom) via a concat view; the persisted receipt list keeps its decoded-subset alignment invariant — the header thus commits to a receiptsRoot the stored receipts cannot reproduce until C3 models deposits as ledger transactions (called out in code).

**3. Normal transactions switch to `opTransition()`**

`EthereumExecutor.h` dispatches per `feature_l2_ethereum_compat`: the OP lane reassembles the raw envelope, validates via `opValidate` with fee params read from the L1Block slots seeded by #5420, executes via `opTransition` (fee/DA/overrides fully assembled per `OpFeeParams.h`), and writes back the state diff. `eth_call` stays on the pure-Ethereum lane (see notes).

**4. BLOBBASEFEE default hardening (OpHost)**

`get_tx_context` previously defaulted an *unset* `block.blob_base_fee` to 0 via `value_or(0)`. This was not a reachable bug on the executor path — `buildBlockInfo` always fills the field for rev ≥ Cancun, and an OP block computes `fake_exponential(1, excessBlobGas=0, …) == 1` — but a future caller leaving the field unset would have exposed BLOBBASEFEE 0 to contracts. The default is now the EIP-4844 minimum of 1 (`value_or(1)`); a filled value passes through unchanged, with a test asserting both halves.

## Verification

- Build: all touched targets compile clean (`bcos-evm-opstack-tests`, `bcos-evm-eth-tests`, `test-opstack-execution`, `test-ethereum-state-smoke`, `test-transaction-scheduler`, `test-bcos-engine`, `eest-runner`, `test-bcos-framework`).
- `ctest` over the evm/opstack/executor/engine suites → 34/34 passed; full `test-bcos-engine` binary reports "No errors detected".
- Negative coverage run in-tree: 5 non-canonical integer encoding vectors on the deposit decoder, and the fault-injection read-failure case.
- Spec anchors checked against the Optimism Upgrade 19 (Karst) notice and EIP-7951: bn256 300 pairs × 192 = 57,600 bytes; P256VERIFY 6,900 via EIP-7951; deposit 20M is a per-L1-block portal budget, not an EL rule.

## Notes for reviewers

- Deposit receipts are not yet persisted/queryable via `eth_getTransactionReceipt` — that requires modeling deposits as ledger transactions and is C3's scope; here they only contribute to block totals (invariant break documented at the concat site).
- `eth_call` does not apply OP precompile overrides yet: a dry-run and real execution can diverge on bn256 inputs in the 57,600–81,984 **byte** range; the boundary is documented in code.

## Follow-up review round (Copilot)

- **Block gas limit.** Deposits and scheduler transactions each received the full block gas limit as their `blockGasLeft`, with no cumulative pool, so the aggregate could exceed `gasLimit`. This is pre-existing on `release-3.18.0` and not deposit-specific. Copilot's suggested remedy — reserving each sealed transaction's declared gasLimit against what deposits left — was implemented and then reverted: op-geth can reserve safely only because its txpool rejects `tx.Gas() > head.GasLimit` at admission (`core/txpool/validation.go:135`), whereas FISCO's ingress has no such check and the executor rejects an over-cap transaction *before* executing it, leaving `gasUsed = 0` and the sender's nonce unmoved — so `MemPoolImpl::remove(state)`, which prunes strictly by nonce, could never evict it. One free `eth_sendRawTransaction` declaring `gas == block limit` would have reserved every future block's budget forever. What ships instead is an aggregate check bounded to the **CL-injected half**: the forced-deposit subtotal exceeding `gasLimit` throws, while a scheduler overrun is logged at ERROR. Throwing on the scheduler half would have been a second denial of service for the same reason (a throw commits nothing, so the mempool keeps re-sealing the identical batch), and it would buy nothing today — externally received payloads are never re-executed on this lane. Full accounting with the refund half needs a gas pool threaded through `TransactionScheduler::executeBlock`, which is C3's scope.
- **Deposit decode diagnostics.** `decodeDepositTx` collapsed every failure into `std::errc::invalid_argument`. It now returns a `DepositDecodeError` category (following the existing `evm_error_category` precedent) with nine distinct values — wrong type byte, malformed envelope, trailing bytes, non-canonical integer, integer width, invalid bool, truncated body, malformed field, gas out of int64 range. Accept/reject sets are bit-for-bit unchanged: no predicate was altered, all pre-existing reject vectors keep their verdict, and six new vectors plus a message-distinctness check were added.
- **Receipt-set naming.** `BuildPayloadResult::receipts` is renamed `persistedReceipts`, stating at the type level that the persisted list aligns index-by-index with the decoded transaction subset only, while header totals derive from the concat view.
- Forced typed/legacy (non-deposit) raw entries in payload attributes still do not execute — B-lane leftover, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
