### PR TITLE
feat(opstack): part 6/7 — web3 handlers pt2 + model (split from #5429)

### DIFF
--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -84,7 +84,8 @@ void JsonRpcImpl_2_0::handleRpcRequest(
     auto weakptrSession = std::weak_ptr<boostssl::ws::WsSession>(_session);
     auto messageFactory = m_wsService->messageFactory();
 
-    onRPCRequest(req, [ext, seq, version, weakptrSession, messageFactory, start](bcos::bytes resp, boost::beast::http::status) {
+    onRPCRequest(req, [ext, seq, version, weakptrSession, messageFactory, start](
+                          bcos::bytes resp, boost::beast::http::status) {
         auto session = weakptrSession.lock();
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -254,7 +255,9 @@ void bcos::rpc::toJsonResp(Json::Value& jResp, bcos::protocol::Transaction const
         codec::rlp::decodeFromPayload(extraBytesRef, web3Tx);
         jResp["value"] = web3Tx.value.str();
         jResp["gasLimit"] = web3Tx.gasLimit;
-        if (web3Tx.type >= TransactionType::EIP1559)
+        // Use explicit range check rather than `>=` so that Deposit (0x7e), which is numerically
+        // larger than all EIP types, is excluded from EIP-1559 field output.
+        if (web3Tx.type >= TransactionType::EIP1559 && web3Tx.type <= TransactionType::EIP4844)
         {
             jResp["maxPriorityFeePerGas"] = web3Tx.maxPriorityFeePerGas.str();
             jResp["maxFeePerGas"] = web3Tx.maxFeePerGas.str();

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -727,9 +727,11 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     auto rawTx = toView(request[0U]);
     auto rawTxBytes = fromHexWithPrefix(rawTx);
     auto bytesRef = bcos::ref(rawTxBytes);
-    // Authoritative first-byte dispatch (RawTransactionDispatch.h). L2 never admits blob
-    // (type-3) transactions, and deposits (0x7e) can only be injected by the consensus
-    // layer through the Engine API, never through the public transaction pool.
+    // Authoritative first-byte dispatch (RawTransactionDispatch.h). FISCO's OP policy rejects
+    // blob (type-3) at the gate — op-geth's decodeTyped accepts them, so this is a deliberate
+    // acceptance divergence, not a reference check (see the OpScheduler.h type-byte gate note).
+    // Deposits (0x7e) can only be injected by the consensus layer through the Engine API, never
+    // through the public transaction pool.
     switch (engine::dispatchRawTransaction(bytesRef))
     {
     case engine::RawTransactionKind::Blob:
@@ -745,6 +747,14 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     if (auto const error = codec::rlp::decode(bytesRef, web3Tx); error != nullptr) [[unlikely]]
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, error->errorMessage()));
+    }
+    // op-geth rejects Deposit (0x7e) from eth_sendRawTransaction
+    // (ErrTxTypeNotSupported); deposits only enter via the derivation/engine
+    // path, never from a client RPC submission.
+    if (web3Tx.type == TransactionType::Deposit) [[unlikely]]
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams,
+            "Deposit (0x7e) transactions are not supported via eth_sendRawTransaction"));
     }
     auto encodeTxHash = web3Tx.txHash();
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -2,9 +2,9 @@
 #include "Log.h"
 #include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
-#include <bcos-crypto/hash/Keccak256.h>
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-crypto/hash/Keccak256.h>
 #include <cstdint>
 
 void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::TransactionReceipt& receipt,
@@ -85,14 +85,49 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
         logs.push_back(std::move(logObj));
     }
     result["logsBloom"] = toHexStringWithPrefix(receipt.logsBloom());
+    // EIP-2718 tx type: for a Web3 tx the authoritative kind is the `web3TypedTxKind` tars slot,
+    // populated by Web3Transaction::takeToTarsTransaction for EVERY Web3 kind (Legacy=0,
+    // EIP-2930=1, EIP-1559=2, EIP-4844=3, Deposit=0x7e). Byte-sniffing extraTransactionBytes was
+    // wrong for typed non-deposit txs: the write side stores encodeForSign() there (RLP WITHOUT
+    // the type byte, first byte is a 0xC0+ list header), so the old `< BYTES_HEAD_BASE` sniff
+    // collapsed EIP-2930/1559/4844 receipts into Legacy 0x0 — while eth_getTransactionByHash
+    // correctly reported 0x01/0x02/0x03. For non-Web3 (BCOS) txs web3TypedTxKind() is 0 == Legacy,
+    // matching the old empty-extraTransactionBytes path.
     auto type = TransactionType::Legacy;
-    if (!tx.extraTransactionBytes().empty())
+    if (tx.type() == bcos::protocol::TransactionType::Web3Transaction)
     {
-        if (auto firstByte = tx.extraTransactionBytes()[0];
-            firstByte < bcos::codec::rlp::BYTES_HEAD_BASE)
-        {
-            type = static_cast<TransactionType>(firstByte);
-        }
+        type = static_cast<TransactionType>(tx.web3TypedTxKind());
     }
     result["type"] = toQuantity(static_cast<uint64_t>(type));
+    // OP extension fields (aligned with op-geth MarshalReceipt). Empty opStackMeta → no output
+    // (never zero/default values); each field is null-checked independently and never throws (D7).
+    if (auto meta = receipt.opStackMeta())
+    {
+        if (meta->l1_gas_price)
+            result["l1GasPrice"] = toQuantity(*meta->l1_gas_price);
+        if (meta->l1_gas_used)
+            result["l1GasUsed"] = toQuantity(*meta->l1_gas_used);
+        if (meta->l1_fee)
+            result["l1Fee"] = toQuantity(*meta->l1_fee);
+        if (meta->l1_blob_base_fee)
+            result["l1BlobBaseFee"] = toQuantity(*meta->l1_blob_base_fee);
+        if (meta->l1_base_fee_scalar)
+            result["l1BaseFeeScalar"] = toQuantity(*meta->l1_base_fee_scalar);
+        if (meta->l1_blob_base_fee_scalar)
+            result["l1BlobBaseFeeScalar"] = toQuantity(*meta->l1_blob_base_fee_scalar);
+        if (meta->operator_fee_scalar)
+            result["operatorFeeScalar"] = toQuantity(*meta->operator_fee_scalar);
+        if (meta->operator_fee_constant)
+            result["operatorFeeConstant"] = toQuantity(*meta->operator_fee_constant);
+        if (meta->da_footprint_gas_scalar)
+            result["daFootprintGasScalar"] = toQuantity(*meta->da_footprint_gas_scalar);
+        if (meta->da_footprint)
+            result["blobGasUsed"] = toQuantity(*meta->da_footprint);  // Jovian reuses da_footprint
+        if (meta->deposit_nonce)
+            result["depositNonce"] = toQuantity(*meta->deposit_nonce);
+        if (meta->deposit_receipt_version)
+            result["depositReceiptVersion"] = toQuantity(*meta->deposit_receipt_version);
+        if (meta->operator_fee)
+            result["operatorFee"] = toQuantity(*meta->operator_fee);  // FISCO extension
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -91,7 +91,9 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
         result["nonce"] = toQuantity(web3Tx.nonce);
         result["type"] = toQuantity(static_cast<uint8_t>(web3Tx.type));
         result["value"] = toQuantity(web3Tx.value);
-        if (web3Tx.type >= TransactionType::EIP2930)
+        // Use explicit range checks rather than `>=` so that Deposit (0x7e), which is numerically
+        // larger than all EIP types, is excluded from EIP-specific field output.
+        if (web3Tx.type >= TransactionType::EIP2930 && web3Tx.type <= TransactionType::EIP4844)
         {
             result["accessList"] = Json::arrayValue;
             result["accessList"].resize(web3Tx.accessList.size());
@@ -109,13 +111,13 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
                 result["accessList"].append(std::move(access));
             }
         }
-        if (web3Tx.type >= TransactionType::EIP1559)
+        if (web3Tx.type >= TransactionType::EIP1559 && web3Tx.type <= TransactionType::EIP4844)
         {
             result["maxPriorityFeePerGas"] = toQuantity(web3Tx.maxPriorityFeePerGas);
             result["maxFeePerGas"] = toQuantity(web3Tx.maxFeePerGas);
         }
         result["chainId"] = toQuantity(web3Tx.chainId.value_or(0));
-        if (web3Tx.type >= TransactionType::EIP4844)
+        if (web3Tx.type == TransactionType::EIP4844)
         {
             result["maxFeePerBlobGas"] = web3Tx.maxFeePerBlobGas.str();
             result["blobVersionedHashes"] = Json::arrayValue;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
@@ -19,101 +19,118 @@
  */
 
 #include "Web3Transaction.h"
+#include "Web3TxHandler.h"
 #include "bcos-utilities/Common.h"
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-framework/protocol/Transaction.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>  // bcos::fromBigEndian (checkEip2Signature reuse, review #5429 S)
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/move.hpp>
 #include <limits>
+#include <range/v3/algorithm/move.hpp>
 #include <utility>
 
 namespace bcos
 {
+namespace
+{
+// EIP-2 canonical-s guard. The secp256k1 group order n and its half. A signature with s > n/2 is
+// "malleable": flipping s -> n - s recovers the same sender and executes byte-for-byte
+// identically, so op-geth rejects it at both admission and block processing. Without this check a
+// mixed-deployment OP chain would silently fork.
+const u256 c_secp256k1n("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+const u256 c_secp256k1nOver2 = c_secp256k1n / 2;
+
+/// Returns a decode error if r/s fall outside EIP-2's valid range (r,s in [1, n-1], s <= n/2),
+/// else nullptr. r/s are the raw 32-byte big-endian scalars (already zero-padded by the handler).
+bcos::Error::UniquePtr checkEip2Signature(
+    bcos::bytes const& signatureR, bcos::bytes const& signatureS)
+{
+    // r/s are raw 32-byte big-endian scalars — decode in place instead of round-tripping through a
+    // "0x"+hex string + u256 parse (4 heap allocations per tx on the shared decode funnel).
+    const u256 r = bcos::fromBigEndian<u256>(signatureR);
+    const u256 s = bcos::fromBigEndian<u256>(signatureS);
+    if (r == 0 || r >= c_secp256k1n || s == 0 || s >= c_secp256k1n || s > c_secp256k1nOver2)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+            "EIP-2: invalid signature (r/s out of [1,n-1], or s exceeds secp256k1n/2 — "
+            "malleable signature)");
+    }
+    return nullptr;
+}
+}  // namespace
+
 namespace rpc
 {
+// These three using-declarations are NOT dead: they are the ADL bridge that lets the generic
+// codec templates (RLPEncode.h encodeItems/Common.h lengthOfItems/RLPDecode.h decodeItems) find
+// the AccessListEntry/Web3Transaction overloads defined at the bottom of this file. Those overloads
+// live in namespace codec::rlp, which is not an associated namespace of bcos::rpc::AccessListEntry;
+// without the using-declaration the unity build fails with "neither visible in the template
+// definition nor found by argument-dependent lookup". Keep the three in sync with the overloads.
 using codec::rlp::decode;
 using codec::rlp::encode;
-using codec::rlp::header;
 using codec::rlp::length;
-
-static bytesConstRef getSignatureRef(bytesConstRef input)
-{
-    const auto* it = ::ranges::find_if(input, [](byte b) { return b != 0; });
-    return {it, input.size() - (it - input.begin())};
-}
 
 bcos::bytes Web3Transaction::encodeForSign() const
 {
-    bcos::bytes out;
-    if (type == TransactionType::Legacy)
+    // Delegate to handler: signing preimage (RLP without type byte, without signature)
+    return handlerFor(type).encodeForSign(*this);
+}
+
+bcos::bytes Web3Transaction::encode() const
+{
+    // Full RLP (with type byte, typed transaction)
+    return handlerFor(type).encode(*this);
+}
+
+bcos::Error::UniquePtr Web3Transaction::decode(bcos::bytesRef& in, bool withSig)
+{
+    if (in.empty())
     {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data])
-        codec::rlp::encodeHeader(out, codec::rlp::headerForSign(*this));
-        codec::rlp::encode(out, nonce);
-        // for legacy tx, it means gas price
-        codec::rlp::encode(out, maxFeePerGas);
-        codec::rlp::encode(out, gasLimit);
-        if (to.has_value())
-        {
-            codec::rlp::encode(out, to.value().ref());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        codec::rlp::encode(out, value);
-        codec::rlp::encode(out, data);
-        if (chainId)
-        {
-            // EIP-155
-            codec::rlp::encode(out, chainId.value());
-            codec::rlp::encode(out, 0U);
-            codec::rlp::encode(out, 0U);
-        }
+        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InputTooShort, "Input too short");
+    }
+    const auto firstByte = in[0];
+    // A valid transaction body is always an RLP list (≥0xC0). Use >= LIST_HEAD_BASE rather than
+    // >= BYTES_HEAD_BASE: the latter would misclassify 0x80-0xBF short-string headers as Legacy.
+    // A typed tx's type byte (0x01-0x04) is below 0xC0 and goes through the enum_cast dispatch
+    // below.
+    if (firstByte >= codec::rlp::LIST_HEAD_BASE)
+    {
+        // Legacy: no type byte
+        type = TransactionType::Legacy;
     }
     else
     {
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes])
-        out.push_back(static_cast<byte>(type));
-        codec::rlp::encodeHeader(out, codec::rlp::headerForSign(*this));
-        codec::rlp::encode(out, chainId.value_or(0));
-        codec::rlp::encode(out, nonce);
-        if (type != TransactionType::EIP2930)
+        auto txType = magic_enum::enum_cast<TransactionType>(firstByte);
+        if (!txType.has_value())
         {
-            codec::rlp::encode(out, maxPriorityFeePerGas);
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
         }
-        // for EIP2930 it means gasPrice; for EIP1559 and EIP4844, it means max priority fee per gas
-        codec::rlp::encode(out, maxFeePerGas);
-        codec::rlp::encode(out, gasLimit);
-        if (to.has_value())
-        {
-            codec::rlp::encode(out, to.value().ref());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        codec::rlp::encode(out, value);
-        codec::rlp::encode(out, data);
-        codec::rlp::encode(out, accessList);
-        if (type == TransactionType::EIP4844)
-        {
-            codec::rlp::encode(out, maxFeePerBlobGas);
-            codec::rlp::encode(out, blobVersionedHashes);
-        }
-        if (type == TransactionType::EIP7702)
-        {
-            codec::rlp::encode(out, authorizationList);
-        }
+        type = txType.value();
     }
-    return out;
+    // ⚠️ Do not pre-strip the type byte: the typed handler consumes the envelope itself (see the
+    // Web3TxHandler.h decode contract); stripping it again here would skip the list header a second
+    // time and fail every typed tx decode.
+    auto err = handlerFor(type).decode(in, *this, withSig);
+    if (err == nullptr && !in.empty())
+    {
+        return BCOS_ERROR_UNIQUE_PTR(
+            codec::rlp::DecodingError::InputTooLong, "Trailing bytes after RLP list");
+    }
+    // EIP-2: reject malleable (high-s) signatures at decode time. This member is the shared funnel
+    // for BOTH OP paths — eth_sendRawTransaction (EthEndpoint.cpp) and engine newPayload
+    // (opEnvelopeToTars) — so the check covers admission AND block processing, matching op-geth.
+    // Deposits (0x7e) are unsigned; the EIP-7702 authorization entries are gated separately
+    // (Eip7702Recover.h) and left untouched here.
+    if (err == nullptr && withSig && type != TransactionType::Deposit)
+    {
+        err = checkEip2Signature(signatureR, signatureS);
+    }
+    return err;
 }
 
 bcos::crypto::HashType Web3Transaction::txHash() const
@@ -131,6 +148,32 @@ bcos::crypto::HashType Web3Transaction::hashForSign() const
 
 bcostars::Transaction Web3Transaction::takeToTarsTransaction()
 {
+    if (type == TransactionType::Deposit)
+    {
+        bcostars::Transaction tarsTx{};
+        tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+        tarsTx.web3TypedTxKind =
+            static_cast<tars::Char>(static_cast<uint8_t>(TransactionType::Deposit));
+        tarsTx.sourceHash = sourceHash.hex();
+        tarsTx.sender.assign(from.begin(), from.end());
+        // 0x-prefixed, matching the read side u256(...) (parsed in TransactionImpl.cpp mint())
+        tarsTx.mint = "0x" + mint.str(0, std::ios_base::hex);
+        tarsTx.isSystemTransaction = isSystemTx ? 1 : 0;
+        // Full 0x7E envelope (encode()). extraTransactionHash is NOT filled here — the
+        // canonical txHash path (TransactionImpl::calculateHash) does not yet handle 0x7e;
+        // deposits are unsigned and rejected at eth_sendRawTransaction (see EthEndpoint.cpp).
+        auto encoded = encode();
+        tarsTx.extraTransactionBytes.reserve(encoded.size());
+        ::ranges::move(encoded, std::back_inserter(tarsTx.extraTransactionBytes));
+        // Generic fields (so consumers on the tars generic read path don't see empty values)
+        tarsTx.data.to = to.has_value() ? to->hexPrefixed() : "";
+        tarsTx.data.input.assign(data.begin(), data.end());
+        tarsTx.data.value = "0x" + value.str(0, std::ios_base::hex);
+        tarsTx.data.gasLimit = gasLimit;
+        tarsTx.data.nonce = "0x0";  // deposit nonce is always 0
+        tarsTx.data.chainID = "0";
+        return tarsTx;
+    }
     bcostars::Transaction tarsTx{};
     tarsTx.data.to = (this->to.has_value()) ? this->to.value().hexPrefixed() : "";
     tarsTx.data.input.reserve(this->data.size());
@@ -138,7 +181,10 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
 
     tarsTx.data.value = "0x" + this->value.str(0, std::ios_base::hex);
     tarsTx.data.gasLimit = this->gasLimit;
-    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559))
+    // Use explicit range check rather than `>=` so that Deposit (0x7e) is excluded;
+    // EIP7702 is fee-market (maxFeePerGas/maxPriorityFeePerGas) so it is included
+    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559) &&
+        static_cast<uint8_t>(this->type) <= static_cast<uint8_t>(TransactionType::EIP7702))
     {
         tarsTx.data.maxFeePerGas = "0x" + this->maxFeePerGas.str(0, std::ios_base::hex);
         tarsTx.data.maxPriorityFeePerGas =
@@ -194,10 +240,10 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
             // entry must still be KEPT in the list: a set_code transaction with an empty
             // authorization list is rejected by the executor, and dropping it would change
             // the signing hash.
-            tarsEntry.chainID = static_cast<int64_t>(
-                entry.chainId > std::numeric_limits<uint64_t>::max() ?
-                    UINT64_MAX :
-                    static_cast<uint64_t>(entry.chainId));
+            tarsEntry.chainID =
+                static_cast<int64_t>(entry.chainId > std::numeric_limits<uint64_t>::max() ?
+                                         UINT64_MAX :
+                                         static_cast<uint64_t>(entry.chainId));
             tarsEntry.address = entry.address.hex();  // 40-char hex, no 0x prefix
             tarsEntry.nonce = static_cast<int64_t>(entry.nonce);
             tarsEntry.v = static_cast<tars::Char>(entry.yParity);
@@ -240,6 +286,9 @@ uint64_t Web3Transaction::getSignatureV() const
 }
 std::string Web3Transaction::sender() const
 {
+    // deposit (0x7e): unsigned, so sender is taken directly from the from field
+    if (type == TransactionType::Deposit)
+        return toHexStringWithPrefix(from);
     bcos::bytes sign{};
     sign.reserve(crypto::SECP256K1_SIGNATURE_LEN);
     sign.insert(sign.end(), signatureR.begin(), signatureR.end());
@@ -274,185 +323,20 @@ std::string Web3Transaction::toString() const noexcept
 namespace codec::rlp
 {
 using namespace bcos::rpc;
-Header header(const AccessListEntry& entry) noexcept
-{
-    auto len = length(entry.storageKeys);
-    return {.isList = true, .payloadLength = Address::SIZE + 1 + len};
-}
-
-size_t length(AccessListEntry const& entry) noexcept
-{
-    auto head = header(entry);
-    return lengthOfLength(head.payloadLength) + head.payloadLength;
-}
-
-Header header(const AuthorizationListEntry& entry) noexcept
-{
-    auto len = codec::rlp::length(entry.chainId) + Address::SIZE + 1 +
-               codec::rlp::length(entry.nonce) +
-               codec::rlp::length(static_cast<uint64_t>(entry.yParity)) +
-               codec::rlp::length(entry.r) + codec::rlp::length(entry.s);
-    return {.isList = true, .payloadLength = len};
-}
-
-size_t length(AuthorizationListEntry const& entry) noexcept
-{
-    auto head = header(entry);
-    return lengthOfLength(head.payloadLength) + head.payloadLength;
-}
-
-void encode(bcos::bytes& out, const AuthorizationListEntry& entry) noexcept
-{
-    encodeHeader(out, header(entry));
-    encode(out, entry.chainId);
-    encode(out, entry.address.ref());
-    encode(out, entry.nonce);
-    encode(out, static_cast<uint64_t>(entry.yParity));
-    encode(out, entry.r);
-    encode(out, entry.s);
-}
-Header headerTxBase(const Web3Transaction& tx) noexcept
-{
-    Header h{.isList = true};
-
-    if (tx.type != TransactionType::Legacy)
-    {
-        h.payloadLength += length(tx.chainId.value_or(0));
-    }
-
-    h.payloadLength += length(tx.nonce);
-    if (tx.type == TransactionType::EIP1559 || tx.type == TransactionType::EIP4844 ||
-        tx.type == TransactionType::EIP7702)
-    {
-        h.payloadLength += length(tx.maxPriorityFeePerGas);
-    }
-    h.payloadLength += length(tx.maxFeePerGas);
-    h.payloadLength += length(tx.gasLimit);
-    h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
-    h.payloadLength += length(tx.value);
-    h.payloadLength += length(tx.data);
-
-    if (tx.type != TransactionType::Legacy)
-    {
-        h.payloadLength += codec::rlp::length(tx.accessList);
-        if (tx.type == TransactionType::EIP4844)
-        {
-            h.payloadLength += length(tx.maxFeePerBlobGas);
-            h.payloadLength += length(tx.blobVersionedHashes);
-        }
-        if (tx.type == TransactionType::EIP7702)
-        {
-            h.payloadLength += codec::rlp::length(tx.authorizationList);
-        }
-    }
-
-    return h;
-}
-Header header(Web3Transaction const& tx) noexcept
-{
-    auto header = headerTxBase(tx);
-    header.payloadLength += (tx.type == TransactionType::Legacy) ? length(tx.getSignatureV()) : 1;
-    header.payloadLength += length(getSignatureRef(ref(tx.signatureR)));
-    header.payloadLength += length(getSignatureRef(ref(tx.signatureS)));
-    return header;
-}
-Header headerForSign(Web3Transaction const& tx) noexcept
-{
-    auto header = headerTxBase(tx);
-    if (tx.type == TransactionType::Legacy && tx.chainId)
-    {
-        header.payloadLength += length(tx.chainId.value()) + 2;
-    }
-    return header;
-}
 size_t length(Web3Transaction const& tx) noexcept
 {
-    auto head = header(tx);
+    auto head = handlerFor(tx.type).header(tx);
     auto len = lengthOfLength(head.payloadLength) + head.payloadLength;
     len = (tx.type == TransactionType::Legacy) ? len : lengthOfLength(len + 1) + len + 1;
     return len;
 }
-void encode(bcos::bytes& out, const AccessListEntry& entry) noexcept
-{
-    encodeHeader(out, header(entry));
-    encode(out, entry.account.ref());
-    encode(out, entry.storageKeys);
-}
 void encode(bcos::bytes& out, const Web3Transaction& tx) noexcept
 {
-    if (tx.type == TransactionType::Legacy)
-    {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
-        encodeHeader(out, header(tx));
-        encode(out, tx.nonce);
-        // for legacy tx, it means gas price
-        encode(out, tx.maxFeePerGas);
-        encode(out, tx.gasLimit);
-        if (tx.to.has_value())
-        {
-            encode(out, tx.to.value());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        encode(out, tx.value);
-        encode(out, tx.data);
-        encode(out, tx.getSignatureV());
-        encode(out, getSignatureRef(ref(tx.signatureR)));
-        encode(out, getSignatureRef(ref(tx.signatureS)));
-    }
-    else
-    {
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
-        // signatureYParity, signatureR, signatureS])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
-        // signature_s])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
-        // signature_y_parity, signature_r, signature_s])
-        out.push_back(static_cast<bcos::byte>(tx.type));
-        encodeHeader(out, header(tx));
-        encode(out, tx.chainId.value_or(0));
-        encode(out, tx.nonce);
-        if (tx.type != TransactionType::EIP2930)
-        {
-            encode(out, tx.maxPriorityFeePerGas);
-        }
-        // for EIP2930 it means gasPrice; for EIP1559 and EIP4844, it means max priority fee per gas
-        encode(out, tx.maxFeePerGas);
-        encode(out, tx.gasLimit);
-        if (tx.to.has_value())
-        {
-            encode(out, tx.to.value());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        encode(out, tx.value);
-        encode(out, tx.data);
-        encode(out, tx.accessList);
-        if (tx.type == TransactionType::EIP4844)
-        {
-            encode(out, tx.maxFeePerBlobGas);
-            encode(out, tx.blobVersionedHashes);
-        }
-        if (tx.type == TransactionType::EIP7702)
-        {
-            encode(out, tx.authorizationList);
-        }
-        encode(out, tx.signatureV);
-        encode(out, getSignatureRef(ref(tx.signatureR)));
-        encode(out, getSignatureRef(ref(tx.signatureS)));
-    }
-}
-bcos::Error::UniquePtr decode(bcos::bytesRef& in, AccessListEntry& out) noexcept
-{
-    return decode(in, out.account, out.storageKeys);
+    // Delegate to the handler. Move the returned vector into `out` to avoid a double allocation:
+    // the handler already reserves internally and returns a complete buffer; copying it into out
+    // would allocate a second time. Callers pass an empty `out` (the previous append semantics
+    // matched move for the empty case), so move-assign preserves compatibility.
+    out = handlerFor(tx.type).encode(tx);
 }
 
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, AuthorizationListEntry& out) noexcept
@@ -502,210 +386,21 @@ bcos::Error::UniquePtr decode(bcos::bytesRef& in, AuthorizationListEntry& out) n
 }
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, Web3Transaction& out) noexcept
 {
-    return decodeTransaction(in, out, true);
+    return out.decode(in, true);
 }
 
 bcos::Error::UniquePtr decodeFromPayload(bcos::bytesRef& in, rpc::Web3Transaction& out) noexcept
 {
-    return decodeTransaction(in, out, false);
+    return out.decode(in, false);
 }
 
 bcos::Error::UniquePtr decodeTransaction(
     bcos::bytesRef& in, rpc::Web3Transaction& out, bool withSignature) noexcept
 {
-    if (in.empty())
-    {
-        return BCOS_ERROR_UNIQUE_PTR(InputTooShort, "Input too short");
-    }
-    Error::UniquePtr decodeError = nullptr;
-    if (auto const& firstByte = in[0]; 0 < firstByte && firstByte < BYTES_HEAD_BASE)
-    {
-        // EIP-2718: Transaction Type
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
-        // signatureYParity, signatureR, signatureS])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
-        // signature_s])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
-        // signature_y_parity, signature_r, signature_s])
-
-        const auto txType = magic_enum::enum_cast<TransactionType>(firstByte);
-        if (!txType.has_value())
-        {
-            return BCOS_ERROR_UNIQUE_PTR(
-                DecodingError::UnsupportedTransactionType, "Unsupported transaction type");
-        }
-        out.type = txType.value();
-        in = in.getCroppedData(1);
-        auto&& [e, header] = decodeHeader(in);
-        if (e != nullptr)
-        {
-            return std::move(e);
-        }
-        if (!header.isList)
-        {
-            return BCOS_ERROR_UNIQUE_PTR(UnexpectedString, "Unexpected String");
-        }
-        uint64_t chainId = 0;
-        if (auto error = decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
-            error != nullptr)
-        {
-            return error;
-        }
-        out.chainId.emplace(chainId);
-        if (out.type == TransactionType::EIP2930)
-        {
-            out.maxFeePerGas = out.maxPriorityFeePerGas;
-        }
-        else if (auto error = decode(in, out.maxFeePerGas); error != nullptr)
-        {
-            return error;
-        }
-
-        if (auto error = decode(in, out.gasLimit); error != nullptr)
-        {
-            return error;
-        }
-
-        if (in[0] == BYTES_HEAD_BASE)
-        {
-            out.to = std::nullopt;
-            in = in.getCroppedData(1);
-        }
-        else
-        {
-            Address addr{};
-            if (auto error = decode(in, addr); error != nullptr)
-            {
-                return error;
-            }
-            out.to.emplace(addr);
-        }
-
-        if (auto error = decodeItems(in, out.value, out.data, out.accessList); error != nullptr)
-        {
-            return error;
-        }
-
-        if (out.type == TransactionType::EIP4844)
-        {
-            if (auto error = decodeItems(in, out.maxFeePerBlobGas, out.blobVersionedHashes);
-                error != nullptr)
-            {
-                return error;
-            }
-        }
-        if (out.type == TransactionType::EIP7702)
-        {
-            if (auto error = decode(in, out.authorizationList); error != nullptr)
-            {
-                return error;
-            }
-        }
-        if (withSignature)
-        {
-            decodeError = decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
-        }
-    }
-    else
-    {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
-        auto&& [error, header] = decodeHeader(in);
-        if (error != nullptr)
-        {
-            return std::move(error);
-        }
-        if (!header.isList)
-        {
-            return BCOS_ERROR_UNIQUE_PTR(UnexpectedList, "Unexpected list");
-        }
-        out.type = TransactionType::Legacy;
-        if (decodeError = decodeItems(in, out.nonce, out.maxPriorityFeePerGas);
-            decodeError != nullptr)
-        {
-            return decodeError;
-        }
-        out.maxFeePerGas = out.maxPriorityFeePerGas;
-
-        if (decodeError = decode(in, out.gasLimit); decodeError != nullptr)
-        {
-            return decodeError;
-        }
-
-        if (in[0] == BYTES_HEAD_BASE)
-        {
-            out.to = std::nullopt;
-            in = in.getCroppedData(1);
-        }
-        else
-        {
-            Address addr{};
-            if (decodeError = decode(in, addr); decodeError != nullptr)
-            {
-                return decodeError;
-            }
-            out.to.emplace(addr);
-        }
-
-        decodeError = decodeItems(in, out.value, out.data);
-        if (withSignature)
-        {
-            if (decodeError = decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
-                decodeError != nullptr)
-            {
-                return decodeError;
-            }
-            // TODO: EIP-155 chainId decode from encoded bytes for sign
-            auto v = out.signatureV;
-            if (v == 27 || v == 28)
-            {
-                // pre EIP-155
-                out.chainId = std::nullopt;
-                out.signatureV = v - 27;
-            }
-            else if (v == 0 || v == 1)
-            {
-                out.chainId = std::nullopt;
-                return decodeError;
-            }
-            else if (v < 35)
-            {
-                return BCOS_ERROR_UNIQUE_PTR(InvalidVInSignature, "Invalid V in signature");
-            }
-            else
-            {
-                // https://eips.ethereum.org/EIPS/eip-155
-                // Find chain_id and y_parity ∈ {0, 1} such that
-                // v = chain_id * 2 + 35 + y_parity
-                out.signatureV = (v - 35) % 2;
-                out.chainId = ((v - 35) >> 1);
-            }
-        }
-        else
-        {
-            uint64_t chainId = 0;
-            decodeError = decode(in, chainId);
-            out.chainId.emplace(chainId);
-        }
-    }
-    if (withSignature)
-    {
-        // rehandle signature and chainId
-        if (out.signatureR.size() < crypto::SECP256K1_SIGNATURE_R_LEN)
-        {
-            out.signatureR.insert(out.signatureR.begin(),
-                crypto::SECP256K1_SIGNATURE_R_LEN - out.signatureR.size(), 0);
-        }
-        if (out.signatureS.size() < crypto::SECP256K1_SIGNATURE_S_LEN)
-        {
-            out.signatureS.insert(out.signatureS.begin(),
-                crypto::SECP256K1_SIGNATURE_S_LEN - out.signatureS.size(), bcos::byte(0));
-        }
-    }
-    return decodeError;
+    // Kept as the entry point (the call target of decodeOpEnvelope/decodeOpEnvelopeWithSig,
+    // EthEndpoint.cpp:73); it now delegates to the member function so the new handler dispatch
+    // path is used.
+    return out.decode(in, withSignature);
 }
 }  // namespace codec::rlp
 }  // namespace bcos

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.h
@@ -39,10 +39,11 @@ namespace rpc
 enum class TransactionType : uint8_t
 {
     Legacy = 0,
-    EIP2930 = 1,  // https://eips.ethereum.org/EIPS/eip-2930
-    EIP1559 = 2,  // https://eips.ethereum.org/EIPS/eip-1559
-    EIP4844 = 3,  // https://eips.ethereum.org/EIPS/eip-4844
-    EIP7702 = 4,  // https://eips.ethereum.org/EIPS/eip-7702
+    EIP2930 = 1,     // https://eips.ethereum.org/EIPS/eip-2930
+    EIP1559 = 2,     // https://eips.ethereum.org/EIPS/eip-1559
+    EIP4844 = 3,     // https://eips.ethereum.org/EIPS/eip-4844
+    EIP7702 = 4,     // https://eips.ethereum.org/EIPS/eip-7702
+    Deposit = 0x7e,  // deposit-only system tx (OP Stack)
 };
 
 constexpr auto operator<=>(TransactionType const& ltype, auto rtype)
@@ -78,11 +79,11 @@ struct AuthorizationListEntry
     uint8_t yParity{0};
     u256 r{0};
     u256 s{0};
-    friend bool operator==(const AuthorizationListEntry& lhs, const AuthorizationListEntry& rhs) noexcept
+    friend bool operator==(
+        const AuthorizationListEntry& lhs, const AuthorizationListEntry& rhs) noexcept
     {
-        return lhs.chainId == rhs.chainId && lhs.address == rhs.address &&
-               lhs.nonce == rhs.nonce && lhs.yParity == rhs.yParity && lhs.r == rhs.r &&
-               lhs.s == rhs.s;
+        return lhs.chainId == rhs.chainId && lhs.address == rhs.address && lhs.nonce == rhs.nonce &&
+               lhs.yParity == rhs.yParity && lhs.r == rhs.r && lhs.s == rhs.s;
     }
 };
 
@@ -98,6 +99,10 @@ public:
 
     // encode for sign, rlp(tx_payload)
     bcos::bytes encodeForSign() const;
+    // full RLP (with type byte) — delegates to handlerFor(type).encode
+    bcos::bytes encode() const;
+    // Decode — delegates to handlerFor(type).decode, propagating decode errors
+    bcos::Error::UniquePtr decode(bcos::bytesRef& in, bool withSig = true);
     // tx hash = keccak256(rlp(tx_payload,v,r,s))
     bcos::crypto::HashType txHash() const;
     // hash for sign = keccak256(rlp(tx_payload))
@@ -122,6 +127,11 @@ public:
     // EIP-4844: Shard Blob Transactions
     u256 maxFeePerBlobGas{0};
     h256s blobVersionedHashes;
+    // deposit-only (0x7e)
+    h256 sourceHash;
+    Address from;
+    u256 mint{0};
+    bool isSystemTx{false};
     // TODO)) blob
     // EIP-7702: Set Code Transactions (Prague+)
     std::vector<AuthorizationListEntry> authorizationList;
@@ -141,9 +151,6 @@ void encode(bcos::bytes& out, const rpc::AuthorizationListEntry&) noexcept;
 size_t length(const rpc::AuthorizationListEntry&) noexcept;
 
 size_t length(const rpc::Web3Transaction&) noexcept;
-Header headerForSign(const rpc::Web3Transaction& tx) noexcept;
-Header headerTxBase(const rpc::Web3Transaction& tx) noexcept;
-Header header(const rpc::Web3Transaction& tx) noexcept;
 void encode(bcos::bytes& out, const rpc::Web3Transaction&) noexcept;
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, rpc::AccessListEntry&) noexcept;
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, rpc::AuthorizationListEntry&) noexcept;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
@@ -608,5 +608,619 @@ struct EIP1559TxHandler : Web3TxHandler
     }
 };
 
+struct DepositTxHandler : Web3TxHandler
+{
+    // Full RLP: 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])
+    // — self-contained inline (consistent with the other typed handlers in this file); the 8-field
+    // unsigned layout's field order/types verified against op-geth DepositTx; field-by-field
+    // layout and to-nilability behaviour cross-checked against op-geth's deposit encoding.
+    // `to` nilability changes the RLP shape (empty string vs 20-byte address),
+    // so the contract-creation branch must be encoded separately.
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::Deposit));
+        // isSystemTransaction uses uint32_t (not uint8_t): RLPEncode.h's uint8_t generic scalar
+        // encoding odr-uses the non-template toCompactBigEndian(byte, unsigned) overload, whose
+        // only definition lives in DataConvertUtility.cpp rather than a header (a pre-existing
+        // bcos-utilities header/library boundary defect); uint32_t only matches in-header
+        // templates and produces identical bytes.
+        const uint32_t isSystemTransactionByte = tx.isSystemTx ? 1 : 0;
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.sourceHash, tx.from, *tx.to, tx.mint, tx.value, tx.gasLimit,
+                isSystemTransactionByte, tx.data);
+        }
+        else
+        {
+            codec::rlp::encode(out, tx.sourceHash, tx.from, bcos::bytesConstRef{}, tx.mint,
+                tx.value, tx.gasLimit, isSystemTransactionByte, tx.data);
+        }
+        return out;
+    }
+
+    // deposit has no signature: the signing preimage is the full envelope (aligned with
+    // op-geth DepositTx.SigningHash, used for extraTransactionBytes).
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override { return encode(tx); }
+
+    // RLP header (length computation): sum of the 8 field lengths (excluding the type byte —
+    // consistent with the other typed handlers).
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.sourceHash);  // h256
+        h.payloadLength += codec::rlp::length(tx.from);        // Address
+        // to (optional Address): empty string 0x80 takes 1 byte, or 20-byte address + 1-byte length
+        // header
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.mint);      // u256
+        h.payloadLength += codec::rlp::length(tx.value);     // u256
+        h.payloadLength += codec::rlp::length(tx.gasLimit);  // uint64
+        h.payloadLength += 1;  // isSystemTransaction (0x80 empty string or 0x01)
+        h.payloadLength += codec::rlp::length(tx.data);  // bytes
+        return h;
+    }
+
+    // Decode: 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])
+    // ⚠️ decode contract: typed handler is self-contained (consumes the type byte + list header
+    // itself); the dispatcher (Web3Transaction::decode) does not trim the type byte first.
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool /*withSig*/) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::Deposit))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::Deposit;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "deposit: expected RLP list");
+        }
+        // Check and propagate errors on every field decode (must not swallow silently)
+        if (auto err = codec::rlp::decode(in, out.sourceHash); err != nullptr)
+            return err;  // h256
+        if (auto err = codec::rlp::decode(in, out.from); err != nullptr)
+            return err;  // Address
+        // to (optional Address; empty string 0x80 = nullopt contract creation)
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto err = codec::rlp::decode(in, addr); err != nullptr)
+                return err;
+            out.to.emplace(addr);
+        }
+        if (auto err = codec::rlp::decode(in, out.mint); err != nullptr)
+            return err;  // u256
+        if (auto err = codec::rlp::decode(in, out.value); err != nullptr)
+            return err;  // u256
+        if (auto err = codec::rlp::decode(in, out.gasLimit); err != nullptr)
+            return err;  // uint64
+        // ⚠️ isSystemTransaction cannot use codec::rlp::decode(bool) (RLPDecode.h:200-217
+        // requires payloadLength==1 and would report UnexpectedLength for the golden 0x80 empty
+        // string). Byte semantics are required: empty string 0x80 → false (op-geth RLP nil);
+        // single byte 0x01 → true; anything else is an error.
+        {
+            bcos::bytes raw{};
+            if (auto err = codec::rlp::decode(in, raw); err != nullptr)
+                return err;
+            if (raw.empty())
+            {
+                out.isSystemTx = false;
+            }
+            else if (raw.size() == 1 && raw[0] == 1)
+            {
+                out.isSystemTx = true;
+            }
+            else
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedLength,
+                    "deposit: invalid isSystemTransaction value");
+            }
+        }
+        if (auto err = codec::rlp::decode(in, out.data); err != nullptr)
+            return err;  // bytes
+        out.nonce = 0;   // deposit nonce is always 0
+        return nullptr;
+    }
+};
+
+struct EIP4844TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerBlobGas);
+        h.payloadLength += codec::rlp::length(tx.blobVersionedHashes);
+        return h;
+    }
+
+    // Signing preimage: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP4844));
+        codec::rlp::encodeHeader(out, headerTxBase(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.maxFeePerBlobGas);
+        codec::rlp::encode(out, tx.blobVersionedHashes);
+        return out;
+    }
+
+    // Full RLP: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
+    // signature_y_parity, signature_r, signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP4844));
+        codec::rlp::encodeHeader(out, header(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.maxFeePerBlobGas);
+        codec::rlp::encode(out, tx.blobVersionedHashes);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP4844))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP4844;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.maxFeePerBlobGas, out.blobVersionedHashes);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig)
+        {
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        return decodeError;
+    }
+};
+
+struct EIP7702TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        h.payloadLength += codec::rlp::length(tx.authorizationList);
+        return h;
+    }
+
+    // Signing preimage: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, authorization_list])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP7702));
+        codec::rlp::encodeHeader(out, headerTxBase(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.authorizationList);
+        return out;
+    }
+
+    // Full RLP: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, authorization_list, signature_y_parity,
+    // signature_r, signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP7702));
+        codec::rlp::encodeHeader(out, header(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.authorizationList);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // destination, amount, data, access_list, authorization_list, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP7702))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP7702;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.authorizationList); error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig)
+        {
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844/7702); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        return decodeError;
+    }
+};
 }  // namespace
+
+Web3TxHandler& handlerFor(TransactionType type)
+{
+    static LegacyTxHandler legacy;
+    static EIP2930TxHandler eip2930;
+    static EIP1559TxHandler eip1559;
+    static EIP4844TxHandler eip4844;
+    static DepositTxHandler deposit;
+    static EIP7702TxHandler eip7702;
+    switch (type)
+    {
+    case TransactionType::Legacy:
+        return legacy;
+    case TransactionType::EIP2930:
+        return eip2930;
+    case TransactionType::EIP1559:
+        return eip1559;
+    case TransactionType::EIP4844:
+        return eip4844;
+    case TransactionType::Deposit:
+        return deposit;
+    case TransactionType::EIP7702:
+        return eip7702;
+    }
+    // Unknown TransactionType: this is a programming error — a new enum value was added
+    // without updating this switch. Return a no-op sentinel handler instead of falling back
+    // to Legacy (which would silently decode/encode as wrong transaction format producing
+    // garbage fields). encode/encodeForSign return empty bytes (fail-safe), and decode
+    // returns UnsupportedTransactionType error.
+    BCOS_LOG(FATAL) << "handlerFor: unhandled TransactionType " << static_cast<int>(type)
+                    << " — update the switch to handle the new type";
+    static struct : Web3TxHandler
+    {
+        bcos::bytes encodeForSign(const Web3Transaction&) const override { return {}; }
+        bcos::bytes encode(const Web3Transaction&) const override { return {}; }
+        codec::rlp::Header header(const Web3Transaction&) const override
+        {
+            return {.isList = true, .payloadLength = 0};
+        }
+        bcos::Error::UniquePtr decode(bcos::bytesRef&, Web3Transaction&, bool) const override
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnsupportedTransactionType, "Unknown transaction type");
+        }
+    } sentinel;
+    return sentinel;
+}
 }  // namespace bcos::rpc
+
+// AccessListEntry RLP codec overloads — defined here (not in Web3Transaction.cpp) because the
+// handlers are the primary consumer: they encode/decode tx.accessList. The three using-declarations
+// above make these visible at the template POI so the generic codec can find them.
+namespace bcos::codec::rlp
+{
+using namespace bcos::rpc;
+Header header(const AccessListEntry& entry) noexcept
+{
+    auto len = length(entry.storageKeys);
+    return {.isList = true, .payloadLength = Address::SIZE + 1 + len};
+}
+
+size_t length(AccessListEntry const& entry) noexcept
+{
+    auto head = header(entry);
+    return lengthOfLength(head.payloadLength) + head.payloadLength;
+}
+
+void encode(bcos::bytes& out, const AccessListEntry& entry) noexcept
+{
+    encodeHeader(out, header(entry));
+    encode(out, entry.account.ref());
+    encode(out, entry.storageKeys);
+}
+
+bcos::Error::UniquePtr decode(bcos::bytesRef& in, AccessListEntry& out) noexcept
+{
+    return decode(in, out.account, out.storageKeys);
+}
+
+Header header(const AuthorizationListEntry& entry) noexcept
+{
+    auto len = codec::rlp::length(entry.chainId) + Address::SIZE + 1 +
+               codec::rlp::length(entry.nonce) +
+               codec::rlp::length(static_cast<uint64_t>(entry.yParity)) +
+               codec::rlp::length(entry.r) + codec::rlp::length(entry.s);
+    return {.isList = true, .payloadLength = len};
+}
+
+size_t length(AuthorizationListEntry const& entry) noexcept
+{
+    auto head = header(entry);
+    return lengthOfLength(head.payloadLength) + head.payloadLength;
+}
+
+void encode(bcos::bytes& out, const AuthorizationListEntry& entry) noexcept
+{
+    encodeHeader(out, header(entry));
+    encode(out, entry.chainId);
+    encode(out, entry.address.ref());
+    encode(out, entry.nonce);
+    encode(out, static_cast<uint64_t>(entry.yParity));
+    encode(out, entry.r);
+    encode(out, entry.s);
+}
+}  // namespace bcos::codec::rlp

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -305,6 +305,9 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .withdrawals = std::nullopt,
         .blobGasUsed = std::nullopt,
         .excessBlobGas = std::nullopt,
+        .blockAccessList = std::nullopt,
+        .slotNumber = std::nullopt,
+        .rawTransactions = std::nullopt,
         .withdrawalsRoot = std::nullopt,
     };
     if (ep.isMember("extraData"))
@@ -329,13 +332,23 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 InvalidParams, "Expected array of hex strings for executionPayload.transactions"));
         }
-        // Raw EIP-2718 bytes, hex-decoded verbatim. No transaction decoding happens
-        // here — getPayload must later return exactly these bytes.
+        // Raw EIP-2718 bytes, hex-decoded verbatim, kept in BOTH carriers:
+        //   - payload.transactions (EngineTransaction{raw, decoded=nullptr}) — the Engine-API
+        //     wire form; getPayload must later return exactly these raw bytes. No decoding
+        //     happens here — classification/decoding of the raw bytes is the dispatch table's
+        //     job (bcos-framework/engine/RawTransactionDispatch.h), matching upstream.
+        //   - payload.rawTransactions (vector<bytes>) — the OP path's sole tx carrier (raw
+        //     EIP-2718 envelope bytes incl. the 0x7E deposit), consumed by OpSchedulerSeam.
         payload.transactions.reserve(ep["transactions"].size());
+        payload.rawTransactions.emplace();
+        payload.rawTransactions->reserve(ep["transactions"].size());
         for (Json::ArrayIndex i = 0; i < ep["transactions"].size(); ++i)
         {
-            payload.transactions.push_back(bcos::engine::EngineTransaction{
-                .raw = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i),
+            auto txData = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i);
+            payload.rawTransactions->push_back(txData);  // keep unconditionally: OP carrier is
+                                                         // decoupled from decode
+            payload.transactions.push_back(engine::EngineTransaction{
+                .raw = std::move(txData),
                 .decoded = nullptr,
             });
         }

--- a/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
@@ -1,0 +1,168 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+// op-geth golden corpus 真实 raw tx（val-loop bcos-evm/test/opstack/t8n/golden/engine/
+// isthmus_access_list.golden.json rawTransactions[0]/[1]，逐字节核验一致）：0x7E deposit +
+// 0x02 EIP-1559 typed。两者经 decodeTransaction 必抛 TarsDecodeMismatch（tars 误解析 RLP）——
+// transactions 填充分支容错跳过，rawTransactions 是 W1 的核心断言对象。
+constexpr std::string_view kDepositRawTx =
+    "0x7ef90104a0ae1a1f61e85683e8084e5004f4c36b050cb2ea1e5f78f1e7d518163ade648a7994deaddeaddeaddead"
+    "deaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be00"
+    "000558000c5fc500000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000006fc23ac0000000000000000000000000000000000000000000000000000000000000f42"
+    "4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000000000000000000000000000";
+constexpr std::string_view kEip1559RawTx =
+    "0x02f8e0822105808405f5e1008477359400830186a094c0de0000000000000000000000000000000000058080f872"
+    "f85994c0de000000000000000000000000000000000005f842a0000000000000000000000000000000000000000000"
+    "0000000000000000000000a00000000000000000000000000000000000000000000000000000000000000005d694dd"
+    "ddddddddddddddddddddddddddddddddddddddc080a0394ee65265d6d1eead7675c85dc4dfa781d7d9b1d27392f51d"
+    "d7feb5d8f2f27ba0434c6ec29d5d0e3b781f461538d61e7120c5f25a33dd5f8a230aa8259dba7d0c";
+constexpr std::string_view kWithdrawalsRoot =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+std::shared_ptr<bcos::protocol::TransactionFactory> makeTxFactory()
+{
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    return std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+}
+
+Json::Value makePayloadParams(
+    std::vector<std::string_view> rawTxs, std::string_view withdrawalsRoot)
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = "0x" + std::string(64, '0');
+    ep["stateRoot"] = "0x" + std::string(64, '0');
+    ep["receiptsRoot"] = "0x" + std::string(64, '0');
+    ep["prevRandao"] = "0x" + std::string(64, '0');
+    ep["gasLimit"] = "0x1c9c380";
+    ep["gasUsed"] = "0x0";
+    ep["baseFeePerGas"] = "0x1";
+    ep["blockHash"] = "0x" + std::string(64, '0');
+    ep["feeRecipient"] = "0x" + std::string(40, '0');
+    ep["timestamp"] = "0x1";
+    ep["blockNumber"] = "0x1";
+    ep["logsBloom"] = "0x" + std::string(512, '0');
+    ep["extraData"] = "0x";
+    ep["withdrawals"] = Json::Value(Json::arrayValue);
+    ep["blobGasUsed"] = "0x0";
+    ep["excessBlobGas"] = "0x0";
+    if (withdrawalsRoot.size())
+    {
+        ep["withdrawalsRoot"] = std::string(withdrawalsRoot);
+    }
+    Json::Value txs(Json::arrayValue);
+    for (auto const& raw : rawTxs)
+    {
+        txs.append(std::string(raw));
+    }
+    ep["transactions"] = txs;
+    // V4 wire shape (#5427): [executionPayload, expectedBlobVersionedHashes,
+    // parentBeaconBlockRoot, executionRequests] — parse enforces the full array.
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+    params.append(Json::Value(Json::arrayValue));
+    params.append("0x3333333333333333333333333333333333333333333333333333333333333333");
+    params.append(Json::Value(Json::arrayValue));
+    return params;
+}
+
+BOOST_AUTO_TEST_SUITE(EngineHelperTest)
+
+// rawTransactions 逐字节保留输入；transactions 同步解码。
+BOOST_AUTO_TEST_CASE(parseFillsRawTransactionsPreservingBytes)
+{
+    auto params = makePayloadParams({kDepositRawTx, kEip1559RawTx}, kWithdrawalsRoot);
+    auto factory = makeTxFactory();
+    // 不得抛：transactions 填充分支容错跳过 decode 失败的 typed tx。
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_REQUIRE_EQUAL(request.executionPayload.rawTransactions->size(), 2u);
+    // 逐字节比对：rawTransactions[i] == fromHex(rawTx[i])
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.rawTransactions->at(i) == expect);
+    }
+    // 合并后语义（上游 parse 不解码，解码交给执行时 dispatch table）：transactions 以
+    // EngineTransaction{raw, decoded=nullptr} 携带 wire 字节；rawTransactions 保留 OP 载体。
+    BOOST_REQUIRE_EQUAL(request.executionPayload.transactions.size(), 2u);
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.transactions[i].raw == expect);
+        BOOST_CHECK(request.executionPayload.transactions[i].decoded == nullptr);
+    }
+}
+
+// withdrawalsRoot 正确解析为 h256。
+BOOST_AUTO_TEST_CASE(parseFillsWithdrawalsRoot)
+{
+    auto params = makePayloadParams({kEip1559RawTx}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.withdrawalsRoot.has_value());
+    auto expect = fromHex(kWithdrawalsRoot);
+    BOOST_CHECK_EQUAL(request.executionPayload.withdrawalsRoot->size(), 32u);
+    BOOST_CHECK(std::equal(
+        expect.begin(), expect.end(), request.executionPayload.withdrawalsRoot->begin()));
+}
+
+// withdrawalsRoot 缺省 → nullopt；错长（31/33 字节）→ bcos::rpc::JsonRpcException。
+BOOST_AUTO_TEST_CASE(parseWithdrawalsRootBoundaries)
+{
+    // Missing withdrawalsRoot on V4 is a malformed payload (#5427 shape gate):
+    // -32602 at parse time, not a silent nullopt (the engine-side INVALID-status
+    // rule covers in-process callers).
+    auto noRoot = makePayloadParams({kEip1559RawTx}, "");
+    BOOST_CHECK_EXCEPTION(parseNewPayloadRequest(noRoot, engine::ApiVersion::V4),
+        bcos::rpc::JsonRpcException, [](auto const& e) { return e.code() == InvalidParams; });
+
+    // 31 字节（62 hex）
+    auto badShort = makePayloadParams({kEip1559RawTx}, "0x" + std::string(62, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badShort, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+    // 33 字节（66 hex）
+    auto badLong = makePayloadParams({kEip1559RawTx}, "0x" + std::string(66, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badLong, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+}
+
+// 缺 transactions 键 → rawTransactions 保持 nullopt（OP 校验 :299 仍拒）。
+BOOST_AUTO_TEST_CASE(parseMissingTransactionsLeavesRawNullopt)
+{
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    params[0].removeMember("transactions");
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_CHECK(!request.executionPayload.rawTransactions.has_value());
+}
+
+// transactions 存在但为空数组 → rawTransactions present-and-empty（OP 校验 :299 接受）。
+BOOST_AUTO_TEST_CASE(parseEmptyTransactionsIsPresentAndEmpty)
+{
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_CHECK(request.executionPayload.rawTransactions->empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <boost/test/unit_test.hpp>
 #include <future>
@@ -19,6 +20,60 @@ using namespace bcos::rpc;
 
 namespace bcos::test
 {
+// FakeLedger::asyncGetTransactionReceiptByHash always reports null (FakeLedger.h:360-364), so
+// seeding storage is inert for eth_getTransactionReceipt. This subclass overrides it to return a
+// seeded receipt, and re-seeds the tx-by-hash lookup with a safe implementation: FakeLedger's
+// storeTransactionsAndReceipts dereferences a default-constructed null shared_ptr (txData is never
+// allocated), so the inherited path cannot be used to populate m_txsHashToData.
+class SeedableLedger : public bcos::test::FakeLedger
+{
+public:
+    SeedableLedger(bcos::protocol::BlockFactory::Ptr blockFactory, size_t blockNumber,
+        size_t txsSize, size_t receiptsSize)
+      : bcos::test::FakeLedger(blockFactory, blockNumber, txsSize, receiptsSize),
+        m_blockFactory(std::move(blockFactory))
+    {}
+
+    protocol::TransactionReceipt::Ptr seededReceipt;
+    std::map<crypto::HashType, std::shared_ptr<bcos::bytes>> m_seedTxs;
+
+    void asyncGetTransactionReceiptByHash(crypto::HashType const&, bool,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr, MerkleProofPtr)> callback)
+        override
+    {
+        callback(nullptr, seededReceipt, nullptr);
+    }
+
+    void asyncGetBatchTxsByHashList(crypto::HashListPtr _txHashList, bool,
+        std::function<void(
+            Error::Ptr, TransactionsPtr, std::shared_ptr<std::map<std::string, MerkleProofPtr>>)>
+            _onGetTx) override
+    {
+        auto txs = std::make_shared<Transactions>();
+        for (auto const& hash : *_txHashList)
+        {
+            if (auto it = m_seedTxs.find(hash); it != m_seedTxs.end())
+            {
+                auto tx = m_blockFactory->transactionFactory()->createTransaction(
+                    bcos::ref(*(it->second)), /*checkSig=*/false);
+                txs->emplace_back(tx);
+            }
+        }
+        _onGetTx(nullptr, txs, nullptr);
+    }
+
+    void seedTx(bcos::protocol::Transaction::Ptr tx)
+    {
+        auto txHash = tx->hash();
+        auto txData = std::make_shared<bcos::bytes>();
+        tx->encode(*txData);
+        m_seedTxs[txHash] = std::move(txData);
+    }
+
+private:
+    bcos::protocol::BlockFactory::Ptr m_blockFactory;
+};
+
 // Drives the web3 (eth_/net_/web3_) coroutine endpoints through the real
 // dispatch path. EthEndpoint.cpp (596 lines) was at 24% because the existing
 // Web3RpcTest only touched ~10 of the ~44 registered methods. onRPCRequest
@@ -227,6 +282,89 @@ BOOST_AUTO_TEST_CASE(sendRawTransactionGarbageReportsError)
     auto resp = call(req("eth_sendRawTransaction", R"(["0xdeadbeef"])"));
     BOOST_CHECK(resp.isMember("error") || resp.isMember("result"));
     BOOST_CHECK(resp.isMember("id"));
+}
+
+BOOST_AUTO_TEST_CASE(getTransactionReceiptHappyPath)
+{
+    // Full read-side happy path (spec §5-5): seed a tx + receipt into a SeedableLedger and drive
+    // eth_getTransactionReceipt / eth_getTransactionByHash through the real dispatch path. The
+    // stock RPCFixture FakeLedger always returns a null receipt, so a subclass is required.
+    auto seedLedger = std::make_shared<SeedableLedger>(m_blockFactory, /*blocks=*/20, 10, 10);
+    seedLedger->setSystemConfig(ledger::SYSTEM_KEY_TX_COUNT_LIMIT, "1000");
+
+    auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
+        "0x1234567890123456789012345678901234567890", bcos::bytes{0x0a}, "0x2", 100, chainId,
+        groupId, 0);
+    BOOST_REQUIRE(tx);
+    // D8 (review ①): install a raw 20-byte sender so the read side must checksum the raw bytes.
+    // Mixed-case hex letters (0x5aAe...BeAed) make EIP-55 checksum casing observable (an
+    // all-digit address would make toChecksumAddress a no-op).
+    tx->forceSender(bcos::fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"));
+    seedLedger->seedTx(tx);
+
+    auto receipt = m_blockFactory->receiptFactory()->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", {}, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    BOOST_REQUIRE(receipt);
+    receipt->setTransactionIndex(0);
+    // C4: seed a receipt WITH opStackMeta so eth_getTransactionReceipt must carry the OP extension
+    // fields through the REAL RPC dispatch (unit-testing combineReceiptResponse alone does not
+    // prove the fields survive the full EthEndpoint → JSON round-trip).
+    protocol::OpStackReceiptMeta meta;
+    meta.l1_gas_price = bcos::u256(5);
+    meta.operator_fee_scalar = 2;
+    receipt->setOpStackMeta(std::move(meta));
+    seedLedger->seededReceipt = receipt;
+
+    // Rebuild the RPC stack over the seedable ledger.
+    auto service = std::make_shared<rpc::NodeService>(
+        seedLedger, scheduler, txPool, nullptr, nullptr, m_blockFactory, nullptr);
+    auto seededRpc = factory->buildLocalRpc(groupInfo, service);
+    auto seededWeb3 = seededRpc->web3JsonRpc();
+    BOOST_REQUIRE(seededWeb3 != nullptr);
+
+    auto const txHashHex = tx->hash().hexPrefixed();
+    auto callSeeded = [&](std::string_view request) {
+        std::promise<bcos::bytes> promise;
+        seededWeb3->onRPCRequest(request, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
+        auto jsonBytes = promise.get_future().get();
+        Json::Value value;
+        Json::Reader reader;
+        std::string_view json((char*)jsonBytes.data(), jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    };
+
+    // eth_getTransactionReceipt returns a complete object with the checksummed from (review ①).
+    {
+        auto resp = callSeeded(req("eth_getTransactionReceipt", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("transactionHash"));
+        BOOST_CHECK_EQUAL(resp["result"]["transactionHash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("logs"));
+        BOOST_CHECK(resp["result"].isMember("blockNumber"));
+        // C4: OP extension fields survive the full RPC round-trip (not just
+        // combineReceiptResponse).
+        BOOST_CHECK_EQUAL(resp["result"]["l1GasPrice"].asString(), "0x5");
+        BOOST_CHECK_EQUAL(resp["result"]["operatorFeeScalar"].asString(), "0x2");
+        // Pinned against the independently-known EIP-55 vector (NOT derived via the same
+        // toChecksumAddress under test, so a checksum-casing regression is actually caught).
+        BOOST_CHECK_EQUAL(
+            resp["result"]["from"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+    }
+
+    // eth_getTransactionByHash resolves the same tx.
+    {
+        auto resp = callSeeded(req("eth_getTransactionByHash", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("hash"));
+        BOOST_CHECK_EQUAL(resp["result"]["hash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("from"));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -9,9 +9,13 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
 
 #include <boost/test/unit_test.hpp>
 using namespace bcos;
@@ -19,6 +23,31 @@ using namespace bcos::rpc;
 
 namespace bcos::test
 {
+namespace
+{
+// Local factories — Web3ResponseTest.cpp has no makeReceipt/makeWeb3Tx helpers; these mirror the
+// construction in combineReceiptResponseShapesReceipt so the OP-field / deposit / 4844 tests below
+// can stay compact.
+bcos::protocol::TransactionReceipt::Ptr makeReceipt(bcos::protocol::BlockFactory::Ptr blockFactory)
+{
+    auto receiptFactory = blockFactory->receiptFactory();
+    std::vector<bcos::protocol::LogEntry> logs;
+    auto receipt = receiptFactory->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", logs, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    receipt->setTransactionIndex(0);
+    return receipt;
+}
+
+bcos::protocol::Transaction::Ptr makeWeb3Tx(bcos::protocol::BlockFactory::Ptr blockFactory,
+    std::string const& chainId, std::string const& groupId)
+{
+    auto txFactory = blockFactory->transactionFactory();
+    return txFactory->createTransaction(0, "0x1234567890123456789012345678901234567890",
+        bcos::bytes{0x0a}, "0x2", 100, chainId, groupId, 0);
+}
+}  // namespace
+
 BOOST_FIXTURE_TEST_SUITE(Web3ResponseTest, RPCFixture)
 
 BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
@@ -143,6 +172,222 @@ BOOST_AUTO_TEST_CASE(combineReceiptResponseShapesReceipt)
     BOOST_CHECK(result.isMember("gasUsed"));
     BOOST_CHECK(result.isMember("logs"));
     BOOST_CHECK(result["logs"].isArray());
+}
+
+BOOST_AUTO_TEST_CASE(combineReceiptResponseEmitsOpExtensionFieldsFromMeta)
+{
+    auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+    BOOST_REQUIRE(tx);
+    // D8 (review ①): non-deposit from must be the checksum of the RAW sender bytes. Install a raw
+    // 20-byte sender; if the read side re-encoded a hex-string (double-encoded) sender this
+    // assertion would fail — that is exactly the bug review ① caught on the write side. The
+    // address carries mixed-case hex letters (0x5aAe...BeAed) so EIP-55 checksum casing is
+    // actually observable — an all-digit address makes toChecksumAddress a no-op and could never
+    // regress-catch.
+    tx->forceSender(bcos::fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"));
+
+    auto receipt = makeReceipt(m_blockFactory);
+    BOOST_REQUIRE(receipt);
+    protocol::OpStackReceiptMeta meta;
+    // D2 (P4-1): ALL 13 mappings positively asserted — a wrong JSON key or value on any field
+    // would otherwise pass (empty-meta test only proves absence-when-empty). Distinct values so
+    // cross-field mixups are caught too.
+    meta.l1_gas_price = bcos::u256(5);
+    meta.l1_gas_used = 6;
+    meta.l1_fee = bcos::u256(10);
+    meta.l1_blob_base_fee = bcos::u256(11);
+    meta.l1_base_fee_scalar = 12;
+    meta.l1_blob_base_fee_scalar = 13;
+    meta.operator_fee_scalar = 14;
+    meta.operator_fee_constant = 15;
+    meta.da_footprint_gas_scalar = 16;
+    meta.da_footprint = 17;
+    meta.deposit_nonce = 18;
+    meta.deposit_receipt_version = 19;
+    meta.operator_fee = bcos::u256(20);
+    receipt->setOpStackMeta(std::move(meta));
+
+    bcos::crypto::HashType blockHash;
+    blockHash[0] = 0x99;
+
+    Json::Value result = Json::objectValue;
+    combineReceiptResponse(result, *receipt, *tx, blockHash);
+
+    BOOST_CHECK_EQUAL(result["l1GasPrice"].asString(), "0x5");
+    BOOST_CHECK_EQUAL(result["l1GasUsed"].asString(), "0x6");
+    BOOST_CHECK_EQUAL(result["l1Fee"].asString(), "0xa");
+    BOOST_CHECK_EQUAL(result["l1BlobBaseFee"].asString(), "0xb");
+    BOOST_CHECK_EQUAL(result["l1BaseFeeScalar"].asString(), "0xc");
+    BOOST_CHECK_EQUAL(result["l1BlobBaseFeeScalar"].asString(), "0xd");
+    BOOST_CHECK_EQUAL(result["operatorFeeScalar"].asString(), "0xe");
+    BOOST_CHECK_EQUAL(result["operatorFeeConstant"].asString(), "0xf");
+    BOOST_CHECK_EQUAL(result["daFootprintGasScalar"].asString(), "0x10");
+    BOOST_CHECK_EQUAL(result["blobGasUsed"].asString(), "0x11");  // ← da_footprint (Jovian 复用)
+    BOOST_CHECK_EQUAL(result["depositNonce"].asString(), "0x12");
+    BOOST_CHECK_EQUAL(result["depositReceiptVersion"].asString(), "0x13");
+    BOOST_CHECK_EQUAL(result["operatorFee"].asString(), "0x14");  // FISCO 扩展
+    // from = checksum of the raw sender bytes (review ①). Pinned against the independently-known
+    // EIP-55 vector 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed (deliberately NOT derived via the
+    // same toChecksumAddress under test, so a checksum-casing regression is actually caught).
+    BOOST_CHECK_EQUAL(result["from"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+}
+
+// Important #1 (whole-branch review): receipt `type` for a Web3 tx must equal the EIP-2718 kind
+// byte. The write side stores encodeForSign() (RLP WITHOUT the type byte) in extraTransactionBytes
+// for typed non-deposit txs, so byte-sniffing extraTransactionBytes collapsed EIP-2930/1559/4844
+// receipts into Legacy 0x0 while eth_getTransactionByHash reported the correct kind.
+// combineReceiptResponse now reads the `web3TypedTxKind` tars slot (populated by
+// takeToTarsTransaction for every Web3 kind).
+BOOST_AUTO_TEST_CASE(combineReceiptResponseTypedTxKindType)
+{
+    auto makeWeb3TarsTx = [&](bcos::rpc::Web3Transaction web3Tx) {
+        auto tarsTx = web3Tx.takeToTarsTransaction();
+        // D4: manual extraTransactionHash so combineReceiptResponse:19 tx.hash() does not throw.
+        bcos::h256 arbitraryHash(
+            "0303030303030303030303030303030303030303030303030303030303030303");
+        tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+        return std::make_shared<bcostars::protocol::TransactionImpl>(
+            [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+    };
+
+    // EIP-1559 (0x02): previously misreported as 0x0 Legacy by the byte-sniff.
+    {
+        bcos::rpc::Web3Transaction web3Tx;
+        web3Tx.type = bcos::rpc::TransactionType::EIP1559;
+        web3Tx.chainId = 1;
+        web3Tx.nonce = 0;
+        web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+        web3Tx.maxFeePerGas = bcos::u256(2);
+        web3Tx.gasLimit = 21000;
+        web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+        web3Tx.value = bcos::u256(0);
+        web3Tx.signatureR = bcos::bytes(32, 0x11);
+        web3Tx.signatureS = bcos::bytes(32, 0x22);
+        web3Tx.signatureV = 0;
+        auto tx = makeWeb3TarsTx(std::move(web3Tx));
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x2");
+    }
+    // Deposit (0x7e): full envelope stored, kind slot set to Deposit.
+    {
+        bcos::rpc::Web3Transaction web3Deposit;
+        web3Deposit.type = bcos::rpc::TransactionType::Deposit;
+        web3Deposit.from = bcos::Address("0xdead000000000000000000000000000000000011");
+        web3Deposit.sourceHash =
+            bcos::h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        web3Deposit.mint = bcos::u256("0x16345785d8a0000");
+        web3Deposit.nonce = 0;
+        web3Deposit.isSystemTx = true;
+        auto tx = makeWeb3TarsTx(std::move(web3Deposit));
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    }
+    // Legacy BCOSTransaction: web3TypedTxKind() is 0 == Legacy → 0x0.
+    {
+        auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x0");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(combineReceiptResponseOmitsOpFieldsWhenMetaEmpty)
+{
+    auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+    BOOST_REQUIRE(tx);
+    auto receipt = makeReceipt(m_blockFactory);
+    BOOST_REQUIRE(receipt);
+
+    bcos::crypto::HashType blockHash;
+    Json::Value result = Json::objectValue;
+    combineReceiptResponse(result, *receipt, *tx, blockHash);
+
+    // Empty opStackMeta → NO OP fields at all (no zero/default placeholders).
+    BOOST_CHECK(!result.isMember("l1GasPrice"));
+    BOOST_CHECK(!result.isMember("l1Fee"));
+    BOOST_CHECK(!result.isMember("l1GasUsed"));
+    BOOST_CHECK(!result.isMember("l1BlobBaseFee"));
+    BOOST_CHECK(!result.isMember("l1BaseFeeScalar"));
+    BOOST_CHECK(!result.isMember("l1BlobBaseFeeScalar"));
+    BOOST_CHECK(!result.isMember("operatorFeeScalar"));
+    BOOST_CHECK(!result.isMember("operatorFeeConstant"));
+    BOOST_CHECK(!result.isMember("daFootprintGasScalar"));
+    BOOST_CHECK(!result.isMember("blobGasUsed"));
+    BOOST_CHECK(!result.isMember("depositNonce"));
+    BOOST_CHECK(!result.isMember("depositReceiptVersion"));
+    BOOST_CHECK(!result.isMember("operatorFee"));
+}
+
+// Read-side deposit (0x7e) transaction shape. takeToTarsTransaction() does NOT fill
+// extraTransactionHash (review ③/D4), and combineTxResponse:44 calls tx.hash() which throws
+// EmptyTransactionHash on an empty one — so the test must install arbitrary 32 bytes.
+BOOST_AUTO_TEST_CASE(combineTxResponseDepositMinimalFields)
+{
+    bcos::rpc::Web3Transaction web3Deposit;
+    web3Deposit.type = bcos::rpc::TransactionType::Deposit;
+    web3Deposit.from = bcos::Address("0xdead000000000000000000000000000000000011");
+    web3Deposit.sourceHash =
+        bcos::h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    web3Deposit.mint = bcos::u256("0x16345785d8a0000");
+    web3Deposit.nonce = 0;
+    web3Deposit.isSystemTx = true;
+
+    auto tarsTx = web3Deposit.takeToTarsTransaction();
+    // D4 (review ③): manual extraTransactionHash so combineTxResponse:44 does not throw.
+    bcos::h256 arbitraryHash("0101010101010101010101010101010101010101010101010101010101010101");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+    bcostars::protocol::TransactionImpl txImpl(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    Json::Value result = Json::objectValue;
+    combineTxResponse(
+        result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+    BOOST_CHECK(result.isMember("nonce"));  // deposit nonce=0
+    BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    // Deposit (0x7e) is numerically larger than every EIP type, so the explicit range checks at
+    // TransactionResponse.cpp:68/:86 exclude it from accessList / blob fields.
+    BOOST_CHECK(!result.isMember("accessList"));
+    BOOST_CHECK(!result.isMember("blobVersionedHashes"));
+}
+
+// Read-side EIP-4844 blob transaction: blobVersionedHashes / maxFeePerBlobGas branches.
+BOOST_AUTO_TEST_CASE(combineTxResponseBlob4844)
+{
+    bcos::rpc::Web3Transaction web3Tx;
+    web3Tx.type = bcos::rpc::TransactionType::EIP4844;
+    web3Tx.chainId = 1;
+    web3Tx.nonce = 0;
+    web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+    web3Tx.maxFeePerGas = bcos::u256(2);
+    web3Tx.gasLimit = 21000;
+    web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+    web3Tx.value = bcos::u256(0);
+    web3Tx.maxFeePerBlobGas = bcos::u256(3);
+    web3Tx.blobVersionedHashes = {
+        bcos::h256("c6bdd1de713471bd6cfa62dd8b5a5b42969ed09e26212d3377f3f8426d8ec210")};
+    web3Tx.signatureR = bcos::bytes(32, 0x11);
+    web3Tx.signatureS = bcos::bytes(32, 0x22);
+    web3Tx.signatureV = 0;
+
+    auto tarsTx = web3Tx.takeToTarsTransaction();
+    // D4 (review ③): manual extraTransactionHash so combineTxResponse:44 does not throw.
+    bcos::h256 arbitraryHash("0202020202020202020202020202020202020202020202020202020202020202");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+    bcostars::protocol::TransactionImpl txImpl(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    Json::Value result = Json::objectValue;
+    combineTxResponse(
+        result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+    BOOST_CHECK(result.isMember("blobVersionedHashes"));
+    BOOST_CHECK(result.isMember("maxFeePerBlobGas"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
@@ -20,6 +20,8 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3TxHandler.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -128,6 +130,9 @@ BOOST_AUTO_TEST_CASE(testEIP2930Transaction)
     BOOST_CHECK_EQUAL(tx.value, 2000000000000000000ull);
     BOOST_CHECK_EQUAL(toHex(tx.data), "6ebaf477f83e051589c1188bcc6ddccd");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-2930 sample carries yParity=0.
+    BOOST_CHECK_EQUAL(tx.signatureV, 0u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -161,6 +166,9 @@ BOOST_AUTO_TEST_CASE(testEIP1559Transaction)
     BOOST_CHECK_EQUAL(tx.value, 2000000000000000000ull);
     BOOST_CHECK_EQUAL(toHex(tx.data), "6ebaf477f83e051589c1188bcc6ddccd");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-1559 sample carries yParity=0.
+    BOOST_CHECK_EQUAL(tx.signatureV, 0u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -239,6 +247,9 @@ BOOST_AUTO_TEST_CASE(testEIP4844Transaction)
     BOOST_CHECK_EQUAL(toHex(tx.blobVersionedHashes[1]),
         "8aaeccaf3873d07cef005aca28c39f8a9f8bdb1ec8d79ffc25afc0a4fa2ab736");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35 + 1);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-4844 sample carries yParity=1 (hence the +1 in getSignatureV above).
+    BOOST_CHECK_EQUAL(tx.signatureV, 1u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -249,6 +260,125 @@ BOOST_AUTO_TEST_CASE(testEIP4844Transaction)
     codec::rlp::encode(encoded, tx);
     auto rawTx2 = toHexStringWithPrefix(encoded);
     BOOST_CHECK_EQUAL(rawTx, rawTx2);
+}
+
+// C2 (W8 review): typed-tx yParity is restricted to 0/1 (Web3TxHandler rejects signatureV > 1 with
+// InvalidVInSignature). Flip the yParity wire byte of each legal typed-tx sample to 0x02
+// (single-byte self-encoding — same wire length, outer RLP prefix unaffected) and assert the
+// decoder rejects it. Wire offsets are RLP-decoding-verified: EIP-2930 field[8] at 178,
+// EIP-1559 field[9] at 184, EIP-4844 field[11] at 232.
+BOOST_AUTO_TEST_CASE(typedTxYParityOverOneRejected)
+{
+    auto byteAt = [](std::string_view hex, std::size_t byteOffset) -> int {
+        auto nibble = [](char c) -> int {
+            if (c >= '0' && c <= '9')
+            {
+                return c - '0';
+            }
+            if (c >= 'a' && c <= 'f')
+            {
+                return c - 'a' + 10;
+            }
+            return c - 'A' + 10;
+        };
+        auto pos = 2 + byteOffset * 2;  // skip "0x"
+        return nibble(hex[pos]) * 16 + nibble(hex[pos + 1]);
+    };
+    auto flipByteToTwo = [](std::string_view hex, std::size_t byteOffset) {
+        std::string out(hex);
+        auto pos = 2 + byteOffset * 2;  // skip "0x"
+        out[pos] = '0';
+        out[pos + 1] = '2';
+        return out;
+    };
+
+    // clang-format off
+    constexpr std::string_view kEIP2930RawTx = "0x01f8f205078506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7881bc16d674ec80000906ebaf477f83e051589c1188bcc6ddccdf872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c080a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    constexpr std::string_view kEIP1559RawTx = "0x02f8f805078502540be4008506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7881bc16d674ec80000906ebaf477f83e051589c1188bcc6ddccdf872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c080a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    constexpr std::string_view kEIP4844RawTx = "0x03f9012705078502540be4008506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7808204f7f872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c07bf842a0c6bdd1de713471bd6cfa62dd8b5a5b42969ed09e26212d3377f3f8426d8ec210a08aaeccaf3873d07cef005aca28c39f8a9f8bdb1ec8d79ffc25afc0a4fa2ab73601a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    // clang-format on
+
+    struct Sample
+    {
+        std::string_view rawTx;
+        std::size_t yParityOffset;
+        int expectedYParityByte;  // the RLP-encoded yParity currently at the offset
+    };
+    const Sample samples[] = {
+        {kEIP2930RawTx, 178, 0x80},
+        {kEIP1559RawTx, 184, 0x80},
+        {kEIP4844RawTx, 232, 0x01},
+    };
+    for (const auto& sample : samples)
+    {
+        // Guard: fail loudly if a wire offset is stale — never silently test the wrong byte.
+        BOOST_CHECK_MESSAGE(
+            byteAt(sample.rawTx, sample.yParityOffset) == sample.expectedYParityByte,
+            "yParity wire byte mismatch at offset " << sample.yParityOffset);
+
+        auto bytes = fromHexWithPrefix(flipByteToTwo(sample.rawTx, sample.yParityOffset));
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto e = codec::rlp::decode(bRef, tx);
+        BOOST_REQUIRE_MESSAGE(
+            e != nullptr, "yParity=2 must be rejected (offset " << sample.yParityOffset << ')');
+        if (e != nullptr)
+        {
+            BOOST_CHECK_EQUAL(e->errorCode(),
+                static_cast<int64_t>(codec::rlp::DecodingError::InvalidVInSignature));
+        }
+    }
+}
+
+// EIP-2 canonical-s: a malleable (high-s) signature must be rejected at decode. decode() is the
+// single funnel for both OP paths — eth_sendRawTransaction (EthEndpoint) and engine newPayload
+// (opEnvelopeToTars) — so this covers admission AND block processing, matching op-geth. Flipping
+// s -> n - s recovers the same sender and would otherwise execute byte-for-byte identically.
+BOOST_AUTO_TEST_CASE(highSsignatureRejectedAtDecode)
+{
+    const u256 kSecpOrder("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+    const u256 kSecpHalfOrder = kSecpOrder / 2;
+
+    Web3Transaction tx;
+    tx.value = 1000000000000000000;
+    tx.type = rpc::TransactionType::Legacy;
+    tx.data = {};
+    tx.to = Address("0x1e58529dAA467406645d0f4B63dec96CA0b87d70");
+    tx.nonce = 19;
+    tx.gasLimit = 210000;
+    tx.maxFeePerGas = 20000000000;
+    tx.maxPriorityFeePerGas = 20000000000;
+    tx.chainId = 31337;
+
+    auto signData = tx.encodeForSign();
+    std::string priv = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    auto key = std::make_shared<KeyImpl>(fromHex(priv));
+    auto newHash = crypto::keccak256Hash(ref(signData));
+    auto signatureImpl = bcos::crypto::Secp256k1Crypto();
+    auto keyPair = std::make_unique<Secp256k1KeyPair>(key);
+    auto signature = signatureImpl.sign(*keyPair, newHash, false);
+    tx.signatureR = {signature->begin(), signature->begin() + 32};
+    tx.signatureS = {signature->begin() + 32, signature->begin() + 64};
+    tx.signatureV = signature->back();
+
+    // Guard: libsecp256k1 signs canonical low-s — confirm before flipping, so a future
+    // libsecp256k1 behavior change fails loudly instead of silently weakening the test.
+    const u256 s = u256("0x" + toHex(tx.signatureS));
+    BOOST_REQUIRE(s <= kSecpHalfOrder);
+
+    // Malleability flip: s' = n - s is high-s but recovers the same sender.
+    tx.signatureS = toBigEndian(kSecpOrder - s);
+    const u256 flipped = u256("0x" + toHex(tx.signatureS));
+    BOOST_REQUIRE(flipped > kSecpHalfOrder);
+
+    bcos::bytes encoded;
+    codec::rlp::encode(encoded, tx);
+    auto bRef = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto e = codec::rlp::decode(bRef, decoded);
+    BOOST_REQUIRE(e != nullptr);
+    BOOST_CHECK_EQUAL(
+        e->errorCode(), static_cast<int64_t>(codec::rlp::DecodingError::InvalidVInSignature));
 }
 
 BOOST_AUTO_TEST_CASE(testEIP7702Transaction)
@@ -444,6 +574,165 @@ BOOST_AUTO_TEST_CASE(EIP4844Recover)
     BOOST_CHECK(re);
     auto address = toHexStringWithPrefix(addr);
     BOOST_CHECK_EQUAL(address, "0xc1b634853cb333d3ad8663715b08f41a3aec47cc");
+}
+
+// Deposit encode→decode roundtrip locks the uint32_t isSystemTransaction workaround
+// (see Web3TxHandler.h header comment) — when the underlying ODR defect is fixed and
+// the field switches back to uint8_t, this test ensures the encoded byte does not
+// silently regress.
+BOOST_AUTO_TEST_CASE(depositRoundtrip)
+{
+    Web3Transaction deposit;
+    deposit.type = rpc::TransactionType::Deposit;
+    deposit.sourceHash = h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    deposit.from = Address("0xdead000000000000000000000000000000000011");
+    deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+    deposit.mint = u256("0x16345785d8a0000");
+    deposit.value = u256(0);
+    deposit.gasLimit = 1000000;
+    deposit.isSystemTx = true;
+    deposit.data = bcos::bytes{};
+
+    // Encode → decode roundtrip
+    auto encoded = deposit.encode();
+    auto ref = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto err = decoded.decode(ref, false);  // withSig=false, deposit has no signature
+    BOOST_REQUIRE(err == nullptr);
+
+    BOOST_CHECK(decoded.type == rpc::TransactionType::Deposit);
+    BOOST_CHECK(decoded.isSystemTx);
+    BOOST_CHECK_EQUAL(decoded.sourceHash.hex(), deposit.sourceHash.hex());
+    BOOST_CHECK_EQUAL(decoded.from.hexPrefixed(), deposit.from.hexPrefixed());
+    BOOST_CHECK(decoded.to.has_value());
+    BOOST_CHECK_EQUAL(decoded.to->hexPrefixed(), deposit.to->hexPrefixed());
+    BOOST_CHECK_EQUAL(decoded.mint, deposit.mint);
+    BOOST_CHECK_EQUAL(decoded.value, deposit.value);
+    BOOST_CHECK_EQUAL(decoded.gasLimit, deposit.gasLimit);
+
+    // Also round-trip the system-tx=false case
+    Web3Transaction nonSysDeposit;
+    nonSysDeposit.type = rpc::TransactionType::Deposit;
+    nonSysDeposit.sourceHash =
+        h256("7bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8");
+    nonSysDeposit.from = Address("0xdead000000000000000000000000000000000011");
+    nonSysDeposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+    nonSysDeposit.mint = u256(100);
+    nonSysDeposit.value = u256(0);
+    nonSysDeposit.gasLimit = 500000;
+    nonSysDeposit.isSystemTx = false;
+    nonSysDeposit.data = bcos::bytes{};
+
+    auto encoded2 = nonSysDeposit.encode();
+    auto ref2 = bcos::ref(encoded2);
+    Web3Transaction decoded2;
+    err = decoded2.decode(ref2, false);
+    BOOST_REQUIRE(err == nullptr);
+
+    BOOST_CHECK(decoded2.type == rpc::TransactionType::Deposit);
+    BOOST_CHECK(!decoded2.isSystemTx);
+    BOOST_CHECK_EQUAL(decoded2.mint, nonSysDeposit.mint);
+}
+
+// The sendRawTransaction guard in EthEndpoint.cpp checks web3Tx.type == Deposit after decoding the
+// raw bytes. The guard itself is a simple `if` + throw; the decode → type-detection path is the
+// test that verifies a valid 0x7E envelope is correctly identified. An RPC-level test would need
+// the full EthEndpoint fixture (future work).
+BOOST_AUTO_TEST_CASE(decodeDepositIdentifiesTypeForSendRawGuard)
+{
+    Web3Transaction deposit;
+    deposit.type = rpc::TransactionType::Deposit;
+    deposit.sourceHash = h256("0xabcd000000000000000000000000000000000000000000000000000000000000");
+    deposit.from = Address("0xdead000000000000000000000000000000000099");
+    deposit.to.emplace(Address("0x4200000000000000000000000000000000000011"));
+    deposit.mint = u256(1);
+    deposit.value = u256(0);
+    deposit.gasLimit = 21000;
+    deposit.isSystemTx = false;
+    deposit.data = bcos::bytes{};
+
+    auto encoded = deposit.encode();
+    BOOST_REQUIRE(!encoded.empty());
+
+    // The raw envelope must start with 0x7E (EIP-2718 type byte)
+    BOOST_CHECK_EQUAL(
+        static_cast<uint8_t>(encoded[0]), static_cast<uint8_t>(rpc::TransactionType::Deposit));
+
+    // Decode through the public codec entry point — this is the path EthEndpoint calls
+    // (codec::rlp::decode → Web3Transaction::decode) before the type-guard check.
+    auto ref = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto err = bcos::codec::rlp::decode(ref, decoded);
+    BOOST_REQUIRE(err == nullptr);
+    BOOST_CHECK(decoded.type == rpc::TransactionType::Deposit);
+    // A real sendRawTransaction call would now hit: if (web3Tx.type == Deposit) → throw
+    // InvalidParams
+}
+
+// Golden-vector deposit encoding: encode known deposit txs and compare byte-for-byte
+// against independently-verified RLP output (cross-validated against the OP Stack deposit
+// spec: 0x7E || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])).
+// The golden hex strings were verified against an independent oracle and op-geth-shaped
+// vectors. If a future change alters the deposit encoding, this test breaks — that's
+// intentional. The 0x80 vs 0x01 isSystemTx distinction is the op-geth convention the
+// uint32_t workaround (see Web3TxHandler.h header comment) exists to preserve.
+BOOST_AUTO_TEST_CASE(depositGoldenEncoding)
+{
+    // isSystemTx=true: 0x7E || rlp([33b sourceHash, 21b from, 21b to, 9b mint,
+    //                          1b value(0), 4b gas, 1b isSystemTx(0x01), 1b data(empty)])
+    // gas = 0x0f4240 = 1000000
+    {
+        Web3Transaction deposit;
+        deposit.type = rpc::TransactionType::Deposit;
+        deposit.sourceHash =
+            h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        deposit.from = Address("0xdead000000000000000000000000000000000011");
+        deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+        deposit.mint = u256("0x16345785d8a0000");
+        deposit.value = u256(0);
+        deposit.gasLimit = 1000000;
+        deposit.isSystemTx = true;
+        deposit.data = bcos::bytes{};
+
+        auto encoded = deposit.encode();
+        BOOST_CHECK_EQUAL(toHex(encoded),
+            "7ef85ba06ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"
+            "94dead000000000000000000000000000000000011"
+            "944200000000000000000000000000000000000022"
+            "88016345785d8a0000"
+            "80"
+            "830f4240"
+            "01"
+            "80");
+    }
+
+    // isSystemTx=false: 0x7E || rlp([33b sourceHash, 21b from, 21b to, 1b mint(0x64=100),
+    //                              1b value(0), 4b gas, 1b isSystemTx(0x80), 1b data(empty)])
+    // gas = 0x07a120 = 500000, list header 0xf853 (shorter: mint is 1 byte vs 9)
+    {
+        Web3Transaction deposit;
+        deposit.type = rpc::TransactionType::Deposit;
+        deposit.sourceHash =
+            h256("7bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8");
+        deposit.from = Address("0xdead000000000000000000000000000000000011");
+        deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+        deposit.mint = u256(100);
+        deposit.value = u256(0);
+        deposit.gasLimit = 500000;
+        deposit.isSystemTx = false;
+        deposit.data = bcos::bytes{};
+
+        auto encoded = deposit.encode();
+        BOOST_CHECK_EQUAL(toHex(encoded),
+            "7ef853a07bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8"
+            "94dead000000000000000000000000000000000011"
+            "944200000000000000000000000000000000000022"
+            "64"
+            "80"
+            "8307a120"
+            "80"
+            "80");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpstackExecutorTest.cpp
+++ b/opstack-executor/tests/OpstackExecutorTest.cpp
@@ -1,0 +1,924 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpstackExecutorTest.cpp — drives OpstackExecutor over BCOS storage. opTransition/runDeposit
+// produce the final FISCO receipt directly (OP metadata + effective gas price already projected),
+// and the state diff is returned via an out-param. Storage is a plain MutableStorage.
+
+#define BOOST_TEST_MODULE BcosOpstackExecutorTests
+#include <boost/test/unit_test.hpp>
+
+#include "bcos-evm/opstack/OpForkSchedule.h"
+#include "bcos-evm/opstack/OpPredeploys.h"
+#include "opstack-executor/OpstackExecutor.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>  // construct a 33-byte-mint envelope for the over-wide test
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
+#include <memory>
+
+using namespace bcos;
+using namespace bcos::executor_v1::opstack;
+using namespace evmc::literals;  // _address / _bytes32
+
+namespace
+{
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+struct Fixture
+{
+    std::shared_ptr<crypto::CryptoSuite> cryptoSuite = std::make_shared<crypto::CryptoSuite>(
+        std::make_shared<crypto::Keccak256>(), nullptr, nullptr);
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory{
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)};
+    MutableStorage storage;
+    ledger::LedgerConfig ledgerConfig;
+
+    const bcos::evm::opstack::OpForkConfig& fork = bcos::evm::opstack::jovianConfig();
+
+    Fixture()
+    {
+        ledgerConfig.setEVMCRevision(fork.rev);
+        ledgerConfig.setGasLimit({30000000, 0});
+        ledgerConfig.setGasPrice({"0x0", 0});
+    }
+
+    bcostars::protocol::TransactionImpl buildWeb3Tx(uint64_t chainId = 10,
+        bcos::Address to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7"))
+    {
+        // Construct a minimal EIP-2930 Web3 tx directly (nonce=7, gasPrice, gasLimit, to, value,
+        // empty data/accessList, yParity=0, 32-byte r/s) — the v1 raw-RLP fixture no longer
+        // decodes under the v2 Web3Transaction path, so build fields instead of RLP. chainId
+        // defaults to 10 to match every executeTransaction call site below, so the fixture
+        // envelope must carry the same chain id the call passes.
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::EIP2930;
+        w3.chainId = chainId;
+        w3.nonce = 7;
+        w3.maxFeePerGas = bcos::u256(30000000000);  // gasPrice (EIP-2930)
+        w3.maxPriorityFeePerGas = w3.maxFeePerGas;
+        w3.gasLimit = 5000000;
+        w3.to = to;
+        w3.value = bcos::u256(2000000000000000000);  // 2 ETH
+        w3.signatureV = 0;                           // yParity
+        w3.signatureR = bcos::bytes(32, 0x01);       // dummy r/s (unused: evmone skips sig verify)
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        auto const txHash = w3.txHash();
+        tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+        // takeToTarsTransaction stores the signing preimage (Web3Transaction.cpp:220-223);
+        // overwrite with the full EIP-2718 envelope (mirroring EngineServiceImpl buildOpBlock) so
+        // the envelope is canonical wire bytes.
+        auto const envelope = w3.encode();
+        tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    // Legacy UNPROTECTED tx mirror (type=Legacy, v=27, chain_id==0) — drives the chainId
+    // EXEMPTION branch of m_prepare's EIP-155 check (legacy chain_id==0 has no chainId concept).
+    bcostars::protocol::TransactionImpl buildLegacyWeb3Tx()
+    {
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::Legacy;
+        w3.chainId = 0;  // unprotected (v=27/28)
+        w3.nonce = 7;
+        w3.maxFeePerGas = bcos::u256(30000000000);  // gasPrice (legacy single-price)
+        w3.maxPriorityFeePerGas = w3.maxFeePerGas;
+        w3.gasLimit = 5000000;
+        w3.to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7");
+        w3.value = bcos::u256(2000000000000000000);
+        w3.signatureV = 27;  // unprotected legacy
+        w3.signatureR = bcos::bytes(32, 0x01);
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        auto const txHash = w3.txHash();
+        tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+        auto const envelope = w3.encode();
+        tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    // Deposit tx mirror for single-tx deposit dispatch. isSystemTx mirrors the
+    // deposit RLP field (tars field 15), NOT Transaction::systemTx().
+    bcostars::protocol::TransactionImpl buildDepositTx(bool isSystemTx = false)
+    {
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::Deposit;
+        w3.sourceHash =
+            bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        w3.from = bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001");
+        w3.to = bcos::Address("0x4200000000000000000000000000000000000015");
+        w3.mint = bcos::u256(5);
+        w3.value = bcos::u256(0);
+        w3.gasLimit = 100000;
+        w3.isSystemTx = isSystemTx;
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    template <class T>
+    static T sync(task::Task<T> t)
+    {
+        return task::syncWait(std::move(t));
+    }
+};
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpstackExecutorTestSuite)
+
+BOOST_AUTO_TEST_CASE(ConstructsWithJovianFork)
+{
+    auto rf =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+    OpstackExecutor executor(rf, makeCryptoSuite()->hashImpl());
+    BOOST_CHECK_NE(&executor.vm(), nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(BuildOpBlockInfoMirrorsBlockPath)
+{
+    // buildBlockInfo must mirror toBlockInfo's field mapping (OpCommon.h:106-121) so eth_call
+    // sees the same block context as block execution: seconds timestamp, header baseFee (via
+    // value_or(0), so optional-less test headers do not throw), and the full field set.
+    auto h = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    h->setNumber(7);
+    h->setTimestamp(1'234'567'890);  // ms; block path divides by 1000
+    h->setCoinbase(bcos::Address{"0x00000000000000000000000000000000000000aa"});
+    h->setBaseFee(bcos::u256(1'000'000'000));
+    h->setPrevRandao(
+        bcos::h256{"0xab00000000000000000000000000000000000000000000000000000000000000"});
+    h->setParentBeaconBlockRoot(
+        bcos::h256{"0xcd00000000000000000000000000000000000000000000000000000000000000"});
+    h->setExtraData(bcos::bytes{0xde, 0xad});
+    h->setBlobGasUsed(bcos::u256(0x1234));
+
+    const auto blk = bcos::executor_v1::opstack::OpstackExecutor::buildBlockInfo(*h, 30'000'000);
+    BOOST_CHECK_EQUAL(blk.number, 7);
+    BOOST_CHECK_EQUAL(blk.timestamp, 1'234'567ULL);  // ms -> s
+    BOOST_CHECK_EQUAL(blk.gas_limit, 30'000'000);    // injected gasLimit
+    // intx::uint256 / evmc::bytes / optional<uint64_t> have no operator<< — use plain BOOST_CHECK
+    // (same predicate as EXPECT_EQ, just without value printing on failure).
+    BOOST_CHECK(blk.base_fee == intx::uint256(1'000'000'000));  // header baseFee, NOT 0
+    BOOST_CHECK_EQUAL(blk.prev_randao.bytes[0], 0xab);          // full field set
+    BOOST_CHECK_EQUAL(blk.parent_beacon_block_root.bytes[0], 0xcd);
+    BOOST_CHECK(blk.extra_data == (evmc::bytes{0xde, 0xad}));
+    BOOST_CHECK(blk.blob_gas_used == 0x1234ULL);
+}
+
+BOOST_FIXTURE_TEST_CASE(ExecutesNormalTransferEndToEnd, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        // EIP-3607: evmone validate_transaction rejects a sender whose code_hash !=
+        // EMPTY_CODE_HASH. Seed the canonical empty-code hash so the sender is recognised as an
+        // EOA.
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    // FISCO internal convention: 0 = success (the Ethereum RPC 0<->1 flip happens later).
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    BOOST_CHECK_GE(receipt->gasUsed(), 21000u);
+    BOOST_CHECK_EQUAL(receipt->blockNumber(), 1);
+    BOOST_CHECK(receipt->opStackMeta().has_value());
+}
+
+BOOST_FIXTURE_TEST_CASE(RejectsForkRevisionMismatch, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    ledgerConfig.setEVMCRevision(EVMC_FRONTIER);  // deliberately != fork.rev
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    auto tx = buildWeb3Tx();
+    bcos::evm::opstack::OpFeeParams fee{};
+    BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(
+                          storage, blockHeader, tx, 0, ledgerConfig, false, fee, 30000000, 10)),
+        bcos::executor_v1::opstack::OpForkRevisionMismatch);
+}
+
+BOOST_FIXTURE_TEST_CASE(RejectsInvalidTx, Fixture)
+{
+    // Balance 0 sender + value transfer -> insufficient balance -> OpTxValidationFailed.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    // No account created -> balance 0 -> validation fails.
+    bcos::evm::opstack::OpFeeParams fee{};
+    BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(
+                          storage, blockHeader, tx, 0, ledgerConfig, false, fee, 30000000, 10)),
+        bcos::executor_v1::opstack::OpTxValidationFailed);
+}
+
+BOOST_FIXTURE_TEST_CASE(ChargesL1AndOperatorFees, Fixture)
+{
+    // Non-zero L1 + operator fee params route through opValidate (pre-charge) -> opTransition
+    // (deriveOpReceiptMeta) and surface in the receipt's opStackMeta.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    fee.l1_base_fee = 1000;
+    fee.base_fee_scalar = 7;
+    fee.blob_base_fee = 2000;
+    fee.blob_base_fee_scalar = 9;
+    fee.operator_fee_scalar = 11;
+    fee.operator_fee_constant = 13;
+
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    // Jovian derives these unconditionally.
+    BOOST_CHECK(meta->l1_fee.has_value());
+    BOOST_CHECK(meta->l1_gas_price.has_value());
+    // operator_fee_scalar filled when has_operator_fee && (scalar != 0 || constant != 0).
+    BOOST_CHECK(meta->operator_fee_scalar.has_value());
+    BOOST_CHECK_EQUAL(*meta->operator_fee_scalar, 11u);
+}
+
+BOOST_FIXTURE_TEST_CASE(ReceiptMetaSurvives, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    fee.l1_base_fee = 1000;
+    fee.base_fee_scalar = 7;
+
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->l1_gas_price.has_value());
+    BOOST_CHECK(*meta->l1_gas_price == bcos::u256(1000));
+    // v2 deriveOpReceiptMeta derives l1_base_fee_scalar from props.fee (not l1_gas_used, which the
+    // v2 implementation no longer fills); the fee below set base_fee_scalar=7.
+    BOOST_REQUIRE(meta->l1_base_fee_scalar.has_value());
+    BOOST_CHECK_EQUAL(*meta->l1_base_fee_scalar, 7u);
+    // effective_gas_price = base_fee(0) + min(maxPriority, maxFee-0); for this EIP-2930 tx
+    // BCOS2Evmone.h maps max_gas_price = max_priority_gas_price = gasPrice, so effective =
+    // gasPrice = 0x6fc23ac00.
+    BOOST_CHECK_EQUAL(receipt->effectiveGasPrice(), "0x6fc23ac00");
+}
+
+// ---- executeDeposit + finalizeBlock (reuse bcos-evm/opstack runDeposit / finalizeOpBlock) ----
+
+BOOST_FIXTURE_TEST_CASE(ExecutesDepositMint, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto kFrom = 0x000000000000000000000000000000000000dead_address;
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x01_bytes32,
+        .from = kFrom,
+        .to = std::nullopt,  // contract creation
+        .mint = intx::uint256{5},
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, kFrom, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    auto receipt = task::syncWait(executor.executeDeposit(
+        storage, blockHeader, dep, /*chainId=*/10, /*blockGasLeft=*/30000000, ledgerConfig));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    // mint(5) added to the from balance.
+    ledger::account::EVMAccount<MutableStorage> acc(storage, kFrom, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+    // deposit_nonce == 0, version == 1 (Canyon+).
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->deposit_nonce.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_nonce, 0u);
+    BOOST_REQUIRE(meta->deposit_receipt_version.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_receipt_version, 1u);
+}
+
+BOOST_FIXTURE_TEST_CASE(ExecutesDepositThroughExecuteTransaction, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    constexpr auto from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    // fee default {} — deposit must ignore it (no L1/operator fee).
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, /*fee=*/{}, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    // mint(5) added to from balance (distinguishes deposit from a normal-path run, which mints
+    // nothing).
+    ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+
+    // deposit_nonce == 0, version == 1 (Canyon+).
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->deposit_nonce.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_nonce, 0u);
+    BOOST_REQUIRE(meta->deposit_receipt_version.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_receipt_version, 1u);
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositLifecycleThroughExecuteContext, Fixture)
+{
+    // Concept lifecycle (createExecuteContext -> prepare -> execute -> finish) on a deposit tx:
+    // the deposit branch must short-circuit opValidate and run executeDeposit, and finish() must
+    // decrement ctx.blockGasLeft + backfill the receipt's cumulativeGasUsed.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    constexpr auto from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    constexpr int64_t kInitialGasLeft = 30000000;
+    OpBlockExecutionContext ctx{};
+    ctx.blockGasLeft = kInitialGasLeft;
+    ctx.chainId = 10;  // blockHashes left null -> executeDeposit uses ZeroBlockHashes
+
+    auto context = task::syncWait(executor.createExecuteContext(
+        storage, blockHeader, tx, /*contextID=*/0, ledgerConfig, /*call=*/false, ctx));
+    task::syncWait(context.prepare());
+    task::syncWait(context.execute());
+    auto receipt = task::syncWait(context.finish());
+
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    // mint(5) applied to the from balance (distinguishes the deposit path from a no-op).
+    ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+    // blockGasLeft decremented by the deposit's gasUsed; cumulative gas backfilled on the receipt.
+    auto const gasUsed = bcos::evm::opstack::narrowGasUsed(receipt->gasUsed());
+    BOOST_CHECK_LT(ctx.blockGasLeft, kInitialGasLeft);
+    BOOST_CHECK_EQUAL(ctx.blockGasLeft, kInitialGasLeft - gasUsed);
+    BOOST_CHECK(ctx.cumulativeGasUsed == gasUsed);
+    BOOST_CHECK_EQUAL(
+        std::string(receipt->cumulativeGasUsed()), bcos::evm::opstack::hexCumulative(gasUsed));
+}
+
+// 6-arg createExecuteContext (generic scheduler / concept form) has no BlockContext: the old
+// default-arg footgun left m_ctx pointing at a destroyed temporary. It must now build a null-ctx
+// context whose prepare() throws a clear OpConsensusError instead of UB.
+BOOST_FIXTURE_TEST_CASE(NullContextSixArgFormThrows, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    auto context = task::syncWait(executor.createExecuteContext(
+        storage, blockHeader, tx, /*contextID=*/0, ledgerConfig, /*call=*/false));
+    BOOST_CHECK_THROW(task::syncWait(context.prepare()), bcos::evm::engine::OpConsensusError);
+    BOOST_CHECK_THROW(task::syncWait(context.execute()), bcos::evm::engine::OpConsensusError);
+    BOOST_CHECK_THROW(task::syncWait(context.finish()), bcos::evm::engine::OpConsensusError);
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositGasLimitReachedIsBlockError, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x02_bytes32,
+        .from = 0x000000000000000000000000000000000000dead_address,
+        .to = 0x0000000000000000000000000000000000000001_address,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    // gas_limit(100000) > blockGasLeft(100) -> runDeposit throws std::runtime_error.
+    BOOST_CHECK_THROW(task::syncWait(executor.executeDeposit(storage, blockHeader, dep,
+                          /*chainId=*/10, /*blockGasLeft=*/100, ledgerConfig)),
+        std::runtime_error);
+}
+
+BOOST_FIXTURE_TEST_CASE(FinalizeOpBlockNoReward, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.setCoinbase(bcos::Address(bcos::bytes(20, 0x11)));
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto kCoinbase = 0x1111111111111111111111111111111111111111_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, kCoinbase, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(100));
+        co_return;
+    }());
+
+    task::syncWait(executor.finalizeBlock(storage, blockHeader, ledgerConfig));
+
+    // OP has no block reward: coinbase balance unchanged.
+    ledger::account::EVMAccount<MutableStorage> acc(storage, kCoinbase, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 100u);
+}
+
+BOOST_FIXTURE_TEST_CASE(BlockInfoGasLimitUsesHeaderGasLimit, Fixture)
+{
+    // buildBlockInfo's gasLimit takes header.gasLimit (not blockGasLeft). Behavior assertion:
+    // executing a minimal GASLIMIT-reading contract, slot0 must store == header.gasLimit().
+    // Before the fix: executeTransaction's BlockInfo.gasLimit = blockGasLeft (injected value), so
+    // the contract stored blockGasLeft; injecting blockGasLeft(250000) < header.gasLimit(1000000)
+    // went red. After the fix: BlockInfo.gasLimit = header.gasLimit == 1000000 → green.
+    // blockGasLeft must be ≥ tx.gasLimit(200000) (else state.cpp:390 GAS_LIMIT_REACHED rejects at
+    // validation and the test is permanently red) AND < header.gasLimit(1000000) to expose the
+    // fork.
+    constexpr auto kObserver = 0x00000000000000000000000000000000000000aa_address;
+    constexpr auto kSender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    const bcos::bytes kObserverCode{0x45, 0x60, 0x00, 0x55, 0x00};  // GASLIMIT; PUSH1 0; SSTORE;
+                                                                    // STOP
+
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.setGasLimit(bcos::u256(1000000));  // exercises the header-gasLimit path
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+    ledgerConfig.setEVMCRevision(fork.rev);
+
+    // Deploy the GASLIMIT observer contract + fund the sender (mirror the fundAccount pattern).
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> obs(storage, kObserver, false);
+        co_await obs.create();
+        co_await obs.setCode(kObserverCode, "", cryptoSuite->hashImpl()->hash(kObserverCode));
+        co_await obs.setBalance(bcos::u256(0));
+        co_await obs.setNonce("0");
+        ledger::account::EVMAccount<MutableStorage> snd(storage, kSender, false);
+        co_await snd.create();
+        co_await snd.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        co_await snd.setBalance(u256("100000000000000000000"));
+        co_await snd.setNonce("0");
+        co_return;
+    }());
+
+    // EIP-1559 tx calling the observer with empty data, value 0. chainId=10 matches the
+    // executeTransaction call below.
+    bcos::rpc::Web3Transaction w3{};
+    w3.type = bcos::rpc::TransactionType::EIP1559;
+    w3.chainId = 10;
+    w3.nonce = 0;
+    w3.maxFeePerGas = bcos::u256(30000000000);
+    w3.maxPriorityFeePerGas = bcos::u256(0);
+    w3.gasLimit = 200000;
+    w3.to = bcos::Address("0x00000000000000000000000000000000000000aa");
+    w3.value = bcos::u256(0);
+    w3.signatureV = 0;
+    w3.signatureR = bcos::bytes(32, 0x01);
+    w3.signatureS = bcos::bytes(32, 0x02);
+    auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+    auto const txHash = w3.txHash();
+    tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+    // Overwrite the signing preimage with the full EIP-2718 envelope.
+    auto const envelope = w3.encode();
+    tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+    bcostars::protocol::TransactionImpl tx([tarsHolder]() { return tarsHolder.get(); });
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(kSender.bytes, kSender.bytes + sizeof(kSender.bytes)));
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    // Inject blockGasLeft=250000 < header.gasLimit=1000000 (≥ tx.gasLimit 200000 passes
+    // validation, < header exposes the GASLIMIT fork) — the key to exposing the fork.
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/250000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    // Read observer slot0: must == header.gasLimit (1000000), not the injected blockGasLeft.
+    // The storage key is raw 32 bytes (evmc_bytes32{}=32 0x00 bytes); neither
+    // storageEntry("0") nor a hex string reads it. EVMAccount::storage() returns an evmc_bytes32
+    // value (all-zero when unset), not an optional — parse slot.bytes with intx::be::load
+    // (32-byte big-endian), not storageEntry's has_value()/operator->.
+    ledger::account::EVMAccount<MutableStorage> obs(storage, kObserver, false);
+    auto slot = task::syncWait(obs.storage(evmc_bytes32{}));  // EVMAccount.h:210
+    BOOST_CHECK(intx::be::load<intx::uint256>(slot.bytes) == intx::uint256(1000000));
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositIsSystemTransactionGetter, Fixture)
+{
+    auto tx = buildDepositTx(/*isSystemTx=*/true);
+    BOOST_CHECK(tx.isDepositTx());                 // web3TypedTxKind == 0x7e
+    BOOST_CHECK(tx.depositIsSystemTransaction());  // tars field 15 == 1
+
+    auto tx2 = buildDepositTx(/*isSystemTx=*/false);
+    BOOST_CHECK(tx2.isDepositTx());
+    BOOST_CHECK(!tx2.depositIsSystemTransaction());  // tars field 15 == 0
+}
+
+/// kyonRay review #5429 K3: consensus deposit fields MUST come from the signed 0x7E envelope
+/// (decodeDepositEnvelope), never from the unauthenticated tars mirrors. Happy path decodes a
+/// legit buildDepositTx envelope; rejection paths cover a non-0x7e type byte and trailing bytes.
+BOOST_AUTO_TEST_CASE(DecodeDepositEnvelopeFromSignedEnvelope)
+{
+    Fixture f;
+    auto tx = f.buildDepositTx(/*isSystemTx=*/false);
+    auto env = tx.extraTransactionBytes();
+    BOOST_REQUIRE(!env.empty());
+    BOOST_CHECK_EQUAL(env[0], 0x7e);
+
+    auto dep = decodeDepositEnvelope(env);
+    // sourceHash matches the builder's fixed h256.
+    bcos::crypto::HashType sh("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    BOOST_CHECK(std::equal(
+        dep.source_hash.bytes, dep.source_hash.bytes + sizeof(dep.source_hash.bytes), sh.begin()));
+    // from == the builder's dead...0001 address.
+    BOOST_CHECK_EQUAL(bcos::toHexStringWithPrefix(
+                          bcos::bytes(dep.from.bytes, dep.from.bytes + sizeof(dep.from.bytes))),
+        "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001");
+    BOOST_REQUIRE(dep.to.has_value());
+    BOOST_CHECK_EQUAL(bcos::toHexStringWithPrefix(
+                          bcos::bytes(dep.to->bytes, dep.to->bytes + sizeof(dep.to->bytes))),
+        "0x4200000000000000000000000000000000000015");
+    BOOST_REQUIRE(dep.mint.has_value());
+    BOOST_CHECK(dep.mint.value() == intx::uint256{5});  // intx::uint256 has no ostream<<
+    BOOST_CHECK(dep.value == intx::uint256{0});
+    BOOST_CHECK_EQUAL(dep.gas_limit, 100000);
+    BOOST_CHECK(!dep.is_system_tx);
+    BOOST_CHECK(dep.data.empty());
+
+    // Rejection: a non-0x7e type byte (the 0x02-envelope + 0x7e-mirror attack) must fail loud.
+    bcos::bytes bad(env.begin(), env.end());
+    bad[0] = 0x02;
+    BOOST_CHECK_THROW(
+        [&]() { (void)decodeDepositEnvelope(bcos::ref(bad)); }(), OpTxValidationFailed);
+
+    // Rejection: trailing bytes after the RLP list must be refused (strict, consensus-grade).
+    bcos::bytes trailing(env.begin(), env.end());
+    trailing.push_back(0x00);
+    BOOST_CHECK_THROW(
+        [&]() { (void)decodeDepositEnvelope(bcos::ref(trailing)); }(), OpTxValidationFailed);
+
+    // Rejection (#1, kyonRay): an over-wide integer (33-byte mint) must fail loud —
+    // rlp::decode(UnsignedIntegral) alone would truncate to the low 32 bytes via fromBigEndian.
+    {
+        bcos::bytes body;
+        bcos::codec::rlp::encode(
+            body, bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"));
+        bcos::codec::rlp::encode(body, bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"));
+        bcos::codec::rlp::encode(body, bcos::Address("0x4200000000000000000000000000000000000015"));
+        bcos::codec::rlp::encode(body, bcos::bytes(33, 0xff));  // 33-byte mint -> over-wide
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // value = 0 (empty RLP item)
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // gas = 0
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // isSystemTx = 0
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // data = empty
+        bcos::bytes list;
+        bcos::codec::rlp::encodeHeader(list, bcos::codec::rlp::Header{true, body.size()});
+        list.insert(list.end(), body.begin(), body.end());
+        bcos::bytes overWideEnv{0x7e};
+        overWideEnv.insert(overWideEnv.end(), list.begin(), list.end());
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(overWideEnv)); }(), OpTxValidationFailed);
+    }
+
+    // Rejection (#2 round 3, kyonRay): non-canonical integers / int64 range / bool — the width
+    // gate does not cover these, and rlp::decode only rejects one non-canonical form (single-byte
+    // payload < 0x80 via decodeHeader). Build an envelope from raw per-field items so we can feed
+    // encodings RLPEncode would never emit. Field order: sourceHash, from, to, mint, value, gas,
+    // isSystemTx, data.
+    auto canonicalItems = []() {
+        bcos::bytes sh, from, to, mint, value, gas, isSystem, data;
+        bcos::codec::rlp::encode(
+            sh, bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"));
+        bcos::codec::rlp::encode(from, bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"));
+        bcos::codec::rlp::encode(to, bcos::Address("0x4200000000000000000000000000000000000015"));
+        bcos::codec::rlp::encode(mint, bcos::bytes{5});                // mint = 5 (bare Byte)
+        bcos::codec::rlp::encode(value, bcos::bytes{});                // value = 0 (empty item)
+        bcos::codec::rlp::encode(gas, bcos::bytes{0x01, 0x86, 0xa0});  // gas = 100000
+        bcos::codec::rlp::encode(isSystem, bcos::bytes{});             // isSystemTx = false
+        bcos::codec::rlp::encode(data, bcos::bytes{});                 // data = empty
+        return std::vector<bcos::bytes>{sh, from, to, mint, value, gas, isSystem, data};
+    };
+    auto envelopeFromItems = [](std::vector<bcos::bytes> const& items) {
+        bcos::bytes body;
+        for (auto const& it : items)
+            body.insert(body.end(), it.begin(), it.end());
+        bcos::bytes list;
+        bcos::codec::rlp::encodeHeader(list, bcos::codec::rlp::Header{true, body.size()});
+        bcos::bytes env{0x7e};
+        env.insert(env.end(), list.begin(), list.end());
+        return env;
+    };
+
+    // (a) leading-zero multi-byte integer (value = 0x82 0x00 0x05): would fold to 5, but op-geth
+    // rejects it as ErrCanonInt.
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x82, 0x00, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (b) single Byte 0x00 (value): integer zero must be the empty item 0x80 — op-geth ErrCanonInt.
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x00};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (c) gas = uint64 max (0x88 FF..FF): static_cast<int64_t>(gas) would wrap to -1; the decoder
+    // rejects values that exceed int64 range.
+    {
+        auto items = canonicalItems();
+        items[5] = bcos::bytes{0x88, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};  // gas
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (d) isSystemTx = bare Byte 2: != 0 would read true, but op-geth decodeBool accepts only the
+    // empty item (false) and 0x01 (true).
+    {
+        auto items = canonicalItems();
+        items[6] = bcos::bytes{0x02};  // isSystemTx
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (e) non-canonical short string (value = 0x81 0x05): a single-byte payload < 0x80 must be a
+    // bare Byte, not a short string — op-geth ErrCanonInt. This is the integerPayloadLength
+    // `pl==1 && ref[1] < 0x80` arm (decodeHeader's NonCanonicalSize is a second, consistent path).
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x81, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (f) RLP list as integer (value = 0xc1 0x05): integerPayloadLength returns nullopt for any
+    // list header — a list is never a well-formed integer (op-geth Stream rejects it).
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0xc1, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (g) isSystemTx = bare Byte 1: end-to-end happy path for the true arm (op-geth decodeBool
+    // 0x01 → true) — the builder's isSystemTx=false default never exercises it.
+    {
+        auto items = canonicalItems();
+        items[6] = bcos::bytes{0x01};  // isSystemTx
+        auto dep = decodeDepositEnvelope(bcos::ref(envelopeFromItems(items)));
+        BOOST_CHECK(dep.is_system_tx);
+    }
+}
+
+// chainId-mismatch enforcement (morebtcg/kyonRay review #5429, review finding E): op-geth
+// EIP155Signer/modernSigner reject txs whose chainId differs from the node's (ErrInvalidChainId).
+// Before this test the rejection had ZERO negative coverage — every test fed a self-consistent
+// chainId. Cases (1)(2) need no sender funding: the check runs before opValidate's gates.
+BOOST_FIXTURE_TEST_CASE(ChainIdMismatchEnforced, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+
+    // (1) protected tx chainId(9) != node chainId(10) -> OpConsensusError.
+    {
+        auto tx = buildWeb3Tx(/*chainId=*/9);
+        tx.clearSenderAndHash();
+        tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+        BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+                              /*contextID=*/0, ledgerConfig, /*call=*/false, fee,
+                              /*blockGasLeft=*/30000000, /*chainId=*/10)),
+            bcos::evm::engine::OpConsensusError);
+    }
+    // (2) typed tx chain_id==0 is NOT exempt (modernSigner rejects 0 != node chainId; a
+    // malicious proposer can craft a 0x02 envelope with chain_id 0). Pinned so a future
+    // "chain_id==0 means unprotected" regression fails.
+    {
+        auto tx = buildWeb3Tx(/*chainId=*/0);
+        tx.clearSenderAndHash();
+        tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+        BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+                              /*contextID=*/0, ledgerConfig, /*call=*/false, fee,
+                              /*blockGasLeft=*/30000000, /*chainId=*/10)),
+            bcos::evm::engine::OpConsensusError);
+    }
+}
+
+// legacy v=27/28 unprotected (chain_id==0) IS exempt: no chainId concept, accepted regardless of
+// the node chainId. Runs the FULL path (funded sender) to prove it executes rather than being
+// caught and reclassified.
+BOOST_FIXTURE_TEST_CASE(LegacyUnprotectedChainIdExempt, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildLegacyWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);       // chainId exempt: executes instead of throwing
+    BOOST_CHECK_EQUAL(receipt->status(), 0);  // and succeeds — not reverted-but-accepted
+}
+
+// CRITICAL-A regression (independent review): a transfer to a c_systemTxsAddress (0x...1000)
+// must credit /apps/<1000> — the table the read side and the state root use — not /sys/<1000>.
+// Before the fix the production write path used the address-taking EVMAccount ctor, which routes
+// these 8 addresses to /sys/, so the credit was invisible to the state root (state-root
+// divergence vs op-geth). Read back via the same Storage2State /apps/ path the root uses.
+BOOST_FIXTURE_TEST_CASE(TransferToSystemAddressCreditsAppsBalance, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto sysAddr = 0x0000000000000000000000000000000000001000_address;  // SYS_CONFIG
+    auto tx =
+        buildWeb3Tx(/*chainId=*/10, bcos::Address("0x0000000000000000000000000000000000001000"));
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+
+    // The state root reads /apps/ (accountTableName); the credit must be visible there.
+    bcos::evm::evmstate::Storage2State<MutableStorage> view(storage, {});
+    auto acc = view.get_account(sysAddr);
+    BOOST_REQUIRE(acc.has_value());
+    BOOST_CHECK(acc->balance == intx::uint256(2000000000000000000));  // the 2 ETH transfer value
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Part **6 of 7** — web3 handlers part 2 and model updates.

> **Depends on**: Part 5 (opstack-s05) — block execution impl + web3 handlers pt1.

## What's in this part
- **Web3Transaction.h/cpp** — deposit/EIP4844/EIP7702 transaction types
- **ReceiptResponse.cpp** — receipt response updates
- **TransactionResponse.cpp** — transaction response updates
- **EthEndpoint.cpp** — eth endpoint updates

## Verification
- Commit Check: valid insertions = **489** (≤ 666 limit)

Split from #5429 | Part 6/7