### PR TITLE
feat(opstack): part 7/7 — engine service & wiring (split from #5429)

### DIFF
--- a/.github/actions/opstack-t8n-regen/action.yml
+++ b/.github/actions/opstack-t8n-regen/action.yml
@@ -1,0 +1,53 @@
+name: opstack-t8n-regen
+description: >-
+  Regenerate opstack t8n reference vectors (opstack-executor/tests/t8n/{vectors,golden})
+  from pinned op-geth before running tests. The generated JSON is git-ignored and never
+  committed; this action materializes it into the checkout source tree, where the C++
+  tests read it via the OP_T8N_* compile-time absolute-path macros.
+  The op-geth provisioning + regen logic lives in
+  opstack-executor/tests/t8n/generator/ensure-vectors.sh, so local verification runs the
+  exact same steps as CI.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve op-geth pin
+      # Single source of truth is regen.sh's PIN= line; this just surfaces it for the
+      # cache key below (and passes it through so ensure-vectors.sh can't drift).
+      id: pin
+      shell: bash
+      run: |
+        set -euo pipefail
+        REGEN="$GITHUB_WORKSPACE/opstack-executor/tests/t8n/generator/regen.sh"
+        PIN="$(sed -nE 's/^PIN="([0-9a-f]{40})"/\1/p' "$REGEN")"
+        if [ -z "$PIN" ]; then
+          echo "::error::failed to extract PIN from regen.sh"
+          exit 1
+        fi
+        echo "pin=${PIN}" >> "$GITHUB_OUTPUT"
+
+    - name: Set up Go
+      # regen.sh builds the generator inside the op-geth module (go.mod: go 1.24.0 at the
+      # pinned commit). Fixed version instead of go-version-file: op-geth is provisioned
+      # by ensure-vectors.sh (a plain shell step), which runs after this action.
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.x'
+
+    - name: Cache pinned op-geth tree
+      # Content-addressed by the pinned commit, so a re-run at the same pin re-uses the
+      # shallow checkout (saves clone time/bandwidth). os in the key: the tree is checked
+      # out per-runner, avoid cross-OS cache restore.
+      id: opcache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/op-geth
+        key: op-geth-${{ runner.os }}-${{ steps.pin.outputs.pin }}
+
+    - name: Regenerate t8n vectors
+      shell: bash
+      env:
+        OPGETH: ${{ runner.temp }}/op-geth
+      run: |
+        set -euo pipefail
+        bash "$GITHUB_WORKSPACE/opstack-executor/tests/t8n/generator/ensure-vectors.sh"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -132,6 +132,12 @@ jobs:
         run: |
           cd build
           cmake --build .
+      - name: Regenerate opstack t8n vectors
+        # The opstack t8n tests (opstack-executor-block-tests) read reference vectors
+        # from the source tree at runtime; the JSON is git-ignored and regenerated here
+        # from pinned op-geth before `ctest`. Windows builds with -DTESTS=OFF, so no tests.
+        if: matrix.os != 'windows-2025'
+        uses: ./.github/actions/opstack-t8n-regen
       - name: Test
         if: matrix.os != 'windows-2025'
         run: |
@@ -376,6 +382,10 @@ jobs:
         run: |
           cd build
           cmake --build . --parallel 3
+      - name: Regenerate opstack t8n vectors
+        # ctest below includes opstack-executor-block-tests, which needs the t8n vectors
+        # in the source tree at runtime (git-ignored, regenerated from pinned op-geth).
+        uses: ./.github/actions/opstack-t8n-regen
       - name: Run tests
         run: |
           cd build

--- a/bcos-evm/test/CMakeLists.txt
+++ b/bcos-evm/test/CMakeLists.txt
@@ -9,40 +9,48 @@ target_link_libraries(bcos-evm-eth-tests PRIVATE
 )
 add_test(NAME BcosEvmEthTests COMMAND bcos-evm-eth-tests)
 
-# opstack 库及其测试仅 FULLNODE 集成构建包含（依赖 bcos-framework/ledger/protocol-tars，
-# standalone 下无这些目标/头）；BCOS_EVM_STANDALONE 分支只构建 bcos-evm-eth-tests。
-if(NOT BCOS_EVM_STANDALONE)
-    add_executable(bcos-evm-opstack-tests
-        opstack/TestMain.cpp
-        opstack/OpForkScheduleTest.cpp
-        opstack/OpHostTest.cpp
-        opstack/OpPrecompilesTest.cpp
-        opstack/OpFeeParamsTest.cpp
-        opstack/OpDepositTxTest.cpp
-        opstack/OpPredeploysTest.cpp
-        opstack/RollupCostTest.cpp
-        opstack/OpValidateTest.cpp
-        opstack/OpTransitionTest.cpp
-        opstack/OpDepositTest.cpp
-        opstack/OpZeroDiffTest.cpp
-        opstack/OpReceiptMetaTest.cpp
-        opstack/Op7702Test.cpp
-        opstack/OpFloorGasTest.cpp
-        opstack/OpZeroFeeSpikeTest.cpp
-        opstack/StateRootComputeTest.cpp
-        opstack/OpCommonTest.cpp
-        opstack/Storage2StateBridgeTest.cpp
-        testutils/MemoryState.cpp
+add_executable(bcos-evm-opstack-tests
+    opstack/TestMain.cpp
+    opstack/OpForkScheduleTest.cpp
+    opstack/OpHostTest.cpp
+    opstack/OpPrecompilesTest.cpp
+    opstack/OpFeeParamsTest.cpp
+    opstack/OpDepositTxTest.cpp
+    opstack/OpPredeploysTest.cpp
+    opstack/RollupCostTest.cpp
+    opstack/OpValidateTest.cpp
+    opstack/OpTransitionTest.cpp
+    opstack/OpDepositTest.cpp
+    opstack/OpZeroDiffTest.cpp
+    opstack/OpReceiptMetaTest.cpp
+    opstack/Op7702Test.cpp
+    opstack/OpFloorGasTest.cpp
+    opstack/OpZeroFeeSpikeTest.cpp
+)
+target_link_libraries(bcos-evm-opstack-tests PRIVATE
+    bcosevm::opstack
+    Boost::unit_test_framework
+)
+
+# OpEnvelopeToTarsTest is the sole guard-block test kept in bcos-evm: it verifies
+# opEnvelopeToTars' sender derivation against known-signature envelopes. It is in-tree-only —
+# it needs bcos-framework targets (codec / protocol-tars / ledger / engine / rpc) that exist only
+# when the top-level CMakeLists.txt add_subdirectory(bcos-framework) runs first. It includes
+# <engine/bcos-engine/EngineServiceImpl.h> (needs the repo root on the include path) and needs
+# `engine` + `rpc` for the non-template helpers / EngineHelper symbols; the jsoncpp link covers
+# EngineServiceImpl.h's include chain (bcos-rpc/jsonrpc/Common.h). `ledger`/`engine`/`rpc` are
+# added by the root CMakeLists.txt AFTER bcos-evm, so the target references resolve at generate
+# time (same pattern as the source branch's test CMake).
+if(TARGET bcos-framework)
+    find_package(jsoncpp CONFIG REQUIRED)
+    target_sources(bcos-evm-opstack-tests PRIVATE
+        opstack/OpEnvelopeToTarsTest.cpp
     )
-    target_include_directories(bcos-evm-opstack-tests PRIVATE
-        ${CMAKE_SOURCE_DIR}/opstack-executor)
     target_link_libraries(bcos-evm-opstack-tests PRIVATE
-        bcosevm::opstack
-        protocol-tars
-        bcos-crypto
-        bcos-utilities
-        ledger
-        Boost::unit_test_framework
-    )
-    add_test(NAME BcosEvmOpstackTests COMMAND bcos-evm-opstack-tests)
+        codec protocol-tars ledger engine bcos-utilities jsoncpp_static rpc)
+    target_include_directories(bcos-evm-opstack-tests PRIVATE
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/bcos-ledger
+        ${CMAKE_SOURCE_DIR}/bcos-rpc)
 endif()
+add_test(NAME BcosEvmOpstackTests COMMAND bcos-evm-opstack-tests)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,7 +11,13 @@ add_library(engine ${SRC_LIST})
 target_include_directories(engine PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-engine>)
-target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger)
+target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger rlp-protocol)
+# rpc is a build-tree-only private link (opEnvelopeToTars in EngineServiceImpl.cpp uses
+# Web3Transaction). rpc is NOT in the fiscobcosTargets export set, so a bare `PRIVATE rpc` would
+# make install(EXPORT fiscobcosTargets) fail ("requires target rpc that is not in any export set").
+# $<BUILD_INTERFACE:...> keeps the link at build time and drops it from the installed export --
+# correct because Web3Transaction.h is only used by the .cpp (D6: never in EngineServiceImpl.h).
+target_link_libraries(engine PRIVATE $<BUILD_INTERFACE:rpc>)
 set_target_properties(engine PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -19,12 +19,92 @@
 #include "EngineServiceImpl.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <limits>
+
+// OP receipt/tx queryability (option B) write-side conversion helper: raw EIP-2718 envelope ->
+// tars Transaction. Web3Transaction.h already pulls in RLPDecode/TransactionImpl; RLPDecode is
+// kept explicitly (rlp::decode is actually used, include self-sufficiency). Keccak256.h and
+// TransactionImpl.h are not used directly in this file, so they were removed.
+#include "bcos-rpc/web3jsonrpc/model/Web3Transaction.h"
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <optional>
+
+namespace bcos::engine::detail
+{
+std::optional<bcostars::Transaction> opEnvelopeToTars(
+    bcos::bytes const& env, bcos::crypto::HashType const& txHash)
+{
+    bcos::rpc::Web3Transaction web3Tx;
+    bcos::bytesRef envRef{const_cast<bcos::byte*>(env.data()), env.size()};
+    if (auto err = bcos::codec::rlp::decode(envRef, web3Tx); err)
+    {
+        return std::nullopt;  // only malformed/un-enumerated envelopes -- no throw; 0x04 is already
+                              // supported by Web3Transaction
+    }
+    auto tarsTx = web3Tx.takeToTarsTransaction();
+    // The read side's tx.hash() returns extraTransactionHash; leaving it empty would throw
+    // EmptyTransactionHash.
+    tarsTx.extraTransactionHash.assign(txHash.begin(), txHash.end());
+    // For non-deposits, fill sender (takeToTarsTransaction leaves it empty; the read side's from
+    // reads tx.sender()). Note: web3Tx.sender() returns a "0x"-prefixed hex string
+    // (Web3Transaction.cpp:207-223), while tarsTx.sender must be raw 20 bytes (the read side's
+    // toHex(tx.sender()) expects raw bytes) -- must restore via fromHex, otherwise it
+    // double-encodes into 84 garbage characters. The deposit branch already fills raw bytes
+    // (:121); the sender.empty() guard skips it.
+    if (tarsTx.sender.empty())
+    {
+        try
+        {
+            auto sender = bcos::fromHex(web3Tx.sender());  // DataConvertUtility.h:119-166, 0x-aware
+            tarsTx.sender.assign(sender.begin(), sender.end());
+        }
+        catch (std::exception const&)
+        {
+            // web3Tx.sender() → Secp256k1Crypto::recoverAddress throws InvalidSignature on a bad
+            // signature. Without this, the exception escapes to the RPC layer and is misclassified
+            // as -32603; the caller's nullopt fallback (EngineServiceImpl.h:1184-1197) instead
+            // carries the raw envelope to decodeOneRawTx, which issues the INVALID verdict.
+            return std::nullopt;
+        }
+    }
+    return tarsTx;
+}
+}  // namespace bcos::engine::detail
 
 namespace
 {
 constexpr std::size_t c_hashBytes = 32;
 constexpr std::size_t c_payloadIdBytes = 8;
+
+// ---- ETH/OP header protocol constants ----
+//
+// These three header fields have no carrier in `ExecutionPayload` because they are fixed by the
+// protocol on post-merge OP chains; the header reconstruction below must still emit them (they
+// are real RLP fields — the header carries them via uncleHash()/difficulty()/nonce(),
+// populated by applyOpHeaderConstants).
+//
+// Values are byte-identical to the two other places in this repo that pin them:
+// `bcos-evm/test/opstack/EthBlockHeaderTest.cpp`'s `kEmptyOmmersHash`/`kPosNonce` (golden-
+// anchored by the 33-vector gate), and `opstack-executor/OpBlockExecute.h`'s
+// `OP_EMPTY_REQUESTS_HASH` for the third. The requests-hash copy here is *checked* rather than
+// merely trusted: the OP branch compares the seal's own `requestsHash` against the reconstructed
+// header's, so any drift between this copy and OpBlockExecute.h's surfaces as a comparison failure
+// instead of a silent wrong block hash. (They are re-declared rather than included because
+// `engine` must not depend on `bcos-evm` -- see EngineServiceImpl.h's `c_opMode` comment.)
+const bcos::h256 c_emptyOmmersHash{
+    std::string{"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"}};
+const bcos::h64 c_posNonce{std::string{"0x0000000000000000"}};
+const bcos::h256 c_opEmptyRequestsHash{
+    std::string{"0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}};
 }  // namespace
+
+void bcos::engine::detail::applyOpHeaderConstants(bcos::protocol::BlockHeader& header)
+{
+    // Post-merge OP chain constants: ommersHash = keccak256(rlp([])), difficulty = 0, nonce = 0.
+    header.setUncleHash(c_emptyOmmersHash);
+    header.setDifficulty(bcos::u256(0));
+    header.setNonce(c_posNonce);
+}
 
 std::string bcos::engine::detail::encodePayloadSequence(std::uint64_t value)
 {
@@ -60,6 +140,16 @@ std::vector<std::string> bcos::engine::detail::supportedCapabilities()
         "engine_forkchoiceUpdatedV2", "engine_forkchoiceUpdatedV3", "engine_getPayloadV1",
         "engine_getPayloadV2", "engine_getPayloadV3", "engine_getPayloadV4", "engine_getPayloadV5",
         "engine_newPayloadV1", "engine_newPayloadV2", "engine_newPayloadV3", "engine_newPayloadV4"};
+}
+
+std::vector<std::string> bcos::engine::detail::supportedOpCapabilities()
+{
+    // Production interop downgrade: do not advertise `engine_newPayloadV4` /
+    // `engine_getPayloadV4` in the OP-mode capability negotiation. Both only have
+    // EngineServiceImpl-layer semantics; the RPC endpoint registration is not implemented, so
+    // advertising V4 would let op-node negotiate to a non-existent endpoint and hit a -38005 stub
+    // on every call. Honestly expose V3; restore the V4 entries here once the endpoints exist.
+    return supportedCapabilities();
 }
 
 bool bcos::engine::detail::isGetPayloadVersionCompatible(
@@ -111,7 +201,8 @@ namespace
 {
 /// Shared over the two transaction carriers (attributes hex strings and payload raw
 /// bytes): a blob (type-3) or unsupported/unknown-type transaction invalidates the whole
-/// carrier — it is never dropped individually (L2 forbids blob transactions entirely).
+/// carrier — it is never dropped individually. Blob rejection is FISCO's OP policy, not an
+/// op-geth check (decodeTyped accepts 0x03; see the OpScheduler.h type-byte gate note).
 std::optional<std::string> validateRawTransactionKind(
     bcos::engine::RawTransactionKind kind, std::size_t index)
 {
@@ -223,4 +314,358 @@ std::optional<std::string> bcos::engine::detail::validateExecutionPayload(
         return std::string("withdrawalsRoot is required for ExecutionPayloadV4 and later");
     }
     return std::nullopt;
+}
+
+// ============================ OP-mode helpers ============================
+// Reached only from `EngineServiceImpl::handleOpNewPayload`, i.e. only from an instantiation with
+// `c_opMode == true`. They are plain non-template functions living in this .cpp (rather than in
+// the header) because none of them touch a template parameter: they work purely on
+// `NewPayloadRequest`/`ExecutionPayload` plus a couple of caller-supplied derived values.
+
+std::optional<std::uint64_t> bcos::engine::detail::narrowU256ToU64(const u256& value)
+{
+    static const u256 maxU64(std::numeric_limits<std::uint64_t>::max());
+    if (value > maxU64)
+    {
+        return std::nullopt;
+    }
+    return static_cast<std::uint64_t>(value);
+}
+
+bcos::h2048 bcos::engine::detail::toEthLogsBloom(const Bloom& logsBloom)
+{
+    // `Bloom` is `std::array<byte, 256>` (bcos-utilities/Bloom.h);
+    // `protocol::BlockHeader::logsBloom` is `h2048` -- same 256 bytes, same order, so this is a
+    // plain byte copy through `FixedBytes(byte const*, size_t)`. Explicit constructor -- `return
+    // {...}` (copy-list-initialization) would not compile.
+    return bcos::h2048(logsBloom.data(), logsBloom.size());
+}
+
+bcos::u256 bcos::engine::detail::calcOpBaseFee(
+    const bcos::protocol::BlockHeader& parent, bool parentIsJovian)
+{
+    // The minimal loop is Isthmus+-only (feature-driven fork selection), so the Holocene+
+    // extraData decode below always applies — there is no pre-Isthmus base to fall back to;
+    // `parentIsJovian` only gates the Jovian 8-byte minBaseFee tail.
+    uint64_t elasticity = 2;
+    uint64_t denominator = 8;
+    std::optional<uint64_t> minBaseFee;
+
+    // Holocene+ extraData: version byte + denominator (uint32 BE) + elasticity (uint32 BE).
+    // Zero-value rejection is guaranteed by the parent's own validateOpNewPayloadRequest.
+    const auto extra = parent.extraData();  // bytesConstRef; operator[] like bytes
+    auto readU32BE = [&extra](std::size_t off) -> uint64_t {
+        return (static_cast<uint64_t>(extra[off]) << 24) |
+               (static_cast<uint64_t>(extra[off + 1]) << 16) |
+               (static_cast<uint64_t>(extra[off + 2]) << 8) | static_cast<uint64_t>(extra[off + 3]);
+    };
+    denominator = readU32BE(1);
+    elasticity = readU32BE(5);
+
+    if (parentIsJovian)
+    {
+        // Jovian extraData extends Holocene with 8-byte minBaseFee (uint64 BE).
+        auto readU64BE = [&extra](std::size_t off) -> uint64_t {
+            return (static_cast<uint64_t>(extra[off]) << 56) |
+                   (static_cast<uint64_t>(extra[off + 1]) << 48) |
+                   (static_cast<uint64_t>(extra[off + 2]) << 40) |
+                   (static_cast<uint64_t>(extra[off + 3]) << 32) |
+                   (static_cast<uint64_t>(extra[off + 4]) << 24) |
+                   (static_cast<uint64_t>(extra[off + 5]) << 16) |
+                   (static_cast<uint64_t>(extra[off + 6]) << 8) |
+                   static_cast<uint64_t>(extra[off + 7]);
+        };
+        minBaseFee = readU64BE(9);
+    }
+
+    const uint64_t parentGasTarget =
+        detail::narrowU256ToU64(parent.gasLimit()).value() / elasticity;
+
+    // Jovian: baseFee is based on max(total gas used, DA footprint) rather than plain gasUsed
+    // (op-geth consensus/misc/eip1559/eip1559.go:99-107).
+    uint64_t parentGasMetered = detail::narrowU256ToU64(parent.gasUsed()).value();
+    if (parentIsJovian &&
+        detail::narrowU256ToU64(parent.blobGasUsed().value()).value() > parentGasMetered)
+    {
+        parentGasMetered = detail::narrowU256ToU64(parent.blobGasUsed().value()).value();
+    }
+
+    // EIP-1559 base fee computation (mirrors op-geth eip1559.go:calcBaseFeeInner).
+    if (parentGasMetered == parentGasTarget)
+    {
+        return parent.baseFee().value();
+    }
+
+    const bcos::u256 parentBaseFee = parent.baseFee().value();
+    bcos::u256 result;
+
+    if (parentGasMetered > parentGasTarget)
+    {
+        // baseFee increases: max(1, parentBaseFee * delta / parentGasTarget / denominator)
+        const uint64_t delta = parentGasMetered - parentGasTarget;
+        bcos::u256 deltaFee = parentBaseFee * delta;
+        deltaFee /= parentGasTarget;
+        deltaFee /= denominator;
+        result = parentBaseFee + (deltaFee > 0 ? deltaFee : bcos::u256{1});
+    }
+    else
+    {
+        // baseFee decreases: parentBaseFee * delta / parentGasTarget / denominator
+        const uint64_t delta = parentGasTarget - parentGasMetered;
+        bcos::u256 deltaFee = parentBaseFee * delta;
+        deltaFee /= parentGasTarget;
+        deltaFee /= denominator;
+        result = deltaFee < parentBaseFee ? parentBaseFee - deltaFee : bcos::u256{0};
+    }
+
+    // Jovian minBaseFee floor (op-geth eip1559.go:86-91).
+    if (minBaseFee.has_value() && result < *minBaseFee)
+    {
+        result = bcos::u256{*minBaseFee};
+    }
+
+    return result;
+}
+
+std::optional<std::string> bcos::engine::detail::validateOpNewPayloadRequest(
+    const NewPayloadRequest& request, bool jovianActive)
+{
+    // Static validation. Every failure here is reported by the caller as INVALID +
+    // latestValidHash = null (the blockHash-mismatch bucket): all of these checks run before
+    // parentKnown, so no ancestor has been established as valid at this point.
+    //
+    // Malformed-input cases assigned to JSON-RPC -32602 (missing/ill-typed members) are *not*
+    // decidable here: they are decoding failures at the RPC parse layer, and RPC endpoint
+    // registration is out of scope for this cycle. By the time a `NewPayloadRequest` exists, an
+    // absent and an empty array are indistinguishable for the vector-typed members. What this
+    // function can and does enforce is the *value* constraint ("present and empty" collapses to
+    // "empty").
+    const auto& payload = request.executionPayload;
+
+    if (!payload.rawTransactions.has_value())
+    {
+        // The OP path's only transaction carrier (Types.h). Its absence is not a semantic
+        // rejection of a block but a malformed request; with no RPC layer to raise -32602 this
+        // cycle, INVALID with a field-naming validationError is the honest local answer.
+        return std::string("executionPayload.rawTransactions is required on the OP path");
+    }
+    if (!payload.withdrawals.has_value() || !payload.withdrawals->empty())
+    {
+        return std::string("withdrawals must be present and empty on the OP path");
+    }
+    if (!request.expectedBlobVersionedHashes.empty())
+    {
+        return std::string("expectedBlobVersionedHashes must be an empty array on the OP path");
+    }
+    if (!request.parentBeaconBlockRoot.has_value())
+    {
+        return std::string("parentBeaconBlockRoot must be a 32-byte hash for newPayloadV4");
+    }
+    if (!payload.withdrawalsRoot.has_value())
+    {
+        // OP Isthmus+ payload extension: the MessagePasser storage root cannot be derived from
+        // the (always empty) withdrawals list, so the header cannot be reconstructed without it.
+        return std::string("withdrawalsRoot is required on the OP path (Isthmus+)");
+    }
+    if (!payload.excessBlobGas.has_value() || *payload.excessBlobGas != 0)
+    {
+        return std::string("excessBlobGas must be present and zero on the OP path");
+    }
+    if (!payload.blobGasUsed.has_value())
+    {
+        return std::string("blobGasUsed must be present on the OP path");
+    }
+    if (!jovianActive && *payload.blobGasUsed != 0)
+    {
+        // Isthmus: the slot is a genuine blob-gas counter and OP blocks carry no blobs, so it
+        // must be 0. From Jovian on the same header slot is repurposed as the DA footprint
+        // (OpBlockExecute.h's OpBlockSeal) and is validated by seal comparison instead -- hence
+        // this check
+        // is gated on the fork, not unconditional.
+        return std::string("blobGasUsed must be zero before Jovian (OP Isthmus)");
+    }
+
+    // Range checks for the header fields whose `ExecutionPayload` type is wider (or signed)
+    // relative to the ETH header's uint64_t. Doing them here makes `rebuildOpEthHeader` total.
+    //
+    // `blockNumber` is `bcos::protocol::BlockNumber` (int64_t), not u256 -- the narrowing hazard
+    // is the sign, not the width: a negative value would wrap to a huge uint64 in the header and,
+    // worse, be lexical_cast into a bogus registration key. Same "explicit check before
+    // narrowing" discipline as `narrowU256ToU64` below, which exists because of this repo's
+    // documented silent-truncation incident.
+    if (payload.blockNumber < 0)
+    {
+        return std::string("blockNumber must not be negative");
+    }
+    if (!narrowU256ToU64(payload.gasLimit).has_value())
+    {
+        return std::string("gasLimit exceeds the uint64 range of the ETH header field");
+    }
+    // gasLimit's *effective* ceiling is int64, not uint64: the execution side narrows it once
+    // more with a plain `static_cast<int64_t>` when filling `evmone::state::BlockInfo::gas_limit`
+    // (OpSchedulerSeam.h's `toBlockInfo`), so anything above 2^63-1 becomes a NEGATIVE block gas
+    // pool. Same "unchecked signed narrowing" class as the deposit `gas_limit` finding, fixed the
+    // same way -- explicitly, at the boundary. op-geth pins the identical bound as
+    // `params.MaxGasLimit` (consensus/beacon/consensus.go:262-264). No acceptance surface
+    // changes: such a block is rejected either way today (the first deposit cannot be paid out of
+    // a negative pool); what changes is that it is rejected for the stated reason instead of by
+    // accident.
+    if (*narrowU256ToU64(payload.gasLimit) >
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
+    {
+        return std::string("gasLimit exceeds the maximum block gas limit (2^63-1)");
+    }
+    // `gasUsed <= gasLimit` has NO pre-execution header check here on purpose, unlike op-geth's
+    // beacon `verifyHeader` (`consensus/beacon/consensus.go:266-268`, reached before any state is
+    // touched). It is guaranteed by the execution side instead, in two layers that together match
+    // op-geth's pre-execution rejection:
+    //   1. by construction — `processOpBlock` (`OpBlockExecute.cpp:126`) starts the gas pool at the
+    //      block gas limit and each tx is gated by `tx.gasLimit <= blockGasLeft` (evmone
+    //      validate/transition) with `gasUsed <= tx.gasLimit`, so the computed `cumulative`
+    //      (= OpExecuteBlockResult::gasUsed) can never exceed the block gas limit;
+    //   2. by commitment comparison — `payload.gasUsed` is one of the six-way comparison fields
+    //      (bcos-evm/bcos-evm/engine/OpSchedulerSeam.h:94-103, struct OpExecuteBlockResult),
+    //      pinned to the computed value, so a payload that CLAIMS `gasUsed > gasLimit` fails the
+    //      comparison after execution -> INVALID.
+    // Behaviorally equivalent to op-geth, with a different timing: FISCO rejects only after
+    // executing the block, op-geth rejects before execution (the same "no full
+    // VerifyHeader/ValidateBody equivalent" structural note as in
+    // docs/opstack-opgeth-e2e-comparison.md). Not a gap, but deliberately not mirrored here.
+    // extraData: OP Holocene+ header shape. op-geth validates it in
+    // `consensus/misc/eip1559/eip1559_optimism.go`'s `ValidateHoloceneExtraData` (Isthmus) /
+    // `ValidateJovianExtraData` (Jovian), reached from BOTH the block-verify path
+    // (`consensus/beacon/consensus.go:240`) and the newPayload path
+    // (`eth/catalyst/api_optimism.go:22`):
+    //   - Isthmus: exactly 9 bytes = 0x00 version ‖ uint32 denominator ‖ uint32 elasticity (big
+    //     endian), with denominator and elasticity both non-zero;
+    //   - Jovian: exactly 17 bytes = 0x01 version ‖ the same 8 eip-1559 bytes ‖ uint64 minBaseFee
+    //     (minBaseFee arbitrary, not validated).
+    // The OP path is always Isthmus+ (`withdrawalsRoot` is required above), so an empty extraData
+    // is never valid here. This shape check subsumes the old 32-byte ETH length bound (9 and 17
+    // are both < 32): a caller-supplied blob longer than 32 bytes now fails the length branch
+    // below with a shape message instead of the generic bound.
+    {
+        const auto& extra = payload.extraData;
+        if (jovianActive)
+        {
+            if (extra.size() != 17)
+            {
+                return std::string("extraData must be exactly 17 bytes on the OP path (Jovian)");
+            }
+            if (extra[0] != 0x01)
+            {
+                return std::string("extraData version byte must be 0x01 on the OP path (Jovian)");
+            }
+        }
+        else
+        {
+            if (extra.size() != 9)
+            {
+                return std::string("extraData must be exactly 9 bytes on the OP path (Isthmus)");
+            }
+            if (extra[0] != 0x00)
+            {
+                return std::string("extraData version byte must be 0x00 on the OP path (Isthmus)");
+            }
+        }
+        // denominator = extra[1:5], elasticity = extra[5:9], both big-endian uint32 and both
+        // required non-zero (op-geth `validateHoloceneExtraDataPart`). The offsets are identical
+        // for Isthmus and Jovian; only the total length and version byte differ.
+        const auto readU32BE = [&extra](std::size_t off) {
+            return (static_cast<std::uint32_t>(extra[off]) << 24) |
+                   (static_cast<std::uint32_t>(extra[off + 1]) << 16) |
+                   (static_cast<std::uint32_t>(extra[off + 2]) << 8) |
+                   static_cast<std::uint32_t>(extra[off + 3]);
+        };
+        if (readU32BE(1) == 0)
+        {
+            return std::string("extraData must encode a non-zero eip-1559 denominator");
+        }
+        if (readU32BE(5) == 0)
+        {
+            return std::string("extraData must encode a non-zero eip-1559 elasticity");
+        }
+    }
+    if (!narrowU256ToU64(payload.gasUsed).has_value())
+    {
+        return std::string("gasUsed exceeds the uint64 range of the ETH header field");
+    }
+    if (!narrowU256ToU64(*payload.blobGasUsed).has_value())
+    {
+        return std::string("blobGasUsed exceeds the uint64 range of the ETH header field");
+    }
+
+    // Jovian DA-footprint block limit. From Jovian on, the header `blobGasUsed` slot carries the
+    // block's DA footprint (OpBlockExecute.h's OpBlockSeal); a block whose DA footprint exceeds its
+    // own
+    // gasLimit is rejected. op-geth checks the recomputed footprint against `block.GasLimit()` in
+    // `core/block_validator.go:131` (Jovian branch, DA footprint from
+    // `core/types/rollup_cost.go`'s `CalcDAFootprint`). Checking the payload's claimed
+    // `blobGasUsed` here is equivalent given the step-5 seal comparison already pins `blobGasUsed`
+    // to the computed footprint; it only ever widens rejection (single direction), never accepts a
+    // block op-geth would reject. Isthmus keeps `blobGasUsed == 0` (checked above), so this is
+    // Jovian-gated. Both operands are u256, compared directly.
+    if (jovianActive && *payload.blobGasUsed > payload.gasLimit)
+    {
+        return std::string("DA footprint (blobGasUsed) exceeds the block gas limit");
+    }
+
+    // The OP path carries no execution requests (there is no engine API to set them -- the RPC
+    // layer always sends nullopt, EngineHelper.cpp:100-105), so a present-and-NON-empty list
+    // contradicts the protocol's request shape and is rejected here, in the same bucket as every
+    // other static check above (INVALID + latestValidHash=null, before parentKnown). This is the
+    // explicit check the sentinel static_assert (EngineNewPayloadGateTest.cpp, mutation class #7's
+    // compile-time half) forced once `NewPayloadRequest::executionRequests` existed; the mutation
+    // test now sets the real carrier instead of the requestsHash surrogate. Rejecting rather than
+    // hashing keeps the reconstructed header's `requestsHash` pin to the OP empty-requests
+    // constant provably consistent: a non-empty list never reaches the reconstruction.
+    if (request.executionRequests.has_value() && !request.executionRequests->empty())
+    {
+        return std::string("executionRequests must be absent or empty on the OP path");
+    }
+    return std::nullopt;
+}
+
+bcos::protocol::BlockHeader::Ptr bcos::engine::detail::rebuildOpEthHeader(
+    const bcos::protocol::BlockHeaderFactory::Ptr& factory, const ExecutionPayload& payload,
+    const h256& transactionsRoot, const h256& parentBeaconBlockRoot)
+{
+    // 21 fields, all of which land in the FISCO BlockHeader (tars, PR #5385); the 3 post-merge
+    // constants (ommersHash/difficulty/nonce) via applyOpHeaderConstants (read back by
+    // encodeOpHeader/opHeaderHash). Field sources: 17 verbatim from the payload (extraData
+    // kept "as-is", never re-derived), 1 caller-derived transactionsRoot (the payload has no such
+    // field), constants at the top of this file. timestamp is stored in milliseconds per FISCO
+    // convention (blockHash/RLP/execution always use seconds; tars storage uses milliseconds).
+    //
+    // Precondition: `validateOpNewPayloadRequest` returned nullopt for this request -- that is
+    // what guarantees the optionals below are engaged. A violated precondition surfaces as a
+    // thrown `std::bad_optional_access`, i.e. loudly, rather than as a quietly wrong block hash.
+    auto header = factory->createBlockHeader();
+    const auto number = static_cast<bcos::protocol::BlockNumber>(payload.blockNumber);
+    header->setNumber(number);
+    header->setTimestamp(static_cast<int64_t>(payload.timestamp));
+    header->setParentInfo(
+        bcos::protocol::ParentInfo{.blockNumber = number - 1, .blockHash = payload.parentHash});
+    header->setCoinbase(payload.feeRecipient);
+    header->setStateRoot(payload.stateRoot);
+    header->setTxsRoot(transactionsRoot);
+    header->setReceiptsRoot(payload.receiptsRoot);
+    const auto bloom = toEthLogsBloom(payload.logsBloom);
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    header->setGasLimit(payload.gasLimit);
+    header->setGasUsed(payload.gasUsed);
+    header->setExtraData(payload.extraData);
+    header->setPrevRandao(payload.prevRandao);
+    header->setBaseFee(payload.baseFeePerGas);
+    header->setWithdrawalsRoot(payload.withdrawalsRoot.value());
+    header->setBlobGasUsed(payload.blobGasUsed.value());
+    // excessBlobGas is pinned to 0 by validation above (consistent with the retired
+    // EthBlockHeader).
+    header->setExcessBlobGas(bcos::u256(0));
+    header->setParentBeaconBlockRoot(parentBeaconBlockRoot);
+    header->setRequestsHash(c_opEmptyRequestsHash);
+    // The 3 post-merge constants (uncleHash/difficulty/nonce) — read back by
+    // encodeOpHeader/opHeaderHash.
+    applyOpHeaderConstants(*header);
+    return header;
 }

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -19,18 +19,25 @@
 
 #pragma once
 
+#include "bcos-concepts/ByteBuffer.h"
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/merkle/Merkle.h"
+#include "bcos-framework/dispatcher/SchedulerInterface.h"
 #include "bcos-framework/engine/EngineService.h"
+#include "bcos-framework/engine/Errors.h"
 #include "bcos-framework/engine/Types.h"
 #include "bcos-framework/ledger/Ledger.h"
 #include "bcos-framework/ledger/LedgerConfig.h"
+#include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/protocol/BlockFactory.h"
 #include "bcos-framework/protocol/ProtocolTypeDef.h"
 #include "bcos-framework/protocol/Transaction.h"
+#include "bcos-framework/storage/Entry.h"
+#include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-ledger/LedgerMethods.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
@@ -38,7 +45,11 @@
 #include "bcos-utilities/DataConvertUtility.h"
 #include "bcos-utilities/Exceptions.h"
 #include "bcos-utilities/FixedBytes.h"
+#include <algorithm>
+#include <bcos-framework/protocol/BlockHeader.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <bcos-tars-protocol/protocol/Web3RawTransaction.h>
+#include <boost/lexical_cast.hpp>
 #include <cstdint>
 #include <deque>
 #include <functional>
@@ -63,6 +74,28 @@ DERIVE_BCOS_EXCEPTION(GlobalStateStorageNotConfigured);
 DERIVE_BCOS_EXCEPTION(UnknownForkchoiceHeadBlock);
 DERIVE_BCOS_EXCEPTION(InvalidForkchoiceState);
 
+// ---- OP-mode exceptions ----
+// These carry the JSON-RPC error codes the Engine API assigns to these conditions. The mapping
+// exception-type -> code is intentionally not implemented yet: `engine_newPayloadV4` /
+// `engine_getPayloadV4` RPC endpoint registration is out of scope for this cycle, so the OP
+// branch is exercised by direct `EngineServiceImpl` calls and the code is
+// documentation-of-intent for whoever wires `bcos-rpc`'s EngineEndpoint later. The existing
+// generic exceptions above are in exactly the same position (no code mapping in-repo).
+
+/// JSON-RPC -38005 "Unsupported fork": the payload timestamp's fork and the called method version
+/// disagree -- Isthmus+ payloads may only arrive on V4, pre-Isthmus timestamps may not use V4.
+DERIVE_BCOS_EXCEPTION(UnsupportedFork);
+
+/// JSON-RPC -38003 "Invalid payload attributes": an OP-mode forkchoiceUpdated carried payload
+/// attributes. Attribute-driven block building is not supported this cycle; the forkchoice state
+/// update itself still takes effect (head advances), only the build is refused.
+DERIVE_BCOS_EXCEPTION(UnsupportedOpPayloadAttributes);
+
+/// `getPayload` in OP mode: block *building* is not OP-ized this cycle, so there is no OP payload
+/// to return and the failure is reported explicitly rather than as `UnknownPayload` (which would
+/// falsely suggest an expired/unknown id).
+DERIVE_BCOS_EXCEPTION(OpPayloadBuildingUnsupported);
+
 namespace detail
 {
 std::string encodePayloadSequence(std::uint64_t value);
@@ -71,6 +104,12 @@ bcos::h256 syntheticHash(std::string_view seed);
 
 std::vector<std::string> supportedCapabilities();
 
+/// OP-mode capability list: `supportedCapabilities()` plus the V4 entries. Selected via
+/// `if constexpr` on `EngineServiceImpl::c_opMode` in `exchangeCapabilities` below -- never
+/// reached by the generic composition root, so the generic path's capability list stays
+/// byte-for-byte the pre-existing 10 entries.
+std::vector<std::string> supportedOpCapabilities();
+
 bool isGetPayloadVersionCompatible(ApiVersion requestVersion, std::uint32_t payloadVersion);
 
 std::optional<std::string> validatePayloadAttributes(
@@ -78,6 +117,60 @@ std::optional<std::string> validatePayloadAttributes(
 
 std::optional<std::string> validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version);
+
+// ---- OP-mode helpers ----
+
+/// Bounds-checked u256 -> uint64 narrowing (nullopt when out of range). Explicit rather than a
+/// bare `convert_to`/`static_cast`: this repo has a documented silent-truncation incident with
+/// unchecked wide-integer narrowing (MEMORY costofprecompiled-int64-overflow), and
+/// `OpSchedulerSeam.h`'s `narrowU256ToU64` applies the same discipline on the execution side.
+std::optional<std::uint64_t> narrowU256ToU64(const u256& value);
+
+/// `Bloom` (std::array<byte,256>, the ExecutionPayload representation) -> `h2048` (the
+/// protocol::BlockHeader::logsBloom representation).
+bcos::h2048 toEthLogsBloom(const Bloom& logsBloom);
+
+/// OP static validation (everything except the blockHash comparison, which needs the
+/// caller-derived transactionsRoot). Returns a field-naming validationError string on rejection.
+/// `jovianActive` selects the fork-dependent `blobGasUsed` rule.
+std::optional<std::string> validateOpNewPayloadRequest(
+    const NewPayloadRequest& request, bool jovianActive);
+
+/// Compute expected baseFeePerGas from the parent header.
+/// Mirrors op-geth consensus/misc/eip1559/eip1559.go:CalcBaseFee, including Holocene extraData
+/// elasticity/denominator, Jovian blobGasUsed substitution, and Jovian minBaseFee floor.
+/// `parentIsJovian` is feature-driven (feature_op_jovian, constant across blocks); the minimal
+/// loop is Isthmus+-only, so the Holocene+ extraData decode always applies (no isthmus flag).
+/// Reads the parent header's accessors: `extraData()` (Holocene/Jovian params), `gasLimit()`,
+/// `gasUsed()`, `blobGasUsed()`, `baseFee()` (optional fields must use `.value()`).
+bcos::u256 calcOpBaseFee(const bcos::protocol::BlockHeader& parent, bool parentIsJovian);
+
+/// Populate the OP header's 3 post-merge constants (ommersHash/difficulty/nonce) into a header —
+/// the values live in EngineServiceImpl.cpp's anonymous namespace. The header's own
+/// uncleHash()/difficulty()/nonce() accessors then feed the rlp-protocol EthBlockHeader bridge
+/// (EthBlockHeader::computeHash / rlpEncode). Called by rebuildOpEthHeader; test seal helpers
+/// share the same source.
+void applyOpHeaderConstants(bcos::protocol::BlockHeader& header);
+
+/// Reconstructs the 21-field ETH/OP header from the payload as a FISCO `protocol::BlockHeader`
+/// (tars) with all 21 fields filled (the 3 post-merge constants via applyOpHeaderConstants).
+/// `opHeaderHash` (codec) is what the payload's `blockHash` is checked against, and
+/// `header->encode()` (tars) is what the block registration stores. Precondition:
+/// `validateOpNewPayloadRequest` accepted the request.
+bcos::protocol::BlockHeader::Ptr rebuildOpEthHeader(
+    const bcos::protocol::BlockHeaderFactory::Ptr& factory, const ExecutionPayload& payload,
+    const h256& transactionsRoot, const h256& parentBeaconBlockRoot);
+
+/// OP envelope -> tars Transaction conversion (implemented in EngineServiceImpl.cpp; returns
+/// nullopt on failure, does not throw). Fills extraTransactionHash and sender. 0x04 (EIP-7702)
+/// is decoded via Web3Transaction RLP (a first-class type since upstream #5411); only a malformed
+/// or un-enumerated envelope yields nullopt. Forward-declared here with the implementation in the
+/// .cpp because EngineServiceImpl.h is included by many consumers (engine/test, libinitializer,
+/// bcos-evm opstack tests) and pulling in Web3Transaction.h would drag in jsoncpp + rpc Common +
+/// RPC_LOG macro pollution. `bcostars::Transaction` is fully visible via LedgerMethods.h, so no
+/// extra forward declaration is needed.
+std::optional<bcostars::Transaction> opEnvelopeToTars(
+    bcos::bytes const& env, bcos::crypto::HashType const& txHash);
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -91,18 +184,42 @@ class EngineServiceImpl
 public:
     using ViewType = typename GlobalStateStorageType::ViewType;
 
+    /// Compile-time OP-mode probe (no runtime bool, matching this class's all-template style):
+    /// detects `SchedulerType::computeTxRoot` via an unevaluated `requires`-expression. Only the
+    /// OP scheduler exposes that member (OpSchedulerSeam.h:137), so `c_opMode` is false for every
+    /// scheduler used by the generic composition root (StubScheduler/BloomScheduler in
+    /// EngineServiceTest.cpp, SchedulerSerialImpl in production) and the generic path is
+    /// byte-for-byte unaffected.
+    ///
+    /// `computeTxRoot` is a static member function template over the raw-tx range; the explicit
+    /// `<std::vector<bcos::bytes>>` pins the sole `auto`-deduced parameter exactly as the removed
+    /// `executeOpBlock` probe did. Address-of is an unevaluated operand inside a
+    /// requires-expression ([expr.prim.req.simple]), so it does not odr-use the function body.
+    ///
+    /// OP block execution is always the delegate's path (`m_delegate->executeBlock` →
+    /// OpScheduler's preBlockOpSteps + SchedulerSerialImpl + finalizeOpBlockResult). `c_opMode` now
+    /// only means "this is an
+    /// OP scheduler": the engine reaches `computeTxRoot` / `isJovianActive` as dependent names
+    /// inside `if constexpr (c_opMode)`.
+    static constexpr bool c_opMode =
+        requires { &SchedulerType::template computeTxRoot<std::vector<bcos::bytes>>; };
+
     EngineServiceImpl(MemPoolType& memPool, GlobalStateStorageType& globalStateStorage,
         ExecutorType& executor, SchedulerType& scheduler,
         bcos::protocol::BlockFactory::Ptr blockFactory,
         bcos::ledger::LedgerInterface::Ptr ledger = nullptr,
-        int64_t blockTxCountLimit = bcos::engine::c_defaultBlockTxCountLimit)
+        int64_t blockTxCountLimit = bcos::engine::c_defaultBlockTxCountLimit,
+        std::uint32_t maxEngineVersion = static_cast<std::uint32_t>(ApiVersion::V3),
+        bcos::scheduler::SchedulerInterface::Ptr delegate = nullptr)
       : m_memPool(std::ref(memPool)),
         m_globalStateStorage(std::ref(globalStateStorage)),
         m_blockTxCountLimit(blockTxCountLimit),
         m_executor(std::ref(executor)),
         m_scheduler(std::ref(scheduler)),
         m_blockFactory(std::move(blockFactory)),
-        m_ledger(std::move(ledger))
+        m_maxEngineVersion(maxEngineVersion),
+        m_ledger(std::move(ledger)),
+        m_delegate(std::move(delegate))
     {
         if (!m_blockFactory)
         {
@@ -119,7 +236,18 @@ public:
         std::vector<std::string> remoteCapabilities)
     {
         (void)remoteCapabilities;
-        co_return detail::supportedCapabilities();
+        // opMode compile-time branch: selects the capability list at compile time via
+        // `if constexpr` on `c_opMode` -- not a runtime bool -- so the generic composition
+        // root's codegen for this function is exactly what it was before (the `else` branch,
+        // unconditionally).
+        if constexpr (c_opMode)
+        {
+            co_return detail::supportedOpCapabilities();
+        }
+        else
+        {
+            co_return detail::supportedCapabilities();
+        }
     }
 
     bcos::task::Task<ForkchoiceUpdatedResult> updateForkchoice(
@@ -133,16 +261,26 @@ public:
         }
         if (payloadAttributes != nullptr)
         {
-            if (auto validationError =
-                    detail::validatePayloadAttributes(*payloadAttributes, version);
-                validationError.has_value())
+            // OP mode skips this pre-check entirely: the OP answer to *any* attributes object --
+            // well-formed or not -- is -38003, and it must be given only AFTER the forkchoice
+            // state has been updated (the forkchoice update is not rolled back, the head advances
+            // normally, only block building is not started). Returning an Invalid payloadStatus
+            // here would abort the update instead. The refusal is raised further down, where the
+            // generic path would start building. `if constexpr` keeps the generic path's codegen
+            // byte-for-byte unchanged.
+            if constexpr (!c_opMode)
             {
-                ForkchoiceUpdatedResult result{
-                    .payloadStatus =
-                        makeStatus(PayloadValidationStatus::Invalid, std::nullopt, validationError),
-                    .payloadId = std::nullopt,
-                };
-                co_return result;
+                if (auto validationError =
+                        detail::validatePayloadAttributes(*payloadAttributes, version);
+                    validationError.has_value())
+                {
+                    ForkchoiceUpdatedResult result{
+                        .payloadStatus = makeStatus(
+                            PayloadValidationStatus::Invalid, std::nullopt, validationError),
+                        .payloadId = std::nullopt,
+                    };
+                    co_return result;
+                }
             }
         }
 
@@ -186,6 +324,16 @@ public:
         // Phase 1: Validate and update tracked block state under lock.
         // The lock is released before any co_await to avoid holding a mutex
         // across a coroutine suspension point (which is UB under POSIX).
+        //
+        // Scope note: this rule is this function's, not the class's. The OP `newPayload` branch
+        // (`handleOpNewPayload` below) deliberately DOES hold `x_state` across `co_await`s --
+        // required by the op-validator-loop coroutine contract (safety premise 2: the engine
+        // execution segment is serialized by the x_state lock), which grants the permission
+        // conditionally: every storage2 backend in play completes synchronously in-thread, so no
+        // coroutine ever resumes on another thread. That contract's invalidation criterion
+        // explicitly covers both that usage and the pre-existing lock-across-`co_await` TODO in
+        // `handleNewPayload`'s generic path. The two are consistent: this comment states the
+        // default, the coroutine contract states the audited exception.
         {
             std::unique_lock lock(x_state);
             if (m_trackedHeadBlock.has_value())
@@ -234,76 +382,95 @@ public:
         {
             co_return result;
         }
-
-        // Mempool operations run without lock — they only depend on the state, not on x_state.
-        // Step 1: Remove stale/tainted transactions from mempool (cleans tx with nonce < state
-        // nonce).
-        // Step 2: Seal valid transactions (in nonce order, with nonce verification) directly on
-        // the executed view. Both MemPoolImpl::remove() and MemPoolImpl::seal() are read-only
-        // with respect to the given view: remove() only erases the mempool's own container, and
-        // seal() only reads the sender's current nonce to pick the gapless executable prefix. It
-        // deliberately does NOT advance the nonce in the view — the authoritative nonce advance
-        // happens during execution itself (evmone), matching how geth's legacypool and reth's
-        // best_transactions() select block transactions without touching state. Sealing on the
-        // executed view is therefore safe: evmone validates tx.nonce >= state.nonce, and the
-        // state nonce here is still the committed one.
-        std::vector<protocol::Transaction::Ptr> sealedTxs;
-        view.newMutable();
-        // noTxPool=true (OP Stack): the payload must not take any transaction from the
-        // pool — it contains exactly the forced transaction list (possibly none). Skip
-        // both pool hygiene and sealing; forced transactions are prepended in
-        // buildPayload.
-        if (!payloadAttributes->noTxPool.value_or(false))
+        if constexpr (c_opMode)
         {
-            m_memPool.get().remove(view);
-            m_memPool.get().seal(m_blockTxCountLimit, view, std::back_inserter(sealedTxs));
+            // An OP validator's L1-derivation path *does* send forkchoiceUpdated with
+            // OP-extended attributes (noTxPool=true + derived transactions) whenever consolidation
+            // fails or there is no unsafe block -- "the validator does not send attributes" is not
+            // true. Attribute-driven building is not supported this cycle (the same road as
+            // OP-izing getPayload), so the answer is -38003.
+            //
+            // Placement is the whole point: everything above -- the storage lookups, the
+            // monotonicity checks, and the tracked-head/safe/finalized update under `x_state` --
+            // has already run and is *kept*. The forkchoice update is not rolled back; only the
+            // build is refused.
+            BOOST_THROW_EXCEPTION(
+                UnsupportedOpPayloadAttributes{} << bcos::errinfo_comment{
+                    "Payload attributes are not supported in OP mode (block building is not "
+                    "OP-ized; JSON-RPC -38003)"});
         }
-
-        // Step 3: Build the payload on the executed view (already mutable above).
-        auto payloadId = nextPayloadID();
-        auto nextBlockNumber = *headBlockNumber + 1;
-        auto built = co_await buildPayload(forkchoiceState, *payloadAttributes, payloadId, version,
-            nextBlockNumber, std::move(sealedTxs), view);
-        PayloadEntry entry{
-            .version = version,
-            .executionPayload = std::move(built.executionPayload),
-            .blockValue = 0,
-            .blobsBundle = std::nullopt,
-            .shouldOverrideBuilder = false,
-            .parentBeaconBlockRoot = payloadAttributes->parentBeaconBlockRoot,
-            .view = std::make_shared<ViewType>(std::move(view)),
-            .header = std::move(built.header),
-            .receipts = std::move(built.receipts),
-        };
-        if (version == static_cast<std::uint32_t>(ApiVersion::V3))
+        else
         {
-            entry.blobsBundle = BlobsBundleV1{};
-        }
-
-        // Re-acquire lock to publish the built payload to the cache.
-        {
-            std::unique_lock lock(x_state);
-            m_blockHashToPayloadId[entry.executionPayload.blockHash] = payloadId;
-            m_payloadCache[payloadId] = std::move(entry);
-            // Bound the payload cache at insert time. A payload is only read between
-            // updateForkchoice / getPayload and newPayload; the single-node driver can skip
-            // newPayload entirely (empty block with produce_empty_blocks=false — the EEST
-            // configuration — or getPayload returning null), and an external CL may abandon
-            // a requested payload. None of those reach handleNewPayload's eviction, so
-            // without a bound here each skipped tick would retain a live storage fork (the
-            // PayloadEntry::view) plus the block's transactions forever.
-            m_payloadOrder.push_back(payloadId);
-            while (m_payloadOrder.size() > c_maxPayloadEntries)
+            // Mempool operations run without lock — they only depend on the state, not on x_state.
+            // Step 1: Remove stale/tainted transactions from mempool (cleans tx with nonce < state
+            // nonce).
+            // Step 2: Seal valid transactions (in nonce order, with nonce verification) directly on
+            // the executed view. Both MemPoolImpl::remove() and MemPoolImpl::seal() are read-only
+            // with respect to the given view: remove() only erases the mempool's own container, and
+            // seal() only reads the sender's current nonce to pick the gapless executable prefix.
+            // It deliberately does NOT advance the nonce in the view — the authoritative nonce
+            // advance happens during execution itself (evmone), matching how geth's legacypool and
+            // reth's best_transactions() select block transactions without touching state. Sealing
+            // on the executed view is therefore safe: evmone validates tx.nonce >= state.nonce, and
+            // the state nonce here is still the committed one.
+            std::vector<protocol::Transaction::Ptr> sealedTxs;
+            view.newMutable();
+            // noTxPool=true (OP Stack): the payload must not take any transaction from the
+            // pool — it contains exactly the forced transaction list (possibly none). Skip
+            // both pool hygiene and sealing; forced transactions are prepended in
+            // buildPayload.
+            if (!payloadAttributes->noTxPool.value_or(false))
             {
-                auto const evictedId = m_payloadOrder.front();
-                m_payloadOrder.pop_front();
-                m_payloadCache.erase(evictedId);
-                std::erase_if(
-                    m_blockHashToPayloadId, [&](auto const& kv) { return kv.second == evictedId; });
+                m_memPool.get().remove(view);
+                m_memPool.get().seal(m_blockTxCountLimit, view, std::back_inserter(sealedTxs));
             }
+
+            // Step 3: Build the payload on the executed view (already mutable above).
+            auto payloadId = nextPayloadID();
+            auto nextBlockNumber = *headBlockNumber + 1;
+            auto built = co_await buildPayload(forkchoiceState, *payloadAttributes, payloadId,
+                version, nextBlockNumber, std::move(sealedTxs), view);
+            PayloadEntry entry{
+                .version = version,
+                .executionPayload = std::move(built.executionPayload),
+                .blockValue = 0,
+                .blobsBundle = std::nullopt,
+                .shouldOverrideBuilder = false,
+                .parentBeaconBlockRoot = payloadAttributes->parentBeaconBlockRoot,
+                .view = std::make_shared<ViewType>(std::move(view)),
+                .header = std::move(built.header),
+                .receipts = std::move(built.receipts),
+            };
+            if (version == static_cast<std::uint32_t>(ApiVersion::V3))
+            {
+                entry.blobsBundle = BlobsBundleV1{};
+            }
+
+            // Re-acquire lock to publish the built payload to the cache.
+            {
+                std::unique_lock lock(x_state);
+                m_blockHashToPayloadId[entry.executionPayload.blockHash] = payloadId;
+                m_payloadCache[payloadId] = std::move(entry);
+                // Bound the payload cache at insert time. A payload is only read between
+                // updateForkchoice / getPayload and newPayload; the single-node driver can skip
+                // newPayload entirely (empty block with produce_empty_blocks=false — the EEST
+                // configuration — or getPayload returning null), and an external CL may abandon
+                // a requested payload. None of those reach handleNewPayload's eviction, so
+                // without a bound here each skipped tick would retain a live storage fork (the
+                // PayloadEntry::view) plus the block's transactions forever.
+                m_payloadOrder.push_back(payloadId);
+                while (m_payloadOrder.size() > c_maxPayloadEntries)
+                {
+                    auto const evictedId = m_payloadOrder.front();
+                    m_payloadOrder.pop_front();
+                    m_payloadCache.erase(evictedId);
+                    std::erase_if(m_blockHashToPayloadId,
+                        [&](auto const& kv) { return kv.second == evictedId; });
+                }
+            }
+            result.payloadId = payloadId;
+            co_return result;
         }
-        result.payloadId = payloadId;
-        co_return result;
     }
 
     bcos::task::Task<GetPayloadResult> getPayload(const PayloadID& payloadId, std::uint32_t version)
@@ -369,10 +536,16 @@ private:
     /// up is served: adapting to Karst does not make the older versions incompatible, and
     /// the V1-V3 callers (the unsafe_allow_v1_executor harness, the integration suites)
     /// keep working.
-    static bool isForkchoiceVersionSupported(std::uint32_t version)
+    ///
+    /// The forkchoiceUpdated window is additionally capped by the runtime ceiling
+    /// `m_maxEngineVersion` (constructor-fixed): the generic composition root leaves it
+    /// at its default (V3 -- zero drift from the static bound); only the OP composition
+    /// root raises it to V4, which the static V3 cap here already absorbs, so the
+    /// effective window is V1..min(V3, m_maxEngineVersion).
+    bool isForkchoiceVersionSupported(std::uint32_t version) const
     {
         return version >= static_cast<std::uint32_t>(ApiVersion::V1) &&
-               version <= static_cast<std::uint32_t>(ApiVersion::V3);
+               version <= std::min(static_cast<std::uint32_t>(ApiVersion::V3), m_maxEngineVersion);
     }
 
     static bool isNewPayloadVersionSupported(std::uint32_t version)
@@ -398,6 +571,26 @@ private:
         };
     }
 
+    /// Maps a delegate-reported SchedulerError code back to a classified outcome (v3 P1-6):
+    /// OpConsensusRejected -> INVALID (with latestValidHash = the verified parent); OpStorageFault
+    /// / UnknownError / any other code -> JSON-RPC -32603 (OpExecutionInternalError, never
+    /// INVALID). The catch(...) fallback in handleOpNewPayload's barrier preserves the
+    /// unclassified -> -32603 semantics for exceptions that escape the delegate path entirely.
+    static PayloadStatus mapDelegateError(
+        bcos::Error const& error, std::optional<h256> latestValidHash)
+    {
+        if (static_cast<bcos::scheduler::SchedulerError>(error.errorCode()) ==
+            bcos::scheduler::SchedulerError::OpConsensusRejected)
+        {
+            return makeStatus(PayloadValidationStatus::Invalid, latestValidHash,
+                std::string("OP block execution rejected the payload: ") + error.errorMessage());
+        }
+        BOOST_THROW_EXCEPTION(
+            OpExecutionInternalError{} << bcos::errinfo_comment{
+                std::string("OP block execution failed (SchedulerError ") +
+                std::to_string(error.errorCode()) + "): " + error.errorMessage()});
+    }
+
     GetPayloadResult handleGetPayload(const PayloadID& payloadId, std::uint32_t version) const
     {
         if (!isGetPayloadVersionSupported(version))
@@ -405,45 +598,60 @@ private:
             BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
                                   << bcos::errinfo_comment{"Unsupported Engine API version"});
         }
-
-        std::shared_lock lock(x_state);
-        auto it = m_payloadCache.find(payloadId);
-        if (it == m_payloadCache.end())
+        if constexpr (c_opMode)
         {
-            BOOST_THROW_EXCEPTION(UnknownPayload{} << bcos::errinfo_comment{"Unknown payload"});
-        }
-        if (!detail::isGetPayloadVersionCompatible(
-                static_cast<ApiVersion>(version), it->second.version))
-        {
+            // `getPayloadV4`'s stated behaviour is "return an explicit error in OP mode (block
+            // building is not OP-ized)". The refusal is unconditional in OP mode rather than
+            // V4-only, because the *cause* is version-independent: OP mode never builds a payload
+            // at all (the attributes path above refuses with -38003), so the cache is always
+            // empty and every version would otherwise answer the misleading `UnknownPayload`.
+            // Full V4 response shaping (executionRequests etc.) ships together with
+            // attributes-driven building.
             BOOST_THROW_EXCEPTION(
-                IncompatiblePayloadVersion{} << bcos::errinfo_comment{
-                    "Payload version is incompatible with requested method version"});
+                OpPayloadBuildingUnsupported{} << bcos::errinfo_comment{
+                    "getPayload is not supported in OP mode (block building is not OP-ized)"});
         }
-        // The version window alone is not enough once the entry may have been REWRITTEN by
-        // a commit: newPayload replaces the cached payload with the request's, and a V3
-        // request carries no withdrawalsRoot (it is a V4+/Isthmus field). Such an entry is
-        // still tagged version 3, so it passes the V4/V5 window above, and
-        // serializeExecutionPayload would then throw InternalError on the missing field.
-        // Answer the version error it really is instead of -32603.
-        if (version >= static_cast<std::uint32_t>(ApiVersion::V4) &&
-            !it->second.executionPayload.withdrawalsRoot.has_value())
+        else
         {
-            BOOST_THROW_EXCEPTION(IncompatiblePayloadVersion{} << bcos::errinfo_comment{
-                                      "Payload does not carry the V4+ response shape"});
-        }
+            std::shared_lock lock(x_state);
+            auto it = m_payloadCache.find(payloadId);
+            if (it == m_payloadCache.end())
+            {
+                BOOST_THROW_EXCEPTION(UnknownPayload{} << bcos::errinfo_comment{"Unknown payload"});
+            }
+            if (!detail::isGetPayloadVersionCompatible(
+                    static_cast<ApiVersion>(version), it->second.version))
+            {
+                BOOST_THROW_EXCEPTION(
+                    IncompatiblePayloadVersion{} << bcos::errinfo_comment{
+                        "Payload version is incompatible with requested method version"});
+            }
+            // The version window alone is not enough once the entry may have been REWRITTEN by
+            // a commit: newPayload replaces the cached payload with the request's, and a V3
+            // request carries no withdrawalsRoot (it is a V4+/Isthmus field). Such an entry is
+            // still tagged version 3, so it passes the V4/V5 window above, and
+            // serializeExecutionPayload would then throw InternalError on the missing field.
+            // Answer the version error it really is instead of -32603.
+            if (version >= static_cast<std::uint32_t>(ApiVersion::V4) &&
+                !it->second.executionPayload.withdrawalsRoot.has_value())
+            {
+                BOOST_THROW_EXCEPTION(IncompatiblePayloadVersion{} << bcos::errinfo_comment{
+                                          "Payload does not carry the V4+ response shape"});
+            }
 
-        return std::make_unique<GetPayloadData>(GetPayloadData{
-            .executionPayload = it->second.executionPayload,
-            .blockValue = it->second.blockValue,
-            .blobsBundle = it->second.blobsBundle,
-            .shouldOverrideBuilder = it->second.shouldOverrideBuilder,
-            // getPayloadV4/V5 responses must carry executionRequests; Karst never has
-            // any, so the value is a present-but-empty list (serialized as []).
-            .executionRequests = version >= static_cast<std::uint32_t>(ApiVersion::V4) ?
-                                     std::optional<std::vector<bytes>>{std::in_place} :
-                                     std::nullopt,
-            .parentBeaconBlockRoot = it->second.parentBeaconBlockRoot,
-        });
+            return std::make_unique<GetPayloadData>(GetPayloadData{
+                .executionPayload = it->second.executionPayload,
+                .blockValue = it->second.blockValue,
+                .blobsBundle = it->second.blobsBundle,
+                .shouldOverrideBuilder = it->second.shouldOverrideBuilder,
+                // getPayloadV4/V5 responses must carry executionRequests; Karst never has
+                // any, so the value is a present-but-empty list (serialized as []).
+                .executionRequests = version >= static_cast<std::uint32_t>(ApiVersion::V4) ?
+                                         std::optional<std::vector<bytes>>{std::in_place} :
+                                         std::nullopt,
+                .parentBeaconBlockRoot = it->second.parentBeaconBlockRoot,
+            });
+        }
     }
 
     bcos::task::Task<PayloadStatus> handleNewPayload(
@@ -454,17 +662,25 @@ private:
             BOOST_THROW_EXCEPTION(UnsupportedEngineApiVersion{}
                                   << bcos::errinfo_comment{"Unsupported Engine API version"});
         }
-
-        if (auto validationError =
-                detail::validateExecutionPayload(request.executionPayload, version);
-            validationError.has_value())
+        // OP branch. Compile-time dispatch on `c_opMode`: the generic composition root never
+        // instantiates `handleOpNewPayload`, and its own path below is the unconditional `else`,
+        // i.e. byte-for-byte the pre-existing body.
+        if constexpr (c_opMode)
         {
-            auto status = validationError->find("blockHash") != std::string::npos ?
-                              PayloadValidationStatus::InvalidBlockHash :
-                              PayloadValidationStatus::Invalid;
-            co_return makeStatus(status, std::nullopt, validationError);
+            co_return co_await handleOpNewPayload(request, version);
         }
-        if (version <= 2 && request.parentBeaconBlockRoot.has_value())
+        else
+        {
+            if (auto validationError =
+                    detail::validateExecutionPayload(request.executionPayload, version);
+                validationError.has_value())
+            {
+                auto status = validationError->find("blockHash") != std::string::npos ?
+                                  PayloadValidationStatus::InvalidBlockHash :
+                                  PayloadValidationStatus::Invalid;
+                co_return makeStatus(status, std::nullopt, validationError);
+            }
+            if (version <= 2 && request.parentBeaconBlockRoot.has_value())
         {
             co_return makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
                 std::string("parentBeaconBlockRoot is only valid for newPayloadV3 and later"));
@@ -510,120 +726,548 @@ private:
                 co_return makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
                     std::string("executionRequests must be a present-but-empty list on this "
                                 "chain"));
+                }
             }
-        }
 
-        std::unique_lock lock(x_state);
-        auto parentKnown = request.executionPayload.parentHash == m_forkchoiceState.headBlockHash ||
-                           m_blockHashToPayloadId.contains(request.executionPayload.parentHash);
-        if (!parentKnown)
-        {
-            co_return makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
-        }
-
-        auto payloadIdIt = m_blockHashToPayloadId.find(request.executionPayload.blockHash);
-        PayloadID payloadId;
-        if (payloadIdIt == m_blockHashToPayloadId.end())
-        {
-            payloadId = nextPayloadID();
-            m_blockHashToPayloadId.emplace(request.executionPayload.blockHash, payloadId);
-        }
-        else
-        {
-            payloadId = payloadIdIt->second;
-        }
-
-        PayloadEntry entry{
-            .version = version,
-            .executionPayload = request.executionPayload,
-            .blockValue = 0,
-            .blobsBundle = std::nullopt,
-            .shouldOverrideBuilder = false,
-            .parentBeaconBlockRoot = request.parentBeaconBlockRoot,
-            .view = nullptr,
-            .header = nullptr,
-            .receipts = {},
-        };
-        if (version == static_cast<std::uint32_t>(ApiVersion::V3))
-        {
-            entry.blobsBundle = BlobsBundleV1{};
-        }
-
-        // If this payload was built locally (via updateForkchoice), commit the view's
-        // state changes to storage. Externally received payloads have no view to commit.
-        // NOTE: mergeView() exists (MultiLayerStorage.h) but is intentionally
-        // non-atomic (pushView and mergeBackStorage are independent critical
-        // sections). Using bare pushView here keeps the state change immediate;
-        // mergeBackStorage follows in the co_await block below.
-        auto it = m_payloadCache.find(payloadId);
-        if (it != m_payloadCache.end() && it->second.view)
-        {
-            m_globalStateStorage.get().pushView(std::move(*it->second.view));
-            if (m_ledger && it->second.header)
+            std::unique_lock lock(x_state);
+            auto parentKnown =
+                request.executionPayload.parentHash == m_forkchoiceState.headBlockHash ||
+                m_blockHashToPayloadId.contains(request.executionPayload.parentHash);
+            if (!parentKnown)
             {
-                // Locally built payload: persist the ledger block tables atomically with
-                // the state merge, using the same FIB-104 prewriteBlockToBuffer pattern the
-                // BaselineScheduler commit path uses. Without these rows a produced block is
-                // invisible to eth_getBlockByNumber / eth_getBlockByHash /
-                // eth_getTransactionReceipt and to ledger::getBlockHash / getCurrentBlockNumber.
-                typename GlobalStateStorageType::MutableStorage prewriteStorage;
-                auto block = m_blockFactory->createBlock();
-                block->setBlockHeader(it->second.header);
-                // Persist the block-level logsBloom (computed in buildPayload from the
-                // per-receipt blooms). Without it every block produced by this driver
-                // answers eth_getBlockByNumber with 256 zero bytes — the legacy
-                // BaselineScheduler commit path sets the block bloom before commit, so
-                // this restores parity with that path (eth_getLogs uses it as a filter).
-                auto const& bloom = it->second.executionPayload.logsBloom;
-                block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
-                // Raw-only entries (forced transactions) carry no decoded form and are
-                // not modeled as ledger transactions until execution wiring lands; the
-                // persisted transaction list therefore matches the receipts list, which
-                // also only covers the executed (decoded) subset.
-                for (auto const& tx : it->second.executionPayload.transactions)
-                {
-                    if (tx.decoded)
-                    {
-                        block->appendTransaction(tx.decoded);
-                    }
-                }
-                for (auto const& receipt : it->second.receipts)
-                {
-                    block->appendReceipt(receipt);
-                }
-                auto blockTxs = std::make_shared<protocol::ConstTransactions>(
-                    it->second.executionPayload.transactions |
-                    ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
-                    ::ranges::views::transform([](auto const& tx) {
-                        return protocol::Transaction::ConstPtr(tx.decoded);
-                    }) |
-                    ::ranges::to<std::vector>());
-                co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
-                co_await m_globalStateStorage.get().mergeBackStorage(prewriteStorage);
+                co_return makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+            }
+
+            auto payloadIdIt = m_blockHashToPayloadId.find(request.executionPayload.blockHash);
+            PayloadID payloadId;
+            if (payloadIdIt == m_blockHashToPayloadId.end())
+            {
+                payloadId = nextPayloadID();
+                m_blockHashToPayloadId.emplace(request.executionPayload.blockHash, payloadId);
             }
             else
             {
-                co_await m_globalStateStorage.get().mergeBackStorage();
+                payloadId = payloadIdIt->second;
+            }
+
+            PayloadEntry entry{
+                .version = version,
+                .executionPayload = request.executionPayload,
+                .blockValue = 0,
+                .blobsBundle = std::nullopt,
+                .shouldOverrideBuilder = false,
+                .parentBeaconBlockRoot = request.parentBeaconBlockRoot,
+                .view = nullptr,
+                .header = nullptr,
+                .receipts = {},
+            };
+            if (version == static_cast<std::uint32_t>(ApiVersion::V3))
+            {
+                entry.blobsBundle = BlobsBundleV1{};
+            }
+
+            // If this payload was built locally (via updateForkchoice), commit the view's
+            // state changes to storage. Externally received payloads have no view to commit.
+            // TODO: merge pushView + mergeBackStorage into a single atomic mergeView()
+            // operation. This will eliminate the risk of leaking a mutable layer if
+            // mergeBackStorage throws, and avoid holding x_state across a co_await.
+            auto it = m_payloadCache.find(payloadId);
+            if (it != m_payloadCache.end() && it->second.view)
+            {
+                m_globalStateStorage.get().pushView(std::move(*it->second.view));
+                if (m_ledger && it->second.header)
+                {
+                    // Locally built payload: persist the ledger block tables atomically with
+                    // the state merge, using the same FIB-104 prewriteBlockToBuffer pattern the
+                    // BaselineScheduler commit path uses. Without these rows a produced block is
+                    // invisible to eth_getBlockByNumber / eth_getBlockByHash /
+                    // eth_getTransactionReceipt and to ledger::getBlockHash /
+                    // getCurrentBlockNumber.
+                    typename GlobalStateStorageType::MutableStorage prewriteStorage;
+                    auto block = m_blockFactory->createBlock();
+                    block->setBlockHeader(it->second.header);
+                    // Persist the block-level logsBloom (computed in buildPayload from the
+                    // per-receipt blooms). Without it every block produced by this driver
+                    // answers eth_getBlockByNumber with 256 zero bytes — the legacy
+                    // BaselineScheduler commit path sets the block bloom before commit, so
+                    // this restores parity with that path (eth_getLogs uses it as a filter).
+                    auto const& bloom = it->second.executionPayload.logsBloom;
+                    block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+                    // Raw-only entries (forced transactions) carry no decoded form and are
+                    // not modeled as ledger transactions until execution wiring lands; the
+                    // persisted transaction list therefore matches the receipts list, which
+                    // also only covers the executed (decoded) subset.
+                    for (auto const& tx : it->second.executionPayload.transactions)
+                    {
+                        if (tx.decoded)
+                        {
+                            block->appendTransaction(tx.decoded);
+                        }
+                    }
+                    for (auto const& receipt : it->second.receipts)
+                    {
+                        block->appendReceipt(receipt);
+                    }
+                    auto blockTxs = std::make_shared<protocol::ConstTransactions>(
+                        it->second.executionPayload.transactions |
+                        ::ranges::views::filter(
+                            [](auto const& tx) { return tx.decoded != nullptr; }) |
+                        ::ranges::views::transform([](auto const& tx) {
+                            return protocol::Transaction::ConstPtr(tx.decoded);
+                        }) |
+                        ::ranges::to<std::vector>());
+                    co_await ledger::prewriteBlockToBuffer(
+                        *m_ledger, blockTxs, block, prewriteStorage);
+                    co_await m_globalStateStorage.get().mergeBackStorage(prewriteStorage);
+                }
+                else
+                {
+                    co_await m_globalStateStorage.get().mergeBackStorage();
+                }
+            }
+
+            m_payloadCache[payloadId] = std::move(entry);
+
+            // Evict stale payload entries. A payload is only read between updateForkchoice /
+            // getPayload and newPayload, so once a block is committed its payloadId and
+            // blockHash are unreachable. The built-in single-node driver mints one new
+            // payloadId per block_interval tick, so without eviction both maps grow by one
+            // row per produced block and hold strong references to every transaction ever
+            // executed (unbounded memory over time). Keep only the just-committed block; the
+            // newPayload() parent check accepts the head hash directly, so dropping older
+            // blockHash rows is safe.
+            std::erase_if(m_blockHashToPayloadId,
+                [&](auto const& kv) { return kv.first != request.executionPayload.blockHash; });
+            std::erase_if(m_payloadCache, [&](auto const& kv) { return kv.first != payloadId; });
+
+            co_return makeStatus(
+                PayloadValidationStatus::Valid, request.executionPayload.blockHash, std::nullopt);
+        }
+    }
+    /// newPayload OP branch. Only ever instantiated when `c_opMode` is true -- i.e. when
+    /// `SchedulerType` is the OP scheduler -- which is what makes every `SchedulerType::`-qualified
+    /// name below legal without this library depending on bcos-evm: they are dependent names,
+    /// resolved at instantiation in a translation unit that included the OP scheduler header (see
+    /// `opstack-executor/OpCommon.h`'s file comment for the seam's full rationale, and
+    /// `c_opMode` above for the purity constraint).
+    ///
+    /// This function is the version gate plus a **classification barrier**: it guarantees that
+    /// every way out of the OP branch is one of the classified outcomes (a `PayloadStatus`,
+    /// `UnsupportedFork`, or `OpExecutionInternalError`) and that nothing escapes unclassified.
+    /// The steps themselves live in `runOpNewPayloadSteps` so that a single try/catch pair can
+    /// cover all of them without wrapping the version gate too -- see the barrier below.
+    bcos::task::Task<PayloadStatus> handleOpNewPayload(
+        const NewPayloadRequest& request, std::uint32_t version)
+    {
+        auto const& payload = request.executionPayload;
+
+        // ---- Step 1: version gate (-38005) ----
+        // The OP engine branch is scoped to Isthmus/Jovian: the minimal loop is Isthmus+-only, and
+        // fork selection is feature-driven (feature_op_jovian — Jovian vs Isthmus, both Isthmus+),
+        // NOT timestamp-based — so there is no "pre-Isthmus" timestamp to reject. Both Isthmus and
+        // Jovian payloads require V4 (Isthmus+ payloads are not allowed on V3).
+        //
+        // Deliberately OUTSIDE the barrier below: `UnsupportedFork` (-38005) is itself a
+        // classified outcome and must reach the caller unchanged, not be re-labelled.
+        constexpr std::uint32_t c_opIsthmusPayloadVersion = 4;
+        if (version != c_opIsthmusPayloadVersion)
+        {
+            BOOST_THROW_EXCEPTION(
+                UnsupportedFork{} << bcos::errinfo_comment{
+                    "Isthmus+ payloads require engine_newPayloadV4 (JSON-RPC -38005)"});
+        }
+
+        // NOTE (independent review #5429, finding B): this V4-only gate is NOT reachable through
+        // the production composition root today. maxEngineVersion defaults to V3 (this class's
+        // ctor, EngineServiceImpl.h:212), the OP composition root cannot raise it
+        // (EngineServiceInitializer::build exposes no maxEngineVersion param),
+        // supportedOpCapabilities() advertises only V3 ("Production interop downgrade",
+        // EngineServiceImpl.cpp:135-142), and the V4 JSON-RPC endpoints are stubs
+        // (EngineEndpoint.cpp:96/143/191, "not yet supported"). A real op-node either negotiates V3
+        // -> newPayloadV3 -> this gate throws UnsupportedFork, or calls newPayloadV4 -> RPC stub —
+        // so OP block execution is unreachable end-to-end via the public Engine API until the V4
+        // endpoint follow-up lands. The OP composition root (executor_version>=3) currently enables
+        // this non-functional mode with no startup refusal. TODO(V4): register real
+        // newPayloadV4/getPayloadV4 + advertise V4 in the OP root, or add a startup InvalidConfig
+        // refusal until then.
+
+        // ---- Classification barrier ----
+        //
+        // The `catch (...)` added around the OP block-execution path in the first pass closed only
+        // ONE window. Everything else in the OP branch still ran outside any handler: step 2's
+        // `computeTxRoot` / `rebuildOpEthHeader` / `hash()`, step 5's `commitmentsOf` and the
+        // comparisons, and the whole of step 6's `registerOpBlock` -- whose `lexical_cast`,
+        // `Entry::set`, `ethHeader.encode()`, `receipt->encode()`, `hashImpl.hash()` and four
+        // `storage2::writeOne` calls can each raise something that is neither
+        // `OpExecutionInternalError` nor an execution-classified error (`bad_alloc`, a tars
+        // encoding error, ...). Such an escape would leave `handleOpNewPayload` entirely and
+        // surface at the caller's `co_await` as neither INVALID nor -32603 -- an outcome the
+        // error classification rules rule out. (The two
+        // `BOOST_THROW_EXCEPTION(OpExecutionInternalError)` calls inside `registerOpBlock` were
+        // never the problem: they arrive already classified, and the rethrow handler below
+        // preserves them verbatim.)
+        //
+        // The barrier is a wrapper rather than an outer try around the existing body so that the
+        // version gate above stays outside it, and so the already-classified paths keep their own
+        // (more specific) messages: `catch (const OpExecutionInternalError&) { throw; }` passes
+        // through the non-tip refusal, the receipt-count invariant, and the execution-phase
+        // fallback untouched, while `catch (...)` labels everything else.
+        try
+        {
+            co_return co_await runOpNewPayloadSteps(request);
+        }
+        catch (const OpExecutionInternalError&)
+        {
+            // Already classified (and carrying a more specific marker) -- pass through unchanged.
+            throw;
+        }
+        catch (...)
+        {
+            // -32603 rather than INVALID, for the same reason as the execution-phase fallback: an
+            // unknown local failure must not make this node vote against a block. The marker
+            // distinguishes this barrier from that fallback, so a test can tell which window an
+            // escape came through (a bare `catch (...)` otherwise collapses every refusal into
+            // one indistinguishable type).
+            BOOST_THROW_EXCEPTION(
+                OpExecutionInternalError{} << bcos::errinfo_comment{
+                    "OP newPayload threw an unclassified exception outside block execution "
+                    "(validation, comparison or registration phase)"});
+        }
+    }
+
+    /// Never called outside `handleOpNewPayload`'s classification barrier;
+    /// the signature carries no OP-dependent name, so the declaration instantiates harmlessly for
+    /// the generic composition root while the body (which is full of them) only instantiates in
+    /// OP mode.
+    bcos::task::Task<PayloadStatus> runOpNewPayloadSteps(const NewPayloadRequest& request)
+    {
+        auto const& payload = request.executionPayload;
+
+        // ---- Step 2: static validation + blockHash ----
+        // All rejections here carry latestValidHash = null: they happen before parentKnown, so no
+        // ancestor has been established as valid yet (the blockHash-mismatch bucket is always
+        // null). Note the status is `Invalid`, never `InvalidBlockHash` -- that Engine API status
+        // has been deprecated since Shanghai and the OP branch does not use it (the enumerator
+        // stays in Types.h for the generic path).
+        if (auto validationError =
+                detail::validateOpNewPayloadRequest(request, m_scheduler.get().isJovianActive());
+            validationError.has_value())
+        {
+            co_return makeStatus(PayloadValidationStatus::Invalid, std::nullopt, validationError);
+        }
+        // `ExecutionPayload` carries no transactionsRoot, so it is derived from the raw envelopes
+        // here -- the same derivation the execution path performs internally (one shared function,
+        // `OpBlockExecute.h`'s `computeOpTxRoot`), which is what lets the blockHash check stay
+        // genuinely static (before parentKnown and before execution).
+        const auto transactionsRoot = SchedulerType::computeTxRoot(*payload.rawTransactions);
+        const auto ethHeader = detail::rebuildOpEthHeader(m_blockFactory->blockHeaderFactory(),
+            payload, transactionsRoot, *request.parentBeaconBlockRoot);
+        // OP hash = keccak(RLP(21 fields)), via the rlp-protocol EthBlockHeader bridge (the 3
+        // post-merge constants are populated into the header by rebuildOpEthHeader /
+        // applyOpHeaderConstants; EthBlockHeader::rlpEncode applies the ms→s /1000 for NON_ETH).
+        // Must not use BlockHeader::hash() -- an empty tars dataHash throws EmptyBlockHeaderHash,
+        // and if the factory back-fills it the result would be the tars-order hash (a known
+        // pitfall).
+        if (bcos::protocol::EthBlockHeader::computeHash(*ethHeader) != payload.blockHash)
+        {
+            co_return makeStatus(PayloadValidationStatus::Invalid, std::nullopt,
+                std::string("blockHash does not match the reconstructed block header"));
+        }
+
+        // From here on the storage/execution segment runs under `x_state`, which is safety
+        // premise 2 of the design's coroutine contract: the engine execution segment is serialized
+        // by the x_state lock. The lock is held across `co_await`s -- sanctioned by that same
+        // contract, whose premise 1 is that every storage2 backend in play completes synchronously
+        // in-thread (memory MultiLayerStorage / blocking RocksDB reads), so the nested awaits
+        // degenerate into plain stack recursion and no coroutine ever resumes on another thread.
+        // The contract's invalidation criterion explicitly covers this lock-across-co_await usage
+        // as well: if any backend ever completes asynchronously, this must be redesigned.
+        std::unique_lock lock(x_state);
+
+        // ---- Step 3: parentKnown, via storage (not the in-memory map) ----
+        // OP semantics: op-node relies on SYNCING to drive its own sync, and the answer must
+        // reflect what is actually persisted, so the query goes to `SYS_HASH_2_NUMBER` through the
+        // ledger accessor rather than to `m_blockHashToPayloadId` (which the generic path uses and
+        // which the OP branch never populates). Nothing is written on this path.
+        auto view = m_globalStateStorage.get().fork();
+        auto parentBlockNumber = co_await bcos::ledger::getBlockNumber(
+            view, payload.parentHash, bcos::ledger::fromStorage);
+        if (!parentBlockNumber.has_value())
+        {
+            co_return makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+        }
+        // Past this point the parent IS a verified ancestor -- that is precisely the operational
+        // definition of "parent verified": present in `SYS_HASH_2_NUMBER`, a table only the VALID
+        // branch below writes. So every INVALID from here on reports `latestValidHash =
+        // parentHash`.
+        const auto latestValidHash = std::make_optional(payload.parentHash);
+
+        // Parent/child number continuity. Load-bearing here: `parentBlockNumber` is already in
+        // hand, and both registration indices written in step 6 (`SYS_NUMBER_2_HASH` and the ETH
+        // header table) are keyed BY NUMBER. Without this check a payload naming a verified parent
+        // but carrying an arbitrary `blockNumber` would silently overwrite an existing height's
+        // index entries -- a corrupted chain index, not merely a rejected block. Classified with
+        // steps 4/5 (INVALID + latestValidHash = parent) because the parent is established valid.
+        if (payload.blockNumber != *parentBlockNumber + 1)
+        {
+            co_return makeStatus(PayloadValidationStatus::Invalid, latestValidHash,
+                std::string("blockNumber must be exactly one greater than the parent's"));
+        }
+
+        // ---- Step 3a: timestamp strictly increases ----
+        //
+        // op-geth rejects this twice over: `eth/catalyst/api.go:891-894`
+        // (`block.Time() <= parent.Time()` -> invalid, latestValidHash = parent) and
+        // `consensus/beacon/consensus.go:253-256` (`errInvalidTimestamp`).
+        //
+        // The timestamp is NO LONGER the fork selector (fork selection is feature-driven —
+        // feature_op_jovian — since the feature-flag refactor), but monotonicity is still required
+        // by op-geth consensus itself (api.go:891-894, consensus.go:253-256); it also keeps
+        // timestamp-ordered history for the header chain.
+        //
+        // Keyed by NUMBER (op-geth keys by HASH, `api.go:887`); equivalent only while
+        // number -> header is injective, which step 3c guarantees today (at most one block per
+        // height). Whoever lifts step 3c must re-key this read by hash in the same change.
+        //
+        // Deliberately ordered BEFORE step 3b's already-known-block short-circuit, unlike op-geth
+        // (known-block first at `api.go:872-876`, timestamp after) -- observationally equivalent,
+        // since a re-delivered block necessarily passed this check when first accepted.
+        //
+        // Missing parent header => SKIP, deliberately (the genesis/first-block case): a trusted
+        // starting point is established by seeding `SYS_HASH_2_NUMBER` alone, so the first block
+        // after it has no stored parent header to compare against. Every block registered BY this
+        // loop does store its header, so the check is live for every subsequent block.
+        const auto parentNumberStr = boost::lexical_cast<std::string>(*parentBlockNumber);
+        // The parent header is read from the standard s_number_2_header table as a tars
+        // BlockHeader, replacing the retired s_eth_block_header RLP read path. Entry::get()
+        // returns a string_view (Entry.h:332) and createBlockHeader has no string_view overload
+        // -- copy explicitly into bytes.
+        if (auto parentHeaderEntry = co_await storage2::readOne(view,
+                executor_v1::StateKeyView{ledger::SYS_NUMBER_2_BLOCK_HEADER, parentNumberStr});
+            parentHeaderEntry.has_value())
+        {
+            const auto storedHeader = parentHeaderEntry->get();  // string_view
+            bcos::protocol::BlockHeader::Ptr parentHeader;
+            try
+            {
+                bcos::bytes parentHeaderBytes(storedHeader.begin(), storedHeader.end());
+                parentHeader =
+                    m_blockFactory->blockHeaderFactory()->createBlockHeader(parentHeaderBytes);
+            }
+            catch (const std::exception& e)
+            {
+                // Our own stored bytes failed to parse: a local storage/consistency fault, not a
+                // verdict on the incoming payload (the error-classification rule cuts both ways).
+                BOOST_THROW_EXCEPTION(
+                    OpExecutionInternalError{} << bcos::errinfo_comment{
+                        std::string("stored parent block header is undecodable: ") + e.what()});
+            }
+            // tars
+            // Tars decoding is lenient: a truncated stream may silently fill defaults. This table
+            // is keyed by height and written only by this loop, so a height mismatch is a local
+            // fault.
+            if (parentHeader->number() != static_cast<int64_t>(*parentBlockNumber))
+            {
+                BOOST_THROW_EXCEPTION(OpExecutionInternalError{} << bcos::errinfo_comment{
+                                          "stored parent block header height mismatch"});
+            }
+            // Note: createBlockHeader(bytesConstRef) auto back-fills dataHash with the tars-order
+            // hasher when it is empty (BlockHeaderFactoryImpl.cpp:21-37) -- that value is NOT the
+            // OP hash. This step only reads timestamp/baseFee/extraData/gasLimit/gasUsed/
+            // blobGasUsed, never hash(), so it is unaffected; this is a known consequence of
+            // deferred dataHash, and any future consumer of OP headers must not call hash().
+            // Monotonicity: payload timestamp is internal milliseconds (Types.h contract),
+            // compared in the same unit as the parent header (milliseconds).
+            if (static_cast<uint64_t>(payload.timestamp) <=
+                static_cast<uint64_t>(parentHeader->timestamp()))
+            {
+                co_return makeStatus(PayloadValidationStatus::Invalid, latestValidHash,
+                    std::string("timestamp must be strictly greater than the parent's"));
+            }
+
+            // Step 3a-2: baseFee consistency (Holocene+ EIP-1559 with Optimism
+            // extensions). op-geth checks this in consensus/misc/eip1559/eip1559.go's
+            // VerifyEIP1559Header → CalcBaseFee. The parent header is already in hand
+            // from the timestamp check above; fork membership is feature-driven — feature_op_jovian
+            // (the chain's Jovian flag), constant across blocks — matching op-geth's
+            // config.IsJovian(parent.Time) for the feature-flag-era chain.
+            {
+                auto expectedBaseFee =
+                    detail::calcOpBaseFee(*parentHeader, m_scheduler.get().isJovianActive());
+                if (payload.baseFeePerGas != expectedBaseFee)
+                {
+                    co_return makeStatus(PayloadValidationStatus::Invalid, latestValidHash,
+                        std::string("baseFeePerGas does not match the value computed "
+                                    "from the parent"));
+                }
             }
         }
 
-        m_payloadCache[payloadId] = std::move(entry);
+        // ---- Step 3b: already-known block -> VALID short-circuit ----
+        //
+        // op-geth does exactly this (`eth/catalyst/api.go:872-876`): a payload whose block is
+        // already in the chain returns VALID without re-executing. Re-delivery is a routine
+        // path, not a reorg -- CL timeouts re-send, and op-node replays unsafe blocks after a
+        // restart. Without this short-circuit the second delivery re-executes ON TOP OF the
+        // state the first delivery already committed, which produces a guaranteed-wrong result
+        // and answers INVALID: user-transaction blocks fail inside `processOpBlock` (the sender
+        // nonce has already advanced), deposit-only blocks fail the receiptsRoot comparison (the
+        // mint is credited twice). Answering INVALID there would make op-node mark a block it
+        // itself just accepted as bad -- the one case in this implementation where a block
+        // op-geth accepts would be rejected.
+        //
+        // Placement is load-bearing: AFTER step 2, so a malformed payload is still rejected on
+        // its own merits rather than waved through on a hash match; AFTER parentKnown/continuity,
+        // so the answer is only ever given for a block that sits where it claims to sit; and
+        // BEFORE the non-tip check below, because a re-delivered block always has a child height
+        // occupied (by itself) and would otherwise trip that check.
+        //
+        // `SYS_HASH_2_NUMBER` is written only by the VALID branch below, so presence there means
+        // "this exact block was executed and accepted by this node" -- the same operational
+        // definition step 5 uses for the parent.
+        if (auto knownBlockNumber = co_await bcos::ledger::getBlockNumber(
+                view, payload.blockHash, bcos::ledger::fromStorage);
+            knownBlockNumber.has_value())
+        {
+            co_return makeStatus(PayloadValidationStatus::Valid, payload.blockHash, std::nullopt);
+        }
 
-        // Evict stale payload entries. A payload is only read between updateForkchoice /
-        // getPayload and newPayload, so once a block is committed its payloadId and
-        // blockHash are unreachable. The built-in single-node driver mints one new
-        // payloadId per block_interval tick, so without eviction both maps grow by one
-        // row per produced block and hold strong references to every transaction ever
-        // executed (unbounded memory over time). Keep only the just-committed block; the
-        // newPayload() parent check accepts the head hash directly, so dropping older
-        // blockHash rows is safe.
-        std::erase_if(m_blockHashToPayloadId,
-            [&](auto const& kv) { return kv.first != request.executionPayload.blockHash; });
-        std::erase_if(m_payloadCache, [&](auto const& kv) { return kv.first != payloadId; });
+        // ---- Step 3c: the parent must be the current chain tip ----
+        //
+        // `fork()` above hands back the top of the layer stack -- the CURRENT tip's state -- not
+        // the state as of `payload.parentHash`. Whenever those differ, execution would silently
+        // run against the wrong base state and produce a result that cannot match the payload,
+        // reported as INVALID: a wrong verdict dressed up as a consensus judgement.
+        //
+        // The criterion is one-directional: an occupied child height ALWAYS implies the parent is
+        // not the tip (this is the direction used to refuse); an empty child height implies the
+        // parent IS the tip only under the invariant that every hash in `SYS_HASH_2_NUMBER`
+        // occupies its own height in `SYS_NUMBER_2_HASH`. `registerOpBlock` below writes both,
+        // always together, as does the production precedent `BaselineScheduler.h:207-220` -- so on
+        // a real ledger the criterion is exact; a store where the two disagree (notably a test
+        // fixture that seeds only `SYS_HASH_2_NUMBER`, a documented exemption) can present an
+        // empty child height for a parent that is not the tip and slip through. The parent/child
+        // number continuity check above does not close that gap: a parent seeded at height 5 with
+        // a payload at height 6 satisfies it.
+        //
+        // (A block already occupying the child height that IS this payload was short-circuited
+        // immediately above, so reaching here with an occupied height means a genuine
+        // sibling/side-chain delivery.)
+        //
+        // Answering `OpExecutionInternalError` (-32603) rather than INVALID is the honest
+        // reply: this node cannot evaluate the block, which is a capability limit, not a verdict.
+        // Serving arbitrary-parent base state needs a `blockHash -> MLS layer` mapping that does
+        // not exist today; that is architecture work, parked (this cycle delivers the explicit
+        // refusal, not the capability).
+        const auto childNumberStr = boost::lexical_cast<std::string>(payload.blockNumber);
+        if (auto occupiedHeight = co_await storage2::readOne(
+                view, executor_v1::StateKeyView{ledger::SYS_NUMBER_2_HASH, childNumberStr});
+            occupiedHeight.has_value())
+        {
+            BOOST_THROW_EXCEPTION(
+                OpExecutionInternalError{} << bcos::errinfo_comment{
+                    "non-tip parent not supported: a different block is already registered at "
+                    "this height, so the forked view's base state is not the payload's parent"});
+        }
 
-        co_return makeStatus(
-            PayloadValidationStatus::Valid, request.executionPayload.blockHash, std::nullopt);
+        // ---- Step 4: delegate block execution + commit (wiring Task 5b) ----
+        //
+        // The OP block's execution / six-way comparison / registerOpBlock are no longer
+        // driven inline here: they are absorbed by the delegate (OpScheduler's execute /
+        // verifyResult / commit hooks running on the shared SchedulerSkeleton). The engine keeps
+        // the static validation above (parentKnown / continuity / 3a / 3a-2 / 3b / 3c) and the
+        // classification barrier below, bridging the delegate's callback-async
+        // executeBlock/commitBlock back into this coroutine's PayloadStatus (v3 P1-6).
+        if (!m_delegate)
+        {
+            BOOST_THROW_EXCEPTION(
+                OpExecutionInternalError{} << bcos::errinfo_comment{
+                    "OP newPayload requires an m_delegate (OpScheduler) for block execution; "
+                    "the composition root did not wire one"});
+        }
+
+        // Block assembly (SEV-8: extraTransactionBytes = the full EIP-2718 envelope, not the
+        // signing preimage) — the delegate's execute hook re-derives rawTxBytes from it.
+        auto block = buildOpBlock(payload, ethHeader);
+
+        // SchedulerInterface executeBlock is synchronous from here (the skeleton runs task::wait
+        // internally), so the callback fires before the call returns. Errors surface as
+        // SchedulerError codes through the callback — never as typed OP exceptions. The header
+        // returned is the delegate's executed header (finishExecute), which commitBlock consumes.
+        bcos::Error::Ptr executeError;
+        bcos::protocol::BlockHeader::Ptr executedHeader;
+        m_delegate->executeBlock(block, /*verify=*/true,
+            [&](bcos::Error::Ptr error, bcos::protocol::BlockHeader::Ptr header, bool) {
+                executeError = std::move(error);
+                executedHeader = std::move(header);
+            });
+        if (executeError)
+        {
+            co_return mapDelegateError(*executeError, latestValidHash);
+        }
+
+        bcos::Error::Ptr commitError;
+        m_delegate->commitBlock(
+            executedHeader, [&](bcos::Error::Ptr error, bcos::ledger::LedgerConfig::Ptr) {
+                commitError = std::move(error);
+            });
+        if (commitError)
+        {
+            co_return mapDelegateError(*commitError, latestValidHash);
+        }
+
+        // The delegate's commit hook (prewriteBlockToBuffer) wrote the 7 ledger tables including
+        // SYS_CURRENT_STATE, and the skeleton merged the execute view + commit storage atomically
+        // (FIB-104). The head-advance monotonic guard semantics the inline path kept
+        // (blockNumber > currentHead) are preserved by OpScheduler::commitContinuityCheck
+        // (v3 P1-6), which refuses already-committed / discontinuous commits on the same view.
+        co_return makeStatus(PayloadValidationStatus::Valid, payload.blockHash, std::nullopt);
     }
+
+    /// OP block assembly (wiring Task 5a, SEV-8). Build a `protocol::Block` carrying the
+    /// payload's raw EIP-2718 envelopes as each transaction's `extraTransactionBytes` -- the
+    /// FULL envelope, not the signing preimage (`takeToTarsTransaction` stores the preimage;
+    /// the delegate's execute hook re-derives rawTxBytes from extraTransactionBytes, so the
+    /// overwrite is load-bearing). Precedent: OpDualPathEquivalenceTest.cpp:566-568. Used only
+    /// by the delegate path.
+    [[maybe_unused]] bcos::protocol::Block::Ptr buildOpBlock(
+        const ExecutionPayload& payload, bcos::protocol::BlockHeader::Ptr header)
+    {
+        auto block = m_blockFactory->createBlock();
+        block->setBlockHeader(std::move(header));
+        auto const& rawTransactions = *payload.rawTransactions;
+        auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
+        for (auto const& env : rawTransactions)
+        {
+            const auto txHash = hashImpl.hash(env);
+            auto tarsTx = detail::opEnvelopeToTars(env, txHash);
+            if (!tarsTx)
+            {
+                // A conversion failure means the envelope is malformed or un-enumerated
+                // (Web3Transaction RLP decode returned an error) -- a consensus-level rejection
+                // of the block, classified INVALID (OpConsensusError -> INVALID), never -32603.
+                // The verdict is issued by the delegate's execute hook: the type-byte gate
+                // (OpScheduler.h:586-590, unsupported type byte -> OpConsensusError), or for a
+                // malformed-but-supported 0x01/0x02/0x04 envelope, opValidate's type whitelist
+                // with the all-zero fallback tars tx failing validate_transaction. Step 2
+                // (validateOpNewPayloadRequest) does NOT decode envelopes, so reaching assembly
+                // does not imply every envelope is canonical and enumerated. Carry the raw
+                // envelope in a minimal tars tx (only the hash and wire bytes populated) so the
+                // delegate's execute hook re-derives it and issues the verdict.
+                bcostars::Transaction fallback;
+                fallback.extraTransactionHash.assign(txHash.begin(), txHash.end());
+                tarsTx = std::move(fallback);
+            }
+            // SEV-8: takeToTarsTransaction stores the signing preimage; overwrite with the full
+            // envelope so the delegate's execute hook decodes the exact wire bytes.
+            tarsTx->extraTransactionBytes.assign(env.begin(), env.end());
+            auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+                [tars = std::move(*tarsTx)]() mutable { return &tars; });
+            block->appendTransaction(std::move(tx));
+        }
+        return block;
+    }
+
 
     PayloadID nextPayloadID() { return detail::encodePayloadSequence(m_nextPayloadSequence++); }
 
@@ -717,6 +1361,9 @@ private:
             .withdrawals = std::nullopt,
             .blobGasUsed = std::nullopt,
             .excessBlobGas = std::nullopt,
+            .blockAccessList = std::nullopt,
+            .slotNumber = std::nullopt,
+            .rawTransactions = std::nullopt,
             .withdrawalsRoot = std::nullopt,
         };
 
@@ -978,10 +1625,17 @@ private:
     std::reference_wrapper<ExecutorType> m_executor;
     std::reference_wrapper<SchedulerType> m_scheduler;
     bcos::protocol::BlockFactory::Ptr m_blockFactory;
+    std::uint32_t m_maxEngineVersion;
     /// Optional ledger used to persist the ledger block tables when a locally built payload
     /// is committed via newPayload(). Null in unit tests / for payloads without block
     /// persistence.
     bcos::ledger::LedgerInterface::Ptr m_ledger;
+    /// OP block-execution delegate (wiring Task 5): when non-null and `c_opMode`, newPayload
+    /// routes block execution + commit through `m_delegate->executeBlock/commitBlock`
+    /// (SchedulerInterface face) instead of any inline OP block-execution path. The delegate is
+    /// the composition root's `OpScheduler` (slot 3). Null for the generic composition root and
+    /// for OP fixtures that never drive block execution (ethereum instances).
+    bcos::scheduler::SchedulerInterface::Ptr m_delegate;
     ForkchoiceState m_forkchoiceState;
     std::optional<TrackedHeadBlock> m_trackedHeadBlock;
     std::optional<bcos::protocol::BlockNumber> m_safeBlockNumber;

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -260,7 +260,8 @@ BloomEngineServiceImpl makeBloomEngineServiceImpl(
     StubExecutor executor;
     static auto blockFactory =
         bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
-    return BloomEngineServiceImpl(memPool, storage, executor, scheduler, blockFactory);
+    return BloomEngineServiceImpl(
+        memPool, storage, executor, scheduler, blockFactory, /*delegate=*/nullptr);
 }
 
 using TestEngineServiceImpl =
@@ -272,7 +273,8 @@ TestEngineServiceImpl makeEngineServiceImpl(MemPoolImpl& memPool, RealGlobalStat
     StubScheduler scheduler;
     static auto blockFactory =
         bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
-    return TestEngineServiceImpl(memPool, storage, executor, scheduler, blockFactory);
+    return TestEngineServiceImpl(
+        memPool, storage, executor, scheduler, blockFactory, /*delegate=*/nullptr);
 }
 
 ForkchoiceState makeForkchoiceState()

--- a/ethereum-executor/CMakeLists.txt
+++ b/ethereum-executor/CMakeLists.txt
@@ -12,9 +12,16 @@ target_include_directories(ethereum-executor PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/ethereum-executor>)
 target_link_libraries(ethereum-executor PUBLIC
-    bcos-framework bcos-protocol
+    bcos-evm-eth bcos-framework bcos-protocol
     evmone::evmone evmone::precompiles intx::intx TBB::tbb)
 set_target_properties(ethereum-executor PROPERTIES UNITY_BUILD OFF)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    # kyonRay review #5429 K5: the pure-Ethereum executor (EthereumTransition.h / EESTRunner)
+    # uses the same skipped-field designated-initializer style as the OP modules; downgrade only
+    # here, not repository-wide.
+    target_compile_options(ethereum-executor PRIVATE
+        -Wno-error=missing-field-initializers -Wno-error=dangling-reference)
+endif()
 
 if (TESTS)
     enable_testing()

--- a/ethereum-executor/EthereumExecutor.h
+++ b/ethereum-executor/EthereumExecutor.h
@@ -6,8 +6,7 @@
 /// finalization) is ported from bcos-evm and integrated here so that it reads
 /// and writes BCOS storage directly through ledger::account::EVMAccount +
 /// storage2 — there is no evmone::state::StateView / BlockHashes / StateDiff
-/// adapter layer (StorageStateView / StorageBlockHashes / applyStateDiff are
-/// gone), transactions are the bcos protocol::Transaction directly, and block
+/// adapter layer, transactions are the bcos protocol::Transaction directly, and block
 /// headers are the bcos protocol::BlockHeader directly (see the
 /// Rollbackable / EthereumState / EthereumHost / EthereumTransition headers).
 ///

--- a/ethereum-executor/tests/ApplyStateDiffTest.cpp
+++ b/ethereum-executor/tests/ApplyStateDiffTest.cpp
@@ -1,0 +1,58 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+/// ApplyStateDiffTest.cpp — Task 6.1 write-back fix (B4): a deleted_accounts entry
+/// must remove the account's SYS_TABLES marker, not just clear its fields. Otherwise a
+/// touch-deleted account lingers as an EIP-161 ghost empty account (existence-marker
+/// row survives while all fields are zeroed), diverging from Storage2State::applyDeletedEntry.
+///
+/// Assertion contract (plan v2, B4): we assert the SYS_TABLES marker is removed — the
+/// field rows are zeroed by clearAccountStorage and are not part of this assertion
+/// (a range-delete of the field rows would be a bigger change than the fix makes).
+
+#define BOOST_TEST_MODULE ApplyStateDiffTest
+#include "TestMemoryStorage.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/ledger/EVMAccount.h"
+#include "bcos-framework/storage2/Storage.h"
+#include "opstack-executor/Storage2State.h"
+#include <bcos-task/Wait.h>
+#include <boost/test/unit_test.hpp>
+#include <evmc/evmc.hpp>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::executor_v1;
+using namespace evmc::literals;  // _address
+
+namespace
+{
+// An ordinary /apps/ account (not one of the c_systemTxsAddress members routed to /sys/).
+constexpr evmc::address kGhostAddr = 0x00000000000000000000000000000000deadbeef_address;
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(applyStateDiffDeletedAccountRemovesSysTablesMarker)
+{
+    MutableStorage storage;
+    bcos::crypto::Keccak256 keccak;
+
+    // Set up an EMPTY account on the ledger: only the SYS_TABLES marker row exists
+    // (nonce=0, balance=0, no code — the EIP-161 touch-delete scenario).
+    ledger::account::EVMAccount<MutableStorage> acc(storage, kGhostAddr, false);
+    task::syncWait(acc.create());
+    std::string tableName = std::string(task::syncWait(acc.path()));
+
+    // Sanity: the empty account exists on the ledger (SYS_TABLES marker present).
+    BOOST_REQUIRE(task::syncWait(
+        storage2::existsOne(storage, executor_v1::StateKeyView(ledger::SYS_TABLES, tableName))));
+
+    evmone::state::StateDiff diff;
+    diff.deleted_accounts.push_back(kGhostAddr);
+
+    task::syncWait(bcos::executor_v1::eth::applyStateDiff(storage, diff, EVMC_SHANGHAI, keccak));
+
+    // B4: the deleted account's SYS_TABLES marker must be removed — no EIP-161 ghost
+    // empty account may linger after touch-delete.
+    BOOST_CHECK(!task::syncWait(
+        storage2::existsOne(storage, executor_v1::StateKeyView(ledger::SYS_TABLES, tableName))));
+}

--- a/ethereum-executor/tests/CMakeLists.txt
+++ b/ethereum-executor/tests/CMakeLists.txt
@@ -1,14 +1,131 @@
+# EEST fixtures download; exposes EVM_REF_EEST_ROOT (CACHE INTERNAL).
+# 注：按计划 Step 4 备选走了最小裁剪——eth-eest-test 仅含下载机制
+# （FetchReferenceAssets.cmake + upstream-pins.json），不含 runner 目标
+# （其 src/runners 依赖 worktree 版 bcos-evm API，主树不可编译）。
+# EEST_FIXTURE_DIR=${EVM_REF_EEST_ROOT}/fixtures（直接含 state_tests/ 等）。
+add_subdirectory(../../bcos-evm/test/eth-eest-test bcos-evm-eest-assets)
+
 # Standalone EEST runner (no Boost.Test dependency, uses TBB for parallelism)
 find_package(jsoncpp CONFIG REQUIRED)
-add_executable(eest-runner EESTRunner.cpp)
+add_executable(eest-runner EESTRunner.cpp EestFailuresJson.cpp)
+# bcosevm::opstack MUST precede bcos-evm-eth: the opstack static archive references eth symbols
+# (OpTransition/OpHost resolve against the vendored eth state), and on mac static linking the
+# defining archive must follow the referencing one.
 target_link_libraries(eest-runner
-    ethereum-executor bcos-evm-eth executor ledger protocol-tars bcos-framework rpc
+    ethereum-executor bcosevm::opstack bcos-evm-eth executor ledger protocol-tars bcos-framework rpc
     evmone::evmone jsoncpp_static TBB::tbb)
 add_dependencies(eest-runner executor)
 set_source_files_properties("EESTRunner.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(eest-runner PROPERTIES UNITY_BUILD OFF)
 set_target_properties(eest-runner PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
+# Standalone unit tests for EestFailuresJson (writeFailuresJson + firstMismatchCategory).
+# Kept independent: bcos-evm-opstack-tests does not link jsoncpp_static and
+# reverse-depending on ethereum-executor would be circular.
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+add_executable(eest-json-tests
+    EestFailuresJsonTest.cpp
+    EestFailuresJson.cpp
+    EestSpikeForkTest.cpp)
+target_link_libraries(eest-json-tests PRIVATE jsoncpp_static Boost::unit_test_framework)
+set_source_files_properties("EestFailuresJsonTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+set_target_properties(eest-json-tests PROPERTIES UNITY_BUILD OFF)
+set_target_properties(eest-json-tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+# ctest registration (matches the BcosEvm*Tests convention in bcos-evm/test): without this
+# the writeFailuresJson 7-field schema, firstMismatchCategory, and spikeForkSelect are dead
+# code in CI (the target is built but never run).
+add_test(NAME EestJsonTests COMMAND eest-json-tests)
+
+# ---------------------------------------------------------------------------
+# PR smoke subset (Task 7): register eest-runner as a ctest so a PR that
+# regresses the EVM turns red automatically.
+#
+# The committed baseline (bcos-evm/test/eth-eest-test/assets/
+# baseline-fails-v540.json) is [] — the full suite passes 100% — so the smoke
+# subset is a small REPRESENTATIVE set of PASSING fixtures (one per fork /
+# feature), NOT the result of subtracting known failures.  It is deterministic
+# (fixed paths), never randomly sampled, and capped well under the 20-file
+# budget for ctest speed (12 files / 473 test executions, ~0.2 s).
+#
+# eest-runner only honors a single --fixture (std::string singleFixture), so a
+# multi-file smoke subset is materialised as a directory of symlinks into the
+# fetched fixture tree and run with --fixture-dir (recursive, file-symlink
+# safe).  The directory + manifest are regenerated at configure time, which
+# re-runs whenever this list changes.
+# ---------------------------------------------------------------------------
+set(EEST_PR_SMOKE_SUBSET
+    "state_tests/prague/eip7702_set_code_tx/test_address_from_set_code.json"
+    "state_tests/cancun/eip1153_tstore/test_basic_tload_after_store.json"
+    "state_tests/cancun/eip5656_mcopy/test_mcopy_on_empty_memory.json"
+    "state_tests/cancun/eip4844_blobs/test_blob_tx_attribute_opcodes.json"
+    "state_tests/shanghai/eip3855_push0/test_push0_contracts.json"
+    "state_tests/shanghai/eip3860_initcode/test_contract_creating_tx.json"
+    "state_tests/london/eip1559_fee_market_change/test_eip1559_tx_validity.json"
+    "state_tests/paris/eip7610_create_collision/test_init_collision_create_tx.json"
+    "state_tests/berlin/eip2930_access_list/test_eip2930_tx_validity.json"
+    "state_tests/istanbul/eip152_blake2/test_blake2b.json"
+    "state_tests/frontier/opcodes/test_all_opcodes.json"
+    "state_tests/static/state_tests/stExample/add11.json")
+
+set(_eest_smoke_dir "${CMAKE_BINARY_DIR}/eest-pr-smoke")
+file(REMOVE_RECURSE "${_eest_smoke_dir}")
+file(MAKE_DIRECTORY "${_eest_smoke_dir}")
+set(_eest_smoke_manifest "${_eest_smoke_dir}/manifest.txt")
+file(WRITE "${_eest_smoke_manifest}" "EEST_ROOT=${EVM_REF_EEST_ROOT}/fixtures\nSMOKE_DIR=${_eest_smoke_dir}\n")
+set(_eest_smoke_idx 0)
+foreach(_rel IN LISTS EEST_PR_SMOKE_SUBSET)
+    math(EXPR _eest_smoke_idx "${_eest_smoke_idx} + 1")
+    get_filename_component(_eest_dir "${_rel}" DIRECTORY)
+    get_filename_component(_eest_base "${_rel}" NAME)
+    string(REGEX REPLACE "/" "_" _eest_flat "${_eest_dir}")
+    if(_eest_smoke_idx LESS 10)
+        set(_eest_prefix "0${_eest_smoke_idx}")
+    else()
+        set(_eest_prefix "${_eest_smoke_idx}")
+    endif()
+    set(_eest_link "${_eest_smoke_dir}/${_eest_prefix}_${_eest_flat}_${_eest_base}")
+    set(_eest_src "${EVM_REF_EEST_ROOT}/fixtures/${_rel}")
+    if(NOT EXISTS "${_eest_src}")
+        message(FATAL_ERROR "EEST PR smoke fixture missing: ${_eest_src}")
+    endif()
+    if(NOT EXISTS "${_eest_link}")
+        file(CREATE_LINK "${_eest_src}" "${_eest_link}" SYMBOLIC)
+    endif()
+    file(APPEND "${_eest_smoke_manifest}" "FIXTURE=${_eest_link}\n")
+endforeach()
+unset(_eest_smoke_manifest)
+unset(_eest_smoke_idx)
+unset(_eest_dir)
+unset(_eest_base)
+unset(_eest_flat)
+unset(_eest_prefix)
+unset(_eest_link)
+unset(_eest_src)
+
+# ctest: `ctest -R EestRunner` runs the smoke subset in baseline mode and fails
+# red on any regression (eest-runner exits 1 when g_totalFailed > 0).  The
+# JSON failures are also left in the build dir for inspection / the regression
+# script.  $<TARGET_FILE:> makes the test independent of PATH/working dir.
+add_test(NAME EestRunner
+    COMMAND $<TARGET_FILE:eest-runner>
+        --fixture-dir "${_eest_smoke_dir}"
+        --json-failures "${CMAKE_BINARY_DIR}/pr-smoke-fails.json")
+set_tests_properties(EestRunner PROPERTIES
+    ENVIRONMENT "EEST_FIXTURE_DIR=${EVM_REF_EEST_ROOT}/fixtures")
+
+# ApplyStateDiff write-back unit tests (Task 6.1, B4): a deleted_accounts entry must
+# remove the account's SYS_TABLES marker so a touch-deleted account cannot linger as an
+# EIP-161 ghost empty account. Directly instantiates eth::applyStateDiff over a memory
+# ledger (no block execution, no tars objects).
+find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+add_executable(ethereum-executor-diff-tests ApplyStateDiffTest.cpp)
+target_link_libraries(ethereum-executor-diff-tests PRIVATE
+    ethereum-executor ledger bcos-crypto protocol-tars bcos-framework
+    evmone::evmone Boost::unit_test_framework)
+set_source_files_properties("ApplyStateDiffTest.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+set_target_properties(ethereum-executor-diff-tests PROPERTIES UNITY_BUILD OFF)
+set_target_properties(ethereum-executor-diff-tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+add_test(NAME EthereumExecutorDiffTests COMMAND ethereum-executor-diff-tests)
 # Compile/instantiation smoke coverage for the split-2/4 orphan headers
 # (EVMSupport.h / EthereumState.h): nothing else includes them yet, so this
 # target is the first place a syntax, template-instantiation or ODR error in

--- a/ethereum-executor/tests/EESTRunner.cpp
+++ b/ethereum-executor/tests/EESTRunner.cpp
@@ -15,10 +15,15 @@
  */
 
 #include "EESTRunner.h"
+#include "EestFailuresJson.h"
+#include "EestSpikeFork.h"
 #include "TestMemoryStorage.h"
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-evm/eth/state/block.hpp"
 #include "bcos-evm/eth/state/system_contracts.hpp"
+#include "bcos-evm/opstack/OpForkSchedule.h"
+#include "bcos-evm/opstack/OpPredeploys.h"
+#include "bcos-evm/opstack/OpTransition.h"
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/ledger/Features.h"
 #include "bcos-framework/protocol/Protocol.h"
@@ -30,15 +35,22 @@
 #include "bcos-task/TBBWait.h"
 #include "TestStorageBridge.h"
 #include "ethereum-executor/EthereumExecutor.h"
+#include <cxxabi.h>
 #include <evmc/evmc.h>
+#include <evmone/evmone.h>
 #include <tbb/concurrent_vector.h>
 #include <boost/algorithm/hex.hpp>
 #include <boost/log/core.hpp>
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
+#include <cstdlib>
+#include <evmc/hex.hpp>
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <intx/intx.hpp>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -47,11 +59,15 @@
 #include <range/v3/algorithm/equal.hpp>
 #include <sstream>
 #include <string>
+#include <test/utils/test_state.hpp>
 #include <vector>
 
 using namespace bcos;
 using namespace bcos::storage2;
 using namespace bcos::executor_v1;
+// opstack is nested in bcos::evm (not bcos), so it needs an explicit alias for the
+// spike-track references below.
+namespace opstack = bcos::evm::opstack;
 namespace fs = std::filesystem;
 
 // =============================================================================
@@ -471,10 +487,8 @@ EESTBlockchainFixture parseBlockchainFixture(
     fixture.name = name;
 
     // genesisBlockHeader (optional: engine_x format lacks it)
-    if (fixtureJson.isMember("genesisBlockHeader") &&
-        fixtureJson["genesisBlockHeader"].isObject())
-        fixture.genesisBlockHeader =
-            parseBlockHeader(fixtureJson["genesisBlockHeader"]);
+    if (fixtureJson.isMember("genesisBlockHeader") && fixtureJson["genesisBlockHeader"].isObject())
+        fixture.genesisBlockHeader = parseBlockHeader(fixtureJson["genesisBlockHeader"]);
 
     // pre state
     if (fixtureJson.isMember("pre") && !fixtureJson["pre"].isNull())
@@ -513,8 +527,7 @@ EESTBlockchainFixture parseBlockchainFixture(
 
     // postState
     if (fixtureJson.isMember("postState") && !fixtureJson["postState"].isNull())
-        for (auto it = fixtureJson["postState"].begin();
-             it != fixtureJson["postState"].end(); ++it)
+        for (auto it = fixtureJson["postState"].begin(); it != fixtureJson["postState"].end(); ++it)
             fixture.postState[it.key().asString()] = parseAccount(*it);
 
     // config
@@ -535,8 +548,7 @@ std::vector<EESTBlockchainFixture> loadEESTBlockchainFixtures(std::string const&
 
     std::ifstream file(filePath);
     if (!file.is_open())
-        BOOST_THROW_EXCEPTION(
-            std::runtime_error("Cannot open fixture file: " + filePath));
+        BOOST_THROW_EXCEPTION(std::runtime_error("Cannot open fixture file: " + filePath));
 
     Json::CharReaderBuilder builder;
     Json::Value root;
@@ -547,8 +559,7 @@ std::vector<EESTBlockchainFixture> loadEESTBlockchainFixtures(std::string const&
 
     for (auto it = root.begin(); it != root.end(); ++it)
     {
-        if (it.key().asString().rfind("//", 0) == 0 ||
-            it.key().asString().rfind("_", 0) == 0)
+        if (it.key().asString().rfind("//", 0) == 0 || it.key().asString().rfind("_", 0) == 0)
             continue;
 
         // Skip non-object values
@@ -557,20 +568,19 @@ std::vector<EESTBlockchainFixture> loadEESTBlockchainFixtures(std::string const&
 
         try
         {
-            fixtures.push_back(
-                parseBlockchainFixture(it.key().asString(), *it));
+            fixtures.push_back(parseBlockchainFixture(it.key().asString(), *it));
         }
         catch (std::exception const& e)
         {
-            std::cerr << "Warning: Failed to parse blockchain fixture '"
-                      << it.key().asString() << "': " << e.what() << std::endl;
+            std::cerr << "Warning: Failed to parse blockchain fixture '" << it.key().asString()
+                      << "': " << e.what() << std::endl;
         }
     }
 
     return fixtures;
 }
 
-evmc_revision forkNameToRevision(std::string const& forkName)
+std::optional<evmc_revision> forkNameToRevision(std::string const& forkName)
 {
     // Normalize: lowercase
     auto lower = forkName;
@@ -612,10 +622,10 @@ evmc_revision forkNameToRevision(std::string const& forkName)
     if (lower == "osaka")
         return EVMC_OSAKA;
 
-    // Unknown fork → default to the latest handled revision so a future fork
-    // is not silently mis-executed as Cancun (which would produce false
-    // pass/fail outcomes in the compliance suite).
-    return EVMC_OSAKA;
+    // Unknown fork → nullopt so the caller can SKIP the fixture instead of
+    // silently executing it under the latest handled revision (which would
+    // produce undefined-behavior pass/fail outcomes in the compliance suite).
+    return std::nullopt;
 }
 }  // namespace bcos::test
 
@@ -626,9 +636,14 @@ struct ProgramOptions
 {
     std::string fixtureDir;     // directory with .json fixtures
     std::string singleFixture;  // single fixture file path
+    std::string jsonFailures;   // write structured failure JSON to this file
     bool quiet = false;         // suppress per-file/per-test output
     bool noLog = false;         // suppress BCOS internal trace/debug log
     bool help = false;
+    // Spike track (Task 5): execute EF fixtures through the REAL opTransition (the opstack
+    // rewrite of evmone's state.cpp) instead of the ethereum-executor baseline.
+    std::string execMode = "baseline";  // "baseline" | "optransition"
+    std::string opFork = "isthmus";  // OP fork config used by the spike track ("isthmus"|"jovian")
 };
 
 ProgramOptions g_opts;
@@ -654,13 +669,8 @@ std::atomic<int> g_unexpectedFailure{0};
 std::atomic<int> g_skippedFiles{0};
 std::atomic<int> g_loadFailures{0};
 
-// Failure details for summary
-struct FailureDetail
-{
-    std::string testName;
-    std::string forkName;
-    std::string reason;
-};
+// Failure details for summary (struct defined in EestFailuresJson.h)
+using bcos::test::FailureDetail;
 tbb::concurrent_vector<FailureDetail> g_failureDetails;
 
 // Mutex for console output (keep lines from interleaving)
@@ -714,6 +724,10 @@ void printUsage(char const* prog)
 Options:
   --fixture-dir DIR    Directory containing EEST .json fixture files (recursive)
   --fixture FILE       Run a single fixture file only
+  --json-failures FILE Write structured failure records (JSON array) to FILE
+  --exec-mode MODE     Execution engine: "baseline" (ethereum-executor, default) or
+                       "optransition" (real opTransition spike track; runs pure Prague only)
+  --op-fork FORK       OP fork config for the spike track: "isthmus" (default) or "jovian"
   --quiet              Suppress per-file/per-test output; show summary only
   --no-log             Suppress BCOS internal trace/debug log output
   --help               Show this help message
@@ -754,6 +768,18 @@ void parseOptions(int argc, char* argv[])
         {
             g_opts.singleFixture = argv[++i];
         }
+        else if (arg == "--json-failures" && i + 1 < argc)
+        {
+            g_opts.jsonFailures = argv[++i];
+        }
+        else if (arg == "--exec-mode" && i + 1 < argc)
+        {
+            g_opts.execMode = argv[++i];
+        }
+        else if (arg == "--op-fork" && i + 1 < argc)
+        {
+            g_opts.opFork = argv[++i];
+        }
         else if (arg.rfind("--fixture-dir=", 0) == 0)
         {
             g_opts.fixtureDir = arg.substr(14);
@@ -762,6 +788,36 @@ void parseOptions(int argc, char* argv[])
         {
             g_opts.singleFixture = arg.substr(10);
         }
+        else if (arg.rfind("--json-failures=", 0) == 0)
+        {
+            g_opts.jsonFailures = arg.substr(16);  // "--json-failures=" = 16 chars
+        }
+        else if (arg.rfind("--exec-mode=", 0) == 0)
+        {
+            g_opts.execMode = arg.substr(12);  // "--exec-mode=" = 12 chars
+        }
+        else if (arg.rfind("--op-fork=", 0) == 0)
+        {
+            g_opts.opFork = arg.substr(10);  // "--op-fork=" = 10 chars
+        }
+    }
+
+    // Validate enumerated options so a typo (e.g. "--exec-mode optranstion") fails loudly
+    // instead of silently falling through to the baseline track (the worst failure mode for
+    // a verification tool).  --help short-circuits above, so these run only on a real run.
+    if (g_opts.execMode != "baseline" && g_opts.execMode != "optransition")
+    {
+        std::cerr << "error: invalid --exec-mode \"" << g_opts.execMode
+                  << "\" (expected \"baseline\" or \"optransition\")\n\n";
+        printUsage(argv[0]);
+        std::exit(1);
+    }
+    if (g_opts.opFork != "isthmus" && g_opts.opFork != "jovian")
+    {
+        std::cerr << "error: invalid --op-fork \"" << g_opts.opFork
+                  << "\" (expected \"isthmus\" or \"jovian\")\n\n";
+        printUsage(argv[0]);
+        std::exit(1);
     }
 }
 
@@ -775,6 +831,183 @@ struct ForkTransition
     evmc_revision toRev = EVMC_CANCUN;
     int64_t transitionTimestamp = 0;
 };
+
+namespace
+{
+// ── opTransition spike track: JSON-string → evmone primitive helpers ─────────
+// EESTRunner.h keeps the parsed account/tx fields as hex strings; the spike track
+// converts them to the evmone::test / evmone::state types opTransition consumes.
+
+/// Parse "0x…" into an evmc::address. Malformed / short input → all-zero address
+/// (a well-formed recipient is exactly 20 bytes; the callers gate on that).
+evmc::address spikeAddrFromHex(std::string const& hex)
+{
+    auto bytes = test::hexToBytes(hex);
+    evmc::address a{};
+    if (bytes.size() == sizeof(evmc::address))
+        std::copy(bytes.begin(), bytes.end(), a.bytes);
+    return a;
+}
+
+/// Parse "0x…" into an intx::uint256 ("" / "0x" → 0).
+intx::uint256 spikeU256FromHex(std::string const& hex)
+{
+    if (hex.empty() || hex == "0x")
+        return 0;
+    return intx::from_string<intx::uint256>(hex);
+}
+
+/// Parse "0x…" into an evmc::bytes32, right-aligned (storage slots are big-endian).
+evmc::bytes32 spikeBytes32FromHex(std::string const& hex)
+{
+    auto bytes = test::hexToBytes(hex);
+    evmc::bytes32 out{};
+    if (bytes.size() <= sizeof(evmc::bytes32))
+        std::copy(bytes.begin(), bytes.end(), out.bytes + sizeof(evmc::bytes32) - bytes.size());
+    else
+        std::copy_n(bytes.end() - sizeof(evmc::bytes32), sizeof(evmc::bytes32), out.bytes);
+    return out;
+}
+
+std::string spikeHexBytes32(evmc::bytes32 const& b)
+{
+    return "0x" + evmc::hex(evmc::bytes_view{b.bytes, sizeof(b.bytes)});
+}
+
+/// intx::uint256 → "0x" + minimal lowercase hex (intx ships no ostream operator<<).
+std::string spikeHexU256(intx::uint256 const& v)
+{
+    return "0x" + intx::to_string(v, 16);
+}
+
+/// bcos::bytes (std::vector<uint8_t>) → evmc::bytes (std::basic_string<uint8_t>).
+/// The two are distinct types; the evmone state structs store the basic_string form.
+evmc::bytes spikeBytesFromHex(std::string const& hex)
+{
+    auto b = test::hexToBytes(hex);
+    return evmc::bytes(b.begin(), b.end());
+}
+
+/// Build an evmone::state::Transaction from the parsed EEST transaction + post indices.
+/// Mirrors BCOS2Evmone::bcosTransactionToEvmone: type selection by web3TypedTxKind and the
+/// legacy/access-list max_priority_gas_price = max_gas_price shim (so a legacy tx's effective
+/// gas price equals its gasPrice under a non-zero base fee).
+evmone::state::Transaction spikeBuildTransaction(
+    ::test::EESTTransaction const& tx, int dataIndex, int gasIndex, int valueIndex, int64_t chainId)
+{
+    evmone::state::Transaction evmTx{};
+
+    if (dataIndex >= 0 && static_cast<size_t>(dataIndex) < tx.data.size())
+        evmTx.data = spikeBytesFromHex(tx.data[dataIndex]);
+
+    std::string gasLimitHex = "0x0";
+    if (gasIndex >= 0 && static_cast<size_t>(gasIndex) < tx.gasLimit.size())
+        gasLimitHex = tx.gasLimit[gasIndex];
+    evmTx.gas_limit = static_cast<int64_t>(test::hexToU256(gasLimitHex));
+
+    std::string valueHex = "0x0";
+    if (valueIndex >= 0 && static_cast<size_t>(valueIndex) < tx.value.size())
+        valueHex = tx.value[valueIndex];
+    evmTx.value = spikeU256FromHex(valueHex);
+
+    if (!tx.sender.empty())
+        evmTx.sender = spikeAddrFromHex(tx.sender);
+
+    if (!tx.to.empty() && tx.to != "0x")
+    {
+        auto tb = test::hexToBytes(tx.to);
+        if (tb.size() == sizeof(evmc::address))
+        {
+            evmc::address ta{};
+            std::copy(tb.begin(), tb.end(), ta.bytes);
+            evmTx.to = ta;
+        }
+    }
+
+    evmTx.nonce = static_cast<uint64_t>(test::hexToU256(tx.nonce));
+    evmTx.chain_id = tx.chainId.empty() ? static_cast<uint64_t>(chainId) :
+                                          static_cast<uint64_t>(test::hexToU256(tx.chainId));
+
+    // Type selection mirrors BCOS2Evmone: blob overrides everything (buildTransaction assigns
+    // web3TypedTxKind=3 last), then set_code, then eip1559, then access_list, else legacy.
+    const bool hasAuthList = tx.authorizationList.has_value();
+    const bool isBlobTx = !tx.maxFeePerBlobGas.empty() || !tx.blobVersionedHashes.empty();
+    const bool isEip1559 = !tx.maxFeePerGas.empty() || !tx.maxPriorityFeePerGas.empty();
+    const bool hasAccessList =
+        (dataIndex >= 0 && static_cast<size_t>(dataIndex) < tx.accessLists.size() &&
+            tx.accessLists[dataIndex].has_value());
+    if (isBlobTx)
+        evmTx.type = evmone::state::Transaction::Type::blob;
+    else if (hasAuthList)
+        evmTx.type = evmone::state::Transaction::Type::set_code;
+    else if (isEip1559)
+        evmTx.type = evmone::state::Transaction::Type::eip1559;
+    else if (hasAccessList)
+        evmTx.type = evmone::state::Transaction::Type::access_list;
+    else
+        evmTx.type = evmone::state::Transaction::Type::legacy;
+
+    if (!tx.gasPrice.empty())
+        evmTx.max_gas_price = spikeU256FromHex(tx.gasPrice);
+    if (!tx.maxFeePerGas.empty())
+        evmTx.max_gas_price = spikeU256FromHex(tx.maxFeePerGas);
+    if (!tx.maxPriorityFeePerGas.empty())
+        evmTx.max_priority_gas_price = spikeU256FromHex(tx.maxPriorityFeePerGas);
+    if (!tx.maxFeePerBlobGas.empty())
+        evmTx.max_blob_gas_price = spikeU256FromHex(tx.maxFeePerBlobGas);
+
+    // For legacy/access_list txs (no explicit priority fee) set priority = gas price, so the
+    // coinbase gets the gas tip and the effective gas price equals the legacy gasPrice.
+    if ((evmTx.type == evmone::state::Transaction::Type::legacy ||
+            evmTx.type == evmone::state::Transaction::Type::access_list) &&
+        evmTx.max_priority_gas_price == 0)
+        evmTx.max_priority_gas_price = evmTx.max_gas_price;
+
+    if (dataIndex >= 0 && static_cast<size_t>(dataIndex) < tx.accessLists.size())
+    {
+        auto const& al = tx.accessLists[dataIndex];
+        if (al.has_value())
+        {
+            for (auto const& [addrHex, keys] : *al)
+            {
+                std::vector<evmc::bytes32> storageKeys;
+                storageKeys.reserve(keys.size());
+                for (auto const& k : keys)
+                    storageKeys.push_back(spikeBytes32FromHex(k));
+                evmTx.access_list.emplace_back(spikeAddrFromHex(addrHex), std::move(storageKeys));
+            }
+        }
+    }
+
+    for (auto const& h : tx.blobVersionedHashes)
+        evmTx.blob_hashes.push_back(spikeBytes32FromHex(h));
+
+    if (tx.authorizationList.has_value())
+    {
+        for (auto const& auth : *tx.authorizationList)
+        {
+            evmone::state::Authorization ea{};
+            ea.chain_id = spikeU256FromHex(test::readHexField(auth, "chainId"));
+            ea.nonce = static_cast<uint64_t>(test::hexToU256(test::readHexField(auth, "nonce")));
+            ea.r = spikeU256FromHex(test::readHexField(auth, "r"));
+            ea.s = spikeU256FromHex(test::readHexField(auth, "s"));
+            // EEST emits both "v" and "yParity" (the baseline reads "v"); prefer "v" for
+            // exact baseline parity.
+            auto vHex = test::readHexField(auth, "v");
+            if (vHex.empty())
+                vHex = test::readHexField(auth, "yParity");
+            ea.v = spikeU256FromHex(vHex);
+            ea.addr = spikeAddrFromHex(test::readHexField(auth, "address"));
+            const auto signerHex = test::readHexField(auth, "signer");
+            if (!signerHex.empty())
+                ea.signer = spikeAddrFromHex(signerHex);
+            evmTx.authorization_list.push_back(std::move(ea));
+        }
+    }
+
+    return evmTx;
+}
+}  // namespace
 
 class EESTRunner
 {
@@ -790,6 +1023,12 @@ public:
     ledger::LedgerConfig m_ledgerConfig;
     std::optional<ForkTransition> m_forkTransition;
     int64_t m_chainId = 1;  // EIP-155 chain id from the fixture config
+    // Spike track (Task 5): the real opTransition needs an evmc::VM (it takes evmc::VM&,
+    // not evmone::VM) and a TransactionReceiptFactory::Ptr. m_receiptFactoryPtr is a
+    // non-owning shared_ptr over the receiptFactory member above (the runner outlives every
+    // synchronous opTransition call).
+    evmc::VM m_vm{evmc_create_evmone()};
+    bcos::protocol::TransactionReceiptFactory::Ptr m_receiptFactoryPtr;
 
     EESTRunner()
       : cryptoSuite(std::make_shared<bcos::crypto::CryptoSuite>(
@@ -801,13 +1040,19 @@ public:
                 int64_t blockNumber, int64_t /*currentHeight*/) -> evmc::bytes32 {
                 return blockHashes->get_block_hash(blockNumber);
             })
-    {}
-
-    void configureFork(std::string const& forkName)
     {
-        auto const rev = test::forkNameToRevision(forkName);
-        m_currentRevision = rev;
-        m_ledgerConfig.setEVMCRevision(rev);
+        // Non-owning shared_ptr over the receiptFactory member (the runner
+        // outlives every synchronous opTransition call that consumes it).
+        m_receiptFactoryPtr = std::shared_ptr<bcostars::protocol::TransactionReceiptFactoryImpl>(
+            &receiptFactory, [](bcostars::protocol::TransactionReceiptFactoryImpl*) {});
+    }
+
+    /// Configure the runner for a fork name. Returns false (and leaves the
+    /// runner unconfigured) when the fork — or either endpoint of a fork
+    /// transition name — is unknown, so callers can skip the fixture instead
+    /// of executing it under an arbitrary revision.
+    bool configureFork(std::string const& forkName)
+    {
         m_forkTransition.reset();
 
         // Detect fork transition names like "CancunToPragueAtTime15k"
@@ -830,14 +1075,38 @@ public:
                 {
                     transitionTime = std::stoll(timeStr);
                 }
-                m_forkTransition = ForkTransition{test::forkNameToRevision(fromFork),
-                    test::forkNameToRevision(toFork), transitionTime};
+                auto const fromRevOpt = test::forkNameToRevision(fromFork);
+                auto const toRevOpt = test::forkNameToRevision(toFork);
+                if (!fromRevOpt.has_value() || !toRevOpt.has_value())
+                {
+                    // Unknown fork in a transition → skip the whole fixture
+                    // (do NOT fall back to executing under fromRev).
+                    return false;
+                }
+                m_forkTransition = ForkTransition{*fromRevOpt, *toRevOpt, transitionTime};
+                // Base the pre-transition revision (and block-header versioning)
+                // on the from-fork rather than an arbitrary default.
+                m_currentRevision = *fromRevOpt;
+                m_ledgerConfig.setEVMCRevision(*fromRevOpt);
+                return true;
             }
             catch (...)
             {
+                // Malformed transition name → treat as unknown/skip.
                 m_forkTransition.reset();
+                return false;
             }
         }
+
+        // Plain (non-transition) fork name.
+        auto const revOpt = test::forkNameToRevision(forkName);
+        if (!revOpt.has_value())
+        {
+            return false;  // unknown fork → skip
+        }
+        m_currentRevision = *revOpt;
+        m_ledgerConfig.setEVMCRevision(*revOpt);
+        return true;
     }
 
     /// Get the EVMC revision for a block given its timestamp (handles fork transitions).
@@ -1197,8 +1466,11 @@ public:
     }
 
     /// Verify post-state. Returns a string with mismatch details (empty = all good).
-    std::string verifyPostState(
-        MutableStorage& storage, std::map<std::string, test::EESTAccount> const& expected)
+    /// When non-null, *firstCategory receives the field category ("nonce"/"balance"/
+    /// "code"/"storage") of the FIRST mismatch found, so callers can tag a FailureDetail.
+    std::string verifyPostState(MutableStorage& storage,
+        std::map<std::string, test::EESTAccount> const& expected,
+        std::string* firstCategory = nullptr)
     {
         std::ostringstream errors;
         int passed = 0, failed = 0;
@@ -1316,14 +1588,332 @@ public:
 
         }  // end for loop over expected accounts
 
+        if (firstCategory != nullptr && !errors.str().empty())
+        {
+            *firstCategory = test::firstMismatchCategory(errors.str());
+        }
+
         return errors.str();
     }
 
-    /// Run a single fixture test case. Returns true if passed.
-    bool runFixture(::test::EESTFixture const& fixture, std::string const& forkName,
-        ::test::EESTForkPost const& post)
+    // ── opTransition spike track (Task 5) ──────────────────────────────────
+    /// Run one tx through the REAL opTransition (the opstack rewrite of evmone's state.cpp),
+    /// using the 10-param API: view / block / hashes / tx / cfg / evmc::VM& / props / chainId /
+    /// receiptFactory, with the state diff returned through outDiff (the FISCO receipt interface
+    /// has no field for it). opTransition does NOT write back to the view — the caller applies
+    /// the diff to the TestState so the post-state can be verified.
+    bcos::protocol::TransactionReceipt::Ptr runOpTransitionTx(evmone::test::TestState& ts,
+        evmone::state::BlockInfo const& block, evmone::state::BlockHashes const& hashes,
+        evmone::state::Transaction const& tx, evmc::bytes_view signedEnvelope,
+        opstack::OpForkConfig const& cfg, evmc::VM& vm, uint64_t chainId,
+        const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory,
+        evmone::state::StateDiff& outDiff)
     {
-        configureFork(forkName);
+        auto props = opstack::opValidateFromState(
+            ts, block, tx, signedEnvelope, cfg, /*blockGasLeft=*/block.gas_limit);
+        if (auto* err = std::get_if<std::error_code>(&props))
+            throw std::runtime_error("opValidate rejected: " + err->message());
+        auto const& p = std::get<opstack::OpTxProperties>(props);
+        auto receipt = opstack::opTransition(
+            ts, block, hashes, tx, cfg, vm, p, chainId, receiptFactory, outDiff);
+        ts.apply(outDiff);  // write the state diff back so the post-state can be verified
+        return receipt;
+    }
+
+    /// Verify post-state for the spike track against the EF post expectations.
+    /// EXCLUDES the OP vault accounts (OpPredeploys.h): opTransition routes the base fee to
+    /// OP_BASE_FEE_VAULT and touches L1/operator/sequencer vaults — those balances are OP fee
+    /// routing artifacts that EF state-test post-states never list, so without the exclusion
+    /// every Prague fixture would mismatch on the vault. The sender's net debit is identical to
+    /// plain EEST (base fee is burned there, credited to the vault here), so sender balances are
+    /// compared normally. Returns an error string (empty = all good) and optionally the
+    /// first-mismatch category. Error-marker format matches verifyPostState so
+    /// test::firstMismatchCategory stays the single source of truth.
+    std::string verifyPostStateSpike(evmone::test::TestState const& ts,
+        std::map<std::string, test::EESTAccount> const& expected,
+        std::string* firstCategory = nullptr)
+    {
+        static constexpr std::array<evmc::address, 4> kSpikeVaults = {opstack::OP_BASE_FEE_VAULT,
+            opstack::OP_L1_FEE_VAULT, opstack::OP_OPERATOR_FEE_VAULT,
+            opstack::OP_SEQUENCER_FEE_VAULT};
+
+        std::ostringstream errors;
+        static const evmone::test::TestAccount kZeroAccount{};
+
+        for (auto const& [addrHex, expectedAcc] : expected)
+        {
+            auto addr = spikeAddrFromHex(addrHex);
+            if (std::find(kSpikeVaults.begin(), kSpikeVaults.end(), addr) != kSpikeVaults.end())
+                continue;  // OP fee routing artifact — not an EF post expectation
+
+            auto const it = ts.find(addr);
+            evmone::test::TestAccount const& got = it != ts.end() ? it->second : kZeroAccount;
+
+            if (!expectedAcc.nonce.empty() && expectedAcc.nonce != "0x")
+            {
+                auto expNonce = test::hexToU256(expectedAcc.nonce);
+                if (bcos::u256(got.nonce) != expNonce)
+                {
+                    errors << "    NONCE " << addrHex << ": expected " << expectedAcc.nonce << " ("
+                           << expNonce << "), got " << got.nonce << "\n";
+                    ++g_nonceMismatch;
+                    continue;  // one mismatch per account, mirroring verifyPostState's co_return
+                }
+            }
+
+            if (!expectedAcc.balance.empty())
+            {
+                auto expBal = spikeU256FromHex(expectedAcc.balance);
+                if (expBal != got.balance)
+                {
+                    errors << "    BALANCE " << addrHex << ": expected " << expectedAcc.balance
+                           << " (" << spikeHexU256(expBal) << "), got " << spikeHexU256(got.balance)
+                           << "\n";
+                    ++g_balanceMismatch;
+                    continue;
+                }
+            }
+
+            if (!expectedAcc.code.empty() && expectedAcc.code != "0x")
+            {
+                auto expCode = spikeBytesFromHex(expectedAcc.code);
+                if (got.code != expCode)
+                {
+                    errors << "    CODE " << addrHex << ": expected " << expectedAcc.code << "\n";
+                    ++g_codeMismatch;
+                    continue;
+                }
+            }
+
+            for (auto const& [key, val] : expectedAcc.storage)
+            {
+                auto expVal = spikeBytes32FromHex(val);
+                auto gotIt = got.storage.find(spikeBytes32FromHex(key));
+                auto gotVal = gotIt != got.storage.end() ? gotIt->second : evmc::bytes32{};
+                if (gotVal != expVal)
+                {
+                    errors << "    STORAGE " << addrHex << " key=" << key << ": expected " << val
+                           << ", got " << spikeHexBytes32(gotVal) << "\n";
+                    ++g_storageMismatch;
+                }
+            }
+        }
+
+        if (firstCategory != nullptr && !errors.str().empty())
+        {
+            *firstCategory = test::firstMismatchCategory(errors.str());
+        }
+        return errors.str();
+    }
+
+    /// Spike track entry: run one fixture (post-key == "Prague" only) through the real
+    /// opTransition and compare the written-back TestState against the EF post expectations,
+    /// recording failures with the same shape as the baseline runFixture path (g_failureDetails
+    /// + the per-category counters), so --json-failures is non-empty in spike mode.
+    bool runFixtureOpTransition(::test::EESTFixture const& fixture, std::string const& forkName,
+        ::test::EESTForkPost const& post, bool* skipped)
+    {
+        // Fork filter: only pure Prague (post key) is aligned with isthmusConfig/jovianConfig
+        // (rev = EVMC_PRAGUE). Everything else — Osaka, fork transitions, pre-Prague forks —
+        // is skipped (not counted as pass/fail), same skip contract as the baseline's
+        // "unknown fork" path.
+        if (!test::spikeForkSelect(forkName))
+        {
+            if (skipped != nullptr)
+            {
+                *skipped = true;
+            }
+            printLine("WARNING: skipping state-test fixture '" + fixture.name + "' [" + forkName +
+                      "]: opTransition spike runs only pure Prague (post key)");
+            return false;
+        }
+
+        m_chainId = fixture.chainId;
+        const auto& cfg =
+            (g_opts.opFork == "jovian") ? opstack::jovianConfig() : opstack::isthmusConfig();
+
+        // pre → TestState. Storage slots with zero value are stripped (trie semantics: a zero
+        // slot is absent — same rule as evmone's test::from_json<TestState> loader).
+        evmone::test::TestState ts;
+        for (auto const& [addrHex, acc] : fixture.pre)
+        {
+            auto& out = ts[spikeAddrFromHex(addrHex)];
+            out.nonce = static_cast<uint64_t>(test::hexToU256(acc.nonce));
+            out.balance = spikeU256FromHex(acc.balance);
+            out.code = spikeBytesFromHex(acc.code);
+            for (auto const& [keyHex, valHex] : acc.storage)
+            {
+                auto val = spikeBytes32FromHex(valHex);
+                if (!evmc::is_zero(val))
+                    out.storage[spikeBytes32FromHex(keyHex)] = val;
+            }
+        }
+        // Mirror the baseline: ensure the sender account exists with the tx nonce when the
+        // fixture's pre-state omitted it (opValidate reads get_account(tx.sender) and rejects a
+        // missing sender with balance 0).
+        if (!fixture.transaction.sender.empty())
+        {
+            auto senderAddr = spikeAddrFromHex(fixture.transaction.sender);
+            if (ts.find(senderAddr) == ts.end())
+            {
+                ts[senderAddr].nonce =
+                    static_cast<uint64_t>(test::hexToU256(fixture.transaction.nonce));
+            }
+        }
+
+        // env → BlockInfo. Fields the fixture does not carry are left at their defaults (e.g.
+        // parent hash / blob params absent from state tests — matching the baseline's empty
+        // FixtureBlockHashes behaviour for BLOCKHASH).
+        evmone::state::BlockInfo blk;
+        blk.number = test::hexToInt64(fixture.env.number);
+        blk.timestamp = test::hexToTimestamp(fixture.env.timestamp);
+        blk.gas_limit = test::hexToInt64(fixture.env.gasLimit);
+        blk.base_fee = static_cast<uint64_t>(test::hexToU256(fixture.env.baseFee));
+        if (!fixture.env.coinbase.empty())
+            blk.coinbase = spikeAddrFromHex(fixture.env.coinbase);
+        if (!fixture.env.random.empty())
+            blk.prev_randao = spikeBytes32FromHex(fixture.env.random);
+        if (!fixture.env.parentBeaconRoot.empty())
+            blk.parent_beacon_block_root = spikeBytes32FromHex(fixture.env.parentBeaconRoot);
+        if (!fixture.env.excessBlobGas.empty())
+            blk.excess_blob_gas = static_cast<uint64_t>(test::hexToU256(fixture.env.excessBlobGas));
+        if (!fixture.env.blobGasUsed.empty())
+            blk.blob_gas_used = static_cast<uint64_t>(test::hexToU256(fixture.env.blobGasUsed));
+        evmone::test::TestBlockHashes hashes;
+
+        auto evmTx = spikeBuildTransaction(
+            fixture.transaction, post.dataIndex, post.gasIndex, post.valueIndex, m_chainId);
+        evmc::bytes envelope{0x02};  // dummy non-empty envelope — opValidate only checks non-empty
+
+        evmone::state::StateDiff diff;
+        bcos::protocol::TransactionReceipt::Ptr receipt;
+        std::string opError;
+        bool executionThrew = false;
+        try
+        {
+            receipt = runOpTransitionTx(ts, blk, hashes, evmTx, envelope, cfg, m_vm,
+                static_cast<uint64_t>(m_chainId), m_receiptFactoryPtr, diff);
+        }
+        catch (std::exception const& e)
+        {
+            opError = e.what();
+            executionThrew = true;
+        }
+        catch (...)
+        {
+            // typed-catch RTTI 兜底（机理同 OpT8nReplayTest.cpp:657-667 注释）：libevmone.a
+            // (-fno-rtti) 带入 hidden 非唯一 typeinfo for std::exception，链接后本二进制
+            // catch(std::exception&) 与 libc++ 抛出侧基类 typeinfo 判不等而漏接。点名动态
+            // 类型，与 typed 分支同语义（记失败、流程不变），不吞异常。
+            const auto* excType = abi::__cxa_current_exception_type();
+            opError = std::string("opTransition threw (typed catch bypassed, type: ") +
+                      (excType ? excType->name() : "<unknown>") + ")";
+            executionThrew = true;
+        }
+
+        bool expectsSuccess = post.expectException.empty();
+        if (expectsSuccess && fixture.name.find("successful_False") != std::string::npos)
+        {
+            expectsSuccess = false;
+        }
+        bool gotSuccess =
+            !executionThrew && receipt &&
+            (receipt->status() == 0 ||
+                receipt->status() == static_cast<int32_t>(protocol::TransactionStatus::None));
+
+        // Failure recording mirrors runFixture's four branches exactly (same reasons, categories,
+        // indices and counters) so --json-failures has the same shape in both exec modes.
+        if (expectsSuccess && !gotSuccess)
+        {
+            std::string category;
+            auto errStr = verifyPostStateSpike(ts, post.state, &category);
+            if (errStr.empty())
+            {
+                return true;  // state matches → tx reverted cleanly
+            }
+            std::ostringstream oss;
+            oss << "FAIL: " << fixture.name << " [" << forkName << "] expected success, got failure"
+                << (executionThrew ? " (exception: " + opError + ")" : "")
+                << (receipt ? " status=" + std::to_string(receipt->status()) : "");
+            printLine(oss.str());
+            g_failureDetails.push_back({fixture.name, forkName, "unexpected failure", "unexpected",
+                post.dataIndex, post.gasIndex, post.valueIndex});
+            ++g_unexpectedFailure;
+            return false;
+        }
+
+        if (!expectsSuccess && gotSuccess)
+        {
+            std::ostringstream oss;
+            oss << "FAIL: " << fixture.name << " [" << forkName << "] expected exception '"
+                << post.expectException << "', got success";
+            printLine(oss.str());
+            g_failureDetails.push_back(
+                {fixture.name, forkName, "expected exception '" + post.expectException + "'",
+                    "expected_exception", post.dataIndex, post.gasIndex, post.valueIndex});
+            ++g_expectedException;
+            return false;
+        }
+
+        if (!expectsSuccess && !gotSuccess)
+        {
+            std::string category;
+            auto errStr = verifyPostStateSpike(ts, post.state, &category);
+            if (!errStr.empty())
+            {
+                std::ostringstream oss;
+                oss << "FAIL: " << fixture.name << " [" << forkName
+                    << "] expected failure, got failure but state mismatch\n"
+                    << errStr;
+                printLine(oss.str());
+                g_failureDetails.push_back(
+                    {fixture.name, forkName, "state mismatch (expected failure)", category,
+                        post.dataIndex, post.gasIndex, post.valueIndex});
+                ++g_unexpectedFailure;
+                return false;
+            }
+            return true;
+        }
+
+        std::string category;
+        auto errStr = verifyPostStateSpike(ts, post.state, &category);
+        if (!errStr.empty())
+        {
+            std::ostringstream oss;
+            oss << "FAIL: " << fixture.name << " [" << forkName << "]\n" << errStr;
+            printLine(oss.str());
+            g_failureDetails.push_back({fixture.name, forkName, "state mismatch", category,
+                post.dataIndex, post.gasIndex, post.valueIndex});
+            return false;
+        }
+        return true;
+    }
+
+    /// Run a single fixture test case. Returns true if passed.
+    /// When the fork is unknown the fixture is skipped: *skipped is set to
+    /// true, a WARNING is printed, and false is returned (the caller must not
+    /// count it as a failure).
+    bool runFixture(::test::EESTFixture const& fixture, std::string const& forkName,
+        ::test::EESTForkPost const& post, bool* skipped = nullptr)
+    {
+        // Spike track (Task 5): execute through the real opTransition instead of the
+        // ethereum-executor baseline. The spike path handles its own fork filter (pure Prague
+        // post key only) and failure recording, same shape as the baseline.
+        if (g_opts.execMode == "optransition")
+        {
+            return runFixtureOpTransition(fixture, forkName, post, skipped);
+        }
+
+        if (!configureFork(forkName))
+        {
+            if (skipped != nullptr)
+            {
+                *skipped = true;
+            }
+            printLine("WARNING: skipping state-test fixture '" + fixture.name + "' [" + forkName +
+                      "]: unknown fork (not in forkNameToRevision)");
+            return false;
+        }
         m_chainId = fixture.chainId;
         m_ledgerConfig.setChainId(
             intx::be::store<evmc::bytes32>(intx::uint256(static_cast<uint64_t>(m_chainId))));
@@ -1395,7 +1985,8 @@ public:
         // expectException for expected-failure tests.
         if (expectsSuccess && !gotSuccess)
         {
-            auto errStr = verifyPostState(storage, post.state);
+            std::string category;
+            auto errStr = verifyPostState(storage, post.state, &category);
             if (errStr.empty())
             {
                 return true;  // State matches → test passes (tx reverted correctly)
@@ -1406,7 +1997,8 @@ public:
                 << (executionThrew ? " (exception: " + evmError + ")" : "")
                 << (receipt ? " status=" + std::to_string(receipt->status()) : "");
             printLine(oss.str());
-            g_failureDetails.push_back({fixture.name, forkName, "unexpected failure"});
+            g_failureDetails.push_back({fixture.name, forkName, "unexpected failure", "unexpected",
+                post.dataIndex, post.gasIndex, post.valueIndex});
             ++g_unexpectedFailure;
             return false;
         }
@@ -1418,7 +2010,8 @@ public:
                 << post.expectException << "', got success";
             printLine(oss.str());
             g_failureDetails.push_back(
-                {fixture.name, forkName, "expected exception '" + post.expectException + "'"});
+                {fixture.name, forkName, "expected exception '" + post.expectException + "'",
+                    "expected_exception", post.dataIndex, post.gasIndex, post.valueIndex});
             ++g_expectedException;
             return false;
         }
@@ -1430,7 +2023,8 @@ public:
         // silently scored as "failed as expected".
         if (!expectsSuccess && !gotSuccess)
         {
-            auto errStr = verifyPostState(storage, post.state);
+            std::string category;
+            auto errStr = verifyPostState(storage, post.state, &category);
             if (!errStr.empty())
             {
                 std::ostringstream oss;
@@ -1439,7 +2033,8 @@ public:
                     << errStr;
                 printLine(oss.str());
                 g_failureDetails.push_back(
-                    {fixture.name, forkName, "state mismatch (expected failure)"});
+                    {fixture.name, forkName, "state mismatch (expected failure)", category,
+                        post.dataIndex, post.gasIndex, post.valueIndex});
                 ++g_unexpectedFailure;
                 return false;
             }
@@ -1447,13 +2042,15 @@ public:
         }
 
         // Success: verify post-state
-        auto errStr = verifyPostState(storage, post.state);
+        std::string category;
+        auto errStr = verifyPostState(storage, post.state, &category);
         if (!errStr.empty())
         {
             std::ostringstream oss;
             oss << "FAIL: " << fixture.name << " [" << forkName << "]\n" << errStr;
             printLine(oss.str());
-            g_failureDetails.push_back({fixture.name, forkName, "state mismatch"});
+            g_failureDetails.push_back({fixture.name, forkName, "state mismatch", category,
+                post.dataIndex, post.gasIndex, post.valueIndex});
             return false;
         }
 
@@ -1625,15 +2222,26 @@ public:
 
     /// Run a blockchain test fixture: execute blocks sequentially,
     /// apply block rewards via finalize(), then verify postState.
-    /// Returns true if passed.
-    bool runBlockchainFixture(test::EESTBlockchainFixture const& fixture)
+    /// Returns true if passed. When the fork is unknown the fixture is
+    /// skipped: *skipped is set to true, a WARNING is printed, and false is
+    /// returned (the caller must not count it as a failure).
+    bool runBlockchainFixture(test::EESTBlockchainFixture const& fixture, bool* skipped = nullptr)
     {
         auto forkName = extractForkFromName(fixture.name);
         if (forkName.empty())
         {
             forkName = "Cancun";  // default
         }
-        configureFork(forkName);
+        if (!configureFork(forkName))
+        {
+            if (skipped != nullptr)
+            {
+                *skipped = true;
+            }
+            printLine("WARNING: skipping blockchain-test fixture '" + fixture.name + "' [" +
+                      forkName + "]: unknown fork (not in forkNameToRevision)");
+            return false;
+        }
         m_chainId = fixture.chainId;
         m_ledgerConfig.setChainId(
             intx::be::store<evmc::bytes32>(intx::uint256(static_cast<uint64_t>(m_chainId))));
@@ -1816,7 +2424,8 @@ public:
                             << " execution threw: " << evmError;
                         printLine(oss.str());
                         g_failureDetails.push_back({fixture.name, forkName,
-                            "tx#" + std::to_string(txIndex) + " execution threw"});
+                            "tx#" + std::to_string(txIndex) + " execution threw", "unexpected", 0,
+                            0, 0});
                         ++g_unexpectedFailure;
                         return false;
                     }
@@ -1911,13 +2520,15 @@ public:
         }
 
         // Verify postState
-        auto errStr = verifyPostState(storage, fixture.postState);
+        std::string category;
+        auto errStr = verifyPostState(storage, fixture.postState, &category);
         if (!errStr.empty())
         {
             std::ostringstream oss;
             oss << "FAIL: " << fixture.name << " [" << forkName << "]\n" << errStr;
             printLine(oss.str());
-            g_failureDetails.push_back({fixture.name, forkName, "state mismatch"});
+            g_failureDetails.push_back(
+                {fixture.name, forkName, "state mismatch", category, 0, 0, 0});
             return false;
         }
 
@@ -2007,7 +2618,16 @@ FileResult processFixtureFile(EESTRunner& runner, fs::path const& filePath)
         for (auto const& fixture : bcFixtures)
         {
             ++g_totalTests;
-            bool passed = runner.runBlockchainFixture(fixture);
+            bool skipped = false;
+            bool passed = runner.runBlockchainFixture(fixture, &skipped);
+            if (skipped)
+            {
+                // Unknown fork → undo the pre-increment and record as skipped
+                // (not passed, not failed).
+                --g_totalTests;
+                ++g_skippedFiles;
+                continue;
+            }
             if (passed)
             {
                 ++g_totalPassed;
@@ -2051,7 +2671,17 @@ FileResult processFixtureFile(EESTRunner& runner, fs::path const& filePath)
             {
                 ++g_totalTests;
                 auto const& post = posts[i];
-                bool passed = runner.runFixture(fixture, forkName, post);
+                bool skipped = false;
+                bool passed = runner.runFixture(fixture, forkName, post, &skipped);
+
+                if (skipped)
+                {
+                    // Unknown fork → undo the pre-increment and record as
+                    // skipped (not passed, not failed).
+                    --g_totalTests;
+                    ++g_skippedFiles;
+                    continue;
+                }
 
                 if (passed)
                 {
@@ -2143,7 +2773,14 @@ int main(int argc, char* argv[])
             std::cerr << "Error: fixture directory not found: " << fixtureDir << '\n';
             return 1;
         }
-        for (auto const& entry : fs::recursive_directory_iterator(fixtureDir))
+        // follow_directory_symlink: the fetched EEST tree under
+        // EVM_REF_EEST_ROOT/fixtures exposes state_tests / blockchain_tests /
+        // transaction_tests as symlinks into the source dir; the default
+        // iterator would not descend into them and the full baseline would
+        // silently see zero files (the earlier "blockchain_tests is empty"
+        // mis-report).
+        for (auto const& entry : fs::recursive_directory_iterator(
+                 fixtureDir, fs::directory_options::follow_directory_symlink))
         {
             if (entry.is_regular_file() && entry.path().extension().string() == ".json")
             {
@@ -2163,8 +2800,10 @@ int main(int argc, char* argv[])
 
     if (fileList.empty())
     {
-        std::cerr << "No fixture files found." << '\n';
-        return 0;
+        std::cerr << "Error: no fixture files found under: " << fixtureDir
+                  << " (dangling smoke symlinks or an empty fixture tree?); "
+                     "refusing a vacuous pass.\n";
+        return 1;
     }
 
     // Sort for deterministic output
@@ -2299,6 +2938,31 @@ int main(int argc, char* argv[])
     }
 
     std::cout << "=================================================\n";
+
+    // Structured failure output (Task 2 baseline recording for Task 3).
+    if (!g_opts.jsonFailures.empty())
+    {
+        std::vector<FailureDetail> details;
+        details.reserve(g_failureDetails.size());
+        for (auto const& fd : g_failureDetails)
+        {
+            details.push_back(fd);
+        }
+        std::ofstream f(g_opts.jsonFailures);
+        if (!f)
+        {
+            std::cerr << "error: cannot open --json-failures file \"" << g_opts.jsonFailures
+                      << "\" for writing\n";
+            return 1;
+        }
+        f << writeFailuresJson(details);
+        if (!f)
+        {
+            std::cerr << "error: failed writing --json-failures file \"" << g_opts.jsonFailures
+                      << "\"\n";
+            return 1;
+        }
+    }
 
     return g_totalFailed > 0 ? 1 : 0;
 }

--- a/ethereum-executor/tests/EESTRunner.h
+++ b/ethereum-executor/tests/EESTRunner.h
@@ -209,7 +209,8 @@ EESTBlockchainFixture parseBlockchainFixture(
 std::vector<EESTBlockchainFixture> loadEESTBlockchainFixtures(std::string const& filePath);
 
 /// Map an EEST fork name to an EVMC revision.
-/// Returns EVMC_OSAKA (latest handled) as a default for unknown forks.
-evmc_revision forkNameToRevision(std::string const& forkName);
+/// Returns std::nullopt for unknown forks so callers can skip the fixture
+/// instead of silently executing it under a wrong (latest) revision.
+std::optional<evmc_revision> forkNameToRevision(std::string const& forkName);
 
 }  // namespace bcos::test

--- a/ethereum-executor/tests/EestFailuresJson.cpp
+++ b/ethereum-executor/tests/EestFailuresJson.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file EestFailuresJson.cpp
+ * @brief Implementation of structured failure serialization for the EEST runner.
+ */
+#include "EestFailuresJson.h"
+
+namespace bcos::test
+{
+std::string writeFailuresJson(std::vector<FailureDetail> const& details)
+{
+    Json::Value root(Json::arrayValue);
+    for (auto const& d : details)
+    {
+        Json::Value obj(Json::objectValue);
+        obj["testName"] = d.testName;
+        obj["forkName"] = d.forkName;
+        obj["reason"] = d.reason;
+        obj["category"] = d.category;
+        obj["dataIndex"] = d.dataIndex;
+        obj["gasIndex"] = d.gasIndex;
+        obj["valueIndex"] = d.valueIndex;
+        root.append(obj);
+    }
+    Json::StyledWriter writer;
+    return writer.write(root);
+}
+
+std::string firstMismatchCategory(std::string const& errorStr)
+{
+    static const char* const markers[] = {
+        "    NONCE ", "    BALANCE ", "    CODE ", "    STORAGE "};
+    static const char* const categories[] = {"nonce", "balance", "code", "storage"};
+
+    size_t bestPos = std::string::npos;
+    int bestIdx = -1;
+    for (int i = 0; i < 4; ++i)
+    {
+        auto pos = errorStr.find(markers[i]);
+        if (pos != std::string::npos && (bestPos == std::string::npos || pos < bestPos))
+        {
+            bestPos = pos;
+            bestIdx = i;
+        }
+    }
+    return (bestIdx >= 0) ? std::string(categories[bestIdx]) : std::string{};
+}
+
+}  // namespace bcos::test

--- a/ethereum-executor/tests/EestFailuresJson.h
+++ b/ethereum-executor/tests/EestFailuresJson.h
@@ -1,0 +1,44 @@
+/**
+ * @file EestFailuresJson.h
+ * @brief Structured failure serialization for the EEST runner.
+ *
+ * Extracted from EESTRunner.cpp so the --json-failures writer and the
+ * first-mismatch category logic can be unit-tested in the standalone
+ * eest-json-tests target (which must not depend on ethereum-executor or
+ * jsoncpp-only linkage).
+ */
+#pragma once
+
+#include <json/json.h>
+#include <string>
+#include <vector>
+
+namespace bcos::test
+{
+/// Structured failure record emitted by eest-runner's --json-failures output.
+/// `category` is the first mismatched field ("nonce"/"balance"/"code"/"storage")
+/// or a control-flow classification ("expected_exception"/"unexpected").
+struct FailureDetail
+{
+    std::string testName;
+    std::string forkName;
+    std::string reason;
+    std::string category;  // nonce|balance|code|storage|expected_exception|unexpected
+    int dataIndex = 0;     // EF post index (data/gas/value combo) for precise diff
+    int gasIndex = 0;
+    int valueIndex = 0;
+};
+
+/// Serialize failure details as a JSON array; each element carries exactly the
+/// seven fields of FailureDetail.
+std::string writeFailuresJson(std::vector<FailureDetail> const& details);
+
+/// Return the field category of the first mismatch marker in a verifyPostState
+/// error string ("nonce"/"balance"/"code"/"storage"), or "" when no marker is
+/// present. verifyPostState appends markers ("    NONCE ", "    BALANCE ",
+/// "    CODE ", "    STORAGE ") in account/category iteration order, so the
+/// earliest marker in the string is the first mismatch; this helper is the
+/// single source of truth used by the runner and exercised by the unit test.
+std::string firstMismatchCategory(std::string const& errorStr);
+
+}  // namespace bcos::test

--- a/ethereum-executor/tests/EestFailuresJsonTest.cpp
+++ b/ethereum-executor/tests/EestFailuresJsonTest.cpp
@@ -1,0 +1,110 @@
+/**
+ * @file EestFailuresJsonTest.cpp
+ * @brief Unit tests for EestFailuresJson (writeFailuresJson + firstMismatchCategory).
+ *
+ * Standalone Boost.Test target (eest-json-tests): links only jsoncpp_static and
+ * Boost::unit_test_framework, so it must not include EESTRunner.cpp.
+ */
+#define BOOST_TEST_MODULE EestFailuresJsonTest
+#include "EestFailuresJson.h"
+
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
+
+namespace bcos::test
+{
+
+BOOST_AUTO_TEST_CASE(writeFailuresJsonEmitsSevenFieldRecords)
+{
+    std::vector<FailureDetail> details;
+    details.push_back({"t/balance_mismatch", "Cancun", "state mismatch", "balance", 0, 1, 2});
+    details.push_back({"t/storage_mismatch", "Prague", "state mismatch", "storage", 3, 4, 5});
+    details.push_back({"t/expected_failure", "Shanghai", "expected exception 'X'",
+        "expected_exception", 6, 7, 8});
+    details.push_back({"t/unexpected", "Paris", "unexpected failure", "unexpected", 9, 10, 11});
+
+    auto jsonStr = writeFailuresJson(details);
+
+    Json::Value root;
+    Json::CharReaderBuilder reader;
+    std::istringstream iss(jsonStr);
+    std::string errs;
+    BOOST_REQUIRE_MESSAGE(
+        Json::parseFromStream(reader, iss, &root, &errs), "invalid JSON: " + errs);
+    BOOST_REQUIRE(root.isArray());
+    BOOST_REQUIRE_EQUAL(root.size(), 4u);
+
+    // Every element must carry exactly the 7 fields.
+    for (auto const& obj : root)
+    {
+        BOOST_REQUIRE(obj.isObject());
+        BOOST_REQUIRE_EQUAL(obj.size(), 7u);
+        BOOST_REQUIRE(obj.isMember("testName"));
+        BOOST_REQUIRE(obj.isMember("forkName"));
+        BOOST_REQUIRE(obj.isMember("reason"));
+        BOOST_REQUIRE(obj.isMember("category"));
+        BOOST_REQUIRE(obj.isMember("dataIndex"));
+        BOOST_REQUIRE(obj.isMember("gasIndex"));
+        BOOST_REQUIRE(obj.isMember("valueIndex"));
+    }
+
+    BOOST_CHECK_EQUAL(root[0]["testName"].asString(), "t/balance_mismatch");
+    BOOST_CHECK_EQUAL(root[0]["forkName"].asString(), "Cancun");
+    BOOST_CHECK_EQUAL(root[0]["reason"].asString(), "state mismatch");
+    BOOST_CHECK_EQUAL(root[0]["category"].asString(), "balance");
+    BOOST_CHECK_EQUAL(root[0]["dataIndex"].asInt(), 0);
+    BOOST_CHECK_EQUAL(root[0]["gasIndex"].asInt(), 1);
+    BOOST_CHECK_EQUAL(root[0]["valueIndex"].asInt(), 2);
+
+    BOOST_CHECK_EQUAL(root[1]["category"].asString(), "storage");
+    BOOST_CHECK_EQUAL(root[1]["dataIndex"].asInt(), 3);
+    BOOST_CHECK_EQUAL(root[1]["gasIndex"].asInt(), 4);
+    BOOST_CHECK_EQUAL(root[1]["valueIndex"].asInt(), 5);
+
+    BOOST_CHECK_EQUAL(root[2]["category"].asString(), "expected_exception");
+    BOOST_CHECK_EQUAL(root[2]["reason"].asString(), "expected exception 'X'");
+    BOOST_CHECK_EQUAL(root[2]["dataIndex"].asInt(), 6);
+    BOOST_CHECK_EQUAL(root[2]["gasIndex"].asInt(), 7);
+    BOOST_CHECK_EQUAL(root[2]["valueIndex"].asInt(), 8);
+
+    BOOST_CHECK_EQUAL(root[3]["category"].asString(), "unexpected");
+    BOOST_CHECK_EQUAL(root[3]["dataIndex"].asInt(), 9);
+    BOOST_CHECK_EQUAL(root[3]["gasIndex"].asInt(), 10);
+    BOOST_CHECK_EQUAL(root[3]["valueIndex"].asInt(), 11);
+}
+
+BOOST_AUTO_TEST_CASE(writeFailuresJsonHandlesEmptyList)
+{
+    auto jsonStr = writeFailuresJson({});
+    Json::Value root;
+    Json::CharReaderBuilder reader;
+    std::istringstream iss(jsonStr);
+    std::string errs;
+    BOOST_REQUIRE_MESSAGE(
+        Json::parseFromStream(reader, iss, &root, &errs), "invalid JSON: " + errs);
+    BOOST_REQUIRE(root.isArray());
+    BOOST_REQUIRE_EQUAL(root.size(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(firstMismatchCategoryDetectsFirstField)
+{
+    // A balance-first verifyPostState error string → "balance".
+    BOOST_CHECK_EQUAL(
+        firstMismatchCategory("    BALANCE 0xaa: expected 0x01, got 0x02\n"), "balance");
+
+    // The earliest marker wins regardless of the marker type.
+    BOOST_CHECK_EQUAL(firstMismatchCategory("    NONCE 0xaa: expected 0x1, got 0x2\n"
+                                            "    STORAGE 0xaa key=0x00: expected 0x1, got 0x2\n"),
+        "nonce");
+
+    BOOST_CHECK_EQUAL(firstMismatchCategory("    CODE 0xaa: expected 0xbb\n"), "code");
+    BOOST_CHECK_EQUAL(
+        firstMismatchCategory("    STORAGE 0xaa key=0x00: expected 0x1, got 0x2\n"), "storage");
+    BOOST_CHECK_EQUAL(firstMismatchCategory(""), "");
+
+    // Storage marker earlier in the string than balance → storage wins.
+    BOOST_CHECK_EQUAL(firstMismatchCategory("    STORAGE a\n    BALANCE b\n"), "storage");
+}
+
+}  // namespace bcos::test

--- a/ethereum-executor/tests/EestSpikeFork.h
+++ b/ethereum-executor/tests/EestSpikeFork.h
@@ -1,0 +1,33 @@
+/**
+ * @file EestSpikeFork.h
+ * @brief Fork-key selector for the eest-runner opTransition spike track.
+ *
+ * Kept as a dependency-free inline header so the predicate can be unit-tested by the
+ * standalone eest-json-tests target (which links only jsoncpp_static and
+ * Boost::unit_test_framework) without pulling in EESTRunner.cpp or the evmone headers.
+ */
+#pragma once
+
+#include <cctype>
+#include <string>
+
+namespace bcos::test
+{
+/// Pure predicate: select which EEST post fork-key enters the opTransition spike track.
+///
+/// Only pure "Prague" is semantically aligned with isthmusConfig/jovianConfig (both carry
+/// rev = EVMC_PRAGUE). Everything else is skipped:
+///   - "Osaka" — Osaka-only EIPs systematically fail under the Prague revision;
+///   - fork transitions (e.g. "CancunToPragueAtTime15000") — forkNameToRevision would map the
+///     "to" fork to EVMC_OSAKA and wrongly admit the fixture under a Prague revision;
+///   - pre-Prague forks ("Cancun", "London", ...).
+///
+/// Case-insensitive: EEST post keys are capitalized ("Prague"), while the unit tests also
+/// exercise the normalized lowercase form.
+inline bool spikeForkSelect(std::string forkKey)
+{
+    for (auto& c : forkKey)
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    return forkKey == "prague";
+}
+}  // namespace bcos::test

--- a/ethereum-executor/tests/EestSpikeForkTest.cpp
+++ b/ethereum-executor/tests/EestSpikeForkTest.cpp
@@ -1,0 +1,42 @@
+/**
+ * @file EestSpikeForkTest.cpp
+ * @brief Unit tests for the opTransition spike-track fork selector (EestSpikeFork.h).
+ *
+ * Compiled into the standalone eest-json-tests target (links only jsoncpp_static and
+ * Boost::unit_test_framework) alongside EestFailuresJsonTest.cpp — it must not include
+ * EESTRunner.cpp. The predicate is dependency-free inline in the header, so the test
+ * exercises the exact function the runner calls.
+ */
+#include "EestSpikeFork.h"
+
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::test
+{
+
+BOOST_AUTO_TEST_CASE(spikeForkSelectAdmitsOnlyPurePrague)
+{
+    // The post key EEST actually emits is capitalized.
+    BOOST_CHECK(spikeForkSelect("Prague"));
+    // Normalized lowercase form is admitted too (the predicate is case-insensitive).
+    BOOST_CHECK(spikeForkSelect("prague"));
+    BOOST_CHECK(spikeForkSelect("PRAGUE"));
+}
+
+BOOST_AUTO_TEST_CASE(spikeForkSelectRejectsNonPrague)
+{
+    BOOST_CHECK(!spikeForkSelect("Osaka"));
+    BOOST_CHECK(!spikeForkSelect("Cancun"));
+    BOOST_CHECK(!spikeForkSelect("London"));
+    BOOST_CHECK(!spikeForkSelect("Shanghai"));
+    // Fork transitions: the "to" fork would resolve to EVMC_OSAKA under forkNameToRevision
+    // and be wrongly admitted if the predicate were not an exact-match on "prague".
+    BOOST_CHECK(!spikeForkSelect("CancunToPragueAtTime15000"));
+    BOOST_CHECK(!spikeForkSelect("CancunToPragueAtTime15k"));
+    BOOST_CHECK(!spikeForkSelect("PragueToOsakaAtTime"));
+    // Empty / degenerate inputs.
+    BOOST_CHECK(!spikeForkSelect(""));
+    BOOST_CHECK(!spikeForkSelect("PragueWithSuffix"));
+}
+
+}  // namespace bcos::test

--- a/ethereum-executor/tests/TestStorageBridge.h
+++ b/ethereum-executor/tests/TestStorageBridge.h
@@ -3,9 +3,8 @@
 ///        evmone::state::StateView / StateDiff interfaces.
 ///
 /// The ethereum-executor LIBRARY no longer ships the StateView / StateDiff
-/// adapter layer (StorageStateView / StorageBlockHashes / applyStateDiff were
-/// removed — the executor reads/writes BCOS storage directly through
-/// EVMAccount / storage2). However the EEST runner also drives bcos-evm's
+/// adapter layer — the executor reads/writes BCOS storage directly through
+/// EVMAccount / storage2. However the EEST runner also drives bcos-evm's
 /// system contracts (EIP-4788 / EIP-2935 / EIP-7002 / EIP-7251) directly, and
 /// those keep the upstream evmone::state::{StateView, BlockHashes} interface
 /// (bcos-evm is unchanged). This header is the small local bridge the test tool

--- a/ethereum-executor/tests/regress_baseline.py
+++ b/ethereum-executor/tests/regress_baseline.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""Regression gate for the EEST baseline (Task 7).
+
+Runs `eest-runner` over a configurable target, collects the structured
+--json-failures output, and diffs the 5-tuple set
+    (testName, forkName, dataIndex, gasIndex, valueIndex)
+against the committed baseline (`bcos-evm/test/eth-eest-test/assets/
+baseline-fails-v540.json`).  Any NEW failure — a 5-tuple that appears in the
+new run but not in the baseline — exits non-zero (the regression trigger).
+
+Targets:
+  (default)   the PR smoke subset materialised by ethereum-executor/tests/
+              CMakeLists.txt into <build>/eest-pr-smoke (deterministic,
+              ~12 representative PASSING fixtures across forks/features).
+  --fixture-dir DIR   an explicit fixture directory (recursive).
+  --fixture FILE ...  one or more individual fixture files (run sequentially,
+                      JSON merged).
+  --full              the whole state_tests suite (nightly full run).
+
+Exit codes:
+  0   no new failures vs baseline (regression-free)
+  1   >=1 new failure(s) (regression)
+  2   infrastructure/usage error (missing runner, missing output, ...)
+
+Self-test (rev.5): `python3 regress_baseline.py --self-test` feeds synthetic
+baseline + synthetic new-failure records through the real diff/exit-code path
+and asserts the non-zero / zero outcomes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+BASELINE_REL = "bcos-evm/test/eth-eest-test/assets/baseline-fails-v540.json"
+SMOKE_MANIFEST_REL = "manifest.txt"  # relative to the smoke dir
+
+
+def repo_root() -> pathlib.Path:
+    """Repo root = parents[2] of this file (tests/ -> ethereum-executor/ -> root)."""
+    return pathlib.Path(__file__).resolve().parents[2]
+
+
+def read_cmake_cache(cache_path: pathlib.Path) -> dict:
+    """Parse the CMakeCache.txt key:type=value lines into a plain dict."""
+    result = {}
+    if not cache_path.is_file():
+        return result
+    for line in cache_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key_part, _, value = line.partition("=")
+        key = key_part.split(":", 1)[0]
+        result[key] = value
+    return result
+
+
+def load_json(path, strict: bool = False) -> list:
+    """Load a JSON array.
+
+    Missing file: warns and returns [] (used for the baseline, whose absence
+    should fail OPEN toward "everything is new").  With strict=True (the
+    new-run --json-failures output), a missing/invalid/truncated file raises
+    json.JSONDecodeError so the gate fails CLOSED instead of scoring
+    "0 new failures" on a partial write (IMP-2).
+    """
+    p = pathlib.Path(path)
+    if not p.is_file():
+        if strict:
+            raise json.JSONDecodeError(f"{p} does not exist", "", 0)
+        print(f"[regress_baseline] WARNING: {p} not found; treating as empty list",
+              file=sys.stderr)
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        if strict:
+            raise
+        print(f"[regress_baseline] WARNING: {p} is not valid JSON; treating as empty",
+              file=sys.stderr)
+        return []
+    if not isinstance(data, list):
+        if strict:
+            raise json.JSONDecodeError(f"{p} is not a JSON array", "", 0)
+        print(f"[regress_baseline] WARNING: {p} is not a JSON array; treating as empty",
+              file=sys.stderr)
+        return []
+    return data
+
+
+def write_json(path, records: list) -> None:
+    pathlib.Path(path).write_text(
+        json.dumps(records, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def five_tuple(record: dict):
+    """The 5-tuple that identifies a failure for regression-diff purposes."""
+    return (record.get("testName", ""),
+            record.get("forkName", ""),
+            int(record.get("dataIndex", 0)),
+            int(record.get("gasIndex", 0)),
+            int(record.get("valueIndex", 0)))
+
+
+def compute_new_failures(new_records: list, baseline_records: list) -> list:
+    """Records present in the new run whose 5-tuple is NOT in the baseline.
+
+    Order follows the new-run records (deterministic).  reason/category are
+    deliberately ignored: a changed reason for the same test/fork/index combo
+    is the same failure, not a new one.
+    """
+    baseline_tuples = {five_tuple(r) for r in baseline_records}
+    return [r for r in new_records if five_tuple(r) not in baseline_tuples]
+
+
+def exit_code_for(new_failures: list) -> int:
+    """Map the diff result to the gate exit code (1 = regression)."""
+    return 1 if new_failures else 0
+
+
+def read_smoke_manifest(manifest_path) -> list:
+    """Read the smoke-subset manifest (key=value lines) and return the FIXTURE paths."""
+    p = pathlib.Path(manifest_path)
+    if not p.is_file():
+        return []
+    return [line.split("=", 1)[1] for line in p.read_text(encoding="utf-8").splitlines()
+            if line.startswith("FIXTURE=")]
+
+
+def run_runner(runner: str, runner_args: list, json_out: pathlib.Path, env: dict):
+    """Run eest-runner once, capturing stdout for summary parsing.
+
+    Returns (returncode, stdout_text).  The runner's own output is re-emitted
+    to this process's stdout/stderr so the user still sees it.
+    A returncode in (0, 1) is expected (0 = all pass, 1 = some fixture failed);
+    anything else means the runner itself crashed (infrastructure error).
+    """
+    cmd = [runner] + runner_args + ["--quiet", "--json-failures", str(json_out)]
+    print(f"[regress_baseline] $ {' '.join(cmd)}")
+    proc = subprocess.run(cmd, env=env, text=True, capture_output=True)
+    if proc.stdout:
+        sys.stdout.write(proc.stdout)
+        sys.stdout.flush()
+    if proc.stderr:
+        sys.stderr.write(proc.stderr)
+        sys.stderr.flush()
+    return proc.returncode, proc.stdout or ""
+
+
+# eest-runner's final summary prints these two counters on stdout even under
+# --quiet.  It does NOT turn them into a non-zero exit, so the gate must parse
+# them itself (IMP-1): a structurally-corrupt fixture (g_loadFailures) or a
+# silently-skipped fixture (g_skippedFiles) would otherwise pass the diff.
+_SUMMARY_RE = re.compile(r"^\s*(Load failures|Skipped files):\s*(\d+)\s*$", re.MULTILINE)
+
+
+def parse_summary_counts(stdout_text: str) -> dict:
+    """Extract the 'Load failures:' / 'Skipped files:' counters from the runner summary."""
+    counts = {"load_failures": 0, "skipped_files": 0}
+    for m in _SUMMARY_RE.finditer(stdout_text):
+        key = "load_failures" if m.group(1) == "Load failures" else "skipped_files"
+        counts[key] = int(m.group(2))
+    return counts
+
+
+def summary_problems(counts: dict, allow_skips: bool) -> list:
+    """Regression signals from the runner's summary counters (IMP-1).
+
+    - Load failures > 0 always fail: a broken parser/loader is a regression
+      signal regardless of mode.
+    - Skipped files > 0 fail for the SMOKE/other targets (expected 0 for the
+      12-fixture all-Prague subset) but are allowed for --full nightly, which
+      legitimately skips transaction_tests and unknown-fork blockchain fixtures.
+    """
+    problems = []
+    if counts["load_failures"] > 0:
+        problems.append(
+            f"eest-runner reported {counts['load_failures']} load failure(s) — a broken "
+            "parser/loader is always a regression signal")
+    if counts["skipped_files"] > 0 and not allow_skips:
+        problems.append(
+            f"eest-runner skipped {counts['skipped_files']} file(s) — expected 0 in this "
+            "target (unknown-fork / transaction_tests skips are only expected in --full)")
+    return problems
+
+
+def run_multiple_fixtures(
+        runner: str, fixture_files: list, json_out: pathlib.Path, env: dict):
+    """Run one file per eest-runner process (runner accepts ONE --fixture) and merge JSON.
+
+    Returns (ok: bool, summary_counts: dict) aggregating the per-file
+    'Load failures:' / 'Skipped files:' counters (IMP-1).
+    """
+    merged: list = []
+    counts = {"load_failures": 0, "skipped_files": 0}
+    for i, f in enumerate(fixture_files):
+        tmp = json_out.with_name(f"{json_out.name}.{i}.json")
+        tmp.unlink(missing_ok=True)
+        rc, stdout = run_runner(runner, ["--fixture", f], tmp, env)
+        per = parse_summary_counts(stdout)
+        counts["load_failures"] += per["load_failures"]
+        counts["skipped_files"] += per["skipped_files"]
+        if rc not in (0, 1):
+            print(f"[regress_baseline] ERROR: eest-runner failed on {f} (returncode={rc})",
+                  file=sys.stderr)
+            return False, counts
+        if not tmp.is_file() or not tmp.read_text(encoding="utf-8",
+                                                  errors="replace").strip():
+            print(f"[regress_baseline] ERROR: eest-runner produced no --json-failures output "
+                  f"for fixture {f}", file=sys.stderr)
+            return False, counts
+        # Strict merge: a truncated per-file --json-failures write must fail the
+        # run, not silently degrade to [] (which would drop that fixture's
+        # failures and could turn a regression green).
+        try:
+            merged.extend(load_json(tmp, strict=True))
+        except json.JSONDecodeError as e:
+            print(f"[regress_baseline] ERROR: per-fixture --json-failures output {tmp} is "
+                  f"invalid or truncated JSON ({e}); failing closed", file=sys.stderr)
+            return False, counts
+        tmp.unlink()
+    write_json(json_out, merged)
+    return True, counts
+
+
+def print_report(new_failures: list, baseline_count: int, run_failure_count: int,
+                 baseline_path: str) -> None:
+    if new_failures:
+        print(f"[regress_baseline] {len(new_failures)} NEW failure(s) vs "
+              f"baseline {baseline_path} ({baseline_count} baseline failures):")
+        for r in new_failures:
+            print(f"  - {r.get('testName', '?')} [{r.get('forkName', '?')}] "
+                  f"data={r.get('dataIndex', 0)} gas={r.get('gasIndex', 0)} "
+                  f"value={r.get('valueIndex', 0)} "
+                  f"category={r.get('category', '')} reason={r.get('reason', '')}")
+        print(f"[regress_baseline] total new-run failures: {run_failure_count}")
+    else:
+        print(f"[regress_baseline] OK: {baseline_count} baseline failure(s), "
+              f"0 new failures (total new-run failures: {run_failure_count}).")
+
+
+def self_test() -> int:
+    """Synthetic gate self-test: new failure -> non-zero, no-new-failure -> zero.
+
+    Exercises the real compute_new_failures + exit_code_for path over real
+    JSON files (temp dir), including the 5-tuple semantics (reason/category
+    changes are NOT new failures).
+    """
+    ok = True
+    with tempfile.TemporaryDirectory(prefix="regress_baseline_selftest_") as td:
+        td = pathlib.Path(td)
+        known = {"testName": "known/fail/A", "forkName": "Cancun",
+                 "reason": "state mismatch", "category": "storage",
+                 "dataIndex": 0, "gasIndex": 0, "valueIndex": 0}
+        brand_new = {"testName": "new/fail/B", "forkName": "Prague",
+                     "reason": "unexpected failure", "category": "nonce",
+                     "dataIndex": 1, "gasIndex": 2, "valueIndex": 3}
+        baseline_path = td / "baseline.json"
+        write_json(baseline_path, [known])
+
+        # Case 1: baseline + one brand-new failure -> exit 1.
+        new_run = baseline_path.with_name("fails1.json")
+        write_json(new_run, [known, brand_new])
+        rc = exit_code_for(
+            compute_new_failures(load_json(new_run), load_json(baseline_path)))
+        status = "PASS" if rc == 1 else "FAIL"
+        if rc != 1:
+            ok = False
+        print(f"self-test {status}: new failure -> exit {rc} (expected 1)")
+
+        # Case 2: new run identical to baseline (no new failures) -> exit 0.
+        same_run = baseline_path.with_name("fails2.json")
+        write_json(same_run, [known])
+        rc = exit_code_for(
+            compute_new_failures(load_json(same_run), load_json(baseline_path)))
+        status = "PASS" if rc == 0 else "FAIL"
+        if rc != 0:
+            ok = False
+        print(f"self-test {status}: no new failure -> exit {rc} (expected 0)")
+
+        # Case 3: empty new run -> exit 0.
+        empty_run = baseline_path.with_name("fails3.json")
+        write_json(empty_run, [])
+        rc = exit_code_for(
+            compute_new_failures(load_json(empty_run), load_json(baseline_path)))
+        status = "PASS" if rc == 0 else "FAIL"
+        if rc != 0:
+            ok = False
+        print(f"self-test {status}: empty run -> exit {rc} (expected 0)")
+
+        # Case 4: same 5-tuple, different reason/category -> NOT a new failure.
+        alt_run = baseline_path.with_name("fails4.json")
+        write_json(alt_run, [dict(known, reason="changed reason", category="balance")])
+        rc = exit_code_for(
+            compute_new_failures(load_json(alt_run), load_json(baseline_path)))
+        status = "PASS" if rc == 0 else "FAIL"
+        if rc != 0:
+            ok = False
+        print(f"self-test {status}: 5-tuple diff ignores reason/category -> exit {rc} "
+              "(expected 0)")
+
+        # Case 5 (IMP-2): truncated/invalid new-run JSON must fail CLOSED, not
+        # score "0 new failures".  The strict loader must raise, and the gate
+        # exit for that condition must be non-zero.
+        trunc_run = baseline_path.with_name("fails5.json")
+        trunc_run.write_text('[{"testName": "a", "forkName": "Prague", '  # truncated mid-object
+                             '"dataIndex": 0, "gasIndex": 0, "valueIndex": 0',
+                             encoding="utf-8")
+        raised = False
+        try:
+            load_json(trunc_run, strict=True)
+        except json.JSONDecodeError:
+            raised = True
+        rc = 0 if not raised else 1  # gate maps "invalid json" to non-zero
+        status = "PASS" if raised and rc != 0 else "FAIL"
+        if not raised or rc == 0:
+            ok = False
+        print(f"self-test {status}: truncated new-run JSON -> strict loader raises / "
+              f"exit {rc} (expected non-zero)")
+
+        # Case 6 (IMP-1): summary counters.  Load failures always fail; skips fail
+        # in smoke mode but are allowed in --full nightly.
+        parsed = parse_summary_counts("  Total tests:   1\n  Passed:        0\n"
+                                      "  Failed:        1\n  Skipped files: 0\n"
+                                      "  Load failures: 1\n")
+        problems_smoke_load = summary_problems(parsed, allow_skips=False)
+        status = "PASS" if problems_smoke_load else "FAIL"
+        if not problems_smoke_load:
+            ok = False
+        print(f"self-test {status}: load-failure counter -> regression signal "
+              f"({len(problems_smoke_load)} problem(s))")
+
+        parsed_skip = {"load_failures": 0, "skipped_files": 2}
+        problems_smoke_skip = summary_problems(parsed_skip, allow_skips=False)
+        problems_full_skip = summary_problems(parsed_skip, allow_skips=True)
+        status = "PASS" if problems_smoke_skip and not problems_full_skip else "FAIL"
+        if not problems_smoke_skip or problems_full_skip:
+            ok = False
+        print(f"self-test {status}: skipped files -> signal in smoke "
+              f"({len(problems_smoke_skip)} problem(s)), allowed in --full "
+              f"({len(problems_full_skip)} problem(s))")
+
+    print("self-test:", "OK" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main(argv: list) -> int:
+    parser = argparse.ArgumentParser(
+        prog="regress_baseline.py",
+        description="Run eest-runner and diff --json-failures against the committed EEST "
+                    "baseline; exit non-zero on NEW failures (regression gate).")
+    parser.add_argument("--runner", default=None,
+                        help="path to eest-runner (default: <build>/ethereum-executor/tests/"
+                             "eest-runner, or $EEST_RUNNER)")
+    parser.add_argument("--fixture-dir", default=None,
+                        help="explicit fixture directory to run (recursive)")
+    parser.add_argument("--fixture", action="append", default=None,
+                        help="individual fixture file(s) to run (repeatable; merged)")
+    parser.add_argument("--full", action="store_true",
+                        help="run the whole state_tests suite (nightly full run)")
+    parser.add_argument("--baseline", default=None,
+                        help="baseline failures JSON (default: repo "
+                             "bcos-evm/test/eth-eest-test/assets/baseline-fails-v540.json)")
+    parser.add_argument("--json-failures", default=None,
+                        help="where to write the new-run --json-failures (default: temp file)")
+    parser.add_argument("--smoke-dir", default=None,
+                        help="smoke subset dir (default: <build>/eest-pr-smoke)")
+    parser.add_argument("--eest-root", default=None,
+                        help="EVM_REF_EEST_ROOT (parent of fixtures/); default from CMakeCache")
+    parser.add_argument("--manifest", default=None,
+                        help="smoke manifest.txt (informational; default: <build>/eest-pr-smoke/"
+                             "manifest.txt)")
+    parser.add_argument("--self-test", action="store_true",
+                        help="run the synthetic gate self-test and exit")
+    args = parser.parse_args(argv)
+
+    # Line-buffer stdout so our progress printouts precede the (inherited-fd)
+    # eest-runner output even when this script's stdout is redirected to a file.
+    sys.stdout.reconfigure(line_buffering=True)
+
+    if args.self_test:
+        return self_test()
+
+    repo = repo_root()
+    cache = read_cmake_cache(repo / "build" / "CMakeCache.txt")
+    build_dir = pathlib.Path(cache.get("CMAKE_BINARY_DIR", str(repo / "build")))
+    fixture_root = args.eest_root or cache.get("EVM_REF_EEST_ROOT")
+
+    runner = args.runner or os.environ.get("EEST_RUNNER")
+    if not runner:
+        cand = build_dir / "ethereum-executor" / "tests" / "eest-runner"
+        if cand.is_file():
+            runner = str(cand)
+    if not runner or not pathlib.Path(runner).is_file():
+        print(f"[regress_baseline] ERROR: eest-runner not found; pass --runner or set "
+              f"EEST_RUNNER (looked for {runner or 'nothing'})", file=sys.stderr)
+        return 2
+
+    baseline_path = args.baseline or str(repo / BASELINE_REL)
+    json_out = pathlib.Path(args.json_failures) if args.json_failures else None
+    tmp_json = None
+    if json_out is None:
+        fd, tmp_name = tempfile.mkstemp(prefix="regress_baseline_fails_", suffix=".json")
+        os.close(fd)
+        tmp_json = pathlib.Path(tmp_name)
+        json_out = tmp_json
+
+    env = dict(os.environ)
+    if fixture_root:
+        env["EEST_FIXTURE_DIR"] = str(pathlib.Path(fixture_root) / "fixtures")
+
+    # --- Resolve the target -------------------------------------------------
+    # Remove any stale json output first so the post-run content is guaranteed
+    # to come from THIS run (eest-runner early-returns before writing json when
+    # e.g. the fixture directory is missing, which would otherwise leave a
+    # stale/0-byte file behind).
+    json_out.unlink(missing_ok=True)
+    runner_rc = None
+    runner_stdout = ""
+    summary_counts = {"load_failures": 0, "skipped_files": 0}
+    label = ""
+    if args.fixture_dir:
+        cmd_args = ["--fixture-dir", args.fixture_dir]
+        label = args.fixture_dir
+        runner_rc, runner_stdout = run_runner(runner, cmd_args, json_out, env)
+        summary_counts = parse_summary_counts(runner_stdout)
+    elif args.full:
+        if not fixture_root:
+            print("[regress_baseline] ERROR: --full needs EVM_REF_EEST_ROOT "
+                  "(pass --eest-root or configure the build)", file=sys.stderr)
+            return 2
+        full_dir = str(pathlib.Path(fixture_root) / "fixtures" / "state_tests")
+        cmd_args = ["--fixture-dir", full_dir]
+        label = full_dir
+        runner_rc, runner_stdout = run_runner(runner, cmd_args, json_out, env)
+        summary_counts = parse_summary_counts(runner_stdout)
+    elif args.fixture:
+        label = " ".join(args.fixture)
+        # run_multiple_fixtures writes json itself; treat "no output" as infra.
+        merged_ok, summary_counts = run_multiple_fixtures(runner, args.fixture, json_out, env)
+        if not merged_ok:
+            if tmp_json is not None:
+                tmp_json.unlink(missing_ok=True)
+            return 2
+    else:
+        smoke_dir = args.smoke_dir or str(build_dir / "eest-pr-smoke")
+        manifest_path = args.manifest or str(pathlib.Path(smoke_dir) / SMOKE_MANIFEST_REL)
+        smoke_fixtures = read_smoke_manifest(manifest_path)
+        print(f"[regress_baseline] smoke subset ({len(smoke_fixtures)} fixture files):")
+        for f in smoke_fixtures:
+            print(f"  - {pathlib.Path(f).name}")
+        cmd_args = ["--fixture-dir", smoke_dir]
+        label = smoke_dir
+        runner_rc, runner_stdout = run_runner(runner, cmd_args, json_out, env)
+        summary_counts = parse_summary_counts(runner_stdout)
+
+    # eest-runner exits 0 (all pass) or 1 (some failures).  Any other code means
+    # the runner itself crashed — an infrastructure error, not a regression.
+    if runner_rc is not None and runner_rc not in (0, 1):
+        print(f"[regress_baseline] ERROR: eest-runner crashed (returncode={runner_rc}, "
+              f"target: {label}); see output above", file=sys.stderr)
+        if tmp_json is not None:
+            tmp_json.unlink(missing_ok=True)
+        return 2
+
+    # A legit run always writes a --json-failures array (empty "[]" when 0
+    # failures).  A missing/empty output means the run never reached the
+    # writer (e.g. fixture directory not found) — fail loud instead of
+    # silently scoring "no failures".
+    if not json_out.is_file() or not json_out.read_text(encoding="utf-8",
+                                                        errors="replace").strip():
+        print(f"[regress_baseline] ERROR: eest-runner produced no --json-failures output "
+              f"(target: {label})", file=sys.stderr)
+        if tmp_json is not None:
+            tmp_json.unlink(missing_ok=True)
+        return 2
+
+    # IMP-1: parser/skip blind spot — the runner does not turn load failures or
+    # skipped files into a non-zero exit, so the gate parses the summary itself.
+    # Skips are only tolerated in --full nightly mode (legit transaction_tests /
+    # unknown-fork skips); any skip in the smoke/other target is a regression.
+    problems = summary_problems(summary_counts, allow_skips=args.full)
+
+    # IMP-2: fail CLOSED on a truncated/invalid new-run JSON (a mid-write crash
+    # must not be scored as "0 new failures").
+    try:
+        new_records = load_json(json_out, strict=True)
+    except json.JSONDecodeError as e:
+        print(f"[regress_baseline] ERROR: --json-failures output {json_out} is invalid or "
+              f"truncated JSON ({e}); failing closed", file=sys.stderr)
+        if tmp_json is not None:
+            tmp_json.unlink(missing_ok=True)
+        return 2
+
+    baseline_records = load_json(baseline_path)
+    new_failures = compute_new_failures(new_records, baseline_records)
+
+    if problems:
+        for p in problems:
+            print(f"[regress_baseline] REGRESSION SIGNAL: {p}")
+    print_report(new_failures, len(baseline_records), len(new_records), baseline_path)
+
+    rc = 1 if (problems or new_failures) else 0
+    if tmp_json is not None:
+        tmp_json.unlink(missing_ok=True)
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/libinitializer/CMakeLists.txt
+++ b/libinitializer/CMakeLists.txt
@@ -42,6 +42,8 @@ target_link_libraries(init PUBLIC
     engine
     ledger
     transaction-scheduler transaction-executor
+    bcosevm::opstack
+    opstack-executor
     ethereum-executor
     scheduler storage executor rpc
     bcos-boostssl
@@ -59,3 +61,8 @@ if(WITH_TIKV)
 endif()
 set_target_properties(init PROPERTIES UNITY_BUILD "ON")
 add_dependencies(init BuildInfo.h)
+
+if(TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/libinitializer/EngineServiceInitializer.h
+++ b/libinitializer/EngineServiceInitializer.h
@@ -21,15 +21,17 @@ public:
         bcos::protocol::BlockFactory::Ptr blockFactory, std::shared_ptr<SchedulerType> scheduler,
         std::shared_ptr<ExecutorType> transactionExecutor, bcos::txpool::MemPoolImpl& memPool,
         bcos::ledger::LedgerInterface::Ptr ledger = nullptr,
-        int64_t blockTxCountLimit = bcos::engine::c_defaultBlockTxCountLimit)
+        int64_t blockTxCountLimit = bcos::engine::c_defaultBlockTxCountLimit,
+        bcos::scheduler::SchedulerInterface::Ptr delegate = nullptr)
     {
         auto initializer = Ptr(new EngineServiceInitializer());
         using ConcreteEngineService = bcos::engine::EngineServiceImpl<bcos::txpool::MemPoolImpl,
             GlobalStateStorage, ExecutorType, SchedulerType>;
-        auto holder = std::make_shared<
-            ConcreteModel<SchedulerType, ExecutorType, ConcreteEngineService>>(
-            std::move(storageInitializer), std::move(blockFactory), std::move(scheduler),
-            std::move(transactionExecutor), memPool, std::move(ledger), blockTxCountLimit);
+        auto holder =
+            std::make_shared<ConcreteModel<SchedulerType, ExecutorType, ConcreteEngineService>>(
+                std::move(storageInitializer), std::move(blockFactory), std::move(scheduler),
+                std::move(transactionExecutor), memPool, std::move(ledger), blockTxCountLimit,
+                std::move(delegate));
         initializer->m_holder = holder;
         initializer->m_engineService =
             std::shared_ptr<bcos::engine::AnyEngineService>(holder, &holder->m_any);
@@ -54,14 +56,16 @@ private:
             bcos::protocol::BlockFactory::Ptr blockFactory,
             std::shared_ptr<SchedulerType> scheduler,
             std::shared_ptr<ExecutorType> transactionExecutor, bcos::txpool::MemPoolImpl& memPool,
-            bcos::ledger::LedgerInterface::Ptr ledger, int64_t blockTxCountLimit)
+            bcos::ledger::LedgerInterface::Ptr ledger, int64_t blockTxCountLimit,
+            bcos::scheduler::SchedulerInterface::Ptr delegate)
           : m_storageInitializer(std::move(storageInitializer)),
             m_memPool(memPool),
             m_transactionExecutor(std::move(transactionExecutor)),
             m_scheduler(std::move(scheduler)),
             m_any(std::in_place_type<ConcreteEngineService>, m_memPool,
                 m_storageInitializer->storage(), *m_transactionExecutor, *m_scheduler,
-                std::move(blockFactory), std::move(ledger), blockTxCountLimit)
+                std::move(blockFactory), std::move(ledger), blockTxCountLimit,
+                static_cast<std::uint32_t>(bcos::engine::ApiVersion::V3), std::move(delegate))
         {}
 
         std::shared_ptr<GlobalStateStorageInitializer> m_storageInitializer;

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -78,6 +78,8 @@
 #include <bcos-transaction-scheduler/SchedulerParallelImpl.h>
 #include <bcos-transaction-scheduler/SchedulerSerialImpl.h>
 #include <legacy/bcos-storage/StorageWrapperImpl.h>
+#include <opstack-executor/OpScheduler.h>
+#include <opstack-executor/OpSchedulerSeam.h>
 #include <rocksdb/slice.h>
 #include <rocksdb/sst_file_reader.h>
 #include <txpool/validator/TxValidator.h>
@@ -94,6 +96,68 @@ using namespace bcos::tool;
 using namespace bcos::protocol;
 using namespace bcos::initializer;
 namespace fs = boost::filesystem;
+
+namespace
+{
+/// A loud refuse stub for the never-selected non-OP slot 3 (MultiVersionScheduler::scheduler(int)
+/// is a public direct-index call; a null slot would crash instead of refusing).
+class OpRefusingStubScheduler : public bcos::scheduler::SchedulerInterface
+{
+public:
+    void executeBlock(bcos::protocol::Block::Ptr, bool,
+        std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool)> cb) override
+    {
+        cb(BCOS_ERROR_PTR(bcos::scheduler::SchedulerError::UnknownError,
+               "OpRefusingStubScheduler: OP scheduler not assembled (executor_version<3)"),
+            nullptr, false);
+    }
+    void commitBlock(bcos::protocol::BlockHeader::Ptr,
+        std::function<void(bcos::Error::Ptr, bcos::ledger::LedgerConfig::Ptr)> cb) override
+    {
+        cb(BCOS_ERROR_PTR(bcos::scheduler::SchedulerError::UnknownError,
+               "OpRefusingStubScheduler: OP scheduler not assembled (executor_version<3)"),
+            nullptr);
+    }
+    void call(bcos::protocol::Transaction::Ptr,
+        std::function<void(bcos::Error::Ptr, bcos::protocol::TransactionReceipt::Ptr)> cb) override
+    {
+        cb(BCOS_ERROR_PTR(bcos::scheduler::SchedulerError::UnknownError,
+               "OpRefusingStubScheduler: OP scheduler not assembled (executor_version<3)"),
+            nullptr);
+    }
+    void preExecuteBlock(
+        bcos::protocol::Block::Ptr, bool, std::function<void(bcos::Error::Ptr)> cb) override
+    {
+        cb(BCOS_ERROR_PTR(bcos::scheduler::SchedulerError::UnknownError,
+            "OpRefusingStubScheduler: OP scheduler not assembled (executor_version<3)"));
+    }
+    void getCode(std::string_view, std::function<void(bcos::Error::Ptr, bcos::bytes)> cb) override
+    {
+        cb(BCOS_ERROR_PTR(bcos::scheduler::SchedulerError::UnknownError,
+               "OpRefusingStubScheduler: OP scheduler not assembled (executor_version<3)"),
+            {});
+    }
+    void getABI(std::string_view, std::function<void(bcos::Error::Ptr, std::string)> cb) override
+    {
+        cb(BCOS_ERROR_PTR(bcos::scheduler::SchedulerError::UnknownError,
+               "OpRefusingStubScheduler: OP scheduler not assembled (executor_version<3)"),
+            {});
+    }
+    task::Task<std::optional<bcos::storage::Entry>> getPendingStorageAt(
+        std::string_view, std::string_view, bcos::protocol::BlockNumber) override
+    {
+        co_return std::nullopt;
+    }
+    void status(
+        std::function<void(bcos::Error::Ptr, bcos::protocol::Session::ConstPtr)> cb) override
+    {
+        cb({}, {});
+    }
+    void reset(std::function<void(bcos::Error::Ptr)> cb) override { cb({}); }
+    // NOTE: no callAtBlock override — SchedulerInterface's defaulted virtual already forwards to
+    // call() (SchedulerInterface.h:59-72); a redundant override would be dead code (round-3 C8).
+};
+}  // namespace
 
 void Initializer::initAirNode(std::string const& _configFilePath, std::string const& _genesisFile,
     bcos::gateway::GatewayInterface::Ptr _gateway, const std::string& _logPath)
@@ -175,12 +239,11 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     std::string const& _configFilePath, std::string const& _genesisFile,
     bcos::gateway::GatewayInterface::Ptr _gateway, bool _airVersion, const std::string& _logPath)
 {
-    // Engine-driven block production (single-node consensus or [op_engine_rpc]) is AIR-only.
-    // Both modes skip txpool/pbft init and wire the in-process mempool into NodeService via
-    // AirNodeInitializer::setMemPool; on a MAX/tars node the flag would start the
-    // block-producing driver while sendRawTransaction still falls through to an
-    // uninitialized txpool. Reject the combination at startup rather than leaving that
-    // state reachable by a config flag.
+    // Single-node consensus mode is AIR-only. It skips txpool/pbft init and wires the
+    // in-process mempool into NodeService via AirNodeInitializer::setMemPool; on a MAX/tars
+    // node the flag would start the block-producing driver while sendRawTransaction still
+    // falls through to an uninitialized txpool. Reject the combination at startup rather
+    // than leaving that state reachable by a config flag.
     if (m_nodeConfig->engineDrivenBlockProduction() &&
         _nodeArchType != bcos::protocol::NodeArchitectureType::AIR)
     {
@@ -375,13 +438,11 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     // respond "engine service not available" (see EngineEndpoint.cpp).
     const bool engineApiForV1Only = (m_executorVersion < scheduler_v1::ETHEREUM_EXECUTOR_VERSION);
 
-    // [op_engine_rpc] requires the v2 pure-Ethereum executor: on executor_version < 2 the
-    // endpoint would silently serve the v1 EngineService built below, and an external
-    // op-node — which trusts the EL and never cross-checks state roots — would drive a
-    // chain with v1 (non-Ethereum) semantics. Fail fast instead. The only exception is the
-    // explicit test-only escape hatch unsafe_allow_v1_executor, which the v1 Engine API
-    // integration harness (tools/engine_integration_test.sh, driving the v1 EngineService
-    // over this endpoint with a mock CL / Lodestar) sets; production configs must not.
+    // An OP Stack chain with v1 (non-Ethereum) semantics is nonsense. Fail fast instead. The only
+    // exception is the explicit test-only escape hatch unsafe_allow_v1_executor, which the v1
+    // Engine API integration harness (tools/engine_integration_test.sh, driving the v1
+    // EngineService over this endpoint with a mock CL / Lodestar) sets; production configs must
+    // not.
     if (m_nodeConfig->enableOpEngineRpc() && engineApiForV1Only)
     {
         if (!m_nodeConfig->opEngineAllowV1Executor())
@@ -440,16 +501,11 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
                 m_protocolInitializer->blockFactory(), ethereumSerialScheduler,
                 m_txpoolInitializer->txpool(), transactionSubmitResultFactory, ledger,
                 ethereumExecutor, !m_nodeConfig->engineDrivenBlockProduction());
-        // Engine-driven modes on the v2 EthereumExecutor: build the Engine API service wired
-        // to the ethereum scheduler + EthereumExecutor so blocks are built with
-        // Ethereum-compliant semantics. Two mutually exclusive drivers use it (NodeConfig
-        // rejects both flags at once): the built-in single-node driver
-        // (enable_single_node_consensus) and an external op-node over the authenticated
-        // [op_engine_rpc] endpoint. In either mode the EngineService is the sole block
-        // producer — the legacy txpool/PBFT pipeline is never initialized or started (see
-        // engineDrivenBlockProduction() guards below and in start()).
-        if (!engineApiForV1Only &&
-            (m_nodeConfig->enableSingleNodeConsensus() || m_nodeConfig->enableOpEngineRpc()))
+        // Single-node consensus mode on the v2 EthereumExecutor: build the Engine API service
+        // wired to the ethereum scheduler + EthereumExecutor so blocks are built with
+        // Ethereum-compliant semantics. In this mode the EngineService is the sole block
+        // producer, so the v1-only gate above does not apply.
+        if (!engineApiForV1Only && m_nodeConfig->enableSingleNodeConsensus())
         {
             m_engineServiceInitializer = EngineServiceInitializer::build(
                 m_globalStateStorageInitializer, m_protocolInitializer->blockFactory(),
@@ -479,15 +535,91 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
                 m_protocolInitializer->blockFactory(), ethereumSerialScheduler,
                 m_txpoolInitializer->txpool(), transactionSubmitResultFactory, ledger,
                 ethereumExecutor, !m_nodeConfig->engineDrivenBlockProduction());
-        // Engine-driven modes on the v2 EthereumExecutor (serial pipeline); see the parallel
-        // branch above for why op_engine_rpc.enable also builds the EngineService here.
-        if (!engineApiForV1Only &&
-            (m_nodeConfig->enableSingleNodeConsensus() || m_nodeConfig->enableOpEngineRpc()))
+        // Single-node consensus mode on the v2 EthereumExecutor (serial pipeline).
+        if (!engineApiForV1Only && m_nodeConfig->enableSingleNodeConsensus())
         {
             m_engineServiceInitializer = EngineServiceInitializer::build(
                 m_globalStateStorageInitializer, m_protocolInitializer->blockFactory(),
                 ethereumSerialScheduler, ethereumExecutor, m_memPoolInitializer->memPool(), ledger);
         }
+    }
+
+    // OP composition root (spec 2026-08-07-op-composition-root-design.md §4): executor_version >=
+    // 3 enters OP mode. EngineService is assembled with OpSchedulerSeam so the engine's c_opMode
+    // SFINAE probe (EngineServiceImpl.h:200-201, on computeTxRoot) activates the OP branch
+    // (block execution via the delegate). engineApiForV1Only (<2) and opStackMode (>=3)
+    // are mutually exclusive;
+    // version 2 (pure EthereumExecutor) still has no Engine API. OP mode runs on
+    // SingleNodeConsensus (enable_single_node_consensus), so PBFT/RPBFT are never initialized
+    // here (see initConsensus); MultiVersionScheduler is untouched.
+    const bool opStackMode = (m_executorVersion >= scheduler_v1::OPSTACK_EXECUTOR_VERSION);
+    if (opStackMode)
+    {
+        // OP fork selection is feature-driven (feature_op_jovian in genesis [features]), NOT
+        // timestamp-based — FISCO has no timestamp fork-activation mechanism. Isthmus is the
+        // OP-mode baseline; jovianActive selects Jovian semantics.
+        auto forkFlags = bcos::evm::opstack::OpForkFlags{
+            .jovianActive = m_nodeConfig->opJovianActive(),
+        };
+        // chainId: NodeConfig::chainId() 返回经 isalNumStr 校验的数字串，按 base-0 解析
+        // （0x 前缀→hex，否则 decimal）；OP 模式下应为数字字符串。默认 genesis 值是 "chain"，
+        // stoull 对非数字串抛裸 STL 异常 → 转成带 FISCO 上下文的 InvalidConfig。
+        uint64_t opChainId = 0;
+        try
+        {
+            opChainId = std::stoull(m_nodeConfig->chainId(), nullptr, 0);
+        }
+        catch (const std::invalid_argument&)
+        {
+            BOOST_THROW_EXCEPTION(bcos::tool::InvalidConfig() << bcos::errinfo_comment(
+                                      "OP mode (executor_version>=3) requires a numeric chain_id "
+                                      "(decimal or 0x-prefixed hex)"));
+        }
+        catch (const std::out_of_range&)
+        {
+            BOOST_THROW_EXCEPTION(bcos::tool::InvalidConfig() << bcos::errinfo_comment(
+                                      "OP mode (executor_version>=3) requires a numeric chain_id "
+                                      "(decimal or 0x-prefixed hex)"));
+        }
+        auto opScheduler =
+            std::make_shared<bcos::evm::engine::OpSchedulerSeam<GlobalStateStorage::ViewType>>(
+                forkFlags);
+        // Wiring Task 5a/5c: engine block-execution delegate = OpScheduler (slot-3, same instance).
+        // A single OpSchedulerSeam serves the engine's SchedulerType seam surface (c_opMode probe /
+        // isJovianActive / computeTxRoot); OpScheduler itself owns the block
+        // execution path (preBlockOpSteps → SchedulerSerialImpl per-tx → finalizeOpBlockResult).
+        auto opDelegate =
+            std::make_shared<bcos::executor_v1::opstack::OpScheduler<GlobalStateStorage>>(
+                m_protocolInitializer->blockFactory()->receiptFactory(),
+                m_protocolInitializer->cryptoSuite()->hashImpl(), opChainId, forkFlags,
+                m_protocolInitializer->blockFactory(), m_globalStateStorageInitializer->storage(),
+                // Task 2: wire the OP delegate's ledger (same LedgerInterface::Ptr as the ethereum
+                // root) so Task 3's commit hook can call prewriteBlockToBuffer. The engine service
+                // below keeps /*ledger=*/nullptr — only the delegate consumes it, avoiding the
+                // EngineServiceImpl.h:714-748 local-build double-write path.
+                m_ledger,
+                // Task 4: SchedulerSerialImpl (serial mode) defers context destruction onto this
+                // pool — required, no default.
+                m_ioServicePool);
+        m_engineServiceInitializer = EngineServiceInitializer::build(
+            m_globalStateStorageInitializer, m_protocolInitializer->blockFactory(), opScheduler,
+            transactionExecutor, m_memPoolInitializer->memPool(), /*ledger=*/nullptr,
+            bcos::engine::c_defaultBlockTxCountLimit, opDelegate);
+        // Compile-time proof that this production composition root activates the OP engine branch.
+        // ⚠️ 必须用裸类型：decltype(*opScheduler) 是 OpSchedulerSeam<...>&（左值引用），若作
+        // SchedulerType 会使 c_opMode 的 requires 表达式对引用类型求值为 false（&T&::...病式），
+        // static_assert 编译失败。用 remove_reference_t 取裸类型，与 build 实际推导一致。
+        using OpEngineServiceT = bcos::engine::EngineServiceImpl<bcos::txpool::MemPoolImpl,
+            GlobalStateStorage, executor_v1::TransactionExecutorImpl,
+            std::remove_reference_t<decltype(*opScheduler)>>;
+        static_assert(OpEngineServiceT::c_opMode,
+            "OP composition root must activate c_opMode (computeTxRoot SFINAE probe)");
+
+        // Slot-3 RPC-face scheduler = OpScheduler (Task 5c): the SAME instance as the engine's
+        // m_delegate. Serves eth_call (OpScheduler::call, absorbed from OpBlockScheduler) and
+        // block execute/commit (via the shared SchedulerSkeleton). The RPC eth_call path routes
+        // via MultiVersionScheduler setVersion(m_executorVersion) -> getScheduler() -> slot 3.
+        m_opScheduler = opDelegate;
     }
 
     executorManager = std::make_shared<bcos::scheduler::TarsExecutorManager>(
@@ -504,7 +636,12 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
         std::to_array<scheduler::SchedulerInterface::Ptr>(
             {std::make_shared<bcos::scheduler::SchedulerManager>(
                  schedulerSeq, factory, executorManager, m_ioServicePool),
-                m_baselineSchedulerHolder(), m_ethereumSchedulerHolder()}));
+                m_baselineSchedulerHolder(), m_ethereumSchedulerHolder(),
+                // Slot 3 = OP scheduler (executor_version>=3). Non-OP mode: a loud refuse stub so
+                // scheduler(3) (public, direct .at() index, no saturation) fails loudly instead of
+                // null-dereferencing. version<3 never selects slot 3 via setVersion; the stub is
+                // insurance against any external scheduler(3) call.
+                m_opScheduler ? m_opScheduler : std::make_shared<OpRefusingStubScheduler>()}));
 
     // m_executorVersion was resolved earlier (before the Engine API gate); apply it now.
     INITIALIZER_LOG(INFO) << "Set executor version to: " << m_executorVersion;
@@ -665,15 +802,16 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
         });
     }
     // init the txpool / pbft.
-    // Engine-driven modes ([consensus] enable_single_node_consensus or [op_engine_rpc])
-    // bypass the legacy txpool/pbft/sealer lifecycle: PBFTInitializer is still constructed
-    // above so groupInfo / NodeService wiring stays intact, but txpool and pbft (and the
-    // sealer and block sync inside pbft) are never initialized or started — block production
-    // is driven instead through the EngineService (by the built-in single-node driver or by
-    // an external op-node), and sendRawTransaction routes to the mempool. Skipping both
-    // keeps the EngineService the sole block producer; otherwise PBFT and the engine driver
-    // would write blocks to the same global storage concurrently. The front service is
-    // still wired for gateway bookkeeping, but its dispatchers are inert with no peers.
+    // Engine-driven block production ([consensus] enable_single_node_consensus OR
+    // [op_engine_rpc] enable — engineDrivenBlockProduction) bypasses the legacy txpool/pbft/sealer
+    // lifecycle: PBFTInitializer is still constructed above so groupInfo / NodeService wiring stays
+    // intact, but txpool and pbft (and the sealer and block sync inside pbft) are never initialized
+    // or started — block production is driven instead by the EngineService (via the built-in
+    // single-node driver or an external op-node CL), and sendRawTransaction routes to the mempool.
+    // The front service is still wired for gateway bookkeeping, but its dispatchers are inert with
+    // no peers. Keeping txpool/PBFT dormant is what makes the EngineService the SOLE block producer
+    // — starting them next to an engine driver would let two producers write the same global
+    // storage concurrently (kyonRay review #5429 MUST-FIX).
     if (!m_nodeConfig->engineDrivenBlockProduction())
     {
         // init the txpool
@@ -687,7 +825,7 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     {
         INITIALIZER_LOG(INFO) << LOG_DESC(
             "EngineDrivenBlockProduction: skip txpool/pbft/sealer init (block production via "
-            "EngineService + mempool; driver = single-node consensus or external op-node)");
+            "EngineService + mempool / external op-node)");
     }
 
     // init the frontService
@@ -915,8 +1053,8 @@ void Initializer::initSysContract()
 
 void Initializer::start()
 {
-    // Engine-driven modes (single-node consensus / op_engine_rpc): txpool/pbft (and the
-    // sealer inside pbft) stay dormant — block production goes through the EngineService.
+    // Engine-driven block production mode: txpool/pbft (and the sealer inside pbft) stay dormant —
+    // block production is driven by the EngineService (single-node driver or external op-node).
     if (!m_nodeConfig->engineDrivenBlockProduction())
     {
         if (m_txpoolInitializer)

--- a/libinitializer/Initializer.h
+++ b/libinitializer/Initializer.h
@@ -198,6 +198,10 @@ private:
     std::function<std::shared_ptr<scheduler::SchedulerInterface>()> m_ethereumSchedulerHolder;
     std::function<void(std::function<void(protocol::BlockNumber)>)>
         m_setEthereumSchedulerBlockNumberNotifier;
+    /// OP scheduler (executor_version>=3) for MultiVersionScheduler slot 3. Kept as a member so
+    /// the OpBlockScheduler (which inherits OpSchedulerSeam's evmc::VM and holds the storage ref)
+    /// stays alive for the whole Initializer lifetime.
+    std::shared_ptr<scheduler::SchedulerInterface> m_opScheduler;
     /// Resolved executor version (0 = legacy SchedulerManager, 1 = TransactionExecutorImpl,
     /// 2 = EthereumExecutor). Cached during initNode so initSysContract can decide whether the
     /// FISCO system-contract deployment block applies (it does not for the ethereum executor).

--- a/libinitializer/MultiVersionScheduler.cpp
+++ b/libinitializer/MultiVersionScheduler.cpp
@@ -8,7 +8,7 @@ bcos::scheduler::SchedulerInterface& bcos::scheduler_v1::MultiVersionScheduler::
 }
 
 bcos::scheduler_v1::MultiVersionScheduler::MultiVersionScheduler(
-    std::array<scheduler::SchedulerInterface::Ptr, 3> schedulers)
+    std::array<scheduler::SchedulerInterface::Ptr, SUPPORTED_EXECUTOR_VERSION_COUNT> schedulers)
   : m_schedulers(std::move(schedulers)), m_currentIndex(0)
 {}
 
@@ -87,8 +87,9 @@ void bcos::scheduler_v1::MultiVersionScheduler::setVersion(
                                                  "(must be >= 0)"));
     }
     // Saturate the upper bound: any version >= the last scheduler index selects the
-    // newest executor (the v2 EthereumExecutor). This keeps the version space
-    // open-ended above 2 so a future executor version needs no array/schema change.
+    // newest executor (the v3 OP scheduler in OP mode, else the v2 EthereumExecutor).
+    // This keeps the version space open-ended above the top slot so a future executor
+    // version needs no array/schema change.
     // The saturation itself is silent by design, but an unknown version above today's
     // set deserves a log line: on a binary that has no such version, "see an unknown
     // version, run the newest" means executing blocks under rules the chain did not

--- a/libinitializer/MultiVersionScheduler.h
+++ b/libinitializer/MultiVersionScheduler.h
@@ -18,10 +18,19 @@ DERIVE_BCOS_EXCEPTION(ExecutorVersionNotSupported);
 /// it without depending on libinitializer); this keeps the scheduler_v1 spelling.
 constexpr static int ETHEREUM_EXECUTOR_VERSION = ledger::ETHEREUM_EXECUTOR_VERSION;
 
+/// OP-Stack executor version (spec D1): executor_version >= this enters OP mode.
+constexpr static int OPSTACK_EXECUTOR_VERSION = ledger::OPSTACK_EXECUTOR_VERSION;
+/// Version ordering invariant: OP sits strictly above the Ethereum executor.
+static_assert(OPSTACK_EXECUTOR_VERSION > ETHEREUM_EXECUTOR_VERSION,
+    "OPSTACK_EXECUTOR_VERSION must be strictly greater than ETHEREUM_EXECUTOR_VERSION");
+
 class MultiVersionScheduler : public bcos::scheduler::SchedulerInterface
 {
 private:
-    static constexpr size_t SUPPORTED_EXECUTOR_VERSION_COUNT = 3;
+    // Slot layout: 0 = SchedulerManager (legacy), 1 = baseline scheduler, 2 = EthereumExecutor
+    // (pure Ethereum), 3 = OP scheduler (OpScheduler, executor_version >= 3; same instance as the
+    // engine's m_delegate — Task 5c wiring).
+    static constexpr size_t SUPPORTED_EXECUTOR_VERSION_COUNT = 4;
 
     std::array<scheduler::SchedulerInterface::Ptr, SUPPORTED_EXECUTOR_VERSION_COUNT> m_schedulers;
     int m_currentIndex;
@@ -31,8 +40,9 @@ private:
 public:
     bcos::scheduler::SchedulerInterface& scheduler(int version);
 
-    MultiVersionScheduler(std::array<scheduler::SchedulerInterface::Ptr,
-        SUPPORTED_EXECUTOR_VERSION_COUNT> schedulers);
+    MultiVersionScheduler(
+        std::array<scheduler::SchedulerInterface::Ptr, SUPPORTED_EXECUTOR_VERSION_COUNT>
+            schedulers);
 
     void executeBlock(bcos::protocol::Block::Ptr block, bool verify,
         std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool sysBlock)>

--- a/libinitializer/tests/CMakeLists.txt
+++ b/libinitializer/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+# MultiVersionScheduler routing test. MultiVersionScheduler.cpp is compiled DIRECTLY into the
+# test target (round-3 C4): the `initializer` target does not exist (the real lib is `init`, which
+# drags ~30 libs). MultiVersionScheduler.cpp only depends on MultiVersionScheduler.h (->
+# SchedulerInterface.h) + Common.h (BoostLog), so direct compilation needs no full dep graph.
+find_package(Boost REQUIRED unit_test_framework)
+add_executable(libinitializer-tests MultiVersionSchedulerTest.cpp ../MultiVersionScheduler.cpp)
+set_target_properties(libinitializer-tests PROPERTIES UNITY_BUILD OFF)
+target_link_libraries(libinitializer-tests PRIVATE bcos-framework Boost::unit_test_framework)
+# 测试 include <libinitializer/MultiVersionScheduler.h>（按仓库根相对），需仓库根在 include 路径上
+target_include_directories(libinitializer-tests PRIVATE ${PROJECT_SOURCE_DIR})
+add_test(NAME LibinitializerTests COMMAND libinitializer-tests)

--- a/libinitializer/tests/MultiVersionSchedulerTest.cpp
+++ b/libinitializer/tests/MultiVersionSchedulerTest.cpp
@@ -1,0 +1,97 @@
+// MultiVersionSchedulerTest — slot-3 routing after the 3->4 slot extension (spec §5.4).
+// Proves: scheduler(3) returns the 4th (OP) scheduler; setVersion(3) selects slot 3; setVersion
+// above the top saturates to slot 3 (min(version, size-1)); scheduler(3) on a non-OP assembly
+// returns the refuse stub (non-null).
+// BOOST_TEST_MODULE must be defined in exactly one TU before the framework include: the compiled
+// Boost.Test library's default main() calls init_unit_test_suite(), which only exists when the
+// module macro is defined (same pattern as opstack-executor-block-tests' TestMain.cpp).
+#define BOOST_TEST_MODULE LibinitializerTests
+#include <bcos-framework/storage/Entry.h>  // complete bcos::storage::Entry (fake's co_return nullopt)
+#include <libinitializer/MultiVersionScheduler.h>
+#include <boost/test/unit_test.hpp>
+#include <functional>
+#include <memory>
+
+namespace
+{
+using bcos::scheduler::SchedulerInterface;
+
+// Minimal fake: records which fake handled a call() (id == 0 means not selected); no-op otherwise.
+struct FakeScheduler : public SchedulerInterface
+{
+    int id;
+    std::shared_ptr<int> lastCallerId;  // shared across the 4 fakes; set by the selected one
+    explicit FakeScheduler(int i, std::shared_ptr<int> recorder) : id(i), lastCallerId(recorder) {}
+    void executeBlock(bcos::protocol::Block::Ptr, bool,
+        std::function<void(bcos::Error::Ptr, bcos::protocol::BlockHeader::Ptr, bool)> cb) override
+    {
+        cb({}, nullptr, false);
+    }
+    void commitBlock(bcos::protocol::BlockHeader::Ptr,
+        std::function<void(bcos::Error::Ptr, bcos::ledger::LedgerConfig::Ptr)> cb) override
+    {
+        cb({}, nullptr);
+    }
+    void call(bcos::protocol::Transaction::Ptr,
+        std::function<void(bcos::Error::Ptr, bcos::protocol::TransactionReceipt::Ptr)> cb) override
+    {
+        *lastCallerId = id;
+        cb({}, nullptr);
+    }
+    void preExecuteBlock(
+        bcos::protocol::Block::Ptr, bool, std::function<void(bcos::Error::Ptr)> cb) override
+    {
+        cb({});
+    }
+    void getCode(std::string_view, std::function<void(bcos::Error::Ptr, bcos::bytes)> cb) override
+    {
+        cb({}, {});
+    }
+    void getABI(std::string_view, std::function<void(bcos::Error::Ptr, std::string)> cb) override
+    {
+        cb({}, {});
+    }
+    bcos::task::Task<std::optional<bcos::storage::Entry>> getPendingStorageAt(
+        std::string_view, std::string_view, bcos::protocol::BlockNumber) override
+    {
+        co_return std::nullopt;
+    }
+    void status(
+        std::function<void(bcos::Error::Ptr, bcos::protocol::Session::ConstPtr)> cb) override
+    {
+        cb({}, {});
+    }
+    void reset(std::function<void(bcos::Error::Ptr)> cb) override { cb({}); }
+};
+
+std::array<bcos::scheduler::SchedulerInterface::Ptr, 4> fakes(std::shared_ptr<int> recorder)
+{
+    return {std::make_shared<FakeScheduler>(0, recorder),
+        std::make_shared<FakeScheduler>(1, recorder), std::make_shared<FakeScheduler>(2, recorder),
+        std::make_shared<FakeScheduler>(3, recorder)};
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(MultiVersionSchedulerSuite)
+
+BOOST_AUTO_TEST_CASE(Slot3Routing)
+{
+    auto recorder = std::make_shared<int>(-1);
+    bcos::scheduler_v1::MultiVersionScheduler mvs(fakes(recorder));
+    // scheduler(3) direct index (public, version-independent) returns the 4th slot.
+    BOOST_CHECK_EQUAL(dynamic_cast<FakeScheduler&>(mvs.scheduler(3)).id, 3);
+    // Selection IS observable through call(): MultiVersionScheduler::call() forwards to
+    // getScheduler() (MultiVersionScheduler.cpp:34-39), the version-selected slot. setVersion(3)
+    // selects slot 3; setVersion(4) saturates to slot 3 (min(version, size-1)).
+    mvs.setVersion(3, {});
+    mvs.call(nullptr, [](bcos::Error::Ptr, bcos::protocol::TransactionReceipt::Ptr) {});
+    BOOST_CHECK_EQUAL(*recorder, 3);
+    mvs.setVersion(4, {});
+    mvs.call(nullptr, [](bcos::Error::Ptr, bcos::protocol::TransactionReceipt::Ptr) {});
+    BOOST_CHECK_EQUAL(*recorder, 3);  // saturation: 4 >= size-1 -> newest (slot 3)
+    mvs.setVersion(0, {});
+    mvs.call(nullptr, [](bcos::Error::Ptr, bcos::protocol::TransactionReceipt::Ptr) {});
+    BOOST_CHECK_EQUAL(*recorder, 0);  // low version routes to the first slot, not OP
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/CMakeLists.txt
+++ b/opstack-executor/tests/CMakeLists.txt
@@ -8,24 +8,64 @@ cmake_path(NORMAL_PATH _evmone_inc_dir)
 set(EVMONE_TEST_UTILS_DIR "${_evmone_inc_dir}/test/utils")
 
 # opstack-executor-tests was the repo's only GTest target; converted to Boost.Test to drop the
-# gtest dependency (not in vcpkg.json, broke CI configure). BOOST_TEST_MODULE is defined in
-# TestMain.cpp (the single main for the whole suite — the earlier three-target split left the
-# add_test entries dangling with no add_executable; this restores the wiring with one target).
+# gtest dependency (not in vcpkg.json, broke CI configure). BOOST_TEST_MODULE is defined in the TU.
+add_executable(opstack-executor-tests OpstackExecutorTest.cpp)
+target_link_libraries(opstack-executor-tests PRIVATE
+    opstack-executor           # INTERFACE: pulls ethereum-executor + bcos-evm-opstack + bcos-evm-eth + bcos-framework
+    protocol-tars              # TransactionImpl / BlockHeaderImpl / TransactionReceiptFactoryImpl
+    bcos-crypto                # CryptoSuite / Keccak256
+    codec                      # rlp::decode for the web3 tx fixture
+    rpc                        # bcos::rpc::Web3Transaction (model .cpp)
+    evmone::evmone
+    Boost::unit_test_framework)
+# Web3Transaction + tars aggregate init are not unity-build friendly here.
+set_target_properties(opstack-executor-tests PROPERTIES UNITY_BUILD OFF)
+add_test(NAME OpstackExecutorTests COMMAND opstack-executor-tests)
+
 find_package(jsoncpp CONFIG REQUIRED)
-add_executable(opstack-executor-tests
+
+add_executable(opstack-executor-block-tests
+    TestMain.cpp
+    OpT8nReplayTest.cpp
+    OpReceiptEncodeTest.cpp
+    OpL1EdgeGateTest.cpp
+    OpNewPayloadRpcE2eTest.cpp
+    OpSchedulerSeamSmokeTest.cpp
+    OpEngineBranchSmokeTest.cpp
+    OpSchedulerTest.cpp
+    OpBlockInjectorTest.cpp
+    OpDualPathEquivalenceTest.cpp
+    Storage2StatePoisonTest.cpp
+    support/SeedPreStateTest.cpp
+    support/GoldenSampleTest.cpp
+    ${EVMONE_TEST_UTILS_DIR}/rlp_encode.cpp
+)
+# 与既有 GTest target 同因：Web3Transaction + tars aggregate init 不宜 unity-build
+set_target_properties(opstack-executor-block-tests PROPERTIES UNITY_BUILD OFF)
+# Vendored evmone test util — same -Wno-missing-field-initializers as the upstream build.
+set_source_files_properties(${EVMONE_TEST_UTILS_DIR}/rlp_encode.cpp
+    PROPERTIES COMPILE_OPTIONS "-Wno-missing-field-initializers")
+target_link_libraries(opstack-executor-block-tests PRIVATE
+    opstack-executor bcosevm::opstack Boost::unit_test_framework
+    codec protocol-tars ledger engine bcos-utilities jsoncpp_static rpc
+    transaction-scheduler)  # OpSchedulerTest: SchedulerSkeleton::current() (BaselineScheduler.cpp)
+target_include_directories(opstack-executor-block-tests PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/bcos-ledger
+    ${CMAKE_SOURCE_DIR}/bcos-rpc)
+target_compile_definitions(opstack-executor-block-tests PRIVATE
+    OP_T8N_VECTORS_DIR="${CMAKE_CURRENT_SOURCE_DIR}/t8n/vectors"
+    OP_T8N_GOLDEN_ENGINE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/t8n/golden/engine")
+add_test(NAME OpstackExecutorBlockTests COMMAND opstack-executor-block-tests)
+
+# Extracted pure-function layer (OpRlpDecode.h / Storage2StateHelpers.h): direct unit tests
+# over the decode primitives and state-bridge helpers, no class-template instantiation.
+add_executable(opstack-executor-detail-tests
     TestMain.cpp
     OpRlpDecodeTest.cpp
     Storage2StateHelpersTest.cpp
-    Storage2StatePoisonTest.cpp
-    support/SeedPreStateTest.cpp
-    ${EVMONE_TEST_UTILS_DIR}/rlp_encode.cpp
 )
-target_link_libraries(opstack-executor-tests PRIVATE
-    opstack-executor
-    ledger
-    jsoncpp_static
-    Boost::unit_test_framework
-)
-set_source_files_properties(${EVMONE_TEST_UTILS_DIR}/rlp_encode.cpp
-    PROPERTIES COMPILE_OPTIONS "-Wno-missing-field-initializers")
-add_test(NAME OpstackExecutorTests COMMAND opstack-executor-tests)
+set_target_properties(opstack-executor-detail-tests PROPERTIES UNITY_BUILD OFF)
+target_link_libraries(opstack-executor-detail-tests PRIVATE
+    opstack-executor codec evmone::evmone intx::intx Boost::unit_test_framework bcos-utilities)
+add_test(NAME OpstackExecutorDetailTests COMMAND opstack-executor-detail-tests)

--- a/opstack-executor/tests/OpBlockInjectorTest.cpp
+++ b/opstack-executor/tests/OpBlockInjectorTest.cpp
@@ -1,0 +1,445 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpBlockInjectorTest — drives the shared block-execution path (preBlockOpSteps →
+// SchedulerSerialImpl(serial=true) → finalizeOpBlockResult — runOpBlockInjection's successor, Task
+// 5) over a plain MutableStorage fixture (spec §7(a); the path is Storage templates, so no MLS is
+// needed). A minimal "L1 attributes deposit + eip1559" block verifies:
+//   (1) the system-call BlockInfo's gas_limit == header.gasLimit (toBlockInfo, trivially true);
+//   (2) receipt count == tx count;
+//   (3) the block-level gasUsed == manual Σ per-receipt gasUsed.
+// Plus: preBlockOpSteps rejects an empty block with OpConsensusError (the retired injector's
+// empty-block guard now lives there).
+// Per-tx BlockInfo gasLimit==header is deliberately NOT asserted here — that belongs to
+// OpstackExecutorTest::BlockInfoGasLimitUsesHeaderGasLimit.
+
+#include "support/OpDepositEncode.h"  // encodeDepositEnvelope (deposit envelope reconstruction)
+#include <opstack-executor/OpBlockExecute.h>
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-transaction-scheduler/SchedulerSerialImpl.h>  // per-tx loop (Task 5)
+#include <bcos-utilities/IOServicePool.h>
+#include <engine/bcos-engine/EngineServiceImpl.h>  // detail::opEnvelopeToTars (tests link engine)
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+using evmc::literals::operator""_address;
+
+namespace
+{
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+
+constexpr uint64_t kChainId = 0x2105;
+constexpr int64_t kHeaderGasLimit = 30'000'000;
+const bcos::Address kSender{"0x1000000000000000000000000000000000000000"};
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+bcos::protocol::TransactionReceiptFactory::Ptr makeReceiptFactory()
+{
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+}
+
+/// A header carrying every optional field toBlockInfo reads via `.value()` (OpCommon.h:106-121):
+/// baseFee / parentBeaconBlockRoot / blobGasUsed must be set or toBlockInfo throws.
+std::shared_ptr<bcostars::protocol::BlockHeaderImpl> makeHeader(int64_t timestampMillis)
+{
+    auto h = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    h->setNumber(1);
+    h->setTimestamp(timestampMillis);
+    h->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 0, .blockHash = bcos::h256{}});
+    h->setCoinbase(bcos::Address{});
+    h->setStateRoot(bcos::h256{});
+    h->setTxsRoot(bcos::h256{});
+    h->setReceiptsRoot(bcos::h256{});
+    h->setGasLimit(bcos::u256(kHeaderGasLimit));
+    h->setGasUsed(bcos::u256(0));
+    h->setExtraData(bcos::bytes{});
+    h->setPrevRandao(bcos::h256{});
+    h->setBaseFee(bcos::u256(1'000'000'000));
+    h->setWithdrawalsRoot(bcos::h256{});
+    h->setBlobGasUsed(bcos::u256(0));
+    h->setExcessBlobGas(bcos::u256(0));
+    h->setParentBeaconBlockRoot(bcos::h256{});
+    h->setRequestsHash(bcos::h256{});
+    return h;
+}
+
+/// The block's L1 attributes deposit: to==OP_L1_BLOCK && from==OP_DEPOSITOR satisfies the
+/// stricter-than-spec content check (OpBlockExecute.h isL1AttributesTx). Isthmus config means
+/// validateJovianBlockShape is a no-op, so the calldata can be minimal.
+bcos::evm::opstack::OpBlockTx makeAttributesDeposit()
+{
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = evmc::bytes32{},
+        .from = bcos::evm::opstack::OP_DEPOSITOR,
+        .to = bcos::evm::opstack::OP_L1_BLOCK,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    return bcos::evm::opstack::OpBlockTx{dep, {}};
+}
+
+/// The block's normal EIP-1559 tx shell. Only `signedEnvelope` is consumed (the raw envelope the
+/// injector classifies by first byte); the evmone fields are filled for realism.
+bcos::evm::opstack::OpBlockTx makeEip1559OpBlockTx()
+{
+    namespace detail = bcos::evm::engine::detail;
+    evmone::state::Transaction evmTx;
+    evmTx.type = evmone::state::Transaction::Type::eip1559;
+    evmTx.sender = detail::toEvmcAddress(kSender);
+    evmTx.to = 0x811a752c8cd697e3cb27279c330ed1ada745a8d7_address;
+    evmTx.gas_limit = 5'000'000;
+    evmTx.max_gas_price = intx::uint256{30'000'000'000ULL};
+    evmTx.max_priority_gas_price = 0;
+    evmTx.nonce = 0;
+    evmTx.value = 0;
+    evmTx.data = {};
+    evmc::bytes envelope(64, 0x02);  // non-empty stand-in for the raw 0x02-prefixed envelope
+    return bcos::evm::opstack::OpBlockTx{evmTx, envelope};
+}
+
+/// Caller-prebuilt FISCO Transaction for the eip1559 tx (buildFiscoTx is the caller's
+/// responsibility — the injector only consumes Transaction::Ptr). EIP-1559 with
+/// maxPriorityFeePerGas=0 keeps effectiveGasPrice == baseFee (BCOS2Evmone's access-list override
+/// never fires), and the dummy r/s is neutralized by forceSender.
+bcos::protocol::Transaction::Ptr buildEip1559FiscoTx()
+{
+    // chainId must match the block chainId (kChainId, 0x2105): a mismatch is rejected in m_prepare
+    // before opValidate.
+    bcos::rpc::Web3Transaction w3{};
+    w3.type = bcos::rpc::TransactionType::EIP1559;
+    w3.chainId = kChainId;
+    w3.nonce = 0;
+    w3.maxFeePerGas = bcos::u256(30'000'000'000ULL);
+    w3.maxPriorityFeePerGas = 0;
+    w3.gasLimit = 5'000'000;
+    w3.to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7");
+    w3.value = bcos::u256(0);
+    w3.signatureV = 0;
+    w3.signatureR = bcos::bytes(32, 0x01);
+    w3.signatureS = bcos::bytes(32, 0x02);
+    auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+    auto const txHash = w3.txHash();
+    tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+    // takeToTarsTransaction stores the signing preimage (which a full-envelope consumer would
+    // reject as a truncated typed envelope); overwrite with the full EIP-2718 envelope.
+    auto const envelope = w3.encode();
+    tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tarsHolder]() { return tarsHolder.get(); });
+    tx->clearSenderAndHash();
+    tx->forceSender(kSender.asBytes());
+    return tx;
+}
+
+/// Fund the sender EOA in the plain MutableStorage so opValidate's balance + EIP-3607 checks pass
+/// (StorageStateView::exists() needs a non-zero codeHash — create + setCode(empty) makes it an
+/// existing account with empty code; a bare setBalance would leave it nonexistent).
+void fundSender(MutableStorage& storage, bcos::crypto::Hash::Ptr const& hashImpl)
+{
+    bcos::ledger::account::EVMAccount<MutableStorage> account(storage, kSender, false);
+    bcos::task::syncWait(account.create());
+    bcos::task::syncWait(account.setCode({}, {}, hashImpl->emptyHash()));
+    bcos::task::syncWait(account.setNonce("0"));
+    bcos::task::syncWait(account.setBalance(bcos::u256(1) << 200));
+}
+
+/// FISCO Transaction from a raw envelope (opEnvelopeToTars + full-envelope override, precedent
+/// OpDualPathEquivalenceTest.cpp buildBlockTx): the shared path's per-tx loop re-derives deposits
+/// from the Transaction objects, so index 0 must carry a REAL deposit tx (not a placeholder).
+bcos::protocol::Transaction::Ptr buildFiscoTxFromEnvelope(
+    bcos::bytes const& env, bcos::crypto::Hash::Ptr const& hashImpl)
+{
+    auto txHash = hashImpl->hash(env);
+    auto tarsTx = bcos::engine::detail::opEnvelopeToTars(env, txHash);
+    if (!tarsTx)
+        return nullptr;
+    tarsTx->extraTransactionBytes.assign(env.begin(), env.end());
+    return std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tars = std::move(*tarsTx)]() mutable { return &tars; });
+}
+
+/// Drive the shared block-execution path (preBlockOpSteps → SchedulerSerialImpl(serial=true) →
+/// finalizeOpBlockResult) — runOpBlockInjection's successor (Task 5). Mirrors OpScheduler::execute
+/// over a plain MutableStorage (no MLS needed: preBlockOpSteps / SchedulerSerialImpl / finalize are
+/// Storage templates). preBlockOpSteps throws OpConsensusError on block-level shape faults (the
+/// empty-block guard).
+bcos::evm::engine::OpExecuteBlockResult runSharedPath(MutableStorage& storage,
+    bcos::protocol::BlockHeader const& header, std::vector<bcos::bytes> const& rawTxBytes,
+    std::vector<bcos::protocol::Transaction::ConstPtr> const& transactions,
+    std::vector<bcos::evm::opstack::DepositTx> const& deposits,
+    bcos::evm::opstack::OpForkConfig const& cfg,
+    bcos::executor_v1::opstack::OpstackExecutor& executor, bcos::crypto::Hash::Ptr const& hashImpl,
+    bcos::IOServicePool::Ptr const& ioServicePool)
+{
+    namespace detail = bcos::evm::engine::detail;
+    bcos::ledger::LedgerConfig execLedgerConfig;
+    execLedgerConfig.setEVMCRevision(cfg.rev);
+
+    std::optional<std::string> hashErr;
+    std::optional<uint16_t> daFootprintGasScalar;
+    std::optional<detail::RecentBlockHashes<MutableStorage>> hashes;
+    bcos::evm::engine::preBlockOpSteps(storage, header, cfg, rawTxBytes, deposits, executor,
+        hashImpl, hashes, hashErr, daFootprintGasScalar);
+    bcos::executor_v1::opstack::OpBlockExecutionContext ctx{.fee = {},
+        .blockGasLeft = static_cast<int64_t>(header.gasLimit()),
+        .blockHashes = &*hashes,
+        .chainId = kChainId,
+        .daFootprintGasScalar = daFootprintGasScalar};
+    bcos::scheduler_v1::SchedulerSerialImpl serialScheduler(
+        ioServicePool, /*chunkSize=*/1, /*serial=*/true);
+    auto transactionsRefs =
+        transactions |
+        ::ranges::views::transform([](bcos::protocol::Transaction::ConstPtr const& ptr)
+                                       -> bcos::protocol::Transaction const& { return *ptr; });
+    auto receipts = bcos::task::syncWait(serialScheduler.executeBlock(
+        storage, executor, header, transactionsRefs, execLedgerConfig, ctx));
+    return bcos::evm::engine::finalizeOpBlockResult(executor, storage, header, execLedgerConfig,
+        cfg, receipts, rawTxBytes, ctx.cumulativeGasUsed, hashErr);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpBlockInjector)
+
+BOOST_AUTO_TEST_CASE(InjectsDepositAndEip1559Block)
+{
+    namespace op = bcos::evm::opstack;
+    namespace engine = bcos::evm::engine;
+    namespace detail = bcos::evm::engine::detail;
+
+    // Isthmus-active fork config.
+    // Isthmus-active fork config (feature_op_jovian OFF).
+    // Named-lvalue first: configAt takes const OpForkFlags&, and GCC-14's -Wdangling-reference
+    // flags passing a prvalue `op::OpForkFlags{}` here even though the returned reference
+    // aliases the static config, never the flags (false positive).
+    const auto forkFlags = op::OpForkFlags{};
+    const auto& cfg = op::configAt(forkFlags);
+
+    MutableStorage storage;
+    auto cryptoSuite = makeCryptoSuite();
+    auto hashImpl = cryptoSuite->hashImpl();
+    auto receiptFactory = makeReceiptFactory();
+    bcos::executor_v1::opstack::OpstackExecutor executor{receiptFactory, hashImpl, cfg};
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1);
+
+    auto header = makeHeader(1'000'000);  // 1000 s
+
+    fundSender(storage, hashImpl);
+
+    auto depTx = makeAttributesDeposit();  // OpBlockTx
+    auto normTx = makeEip1559OpBlockTx();  // OpBlockTx
+    std::vector<op::DepositTx> deposits{std::get<op::DepositTx>(depTx.tx)};
+    // makeAttributesDeposit leaves signedEnvelope empty; the type-byte classification reads
+    // rawTxBytes[0][0] -> rebuild the real 0x7e envelope with encodeDepositEnvelope.
+    bcos::bytes depEnv = encodeDepositEnvelope(std::get<op::DepositTx>(depTx.tx));
+    bcos::bytes normEnv(normTx.signedEnvelope.begin(), normTx.signedEnvelope.end());
+    std::vector<bcos::bytes> rawTxBytes{depEnv, normEnv};
+
+    // Block-order transactions: index 0 is a REAL deposit tx (the shared per-tx loop re-derives
+    // deposits from the Transaction objects), index 1 is normal.
+    auto depFiscoTx = buildFiscoTxFromEnvelope(depEnv, hashImpl);
+    BOOST_REQUIRE(depFiscoTx != nullptr);
+    std::vector<bcos::protocol::Transaction::ConstPtr> transactions{
+        depFiscoTx, buildEip1559FiscoTx()};
+
+    auto result = runSharedPath(storage, *header, rawTxBytes, transactions, deposits, cfg, executor,
+        hashImpl, ioServicePool);
+
+    // System-call BlockInfo gas_limit == header.gasLimit (toBlockInfo, trivially true here).
+    const auto sysBlk = detail::toBlockInfo(*header);
+    BOOST_CHECK_EQUAL(sysBlk.gas_limit, kHeaderGasLimit);
+    BOOST_CHECK_EQUAL(sysBlk.gas_limit,
+        static_cast<int64_t>(detail::narrowU256ToU64(header->gasLimit(), "test")));
+
+    // Receipt count == tx count (both txs execute).
+    BOOST_CHECK_EQUAL(result.receipts.size(), rawTxBytes.size());
+
+    // gasUsed == manual Σ per-receipt gasUsed (the block-level cumulative accumulator).
+    int64_t manual = 0;
+    for (auto const& r : result.receipts)
+        manual += op::narrowGasUsed(r->gasUsed());
+    BOOST_CHECK_EQUAL(result.gasUsed, static_cast<uint64_t>(manual));
+    BOOST_CHECK_GT(manual, 0);  // both txs actually consumed gas
+}
+
+/// Empty-block rejection: preBlockOpSteps with empty rawTxBytes → OpConsensusError (a
+/// std::runtime_error subclass). The retired runOpBlockInjection's empty-block guard lives here
+/// now.
+BOOST_AUTO_TEST_CASE(EmptyBlockRejectedByBlockPreSteps)
+{
+    namespace op = bcos::evm::opstack;
+    namespace engine = bcos::evm::engine;
+    namespace detail = bcos::evm::engine::detail;
+
+    // Isthmus-active fork config (feature_op_jovian OFF).
+    // Named-lvalue first: configAt takes const OpForkFlags&, and GCC-14's -Wdangling-reference
+    // flags passing a prvalue `op::OpForkFlags{}` here even though the returned reference
+    // aliases the static config, never the flags (false positive).
+    const auto forkFlags = op::OpForkFlags{};
+    const auto& cfg = op::configAt(forkFlags);
+
+    MutableStorage storage;
+    auto cryptoSuite = makeCryptoSuite();
+    auto hashImpl = cryptoSuite->hashImpl();
+    auto receiptFactory = makeReceiptFactory();
+    bcos::executor_v1::opstack::OpstackExecutor executor{receiptFactory, hashImpl, cfg};
+
+    auto header = makeHeader(1'000'000);
+
+    // Empty deposits/rawTxBytes → "op block: missing L1 attributes deposit (empty block)" →
+    // OpConsensusError.
+    std::vector<op::DepositTx> deposits;
+    std::vector<bcos::bytes> rawTxBytes;
+    std::optional<std::string> hashErr;
+    std::optional<uint16_t> daFootprintGasScalar;
+    std::optional<detail::RecentBlockHashes<MutableStorage>> hashes;
+    BOOST_CHECK_THROW(engine::preBlockOpSteps(storage, *header, cfg, rawTxBytes, deposits, executor,
+                          hashImpl, hashes, hashErr, daFootprintGasScalar),
+        std::runtime_error);
+}
+
+/// Finding J (round-2 review #5429): pin the M2 accept path — a deposit AFTER a non-deposit is
+/// ACCEPTED (D demoted it from OpConsensusError to BCOS_LOG(WARNING) + continue in f974bb1a9).
+/// op-geth/op-reth enforce deposit-first only at the sequencer (construction), never at
+/// validation, so this block must execute with all three txs. Without this anchor, a regression
+/// to the old hard reject (which would re-divergence from the reference clients by rejecting a
+/// block they accept) has no CI signal.
+BOOST_AUTO_TEST_CASE(DepositAfterNonDepositAccepted)
+{
+    namespace op = bcos::evm::opstack;
+
+    // Isthmus-active fork config (feature_op_jovian OFF).
+    // Named-lvalue first: configAt takes const OpForkFlags&, and GCC-14's -Wdangling-reference
+    // flags passing a prvalue `op::OpForkFlags{}` here (false positive, see
+    // InjectsDepositAndEip1559Block).
+    const auto forkFlags = op::OpForkFlags{};
+    const auto& cfg = op::configAt(forkFlags);
+
+    MutableStorage storage;
+    auto cryptoSuite = makeCryptoSuite();
+    auto hashImpl = cryptoSuite->hashImpl();
+    auto receiptFactory = makeReceiptFactory();
+    bcos::executor_v1::opstack::OpstackExecutor executor{receiptFactory, hashImpl, cfg};
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1);
+
+    auto header = makeHeader(1'000'000);
+    fundSender(storage, hashImpl);
+
+    // Block: [L1 attributes deposit, normal tx, deposit] — the third tx is a deposit after a
+    // non-deposit, the M2 order-gate case that was demoted to an observable WARNING.
+    auto attrDep = makeAttributesDeposit();
+    auto normTx = makeEip1559OpBlockTx();
+    auto lateDep = makeAttributesDeposit();
+    std::vector<op::DepositTx> deposits{std::get<op::DepositTx>(attrDep.tx)};
+    bcos::bytes attrEnv = encodeDepositEnvelope(std::get<op::DepositTx>(attrDep.tx));
+    bcos::bytes normEnv(normTx.signedEnvelope.begin(), normTx.signedEnvelope.end());
+    bcos::bytes lateEnv = encodeDepositEnvelope(std::get<op::DepositTx>(lateDep.tx));
+    std::vector<bcos::bytes> rawTxBytes{attrEnv, normEnv, lateEnv};
+
+    auto attrFiscoTx = buildFiscoTxFromEnvelope(attrEnv, hashImpl);
+    auto lateFiscoTx = buildFiscoTxFromEnvelope(lateEnv, hashImpl);
+    BOOST_REQUIRE(attrFiscoTx != nullptr);
+    BOOST_REQUIRE(lateFiscoTx != nullptr);
+    std::vector<bcos::protocol::Transaction::ConstPtr> transactions{
+        attrFiscoTx, buildEip1559FiscoTx(), lateFiscoTx};
+
+    auto result = runSharedPath(storage, *header, rawTxBytes, transactions, deposits, cfg, executor,
+        hashImpl, ioServicePool);
+
+    // All three txs execute — the late deposit is accepted, not rejected.
+    BOOST_CHECK_EQUAL(result.receipts.size(), rawTxBytes.size());
+    BOOST_CHECK_EQUAL(result.receipts.size(), 3u);
+    int64_t manual = 0;
+    for (auto const& r : result.receipts)
+        manual += op::narrowGasUsed(r->gasUsed());
+    BOOST_CHECK_GT(manual, 0);  // all three txs actually consumed gas
+}
+
+/// Finding J (round-2 review #5429): pin the isL1AttributesTx accept path — a first deposit that
+/// is NOT the L1-attributes tx (to/from != OP_L1_BLOCK/OP_DEPOSITOR) is ACCEPTED (D demoted the
+/// content check from a hard reject to BCOS_LOG(WARNING) in f974bb1a9; op-geth's extract_l1_info
+/// and op-reth's validation do not validate L1-attributes identity). The block must execute with
+/// both txs. Isthmus config keeps the Jovian DA-footprint shape checks (which read
+/// deposits[0].data) out of the way.
+BOOST_AUTO_TEST_CASE(FirstDepositNotL1AttributesAccepted)
+{
+    namespace op = bcos::evm::opstack;
+
+    // Isthmus-active fork config (feature_op_jovian OFF).
+    const auto forkFlags = op::OpForkFlags{};
+    const auto& cfg = op::configAt(forkFlags);
+
+    MutableStorage storage;
+    auto cryptoSuite = makeCryptoSuite();
+    auto hashImpl = cryptoSuite->hashImpl();
+    auto receiptFactory = makeReceiptFactory();
+    bcos::executor_v1::opstack::OpstackExecutor executor{receiptFactory, hashImpl, cfg};
+    auto ioServicePool = std::make_shared<bcos::IOServicePool>(1);
+
+    auto header = makeHeader(1'000'000);
+    fundSender(storage, hashImpl);
+
+    // First deposit deliberately NOT the L1-attributes tx: arbitrary from/to (the L1-attributes
+    // content check is demoted to a WARNING, so this does not reject the block).
+    bcos::evm::opstack::DepositTx nonAttrDep{
+        .source_hash = evmc::bytes32{},
+        .from = 0x811a752c8cd697e3cb27279c330ed1ada745a8d7_address,
+        .to = 0x811a752c8cd697e3cb27279c330ed1ada745a8d7_address,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    auto normTx = makeEip1559OpBlockTx();
+    std::vector<op::DepositTx> deposits{nonAttrDep};
+    bcos::bytes depEnv = encodeDepositEnvelope(nonAttrDep);
+    bcos::bytes normEnv(normTx.signedEnvelope.begin(), normTx.signedEnvelope.end());
+    std::vector<bcos::bytes> rawTxBytes{depEnv, normEnv};
+
+    auto depFiscoTx = buildFiscoTxFromEnvelope(depEnv, hashImpl);
+    BOOST_REQUIRE(depFiscoTx != nullptr);
+    std::vector<bcos::protocol::Transaction::ConstPtr> transactions{
+        depFiscoTx, buildEip1559FiscoTx()};
+
+    auto result = runSharedPath(storage, *header, rawTxBytes, transactions, deposits, cfg, executor,
+        hashImpl, ioServicePool);
+
+    // Both txs execute — the non-L1-attributes first deposit is accepted, not rejected.
+    BOOST_CHECK_EQUAL(result.receipts.size(), rawTxBytes.size());
+    BOOST_CHECK_EQUAL(result.receipts.size(), 2u);
+    int64_t manual = 0;
+    for (auto const& r : result.receipts)
+        manual += op::narrowGasUsed(r->gasUsed());
+    BOOST_CHECK_GT(manual, 0);  // both txs actually consumed gas
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpDualPathEquivalenceTest.cpp
+++ b/opstack-executor/tests/OpDualPathEquivalenceTest.cpp
@@ -1,0 +1,763 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpDualPathEquivalenceTest.cpp — OP single-path golden execution harness (route B retired with
+// runOpBlockInjection, Task 5). Each t8n vector / chain block is driven through
+// OpScheduler.executeBlock — the production OP execution path (preBlockOpSteps →
+// SchedulerSerialImpl(serial=true) → finalizeOpBlockResult) — with the ANNOUNCED header carrying
+// the op-geth golden commitments (`_op_expected.header` + the deterministic computeOpTxRoot), so
+// the skeleton's unconditional six-way verify asserts FISCO reproduces op-geth's block commitments.
+//
+// Scope (per vector):
+//   - isthmus/jovian (incl. chain): route A MUST succeed — the six-way verify is a hard gate
+//     (FISCO == op-geth commitments) — then the golden three-way (path A.stateRoot ==
+//     `_op_expected.header.stateRoot`) is hard for non-contract_create, soft REPORT for
+//     contract_create (the create-output divergence is a known base-layer issue); green guard
+//     (deposit_basefee ×2) is always hard; receipt-count sanity is asserted.
+//   - pre-isthmus (ecotone/fjord/granite): FISCO executes under isthmus semantics by design (the
+//     golden fork mismatch is expected output); the announced golden commitments are a different
+//     fork's, so route A is expected to be rejected at the six-way verify → soft REPORT (never
+//     hard). Any OTHER failure (shape/validation) is a real bug → BOOST_ERROR.
+//
+// Fork model: `forkFlagsFor(bool jovian)` + `configAt` (feature-op_jovian: isthmus/jovian). Fork
+// parity is
+// asserted by resolving cfg from the same source as the scheduler's internal configAt.
+// Exception handling: per-vector catches use catch(std::exception)/catch(...) (libevmone -fno-rtti
+// makes typed catch unreliable) — catch → BOOST_ERROR + continue.
+// has_storage scan (same-block create pre-triage) + /sys tripwire derived-table prefix assertion
+// (accountTableName(addr) prefix == apps/).
+
+#include "support/GoldenSample.h"
+#include "support/OpDepositEncode.h"  // encodeDepositEnvelope (deposit envelope reconstruction)
+#include "support/SeedPreState.h"
+
+#include <bcos-concepts/ByteBuffer.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-evm/adapter/StateRootCompute.h>
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <cxxabi.h>
+#include <engine/bcos-engine/EngineServiceImpl.h>
+#include <opstack-executor/Storage2State.h>
+#include <json/json.h>
+#include <opstack-executor/OpBlockExecute.h>
+#include <opstack-executor/OpScheduler.h>  // route A surgery (Task 6 P1-8): executeBlock drives
+#include <opstack-executor/OpSchedulerSeam.h>
+#include <opstack-executor/OpstackExecutor.h>
+#include <opstack-executor/Storage2State.h>
+#include <opstack-executor/Storage2StateHelpers.h>
+#include <boost/exception/diagnostic_information.hpp>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <optional>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+using JsonValue = Json::Value;
+
+namespace
+{
+namespace op = bcos::evm::opstack;
+namespace engine = bcos::evm::engine;
+namespace eth = bcos::executor_v1::eth;
+namespace detail = bcos::evm::engine::detail;
+
+// ── jsoncpp .at() equivalent (shared with OpT8nReplayTest.cpp:60-84) ─────────────────
+// key is `const char*` (not `const std::string&`) deliberately: a string literal argument
+// would materialize a temporary std::string, and GCC-14's -Wdangling-reference flags any
+// reference-returning call that receives a class-type temporary — even though the returned
+// reference aliases `v`, never `key` (false positive). A `const char*` argument creates no
+// temporary, so the warning cannot fire.
+inline const Json::Value& jAt(const Json::Value& v, const char* key)
+{
+    if (!v.isMember(key))
+        throw std::invalid_argument(std::string("missing required field: ") + key);
+    return v[key];
+}
+
+inline Json::Value jParse(std::istream& input)
+{
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(input, root))
+        throw std::runtime_error("JSON parse failed: " + reader.getFormattedErrorMessages());
+    return root;
+}
+
+
+// ── Fixture (mirrored from OpNewPayloadRpcE2eTest.cpp:48-167) ──────────────────────────
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& storage) noexcept : m_storage(storage) {}
+    Storage& open() & { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const&) & { std::abort(); }
+    void createCheckpoint(Storage&, CheckpointName const&) {}
+    void deleteCheckpoint(CheckpointName const&) {}
+    [[nodiscard]] std::optional<CheckpointName> latestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+    [[nodiscard]] std::optional<CheckpointName> oldestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+};
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+using BackendMemStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+    std::hash<StateKey>>;
+using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, BackendMemStorage>;
+using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+bcos::protocol::TransactionReceiptFactory::Ptr makeReceiptFactory()
+{
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+}
+
+bcos::protocol::BlockFactory::Ptr makeBlockFactory()
+{
+    auto cryptoSuite = makeCryptoSuite();
+    auto blockHeaderFactory =
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite);
+    auto transactionFactory =
+        std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    auto receiptFactory =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite);
+    return std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+        cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory);
+}
+
+constexpr uint64_t kChainId = 0x2105;
+
+bcos::evm::opstack::OpForkFlags forkFlagsFor(bool jovian)
+{
+    return bcos::evm::opstack::OpForkFlags{.jovianActive = jovian};
+}
+
+struct Fixture
+{
+    // Single-bucket CONCURRENT backend: the range(SYS_TABLES) scan for stateRoot relies on
+    // RANGE_SEEK semantics; multi-bucket would scan wrong (OpNewPayloadRpcE2eTest.cpp:147-152).
+    BackendMemStorage backendStorage{1};
+    CheckpointBackend checkpointBackend{backendStorage};
+    MLS multiLayerStorage{checkpointBackend};
+    bcos::crypto::CryptoSuite::Ptr cryptoSuite{makeCryptoSuite()};
+    bcos::crypto::Hash::Ptr hashImpl{cryptoSuite->hashImpl()};
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory{makeReceiptFactory()};
+    bcos::protocol::BlockFactory::Ptr blockFactory{makeBlockFactory()};
+    // Task 4: SchedulerSerialImpl (route A's per-tx driver) needs a live io pool.
+    bcos::IOServicePool::Ptr ioServicePool{std::make_shared<bcos::IOServicePool>(1)};
+};
+
+struct GoldenStats
+{
+    int flat = 0;
+    int chainBlocks = 0;
+    int match = 0;
+    int mismatch = 0;
+    int greenGuardOk = 0;
+};
+
+// ── Helper functions ─────────────────────────────────────────────────────────────────
+
+/// bcos::h256 from a vector hex string, tolerating "0"/"0x0" (zero). jsoncpp vectors write
+/// prev_randao as "0x0" when zero; bcos::h256(string) needs full 64 hex.
+bcos::h256 jsonH256(const std::string& s)
+{
+    if (s.empty() || s == "0" || s == "0x0")
+        return bcos::h256{};
+    return bcos::h256(s);
+}
+
+/// bcos::u256 from a vector hex string ("0x...") — boost cpp_int natively parses the 0x prefix.
+bcos::u256 jsonBcosU256(const std::string& s)
+{
+    return bcos::u256(s);
+}
+
+/// chain vectors have no golden: build a FISCO BlockHeaderImpl from env (current block).
+/// toBlockInfo reads number/timestamp/gasLimit/baseFee/coinbase/prevRandao/
+/// parentBeaconBlockRoot/extraData/blobGasUsed (OpCommon.h:106-121, optional fields .value());
+/// parentInfo serves RecentBlockHashes.
+bcostars::protocol::BlockHeaderImpl::Ptr buildHeaderFromEnv(const Json::Value& env)
+{
+    auto h = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    const int64_t number =
+        static_cast<int64_t>(w6test::jsonU64(jAt(env, "currentNumber").asString()));
+    h->setNumber(number);
+    // FISCO tars store milliseconds; the vector currentTimestamp is in seconds (OP semantics).
+    // toBlockInfo then /1000 restores seconds.
+    h->setTimestamp(
+        static_cast<int64_t>(w6test::jsonU64(jAt(env, "currentTimestamp").asString()) * 1000));
+    h->setGasLimit(jsonBcosU256(jAt(env, "currentGasLimit").asString()));
+    h->setGasUsed(bcos::u256(0));
+    h->setBaseFee(jsonBcosU256(jAt(env, "currentBaseFee").asString()));
+    h->setCoinbase(bcos::Address(jAt(env, "currentCoinbase").asString()));
+    h->setPrevRandao(jsonH256(jAt(env, "currentRandom").asString()));
+    h->setParentBeaconBlockRoot(jsonH256(jAt(env, "parentBeaconBlockRoot").asString()));
+    const auto parentHash = jsonH256(jAt(env, "parentHash").asString());
+    h->setParentInfo(bcos::protocol::ParentInfo{
+        .blockNumber = (number > 0 ? number - 1 : 0), .blockHash = parentHash});
+    h->setExtraData(bcos::bytes{});
+    h->setBlobGasUsed(bcos::u256(0));
+    h->setExcessBlobGas(bcos::u256(0));
+    h->setStateRoot(bcos::h256{});
+    h->setTxsRoot(bcos::h256{});
+    h->setReceiptsRoot(bcos::h256{});
+    h->setWithdrawalsRoot(bcos::h256{});
+    h->setRequestsHash(bcos::h256{});
+    return h;
+}
+
+/// Build raw envelope bytes from vector block.transactions (for txRoot / executeOpBlock decode):
+/// deposit → rebuild DepositTx from _op_deposit → encodeDepositEnvelope (tests/support);
+/// normal → _op_raw as-is. Asserts _op_raw is present (every chain-vector normal tx carries it).
+std::vector<bcos::bytes> buildRawTxBytes(const Json::Value& blk, const std::string& id)
+{
+    std::vector<bcos::bytes> rawTxBytes;
+    for (const auto& t : jAt(jAt(blk, "block"), "transactions"))
+    {
+        const auto opType = jAt(t, "_op_type").asString();
+        if (opType == "deposit")
+        {
+            const auto& d = jAt(t, "_op_deposit");
+            op::DepositTx dep;
+            dep.source_hash = detail::toEvmcBytes32(jsonH256(jAt(d, "source_hash").asString()));
+            dep.from = w6test::jsonAddress(jAt(d, "from").asString());
+            dep.to = jAt(d, "to").isNull() ?
+                         std::nullopt :
+                         std::optional{w6test::jsonAddress(jAt(d, "to").asString())};
+            dep.mint = d.isMember("mint") ?
+                           std::optional{w6test::jsonU256(jAt(d, "mint").asString())} :
+                           std::nullopt;
+            dep.value = d.isMember("value") ? w6test::jsonU256(jAt(d, "value").asString()) :
+                                              intx::uint256{0};
+            dep.gas_limit = static_cast<int64_t>(w6test::jsonU64(jAt(d, "gas").asString()));
+            dep.is_system_tx = jAt(d, "is_system_tx").asBool();
+            dep.data = w6test::jsonBytes(jAt(t, "data").asString());
+            rawTxBytes.push_back(encodeDepositEnvelope(dep));
+        }
+        else
+        {
+            if (!t.isMember("_op_raw"))
+                throw std::invalid_argument(id + ": normal tx missing _op_raw");
+            rawTxBytes.push_back(bcos::fromHex(jAt(t, "_op_raw").asString()));
+        }
+    }
+    return rawTxBytes;
+}
+
+/// FISCO tx for block assembly: built from the raw envelope
+/// (opEnvelopeToTars + SEV-8 full-envelope override) — block assembly must also build txs for
+/// deposits (getTransactions returns the full set; the execute hook pulls raw bytes from
+/// extraTransactionBytes and classifies by type byte). Precedent:
+/// EngineServiceImpl.h:1176-1196 buildOpBlock.
+bcos::protocol::Transaction::Ptr buildBlockTx(
+    bcos::bytes const& env, bcos::crypto::Hash::Ptr const& hashImpl)
+{
+    auto txHash = hashImpl->hash(env);
+    auto tarsTx = bcos::engine::detail::opEnvelopeToTars(env, txHash);
+    if (!tarsTx)
+        return nullptr;
+    tarsTx->extraTransactionBytes.assign(env.begin(), env.end());
+    return std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tars = std::move(*tarsTx)]() mutable { return &tars; });
+}
+
+/// Backfill the announced header's commitment fields from the vector's golden
+/// `_op_expected.header` (op-geth's real block, from the t8n generator), so OpScheduler's
+/// unconditional six-way verify compares FISCO's execution against the op-geth golden. txRoot is
+/// absent from _op_expected — it is the deterministic trie root over rawTxBytes (computeOpTxRoot,
+/// the same function finalizeOpBlockResult uses → equal by construction).
+/// withdrawalsRoot/requestsHash/blobGasUsed are set only when present; blobGasUsed MUST be filled
+/// when the golden carries it (a buildHeaderFromEnv default of 0 would otherwise false-mismatch a
+/// Jovian block whose seal carries a non-zero value).
+void fillAnnouncedHeaderFromGolden(bcos::protocol::BlockHeader::Ptr const& header,
+    const JsonValue& vec, const std::vector<bcos::bytes>& rawTxBytes)
+{
+    const auto& ex = jAt(jAt(vec, "_op_expected"), "header");
+    header->setStateRoot(jsonH256(jAt(ex, "stateRoot").asString()));
+    header->setReceiptsRoot(jsonH256(jAt(ex, "receiptsRoot").asString()));
+    header->setGasUsed(jsonBcosU256(jAt(ex, "gasUsed").asString()));
+    header->setTxsRoot(bcos::evm::engine::computeOpTxRoot(rawTxBytes));
+    auto bloom = bcos::fromHex(jAt(ex, "logsBloom").asString());
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    if (ex.isMember("withdrawalsRoot"))
+        header->setWithdrawalsRoot(jsonH256(ex["withdrawalsRoot"].asString()));
+    if (ex.isMember("requestsHash"))
+        header->setRequestsHash(jsonH256(ex["requestsHash"].asString()));
+    if (ex.isMember("blobGasUsed"))
+        header->setBlobGasUsed(jsonBcosU256(ex["blobGasUsed"].asString()));
+}
+
+/// /sys tripwire: derived-table prefix assertion — for every vector
+/// pre/postState/tx to/from/coinbase address, accountTableName(addr) must prefix with apps/
+/// (more robust than enumerating c_systemTxsAddress).
+void checkSysTripwire(const std::string& id, const JsonValue& vec)
+{
+    std::set<std::string> tables;
+    const auto add = [&](const JsonValue& j) {
+        if (j.isNull() || !j.isObject())
+            return;
+        for (const char* k : {"to", "from", "sender"})
+        {
+            if (j.isMember(k) && !j[k].isNull())
+                tables.insert(
+                    bcos::evm::evmstate::accountTableName(w6test::jsonAddress(j[k].asString())));
+        }
+    };
+    if (vec.isMember("pre"))
+    {
+        for (const auto& a : vec["pre"].getMemberNames())
+            tables.insert(bcos::evm::evmstate::accountTableName(w6test::jsonAddress(a)));
+    }
+    if (vec.isMember("postState"))
+    {
+        for (const auto& a : vec["postState"].getMemberNames())
+            tables.insert(bcos::evm::evmstate::accountTableName(w6test::jsonAddress(a)));
+    }
+    if (vec.isMember("env"))
+    {
+        const auto& cb = vec["env"]["currentCoinbase"];
+        if (cb.isString())
+            tables.insert(
+                bcos::evm::evmstate::accountTableName(w6test::jsonAddress(cb.asString())));
+    }
+    if (vec.isMember("block") && vec["block"].isMember("transactions"))
+    {
+        for (const auto& t : vec["block"]["transactions"])
+        {
+            add(t);
+            if (t.isMember("_op_deposit"))
+                add(t["_op_deposit"]);
+        }
+    }
+    for (const auto& t : tables)
+    {
+        if (t.rfind(bcos::ledger::SYS_DIRECTORY::USER_APPS, 0) != 0)
+            BOOST_ERROR(
+                id << ": /sys tripwire: derived table '" << t << "' does not start with apps/");
+    }
+}
+
+/// has_storage scan (without pre-fixing): P1 scans same-block creates for
+/// early triage — the corpus likely does not trigger StorageStateView's has_storage read-side
+/// asymmetry; a hit only REPORTs, never fails. Post-refactor the block's txs are deposits +
+/// FISCO Transactions; contract creations are visible as deposits with a nullopt `to` (the L1
+/// attributes deposit always carries a `to`, so a hit would be a genuine create deposit).
+void hasStorageScan(
+    const std::string& id, const std::vector<bcos::evm::opstack::DepositTx>& deposits)
+{
+    int creates = 0;
+    for (const auto& dep : deposits)
+    {
+        if (!dep.to.has_value())
+            ++creates;
+    }
+    if (creates > 0)
+        std::cout << "  has-storage-triage " << id << " creates=" << creates
+                  << " (zero-write/CREATE2-same-addr collision risk scan: corpus not expected to "
+                     "trigger)\n";
+}
+
+/// golden three-way: path A.stateRoot == vector
+/// _op_expected.header.stateRoot. When hardGolden=true, a mismatch is a hard BOOST_CHECK failure
+/// (scope = isthmus/jovian non-contract_create); greenGuard (deposit_basefee green guard) is
+/// always hard; the rest (pre-isthmus / contract_create) stays soft REPORT.
+void reportGolden(const std::string& id, const JsonValue& vec, const bcos::h256& stateRootA,
+    bool greenGuard, bool hardGolden, GoldenStats& stats)
+{
+    const auto want = jAt(jAt(vec, "_op_expected"), "header")["stateRoot"].asString();
+    const auto got = stateRootA.hexPrefixed();
+    if (want == got)
+    {
+        ++stats.match;
+        if (greenGuard)
+        {
+            ++stats.greenGuardOk;
+            std::cout << "  GREEN-GUARD " << id << " three-way consistent stateRoot=" << got
+                      << "\n";
+        }
+        return;
+    }
+    ++stats.mismatch;
+    if (greenGuard)
+    {
+        BOOST_CHECK_MESSAGE(false, id << ": green-guard three-way mismatch A.stateRoot=" << got
+                                      << " vector.stateRoot=" << want);
+    }
+    else if (hardGolden)
+    {
+        BOOST_CHECK_MESSAGE(false, id << ": golden three-way mismatch A.stateRoot=" << got
+                                      << " vector.stateRoot=" << want
+                                      << " (P3 hard, scope=isthmus/jovian non-contract_create)");
+    }
+    else
+    {
+        std::cout
+            << "  GOLDEN-REPORT " << id << " stateRoot MISMATCH A=" << got << " vector=" << want
+            << " (soft REPORT: pre-isthmus fork-mismatch or contract_create known-divergence)\n";
+    }
+}
+
+/// Single-block execution: seedPreState is already done externally; the announced header carries
+/// the golden commitments (filled by the caller via fillAnnouncedHeaderFromGolden), route A runs
+/// through OpScheduler.executeBlock, and the golden three-way + receipt sanity are checked.
+/// isthmus/jovian must pass the six-way verify (FISCO == op-geth commitments); pre-isthmus is
+/// expected to be rejected at the verify (fork mismatch) → soft REPORT. mergeBackStorage persists
+/// route A's authoritative post-state (chain inheritance).
+void runBlockEquivalence(const std::string& id, Fixture& fixture,
+    bcos::protocol::BlockHeader::Ptr const& header, const std::vector<bcos::bytes>& rawTxBytes,
+    const JsonValue& vec, bool jovian, const bcos::evm::opstack::OpForkConfig& vectorCfg,
+    bool greenGuard, GoldenStats& stats)
+{
+    // Fork parity: cfg = configAt(forkFlagsFor(jovian)), resolved from the same source as the
+    // scheduler's internal configAt (same forkFlagsFor, same static singleton object).
+    // Bind forkFlagsFor(jovian) to a named lvalue first: configAt takes const OpForkFlags&, and
+    // GCC-14's -Wdangling-reference flags passing a prvalue temporary here even though the
+    // returned reference aliases the static config, never the flags (false positive). The named
+    // lvalue preserves the reference + its address identity (the &cfg == &vectorCfg check below).
+    const auto forkFlags = forkFlagsFor(jovian);
+    const auto& cfg = op::configAt(forkFlags);
+    BOOST_CHECK_MESSAGE(&cfg == &vectorCfg, id << ": fork parity broken: block cfg != vector cfg");
+
+    const auto hardfork = jAt(jAt(vec, "_info"), "hardfork").asString();
+    const bool isIsthmusJovian = (hardfork == "isthmus" || hardfork == "jovian");
+    const bool hardGolden = isIsthmusJovian && (id.find("contract_create") == std::string::npos);
+
+    // Deposits (has_storage triage scan), built from the block-order Transaction objects
+    // (mirroring the execute hook, no RLP parse).
+    std::vector<bcos::protocol::Transaction::ConstPtr> transactions;
+    transactions.reserve(rawTxBytes.size());
+    for (auto const& raw : rawTxBytes)
+    {
+        auto tx = buildBlockTx(raw, fixture.hashImpl);
+        if (tx == nullptr)
+        {
+            BOOST_ERROR(id << ": buildBlockTx failed");
+            return;
+        }
+        transactions.push_back(tx);
+    }
+    std::vector<op::DepositTx> deposits;
+    deposits.reserve(rawTxBytes.size());
+    for (std::size_t i = 0; i < rawTxBytes.size(); ++i)
+        if (rawTxBytes[i][0] == static_cast<uint8_t>(op::kDepositTxType))
+            deposits.push_back(
+                bcos::executor_v1::opstack::OpstackExecutor::depositFromTransaction(*transactions[i]));
+
+    // Route A: OpScheduler.executeBlock — view lifecycle owned by the skeleton (fork/pushView
+    // inside it). The announced header carries the golden commitments (filled by the caller), so
+    // the unconditional six-way verify is the FISCO-vs-op-geth gate.
+    engine::OpExecuteBlockResult resultA;
+    bcos::Error::Ptr routeAErr;
+    try
+    {
+        // Block assembly: extraTransactionBytes = full envelope (SEV-8, overridden by
+        // buildBlockTx).
+        auto block = fixture.blockFactory->createBlock();
+        block->setBlockHeader(header);
+        for (const auto& raw : rawTxBytes)
+        {
+            auto tx = buildBlockTx(raw, fixture.hashImpl);
+            if (tx == nullptr)
+            {
+                BOOST_ERROR(id << ": buildBlockTx failed (opEnvelopeToTars nullopt)");
+                return;
+            }
+            block->appendTransaction(std::move(tx));
+        }
+
+        auto opScheduler = std::make_shared<bcos::executor_v1::opstack::OpScheduler<MLS>>(
+            fixture.receiptFactory, fixture.hashImpl, kChainId, forkFlagsFor(jovian),
+            fixture.blockFactory, fixture.multiLayerStorage, /*ledger=*/nullptr,
+            fixture.ioServicePool);
+
+        opScheduler->executeBlock(block, /*verify=*/true,
+            [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr, bool) {
+                routeAErr = std::move(e);
+            });
+        if (routeAErr)
+        {
+            // isthmus/jovian: any executeBlock error is a real failure (FISCO must reproduce
+            // op-geth). pre-isthmus: a six-way commitment mismatch is the expected fork-mismatch
+            // divergence → soft REPORT; any other error is a real bug.
+            const std::string msg = routeAErr->errorMessage();
+            const bool sixWayMismatch =
+                msg.find("six-way commitment mismatch") != std::string::npos;
+            if (!isIsthmusJovian && sixWayMismatch)
+            {
+                ++stats.mismatch;
+                std::cout << "  GOLDEN-REPORT " << id
+                          << " route A rejected at six-way verify (pre-isthmus fork mismatch): "
+                          << msg << "\n";
+                return;
+            }
+            BOOST_ERROR(id << ": route A executeBlock failed: " << msg);
+            return;
+        }
+        auto peeked = opScheduler->peekExecuteResult();
+        if (!peeked)
+        {
+            BOOST_ERROR(id << ": route A executeBlock produced no result");
+            return;
+        }
+        resultA = std::move(*peeked);
+    }
+    catch (const std::exception& e)
+    {
+        BOOST_ERROR(id << ": route A threw: " << e.what());
+        return;
+    }
+    catch (...)
+    {
+        const auto* excType = abi::__cxa_current_exception_type();
+        BOOST_ERROR(id << ": route A threw (typed catch bypassed, exception type: "
+                       << (excType ? excType->name() : "<unknown>") << ")");
+        return;
+    }
+
+    // Route A succeeded — six-way verify passed against the announced golden commitments.
+    // Receipt sanity + golden three-way + /sys tripwire + has_storage scan.
+    try
+    {
+        if (resultA.receipts.size() != rawTxBytes.size())
+            BOOST_ERROR(id << ": receipt count mismatch: got " << resultA.receipts.size()
+                           << " want " << rawTxBytes.size());
+        BOOST_CHECK_GT(resultA.gasUsed, 0);
+
+        reportGolden(id, vec, resultA.stateRoot, greenGuard, hardGolden, stats);
+        checkSysTripwire(id, vec);
+        hasStorageScan(id, deposits);
+
+        // Chain inheritance: route A's authoritative post-state was already pushed into MLS by the
+        // skeleton's pushView; only mergeBackStorage to persist (do not pushView again).
+        bcos::task::syncWait(fixture.multiLayerStorage.mergeBackStorage());
+    }
+    catch (const std::exception& e)
+    {
+        BOOST_ERROR(id << ": tail threw: " << e.what());
+    }
+    catch (...)
+    {
+        const auto* excType = abi::__cxa_current_exception_type();
+        BOOST_ERROR(id << ": tail threw (typed catch bypassed, exception type: "
+                       << (excType ? excType->name() : "<unknown>") << ")");
+    }
+}
+
+/// Single-block vector: seedPreState → build the announced header (golden commitments) →
+/// runBlockEquivalence. golden is loaded manually from .golden.json (isJovianVector throws for
+/// pre-isthmus, so loadVectorSample cannot be used).
+void runSingleVector(const std::string& id, const JsonValue& vec, Fixture& fixture,
+    bool greenGuard, GoldenStats& stats)
+{
+    w6test::GoldenSample sample;
+    sample.id = id;
+    sample.vector = vec;
+    sample.golden =
+        w6test::loadJsonFile(std::string(OP_T8N_GOLDEN_ENGINE_DIR) + "/" + id + ".golden.json");
+    const bool jovian = (jAt(jAt(vec, "_info"), "hardfork").asString() == "jovian");
+    sample.jovian = jovian;
+    try
+    {
+        w6test::seedPreState(fixture.multiLayerStorage, vec["pre"]);
+    }
+    catch (const std::exception& e)
+    {
+        BOOST_ERROR(id << ": seedPreState threw: " << e.what());
+        return;
+    }
+    catch (...)
+    {
+        const auto* excType = abi::__cxa_current_exception_type();
+        BOOST_ERROR(id << ": seedPreState threw (typed catch bypassed, exception type: "
+                       << (excType ? excType->name() : "<unknown>") << ")");
+        return;
+    }
+    bcos::protocol::BlockHeader::Ptr header;
+    // Single-block vector header: isthmus/jovian use decodeGoldenHeader (golden authoritative
+    // op-geth header); pre-isthmus (ecotone/fjord/granite) encodedHeaderHex would throw under
+    // decodeOpHeader's strict 21-field decode (RTTI-bypass runtime_error, verified empirically),
+    // so fall back to buildHeaderFromEnv (same source as chain). Both execute under the same cfg
+    // (configAt → isthmusConfig); the golden three-way REPORTs a fork mismatch for pre-isthmus
+    // (soft) and the six-way verify is expected to reject them (see runBlockEquivalence).
+    const auto hardfork = jAt(jAt(vec, "_info"), "hardfork").asString();
+    try
+    {
+        if (hardfork == "isthmus" || hardfork == "jovian")
+            header = w6test::decodeGoldenHeader(sample);
+        else
+            header = buildHeaderFromEnv(jAt(vec, "env"));
+    }
+    catch (const std::exception& e)
+    {
+        BOOST_ERROR(id << ": decodeGoldenHeader threw: " << e.what());
+        return;
+    }
+    catch (...)
+    {
+        const auto* excType = abi::__cxa_current_exception_type();
+        BOOST_ERROR(id << ": decodeGoldenHeader threw (typed catch bypassed, exception type: "
+                       << (excType ? excType->name() : "<unknown>") << ")");
+        return;
+    }
+    // golden rawTransactions (single-block vector: deposit is already a 0x7E envelope, normal
+    // already a 0x02 envelope).
+    std::vector<bcos::bytes> rawTxBytes;
+    for (const auto& raw : sample.golden["rawTransactions"])
+        rawTxBytes.push_back(bcos::fromHex(raw.asString()));
+    // The announced header carries the golden commitments (route A's six-way verify = the
+    // FISCO-vs-op-geth gate).
+    fillAnnouncedHeaderFromGolden(header, vec, rawTxBytes);
+    // Named-lvalue first (see runBlockEquivalence's fork-parity comment): GCC-14
+    // -Wdangling-reference false positive on a prvalue OpForkFlags argument.
+    const auto forkFlags = forkFlagsFor(jovian);
+    const auto& vectorCfg = op::configAt(forkFlags);
+    runBlockEquivalence(id, fixture, header, rawTxBytes, vec, jovian, vectorCfg, greenGuard, stats);
+}
+
+/// Chain vector: per-block runBlockEquivalence with route A mergeView inheritance (authoritative
+/// path). Block 0 pre is explicit; later blocks inherit the previous block's route A post-state.
+/// Each block's announced header carries its golden commitments (isthmus/jovian → the six-way
+/// verify is a hard FISCO-vs-op-geth gate).
+void runChainVector(const std::string& id, const JsonValue& vec, Fixture& fixture,
+    GoldenStats& stats)
+{
+    const auto& blocks = jAt(vec, "blocks");
+    for (std::size_t i = 0; i < blocks.size(); ++i)
+    {
+        const auto& blk = blocks[static_cast<Json::ArrayIndex>(i)];
+        const std::string bid = id + "[" + std::to_string(i) + "]";
+        if (blk.isMember("pre") && !blk["pre"].isNull())
+            w6test::seedPreState(fixture.multiLayerStorage, blk["pre"]);
+        const auto header = buildHeaderFromEnv(jAt(blk, "env"));
+        const auto rawTxBytes = buildRawTxBytes(blk, bid);
+        fillAnnouncedHeaderFromGolden(header, blk, rawTxBytes);
+        const bool jovian = (jAt(jAt(blk, "_info"), "hardfork").asString() == "jovian");
+        const auto forkFlags = forkFlagsFor(jovian);  // named-lvalue first (GCC-14 dangling false positive)
+        const auto& vectorCfg = op::configAt(forkFlags);
+        runBlockEquivalence(bid, fixture, header, rawTxBytes, blk, jovian, vectorCfg,
+            /*greenGuard=*/false, stats);
+        ++stats.chainBlocks;
+    }
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpDualPathEquivalence)
+
+BOOST_AUTO_TEST_CASE(Vectors)
+{
+    const fs::path vectorsDir = OP_T8N_VECTORS_DIR;
+    BOOST_REQUIRE_MESSAGE(fs::is_directory(vectorsDir), vectorsDir);
+
+    // Iterate the directory: skip the invalid_ prefix and _op_expected.reject; chain goes
+    // through the blocks[] branch.
+    std::vector<std::string> names;
+    for (const auto& entry : fs::directory_iterator(vectorsDir))
+    {
+        if (entry.is_regular_file() && entry.path().extension() == ".json")
+        {
+            const auto name = entry.path().filename().string();
+            if (name.rfind("invalid_", 0) == 0)
+                continue;
+            names.push_back(name);
+        }
+    }
+    std::sort(names.begin(), names.end());
+
+    GoldenStats stats;
+    for (const auto& name : names)
+    {
+        try
+        {
+            std::ifstream input(vectorsDir / name);
+            const auto doc = jParse(input);
+            std::string id;
+            const JsonValue* vec = nullptr;
+            for (const auto& key : doc.getMemberNames())
+            {
+                if (key == "_op_test_vectors")
+                    continue;
+                if (vec != nullptr)
+                    throw std::runtime_error("more than one vector object in file");
+                id = key;
+                vec = &doc[key];
+            }
+            if (vec == nullptr)
+                throw std::runtime_error("no vector object in file");
+            if (id != fs::path(name).stem().string())
+                throw std::runtime_error("vector id '" + id + "' != filename stem");
+
+            Fixture fixture;
+            if (vec->isMember("blocks"))
+            {
+                runChainVector(id, *vec, fixture, stats);
+                continue;
+            }
+            if (vec->isMember("_op_expected") && (*vec)["_op_expected"].isMember("reject"))
+                continue;  // reject vectors are consumed by OpT8nReplay/OpNewPayloadRpcE2e;
+                           // harness skips them
+            ++stats.flat;
+            const bool greenGuard = (id.find("deposit_basefee_observer") != std::string::npos);
+            runSingleVector(id, *vec, fixture, greenGuard, stats);
+        }
+        catch (const std::exception& e)
+        {
+            BOOST_ERROR(name << ": " << e.what());
+        }
+        catch (...)
+        {
+            const auto* excType = abi::__cxa_current_exception_type();
+            BOOST_ERROR(name << ": exception escaped typed catch (exception type: "
+                             << (excType ? excType->name() : "<unknown>")
+                             << ") diag: " << boost::current_exception_diagnostic_information());
+        }
+    }
+
+    // green guard + golden summary report.
+    std::cout << "single-path summary: flat=" << stats.flat << " chainBlocks=" << stats.chainBlocks
+              << " goldenMatch=" << stats.match << " goldenMismatch=" << stats.mismatch
+              << " greenGuard=" << stats.greenGuardOk << "\n";
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpEngineBranchSmokeTest.cpp
+++ b/opstack-executor/tests/OpEngineBranchSmokeTest.cpp
@@ -1,0 +1,139 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpEngineBranchSmokeTest — compile-and-run verification that the ported engine OP branch
+// (`EngineServiceImpl`'s `handleOpNewPayload` / `runOpNewPayloadSteps` / `registerOpBlock`, only
+// instantiated when `c_opMode` is true) type-checks against `OpSchedulerSeam` on this branch.
+// The full branch-by-branch suite lives on the source branch (EngineOpBranchTest.cpp); this file
+// pins the one thing the two normal build targets cannot: an instantiation with an OP-mode
+// scheduler, which forces the entire `if constexpr (c_opMode)` body to compile. The -38005
+// pre-Isthmus gate is the runtime assertion (the version gate sits before the classification
+// barrier, so it throws `UnsupportedFork`), but the compile-time instantiation of the body is
+// the point.
+#include "engine/bcos-engine/EngineServiceImpl.h"
+
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/testutils/faker/FakeBlock.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-framework/transaction-executor/TransactionExecutor.h>
+#include <bcos-framework/transaction-scheduler/TransactionScheduler.h>
+#include <bcos-task/Wait.h>
+#include <opstack-executor/OpSchedulerSeam.h>
+#include <boost/test/unit_test.hpp>
+#include <stdexcept>
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+namespace
+{
+// Per-file local fixture copy (same convention as the source branch's test files).
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& storage) noexcept : m_storage(storage) {}
+    Storage& open() & { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const& /*unused*/) & { std::abort(); }
+    void createCheckpoint(Storage& /*unused*/, CheckpointName const& /*unused*/) {}
+    void deleteCheckpoint(CheckpointName const& /*unused*/) {}
+    [[nodiscard]] std::optional<CheckpointName> latestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+    [[nodiscard]] std::optional<CheckpointName> oldestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+};
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+using BackendMemStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+    std::hash<StateKey>>;
+using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, BackendMemStorage>;
+using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
+using ViewType = typename MLS::ViewType;
+
+struct StubMemPool
+{
+};
+
+struct StubExecutor
+{
+    template <class Storage>
+    struct ExecuteContext
+    {
+        bcos::task::Task<void> prepare() { co_return; }
+        bcos::task::Task<void> execute() { co_return; }
+        bcos::task::Task<bcos::protocol::TransactionReceipt::Ptr> finish() { co_return nullptr; }
+    };
+
+    template <class Storage>
+    bcos::task::Task<bcos::protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
+        const bcos::protocol::BlockHeader&, const bcos::protocol::Transaction&, int,
+        const bcos::ledger::LedgerConfig&, bool)
+    {
+        co_return nullptr;
+    }
+
+    template <class Storage>
+    bcos::task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&,
+        const bcos::protocol::BlockHeader&, const bcos::protocol::Transaction&, int,
+        const bcos::ledger::LedgerConfig&, bool)
+    {
+        co_return ExecuteContext<Storage>{};
+    }
+};
+
+using OpEngine = bcos::engine::EngineServiceImpl<StubMemPool, MLS, StubExecutor,
+    bcos::evm::engine::OpSchedulerSeam<ViewType>>;
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpEngineBranchSmokeSuite)
+
+BOOST_AUTO_TEST_CASE(OpModeInstantiatesAndGatesV4)
+{
+    // The compiler instantiating this composition is the test: `c_opMode` becomes true, which
+    // forces `handleOpNewPayload` (and through it `runOpNewPayloadSteps` / `registerOpBlock`) to
+    // be instantiated. A type conflict anywhere in the OP branch body fails the build here.
+    BackendMemStorage backendStorage;
+    CheckpointBackend checkpointBackend(backendStorage);
+    MLS storage(checkpointBackend);
+
+    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(bcos::evm::opstack::OpForkFlags{});
+    StubMemPool memPool;
+    StubExecutor executor;
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+
+    // The OP composition root relaxes the version-gate upper bound to V4 (spec §6.3, ruling B1);
+    // the generic root's V3 default would refuse version 4 before the OP branch's -38005 gate.
+    OpEngine engine(memPool, storage, executor, scheduler, blockFactory,
+        /*ledger=*/nullptr, bcos::engine::c_defaultBlockTxCountLimit,
+        static_cast<std::uint32_t>(bcos::engine::ApiVersion::V4), /*delegate=*/nullptr);
+
+    // A V3 newPayload hits the -38005 version gate (Isthmus+ payloads require V4; the gate lives
+    // outside the classification barrier), proving the OP branch is wired end-to-end. Fork
+    // selection is feature-driven (feature_op_jovian) since the feature-flag refactor — there is
+    // no pre-Isthmus TIMESTAMP rejection anymore; OP mode itself is the Isthmus+ admission.
+    bcos::engine::NewPayloadRequest request;
+    request.executionPayload.timestamp = 1000;  // any timestamp — not a fork selector
+    request.executionPayload.blockNumber = 1;
+    request.executionPayload.rawTransactions = std::vector<bcos::bytes>{};
+    request.executionPayload.withdrawals = std::vector<bcos::engine::WithdrawalV1>{};
+    request.executionPayload.withdrawalsRoot = bcos::h256{};
+    request.executionPayload.excessBlobGas = bcos::u256(0);
+    request.executionPayload.blobGasUsed = bcos::u256(0);
+    request.parentBeaconBlockRoot = bcos::h256{};
+
+    BOOST_CHECK_THROW(
+        bcos::task::syncWait(engine.newPayload(request, 3)), bcos::engine::UnsupportedFork);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpL1EdgeGateTest.cpp
+++ b/opstack-executor/tests/OpL1EdgeGateTest.cpp
@@ -1,0 +1,314 @@
+// bcos-evm/test/opstack/OpL1EdgeGateTest.cpp
+// L1 edge gate: B-5b Jovian DA-footprint rejection + D-4 validate-snapshot contract.
+//
+// B-5b: engine_newPayloadV4 whose blobGasUsed (= the Jovian DA footprint header slot) exceeds
+//       gasLimit must be rejected INVALID in Step 2 static validation, BEFORE parentKnown /
+//       execution -- so no seedPreState / registerVerifiedBlock is needed. The rejection is
+//       fork-gated on Jovian, so the fixture uses jovian fork timestamps.
+// D-4:  opValidate freezes the OpFeeParams into OpTxProperties.fee (the snapshot). opTransition
+//       must price and receipt the tx from that snapshot, NOT by re-reading the L1Block storage
+//       slots (which may have moved on to a different fee F' by transition time).
+//
+// B-5b reuses the W6 harness fixture pattern (OpNewPayloadRpcE2eTest.cpp). That fixture lives in
+// an anonymous namespace and is TU-local, so it is copied here (only the parts this file needs).
+// D-4 follows the OpTransitionTest test::TestState pattern (no harness / MLS needed).
+#include "support/GoldenSample.h"
+#include <bcos-concepts/ByteBuffer.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <opstack-executor/OpCommon.h>
+#include <opstack-executor/OpSchedulerSeam.h>
+// EngineHelper.h's parseNewPayloadRequest declaration references
+// bcos::protocol::TransactionFactory&, but EngineHelper.h does not declare that type
+// itself (production relies on bcos-rpc unity-build include order). A single-TU direct
+// compile must include TransactionFactory.h first or the declaration fails
+// (OpNewPayloadRpcE2eTest.cpp:20 pattern).
+#include <bcos-framework/protocol/TransactionFactory.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <engine/bcos-engine/EngineServiceImpl.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+
+// D-4: TestState pattern (following OpTransitionTest.cpp)
+#include "OpPredeploysSeed.h"
+#include "OpTestReceiptFactory.h"
+#include "TestPrinters.h"
+#include <bcos-evm/opstack/OpFeeParams.h>
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <evmone/evmone.h>
+#include <test/utils/test_state.hpp>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+// D-4's TestState/opstack names (following OpTransitionTest.cpp:16-20)
+using namespace bcos::evm::opstack;
+using namespace bcos::evm::opstack::testutil;
+using namespace evmone;
+using namespace evmc::literals;
+using intx::operator""_u256;
+
+namespace
+{
+// ── storage fixture (copy of OpNewPayloadRpcE2eTest's anonymous-namespace fixture; an
+//    anonymous namespace cannot cross TUs, so B-5b builds its own) ──
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& storage) noexcept : m_storage(storage) {}
+    Storage& open() & { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const&) & { std::abort(); }
+    void createCheckpoint(Storage&, CheckpointName const&) {}
+    void deleteCheckpoint(CheckpointName const&) {}
+    [[nodiscard]] std::optional<CheckpointName> latestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+    [[nodiscard]] std::optional<CheckpointName> oldestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+};
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+using BackendMemStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+    std::hash<StateKey>>;
+using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, BackendMemStorage>;
+using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
+using ViewType = typename MLS::ViewType;
+
+struct StubMemPool
+{
+};
+struct StubExecutor
+{
+    template <class Storage>
+    struct ExecuteContext
+    {
+        bcos::task::Task<void> prepare() { co_return; }
+        bcos::task::Task<void> execute() { co_return; }
+        bcos::task::Task<bcos::protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
+    };
+    template <class Storage>
+    bcos::task::Task<bcos::protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
+        const bcos::protocol::BlockHeader&, const bcos::protocol::Transaction&, int,
+        const bcos::ledger::LedgerConfig&, bool)
+    {
+        co_return nullptr;
+    }
+    template <class Storage>
+    bcos::task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&,
+        const bcos::protocol::BlockHeader&, const bcos::protocol::Transaction&, int,
+        const bcos::ledger::LedgerConfig&, bool)
+    {
+        co_return ExecuteContext<Storage>{};
+    }
+};
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+bcos::protocol::BlockFactory::Ptr makeBlockFactory()
+{
+    auto cryptoSuite = makeCryptoSuite();
+    auto blockHeaderFactory =
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite);
+    auto transactionFactory =
+        std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    auto receiptFactory =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite);
+    return std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+        cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory);
+}
+
+bcos::protocol::TransactionReceiptFactory::Ptr makeReceiptFactory()
+{
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+}
+
+constexpr uint64_t kChainId = 0x2105;
+
+bcos::evm::opstack::OpForkFlags forkFlagsFor(bool jovian)
+{
+    return bcos::evm::opstack::OpForkFlags{.jovianActive = jovian};
+}
+
+using EngineOpScheduler = bcos::evm::engine::OpSchedulerSeam<ViewType>;
+using OpEngineService =
+    bcos::engine::EngineServiceImpl<StubMemPool, MLS, StubExecutor, EngineOpScheduler>;
+
+struct OpE2eFixture
+{
+    BackendMemStorage backendStorage;
+    CheckpointBackend checkpointBackend{backendStorage};
+    MLS multiLayerStorage{checkpointBackend};
+    StubMemPool memPool;
+    StubExecutor executor;
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory{makeReceiptFactory()};
+    EngineOpScheduler scheduler;
+    bcos::protocol::BlockFactory::Ptr blockFactory{makeBlockFactory()};
+    OpEngineService service;
+
+    explicit OpE2eFixture(bcos::evm::opstack::OpForkFlags forkFlags)
+      : scheduler(forkFlags),
+        service(memPool, multiLayerStorage, executor, scheduler, blockFactory,
+            /*ledger=*/nullptr, bcos::engine::c_defaultBlockTxCountLimit, /*maxEngineVersion=*/4,
+            /*delegate=*/nullptr)
+    {}
+};
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpL1EdgeGateSuite)
+
+// B-5b: under Jovian, blobGasUsed (the DA-footprint slot) > gasLimit -> Step 2 static
+// validation INVALID + validationError contains "DA footprint". The DA check is gated on
+// jovianActive (EngineServiceImpl.cpp:442), so the fixture must use jovian timestamps;
+// Step 2 runs before parentKnown/execution, so no seedPreState / registerVerifiedBlock needed.
+BOOST_AUTO_TEST_CASE(DAFootprintExceedsGasLimitRejected)
+{
+    auto sample = w6test::loadVectorSample("jovian_da_mix");
+    auto params = w6test::makeParamsJson(sample);
+    // Read the golden header's gasLimit; override blobGasUsed = gasLimit+1
+    const auto gasLimit = w6test::decodeGoldenHeader(sample)->gasLimit();
+    // Warning: do not use (gasLimit+1).str(16) — decimal digits are not hex
+    // (GoldenSample.h:85-90 warns); quantityOf is correct.
+    params[0u]["blobGasUsed"] = w6test::quantityOf(gasLimit + 1);
+
+    auto fixture = std::make_unique<OpE2eFixture>(forkFlagsFor(true));
+    auto request = bcos::rpc::parseNewPayloadRequest(params, bcos::engine::ApiVersion::V4);
+    auto status = bcos::task::syncWait(fixture->service.newPayload(request, 4));
+    // PayloadValidationStatus is an enum class without operator<<; must compare via
+    // static_cast<int>.
+    BOOST_CHECK_EQUAL(static_cast<int>(status.status),
+        static_cast<int>(bcos::engine::PayloadValidationStatus::Invalid));
+    BOOST_REQUIRE(status.validationError.has_value());
+    // Warning: the real string includes (blobGasUsed); check "DA footprint" (not "DA footprint
+    // exceeds").
+    BOOST_CHECK(status.validationError->find("DA footprint") != std::string::npos);
+}
+
+// D-4: opValidate injects fee F -> props.fee frozen snapshot -> mutate L1Block slot1 to a
+// markedly different F' -> opTransition still prices/receipts from props (F), not by
+// re-reading storage (F'). Signature follows OpTransitionTest.cpp's
+// OperatorFeeConservesWhenCfgDisagreesWithProps (:337-397); the difference is that that
+// case mutates cfg, this one mutates a storage slot.
+BOOST_AUTO_TEST_CASE(TransitionUsesValidateSnapshot)
+{
+    constexpr auto sender = 0x00000000000000000000000000000000000000aa_address;
+    constexpr auto dest = 0x00000000000000000000000000000000000000bb_address;
+    auto vm = evmc::VM{evmc_create_evmone()};
+    test::TestState ts;
+    ts[sender] = {.nonce = 0,
+        .balance = 340282366920938463463374607431768211456_u256,
+        .storage = {},
+        .code = {}};
+    ts[dest] = {};
+    // Warning: seedOpPredeploys returns void; cannot auto ts = seedOpPredeploys(...)
+    seedOpPredeploys(ts);
+    test::TestBlockHashes hashes;
+
+    state::BlockInfo block;
+    block.number = 1;
+    block.gas_limit = 30000000;
+    block.base_fee = 7;
+    block.coinbase = OP_SEQUENCER_FEE_VAULT;
+
+    state::Transaction tx;
+    tx.type = state::Transaction::Type::eip1559;
+    tx.sender = sender;
+    tx.to = dest;
+    tx.gas_limit = 100000;
+    tx.max_gas_price = 1000;
+    tx.max_priority_gas_price = 10;
+    tx.value = intx::uint256{0};
+    tx.nonce = 0;
+
+    // Inject fee F: l1_base_fee = 1 gwei (non-zero), base_fee_scalar 1100 -> props.l1_cost
+    // non-zero.
+    OpFeeParams F{.l1_base_fee = 1000000000_u256,
+        .base_fee_scalar = 1100,
+        .blob_base_fee_scalar = 0,
+        .blob_base_fee = 0_u256,
+        .operator_fee_scalar = 0,
+        .operator_fee_constant = 0};
+    std::vector<uint8_t> env(120, 0x11);  // non-empty envelope: flz non-zero -> l1_cost non-zero
+
+    // opValidate returns std::variant<OpTxProperties, std::error_code>; must
+    // std::get<OpTxProperties>.
+    const auto v =
+        opValidate(ts, block, tx, {env.data(), env.size()}, isthmusConfig(), F, 30000000);
+    BOOST_REQUIRE(std::holds_alternative<OpTxProperties>(v));
+    const auto& props = std::get<OpTxProperties>(v);
+    BOOST_REQUIRE_MESSAGE(props.l1_cost > intx::uint256{0}, "test is vacuous unless l1_cost > 0");
+
+    // OpFeeParams has no operator== (non-defaulted aggregate, not generated in C++20) -> compare
+    // the snapshot to the injected values field-by-field.
+    BOOST_CHECK(props.fee.l1_base_fee == F.l1_base_fee);
+    BOOST_CHECK(props.fee.base_fee_scalar == F.base_fee_scalar);
+    BOOST_CHECK(props.fee.blob_base_fee_scalar == F.blob_base_fee_scalar);
+    BOOST_CHECK(props.fee.blob_base_fee == F.blob_base_fee);
+    BOOST_CHECK(props.fee.operator_fee_scalar == F.operator_fee_scalar);
+    BOOST_CHECK(props.fee.operator_fee_constant == F.operator_fee_constant);
+    BOOST_CHECK(props.fee.da_footprint_gas_scalar == F.da_footprint_gas_scalar);
+
+    // Mutate slot1 (the l1_base_fee slot) to a markedly different F': 7 vs 1e9. If
+    // opTransition re-read storage, l1_cost would shrink to ~7/1e9 and the receipt l1_fee
+    // assertion would go red (slot3 packed mutation is fiddly; a single slot1 change suffices).
+    auto key = [](uint8_t s) {
+        evmc::bytes32 k{};
+        k.bytes[31] = s;
+        return k;
+    };
+    auto low8 = [](uint64_t v) {
+        evmc::bytes32 w{};
+        for (int i = 0; i < 8; ++i)
+            w.bytes[31 - i] = static_cast<uint8_t>(v >> (8 * i));
+        return w;
+    };
+    ts[OP_L1_BLOCK].storage[key(1)] = low8(7);  // F'.l1_base_fee = 7
+
+    // opTransition consumes props (does not re-read storage); signature per OpTransition.h:134-139.
+    evmone::state::StateDiff diff;
+    const auto txR = opTransition(
+        ts, block, hashes, tx, isthmusConfig(), vm, props, 1234, kOpTestReceiptFactory, diff);
+    BOOST_REQUIRE_EQUAL(txR->status(), 0);
+
+    // Receipt opStackMeta l1_fee == value computed from F (props.l1_cost), not F'
+    // (following OpTransitionTest.cpp:146-149).
+    const auto& meta = txR->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->l1_fee.has_value());
+    BOOST_CHECK_EQUAL(*meta->l1_fee, bcosU256FromIntx(props.l1_cost));
+    // Strengthen: l1_gas_price likewise comes from the F snapshot, not re-read storage
+    // (deriveOpReceiptMeta OpTransition.cpp:214).
+    BOOST_REQUIRE(meta->l1_gas_price.has_value());
+    BOOST_CHECK_EQUAL(*meta->l1_gas_price, bcosU256FromIntx(F.l1_base_fee));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpNewPayloadRpcE2eTest.cpp
+++ b/opstack-executor/tests/OpNewPayloadRpcE2eTest.cpp
@@ -1,0 +1,1375 @@
+// bcos-evm/test/opstack/OpNewPayloadRpcE2eTest.cpp
+// L2 end-to-end real-chain comparison: real JSON params ->
+// EngineHelper::parseNewPayloadRequest(V4) -> EngineService<OpSchedulerSeam>.newPayload(4)
+// -> executeOpBlock -> seven assertions vs golden. The fixture composition mirrors the
+// val-loop EngineNewPayloadGateTest GateFixture (member order storage->memPool->executor->
+// receiptFactory->scheduler->blockFactory->service).
+#include "support/GoldenSample.h"
+#include "support/SeedPreState.h"
+#include <bcos-concepts/ByteBuffer.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <opstack-executor/OpCommon.h>
+#include <opstack-executor/OpScheduler.h>
+#include <opstack-executor/OpSchedulerSeam.h>
+// EngineHelper.h's parseNewPayloadRequest declaration references
+// bcos::protocol::TransactionFactory&, but EngineHelper.h does not declare that type
+// itself (production relies on bcos-rpc unity-build include order). A single-TU
+// direct compile must include TransactionFactory.h first or the declaration fails.
+#include <bcos-framework/protocol/TransactionFactory.h>
+#include <bcos-ledger/Ledger.h>  // real bcos::ledger::Ledger for the delegate's commit hook
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-table/src/LegacyStorageWrapper.h>  // LegacyStorageWrapper<BackendMemStorage>
+#include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/IOServicePool.h>
+#include <engine/bcos-engine/EngineServiceImpl.h>
+#include <json/json.h>
+#include <boost/lexical_cast.hpp>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <fstream>
+#include <set>
+#include <string>
+#include <vector>
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+namespace
+{
+
+// ── storage fixture (same as the Task 2 tests) ──
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& storage) noexcept : m_storage(storage) {}
+    Storage& open() & { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const&) & { std::abort(); }
+    void createCheckpoint(Storage&, CheckpointName const&) {}
+    void deleteCheckpoint(CheckpointName const&) {}
+    [[nodiscard]] std::optional<CheckpointName> latestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+    [[nodiscard]] std::optional<CheckpointName> oldestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+};
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+using BackendMemStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+    std::hash<StateKey>>;
+using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, BackendMemStorage>;
+using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
+using ViewType = typename MLS::ViewType;
+
+// ── Composition-root stand-ins (OP mode bypasses memPool/executor) ──
+struct StubMemPool
+{
+};
+struct StubExecutor
+{
+    template <class Storage>
+    struct ExecuteContext
+    {
+        bcos::task::Task<void> prepare() { co_return; }
+        bcos::task::Task<void> execute() { co_return; }
+        bcos::task::Task<bcos::protocol::TransactionReceipt::Ptr> finish() { co_return {}; }
+    };
+    template <class Storage>
+    bcos::task::Task<bcos::protocol::TransactionReceipt::Ptr> executeTransaction(Storage&,
+        const bcos::protocol::BlockHeader&, const bcos::protocol::Transaction&, int,
+        const bcos::ledger::LedgerConfig&, bool)
+    {
+        co_return nullptr;
+    }
+    template <class Storage>
+    bcos::task::Task<ExecuteContext<Storage>> createExecuteContext(Storage&,
+        const bcos::protocol::BlockHeader&, const bcos::protocol::Transaction&, int,
+        const bcos::ledger::LedgerConfig&, bool)
+    {
+        co_return ExecuteContext<Storage>{};
+    }
+};
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+bcos::protocol::BlockFactory::Ptr makeBlockFactory()
+{
+    auto cryptoSuite = makeCryptoSuite();
+    auto blockHeaderFactory =
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite);
+    auto transactionFactory =
+        std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    auto receiptFactory =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite);
+    return std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+        cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory);
+}
+
+bcos::protocol::TransactionReceiptFactory::Ptr makeReceiptFactory()
+{
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+}
+
+constexpr uint64_t kChainId = 0x2105;
+
+bcos::evm::opstack::OpForkFlags forkFlagsFor(bool jovian)
+{
+    return bcos::evm::opstack::OpForkFlags{.jovianActive = jovian};
+}
+
+using EngineOpScheduler = bcos::evm::engine::OpSchedulerSeam<ViewType>;
+using OpEngineService =
+    bcos::engine::EngineServiceImpl<StubMemPool, MLS, StubExecutor, EngineOpScheduler>;
+
+/// Seed the SYS_TABLES meta-rows for the ledger SYS tables (each uses the SYS_VALUE field,
+/// Ledger.cpp buildGenesisBlock). The delegate's commit hook runs prewriteBlockToBuffer, whose
+/// asyncPrewriteBlock ends with asyncGetTotalTransactionCount opening SYS_CURRENT_STATE through
+/// the Ledger's OWN m_stateStorage (here: a LegacyStorageWrapper over the MLS backend). Without
+/// the SYS_TABLES row the open fails and the whole asyncPrewriteBlock errors out. The rows sort
+/// before the /apps/ account range, so stateRoot's visitAccounts scan is unaffected.
+void seedSysTables(MLS& multiLayerStorage)
+{
+    auto view = multiLayerStorage.fork();
+    view.newMutable();
+    constexpr std::string_view sysTables[] = {bcos::ledger::SYS_CURRENT_STATE,
+        bcos::ledger::SYS_HASH_2_TX, bcos::ledger::SYS_HASH_2_NUMBER,
+        bcos::ledger::SYS_NUMBER_2_HASH, bcos::ledger::SYS_NUMBER_2_BLOCK_HEADER,
+        bcos::ledger::SYS_NUMBER_2_TXS, bcos::ledger::SYS_HASH_2_RECEIPT,
+        bcos::ledger::SYS_BLOCK_NUMBER_2_NONCES};
+    for (auto const& table : sysTables)
+    {
+        bcos::storage::Entry e;
+        e.set(std::string(bcos::ledger::SYS_VALUE));
+        bcos::task::syncWait(bcos::storage2::writeOne(
+            view, StateKey{bcos::ledger::SYS_TABLES, std::string(table)}, std::move(e)));
+    }
+    bcos::task::syncWait(multiLayerStorage.mergeView(std::move(view)));
+}
+
+struct OpE2eFixture
+{
+    // Single-bucket CONCURRENT backend: seed/parent lands in the
+    // backend via mergeView, and stateRoot's range(SYS_TABLES) scan relies on the
+    // backend's RANGE_SEEK semantics. With multiple buckets (default
+    // hardware_concurrency*2+1), MemoryStorage's range only seeks bucket 0, so buckets
+    // 1+ return non-SYS_TABLES keys, visitAccounts breaks early, and stateRoot is empty.
+    // A single bucket keeps the range correct.
+    BackendMemStorage backendStorage{1};
+    CheckpointBackend checkpointBackend{backendStorage};
+    MLS multiLayerStorage{checkpointBackend};
+    StubMemPool memPool;
+    StubExecutor executor;
+    bcos::crypto::Hash::Ptr hashImpl;
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory;
+    EngineOpScheduler scheduler;  // engine seam SchedulerType (OpSchedulerSeam<ViewType>)
+    bcos::protocol::BlockFactory::Ptr blockFactory{makeBlockFactory()};
+    /// A real Ledger wired into the delegate's m_ledger (the commit hook now calls
+    /// prewriteBlockToBuffer; every newPayload VALID submission commits through the delegate).
+    /// prewriteBlockToBuffer writes through the commit hook's MutableStorage, so the Ledger's own
+    /// m_stateStorage is only read by asyncGetTotalTransactionCount (SYS_CURRENT_STATE) — the
+    /// seedSysTables call below makes that open succeed. LegacyStorageWrapper holds a reference;
+    /// backendStorage is declared first and outlives it. The engine service's own ledger stays
+    /// null (its local-payload persist path at EngineServiceImpl.h:714 is null-guarded and the
+    /// forkchoice tests depend on that branch staying inert).
+    std::shared_ptr<bcos::storage::LegacyStorageWrapper<BackendMemStorage>> legacyLedgerStorage;
+    std::shared_ptr<bcos::ledger::Ledger> ledger;
+    // Task 4: SchedulerSerialImpl (the delegate's per-tx driver) needs a live io pool.
+    bcos::IOServicePool::Ptr ioServicePool{std::make_shared<bcos::IOServicePool>(1)};
+    /// The engine's OP block-execution delegate (slot-3 OpScheduler<MLS>).
+    /// A single OpSchedulerSeam serves the seam SchedulerType (route A executeOpBlock retired);
+    /// OpScheduler holds no execution kernel — block execution is the delegate's route B.
+    std::shared_ptr<bcos::executor_v1::opstack::OpScheduler<MLS>> opDelegate;
+    OpEngineService service;
+
+    explicit OpE2eFixture(bcos::evm::opstack::OpForkFlags forkFlags)
+      : hashImpl(makeCryptoSuite()->hashImpl()),
+        receiptFactory(makeReceiptFactory()),
+        scheduler(forkFlags),
+        legacyLedgerStorage(
+            std::make_shared<bcos::storage::LegacyStorageWrapper<BackendMemStorage>>(
+                backendStorage)),
+        ledger(std::make_shared<bcos::ledger::Ledger>(blockFactory, legacyLedgerStorage, 1000)),
+        opDelegate(std::make_shared<bcos::executor_v1::opstack::OpScheduler<MLS>>(receiptFactory,
+            hashImpl, kChainId, forkFlags, blockFactory, multiLayerStorage, ledger, ioServicePool)),
+        service(memPool, multiLayerStorage, executor, scheduler, blockFactory,
+            /*ledger=*/nullptr, bcos::engine::c_defaultBlockTxCountLimit, /*maxEngineVersion=*/4,
+            opDelegate)
+    {
+        seedSysTables(multiLayerStorage);
+    }
+};
+
+/// Produced header: production-mapping reconstruction (val-loop GateFixture's
+/// productionHeaderOf pattern). `bcos::engine::detail::rebuildOpEthHeader`
+/// (EngineServiceImpl.cpp:470 or so: 17 fields verbatim from payload + txRoot + 3
+/// constants via applyOpHeaderConstants). OP block hash uses `opHeaderHash()` =
+/// keccak256(encodeOpHeader()), NOT BlockHeader::hash() (empty dataHash / factory
+/// TARS-order backfill).
+bcos::protocol::BlockHeader::Ptr productionHeaderOf(
+    bcos::protocol::BlockFactory::Ptr const& blockFactory,
+    bcos::engine::NewPayloadRequest const& request)
+{
+    auto const& payload = request.executionPayload;
+    const auto transactionsRoot = EngineOpScheduler::computeTxRoot(*payload.rawTransactions);
+    return bcos::engine::detail::rebuildOpEthHeader(blockFactory->blockHeaderFactory(), payload,
+        transactionsRoot, *request.parentBeaconBlockRoot);
+}
+
+/// Parent pre-registration: the OP path's step-3 parentKnown
+/// checks SYS_HASH_2_NUMBER. All 33 isolated vectors are block 1, so the parent must be
+/// pre-registered as a trusted genesis, otherwise newPayload returns SYNCING. The write
+/// encoding must match production: key = raw 32-byte hash, value = decimal number string
+/// (gate test registerVerifiedBlock, EngineNewPayloadGateTest.cpp:188-198).
+void registerVerifiedBlock(MLS& multiLayerStorage, bcos::h256 const& blockHash, int64_t number)
+{
+    auto view = multiLayerStorage.fork();
+    view.newMutable();
+    bcos::storage::Entry entry;
+    entry.set(boost::lexical_cast<std::string>(number));
+    bcos::task::syncWait(bcos::storage2::writeOne(view,
+        StateKey{bcos::ledger::SYS_HASH_2_NUMBER, bcos::concepts::bytebuffer::toView(blockHash)},
+        std::move(entry)));
+    // mergeBackStorage merges the oldest layer (FIFO).
+    // Drain the stack — parent pre-registration lands in the backend immediately, and
+    // with an empty stack before each block push, mergeView persists right away so the
+    // backend assertions can pass.
+    bcos::task::syncWait(multiLayerStorage.mergeView(std::move(view)));
+}
+
+// ── seven assertions ──
+void assertSevenFields(std::string const& id, bcos::protocol::BlockHeader::Ptr const& produced,
+    bcostars::protocol::BlockHeaderImpl::Ptr const& goldenHeader, bcos::h256 const& goldenBlockHash)
+{
+    // 1. blockHash: EthBlockHeader::computeHash = keccak256(rlpEncode) must equal
+    //    golden.blockHash (op-geth's block.Hash() = keccak(RLP(21 fields)) definition). The
+    //    3 post-merge constants are in the header (producer populates them).
+    // Warning: this repo's Boost.Test macros do not support `<< id << msg` chaining;
+    // uniformly use BOOST_CHECK_MESSAGE(id << msg).
+    BOOST_CHECK_MESSAGE(bcos::protocol::EthBlockHeader::computeHash(*produced) == goldenBlockHash,
+        id << ": blockHash");
+    BOOST_CHECK_MESSAGE(produced->stateRoot() == goldenHeader->stateRoot(), id << ": stateRoot");
+    BOOST_CHECK_MESSAGE(
+        produced->receiptsRoot() == goldenHeader->receiptsRoot(), id << ": receiptsRoot");
+    BOOST_CHECK_MESSAGE(
+        produced->withdrawalsRoot() == goldenHeader->withdrawalsRoot(), id << ": withdrawalsRoot");
+    BOOST_CHECK_MESSAGE(produced->gasUsed() == goldenHeader->gasUsed(), id << ": gasUsed");
+    BOOST_CHECK_MESSAGE(produced->txsRoot() == goldenHeader->txsRoot(), id << ": txRoot");
+    // Warning: bytesConstRef(RefDataContainer)'s operator== is a "pointer+length"
+    // shallow compare, not a content compare (RefDataContainer.h:84-87). produced/golden
+    // hold the same 256-byte bloom in different storage, so the pointers always differ —
+    // must use std::equal for byte-wise content compare (encodeOpHeader byte-level
+    // assertion already covers content; this keeps the seven-field slot separately).
+    BOOST_CHECK_MESSAGE(std::equal(produced->logsBloom().begin(), produced->logsBloom().end(),
+                            goldenHeader->logsBloom().begin(), goldenHeader->logsBloom().end()),
+        id << ": logsBloom");
+    // Main assertion: byte-exact equality of EthBlockHeader::rlpEncode (covers the full RLP
+    // encoding of all fields)
+    bcos::bytes producedEncoded, goldenEncoded;
+    bcos::protocol::EthBlockHeader(*produced).rlpEncode(producedEncoded);
+    bcos::protocol::EthBlockHeader(*goldenHeader).rlpEncode(goldenEncoded);
+    BOOST_CHECK_MESSAGE(producedEncoded == goldenEncoded, id << ": encodeOpHeader");
+}
+
+/// One vector end-to-end: seed pre -> register parent -> makeParamsJson ->
+/// parseNewPayloadRequest(V4) -> newPayload(4) -> assertions.
+void runGoldenVector(std::string const& id)
+{
+    auto sample = w6test::loadVectorSample(id);
+    auto fixture = std::make_unique<OpE2eFixture>(forkFlagsFor(sample.jovian));
+    w6test::seedPreState(fixture->multiLayerStorage, sample.vector["pre"]);
+    // Warning: parent pre-registration (gap A): without it -> SYNCING instead of VALID. parentHash
+    // is decoded from the golden header
+    const auto goldenHeader = w6test::decodeGoldenHeader(sample);
+    registerVerifiedBlock(fixture->multiLayerStorage, goldenHeader->parentInfo().blockHash, 0);
+
+    auto params = w6test::makeParamsJson(sample);
+    auto request = bcos::rpc::parseNewPayloadRequest(params, bcos::engine::ApiVersion::V4);
+
+    auto status = bcos::task::syncWait(fixture->service.newPayload(request, 4));
+    // Warning: PayloadValidationStatus is an enum class without operator<<; must compare
+    // via static_cast<int> (same as existing engine tests, e.g. EngineServiceTest.cpp:312).
+    BOOST_REQUIRE_MESSAGE(static_cast<int>(status.status) ==
+                              static_cast<int>(bcos::engine::PayloadValidationStatus::Valid),
+        id << ": expected VALID, got " << static_cast<int>(status.status)
+           << (status.validationError ? " : " + *status.validationError : ""));
+
+    // #19: after a VALID payload the head pointer must advance (same-view write).
+    {
+        auto headView = fixture->multiLayerStorage.fork();
+        const auto head = bcos::task::syncWait(
+            bcos::ledger::getCurrentBlockNumber(headView, bcos::ledger::fromStorage));
+        BOOST_CHECK_MESSAGE(head == request.executionPayload.blockNumber,
+            id << ": SYS_CURRENT_STATE head must equal the VALID payload's number, got " << head
+               << " want " << request.executionPayload.blockNumber);
+    }
+
+    // produced header (production-mapping reconstruction) + golden header (reuse the
+    // goldenHeader decoded above for parent registration; redeclaring it in the same
+    // block would be a compile error, caught by R2-A)
+    auto produced = productionHeaderOf(fixture->blockFactory, request);
+    const auto goldenBlockHash = bcos::h256(std::string(sample.golden["blockHash"].asString()));
+    assertSevenFields(id, produced, goldenHeader, goldenBlockHash);
+
+    // Plan-B write side: OP txs land in SYS_HASH_2_TX (tars encoding); s_eth_hash_2_rawtx
+    // is no longer written. newPayload's registerOpBlock converts each raw EIP-2718
+    // envelope to a tars Transaction and writes SYS_HASH_2_TX[txHash]
+    // (extraTransactionHash=txHash pins D4); the raw envelope is no longer stored in
+    // s_eth_hash_2_rawtx (D1). 0x04 (EIP-7702) has been a first-class TransactionType
+    // (EIP7702=4) since upstream #5411, so opEnvelopeToTars converts it and it lands in
+    // SYS_HASH_2_TX like any other typed tx (no longer absent; D7 is obsolete).
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());  // missing field fails
+                                                                          // cleanly
+    auto const& rawTxs = *request.executionPayload.rawTransactions;
+    auto& hashImpl = *fixture->blockFactory->cryptoSuite()->hashImpl();
+    auto view = fixture->multiLayerStorage.fork();
+    for (std::size_t i = 0; i < rawTxs.size(); ++i)
+    {
+        auto txHash = hashImpl.hash(rawTxs[i]);
+        // SYS_HASH_2_TX present + round-trip (tars decode back to Transaction, hash==txHash pins
+        // D4)
+        auto txEntry = bcos::task::syncWait(
+            bcos::storage2::readOne(view, bcos::executor_v1::StateKey{bcos::ledger::SYS_HASH_2_TX,
+                                              bcos::concepts::bytebuffer::toView(txHash)}));
+        BOOST_REQUIRE_MESSAGE(txEntry.has_value(), id << ": tx #" << i << " SYS_HASH_2_TX present");
+        auto txBytes = bcos::bytesConstRef(
+            reinterpret_cast<bcos::byte const*>(txEntry->get().data()), txEntry->get().size());
+        auto tx = fixture->blockFactory->transactionFactory()->createTransaction(
+            txBytes, /*checkSig=*/false, /*checkHash=*/false, /*tainted=*/false);
+        BOOST_CHECK_MESSAGE(
+            tx->hash() == txHash, id << ": tx #" << i << " round-trip hash==txHash");
+        // C2: data must land in the backend (m_latestBackend) — restart-recovery semantics.
+        auto backendEntry =
+            bcos::task::syncWait(bcos::storage2::readOne(fixture->multiLayerStorage.latestBackend(),
+                bcos::executor_v1::StateKey{
+                    bcos::ledger::SYS_HASH_2_TX, bcos::concepts::bytebuffer::toView(txHash)}));
+        BOOST_CHECK_MESSAGE(
+            backendEntry.has_value(), id << ": tx #" << i << " SYS_HASH_2_TX in backend");
+        // rawtx table absent (D1: not retained)
+        auto rawEntry = bcos::task::syncWait(bcos::storage2::readOne(
+            view, bcos::executor_v1::StateKey{EngineOpScheduler::c_ethRawTxTable,
+                      bcos::concepts::bytebuffer::toView(txHash)}));
+        BOOST_CHECK_MESSAGE(
+            !rawEntry.has_value(), id << ": tx #" << i << " s_eth_hash_2_rawtx absent");
+    }
+}
+
+/// Chained two-block: seed only A's pre -> register A's
+/// parent(0) -> submit B first (SYNCING) -> submit A (VALID) -> submit B again (VALID).
+/// FCU deliberately omitted (see implementation hint #4).
+void runChainedPair(std::string const& aId, std::string const& bId)
+{
+    auto sampleA = w6test::loadChainedSample(aId);
+    auto sampleB = w6test::loadChainedSample(bId);
+    BOOST_REQUIRE(sampleA.jovian == sampleB.jovian);  // chained pair shares one fork (isthmus or
+                                                      // jovian)
+    auto fixture = std::make_unique<OpE2eFixture>(forkFlagsFor(sampleA.jovian));
+
+    // Seed only A's pre (B's pre is A's postState; never re-seed)
+    w6test::seedPreState(fixture->multiLayerStorage, sampleA.vector["pre"]);
+    const auto goldenHeaderA = w6test::decodeGoldenHeader(sampleA);
+    // Register A's parent (trusted genesis height 0)
+    registerVerifiedBlock(fixture->multiLayerStorage, goldenHeaderA->parentInfo().blockHash, 0);
+
+    auto requestA = bcos::rpc::parseNewPayloadRequest(
+        w6test::makeParamsJson(sampleA), bcos::engine::ApiVersion::V4);
+    auto requestB = bcos::rpc::parseNewPayloadRequest(
+        w6test::makeParamsJson(sampleB), bcos::engine::ApiVersion::V4);
+
+    // Submit B first: parent(A) not yet registered -> SYNCING
+    auto earlyB = bcos::task::syncWait(fixture->service.newPayload(requestB, 4));
+    BOOST_CHECK_MESSAGE(static_cast<int>(earlyB.status) ==
+                            static_cast<int>(bcos::engine::PayloadValidationStatus::Syncing),
+        bId << ": first B should be SYNCING (parent A unknown)");
+
+    // Submit A: VALID (registerOpBlock writes SYS_HASH_2_NUMBER[hashA]=1)
+    auto statusA = bcos::task::syncWait(fixture->service.newPayload(requestA, 4));
+    BOOST_REQUIRE_MESSAGE(static_cast<int>(statusA.status) ==
+                              static_cast<int>(bcos::engine::PayloadValidationStatus::Valid),
+        aId << ": A expected VALID, got " << static_cast<int>(statusA.status));
+
+    // #19: after A is VALID the head pointer must equal A's number (same-view write).
+    {
+        auto headView = fixture->multiLayerStorage.fork();
+        const auto head = bcos::task::syncWait(
+            bcos::ledger::getCurrentBlockNumber(headView, bcos::ledger::fromStorage));
+        BOOST_CHECK_MESSAGE(head == requestA.executionPayload.blockNumber,
+            aId << ": SYS_CURRENT_STATE head must equal A's number, got " << head << " want "
+                << requestA.executionPayload.blockNumber);
+    }
+
+    // Submit B again: parentKnown hits A -> VALID
+    auto statusB = bcos::task::syncWait(fixture->service.newPayload(requestB, 4));
+    BOOST_REQUIRE_MESSAGE(static_cast<int>(statusB.status) ==
+                              static_cast<int>(bcos::engine::PayloadValidationStatus::Valid),
+        bId << ": B expected VALID after A, got " << static_cast<int>(statusB.status));
+
+    // #19: after B is VALID the head pointer must advance to B's number.
+    {
+        auto headView = fixture->multiLayerStorage.fork();
+        const auto head = bcos::task::syncWait(
+            bcos::ledger::getCurrentBlockNumber(headView, bcos::ledger::fromStorage));
+        BOOST_CHECK_MESSAGE(head == requestB.executionPayload.blockNumber,
+            bId << ": SYS_CURRENT_STATE head must equal B's number, got " << head << " want "
+                << requestB.executionPayload.blockNumber);
+    }
+
+    // Seven assertions for each (productionHeaderOf rebuilt from request, independent of execution)
+    auto producedA = productionHeaderOf(fixture->blockFactory, requestA);
+    const auto goldenBlockHashA = bcos::h256(std::string(sampleA.golden["blockHash"].asString()));
+    assertSevenFields(aId, producedA, goldenHeaderA, goldenBlockHashA);
+    auto producedB = productionHeaderOf(fixture->blockFactory, requestB);
+    auto goldenHeaderB = w6test::decodeGoldenHeader(sampleB);
+    const auto goldenBlockHashB = bcos::h256(std::string(sampleB.golden["blockHash"].asString()));
+    assertSevenFields(bId, producedB, goldenHeaderB, goldenBlockHashB);
+}
+
+/// Seeds and submits one vector block, returning {fixture, blockHash, blockNumber} for
+/// FCU case reuse. Mirrors runGoldenVector's flow but keeps the fixture and block
+/// identity — updateForkchoice seeds head/safe/finalized with that block. Warning:
+/// parseNewPayloadRequest's real signature is the 3-arg
+/// `bcos::rpc::parseNewPayloadRequest(params, txFactory, version)` (EngineHelper.h:68-70);
+/// the task brief's 1-arg `bcos::engine::parseNewPayloadRequest(params)` is a stale draft.
+std::tuple<std::unique_ptr<OpE2eFixture>, bcos::h256, bcos::protocol::BlockNumber>
+runVectorAndGetBlockHash(std::string const& id)
+{
+    auto sample = w6test::loadVectorSample(id);
+    auto fixture = std::make_unique<OpE2eFixture>(forkFlagsFor(sample.jovian));
+    w6test::seedPreState(fixture->multiLayerStorage, sample.vector["pre"]);
+    const auto goldenHeader = w6test::decodeGoldenHeader(sample);
+    registerVerifiedBlock(fixture->multiLayerStorage, goldenHeader->parentInfo().blockHash, 0);
+    auto params = w6test::makeParamsJson(sample);
+    auto req = bcos::rpc::parseNewPayloadRequest(params, bcos::engine::ApiVersion::V4);
+    auto status = bcos::task::syncWait(fixture->service.newPayload(req, /*version=*/4));
+    BOOST_REQUIRE_MESSAGE(static_cast<int>(status.status) ==
+                              static_cast<int>(bcos::engine::PayloadValidationStatus::Valid),
+        id << ": seed newPayload expected VALID, got " << static_cast<int>(status.status));
+    return {std::move(fixture), bcos::h256(std::string(sample.golden["blockHash"].asString())),
+        goldenHeader->number()};
+}
+
+// ═══════════════════ Invalid-vector runner (classification-driven) ════
+// Consumer-first (atomicity): self-tests use inline vectors (no dependence on corpus
+// files); the runner also accepts on-disk invalid_*.json. Reject schema:
+// fisco.consumer / classification ("INVALID"|"SYNCING"|"-38005"|"-32603") /
+// latest_valid_hash("parent"|null) / validation_error_contains(optional) /
+// expect_throw("UnsupportedFork"|"OpExecutionInternalError") / version(optional, -38005 sets 3).
+
+/// Parses the parent hash from `_op_payload.parentHash` (needed for INVALID's
+/// latestValidHash=parent assertion).
+bcos::h256 parseParentHashFromPayload(w6test::InvalidSample const& sample)
+{
+    return bcos::h256(std::string(sample.vector["_op_payload"]["parentHash"].asString()));
+}
+
+/// Construction spec for an inline invalid vector: derives a "self-consistent corrupt"
+/// payload from an existing golden sample.
+struct InlineInvalidSpec
+{
+    std::string baseId;          // golden-sample base (valid deposit/transfer shape)
+    std::string corruptField;    // "stateRoot"|"parentHash"|"feeRecipient"|"" (no corruption)
+    std::string classification;  // "INVALID"|"SYNCING"|"-38005"|"-32603"
+    std::string validationContains = "";  // optional validation_error_contains
+    std::uint32_t version = 4;            // -38005 uses 3 (version!=4 triggers UnsupportedFork)
+    bool carryCanonical = false;      // -32603 carries an uncorrupted canonical sibling (two-pour)
+    std::string consumer = "engine";  // Task 4 gate regression: executor skips message assertion
+};
+
+/// Derives an inline invalid vector from a golden sample. Self-consistent corruption
+/// model: mutate a header field -> recompute blockHash — rebuild the OP header with
+/// productionHeaderOf (does not read payload.blockHash) and take opHeaderHash as the
+/// new blockHash, so the step-2 blockHash check passes and field-level hits (step-5
+/// compare / parentKnown / step-3c) stay reachable.
+w6test::InvalidSample buildInlineInvalidSample(std::string const& id, InlineInvalidSpec const& spec)
+{
+    auto base = w6test::loadVectorSample(spec.baseId);
+    auto blockFactory = makeBlockFactory();
+    auto params = w6test::makeParamsJson(base);
+    auto& ep = params[0u];
+
+    if (spec.corruptField == "stateRoot")
+    {
+        auto b = bcos::fromHex(ep["stateRoot"].asString());
+        b[0] ^= 0xff;
+        ep["stateRoot"] = "0x" + bcos::toHex(b);
+    }
+    else if (spec.corruptField == "parentHash")
+    {
+        ep["parentHash"] = "0x0000000000000000000000000000000000000000000000000000000000000001";
+    }
+    else if (spec.corruptField == "feeRecipient")
+    {
+        auto b = bcos::fromHex(ep["feeRecipient"].asString());
+        b[0] ^= 0xff;
+        ep["feeRecipient"] = "0x" + bcos::toHex(b);
+    }
+    else if (!spec.corruptField.empty())
+    {
+        throw std::runtime_error(
+            "buildInlineInvalidSample: unknown corruptField " + spec.corruptField);
+    }
+
+    // Self-consistent: recompute blockHash (the rebuilt header excludes payload.blockHash ->
+    // opHeaderHash)
+    auto request = bcos::rpc::parseNewPayloadRequest(params, bcos::engine::ApiVersion::V4);
+    auto header = productionHeaderOf(blockFactory, request);
+    ep["blockHash"] = w6test::hexPrefixedH256(bcos::protocol::EthBlockHeader::computeHash(*header));
+
+    w6test::InvalidSample sample;
+    sample.hardfork = base.jovian ? "jovian" : "isthmus";
+    sample.jovian = base.jovian;
+    sample.vector["_info"]["hardfork"] = sample.hardfork;
+    sample.vector["pre"] = base.vector["pre"];
+    sample.vector["_op_payload"] = ep;
+    // V4 static validation requires parentBeaconBlockRoot (EngineServiceImpl.cpp:340); params[2]
+    // always holds the real value
+    sample.vector["_op_payload"]["parentBeaconBlockRoot"] = params[2u];
+    if (spec.carryCanonical)
+    {
+        // -32603 canonical sibling = the uncorrupted base payload (same parent/height, different
+        // blockHash)
+        auto canonicalParams = w6test::makeParamsJson(base);
+        sample.vector["_op_canonical"] = canonicalParams[0u];
+        sample.vector["_op_canonical"]["parentBeaconBlockRoot"] = canonicalParams[2u];
+    }
+
+    auto& fisco = sample.vector["_op_expected"]["reject"]["fisco"];
+    fisco["consumer"] = spec.consumer;
+    fisco["classification"] = spec.classification;
+    if (spec.classification == "INVALID")
+    {
+        fisco["latest_valid_hash"] = "parent";
+    }
+    else if (spec.classification == "-38005")
+    {
+        fisco["latest_valid_hash"] = Json::Value(Json::nullValue);
+        fisco["expect_throw"] = "UnsupportedFork";
+        fisco["version"] = spec.version;
+    }
+    else if (spec.classification == "-32603")
+    {
+        fisco["latest_valid_hash"] = Json::Value(Json::nullValue);
+        fisco["expect_throw"] = "OpExecutionInternalError";
+    }
+    if (!spec.validationContains.empty())
+    {
+        fisco["validation_error_contains"] = spec.validationContains;
+    }
+    return sample;
+}
+
+/// Inline self-test vector registry (on-disk corpus uses
+/// w6test::loadInvalidSample).
+w6test::InvalidSample makeInlineInvalidSample(std::string const& id)
+{
+    if (id == "inline_invalid_stateRoot")
+    {
+        return buildInlineInvalidSample(id, InlineInvalidSpec{
+                                                .baseId = "jovian_deposit_only",
+                                                .corruptField = "stateRoot",
+                                                .classification = "INVALID",
+                                                .validationContains = "stateRoot",
+                                            });
+    }
+    if (id == "inline_invalid_parentUnknown")
+    {
+        return buildInlineInvalidSample(id, InlineInvalidSpec{
+                                                .baseId = "jovian_deposit_only",
+                                                .corruptField = "parentHash",
+                                                .classification = "SYNCING",
+                                            });
+    }
+    if (id == "inline_invalid_unsupportedFork")
+    {
+        return buildInlineInvalidSample(id, InlineInvalidSpec{
+                                                .baseId = "jovian_deposit_only",
+                                                .corruptField = "",
+                                                .classification = "-38005",
+                                                .version = 3u,
+                                            });
+    }
+    if (id == "inline_invalid_siblingFork")
+    {
+        return buildInlineInvalidSample(id, InlineInvalidSpec{
+                                                .baseId = "jovian_deposit_only",
+                                                .corruptField = "feeRecipient",
+                                                .classification = "-32603",
+                                                .carryCanonical = true,
+                                            });
+    }
+    // An executor-consumer vector's validation_error_contains is
+    // a T8n execution-layer throw message ("intrinsic gas too low"), which the engine's
+    // RTTI-bypass folds into a generic message — if the runner does not skip the message
+    // assertion per consumer, this vector would go red. INVALID classification +
+    // latest_valid_hash=parent must still be asserted.
+    if (id == "inline_invalid_executorStateRoot")
+    {
+        return buildInlineInvalidSample(id, InlineInvalidSpec{
+                                                .baseId = "jovian_deposit_only",
+                                                .corruptField = "stateRoot",
+                                                .classification = "INVALID",
+                                                .validationContains = "intrinsic gas too low",
+                                                .consumer = "executor",
+                                            });
+    }
+    throw std::runtime_error("makeInlineInvalidSample: unknown inline id " + id);
+}
+
+/// Classification-driven runner. Key branches:
+///  - SYNCING: skips registerVerifiedBlock (unknown parent is the intent — registering
+///    would let parentKnown pass and it would no longer be SYNCING)
+///  - -38005/-32603: expect_throw picks UnsupportedFork / OpExecutionInternalError by
+///    classification; version read from fisco.version (-38005 sets 3), call
+///    newPayload(request, version)
+///  - -32603: two-pour — submit the canonical child first (VALID, writes SYS_NUMBER_2_HASH
+///    occupancy), then the same-height sibling (canonical read from vector `_op_canonical`;
+///    Task 5 chain_fork_* carriers use the same schema)
+///  - INVALID: assert status + latestValidHash(=parent or null) + validationError substring
+void runInvalidVector(std::string const& id)
+{
+    auto sample =
+        (id.rfind("inline_", 0) == 0) ? makeInlineInvalidSample(id) : w6test::loadInvalidSample(id);
+    auto fixture = std::make_unique<OpE2eFixture>(forkFlagsFor(sample.jovian));
+    const auto& fisco = sample.vector["_op_expected"]["reject"]["fisco"];
+    const auto classification = fisco["classification"].asString();
+    // Consumer gate: for executor-consumer vectors (non-decode class), the
+    // validation_error_contains is a T8n execution-layer throw message, which the engine's
+    // RTTI-bypass folds into a generic message, so a substring assertion would always
+    // mismatch. For consumer=="both" (blob) the decode message is a reliable engine-side
+    // string and must still be asserted. Default treated as engine.
+    const auto consumer = fisco.get("consumer", "engine").asString();
+
+    if (classification == "SYNCING")
+    {
+        // Warning: do not register the parent — a corrupted/broken parentHash vector intends parent
+        // unknown
+        w6test::seedPreState(fixture->multiLayerStorage, sample.vector["pre"]);
+        auto params = w6test::makeInvalidParamsJson(sample);
+        auto request = bcos::rpc::parseNewPayloadRequest(params, bcos::engine::ApiVersion::V4);
+        auto status = bcos::task::syncWait(fixture->service.newPayload(request, 4));
+        BOOST_CHECK_MESSAGE(static_cast<int>(status.status) ==
+                                static_cast<int>(bcos::engine::PayloadValidationStatus::Syncing),
+            id << ": expected SYNCING, got " << static_cast<int>(status.status));
+        return;
+    }
+
+    // Non-SYNCING: seed pre + register parent first (after self-consistent corruption, parentHash
+    // is a known valid ancestor)
+    w6test::seedPreState(fixture->multiLayerStorage, sample.vector["pre"]);
+    const auto parentHash = parseParentHashFromPayload(sample);
+    registerVerifiedBlock(fixture->multiLayerStorage, parentHash, 0);
+
+    if (classification == "-38005" || classification == "-32603")
+    {
+        auto params = w6test::makeInvalidParamsJson(sample);
+        const auto version = fisco.isMember("version") ? fisco["version"].asUInt() : 4u;
+        auto request = bcos::rpc::parseNewPayloadRequest(
+            params, static_cast<bcos::engine::ApiVersion>(version));
+        if (classification == "-38005")
+        {
+            BOOST_CHECK_THROW(bcos::task::syncWait(fixture->service.newPayload(request, version)),
+                bcos::engine::UnsupportedFork);
+        }
+        else  // -32603: two-pour — submit canonical child first (VALID, writes SYS_NUMBER_2_HASH
+              // occupancy), then sibling
+        {
+            // The canonical sibling must travel with the vector (Task 5 chain_fork_*
+            // carriers share the schema). Missing = malformed corpus: a single sibling
+            // submit is VALID and does not throw, so a silent skip would give a
+            // misleading failure — fail loudly with a named schema violation.
+            BOOST_REQUIRE_MESSAGE(sample.vector.isMember("_op_canonical"),
+                id << ": -32603 vector must carry _op_canonical (two-pour canonical sibling)");
+            w6test::InvalidSample canonicalSample;
+            canonicalSample.vector["_info"]["hardfork"] = sample.hardfork;
+            canonicalSample.vector["_op_payload"] = sample.vector["_op_canonical"];
+            canonicalSample.jovian = sample.jovian;
+            auto canonicalParams = w6test::makeInvalidParamsJson(canonicalSample);
+            auto canonicalReq =
+                bcos::rpc::parseNewPayloadRequest(canonicalParams, bcos::engine::ApiVersion::V4);
+            auto canonicalStatus =
+                bcos::task::syncWait(fixture->service.newPayload(canonicalReq, 4));
+            BOOST_REQUIRE_MESSAGE(
+                static_cast<int>(canonicalStatus.status) ==
+                    static_cast<int>(bcos::engine::PayloadValidationStatus::Valid),
+                id << ": canonical expected VALID, got " << static_cast<int>(canonicalStatus.status)
+                   << (canonicalStatus.validationError ? " : " + *canonicalStatus.validationError :
+                                                         ""));
+            BOOST_CHECK_THROW(bcos::task::syncWait(fixture->service.newPayload(request, 4)),
+                bcos::engine::OpExecutionInternalError);
+        }
+        return;
+    }
+
+    // INVALID (default path)
+    auto params = w6test::makeInvalidParamsJson(sample);
+    auto request = bcos::rpc::parseNewPayloadRequest(params, bcos::engine::ApiVersion::V4);
+    auto status = bcos::task::syncWait(fixture->service.newPayload(request, 4));
+    BOOST_CHECK_MESSAGE(static_cast<int>(status.status) ==
+                            static_cast<int>(bcos::engine::PayloadValidationStatus::Invalid),
+        id << ": expected INVALID, got " << static_cast<int>(status.status));
+    // An INVALID vector must declare latest_valid_hash ("parent"|null); missing =
+    // malformed corpus, fail loudly rather than reading the missing field as null and
+    // asserting the wrong thing (stateRoot corruption returning parent would false-fail
+    // misleadingly).
+    if (!fisco.isMember("latest_valid_hash"))
+    {
+        BOOST_ERROR(id << ": malformed vector — fisco.latest_valid_hash missing for INVALID");
+    }
+    else if (fisco["latest_valid_hash"].isNull())
+    {
+        BOOST_CHECK_MESSAGE(
+            !status.latestValidHash.has_value(), id << ": latestValidHash should be null");
+    }
+    else
+    {
+        BOOST_CHECK_MESSAGE(
+            status.latestValidHash.has_value() && *status.latestValidHash == parentHash,
+            id << ": latestValidHash should be parent");
+    }
+    if (consumer != "executor" && fisco.isMember("validation_error_contains"))
+    {
+        const auto expected = fisco["validation_error_contains"].asString();
+        BOOST_CHECK_MESSAGE(
+            status.validationError && status.validationError->find(expected) != std::string::npos,
+            id << ": validationError missing '" << expected
+               << "', got: " << (status.validationError ? *status.validationError : "<none>"));
+    }
+}
+
+/// One manifest line -> invalid-vector stem. Warning: must strip the `.json` suffix —
+/// manifest.txt entries are `xxx.json`, and `loadInvalidSample` (GoldenSample.h) re-appends
+/// `OP_T8N_VECTORS_DIR + "/" + id + ".json"`, so not stripping would hard-crash on
+/// `vectors/invalid_xxx.json.json`. Returns an empty string when the line is not an
+/// invalid-vector entry (comment/blank/non-`invalid_` prefix).
+std::string invalidStemFromManifestLine(std::string line)
+{
+    const auto b = line.find_first_not_of(" \t\r");
+    if (b == std::string::npos)
+        return {};
+    const auto e = line.find_last_not_of(" \t\r");
+    line = line.substr(b, e - b + 1);
+    if (line.empty() || line[0] == '#')
+        return {};
+    if (line.rfind("invalid_", 0) != 0)
+        return {};
+    if (line.size() > 5 && line.rfind(".json") == line.size() - 5)
+        line = line.substr(0, line.size() - 5);
+    return line;
+}
+
+/// The `invalid_*` subset of manifest.txt (same logic as loadManifest; entries are
+/// stored as stems without `.json`). Empty before Task 3 corpus lands -> zero iterations
+/// of InvalidVectorsFromManifest (forward-compat hook).
+std::set<std::string> loadInvalidManifest()
+{
+    std::set<std::string> names;
+    std::ifstream input(std::string(OP_T8N_VECTORS_DIR) + "/manifest.txt");
+    if (!input.is_open())
+    {
+        BOOST_ERROR("manifest.txt missing");
+        return names;
+    }
+    std::string line;
+    while (std::getline(input, line))
+    {
+        auto stem = invalidStemFromManifestLine(line);
+        if (!stem.empty())
+            names.insert(stem);
+    }
+    return names;
+}
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpNewPayloadRpcE2eSuite)
+
+BOOST_AUTO_TEST_CASE(JovianDepositOnly)
+{
+    runGoldenVector("jovian_deposit_only");
+}
+
+BOOST_AUTO_TEST_CASE(JovianTransferMulti)
+{
+    runGoldenVector("jovian_transfer_multi");
+}
+
+BOOST_AUTO_TEST_CASE(JovianDaMix)
+{
+    runGoldenVector("jovian_da_mix");
+}
+
+BOOST_AUTO_TEST_CASE(JovianFirstBlock)
+{
+    runGoldenVector("jovian_first_block");
+}
+
+BOOST_AUTO_TEST_CASE(IsthmusDepositOnly)
+{
+    runGoldenVector("isthmus_deposit_only");
+}
+
+BOOST_AUTO_TEST_CASE(IsthmusTransferMulti)
+{
+    runGoldenVector("isthmus_transfer_multi");
+}
+
+BOOST_AUTO_TEST_CASE(IsthmusSetcode7702)
+{
+    runGoldenVector("isthmus_setcode_7702");
+}
+
+BOOST_AUTO_TEST_CASE(IsthmusTxReverted)
+{
+    runGoldenVector("isthmus_tx_reverted");
+}
+
+BOOST_AUTO_TEST_CASE(IsthmusBigBlock130tx)
+{
+    runGoldenVector("isthmus_big_block_130tx");
+}
+
+// Single-fork isthmus system-call-order observable vector.
+// Wrong order -> L1 reader REVERT -> stateRoot mismatch -> VALID assertion + seven-field
+// assertions turn red.
+BOOST_AUTO_TEST_CASE(SystemCallOrderObservable)
+{
+    runGoldenVector("isthmus_system_call_order_observable");
+}
+
+// ── all 33 vectors (16 isthmus + 17 jovian), one per line ──
+BOOST_AUTO_TEST_CASE(IsthmusAccessList)
+{
+    runGoldenVector("isthmus_access_list");
+}
+BOOST_AUTO_TEST_CASE(IsthmusContractCreate)
+{
+    runGoldenVector("isthmus_contract_create");
+}
+BOOST_AUTO_TEST_CASE(IsthmusContractLogs)
+{
+    runGoldenVector("isthmus_contract_logs");
+}
+BOOST_AUTO_TEST_CASE(IsthmusDepositFailed)
+{
+    runGoldenVector("isthmus_deposit_failed");
+}
+BOOST_AUTO_TEST_CASE(IsthmusDepositMint)
+{
+    runGoldenVector("isthmus_deposit_mint");
+}
+BOOST_AUTO_TEST_CASE(IsthmusEmptyAccountCleanup)
+{
+    runGoldenVector("isthmus_empty_account_cleanup");
+}
+BOOST_AUTO_TEST_CASE(IsthmusFeeEnvObserver)
+{
+    runGoldenVector("isthmus_fee_env_observer");
+}
+BOOST_AUTO_TEST_CASE(IsthmusMessagePasserWrite)
+{
+    runGoldenVector("isthmus_message_passer_write");
+}
+BOOST_AUTO_TEST_CASE(IsthmusSetcode7702Skips)
+{
+    runGoldenVector("isthmus_setcode_7702_skips");
+}
+BOOST_AUTO_TEST_CASE(IsthmusSystemContractsReal)
+{
+    runGoldenVector("isthmus_system_contracts_real");
+}
+BOOST_AUTO_TEST_CASE(IsthmusTransferBasic)
+{
+    runGoldenVector("isthmus_transfer_basic");
+}
+BOOST_AUTO_TEST_CASE(JovianAccessList)
+{
+    runGoldenVector("jovian_access_list");
+}
+BOOST_AUTO_TEST_CASE(JovianContractCreate)
+{
+    runGoldenVector("jovian_contract_create");
+}
+BOOST_AUTO_TEST_CASE(JovianContractLogs)
+{
+    runGoldenVector("jovian_contract_logs");
+}
+BOOST_AUTO_TEST_CASE(JovianDepositFailed)
+{
+    runGoldenVector("jovian_deposit_failed");
+}
+BOOST_AUTO_TEST_CASE(JovianDepositMint)
+{
+    runGoldenVector("jovian_deposit_mint");
+}
+BOOST_AUTO_TEST_CASE(JovianEmptyAccountCleanup)
+{
+    runGoldenVector("jovian_empty_account_cleanup");
+}
+BOOST_AUTO_TEST_CASE(JovianFeeEnvObserver)
+{
+    runGoldenVector("jovian_fee_env_observer");
+}
+BOOST_AUTO_TEST_CASE(JovianMessagePasserWrite)
+{
+    runGoldenVector("jovian_message_passer_write");
+}
+BOOST_AUTO_TEST_CASE(JovianSetcode7702)
+{
+    runGoldenVector("jovian_setcode_7702");
+}
+BOOST_AUTO_TEST_CASE(JovianSetcode7702Skips)
+{
+    runGoldenVector("jovian_setcode_7702_skips");
+}
+BOOST_AUTO_TEST_CASE(JovianSystemContractsReal)
+{
+    runGoldenVector("jovian_system_contracts_real");
+}
+BOOST_AUTO_TEST_CASE(JovianTransferBasic)
+{
+    runGoldenVector("jovian_transfer_basic");
+}
+BOOST_AUTO_TEST_CASE(JovianTxReverted)
+{
+    runGoldenVector("jovian_tx_reverted");
+}
+
+// ── Engine-gate probe: 5 representative precompile vectors ─────────
+// (five risk faces: over-cap / 7702 / Jovian / value / successful output)
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBn256PairNorm)
+{
+    runGoldenVector("isthmus_precompile_bn256pair_norm");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsPairingOvercap)
+{
+    runGoldenVector("isthmus_precompile_bls_pairing_overcap");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileWrapEip7702)
+{
+    runGoldenVector("isthmus_precompile_wrap_eip7702");
+}
+BOOST_AUTO_TEST_CASE(JovianPrecompileWrapValueOvercap)
+{
+    runGoldenVector("jovian_precompile_wrap_value_overcap");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileEcrecover)
+{
+    runGoldenVector("isthmus_precompile_ecrecover");
+}
+
+// BOOST_AUTO_TEST_CASE names must not repeat: the completion-case names below deliberately avoid
+// the 9 sample-case names above.
+// Chained pair: one case (runChainedPair) runs chainA+chainB in one flow (B SYNCING -> A VALID -> B
+// VALID).
+BOOST_AUTO_TEST_CASE(ChainedAB)
+{
+    runChainedPair("chainA", "chainB");
+}
+
+// B-5c: jovian chained pair. runChainedPair's block2 VALID assertion = step 3a-2 baseFee
+// consistency check passing, which exercises the max branch (baseFee derived from the
+// parent block + capped by rounding up).
+BOOST_AUTO_TEST_CASE(JovianChainedAB)
+{
+    runChainedPair("jovianChainA", "jovianChainB");
+}
+// ── Precompile matrix completion: 24 vectors ──
+// The 5 probes (bn256pair_norm/bls_pairing_overcap/wrap_eip7702/wrap_value_overcap/ecrecover)
+// covered the five risk faces; this section completes the remaining 24, totaling 29 precompile
+// cases.
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlake2f)
+{
+    runGoldenVector("isthmus_precompile_blake2f");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBn256Add)
+{
+    runGoldenVector("isthmus_precompile_bn256add");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBn256Mul)
+{
+    runGoldenVector("isthmus_precompile_bn256mul");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsG1Add)
+{
+    runGoldenVector("isthmus_precompile_bls_g1add");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsG1Msm)
+{
+    runGoldenVector("isthmus_precompile_bls_g1msm");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsG1MsmOvercap)
+{
+    runGoldenVector("isthmus_precompile_bls_g1msm_overcap");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsG2Add)
+{
+    runGoldenVector("isthmus_precompile_bls_g2add");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsG2Msm)
+{
+    runGoldenVector("isthmus_precompile_bls_g2msm");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsG2MsmOvercap)
+{
+    runGoldenVector("isthmus_precompile_bls_g2msm_overcap");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsMapG1)
+{
+    runGoldenVector("isthmus_precompile_bls_map_g1");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsMapG2)
+{
+    runGoldenVector("isthmus_precompile_bls_map_g2");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileBlsPairing)
+{
+    runGoldenVector("isthmus_precompile_bls_pairing");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileExpmod)
+{
+    runGoldenVector("isthmus_precompile_expmod");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileIdentity)
+{
+    runGoldenVector("isthmus_precompile_identity");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompilePointEvaluation)
+{
+    runGoldenVector("isthmus_precompile_point_evaluation");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileRipemd160)
+{
+    runGoldenVector("isthmus_precompile_ripemd160");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileSha256)
+{
+    runGoldenVector("isthmus_precompile_sha256");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileWrap63of64)
+{
+    runGoldenVector("isthmus_precompile_wrap_63of64");
+}
+BOOST_AUTO_TEST_CASE(IsthmusPrecompileWrapReturndata)
+{
+    runGoldenVector("isthmus_precompile_wrap_returndata");
+}
+BOOST_AUTO_TEST_CASE(JovianPrecompileBlsG1MsmOvercap)
+{
+    runGoldenVector("jovian_precompile_bls_g1msm_overcap");
+}
+BOOST_AUTO_TEST_CASE(JovianPrecompileBlsG2MsmOvercap)
+{
+    runGoldenVector("jovian_precompile_bls_g2msm_overcap");
+}
+BOOST_AUTO_TEST_CASE(JovianPrecompileBlsPairingOvercap)
+{
+    runGoldenVector("jovian_precompile_bls_pairing_overcap");
+}
+BOOST_AUTO_TEST_CASE(JovianPrecompileBn256PairOvercap)
+{
+    runGoldenVector("jovian_precompile_bn256pair_overcap");
+}
+BOOST_AUTO_TEST_CASE(JovianPrecompileWrapValueRevert)
+{
+    runGoldenVector("jovian_precompile_wrap_value_revert");
+}
+
+// Final tally: 65 cases = 63 single vectors + 2 chained pairs (chainA/B + jovianChainA/B,
+// covering 4 chained samples). 63 single = 34 base vectors (33 +
+// isthmus_system_call_order_observable) + 29 precompile (probes 5 + completion 24).
+
+// ── E2E invalid-vector runner (classification-driven) ──
+// Inline self-test vectors (no dependence on corpus files): the
+// classification-driven runner covers all four branches —
+//   INVALID (stateRoot self-consistent corruption + latestValidHash=parent + "stateRoot")
+//   SYNCING (parentHash broken chain -> do not register parent)
+//   -38005 (Isthmus+ timestamp + version!=4 -> UnsupportedFork)
+//   -32603 (same-parent twins: canonical VALID writes SYS_NUMBER_2_HASH occupancy, then sibling ->
+//   two-pour)
+BOOST_AUTO_TEST_CASE(InvalidStateRootRejected)
+{
+    runInvalidVector("inline_invalid_stateRoot");
+}
+
+BOOST_AUTO_TEST_CASE(InvalidParentUnknownSyncing)
+{
+    runInvalidVector("inline_invalid_parentUnknown");
+}
+
+BOOST_AUTO_TEST_CASE(InvalidUnsupportedForkVersion3)
+{
+    runInvalidVector("inline_invalid_unsupportedFork");
+}
+
+BOOST_AUTO_TEST_CASE(InvalidSiblingForkRejected)
+{
+    runInvalidVector("inline_invalid_siblingFork");
+}
+
+// Executor-consumer vectors skip the validation_error_contains assertion (engine RTTI-bypass
+// folds T8n messages), but INVALID classification + latest_valid_hash=parent must still be
+// asserted.
+BOOST_AUTO_TEST_CASE(ExecutorConsumerSkipsMessageAssertion)
+{
+    runInvalidVector("inline_invalid_executorStateRoot");
+}
+
+// Manifest subset iteration (invalid_*.json). Empty corpus -> zero iterations (forward compat).
+BOOST_AUTO_TEST_CASE(InvalidVectorsFromManifest)
+{
+    for (auto const& id : loadInvalidManifest())
+    {
+        runInvalidVector(id);
+    }
+}
+
+// Regression (review Important): manifest entries are `invalid_xxx.json`, and
+// loadInvalidSample re-appends `.json`. invalidStemFromManifestLine must strip the suffix —
+// otherwise runInvalidVector gets `vectors/invalid_xxx.json.json` -> loadJsonFile hard crash.
+// Proves the manifest->load path no longer double-appends.
+BOOST_AUTO_TEST_CASE(InvalidManifestStemStripsJsonSuffix)
+{
+    // Real manifest line shape -> stem without suffix (loadInvalidSample re-appends to the original
+    // filename)
+    BOOST_CHECK_EQUAL(
+        invalidStemFromManifestLine("invalid_inline_stateRoot.json"), "invalid_inline_stateRoot");
+    BOOST_CHECK_EQUAL(
+        invalidStemFromManifestLine("  invalid_foo_static_3.json  "), "invalid_foo_static_3");
+    // non-invalid_ prefix / comment / blank -> not in the subset
+    BOOST_CHECK_EQUAL(invalidStemFromManifestLine("jovian_deposit_only.json"), "");
+    BOOST_CHECK_EQUAL(invalidStemFromManifestLine("# comment"), "");
+    BOOST_CHECK_EQUAL(invalidStemFromManifestLine("   "), "");
+    BOOST_CHECK_EQUAL(invalidStemFromManifestLine(""), "");
+}
+
+// ── Coverage-matrix assertion (manifest-registered subset driven) ─────
+// Iterates manifest invalid_* vectors + inline vectors, asserting every required
+// set member is covered (missing -> FAILURE): each classification (incl. -38005 — satisfied
+// by the Task 2 version vector; -32603 satisfied by the two-pour runner), each
+// latest_valid_hash value ("parent"|null), each static item (except 3/12 — inexpressible
+// through the loader, forced out of manifest), each validation_error_contains target string.
+BOOST_AUTO_TEST_CASE(CoverageMatrixFromManifest)
+{
+    const auto names = loadInvalidManifest();
+    BOOST_REQUIRE_MESSAGE(!names.empty(), "coverage: manifest has no invalid_* vectors");
+    std::set<std::string> classifications;
+    std::set<std::string> lvh;  // "parent" | "null" | "absent"
+    std::set<int> staticItems;
+    std::set<std::string> errStrings;
+    for (auto const& id : names)
+    {
+        auto sample = w6test::loadInvalidSample(id);
+        auto const& fisco = sample.vector["_op_expected"]["reject"]["fisco"];
+        classifications.insert(fisco["classification"].asString());
+        if (fisco.isMember("latest_valid_hash"))
+            lvh.insert(fisco["latest_valid_hash"].isNull() ? "null" :
+                                                             fisco["latest_valid_hash"].asString());
+        else
+            lvh.insert("absent");
+        if (fisco.isMember("validation_error_contains"))
+            errStrings.insert(fisco["validation_error_contains"].asString());
+        const auto pos = id.rfind("_static_");
+        if (pos != std::string::npos)
+            staticItems.insert(std::stoi(id.substr(pos + 8)));
+    }
+    // Inline vectors (-38005 / two-pour -32603 / SYNCING satisfied inline; not in manifest).
+    for (auto const* id : {"inline_invalid_stateRoot", "inline_invalid_parentUnknown",
+             "inline_invalid_unsupportedFork", "inline_invalid_siblingFork"})
+    {
+        auto sample = makeInlineInvalidSample(id);
+        auto const& fisco = sample.vector["_op_expected"]["reject"]["fisco"];
+        classifications.insert(fisco["classification"].asString());
+        if (fisco.isMember("latest_valid_hash"))
+            lvh.insert(fisco["latest_valid_hash"].isNull() ? "null" :
+                                                             fisco["latest_valid_hash"].asString());
+    }
+    // Required: classification (all four states covered)
+    for (auto const* c : {"INVALID", "SYNCING", "-38005", "-32603"})
+        BOOST_CHECK_MESSAGE(
+            classifications.count(c), "coverage: classification '" << c << "' has no vector");
+    // Required: latest_valid_hash (both "parent" and null values)
+    for (auto const* h : {"parent", "null"})
+        BOOST_CHECK_MESSAGE(
+            lvh.count(h), "coverage: latest_valid_hash '" << h << "' has no vector");
+    // Required: static items 1..11 (except 3/12 — forced out of manifest)
+    for (int n : {1, 2, 4, 5, 6, 7, 8, 9, 10, 11})
+        BOOST_CHECK_MESSAGE(
+            staticItems.count(n), "coverage: static item " << n << " has no vector");
+    BOOST_CHECK_MESSAGE(!staticItems.count(3),
+        "coverage: static item 3 must NOT be manifest-registered (loader inexpressible)");
+    BOOST_CHECK_MESSAGE(!staticItems.count(12),
+        "coverage: static item 12 must NOT be manifest-registered (loader inexpressible)");
+    // Required: full set of validation_error_contains target strings (corrupt fields / static faces
+    // / invalid-tx messages)
+    static const char* kRequiredErrors[] = {
+        "stateRoot",
+        "gasUsed",
+        "receiptsRoot",
+        "blockHash does not match the reconstructed block header",
+        "extraData must be exactly 9 bytes on the OP path (Isthmus)",
+        "extraData must be exactly 17 bytes on the OP path (Jovian)",
+        "executionPayload.rawTransactions is required on the OP path",
+        "withdrawals must be present and empty on the OP path",
+        "parentBeaconBlockRoot must be a 32-byte hash for newPayloadV4",
+        "withdrawalsRoot is required on the OP path (Isthmus+)",
+        "excessBlobGas must be present and zero on the OP path",
+        "blobGasUsed must be zero before Jovian (OP Isthmus)",
+        "blockNumber must not be negative",
+        "gasLimit exceeds the maximum block gas limit (2^63-1)",
+        "DA footprint (blobGasUsed) exceeds the block gas limit",
+        "intrinsic gas too low",
+        "nonce too low",
+        "nonce too high",
+        "insufficient funds for gas * price + value",
+        "max fee per gas less than block base fee",
+        "sender not an eoa",
+        "set code transaction must not be a create transaction",
+        "empty authorization list",
+        "unsupported tx type byte 0x03",
+    };
+    for (auto const* s : kRequiredErrors)
+        BOOST_CHECK_MESSAGE(
+            errStrings.count(s), "coverage: validation_error_contains '" << s << "' has no vector");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(OpForkchoiceRpcE2eSuite)
+// ── FCU end-to-end 6 cases ──
+// ── Mirrors op-geth v1.101702.2 eth/catalyst/api.go forkchoiceUpdated semantics:
+//   head known -> VALID + LatestValidHash=head (api.go:316-322 valid())
+//   head unknown -> STATUS_SYNCING (api.go:238 network pull)
+//   OP + attributes -> -38003 (checkOptimismPayloadAttributes rejects; here
+//   UnsupportedOpPayloadAttributes)  monotonicity finalized>head -> -38002 (api.go
+//   safe/finalized checks; here InvalidForkchoiceState :263-280)  head increment must be
+//   exactly +1 (:318-323)  no attributes -> head/safe/finalized advance
+//   (updateTrackedBlockNumbers :1520-1525)
+
+// ① head known -> VALID + LatestValidHash=head (mirrors op-geth valid())
+BOOST_AUTO_TEST_CASE(ForkchoiceHeadKnownValid)
+{
+    auto [fixture, blockHash, number] = runVectorAndGetBlockHash("jovian_deposit_only");
+    (void)number;
+    auto [state, payloadId] = bcos::task::syncWait(fixture->service.updateForkchoice(
+        bcos::engine::ForkchoiceState{blockHash, blockHash, blockHash}, nullptr, /*version=*/3));
+    (void)payloadId;
+    BOOST_CHECK_EQUAL(static_cast<int>(state.status),
+        static_cast<int>(bcos::engine::PayloadValidationStatus::Valid));
+    BOOST_CHECK(state.latestValidHash.has_value());
+    BOOST_CHECK_EQUAL(*state.latestValidHash, blockHash);
+}
+
+// ② head unknown -> SYNCING (mirrors op-geth STATUS_SYNCING; getBlockNumber has no value ->
+// :253-262)
+BOOST_AUTO_TEST_CASE(ForkchoiceHeadUnknownSyncing)
+{
+    auto fixture = std::make_unique<OpE2eFixture>(forkFlagsFor(/*jovian=*/false));
+    bcos::h256 unknownHash(0xdeadbeef);  // no block registered
+    auto [state, payloadId] = bcos::task::syncWait(fixture->service.updateForkchoice(
+        bcos::engine::ForkchoiceState{unknownHash, unknownHash, unknownHash}, nullptr,
+        /*version=*/3));
+    (void)payloadId;
+    BOOST_CHECK_EQUAL(static_cast<int>(state.status),
+        static_cast<int>(bcos::engine::PayloadValidationStatus::Syncing));
+}
+
+// ③ OP attributes -> -38003 (UnsupportedOpPayloadAttributes; mirrors op-geth attribute rejection).
+// Note: the forkchoice state update takes effect first, then the build is rejected
+// (EngineServiceImpl.h:356-359).
+BOOST_AUTO_TEST_CASE(ForkchoiceAttributesRejected)
+{
+    auto [fixture, blockHash, number] = runVectorAndGetBlockHash("jovian_deposit_only");
+    (void)number;
+    bcos::engine::PayloadAttributes attrs;
+    BOOST_CHECK_THROW(bcos::task::syncWait(fixture->service.updateForkchoice(
+                          bcos::engine::ForkchoiceState{blockHash, blockHash, blockHash}, &attrs,
+                          /*version=*/3)),
+        bcos::engine::UnsupportedOpPayloadAttributes);
+}
+
+// ④ finalized > head -> InvalidForkchoiceState (-38002 monotonicity; mirrors updateForkchoice
+// :263-280)
+BOOST_AUTO_TEST_CASE(ForkchoiceMonotonicityRejected)
+{
+    auto [fixture, blockHash, number] = runVectorAndGetBlockHash("jovian_deposit_only");
+    // Manually register a higher-numbered "known" block for finalized (registerVerifiedBlock writes
+    // SYS_HASH_2_NUMBER)
+    bcos::h256 higherBlock("0x9999999999999999999999999999999999999999999999999999999999999999");
+    registerVerifiedBlock(fixture->multiLayerStorage, higherBlock, number + 2);
+    // finalized (number+2) > head (number) -> throws InvalidForkchoiceState at :269-274
+    BOOST_CHECK_THROW(bcos::task::syncWait(fixture->service.updateForkchoice(
+                          bcos::engine::ForkchoiceState{blockHash, blockHash, higherBlock}, nullptr,
+                          /*version=*/3)),
+        bcos::engine::InvalidForkchoiceState);
+}
+
+// ⑤ head increment must be exactly +1: skipping (missing middle block) -> conflict; strict +1 ->
+// VALID (mirrors :318-323)
+BOOST_AUTO_TEST_CASE(ForkchoiceHeadIncrement)
+{
+    auto [fixture, blockHash1, n1] = runVectorAndGetBlockHash("jovian_deposit_only");
+    // First FCU(head=block1) -> VALID (tracked head set to block1, number n1)
+    auto [s1, p1] = bcos::task::syncWait(fixture->service.updateForkchoice(
+        bcos::engine::ForkchoiceState{blockHash1, blockHash1, blockHash1}, nullptr,
+        /*version=*/3));
+    (void)p1;
+    BOOST_CHECK_EQUAL(static_cast<int>(s1.status),
+        static_cast<int>(bcos::engine::PayloadValidationStatus::Valid));
+    // Skipping: FCU straight to the registered block n1+2 (n1+1 not registered) ->
+    // :318-323 "must increase by exactly 1" throws InvalidForkchoiceState (thrown before
+    // m_trackedHeadBlock is assigned; tracked remains n1)
+    bcos::h256 jumpBlock("0x8888888888888888888888888888888888888888888888888888888888888888");
+    registerVerifiedBlock(fixture->multiLayerStorage, jumpBlock, n1 + 2);
+    BOOST_CHECK_THROW(bcos::task::syncWait(fixture->service.updateForkchoice(
+                          bcos::engine::ForkchoiceState{jumpBlock, jumpBlock, jumpBlock}, nullptr,
+                          /*version=*/3)),
+        bcos::engine::InvalidForkchoiceState);
+    // Strict +1: register block n1+1 -> VALID (tracked head advances from n1 to n1+1)
+    bcos::h256 nextBlock("0x7777777777777777777777777777777777777777777777777777777777777777");
+    registerVerifiedBlock(fixture->multiLayerStorage, nextBlock, n1 + 1);
+    auto [s2, p2] = bcos::task::syncWait(fixture->service.updateForkchoice(
+        bcos::engine::ForkchoiceState{nextBlock, nextBlock, nextBlock}, nullptr, /*version=*/3));
+    (void)p2;
+    BOOST_CHECK_EQUAL(static_cast<int>(s2.status),
+        static_cast<int>(bcos::engine::PayloadValidationStatus::Valid));
+}
+
+// ⑥ no attributes -> head advance (getSafe/Finalized reflect it; mirrors updateForkchoice
+// :334-338 + updateTrackedBlockNumbers :1520-1525)
+BOOST_AUTO_TEST_CASE(ForkchoiceNoAttributesHeadAdvance)
+{
+    auto [fixture, blockHash, number] = runVectorAndGetBlockHash("jovian_deposit_only");
+    auto [state, payloadId] = bcos::task::syncWait(fixture->service.updateForkchoice(
+        bcos::engine::ForkchoiceState{blockHash, blockHash, blockHash}, nullptr, /*version=*/3));
+    (void)payloadId;
+    BOOST_CHECK_EQUAL(static_cast<int>(state.status),
+        static_cast<int>(bcos::engine::PayloadValidationStatus::Valid));
+    // safe/finalized sync to the FCU-passed numbers (in-memory; FCU has no persistence)
+    auto safe = fixture->service.getSafeBlockNumber();
+    auto finalized = fixture->service.getFinalizedBlockNumber();
+    BOOST_REQUIRE(safe.has_value());
+    BOOST_REQUIRE(finalized.has_value());
+    BOOST_CHECK_EQUAL(*safe, number);
+    BOOST_CHECK_EQUAL(*finalized, number);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpPredeploysSeed.h
+++ b/opstack-executor/tests/OpPredeploysSeed.h
@@ -1,0 +1,33 @@
+#pragma once
+
+// Test-genesis seeding for the OP predeploy/vault accounts (moved out of the production
+// opstack module: every caller is a test; the production side only consumes the address
+// constants in OpPredeploys.h).
+// TODO(eth-utils-removal): seedOpPredeploys parameter TestState -> in-memory ledger; update all
+// test callers together.
+
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <test/utils/test_state.hpp>
+
+namespace bcos::evm::opstack
+{
+/// Pre-seed the 6 predeploy/vault accounts as empty accounts with balance 0 (M5 block-level
+/// harness genesis preparation). The four fee vaults carry a 1-byte stub code (0x00) to avoid
+/// being deleted as empty accounts by EIP-161 under zero fees. The code for OP_L1_BLOCK /
+/// OP_GAS_PRICE_ORACLE is still managed by the harness setter itself.
+inline void seedOpPredeploys(evmone::test::TestState& state)
+{
+    for (const auto& addr : {OP_L1_BLOCK, OP_GAS_PRICE_ORACLE, OP_SEQUENCER_FEE_VAULT,
+             OP_BASE_FEE_VAULT, OP_L1_FEE_VAULT, OP_OPERATOR_FEE_VAULT})
+    {
+        state[addr];  // insert a default account
+    }
+    // The four fee vaults: minimal non-empty runtime code (1-byte STOP), so they are not deleted as
+    // empty accounts under a zero-value diff.
+    for (const auto& v :
+        {OP_SEQUENCER_FEE_VAULT, OP_BASE_FEE_VAULT, OP_L1_FEE_VAULT, OP_OPERATOR_FEE_VAULT})
+    {
+        state[v].code = evmc::bytes{0x00};
+    }
+}
+}  // namespace bcos::evm::opstack

--- a/opstack-executor/tests/OpSchedulerTest.cpp
+++ b/opstack-executor/tests/OpSchedulerTest.cpp
@@ -1,0 +1,799 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpSchedulerTest — minimal OP-block + three-way-classification unit tests for the OpScheduler
+// class.
+//
+// 1. CommitPersistsSevenLedgerTables: the minimal OP block (deposit + 1 normal with envelope,
+//    SEV-8: extraTransactionBytes = full envelope, precedent OpDualPathEquivalenceTest.cpp) driven
+//    via OpScheduler.executeBlock + commitBlock; the announced header's commitments come from a
+//    direct execution probe (preBlockOpSteps → SchedulerSerialImpl → finalizeOpBlockResult, the
+//    shared Task 5 path). The transition-equivalence test (OpScheduler vs the retired
+//    runOpBlockInjection) was deleted together with runOpBlockInjection.
+// 2. ConsensusRejectionClassifiedAsOpConsensusRejected: the execute hook throws OpConsensusError
+//    (unsupported tx type byte 0x03, type-byte classification throws deterministically) → the
+//    skeleton's coExecuteBlock classifies via classifyException → Error code ==
+//    OpConsensusRejected.
+// 3. classifyException direct three-way mapping: OpConsensusError→OpConsensusRejected /
+//    OpStorageError→OpStorageFault / other→UnknownError.
+#include "support/OpDepositEncode.h"  // encodeDepositEnvelope (deposit envelope reconstruction)
+#include <opstack-executor/OpScheduler.h>
+#include <opstack-executor/OpSchedulerSeam.h>
+#include <opstack-executor/Storage2StateHelpers.h>  // accountTableName (corrupt-slot seeding)
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-ledger/Ledger.h>  // real bcos::ledger::Ledger for the commit hook
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>  // for migrated call cases
+#include <bcos-table/src/LegacyStorageWrapper.h>         // LegacyStorageWrapper<BackendMemStorage>
+#include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Error.h>
+#include <engine/bcos-engine/EngineServiceImpl.h>  // detail::opEnvelopeToTars (tests link engine)
+#include <boost/test/unit_test.hpp>
+#include <evmc/evmc.hpp>
+#include <evmc/hex.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+using evmc::literals::operator""_address;
+using evmc::literals::operator""_bytes32;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+namespace
+{
+namespace detail = bcos::evm::engine::detail;
+
+constexpr uint64_t kChainId = 0x2105;  // 8453 — the FISCO OP chain id (vector eip1559 chainId)
+const bcos::Address kSender{"0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"};  // eip1559 recovered
+                                                                            // sender
+
+// Corpus isthmus_transfer_basic.json: block.transactions[1]._op_raw (op-geth-signed eip1559
+// envelope).
+constexpr const char* kEip1559EnvelopeHex =
+    "0x02f874822105808405f5e100847735940082520894b0b0000000000000000000000000000000000001880de"
+    "0b6b3a764000080c001a0e37533ddb9f696c0b21788f1b00c78adc4a81b1d811d84e70fad672096fc924ea00ae"
+    "693f4d68955a4c01ee8bab26f5be740ee416dd2556822f68b747d5aab7714";
+
+// Minimal CheckpointStorage stub (same as the source-branch fixture: do not cross-include other
+// modules' test-private headers).
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& storage) noexcept : m_storage(storage) {}
+    Storage& open() & { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const& /*unused*/) &
+    {
+        std::abort();  // this fixture never needs a historical checkpoint.
+    }
+    void createCheckpoint(Storage& /*unused*/, CheckpointName const& /*unused*/) {}
+    void deleteCheckpoint(CheckpointName const& /*unused*/) {}
+    [[nodiscard]] std::optional<CheckpointName> latestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+    [[nodiscard]] std::optional<CheckpointName> oldestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+};
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+using BackendMemStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+    std::hash<StateKey>>;
+using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, BackendMemStorage>;
+using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
+using ViewType = typename MLS::ViewType;
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+bcos::protocol::BlockFactory::Ptr makeBlockFactory()
+{
+    auto cryptoSuite = makeCryptoSuite();
+    auto blockHeaderFactory =
+        std::make_shared<bcostars::protocol::BlockHeaderFactoryImpl>(cryptoSuite);
+    auto transactionFactory =
+        std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+    auto receiptFactory =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite);
+    return std::make_shared<bcostars::protocol::BlockFactoryImpl>(
+        cryptoSuite, blockHeaderFactory, transactionFactory, receiptFactory);
+}
+
+bcos::protocol::TransactionReceiptFactory::Ptr makeReceiptFactory()
+{
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+}
+
+/// L1 attributes deposit (the isthmus_transfer_basic corpus deposit shape): to==OP_L1_BLOCK &&
+/// from==OP_DEPOSITOR satisfies isL1AttributesTx (OpBlockExecute.h:97-99). data is empty — under
+/// Isthmus (pre-Jovian) validateJovianBlockShape is a no-op (OpBlockExecute.h:76); processOpBlock
+/// classifies isL1AttributesTx purely by content and never validates calldata (precedent: the
+/// empty-data deposit in OpBlockInjectorTest.cpp:88-101 passes likewise).
+bcos::evm::opstack::DepositTx makeDeposit()
+{
+    bcos::evm::opstack::DepositTx dep;
+    dep.source_hash = 0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7_bytes32;
+    dep.from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address;
+    dep.to = 0x4200000000000000000000000000000000000015_address;
+    dep.mint = std::nullopt;
+    dep.value = intx::uint256{0};
+    dep.gas_limit = 0xf4240;  // 1000000 (corpus gas: "0xf4240")
+    dep.is_system_tx = false;
+    dep.data = {};
+    return dep;
+}
+
+/// OP header from the corpus environment (isthmus_transfer_basic env). timestamp is stored in
+/// milliseconds (FISCO convention; /1000 gives OP seconds). Commitment fields (stateRoot/txsRoot/
+/// receiptsRoot/gasUsed/withdrawalsRoot/logsBloom/requestsHash) are back-filled by the caller from
+/// the direct execution probe (runExecutionProbe) result — the announced header carries the true
+/// commitments, so the six-field comparison verifies.
+std::shared_ptr<bcostars::protocol::BlockHeaderImpl> makeHeader()
+{
+    auto h = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    h->setNumber(1);
+    h->setTimestamp(0x3f2 * 1000);  // 0x3f2 = 1010 s (OP seconds) → 1_010_000 ms
+    h->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 0,
+        .blockHash =
+            bcos::h256{"0x45daac1c62119a8624509cd80f0b2543f6c78fd21457213af891d8a6d8b14f74"}});
+    h->setCoinbase(bcos::Address{"0x4200000000000000000000000000000000000011"});
+    h->setStateRoot(bcos::h256{});
+    h->setTxsRoot(bcos::h256{});
+    h->setReceiptsRoot(bcos::h256{});
+    h->setGasLimit(bcos::u256(0x989680));  // 10000000 (corpus currentGasLimit)
+    h->setGasUsed(bcos::u256(0));
+    h->setExtraData(bcos::bytes{});
+    h->setPrevRandao(bcos::h256{});
+    h->setBaseFee(bcos::u256(0x3a699d00));  // 981000000 (corpus currentBaseFee)
+    h->setWithdrawalsRoot(bcos::h256{});
+    h->setBlobGasUsed(bcos::u256(0));
+    h->setExcessBlobGas(bcos::u256(0));
+    h->setParentBeaconBlockRoot(
+        bcos::h256{"0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"});
+    h->setRequestsHash(bcos::h256{});
+    return h;
+}
+
+/// Back-fill the announced header's commitment fields from the execution probe result
+/// (finishExecute writes the same batch of fields, so verify compares equal).
+void fillAnnouncedHeader(bcos::protocol::BlockHeader::Ptr const& header,
+    bcos::evm::engine::OpExecuteBlockResult const& result)
+{
+    header->setStateRoot(result.stateRoot);
+    header->setTxsRoot(result.txRoot);
+    header->setReceiptsRoot(detail::toBcosH256(result.seal.receiptsRoot));
+    header->setGasUsed(bcos::u256(result.gasUsed));
+    header->setLogsBloom(bcos::bytesConstRef(result.seal.logsBloom.bytes, 256));
+    header->setWithdrawalsRoot(detail::toBcosH256(result.seal.withdrawalsRoot));
+    if (result.seal.requestsHash.has_value())
+        header->setRequestsHash(detail::toBcosH256(*result.seal.requestsHash));
+    if (result.seal.blobGasUsed.has_value())
+        header->setBlobGasUsed(bcos::u256(*result.seal.blobGasUsed));
+}
+
+/// opEnvelopeToTars + SEV-8 full-envelope override (precedent
+/// OpDualPathEquivalenceTest.cpp:566-568): takeToTarsTransaction stores the signing preimage;
+/// executeTransaction reads extraTransactionBytes as the full envelope (OpstackExecutor.h:280-281).
+bcos::protocol::Transaction::Ptr buildFiscoTx(
+    bcos::bytes const& env, bcos::crypto::Hash::Ptr const& hashImpl)
+{
+    auto txHash = hashImpl->hash(env);
+    auto tarsTx = bcos::engine::detail::opEnvelopeToTars(env, txHash);
+    if (!tarsTx)
+    {
+        return nullptr;
+    }
+    tarsTx->extraTransactionBytes.assign(env.begin(), env.end());
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tars = std::move(*tarsTx)]() mutable { return &tars; });
+    return tx;
+}
+
+/// A one-byte 0x03 envelope — the execute hook's type-byte classification deterministically throws
+/// OpConsensusError ("unsupported tx type byte", OpScheduler.h). Used to reliably drive the execute
+/// hook into the consensus-rejected classification (independent of RTTI-boundary runtime behavior).
+bcos::protocol::Transaction::Ptr buildUnsupportedTypeTx()
+{
+    bcostars::Transaction tars;
+    tars.extraTransactionBytes.push_back(0x03);
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tars = std::move(tars)]() mutable { return &tars; });
+    return tx;
+}
+
+/// Seed the eip1559 sender account into the MLS backend (StorageStateView::exists() needs a
+/// non-zero codeHash — create() + setCode(empty); a bare setBalance would be deemed non-existent).
+void seedSender(MLS& mls, bcos::Address const& addr, bcos::crypto::Hash::Ptr const& hashImpl)
+{
+    auto view = mls.fork();
+    view.newMutable();
+    bcos::ledger::account::EVMAccount account(view, addr, /*rawAddress=*/false);
+    bcos::task::syncWait(account.create());
+    bcos::task::syncWait(account.setCode({}, {}, hashImpl->emptyHash()));
+    bcos::task::syncWait(account.setNonce("0"));
+    bcos::task::syncWait(account.setBalance(bcos::u256(1) << 200));
+    bcos::task::syncWait(mls.mergeView(std::move(view)));
+}
+
+/// Seed the SYS_TABLES meta-rows for the ledger SYS tables (each uses the SYS_VALUE field,
+/// Ledger.cpp buildGenesisBlock). A real bcos::ledger::Ledger's asyncPrewriteBlock ends with
+/// asyncGetTotalTransactionCount, which opens SYS_CURRENT_STATE through the Ledger's OWN
+/// m_stateStorage (here: a LegacyStorageWrapper over the MLS backend, distinct from the
+/// commit-hook MutableStorage that prewriteBlockToBuffer writes through). Without the SYS_TABLES
+/// row the open fails (Table does not exist) and the whole asyncPrewriteBlock errors out.
+void seedSysTables(MLS& mls)
+{
+    auto view = mls.fork();
+    view.newMutable();
+    constexpr std::string_view sysTables[] = {bcos::ledger::SYS_CURRENT_STATE,
+        bcos::ledger::SYS_HASH_2_TX, bcos::ledger::SYS_HASH_2_NUMBER,
+        bcos::ledger::SYS_NUMBER_2_HASH, bcos::ledger::SYS_NUMBER_2_BLOCK_HEADER,
+        bcos::ledger::SYS_NUMBER_2_TXS, bcos::ledger::SYS_HASH_2_RECEIPT,
+        bcos::ledger::SYS_BLOCK_NUMBER_2_NONCES};
+    for (auto const& table : sysTables)
+    {
+        bcos::storage::Entry e;
+        e.set(std::string(bcos::ledger::SYS_VALUE));
+        bcos::task::syncWait(bcos::storage2::writeOne(
+            view, StateKey{bcos::ledger::SYS_TABLES, std::string(table)}, std::move(e)));
+    }
+    bcos::task::syncWait(mls.mergeView(std::move(view)));
+}
+
+struct Fixture
+{
+    BackendMemStorage backendStorage{1};
+    CheckpointBackend checkpointBackend{backendStorage};
+    MLS multiLayerStorage{checkpointBackend};
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory{makeReceiptFactory()};
+    bcos::crypto::Hash::Ptr hashImpl{makeCryptoSuite()->hashImpl()};
+    bcos::protocol::BlockFactory::Ptr blockFactory{makeBlockFactory()};
+    bcos::evm::opstack::OpForkFlags forkFlags{.jovianActive = false};
+    // A real Ledger wired into the scheduler's m_ledger (the commit hook now calls
+    // prewriteBlockToBuffer). prewriteBlockToBuffer writes through the commit hook's MutableStorage
+    // (wrapped into a fresh LegacyStorageWrapper by prewriteBlock), so the Ledger's own
+    // m_stateStorage is only read by asyncGetTotalTransactionCount (SYS_CURRENT_STATE) — the
+    // seedSysTables call below makes that open succeed. LegacyStorageWrapper holds a reference;
+    // backendStorage is declared first and outlives it.
+    std::shared_ptr<bcos::storage::LegacyStorageWrapper<BackendMemStorage>> legacyLedgerStorage;
+    std::shared_ptr<bcos::ledger::Ledger> ledger;
+    bcos::IOServicePool::Ptr ioServicePool{std::make_shared<bcos::IOServicePool>(1)};
+    std::shared_ptr<bcos::executor_v1::opstack::OpScheduler<MLS>> scheduler;
+
+    Fixture()
+      : legacyLedgerStorage(
+            std::make_shared<bcos::storage::LegacyStorageWrapper<BackendMemStorage>>(
+                backendStorage)),
+        ledger(std::make_shared<bcos::ledger::Ledger>(blockFactory, legacyLedgerStorage, 1000)),
+        scheduler(std::make_shared<bcos::executor_v1::opstack::OpScheduler<MLS>>(receiptFactory,
+            hashImpl, kChainId, forkFlags, blockFactory, multiLayerStorage, ledger, ioServicePool))
+    {
+        seedSender(multiLayerStorage, kSender, hashImpl);
+        seedSysTables(multiLayerStorage);
+    }
+};
+
+// ── call/getCode case migration (verbatim from the deleted OpBlockSchedulerTest) ──
+// Once OpScheduler absorbed OpBlockScheduler's call/getCode pure-virtual implementations, the
+// original OpBlockSchedulerTest RPC-face cases (StatusAndResetNoOp / GetCodeEmpty /
+// CallInvalidReturnsError / CallHappyPathInjectsRealBaseFee) moved into this suite, with the driven
+// object changed to OpScheduler (f.scheduler).
+const bcos::Address kCallSender{"0x1000000000000000000000000000000000000000"};
+
+/// A genesis header carrying every field coCallLatest's buildOpBlockInfo/toBlockInfo reads
+/// (baseFee=1e9 is the target value of CallHappyPath's injection assertion).
+std::shared_ptr<bcostars::protocol::BlockHeaderImpl> makeCallGenesisHeader()
+{
+    auto h = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    h->setNumber(0);
+    h->setTimestamp(1000000);
+    h->setParentInfo(bcos::protocol::ParentInfo{.blockNumber = 0, .blockHash = bcos::h256{}});
+    h->setCoinbase(bcos::Address{});
+    h->setStateRoot(bcos::h256{});
+    h->setTxsRoot(bcos::h256{});
+    h->setReceiptsRoot(bcos::h256{});
+    h->setGasLimit(bcos::u256(30000000));
+    h->setGasUsed(bcos::u256(0));
+    h->setExtraData(bcos::bytes{});
+    h->setPrevRandao(bcos::h256{});
+    h->setBaseFee(bcos::u256(1000000000));
+    h->setWithdrawalsRoot(bcos::h256{});
+    h->setBlobGasUsed(bcos::u256(0));
+    h->setExcessBlobGas(bcos::u256(0));
+    h->setParentBeaconBlockRoot(bcos::h256{});
+    h->setRequestsHash(bcos::h256{});
+    return h;
+}
+
+/// Seed the minimal OP ledger the RPC call()/read paths need: current head (SYS_CURRENT_STATE)
+/// and the block-0 header (getBlockData(HEADER) reads SYS_NUMBER_2_BLOCK_HEADER by number).
+void seedCallGenesis(MLS& mls, bcos::protocol::BlockHeader::Ptr const& genesisHeader)
+{
+    auto view = mls.fork();
+    view.newMutable();
+    {
+        bcos::storage::Entry e;
+        e.set(boost::lexical_cast<std::string>(genesisHeader->number()));
+        bcos::task::syncWait(bcos::storage2::writeOne(view,
+            StateKey{bcos::ledger::SYS_CURRENT_STATE, bcos::ledger::SYS_KEY_CURRENT_NUMBER},
+            std::move(e)));
+    }
+    {
+        bcos::bytes buf;
+        genesisHeader->encode(buf);
+        bcos::storage::Entry e;
+        e.set(std::move(buf));
+        bcos::task::syncWait(bcos::storage2::writeOne(view,
+            StateKey{bcos::ledger::SYS_NUMBER_2_BLOCK_HEADER,
+                boost::lexical_cast<std::string>(genesisHeader->number())},
+            std::move(e)));
+    }
+    bcos::task::syncWait(mls.mergeView(std::move(view)));
+}
+
+/// Build an EIP-1559 (type 2) web3 tx wrapped as a tars Transaction::Ptr (lambda-holder form).
+/// EIP-1559 is deliberate: an EIP-2930/legacy tx with maxPriorityFeePerGas=0 would
+/// trigger BCOS2Evmone's access_list override (max_priority=max_gas), making effectiveGasPrice =
+/// maxFeePerGas instead of baseFee — a false positive; EIP-1559 keeps max_priority=0 so
+/// effectiveGasPrice == baseFee exactly (injection-sensitive).
+bcos::protocol::Transaction::Ptr buildWeb3Tx(
+    bcos::u256 maxFeePerGas, bcos::u256 maxPriorityFeePerGas)
+{
+    bcos::rpc::Web3Transaction w3{};
+    w3.type = bcos::rpc::TransactionType::EIP1559;
+    w3.chainId = 5;
+    w3.nonce = 0;
+    w3.maxFeePerGas = maxFeePerGas;
+    w3.maxPriorityFeePerGas = maxPriorityFeePerGas;
+    w3.gasLimit = 5000000;
+    w3.to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7");
+    w3.value = bcos::u256(0);
+    w3.signatureV = 0;
+    w3.signatureR = bcos::bytes(32, 0x01);
+    w3.signatureS = bcos::bytes(32, 0x02);
+    auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+    auto const txHash = w3.txHash();
+    tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tarsHolder]() { return tarsHolder.get(); });
+    // The dummy r/s cannot recover a sender; force it so opValidate sees the funded account.
+    tx->clearSenderAndHash();
+    tx->forceSender(kCallSender.asBytes());
+    return tx;
+}
+
+/// Fund an EOA so opValidate passes (same create()+setCode(empty) existence pattern as seedSender).
+void fundCallAccount(MLS& mls, bcos::Address const& addr, bcos::crypto::Hash::Ptr const& hashImpl,
+    bcos::u256 const& balance)
+{
+    auto view = mls.fork();
+    view.newMutable();
+    bcos::ledger::account::EVMAccount account(view, addr, /*rawAddress=*/false);
+    bcos::task::syncWait(account.create());
+    bcos::task::syncWait(account.setCode({}, {}, hashImpl->emptyHash()));
+    bcos::task::syncWait(account.setNonce("0"));
+    bcos::task::syncWait(account.setBalance(balance));
+    bcos::task::syncWait(mls.mergeView(std::move(view)));
+}
+
+/// Seed an account whose table carries a wrong-length storage slot row (32-byte key, 4-byte
+/// value). Storage2State::fetchAllStorage validates the slot value length (Storage2State.h:496-500)
+/// and throws std::length_error — the finalize bridge's visitAccounts (OpBlockExecute.h:170-177)
+/// hits it, so the block-level poison check (OpBlockExecute.h:178-183) rejects the block.
+void seedCorruptAccount(
+    MLS& mls, evmc::address const& addr, bcos::crypto::Hash::Ptr const& hashImpl)
+{
+    auto view = mls.fork();
+    view.newMutable();
+    bcos::ledger::account::EVMAccount account(view, addr, /*binaryAddress=*/false);
+    bcos::task::syncWait(account.create());
+    bcos::task::syncWait(account.setCode({}, {}, hashImpl->emptyHash()));
+    bcos::task::syncWait(account.setNonce("0"));
+    bcos::task::syncWait(account.setBalance(bcos::u256(0)));
+    bcos::storage::Entry e;
+    e.set(std::string("abcd"));  // 4 bytes — not a valid 32-byte slot value
+    bcos::task::syncWait(bcos::storage2::writeOne(view,
+        StateKey{bcos::evm::evmstate::accountTableName(addr), std::string(32, '\x01')},
+        std::move(e)));
+    bcos::task::syncWait(mls.mergeView(std::move(view)));
+}
+
+/// Direct execution probe (replaces the retired runOpBlockInjection, Task 5): assemble deposits +
+/// block-order transactions + OpstackExecutor, then drive the SAME shared path OpScheduler::execute
+/// uses — preBlockOpSteps → SchedulerSerialImpl(serial=true) → finalizeOpBlockResult — returning
+/// the OpExecuteBlockResult. The announced header is back-filled from this probe's commitments so
+/// the full executeBlock's six-way verify passes (equal by construction). preBlockOpSteps throws on
+/// block-level faults — the caller wraps the probe accordingly.
+bcos::evm::engine::OpExecuteBlockResult runExecutionProbe(Fixture& f, ViewType& view,
+    bcos::protocol::BlockHeader const& header, std::vector<bcos::bytes> const& rawTxBytes)
+{
+    namespace op = bcos::evm::opstack;
+    namespace detail = bcos::evm::engine::detail;
+    const auto& cfg = op::configAt(f.forkFlags);
+    // Build block-order transactions first (mirroring buildOpBlock: opEnvelopeToTars + full
+    // envelope overwrite).
+    std::vector<bcos::protocol::Transaction::ConstPtr> transactions;
+    transactions.reserve(rawTxBytes.size());
+    for (auto const& raw : rawTxBytes)
+    {
+        const auto txHash = f.hashImpl->hash(raw);
+        auto tarsTx = bcos::engine::detail::opEnvelopeToTars(raw, txHash);
+        if (!tarsTx)
+        {  // mirror buildOpBlock fallback: minimal tx (hash + wire bytes)
+            bcostars::Transaction fallback;
+            fallback.extraTransactionHash.assign(txHash.begin(), txHash.end());
+            fallback.extraTransactionBytes.assign(raw.begin(), raw.end());
+            tarsTx = std::move(fallback);
+        }
+        tarsTx->extraTransactionBytes.assign(raw.begin(), raw.end());
+        transactions.push_back(std::make_shared<bcostars::protocol::TransactionImpl>(
+            [tarsTx = std::move(*tarsTx)]() mutable { return &tarsTx; }));
+    }
+    // Deposits built from the Transaction objects (mirroring the execute hook, no RLP parse).
+    std::vector<op::DepositTx> deposits;
+    deposits.reserve(rawTxBytes.size());
+    for (std::size_t i = 0; i < rawTxBytes.size(); ++i)
+        if (rawTxBytes[i][0] == static_cast<uint8_t>(op::kDepositTxType))
+            deposits.push_back(bcos::executor_v1::opstack::OpstackExecutor::depositFromTransaction(
+                *transactions[i]));
+    bcos::ledger::LedgerConfig execLedgerConfig;
+    execLedgerConfig.setEVMCRevision(cfg.rev);
+    bcos::executor_v1::opstack::OpstackExecutor executor{f.receiptFactory, f.hashImpl, cfg};
+
+    std::optional<std::string> hashErr;
+    std::optional<uint16_t> daFootprintGasScalar;
+    std::optional<detail::RecentBlockHashes<ViewType>> hashes;
+    bcos::evm::engine::preBlockOpSteps(view, header, cfg, rawTxBytes, deposits, executor,
+        f.hashImpl, hashes, hashErr, daFootprintGasScalar);
+    bcos::executor_v1::opstack::OpBlockExecutionContext ctx{.fee = {},
+        .blockGasLeft = static_cast<int64_t>(header.gasLimit()),
+        .blockHashes = &*hashes,
+        .chainId = kChainId,
+        .daFootprintGasScalar = daFootprintGasScalar};
+    bcos::scheduler_v1::SchedulerSerialImpl serialScheduler(
+        f.ioServicePool, /*chunkSize=*/1, /*serial=*/true);
+    auto transactionsRefs =
+        transactions |
+        ::ranges::views::transform([](bcos::protocol::Transaction::ConstPtr const& ptr)
+                                       -> bcos::protocol::Transaction const& { return *ptr; });
+    auto receipts = bcos::task::syncWait(serialScheduler.executeBlock(
+        view, executor, header, transactionsRefs, execLedgerConfig, ctx));
+    return bcos::evm::engine::finalizeOpBlockResult(executor, view, header, execLedgerConfig, cfg,
+        receipts, rawTxBytes, ctx.cumulativeGasUsed, hashErr);
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpSchedulerSuite)
+
+/// After OpScheduler executeBlock + commitBlock, 7 SYS tables are persisted
+/// (SYS_NUMBER_2_HASH / SYS_HASH_2_NUMBER / SYS_NUMBER_2_BLOCK_HEADER / SYS_CURRENT_STATE /
+/// SYS_NUMBER_2_TXS / SYS_HASH_2_RECEIPT / SYS_HASH_2_TX). OP block execution/commit is genuinely
+/// persisted via OpScheduler (not a refused stub).
+BOOST_AUTO_TEST_CASE(CommitPersistsSevenLedgerTables)
+{
+    Fixture f;
+
+    // Corpus envelopes (same as ExecutesMinimalOpBlockEqualToDirectRouteB): deposit + eip1559.
+    auto depTx = makeDeposit();
+    bcos::bytes depEnv = encodeDepositEnvelope(depTx);
+    auto eipEvmcBytes = evmc::from_hex(kEip1559EnvelopeHex).value();
+    bcos::bytes eipEnvBytes(eipEvmcBytes.begin(), eipEvmcBytes.end());
+    std::vector<bcos::bytes> rawTxBytes{depEnv, eipEnvBytes};
+
+    auto header = makeHeader();
+
+    // The execution probe yields the real commitments; back-fill the announced header (so verify's
+    // six-field comparison passes). Same shared path as OpScheduler::execute (preBlockOpSteps →
+    // SchedulerSerialImpl → finalizeOpBlockResult), so the full executeBlock's verify passes.
+    auto viewA = f.multiLayerStorage.fork();
+    viewA.newMutable();
+    bcos::evm::engine::OpExecuteBlockResult resultA =
+        runExecutionProbe(f, viewA, *header, rawTxBytes);
+    BOOST_REQUIRE_EQUAL(resultA.receipts.size(), rawTxBytes.size());
+    fillAnnouncedHeader(header, resultA);
+
+    // Block assembly (full envelope).
+    auto block = f.blockFactory->createBlock();
+    block->setBlockHeader(header);
+    auto depFiscoTx = buildFiscoTx(depEnv, f.hashImpl);
+    auto eipFiscoTx = buildFiscoTx(eipEnvBytes, f.hashImpl);
+    BOOST_REQUIRE(depFiscoTx != nullptr);
+    BOOST_REQUIRE(eipFiscoTx != nullptr);
+    block->appendTransaction(depFiscoTx);
+    block->appendTransaction(eipFiscoTx);
+
+    // executeBlock → commitBlock (slot-3 driving).
+    bcos::Error::Ptr execErr;
+    bcos::protocol::BlockHeader::Ptr executedHeader;
+    bool called = false;
+    f.scheduler->executeBlock(
+        block, /*verify=*/true, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr h, bool) {
+            called = true;
+            execErr = std::move(e);
+            executedHeader = std::move(h);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE_MESSAGE(
+        execErr == nullptr, "executeBlock failed: " << (execErr ? execErr->errorMessage() : ""));
+    BOOST_REQUIRE(executedHeader != nullptr);
+
+    bcos::Error::Ptr commitErr;
+    called = false;
+    f.scheduler->commitBlock(
+        executedHeader, [&](bcos::Error::Ptr e, bcos::ledger::LedgerConfig::Ptr) {
+            called = true;
+            commitErr = std::move(e);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE_MESSAGE(commitErr == nullptr,
+        "commitBlock failed: " << (commitErr ? commitErr->errorMessage() : ""));
+
+    // ── 7-table persistence assertions ──
+    auto const blockNumberStr = boost::lexical_cast<std::string>(header->number());
+    auto& hashImpl = *f.blockFactory->cryptoSuite()->hashImpl();
+    auto view = f.multiLayerStorage.fork();
+    const auto expectedBlockHash = bcos::protocol::EthBlockHeader::computeHash(*header);
+
+    // 1. SYS_NUMBER_2_HASH[number] = blockHash (announced header opHeaderHash, commit hook key).
+    auto number2Hash = bcos::task::syncWait(
+        bcos::storage2::readOne(view, StateKey{bcos::ledger::SYS_NUMBER_2_HASH, blockNumberStr}));
+    BOOST_REQUIRE_MESSAGE(number2Hash.has_value(), "SYS_NUMBER_2_HASH must be written");
+    {
+        auto const& stored = number2Hash->get();
+        BOOST_REQUIRE_EQUAL(stored.size(), size_t(32));
+        // Compare as hex: the entry stores raw bytes as char (signed on AppleClang), so a
+        // byte-wise std::equal against h256's unsigned bytes fails for high bytes (>= 0x80).
+        BOOST_CHECK_EQUAL(bcos::toHex(stored), expectedBlockHash.hex());
+    }
+
+    // 2. SYS_HASH_2_NUMBER[blockHash] = number.
+    auto hash2Number = bcos::task::syncWait(
+        bcos::storage2::readOne(view, StateKey{bcos::ledger::SYS_HASH_2_NUMBER,
+                                          bcos::concepts::bytebuffer::toView(expectedBlockHash)}));
+    BOOST_REQUIRE_MESSAGE(hash2Number.has_value(), "SYS_HASH_2_NUMBER must be written");
+    BOOST_CHECK_EQUAL(std::string(hash2Number->get()), blockNumberStr);
+
+    // 3. SYS_NUMBER_2_BLOCK_HEADER[number] = tars header (non-empty).
+    auto headerEntry = bcos::task::syncWait(bcos::storage2::readOne(
+        view, StateKey{bcos::ledger::SYS_NUMBER_2_BLOCK_HEADER, blockNumberStr}));
+    BOOST_REQUIRE_MESSAGE(headerEntry.has_value(), "SYS_NUMBER_2_BLOCK_HEADER must be written");
+    BOOST_CHECK(!headerEntry->get().empty());
+
+    // 4. SYS_CURRENT_STATE[SYS_KEY_CURRENT_NUMBER] = number (head advanced).
+    auto currentState = bcos::task::syncWait(bcos::storage2::readOne(
+        view, StateKey{bcos::ledger::SYS_CURRENT_STATE, bcos::ledger::SYS_KEY_CURRENT_NUMBER}));
+    BOOST_REQUIRE_MESSAGE(currentState.has_value(), "SYS_CURRENT_STATE head must advance");
+    BOOST_CHECK_EQUAL(std::string(currentState->get()), blockNumberStr);
+
+    // 5. SYS_NUMBER_2_TXS[number] = tx metadata (SEV-10's 7th table).
+    auto number2Txs = bcos::task::syncWait(
+        bcos::storage2::readOne(view, StateKey{bcos::ledger::SYS_NUMBER_2_TXS, blockNumberStr}));
+    BOOST_REQUIRE_MESSAGE(number2Txs.has_value(), "SYS_NUMBER_2_TXS (SEV-10) must be written");
+    BOOST_CHECK(!number2Txs->get().empty());
+
+    // 6/7. SYS_HASH_2_RECEIPT + SYS_HASH_2_TX per tx.
+    for (auto const& env : rawTxBytes)
+    {
+        const auto txHash = hashImpl.hash(env);
+        auto receiptEntry = bcos::task::syncWait(
+            bcos::storage2::readOne(view, StateKey{bcos::ledger::SYS_HASH_2_RECEIPT,
+                                              bcos::concepts::bytebuffer::toView(txHash)}));
+        BOOST_REQUIRE_MESSAGE(
+            receiptEntry.has_value(), "SYS_HASH_2_RECEIPT must be written for tx " << txHash.hex());
+        auto txEntry = bcos::task::syncWait(bcos::storage2::readOne(view,
+            StateKey{bcos::ledger::SYS_HASH_2_TX, bcos::concepts::bytebuffer::toView(txHash)}));
+        BOOST_REQUIRE_MESSAGE(
+            txEntry.has_value(), "SYS_HASH_2_TX must be written for tx " << txHash.hex());
+    }
+
+    // OP never writes SYS_BLOCK_NUMBER_2_NONCES (prewriteBlockToBuffer writeNonces=false) -
+    // regression guard against the commit hook unexpectedly writing the nonce table.
+    auto noncesEntry = bcos::task::syncWait(bcos::storage2::readOne(
+        view, StateKey{bcos::ledger::SYS_BLOCK_NUMBER_2_NONCES, blockNumberStr}));
+    BOOST_CHECK_MESSAGE(!noncesEntry.has_value(),
+        "SYS_BLOCK_NUMBER_2_NONCES must NOT be written for OP commits (writeNonces=false)");
+}
+
+// ── RPC-face case migration (verbatim from the deleted OpBlockSchedulerTest; driven object
+//    changed to OpScheduler — call/getCode/status/reset inherited) ──
+
+/// Skeleton defaults to no-op status/reset (same semantics as OpBlockScheduler).
+BOOST_AUTO_TEST_CASE(StatusAndResetNoOp)
+{
+    Fixture f;
+    f.scheduler->status([&](bcos::Error::Ptr err, bcos::protocol::Session::ConstPtr) {
+        BOOST_REQUIRE(err == nullptr);
+    });
+    f.scheduler->reset([&](bcos::Error::Ptr err) { BOOST_REQUIRE(err == nullptr); });
+}
+
+/// Unknown address → empty code, no error (getCode only reads features, never calls
+/// getLedgerConfig; the OP header's empty dataHash doesn't touch BlockHeader::hash()).
+BOOST_AUTO_TEST_CASE(GetCodeEmpty)
+{
+    Fixture f;
+    seedCallGenesis(f.multiLayerStorage, makeCallGenesisHeader());
+    bool called = false;
+    f.scheduler->getCode(
+        "0x0000000000000000000000000000000000000001", [&](bcos::Error::Ptr err, bcos::bytes code) {
+            called = true;
+            BOOST_REQUIRE(err == nullptr);
+            BOOST_REQUIRE(code.empty());
+        });
+    BOOST_REQUIRE(called);
+}
+
+/// Invalid call (maxFeePerGas=1 < baseFee(1e9) trips evmone validate FEE_CAP_LESS_THAN_BLOCKS; an
+/// unfunded sender also trips the balance check) → JSON-RPC Error, never a status-0 receipt.
+BOOST_AUTO_TEST_CASE(CallInvalidReturnsError)
+{
+    Fixture f;
+    seedCallGenesis(f.multiLayerStorage, makeCallGenesisHeader());
+    auto tx = buildWeb3Tx(/*maxFeePerGas=*/1, /*maxPriorityFeePerGas=*/0);
+    bool called = false;
+    f.scheduler->call(
+        std::move(tx), [&](bcos::Error::Ptr err, bcos::protocol::TransactionReceipt::Ptr) {
+            called = true;
+            BOOST_REQUIRE(err != nullptr);  // Error (JSON-RPC), never a status-0 receipt
+        });
+    BOOST_REQUIRE(called);
+}
+
+/// Scheduler-level call-chain (OpScheduler::call → coCallLatest → buildOpBlockInfo) baseFee
+/// injection cross-check: maxPriorityFeePerGas=0 (EIP-1559, BCOS2Evmone access_list override not
+/// triggered) → effectiveGasPrice == base_fee + min(0, maxFee-base_fee) == base_fee exactly.
+/// Pre-fix buildOpBlockInfo injected base_fee=0 → egp "0x0"; post-fix the header baseFee(1e9)
+/// shines through — proving buildOpBlockInfo's baseFee fix takes effect on the scheduler-level
+/// call chain.
+BOOST_AUTO_TEST_CASE(CallHappyPathInjectsRealBaseFee)
+{
+    Fixture f;
+    seedCallGenesis(f.multiLayerStorage, makeCallGenesisHeader());
+    fundCallAccount(f.multiLayerStorage, kCallSender, f.hashImpl, bcos::u256(1) << 200);
+
+    auto tx = buildWeb3Tx(
+        /*maxFeePerGas=*/bcos::u256(30'000'000'000ULL), /*maxPriorityFeePerGas=*/0);
+
+    bcos::protocol::TransactionReceipt::Ptr got;
+    bcos::Error::Ptr err;
+    f.scheduler->call(
+        std::move(tx), [&](bcos::Error::Ptr e, bcos::protocol::TransactionReceipt::Ptr r) {
+            err = std::move(e);
+            got = std::move(r);
+        });
+    BOOST_REQUIRE_MESSAGE(
+        err == nullptr, "eth_call must succeed, got error: " << (err ? err->errorMessage() : ""));
+    BOOST_REQUIRE(got != nullptr);
+    // effectiveGasPrice is a hex string ("0x...", TransactionReceipt.h:75). Parse to u256 and
+    // assert
+    // == header baseFee(1e9) — exact (EIP-1559 + maxPriority=0 → effectiveGasPrice == baseFee).
+    const auto egp = bcos::u256(std::string(got->effectiveGasPrice()));
+    const auto baseFee = bcos::u256(1'000'000'000);
+    BOOST_CHECK_MESSAGE(
+        egp == baseFee, "effectiveGasPrice " << egp << " must equal header baseFee " << baseFee);
+}
+
+/// execute hook throws OpConsensusError (the 0x03 envelope is deterministically thrown by the
+/// type-byte classification) → skeleton classify → Error code == OpConsensusRejected.
+BOOST_AUTO_TEST_CASE(ConsensusRejectionClassifiedAsOpConsensusRejected)
+{
+    Fixture f;
+
+    auto block = f.blockFactory->createBlock();
+    block->setBlockHeader(makeHeader());
+    auto badTx = buildUnsupportedTypeTx();
+    BOOST_REQUIRE(badTx != nullptr);
+    block->appendTransaction(badTx);
+
+    bcos::Error::Ptr err;
+    bcos::protocol::BlockHeader::Ptr executedHeader;
+    bool called = false;
+    f.scheduler->executeBlock(
+        block, /*verify=*/true, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr h, bool) {
+            called = true;
+            err = std::move(e);
+            executedHeader = std::move(h);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK_EQUAL(err->errorCode(), (int)bcos::scheduler::SchedulerError::OpConsensusRejected);
+    BOOST_CHECK(executedHeader == nullptr);
+}
+
+/// Three-way classification direct call: OpConsensusError→OpConsensusRejected /
+/// OpStorageError→OpStorageFault / other→Unknown.
+BOOST_AUTO_TEST_CASE(ClassifyExceptionThreeWayMapping)
+{
+    Fixture f;
+
+    auto consensus = f.scheduler->classifyException(
+        std::make_exception_ptr(bcos::evm::engine::OpConsensusError{"block-level consensus"}));
+    BOOST_CHECK_EQUAL(consensus, bcos::scheduler::SchedulerError::OpConsensusRejected);
+
+    auto storage = f.scheduler->classifyException(
+        std::make_exception_ptr(bcos::evm::engine::OpStorageError{"ledger bridge poison"}));
+    BOOST_CHECK_EQUAL(storage, bcos::scheduler::SchedulerError::OpStorageFault);
+
+    auto unknown = f.scheduler->classifyException(
+        std::make_exception_ptr(std::runtime_error{"generic ethereum-mode fault"}));
+    BOOST_CHECK_EQUAL(unknown, bcos::scheduler::SchedulerError::UnknownError);
+}
+
+/// A storage-read fault during block execution rejects the whole block as OpStorageFault: the
+/// per-tx Storage2State instances share the block error slot with the finalize bridge (Part 2 of
+/// the StorageStateView→Storage2State merge), so a corrupt row discovered at finalize
+/// (visitAccounts → fetchAllStorage length check) poisons the shared sink and
+/// finalizeOpBlockResult throws OpStorageError — classified OpStorageFault, never a consensus
+/// INVALID or an UnknownError.
+BOOST_AUTO_TEST_CASE(StorageReadFaultRejectsBlockAsStorageFault)
+{
+    Fixture f;
+    constexpr evmc::address kPoisonAddr = 0x00000000000000000000000000000000deadc0de_address;
+    seedCorruptAccount(f.multiLayerStorage, kPoisonAddr, f.hashImpl);
+
+    // The minimal OP block from CommitPersistsSevenLedgerTables: L1 attributes deposit + one
+    // eip1559 transfer. Neither tx touches the corrupt account — it is only reached by the
+    // finalize bridge's visitAccounts.
+    auto depTx = makeDeposit();
+    bcos::bytes depEnv = encodeDepositEnvelope(depTx);
+    auto eipEvmcBytes = evmc::from_hex(kEip1559EnvelopeHex).value();
+    bcos::bytes eipEnvBytes(eipEvmcBytes.begin(), eipEvmcBytes.end());
+
+    auto header = makeHeader();
+    auto block = f.blockFactory->createBlock();
+    block->setBlockHeader(header);
+    auto depFiscoTx = buildFiscoTx(depEnv, f.hashImpl);
+    auto eipFiscoTx = buildFiscoTx(eipEnvBytes, f.hashImpl);
+    BOOST_REQUIRE(depFiscoTx != nullptr);
+    BOOST_REQUIRE(eipFiscoTx != nullptr);
+    block->appendTransaction(depFiscoTx);
+    block->appendTransaction(eipFiscoTx);
+
+    bcos::Error::Ptr err;
+    bcos::protocol::BlockHeader::Ptr executedHeader;
+    bool called = false;
+    f.scheduler->executeBlock(
+        block, /*verify=*/true, [&](bcos::Error::Ptr e, bcos::protocol::BlockHeader::Ptr h, bool) {
+            called = true;
+            err = std::move(e);
+            executedHeader = std::move(h);
+        });
+    BOOST_REQUIRE(called);
+    BOOST_REQUIRE(err != nullptr);
+    // Corrupt row → fetchAllStorage length_error → poisoned shared sink → OpStorageError,
+    // classified OpStorageFault (not a consensus INVALID, not an UnknownError).
+    BOOST_CHECK_EQUAL(err->errorCode(), (int)bcos::scheduler::SchedulerError::OpStorageFault);
+    BOOST_CHECK(executedHeader == nullptr);
+    // The message names the poison cause (diagnostic_information preserves what()).
+    BOOST_CHECK(err->errorMessage().find("poisoned") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/support/GoldenSample.h
+++ b/opstack-executor/tests/support/GoldenSample.h
@@ -1,0 +1,221 @@
+#pragma once
+// Golden sample loading + OP header decode + engine_newPayloadV4 params construction.
+// The golden encodedHeaderHex is op-geth v1.101702.2's full RLP header; parsed via FISCO's
+// BlockHeaderImpl::decodeOpHeader (BlockHeader.h:206, strict 21-field RLP inverse), and the
+// accessors build the params. Timestamp units: decodeOpHeader reads OP seconds and stores
+// FISCO milliseconds (x1000, BlockHeader.h:195 comment); params must convert back to OP
+// seconds (/1000).
+#include "SeedPreState.h"
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <engine/bcos-engine/EngineServiceImpl.h>
+#include <json/json.h>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace w6test
+{
+
+inline Json::Value loadJsonFile(std::string const& path)
+{
+    std::ifstream in(path);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(ss.str(), root))
+        throw std::runtime_error("loadJsonFile: parse failed: " + path);
+    return root;
+}
+
+struct GoldenSample
+{
+    std::string id;
+    Json::Value vector;  // vectors/<id>.json -> [<id>] (contains env/pre/_op_expected)
+    Json::Value golden;  // golden/engine/<id>.golden.json (contains
+                         // rawTransactions/encodedHeaderHex/blockHash)
+    bool jovian = false;
+};
+
+inline bool isJovianVector(Json::Value const& vec)
+{
+    const auto hardfork = vec["_info"]["hardfork"].asString();
+    if (hardfork == "jovian")
+        return true;
+    if (hardfork != "isthmus")
+        throw std::runtime_error("_info.hardfork must be exactly isthmus|jovian, got " + hardfork);
+    return false;
+}
+
+inline GoldenSample loadVectorSample(std::string const& id)
+{
+    GoldenSample sample;
+    sample.id = id;
+    auto root = loadJsonFile(std::string(OP_T8N_VECTORS_DIR) + "/" + id + ".json");
+    sample.vector = root[id];
+    sample.golden = loadJsonFile(std::string(OP_T8N_GOLDEN_ENGINE_DIR) + "/" + id + ".golden.json");
+    sample.jovian = isJovianVector(sample.vector);
+    return sample;
+}
+
+inline GoldenSample loadChainedSample(std::string const& name)
+{
+    GoldenSample sample;
+    sample.id = name;
+    sample.vector =
+        loadJsonFile(std::string(OP_T8N_GOLDEN_ENGINE_DIR) + "/chained/" + name + ".golden.json");
+    sample.golden = sample.vector;  // flat document is both vector and golden
+    sample.jovian = isJovianVector(sample.vector);
+    return sample;
+}
+
+/// Parses golden.encodedHeaderHex into a FISCO BlockHeaderImpl via decodeOpHeader.
+/// Returns nullptr on failure (decodeOpHeader returns Error::UniquePtr; non-null = failed).
+inline bcostars::protocol::BlockHeaderImpl::Ptr decodeGoldenHeader(GoldenSample const& sample)
+{
+    auto bytes = bcos::fromHex(sample.golden["encodedHeaderHex"].asString());
+    auto header = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    // Non-validating OP/ETH header RLP decode (EthBlockHeader::decodeTarsHeader — toTarsHeader's
+    // validateHeader rejects NON_ETH headers). Writes the 3 post-merge constants + all fields,
+    // RLP seconds → ms timestamp.
+    if (auto err = bcos::protocol::EthBlockHeader::decodeTarsHeader(header, bcos::ref(bytes));
+        err != nullptr)
+        throw std::runtime_error("decodeGoldenHeader: " + err->errorMessage());
+    return header;
+}
+
+inline std::string quantityOf(bcos::u256 const& v)
+{
+    // Warning: do not use v.str(16) — Boost multiprecision's str(streamsize, fmtflags)
+    // first arg is the number of digits, not the base; fmtflags(0) = decimal.
+    // bcos::toQuantity is the correct helper (DataConvertUtility.h:468).
+    return bcos::toQuantity(v);
+}
+
+inline std::string hexOfBytes(bcos::bytes const& b)
+{
+    std::string out = "0x";
+    for (auto byte : b)
+        out += "0123456789abcdef"[byte >> 4], out += "0123456789abcdef"[byte & 0xf];
+    return out;
+}
+
+inline std::string hexPrefixedH256(bcos::h256 const& h)
+{
+    return h.hexPrefixed();
+}
+
+/// Builds the engine_newPayloadV4 params JSON from the golden sample:
+/// [ExecutionPayload, expectedBlobVersionedHashes=[], parentBeaconBlockRoot].
+/// Field names strictly follow the engine_newPayloadV4 ExecutionPayload schema
+/// (keys read by parseNewPayloadRequest, EngineHelper.cpp:26-136); the shape follows
+/// W1 EngineHelperTest.cpp's V4 params.
+inline Json::Value makeParamsJson(GoldenSample const& sample)
+{
+    auto header = decodeGoldenHeader(sample);
+    auto const& golden = sample.golden;
+
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = hexPrefixedH256(header->parentInfo().blockHash);
+    ep["feeRecipient"] = "0x" + bcos::toHex(header->coinbase());  // Address is a contiguous range
+    ep["stateRoot"] = hexPrefixedH256(header->stateRoot());
+    ep["receiptsRoot"] = hexPrefixedH256(header->receiptsRoot());
+    ep["logsBloom"] =
+        hexOfBytes(bcos::bytes(header->logsBloom().begin(), header->logsBloom().end()));
+    ep["prevRandao"] = hexPrefixedH256(header->prevRandao());
+    ep["blockNumber"] = quantityOf(bcos::u256(header->number()));
+    ep["gasLimit"] = quantityOf(header->gasLimit());
+    ep["gasUsed"] = quantityOf(header->gasUsed());
+    // timestamp: OP seconds (decodeOpHeader stored milliseconds; /1000)
+    ep["timestamp"] = quantityOf(bcos::u256(header->timestamp() / 1000));
+    ep["extraData"] =
+        hexOfBytes(header->extraData().toBytes());         // extraData() returns bytesConstRef
+    ep["baseFeePerGas"] = quantityOf(*header->baseFee());  // baseFee() returns optional<u256>
+    ep["blockHash"] = golden["blockHash"].asString();
+    // OP path requires present-and-empty (validateOpNewPayloadRequest
+    // EngineServiceImpl.cpp:301-303)
+    ep["withdrawals"] = Json::Value(Json::arrayValue);
+    Json::Value txs(Json::arrayValue);
+    for (auto const& raw : golden["rawTransactions"])
+        txs.append(raw.asString());
+    ep["transactions"] = txs;
+    if (header->withdrawalsRoot())
+        ep["withdrawalsRoot"] = hexPrefixedH256(*header->withdrawalsRoot());
+    ep["blobGasUsed"] =
+        quantityOf(*header->blobGasUsed());  // optional<u256>, always filled by decodeOpHeader
+    ep["excessBlobGas"] =
+        quantityOf(*header->excessBlobGas());  // optional<u256>, always filled by decodeOpHeader
+
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+    params.append(Json::Value(Json::arrayValue));  // expectedBlobVersionedHashes = []
+    if (header->parentBeaconBlockRoot())
+        params.append(hexPrefixedH256(*header->parentBeaconBlockRoot()));
+    else
+        params.append(Json::Value(Json::nullValue));
+    return params;
+}
+
+/// Invalid-vector sample. `vector` is the full vector document (contains
+/// `_info`/`pre`/`_op_payload`/`_op_expected.reject`, optional `_op_canonical` — the
+/// -32603 two-pour canonical-sibling carrier).
+struct InvalidSample
+{
+    Json::Value vector;
+    bool jovian = false;
+    std::string hardfork;
+};
+
+/// Builds the ExecutionPayload JSON verbatim from `_op_payload` (the input to the engine's
+/// direct parseNewPayloadRequest). Field names/units align with makeParamsJson (timestamp
+/// seconds; Quantity hex); corrupted values + recomputed blockHash + base truths
+/// (logsBloom/extraData/withdrawalsRoot etc.) all come from `_op_payload`.
+/// - `withdrawals` is a fixed OP-path requirement (present-and-empty,
+///   EngineServiceImpl.cpp:332); when the vector omits it, pad an empty array;
+/// - null `blobGasUsed`/`excessBlobGas` in `_op_payload` must not enter ep —
+///   parseNewPayloadRequest's `isMember` + `fromBigQuantity("")` would throw; remove them;
+/// - `parentBeaconBlockRoot` is params[2] (not an ExecutionPayload field), so it does not
+///   enter ep.
+inline Json::Value makeInvalidParamsJson(InvalidSample const& sample)
+{
+    auto const& op = sample.vector["_op_payload"];
+    Json::Value ep(Json::objectValue);
+    for (auto const& member : op.getMemberNames())
+    {
+        if (member == "parentBeaconBlockRoot")
+            continue;  // not an ExecutionPayload field; passed via params[2]
+        ep[member] = op[member];
+    }
+    if (!ep.isMember("withdrawals"))
+        ep["withdrawals"] = Json::Value(Json::arrayValue);
+    if (!ep.isMember("transactions"))
+        ep["transactions"] = Json::Value(Json::arrayValue);  // static-face rawTransactions missing
+    if (ep.isMember("blobGasUsed") && ep["blobGasUsed"].isNull())
+        ep.removeMember("blobGasUsed");
+    if (ep.isMember("excessBlobGas") && ep["excessBlobGas"].isNull())
+        ep.removeMember("excessBlobGas");
+
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+    params.append(Json::Value(Json::arrayValue));  // expectedBlobVersionedHashes = []
+    if (op.isMember("parentBeaconBlockRoot") && !op["parentBeaconBlockRoot"].isNull())
+        params.append(op["parentBeaconBlockRoot"]);
+    else
+        params.append(Json::Value(Json::nullValue));
+    return params;
+}
+
+/// On-disk corpus loading (the generator emits `invalid_*.json`; the outer `{ "<stem>": {...} }`
+/// wrapper matches existing vectors).
+inline InvalidSample loadInvalidSample(std::string const& id)
+{
+    InvalidSample sample;
+    auto root = loadJsonFile(std::string(OP_T8N_VECTORS_DIR) + "/" + id + ".json");
+    sample.vector = root[id];
+    sample.hardfork = sample.vector["_info"]["hardfork"].asString();
+    sample.jovian = isJovianVector(sample.vector);
+    return sample;
+}
+
+}  // namespace w6test

--- a/opstack-executor/tests/support/GoldenSampleTest.cpp
+++ b/opstack-executor/tests/support/GoldenSampleTest.cpp
@@ -1,0 +1,138 @@
+// bcos-evm/test/opstack/support/GoldenSampleTest.cpp
+#include "GoldenSample.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <string>
+#include <string_view>
+
+BOOST_AUTO_TEST_SUITE(GoldenSampleSuite)
+
+BOOST_AUTO_TEST_CASE(LoadVectorAndGolden)
+{
+    auto sample = w6test::loadVectorSample("jovian_deposit_only");
+    BOOST_CHECK_EQUAL(sample.id, "jovian_deposit_only");
+    // vector has env/pre/_op_expected; golden has rawTransactions/encodedHeaderHex/blockHash
+    BOOST_CHECK(sample.vector.isMember("pre"));
+    BOOST_CHECK(sample.vector.isMember("env"));
+    BOOST_CHECK(sample.golden.isMember("rawTransactions"));
+    BOOST_CHECK(sample.golden.isMember("encodedHeaderHex"));
+    BOOST_CHECK(sample.golden.isMember("blockHash"));
+    BOOST_CHECK(sample.jovian);  // _info.hardfork == "jovian"
+}
+
+BOOST_AUTO_TEST_CASE(DecodeGoldenHeaderRoundTrip)
+{
+    auto sample = w6test::loadVectorSample("jovian_deposit_only");
+    auto header = w6test::decodeGoldenHeader(sample);
+    BOOST_REQUIRE(header != nullptr);
+    // Byte-equivalence gate: EthBlockHeader::rlpEncode must reproduce the golden encodedHeaderHex
+    // (the golden was pinned against the former BlockHeader::encodeOpHeader — same 21-field order
+    // + NON_ETH ms→s /1000). decodeTarsHeader is the strict inverse; the roundtrip must match.
+    bcos::bytes encoded;
+    bcos::protocol::EthBlockHeader(*header).rlpEncode(encoded);
+    BOOST_CHECK(encoded == bcos::fromHex(sample.golden["encodedHeaderHex"].asString()));
+    // computeHash = keccak256(rlpEncode) == golden.blockHash
+    BOOST_CHECK_EQUAL(bcos::protocol::EthBlockHeader::computeHash(*header).hex(),
+        std::string(sample.golden["blockHash"].asString()).substr(2));
+}
+
+BOOST_AUTO_TEST_CASE(MakeParamsJsonShape)
+{
+    auto sample = w6test::loadVectorSample("jovian_deposit_only");
+    auto params = w6test::makeParamsJson(sample);
+    // engine_newPayloadV4 params = [ExecutionPayload, blobHashes, parentBeaconBlockRoot]
+    BOOST_REQUIRE(params.isArray());
+    BOOST_REQUIRE(params.size() >= 3);
+    auto const& ep = params[0u];
+    BOOST_CHECK(ep.isMember("parentHash"));
+    BOOST_CHECK(ep.isMember("stateRoot"));
+    BOOST_CHECK(ep.isMember("receiptsRoot"));
+    BOOST_CHECK(ep.isMember("logsBloom"));
+    BOOST_CHECK(ep.isMember("transactions"));
+    BOOST_CHECK(ep.isMember("blockHash"));
+    BOOST_CHECK(ep.isMember("withdrawalsRoot"));
+    // OP path requires withdrawals present-and-empty (validateOpNewPayloadRequest hard requirement)
+    BOOST_CHECK(ep.isMember("withdrawals"));
+    BOOST_CHECK(ep["withdrawals"].isArray());
+    BOOST_CHECK_EQUAL(ep["withdrawals"].size(), 0);
+    BOOST_CHECK(ep["timestamp"].asString().size() >= 3);  // "0x..."
+    // rawTransactions go into transactions verbatim (parse-layer decode is fault-tolerant; raw is
+    // always retained)
+    BOOST_CHECK_EQUAL(ep["transactions"].size(), 1);  // jovian_deposit_only has 1 deposit
+}
+
+BOOST_AUTO_TEST_CASE(ManifestCorpusConsistency)
+{
+    // D4: automatic golden-manifest validation — manifest.txt (non-comment lines) ↔
+    // vectors/*.json ↔ golden/engine/*.golden.json must be consistent. Guards against
+    // missing vectors (should have been generated), orphan vectors, and manifest drift —
+    // beyond regen.sh's manual diff, this is checked at test runtime (catches corpus
+    // changes even when regen is not rerun).
+    auto basenameSet = [](std::filesystem::path const& dir, std::string_view suffix) {
+        std::set<std::string> names;
+        for (auto const& entry : std::filesystem::directory_iterator(dir))
+        {
+            if (!entry.is_regular_file())
+                continue;
+            auto name = entry.path().filename().string();
+            if (name.size() > suffix.size() &&
+                name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0)
+                names.insert(name.substr(0, name.size() - suffix.size()));
+        }
+        return names;
+    };
+
+    // manifest.txt: non-comment, non-blank lines -> basename (suffix .json stripped)
+    std::set<std::string> manifest;
+    {
+        std::ifstream in(std::string(OP_T8N_VECTORS_DIR) + "/manifest.txt");
+        BOOST_REQUIRE(in.good());
+        std::string line;
+        while (std::getline(in, line))
+        {
+            if (line.empty() || line[0] == '#')
+                continue;
+            constexpr std::string_view kJsonSuffix = ".json";
+            if (line.size() > kJsonSuffix.size() && line.compare(line.size() - kJsonSuffix.size(),
+                                                        kJsonSuffix.size(), kJsonSuffix) == 0)
+                line.resize(line.size() - kJsonSuffix.size());
+            manifest.insert(line);
+        }
+    }
+
+    auto vectors = basenameSet(OP_T8N_VECTORS_DIR, ".json");
+    // Static items 3/12 (expectedBlobVersionedHashes/executionRequests) are generated but
+    // forced out of the manifest (inexpressible through the GoldenSample loader) — set
+    // equality exempts them (Task 6, same as OpT8nReplayTest.cpp's isUnregisteredStatic;
+    // entries have .json stripped). "_static_3"=9 chars / "_static_12"=10 chars.
+    const auto isUnregisteredStatic = [](std::string const& n) {
+        return (n.size() >= 9 && n.rfind("_static_3") == n.size() - 9) ||
+               (n.size() >= 10 && n.rfind("_static_12") == n.size() - 10);
+    };
+    for (auto it = vectors.begin(); it != vectors.end();)
+    {
+        if (isUnregisteredStatic(*it))
+            it = vectors.erase(it);
+        else
+            ++it;
+    }
+    auto golden = basenameSet(OP_T8N_GOLDEN_ENGINE_DIR, ".golden.json");
+
+    BOOST_CHECK_MESSAGE(manifest == vectors,
+        "manifest.txt vs vectors/ basename sets mismatch (missing/orphan/drifted)");
+    // golden/engine is a subset of the engine-gate golden ritual: the line-B
+    // (precompile-matrix) golden extension is a recorded deferred obligation (the
+    // differential gate does not consume golden/, does not block acceptance), so vectors
+    // may exceed golden. The assertion is tightened to golden ⊆ vectors: every golden must
+    // have a corresponding vector (no orphan golden), while deferred vectors are tolerated.
+    BOOST_CHECK_MESSAGE(std::includes(vectors.begin(), vectors.end(), golden.begin(), golden.end()),
+        "golden/engine vs vectors/ sets mismatch (orphan golden / missing vector)");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/support/OpDepositEncode.h
+++ b/opstack-executor/tests/support/OpDepositEncode.h
@@ -1,0 +1,22 @@
+#pragma once
+// Test-only deposit-envelope encoder. Production buildOpBlock / DepositTxHandler encode deposit
+// envelopes; the tests rebuild them from a DepositTx for rawTxBytes classification + txRoot.
+#include "RlpEncodeTuple.h"
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-utilities/Common.h>
+#include <evmc/evmc.hpp>
+
+// 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data]).
+inline bcos::bytes encodeDepositEnvelope(const bcos::evm::opstack::DepositTx& d)
+{
+    using bcos::evm::eth::detail::encodeTuple;
+    auto body = encodeTuple(evmc::bytes_view(d.source_hash), evmc::bytes_view(d.from),
+        d.to.has_value() ? evmc::bytes_view(*d.to) : evmc::bytes_view{}, d.mint.value_or(0),
+        d.value, static_cast<uint64_t>(d.gas_limit),
+        static_cast<uint64_t>(d.is_system_tx ? 1 : 0), d.data);
+    bcos::bytes out;
+    out.reserve(body.size() + 1);
+    out.push_back(0x7e);
+    out.insert(out.end(), body.begin(), body.end());
+    return out;
+}

--- a/opstack-executor/tests/support/RlpEncodeTuple.h
+++ b/opstack-executor/tests/support/RlpEncodeTuple.h
@@ -1,0 +1,140 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+// Test-support header: canonical RLP tuple encoder (bcos::evm::eth::detail::encodeTuple) used
+// ONLY by test code — currently OpDepositEncode.h (0x7e deposit-envelope reconstruction).
+//
+// Byte-for-byte equivalents of the evmone *test-only* RLP encoder (test/utils/rlp.hpp +
+// test/utils/rlp_encode.hpp), rebuilt on the production bcos-codec encoder. `encodeTuple` mirrors
+// evmone::rlp::encode_tuple. Lives in the opstack test tree because it has no production consumer.
+// (a list header + each element's canonical RLP); the element dispatch (`encodeRlp`) covers
+// exactly the types the consumers need — unsigned scalars, intx::uint256, fixed-width evmc
+// bytes, and the access/authorization lists. Equivalence to evmone is asserted by the
+// 125-vector golden corpus plus the whole-envelope `assertCanonicalRoundTrip` in OpTxDecode.h.
+
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-evm/eth/state/transaction.hpp>
+#include <concepts>
+#include <cstdint>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+#include <utility>
+#include <vector>
+
+namespace bcos::evm::eth::detail
+{
+/// RLP integer scalar for intx::uint256 (bcos-codec has no intx overload): 0 -> 0x80, otherwise
+/// minimal big-endian + length prefix — identical to evmone::rlp::encode(const intx::uint256&).
+inline void encodeRlp(bcos::bytes& to, const intx::uint256& x)
+{
+    if (x == 0)
+    {
+        to.push_back(bcos::codec::rlp::BYTES_HEAD_BASE);
+        return;
+    }
+    uint8_t be[sizeof(intx::uint256)]{};
+    intx::be::store(be, x);
+    size_t first = 0;
+    while (be[first] == 0)
+        ++first;
+    const size_t len = sizeof(intx::uint256) - first;
+    if (len == 1 && be[first] < bcos::codec::rlp::BYTES_HEAD_BASE)
+    {
+        to.push_back(be[first]);
+        return;
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = false, .payloadLength = len});
+    to.insert(to.end(), be + first, be + sizeof(intx::uint256));
+}
+
+/// Unsigned integer scalars (bcos-codec's UnsignedByte path already matches evmone for these).
+/// Promoted to uint64_t first: the uint8_t path would instantiate the byte overload of
+/// bcos::toCompactBigEndian, which is declared inline in the header but defined in a .cpp —
+/// -Werror,-Wundefined-inline fires in any TU that instantiates it. uint64_t is byte-identical
+/// RLP for every scalar the consumers produce (evmone promotes uint8_t to uint64_t the same way).
+inline void encodeRlp(bcos::bytes& to, std::unsigned_integral auto v) noexcept
+{
+    bcos::codec::rlp::encode(to, static_cast<uint64_t>(v));
+}
+
+inline void encodeRlp(bcos::bytes& to, evmc::bytes_view v)
+{
+    bcos::codec::rlp::encode(to, bcos::bytesConstRef(v.data(), v.size()));
+}
+
+inline void encodeRlp(bcos::bytes& to, const evmc::bytes& b)
+{
+    encodeRlp(to, evmc::bytes_view(b.data(), b.size()));
+}
+
+inline void encodeRlp(bcos::bytes& to, const evmc::address& a)
+{
+    encodeRlp(to, evmc::bytes_view(a));
+}
+
+inline void encodeRlp(bcos::bytes& to, const evmc::bytes32& h)
+{
+    encodeRlp(to, evmc::bytes_view(h));
+}
+
+inline void encodeRlp(bcos::bytes& to, const std::vector<evmc::bytes32>& keys)
+{
+    bcos::bytes payload;
+    for (const auto& key : keys)
+        encodeRlp(payload, key);
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = payload.size()});
+    to.insert(to.end(), payload.begin(), payload.end());
+}
+
+/// Access list: rlp([ [address, [storageKey...]], ... ]) — each pair encodes as an RLP list of
+/// (address, keys-list), matching evmone's pair overload.
+inline void encodeRlp(bcos::bytes& to, const evmone::state::AccessList& al)
+{
+    bcos::bytes payload;
+    for (const auto& [addr, keys] : al)
+    {
+        bcos::bytes item;
+        encodeRlp(item, addr);
+        encodeRlp(item, keys);
+        bcos::codec::rlp::encodeHeader(payload, {.isList = true, .payloadLength = item.size()});
+        payload.insert(payload.end(), item.begin(), item.end());
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = payload.size()});
+    to.insert(to.end(), payload.begin(), payload.end());
+}
+
+/// EIP-7702 authorization list: rlp([ [chainId, address, nonce, v, r, s], ... ]) — same field
+/// order as evmone::state::rlp_encode(const Authorization&).
+inline void encodeRlp(bcos::bytes& to, const evmone::state::AuthorizationList& al)
+{
+    bcos::bytes payload;
+    for (const auto& auth : al)
+    {
+        bcos::bytes item;
+        encodeRlp(item, auth.chain_id);
+        encodeRlp(item, auth.addr);
+        encodeRlp(item, auth.nonce);
+        encodeRlp(item, auth.v);
+        encodeRlp(item, auth.r);
+        encodeRlp(item, auth.s);
+        bcos::codec::rlp::encodeHeader(payload, {.isList = true, .payloadLength = item.size()});
+        payload.insert(payload.end(), item.begin(), item.end());
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = payload.size()});
+    to.insert(to.end(), payload.begin(), payload.end());
+}
+
+/// evmone::rlp::encode_tuple equivalent: RLP-list-encodes the heterogeneous args. Returns
+/// evmc::bytes so call sites keep `evmc::bytes{0x02} + encodeTuple(...)` concatenation intact.
+template <typename... Args>
+inline evmc::bytes encodeTuple(const Args&... args)
+{
+    bcos::bytes payload;
+    (encodeRlp(payload, args), ...);
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payload.size()});
+    out.insert(out.end(), payload.begin(), payload.end());
+    return evmc::bytes(out.begin(), out.end());
+}
+}  // namespace bcos::evm::eth::detail

--- a/tools/op-block-check.sh
+++ b/tools/op-block-check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# op-block-check：跑代码裁决 wrapper（零新 C++，复用现有 Boost 测试）
+REPO="$(git rev-parse --show-toplevel)"
+BLOCK_TESTS="${BLOCK_TESTS:-$REPO/build/opstack-executor/tests/opstack-executor-block-tests}"
+VECTORS_DIR="$REPO/opstack-executor/tests/t8n/vectors"
+
+# 前置：向量 json 必须存在（.gitignore'd + CI 现场生成；manifest.txt 是跟踪的，不能当哨兵）
+if ! ls "$VECTORS_DIR"/*.json >/dev/null 2>&1; then
+  echo "ERROR: t8n 向量 json 缺失（需 Go 工具链 + op-geth@pin 克隆）。先跑:" >&2
+  echo "  bash opstack-executor/tests/t8n/generator/ensure-vectors.sh" >&2
+  exit 2
+fi
+if [ ! -x "$BLOCK_TESTS" ]; then
+  echo "ERROR: 测试二进制缺失。先构建: ninja -C build opstack-executor-block-tests" >&2
+  exit 2
+fi
+
+echo "== 跑 opstack-executor-block-tests（整二进制 = CI gate，含 Path A/B）=="
+rc=0
+OUT="$("$BLOCK_TESTS" 2>&1)" || rc=$?    # 捕获退出码（主信号），不 set -e 中断
+echo "$OUT"
+
+# 汇总（诊断辅助；成败以 rc 为准）
+KNOWN=$(echo "$OUT" | grep -c 'KNOWN-DIVERGE' || true)
+SUMMARY=$(echo "$OUT" | grep 'single-path summary:' || echo "single-path summary: <absent>")
+
+if [ "${rc}" -eq 0 ]; then
+  echo "PASS 全绿 exempt=$KNOWN | $SUMMARY"
+  exit 0
+fi
+# 失败/崩溃区分（rc 免疫输出格式漂移）；先判 200（setup 错误），再判 >=128（信号崩溃）
+if [ "${rc}" -eq 200 ]; then
+  echo "FAIL 测试 setup 错误（filter 无匹配等）rc=200; $SUMMARY" >&2
+elif [ "${rc}" -ge 128 ]; then
+  echo "FAIL 测试二进制崩溃 signal=$((rc-128)); exempt=$KNOWN | $SUMMARY" >&2
+  echo "$OUT" | grep -E 'Segmentation fault|Abort|Signal' | head -5 >&2 || true
+else
+  echo "FAIL 有测试失败 rc=${rc}; exempt=$KNOWN | $SUMMARY" >&2
+  echo "$OUT" | grep -E 'error: in|failures are detected' | head -20 >&2 || true
+fi
+exit 1


### PR DESCRIPTION
## Summary

Part **7 of 7** — engine service implementation and final wiring.

> **Depends on**: Part 6 (opstack-s06) — web3 handlers pt2 + model.

## What's in this part
- **EngineServiceImpl** — engine service implementation
- **libinitializer** — engine service initializer
- **ethereum-executor** — EEST/t8n CI tests
- **tools** — op-block-check script

## Verification
- Commit Check: valid insertions = **477** (≤ 666 limit)

Split from #5429 | Part 7/7