### PR TITLE
[NodeConfig] Add config-domain structs and syncConfigStructs (phase 1 of 3)

### DIFF
--- a/bcos-pbft/test/unittests/pbft/PBFTViewChangeTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/PBFTViewChangeTest.cpp
@@ -121,7 +121,14 @@ BOOST_AUTO_TEST_CASE(testViewChangeWithPrecommitProposals)
         {
             auto cacheProc = std::dynamic_pointer_cast<FakeCacheProcessor>(
                 otherNode.second->pbftEngine()->cacheProcessor());
-            if (cacheProc->caches().size() < 2)
+            // caches() is std::map<BlockNumber, PBFTCache::Ptr>: the loop below
+            // dereferences [expectedProposal] and [futureBlockIndex], so guard
+            // on key presence, not on the entry count (a size check passes even
+            // when both slots are unrelated blocks, and operator[] would then
+            // insert a null cache).
+            auto const& caches = cacheProc->caches();
+            if (caches.count(expectedProposal) == 0 ||
+                caches.count(futureBlockIndex) == 0)
             {
                 allInPrecommit = false;
                 break;

--- a/bcos-pbft/test/unittests/pbft/PBFTViewChangeTest.cpp
+++ b/bcos-pbft/test/unittests/pbft/PBFTViewChangeTest.cpp
@@ -103,11 +103,14 @@ BOOST_AUTO_TEST_CASE(testViewChangeWithPrecommitProposals)
     BOOST_CHECK(futureCache->index() == futureBlockIndex);
     BOOST_CHECK(futureCache->prePrepare());
 
-    // Poll until all nodes reach preCommit (2 caches each), with timeout
+    // Poll until all nodes reach preCommit (2 caches each), with timeout.
+    // The timeout is deliberately generous: on slow CI runners (e.g. ARM)
+    // ten fake nodes need longer to drive every cache into preCommit, and the
+    // loop below dereferences caches()[expectedProposal] unconditionally.
     auto precommitStartT = std::chrono::steady_clock::now();
     bool allInPrecommit = false;
     while (!allInPrecommit &&
-           std::chrono::steady_clock::now() - precommitStartT < std::chrono::seconds(3))
+           std::chrono::steady_clock::now() - precommitStartT < std::chrono::seconds(15))
     {
         for (auto const& otherNode : fakerMap)
         {
@@ -126,6 +129,12 @@ BOOST_AUTO_TEST_CASE(testViewChangeWithPrecommitProposals)
         }
         if (!allInPrecommit)
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    if (!allInPrecommit)
+    {
+        // caches()[expectedProposal] below would dereference a null cache and
+        // segfault on slow runners; fail cleanly so the timeout is visible.
+        BOOST_FAIL("nodes did not reach preCommit within the 15s timeout");
     }
     // assume five nodes into preCommit
     size_t precommitSize = 5;

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -120,6 +120,180 @@ NodeConfig::NodeConfig(KeyFactory::Ptr _keyFactory)
 
 NodeConfig::NodeConfig() : m_ledgerConfig(std::make_shared<LedgerConfig>()) {}
 
+// Phase 1 of a staged refactor: copy the legacy members into the new
+// config-domain structs after loading. The getters/setters still read the
+// legacy members; the cutover phase removes them and migrates callers to the
+// struct fields directly.
+void NodeConfig::syncConfigStructs()
+{
+    // txpool
+    txpool.limit = m_txpoolLimit;
+    txpool.txsExpirationTime = m_txsExpirationTime;
+    txpool.checkBlockLimit = m_checkBlockLimit;
+    txpool.enableTxsFromFreeNode = m_enableTxsFromFreeNode;
+    txpool.preStoreBackpressureEnabled = m_preStoreBackpressureEnabled;
+    txpool.preStoreMaxInflight = m_preStoreMaxInflight;
+
+    // chain
+    chain.blockLimit = m_blockLimit;
+
+    // sealer
+    sealer.minSealTime = m_minSealTime;
+    sealer.allowFreeNode = m_allowFreeNode;
+
+    // consensus
+    consensus.checkPointTimeoutInterval = m_checkPointTimeoutInterval;
+    consensus.pipelineSize = m_pipelineSize;
+    consensus.pipelineAdmissionEnabled = m_pipelineAdmissionEnabled;
+    consensus.pipelinePerPeerCapacity = m_pipelinePerPeerCapacity;
+    consensus.pipelineLruCapacity = m_pipelineLruCapacity;
+    consensus.pipelineMaxPeers = m_pipelineMaxPeers;
+
+    // security
+    security.privateKeyPath = m_privateKeyPath;
+    security.hsmLibPath = m_hsmLibPath;
+    security.keyIndex = m_keyIndex;
+    security.password = m_password;
+    security.keyEncryptionType = m_keyEncryptionType;
+    security.keyEncryptionUrl = m_KeyEncryptionUrl;
+    security.cloudKmsType = m_cloudKmsType;
+    security.bcosKmsKeySecurityCipherDataKey = m_bcosKmsKeySecurityCipherDataKey;
+
+    // storage security
+    storageSecurity.enable = m_storageSecurityEnable;
+    storageSecurity.keyCenterUrl = m_storageSecurityUrl;
+    storageSecurity.cipherDataKey = m_storageSecurityCipherDataKey;
+    storageSecurity.encryptionType = m_storageEncryptionType;
+
+    // storage
+    storage.dataPath = m_storagePath;
+    storage.type = m_storageType;
+    storage.keyPageSize = m_keyPageSize;
+    storage.pdAddrs = m_pd_addrs;
+    storage.pdCaPath = m_pdCaPath;
+    storage.pdCertPath = m_pdCertPath;
+    storage.pdKeyPath = m_pdKeyPath;
+    storage.enableStatistics = m_enableDBStatistics;
+    storage.maxWriteBufferNumber = m_maxWriteBufferNumber;
+    storage.maxBackgroundJobs = m_maxBackgroundJobs;
+    storage.writeBufferSize = m_writeBufferSize;
+    storage.minWriteBufferNumberToMerge = m_minWriteBufferNumberToMerge;
+    storage.blockCacheSize = m_blockCacheSize;
+    storage.enableRocksDBBlob = m_enableRocksDBBlob;
+    storage.enableArchive = m_enableArchive;
+    storage.syncArchivedBlocks = m_syncArchivedBlocks;
+    storage.enableSeparateBlockAndState = m_enableSeparateBlockAndState;
+    storage.stateDBPath = m_stateDBPath;
+    storage.blockDBPath = m_blockDBPath;
+    storage.archiveListenIP = m_archiveListenIP;
+    storage.archiveListenPort = m_archiveListenPort;
+    storage.dbName = m_storageDBName;
+    storage.stateDBName = m_stateDBName;
+    storage.enableLRUCacheStorage = m_enableLRUCacheStorage;
+    storage.cacheSize = m_cacheSize;
+
+    // executor
+    executor.vmCacheSize = m_vmCacheSize;
+    executor.baselineScheduler = m_baselineSchedulerConfig;
+
+    // rpc
+    rpc.listenIP = m_rpcListenIP;
+    rpc.listenPort = m_rpcListenPort;
+    rpc.filterTimeout = m_rpcFilterTimeout;
+    rpc.maxProcessBlock = m_rpcMaxProcessBlock;
+    rpc.smSsl = m_rpcSmSsl;
+    rpc.disableSsl = m_rpcDisableSsl;
+
+    // web3 rpc
+    web3Rpc.enable = m_enableWeb3Rpc;
+    web3Rpc.listenIP = m_web3RpcListenIP;
+    web3Rpc.listenPort = m_web3RpcListenPort;
+    web3Rpc.filterTimeout = m_web3FilterTimeout;
+    web3Rpc.maxProcessBlock = m_web3MaxProcessBlock;
+    web3Rpc.batchRequestSizeLimit = m_web3BatchRequestSizeLimit;
+    web3Rpc.httpBodySizeLimit = m_web3HttpBodySizeLimit;
+    web3Rpc.enableCors = m_web3EnableCors;
+    web3Rpc.corsAllowedOrigins = m_web3CorsAllowedOrigins;
+    web3Rpc.corsAllowedMethods = m_web3CorsAllowedMethods;
+    web3Rpc.corsAllowedHeaders = m_web3CorsAllowedHeaders;
+    web3Rpc.corsMaxAge = m_web3CorsMaxAge;
+    web3Rpc.corsAllowCredentials = m_web3CorsAllowCredentials;
+    web3Rpc.syncTransaction = m_web3SyncTransaction;
+    web3Rpc.safeBlockDepth = m_web3SafeBlockDepth;
+    web3Rpc.finalizedBlockDepth = m_web3FinalizedBlockDepth;
+
+    // op engine rpc
+    opEngineRpc.enable = m_enableOpEngineRpc;
+    opEngineRpc.listenIP = m_opEngineRpcListenIP;
+    opEngineRpc.listenPort = m_opEngineRpcListenPort;
+    opEngineRpc.httpBodySizeLimit = m_opEngineHttpBodySizeLimit;
+    opEngineRpc.batchRequestSizeLimit = m_opEngineBatchRequestSizeLimit;
+    opEngineRpc.jwtSecretFile = m_opEngineJwtSecretFile;
+    opEngineRpc.clockSkewSecs = m_opEngineClockSkewSecs;
+    opEngineRpc.allowV1Executor = m_opEngineAllowV1Executor;
+
+    // single-node consensus
+    singleNodeConsensus.enable = m_enableSingleNodeConsensus;
+    singleNodeConsensus.blockInterval = m_singleNodeConsensusBlockInterval;
+    singleNodeConsensus.produceEmptyBlocks = m_singleNodeConsensusProduceEmptyBlocks;
+    singleNodeConsensus.feeRecipient = m_singleNodeConsensusFeeRecipient;
+    singleNodeConsensus.prevRandao = m_singleNodeConsensusPrevRandao;
+    singleNodeConsensus.fixedTimestamp = m_singleNodeConsensusFixedTimestamp;
+
+    // gateway
+    gateway.listenIP = m_p2pListenIP;
+    gateway.listenPort = m_p2pListenPort;
+    gateway.smSsl = m_p2pSmSsl;
+    gateway.nodeDir = m_p2pNodeDir;
+    gateway.nodeFileName = m_p2pNodeFileName;
+
+    // sync
+    sync.enableSendBlockStatusByTree = m_enableSendBlockStatusByTree;
+    sync.enableSendTxByTree = m_enableSendTxByTree;
+    sync.treeWidth = m_treeWidth;
+
+    // cert
+    cert.path = m_certPath;
+    cert.caCert = m_caCert;
+    cert.nodeCert = m_nodeCert;
+    cert.nodeKey = m_nodeKey;
+    cert.smCaCert = m_smCaCert;
+    cert.smNodeCert = m_smNodeCert;
+    cert.smNodeKey = m_smNodeKey;
+    cert.enSmNodeCert = m_enSmNodeCert;
+    cert.enSmNodeKey = m_enSmNodeKey;
+
+    // failover
+    failOver.enable = m_enableFailOver;
+    failOver.clusterUrl = m_failOverClusterUrl;
+    failOver.memberID = m_memberID;
+    failOver.leaseTTL = m_leaseTTL;
+
+    // thread pool
+    threadPool.ioThreadCount = m_ioThreadCount;
+    threadPool.tbbThreadCount = m_tbbThreadCount;
+
+    // tars rpc
+    tarsRPC = m_tarsRPCConfig;
+
+    // others
+    others.sendTxTimeout = m_sendTxTimeout;
+    others.checkTransactionSignature = m_checkTransactionSignature;
+    others.checkParallelConflict = m_checkParallelConflict;
+    others.singlePointConsensus = m_singlePointConsensus;
+    others.forceSender = m_forceSender;
+
+    // service
+    service.withoutTarsFramework = m_withoutTarsFramework;
+    service.tarsSN2EndPoints = m_tarsSN2EndPoints;
+    service.rpcServiceName = m_rpcServiceName;
+    service.gatewayServiceName = m_gatewayServiceName;
+    service.schedulerServiceName = m_schedulerServiceName;
+    service.executorServiceName = m_executorServiceName;
+    service.txpoolServiceName = m_txpoolServiceName;
+    service.nodeName = m_nodeName;
+}
+
 void NodeConfig::loadConfig(std::string const& _configPath, bool _enforceMemberID,
     bool enforceChainConfig, bool enforceGroupId)
 {
@@ -180,6 +354,7 @@ void NodeConfig::loadConfig(boost::property_tree::ptree const& _pt, bool _enforc
     loadConsensusConfig(_pt);
     loadSyncConfig(_pt);
     loadOthersConfig(_pt);
+    syncConfigStructs();
 }
 
 void NodeConfig::loadGenesisConfig(boost::property_tree::ptree const& _genesisConfig)
@@ -204,6 +379,7 @@ void NodeConfig::loadGenesisConfig(boost::property_tree::ptree const& _genesisCo
     // === A3: B0 full Ethereum genesis header from the merged genesis artifact ===
     loadEthGenesisHeader(_genesisConfig);
     validateL2Invariants();
+    syncConfigStructs();
 }
 
 void NodeConfig::loadAllocs(boost::property_tree::ptree const& _genesisConfig)

--- a/bcos-tool/bcos-tool/NodeConfig.h
+++ b/bcos-tool/bcos-tool/NodeConfig.h
@@ -46,6 +46,234 @@ public:
     constexpr static ssize_t DEFAULT_PIPELINE_SIZE = 50;
 
     using Ptr = std::shared_ptr<NodeConfig>;
+
+    // ================================================================
+    // Config domains — public fields grouped per config domain (mostly 1:1
+    // with INI sections; a few load()s read across sections, and
+    // ServiceConfig is populated by the loadXxxServiceConfig methods).
+    // Phase 1 of a staged refactor: these structs are populated from the
+    // legacy members by syncConfigStructs() after loading; the getters/
+    // setters still expose the legacy members until the cutover phase.
+    // ================================================================
+
+    struct BaselineSchedulerConfig
+    {
+        bool parallel = false;
+        int grainSize = 0;
+    };
+
+    struct TarsRPCConfig
+    {
+        std::string host;
+        uint16_t port = 0;
+    } tarsRPC;
+
+    struct ChainConfig
+    {
+        size_t blockLimit = 1000;
+    } chain;
+
+    struct TxPoolConfig
+    {
+        size_t limit = 15000;
+        int64_t txsExpirationTime = 600'000;
+        bool checkBlockLimit = true;
+        bool enableTxsFromFreeNode = false;
+        bool preStoreBackpressureEnabled = true;
+        size_t preStoreMaxInflight = 1024;
+    } txpool;
+
+    struct SealerConfig
+    {
+        size_t minSealTime = 500;
+        bool allowFreeNode = false;
+    } sealer;
+
+    struct ConsensusConfig
+    {
+        size_t checkPointTimeoutInterval = DEFAULT_MIN_CONSENSUS_TIME_MS;
+        size_t pipelineSize = DEFAULT_PIPELINE_SIZE;
+        bool pipelineAdmissionEnabled = true;
+        size_t pipelinePerPeerCapacity = 64;
+        size_t pipelineLruCapacity = 256;
+        size_t pipelineMaxPeers = 1024;
+    } consensus;
+
+    struct SecurityConfig
+    {
+        std::string privateKeyPath = "node.pem";
+        std::string hsmLibPath;
+        int keyIndex{};
+        std::string password;
+        security::KeyEncryptionType keyEncryptionType = security::KeyEncryptionType::LEGACY;
+        security::CloudKmsType cloudKmsType = security::CloudKmsType::AWS;
+        std::string keyEncryptionUrl;
+        std::string bcosKmsKeySecurityCipherDataKey;
+    } security;
+
+    struct StorageSecurityConfig
+    {
+        bool enable = false;
+        security::StorageEncryptionType encryptionType = security::StorageEncryptionType::LEGACY;
+        std::string keyCenterUrl;
+        std::string cipherDataKey;
+    } storageSecurity;
+
+    struct StorageConfig
+    {
+        std::string dataPath;
+        std::string type = "RocksDB";
+        size_t keyPageSize = 10240;
+        std::vector<std::string> pdAddrs;
+        std::string pdCaPath;
+        std::string pdCertPath;
+        std::string pdKeyPath;
+        bool enableStatistics = false;
+        // Effective defaults are 4/4/64MB/1 (matching load()); the struct is the
+        // single source and load() falls back to these members.
+        int maxWriteBufferNumber = 4;
+        int maxBackgroundJobs = 4;
+        size_t writeBufferSize = 64 << 20;
+        int minWriteBufferNumberToMerge = 1;
+        size_t blockCacheSize = 128 << 20;
+        bool enableRocksDBBlob = false;
+        bool enableArchive = false;
+        bool syncArchivedBlocks = false;
+        bool enableSeparateBlockAndState = false;
+        std::string stateDBPath;
+        std::string blockDBPath;
+        std::string archiveListenIP;
+        uint16_t archiveListenPort = 0;
+        std::string dbName = "storage";
+        std::string stateDBName = "state";
+        bool enableLRUCacheStorage = true;
+        ssize_t cacheSize = DEFAULT_CACHE_SIZE;
+    } storage;
+
+    struct ExecutorConfig
+    {
+        size_t vmCacheSize = 1024;
+        BaselineSchedulerConfig baselineScheduler;
+    } executor;
+
+    struct RpcConfig
+    {
+        std::string listenIP = "0.0.0.0";
+        uint16_t listenPort = 20200;
+        uint32_t filterTimeout = 300'000;  // ms
+        uint32_t maxProcessBlock = 10;
+        bool smSsl = false;
+        bool disableSsl = false;
+    } rpc;
+
+    struct Web3RpcConfig
+    {
+        bool enable = false;
+        std::string listenIP = "127.0.0.1";
+        uint16_t listenPort = 8545;
+        uint32_t filterTimeout = 300'000;  // ms
+        uint32_t maxProcessBlock = 10;
+        uint32_t batchRequestSizeLimit = 8;
+        uint32_t httpBodySizeLimit = 10'240'000;
+        bool enableCors = true;
+        std::string corsAllowedOrigins = "*";
+        std::string corsAllowedMethods = "GET, POST, OPTIONS";
+        std::string corsAllowedHeaders = "Content-Type, Authorization, X-Requested-With";
+        int32_t corsMaxAge = 86400;
+        bool corsAllowCredentials = true;
+        bool syncTransaction = false;
+        // "safe"/"finalized" point latest - depth blocks behind; 0 = latest
+        uint32_t safeBlockDepth = 0;
+        uint32_t finalizedBlockDepth = 0;
+    } web3Rpc;
+
+    struct OpEngineRpcConfig
+    {
+        bool enable = false;
+        std::string listenIP = "127.0.0.1";
+        uint16_t listenPort = 8551;
+        uint32_t httpBodySizeLimit = 10'485'760;
+        uint32_t batchRequestSizeLimit = 8;
+        std::string jwtSecretFile = "conf/op-engine/jwt.hex";
+        int32_t clockSkewSecs = 60;
+        // test-only escape hatch, see Initializer's executor-version guard
+        bool allowV1Executor = false;
+    } opEngineRpc;
+
+    struct SingleNodeConsensusConfig
+    {
+        bool enable = false;
+        uint64_t blockInterval = 1000;
+        bool produceEmptyBlocks = true;
+        std::string feeRecipient = "0x0000000000000000000000000000000000000000";
+        std::string prevRandao;
+        uint64_t fixedTimestamp = 0;
+    } singleNodeConsensus;
+
+    struct GatewayConfig
+    {
+        std::string listenIP;
+        uint16_t listenPort{};
+        bool smSsl = false;
+        std::string nodeDir = "./";
+        std::string nodeFileName = "nodes.json";
+    } gateway;
+
+    struct SyncConfig
+    {
+        bool enableSendBlockStatusByTree = false;
+        bool enableSendTxByTree = false;
+        uint32_t treeWidth = 3;
+    } sync;
+
+    struct CertConfig
+    {
+        std::string path = "./";
+        std::string caCert;
+        std::string nodeCert;
+        std::string nodeKey;
+        std::string smCaCert;
+        std::string smNodeCert;
+        std::string smNodeKey;
+        std::string enSmNodeCert;
+        std::string enSmNodeKey;
+    } cert;
+
+    struct FailOverConfig
+    {
+        bool enable = false;
+        std::string clusterUrl = "127.0.0.1:2379";
+        std::string memberID;
+        unsigned leaseTTL = 0;
+    } failOver;
+
+    struct ThreadPoolConfig
+    {
+        size_t ioThreadCount{};
+        size_t tbbThreadCount{};
+    } threadPool;
+
+    struct OthersConfig
+    {
+        int sendTxTimeout = -1;
+        bool checkTransactionSignature = true;
+        bool checkParallelConflict = true;
+        bool singlePointConsensus = false;
+        bytes forceSender;
+    } others;
+
+    struct ServiceConfig
+    {
+        bool withoutTarsFramework = false;
+        std::unordered_map<std::string, std::vector<tars::TC_Endpoint>> tarsSN2EndPoints;
+        std::string rpcServiceName;
+        std::string gatewayServiceName;
+        std::string schedulerServiceName;
+        std::string executorServiceName;
+        std::string txpoolServiceName;
+        std::string nodeName;
+    } service;
+
     NodeConfig();
 
     NodeConfig(const NodeConfig&) = default;
@@ -286,24 +514,13 @@ public:
     void getTarsClientProxyEndpoints(
         const std::string& _clientPrx, std::vector<tars::TC_Endpoint>& _endPoints);
 
-    struct BaselineSchedulerConfig
-    {
-        bool parallel = false;
-        int grainSize = 0;
-    };
-    BaselineSchedulerConfig const& baselineSchedulerConfig() const;
-
-    struct TarsRPCConfig
-    {
-        std::string host;
-        uint16_t port = 0;
-    };
-    TarsRPCConfig const& tarsRPCConfig() const;
-
     bool checkTransactionSignature() const;
     bool checkParallelConflict() const;
     bool singlePointConsensus() const;
     const bytes& forceSender() const;
+
+    BaselineSchedulerConfig const& baselineSchedulerConfig() const;
+    TarsRPCConfig const& tarsRPCConfig() const;
 
     ledger::GenesisConfig const& genesisConfig() const;
 
@@ -351,6 +568,10 @@ protected:
         std::string const& _configSection, std::string const& _objName,
         std::string const& _defaultValue = "", bool _require = true);
     void checkService(std::string const& _serviceType, std::string const& _serviceName);
+
+    // Phase 1 of a staged refactor: copies the legacy members into the new
+    // config-domain structs after loading (removed in the cutover phase).
+    void syncConfigStructs();
 
 private:
     void loadGenesisFeatures(boost::property_tree::ptree const& ptree);

--- a/bcos-tool/bcos-tool/NodeConfig.h
+++ b/bcos-tool/bcos-tool/NodeConfig.h
@@ -75,6 +75,13 @@ public:
 
     struct TxPoolConfig
     {
+        // NOTE: this nested name collides with bcos::txpool::TxPoolConfig (and
+        // likewise ConsensusConfig/GatewayConfig/SyncConfig/CertConfig below).
+        // Different scopes, so no compile conflict today; a caller that does
+        // `using namespace bcos::txpool` would hit an ambiguity. Kept for
+        // symmetry with the config domains; rename before relying on the
+        // structs as the public read surface if the collision becomes a
+        // problem.
         size_t limit = 15000;
         int64_t txsExpirationTime = 600'000;
         bool checkBlockLimit = true;


### PR DESCRIPTION
# [NodeConfig] 阶段一:新增配置域结构体与 syncConfigStructs()

## 背景

`NodeConfig` 类原先有大量 `m_xxx` 私有成员与对应的 getter/setter(约 145 个),代码冗长、可读性差。为提升可维护性,计划分 **三个阶段** 重构:

1. **本 PR(阶段一)**:新增按配置域分组的公共结构体(仅字段,不带方法),并新增私有 `syncConfigStructs()` 方法,在加载完成后把旧的 `m_xxx` 成员同步到结构体字段。
2. 阶段二:各 `loadXxxConfig` 直接写入结构体字段,getter 改为返回结构体字段,删除旧成员。
3. 阶段三:删除全部 getter/setter,`genesisConfig`/`ledgerConfig`/`keyFactory` 改为公共成员,迁移调用方。

## 本 PR 改动内容

- `bcos-tool/bcos-tool/NodeConfig.h`
  - 新增 20 个配置域结构体:`chain`、`txpool`、`sealer`、`consensus`、`security`、`storageSecurity`、`storage`、`executor`、`rpc`、`web3Rpc`、`opEngineRpc`、`singleNodeConsensus`、`gateway`、`sync`、`cert`、`failOver`、`threadPool`、`tarsRPC`、`others`、`service`(结构体定义仅含字段与默认值)。
  - `BaselineSchedulerConfig` / `TarsRPCConfig` 结构体定义上移至结构体块顶部(供 `ExecutorConfig` 引用)。
  - 新增私有方法声明 `void syncConfigStructs();`。
  - **API 完全兼容**:所有 getter/setter 声明保持不变(含 `baselineSchedulerConfig()` / `tarsRPCConfig()`),调用方无需任何改动。
- `bcos-tool/bcos-tool/NodeConfig.cpp`
  - 新增 `syncConfigStructs()` 实现:把各 `m_xxx` 成员复制到对应结构体字段。
  - 在 `loadConfig(ptree)` 与 `loadGenesisConfig(ptree)` 末尾调用 `syncConfigStructs()`。

## 行为说明

- 加载逻辑与外部 API 行为**完全不变**,仅增加"加载后同步到结构体"这一步。
- 结构体默认值与 `load()` 实际生效默认值保持一致(例如 `storage` 的 4/4/64MB/1)。

## 验证

- `ninja tool test-bcos-tool librpc.a libinit.a libsecurity.a libsealer.a libscheduler.a` 全部通过。
- `test-bcos-tool` 单元测试全部通过(No errors detected)。

## 后续

本 PR 是纯增量改动,便于评审;阶段二、阶段三将基于本分支继续(stacked PR),保证每个 PR 的 diff 控制在 check_commit 行数限制内。
