### PR TITLE
Engine API interop: accept op-node's bare-number minBaseFee, store the eth-genesis timestamp in the millisecond domain

### DIFF
--- a/bcos-framework/bcos-framework/ledger/GenesisConfig.h
+++ b/bcos-framework/bcos-framework/ledger/GenesisConfig.h
@@ -62,8 +62,9 @@ struct Alloc
 // every field is REQUIRED (NodeConfig fail-fasts on the first missing key).
 // m_hash is a checksum, not an input: Ledger::buildGenesisBlock recomputes
 // keccak256(rlp(header)) from the other 21 fields and refuses to start if it
-// differs. m_timestamp is in SECONDS (the Ethereum header domain) — B0 is
-// artifact-authoritative, unlike FISCO's millisecond block timestamps.
+// differs. m_timestamp is in SECONDS (the Ethereum header domain);
+// Ledger::applyEthGenesisHeader multiplies by 1000 when projecting it onto the
+// internal BlockHeader, which stores milliseconds like every other block.
 struct EthGenesisHeader
 {
     crypto::HashType m_parentHash;

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -2000,9 +2000,14 @@ static void applyEthGenesisHeader(
     header.setDifficulty(ethHeader.m_difficulty);
     header.setGasLimit(ethHeader.m_gasLimit);
     header.setGasUsed(ethHeader.m_gasUsed);
-    // B0's timestamp is artifact-authoritative and in SECONDS (the Ethereum
-    // header domain): the RLP hash must reproduce the artifact byte-for-byte.
-    header.setTimestamp(ethHeader.m_timestamp);
+    // The artifact carries B0's timestamp in SECONDS (the Ethereum header
+    // domain); internal BlockHeader timestamps are MILLISECONDS everywhere, so
+    // convert on the way in. The RLP bridge (EthBlockHeader) divides by 1000 on
+    // encode, so keccak256(rlp(header)) still reproduces the artifact hash
+    // byte-for-byte. No int64 overflow: the config parser bounds the artifact
+    // seconds by INT64_MAX/1000 (NodeConfig's [eth_genesis_header].timestamp
+    // check), so the x1000 cannot wrap.
+    header.setTimestamp(ethHeader.m_timestamp * 1000);
     header.setExtraData(bcos::bytes(ethHeader.m_extraData));
     header.setPrevRandao(ethHeader.m_mixHash);
     header.setNonce(ethHeader.m_nonce);

--- a/bcos-ledger/test/unittests/ledger/test_GenesisEthHeader.cpp
+++ b/bcos-ledger/test/unittests/ledger/test_GenesisEthHeader.cpp
@@ -136,8 +136,9 @@ BOOST_AUTO_TEST_CASE(BuildsRlpHashMatchingPythonReference)
         // The stored header keeps its Ethereum identity across encode/decode.
         BOOST_CHECK(header->ethBlockVersion() == EthBlockVersion::PRAGUE);
         BOOST_CHECK_EQUAL(header->stateRoot().hex(), std::string(c_emptyTrieRoot));
-        // B0 timestamp is the artifact's, in seconds.
-        BOOST_CHECK_EQUAL(header->timestamp(), 0x689d5c00);
+        // B0 timestamp is stored in the internal MILLISECOND domain (artifact
+        // seconds x 1000); the RLP bridge divides back to seconds for the hash.
+        BOOST_CHECK_EQUAL(header->timestamp(), 0x689d5c00LL * 1000);
 
         // The FISCO genesis pin moved to SYS_CONFIG.
         auto pinEntry = co_await storage2::readOne(

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -22,6 +22,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <boost/throw_exception.hpp>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 
 using namespace bcos;
@@ -44,9 +45,10 @@ bcos::Error::UniquePtr EthBlockHeader::calculateRLPHash(bcos::protocol::BlockHea
     return nullptr;
 }
 
-// Precondition: for NON_ETH headers, utcTime() must be a whole number of seconds
-// (ms divisible by 1000). Sub-second timestamps produce an RLP hash that cannot
-// be reproduced from the decoded form. Throws std::invalid_argument on violation.
+// Precondition: the header's timestamp (internal milliseconds, every version) must be a
+// whole number of seconds (ms divisible by 1000). Sub-second timestamps produce an RLP
+// hash that cannot be reproduced from the decoded form. Throws std::invalid_argument on
+// violation.
 bcos::crypto::HashType EthBlockHeader::computeHash(
     const bcos::protocol::BlockHeader& header) noexcept(false)
 {
@@ -88,6 +90,7 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
+    // rlpDecode already converted the wire's seconds into internal milliseconds.
     header->setTimestamp(ethHeader.data().timestamp);
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
@@ -166,16 +169,16 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     // Like toTarsHeader's field writes but WITHOUT validateHeader — usable for FISCO-native/OP
     // (NON_ETH) headers that validateHeader rejects. TWO DELIBERATE omissions from toTarsHeader:
     //   1. ethBlockVersion is pinned to NON_ETH here instead of copying ethHeader.version()
-    //      (which is itself always NON_ETH — the RLP stream carries no version). Write it
-    //      explicitly so the seconds↔milliseconds pairing below does not rest on header->clear()
-    //      leaving the tars field at its default 0 happening to equal NON_ETH: rlpEncode's /1000
-    //      keys off ethBlockVersion == NON_ETH, and a header of any other version would encode
-    //      the millisecond timestamp raw and silently change the block hash.
-    //   2. rlpHash is NOT set (toTarsHeader writes it via rlpEncode+keccak256 at :140). Callers
+    //      (which after rlpDecode is derived from the optional-field cascade). Headers decoded
+    //      through this path are FISCO-native/OP, and downstream routing (e.g.
+    //      BlockHeaderImpl::calculateHash) keys off the version — write it explicitly instead
+    //      of relying on header->clear() leaving the tars field at its default 0 happening to
+    //      equal NON_ETH. The timestamp domain does NOT depend on this pin: internal is always
+    //      milliseconds, and rlpDecode/rlpEncode convert unconditionally for every version.
+    //   2. rlpHash is NOT set (toTarsHeader writes it via rlpEncode+keccak256). Callers
     //      that need the block hash should call computeHash() or calculateRLPHash() explicitly —
     //      computing it here would force a full re-encode for every decode, even when the caller
     //      only needs field access.
-    // For NON_ETH the RLP timestamp is SECONDS and the FISCO header stores MILLISECONDS, so ×1000.
     header->setEthBlockVersion(bcos::protocol::EthBlockVersion::NON_ETH);
     header->setParentInfo(ethHeader.data().parentInfo);
     header->setCoinbase(ethHeader.data().coinbase);
@@ -187,7 +190,7 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
-    header->setTimestamp(ethHeader.data().timestamp * 1000);  // NON_ETH RLP seconds -> ms
+    header->setTimestamp(ethHeader.data().timestamp);  // already ms (rlpDecode converted)
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
     header->setExtraData(ethHeader.data().extraData);
@@ -300,6 +303,14 @@ bool EthBlockHeader::validateHeader(
     if (_header.timestamp() < 0)
     {
         return invalid("EthBlockHeader: invalid timestamp");
+    }
+    // Internal timestamps are milliseconds and must be whole seconds so rlpEncode's /1000 is
+    // lossless. Rejecting here keeps the calculateRLPHash path on its Error-return contract
+    // (and BlockHeaderImpl::calculateHash's clear-on-failure promise) for a wire-supplied
+    // sub-second value — rlpEncode's throw then only backstops validate-skipping callers.
+    if (_header.timestamp() % 1000 != 0)
+    {
+        return invalid("EthBlockHeader: timestamp must be a whole number of seconds");
     }
 
     // Fork-gated optional fields: a version N header must carry every field introduced by
@@ -454,21 +465,22 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
 
 void EthBlockHeader::rlpEncode(bcos::bytes& out) const
 {
-    // FISCO-native / OP headers (EthBlockVersion::NON_ETH) store the timestamp in MILLISECONDS;
-    // the Ethereum RLP field is SECONDS — /1000 applies only to those (ETH-version headers
-    // already carry seconds, e.g. via EthBlockHeader::toTarsHeader's passthrough).
+    // Timestamp domain model: internal is always milliseconds (every EthBlockVersion,
+    // NON_ETH included); the RLP surface always carries seconds; conversion happens
+    // unconditionally at this bridge (/1000 here, ×1000 in rlpDecode) — no per-version
+    // branching.
     //
-    // Integer division is lossy for sub-second precision (1001 ms → 1 s). Real OP
-    // timestamps are whole seconds today; sub-second input would produce an RLP hash
-    // not reproducible from the decoded form. Throw (not assert — assert is compiled
-    // out under NDEBUG).
-    if (m_version == EthBlockVersion::NON_ETH && m_data.timestamp % 1000 != 0)
+    // Integer division is lossy for sub-second precision (1001 ms → 1 s). Every producer
+    // that reaches this bridge carries whole-second milliseconds by construction (the
+    // Engine API boundary, the eth-genesis path and rlpDecode all multiply seconds by
+    // 1000); sub-second input would produce an RLP hash not reproducible from the decoded
+    // form. Throw (not assert — assert is compiled out under NDEBUG).
+    if (m_data.timestamp % 1000 != 0)
     {
         BOOST_THROW_EXCEPTION(std::invalid_argument(
-            "NON_ETH timestamp must be a whole number of seconds (ms divisible by 1000)"));
+            "timestamp must be a whole number of seconds (ms divisible by 1000)"));
     }
-    const auto rlpTimestamp =
-        m_version == EthBlockVersion::NON_ETH ? m_data.timestamp / 1000 : m_data.timestamp;
+    const auto rlpTimestamp = m_data.timestamp / 1000;
     codec::rlp::encode(out, m_data.parentInfo.blockHash, m_data.uncleHash, m_data.coinbase,
         m_data.stateRoot, m_data.txsRoot, m_data.receiptsRoot,
         bcos::bytesConstRef(m_data.logsBloom.data(), m_data.logsBloom.size()), m_data.difficulty,
@@ -504,7 +516,18 @@ bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
     }
 
     m_data.number = static_cast<int64_t>(_number);
-    m_data.timestamp = static_cast<int64_t>(_timestamp);
+
+    // The wire timestamp is seconds; the internal domain (m_data mirrors the internal
+    // BlockHeader) is milliseconds for every version — convert unconditionally, bounded by
+    // int64 first so a hostile wire value cannot trigger signed overflow on the ×1000.
+    constexpr auto c_maxWireTimestampSeconds =
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max() / 1000);
+    if (_timestamp > c_maxWireTimestampSeconds)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
+            "EthBlockHeader: timestamp out of representable millisecond range");
+    }
+    m_data.timestamp = static_cast<int64_t>(_timestamp) * 1000;
 
     // Optional fork fields are decoded positionally, so the set of present optionals is
     // always a contiguous prefix — a later field can only be present if the view was still

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
@@ -54,6 +54,9 @@ struct EthBlockHeaderData
     bcos::Address coinbase;
     bcos::h64 nonce;
     int64_t number{0};
+    // Always MILLISECONDS — mirrors the internal BlockHeader domain for every version.
+    // The RLP surface always carries seconds; rlpEncode (/1000) and rlpDecode (×1000)
+    // convert unconditionally at that bridge.
     int64_t timestamp{0};
 
     // Optional fields (16–23)
@@ -105,19 +108,20 @@ public:
         bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data);
     /// Like toTarsHeader but WITHOUT validateHeader — usable for FISCO-native/OP (NON_ETH)
     /// headers that validateHeader rejects. Unlike toTarsHeader, ethBlockVersion is PINNED to
-    /// NON_ETH (not copied): headers this produces are always treated as NON_ETH, so the RLP
-    /// timestamp is SECONDS and the FISCO header stores MILLISECONDS, ×1000 is applied, and
-    /// rlpEncode's /1000 pairs with it.
+    /// NON_ETH (not copied). The produced header's timestamp is MILLISECONDS like every other
+    /// internal header (the RLP surface's seconds are converted by rlpDecode, unconditionally
+    /// for every version).
     static bcos::Error::UniquePtr decodeTarsHeader(
         bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data);
     static bcos::Error::UniquePtr toEthBlockHeader(
         EthBlockHeader& ethHeader, bcos::bytesConstRef _data);
     static bcos::Error::UniquePtr calculateRLPHash(bcos::protocol::BlockHeader& header);
     /// Compute keccak256(rlp(header)) WITHOUT validation or state mutation — usable for
-    /// FISCO-native/OP headers (EthBlockVersion::NON_ETH, timestamp ms → rlpEncode /1000) that
-    /// calculateRLPHash's validateHeader rejects. Returns the 32-byte Ethereum block hash.
-    /// Throws std::invalid_argument if a NON_ETH header's timestamp is not a whole number
-    /// of seconds (ms not divisible by 1000) — callers that cannot tolerate exceptions
+    /// FISCO-native/OP headers (EthBlockVersion::NON_ETH) that calculateRLPHash's
+    /// validateHeader rejects. Returns the 32-byte Ethereum block hash. The header's
+    /// timestamp is internal milliseconds (every version); rlpEncode divides by 1000
+    /// unconditionally and throws std::invalid_argument if it is not a whole number of
+    /// seconds (ms not divisible by 1000) — callers that cannot tolerate exceptions
     /// should use calculateRLPHash (which returns Error::UniquePtr) instead.
     static bcos::crypto::HashType computeHash(const bcos::protocol::BlockHeader& header) noexcept(
         false);

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -41,7 +41,7 @@ static bcos::protocol::BlockHeader::Ptr makeEthHeader(
     auto tars = std::make_shared<bcostars::BlockHeader>();
     auto& data = tars->data;
     data.blockNumber = 77;
-    data.timestamp = 1700000000;
+    data.timestamp = 1700000000000LL;  // internal domain: milliseconds (whole seconds)
     data.gasLimit = "30000000";
     data.gasUsed = "21000";
     data.coinbase.assign(20, static_cast<char>(0xab));
@@ -93,7 +93,8 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     // header -> Eth
     EthBlockHeader ethHeader(*header);
     BOOST_CHECK_EQUAL(ethHeader.data().number, 77);
-    BOOST_CHECK_EQUAL(ethHeader.data().timestamp, 1700000000);
+    // The bridge struct mirrors the internal millisecond domain; only the RLP bytes are seconds.
+    BOOST_CHECK_EQUAL(ethHeader.data().timestamp, 1700000000000LL);
     BOOST_CHECK_EQUAL(ethHeader.data().gasLimit, u256(30000000));
     BOOST_CHECK_EQUAL(ethHeader.data().gasUsed, u256(21000));
     BOOST_CHECK_EQUAL(ethHeader.data().uncleHash,
@@ -114,7 +115,8 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     ethError = EthBlockHeader::toEthBlockHeader(decodedEth, bcos::ref(rlp));
     BOOST_CHECK(!ethError);
     BOOST_CHECK_EQUAL(decodedEth.data().number, 77);
-    BOOST_CHECK_EQUAL(decodedEth.data().timestamp, 1700000000);
+    // rlpDecode converts the wire's seconds back into internal milliseconds.
+    BOOST_CHECK_EQUAL(decodedEth.data().timestamp, 1700000000000LL);
     BOOST_CHECK_EQUAL(decodedEth.data().gasLimit, u256(30000000));
     BOOST_CHECK_EQUAL(decodedEth.data().gasUsed, u256(21000));
     BOOST_CHECK(decodedEth.data().baseFee.has_value());
@@ -141,7 +143,7 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     ethError = EthBlockHeader::toTarsHeader(decodedHeader, bcos::ref(rlp));
     BOOST_CHECK(!ethError);
     BOOST_CHECK_EQUAL(decodedHeader->number(), 77);
-    BOOST_CHECK_EQUAL(decodedHeader->timestamp(), 1700000000);
+    BOOST_CHECK_EQUAL(decodedHeader->timestamp(), 1700000000000LL);
     BOOST_CHECK_EQUAL(decodedHeader->gasLimit(), u256(30000000));
     BOOST_CHECK_EQUAL(decodedHeader->gasUsed(), u256(21000));
     // The converted header must be marked as an Eth header
@@ -407,6 +409,22 @@ BOOST_AUTO_TEST_CASE(validateHeaderRejectsNegativeScalars)
     BOOST_CHECK(error != nullptr);
 }
 
+// A wire-supplied sub-second millisecond timestamp on an otherwise-valid ETH-version header
+// must be rejected by validateHeader on the calculateRLPHash path (Error return, not the
+// rlpEncode throw), keeping BlockHeaderImpl::calculateHash's clear-on-failure promise intact.
+BOOST_AUTO_TEST_CASE(validateHeaderRejectsSubSecondTimestamp)
+{
+    auto header = makeEthHeader();
+    auto impl = std::dynamic_pointer_cast<bcostars::protocol::BlockHeaderImpl>(header);
+    BOOST_REQUIRE(impl != nullptr);
+    impl->inner().data.timestamp = 1700000000001LL;  // ms not divisible by 1000
+
+    bcos::Error::UniquePtr error;
+    BOOST_CHECK_NO_THROW(error = bcos::protocol::EthBlockHeader::calculateRLPHash(*header));
+    BOOST_REQUIRE(error != nullptr);
+    BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
+}
+
 // Real mainnet golden vector: Ethereum block #19800000 (Cancun era, 20-item header).
 // Fields are the actual on-chain values; the expected hash is the block hash published on
 // the chain (0x95d7f597…), independently verified to equal keccak256(rlp(header)). This is
@@ -418,7 +436,9 @@ BOOST_AUTO_TEST_CASE(goldenMainnetCancunHeader)
     BOOST_REQUIRE(impl != nullptr);
     auto& data = impl->inner().data;
     data.blockNumber = 19800000;
-    data.timestamp = 1714865051;
+    // On-chain seconds 1714865051, stored in the internal millisecond domain; the RLP
+    // bridge divides back to seconds, so the golden hash/bytes below stay byte-identical.
+    data.timestamp = 1714865051000LL;
     data.gasLimit = "30000000";
     data.gasUsed = "8020412";
     data.baseFee = "5007423601";
@@ -632,6 +652,31 @@ BOOST_AUTO_TEST_CASE(toTarsHeaderClearsResidual)
     BOOST_CHECK(reused->ethBlockVersion() == EthBlockVersion::PRE_LONDON);
 }
 
+// A wire header whose seconds timestamp would overflow int64 milliseconds must be rejected
+// by the decode bridge (rlpDecode) before its x1000 conversion, surfacing through
+// decodeTarsHeader as an error (regression for the seconds->ms bridge).
+BOOST_AUTO_TEST_CASE(decodeTarsHeaderRejectsOverflowingTimestamp)
+{
+    // Re-encode a valid header's fields with a hostile timestamp: 2^63 encodes fine as a
+    // uint64 RLP scalar but has no int64 millisecond representation.
+    auto header = makeEthHeader();
+    EthBlockHeader ethHeader(*header);
+    auto const& d = ethHeader.data();
+    constexpr uint64_t hostileTimestamp = 0x8000000000000000ULL;
+
+    bytes rlp;
+    codec::rlp::encode(rlp, d.parentInfo.blockHash, d.uncleHash, d.coinbase, d.stateRoot, d.txsRoot,
+        d.receiptsRoot, bcos::bytesConstRef(d.logsBloom.data(), d.logsBloom.size()), d.difficulty,
+        static_cast<uint64_t>(d.number), d.gasLimit, d.gasUsed, hostileTimestamp, d.extraData,
+        d.prevRandao, d.nonce, d.baseFee, d.withdrawalsHash, d.blobGasUsed, d.excessBlobGas,
+        d.parentBeaconRoot, d.requestsHash);
+
+    auto decodedHeader = makeEthHeader();
+    auto error = EthBlockHeader::decodeTarsHeader(decodedHeader, bcos::ref(rlp));
+    BOOST_REQUIRE(error != nullptr);
+    BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
+}
+
 // An invalid Eth header: calculateHash clears dataHash, so hash() must throw
 // EmptyBlockHeaderHash (regression for the FIB-130 clear-on-failure behaviour).
 BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
@@ -647,10 +692,11 @@ BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
 }
 
 // decodeTarsHeader pins ethBlockVersion to NON_ETH explicitly instead of relying on the tars
-// default 0 happening to equal it: the ×1000 timestamp write pairs with rlpEncode's
-// NON_ETH-only /1000, so the version decides the block hash. The pin holds even when the
-// destination header carried a real ETH version before the decode, and the seconds↔ms
-// round-trip through the pinned NON_ETH path reproduces the input RLP byte-for-byte.
+// default 0 happening to equal it. The pin holds even when the destination header carried a
+// real ETH version before the decode. Internal timestamps are milliseconds for every version
+// (the RLP surface is seconds, converted unconditionally by rlpDecode/rlpEncode), so the
+// decoded header's timestamp equals the ms source's and the seconds↔ms round-trip reproduces
+// the input RLP byte-for-byte regardless of the pinned version.
 BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
 {
     auto source = makeEthHeader(EthBlockVersion::PRAGUE);
@@ -663,10 +709,10 @@ BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
     error = EthBlockHeader::decodeTarsHeader(decoded, bcos::ref(rlp));
     BOOST_CHECK(!error);
     BOOST_CHECK(decoded->ethBlockVersion() == EthBlockVersion::NON_ETH);
-    BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp() * 1000);
+    BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp());
 
     // Re-encoding the decoded header must reproduce the input RLP: ×1000 on decode, /1000 on
-    // the NON_ETH encode — the inverse pair the pin guarantees.
+    // encode — the unconditional inverse pair at the RLP bridge.
     EthBlockHeader roundTrip(*decoded);
     bytes reencoded;
     roundTrip.rlpEncode(reencoded);

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -103,6 +103,32 @@ uint64_t parseQuantity(Json::Value const& value, std::string_view field)
         bcos::rpc::InvalidParams, std::string(field) + " must be a uint64 hex quantity string"));
 }
 
+/// minBaseFee-only reader. op-node declares PayloadAttributes.MinBaseFee as a plain
+/// `*uint64` with `json:"minBaseFee,omitempty"` (op-service/eth/types.go:523, v1.19.3) —
+/// unlike every sibling quantity field, it is NOT wrapped in hexutil, so op-node puts a
+/// bare JSON number on the wire ("minBaseFee": 0). Accept exactly that extra form here,
+/// on top of the usual hex quantity string. The number path must never go through
+/// asString(): jsoncpp stringifies the number 10 to "10", which the hex reader would
+/// then parse as 0x10 = 16 — a silently forged value. Reals (1.5, and 10.0 too) never
+/// carry the int/uint JSON types, so they fall through to the rejection.
+uint64_t parseQuantityOrUInt64Number(Json::Value const& value, std::string_view field)
+{
+    if (value.type() == Json::uintValue || (value.type() == Json::intValue && value.asInt64() >= 0))
+    {
+        return value.asUInt64();
+    }
+    if (value.isString())
+    {
+        if (auto parsed = bcos::safeFromQuantity(value.asString()))
+        {
+            return *parsed;
+        }
+    }
+    BOOST_THROW_EXCEPTION(bcos::rpc::JsonRpcException(bcos::rpc::InvalidParams,
+        std::string(field) +
+            " must be a uint64 hex quantity string or a non-negative JSON integer"));
+}
+
 /// The owning object of a group of fields (executionPayload, payloadAttributes,
 /// forkchoiceState). jsoncpp's operator[](char const*) throws Json::LogicError when the
 /// value is not an object, and that would surface as -32603 InternalError for input that
@@ -576,7 +602,11 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
     }
     if (pa.isMember("minBaseFee") && !pa["minBaseFee"].isNull())
     {
-        attrs.minBaseFee = parseQuantity(pa["minBaseFee"], "payloadAttributes.minBaseFee");
+        // Bare-number form accepted alongside hex: op-node serializes MinBaseFee
+        // without hexutil (op-service/eth/types.go:523), so every post-Jovian FCU
+        // carries e.g. "minBaseFee": 0 and a hex-only reader rejects it with -32602.
+        attrs.minBaseFee =
+            parseQuantityOrUInt64Number(pa["minBaseFee"], "payloadAttributes.minBaseFee");
     }
     return attrs;
 }

--- a/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineProtoAlignB1Test.cpp
@@ -185,6 +185,77 @@ BOOST_AUTO_TEST_CASE(payloadAttributesMalformedQuantitiesMapToInvalidParams)
     expectInvalidParams(malformedEip1559);
 }
 
+BOOST_AUTO_TEST_CASE(payloadAttributesMinBaseFeeAcceptsBareJsonNumber)
+{
+    // op-node v1.19.3 serializes PayloadAttributes.MinBaseFee as a plain *uint64 with
+    // no hexutil wrapper (op-service/eth/types.go:523), so the wire form is a bare JSON
+    // number — every post-Jovian FCU carries e.g. "minBaseFee": 0.
+    auto parseWithMinBaseFee = [](Json::Value minBaseFee) {
+        auto attrs = makeBaseAttributes();
+        attrs["minBaseFee"] = std::move(minBaseFee);
+        return parsePayloadAttributes(
+            makeAttributesParams(std::move(attrs)), engine::ApiVersion::V3);
+    };
+
+    auto zero = parseWithMinBaseFee(Json::Value(0));
+    BOOST_REQUIRE(zero.has_value() && zero->minBaseFee.has_value());
+    BOOST_CHECK_EQUAL(*zero->minBaseFee, 0ULL);
+
+    // Decimal 10 must stay 10. The trap: jsoncpp asString() stringifies 10 to "10",
+    // which the hex reader would parse as 0x10 = 16 — a silently forged value.
+    auto ten = parseWithMinBaseFee(Json::Value(10));
+    BOOST_REQUIRE(ten.has_value() && ten->minBaseFee.has_value());
+    BOOST_CHECK_EQUAL(*ten->minBaseFee, 10ULL);
+
+    auto max = parseWithMinBaseFee(Json::Value(Json::UInt64(UINT64_MAX)));
+    BOOST_REQUIRE(max.has_value() && max->minBaseFee.has_value());
+    BOOST_CHECK_EQUAL(*max->minBaseFee, UINT64_MAX);
+
+    // The hex string form stays accepted: "0xa" is 10.
+    auto hexTen = parseWithMinBaseFee(Json::Value("0xa"));
+    BOOST_REQUIRE(hexTen.has_value() && hexTen->minBaseFee.has_value());
+    BOOST_CHECK_EQUAL(*hexTen->minBaseFee, 10ULL);
+}
+
+BOOST_AUTO_TEST_CASE(payloadAttributesMinBaseFeeRejectsNonIntegerForms)
+{
+    auto expectInvalidParams = [](Json::Value minBaseFee) {
+        auto attrs = makeBaseAttributes();
+        attrs["minBaseFee"] = std::move(minBaseFee);
+        BOOST_CHECK_EXCEPTION(
+            parsePayloadAttributes(makeAttributesParams(std::move(attrs)), engine::ApiVersion::V3),
+            JsonRpcException,
+            [](JsonRpcException const& error) { return error.code() == InvalidParams; });
+    };
+
+    expectInvalidParams(Json::Value(-1));
+    expectInvalidParams(Json::Value(1.5));
+    expectInvalidParams(Json::Value("notahex"));
+    expectInvalidParams(Json::Value(Json::arrayValue));
+    expectInvalidParams(Json::Value(Json::objectValue));
+}
+
+BOOST_AUTO_TEST_CASE(payloadAttributesBareNumberStaysMinBaseFeeOnly)
+{
+    // The bare-number acceptance is scoped to minBaseFee: op-node wraps every other
+    // uint64 attribute (timestamp, gasLimit) in hexutil.Uint64, so a bare number there
+    // is still a malformed request.
+    auto expectInvalidParams = [](Json::Value attrs) {
+        BOOST_CHECK_EXCEPTION(
+            parsePayloadAttributes(makeAttributesParams(std::move(attrs)), engine::ApiVersion::V3),
+            JsonRpcException,
+            [](JsonRpcException const& error) { return error.code() == InvalidParams; });
+    };
+
+    auto bareGasLimit = makeBaseAttributes();
+    bareGasLimit["gasLimit"] = 30000000;
+    expectInvalidParams(bareGasLimit);
+
+    auto bareTimestamp = makeBaseAttributes();
+    bareTimestamp["timestamp"] = 100;
+    expectInvalidParams(bareTimestamp);
+}
+
 BOOST_AUTO_TEST_CASE(payloadAttributesTransactionsMustBeArray)
 {
     auto attrs = makeBaseAttributes();

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -887,12 +887,18 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV3RejectsMalformedPayloadAttributes)
             [](JsonRpcException const& e) { return e.code() == InvalidParams; });
     };
 
-    for (auto const* field : {"timestamp", "gasLimit", "minBaseFee"})
+    // timestamp / gasLimit are hexutil.Uint64 on the op-node wire, so a bare JSON number
+    // stays malformed for them. minBaseFee is deliberately absent from the numeric loop:
+    // op-node serializes it as a plain *uint64 (op-service/eth/types.go:523), so the bare
+    // number form is VALID there — accepted-path coverage lives in EngineProtoAlignB1Test.
+    for (auto const* field : {"timestamp", "gasLimit"})
     {
         auto numeric = makeAttrs();
         numeric[field] = 123;
         expectInvalidParams(numeric);
-
+    }
+    for (auto const* field : {"timestamp", "gasLimit", "minBaseFee"})
+    {
         auto badHex = makeAttrs();
         badHex[field] = "0xnothex";
         expectInvalidParams(badHex);

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -19,6 +19,31 @@ using namespace bcos::rpc;
 
 namespace bcos::test
 {
+namespace
+{
+// calculateHash routes headers with ethBlockVersion != NON_ETH through
+// EthBlockHeader::validate, which demands every mandatory and fork-gated PRAGUE field —
+// fill them all so the header hashes. Distinctively named for unity-build safety.
+void fillWeb3ResponseTestPragueFields(bcos::protocol::BlockHeader& header)
+{
+    bcos::crypto::HashType nonZero;
+    nonZero[0] = 0x42;
+    header.setUncleHash(nonZero);
+    header.setStateRoot(nonZero);
+    header.setTxsRoot(nonZero);
+    header.setReceiptsRoot(nonZero);
+    bcos::bytes bloom(256, 0x00);
+    header.setLogsBloom(bcos::ref(bloom));
+    header.setBaseFee(u256(1000000000));
+    header.setWithdrawalsRoot(nonZero);
+    header.setBlobGasUsed(u256(0));
+    header.setExcessBlobGas(u256(0));
+    header.setParentBeaconBlockRoot(nonZero);
+    header.setRequestsHash(nonZero);
+    header.setEthBlockVersion(bcos::protocol::EthBlockVersion::PRAGUE);
+}
+}  // namespace
+
 BOOST_FIXTURE_TEST_SUITE(Web3ResponseTest, RPCFixture)
 
 BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
@@ -75,6 +100,68 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseNonGenesisComputesMiner)
     BOOST_CHECK_EQUAL(result["gasUsed"].asString(), "0x5208");  // 21000
     // timestamp is emitted in seconds (ms / 1000): 1700000000 == 0x6553f100.
     BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x6553f100");
+}
+
+BOOST_AUTO_TEST_CASE(combineBlockResponseEthGenesisTimestampSeconds)
+{
+    // The eth-genesis B0 stores its timestamp in the internal MILLISECOND domain
+    // (Ledger::applyEthGenesisHeader multiplies the artifact's seconds by 1000),
+    // exactly like every other block, so the web3 view's uniform ms->s division
+    // reports the artifact value — no B0 special case.
+    auto block = m_blockFactory->createBlock();
+    auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(0);
+    header->setGasUsed(u256(0));
+    header->setTimestamp(1755143168000);  // ms: artifact seconds x 1000
+    fillWeb3ResponseTestPragueFields(*header);
+    header->calculateHash(*hashImpl);
+    block->setBlockHeader(header);
+
+    Json::Value result(Json::objectValue);
+    combineBlockResponse(result, *block, /*fullTxs=*/false);
+
+    // 1755143168 == 0x689d5c00: the artifact's seconds value.
+    BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x689d5c00");
+}
+
+BOOST_AUTO_TEST_CASE(combineBlockResponseEthNonGenesisTimestampStillDivided)
+{
+    // Every block >= 1 keeps the internal milliseconds domain and the seconds
+    // view keeps dividing.
+    auto block = m_blockFactory->createBlock();
+    auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(1);
+    header->setGasUsed(u256(0));
+    header->setTimestamp(1700000000000);  // ms
+    fillWeb3ResponseTestPragueFields(*header);
+    bcos::crypto::HashType parentHash;
+    parentHash[0] = 0x24;
+    header->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 0, .blockHash = parentHash});
+    header->calculateHash(*hashImpl);
+    block->setBlockHeader(header);
+
+    Json::Value result(Json::objectValue);
+    combineBlockResponse(result, *block, /*fullTxs=*/false);
+
+    BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x6553f100");  // 1700000000
+}
+
+BOOST_AUTO_TEST_CASE(combineBlockResponseLegacyGenesisTimestampStillDivided)
+{
+    // A legacy FISCO genesis header (NON_ETH) stores milliseconds like every
+    // other header; its B0 gets the same milliseconds-to-seconds division.
+    auto block = m_blockFactory->createBlock();
+    auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(0);
+    header->setGasUsed(u256(0));
+    header->setTimestamp(2000);  // ms
+    header->calculateHash(*hashImpl);
+    block->setBlockHeader(header);
+
+    Json::Value result(Json::objectValue);
+    combineBlockResponse(result, *block, /*fullTxs=*/false);
+
+    BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x2");  // 2000 ms -> 2 s
 }
 
 BOOST_AUTO_TEST_CASE(combineBlockResponseFullTxsEmptyList)

--- a/bcos-tool/bcos-tool/NodeConfig.cpp
+++ b/bcos-tool/bcos-tool/NodeConfig.cpp
@@ -367,10 +367,12 @@ void NodeConfig::loadEthGenesisHeader(boost::property_tree::ptree const& _genesi
     header.m_gasLimit = quantityField("gas_limit");
     header.m_gasUsed = quantityField("gas_used");
     auto timestamp = quantityField("timestamp");
-    if (timestamp > u256(std::numeric_limits<int64_t>::max()))
+    // The artifact timestamp is seconds; Ledger::applyEthGenesisHeader multiplies it by 1000
+    // to store internal milliseconds, so the parse bound must leave headroom for the x1000.
+    if (timestamp > u256(std::numeric_limits<int64_t>::max() / 1000))
     {
-        BOOST_THROW_EXCEPTION(
-            InvalidConfig() << errinfo_comment("[eth_genesis_header].timestamp exceeds int64"));
+        BOOST_THROW_EXCEPTION(InvalidConfig() << errinfo_comment(
+                                  "[eth_genesis_header].timestamp exceeds int64 milliseconds"));
     }
     header.m_timestamp = static_cast<int64_t>(timestamp);
     auto extraData = requireField("extra_data");

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -264,6 +264,10 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
         "transactions": [DEPOSIT_RAW],
         "noTxPool": no_tx_pool,
         "gasLimit": ATTRS_GAS_LIMIT,
+        # Bare JSON number, NOT a hex string: op-node serializes MinBaseFee as a plain
+        # *uint64 without hexutil (op-service/eth/types.go:523, v1.19.3), so the mock
+        # must put the same wire shape on the wire ("minBaseFee": 0).
+        "minBaseFee": 0,
     }
 
     fcu = rpc_result("engine_forkchoiceUpdatedV3", [fc_state, payload_attrs])


### PR DESCRIPTION
## What

Two Engine API interop fixes found by running a real **op-node v1.19.3** (official docker image, sequencer mode) against a node built at release-3.18.0 head with `[op_engine_rpc]` enabled. Both were hard blockers: with them in place the sequencing loop reaches `Sequencer sealed block number=1` end to end; without them op-node cannot issue a single successful forkchoiceUpdated with attributes.

### 1. Accept a bare JSON number for `payloadAttributes.minBaseFee`

op-node declares `MinBaseFee *uint64` with no hexutil wrapper (`op-service/eth/types.go:523`), so the wire carries `"minBaseFee": 0` — a bare JSON number, unlike every other quantity field it sends (those are hex `Uint64Quantity` strings). Our parser accepted only hex quantity strings and answered -32602, which op-node classifies as a temporary engine error and retries forever.

The new `parseQuantityOrUInt64Number` admits unsigned JSON integers via the jsoncpp type tag. Two deliberate choices: it never goes through `asString()` (jsoncpp stringifies numbers, so `10` would re-parse as hex 16 — silent value forgery), and it does not use `isUInt64()` as the gate (that predicate admits integral doubles like `10.0`). Only the minBaseFee call site uses the new helper; `timestamp`/`gasLimit` stay hex-string-only, pinned by a dedicated test so the accepted surface cannot silently widen.

### 2. Store the eth-genesis timestamp in the internal millisecond domain

Since #5420, `applyEthGenesisHeader` copied the artifact's timestamp (seconds, the Ethereum header domain) verbatim into the internal millisecond-domain header field. That left one seconds-valued outlier inside a millisecond domain, and every consumer needed a special case for B0: the web3 block view divided it by 1000 and reported January 1970 (op-node then refuses to sequence: `cannot build L2 block ... before L1 origin`, and `gen_rollup_config.py` derived a wrong `l2_time`), and the EVM `TIMESTAMP` path (`HostContext.cpp`) had the same latent bug.

**Timestamp domain rule (maintainer decision), which this PR implements:** the internal `BlockHeader.timestamp` carries **milliseconds for every header version**; conversion to the Ethereum seconds domain happens only at the boundaries — RLP encoding (unconditional ÷1000), RLP/wire decoding (unconditional ×1000, with an `INT64_MAX/1000` bound rejecting wire values that would overflow, covered by a red test), EVM execution, and RPC output. The existing unconditional ÷1000 in the web3 block view and in the EVM `TIMESTAMP` path are already correct under this rule — no version-keyed branches anywhere.

This deliberately supersedes the per-version placement introduced by #5434 (`rlpEncode` divided only for `NON_ETH` and passed ETH-version headers through, implying ETH-version headers hold seconds internally). The rationale is to avoid version-keyed if/else spreading through every consumer. Concretely on top of #5434: `rlpEncode` now always divides (and its sub-second rejection applies to every version — ETH-version headers are only ever produced from whole-second sources, verified by caller inventory); `rlpDecode` multiplies (the overflow guard sits here so all three RLP→header paths — `decodeTarsHeader`, `toTarsHeader`, `toEthBlockHeader` — share one conversion point and decode→re-encode round-trips stay canonical); `toTarsHeader`/`decodeTarsHeader` pass through what is now already milliseconds. `validateHeader` additionally rejects sub-second timestamps. `applyEthGenesisHeader` stores `seconds * 1000`, and the `[eth_genesis_header].timestamp` config bound tightens to `INT64_MAX/1000` so the multiplication cannot overflow. `ms = s * 1000` round-trips losslessly, so the genesis hash is byte-for-byte unchanged — the offline python reference hash in `GenesisEthHeaderTest` and the golden mainnet Cancun header hash + RLP bytes both pass unmodified.

**Breaking note (unreleased feature only):** chains built with an `[eth_genesis_header]` before this change store B0 in seconds and will fail the genesis-hash consistency check on restart; rebuild the datadir. Legacy chains are unaffected (their B0 never sets `ethBlockVersion` and is already in milliseconds; NON_ETH headers never enter the RLP-hash path, `BlockHeaderImpl.cpp` keeps them on the Tars hash branch).

## Verification

- minBaseFee: 6 new unit cases (bare `0` -> 0, bare `10` -> **10, not 16**, `UINT64_MAX` boundary, hex string still accepted; `-1` / `1.5` / `"notahex"` / `[]` / `{}` rejected with -32602; timestamp/gasLimit bare numbers still rejected). The mock CL now sends `minBaseFee` as a bare number, matching the real op-node wire shape.
- Timestamp domain (on top of the rebased base 63e131920): `test-bcos-rlp-protocol` 25/25 (golden mainnet header hash `95d7f597…` and RLP bytes unchanged; new sub-second-rejection and overflow-rejection cases), `test-bcos-ledger` green incl. all 7 `GenesisEthHeaderTest` cases (python reference `b153f41d…` unchanged) — the only red suite is `ComputeTrieRootSuite`, a pre-existing Debug-only assert introduced with the base itself (zero MPT files in this diff); `test-bcos-rpc`, `test-bcos-tars-protocol`, `test-bcos-codec`, `test-bcos-framework`, `test-transaction-scheduler`, `test-bcos-tool` all green (the latter five cover the tests the base PR added).
- Live run: op-node v1.19.3 connected **directly** to port 8551 (the first smoke needed a JSON-rewriting proxy to get past minBaseFee). Zero -32602, block 1 sealed and inserted, `eth_getBlockByNumber("0x0")` returns `0x689d5c00`, regenerated rollup.json carries `l2_time: 1755143168`. The session then stops at the next known gap (committed engine blocks exposed no transactions over RPC — addressed in #5445), with no new errors before it.

## Notes for follow-up parts of the OP series

- New header producers must write **milliseconds** into `BlockHeader.timestamp` (the Engine API boundary already converts attribute seconds ×1000); consumers of `EthBlockHeader::data().timestamp` now receive milliseconds and must not multiply again.
- `computeHash`/`rlpEncode` throw on sub-second millisecond values — a loud failure rather than a silently wrong hash if a legacy `utcTime()` header ever reaches the eth-hash path.
