### PR TITLE
Fix five independent causes of red CI: Worker teardown UAF, FIB-184 test race, Windows gmp/ERROR-macro/evmc

### DIFF
--- a/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
+++ b/bcos-gateway/test/unittests/FIB184_SessionAsyncLifetimeTest.cpp
@@ -40,6 +40,8 @@
 #include <boost/asio/error.hpp>
 
 #include <boost/test/unit_test.hpp>
+#include <chrono>
+#include <future>
 using namespace bcos;
 using namespace bcos::gateway;
 using namespace bcos::test;
@@ -171,14 +173,40 @@ BOOST_AUTO_TEST_CASE(InFlightReadKeepsSessionAlive)
         "alive; pre-fix weak_ptr capture would have destroyed it here");
 
     // Completing the read with EOF drives drop(): no re-arm, so the read handler releases its
-    // reference. drop() defers the socket teardown onto the socket's io_context; mark the socket
-    // disconnected first so closeSocket() early-returns (no real SSL shutdown in the test), then
-    // drain that io_context so the deferred handler releases its reference too.
+    // reference. drop() then hands out TWO deferred pieces of work, on two different executors:
+    //   1. closeSocket(), posted to the socket's own io_context -- drained by poll() below.
+    //      Mark the socket disconnected first so closeSocket() early-returns (no real SSL
+    //      shutdown here).
+    //   2. the teardown notification, posted to Host::m_teardownPool -- a dedicated executor this
+    //      test drains with a sentinel below.
     fakeSocket->m_connected = false;
     fakeAsio->fireReadHandler(boost::asio::error::eof, 0);
     fakeSocket->ioService().poll();
 
-    BOOST_CHECK_MESSAGE(weakSession.lock() == nullptr,
+    // Piece 2 is why the release cannot be asserted the instant fireReadHandler returns: the
+    // notification lambda captures weak_from_this() but calls lock() on the teardown thread, so
+    // while it runs it holds a strong reference (plus the copy it passes to m_messageHandler).
+    // Asserting straight away raced that thread and made this case fail randomly in CI.
+    //
+    // Drain it instead of sleeping on it. m_teardownPool is a ONE-worker IOServicePool -- a single
+    // io_context serviced by a single thread (Host.cpp: IOServicePool(1, "p2pTeardown")) -- so
+    // posted handlers run strictly FIFO, and drop() ran synchronously inside fireReadHandler above,
+    // which means the notification is already queued. A sentinel posted now therefore runs after
+    // it, by which point notifyDisconnect has returned and both of its strong references are gone.
+    // If the pool ever gains a second worker this barrier stops holding and must be revisited.
+    //
+    // The promise is captured by value through a shared_ptr on purpose: should the wait below time
+    // out and BOOST_REQUIRE unwind the stack, the sentinel may still be sitting in the teardown
+    // queue, and a by-reference capture of a dead local would be exactly the use-after-free this
+    // file exists to prevent.
+    auto teardownDone = std::make_shared<std::promise<void>>();
+    auto teardownDrained = teardownDone->get_future();
+    fakeHost->postTeardown([teardownDone]() { teardownDone->set_value(); });
+    BOOST_REQUIRE_MESSAGE(
+        teardownDrained.wait_for(std::chrono::seconds(5)) == std::future_status::ready,
+        "the teardown executor never drained -- the notification was never dispatched");
+
+    BOOST_CHECK_MESSAGE(weakSession.expired(),
         "FIB-184: once the outstanding read and the deferred teardown complete, the Session must "
         "be released (no leak / self-reference cycle)");
 }

--- a/bcos-utilities/bcos-utilities/FixedBytes.h
+++ b/bcos-utilities/bcos-utilities/FixedBytes.h
@@ -402,7 +402,10 @@ public:
 
     auto begin() { return m_data.begin(); }
     auto end() { return m_data.end(); }
-    auto size() const { return SIZE; }
+    // Returns size_t, not the unnamed enum SIZE is declared in. MSVC rejects
+    // bytesConstRef{data(), size()} otherwise: brace-init forbids narrowing, and the enum's
+    // underlying type is signed int, so int -> size_t is a narrowing conversion there.
+    constexpr size_t size() const { return SIZE; }
     void clear() { m_data.fill(0); }
 
 private:

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -25,6 +25,15 @@
 #include <exception>
 #include <future>
 
+// windows.h -- dragged in by <boost/asio/...> above -- defines ERROR as 0, which turns the
+// BCOS_LOG(ERROR) calls below into bcos::LogLevel::0. BoostLog.h undefs it, but BoostLog.h is
+// #pragma once: in a unity build some earlier file in the same blob has already included it, back
+// when ERROR was still undefined, so its #undef ran as a no-op and cannot run again here. Undo it
+// after every include in this file, so no later asio header can re-introduce it before use.
+#ifdef ERROR
+#undef ERROR
+#endif
+
 using namespace bcos;
 
 namespace

--- a/bcos-utilities/bcos-utilities/Worker.cpp
+++ b/bcos-utilities/bcos-utilities/Worker.cpp
@@ -27,21 +27,29 @@
 
 using namespace bcos;
 
+namespace
+{
+// Upper bound on how long a stop/destroy will wait for the io_context to drain. Exceeding it is
+// always a bug (a wedged handler, or an io_context nobody runs), so it is logged rather than
+// silently tolerated -- but it is bounded so a wedge degrades into a stall, never a deadlock.
+constexpr auto c_drainTimeout = std::chrono::seconds(5);
+}  // namespace
+
 Worker::~Worker()
 {
     stopWorking();
-    // stopWorking() may return early when m_workerState is already
-    // Stopped (e.g. Sealer::stop() called stopWorking() before the
-    // destructor).  In that case pending [this]-capturing handlers
-    // (operation_aborted from cancel, notify() posts) may still be
-    // queued in the io_context.  Post a drain barrier and wait so
-    // that all such handlers are processed before *this is freed.
+    // stopWorking() now owns the main barrier; this one is the backstop for the cases it
+    // cannot cover: it returned early because m_workerState was already Stopped (e.g.
+    // Sealer::stop() ran first) and handlers landed afterwards; it took one of its two
+    // no-wait branches; or its own wait timed out. Pending [this]-capturing handlers
+    // (operation_aborted from cancel, notify() posts) may still be queued in those cases,
+    // so post a drain barrier and wait before *this is freed.
     if (!m_ioContext.stopped() && !m_ioContext.get_executor().running_in_this_thread())
     {
         auto drainPromise = std::make_shared<std::promise<void>>();
         auto drainFuture = drainPromise->get_future();
         boost::asio::post(m_ioContext, [drainPromise]() { drainPromise->set_value(); });
-        auto drainStatus = drainFuture.wait_for(std::chrono::seconds(5));
+        auto drainStatus = drainFuture.wait_for(c_drainTimeout);
         if (drainStatus != std::future_status::ready)
         {
             BCOS_LOG(ERROR) << LOG_DESC("Worker::~Worker() timed out waiting for handler drain")
@@ -96,19 +104,55 @@ void Worker::stopWorking()
         return;  // Not running, or another thread is already stopping
     }
 
-    // Cancel the timer.  If we are already on the io_context thread we
-    // can mutate m_timer directly; otherwise we post the cancel.
-    // No need to wait — ~Worker() drains all [this]-capturing handlers
-    // before the object can be freed, and any timer tick that fires
-    // between now and the cancel will early-return on !Started.
+    // Cancel the timer and WAIT until the io_context has drained, so that stopWorking()
+    // returning means "no timer-driven executeWorker() is in flight, and nothing this Worker
+    // queued is still pending".
+    //
+    // What this does NOT cover: notify() (below) reads m_workerState and posts in two separate
+    // steps, so a concurrent notify() that passed its check just before the CAS can still land a
+    // handler after this barrier has drained. Closing that needs the handlers to hold ownership
+    // of the object (weak_from_this in every posted lambda), which is a separate change.
+    //
+    // The wait is not optional. The CAS above only stops FUTURE ticks from entering
+    // executeWorker(); a tick that already entered keeps running on the io_context
+    // thread. ~Worker() does drain the queue, but by C++ destruction order it runs
+    // AFTER the derived class has destroyed its own members -- so a derived
+    // executeWorker() (e.g. Sealer's, which dereferences m_sealingManager) would be
+    // touching freed memory long before that drain is reached. The barrier has to be
+    // here, while the whole object is still intact.
     if (m_ioContext.get_executor().running_in_this_thread())
     {
+        // We ARE the io_context thread, so the only handler that could be in flight is the one
+        // calling us: there is nothing to wait for, and waiting would deadlock against
+        // ourselves. Cancelling here is safe precisely because we are on that thread.
         m_timer.cancel();
     }
-    else
+    else if (!m_ioContext.stopped())
     {
-        boost::asio::post(m_ioContext, [this]() { m_timer.cancel(); });
+        auto drainPromise = std::make_shared<std::promise<void>>();
+        auto drainFuture = drainPromise->get_future();
+        // The barrier is posted from INSIDE the cancel handler on purpose. It is
+        // m_timer.cancel() that queues the outstanding async_wait's operation_aborted
+        // completion, so a barrier posted from this thread alongside the cancel would
+        // sit AHEAD of that completion and let stopWorking() return with a handler
+        // still queued. Posting it after the cancel call puts it behind.
+        boost::asio::post(m_ioContext, [this, drainPromise]() {
+            m_timer.cancel();
+            boost::asio::post(m_ioContext, [drainPromise]() { drainPromise->set_value(); });
+        });
+        // Deliberately wait_for() and never get(): if the outer handler is destroyed without
+        // running, the future is ready-with-broken_promise, and get() would rethrow that inside
+        // whoever is stopping us. Only readiness matters here.
+        if (drainFuture.wait_for(c_drainTimeout) != std::future_status::ready)
+        {
+            BCOS_LOG(ERROR) << LOG_DESC("Worker::stopWorking() timed out draining handlers")
+                            << LOG_KV("threadName", m_threadName);
+        }
     }
+    // else: the io_context is stopped. No handler is running, none ever will be, and the
+    // operation_aborted completion a cancel would queue could never be delivered either -- so
+    // there is nothing to cancel and nothing to drain. Touching m_timer from this thread would
+    // only add a cross-thread access to an object asio documents as unsafe to share.
 
     try
     {
@@ -179,6 +223,10 @@ void Worker::handleTimerTick(boost::system::error_code const& ec)
 
 void Worker::notify()
 {
+    // NOTE: this check and the post below are not atomic, so a caller that reads Started here can
+    // still land its handler after stopWorking() has drained and the object has been destroyed.
+    // stopWorking()'s barrier does NOT cover that window; closing it needs the posted lambdas to
+    // hold ownership (weak_from_this) rather than a raw this.
     if (m_workerState == WorkerState::Started)
     {
         // Cancel any pending timer and immediately trigger one worker cycle

--- a/bcos-utilities/test/unittests/libutilities/WorkerStopBarrierTest.cpp
+++ b/bcos-utilities/test/unittests/libutilities/WorkerStopBarrierTest.cpp
@@ -1,0 +1,136 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test: Worker::stopWorking() must not return while executeWorker() runs
+ * @file WorkerStopBarrierTest.cpp
+ * @date 2026-08-18
+ *
+ * Sealer's FIB164_OnReadyLifecycle test crashed at random on CI (SIGSEGV / "pthread_mutex_lock:
+ * Invalid argument") because stopWorking()'s compare_exchange only stops FUTURE ticks from
+ * entering executeWorker(); a tick that had already entered kept running on the io_context
+ * thread. Sealer::stop() therefore returned while executeWorker() was still dereferencing
+ * m_sealingManager, and the caller was free to destroy the Sealer right after -- freeing that
+ * member out from under the running tick.
+ *
+ * ~Worker() does drain the io_context, but by C++ destruction order it runs AFTER the derived
+ * class has already destroyed its own members, so it cannot protect them. The barrier belongs in
+ * stopWorking(), while the whole object is still intact. This test pins that.
+ */
+
+#include "bcos-utilities/Worker.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using namespace bcos;
+
+namespace bcos::test
+{
+namespace
+{
+// How long the blocked tick stays inside executeWorker() after it has observed the stop request.
+// This is a margin, not a timing assumption: without the barrier stopWorking() returns in
+// microseconds (it only posts a cancel), so any value well above scheduling jitter makes the
+// pre-fix behaviour deterministically observable. With the barrier the wait is unbounded from the
+// test's point of view -- stopWorking() returns only once executeWorker() has returned, whatever
+// this value is.
+constexpr auto c_holdAfterStopRequested = std::chrono::milliseconds(200);
+
+// Bound on waiting for the first tick to start, so a broken Worker fails the assert below rather
+// than hanging the suite.
+constexpr auto c_tickStartTimeout = std::chrono::seconds(5);
+}  // namespace
+
+// A Worker whose first tick parks inside executeWorker() until the stop request is visible, then
+// lingers before returning. Everything is observed through atomics -- the test never sleeps to
+// "wait for" anything.
+class BarrierWorker : public Worker
+{
+public:
+    explicit BarrierWorker(boost::asio::io_context& _ioContext)
+      : Worker(_ioContext, "BarrierWorker", 0)
+    {}
+
+    void run() { startWorking(); }
+    void stop() { stopWorking(); }
+
+    bool entered() const { return m_entered.load(); }
+    bool leftExecuteWorker() const { return m_left.load(); }
+
+protected:
+    void executeWorker() override
+    {
+        // Only the first tick parks; later ticks (if any) must not block the barrier.
+        if (m_entered.exchange(true))
+        {
+            return;
+        }
+        // Park until stopWorking() has flipped the state. That instant is exactly where the
+        // pre-fix code returned from stopWorking(), so from here on the only thing that can keep
+        // stopWorking() waiting is the barrier under test.
+        while (!shouldStop())
+        {
+            std::this_thread::yield();
+        }
+        std::this_thread::sleep_for(c_holdAfterStopRequested);
+        m_left.store(true);
+    }
+
+private:
+    std::atomic_bool m_entered{false};
+    std::atomic_bool m_left{false};
+};
+
+BOOST_FIXTURE_TEST_SUITE(WorkerStopBarrier, TestPromptFixture)
+
+BOOST_AUTO_TEST_CASE(stopWorkingWaitsForInFlightExecuteWorker)
+{
+    boost::asio::io_context ioContext;
+    auto work = boost::asio::make_work_guard(ioContext);
+    std::thread ioThread([&]() { ioContext.run(); });
+
+    BarrierWorker worker(ioContext);
+    worker.run();
+
+    // Hand the io_context thread time to get INTO executeWorker(); stopping before the tick even
+    // starts would test nothing. Bounded so a broken Worker fails the assert instead of hanging.
+    auto deadline = std::chrono::steady_clock::now() + c_tickStartTimeout;
+    while (!worker.entered() && std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::yield();
+    }
+    BOOST_REQUIRE_MESSAGE(worker.entered(), "executeWorker() never ran; the test setup is broken");
+
+    worker.stop();
+
+    // The regression. Pre-fix stopWorking() posted the timer cancel and returned immediately,
+    // leaving executeWorker() running on the io_context thread -- so a caller that destroys the
+    // derived object right here frees members the tick is still using.
+    BOOST_CHECK_MESSAGE(worker.leftExecuteWorker(),
+        "stopWorking() returned while executeWorker() was still running: a derived class "
+        "destroyed right after stop() would free its members under the running tick");
+
+    work.reset();
+    ioContext.stop();
+    ioThread.join();
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/ports/evmc/portfile.cmake
+++ b/ports/evmc/portfile.cmake
@@ -1,0 +1,30 @@
+# EVMC headers only, split out of the evmone port.
+#
+# bcos-framework/ledger/LedgerConfig.h has used evmc types (evmc::bytes32, evmc_uint256be,
+# evmc_revision) in its public interface since 2024-04, and bcos-framework is built
+# unconditionally -- including the Windows CI job, which configures with -DFULLNODE=OFF. The
+# headers used to arrive only as a side effect of installing evmone, a fullnode-feature
+# dependency, so that job could not compile bcos-framework at all. (It never got far enough to
+# notice: vcpkg install died earlier, on gmp.)
+#
+# The headers are vendored inside the evmone source archive, so this port fetches the same
+# archive and installs nothing but evmc/include/evmc. evmone no longer installs them and depends
+# on this port instead -- two ports must not install the same files, vcpkg rejects that outright.
+#
+# Keep REF/SHA512 in lockstep with ports/evmone/portfile.cmake. They name the same upstream
+# archive, so vcpkg downloads it once and both ports extract from the cached copy.
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ipsilon/evmone
+    REF v0.21.0
+    SHA512 bc2928d42140d2fbb47d1e06773e634d208945e52ac70a418798586897a60164910cc2b23c80479ae172941d8d9142ea6fdd86e13f560195cff44ccdc1f1d0f2
+    HEAD_REF master
+)
+
+file(INSTALL "${SOURCE_PATH}/evmc/include/evmc/" DESTINATION "${CURRENT_PACKAGES_DIR}/include/evmc")
+
+# Header-only: no libraries, so no debug tree and nothing for vcpkg's post-build lib checks.
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+file(INSTALL "${SOURCE_PATH}/LICENSE" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}"
+     RENAME copyright)

--- a/ports/evmc/vcpkg.json
+++ b/ports/evmc/vcpkg.json
@@ -1,0 +1,12 @@
+{
+    "name": "evmc",
+    "version-string": "0.21.0",
+    "homepage": "https://github.com/ipsilon/evmone",
+    "description": "EVMC headers, as vendored by evmone 0.21.0 (header-only)",
+    "dependencies": [
+        {
+            "name": "vcpkg-cmake",
+            "host": true
+        }
+    ]
+}

--- a/ports/evmone/portfile.cmake
+++ b/ports/evmone/portfile.cmake
@@ -37,9 +37,11 @@ file(REMOVE_RECURSE
     "${CURRENT_PACKAGES_DIR}/debug/lib/cmake/evmone"
 )
 
-# 4. Install evmc headers (evmone's build doesn't install them)
-file(INSTALL "${SOURCE_PATH}/evmc/include/evmc/"
-    DESTINATION "${CURRENT_PACKAGES_DIR}/include/evmc")
+# 4. The vendored evmc headers are installed by the separate `evmc` port, not here. They are
+#    needed by bcos-framework, which is built even when FULLNODE=OFF and therefore without
+#    evmone; shipping them from this port made them unavailable to that configuration. Two ports
+#    installing the same files is rejected by vcpkg, so this port must not install them as well.
+#    evmone's own build is unaffected -- it compiles against the copy in its source tree.
 
 # 4a. Install evmone precompiles static library because evmone.a depends on it transitively.
 # Use platform-aware library name: .lib on Windows, .a on Unix.

--- a/ports/evmone/vcpkg.json
+++ b/ports/evmone/vcpkg.json
@@ -1,7 +1,7 @@
 {
     "name": "evmone",
     "version-string": "0.21.0",
-    "port-version": 8,
+    "port-version": 9,
     "homepage": "https://github.com/ipsilon/evmone",
     "description": "Fast Ethereum Virtual Machine implementation (EVMC merged)",
     "dependencies": [
@@ -13,6 +13,7 @@
             "name": "vcpkg-cmake-config",
             "host": true
         },
+        "evmc",
         "intx",
         "blst"
     ]

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -17,6 +17,7 @@
     "./ports/tarscpp",
     "./ports/rapidhash",
     "./ports/openssl",
+    "./ports/evmc",
     "./ports/evmone",
     "./ports/intx",
     "./ports/blst",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,7 +35,6 @@
     "tbb",
     "jsoncpp",
     "jwt-cpp",
-    "gmp",
     "curl",
     "tomlplusplus",
     {
@@ -78,6 +77,7 @@
         "tarscpp",
         "blst",
         "ittapi",
+        "gmp",
         "group-sig",
         "paillier"
       ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -35,6 +35,7 @@
     "tbb",
     "jsoncpp",
     "jwt-cpp",
+    "evmc",
     "curl",
     "tomlplusplus",
     {


### PR DESCRIPTION
Five independent causes of red CI on `release-3.18.0`, one commit each. None of them is a flaw in the code under test — two are races in the tests' own synchronisation and one is a use-after-free in `Worker` that only a test happened to be tight enough to catch.

## 1. `Worker::stopWorking()` returned while `executeWorker()` was still running

`FIB164_OnReadyLifecycle/callback_invokes_noteGenerateProposal_while_sealer_alive` crashed at random on the macOS runner ([example](https://github.com/FISCO-BCOS/FISCO-BCOS/actions/runs/31161206064/job/92811722231)), either SIGSEGV or `boost: mutex lock failed in pthread_mutex_lock: Invalid argument`. lldb pins it:

```
thread #2, EXC_BAD_ACCESS (address=0x58)
  frame #0: bcos::sealer::Sealer::executeWorker(this=0x795038018) at Sealer.cpp:134
   -> if (m_sealingManager->fetchTransactions() == ...NO_TRANSACTION)
```

The `Sealer` is intact; the member it dereferences is not.

`Sealer` derives from `Worker` first, so destruction runs `~Sealer`'s body, then Sealer's own members (`m_sealingManager` among them), and only then `~Worker` — where the sole io_context drain barrier lives. It runs after the members it was meant to protect are already gone. And `stopWorking()`'s CAS only keeps *future* ticks out of `executeWorker()`; the old code explicitly did not wait for a tick that had already entered. So `stop()` could return mid-`executeWorker()`, and destroying the Sealer right after freed the member under the running tick.

The fix moves the barrier into `stopWorking()`, while the object is still whole. The nesting matters: `m_timer.cancel()` is what queues the outstanding `async_wait`'s `operation_aborted` completion, so the barrier is posted from *inside* the cancel handler — posted alongside it from the calling thread, it would sit ahead of that completion.

**Shutdown behaviour changes:** `stopWorking()` now blocks until the io_context drains. These contexts come from the shared `IOServicePool` and also carry scheduler/executor/txpool work, so shutdown latency is bounded by the longest in-flight handler there, capped at 5s per Worker. A wedge degrades into a logged stall, not a deadlock.

**Not closed by this PR:** `notify()` reads `m_workerState` and posts in two separate steps, so a caller that passed its check just before the CAS can still land a handler after the barrier drained. Closing it needs the posted lambdas to own the object (`weak_from_this` instead of a raw `this`) — a separate change. Both sites now say so in comments.

## 2. FIB-184 gateway test raced the teardown executor

`InFlightReadKeepsSessionAlive` failed at random on its last assertion. `Session::drop()` hands out two deferred pieces of work on two different executors: `closeSocket()` to the socket's io_context (which the test drained), and the teardown notification to `Host::m_teardownPool`, which the test never synchronised with. That notification captures `weak_from_this()` but calls `lock()` on the teardown thread, so while it runs it holds a strong reference plus the copy passed to `m_messageHandler`.

The test now drains that executor with a sentinel through `Host::postTeardown()`. `m_teardownPool` is a one-worker `IOServicePool`, so handlers run strictly FIFO, and `drop()` runs synchronously inside `fireReadHandler()` — the notification is already queued when the sentinel is posted.

## 3. windows-2025 cannot build `gmp` any more

Not flaky — deterministic on a cold vcpkg cache, and reproducible on `release-3.18.0` itself ([run 31991944289](https://github.com/FISCO-BCOS/FISCO-BCOS/actions/runs/31991944289)):

```
Downloading autoconf2.71-2.71-3-any.pkg.tar.zst, trying https://mirror.msys2.org/...
error: ... failed: status code 404      (all six mirrors)
error: building gmp:x64-windows failed with: BUILD_FAILED
```

gmp's portfile goes through `vcpkg_configure_make` → `vcpkg_acquire_msys`, which pins an exact MSYS2 package version that MSYS2 has since dropped from every mirror. When `actions/cache` hits, vcpkg install is skipped and the job is green; when the key changes it goes red — hence the intermittent appearance.

Windows configures with `-DFULLNODE=OFF` and does not need gmp: the only consumer is `ports/group-sig`, which declares gmp in its own manifest, and group-sig/paillier are fullnode dependencies. Moving gmp under `features.fullnode` leaves Linux/macOS resolution identical and drops it from the Windows plan entirely.

## 4. `Worker.cpp` did not survive windows.h's `ERROR` macro

Removing gmp let the Windows compiler run for the first time in a long while, and it immediately failed:

```
Worker.cpp(55): error C2589: 'constant': illegal token on right side of '::'
Worker.cpp(148): error C2589: ...
```

windows.h, pulled in by the asio headers, defines `ERROR` as 0, so `BCOS_LOG(ERROR)` becomes `bcos::LogLevel::0`. `BoostLog.h` undefs `ERROR`, and in a standalone translation unit that suffices. But bcos-utilities is a unity build and the failing object is `Unity/unity_1_cxx.cxx`: an earlier file in the blob had already included `BoostLog.h` while `ERROR` was still undefined, so its `#undef` ran as a no-op, and `#pragma once` stops it running again. Line 55 is pre-existing; line 148 came with the barrier in commit 1.

Reproduced without MSVC by rebuilding the unity include order — include `BoostLog.h`, `#define ERROR 0`, then the file under test. Pre-fix that errors at exactly lines 55 and 148; post-fix it is clean.

## 5. `evmc` headers were unreachable without the fullnode feature

Next layer down, same job:

```
bcos-framework/ledger/LedgerConfig.h(26): fatal error C1083:
  Cannot open include file: 'evmc/evmc.hpp': No such file or directory
```

`LedgerConfig.h` has used evmc types in its public interface since 2024-04, and bcos-framework is built unconditionally — including on Windows with `-DFULLNODE=OFF`. The headers only ever arrived as a side effect of installing evmone, a fullnode dependency.

A new `ports/evmc` fetches the same evmone archive (same REF/SHA512, so it downloads once) and installs only `evmc/include/evmc`; evmone stops installing them and depends on it instead, since vcpkg rejects two ports installing the same files. `ports/evmc` also has to be listed in `vcpkg-configuration.json`'s `overlay-ports` — that list names directories one by one, and a port missing from it falls through to the registry with `the baseline does not contain an entry for port evmc`.

The 9 installed headers are byte-identical to the ones evmone used to install.


## Verification

Run locally on macOS ARM64 this session:

| | result |
|---|---|
| New `WorkerStopBarrierTest`, pre-fix `Worker.cpp` | fails 10/10 |
| New `WorkerStopBarrierTest`, post-fix | passes 30/30 |
| Sealer FIB-164 under 8-way concurrency, pre-fix | 2 crashes / 320 runs |
| Sealer FIB-164 under 8-way concurrency, post-fix | 0 / 400 |
| Sealer FIB-164 with a 500ms probe widening the window, pre-fix | 6 crashes / 10 runs |
| same, post-fix | 0 / 10 |
| FIB-184 gateway test with a 300ms widened window, old assertion | fails (same message as CI) |
| same, new assertion | passes |
| FIB-184 with a deliberate leak, new assertion | still fails, in 7ms |
| `vcpkg install --dry-run --x-feature=fullnode` | gmp present, via group-sig |
| `vcpkg install --dry-run` (no fullnode) | gmp absent |

`ctest` after rebasing onto `944d450ec`: bcos-utilities 72/72, bcos-sealer 53/53, bcos-sync 1/1, bcos-pbft 143/143, bcos-rpc 241/241, bcos-gateway 130/130.

Not verified locally: the Windows build itself (no Windows machine here) — the gmp change rests on vcpkg dependency-graph evidence and needs the cold-cache windows-2025 run in this PR to confirm. Changing `vcpkg.json` invalidates the cache key, so this PR's run is exactly that cold-cache case.
