### PR TITLE
Engine: persist forced 0x7E deposits as ledger transactions so op-node can read them back

### DIFF
--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -1794,7 +1794,13 @@ void Ledger::getReceiptProof(protocol::TransactionReceipt::Ptr _receipt,
                 return;
             }
 
-            asyncBatchGetReceipts(std::make_shared<std::vector<std::string>>(_hashList),
+            // TEMPORARY (op-node interop breakpoint #3): allowMissing tolerates the
+            // receipt holes of persisted-but-unexecuted deposits. The compacted list
+            // (executed receipts in block order) is exactly the receiptsRoot preimage,
+            // so the merkle below stays correct; for fully-executed blocks the list is
+            // unchanged.
+            asyncBatchGetReceipts(
+                std::make_shared<std::vector<std::string>>(_hashList),
                 [this, cryptoSuite = this->m_blockFactory->cryptoSuite(), _onGetProof,
                     receiptHash = receiptHash, blockNumber](Error::Ptr&& _error,
                     std::vector<protocol::TransactionReceipt::Ptr>&& _receiptList) {
@@ -1822,7 +1828,8 @@ void Ledger::getReceiptProof(protocol::TransactionReceipt::Ptr _receipt,
                         << LOG_BADGE("getReceiptProof") << LOG_DESC("get merkle proof success")
                         << LOG_KV("receiptHash", receiptHash.hex());
                     _onGetProof(nullptr, std::move(merkleProofPtr));
-                });
+                },
+                /*allowMissing=*/true);
         });
 }
 

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -735,8 +735,9 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
                 if ((_blockFlag & RECEIPTS) != 0)
                 {
                     asyncBatchGetReceipts(
-                        hashesPtr, [block, finally](Error::Ptr&& error,
-                                       std::vector<protocol::TransactionReceipt::Ptr>&& receipts) {
+                        hashesPtr,
+                        [block, finally](Error::Ptr&& error,
+                            std::vector<protocol::TransactionReceipt::Ptr>&& receipts) {
                             for (auto& it : receipts)
                             {
                                 block->appendReceipt(it);
@@ -761,7 +762,8 @@ void Ledger::asyncGetBlockDataByNumber(bcos::protocol::BlockNumber _blockNumber,
                             block->setLogsBloom(
                                 bcos::bytesConstRef(logsBloom.data(), logsBloom.size()));
                             finally(std::move(error));
-                        });
+                        },
+                        /*allowMissing=*/true);
                 }
                 if ((_blockFlag & TRANSACTIONS_HASH) != 0)
                 {
@@ -1585,10 +1587,12 @@ void Ledger::asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>>
 }
 
 void Ledger::asyncBatchGetReceipts(std::shared_ptr<std::vector<std::string>> hashes,
-    std::function<void(Error::Ptr&&, std::vector<protocol::TransactionReceipt::Ptr>&&)> callback)
+    std::function<void(Error::Ptr&&, std::vector<protocol::TransactionReceipt::Ptr>&&)> callback,
+    bool allowMissing)
 {
     getBlockStorage()->asyncGetRows(SYS_HASH_2_RECEIPT, *hashes,
-        [this, hashes, callback](auto&& error, std::vector<std::optional<Entry>>&& entries) {
+        [this, hashes, callback, allowMissing](
+            auto&& error, std::vector<std::optional<Entry>>&& entries) {
             if (error)
             {
                 LEDGER_LOG(DEBUG) << "Batch get receipt failed!"
@@ -1607,6 +1611,15 @@ void Ledger::asyncBatchGetReceipts(std::shared_ptr<std::vector<std::string>> has
             {
                 if (!entry.has_value())
                 {
+                    if (allowMissing)
+                    {
+                        // TEMPORARY (op-node interop breakpoint #3): unexecuted deposit
+                        // transactions are persisted without receipts; skip the hole so
+                        // the surrounding block fetch still succeeds.
+                        LEDGER_LOG(DEBUG) << "Skip missing receipt entry: " << toHex((*hashes)[i]);
+                        ++i;
+                        continue;
+                    }
                     LEDGER_LOG(DEBUG) << "Get receipt with empty entry: " << toHex((*hashes)[i]);
                     callback(BCOS_ERROR_PTR(
                                  LedgerError::GetStorageError, "Batch get transaction failed"),

--- a/bcos-ledger/bcos-ledger/Ledger.h
+++ b/bcos-ledger/bcos-ledger/Ledger.h
@@ -166,9 +166,14 @@ private:
     void asyncBatchGetTransactions(std::shared_ptr<std::vector<std::string>> hashes,
         std::function<void(Error::Ptr&&, std::vector<protocol::Transaction::Ptr>&&)> callback);
 
+    // allowMissing — TEMPORARY (op-node interop breakpoint #3): persisted-but-unexecuted
+    // deposit transactions have no SYS_HASH_2_RECEIPT row; asyncGetBlockDataByNumber
+    // passes true so eth_getBlockByHash/ByNumber can still assemble such blocks. Every
+    // other caller keeps the strict default (missing row = storage error).
     void asyncBatchGetReceipts(std::shared_ptr<std::vector<std::string>> hashes,
         std::function<void(Error::Ptr&&, std::vector<protocol::TransactionReceipt::Ptr>&&)>
-            callback);
+            callback,
+        bool allowMissing = false);
 
     void getTxProof(const crypto::HashType& _txHash,
         std::function<void(Error::Ptr&&, MerkleProofPtr&&)> _onGetProof);

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -111,12 +111,24 @@ task::Task<void> tag_invoke(ledger::tag_t<prewriteBlockToBuffer> /*unused*/,
     auto blockReceipts = block->receipts();
 
     // SYS_HASH_2_RECEIPT — encoded receipts keyed by tx hash.
+    //
+    // TEMPORARY (op-node interop breakpoint #3): the Engine commit path persists
+    // unexecuted forced deposits (0x7E) as transactions WITHOUT receipts, and OP payload
+    // ordering places them as a prefix of the transaction list. Receipt i therefore
+    // belongs to transaction i + (txCount - receiptCount). For every legacy caller the
+    // two counts are equal and the offset is 0 (unchanged behavior). Removed when
+    // deposit execution wiring generates real receipts.
+    auto const pairedTxCount = blockTxs ? blockTxs->size() : block->transactionsSize();
+    auto const receiptTxOffset = pairedTxCount >= block->receiptsSize() ?
+                                     pairedTxCount - block->receiptsSize() :
+                                     static_cast<size_t>(0);
     for (size_t i = 0; i < block->receiptsSize(); ++i)
     {
         bytes encodedReceipt;
         blockReceipts[i]->encode(encodedReceipt);
 
-        auto txHash = blockTxs ? blockTxs->at(i)->hash() : inlineTxs[i]->hash();
+        auto txHash = blockTxs ? blockTxs->at(i + receiptTxOffset)->hash() :
+                                 inlineTxs[i + receiptTxOffset]->hash();
 
         storage::Entry receiptEntry;
         receiptEntry.set(std::move(encodedReceipt));
@@ -256,6 +268,14 @@ task::Task<protocol::Block::Ptr> tag_invoke(ledger::tag_t<getBlockData> /*unused
                     }));
                 for (auto& receiptEntry : receipts)
                 {
+                    // TEMPORARY (op-node interop breakpoint #3): persisted-but-unexecuted
+                    // deposits have a SYS_HASH_2_TX row but no SYS_HASH_2_RECEIPT row, so
+                    // a missing entry is legal for such blocks — skip it instead of
+                    // dereferencing an empty optional.
+                    if (!receiptEntry)
+                    {
+                        continue;
+                    }
                     auto field = receiptEntry->get();
                     auto receipt = blockFactory.receiptFactory()->createReceipt(
                         bcos::bytesConstRef((bcos::byte*)field.data(), field.size()));

--- a/bcos-rpc/bcos-rpc/event/EventSubMatcher.cpp
+++ b/bcos-rpc/bcos-rpc/event/EventSubMatcher.cpp
@@ -31,10 +31,20 @@ uint32_t EventSubMatcher::matches(
     uint32_t count = 0;
     auto transactions = _block->transactions();
     auto receipts = _block->receipts();
-    for (auto [index, transaction, receipt] :
-        ::ranges::views::zip(::ranges::views::iota(0), transactions, receipts))
+    // TEMPORARY (op-node interop breakpoint #3): persisted-but-unexecuted 0x7E deposits
+    // have no receipt, and the block fetch compacts the receipt list to the executed
+    // subset. Deposits form a prefix (OP payload ordering), so receipt i belongs to
+    // transaction i + (txCount - receiptCount); a plain zip would pair receipts with the
+    // deposit prefix and drop the executed tail. The offset is 0 for every block whose
+    // transactions all executed (legacy behavior unchanged).
+    auto const receiptCount = _block->receiptsSize();
+    auto const transactionCount = _block->transactionsSize();
+    auto const offset = transactionCount >= receiptCount ? transactionCount - receiptCount : 0;
+    for (std::size_t index = 0; index < receiptCount; index++)
     {
-        count += matches(_params, *receipt, *transaction, index, _result);
+        auto receipt = receipts[index];
+        auto transaction = transactions[index + offset];
+        count += matches(_params, *receipt, *transaction, index + offset, _result);
     }
 
     return count;

--- a/bcos-rpc/bcos-rpc/filter/LogMatcher.cpp
+++ b/bcos-rpc/bcos-rpc/filter/LogMatcher.cpp
@@ -12,11 +12,21 @@ uint32_t LogMatcher::matches(
 {
     uint32_t count = 0;
     auto receipts = _block->receipts();
-    for (std::size_t index = 0; index < _block->transactionsMetaDataSize(); index++)
+    // TEMPORARY (op-node interop breakpoint #3): persisted-but-unexecuted 0x7E deposits
+    // have no receipt, and the block fetch compacts the receipt list to the executed
+    // subset, so a deposit-bearing block has fewer receipts than transaction hashes.
+    // Deposits form a prefix (OP payload ordering), so receipt i belongs to transaction
+    // i + (txCount - receiptCount). Iterating transactionsMetaDataSize here would read
+    // receipts[] out of bounds AND attribute logs to the wrong transaction. The offset
+    // is 0 for every block whose transactions all executed (legacy behavior unchanged).
+    auto const receiptCount = _block->receiptsSize();
+    auto const metaCount = _block->transactionsMetaDataSize();
+    auto const offset = metaCount >= receiptCount ? metaCount - receiptCount : 0;
+    for (std::size_t index = 0; index < receiptCount; index++)
     {
         auto receipt = receipts[index];
         count += matches(_params, _block->blockHeader()->hash(), *receipt,
-            _block->transactionHash(index), index, _result);
+            _block->transactionHash(index + offset), index + offset, _result);
     }
 
     return count;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -283,8 +283,7 @@ static std::string storageValueToData(std::string_view value)
 {
     bcos::bytes word(32, 0);
     auto const copyLen = (std::min)(value.size(), word.size());
-    std::copy_n(
-        value.data(), copyLen, word.end() - static_cast<std::ptrdiff_t>(copyLen));
+    std::copy_n(value.data(), copyLen, word.end() - static_cast<std::ptrdiff_t>(copyLen));
     return toHex(word, "0x");
 }
 
@@ -301,8 +300,7 @@ task::Task<void> EthEndpoint::getStorageAt(const Json::Value& request, Json::Val
     boost::algorithm::to_lower(addressStr);
     auto position = toView(request[1u]);
     std::string positionStr = std::string(
-        (position.starts_with("0x") || position.starts_with("0X")) ? position.substr(2) :
-                                                                    position);
+        (position.starts_with("0x") || position.starts_with("0X")) ? position.substr(2) : position);
     if (position.size() % 2 != 0)
     {
         positionStr.insert(0, "0");
@@ -1043,10 +1041,41 @@ task::Task<void> EthEndpoint::getTransactionByHash(
     try
     {
         auto const txs = co_await ledger::getTransactions(*ledger, std::move(hashList));
-        auto receipt = co_await ledger::getReceipt(*ledger, hash);
-        if (!receipt || !txs || txs->empty())
+        if (!txs || txs->empty())
         {
             result = Json::nullValue;
+            buildJsonContent(result, response);
+            co_return;
+        }
+        protocol::TransactionReceipt::Ptr receipt;
+        try
+        {
+            receipt = co_await ledger::getReceipt(*ledger, hash);
+        }
+        catch (std::exception const&)
+        {
+            receipt = nullptr;
+        }
+        if (!receipt)
+        {
+            // TEMPORARY (op-node interop breakpoint #3): a persisted-but-unexecuted
+            // 0x7E deposit has no receipt yet, so no block context can be resolved
+            // through it. Render the geth deposit shape with null block fields (the
+            // shape geth uses for pending transactions). Non-deposit receiptless
+            // hashes keep answering null.
+            auto const& tx = *txs->at(0);
+            if (engine::dispatchRawTransaction(tx.extraTransactionBytes()) ==
+                engine::RawTransactionKind::Deposit)
+            {
+                combineTxResponse(result, tx, 0, 0, crypto::HashType{});
+                result["blockHash"] = Json::nullValue;
+                result["blockNumber"] = Json::nullValue;
+                result["transactionIndex"] = Json::nullValue;
+            }
+            else
+            {
+                result = Json::nullValue;
+            }
             buildJsonContent(result, response);
             co_return;
         }
@@ -1088,8 +1117,25 @@ task::Task<void> EthEndpoint::getTransactionByBlockHashAndIndex(
     }
     auto transactions = block->transactions();
     auto tx = transactions.at(transactionIndex);
-    auto receipt = co_await ledger::getReceipt(*ledger, tx->hash());
-    combineTxResponse(result, *tx, *receipt, hash);
+    protocol::TransactionReceipt::Ptr receipt;
+    try
+    {
+        receipt = co_await ledger::getReceipt(*ledger, tx->hash());
+    }
+    catch (std::exception const&)
+    {
+        receipt = nullptr;
+    }
+    if (receipt)
+    {
+        combineTxResponse(result, *tx, *receipt, hash);
+    }
+    else
+    {
+        // TEMPORARY (op-node interop breakpoint #3): persisted-but-unexecuted deposits
+        // carry no receipt; the block context is already known here, so render from it.
+        combineTxResponse(result, *tx, transactionIndex, number, hash);
+    }
     buildJsonContent(result, response);
 }
 
@@ -1120,9 +1166,26 @@ task::Task<void> EthEndpoint::getTransactionByBlockNumberAndIndex(
         {
             BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid transaction index!"));
         }
-        auto receipt = co_await ledger::getReceipt(*ledger, txHash);
         auto blockHash = block->blockHeader()->hash();
-        combineTxResponse(result, *(*tx)[0], *receipt, blockHash);
+        protocol::TransactionReceipt::Ptr receipt;
+        try
+        {
+            receipt = co_await ledger::getReceipt(*ledger, txHash);
+        }
+        catch (std::exception const&)
+        {
+            receipt = nullptr;
+        }
+        if (receipt)
+        {
+            combineTxResponse(result, *(*tx)[0], *receipt, blockHash);
+        }
+        else
+        {
+            // TEMPORARY (op-node interop breakpoint #3): persisted-but-unexecuted
+            // deposits carry no receipt; the block context is already known here.
+            combineTxResponse(result, *(*tx)[0], transactionIndex, blockNumber, blockHash);
+        }
     }
     catch (std::exception const& e)
     {
@@ -1185,8 +1248,8 @@ task::Task<void> EthEndpoint::newFilter(const Json::Value& request, Json::Value&
     auto const ledger = m_nodeService->ledger();
     auto const latest = co_await ledger::getCurrentBlockNumber(*ledger);
     auto params = m_filterSystem->requestFactory()->create();
-    params->fromJson(jParams, latest, m_nodeService->safeBlockDepth(),
-        m_nodeService->finalizedBlockDepth());
+    params->fromJson(
+        jParams, latest, m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
     Json::Value result = co_await m_filterSystem->newFilter(params);
     buildJsonContent(result, response);
 }
@@ -1234,8 +1297,8 @@ task::Task<void> EthEndpoint::getLogs(const Json::Value& request, Json::Value& r
     auto const ledger = m_nodeService->ledger();
     auto const latest = co_await ledger::getCurrentBlockNumber(*ledger);
     auto params = m_filterSystem->requestFactory()->create();
-    params->fromJson(jParams, latest, m_nodeService->safeBlockDepth(),
-        m_nodeService->finalizedBlockDepth());
+    params->fromJson(
+        jParams, latest, m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
     Json::Value result = co_await m_filterSystem->getLogs(params);
     buildJsonContent(result, response);
 }
@@ -1244,8 +1307,8 @@ task::Task<std::tuple<protocol::BlockNumber, bool>> EthEndpoint::getBlockNumberB
 {
     auto ledger = m_nodeService->ledger();
     auto latest = co_await ledger::getCurrentBlockNumber(*ledger);
-    auto [number, _] = bcos::rpc::getBlockNumberByTag(latest, blockTag,
-        m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
+    auto [number, _] = bcos::rpc::getBlockNumberByTag(
+        latest, blockTag, m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
     co_return std::make_tuple(number, std::cmp_equal(latest, number));
 }
 

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -17,8 +17,10 @@
  */
 
 #include "EngineServiceImpl.h"
+#include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
 
 namespace
 {
@@ -42,6 +44,28 @@ bcos::h256 bcos::engine::detail::syntheticHash(std::string_view seed)
     }
     hex.resize((c_hashBytes * 2) + 2);
     return bcos::h256(bcos::fromHex(hex));
+}
+
+bcos::protocol::Transaction::Ptr bcos::engine::detail::makeDepositLedgerTransaction(
+    bcos::bytesConstRef raw)
+{
+    // TEMPORARY (op-node interop breakpoint #3): ledger carrier for an unexecuted OP
+    // deposit. The full EIP-2718 envelope (0x7e || rlp(...)) goes into
+    // extraTransactionBytes — the field the Web3 RPC renderer decodes into the geth
+    // deposit shape (bcos-rpc TransactionResponse.cpp keys the deposit branch on its
+    // first byte) — and the canonical txHash keccak256(raw) into extraTransactionHash,
+    // which TransactionImpl::hash() returns for Web3-typed transactions and which
+    // matches the hash buildPayload feeds the transaction Merkle root for raw-only
+    // entries. No field-level decode happens here: the RPC layer already owns the
+    // read-side decode (decodeDepositTransaction) and the execution-lane wiring will
+    // own the executable decode.
+    auto transaction = std::make_shared<bcostars::protocol::TransactionImpl>();
+    auto& inner = transaction->mutableInner();
+    inner.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+    inner.extraTransactionBytes.assign(raw.begin(), raw.end());
+    auto const hash = bcos::crypto::keccak256Hash(raw);
+    inner.extraTransactionHash.assign(hash.begin(), hash.end());
+    return transaction;
 }
 
 std::vector<std::string> bcos::engine::detail::supportedCapabilities()

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -22,6 +22,7 @@
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/merkle/Merkle.h"
 #include "bcos-framework/engine/EngineService.h"
+#include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-framework/engine/Types.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
@@ -78,6 +79,11 @@ std::optional<std::string> validatePayloadAttributes(
 
 std::optional<std::string> validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version);
+
+/// TEMPORARY (op-node interop breakpoint #3): wrap raw 0x7E deposit bytes into a ledger
+/// transaction carrier without decoding its fields. Replaced when deposit execution
+/// wiring (runDeposit + receipts) lands. See the commit-path comment in newPayload().
+bcos::protocol::Transaction::Ptr makeDepositLedgerTransaction(bcos::bytesConstRef raw);
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -576,28 +582,37 @@ private:
                 // this restores parity with that path (eth_getLogs uses it as a filter).
                 auto const& bloom = it->second.executionPayload.logsBloom;
                 block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
-                // Raw-only entries (forced transactions) carry no decoded form and are
-                // not modeled as ledger transactions until execution wiring lands; the
-                // persisted transaction list therefore matches the receipts list, which
-                // also only covers the executed (decoded) subset.
+                // TEMPORARY (op-node interop breakpoint #3, smoke run 2026-08-19):
+                // forced raw-only 0x7E deposits ARE persisted as ledger transactions so
+                // eth_getBlockByHash/ByNumber (full) can serve them. op-node reads block
+                // N's tx[0] (the L1-info deposit) before building block N+1 and without
+                // this it stalls forever at block 1 ("missing L1 info deposit tx", 633
+                // retries observed). The deposit is stored but NOT executed: no receipt
+                // is generated and state does not advance, so the block's receipt list is
+                // shorter than its transaction list (deposits form a prefix — OP payload
+                // ordering — which the ledger's receipt/tx pairing relies on). The
+                // execution-lane wiring (runDeposit + receipts) replaces this hook.
+                // Non-deposit raw-only entries stay unmodeled until then.
+                auto blockTxs = std::make_shared<protocol::ConstTransactions>();
                 for (auto const& tx : it->second.executionPayload.transactions)
                 {
-                    if (tx.decoded)
+                    protocol::Transaction::Ptr ledgerTx = tx.decoded;
+                    if (!ledgerTx)
                     {
-                        block->appendTransaction(tx.decoded);
+                        if (dispatchRawTransaction(bcos::ref(tx.raw)) !=
+                            RawTransactionKind::Deposit)
+                        {
+                            continue;
+                        }
+                        ledgerTx = detail::makeDepositLedgerTransaction(bcos::ref(tx.raw));
                     }
+                    block->appendTransaction(ledgerTx);
+                    blockTxs->emplace_back(std::move(ledgerTx));
                 }
                 for (auto const& receipt : it->second.receipts)
                 {
                     block->appendReceipt(receipt);
                 }
-                auto blockTxs = std::make_shared<protocol::ConstTransactions>(
-                    it->second.executionPayload.transactions |
-                    ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
-                    ::ranges::views::transform([](auto const& tx) {
-                        return protocol::Transaction::ConstPtr(tx.decoded);
-                    }) |
-                    ::ranges::to<std::vector>());
                 co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
                 co_await m_globalStateStorage.get().mergeBackStorage(prewriteStorage);
             }

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -17,10 +17,13 @@
 #include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <bcos-framework/testutils/faker/FakeBlock.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/Ledger.h>
 #include <bcos-mempool/MemPoolImpl.h>
+#include <bcos-table/src/StateStorage.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-tars-protocol/protocol/TransactionReceiptImpl.h>
 #include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
@@ -315,6 +318,72 @@ PayloadAttributes makeKarstPayloadAttributes()
     payloadAttributes.withdrawals = std::vector<WithdrawalV1>{};
     return payloadAttributes;
 }
+
+/// One receipt per executed transaction — models a real scheduler's receipt count so the
+/// deposit-persistence tests can distinguish executed transactions (which get receipts)
+/// from persisted-but-unexecuted forced deposits (which do not).
+struct EchoScheduler
+{
+    template <class Storage, class Executor>
+    task::Task<std::vector<protocol::TransactionReceipt::Ptr>> executeBlock(Storage&, Executor&,
+        const protocol::BlockHeader&, ::ranges::input_range auto&& transactions,
+        const ledger::LedgerConfig&)
+    {
+        Keccak256 hasher;
+        std::vector<protocol::TransactionReceipt::Ptr> receipts;
+        for ([[maybe_unused]] auto const& transaction : transactions)
+        {
+            auto receipt = std::make_shared<bcostars::protocol::TransactionReceiptImpl>();
+            receipt->calculateHash(hasher);
+            receipts.push_back(std::move(receipt));
+        }
+        co_return receipts;
+    }
+};
+
+/// Encode `0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data])` — a
+/// well-formed OP deposit envelope (same shape the RPC-side decodeDepositTransaction
+/// tests use).
+static bytes buildDepositRaw()
+{
+    bytes body;
+    bcos::codec::rlp::encode(
+        body, crypto::HashType("1111111111111111111111111111111111111111111111111111111111111111"));
+    bcos::codec::rlp::encode(body, Address("2222222222222222222222222222222222222222"));
+    bcos::codec::rlp::encode(body, Address("3333333333333333333333333333333333333333"));
+    bcos::codec::rlp::encode(body, u256(1000));                    // mint
+    bcos::codec::rlp::encode(body, u256(7));                       // value
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(21000));  // gas
+    bcos::codec::rlp::encode(body, static_cast<uint64_t>(0));      // isSystemTx = false
+    bcos::codec::rlp::encode(body, bytes{0xde, 0xad, 0xbe, 0xef});
+    bytes raw;
+    raw.push_back(0x7e);
+    bcos::codec::rlp::encodeHeader(
+        raw, bcos::codec::rlp::Header{.isList = true, .payloadLength = body.size()});
+    raw.insert(raw.end(), body.begin(), body.end());
+    return raw;
+}
+
+/// A real bcos::ledger::Ledger over an in-memory StateStorage, so newPayload's commit
+/// path exercises the genuine prewriteBlockToBuffer persistence (block tx-hash list +
+/// SYS_HASH_2_TX rows) instead of being skipped for lack of a ledger.
+struct LedgerBackedFixture
+{
+    std::shared_ptr<bcos::storage::StateStorage> ledgerStateStorage =
+        std::make_shared<bcos::storage::StateStorage>(nullptr, false);
+    bcos::protocol::BlockFactory::Ptr blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    std::shared_ptr<bcos::ledger::Ledger> ledger;
+
+    LedgerBackedFixture()
+    {
+        // asyncPrewriteBlock reads the running total transaction count from the ledger's
+        // own state storage; the table just has to exist (missing keys count as zero).
+        ledgerStateStorage->createTable(
+            std::string(bcos::ledger::SYS_CURRENT_STATE), std::string(bcos::ledger::SYS_VALUE));
+        ledger = std::make_shared<bcos::ledger::Ledger>(blockFactory, ledgerStateStorage, 100);
+    }
+};
 
 NewPayloadRequest makeNewPayloadRequestV3(const ExecutionPayload& executionPayload)
 {
@@ -1239,6 +1308,142 @@ BOOST_AUTO_TEST_CASE(per_method_version_windows_and_unknown_payload)
         task::syncWait(engineService.newPayload(request, 5)), UnsupportedEngineApiVersion);
     BOOST_CHECK_THROW(
         task::syncWait(engineService.getPayload("0x01", 6)), UnsupportedEngineApiVersion);
+}
+
+// TEMPORARY contract (op-node interop breakpoint #3, smoke run 2026-08-19): a forced
+// 0x7E deposit IS persisted as a ledger transaction (op-node reads block N's tx[0] to
+// build block N+1) but is NOT executed — no receipt row exists until the execution-lane
+// wiring lands, at which point this test's receipt-side assertions flip.
+BOOST_AUTO_TEST_CASE(deposit_only_block_persists_transaction_without_receipt)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    LedgerBackedFixture ledgerFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    StubExecutor executor;
+    StubScheduler scheduler;
+    TestEngineServiceImpl engineService(memPool, globalStateStorageFixture.storage, executor,
+        scheduler, ledgerFixture.blockFactory, ledgerFixture.ledger);
+
+    auto const depositRaw = buildDepositRaw();
+    auto attributes = makePayloadAttributesV3();
+    attributes.noTxPool = true;
+    attributes.transactions = std::vector<std::string>{toHexStringWithPrefix(depositRaw)};
+
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 1);
+
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
+
+    // SYS_HASH_2_TX has a row under the canonical hash keccak256(raw), decodable back to
+    // a transaction that carries the exact envelope bytes.
+    auto const txHash = bcos::crypto::keccak256Hash(bcos::ref(depositRaw));
+    auto txEntry = task::syncWait(bcos::storage2::readOne(globalStateStorageFixture.backendStorage,
+        bcos::executor_v1::StateKeyView{
+            ledger::SYS_HASH_2_TX, bcos::concepts::bytebuffer::toView(txHash)}));
+    BOOST_REQUIRE(txEntry.has_value());
+    auto txField = txEntry->get();
+    auto storedTx = ledgerFixture.blockFactory->transactionFactory()->createTransaction(
+        bcos::bytesConstRef(reinterpret_cast<const bcos::byte*>(txField.data()), txField.size()),
+        false, false, false);
+    BOOST_CHECK_EQUAL(storedTx->hash(), txHash);
+    auto storedRaw = storedTx->extraTransactionBytes();
+    BOOST_CHECK(bytes(storedRaw.begin(), storedRaw.end()) == depositRaw);
+
+    // No receipt row — the deposit was not executed (receiptsSize()==0 side).
+    auto receiptEntry =
+        task::syncWait(bcos::storage2::readOne(globalStateStorageFixture.backendStorage,
+            bcos::executor_v1::StateKeyView{
+                ledger::SYS_HASH_2_RECEIPT, bcos::concepts::bytebuffer::toView(txHash)}));
+    BOOST_CHECK(!receiptEntry.has_value());
+
+    // The committed block models exactly one transaction: its persisted tx-hash list
+    // (SYS_NUMBER_2_TXS) holds the deposit hash alone.
+    auto metaEntry =
+        task::syncWait(bcos::storage2::readOne(globalStateStorageFixture.backendStorage,
+            bcos::executor_v1::StateKeyView{
+                ledger::SYS_NUMBER_2_TXS, std::to_string(c_initialBlockNumber + 1)}));
+    BOOST_REQUIRE(metaEntry.has_value());
+    auto metaField = metaEntry->get();
+    auto metaBlock = ledgerFixture.blockFactory->createBlock(
+        bcos::bytesConstRef(
+            reinterpret_cast<const bcos::byte*>(metaField.data()), metaField.size()),
+        false, false);
+    BOOST_REQUIRE_EQUAL(metaBlock->transactionsMetaDataSize(), 1);
+    BOOST_CHECK_EQUAL(metaBlock->transactionHash(0), txHash);
+}
+
+// Mixed block: forced deposit (no receipt) + executed Web3 transaction (one receipt).
+// The receipt must be keyed under the WEB3 transaction's hash — the deposit prefix must
+// not shift the receipt/tx pairing in prewriteBlockToBuffer.
+BOOST_AUTO_TEST_CASE(deposit_prefix_block_keys_receipts_to_executed_transactions)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    LedgerBackedFixture ledgerFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    std::string sender("acacacacacacacacacac", 20);
+    auto poolTx = makeWeb3Tx(sender, 0);
+    memPool.add(std::vector{poolTx});
+    globalStateStorageFixture.setNonce(sender, "0");
+    StubExecutor executor;
+    EchoScheduler scheduler;
+    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, EchoScheduler>
+        engineService(memPool, globalStateStorageFixture.storage, executor, scheduler,
+            ledgerFixture.blockFactory, ledgerFixture.ledger);
+
+    auto const depositRaw = buildDepositRaw();
+    auto attributes = makePayloadAttributesV3();
+    attributes.transactions = std::vector<std::string>{toHexStringWithPrefix(depositRaw)};
+
+    auto result = task::syncWait(engineService.updateForkchoice(forkchoiceState, &attributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    // Deposit first (OP payload ordering), then the mempool transaction.
+    BOOST_REQUIRE_EQUAL(payload->executionPayload.transactions.size(), 2);
+    BOOST_CHECK(payload->executionPayload.transactions[0].decoded == nullptr);
+    BOOST_CHECK(payload->executionPayload.transactions[1].decoded == poolTx);
+
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
+
+    auto const depositHash = bcos::crypto::keccak256Hash(bcos::ref(depositRaw));
+    // Both transactions persisted...
+    for (auto const& hash : {depositHash, poolTx->hash()})
+    {
+        auto txEntry =
+            task::syncWait(bcos::storage2::readOne(globalStateStorageFixture.backendStorage,
+                bcos::executor_v1::StateKeyView{
+                    ledger::SYS_HASH_2_TX, bcos::concepts::bytebuffer::toView(hash)}));
+        BOOST_REQUIRE(txEntry.has_value());
+    }
+    // ...but the single receipt belongs to the executed Web3 transaction, not the
+    // deposit occupying transaction index 0.
+    auto web3ReceiptEntry =
+        task::syncWait(bcos::storage2::readOne(globalStateStorageFixture.backendStorage,
+            bcos::executor_v1::StateKeyView{
+                ledger::SYS_HASH_2_RECEIPT, bcos::concepts::bytebuffer::toView(poolTx->hash())}));
+    BOOST_CHECK(web3ReceiptEntry.has_value());
+    auto depositReceiptEntry =
+        task::syncWait(bcos::storage2::readOne(globalStateStorageFixture.backendStorage,
+            bcos::executor_v1::StateKeyView{
+                ledger::SYS_HASH_2_RECEIPT, bcos::concepts::bytebuffer::toView(depositHash)}));
+    BOOST_CHECK(!depositReceiptEntry.has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## What

Persist the forced 0x7E deposit transactions (injected by op-node through `payloadAttributes.transactions`) into the ledger block tables when an engine-built payload is committed, so `eth_getBlockByHash/ByNumber` (full), `eth_getTransactionByHash` and the index endpoints can serve them. The deposits are **not executed** and produce **no receipts** — execution wiring belongs to the execution lane and every hook added here is marked `TEMPORARY (op-node interop breakpoint #3)` with the condition under which it is superseded.

## Why

Live smoke against op-node v1.19.3: before building block N+1, op-node reads block N's first transaction (the L1-info deposit) to recover the block's L1 origin. Engine-built blocks persisted only decoded transactions, and forced deposits are raw-only, so `eth_getBlockByHash` answered `transactions: []` and op-node retried `failed to retrieve L2 parent block: l2 block is missing L1 info deposit tx` forever (633 retries in the first run) — the chain could never grow past block 1.

## How

Reuse over reimplementation — no new decode path:

- Classification reuses `dispatchRawTransaction` (`bcos-framework/engine/RawTransactionDispatch.h`); the geth-shaped RPC rendering reuses the existing `decodeDepositTransaction` (`web3jsonrpc/model/DepositTransaction.cpp`), which keys off `extraTransactionBytes()[0] == 0x7e` and decodes fields itself, so the ledger carrier needs no field-level decoding.
- The single new helper `detail::makeDepositLedgerTransaction` wraps the raw envelope into a `TransactionImpl` (`type=Web3Transaction`, `extraTransactionBytes` = envelope, `extraTransactionHash` = keccak256(raw) — the same hash buildPayload already uses for raw-only entries in the transactions root). Read-back paths use `createTransaction(bytes, false, false, false)`, so no signature verification is triggered anywhere.
- The hook sits in the newPayload commit path, not in buildPayload: setting `decoded` at build time would push deposits through the scheduler execution filter, which is exactly what this PR must not do.
- Readers aligned for "more transactions than receipts" blocks: receipt/transaction pairing in `prewriteBlockToBuffer` uses the deposit-prefix offset (legacy blocks keep offset 0), `asyncBatchGetReceipts` grows an `allowMissing` mode used only by block-data reads, and the three `eth_getTransaction*` endpoints tolerate a missing receipt.

## A crash found and fixed along the way

The pre-push self-review caught that `eth_getLogs` with an address filter over a deposit-only block **killed the node** (out-of-bounds in `LogMatcher` when receipts are fewer than transactions), verified live before and after: the fixed node answers `[]` and stays up. The sibling mismatches in `EventSubMatcher` (zip pairing) and `getReceiptProof` are fixed in the same commit.

## Known temporary state (documented in-code)

- Deposits do not count into `SYS_KEY_TOTAL_TRANSACTION_COUNT` (receipt-based counter); display-only skew.
- PBFT-mode writers/readers (`storeTransactionsAndReceipts`, archive tooling, txpool nonce checker) still assume 1:1 tx/receipt pairing. None of them are initialized under `[op_engine_rpc]` mode; a datadir produced by this mode must not be reused under PBFT until the execution lane lands real receipts.
- `transactionIndex` in receipts of mixed blocks still numbers the executed subset.

All of the above disappear once the execution lane executes deposits and produces real receipts; this PR deliberately does not preempt that design.

## Verification

- `test-bcos-engine` 28/28 cases (438 assertions), including two new cases: a deposit-only block persists the transaction (correct hash, byte-identical envelope, `SYS_HASH_2_TX` row, no receipt row) and a mixed block keys receipts to the executed transactions despite the deposit prefix. `test-bcos-rpc`, `test-bcos-ledger`, `test-bcos-mempool`, `test-bcos-tars-protocol` all green.
- Live re-run (op-node v1.19.3, direct Engine connection): zero "missing L1 info deposit tx" occurrences; block 1 serves the full geth-shaped deposit (`sourceHash`/`from`/`to`/`mint`/`type: 0x7e`), `eth_getBlockTransactionCountByHash = 0x1`, `eth_getTransactionReceipt = null` as expected. The session now stops at the next known gap (engine-built headers carry no Jovian 17-byte extraData — separate follow-up), with no new errors before it.
