### PR TITLE
feat(EthBlockHeader): Integrate Ethereum block headers into EngineService and serve real header fields via eth_ RPC responses*

### DIFF
--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -2188,6 +2188,10 @@ bool Ledger::buildGenesisBlock(
         // (asyncCreateTable rejects an existing table on the next attempt).
         auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
         header->setNumber(0);
+        // Genesis deliberately leaves parentInfo unset: parentInfo() reads back the default
+        // zero hash (BlockHeaderImpl returns {} for an empty list), which is exactly the
+        // value a genesis block must carry. Keeping it data-driven rather than forcing a
+        // zero here means the RLP genesis hash is invariant regardless of representation.
         if (versionNumber >= protocol::BlockVersion::V3_1_VERSION)
         {
             header->setVersion(versionNumber);

--- a/bcos-ledger/test/unittests/ledger/test_GenesisEthHeader.cpp
+++ b/bcos-ledger/test/unittests/ledger/test_GenesisEthHeader.cpp
@@ -136,9 +136,8 @@ BOOST_AUTO_TEST_CASE(BuildsRlpHashMatchingPythonReference)
         // The stored header keeps its Ethereum identity across encode/decode.
         BOOST_CHECK(header->ethBlockVersion() == EthBlockVersion::PRAGUE);
         BOOST_CHECK_EQUAL(header->stateRoot().hex(), std::string(c_emptyTrieRoot));
-        // B0 timestamp is stored in the internal MILLISECOND domain (artifact
-        // seconds x 1000); the RLP bridge divides back to seconds for the hash.
-        BOOST_CHECK_EQUAL(header->timestamp(), 0x689d5c00LL * 1000);
+        // B0 timestamp is the artifact's, converted to BlockHeader milliseconds.
+        BOOST_CHECK_EQUAL(header->timestamp(), 0x689d5c00 * 1000LL);
 
         // The FISCO genesis pin moved to SYS_CONFIG.
         auto pinEntry = co_await storage2::readOne(

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -45,19 +45,6 @@ bcos::Error::UniquePtr EthBlockHeader::calculateRLPHash(bcos::protocol::BlockHea
     return nullptr;
 }
 
-// Precondition: the header's timestamp (internal milliseconds, every version) must be a
-// whole number of seconds (ms divisible by 1000). Sub-second timestamps produce an RLP
-// hash that cannot be reproduced from the decoded form. Throws std::invalid_argument on
-// violation.
-bcos::crypto::HashType EthBlockHeader::computeHash(
-    const bcos::protocol::BlockHeader& header) noexcept(false)
-{
-    EthBlockHeader ethHeader(header);
-    bcos::bytes encoded;
-    ethHeader.rlpEncode(encoded);
-    return bcos::crypto::keccak256Hash(bcos::ref(encoded));
-}
-
 bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data)
 {
@@ -90,6 +77,15 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
+    // EthBlockHeaderData stores SECONDS; the internal BlockHeader stores MILLISECONDS.
+    // Bound by int64 before the ×1000 so a hostile wire value cannot trigger signed
+    // overflow on the conversion.
+    if (ethHeader.data().timestamp >
+        std::numeric_limits<int64_t>::max() / 1000)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
+            "EthBlockHeader: timestamp out of representable millisecond range");
+    }
     header->setTimestamp(ethHeader.data().timestamp * 1000);
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
@@ -157,28 +153,22 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
         return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeaderType),
             "EthBlockHeader: header is null");
     }
+
+    // Reset the destination first so reusing a header (previously holding higher-version
+    // optional fields) cannot leak stale values into this decode.
     header->clear();
 
     EthBlockHeader ethHeader;
+    // Call rlpDecode directly (not via toEthBlockHeader) so a timestamp-overflow
+    // InvalidHeader error surfaces with its original code instead of being re-wrapped
+    // as RlpDecodeFailed.
     if (auto err = ethHeader.rlpDecode(_data))
     {
         return err;
     }
 
-    // Like toTarsHeader's field writes but WITHOUT validateHeader — usable for FISCO-native/OP
-    // (NON_ETH) headers that validateHeader rejects. TWO DELIBERATE omissions from toTarsHeader:
-    //   1. ethBlockVersion is pinned to NON_ETH here instead of copying ethHeader.version()
-    //      (which after rlpDecode is derived from the optional-field cascade). Headers decoded
-    //      through this path are FISCO-native/OP, and downstream routing (e.g.
-    //      BlockHeaderImpl::calculateHash) keys off the version — write it explicitly instead
-    //      of relying on header->clear() leaving the tars field at its default 0 happening to
-    //      equal NON_ETH. The timestamp domain does NOT depend on this pin: internal is always
-    //      milliseconds, and rlpDecode/rlpEncode convert unconditionally for every version.
-    //   2. rlpHash is NOT set (toTarsHeader writes it via rlpEncode+keccak256). Callers
-    //      that need the block hash should call computeHash() or calculateRLPHash() explicitly —
-    //      computing it here would force a full re-encode for every decode, even when the caller
-    //      only needs field access.
-    header->setEthBlockVersion(bcos::protocol::EthBlockVersion::NON_ETH);
+    // Same field projection as toTarsHeader, but deliberately WITHOUT validateHeader:
+    // this path serves FISCO-native/OP (NON_ETH) headers that validateHeader rejects.
     header->setParentInfo(ethHeader.data().parentInfo);
     header->setCoinbase(ethHeader.data().coinbase);
     header->setUncleHash(ethHeader.data().uncleHash);
@@ -189,12 +179,21 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
-    header->setTimestamp(ethHeader.data().timestamp);  // already ms (rlpDecode converted)
+    // EthBlockHeaderData stores SECONDS; the internal BlockHeader stores MILLISECONDS.
+    // Bound by int64 before the ×1000 so a hostile wire value cannot trigger signed
+    // overflow on the conversion.
+    if (ethHeader.data().timestamp > std::numeric_limits<int64_t>::max() / 1000)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
+            "EthBlockHeader: timestamp out of representable millisecond range");
+    }
+    header->setTimestamp(ethHeader.data().timestamp * 1000);
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
     header->setExtraData(ethHeader.data().extraData);
     header->setLogsBloom(
         bcos::bytesConstRef(ethHeader.data().logsBloom.data(), ethHeader.data().logsBloom.size()));
+
     if (ethHeader.data().baseFee.has_value())
     {
         header->setBaseFee(*ethHeader.data().baseFee);
@@ -219,6 +218,11 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     {
         header->setRequestsHash(*ethHeader.data().requestsHash);
     }
+
+    // Unlike toTarsHeader, the version is PINNED to NON_ETH (not copied): this decode path
+    // serves FISCO-native/OP headers, whose hashing stays on the Tars side, not the RLP
+    // bridge. No RLP hash is injected for the same reason.
+    header->setEthBlockVersion(EthBlockVersion::NON_ETH);
     return nullptr;
 }
 
@@ -405,11 +409,9 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     // Required fields — converted directly, with defensive defaults for empty fields so
     // constructing from an incomplete header never crashes (validation is the caller's job,
     // e.g. via calculateRLPHash -> validateHeader).
-    // ETH-version headers carry the timestamp in SECONDS in EthBlockHeaderData: the header
-    // (milliseconds) is divided by 1000. NON_ETH headers keep MILLISECONDS in
-    // EthBlockHeaderData — rlpEncode's /1000 then produces the seconds the RLP field carries,
-    // so the header timestamp is passed through unchanged. m_version must be set first since
-    // the conversion keys off it.
+    // Timestamp domain model: EthBlockHeaderData carries SECONDS (the Ethereum RLP domain);
+    // the internal BlockHeader stores MILLISECONDS. Convert unconditionally at this bridge
+    // (ms /1000) for every version — no per-version branching.
     m_version = _header.ethBlockVersion();
     auto parent = _header.parentInfo();
     m_data.parentInfo.blockNumber = parent.blockNumber;
@@ -424,8 +426,7 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     m_data.gasLimit = _header.gasLimit();
     m_data.gasUsed = _header.gasUsed();
     m_data.number = _header.number();
-    m_data.timestamp = (m_version == EthBlockVersion::NON_ETH) ? _header.timestamp() :
-                                                                 _header.timestamp() / 1000;
+    m_data.timestamp = _header.timestamp() / 1000;
     m_data.prevRandao = _header.prevRandao();
     m_data.nonce = _header.nonce();
 
@@ -469,27 +470,15 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
 
 void EthBlockHeader::rlpEncode(bcos::bytes& out) const
 {
-    // Timestamp domain model: internal is always milliseconds (every EthBlockVersion,
-    // NON_ETH included); the RLP surface always carries seconds; conversion happens
-    // unconditionally at this bridge (/1000 here, ×1000 in rlpDecode) — no per-version
-    // branching.
-    //
-    // Integer division is lossy for sub-second precision (1001 ms → 1 s). Every producer
-    // that reaches this bridge carries whole-second milliseconds by construction (the
-    // Engine API boundary, the eth-genesis path and rlpDecode all multiply seconds by
-    // 1000); sub-second input would produce an RLP hash not reproducible from the decoded
-    // form. Throw (not assert — assert is compiled out under NDEBUG).
-    if (m_data.timestamp % 1000 != 0)
-    {
-        BOOST_THROW_EXCEPTION(std::invalid_argument(
-            "timestamp must be a whole number of seconds (ms divisible by 1000)"));
-    }
-    const auto rlpTimestamp = m_data.timestamp / 1000;
+    // Timestamp domain model: EthBlockHeaderData stores SECONDS (the Ethereum RLP domain);
+    // the RLP surface carries seconds directly — no conversion here. The ms->s conversion
+    // happens only at the EthBlockHeader<->BlockHeader boundary (constructor /1000,
+    // toTarsHeader/decodeTarsHeader ×1000).
     codec::rlp::encode(out, m_data.parentInfo.blockHash, m_data.uncleHash, m_data.coinbase,
         m_data.stateRoot, m_data.txsRoot, m_data.receiptsRoot,
         bcos::bytesConstRef(m_data.logsBloom.data(), m_data.logsBloom.size()), m_data.difficulty,
         static_cast<uint64_t>(m_data.number), m_data.gasLimit, m_data.gasUsed,
-        static_cast<uint64_t>(rlpTimestamp), m_data.extraData, m_data.prevRandao, m_data.nonce,
+        static_cast<uint64_t>(m_data.timestamp), m_data.extraData, m_data.prevRandao, m_data.nonce,
         m_data.baseFee, m_data.withdrawalsHash, m_data.blobGasUsed, m_data.excessBlobGas,
         m_data.parentBeaconRoot, m_data.requestsHash);
 }
@@ -521,17 +510,17 @@ bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
 
     m_data.number = static_cast<int64_t>(_number);
 
-    // The wire timestamp is seconds; the internal domain (m_data mirrors the internal
-    // BlockHeader) is milliseconds for every version — convert unconditionally, bounded by
-    // int64 first so a hostile wire value cannot trigger signed overflow on the ×1000.
-    constexpr auto c_maxWireTimestampSeconds =
-        static_cast<uint64_t>(std::numeric_limits<int64_t>::max() / 1000);
-    if (_timestamp > c_maxWireTimestampSeconds)
+    // The wire timestamp is seconds; the internal EthBlockHeaderData domain is also seconds
+    // for every version — no conversion here. Bound by int64 so a hostile wire value cannot
+    // wrap on the cast. The seconds->milliseconds conversion (×1000) happens only at the
+    // EthBlockHeader->BlockHeader boundary (toTarsHeader / decodeTarsHeader), where an
+    // overflow check guards the multiplication.
+    if (_timestamp > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
     {
         return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
-            "EthBlockHeader: timestamp out of representable millisecond range");
+            "EthBlockHeader: timestamp out of representable range");
     }
-    m_data.timestamp = static_cast<int64_t>(_timestamp) * 1000;
+    m_data.timestamp = static_cast<int64_t>(_timestamp);
 
     // Optional fork fields are decoded positionally, so the set of present optionals is
     // always a contiguous prefix — a later field can only be present if the view was still

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -405,6 +405,12 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     // Required fields — converted directly, with defensive defaults for empty fields so
     // constructing from an incomplete header never crashes (validation is the caller's job,
     // e.g. via calculateRLPHash -> validateHeader).
+    // ETH-version headers carry the timestamp in SECONDS in EthBlockHeaderData: the header
+    // (milliseconds) is divided by 1000. NON_ETH headers keep MILLISECONDS in
+    // EthBlockHeaderData — rlpEncode's /1000 then produces the seconds the RLP field carries,
+    // so the header timestamp is passed through unchanged. m_version must be set first since
+    // the conversion keys off it.
+    m_version = _header.ethBlockVersion();
     auto parent = _header.parentInfo();
     m_data.parentInfo.blockNumber = parent.blockNumber;
     m_data.parentInfo.blockHash = parent.blockHash;
@@ -418,7 +424,8 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     m_data.gasLimit = _header.gasLimit();
     m_data.gasUsed = _header.gasUsed();
     m_data.number = _header.number();
-    m_data.timestamp = _header.timestamp() / 1000;
+    m_data.timestamp = (m_version == EthBlockVersion::NON_ETH) ? _header.timestamp() :
+                                                                 _header.timestamp() / 1000;
     m_data.prevRandao = _header.prevRandao();
     m_data.nonce = _header.nonce();
 
@@ -458,8 +465,6 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     {
         m_data.requestsHash = _header.requestsHash();
     }
-
-    m_version = _header.ethBlockVersion();
 }
 
 void EthBlockHeader::rlpEncode(bcos::bytes& out) const

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -145,6 +145,18 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     return nullptr;
 }
 
+bcos::Error::UniquePtr EthBlockHeader::toEthBlockHeader(
+    EthBlockHeader& ethHeader, bcos::bytesConstRef _data)
+{
+    auto err = ethHeader.rlpDecode(_data);
+    if (err)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::RlpDecodeFailed),
+            "EthBlockHeader: rlpDecode failed: " + err->errorMessage());
+    }
+    return nullptr;
+}
+
 bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data)
 {
@@ -223,18 +235,6 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     // serves FISCO-native/OP headers, whose hashing stays on the Tars side, not the RLP
     // bridge. No RLP hash is injected for the same reason.
     header->setEthBlockVersion(EthBlockVersion::NON_ETH);
-    return nullptr;
-}
-
-bcos::Error::UniquePtr EthBlockHeader::toEthBlockHeader(
-    EthBlockHeader& ethHeader, bcos::bytesConstRef _data)
-{
-    auto err = ethHeader.rlpDecode(_data);
-    if (err)
-    {
-        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::RlpDecodeFailed),
-            "EthBlockHeader: rlpDecode failed: " + err->errorMessage());
-    }
     return nullptr;
 }
 
@@ -474,6 +474,19 @@ void EthBlockHeader::rlpEncode(bcos::bytes& out) const
     // the RLP surface carries seconds directly — no conversion here. The ms->s conversion
     // happens only at the EthBlockHeader<->BlockHeader boundary (constructor /1000,
     // toTarsHeader/decodeTarsHeader ×1000).
+    //
+    // Defense-in-depth: a negative number/timestamp would wrap into a huge u64 on the
+    // static_cast below, silently corrupting the RLP. calculateRLPHash guards via
+    // validateHeader, but rlpEncode is public — reject here so a direct caller cannot
+    // produce a wrong encoding.
+    if (m_data.number < 0)
+    {
+        BOOST_THROW_EXCEPTION(std::invalid_argument("number must be non-negative"));
+    }
+    if (m_data.timestamp < 0)
+    {
+        BOOST_THROW_EXCEPTION(std::invalid_argument("timestamp must be non-negative"));
+    }
     codec::rlp::encode(out, m_data.parentInfo.blockHash, m_data.uncleHash, m_data.coinbase,
         m_data.stateRoot, m_data.txsRoot, m_data.receiptsRoot,
         bcos::bytesConstRef(m_data.logsBloom.data(), m_data.logsBloom.size()), m_data.difficulty,

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -90,8 +90,7 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
-    // rlpDecode already converted the wire's seconds into internal milliseconds.
-    header->setTimestamp(ethHeader.data().timestamp);
+    header->setTimestamp(ethHeader.data().timestamp * 1000);
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
     header->setExtraData(ethHeader.data().extraData);
@@ -419,7 +418,7 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     m_data.gasLimit = _header.gasLimit();
     m_data.gasUsed = _header.gasUsed();
     m_data.number = _header.number();
-    m_data.timestamp = _header.timestamp();
+    m_data.timestamp = _header.timestamp() / 1000;
     m_data.prevRandao = _header.prevRandao();
     m_data.nonce = _header.nonce();
 

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
@@ -54,9 +54,9 @@ struct EthBlockHeaderData
     bcos::Address coinbase;
     bcos::h64 nonce;
     int64_t number{0};
-    // Always MILLISECONDS — mirrors the internal BlockHeader domain for every version.
-    // The RLP surface always carries seconds; rlpEncode (/1000) and rlpDecode (×1000)
-    // convert unconditionally at that bridge.
+    // Always SECONDS — mirrors the Ethereum RLP domain for every version. The internal
+    // BlockHeader (BlockHeaderImpl/tars) stores MILLISECONDS; the bridge converts only at
+    // the EthBlockHeader<->BlockHeader boundary (constructor /1000, toTarsHeader ×1000).
     int64_t timestamp{0};
 
     // Optional fields (16–23)
@@ -106,25 +106,18 @@ public:
     //    base-class header via setRLPHash.
     static bcos::Error::UniquePtr toTarsHeader(
         bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data);
+    /// Decode an RLP header into the caller-provided EthBlockHeader (no header projection;
+    /// EthBlockHeaderData keeps the RLP domain — timestamp in seconds).
+    static bcos::Error::UniquePtr toEthBlockHeader(
+        EthBlockHeader& ethHeader, bcos::bytesConstRef _data);
     /// Like toTarsHeader but WITHOUT validateHeader — usable for FISCO-native/OP (NON_ETH)
     /// headers that validateHeader rejects. Unlike toTarsHeader, ethBlockVersion is PINNED to
     /// NON_ETH (not copied). The produced header's timestamp is MILLISECONDS like every other
-    /// internal header (the RLP surface's seconds are converted by rlpDecode, unconditionally
-    /// for every version).
+    /// internal header (EthBlockHeaderData stores seconds; the ×1000 conversion to the
+    /// internal BlockHeader domain happens here, unconditionally for every version).
     static bcos::Error::UniquePtr decodeTarsHeader(
         bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data);
-    static bcos::Error::UniquePtr toEthBlockHeader(
-        EthBlockHeader& ethHeader, bcos::bytesConstRef _data);
     static bcos::Error::UniquePtr calculateRLPHash(bcos::protocol::BlockHeader& header);
-    /// Compute keccak256(rlp(header)) WITHOUT validation or state mutation — usable for
-    /// FISCO-native/OP headers (EthBlockVersion::NON_ETH) that calculateRLPHash's
-    /// validateHeader rejects. Returns the 32-byte Ethereum block hash. The header's
-    /// timestamp is internal milliseconds (every version); rlpEncode divides by 1000
-    /// unconditionally and throws std::invalid_argument if it is not a whole number of
-    /// seconds (ms not divisible by 1000) — callers that cannot tolerate exceptions
-    /// should use calculateRLPHash (which returns Error::UniquePtr) instead.
-    static bcos::crypto::HashType computeHash(const bcos::protocol::BlockHeader& header) noexcept(
-        false);
 
     const EthBlockHeaderData& data() const { return m_data; }
 

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -95,8 +95,9 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     // header -> Eth
     EthBlockHeader ethHeader(*header);
     BOOST_CHECK_EQUAL(ethHeader.data().number, 77);
-    // The bridge struct mirrors the internal millisecond domain; only the RLP bytes are seconds.
-    BOOST_CHECK_EQUAL(ethHeader.data().timestamp, 1700000000000LL);
+    // The bridge struct mirrors the Ethereum RLP domain (seconds); the internal BlockHeader
+    // milliseconds are converted at construction (ms -> s).
+    BOOST_CHECK_EQUAL(ethHeader.data().timestamp, 1700000000LL);
     BOOST_CHECK_EQUAL(ethHeader.data().gasLimit, u256(30000000));
     BOOST_CHECK_EQUAL(ethHeader.data().gasUsed, u256(21000));
     BOOST_CHECK_EQUAL(ethHeader.data().uncleHash,
@@ -117,8 +118,8 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     ethError = EthBlockHeader::toEthBlockHeader(decodedEth, bcos::ref(rlp));
     BOOST_CHECK(!ethError);
     BOOST_CHECK_EQUAL(decodedEth.data().number, 77);
-    // rlpDecode converts the wire's seconds back into internal milliseconds.
-    BOOST_CHECK_EQUAL(decodedEth.data().timestamp, 1700000000000LL);
+    // rlpDecode keeps the wire's seconds directly in EthBlockHeaderData (no ms conversion).
+    BOOST_CHECK_EQUAL(decodedEth.data().timestamp, 1700000000LL);
     BOOST_CHECK_EQUAL(decodedEth.data().gasLimit, u256(30000000));
     BOOST_CHECK_EQUAL(decodedEth.data().gasUsed, u256(21000));
     BOOST_CHECK(decodedEth.data().baseFee.has_value());
@@ -656,8 +657,8 @@ BOOST_AUTO_TEST_CASE(toTarsHeaderClearsResidual)
 }
 
 // A wire header whose seconds timestamp would overflow int64 milliseconds must be rejected
-// by the decode bridge (rlpDecode) before its x1000 conversion, surfacing through
-// decodeTarsHeader as an error (regression for the seconds->ms bridge).
+// by the decode path — rlpDecode rejects a seconds value that cannot fit int64 (2^63), so
+// decodeTarsHeader surfaces the InvalidHeader error before its ×1000 ms conversion.
 BOOST_AUTO_TEST_CASE(decodeTarsHeaderRejectsOverflowingTimestamp)
 {
     // Re-encode a valid header's fields with a hostile timestamp: 2^63 encodes fine as a
@@ -696,10 +697,10 @@ BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
 
 // decodeTarsHeader pins ethBlockVersion to NON_ETH explicitly instead of relying on the tars
 // default 0 happening to equal it. The pin holds even when the destination header carried a
-// real ETH version before the decode. Internal timestamps are milliseconds for every version
-// (the RLP surface is seconds, converted unconditionally by rlpDecode/rlpEncode), so the
-// decoded header's timestamp equals the ms source's and the seconds↔ms round-trip reproduces
-// the input RLP byte-for-byte regardless of the pinned version.
+// real ETH version before the decode. EthBlockHeaderData carries SECONDS (the RLP domain);
+// decodeTarsHeader converts to the internal BlockHeader milliseconds (×1000), so the decoded
+// header's timestamp equals the ms source's and the seconds↔ms round-trip reproduces the
+// input RLP byte-for-byte regardless of the pinned version.
 BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
 {
     auto source = makeEthHeader(EthBlockVersion::PRAGUE);
@@ -716,8 +717,9 @@ BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
     // header timestamp is already milliseconds, so the two must be equal — NOT ×1000 again.
     BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp());
 
-    // Re-encoding the decoded header must reproduce the input RLP: ×1000 on decode, /1000 on
-    // encode — the unconditional inverse pair at the RLP bridge.
+    // Re-encoding the decoded header must reproduce the input RLP: ×1000 on the
+    // EthBlockHeader->BlockHeader boundary, /1000 on the BlockHeader->EthBlockHeader
+    // boundary — the unconditional inverse pair of the bridge.
     EthBlockHeader roundTrip(*decoded);
     bytes reencoded;
     roundTrip.rlpEncode(reencoded);

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -712,6 +712,8 @@ BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
     error = EthBlockHeader::decodeTarsHeader(decoded, bcos::ref(rlp));
     BOOST_CHECK(!error);
     BOOST_CHECK(decoded->ethBlockVersion() == EthBlockVersion::NON_ETH);
+    // decodeTarsHeader writes the RLP seconds ×1000 into the header (milliseconds); source's
+    // header timestamp is already milliseconds, so the two must be equal — NOT ×1000 again.
     BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp());
 
     // Re-encoding the decoded header must reproduce the input RLP: ×1000 on decode, /1000 on

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -656,31 +656,6 @@ BOOST_AUTO_TEST_CASE(toTarsHeaderClearsResidual)
     BOOST_CHECK(reused->ethBlockVersion() == EthBlockVersion::PRE_LONDON);
 }
 
-// A wire header whose seconds timestamp would overflow int64 milliseconds must be rejected
-// by the decode path — rlpDecode rejects a seconds value that cannot fit int64 (2^63), so
-// decodeTarsHeader surfaces the InvalidHeader error before its ×1000 ms conversion.
-BOOST_AUTO_TEST_CASE(decodeTarsHeaderRejectsOverflowingTimestamp)
-{
-    // Re-encode a valid header's fields with a hostile timestamp: 2^63 encodes fine as a
-    // uint64 RLP scalar but has no int64 millisecond representation.
-    auto header = makeEthHeader();
-    EthBlockHeader ethHeader(*header);
-    auto const& d = ethHeader.data();
-    constexpr uint64_t hostileTimestamp = 0x8000000000000000ULL;
-
-    bytes rlp;
-    codec::rlp::encode(rlp, d.parentInfo.blockHash, d.uncleHash, d.coinbase, d.stateRoot, d.txsRoot,
-        d.receiptsRoot, bcos::bytesConstRef(d.logsBloom.data(), d.logsBloom.size()), d.difficulty,
-        static_cast<uint64_t>(d.number), d.gasLimit, d.gasUsed, hostileTimestamp, d.extraData,
-        d.prevRandao, d.nonce, d.baseFee, d.withdrawalsHash, d.blobGasUsed, d.excessBlobGas,
-        d.parentBeaconRoot, d.requestsHash);
-
-    auto decodedHeader = makeEthHeader();
-    auto error = EthBlockHeader::decodeTarsHeader(decodedHeader, bcos::ref(rlp));
-    BOOST_REQUIRE(error != nullptr);
-    BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
-}
-
 // An invalid Eth header: calculateHash clears dataHash, so hash() must throw
 // EmptyBlockHeaderHash (regression for the FIB-130 clear-on-failure behaviour).
 BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
@@ -693,37 +668,6 @@ BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
     bcos::crypto::Keccak256 keccak;
     BOOST_CHECK_NO_THROW(impl->calculateHash(keccak));
     BOOST_CHECK_THROW(header->hash(), std::exception);
-}
-
-// decodeTarsHeader pins ethBlockVersion to NON_ETH explicitly instead of relying on the tars
-// default 0 happening to equal it. The pin holds even when the destination header carried a
-// real ETH version before the decode. EthBlockHeaderData carries SECONDS (the RLP domain);
-// decodeTarsHeader converts to the internal BlockHeader milliseconds (×1000), so the decoded
-// header's timestamp equals the ms source's and the seconds↔ms round-trip reproduces the
-// input RLP byte-for-byte regardless of the pinned version.
-BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
-{
-    auto source = makeEthHeader(EthBlockVersion::PRAGUE);
-    EthBlockHeader sourceBridge(*source);
-    bytes rlp;
-    sourceBridge.rlpEncode(rlp);
-
-    auto decoded = makeEthHeader(EthBlockVersion::PRAGUE);  // nonzero version pre-decode
-    bcos::Error::UniquePtr error;
-    error = EthBlockHeader::decodeTarsHeader(decoded, bcos::ref(rlp));
-    BOOST_CHECK(!error);
-    BOOST_CHECK(decoded->ethBlockVersion() == EthBlockVersion::NON_ETH);
-    // decodeTarsHeader writes the RLP seconds ×1000 into the header (milliseconds); source's
-    // header timestamp is already milliseconds, so the two must be equal — NOT ×1000 again.
-    BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp());
-
-    // Re-encoding the decoded header must reproduce the input RLP: ×1000 on the
-    // EthBlockHeader->BlockHeader boundary, /1000 on the BlockHeader->EthBlockHeader
-    // boundary — the unconditional inverse pair of the bridge.
-    EthBlockHeader roundTrip(*decoded);
-    bytes reencoded;
-    roundTrip.rlpEncode(reencoded);
-    BOOST_CHECK(reencoded == rlp);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -41,7 +41,9 @@ static bcos::protocol::BlockHeader::Ptr makeEthHeader(
     auto tars = std::make_shared<bcostars::BlockHeader>();
     auto& data = tars->data;
     data.blockNumber = 77;
-    data.timestamp = 1700000000000LL;  // internal domain: milliseconds (whole seconds)
+    // BlockHeader stores the timestamp in MILLISECONDS; EthBlockHeaderData (the RLP
+    // domain) stores seconds. The bridge converts at construction (ms -> s).
+    data.timestamp = 1700000000 * 1000LL;
     data.gasLimit = "30000000";
     data.gasUsed = "21000";
     data.coinbase.assign(20, static_cast<char>(0xab));
@@ -138,12 +140,13 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     decodedEth.rlpEncode(rlpReencoded);
     BOOST_CHECK(rlp == rlpReencoded);
 
-    // Static: decode RLP into a caller-provided base-class header
+    // Static: decode RLP into a caller-provided base-class header. The RLP carries seconds,
+    // the bridge converts to BlockHeader milliseconds.
     auto decodedHeader = makeEthHeader();
     ethError = EthBlockHeader::toTarsHeader(decodedHeader, bcos::ref(rlp));
     BOOST_CHECK(!ethError);
     BOOST_CHECK_EQUAL(decodedHeader->number(), 77);
-    BOOST_CHECK_EQUAL(decodedHeader->timestamp(), 1700000000000LL);
+    BOOST_CHECK_EQUAL(decodedHeader->timestamp(), 1700000000 * 1000LL);
     BOOST_CHECK_EQUAL(decodedHeader->gasLimit(), u256(30000000));
     BOOST_CHECK_EQUAL(decodedHeader->gasUsed(), u256(21000));
     // The converted header must be marked as an Eth header
@@ -436,9 +439,9 @@ BOOST_AUTO_TEST_CASE(goldenMainnetCancunHeader)
     BOOST_REQUIRE(impl != nullptr);
     auto& data = impl->inner().data;
     data.blockNumber = 19800000;
-    // On-chain seconds 1714865051, stored in the internal millisecond domain; the RLP
-    // bridge divides back to seconds, so the golden hash/bytes below stay byte-identical.
-    data.timestamp = 1714865051000LL;
+    // BlockHeader milliseconds; the bridge converts to seconds for the RLP encoding, which
+    // must reproduce the on-chain 1714865051 second timestamp.
+    data.timestamp = 1714865051 * 1000LL;
     data.gasLimit = "30000000";
     data.gasUsed = "8020412";
     data.baseFee = "5007423601";

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -77,9 +77,8 @@ void bcos::rpc::combineBlockResponse(
     result["size"] = toQuantity(block.size());
     result["gasLimit"] = toQuantity(blockHeader->gasLimit());
     result["gasUsed"] = toQuantity(static_cast<uint64_t>(blockHeader->gasUsed()));
-    // Eth headers carry the timestamp in seconds already; FISCO headers in milliseconds.
-    result["timestamp"] = toQuantity(
-        isEth ? blockHeader->timestamp() : blockHeader->timestamp() / 1000);
+    // BlockHeader stores the timestamp in milliseconds; the eth_* RPC emits seconds.
+    result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);
 
     // Fork-gated Ethereum fields: only defined for the fork that introduced them.
     auto versionAtLeast = [&](bcos::protocol::EthBlockVersion fork) {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -21,7 +21,8 @@ void bcos::rpc::combineBlockResponse(
 
     if (isEth)
     {
-        // Ethereum header: every field is taken verbatim from the header.
+        // Ethereum header: header-carried fields are taken from the header. The block-body
+        // fields (withdrawals list, totalDifficulty) remain placeholders below.
         result["nonce"] = blockHeader->nonce().hexPrefixed();
         result["sha3Uncles"] = blockHeader->uncleHash().hexPrefixed();
         // EIP-55 checksummed address, matching geth's eth_getBlock* output.

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -24,7 +24,11 @@ void bcos::rpc::combineBlockResponse(
         // Ethereum header: every field is taken verbatim from the header.
         result["nonce"] = blockHeader->nonce().hexPrefixed();
         result["sha3Uncles"] = blockHeader->uncleHash().hexPrefixed();
-        result["miner"] = blockHeader->coinbase().hexPrefixed();
+        // EIP-55 checksummed address, matching geth's eth_getBlock* output.
+        auto minerAddr = blockHeader->coinbase().hex();
+        auto minerAddrHash = crypto::keccak256Hash(bytesConstRef(minerAddr)).hex();
+        toChecksumAddress(minerAddr, minerAddrHash);
+        result["miner"] = "0x" + minerAddr;
         result["difficulty"] = toQuantity(blockHeader->difficulty());
         result["mixHash"] = blockHeader->prevRandao().hexPrefixed();
     }
@@ -75,20 +79,26 @@ void bcos::rpc::combineBlockResponse(
     result["totalDifficulty"] = "0x0";
     result["extraData"] = toHexStringWithPrefix(blockHeader->extraData());
     result["size"] = toQuantity(block.size());
-    result["gasLimit"] = toQuantity(blockHeader->gasLimit());
+    // Native FISCO-BCOS blocks never call setGasLimit, so the header field reads back as 0;
+    // keep the historical fixed value for NON_ETH blocks (the Ethereum-compatible gas limit),
+    // and the real header value for Eth blocks (where buildPayload always sets it).
+    result["gasLimit"] = toQuantity(
+        isEth ? blockHeader->gasLimit() : bcos::u256(30000000));
     result["gasUsed"] = toQuantity(static_cast<uint64_t>(blockHeader->gasUsed()));
     // BlockHeader stores the timestamp in milliseconds; the eth_* RPC emits seconds.
     result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);
 
-    // Fork-gated Ethereum fields: only defined for the fork that introduced them.
+    // Fork-gated Ethereum fields: only defined for the fork that introduced them. Eth blocks
+    // read the values from the header; native NON_ETH blocks keep the historical fixed mock
+    // values so their RPC shape is unchanged.
     auto versionAtLeast = [&](bcos::protocol::EthBlockVersion fork) {
-        return isEth && static_cast<uint8_t>(ethVersion) >= static_cast<uint8_t>(fork);
+        return static_cast<uint8_t>(ethVersion) >= static_cast<uint8_t>(fork);
     };
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::LONDON))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::LONDON))
     {
         result["baseFeePerGas"] = toQuantity(blockHeader->baseFee().value_or(bcos::u256(0)));
     }
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::SHANGHAI))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::SHANGHAI))
     {
         // The withdrawals operation list is a block-body field and is not persisted in the
         // header (only its trie root is); emit the always-empty list so Shanghai-shaped
@@ -99,7 +109,7 @@ void bcos::rpc::combineBlockResponse(
             result["withdrawalsRoot"] = root->hexPrefixed();
         }
     }
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
     {
         if (auto blobGasUsed = blockHeader->blobGasUsed())
         {
@@ -114,12 +124,23 @@ void bcos::rpc::combineBlockResponse(
             result["parentBeaconBlockRoot"] = beaconRoot->hexPrefixed();
         }
     }
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::PRAGUE))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::PRAGUE))
     {
         if (auto requestsHash = blockHeader->requestsHash())
         {
             result["requestsHash"] = requestsHash->hexPrefixed();
         }
+    }
+    if (!isEth)
+    {
+        // Native FISCO-BCOS blocks keep their pre-existing Ethereum-compatible mock shape.
+        result["baseFeePerGas"] = "0x0";
+        result["withdrawals"] = Json::Value(Json::arrayValue);
+        // empty withdrawals trie root hash
+        result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
+        result["blobGasUsed"] = "0x0";
+        result["excessBlobGas"] = "0x0";
+        result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
     }
 
     if (fullTxs)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -1,6 +1,7 @@
 #include "BlockResponse.h"
 #include "Log.h"
 
+#include <bcos-framework/protocol/Protocol.h>
 #include <bcos-utilities/Bloom.h>
 
 #include <range/v3/view/enumerate.hpp>
@@ -11,12 +12,48 @@ void bcos::rpc::combineBlockResponse(
     auto blockHeader = block.blockHeader();
     auto blockHash = blockHeader->hash();
     auto blockNumber = blockHeader->number();
+    auto const ethVersion = blockHeader->ethBlockVersion();
+    auto const isEth = ethVersion != bcos::protocol::EthBlockVersion::NON_ETH;
+
     result["number"] = toQuantity(blockNumber);
     result["hash"] = blockHash.hexPrefixed();
     result["parentHash"] = blockHeader->parentInfo().blockHash.hexPrefixed();
-    result["nonce"] = "0x0000000000000000";
-    // empty uncle hash: keccak256(RLP([]))
-    result["sha3Uncles"] = "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
+
+    if (isEth)
+    {
+        // Ethereum header: every field is taken verbatim from the header.
+        result["nonce"] = blockHeader->nonce().hexPrefixed();
+        result["sha3Uncles"] = blockHeader->uncleHash().hexPrefixed();
+        result["miner"] = blockHeader->coinbase().hexPrefixed();
+        result["difficulty"] = toQuantity(blockHeader->difficulty());
+        result["mixHash"] = blockHeader->prevRandao().hexPrefixed();
+    }
+    else
+    {
+        // FISCO-BCOS header: fixed Ethereum-compatible empty values, miner derived from
+        // the sealer list (FISCO headers carry no coinbase).
+        result["nonce"] = "0x0000000000000000";
+        // empty uncle hash: keccak256(RLP([]))
+        result["sha3Uncles"] =
+            "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
+        result["difficulty"] = "0x0";
+        result["mixHash"] = crypto::HashType().hexPrefixed();
+        if (blockNumber == 0)
+        {
+            result["miner"] = "0x0000000000000000000000000000000000000000";
+        }
+        else if (std::cmp_greater(blockHeader->sealerList().size(), blockHeader->sealer()))
+        {
+            auto pk = blockHeader->sealerList()[blockHeader->sealer()];
+            auto hash = crypto::keccak256Hash(bcos::ref(pk));
+            Address address = right160(hash);
+            auto addrString = address.hex();
+            auto addrHash = crypto::keccak256Hash(bytesConstRef(addrString)).hex();
+            toChecksumAddress(addrString, addrHash);
+            result["miner"] = "0x" + addrString;
+        }
+    }
+
     rpc::Logs logs;
     for (auto receipt : block.receipts())
     {
@@ -30,34 +67,62 @@ void bcos::rpc::combineBlockResponse(
             logs.push_back(std::move(logObj));
         }
     }
-    result["logsBloom"] = toPaddingHexStringWithPrefix(BloomBytesSize, block.logsBloom());
+    result["logsBloom"] = toPaddingHexStringWithPrefix(
+        BloomBytesSize, isEth ? blockHeader->logsBloom() : block.logsBloom());
     result["transactionsRoot"] = blockHeader->txsRoot().hexPrefixed();
     result["stateRoot"] = blockHeader->stateRoot().hexPrefixed();
     result["receiptsRoot"] = blockHeader->receiptsRoot().hexPrefixed();
-    if (std::cmp_greater(blockHeader->sealerList().size(), blockHeader->sealer()))
-    {
-        auto pk = blockHeader->sealerList()[blockHeader->sealer()];
-        auto hash = crypto::keccak256Hash(bcos::ref(pk));
-        Address address = right160(hash);
-        auto addrString = address.hex();
-        auto addrHash = crypto::keccak256Hash(bytesConstRef(addrString)).hex();
-        toChecksumAddress(addrString, addrHash);
-        result["miner"] = "0x" + addrString;
-    }
-    // genesis block
-    if (blockHeader->number() == 0)
-    {
-        result["miner"] = "0x0000000000000000000000000000000000000000";
-        result["parentHash"] = "0x0000000000000000000000000000000000000000000000000000000000000000";
-    }
-    result["difficulty"] = "0x0";
     result["totalDifficulty"] = "0x0";
     result["extraData"] = toHexStringWithPrefix(blockHeader->extraData());
     result["size"] = toQuantity(block.size());
-    // TODO: change it wen block gas limit apply
-    result["gasLimit"] = toQuantity(30000000ULL);
-    result["gasUsed"] = toQuantity((uint64_t)blockHeader->gasUsed());
-    result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);  // to seconds
+    result["gasLimit"] = toQuantity(blockHeader->gasLimit());
+    result["gasUsed"] = toQuantity(static_cast<uint64_t>(blockHeader->gasUsed()));
+    // Eth headers carry the timestamp in seconds already; FISCO headers in milliseconds.
+    result["timestamp"] = toQuantity(
+        isEth ? blockHeader->timestamp() : blockHeader->timestamp() / 1000);
+
+    // Fork-gated Ethereum fields: only defined for the fork that introduced them.
+    auto versionAtLeast = [&](bcos::protocol::EthBlockVersion fork) {
+        return isEth && static_cast<uint8_t>(ethVersion) >= static_cast<uint8_t>(fork);
+    };
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::LONDON))
+    {
+        result["baseFeePerGas"] = toQuantity(blockHeader->baseFee().value_or(bcos::u256(0)));
+    }
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::SHANGHAI))
+    {
+        // The withdrawals operation list is a block-body field and is not persisted in the
+        // header (only its trie root is); emit the always-empty list so Shanghai-shaped
+        // clients keep working, and the root verbatim from the header.
+        result["withdrawals"] = Json::Value(Json::arrayValue);
+        if (auto root = blockHeader->withdrawalsRoot())
+        {
+            result["withdrawalsRoot"] = root->hexPrefixed();
+        }
+    }
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
+    {
+        if (auto blobGasUsed = blockHeader->blobGasUsed())
+        {
+            result["blobGasUsed"] = toQuantity(*blobGasUsed);
+        }
+        if (auto excessBlobGas = blockHeader->excessBlobGas())
+        {
+            result["excessBlobGas"] = toQuantity(*excessBlobGas);
+        }
+        if (auto beaconRoot = blockHeader->parentBeaconBlockRoot())
+        {
+            result["parentBeaconBlockRoot"] = beaconRoot->hexPrefixed();
+        }
+    }
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::PRAGUE))
+    {
+        if (auto requestsHash = blockHeader->requestsHash())
+        {
+            result["requestsHash"] = requestsHash->hexPrefixed();
+        }
+    }
+
     if (fullTxs)
     {
         Json::Value txList = Json::arrayValue;
@@ -79,12 +144,4 @@ void bcos::rpc::combineBlockResponse(
         result["transactions"] = std::move(txHashesList);
     }
     result["uncles"] = Json::Value(Json::arrayValue);
-    result["mixHash"] = crypto::HashType().hexPrefixed();
-    result["baseFeePerGas"] = "0x0";
-    result["withdrawals"] = Json::Value(Json::arrayValue);
-    // empty withdrawals trie root hash
-    result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
-    result["blobGasUsed"] = "0x0";
-    result["excessBlobGas"] = "0x0";
-    result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
 }

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -69,8 +69,9 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
     BOOST_CHECK_EQUAL(result["uncles"].size(), 0U);
     // fullTxs=false → transactions is an array of hashes (empty here).
     BOOST_CHECK(result["transactions"].isArray());
-    BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x0");
-    BOOST_CHECK(result.isMember("withdrawalsRoot"));
+    // A FISCO (NON_ETH) header carries none of the Eth fork-gated fields.
+    BOOST_CHECK(!result.isMember("baseFeePerGas"));
+    BOOST_CHECK(!result.isMember("withdrawalsRoot"));
     BOOST_CHECK(result.isMember("logsBloom"));
 }
 
@@ -179,6 +180,76 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseFullTxsEmptyList)
     // fullTxs=true with no transactions → still an (empty) array.
     BOOST_REQUIRE(result["transactions"].isArray());
     BOOST_CHECK_EQUAL(result["transactions"].size(), 0U);
+}
+
+BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
+{
+    auto block = m_blockFactory->createBlock();
+    auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+    // An Eth CANCUN header: all fork-gated fields come from the header, the timestamp is
+    // stored in seconds and emitted as-is.
+    header->setNumber(7);
+    header->setTimestamp(1700000000);  // already seconds
+    header->setEthBlockVersion(bcos::protocol::EthBlockVersion::CANCUN);
+    header->setParentInfo(
+        bcos::protocol::ParentInfo{.blockNumber = 6,
+            .blockHash = bcos::crypto::HashType(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
+    header->setUncleHash(
+        bcos::crypto::HashType("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
+    header->setDifficulty(bcos::u256(0));
+    header->setNonce(bcos::h64(0));
+    header->setPrevRandao(
+        bcos::h256("1111111111111111111111111111111111111111111111111111111111111111"));
+    header->setGasLimit(bcos::u256(30000000));
+    header->setGasUsed(bcos::u256(21000));
+    // Required non-optional Eth fields so calculateHash can recompute the RLP hash.
+    header->setStateRoot(
+        bcos::h256("4444444444444444444444444444444444444444444444444444444444444444"));
+    header->setTxsRoot(
+        bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
+    header->setReceiptsRoot(
+        bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
+    bcos::Bloom bloom;
+    bloom[0] = 0xab;
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    header->setBaseFee(bcos::u256(1000000000));
+    header->setWithdrawalsRoot(
+        bcos::h256("2222222222222222222222222222222222222222222222222222222222222222"));
+    header->setBlobGasUsed(bcos::u256(0));
+    header->setExcessBlobGas(bcos::u256(0));
+    header->setParentBeaconBlockRoot(
+        bcos::h256("3333333333333333333333333333333333333333333333333333333333333333"));
+    header->calculateHash(*hashImpl);
+    block->setBlockHeader(header);
+
+    Json::Value result(Json::objectValue);
+    combineBlockResponse(result, *block, /*fullTxs=*/false);
+
+    // Header-derived Eth fields, not mock constants.
+    BOOST_CHECK_EQUAL(result["miner"].asString(),
+        "0x1234567890abcdef1234567890abcdef12345678");
+    BOOST_CHECK_EQUAL(result["sha3Uncles"].asString(),
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0000000000000000");
+    BOOST_CHECK_EQUAL(result["mixHash"].asString(),
+        "0x1111111111111111111111111111111111111111111111111111111111111111");
+    // Eth timestamp is already in seconds: emitted without /1000.
+    BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x6553f100");
+    // gasLimit/gasUsed come from the header.
+    BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000
+    BOOST_CHECK_EQUAL(result["gasUsed"].asString(), "0x5208");      // 21000
+    // CANCUN fork-gated fields: present.
+    BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x3b9aca00");  // 1000000000
+    BOOST_CHECK_EQUAL(result["withdrawalsRoot"].asString(),
+        "0x2222222222222222222222222222222222222222222222222222222222222222");
+    BOOST_CHECK(result.isMember("blobGasUsed"));
+    BOOST_CHECK(result.isMember("excessBlobGas"));
+    BOOST_CHECK_EQUAL(result["parentBeaconBlockRoot"].asString(),
+        "0x3333333333333333333333333333333333333333333333333333333333333333");
+    // PRAGUE-only field: not defined for a CANCUN header.
+    BOOST_CHECK(!result.isMember("requestsHash"));
 }
 
 BOOST_AUTO_TEST_CASE(combineTxResponseShapesTransaction)

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -250,6 +250,8 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     // gasLimit/gasUsed come from the header.
     BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000
     BOOST_CHECK_EQUAL(result["gasUsed"].asString(), "0x5208");      // 21000
+    // Eth blocks take logsBloom from the header (bloom[0] = 0xab), not from the block body.
+    BOOST_CHECK(result["logsBloom"].asString().starts_with("0xab"));
     // CANCUN fork-gated fields: present.
     BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x3b9aca00");  // 1000000000
     BOOST_CHECK_EQUAL(result["withdrawalsRoot"].asString(),
@@ -260,6 +262,14 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
         "0x3333333333333333333333333333333333333333333333333333333333333333");
     // PRAGUE-only field: not defined for a CANCUN header.
     BOOST_CHECK(!result.isMember("requestsHash"));
+
+    // Independent EIP-55 oracle: the checksum above recomputes via the same
+    // toChecksumAddress as the implementation, so pin one official EIP-55 spec vector
+    // (the spec's first example) to catch a wrong checksum algorithm.
+    std::string specAddr = "5aaeb6053f3e94c9b9a09f33669435e7ef1beaed";
+    auto specHash = bcos::crypto::keccak256Hash(bcos::bytesConstRef(specAddr)).hex();
+    toChecksumAddress(specAddr, specHash);
+    BOOST_CHECK_EQUAL(specAddr, "5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
 }
 
 BOOST_AUTO_TEST_CASE(combineTxResponseShapesTransaction)

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
@@ -69,9 +70,15 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
     BOOST_CHECK_EQUAL(result["uncles"].size(), 0U);
     // fullTxs=false → transactions is an array of hashes (empty here).
     BOOST_CHECK(result["transactions"].isArray());
-    // A FISCO (NON_ETH) header carries none of the Eth fork-gated fields.
-    BOOST_CHECK(!result.isMember("baseFeePerGas"));
-    BOOST_CHECK(!result.isMember("withdrawalsRoot"));
+    // Native FISCO (NON_ETH) blocks keep the historical Ethereum-compatible mock shape:
+    // baseFeePerGas / withdrawals / blob fields are present with fixed values, and gasLimit
+    // falls back to the fixed 30000000 (native headers never set it).
+    BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000
+    BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x0");
+    BOOST_CHECK(result.isMember("withdrawalsRoot"));
+    BOOST_CHECK(result.isMember("blobGasUsed"));
+    BOOST_CHECK(result.isMember("excessBlobGas"));
+    BOOST_CHECK(result.isMember("parentBeaconBlockRoot"));
     BOOST_CHECK(result.isMember("logsBloom"));
 }
 
@@ -227,9 +234,12 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     Json::Value result(Json::objectValue);
     combineBlockResponse(result, *block, /*fullTxs=*/false);
 
-    // Header-derived Eth fields, not mock constants.
-    BOOST_CHECK_EQUAL(result["miner"].asString(),
-        "0x1234567890abcdef1234567890abcdef12345678");
+    // Header-derived Eth fields, not mock constants. miner is the EIP-55 checksummed coinbase.
+    auto minerAddr = bcos::Address("1234567890abcdef1234567890abcdef12345678").hex();
+    auto minerAddrHash = bcos::crypto::keccak256Hash(bcos::bytesConstRef(minerAddr)).hex();
+    toChecksumAddress(minerAddr, minerAddrHash);
+    BOOST_CHECK_EQUAL(result["miner"].asString(), "0x" + minerAddr);
+    BOOST_CHECK_NE(result["miner"].asString(), "0x1234567890abcdef1234567890abcdef12345678");
     BOOST_CHECK_EQUAL(result["sha3Uncles"].asString(),
         "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
     BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0000000000000000");

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -187,9 +187,9 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     auto block = m_blockFactory->createBlock();
     auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
     // An Eth CANCUN header: all fork-gated fields come from the header, the timestamp is
-    // stored in seconds and emitted as-is.
+    // stored in BlockHeader milliseconds and emitted as seconds (/1000).
     header->setNumber(7);
-    header->setTimestamp(1700000000);  // already seconds
+    header->setTimestamp(1700000000 * 1000LL);  // BlockHeader milliseconds == 1700000000 s
     header->setEthBlockVersion(bcos::protocol::EthBlockVersion::CANCUN);
     header->setParentInfo(
         bcos::protocol::ParentInfo{.blockNumber = 6,
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0000000000000000");
     BOOST_CHECK_EQUAL(result["mixHash"].asString(),
         "0x1111111111111111111111111111111111111111111111111111111111111111");
-    // Eth timestamp is already in seconds: emitted without /1000.
+    // Eth timestamp: header milliseconds /1000 = seconds.
     BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x6553f100");
     // gasLimit/gasUsed come from the header.
     BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(engine ${SRC_LIST})
 target_include_directories(engine PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-engine>)
-target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger rlp-protocol)
+target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger PRIVATE rlp-protocol)
 set_target_properties(engine PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(engine ${SRC_LIST})
 target_include_directories(engine PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-engine>)
-target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger)
+target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger rlp-protocol)
 set_target_properties(engine PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -19,7 +19,6 @@
 #include "EngineServiceImpl.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
-#include <bcos-ledger/mpt/Constants.h>
 #include <bcos-rlp-protocol/EthBlockHeader.h>
 
 namespace
@@ -237,8 +236,15 @@ bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(std::ui
         return bcos::protocol::EthBlockVersion::SHANGHAI;
     case static_cast<std::uint32_t>(ApiVersion::V3):
         return bcos::protocol::EthBlockVersion::CANCUN;
+    case static_cast<std::uint32_t>(ApiVersion::V4):
+        return bcos::protocol::EthBlockVersion::PRAGUE;
     default:
-        return bcos::protocol::EthBlockVersion::PRAGUE;  // V4+
+        // A version beyond the known fork window must fail loudly here rather than being
+        // silently mapped to PRAGUE: the fork marker decides the RLP hash, so a wrong mapping
+        // would corrupt every block built under the unknown version.
+        BOOST_THROW_EXCEPTION(
+            UnsupportedEngineApiVersion{} << bcos::errinfo_comment{
+                "EngineService: unsupported Engine API version " + std::to_string(version)});
     }
 }
 
@@ -275,6 +281,15 @@ void bcos::engine::detail::finalizeEthBlockHeader(bcos::protocol::BlockHeader& h
         header.setBlobGasUsed(payload.blobGasUsed.value_or(bcos::u256(0)));
         header.setExcessBlobGas(payload.excessBlobGas.value_or(bcos::u256(0)));
         header.setParentBeaconBlockRoot(parentBeaconBlockRoot.value_or(bcos::h256{}));
+    }
+
+    // PRAGUE (V4): EIP-7685 execution-requests hash. FISCO-BCOS produces no execution
+    // requests, so the canonical empty-requests hash (sha256 of the empty input,
+    // 0xe3b0c442…) is used — the value the RLP hash must carry to validate as PRAGUE.
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V4))
+    {
+        header.setRequestsHash(bcos::crypto::HashType(
+            "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
     }
 
     // Mark the header as an Eth header, then compute and inject its RLP hash.

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -19,6 +19,8 @@
 #include "EngineServiceImpl.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 
 namespace
 {
@@ -223,4 +225,63 @@ std::optional<std::string> bcos::engine::detail::validateExecutionPayload(
         return std::string("withdrawalsRoot is required for ExecutionPayloadV4 and later");
     }
     return std::nullopt;
+}
+
+bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(std::uint32_t version)
+{
+    switch (version)
+    {
+    case static_cast<std::uint32_t>(ApiVersion::V1):
+        return bcos::protocol::EthBlockVersion::LONDON;
+    case static_cast<std::uint32_t>(ApiVersion::V2):
+        return bcos::protocol::EthBlockVersion::SHANGHAI;
+    case static_cast<std::uint32_t>(ApiVersion::V3):
+        return bcos::protocol::EthBlockVersion::CANCUN;
+    default:
+        return bcos::protocol::EthBlockVersion::PRAGUE;  // V4+
+    }
+}
+
+void bcos::engine::detail::finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
+    const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
+    std::uint32_t version)
+{
+    // Post-merge constants: the empty-ommers hash (keccak256(rlp([]))), difficulty 0 and nonce 0
+    // are fixed on every PoS Ethereum block.
+    static const auto kEmptyOmmersHash = bcos::crypto::HashType(
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    header.setUncleHash(kEmptyOmmersHash);
+    header.setDifficulty(bcos::u256(0));
+    header.setNonce(bcos::h64(0));
+
+    // The header itself must carry the 256-byte bloom: calculateRLPHash reads it from the header
+    // (handleNewPayload sets it on the block wrapper separately).
+    header.setLogsBloom(bcos::bytesConstRef(payload.logsBloom.data(), payload.logsBloom.size()));
+
+    // EIP-1559 base fee (LONDON+). FISCO-BCOS does not compute a real base fee yet, so this is
+    // whatever buildPayload placed in the payload (currently 0).
+    header.setBaseFee(payload.baseFeePerGas);
+
+    // SHANGHAI+ (V2): withdrawalsRoot. The withdrawals trie root is not computed yet, so the
+    // empty-trie root is used as a placeholder.
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V2))
+    {
+        header.setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
+    }
+
+    // CANCUN+ (V3): blob gas fields and parent beacon block root.
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V3))
+    {
+        header.setBlobGasUsed(payload.blobGasUsed.value_or(bcos::u256(0)));
+        header.setExcessBlobGas(payload.excessBlobGas.value_or(bcos::u256(0)));
+        header.setParentBeaconBlockRoot(parentBeaconBlockRoot.value_or(bcos::h256{}));
+    }
+
+    // Mark the header as an Eth header, then compute and inject its RLP hash.
+    header.setEthBlockVersion(ethBlockVersionFor(version));
+    if (auto error = bcos::protocol::EthBlockHeader::calculateRLPHash(header))
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error{
+            "EngineService: failed to compute Eth RLP hash: " + error->errorMessage()});
+    }
 }

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -31,6 +31,7 @@
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-ledger/LedgerMethods.h"
+#include <bcos-ledger/mpt/Constants.h>
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
@@ -78,6 +79,18 @@ std::optional<std::string> validatePayloadAttributes(
 
 std::optional<std::string> validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version);
+
+// Map an Engine API version to the Ethereum fork era of the blocks it produces.
+bcos::protocol::EthBlockVersion ethBlockVersionFor(std::uint32_t version);
+
+// Fill the Ethereum header fields on a locally built header, mark it as an Eth header
+// (setEthBlockVersion), and compute + inject its RLP hash. Throws on validation/hash failure.
+void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
+    const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
+    std::uint32_t version);
+
+// The internal timestamp carrier is milliseconds (Types.h); the Eth header stores seconds.
+inline constexpr std::uint64_t c_millisPerSecond = 1000;
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -762,11 +775,12 @@ private:
         co_await ledger::getLedgerConfig(view, ledgerConfig, nextBlockNumber - 1, *m_blockFactory);
         auto blockVersion = ledgerConfig.compatibilityVersion();
 
-        // Fill gasLimit from ledger config (FISCO-BCOS does not use EIP-1559 baseFeePerGas,
-        // and logsBloom is not part of BlockHeader hash computation in FISCO-BCOS).
+        // Fill gasLimit from ledger config. baseFeePerGas is carried in the payload (currently
+        // 0 — FISCO-BCOS does not compute a real EIP-1559 base fee yet) and copied onto the Eth
+        // header by finalizeEthBlockHeader.
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
 
-        // Real EVM execution: execute transactions and compute real hashes.
+        // Execute transactions (if any) and finalize the Eth header with its RLP hash.
         if (executionPayload.transactions.empty())
         {
             auto emptyHeader = m_blockFactory->blockHeaderFactory()->createBlockHeader();
@@ -775,17 +789,24 @@ private:
             emptyHeader->setParentInfo(parentInfo);
             emptyHeader->setNumber(nextBlockNumber);
             emptyHeader->setVersion(blockVersion);
-            emptyHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
+            // Eth headers carry the timestamp in SECONDS (Types.h keeps the internal carrier in
+            // milliseconds); convert once here since an empty block never passes through the
+            // executor's millisecond-consuming path.
+            emptyHeader->setTimestamp(static_cast<int64_t>(
+                payloadAttributes.timestamp / detail::c_millisPerSecond));
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
             emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
             emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
-            emptyHeader->setReceiptsRoot(h256{});
-            emptyHeader->setTxsRoot(h256{});
+            // An empty block's transaction/receipt tries are the canonical empty-trie root, not
+            // the all-zero hash (validateHeader rejects a zero receiptsRoot/txsRoot).
+            emptyHeader->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
+            emptyHeader->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
             emptyHeader->setGasUsed(0);
-            emptyHeader->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
+            detail::finalizeEthBlockHeader(
+                *emptyHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, version);
             executionPayload.stateRoot = emptyHeader->stateRoot();
-            executionPayload.receiptsRoot = h256{};
+            executionPayload.receiptsRoot = bcos::ledger::mpt::emptyRootHash();
             executionPayload.gasUsed = 0;
             executionPayload.blockHash = emptyHeader->hash();
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
@@ -823,8 +844,9 @@ private:
         // Step 2d: Compute transaction root (Merkle over tx hashes)
         // TODO: Use scheduler_v1::calculateTransactionRoot from BaselineScheduler.h
         // once MPTStorage is available. The current tx->hash() call lacks exception
-        // handling for malformed transactions.
-        h256 txRoot;
+        // handling for malformed transactions. An empty transaction list maps to the
+        // canonical empty-trie root (validateHeader rejects an all-zero txsRoot).
+        h256 txRoot = bcos::ledger::mpt::emptyRootHash();
         {
             auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
             auto hasher = hashImpl.hasher();
@@ -849,8 +871,10 @@ private:
             }
         }
 
-        // Step 2e: Compute receipt root (Merkle over receipt hashes)
-        h256 receiptRoot;
+        // Step 2e: Compute receipt root (Merkle over receipt hashes). An empty receipt list
+        // maps to the canonical empty-trie root (validateHeader rejects an all-zero
+        // receiptsRoot).
+        h256 receiptRoot = bcos::ledger::mpt::emptyRootHash();
         {
             // Validate receipts are non-null before computing hashes
             if (::ranges::any_of(receipts, [](auto& r) { return !r; }))
@@ -896,12 +920,21 @@ private:
         // Step 2g: Compute state root (MPT over state storage)
         h256 stateRoot = co_await calculateStateRoot(view, blockHeader->version());
 
-        // Step 2h: Set computed values in the block header and calculate block hash
+        // Step 2h: Set computed values in the block header and calculate the block hash.
+        // The executor consumed the header timestamp in milliseconds; the Eth header stores it in
+        // seconds, so switch units after execution and before the RLP hash is computed.
         blockHeader->setStateRoot(stateRoot);
         blockHeader->setReceiptsRoot(receiptRoot);
         blockHeader->setTxsRoot(txRoot);
         blockHeader->setGasUsed(totalGasUsed);
-        blockHeader->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
+        blockHeader->setTimestamp(static_cast<int64_t>(
+            payloadAttributes.timestamp / detail::c_millisPerSecond));
+
+        // Copy the block bloom onto the payload before finalizeEthBlockHeader, which reads it
+        // onto the header (the header's logsBloom is part of the RLP hash).
+        executionPayload.logsBloom = logsBloom;
+        detail::finalizeEthBlockHeader(
+            *blockHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, version);
 
         // Step 2i: Fill the execution payload with real values
         executionPayload.stateRoot = stateRoot;
@@ -909,7 +942,6 @@ private:
         executionPayload.gasUsed = totalGasUsed;
         executionPayload.blockHash = blockHeader->hash();
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
-        executionPayload.logsBloom = logsBloom;
 
         co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
             .header = std::move(blockHeader),

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -793,7 +793,7 @@ private:
             // milliseconds); convert once here since an empty block never passes through the
             // executor's millisecond-consuming path.
             emptyHeader->setTimestamp(static_cast<int64_t>(
-                payloadAttributes.timestamp / detail::c_millisPerSecond));
+                payloadAttributes.timestamp * detail::c_millisPerSecond));
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
             emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -821,7 +821,8 @@ private:
         blockHeader->setParentInfo(parentInfo);
         blockHeader->setNumber(nextBlockNumber);
         blockHeader->setVersion(blockVersion);
-        blockHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
+        blockHeader->setTimestamp(static_cast<int64_t>(
+            payloadAttributes.timestamp * detail::c_millisPerSecond));
         blockHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -927,8 +928,6 @@ private:
         blockHeader->setReceiptsRoot(receiptRoot);
         blockHeader->setTxsRoot(txRoot);
         blockHeader->setGasUsed(totalGasUsed);
-        blockHeader->setTimestamp(static_cast<int64_t>(
-            payloadAttributes.timestamp / detail::c_millisPerSecond));
 
         // Copy the block bloom onto the payload before finalizeEthBlockHeader, which reads it
         // onto the header (the header's logsBloom is part of the RLP hash).

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -88,9 +88,6 @@ bcos::protocol::EthBlockVersion ethBlockVersionFor(std::uint32_t version);
 void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
     const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
     std::uint32_t version);
-
-// The internal timestamp carrier is milliseconds (Types.h); the Eth header stores seconds.
-inline constexpr std::uint64_t c_millisPerSecond = 1000;
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -789,11 +786,10 @@ private:
             emptyHeader->setParentInfo(parentInfo);
             emptyHeader->setNumber(nextBlockNumber);
             emptyHeader->setVersion(blockVersion);
-            // Eth headers carry the timestamp in SECONDS (Types.h keeps the internal carrier in
-            // milliseconds); convert once here since an empty block never passes through the
-            // executor's millisecond-consuming path.
-            emptyHeader->setTimestamp(static_cast<int64_t>(
-                payloadAttributes.timestamp * detail::c_millisPerSecond));
+            // BlockHeader stores the timestamp in milliseconds (matching the internal carrier
+            // and the executor's ms-consuming path); EthBlockHeader converts to seconds at the
+            // RLP boundary.
+            emptyHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
             emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -821,8 +817,9 @@ private:
         blockHeader->setParentInfo(parentInfo);
         blockHeader->setNumber(nextBlockNumber);
         blockHeader->setVersion(blockVersion);
-        blockHeader->setTimestamp(static_cast<int64_t>(
-            payloadAttributes.timestamp * detail::c_millisPerSecond));
+        // BlockHeader stores milliseconds; EthBlockHeader converts to seconds at the RLP
+        // boundary (the executor consumes this header in milliseconds).
+        blockHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
         blockHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -922,8 +919,8 @@ private:
         h256 stateRoot = co_await calculateStateRoot(view, blockHeader->version());
 
         // Step 2h: Set computed values in the block header and calculate the block hash.
-        // The executor consumed the header timestamp in milliseconds; the Eth header stores it in
-        // seconds, so switch units after execution and before the RLP hash is computed.
+        // The header timestamp stays in milliseconds throughout (the executor consumed it in
+        // milliseconds above); EthBlockHeader converts to seconds at the RLP boundary.
         blockHeader->setStateRoot(stateRoot);
         blockHeader->setReceiptsRoot(receiptRoot);
         blockHeader->setTxsRoot(txRoot);

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${TEST_BINARY_NAME} PRIVATE . ${CMAKE_SOURCE_DIR})
 
 find_package(Boost REQUIRED unit_test_framework)
 
-target_link_libraries(${TEST_BINARY_NAME} PUBLIC engine mempool protocol-tars Boost::unit_test_framework)
+target_link_libraries(${TEST_BINARY_NAME} PUBLIC engine mempool protocol-tars rlp-protocol Boost::unit_test_framework)
 set_source_files_properties("unittests/main/main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" ${TEST_BINARY_NAME} "" "")

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -5,6 +5,7 @@
 
 #include "engine/bcos-engine/EngineServiceImpl.h"
 
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-concepts/ByteBuffer.h>
@@ -30,7 +31,10 @@ using namespace bcos::engine;
 
 namespace
 {
-constexpr std::uint64_t c_timestamp = 123456;
+// Whole-second milliseconds (1700000000s): every Eth header produced by finalizeEthBlockHeader
+// must satisfy validateHeader's "timestamp is a whole number of seconds" check, so a fixture
+// timestamp with sub-second milliseconds would make every build path throw.
+constexpr std::uint64_t c_timestamp = 1700000000ULL * 1000ULL;
 constexpr bcos::protocol::BlockNumber c_initialBlockNumber = 5;
 constexpr bcos::protocol::BlockNumber c_trackedInitialBlockNumber = 10;
 constexpr bcos::protocol::BlockNumber c_trackedNextBlockNumber = 11;
@@ -1250,7 +1254,8 @@ static bcos::protocol::BlockHeader::Ptr makeValidCancunHeader(
     header->setParentInfo(bcos::protocol::ParentInfo{
         .blockNumber = 9, .blockHash = parentHash});
     header->setNumber(10);
-    header->setTimestamp(1700000000);
+    // Internal BlockHeader timestamps are milliseconds: the whole-second value × 1000.
+    header->setTimestamp(1700000000 * 1000LL);
     header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
     header->setPrevRandao(
         bcos::h256("1111111111111111111111111111111111111111111111111111111111111111"));
@@ -1413,6 +1418,47 @@ BOOST_AUTO_TEST_CASE(buildPayloadEmptyBlockInjectsRlpHash)
     auto const& blockHash = payload->executionPayload.blockHash;
     BOOST_CHECK_NE(blockHash, bcos::engine::detail::syntheticHash(*result.payloadId));
     BOOST_CHECK_NE(blockHash, bcos::crypto::HashType{});
+
+    // Strong anchor: recompute keccak256(rlp(header)) from the payload fields via the
+    // EthBlockHeader bridge and compare against the block hash. The old anchor (≠ synthetic
+    // hash, ≠ zero) stayed green even when finalizeEthBlockHeader hashed a wrong timestamp,
+    // so it could not catch the merge-broken unit conversion.
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    auto const& executionPayload = payload->executionPayload;
+    header->setParentInfo(bcos::protocol::ParentInfo{
+        .blockNumber = static_cast<int64_t>(executionPayload.blockNumber) - 1,
+        .blockHash = executionPayload.parentHash});
+    header->setNumber(static_cast<int64_t>(executionPayload.blockNumber));
+    // Internal BlockHeader milliseconds; the bridge converts to seconds at encode.
+    header->setTimestamp(static_cast<int64_t>(executionPayload.timestamp));
+    header->setCoinbase(executionPayload.feeRecipient);
+    header->setUncleHash(bcos::crypto::HashType(
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setPrevRandao(executionPayload.prevRandao);
+    header->setNonce(bcos::h64(0));
+    header->setDifficulty(bcos::u256(0));
+    header->setGasLimit(executionPayload.gasLimit);
+    header->setGasUsed(executionPayload.gasUsed);
+    header->setStateRoot(executionPayload.stateRoot);
+    header->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
+    header->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
+    header->setLogsBloom(bcos::bytesConstRef(
+        executionPayload.logsBloom.data(), executionPayload.logsBloom.size()));
+    header->setBaseFee(executionPayload.baseFeePerGas);
+    header->setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
+    header->setBlobGasUsed(executionPayload.blobGasUsed.value_or(bcos::u256(0)));
+    header->setExcessBlobGas(executionPayload.excessBlobGas.value_or(bcos::u256(0)));
+    header->setParentBeaconBlockRoot(
+        payloadAttributes.parentBeaconBlockRoot.value_or(bcos::h256{}));
+    header->setEthBlockVersion(bcos::protocol::EthBlockVersion::CANCUN);
+
+    bcos::protocol::EthBlockHeader ethHeader(*header);
+    bcos::bytes rlp;
+    ethHeader.rlpEncode(rlp);
+    BOOST_CHECK_EQUAL(
+        blockHash.hex(), bcos::crypto::keccak256Hash(bcos::ref(rlp)).hex());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -1241,4 +1241,159 @@ BOOST_AUTO_TEST_CASE(per_method_version_windows_and_unknown_payload)
         task::syncWait(engineService.getPayload("0x01", 6)), UnsupportedEngineApiVersion);
 }
 
+/// Build a BlockHeader carrying every field EthBlockHeader::validateHeader requires for a
+/// CANCUN header, so finalizeEthBlockHeader's calculateRLPHash succeeds.
+static bcos::protocol::BlockHeader::Ptr makeValidCuncunHeader(
+    bcos::protocol::BlockFactory::Ptr blockFactory, bcos::crypto::HashType parentHash)
+{
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setParentInfo(bcos::protocol::ParentInfo{
+        .blockNumber = 9, .blockHash = parentHash});
+    header->setNumber(10);
+    header->setTimestamp(1700000000);
+    header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
+    header->setPrevRandao(
+        bcos::h256("1111111111111111111111111111111111111111111111111111111111111111"));
+    header->setGasLimit(bcos::u256(30000000));
+    header->setGasUsed(bcos::u256(21000));
+    header->setStateRoot(
+        bcos::h256("4444444444444444444444444444444444444444444444444444444444444444"));
+    header->setTxsRoot(
+        bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
+    header->setReceiptsRoot(
+        bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
+    bcos::Bloom bloom;
+    bloom[0] = 0xab;
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    return header;
+}
+
+BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEngineVersions)
+{
+    using bcos::protocol::EthBlockVersion;
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(1)),
+        static_cast<int>(EthBlockVersion::LONDON));
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(2)),
+        static_cast<int>(EthBlockVersion::SHANGHAI));
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(3)),
+        static_cast<int>(EthBlockVersion::CANCUN));
+    // V4+ falls back to the newest known fork.
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(4)),
+        static_cast<int>(EthBlockVersion::PRAGUE));
+}
+
+BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
+{
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto parentHash = bcos::crypto::HashType(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    auto header = makeValidCuncunHeader(blockFactory, parentHash);
+
+    bcos::engine::ExecutionPayload payload;
+    payload.logsBloom = bcos::Bloom{};
+    payload.baseFeePerGas = bcos::u256(1000);
+    payload.blobGasUsed = bcos::u256(0);
+    payload.excessBlobGas = bcos::u256(0);
+
+    auto beaconRoot = bcos::h256(
+        "3333333333333333333333333333333333333333333333333333333333333333");
+    bcos::engine::detail::finalizeEthBlockHeader(*header, payload, beaconRoot, 3);
+
+    // The header is marked as an Eth CANCUN header.
+    BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::CANCUN);
+    // Post-merge constants.
+    BOOST_CHECK_EQUAL(header->uncleHash().hexPrefixed(),
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    BOOST_CHECK_EQUAL(header->difficulty(), bcos::u256(0));
+    BOOST_CHECK_EQUAL(header->nonce(), bcos::h64(0));
+    // Base fee taken from the payload.
+    BOOST_REQUIRE(header->baseFee().has_value());
+    BOOST_CHECK_EQUAL(*header->baseFee(), bcos::u256(1000));
+    // SHANGHAI+ withdrawals root is the empty-trie root placeholder.
+    BOOST_REQUIRE(header->withdrawalsRoot().has_value());
+    BOOST_CHECK_EQUAL(*header->withdrawalsRoot(), bcos::ledger::mpt::emptyRootHash());
+    // CANCUN blob fields + beacon root.
+    BOOST_REQUIRE(header->blobGasUsed().has_value());
+    BOOST_REQUIRE(header->excessBlobGas().has_value());
+    BOOST_REQUIRE(header->parentBeaconBlockRoot().has_value());
+    BOOST_CHECK_EQUAL(*header->parentBeaconBlockRoot(), beaconRoot);
+    // The RLP hash was computed and injected (not a synthetic / zero hash).
+    BOOST_CHECK_NE(header->hash(), bcos::crypto::HashType{});
+}
+
+BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
+{
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto parentHash = bcos::crypto::HashType(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    bcos::engine::ExecutionPayload payload;
+    payload.logsBloom = bcos::Bloom{};
+    payload.baseFeePerGas = bcos::u256(1000);
+
+    // V1/LONDON: baseFee present, no withdrawalsRoot / blob fields / beacon root.
+    {
+        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 1);
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::LONDON);
+        BOOST_REQUIRE(header->baseFee().has_value());
+        BOOST_CHECK(!header->withdrawalsRoot().has_value());
+        BOOST_CHECK(!header->blobGasUsed().has_value());
+        BOOST_CHECK(!header->excessBlobGas().has_value());
+        BOOST_CHECK(!header->parentBeaconBlockRoot().has_value());
+    }
+
+    // V2/SHANGHAI: + withdrawalsRoot, no blob fields / beacon root.
+    {
+        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 2);
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::SHANGHAI);
+        BOOST_REQUIRE(header->withdrawalsRoot().has_value());
+        BOOST_CHECK(!header->blobGasUsed().has_value());
+        BOOST_CHECK(!header->excessBlobGas().has_value());
+        BOOST_CHECK(!header->parentBeaconBlockRoot().has_value());
+    }
+
+    // V3/CANCUN: everything present.
+    {
+        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto beaconRoot = bcos::h256(
+            "3333333333333333333333333333333333333333333333333333333333333333");
+        payload.blobGasUsed = bcos::u256(0);
+        payload.excessBlobGas = bcos::u256(0);
+        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, beaconRoot, 3);
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::CANCUN);
+        BOOST_REQUIRE(header->withdrawalsRoot().has_value());
+        BOOST_REQUIRE(header->blobGasUsed().has_value());
+        BOOST_REQUIRE(header->excessBlobGas().has_value());
+        BOOST_REQUIRE(header->parentBeaconBlockRoot().has_value());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(buildPayloadEmptyBlockInjectsRlpHash)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    // Empty block: no transactions, no mempool seeding.
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(payload);
+    // The block hash must be the injected RLP hash — deterministic and not the synthetic
+    // placeholder (which would have been derived from just the payloadId).
+    auto const& blockHash = payload->executionPayload.blockHash;
+    BOOST_CHECK_NE(blockHash, bcos::engine::detail::syntheticHash(*result.payloadId));
+    BOOST_CHECK_NE(blockHash, bcos::crypto::HashType{});
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -1243,7 +1243,7 @@ BOOST_AUTO_TEST_CASE(per_method_version_windows_and_unknown_payload)
 
 /// Build a BlockHeader carrying every field EthBlockHeader::validateHeader requires for a
 /// CANCUN header, so finalizeEthBlockHeader's calculateRLPHash succeeds.
-static bcos::protocol::BlockHeader::Ptr makeValidCuncunHeader(
+static bcos::protocol::BlockHeader::Ptr makeValidCancunHeader(
     bcos::protocol::BlockFactory::Ptr blockFactory, bcos::crypto::HashType parentHash)
 {
     auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
@@ -1277,9 +1277,11 @@ BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEngineVersions)
         static_cast<int>(EthBlockVersion::SHANGHAI));
     BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(3)),
         static_cast<int>(EthBlockVersion::CANCUN));
-    // V4+ falls back to the newest known fork.
+    // V4 explicitly maps to the newest known fork.
     BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(4)),
         static_cast<int>(EthBlockVersion::PRAGUE));
+    // Versions beyond the known fork window fail loudly instead of silently mapping to PRAGUE.
+    BOOST_CHECK_THROW(bcos::engine::detail::ethBlockVersionFor(5), UnsupportedEngineApiVersion);
 }
 
 BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
@@ -1288,7 +1290,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
         bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
     auto parentHash = bcos::crypto::HashType(
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-    auto header = makeValidCuncunHeader(blockFactory, parentHash);
+    auto header = makeValidCancunHeader(blockFactory, parentHash);
 
     bcos::engine::ExecutionPayload payload;
     payload.logsBloom = bcos::Bloom{};
@@ -1335,7 +1337,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
 
     // V1/LONDON: baseFee present, no withdrawalsRoot / blob fields / beacon root.
     {
-        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
         bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 1);
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::LONDON);
         BOOST_REQUIRE(header->baseFee().has_value());
@@ -1347,7 +1349,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
 
     // V2/SHANGHAI: + withdrawalsRoot, no blob fields / beacon root.
     {
-        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
         bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 2);
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::SHANGHAI);
         BOOST_REQUIRE(header->withdrawalsRoot().has_value());
@@ -1358,7 +1360,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
 
     // V3/CANCUN: everything present.
     {
-        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
         auto beaconRoot = bcos::h256(
             "3333333333333333333333333333333333333333333333333333333333333333");
         payload.blobGasUsed = bcos::u256(0);
@@ -1369,6 +1371,23 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
         BOOST_REQUIRE(header->blobGasUsed().has_value());
         BOOST_REQUIRE(header->excessBlobGas().has_value());
         BOOST_REQUIRE(header->parentBeaconBlockRoot().has_value());
+    }
+
+    // V4/PRAGUE: everything plus the EIP-7685 empty requests hash — finalize must not throw
+    // (regression: PRAGUE previously produced a header that failed validateHeader).
+    {
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
+        auto beaconRoot = bcos::h256(
+            "3333333333333333333333333333333333333333333333333333333333333333");
+        payload.blobGasUsed = bcos::u256(0);
+        payload.excessBlobGas = bcos::u256(0);
+        BOOST_CHECK_NO_THROW(bcos::engine::detail::finalizeEthBlockHeader(
+            *header, payload, beaconRoot, 4));
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::PRAGUE);
+        BOOST_REQUIRE(header->requestsHash().has_value());
+        BOOST_CHECK_EQUAL(header->requestsHash()->hex(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        BOOST_CHECK_NE(header->hash(), bcos::crypto::HashType{});
     }
 }
 


### PR DESCRIPTION
## pr概述

在 FISCO-BCOS 上承载 OP Stack L2（以太坊兼容层）的进程中，通过 Engine API 产出的区块此前只有 FISCO-BCOS 原生区块头，缺少以太坊标准字段；`eth_*` RPC 返回的区块响应中，`nonce`、`sha3Uncles`、`difficulty`、`baseFeePerGas`、`withdrawalsRoot`、`blobGasUsed` 等字段均为 mock 固定值，无法与 op-node/geth 对齐。

本 PR 是前序基建（`EthBlockHeader` RLP 桥、Tars schema eth 字段、`calculateHash` 的 eth 分派、eth genesis artifact，见 #5409 等）的最后一公里：把 Engine 产块写路径与 `eth_*` 读路径接入这套基建。

## 改动内容

### 1. EngineService：为 Engine API 产出的区块标记 Eth 头并计算 RLP 哈希

- 在 `buildPayload` 新增 `finalizeEthBlockHeader`：将本地构建的区块头填充为以太坊标准头——
  - post-merge 固定值：`uncleHash`（空 ommer 常量 `0x1dcc4de8…`）、`difficulty=0`、`nonce=0`；
  - 从 payload 透传：`baseFee`、`blobGasUsed`、`excessBlobGas`、`parentBeaconBlockRoot`、`logsBloom`；
  - 分叉占位：`withdrawalsRoot`（空 trie root，真实计算留待后续）。
- 按 Engine API 版本映射 `EthBlockVersion`（V1→LONDON、V2→SHANGHAI、V3→CANCUN、V4→PRAGUE；**V4 起设置 EIP-7685 空 requests hash**，超出已知版本窗口显式抛 `UnsupportedEngineApiVersion` 而非静默映射），调用 `EthBlockHeader::calculateRLPHash` 计算 RLP 哈希并注入 header 的 `dataHash`，随区块持久化到存储，使 `eth_getBlockByHash/ByNumber` 能取到与以太坊语义一致的区块哈希。
- 修正区块根字段语义：空区块的 `txsRoot`/`receiptsRoot` 从全零改为空 trie root（`mpt::emptyRootHash()`），满足 Eth header 校验。
- **timestamp 单位统一**：BlockHeader 一律存毫秒；`EthBlockHeader` 在 RLP 边界换算（header→Eth 构造 `/1000`，RLP→header `toTarsHeader`/`decodeTarsHeader` `×1000`）；RPC 输出一律 `/1000` 得秒。
- `engine` 目标链接 `rlp-protocol`，并补充单元测试（版本映射、字段填充、分叉门控、空区块 RLP 哈希注入、V5 版本拒绝、V4/PRAGUE finalize）。

### 2. RPC：`combineBlockResponse` 从区块头直接取值，按 `EthBlockVersion` 分叉输出字段

- 移除 Eth 头的 mock 固定值，`nonce`、`sha3Uncles`、`miner`（EIP-55 checksum 地址）、`difficulty`、`mixHash`、`gasLimit`、`gasUsed`、`logsBloom` 等全部直接读取 header。
- 分叉字段按版本门控输出：`baseFeePerGas`（LONDON+）、`withdrawals`/`withdrawalsRoot`（SHANGHAI+）、`blobGasUsed`/`excessBlobGas`/`parentBeaconBlockRoot`（CANCUN+）、`requestsHash`（PRAGUE+）——**版本未引入的字段直接不定义**。
- **NON_ETH 原生头保留原有行为**：`gasLimit` 仍为固定值 `0x1c9c380`（原生出块路径不写 `setGasLimit`，header 读回为 0），`baseFeePerGas`/`withdrawals`/`withdrawalsRoot`/blob 等 mock 字段原样输出，miner 由 sealer 列表推导——**原生链 RPC 响应形状不变**。
- 更新/新增 `Web3ResponseTest` 用例覆盖 Eth 头响应构造与原生头行为保持。

### 3. 修复 EthBlockHeader NON_ETH round-trip 单位错误

- `EthBlockHeader` 构造函数原无条件 `timestamp/1000`，与 `rlpEncode` 的 NON_ETH-only `/1000` 冲突，导致 NON_ETH 头双重除法、round-trip 无法复现原始 RLP。修复为按版本区分：NON_ETH 透传毫秒（`rlpEncode` 时 `/1000` 得秒），ETH 版本 `/1000`（内部存秒）。

## 影响与兼容性

- **FISCO-BCOS 原生链的 RPC 响应行为保持不变**（gasLimit 仍为 `0x1c9c380`、mock 字段仍在、miner 仍由 sealer 推导）；仅 Engine API 产出的 Eth 区块走新的 header 直读 + 分叉门控路径。
- **占位/近似项**（与 op-node/geth 的完全对齐待后续 MPT 工作）：
  - `stateRoot` 为 XOR 近似（既有实现，已标注 TODO）；
  - `withdrawalsRoot` 为空 trie root 占位；
  - **非空块的 `txsRoot`/`receiptsRoot` 是 FISCO 二叉 Merkle 而非以太坊 trie root**——"与 op-node/geth 对齐"目前仅对空块成立；
  - `baseFee` 为 0（FISCO 尚不计算真实 EIP-1559 base fee）。
- 旧数据兼容性：base 期间初始化的 dev 链 genesis 头存的是秒，升级后需重建 devnet（特性未发布，可接受）。

## 测试

- `test-bcos-rlp-protocol`：RLP 编解码 round-trip、golden 主网块哈希、版本推导、NON_ETH round-trip。
- `test-bcos-engine`：版本映射（含 V5 拒绝）、finalize 字段填充与分叉门控（含 V4/PRAGUE）、空区块 RLP 哈希注入。
- `GenesisEthHeaderTest`：eth genesis artifact 哈希与 python 参考一致、重启/篡改场景。
- `Web3ResponseTest`：Eth 头响应构造、NON_ETH 原生头行为保持。

