### PR TITLE
Engine: stamp Jovian/Holocene extraData on built payloads and headers

### DIFF
--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -148,21 +148,86 @@ constexpr std::size_t c_jovianExtraDataBytes = 17;
 /// protocol constants, like the EL does too", using ChainOpConfig
 /// .EIP1559DenominatorCanyon / .EIP1559Elasticity). This node has no rollup config to
 /// read them from, so they are pinned to the OP Stack defaults (250, 6) that our
-/// deployment's rollup.json chain_op_config carries; a deployment configuring different
-/// chain_op_config values would fail op-node's consolidation match.
+/// deployment's rollup.json chain_op_config carries (tools/opstack-genesis/
+/// gen_rollup_config.py defaults, emitted into tools/opnode-check/rollup.json).
+///
+/// DEPLOYMENT CONSTRAINT: a chain whose rollup.json sets different chain_op_config
+/// values would fail op-node's consolidation match and stall. Making these
+/// configurable is deliberately NOT done here: chain_op_config is a chain-level
+/// constant, so a per-node ini key would let two nodes stamp different extraData on
+/// the same height and split the chain. The correct home is a consensus-pinned
+/// value (the genesis config / SYS_CONFIG lane, alongside the eth genesis header),
+/// which changes the genesis artifact and belongs to that lane's PR.
 constexpr std::uint32_t c_eip1559DenominatorCanyon = 250;
 constexpr std::uint32_t c_eip1559ElasticityCanyon = 6;
 
-/// Big-endian read of the two u32 halves of the 8-byte eip1559Params
+/// Width of the eip1559Params attribute field and of the parameter half of a
+/// non-empty extraData (op-service/eth/types.go:521 declares it as a Bytes8).
+constexpr std::size_t c_eip1559ParamsBytes = 8;
+
+/// Big-endian read of the two u32 halves of an 8-byte eip1559Params field
 /// (op-core/eip1559/eip1559.go DecodeHolocene1559Params: denominator [0:4],
 /// elasticity [4:8]).
-std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(const bcos::bytes& params)
+///
+/// Precondition: params.size() >= 8. std::span::first / ::subspan state that as a
+/// hard precondition ([span.sub]), so a shorter span is undefined behaviour here,
+/// NOT a std::out_of_range — every caller must establish the length first. The two
+/// callers that take CL-supplied bytes do: validatePayloadAttributes and
+/// validateOptimismExtraDataShape both check the length before decoding, and
+/// encodeOptimismExtraData rejects anything else at its entry.
+std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(std::span<const bcos::byte> params)
 {
-    auto denominator =
-        bcos::fromBigEndian<std::uint32_t>(std::span<const bcos::byte>(params).first(4));
-    auto elasticity =
-        bcos::fromBigEndian<std::uint32_t>(std::span<const bcos::byte>(params).subspan(4, 4));
+    BOOST_ASSERT(params.size() >= c_eip1559ParamsBytes);
+    auto denominator = bcos::fromBigEndian<std::uint32_t>(params.first(4));
+    auto elasticity = bcos::fromBigEndian<std::uint32_t>(params.subspan(4, 4));
     return {denominator, elasticity};
+}
+
+/// OP-Stack header extraData shapes, as op-geth validates them on every block it
+/// imports — including the ones a CL hands back through newPayload
+/// (consensus/beacon/consensus.go:240-243 calls eip1559.ValidateOptimismExtraData,
+/// which picks the rule from the chain's fork schedule and skips only the genesis
+/// block). This service has no fork schedule to pick with, so it accepts any of the
+/// three legal shapes and rejects everything else: empty (pre-Holocene,
+/// eip1559.go:27-28), 9 bytes with version byte 0x00 (ValidateHoloceneExtraData,
+/// eip1559.go:119-127), 17 bytes with version byte 0x01 (ValidateJovianExtraData,
+/// eip1559.go:167-176). Both non-empty forms carry the denominator/elasticity pair
+/// in [1, 9), which must be non-zero on a header — unlike the attribute side, where
+/// 0,0 is legal and gets translated (validateHoloceneExtraDataPart,
+/// eip1559.go:105-113, and the note above ValidateHoloceneExtraData spelling out the
+/// difference).
+std::optional<std::string> validateOptimismExtraDataShape(const bcos::bytes& extraData)
+{
+    if (extraData.empty())
+    {
+        return std::nullopt;
+    }
+    if (extraData.size() != c_holoceneExtraDataBytes && extraData.size() != c_jovianExtraDataBytes)
+    {
+        return "executionPayload.extraData must be empty (pre-Holocene), " +
+               std::to_string(c_holoceneExtraDataBytes) + " bytes (Holocene) or " +
+               std::to_string(c_jovianExtraDataBytes) + " bytes (Jovian), got " +
+               std::to_string(extraData.size());
+    }
+    auto const expectedVersion = extraData.size() == c_jovianExtraDataBytes ?
+                                     c_jovianExtraDataVersion :
+                                     c_holoceneExtraDataVersion;
+    if (extraData[0] != expectedVersion)
+    {
+        return "executionPayload.extraData version byte must be " +
+               std::to_string(static_cast<unsigned>(expectedVersion)) + " for a " +
+               std::to_string(extraData.size()) + "-byte extraData, got " +
+               std::to_string(static_cast<unsigned>(extraData[0]));
+    }
+    auto [denominator, elasticity] = decodeEip1559Params(
+        std::span<const bcos::byte>(extraData).subspan(1, c_eip1559ParamsBytes));
+    if (denominator == 0 || elasticity == 0)
+    {
+        return std::string(
+            "executionPayload.extraData must encode a non-zero EIP-1559 denominator and "
+            "elasticity");
+    }
+    return std::nullopt;
 }
 }  // namespace
 
@@ -173,6 +238,18 @@ bcos::bytes bcos::engine::detail::encodeOptimismExtraData(
     {
         // Pre-Holocene: extraData must be empty (op-core/eip1559/eip1559.go:27-28).
         return {};
+    }
+    if (payloadAttributes.eip1559Params->size() != c_eip1559ParamsBytes)
+    {
+        // A precondition, not a wire error: the RPC parse layer and then
+        // validatePayloadAttributes both reject any other length, so reaching this
+        // means an in-process PayloadAttributes producer bypassed the gate. Fail
+        // loudly rather than read out of bounds (decodeEip1559Params' span
+        // arithmetic is UB on a short span), and rather than return empty, which
+        // would silently stamp pre-Holocene extraData on a Holocene block and stall
+        // op-node at read-back.
+        BOOST_THROW_EXCEPTION(std::invalid_argument{
+            "encodeOptimismExtraData requires exactly 8 bytes of eip1559Params"});
     }
     auto [denominator, elasticity] = decodeEip1559Params(*payloadAttributes.eip1559Params);
     if (denominator == 0 && elasticity == 0)
@@ -342,6 +419,25 @@ std::optional<std::string> bcos::engine::detail::validateExecutionPayload(
     if (version >= 4 && !executionPayload.withdrawalsRoot.has_value())
     {
         return std::string("withdrawalsRoot is required for ExecutionPayloadV4 and later");
+    }
+    // extraData is a V1-onwards field, so this applies at every newPayload version.
+    // Since this PR makes extraData part of the block hash, an unchecked extraData is
+    // an unchecked block-hash input.
+    if (auto error = validateOptimismExtraDataShape(executionPayload.extraData))
+    {
+        return error;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> bcos::engine::detail::compareWithBuiltPayload(
+    const ExecutionPayload& submitted, const ExecutionPayload& built)
+{
+    if (submitted.extraData != built.extraData)
+    {
+        return std::string(
+            "executionPayload.extraData does not match the payload this node built under the "
+            "submitted blockHash");
     }
     return std::nullopt;
 }

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -240,6 +240,25 @@ std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     {
         return std::string("parentBeaconBlockRoot must be a 32-byte hash for V3");
     }
+    // eip1559Params (Holocene) and minBaseFee (Jovian) reach the EL only on a
+    // forkchoiceUpdatedV3. op-node's FCU version ladder tops out at V3 — Config
+    // ::ForkchoiceUpdatedVersion (op-node/rollup/types.go:727-745, v1.19.3) answers
+    // FCUV3 from Ecotone onwards, FCUV2 for Canyon and FCUV1 before it, and there is
+    // no FCUV4 constant at all (op-service/eth/types.go:799-801) — while Holocene and
+    // Jovian both activate after Ecotone. So a conforming CL carries both fields on V3
+    // and only V3; op-geth's V1/V2 payload-attribute structs have no such field and
+    // reject them outright. Without this gate a V1/V2 forkchoiceUpdated carrying
+    // eip1559Params would stamp Holocene extraData on a pre-Holocene build, which a
+    // spec-conformant CL then rejects on read-back ("extraData must be empty before
+    // Holocene", op-core/eip1559/eip1559.go:27-28).
+    if (version <= 2 && payloadAttributes.eip1559Params.has_value())
+    {
+        return std::string("eip1559Params is only valid for PayloadAttributesV3");
+    }
+    if (version <= 2 && payloadAttributes.minBaseFee.has_value())
+    {
+        return std::string("minBaseFee is only valid for PayloadAttributesV3");
+    }
     // Jovian attributes always pair minBaseFee with eip1559Params: op-node fills both
     // once Jovian is active (op-service/eth/types.go PayloadAttributes), and a
     // post-Jovian block must carry the 17-byte extraData whose [1:9) params come from

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -19,7 +19,10 @@
 #include "EngineServiceImpl.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <boost/assert.hpp>
+#include <boost/throw_exception.hpp>
 #include <span>
+#include <stdexcept>
 #include <utility>
 
 namespace
@@ -323,8 +326,22 @@ std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     // FCUV3 from Ecotone onwards, FCUV2 for Canyon and FCUV1 before it, and there is
     // no FCUV4 constant at all (op-service/eth/types.go:799-801) — while Holocene and
     // Jovian both activate after Ecotone. So a conforming CL carries both fields on V3
-    // and only V3; op-geth's V1/V2 payload-attribute structs have no such field and
-    // reject them outright. Without this gate a V1/V2 forkchoiceUpdated carrying
+    // and only V3.
+    //
+    // Note this is NOT how op-geth expresses the same rule, and the difference is worth
+    // recording. op-geth has a single engine.PayloadAttributes shared by all three FCU
+    // versions, and it does carry EIP1559Params / MinBaseFee at every version
+    // (beacon/engine/types.go:83-89); its ForkchoiceUpdatedV1/V2/V3 wrappers check only
+    // withdrawals, the beacon root and the fork window (eth/catalyst/api.go:166-214) and
+    // never look at these two fields. The rejection happens later, in the shared path:
+    // checkOptimismPayloadAttributes (eth/catalyst/api_optimism.go:40-64, called from
+    // api.go:254) answers "non-empty eip155Params pre-Holocene" as a -38003
+    // InvalidPayloadAttributes, keyed off the FORK SCHEDULE (cfg.IsHolocene(timestamp)),
+    // not off the Engine API method version. This service has no fork schedule to key
+    // off, so the FCU version is the only equivalent signal available — sound precisely
+    // because op-node's version ladder above pins these fields to V3.
+    //
+    // Without this gate a V1/V2 forkchoiceUpdated carrying
     // eip1559Params would stamp Holocene extraData on a pre-Holocene build, which a
     // spec-conformant CL then rejects on read-back ("extraData must be empty before
     // Holocene", op-core/eip1559/eip1559.go:27-28).

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -188,14 +188,14 @@ bcos::bytes bcos::engine::detail::encodeOptimismExtraData(
     bool jovian = payloadAttributes.minBaseFee.has_value();
     bcos::bytes extraData(jovian ? c_jovianExtraDataBytes : c_holoceneExtraDataBytes, 0);
     extraData[0] = jovian ? c_jovianExtraDataVersion : c_holoceneExtraDataVersion;
-    auto span = std::span(extraData);
-    auto denominatorOut = span.subspan(1, 4);
+    auto out = std::span(extraData);
+    auto denominatorOut = out.subspan(1, 4);
     bcos::toBigEndian(denominator, denominatorOut);
-    auto elasticityOut = span.subspan(5, 4);
+    auto elasticityOut = out.subspan(5, 4);
     bcos::toBigEndian(elasticity, elasticityOut);
     if (jovian)
     {
-        auto minBaseFeeOut = span.subspan(9, 8);
+        auto minBaseFeeOut = out.subspan(9, 8);
         bcos::toBigEndian(*payloadAttributes.minBaseFee, minBaseFeeOut);
     }
     return extraData;
@@ -253,6 +253,13 @@ std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     }
     if (payloadAttributes.eip1559Params.has_value())
     {
+        // The RPC parse layer already enforces exactly 8 bytes (EngineHelper.cpp), but
+        // this gate is the precondition encodeOptimismExtraData and the decode below
+        // rely on, so enforce it here too for in-process PayloadAttributes producers.
+        if (payloadAttributes.eip1559Params->size() != 8)
+        {
+            return std::string("eip1559Params must be exactly 8 bytes");
+        }
         // ValidateHolocene1559Params (op-core/eip1559/eip1559.go:89-100): denominator
         // and elasticity must be both zero or both non-zero. 0,0 is valid attribute
         // input and is translated to the Canyon constants by encodeOptimismExtraData.

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -19,6 +19,8 @@
 #include "EngineServiceImpl.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <span>
+#include <utility>
 
 namespace
 {
@@ -129,6 +131,76 @@ std::optional<std::string> validateRawTransactionKind(
 }
 }  // namespace
 
+namespace
+{
+/// extraData version bytes (op-core/eip1559/eip1559.go:10-13). Note the Jovian version
+/// byte is 0x01, not 0x00: ValidateJovianExtraData (eip1559.go:167-176) rejects any
+/// other value on every post-Jovian block op-node reads back.
+constexpr bcos::byte c_holoceneExtraDataVersion = 0x00;
+constexpr bcos::byte c_jovianExtraDataVersion = 0x01;
+constexpr std::size_t c_holoceneExtraDataBytes = 9;
+constexpr std::size_t c_jovianExtraDataBytes = 17;
+
+/// Canyon EIP-1559 constants used to translate all-zero attribute params. op-node sends
+/// eip1559Params = 0,0 while the SystemConfig has not set the parameters, and expects
+/// the EL to translate them to the chain's Canyon constants (op-node/rollup/attributes/
+/// engine_consolidate.go checkExtraDataParamsMatch: "Translate 0,0 to the pre-Holocene
+/// protocol constants, like the EL does too", using ChainOpConfig
+/// .EIP1559DenominatorCanyon / .EIP1559Elasticity). This node has no rollup config to
+/// read them from, so they are pinned to the OP Stack defaults (250, 6) that our
+/// deployment's rollup.json chain_op_config carries; a deployment configuring different
+/// chain_op_config values would fail op-node's consolidation match.
+constexpr std::uint32_t c_eip1559DenominatorCanyon = 250;
+constexpr std::uint32_t c_eip1559ElasticityCanyon = 6;
+
+/// Big-endian read of the two u32 halves of the 8-byte eip1559Params
+/// (op-core/eip1559/eip1559.go DecodeHolocene1559Params: denominator [0:4],
+/// elasticity [4:8]).
+std::pair<std::uint32_t, std::uint32_t> decodeEip1559Params(const bcos::bytes& params)
+{
+    auto denominator =
+        bcos::fromBigEndian<std::uint32_t>(std::span<const bcos::byte>(params).first(4));
+    auto elasticity =
+        bcos::fromBigEndian<std::uint32_t>(std::span<const bcos::byte>(params).subspan(4, 4));
+    return {denominator, elasticity};
+}
+}  // namespace
+
+bcos::bytes bcos::engine::detail::encodeOptimismExtraData(
+    const PayloadAttributes& payloadAttributes)
+{
+    if (!payloadAttributes.eip1559Params.has_value())
+    {
+        // Pre-Holocene: extraData must be empty (op-core/eip1559/eip1559.go:27-28).
+        return {};
+    }
+    auto [denominator, elasticity] = decodeEip1559Params(*payloadAttributes.eip1559Params);
+    if (denominator == 0 && elasticity == 0)
+    {
+        denominator = c_eip1559DenominatorCanyon;
+        elasticity = c_eip1559ElasticityCanyon;
+    }
+
+    // Jovian 17-byte form (EncodeJovianExtraData, eip1559.go:152-162) when the CL sent
+    // minBaseFee, Holocene 9-byte form (EncodeHoloceneExtraData, eip1559.go:74-83)
+    // otherwise. checkExtraDataParamsMatch requires the block to carry minBaseFee iff
+    // the attributes did.
+    bool jovian = payloadAttributes.minBaseFee.has_value();
+    bcos::bytes extraData(jovian ? c_jovianExtraDataBytes : c_holoceneExtraDataBytes, 0);
+    extraData[0] = jovian ? c_jovianExtraDataVersion : c_holoceneExtraDataVersion;
+    auto span = std::span(extraData);
+    auto denominatorOut = span.subspan(1, 4);
+    bcos::toBigEndian(denominator, denominatorOut);
+    auto elasticityOut = span.subspan(5, 4);
+    bcos::toBigEndian(elasticity, elasticityOut);
+    if (jovian)
+    {
+        auto minBaseFeeOut = span.subspan(9, 8);
+        bcos::toBigEndian(*payloadAttributes.minBaseFee, minBaseFeeOut);
+    }
+    return extraData;
+}
+
 std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     const PayloadAttributes& payloadAttributes, std::uint32_t version)
 {
@@ -167,6 +239,29 @@ std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     if (version == 3 && !payloadAttributes.parentBeaconBlockRoot.has_value())
     {
         return std::string("parentBeaconBlockRoot must be a 32-byte hash for V3");
+    }
+    // Jovian attributes always pair minBaseFee with eip1559Params: op-node fills both
+    // once Jovian is active (op-service/eth/types.go PayloadAttributes), and a
+    // post-Jovian block must carry the 17-byte extraData whose [1:9) params come from
+    // eip1559Params — minBaseFee alone leaves the params half undefined. op-geth rejects
+    // such attributes as invalid rather than guessing (engine error -38003
+    // InvalidPayloadAttributes); this service reports attribute errors through the
+    // INVALID payload status channel instead (see updateForkchoice).
+    if (payloadAttributes.minBaseFee.has_value() && !payloadAttributes.eip1559Params.has_value())
+    {
+        return std::string("minBaseFee requires eip1559Params (Jovian attributes carry both)");
+    }
+    if (payloadAttributes.eip1559Params.has_value())
+    {
+        // ValidateHolocene1559Params (op-core/eip1559/eip1559.go:89-100): denominator
+        // and elasticity must be both zero or both non-zero. 0,0 is valid attribute
+        // input and is translated to the Canyon constants by encodeOptimismExtraData.
+        auto [denominator, elasticity] = decodeEip1559Params(*payloadAttributes.eip1559Params);
+        if ((denominator == 0) != (elasticity == 0))
+        {
+            return std::string(
+                "eip1559Params denominator and elasticity must be both zero or both non-zero");
+        }
     }
     return std::nullopt;
 }

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -99,13 +99,14 @@ std::optional<std::string> validateExecutionPayload(
 ///    withdrawalsRoot even when the build set one — so comparing them would reject
 ///    honest CLs.
 ///  - The transaction list is NOT compared, even though a differing list under a
-///    blockHash this node minted is equally contradictory. newPayload is currently
-///    specified to REWRITE the cached payload from the request (see
-///    new_payload_round_trips_deposit_raw_bytes and
-///    payload_carries_parent_beacon_block_root_and_withdrawals_root in
-///    EngineServiceTest), and payload bodies are not independently verifiable until
-///    externally supplied payloads are actually executed — tracked as #5468. Closing
-///    the body half belongs with that work.
+///    blockHash this node minted is equally contradictory — and, on this branch, it
+///    would be perfectly comparable, since the built payload is right here. The
+///    blocker is a contract, not a capability: newPayload is currently specified to
+///    REWRITE the cached payload body from the request, which
+///    new_payload_round_trips_deposit_raw_bytes pins by appending transactions to a
+///    locally built payload and asserting VALID. Tightening the body half means
+///    changing that contract first, which belongs with #5468 (the work that makes
+///    externally supplied payload bodies verifiable at all).
 ///
 /// extraData is in scope here because this change puts it into the block hash, so
 /// leaving it unchecked would leave a hash input unchecked.
@@ -570,19 +571,24 @@ private:
             // disagree (beacon/engine/types.go:287-288, reached from
             // eth/catalyst/api.go:831). This service cannot re-derive an Ethereum block
             // hash from an ExecutionPayload, so it compares against what it handed out
-            // instead. Without this a CL could alter the extraData or the transaction
-            // list, keep the blockHash it was given, and have the node commit its own
-            // (different) header while answering VALID — the submitted payload never
-            // checked. A non-null header is what marks an entry as locally built; after
-            // a commit rewrites the entry the header is gone, so an idempotent re-submit
-            // of an already-committed block is not re-compared.
+            // instead. Without this a CL could alter the extraData, keep the blockHash it
+            // was given, and have the node commit its own (different) header while
+            // answering VALID — the submitted payload never checked. Only extraData is
+            // compared; the transaction list stays out of scope for the contract reason
+            // spelled out on compareWithBuiltPayload.
+            //
+            // Every cache hit is compared, including a re-submission of an already
+            // committed block (whose entry no longer carries a header). An honest
+            // idempotent re-submit is byte-identical and passes; gating on the header
+            // would let a second, altered submission of the same blockHash overwrite the
+            // cached payload and still be answered VALID. op-geth likewise re-derives the
+            // hash on every newPayload, committed or not.
             //
             // SCOPE: payloads this node did NOT build (lookup miss) are a separate,
             // pre-existing gap — they are answered VALID without being executed or
             // stored at all. That is tracked as #5468 and deliberately not addressed
             // here.
-            if (auto builtIt = m_payloadCache.find(payloadId);
-                builtIt != m_payloadCache.end() && builtIt->second.header)
+            if (auto builtIt = m_payloadCache.find(payloadId); builtIt != m_payloadCache.end())
             {
                 if (auto mismatch = detail::compareWithBuiltPayload(
                         request.executionPayload, builtIt->second.executionPayload))

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -76,6 +76,16 @@ bool isGetPayloadVersionCompatible(ApiVersion requestVersion, std::uint32_t payl
 std::optional<std::string> validatePayloadAttributes(
     const PayloadAttributes& payloadAttributes, std::uint32_t version);
 
+/// Encodes the OP-Stack block-header extraData from the CL-supplied payload attributes.
+/// Attribute presence is the fork signal (op-node sends eip1559Params iff Holocene is
+/// active, and minBaseFee iff Jovian is active — op-node/rollup/attributes/
+/// engine_consolidate.go checkExtraDataParamsMatch): no eip1559Params -> empty
+/// (pre-Holocene), eip1559Params only -> 9-byte Holocene form, eip1559Params +
+/// minBaseFee -> 17-byte Jovian form (op-core/eip1559/eip1559.go
+/// EncodeHoloceneExtraData / EncodeJovianExtraData). Requires attributes that passed
+/// validatePayloadAttributes (8-byte params, valid zero-pairing).
+bcos::bytes encodeOptimismExtraData(const PayloadAttributes& payloadAttributes);
+
 std::optional<std::string> validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version);
 }  // namespace detail
@@ -699,6 +709,14 @@ private:
             });
         }
 
+        // OP-Stack extraData derived from the attributes' eip1559Params / minBaseFee
+        // (Jovian 17-byte form on our chains). Stamped identically on the returned
+        // payload AND on the persisted block header below — op-node re-reads the header
+        // via eth_getBlockByNumber (BlockResponse serves blockHeader->extraData()) and
+        // re-validates it (op-core/eip1559/eip1559.go ValidateJovianExtraData), so the
+        // two must match byte for byte.
+        bytes extraData = detail::encodeOptimismExtraData(payloadAttributes);
+
         ExecutionPayload executionPayload{
             .logsBloom = Bloom{},
             .parentHash = forkchoiceState.headBlockHash,
@@ -710,7 +728,7 @@ private:
             .baseFeePerGas = 0,
             .blockHash = detail::syntheticHash(payloadId),
             .transactions = std::move(engineTransactions),
-            .extraData = {},
+            .extraData = extraData,
             .feeRecipient = payloadAttributes.suggestedFeeRecipient,
             .timestamp = payloadAttributes.timestamp,
             .blockNumber = nextBlockNumber,
@@ -779,6 +797,9 @@ private:
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
             emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
+            // Must precede calculateHash: extraData is part of the Tars header hash
+            // (bcos-tars-protocol/impl/TarsHashable.h).
+            emptyHeader->setExtraData(std::move(extraData));
             emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
             emptyHeader->setReceiptsRoot(h256{});
             emptyHeader->setTxsRoot(h256{});
@@ -804,6 +825,9 @@ private:
         blockHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
+        // Must precede calculateHash: extraData is part of the Tars header hash
+        // (bcos-tars-protocol/impl/TarsHashable.h).
+        blockHeader->setExtraData(std::move(extraData));
 
         // Step 2c: Execute transactions via the scheduler, over the decoded executable
         // forms. Raw-only entries (forced transactions from the OP attributes list) have

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -88,6 +88,29 @@ bcos::bytes encodeOptimismExtraData(const PayloadAttributes& payloadAttributes);
 
 std::optional<std::string> validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version);
+
+/// Compares a payload the CL submitted through newPayload against the one this node
+/// built and handed out under the same blockHash.
+///
+/// Deliberately narrow: only extraData is compared. Two other candidates are
+/// excluded on purpose.
+///  - Version-specific fields (withdrawalsRoot, the blob-gas pair) are dropped by the
+///    wire dialect on the way back — a V3 newPayload request carries no
+///    withdrawalsRoot even when the build set one — so comparing them would reject
+///    honest CLs.
+///  - The transaction list is NOT compared, even though a differing list under a
+///    blockHash this node minted is equally contradictory. newPayload is currently
+///    specified to REWRITE the cached payload from the request (see
+///    new_payload_round_trips_deposit_raw_bytes and
+///    payload_carries_parent_beacon_block_root_and_withdrawals_root in
+///    EngineServiceTest), and payload bodies are not independently verifiable until
+///    externally supplied payloads are actually executed — tracked as #5468. Closing
+///    the body half belongs with that work.
+///
+/// extraData is in scope here because this change puts it into the block hash, so
+/// leaving it unchecked would leave a hash input unchecked.
+std::optional<std::string> compareWithBuiltPayload(
+    const ExecutionPayload& submitted, const ExecutionPayload& built);
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -541,6 +564,33 @@ private:
         else
         {
             payloadId = payloadIdIt->second;
+            // Local-build hit: the CL is handing back a payload this node built. op-geth
+            // needs no such comparison because it re-derives the block hash from the
+            // payload fields it received and answers INVALID_BLOCK_HASH when the two
+            // disagree (beacon/engine/types.go:287-288, reached from
+            // eth/catalyst/api.go:831). This service cannot re-derive an Ethereum block
+            // hash from an ExecutionPayload, so it compares against what it handed out
+            // instead. Without this a CL could alter the extraData or the transaction
+            // list, keep the blockHash it was given, and have the node commit its own
+            // (different) header while answering VALID — the submitted payload never
+            // checked. A non-null header is what marks an entry as locally built; after
+            // a commit rewrites the entry the header is gone, so an idempotent re-submit
+            // of an already-committed block is not re-compared.
+            //
+            // SCOPE: payloads this node did NOT build (lookup miss) are a separate,
+            // pre-existing gap — they are answered VALID without being executed or
+            // stored at all. That is tracked as #5468 and deliberately not addressed
+            // here.
+            if (auto builtIt = m_payloadCache.find(payloadId);
+                builtIt != m_payloadCache.end() && builtIt->second.header)
+            {
+                if (auto mismatch = detail::compareWithBuiltPayload(
+                        request.executionPayload, builtIt->second.executionPayload))
+                {
+                    co_return makeStatus(
+                        PayloadValidationStatus::InvalidBlockHash, std::nullopt, mismatch);
+                }
+            }
         }
 
         PayloadEntry entry{

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -21,6 +21,7 @@
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-tars-protocol/protocol/TransactionReceiptImpl.h>
 #include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
@@ -1126,6 +1127,46 @@ BOOST_AUTO_TEST_CASE(karst_v3_build_v5_get_v4_commit_round_trip)
     auto status = task::syncWait(engineService.newPayload(request, 4));
     BOOST_CHECK_EQUAL(
         static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
+}
+
+// Round-5 op-node breakpoint: a Jovian CL sends eip1559Params + minBaseFee and expects
+// the built block to carry the 17-byte Jovian extraData, re-validated when it reads the
+// header back (op-core/eip1559/eip1559.go ValidateJovianExtraData). The payload and the
+// header the block hash was computed over must agree: buildPayload stamps the same bytes
+// on both before calculateHash.
+BOOST_AUTO_TEST_CASE(build_payload_stamps_jovian_extra_data_on_payload)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    // What op-node actually sent in round 5: all-zero params (SystemConfig defaults),
+    // minBaseFee 0. The EL must translate 0,0 to the Canyon constants (250, 6).
+    payloadAttributes.eip1559Params = bytes(8, 0);
+    payloadAttributes.minBaseFee = 0;
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(payload);
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(payload->executionPayload.extraData),
+        "0x01000000fa000000060000000000000000");
+
+    // minBaseFee absent -> Holocene 9-byte form, version byte 0x00.
+    auto holoceneAttributes = makeKarstPayloadAttributes();
+    holoceneAttributes.eip1559Params = fromHexWithPrefix("0x000000fa00000006");
+    auto holoceneResult =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &holoceneAttributes, 3));
+    BOOST_REQUIRE(holoceneResult.payloadId.has_value());
+    auto holocenePayload = task::syncWait(engineService.getPayload(*holoceneResult.payloadId, 3));
+    BOOST_REQUIRE(holocenePayload);
+    BOOST_CHECK_EQUAL(
+        toHexStringWithPrefix(holocenePayload->executionPayload.extraData), "0x00000000fa00000006");
 }
 
 BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -253,21 +253,6 @@ struct BloomScheduler
     }
 };
 
-using BloomEngineServiceImpl =
-    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, BloomScheduler>;
-
-BloomEngineServiceImpl makeBloomEngineServiceImpl(
-    MemPoolImpl& memPool, RealGlobalStateStorage& storage, BloomScheduler& scheduler)
-{
-    StubExecutor executor;
-    static auto blockFactory =
-        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
-    return BloomEngineServiceImpl(memPool, storage, executor, scheduler, blockFactory);
-}
-
-using TestEngineServiceImpl =
-    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, StubScheduler>;
-
 bcos::protocol::BlockFactory::Ptr testBlockFactory()
 {
     static auto blockFactory =
@@ -275,11 +260,39 @@ bcos::protocol::BlockFactory::Ptr testBlockFactory()
     return blockFactory;
 }
 
+/// EngineServiceImpl stores the executor and scheduler BY REFERENCE (std::ref, see its
+/// constructor), so a function-local stub would dangle the moment a factory returns. The
+/// stubs are stateless, which is why that went unnoticed; keep one long-lived instance of
+/// each so it stays true no matter what a stub grows later.
+StubExecutor& sharedStubExecutor()
+{
+    static StubExecutor executor;
+    return executor;
+}
+
+StubScheduler& sharedStubScheduler()
+{
+    static StubScheduler scheduler;
+    return scheduler;
+}
+
+using BloomEngineServiceImpl =
+    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, BloomScheduler>;
+
+BloomEngineServiceImpl makeBloomEngineServiceImpl(
+    MemPoolImpl& memPool, RealGlobalStateStorage& storage, BloomScheduler& scheduler)
+{
+    return BloomEngineServiceImpl(
+        memPool, storage, sharedStubExecutor(), scheduler, testBlockFactory());
+}
+
+using TestEngineServiceImpl =
+    EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, StubScheduler>;
+
 TestEngineServiceImpl makeEngineServiceImpl(MemPoolImpl& memPool, RealGlobalStateStorage& storage)
 {
-    StubExecutor executor;
-    StubScheduler scheduler;
-    return TestEngineServiceImpl(memPool, storage, executor, scheduler, testBlockFactory());
+    return TestEngineServiceImpl(
+        memPool, storage, sharedStubExecutor(), sharedStubScheduler(), testBlockFactory());
 }
 
 /// The production ledger with its one state-storage dependency short-circuited:
@@ -303,10 +316,8 @@ public:
 TestEngineServiceImpl makeCommittingEngineServiceImpl(MemPoolImpl& memPool,
     RealGlobalStateStorage& storage, bcos::ledger::LedgerInterface::Ptr ledger)
 {
-    StubExecutor executor;
-    StubScheduler scheduler;
-    return TestEngineServiceImpl(
-        memPool, storage, executor, scheduler, testBlockFactory(), std::move(ledger));
+    return TestEngineServiceImpl(memPool, storage, sharedStubExecutor(), sharedStubScheduler(),
+        testBlockFactory(), std::move(ledger));
 }
 
 /// Reads the block header the commit persisted, the way eth_getBlockByNumber reaches it

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -17,6 +17,7 @@
 #include <bcos-framework/storage2/MultiLayerStorage.h>
 #include <bcos-framework/testutils/faker/FakeBlock.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/Ledger.h>
 #include <bcos-mempool/MemPoolImpl.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-tars-protocol/protocol/TransactionReceiptImpl.h>
@@ -267,13 +268,63 @@ BloomEngineServiceImpl makeBloomEngineServiceImpl(
 using TestEngineServiceImpl =
     EngineServiceImpl<MemPoolImpl, RealGlobalStateStorage, StubExecutor, StubScheduler>;
 
+bcos::protocol::BlockFactory::Ptr testBlockFactory()
+{
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    return blockFactory;
+}
+
 TestEngineServiceImpl makeEngineServiceImpl(MemPoolImpl& memPool, RealGlobalStateStorage& storage)
 {
     StubExecutor executor;
     StubScheduler scheduler;
-    static auto blockFactory =
-        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
-    return TestEngineServiceImpl(memPool, storage, executor, scheduler, blockFactory);
+    return TestEngineServiceImpl(memPool, storage, executor, scheduler, testBlockFactory());
+}
+
+/// The production ledger with its one state-storage dependency short-circuited:
+/// Ledger::asyncPrewriteBlock self-calls asyncGetTotalTransactionCount, which opens
+/// SYS_CURRENT_STATE and fails the whole prewrite when that table is unknown
+/// (Ledger.cpp:396 -> :1051). Everything asserted below — the
+/// SYS_NUMBER_2_BLOCK_HEADER row — is written by the real header encode path above
+/// that call, so this keeps the commit exercising production code rather than a fake.
+class CommitLedger : public bcos::ledger::Ledger
+{
+public:
+    using bcos::ledger::Ledger::Ledger;
+    void asyncGetTotalTransactionCount(
+        std::function<void(bcos::Error::Ptr, int64_t, int64_t, bcos::protocol::BlockNumber)>
+            callback) override
+    {
+        callback(nullptr, 0, 0, 0);
+    }
+};
+
+TestEngineServiceImpl makeCommittingEngineServiceImpl(MemPoolImpl& memPool,
+    RealGlobalStateStorage& storage, bcos::ledger::LedgerInterface::Ptr ledger)
+{
+    StubExecutor executor;
+    StubScheduler scheduler;
+    return TestEngineServiceImpl(
+        memPool, storage, executor, scheduler, testBlockFactory(), std::move(ledger));
+}
+
+/// Reads the block header the commit persisted, the way eth_getBlockByNumber reaches it
+/// (SYS_NUMBER_2_BLOCK_HEADER keyed by the decimal block number; decode pattern from
+/// bcos-ledger/bcos-ledger/LedgerMethods.h:204-215).
+bcos::protocol::BlockHeader::Ptr readPersistedHeader(
+    RealGlobalStateBackendStorage& backendStorage, bcos::protocol::BlockNumber blockNumber)
+{
+    auto entry = task::syncWait(bcos::storage2::readOne(
+        backendStorage, bcos::executor_v1::StateKey{ledger::SYS_NUMBER_2_BLOCK_HEADER,
+                            boost::lexical_cast<std::string>(blockNumber)}));
+    if (!entry)
+    {
+        return nullptr;
+    }
+    auto field = entry->get();
+    return testBlockFactory()->blockHeaderFactory()->createBlockHeader(
+        bcos::bytesConstRef(reinterpret_cast<const bcos::byte*>(field.data()), field.size()));
 }
 
 ForkchoiceState makeForkchoiceState()
@@ -1167,6 +1218,115 @@ BOOST_AUTO_TEST_CASE(build_payload_stamps_jovian_extra_data_on_payload)
     BOOST_REQUIRE(holocenePayload);
     BOOST_CHECK_EQUAL(
         toHexStringWithPrefix(holocenePayload->executionPayload.extraData), "0x00000000fa00000006");
+}
+
+// The invariant op-node actually depends on is the PERSISTED HEADER's extraData: after
+// the CL commits a block it re-reads the header over eth_getBlockByNumber and runs
+// ValidateJovianExtraData on it (op-core/eip1559/eip1559.go:167-176, reached from
+// op-node/rollup/derive/payload_util.go PayloadToSystemConfig and
+// engine_consolidate.go). Asserting only the getPayload response would stay green if
+// buildPayload ever stamped the payload but not the header — and op-node would reject
+// every block. So commit the payload and read the header back out of storage.
+BOOST_AUTO_TEST_CASE(committed_header_carries_the_same_jovian_extra_data_as_the_payload)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    payloadAttributes.eip1559Params = bytes(8, 0);
+    payloadAttributes.minBaseFee = 0;
+
+    auto ledger = std::make_shared<CommitLedger>(testBlockFactory(), nullptr, /*blockLimit=*/100);
+    auto engineService =
+        makeCommittingEngineServiceImpl(memPool, globalStateStorageFixture.storage, ledger);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(payload);
+
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_REQUIRE_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
+
+    auto persisted =
+        readPersistedHeader(globalStateStorageFixture.backendStorage, c_initialBlockNumber + 1);
+    BOOST_REQUIRE(persisted);
+    // Byte-for-byte with the payload the CL was handed, and equal to the Jovian vector.
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(persisted->extraData()),
+        toHexStringWithPrefix(payload->executionPayload.extraData));
+    BOOST_CHECK_EQUAL(
+        toHexStringWithPrefix(persisted->extraData()), "0x01000000fa000000060000000000000000");
+}
+
+// A CL that alters the extraData of a payload this node built, while keeping the
+// blockHash it was handed, must not get VALID: the node would otherwise commit its own
+// (different) header and leave the CL believing its version was taken.
+BOOST_AUTO_TEST_CASE(new_payload_rejects_altered_extra_data_under_a_built_block_hash)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    payloadAttributes.eip1559Params = bytes(8, 0);
+    payloadAttributes.minBaseFee = 0;
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(payload);
+
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    // Same blockHash, different extraData: a well-formed Jovian shape, so this is the
+    // local-build comparison talking, not the shape gate.
+    request.executionPayload.extraData = fromHexWithPrefix("0x01000000fa000000060000000000000009");
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(status.status),
+        static_cast<int>(PayloadValidationStatus::InvalidBlockHash));
+
+    // The untouched payload still commits.
+    auto honest = makeNewPayloadRequestV3(payload->executionPayload);
+    BOOST_CHECK_EQUAL(static_cast<int>(task::syncWait(engineService.newPayload(honest, 3)).status),
+        static_cast<int>(PayloadValidationStatus::Valid));
+}
+
+// A malformed extraData shape is rejected on the commit side regardless of whether the
+// node built the block, mirroring op-geth's header verification
+// (consensus/beacon/consensus.go:240-243 -> eip1559.ValidateOptimismExtraData).
+BOOST_AUTO_TEST_CASE(new_payload_rejects_malformed_extra_data_shape)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(payload);
+
+    auto request = makeNewPayloadRequestV3(payload->executionPayload);
+    // 17 bytes carrying the Holocene version byte: neither shape accepts it.
+    request.executionPayload.extraData = fromHexWithPrefix("0x00000000fa000000060000000000000000");
+    auto status = task::syncWait(engineService.newPayload(request, 3));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Invalid));
 }
 
 BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)

--- a/engine/test/unittests/engine/JovianExtraDataTest.cpp
+++ b/engine/test/unittests/engine/JovianExtraDataTest.cpp
@@ -20,11 +20,20 @@ using namespace bcos::engine;
 
 namespace
 {
+/// V3-shaped attributes: eip1559Params and minBaseFee only ever arrive on a
+/// forkchoiceUpdatedV3 (op-node/rollup/types.go ForkchoiceUpdatedVersion tops out at
+/// FCUV3, and both fields postdate Ecotone), so the validation cases below run at
+/// version 3. That means withdrawals and parentBeaconBlockRoot must be present too,
+/// or the sibling V3 gates fire before the eip1559 ones and the cases would assert
+/// against the wrong error.
 PayloadAttributes makeAttributes(
     std::optional<bytes> eip1559Params, std::optional<std::uint64_t> minBaseFee)
 {
     PayloadAttributes attributes;
     attributes.timestamp = 1;
+    attributes.withdrawals = std::vector<WithdrawalV1>{};
+    attributes.parentBeaconBlockRoot =
+        h256("2222222222222222222222222222222222222222222222222222222222222222");
     attributes.eip1559Params = std::move(eip1559Params);
     attributes.minBaseFee = minBaseFee;
     return attributes;
@@ -91,7 +100,7 @@ BOOST_AUTO_TEST_CASE(missing_eip1559_params_keeps_extra_data_empty)
 // undefined; the attributes are rejected instead of guessed at.
 BOOST_AUTO_TEST_CASE(min_base_fee_without_params_is_rejected)
 {
-    auto error = engine::detail::validatePayloadAttributes(makeAttributes(std::nullopt, 0), 1);
+    auto error = engine::detail::validatePayloadAttributes(makeAttributes(std::nullopt, 0), 3);
     BOOST_REQUIRE(error.has_value());
     BOOST_CHECK_NE(error->find("eip1559Params"), std::string::npos);
 }
@@ -101,9 +110,9 @@ BOOST_AUTO_TEST_CASE(min_base_fee_without_params_is_rejected)
 BOOST_AUTO_TEST_CASE(wrong_length_eip1559_params_are_rejected)
 {
     BOOST_CHECK(
-        engine::detail::validatePayloadAttributes(makeAttributes(bytes(7, 0), 0), 1).has_value());
+        engine::detail::validatePayloadAttributes(makeAttributes(bytes(7, 0), 0), 3).has_value());
     BOOST_CHECK(
-        engine::detail::validatePayloadAttributes(makeAttributes(bytes(9, 0), 0), 1).has_value());
+        engine::detail::validatePayloadAttributes(makeAttributes(bytes(9, 0), 0), 3).has_value());
 }
 
 // ValidateHolocene1559Params (eip1559.go:89-100): a zero denominator with a non-zero
@@ -111,17 +120,76 @@ BOOST_AUTO_TEST_CASE(wrong_length_eip1559_params_are_rejected)
 BOOST_AUTO_TEST_CASE(mixed_zero_eip1559_params_are_rejected)
 {
     BOOST_CHECK(engine::detail::validatePayloadAttributes(
-        makeAttributes(fromHexWithPrefix("0x0000000000000006"), 0), 1)
+        makeAttributes(fromHexWithPrefix("0x0000000000000006"), 0), 3)
             .has_value());
     BOOST_CHECK(engine::detail::validatePayloadAttributes(
-        makeAttributes(fromHexWithPrefix("0x000000fa00000000"), 0), 1)
+        makeAttributes(fromHexWithPrefix("0x000000fa00000000"), 0), 3)
             .has_value());
     // Both zero and both non-zero stay valid.
     BOOST_CHECK(
-        !engine::detail::validatePayloadAttributes(makeAttributes(bytes(8, 0), 0), 1).has_value());
+        !engine::detail::validatePayloadAttributes(makeAttributes(bytes(8, 0), 0), 3).has_value());
     BOOST_CHECK(engine::detail::validatePayloadAttributes(
-                    makeAttributes(fromHexWithPrefix("0x000000fa00000006"), 0), 1)
+                    makeAttributes(fromHexWithPrefix("0x000000fa00000006"), 0), 3)
                     .has_value() == false);
+}
+
+// Both fields reach the EL only on a forkchoiceUpdatedV3: op-node's
+// Config::ForkchoiceUpdatedVersion (op-node/rollup/types.go:727-745, v1.19.3) answers
+// FCUV3 from Ecotone onwards and there is no FCUV4 constant, while Holocene (which
+// introduces eip1559Params) and Jovian (minBaseFee) both activate after Ecotone. A
+// V1/V2 forkchoiceUpdated carrying them must be rejected rather than stamp
+// Holocene/Jovian extraData on a pre-Holocene build.
+BOOST_AUTO_TEST_CASE(eip1559_fields_are_rejected_below_version_three)
+{
+    // The probes must otherwise be valid for the version under test, or a sibling gate
+    // (withdrawals on V1, parentBeaconBlockRoot on V1/V2) reports first and the case
+    // would pass without exercising the new gate at all.
+    auto attributesForVersion = [](std::uint32_t version) {
+        auto attributes = makeAttributes(std::nullopt, std::nullopt);
+        if (version == 1)
+        {
+            attributes.withdrawals = std::nullopt;
+        }
+        if (version <= 2)
+        {
+            attributes.parentBeaconBlockRoot = std::nullopt;
+        }
+        return attributes;
+    };
+
+    for (std::uint32_t version : {1U, 2U})
+    {
+        // Baseline: without the two fields these attributes are accepted at this
+        // version, so any error below is attributable to the new gate.
+        BOOST_REQUIRE(
+            !engine::detail::validatePayloadAttributes(attributesForVersion(version), version)
+                .has_value());
+
+        auto holocene = attributesForVersion(version);
+        holocene.eip1559Params = fromHexWithPrefix("0x000000fa00000006");
+        auto holoceneError = engine::detail::validatePayloadAttributes(holocene, version);
+        BOOST_REQUIRE(holoceneError.has_value());
+        BOOST_CHECK_NE(holoceneError->find("eip1559Params"), std::string::npos);
+
+        auto jovian = holocene;
+        jovian.minBaseFee = 7;
+        BOOST_CHECK(engine::detail::validatePayloadAttributes(jovian, version).has_value());
+
+        // minBaseFee is version-gated in its own right, before the pairing rule.
+        auto minBaseFeeOnly = attributesForVersion(version);
+        minBaseFeeOnly.minBaseFee = 7;
+        auto minBaseFeeError = engine::detail::validatePayloadAttributes(minBaseFeeOnly, version);
+        BOOST_REQUIRE(minBaseFeeError.has_value());
+        BOOST_CHECK_NE(minBaseFeeError->find("minBaseFee"), std::string::npos);
+    }
+
+    // V3 is the version op-node actually uses, so both forms stay valid there.
+    BOOST_CHECK(!engine::detail::validatePayloadAttributes(
+        makeAttributes(fromHexWithPrefix("0x000000fa00000006"), std::nullopt), 3)
+            .has_value());
+    BOOST_CHECK(!engine::detail::validatePayloadAttributes(
+        makeAttributes(fromHexWithPrefix("0x000000fa00000006"), 7), 3)
+            .has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/JovianExtraDataTest.cpp
+++ b/engine/test/unittests/engine/JovianExtraDataTest.cpp
@@ -96,6 +96,16 @@ BOOST_AUTO_TEST_CASE(min_base_fee_without_params_is_rejected)
     BOOST_CHECK_NE(error->find("eip1559Params"), std::string::npos);
 }
 
+// The 8-byte params precondition is enforced by the validation gate itself, not only
+// by the RPC parse layer, so in-process PayloadAttributes producers are covered too.
+BOOST_AUTO_TEST_CASE(wrong_length_eip1559_params_are_rejected)
+{
+    BOOST_CHECK(
+        engine::detail::validatePayloadAttributes(makeAttributes(bytes(7, 0), 0), 1).has_value());
+    BOOST_CHECK(
+        engine::detail::validatePayloadAttributes(makeAttributes(bytes(9, 0), 0), 1).has_value());
+}
+
 // ValidateHolocene1559Params (eip1559.go:89-100): a zero denominator with a non-zero
 // elasticity (or vice versa) is invalid attribute input.
 BOOST_AUTO_TEST_CASE(mixed_zero_eip1559_params_are_rejected)

--- a/engine/test/unittests/engine/JovianExtraDataTest.cpp
+++ b/engine/test/unittests/engine/JovianExtraDataTest.cpp
@@ -1,0 +1,117 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+// OP-Stack extraData encoding (engine::detail::encodeOptimismExtraData) and the attribute
+// consistency checks feeding it. Oracle: op-core/eip1559/eip1559.go of
+// optimism v1.19.3 — EncodeJovianExtraData / EncodeHoloceneExtraData for the byte
+// layout, ValidateJovianExtraData for the version byte (0x01), and
+// engine_consolidate.go checkExtraDataParamsMatch for the 0,0 -> Canyon-constants
+// translation.
+
+#include "engine/bcos-engine/EngineServiceImpl.h"
+
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::engine;
+
+namespace
+{
+PayloadAttributes makeAttributes(
+    std::optional<bytes> eip1559Params, std::optional<std::uint64_t> minBaseFee)
+{
+    PayloadAttributes attributes;
+    attributes.timestamp = 1;
+    attributes.eip1559Params = std::move(eip1559Params);
+    attributes.minBaseFee = minBaseFee;
+    return attributes;
+}
+
+void checkExtraData(const bytes& actual, std::string_view expectedHex)
+{
+    BOOST_CHECK_EQUAL(toHexStringWithPrefix(actual), expectedHex);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(JovianExtraDataTest)
+
+// The round-5 breakpoint vector: op-node sends eip1559Params = 0x0000000000000000 and
+// minBaseFee = 0 while the SystemConfig has not set the params, and expects the EL to
+// translate 0,0 to the Canyon constants (250, 6). Expected bytes: version 0x01
+// (op-core requires 0x01 for Jovian, NOT the 0x00 our genesis fixture carries —
+// the genesis header is never re-validated by op-node, blocks >= 1 are), u32 BE
+// denominator 250 = 0x000000fa, u32 BE elasticity 6, u64 BE minBaseFee 0.
+BOOST_AUTO_TEST_CASE(jovian_zero_params_translate_to_canyon_constants)
+{
+    auto attributes = makeAttributes(bytes(8, 0), 0);
+    auto extraData = engine::detail::encodeOptimismExtraData(attributes);
+    BOOST_REQUIRE_EQUAL(extraData.size(), 17);
+    checkExtraData(extraData, "0x01000000fa000000060000000000000000");
+}
+
+// Non-zero attribute params pass through untranslated, and minBaseFee lands as a big-
+// endian u64 in bytes [9, 17) (EncodeJovianExtraData, eip1559.go:152-162).
+BOOST_AUTO_TEST_CASE(jovian_explicit_params_and_min_base_fee_encode_big_endian)
+{
+    auto attributes =
+        makeAttributes(fromHexWithPrefix("0x000000fa00000006"), 0x0102030405060708ULL);
+    auto extraData = engine::detail::encodeOptimismExtraData(attributes);
+    BOOST_REQUIRE_EQUAL(extraData.size(), 17);
+    checkExtraData(extraData, "0x01000000fa000000060102030405060708");
+
+    auto second = makeAttributes(fromHexWithPrefix("0x0000005000000004"), 7);
+    checkExtraData(
+        engine::detail::encodeOptimismExtraData(second), "0x0100000050000000040000000000000007");
+}
+
+// Holocene shape: attributes without minBaseFee produce the 9-byte, version-0x00 form
+// (EncodeHoloceneExtraData, eip1559.go:74-83); the 0,0 translation applies there too.
+BOOST_AUTO_TEST_CASE(holocene_without_min_base_fee_encodes_nine_bytes)
+{
+    checkExtraData(engine::detail::encodeOptimismExtraData(
+                       makeAttributes(fromHexWithPrefix("0x000000fa00000006"), std::nullopt)),
+        "0x00000000fa00000006");
+    checkExtraData(
+        engine::detail::encodeOptimismExtraData(makeAttributes(bytes(8, 0), std::nullopt)),
+        "0x00000000fa00000006");
+}
+
+// Pre-Holocene: no eip1559Params in the attributes -> extraData must stay empty
+// (op-core/eip1559/eip1559.go:27-28).
+BOOST_AUTO_TEST_CASE(missing_eip1559_params_keeps_extra_data_empty)
+{
+    BOOST_CHECK(engine::detail::encodeOptimismExtraData(makeAttributes(std::nullopt, std::nullopt))
+            .empty());
+}
+
+// minBaseFee without eip1559Params leaves the params half of the 17-byte form
+// undefined; the attributes are rejected instead of guessed at.
+BOOST_AUTO_TEST_CASE(min_base_fee_without_params_is_rejected)
+{
+    auto error = engine::detail::validatePayloadAttributes(makeAttributes(std::nullopt, 0), 1);
+    BOOST_REQUIRE(error.has_value());
+    BOOST_CHECK_NE(error->find("eip1559Params"), std::string::npos);
+}
+
+// ValidateHolocene1559Params (eip1559.go:89-100): a zero denominator with a non-zero
+// elasticity (or vice versa) is invalid attribute input.
+BOOST_AUTO_TEST_CASE(mixed_zero_eip1559_params_are_rejected)
+{
+    BOOST_CHECK(engine::detail::validatePayloadAttributes(
+        makeAttributes(fromHexWithPrefix("0x0000000000000006"), 0), 1)
+            .has_value());
+    BOOST_CHECK(engine::detail::validatePayloadAttributes(
+        makeAttributes(fromHexWithPrefix("0x000000fa00000000"), 0), 1)
+            .has_value());
+    // Both zero and both non-zero stay valid.
+    BOOST_CHECK(
+        !engine::detail::validatePayloadAttributes(makeAttributes(bytes(8, 0), 0), 1).has_value());
+    BOOST_CHECK(engine::detail::validatePayloadAttributes(
+                    makeAttributes(fromHexWithPrefix("0x000000fa00000006"), 0), 1)
+                    .has_value() == false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/JovianExtraDataTest.cpp
+++ b/engine/test/unittests/engine/JovianExtraDataTest.cpp
@@ -43,6 +43,30 @@ void checkExtraData(const bytes& actual, std::string_view expectedHex)
 {
     BOOST_CHECK_EQUAL(toHexStringWithPrefix(actual), expectedHex);
 }
+
+/// A payload that passes every non-extraData gate of validateExecutionPayload at
+/// version 3, so the cases below isolate the extraData shape check.
+ExecutionPayload makeExecutionPayloadV3(bytes extraData)
+{
+    ExecutionPayload payload;
+    payload.withdrawals = std::vector<WithdrawalV1>{};
+    payload.blobGasUsed = 0;
+    payload.excessBlobGas = 0;
+    payload.extraData = std::move(extraData);
+    return payload;
+}
+
+ExecutionPayload makePayloadWithTransactions(bytes extraData, std::vector<bytes> rawTransactions)
+{
+    auto payload = makeExecutionPayloadV3(std::move(extraData));
+    for (auto& raw : rawTransactions)
+    {
+        EngineTransaction transaction;
+        transaction.raw = std::move(raw);
+        payload.transactions.push_back(std::move(transaction));
+    }
+    return payload;
+}
 }  // namespace
 
 BOOST_AUTO_TEST_SUITE(JovianExtraDataTest)
@@ -190,6 +214,87 @@ BOOST_AUTO_TEST_CASE(eip1559_fields_are_rejected_below_version_three)
     BOOST_CHECK(!engine::detail::validatePayloadAttributes(
         makeAttributes(fromHexWithPrefix("0x000000fa00000006"), 7), 3)
             .has_value());
+}
+
+// encodeOptimismExtraData is an exported detail:: entry point reachable from
+// in-process PayloadAttributes producers that never went through
+// validatePayloadAttributes. Its decode does span arithmetic whose precondition is
+// 8 bytes ([span.sub] makes a shorter span undefined behaviour, not an exception),
+// so the entry point enforces the length itself instead of trusting the caller.
+BOOST_AUTO_TEST_CASE(encode_rejects_params_shorter_than_eight_bytes)
+{
+    for (std::size_t size : {std::size_t{0}, std::size_t{1}, std::size_t{7}, std::size_t{9}})
+    {
+        BOOST_CHECK_THROW(
+            engine::detail::encodeOptimismExtraData(makeAttributes(bytes(size, 0), 0)),
+            std::invalid_argument);
+    }
+}
+
+// Commit-side shape check. op-geth validates header extraData on every block it
+// imports (consensus/beacon/consensus.go:240-243 -> eip1559.ValidateOptimismExtraData);
+// this service has no fork schedule, so it accepts the three legal shapes and rejects
+// everything else. Since extraData now feeds the block hash, an unchecked extraData is
+// an unchecked block-hash input.
+BOOST_AUTO_TEST_CASE(execution_payload_extra_data_shape_is_validated)
+{
+    auto accepted = [](bytes extraData) {
+        return !engine::detail::validateExecutionPayload(
+            makeExecutionPayloadV3(std::move(extraData)), 3)
+                    .has_value();
+    };
+
+    // Empty (pre-Holocene), 9-byte Holocene and 17-byte Jovian forms.
+    BOOST_CHECK(accepted({}));
+    BOOST_CHECK(accepted(fromHexWithPrefix("0x00000000fa00000006")));
+    BOOST_CHECK(accepted(fromHexWithPrefix("0x01000000fa000000060000000000000000")));
+
+    // Wrong lengths.
+    BOOST_CHECK(!accepted(bytes(8, 0)));
+    BOOST_CHECK(!accepted(bytes(16, 0)));
+    BOOST_CHECK(!accepted(bytes(32, 0)));
+    // Wrong version byte for the length: Jovian must be 0x01, Holocene 0x00.
+    BOOST_CHECK(!accepted(fromHexWithPrefix("0x00000000fa000000060000000000000000")));
+    BOOST_CHECK(!accepted(fromHexWithPrefix("0x01000000fa00000006")));
+    // A header, unlike attributes, may not encode a zero denominator or elasticity
+    // (validateHoloceneExtraDataPart, op-core/eip1559/eip1559.go:105-113).
+    BOOST_CHECK(!accepted(fromHexWithPrefix("0x000000000000000006")));
+    BOOST_CHECK(!accepted(fromHexWithPrefix("0x000000000000000000")));
+    BOOST_CHECK(!accepted(fromHexWithPrefix("0x00000000fa00000000")));
+}
+
+// A CL returning a payload under a blockHash this node minted must return the same
+// extraData it was handed, since that is a block-hash input from this change onwards.
+BOOST_AUTO_TEST_CASE(compare_with_built_payload_catches_altered_extra_data)
+{
+    auto built = makePayloadWithTransactions(
+        fromHexWithPrefix("0x01000000fa000000060000000000000000"), {{0x7e, 0x01}, {0x02, 0x03}});
+
+    BOOST_CHECK(!engine::detail::compareWithBuiltPayload(built, built).has_value());
+
+    auto alteredExtraData = built;
+    alteredExtraData.extraData = fromHexWithPrefix("0x01000000fa000000060000000000000001");
+    auto extraDataError = engine::detail::compareWithBuiltPayload(alteredExtraData, built);
+    BOOST_REQUIRE(extraDataError.has_value());
+    BOOST_CHECK_NE(extraDataError->find("extraData"), std::string::npos);
+
+    auto strippedExtraData = built;
+    strippedExtraData.extraData.clear();
+    BOOST_CHECK(engine::detail::compareWithBuiltPayload(strippedExtraData, built).has_value());
+
+    // Documented non-goals of this comparison, asserted so the boundary is visible.
+    // withdrawalsRoot is dropped by the V3 wire dialect on the way back
+    // (get_payload_v5_rejects_a_v3_committed_entry_without_withdrawals_root in
+    // EngineServiceTest relies on that staying VALID), and the transaction list is
+    // left to #5468, which is what makes payload bodies verifiable at all.
+    auto withoutWithdrawalsRoot = built;
+    withoutWithdrawalsRoot.withdrawalsRoot = std::nullopt;
+    BOOST_CHECK(
+        !engine::detail::compareWithBuiltPayload(withoutWithdrawalsRoot, built).has_value());
+
+    auto alteredTransaction = built;
+    alteredTransaction.transactions[1].raw = bytes{0x02, 0x04};
+    BOOST_CHECK(!engine::detail::compareWithBuiltPayload(alteredTransaction, built).has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -268,6 +268,12 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
         # *uint64 without hexutil (op-service/eth/types.go:523, v1.19.3), so the mock
         # must put the same wire shape on the wire ("minBaseFee": 0).
         "minBaseFee": 0,
+        # Holocene Bytes8 wire shape: an 8-byte hex string, u32 BE denominator in
+        # [0:4] and u32 BE elasticity in [4:8] (op-service/eth/types.go:521,
+        # EIP1559Params *Bytes8, v1.19.3). All-zero means "SystemConfig has not set
+        # the params"; the EL translates 0,0 to the Canyon constants (250, 6) in the
+        # built extraData.
+        "eip1559Params": "0x0000000000000000",
     }
 
     fcu = rpc_result("engine_forkchoiceUpdatedV3", [fc_state, payload_attrs])

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -421,6 +421,62 @@ def run_v2_block_flow() -> None:
     _log_pass()
 
 
+def test_eip1559_fields_are_v3_only() -> None:
+    """eip1559Params / minBaseFee must be refused on a pre-Holocene FCU version.
+
+    op-node only ever puts these on a forkchoiceUpdatedV3: Config.ForkchoiceUpdatedVersion
+    (op-node/rollup/types.go:727-745, v1.19.3) answers FCUV3 from Ecotone onwards, FCUV2
+    for Canyon and FCUV1 before it, and there is no FCUV4 — while Holocene (eip1559Params)
+    and Jovian (minBaseFee) both activate after Ecotone. If a V1/V2 FCU carrying them were
+    accepted, the build would stamp Holocene/Jovian extraData on a pre-Holocene block and
+    a spec-conformant CL would reject the header on read-back ("extraData must be empty
+    before Holocene", op-core/eip1559/eip1559.go:27-28).
+
+    Attribute errors surface through the payloadStatus channel, not as a JSON-RPC error.
+    """
+    _log_test("eip1559Params / minBaseFee are rejected below forkchoiceUpdatedV3")
+
+    head_hash = get_head_hash()
+    fc_state = {
+        "headBlockHash": head_hash,
+        "safeBlockHash": head_hash,
+        "finalizedBlockHash": head_hash,
+    }
+
+    def v2_attrs(**extra: object) -> dict:
+        attrs = {
+            "timestamp": next_timestamp(),
+            "prevRandao": PREV_RANDAO,
+            "suggestedFeeRecipient": FEE_RECIPIENT,
+            "withdrawals": [],
+        }
+        attrs.update(extra)
+        return attrs
+
+    # Control: the same attributes without the two fields still build on V2, so a
+    # rejection below is attributable to the new gate and not to an unrelated V2 error.
+    control = rpc_result("engine_forkchoiceUpdatedV2", [fc_state, v2_attrs()])
+    if control["payloadStatus"]["status"] != "VALID" or not control.get("payloadId"):
+        _log_fail(f"control V2 FCU did not build a payload: {control}")
+        return
+
+    for field, value in (
+        ("eip1559Params", "0x000000fa00000006"),
+        ("minBaseFee", 0),
+    ):
+        fcu = rpc_result("engine_forkchoiceUpdatedV2", [fc_state, v2_attrs(**{field: value})])
+        status = fcu["payloadStatus"]["status"]
+        if status != "INVALID" or fcu.get("payloadId"):
+            _log_fail(
+                f"forkchoiceUpdatedV2 accepted {field}: status={status}, "
+                f"payloadId={fcu.get('payloadId')}"
+            )
+            return
+        _log_info(f"V2 + {field} -> INVALID ({fcu['payloadStatus'].get('validationError')})")
+
+    _log_pass()
+
+
 def test_attributes_gas_limit_is_ignored() -> None:
     """KNOWN GAP pin: payloadAttributes.gasLimit does not reach the built block.
 
@@ -580,10 +636,13 @@ def main() -> int:
         # 6. The pre-Karst surface is still live.
         run_v2_block_flow()
 
-        # 7. Known gap: attributes.gasLimit does not reach the built block.
+        # 7. Holocene/Jovian attribute fields are forkchoiceUpdatedV3-only.
+        test_eip1559_fields_are_v3_only()
+
+        # 8. Known gap: attributes.gasLimit does not reach the built block.
         test_attributes_gas_limit_is_ignored()
 
-        # 8. Error semantics.
+        # 9. Error semantics.
         test_negative_cases()
 
     except requests.ConnectionError:

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -477,6 +477,72 @@ def test_eip1559_fields_are_v3_only() -> None:
     _log_pass()
 
 
+def test_new_payload_rejects_tampered_extra_data() -> None:
+    """newPayload must not wave through a payload whose extraData was altered.
+
+    extraData is a block-hash input from this change onwards, so a CL returning a
+    payload under the blockHash it was handed must return the same extraData. op-geth
+    catches this by re-deriving the block hash from the payload fields it received
+    (beacon/engine/types.go:287-288); this node cannot re-derive an Ethereum block hash,
+    so it compares against the payload it handed out. A malformed shape is rejected too,
+    mirroring op-geth's header verification (consensus/beacon/consensus.go:240-243).
+    """
+    _log_test("newPayload rejects altered / malformed extraData")
+
+    head_hash = get_head_hash()
+    fc_state = {
+        "headBlockHash": head_hash,
+        "safeBlockHash": head_hash,
+        "finalizedBlockHash": head_hash,
+    }
+    attrs = {
+        "timestamp": next_timestamp(),
+        "prevRandao": PREV_RANDAO,
+        "suggestedFeeRecipient": FEE_RECIPIENT,
+        "withdrawals": [],
+        "parentBeaconBlockRoot": ZERO_HASH,
+        "noTxPool": True,
+        "minBaseFee": 0,
+        "eip1559Params": "0x0000000000000000",
+    }
+
+    fcu = rpc_result("engine_forkchoiceUpdatedV3", [fc_state, attrs])
+    payload_id = fcu.get("payloadId")
+    if not payload_id:
+        _log_fail(f"FCU built no payload: {fcu}")
+        return
+    payload = rpc_result("engine_getPayloadV3", [payload_id])["executionPayload"]
+
+    # The build must have stamped the 17-byte Jovian form (0,0 -> Canyon 250/6).
+    if payload["extraData"].lower() != "0x01000000fa000000060000000000000000":
+        _log_fail(f"built extraData is not the Jovian vector: {payload['extraData']}")
+        return
+
+    for label, extra_data in (
+        # Same shape, different minBaseFee byte: this is the built-payload comparison.
+        ("altered", "0x01000000fa000000060000000000000009"),
+        # 17 bytes carrying the Holocene version byte: this is the shape gate.
+        ("malformed", "0x00000000fa000000060000000000000000"),
+        # Zero denominator/elasticity is illegal on a header (legal only in attributes).
+        ("zero-params", "0x010000000000000000" + "00" * 8),
+    ):
+        tampered = dict(payload, extraData=extra_data)
+        status = rpc_result("engine_newPayloadV3", [tampered, [], ZERO_HASH])
+        if status["status"] == "VALID":
+            _log_fail(f"newPayload accepted {label} extraData {extra_data}")
+            return
+        _log_info(f"{label} -> {status['status']} ({status.get('validationError')})")
+
+    # Control: the untouched payload still commits, so the checks above are not simply
+    # rejecting everything.
+    status = rpc_result("engine_newPayloadV3", [payload, [], ZERO_HASH])
+    if status["status"] != "VALID":
+        _log_fail(f"newPayload rejected the untouched payload it built: {status}")
+        return
+    _log_info("untouched payload -> VALID")
+    _log_pass()
+
+
 def test_attributes_gas_limit_is_ignored() -> None:
     """KNOWN GAP pin: payloadAttributes.gasLimit does not reach the built block.
 
@@ -639,10 +705,13 @@ def main() -> int:
         # 7. Holocene/Jovian attribute fields are forkchoiceUpdatedV3-only.
         test_eip1559_fields_are_v3_only()
 
-        # 8. Known gap: attributes.gasLimit does not reach the built block.
+        # 8. Commit-side extraData gates: altered / malformed shapes are not VALID.
+        test_new_payload_rejects_tampered_extra_data()
+
+        # 9. Known gap: attributes.gasLimit does not reach the built block.
         test_attributes_gas_limit_is_ignored()
 
-        # 9. Error semantics.
+        # 10. Error semantics.
         test_negative_cases()
 
     except requests.ConnectionError:


### PR DESCRIPTION
## What

Engine-built payloads and their persisted headers now carry the OP Stack extraData that op-node validates on every L2 block header from Holocene onwards:

- attributes carrying `eip1559Params` **and** `minBaseFee` produce the 17-byte Jovian form — version byte **0x01**, u32 BE EIP-1559 denominator, u32 BE elasticity, u64 BE minBaseFee;
- attributes carrying only `eip1559Params` produce the 9-byte Holocene form (version 0x00);
- neither field present leaves extraData empty (pre-Holocene behaviour, and the built-in single-node driver is unaffected).

All-zero `eip1559Params` translate to the chain's Canyon constants (250/6), matching op-node's consolidation rule (`op-node/rollup/attributes/engine_consolidate.go checkExtraDataParamsMatch`, cross-checked against kona's `attributes.rs`). The payload and the persisted header get identical bytes, stamped before `calculateHash`. The attributes validation gate rejects minBaseFee-without-params, mixed zero/non-zero params, and non-8-byte params.

## Why

Live smoke against op-node v1.19.3 (sequencer mode): once committed blocks became readable (#5445), op-node validated block 1's header and errored `Jovian extraData should be 17 bytes, got 0` — 447 retries per minute, chain stuck at block 1. The validator is `op-core/eip1559/eip1559.go:167-176` (`ValidateJovianExtraData`: exactly 17 bytes, version byte 0x01, non-zero denominator/elasticity), reached from both `op-node/rollup/derive/payload_util.go:129` (PayloadToSystemConfig on the parent block) and `engine_consolidate.go:124`. The encoder oracle is `EncodeJovianExtraData` (`eip1559.go:152-162`); the 9-byte Holocene form is `:74-83`. Wire shapes: `EIP1559Params *Bytes8` (8-byte hex string) and `MinBaseFee *uint64` (bare JSON number), `op-service/eth/types.go:521-523`.

## Impact containment

- Consensus/sealer paths never set header extraData (verified by a repo-wide caller inventory: the only other production `setExtraData` sites are the genesis build and the RLP bridge carry-over), so existing Tars header hashes are byte-for-byte unchanged.
- The transactions root does not include extraData; no storage schema is touched.

## Verification

- New `JovianExtraDataTest` (7 cases): byte-exact vector against the genesis fixture values (`0x01000000fa000000060000000000000000`), a second explicit-value vector with a >32-bit minBaseFee, the 9-byte Holocene form, the empty pre-Holocene form, and the three rejection paths. Plus an end-to-end engine case asserting the stamped extraData on a getPayload response in both forms. `test-bcos-engine` fully green; both touched .cpp files pass the standalone `-fsyntax-only` unity-leak check.
- Live re-run with this fix: **1048 blocks sealed continuously** (2s cadence after catch-up), `Jovian extraData` error count dropped from 480 to **0**; extraData spot-checked on blocks 1/5/10/900 (the latter carrying a deposit).
- The mock CL now sends `eip1559Params` in the real op-node wire shape, guarding against regression in CI.

## Notes

- Running against a real op-node also requires the bare-number `minBaseFee` parsing fix from #5442; the two PRs are code-independent (same base, no shared files) but were live-verified together.
- The genesis fixture's own 17-byte extraData uses version byte 0x00, which op-node never validates (only blocks >= 1 are checked) but does not match the 0x01 Jovian version byte; fixing it changes the genesis hash and is left to a follow-up on the eth-header lane.

## Review round 2 (commits 4-7)

Three reviewers converged on two blockers; both are fixed, along with three smaller findings.

**Version gating (blocking).** `eip1559Params` and `minBaseFee` were the only checks in `validatePayloadAttributes` that ignored the `version` argument, so a pre-Holocene forkchoiceUpdatedV1/V2 carrying them would have stamped Holocene extraData on a pre-Holocene build. Both fields are now rejected below V3. The exact threshold matters: `ForkchoiceUpdatedVersion` tops out at V3 (`op-node/rollup/types.go:727-745`; `op-service/eth/types.go:799-801` has no FCUV4 constant), and both Holocene and Jovian post-date Ecotone, so V3 is the only version that can legitimately carry either field — rejecting at `<= 3` would reject the version op-node actually uses. For the record, op-geth does not reject these fields structurally: all three FCU versions share one `PayloadAttributes` that carries them, and `checkOptimismPayloadAttributes` rejects by fork schedule with -38003.

**Commit-side validation (blocking).** The build side guaranteed byte-identical extraData between the payload and the header, but `newPayload` never checked extraData at all, and on a local-build hit the cached header was persisted without comparing it to what the CL submitted. Since this PR makes extraData part of the block hash, a CL returning an altered payload matters. `validateExecutionPayload` now checks the extraData shape (length, version byte, params), and a local-build hit compares the submitted payload against the one this node produced, answering INVALID on mismatch. op-geth reaches the same outcome differently — it recomputes the block hash from the payload fields (`beacon/engine/types.go:287-288` via `eth/catalyst/api.go:831`) and validates extraData during header verification (`consensus/beacon/consensus.go:240-243`) — which this service cannot yet do, so it validates shape and compares against its own build instead. Executing externally supplied payloads remains out of scope (#5468); the boundary is marked in code.

**Smaller findings.** `encodeOptimismExtraData` now rejects a wrongly sized `eip1559Params` at its entry rather than relying on callers having passed through validation — `std::span::first`/`subspan` past the end is a precondition violation (undefined behaviour), not a throwing operation. The end-to-end test now commits the payload and reads the persisted header back, asserting byte equality with the payload; it was checked against a negative control (with the `setExtraData` calls removed the case fails, so it is not a vacuous assertion). A latent bug found while re-reviewing — a factory handing out a reference to a stack object — is fixed here along with the two pre-existing sites of the same shape.

**Not changed:** the 0,0 -> Canyon-constants translation stays hard-coded at (250, 6). These are chain-level constants; exposing them as a per-node config key would let two nodes stamp different extraData at the same height and fork the block hash. They belong with the consensus-fixed genesis/SYS_CONFIG values, which means touching the genesis artifact — out of scope here, and the deployment constraint is now documented at the call site.

**Pre-existing issues noticed, not addressed here:** payload-cache routing keys off a substring match on an error message (`find("blockHash")`), which will misroute if another validation error ever contains that word; and `handleNewPayload` holds `x_state` across a `co_await`, contradicting the rule `updateForkchoice` documents for itself.
