### PR TITLE
feat(opstack): part 4/7 — web3 handlers + model (split from #5429)

### DIFF
--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -161,6 +161,18 @@ struct ExecutionPayload
     std::optional<bytes> blockAccessList = std::nullopt;
     std::optional<std::uint64_t> slotNumber = std::nullopt;
 
+    /// OP-mode carrier fields (op-validator-loop design §4.2/§5.2). Both are optional and unread
+    /// by the generic (non-OP) engine path — zero behavioral change for existing callers.
+    /// - rawTransactions: the block's transactions as raw EIP-2718 envelope bytes (typed tx
+    ///   MarshalBinary() output, including the OP 0x7E deposit envelope). This is the OP path's
+    ///   only transaction carrier consumed by `bcos::evm::engine::OpSchedulerSeam::executeOpBlock`
+    ///   (via its `rawTxBytes` parameter) — `transactions` above (bcos::protocol::Transactions)
+    ///   is the generic-path carrier and is not populated/read on the OP path.
+    /// - withdrawalsRoot: OP Isthmus+ extends the payload with an explicit withdrawals-root field
+    ///   (= MessagePasser storage root) that cannot be derived from the (always-empty)
+    ///   `withdrawals` list above — op-geth's NewPayloadV4 requires it on OP chains (design §5.2).
+    std::optional<std::vector<bytes>> rawTransactions;
+
     // Required by ExecutionPayloadV4/V5 (OP Stack, Isthmus onwards): storage root of
     // the L2ToL1MessagePasser predeploy. May carry a placeholder until real-value
     // header wiring lands.

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -84,7 +84,8 @@ void JsonRpcImpl_2_0::handleRpcRequest(
     auto weakptrSession = std::weak_ptr<boostssl::ws::WsSession>(_session);
     auto messageFactory = m_wsService->messageFactory();
 
-    onRPCRequest(req, [ext, seq, version, weakptrSession, messageFactory, start](bcos::bytes resp, boost::beast::http::status) {
+    onRPCRequest(req, [ext, seq, version, weakptrSession, messageFactory, start](
+                          bcos::bytes resp, boost::beast::http::status) {
         auto session = weakptrSession.lock();
 
         auto end = std::chrono::high_resolution_clock::now();
@@ -254,7 +255,9 @@ void bcos::rpc::toJsonResp(Json::Value& jResp, bcos::protocol::Transaction const
         codec::rlp::decodeFromPayload(extraBytesRef, web3Tx);
         jResp["value"] = web3Tx.value.str();
         jResp["gasLimit"] = web3Tx.gasLimit;
-        if (web3Tx.type >= TransactionType::EIP1559)
+        // Use explicit range check rather than `>=` so that Deposit (0x7e), which is numerically
+        // larger than all EIP types, is excluded from EIP-1559 field output.
+        if (web3Tx.type >= TransactionType::EIP1559 && web3Tx.type <= TransactionType::EIP4844)
         {
             jResp["maxPriorityFeePerGas"] = web3Tx.maxPriorityFeePerGas.str();
             jResp["maxFeePerGas"] = web3Tx.maxFeePerGas.str();

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -727,9 +727,11 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     auto rawTx = toView(request[0U]);
     auto rawTxBytes = fromHexWithPrefix(rawTx);
     auto bytesRef = bcos::ref(rawTxBytes);
-    // Authoritative first-byte dispatch (RawTransactionDispatch.h). L2 never admits blob
-    // (type-3) transactions, and deposits (0x7e) can only be injected by the consensus
-    // layer through the Engine API, never through the public transaction pool.
+    // Authoritative first-byte dispatch (RawTransactionDispatch.h). FISCO's OP policy rejects
+    // blob (type-3) at the gate — op-geth's decodeTyped accepts them, so this is a deliberate
+    // acceptance divergence, not a reference check (see the OpScheduler.h type-byte gate note).
+    // Deposits (0x7e) can only be injected by the consensus layer through the Engine API, never
+    // through the public transaction pool.
     switch (engine::dispatchRawTransaction(bytesRef))
     {
     case engine::RawTransactionKind::Blob:
@@ -745,6 +747,14 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     if (auto const error = codec::rlp::decode(bytesRef, web3Tx); error != nullptr) [[unlikely]]
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, error->errorMessage()));
+    }
+    // op-geth rejects Deposit (0x7e) from eth_sendRawTransaction
+    // (ErrTxTypeNotSupported); deposits only enter via the derivation/engine
+    // path, never from a client RPC submission.
+    if (web3Tx.type == TransactionType::Deposit) [[unlikely]]
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams,
+            "Deposit (0x7e) transactions are not supported via eth_sendRawTransaction"));
     }
     auto encodeTxHash = web3Tx.txHash();
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -2,9 +2,9 @@
 #include "Log.h"
 #include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
-#include <bcos-crypto/hash/Keccak256.h>
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-crypto/hash/Keccak256.h>
 #include <cstdint>
 
 void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::TransactionReceipt& receipt,
@@ -85,14 +85,49 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
         logs.push_back(std::move(logObj));
     }
     result["logsBloom"] = toHexStringWithPrefix(receipt.logsBloom());
+    // EIP-2718 tx type: for a Web3 tx the authoritative kind is the `web3TypedTxKind` tars slot,
+    // populated by Web3Transaction::takeToTarsTransaction for EVERY Web3 kind (Legacy=0,
+    // EIP-2930=1, EIP-1559=2, EIP-4844=3, Deposit=0x7e). Byte-sniffing extraTransactionBytes was
+    // wrong for typed non-deposit txs: the write side stores encodeForSign() there (RLP WITHOUT
+    // the type byte, first byte is a 0xC0+ list header), so the old `< BYTES_HEAD_BASE` sniff
+    // collapsed EIP-2930/1559/4844 receipts into Legacy 0x0 — while eth_getTransactionByHash
+    // correctly reported 0x01/0x02/0x03. For non-Web3 (BCOS) txs web3TypedTxKind() is 0 == Legacy,
+    // matching the old empty-extraTransactionBytes path.
     auto type = TransactionType::Legacy;
-    if (!tx.extraTransactionBytes().empty())
+    if (tx.type() == bcos::protocol::TransactionType::Web3Transaction)
     {
-        if (auto firstByte = tx.extraTransactionBytes()[0];
-            firstByte < bcos::codec::rlp::BYTES_HEAD_BASE)
-        {
-            type = static_cast<TransactionType>(firstByte);
-        }
+        type = static_cast<TransactionType>(tx.web3TypedTxKind());
     }
     result["type"] = toQuantity(static_cast<uint64_t>(type));
+    // OP extension fields (aligned with op-geth MarshalReceipt). Empty opStackMeta → no output
+    // (never zero/default values); each field is null-checked independently and never throws (D7).
+    if (auto meta = receipt.opStackMeta())
+    {
+        if (meta->l1_gas_price)
+            result["l1GasPrice"] = toQuantity(*meta->l1_gas_price);
+        if (meta->l1_gas_used)
+            result["l1GasUsed"] = toQuantity(*meta->l1_gas_used);
+        if (meta->l1_fee)
+            result["l1Fee"] = toQuantity(*meta->l1_fee);
+        if (meta->l1_blob_base_fee)
+            result["l1BlobBaseFee"] = toQuantity(*meta->l1_blob_base_fee);
+        if (meta->l1_base_fee_scalar)
+            result["l1BaseFeeScalar"] = toQuantity(*meta->l1_base_fee_scalar);
+        if (meta->l1_blob_base_fee_scalar)
+            result["l1BlobBaseFeeScalar"] = toQuantity(*meta->l1_blob_base_fee_scalar);
+        if (meta->operator_fee_scalar)
+            result["operatorFeeScalar"] = toQuantity(*meta->operator_fee_scalar);
+        if (meta->operator_fee_constant)
+            result["operatorFeeConstant"] = toQuantity(*meta->operator_fee_constant);
+        if (meta->da_footprint_gas_scalar)
+            result["daFootprintGasScalar"] = toQuantity(*meta->da_footprint_gas_scalar);
+        if (meta->da_footprint)
+            result["blobGasUsed"] = toQuantity(*meta->da_footprint);  // Jovian reuses da_footprint
+        if (meta->deposit_nonce)
+            result["depositNonce"] = toQuantity(*meta->deposit_nonce);
+        if (meta->deposit_receipt_version)
+            result["depositReceiptVersion"] = toQuantity(*meta->deposit_receipt_version);
+        if (meta->operator_fee)
+            result["operatorFee"] = toQuantity(*meta->operator_fee);  // FISCO extension
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -91,7 +91,9 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
         result["nonce"] = toQuantity(web3Tx.nonce);
         result["type"] = toQuantity(static_cast<uint8_t>(web3Tx.type));
         result["value"] = toQuantity(web3Tx.value);
-        if (web3Tx.type >= TransactionType::EIP2930)
+        // Use explicit range checks rather than `>=` so that Deposit (0x7e), which is numerically
+        // larger than all EIP types, is excluded from EIP-specific field output.
+        if (web3Tx.type >= TransactionType::EIP2930 && web3Tx.type <= TransactionType::EIP4844)
         {
             result["accessList"] = Json::arrayValue;
             result["accessList"].resize(web3Tx.accessList.size());
@@ -109,13 +111,13 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
                 result["accessList"].append(std::move(access));
             }
         }
-        if (web3Tx.type >= TransactionType::EIP1559)
+        if (web3Tx.type >= TransactionType::EIP1559 && web3Tx.type <= TransactionType::EIP4844)
         {
             result["maxPriorityFeePerGas"] = toQuantity(web3Tx.maxPriorityFeePerGas);
             result["maxFeePerGas"] = toQuantity(web3Tx.maxFeePerGas);
         }
         result["chainId"] = toQuantity(web3Tx.chainId.value_or(0));
-        if (web3Tx.type >= TransactionType::EIP4844)
+        if (web3Tx.type == TransactionType::EIP4844)
         {
             result["maxFeePerBlobGas"] = web3Tx.maxFeePerBlobGas.str();
             result["blobVersionedHashes"] = Json::arrayValue;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
@@ -19,101 +19,118 @@
  */
 
 #include "Web3Transaction.h"
+#include "Web3TxHandler.h"
 #include "bcos-utilities/Common.h"
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-framework/protocol/Transaction.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>  // bcos::fromBigEndian (checkEip2Signature reuse, review #5429 S)
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/move.hpp>
 #include <limits>
+#include <range/v3/algorithm/move.hpp>
 #include <utility>
 
 namespace bcos
 {
+namespace
+{
+// EIP-2 canonical-s guard. The secp256k1 group order n and its half. A signature with s > n/2 is
+// "malleable": flipping s -> n - s recovers the same sender and executes byte-for-byte
+// identically, so op-geth rejects it at both admission and block processing. Without this check a
+// mixed-deployment OP chain would silently fork.
+const u256 c_secp256k1n("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+const u256 c_secp256k1nOver2 = c_secp256k1n / 2;
+
+/// Returns a decode error if r/s fall outside EIP-2's valid range (r,s in [1, n-1], s <= n/2),
+/// else nullptr. r/s are the raw 32-byte big-endian scalars (already zero-padded by the handler).
+bcos::Error::UniquePtr checkEip2Signature(
+    bcos::bytes const& signatureR, bcos::bytes const& signatureS)
+{
+    // r/s are raw 32-byte big-endian scalars — decode in place instead of round-tripping through a
+    // "0x"+hex string + u256 parse (4 heap allocations per tx on the shared decode funnel).
+    const u256 r = bcos::fromBigEndian<u256>(signatureR);
+    const u256 s = bcos::fromBigEndian<u256>(signatureS);
+    if (r == 0 || r >= c_secp256k1n || s == 0 || s >= c_secp256k1n || s > c_secp256k1nOver2)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+            "EIP-2: invalid signature (r/s out of [1,n-1], or s exceeds secp256k1n/2 — "
+            "malleable signature)");
+    }
+    return nullptr;
+}
+}  // namespace
+
 namespace rpc
 {
+// These three using-declarations are NOT dead: they are the ADL bridge that lets the generic
+// codec templates (RLPEncode.h encodeItems/Common.h lengthOfItems/RLPDecode.h decodeItems) find
+// the AccessListEntry/Web3Transaction overloads defined at the bottom of this file. Those overloads
+// live in namespace codec::rlp, which is not an associated namespace of bcos::rpc::AccessListEntry;
+// without the using-declaration the unity build fails with "neither visible in the template
+// definition nor found by argument-dependent lookup". Keep the three in sync with the overloads.
 using codec::rlp::decode;
 using codec::rlp::encode;
-using codec::rlp::header;
 using codec::rlp::length;
-
-static bytesConstRef getSignatureRef(bytesConstRef input)
-{
-    const auto* it = ::ranges::find_if(input, [](byte b) { return b != 0; });
-    return {it, input.size() - (it - input.begin())};
-}
 
 bcos::bytes Web3Transaction::encodeForSign() const
 {
-    bcos::bytes out;
-    if (type == TransactionType::Legacy)
+    // Delegate to handler: signing preimage (RLP without type byte, without signature)
+    return handlerFor(type).encodeForSign(*this);
+}
+
+bcos::bytes Web3Transaction::encode() const
+{
+    // Full RLP (with type byte, typed transaction)
+    return handlerFor(type).encode(*this);
+}
+
+bcos::Error::UniquePtr Web3Transaction::decode(bcos::bytesRef& in, bool withSig)
+{
+    if (in.empty())
     {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data])
-        codec::rlp::encodeHeader(out, codec::rlp::headerForSign(*this));
-        codec::rlp::encode(out, nonce);
-        // for legacy tx, it means gas price
-        codec::rlp::encode(out, maxFeePerGas);
-        codec::rlp::encode(out, gasLimit);
-        if (to.has_value())
-        {
-            codec::rlp::encode(out, to.value().ref());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        codec::rlp::encode(out, value);
-        codec::rlp::encode(out, data);
-        if (chainId)
-        {
-            // EIP-155
-            codec::rlp::encode(out, chainId.value());
-            codec::rlp::encode(out, 0U);
-            codec::rlp::encode(out, 0U);
-        }
+        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InputTooShort, "Input too short");
+    }
+    const auto firstByte = in[0];
+    // A valid transaction body is always an RLP list (≥0xC0). Use >= LIST_HEAD_BASE rather than
+    // >= BYTES_HEAD_BASE: the latter would misclassify 0x80-0xBF short-string headers as Legacy.
+    // A typed tx's type byte (0x01-0x04) is below 0xC0 and goes through the enum_cast dispatch
+    // below.
+    if (firstByte >= codec::rlp::LIST_HEAD_BASE)
+    {
+        // Legacy: no type byte
+        type = TransactionType::Legacy;
     }
     else
     {
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes])
-        out.push_back(static_cast<byte>(type));
-        codec::rlp::encodeHeader(out, codec::rlp::headerForSign(*this));
-        codec::rlp::encode(out, chainId.value_or(0));
-        codec::rlp::encode(out, nonce);
-        if (type != TransactionType::EIP2930)
+        auto txType = magic_enum::enum_cast<TransactionType>(firstByte);
+        if (!txType.has_value())
         {
-            codec::rlp::encode(out, maxPriorityFeePerGas);
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
         }
-        // for EIP2930 it means gasPrice; for EIP1559 and EIP4844, it means max priority fee per gas
-        codec::rlp::encode(out, maxFeePerGas);
-        codec::rlp::encode(out, gasLimit);
-        if (to.has_value())
-        {
-            codec::rlp::encode(out, to.value().ref());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        codec::rlp::encode(out, value);
-        codec::rlp::encode(out, data);
-        codec::rlp::encode(out, accessList);
-        if (type == TransactionType::EIP4844)
-        {
-            codec::rlp::encode(out, maxFeePerBlobGas);
-            codec::rlp::encode(out, blobVersionedHashes);
-        }
-        if (type == TransactionType::EIP7702)
-        {
-            codec::rlp::encode(out, authorizationList);
-        }
+        type = txType.value();
     }
-    return out;
+    // ⚠️ Do not pre-strip the type byte: the typed handler consumes the envelope itself (see the
+    // Web3TxHandler.h decode contract); stripping it again here would skip the list header a second
+    // time and fail every typed tx decode.
+    auto err = handlerFor(type).decode(in, *this, withSig);
+    if (err == nullptr && !in.empty())
+    {
+        return BCOS_ERROR_UNIQUE_PTR(
+            codec::rlp::DecodingError::InputTooLong, "Trailing bytes after RLP list");
+    }
+    // EIP-2: reject malleable (high-s) signatures at decode time. This member is the shared funnel
+    // for BOTH OP paths — eth_sendRawTransaction (EthEndpoint.cpp) and engine newPayload
+    // (opEnvelopeToTars) — so the check covers admission AND block processing, matching op-geth.
+    // Deposits (0x7e) are unsigned; the EIP-7702 authorization entries are gated separately
+    // (Eip7702Recover.h) and left untouched here.
+    if (err == nullptr && withSig && type != TransactionType::Deposit)
+    {
+        err = checkEip2Signature(signatureR, signatureS);
+    }
+    return err;
 }
 
 bcos::crypto::HashType Web3Transaction::txHash() const
@@ -131,6 +148,32 @@ bcos::crypto::HashType Web3Transaction::hashForSign() const
 
 bcostars::Transaction Web3Transaction::takeToTarsTransaction()
 {
+    if (type == TransactionType::Deposit)
+    {
+        bcostars::Transaction tarsTx{};
+        tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+        tarsTx.web3TypedTxKind =
+            static_cast<tars::Char>(static_cast<uint8_t>(TransactionType::Deposit));
+        tarsTx.sourceHash = sourceHash.hex();
+        tarsTx.sender.assign(from.begin(), from.end());
+        // 0x-prefixed, matching the read side u256(...) (parsed in TransactionImpl.cpp mint())
+        tarsTx.mint = "0x" + mint.str(0, std::ios_base::hex);
+        tarsTx.isSystemTransaction = isSystemTx ? 1 : 0;
+        // Full 0x7E envelope (encode()). extraTransactionHash is NOT filled here — the
+        // canonical txHash path (TransactionImpl::calculateHash) does not yet handle 0x7e;
+        // deposits are unsigned and rejected at eth_sendRawTransaction (see EthEndpoint.cpp).
+        auto encoded = encode();
+        tarsTx.extraTransactionBytes.reserve(encoded.size());
+        ::ranges::move(encoded, std::back_inserter(tarsTx.extraTransactionBytes));
+        // Generic fields (so consumers on the tars generic read path don't see empty values)
+        tarsTx.data.to = to.has_value() ? to->hexPrefixed() : "";
+        tarsTx.data.input.assign(data.begin(), data.end());
+        tarsTx.data.value = "0x" + value.str(0, std::ios_base::hex);
+        tarsTx.data.gasLimit = gasLimit;
+        tarsTx.data.nonce = "0x0";  // deposit nonce is always 0
+        tarsTx.data.chainID = "0";
+        return tarsTx;
+    }
     bcostars::Transaction tarsTx{};
     tarsTx.data.to = (this->to.has_value()) ? this->to.value().hexPrefixed() : "";
     tarsTx.data.input.reserve(this->data.size());
@@ -138,7 +181,10 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
 
     tarsTx.data.value = "0x" + this->value.str(0, std::ios_base::hex);
     tarsTx.data.gasLimit = this->gasLimit;
-    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559))
+    // Use explicit range check rather than `>=` so that Deposit (0x7e) is excluded;
+    // EIP7702 is fee-market (maxFeePerGas/maxPriorityFeePerGas) so it is included
+    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559) &&
+        static_cast<uint8_t>(this->type) <= static_cast<uint8_t>(TransactionType::EIP7702))
     {
         tarsTx.data.maxFeePerGas = "0x" + this->maxFeePerGas.str(0, std::ios_base::hex);
         tarsTx.data.maxPriorityFeePerGas =
@@ -194,10 +240,10 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
             // entry must still be KEPT in the list: a set_code transaction with an empty
             // authorization list is rejected by the executor, and dropping it would change
             // the signing hash.
-            tarsEntry.chainID = static_cast<int64_t>(
-                entry.chainId > std::numeric_limits<uint64_t>::max() ?
-                    UINT64_MAX :
-                    static_cast<uint64_t>(entry.chainId));
+            tarsEntry.chainID =
+                static_cast<int64_t>(entry.chainId > std::numeric_limits<uint64_t>::max() ?
+                                         UINT64_MAX :
+                                         static_cast<uint64_t>(entry.chainId));
             tarsEntry.address = entry.address.hex();  // 40-char hex, no 0x prefix
             tarsEntry.nonce = static_cast<int64_t>(entry.nonce);
             tarsEntry.v = static_cast<tars::Char>(entry.yParity);
@@ -240,6 +286,9 @@ uint64_t Web3Transaction::getSignatureV() const
 }
 std::string Web3Transaction::sender() const
 {
+    // deposit (0x7e): unsigned, so sender is taken directly from the from field
+    if (type == TransactionType::Deposit)
+        return toHexStringWithPrefix(from);
     bcos::bytes sign{};
     sign.reserve(crypto::SECP256K1_SIGNATURE_LEN);
     sign.insert(sign.end(), signatureR.begin(), signatureR.end());
@@ -274,185 +323,20 @@ std::string Web3Transaction::toString() const noexcept
 namespace codec::rlp
 {
 using namespace bcos::rpc;
-Header header(const AccessListEntry& entry) noexcept
-{
-    auto len = length(entry.storageKeys);
-    return {.isList = true, .payloadLength = Address::SIZE + 1 + len};
-}
-
-size_t length(AccessListEntry const& entry) noexcept
-{
-    auto head = header(entry);
-    return lengthOfLength(head.payloadLength) + head.payloadLength;
-}
-
-Header header(const AuthorizationListEntry& entry) noexcept
-{
-    auto len = codec::rlp::length(entry.chainId) + Address::SIZE + 1 +
-               codec::rlp::length(entry.nonce) +
-               codec::rlp::length(static_cast<uint64_t>(entry.yParity)) +
-               codec::rlp::length(entry.r) + codec::rlp::length(entry.s);
-    return {.isList = true, .payloadLength = len};
-}
-
-size_t length(AuthorizationListEntry const& entry) noexcept
-{
-    auto head = header(entry);
-    return lengthOfLength(head.payloadLength) + head.payloadLength;
-}
-
-void encode(bcos::bytes& out, const AuthorizationListEntry& entry) noexcept
-{
-    encodeHeader(out, header(entry));
-    encode(out, entry.chainId);
-    encode(out, entry.address.ref());
-    encode(out, entry.nonce);
-    encode(out, static_cast<uint64_t>(entry.yParity));
-    encode(out, entry.r);
-    encode(out, entry.s);
-}
-Header headerTxBase(const Web3Transaction& tx) noexcept
-{
-    Header h{.isList = true};
-
-    if (tx.type != TransactionType::Legacy)
-    {
-        h.payloadLength += length(tx.chainId.value_or(0));
-    }
-
-    h.payloadLength += length(tx.nonce);
-    if (tx.type == TransactionType::EIP1559 || tx.type == TransactionType::EIP4844 ||
-        tx.type == TransactionType::EIP7702)
-    {
-        h.payloadLength += length(tx.maxPriorityFeePerGas);
-    }
-    h.payloadLength += length(tx.maxFeePerGas);
-    h.payloadLength += length(tx.gasLimit);
-    h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
-    h.payloadLength += length(tx.value);
-    h.payloadLength += length(tx.data);
-
-    if (tx.type != TransactionType::Legacy)
-    {
-        h.payloadLength += codec::rlp::length(tx.accessList);
-        if (tx.type == TransactionType::EIP4844)
-        {
-            h.payloadLength += length(tx.maxFeePerBlobGas);
-            h.payloadLength += length(tx.blobVersionedHashes);
-        }
-        if (tx.type == TransactionType::EIP7702)
-        {
-            h.payloadLength += codec::rlp::length(tx.authorizationList);
-        }
-    }
-
-    return h;
-}
-Header header(Web3Transaction const& tx) noexcept
-{
-    auto header = headerTxBase(tx);
-    header.payloadLength += (tx.type == TransactionType::Legacy) ? length(tx.getSignatureV()) : 1;
-    header.payloadLength += length(getSignatureRef(ref(tx.signatureR)));
-    header.payloadLength += length(getSignatureRef(ref(tx.signatureS)));
-    return header;
-}
-Header headerForSign(Web3Transaction const& tx) noexcept
-{
-    auto header = headerTxBase(tx);
-    if (tx.type == TransactionType::Legacy && tx.chainId)
-    {
-        header.payloadLength += length(tx.chainId.value()) + 2;
-    }
-    return header;
-}
 size_t length(Web3Transaction const& tx) noexcept
 {
-    auto head = header(tx);
+    auto head = handlerFor(tx.type).header(tx);
     auto len = lengthOfLength(head.payloadLength) + head.payloadLength;
     len = (tx.type == TransactionType::Legacy) ? len : lengthOfLength(len + 1) + len + 1;
     return len;
 }
-void encode(bcos::bytes& out, const AccessListEntry& entry) noexcept
-{
-    encodeHeader(out, header(entry));
-    encode(out, entry.account.ref());
-    encode(out, entry.storageKeys);
-}
 void encode(bcos::bytes& out, const Web3Transaction& tx) noexcept
 {
-    if (tx.type == TransactionType::Legacy)
-    {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
-        encodeHeader(out, header(tx));
-        encode(out, tx.nonce);
-        // for legacy tx, it means gas price
-        encode(out, tx.maxFeePerGas);
-        encode(out, tx.gasLimit);
-        if (tx.to.has_value())
-        {
-            encode(out, tx.to.value());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        encode(out, tx.value);
-        encode(out, tx.data);
-        encode(out, tx.getSignatureV());
-        encode(out, getSignatureRef(ref(tx.signatureR)));
-        encode(out, getSignatureRef(ref(tx.signatureS)));
-    }
-    else
-    {
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
-        // signatureYParity, signatureR, signatureS])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
-        // signature_s])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
-        // signature_y_parity, signature_r, signature_s])
-        out.push_back(static_cast<bcos::byte>(tx.type));
-        encodeHeader(out, header(tx));
-        encode(out, tx.chainId.value_or(0));
-        encode(out, tx.nonce);
-        if (tx.type != TransactionType::EIP2930)
-        {
-            encode(out, tx.maxPriorityFeePerGas);
-        }
-        // for EIP2930 it means gasPrice; for EIP1559 and EIP4844, it means max priority fee per gas
-        encode(out, tx.maxFeePerGas);
-        encode(out, tx.gasLimit);
-        if (tx.to.has_value())
-        {
-            encode(out, tx.to.value());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        encode(out, tx.value);
-        encode(out, tx.data);
-        encode(out, tx.accessList);
-        if (tx.type == TransactionType::EIP4844)
-        {
-            encode(out, tx.maxFeePerBlobGas);
-            encode(out, tx.blobVersionedHashes);
-        }
-        if (tx.type == TransactionType::EIP7702)
-        {
-            encode(out, tx.authorizationList);
-        }
-        encode(out, tx.signatureV);
-        encode(out, getSignatureRef(ref(tx.signatureR)));
-        encode(out, getSignatureRef(ref(tx.signatureS)));
-    }
-}
-bcos::Error::UniquePtr decode(bcos::bytesRef& in, AccessListEntry& out) noexcept
-{
-    return decode(in, out.account, out.storageKeys);
+    // Delegate to the handler. Move the returned vector into `out` to avoid a double allocation:
+    // the handler already reserves internally and returns a complete buffer; copying it into out
+    // would allocate a second time. Callers pass an empty `out` (the previous append semantics
+    // matched move for the empty case), so move-assign preserves compatibility.
+    out = handlerFor(tx.type).encode(tx);
 }
 
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, AuthorizationListEntry& out) noexcept
@@ -502,210 +386,21 @@ bcos::Error::UniquePtr decode(bcos::bytesRef& in, AuthorizationListEntry& out) n
 }
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, Web3Transaction& out) noexcept
 {
-    return decodeTransaction(in, out, true);
+    return out.decode(in, true);
 }
 
 bcos::Error::UniquePtr decodeFromPayload(bcos::bytesRef& in, rpc::Web3Transaction& out) noexcept
 {
-    return decodeTransaction(in, out, false);
+    return out.decode(in, false);
 }
 
 bcos::Error::UniquePtr decodeTransaction(
     bcos::bytesRef& in, rpc::Web3Transaction& out, bool withSignature) noexcept
 {
-    if (in.empty())
-    {
-        return BCOS_ERROR_UNIQUE_PTR(InputTooShort, "Input too short");
-    }
-    Error::UniquePtr decodeError = nullptr;
-    if (auto const& firstByte = in[0]; 0 < firstByte && firstByte < BYTES_HEAD_BASE)
-    {
-        // EIP-2718: Transaction Type
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
-        // signatureYParity, signatureR, signatureS])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
-        // signature_s])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
-        // signature_y_parity, signature_r, signature_s])
-
-        const auto txType = magic_enum::enum_cast<TransactionType>(firstByte);
-        if (!txType.has_value())
-        {
-            return BCOS_ERROR_UNIQUE_PTR(
-                DecodingError::UnsupportedTransactionType, "Unsupported transaction type");
-        }
-        out.type = txType.value();
-        in = in.getCroppedData(1);
-        auto&& [e, header] = decodeHeader(in);
-        if (e != nullptr)
-        {
-            return std::move(e);
-        }
-        if (!header.isList)
-        {
-            return BCOS_ERROR_UNIQUE_PTR(UnexpectedString, "Unexpected String");
-        }
-        uint64_t chainId = 0;
-        if (auto error = decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
-            error != nullptr)
-        {
-            return error;
-        }
-        out.chainId.emplace(chainId);
-        if (out.type == TransactionType::EIP2930)
-        {
-            out.maxFeePerGas = out.maxPriorityFeePerGas;
-        }
-        else if (auto error = decode(in, out.maxFeePerGas); error != nullptr)
-        {
-            return error;
-        }
-
-        if (auto error = decode(in, out.gasLimit); error != nullptr)
-        {
-            return error;
-        }
-
-        if (in[0] == BYTES_HEAD_BASE)
-        {
-            out.to = std::nullopt;
-            in = in.getCroppedData(1);
-        }
-        else
-        {
-            Address addr{};
-            if (auto error = decode(in, addr); error != nullptr)
-            {
-                return error;
-            }
-            out.to.emplace(addr);
-        }
-
-        if (auto error = decodeItems(in, out.value, out.data, out.accessList); error != nullptr)
-        {
-            return error;
-        }
-
-        if (out.type == TransactionType::EIP4844)
-        {
-            if (auto error = decodeItems(in, out.maxFeePerBlobGas, out.blobVersionedHashes);
-                error != nullptr)
-            {
-                return error;
-            }
-        }
-        if (out.type == TransactionType::EIP7702)
-        {
-            if (auto error = decode(in, out.authorizationList); error != nullptr)
-            {
-                return error;
-            }
-        }
-        if (withSignature)
-        {
-            decodeError = decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
-        }
-    }
-    else
-    {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
-        auto&& [error, header] = decodeHeader(in);
-        if (error != nullptr)
-        {
-            return std::move(error);
-        }
-        if (!header.isList)
-        {
-            return BCOS_ERROR_UNIQUE_PTR(UnexpectedList, "Unexpected list");
-        }
-        out.type = TransactionType::Legacy;
-        if (decodeError = decodeItems(in, out.nonce, out.maxPriorityFeePerGas);
-            decodeError != nullptr)
-        {
-            return decodeError;
-        }
-        out.maxFeePerGas = out.maxPriorityFeePerGas;
-
-        if (decodeError = decode(in, out.gasLimit); decodeError != nullptr)
-        {
-            return decodeError;
-        }
-
-        if (in[0] == BYTES_HEAD_BASE)
-        {
-            out.to = std::nullopt;
-            in = in.getCroppedData(1);
-        }
-        else
-        {
-            Address addr{};
-            if (decodeError = decode(in, addr); decodeError != nullptr)
-            {
-                return decodeError;
-            }
-            out.to.emplace(addr);
-        }
-
-        decodeError = decodeItems(in, out.value, out.data);
-        if (withSignature)
-        {
-            if (decodeError = decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
-                decodeError != nullptr)
-            {
-                return decodeError;
-            }
-            // TODO: EIP-155 chainId decode from encoded bytes for sign
-            auto v = out.signatureV;
-            if (v == 27 || v == 28)
-            {
-                // pre EIP-155
-                out.chainId = std::nullopt;
-                out.signatureV = v - 27;
-            }
-            else if (v == 0 || v == 1)
-            {
-                out.chainId = std::nullopt;
-                return decodeError;
-            }
-            else if (v < 35)
-            {
-                return BCOS_ERROR_UNIQUE_PTR(InvalidVInSignature, "Invalid V in signature");
-            }
-            else
-            {
-                // https://eips.ethereum.org/EIPS/eip-155
-                // Find chain_id and y_parity ∈ {0, 1} such that
-                // v = chain_id * 2 + 35 + y_parity
-                out.signatureV = (v - 35) % 2;
-                out.chainId = ((v - 35) >> 1);
-            }
-        }
-        else
-        {
-            uint64_t chainId = 0;
-            decodeError = decode(in, chainId);
-            out.chainId.emplace(chainId);
-        }
-    }
-    if (withSignature)
-    {
-        // rehandle signature and chainId
-        if (out.signatureR.size() < crypto::SECP256K1_SIGNATURE_R_LEN)
-        {
-            out.signatureR.insert(out.signatureR.begin(),
-                crypto::SECP256K1_SIGNATURE_R_LEN - out.signatureR.size(), 0);
-        }
-        if (out.signatureS.size() < crypto::SECP256K1_SIGNATURE_S_LEN)
-        {
-            out.signatureS.insert(out.signatureS.begin(),
-                crypto::SECP256K1_SIGNATURE_S_LEN - out.signatureS.size(), bcos::byte(0));
-        }
-    }
-    return decodeError;
+    // Kept as the entry point (the call target of decodeOpEnvelope/decodeOpEnvelopeWithSig,
+    // EthEndpoint.cpp:73); it now delegates to the member function so the new handler dispatch
+    // path is used.
+    return out.decode(in, withSignature);
 }
 }  // namespace codec::rlp
 }  // namespace bcos

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.h
@@ -39,10 +39,11 @@ namespace rpc
 enum class TransactionType : uint8_t
 {
     Legacy = 0,
-    EIP2930 = 1,  // https://eips.ethereum.org/EIPS/eip-2930
-    EIP1559 = 2,  // https://eips.ethereum.org/EIPS/eip-1559
-    EIP4844 = 3,  // https://eips.ethereum.org/EIPS/eip-4844
-    EIP7702 = 4,  // https://eips.ethereum.org/EIPS/eip-7702
+    EIP2930 = 1,     // https://eips.ethereum.org/EIPS/eip-2930
+    EIP1559 = 2,     // https://eips.ethereum.org/EIPS/eip-1559
+    EIP4844 = 3,     // https://eips.ethereum.org/EIPS/eip-4844
+    EIP7702 = 4,     // https://eips.ethereum.org/EIPS/eip-7702
+    Deposit = 0x7e,  // deposit-only system tx (OP Stack)
 };
 
 constexpr auto operator<=>(TransactionType const& ltype, auto rtype)
@@ -78,11 +79,11 @@ struct AuthorizationListEntry
     uint8_t yParity{0};
     u256 r{0};
     u256 s{0};
-    friend bool operator==(const AuthorizationListEntry& lhs, const AuthorizationListEntry& rhs) noexcept
+    friend bool operator==(
+        const AuthorizationListEntry& lhs, const AuthorizationListEntry& rhs) noexcept
     {
-        return lhs.chainId == rhs.chainId && lhs.address == rhs.address &&
-               lhs.nonce == rhs.nonce && lhs.yParity == rhs.yParity && lhs.r == rhs.r &&
-               lhs.s == rhs.s;
+        return lhs.chainId == rhs.chainId && lhs.address == rhs.address && lhs.nonce == rhs.nonce &&
+               lhs.yParity == rhs.yParity && lhs.r == rhs.r && lhs.s == rhs.s;
     }
 };
 
@@ -98,6 +99,10 @@ public:
 
     // encode for sign, rlp(tx_payload)
     bcos::bytes encodeForSign() const;
+    // full RLP (with type byte) — delegates to handlerFor(type).encode
+    bcos::bytes encode() const;
+    // Decode — delegates to handlerFor(type).decode, propagating decode errors
+    bcos::Error::UniquePtr decode(bcos::bytesRef& in, bool withSig = true);
     // tx hash = keccak256(rlp(tx_payload,v,r,s))
     bcos::crypto::HashType txHash() const;
     // hash for sign = keccak256(rlp(tx_payload))
@@ -122,6 +127,11 @@ public:
     // EIP-4844: Shard Blob Transactions
     u256 maxFeePerBlobGas{0};
     h256s blobVersionedHashes;
+    // deposit-only (0x7e)
+    h256 sourceHash;
+    Address from;
+    u256 mint{0};
+    bool isSystemTx{false};
     // TODO)) blob
     // EIP-7702: Set Code Transactions (Prague+)
     std::vector<AuthorizationListEntry> authorizationList;
@@ -141,9 +151,6 @@ void encode(bcos::bytes& out, const rpc::AuthorizationListEntry&) noexcept;
 size_t length(const rpc::AuthorizationListEntry&) noexcept;
 
 size_t length(const rpc::Web3Transaction&) noexcept;
-Header headerForSign(const rpc::Web3Transaction& tx) noexcept;
-Header headerTxBase(const rpc::Web3Transaction& tx) noexcept;
-Header header(const rpc::Web3Transaction& tx) noexcept;
 void encode(bcos::bytes& out, const rpc::Web3Transaction&) noexcept;
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, rpc::AccessListEntry&) noexcept;
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, rpc::AuthorizationListEntry&) noexcept;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
@@ -1,0 +1,612 @@
+// bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
+#include "Web3TxHandler.h"
+#include "Web3Transaction.h"
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Log.h>
+#include <cstdint>
+
+// These using-declarations are NOT dead: they are the ADL bridge that lets the generic codec
+// templates (RLPEncode.h encodeItems / Common.h lengthOfItems / RLPDecode.h decodeItems) find the
+// AccessListEntry overloads defined at the bottom of this file. Those overloads live in namespace
+// codec::rlp, which is not an associated namespace of bcos::rpc::AccessListEntry; without the
+// using-declaration a standalone TU (or a unity-batch reorder) fails with "neither visible in the
+// template definition nor found by argument-dependent lookup". Keep the three in sync with the
+// overloads.
+using bcos::codec::rlp::decode;
+using bcos::codec::rlp::encode;
+using bcos::codec::rlp::length;
+
+namespace bcos::rpc
+{
+namespace
+{
+// Strip leading zero bytes from signature data (R/S) to keep RLP encoding canonical.
+// Note: cannot be named getSignatureRef — it would collide with the same-named static
+// function in Web3Transaction.cpp under unity build (same TU); the logic is fully equivalent.
+bcos::bytesConstRef trimLeadingZeroBytes(bcos::bytesConstRef input) noexcept
+{
+    size_t i = 0;
+    while (i < input.size() && input[i] == bcos::byte{0})
+    {
+        ++i;
+    }
+    return {input.data() + i, input.size() - i};
+}
+
+// Signature length padding matching the end of decodeTransaction (32 bytes each for R/S).
+void padSignature(bcos::bytes& signatureR, bcos::bytes& signatureS) noexcept
+{
+    if (signatureR.size() < bcos::crypto::SECP256K1_SIGNATURE_R_LEN)
+    {
+        signatureR.insert(signatureR.begin(),
+            bcos::crypto::SECP256K1_SIGNATURE_R_LEN - signatureR.size(), bcos::byte{0});
+    }
+    if (signatureS.size() < bcos::crypto::SECP256K1_SIGNATURE_S_LEN)
+    {
+        signatureS.insert(signatureS.begin(),
+            bcos::crypto::SECP256K1_SIGNATURE_S_LEN - signatureS.size(), bcos::byte{0});
+    }
+}
+
+// ⚠️ decode contract: each handler's decode is self-contained (consumes the envelope itself —
+// Legacy: RLP list header; typed: type byte + RLP list header), copied field-by-field from the
+// corresponding branch of Web3Transaction.cpp decodeTransaction. The dispatcher
+// (Web3Transaction::decode member) should determine the type from the first byte, set out.type,
+// then call handlerFor(type).decode(in, out, withSig), and must not consume the type byte first.
+
+struct LegacyTxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        // for legacy tx, it means gas price
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        return h;
+    }
+
+    // Signing preimage: rlp([nonce, gasPrice, gasLimit, to, value, data]) + EIP-155 chainId tail
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = headerTxBase(tx);
+        if (tx.chainId)
+        {
+            // EIP-155: chainId and the two trailing 0 placeholders
+            head.payloadLength += codec::rlp::length(tx.chainId.value()) + 2;
+        }
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.nonce);
+        // for legacy tx, it means gas price
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        if (tx.chainId)
+        {
+            // EIP-155
+            codec::rlp::encode(out, tx.chainId.value());
+            codec::rlp::encode(out, 0U);
+            codec::rlp::encode(out, 0U);
+        }
+        return out;
+    }
+
+    // Full RLP (no type byte): rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        codec::rlp::encodeHeader(out, header(tx));
+        codec::rlp::encode(out, tx.nonce);
+        // for legacy tx, it means gas price
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.getSignatureV());
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation): base fields + signature length (Legacy special: signatureV
+    // uses getSignatureV())
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += codec::rlp::length(tx.getSignatureV());
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        auto&& [error, head] = codec::rlp::decodeHeader(in);
+        if (error != nullptr)
+        {
+            return std::move(error);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedList, "Unexpected list");
+        }
+        out.type = TransactionType::Legacy;
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (decodeError = codec::rlp::decodeItems(in, out.nonce, out.maxPriorityFeePerGas);
+            decodeError != nullptr)
+        {
+            return decodeError;
+        }
+        out.maxFeePerGas = out.maxPriorityFeePerGas;
+
+        if (decodeError = codec::rlp::decode(in, out.gasLimit); decodeError != nullptr)
+        {
+            return decodeError;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (decodeError = codec::rlp::decode(in, addr); decodeError != nullptr)
+            {
+                return decodeError;
+            }
+            out.to.emplace(addr);
+        }
+
+        // ⚠️ Check value/data decode errors immediately: if deferred to the withSig branch,
+        // a later successful signature decode would overwrite decodeError and misjudge
+        // malformed input as valid.
+        if (auto err = codec::rlp::decodeItems(in, out.value, out.data); err != nullptr)
+        {
+            return err;
+        }
+        if (withSig)
+        {
+            if (decodeError =
+                    codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+                decodeError != nullptr)
+            {
+                return decodeError;
+            }
+            // TODO: EIP-155 chainId decode from encoded bytes for sign
+            auto v = out.signatureV;
+            if (v == 27 || v == 28)
+            {
+                // pre EIP-155
+                out.chainId = std::nullopt;
+                out.signatureV = v - 27;
+            }
+            else if (v == 0 || v == 1)
+            {
+                // pre-EIP-155 v must be 27/28; v=0/1 is an invalid signature (treated the same as
+                // v<35). The original implementation returned decodeError(nullptr), which callers
+                // treated as success — changed to report an explicit error.
+                out.chainId = std::nullopt;
+                return BCOS_ERROR_UNIQUE_PTR(
+                    codec::rlp::DecodingError::InvalidVInSignature, "Invalid V in signature");
+            }
+            else if (v < 35)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(
+                    codec::rlp::DecodingError::InvalidVInSignature, "Invalid V in signature");
+            }
+            else
+            {
+                // https://eips.ethereum.org/EIPS/eip-155
+                // Find chain_id and y_parity ∈ {0, 1} such that
+                // v = chain_id * 2 + 35 + y_parity
+                out.signatureV = (v - 35) % 2;
+                out.chainId = ((v - 35) >> 1);
+            }
+        }
+        else
+        {
+            uint64_t chainId = 0;
+            decodeError = codec::rlp::decode(in, chainId);
+            if (decodeError != nullptr)
+            {
+                return decodeError;
+            }
+            out.chainId.emplace(chainId);
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        return decodeError;
+    }
+};
+
+struct EIP2930TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        // EIP2930 does not encode maxPriorityFeePerGas; gasPrice is carried by maxFeePerGas
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        return h;
+    }
+
+    // Signing preimage: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data,
+    // accessList])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP2930));
+        codec::rlp::encodeHeader(out, headerTxBase(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        // for EIP2930 it means gasPrice
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        return out;
+    }
+
+    // Full RLP: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
+    // signatureYParity, signatureR, signatureS])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP2930));
+        codec::rlp::encodeHeader(out, header(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        // for EIP2930 it means gasPrice
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation): base fields + 1 (signatureV y-parity after the type byte) +
+    // signature length
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
+    // yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP2930))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP2930;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        // EIP2930: gasPrice is carried in maxFeePerGas
+        out.maxFeePerGas = out.maxPriorityFeePerGas;
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig)
+        {
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        return decodeError;
+    }
+};
+
+struct EIP1559TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        return h;
+    }
+
+    // Signing preimage: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP1559));
+        codec::rlp::encodeHeader(out, headerTxBase(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        return out;
+    }
+
+    // Full RLP: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
+    // signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP1559));
+        codec::rlp::encodeHeader(out, header(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // destination, amount, data, access_list, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP1559))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP1559;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig)
+        {
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        return decodeError;
+    }
+};
+
+}  // namespace
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
@@ -608,5 +608,619 @@ struct EIP1559TxHandler : Web3TxHandler
     }
 };
 
+struct DepositTxHandler : Web3TxHandler
+{
+    // Full RLP: 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])
+    // — self-contained inline (consistent with the other typed handlers in this file); the 8-field
+    // unsigned layout's field order/types verified against op-geth DepositTx; field-by-field
+    // layout and to-nilability behaviour cross-checked against op-geth's deposit encoding.
+    // `to` nilability changes the RLP shape (empty string vs 20-byte address),
+    // so the contract-creation branch must be encoded separately.
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::Deposit));
+        // isSystemTransaction uses uint32_t (not uint8_t): RLPEncode.h's uint8_t generic scalar
+        // encoding odr-uses the non-template toCompactBigEndian(byte, unsigned) overload, whose
+        // only definition lives in DataConvertUtility.cpp rather than a header (a pre-existing
+        // bcos-utilities header/library boundary defect); uint32_t only matches in-header
+        // templates and produces identical bytes.
+        const uint32_t isSystemTransactionByte = tx.isSystemTx ? 1 : 0;
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.sourceHash, tx.from, *tx.to, tx.mint, tx.value, tx.gasLimit,
+                isSystemTransactionByte, tx.data);
+        }
+        else
+        {
+            codec::rlp::encode(out, tx.sourceHash, tx.from, bcos::bytesConstRef{}, tx.mint,
+                tx.value, tx.gasLimit, isSystemTransactionByte, tx.data);
+        }
+        return out;
+    }
+
+    // deposit has no signature: the signing preimage is the full envelope (aligned with
+    // op-geth DepositTx.SigningHash, used for extraTransactionBytes).
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override { return encode(tx); }
+
+    // RLP header (length computation): sum of the 8 field lengths (excluding the type byte —
+    // consistent with the other typed handlers).
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.sourceHash);  // h256
+        h.payloadLength += codec::rlp::length(tx.from);        // Address
+        // to (optional Address): empty string 0x80 takes 1 byte, or 20-byte address + 1-byte length
+        // header
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.mint);      // u256
+        h.payloadLength += codec::rlp::length(tx.value);     // u256
+        h.payloadLength += codec::rlp::length(tx.gasLimit);  // uint64
+        h.payloadLength += 1;  // isSystemTransaction (0x80 empty string or 0x01)
+        h.payloadLength += codec::rlp::length(tx.data);  // bytes
+        return h;
+    }
+
+    // Decode: 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])
+    // ⚠️ decode contract: typed handler is self-contained (consumes the type byte + list header
+    // itself); the dispatcher (Web3Transaction::decode) does not trim the type byte first.
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool /*withSig*/) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::Deposit))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::Deposit;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "deposit: expected RLP list");
+        }
+        // Check and propagate errors on every field decode (must not swallow silently)
+        if (auto err = codec::rlp::decode(in, out.sourceHash); err != nullptr)
+            return err;  // h256
+        if (auto err = codec::rlp::decode(in, out.from); err != nullptr)
+            return err;  // Address
+        // to (optional Address; empty string 0x80 = nullopt contract creation)
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto err = codec::rlp::decode(in, addr); err != nullptr)
+                return err;
+            out.to.emplace(addr);
+        }
+        if (auto err = codec::rlp::decode(in, out.mint); err != nullptr)
+            return err;  // u256
+        if (auto err = codec::rlp::decode(in, out.value); err != nullptr)
+            return err;  // u256
+        if (auto err = codec::rlp::decode(in, out.gasLimit); err != nullptr)
+            return err;  // uint64
+        // ⚠️ isSystemTransaction cannot use codec::rlp::decode(bool) (RLPDecode.h:200-217
+        // requires payloadLength==1 and would report UnexpectedLength for the golden 0x80 empty
+        // string). Byte semantics are required: empty string 0x80 → false (op-geth RLP nil);
+        // single byte 0x01 → true; anything else is an error.
+        {
+            bcos::bytes raw{};
+            if (auto err = codec::rlp::decode(in, raw); err != nullptr)
+                return err;
+            if (raw.empty())
+            {
+                out.isSystemTx = false;
+            }
+            else if (raw.size() == 1 && raw[0] == 1)
+            {
+                out.isSystemTx = true;
+            }
+            else
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedLength,
+                    "deposit: invalid isSystemTransaction value");
+            }
+        }
+        if (auto err = codec::rlp::decode(in, out.data); err != nullptr)
+            return err;  // bytes
+        out.nonce = 0;   // deposit nonce is always 0
+        return nullptr;
+    }
+};
+
+struct EIP4844TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerBlobGas);
+        h.payloadLength += codec::rlp::length(tx.blobVersionedHashes);
+        return h;
+    }
+
+    // Signing preimage: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP4844));
+        codec::rlp::encodeHeader(out, headerTxBase(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.maxFeePerBlobGas);
+        codec::rlp::encode(out, tx.blobVersionedHashes);
+        return out;
+    }
+
+    // Full RLP: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
+    // signature_y_parity, signature_r, signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP4844));
+        codec::rlp::encodeHeader(out, header(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.maxFeePerBlobGas);
+        codec::rlp::encode(out, tx.blobVersionedHashes);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP4844))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP4844;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.maxFeePerBlobGas, out.blobVersionedHashes);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig)
+        {
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        return decodeError;
+    }
+};
+
+struct EIP7702TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        h.payloadLength += codec::rlp::length(tx.authorizationList);
+        return h;
+    }
+
+    // Signing preimage: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, authorization_list])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP7702));
+        codec::rlp::encodeHeader(out, headerTxBase(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.authorizationList);
+        return out;
+    }
+
+    // Full RLP: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, authorization_list, signature_y_parity,
+    // signature_r, signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP7702));
+        codec::rlp::encodeHeader(out, header(tx));
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.authorizationList);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // destination, amount, data, access_list, authorization_list, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP7702))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP7702;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.authorizationList); error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig)
+        {
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844/7702); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        return decodeError;
+    }
+};
 }  // namespace
+
+Web3TxHandler& handlerFor(TransactionType type)
+{
+    static LegacyTxHandler legacy;
+    static EIP2930TxHandler eip2930;
+    static EIP1559TxHandler eip1559;
+    static EIP4844TxHandler eip4844;
+    static DepositTxHandler deposit;
+    static EIP7702TxHandler eip7702;
+    switch (type)
+    {
+    case TransactionType::Legacy:
+        return legacy;
+    case TransactionType::EIP2930:
+        return eip2930;
+    case TransactionType::EIP1559:
+        return eip1559;
+    case TransactionType::EIP4844:
+        return eip4844;
+    case TransactionType::Deposit:
+        return deposit;
+    case TransactionType::EIP7702:
+        return eip7702;
+    }
+    // Unknown TransactionType: this is a programming error — a new enum value was added
+    // without updating this switch. Return a no-op sentinel handler instead of falling back
+    // to Legacy (which would silently decode/encode as wrong transaction format producing
+    // garbage fields). encode/encodeForSign return empty bytes (fail-safe), and decode
+    // returns UnsupportedTransactionType error.
+    BCOS_LOG(FATAL) << "handlerFor: unhandled TransactionType " << static_cast<int>(type)
+                    << " — update the switch to handle the new type";
+    static struct : Web3TxHandler
+    {
+        bcos::bytes encodeForSign(const Web3Transaction&) const override { return {}; }
+        bcos::bytes encode(const Web3Transaction&) const override { return {}; }
+        codec::rlp::Header header(const Web3Transaction&) const override
+        {
+            return {.isList = true, .payloadLength = 0};
+        }
+        bcos::Error::UniquePtr decode(bcos::bytesRef&, Web3Transaction&, bool) const override
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnsupportedTransactionType, "Unknown transaction type");
+        }
+    } sentinel;
+    return sentinel;
+}
 }  // namespace bcos::rpc
+
+// AccessListEntry RLP codec overloads — defined here (not in Web3Transaction.cpp) because the
+// handlers are the primary consumer: they encode/decode tx.accessList. The three using-declarations
+// above make these visible at the template POI so the generic codec can find them.
+namespace bcos::codec::rlp
+{
+using namespace bcos::rpc;
+Header header(const AccessListEntry& entry) noexcept
+{
+    auto len = length(entry.storageKeys);
+    return {.isList = true, .payloadLength = Address::SIZE + 1 + len};
+}
+
+size_t length(AccessListEntry const& entry) noexcept
+{
+    auto head = header(entry);
+    return lengthOfLength(head.payloadLength) + head.payloadLength;
+}
+
+void encode(bcos::bytes& out, const AccessListEntry& entry) noexcept
+{
+    encodeHeader(out, header(entry));
+    encode(out, entry.account.ref());
+    encode(out, entry.storageKeys);
+}
+
+bcos::Error::UniquePtr decode(bcos::bytesRef& in, AccessListEntry& out) noexcept
+{
+    return decode(in, out.account, out.storageKeys);
+}
+
+Header header(const AuthorizationListEntry& entry) noexcept
+{
+    auto len = codec::rlp::length(entry.chainId) + Address::SIZE + 1 +
+               codec::rlp::length(entry.nonce) +
+               codec::rlp::length(static_cast<uint64_t>(entry.yParity)) +
+               codec::rlp::length(entry.r) + codec::rlp::length(entry.s);
+    return {.isList = true, .payloadLength = len};
+}
+
+size_t length(AuthorizationListEntry const& entry) noexcept
+{
+    auto head = header(entry);
+    return lengthOfLength(head.payloadLength) + head.payloadLength;
+}
+
+void encode(bcos::bytes& out, const AuthorizationListEntry& entry) noexcept
+{
+    encodeHeader(out, header(entry));
+    encode(out, entry.chainId);
+    encode(out, entry.address.ref());
+    encode(out, entry.nonce);
+    encode(out, static_cast<uint64_t>(entry.yParity));
+    encode(out, entry.r);
+    encode(out, entry.s);
+}
+}  // namespace bcos::codec::rlp

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.h
@@ -1,0 +1,48 @@
+// bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.h
+// ⚠️ isSystemTransaction encoding workaround: DepositTxHandler::encode() encodes
+// isSystemTransaction as uint32_t (not uint8_t) because RLPEncode.h's generic scalar
+// encoding for uint8_t odr-uses the non-template toCompactBigEndian(byte, unsigned)
+// overload, whose only definition lives in DataConvertUtility.cpp rather than a header
+// (a pre-existing bcos-utilities header/library boundary defect). uint32_t only matches
+// in-header templates and produces identical 1-byte RLP output (0x80 or 0x01). When the
+// underlying ODR defect is fixed, switch back to uint8_t — the round-trip test in
+// Web3TypeTest (depositRoundtrip) locks the correct output byte so the switch cannot
+// silently regress.
+#pragma once
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/Error.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <json/json.h>
+#include <cstdint>
+
+namespace bcos::rpc
+{
+class Web3Transaction;
+// TransactionType is defined in Web3Transaction.h (enum class : uint8_t); forward-declare the
+// underlying type so handlerFor can be declared without pulling in the whole header.
+enum class TransactionType : uint8_t;
+// NOTE: Header is actually bcos::codec::rlp::Header (Common.h:45), so it must be included, not
+// forward-declared. The include must stay OUTSIDE the namespace: expanding Common.h inside
+// namespace bcos::rpc would resolve `namespace bcos::codec::rlp` as a nested
+// bcos::rpc::bcos::codec::rlp, polluting the namespace.
+
+struct Web3TxHandler
+{
+    virtual ~Web3TxHandler() = default;
+    // Signing preimage (RLP without type byte or signature)
+    virtual bcos::bytes encodeForSign(const Web3Transaction&) const = 0;
+    // Full RLP (with type byte for typed transactions)
+    virtual bcos::bytes encode(const Web3Transaction&) const = 0;
+    // RLP header (length computation)
+    virtual bcos::codec::rlp::Header header(const Web3Transaction&) const = 0;
+    // Decode (populates Web3Transaction; withSig controls whether the signature is parsed).
+    // ⚠️ Returns Error::UniquePtr (not void): decode errors must propagate, not be silently
+    // swallowed (found by review).
+    virtual bcos::Error::UniquePtr decode(
+        bcos::bytesRef&, Web3Transaction&, bool withSig) const = 0;
+};
+
+// Dispatch by type via a lookup table. Unknown types fall back to the Legacy handler (defensive).
+Web3TxHandler& handlerFor(TransactionType type);
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -305,6 +305,9 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .withdrawals = std::nullopt,
         .blobGasUsed = std::nullopt,
         .excessBlobGas = std::nullopt,
+        .blockAccessList = std::nullopt,
+        .slotNumber = std::nullopt,
+        .rawTransactions = std::nullopt,
         .withdrawalsRoot = std::nullopt,
     };
     if (ep.isMember("extraData"))
@@ -329,13 +332,23 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 InvalidParams, "Expected array of hex strings for executionPayload.transactions"));
         }
-        // Raw EIP-2718 bytes, hex-decoded verbatim. No transaction decoding happens
-        // here — getPayload must later return exactly these bytes.
+        // Raw EIP-2718 bytes, hex-decoded verbatim, kept in BOTH carriers:
+        //   - payload.transactions (EngineTransaction{raw, decoded=nullptr}) — the Engine-API
+        //     wire form; getPayload must later return exactly these raw bytes. No decoding
+        //     happens here — classification/decoding of the raw bytes is the dispatch table's
+        //     job (bcos-framework/engine/RawTransactionDispatch.h), matching upstream.
+        //   - payload.rawTransactions (vector<bytes>) — the OP path's sole tx carrier (raw
+        //     EIP-2718 envelope bytes incl. the 0x7E deposit), consumed by OpSchedulerSeam.
         payload.transactions.reserve(ep["transactions"].size());
+        payload.rawTransactions.emplace();
+        payload.rawTransactions->reserve(ep["transactions"].size());
         for (Json::ArrayIndex i = 0; i < ep["transactions"].size(); ++i)
         {
-            payload.transactions.push_back(bcos::engine::EngineTransaction{
-                .raw = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i),
+            auto txData = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i);
+            payload.rawTransactions->push_back(txData);  // keep unconditionally: OP carrier is
+                                                         // decoupled from decode
+            payload.transactions.push_back(engine::EngineTransaction{
+                .raw = std::move(txData),
                 .decoded = nullptr,
             });
         }

--- a/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
@@ -1,0 +1,168 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+// op-geth golden corpus 真实 raw tx（val-loop bcos-evm/test/opstack/t8n/golden/engine/
+// isthmus_access_list.golden.json rawTransactions[0]/[1]，逐字节核验一致）：0x7E deposit +
+// 0x02 EIP-1559 typed。两者经 decodeTransaction 必抛 TarsDecodeMismatch（tars 误解析 RLP）——
+// transactions 填充分支容错跳过，rawTransactions 是 W1 的核心断言对象。
+constexpr std::string_view kDepositRawTx =
+    "0x7ef90104a0ae1a1f61e85683e8084e5004f4c36b050cb2ea1e5f78f1e7d518163ade648a7994deaddeaddeaddead"
+    "deaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be00"
+    "000558000c5fc500000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000006fc23ac0000000000000000000000000000000000000000000000000000000000000f42"
+    "4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000000000000000000000000000";
+constexpr std::string_view kEip1559RawTx =
+    "0x02f8e0822105808405f5e1008477359400830186a094c0de0000000000000000000000000000000000058080f872"
+    "f85994c0de000000000000000000000000000000000005f842a0000000000000000000000000000000000000000000"
+    "0000000000000000000000a00000000000000000000000000000000000000000000000000000000000000005d694dd"
+    "ddddddddddddddddddddddddddddddddddddddc080a0394ee65265d6d1eead7675c85dc4dfa781d7d9b1d27392f51d"
+    "d7feb5d8f2f27ba0434c6ec29d5d0e3b781f461538d61e7120c5f25a33dd5f8a230aa8259dba7d0c";
+constexpr std::string_view kWithdrawalsRoot =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+std::shared_ptr<bcos::protocol::TransactionFactory> makeTxFactory()
+{
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    return std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+}
+
+Json::Value makePayloadParams(
+    std::vector<std::string_view> rawTxs, std::string_view withdrawalsRoot)
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = "0x" + std::string(64, '0');
+    ep["stateRoot"] = "0x" + std::string(64, '0');
+    ep["receiptsRoot"] = "0x" + std::string(64, '0');
+    ep["prevRandao"] = "0x" + std::string(64, '0');
+    ep["gasLimit"] = "0x1c9c380";
+    ep["gasUsed"] = "0x0";
+    ep["baseFeePerGas"] = "0x1";
+    ep["blockHash"] = "0x" + std::string(64, '0');
+    ep["feeRecipient"] = "0x" + std::string(40, '0');
+    ep["timestamp"] = "0x1";
+    ep["blockNumber"] = "0x1";
+    ep["logsBloom"] = "0x" + std::string(512, '0');
+    ep["extraData"] = "0x";
+    ep["withdrawals"] = Json::Value(Json::arrayValue);
+    ep["blobGasUsed"] = "0x0";
+    ep["excessBlobGas"] = "0x0";
+    if (withdrawalsRoot.size())
+    {
+        ep["withdrawalsRoot"] = std::string(withdrawalsRoot);
+    }
+    Json::Value txs(Json::arrayValue);
+    for (auto const& raw : rawTxs)
+    {
+        txs.append(std::string(raw));
+    }
+    ep["transactions"] = txs;
+    // V4 wire shape (#5427): [executionPayload, expectedBlobVersionedHashes,
+    // parentBeaconBlockRoot, executionRequests] — parse enforces the full array.
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+    params.append(Json::Value(Json::arrayValue));
+    params.append("0x3333333333333333333333333333333333333333333333333333333333333333");
+    params.append(Json::Value(Json::arrayValue));
+    return params;
+}
+
+BOOST_AUTO_TEST_SUITE(EngineHelperTest)
+
+// rawTransactions 逐字节保留输入；transactions 同步解码。
+BOOST_AUTO_TEST_CASE(parseFillsRawTransactionsPreservingBytes)
+{
+    auto params = makePayloadParams({kDepositRawTx, kEip1559RawTx}, kWithdrawalsRoot);
+    auto factory = makeTxFactory();
+    // 不得抛：transactions 填充分支容错跳过 decode 失败的 typed tx。
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_REQUIRE_EQUAL(request.executionPayload.rawTransactions->size(), 2u);
+    // 逐字节比对：rawTransactions[i] == fromHex(rawTx[i])
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.rawTransactions->at(i) == expect);
+    }
+    // 合并后语义（上游 parse 不解码，解码交给执行时 dispatch table）：transactions 以
+    // EngineTransaction{raw, decoded=nullptr} 携带 wire 字节；rawTransactions 保留 OP 载体。
+    BOOST_REQUIRE_EQUAL(request.executionPayload.transactions.size(), 2u);
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.transactions[i].raw == expect);
+        BOOST_CHECK(request.executionPayload.transactions[i].decoded == nullptr);
+    }
+}
+
+// withdrawalsRoot 正确解析为 h256。
+BOOST_AUTO_TEST_CASE(parseFillsWithdrawalsRoot)
+{
+    auto params = makePayloadParams({kEip1559RawTx}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.withdrawalsRoot.has_value());
+    auto expect = fromHex(kWithdrawalsRoot);
+    BOOST_CHECK_EQUAL(request.executionPayload.withdrawalsRoot->size(), 32u);
+    BOOST_CHECK(std::equal(
+        expect.begin(), expect.end(), request.executionPayload.withdrawalsRoot->begin()));
+}
+
+// withdrawalsRoot 缺省 → nullopt；错长（31/33 字节）→ bcos::rpc::JsonRpcException。
+BOOST_AUTO_TEST_CASE(parseWithdrawalsRootBoundaries)
+{
+    // Missing withdrawalsRoot on V4 is a malformed payload (#5427 shape gate):
+    // -32602 at parse time, not a silent nullopt (the engine-side INVALID-status
+    // rule covers in-process callers).
+    auto noRoot = makePayloadParams({kEip1559RawTx}, "");
+    BOOST_CHECK_EXCEPTION(parseNewPayloadRequest(noRoot, engine::ApiVersion::V4),
+        bcos::rpc::JsonRpcException, [](auto const& e) { return e.code() == InvalidParams; });
+
+    // 31 字节（62 hex）
+    auto badShort = makePayloadParams({kEip1559RawTx}, "0x" + std::string(62, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badShort, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+    // 33 字节（66 hex）
+    auto badLong = makePayloadParams({kEip1559RawTx}, "0x" + std::string(66, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badLong, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+}
+
+// 缺 transactions 键 → rawTransactions 保持 nullopt（OP 校验 :299 仍拒）。
+BOOST_AUTO_TEST_CASE(parseMissingTransactionsLeavesRawNullopt)
+{
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    params[0].removeMember("transactions");
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_CHECK(!request.executionPayload.rawTransactions.has_value());
+}
+
+// transactions 存在但为空数组 → rawTransactions present-and-empty（OP 校验 :299 接受）。
+BOOST_AUTO_TEST_CASE(parseEmptyTransactionsIsPresentAndEmpty)
+{
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_CHECK(request.executionPayload.rawTransactions->empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <boost/test/unit_test.hpp>
 #include <future>
@@ -19,6 +20,60 @@ using namespace bcos::rpc;
 
 namespace bcos::test
 {
+// FakeLedger::asyncGetTransactionReceiptByHash always reports null (FakeLedger.h:360-364), so
+// seeding storage is inert for eth_getTransactionReceipt. This subclass overrides it to return a
+// seeded receipt, and re-seeds the tx-by-hash lookup with a safe implementation: FakeLedger's
+// storeTransactionsAndReceipts dereferences a default-constructed null shared_ptr (txData is never
+// allocated), so the inherited path cannot be used to populate m_txsHashToData.
+class SeedableLedger : public bcos::test::FakeLedger
+{
+public:
+    SeedableLedger(bcos::protocol::BlockFactory::Ptr blockFactory, size_t blockNumber,
+        size_t txsSize, size_t receiptsSize)
+      : bcos::test::FakeLedger(blockFactory, blockNumber, txsSize, receiptsSize),
+        m_blockFactory(std::move(blockFactory))
+    {}
+
+    protocol::TransactionReceipt::Ptr seededReceipt;
+    std::map<crypto::HashType, std::shared_ptr<bcos::bytes>> m_seedTxs;
+
+    void asyncGetTransactionReceiptByHash(crypto::HashType const&, bool,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr, MerkleProofPtr)> callback)
+        override
+    {
+        callback(nullptr, seededReceipt, nullptr);
+    }
+
+    void asyncGetBatchTxsByHashList(crypto::HashListPtr _txHashList, bool,
+        std::function<void(
+            Error::Ptr, TransactionsPtr, std::shared_ptr<std::map<std::string, MerkleProofPtr>>)>
+            _onGetTx) override
+    {
+        auto txs = std::make_shared<Transactions>();
+        for (auto const& hash : *_txHashList)
+        {
+            if (auto it = m_seedTxs.find(hash); it != m_seedTxs.end())
+            {
+                auto tx = m_blockFactory->transactionFactory()->createTransaction(
+                    bcos::ref(*(it->second)), /*checkSig=*/false);
+                txs->emplace_back(tx);
+            }
+        }
+        _onGetTx(nullptr, txs, nullptr);
+    }
+
+    void seedTx(bcos::protocol::Transaction::Ptr tx)
+    {
+        auto txHash = tx->hash();
+        auto txData = std::make_shared<bcos::bytes>();
+        tx->encode(*txData);
+        m_seedTxs[txHash] = std::move(txData);
+    }
+
+private:
+    bcos::protocol::BlockFactory::Ptr m_blockFactory;
+};
+
 // Drives the web3 (eth_/net_/web3_) coroutine endpoints through the real
 // dispatch path. EthEndpoint.cpp (596 lines) was at 24% because the existing
 // Web3RpcTest only touched ~10 of the ~44 registered methods. onRPCRequest
@@ -227,6 +282,89 @@ BOOST_AUTO_TEST_CASE(sendRawTransactionGarbageReportsError)
     auto resp = call(req("eth_sendRawTransaction", R"(["0xdeadbeef"])"));
     BOOST_CHECK(resp.isMember("error") || resp.isMember("result"));
     BOOST_CHECK(resp.isMember("id"));
+}
+
+BOOST_AUTO_TEST_CASE(getTransactionReceiptHappyPath)
+{
+    // Full read-side happy path (spec §5-5): seed a tx + receipt into a SeedableLedger and drive
+    // eth_getTransactionReceipt / eth_getTransactionByHash through the real dispatch path. The
+    // stock RPCFixture FakeLedger always returns a null receipt, so a subclass is required.
+    auto seedLedger = std::make_shared<SeedableLedger>(m_blockFactory, /*blocks=*/20, 10, 10);
+    seedLedger->setSystemConfig(ledger::SYSTEM_KEY_TX_COUNT_LIMIT, "1000");
+
+    auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
+        "0x1234567890123456789012345678901234567890", bcos::bytes{0x0a}, "0x2", 100, chainId,
+        groupId, 0);
+    BOOST_REQUIRE(tx);
+    // D8 (review ①): install a raw 20-byte sender so the read side must checksum the raw bytes.
+    // Mixed-case hex letters (0x5aAe...BeAed) make EIP-55 checksum casing observable (an
+    // all-digit address would make toChecksumAddress a no-op).
+    tx->forceSender(bcos::fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"));
+    seedLedger->seedTx(tx);
+
+    auto receipt = m_blockFactory->receiptFactory()->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", {}, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    BOOST_REQUIRE(receipt);
+    receipt->setTransactionIndex(0);
+    // C4: seed a receipt WITH opStackMeta so eth_getTransactionReceipt must carry the OP extension
+    // fields through the REAL RPC dispatch (unit-testing combineReceiptResponse alone does not
+    // prove the fields survive the full EthEndpoint → JSON round-trip).
+    protocol::OpStackReceiptMeta meta;
+    meta.l1_gas_price = bcos::u256(5);
+    meta.operator_fee_scalar = 2;
+    receipt->setOpStackMeta(std::move(meta));
+    seedLedger->seededReceipt = receipt;
+
+    // Rebuild the RPC stack over the seedable ledger.
+    auto service = std::make_shared<rpc::NodeService>(
+        seedLedger, scheduler, txPool, nullptr, nullptr, m_blockFactory, nullptr);
+    auto seededRpc = factory->buildLocalRpc(groupInfo, service);
+    auto seededWeb3 = seededRpc->web3JsonRpc();
+    BOOST_REQUIRE(seededWeb3 != nullptr);
+
+    auto const txHashHex = tx->hash().hexPrefixed();
+    auto callSeeded = [&](std::string_view request) {
+        std::promise<bcos::bytes> promise;
+        seededWeb3->onRPCRequest(request, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
+        auto jsonBytes = promise.get_future().get();
+        Json::Value value;
+        Json::Reader reader;
+        std::string_view json((char*)jsonBytes.data(), jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    };
+
+    // eth_getTransactionReceipt returns a complete object with the checksummed from (review ①).
+    {
+        auto resp = callSeeded(req("eth_getTransactionReceipt", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("transactionHash"));
+        BOOST_CHECK_EQUAL(resp["result"]["transactionHash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("logs"));
+        BOOST_CHECK(resp["result"].isMember("blockNumber"));
+        // C4: OP extension fields survive the full RPC round-trip (not just
+        // combineReceiptResponse).
+        BOOST_CHECK_EQUAL(resp["result"]["l1GasPrice"].asString(), "0x5");
+        BOOST_CHECK_EQUAL(resp["result"]["operatorFeeScalar"].asString(), "0x2");
+        // Pinned against the independently-known EIP-55 vector (NOT derived via the same
+        // toChecksumAddress under test, so a checksum-casing regression is actually caught).
+        BOOST_CHECK_EQUAL(
+            resp["result"]["from"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+    }
+
+    // eth_getTransactionByHash resolves the same tx.
+    {
+        auto resp = callSeeded(req("eth_getTransactionByHash", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("hash"));
+        BOOST_CHECK_EQUAL(resp["result"]["hash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("from"));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -9,9 +9,13 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
 
 #include <boost/test/unit_test.hpp>
 using namespace bcos;
@@ -19,6 +23,31 @@ using namespace bcos::rpc;
 
 namespace bcos::test
 {
+namespace
+{
+// Local factories — Web3ResponseTest.cpp has no makeReceipt/makeWeb3Tx helpers; these mirror the
+// construction in combineReceiptResponseShapesReceipt so the OP-field / deposit / 4844 tests below
+// can stay compact.
+bcos::protocol::TransactionReceipt::Ptr makeReceipt(bcos::protocol::BlockFactory::Ptr blockFactory)
+{
+    auto receiptFactory = blockFactory->receiptFactory();
+    std::vector<bcos::protocol::LogEntry> logs;
+    auto receipt = receiptFactory->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", logs, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    receipt->setTransactionIndex(0);
+    return receipt;
+}
+
+bcos::protocol::Transaction::Ptr makeWeb3Tx(bcos::protocol::BlockFactory::Ptr blockFactory,
+    std::string const& chainId, std::string const& groupId)
+{
+    auto txFactory = blockFactory->transactionFactory();
+    return txFactory->createTransaction(0, "0x1234567890123456789012345678901234567890",
+        bcos::bytes{0x0a}, "0x2", 100, chainId, groupId, 0);
+}
+}  // namespace
+
 BOOST_FIXTURE_TEST_SUITE(Web3ResponseTest, RPCFixture)
 
 BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
@@ -143,6 +172,222 @@ BOOST_AUTO_TEST_CASE(combineReceiptResponseShapesReceipt)
     BOOST_CHECK(result.isMember("gasUsed"));
     BOOST_CHECK(result.isMember("logs"));
     BOOST_CHECK(result["logs"].isArray());
+}
+
+BOOST_AUTO_TEST_CASE(combineReceiptResponseEmitsOpExtensionFieldsFromMeta)
+{
+    auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+    BOOST_REQUIRE(tx);
+    // D8 (review ①): non-deposit from must be the checksum of the RAW sender bytes. Install a raw
+    // 20-byte sender; if the read side re-encoded a hex-string (double-encoded) sender this
+    // assertion would fail — that is exactly the bug review ① caught on the write side. The
+    // address carries mixed-case hex letters (0x5aAe...BeAed) so EIP-55 checksum casing is
+    // actually observable — an all-digit address makes toChecksumAddress a no-op and could never
+    // regress-catch.
+    tx->forceSender(bcos::fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"));
+
+    auto receipt = makeReceipt(m_blockFactory);
+    BOOST_REQUIRE(receipt);
+    protocol::OpStackReceiptMeta meta;
+    // D2 (P4-1): ALL 13 mappings positively asserted — a wrong JSON key or value on any field
+    // would otherwise pass (empty-meta test only proves absence-when-empty). Distinct values so
+    // cross-field mixups are caught too.
+    meta.l1_gas_price = bcos::u256(5);
+    meta.l1_gas_used = 6;
+    meta.l1_fee = bcos::u256(10);
+    meta.l1_blob_base_fee = bcos::u256(11);
+    meta.l1_base_fee_scalar = 12;
+    meta.l1_blob_base_fee_scalar = 13;
+    meta.operator_fee_scalar = 14;
+    meta.operator_fee_constant = 15;
+    meta.da_footprint_gas_scalar = 16;
+    meta.da_footprint = 17;
+    meta.deposit_nonce = 18;
+    meta.deposit_receipt_version = 19;
+    meta.operator_fee = bcos::u256(20);
+    receipt->setOpStackMeta(std::move(meta));
+
+    bcos::crypto::HashType blockHash;
+    blockHash[0] = 0x99;
+
+    Json::Value result = Json::objectValue;
+    combineReceiptResponse(result, *receipt, *tx, blockHash);
+
+    BOOST_CHECK_EQUAL(result["l1GasPrice"].asString(), "0x5");
+    BOOST_CHECK_EQUAL(result["l1GasUsed"].asString(), "0x6");
+    BOOST_CHECK_EQUAL(result["l1Fee"].asString(), "0xa");
+    BOOST_CHECK_EQUAL(result["l1BlobBaseFee"].asString(), "0xb");
+    BOOST_CHECK_EQUAL(result["l1BaseFeeScalar"].asString(), "0xc");
+    BOOST_CHECK_EQUAL(result["l1BlobBaseFeeScalar"].asString(), "0xd");
+    BOOST_CHECK_EQUAL(result["operatorFeeScalar"].asString(), "0xe");
+    BOOST_CHECK_EQUAL(result["operatorFeeConstant"].asString(), "0xf");
+    BOOST_CHECK_EQUAL(result["daFootprintGasScalar"].asString(), "0x10");
+    BOOST_CHECK_EQUAL(result["blobGasUsed"].asString(), "0x11");  // ← da_footprint (Jovian 复用)
+    BOOST_CHECK_EQUAL(result["depositNonce"].asString(), "0x12");
+    BOOST_CHECK_EQUAL(result["depositReceiptVersion"].asString(), "0x13");
+    BOOST_CHECK_EQUAL(result["operatorFee"].asString(), "0x14");  // FISCO 扩展
+    // from = checksum of the raw sender bytes (review ①). Pinned against the independently-known
+    // EIP-55 vector 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed (deliberately NOT derived via the
+    // same toChecksumAddress under test, so a checksum-casing regression is actually caught).
+    BOOST_CHECK_EQUAL(result["from"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+}
+
+// Important #1 (whole-branch review): receipt `type` for a Web3 tx must equal the EIP-2718 kind
+// byte. The write side stores encodeForSign() (RLP WITHOUT the type byte) in extraTransactionBytes
+// for typed non-deposit txs, so byte-sniffing extraTransactionBytes collapsed EIP-2930/1559/4844
+// receipts into Legacy 0x0 while eth_getTransactionByHash reported the correct kind.
+// combineReceiptResponse now reads the `web3TypedTxKind` tars slot (populated by
+// takeToTarsTransaction for every Web3 kind).
+BOOST_AUTO_TEST_CASE(combineReceiptResponseTypedTxKindType)
+{
+    auto makeWeb3TarsTx = [&](bcos::rpc::Web3Transaction web3Tx) {
+        auto tarsTx = web3Tx.takeToTarsTransaction();
+        // D4: manual extraTransactionHash so combineReceiptResponse:19 tx.hash() does not throw.
+        bcos::h256 arbitraryHash(
+            "0303030303030303030303030303030303030303030303030303030303030303");
+        tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+        return std::make_shared<bcostars::protocol::TransactionImpl>(
+            [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+    };
+
+    // EIP-1559 (0x02): previously misreported as 0x0 Legacy by the byte-sniff.
+    {
+        bcos::rpc::Web3Transaction web3Tx;
+        web3Tx.type = bcos::rpc::TransactionType::EIP1559;
+        web3Tx.chainId = 1;
+        web3Tx.nonce = 0;
+        web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+        web3Tx.maxFeePerGas = bcos::u256(2);
+        web3Tx.gasLimit = 21000;
+        web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+        web3Tx.value = bcos::u256(0);
+        web3Tx.signatureR = bcos::bytes(32, 0x11);
+        web3Tx.signatureS = bcos::bytes(32, 0x22);
+        web3Tx.signatureV = 0;
+        auto tx = makeWeb3TarsTx(std::move(web3Tx));
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x2");
+    }
+    // Deposit (0x7e): full envelope stored, kind slot set to Deposit.
+    {
+        bcos::rpc::Web3Transaction web3Deposit;
+        web3Deposit.type = bcos::rpc::TransactionType::Deposit;
+        web3Deposit.from = bcos::Address("0xdead000000000000000000000000000000000011");
+        web3Deposit.sourceHash =
+            bcos::h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        web3Deposit.mint = bcos::u256("0x16345785d8a0000");
+        web3Deposit.nonce = 0;
+        web3Deposit.isSystemTx = true;
+        auto tx = makeWeb3TarsTx(std::move(web3Deposit));
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    }
+    // Legacy BCOSTransaction: web3TypedTxKind() is 0 == Legacy → 0x0.
+    {
+        auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x0");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(combineReceiptResponseOmitsOpFieldsWhenMetaEmpty)
+{
+    auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+    BOOST_REQUIRE(tx);
+    auto receipt = makeReceipt(m_blockFactory);
+    BOOST_REQUIRE(receipt);
+
+    bcos::crypto::HashType blockHash;
+    Json::Value result = Json::objectValue;
+    combineReceiptResponse(result, *receipt, *tx, blockHash);
+
+    // Empty opStackMeta → NO OP fields at all (no zero/default placeholders).
+    BOOST_CHECK(!result.isMember("l1GasPrice"));
+    BOOST_CHECK(!result.isMember("l1Fee"));
+    BOOST_CHECK(!result.isMember("l1GasUsed"));
+    BOOST_CHECK(!result.isMember("l1BlobBaseFee"));
+    BOOST_CHECK(!result.isMember("l1BaseFeeScalar"));
+    BOOST_CHECK(!result.isMember("l1BlobBaseFeeScalar"));
+    BOOST_CHECK(!result.isMember("operatorFeeScalar"));
+    BOOST_CHECK(!result.isMember("operatorFeeConstant"));
+    BOOST_CHECK(!result.isMember("daFootprintGasScalar"));
+    BOOST_CHECK(!result.isMember("blobGasUsed"));
+    BOOST_CHECK(!result.isMember("depositNonce"));
+    BOOST_CHECK(!result.isMember("depositReceiptVersion"));
+    BOOST_CHECK(!result.isMember("operatorFee"));
+}
+
+// Read-side deposit (0x7e) transaction shape. takeToTarsTransaction() does NOT fill
+// extraTransactionHash (review ③/D4), and combineTxResponse:44 calls tx.hash() which throws
+// EmptyTransactionHash on an empty one — so the test must install arbitrary 32 bytes.
+BOOST_AUTO_TEST_CASE(combineTxResponseDepositMinimalFields)
+{
+    bcos::rpc::Web3Transaction web3Deposit;
+    web3Deposit.type = bcos::rpc::TransactionType::Deposit;
+    web3Deposit.from = bcos::Address("0xdead000000000000000000000000000000000011");
+    web3Deposit.sourceHash =
+        bcos::h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    web3Deposit.mint = bcos::u256("0x16345785d8a0000");
+    web3Deposit.nonce = 0;
+    web3Deposit.isSystemTx = true;
+
+    auto tarsTx = web3Deposit.takeToTarsTransaction();
+    // D4 (review ③): manual extraTransactionHash so combineTxResponse:44 does not throw.
+    bcos::h256 arbitraryHash("0101010101010101010101010101010101010101010101010101010101010101");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+    bcostars::protocol::TransactionImpl txImpl(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    Json::Value result = Json::objectValue;
+    combineTxResponse(
+        result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+    BOOST_CHECK(result.isMember("nonce"));  // deposit nonce=0
+    BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    // Deposit (0x7e) is numerically larger than every EIP type, so the explicit range checks at
+    // TransactionResponse.cpp:68/:86 exclude it from accessList / blob fields.
+    BOOST_CHECK(!result.isMember("accessList"));
+    BOOST_CHECK(!result.isMember("blobVersionedHashes"));
+}
+
+// Read-side EIP-4844 blob transaction: blobVersionedHashes / maxFeePerBlobGas branches.
+BOOST_AUTO_TEST_CASE(combineTxResponseBlob4844)
+{
+    bcos::rpc::Web3Transaction web3Tx;
+    web3Tx.type = bcos::rpc::TransactionType::EIP4844;
+    web3Tx.chainId = 1;
+    web3Tx.nonce = 0;
+    web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+    web3Tx.maxFeePerGas = bcos::u256(2);
+    web3Tx.gasLimit = 21000;
+    web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+    web3Tx.value = bcos::u256(0);
+    web3Tx.maxFeePerBlobGas = bcos::u256(3);
+    web3Tx.blobVersionedHashes = {
+        bcos::h256("c6bdd1de713471bd6cfa62dd8b5a5b42969ed09e26212d3377f3f8426d8ec210")};
+    web3Tx.signatureR = bcos::bytes(32, 0x11);
+    web3Tx.signatureS = bcos::bytes(32, 0x22);
+    web3Tx.signatureV = 0;
+
+    auto tarsTx = web3Tx.takeToTarsTransaction();
+    // D4 (review ③): manual extraTransactionHash so combineTxResponse:44 does not throw.
+    bcos::h256 arbitraryHash("0202020202020202020202020202020202020202020202020202020202020202");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+    bcostars::protocol::TransactionImpl txImpl(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    Json::Value result = Json::objectValue;
+    combineTxResponse(
+        result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+    BOOST_CHECK(result.isMember("blobVersionedHashes"));
+    BOOST_CHECK(result.isMember("maxFeePerBlobGas"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
@@ -20,6 +20,8 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3TxHandler.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -128,6 +130,9 @@ BOOST_AUTO_TEST_CASE(testEIP2930Transaction)
     BOOST_CHECK_EQUAL(tx.value, 2000000000000000000ull);
     BOOST_CHECK_EQUAL(toHex(tx.data), "6ebaf477f83e051589c1188bcc6ddccd");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-2930 sample carries yParity=0.
+    BOOST_CHECK_EQUAL(tx.signatureV, 0u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -161,6 +166,9 @@ BOOST_AUTO_TEST_CASE(testEIP1559Transaction)
     BOOST_CHECK_EQUAL(tx.value, 2000000000000000000ull);
     BOOST_CHECK_EQUAL(toHex(tx.data), "6ebaf477f83e051589c1188bcc6ddccd");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-1559 sample carries yParity=0.
+    BOOST_CHECK_EQUAL(tx.signatureV, 0u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -239,6 +247,9 @@ BOOST_AUTO_TEST_CASE(testEIP4844Transaction)
     BOOST_CHECK_EQUAL(toHex(tx.blobVersionedHashes[1]),
         "8aaeccaf3873d07cef005aca28c39f8a9f8bdb1ec8d79ffc25afc0a4fa2ab736");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35 + 1);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-4844 sample carries yParity=1 (hence the +1 in getSignatureV above).
+    BOOST_CHECK_EQUAL(tx.signatureV, 1u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -249,6 +260,125 @@ BOOST_AUTO_TEST_CASE(testEIP4844Transaction)
     codec::rlp::encode(encoded, tx);
     auto rawTx2 = toHexStringWithPrefix(encoded);
     BOOST_CHECK_EQUAL(rawTx, rawTx2);
+}
+
+// C2 (W8 review): typed-tx yParity is restricted to 0/1 (Web3TxHandler rejects signatureV > 1 with
+// InvalidVInSignature). Flip the yParity wire byte of each legal typed-tx sample to 0x02
+// (single-byte self-encoding — same wire length, outer RLP prefix unaffected) and assert the
+// decoder rejects it. Wire offsets are RLP-decoding-verified: EIP-2930 field[8] at 178,
+// EIP-1559 field[9] at 184, EIP-4844 field[11] at 232.
+BOOST_AUTO_TEST_CASE(typedTxYParityOverOneRejected)
+{
+    auto byteAt = [](std::string_view hex, std::size_t byteOffset) -> int {
+        auto nibble = [](char c) -> int {
+            if (c >= '0' && c <= '9')
+            {
+                return c - '0';
+            }
+            if (c >= 'a' && c <= 'f')
+            {
+                return c - 'a' + 10;
+            }
+            return c - 'A' + 10;
+        };
+        auto pos = 2 + byteOffset * 2;  // skip "0x"
+        return nibble(hex[pos]) * 16 + nibble(hex[pos + 1]);
+    };
+    auto flipByteToTwo = [](std::string_view hex, std::size_t byteOffset) {
+        std::string out(hex);
+        auto pos = 2 + byteOffset * 2;  // skip "0x"
+        out[pos] = '0';
+        out[pos + 1] = '2';
+        return out;
+    };
+
+    // clang-format off
+    constexpr std::string_view kEIP2930RawTx = "0x01f8f205078506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7881bc16d674ec80000906ebaf477f83e051589c1188bcc6ddccdf872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c080a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    constexpr std::string_view kEIP1559RawTx = "0x02f8f805078502540be4008506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7881bc16d674ec80000906ebaf477f83e051589c1188bcc6ddccdf872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c080a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    constexpr std::string_view kEIP4844RawTx = "0x03f9012705078502540be4008506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7808204f7f872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c07bf842a0c6bdd1de713471bd6cfa62dd8b5a5b42969ed09e26212d3377f3f8426d8ec210a08aaeccaf3873d07cef005aca28c39f8a9f8bdb1ec8d79ffc25afc0a4fa2ab73601a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    // clang-format on
+
+    struct Sample
+    {
+        std::string_view rawTx;
+        std::size_t yParityOffset;
+        int expectedYParityByte;  // the RLP-encoded yParity currently at the offset
+    };
+    const Sample samples[] = {
+        {kEIP2930RawTx, 178, 0x80},
+        {kEIP1559RawTx, 184, 0x80},
+        {kEIP4844RawTx, 232, 0x01},
+    };
+    for (const auto& sample : samples)
+    {
+        // Guard: fail loudly if a wire offset is stale — never silently test the wrong byte.
+        BOOST_CHECK_MESSAGE(
+            byteAt(sample.rawTx, sample.yParityOffset) == sample.expectedYParityByte,
+            "yParity wire byte mismatch at offset " << sample.yParityOffset);
+
+        auto bytes = fromHexWithPrefix(flipByteToTwo(sample.rawTx, sample.yParityOffset));
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto e = codec::rlp::decode(bRef, tx);
+        BOOST_REQUIRE_MESSAGE(
+            e != nullptr, "yParity=2 must be rejected (offset " << sample.yParityOffset << ')');
+        if (e != nullptr)
+        {
+            BOOST_CHECK_EQUAL(e->errorCode(),
+                static_cast<int64_t>(codec::rlp::DecodingError::InvalidVInSignature));
+        }
+    }
+}
+
+// EIP-2 canonical-s: a malleable (high-s) signature must be rejected at decode. decode() is the
+// single funnel for both OP paths — eth_sendRawTransaction (EthEndpoint) and engine newPayload
+// (opEnvelopeToTars) — so this covers admission AND block processing, matching op-geth. Flipping
+// s -> n - s recovers the same sender and would otherwise execute byte-for-byte identically.
+BOOST_AUTO_TEST_CASE(highSsignatureRejectedAtDecode)
+{
+    const u256 kSecpOrder("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+    const u256 kSecpHalfOrder = kSecpOrder / 2;
+
+    Web3Transaction tx;
+    tx.value = 1000000000000000000;
+    tx.type = rpc::TransactionType::Legacy;
+    tx.data = {};
+    tx.to = Address("0x1e58529dAA467406645d0f4B63dec96CA0b87d70");
+    tx.nonce = 19;
+    tx.gasLimit = 210000;
+    tx.maxFeePerGas = 20000000000;
+    tx.maxPriorityFeePerGas = 20000000000;
+    tx.chainId = 31337;
+
+    auto signData = tx.encodeForSign();
+    std::string priv = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    auto key = std::make_shared<KeyImpl>(fromHex(priv));
+    auto newHash = crypto::keccak256Hash(ref(signData));
+    auto signatureImpl = bcos::crypto::Secp256k1Crypto();
+    auto keyPair = std::make_unique<Secp256k1KeyPair>(key);
+    auto signature = signatureImpl.sign(*keyPair, newHash, false);
+    tx.signatureR = {signature->begin(), signature->begin() + 32};
+    tx.signatureS = {signature->begin() + 32, signature->begin() + 64};
+    tx.signatureV = signature->back();
+
+    // Guard: libsecp256k1 signs canonical low-s — confirm before flipping, so a future
+    // libsecp256k1 behavior change fails loudly instead of silently weakening the test.
+    const u256 s = u256("0x" + toHex(tx.signatureS));
+    BOOST_REQUIRE(s <= kSecpHalfOrder);
+
+    // Malleability flip: s' = n - s is high-s but recovers the same sender.
+    tx.signatureS = toBigEndian(kSecpOrder - s);
+    const u256 flipped = u256("0x" + toHex(tx.signatureS));
+    BOOST_REQUIRE(flipped > kSecpHalfOrder);
+
+    bcos::bytes encoded;
+    codec::rlp::encode(encoded, tx);
+    auto bRef = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto e = codec::rlp::decode(bRef, decoded);
+    BOOST_REQUIRE(e != nullptr);
+    BOOST_CHECK_EQUAL(
+        e->errorCode(), static_cast<int64_t>(codec::rlp::DecodingError::InvalidVInSignature));
 }
 
 BOOST_AUTO_TEST_CASE(testEIP7702Transaction)
@@ -444,6 +574,165 @@ BOOST_AUTO_TEST_CASE(EIP4844Recover)
     BOOST_CHECK(re);
     auto address = toHexStringWithPrefix(addr);
     BOOST_CHECK_EQUAL(address, "0xc1b634853cb333d3ad8663715b08f41a3aec47cc");
+}
+
+// Deposit encode→decode roundtrip locks the uint32_t isSystemTransaction workaround
+// (see Web3TxHandler.h header comment) — when the underlying ODR defect is fixed and
+// the field switches back to uint8_t, this test ensures the encoded byte does not
+// silently regress.
+BOOST_AUTO_TEST_CASE(depositRoundtrip)
+{
+    Web3Transaction deposit;
+    deposit.type = rpc::TransactionType::Deposit;
+    deposit.sourceHash = h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    deposit.from = Address("0xdead000000000000000000000000000000000011");
+    deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+    deposit.mint = u256("0x16345785d8a0000");
+    deposit.value = u256(0);
+    deposit.gasLimit = 1000000;
+    deposit.isSystemTx = true;
+    deposit.data = bcos::bytes{};
+
+    // Encode → decode roundtrip
+    auto encoded = deposit.encode();
+    auto ref = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto err = decoded.decode(ref, false);  // withSig=false, deposit has no signature
+    BOOST_REQUIRE(err == nullptr);
+
+    BOOST_CHECK(decoded.type == rpc::TransactionType::Deposit);
+    BOOST_CHECK(decoded.isSystemTx);
+    BOOST_CHECK_EQUAL(decoded.sourceHash.hex(), deposit.sourceHash.hex());
+    BOOST_CHECK_EQUAL(decoded.from.hexPrefixed(), deposit.from.hexPrefixed());
+    BOOST_CHECK(decoded.to.has_value());
+    BOOST_CHECK_EQUAL(decoded.to->hexPrefixed(), deposit.to->hexPrefixed());
+    BOOST_CHECK_EQUAL(decoded.mint, deposit.mint);
+    BOOST_CHECK_EQUAL(decoded.value, deposit.value);
+    BOOST_CHECK_EQUAL(decoded.gasLimit, deposit.gasLimit);
+
+    // Also round-trip the system-tx=false case
+    Web3Transaction nonSysDeposit;
+    nonSysDeposit.type = rpc::TransactionType::Deposit;
+    nonSysDeposit.sourceHash =
+        h256("7bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8");
+    nonSysDeposit.from = Address("0xdead000000000000000000000000000000000011");
+    nonSysDeposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+    nonSysDeposit.mint = u256(100);
+    nonSysDeposit.value = u256(0);
+    nonSysDeposit.gasLimit = 500000;
+    nonSysDeposit.isSystemTx = false;
+    nonSysDeposit.data = bcos::bytes{};
+
+    auto encoded2 = nonSysDeposit.encode();
+    auto ref2 = bcos::ref(encoded2);
+    Web3Transaction decoded2;
+    err = decoded2.decode(ref2, false);
+    BOOST_REQUIRE(err == nullptr);
+
+    BOOST_CHECK(decoded2.type == rpc::TransactionType::Deposit);
+    BOOST_CHECK(!decoded2.isSystemTx);
+    BOOST_CHECK_EQUAL(decoded2.mint, nonSysDeposit.mint);
+}
+
+// The sendRawTransaction guard in EthEndpoint.cpp checks web3Tx.type == Deposit after decoding the
+// raw bytes. The guard itself is a simple `if` + throw; the decode → type-detection path is the
+// test that verifies a valid 0x7E envelope is correctly identified. An RPC-level test would need
+// the full EthEndpoint fixture (future work).
+BOOST_AUTO_TEST_CASE(decodeDepositIdentifiesTypeForSendRawGuard)
+{
+    Web3Transaction deposit;
+    deposit.type = rpc::TransactionType::Deposit;
+    deposit.sourceHash = h256("0xabcd000000000000000000000000000000000000000000000000000000000000");
+    deposit.from = Address("0xdead000000000000000000000000000000000099");
+    deposit.to.emplace(Address("0x4200000000000000000000000000000000000011"));
+    deposit.mint = u256(1);
+    deposit.value = u256(0);
+    deposit.gasLimit = 21000;
+    deposit.isSystemTx = false;
+    deposit.data = bcos::bytes{};
+
+    auto encoded = deposit.encode();
+    BOOST_REQUIRE(!encoded.empty());
+
+    // The raw envelope must start with 0x7E (EIP-2718 type byte)
+    BOOST_CHECK_EQUAL(
+        static_cast<uint8_t>(encoded[0]), static_cast<uint8_t>(rpc::TransactionType::Deposit));
+
+    // Decode through the public codec entry point — this is the path EthEndpoint calls
+    // (codec::rlp::decode → Web3Transaction::decode) before the type-guard check.
+    auto ref = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto err = bcos::codec::rlp::decode(ref, decoded);
+    BOOST_REQUIRE(err == nullptr);
+    BOOST_CHECK(decoded.type == rpc::TransactionType::Deposit);
+    // A real sendRawTransaction call would now hit: if (web3Tx.type == Deposit) → throw
+    // InvalidParams
+}
+
+// Golden-vector deposit encoding: encode known deposit txs and compare byte-for-byte
+// against independently-verified RLP output (cross-validated against the OP Stack deposit
+// spec: 0x7E || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])).
+// The golden hex strings were verified against an independent oracle and op-geth-shaped
+// vectors. If a future change alters the deposit encoding, this test breaks — that's
+// intentional. The 0x80 vs 0x01 isSystemTx distinction is the op-geth convention the
+// uint32_t workaround (see Web3TxHandler.h header comment) exists to preserve.
+BOOST_AUTO_TEST_CASE(depositGoldenEncoding)
+{
+    // isSystemTx=true: 0x7E || rlp([33b sourceHash, 21b from, 21b to, 9b mint,
+    //                          1b value(0), 4b gas, 1b isSystemTx(0x01), 1b data(empty)])
+    // gas = 0x0f4240 = 1000000
+    {
+        Web3Transaction deposit;
+        deposit.type = rpc::TransactionType::Deposit;
+        deposit.sourceHash =
+            h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        deposit.from = Address("0xdead000000000000000000000000000000000011");
+        deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+        deposit.mint = u256("0x16345785d8a0000");
+        deposit.value = u256(0);
+        deposit.gasLimit = 1000000;
+        deposit.isSystemTx = true;
+        deposit.data = bcos::bytes{};
+
+        auto encoded = deposit.encode();
+        BOOST_CHECK_EQUAL(toHex(encoded),
+            "7ef85ba06ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"
+            "94dead000000000000000000000000000000000011"
+            "944200000000000000000000000000000000000022"
+            "88016345785d8a0000"
+            "80"
+            "830f4240"
+            "01"
+            "80");
+    }
+
+    // isSystemTx=false: 0x7E || rlp([33b sourceHash, 21b from, 21b to, 1b mint(0x64=100),
+    //                              1b value(0), 4b gas, 1b isSystemTx(0x80), 1b data(empty)])
+    // gas = 0x07a120 = 500000, list header 0xf853 (shorter: mint is 1 byte vs 9)
+    {
+        Web3Transaction deposit;
+        deposit.type = rpc::TransactionType::Deposit;
+        deposit.sourceHash =
+            h256("7bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8");
+        deposit.from = Address("0xdead000000000000000000000000000000000011");
+        deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+        deposit.mint = u256(100);
+        deposit.value = u256(0);
+        deposit.gasLimit = 500000;
+        deposit.isSystemTx = false;
+        deposit.data = bcos::bytes{};
+
+        auto encoded = deposit.encode();
+        BOOST_CHECK_EQUAL(toHex(encoded),
+            "7ef853a07bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8"
+            "94dead000000000000000000000000000000000011"
+            "944200000000000000000000000000000000000022"
+            "64"
+            "80"
+            "8307a120"
+            "80"
+            "80");
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/CMakeLists.txt
+++ b/opstack-executor/CMakeLists.txt
@@ -4,20 +4,19 @@ find_package(evmone REQUIRED)
 find_package(intx REQUIRED)
 find_package(TBB CONFIG REQUIRED)
 
-add_library(opstack-executor INTERFACE)
-target_include_directories(opstack-executor INTERFACE
+add_library(opstack-executor
+    OpBlockExecute.cpp
+)
+target_include_directories(opstack-executor PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/opstack-executor>)
-# No direct `ledger` / `rlp-protocol` links: header-only usage only (Classify.h), and both drag
-# the bcos-crypto→wedprcrypto chain that breaks libc++ typed catch binary-wide
-# (bcos-rpc/test/CMakeLists.txt:29-34). `ledger` still arrives transitively via bcos-evm-eth.
-target_link_libraries(opstack-executor INTERFACE
+target_link_libraries(opstack-executor PUBLIC
     bcos-evm-opstack ethereum-executor bcos-framework bcos-protocol
-    evmone::evmone intx::intx TBB::tbb)
+    ledger evmone::evmone intx::intx TBB::tbb rlp-protocol)
 set_target_properties(opstack-executor PROPERTIES UNITY_BUILD OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    # OP modules deliberately use skipped-field designated initializers and GCC-13
-    # reference-returning helpers (jAt); downgrade only here, not repository-wide.
+    # kyonRay review #5429 K5: OP modules deliberately use skipped-field designated initializers
+    # and GCC-13 reference-returning helpers (jAt); downgrade only here, not repository-wide.
     target_compile_options(opstack-executor PRIVATE
         -Wno-error=missing-field-initializers -Wno-error=dangling-reference)
 endif()

--- a/opstack-executor/OpBlockExecute.cpp
+++ b/opstack-executor/OpBlockExecute.cpp
@@ -1,0 +1,313 @@
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-evm/adapter/StateDiffSanitize.h>
+#include <bcos-evm/opstack/OpFeeParams.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-framework/protocol/LogEntry.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-utilities/DataConvertUtility.h>  // bcos::safeFromQuantity (parseHexUint64 reuse, review #5429 T)
+#include <opstack-executor/OpBlockExecute.h>
+#include <algorithm>
+#include <bcos-evm/eth/state/state.hpp>  // evmone::state::finalize
+#include <bcos-evm/eth/state/system_contracts.hpp>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+// isL1AttributesTx lives in OpBlockExecute.h; narrowGasUsed / hexCumulative live in OpCommon.h
+// (both shared with the per-tx loop — one implementation, no copy drift).
+
+namespace bcos::evm::opstack
+{
+void validateJovianBlockShape(std::span<const OpBlockTx> txs, const OpForkConfig& cfg)
+{
+    if (!cfg.has_da_footprint)  // Jovian-only (op-geth CalcDAFootprint)
+        return;
+    if (txs.empty())  // rejected by processOpBlock anyway
+        return;
+    const auto* firstDep = std::get_if<DepositTx>(&txs[0].tx);
+    if (firstDep == nullptr)
+        return;
+
+    const auto& data = firstDep->data;
+    if (data.size() == IsthmusL1AttributesLen)
+    {
+        // Jovian activation block: Isthmus-length attributes, must be deposits-only (op-geth
+        // rollup_cost.go:568-576). Checking the last tx suffices (deposits always precede
+        // non-deposits).
+        if (!std::holds_alternative<DepositTx>(txs.back().tx))
+            throw std::runtime_error(
+                "op block: unexpected non-deposit transactions in Jovian activation block");
+        return;
+    }
+
+    // Normal Jovian block: L1 attributes must carry the Jovian selector and be ≥ Jovian length.
+    if (data.size() < JovianL1AttributesLen)
+        throw std::runtime_error(
+            "op block: L1 attributes transaction data too short for DA footprint gas scalar");
+    if (!std::equal(
+            JovianL1AttributesSelector.begin(), JovianL1AttributesSelector.end(), data.begin()))
+        throw std::runtime_error(
+            "op block: L1 attributes transaction data does not have Jovian selector");
+}
+
+evmone::state::StateDiff finalizeOpBlock(
+    const evmone::state::StateView& view, const OpForkConfig& cfg, const evmc::address& coinbase)
+{
+    if (!cfg.disable_prague_requests)
+        // runtime_error (not logic_error): block-level rejection (INVALID), not a local fault.
+        throw std::runtime_error("op finalize: prague requests unsupported on OP chains");
+    return bcos::evm::sanitizeStateDiff(
+        view, evmone::state::finalize(view, cfg.rev, coinbase, std::nullopt, {}, {}));
+}
+
+OpBlockResult processOpBlock(const evmone::state::StateView& view,
+    const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
+    std::span<const OpBlockTx> txs, const OpForkConfig& cfg, evmc::VM& vm, uint64_t chainId,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory,
+    const std::function<void(const evmone::state::StateDiff&)>& applyDiff)
+{
+    // Step 1: pre-block system call (4788/2935; gating/skip handled inside evmone).
+    applyDiff(bcos::evm::sanitizeStateDiff(
+        view, evmone::state::system_call_block_start(view, block, hashes, cfg.rev, vm)));
+
+    // Step 2: first tx must be the L1 attributes deposit (stricter-than-spec) + Jovian shape.
+    if (txs.empty())
+        throw std::runtime_error("op block: missing L1 attributes deposit (empty block)");
+    const auto* firstDep = std::get_if<DepositTx>(&txs[0].tx);
+    if (firstDep == nullptr || !isL1AttributesTx(*firstDep))
+        throw std::runtime_error("op block: first tx is not the L1 attributes deposit");
+    validateJovianBlockShape(txs, cfg);
+
+    OpBlockResult result;
+    result.receipts.reserve(txs.size());
+    result.txTypes.reserve(txs.size());
+    int64_t blockGasLeft = block.gas_limit;
+    int64_t cumulative = 0;
+    bool seenNonDeposit = false;
+    bool feeLoaded = false;
+    OpFeeParams fee{};
+
+    for (const auto& btx : txs)
+    {
+        if (const auto* dep = std::get_if<DepositTx>(&btx.tx))
+        {
+            if (seenNonDeposit)
+                throw std::runtime_error("op block: deposit after non-deposit tx");
+            evmone::state::StateDiff diff;
+            auto receipt = runDeposit(
+                view, block, hashes, *dep, cfg, vm, chainId, blockGasLeft, receiptFactory, diff);
+            applyDiff(diff);
+            const auto gasUsed = narrowGasUsed(receipt->gasUsed());
+            blockGasLeft -= gasUsed;
+            cumulative += gasUsed;
+            receipt->setCumulativeGasUsed(hexCumulative(cumulative));
+            result.receipts.emplace_back(std::move(receipt));
+            result.txTypes.emplace_back(classifyTxType(static_cast<uint8_t>(kDepositTxType)));
+        }
+        else
+        {
+            seenNonDeposit = true;
+            if (!feeLoaded)
+            {
+                // Fee params lazily loaded at the first normal tx (op-geth's per-block cache). DA
+                // scalar reads calldata[176:178] (authoritative even if the attributes deposit
+                // rolled back L1Block slot8); activation block (176B) forces 0.
+                fee = loadOpFeeParams(view);
+                if (cfg.has_da_footprint)
+                {
+                    const auto& attrData = std::get<DepositTx>(txs[0].tx).data;
+                    if (attrData.size() == IsthmusL1AttributesLen)
+                        fee.da_footprint_gas_scalar = 0;
+                    else if (attrData.size() >= JovianL1AttributesLen)
+                    {
+                        fee.da_footprint_gas_scalar = static_cast<uint16_t>(
+                            (static_cast<uint16_t>(attrData[JovianL1AttributesLen - 2]) << 8) |
+                            static_cast<uint16_t>(attrData[JovianL1AttributesLen - 1]));
+                    }
+                }
+                feeLoaded = true;
+            }
+            const auto& tx = std::get<evmone::state::Transaction>(btx.tx);
+            const evmc::bytes_view env{btx.signedEnvelope.data(), btx.signedEnvelope.size()};
+            auto v = opValidate(view, block, tx, env, cfg, fee, blockGasLeft);
+            if (const auto* err = std::get_if<std::error_code>(&v))
+                // No failed-receipt mechanism for normal txs: void the whole block (op-geth).
+                throw std::runtime_error("op block: invalid non-deposit tx: " + err->message());
+            // opTransition charges from props.fee (the validate-time snapshot — no second read).
+            evmone::state::StateDiff diff;
+            auto receipt = opTransition(view, block, hashes, tx, cfg, vm,
+                std::get<OpTxProperties>(v), chainId, receiptFactory, diff);
+            applyDiff(diff);
+            const auto gasUsed = narrowGasUsed(receipt->gasUsed());
+            blockGasLeft -= gasUsed;
+            cumulative += gasUsed;
+            receipt->setCumulativeGasUsed(hexCumulative(cumulative));
+            result.receipts.emplace_back(std::move(receipt));
+            result.txTypes.emplace_back(classifyTxType(static_cast<uint8_t>(tx.type)));
+        }
+    }
+
+    // Step 4: end-of-block finalize.
+    result.finalizeDiff = finalizeOpBlock(view, cfg, block.coinbase);
+    applyDiff(result.finalizeDiff);
+
+    result.gasUsed = cumulative;
+    return result;
+}
+
+// ---- block-header seal ----
+namespace
+{
+/// Parse "0x"-prefixed hex back to uint64 (the EncodeIndex leaf's cumulativeGasUsed). Delegates to
+/// the strict library parser bcos::safeFromQuantity — the previous hand-rolled loop silently
+/// wrapped >16-hex-digit input, where the library rejects overflow (review #5429 T).
+[[nodiscard]] uint64_t parseHexUint64(std::string_view s)
+{
+    if (auto v = bcos::safeFromQuantity(s))
+        return *v;
+    throw std::runtime_error(
+        "op block: invalid cumulativeGasUsed in receipt (not hex or overflow): " + std::string(s));
+}
+
+/// RLP list of logs: [address, [topics...], data] each, whole collection wrapped in a list
+/// (byte-identical to evmone's rlp::encode_container over vector<Log>).
+inline void encodeLogsList(bcos::bytes& to, gsl::span<const bcos::protocol::LogEntry> logs)
+{
+    bcos::bytes content;
+    for (const auto& log : logs)
+    {
+        bcos::bytes entry;
+        bcos::codec::rlp::encode(entry, log.address());
+        bcos::bytes topics;
+        for (const auto& topic : log.topics())
+            bcos::codec::rlp::encode(topics, topic);
+        bcos::codec::rlp::encodeHeader(entry, {.isList = true, .payloadLength = topics.size()});
+        entry.insert(entry.end(), topics.begin(), topics.end());
+        bcos::codec::rlp::encode(entry, log.data());
+        bcos::codec::rlp::encodeHeader(content, {.isList = true, .payloadLength = entry.size()});
+        content.insert(content.end(), entry.begin(), entry.end());
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = content.size()});
+    to.insert(to.end(), content.begin(), content.end());
+}
+}  // namespace
+
+evmone::hash256 opStorageRoot(const std::map<evmc::bytes32, evmc::bytes32>& storage)
+{
+    // Secure trie over the live slot map (key = keccak256(slot), leaf = rlp(trimmed value)).
+    std::map<bcos::h256, bcos::bytes> entries;
+    for (const auto& [key, value] : storage)
+    {
+        if (evmc::is_zero(value))
+            continue;
+        size_t first = 0;
+        while (first < sizeof(value.bytes) && value.bytes[first] == 0)
+        {
+            ++first;
+        }
+        bcos::bytes leaf;
+        bcos::codec::rlp::encode(
+            leaf, bcos::bytes(value.bytes + first, value.bytes + sizeof(value.bytes)));
+        entries[bcos::h256{evmone::keccak256(key).bytes, 32}] = std::move(leaf);
+    }
+    auto result = bcos::ledger::mpt::computeTrieRoot(entries);
+    evmone::hash256 root{};
+    std::memcpy(root.bytes, result.root.data(), sizeof(root.bytes));
+    return root;
+}
+
+evmc::bytes encodeReceiptForRoot(const bcos::protocol::TransactionReceipt& r, uint8_t txType)
+{
+    // RLP bool semantics: true → 0x01, false → 0x80 (raw push; the UnsignedByte encode path
+    // mis-handles bool). Payload = rlp([status, cumGas, bloom, logs]) + (deposit) [nonce, version].
+    const bool success = (r.status() == 0);
+    const uint64_t cumGas = parseHexUint64(r.cumulativeGasUsed());
+    const auto bloom = r.logsBloom();
+    const auto logs = r.logEntries();
+
+    bcos::bytes payload;
+    payload.push_back(success ? 0x01 : 0x80);
+    bcos::codec::rlp::encode(payload, cumGas);
+    bcos::codec::rlp::encode(payload, bloom);
+    encodeLogsList(payload, logs);
+
+    if (txType == static_cast<uint8_t>(kDepositTxType))
+    {
+        const auto& meta = r.opStackMeta();
+        const uint64_t nonce = (meta && meta->deposit_nonce) ? *meta->deposit_nonce : uint64_t{0};
+        const uint64_t version =
+            (meta && meta->deposit_receipt_version) ? *meta->deposit_receipt_version : uint64_t{0};
+        bcos::codec::rlp::encode(payload, nonce);
+        bcos::codec::rlp::encode(payload, version);
+    }
+
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payload.size()});
+    out.insert(out.end(), payload.begin(), payload.end());
+    // typed raw-byte prefix (legacy has none; deposit's 0x7e is the EIP-2718 type byte).
+    if (txType != static_cast<uint8_t>(evmone::state::Transaction::Type::legacy))
+        out.insert(out.begin(), txType);
+    return evmc::bytes(out.begin(), out.end());
+}
+
+OpBlockSeal sealOpBlock(const OpBlockResult& result, const OpForkConfig& cfg,
+    const std::map<evmc::bytes32, evmc::bytes32>& messagePasserStorage)
+{
+    OpBlockSeal seal{};
+
+    // receipts-root: var-key trie (key = rlp(index), leaf = EncodeIndex encoding).
+    std::vector<std::pair<bcos::bytes, bcos::bytes>> receiptsEntries;
+    receiptsEntries.reserve(result.receipts.size());
+    for (size_t i = 0; i < result.receipts.size(); ++i)
+    {
+        bcos::bytes key;
+        bcos::codec::rlp::encode(key, static_cast<uint64_t>(i));
+        auto const leaf = encodeReceiptForRoot(*result.receipts[i], result.txTypes[i]);
+        receiptsEntries.emplace_back(std::move(key), bcos::bytes{leaf.begin(), leaf.end()});
+    }
+    auto receiptsResult = bcos::ledger::mpt::computeTrieRootVarKey(receiptsEntries);
+    std::memcpy(
+        seal.receiptsRoot.bytes, receiptsResult.root.data(), sizeof(seal.receiptsRoot.bytes));
+
+    // Block-level logsBloom = bitwise-OR of each receipt's 256-byte bloom.
+    for (const auto& r : result.receipts)
+    {
+        const auto bloom = r->logsBloom();
+        for (size_t i = 0; i < 256 && i < bloom.size(); ++i)
+            seal.logsBloom.bytes[i] |= bloom[i];
+    }
+
+    // Isthmus+: withdrawalsRoot = MessagePasser storage root, requestsHash = sha256("").
+    // Pre-Isthmus: withdrawals list is always empty → empty-trie root; no requests field.
+    if (cfg.fork >= OpFork::Isthmus)
+    {
+        seal.withdrawalsRoot = opStorageRoot(messagePasserStorage);
+        seal.requestsHash = OP_EMPTY_REQUESTS_HASH;
+    }
+    else
+    {
+        auto const emptyRoot = bcos::ledger::mpt::emptyRootHash();
+        std::memcpy(
+            seal.withdrawalsRoot.bytes, emptyRoot.data(), sizeof(seal.withdrawalsRoot.bytes));
+    }
+
+    // Jovian: header blobGasUsed slot = DA footprint (Σ da_footprint over non-deposit receipts;
+    // deposits carry nullopt, so summing every receipt is equivalent).
+    if (cfg.has_da_footprint)
+    {
+        uint64_t footprint = 0;
+        for (const auto& r : result.receipts)
+        {
+            const auto& meta = r->opStackMeta();
+            if (meta && meta->da_footprint)
+                footprint += *meta->da_footprint;
+        }
+        seal.blobGasUsed = footprint;
+    }
+    return seal;
+}
+}  // namespace bcos::evm::opstack

--- a/opstack-executor/tests/OpReceiptEncodeTest.cpp
+++ b/opstack-executor/tests/OpReceiptEncodeTest.cpp
@@ -1,0 +1,238 @@
+#include "OpTestReceiptFactory.h"
+#include "TestPrinters.h"
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <opstack-executor/OpBlockExecute.h>  // encodeReceiptForRoot (seal merged here)
+#include <boost/test/unit_test.hpp>
+#include <bcos-evm/eth/state/bloom_filter.hpp>
+#include <sstream>
+#include <test/utils/rlp.hpp>
+#include <test/utils/rlp_encode.hpp>
+
+using namespace bcos::evm::opstack;
+using namespace bcos::evm::opstack::testutil;
+using namespace evmc::literals;
+
+namespace
+{
+/// A deposit receipt projected onto the FISCO receipt: cumulative "0x5208" (21000), 256-zero
+/// bloom, deposit_nonce/version in opStackMeta. `status` is the FISCO status (0 = success).
+bcos::protocol::TransactionReceipt::Ptr minimalDepositReceipt(int32_t status = 0)
+{
+    auto r = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, status, bcos::bytesConstRef{}, /*blockNumber=*/1);
+    r->setCumulativeGasUsed("0x5208");
+    bcos::bytes bloom(256, 0x00);
+    r->setLogsBloom(bcos::ref(bloom));
+    bcos::protocol::OpStackReceiptMeta meta;
+    meta.deposit_nonce = 5;
+    meta.deposit_receipt_version = 1;
+    r->setOpStackMeta(std::move(meta));
+    return r;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpReceiptEncodeSuite)
+
+// Hand-derived golden fixture byte-by-byte (assertion-numerics discipline: derivation is
+// the anchor; final byte authority belongs to M-B3 differential). RLP list items:
+// status success -> 0x01 (1B); cumGas 21000=0x5208 -> 0x82 52 08 (3B); bloom 256 zero
+// bytes -> 0xb9 0x0100 + 00x256 (259B); logs [] -> 0xc0 (1B); nonce 5 -> 0x05 (1B);
+// version 1 -> 0x01 (1B). Payload = 1+3+259+1+1+1 = 266 = 0x010a -> list header 0xf9 01 0a
+// (3B). Prefix 0x7e. Total 1+3+266 = 270.
+BOOST_AUTO_TEST_CASE(DepositGoldenBytes)
+{
+    const auto enc =
+        encodeReceiptForRoot(*minimalDepositReceipt(), static_cast<uint8_t>(kDepositTxType));
+    evmc::bytes expected{0x7e, 0xf9, 0x01, 0x0a, 0x01, 0x82, 0x52, 0x08, 0xb9, 0x01, 0x00};
+    expected += evmc::bytes(256, 0x00);
+    expected += evmc::bytes{0xc0, 0x05, 0x01};
+    BOOST_REQUIRE_EQUAL(enc.size(), 270u);
+    BOOST_CHECK_EQUAL(enc, expected);
+}
+
+// Failed deposit: status item = empty string 0x80 (op-geth statusEncoding failure branch).
+// rev.2 correction: 0x80 and the success 0x01 are both 1 byte (RLP single-byte
+// optimization yields 0x80 for the empty string, no content); payload stays 266 = 0x010a
+// and total stays 270 — only byte 5 changes 0x01 -> 0x80.
+BOOST_AUTO_TEST_CASE(FailedDepositStatusIsEmptyString)
+{
+    auto dep = minimalDepositReceipt(/*status=*/1);  // FISCO non-zero = failed
+    const auto enc = encodeReceiptForRoot(*dep, static_cast<uint8_t>(kDepositTxType));
+    evmc::bytes expected{0x7e, 0xf9, 0x01, 0x0a, 0x80, 0x82, 0x52, 0x08, 0xb9, 0x01, 0x00};
+    expected += evmc::bytes(256, 0x00);
+    expected += evmc::bytes{0xc0, 0x05, 0x01};
+    BOOST_REQUIRE_EQUAL(enc.size(), 270u);
+    BOOST_CHECK_EQUAL(enc, expected);
+}
+
+// Deposit with logs: the logs segment (incl. the vector-list wrapper) is compared as a
+// whole against evmone's independent encoding; the tail 2 bytes are {nonce, version}.
+// Total-length anchor (rev.2 red-team hardening, closing the wrapper-loss blind spot):
+// the empty-logs version totals 270, where the logs item is 1 byte (0xc0) -> total =
+// 269 + |rlp(logs)| (bloom encoding length is content-independent, always 259; nonce 7
+// and 5 are both 1 byte).
+BOOST_AUTO_TEST_CASE(DepositWithLogEmbedsEncodedLogsAndNonceTail)
+{
+    constexpr auto kAddr = 0x00000000000000000000000000000000000000aa_address;
+    evmone::state::Log evmoneLog{
+        .addr = kAddr, .data = evmc::bytes{0x68, 0x69}, .topics = {0x01_bytes32}};
+
+    // Project the log onto a FISCO LogEntry (raw bytes, same mapping mapOpLogs uses).
+    evmc::bytes32 topicVal = 0x01_bytes32;
+    std::vector<bcos::protocol::LogEntry> logs;
+    logs.emplace_back(bcos::bytes(kAddr.bytes, kAddr.bytes + sizeof(kAddr.bytes)),
+        bcos::h256s{bcos::h256(topicVal.bytes, sizeof(topicVal.bytes))}, bcos::bytes{0x68, 0x69});
+    auto dep = kOpTestReceiptFactory->createReceipt(
+        bcos::u256(21000), std::string{}, logs, /*status=*/0, bcos::bytesConstRef{}, 1);
+    dep->setCumulativeGasUsed("0x5208");
+    const auto bloomF =
+        evmone::state::compute_bloom_filter(std::span<const evmone::state::Log>{&evmoneLog, 1});
+    bcos::bytes bloom(bloomF.bytes, bloomF.bytes + sizeof(bloomF.bytes));
+    dep->setLogsBloom(bcos::ref(bloom));
+    bcos::protocol::OpStackReceiptMeta meta;
+    meta.deposit_nonce = 7;
+    meta.deposit_receipt_version = 1;
+    dep->setOpStackMeta(std::move(meta));
+
+    const auto enc = encodeReceiptForRoot(*dep, static_cast<uint8_t>(kDepositTxType));
+    BOOST_CHECK_EQUAL(enc[0], 0x7e);
+    // evmone's vector<Log> list encoding (independent path) must appear whole — covers the list
+    // wrapper bytes
+    const auto logsBytes = evmone::rlp::encode(std::vector<evmone::state::Log>{evmoneLog});
+    BOOST_CHECK_NE(enc.find(logsBytes), evmc::bytes::npos);
+    BOOST_REQUIRE_EQUAL(enc.size(), 269u + logsBytes.size());
+    BOOST_CHECK_EQUAL(enc[enc.size() - 2], 0x07);  // nonce
+    BOOST_CHECK_EQUAL(enc[enc.size() - 1], 0x01);  // version
+}
+
+// Normal tx: byte-for-byte equivalent to evmone rlp_encode (incl. the typed prefix) —
+// rebuilt from a FISCO receipt and must match evmone's encoding of the same-shaped
+// evmone receipt.
+BOOST_AUTO_TEST_CASE(NormalReceiptMatchesEvmoneEncoding)
+{
+    // evmone reference: eip1559, success, cumGas 42000, empty logs, zero bloom.
+    evmone::state::TransactionReceipt ref;
+    ref.type = evmone::state::Transaction::Type::eip1559;
+    ref.status = EVMC_SUCCESS;
+    ref.cumulative_gas_used = 42000;
+    const auto expected = evmone::state::rlp_encode(ref);
+
+    auto r = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/1);
+    r->setCumulativeGasUsed("0xa410");  // 42000
+    bcos::bytes bloom(256, 0x00);
+    r->setLogsBloom(bcos::ref(bloom));
+    const auto enc =
+        encodeReceiptForRoot(*r, static_cast<uint8_t>(evmone::state::Transaction::Type::eip1559));
+
+    BOOST_CHECK_EQUAL(enc[0], 0x02);  // eip1559 typed prefix
+    BOOST_CHECK_EQUAL(enc, evmc::bytes(expected.begin(), expected.end()));
+}
+
+// legacy (no typed prefix) + access_list prefixes are also byte-identical to evmone
+BOOST_AUTO_TEST_CASE(NormalReceiptLegacyAndAccessListPrefixes)
+{
+    const auto makeFisco = [](uint64_t cumGas) {
+        auto r = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+            std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{}, 1);
+        std::ostringstream oss;
+        oss << "0x" << std::hex << cumGas;
+        r->setCumulativeGasUsed(oss.str());
+        bcos::bytes bloom(256, 0x00);
+        r->setLogsBloom(bcos::ref(bloom));
+        return r;
+    };
+    const auto compareToEvmone = [](const auto& fisco, evmone::state::Transaction::Type type) {
+        evmone::state::TransactionReceipt ref;
+        ref.type = type;
+        ref.status = EVMC_SUCCESS;
+        ref.cumulative_gas_used = 42000;
+        const auto expected = evmone::state::rlp_encode(ref);
+        const auto enc = encodeReceiptForRoot(*fisco, static_cast<uint8_t>(type));
+        BOOST_CHECK_EQUAL(enc, evmc::bytes(expected.begin(), expected.end()));
+    };
+
+    auto legacy = makeFisco(42000);
+    compareToEvmone(legacy, evmone::state::Transaction::Type::legacy);
+    auto accessList = makeFisco(42000);
+    compareToEvmone(accessList, evmone::state::Transaction::Type::access_list);
+}
+
+// Deposit and normal txs must produce different leaves (prefix and tail fields both differ)
+BOOST_AUTO_TEST_CASE(DepositAndNormalLeavesDiffer)
+{
+    const auto depEnc =
+        encodeReceiptForRoot(*minimalDepositReceipt(), static_cast<uint8_t>(kDepositTxType));
+    auto normal = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{}, 1);
+    normal->setCumulativeGasUsed("0x5208");
+    bcos::bytes bloom(256, 0x00);
+    normal->setLogsBloom(bcos::ref(bloom));
+    const auto normalEnc = encodeReceiptForRoot(
+        *normal, static_cast<uint8_t>(evmone::state::Transaction::Type::eip1559));
+    BOOST_CHECK_NE(depEnc, normalEnc);
+}
+
+// End-to-end receiptsRoot equivalence (leaf-level proof): building
+// the root from FISCO receipts via sealOpBlock must be bit-identical to building it from
+// equivalent evmone receipts via evmone rlp_encode. Of sealOpBlock's three subtrees, only
+// the receiptsRoot leaf encoding is reconstructed here (trie construction unchanged), so
+// this case + NormalReceiptMatchesEvmoneEncoding together pin the receiptsRoot byte
+// equivalence.
+BOOST_AUTO_TEST_CASE(SealReceiptsRootMatchesEvmoneReferenceTrie)
+{
+    // FISCO receipt #0: deposit (status 0, cumGas 21000, nonce 5, version 1).
+    auto dep = minimalDepositReceipt();
+    // FISCO receipt #1: eip1559 (status 0, cumGas 42000).
+    auto normal = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{}, 1);
+    normal->setCumulativeGasUsed("0xa410");  // 42000
+    bcos::bytes bloom(256, 0x00);
+    normal->setLogsBloom(bcos::ref(bloom));
+
+    bcos::evm::opstack::OpBlockResult result;
+    result.receipts.push_back(dep);
+    result.receipts.push_back(normal);
+    result.txTypes.push_back(static_cast<uint8_t>(kDepositTxType));
+    result.txTypes.push_back(static_cast<uint8_t>(evmone::state::Transaction::Type::eip1559));
+
+    const auto seal =
+        bcos::evm::opstack::sealOpBlock(result, bcos::evm::opstack::isthmusConfig(), {});
+
+    // Reference: equivalent evmone receipts, same leaves via evmone rlp_encode, same trie.
+    evmone::state::TransactionReceipt refDep;
+    refDep.type = kDepositTxType;
+    refDep.status = EVMC_SUCCESS;
+    refDep.cumulative_gas_used = 21000;
+    refDep.logs_bloom_filter = evmone::state::BloomFilter{};
+    const auto depLeaf = evmc::bytes{0x7e} + evmone::rlp::encode_tuple(bool{true}, uint64_t{21000},
+                                                 evmone::bytes_view(refDep.logs_bloom_filter),
+                                                 refDep.logs, uint64_t{5}, uint64_t{1});
+
+    evmone::state::TransactionReceipt refNormal;
+    refNormal.type = evmone::state::Transaction::Type::eip1559;
+    refNormal.status = EVMC_SUCCESS;
+    refNormal.cumulative_gas_used = 42000;
+    refNormal.logs_bloom_filter = evmone::state::BloomFilter{};
+    const auto normalLeaf = evmone::state::rlp_encode(refNormal);
+
+    std::vector<std::pair<bcos::bytes, bcos::bytes>> refEntries;
+    for (size_t i = 0; i < 2; ++i)
+    {
+        bcos::bytes key;
+        bcos::codec::rlp::encode(key, static_cast<uint64_t>(i));
+        const auto& leaf = (i == 0) ? depLeaf : normalLeaf;
+        refEntries.emplace_back(std::move(key), bcos::bytes{leaf.begin(), leaf.end()});
+    }
+    const auto refRoot = bcos::ledger::mpt::computeTrieRootVarKey(refEntries);
+
+    bcos::h256 actual(seal.receiptsRoot.bytes, sizeof(seal.receiptsRoot.bytes));
+    bcos::h256 expected;
+    std::memcpy(expected.mutableData().data(), refRoot.root.data(), sizeof(expected));
+    BOOST_CHECK_EQUAL(actual, expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
+++ b/opstack-executor/tests/OpSchedulerSeamSmokeTest.cpp
@@ -1,0 +1,117 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpSchedulerSeamSmokeTest — minimal compile-and-run verification that the ported
+// `bcos::evm::engine::OpSchedulerSeam` header instantiates against the current branch's types and
+// that its engine-facing seam surface works. Exercises only:
+//   1. construction over a real MultiLayerStorage ViewType;
+//   2. the static seam surface the engine reaches as dependent names
+//      (computeTxRoot / commitmentsOf / isJovianActive);
+//   3. executeOpBlock's empty-block rejection (processOpBlock throws -> classified escape).
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/MultiLayerStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-task/Wait.h>
+#include <opstack-executor/OpSchedulerSeam.h>
+#include <boost/test/unit_test.hpp>
+#include <stdexcept>
+#include <vector>
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+namespace
+{
+// Minimal CheckpointStorage stub — per-file local copy (the source-branch fixture's rationale:
+// do not cross-include another module's test-private header).
+template <class Key, class Value, bcos::storage2::ReadWriteStorage<Key, Value> Storage>
+struct TrivialCheckpointStorage
+{
+    using CheckpointName = bcos::h256;
+
+    Storage& m_storage;
+    explicit TrivialCheckpointStorage(Storage& storage) noexcept : m_storage(storage) {}
+    Storage& open() & { return m_storage; }
+    [[noreturn]] Storage& open(CheckpointName const& /*unused*/) &
+    {
+        std::abort();  // this fixture never needs historical checkpoints.
+    }
+    void createCheckpoint(Storage& /*unused*/, CheckpointName const& /*unused*/) {}
+    void deleteCheckpoint(CheckpointName const& /*unused*/) {}
+    [[nodiscard]] std::optional<CheckpointName> latestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+    [[nodiscard]] std::optional<CheckpointName> oldestCheckpointName() const
+    {
+        return std::nullopt;
+    }
+};
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+using BackendMemStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::CONCURRENT),
+    std::hash<StateKey>>;
+using CheckpointBackend = TrivialCheckpointStorage<StateKey, StateValue, BackendMemStorage>;
+using MLS = bcos::storage2::MultiLayerStorage<MutableStorage, void, CheckpointBackend>;
+using ViewType = typename MLS::ViewType;
+
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpSchedulerSeamSmokeSuite)
+
+BOOST_AUTO_TEST_CASE(ConstructAndSeamSurface)
+{
+    BackendMemStorage backendStorage;
+    CheckpointBackend checkpointBackend(backendStorage);
+    MLS multiLayerStorage(checkpointBackend);
+    auto view = multiLayerStorage.fork();
+    view.newMutable();
+
+    // The ctor takes only fork flags (feature-driven fork selection; this is a pure seam shim —
+    // no receipt factory / chain id / VM).
+    bcos::evm::engine::OpSchedulerSeam<ViewType> scheduler(
+        bcos::evm::opstack::OpForkFlags{.jovianActive = false});
+
+    // Fork predicate: feature-driven (feature_op_jovian), constant across blocks — no timestamps.
+    BOOST_CHECK(!scheduler.isJovianActive());
+    bcos::evm::engine::OpSchedulerSeam<ViewType> jovianScheduler(
+        bcos::evm::opstack::OpForkFlags{.jovianActive = true});
+    BOOST_CHECK(jovianScheduler.isJovianActive());
+
+    // computeTxRoot over the empty range: the standard empty-trie root (0x56e81f...), which
+    // proves the trie built and hashed end-to-end.
+    std::vector<bcos::bytes> emptyTxs;
+    const auto txRoot = scheduler.computeTxRoot(emptyTxs);
+    const bcos::h256 kEmptyTrieRoot{
+        std::string{"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"}};
+    BOOST_CHECK_EQUAL(txRoot, kEmptyTrieRoot);
+
+    // commitmentsOf projects the seal + result members into the engine-facing surface.
+    bcos::evm::opstack::OpBlockSeal seal;
+    seal.receiptsRoot = evmone::hash256{};
+    seal.logsBloom = evmone::state::BloomFilter{};
+    seal.withdrawalsRoot = evmone::hash256{};
+    bcos::evm::engine::OpExecuteBlockResult result{
+        .receipts = {},
+        .seal = seal,
+        .stateRoot = bcos::h256{},
+        .gasUsed = 0,
+        .txRoot = txRoot,
+    };
+    const auto commitments = scheduler.commitmentsOf(result);
+    BOOST_CHECK_EQUAL(commitments.stateRoot, bcos::h256{});
+    BOOST_CHECK_EQUAL(commitments.gasUsed, bcos::u256(0));
+    BOOST_CHECK_EQUAL(commitments.txRoot, txRoot);
+}
+
+// Note: the empty-block rejection test lives in OpBlockInjectorTest
+// (EmptyBlockRejectedByBlockPreSteps), now driving preBlockOpSteps (the retired
+// runOpBlockInjection's guard). OpSchedulerSeam is a pure engine seam and no longer executes
+// blocks, so there is no matching execution case here. The EIP-7702 authorization yParity width
+// test was removed with the RLP decode primitives (decodeAuthYParityScalar retired in OpCommon.h).
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpT8nReplayTest.cpp
+++ b/opstack-executor/tests/OpT8nReplayTest.cpp
@@ -1,0 +1,1599 @@
+// OpT8nReplayTest.cpp — OP block-level differential replay gate.
+//
+// Replays test/opstack/t8n/vectors/*.json (schema v3-block, op-geth
+// GenerateChain+InsertChain golden, generator in t8n/generator/) block-by-block
+// through processOpBlock -> sealOpBlock, comparing header fields, per-receipt
+// fields, and postState (bidirectional + applyDiff write-set coverage) against
+// _op_expected.
+//
+// Hard assertion discipline: A) dir *.json set == manifest.txt set; parse
+// failure / missing required field = named ADD_FAILURE; per-vector comparison
+// count recorded, 0 = FAILURE. B) required fields via jAt(); hardfork must be
+// exactly ecotone|fjord|granite|holocene|isthmus|jovian (no default fork);
+// unknown _op_type / receipt count mismatch = FAILURE (no zip-min).
+// D) comparisons routed through checkField/checkOptional into DivergenceLedger;
+// checkOptional never gated on has_value() (one-sided absence = DIVERGE
+// <absent>); bloom always 512 hex; postState bidirectional with zero-slot trie
+// reduction (0 == absent) + write-set coverage. E) exemptions only from
+// DIVERGENCES.md ALLOWLIST tuples (a:PENDING-FIX / c:SIGNED-OFF); dangling
+// entry= or never-hit exemptions = FAILURE.
+
+#include "StateDiffWriteback.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-evm/adapter/StateRootCompute.h>
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <cxxabi.h>
+#include <evmone/evmone.h>
+#include <fmt/format.h>
+#include <json/json.h>
+#include <opstack-executor/OpBlockExecute.h>
+#include <opstack-executor/OpBlockExecute.h>  // seal (merged into the block-execution module)
+#include <opstack-executor/OpSchedulerSeam.h>
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+#include <bcos-evm/eth/state/hash_utils.hpp>
+#include <evmone_precompiles/secp256k1.hpp>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <test/utils/rlp.hpp>
+#include <test/utils/test_state.hpp>
+#include <vector>
+
+namespace fs = std::filesystem;
+// Non-conflicting alias for jsoncpp's value type (a bare `using Json = Json::Value`
+// would shadow the `Json` namespace and break Json::Reader/Json::Value).
+using JsonValue = Json::Value;
+
+// ── jsoncpp .at() equivalent ────────────────────────────────────────────────
+// nlohmann's .at(key) throws on a missing member; jsoncpp's operator[] silently
+// fabricates a null. Every required-field access in this replayer goes through
+// jAt so a missing field is a named failure, never a silent null read.
+//
+// key is `const char*` (not `const std::string&`) deliberately: a string literal
+// argument would materialize a temporary std::string, and GCC-14's -Wdangling-reference
+// flags any reference-returning call that receives a class-type temporary — even though
+// the returned reference aliases `v`, never `key` (false positive). A `const char*`
+// argument creates no temporary, so the warning cannot fire. Callers with a std::string
+// key pass .c_str() (jAt(post, authAddr)).
+inline const Json::Value& jAt(const Json::Value& v, const char* key)
+{
+    if (!v.isMember(key))
+        throw std::invalid_argument(std::string("missing required field: ") + key);
+    return v[key];
+}
+
+// jsoncpp Reader-based parse (nlohmann Json::parse equivalent; string and stream).
+inline Json::Value jParse(const std::string& input)
+{
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(input, root))
+        throw std::runtime_error("JSON parse failed: " + reader.getFormattedErrorMessages());
+    return root;
+}
+
+inline Json::Value jParse(std::istream& input)
+{
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(input, root))
+        throw std::runtime_error("JSON parse failed: " + reader.getFormattedErrorMessages());
+    return root;
+}
+using namespace bcos::evm::opstack;
+using namespace evmone;
+
+// ── Local subset re-implementation of evmone test::from_json ─────────────────
+// The vcpkg evmone package does not ship test/utils/statetest.hpp (which declares
+// evmone's test::from_json<T>); the t8n gate needs a few of its conversions.
+// Declare the primary template and define only the used specializations, with
+// semantics identical to evmone statetest_loader.cpp (ints accept number or "0x"
+// hex strings; bytes/address/hash256 via evmc::from_hex; TestState parses
+// account objects and drops zero-valued storage slots).
+namespace evmone::test
+{
+template <typename T>
+T from_json(const Json::Value& j) = delete;
+
+template <>
+int64_t from_json<int64_t>(const Json::Value& j)
+{
+    if (j.isIntegral())
+    {
+        if (j.isInt64())
+            return j.asInt64();
+        throw std::invalid_argument("from_json<int64_t>: integer out of range");
+    }
+    if (!j.isString())
+        throw std::invalid_argument("from_json<int64_t>: must be integer or string of integer");
+    const auto s = j.asString();
+    size_t num_processed = 0;
+    const auto v = static_cast<int64_t>(std::stoull(s, &num_processed, 0));
+    if (num_processed == 0 || num_processed != s.size())
+        throw std::invalid_argument("from_json<int64_t>: must be integer or string of integer");
+    return v;
+}
+
+template <>
+uint64_t from_json<uint64_t>(const Json::Value& j)
+{
+    if (j.isIntegral())
+    {
+        if (j.isUInt64())
+            return j.asUInt64();
+        throw std::invalid_argument("from_json<uint64_t>: integer out of range");
+    }
+    if (!j.isString())
+        throw std::invalid_argument("from_json<uint64_t>: must be integer or string of integer");
+    const auto s = j.asString();
+    size_t num_processed = 0;
+    const auto v = static_cast<uint64_t>(std::stoull(s, &num_processed, 0));
+    if (num_processed == 0 || num_processed != s.size())
+        throw std::invalid_argument("from_json<uint64_t>: must be integer or string of integer");
+    return v;
+}
+
+template <>
+intx::uint256 from_json<intx::uint256>(const Json::Value& j)
+{
+    return intx::from_string<intx::uint256>(j.asString());
+}
+
+template <>
+evmone::bytes from_json<evmone::bytes>(const Json::Value& j)
+{
+    return evmc::from_hex(j.asString()).value();
+}
+
+template <>
+evmc::address from_json<evmc::address>(const Json::Value& j)
+{
+    const auto v = evmc::from_hex<evmc::address>(j.asString());
+    if (!v.has_value())
+        throw std::invalid_argument("from_json<address>: must be hexadecimal string");
+    return *v;
+}
+
+// Note: evmone::hash256 is a using-alias of evmc::bytes32, so this one specialization serves both
+// from_json<hash256> (header hashes) and from_json<bytes32> (storage keys/values).
+template <>
+evmc::bytes32 from_json<evmc::bytes32>(const Json::Value& j)
+{
+    const auto s = j.asString();
+    if (s == "0" || s == "0x0")  // Special case to handle "0". Required by exec-spec-tests.
+        return evmc::bytes32{};
+    const auto v = evmc::from_hex<evmc::bytes32>(s);
+    if (!v.has_value())
+        throw std::invalid_argument("from_json<bytes32>: must be hexadecimal string");
+    return *v;
+}
+
+template <>
+evmone::test::TestState from_json<evmone::test::TestState>(const Json::Value& j)
+{
+    evmone::test::TestState o;
+    assert(j.isObject());
+    for (const auto& j_addr : j.getMemberNames())
+    {
+        const auto& j_acc = j[j_addr];
+        auto& acc = o[from_json<evmc::address>(Json::Value(j_addr))] = {
+            .nonce = from_json<uint64_t>(jAt(j_acc, "nonce")),
+            .balance = from_json<intx::uint256>(jAt(j_acc, "balance")),
+            .storage = {},
+            .code = from_json<evmone::bytes>(jAt(j_acc, "code"))};
+        if (j_acc.isMember("storage"))
+        {
+            const auto& storage = j_acc["storage"];
+            for (const auto& j_key : storage.getMemberNames())
+            {
+                const auto& j_value = storage[j_key];
+                if (const auto value = from_json<evmc::bytes32>(j_value); !evmc::is_zero(value))
+                    acc.storage[from_json<evmc::bytes32>(Json::Value(j_key))] = value;
+            }
+        }
+    }
+    return o;
+}
+}  // namespace evmone::test
+
+namespace
+{
+// ── Canonical printing (the only want/got form written by DIVERGE/ALLOWLIST) ─
+// Numeric: "0x"-prefixed lowercase minimal hex (same shape as generator
+// hexutil.EncodeUint64/EncodeBig). Hash/address: "0x" fixed-length lowercase.
+// The absent side is always "<absent>".
+
+constexpr const char* kAbsent = "<absent>";
+
+std::string hexU64(uint64_t v)
+{
+    std::ostringstream out;
+    out << "0x" << std::hex << v;
+    return out.str();
+}
+
+std::string hexU256(const intx::uint256& v)
+{
+    return "0x" + intx::to_string(v, 16);
+}
+
+std::string hexHash(const hash256& h)
+{
+    return "0x" + evmc::hex(evmc::bytes_view{h.bytes, sizeof(h.bytes)});
+}
+
+std::string hexAddr(const evmc::address& a)
+{
+    return "0x" + evmc::hex(evmc::bytes_view{a.bytes, sizeof(a.bytes)});
+}
+
+std::string hexBytes(evmc::bytes_view b)
+{
+    return "0x" + evmc::hex(b);
+}
+
+// bytes32 slot keys/values are written as minimal-numeric hex (trie semantics: 0 == absent,
+// compared after normalization).
+std::string hexSlot(const evmc::bytes32& b)
+{
+    return hexU256(intx::be::load<intx::uint256>(b));
+}
+
+intx::uint256 parseU256(const JsonValue& j)
+{
+    return intx::from_string<intx::uint256>(j.asString());
+}
+
+// ── DivergenceLedger (brief block E) ────────────────────────────────────────
+
+struct AllowEntry
+{
+    std::string vectorId, field, entryId, attribution, status, want, got;
+    bool exempt = false;
+    int hits = 0;
+};
+
+class DivergenceLedger
+{
+public:
+    // Missing ledger file = FAILURE (the ledger is a gate deliverable; a missing file must never
+    // imply all-exempt/all-empty).
+    static DivergenceLedger load(const fs::path& path)
+    {
+        DivergenceLedger ledger;
+        std::ifstream input(path);
+        if (!input.is_open())
+        {
+            BOOST_ERROR("DIVERGENCES.md missing: " << path);
+            return ledger;
+        }
+        // Mirrors the DIVERGENCES.md "machine format" section verbatim.
+        static const std::regex linePattern(
+            R"(<!--\s*ALLOWLIST\s+vectorId=(\S+)\s+field=(\S+)\s+entry=(\S+)\s+attribution=(\S+)\s+status=(\S+)\s+want=(\S+)\s+got=(\S+)\s*-->)");
+        static const std::regex headingPattern(R"(^##\s+(\S+))");
+        std::string line;
+        std::set<std::string> headings;
+        while (std::getline(input, line))
+        {
+            std::smatch m;
+            if (std::regex_search(line, m, headingPattern))
+                headings.insert(m[1].str());
+            if (std::regex_search(line, m, linePattern))
+            {
+                AllowEntry e{m[1].str(), m[2].str(), m[3].str(), m[4].str(), m[5].str(), m[6].str(),
+                    m[7].str()};
+                e.exempt = (e.attribution == "a" && e.status == "PENDING-FIX") ||
+                           (e.attribution == "c" && e.status == "SIGNED-OFF");
+                // FINDING-dual-* entries belong to OpDualPathEquivalenceTest's own ledger
+                // instance (A-vs-B harness); this suite's finish() stale-check must not see them.
+                if (e.entryId.rfind("FINDING-dual-", 0) != 0)
+                    ledger.m_entries.push_back(std::move(e));
+            }
+        }
+        // Dangling entry= (no matching "## <ENTRY-ID>" heading) = FAILURE: an
+        // ALLOWLIST row must hang under a real FINDING/entry section; a lone row has no evidence.
+        for (const auto& e : ledger.m_entries)
+        {
+            if (!headings.contains(e.entryId))
+                BOOST_ERROR("DIVERGENCES.md ALLOWLIST entry="
+                            << e.entryId << " (vectorId=" << e.vectorId << " field=" << e.field
+                            << ") has no matching '## " << e.entryId << "' heading");
+        }
+        return ledger;
+    }
+
+    // Single divergence-reporting entry point: full 4-tuple match with exempt
+    // status -> KNOWN-DIVERGE (stdout + count); otherwise ADD_FAILURE. The
+    // 4-tuple match prevents new regressions on the same field riding old exemptions.
+    void diverge(const std::string& vectorId, const std::string& field, const std::string& want,
+        const std::string& got)
+    {
+        for (auto& e : m_entries)
+        {
+            if (e.exempt && e.vectorId == vectorId && e.field == field && e.want == want &&
+                e.got == got)
+            {
+                ++e.hits;
+                ++m_knownCount;
+                std::cout << "KNOWN-DIVERGE " << vectorId << " " << e.entryId << " field=" << field
+                          << " want=" << want << " got=" << got << "\n";
+                return;
+            }
+        }
+        BOOST_ERROR("DIVERGE " << vectorId << " " << field << " want=" << want << " got=" << got);
+    }
+
+    // An exemption never hit this run = FAILURE (stale exemption turns red; must be cleared after
+    // fix/vector regen).
+    void finish() const
+    {
+        for (const auto& e : m_entries)
+        {
+            if (e.exempt && e.hits == 0)
+                BOOST_ERROR("stale ALLOWLIST exemption never hit this run: entry="
+                            << e.entryId << " vectorId=" << e.vectorId << " field=" << e.field
+                            << " want=" << e.want << " got=" << e.got);
+        }
+    }
+
+private:
+    std::vector<AllowEntry> m_entries;
+    int m_knownCount = 0;
+};
+
+// ── Per-vector comparison context (comparison count + field prefix) ─────────
+
+struct VectorContext
+{
+    DivergenceLedger& ledger;
+    std::string id;
+    int comparisons = 0;
+
+    void checkField(const std::string& field, const std::string& want, const std::string& got)
+    {
+        ++comparisons;
+        if (want != got)
+            ledger.diverge(id, field, want, got);
+    }
+
+    // checkOptional semantics (brief block D): want present + got absent ->
+    // got=<absent>; want absent + got present -> want=<absent>; both absent pass.
+    // Never gate on has_value() before comparing.
+    void checkOptional(const std::string& field, const std::optional<std::string>& want,
+        const std::optional<std::string>& got)
+    {
+        ++comparisons;
+        if (!want.has_value() && !got.has_value())
+            return;
+        const auto w = want.value_or(kAbsent);
+        const auto g = got.value_or(kAbsent);
+        if (w != g)
+            ledger.diverge(id, field, w, g);
+    }
+};
+
+// ── BlockHashes: return env.parentHash only for number-1 ────────────────────
+// (EIP-2935 system call in block 1 stores the genesis hash = env.parentHash;
+// other heights are never queried by this corpus, so returning zero exposes any
+// out-of-range query instead of silently fabricating a hash chain.)
+
+struct ParentOnlyBlockHashes final : state::BlockHashes
+{
+    int64_t blockNumber = 0;
+    hash256 parentHash{};
+
+    evmc::bytes32 get_block_hash(int64_t block_number) const noexcept override
+    {
+        return block_number == blockNumber - 1 ? parentHash : evmc::bytes32{};
+    }
+};
+
+// ── EIP-7702 authority recovery ─────────────────────────────────────────────
+// The in-module recoverAuthority (OpTransition.cpp:34-45) lives in an anonymous
+// namespace and is not exported; minimally re-implement it here (same formula
+// keccak256(0x05 || rlp([chain_id,address,nonce])) + evmmax secp256k1 ecrecover).
+// After building, assert signer.has_value() — evmone/module transition silently
+// skips tuples whose signer was not recovered, so corpus signatures must be recoverable.
+
+// ── structurallyUnrecoverable: secp256k1 structural-validity predicate ──────
+// (EIP-2/EIP-7702 malleability boundary; no ecrecover, only whether r/s/v fall
+// outside the recoverable domain.)
+
+inline const intx::uint256 kSecpN = intx::from_string<intx::uint256>(
+    "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+inline const intx::uint256 kSecpHalfN = kSecpN >> 1;
+
+inline bool structurallyUnrecoverable(const evmone::state::Authorization& a)
+{
+    return a.v > 1 || a.s > kSecpHalfN || a.r == 0 || a.r >= kSecpN || a.s == 0 || a.s >= kSecpN;
+}
+
+std::optional<evmc::address> replayRecoverAuthority(const state::Authorization& auth)
+{
+    const auto msg = bytes{0x05} + rlp::encode_tuple(auth.chain_id, auth.addr, auth.nonce);
+    const auto h = keccak256(msg);
+    const auto r = intx::be::store<evmc::bytes32>(auth.r);
+    const auto s = intx::be::store<evmc::bytes32>(auth.s);
+    return evmmax::secp256k1::ecrecover(std::span<const uint8_t, 32>{h.bytes, 32},
+        std::span<const uint8_t, 32>{r.bytes, 32}, std::span<const uint8_t, 32>{s.bytes, 32},
+        auth.v != 0);
+}
+
+// ── manifest.txt: one required vector filename per line ('#' comments and blank lines ignored) ─
+
+std::set<std::string> loadManifest(const fs::path& path)
+{
+    std::set<std::string> names;
+    std::ifstream input(path);
+    if (!input.is_open())
+    {
+        BOOST_ERROR("manifest.txt missing: " << path);
+        return names;
+    }
+    std::string line;
+    while (std::getline(input, line))
+    {
+        const auto b = line.find_first_not_of(" \t\r");
+        if (b == std::string::npos)
+            continue;
+        const auto e = line.find_last_not_of(" \t\r");
+        line = line.substr(b, e - b + 1);
+        if (line.empty() || line[0] == '#')
+            continue;
+        names.insert(line);
+    }
+    return names;
+}
+
+// ── Corpus chain id ──────────────────────────────────────────────────────────
+// The generator buildChainConfig (generator/main.go) pins all cases to 8453
+// (0x2105). Vectors with normal txs use tx.chainId (asserted consistent across
+// the block); deposit-only vectors carry no chainId, so this corpus constant is
+// used — a mirror of the generator's constant, not a fallback default.
+
+constexpr uint64_t kCorpusChainId = 0x2105;
+
+// ── Current API adaptation helpers ───────────────────────────────────────────
+// After plan A phase 2 (cf8d1af70): processOpBlock takes 9 params
+// (receiptFactory), receipts are bcos::protocol::TransactionReceipt::Ptr, OP
+// fields come via opStackMeta() (bcos::u256 / uint64).
+// bcos::u256 -> "0x" + lowercase no-leading-zero hex (same shape as setOpStackMeta's u256ToHex).
+std::string hexU256Bcos(const bcos::u256& v)
+{
+    return "0x" + v.str(0, std::ios_base::hex);
+}
+
+/// Same receiptFactory construction as the W6 harness (OpNewPayloadRpcE2eTest.cpp:93-95).
+bcos::protocol::TransactionReceiptFactory::Ptr makeTestReceiptFactory()
+{
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(
+        std::make_shared<bcos::crypto::CryptoSuite>(
+            std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr));
+}
+
+// ── TestState -> stateRootOf Ledger bridge ───────────────────────────────────
+// bcos::evm::stateRootOf<Ledger> (adapter/StateRootCompute.h) is a template
+// building a secure trie over any Ledger exposing `bool visitAccounts(Visitor) const`.
+// evmone::test::TestState is a std::map, not a Ledger, so expose the account
+// visit surface here. AccountView mirrors MemoryState::AccountView's root-building
+// fields (addr/nonce/balance/codeHash/storage); stateRootOf uses only these five.
+struct TestStateLedger
+{
+    const evmone::test::TestState& state;
+
+    template <class Visitor>
+    bool visitAccounts(Visitor&& visitor) const noexcept
+    {
+        for (const auto& [addr, account] : state)
+        {
+            struct View
+            {
+                const evmc::address& addr;
+                uint64_t nonce;
+                const intx::uint256& balance;
+                evmc::bytes32 codeHash;
+                const std::map<evmc::bytes32, evmc::bytes32>& storage;
+                [[nodiscard]] const evmc::bytes& code() const noexcept { return m_code; }
+                const evmc::bytes& m_code;
+            };
+            const View view{.addr = addr,
+                .nonce = account.nonce,
+                .balance = account.balance,
+                .codeHash = evmone::keccak256(account.code),
+                .storage = account.storage,
+                .m_code = account.code};
+            if (!visitor(view))
+                return false;
+        }
+        return true;
+    }
+};
+
+// ── Single-block load context (shared by replaySingleBlockInto / assertRejectThrow) ──
+// Pure move of the load section from the original replayVector path (previously
+// :456-643), no assertion-logic change. On failure (invalid hardfork /
+// inconsistent intra-block chainId / unknown _op_type) it BOOST_ERRORs and
+// returns false; the caller returns directly.
+
+struct BlockContext
+{
+    const OpForkConfig* cfg = nullptr;
+    bool isJovian = false;
+    state::BlockInfo blk;
+    ParentOnlyBlockHashes hashes;
+    std::vector<OpBlockTx> txs;
+    uint64_t chainId = kCorpusChainId;
+    // decode-class reject (blob): processOpBlock never reaches raw-tx decode
+    // (txs are already OpBlockTx), so the load section reproduces the real
+    // rejection via the type-byte classification (execute hook / runOpBlockInjection)
+    // and records the message here for assertRejectThrow to assert directly.
+    std::optional<std::string> decodeRejectMessage;
+};
+
+bool loadBlockContext(const std::string& id, const JsonValue& blk, BlockContext& out)
+{
+    // _info.hardfork must be exactly ecotone|fjord|granite|holocene|isthmus|jovian,
+    // anything else = FAILURE. No default fork (the default-Isthmus precedent is a
+    // known hole, not ported). isJovian drives the blobGasUsed header gate and the
+    // _op_da_footprint expectation — ecotone/fjord/granite/holocene are all false,
+    // matching isthmus semantics (has_da_footprint true only on Jovian).
+    const auto hardfork = jAt(jAt(blk, "_info"), "hardfork").asString();
+    if (hardfork == "isthmus")
+        out.cfg = &isthmusConfig();
+    else if (hardfork == "jovian")
+    {
+        out.cfg = &jovianConfig();
+        out.isJovian = true;
+    }
+    else if (hardfork == "ecotone")
+        out.cfg = &ecotoneConfig();
+    else if (hardfork == "fjord")
+        out.cfg = &fjordConfig();
+    else if (hardfork == "granite")
+        out.cfg = &graniteConfig();
+    else if (hardfork == "holocene")
+        out.cfg = &holoceneConfig();
+    else
+    {
+        BOOST_ERROR(id << ": _info.hardfork must be exactly "
+                          "ecotone|fjord|granite|holocene|isthmus|jovian, got '"
+                       << hardfork << "' (no default fork)");
+        return false;
+    }
+
+    // env (all 8 fields required) -> hand-built BlockInfo.
+    const auto& env = jAt(blk, "env");
+    auto& bi = out.blk;
+    bi.number = test::from_json<int64_t>(jAt(env, "currentNumber"));
+    bi.timestamp = test::from_json<int64_t>(jAt(env, "currentTimestamp"));
+    bi.gas_limit = test::from_json<int64_t>(jAt(env, "currentGasLimit"));
+    bi.base_fee = test::from_json<uint64_t>(jAt(env, "currentBaseFee"));
+    bi.coinbase = test::from_json<evmc::address>(jAt(env, "currentCoinbase"));
+    bi.prev_randao = test::from_json<hash256>(jAt(env, "currentRandom"));
+    bi.parent_beacon_block_root = test::from_json<hash256>(jAt(env, "parentBeaconBlockRoot"));
+
+    auto& hs = out.hashes;
+    hs.blockNumber = bi.number;
+    hs.parentHash = test::from_json<hash256>(jAt(env, "parentHash"));
+
+    // Three transaction arms (deposit / eip1559 / setcode). Unknown _op_type = FAILURE.
+    auto& txs = out.txs;
+    std::optional<uint64_t> vectorChainId;
+    for (const auto& t : jAt(jAt(blk, "block"), "transactions"))
+    {
+        const auto opType = jAt(t, "_op_type").asString();
+        if (opType == "deposit")
+        {
+            const auto& d = jAt(t, "_op_deposit");
+            DepositTx dep;
+            dep.source_hash = test::from_json<hash256>(jAt(d, "source_hash"));
+            dep.from = test::from_json<evmc::address>(jAt(d, "from"));
+            dep.to = jAt(d, "to").isNull() ?
+                         std::nullopt :
+                         std::optional{test::from_json<evmc::address>(jAt(d, "to"))};
+            dep.mint = d.isMember("mint") ? std::optional{parseU256(jAt(d, "mint"))} : std::nullopt;
+            dep.value = d.isMember("value") ? parseU256(jAt(d, "value")) : intx::uint256{0};
+            dep.gas_limit = test::from_json<int64_t>(jAt(d, "gas"));
+            dep.is_system_tx = jAt(d, "is_system_tx").asBool();
+            dep.data = test::from_json<bytes>(jAt(t, "data"));
+            txs.push_back({.tx = std::move(dep), .signedEnvelope = {}});
+        }
+        else if (opType == "eip1559" || opType == "setcode")
+        {
+            state::Transaction tx;
+            tx.type = opType == "setcode" ? state::Transaction::Type::set_code :
+                                            state::Transaction::Type::eip1559;
+            tx.sender = test::from_json<evmc::address>(jAt(t, "sender"));
+            tx.to = jAt(t, "to").isNull() ?
+                        std::nullopt :
+                        std::optional{test::from_json<evmc::address>(jAt(t, "to"))};
+            tx.nonce = test::from_json<uint64_t>(jAt(t, "nonce"));
+            tx.gas_limit = test::from_json<int64_t>(jAt(t, "gas"));
+            tx.max_gas_price = parseU256(jAt(t, "maxFeePerGas"));
+            tx.max_priority_gas_price = parseU256(jAt(t, "maxPriorityFeePerGas"));
+            tx.value = parseU256(jAt(t, "value"));
+            tx.data = test::from_json<bytes>(jAt(t, "data"));
+            // EIP-2930 access list (optional; no hits in the legacy 25 vectors, dormant path).
+            if (t.isMember("accessList"))
+            {
+                for (const auto& e : jAt(t, "accessList"))
+                {
+                    std::vector<evmc::bytes32> keys;
+                    for (const auto& k : jAt(e, "storageKeys"))
+                        keys.push_back(test::from_json<hash256>(k));
+                    tx.access_list.emplace_back(
+                        test::from_json<evmc::address>(jAt(e, "address")), std::move(keys));
+                }
+            }
+            tx.chain_id = test::from_json<uint64_t>(jAt(t, "chainId"));
+            if (vectorChainId.has_value() && *vectorChainId != tx.chain_id)
+            {
+                BOOST_ERROR(id << ": inconsistent chainId across txs: " << hexU64(*vectorChainId)
+                               << " vs " << hexU64(tx.chain_id));
+                return false;
+            }
+            vectorChainId = tx.chain_id;
+            if (opType == "setcode")
+            {
+                // hasMarked/hasUnmarked/anchorOk: mix-check marked tuples
+                // (structurally unrecoverable, _op_signer_unrecoverable=true) and
+                // unmarked tuples (existing recovery path); when marked tuples exist
+                // there must be >=1 unmarked tuple anchoring the delegation in postState.
+                bool hasMarked = false;
+                bool hasUnmarked = false;
+                bool anchorOk = false;
+                for (const auto& a : jAt(t, "_op_authorization_list"))
+                {
+                    state::Authorization auth;
+                    auth.chain_id = parseU256(jAt(a, "chainId"));
+                    auth.addr = test::from_json<evmc::address>(jAt(a, "address"));
+                    auth.nonce = test::from_json<uint64_t>(jAt(a, "nonce"));
+                    auth.r = parseU256(jAt(a, "r"));
+                    auth.s = parseU256(jAt(a, "s"));
+                    auth.v = parseU256(jAt(a, "yParity"));
+
+                    const bool marked = a.isMember("_op_signer_unrecoverable");
+                    if (marked && (!jAt(a, "_op_signer_unrecoverable").isBool() ||
+                                      !jAt(a, "_op_signer_unrecoverable").asBool()))
+                    {
+                        BOOST_ERROR(id << ": _op_signer_unrecoverable must be literal true");
+                        continue;
+                    }
+                    if (marked)
+                    {
+                        // Reverse-verify with the structural predicate (no bare
+                        // ecrecover); signer left empty and tuple passed through as-is —
+                        // production OpTransition.cpp:46-135 does real ecrecover and
+                        // skips per its predicate (the real differential path).
+                        if (!structurallyUnrecoverable(auth))
+                            BOOST_ERROR(
+                                id << ": marked unrecoverable but structurally recoverable");
+                        hasMarked = true;
+                    }
+                    else
+                    {
+                        // Fill recovered signer + assert per tuple (evmone silently skips tuples
+                        // without a signer).
+                        auth.signer = replayRecoverAuthority(auth);
+                        if (!auth.signer.has_value())
+                            BOOST_ERROR(id << ": authorization signer recovery failed (unmarked "
+                                              "tuple)");
+                        else
+                        {
+                            hasUnmarked = true;
+                            // Non-empty delegation anchor existence: the authority must
+                            // carry 0xef0100||tuple.addr delegation code in the vector
+                            // postState (required only when this tx has marked tuples).
+                            const auto authAddr = hexAddr(*auth.signer);
+                            const auto& post = jAt(blk, "postState");
+                            if (post.isMember(authAddr))
+                            {
+                                const std::string wantCode =
+                                    "0xef0100" + hexAddr(auth.addr).substr(2);
+                                if (jAt(post, authAddr.c_str())
+                                        .get("code", Json::Value(""))
+                                        .asString() == wantCode)
+                                    anchorOk = true;
+                            }
+                        }
+                    }
+                    tx.authorization_list.push_back(std::move(auth));
+                }
+                if (hasMarked && !hasUnmarked)
+                    BOOST_ERROR(id << ": setcode tx with marked tuples must contain >=1 unmarked "
+                                      "tuple");
+                if (hasMarked && hasUnmarked && !anchorOk)
+                    BOOST_ERROR(id << ": marked-tuple tx has no applied delegation anchor in "
+                                      "postState");
+            }
+            auto envelope = test::from_json<bytes>(jAt(t, "_op_raw"));
+            txs.push_back({.tx = std::move(tx), .signedEnvelope = std::move(envelope)});
+        }
+        else if (opType == "legacy")
+        {
+            // Task 3 F1 legacy arm: type-0 EIP-155 protected tx. Single gasPrice (no
+            // maxFeePerGas/maxPriorityFeePerGas); evmone legacy has priority==max==gasPrice.
+            state::Transaction tx;
+            tx.type = state::Transaction::Type::legacy;
+            tx.sender = test::from_json<evmc::address>(jAt(t, "sender"));
+            tx.to = jAt(t, "to").isNull() ?
+                        std::nullopt :
+                        std::optional{test::from_json<evmc::address>(jAt(t, "to"))};
+            tx.nonce = test::from_json<uint64_t>(jAt(t, "nonce"));
+            tx.gas_limit = test::from_json<int64_t>(jAt(t, "gas"));
+            const auto gasPrice = parseU256(jAt(t, "gasPrice"));
+            tx.max_gas_price = gasPrice;
+            tx.max_priority_gas_price = gasPrice;
+            tx.value = parseU256(jAt(t, "value"));
+            tx.data = test::from_json<bytes>(jAt(t, "data"));
+            tx.chain_id = test::from_json<uint64_t>(jAt(t, "chainId"));
+            if (vectorChainId.has_value() && *vectorChainId != tx.chain_id)
+            {
+                BOOST_ERROR(id << ": inconsistent chainId across txs: " << hexU64(*vectorChainId)
+                               << " vs " << hexU64(tx.chain_id));
+                return false;
+            }
+            vectorChainId = tx.chain_id;
+            auto envelope = test::from_json<bytes>(jAt(t, "_op_raw"));
+            txs.push_back({.tx = std::move(tx), .signedEnvelope = std::move(envelope)});
+        }
+        else if (opType == "blob")
+        {
+            // Task 4 blob arm: type-0x3 blob txs are decode-class rejected on OP chains.
+            // processOpBlock never reaches raw-tx decode (txs are already OpBlockTx), so
+            // reproduce the real rejection via the type-byte classification the execute hook /
+            // runOpBlockInjection apply (rawTxBytes[i][0] == 0x03 → OpConsensusError), record the
+            // message, and let assertRejectThrow assert it directly (consumer-first; review R16
+            // consumer:both).
+            const auto raw = test::from_json<bytes>(jAt(t, "_op_raw"));
+            const bcos::bytes rawVec(raw.begin(), raw.end());
+            try
+            {
+                // Same type-byte classification as OpScheduler::execute / runOpBlockInjection:
+                // blob (0x03) is not in {0x01, 0x02, 0x04} and not a legacy RLP list (>= 0xc0).
+                if (rawVec.empty())
+                    throw bcos::evm::engine::OpConsensusError("op block: empty envelope");
+                constexpr uint8_t kRlpListBase = 0xc0;
+                const auto typeByte = rawVec[0];
+                if (typeByte < kRlpListBase && typeByte != 0x01 && typeByte != 0x02 &&
+                    typeByte != 0x04)
+                    throw bcos::evm::engine::OpConsensusError(
+                        fmt::format("op block: unsupported tx type byte 0x{:02x}",
+                            static_cast<unsigned>(typeByte)));
+                BOOST_ERROR(
+                    id << ": blob raw envelope must be rejected by type-byte classification");
+                return false;
+            }
+            catch (const std::runtime_error& e)
+            {
+                // Note: must not use catch(std::exception) — libevmone(-fno-rtti)
+                // brings in a hidden non-unique typeinfo for std::exception, so typed
+                // catch does not reliably bind the runtime_error subtree
+                // (see OpSchedulerSeam.h:1083-1104); the runtime_error branch is
+                // verified to bind (assertRejectThrow). OpConsensusError is a FISCO-side
+                // runtime_error subclass with libc++ unique typeinfo — it binds.
+                out.decodeRejectMessage = std::string(e.what());
+            }
+            // Placeholder tx: keeps the post-deposit non-deposit structure (the
+            // decodeRejectMessage branch never runs processOpBlock; the placeholder
+            // is only for structural completeness).
+            state::Transaction placeholder;
+            placeholder.type = state::Transaction::Type::blob;
+            placeholder.sender = test::from_json<evmc::address>(jAt(t, "sender"));
+            placeholder.to = jAt(t, "to").isNull() ?
+                                 std::nullopt :
+                                 std::optional{test::from_json<evmc::address>(jAt(t, "to"))};
+            placeholder.gas_limit = test::from_json<int64_t>(jAt(t, "gas"));
+            placeholder.value = parseU256(jAt(t, "value"));
+            placeholder.data = test::from_json<bytes>(jAt(t, "data"));
+            placeholder.max_gas_price =
+                t.isMember("maxFeePerGas") ? parseU256(jAt(t, "maxFeePerGas")) : intx::uint256{};
+            placeholder.max_priority_gas_price = t.isMember("maxPriorityFeePerGas") ?
+                                                     parseU256(jAt(t, "maxPriorityFeePerGas")) :
+                                                     intx::uint256{};
+            placeholder.chain_id = vectorChainId.value_or(kCorpusChainId);
+            txs.push_back({.tx = std::move(placeholder), .signedEnvelope = std::move(raw)});
+        }
+        else
+        {
+            BOOST_ERROR(id << ": unknown _op_type '" << opType << "'");
+            return false;
+        }
+    }
+    out.chainId = vectorChainId.value_or(kCorpusChainId);
+    return true;
+}
+
+/// Executes one block: blk env/hardfork/transactions + ts (pre ready or inherited).
+/// A nullptr pre skips pre parsing (chain block i>0 pre:null inherits ts after the
+/// previous block's applyDiff writes). touchedAddrs/touchedSlots are per-block
+/// (block N's .uncovered must not see addresses touched in blocks 0..N-1).
+void replaySingleBlockInto(const std::string& id, const JsonValue& blk, evmone::test::TestState& ts,
+    const JsonValue* pre, DivergenceLedger& ledger, evmc::VM& vm,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory)
+{
+    VectorContext ctx{ledger, id};
+    BlockContext bc;
+    if (!loadBlockContext(id, blk, bc))
+        return;
+    const auto& cfg = *bc.cfg;
+    const bool isJovian = bc.isJovian;
+
+    // pre -> TestState (evmone golden loader; balance/nonce/code required, zero-valued
+    // storage slots dropped per trie semantics). A nullptr pre inherits the caller's ts.
+    if (pre != nullptr)
+        ts = test::from_json<test::TestState>(*pre);
+
+    // Execute: the applyDiff callback both writes back into TestState and accumulates the write set
+    // (used by the coverage assertion).
+    std::set<evmc::address> touchedAddrs;
+    std::map<evmc::address, std::set<evmc::bytes32>> touchedSlots;
+    const auto apply = [&](const state::StateDiff& d) {
+        for (const auto& m : d.modified_accounts)
+        {
+            touchedAddrs.insert(m.addr);
+            for (const auto& [k, val] : m.modified_storage)
+                touchedSlots[m.addr].insert(k);
+        }
+        for (const auto& a : d.deleted_accounts)
+            touchedAddrs.insert(a);
+        bcos::evm::applyStateDiffStrict(ts, d);
+    };
+
+    OpBlockResult result;
+    try
+    {
+        result = processOpBlock(
+            ts, bc.blk, bc.hashes, bc.txs, cfg, vm, bc.chainId, receiptFactory, apply);
+    }
+    catch (const std::exception& e)
+    {
+        BOOST_ERROR(id << ": processOpBlock threw block-level error: " << e.what());
+        return;
+    }
+    catch (...)
+    {
+        // typed-catch RTTI fallback (see docs/audits/2026-07-12-typed-catch-rtti-investigation.md):
+        // libevmone.a (-fno-rtti) ships a hidden non-unique typeinfo copy for
+        // std::exception, so after linking all catch(std::exception&) here compare
+        // unequal to the libc++ throwing side's base typeinfo and miss (arm64
+        // non-unique RTTI bit-mix rule). Diagnosis is not swallowed: name the dynamic
+        // type, then finish with the same semantics as the typed branch.
+        const auto* excType = abi::__cxa_current_exception_type();
+        BOOST_ERROR(id << ": processOpBlock threw block-level error (typed catch "
+                       << "bypassed, exception type: " << (excType ? excType->name() : "<unknown>")
+                       << ")");
+        return;
+    }
+
+    // seal: message passer storage = end-of-block (post-finalize) snapshot (OpBlockExecute.h
+    // contract).
+    const std::map<evmc::bytes32, evmc::bytes32> mpStorage =
+        ts.contains(OP_L2_TO_L1_MESSAGE_PASSER) ? ts.at(OP_L2_TO_L1_MESSAGE_PASSER).storage :
+                                                  std::map<evmc::bytes32, evmc::bytes32>{};
+    const auto seal = sealOpBlock(result, cfg, mpStorage);
+
+    // ── header six fields ────────────────────────────────────────────────────
+    const auto& h = jAt(jAt(blk, "_op_expected"), "header");
+    ctx.checkField("gasUsed", hexU256(parseU256(jAt(h, "gasUsed"))),
+        hexU64(static_cast<uint64_t>(result.gasUsed)));
+    ctx.checkField("receiptsRoot", hexHash(test::from_json<hash256>(jAt(h, "receiptsRoot"))),
+        hexHash(seal.receiptsRoot));
+    // bloom is always compared as 512 hex chars (a zero bloom is an all-zero string, not absent).
+    {
+        auto wantBloom = jAt(h, "logsBloom").asString();
+        std::ranges::transform(wantBloom, wantBloom.begin(),
+            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (wantBloom.size() != 2 + 512 || !wantBloom.starts_with("0x"))
+        {
+            BOOST_ERROR(id << ": header.logsBloom must be 0x + 512 hex chars, got "
+                           << wantBloom.size() << " chars");
+            return;
+        }
+        ctx.checkField("logsBloom", wantBloom, hexBytes(evmc::bytes_view(seal.logsBloom)));
+    }
+    ctx.checkField("withdrawalsRoot", hexHash(test::from_json<hash256>(jAt(h, "withdrawalsRoot"))),
+        hexHash(seal.withdrawalsRoot));
+    // ── header.stateRoot (single leg: execution+engine vs op-geth consensus root) ─
+    // Timing: the seal-stage ts is already the full post-finalize world state (same
+    // anchor as the messagePasserStorage snapshot); later postState comparisons only
+    // read ts, never write — safe to build the root here. Engine correctness
+    // (evmone mpt_hash) is anchored upstream; not re-proven here. Red failures
+    // should be attributed to execution/accounting or pre-alloc completeness first.
+    ctx.checkField("stateRoot", hexHash(test::from_json<hash256>(jAt(h, "stateRoot"))),
+        hexHash(bcos::evm::stateRootOf(TestStateLedger{ts})));
+    // requestsHash: pre-Prague (ecotone/fjord/..., incl. ecotone_upgrade_fjord_activation)
+    // vectors do not emit this key (op-geth t8n omitempty; only Prague has EIP-7685
+    // requests), so the want side goes through checkOptional by presence.
+    ctx.checkOptional("requestsHash",
+        h.isMember("requestsHash") ?
+            std::optional{hexHash(test::from_json<hash256>(jAt(h, "requestsHash")))} :
+            std::nullopt,
+        seal.requestsHash.has_value() ? std::optional{hexHash(*seal.requestsHash)} : std::nullopt);
+    // blobGasUsed: all six forks emit it in vectors (op-geth headers really carry 0x0,
+    // a 4844 leftover field from Ecotone+). Jovian -> value compare ("0x0" is an
+    // in-place zero, e.g. jovian_first_block); the other five forks assert the C++
+    // side is absent (seal.blobGasUsed semantics = Jovian DA-footprint header field;
+    // pre-Isthmus has no such reuse bit, and the vector's 0x0 is informational only).
+    {
+        const auto wantBlobGas =
+            parseU256(jAt(h, "blobGasUsed"));  // required (always emitted on Ecotone+)
+        const auto gotBlobGas =
+            seal.blobGasUsed.has_value() ? std::optional{hexU64(*seal.blobGasUsed)} : std::nullopt;
+        if (isJovian)
+            ctx.checkOptional("blobGasUsed", std::optional{hexU256(wantBlobGas)}, gotBlobGas);
+        else
+            ctx.checkOptional("blobGasUsed", std::nullopt, gotBlobGas);
+    }
+
+    // ── receipts ────────────────────────────────────────────────────────────
+    const auto& expReceipts = jAt(jAt(blk, "_op_expected"), "receipts");
+    if (expReceipts.size() != result.receipts.size())
+    {
+        BOOST_ERROR(id << ": receipts count mismatch: expected " << expReceipts.size() << " got "
+                       << result.receipts.size() << " (no zip-min)");
+        return;
+    }
+    for (size_t i = 0; i < expReceipts.size(); ++i)
+    {
+        const auto& er = expReceipts[static_cast<Json::ArrayIndex>(i)];
+        const std::string p = "receipts[" + std::to_string(i) + "]";
+
+        // Got-side unified view (plan A phase 2 API): FISCO TransactionReceipt::Ptr +
+        // parallel txTypes byte (EIP-2718 type). OP fields via opStackMeta(); deposit vs
+        // normal tx discriminated by kDepositTxType (equivalent to the old
+        // OpDepositReceipt/OpTxReceipt variant discrimination).
+        const auto& receipt = result.receipts[i];
+        const bool isDeposit = (result.txTypes[i] == static_cast<uint8_t>(kDepositTxType));
+        const auto& meta = receipt->opStackMeta();
+        std::optional<std::string> gotDepNonce, gotDepVersion, gotL1Fee, gotOperatorFee,
+            gotDaFootprint, gotL1GasPrice, gotL1BlobBaseFee, gotL1GasUsed, gotL1BaseFeeScalar,
+            gotL1BlobBaseFeeScalar, gotOpFeeScalar, gotOpFeeConstant, gotDaFootprintGasScalar;
+        if (isDeposit)
+        {
+            if (meta && meta->deposit_nonce.has_value())
+                gotDepNonce = hexU64(*meta->deposit_nonce);
+            if (meta && meta->deposit_receipt_version.has_value())
+                gotDepVersion = hexU64(*meta->deposit_receipt_version);
+        }
+        else
+        {
+            if (meta && meta->l1_fee.has_value())
+                gotL1Fee = hexU256Bcos(*meta->l1_fee);
+            // _op_operator_fee presence mirrors op-geth deriveOPStackFields (slot 8
+            // scalar/constant not emitted when all-zero); on this side the same rule
+            // rides meta.operator_fee_scalar/constant (deriveOpReceiptMeta only fills
+            // when non-zero). meta.operator_fee itself is a FISCO extension always
+            // filled on Isthmus+ (incl. 0); comparing it directly would report a
+            // representation difference as a divergence.
+            if (meta &&
+                (meta->operator_fee_scalar.has_value() || meta->operator_fee_constant.has_value()))
+                gotOperatorFee = hexU256Bcos(meta->operator_fee.value_or(bcos::u256{0}));
+            if (meta && meta->da_footprint.has_value())
+                gotDaFootprint = hexU64(*meta->da_footprint);
+            // Full-field compare across the ecotone/fjord/granite/holocene/isthmus/jovian
+            // fieldmap: u256 -> hexU256Bcos, uint64 -> hexU64. got-reads live inside the
+            // non-deposit branch (mirrors generator !IsDepositTx emission: deposit receipts
+            // carry no fee fields on either side; ungated reads would false-diverge).
+            // operator-fee absent pre-Isthmus: ecotone..holocene has_operator_fee=false ->
+            // deriveOpReceiptMeta fills no operator_fee* -> all got nullopt; generator does
+            // not emit _op_operator_fee pre-Isthmus -> optWant also nullopt -> both-absent
+            // pass (no false divergence). l1_gas_used kept unconditionally — even when the
+            // vector lacks the key (optWant nullopt), assert FISCO-side presence
+            // (Task 4 recomputation; Fjord+ always emits, Ecotone uses bedrockCalldataGasUsed).
+            if (meta && meta->l1_gas_price.has_value())
+                gotL1GasPrice = hexU256Bcos(*meta->l1_gas_price);
+            if (meta && meta->l1_blob_base_fee.has_value())
+                gotL1BlobBaseFee = hexU256Bcos(*meta->l1_blob_base_fee);
+            if (meta && meta->l1_gas_used.has_value())
+                gotL1GasUsed = hexU64(*meta->l1_gas_used);
+            if (meta && meta->l1_base_fee_scalar.has_value())
+                gotL1BaseFeeScalar = hexU64(*meta->l1_base_fee_scalar);
+            if (meta && meta->l1_blob_base_fee_scalar.has_value())
+                gotL1BlobBaseFeeScalar = hexU64(*meta->l1_blob_base_fee_scalar);
+            if (meta && meta->operator_fee_scalar.has_value())
+                gotOpFeeScalar = hexU64(*meta->operator_fee_scalar);
+            if (meta && meta->operator_fee_constant.has_value())
+                gotOpFeeConstant = hexU64(*meta->operator_fee_constant);
+            if (meta && meta->da_footprint_gas_scalar.has_value())
+                gotDaFootprintGasScalar = hexU64(*meta->da_footprint_gas_scalar);
+        }
+
+        ctx.checkField(p + ".type", hexU256(parseU256(jAt(er, "type"))),
+            hexU64(static_cast<uint64_t>(result.txTypes[i])));
+        ctx.checkField(p + ".status", hexU256(parseU256(jAt(er, "status"))),
+            receipt->status() == 0 ? "0x1" : "0x0");
+        ctx.checkField(p + ".gasUsed", hexU256(parseU256(jAt(er, "gasUsed"))),
+            hexU64(static_cast<uint64_t>(receipt->gasUsed())));
+        ctx.checkField(p + ".cumulativeGasUsed", hexU256(parseU256(jAt(er, "cumulativeGasUsed"))),
+            std::string{receipt->cumulativeGasUsed()});
+        ctx.checkField(p + ".logsCount", std::to_string(jAt(er, "logsCount").asInt64()),
+            std::to_string(receipt->logEntries().size()));
+        // Receipt output (tx return data): the generator always emits it (empty = "0x");
+        // FISCO output() returns raw bytes, normalized to "0x"+lowercase hex by hexBytes.
+        // Both-absent/both-present byte-exact compare — wrapper returndata truncation and
+        // p256 32-byte-1 are both pinned by it.
+        ctx.checkOptional(p + ".output",
+            er.isMember("output") ? std::optional{jAt(er, "output").asString()} : std::nullopt,
+            std::optional{
+                hexBytes(evmc::bytes_view{receipt->output().data(), receipt->output().size()})});
+
+        const auto optWant = [&](const char* key) -> std::optional<std::string> {
+            return er.isMember(key) ? std::optional{hexU256(parseU256(jAt(er, key)))} :
+                                      std::nullopt;
+        };
+        ctx.checkOptional(p + "._op_deposit_nonce", optWant("_op_deposit_nonce"), gotDepNonce);
+        ctx.checkOptional(p + "._op_deposit_receipt_version",
+            optWant("_op_deposit_receipt_version"), gotDepVersion);
+        ctx.checkOptional(p + "._op_l1_fee", optWant("_op_l1_fee"), gotL1Fee);
+        ctx.checkOptional(p + "._op_operator_fee", optWant("_op_operator_fee"), gotOperatorFee);
+        ctx.checkOptional(p + "._op_da_footprint", optWant("_op_da_footprint"), gotDaFootprint);
+        ctx.checkOptional(p + "._op_l1_gas_price", optWant("_op_l1_gas_price"), gotL1GasPrice);
+        ctx.checkOptional(
+            p + "._op_l1_blob_base_fee", optWant("_op_l1_blob_base_fee"), gotL1BlobBaseFee);
+        ctx.checkOptional(p + "._op_l1_gas_used", optWant("_op_l1_gas_used"), gotL1GasUsed);
+        ctx.checkOptional(
+            p + "._op_l1_base_fee_scalar", optWant("_op_l1_base_fee_scalar"), gotL1BaseFeeScalar);
+        ctx.checkOptional(p + "._op_l1_blob_base_fee_scalar",
+            optWant("_op_l1_blob_base_fee_scalar"), gotL1BlobBaseFeeScalar);
+        ctx.checkOptional(
+            p + "._op_operator_fee_scalar", optWant("_op_operator_fee_scalar"), gotOpFeeScalar);
+        ctx.checkOptional(p + "._op_operator_fee_constant", optWant("_op_operator_fee_constant"),
+            gotOpFeeConstant);
+        ctx.checkOptional(p + "._op_da_footprint_gas_scalar",
+            optWant("_op_da_footprint_gas_scalar"), gotDaFootprintGasScalar);
+    }
+
+    // ── postState bidirectional (decision record 8) ───────────────────────────
+    // Forward: vector per-account per-slot vs replay final state. Zero slots/accounts
+    // reduced per trie semantics (0 == absent): the vector emits "candidate accounts
+    // absent after the block" as {"balance":"0x0"} — the compare is "all four fields
+    // zero + all slots zero", and a missing got-side account is treated as a zero
+    // account, so identity => pass. A present-but-empty got account also passes
+    // (EIP-161 empty account == absent from trie).
+    const auto& post = jAt(blk, "postState");
+    std::set<evmc::address> postAddrs;
+    static const test::TestAccount kZeroAccount{};
+    for (const auto& addrStr : post.getMemberNames())
+    {
+        const auto& acc = post[addrStr];
+        const auto addr = test::from_json<evmc::address>(Json::Value(addrStr));
+        postAddrs.insert(addr);
+        const auto ap = "postState." + hexAddr(addr);
+
+        const auto it = ts.find(addr);
+        const test::TestAccount& got = it != ts.end() ? it->second : kZeroAccount;
+
+        ctx.checkField(
+            ap + ".balance", hexU256(parseU256(jAt(acc, "balance"))), hexU256(got.balance));
+        ctx.checkField(ap + ".nonce",
+            hexU64(acc.isMember("nonce") ? test::from_json<uint64_t>(jAt(acc, "nonce")) : 0),
+            hexU64(got.nonce));
+        ctx.checkField(ap + ".code",
+            acc.isMember("code") ? hexBytes(test::from_json<bytes>(jAt(acc, "code"))) : "0x",
+            hexBytes(got.code));
+
+        // Slot union = vector-declared slots ∪ got non-zero slots ∪ replay write-set
+        // touched slots (slot dimension of coverage assertion (ii): a touched slot is
+        // always in the union and explicitly compared — final non-zero while unlisted
+        // by the vector => want=0x0 turns red; final zero while unlisted => 0==absent
+        // both-zero pass, i.e. "covered").
+        std::map<evmc::bytes32, intx::uint256> wantStorage;
+        if (acc.isMember("storage"))
+        {
+            const auto& storage = acc["storage"];
+            for (const auto& slotStr : storage.getMemberNames())
+                wantStorage[test::from_json<hash256>(Json::Value(slotStr))] =
+                    parseU256(storage[slotStr]);
+        }
+        std::set<evmc::bytes32> slots;
+        for (const auto& [k, val] : wantStorage)
+            slots.insert(k);
+        for (const auto& [k, val] : got.storage)
+            slots.insert(k);
+        if (const auto tIt = touchedSlots.find(addr); tIt != touchedSlots.end())
+            slots.insert(tIt->second.begin(), tIt->second.end());
+        for (const auto& slot : slots)
+        {
+            const auto wIt = wantStorage.find(slot);
+            const auto want = wIt != wantStorage.end() ? wIt->second : intx::uint256{0};
+            const auto gIt = got.storage.find(slot);
+            const auto gotVal = gIt != got.storage.end() ?
+                                    intx::be::load<intx::uint256>(gIt->second) :
+                                    intx::uint256{0};
+            ctx.checkField(ap + ".storage." + hexSlot(slot), hexU256(want), hexU256(gotVal));
+        }
+    }
+    // Reverse existence: a non-empty account in the replay final state not listed by
+    // the vector = DIVERGE (the vector candidate set claims coverage of all written
+    // accounts; empty accounts == absent from trie, reduced to pass).
+    for (const auto& [addr, acc] : ts)
+    {
+        if (postAddrs.contains(addr))
+            continue;
+        const bool storageAllZero = std::ranges::all_of(
+            acc.storage, [](const auto& kv) { return evmc::is_zero(kv.second); });
+        if (acc.nonce != 0 || acc.balance != 0 || !acc.code.empty() || !storageAllZero)
+            ledger.diverge(id, "postState." + hexAddr(addr) + ".exists", kAbsent, "<present>");
+    }
+    // Coverage assertion (ii) address dimension: an address touched by replay applyDiff
+    // but not listed in the vector postState = DIVERGE .uncovered (an account touched
+    // then deleted is emitted by the generator as {"balance":"0x0"} and stays in
+    // postAddrs — absent means the corpus candidate set missed an account).
+    for (const auto& addr : touchedAddrs)
+    {
+        if (!postAddrs.contains(addr))
+            ledger.diverge(
+                id, "postState." + hexAddr(addr) + ".uncovered", "<covered>", "<uncovered>");
+    }
+
+    // Per-vector comparison count: 0 = FAILURE (prevents a vacuous green).
+    if (ctx.comparisons == 0)
+        BOOST_ERROR(id << ": zero comparisons executed");
+}
+
+// ── Single-vector replay (flat vector: pre at top level; chain vectors call replayChainVector per
+// block) ─
+
+void replayVector(const std::string& id, const JsonValue& v, DivergenceLedger& ledger, evmc::VM& vm,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory)
+{
+    evmone::test::TestState ts;
+    replaySingleBlockInto(id, v, ts, &jAt(v, "pre"), ledger, vm, receiptFactory);
+}
+
+// ── reject branch ────────────────────────────────────────────────────────────
+// Top-level _op_expected.reject present -> invalid vector. The T8n side only
+// consumes executor/both (engine direct-connect field-corruption classes are
+// consumed by OpNewPayloadRpcE2eTest, Task 2).
+
+bool hasReject(const JsonValue& v)
+{
+    return v.isMember("_op_expected") && jAt(v, "_op_expected").isMember("reject");
+}
+
+std::string rejectConsumer(const JsonValue& v)
+{
+    // consumer defaults to executor (T8n is an execution-layer replayer; engine-class vectors
+    // explicitly write engine).
+    return jAt(jAt(jAt(v, "_op_expected"), "reject"), "fisco")
+        .get("consumer", Json::Value("executor"))
+        .asString();
+}
+
+/// reject(executor/both) assertion: processOpBlock must throw std::runtime_error whose
+/// what() contains the expected substring. Reuses loadBlockContext loading
+/// (env->BlockInfo / ParentOnlyBlockHashes / transactions->OpBlockTx) but skips the
+/// success-execution assertion path (no header/receipts/postState compares).
+/// The throw side is verified catchable by typed catch: OpSchedulerSeamSmokeTest.cpp:161
+/// catches processOpBlock's empty-block rejection via BOOST_CHECK_THROW(..., std::runtime_error)
+/// and is green (FISCO-side throws use libc++ unique typeinfo, not the libevmone
+/// -fno-rtti hidden copy).
+void assertRejectThrow(const std::string& id, const JsonValue& v, evmc::VM& vm,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory)
+{
+    BlockContext bc;
+    if (!loadBlockContext(id, v, bc))
+        return;
+    // decode-class reject (blob): the load section already reproduced the type-byte-classification
+    // rejection and recorded the message. processOpBlock never reaches that decode (txs
+    // are already OpBlockTx); assert the recorded message directly (same string as the engine
+    // side).
+    if (bc.decodeRejectMessage.has_value())
+    {
+        const auto expected =
+            jAt(jAt(jAt(jAt(v, "_op_expected"), "reject"), "fisco"), "validation_error_contains")
+                .asString();
+        BOOST_CHECK_MESSAGE(bc.decodeRejectMessage->find(expected) != std::string::npos,
+            id << ": decode reject message missing '" << expected
+               << "', got: " << *bc.decodeRejectMessage);
+        return;
+    }
+    evmone::test::TestState ts = test::from_json<test::TestState>(jAt(v, "pre"));
+    // applyDiff callback matches the replaySingleBlockInto execute section (incl. ts write-back);
+    // ts is discarded after reject.
+    std::set<evmc::address> touchedAddrs;
+    std::map<evmc::address, std::set<evmc::bytes32>> touchedSlots;
+    const auto apply = [&](const state::StateDiff& d) {
+        for (const auto& m : d.modified_accounts)
+        {
+            touchedAddrs.insert(m.addr);
+            for (const auto& [k, val] : m.modified_storage)
+                touchedSlots[m.addr].insert(k);
+        }
+        for (const auto& a : d.deleted_accounts)
+            touchedAddrs.insert(a);
+        bcos::evm::applyStateDiffStrict(ts, d);
+    };
+    try
+    {
+        // Warning: only an invalid tx inserted after the first deposit throws "invalid
+        //    non-deposit tx"; a deposit-only block does not throw (legal execution) —
+        //    the vector must contain an invalid transaction.
+        processOpBlock(
+            ts, bc.blk, bc.hashes, bc.txs, *bc.cfg, vm, bc.chainId, receiptFactory, apply);
+    }
+    catch (const std::runtime_error& e)
+    {
+        const auto expected =
+            jAt(jAt(jAt(jAt(v, "_op_expected"), "reject"), "fisco"), "validation_error_contains")
+                .asString();
+        BOOST_CHECK_MESSAGE(std::string(e.what()).find(expected) != std::string::npos,
+            id << ": throw message missing '" << expected << "', got: " << e.what());
+        return;
+    }
+    catch (...)
+    {
+        // typed-catch RTTI fallback (mechanism in replaySingleBlockInto's typed-catch
+        // comment) — name the dynamic type, then finish with typed-branch semantics.
+        const auto* excType = abi::__cxa_current_exception_type();
+        BOOST_ERROR(id << ": threw non-runtime_error (typed catch bypassed, exception type: "
+                       << (excType ? excType->name() : "<unknown>") << ")");
+        return;
+    }
+    BOOST_ERROR(id << ": expected processOpBlock to reject, but it executed");
+}
+
+// ── Chain replay ─────────────────────────────────────────────────────────────
+// blocks[0] seeds pre; blocks[i>0] with pre:null uses the previous block's
+// post-state (ts after applyDiff write-back). chainState is passed by reference
+// across blocks (blocks[i>0] skip pre parsing — pre:null would trip from_json's
+// is_object assert, hence the nullptr pre pointer). ParentOnlyBlockHashes only
+// answers blockNumber-1 (see above), so chain vectors must not contain txs that
+// read historical blockhashes (transfer-safe; review R13).
+
+void replayChainVector(const std::string& id, const JsonValue& v, DivergenceLedger& ledger,
+    evmc::VM& vm, const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory)
+{
+    const auto& blocks = jAt(v, "blocks");
+    evmone::test::TestState chainState;
+    for (std::size_t i = 0; i < blocks.size(); ++i)
+    {
+        const auto& blk = blocks[static_cast<Json::ArrayIndex>(i)];
+        const JsonValue* pre = nullptr;
+        if (blk.isMember("pre") && !blk["pre"].isNull())
+        {
+            chainState = test::from_json<test::TestState>(jAt(blk, "pre"));
+            pre = &blk["pre"];
+        }
+        replaySingleBlockInto(
+            id + "[" + std::to_string(i) + "]", blk, chainState, pre, ledger, vm, receiptFactory);
+    }
+}
+}  // namespace
+// ── structurallyUnrecoverable predicate boundary unit test (prevents the predicate degenerating to
+// always-true/always-false and letting marked tuples escape) ──
+BOOST_AUTO_TEST_SUITE(OpT8nReplay)
+
+BOOST_AUTO_TEST_CASE(StructurallyUnrecoverablePredicateBoundaries)
+{
+    auto mk = [](uint64_t v, const intx::uint256& r, const intx::uint256& s) {
+        evmone::state::Authorization a{};
+        a.v = v;
+        a.r = r;
+        a.s = s;
+        return a;
+    };
+    const intx::uint256 one{1};
+    BOOST_CHECK(!structurallyUnrecoverable(mk(0, one, one)));
+    BOOST_CHECK(!structurallyUnrecoverable(mk(1, one, kSecpHalfN)));       // s == N/2 is legal
+    BOOST_CHECK(structurallyUnrecoverable(mk(2, one, one)));               // v > 1
+    BOOST_CHECK(structurallyUnrecoverable(mk(0, one, kSecpHalfN + 1)));    // s > N/2
+    BOOST_CHECK(structurallyUnrecoverable(mk(0, intx::uint256{0}, one)));  // r == 0
+    BOOST_CHECK(!structurallyUnrecoverable(mk(0, kSecpN - 1, one)));
+    BOOST_CHECK(structurallyUnrecoverable(mk(0, kSecpN, one)));            // r >= N
+    BOOST_CHECK(structurallyUnrecoverable(mk(0, one, intx::uint256{0})));  // s == 0
+}
+
+BOOST_AUTO_TEST_CASE(Vectors)
+{
+    const fs::path vectorsDir = OP_T8N_VECTORS_DIR;
+    BOOST_REQUIRE_MESSAGE(fs::is_directory(vectorsDir), vectorsDir);
+
+    // A) Set equality: dir *.json filename set == manifest.txt list (missing or extra = FAILURE).
+    const auto manifest = loadManifest(vectorsDir / "manifest.txt");
+    BOOST_REQUIRE_MESSAGE(!manifest.empty(), "empty manifest");
+    std::set<std::string> present;
+    for (const auto& entry : fs::directory_iterator(vectorsDir))
+    {
+        if (entry.is_regular_file() && entry.path().extension() == ".json")
+            present.insert(entry.path().filename().string());
+    }
+    for (const auto& name : manifest)
+    {
+        if (!present.contains(name))
+            BOOST_ERROR("manifest lists " << name << " but file is missing");
+    }
+    // Exclusions (forced): expectedBlobVersionedHashes / executionRequests cannot
+    // be expressed through the GoldenSample loader, so the generator still emits files
+    // but keeps them out of the manifest. Set equality exempts these two known
+    // unregistered static-face files (suffix match, base-independent).
+    const auto isUnregisteredStatic = [](std::string const& n) {
+        // "_static_3.json" = 14 chars, "_static_12.json" = 15 chars (suffix match,
+        // base-independent)
+        return (n.size() >= 14 && n.rfind("_static_3.json") == n.size() - 14) ||
+               (n.size() >= 15 && n.rfind("_static_12.json") == n.size() - 15);
+    };
+    for (const auto& name : present)
+    {
+        if (!manifest.contains(name) && !isUnregisteredStatic(name))
+            BOOST_ERROR("unmanifested vector file present: " << name);
+    }
+
+    auto ledger = DivergenceLedger::load(vectorsDir / "DIVERGENCES.md");
+    auto vm = evmc::VM{evmc_create_evmone()};
+    auto receiptFactory = makeTestReceiptFactory();
+
+    // Replay only the set intersection (missing/extra already FAILURE'd; don't let set errors
+    // cascade into parse crashes).
+    for (const auto& name : manifest)
+    {
+        if (!present.contains(name))
+            continue;
+        const auto file = vectorsDir / name;
+        // parse failure / missing required field -> named ADD_FAILURE, then next file; never
+        // silent.
+        try
+        {
+            std::ifstream input(file);
+            const auto doc = jParse(input);
+            std::string id;
+            const JsonValue* vec = nullptr;
+            for (const auto& key : doc.getMemberNames())
+            {
+                if (key == "_op_test_vectors")
+                    continue;
+                if (vec != nullptr)
+                    throw std::runtime_error("more than one vector object in file");
+                id = key;
+                vec = &doc[key];
+            }
+            if (vec == nullptr)
+                throw std::runtime_error("no vector object in file");
+            const auto stem = file.stem().string();
+            if (id != stem)
+                throw std::runtime_error("vector id '" + id + "' != filename stem '" + stem + "'");
+            // Warning — order: chain vectors have only blocks at top level, no
+            // _op_expected, so the reject check (jAt(v, "_op_expected")) would throw
+            // invalid_argument; must test blocks first.
+            if (vec->isMember("blocks"))
+            {
+                replayChainVector(id, *vec, ledger, vm, receiptFactory);
+                continue;
+            }
+            if (hasReject(*vec))
+            {
+                const auto consumer = rejectConsumer(*vec);
+                if (consumer == "engine")
+                    continue;  // field-corruption class: OpNewPayloadRpcE2eTest only
+                assertRejectThrow(id, *vec, vm, receiptFactory);  // executor/both
+                continue;
+            }
+            replayVector(id, *vec, ledger, vm, receiptFactory);
+        }
+        catch (const std::exception& e)
+        {
+            BOOST_ERROR(name << ": " << e.what());
+        }
+        catch (...)
+        {
+            // typed-catch RTTI fallback (same mechanism as above) — name the type,
+            // same semantics as the typed branch (record FAILURE then next vector file).
+            const auto* excType = abi::__cxa_current_exception_type();
+            BOOST_ERROR(name << ": exception escaped typed catch (exception type: "
+                             << (excType ? excType->name() : "<unknown>") << ")");
+        }
+    }
+
+    // E) End-of-run ledger: stale exemptions turn red + KNOWN-DIVERGE total into RecordProperty.
+    ledger.finish();
+}
+
+// ── reject branch: processOpBlock must throw std::runtime_error
+//    ("op block: invalid non-deposit tx: ...", OpBlockExecute.cpp:190) for an invalid
+//    non-deposit tx; assert throw + what() substring. Inline vector
+//    (not a corpus file, embedded directly here) — fields must satisfy loader
+//    requirements: deposit data at the tx top level (jAt(t, "data")); from=OP_DEPOSITOR
+//    to=OP_L1_BLOCK (OpPredeploys.h / OpBlockExecute.cpp); mint/value/gas as hex strings.
+//    The second eip1559 tx must carry a real signed EIP-2718 _op_raw envelope
+//    (opValidate forces non-empty signedTxEnvelope, OpTransition.cpp:362); gas=0 ->
+//    validate_transaction throws INTRINSIC_GAS_TOO_LOW (eth/state/errors.hpp:51) ->
+//    processOpBlock throws "op block: invalid non-deposit tx: intrinsic gas too low".
+BOOST_AUTO_TEST_CASE(RejectExecutorSurface)
+{
+    auto vm = evmc::VM{evmc_create_evmone()};
+    auto receiptFactory = makeTestReceiptFactory();
+    // Warning: DivergenceLedger is default-constructed; load("") would BOOST_ERROR
+    // ("DIVERGENCES.md missing"). assertRejectThrow does not consume the ledger
+    // (reject vectors have no postState/exemption compares); kept for brief conformance.
+    DivergenceLedger ledger;
+    // Hand-built vector uses the jsoncpp Reader on a raw string (a Json::Value
+    // initializer-list tree would fight jsoncpp's aggregate Value constructors).
+    JsonValue v = jParse(R"({
+        "_info": {"hardfork": "isthmus"},
+        "env": {
+            "currentNumber": 1, "currentTimestamp": "0x64",
+            "currentGasLimit": "0x989680", "currentBaseFee": "0x3b9aca00",
+            "currentCoinbase": "0x0000000000000000000000000000000000000000",
+            "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "pre": {
+            "0x0000000000000000000000000000000000000001": {
+                "balance": "0xde0b6b3a7640000", "nonce": "0x0", "code": "0x"
+            }
+        },
+        "block": {
+            "transactions": [
+                {
+                    "_op_type": "deposit",
+                    "_op_deposit": {
+                        "source_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                        "to": "0x4200000000000000000000000000000000000015",
+                        "mint": "0x0", "value": "0x0", "gas": "0x186a0",
+                        "is_system_tx": false
+                    },
+                    "data": "0x"
+                },
+                {
+                    "_op_type": "eip1559",
+                    "_op_raw": "0x02f874822105808405f5e100847735940082520894b0b0000000000000000000000000000000000001880de0b6b3a764000080c001a0e37533ddb9f696c0b21788f1b00c78adc4a81b1d811d84e70fad672096fc924ea00ae693f4d68955a4c01ee8bab26f5be740ee416dd2556822f68b747d5aab7714",
+                    "chainId": "0x2105", "nonce": "0x0",
+                    "to": "0xb0b0000000000000000000000000000000000001",
+                    "gas": "0x0", "maxFeePerGas": "0x77359400", "maxPriorityFeePerGas": "0x5f5e100",
+                    "value": "0x0", "data": "0x",
+                    "sender": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+                }
+            ]
+        },
+        "_op_expected": {
+            "reject": {
+                "op_geth": "intrinsic gas too low",
+                "fisco": {
+                    "consumer": "executor", "classification": "INVALID",
+                    "latest_valid_hash": "parent",
+                    "validation_error_contains": "invalid non-deposit tx"
+                }
+            }
+        }
+    })");
+    assertRejectThrow("reject_executor_intrinsic", v, vm, receiptFactory);
+}
+
+// ── blob decode-class reject (consumer:both) ─────────────────────────
+// The blob arm reproduces the real rejection via the type-byte classification
+// (processOpBlock never reaches raw-tx decode); the message is
+// "op block: unsupported tx type byte 0x03" (runOpBlockInjection / OpScheduler execute hook).
+// _op_raw only needs the type-0x03 first byte to hit the classification branch (it checks the
+// type byte before parsing any field).
+BOOST_AUTO_TEST_CASE(RejectBlobDecode)
+{
+    auto vm = evmc::VM{evmc_create_evmone()};
+    auto receiptFactory = makeTestReceiptFactory();
+    DivergenceLedger ledger;
+    JsonValue v = jParse(R"({
+        "_info": {"hardfork": "isthmus"},
+        "env": {
+            "currentNumber": 1, "currentTimestamp": "0x64",
+            "currentGasLimit": "0x989680", "currentBaseFee": "0x3b9aca00",
+            "currentCoinbase": "0x0000000000000000000000000000000000000000",
+            "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "pre": {
+            "0x0000000000000000000000000000000000000001": {
+                "balance": "0xde0b6b3a7640000", "nonce": "0x0", "code": "0x"
+            }
+        },
+        "block": {
+            "transactions": [
+                {
+                    "_op_type": "deposit",
+                    "_op_deposit": {
+                        "source_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                        "to": "0x4200000000000000000000000000000000000015",
+                        "mint": "0x0", "value": "0x0", "gas": "0x186a0",
+                        "is_system_tx": false
+                    },
+                    "data": "0x"
+                },
+                {
+                    "_op_type": "blob",
+                    "_op_raw": "0x03",
+                    "chainId": "0x2105", "nonce": "0x0",
+                    "to": "0xb0b0000000000000000000000000000000000001",
+                    "gas": "0x186a0", "maxFeePerGas": "0x77359400", "maxPriorityFeePerGas": "0x5f5e100",
+                    "value": "0x0", "data": "0x",
+                    "sender": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+                }
+            ]
+        },
+        "_op_expected": {
+            "reject": {
+                "op_geth": "data blobs present in block body",
+                "fisco": {
+                    "consumer": "both", "classification": "INVALID",
+                    "latest_valid_hash": "parent",
+                    "validation_error_contains": "unsupported tx type byte 0x03"
+                }
+            }
+        }
+    })");
+    assertRejectThrow("reject_blob_decode", v, vm, receiptFactory);
+}
+
+// ── legacy arm loading ───────────────────────────────────────────
+// Verifies _op_type "legacy" loads a type=legacy tx and fills gasPrice into both
+// max/priority (evmone legacy single-price semantics). _op_raw is structural
+// placeholder only (load section does not decode); the full golden path is covered
+// by the corpus isthmus/jovian_legacy_transfer vectors (replayed in full after regen).
+BOOST_AUTO_TEST_CASE(LegacyArmBuildsLegacyTx)
+{
+    JsonValue v = jParse(R"({
+        "_info": {"hardfork": "isthmus"},
+        "env": {
+            "currentNumber": 1, "currentTimestamp": "0x64",
+            "currentGasLimit": "0x989680", "currentBaseFee": "0x3b9aca00",
+            "currentCoinbase": "0x0000000000000000000000000000000000000000",
+            "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "parentBeaconBlockRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "pre": {
+            "0x0000000000000000000000000000000000000001": {
+                "balance": "0xde0b6b3a7640000", "nonce": "0x0", "code": "0x"
+            }
+        },
+        "block": {
+            "transactions": [
+                {
+                    "_op_type": "deposit",
+                    "_op_deposit": {
+                        "source_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                        "from": "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001",
+                        "to": "0x4200000000000000000000000000000000000015",
+                        "mint": "0x0", "value": "0x0", "gas": "0x186a0",
+                        "is_system_tx": false
+                    },
+                    "data": "0x"
+                },
+                {
+                    "_op_type": "legacy",
+                    "_op_raw": "0x01",
+                    "chainId": "0x2105", "nonce": "0x0",
+                    "to": "0xb0b0000000000000000000000000000000000001",
+                    "gas": "0x5208", "gasPrice": "0x4a817c800",
+                    "value": "0xde0b6b3a7640000", "data": "0x",
+                    "sender": "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"
+                }
+            ]
+        }
+    })");
+    BlockContext bc;
+    BOOST_REQUIRE_MESSAGE(loadBlockContext("legacy_arm_load", v, bc), "legacy vector must load");
+    BOOST_REQUIRE_EQUAL(bc.txs.size(), 2u);
+    const auto* tx = std::get_if<state::Transaction>(&bc.txs[1].tx);
+    BOOST_REQUIRE_MESSAGE(tx != nullptr, "tx[1] must be a normal tx");
+    BOOST_CHECK(tx->type == state::Transaction::Type::legacy);
+    BOOST_CHECK_EQUAL(tx->chain_id, uint64_t{0x2105});
+    // legacy single-price: max == priority == gasPrice
+    BOOST_CHECK(tx->max_gas_price == tx->max_priority_gas_price);
+    BOOST_CHECK(tx->max_gas_price == parseU256(jParse("\"0x4a817c800\"")));
+    BOOST_CHECK(bc.txs[1].signedEnvelope.size() > 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpTestReceiptFactory.h
+++ b/opstack-executor/tests/OpTestReceiptFactory.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// OpTestReceiptFactory — test-side receipt factory. opTransition and
+// runDeposit now inject a bcos::protocol::TransactionReceiptFactory::Ptr (they produce FISCO
+// receipts directly); the tests build the real bcostars implementation over a Keccak256 suite,
+// the same construction bcos-tars-protocol's own TransactionReceiptImplTest uses.
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-framework/protocol/TransactionReceiptFactory.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+
+namespace bcos::evm::opstack::testutil
+{
+/// One shared receipt factory for the whole suite (cheap: the factory is stateless beyond the
+/// crypto suite; the receipt objects it creates are independent).
+inline bcos::protocol::TransactionReceiptFactory::Ptr makeOpTestReceiptFactory()
+{
+    auto suite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(suite);
+}
+
+/// intx::uint256 → bcos::u256, full-width big-endian conversion (same pattern as the production
+/// helper in OpTransition.cpp; duplicated here so tests can compare opStackMeta fields against
+/// the intx values the fee code computes).
+inline bcos::u256 bcosU256FromIntx(intx::uint256 const& val)
+{
+    auto be = intx::be::store<evmc::uint256be>(val);
+    return bcos::fromBigEndian<bcos::u256>(
+        bcos::bytesConstRef{reinterpret_cast<bcos::byte const*>(be.bytes), sizeof(be.bytes)});
+}
+
+/// One shared factory instance across test TUs (inline variable: one per program, stateless).
+inline const bcos::protocol::TransactionReceiptFactory::Ptr kOpTestReceiptFactory =
+    makeOpTestReceiptFactory();
+}  // namespace bcos::evm::opstack::testutil

--- a/opstack-executor/tests/OpstackExecutorTest.cpp
+++ b/opstack-executor/tests/OpstackExecutorTest.cpp
@@ -1,0 +1,924 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpstackExecutorTest.cpp — drives OpstackExecutor over BCOS storage. opTransition/runDeposit
+// produce the final FISCO receipt directly (OP metadata + effective gas price already projected),
+// and the state diff is returned via an out-param. Storage is a plain MutableStorage.
+
+#define BOOST_TEST_MODULE BcosOpstackExecutorTests
+#include <boost/test/unit_test.hpp>
+
+#include "bcos-evm/opstack/OpForkSchedule.h"
+#include "bcos-evm/opstack/OpPredeploys.h"
+#include "opstack-executor/OpstackExecutor.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>  // construct a 33-byte-mint envelope for the over-wide test
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
+#include <memory>
+
+using namespace bcos;
+using namespace bcos::executor_v1::opstack;
+using namespace evmc::literals;  // _address / _bytes32
+
+namespace
+{
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+struct Fixture
+{
+    std::shared_ptr<crypto::CryptoSuite> cryptoSuite = std::make_shared<crypto::CryptoSuite>(
+        std::make_shared<crypto::Keccak256>(), nullptr, nullptr);
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory{
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)};
+    MutableStorage storage;
+    ledger::LedgerConfig ledgerConfig;
+
+    const bcos::evm::opstack::OpForkConfig& fork = bcos::evm::opstack::jovianConfig();
+
+    Fixture()
+    {
+        ledgerConfig.setEVMCRevision(fork.rev);
+        ledgerConfig.setGasLimit({30000000, 0});
+        ledgerConfig.setGasPrice({"0x0", 0});
+    }
+
+    bcostars::protocol::TransactionImpl buildWeb3Tx(uint64_t chainId = 10,
+        bcos::Address to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7"))
+    {
+        // Construct a minimal EIP-2930 Web3 tx directly (nonce=7, gasPrice, gasLimit, to, value,
+        // empty data/accessList, yParity=0, 32-byte r/s) — the v1 raw-RLP fixture no longer
+        // decodes under the v2 Web3Transaction path, so build fields instead of RLP. chainId
+        // defaults to 10 to match every executeTransaction call site below, so the fixture
+        // envelope must carry the same chain id the call passes.
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::EIP2930;
+        w3.chainId = chainId;
+        w3.nonce = 7;
+        w3.maxFeePerGas = bcos::u256(30000000000);  // gasPrice (EIP-2930)
+        w3.maxPriorityFeePerGas = w3.maxFeePerGas;
+        w3.gasLimit = 5000000;
+        w3.to = to;
+        w3.value = bcos::u256(2000000000000000000);  // 2 ETH
+        w3.signatureV = 0;                           // yParity
+        w3.signatureR = bcos::bytes(32, 0x01);       // dummy r/s (unused: evmone skips sig verify)
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        auto const txHash = w3.txHash();
+        tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+        // takeToTarsTransaction stores the signing preimage (Web3Transaction.cpp:220-223);
+        // overwrite with the full EIP-2718 envelope (mirroring EngineServiceImpl buildOpBlock) so
+        // the envelope is canonical wire bytes.
+        auto const envelope = w3.encode();
+        tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    // Legacy UNPROTECTED tx mirror (type=Legacy, v=27, chain_id==0) — drives the chainId
+    // EXEMPTION branch of m_prepare's EIP-155 check (legacy chain_id==0 has no chainId concept).
+    bcostars::protocol::TransactionImpl buildLegacyWeb3Tx()
+    {
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::Legacy;
+        w3.chainId = 0;  // unprotected (v=27/28)
+        w3.nonce = 7;
+        w3.maxFeePerGas = bcos::u256(30000000000);  // gasPrice (legacy single-price)
+        w3.maxPriorityFeePerGas = w3.maxFeePerGas;
+        w3.gasLimit = 5000000;
+        w3.to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7");
+        w3.value = bcos::u256(2000000000000000000);
+        w3.signatureV = 27;  // unprotected legacy
+        w3.signatureR = bcos::bytes(32, 0x01);
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        auto const txHash = w3.txHash();
+        tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+        auto const envelope = w3.encode();
+        tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    // Deposit tx mirror for single-tx deposit dispatch. isSystemTx mirrors the
+    // deposit RLP field (tars field 15), NOT Transaction::systemTx().
+    bcostars::protocol::TransactionImpl buildDepositTx(bool isSystemTx = false)
+    {
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::Deposit;
+        w3.sourceHash =
+            bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        w3.from = bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001");
+        w3.to = bcos::Address("0x4200000000000000000000000000000000000015");
+        w3.mint = bcos::u256(5);
+        w3.value = bcos::u256(0);
+        w3.gasLimit = 100000;
+        w3.isSystemTx = isSystemTx;
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    template <class T>
+    static T sync(task::Task<T> t)
+    {
+        return task::syncWait(std::move(t));
+    }
+};
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpstackExecutorTestSuite)
+
+BOOST_AUTO_TEST_CASE(ConstructsWithJovianFork)
+{
+    auto rf =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+    OpstackExecutor executor(rf, makeCryptoSuite()->hashImpl());
+    BOOST_CHECK_NE(&executor.vm(), nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(BuildOpBlockInfoMirrorsBlockPath)
+{
+    // buildBlockInfo must mirror toBlockInfo's field mapping (OpCommon.h:106-121) so eth_call
+    // sees the same block context as block execution: seconds timestamp, header baseFee (via
+    // value_or(0), so optional-less test headers do not throw), and the full field set.
+    auto h = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    h->setNumber(7);
+    h->setTimestamp(1'234'567'890);  // ms; block path divides by 1000
+    h->setCoinbase(bcos::Address{"0x00000000000000000000000000000000000000aa"});
+    h->setBaseFee(bcos::u256(1'000'000'000));
+    h->setPrevRandao(
+        bcos::h256{"0xab00000000000000000000000000000000000000000000000000000000000000"});
+    h->setParentBeaconBlockRoot(
+        bcos::h256{"0xcd00000000000000000000000000000000000000000000000000000000000000"});
+    h->setExtraData(bcos::bytes{0xde, 0xad});
+    h->setBlobGasUsed(bcos::u256(0x1234));
+
+    const auto blk = bcos::executor_v1::opstack::OpstackExecutor::buildBlockInfo(*h, 30'000'000);
+    BOOST_CHECK_EQUAL(blk.number, 7);
+    BOOST_CHECK_EQUAL(blk.timestamp, 1'234'567ULL);  // ms -> s
+    BOOST_CHECK_EQUAL(blk.gas_limit, 30'000'000);    // injected gasLimit
+    // intx::uint256 / evmc::bytes / optional<uint64_t> have no operator<< — use plain BOOST_CHECK
+    // (same predicate as EXPECT_EQ, just without value printing on failure).
+    BOOST_CHECK(blk.base_fee == intx::uint256(1'000'000'000));  // header baseFee, NOT 0
+    BOOST_CHECK_EQUAL(blk.prev_randao.bytes[0], 0xab);          // full field set
+    BOOST_CHECK_EQUAL(blk.parent_beacon_block_root.bytes[0], 0xcd);
+    BOOST_CHECK(blk.extra_data == (evmc::bytes{0xde, 0xad}));
+    BOOST_CHECK(blk.blob_gas_used == 0x1234ULL);
+}
+
+BOOST_FIXTURE_TEST_CASE(ExecutesNormalTransferEndToEnd, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        // EIP-3607: evmone validate_transaction rejects a sender whose code_hash !=
+        // EMPTY_CODE_HASH. Seed the canonical empty-code hash so the sender is recognised as an
+        // EOA.
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    // FISCO internal convention: 0 = success (the Ethereum RPC 0<->1 flip happens later).
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    BOOST_CHECK_GE(receipt->gasUsed(), 21000u);
+    BOOST_CHECK_EQUAL(receipt->blockNumber(), 1);
+    BOOST_CHECK(receipt->opStackMeta().has_value());
+}
+
+BOOST_FIXTURE_TEST_CASE(RejectsForkRevisionMismatch, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    ledgerConfig.setEVMCRevision(EVMC_FRONTIER);  // deliberately != fork.rev
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    auto tx = buildWeb3Tx();
+    bcos::evm::opstack::OpFeeParams fee{};
+    BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(
+                          storage, blockHeader, tx, 0, ledgerConfig, false, fee, 30000000, 10)),
+        bcos::executor_v1::opstack::OpForkRevisionMismatch);
+}
+
+BOOST_FIXTURE_TEST_CASE(RejectsInvalidTx, Fixture)
+{
+    // Balance 0 sender + value transfer -> insufficient balance -> OpTxValidationFailed.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    // No account created -> balance 0 -> validation fails.
+    bcos::evm::opstack::OpFeeParams fee{};
+    BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(
+                          storage, blockHeader, tx, 0, ledgerConfig, false, fee, 30000000, 10)),
+        bcos::executor_v1::opstack::OpTxValidationFailed);
+}
+
+BOOST_FIXTURE_TEST_CASE(ChargesL1AndOperatorFees, Fixture)
+{
+    // Non-zero L1 + operator fee params route through opValidate (pre-charge) -> opTransition
+    // (deriveOpReceiptMeta) and surface in the receipt's opStackMeta.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    fee.l1_base_fee = 1000;
+    fee.base_fee_scalar = 7;
+    fee.blob_base_fee = 2000;
+    fee.blob_base_fee_scalar = 9;
+    fee.operator_fee_scalar = 11;
+    fee.operator_fee_constant = 13;
+
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    // Jovian derives these unconditionally.
+    BOOST_CHECK(meta->l1_fee.has_value());
+    BOOST_CHECK(meta->l1_gas_price.has_value());
+    // operator_fee_scalar filled when has_operator_fee && (scalar != 0 || constant != 0).
+    BOOST_CHECK(meta->operator_fee_scalar.has_value());
+    BOOST_CHECK_EQUAL(*meta->operator_fee_scalar, 11u);
+}
+
+BOOST_FIXTURE_TEST_CASE(ReceiptMetaSurvives, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    fee.l1_base_fee = 1000;
+    fee.base_fee_scalar = 7;
+
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->l1_gas_price.has_value());
+    BOOST_CHECK(*meta->l1_gas_price == bcos::u256(1000));
+    // v2 deriveOpReceiptMeta derives l1_base_fee_scalar from props.fee (not l1_gas_used, which the
+    // v2 implementation no longer fills); the fee below set base_fee_scalar=7.
+    BOOST_REQUIRE(meta->l1_base_fee_scalar.has_value());
+    BOOST_CHECK_EQUAL(*meta->l1_base_fee_scalar, 7u);
+    // effective_gas_price = base_fee(0) + min(maxPriority, maxFee-0); for this EIP-2930 tx
+    // BCOS2Evmone.h maps max_gas_price = max_priority_gas_price = gasPrice, so effective =
+    // gasPrice = 0x6fc23ac00.
+    BOOST_CHECK_EQUAL(receipt->effectiveGasPrice(), "0x6fc23ac00");
+}
+
+// ---- executeDeposit + finalizeBlock (reuse bcos-evm/opstack runDeposit / finalizeOpBlock) ----
+
+BOOST_FIXTURE_TEST_CASE(ExecutesDepositMint, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto kFrom = 0x000000000000000000000000000000000000dead_address;
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x01_bytes32,
+        .from = kFrom,
+        .to = std::nullopt,  // contract creation
+        .mint = intx::uint256{5},
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, kFrom, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    auto receipt = task::syncWait(executor.executeDeposit(
+        storage, blockHeader, dep, /*chainId=*/10, /*blockGasLeft=*/30000000, ledgerConfig));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    // mint(5) added to the from balance.
+    ledger::account::EVMAccount<MutableStorage> acc(storage, kFrom, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+    // deposit_nonce == 0, version == 1 (Canyon+).
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->deposit_nonce.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_nonce, 0u);
+    BOOST_REQUIRE(meta->deposit_receipt_version.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_receipt_version, 1u);
+}
+
+BOOST_FIXTURE_TEST_CASE(ExecutesDepositThroughExecuteTransaction, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    constexpr auto from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    // fee default {} — deposit must ignore it (no L1/operator fee).
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, /*fee=*/{}, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    // mint(5) added to from balance (distinguishes deposit from a normal-path run, which mints
+    // nothing).
+    ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+
+    // deposit_nonce == 0, version == 1 (Canyon+).
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->deposit_nonce.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_nonce, 0u);
+    BOOST_REQUIRE(meta->deposit_receipt_version.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_receipt_version, 1u);
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositLifecycleThroughExecuteContext, Fixture)
+{
+    // Concept lifecycle (createExecuteContext -> prepare -> execute -> finish) on a deposit tx:
+    // the deposit branch must short-circuit opValidate and run executeDeposit, and finish() must
+    // decrement ctx.blockGasLeft + backfill the receipt's cumulativeGasUsed.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    constexpr auto from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    constexpr int64_t kInitialGasLeft = 30000000;
+    OpBlockExecutionContext ctx{};
+    ctx.blockGasLeft = kInitialGasLeft;
+    ctx.chainId = 10;  // blockHashes left null -> executeDeposit uses ZeroBlockHashes
+
+    auto context = task::syncWait(executor.createExecuteContext(
+        storage, blockHeader, tx, /*contextID=*/0, ledgerConfig, /*call=*/false, ctx));
+    task::syncWait(context.prepare());
+    task::syncWait(context.execute());
+    auto receipt = task::syncWait(context.finish());
+
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    // mint(5) applied to the from balance (distinguishes the deposit path from a no-op).
+    ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+    // blockGasLeft decremented by the deposit's gasUsed; cumulative gas backfilled on the receipt.
+    auto const gasUsed = bcos::evm::opstack::narrowGasUsed(receipt->gasUsed());
+    BOOST_CHECK_LT(ctx.blockGasLeft, kInitialGasLeft);
+    BOOST_CHECK_EQUAL(ctx.blockGasLeft, kInitialGasLeft - gasUsed);
+    BOOST_CHECK(ctx.cumulativeGasUsed == gasUsed);
+    BOOST_CHECK_EQUAL(
+        std::string(receipt->cumulativeGasUsed()), bcos::evm::opstack::hexCumulative(gasUsed));
+}
+
+// 6-arg createExecuteContext (generic scheduler / concept form) has no BlockContext: the old
+// default-arg footgun left m_ctx pointing at a destroyed temporary. It must now build a null-ctx
+// context whose prepare() throws a clear OpConsensusError instead of UB.
+BOOST_FIXTURE_TEST_CASE(NullContextSixArgFormThrows, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    auto context = task::syncWait(executor.createExecuteContext(
+        storage, blockHeader, tx, /*contextID=*/0, ledgerConfig, /*call=*/false));
+    BOOST_CHECK_THROW(task::syncWait(context.prepare()), bcos::evm::engine::OpConsensusError);
+    BOOST_CHECK_THROW(task::syncWait(context.execute()), bcos::evm::engine::OpConsensusError);
+    BOOST_CHECK_THROW(task::syncWait(context.finish()), bcos::evm::engine::OpConsensusError);
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositGasLimitReachedIsBlockError, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x02_bytes32,
+        .from = 0x000000000000000000000000000000000000dead_address,
+        .to = 0x0000000000000000000000000000000000000001_address,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    // gas_limit(100000) > blockGasLeft(100) -> runDeposit throws std::runtime_error.
+    BOOST_CHECK_THROW(task::syncWait(executor.executeDeposit(storage, blockHeader, dep,
+                          /*chainId=*/10, /*blockGasLeft=*/100, ledgerConfig)),
+        std::runtime_error);
+}
+
+BOOST_FIXTURE_TEST_CASE(FinalizeOpBlockNoReward, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.setCoinbase(bcos::Address(bcos::bytes(20, 0x11)));
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto kCoinbase = 0x1111111111111111111111111111111111111111_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, kCoinbase, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(100));
+        co_return;
+    }());
+
+    task::syncWait(executor.finalizeBlock(storage, blockHeader, ledgerConfig));
+
+    // OP has no block reward: coinbase balance unchanged.
+    ledger::account::EVMAccount<MutableStorage> acc(storage, kCoinbase, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 100u);
+}
+
+BOOST_FIXTURE_TEST_CASE(BlockInfoGasLimitUsesHeaderGasLimit, Fixture)
+{
+    // buildBlockInfo's gasLimit takes header.gasLimit (not blockGasLeft). Behavior assertion:
+    // executing a minimal GASLIMIT-reading contract, slot0 must store == header.gasLimit().
+    // Before the fix: executeTransaction's BlockInfo.gasLimit = blockGasLeft (injected value), so
+    // the contract stored blockGasLeft; injecting blockGasLeft(250000) < header.gasLimit(1000000)
+    // went red. After the fix: BlockInfo.gasLimit = header.gasLimit == 1000000 → green.
+    // blockGasLeft must be ≥ tx.gasLimit(200000) (else state.cpp:390 GAS_LIMIT_REACHED rejects at
+    // validation and the test is permanently red) AND < header.gasLimit(1000000) to expose the
+    // fork.
+    constexpr auto kObserver = 0x00000000000000000000000000000000000000aa_address;
+    constexpr auto kSender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    const bcos::bytes kObserverCode{0x45, 0x60, 0x00, 0x55, 0x00};  // GASLIMIT; PUSH1 0; SSTORE;
+                                                                    // STOP
+
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.setGasLimit(bcos::u256(1000000));  // exercises the header-gasLimit path
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+    ledgerConfig.setEVMCRevision(fork.rev);
+
+    // Deploy the GASLIMIT observer contract + fund the sender (mirror the fundAccount pattern).
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> obs(storage, kObserver, false);
+        co_await obs.create();
+        co_await obs.setCode(kObserverCode, "", cryptoSuite->hashImpl()->hash(kObserverCode));
+        co_await obs.setBalance(bcos::u256(0));
+        co_await obs.setNonce("0");
+        ledger::account::EVMAccount<MutableStorage> snd(storage, kSender, false);
+        co_await snd.create();
+        co_await snd.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        co_await snd.setBalance(u256("100000000000000000000"));
+        co_await snd.setNonce("0");
+        co_return;
+    }());
+
+    // EIP-1559 tx calling the observer with empty data, value 0. chainId=10 matches the
+    // executeTransaction call below.
+    bcos::rpc::Web3Transaction w3{};
+    w3.type = bcos::rpc::TransactionType::EIP1559;
+    w3.chainId = 10;
+    w3.nonce = 0;
+    w3.maxFeePerGas = bcos::u256(30000000000);
+    w3.maxPriorityFeePerGas = bcos::u256(0);
+    w3.gasLimit = 200000;
+    w3.to = bcos::Address("0x00000000000000000000000000000000000000aa");
+    w3.value = bcos::u256(0);
+    w3.signatureV = 0;
+    w3.signatureR = bcos::bytes(32, 0x01);
+    w3.signatureS = bcos::bytes(32, 0x02);
+    auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+    auto const txHash = w3.txHash();
+    tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+    // Overwrite the signing preimage with the full EIP-2718 envelope.
+    auto const envelope = w3.encode();
+    tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+    bcostars::protocol::TransactionImpl tx([tarsHolder]() { return tarsHolder.get(); });
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(kSender.bytes, kSender.bytes + sizeof(kSender.bytes)));
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    // Inject blockGasLeft=250000 < header.gasLimit=1000000 (≥ tx.gasLimit 200000 passes
+    // validation, < header exposes the GASLIMIT fork) — the key to exposing the fork.
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/250000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    // Read observer slot0: must == header.gasLimit (1000000), not the injected blockGasLeft.
+    // The storage key is raw 32 bytes (evmc_bytes32{}=32 0x00 bytes); neither
+    // storageEntry("0") nor a hex string reads it. EVMAccount::storage() returns an evmc_bytes32
+    // value (all-zero when unset), not an optional — parse slot.bytes with intx::be::load
+    // (32-byte big-endian), not storageEntry's has_value()/operator->.
+    ledger::account::EVMAccount<MutableStorage> obs(storage, kObserver, false);
+    auto slot = task::syncWait(obs.storage(evmc_bytes32{}));  // EVMAccount.h:210
+    BOOST_CHECK(intx::be::load<intx::uint256>(slot.bytes) == intx::uint256(1000000));
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositIsSystemTransactionGetter, Fixture)
+{
+    auto tx = buildDepositTx(/*isSystemTx=*/true);
+    BOOST_CHECK(tx.isDepositTx());                 // web3TypedTxKind == 0x7e
+    BOOST_CHECK(tx.depositIsSystemTransaction());  // tars field 15 == 1
+
+    auto tx2 = buildDepositTx(/*isSystemTx=*/false);
+    BOOST_CHECK(tx2.isDepositTx());
+    BOOST_CHECK(!tx2.depositIsSystemTransaction());  // tars field 15 == 0
+}
+
+/// kyonRay review #5429 K3: consensus deposit fields MUST come from the signed 0x7E envelope
+/// (decodeDepositEnvelope), never from the unauthenticated tars mirrors. Happy path decodes a
+/// legit buildDepositTx envelope; rejection paths cover a non-0x7e type byte and trailing bytes.
+BOOST_AUTO_TEST_CASE(DecodeDepositEnvelopeFromSignedEnvelope)
+{
+    Fixture f;
+    auto tx = f.buildDepositTx(/*isSystemTx=*/false);
+    auto env = tx.extraTransactionBytes();
+    BOOST_REQUIRE(!env.empty());
+    BOOST_CHECK_EQUAL(env[0], 0x7e);
+
+    auto dep = decodeDepositEnvelope(env);
+    // sourceHash matches the builder's fixed h256.
+    bcos::crypto::HashType sh("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    BOOST_CHECK(std::equal(
+        dep.source_hash.bytes, dep.source_hash.bytes + sizeof(dep.source_hash.bytes), sh.begin()));
+    // from == the builder's dead...0001 address.
+    BOOST_CHECK_EQUAL(bcos::toHexStringWithPrefix(
+                          bcos::bytes(dep.from.bytes, dep.from.bytes + sizeof(dep.from.bytes))),
+        "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001");
+    BOOST_REQUIRE(dep.to.has_value());
+    BOOST_CHECK_EQUAL(bcos::toHexStringWithPrefix(
+                          bcos::bytes(dep.to->bytes, dep.to->bytes + sizeof(dep.to->bytes))),
+        "0x4200000000000000000000000000000000000015");
+    BOOST_REQUIRE(dep.mint.has_value());
+    BOOST_CHECK(dep.mint.value() == intx::uint256{5});  // intx::uint256 has no ostream<<
+    BOOST_CHECK(dep.value == intx::uint256{0});
+    BOOST_CHECK_EQUAL(dep.gas_limit, 100000);
+    BOOST_CHECK(!dep.is_system_tx);
+    BOOST_CHECK(dep.data.empty());
+
+    // Rejection: a non-0x7e type byte (the 0x02-envelope + 0x7e-mirror attack) must fail loud.
+    bcos::bytes bad(env.begin(), env.end());
+    bad[0] = 0x02;
+    BOOST_CHECK_THROW(
+        [&]() { (void)decodeDepositEnvelope(bcos::ref(bad)); }(), OpTxValidationFailed);
+
+    // Rejection: trailing bytes after the RLP list must be refused (strict, consensus-grade).
+    bcos::bytes trailing(env.begin(), env.end());
+    trailing.push_back(0x00);
+    BOOST_CHECK_THROW(
+        [&]() { (void)decodeDepositEnvelope(bcos::ref(trailing)); }(), OpTxValidationFailed);
+
+    // Rejection (#1, kyonRay): an over-wide integer (33-byte mint) must fail loud —
+    // rlp::decode(UnsignedIntegral) alone would truncate to the low 32 bytes via fromBigEndian.
+    {
+        bcos::bytes body;
+        bcos::codec::rlp::encode(
+            body, bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"));
+        bcos::codec::rlp::encode(body, bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"));
+        bcos::codec::rlp::encode(body, bcos::Address("0x4200000000000000000000000000000000000015"));
+        bcos::codec::rlp::encode(body, bcos::bytes(33, 0xff));  // 33-byte mint -> over-wide
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // value = 0 (empty RLP item)
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // gas = 0
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // isSystemTx = 0
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // data = empty
+        bcos::bytes list;
+        bcos::codec::rlp::encodeHeader(list, bcos::codec::rlp::Header{true, body.size()});
+        list.insert(list.end(), body.begin(), body.end());
+        bcos::bytes overWideEnv{0x7e};
+        overWideEnv.insert(overWideEnv.end(), list.begin(), list.end());
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(overWideEnv)); }(), OpTxValidationFailed);
+    }
+
+    // Rejection (#2 round 3, kyonRay): non-canonical integers / int64 range / bool — the width
+    // gate does not cover these, and rlp::decode only rejects one non-canonical form (single-byte
+    // payload < 0x80 via decodeHeader). Build an envelope from raw per-field items so we can feed
+    // encodings RLPEncode would never emit. Field order: sourceHash, from, to, mint, value, gas,
+    // isSystemTx, data.
+    auto canonicalItems = []() {
+        bcos::bytes sh, from, to, mint, value, gas, isSystem, data;
+        bcos::codec::rlp::encode(
+            sh, bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"));
+        bcos::codec::rlp::encode(from, bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"));
+        bcos::codec::rlp::encode(to, bcos::Address("0x4200000000000000000000000000000000000015"));
+        bcos::codec::rlp::encode(mint, bcos::bytes{5});                // mint = 5 (bare Byte)
+        bcos::codec::rlp::encode(value, bcos::bytes{});                // value = 0 (empty item)
+        bcos::codec::rlp::encode(gas, bcos::bytes{0x01, 0x86, 0xa0});  // gas = 100000
+        bcos::codec::rlp::encode(isSystem, bcos::bytes{});             // isSystemTx = false
+        bcos::codec::rlp::encode(data, bcos::bytes{});                 // data = empty
+        return std::vector<bcos::bytes>{sh, from, to, mint, value, gas, isSystem, data};
+    };
+    auto envelopeFromItems = [](std::vector<bcos::bytes> const& items) {
+        bcos::bytes body;
+        for (auto const& it : items)
+            body.insert(body.end(), it.begin(), it.end());
+        bcos::bytes list;
+        bcos::codec::rlp::encodeHeader(list, bcos::codec::rlp::Header{true, body.size()});
+        bcos::bytes env{0x7e};
+        env.insert(env.end(), list.begin(), list.end());
+        return env;
+    };
+
+    // (a) leading-zero multi-byte integer (value = 0x82 0x00 0x05): would fold to 5, but op-geth
+    // rejects it as ErrCanonInt.
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x82, 0x00, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (b) single Byte 0x00 (value): integer zero must be the empty item 0x80 — op-geth ErrCanonInt.
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x00};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (c) gas = uint64 max (0x88 FF..FF): static_cast<int64_t>(gas) would wrap to -1; the decoder
+    // rejects values that exceed int64 range.
+    {
+        auto items = canonicalItems();
+        items[5] = bcos::bytes{0x88, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};  // gas
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (d) isSystemTx = bare Byte 2: != 0 would read true, but op-geth decodeBool accepts only the
+    // empty item (false) and 0x01 (true).
+    {
+        auto items = canonicalItems();
+        items[6] = bcos::bytes{0x02};  // isSystemTx
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (e) non-canonical short string (value = 0x81 0x05): a single-byte payload < 0x80 must be a
+    // bare Byte, not a short string — op-geth ErrCanonInt. This is the integerPayloadLength
+    // `pl==1 && ref[1] < 0x80` arm (decodeHeader's NonCanonicalSize is a second, consistent path).
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x81, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (f) RLP list as integer (value = 0xc1 0x05): integerPayloadLength returns nullopt for any
+    // list header — a list is never a well-formed integer (op-geth Stream rejects it).
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0xc1, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (g) isSystemTx = bare Byte 1: end-to-end happy path for the true arm (op-geth decodeBool
+    // 0x01 → true) — the builder's isSystemTx=false default never exercises it.
+    {
+        auto items = canonicalItems();
+        items[6] = bcos::bytes{0x01};  // isSystemTx
+        auto dep = decodeDepositEnvelope(bcos::ref(envelopeFromItems(items)));
+        BOOST_CHECK(dep.is_system_tx);
+    }
+}
+
+// chainId-mismatch enforcement (morebtcg/kyonRay review #5429, review finding E): op-geth
+// EIP155Signer/modernSigner reject txs whose chainId differs from the node's (ErrInvalidChainId).
+// Before this test the rejection had ZERO negative coverage — every test fed a self-consistent
+// chainId. Cases (1)(2) need no sender funding: the check runs before opValidate's gates.
+BOOST_FIXTURE_TEST_CASE(ChainIdMismatchEnforced, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+
+    // (1) protected tx chainId(9) != node chainId(10) -> OpConsensusError.
+    {
+        auto tx = buildWeb3Tx(/*chainId=*/9);
+        tx.clearSenderAndHash();
+        tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+        BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+                              /*contextID=*/0, ledgerConfig, /*call=*/false, fee,
+                              /*blockGasLeft=*/30000000, /*chainId=*/10)),
+            bcos::evm::engine::OpConsensusError);
+    }
+    // (2) typed tx chain_id==0 is NOT exempt (modernSigner rejects 0 != node chainId; a
+    // malicious proposer can craft a 0x02 envelope with chain_id 0). Pinned so a future
+    // "chain_id==0 means unprotected" regression fails.
+    {
+        auto tx = buildWeb3Tx(/*chainId=*/0);
+        tx.clearSenderAndHash();
+        tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+        BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+                              /*contextID=*/0, ledgerConfig, /*call=*/false, fee,
+                              /*blockGasLeft=*/30000000, /*chainId=*/10)),
+            bcos::evm::engine::OpConsensusError);
+    }
+}
+
+// legacy v=27/28 unprotected (chain_id==0) IS exempt: no chainId concept, accepted regardless of
+// the node chainId. Runs the FULL path (funded sender) to prove it executes rather than being
+// caught and reclassified.
+BOOST_FIXTURE_TEST_CASE(LegacyUnprotectedChainIdExempt, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildLegacyWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);       // chainId exempt: executes instead of throwing
+    BOOST_CHECK_EQUAL(receipt->status(), 0);  // and succeeds — not reverted-but-accepted
+}
+
+// CRITICAL-A regression (independent review): a transfer to a c_systemTxsAddress (0x...1000)
+// must credit /apps/<1000> — the table the read side and the state root use — not /sys/<1000>.
+// Before the fix the production write path used the address-taking EVMAccount ctor, which routes
+// these 8 addresses to /sys/, so the credit was invisible to the state root (state-root
+// divergence vs op-geth). Read back via the same Storage2State /apps/ path the root uses.
+BOOST_FIXTURE_TEST_CASE(TransferToSystemAddressCreditsAppsBalance, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto sysAddr = 0x0000000000000000000000000000000000001000_address;  // SYS_CONFIG
+    auto tx =
+        buildWeb3Tx(/*chainId=*/10, bcos::Address("0x0000000000000000000000000000000000001000"));
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+
+    // The state root reads /apps/ (accountTableName); the credit must be visible there.
+    bcos::evm::evmstate::Storage2State<MutableStorage> view(storage, {});
+    auto acc = view.get_account(sysAddr);
+    BOOST_REQUIRE(acc.has_value());
+    BOOST_CHECK(acc->balance == intx::uint256(2000000000000000000));  // the 2 ETH transfer value
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/StateDiffWriteback.h
+++ b/opstack-executor/tests/StateDiffWriteback.h
@@ -1,0 +1,45 @@
+// Test-only strict StateDiff write-back helper (moved out of bcos-evm/adapter/: all callers
+// are tests, so it does not belong in the production adapter surface).
+#pragma once
+
+#include <evmc/hex.hpp>
+#include <bcos-evm/eth/state/state_diff.hpp>
+// TODO(eth-utils-removal): TestState(eth/utils) -> in-house in-memory ledger; the
+// applyStateDiff/applyStateDiffStrict signatures and the three write-back contracts below
+// (delete / clear slot / conditional overwrite) are preserved unchanged.
+#include <test/utils/test_state.hpp>
+#include <stdexcept>
+
+namespace bcos::evm
+{
+/// v1 write-back seam: apply an evmone StateDiff to the in-memory TestState.
+/// Contract (a real-ledger write-back implementation must satisfy this; the block-level
+/// seam-contract test suite that exercises it is out of this PR's tx-level scope):
+///   1) deleted_accounts must be deleted (not always empty after Cancun: EIP-6780 same-tx
+///      selfdestruct and EIP-161 empty-account erasure both produce deletion entries; the
+///      "always empty" comment in state_diff.hpp is outdated);
+///   2) a modified_storage value of 0 means erase the slot, not store zero;
+///   3) code is overwritten only when has_value().
+/// For a diff sanitized at its production site (see StateDiffSanitize.h), the deleted_accounts
+/// entries are guaranteed to exist in the view.
+inline void applyStateDiff(evmone::test::TestState& state, const evmone::state::StateDiff& diff)
+{
+    state.apply(diff);
+}
+
+/// Consumer-side tripwire: delete-of-nonexistent is precisely the ghost signature
+/// (in the test context the write-back target ≡ view and is applied synchronously; the EIP-6780
+/// class is already stripped at the production site, and cross-tx duplicate deletes are stripped
+/// by the post-prior-tx view sanitize — zero false positives). Any future exit that misses
+/// sanitizing turns the write-back-type tests red immediately, without relying on corpus coverage.
+/// Tests that verify the raw, un-sanitized behavior continue to use the raw applyStateDiff.
+inline void applyStateDiffStrict(
+    evmone::test::TestState& state, const evmone::state::StateDiff& diff)
+{
+    for (const auto& addr : diff.deleted_accounts)
+        if (state.find(addr) == state.end())
+            throw std::runtime_error(
+                "ghost delete reached writeback: " + evmc::hex(evmc::bytes_view(addr)));
+    applyStateDiff(state, diff);
+}
+}  // namespace bcos::evm

--- a/opstack-executor/tests/TestPrinters.h
+++ b/opstack-executor/tests/TestPrinters.h
@@ -1,0 +1,80 @@
+#pragma once
+
+// Boost.Test print_log_value specializations for the types the opstack suites compare with
+// BOOST_CHECK_EQUAL et al. — keeps the rich failure output (both operands printed) that a
+// predicate-form BOOST_CHECK(a == b) would lose. Boost requires operator<< (or this
+// customization point) for every printed operand; gtest printed these via its universal
+// fallback, so the port needs the explicit forms.
+
+#include <boost/test/unit_test.hpp>
+
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-evm/eth/state/transaction.hpp>
+#include <evmc/evmc.hpp>
+#include <evmc/hex.hpp>
+#include <intx/intx.hpp>
+#include <ostream>
+#include <system_error>
+
+namespace boost::test_tools::tt_detail
+{
+template <>
+struct print_log_value<intx::uint256>
+{
+    void operator()(std::ostream& ostr, const intx::uint256& value)
+    {
+        ostr << intx::to_string(value);
+    }
+};
+
+template <>
+struct print_log_value<evmc::address>
+{
+    void operator()(std::ostream& ostr, const evmc::address& value)
+    {
+        ostr << evmc::hex({value.bytes, sizeof(value.bytes)});
+    }
+};
+
+template <>
+struct print_log_value<evmc::bytes32>
+{
+    void operator()(std::ostream& ostr, const evmc::bytes32& value)
+    {
+        ostr << evmc::hex({value.bytes, sizeof(value.bytes)});
+    }
+};
+
+template <>
+struct print_log_value<evmc::bytes>
+{
+    void operator()(std::ostream& ostr, const evmc::bytes& value)
+    {
+        ostr << evmc::hex({value.data(), value.size()});
+    }
+};
+
+template <>
+struct print_log_value<bcos::evm::opstack::OpFork>
+{
+    void operator()(std::ostream& ostr, bcos::evm::opstack::OpFork value)
+    {
+        ostr << static_cast<int>(value);
+    }
+};
+
+template <>
+struct print_log_value<evmone::state::Transaction::Type>
+{
+    void operator()(std::ostream& ostr, evmone::state::Transaction::Type value)
+    {
+        ostr << static_cast<int>(value);
+    }
+};
+
+template <>
+struct print_log_value<std::errc>
+{
+    void operator()(std::ostream& ostr, std::errc value) { ostr << static_cast<int>(value); }
+};
+}  // namespace boost::test_tools::tt_detail

--- a/opstack-executor/tests/t8n/generator/cases.go
+++ b/opstack-executor/tests/t8n/generator/cases.go
@@ -1,0 +1,1779 @@
+// Corpus definitions for the M-B3+M6 block-level vector matrix (plan Step 2
+// table, 14 cases x fork column = 25 vectors; corpus augmentation spec rev.3
+// adds 3 cases x both forks = 31 vectors; the defer-sweep batch adds
+// empty_account_cleanup x both forks = 34 vectors). Phase 2 line A (Task 3)
+// adds 7 vectors: 2 Ecotone + 2 Fjord formula-boundary + 3 upgrade-boundary
+// activation cases = 41 vectors; line B (precompile matrix) adds 36 = 77
+// vectors. `opt8n-ref --write-cases <dir>`
+// re-emits the *.in.json files deterministically from these definitions, so
+// the L1Block slot pre-seeding and the L1-attributes deposit calldata are
+// built from ONE feeParams source and cannot drift apart -- and
+// processBlockVector still re-asserts their consistency at startup.
+package main
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+// l1BlockRuntimeCode is the real L1Block predeploy runtime bytecode
+// (gen_l1block.py, tools/op-e2e, op-alignment branch) implementing
+// setL1BlockValues{Ecotone,Isthmus,Jovian}: selector-dispatches, writes slots
+// 1/3/7/8 from the L1-attributes calldata offsets that unpackOpFeeParams reads,
+// reverts on calldatasize<4 or unknown selector. Injecting it into the vector
+// genesis makes the C++ differential replayer execute the real predeploy path
+// on EVERY deposit -- the same bytecode that carried the historical
+// LT-direction / PUSH28-mask / JUMPDEST bugs is now under the op-geth-anchored
+// gate, so a reintroduced bug diverges from op-geth's execution of the same
+// code.
+var l1BlockRuntimeCode = common.FromHex("0x6004361060255760003560e01c63098999be14602b5760003560e01c633db6be2b14602b575b60006000fd5b6000358060c01c63ffffffff1660601b60003560a01c63ffffffff1660401b176003555060243560015560443560075560a03560c01c63ffffffff1660401b60a03560801c67ffffffffffffffff161760b03560f01c61ffff1660601b1760085560006000f3")
+
+// ---------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------
+
+var (
+	chainID = big.NewInt(8453) // 0x2105
+
+	// Canonical L1-attributes depositor (L1 info sender). MUST be the real
+	// op-stack constant 0xdead…dead0001 (op-geth eth/downloader/
+	// receiptreference.go:28 systemAddress; op-node rollup/derive
+	// L1InfoDepositerAddress) — the C++ replayer's processOpBlock hard-asserts
+	// first-tx from == OP_DEPOSITOR (OpPredeploys.h, same constant). The
+	// original dead×10 value was a corpus typo op-geth's own InsertChain
+	// cannot catch (it never checks the depositor address).
+	attributesDepositor = common.HexToAddress("0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001")
+	// Second depositor for user-deposit cases.
+	userDepositor = common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	recA = common.HexToAddress("0xb0b0000000000000000000000000000000000001")
+	recB = common.HexToAddress("0xb0b0000000000000000000000000000000000002")
+	recC = common.HexToAddress("0xb0b0000000000000000000000000000000000003")
+
+	revertAddr   = common.HexToAddress("0xc0de000000000000000000000000000000000001")
+	logsAddr     = common.HexToAddress("0xc0de000000000000000000000000000000000002")
+	feeObsAddr   = common.HexToAddress("0xc0de000000000000000000000000000000000003")
+	delegateAddr = common.HexToAddress("0xc0de000000000000000000000000000000000004")
+	// access_list case: SLOAD target + a listed-but-never-called address.
+	aclAddr       = common.HexToAddress("0xc0de000000000000000000000000000000000005")
+	aclListedOnly = common.HexToAddress("0xdddddddddddddddddddddddddddddddddddddddd")
+	// system_call_order_observable (B-7): user reader contract that CALLs the
+	// EIP-4788 GET path (the BeaconRootsAddress predeploy) and SSTOREs the
+	// returned root.
+	readerAddr = common.HexToAddress("0xc0de000000000000000000000000000000000006")
+	// gaslimit_observer / deposit_basefee_observer: 定向分叉观察者目标地址。
+	// 审查 R1：用 0x...0007/0008 —— 0x...0004/0005 已被 delegateAddr/aclAddr 占用。
+	gaslimitObsAddr = common.HexToAddress("0xc0de000000000000000000000000000000000007")
+	basefeeObsAddr  = common.HexToAddress("0xc0de000000000000000000000000000000000008")
+	// empty_account_cleanup case: pre-seeded exists-but-empty account
+	// (balance 0, nonce 0, no code, no storage). NOT a precompile on either
+	// side (exact-set membership; op-stack P256VERIFY sits at 0x…0100).
+	emptyTouchAddr = common.HexToAddress("0x00000000000000000000000000000000000000e0")
+
+	// PUSH0 PUSH0 REVERT
+	revertCode = hexutil.MustDecode("0x5f5ffd")
+	// SSTORE(0, 0x2a); LOG1 x3 (empty data, distinct topics); STOP
+	// (assembled below in logsCode()).
+	// SSTORE(1, CALLDATALOAD(0)); STOP
+	messagePasserCode = hexutil.MustDecode("0x5f3560015500")
+	// SSTORE(1, 0x2a); STOP -- EIP-7702 delegate target
+	delegateCode = hexutil.MustDecode("0x602a60015500")
+	// SSTORE(0, GASPRICE); SSTORE(1, BASEFEE); SSTORE(2, SELFBALANCE); STOP
+	feeObserverCode = hexutil.MustDecode("0x3a5f55486001554760025500")
+	// spec §6：gaslimit: GASLIMIT(0x45) PUSH1 0 SSTORE STOP —— 存 gaslimit()。
+	// basefee: BASEFEE(0x48) PUSH1 0 SSTORE STOP —— 存 basefee()。
+	gaslimitObserverCode = hexutil.MustDecode("0x4560005500")
+	basefeeObserverCode  = hexutil.MustDecode("0x4860005500")
+	// contract_create initcode: init phase SSTORE(0,1), then the classic
+	// PUSH+MSTORE+RETURN deploy of the 6-byte runtime 0x600160005500
+	// (= SSTORE(0,1); STOP; never called in-block):
+	//   6001 6000 55            SSTORE(0, 1)
+	//   65 600160005500         PUSH6 <runtime>
+	//   6000 52                 MSTORE(0, runtime)   (right-aligned: bytes 26..31)
+	//   6006 601a f3            RETURN(0x1a, 6)
+	createInitCode = hexutil.MustDecode("0x6001600055656001600055006000526006601af3")
+	// access_list target: SLOAD(0); SLOAD(2); STOP. slot0 = listed+accessed,
+	// slot2 = accessed-NOT-listed (the cold-price discriminator).
+	aclCode = hexutil.MustDecode("0x60005460025400")
+
+	// EIP-4788 beacon roots contract, deployed runtime bytecode.
+	// Provenance: execution-specs checkout
+	// /Users/octopus/octo/code/blockchain-impl/execution-specs
+	// @ c3462e030f7e2cebe93688d15d2423dcf16fc8cc,
+	// packages/testing/src/execution_testing/forks/forks/eips/cancun/eip_4788.py
+	// (EEST fork pre-allocation; NOT hand-typed).
+	beaconRootsCode = hexutil.MustDecode("0x3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500")
+	// EIP-2935 history storage contract, deployed runtime bytecode.
+	// Provenance: same checkout,
+	// packages/testing/src/execution_testing/forks/forks/eips/prague/contracts/history_contract.bin
+	// (xxd dump; NOT hand-typed).
+	historyStorageCode = hexutil.MustDecode("0x3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f35600143038111604257611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500")
+
+	// EIP-4788 order-observable reader (B-7), hand-assembled; disassembly in
+	// Task 1 report. BUILT from params.BeaconRootsAddress so the CALL target
+	// can never drift from the real EIP-4788 predeploy (0xfff...ffe is the
+	// SystemAddress, which carries no code). Flow:
+	//   TIMESTAMP; PUSH0; MSTORE             mem[0:32] = block.timestamp
+	//   PUSH2 0x1fff; TIMESTAMP; MOD          idx = t % 8191 (own storage slot)
+	//   PUSH1 32; PUSH0; PUSH1 32; PUSH0; PUSH0
+	//   PUSH20 <BeaconRootsAddress>; GAS; CALL   GET (calldata=timestamp; out buf mem[0:32])
+	//   POP; PUSH1 32; PUSH0; PUSH0; RETURNDATACOPY  no-op on success (root is already
+	//                                        in mem[0:32] via the CALL out-buffer); the
+	//                                        "empty returndata halts" path is what makes
+	//                                        the wrong-order reader tx fail
+	//   PUSH0; MLOAD; SWAP1; SSTORE; STOP     storage[idx] = returned root
+	// The 4788 GET path (beaconRootsCode) only returns a value once its
+	// ts==sload(ts) ring check passes, which happens ONLY AFTER the block's
+	// 4788 system call overwrote the stale pre-seeded ring slot -- so a
+	// replayer that runs user txs before the system call makes the reader's
+	// CALL revert (empty returndata -> RETURNDATACOPY halts) and the reader tx
+	// diverges (status 0, no storage write).
+	beaconReaderCode = func() []byte {
+		head := hexutil.MustDecode("0x425f52611fff420660205f60205f5f73") // up to the PUSH20
+		tail := hexutil.MustDecode("0x5af15060205f5f3e5f51905500")       // GAS CALL POP RDC PUSH0 MLOAD SWAP1 SSTORE STOP
+		out := append(head, params.BeaconRootsAddress.Bytes()...)
+		return append(out, tail...)
+	}()
+
+	// -----------------------------------------------------------------
+	// Phase 2 line B (Task 1): precompile vector INPUTS. Each is genuinely
+	// valid so the precompile succeeds where the plan says success (verified
+	// end-to-end by --probe-receipt-fields during Task 1; construction detail
+	// in the Task 1 report).
+	// -----------------------------------------------------------------
+
+	// validEcrecoverInput is a REAL secp256k1 signature recovering to key 1
+	// (0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf). hash = sha256("fisco
+	// line-b ecrecover"), signed with privKey(1); recovery verified against
+	// crypto.Ecrecover during generation. Layout follows op-geth core/vm
+	// ecrecover.Run: hash(32) || v-slot(32, last byte = recovery-id + 27) ||
+	// r(32) || s(32).
+	validEcrecoverInput = hexutil.MustDecode("0x" +
+		"34fd596c5986a266fe0e5c5f2a160701bb8877079ecc6f617c81bfddcdbbbe5b" + // hash
+		"000000000000000000000000000000000000000000000000000000000000001b" + // v-slot (recid 0 -> 0x1b)
+		"a048fc6ef02730c5eff7fedfdaa9ed5f27725d2ae4edea299ec783192c6adf9e" + // r
+		"62d797bf5a0d6cb3cd9f2b5caa77ef735a2cffe4f1907d8c880c7157e0f4d074") // s
+
+	// validBlake2fInput is EIP-152 test vector 5 (the BLAKE2b F-compression
+	// "abc" case): rounds=12, h = BLAKE2b IV ^ 0x01010040, m = "abc", final=1.
+	// Provenance: op-geth core/vm/testdata/precompiles/blake2F.json vector 5
+	// (canonical; Expected = ba80a53f…409923).
+	validBlake2fInput = hexutil.MustDecode("0x0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001")
+
+	// expmodZeroHeader: 96B modexp header with baseLen=expLen=modLen=0 (empty
+	// base/exp/mod). op-geth bigModExp.Run returns []byte{} for baseLen==0 &&
+	// modLen==0 (EIP-198) -- SUCCESS (status 1) with an empty output, NOT "1"
+	// as the Task 1 brief stated (corrected; the receipt is unaffected).
+	expmodZeroHeader = make([]byte, 96)
+
+	// bn256AddInput: two valid G1 points (128B, EIP-196).
+	bn256AddInput = repeatedPair(validBn256G1(), 2)
+	// bn256MulInput: valid G1 point (64B) || scalar 0x02 (32B) = 96B.
+	bn256MulInput = append(validBn256G1(), common.BigToHash(big.NewInt(2)).Bytes()...)
+
+	// deadbeefInput: shared 4-byte input for sha256/ripemd160/identity.
+	deadbeefInput = hexutil.MustDecode("0xdeadbeef")
+)
+
+// ---------------------------------------------------------------------
+// Precompile addresses (EIP-196/197/198/152/2537/4844/7212 + OP extension)
+// ---------------------------------------------------------------------
+
+const (
+	preEcRecover    = 0x01
+	preSha256       = 0x02
+	preRipemd160    = 0x03
+	preIdentity     = 0x04
+	preExpMod       = 0x05
+	preBn256Add     = 0x06
+	preBn256Mul     = 0x07
+	preBn256Pairing = 0x08
+	preBlake2f      = 0x09
+	prePointEval    = 0x0a // EIP-4844 KZG point evaluation
+	preBlsG1Add     = 0x0b
+	preBlsG1MSM     = 0x0c
+	preBlsG2Add     = 0x0d
+	preBlsG2MSM     = 0x0e
+	preBlsPairing   = 0x0f
+	preBlsMapG1     = 0x10
+	preBlsMapG2     = 0x11
+	preP256Verify   = 0x100 // RIP-7212; 20-byte address 0x…0100 (two low bytes)
+)
+
+// addrBytes(n) returns the 20-byte precompile address. The single-byte
+// precompiles (0x01..0x11) sit at 0x…00nn; P256VERIFY (0x100) needs the
+// second-lowest byte set (0x…0100), so values above 0xFF write into b[18].
+func addrBytes(n uint) []byte {
+	b := make([]byte, 20)
+	if n > 0xFF {
+		b[18] = byte(n >> 8)
+	}
+	b[19] = byte(n)
+	return b
+}
+
+// senderHex returns the checksummed hex form of the EOA for private key i
+// (key 1 is the standard precompile-call sender; precompileFrame funds it).
+func senderHex(i byte) string {
+	return addrOfKey(i).Hex()
+}
+
+func logsCode() []byte {
+	code := hexutil.MustDecode("0x602a5f55") // SSTORE(0, 0x2a)
+	for i := 1; i <= 3; i++ {
+		topic := crypto.Keccak256([]byte(fmt.Sprintf("opt8n-ref topic %d", i)))
+		code = append(code, 0x7f)       // PUSH32
+		code = append(code, topic...)   //   topic
+		code = append(code, 0x5f, 0x5f) // PUSH0 PUSH0 (size, offset)
+		code = append(code, 0xa1)       // LOG1
+	}
+	return append(code, 0x00) // STOP
+}
+
+// ---------------------------------------------------------------------
+// Small builders
+// ---------------------------------------------------------------------
+
+func hd64(v uint64) *math.HexOrDecimal64 { h := math.HexOrDecimal64(v); return &h }
+func hd256(v *big.Int) *math.HexOrDecimal256 {
+	return (*math.HexOrDecimal256)(new(big.Int).Set(v))
+}
+func hdu(v uint64) *math.HexOrDecimal256 { return hd256(new(big.Int).SetUint64(v)) }
+
+func eth(n int64) *big.Int { // n * 10^18
+	return new(big.Int).Mul(big.NewInt(n), big.NewInt(1_000_000_000_000_000_000))
+}
+func milliEth(n int64) *big.Int { // n * 10^15
+	return new(big.Int).Mul(big.NewInt(n), big.NewInt(1_000_000_000_000_000))
+}
+
+func privKey(i byte) hexutil.Bytes {
+	k := make([]byte, 32)
+	k[31] = i
+	return k
+}
+
+func addrOfKey(i byte) common.Address {
+	key, err := crypto.ToECDSA(privKey(i))
+	if err != nil {
+		panic(err)
+	}
+	return crypto.PubkeyToAddress(key.PublicKey)
+}
+
+func junkData(label string, n int) hexutil.Bytes {
+	out := make([]byte, 0, n+32)
+	cur := crypto.Keccak256([]byte("opt8n-ref junk " + label))
+	for len(out) < n {
+		out = append(out, cur...)
+		cur = crypto.Keccak256(cur)
+	}
+	return out[:n]
+}
+
+func sourceHash(label string) common.Hash {
+	return crypto.Keccak256Hash([]byte("opt8n-ref source " + label))
+}
+
+// l1AttributesLayout is the L1-attributes deposit layout for an OP-Stack fork
+// (the per-fork byte form of the L1InfoDeposit calldata, mirroring op-geth
+// core/types/rollup_cost.go extractL1GasParamsPostEcotone/PostIsthmus and
+// ExtractDAFootprintGasScalar). Ecotone/Fjord/Granite/Holocene all use the
+// 164-byte Ecotone layout; only Isthmus adds the operator-fee segment and
+// Jovian the DA-footprint scalar.
+type l1AttributesLayout int
+
+const (
+	layoutEcotone l1AttributesLayout = iota // 164B, selector 0x440a5e20, no operator-fee/DA segment
+	layoutIsthmus                           // 176B, selector 0x098999be, + operatorFeeScalar/Constant [164:176]
+	layoutJovian                            // 178B, selector 0x3db6be2b, + daFootprintGasScalar [176:178]
+)
+
+// forkLayout maps a hardfork name to its L1-attributes layout. The four
+// Ecotone-family forks (ecotone/fjord/granite/holocene) are byte-identical for
+// L1 attributes -- op-geth only branches on the Ecotone selector, and
+// extractL1GasParamsPostEcotone hard-rejects any non-164-byte payload.
+func forkLayout(fork string) l1AttributesLayout {
+	switch fork {
+	case "ecotone", "fjord", "granite", "holocene":
+		return layoutEcotone
+	case "isthmus":
+		return layoutIsthmus
+	case "jovian":
+		return layoutJovian
+	default:
+		panic(fmt.Sprintf("unknown hardfork %q in forkLayout", fork))
+	}
+}
+
+// feeParams is the single source for BOTH the L1Block storage pre-seeding and
+// the L1-attributes deposit calldata (iron rule: field-for-field identical).
+type feeParams struct {
+	l1BaseFee         *big.Int
+	blobBaseFee       *big.Int
+	baseFeeScalar     uint32
+	blobBaseFeeScalar uint32
+	opFeeScalar       uint32
+	opFeeConstant     uint64
+	daScalar          uint16
+	isthmusLayout     bool // force 176B Isthmus-selector calldata under a Jovian config (activation form)
+}
+
+func defaultFeeParams() feeParams {
+	return feeParams{
+		l1BaseFee:         big.NewInt(30_000_000_000), // 30 gwei
+		blobBaseFee:       big.NewInt(1_000_000),
+		baseFeeScalar:     1368,
+		blobBaseFeeScalar: 810949,
+	}
+}
+
+func (fp feeParams) attributesData(fork string) hexutil.Bytes {
+	layout := forkLayout(fork)
+	if layout == layoutJovian && fp.isthmusLayout {
+		layout = layoutIsthmus // Jovian activation form: Isthmus-length/selector calldata (case 12)
+	}
+	var size int
+	var selector []byte
+	switch layout {
+	case layoutEcotone:
+		size, selector = 164, types.EcotoneL1AttributesSelector // extractL1GasParamsPostEcotone: hard 164
+	case layoutIsthmus:
+		size, selector = types.IsthmusL1AttributesLen, types.IsthmusL1AttributesSelector
+	case layoutJovian:
+		size, selector = types.JovianL1AttributesLen, types.JovianL1AttributesSelector
+	}
+	buf := make([]byte, size)
+	copy(buf[0:4], selector)
+	binary.BigEndian.PutUint32(buf[4:8], fp.baseFeeScalar)
+	binary.BigEndian.PutUint32(buf[8:12], fp.blobBaseFeeScalar)
+	// [12:20] sequenceNumber, [20:28] l1 timestamp, [28:36] l1 number: zero
+	// (not read by any cost function; not slot-mirrored -- see README).
+	fp.l1BaseFee.FillBytes(buf[36:68])
+	fp.blobBaseFee.FillBytes(buf[68:100])
+	// [100:132] l1 block hash, [132:164] batcher hash: zero.
+	if layout != layoutEcotone {
+		// Operator-fee segment exists ONLY in Isthmus+ layouts (the Ecotone
+		// 164B form has no [164:176] -- writing it would make data 176B and
+		// extractL1GasParamsPostEcotone would reject it).
+		binary.BigEndian.PutUint32(buf[164:168], fp.opFeeScalar)
+		binary.BigEndian.PutUint64(buf[168:176], fp.opFeeConstant)
+	}
+	if layout == layoutJovian {
+		binary.BigEndian.PutUint16(buf[176:178], fp.daScalar)
+	}
+	return buf
+}
+
+func (fp feeParams) l1BlockStorage(fork string) map[common.Hash]common.Hash {
+	st := map[common.Hash]common.Hash{}
+	st[types.L1BaseFeeSlot] = common.BigToHash(fp.l1BaseFee)
+	st[types.L1BlobBaseFeeSlot] = common.BigToHash(fp.blobBaseFee)
+	var slot3 common.Hash
+	binary.BigEndian.PutUint32(slot3[16:20], fp.baseFeeScalar)
+	binary.BigEndian.PutUint32(slot3[20:24], fp.blobBaseFeeScalar)
+	st[types.L1FeeScalarsSlot] = slot3
+	var slot8 common.Hash
+	switch forkLayout(fork) {
+	case layoutJovian:
+		if !fp.isthmusLayout {
+			binary.BigEndian.PutUint16(slot8[18:20], fp.daScalar)
+		}
+		binary.BigEndian.PutUint32(slot8[20:24], fp.opFeeScalar)
+		binary.BigEndian.PutUint64(slot8[24:32], fp.opFeeConstant)
+	case layoutIsthmus:
+		binary.BigEndian.PutUint32(slot8[20:24], fp.opFeeScalar)
+		binary.BigEndian.PutUint64(slot8[24:32], fp.opFeeConstant)
+	case layoutEcotone:
+		// No operator-fee / DA segment in the Ecotone 164B layout: slot 8
+		// (OperatorFeeParams) stays unseeded -- it is an Isthmus+ concept.
+	}
+	if slot8 != (common.Hash{}) {
+		st[types.OperatorFeeParamsSlot] = slot8
+	}
+	return st
+}
+
+func (fp feeParams) attributesTx(label string, fork string) inputTx {
+	to := l1BlockAddr
+	return inputTx{
+		OpType: "deposit",
+		OpDeposit: &inputDeposit{
+			From:       attributesDepositor,
+			To:         &to,
+			Gas:        math.HexOrDecimal64(1_000_000),
+			IsSystemTx: false,
+			SourceHash: sourceHash("attributes " + label),
+		},
+		Data: fp.attributesData(fork),
+	}
+}
+
+func transferTx(key byte, nonce uint64, to common.Address, value *big.Int, gas uint64, data hexutil.Bytes) inputTx {
+	k := privKey(key)
+	toCopy := to
+	return inputTx{
+		OpType:               "eip1559",
+		ChainID:              hd256(chainID),
+		Nonce:                hd64(nonce),
+		To:                   &toCopy,
+		Value:                hd256(value),
+		Gas:                  hd64(gas),
+		MaxFeePerGas:         hdu(2_000_000_000), // 2 gwei
+		MaxPriorityFeePerGas: hdu(100_000_000),   // 0.1 gwei
+		Data:                 data,
+		SecretKey:            &k,
+	}
+}
+
+// legacyTransferTx builds a type-0 legacy tx with an EIP-155 protected
+// signature (B-scope base). gasPrice is the single per-gas price; 2 gwei is
+// above the 1 gwei base fee of every caseFrame so the transfer is payable.
+func legacyTransferTx(key byte, nonce uint64, to common.Address, value *big.Int, gas uint64, data hexutil.Bytes) inputTx {
+	k := privKey(key)
+	toCopy := to
+	return inputTx{
+		OpType:    "legacy",
+		ChainID:   hd256(chainID),
+		Nonce:     hd64(nonce),
+		To:        &toCopy,
+		Value:     hd256(value),
+		Gas:       hd64(gas),
+		GasPrice:  hdu(2_000_000_000), // 2 gwei
+		Data:      data,
+		SecretKey: &k,
+	}
+}
+
+// caseFrame assembles the shared skeleton: genesis knobs, coinbase, beacon
+// root, and the baseline pre (L1Block slots seeded from fp; the
+// L2ToL1MessagePasser always on record per plan Step 2).
+func caseFrame(fork, name, desc string, fp feeParams, gasLimit uint64) inputCase {
+	jovianCfg := fork == "jovian"
+	knobs := genesisKnobs{
+		Timestamp:          math.HexOrDecimal64(1000),
+		GasLimit:           math.HexOrDecimal64(gasLimit),
+		BaseFee:            hdu(1_000_000_000), // 1 gwei
+		EIP1559Denominator: math.HexOrDecimal64(50),
+		EIP1559Elasticity:  math.HexOrDecimal64(6),
+	}
+	if jovianCfg {
+		knobs.MinBaseFee = hd64(0)
+	}
+	// L1Block carries the REAL predeploy runtime code (l1BlockRuntimeCode), so
+	// the attributes deposit actually executes setL1BlockValues* and writes
+	// slots 1/3/7/8 from the calldata -- mirroring the real chain. Because the
+	// calldata and the pre-seeded slots are built from ONE feeParams source
+	// (iron rule below), the code writes exactly the seeded values; the C++
+	// replayer then sees the genuine deposit→predeploy execution path against
+	// op-geth's execution of the same bytecode (the LT-direction / PUSH28-mask
+	// / JUMPDEST regressions of the historical handwritten bytecode are now
+	// under the op-geth-anchored differential gate). Nonce 1 + code keeps the
+	// account non-empty under EIP-158.
+	pre := types.GenesisAlloc{
+		l1BlockAddr:       {Balance: big.NewInt(0), Nonce: 1, Code: l1BlockRuntimeCode, Storage: fp.l1BlockStorage(fork)},
+		messagePasserAddr: {Balance: big.NewInt(0), Nonce: 1},
+	}
+	return inputCase{
+		Info:                  caseInfo{Hardfork: fork, Description: desc},
+		Genesis:               knobs,
+		Coinbase:              sequencerVault,
+		ParentBeaconBlockRoot: common.HexToHash("0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
+		Pre:                   pre,
+		Transactions: []inputTx{
+			fp.attributesTx(fork+"_"+name, fork),
+		},
+	}
+}
+
+// opForkOrder is the strict OP-Stack fork sequence. upgradeFrame activates
+// EVERY fork strictly after baseFork and up to (and including) activationFork
+// at activationT: real OP chains cannot skip forks -- a fjord->isthmus upgrade
+// must also fire granite+holocene, otherwise the block's extraData stays empty
+// (pre-Holocene) instead of the mandatory 9-byte Holocene form. The base fork
+// itself and all forks before it stay at 0 (already active at genesis).
+var opForkOrder = []string{"ecotone", "fjord", "granite", "holocene", "isthmus", "jovian"}
+
+// upgradeFrame assembles the upgrade-boundary skeleton (spec A2, Task 3):
+// genesis in baseFork, single block (timestamp = genesis+10 = 1010) crossing
+// into activationFork at activationT = 1005 -- the 10-second coupling
+// (1000 < 1005 <= 1010 holds, so the single block is the FIRST block of the
+// new fork). The L1-attributes deposit format switches at the fork boundary
+// (op-geth extractL1GasParams branches on the selector), so the L1Block slot
+// seeding and the deposit calldata are REBUILT under the activation fork's
+// layout -- still from the same feeParams (iron rule: slot <-> calldata).
+func upgradeFrame(baseFork, name, desc string, fp feeParams, gasLimit uint64, activationFork string, activationT uint64) inputCase {
+	c := caseFrame(baseFork, name, desc, fp, gasLimit)
+	c.Pre[l1BlockAddr] = types.Account{Balance: big.NewInt(0), Nonce: 1, Code: l1BlockRuntimeCode, Storage: fp.l1BlockStorage(activationFork)}
+	c.Transactions[0] = fp.attributesTx(baseFork+"_"+name, activationFork)
+	c.Info.Activations = map[string]uint64{}
+	started := false
+	for _, f := range opForkOrder {
+		if !started {
+			if f == baseFork {
+				started = true
+			}
+			continue
+		}
+		c.Info.Activations[f] = activationT
+		if f == activationFork {
+			break
+		}
+	}
+	if activationFork == "jovian" {
+		// EncodeOptimismExtraData panics on nil minBaseFee for Jovian BLOCKS;
+		// processBlockVector gates minBaseFee on blockTime (Task 3 handoff A),
+		// so a genesis that is pre-Jovian but crosses JovianTime must still
+		// carry genesis.minBaseFee.
+		c.Genesis.MinBaseFee = hd64(0)
+	}
+	// _info.hardfork carries the BLOCK-TIME fork (the upgrade TARGET), matching
+	// its established meaning across every other vector -- "the fork the block
+	// executes under" -- so the C++ differential-gate replayer (which selects
+	// its chain config from _info.hardfork ONLY and never reads activations)
+	// replays the block under the target fork instead of the genesis base fork.
+	// The base fork lives only in the vector FILE name (vectorName) and in the
+	// activations schedule. buildConfigForCase still derives an IDENTICAL chain
+	// config from (hardfork = target, activations): the target-as-base keeps
+	// every fork through the target at 0 and the activations map re-timestamps
+	// exactly the forks that fire at activationT, so op-geth generation output
+	// is byte-for-byte unchanged -- this is a metadata-only edit.
+	c.Info.Hardfork = activationFork
+	return c
+}
+
+func fund(c *inputCase, key byte, amount *big.Int) {
+	c.Pre[addrOfKey(key)] = types.Account{Balance: amount}
+}
+
+// precompileCallTx builds a direct EIP-1559 call to a precompile address
+// (To = the 20-byte precompile address, Data = the precompile input). Field
+// shape mirrors transferTx (cases.go) / buildTx's eip1559 arm (main.go):
+// sender is key 1 (SecretKey), nonce 0 -- precompileFrame funds key 1, and a
+// frame holding several precompile txs must raise nonces at its call site.
+// gas is the full tx gas limit (line-B §4.1: cap-over-limit vectors need
+// gas >= RequiredGas(cap-sized input) so the call reaches the precompile's own
+// cap check instead of OOG-ing first); value defaults to 0.
+func precompileCallTx(addr []byte, data []byte, gas uint64, value uint64) inputTx {
+	k := privKey(1)
+	to := common.BytesToAddress(addr)
+	return inputTx{
+		OpType:               "eip1559",
+		ChainID:              hd256(chainID),
+		Nonce:                hd64(0),
+		To:                   &to,
+		Value:                hd256(new(big.Int).SetUint64(value)),
+		Gas:                  hd64(gas),
+		MaxFeePerGas:         hdu(2_000_000_000), // 2 gwei
+		MaxPriorityFeePerGas: hdu(100_000_000),   // 0.1 gwei
+		Data:                 data,
+		SecretKey:            &k,
+	}
+}
+
+// precompileFrame assembles a single-block precompile case on top of the
+// line-A caseFrame skeleton (genesis knobs, coinbase, beacon root, L1Block
+// slot seeding, L1-attributes deposit tx0). txs are appended after the
+// attributes deposit; sender key 1 is funded eth(100) -- plenty for a ~20M-gas
+// over-limit call at 2 gwei plus its calldata/L1 fee.
+//
+// blockGasLimit is threaded straight into caseFrame's gasLimit -> genesisKnobs
+// GasLimit -> inputCase.Genesis.GasLimit, which processBlockVector
+// (main.go:652) reads verbatim as core.Genesis.GasLimit; the single generated
+// block inherits the genesis gas limit, so a raised value (30M, big_block
+// precedent) is what lets cap-over-limit vectors clear the block-level OOG and
+// actually reach the precompile cap path. Default is 10_000_000 (line-A norm).
+//
+// It returns a caseSpec for Tasks 1-4 to drop into the caseSpecs table (Task 0
+// itself adds no vectors, keeping regen.sh's 41-case count stable; the
+// --probe-precompile dev probe exercises this constructor end-to-end).
+func precompileFrame(fork, name, desc string, txs []inputTx, blockGasLimit uint64) caseSpec {
+	return caseSpec{
+		name:  name,
+		forks: []string{fork},
+		build: func(f string) inputCase {
+			c := caseFrame(f, name, desc, defaultFeeParams(), blockGasLimit)
+			fund(&c, 1, eth(100))
+			c.Transactions = append(c.Transactions, txs...)
+			return c
+		},
+	}
+}
+
+// basePrecompileCase is the shared shape for the base-7 + bn256 add/mul normal
+// vectors (line B Task 1 steps 1-2): fork=isthmus, a single direct EIP-1559
+// call to precompile addr with a VALID input. tx gas 500_000 covers the
+// intrinsic gas (~21.5k) PLUS the precompile's RequiredGas (see the Task 0
+// probe note: a 150-gas tx would OOG at the intrinsic check and never reach
+// the precompile); block gas 10M (precompileFrame default).
+func basePrecompileCase(name, desc string, addr uint, input []byte) caseSpec {
+	return precompileFrame("isthmus", name, desc,
+		[]inputTx{precompileCallTx(addrBytes(addr), input, 500_000, 0)},
+		10_000_000)
+}
+
+// bn256 pairing over-cap tx gas (line B §4.1 / Task 1 brief constraint
+// "tx gas >= max(intrinsic, floor, RequiredGas) + margin"). The tx gas limit
+// is charged intrinsic FIRST (state_transition.go:563), so it must clear
+// intrinsic + RequiredGas or the precompile OOGs before its cap check.
+// RequiredGas = 45000 + 34000×pairs (Istanbul rate; Granite/Jovian defer to
+// it). Measured (Task 1 report, reproducible):
+//
+//	587 pairs (granite/fjord): intrinsic 1,373,448 + RequiredGas 20,003,000
+//	                           = 21,376,448 -> 21,400,000
+//	428 pairs (jovian):        intrinsic 1,007,112 + RequiredGas 14,597,000
+//	                           = 15,604,112 -> 15,700,000
+//
+// The EIP-7623 floor (3.40M / 2.49M) does not bind. EIP-7825's 16.7M MaxTxGas
+// cap does NOT apply: OsakaTime is nil in every OP vector config
+// (buildChainConfig), so rules.IsOsaka is false.
+const (
+	bn256PairOvercapGas587 = 21_400_000
+	bn256PairOvercapGas428 = 15_700_000
+)
+
+// ---------------------------------------------------------------------
+// The 18 cases (14 from the M-B3+M6 plan table + 3 corpus-augmentation
+// cases, spec rev.3, + 1 defer-sweep case)
+// ---------------------------------------------------------------------
+
+type caseSpec struct {
+	name  string
+	forks []string
+	build func(fork string) inputCase
+}
+
+// bScopeSpecs names the B-scope bases (Task 3 F1): buildable for
+// corrupt/invalid-tx bases but NOT emitted by --write-cases / emitCases (the
+// T8n replayer has no consumer arm for them yet). legacy_transfer WAS the sole
+// bScope spec; the replayer legacy arm landed in Task 6 (OpT8nReplayTest.cpp),
+// so the set is now EMPTY and legacy_transfer is emitted normally. Kept as a
+// set (not a struct field) so the shared table's positional literals stay
+// untouched; re-populate it if a future base outpaces its consumer arm.
+var bScopeSpecs = map[string]bool{}
+
+var bothForks = []string{"isthmus", "jovian"}
+
+var caseSpecs = []caseSpec{
+	{"deposit_only", bothForks, func(fork string) inputCase {
+		return caseFrame(fork, "deposit_only",
+			"L1 attributes deposit only; header commitments over an otherwise empty block",
+			defaultFeeParams(), 10_000_000)
+	}},
+
+	{"transfer_basic", bothForks, func(fork string) inputCase {
+		c := caseFrame(fork, "transfer_basic",
+			"attributes + one EIP-1559 value transfer",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, recA, eth(1), 21_000, nil))
+		return c
+	}},
+
+	{"legacy_transfer", bothForks, func(fork string) inputCase {
+		// B-scope base: a type-0 legacy tx with an EIP-155 protected signature
+		// (V = chainID*2+35/36). Serves as the base for corrupt/invalid-tx
+		// vectors and as a B-scope valid vector. Replayer legacy arm landed in
+		// Task 6 (OpT8nReplayTest.cpp legacy 臂), so it is emitted by
+		// --write-cases (bScopeSpecs is empty).
+		c := caseFrame(fork, "legacy_transfer",
+			"attributes + one type-0 EIP-155 protected legacy value transfer",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, legacyTransferTx(1, 0, recA, eth(1), 21_000, nil))
+		return c
+	}},
+
+	{"transfer_multi", bothForks, func(fork string) inputCase {
+		c := caseFrame(fork, "transfer_multi",
+			"attributes + five transfers from three senders with interleaved nonces",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		fund(&c, 2, eth(100))
+		fund(&c, 3, eth(100))
+		c.Transactions = append(c.Transactions,
+			transferTx(1, 0, recA, eth(1), 21_000, nil),
+			transferTx(2, 0, recB, eth(2), 21_000, nil),
+			transferTx(1, 1, recC, milliEth(500), 21_000, nil),
+			transferTx(3, 0, recA, milliEth(250), 21_000, nil),
+			transferTx(2, 1, recB, milliEth(750), 21_000, nil),
+		)
+		return c
+	}},
+
+	{"deposit_mint", bothForks, func(fork string) inputCase {
+		c := caseFrame(fork, "deposit_mint",
+			"attributes + user deposit with mint and value to an EOA",
+			defaultFeeParams(), 10_000_000)
+		to := recA
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType: "deposit",
+			OpDeposit: &inputDeposit{
+				From:       userDepositor,
+				To:         &to,
+				Mint:       hd256(eth(2)),
+				Value:      hd256(eth(1)),
+				Gas:        math.HexOrDecimal64(50_000),
+				SourceHash: sourceHash("deposit_mint " + fork),
+			},
+		})
+		return c
+	}},
+
+	{"deposit_failed", bothForks, func(fork string) inputCase {
+		// EVM-revert deposit: status 0 with ACTUAL gasUsed (gasUsed==gasLimit
+		// happens only for consensus-failing deposits, which cannot appear in
+		// a valid block -- see README "Known boundaries"). Mint is still
+		// credited to the sender; the value transfer is rolled back.
+		c := caseFrame(fork, "deposit_failed",
+			"attributes + user deposit that reverts in the EVM (status 0, actual gasUsed, mint still credited)",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[revertAddr] = types.Account{Balance: big.NewInt(0), Code: revertCode}
+		to := revertAddr
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType: "deposit",
+			OpDeposit: &inputDeposit{
+				From:       userDepositor,
+				To:         &to,
+				Mint:       hd256(eth(1)),
+				Value:      hd256(milliEth(500)),
+				Gas:        math.HexOrDecimal64(100_000),
+				SourceHash: sourceHash("deposit_failed " + fork),
+			},
+		})
+		return c
+	}},
+
+	{"contract_logs", bothForks, func(fork string) inputCase {
+		c := caseFrame(fork, "contract_logs",
+			"attributes + call to a contract emitting LOG1 x3 and one SSTORE (non-trivial bloom/logsCount)",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[logsAddr] = types.Account{Balance: big.NewInt(0), Code: logsCode()}
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, logsAddr, big.NewInt(0), 200_000, nil))
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			logsAddr: {common.BigToHash(big.NewInt(0))},
+		}
+		return c
+	}},
+
+	{"message_passer_write", bothForks, func(fork string) inputCase {
+		// The L2ToL1MessagePasser gets a minimal SSTORE code so its storage
+		// root -- and therefore the Isthmus withdrawalsRoot -- changes.
+		c := caseFrame(fork, "message_passer_write",
+			"attributes + tx writing to the L2ToL1MessagePasser (withdrawalsRoot becomes non-empty)",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[messagePasserAddr] = types.Account{Balance: big.NewInt(0), Nonce: 1, Code: messagePasserCode}
+		fund(&c, 1, eth(100))
+		payload := common.HexToHash("0x000000000000000000000000000000000000000000000000000000000000beef")
+		c.Transactions = append(c.Transactions, transferTx(1, 0, messagePasserAddr, big.NewInt(0), 100_000, payload[:]))
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			messagePasserAddr: {common.BigToHash(big.NewInt(1))},
+		}
+		return c
+	}},
+
+	{"tx_reverted", bothForks, func(fork string) inputCase {
+		c := caseFrame(fork, "tx_reverted",
+			"attributes + normal tx that REVERTs (status 0 in a valid block; value transfer rolled back)",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[revertAddr] = types.Account{Balance: big.NewInt(0), Code: revertCode}
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, revertAddr, milliEth(100), 100_000, nil))
+		return c
+	}},
+
+	{"setcode_7702", bothForks, func(fork string) inputCase {
+		// Sponsor (key 1) sends the 0x04 tx to the authority (key 4), whose
+		// authorization delegates to delegateAddr; the call then executes the
+		// delegated code in the authority's context (SSTORE slot1=0x2a).
+		c := caseFrame(fork, "setcode_7702",
+			"attributes + EIP-7702 setcode tx (sponsor != authority); delegated code runs in authority context",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		authority := addrOfKey(4)
+		c.Pre[authority] = types.Account{Balance: eth(1)}
+		c.Pre[delegateAddr] = types.Account{Balance: big.NewInt(0), Code: delegateCode}
+		authKey := privKey(4)
+		sponsorKey := privKey(1)
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType:               "setcode",
+			ChainID:              hd256(chainID),
+			Nonce:                hd64(0),
+			To:                   &authority,
+			Value:                hd256(big.NewInt(0)),
+			Gas:                  hd64(200_000),
+			MaxFeePerGas:         hdu(2_000_000_000),
+			MaxPriorityFeePerGas: hdu(100_000_000),
+			SecretKey:            &sponsorKey,
+			OpAuthorizations: []inputAuthorization{{
+				ChainID:       hd256(chainID),
+				Address:       delegateAddr,
+				Nonce:         0,
+				AuthSecretKey: authKey,
+			}},
+		})
+		c.ExtraCandidates = []common.Address{delegateAddr}
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			authority: {common.BigToHash(big.NewInt(1))},
+		}
+		return c
+	}},
+
+	{"big_block_130tx", []string{"isthmus"}, func(fork string) inputCase {
+		// 131 txs total (attributes + 130 transfers): receipt/tx trie keys
+		// 128..130 exercise the two-byte RLP key encoding; 30M gas limit.
+		c := caseFrame(fork, "big_block_130tx",
+			"attributes + 130 transfers (tx/receipt trie two-byte RLP keys at indices 128+; 30M gas limit)",
+			defaultFeeParams(), 30_000_000)
+		fund(&c, 1, eth(100))
+		for i := uint64(0); i < 130; i++ {
+			c.Transactions = append(c.Transactions,
+				transferTx(1, i, recA, big.NewInt(int64(1000+i)), 21_000, nil))
+		}
+		return c
+	}},
+
+	{"system_contracts_real", bothForks, func(fork string) inputCase {
+		// Real EIP-4788/2935 bytecode (provenance: see constants above).
+		// Ring slots pre-seeded STALE and asserted overwritten by the block's
+		// system calls: 4788 slots time%8191 (timestamp) and +8191 (root),
+		// 2935 slot (number-1)%8191 (parent hash == genesis hash).
+		// Ring WRAP (Genesis.Number=8191) is NOT representable: op-geth
+		// Genesis.Commit rejects number>0 (core/genesis.go:728) -- probed at
+		// runtime via --probe-genesis-number; recorded in README.
+		c := caseFrame(fork, "system_contracts_real",
+			"real EIP-4788/2935 bytecode; pre-seeded stale ring slots overwritten by system calls",
+			defaultFeeParams(), 10_000_000)
+		blockTime := uint64(c.Genesis.Timestamp) + 10
+		blockNumber := uint64(1)
+		slot4788a := common.BigToHash(new(big.Int).SetUint64(blockTime % ringSize))
+		slot4788b := common.BigToHash(new(big.Int).SetUint64(blockTime%ringSize + ringSize))
+		slot2935 := common.BigToHash(new(big.Int).SetUint64((blockNumber - 1) % ringSize))
+		c.Pre[beaconRootsAddr] = types.Account{
+			Balance: big.NewInt(0),
+			Nonce:   1,
+			Code:    beaconRootsCode,
+			Storage: map[common.Hash]common.Hash{
+				slot4788a: common.HexToHash("0xdead000000000000000000000000000000000000000000000000000000000001"),
+				slot4788b: common.HexToHash("0xdead000000000000000000000000000000000000000000000000000000000002"),
+			},
+		}
+		c.Pre[historyStorage] = types.Account{
+			Balance: big.NewInt(0),
+			Nonce:   1,
+			Code:    historyStorageCode,
+			Storage: map[common.Hash]common.Hash{
+				slot2935: common.HexToHash("0xdead000000000000000000000000000000000000000000000000000000000003"),
+			},
+		}
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, recA, eth(1), 21_000, nil))
+		return c
+	}},
+
+	// ----- B-7 order-observable batch: +1 single-fork (isthmus) case = 34 vectors -----
+
+	{"system_call_order_observable", []string{"isthmus"}, func(fork string) inputCase {
+		// B-7 (single fork isthmus, order-observable). Same real EIP-4788/2935
+		// pre-deployment as system_contracts_real (stale ring slots), PLUS a
+		// user reader contract that CALLs the 4788 GET path with the block
+		// timestamp and SSTOREs the returned beacon root into its own slot
+		// t%8191. The 4788 GET path's ts==sload(ts) check passes only after the
+		// block's system call overwrote the stale pre-seeded slot -- so the
+		// stored root (and the reader tx status) is a direct probe of whether
+		// the system call precedes the user tx.
+		c := caseFrame(fork, "system_call_order_observable",
+			"real EIP-4788/2935 bytecode + user reader that CALLs the 4788 GET path and SSTOREs the returned root (order-observable: system call must precede user txs)",
+			defaultFeeParams(), 10_000_000)
+		blockTime := uint64(c.Genesis.Timestamp) + 10
+		blockNumber := uint64(1)
+		slot4788a := common.BigToHash(new(big.Int).SetUint64(blockTime % ringSize))
+		slot4788b := common.BigToHash(new(big.Int).SetUint64(blockTime%ringSize + ringSize))
+		slot2935 := common.BigToHash(new(big.Int).SetUint64((blockNumber - 1) % ringSize))
+		c.Pre[beaconRootsAddr] = types.Account{
+			Balance: big.NewInt(0),
+			Nonce:   1,
+			Code:    beaconRootsCode,
+			Storage: map[common.Hash]common.Hash{
+				slot4788a: common.HexToHash("0xdead000000000000000000000000000000000000000000000000000000000001"),
+				slot4788b: common.HexToHash("0xdead000000000000000000000000000000000000000000000000000000000002"),
+			},
+		}
+		c.Pre[historyStorage] = types.Account{
+			Balance: big.NewInt(0),
+			Nonce:   1,
+			Code:    historyStorageCode,
+			Storage: map[common.Hash]common.Hash{
+				slot2935: common.HexToHash("0xdead000000000000000000000000000000000000000000000000000000000003"),
+			},
+		}
+		c.Pre[readerAddr] = types.Account{Balance: big.NewInt(0), Code: beaconReaderCode}
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, readerAddr, big.NewInt(0), 100_000, nil))
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			readerAddr: {common.BigToHash(new(big.Int).SetUint64(blockTime % ringSize))},
+		}
+		return c
+	}},
+
+	{"first_block", []string{"jovian"}, func(fork string) inputCase {
+		// Jovian activation form: Isthmus-length/selector attributes,
+		// deposits-only, header blobGasUsed == an EXPLICIT 0x0.
+		fp := defaultFeeParams()
+		fp.isthmusLayout = true
+		return caseFrame(fork, "first_block",
+			"Jovian activation block: Isthmus-length attributes, deposits-only, blobGasUsed emitted as explicit 0x0",
+			fp, 10_000_000)
+	}},
+
+	{"da_mix", []string{"jovian"}, func(fork string) inputCase {
+		// Non-zero daFootprintGasScalar; three txs landing on the
+		// estimatedDASizeScaled 100e6 FLOOR branch (plain transfer) and the
+		// LINEAR branch (two calldata sizes) -- per-tx _op_da_footprint
+		// mutually distinct and non-zero.
+		fp := defaultFeeParams()
+		fp.daScalar = 400
+		c := caseFrame(fork, "da_mix",
+			"Jovian DA footprint: floor-branch transfer + two linear-branch calldata txs, distinct non-zero per-tx footprints",
+			fp, 10_000_000)
+		fund(&c, 1, eth(100))
+		fund(&c, 2, eth(100))
+		fund(&c, 3, eth(100))
+		c.Transactions = append(c.Transactions,
+			transferTx(1, 0, recA, eth(1), 21_000, nil),
+			transferTx(2, 0, recA, big.NewInt(0), 200_000, junkData("da_mix small", 300)),
+			transferTx(3, 0, recA, big.NewInt(0), 400_000, junkData("da_mix large", 1200)),
+		)
+		return c
+	}},
+
+	{"fee_env_observer", bothForks, func(fork string) inputCase {
+		// Contract SSTOREs GASPRICE/BASEFEE/SELFBALANCE; operator fee
+		// scalar/constant non-zero, so the Isthmus /1e6 vs Jovian x100
+		// formulas produce different vault balances and per-tx fees.
+		fp := defaultFeeParams()
+		fp.opFeeScalar = 5000
+		fp.opFeeConstant = 7777
+		c := caseFrame(fork, "fee_env_observer",
+			"contract observes GASPRICE/BASEFEE/SELFBALANCE via SSTORE; non-zero operator fee params (fork-specific formula)",
+			fp, 10_000_000)
+		c.Pre[feeObsAddr] = types.Account{Balance: big.NewInt(0), Code: feeObserverCode}
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, feeObsAddr, milliEth(500), 200_000, nil))
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			feeObsAddr: {
+				common.BigToHash(big.NewInt(0)),
+				common.BigToHash(big.NewInt(1)),
+				common.BigToHash(big.NewInt(2)),
+			},
+		}
+		return c
+	}},
+
+	{"gaslimit_observer", bothForks, func(fork string) inputCase {
+		// 触发注入路径 BlockInfo.gasLimit=blockGasLeft vs 块头 gasLimit 的分叉（spec §6.1）。
+		c := caseFrame(fork, "gaslimit_observer",
+			"contract reads GASLIMIT and SSTOREs slot0; injected-path BlockInfo.gasLimit=blockGasLeft diverges from header gasLimit",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[gaslimitObsAddr] = types.Account{Balance: big.NewInt(0), Code: gaslimitObserverCode}
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, gaslimitObsAddr, big.NewInt(0), 200_000, nil))
+		// opt8n-ref postState 校验：contract 执行期写入的每个 slot 都必须由 corpus 声明
+		// （pre storage / extra_storage）。gaslimitObserverCode 仅写 slot 0。
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			gaslimitObsAddr: {common.BigToHash(big.NewInt(0))},
+		}
+		return c
+	}},
+
+	{"deposit_basefee_observer", bothForks, func(fork string) inputCase {
+		// v2（D7）：绿守卫向量——不再触发分叉（Task 4 后 executeDeposit 读 header baseFee），
+		// 验证 deposit 内 BASEFEE 读数三方（A/B/op-geth）一致 == header baseFee，回归保护 Task 4 修复。
+		// spec §6.2 已按 v2 修订为「绿守卫语义」。
+		c := caseFrame(fork, "deposit_basefee_observer",
+			"deposit calls a contract reading BASEFEE; guards that injected path reads header baseFee (Task 4)",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[basefeeObsAddr] = types.Account{Balance: big.NewInt(0), Code: basefeeObserverCode}
+		to := basefeeObsAddr // 审查 R1：inputDeposit.To 是 *common.Address，必须取地址
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType: "deposit",
+			OpDeposit: &inputDeposit{
+				From: userDepositor, To: &to, Gas: 200_000,
+				SourceHash: sourceHash("deposit_basefee_observer " + fork),
+			},
+			Data: hexutil.Bytes{},
+		})
+		// opt8n-ref postState 校验：contract 执行期写入的每个 slot 都必须由 corpus 声明。
+		// basefeeObserverCode 仅写 slot 0。
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			basefeeObsAddr: {common.BigToHash(big.NewInt(0))},
+		}
+		return c
+	}},
+
+	// ----- corpus augmentation (spec rev.3): +3 cases x both forks -----
+
+	{"contract_create", bothForks, func(fork string) inputCase {
+		// Deposit-CREATE + EIP-1559 CREATE. Created addresses are pre-derived
+		// (crypto.CreateAddress; the deposit with its pre-tx nonce) into
+		// extra_candidates and the init-phase slot 0x0 into extra_storage --
+		// the generator's receipt.ContractAddress merge is the runtime second
+		// bottom of the same facts.
+		c := caseFrame(fork, "contract_create",
+			"attributes + deposit-CREATE + EIP-1559 CREATE; initcode SSTOREs slot0 then deploys a 6-byte runtime",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType: "deposit",
+			OpDeposit: &inputDeposit{
+				From:       userDepositor,
+				To:         nil, // deposit-CREATE
+				Gas:        math.HexOrDecimal64(200_000),
+				SourceHash: sourceHash("contract_create " + fork),
+			},
+			Data: createInitCode,
+		})
+		k := privKey(1)
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType:               "eip1559",
+			ChainID:              hd256(chainID),
+			Nonce:                hd64(0),
+			Value:                hd256(big.NewInt(0)),
+			Gas:                  hd64(200_000),
+			MaxFeePerGas:         hdu(2_000_000_000),
+			MaxPriorityFeePerGas: hdu(100_000_000),
+			Data:                 createInitCode,
+			SecretKey:            &k,
+		})
+		depositCreated := crypto.CreateAddress(userDepositor, 0) // pre-tx nonce 0
+		eipCreated := crypto.CreateAddress(addrOfKey(1), 0)
+		c.ExtraCandidates = []common.Address{depositCreated, eipCreated}
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			depositCreated: {common.BigToHash(big.NewInt(0))},
+			eipCreated:     {common.BigToHash(big.NewInt(0))},
+		}
+		return c
+	}},
+
+	{"access_list", bothForks, func(fork string) inputCase {
+		// tx1 carries an EIP-2930 access list against the SLOAD target:
+		// slot0 listed+accessed, slot5 listed-not-accessed, slot2
+		// accessed-NOT-listed (cold-price discriminator), plus a
+		// listed-but-never-called address with an empty key list. tx2 is the
+		// same call WITHOUT a list (narrowed cancellation-surface control).
+		c := caseFrame(fork, "access_list",
+			"attributes + EIP-2930 access-list call (listed/unlisted slot mix) + identical no-list control call",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[aclAddr] = types.Account{
+			Balance: big.NewInt(0),
+			Code:    aclCode,
+			Storage: map[common.Hash]common.Hash{
+				common.BigToHash(big.NewInt(0)): common.BigToHash(big.NewInt(0xa0)),
+				common.BigToHash(big.NewInt(2)): common.BigToHash(big.NewInt(0xa2)),
+			},
+		}
+		fund(&c, 1, eth(100))
+		fund(&c, 2, eth(100))
+		k1 := privKey(1)
+		target := aclAddr
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType:               "eip1559",
+			ChainID:              hd256(chainID),
+			Nonce:                hd64(0),
+			To:                   &target,
+			Value:                hd256(big.NewInt(0)),
+			Gas:                  hd64(100_000),
+			MaxFeePerGas:         hdu(2_000_000_000),
+			MaxPriorityFeePerGas: hdu(100_000_000),
+			AccessList: []outputAccessTuple{
+				{Address: aclAddr, StorageKeys: []common.Hash{
+					common.BigToHash(big.NewInt(0)),
+					common.BigToHash(big.NewInt(5)),
+				}},
+				{Address: aclListedOnly, StorageKeys: []common.Hash{}},
+			},
+			SecretKey: &k1,
+		},
+			transferTx(2, 0, aclAddr, big.NewInt(0), 100_000, nil),
+		)
+		return c
+	}},
+
+	{"setcode_7702_skips", bothForks, func(fork string) inputCase {
+		// Four-tuple skip matrix: [valid, chainId=9999 (signed), nonce=99
+		// (signed), raw-override rawYParity=5 (marked structurally
+		// unrecoverable)]. The valid tuple's applied delegation code on the
+		// authority is the postState byte-for-byte anchor (Task 1 rule (3));
+		// the three skipped tuples still cost 7702 intrinsic gas x4 -- a
+		// discarded marked tuple would show up as receipts[i].gasUsed red.
+		c := caseFrame(fork, "setcode_7702_skips",
+			"attributes + EIP-7702 tx with non-empty access list and 4 tuples: valid + chainId-mismatch + nonce-mismatch + structurally-unrecoverable (marked)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		authority := addrOfKey(4)
+		c.Pre[authority] = types.Account{Balance: eth(1)}
+		c.Pre[delegateAddr] = types.Account{Balance: big.NewInt(0), Code: delegateCode}
+		sponsorKey := privKey(1)
+		authKey4 := privKey(4)
+		authKey5 := privKey(5)
+		authKey6 := privKey(6)
+		rawY := hexutil.Uint64(5)
+		rawOne := (*hexutil.Big)(big.NewInt(1))
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType:               "setcode",
+			ChainID:              hd256(chainID),
+			Nonce:                hd64(0),
+			To:                   &authority,
+			Value:                hd256(big.NewInt(0)),
+			Gas:                  hd64(300_000),
+			MaxFeePerGas:         hdu(2_000_000_000),
+			MaxPriorityFeePerGas: hdu(100_000_000),
+			AccessList: []outputAccessTuple{
+				{Address: delegateAddr, StorageKeys: []common.Hash{
+					common.BigToHash(big.NewInt(0)),
+				}},
+			},
+			SecretKey: &sponsorKey,
+			OpAuthorizations: []inputAuthorization{
+				{ // applies: delegation anchor on the authority
+					ChainID:       hd256(chainID),
+					Address:       delegateAddr,
+					Nonce:         0,
+					AuthSecretKey: authKey4,
+				},
+				{ // skipped: chain-id mismatch (signature itself valid)
+					ChainID:       hd256(big.NewInt(9999)),
+					Address:       delegateAddr,
+					Nonce:         0,
+					AuthSecretKey: authKey5,
+				},
+				{ // skipped: authority nonce mismatch (signature itself valid)
+					ChainID:       hd256(chainID),
+					Address:       delegateAddr,
+					Nonce:         99,
+					AuthSecretKey: authKey6,
+				},
+				{ // skipped: raw override, structurally unrecoverable (marked)
+					ChainID:             hd256(chainID),
+					Address:             delegateAddr,
+					Nonce:               0,
+					SignerUnrecoverable: true,
+					RawYParity:          &rawY,
+					RawR:                rawOne,
+					RawS:                rawOne,
+				},
+			},
+		})
+		c.ExtraCandidates = []common.Address{delegateAddr}
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			authority: {common.BigToHash(big.NewInt(1))},
+		}
+		return c
+	}},
+
+	// ----- defer-sweep batch: +1 case x both forks = 33 vectors -----
+
+	{"empty_account_cleanup", bothForks, func(fork string) inputCase {
+		// EIP-161 touch-delete corpus case. Pre seeds an exists-but-empty
+		// account (balance 0, nonce 0, no code, no storage): genesis
+		// flushAlloc commits with deleteEmptyObjects=false (core/genesis.go),
+		// so the account IS materialized in the genesis trie (probed against
+		// op-geth @ e8800cffe: Exist=true/Empty=true at genesis, and the
+		// genesis root differs from the same alloc without it). A zero-value
+		// 21000-gas CALL touches it; at block commit (EIP-158 active) it is
+		// deleted, so op-geth's postState emits the vanished candidate as the
+		// trie-semantic zero account {"balance":"0x0"}.
+		// Honest gate boundary: the replay's postState comparison
+		// canonicalizes empty == absent (OpT8nReplayTest.cpp postState
+		// rules), so a replay that DROPPED the delete would still stay green
+		// on this vector -- it is NOT a delete-vs-keep discriminator on its
+		// own. The deletion is pinned instead by (a) the gold side (op-geth
+		// InsertChain self-check generated this vector from a state where
+		// the delete provably happens), (b) the tx-level unit test
+		// OpStateDiffSanitize.RealEmptyAccountDeleteSurvivesSanitize, and
+		// (c) the block-level GTest
+		// OpStateDiffSanitize.BlockLevelRealDeleteSurvivesSanitize.
+		c := caseFrame(fork, "empty_account_cleanup",
+			"attributes + zero-value CALL touching a pre-seeded exists-but-empty account (EIP-161 touch-delete; postState emits the zero account)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		c.Pre[emptyTouchAddr] = types.Account{Balance: big.NewInt(0)}
+		c.Transactions = append(c.Transactions,
+			transferTx(1, 0, emptyTouchAddr, big.NewInt(0), 21_000, nil))
+		return c
+	}},
+
+	// ----- Phase 2 line A: formula-boundary cases (Task 3 Step 1) -----
+	// Ecotone/Fjord run at EVMC_CANCUN (PragueTime nilled together with
+	// IsthmusTime): NO 7702/setcode arm, rev = CANCUN. The transfer carries
+	// calldata so the L1 formula is meaningfully exercised (a data-less
+	// transfer would sit on the FastLZ/Ecotone floor and not discriminate).
+
+	{"transfer_basic", []string{"ecotone"}, func(fork string) inputCase {
+		c := caseFrame(fork, "transfer_basic",
+			"Ecotone formula boundary: attributes + EIP-1559 transfer with calldata (activates the Ecotone calldata-gas L1 formula; l1_gas_used > floor)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, recA, eth(1), 100_000, junkData("ecotone_transfer_basic", 200)))
+		return c
+	}},
+
+	{"contract_create", []string{"ecotone"}, func(fork string) inputCase {
+		// EIP-1559 CREATE: the initcode IS the tx calldata, so the Ecotone
+		// calldata formula charges against it; created address pre-derived into
+		// extra_candidates and its init-phase slot 0x0 into extra_storage.
+		c := caseFrame(fork, "contract_create",
+			"Ecotone formula boundary: attributes + EIP-1559 CREATE (initcode calldata exercises the Ecotone L1 formula)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		k := privKey(1)
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType:               "eip1559",
+			ChainID:              hd256(chainID),
+			Nonce:                hd64(0),
+			Value:                hd256(big.NewInt(0)),
+			Gas:                  hd64(200_000),
+			MaxFeePerGas:         hdu(2_000_000_000),
+			MaxPriorityFeePerGas: hdu(100_000_000),
+			Data:                 createInitCode,
+			SecretKey:            &k,
+		})
+		eipCreated := crypto.CreateAddress(addrOfKey(1), 0)
+		c.ExtraCandidates = []common.Address{eipCreated}
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			eipCreated: {common.BigToHash(big.NewInt(0))},
+		}
+		return c
+	}},
+
+	{"transfer_basic", []string{"fjord"}, func(fork string) inputCase {
+		c := caseFrame(fork, "transfer_basic",
+			"Fjord formula boundary: attributes + EIP-1559 transfer with calldata (activates the FastLZ linear-regression L1 formula; l1_gas_used via estimatedDASizeScaled)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, recA, eth(1), 100_000, junkData("fjord_transfer_basic", 200)))
+		return c
+	}},
+
+	{"contract_create", []string{"fjord"}, func(fork string) inputCase {
+		c := caseFrame(fork, "contract_create",
+			"Fjord formula boundary: attributes + EIP-1559 CREATE (initcode calldata exercises the FastLZ L1 formula)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		k := privKey(1)
+		c.Transactions = append(c.Transactions, inputTx{
+			OpType:               "eip1559",
+			ChainID:              hd256(chainID),
+			Nonce:                hd64(0),
+			Value:                hd256(big.NewInt(0)),
+			Gas:                  hd64(200_000),
+			MaxFeePerGas:         hdu(2_000_000_000),
+			MaxPriorityFeePerGas: hdu(100_000_000),
+			Data:                 createInitCode,
+			SecretKey:            &k,
+		})
+		eipCreated := crypto.CreateAddress(addrOfKey(1), 0)
+		c.ExtraCandidates = []common.Address{eipCreated}
+		c.ExtraStorage = map[common.Address][]common.Hash{
+			eipCreated: {common.BigToHash(big.NewInt(0))},
+		}
+		return c
+	}},
+
+	// ----- Phase 2 line A: upgrade-boundary cases (Task 3 Step 2, spec A2) -----
+	// chainConfigSpec expressed via _info.activations (base = _info.hardfork).
+	// 10-second coupling: genesis timestamp 1000 (= T-5), blockTime 1010
+	// (= genesis+10 = T+5) -- the single block is the FIRST block of the new
+	// fork (1000 < 1005 <= 1010 holds).
+
+	{"upgrade_fjord_activation", []string{"ecotone"}, func(fork string) inputCase {
+		// L1 formula switch: Ecotone calldata formula -> Fjord FastLZ. The
+		// block (timestamp 1010) is Fjord; l1_gas_used reflects the FastLZ
+		// estimatedDASizeScaled model instead of bedrockCalldataGasUsed.
+		c := upgradeFrame("ecotone", "upgrade_fjord_activation",
+			"upgrade boundary ecotone->fjord: genesis Ecotone, single block crosses FjordTime; calldataGas -> FastLZ formula switch observable in l1_gas_used",
+			defaultFeeParams(), 10_000_000, "fjord", 1005)
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, recA, eth(1), 100_000, junkData("upgrade_fjord_activation", 200)))
+		return c
+	}},
+
+	{"upgrade_isthmus_activation", []string{"fjord"}, func(fork string) inputCase {
+		// Operator fee introduced: genesis Fjord, single block crosses
+		// IsthmusTime. Non-zero operator fee params -> the operator fee is
+		// charged for the first time (gasUsed*scalar/1e6 + constant, Isthmus
+		// formula), and the receipt emits the operator field group.
+		fp := defaultFeeParams()
+		fp.opFeeScalar = 5000
+		fp.opFeeConstant = 7777
+		c := upgradeFrame("fjord", "upgrade_isthmus_activation",
+			"upgrade boundary fjord->isthmus: genesis Fjord, single block crosses IsthmusTime; operator fee first charged (Isthmus formula, non-zero scalar/constant)",
+			fp, 10_000_000, "isthmus", 1005)
+		fund(&c, 1, eth(100))
+		c.Transactions = append(c.Transactions, transferTx(1, 0, recA, eth(1), 100_000, junkData("upgrade_isthmus_activation", 64)))
+		return c
+	}},
+
+	{"upgrade_jovian_activation", []string{"isthmus"}, func(fork string) inputCase {
+		// DA fields appear: genesis Isthmus, single block crosses JovianTime.
+		// Deposits-ONLY + Isthmus-length/selector attributes (fp.isthmusLayout):
+		// op-geth CalcDAFootprint (rollup_cost.go:568-575) hard-requires this
+		// shape for the first Jovian block (176B -> no non-deposit txs -> DA
+		// footprint 0). Header BlobGasUsed = 0.
+		fp := defaultFeeParams()
+		fp.isthmusLayout = true
+		c := upgradeFrame("isthmus", "upgrade_jovian_activation",
+			"upgrade boundary isthmus->jovian: genesis Isthmus, single block crosses JovianTime; deposits-only with Isthmus-length attributes (CalcDAFootprint activation form), DA fields appear in header semantics",
+			fp, 10_000_000, "jovian", 1005)
+		return c
+	}},
+
+	// ----- Phase 2 line B: precompile vectors (Task 1, 13 cases) -----
+	// Step 1: base-7 normal vectors (fork=isthmus, tx gas 500_000). Each input
+	// is genuinely valid (probe-confirmed) so the precompile returns success.
+	basePrecompileCase("precompile_ecrecover",
+		"ecrecover (0x01): real secp256k1 signature recovering to key 1; hash = sha256(\"fisco line-b ecrecover\")",
+		preEcRecover, validEcrecoverInput),
+	basePrecompileCase("precompile_sha256",
+		"sha256 (0x02): 4-byte input 0xdeadbeef",
+		preSha256, deadbeefInput),
+	basePrecompileCase("precompile_ripemd160",
+		"ripemd160 (0x03): 4-byte input 0xdeadbeef",
+		preRipemd160, deadbeefInput),
+	basePrecompileCase("precompile_identity",
+		"identity (0x04): 4-byte input 0xdeadbeef (returns it verbatim)",
+		preIdentity, deadbeefInput),
+	basePrecompileCase("precompile_expmod",
+		"modexp (0x05): 96B zero-header (baseLen=expLen=modLen=0) -> success; empty output (EIP-198 baseLen==modLen==0 rule)",
+		preExpMod, expmodZeroHeader),
+	basePrecompileCase("precompile_blake2f",
+		"blake2f (0x09): EIP-152 vector 5 (rounds=12, h=IV^0x01010040, m=\"abc\", final=1)",
+		preBlake2f, validBlake2fInput),
+	basePrecompileCase("precompile_point_evaluation",
+		"kzg point evaluation (0x0a): valid EIP-4844 proof (192B, validKZGInput)",
+		prePointEval, validKZGInput()),
+
+	// Step 2: bn256 add/mul normal vectors (fork=isthmus, tx gas 500_000).
+	basePrecompileCase("precompile_bn256add",
+		"bn256 add (0x06): two valid G1 points (128B input; RequiredGas 150)",
+		preBn256Add, bn256AddInput),
+	basePrecompileCase("precompile_bn256mul",
+		"bn256 scalar mul (0x07): valid G1 + scalar 0x02 (96B input; RequiredGas 6000)",
+		preBn256Mul, bn256MulInput),
+
+	// Step 3: bn256 pairing 4-cap matrix (cap discriminators, block gas 30M).
+	{"precompile_bn256pair_norm", []string{"isthmus"}, func(fork string) inputCase {
+		// One valid pair (192B): well under the granite cap (112687) that is
+		// active at isthmus; pairing check runs and returns (status 1).
+		return precompileFrame(fork, "precompile_bn256pair_norm",
+			"bn256 pairing (0x08): one valid pair (192B) succeeds at isthmus (granite-cap active, 192 << 112687)",
+			[]inputTx{precompileCallTx(addrBytes(preBn256Pairing), repeatedBn256Pair(1), 500_000, 0)},
+			10_000_000).build(fork)
+	}},
+	{"precompile_bn256pair_overcap", []string{"granite"}, func(fork string) inputCase {
+		// 587 pairs = 112704B > granite cap 112687 -> bn256PairingGranite.Run
+		// returns errBadPairingInputSize AFTER charging RequiredGas (20,003,000)
+		// -> status 0, ALL call gas consumed (gasUsed = tx gas). tx gas clears
+		// intrinsic + RequiredGas so the CAP check (not an OOG) is what fires.
+		return precompileFrame(fork, "precompile_bn256pair_overcap",
+			"bn256 pairing over granite cap: 587 pairs (112704B > 112687) rejected with errBadPairingInputSize after charging RequiredGas",
+			[]inputTx{precompileCallTx(addrBytes(preBn256Pairing), repeatedBn256Pair(587), bn256PairOvercapGas587, 0)},
+			30_000_000).build(fork)
+	}},
+	{"precompile_bn256pair_overcap", []string{"jovian"}, func(fork string) inputCase {
+		// 428 pairs = 82176B > jovian cap 81984 (and <= granite's 112687):
+		// DISCRIMINATES jovian's tighter cap from granite's. Same cap-path
+		// semantics as granite (errBadPairingInputSize, status 0, all gas).
+		return precompileFrame(fork, "precompile_bn256pair_overcap",
+			"bn256 pairing over jovian cap: 428 pairs (82176B > 81984, <= granite 112687) rejected with errBadPairingInputSize (tighter cap than granite)",
+			[]inputTx{precompileCallTx(addrBytes(preBn256Pairing), repeatedBn256Pair(428), bn256PairOvercapGas428, 0)},
+			30_000_000).build(fork)
+	}},
+	{"precompile_bn256pair_large_success", []string{"fjord"}, func(fork string) inputCase {
+		// No cap at fjord (bn256PairingIstanbul): 587 VALID pairs SUCCEED
+		// (status 1, 32B output). Proves the 112687B cap appears only at
+		// granite+ (same input as the granite over-cap case diverges).
+		return precompileFrame(fork, "precompile_bn256pair_large_success",
+			"bn256 pairing large input: 587 valid pairs (112704B) SUCCEED at fjord (no cap yet; granite+ introduces the 112687B cap)",
+			[]inputTx{precompileCallTx(addrBytes(preBn256Pairing), repeatedBn256Pair(587), bn256PairOvercapGas587, 0)},
+			30_000_000).build(fork)
+	}},
+}
+
+// vectorName maps a spec x fork to the checked-in file base name (matches
+// vectors/manifest.txt; note the two Jovian-only cases keep their plan names
+// jovian_first_block / jovian_da_mix).
+func vectorName(fork, name string) string {
+	return fork + "_" + name
+}
+
+// emitableSpecs returns the caseSpecs that --write-cases emits: the shared
+// table minus bScopeSpecs entries (Task 3 F1: legacy_transfer must not be
+// emitted until the T8n replayer has a legacy consumer arm).
+func emitableSpecs() []caseSpec {
+	out := make([]caseSpec, 0, len(caseSpecs))
+	for _, spec := range caseSpecs {
+		if bScopeSpecs[spec.name] {
+			continue
+		}
+		out = append(out, spec)
+	}
+	return out
+}
+
+func emitCases(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	count := 0
+	for _, spec := range emitableSpecs() {
+		for _, fork := range spec.forks {
+			c := spec.build(fork)
+			raw, err := json.MarshalIndent(&c, "", "  ")
+			if err != nil {
+				return err
+			}
+			raw = append(raw, '\n')
+			path := filepath.Join(dir, vectorName(fork, spec.name)+".in.json")
+			if err := os.WriteFile(path, raw, 0o644); err != nil {
+				return err
+			}
+			count++
+		}
+	}
+	fmt.Printf("wrote %d case files to %s\n", count, dir)
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// §4b invalid-tx kinds (Task 4). INDEPENDENT table — MUST NOT enter the shared
+// caseSpecs/emitCases (review R7): GenerateChainWithGenesis.AddTx rejects an
+// invalid tx outright, so a shared entry would make --write-cases emit an
+// .in.json the valid pipeline cannot regenerate. The invalid-tx generation
+// path (buildInvalidTxBlock) hand-rolls txRoot/blockHash instead.
+// ---------------------------------------------------------------------
+
+// invalidTxBuilder builds the invalid non-deposit tx (a *types.Transaction)
+// AND its block.transactions structured output object (the replayer's
+// loadBlockContext three-arm loader). The output object is authoritative: the
+// replayer reads the STRUCTURED fields to build the evmone tx and keeps _op_raw
+// as the signed EIP-2718 envelope for opValidate's L1-cost derivation.
+type invalidTxBuilder func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error)
+
+// invalidTxCaseSpec describes one §4b kind. consumer follows review R16:
+// decode-level kinds (blob) are consumer:"both" (engine decode message is the
+// validation_error_contains anchor); every other kind is consumer:"executor"
+// (the engine RTTI-bypass collapses the tx-level message to a generic one, so
+// the T8n throw assertion is the ONLY transaction-level semantic anchor).
+type invalidTxCaseSpec struct {
+	kind     string
+	forks    []string
+	consumer string // "executor" | "both"
+	opGeth   string // op-geth rejection message substring (weak anchor)
+	t8n      string // T8n throw message substring (validation_error_contains)
+	decode   string // FISCO raw-tx decode message (decode-level kinds only; blob)
+	build    func(fork string) (inputCase, invalidTxBuilder)
+}
+
+// invalidTxKinds returns the kind names for diagnostics.
+func invalidTxKinds() []string {
+	out := make([]string, len(invalidTxCaseSpecs))
+	for i := range invalidTxCaseSpecs {
+		out[i] = invalidTxCaseSpecs[i].kind
+	}
+	return out
+}
+
+// ptrBytes returns a *hexutil.Bytes for an inputTx SecretKey.
+func ptrBytes(b hexutil.Bytes) *hexutil.Bytes { return &b }
+
+var invalidTxCaseSpecs = []invalidTxCaseSpec{
+	// intrinsic_gas: EIP-1559 value transfer with gas=0 < 21000 intrinsic.
+	{"intrinsic_gas", bothForks, "executor", "intrinsic gas too low", "intrinsic gas too low", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_intrinsic_gas",
+			"deposit + gas=0 EIP-1559 tx (intrinsic gas too low)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			k := privKey(1)
+			to := recA
+			in := inputTx{
+				OpType: "eip1559", ChainID: hd256(chainID), Nonce: hd64(0), To: &to,
+				Value: hdu(0), Gas: hd64(0), // gas=0 → intrinsic gas too low
+				MaxFeePerGas: hdu(2_000_000_000), MaxPriorityFeePerGas: hdu(100_000_000),
+				Data: nil, SecretKey: &k,
+			}
+			return buildTx(&in, signer, cfg)
+		}
+	}},
+
+	// nonce_low: tx nonce 0 < account nonce 1 (pre-state raises the nonce).
+	{"nonce_low", bothForks, "executor", "nonce too low", "nonce too low", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_nonce_low",
+			"deposit + nonce-0 EIP-1559 tx against account nonce 1 (nonce too low)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		c.Pre[addrOfKey(1)] = types.Account{Balance: eth(100), Nonce: 1}
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			k := privKey(1)
+			to := recA
+			in := inputTx{
+				OpType: "eip1559", ChainID: hd256(chainID), Nonce: hd64(0), To: &to,
+				Value: hdu(0), Gas: hd64(21_000),
+				MaxFeePerGas: hdu(2_000_000_000), MaxPriorityFeePerGas: hdu(100_000_000),
+				Data: nil, SecretKey: &k,
+			}
+			return buildTx(&in, signer, cfg)
+		}
+	}},
+
+	// nonce_high: tx nonce 5 > account nonce 0.
+	{"nonce_high", bothForks, "executor", "nonce too high", "nonce too high", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_nonce_high",
+			"deposit + nonce-5 EIP-1559 tx against account nonce 0 (nonce too high)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			k := privKey(1)
+			to := recA
+			in := inputTx{
+				OpType: "eip1559", ChainID: hd256(chainID), Nonce: hd64(5), To: &to,
+				Value: hdu(0), Gas: hd64(21_000),
+				MaxFeePerGas: hdu(2_000_000_000), MaxPriorityFeePerGas: hdu(100_000_000),
+				Data: nil, SecretKey: &k,
+			}
+			return buildTx(&in, signer, cfg)
+		}
+	}},
+
+	// insufficient_funds: balance 1 ETH < value 2 ETH (+ gas + L1 cost).
+	{"insufficient_funds", bothForks, "executor", "insufficient funds for gas * price + value", "insufficient funds for gas * price + value", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_insufficient_funds",
+			"deposit + 2-ETH value transfer from a 1-ETH account (insufficient funds)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(1))
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			k := privKey(1)
+			to := recA
+			in := inputTx{
+				OpType: "eip1559", ChainID: hd256(chainID), Nonce: hd64(0), To: &to,
+				Value: hd256(eth(2)), Gas: hd64(21_000),
+				MaxFeePerGas: hdu(2_000_000_000), MaxPriorityFeePerGas: hdu(100_000_000),
+				Data: nil, SecretKey: &k,
+			}
+			return buildTx(&in, signer, cfg)
+		}
+	}},
+
+	// fee_cap_low: maxFeePerGas 0.5 gwei < baseFee 1 gwei (London preCheck).
+	{"fee_cap_low", bothForks, "executor", "max fee per gas less than block base fee", "max fee per gas less than block base fee", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_fee_cap_low",
+			"deposit + 0.5-gwei maxFeePerGas tx under 1-gwei base fee (fee cap less than base fee)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			k := privKey(1)
+			to := recA
+			in := inputTx{
+				OpType: "eip1559", ChainID: hd256(chainID), Nonce: hd64(0), To: &to,
+				Value: hdu(0), Gas: hd64(21_000),
+				MaxFeePerGas: hdu(500_000_000), MaxPriorityFeePerGas: hdu(100_000_000),
+				Data: nil, SecretKey: &k,
+			}
+			return buildTx(&in, signer, cfg)
+		}
+	}},
+
+	// sender_no_eoa: sender address carries code (EIP-3607).
+	{"sender_no_eoa", bothForks, "executor", "sender not an eoa", "sender not an eoa", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_sender_no_eoa",
+			"deposit + EIP-1559 tx from a contract account (sender not an eoa)",
+			defaultFeeParams(), 10_000_000)
+		c.Pre[addrOfKey(1)] = types.Account{Balance: eth(100), Code: revertCode}
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			k := privKey(1)
+			to := recA
+			in := inputTx{
+				OpType: "eip1559", ChainID: hd256(chainID), Nonce: hd64(0), To: &to,
+				Value: hdu(0), Gas: hd64(21_000),
+				MaxFeePerGas: hdu(2_000_000_000), MaxPriorityFeePerGas: hdu(100_000_000),
+				Data: nil, SecretKey: &k,
+			}
+			return buildTx(&in, signer, cfg)
+		}
+	}},
+
+	// setcode_create: EIP-7702 create (ErrSetCodeTxCreate). A real signed
+	// SetCodeTx envelope cannot express nil To (To() is always non-nil), so the
+	// STRUCTURED tx carries to:null (→ evmone CREATE_SET_CODE_TX) while the
+	// _op_raw envelope is a setcode tx to the zero address. op_geth anchor is
+	// documentation-only (the error is not reachable through a real envelope).
+	{"setcode_create", bothForks, "executor", "EIP-7702 transaction cannot be used to create contract", "set code transaction must not be a create transaction", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_setcode_create",
+			"deposit + EIP-7702 create tx (structured to:null → set code tx must not be a create)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			prv, from, err := parseKey(ptrBytes(privKey(1)))
+			if err != nil {
+				return nil, nil, err
+			}
+			auth, err := types.SignSetCode(prv, types.SetCodeAuthorization{
+				ChainID: *uint256.MustFromBig(chainID),
+				Address: recA,
+				Nonce:   0,
+			})
+			if err != nil {
+				return nil, nil, fmt.Errorf("setcode_create: SignSetCode: %w", err)
+			}
+			tx := types.MustSignNewTx(prv, signer, &types.SetCodeTx{
+				ChainID:   uint256.MustFromBig(chainID),
+				Nonce:     0,
+				GasTipCap: uint256.MustFromBig(big.NewInt(100_000_000)),
+				GasFeeCap: uint256.MustFromBig(big.NewInt(2_000_000_000)),
+				Gas:       100_000,
+				To:        common.Address{}, // envelope can't express nil To; structured to:null carries the create
+				Value:     uint256.NewInt(0),
+				Data:      nil,
+				AuthList:  []types.SetCodeAuthorization{auth},
+			})
+			rawBin, err := tx.MarshalBinary()
+			if err != nil {
+				return nil, nil, err
+			}
+			outJSON, err := json.Marshal(outputSetCodeTxCreate{
+				OpType:  "setcode",
+				OpRaw:   hexutil.Encode(rawBin),
+				ChainID: (*math.HexOrDecimal256)(chainID), Nonce: math.HexOrDecimal64(0),
+				To:                   nil, // → replayer builds to:nullopt → CREATE_SET_CODE_TX
+				Gas:                  math.HexOrDecimal64(100_000),
+				MaxFeePerGas:         (*math.HexOrDecimal256)(big.NewInt(2_000_000_000)),
+				MaxPriorityFeePerGas: (*math.HexOrDecimal256)(big.NewInt(100_000_000)),
+				Value:                (*math.HexOrDecimal256)(big.NewInt(0)),
+				Data:                 hexutil.Bytes{},
+				Sender:               from,
+				OpAuthorizationList: []outputAuthorization{{
+					ChainID: (*math.HexOrDecimal256)(chainID),
+					Address: recA,
+					Nonce:   math.HexOrDecimal64(0),
+					YParity: math.HexOrDecimal64(auth.V),
+					R:       (*math.HexOrDecimal256)(auth.R.ToBig()),
+					S:       (*math.HexOrDecimal256)(auth.S.ToBig()),
+				}},
+			})
+			return tx, outJSON, err
+		}
+	}},
+
+	// empty_auth_list: EIP-7702 tx with an EMPTY authorization list.
+	{"empty_auth_list", bothForks, "executor", "EIP-7702 transaction with empty auth list", "empty authorization list", "", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_empty_auth_list",
+			"deposit + EIP-7702 tx with empty auth list (empty authorization list)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			prv, from, err := parseKey(ptrBytes(privKey(1)))
+			if err != nil {
+				return nil, nil, err
+			}
+			tx := types.MustSignNewTx(prv, signer, &types.SetCodeTx{
+				ChainID:   uint256.MustFromBig(chainID),
+				Nonce:     0,
+				GasTipCap: uint256.MustFromBig(big.NewInt(100_000_000)),
+				GasFeeCap: uint256.MustFromBig(big.NewInt(2_000_000_000)),
+				Gas:       100_000,
+				To:        recA,
+				Value:     uint256.NewInt(0),
+				Data:      nil,
+				AuthList:  []types.SetCodeAuthorization{},
+			})
+			rawBin, err := tx.MarshalBinary()
+			if err != nil {
+				return nil, nil, err
+			}
+			outJSON, err := json.Marshal(outputSetCodeTx{
+				OpType:  "setcode",
+				OpRaw:   hexutil.Encode(rawBin),
+				ChainID: (*math.HexOrDecimal256)(chainID), Nonce: math.HexOrDecimal64(0),
+				To:                   recA,
+				Gas:                  math.HexOrDecimal64(100_000),
+				MaxFeePerGas:         (*math.HexOrDecimal256)(big.NewInt(2_000_000_000)),
+				MaxPriorityFeePerGas: (*math.HexOrDecimal256)(big.NewInt(100_000_000)),
+				Value:                (*math.HexOrDecimal256)(big.NewInt(0)),
+				Data:                 hexutil.Bytes{},
+				Sender:               from,
+				OpAuthorizationList:  []outputAuthorization{},
+			})
+			return tx, outJSON, err
+		}
+	}},
+
+	// blob: type-3 blob tx. op-geth OP rejects at txpool ("transaction type
+	// not supported") and at block validation ("data blobs present in block
+	// body"); FISCO rejects at raw-tx DECODE ("unsupported tx type byte 0x03").
+	// consumer:"both" (review R16) — the decode message is a reliable engine
+	// validationError surface.
+	{"blob", bothForks, "both", "data blobs present in block body", "unsupported tx type byte 0x03", "unsupported tx type byte 0x03", func(fork string) (inputCase, invalidTxBuilder) {
+		c := caseFrame(fork, "invalid_blob",
+			"deposit + type-3 blob tx (OP rejects blobs; FISCO decode fails)",
+			defaultFeeParams(), 10_000_000)
+		fund(&c, 1, eth(100))
+		return c, func(signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+			prv, from, err := parseKey(ptrBytes(privKey(1)))
+			if err != nil {
+				return nil, nil, err
+			}
+			blobHash := common.HexToHash("0x0101010101010101010101010101010101010101010101010101010101010101")
+			// The OP Isthmus signer EXPLICITLY unsets BlobTxType (it is an
+			// invalid-tx kind on OP chains), so sign the envelope with the
+			// Cancun signer instead — the tx is rejected at decode/block
+			// validation before signature validity is ever consulted.
+			blobSigner := types.NewCancunSigner(chainID)
+			tx := types.MustSignNewTx(prv, blobSigner, &types.BlobTx{
+				ChainID:    uint256.MustFromBig(chainID),
+				Nonce:      0,
+				GasTipCap:  uint256.MustFromBig(big.NewInt(100_000_000)),
+				GasFeeCap:  uint256.MustFromBig(big.NewInt(2_000_000_000)),
+				Gas:        100_000,
+				To:         recA,
+				Value:      uint256.NewInt(0),
+				Data:       nil,
+				BlobFeeCap: uint256.MustFromBig(big.NewInt(1_000_000_000)),
+				BlobHashes: []common.Hash{blobHash},
+				Sidecar:    nil, // block body blob txs must NOT carry a sidecar (block_validator.go:99)
+			})
+			rawBin, err := tx.MarshalBinary()
+			if err != nil {
+				return nil, nil, err
+			}
+			outJSON, err := json.Marshal(outputBlobTx{
+				OpType:  "blob",
+				OpRaw:   hexutil.Encode(rawBin),
+				ChainID: (*math.HexOrDecimal256)(chainID), Nonce: math.HexOrDecimal64(0),
+				To:                   &recA,
+				Gas:                  math.HexOrDecimal64(100_000),
+				MaxFeePerGas:         (*math.HexOrDecimal256)(big.NewInt(2_000_000_000)),
+				MaxPriorityFeePerGas: (*math.HexOrDecimal256)(big.NewInt(100_000_000)),
+				BlobFeeCap:           (*math.HexOrDecimal256)(big.NewInt(1_000_000_000)),
+				BlobHashes:           []common.Hash{blobHash},
+				Value:                (*math.HexOrDecimal256)(big.NewInt(0)),
+				Data:                 hexutil.Bytes{},
+				Sender:               from,
+			})
+			return tx, outJSON, err
+		}
+	}},
+}

--- a/opstack-executor/tests/t8n/generator/cases_precompile_bls.go
+++ b/opstack-executor/tests/t8n/generator/cases_precompile_bls.go
@@ -1,0 +1,306 @@
+// BLS12-381 precompile vectors (Phase 2 line B Task 2): 14 caseSpecs --
+// 7 normal (fork=isthmus), 6 cap-over-limit (3 isthmus + 3 jovian), 1 no-op
+// (fork=fjord). Registered into the shared caseSpecs table via init(); the
+// Task 1 file cases.go owns its own 13 and peer files
+// cases_precompile_p256.go / cases_precompile_wrapper.go (Tasks 3/4) own
+// theirs -- each init() appends, so the slices never collide.
+//
+// EIP-2537 UNCOMPRESSED encodings (both sides authoritative; mirrors core/vm
+// decodeBLS12381FieldElement / encodePointG1/G2):
+//
+//	Fp = 64B (16 zero || 48B big-endian; 381-bit field)
+//	G1 = 128B (x,y in Fp), G2 = 256B (x,y in Fp2, each c0||c1 in Fp)
+//	G1MSM element = G1 128B + scalar 32B = 160B
+//	G2MSM element = G2 256B + scalar 32B = 288B
+//	pairing pair  = G1 128B + G2 256B = 384B
+//	mapG1 input   = Fp 64B, mapG2 input = Fp2 128B
+//
+// Gas (op-geth params/protocol_params.go:174-181 + core/vm RequiredGas):
+//
+//	G1Add 375, G1MSM k*12000*discount/1000, G2Add 600,
+//	G2MSM k*22500*discount/1000, pairing 37700+32600*k, mapG1 5500, mapG2 23800.
+//
+// The 6 over-cap inputs are the SMALLEST element-multiple strictly exceeding
+// the fork's cap (isthmus 513760/488448/235008, jovian 288960/278784/156672;
+// caps are strictly `len > cap`). The cap check lives inside Run AFTER
+// RequiredGas is charged (RunPrecompiledContract deducts RequiredGas first),
+// so the tx gas limit must clear intrinsic + RequiredGas(over-cap input) --
+// otherwise the call OOGs at the gas cost and never reaches the cap check.
+package main
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+func init() {
+	caseSpecs = append(caseSpecs, blsPrecompileCases()...)
+	if os.Getenv("OPT8N_PROBE_BLS") == "1" {
+		blsProbeEvidence()
+		os.Exit(0)
+	}
+}
+
+// ---------------------------------------------------------------------
+// BLS gas helpers (mirror op-geth core/vm RequiredGas)
+// ---------------------------------------------------------------------
+
+const (
+	blsG1MulGas = params.Bls12381G1MulGas          // 12000
+	blsG2MulGas = params.Bls12381G2MulGas          // 22500
+	blsPairBase = params.Bls12381PairingBaseGas    // 37700
+	blsPairPerK = params.Bls12381PairingPerPairGas // 32600
+	// Discount-table floors: for k >= 128 (the table length) RequiredGas uses
+	// the LAST entry (519 G1 / 524 G2). Every over-cap vector has k in the
+	// thousands, so the floor applies.
+	blsG1Discount = 519
+	blsG2Discount = 524
+)
+
+// blsG1MSMGas is the G1 MSM RequiredGas for k points at the discount-table
+// floor (k >= 128). Mirrors bls12381G1MultiExp.RequiredGas.
+func blsG1MSMGas(k int) uint64 {
+	if k < 128 {
+		panic("blsG1MSMGas: discount floor only valid for k >= 128")
+	}
+	return uint64(k) * blsG1MulGas * blsG1Discount / 1000
+}
+
+// blsG2MSMGas is the G2 MSM RequiredGas for k points at the discount-table
+// floor (k >= 128). Mirrors bls12381G2MultiExp.RequiredGas.
+func blsG2MSMGas(k int) uint64 {
+	if k < 128 {
+		panic("blsG2MSMGas: discount floor only valid for k >= 128")
+	}
+	return uint64(k) * blsG2MulGas * blsG2Discount / 1000
+}
+
+// blsPairingGas is the pairing RequiredGas for k pairs.
+func blsPairingGas(k int) uint64 {
+	return blsPairBase + uint64(k)*blsPairPerK
+}
+
+// txIntrinsicGas is the EIP-2028 intrinsic gas for an eip1559 tx carrying the
+// given calldata (21000 base + 16/non-zero-byte + 4/zero-byte). OP-stack
+// charges this FIRST (core/state_transition.go:563), before the precompile
+// call's RequiredGas -- so a cap vector's tx gas must be
+// intrinsic + RequiredGas + margin or the call OOGs at the gas cost.
+func txIntrinsicGas(data []byte) uint64 {
+	var nz, z uint64
+	for _, b := range data {
+		if b == 0 {
+			z++
+		} else {
+			nz++
+		}
+	}
+	return 21000 + 16*nz + 4*z
+}
+
+// ---------------------------------------------------------------------
+// EIP-2537 input construction (valid content; see precompile_inputs.go)
+// ---------------------------------------------------------------------
+
+// blsScalar2 is the 32-byte big-endian scalar 0x02 used by the MSM vectors.
+func blsScalar2() []byte { return common.BigToHash(big.NewInt(2)).Bytes() }
+
+// blsG1MSMInput returns k copies of (valid G1 point || scalar 0x02) = 160B each.
+func blsG1MSMInput(k int) []byte {
+	elem := append(validBlsG1(), blsScalar2()...)
+	if len(elem) != 160 {
+		panic("blsG1MSMInput: element length mismatch")
+	}
+	return repeatedPair(elem, k)
+}
+
+// blsG2MSMInput returns k copies of (valid G2 point || scalar 0x02) = 288B each.
+func blsG2MSMInput(k int) []byte {
+	elem := append(validBlsG2(), blsScalar2()...)
+	if len(elem) != 288 {
+		panic("blsG2MSMInput: element length mismatch")
+	}
+	return repeatedPair(elem, k)
+}
+
+// blsPairInput returns k copies of (valid G1 || valid G2) = 384B each.
+func blsPairInput(k int) []byte {
+	pair := append(validBlsG1(), validBlsG2()...)
+	if len(pair) != 384 {
+		panic("blsPairInput: pair length mismatch")
+	}
+	return repeatedPair(pair, k)
+}
+
+// blsMapG1Input returns one Fp element (64B): the generator G1's x-coordinate
+// (validBlsG1()[0:64] IS the 64B Fp-slot encoding, 16 zero || 48B).
+func blsMapG1Input() []byte { return validBlsG1()[:64] }
+
+// blsMapG2Input returns one Fp2 element (128B): the generator G2's
+// x-coordinate (validBlsG2()[0:128] IS the c0||c1 Fp2 encoding).
+func blsMapG2Input() []byte { return validBlsG2()[:128] }
+
+// ---------------------------------------------------------------------
+// Case list (14)
+// ---------------------------------------------------------------------
+
+func blsPrecompileCases() []caseSpec {
+	// ---- Step 1: 7 normal vectors (fork=isthmus, tx gas 500_000) ----
+	// basePrecompileCase covers intrinsic + RequiredGas for every input here
+	// (max pairing RequiredGas 70,300). Each input is genuinely valid
+	// (probe-confirmed below) so the precompile succeeds.
+	normal := []caseSpec{
+		basePrecompileCase("precompile_bls_g1add",
+			"bls12-381 g1 add (0x0b): two valid G1 points (256B input; RequiredGas 375)",
+			preBlsG1Add, repeatedPair(validBlsG1(), 2)),
+		basePrecompileCase("precompile_bls_g1msm",
+			"bls12-381 g1 multi-scalar-mul (0x0c): 2 valid (G1, scalar 0x02) pairs (320B input; RequiredGas 22776)",
+			preBlsG1MSM, blsG1MSMInput(2)),
+		basePrecompileCase("precompile_bls_g2add",
+			"bls12-381 g2 add (0x0d): two valid G2 points (512B input; RequiredGas 600)",
+			preBlsG2Add, repeatedPair(validBlsG2(), 2)),
+		basePrecompileCase("precompile_bls_g2msm",
+			"bls12-381 g2 multi-scalar-mul (0x0e): 2 valid (G2, scalar 0x02) pairs (576B input; RequiredGas 45000)",
+			preBlsG2MSM, blsG2MSMInput(2)),
+		basePrecompileCase("precompile_bls_pairing",
+			"bls12-381 pairing check (0x0f): one valid (G1, G2) pair (384B input; RequiredGas 70300)",
+			preBlsPairing, blsPairInput(1)),
+		basePrecompileCase("precompile_bls_map_g1",
+			"bls12-381 map to G1 (0x10): one Fp element, the generator G1 x-coordinate (64B input; RequiredGas 5500)",
+			preBlsMapG1, blsMapG1Input()),
+		basePrecompileCase("precompile_bls_map_g2",
+			"bls12-381 map to G2 (0x11): one Fp2 element, the generator G2 x-coordinate (128B input; RequiredGas 23800)",
+			preBlsMapG2, blsMapG2Input()),
+	}
+
+	// ---- Step 2: 6 cap-over-limit vectors ----
+	// Each input is the smallest element-multiple strictly exceeding the fork's
+	// cap. Run's cap check (len > cap) fires AFTER RequiredGas is charged, so
+	// tx gas clears intrinsic + RequiredGas + margin; block gas 30M. Status 0,
+	// ALL call gas consumed (RunPrecompiledContract zeroes gas on precompile
+	// error -- vm/evm.go:390), so receipt gasUsed == tx gas.
+	overcap := []caseSpec{
+		blsOvercapCase("precompile_bls_g1msm_overcap", "isthmus", preBlsG1MSM,
+			blsG1MSMInput(3212), params.Bls12381G1MulMaxInputSizeIsthmus, blsG1MSMGas(3212)),
+		blsOvercapCase("precompile_bls_g2msm_overcap", "isthmus", preBlsG2MSM,
+			blsG2MSMInput(1697), params.Bls12381G2MulMaxInputSizeIsthmus, blsG2MSMGas(1697)),
+		blsOvercapCase("precompile_bls_pairing_overcap", "isthmus", preBlsPairing,
+			blsPairInput(613), params.Bls12381PairingMaxInputSizeIsthmus, blsPairingGas(613)),
+		blsOvercapCase("precompile_bls_g1msm_overcap", "jovian", preBlsG1MSM,
+			blsG1MSMInput(1807), params.Bls12381G1MulMaxInputSizeJovian, blsG1MSMGas(1807)),
+		blsOvercapCase("precompile_bls_g2msm_overcap", "jovian", preBlsG2MSM,
+			blsG2MSMInput(969), params.Bls12381G2MulMaxInputSizeJovian, blsG2MSMGas(969)),
+		blsOvercapCase("precompile_bls_pairing_overcap", "jovian", preBlsPairing,
+			blsPairInput(409), params.Bls12381PairingMaxInputSizeJovian, blsPairingGas(409)),
+	}
+
+	// ---- Step 3: fjord no-op (BLS inactive) ----
+	// At fjord the BLS precompiles are NOT active (PrecompiledContractsFjord
+	// has no 0x0b), so calling 0x0b hits empty code: EVMC_SUCCESS, full call
+	// gas refunded, empty output. Receipt status 1 with gasUsed == intrinsic.
+	noop := []caseSpec{
+		precompileFrame("fjord", "precompile_bls_noop",
+			"bls12-381 g1 add at fjord (0x0b, BLS not yet active): empty-code no-op -> status 1, full gas refunded, empty output",
+			[]inputTx{precompileCallTx(addrBytes(preBlsG1Add), repeatedPair(validBlsG1(), 2), 500_000, 0)},
+			10_000_000),
+	}
+
+	out := make([]caseSpec, 0, len(normal)+len(overcap)+len(noop))
+	out = append(out, normal...)
+	out = append(out, overcap...)
+	out = append(out, noop...)
+	return out
+}
+
+// blsOvercapCase builds one BLS cap-over-limit vector. input is the over-cap
+// byte string (len > capBytes); required is the precompile's own RequiredGas
+// for that input. tx gas = intrinsic + required + 100_000 margin so the call
+// reaches Run's cap check (errBLS12381Max*) instead of OOG-ing at the gas
+// cost; block gas 30M (the ~20M-class required gas needs it).
+func blsOvercapCase(name, fork string, addr uint, input []byte, capBytes, required uint64) caseSpec {
+	gas := txIntrinsicGas(input) + required + 100_000
+	desc := fmt.Sprintf(
+		"bls12-381 over-cap (%s): %dB input > %dB cap; RequiredGas %d; Run returns the max-size error -> status 0, all call gas consumed",
+		name, len(input), capBytes, required)
+	return precompileFrame(fork, name, desc,
+		[]inputTx{precompileCallTx(addrBytes(addr), input, gas, 0)},
+		30_000_000)
+}
+
+// ---------------------------------------------------------------------
+// Direct precompile-Run probe (OPT8N_PROBE_BLS=1, Task 2 Step 4 evidence)
+// ---------------------------------------------------------------------
+
+// blsProbeEvidence feeds every BLS input to the REAL op-geth precompile Run
+// from the fork's registry (PrecompiledContractsIsthmus / Jovian -- the
+// registries that actually carry the cap variants) and prints acceptance/cap
+// evidence. The 6 over-cap inputs MUST return the max-size cap error (proving
+// the cap path fires, not a decode error); the 7 normal inputs MUST Run clean.
+// Gated by OPT8N_PROBE_BLS=1 so normal generator runs are unaffected.
+func blsProbeEvidence() {
+	isthmus := vm.PrecompiledContractsIsthmus
+	jovian := vm.PrecompiledContractsJovian
+	pc := func(m vm.PrecompiledContracts, n uint) vm.PrecompiledContract {
+		c, ok := m[common.BytesToAddress(addrBytes(n))]
+		if !ok {
+			panic(fmt.Sprintf("bls probe: no precompile at 0x%x in registry", n))
+		}
+		return c
+	}
+
+	type check struct {
+		label  string
+		addr   uint
+		pc     vm.PrecompiledContract
+		input  []byte
+		wantOK bool // true: expect Run success; false: expect a max-size cap error
+	}
+	checks := []check{
+		{"isthmus G1Add", preBlsG1Add, pc(isthmus, preBlsG1Add), repeatedPair(validBlsG1(), 2), true},
+		{"isthmus G1MSM k=2", preBlsG1MSM, pc(isthmus, preBlsG1MSM), blsG1MSMInput(2), true},
+		{"isthmus G2Add", preBlsG2Add, pc(isthmus, preBlsG2Add), repeatedPair(validBlsG2(), 2), true},
+		{"isthmus G2MSM k=2", preBlsG2MSM, pc(isthmus, preBlsG2MSM), blsG2MSMInput(2), true},
+		{"isthmus Pairing k=1", preBlsPairing, pc(isthmus, preBlsPairing), blsPairInput(1), true},
+		{"isthmus MapG1", preBlsMapG1, pc(isthmus, preBlsMapG1), blsMapG1Input(), true},
+		{"isthmus MapG2", preBlsMapG2, pc(isthmus, preBlsMapG2), blsMapG2Input(), true},
+
+		{"isthmus G1MSM k=3212 over-cap", preBlsG1MSM, pc(isthmus, preBlsG1MSM), blsG1MSMInput(3212), false},
+		{"isthmus G2MSM k=1697 over-cap", preBlsG2MSM, pc(isthmus, preBlsG2MSM), blsG2MSMInput(1697), false},
+		{"isthmus Pairing k=613 over-cap", preBlsPairing, pc(isthmus, preBlsPairing), blsPairInput(613), false},
+		{"jovian G1MSM k=1807 over-cap", preBlsG1MSM, pc(jovian, preBlsG1MSM), blsG1MSMInput(1807), false},
+		{"jovian G2MSM k=969 over-cap", preBlsG2MSM, pc(jovian, preBlsG2MSM), blsG2MSMInput(969), false},
+		{"jovian Pairing k=409 over-cap", preBlsPairing, pc(jovian, preBlsPairing), blsPairInput(409), false},
+	}
+
+	// No-op confirmation: at fjord 0x0b is NOT in the fjord registry -> the
+	// call hits empty code (no-op success), not a BLS precompile.
+	if _, ok := vm.PrecompiledContractsFjord[common.BytesToAddress(addrBytes(preBlsG1Add))]; ok {
+		panic("bls probe: 0x0b unexpectedly present in the fjord precompile registry")
+	}
+	fmt.Printf("  ok    0x0b absent from PrecompiledContractsFjord (empty-code no-op at fjord)\n")
+
+	fail := 0
+	for _, c := range checks {
+		out, err := c.pc.Run(c.input)
+		switch {
+		case c.wantOK && err != nil:
+			fmt.Printf("  FAIL  %-34s Run error: %v\n", c.label, err)
+			fail++
+		case !c.wantOK && err == nil:
+			fmt.Printf("  FAIL  %-34s expected max-size cap error, got success (out %dB)\n", c.label, len(out))
+			fail++
+		case c.wantOK:
+			fmt.Printf("  ok    %-34s Run ok, output %dB (RequiredGas=%d)\n", c.label, len(out), c.pc.RequiredGas(c.input))
+		default:
+			fmt.Printf("  ok    %-34s Run err=%q (RequiredGas=%d)\n", c.label, err.Error(), c.pc.RequiredGas(c.input))
+		}
+	}
+	if fail > 0 {
+		panic(fmt.Sprintf("blsProbeEvidence: %d check(s) FAILED", fail))
+	}
+	fmt.Printf("bls probe: all %d checks passed (cap path confirmed for the 6 over-cap inputs)\n", len(checks))
+}

--- a/opstack-executor/tests/t8n/generator/cases_precompile_p256.go
+++ b/opstack-executor/tests/t8n/generator/cases_precompile_p256.go
@@ -1,0 +1,53 @@
+// RIP-7212 secp256r1 P256VERIFY (0x0100) precompile vectors (Phase 2 line B,
+// Task 3). Four cases spanning the p256Verify semantics matrix:
+//
+//	fjord_precompile_p256_valid     valid signature (160B) -> 32-byte-1, precompile gas 3450
+//	fjord_precompile_p256_invalid   wrong r (160B)         -> empty-output SUCCESS, precompile gas 3450
+//	fjord_precompile_p256_wronglen  159B                   -> empty-output SUCCESS, precompile gas 3450
+//	ecotone_precompile_p256_noop    valid sig, pre-Fjord   -> no-op, full gas, empty output
+//
+// p256Verify.Run (op-geth core/vm/contracts.go:1717-1733): requires exactly
+// 160 bytes; wrong length OR invalid signature returns (nil, nil) = empty
+// SUCCESS; a valid signature returns 32-byte-1. FISCO p256verify_execute
+// (bcos-evm/eth/state/precompiles.cpp:753-775) matches. At ecotone the
+// precompile is not yet in the active set (Fjord is the first OP fork to bind
+// 0x0100, core/vm/contracts.go:182-193; activePrecompiledContracts falls back
+// to PrecompiledContractsCancun), so the CALL hits an empty-code account:
+// no-op success, full gas returned, empty output.
+package main
+
+// invalidP256Sig returns a structurally valid 160B P256VERIFY input with a
+// WRONG signature: the valid sig's r with its first byte flipped (0x1a ->
+// 0x1b). r stays in [1, N-1] but no longer satisfies the ECDSA equation, so
+// secp256r1.Verify returns false and p256Verify.Run returns (nil, nil) =
+// empty-output success.
+func invalidP256Sig() []byte {
+	in := append([]byte(nil), validP256Sig()...)
+	in[32] ^= 0x01
+	return in
+}
+
+// wrongLenP256Sig is the valid signature truncated to 159 bytes -- one byte
+// short of p256Verify's 160B requirement (len != 160 -> (nil, nil)).
+var wrongLenP256Sig = validP256Sig()[:159]
+
+func init() {
+	caseSpecs = append(caseSpecs,
+		precompileFrame("fjord", "precompile_p256_valid",
+			"RIP-7212 P256VERIFY (0x0100): valid secp256r1 signature (160B = hash||r||s||x||y, validP256Sig) -> success, 32-byte-1 output; precompile gas 3450",
+			[]inputTx{precompileCallTx(addrBytes(preP256Verify), validP256Sig(), 500_000, 0)},
+			10_000_000),
+		precompileFrame("fjord", "precompile_p256_invalid",
+			"RIP-7212 P256VERIFY (0x0100): structurally valid 160B input with WRONG r (first byte of valid r flipped) -> empty-output success (nil,nil); precompile gas 3450",
+			[]inputTx{precompileCallTx(addrBytes(preP256Verify), invalidP256Sig(), 500_000, 0)},
+			10_000_000),
+		precompileFrame("fjord", "precompile_p256_wronglen",
+			"RIP-7212 P256VERIFY (0x0100): 159B input (valid signature truncated by 1B) -> empty-output success (len != 160 -> nil,nil); precompile gas 3450",
+			[]inputTx{precompileCallTx(addrBytes(preP256Verify), wrongLenP256Sig, 500_000, 0)},
+			10_000_000),
+		precompileFrame("ecotone", "precompile_p256_noop",
+			"RIP-7212 P256VERIFY (0x0100) BEFORE Fjord activation (ecotone): 0x0100 has no code -> no-op success, full gas returned, empty output (no 3450 charged)",
+			[]inputTx{precompileCallTx(addrBytes(preP256Verify), validP256Sig(), 500_000, 0)},
+			10_000_000),
+	)
+}

--- a/opstack-executor/tests/t8n/generator/cases_precompile_wrapper.go
+++ b/opstack-executor/tests/t8n/generator/cases_precompile_wrapper.go
@@ -1,0 +1,250 @@
+// Wrapper-contract CALL-semantics precompile vectors (Phase 2 line B Task 4).
+//
+// Five cases exercise the CALL path from a wrapper CONTRACT into a precompile
+// (as opposed to the Task-1 direct-call vectors): EIP-150 63/64 gas
+// forwarding, returndata-size truncation, value-bearing revert propagation,
+// the OpHost cap-before-value early return (net-semantics regression pin), and
+// EIP-7702 delegation to a precompile address.
+//
+// The wrapper bytecode is built by buildPrecompileWrapper (below); its
+// disassembly was verified against the op-geth opcode table (see the Task 4
+// report). It differs from the task brief's sketch in three ways, all required
+// for the stated semantics to actually hold:
+//
+//  1. CALLDATACOPY: the brief's sketch read mem[0:CALLDATASIZE] as the inner
+//     call's input, but calldata is never auto-copied to memory -- without
+//     CALLDATACOPY the precompile would receive zero bytes (p256 verify would
+//     fail, bn256 add would return the point-at-infinity). The builder copies
+//     calldata to mem[0:cd] first, pushing length FIRST (CALLDATACOPY pops
+//     memOffset, then dataOffset, then length -- geth opCallDataCopy).
+//  2. CALL operand order: the sketch pushed (CALLDATASIZE PUSH0 PUSH0 PUSH1
+//     0x20 PUSH20<addr> ... GAS CALL), which geth's opCall pops as
+//     gas, addr=0, value=addr (calling address 0 with the precompile address
+//     as value). The builder pushes retSize, retOffset, inSize, inOffset,
+//     value, to, gas (the verified bottom-to-top order, same as the proven
+//     beaconReaderCode precedent).
+//  3. Revert-on-failure: the sketch's always-RETURN wrapper would yield tx
+//     status 1 for the value-bearing failure cases, but the case table (and
+//     the "revert 传播" acceptance) require status 0. The builder REVERTs
+//     when the inner CALL returns 0, propagating the precompile failure.
+//  4. RETURN operand order: the sketch's tail ... PUSH0 PUSH1 0x20 RETURN
+//     pops offset=0x20, size=0 (geth opReturn pops offset first), returning
+//     mem[32:0] = EMPTY -- so even the success path returned no data. The
+//     builder pushes size then offset (PUSH1 0x20 PUSH0 RETURN) and drops the
+//     pointless PUSH0 MLOAD.
+package main
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Wrapper-contract and EIP-7702-authority addresses (continuation of the
+// cases.go:51-56 c0de series; distinct range so peer Tasks 2/3 files cannot
+// collide).
+var (
+	wrapAddr63 = common.HexToAddress("0xc0de000000000000000000000000000000000007")
+	wrapAddrRd = common.HexToAddress("0xc0de000000000000000000000000000000000009")
+	wrapAddrVr = common.HexToAddress("0xc0de00000000000000000000000000000000000a")
+	wrapAddrVo = common.HexToAddress("0xc0de00000000000000000000000000000000000b")
+)
+
+// malformedBn256AddInput is a 128-byte bn256 add (0x06) input whose two G1
+// points are both (x=1, y=3) -- NOT on alt_bn128 (y^2 = 9 != x^3+3 = 4). Both
+// op-geth's newCurvePoint and FISCO's ecadd_execute reject it, so the
+// precompile genuinely FAILS (EVMC_PRECOMPILE_FAILURE / "point is not on
+// curve"), driving the wrapper's revert path.
+//
+// The task brief's value_revert row specified 0x100 (P256VERIFY) with a
+// "malformed in-cap sig", but that precompile NEVER fails: op-geth
+// p256Verify.Run returns (nil, nil) for both wrong-length and failed-verify
+// input (contracts.go:1709-1731), and FISCO p256verify_execute returns
+// {EVMC_SUCCESS, 0} for the same (precompiles.cpp:753-771) -- a malformed
+// p256 input yields SUCCESS with empty output, not a revert. The only failure
+// path of the 0x100 gas-override branch is the OOG check (OpHost.cpp:20-26,
+// msg.gas < 3450), which would make the case a knife-edge gas test. 0x06 was
+// chosen instead: a real precompile error, in-cap (generous gas), with the
+// same observable net semantics the brief wants (value rolled back, wrapper
+// status 0).
+var malformedBn256AddInput = func() []byte {
+	in := make([]byte, 128)
+	in[31] = 1 // point1 x = 1
+	in[63] = 3 // point1 y = 3
+	in[95] = 1 // point2 x = 1
+	in[127] = 3 // point2 y = 3
+	return in
+}()
+
+// buildPrecompileWrapper assembles the canonical wrapper runtime bytecode:
+//
+//	CALLDATACOPY mem[0:cd] = calldata
+//	CALL <precompile> with gas=GAS (EIP-150 caps to 63/64), value = 0 or
+//	    CALLVALUE, in = mem[0:CALLDATASIZE] (the wrapper's own calldata),
+//	    out = mem[0:32] (only the first 32 bytes of returndata are copied --
+//	    the returndata-size quirk)
+//	on CALL success: RETURN mem[0:32]
+//	on CALL failure: REVERT (propagates the precompile failure -> tx status 0)
+//
+// Disassembly (verified against op-geth's opcode table; Task 4 report):
+//
+//	0000 CALLDATASIZE   length(CALLDATACOPY)
+//	0001 PUSH0          dataOffset(CALLDATACOPY)
+//	0002 PUSH0          memOffset(CALLDATACOPY)
+//	0003 CALLDATACOPY   mem[0:cd] = calldata
+//	0004 PUSH1 0x20     retSize
+//	0006 PUSH0          retOffset
+//	0007 CALLDATASIZE   inSize
+//	0008 PUSH0          inOffset
+//	0009 PUSH0/CALLVALUE value
+//	000a PUSH20 <addr>  to
+//	001f GAS            gas
+//	0020 CALL           -> [success]
+//	0021 PUSH2 0x28     dest
+//	0024 JUMPI          if success -> 0x28
+//	0025 PUSH0 PUSH0 REVERT   failure path
+//	0028 JUMPDEST
+//	0029 PUSH1 0x20     size(RETURN)
+//	002b PUSH0          offset(RETURN)
+//	002c RETURN         mem[0:32]
+func buildPrecompileWrapper(addr []byte, withValue bool) []byte {
+	head := hexutil.MustDecode("0x365f5f3760205f365f") // CALLDATASIZE PUSH0 PUSH0 CALLDATACOPY PUSH1 0x20 PUSH0 CALLDATASIZE PUSH0
+	var value byte = 0x5f                              // PUSH0 (value = 0)
+	if withValue {
+		value = 0x34 // CALLVALUE
+	}
+	tail := hexutil.MustDecode("0x5af1610028575f5ffd5b60205ff3") // GAS CALL PUSH2 0x28 JUMPI PUSH0 PUSH0 REVERT JUMPDEST PUSH1 0x20 PUSH0 RETURN
+	out := append(append(head, value), 0x73)                      // PUSH20 <addr>
+	out = append(out, addr...)
+	return append(out, tail...)
+}
+
+// wrapperFrame is precompileFrame + the wrapper contract pre-deployed at wrap
+// (code + balance) and a single user tx appended after the attributes deposit.
+// key 1 is the tx sender (precompileFrame funds it eth(100)); the wrapper's
+// balance covers the value-bearing cases' 1-wei inner transfer.
+func wrapperFrame(fork, name, desc string, wrap common.Address, code []byte, tx inputTx, blockGasLimit uint64) caseSpec {
+	return caseSpec{
+		name:  name,
+		forks: []string{fork},
+		build: func(f string) inputCase {
+			c := caseFrame(f, name, desc, defaultFeeParams(), blockGasLimit)
+			fund(&c, 1, eth(100))
+			c.Pre[wrap] = types.Account{Code: code, Balance: eth(1)}
+			c.Transactions = append(c.Transactions, tx)
+			c.ExtraCandidates = append(c.ExtraCandidates, wrap)
+			return c
+		},
+	}
+}
+
+func init() {
+	caseSpecs = append(caseSpecs,
+
+		// ist: 0x100 P256VERIFY, valid sig, no value. The wrapper CALLs with
+		// gas=GAS (EIP-150 63/64 of remaining); the precompile's 3450 is
+		// covered by the forwarded gas, the verify succeeds, and the wrapper
+		// returns the 32-byte-1 the precompile wrote. gasUsed therefore
+		// reflects: intrinsic + wrapper overhead + CALL cost + 3450 (the p256
+		// consumption charged against the 63/64-forwarded gas).
+		wrapperFrame("isthmus", "precompile_wrap_63of64",
+			"wrapper contract CALLs P256VERIFY (0x100) with a valid sig, gas=GAS (EIP-150 63/64 forwarding); precompile's 3450 covered by forwarded gas; wrapper returns the 32-byte-1 success output",
+			wrapAddr63, buildPrecompileWrapper(addrBytes(preP256Verify), false),
+			precompileCallTx(wrapAddr63.Bytes(), validP256Sig(), 500_000, 0),
+			10_000_000),
+
+		// ist: 0x06 bn256 add, valid 2-point input, no value. The precompile
+		// returns the 64-byte G1 sum; the wrapper's CALL copies only the first
+		// 32 bytes (retSize 0x20) into mem[0:32] and returns them -- the
+		// receipt output is the 32-byte x-coordinate, NOT the full 64-byte
+		// point (returndata-size truncation quirk).
+		//
+		// NOTE: the brief's table lists 0x08 "valid pair" here, but 0x08
+		// (bn256 pairing) returns 32 bytes -- a 32-of-32 copy is not an
+		// observable truncation. The behavior column ("bn256 add 输出 64B")
+		// and the returndata-size quirk require the 64-byte-output 0x06, which
+		// takes two valid G1 points ("a pair" of points).
+		wrapperFrame("isthmus", "precompile_wrap_returndata",
+			"wrapper contract CALLs bn256 add (0x06) with two valid G1 points; 64B output truncated to the first 32B by the CALL's retSize (returndata-size quirk) -- receipt output is the x-coordinate only",
+			wrapAddrRd, buildPrecompileWrapper(addrBytes(preBn256Add), false),
+			precompileCallTx(wrapAddrRd.Bytes(), bn256AddInput, 500_000, 0),
+			10_000_000),
+
+		// jov: 0x06 bn256 add, malformed off-curve input, value 1 wei. The
+		// precompile genuinely fails (invalid point -> EVMC_PRECOMPILE_FAILURE
+		// on FISCO / "point is not on curve" on op-geth); the value transfer is
+		// rolled back on both sides and the wrapper REVERTs, propagating the
+		// failure -> tx status 0, no balance residue on 0x06. (0x100 was not
+		// usable: P256VERIFY never errors on malformed input -- see
+		// malformedBn256AddInput comment.)
+		wrapperFrame("jovian", "precompile_wrap_value_revert",
+			"wrapper contract CALLs bn256 add (0x06) with a malformed off-curve point and value 1 wei; precompile errors -> value rolled back, wrapper REVERT propagates the failure (tx status 0, no balance residue)",
+			wrapAddrVr, buildPrecompileWrapper(addrBytes(preBn256Add), true),
+			precompileCallTx(wrapAddrVr.Bytes(), malformedBn256AddInput, 500_000, 1),
+			10_000_000),
+
+		// jov: 0x08 bn256 pairing, 428 pairs (82176B > jovian cap 81984),
+		// value 1 wei. OpHost's length-limit early return fires BEFORE value
+		// application (cap 先于 value) and returns EVMC_FAILURE with 0 gas
+		// (all forwarded gas consumed); op-geth transfers the value then
+		// reverts it and zeroes the call gas. NET SEMANTICS are identical:
+		// status 0, forwarded gas fully consumed, no value residue on 0x08.
+		// tx gas 17M ensures the forwarded gas (63/64 of remaining after
+		// intrinsic 1,007,112 + wrapper overhead + CALL cost) clears the
+		// precompile's RequiredGas(428)=14,597,000 so the CAP CHECK (not an
+		// OOG) is what fires -- the path this case pins.
+		wrapperFrame("jovian", "precompile_wrap_value_overcap",
+			"wrapper contract CALLs bn256 pairing (0x08) with an over-cap 428-pair input and value 1 wei; OpHost length-limit early return fires before value application -> status 0, all forwarded gas consumed, no value residue (net-semantics regression pin)",
+			wrapAddrVo, buildPrecompileWrapper(addrBytes(preBn256Pairing), true),
+			precompileCallTx(wrapAddrVo.Bytes(), repeatedBn256Pair(428), 17_000_000, 1),
+			30_000_000),
+
+		// ist: EIP-7702 setcode arm. The setcode tx (sponsor key 1) installs on
+		// the authority (key 7) a delegation designator pointing at the 0x08
+		// precompile; the tx then executes the delegated code -- empty (0x08
+		// carries no state code). A second user tx calls the authority; FISCO's
+		// state.cpp resolves the delegation (code_address=0x08, EVMC_DELEGATED)
+		// and OpHost's EVMC_DELEGATED branch runs empty code instead of the
+		// precompile. BOTH txs succeed (status 1) with empty output and no
+		// storage writes -- the "双端执行空码" observable.
+		caseSpec{"precompile_wrap_eip7702", []string{"isthmus"}, func(fork string) inputCase {
+			c := caseFrame(fork, "precompile_wrap_eip7702",
+				"EIP-7702 setcode tx installs a delegation designator to the 0x08 precompile on the authority; setcode tx AND a user call to the authority both execute EMPTY code (EVMC_DELEGATED branch) -- status 1, no storage, no precompile execution",
+				defaultFeeParams(), 10_000_000)
+			fund(&c, 1, eth(100))
+			authority := addrOfKey(7)
+			c.Pre[authority] = types.Account{Balance: eth(1)}
+			sponsorKey := privKey(1)
+			authKey := privKey(7)
+			precompileAddr := common.BytesToAddress(addrBytes(preBn256Pairing))
+			// Tx 1: setcode. Authorization signed by key 7 (the authority),
+			// address = the 0x08 precompile -> the authority's code becomes
+			// 0xef0100||0x08 (types.AddressToDelegation). The tx then executes
+			// the delegated code (empty).
+			c.Transactions = append(c.Transactions, inputTx{
+				OpType:               "setcode",
+				ChainID:              hd256(chainID),
+				Nonce:                hd64(0),
+				To:                   &authority,
+				Value:                hd256(big.NewInt(0)),
+				Gas:                  hd64(300_000),
+				MaxFeePerGas:         hdu(2_000_000_000),
+				MaxPriorityFeePerGas: hdu(100_000_000),
+				SecretKey:            &sponsorKey,
+				OpAuthorizations: []inputAuthorization{{
+					ChainID:       hd256(chainID),
+					Address:       precompileAddr,
+					Nonce:         0,
+					AuthSecretKey: authKey,
+				}},
+			})
+			// Tx 2: user call to the authority (key 1, nonce 1). Delegation
+			// resolves to the precompile -> empty code -> success, empty output.
+			c.Transactions = append(c.Transactions, transferTx(1, 1, authority, big.NewInt(0), 100_000, nil))
+			c.ExtraCandidates = append(c.ExtraCandidates, authority)
+			return c
+		}},
+	)
+}

--- a/opstack-executor/tests/t8n/generator/ensure-vectors.sh
+++ b/opstack-executor/tests/t8n/generator/ensure-vectors.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# =============================================================================
+# 确保 opstack t8n 参考向量落地：op-geth@pin 就位（复用或克隆）→ 跑 regen.sh。
+#
+# 本地与 CI 共用同一逻辑：GitHub composite action (.github/actions/opstack-t8n-regen)
+# 只负责 GitHub 专属部分（actions/setup-go + actions/cache），然后委托本脚本，
+# 因此「本地跑本脚本 == CI 里 composite action 的行为」。
+#
+# 用法
+#   bash opstack-executor/tests/t8n/generator/ensure-vectors.sh
+#   OPGETH=/path/to/op-geth bash .../ensure-vectors.sh   # 指定现有 op-geth checkout
+#   ./.../ensure-vectors.sh                              # 脚本可执行后直接跑
+#
+# 环境变量
+#   OPGETH           op-geth checkout 路径。缺省用 ${OPGETH_CACHE_DIR}/op-geth-<pin>
+#                    （默认 ~/.cache/op-geth/op-geth-<pin>，自动克隆并钉住 pin）。
+#   OPGETH_CACHE_DIR 覆盖本地缓存目录（仅当 OPGETH 未设置时生效）。
+#   OPGETH_PIN       覆盖 pin；缺省从 regen.sh 提取（单一事实源）。
+#
+# 退出码
+#   0  = 向量已生成且 regen.sh 全部校验通过；非 0 = 失败（见 regen.sh 判据）。
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+REGEN="$REPO_ROOT/opstack-executor/tests/t8n/generator/regen.sh"
+[ -f "$REGEN" ] || { echo "找不到 regen.sh: $REGEN" >&2; exit 1; }
+
+PIN="${OPGETH_PIN:-$(sed -nE 's/^PIN="([0-9a-f]{40})"/\1/p' "$REGEN")}"
+[ -n "$PIN" ] || { echo "无法从 regen.sh 提取 PIN" >&2; exit 1; }
+
+USER_OPGETH="${OPGETH:-}"   # 用户显式传入则视为自有 checkout，绝不删除
+if [ -z "$USER_OPGETH" ]; then
+  CACHE_ROOT="${OPGETH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/op-geth}"
+  OPGETH="$CACHE_ROOT/op-geth-$PIN"
+fi
+
+command -v go >/dev/null 2>&1 || { echo "需要 Go 工具链（regen.sh 要在 op-geth 模块内 go build）" >&2; exit 1; }
+
+# 确保 $OPGETH 是一个 HEAD==pin 且干净（regen.sh 两条前置）的 checkout。
+#   - 已就位且 pin 正确：清理 regen 遗留产物（cmd/opt8n-ref 目录 + 顶层二进制），
+#     保证 git status 干净后复用。
+#   - 未就位：浅克隆（--filter=blob:none）→ fetch 精确 SHA → checkout。
+#   - 已就位但 pin 不符：
+#       用户显式传入（$USER_OPGETH）→ 视为自有 checkout，直接报错，绝不删除；
+#       脚本自管缓存目录 → 视为陈旧缓存，rm -rf 后重建。
+ensure_opgeth() {
+  local existing=""
+  [ -d "$OPGETH/.git" ] && existing="$(git -C "$OPGETH" rev-parse HEAD 2>/dev/null || true)"
+  if [ -n "$existing" ] && [ "$existing" = "$PIN" ]; then
+    echo "复用 op-geth@${PIN:0:8}: $OPGETH"
+    git -C "$OPGETH" clean -fdx -- cmd/opt8n-ref >/dev/null 2>&1 || true
+    rm -f "$OPGETH/opt8n-ref"
+  elif [ -n "$existing" ] && [ -n "$USER_OPGETH" ]; then
+    echo "OPGETH 指向的 checkout 在 ${existing:0:8}，需要 ${PIN:0:8}。请改用正确 pin 的 checkout，或不要设置 OPGETH 让脚本管理缓存目录。" >&2
+    exit 1
+  else
+    mkdir -p "$(dirname "$OPGETH")"
+    rm -rf "$OPGETH"
+    echo "克隆 op-geth@${PIN:0:8} -> $OPGETH"
+    git clone --filter=blob:none https://github.com/ethereum-optimism/op-geth "$OPGETH"
+    git -C "$OPGETH" fetch --depth 1 origin "$PIN"
+    git -C "$OPGETH" checkout FETCH_HEAD
+  fi
+}
+
+ensure_opgeth
+echo ">>> 运行 regen.sh（OPGETH=${OPGETH}）"
+OPGETH="$OPGETH" bash "$REGEN"

--- a/opstack-executor/tests/t8n/generator/main.go
+++ b/opstack-executor/tests/t8n/generator/main.go
@@ -1,0 +1,3967 @@
+// Command opt8n-ref is the M-B3+M6 block-level OP-Stack vector generator for
+// bcos-evm-ref. It drives op-geth AS A LIBRARY (checkout pinned in
+// _op_test_vectors.generator_commit) through the exact block-building +
+// re-validation pipeline op-geth itself uses in its tests:
+//
+//	core.GenerateChainWithGenesis  (AddTx == real core.ApplyTransaction,
+//	                                FinalizeAndAssemble == real header commitments)
+//	core.NewBlockChain + InsertChain on an independent fresh DB
+//	                               (== real Process + ValidateState self-check)
+//
+// It descends from the M-T tx-level generator
+// (bcos-evm/test/opstack/t8n/generator/main.go): buildTx's three arms
+// (deposit / eip1559 / setcode) and MakePreState-style pre handling are
+// reused; processVector is replaced by processBlockVector; postState emission
+// is the plan's decision-record-8 "candidate set, all accounts, all slots"
+// semantics instead of a diff.
+//
+// Two subcommands:
+//
+//	opt8n-ref --write-cases <dir>
+//	    deterministically (re)writes the 77 corpus case files (*.in.json).
+//	    The corpus definitions live in this file (see caseDefs) so that the
+//	    L1Block slot values and the L1-attributes calldata can never drift
+//	    apart by hand-editing -- and processBlockVector re-asserts their
+//	    consistency at startup anyway (iron rule: slot<->calldata).
+//
+//	opt8n-ref --input <case.in.json> --output <vector.json> --op-geth-commit <sha>
+//	    generates one v3-block vector. The hardfork is taken from the case's
+//	    _info.hardfork (ecotone|fjord|granite|holocene|isthmus|jovian); upgrade
+//	    boundaries use the chainConfigSpec shape (see buildChainConfigSpec).
+//
+// This file is checked into the FISCO-BCOS repo as source of truth but is
+// built from inside an op-geth checkout (see README.md):
+//
+//	cp -r test/opstack/t8n/generator <op-geth>/cmd/opt8n-ref
+//	cd <op-geth> && go build ./cmd/opt8n-ref
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/binary"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/holiman/uint256"
+)
+
+// schemaVersion is `_op_test_vectors.version` (v3-block, plan schema).
+const schemaVersion = "3-block"
+
+// Fixed OP-Stack / system addresses (op-geth params + rollup_cost.go).
+var (
+	l1BlockAddr       = types.L1BlockAddr // 0x4200...0015
+	messagePasserAddr = params.OptimismL2ToL1MessagePasser
+	sequencerVault    = common.HexToAddress("0x4200000000000000000000000000000000000011")
+	baseFeeVault      = params.OptimismBaseFeeRecipient
+	l1FeeVault        = params.OptimismL1FeeRecipient
+	operatorFeeVault  = params.OptimismOperatorFeeRecipient
+	beaconRootsAddr   = params.BeaconRootsAddress    // EIP-4788
+	historyStorage    = params.HistoryStorageAddress // EIP-2935
+)
+
+const ringSize = 8191 // EIP-4788 HISTORY_BUFFER_LENGTH == EIP-2935 window
+
+func main() {
+	var (
+		writeCases     = flag.String("write-cases", "", "write the 77 corpus case files into <dir> and exit")
+		probeFields    = flag.String("probe-receipt-fields", "", "dev probe: run one <case.in.json> through the self-contained op-geth pipeline and dump every receipt's OP-Stack field emission (presence + hex value), then exit")
+		inputPath      = flag.String("input", "", "input case JSON")
+		outputPath     = flag.String("output", "", "output vector JSON")
+		opGethCommit   = flag.String("op-geth-commit", "unknown", "full sha of the op-geth checkout, recorded into _op_test_vectors.generator_commit")
+		probeWrap      = flag.Bool("probe-genesis-number", false, "dev probe: attempt Genesis.Number=8191 (ring-wrap feasibility) and report")
+		probeSpec      = flag.Bool("probe-spec", false, "dev probe: build representative chainConfigSpec values through buildChainConfigSpec and print each activation timeline (verifies the Task-0 upgrade-boundary interface), then exit")
+		probePrecomp   = flag.String("probe-precompile", "", "dev probe: verify every precompile valid-input helper against the real op-geth precompile Run (core/vm.PrecompiledContractsOsaka), then build+generate the bn256-add probe frame and dump its receipts (line-B Task 0 infra), then exit")
+		goldenOutput   = flag.String("golden-output", "", "Task 2 (engine gate golden ritual): also emit blockHash/transactionsRoot/extraData/excessBlobGas/rawTransactions/encodedHeaderHex for this vector to this path (vectors/ itself is untouched)")
+		chainOutputDir = flag.String("chain-output-dir", "", "Task 2 Step 2: generate the off-line 1->2 chained golden pair (GenerateChainWithGenesis n=2, InsertChain-validated) into this directory and exit")
+		// Task 3 corrupt/static modes: independent of --write-cases (they take
+		// the ASSEMBLED valid product of a base case and re-emit it as an invalid
+		// vector). corrupt emits invalid_<base>_<field>.json for every §4a field;
+		// static emits invalid_<base>_static_<n>.json for every §4c item.
+		invalidMode = flag.String("mode", "", "corrupt|static|invalid-tx: emit invalid vectors from a base case stem; chain:<N>[:fork|:break]: emit a linear chain / fork / break vector")
+		baseStem    = flag.String("base", "isthmus_transfer_basic", "base case stem for --mode=corrupt/static (e.g. isthmus_transfer_basic)")
+		invalidOut  = flag.String("out-dir", "", "output dir for --mode=corrupt/static invalid vectors")
+	)
+	flag.Parse()
+
+	switch {
+	case *probeWrap:
+		probeGenesisNumber()
+	case *probeSpec:
+		if err := probeChainConfigSpec(); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	case *probePrecomp != "":
+		if err := probePrecompile(*probePrecomp); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	case *writeCases != "":
+		if err := emitCases(*writeCases); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	case *probeFields != "":
+		raw, err := os.ReadFile(*probeFields)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+		var in inputCase
+		if err := json.Unmarshal(raw, &in); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: parsing %s: %v\n", *probeFields, err)
+			os.Exit(1)
+		}
+		if err := probeReceiptFields(&in); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	case *chainOutputDir != "":
+		if err := runChainPair(*chainOutputDir, *opGethCommit); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	case strings.HasPrefix(*invalidMode, "chain:"):
+		if err := runChainMode(*invalidMode, *invalidOut, *opGethCommit); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	case *invalidMode == "corrupt" || *invalidMode == "static" || *invalidMode == "invalid-tx":
+		if err := runInvalidMode(*invalidMode, *baseStem, *invalidOut, *opGethCommit); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	case *inputPath != "" && *outputPath != "":
+		if err := run(*inputPath, *outputPath, *opGethCommit, *goldenOutput); err != nil {
+			fmt.Fprintf(os.Stderr, "opt8n-ref: %v\n", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintln(os.Stderr, "usage: opt8n-ref --write-cases <dir> | --probe-receipt-fields <case.in.json> | --probe-spec | --probe-genesis-number | --probe-precompile <fork> | --input <case.in.json> --output <vector.json> [--golden-output <golden.json>] [--op-geth-commit <sha>] | --chain-output-dir <dir> [--op-geth-commit <sha>] | --mode corrupt|static|invalid-tx --base <stem> --out-dir <dir> [--op-geth-commit <sha>] | --mode chain:<N>[:fork|:break] --out-dir <dir> [--op-geth-commit <sha>]")
+		os.Exit(2)
+	}
+}
+
+// ---------------------------------------------------------------------
+// Input schema (.in.json)
+// ---------------------------------------------------------------------
+
+type caseInfo struct {
+	Hardfork    string `json:"hardfork"`
+	Description string `json:"description"`
+	// Activations is the upgrade-boundary spec (Task 3): per-fork activation
+	// timestamps. Present only on the upgrade_*_activation cases; when set,
+	// processBlockVector/probeReceiptFields build the chain config via
+	// buildChainConfigSpec({base: hardfork, activations}) instead of the plain
+	// buildChainConfig(hardfork). omitempty keeps the pre-existing 33 case
+	// files byte-stable under regeneration.
+	Activations map[string]uint64 `json:"activations,omitempty"`
+}
+
+// genesisKnobs are the ONLY environment inputs (plan decision record 7):
+// env is an emission derived from the generated block header, not an input.
+type genesisKnobs struct {
+	Timestamp          math.HexOrDecimal64   `json:"timestamp"`
+	GasLimit           math.HexOrDecimal64   `json:"gasLimit"`
+	BaseFee            *math.HexOrDecimal256 `json:"baseFee,omitempty"`
+	EIP1559Denominator math.HexOrDecimal64   `json:"eip1559Denominator"`
+	EIP1559Elasticity  math.HexOrDecimal64   `json:"eip1559Elasticity"`
+	MinBaseFee         *math.HexOrDecimal64  `json:"minBaseFee,omitempty"` // Jovian only (mandatory there)
+}
+
+type inputCase struct {
+	Info                  caseInfo                         `json:"_info"`
+	Genesis               genesisKnobs                     `json:"genesis"`
+	Coinbase              common.Address                   `json:"coinbase"`
+	ParentBeaconBlockRoot common.Hash                      `json:"parentBeaconBlockRoot"`
+	Pre                   types.GenesisAlloc               `json:"pre"`
+	Transactions          []inputTx                        `json:"transactions"`
+	ExtraCandidates       []common.Address                 `json:"extra_candidates,omitempty"`
+	ExtraStorage          map[common.Address][]common.Hash `json:"extra_storage,omitempty"`
+}
+
+type inputDeposit struct {
+	From       common.Address        `json:"from"`
+	To         *common.Address       `json:"to"`
+	Mint       *math.HexOrDecimal256 `json:"mint,omitempty"`
+	Value      *math.HexOrDecimal256 `json:"value,omitempty"`
+	Gas        math.HexOrDecimal64   `json:"gas"`
+	IsSystemTx bool                  `json:"is_system_tx"`
+	SourceHash common.Hash           `json:"source_hash"`
+}
+
+// inputAuthorization is one EIP-7702 tuple. Two mutually-exclusive forms:
+//   - normal: authSecretKey present -> types.SignSetCode (valid signature);
+//   - raw override (spec rev.2 (2), corpus-augmentation): the three raw*
+//     fields present -> the tuple is emitted UNSIGNED with yParity/r/s taken
+//     verbatim, and MUST be marked _op_signer_unrecoverable=true and be
+//     structurally unrecoverable (same predicate as the replayer). All new
+//     fields are omitempty (iron rule: --write-cases re-emits the old 25
+//     case files; a missing field must not inject null).
+type inputAuthorization struct {
+	ChainID       *math.HexOrDecimal256 `json:"chainId,omitempty"`
+	Address       common.Address        `json:"address"`
+	Nonce         math.HexOrDecimal64   `json:"nonce"`
+	AuthSecretKey hexutil.Bytes         `json:"authSecretKey,omitempty"`
+
+	SignerUnrecoverable bool            `json:"_op_signer_unrecoverable,omitempty"`
+	RawYParity          *hexutil.Uint64 `json:"rawYParity,omitempty"`
+	RawR                *hexutil.Big    `json:"rawR,omitempty"`
+	RawS                *hexutil.Big    `json:"rawS,omitempty"`
+}
+
+type inputTx struct {
+	OpType           string               `json:"_op_type"`
+	OpDeposit        *inputDeposit        `json:"_op_deposit,omitempty"`
+	OpAuthorizations []inputAuthorization `json:"_op_authorization_list,omitempty"`
+
+	Nonce                *math.HexOrDecimal64  `json:"nonce,omitempty"`
+	To                   *common.Address       `json:"to,omitempty"`
+	Value                *math.HexOrDecimal256 `json:"value,omitempty"`
+	Gas                  *math.HexOrDecimal64  `json:"gas,omitempty"`
+	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas,omitempty"`
+	// GasPrice is the type-0 (legacy) arm's per-gas price (EIP-1559 arms use
+	// maxFeePerGas/maxPriorityFeePerGas). omitempty: absent on all pre-existing
+	// cases, must not re-emit as null.
+	GasPrice *math.HexOrDecimal256 `json:"gasPrice,omitempty"`
+	Data     hexutil.Bytes         `json:"data,omitempty"`
+	// EIP-2930 access list, same shape as the output field (omitempty, iron
+	// rule: absent on the old 25 cases, must not re-emit as null).
+	AccessList []outputAccessTuple   `json:"accessList,omitempty"`
+	ChainID    *math.HexOrDecimal256 `json:"chainId,omitempty"`
+	SecretKey  *hexutil.Bytes        `json:"secretKey,omitempty"`
+}
+
+// ---------------------------------------------------------------------
+// Output schema (v3-block)
+// ---------------------------------------------------------------------
+
+type outputEnv struct {
+	CurrentCoinbase       string `json:"currentCoinbase"`
+	CurrentNumber         string `json:"currentNumber"`
+	CurrentTimestamp      string `json:"currentTimestamp"`
+	CurrentGasLimit       string `json:"currentGasLimit"`
+	CurrentBaseFee        string `json:"currentBaseFee"`
+	CurrentRandom         string `json:"currentRandom"`
+	ParentBeaconBlockRoot string `json:"parentBeaconBlockRoot"`
+	ParentHash            string `json:"parentHash"`
+}
+
+type outputDepositTx struct {
+	OpType    string        `json:"_op_type"`
+	OpDeposit inputDeposit  `json:"_op_deposit"`
+	Data      hexutil.Bytes `json:"data"`
+}
+
+// outputAccessTuple is one EIP-2930 access-list entry, replayer field
+// contract: {address, storageKeys[]}. StorageKeys is always emitted (an
+// empty tuple must serialize as [], never null).
+type outputAccessTuple struct {
+	Address     common.Address `json:"address"`
+	StorageKeys []common.Hash  `json:"storageKeys"`
+}
+
+// math.HexOrDecimal256 marshals via pointer receiver only -- every such field
+// below must stay a pointer (M-T gotcha, kept).
+//
+// AccessList / SignerUnrecoverable below deliberately deviate from the
+// no-omitempty style of this schema: the old 25 vectors predate the fields
+// and byte-invariance under regeneration (regen.sh's final diff clause)
+// requires absent-not-null.
+type outputSignedTx struct {
+	OpType               string                `json:"_op_type"`
+	OpRaw                string                `json:"_op_raw"`
+	ChainID              *math.HexOrDecimal256 `json:"chainId"`
+	Nonce                math.HexOrDecimal64   `json:"nonce"`
+	To                   *common.Address       `json:"to"`
+	Gas                  math.HexOrDecimal64   `json:"gas"`
+	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas"`
+	Value                *math.HexOrDecimal256 `json:"value"`
+	Data                 hexutil.Bytes         `json:"data"`
+	AccessList           []outputAccessTuple   `json:"accessList,omitempty"`
+	Sender               common.Address        `json:"sender"`
+}
+
+type outputAuthorization struct {
+	ChainID *math.HexOrDecimal256 `json:"chainId"`
+	Address common.Address        `json:"address"`
+	Nonce   math.HexOrDecimal64   `json:"nonce"`
+	YParity math.HexOrDecimal64   `json:"yParity"`
+	R       *math.HexOrDecimal256 `json:"r"`
+	S       *math.HexOrDecimal256 `json:"s"`
+	// true only on raw-override tuples (see inputAuthorization); omitempty is
+	// the marker contract -- the replayer treats field presence as marked.
+	SignerUnrecoverable bool `json:"_op_signer_unrecoverable,omitempty"`
+}
+
+type outputSetCodeTx struct {
+	OpType               string                `json:"_op_type"`
+	OpRaw                string                `json:"_op_raw"`
+	ChainID              *math.HexOrDecimal256 `json:"chainId"`
+	Nonce                math.HexOrDecimal64   `json:"nonce"`
+	To                   common.Address        `json:"to"`
+	Gas                  math.HexOrDecimal64   `json:"gas"`
+	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas"`
+	Value                *math.HexOrDecimal256 `json:"value"`
+	Data                 hexutil.Bytes         `json:"data"`
+	AccessList           []outputAccessTuple   `json:"accessList,omitempty"`
+	Sender               common.Address        `json:"sender"`
+	OpAuthorizationList  []outputAuthorization `json:"_op_authorization_list"`
+}
+
+// outputLegacyTx is the type-0 (EIP-155 protected) arm's output object. Unlike
+// the EIP-1559 arms it carries a single `gasPrice` (no maxFeePerGas /
+// maxPriorityFeePerGas). ⚠️ The T8n replayer does not yet parse `_op_type
+// "legacy"` (OpT8nReplayTest.cpp:513-644); the legacy vectors must not be
+// manifest-registered until that consumer arm lands (see task-3-report).
+type outputLegacyTx struct {
+	OpType   string                `json:"_op_type"`
+	OpRaw    string                `json:"_op_raw"`
+	ChainID  *math.HexOrDecimal256 `json:"chainId"`
+	Nonce    math.HexOrDecimal64   `json:"nonce"`
+	To       *common.Address       `json:"to"`
+	Gas      math.HexOrDecimal64   `json:"gas"`
+	GasPrice *math.HexOrDecimal256 `json:"gasPrice"`
+	Value    *math.HexOrDecimal256 `json:"value"`
+	Data     hexutil.Bytes         `json:"data"`
+	Sender   common.Address        `json:"sender"`
+}
+
+// outputSetCodeTxCreate is the setcode_create invalid-tx output object
+// (Task 4). Unlike outputSetCodeTx, To is *common.Address so the vector can
+// carry `to: null` — the evmone opValidate CREATE_SET_CODE_TX trigger
+// (eth/state/state.cpp:356-357). The replayer's setcode loader reads to
+// verbatim (OpT8nReplayTest.cpp:541-543), so the structured object (not the
+// raw envelope) is what makes the create rejection reachable.
+type outputSetCodeTxCreate struct {
+	OpType               string                `json:"_op_type"`
+	OpRaw                string                `json:"_op_raw"`
+	ChainID              *math.HexOrDecimal256 `json:"chainId"`
+	Nonce                math.HexOrDecimal64   `json:"nonce"`
+	To                   *common.Address       `json:"to"`
+	Gas                  math.HexOrDecimal64   `json:"gas"`
+	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas"`
+	Value                *math.HexOrDecimal256 `json:"value"`
+	Data                 hexutil.Bytes         `json:"data"`
+	Sender               common.Address        `json:"sender"`
+	OpAuthorizationList  []outputAuthorization `json:"_op_authorization_list"`
+}
+
+// outputBlobTx is the blob invalid-tx output object (Task 4). The replayer has
+// no blob arm yet (consumer follow-up); the engine payload consumes the _op_raw
+// envelope directly, and this structured object carries the fields the future
+// blob loader would need (EIP-4844: blobFeeCap + blobHashes).
+type outputBlobTx struct {
+	OpType               string                `json:"_op_type"`
+	OpRaw                string                `json:"_op_raw"`
+	ChainID              *math.HexOrDecimal256 `json:"chainId"`
+	Nonce                math.HexOrDecimal64   `json:"nonce"`
+	To                   *common.Address       `json:"to"`
+	Gas                  math.HexOrDecimal64   `json:"gas"`
+	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas"`
+	BlobFeeCap           *math.HexOrDecimal256 `json:"blobFeeCap"`
+	BlobHashes           []common.Hash         `json:"blobHashes"`
+	Value                *math.HexOrDecimal256 `json:"value"`
+	Data                 hexutil.Bytes         `json:"data"`
+	Sender               common.Address        `json:"sender"`
+}
+
+type outputBlock struct {
+	Transactions []json.RawMessage `json:"transactions"`
+}
+
+type expectedHeader struct {
+	GasUsed         string  `json:"gasUsed"`
+	ReceiptsRoot    string  `json:"receiptsRoot"`
+	LogsBloom       string  `json:"logsBloom"`
+	WithdrawalsRoot string  `json:"withdrawalsRoot"`
+	RequestsHash    *string `json:"requestsHash,omitempty"` // nil pre-Prague (ecotone/fjord/granite/holocene): op-geth t8n omits it
+	BlobGasUsed     string  `json:"blobGasUsed"`
+	StateRoot       string  `json:"stateRoot"`
+}
+
+type expectedReceipt struct {
+	Type              string `json:"type"`
+	Status            string `json:"status"`
+	GasUsed           string `json:"gasUsed"`
+	CumulativeGasUsed string `json:"cumulativeGasUsed"`
+	LogsCount         int    `json:"logsCount"`
+	// Tx return data (receipt output), hex-encoded; always emitted ("0x" for
+	// empty). Captured by reexecuting the block (chain-maker AddTx discards it).
+	Output                  string  `json:"output"`
+	OpDepositNonce          *string `json:"_op_deposit_nonce,omitempty"`
+	OpDepositReceiptVersion *string `json:"_op_deposit_receipt_version,omitempty"`
+	OpL1Fee                 *string `json:"_op_l1_fee,omitempty"`
+	OpOperatorFee           *string `json:"_op_operator_fee,omitempty"`
+	OpDaFootprint           *string `json:"_op_da_footprint,omitempty"`
+	// 线 C 新增（按 OP_RECEIPT_FIELDMAP.md 发射面）
+	OpL1GasPrice           *string `json:"_op_l1_gas_price,omitempty"`
+	OpL1BlobBaseFee        *string `json:"_op_l1_blob_base_fee,omitempty"`
+	OpL1GasUsed            *string `json:"_op_l1_gas_used,omitempty"`
+	OpL1BaseFeeScalar      *string `json:"_op_l1_base_fee_scalar,omitempty"`
+	OpL1BlobBaseFeeScalar  *string `json:"_op_l1_blob_base_fee_scalar,omitempty"`
+	OpOperatorFeeScalar    *string `json:"_op_operator_fee_scalar,omitempty"`
+	OpOperatorFeeConstant  *string `json:"_op_operator_fee_constant,omitempty"`
+	OpDaFootprintGasScalar *string `json:"_op_da_footprint_gas_scalar,omitempty"`
+}
+
+type opExpected struct {
+	Header   expectedHeader    `json:"header"`
+	Receipts []expectedReceipt `json:"receipts"`
+	// Reject is present ONLY on invalid vectors (Task 3 corrupt/static modes).
+	// omitempty keeps the old 77 valid vectors byte-for-byte stable under
+	// regeneration (review E11).
+	Reject *rejectExpected `json:"reject,omitempty"`
+}
+
+// rejectExpected is the _op_expected.reject schema (task-2/3 brief): the
+// op-geth anchor message (weak, documentation-only) plus the FISCO consumer
+// contract that the C++ runners (OpNewPayloadRpcE2eTest / OpT8nReplayTest)
+// actually assert against. Field presence is the contract -- every
+// non-omitempty field is required on an invalid vector.
+type rejectExpected struct {
+	OpGeth string      `json:"op_geth"`
+	Fisco  fiscoReject `json:"fisco"`
+}
+
+// fiscoReject is the FISCO-side expectation. Consumer is "engine" for the
+// newPayload gate (field/static corruptions, this task) and "executor"/"both"
+// for the T8n processOpBlock throw path (task 1/2 vectors).
+type fiscoReject struct {
+	Consumer                string          `json:"consumer,omitempty"`
+	Classification          string          `json:"classification"`              // INVALID | SYNCING | -32603 | -38005
+	LatestValidHash         json.RawMessage `json:"latest_valid_hash,omitempty"` // "parent" | null (INVALID only)
+	ValidationErrorContains string          `json:"validation_error_contains,omitempty"`
+	// ExpectThrow is the engine-throw class the E2E runner asserts via
+	// BOOST_CHECK_THROW (OpNewPayloadRpcE2eTest.cpp runInvalidVector):
+	// "OpExecutionInternalError" for the -32603 same-height fork two-pour.
+	ExpectThrow string `json:"expect_throw,omitempty"`
+}
+
+// outputAccount is the canonical EF state-test account shape:
+// balance/nonce/code ALWAYS present (storage only when non-empty). The C++
+// replayer feeds `pre` verbatim to evmone's from_json<TestState>, which
+// hard-requires all three fields (statetest_loader.cpp:353-356, j_acc.at).
+// types.GenesisAlloc's own marshaling (omitempty on Nonce/Code) is a geth
+// t8n-alloc convention, not the EF shape — emitting it for `pre` made every
+// vector unparseable on the replay side. `postState` intentionally stays
+// GenesisAlloc-shaped: its {"balance":"0x0"} zero-account convention (see
+// emitPostState) is parsed by the replayer's own comparator, not by evmone.
+type outputAccount struct {
+	Balance *math.HexOrDecimal256       `json:"balance"`
+	Nonce   math.HexOrDecimal64         `json:"nonce"`
+	Code    hexutil.Bytes               `json:"code"`
+	Storage map[common.Hash]common.Hash `json:"storage,omitempty"`
+}
+
+func emitPre(alloc types.GenesisAlloc) map[common.Address]outputAccount {
+	out := make(map[common.Address]outputAccount, len(alloc))
+	for addr, acc := range alloc {
+		bal := acc.Balance
+		if bal == nil {
+			bal = new(big.Int)
+		}
+		oa := outputAccount{
+			Balance: (*math.HexOrDecimal256)(bal),
+			Nonce:   math.HexOrDecimal64(acc.Nonce),
+			Code:    hexutil.Bytes(acc.Code), // nil -> "0x"
+		}
+		if len(acc.Storage) > 0 {
+			oa.Storage = acc.Storage
+		}
+		out[addr] = oa
+	}
+	return out
+}
+
+type outputVector struct {
+	Info       caseInfo                         `json:"_info"`
+	Env        outputEnv                        `json:"env"`
+	Pre        map[common.Address]outputAccount `json:"pre"`
+	Block      outputBlock                      `json:"block"`
+	PostState  types.GenesisAlloc               `json:"postState"`
+	OpExpected opExpected                       `json:"_op_expected"`
+}
+
+// invalidVectorDoc is the on-disk shape of a Task 3/4 invalid vector
+// (vectors/invalid_*.json). The engine consumer (OpNewPayloadRpcE2eTest,
+// w6test::loadInvalidSample) reads _info.hardfork / pre / _op_payload /
+// _op_expected.reject. The Task 4 invalid-tx vectors ADD env + block
+// (omitempty, so corrupt/static vectors stay byte-identical): the T8n replayer
+// (OpT8nReplayTest::loadBlockContext) needs env + block.transactions (the
+// structured tx objects) to reach assertRejectThrow.
+type invalidVectorDoc struct {
+	Info caseInfo                         `json:"_info"`
+	Pre  map[common.Address]outputAccount `json:"pre"`
+	// Env/Block/PostState are *pointers* + omitempty: Go's omitempty does NOT
+	// elide a zero struct, so a value field would leak `env`/`block` into the
+	// Task 3 corrupt/static vectors and break byte-invariance. The Task 4
+	// invalid-tx vectors set them (the T8n replayer needs env + block; the
+	// setcode loader needs a present postState).
+	Env        *outputEnv             `json:"env,omitempty"`
+	Block      *outputBlock           `json:"block,omitempty"`
+	PostState  *types.GenesisAlloc    `json:"postState,omitempty"`
+	OpPayload  map[string]interface{} `json:"_op_payload"`
+	OpExpected invalidExpected        `json:"_op_expected"`
+	// OpCanonical is the -32603 two-pour carrier (Task 2 handoff): the
+	// CANONICAL sibling's full ExecutionPayload (with parentBeaconBlockRoot),
+	// which the E2E runner pours FIRST and expects VALID. Only chain_fork_*
+	// vectors carry it.
+	OpCanonical map[string]interface{} `json:"_op_canonical,omitempty"`
+}
+
+// invalidExpected is the lean _op_expected for invalid vectors: only the reject
+// schema is emitted.
+type invalidExpected struct {
+	Reject *rejectExpected `json:"reject"`
+}
+
+// ---------------------------------------------------------------------
+// Chain config (per-fork recipe, mirroring op-geth
+// miner/payload_building_test.go holoceneConfig()/isthmusConfig()/
+// jovianConfig() and params.OptimismTestConfig: start from
+// OptimismTestConfig and nil-out later forks. OptimismTestConfig already has
+// Regolith..Jovian at time 0, KarstTime=nil, OsakaTime=nil, InteropTime=nil,
+// and the ETH twins Shanghai/Cancun/Prague at 0 -- which is exactly what
+// CheckOptimismValidity requires (Shanghai==Canyon, Cancun==Ecotone,
+// Prague==Isthmus). Every pre-Isthmus recipe therefore ALSO nils PragueTime
+// together with IsthmusTime (ETH twin: equalPtrValues(Prague, Isthmus)).
+// Note the consequence: nil PragueTime disables EIP-2935 / EIP-7702 /
+// requestsHash, so ecotone/fjord/granite/holocene cases cannot use the
+// setcode/7702 arm (and ecotoneConfig/fjordConfig run at EVMC_CANCUN).
+// ---------------------------------------------------------------------
+
+func buildChainConfig(fork string) (*params.ChainConfig, error) {
+	conf := *params.OptimismTestConfig
+	conf.ChainID = big.NewInt(8453) // 0x2105, Base mainnet, matches the plan's schema example
+	switch fork {
+	case "jovian":
+		// OptimismTestConfig already sets JovianTime = 0 (Regolith..Jovian at 0).
+	case "isthmus":
+		conf.JovianTime = nil
+	case "holocene":
+		conf.IsthmusTime = nil
+		conf.JovianTime = nil
+		conf.PragueTime = nil // ETH twin: PragueTime == IsthmusTime
+	case "granite":
+		conf.HoloceneTime = nil
+		conf.IsthmusTime = nil
+		conf.JovianTime = nil
+		conf.PragueTime = nil
+	case "fjord":
+		conf.GraniteTime = nil
+		conf.HoloceneTime = nil
+		conf.IsthmusTime = nil
+		conf.JovianTime = nil
+		conf.PragueTime = nil
+	case "ecotone":
+		conf.FjordTime = nil
+		conf.GraniteTime = nil
+		conf.HoloceneTime = nil
+		conf.IsthmusTime = nil
+		conf.JovianTime = nil
+		conf.PragueTime = nil
+	default:
+		return nil, fmt.Errorf("unknown hardfork %q (want ecotone|fjord|granite|holocene|isthmus|jovian)", fork)
+	}
+	if err := conf.CheckOptimismValidity(); err != nil {
+		return nil, fmt.Errorf("chain config invalid: %w", err)
+	}
+	return &conf, nil
+}
+
+// chainConfigSpec is the upgrade-boundary config shape: base = the fork the
+// chain starts at genesis; activations = per-fork activation timestamps.
+// buildChainConfig(fork) only produces fork-at-0 configs (a single block
+// cannot express "genesis in old fork, one block crosses into a new fork");
+// this shape does. The single block's timestamp is controlled by the case's
+// blockTime (= genesisTime+10, chain_makers.makeHeader), so an activation T
+// must satisfy genesisTime < T <= genesisTime+10 -- the case constructor
+// picks genesisTime in [T-10, T-1]. Consumed by Tasks 1/3 for the
+// upgrade-boundary vectors; here it is exercised by --probe-spec.
+type chainConfigSpec struct {
+	base        string            // ecotone|fjord|granite|holocene|isthmus|jovian
+	activations map[string]uint64 // may be nil; e.g. {"fjord": T} => FjordTime=T
+}
+
+// buildChainConfigSpec starts from buildChainConfig(spec.base) and then sets
+// the per-fork activation timestamps. ETH twins are re-coupled on activation
+// (canyon->Shanghai, ecotone->Cancun, isthmus->Prague per CheckOptimismValidity)
+// so a pre-Isthmus base activated into Isthmus stays valid.
+func buildChainConfigSpec(spec chainConfigSpec) (*params.ChainConfig, error) {
+	cfg, err := buildChainConfig(spec.base)
+	if err != nil {
+		return nil, err
+	}
+	for fork, ts := range spec.activations {
+		switch fork {
+		case "regolith":
+			cfg.RegolithTime = uint64Ptr(ts)
+		case "canyon":
+			cfg.CanyonTime = uint64Ptr(ts)
+			cfg.ShanghaiTime = uint64Ptr(ts) // ETH twin
+		case "ecotone":
+			cfg.EcotoneTime = uint64Ptr(ts)
+			cfg.CancunTime = uint64Ptr(ts) // ETH twin
+		case "fjord":
+			cfg.FjordTime = uint64Ptr(ts)
+		case "granite":
+			cfg.GraniteTime = uint64Ptr(ts)
+		case "holocene":
+			cfg.HoloceneTime = uint64Ptr(ts)
+		case "isthmus":
+			cfg.IsthmusTime = uint64Ptr(ts)
+			cfg.PragueTime = uint64Ptr(ts) // ETH twin
+		case "jovian":
+			cfg.JovianTime = uint64Ptr(ts)
+		default:
+			return nil, fmt.Errorf("unknown activation fork %q", fork)
+		}
+	}
+	if err := cfg.CheckOptimismValidity(); err != nil {
+		return nil, fmt.Errorf("chain config invalid: %w", err)
+	}
+	return cfg, nil
+}
+
+func uint64Ptr(v uint64) *uint64 { return &v }
+
+// buildConfigForCase builds the chain config for one case: the plain per-fork
+// recipe for pure-fork cases, or the upgrade-boundary spec (base fork + the
+// _info.activations timestamps) for the Task-3 activation vectors. The 10-second
+// coupling is enforced by the case constructor (genesis timestamp = T-5,
+// blockTime = genesis+10 = T+5), not here.
+func buildConfigForCase(in *inputCase) (*params.ChainConfig, error) {
+	if len(in.Info.Activations) > 0 {
+		return buildChainConfigSpec(chainConfigSpec{base: in.Info.Hardfork, activations: in.Info.Activations})
+	}
+	return buildChainConfig(in.Info.Hardfork)
+}
+
+// probeChainConfigSpec is a self-contained dev probe (--probe-spec) that
+// builds representative chainConfigSpec values through buildChainConfigSpec
+// and prints each fork activation timeline. It verifies the Task-0 acceptance
+// criteria -- the interface can express pure Ecotone/Fjord AND upgrade
+// boundaries, with the ETH twins nil'd/co-activated together -- without
+// touching the golden path. The 10-second coupling is demonstrated by placing
+// every activation at T=1005 with the corpus-default genesisTime=1000 /
+// blockTime=1010 (1000 < 1005 <= 1010 holds).
+func probeChainConfigSpec() error {
+	specs := []struct {
+		label string
+		spec  chainConfigSpec
+	}{
+		{"pure ecotone", chainConfigSpec{base: "ecotone"}},
+		{"pure fjord", chainConfigSpec{base: "fjord"}},
+		{"pure granite", chainConfigSpec{base: "granite"}},
+		{"pure holocene", chainConfigSpec{base: "holocene"}},
+		{"pure isthmus", chainConfigSpec{base: "isthmus"}},
+		{"pure jovian", chainConfigSpec{base: "jovian"}},
+		{"upgrade ecotone->fjord @1005", chainConfigSpec{base: "ecotone", activations: map[string]uint64{"fjord": 1005}}},
+		{"upgrade fjord->granite @1005", chainConfigSpec{base: "fjord", activations: map[string]uint64{"granite": 1005}}},
+		{"upgrade granite->holocene @1005", chainConfigSpec{base: "granite", activations: map[string]uint64{"holocene": 1005}}},
+		{"upgrade holocene->isthmus @1005", chainConfigSpec{base: "holocene", activations: map[string]uint64{"isthmus": 1005}}},
+		{"upgrade isthmus->jovian @1005", chainConfigSpec{base: "isthmus", activations: map[string]uint64{"jovian": 1005}}},
+	}
+	for _, s := range specs {
+		cfg, err := buildChainConfigSpec(s.spec)
+		if err != nil {
+			return fmt.Errorf("spec %q: %w", s.label, err)
+		}
+		fmt.Printf("%-30s chainID=%s\n", s.label, cfg.ChainID)
+		fmt.Printf("  regolith=%-4s canyon=%-4s ecotone=%-4s fjord=%-4s granite=%-4s holocene=%-4s isthmus=%-4s jovian=%-4s\n",
+			ptrOrNil(cfg.RegolithTime), ptrOrNil(cfg.CanyonTime), ptrOrNil(cfg.EcotoneTime), ptrOrNil(cfg.FjordTime),
+			ptrOrNil(cfg.GraniteTime), ptrOrNil(cfg.HoloceneTime), ptrOrNil(cfg.IsthmusTime), ptrOrNil(cfg.JovianTime))
+		fmt.Printf("  shanghai=%-4s cancun=%-4s prague=%-4s   (ETH twins: shanghai==canyon, cancun==ecotone, prague==isthmus)\n",
+			ptrOrNil(cfg.ShanghaiTime), ptrOrNil(cfg.CancunTime), ptrOrNil(cfg.PragueTime))
+	}
+	return nil
+}
+
+func ptrOrNil(p *uint64) string {
+	if p == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%d", *p)
+}
+
+// probePrecompile is the line-B Task 0 dev probe (--probe-precompile <fork>).
+// Two halves:
+//
+//  1. Input-helper verification: every valid-* / repeated* helper output is fed
+//     to the REAL op-geth precompile Run (core/vm.PrecompiledContractsOsaka, the
+//     map carrying bn256 + KZG + BLS12-381 + P256VERIFY). A helper passes iff
+//     Run returns no error; p256/KZG additionally assert the exact expected
+//     output (32-byte-1 / the EIP-4844 fixed return value), proving the
+//     signature/proof actually verify.
+//  2. Frame generation: build the bn256-add probe frame via precompileFrame +
+//     precompileCallTx (To=0x06, two valid G1 points, gas 500_000 -- see the
+//     NOTE below on OP intrinsic gas) under the given fork and push it through
+//     probeReceiptFields (the full GenerateChainWithGenesis + AddTx pipeline).
+//     Confirms the constructor + block gasLimit plumbing produce a generated
+//     block whose precompile tx receipt shows success (status 1) and gasUsed
+//     ~intrinsic+150.
+func probePrecompile(fork string) error {
+	osaka := vm.PrecompiledContractsOsaka
+	pc := func(n uint) vm.PrecompiledContract {
+		c, ok := osaka[common.BytesToAddress(addrBytes(n))]
+		if !ok {
+			panic(fmt.Sprintf("probe: no precompile at 0x%x in PrecompiledContractsOsaka", n))
+		}
+		return c
+	}
+
+	// --- Half 1: verify every input helper against the real precompile Run ---
+	type check struct {
+		label   string
+		addr    uint
+		input   func() []byte
+		wantOut []byte // nil => assert no-error only
+	}
+	kzgReturn := common.Hex2Bytes("000000000000000000000000000000000000000000000000000000000000100073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")
+	true32 := make([]byte, 32)
+	true32[31] = 1
+	checks := []check{
+		{"bn256 G1 x2 (add input)", preBn256Add, func() []byte { return repeatedPair(validBn256G1(), 2) }, nil},
+		{"bn256 G2 (pairing, 1 pair)", preBn256Pairing, func() []byte { return repeatedBn256Pair(1) }, nil},
+		{"bn256 pairing, 2 pairs", preBn256Pairing, func() []byte { return repeatedBn256Pair(2) }, nil},
+		{"bls12-381 G1 x2 (g1add input)", preBlsG1Add, func() []byte { return repeatedPair(validBlsG1(), 2) }, nil},
+		{"bls12-381 G2 x2 (g2add input)", preBlsG2Add, func() []byte { return repeatedPair(validBlsG2(), 2) }, nil},
+		{"bls12-381 pairing (1 pair)", preBlsPairing, func() []byte { return append(validBlsG1(), validBlsG2()...) }, nil},
+		{"kzg4844 point evaluation", prePointEval, validKZGInput, kzgReturn},
+		{"secp256r1 (RIP-7212)", preP256Verify, validP256Sig, true32},
+	}
+
+	fmt.Printf("helper length assertions:\n")
+	fmt.Printf("  validBn256G1()       len=%d (want 64)\n", len(validBn256G1()))
+	fmt.Printf("  validBn256G2()       len=%d (want 128)\n", len(validBn256G2()))
+	fmt.Printf("  repeatedBn256Pair(1) len=%d (want 192)\n", len(repeatedBn256Pair(1)))
+	fmt.Printf("  validBlsG1()         len=%d (want 128)\n", len(validBlsG1()))
+	fmt.Printf("  validBlsG2()         len=%d (want 256)\n", len(validBlsG2()))
+	fmt.Printf("  validP256Sig()       len=%d (want 160)\n", len(validP256Sig()))
+	fmt.Printf("  validKZGInput()      len=%d (want 192)\n", len(validKZGInput()))
+
+	fail := 0
+	for _, c := range checks {
+		in := c.input()
+		out, err := pc(c.addr).Run(in)
+		if err != nil {
+			fmt.Printf("  FAIL  %-34s Run error: %v\n", c.label, err)
+			fail++
+			continue
+		}
+		if c.wantOut != nil && !bytes.Equal(out, c.wantOut) {
+			fmt.Printf("  FAIL  %-34s output mismatch: got 0x%x\n", c.label, out)
+			fail++
+			continue
+		}
+		fmt.Printf("  ok    %-34s Run accepted %dB input, output %dB\n", c.label, len(in), len(out))
+	}
+	if fail > 0 {
+		return fmt.Errorf("probe-precompile: %d input-helper check(s) FAILED", fail)
+	}
+
+	// --- Half 2: build + generate the bn256-add probe frame ---
+	// NOTE: tx gas 500_000, NOT the precompile's 150. On OP-stack the tx gas
+	// limit must cover INTRINSIC gas (21000 base + calldata cost; ~21560 for a
+	// 128-byte call) and the precompile's RequiredGas (150) is charged on top.
+	// A 150-gas tx would OOG at the intrinsic check ("intrinsic gas too low: have
+	// 150, want 21560") and never reach the precompile. The brief's "gas 150 /
+	// gasUsed ~150" predates the OP intrinsic-gas reality; the receipt's gasUsed
+	// is intrinsic + 150 (~21710), with the precompile's 150 visible as the
+	// delta over an empty-calldata transfer.
+	probeInput := repeatedPair(validBn256G1(), 2) // 128B: two valid G1 points
+	spec := precompileFrame(fork, "probe_bn256_add",
+		"probe: bn256 add with two valid G1 points (line-B Task 0 infra)",
+		[]inputTx{precompileCallTx(addrBytes(preBn256Add), probeInput, 500_000, 0)},
+		10_000_000)
+	in := spec.build(fork)
+	fmt.Printf("\nprobe frame: fork=%s name=%s blockGasLimit=%d txs=%d\n",
+		fork, spec.name, uint64(in.Genesis.GasLimit), len(in.Transactions))
+	return probeReceiptFields(&in)
+}
+
+// ---------------------------------------------------------------------
+// Vector generation
+// ---------------------------------------------------------------------
+
+func run(inputPath, outputPath, opGethCommit, goldenOutputPath string) error {
+	raw, err := os.ReadFile(inputPath)
+	if err != nil {
+		return err
+	}
+	var in inputCase
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return fmt.Errorf("parsing %s: %w", inputPath, err)
+	}
+	id := strings.TrimSuffix(filepath.Base(inputPath), ".in.json")
+
+	vec, golden, err := processBlockVector(&in, id)
+	if err != nil {
+		return fmt.Errorf("vector %q: %w", id, err)
+	}
+
+	meta, err := json.Marshal(struct {
+		Version         string `json:"version"`
+		Generator       string `json:"generator"`
+		GeneratorCommit string `json:"generator_commit"`
+	}{schemaVersion, "opt8n-ref", opGethCommit})
+	if err != nil {
+		return err
+	}
+	out := map[string]json.RawMessage{"_op_test_vectors": meta, id: vec}
+	outBytes, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	outBytes = append(outBytes, '\n')
+	if err := os.WriteFile(outputPath, outBytes, 0o644); err != nil {
+		return err
+	}
+	if goldenOutputPath == "" {
+		return nil
+	}
+	return writeJSON(goldenOutputPath, golden)
+}
+
+func processBlockVector(in *inputCase, id string) (json.RawMessage, *goldenRecord, error) {
+	cfg, err := buildConfigForCase(in)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// --- Startup consistency assertion (iron rule 2): L1Block slots <->
+	// attributes calldata, field for field, plus the first-Ecotone-fallback
+	// trap guard. Mismatch = corpus authoring error, hard stop.
+	if err := assertL1BlockConsistency(cfg, in); err != nil {
+		return nil, nil, fmt.Errorf("L1Block slot<->calldata consistency: %w", err)
+	}
+	if err := assertDepositsFirst(in.Transactions); err != nil {
+		return nil, nil, err
+	}
+
+	// --- Genesis (iron rule 1: extraData on BOTH genesis and the generated
+	// block; 9B Isthmus / 17B Jovian incl. mandatory minBaseFee).
+	genesisTime := uint64(in.Genesis.Timestamp)
+	blockTime := genesisTime + 10 // chain_makers.makeHeader: block time fixed at parent+10
+	denom := uint64(in.Genesis.EIP1559Denominator)
+	elasticity := uint64(in.Genesis.EIP1559Elasticity)
+	// minBaseFee is gated on BLOCK time (Task 3 handoff A), not genesis time:
+	// an upgrade-boundary vector whose genesis is pre-Jovian but whose single
+	// block crosses JovianTime still needs a non-nil minBaseFee for the BLOCK
+	// extraData (EncodeOptimismExtraData panics on nil under Jovian). The
+	// genesis extraData (pre-Jovian Holocene form) ignores minBaseFee.
+	var minBaseFee *uint64
+	if cfg.IsJovian(blockTime) {
+		if in.Genesis.MinBaseFee == nil {
+			return nil, nil, fmt.Errorf("jovian case must set genesis.minBaseFee (EncodeOptimismExtraData requires it)")
+		}
+		v := uint64(*in.Genesis.MinBaseFee)
+		minBaseFee = &v
+	}
+	var genesisBaseFee *big.Int
+	if in.Genesis.BaseFee != nil {
+		genesisBaseFee = (*big.Int)(in.Genesis.BaseFee)
+	}
+	genesis := &core.Genesis{
+		Config:     cfg,
+		Timestamp:  genesisTime,
+		GasLimit:   uint64(in.Genesis.GasLimit),
+		BaseFee:    genesisBaseFee,
+		Difficulty: big.NewInt(0),
+		ExtraData:  eip1559.EncodeOptimismExtraData(cfg, genesisTime, denom, elasticity, minBaseFee),
+		Alloc:      in.Pre,
+	}
+
+	// --- Build transactions. Signer per iron rule 9: MakeSigner(cfg, 1, blockTime).
+	signer := types.MakeSigner(cfg, big.NewInt(1), blockTime)
+	var (
+		txs    []*types.Transaction
+		outTxs []json.RawMessage
+	)
+	for i := range in.Transactions {
+		tx, outTx, err := buildTx(&in.Transactions[i], signer, cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("tx %d: %w", i, err)
+		}
+		txs = append(txs, tx)
+		outTxs = append(outTxs, outTx)
+	}
+
+	// --- Generate the block (iron rules 1(ii), 3, 4).
+	blockExtra := eip1559.EncodeOptimismExtraData(cfg, blockTime, denom, elasticity, minBaseFee)
+	engine := beacon.New(ethash.NewFaker())
+	var (
+		db          ethdb.Database
+		blocks      []*types.Block
+		receiptsAll []types.Receipts
+	)
+	if err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("GenerateChainWithGenesis panic: %v", r)
+			}
+		}()
+		db, blocks, receiptsAll = core.GenerateChainWithGenesis(genesis, engine, 1, func(i int, b *core.BlockGen) {
+			b.SetCoinbase(in.Coinbase)
+			b.SetExtra(blockExtra)                          // iron rule 1(ii): InsertChain verifyHeader rejects otherwise
+			b.SetParentBeaconRoot(in.ParentBeaconBlockRoot) // iron rule 4: 4788 build/replay symmetry
+			for _, tx := range txs {
+				b.AddTx(tx) // L1CostFunc/OperatorCostFunc wired inside NewEVMBlockContext (core/evm.go)
+			}
+		})
+		return nil
+	}(); err != nil {
+		return nil, nil, err
+	}
+	if len(blocks) != 1 {
+		return nil, nil, fmt.Errorf("expected 1 generated block, got %d", len(blocks))
+	}
+	block, receipts := blocks[0], receiptsAll[0]
+	header := block.Header()
+	if header.Time != blockTime || header.Number.Uint64() != 1 {
+		return nil, nil, fmt.Errorf("unexpected generated header number/time: %d/%d", header.Number.Uint64(), header.Time)
+	}
+	if len(receipts) != len(txs) {
+		return nil, nil, fmt.Errorf("receipt/tx count mismatch: %d vs %d", len(receipts), len(txs))
+	}
+
+	// --- Self-check (iron rule 5): independent fresh DB, real
+	// Process+ValidateState. Failure = generator/corpus defect; NEVER bypass.
+	if err := selfCheck(genesis, blocks); err != nil {
+		return nil, nil, fmt.Errorf("InsertChain self-check FAILED (corpus/generator defect, do not bypass): %w", err)
+	}
+
+	out, golden, err := assembleOutput(in, cfg, signer, genesis, db, block, receipts, txs, outTxs, genesis.ToBlock().Root())
+	if err != nil {
+		return nil, nil, fmt.Errorf("vector %q: %w", id, err)
+	}
+	vec, err := json.Marshal(out)
+	if err != nil {
+		return nil, nil, err
+	}
+	return vec, golden, nil
+}
+
+// probeReceiptFields is a SELF-CONTAINED dev probe that drives the op-geth
+// pipeline for one case and dumps the full OP-Stack receipt field emission
+// surface (presence + hex value) of every receipt. It deliberately does NOT
+// reuse processBlockVector: that path returns (json.RawMessage, *goldenRecord,
+// error) and hides receipts, and refactoring its front half would disturb the
+// golden path (selfCheck / assembleOutput need genesis/blocks/db/txs/outTxs/
+// signer). A throwaway probe -- the front half is copied verbatim below
+// (main.go:436-517, genesis construction -> tx signing ->
+// GenerateChainWithGenesis -> receiptsAll); the copy produces
+// signer/db/engine/genesis/txs/blocks/receiptsAll. Only receiptsAll is read.
+// This feeds the OP_RECEIPT_FIELDMAP.md fieldmap (Phase 2 line C task 0).
+func probeReceiptFields(in *inputCase) error {
+	// cfg/fork -- replaces processBlockVector :431-434.
+	cfg, err := buildConfigForCase(in)
+	if err != nil {
+		return err
+	}
+
+	// ── copied from processBlockVector front half (main.go:436-517) ──
+	// --- Startup consistency assertion (iron rule 2): L1Block slots <->
+	// attributes calldata, field for field, plus the first-Ecotone-fallback
+	// trap guard. Mismatch = corpus authoring error, hard stop.
+	if err := assertL1BlockConsistency(cfg, in); err != nil {
+		return fmt.Errorf("L1Block slot<->calldata consistency: %w", err)
+	}
+	if err := assertDepositsFirst(in.Transactions); err != nil {
+		return err
+	}
+
+	// --- Genesis (iron rule 1: extraData on BOTH genesis and the generated
+	// block; 9B Isthmus / 17B Jovian incl. mandatory minBaseFee).
+	genesisTime := uint64(in.Genesis.Timestamp)
+	blockTime := genesisTime + 10 // chain_makers.makeHeader: block time fixed at parent+10
+	denom := uint64(in.Genesis.EIP1559Denominator)
+	elasticity := uint64(in.Genesis.EIP1559Elasticity)
+	// minBaseFee gated on BLOCK time, not genesis time (Task 3 handoff A) --
+	// see processBlockVector for the upgrade-boundary rationale.
+	var minBaseFee *uint64
+	if cfg.IsJovian(blockTime) {
+		if in.Genesis.MinBaseFee == nil {
+			return fmt.Errorf("jovian case must set genesis.minBaseFee (EncodeOptimismExtraData requires it)")
+		}
+		v := uint64(*in.Genesis.MinBaseFee)
+		minBaseFee = &v
+	}
+	var genesisBaseFee *big.Int
+	if in.Genesis.BaseFee != nil {
+		genesisBaseFee = (*big.Int)(in.Genesis.BaseFee)
+	}
+	genesis := &core.Genesis{
+		Config:     cfg,
+		Timestamp:  genesisTime,
+		GasLimit:   uint64(in.Genesis.GasLimit),
+		BaseFee:    genesisBaseFee,
+		Difficulty: big.NewInt(0),
+		ExtraData:  eip1559.EncodeOptimismExtraData(cfg, genesisTime, denom, elasticity, minBaseFee),
+		Alloc:      in.Pre,
+	}
+
+	// --- Build transactions. Signer per iron rule 9: MakeSigner(cfg, 1, blockTime).
+	signer := types.MakeSigner(cfg, big.NewInt(1), blockTime)
+	var txs []*types.Transaction
+	for i := range in.Transactions {
+		tx, _, err := buildTx(&in.Transactions[i], signer, cfg)
+		if err != nil {
+			return fmt.Errorf("tx %d: %w", i, err)
+		}
+		txs = append(txs, tx)
+	}
+
+	// --- Generate the block (iron rules 1(ii), 3, 4).
+	blockExtra := eip1559.EncodeOptimismExtraData(cfg, blockTime, denom, elasticity, minBaseFee)
+	engine := beacon.New(ethash.NewFaker())
+	var (
+		db          ethdb.Database
+		blocks      []*types.Block
+		receiptsAll []types.Receipts
+	)
+	if err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("GenerateChainWithGenesis panic: %v", r)
+			}
+		}()
+		db, blocks, receiptsAll = core.GenerateChainWithGenesis(genesis, engine, 1, func(i int, b *core.BlockGen) {
+			b.SetCoinbase(in.Coinbase)
+			b.SetExtra(blockExtra)                          // iron rule 1(ii): InsertChain verifyHeader rejects otherwise
+			b.SetParentBeaconRoot(in.ParentBeaconBlockRoot) // iron rule 4: 4788 build/replay symmetry
+			for _, tx := range txs {
+				b.AddTx(tx) // L1CostFunc/OperatorCostFunc wired inside NewEVMBlockContext (core/evm.go)
+			}
+		})
+		return nil
+	}(); err != nil {
+		return err
+	}
+	if len(blocks) != 1 {
+		return fmt.Errorf("expected 1 generated block, got %d", len(blocks))
+	}
+	// ── end copied front half (skips :518 `block, receipts := blocks[0], receiptsAll[0]`) ──
+	// db is only read by assembleOutput on the golden path; unused here.
+	_ = db
+
+	receipts := receiptsAll[0]
+	for i, r := range receipts {
+		fmt.Printf("tx[%d] type=0x%02x status=0x%x gasUsed=%d cumulativeGasUsed=%d\n",
+			i, r.Type, r.Status, r.GasUsed, r.CumulativeGasUsed)
+		if r.DepositNonce != nil {
+			fmt.Printf("  DepositNonce\t0x%x\n", *r.DepositNonce)
+		} else {
+			fmt.Printf("  DepositNonce\tabsent\n")
+		}
+		if r.DepositReceiptVersion != nil {
+			fmt.Printf("  DepositReceiptVersion\t0x%x\n", *r.DepositReceiptVersion)
+		} else {
+			fmt.Printf("  DepositReceiptVersion\tabsent\n")
+		}
+		if r.L1GasPrice != nil {
+			fmt.Printf("  L1GasPrice\t0x%x\n", r.L1GasPrice)
+		} else {
+			fmt.Printf("  L1GasPrice\tabsent\n")
+		}
+		if r.L1BlobBaseFee != nil {
+			fmt.Printf("  L1BlobBaseFee\t0x%x\n", r.L1BlobBaseFee)
+		} else {
+			fmt.Printf("  L1BlobBaseFee\tabsent\n")
+		}
+		if r.L1GasUsed != nil {
+			fmt.Printf("  L1GasUsed\t0x%x\n", r.L1GasUsed)
+		} else {
+			fmt.Printf("  L1GasUsed\tabsent\n")
+		}
+		if r.L1Fee != nil {
+			fmt.Printf("  L1Fee\t0x%x\n", r.L1Fee)
+		} else {
+			fmt.Printf("  L1Fee\tabsent\n")
+		}
+		if r.FeeScalar != nil {
+			fmt.Printf("  FeeScalar\t%s\n", r.FeeScalar.String())
+		} else {
+			fmt.Printf("  FeeScalar\tabsent\n")
+		}
+		if r.L1BaseFeeScalar != nil {
+			fmt.Printf("  L1BaseFeeScalar\t0x%x\n", *r.L1BaseFeeScalar)
+		} else {
+			fmt.Printf("  L1BaseFeeScalar\tabsent\n")
+		}
+		if r.L1BlobBaseFeeScalar != nil {
+			fmt.Printf("  L1BlobBaseFeeScalar\t0x%x\n", *r.L1BlobBaseFeeScalar)
+		} else {
+			fmt.Printf("  L1BlobBaseFeeScalar\tabsent\n")
+		}
+		if r.OperatorFeeScalar != nil {
+			fmt.Printf("  OperatorFeeScalar\t0x%x\n", *r.OperatorFeeScalar)
+		} else {
+			fmt.Printf("  OperatorFeeScalar\tabsent\n")
+		}
+		if r.OperatorFeeConstant != nil {
+			fmt.Printf("  OperatorFeeConstant\t0x%x\n", *r.OperatorFeeConstant)
+		} else {
+			fmt.Printf("  OperatorFeeConstant\tabsent\n")
+		}
+		if r.DAFootprintGasScalar != nil {
+			fmt.Printf("  DAFootprintGasScalar\t0x%x\n", *r.DAFootprintGasScalar)
+		} else {
+			fmt.Printf("  DAFootprintGasScalar\tabsent\n")
+		}
+		if r.BlobGasUsed != 0 {
+			fmt.Printf("  BlobGasUsed\t0x%x\n", r.BlobGasUsed)
+		} else {
+			fmt.Printf("  BlobGasUsed\tabsent\n")
+		}
+	}
+	return nil
+}
+
+// assembleOutput turns one generated block (still open on its generation db,
+// together with its receipts/txs) into both the existing v3-block
+// outputVector and the Task 2 engine-gate golden record (spec §7.1:
+// blockHash/transactionsRoot/extraData/excessBlobGas/rawTransactions/
+// encodedHeaderHex -- extraData taken VERBATIM from header.Extra, no
+// hand-picked value). This is the "扩展 opt8n-ref 发射段" (裁定 A3): the
+// candidate-set / postState / receipt-expectation logic below is byte-for-
+// byte what processBlockVector always computed (moved here unchanged, just
+// with the pre-generation and post-generation halves of the candidate-set
+// build merged into one pass now that txs/receipts are both in scope) --
+// only the golden extraction at the end is new. Shared verbatim between the
+// 34-case single-block path (processBlockVector) and the off-line 1->2
+// chained pair (processChainPair, Step 2): both need identical assembly
+// logic, just fed a different (in, db, block, receipts, txs, signer) tuple
+// per block.
+// startRoot is the re-execution origin for this block: genesis root for chain
+// block 0 / single-block vectors, blocks[i-1].Root() for chain block i (see
+// reexecuteOutputs).
+func assembleOutput(in *inputCase, cfg *params.ChainConfig, signer types.Signer, genesis *core.Genesis, db ethdb.Database, block *types.Block, receipts types.Receipts, txs []*types.Transaction, outTxs []json.RawMessage, startRoot common.Hash) (outputVector, *goldenRecord, error) {
+	header := block.Header()
+
+	// --- postState: decision-record-8 candidate set, all accounts, all slots,
+	// with a trie-iteration completeness check (any post-state account or
+	// storage slot outside the declared candidate sets = hard error).
+	candidates := newAddrSet()
+	for i := range txs {
+		// Tx participants -> candidate set (senders, to, 7702 authorities).
+		from, err := types.Sender(signer, txs[i])
+		if err == nil {
+			candidates.add(from)
+		} else if txs[i].IsDepositTx() {
+			candidates.add(in.Transactions[i].OpDeposit.From)
+		} else {
+			return outputVector{}, nil, fmt.Errorf("tx %d: sender recovery: %w", i, err)
+		}
+		if to := txs[i].To(); to != nil {
+			candidates.add(*to)
+		}
+		for _, auth := range txs[i].SetCodeAuthorizations() {
+			if authority, err := auth.Authority(); err == nil {
+				candidates.add(authority)
+			}
+		}
+	}
+	// Created-contract candidates (tx/receipt paired by index): the runtime
+	// half of the double-bottoming -- the corpus also pre-derives the same
+	// addresses into extra_candidates, and the slot-completeness check would
+	// expose any disagreement between the two.
+	for i := range txs {
+		if txs[i].To() == nil && receipts[i].ContractAddress != (common.Address{}) {
+			candidates.add(receipts[i].ContractAddress)
+		}
+	}
+	candidates.add(in.Coinbase)
+	for _, a := range []common.Address{
+		sequencerVault, baseFeeVault, l1FeeVault, operatorFeeVault,
+		l1BlockAddr, messagePasserAddr, beaconRootsAddr, historyStorage,
+	} {
+		candidates.add(a)
+	}
+	for addr := range in.Pre {
+		candidates.add(addr)
+	}
+	for _, addr := range in.ExtraCandidates {
+		candidates.add(addr)
+	}
+	slotCands := buildSlotCandidates(in, header.Time, header.Number.Uint64())
+	postState, postDB, err := emitPostState(db, block.Root(), candidates, slotCands)
+	if err != nil {
+		return outputVector{}, nil, fmt.Errorf("postState emission: %w", err)
+	}
+
+	// --- Receipt expectations. Operator fee is computed BY THIS GENERATOR
+	// per fork formula (iron rule 7; rollup_cost.go:254-287) from the
+	// pre-state slot-8 params, then cross-checked against op-geth's own
+	// NewOperatorCostFunc and against the OperatorFeeVault balance delta.
+	// --- Receipt output: re-execute the block to capture return data (the
+	// chain maker discards ExecutionResult.ReturnData). Rejected if the replay
+	// does not reproduce the real receipts' gasUsed/status per tx.
+	outputs, err := reexecuteOutputs(cfg, genesis, db, header, txs, receipts,
+		in.Coinbase, in.ParentBeaconBlockRoot, startRoot)
+	if err != nil {
+		return outputVector{}, nil, err
+	}
+	expReceipts, err := buildExpectedReceipts(cfg, in, txs, receipts, outputs, header.Time)
+	if err != nil {
+		return outputVector{}, nil, err
+	}
+	if err := crossCheckVaults(in, expReceipts, postDB); err != nil {
+		return outputVector{}, nil, err
+	}
+
+	// --- Header expectations + env (both emissions from the header; iron rule 6).
+	// RequestsHash is NOT required: pre-Prague forks (ecotone/fjord/granite/
+	// holocene) have no requests (chain_makers.collectRequests returns nil), so
+	// the header's RequestsHash stays nil and is emitted absent, mirroring
+	// op-geth's own t8n (requestsHash,omitempty).
+	if header.WithdrawalsHash == nil || header.BlobGasUsed == nil {
+		return outputVector{}, nil, fmt.Errorf("generated header missing WithdrawalsHash/BlobGasUsed")
+	}
+	if header.MixDigest != (common.Hash{}) {
+		return outputVector{}, nil, fmt.Errorf("generated header MixDigest expected zero, got %s", header.MixDigest)
+	}
+	out := outputVector{
+		Info: in.Info,
+		Env: outputEnv{
+			CurrentCoinbase:       strings.ToLower(header.Coinbase.Hex()),
+			CurrentNumber:         hexutil.EncodeUint64(header.Number.Uint64()),
+			CurrentTimestamp:      hexutil.EncodeUint64(header.Time),
+			CurrentGasLimit:       hexutil.EncodeUint64(header.GasLimit),
+			CurrentBaseFee:        hexutil.EncodeBig(header.BaseFee),
+			CurrentRandom:         "0x0", // header.MixDigest is zero (asserted above)
+			ParentBeaconBlockRoot: header.ParentBeaconRoot.Hex(),
+			ParentHash:            header.ParentHash.Hex(),
+		},
+		Pre:       emitPre(in.Pre),
+		Block:     outputBlock{Transactions: outTxs},
+		PostState: postState,
+	}
+	expHeader := expectedHeader{
+		GasUsed:         hexutil.EncodeUint64(header.GasUsed),
+		ReceiptsRoot:    header.ReceiptHash.Hex(),
+		LogsBloom:       hexutil.Encode(header.Bloom[:]),
+		WithdrawalsRoot: header.WithdrawalsHash.Hex(),
+		BlobGasUsed:     hexutil.EncodeUint64(*header.BlobGasUsed),
+		StateRoot:       header.Root.Hex(),
+	}
+	if header.RequestsHash != nil {
+		s := header.RequestsHash.Hex()
+		expHeader.RequestsHash = &s
+	}
+	out.OpExpected = opExpected{
+		Header:   expHeader,
+		Receipts: expReceipts,
+	}
+
+	golden, err := buildGoldenRecord(block, txs)
+	if err != nil {
+		return outputVector{}, nil, fmt.Errorf("golden record: %w", err)
+	}
+	return out, golden, nil
+}
+
+// goldenRecord is the Task 2 engine-gate golden extension (spec §7.1): the
+// fields the corpus's own v3-block vectors are structurally missing, and
+// nothing else -- vectors/*.json stay byte-for-byte unmodified.
+//
+//   - BlockHash/TransactionsRoot: block.Hash() / header.TxHash, the off-line
+//     op-geth-backed values the newPayload gate cross-checks against
+//     (diagnostic honesty per spec §7.1: NOT self-consistency).
+//   - ExtraData: header.Extra VERBATIM (9B Isthmus / 17B Jovian incl. the
+//     mandatory minBaseFee) -- rev.2's hand-picked-value scheme is retired.
+//   - ExcessBlobGas: always "0x0" on this no-blob OP chain (asserted, not
+//     assumed).
+//   - RawTransactions: tx.MarshalBinary() for every tx INCLUDING the 0x7E
+//     deposit envelope (outputDepositTx carries no raw bytes) -- doubles as
+//     the Task 3 OpDepositEncode byte-level golden.
+//   - EncodedHeaderHex: the full header RLP hex, for the field-level
+//     encode()==golden assertion that must precede the hash() assertion
+//     (spec §7.5, decision C3).
+type goldenRecord struct {
+	BlockHash        string   `json:"blockHash"`
+	TransactionsRoot string   `json:"transactionsRoot"`
+	ExtraData        string   `json:"extraData"`
+	ExcessBlobGas    string   `json:"excessBlobGas"`
+	RawTransactions  []string `json:"rawTransactions"`
+	EncodedHeaderHex string   `json:"encodedHeaderHex"`
+}
+
+func buildGoldenRecord(block *types.Block, txs []*types.Transaction) (*goldenRecord, error) {
+	header := block.Header()
+	if header.ExcessBlobGas == nil || *header.ExcessBlobGas != 0 {
+		return nil, fmt.Errorf("expected header.ExcessBlobGas == 0 (no-blob OP chain), got %v", header.ExcessBlobGas)
+	}
+	rawTxs := make([]string, len(txs))
+	for i, tx := range txs {
+		b, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("tx %d MarshalBinary: %w", i, err)
+		}
+		rawTxs[i] = hexutil.Encode(b)
+	}
+	headerRLP, err := rlp.EncodeToBytes(header)
+	if err != nil {
+		return nil, fmt.Errorf("header RLP encode: %w", err)
+	}
+	return &goldenRecord{
+		BlockHash:        block.Hash().Hex(),
+		TransactionsRoot: header.TxHash.Hex(),
+		ExtraData:        hexutil.Encode(header.Extra),
+		ExcessBlobGas:    hexutil.EncodeUint64(*header.ExcessBlobGas),
+		RawTransactions:  rawTxs,
+		EncodedHeaderHex: hexutil.Encode(headerRLP),
+	}, nil
+}
+
+func writeJSON(path string, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return os.WriteFile(path, b, 0o644)
+}
+
+// ---------------------------------------------------------------------
+// Off-line chained pair (Task 2 Step 2, spec §7.1 rev.3 decision A2): a
+// dedicated 1->2 block chain generated in ONE GenerateChainWithGenesis(n=2)
+// call (real chain_makers parent-chaining -- block B's pre-state IS block
+// A's generated post-state) and re-validated by InsertChain-ing BOTH blocks
+// together. This is NOT two independent single-block vectors spliced by hand
+// (rev.2's "set A's blockHash as B's parentHash" splice is retired -- three
+// ways broken: static validation would reject it first, the golden values
+// would be wrong, and state/number would disagree with a real chain).
+// ---------------------------------------------------------------------
+
+func processChainPair(fork string) (outputVector, outputVector, *goldenRecord, *goldenRecord, error) {
+	cfg, err := buildChainConfig(fork)
+	if err != nil {
+		return outputVector{}, outputVector{}, nil, nil, err
+	}
+	jovianCfg := fork == "jovian"
+	fp := defaultFeeParams()
+	if jovianCfg {
+		fp.daScalar = 400 // non-zero DA scalar: block1 DA footprint (header.BlobGasUsed) > gasUsed, max branch observable
+	}
+	const (
+		genesisTime = uint64(1000)
+		denom       = uint64(50)
+		elasticity  = uint64(6)
+		gasLimit    = uint64(10_000_000)
+	)
+	beaconRoot := common.HexToHash("0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c")
+	senderAddr := addrOfKey(1)
+	genesisPre := types.GenesisAlloc{
+		l1BlockAddr:       {Balance: big.NewInt(0), Nonce: 1, Code: l1BlockRuntimeCode, Storage: fp.l1BlockStorage(fork)},
+		messagePasserAddr: {Balance: big.NewInt(0), Nonce: 1},
+		senderAddr:        {Balance: eth(100)},
+	}
+	if jovianCfg {
+		genesisPre[addrOfKey(2)] = types.Account{Balance: eth(100)} // block1 junk-calldata tx sender
+	}
+	// Jovian requires a non-nil minBaseFee in EncodeOptimismExtraData
+	// (eip1559_optimism.go:51-53 panics otherwise) -- mandatory for the three
+	// extraData encodings below (genesis + both blocks).
+	var minBaseFee *uint64
+	knobs := genesisKnobs{
+		Timestamp:          math.HexOrDecimal64(genesisTime),
+		GasLimit:           math.HexOrDecimal64(gasLimit),
+		BaseFee:            hdu(1_000_000_000),
+		EIP1559Denominator: math.HexOrDecimal64(denom),
+		EIP1559Elasticity:  math.HexOrDecimal64(elasticity),
+	}
+	if jovianCfg {
+		v := uint64(0)
+		minBaseFee = &v
+		knobs.MinBaseFee = hd64(0)
+	}
+	genesis := &core.Genesis{
+		Config:     cfg,
+		Timestamp:  genesisTime,
+		GasLimit:   gasLimit,
+		BaseFee:    big.NewInt(1_000_000_000),
+		Difficulty: big.NewInt(0),
+		ExtraData:  eip1559.EncodeOptimismExtraData(cfg, genesisTime, denom, elasticity, minBaseFee),
+		Alloc:      genesisPre,
+	}
+
+	var (
+		ins     [2]*inputCase
+		txSets  [2][]*types.Transaction
+		outSets [2][]json.RawMessage
+	)
+	engine := beacon.New(ethash.NewFaker())
+	var (
+		db          ethdb.Database
+		blocks      []*types.Block
+		receiptsAll []types.Receipts
+	)
+	if err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("GenerateChainWithGenesis panic: %v", r)
+			}
+		}()
+		db, blocks, receiptsAll = core.GenerateChainWithGenesis(genesis, engine, 2, func(i int, bg *core.BlockGen) {
+			blockTime := bg.Timestamp() // chain_makers: parent.Time()+10, real per-block advance
+			blockExtra := eip1559.EncodeOptimismExtraData(cfg, blockTime, denom, elasticity, minBaseFee)
+			bg.SetCoinbase(sequencerVault)
+			bg.SetExtra(blockExtra)
+			bg.SetParentBeaconRoot(beaconRoot)
+			signer := bg.Signer() // == MakeSigner(cfg, bg.Number(), bg.Timestamp())
+
+			attr := fp.attributesTx(fmt.Sprintf("chain_%d", i), fork)
+			tx0, outTx0, terr := buildTx(&attr, signer, cfg)
+			if terr != nil {
+				panic(fmt.Errorf("block %d attributes tx: %w", i, terr))
+			}
+			bg.AddTx(tx0)
+
+			nonce := bg.TxNonce(senderAddr) // real chained nonce (0 in A, 1 in B), not hand-tracked
+			transfer := transferTx(1, nonce, recA, eth(1), 21_000, nil)
+			tx1, outTx1, terr := buildTx(&transfer, signer, cfg)
+			if terr != nil {
+				panic(fmt.Errorf("block %d transfer tx: %w", i, terr))
+			}
+			bg.AddTx(tx1)
+
+			txs := []*types.Transaction{tx0, tx1}
+			outTxs := []json.RawMessage{outTx0, outTx1}
+			transactions := []inputTx{attr, transfer}
+			// Jovian block1 carries a large-calldata tx so its DA footprint
+			// (header.BlobGasUsed, daScalar=400) exceeds gasUsed -- the max
+			// branch of the DA-footprint model is observable (and stays well
+			// below gasLimit). Isthmus has no DA footprint; its chainA/B stay
+			// byte-identical to the pre-W5 output.
+			if jovianCfg && i == 0 {
+				junk := transferTx(2, bg.TxNonce(addrOfKey(2)), recB, big.NewInt(0), 400_000, junkData("chain jovian block1", 5000))
+				txJ, outTxJ, jerr := buildTx(&junk, signer, cfg)
+				if jerr != nil {
+					panic(fmt.Errorf("block %d junk calldata tx: %w", i, jerr))
+				}
+				bg.AddTx(txJ)
+				txs = append(txs, txJ)
+				outTxs = append(outTxs, outTxJ)
+				transactions = append(transactions, junk)
+			}
+
+			in := &inputCase{
+				Info:                  caseInfo{Hardfork: fork, Description: fmt.Sprintf("off-line chained pair (spec §7.1 Step 2, decision A2), block %d/2", i+1)},
+				Genesis:               knobs,
+				Coinbase:              sequencerVault,
+				ParentBeaconBlockRoot: beaconRoot,
+				Transactions:          transactions,
+			}
+			if i == 0 {
+				in.Pre = genesisPre // block B's Pre is filled in AFTER generation, from A's postState
+			}
+			ins[i] = in
+			txSets[i] = txs
+			outSets[i] = outTxs
+		})
+		return nil
+	}(); err != nil {
+		return outputVector{}, outputVector{}, nil, nil, err
+	}
+	if len(blocks) != 2 {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("expected 2 generated blocks, got %d", len(blocks))
+	}
+
+	if err := assertL1BlockConsistency(cfg, ins[0]); err != nil {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("block A: %w", err)
+	}
+	if err := assertDepositsFirst(ins[0].Transactions); err != nil {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("block A: %w", err)
+	}
+
+	// --- Self-check (iron rule 5, extended to a real 2-block InsertChain):
+	// independent fresh DB, Process+ValidateState over BOTH blocks in
+	// sequence -- this IS the "经 InsertChain 头校验" the chain pair exists
+	// to exercise (real parent-child header linkage), not two independently
+	// self-checked singles spliced by hand.
+	if err := selfCheck(genesis, blocks); err != nil {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("chain pair InsertChain self-check FAILED: %w", err)
+	}
+
+	signerA := types.MakeSigner(cfg, blocks[0].Number(), blocks[0].Time())
+	outA, goldenA, err := assembleOutput(ins[0], cfg, signerA, genesis, db, blocks[0], receiptsAll[0], txSets[0], outSets[0], genesis.ToBlock().Root())
+	if err != nil {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("chain block A: %w", err)
+	}
+
+	// Block B's pre IS block A's post -- not a second seed (decision A2).
+	ins[1].Pre = outA.PostState
+	if err := assertL1BlockConsistency(cfg, ins[1]); err != nil {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("block B: %w", err)
+	}
+	if err := assertDepositsFirst(ins[1].Transactions); err != nil {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("block B: %w", err)
+	}
+	signerB := types.MakeSigner(cfg, blocks[1].Number(), blocks[1].Time())
+	outB, goldenB, err := assembleOutput(ins[1], cfg, signerB, genesis, db, blocks[1], receiptsAll[1], txSets[1], outSets[1], blocks[0].Root())
+	if err != nil {
+		return outputVector{}, outputVector{}, nil, nil, fmt.Errorf("chain block B: %w", err)
+	}
+
+	return outA, outB, goldenA, goldenB, nil
+}
+
+// chainedBlockOutput is one block of the off-line chained pair (Task 2 Step
+// 2): the full v3-block payload (same fields as outputVector) merged flatly
+// with the golden extension (same fields as goldenRecord) -- there is no
+// pre-existing vectors/chainX.json to complement, so unlike the 34 flat
+// golden files, these carry the complete per-block record.
+type chainedBlockOutput struct {
+	Info       caseInfo                         `json:"_info"`
+	Env        outputEnv                        `json:"env"`
+	Pre        map[common.Address]outputAccount `json:"pre"`
+	Block      outputBlock                      `json:"block"`
+	PostState  types.GenesisAlloc               `json:"postState"`
+	OpExpected opExpected                       `json:"_op_expected"`
+
+	BlockHash        string   `json:"blockHash"`
+	TransactionsRoot string   `json:"transactionsRoot"`
+	ExtraData        string   `json:"extraData"`
+	ExcessBlobGas    string   `json:"excessBlobGas"`
+	RawTransactions  []string `json:"rawTransactions"`
+	EncodedHeaderHex string   `json:"encodedHeaderHex"`
+}
+
+func runChainPair(outputDir, opGethCommit string) error {
+	_ = opGethCommit // recorded in golden/engine/README.md's generation record, not per-file (chained pair has no vectors/ counterpart to key off)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return err
+	}
+	write := func(id string, out outputVector, g *goldenRecord) error {
+		merged := chainedBlockOutput{
+			Info: out.Info, Env: out.Env, Pre: out.Pre, Block: out.Block,
+			PostState: out.PostState, OpExpected: out.OpExpected,
+			BlockHash: g.BlockHash, TransactionsRoot: g.TransactionsRoot,
+			ExtraData: g.ExtraData, ExcessBlobGas: g.ExcessBlobGas,
+			RawTransactions: g.RawTransactions, EncodedHeaderHex: g.EncodedHeaderHex,
+		}
+		if err := writeJSON(filepath.Join(outputDir, id+".golden.json"), merged); err != nil {
+			return err
+		}
+		if err := writeJSON(filepath.Join(outputDir, id+".pre.json"), out.Pre); err != nil {
+			return err
+		}
+		if err := writeJSON(filepath.Join(outputDir, id+".post.json"), out.PostState); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Parameterized by fork (W5 review A#4/B#2): each fork produces its own
+	// pair prefix so the jovian pair (jovianChainA/B) does not clobber the
+	// existing isthmus chainA/B files.
+	for _, p := range []struct{ fork, prefix string }{
+		{"isthmus", "chain"},
+		{"jovian", "jovianChain"},
+	} {
+		outA, outB, goldenA, goldenB, err := processChainPair(p.fork)
+		if err != nil {
+			return fmt.Errorf("%s chain pair: %w", p.fork, err)
+		}
+		if err := write(p.prefix+"A", outA, goldenA); err != nil {
+			return fmt.Errorf("%sA: %w", p.prefix, err)
+		}
+		if err := write(p.prefix+"B", outB, goldenB); err != nil {
+			return fmt.Errorf("%sB: %w", p.prefix, err)
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// Task 5: chain mode (spec §1b). A NEW output shape: one GenerateChainWithGenesis
+// call for n>=3 blocks, emitted as `{ "blocks": [...] }` -- NOT the flat
+// per-block files of runChainPair (:1546). The replayer (OpT8nReplayTest.cpp
+// replayChainVector :1044) inherits the running chain state across blocks:
+// blocks[0] carries `pre`, blocks[i>0] emit NO pre (null/absent -- a real pre
+// object would reset the state). Each block MUST carry its own
+// _op_expected.header/receipts + postState (Task 1 handoff: replaySingleBlockInto
+// reads them with .at(), missing = out_of_range). Recipe constraint (review
+// R13): chain blocks must not read historical blockhashes (ParentOnlyBlockHashes
+// only answers number-1) -- the attributes-deposit + transfer recipe is safe.
+// ---------------------------------------------------------------------
+
+// chainBlockOutput is one block of the chain-mode vector. `pre` is a pointer +
+// omitempty so blocks[i>0] emit NO pre key (the replayer inherits chainState).
+type chainBlockOutput struct {
+	Info       caseInfo                          `json:"_info"`
+	Env        outputEnv                         `json:"env"`
+	Pre        *map[common.Address]outputAccount `json:"pre,omitempty"`
+	Block      outputBlock                       `json:"block"`
+	PostState  types.GenesisAlloc                `json:"postState"`
+	OpExpected opExpected                        `json:"_op_expected"`
+}
+
+// chainOutput is the chain-mode vector schema (spec §1b): a top-level `blocks`
+// array. The outer file wraps it in `_op_test_vectors` + the vector id, same
+// as every other vector.
+type chainOutput struct {
+	Blocks []chainBlockOutput `json:"blocks"`
+}
+
+// chainContext is the internal (non-JSON) chain result the fork/break arms
+// need: the raw generated blocks (txs come from block.Transactions()), the
+// genesis, the chain config and the genesis pre-state. processChainN's public
+// *chainOutput derives from it.
+type chainContext struct {
+	cfg        *params.ChainConfig
+	genesis    *core.Genesis
+	genesisPre types.GenesisAlloc
+	blocks     []*types.Block
+}
+
+// generateChainN builds an n-block linear chain (spec §1b): ONE
+// GenerateChainWithGenesis(n) call (real chain_makers parent-chaining -- block
+// i's pre-state IS block i-1's generated post-state), self-checked by
+// InsertChain-ing ALL n blocks together, then assembled per-block into the
+// chain vector. The per-block recipe is the chain-pair recipe (L1-attributes
+// deposit + a sender transfer with the real chained nonce from bg.TxNonce).
+func generateChainN(fork string, n int) (*chainOutput, *chainContext, error) {
+	if n < 3 {
+		return nil, nil, fmt.Errorf("generateChainN: n must be >= 3 (got %d)", n)
+	}
+	cfg, err := buildChainConfig(fork)
+	if err != nil {
+		return nil, nil, err
+	}
+	jovianCfg := fork == "jovian"
+	fp := defaultFeeParams()
+	if jovianCfg {
+		fp.daScalar = 400 // non-zero DA scalar: block DA footprint observable
+	}
+	const (
+		genesisTime = uint64(1000)
+		denom       = uint64(50)
+		elasticity  = uint64(6)
+		gasLimit    = uint64(10_000_000)
+	)
+	beaconRoot := common.HexToHash("0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c")
+	senderAddr := addrOfKey(1)
+	genesisPre := types.GenesisAlloc{
+		l1BlockAddr:       {Balance: big.NewInt(0), Nonce: 1, Code: l1BlockRuntimeCode, Storage: fp.l1BlockStorage(fork)},
+		messagePasserAddr: {Balance: big.NewInt(0), Nonce: 1},
+		senderAddr:        {Balance: eth(100)},
+	}
+	// Jovian requires a non-nil minBaseFee in EncodeOptimismExtraData (see
+	// processChainPair for the panic rationale).
+	var minBaseFee *uint64
+	knobs := genesisKnobs{
+		Timestamp:          math.HexOrDecimal64(genesisTime),
+		GasLimit:           math.HexOrDecimal64(gasLimit),
+		BaseFee:            hdu(1_000_000_000),
+		EIP1559Denominator: math.HexOrDecimal64(denom),
+		EIP1559Elasticity:  math.HexOrDecimal64(elasticity),
+	}
+	if jovianCfg {
+		v := uint64(0)
+		minBaseFee = &v
+		knobs.MinBaseFee = hd64(0)
+	}
+	genesis := &core.Genesis{
+		Config:     cfg,
+		Timestamp:  genesisTime,
+		GasLimit:   gasLimit,
+		BaseFee:    big.NewInt(1_000_000_000),
+		Difficulty: big.NewInt(0),
+		ExtraData:  eip1559.EncodeOptimismExtraData(cfg, genesisTime, denom, elasticity, minBaseFee),
+		Alloc:      genesisPre,
+	}
+
+	engine := beacon.New(ethash.NewFaker())
+	var (
+		db          ethdb.Database
+		blocks      []*types.Block
+		receiptsAll []types.Receipts
+	)
+	ins := make([]*inputCase, n)
+	txSets := make([][]*types.Transaction, n)
+	outSets := make([][]json.RawMessage, n)
+	if err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("GenerateChainWithGenesis panic: %v", r)
+			}
+		}()
+		db, blocks, receiptsAll = core.GenerateChainWithGenesis(genesis, engine, n, func(i int, bg *core.BlockGen) {
+			blockTime := bg.Timestamp() // chain_makers: parent.Time()+10, real per-block advance
+			blockExtra := eip1559.EncodeOptimismExtraData(cfg, blockTime, denom, elasticity, minBaseFee)
+			bg.SetCoinbase(sequencerVault)
+			bg.SetExtra(blockExtra)
+			bg.SetParentBeaconRoot(beaconRoot)
+			signer := bg.Signer() // == MakeSigner(cfg, bg.Number(), bg.Timestamp())
+
+			attr := fp.attributesTx(fmt.Sprintf("chainN_%d_%d", n, i), fork)
+			tx0, outTx0, terr := buildTx(&attr, signer, cfg)
+			if terr != nil {
+				panic(fmt.Errorf("block %d attributes tx: %w", i, terr))
+			}
+			bg.AddTx(tx0)
+
+			nonce := bg.TxNonce(senderAddr) // real chained nonce (0, 1, 2, ...)
+			transfer := transferTx(1, nonce, recA, eth(1), 21_000, nil)
+			tx1, outTx1, terr := buildTx(&transfer, signer, cfg)
+			if terr != nil {
+				panic(fmt.Errorf("block %d transfer tx: %w", i, terr))
+			}
+			bg.AddTx(tx1)
+
+			in := &inputCase{
+				Info: caseInfo{Hardfork: fork,
+					Description: fmt.Sprintf("linear chain of %d blocks (spec §1b), block %d/%d", n, i+1, n)},
+				Genesis:               knobs,
+				Coinbase:              sequencerVault,
+				ParentBeaconBlockRoot: beaconRoot,
+				Transactions:          []inputTx{attr, transfer},
+			}
+			if i == 0 {
+				in.Pre = genesisPre // block i>0's Pre is filled AFTER assembly, from i-1's postState
+			}
+			ins[i] = in
+			txSets[i] = []*types.Transaction{tx0, tx1}
+			outSets[i] = []json.RawMessage{outTx0, outTx1}
+		})
+		return nil
+	}(); err != nil {
+		return nil, nil, err
+	}
+	if len(blocks) != n {
+		return nil, nil, fmt.Errorf("expected %d generated blocks, got %d", n, len(blocks))
+	}
+
+	// Self-check: independent fresh DB, Process+ValidateState over ALL n blocks
+	// in sequence -- this IS the "经 InsertChain 头校验" the chain exists to
+	// exercise (real parent-child header linkage).
+	if err := selfCheck(genesis, blocks); err != nil {
+		return nil, nil, fmt.Errorf("chain InsertChain self-check FAILED: %w", err)
+	}
+
+	out := &chainOutput{Blocks: make([]chainBlockOutput, n)}
+	for i := range blocks {
+		// Decision A2 generalized: block i's pre IS block i-1's post-state
+		// (the existing ins[1].Pre = outA.PostState for the chain pair).
+		if i > 0 {
+			ins[i].Pre = out.Blocks[i-1].PostState
+		}
+		if err := assertL1BlockConsistency(cfg, ins[i]); err != nil {
+			return nil, nil, fmt.Errorf("block %d: %w", i, err)
+		}
+		if err := assertDepositsFirst(ins[i].Transactions); err != nil {
+			return nil, nil, fmt.Errorf("block %d: %w", i, err)
+		}
+		signer := types.MakeSigner(cfg, blocks[i].Number(), blocks[i].Time())
+		var startRoot common.Hash
+		if i == 0 {
+			startRoot = genesis.ToBlock().Root()
+		} else {
+			startRoot = blocks[i-1].Root() // replay origin = previous post-state (Task 5 前置 fix)
+		}
+		o, _, err := assembleOutput(ins[i], cfg, signer, genesis, db, blocks[i], receiptsAll[i], txSets[i], outSets[i], startRoot)
+		if err != nil {
+			return nil, nil, fmt.Errorf("chain block %d: %w", i, err)
+		}
+		var pre *map[common.Address]outputAccount
+		if i == 0 {
+			p := emitPre(ins[i].Pre)
+			pre = &p
+		}
+		out.Blocks[i] = chainBlockOutput{
+			Info: o.Info, Env: o.Env, Pre: pre, Block: o.Block,
+			PostState: o.PostState, OpExpected: o.OpExpected,
+		}
+	}
+	return out, &chainContext{
+		cfg: cfg, genesis: genesis, genesisPre: genesisPre, blocks: blocks,
+	}, nil
+}
+
+// processChainN is the public chain-mode entry (Task 5 interface): an n-block
+// linear chain vector. The fork/break arms use generateChainN directly for the
+// internal context.
+func processChainN(fork string, n int) (*chainOutput, error) {
+	out, _, err := generateChainN(fork, n)
+	return out, err
+}
+
+// genSiblingFork builds a SECOND child of the same parent at the same height as
+// firstChild (a SIBLING block): same parent (genesis), same height 1, but
+// different content (a larger transfer value) so its hash differs. op-geth
+// InsertChain ACCEPTS the sibling as a side chain -- the divergence recorded in
+// the fork carrier's op_geth anchor ("VALID (side chain)"). The FISCO engine
+// gate rejects the SECOND pour of the same height with -32603
+// OpExecutionInternalError (SYS_NUMBER_2_HASH collision, Task 2 two-pour).
+func genSiblingFork(firstChild *types.Block, cfg *params.ChainConfig, genesis *core.Genesis) (*types.Block, error) {
+	if firstChild == nil || cfg == nil || genesis == nil {
+		return nil, fmt.Errorf("genSiblingFork: nil firstChild/cfg/genesis")
+	}
+	if firstChild.NumberU64() != 1 {
+		return nil, fmt.Errorf("genSiblingFork: firstChild must be height 1 (child of genesis), got %d", firstChild.NumberU64())
+	}
+	jovianCfg := cfg.IsJovian(firstChild.Time())
+	fork := "isthmus"
+	if jovianCfg {
+		fork = "jovian"
+	}
+	fp := defaultFeeParams()
+	if jovianCfg {
+		fp.daScalar = 400
+	}
+	denom := uint64(50)
+	elasticity := uint64(6)
+	var minBaseFee *uint64
+	if jovianCfg {
+		v := uint64(0)
+		minBaseFee = &v
+	}
+	var beaconRoot common.Hash
+	if firstChild.Header().ParentBeaconRoot != nil {
+		beaconRoot = *firstChild.Header().ParentBeaconRoot
+	}
+	engine := beacon.New(ethash.NewFaker())
+	var (
+		db     ethdb.Database
+		blocks []*types.Block
+	)
+	if err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("GenerateChainWithGenesis panic: %v", r)
+			}
+		}()
+		db, blocks, _ = core.GenerateChainWithGenesis(genesis, engine, 1, func(i int, bg *core.BlockGen) {
+			blockTime := bg.Timestamp()
+			blockExtra := eip1559.EncodeOptimismExtraData(cfg, blockTime, denom, elasticity, minBaseFee)
+			bg.SetCoinbase(sequencerVault)
+			bg.SetExtra(blockExtra)
+			bg.SetParentBeaconRoot(beaconRoot)
+			signer := bg.Signer()
+			attr := fp.attributesTx("sibling_fork", fork)
+			tx0, _, terr := buildTx(&attr, signer, cfg)
+			if terr != nil {
+				panic(fmt.Errorf("sibling attributes tx: %w", terr))
+			}
+			bg.AddTx(tx0)
+			nonce := bg.TxNonce(addrOfKey(1))
+			// 2 ETH instead of the canonical 1 ETH -> different state root ->
+			// different block hash, same parent + height.
+			transfer := transferTx(1, nonce, recA, eth(2), 21_000, nil)
+			tx1, _, terr := buildTx(&transfer, signer, cfg)
+			if terr != nil {
+				panic(fmt.Errorf("sibling transfer tx: %w", terr))
+			}
+			bg.AddTx(tx1)
+		})
+		return nil
+	}(); err != nil {
+		return nil, err
+	}
+	_ = db // the sibling's generation DB is only needed for its own assembly; the carrier uses the block
+	if len(blocks) != 1 {
+		return nil, fmt.Errorf("expected 1 sibling block, got %d", len(blocks))
+	}
+	sibling := blocks[0]
+	if sibling.Hash() == firstChild.Hash() {
+		return nil, fmt.Errorf("sibling hash %s equals firstChild (recipe did not diverge)", sibling.Hash().Hex())
+	}
+	if sibling.ParentHash() != firstChild.ParentHash() {
+		return nil, fmt.Errorf("sibling parent %s != firstChild parent %s (must share parent)", sibling.ParentHash().Hex(), firstChild.ParentHash().Hex())
+	}
+	if sibling.NumberU64() != firstChild.NumberU64() {
+		return nil, fmt.Errorf("sibling number %d != firstChild number %d", sibling.NumberU64(), firstChild.NumberU64())
+	}
+	return sibling, nil
+}
+
+// buildForkVector assembles the chain_fork carrier (spec §1b fork arm): the
+// canonical child's full ExecutionPayload under _op_canonical (Task 2 handoff
+// field name -- the E2E runner pours it FIRST and expects VALID, writing
+// SYS_NUMBER_2_HASH[1]) and the sibling's payload under _op_payload (the SECOND
+// pour of the same height, which collides -> -32603 OpExecutionInternalError).
+// op_geth documents the divergence: op-geth ACCEPTS the side-chain sibling.
+func buildForkVector(fork string, canonical, sibling *types.Block, genesisPre types.GenesisAlloc) (invalidVectorDoc, error) {
+	if canonical == nil || sibling == nil {
+		return invalidVectorDoc{}, fmt.Errorf("buildForkVector: nil canonical/sibling")
+	}
+	return invalidVectorDoc{
+		Info: caseInfo{
+			Hardfork: fork,
+			Description: fmt.Sprintf("same-parent same-height fork: canonical %s + sibling %s (two-pour -32603)",
+				canonical.Hash().Hex(), sibling.Hash().Hex()),
+		},
+		Pre:         emitPre(genesisPre),
+		OpPayload:   buildPayloadFromHeader(sibling.Header(), sibling.Hash(), sibling.Transactions()),
+		OpCanonical: buildPayloadFromHeader(canonical.Header(), canonical.Hash(), canonical.Transactions()),
+		OpExpected: invalidExpected{
+			Reject: &rejectExpected{
+				OpGeth: "VALID (side chain)",
+				Fisco: fiscoReject{
+					Consumer:        "engine",
+					Classification:  "-32603",
+					LatestValidHash: json.RawMessage("null"),
+					ExpectThrow:     "OpExecutionInternalError",
+				},
+			},
+		},
+	}, nil
+}
+
+// genParentBreak builds the chain-break carrier (spec §1b break arm): the
+// chain's height-1 block re-emitted with parentHash pointing at an UNKNOWN
+// ancestor (0x...01), which classifies SYNCING (consumer: engine). The E2E
+// runner SKIPS parent registration for SYNCING vectors (OpNewPayloadRpcE2eTest
+// runInvalidVector) and asserts newPayload -> Syncing. The op_geth anchor is
+// the real InsertChain "unknown ancestor" rejection.
+func genParentBreak(fork string, block *types.Block, cfg *params.ChainConfig, genesis *core.Genesis, genesisPre types.GenesisAlloc) (invalidVectorDoc, error) {
+	if block == nil || cfg == nil || genesis == nil {
+		return invalidVectorDoc{}, fmt.Errorf("genParentBreak: nil block/cfg/genesis")
+	}
+	header := types.CopyHeader(block.Header())
+	header.ParentHash = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
+	blockHash := recomputeOpHeaderHash(header)
+	payload := buildPayloadFromHeader(header, blockHash, block.Transactions())
+	msg, err := captureInsertChainRejection(genesis, block.WithSeal(header))
+	if err != nil {
+		return invalidVectorDoc{}, fmt.Errorf("genParentBreak: InsertChain capture: %w", err)
+	}
+	return invalidVectorDoc{
+		Info: caseInfo{
+			Hardfork: fork,
+			Description: fmt.Sprintf("parent break: %s re-emitted with unknown parent 0x...01 (SYNCING)",
+				block.Hash().Hex()),
+		},
+		Pre:       emitPre(genesisPre),
+		OpPayload: payload,
+		OpExpected: invalidExpected{
+			Reject: &rejectExpected{
+				OpGeth: msg,
+				Fisco: fiscoReject{
+					Consumer:       "engine",
+					Classification: "SYNCING",
+				},
+			},
+		},
+	}, nil
+}
+
+func selfCheck(genesis *core.Genesis, blocks []*types.Block) error {
+	engine := beacon.New(ethash.NewFaker())
+	chain, err := core.NewBlockChain(rawdb.NewMemoryDatabase(), genesis, engine, nil)
+	if err != nil {
+		return fmt.Errorf("NewBlockChain: %w", err)
+	}
+	defer chain.Stop()
+	if _, err := chain.InsertChain(blocks); err != nil {
+		return err
+	}
+	if got, want := chain.CurrentBlock().Hash(), blocks[len(blocks)-1].Hash(); got != want {
+		return fmt.Errorf("head after InsertChain %s != generated %s", got, want)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// Task 3: corrupt / static modes (self-consistent corruption + §4c static
+// surface). These are INDEPENDENT modes -- they take the ASSEMBLED valid
+// product of a base case (buildBlockVector) and re-emit it as an invalid
+// vector; they never run inside --write-cases (the old 77 case files stay
+// byte-for-byte untouched).
+// ---------------------------------------------------------------------
+
+// blockVector is the full context of one generated, self-checked block: the
+// assembled output vector PLUS the block objects the corrupt/static modes need
+// to rebuild a corrupt block and capture its InsertChain rejection.
+type blockVector struct {
+	in       *inputCase
+	cfg      *params.ChainConfig
+	signer   types.Signer
+	genesis  *core.Genesis
+	block    *types.Block
+	txs      []*types.Transaction
+	receipts types.Receipts
+	outTxs   []json.RawMessage
+	vec      outputVector
+	golden   *goldenRecord
+}
+
+// buildBlockVector replicates the processBlockVector front half (genesis -> tx
+// build -> GenerateChainWithGenesis -> selfCheck) and returns the full block
+// context. It deliberately COPIES that logic rather than sharing it:
+// processBlockVector is the byte-invariant golden path and must not be
+// disturbed; this is the same "copy the front half" pattern probeReceiptFields
+// already uses (main.go:847).
+func buildBlockVector(in *inputCase) (*blockVector, error) {
+	// ── copied from processBlockVector front half (main.go:436-517) ──
+	cfg, err := buildConfigForCase(in)
+	if err != nil {
+		return nil, err
+	}
+	if err := assertL1BlockConsistency(cfg, in); err != nil {
+		return nil, fmt.Errorf("L1Block slot<->calldata consistency: %w", err)
+	}
+	if err := assertDepositsFirst(in.Transactions); err != nil {
+		return nil, err
+	}
+	genesisTime := uint64(in.Genesis.Timestamp)
+	blockTime := genesisTime + 10
+	denom := uint64(in.Genesis.EIP1559Denominator)
+	elasticity := uint64(in.Genesis.EIP1559Elasticity)
+	var minBaseFee *uint64
+	if cfg.IsJovian(blockTime) {
+		if in.Genesis.MinBaseFee == nil {
+			return nil, fmt.Errorf("jovian case must set genesis.minBaseFee (EncodeOptimismExtraData requires it)")
+		}
+		v := uint64(*in.Genesis.MinBaseFee)
+		minBaseFee = &v
+	}
+	var genesisBaseFee *big.Int
+	if in.Genesis.BaseFee != nil {
+		genesisBaseFee = (*big.Int)(in.Genesis.BaseFee)
+	}
+	genesis := &core.Genesis{
+		Config:     cfg,
+		Timestamp:  genesisTime,
+		GasLimit:   uint64(in.Genesis.GasLimit),
+		BaseFee:    genesisBaseFee,
+		Difficulty: big.NewInt(0),
+		ExtraData:  eip1559.EncodeOptimismExtraData(cfg, genesisTime, denom, elasticity, minBaseFee),
+		Alloc:      in.Pre,
+	}
+	signer := types.MakeSigner(cfg, big.NewInt(1), blockTime)
+	var (
+		txs    []*types.Transaction
+		outTxs []json.RawMessage
+	)
+	for i := range in.Transactions {
+		tx, outTx, err := buildTx(&in.Transactions[i], signer, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("tx %d: %w", i, err)
+		}
+		txs = append(txs, tx)
+		outTxs = append(outTxs, outTx)
+	}
+	blockExtra := eip1559.EncodeOptimismExtraData(cfg, blockTime, denom, elasticity, minBaseFee)
+	engine := beacon.New(ethash.NewFaker())
+	var (
+		db          ethdb.Database
+		blocks      []*types.Block
+		receiptsAll []types.Receipts
+	)
+	if err := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("GenerateChainWithGenesis panic: %v", r)
+			}
+		}()
+		db, blocks, receiptsAll = core.GenerateChainWithGenesis(genesis, engine, 1, func(i int, b *core.BlockGen) {
+			b.SetCoinbase(in.Coinbase)
+			b.SetExtra(blockExtra)
+			b.SetParentBeaconRoot(in.ParentBeaconBlockRoot)
+			for _, tx := range txs {
+				b.AddTx(tx)
+			}
+		})
+		return nil
+	}(); err != nil {
+		return nil, err
+	}
+	if len(blocks) != 1 {
+		return nil, fmt.Errorf("expected 1 generated block, got %d", len(blocks))
+	}
+	block, receipts := blocks[0], receiptsAll[0]
+	header := block.Header()
+	if header.Time != blockTime || header.Number.Uint64() != 1 {
+		return nil, fmt.Errorf("unexpected generated header number/time: %d/%d", header.Number.Uint64(), header.Time)
+	}
+	if len(receipts) != len(txs) {
+		return nil, fmt.Errorf("receipt/tx count mismatch: %d vs %d", len(receipts), len(txs))
+	}
+	if err := selfCheck(genesis, blocks); err != nil {
+		return nil, fmt.Errorf("InsertChain self-check FAILED (corpus/generator defect, do not bypass): %w", err)
+	}
+	vec, golden, err := assembleOutput(in, cfg, signer, genesis, db, block, receipts, txs, outTxs, genesis.ToBlock().Root())
+	if err != nil {
+		return nil, fmt.Errorf("vector assembly: %w", err)
+	}
+	return &blockVector{
+		in: in, cfg: cfg, signer: signer, genesis: genesis, block: block,
+		txs: txs, receipts: receipts, outTxs: outTxs, vec: vec, golden: golden,
+	}, nil
+}
+
+// runChainMode implements --mode=chain:<N>[:fork|:break] (Task 5). n>=3 emits
+// the linear-chain vector (isthmus_chain_<n>.json + jovian_chain_<n>.json);
+// :fork emits the same-parent fork carrier (invalid_<fork>_chain_<n>_fork, -32603
+// two-pour); :break emits the unknown-parent SYNCING carrier
+// (invalid_<fork>_chain_<n>_break). fork/break 带 invalid_ 前缀以便 E2E
+// InvalidVectorsFromManifest 消费（Task 5 交接决策）。
+func runChainMode(mode, outDir, opGethCommit string) error {
+	if outDir == "" {
+		return fmt.Errorf("--out-dir is required for --mode=chain")
+	}
+	rest := strings.TrimPrefix(mode, "chain:")
+	parts := strings.Split(rest, ":")
+	if len(parts) == 0 || parts[0] == "" {
+		return fmt.Errorf("--mode=chain:<N>[:fork|:break], got %q", mode)
+	}
+	n, err := strconv.Atoi(parts[0])
+	if err != nil || n < 3 {
+		return fmt.Errorf("--mode=chain:<N> requires N>=3, got %q", parts[0])
+	}
+	variant := ""
+	if len(parts) > 1 {
+		variant = parts[1]
+	}
+	if variant != "" && variant != "fork" && variant != "break" {
+		return fmt.Errorf("--mode=chain:<N>[:fork|:break], got variant %q", variant)
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return err
+	}
+	for _, fork := range []string{"isthmus", "jovian"} {
+		chain, ctx, err := generateChainN(fork, n)
+		if err != nil {
+			return fmt.Errorf("%s chain %d: %w", fork, n, err)
+		}
+		switch variant {
+		case "":
+			stem := fmt.Sprintf("%s_chain_%d", fork, n)
+			if err := writeChainVector(outDir, stem, chain, opGethCommit); err != nil {
+				return err
+			}
+		case "fork":
+			canonical := ctx.blocks[0] // height-1 child of genesis (the canonical first pour)
+			sibling, err := genSiblingFork(canonical, ctx.cfg, ctx.genesis)
+			if err != nil {
+				return fmt.Errorf("%s fork: %w", fork, err)
+			}
+			doc, err := buildForkVector(fork, canonical, sibling, ctx.genesisPre)
+			if err != nil {
+				return fmt.Errorf("%s fork carrier: %w", fork, err)
+			}
+			// invalid_ 前缀：E2E InvalidVectorsFromManifest 按 invalidStemFromManifestLine
+			// 只消费 invalid_* 行（OpNewPayloadRpcE2eTest.cpp:634），fork/break 是 -32603/
+			// SYNCING 无效向量载体，必须前缀统一（Task 5 交接决策）。
+			if err := writeInvalidVector(outDir, fmt.Sprintf("invalid_%s_chain_%d_fork", fork, n), doc, opGethCommit); err != nil {
+				return err
+			}
+		case "break":
+			doc, err := genParentBreak(fork, ctx.blocks[0], ctx.cfg, ctx.genesis, ctx.genesisPre)
+			if err != nil {
+				return fmt.Errorf("%s break: %w", fork, err)
+			}
+			if err := writeInvalidVector(outDir, fmt.Sprintf("invalid_%s_chain_%d_break", fork, n), doc, opGethCommit); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// writeChainVector writes one chain-mode vector as vectors/<stem>.json with the
+// same outer-wrapping convention as run() (a `_op_test_vectors` meta object plus
+// the single vector object keyed by the stem).
+func writeChainVector(outDir, stem string, chain *chainOutput, opGethCommit string) error {
+	meta, err := json.Marshal(struct {
+		Version         string `json:"version"`
+		Generator       string `json:"generator"`
+		GeneratorCommit string `json:"generator_commit"`
+	}{schemaVersion, "opt8n-ref", opGethCommit})
+	if err != nil {
+		return err
+	}
+	docBytes, err := json.Marshal(chain)
+	if err != nil {
+		return err
+	}
+	out := map[string]json.RawMessage{
+		"_op_test_vectors": meta,
+		stem:               docBytes,
+	}
+	outBytes, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	outBytes = append(outBytes, '\n')
+	return os.WriteFile(filepath.Join(outDir, stem+".json"), outBytes, 0o644)
+}
+
+// runInvalidMode dispatches the --mode=corrupt / --mode=static CLI paths. Both
+// load the base case from the caseSpecs table (no filesystem dependency; the
+// base stem is "fork_name", split on the first underscore).
+func runInvalidMode(mode, baseStem, outDir, opGethCommit string) error {
+	if outDir == "" {
+		return fmt.Errorf("--out-dir is required for --mode=%s", mode)
+	}
+	fork, name, err := splitVectorName(baseStem)
+	if err != nil {
+		return err
+	}
+	if fork != "isthmus" && fork != "jovian" {
+		return fmt.Errorf("--mode=%s requires an isthmus/jovian base (OP Isthmus+ path), got fork %q", mode, fork)
+	}
+	// corrupt/static need the ASSEMBLED valid base block; invalid-tx does not
+	// (its kinds build their own case from the independent invalidTxCaseSpecs).
+	if mode == "invalid-tx" {
+		// baseStem = "fork_kind" (e.g. isthmus_intrinsic_gas). Each kind is an
+		// INDEPENDENT invalidTxCaseSpecs entry (review R7) — never shared
+		// caseSpecs/emitCases. Emits one invalid_<stem>.json.
+		doc, _, _, err := buildInvalidTxVector(name, fork)
+		if err != nil {
+			return fmt.Errorf("invalid-tx %s/%s: %w", fork, name, err)
+		}
+		return writeInvalidVector(outDir, "invalid_"+baseStem, doc, opGethCommit)
+	}
+
+	in, err := buildCaseFromSpecs(name, fork)
+	if err != nil {
+		return err
+	}
+	base, err := buildBlockVector(&in)
+	if err != nil {
+		return fmt.Errorf("build base %q: %w", baseStem, err)
+	}
+	switch mode {
+	case "corrupt":
+		for _, field := range []string{"stateRoot", "gasUsed", "receiptsRoot", "parentHash", "extraData", "blockHash"} {
+			doc, _, err := corruptVector(base, field)
+			if err != nil {
+				return fmt.Errorf("corrupt %s: %w", field, err)
+			}
+			stem := "invalid_" + baseStem + "_" + field
+			if err := writeInvalidVector(outDir, stem, doc, opGethCommit); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "static":
+		// The §4c items that need a Jovian base (DA-footprint, item 11) derive
+		// from the canonical jovian_transfer_basic; the rest use the passed base.
+		jovIn, err := buildCaseFromSpecs("transfer_basic", "jovian")
+		if err != nil {
+			return err
+		}
+		jovBase, err := buildBlockVector(&jovIn)
+		if err != nil {
+			return fmt.Errorf("build jovian base: %w", err)
+		}
+		for _, item := range staticSurfaceItems {
+			b := base
+			stemBase := baseStem
+			if item.fork == "jovian" {
+				b = jovBase
+				stemBase = "jovian_transfer_basic"
+			}
+			doc, err := emitStaticSurfaceVector(b, item)
+			if err != nil {
+				return fmt.Errorf("static %s: %w", item.name, err)
+			}
+			stem := "invalid_" + stemBase + "_static_" + itoa(item.n)
+			if err := writeInvalidVector(outDir, stem, doc, opGethCommit); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown --mode %q", mode)
+	}
+}
+
+// buildCaseFromSpecs finds a caseSpec by name+fork and builds the input case.
+// Used by both the CLI modes and the Go tests.
+func buildCaseFromSpecs(name, fork string) (inputCase, error) {
+	for _, spec := range caseSpecs {
+		if spec.name != name {
+			continue
+		}
+		for _, f := range spec.forks {
+			if f == fork {
+				return spec.build(fork), nil
+			}
+		}
+		return inputCase{}, fmt.Errorf("caseSpec %q has no fork %q (available: %v)", name, fork, spec.forks)
+	}
+	return inputCase{}, fmt.Errorf("caseSpec %q not found in caseSpecs", name)
+}
+
+// splitVectorName splits a vector stem "fork_name" into its fork prefix and the
+// remaining name. Fork names contain no underscores, so the first underscore is
+// the boundary (e.g. isthmus_transfer_basic -> isthmus/transfer_basic).
+func splitVectorName(stem string) (fork, name string, err error) {
+	i := strings.IndexByte(stem, '_')
+	if i < 0 {
+		return "", "", fmt.Errorf("stem %q has no fork prefix (want fork_name)", stem)
+	}
+	return stem[:i], stem[i+1:], nil
+}
+
+func itoa(n int) string {
+	return fmt.Sprintf("%d", n)
+}
+
+// ---------------------------------------------------------------------
+// Task 4: invalid-tx mode (§4b). Independent from the shared caseSpecs table.
+// ---------------------------------------------------------------------
+
+// invalidTxSpec returns the §4b spec for a kind.
+func invalidTxSpec(kind string) (*invalidTxCaseSpec, error) {
+	for i := range invalidTxCaseSpecs {
+		if invalidTxCaseSpecs[i].kind == kind {
+			return &invalidTxCaseSpecs[i], nil
+		}
+	}
+	return nil, fmt.Errorf("invalidTxSpec: unknown kind %q (available: %v)", kind, invalidTxKinds())
+}
+
+// buildInvalidTxCase looks up a §4b kind+fork and builds the input case
+// (deposit + pre-state) plus the kind's invalid-tx builder.
+func buildInvalidTxCase(kind, fork string) (inputCase, invalidTxBuilder, error) {
+	spec, err := invalidTxSpec(kind)
+	if err != nil {
+		return inputCase{}, nil, err
+	}
+	for _, f := range spec.forks {
+		if f == fork {
+			in, builder := spec.build(fork)
+			return in, builder, nil
+		}
+	}
+	return inputCase{}, nil, fmt.Errorf("invalidTxSpec %q has no fork %q (available: %v)", kind, fork, spec.forks)
+}
+
+// buildGenesisForCase assembles the core.Genesis for an input case — the same
+// construction buildBlockVector/processBlockVector use (byte-invariant golden
+// path), factored out for the invalid-tx path (which cannot go through
+// GenerateChainWithGenesis: AddTx rejects invalid txs).
+func buildGenesisForCase(in *inputCase, cfg *params.ChainConfig) (*core.Genesis, error) {
+	genesisTime := uint64(in.Genesis.Timestamp)
+	denom := uint64(in.Genesis.EIP1559Denominator)
+	elasticity := uint64(in.Genesis.EIP1559Elasticity)
+	var minBaseFee *uint64
+	if cfg.IsJovian(genesisTime) {
+		if in.Genesis.MinBaseFee == nil {
+			return nil, fmt.Errorf("jovian case must set genesis.minBaseFee (EncodeOptimismExtraData requires it)")
+		}
+		v := uint64(*in.Genesis.MinBaseFee)
+		minBaseFee = &v
+	}
+	var genesisBaseFee *big.Int
+	if in.Genesis.BaseFee != nil {
+		genesisBaseFee = (*big.Int)(in.Genesis.BaseFee)
+	}
+	return &core.Genesis{
+		Config:     cfg,
+		Timestamp:  genesisTime,
+		GasLimit:   uint64(in.Genesis.GasLimit),
+		BaseFee:    genesisBaseFee,
+		Difficulty: big.NewInt(0),
+		ExtraData:  eip1559.EncodeOptimismExtraData(cfg, genesisTime, denom, elasticity, minBaseFee),
+		Alloc:      in.Pre,
+	}, nil
+}
+
+// buildInvalidTxBlock assembles a STRUCTURALLY-valid block whose body contains
+// deposit + invalid (an invalid non-deposit tx). GenerateChain cannot AddTx an
+// invalid tx, so txRoot is hand-rolled (types.DeriveSha over the two txs) and
+// blockHash is recomputed from the header; stateRoot is a placeholder (the
+// block fails at execution, before any stateRoot comparison — FISCO only
+// reaches execution after the step-2 blockHash check). The header is fully
+// legal: extraData = EncodeOptimismExtraData (else VerifyHeaders rejects
+// first), baseFee recomputed from the parent (else InsertChain rejects with
+// "invalid baseFee" before the tx), withdrawalsRoot = EmptyWithdrawalsHash
+// (Isthmus+), requestsHash = EmptyRequestsHash, blobGasUsed/excessBlobGas = 0,
+// parentBeaconRoot set. The invalid tx is inserted AFTER the L1 attributes
+// deposit: the first-tx-is-L1-attributes gate was demoted to a WARNING log
+// (finding D #5429 — FISCO accepts like op-geth/op-reth), so the anchor for
+// this vector is the invalid tx's execution failure, not the position-0 gate.
+func buildInvalidTxBlock(in *inputCase, cfg *params.ChainConfig, genesis *core.Genesis,
+	signer types.Signer, deposit, invalid *types.Transaction) (*types.Block, error) {
+	if in == nil || cfg == nil || genesis == nil {
+		return nil, fmt.Errorf("buildInvalidTxBlock: nil in/cfg/genesis")
+	}
+	if deposit == nil || invalid == nil {
+		return nil, fmt.Errorf("buildInvalidTxBlock: nil deposit/invalid tx")
+	}
+	if !deposit.IsDepositTx() {
+		return nil, fmt.Errorf("buildInvalidTxBlock: tx0 must be the L1 attributes deposit (got type %d)", deposit.Type())
+	}
+	genesisTime := uint64(in.Genesis.Timestamp)
+	blockTime := genesisTime + 10
+	denom := uint64(in.Genesis.EIP1559Denominator)
+	elasticity := uint64(in.Genesis.EIP1559Elasticity)
+	var minBaseFee *uint64
+	if cfg.IsJovian(blockTime) {
+		if in.Genesis.MinBaseFee == nil {
+			return nil, fmt.Errorf("jovian invalid-tx case must set genesis.minBaseFee (EncodeOptimismExtraData requires it)")
+		}
+		v := uint64(*in.Genesis.MinBaseFee)
+		minBaseFee = &v
+	}
+	extra := eip1559.EncodeOptimismExtraData(cfg, blockTime, denom, elasticity, minBaseFee)
+
+	txs := []*types.Transaction{deposit, invalid}
+	txRoot := types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil))
+	parentBlock := genesis.ToBlock()
+	parentHash := parentBlock.Hash()
+	// Block 1 baseFee is recomputed from the parent (genesis) by the chain —
+	// a hardcoded parent BaseFee would fail InsertChain's "invalid baseFee"
+	// header check BEFORE reaching the invalid tx, mis-anchoring the rejection.
+	baseFee := eip1559.CalcBaseFee(cfg, parentBlock.Header(), blockTime)
+
+	header := &types.Header{
+		ParentHash:       parentHash,
+		UncleHash:        types.EmptyUncleHash,
+		Coinbase:         in.Coinbase,
+		Root:             types.EmptyRootHash, // placeholder — execution fails before stateRoot comparison
+		TxHash:           txRoot,
+		ReceiptHash:      types.EmptyReceiptsHash,
+		Bloom:            types.Bloom{},
+		Difficulty:       big.NewInt(0),
+		Number:           big.NewInt(1),
+		GasLimit:         genesis.GasLimit,
+		GasUsed:          0,
+		Time:             blockTime,
+		Extra:            extra,
+		MixDigest:        common.Hash{},
+		BaseFee:          baseFee,
+		WithdrawalsHash:  &types.EmptyWithdrawalsHash,
+		RequestsHash:     &types.EmptyRequestsHash,
+		BlobGasUsed:      new(uint64),
+		ExcessBlobGas:    new(uint64),
+		ParentBeaconRoot: &in.ParentBeaconBlockRoot,
+	}
+	// NewBlock requires non-nil empty withdrawals on the Isthmus+ path
+	// (HasOptimismWithdrawalsRoot → panic on nil), and recomputes TxHash /
+	// ReceiptHash / WithdrawalsHash from the body (all agree with our header).
+	body := &types.Body{Transactions: txs, Withdrawals: types.Withdrawals{}}
+	block := types.NewBlock(header, body, nil, trie.NewStackTrie(nil), cfg)
+	if block.Hash() != header.Hash() {
+		return nil, fmt.Errorf("buildInvalidTxBlock: NewBlock hash %s != header hash %s", block.Hash().Hex(), header.Hash().Hex())
+	}
+	return block, nil
+}
+
+// buildInvalidTxPayload assembles the ExecutionPayload JSON for an invalid-tx
+// block (same field units/conventions as buildOpPayload: timestamp in OP
+// seconds, every quantity a hex string). txs are the block's transactions in
+// order (deposit, invalid) — the raw envelopes the engine decodes.
+func buildInvalidTxPayload(header *types.Header, blockHash common.Hash, txs []*types.Transaction) (map[string]interface{}, error) {
+	if header.WithdrawalsHash == nil || header.BlobGasUsed == nil || header.ExcessBlobGas == nil || header.ParentBeaconRoot == nil {
+		return nil, fmt.Errorf("buildInvalidTxPayload: header missing WithdrawalsHash/BlobGasUsed/ExcessBlobGas/ParentBeaconRoot")
+	}
+	txHexes := make([]string, len(txs))
+	for i, tx := range txs {
+		b, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("buildInvalidTxPayload: tx %d MarshalBinary: %w", i, err)
+		}
+		txHexes[i] = hexutil.Encode(b)
+	}
+	return map[string]interface{}{
+		"parentHash":            header.ParentHash.Hex(),
+		"feeRecipient":          strings.ToLower(header.Coinbase.Hex()),
+		"stateRoot":             header.Root.Hex(),
+		"receiptsRoot":          header.ReceiptHash.Hex(),
+		"logsBloom":             hexutil.Encode(header.Bloom[:]),
+		"prevRandao":            header.MixDigest.Hex(),
+		"blockNumber":           hexutil.EncodeUint64(header.Number.Uint64()),
+		"gasLimit":              hexutil.EncodeUint64(header.GasLimit),
+		"gasUsed":               hexutil.EncodeUint64(header.GasUsed),
+		"timestamp":             hexutil.EncodeUint64(header.Time),
+		"extraData":             hexutil.Encode(header.Extra),
+		"baseFeePerGas":         hexutil.EncodeBig(header.BaseFee),
+		"blockHash":             blockHash.Hex(),
+		"withdrawalsRoot":       header.WithdrawalsHash.Hex(),
+		"blobGasUsed":           hexutil.EncodeUint64(*header.BlobGasUsed),
+		"excessBlobGas":         hexutil.EncodeUint64(*header.ExcessBlobGas),
+		"parentBeaconBlockRoot": header.ParentBeaconRoot.Hex(),
+		"withdrawals":           []interface{}{},
+		"transactions":          txHexes,
+	}, nil
+}
+
+// buildInvalidTxReject fills the _op_expected.reject schema for a §4b kind.
+// consumer follows review R16: decode-level kinds carry the FISCO decode
+// message as validation_error_contains (a reliable engine surface); the rest
+// carry the T8n throw message (executor-only semantics — the engine
+// RTTI-bypass collapses it to a generic message, so the E2E runner must not
+// assert validation_error_contains on those).
+func buildInvalidTxReject(spec *invalidTxCaseSpec) *rejectExpected {
+	validationContains := spec.t8n
+	if spec.decode != "" {
+		validationContains = spec.decode
+	}
+	return &rejectExpected{
+		OpGeth: spec.opGeth,
+		Fisco: fiscoReject{
+			Consumer:                spec.consumer,
+			Classification:          "INVALID",
+			LatestValidHash:         json.RawMessage(`"parent"`),
+			ValidationErrorContains: validationContains,
+		},
+	}
+}
+
+// buildInvalidTxVector assembles the full on-disk invalid vector for a §4b
+// kind+fork, plus the built block and genesis (the Go tests verify txRoot /
+// blockHash / InsertChain rejection against them). The vector carries BOTH the
+// engine payload (_op_payload) AND the T8n replay surface (env + block).
+func buildInvalidTxVector(kind, fork string) (invalidVectorDoc, *types.Block, *core.Genesis, error) {
+	zero := invalidVectorDoc{}
+	spec, err := invalidTxSpec(kind)
+	if err != nil {
+		return zero, nil, nil, err
+	}
+	in, buildInvalid, err := buildInvalidTxCase(kind, fork)
+	if err != nil {
+		return zero, nil, nil, err
+	}
+	cfg, err := buildConfigForCase(&in)
+	if err != nil {
+		return zero, nil, nil, err
+	}
+	genesis, err := buildGenesisForCase(&in, cfg)
+	if err != nil {
+		return zero, nil, nil, err
+	}
+	blockTime := uint64(in.Genesis.Timestamp) + 10
+	signer := types.MakeSigner(cfg, big.NewInt(1), blockTime)
+	deposit, depositOut, err := buildTx(&in.Transactions[0], signer, cfg)
+	if err != nil {
+		return zero, nil, nil, fmt.Errorf("deposit: %w", err)
+	}
+	invalid, invalidOut, err := buildInvalid(signer, cfg)
+	if err != nil {
+		return zero, nil, nil, fmt.Errorf("invalid tx: %w", err)
+	}
+	blk, err := buildInvalidTxBlock(&in, cfg, genesis, signer, deposit, invalid)
+	if err != nil {
+		return zero, nil, nil, err
+	}
+	payload, err := buildInvalidTxPayload(blk.Header(), blk.Hash(), []*types.Transaction{deposit, invalid})
+	if err != nil {
+		return zero, nil, nil, err
+	}
+	env := outputEnv{
+		CurrentCoinbase:       strings.ToLower(in.Coinbase.Hex()),
+		CurrentNumber:         hexutil.EncodeUint64(1),
+		CurrentTimestamp:      hexutil.EncodeUint64(blockTime),
+		CurrentGasLimit:       hexutil.EncodeUint64(blk.GasLimit()),
+		CurrentBaseFee:        hexutil.EncodeBig(blk.BaseFee()),
+		CurrentRandom:         "0x0",
+		ParentBeaconBlockRoot: in.ParentBeaconBlockRoot.Hex(),
+		ParentHash:            blk.ParentHash().Hex(),
+	}
+	doc := invalidVectorDoc{
+		Info: caseInfo{
+			Hardfork: fork,
+			Description: fmt.Sprintf("%s: %s (invalid %s tx inserted after the L1 attributes deposit)",
+				spec.kind, spec.opGeth, spec.kind),
+		},
+		Pre:   emitPre(in.Pre),
+		Env:   &env,
+		Block: &outputBlock{Transactions: []json.RawMessage{depositOut, invalidOut}},
+		// The replayer's setcode loader hard-requires `postState` for any auth
+		// tuple; the rejected block applies no delegation, so the map is empty.
+		// Only setcode txs carry it (all other arms never read postState).
+		PostState: &types.GenesisAlloc{},
+		OpPayload: payload,
+		OpExpected: invalidExpected{
+			Reject: buildInvalidTxReject(spec),
+		},
+	}
+	return doc, blk, genesis, nil
+}
+
+// recomputeOpHeaderHash returns the canonical OP block hash: keccak256 of the
+// RLP-encoded header (op-geth types.Header.Hash(), core/types/block.go:124).
+// This is what makes a corruption SELF-CONSISTENT -- the payload blockHash is
+// re-derived from the corrupt header, so the engine gate's step-2 blockHash
+// check passes and the rejection lands on the corrupted FIELD (step-5/six-way).
+func recomputeOpHeaderHash(h *types.Header) common.Hash {
+	return h.Hash()
+}
+
+// corruptVector applies the §4a per-field corrupt recipe to a valid generated
+// block and returns the invalid vector document plus the rebuilt corrupt block
+// (for captureInsertChainRejection). The blockHash field is the documented
+// exception: no corrupt block is produced (InsertChain would ACCEPT it -- the
+// block's own hash stays self-consistent) and the anchor is the engine-API
+// "blockhash mismatch" message recorded directly.
+func corruptVector(base *blockVector, field string) (invalidVectorDoc, *types.Block, error) {
+	if base == nil || base.block == nil || base.genesis == nil || base.golden == nil {
+		return invalidVectorDoc{}, nil, fmt.Errorf("corruptVector: nil base/block/genesis/golden")
+	}
+	header := base.block.Header()
+	corruptHeader := types.CopyHeader(header)
+	blockHash := common.Hash{}
+	recompute := true
+
+	switch field {
+	case "stateRoot":
+		flipHashByte(&corruptHeader.Root)
+	case "gasUsed":
+		corruptHeader.GasUsed = corruptGasUsedValue(header.GasLimit, header.GasUsed)
+	case "receiptsRoot":
+		flipHashByte(&corruptHeader.ReceiptHash)
+	case "parentHash":
+		// Unknown-ancestor recipe: the parent becomes a hash nothing in the
+		// chain answers to -> SYNCING on the FISCO side, "unknown ancestor" on
+		// the op-geth InsertChain side.
+		corruptHeader.ParentHash = common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
+	case "extraData":
+		// Shape break (size), NO blockHash recompute: the static shape check
+		// (FISCO validateOpNewPayloadRequest / op-geth ValidateHoloceneExtraData)
+		// fires before any blockHash comparison, so the payload keeps the
+		// ORIGINAL golden blockHash.
+		recompute = false
+		blockHash = common.HexToHash(base.golden.BlockHash)
+		corruptHeader.Extra = corruptExtraData(base.cfg, header.Time)
+	case "blockHash":
+		// payload.blockHash corruption, NO recompute, NO capture block.
+		recompute = false
+		bh := common.HexToHash(base.golden.BlockHash)
+		flipHashByte(&bh)
+		blockHash = bh
+		corruptHeader = nil
+	default:
+		return invalidVectorDoc{}, nil, fmt.Errorf("corruptVector: unknown field %q", field)
+	}
+	if recompute {
+		blockHash = recomputeOpHeaderHash(corruptHeader)
+	}
+
+	// Rebuild the corrupt block: base block (built with types.NewBlock per the
+	// brief) + WithSeal to swap in the corrupt header while keeping the body.
+	// WithSeal is safe where NewBlockWithHeader is not: it preserves the
+	// transactions (NewBlockWithHeader would drop them).
+	var corruptBlock *types.Block
+	if corruptHeader != nil {
+		corruptBlock = base.block.WithSeal(corruptHeader)
+	}
+
+	rej, err := buildRejectForCorruptField(base, field, corruptBlock)
+	if err != nil {
+		return invalidVectorDoc{}, nil, err
+	}
+
+	payloadHeader := header
+	if corruptHeader != nil {
+		payloadHeader = corruptHeader
+	}
+	payload := buildOpPayload(base, payloadHeader, blockHash)
+
+	doc := invalidVectorDoc{
+		Info: caseInfo{
+			Hardfork:    base.vec.Info.Hardfork,
+			Description: base.vec.Info.Description + " (corrupt " + field + ")",
+		},
+		Pre:       base.vec.Pre,
+		OpPayload: payload,
+		OpExpected: invalidExpected{
+			Reject: rej,
+		},
+	}
+	return doc, corruptBlock, nil
+}
+
+func flipHashByte(h *common.Hash) {
+	b := h[:]
+	b[0] ^= 0xff
+}
+
+// corruptGasUsedValue returns a gasUsed value that is <= gasLimit and differs
+// from the actual value, so the corruption lands in the "invalid gas used"
+// bucket (op-geth block_validator.go:154) instead of the gasLimit bound check.
+func corruptGasUsedValue(gasLimit, actual uint64) uint64 {
+	v := gasLimit
+	if v == actual {
+		if v == 0 {
+			return 0 // cannot corrupt below 0; caller asserts rejection elsewhere
+		}
+		v--
+	}
+	return v
+}
+
+// corruptExtraData breaks the Holocene+ extraData shape: it returns a wrong
+// length (8 bytes for Isthmus, 16 for Jovian) whose version byte is correct so
+// the failure is unambiguous -- "should be 9/17 bytes". op-geth anchor:
+// "invalid optimism extraData: holocene extraData should be 9 bytes, got 8"
+// (Isthmus) / "Jovian extraData should be 17 bytes, got 16" (Jovian). FISCO:
+// "extraData must be exactly 9/17 bytes on the OP path (Isthmus/Jovian)".
+func corruptExtraData(cfg *params.ChainConfig, blockTime uint64) []byte {
+	if cfg.IsJovian(blockTime) {
+		return []byte{0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0} // 16B, version 0x01
+	}
+	return []byte{0x00, 0, 0, 0, 0, 0, 0, 0} // 8B, version 0x00
+}
+
+// buildRejectForCorruptField fills the _op_expected.reject schema for a corrupt
+// field. For every field EXCEPT blockHash it captures the REAL op-geth
+// InsertChain rejection message (the weak op_geth anchor) and derives the FISCO
+// classification from the recipe.
+func buildRejectForCorruptField(base *blockVector, field string, corruptBlock *types.Block) (*rejectExpected, error) {
+	switch field {
+	case "stateRoot", "gasUsed", "receiptsRoot":
+		if corruptBlock == nil {
+			return nil, fmt.Errorf("corrupt %s: nil capture block", field)
+		}
+		msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+		if err != nil {
+			return nil, fmt.Errorf("corrupt %s: InsertChain capture: %w", field, err)
+		}
+		return &rejectExpected{
+			OpGeth: msg,
+			Fisco: fiscoReject{
+				Consumer:                "engine",
+				Classification:          "INVALID",
+				LatestValidHash:         json.RawMessage(`"parent"`),
+				ValidationErrorContains: field,
+			},
+		}, nil
+	case "parentHash":
+		if corruptBlock == nil {
+			return nil, fmt.Errorf("corrupt parentHash: nil capture block")
+		}
+		msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+		if err != nil {
+			return nil, fmt.Errorf("corrupt parentHash: InsertChain capture: %w", err)
+		}
+		// SYNCING: parent unknown is the design intent; no latest_valid_hash, no
+		// validation_error (the FISCO runner asserts SYNCING status only).
+		return &rejectExpected{
+			OpGeth: msg,
+			Fisco: fiscoReject{
+				Consumer:       "engine",
+				Classification: "SYNCING",
+			},
+		}, nil
+	case "extraData":
+		if corruptBlock == nil {
+			return nil, fmt.Errorf("corrupt extraData: nil capture block")
+		}
+		msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+		if err != nil {
+			return nil, fmt.Errorf("corrupt extraData: InsertChain capture: %w", err)
+		}
+		return &rejectExpected{
+			OpGeth: msg,
+			Fisco: fiscoReject{
+				Consumer:                "engine",
+				Classification:          "INVALID",
+				LatestValidHash:         json.RawMessage("null"),
+				ValidationErrorContains: fiscoExtraDataMessage(base.cfg, base.block.Header().Time),
+			},
+		}, nil
+	case "blockHash":
+		// No InsertChain capture: the block's own hash stays self-consistent, so
+		// InsertChain ACCEPTS it. The anchor is the engine-API ExecutableDataToBlock
+		// message (beacon/engine/types.go:281). FISCO rebuilds the header and
+		// rejects with "blockHash does not match the reconstructed block header"
+		// (EngineServiceImpl.h:895-899), INVALID + latestValidHash=null.
+		return &rejectExpected{
+			OpGeth: "blockhash mismatch",
+			Fisco: fiscoReject{
+				Consumer:                "engine",
+				Classification:          "INVALID",
+				LatestValidHash:         json.RawMessage("null"),
+				ValidationErrorContains: "blockHash does not match the reconstructed block header",
+			},
+		}, nil
+	default:
+		return nil, fmt.Errorf("buildRejectForCorruptField: unknown field %q", field)
+	}
+}
+
+// fiscoExtraDataMessage returns the FISCO validateOpNewPayloadRequest substring
+// that matches the corruptExtraData shape break (EngineServiceImpl.cpp:430-452).
+func fiscoExtraDataMessage(cfg *params.ChainConfig, blockTime uint64) string {
+	if cfg.IsJovian(blockTime) {
+		return "extraData must be exactly 17 bytes on the OP path (Jovian)"
+	}
+	return "extraData must be exactly 9 bytes on the OP path (Isthmus)"
+}
+
+// buildOpPayload assembles the full ExecutionPayload JSON for an invalid vector
+// from a (possibly corrupt) header. Field names/units follow makeParamsJson
+// (GoldenSample.h): timestamp in OP seconds; every quantity a hex string.
+func buildOpPayload(base *blockVector, header *types.Header, blockHash common.Hash) map[string]interface{} {
+	return buildPayloadFromHeader(header, blockHash, base.txs)
+}
+
+// buildPayloadFromHeader assembles the full ExecutionPayload JSON from a
+// (possibly corrupt) header + its tx list. Shared by buildOpPayload (the
+// blockVector path) and the Task 5 chain fork/break carriers (which have raw
+// *types.Block and no blockVector).
+func buildPayloadFromHeader(header *types.Header, blockHash common.Hash, txs []*types.Transaction) map[string]interface{} {
+	if header.WithdrawalsHash == nil || header.BlobGasUsed == nil || header.ExcessBlobGas == nil {
+		// Cannot happen on the isthmus/jovian path (assembleOutput asserts the
+		// first two; buildGoldenRecord asserts ExcessBlobGas == 0) -- guard for
+		// a nil-deref-free error surface.
+		panic("buildPayloadFromHeader: header missing WithdrawalsHash/BlobGasUsed/ExcessBlobGas")
+	}
+	txHexes := make([]string, len(txs))
+	for i, tx := range txs {
+		b, err := tx.MarshalBinary()
+		if err != nil {
+			panic("buildPayloadFromHeader: tx MarshalBinary: " + err.Error())
+		}
+		txHexes[i] = hexutil.Encode(b)
+	}
+	return map[string]interface{}{
+		"parentHash":            header.ParentHash.Hex(),
+		"feeRecipient":          strings.ToLower(header.Coinbase.Hex()),
+		"stateRoot":             header.Root.Hex(),
+		"receiptsRoot":          header.ReceiptHash.Hex(),
+		"logsBloom":             hexutil.Encode(header.Bloom[:]),
+		"prevRandao":            header.MixDigest.Hex(),
+		"blockNumber":           hexutil.EncodeUint64(header.Number.Uint64()),
+		"gasLimit":              hexutil.EncodeUint64(header.GasLimit),
+		"gasUsed":               hexutil.EncodeUint64(header.GasUsed),
+		"timestamp":             hexutil.EncodeUint64(header.Time),
+		"extraData":             hexutil.Encode(header.Extra),
+		"baseFeePerGas":         hexutil.EncodeBig(header.BaseFee),
+		"blockHash":             blockHash.Hex(),
+		"withdrawalsRoot":       header.WithdrawalsHash.Hex(),
+		"blobGasUsed":           hexutil.EncodeUint64(*header.BlobGasUsed),
+		"excessBlobGas":         hexutil.EncodeUint64(*header.ExcessBlobGas),
+		"parentBeaconBlockRoot": header.ParentBeaconRoot.Hex(),
+		"withdrawals":           []interface{}{},
+		"transactions":          txHexes,
+	}
+}
+
+// captureInsertChainRejection runs a corrupt block through a fresh
+// core.NewBlockChain (4-arg, matching this checkout's selfCheck precedent at
+// main.go:1464) + InsertChain and returns the rejection message. A corrupt
+// block that is ACCEPTED is a hard error (iron-rule mirror violation: the
+// corruption recipe silently failed to produce a rejection).
+func captureInsertChainRejection(genesis *core.Genesis, block *types.Block) (string, error) {
+	engine := beacon.New(ethash.NewFaker())
+	chain, err := core.NewBlockChain(rawdb.NewMemoryDatabase(), genesis, engine, nil)
+	if err != nil {
+		return "", fmt.Errorf("NewBlockChain: %w", err)
+	}
+	defer chain.Stop()
+	if _, err := chain.InsertChain(types.Blocks{block}); err == nil {
+		return "", fmt.Errorf("corrupt block ACCEPTED (iron-rule mirror violation)")
+	} else {
+		return err.Error(), nil
+	}
+}
+
+// ---------------------------------------------------------------------
+// §4c static surface (--mode=static)
+// ---------------------------------------------------------------------
+
+// staticItem is one §4c static-validation malformation. mutate rewrites the
+// base payload; fiscoMessage is the EXACT substring the FISCO
+// validateOpNewPayloadRequest (EngineServiceImpl.cpp:310-508) returns, which the
+// E2E runner asserts via validation_error_contains. fork selects the base block
+// (isthmus|jovian) -- item 11 (Jovian DA footprint) needs a Jovian base.
+type staticItem struct {
+	n            int
+	name         string
+	fork         string
+	mutate       func(payload map[string]interface{}) error
+	fiscoMessage string
+}
+
+// staticSurfaceItems enumerates the 12 §4c items. ⚠️ Expressibility through the
+// Task 2 loader (GoldenSample.h makeInvalidParamsJson) + parseNewPayloadRequest
+// is the constraint that decides whether an item actually reaches its FISCO
+// message in the E2E runner:
+//   - items 3 (expectedBlobVersionedHashes non-empty) and 12 (executionRequests
+//     non-empty) CANNOT be expressed: the loader hardcodes params[1] = [] and
+//     parseNewPayloadRequest never parses executionRequests. They are emitted
+//     per the brief but must NOT be manifest-registered until the loader/RPC
+//     parse is extended (see task-3-report).
+//   - item 1 (rawTransactions missing) is expressed as `transactions: null`
+//     (NOT omission -- the loader substitutes an empty array for a missing
+//     member, which would convert the case into a blockHash mismatch).
+//   - item 8 (blockNumber negative) is expressed as 0x8000000000000000, which
+//     fromQuantity parses as uint64 and the cast to int64 wraps negative.
+var staticSurfaceItems = []staticItem{
+	{1, "rawTransactions_missing", "isthmus", func(p map[string]interface{}) error {
+		p["transactions"] = nil
+		return nil
+	}, "executionPayload.rawTransactions is required on the OP path"},
+	{2, "withdrawals_nonempty", "isthmus", func(p map[string]interface{}) error {
+		p["withdrawals"] = []map[string]interface{}{
+			{"index": "0x0", "validatorIndex": "0x0", "amount": "0x1", "address": "0x0000000000000000000000000000000000000001"},
+		}
+		return nil
+	}, "withdrawals must be present and empty on the OP path"},
+	{3, "expectedBlobVersionedHashes_nonempty", "isthmus", func(p map[string]interface{}) error {
+		p["expectedBlobVersionedHashes"] = []string{"0x0000000000000000000000000000000000000000000000000000000000000001"}
+		return nil
+	}, "expectedBlobVersionedHashes must be an empty array on the OP path"},
+	{4, "parentBeaconBlockRoot_missing", "isthmus", func(p map[string]interface{}) error {
+		delete(p, "parentBeaconBlockRoot")
+		return nil
+	}, "parentBeaconBlockRoot must be a 32-byte hash for newPayloadV4"},
+	{5, "withdrawalsRoot_missing", "isthmus", func(p map[string]interface{}) error {
+		delete(p, "withdrawalsRoot")
+		return nil
+	}, "withdrawalsRoot is required on the OP path (Isthmus+)"},
+	{6, "excessBlobGas_nonzero", "isthmus", func(p map[string]interface{}) error {
+		p["excessBlobGas"] = "0x1"
+		return nil
+	}, "excessBlobGas must be present and zero on the OP path"},
+	{7, "isthmus_blobGasUsed_nonzero", "isthmus", func(p map[string]interface{}) error {
+		p["blobGasUsed"] = "0x1"
+		return nil
+	}, "blobGasUsed must be zero before Jovian (OP Isthmus)"},
+	{8, "blockNumber_negative", "isthmus", func(p map[string]interface{}) error {
+		p["blockNumber"] = "0x8000000000000000" // uint64 2^63 wraps to negative int64
+		return nil
+	}, "blockNumber must not be negative"},
+	{9, "gasLimit_overlimit", "isthmus", func(p map[string]interface{}) error {
+		p["gasLimit"] = "0xffffffffffffffff" // 2^64-1 > 2^63-1
+		return nil
+	}, "gasLimit exceeds the maximum block gas limit (2^63-1)"},
+	{10, "extraData_shape", "isthmus", func(p map[string]interface{}) error {
+		p["extraData"] = "0x0000000000000000" // 8 bytes, not 9
+		return nil
+	}, "extraData must be exactly 9 bytes on the OP path (Isthmus)"},
+	{11, "jovian_da_footprint_over_gaslimit", "jovian", func(p map[string]interface{}) error {
+		p["blobGasUsed"] = "0x2000000" // 2^25 = 33554432 > 10M gasLimit
+		return nil
+	}, "DA footprint (blobGasUsed) exceeds the block gas limit"},
+	{12, "executionRequests_nonempty", "isthmus", func(p map[string]interface{}) error {
+		p["executionRequests"] = []map[string]interface{}{
+			{"type": "0x0", "data": "0xdeadbeef"},
+		}
+		return nil
+	}, "executionRequests must be absent or empty on the OP path"},
+}
+
+// buildBasePayload assembles the FULL valid payload of a base block (all base
+// true values + the original golden blockHash). The §4c items start from here
+// and malform one field.
+func buildBasePayload(base *blockVector) map[string]interface{} {
+	return buildOpPayload(base, base.block.Header(), common.HexToHash(base.golden.BlockHash))
+}
+
+// emitStaticSurfaceVector builds the invalid vector document for one §4c static
+// item: base payload + the item's malformation + the FISCO static reject schema.
+// All static items reject at validateOpNewPayloadRequest -> INVALID +
+// latestValidHash=null.
+func emitStaticSurfaceVector(base *blockVector, item staticItem) (invalidVectorDoc, error) {
+	if base == nil || base.block == nil || base.golden == nil {
+		return invalidVectorDoc{}, fmt.Errorf("emitStaticSurfaceVector: nil base")
+	}
+	payload := buildBasePayload(base)
+	if item.mutate != nil {
+		if err := item.mutate(payload); err != nil {
+			return invalidVectorDoc{}, err
+		}
+	}
+	return invalidVectorDoc{
+		Info: caseInfo{
+			Hardfork:    base.vec.Info.Hardfork,
+			Description: base.vec.Info.Description + " (static " + item.name + ")",
+		},
+		Pre:       base.vec.Pre,
+		OpPayload: payload,
+		OpExpected: invalidExpected{
+			Reject: &rejectExpected{
+				OpGeth: item.fiscoMessage,
+				Fisco: fiscoReject{
+					Consumer:                "engine",
+					Classification:          "INVALID",
+					LatestValidHash:         json.RawMessage("null"),
+					ValidationErrorContains: item.fiscoMessage,
+				},
+			},
+		},
+	}, nil
+}
+
+// writeInvalidVector writes one invalid vector as vectors/invalid_*.json with
+// the same outer-wrapping convention as run() (a `_op_test_vectors` meta object
+// plus the single vector object keyed by the stem).
+func writeInvalidVector(outDir, stem string, doc invalidVectorDoc, opGethCommit string) error {
+	meta, err := json.Marshal(struct {
+		Version         string `json:"version"`
+		Generator       string `json:"generator"`
+		GeneratorCommit string `json:"generator_commit"`
+	}{schemaVersion, "opt8n-ref", opGethCommit})
+	if err != nil {
+		return err
+	}
+	docBytes, err := json.Marshal(doc)
+	if err != nil {
+		return err
+	}
+	out := map[string]json.RawMessage{
+		"_op_test_vectors": meta,
+		stem:               docBytes,
+	}
+	outBytes, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return err
+	}
+	outBytes = append(outBytes, '\n')
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outDir, stem+".json"), outBytes, 0o644)
+}
+
+// ---------------------------------------------------------------------
+// L1Block slot <-> calldata consistency (iron rule 2)
+//
+// Calldata layout (rollup_cost.go extractL1GasParamsPostEcotone /
+// extractL1GasParamsPostIsthmus / ExtractDAFootprintGasScalar):
+//   [0:4]   selector (Ecotone 0x440a5e20 / Isthmus 0x098999be / Jovian 0x3db6be2b)
+//   [4:8]   baseFeeScalar        <-> slot 3 bytes [16:20]
+//   [8:12]  blobBaseFeeScalar    <-> slot 3 bytes [20:24]
+//   [36:68] l1BaseFee            <-> slot 1
+//   [68:100] l1BlobBaseFee       <-> slot 7
+//   [164:168] operatorFeeScalar  <-> slot 8 bytes [20:24]   (Isthmus+ only)
+//   [168:176] operatorFeeConstant<-> slot 8 bytes [24:32]   (Isthmus+ only)
+//   [176:178] daFootprintGasScalar (Jovian) <-> slot 8 bytes [18:20]
+//             (slot mapping mirrors bcos-evm-ref OpFeeParams.h)
+// The Ecotone 164B layout has NO [164:176] operator-fee segment and no
+// [176:178] DA scalar. extractL1GasParamsPostEcotone hard-rejects any
+// non-164-byte payload, so the length/selector checks here are the corpus
+// guard against emitting an Isthmus-shaped deposit under an Ecotone-family
+// fork.
+// ---------------------------------------------------------------------
+
+// blockFork returns the fork that governs a block at the given time under cfg:
+// the latest activated OP fork (jovian > isthmus > holocene > granite > fjord
+// > ecotone). For pure fork-at-0 recipes this equals the case's hardfork; for
+// upgrade-boundary specs (Task 3) it is the BLOCK-TIME fork, which is what
+// decides the L1-attributes byte layout.
+func blockFork(cfg *params.ChainConfig, blockTime uint64) string {
+	switch {
+	case cfg.IsJovian(blockTime):
+		return "jovian"
+	case cfg.IsIsthmus(blockTime):
+		return "isthmus"
+	case cfg.IsHolocene(blockTime):
+		return "holocene"
+	case cfg.IsGranite(blockTime):
+		return "granite"
+	case cfg.IsFjord(blockTime):
+		return "fjord"
+	default:
+		return "ecotone"
+	}
+}
+
+func assertL1BlockConsistency(cfg *params.ChainConfig, in *inputCase) error {
+	if len(in.Transactions) == 0 {
+		return fmt.Errorf("case has no transactions (needs the L1 attributes deposit)")
+	}
+	tx0 := &in.Transactions[0]
+	if tx0.OpType != "deposit" || tx0.OpDeposit == nil {
+		return fmt.Errorf("tx 0 must be the L1 attributes deposit")
+	}
+	if tx0.OpDeposit.To == nil || *tx0.OpDeposit.To != l1BlockAddr {
+		return fmt.Errorf("tx 0 must target the L1Block predeploy %s", l1BlockAddr)
+	}
+	data := []byte(tx0.Data)
+	slot := func(n int64) common.Hash {
+		acc, ok := in.Pre[l1BlockAddr]
+		if !ok {
+			return common.Hash{}
+		}
+		return acc.Storage[common.BigToHash(big.NewInt(n))]
+	}
+	slot1, slot3, slot7, slot8 := slot(1), slot(3), slot(7), slot(8)
+
+	// blockTime (NOT genesis time) decides jovianCfg and the attributes LAYOUT:
+	// an upgrade-boundary vector whose genesis is pre-Isthmus/pre-Jovian but
+	// whose single block crosses IsthmusTime/JovianTime must be judged by the
+	// block-time fork -- op-geth switches the attributes deposit format at the
+	// fork boundary. For pure fork-at-0 recipes blockFork == the case hardfork.
+	blockTime := uint64(in.Genesis.Timestamp) + 10 // chain_makers.makeHeader: block time fixed at parent+10
+	jovianCfg := cfg.IsJovian(blockTime)
+	layout := forkLayout(blockFork(cfg, blockTime))
+
+	checkCommon := func(layout l1AttributesLayout) error {
+		if !bytes.Equal(slot1[:], data[36:68]) {
+			return fmt.Errorf("slot1 (l1BaseFee) %x != calldata[36:68] %x", slot1, data[36:68])
+		}
+		if !bytes.Equal(slot7[:], data[68:100]) {
+			return fmt.Errorf("slot7 (blobBaseFee) %x != calldata[68:100] %x", slot7, data[68:100])
+		}
+		if !bytes.Equal(slot3[16:20], data[4:8]) {
+			return fmt.Errorf("slot3[16:20] (baseFeeScalar) %x != calldata[4:8] %x", slot3[16:20], data[4:8])
+		}
+		if !bytes.Equal(slot3[20:24], data[8:12]) {
+			return fmt.Errorf("slot3[20:24] (blobBaseFeeScalar) %x != calldata[8:12] %x", slot3[20:24], data[8:12])
+		}
+		if layout != layoutEcotone {
+			// Operator-fee segment exists only in Isthmus+ layouts; the
+			// Ecotone 164B form has no [164:176] bytes to mirror.
+			if !bytes.Equal(slot8[20:24], data[164:168]) {
+				return fmt.Errorf("slot8[20:24] (operatorFeeScalar) %x != calldata[164:168] %x", slot8[20:24], data[164:168])
+			}
+			if !bytes.Equal(slot8[24:32], data[168:176]) {
+				return fmt.Errorf("slot8[24:32] (operatorFeeConstant) %x != calldata[168:176] %x", slot8[24:32], data[168:176])
+			}
+		}
+		// First-Ecotone fallback trap (rollup_cost.go:169-179): blob slot and
+		// BOTH 4-byte scalars all zero would silently select the Bedrock cost
+		// function. Forbidden corpus-wide.
+		if slot7 == (common.Hash{}) && isZero(slot3[16:24]) {
+			return fmt.Errorf("first-Ecotone fallback trap: slot7 and both slot3 scalars are all zero")
+		}
+		return nil
+	}
+
+	switch {
+	case jovianCfg && len(data) == types.IsthmusL1AttributesLen:
+		// Jovian config + Isthmus-length calldata = "first Jovian block"
+		// form (case 12): deposits only, slot-8 DA bytes zero, skip [176:178].
+		if !bytes.Equal(data[0:4], types.IsthmusL1AttributesSelector) {
+			return fmt.Errorf("Isthmus-length attributes under Jovian must use the Isthmus selector, got %x", data[0:4])
+		}
+		for i := range in.Transactions {
+			if in.Transactions[i].OpType != "deposit" {
+				return fmt.Errorf("Jovian activation-form block must be deposits-only (tx %d is %q)", i, in.Transactions[i].OpType)
+			}
+		}
+		if !isZero(slot8[18:20]) {
+			return fmt.Errorf("Jovian activation-form block requires slot8 DA bytes [18:20] zero, got %x", slot8[18:20])
+		}
+		return checkCommon(layoutIsthmus)
+	case jovianCfg:
+		if len(data) != types.JovianL1AttributesLen {
+			return fmt.Errorf("Jovian attributes must be %d bytes (or %d for the activation form), got %d",
+				types.JovianL1AttributesLen, types.IsthmusL1AttributesLen, len(data))
+		}
+		if !bytes.Equal(data[0:4], types.JovianL1AttributesSelector) {
+			return fmt.Errorf("Jovian attributes selector mismatch: got %x", data[0:4])
+		}
+		if err := checkCommon(layoutJovian); err != nil {
+			return err
+		}
+		if !bytes.Equal(slot8[18:20], data[176:178]) {
+			return fmt.Errorf("slot8[18:20] (daFootprintGasScalar) %x != calldata[176:178] %x", slot8[18:20], data[176:178])
+		}
+		return nil
+	case layout == layoutEcotone:
+		// Ecotone/Fjord/Granite/Holocene: exactly 164B with the Ecotone
+		// selector and NO operator-fee/DA segment. extractL1GasParamsPostEcotone
+		// (rollup_cost.go:477-479) hard-rejects any other length, so this is
+		// also the corpus-side guard that the deposit is not Isthmus-shaped.
+		if len(data) != 164 {
+			return fmt.Errorf("Ecotone-family attributes must be 164 bytes, got %d", len(data))
+		}
+		if !bytes.Equal(data[0:4], types.EcotoneL1AttributesSelector) {
+			return fmt.Errorf("Ecotone-family attributes selector mismatch: got %x", data[0:4])
+		}
+		return checkCommon(layoutEcotone)
+	default: // isthmus
+		if len(data) != types.IsthmusL1AttributesLen {
+			return fmt.Errorf("Isthmus attributes must be %d bytes, got %d", types.IsthmusL1AttributesLen, len(data))
+		}
+		if !bytes.Equal(data[0:4], types.IsthmusL1AttributesSelector) {
+			return fmt.Errorf("Isthmus attributes selector mismatch: got %x", data[0:4])
+		}
+		return checkCommon(layoutIsthmus)
+	}
+}
+
+func assertDepositsFirst(txs []inputTx) error {
+	seenNonDeposit := false
+	for i := range txs {
+		if txs[i].OpType == "deposit" {
+			if seenNonDeposit {
+				return fmt.Errorf("tx %d: deposit after non-deposit (deposits must come first)", i)
+			}
+		} else {
+			seenNonDeposit = true
+		}
+	}
+	return nil
+}
+
+func isZero(b []byte) bool {
+	for _, x := range b {
+		if x != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------
+// Transactions (three arms reused from the M-T generator, reshaped to the
+// v3-block output forms)
+// ---------------------------------------------------------------------
+
+// buildAccessList converts the input access list into (a) the geth form for
+// signing/execution and (b) the output mirror. The geth list is always
+// non-nil (empty list, same RLP as before the field existed); the output
+// mirror is nil when empty so omitempty keeps the old 25 vectors byte-stable.
+// A tuple's nil StorageKeys is normalized to [] on both sides (the replayer
+// iterates storageKeys; null is a schema violation).
+func buildAccessList(in []outputAccessTuple) (types.AccessList, []outputAccessTuple) {
+	al := types.AccessList{}
+	var out []outputAccessTuple
+	for _, t := range in {
+		keys := t.StorageKeys
+		if keys == nil {
+			keys = []common.Hash{}
+		}
+		al = append(al, types.AccessTuple{Address: t.Address, StorageKeys: keys})
+		out = append(out, outputAccessTuple{Address: t.Address, StorageKeys: keys})
+	}
+	return al, out
+}
+
+// authStructurallyUnrecoverable mirrors the replayer's predicate verbatim
+// (OpT8nReplayTest.cpp structurallyUnrecoverable: secp256k1 EIP-2/EIP-7702
+// malleability boundary, no ecrecover). Same predicate on both sides so a
+// (b)-class corpus authoring error is stopped at generation time.
+var (
+	secpN     = crypto.S256().Params().N
+	secpHalfN = new(big.Int).Rsh(crypto.S256().Params().N, 1)
+)
+
+func authStructurallyUnrecoverable(a types.SetCodeAuthorization) bool {
+	r, s := a.R.ToBig(), a.S.ToBig()
+	return a.V > 1 || s.Cmp(secpHalfN) > 0 || r.Sign() == 0 || r.Cmp(secpN) >= 0 ||
+		s.Sign() == 0 || s.Cmp(secpN) >= 0
+}
+
+func buildTx(in *inputTx, signer types.Signer, cfg *params.ChainConfig) (*types.Transaction, json.RawMessage, error) {
+	switch in.OpType {
+	case "deposit":
+		if in.OpDeposit == nil {
+			return nil, nil, fmt.Errorf(`_op_type="deposit" requires "_op_deposit"`)
+		}
+		d := in.OpDeposit
+		var mint *big.Int
+		if d.Mint != nil {
+			mint = (*big.Int)(d.Mint)
+		}
+		value := big.NewInt(0)
+		if d.Value != nil {
+			value = (*big.Int)(d.Value)
+		}
+		tx := types.NewTx(&types.DepositTx{
+			SourceHash:          d.SourceHash,
+			From:                d.From,
+			To:                  d.To,
+			Mint:                mint,
+			Value:               value,
+			Gas:                 uint64(d.Gas),
+			IsSystemTransaction: d.IsSystemTx,
+			Data:                []byte(in.Data),
+		})
+		outJSON, err := json.Marshal(outputDepositTx{
+			OpType:    "deposit",
+			OpDeposit: *d,
+			Data:      in.Data,
+		})
+		return tx, outJSON, err
+
+	case "eip1559":
+		prv, from, err := parseKey(in.SecretKey)
+		if err != nil {
+			return nil, nil, err
+		}
+		chainID, nonce, gas, value, tip, feeCap := txScalars(in)
+		accessList, outAccessList := buildAccessList(in.AccessList)
+		txdata := &types.DynamicFeeTx{
+			ChainID:    chainID,
+			Nonce:      nonce,
+			GasTipCap:  tip,
+			GasFeeCap:  feeCap,
+			Gas:        gas,
+			To:         in.To,
+			Value:      value,
+			Data:       []byte(in.Data),
+			AccessList: accessList,
+		}
+		tx, err := types.SignNewTx(prv, signer, txdata)
+		if err != nil {
+			return nil, nil, fmt.Errorf("signing eip1559 tx: %w", err)
+		}
+		rawBin, err := tx.MarshalBinary() // iron rule: _op_raw = tx.MarshalBinary()
+		if err != nil {
+			return nil, nil, err
+		}
+		outJSON, err := json.Marshal(outputSignedTx{
+			OpType:               "eip1559",
+			OpRaw:                hexutil.Encode(rawBin),
+			ChainID:              (*math.HexOrDecimal256)(chainID),
+			Nonce:                math.HexOrDecimal64(nonce),
+			To:                   in.To,
+			Gas:                  math.HexOrDecimal64(gas),
+			MaxFeePerGas:         (*math.HexOrDecimal256)(feeCap),
+			MaxPriorityFeePerGas: (*math.HexOrDecimal256)(tip),
+			Value:                (*math.HexOrDecimal256)(value),
+			Data:                 in.Data,
+			AccessList:           outAccessList,
+			Sender:               from,
+		})
+		return tx, outJSON, err
+
+	case "legacy":
+		// Type-0 legacy tx with an EIP-155 protected signature (B scope base for
+		// corrupt/invalid-tx vectors). Signing with the standard MakeSigner
+		// signer (Isthmus/London on this chain) routes LegacyTxType through the
+		// EIP155Signer arm (transaction_signing.go:299-300), producing
+		// V = chainID*2+35/36. GasPrice is the sole per-gas price; a legacy tx on
+		// an EIP-1559 chain is valid as long as gasPrice >= baseFee.
+		prv, from, err := parseKey(in.SecretKey)
+		if err != nil {
+			return nil, nil, err
+		}
+		chainID, nonce, gas, value, _, _ := txScalars(in)
+		gasPrice := big.NewInt(0)
+		if in.GasPrice != nil {
+			gasPrice = (*big.Int)(in.GasPrice)
+		}
+		txdata := &types.LegacyTx{
+			Nonce:    nonce,
+			GasPrice: gasPrice,
+			Gas:      gas,
+			To:       in.To,
+			Value:    value,
+			Data:     []byte(in.Data),
+		}
+		tx, err := types.SignNewTx(prv, signer, txdata)
+		if err != nil {
+			return nil, nil, fmt.Errorf("signing legacy tx: %w", err)
+		}
+		rawBin, err := tx.MarshalBinary() // iron rule: _op_raw = tx.MarshalBinary()
+		if err != nil {
+			return nil, nil, err
+		}
+		outJSON, err := json.Marshal(outputLegacyTx{
+			OpType:   "legacy",
+			OpRaw:    hexutil.Encode(rawBin),
+			ChainID:  (*math.HexOrDecimal256)(chainID),
+			Nonce:    math.HexOrDecimal64(nonce),
+			To:       in.To,
+			Gas:      math.HexOrDecimal64(gas),
+			GasPrice: (*math.HexOrDecimal256)(gasPrice),
+			Value:    (*math.HexOrDecimal256)(value),
+			Data:     in.Data,
+			Sender:   from,
+		})
+		return tx, outJSON, err
+
+	case "setcode":
+		prv, from, err := parseKey(in.SecretKey)
+		if err != nil {
+			return nil, nil, err
+		}
+		if in.To == nil {
+			return nil, nil, fmt.Errorf(`_op_type="setcode" requires "to" (EIP-7702 txs cannot create contracts)`)
+		}
+		if len(in.OpAuthorizations) == 0 {
+			return nil, nil, fmt.Errorf(`_op_type="setcode" requires a non-empty "_op_authorization_list"`)
+		}
+		chainID, nonce, gas, value, tip, feeCap := txScalars(in)
+		accessList, outAccessList := buildAccessList(in.AccessList)
+		authList := make([]types.SetCodeAuthorization, len(in.OpAuthorizations))
+		outAuths := make([]outputAuthorization, len(in.OpAuthorizations))
+		for i, a := range in.OpAuthorizations {
+			authChainID := big.NewInt(0)
+			if a.ChainID != nil {
+				authChainID = (*big.Int)(a.ChainID)
+			}
+			overridePresent := a.RawYParity != nil || a.RawR != nil || a.RawS != nil
+			var auth types.SetCodeAuthorization
+			if overridePresent {
+				// Raw override: structurally-bad signature, taken verbatim,
+				// NOT signed. All three fields must come together, and the
+				// tuple must not also carry a signing key.
+				if a.RawYParity == nil || a.RawR == nil || a.RawS == nil {
+					return nil, nil, fmt.Errorf("_op_authorization_list[%d]: partial raw override (rawYParity/rawR/rawS must appear together)", i)
+				}
+				if len(a.AuthSecretKey) != 0 {
+					return nil, nil, fmt.Errorf("_op_authorization_list[%d]: raw override and authSecretKey are mutually exclusive", i)
+				}
+				if *a.RawYParity > 255 {
+					return nil, nil, fmt.Errorf("_op_authorization_list[%d]: rawYParity %d does not fit uint8", i, *a.RawYParity)
+				}
+				auth = types.SetCodeAuthorization{
+					ChainID: *uint256.MustFromBig(authChainID),
+					Address: a.Address,
+					Nonce:   uint64(a.Nonce),
+					V:       uint8(*a.RawYParity),
+					R:       *uint256.MustFromBig((*big.Int)(a.RawR)),
+					S:       *uint256.MustFromBig((*big.Int)(a.RawS)),
+				}
+			} else {
+				authPrv, err := crypto.ToECDSA(a.AuthSecretKey)
+				if err != nil {
+					return nil, nil, fmt.Errorf("_op_authorization_list[%d]: %w", i, err)
+				}
+				auth, err = types.SignSetCode(authPrv, types.SetCodeAuthorization{
+					ChainID: *uint256.MustFromBig(authChainID),
+					Address: a.Address,
+					Nonce:   uint64(a.Nonce),
+				})
+				if err != nil {
+					return nil, nil, fmt.Errorf("_op_authorization_list[%d]: SignSetCode: %w", i, err)
+				}
+			}
+			// Three-way consistency assertion (iron rule): marker <=> override
+			// present <=> structural predicate true. Any mismatch is a corpus
+			// authoring error and stops generation ((b)-class, same predicate
+			// as the replayer).
+			pred := authStructurallyUnrecoverable(auth)
+			if a.SignerUnrecoverable != overridePresent || overridePresent != pred {
+				return nil, nil, fmt.Errorf(
+					"_op_authorization_list[%d]: marker/override/predicate mismatch (marker=%v, override=%v, structurally-unrecoverable=%v)",
+					i, a.SignerUnrecoverable, overridePresent, pred)
+			}
+			authList[i] = auth
+			outAuths[i] = outputAuthorization{
+				ChainID:             (*math.HexOrDecimal256)(authChainID),
+				Address:             a.Address,
+				Nonce:               a.Nonce,
+				YParity:             math.HexOrDecimal64(auth.V),
+				R:                   (*math.HexOrDecimal256)(auth.R.ToBig()),
+				S:                   (*math.HexOrDecimal256)(auth.S.ToBig()),
+				SignerUnrecoverable: a.SignerUnrecoverable,
+			}
+		}
+		txdata := &types.SetCodeTx{
+			ChainID:    uint256.MustFromBig(chainID),
+			Nonce:      nonce,
+			GasTipCap:  uint256.MustFromBig(tip),
+			GasFeeCap:  uint256.MustFromBig(feeCap),
+			Gas:        gas,
+			To:         *in.To,
+			Value:      uint256.MustFromBig(value),
+			Data:       []byte(in.Data),
+			AccessList: accessList,
+			AuthList:   authList,
+		}
+		tx, err := types.SignNewTx(prv, signer, txdata)
+		if err != nil {
+			return nil, nil, fmt.Errorf("signing setcode tx: %w", err)
+		}
+		rawBin, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, nil, err
+		}
+		outJSON, err := json.Marshal(outputSetCodeTx{
+			OpType:               "setcode",
+			OpRaw:                hexutil.Encode(rawBin),
+			ChainID:              (*math.HexOrDecimal256)(chainID),
+			Nonce:                math.HexOrDecimal64(nonce),
+			To:                   *in.To,
+			Gas:                  math.HexOrDecimal64(gas),
+			MaxFeePerGas:         (*math.HexOrDecimal256)(feeCap),
+			MaxPriorityFeePerGas: (*math.HexOrDecimal256)(tip),
+			Value:                (*math.HexOrDecimal256)(value),
+			Data:                 in.Data,
+			AccessList:           outAccessList,
+			Sender:               from,
+			OpAuthorizationList:  outAuths,
+		})
+		return tx, outJSON, err
+
+	default:
+		return nil, nil, fmt.Errorf("unknown _op_type %q", in.OpType)
+	}
+}
+
+func parseKey(k *hexutil.Bytes) (*ecdsa.PrivateKey, common.Address, error) {
+	if k == nil {
+		return nil, common.Address{}, fmt.Errorf("signed tx requires secretKey")
+	}
+	key, err := crypto.ToECDSA(*k)
+	if err != nil {
+		return nil, common.Address{}, fmt.Errorf("parsing secretKey: %w", err)
+	}
+	return key, crypto.PubkeyToAddress(key.PublicKey), nil
+}
+
+func txScalars(in *inputTx) (chainID *big.Int, nonce, gas uint64, value, tip, feeCap *big.Int) {
+	chainID = big.NewInt(0)
+	if in.ChainID != nil {
+		chainID = (*big.Int)(in.ChainID)
+	}
+	if in.Nonce != nil {
+		nonce = uint64(*in.Nonce)
+	}
+	if in.Gas != nil {
+		gas = uint64(*in.Gas)
+	}
+	value, tip, feeCap = big.NewInt(0), big.NewInt(0), big.NewInt(0)
+	if in.Value != nil {
+		value = (*big.Int)(in.Value)
+	}
+	if in.MaxPriorityFeePerGas != nil {
+		tip = (*big.Int)(in.MaxPriorityFeePerGas)
+	}
+	if in.MaxFeePerGas != nil {
+		feeCap = (*big.Int)(in.MaxFeePerGas)
+	}
+	return
+}
+
+// ---------------------------------------------------------------------
+// postState: candidate-set full emission + trie completeness check
+// ---------------------------------------------------------------------
+
+type addrSet struct{ m map[common.Address]struct{} }
+
+func newAddrSet() *addrSet              { return &addrSet{m: map[common.Address]struct{}{}} }
+func (s *addrSet) add(a common.Address) { s.m[a] = struct{}{} }
+func (s *addrSet) sorted() []common.Address {
+	out := make([]common.Address, 0, len(s.m))
+	for a := range s.m {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return bytes.Compare(out[i][:], out[j][:]) < 0 })
+	return out
+}
+
+// buildSlotCandidates returns, per account, the author-known slot set
+// (decision record 8): slots declared in pre, slots declared in
+// extra_storage, and the analytically-known EIP-4788/2935 ring slots for the
+// generated block (written by the system calls, outside any tx).
+func buildSlotCandidates(in *inputCase, blockTime, blockNumber uint64) map[common.Address]map[common.Hash]struct{} {
+	out := map[common.Address]map[common.Hash]struct{}{}
+	addSlot := func(addr common.Address, slot common.Hash) {
+		if out[addr] == nil {
+			out[addr] = map[common.Hash]struct{}{}
+		}
+		out[addr][slot] = struct{}{}
+	}
+	for addr, acc := range in.Pre {
+		for slot := range acc.Storage {
+			addSlot(addr, slot)
+		}
+	}
+	for addr, slots := range in.ExtraStorage {
+		for _, slot := range slots {
+			addSlot(addr, slot)
+		}
+	}
+	// EIP-4788: timestamp % 8191 (timestamp) and + 8191 (root).
+	addSlot(beaconRootsAddr, common.BigToHash(new(big.Int).SetUint64(blockTime%ringSize)))
+	addSlot(beaconRootsAddr, common.BigToHash(new(big.Int).SetUint64(blockTime%ringSize+ringSize)))
+	// EIP-2935: (number-1) % 8191 <- parent hash.
+	addSlot(historyStorage, common.BigToHash(new(big.Int).SetUint64((blockNumber-1)%ringSize)))
+	return out
+}
+
+// emitPostState opens the post-block state from the generation DB, verifies
+// via secure-trie iteration that every existing account is in the candidate
+// set and every storage slot of every candidate is in its declared slot set
+// (hashed-key comparison, no preimages needed), then emits the full candidate
+// set: for every candidate account its balance/nonce/code and all non-zero
+// declared slots. A candidate that does not exist post-block is emitted as
+// the trie-semantic zero account {"balance":"0x0"}.
+func emitPostState(db ethdb.Database, root common.Hash, candidates *addrSet, slotCands map[common.Address]map[common.Hash]struct{}) (types.GenesisAlloc, *state.StateDB, error) {
+	tdb := triedb.NewDatabase(db, triedb.HashDefaults)
+	sdb := state.NewDatabase(tdb, nil)
+	statedb, err := state.New(root, sdb)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open post state: %w", err)
+	}
+	tr, err := sdb.OpenTrie(root)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open account trie: %w", err)
+	}
+
+	hashedToAddr := map[common.Hash]common.Address{}
+	for addr := range candidates.m {
+		hashedToAddr[common.BytesToHash(crypto.Keccak256(addr[:]))] = addr
+	}
+
+	nodeIt, err := tr.NodeIterator(nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	accounts := map[common.Address]types.StateAccount{}
+	it := trie.NewIterator(nodeIt)
+	for it.Next() {
+		addr, ok := hashedToAddr[common.BytesToHash(it.Key)]
+		if !ok {
+			return nil, nil, fmt.Errorf("post-state account outside candidate set (hashed key %x) -- corpus must list every written address (extra_candidates)", it.Key)
+		}
+		var acct types.StateAccount
+		if err := rlp.DecodeBytes(it.Value, &acct); err != nil {
+			return nil, nil, fmt.Errorf("decode account %s: %w", addr, err)
+		}
+		accounts[addr] = acct
+	}
+	if it.Err != nil {
+		return nil, nil, fmt.Errorf("account trie iteration: %w", it.Err)
+	}
+
+	out := types.GenesisAlloc{}
+	for _, addr := range candidates.sorted() {
+		acct, exists := accounts[addr]
+		storage := map[common.Hash]common.Hash{}
+		if exists && acct.Root != types.EmptyRootHash {
+			hashedToSlot := map[common.Hash]common.Hash{}
+			for slot := range slotCands[addr] {
+				hashedToSlot[common.BytesToHash(crypto.Keccak256(slot[:]))] = slot
+			}
+			str, err := sdb.OpenStorageTrie(root, addr, acct.Root, tr)
+			if err != nil {
+				return nil, nil, fmt.Errorf("open storage trie of %s: %w", addr, err)
+			}
+			snIt, err := str.NodeIterator(nil)
+			if err != nil {
+				return nil, nil, err
+			}
+			sit := trie.NewIterator(snIt)
+			for sit.Next() {
+				slot, ok := hashedToSlot[common.BytesToHash(sit.Key)]
+				if !ok {
+					return nil, nil, fmt.Errorf("account %s has a storage slot outside the declared slot set (hashed key %x) -- corpus must list every written slot (pre storage / extra_storage)", addr, sit.Key)
+				}
+				_, content, _, err := rlp.Split(sit.Value)
+				if err != nil {
+					return nil, nil, fmt.Errorf("decode storage value of %s: %w", addr, err)
+				}
+				storage[slot] = common.BytesToHash(content)
+			}
+			if sit.Err != nil {
+				return nil, nil, fmt.Errorf("storage trie iteration of %s: %w", addr, sit.Err)
+			}
+		}
+		acc := types.Account{
+			Balance: statedb.GetBalance(addr).ToBig(),
+			Nonce:   statedb.GetNonce(addr),
+		}
+		if code := statedb.GetCode(addr); len(code) > 0 {
+			acc.Code = code
+		}
+		if len(storage) > 0 {
+			acc.Storage = storage
+		}
+		out[addr] = acc
+	}
+	return out, statedb, nil
+}
+
+// ---------------------------------------------------------------------
+// Receipt expectations + fee cross-checks
+// ---------------------------------------------------------------------
+
+// preStateGetter adapts the case's pre alloc to types.StateGetter, so the
+// generator's own operator-fee math can be cross-checked against op-geth's
+// NewOperatorCostFunc over the exact same slot-8 params. (结构性保证：语料规则
+// 禁止 L1Block 携 code，块内无路径可写其槽 -- so pre == the state the
+// lazily-initialized cost funcs observe.)
+type preStateGetter types.GenesisAlloc
+
+func (p preStateGetter) GetState(addr common.Address, slot common.Hash) common.Hash {
+	acc, ok := types.GenesisAlloc(p)[addr]
+	if !ok {
+		return common.Hash{}
+	}
+	return acc.Storage[slot]
+}
+
+// operatorFee implements the fork formulas from rollup_cost.go:254-287:
+//
+//	Isthmus: gasUsed*scalar/1e6 + constant
+//	Jovian:  gasUsed*scalar*100 + constant
+func operatorFee(jovian bool, gasUsed uint64, scalar uint32, constant uint64) *big.Int {
+	fee := new(big.Int).SetUint64(gasUsed)
+	fee.Mul(fee, new(big.Int).SetUint64(uint64(scalar)))
+	if jovian {
+		fee.Mul(fee, big.NewInt(100))
+	} else {
+		fee.Div(fee, big.NewInt(1_000_000))
+	}
+	return fee.Add(fee, new(big.Int).SetUint64(constant))
+}
+
+// chainCtxStub satisfies core.ChainContext for the output re-execution. The EVM
+// block context reads Config() (blob base fee) and defers GetHeader* to
+// BLOCKHASH; the corpus never executes BLOCKHASH, so the lookups are inert.
+// core.BlockChain's chainConfig field is unexported, so a hand stub is required
+// outside the core package.
+type chainCtxStub struct{ cfg *params.ChainConfig }
+
+func (c chainCtxStub) Engine() consensus.Engine {
+	return nil
+}
+func (c chainCtxStub) Config() *params.ChainConfig {
+	return c.cfg
+}
+func (c chainCtxStub) CurrentHeader() *types.Header {
+	return nil
+}
+func (c chainCtxStub) GetHeader(common.Hash, uint64) *types.Header {
+	return nil
+}
+func (c chainCtxStub) GetHeaderByNumber(uint64) *types.Header {
+	return nil
+}
+func (c chainCtxStub) GetHeaderByHash(common.Hash) *types.Header {
+	return nil
+}
+
+// reexecuteOutputs replays a generated block's txs against a fresh state and
+// returns each tx's return data (the receipt output). The chain maker's AddTx
+// discards ExecutionResult.ReturnData, so the real receipts never carry output;
+// this replay reproduces the chain maker's pre-tx state (startRoot + EIP-2935
+// parent-hash + EIP-4788 beacon-root system calls, same order as GenerateChain)
+// and applies each tx via core.ApplyMessage, capturing ReturnData. Faithfulness
+// is enforced per tx: each replayed result's UsedGas and success/failure must
+// equal the real receipt's gasUsed/status, otherwise the emitted outputs are
+// rejected (a divergence between the replay and the actual block execution would
+// make the output field untrustworthy).
+//
+// startRoot is the per-block replay origin: the GENESIS root for a single-block
+// vector (or chain block 0), and blocks[i-1].Root() for chain block i -- chain
+// block B's pre-state IS block A's post-state, so a genesis-root replay would
+// see B's sender nonce as 0 and reject B's nonce-1 transfer ("nonce too high").
+func reexecuteOutputs(cfg *params.ChainConfig, genesis *core.Genesis, db ethdb.Database,
+	header *types.Header, txs []*types.Transaction, receipts types.Receipts,
+	coinbase common.Address, parentBeaconRoot common.Hash, startRoot common.Hash) ([][]byte, error) {
+	tdb := triedb.NewDatabase(db, triedb.HashDefaults)
+	defer tdb.Close()
+	statedb, err := state.New(startRoot, state.NewDatabase(tdb, nil))
+	if err != nil {
+		return nil, fmt.Errorf("open re-execution state: %w", err)
+	}
+	gp := core.NewGasPool(header.GasLimit)
+	bc := &chainCtxStub{cfg: cfg}
+
+	// EIP-2935 parent-hash: gated exactly as chain_makers.genblock does. EIP-4788
+	// beacon-root runs unconditionally (SetParentBeaconRoot always calls it); both
+	// are no-ops pre-Prague (empty system-contract code).
+	if cfg.IsPrague(header.Number, header.Time) || cfg.IsVerkle(header.Number, header.Time) {
+		blockCtx := core.NewEVMBlockContext(header, bc, &coinbase, cfg, statedb)
+		blockCtx.Random = &common.Hash{} // enable post-merge instruction set
+		core.ProcessParentBlockHash(header.ParentHash, vm.NewEVM(blockCtx, statedb, cfg, vm.Config{}))
+	}
+	blockCtx := core.NewEVMBlockContext(header, bc, &coinbase, cfg, statedb)
+	core.ProcessBeaconBlockRoot(parentBeaconRoot, vm.NewEVM(blockCtx, statedb, cfg, vm.Config{}))
+
+	outs := make([][]byte, len(txs))
+	for i, tx := range txs {
+		statedb.SetTxContext(tx.Hash(), i)
+		blockCtx := core.NewEVMBlockContext(header, bc, &coinbase, cfg, statedb)
+		evm := vm.NewEVM(blockCtx, statedb, cfg, vm.Config{})
+		msg, err := core.TransactionToMessage(tx, types.MakeSigner(cfg, header.Number, header.Time), header.BaseFee)
+		if err != nil {
+			return nil, fmt.Errorf("replay tx %d msg: %w", i, err)
+		}
+		result, err := core.ApplyMessage(evm, msg, gp)
+		if err != nil {
+			return nil, fmt.Errorf("replay tx %d: %w", i, err)
+		}
+		// Faithfulness cross-check: the replay must reproduce the real block's
+		// receipt (MakeReceipt sets GasUsed = result.UsedGas, Status from Failed).
+		if result.UsedGas != receipts[i].GasUsed ||
+			result.Failed() != (receipts[i].Status != types.ReceiptStatusSuccessful) {
+			return nil, fmt.Errorf("replay tx %d: gasUsed/status mismatch (replay %d/%v vs receipt %d/%d)",
+				i, result.UsedGas, result.Failed(), receipts[i].GasUsed, receipts[i].Status)
+		}
+		outs[i] = common.CopyBytes(result.ReturnData)
+		statedb.Finalise(true)
+	}
+	return outs, nil
+}
+
+func buildExpectedReceipts(cfg *params.ChainConfig, in *inputCase, txs []*types.Transaction, receipts types.Receipts, outputs [][]byte, blockTime uint64) ([]expectedReceipt, error) {
+	jovian := cfg.IsJovian(blockTime)
+	if len(outputs) != len(receipts) {
+		return nil, fmt.Errorf("outputs/receipts count mismatch: %d vs %d", len(outputs), len(receipts))
+	}
+	slot8 := preStateGetter(in.Pre).GetState(l1BlockAddr, types.OperatorFeeParamsSlot)
+	opScalar := binary.BigEndian.Uint32(slot8[20:24])
+	opConstant := binary.BigEndian.Uint64(slot8[24:32])
+	emitOpFee := opScalar != 0 || opConstant != 0 // presence mirrors deriveOPStackFields
+	refOpCost := types.NewOperatorCostFunc(cfg, preStateGetter(in.Pre))
+
+	out := make([]expectedReceipt, len(receipts))
+	var cumulative uint64
+	for i, r := range receipts {
+		if r.CumulativeGasUsed < cumulative {
+			return nil, fmt.Errorf("receipt %d: non-monotonic cumulative gas", i)
+		}
+		cumulative = r.CumulativeGasUsed
+		er := expectedReceipt{
+			Type:              hexutil.EncodeUint64(uint64(r.Type)),
+			Status:            hexutil.EncodeUint64(r.Status),
+			GasUsed:           hexutil.EncodeUint64(r.GasUsed),
+			CumulativeGasUsed: hexutil.EncodeUint64(r.CumulativeGasUsed),
+			LogsCount:         len(r.Logs),
+			Output:            hexutil.Encode(outputs[i]),
+		}
+		if r.DepositNonce != nil {
+			s := hexutil.EncodeUint64(*r.DepositNonce)
+			er.OpDepositNonce = &s
+		}
+		if r.DepositReceiptVersion != nil {
+			s := hexutil.EncodeUint64(*r.DepositReceiptVersion)
+			er.OpDepositReceiptVersion = &s
+		}
+		if !txs[i].IsDepositTx() {
+			if r.L1Fee == nil {
+				return nil, fmt.Errorf("receipt %d: non-deposit tx missing L1Fee after DeriveFields", i)
+			}
+			s := hexutil.EncodeBig(r.L1Fee)
+			er.OpL1Fee = &s
+			// 线 C：字段发射面按 OP_RECEIPT_FIELDMAP.md（nil → absent → omitempty）。
+			if r.L1GasPrice != nil {
+				s := hexutil.EncodeBig(r.L1GasPrice)
+				er.OpL1GasPrice = &s
+			}
+			if r.L1BlobBaseFee != nil {
+				s := hexutil.EncodeBig(r.L1BlobBaseFee)
+				er.OpL1BlobBaseFee = &s
+			}
+			if r.L1GasUsed != nil {
+				s := hexutil.EncodeBig(r.L1GasUsed)
+				er.OpL1GasUsed = &s
+			}
+			if r.L1BaseFeeScalar != nil {
+				s := hexutil.EncodeUint64(*r.L1BaseFeeScalar)
+				er.OpL1BaseFeeScalar = &s
+			}
+			if r.L1BlobBaseFeeScalar != nil {
+				s := hexutil.EncodeUint64(*r.L1BlobBaseFeeScalar)
+				er.OpL1BlobBaseFeeScalar = &s
+			}
+			if r.OperatorFeeScalar != nil {
+				s := hexutil.EncodeUint64(*r.OperatorFeeScalar)
+				er.OpOperatorFeeScalar = &s
+			}
+			if r.OperatorFeeConstant != nil {
+				s := hexutil.EncodeUint64(*r.OperatorFeeConstant)
+				er.OpOperatorFeeConstant = &s
+			}
+			if r.DAFootprintGasScalar != nil {
+				s := hexutil.EncodeUint64(*r.DAFootprintGasScalar)
+				er.OpDaFootprintGasScalar = &s
+			}
+			if emitOpFee {
+				fee := operatorFee(jovian, r.GasUsed, opScalar, opConstant)
+				// Cross-check the hand formula against op-geth's own cost func.
+				if ref := refOpCost(r.GasUsed, blockTime); ref.ToBig().Cmp(fee) != 0 {
+					return nil, fmt.Errorf("receipt %d: operator fee formula mismatch: generator %s vs op-geth %s", i, fee, ref)
+				}
+				sf := hexutil.EncodeBig(fee)
+				er.OpOperatorFee = &sf
+			}
+			if jovian {
+				sd := hexutil.EncodeUint64(r.BlobGasUsed) // deriveOPStackFields: daScalar * EstimatedDASize
+				er.OpDaFootprint = &sd
+			}
+		}
+		out[i] = er
+	}
+	return out, nil
+}
+
+// crossCheckVaults asserts sum(per-tx op fee) and sum(per-tx L1 fee) against
+// the OperatorFeeVault / L1FeeVault balance deltas of the actually-executed
+// block -- i.e. the emitted receipt expectations are provably the values the
+// state transition charged, not merely re-derived from the same inputs.
+func crossCheckVaults(in *inputCase, exp []expectedReceipt, post *state.StateDB) error {
+	sumOp, sumL1 := new(big.Int), new(big.Int)
+	for i := range exp {
+		if exp[i].OpOperatorFee != nil {
+			v, err := hexutil.DecodeBig(*exp[i].OpOperatorFee)
+			if err != nil {
+				return err
+			}
+			sumOp.Add(sumOp, v)
+		}
+		if exp[i].OpL1Fee != nil {
+			v, err := hexutil.DecodeBig(*exp[i].OpL1Fee)
+			if err != nil {
+				return err
+			}
+			sumL1.Add(sumL1, v)
+		}
+	}
+	delta := func(addr common.Address) *big.Int {
+		preBal := big.NewInt(0)
+		if acc, ok := in.Pre[addr]; ok && acc.Balance != nil {
+			preBal = acc.Balance
+		}
+		return new(big.Int).Sub(post.GetBalance(addr).ToBig(), preBal)
+	}
+	if d := delta(operatorFeeVault); d.Cmp(sumOp) != 0 {
+		return fmt.Errorf("operator fee cross-check: vault delta %s != sum of per-tx fees %s", d, sumOp)
+	}
+	if d := delta(l1FeeVault); d.Cmp(sumL1) != 0 {
+		return fmt.Errorf("l1 fee cross-check: vault delta %s != sum of per-tx L1 fees %s", d, sumL1)
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------
+// Dev probe: ring-wrap feasibility (case 11 note). Genesis.Commit refuses
+// number > 0 (op-geth core/genesis.go:728) -- this probe demonstrates it at
+// runtime so the README's "wrap has no discriminating case" note is
+// evidence-backed, not read-only.
+// ---------------------------------------------------------------------
+
+func probeGenesisNumber() {
+	cfg, _ := buildChainConfig("isthmus")
+	zero := uint64(0)
+	_ = zero
+	genesis := &core.Genesis{
+		Config:     cfg,
+		Timestamp:  1000,
+		GasLimit:   10_000_000,
+		Difficulty: big.NewInt(0),
+		ExtraData:  eip1559.EncodeOptimismExtraData(cfg, 1000, 50, 6, nil),
+		Alloc:      types.GenesisAlloc{},
+		Number:     ringSize, // 8191 -> block 8192 would wrap the 2935 ring
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("probe: Genesis.Number=8191 REJECTED (panic: %v)\n", r)
+		}
+	}()
+	_, blocks, _ := core.GenerateChainWithGenesis(genesis, beacon.New(ethash.NewFaker()), 1, nil)
+	fmt.Printf("probe: unexpectedly generated block %d\n", blocks[0].NumberU64())
+}

--- a/opstack-executor/tests/t8n/generator/main_test.go
+++ b/opstack-executor/tests/t8n/generator/main_test.go
@@ -1,0 +1,809 @@
+package main
+
+// Task 3/4 TDD tests. ⚠️ Every test references at least one function that is
+// UNDEFINED before the implementation lands (buildBlockVector / corruptVector /
+// captureInsertChainRejection / recomputeOpHeaderHash / buildCaseFromSpecs /
+// emitStaticSurfaceVector / staticSurfaceItems / legacy arm for Task 3;
+// buildInvalidTxCase / buildInvalidTxBlock / buildInvalidTxVector /
+// invalidTxCaseSpecs / invalidTxSpec / emitableSpecs for Task 4). Before the
+// implementation steps this file fails to COMPILE (real red); after
+// implementation it goes green.
+
+import (
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+// rejectOf is a small accessor: returns the reject schema or nil.
+func rejectOf(doc invalidVectorDoc) *rejectExpected {
+	return doc.OpExpected.Reject
+}
+
+func TestCorruptStateRootRejectedByOpGeth(t *testing.T) {
+	in, err := buildCaseFromSpecs("transfer_basic", "isthmus")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs: %v", err)
+	}
+	base, err := buildBlockVector(&in)
+	if err != nil {
+		t.Fatalf("buildBlockVector: %v", err)
+	}
+	doc, corruptBlock, err := corruptVector(base, "stateRoot")
+	if err != nil {
+		t.Fatalf("corruptVector: %v", err)
+	}
+	// Iron-rule mirror: the self-consistent corrupt block MUST be rejected by
+	// op-geth's own InsertChain (fresh DB, same genesis).
+	msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+	if err != nil {
+		t.Fatalf("expected reject, got accept: %v", err)
+	}
+	if !strings.Contains(msg, "invalid merkle root") {
+		t.Fatalf("want 'invalid merkle root', got %q", msg)
+	}
+	rej := rejectOf(doc)
+	if rej == nil {
+		t.Fatal("corrupt vector missing _op_expected.reject")
+	}
+	if rej.Fisco.Classification != "INVALID" {
+		t.Fatalf("classification want INVALID, got %q", rej.Fisco.Classification)
+	}
+	if rej.Fisco.Consumer != "engine" {
+		t.Fatalf("consumer want engine, got %q", rej.Fisco.Consumer)
+	}
+	if !strings.Contains(rej.Fisco.ValidationErrorContains, "stateRoot") {
+		t.Fatalf("validation_error_contains want stateRoot, got %q", rej.Fisco.ValidationErrorContains)
+	}
+	// Self-consistent: payload blockHash == hash of the CORRUPT header.
+	wantHash := recomputeOpHeaderHash(corruptBlock.Header())
+	if doc.OpPayload["blockHash"] != wantHash.Hex() {
+		t.Fatalf("payload blockHash %v != recomputed %v", doc.OpPayload["blockHash"], wantHash.Hex())
+	}
+	if doc.OpPayload["stateRoot"] == base.vec.OpExpected.Header.StateRoot {
+		t.Fatal("stateRoot not actually corrupted in payload")
+	}
+}
+
+func TestCorruptGasUsedRejectedByOpGeth(t *testing.T) {
+	in, err := buildCaseFromSpecs("transfer_basic", "isthmus")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs: %v", err)
+	}
+	base, err := buildBlockVector(&in)
+	if err != nil {
+		t.Fatalf("buildBlockVector: %v", err)
+	}
+	doc, corruptBlock, err := corruptVector(base, "gasUsed")
+	if err != nil {
+		t.Fatalf("corruptVector: %v", err)
+	}
+	msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+	if err != nil {
+		t.Fatalf("expected reject, got accept: %v", err)
+	}
+	if !strings.Contains(msg, "invalid gas used") {
+		t.Fatalf("want 'invalid gas used', got %q", msg)
+	}
+	rej := rejectOf(doc)
+	if rej == nil || !strings.Contains(rej.Fisco.ValidationErrorContains, "gasUsed") {
+		t.Fatalf("reject missing gasUsed anchor: %+v", rej)
+	}
+	// gasUsed must stay <= gasLimit (recipe constraint).
+	gasUsed := doc.OpPayload["gasUsed"].(string)
+	gasLimit := doc.OpPayload["gasLimit"].(string)
+	if gasUsed > gasLimit {
+		t.Fatalf("corrupt gasUsed %s > gasLimit %s (must stay <= gasLimit)", gasUsed, gasLimit)
+	}
+}
+
+func TestCorruptReceiptsRootRejectedByOpGeth(t *testing.T) {
+	in, err := buildCaseFromSpecs("transfer_basic", "isthmus")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs: %v", err)
+	}
+	base, err := buildBlockVector(&in)
+	if err != nil {
+		t.Fatalf("buildBlockVector: %v", err)
+	}
+	doc, corruptBlock, err := corruptVector(base, "receiptsRoot")
+	if err != nil {
+		t.Fatalf("corruptVector: %v", err)
+	}
+	msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+	if err != nil {
+		t.Fatalf("expected reject, got accept: %v", err)
+	}
+	if !strings.Contains(msg, "invalid receipt root hash") {
+		t.Fatalf("want 'invalid receipt root hash', got %q", msg)
+	}
+	rej := rejectOf(doc)
+	if rej == nil || !strings.Contains(rej.Fisco.ValidationErrorContains, "receiptsRoot") {
+		t.Fatalf("reject missing receiptsRoot anchor: %+v", rej)
+	}
+}
+
+func TestCorruptParentHashUnknownAncestor(t *testing.T) {
+	in, err := buildCaseFromSpecs("transfer_basic", "isthmus")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs: %v", err)
+	}
+	base, err := buildBlockVector(&in)
+	if err != nil {
+		t.Fatalf("buildBlockVector: %v", err)
+	}
+	doc, corruptBlock, err := corruptVector(base, "parentHash")
+	if err != nil {
+		t.Fatalf("corruptVector: %v", err)
+	}
+	msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+	if err != nil {
+		t.Fatalf("expected reject, got accept: %v", err)
+	}
+	if !strings.Contains(msg, "unknown ancestor") {
+		t.Fatalf("want 'unknown ancestor', got %q", msg)
+	}
+	rej := rejectOf(doc)
+	if rej == nil {
+		t.Fatal("missing reject")
+	}
+	if rej.Fisco.Classification != "SYNCING" {
+		t.Fatalf("parentHash corrupt must classify SYNCING, got %q", rej.Fisco.Classification)
+	}
+	if len(rej.Fisco.LatestValidHash) != 0 {
+		t.Fatalf("SYNCING must omit latest_valid_hash, got %s", rej.Fisco.LatestValidHash)
+	}
+}
+
+func TestCorruptExtraDataShapeRejected(t *testing.T) {
+	in, err := buildCaseFromSpecs("transfer_basic", "isthmus")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs: %v", err)
+	}
+	base, err := buildBlockVector(&in)
+	if err != nil {
+		t.Fatalf("buildBlockVector: %v", err)
+	}
+	doc, corruptBlock, err := corruptVector(base, "extraData")
+	if err != nil {
+		t.Fatalf("corruptVector: %v", err)
+	}
+	msg, err := captureInsertChainRejection(base.genesis, corruptBlock)
+	if err != nil {
+		t.Fatalf("expected reject, got accept: %v", err)
+	}
+	if !strings.Contains(msg, "invalid optimism extraData") {
+		t.Fatalf("want 'invalid optimism extraData', got %q", msg)
+	}
+	rej := rejectOf(doc)
+	if rej == nil {
+		t.Fatal("missing reject")
+	}
+	// extraData shape break must NOT recompute blockHash: payload carries the
+	// ORIGINAL golden blockHash (the static shape check fires before blockHash).
+	if doc.OpPayload["blockHash"] != base.golden.BlockHash {
+		t.Fatalf("extraData corrupt must keep original blockHash, got %v want %v",
+			doc.OpPayload["blockHash"], base.golden.BlockHash)
+	}
+	if !strings.Contains(rej.Fisco.ValidationErrorContains, "extraData") {
+		t.Fatalf("validation_error_contains want extraData substring, got %q", rej.Fisco.ValidationErrorContains)
+	}
+}
+
+func TestBlockHashCorruptAnchorsBlockhashMismatch(t *testing.T) {
+	in, err := buildCaseFromSpecs("transfer_basic", "isthmus")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs: %v", err)
+	}
+	base, err := buildBlockVector(&in)
+	if err != nil {
+		t.Fatalf("buildBlockVector: %v", err)
+	}
+	// blockHash corruption is the EXCEPTION: no InsertChain capture (the block's
+	// own hash stays self-consistent), anchored on the engine-API message.
+	doc, corruptBlock, err := corruptVector(base, "blockHash")
+	if err != nil {
+		t.Fatalf("corruptVector: %v", err)
+	}
+	if corruptBlock != nil {
+		t.Fatal("blockHash corrupt must not produce a capture block")
+	}
+	rej := rejectOf(doc)
+	if rej == nil {
+		t.Fatal("missing reject")
+	}
+	if rej.OpGeth != "blockhash mismatch" {
+		t.Fatalf("op_geth want 'blockhash mismatch', got %q", rej.OpGeth)
+	}
+	if rej.Fisco.Classification != "INVALID" {
+		t.Fatalf("classification want INVALID, got %q", rej.Fisco.Classification)
+	}
+	if string(rej.Fisco.LatestValidHash) != "null" {
+		t.Fatalf("blockHash mismatch must be latest_valid_hash null, got %s", rej.Fisco.LatestValidHash)
+	}
+	// The payload blockHash must actually differ from the golden hash.
+	if doc.OpPayload["blockHash"] == base.golden.BlockHash {
+		t.Fatal("blockHash not actually corrupted")
+	}
+}
+
+func TestStaticSurfaceAllItemsCarryFiscoMessage(t *testing.T) {
+	isth, err := buildCaseFromSpecs("transfer_basic", "isthmus")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs(isthmus): %v", err)
+	}
+	jov, err := buildCaseFromSpecs("transfer_basic", "jovian")
+	if err != nil {
+		t.Fatalf("buildCaseFromSpecs(jovian): %v", err)
+	}
+	isthBase, err := buildBlockVector(&isth)
+	if err != nil {
+		t.Fatalf("buildBlockVector(isthmus): %v", err)
+	}
+	jovBase, err := buildBlockVector(&jov)
+	if err != nil {
+		t.Fatalf("buildBlockVector(jovian): %v", err)
+	}
+	if len(staticSurfaceItems) < 12 {
+		t.Fatalf("static surface must enumerate 12 items, got %d", len(staticSurfaceItems))
+	}
+	for _, item := range staticSurfaceItems {
+		base := isthBase
+		if item.fork == "jovian" {
+			base = jovBase
+		}
+		doc, err := emitStaticSurfaceVector(base, item)
+		if err != nil {
+			t.Fatalf("emitStaticSurfaceVector(%s): %v", item.name, err)
+		}
+		rej := rejectOf(doc)
+		if rej == nil {
+			t.Fatalf("static item %s missing reject", item.name)
+		}
+		if rej.Fisco.Classification != "INVALID" {
+			t.Fatalf("static item %s: classification want INVALID, got %q", item.name, rej.Fisco.Classification)
+		}
+		if rej.Fisco.ValidationErrorContains != item.fiscoMessage {
+			t.Fatalf("static item %s: validation_error_contains %q != fiscoMessage %q",
+				item.name, rej.Fisco.ValidationErrorContains, item.fiscoMessage)
+		}
+		// Static checks fire at validateOpNewPayloadRequest → INVALID + null.
+		if string(rej.Fisco.LatestValidHash) != "null" {
+			t.Fatalf("static item %s: latest_valid_hash want null, got %s", item.name, rej.Fisco.LatestValidHash)
+		}
+	}
+}
+
+// TestChainPairReplayStartRoot is the Task-5 前置 regression: --chain-output-dir's
+// chain-pair block B replay started from the GENESIS root instead of block A's
+// post-state root, so block B's transfer (nonce 1) was replayed against nonce 0
+// -> "chain block B: replay tx 1: nonce too high". The fix threads a per-block
+// start root into reexecuteOutputs (block i replays from blocks[i-1].Root();
+// single-block vectors keep the genesis root).
+func TestChainPairReplayStartRoot(t *testing.T) {
+	for _, fork := range []string{"isthmus", "jovian"} {
+		outA, outB, goldenA, goldenB, err := processChainPair(fork)
+		if err != nil {
+			t.Fatalf("processChainPair(%s): %v", fork, err)
+		}
+		if goldenA == nil || goldenB == nil {
+			t.Fatalf("%s: nil golden record", fork)
+		}
+		sender := addrOfKey(1)
+		// Block A's post-state must carry the spent nonce (the chain-pair
+		// output is only trustworthy if the replay reproduced it).
+		if accA, ok := outA.PostState[sender]; !ok || accA.Nonce != 1 {
+			t.Fatalf("%s: block A postState sender nonce want 1, got %v (present %v)", fork, accA.Nonce, ok)
+		}
+		// Decision A2: block B's emitted pre IS block A's post-state. Block A's
+		// transfer consumed sender nonce 0, so block B's pre must show nonce 1
+		// (a genesis-root replay would show 0 -- the pre-existing bug).
+		acc, ok := outB.Pre[sender]
+		if !ok {
+			t.Fatalf("%s: block B pre missing sender %s", fork, sender.Hex())
+		}
+		if acc.Nonce != 1 {
+			t.Fatalf("%s: block B pre sender nonce want 1 (block A spent nonce 0), got %d", fork, acc.Nonce)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------
+// Task 5 TDD tests — chain mode (N>=3 linear chain + same-parent fork + parent
+// break). ⚠️ Every test references at least one function that is UNDEFINED
+// before the implementation lands (processChainN / generateChainN /
+// genSiblingFork / buildForkVector / genParentBreak). Before Step 3 this file
+// fails to COMPILE (real red); after implementation it goes green.
+// ---------------------------------------------------------------------
+
+func TestChain3Blocks(t *testing.T) {
+	for _, fork := range []string{"isthmus", "jovian"} {
+		out, err := processChainN(fork, 3)
+		if err != nil {
+			t.Fatalf("processChainN(%s, 3): %v", fork, err)
+		}
+		if out == nil || len(out.Blocks) != 3 {
+			t.Fatalf("%s: chain must have 3 blocks, got %d", fork, len(out.Blocks))
+		}
+		sender := addrOfKey(1)
+		for i, blk := range out.Blocks {
+			// Every block must carry its own _op_expected.header + receipts and
+			// postState (Task 1 handoff contract -- replaySingleBlockInto reads
+			// them with .at(), missing = out_of_range).
+			h := blk.OpExpected.Header
+			if h.GasUsed == "" || h.ReceiptsRoot == "" || h.StateRoot == "" || h.WithdrawalsRoot == "" {
+				t.Fatalf("%s block %d: incomplete header expectation %+v", fork, i, h)
+			}
+			if len(blk.OpExpected.Receipts) != 2 {
+				t.Fatalf("%s block %d: want 2 receipts (deposit + transfer), got %d", fork, i, len(blk.OpExpected.Receipts))
+			}
+			// State accumulates across the chain: block i's postState carries
+			// sender nonce i+1 (block 0 transfer spends nonce 0, block 1 spends 1,
+			// block 2 spends 2).
+			acc, ok := blk.PostState[sender]
+			if !ok {
+				t.Fatalf("%s block %d: postState missing sender %s", fork, i, sender.Hex())
+			}
+			if acc.Nonce != uint64(i+1) {
+				t.Fatalf("%s block %d: sender postState nonce want %d, got %d", fork, i, i+1, acc.Nonce)
+			}
+			// pre present ONLY on block 0 (the replayer inherits the running
+			// chain state for blocks i>0).
+			if i == 0 {
+				if blk.Pre == nil {
+					t.Fatalf("%s block 0 must carry pre", fork)
+				}
+			} else if blk.Pre != nil {
+				t.Fatalf("%s block %d must NOT carry pre (replayer inherits chain state)", fork, i)
+			}
+		}
+	}
+}
+
+func TestSiblingForkIsDivergence(t *testing.T) {
+	// Build the chain to obtain the canonical height-1 child (block 0).
+	_, ctx, err := generateChainN("isthmus", 3)
+	if err != nil {
+		t.Fatalf("generateChainN: %v", err)
+	}
+	canonical := ctx.blocks[0]
+	sibling, err := genSiblingFork(canonical, ctx.cfg, ctx.genesis)
+	if err != nil {
+		t.Fatalf("genSiblingFork: %v", err)
+	}
+	// Same parent + same height, different hash.
+	if sibling.Hash() == canonical.Hash() {
+		t.Fatalf("sibling must diverge from canonical, both %s", canonical.Hash().Hex())
+	}
+	if sibling.ParentHash() != canonical.ParentHash() {
+		t.Fatalf("sibling parent %s != canonical parent %s (must share parent)", sibling.ParentHash().Hex(), canonical.ParentHash().Hex())
+	}
+	if sibling.NumberU64() != canonical.NumberU64() {
+		t.Fatalf("sibling number %d != canonical number %d (must share height)", sibling.NumberU64(), canonical.NumberU64())
+	}
+	// ⚠️ Minimal experiment (review-required): op-geth InsertChain must ACCEPT
+	// the side-chain sibling -- the divergence recorded as "VALID (side chain)".
+	// First insert the canonical child, then the sibling as a side chain. (In a
+	// plain beacon-engine NewBlockChain with no explicit forkChoiceUpdate, geth
+	// moves its local head to the last-inserted same-height block; that internal
+	// artifact is NOT asserted -- only the nil acceptance, which is the divergence.)
+	engine := beacon.New(ethash.NewFaker())
+	chain, err := core.NewBlockChain(rawdb.NewMemoryDatabase(), ctx.genesis, engine, nil)
+	if err != nil {
+		t.Fatalf("NewBlockChain: %v", err)
+	}
+	defer chain.Stop()
+	if _, err := chain.InsertChain(types.Blocks{canonical}); err != nil {
+		t.Fatalf("InsertChain canonical: %v", err)
+	}
+	if _, err := chain.InsertChain(types.Blocks{sibling}); err != nil {
+		t.Fatalf("expected op-geth accept (side chain), got: %v", err)
+	}
+}
+
+func TestForkCarrierSchema(t *testing.T) {
+	_, ctx, err := generateChainN("isthmus", 3)
+	if err != nil {
+		t.Fatalf("generateChainN: %v", err)
+	}
+	canonical := ctx.blocks[0]
+	sibling, err := genSiblingFork(canonical, ctx.cfg, ctx.genesis)
+	if err != nil {
+		t.Fatalf("genSiblingFork: %v", err)
+	}
+	doc, err := buildForkVector("isthmus", canonical, sibling, ctx.genesisPre)
+	if err != nil {
+		t.Fatalf("buildForkVector: %v", err)
+	}
+	// Task 2 handoff: the -32603 carrier MUST carry _op_canonical (the E2E
+	// runner's two-pour reads it -- OpNewPayloadRpcE2eTest.cpp:563).
+	if doc.OpCanonical == nil {
+		t.Fatal("fork carrier missing _op_canonical")
+	}
+	if doc.OpPayload == nil {
+		t.Fatal("fork carrier missing _op_payload")
+	}
+	// _op_canonical must be the canonical child's payload (blockHash matches).
+	if ch, ok := doc.OpCanonical["blockHash"].(string); !ok || ch != canonical.Hash().Hex() {
+		t.Fatalf("_op_canonical blockHash want %s, got %v", canonical.Hash().Hex(), doc.OpCanonical["blockHash"])
+	}
+	// _op_payload must be the sibling's payload.
+	if ph, ok := doc.OpPayload["blockHash"].(string); !ok || ph != sibling.Hash().Hex() {
+		t.Fatalf("_op_payload blockHash want %s, got %v", sibling.Hash().Hex(), doc.OpPayload["blockHash"])
+	}
+	rej := rejectOf(doc)
+	if rej == nil {
+		t.Fatal("fork carrier missing reject")
+	}
+	if rej.Fisco.Classification != "-32603" {
+		t.Fatalf("classification want -32603, got %q", rej.Fisco.Classification)
+	}
+	if rej.Fisco.ExpectThrow != "OpExecutionInternalError" {
+		t.Fatalf("expect_throw want OpExecutionInternalError, got %q", rej.Fisco.ExpectThrow)
+	}
+	if string(rej.Fisco.LatestValidHash) != "null" {
+		t.Fatalf("-32603 latest_valid_hash want null, got %s", rej.Fisco.LatestValidHash)
+	}
+	if rej.OpGeth != "VALID (side chain)" {
+		t.Fatalf("op_geth want 'VALID (side chain)', got %q", rej.OpGeth)
+	}
+}
+
+func TestParentBreakSyncs(t *testing.T) {
+	_, ctx, err := generateChainN("isthmus", 3)
+	if err != nil {
+		t.Fatalf("generateChainN: %v", err)
+	}
+	doc, err := genParentBreak("isthmus", ctx.blocks[0], ctx.cfg, ctx.genesis, ctx.genesisPre)
+	if err != nil {
+		t.Fatalf("genParentBreak: %v", err)
+	}
+	rej := rejectOf(doc)
+	if rej == nil {
+		t.Fatal("break vector missing reject")
+	}
+	if rej.Fisco.Classification != "SYNCING" {
+		t.Fatalf("classification want SYNCING, got %q", rej.Fisco.Classification)
+	}
+	if rej.Fisco.Consumer != "engine" {
+		t.Fatalf("consumer want engine, got %q", rej.Fisco.Consumer)
+	}
+	if len(rej.Fisco.LatestValidHash) != 0 {
+		t.Fatalf("SYNCING must omit latest_valid_hash, got %s", rej.Fisco.LatestValidHash)
+	}
+	// payload parentHash must be the unknown ancestor (0x...01).
+	ph, ok := doc.OpPayload["parentHash"].(string)
+	if !ok || ph != "0x0000000000000000000000000000000000000000000000000000000000000001" {
+		t.Fatalf("break payload parentHash want unknown ancestor, got %v", ph)
+	}
+	// op-geth anchor: the real InsertChain "unknown ancestor" rejection.
+	if !strings.Contains(rej.OpGeth, "unknown ancestor") {
+		t.Fatalf("op_geth want 'unknown ancestor' substring, got %q", rej.OpGeth)
+	}
+}
+
+func TestRejectFieldOmitEmptyKeepsValidVectorBytes(t *testing.T) {
+	// The Reject field must be omitempty: a VALID vector's marshaled bytes must
+	// not contain a "reject" key (byte-invariance for the old 77 vectors).
+	vec := outputVector{
+		Info: caseInfo{Hardfork: "isthmus", Description: "x"},
+		OpExpected: opExpected{
+			Header:   expectedHeader{},
+			Receipts: []expectedReceipt{},
+		},
+	}
+	b, err := json.Marshal(vec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "reject") {
+		t.Fatalf("valid vector must not emit reject key, got %s", b)
+	}
+}
+
+func TestLegacyTransferCaseSpec(t *testing.T) {
+	for _, fork := range []string{"isthmus", "jovian"} {
+		in, err := buildCaseFromSpecs("legacy_transfer", fork)
+		if err != nil {
+			t.Fatalf("buildCaseFromSpecs(legacy_transfer, %s): %v", fork, err)
+		}
+		// type-0 + EIP-155: the built tx must carry _op_type legacy and a raw
+		// envelope that decodes to a protected (EIP-155) legacy tx.
+		if len(in.Transactions) != 2 {
+			t.Fatalf("%s: legacy_transfer must have deposit + legacy tx, got %d", fork, len(in.Transactions))
+		}
+		if in.Transactions[1].OpType != "legacy" {
+			t.Fatalf("%s: tx1 must be legacy, got %q", fork, in.Transactions[1].OpType)
+		}
+		base, err := buildBlockVector(&in)
+		if err != nil {
+			t.Fatalf("buildBlockVector(legacy_transfer, %s): %v", fork, err)
+		}
+		if len(base.vec.Block.Transactions) != 2 {
+			t.Fatalf("%s: output must have 2 transactions, got %d", fork, len(base.vec.Block.Transactions))
+		}
+		// Valid vector → no reject.
+		if base.vec.OpExpected.Reject != nil {
+			t.Fatalf("%s: legacy_transfer is a VALID case, must not carry reject", fork)
+		}
+		// The legacy output object is the second transaction.
+		var txObj map[string]interface{}
+		if err := json.Unmarshal(base.vec.Block.Transactions[1], &txObj); err != nil {
+			t.Fatalf("%s: unmarshal legacy out tx: %v", fork, err)
+		}
+		if txObj["_op_type"] != "legacy" {
+			t.Fatalf("%s: output tx1 _op_type want legacy, got %v", fork, txObj["_op_type"])
+		}
+		if _, ok := txObj["_op_raw"]; !ok {
+			t.Fatalf("%s: legacy output must carry _op_raw", fork)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------
+// Task 4 TDD tests — invalid-tx mode. ⚠️ Every test references at least one
+// function/type that is UNDEFINED before the implementation lands
+// (buildInvalidTxCase / buildInvalidTxBlock / buildInvalidTxVector /
+// invalidTxCaseSpecs / emitableSpecs). Before Step 3 this file fails to
+// COMPILE (real red); after implementation it goes green.
+// ---------------------------------------------------------------------
+
+// invalidTxAnchor is one kind's expected rejection signature: the op-geth
+// message substring (weak anchor) and the T8n/executor throw substring
+// (validation_error_contains).
+type invalidTxAnchor struct {
+	kind   string
+	opGeth string // op-geth rejection message substring
+	t8n    string // T8n throw message substring (validation_error_contains)
+}
+
+var invalidTxAnchorTable = []invalidTxAnchor{
+	{"intrinsic_gas", "intrinsic gas too low", "intrinsic gas too low"},
+	{"nonce_low", "nonce too low", "nonce too low"},
+	{"nonce_high", "nonce too high", "nonce too high"},
+	{"insufficient_funds", "insufficient funds for gas * price + value", "insufficient funds for gas * price + value"},
+	{"fee_cap_low", "max fee per gas less than block base fee", "max fee per gas less than block base fee"},
+	{"sender_no_eoa", "sender not an eoa", "sender not an eoa"},
+	// setcode_create: op-geth ErrSetCodeTxCreate is NOT reachable through a real
+	// signed SetCodeTx (To() is always non-nil) — the op_geth field is a
+	// documentation-only weak anchor; the hard rejection is the T8n opValidate
+	// CREATE_SET_CODE_TX path (structured to:null).
+	{"setcode_create", "EIP-7702 transaction cannot be used to create contract", "set code transaction must not be a create transaction"},
+	{"empty_auth_list", "EIP-7702 transaction with empty auth list", "empty authorization list"},
+	// blob: op-geth rejects at block validation ("data blobs present in block
+	// body"); FISCO rejects at raw-tx DECODE ("unsupported tx type byte 0x03").
+	{"blob", "data blobs present in block body", "unsupported tx type byte 0x03"},
+}
+
+func TestInvalidTxCaseSpecsIndependentTable(t *testing.T) {
+	// The 9 §4b kinds must live in the INDEPENDENT invalidTxCaseSpecs table and
+	// must NOT be reachable from the shared caseSpecs table (review R7:
+	// GenerateChainWithGenesis.AddTx rejects invalid txs → emitCases would emit
+	// an .in.json that the valid pipeline cannot regenerate).
+	if len(invalidTxCaseSpecs) != 9 {
+		t.Fatalf("invalidTxCaseSpecs must enumerate 9 kinds, got %d", len(invalidTxCaseSpecs))
+	}
+	for _, tc := range invalidTxAnchorTable {
+		spec, err := invalidTxSpec(tc.kind)
+		if err != nil {
+			t.Fatalf("invalidTxSpec(%s): %v", tc.kind, err)
+		}
+		if spec == nil || spec.kind != tc.kind {
+			t.Fatalf("invalidTxSpec(%s) returned wrong spec", tc.kind)
+		}
+		for _, name := range []string{"caseSpecs"} {
+			_ = name
+		}
+	}
+	// No invalid-tx kind may be reachable via buildCaseFromSpecs (shared table).
+	if _, err := buildCaseFromSpecs("intrinsic_gas", "isthmus"); err == nil {
+		t.Fatal("intrinsic_gas must NOT be in the shared caseSpecs table")
+	}
+}
+
+func TestLegacyTransferEmittedFromEmitCases(t *testing.T) {
+	// Task 3 F1 → Task 6: legacy_transfer was a B-scope caseSpec gated OUT of
+	// --write-cases; the T8n replayer legacy arm landed (OpT8nReplayTest.cpp),
+	// so bScopeSpecs is empty and it must now be emitted (Task 6 B 范围承诺).
+	seen := false
+	for _, spec := range emitableSpecs() {
+		if spec.name == "legacy_transfer" {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Fatal("legacy_transfer must be emitted by emitCases after the replayer legacy arm landed")
+	}
+	// And it stays reachable as a base for corrupt/invalid-tx vectors.
+	if _, err := buildCaseFromSpecs("legacy_transfer", "isthmus"); err != nil {
+		t.Fatalf("legacy_transfer must remain a buildable base caseSpec: %v", err)
+	}
+}
+
+func TestInvalidIntrinsicGasAnchored(t *testing.T) {
+	// deposit 首笔 + gas=0 eip1559（插在 deposit 之后）。
+	in, buildInvalid, err := buildInvalidTxCase("intrinsic_gas", "isthmus")
+	if err != nil {
+		t.Fatalf("buildInvalidTxCase: %v", err)
+	}
+	cfg, err := buildConfigForCase(&in)
+	if err != nil {
+		t.Fatalf("buildConfigForCase: %v", err)
+	}
+	genesis, err := buildGenesisForCase(&in, cfg)
+	if err != nil {
+		t.Fatalf("buildGenesisForCase: %v", err)
+	}
+	signer := types.MakeSigner(cfg, big.NewInt(1), uint64(in.Genesis.Timestamp)+10)
+	deposit, _, err := buildTx(&in.Transactions[0], signer, cfg)
+	if err != nil {
+		t.Fatalf("buildTx(deposit): %v", err)
+	}
+	invalidTx, _, err := buildInvalid(signer, cfg)
+	if err != nil {
+		t.Fatalf("buildInvalid: %v", err)
+	}
+	blk, err := buildInvalidTxBlock(&in, cfg, genesis, signer, deposit, invalidTx)
+	if err != nil {
+		t.Fatalf("buildInvalidTxBlock: %v", err)
+	}
+	// 手搓 txRoot：types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil))。
+	txs := []*types.Transaction{deposit, invalidTx}
+	if want := types.DeriveSha(types.Transactions(txs), trie.NewStackTrie(nil)); blk.TxHash() != want {
+		t.Fatalf("txRoot %s != DeriveSha %s", blk.TxHash().Hex(), want.Hex())
+	}
+	// header 结构合法：extraData = EncodeOptimismExtraData（否则 VerifyHeaders 先拒）。
+	if len(blk.Extra()) == 0 {
+		t.Fatal("header extraData empty (must be EncodeOptimismExtraData)")
+	}
+	// 跑 op-geth ValidateTransaction → 断言含 "intrinsic gas too low"。
+	head := blk.Header()
+	if err := txpool.ValidateTransaction(invalidTx, head, signer, &txpool.ValidationOptions{
+		Config:  cfg,
+		Accept:  1 << uint(invalidTx.Type()),
+		MaxSize: 128 * 1024,
+		MinTip:  big.NewInt(0),
+	}); err == nil {
+		t.Fatal("ValidateTransaction accepted the gas=0 tx")
+	} else if !strings.Contains(err.Error(), "intrinsic gas too low") {
+		t.Fatalf("ValidateTransaction want 'intrinsic gas too low', got %q", err.Error())
+	}
+	// op-geth 块级（InsertChain）也拒绝（iron-rule mirror）。
+	if msg, err := captureInsertChainRejection(genesis, blk); err != nil {
+		t.Fatalf("captureInsertChainRejection: %v", err)
+	} else if !strings.Contains(msg, "intrinsic gas too low") {
+		t.Fatalf("InsertChain want 'intrinsic gas too low', got %q", msg)
+	}
+	// 非法交易插在 deposit 之后（位置 0 以 "first tx is not deposit" 拒，锚错位）。
+	if len(blk.Transactions()) != 2 || blk.Transactions()[0].Type() != types.DepositTxType {
+		t.Fatalf("block must be [deposit, invalid], got %d txs", len(blk.Transactions()))
+	}
+}
+
+// buildInvalidTxVectorForTest builds the full vector + block + genesis for a
+// kind/fork via the (to-be-implemented) buildInvalidTxVector helper.
+func buildInvalidTxVectorForTest(t *testing.T, kind, fork string) (invalidVectorDoc, *types.Block, *core.Genesis) {
+	t.Helper()
+	doc, blk, genesis, err := buildInvalidTxVector(kind, fork)
+	if err != nil {
+		t.Fatalf("buildInvalidTxVector(%s, %s): %v", kind, fork, err)
+	}
+	if blk == nil || genesis == nil {
+		t.Fatalf("buildInvalidTxVector(%s, %s): nil blk/genesis", kind, fork)
+	}
+	return doc, blk, genesis
+}
+
+func TestInvalidTxAllKindsRejectSchemaAndAnchors(t *testing.T) {
+	for _, tc := range invalidTxAnchorTable {
+		for _, fork := range []string{"isthmus", "jovian"} {
+			doc, blk, genesis := buildInvalidTxVectorForTest(t, tc.kind, fork)
+			rej := rejectOf(doc)
+			if rej == nil {
+				t.Fatalf("%s/%s: missing reject schema", tc.kind, fork)
+			}
+			if rej.Fisco.Classification != "INVALID" {
+				t.Fatalf("%s/%s: classification want INVALID, got %q", tc.kind, fork, rej.Fisco.Classification)
+			}
+			if string(rej.Fisco.LatestValidHash) != `"parent"` {
+				t.Fatalf("%s/%s: latest_valid_hash want parent, got %s", tc.kind, fork, rej.Fisco.LatestValidHash)
+			}
+			// consumer 约束（审查 R16）：decode 级 blob → both；其余 → executor。
+			wantConsumer := "executor"
+			if tc.kind == "blob" {
+				wantConsumer = "both"
+			}
+			if rej.Fisco.Consumer != wantConsumer {
+				t.Fatalf("%s/%s: consumer want %q, got %q", tc.kind, fork, wantConsumer, rej.Fisco.Consumer)
+			}
+			// validation_error_contains 必须携带交易级语义（T8n 断言唯一落点）。
+			if rej.Fisco.ValidationErrorContains == "" {
+				t.Fatalf("%s/%s: missing validation_error_contains", tc.kind, fork)
+			}
+			if !strings.Contains(rej.Fisco.ValidationErrorContains, tc.t8n) {
+				t.Fatalf("%s/%s: validation_error_contains %q missing t8n anchor %q",
+					tc.kind, fork, rej.Fisco.ValidationErrorContains, tc.t8n)
+			}
+			// 非 decode 级：engine 端不带 validation_error_contains（RTTI-bypass 通用消息）——
+			// 即 consumer=executor 时字段只在 executor 端有意义；此处只验证 schema 形状。
+			// op_geth 弱锚必须命中期望消息（文档性，但至少非空且语义相关）。
+			if rej.OpGeth == "" {
+				t.Fatalf("%s/%s: missing op_geth anchor", tc.kind, fork)
+			}
+			// iron-rule mirror：op-geth InsertChain 必须真实拒绝该块，且消息含期望锚
+			// （setcode_create 例外：ErrSetCodeTxCreate 无法经真实信封触达，锚为文档性，
+			// InsertChain 的拒绝消息不同——该 kind 的交易级拒绝只由 T8n opValidate 覆盖）。
+			if tc.kind == "setcode_create" {
+				continue
+			}
+			msg, err := captureInsertChainRejection(genesis, blk)
+			if err != nil {
+				t.Fatalf("%s/%s: captureInsertChainRejection: %v", tc.kind, fork, err)
+			}
+			if !strings.Contains(msg, tc.opGeth) {
+				t.Fatalf("%s/%s: InsertChain want op-geth anchor %q, got %q", tc.kind, fork, tc.opGeth, msg)
+			}
+		}
+	}
+}
+
+func TestInvalidTxBlobDecodeMessage(t *testing.T) {
+	doc, _, _ := buildInvalidTxVectorForTest(t, "blob", "isthmus")
+	rej := rejectOf(doc)
+	if rej == nil {
+		t.Fatal("blob: missing reject")
+	}
+	// FISCO decode 消息（decode 级 kind）：validation_error_contains 必须是它。
+	if !strings.Contains(rej.Fisco.ValidationErrorContains, "unsupported tx type byte 0x03") {
+		t.Fatalf("blob: validation_error_contains %q missing decode anchor", rej.Fisco.ValidationErrorContains)
+	}
+	// 结构化交易对象（block.transactions）必须带 _op_type blob + _op_raw（真实签名 EIP-2718 信封）。
+	if len(doc.Block.Transactions) != 2 {
+		t.Fatalf("blob: block.transactions must have 2 entries, got %d", len(doc.Block.Transactions))
+	}
+	var txObj map[string]interface{}
+	if err := json.Unmarshal(doc.Block.Transactions[1], &txObj); err != nil {
+		t.Fatalf("blob: unmarshal out tx: %v", err)
+	}
+	if txObj["_op_type"] != "blob" {
+		t.Fatalf("blob: _op_type want blob, got %v", txObj["_op_type"])
+	}
+	if _, ok := txObj["_op_raw"]; !ok {
+		t.Fatal("blob: output must carry _op_raw")
+	}
+	// _op_payload.transactions（engine 消费）携带原始 hex 信封。
+	rawTxHex, ok := doc.OpPayload["transactions"].([]string)
+	if !ok || len(rawTxHex) != 2 {
+		t.Fatalf("blob: _op_payload.transactions must have 2 entries, got %#v", doc.OpPayload["transactions"])
+	}
+	// 第二笔（blob）必须是 type-0x03 信封（FISCO decode 拒 "unsupported tx type byte 0x03"）。
+	if len(rawTxHex[1]) < 4 || rawTxHex[1][:4] != "0x03" {
+		t.Fatalf("blob: second envelope must be type 0x03, got %q", rawTxHex[1])
+	}
+}
+
+func TestInvalidTxManualTxRootAndBlockHash(t *testing.T) {
+	// 非法交易参与 txRoot + 占位 stateRoot + blockHash 重算：payload blockHash ==
+	// recomputeOpHeaderHash(block.Header())。FISCO 只有过 step-2 blockHash 检查才进执行。
+	for _, tc := range invalidTxAnchorTable {
+		doc, blk, _ := buildInvalidTxVectorForTest(t, tc.kind, "isthmus")
+		if doc.OpPayload["blockHash"] != recomputeOpHeaderHash(blk.Header()).Hex() {
+			t.Fatalf("%s: payload blockHash %v != recomputed %v",
+				tc.kind, doc.OpPayload["blockHash"], recomputeOpHeaderHash(blk.Header()).Hex())
+		}
+		// 占位 stateRoot：不必等于真实执行结果（执行前先失败），但必须是 32 字节哈希。
+		root, ok := doc.OpPayload["stateRoot"].(string)
+		if !ok || !strings.HasPrefix(root, "0x") || len(root) != 66 {
+			t.Fatalf("%s: placeholder stateRoot malformed: %v", tc.kind, doc.OpPayload["stateRoot"])
+		}
+	}
+}

--- a/opstack-executor/tests/t8n/generator/precompile_inputs.go
+++ b/opstack-executor/tests/t8n/generator/precompile_inputs.go
@@ -1,0 +1,184 @@
+// Valid-input construction helpers for the Phase 2 line-B precompile vectors
+// (Task 0). Each helper builds an input that the corresponding op-geth
+// precompile ACCEPTS (parseable + on-curve/subgroup where the precompile
+// checks, or a proof/signature that actually verifies). Encoding sizes are the
+// authoritative EIP/RIP forms, NOT the bn256 sizes:
+//
+//	bn256 (alt_bn128, EIP-196/197): G1 = 64B (x||y, 2x32), G2 = 128B,
+//	                               pair = 192B.
+//	BLS12-381 (EIP-2537): UNCOMPRESSED: Fp = 64B (16 zero bytes || 48B
+//	                               big-endian; 381-bit field), G1 = 128B
+//	                               (x,y in Fp), G2 = 256B (x,y in Fp2, each
+//	                               c0||c1 in Fp). Mirrors core/vm
+//	                               decodeBLS12381FieldElement/encodePointG1/G2.
+//	secp256r1 (RIP-7212): 160B = hash(32) || r(32) || s(32) || x(32) || y(32)
+//	                               -- the ORDER in op-geth core/vm p256Verify
+//	                               .Run (input[0:32] hash, [32:64] r, [64:96] s,
+//	                               [96:128] x, [128:160] y).
+//	KZG (EIP-4844): 192B = versionedHash(32) || z(32) || y(32) ||
+//	                       commitment(48) || proof(48).
+//
+// Verification (the `// go test`-style assertions) is performed by the
+// --probe-precompile dev probe in main.go: every helper output is fed to the
+// REAL op-geth precompile Run (core/vm.PrecompiledContractsOsaka) and must
+// return no error (plus, for p256/KZG, the exact expected output). All helpers
+// are deterministic.
+package main
+
+import (
+	"crypto/sha256"
+	"math/big"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	bn256cf "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
+)
+
+// repeatedPair repeats a byte slice count times (the generic building block for
+// multi-pair / multi-point precompile inputs).
+func repeatedPair(pair []byte, count int) []byte {
+	if count < 0 {
+		panic("repeatedPair: negative count")
+	}
+	out := make([]byte, 0, len(pair)*count)
+	for i := 0; i < count; i++ {
+		out = append(out, pair...)
+	}
+	return out
+}
+
+// validBn256G1 returns one valid alt_bn128 G1 point (64 bytes = x||y, each 32B
+// big-endian). Constructed as [1]G1 (the generator point) via the cloudflare
+// bn256 backend; the EVM format for G1 is identical across cloudflare/gnark, so
+// the marshal output is directly what the precompile's G1.Unmarshal accepts.
+func validBn256G1() []byte {
+	g1 := new(bn256cf.G1).ScalarBaseMult(big.NewInt(1))
+	out := g1.Marshal()
+	if len(out) != 64 {
+		panic("validBn256G1: unexpected marshal length")
+	}
+	return out
+}
+
+// validBn256G2 returns one valid alt_bn128 G2 point (128 bytes). The cloudflare
+// backend's Marshal order (x.x||x.y||y.x||y.y) is byte-identical to what the
+// top-level crypto/bn256 package's G2.Unmarshal (gnark on amd64/arm64, google
+// elsewhere) expects -- verified empirically by --probe-precompile, which
+// brute-forced all 24 permutations of the four 32B words against gnark and
+// found [0,1,2,3] (the raw marshal) is the accepted one. No re-ordering needed.
+func validBn256G2() []byte {
+	g2 := new(bn256cf.G2).ScalarBaseMult(big.NewInt(1))
+	cf := g2.Marshal()
+	if len(cf) != 128 {
+		panic("validBn256G2: unexpected marshal length")
+	}
+	return cf
+}
+
+// repeatedBn256Pair returns k copies of a valid bn256 pairing input
+// (192 bytes = G1 64 + G2 128, per EIP-197).
+func repeatedBn256Pair(k int) []byte {
+	pair := append(validBn256G1(), validBn256G2()...)
+	if len(pair) != 192 {
+		panic("repeatedBn256Pair: pair length mismatch")
+	}
+	return repeatedPair(pair, k)
+}
+
+// blsFpBytes returns the 48-byte big-endian encoding of a BLS12-381 field
+// element (the low bytes of the EIP-2537 64-byte Fp slot).
+func blsFpBytes(b [48]byte) []byte {
+	return b[:]
+}
+
+// validBlsG1 returns one valid BLS12-381 G1 point in the EIP-2537 UNCOMPRESSED
+// encoding: 128 bytes = x(64B) || y(64B), each Fp slot = 16 zero bytes || 48B
+// big-endian field element. Constructed as [1]g1 (the generator) via
+// gnark-crypto (the same bls12381 package core/vm precompiles use) and encoded
+// exactly like core/vm encodePointG1.
+func validBlsG1() []byte {
+	var p bls12381.G1Affine
+	p.ScalarMultiplicationBase(big.NewInt(1))
+	if !p.IsOnCurve() || !p.IsInSubGroup() {
+		panic("validBlsG1: generator not on curve/subgroup")
+	}
+	out := make([]byte, 128)
+	copy(out[16:64], blsFpBytes(p.X.Bytes()))
+	copy(out[80:128], blsFpBytes(p.Y.Bytes()))
+	return out
+}
+
+// validBlsG2 returns one valid BLS12-381 G2 point in the EIP-2537 UNCOMPRESSED
+// encoding: 256 bytes = x(128B) || y(128B), each Fp2 = c0(64B) || c1(64B), each
+// Fp slot = 16 zero bytes || 48B big-endian. Encoded exactly like core/vm
+// encodePointG2 (x.A0, x.A1, y.A0, y.A1).
+func validBlsG2() []byte {
+	var p bls12381.G2Affine
+	p.ScalarMultiplicationBase(big.NewInt(1))
+	if !p.IsOnCurve() || !p.IsInSubGroup() {
+		panic("validBlsG2: generator not on curve/subgroup")
+	}
+	out := make([]byte, 256)
+	copy(out[16:64], blsFpBytes(p.X.A0.Bytes()))
+	copy(out[80:128], blsFpBytes(p.X.A1.Bytes()))
+	copy(out[144:192], blsFpBytes(p.Y.A0.Bytes()))
+	copy(out[208:256], blsFpBytes(p.Y.A1.Bytes()))
+	return out
+}
+
+// validP256Sig returns a valid RIP-7212 secp256r1 verification input
+// (160 bytes = hash || r || s || x || y, matching op-geth p256Verify.Run's
+// slice order). Inlined as a hex constant generated once (see below): private
+// key scalar 0x01 (public key = the secp256r1 generator), message
+// sha256("fisco line-b p256 vector"), produced and stdlib-verified by a
+// one-off program; re-verified against op-geth crypto/secp256r1.Verify (via
+// the p256Verify precompile) by --probe-precompile.
+func validP256Sig() []byte {
+	return hexutil.MustDecode("0x" +
+		// hash = sha256("fisco line-b p256 vector")
+		"83571dbb808737a2c0e9073de851ede5617b614ec79efea8a56032258f66338a" +
+		// r
+		"1ae7651cef64eafa8d8637c9d921802c7a7f34239271ae11c8a2977d548cfa4d" +
+		// s
+		"6aa2d187b2280a566e3d21827ea5f997b95aaa29ee114b6e8af4b9b725114f3f" +
+		// x (generator x = 6b17d1f2…)
+		"6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296" +
+		// y (generator y = 4fe342e2…)
+		"4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5")
+}
+
+// validKZGInput returns a valid EIP-4844 point-evaluation input
+// (192 bytes = versionedHash(32) || z(32) || y(32) || commitment(48) ||
+// proof(48)). A fixed 131072-byte blob (every byte 0x01, so every 32-byte
+// field element is < the BLS scalar modulus) is committed, a proof at a fixed
+// point z = 0x0001…1f is computed, and the versioned hash is sha256(commitment)
+// with the EIP-4844 version byte 0x01. kzg4844.VerifyProof (the precompile's
+// own check) then succeeds by construction.
+func validKZGInput() []byte {
+	var blob kzg4844.Blob
+	for i := range blob {
+		blob[i] = 0x01
+	}
+	commitment, err := kzg4844.BlobToCommitment(&blob)
+	if err != nil {
+		panic("validKZGInput: BlobToCommitment: " + err.Error())
+	}
+	var point kzg4844.Point
+	for i := range point {
+		point[i] = byte(i)
+	}
+	proof, claim, err := kzg4844.ComputeProof(&blob, point)
+	if err != nil {
+		panic("validKZGInput: ComputeProof: " + err.Error())
+	}
+	versionedHash := sha256.Sum256(commitment[:])
+	versionedHash[0] = 0x01 // EIP-4844 commitment version (KZG)
+	in := make([]byte, 192)
+	copy(in[0:32], versionedHash[:])
+	copy(in[32:64], point[:])
+	copy(in[64:96], claim[:])
+	copy(in[96:144], commitment[:])
+	copy(in[144:192], proof[:])
+	return in
+}

--- a/opstack-executor/tests/t8n/generator/regen.sh
+++ b/opstack-executor/tests/t8n/generator/regen.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# =============================================================================
+# opstack-executor t8n 向量整批重生成仪式
+#   spec rev.4 + Phase-2 线 B Task 5 预编译矩阵 + Task 6 增强语料 +
+#   Task 7 三模式（corrupt/static/invalid-tx/chain）集成 + diff 源重定义 + golden 覆盖。
+# =============================================================================
+#
+# 用途
+#   op-geth 参考向量（vectors/*.json）与引擎黄金数据（golden/engine/*.golden.json）
+#   的确定性整批重生成 + 可复现性校验。数据源为 generator/*.go 里的 Go 用例定义。
+#
+# 依赖（不满足直接 exit 1）
+#   1. op-geth checkout：默认 $OPGETH=/Users/octopus/octo/code/blockchain-impl/op-geth，
+#      HEAD 必须等于 pin e8800cffe53d459cde8a07c8e8f1de9d86e79e07，且工作树必须干净。
+#   2. Go 工具链：脚本把 generator/ 拷进 op-geth/cmd/opt8n-ref 并 go build。
+#
+# 命令
+#   OPGETH=/path/to/op-geth bash opstack-executor/tests/t8n/generator/regen.sh
+#   （OPGETH 缺省用默认路径；在仓库任意位置运行均可，路径由脚本自行解析）
+#
+# 产物（写入 opstack-executor/tests/t8n/）
+#   - cases/                      逐 case 输入（瞬态，不入库，脚本不校验其字节）
+#   - vectors/*.json              逐 case 参考向量 + 三模式派生（corrupt/static/invalid-tx/chain）
+#   - golden/engine/*.golden.json 引擎黄金 + chained/ 链式黄金
+#   - vectors/manifest.txt        注册表（幂等 append；static item 3/12 强制排除，loader 不可表达）
+#
+# 何时运行
+#   - CI：由 composite action .github/actions/opstack-t8n-regen 在测试前自动执行
+#     （主 workflow build/coverage job 已接入）。
+#   - 本地：跑 opstack-executor 测试前需先手动执行本脚本一次（生成物已 .gitignore，
+#     不入库）。生成的 json 会被 git 忽略，不会污染工作树。
+#
+# 验证判据（全部满足才 exit 0）
+#   1. 每个 cases/*.in.json 都产出对应 vectors/<base>.json 与 golden/engine/<base>.golden.json，
+#      缺任一即失败。
+#   2. manifest 非注释非空行集合 == cases ∪ 三模式产物集合（sort + diff 对拍），
+#      防孤儿向量 / 漏注册。
+#   3. git diff --exit-code 只覆盖非生成契约文件（vectors/manifest.txt、vectors/*.md、
+#      golden/engine/manifest.txt、golden/engine/SHA256SUMS）：regen 绝不能改动它们。
+#      corpus 完整性由 #2 保证；op-geth 参考无漂移由本文件头部 PIN 保证。
+# =============================================================================
+set -euo pipefail
+OPGETH="${OPGETH:-/Users/octopus/octo/code/blockchain-impl/op-geth}"
+PIN="e8800cffe53d459cde8a07c8e8f1de9d86e79e07"
+GEN_DIR="$(cd "$(dirname "$0")" && pwd)"
+T8N_DIR="$(dirname "$GEN_DIR")"
+REPO_ROOT="$(git -C "$GEN_DIR" rev-parse --show-toplevel)"
+SCRATCH="$OPGETH/cmd/opt8n-ref"
+N_CHAIN=3
+
+[ "$(git -C "$OPGETH" rev-parse HEAD)" = "$PIN" ] || { echo "op-geth HEAD != $PIN" >&2; exit 1; }
+# ⚠️ 检查须在 opt8n-ref 二进制/目录被本脚本创建前进行：上一轮正常退出已被 cleanup trap
+# rm 掉，此处只拦「有人手工把东西丢进 op-geth 工作树」。
+[ -z "$(git -C "$OPGETH" status --porcelain)" ] || { echo "op-geth worktree dirty" >&2; exit 1; }
+
+cleanup() { rc=$?; rm -rf "$SCRATCH"; rm -f "$OPGETH/opt8n-ref"; exit $rc; }
+trap cleanup EXIT
+
+rm -rf "$SCRATCH"; cp -r "$GEN_DIR" "$SCRATCH"
+( cd "$OPGETH" && go build ./cmd/opt8n-ref )
+
+"$OPGETH/opt8n-ref" --write-cases "$T8N_DIR/cases"          # 单源重发全部 case 文件（含 legacy_transfer）
+
+# ── 逐 case 向量 + engine golden ─────────────────────────────────────────
+# 动态计数（Task 7 Step 1：原 `[ "$n" -eq 77 ]` 硬计数改动态）：每个 .in.json 必须产出
+# vectors/<base>.json 与 golden/engine/<base>.golden.json，缺任一 = FAILURE。
+for in_json in "$T8N_DIR"/cases/*.in.json; do               # fork 在文件名/_info 内，无 --fork
+  base="$(basename "$in_json" .in.json)"
+  "$OPGETH/opt8n-ref" --input "$in_json" --output "$T8N_DIR/vectors/${base}.json" \
+    --golden-output "$T8N_DIR/golden/engine/${base}.golden.json" \
+    --op-geth-commit "$PIN"
+done
+missing=0
+for in_json in "$T8N_DIR"/cases/*.in.json; do
+  base="$(basename "$in_json" .in.json)"
+  [ -f "$T8N_DIR/vectors/${base}.json" ] || { echo "missing vector ${base}.json" >&2; missing=$((missing+1)); }
+  [ -f "$T8N_DIR/golden/engine/${base}.golden.json" ] || { echo "missing golden ${base}.golden.json" >&2; missing=$((missing+1)); }
+done
+[ "$missing" -eq 0 ] || exit 1
+
+# ── 三模式派生向量（Task 7 Step 1）────────────────────────────────────────
+# corrupt：§4a 6 字段 × isthmus/jovian 两 base → invalid_<base>_<field>.json（12）
+"$OPGETH/opt8n-ref" --mode=corrupt --base isthmus_transfer_basic --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+"$OPGETH/opt8n-ref" --mode=corrupt --base jovian_transfer_basic --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+# static：§4c 12 项（item 3/12 生成但强制不入 manifest——GoldenSample loader 不可表达）
+"$OPGETH/opt8n-ref" --mode=static --base isthmus_transfer_basic --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+# invalid-tx：9 kinds × 2 forks → invalid_<fork>_<kind>.json（18）
+for kind in intrinsic_gas nonce_low nonce_high insufficient_funds fee_cap_low sender_no_eoa setcode_create empty_auth_list blob; do
+  "$OPGETH/opt8n-ref" --mode=invalid-tx --base "isthmus_${kind}" --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+  "$OPGETH/opt8n-ref" --mode=invalid-tx --base "jovian_${kind}" --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+done
+# chain：线性 + fork + break（N=3）。fork/break 带 invalid_ 前缀（E2E invalid 子集消费）。
+"$OPGETH/opt8n-ref" --mode="chain:${N_CHAIN}" --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+"$OPGETH/opt8n-ref" --mode="chain:${N_CHAIN}:fork" --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+"$OPGETH/opt8n-ref" --mode="chain:${N_CHAIN}:break" --out-dir "$T8N_DIR/vectors" --op-geth-commit "$PIN"
+
+"$OPGETH/opt8n-ref" --chain-output-dir "$T8N_DIR/golden/engine/chained" \
+  --op-geth-commit "$PIN"                                    # 链式对 golden（chainA/B + jovianChainA/B）
+
+# ── manifest 幂等自动追加（Task 6 Step 1）─────────────────────────────────
+# append-if-absent：已注册的向量（非注释非空行）不再追加；static item 3/12 强制排除。
+append_if_absent() {
+  local manifest="$1"; local comment="$2"; shift 2
+  local pending=()
+  for f in "$@"; do
+    if ! grep -qxF "$f" "$manifest"; then
+      pending+=("$f")
+    fi
+  done
+  if [ "${#pending[@]}" -gt 0 ]; then
+    {
+      printf '\n# %s\n' "$comment"
+      printf '%s\n' "${pending[@]}"
+    } >> "$manifest"
+  fi
+}
+
+is_unregistered_static() {  # §4c item 3/12：生成但不入 manifest
+  case "$1" in
+    *_static_3.json|*_static_12.json) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+manifest="$T8N_DIR/vectors/manifest.txt"
+# 终审 M-2：观察者定向向量（gaslimit/basefee，bothForks）单独成组 append，勿再并入
+# Phase-3 注释（否则 manifest 出现重复的 Phase-3 注释行）。幂等：已注册则两段 append 均 no-op。
+observer_vectors=(isthmus_deposit_basefee_observer.json isthmus_gaslimit_observer.json
+                  jovian_deposit_basefee_observer.json jovian_gaslimit_observer.json)
+is_observer() {
+  local base="$1"
+  for o in "${observer_vectors[@]}"; do
+    [ "$base" = "$o" ] && return 0
+  done
+  return 1
+}
+registerable=()
+for f in "$T8N_DIR"/vectors/*.json; do
+  base="$(basename "$f")"
+  if is_unregistered_static "$base"; then continue; fi
+  if is_observer "$base"; then continue; fi
+  registerable+=("$base")
+done
+# 确定性顺序：排序后追加（与 diff 集合比较同序）。
+# 不用 readarray/mapfile（bash 4+）：macOS runner 默认 bash 3.2 没有该命令（CI exit 127）。
+sorted=()
+while IFS= read -r line; do sorted+=("$line"); done < <(printf '%s\n' "${registerable[@]}" | sort)
+append_if_absent "$manifest" "Phase-3 enhanced corpus (Task 6): corrupt 12 + static 10 + invalid-tx 18 + chain 6 + legacy 2 = 48 vectors (idempotent; §4c item 3/12 excluded — loader 不可表达)" "${sorted[@]}"
+sorted_obs=()
+while IFS= read -r line; do sorted_obs+=("$line"); done < <(printf '%s\n' "${observer_vectors[@]}" | sort)
+append_if_absent "$manifest" "Dual-path observer vectors (gaslimit/basefee, bothForks)" "${sorted_obs[@]}"
+
+# ── diff 源重定义（Task 7 Step 1，审查 R10）：cases ∪ 三模式产物 == manifest ──
+# cases basename 展开（.in.json → .json）∪ 派生名（corrupt/static 注册项/invalid-tx/chain）
+# 与 manifest 非注释行比集合相等（防孤儿向量/漏格）。
+{
+  ls "$T8N_DIR"/cases/*.in.json | xargs -n1 basename | sed 's/\.in\.json$/.json/'
+  printf 'invalid_isthmus_transfer_basic_%s.json\n' stateRoot gasUsed receiptsRoot parentHash extraData blockHash
+  printf 'invalid_jovian_transfer_basic_%s.json\n' stateRoot gasUsed receiptsRoot parentHash extraData blockHash
+  printf 'invalid_isthmus_transfer_basic_static_%d.json\n' 1 2 4 5 6 7 8 9 10
+  printf 'invalid_jovian_transfer_basic_static_%d.json\n' 11
+  for kind in intrinsic_gas nonce_low nonce_high insufficient_funds fee_cap_low sender_no_eoa setcode_create empty_auth_list blob; do
+    printf 'invalid_isthmus_%s.json\n' "$kind"
+    printf 'invalid_jovian_%s.json\n' "$kind"
+  done
+  printf 'isthmus_chain_%d.json\n' "$N_CHAIN"
+  printf 'jovian_chain_%d.json\n' "$N_CHAIN"
+  printf 'invalid_isthmus_chain_%d_fork.json\n' "$N_CHAIN"
+  printf 'invalid_jovian_chain_%d_fork.json\n' "$N_CHAIN"
+  printf 'invalid_isthmus_chain_%d_break.json\n' "$N_CHAIN"
+  printf 'invalid_jovian_chain_%d_break.json\n' "$N_CHAIN"
+} | sort > /tmp/opt8n-left.$$
+grep -v '^#' "$manifest" | sed '/^$/d' | sort > /tmp/opt8n-right.$$
+if ! diff /tmp/opt8n-left.$$ /tmp/opt8n-right.$$; then
+  echo "cases∪modes / manifest set mismatch" >&2
+  rm -f /tmp/opt8n-left.$$ /tmp/opt8n-right.$$
+  exit 1
+fi
+rm -f /tmp/opt8n-left.$$ /tmp/opt8n-right.$$
+
+# ── 终步：契约文件无漂移（向量 json 不入库后，字节等同判据改为只盯非生成契约）──
+# 生成的 vectors/golden json 已不入库（.gitignore + CI composite action 现场重生成），
+# 因此不再有「与入库字节等同」的基线。此处只保证 regen 绝不改动非生成的契约文件：
+#   - vectors/manifest.txt（corpus 契约；若合法扩 corpus，regen 会 append 它 → 本 gate
+#     失败，开发须按流程提交新 manifest，属预期仪式）
+#   - vectors/*.md（DIVERGENCES / ANCHOR-CORRECTIONS / OP_RECEIPT_FIELDMAP，手维护）
+#   - golden/engine/manifest.txt、golden/engine/SHA256SUMS（测试不读，仅契约）
+# corpus 完整性由上方判据 #2（manifest 集合 == cases∪三模式产物）保证；op-geth 参考
+# 无漂移由脚本头部 PIN 保证。
+git -C "$REPO_ROOT" diff --exit-code -- \
+  "$T8N_DIR/vectors/manifest.txt" \
+  "$T8N_DIR/vectors/"*.md \
+  "$T8N_DIR/golden/engine/manifest.txt" \
+  "$T8N_DIR/golden/engine/SHA256SUMS"

--- a/opstack-executor/tests/t8n/golden/engine/SHA256SUMS
+++ b/opstack-executor/tests/t8n/golden/engine/SHA256SUMS
@@ -1,0 +1,108 @@
+# SHA256SUMS — provenance tripwire for the engine-gate golden corpus
+# (op-validator-minimal-loop, final review batch 3 / B3-5).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# The gate in ../../../EngineNewPayloadGateTest.cpp derives ALL of its judging
+# power from these files being op-geth's output and not this repository's own.
+# Feed it values regenerated from our own implementation and every assertion in
+# it still passes -- the gate silently degenerates into a tautology, green.
+# Nothing in the data itself said otherwise: a *.golden.json carries six data
+# keys and no provenance whatsoever, and the op-geth pin lived only in README
+# prose. These checksums are the machine-checked half of that pin.
+#
+# WHAT IT DOES AND DOES NOT PROVE
+# -------------------------------
+# It proves: these bytes have not changed since the values were generated from
+# pinned op-geth. Any regeneration -- accidental, or "let me just refresh the
+# goldens" -- turns EngineNewPayloadGate.GoldenCorpusProvenanceIsPinned red
+# instead of passing unnoticed.
+# It does NOT prove: that a determined regenerator who also refreshes this file
+# used op-geth. Nothing local can prove that; the defence there is that
+# updating a file called SHA256SUMS is a deliberate, reviewable act, and that
+# the companion assertion in the same test checks every vectors/*.json still
+# declares `_op_test_vectors.generator_commit ==
+# e8800cffe53d459cde8a07c8e8f1de9d86e79e07` (op-geth v1.101702.2).
+#
+# REGENERATING (only alongside a real golden regeneration, per README's ritual)
+# ---------------------------------------------------------------------------
+#   cd bcos-evm/test/opstack/t8n/golden/engine
+#   { for f in $(ls *.golden.json | sort); do shasum -a 256 "$f"; done; \
+#     for f in $(ls chained/*.json | sort); do shasum -a 256 "$f"; done; }
+# Standard format: verifiable from a shell with
+#   grep -v '^#' SHA256SUMS | shasum -a 256 -c
+0b8b4ac95f1835265d3f69fb3149785eefb26ce1e7d2919d28ac7ed1b933c677  isthmus_access_list.golden.json
+47ab774ae73c7525f313590b717bcb9b5429da270dfbbf64f4dc7d70cc03749b  isthmus_big_block_130tx.golden.json
+2a6a4312d20c47f48e754f5b91a2ad99f4bab9ca0a2991e2a20cc34f32106488  isthmus_contract_create.golden.json
+96b1e97fb75ef21d281001759978cb17975f66940f106f11e934b3a7653deed9  isthmus_contract_logs.golden.json
+b34aed8b140c3672eb0b6fe35cfeebce3cd6297149123740711b8b3751cef6db  isthmus_deposit_failed.golden.json
+b4ee9c9c863460207d28a9069c583d290fe4698f2981e55d38cacf572eab6d32  isthmus_deposit_mint.golden.json
+8f35b0526c4240981bf101b1f0435b36eb7d75f719775bc9e36250b3970ca3a3  isthmus_deposit_only.golden.json
+8c562f023b62710cdd4dfb551ed3541467548a9f2c39d388ad266be74530a254  isthmus_empty_account_cleanup.golden.json
+f1fca3f5b8ef4f20a925d75937c3294368aa554f11388048491e597b163b110b  isthmus_fee_env_observer.golden.json
+1148b79ba70a525419954484d8388140b8cc9883c0efe93e9c9819d9639a3b88  isthmus_message_passer_write.golden.json
+eb99d8a207906b2996001e51d051eab618c1dcd8119000a7b8fe6b320e4d4674  isthmus_setcode_7702.golden.json
+88f4fceda6c8dba32a227bfc46afaece1d15d5454bc4dcf181cb4628f986febb  isthmus_setcode_7702_skips.golden.json
+920b14417723d7aa4591d0df605a9789bdc1cc51497543e70bc9f628e257e1c9  isthmus_system_call_order_observable.golden.json
+f81087d7f1bfbbb2f870ecdbd6baea0a3b32eb8c258904d5ba6dc0963e76a84d  isthmus_system_contracts_real.golden.json
+534f24db0124baa3ed75f667698870a4ddde2272abc5489428c49db42ffe358d  isthmus_transfer_basic.golden.json
+872fc3ee1f756a893ed1f12cd70532888c5c46f120fe9ab6aad611b020067832  isthmus_transfer_multi.golden.json
+2f0ea47f8fd4e56164a8b361964b0b1e1f3a6fbc7d58e1730b6908b23fb49c10  isthmus_tx_reverted.golden.json
+9c6a7e60242c070f51e57f1f8bdbf731b156741c2ba4dcfd553c27e56ae86884  jovian_access_list.golden.json
+7d7926f488d8277dd7a2b2058898b9d37e9d0ecf14942d5f62ac92d828811117  jovian_contract_create.golden.json
+a11aec37b73661e2e4ea87ba55d6eb03066d0a8437411500a0b3b8ff7f8e828b  jovian_contract_logs.golden.json
+bb9f95fb93d3950f6b1a0d2007d1fb81d25e8181990027cced8a8546f76d149e  jovian_da_mix.golden.json
+8abd2012ca5771e88b6cf0ad236f704e8cef9a299194307285e59b204cc7e7fd  jovian_deposit_failed.golden.json
+44c173880badb08445fe300665bccb33906eadfcf0f247dc7923ed87e54b6f3f  jovian_deposit_mint.golden.json
+0c7c087545530f34560d632e9260147bbb6f62021110f90fba154ab079de2d72  jovian_deposit_only.golden.json
+097b067dfd893377b22271e72e5ad510860d9cc5d75a57138a0b42d6bb67ea2a  jovian_empty_account_cleanup.golden.json
+8d9651dc49dbccd9c2901effcdbd7fd21f93843654a1f72ae19350f5a20833b3  jovian_fee_env_observer.golden.json
+ad39daaecce95eb5c3f2042583e50bad22a93a6c32d85b5a96b1da85198a0611  jovian_first_block.golden.json
+9e6b75c8edaa421330e32dc69de27ced1dee2bca20b193b4784330f94e2a8923  jovian_message_passer_write.golden.json
+4fd61e28c5a7543ab6288fd6d2ac1e409815547ca1a32e5ebdc637f9b02b217d  jovian_setcode_7702.golden.json
+692028f2c9ac148ece8fba0fe0d1d18fbc8416bdc2b1b2777607a1047df2c1b0  jovian_setcode_7702_skips.golden.json
+b63ddbbe1d25377de0b51a81963502c866e271f2501b45afb19e476fe3e93550  jovian_system_contracts_real.golden.json
+09a60e7da2dbf7f3e473ae2df836ad683a4e59cab2851a77a60706c6821053ff  jovian_transfer_basic.golden.json
+5c4fe8f5b461987f92aad640e3e2892c5b458b7e98c0113dd37ea238207366c7  jovian_transfer_multi.golden.json
+991ea25a9890775c863d823856bc144b7f01ce68e958f45be94b00fa35c460e1  jovian_tx_reverted.golden.json
+09d2eefb6fcd4991624ec4d6cf0cc8174dec78b2be5e2dac2899ba5e86213d47  chained/chainA.golden.json
+6a956868b11ad7e0e6d035bc7a317cc6ed9b4927c937e716557c46ed64b4ea35  chained/chainA.post.json
+e07be2ea79b8b2fab0a391fe33108b837132ec2e1fe5a778c159e3ce02072c72  chained/chainA.pre.json
+3041a30ab502730e0bc376b81d2271fbb7d2b5c7d1be8bea86f0599e430f8e50  chained/chainB.golden.json
+701c7b77e361812cedd518a225da7a21de154045e6625e191539081d96e44a3b  chained/chainB.post.json
+320ded36e7937ec26495f8bb1608ef9beb1d174090fcbdb7ed04a61698da3854  chained/chainB.pre.json
+8b2e67273c1b7762d38227dbc8933baf1d3497abed55a3886edb34426734a2fa  chained/jovianChainA.golden.json
+969b17353f73c99eaae0aa33c5ad5ec9e7d978c8d5445cae964d43c8f9d5310f  chained/jovianChainA.post.json
+61521c064b185687f62ca90bc2c6aed8d707929a807b045cb2f7fad8145ea5b4  chained/jovianChainA.pre.json
+92dcf78c2563dc51814b4b7c33ed0c8247134bee286306ba6d44ed2853dbd455  chained/jovianChainB.golden.json
+ad4d269034c49224880532cbadf265a1d691b53973bf196115c66c6a3519375e  chained/jovianChainB.post.json
+928cf646c0f73d68b7c462c754a1b6526ac194f09d21bbb4813d255ac4fba5cf  chained/jovianChainB.pre.json
+aba3680abced319e81f7d2e1b53e23760da0a8023b8c768da2c7082c21649989  isthmus_precompile_blake2f.golden.json
+288f288e8ca5cddca0db1776ef1ba97b07407e8d50f8deea66aea35a3d629e72  isthmus_precompile_bn256add.golden.json
+8a24fd37f36fa3b5111f16de03e87c0ad734529896f603d663d0eb1aba2debaf  isthmus_precompile_bn256mul.golden.json
+ce5db390e35d0dce49fc011ec4c9f802bac7926dc9f1adf1750598bb18030cbb  isthmus_precompile_bn256pair_norm.golden.json
+96b285bb2fb9167d96dc71bc23281883ed43cc9e427faca8430d6a70a58f13bd  isthmus_precompile_bls_g1add.golden.json
+688a624fe4d9852f99cc6a0677625cb7f790c37a56e1fec7bff4b6972744217b  isthmus_precompile_bls_g1msm.golden.json
+21b144436cf42ea5528ff49203fab2926c160636ca2601a788bfbda261cb76a1  isthmus_precompile_bls_g1msm_overcap.golden.json
+4813e9d00d2476352d9f4bba59850e1ac5e5821162d1eabb147f2d1b32669add  isthmus_precompile_bls_g2add.golden.json
+9133e34f824c91422f7872a986c973b8e917f7433591a9dc21c531ee4e7a7e85  isthmus_precompile_bls_g2msm.golden.json
+c9fc964254ab590d68dd829b70b9fc1a71c25b95836832f895eda6f1f209759f  isthmus_precompile_bls_g2msm_overcap.golden.json
+a7a6b215fceb01d8f6ccd15c58cb7f38955964a510509ad3886cca4c9003ec32  isthmus_precompile_bls_map_g1.golden.json
+fc0ee21f8fcb7cbba87082c78e6495ba7f59ba7e57e350fb23a8aadb9a50e353  isthmus_precompile_bls_map_g2.golden.json
+b7932f358f9b41d4a0d77e092d373df1cd806ccc344ca600b53a711b8c44677c  isthmus_precompile_bls_pairing.golden.json
+f466409095fd750d9b9240ee4b99652dcfc40033651a16063b6be75c491f2113  isthmus_precompile_bls_pairing_overcap.golden.json
+548b07a8adfa80ae6c70ffdb858267b4cde88f16229a91f4578c6c1eb79c238c  isthmus_precompile_ecrecover.golden.json
+28c94999ce590aa03fadf0a81bf089e37411f2be1d2dc7b12717bd4283ed87a3  isthmus_precompile_expmod.golden.json
+cdb2c77fc2a44c698ae71be9e21d0c0fcb13e371e4b1c146e3e28f502233c274  isthmus_precompile_identity.golden.json
+3279ede5a3959134ac37f4258045a83d90e642aa59b9179c042dfb2ce558c3e0  isthmus_precompile_point_evaluation.golden.json
+5c5d6a1ca7b2afcacc8cafb0d47eda1e3677b30529663ef184beab34ef379f38  isthmus_precompile_ripemd160.golden.json
+e3ed4d5ea8f333ebbc7ada1e5d18e4657e48fc6357503247ca64c1b7fadea63c  isthmus_precompile_sha256.golden.json
+d63b0c6ddcdaf0d89434b5ec0ac1f8f9db8fb714af38073773c4f3023060eae9  isthmus_precompile_wrap_63of64.golden.json
+dab65d35f73e4429b4379bb8731720a750ed95da27d3bb4b44b869e2bc4c9d81  isthmus_precompile_wrap_eip7702.golden.json
+42a3ba74b8c41938c8bc8a17af10197787f63b6f8a66ee24d46b0031871eb263  isthmus_precompile_wrap_returndata.golden.json
+3344f7497144e48939dc5643b0823dba2f518c58ee7a107b70b6ec16162759b1  jovian_precompile_bls_g1msm_overcap.golden.json
+451d881a78829eb7bc216d2f573d106ed55437a722f3c945acfbd0e42df64b43  jovian_precompile_bls_g2msm_overcap.golden.json
+058908524ffbdf27678fe8bc1366683d9d8e6dfe96326f3ea2203310142678c4  jovian_precompile_bls_pairing_overcap.golden.json
+12512193304d9e35d9697820d7cea348134096f7c486ce4a0f437a1fe46e05cc  jovian_precompile_bn256pair_overcap.golden.json
+8971fe35dcbd9ea945d0567c52f577ab0ca2a130f4de274b0e2f8c7d6a3086c0  jovian_precompile_wrap_value_overcap.golden.json
+90fdd01ba2903a61e01c1541bf65fab57dee6bf85bb03f9b054a58ed5c50961f  jovian_precompile_wrap_value_revert.golden.json

--- a/opstack-executor/tests/t8n/golden/engine/manifest.txt
+++ b/opstack-executor/tests/t8n/golden/engine/manifest.txt
@@ -1,0 +1,83 @@
+# Task 2 (op-validator-minimal-loop spec §7.1) engine-gate golden manifest.
+# One <id>.golden.json per vectors/<id>.json (same id, 63/63, set-equal to
+# cases/*.in.json -- checked at generation time). Each file carries exactly
+# the fields the corpus's own v3-block vectors are structurally missing:
+# blockHash/transactionsRoot/extraData/excessBlobGas/rawTransactions/
+# encodedHeaderHex. vectors/*.json themselves are byte-for-byte untouched
+# (git diff --stat -- ../../vectors/ is empty by construction: golden output
+# and vector regeneration write to disjoint paths, see README.md ritual log).
+isthmus_deposit_only.golden.json
+jovian_deposit_only.golden.json
+isthmus_transfer_basic.golden.json
+jovian_transfer_basic.golden.json
+isthmus_transfer_multi.golden.json
+jovian_transfer_multi.golden.json
+isthmus_deposit_mint.golden.json
+jovian_deposit_mint.golden.json
+isthmus_deposit_failed.golden.json
+jovian_deposit_failed.golden.json
+isthmus_contract_logs.golden.json
+jovian_contract_logs.golden.json
+isthmus_message_passer_write.golden.json
+jovian_message_passer_write.golden.json
+isthmus_tx_reverted.golden.json
+jovian_tx_reverted.golden.json
+isthmus_setcode_7702.golden.json
+jovian_setcode_7702.golden.json
+isthmus_big_block_130tx.golden.json
+isthmus_system_contracts_real.golden.json
+jovian_system_contracts_real.golden.json
+jovian_first_block.golden.json
+jovian_da_mix.golden.json
+isthmus_fee_env_observer.golden.json
+jovian_fee_env_observer.golden.json
+isthmus_contract_create.golden.json
+jovian_contract_create.golden.json
+isthmus_access_list.golden.json
+jovian_access_list.golden.json
+isthmus_setcode_7702_skips.golden.json
+jovian_setcode_7702_skips.golden.json
+isthmus_empty_account_cleanup.golden.json
+jovian_empty_account_cleanup.golden.json
+# B-7 order-observable batch (W5): 1 single-fork (isthmus) case = +1 -> 34.
+isthmus_system_call_order_observable.golden.json
+#
+# Off-line chained pair (spec §7.1 rev.3 decision A2, Step 2): NOT part of
+# the 34-set above -- a dedicated 1->2 block chain (no vectors/ counterpart),
+# each file carrying the FULL v3-block payload merged flatly with the golden
+# extension. Lives in chained/, not listed by basename here (4 files, fixed
+# names, self-describing). The jovian pair (jovianChainA/B) exercises the DA
+# max/linear branch (block1 blobGasUsed > gasUsed).
+#   chained/chainA.golden.json  chained/chainA.pre.json  chained/chainA.post.json
+#   chained/chainB.golden.json  chained/chainB.pre.json  chained/chainB.post.json
+#   chained/jovianChainA.golden.json  chained/jovianChainA.pre.json  chained/jovianChainA.post.json
+#   chained/jovianChainB.golden.json  chained/jovianChainB.pre.json  chained/jovianChainB.post.json
+isthmus_precompile_blake2f.golden.json
+isthmus_precompile_bn256add.golden.json
+isthmus_precompile_bn256mul.golden.json
+isthmus_precompile_bn256pair_norm.golden.json
+isthmus_precompile_bls_g1add.golden.json
+isthmus_precompile_bls_g1msm.golden.json
+isthmus_precompile_bls_g1msm_overcap.golden.json
+isthmus_precompile_bls_g2add.golden.json
+isthmus_precompile_bls_g2msm.golden.json
+isthmus_precompile_bls_g2msm_overcap.golden.json
+isthmus_precompile_bls_map_g1.golden.json
+isthmus_precompile_bls_map_g2.golden.json
+isthmus_precompile_bls_pairing.golden.json
+isthmus_precompile_bls_pairing_overcap.golden.json
+isthmus_precompile_ecrecover.golden.json
+isthmus_precompile_expmod.golden.json
+isthmus_precompile_identity.golden.json
+isthmus_precompile_point_evaluation.golden.json
+isthmus_precompile_ripemd160.golden.json
+isthmus_precompile_sha256.golden.json
+isthmus_precompile_wrap_63of64.golden.json
+isthmus_precompile_wrap_eip7702.golden.json
+isthmus_precompile_wrap_returndata.golden.json
+jovian_precompile_bls_g1msm_overcap.golden.json
+jovian_precompile_bls_g2msm_overcap.golden.json
+jovian_precompile_bls_pairing_overcap.golden.json
+jovian_precompile_bn256pair_overcap.golden.json
+jovian_precompile_wrap_value_overcap.golden.json
+jovian_precompile_wrap_value_revert.golden.json

--- a/opstack-executor/tests/t8n/vectors/ANCHOR-CORRECTIONS.md
+++ b/opstack-executor/tests/t8n/vectors/ANCHOR-CORRECTIONS.md
@@ -1,0 +1,65 @@
+# ANCHOR-CORRECTIONS.md — 校正后锚点表（W4 L0 差异矩阵底稿）
+
+> **用途**：W4 L0 静态对拍差异矩阵（Task 2-4）的锚点底稿。替换 `docs/opstack-opgeth-e2e-comparison.md` §1 中已过时/错位的锚点。
+>
+> **校正值来源**：W4 审查 R1/R2（4-agent 证据级复核，含 off-by-1 修正）。本文件每行均已在**当前分支**实际 grep/Read 核实（2026-08-10）。
+>
+> **核实基准**：FISCO 侧 = 本分支 `feat-op-executor-e2e`；op-geth 侧 = `~/octo/code/blockchain-impl/op-geth`（`v1.101702.2`，git describe 确认）。
+>
+> 表格式：`| 阶段 | 锚点（§1 原） | 校正后 FISCO 锚点 | 校正后 op-geth 锚点 | 校正依据 |`
+> 依据列 = 「W4 审查 R1/R2 + 本次 grep/Read 核实」（列本次核实证据：grep 命令命中行或 Read 区段）。
+
+---
+
+## 表 A — FISCO 侧校正锚点（核本分支）
+
+| 阶段 | 锚点（§1 原） | 校正后 FISCO 锚点 | 校正后 op-geth 锚点（对照） | 校正依据 |
+|---|---|---|---|---|
+| 0 数据形态 | `OpSchedulerImpl.h:857` `decodeOneRawTx` | **`bcos-evm/bcos-evm/engine/OpSchedulerImpl.h:855`**（定义；executeOpBlock 调用点 :1023） | `Transaction.decodeTyped`（`core/types/transaction.go:212`） | W4 审查 R1/R2 + grep `decodeOneRawTx` 命中 :855 |
+| 0 数据形态 | `bcosTransactionToEvmone`（OP 锚点误） | **OP 路径 = `bcos-evm/bcos-evm/opstack/OpTransition.cpp:456-457`**（`evmone::state::Transaction tx;` 直接构造，type=legacy :457） | `Transaction.UnmarshalBinary`/`decodeTyped`（`core/types/transaction.go:212`，deposit 内联） | W4 审查 R1/R2 + grep `evmone::state::Transaction` 命中 :456-457；`bcosTransactionToEvmone` 非 OP 路径（见「实质过时」#2） |
+| 2 块校验 | `EngineServiceImpl.cpp:233-239` | **def `engine/bcos-engine/EngineServiceImpl.cpp:191`**（`calcOpBaseFee` 定义）；Jovian max 逻辑 :233-240（`parentIsJovian && parent.blobGasUsed>gasUsed` 取 max，:236-239） | `eip1559.CalcBaseFee`（`eip1559.go:64`）；Jovian `calcBaseFeeInner` `:99-107` | W4 审查 R1/R2 + grep `calcOpBaseFee` 命中 :191；Read :225-249 确认 :233-240 |
+| 3 状态执行 | `OpValidate.cpp:7`（**文件不存在**） | **`bcos-evm/bcos-evm/opstack/OpTransition.cpp:328`**（`opValidate`） | `preCheck` deposit 分支（`state_transition.go:346-361`） | W4 审查 R1/R2 + grep `opValidate` 命中 :328；`opstack/` 目录无 `OpValidate.cpp` |
+| 3 状态执行 | `OpDepositTx.cpp:58`（**文件不存在**） | **`bcos-evm/bcos-evm/opstack/OpTransition.cpp:441`**（`runDeposit`；OpBlockExecute.cpp:139 调用） | `core/types/deposit_tx.go:27-46`；`NewL1CostFunc`/`NewOperatorCostFunc`（`rollup_cost.go:151,215,353`） | W4 审查 R1/R2 + grep `runDeposit` 命中 :441；`opstack/` 目录无 `OpDepositTx.cpp` |
+| 3 状态执行 | `OpBlockExecute.cpp:75` `processOpBlock` | **`bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:99`** | `ProcessBlock`（`core/blockchain.go:2121` 校正）→ `StateProcessor.Process`（`state_processor.go:62`） | W4 审查 R1/R2 + grep `processOpBlock` 命中 :99 |
+| 3 状态执行 | `OpBlockExecute.cpp:85-91` 首笔 deposit | **`bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:112-116`**（empty-block 拒 :112-113；首笔必须 L1 attributes deposit :114-116） | `checkOptimismPayload`（`api_optimism.go:12`，Isthmus deposits-only） | W4 审查 R1/R2 + Read :105-189 确认 :112-116 |
+| 3 状态执行 | `OpBlockExecute.cpp:115/:165` `blockGasLeft` | **`bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:143/:198`**（deposit 分支 :143 / 普通 tx 分支 :198，`blockGasLeft -= gasUsed`） | `buyGas`（`state_transition.go:282`，预扣 gasLimit*gasPrice 叠加 L1+operator :288-308） | W4 审查 R1/R2 + Read :105-212 确认 :143/:198 |
+| 3 状态执行 | `OpBlockExecute.cpp:128` `loadOpFeeParams` | **`bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:157`**（惰性加载，feeLoaded 守卫 :152） | `NewL1CostFunc`/`NewOperatorCostFunc`（`rollup_cost.go:151,215,353`） | W4 审查 R1/R2 + grep `loadOpFeeParams` 命中 :157 |
+| 3 状态执行 | `OpBlockExecute.cpp:130-152` DA calldata | **`bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:164-180`**；`JovianL1AttributesLen=178`（OpBlockExecute.h:66），**提取在 :176-178**（`attrData[176]<<8 | attrData[177]` = calldata[176:178]；W4-B off-by-1 修正后固定偏移） | `ExtractDAFootprintGasScalar`（`rollup_cost.go:555`）；`CalcDAFootprint:571-577`（激活块 len==176 强制 0） | W4 审查 R1/R2 + Read :164-180 确认；常量 grep `JovianL1AttributesLen=178`（OpBlockExecute.h:66） |
+| 3 状态执行 | `OpTransition.cpp:143/:186-191` `opTransition`/vault | **`bcos-evm/bcos-evm/opstack/OpTransition.cpp:237`**（`opTransition` 定义）；**vault 路由 :295-300**（OP_BASE_FEE_VAULT :295、OP_L1_FEE_VAULT :297、OP_OPERATOR_FEE_VAULT :300） | `execute` OP fee 分发三目标（base→BaseFeeRecipient :719、L1→L1FeeRecipient :725、operator→OperatorFeeRecipient :732，:711-734）；`refundIsthmusOperatorCost` :836-846 | W4 审查 R1/R2 + grep `opTransition\|OP_BASE_FEE_VAULT` 命中 :237/:295；Read :290-304 确认 vault 路由 |
+| 4 块级收尾 | `OpReceiptMap.h:120`（**文件不存在**） | **`bcos-evm/bcos-evm/opstack/OpTransition.cpp:318-321`**（`makeFiscoReceipt` :318 调用 + `setOpStackMeta` :319；`:144` 为 makeFiscoReceipt 定义；mapOpReceipt 区） | `MakeReceipt`（`core/state_processor.go:199`）；`receipt_opstack.go:11` `deriveOPStackFields` | W4 审查 R1/R2 + grep `makeFiscoReceipt\|setOpStackMeta` 命中 :144/:318-319/:519-526；`opstack/` 目录无 `OpReceiptMap.h` |
+| 4 块级收尾 | `OpBlockSeal.cpp:29` `sealOpBlock` | **`bcos-evm/bcos-evm/opstack/OpBlockSeal.cpp:138`** | `Beacon.FinalizeAndAssemble`（`consensus/beacon/consensus.go:383`） | W4 审查 R1/R2 + grep `sealOpBlock` 命中 :138 |
+| 4 块级收尾 | `OpBlockSeal.cpp:60-64` withdrawalsRoot | **`bcos-evm/bcos-evm/opstack/OpBlockSeal.cpp:170-174`**（Isthmus 分支 :170，`seal.withdrawalsRoot = opStorageRoot(messagePasserStorage)` :172，requestsHash :173） | Isthmus `withdrawalsRoot=statedb.GetStorageRoot(L2ToL1MessagePasser)`（`consensus.go:416-427`） | W4 审查 R1/R2 + grep `withdrawalsRoot` 命中 :172；Read :168-181 确认调用点 :170-174 |
+| 4 块级收尾 | `OpBlockSeal.cpp:74-80` blobGasUsed | **`bcos-evm/bcos-evm/opstack/OpBlockSeal.cpp:187-197`**（`cfg.has_da_footprint` :187，Σ meta.da_footprint :193-194，`seal.blobGasUsed = footprint` :196） | Jovian 写 `CalcDAFootprint` 进 header.BlobGasUsed（`consensus.go:429-437`） | W4 审查 R1/R2 + grep `blobGasUsed\|da_footprint` 命中 :185-197 |
+| 4 块级收尾 | `StateRootCompute.h:83` | **`bcos-evm/bcos-evm/adapter/StateRootCompute.h:76`**（`stateRootOf`） | `statedb.Commit`（`core/blockchain.go:1681-1697`） | W4 审查 R1/R2 + grep `stateRootOf` 命中 :76 |
+| 5 落库/索引 | `LedgerMethods.h:233-235` | **`bcos-ledger/bcos-ledger/LedgerMethods.h:237`**（解引用点 `auto field = txEntry->get()`；循环 :235） | `writeBlockWithState`（`core/blockchain.go:1650`） | W4 审查 R1/R2 + grep `txEntry` 命中 :235/:237 |
+
+**FISCO 核实统计**：17 条校正锚点全部 grep/Read 命中；其中 3 条原锚点指向的文件不存在（`OpValidate.cpp`/`OpDepositTx.cpp`/`OpReceiptMap.h`，均已并入 `OpTransition.cpp`/`OpBlockExecute.cpp`）。
+
+---
+
+## 表 B — op-geth 侧校正锚点（核 v1.101702.2）
+
+| 阶段 | 锚点（§1 原） | 校正后 FISCO 锚点（对照） | 校正后 op-geth 锚点 | 校正依据 |
+|---|---|---|---|---|
+| 3 状态执行 | `core/blockchain.go:2086` `ProcessBlock` | `processOpBlock`（`OpBlockExecute.cpp:99` 校正） | **`core/blockchain.go:2121`**（`func (bc *BlockChain) ProcessBlock(...)`；:2086 实为 `bpr.Witness()`） | W4 审查 R1/R2 + grep `func.*ProcessBlock` 命中 :2121；Read :2080-2095 确认 :2086 = `bpr.Witness()` |
+| 2 块校验 | `eip1559_optimism.go:22` | `validateOpNewPayloadRequest` extraData 校验（`engine/bcos-engine/EngineServiceImpl.cpp:279`） | **`consensus/misc/eip1559/eip1559_optimism.go:22`**（`ValidateOptimismExtraData`） | W4 审查 R1/R2 + 路径补全核实 `ls` 确认文件存在 |
+| 2/3 块校验/状态执行 | `rollup_cost.go` | `loadOpFeeParams`（`OpBlockExecute.cpp:157` 校正）；`RollupCost.cpp` | **`core/types/rollup_cost.go`** | W4 审查 R1/R2 + 路径补全核实 `ls` 确认文件存在 |
+| 4 块级收尾 | `receipt.go:199` `MakeReceipt` | `makeFiscoReceipt`/`setOpStackMeta`（`OpTransition.cpp:318-321` 校正） | **`core/state_processor.go:199`**（`func MakeReceipt(...)`） | W4 审查 R1/R2 + grep `func MakeReceipt` 命中 `core/state_processor.go:199` |
+
+**op-geth 核实统计**：4 条校正锚点全部命中；`git describe` 确认 checkout 为 `v1.101702.2`。
+
+---
+
+## 实质过时记录（供矩阵差异点用）
+
+1. **缺口A 已修**：`bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp` `parseNewPayloadRequest` 现填 `rawTransactions` **:71-76**（`:71` `payload.rawTransactions.emplace()`、`:76` `push_back(txData)` 无条件保留，与 decode 解耦）与 `withdrawalsRoot` **:116-119**（`:118` `parseH256`）。§1 阶段 0/1 所述「FISCO 侧 rawTransactions 未接 RPC / 缺口A 静态拒绝」已过时（已核实，Read :60-119）。OP 交易不再依赖 `payload.transactions` 解码（decode 失败仅跳过，`catch(...)` 注释记录 evmone -fno-rtti 下 typed-catch 不可靠）。
+2. **`bcosTransactionToEvmone` 非 OP 路径**：§1 阶段 0 用它描述 OP 宽松转换系锚点误置；OP 路径实际在 `OpTransition.cpp:456-457` 直接构造 `evmone::state::Transaction`（见表 A 阶段 0 行），`bcosTransactionToEvmone` 属以太坊 executor 通道，不在 OP 块执行链上。
+
+---
+
+## 核实统计汇总
+
+| 侧 | 校正条数 | 全部命中 | 原锚点文件不存在 | 实质过时记录 |
+|---|---|---|---|---|
+| FISCO（本分支） | 17 | 17/17 | 3（OpValidate.cpp / OpDepositTx.cpp / OpReceiptMap.h） | 2（缺口A / bcosTransactionToEvmone） |
+| op-geth（v1.101702.2） | 4 | 4/4 | — | — |

--- a/opstack-executor/tests/t8n/vectors/DIVERGENCES.md
+++ b/opstack-executor/tests/t8n/vectors/DIVERGENCES.md
@@ -1,0 +1,241 @@
+# DIVERGENCES — FISCO opstack ↔ op-geth v1.101702.2 块执行差异矩阵
+
+> 来源：W4（L0 静态对拍）。锚点以 `ANCHOR-CORRECTIONS.md` 校正后为准。
+> 判定：等价 / 已知分叉 / 结构性差异。状态：已确认 / 已修一致 / 事实达成 / 待W5。
+> 覆盖：7 阶段 + 8 项 B 项（B-5 拆 a/b/c）+ 结构性差异 + D 项。
+
+> 核实基准：FISCO 侧 = 本分支 `feat-op-executor-e2e`（worktree 根）；op-geth 侧 = `~/octo/code/blockchain-impl/op-geth`（`v1.101702.2`，git describe 确认）。本文件所有锚点已按 ANCHOR-CORRECTIONS 校正并在两侧 grep/Read 复核（2026-08-10）。op-geth 锚点路径已补全至模块前缀。
+
+## 状态图例（§4.1 四态）
+
+| 状态 | 含义 |
+|---|---|
+| 已确认 | 静态对拍已确认：双端实现存在、锚点证据级核实、路径对齐。 |
+| 已修一致 | 该差异此前已存在，现已修复，双端现行为一致。 |
+| 事实达成 | 双端实现路径不同，但最终事实等价（字节级/行为级已由向量佐证）。 |
+| 待W5 | 需 W5 动态验证或 Jovian 链式对才能定论（含 B-5 项单侧路径）。 |
+
+## 判定三态
+
+| 判定 | 含义 |
+|---|---|
+| 等价 | 双端行为/结果一致。 |
+| 已知分叉 | 双端存在已识别的行为差异，分叉点已知且有意保留。 |
+| 结构性差异 | 双端架构/实现位置不同；语义可能仍等价，需逐点看证据列。 |
+
+> 两维正交：判定三态描述「行为是否一致」，状态图例描述「证据强度 / 当前处置」。
+
+---
+
+## 阶段 0 矩阵（数据形态）
+
+| 锚点 | FISCO 锚点 | op-geth 锚点 | 判定 | 证据 | 状态 |
+|---|---|---|---|---|---|
+| ExecutionPayload | `bcos-framework/bcos-framework/engine/Types.h:89-130` | `beacon/engine/types.go:252` DecodeTransactions | 等价 | 结构一致 | 已确认 |
+| typed tx 解码 | `opstack-executor/OpScheduler.h:586` type-byte 门 | `core/types/transaction.go:218` decodeTyped | 已知分叉 | FISCO 白名单 {0x7E/0x01/0x02/0x04}；op-geth 另接受 0x03(blob)/0x7d(post-exec)——FISCO 刻意拒（非等价，见 OpScheduler.h 门注释） | 已确认 |
+| deposit 转换 | `bcos-evm/bcos-evm/opstack/OpTransition.cpp:456-457` | `core/types/deposit_tx.go:27-46` | 等价 | 字段映射一致 | 已确认 |
+| 差异点：三次类型翻译 | — | — | 结构性差异 | FISCO 双端三次翻译 vs op-geth 一次 | 已确认 |
+
+> **注（F-1）**：新 OP 路径（「deposit 转换」行）在 `OpTransition.cpp:456-457` 直接构造 `evmone::state::Transaction`，已不走 `bcosTransactionToEvmone`（该函数属以太坊 executor 通道，非 OP 块执行链，ANCHOR-CORRECTIONS「实质过时」#2）；但旧模块 `opstack-executor/OpstackExecutor.h:258,289` 仍复用 `bcosTransactionToEvmone`（validate :258 / execute :289），存在新、旧两条 tx 翻译路径并存——旧模块属历史 executor 通道，不参与本矩阵的阶段 0 新路径，但语义迁移时需留意。
+
+---
+
+## 阶段 1 矩阵（RPC 入口）
+
+| 锚点 | FISCO 锚点 | op-geth 锚点 | 判定 | 证据 | 状态 |
+|---|---|---|---|---|---|
+| 注册 | `bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp:68-71` | `eth/catalyst/api.go:695/703/724/743/770` | 结构性差异 | FISCO V4 桩、V5 缺失 | 已确认 |
+| 分派 | `bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp:177-221` | `eth/catalyst/api.go:796` newPayload | 等价 | 唯一路径 | 已确认 |
+| OP 校验 | `engine/bcos-engine/EngineServiceImpl.cpp:279/:294/:313` | `beacon/engine/types.go:289/:320-327` | 等价 | rawTransactions 必填 :294、withdrawalsRoot 必填 :313（W4-B 修正 :299/:318） | 已确认 |
+| 差异点：校验位置 | validateOpNewPayloadRequest | checkOptimismPayload | 结构性差异 | 执行后 vs catalyst 层 | 已确认 |
+
+---
+
+## 阶段 2 矩阵（块校验）
+
+| 锚点 | FISCO 锚点 | op-geth 锚点 | 判定 | 证据 | 状态 |
+|---|---|---|---|---|---|
+| 块校验主体 | `engine/bcos-engine/EngineServiceImpl.h:1094-1147` 承诺比对 | `core/block_validator.go:51` ValidateBody | 结构性差异 | 执行后承诺比对 vs 预校验（§2 结构性差异） | 已确认 |
+| extraData | `engine/bcos-engine/EngineServiceImpl.cpp:383-421`（validateOpNewPayloadRequest 内 Isthmus 9B/Jovian 17B 形状校验） | `consensus/misc/eip1559/eip1559_optimism.go:22` | 等价 | FISCO 已实现（对齐 ValidateHolocene/JovianExtraData）；W4-C 证伪「无对应」 | 已确认 |
+| base fee | `engine/bcos-engine/EngineServiceImpl.cpp:191`（def）；Jovian max 分支 :233-240 | `consensus/misc/eip1559/eip1559.go:64/:99-107` | 等价 | 一般路径经 33 向量 encodeOpHeader 字节级佐证；**Jovian max 分支已由 jovian 链式对证实（B-5c：block2 baseFee=0x3a7e98a8=calcOpBaseFee(DA)）** | 已确认 |
+| DA footprint ==≤GasLimit | `engine/bcos-engine/EngineServiceImpl.cpp:442-444` | `core/block_validator.go:119-134` | 等价 | 均实现（jovian_da_mix DA=593600 字节级） | 事实达成 |
+| 单侧：DA 拒绝路径 | `engine/bcos-engine/EngineServiceImpl.cpp:442-444` | `core/block_validator.go:131-132` | 结构性差异 | B-5b 拒绝向量已验证：`jovian_da_mix` 改 `blobGasUsed=gasLimit+1` → INVALID + "DA footprint"（OpL1EdgeGateTest/DAFootprintExceedsGasLimitRejected） | 已确认 |
+
+> ⚠️ base fee 的 FISCO 锚点是 `EngineServiceImpl.cpp:191`（def）——§1 写 :233-239 是 Jovian max 逻辑，两者都要在证据列区分；Jovian max 分支状态与 B-5c 保持一致（已确认）。
+
+---
+
+## 阶段 3 矩阵（状态执行）
+
+| 锚点 | FISCO 锚点 | op-geth 锚点 | 判定 | 证据 | 状态 |
+|---|---|---|---|---|---|
+| 块执行入口 | `bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:99` processOpBlock | `core/state_processor.go:62` Process | 等价 | 首笔 deposit 强制（:112-116） | 已确认 |
+| 首笔 L1 attributes | `bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:112-116` | `core/state_transition.go:346-361` preCheck | 等价 | D-1 交易级 | 已确认 |
+| blockGasLeft 递减 | `bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:143/:198` | `core/state_transition.go:282` buyGas | 等价 | B-4 相关 | 事实达成 |
+| fee 惰性加载 | `bcos-evm/bcos-evm/opstack/OpBlockExecute.cpp:157` loadOpFeeParams | `core/types/rollup_cost.go:151/:215/:353`（NewL1CostFunc/NewOperatorCostFunc/NewTotalRollupCostFunc） | 等价 | D-4 相关；随 D-4 快照契约固化 + 既有 golden（jovian 链式对 baseFee=calcOpBaseFee(DA)）关闭 | 已确认 |
+| validate | `bcos-evm/bcos-evm/opstack/OpTransition.cpp:328` opValidate | `core/state_transition.go:346` preCheck | 等价 | D-1 | 已确认 |
+| fee 路由至 vaults | `bcos-evm/bcos-evm/opstack/OpTransition.cpp:295-300` | `core/state_transition.go:711-734` | 等价 | C-5 校正后 | 已确认 |
+| deposit 执行 | `bcos-evm/bcos-evm/opstack/OpTransition.cpp:441` runDeposit | `core/state_transition.go:473-511` | 等价 | D-1 | 已确认 |
+| 差异点#1 快照契约 | `opValidate/opTransition 共享快照（OpTransition.cpp:328/:237）` | `buyGas/innerExecute 即时读（state_transition.go:282/:515）` | 已知分叉 | D-4 契约已固化（TransitionUsesValidateSnapshot：opValidate 写 F → slot1 写 F' → opTransition 用 props=F 非 F'） | 已确认 |
+| tx chainId 校验 | `opstack-executor/OpstackExecutor.h:749-775` m_prepare chainId gate | `core/types/transaction_signing.go` EIP155Signer.Sender / modernSigner.Sender（`tx.ChainId()==chainID`，ErrInvalidChainId） | 等价 | morebtcg #5429：protected legacy mismatch + typed chain_id==0 → OpConsensusError；仅 legacy 未保护 v=27/28 豁免；eth_call 跳过 | 已确认 |
+| 残余：legacy v=35/36 chain_id==0 | `opstack-executor/OpstackExecutor.h:764`（`chain_id!=0` 守卫豁免） | `transaction_signing.go` `tx.Protected()`（V≠27/28 → EIP155Signer）→ chainId 0 ≠ 节点 chainId → ErrInvalidChainId | 已知分叉 | review K：tars 层把 v=35/36（chain id 0）折叠成与 v=27/28 相同的 "0"，executor 无法区分 → 接受；nil 安全影响（v=35 签名可重编码为 v=27/28，两客户端均收）；完整 parity 需 tars Transaction 携带 protected 标志 | 已确认 |
+
+---
+
+## 阶段 4 矩阵（块级收尾）
+
+| 锚点 | FISCO 锚点 | op-geth 锚点 | 判定 | 证据 | 状态 |
+|---|---|---|---|---|---|
+| txRoot | `bcos-evm/bcos-evm/engine/OpEngineSeam.h:171` computeOpTxRoot | `core/types/block.go:271` DeriveSha（TxHash） | 等价 | HashBuilder 排序修复 | 已修一致 |
+| 密封 header | `bcos-evm/bcos-evm/opstack/OpBlockSeal.cpp:138` sealOpBlock | `consensus/beacon/consensus.go:383` FinalizeAndAssemble | 等价 | encodeOpHeader 字节级 | 事实达成 |
+| withdrawalsRoot | `bcos-evm/bcos-evm/opstack/OpBlockSeal.cpp:170-174` | `consensus/beacon/consensus.go:416-427` | 等价 | B-1 | 已修一致 |
+| blobGasUsed | `bcos-evm/bcos-evm/opstack/OpBlockSeal.cpp:187-197` | `consensus/beacon/consensus.go:429-437` | 等价 | B-5a | 事实达成 |
+| stateRoot | `bcos-evm/bcos-evm/adapter/StateRootCompute.h:76` stateRootOf | `core/blockchain.go:1681-1697` Commit | 等价 | 33 向量 | 事实达成 |
+| 回执映射 | `bcos-evm/bcos-evm/opstack/OpTransition.cpp:318-321` | `core/state_processor.go:199` MakeReceipt | 等价 | B-2 | 事实达成 |
+| 回执扩展字段 | `bcos-evm/bcos-evm/opstack/OpTransition.cpp:319` setOpStackMeta | `core/types/receipt.go:596` DeriveFields | 已知分叉 | B-3 | 已确认 |
+
+---
+
+## 阶段 5 矩阵（落库/索引）
+
+| 锚点 | FISCO 锚点 | op-geth 锚点 | 判定 | 证据 | 状态 |
+|---|---|---|---|---|---|
+| 落库入口 | `engine/bcos-engine/EngineServiceImpl.h:1200` registerOpBlock | `core/blockchain.go:1650` writeBlockWithState | 等价 | 单入口落库（OP 块 VALID 后统一走 registerOpBlock） | 已确认 |
+| number→hash | `EngineServiceImpl.h:1207-1209` SYS_NUMBER_2_HASH | `core/blockchain.go:1664` rawdb.WriteBlock | 等价 | key=number 十进制串 → value=hash raw 32B；与 op-geth canonical 索引同语义 | 已确认 |
+| hash→number | `EngineServiceImpl.h:1213-1216` SYS_HASH_2_NUMBER | `core/blockchain.go:1664` rawdb.WriteBlock | 等价 | key=hash raw 32B → value=number 十进制串 | 已确认 |
+| header | `EngineServiceImpl.h:1227-1229` SYS_NUMBER_2_BLOCK_HEADER | `core/blockchain.go:1664` rawdb.WriteBlock | 等价 | OP 头以 tars BlockHeader 落标准表（spec D3：一等公民，同 `Ledger.cpp:234`） | 已确认 |
+| 回执 | `EngineServiceImpl.h:1288-1291` SYS_HASH_2_RECEIPT | `core/blockchain.go:1665` rawdb.WriteReceipts | 等价 | key=tx hash（keccak over raw EIP-2718 信封，:1284） | 已确认 |
+| 交易 | `EngineServiceImpl.h:1293-1307` SYS_HASH_2_TX（方案 B：`opEnvelopeToTars` 转换后写 tars Transaction，key=keccak 信封；0x04/损坏信封返回 nullopt 跳过写表 D7） | `core/blockchain.go:1664` rawdb.WriteBlock（txs 内联于 block） | 等价 | 方案 B（2026-08-10）：OP 交易落通用 SYS_HASH_2_TX，读侧 eth_getTransactionByHash/eth_getTransactionReceipt 与普通交易同通道可查；s_eth_hash_2_rawtx 写已删（:1253-1254）。残留：0x04 (EIP-7702) 读侧 null（TransactionType 无 handler） | 已确认 |
+| 差异点：OP 交易落库（方案 B） | `EngineServiceImpl.h:1293-1307`（opEnvelopeToTars 转换后写 SYS_HASH_2_TX；D7：0x04/损坏信封 nullopt 跳过写表——读侧 null，块仍 VALID）+ `:1253-1254`（s_eth_hash_2_rawtx 写删） | `core/blockchain.go:1664` rawdb.WriteBlock（txs 内联于 block） | 等价 | 2026-08-10 方案 B 后 OP 交易经通用通道可查；0x04 (EIP-7702) 读侧 null 是已知 divergence（TransactionType 无 handler，与 op-geth 不一致） | 已确认 |
+
+> **注（阶段 5，UB）**：`bcos-ledger/bcos-ledger/LedgerMethods.h:237` 对缺失 SYS_HASH_2_TX 行无 `has_value()` 检查直接解引用（循环 :235，`auto field = txEntry->get()`）——pre-existing 缺陷，非 OP 引入（任何块 tx 元数据超 SYS_HASH_2_TX 都会命中）；写入假交易不修复它，只是把可发现的崩溃换成不可发现的错误答案（EngineServiceImpl.h:1247-1252）。
+
+---
+
+## 阶段 6 矩阵（输出）
+
+| 锚点 | FISCO 锚点 | op-geth 锚点 | 判定 | 证据 | 状态 |
+|---|---|---|---|---|---|
+| block hash | `engine/bcos-engine/EngineServiceImpl.h:799-803`（opHeaderHash 重建比对）+ `:1094-1147`（六项承诺比对） | `core/types/block.go:124` Header.Hash()（RLP keccak） | 等价 | 33 向量 + chainA/B `encodeOpHeader` 字节级全等 | 已确认 |
+| 差异点：output root | 无对应（不在 EL 范围） | `optimism/op-node/rollup/output_root.go:29` ComputeL2OutputRootV0（op-node 职责） | 不在范围 | output root 由 op-node（CL 侧）计算，非 EL 执行器对比范围；FISCO gate 测试用 `block.Hash()` 对齐 | 标注 |
+
+---
+
+## 结构性差异（架构层，§2 结构性差异节）
+
+| # | 结构性差异 | FISCO 锚点 | op-geth 锚点 | 说明 |
+|---|---|---|---|---|
+| 1 | 块校验位置 | 执行后六项承诺比对 `engine/bcos-engine/EngineServiceImpl.h:1094-1147` + blockHash 重建比对 `:799-803` | `core/block_validator.go:51` ValidateBody（预校验） | FISCO 主体仍是执行后承诺比对，无完整 VerifyHeader/ValidateBody 等价物（§0.0 C-13）；→ 阶段2「块校验主体」行 |
+| 2 | 双执行器并存 | `opstack-executor/OpstackExecutor.h:54`（v2 独立模块，未装配）+ `bcos-evm/bcos-evm/engine/OpSchedulerImpl.h:1014` executeOpBlock（生产单路径） | 唯一路径：`core/state_processor.go:62` Process | v2 模块未装配，生产仅 executeOpBlock 单路径；op-geth 只一条路径（W4-A/D 修正：以 OpstackExecutor.h 为 v2 参照） |
+| 3 | 索引隔离（已消除） | 方案 B（2026-08-10）：`EngineServiceImpl.h:1293-1307` 写 SYS_HASH_2_TX（opEnvelopeToTars 转换）+ `:1253-1254` rawtx 写删 | rawdb 统一索引（`core/blockchain.go:1664-1665`） | 已消除：OP 交易落通用 SYS_HASH_2_TX，读侧统一可查；残留 divergence = 0x04 (EIP-7702) 读侧 null（TransactionType 无 handler，块仍 VALID）→ 阶段5「差异点」行 |
+| 4 | PBFT 双执行防护 | `OpSchedulerImpl.h:987/:993` executeBlock throw 哑桩（实测定义 :985、throw :991-992） | —（无对应） | 仅在 OP scheduler 装配后生效；OP 模式禁用 PBFT executeBlock（§4 缺口C） |
+
+---
+
+## D 项（已确认，§2 直接纳入）
+
+| # | 差异 | 判定 | 锚点 / 证据 | 状态 |
+|---|---|---|---|---|
+| D-1 | 交易级执行（费用/L1+operator/Flz/deposit/7702/intrinsic/空账户/CREATE 地址/receipt 共识编码）逐位等价 | 等价 | 记忆审计（v1.101702.2）；→ 阶段3 各交易级行 | 已确认 |
+| D-2 | **Karst 占位**：karstConfig 仅 jovianConfig 别名 | 已知分叉 | `bcos-evm/bcos-evm/opstack/OpForkSchedule.cpp:93-101`（karstConfig；:96-98 复制 jovianConfig 仅改 fork tag :97） | 🔴 上线 Karst 前必须按真实 diff 适配 |
+| D-3 | Jovian DA footprint 是纯块级 header 字段，不进 tx 级状态 | 等价 | `OpBlockSeal.cpp:196` seal.blobGasUsed=Σ meta.da_footprint（块级）；tx 级 gas_used/cumulative/receiptsRoot/stateRoot 不含 DA（记忆已核实） | 已确认 |
+| D-4 | validate↔transition 费用快照契约：FISCO 两阶段共享快照 vs op-geth 即时读 | 已知分叉（契约已固化） | `OpTransition.cpp:328/:237`（共享快照）vs `core/state_transition.go:282/:515`（即时读） | W5 契约测试已固化：opValidate 写 F → slot1 写 F' → opTransition 用 props=F 非 F'（TransitionUsesValidateSnapshot，OpL1EdgeGateTest）；→ 阶段3「差异点#1」行，已确认 |
+
+---
+
+## 差异点归位对照表（§4.2 归位规则，覆盖全部 7 阶段）
+
+| 阶段 | 差异点（comparison doc §1） | 归位 | 指向 | 判定 / 状态 |
+|---|---|---|---|---|
+| 阶段0 | 三次类型翻译（FISCO 双端三次 vs op-geth 一次） | 矩阵行 | 阶段0「差异点：三次类型翻译」行 | 结构性差异 / 已确认 |
+| 阶段1 | 校验位置（validateOpNewPayloadRequest vs checkOptimismPayload） | 矩阵行 | 阶段1「差异点：校验位置」行 | 结构性差异 / 已确认 |
+| 阶段2 | 块校验完整度（op-geth VerifyHeader/ValidateBody vs FISCO 承诺比对） | 矩阵行 | 阶段2「块校验主体」行（承诺比对 :1094-1147） | 结构性差异 / 已确认 |
+| 阶段3 #1 | 快照契约（两阶段共享快照 vs 即时读） | D-4 | 阶段3「差异点#1 快照契约」行 = D-4 | 已知分叉（契约已固化） / 已确认 |
+| 阶段3 #2 | fee 惰性加载（loadOpFeeParams vs L1Block 槽即时解析） | 矩阵行 | 阶段3「fee 惰性加载」行 | 等价 / 已确认 |
+| 阶段3 #3 | DA footprint 不进 tx 级 | D-3 | D 项表 D-3 | 等价 / 已确认 |
+| 阶段4 #1 | withdrawalsRoot 语义一致（opStorageRoot vs GetStorageRoot） | B-1 | B 台账 B-1 | 等价 / 已修一致 |
+| 阶段4 #2 | receiptsRoot 编码（encodeReceiptForRoot vs receiptRLP/depositReceiptRLP） | B-2 | B 台账 B-2 | 等价 / 事实达成 |
+| 阶段4 #3 | OP 回执扩展字段（setOpStackMeta vs deriveOPStackFields） | B-3 | B 台账 B-3 | 已知分叉（2 delta）/ 已确认 |
+| 阶段5 | OP 交易落库（方案 B：opEnvelopeToTars 转换后写 SYS_HASH_2_TX；0x04 跳过） | 等价 | 阶段5「差异点：OP 交易落库」行 + 结构性差异#3（已消除） | 等价 / 已确认 |
+| 阶段6 | output root 不在 EL 范围（op-node 职责） | 不在范围 | 阶段6「差异点：output root」行（标注） | 不在范围 / 标注 |
+
+---
+
+## B 项台账（§4.3，B-5 拆 a/b/c）
+
+| B 项 | 判定 | 状态 | 锚点（FISCO / op-geth） | 依据 |
+|---|---|---|---|---|
+| B-1 | 等价 | 已修一致 | `bcos-evm/bcos-evm/opstack/OpBlockSeal.cpp:170-174` / `consensus/beacon/consensus.go:416-427` | W6 分歧1（opStorageRoot leaf 二次 RLP，OpBlockSeal.cpp:67-97 修复）；`message_passer_write` isthmus+jovian 两向量逐位验证 |
+| B-2 | 等价 | 事实达成 | `OpBlockSeal.cpp:138` sealOpBlock / `core/state_processor.go:199` MakeReceipt（+ `core/types/receipt.go:128-148`） | 承诺比对（EngineServiceImpl.h:1094-1147）+ 七项断言 33 向量逐位匹配；正式迁移留 W7 |
+| B-3 | 已知分叉（2 delta） | 已确认（动态 manifest 待 W5/RPC 层对拍） | `OpTransition.cpp:319` setOpStackMeta / `core/types/receipt.go:596` DeriveFields + `core/types/receipt_opstack.go:11` | 2 delta：`operator_fee`=FISCO 扩展（`OpTransition.h:96-97` 明标）；legacy `FeeScalar`（pre-Ecotone）FISCO 无；W6 harness 不覆盖回执扩展字段（encodeReceiptForRoot 只共识编码） |
+| B-4 | 等价 | 事实达成 | `OpBlockExecute.cpp:143/:198` blockGasLeft 递减 / `core/state_transition.go:282` buyGas | 承诺比对 gasUsed + 七项断言 33 向量（deposit/normal 均递减+回填） |
+| B-5a | 等价 | 事实达成 | `OpBlockSeal.cpp:187-197` / `consensus/beacon/consensus.go:429-437` | `jovian_da_mix`（DA=593600=0x90ec0）字节级对拍通过（seal.blobGasUsed=Σ meta.da_footprint :193-194） |
+| B-5b | 结构性差异 | 已确认 | `EngineServiceImpl.cpp:442-444` / `core/block_validator.go:119-134`（:131-132 拒绝） | W5 拒绝向量已验证：`jovian_da_mix` 改 `blobGasUsed=gasLimit+1` → INVALID + "DA footprint"（OpL1EdgeGateTest/DAFootprintExceedsGasLimitRejected） |
+| B-5c | 等价 | 已确认 | `EngineServiceImpl.cpp:233-240` calcOpBaseFee Jovian max / `consensus/misc/eip1559/eip1559.go:99-107` | W5 jovian 链式对已验证：jovianChainA block1 DA=1,783,600（0x1b3730）> gasUsed=264,840（0x40a88），block2 baseFee=0x3a7e98a8=calcOpBaseFee(DA)（JovianChainedAB） |
+| B-6 | 等价 | 已确认 | `OpBlockExecute.cpp:176-178`（calldata[176:178] 提取，`OpBlockExecute.h:66` JovianL1AttributesLen=178）/ `core/types/rollup_cost.go:547-557` ExtractDAFootprintGasScalar | 仅从首笔 L1 attributes calldata 提取，不读任何槽（slot8=OperatorFeeParamsSlot，非 DA scalar）；FISCO 同法 |
+| B-7 | 等价 | 已确认 | `OpBlockExecute.cpp:112-116`（首笔 L1 attributes；pre-block system call :106-108 先于首笔）/ `core/state_processor.go:90-95`（beaconRoot/parentHash 预执行） | W5 order-observable 向量已验证：`isthmus_system_call_order_observable`，顺序错 → L1 读者 REVERT → stateRoot 失配 → VALID+七项断言变红（SystemCallOrderObservable）；效果已由 stateRoot 逐位 golden 一致证实（`system_contracts_real`） |
+| B-8 | 等价 | 已修一致 | `OpEngineSeam.h:171` computeOpTxRoot / `core/types/block.go:271` DeriveSha（TxHash） | W6 链式对（chainA/B state 延续+跨块 fee）+ 分歧2（txRoot ≥128 笔排序，`bcos-ledger/bcos-ledger/mpt/HashBuilder.cpp:199-231`，排序 :229-230） |
+
+---
+
+## M-B 块级台账（W5，L1 差分 gate）
+
+> W5（L1 差分 gate）对 B 台账 B-5b/B-5c/B-7/D-4 的动态定论。schema 依 spec §6；实测值来自 W5 T2-T4 交付的用例/golden（OpL1EdgeGateTest / OpNewPayloadRpcE2eTest）。
+
+| M-B项 | 验证手段 | 断言 | 用例/golden | 结果状态 |
+|---|---|---|---|---|
+| M-B5b | 拒绝向量：`jovian_da_mix` 改 `blobGasUsed=gasLimit+1` | INVALID + "DA footprint" | OpL1EdgeGateTest | ✅ 已验证 |
+| M-B5c | jovian 链式对：jovianChainA block1 DA=1,783,600 > gasUsed=264,840 | block2 baseFee=0x3a7e98a8=calcOpBaseFee(DA)，VALID（step 3a-2） | OpNewPayloadRpcE2eSuite/JovianChainedAB | ✅ 已验证 |
+| M-B7 | order-observable 向量：`isthmus_system_call_order_observable`，顺序错 reader REVERT | VALID + 七项；stateRoot 失配捕获 | OpNewPayloadRpcE2eSuite/SystemCallOrderObservable | ✅ 已验证 |
+| M-D4 | opValidate/opTransition 函数对：opValidate 写 F → slot1 写 F' → opTransition 用 props | transition 用快照 F 非 F' | OpL1EdgeGateTest | ✅ 已固化 |
+
+> **注（Task 5 闭合，2026-08-10）**：Ecotone 下 `_op_l1_gas_used` 差分分歧已闭合——`deriveOpReceiptMeta`
+> 现读 validate 期快照 `props.ecotone_calldata_gas_used`（= envelope `bedrockCalldataGasUsed`），Fjord+ 仍走
+> flz_len 的 Fjord 公式（字段保持 nullopt）。41 向量 t8n 差分门全绿（0 DIVERGE），本文件无需新增
+> ALLOWLIST 条目；`ecotone_transfer_basic` / `ecotone_contract_create` 曾报 want=0x130c/0x6b8 got=0x640 已一致。
+
+---
+
+## FINDING-create-output
+
+**回执 output（CREATE 交易）基座层语义分叉（2026-08-11，output 维度新增比对后暴露）**。
+
+门跑新增 `output` 字段比对后，6 个 `*_contract_create` 向量的创建交易回执 `output` 分歧：
+- **want** = `0x600160005500`：op-geth `ExecutionResult.ReturnData` 对合约创建 = 部署出的合约字节码（init code 的 return）。
+- **got** = `0x`：FISCO `opTransition` 经 vendored evmone `Host::create()` 执行，成功创建后返回
+  `evmc::Result{status, gas_left, gas_refund, create_address}`（`bcos-evm/bcos-evm/eth/state/host.cpp:305`
+  的 4 参构造，不带 output_data）；创建代码写入 state 账户 `new_acc->code`，而非 result.output_data。
+
+**归属**：**基座层（vendored evmone）语义差异**，非 opstack 层 bug——evmone 的 create 结果不携带
+代码到 output，op-geth 的 ReturnData 则携带。回执 `output` 是 FISCO 自有 TARS 扩展字段（非共识编码，
+`encodeReceiptForRoot` 不含它，receiptsRoot 不受影响），op-geth 回执本无此字段，故这是
+「FISCO 回执 output 与 op-geth 执行结果 ReturnData 的表示差异」而非块执行语义分叉。
+
+**处置**：`attribution=a`（基座层 PENDING-FIX）ALLOWLIST 豁免，**不修**（按线 B 纪律：base 层立案不修；
+改动 vendored evmone create 结果携带代码属独立决策，留作后续）。wrapper/precompile 的 output 语义
+（截断 quirk、32-byte-1、ecrecover 地址）已全绿，正是本维度新增比对的目的。
+
+<!-- ALLOWLIST vectorId=ecotone_contract_create field=receipts[1].output entry=FINDING-create-output attribution=a status=PENDING-FIX want=0x600160005500 got=0x -->
+<!-- ALLOWLIST vectorId=fjord_contract_create field=receipts[1].output entry=FINDING-create-output attribution=a status=PENDING-FIX want=0x600160005500 got=0x -->
+<!-- ALLOWLIST vectorId=isthmus_contract_create field=receipts[1].output entry=FINDING-create-output attribution=a status=PENDING-FIX want=0x600160005500 got=0x -->
+<!-- ALLOWLIST vectorId=isthmus_contract_create field=receipts[2].output entry=FINDING-create-output attribution=a status=PENDING-FIX want=0x600160005500 got=0x -->
+<!-- ALLOWLIST vectorId=jovian_contract_create field=receipts[1].output entry=FINDING-create-output attribution=a status=PENDING-FIX want=0x600160005500 got=0x -->
+<!-- ALLOWLIST vectorId=jovian_contract_create field=receipts[2].output entry=FINDING-create-output attribution=a status=PENDING-FIX want=0x600160005500 got=0x -->
+
+
+---
+
+## 结构性差异：同父双子分叉（Task 6，chain_fork 载体）
+
+**FISCO -32603 vs op-geth VALID**（已确认，结构性差异）。同一父块下、同高度两个不同 blockHash 的子块：
+
+- **op-geth**：`InsertChain` 接受侧链兄弟块（side chain）→ 新块 VALID，父块保持权威链。
+- **FISCO**：`newPayload` 对同一父块（`SYS_NUMBER_2_HASH` 已占用该高度）再次投同高度不同 hash 的块
+  → `OpExecutionInternalError`（-32603），latestValidHash=null。
+
+**载体**：`invalid_isthmus_chain_3_fork.json` / `invalid_jovian_chain_3_fork.json`（`_op_canonical` =
+canonical 子块 payload，`_op_payload` = sibling）。E2E 两投 runner（OpNewPayloadRpcE2eTest.cpp
+runInvalidVector -32603 分支）先投 canonical（VALID 写 SYS_NUMBER_2_HASH 占用）再投 sibling →
+抛 OpExecutionInternalError。
+
+**处置**：FISCO 侧保留该行为（PBFT 单一权威链语义），记为结构性差异，不修。

--- a/opstack-executor/tests/t8n/vectors/OP_RECEIPT_FIELDMAP.md
+++ b/opstack-executor/tests/t8n/vectors/OP_RECEIPT_FIELDMAP.md
@@ -1,0 +1,321 @@
+# OP_RECEIPT_FIELDMAP — op-geth 回执 OP 字段映射（isthmus/jovian）最终版
+
+Phase 2 line C 最终字段映射文档。初版为 Task 0 探针产物（`--probe-receipt-fields <case.in.json>`，
+`opt8n-ref`，`bcos-evm/test/opstack/t8n/generator/main.go` 自含 op-geth 管线 dump 发射面）；
+Task 1 扩发射、Task 2 重生成、Task 3 全字段比对、Task 4 修复全绿后演进为本文件。
+op-geth 以 PIN `e8800cffe53d459cde8a07c8e8f1de9d86e79e07` 为准。
+
+**本文件是线 C 的权威字段映射规范**：每字段的存在性规则、值格式、FISCO meta 对应、比对结论。
+引用本文件时，一律以本表为准，不复述探针。
+
+---
+
+## 1. 结论速览（最终比对字段集，Task 0-4 全绿）
+
+| # | FISCO `_op_` 字段 | op-geth 源字段 | 发射条件 | 值格式 | 状态（线 C 终态） |
+|---|---|---|---|---|---|
+| 1 | `_op_deposit_nonce` | `Receipt.DepositNonce` | 仅 deposit 回执（Regolith+） | hex `0x…` | 已发射+已比对（全绿） |
+| 2 | `_op_deposit_receipt_version` | `Receipt.DepositReceiptVersion` | 仅 deposit 回执（Canyon+） | hex `0x…` | 已发射+已比对（全绿） |
+| 3 | `_op_l1_fee` | `Receipt.L1Fee` | 每笔非 deposit 回执 | hex `0x…` | 已发射+已比对（全绿） |
+| 4 | `_op_operator_fee` | **FISCO 派生**（无 op-geth 字段） | 非 deposit ∧ operator scalar/constant 非零 | hex `0x…` | 已发射+已比对（全绿） |
+| 5 | `_op_da_footprint` | **从 `Receipt.BlobGasUsed` 派生** | 非 deposit ∧ Jovian | hex `0x…` | 已发射+已比对（全绿） |
+| 6 | `_op_l1_gas_price` | `Receipt.L1GasPrice` | 每笔非 deposit 回执 | hex `0x…` | 已发射+已比对（全绿） |
+| 7 | `_op_l1_blob_base_fee` | `Receipt.L1BlobBaseFee` | 每笔非 deposit 回执 | hex `0x…` | 已发射+已比对（全绿） |
+| 8 | `_op_l1_gas_used` | `Receipt.L1GasUsed` | **每笔非 deposit 回执（裁决：恒发射）** | hex `0x…` | 已发射+已比对（全绿，FISCO Task 4 补算） |
+| 9 | `_op_l1_base_fee_scalar` | `Receipt.L1BaseFeeScalar` | 每笔非 deposit 回执 | hex `0x…` | 已发射+已比对（全绿） |
+| 10 | `_op_l1_blob_base_fee_scalar` | `Receipt.L1BlobBaseFeeScalar` | 每笔非 deposit 回执 | hex `0x…` | 已发射+已比对（全绿） |
+| 11 | `_op_operator_fee_scalar` | `Receipt.OperatorFeeScalar` | 非 deposit ∧ scalar/constant 非零 | hex `0x…` | 已发射+已比对（全绿） |
+| 12 | `_op_operator_fee_constant` | `Receipt.OperatorFeeConstant` | 非 deposit ∧ scalar/constant 非零 | hex `0x…` | 已发射+已比对（全绿） |
+| 13 | `_op_da_footprint_gas_scalar` | `Receipt.DAFootprintGasScalar` | 非 deposit ∧ Jovian | hex `0x…` | 已发射+已比对（全绿） |
+
+`FeeScalar`（op-geth `Receipt.FeeScalar`, `*big.Float`）在 isthmus/jovian 下恒 absent（post-Ecotone 已废弃），
+无 FISCO meta 对应，不列入 gate。
+
+> 注：`_op_operator_fee`（#4）与 `_op_da_footprint`（#5）虽为 FISCO 侧派生/可派生字段，
+> **两者都进值比对，不豁免**——见 §5.2/§5.3。
+
+---
+
+## 2. FeeScalar 映射（isthmus/jovian，spec C4）
+
+- FISCO `l1_base_fee_scalar` ↔ op-geth `L1BaseFeeScalar`（直接值映射，无打包）
+- FISCO `l1_blob_base_fee_scalar` ↔ op-geth `L1BlobBaseFeeScalar`（直接值映射）
+- op-geth 打包 `FeeScalar` 仅 pre-Ecotone 发射；isthmus/jovian 不出现 → 无需解包
+- Ecotone calldataGas 打包映射归线 A（另立）
+
+---
+
+## 3. 探针方法
+
+- 探针 4 case（`--write-cases` 生成 `.in.json` 后逐个跑）：
+  `isthmus_transfer_basic`（普通）、`jovian_da_mix`（Jovian DA）、
+  `isthmus_deposit_only`（纯 deposit）、`isthmus_fee_env_observer`（唯一 operator scalar 非零的 case）。
+- 管线：genesis 构造 → tx 签名 → `GenerateChainWithGenesis` → `receiptsAll[0]`，
+  与 `processBlockVector` 前半段逐行同源（探针为自含一次性工具，不重构 `processBlockVector`）。
+- 数值字段统一 hex 打印；`FeeScalar` 用 `*big.Float.String()` 十进制。
+
+## 4. 发射矩阵（探针实测）
+
+### 4.1 deposit 回执（op-geth `receipt_opstack.go:36-38`：最后一笔 tx 是 deposit 则整体早退）
+
+| 字段 | deposit_only | deposit 出现在其他 case |
+|---|---|---|
+| `DepositNonce` | `0x0` | `0x0` |
+| `DepositReceiptVersion` | `0x1` | `0x1` |
+| `L1GasPrice`/`L1BlobBaseFee`/`L1GasUsed`/`L1Fee`/`FeeScalar`/`L1BaseFeeScalar`/`L1BlobBaseFeeScalar`/`OperatorFeeScalar`/`OperatorFeeConstant`/`DAFootprintGasScalar`/`BlobGasUsed` | 全 absent | 全 absent |
+
+### 4.2 非 deposit 回执（isthmus，`fee_env_observer` 实测）
+
+| 字段 | 值 |
+|---|---|
+| `L1GasPrice` | `0x6fc23ac00`（30 gwei） |
+| `L1BlobBaseFee` | `0xf4240`（1,000,000） |
+| `L1GasUsed` | `0x640`（1,600） |
+| `L1Fee` | `0xf4eb688f4` |
+| `FeeScalar` | absent（post-Ecotone 恒 nil） |
+| `L1BaseFeeScalar` | `0x558`（1,368） |
+| `L1BlobBaseFeeScalar` | `0xc5fc5`（810,949） |
+| `OperatorFeeScalar` | `0x1388`（5,000） |
+| `OperatorFeeConstant` | `0x1e61`（7,777） |
+| `DAFootprintGasScalar` | absent（isthmus） |
+| `BlobGasUsed` | absent（0，isthmus） |
+
+### 4.3 非 deposit 回执（jovian，`da_mix` 实测，DA scalar=400）
+
+| 字段 | tx1 | tx2 | tx3 |
+|---|---|---|---|
+| `L1GasUsed` | `0x640` | `0x1308` | `0x438d` |
+| `L1Fee` | `0xf4eb688f4` | `0x2e9ee82768` | `0xa572c76232` |
+| `DAFootprintGasScalar` | `0x190` | `0x190` | `0x190` |
+| `BlobGasUsed` | `0x9c40`（40,000） | `0x1db00`（121,600） | `0x69780`（432,000） |
+
+`BlobGasUsed` 与向量 `_op_da_footprint` 逐笔一致（`0x9c40`/`0x1db00`/`0x69780`）——Jovian 载体确认。
+`OperatorFeeScalar`/`OperatorFeeConstant` 在此 case absent（scalar=0）。
+
+---
+
+## 5. 关键裁决
+
+### 5.1 `L1GasUsed` 裁决：恒发射（每笔非 deposit 回执）
+
+op-geth `deriveOPStackFields`（`receipt_opstack.go:40`）对每笔非 deposit 回执赋值
+`rs[i].L1Fee, rs[i].L1GasUsed = gasParams.costFunc(rcd)`——**非 deposit 回执的 `L1GasUsed` 恒非 nil**。
+4 case 探针无一例外。→ Task 1 **保留**该字段，Task 3 **保留比对**；
+FISCO 侧 `_op_l1_gas_used` 存在性断言**永不删除**（§7 Global Constraints）。
+
+### 5.2 `_op_operator_fee`：FISCO 派生字段（op-geth 无 `OperatorFee` 字段）
+
+op-geth 回执不发射聚合 operator fee；`buildExpectedReceipts`（`main.go:1570-1623`）用
+`operatorFee()` 公式（scalar/constant × gasUsed，Isthmus `/1e6` vs Jovian `×100`）手算，
+并与 op-geth `NewOperatorCostFunc` 交叉校验。**值比对照常做**（不豁免）。
+
+### 5.3 `_op_da_footprint`：op-geth 可派生字段（载体 `BlobGasUsed`）
+
+Jovian 下 `deriveOPStackFields` 令 `BlobGasUsed = daFootprintGasScalar × EstimatedDASize`。
+`_op_da_footprint` 即 `r.BlobGasUsed` 的 hex。**值比对照常做**（不豁免）。
+
+### 5.4 Operator scalar/constant：仅非零发射
+
+`receipt_opstack.go:44`：`operatorFeeScalar != 0 || operatorFeeConstant != 0` 才写回执。
+`transfer_basic`/`da_mix`（scalar=0）absent；`fee_env_observer`（5000/7777）present。
+生成器 `buildExpectedReceipts` 以 `emitOpFee := opScalar != 0 || opConstant != 0` 同源镜像。
+
+---
+
+## 6. Task 4 结果：`_op_l1_gas_used` FISCO 补算 → gate 全绿
+
+§5.1 裁决 op-geth 对每笔非 deposit 回执恒发射 `L1GasUsed`；Task 3 重放器升级为全字段比对
+（commit f8c1751b3）后暴露 FISCO 侧 `_op_l1_gas_used` 恒 nullopt —— **168 行 DIVERGE**
+（want=`0x…` got=`<absent>`，存在性不对称，category 2），零回归（7 新增 + 5 既有字段）。
+
+**修复（Task 4，commit 729d68bdc，`OpTransition.cpp:223`）**——FISCO 侧补算 Fjord L1 calldata gas：
+
+```cpp
+m.l1_gas_used = static_cast<uint64_t>(estimatedDaSizeScaled(props.flz_len) * 16 / 1'000'000);
+```
+
+- 公式对照 op-geth `core/types/rollup_cost.go:623-624`（`NewL1CostFuncFjord`）：
+  `L1GasUsed = estimatedDASizeScaled(fastLzSize) * TxDataNonZeroGasEIP2028(16) / 1e6`。
+- 用 `estimatedDaSizeScaled`（`RollupCost.h:17`）而非 `estimatedDaSizeFromFlz`——后者 flz==0 → 0 分叉
+  且先除后乘低报线性支。
+- 发射规则对照 op-geth `core/types/receipt_opstack.go` `deriveOPStackFields`（:40, :59-63）：
+  非 deposit 恒设；FISCO `deriveOpReceiptMeta` 仅经 `opTransition`（非 deposit）可达，
+  `runDeposit` 直接构造 deposit 字段不受影响。
+- 数值回放：Task 3 want 值 5 个 distinct（`0x640`/`0x7e6`/`0x1141`/`0x1308`/`0x438d`）全部精确复现。
+
+**Gate 结果**：`bcos-evm-opstack-tests --run_test=OpT8nReplay` → **exit 0，0 DIVERGE**（原 168）；
+全量 suite 无回归；`DIVERGENCES.md` diff 空、无 ALLOWLIST 新增——`l1_gas_used` 是 **FIXED 非豁免**。
+
+> **Ecotone latent divergence（归线 A，gate 不可见）**：`deriveOpReceiptMeta` 不取 `cfg`，
+> Ecotone 下 `props.flz_len == 0` → 补算 `estimatedDaSizeScaled(0)*16/1e6 = 1600`，
+> 而 op-geth Ecotone `L1GasUsed` 为 `bedrockCalldataGasUsed`（zeros*4 + nonzeros*16）。
+> 34 向量全为 isthmus/jovian（Fjord+），gate 覆盖不到；未来若开 Ecotone 回执 gate 需 cfg-aware 分支。
+
+---
+
+## 7. 全局约束（Global Constraints）
+
+1. `_op_l1_gas_used` 的 FISCO 侧存在性断言永不删除（§5.1）。
+2. 探针 4 case 覆盖普通/Jovian/deposit/operator-fee 四分支；任何一支缺失即 fieldmap 失效。
+3. op-geth 侧字段以 PIN `e8800cff` 为准；字段名冲突时 `grep -nE "BlobGasUsed|OperatorFeeScalar|L1GasUsed" <op-geth>/core/types/receipt.go` 核对。
+4. `types.Receipt` 无 `DAFootprint` 字段——DA footprint 的载体是 `BlobGasUsed`，禁直接引用 `DAFootprint`。
+
+---
+
+## 8. 探针原始输出（4 case 全量）
+
+### 8.1 isthmus_transfer_basic（deposit + 1 transfer）
+
+```
+tx[0] type=0x7e
+  DepositNonce	0x0
+  DepositReceiptVersion	0x1
+  L1GasPrice	absent
+  L1BlobBaseFee	absent
+  L1GasUsed	absent
+  L1Fee	absent
+  FeeScalar	absent
+  L1BaseFeeScalar	absent
+  L1BlobBaseFeeScalar	absent
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	absent
+  BlobGasUsed	absent
+tx[1] type=0x02
+  DepositNonce	absent
+  DepositReceiptVersion	absent
+  L1GasPrice	0x6fc23ac00
+  L1BlobBaseFee	0xf4240
+  L1GasUsed	0x640
+  L1Fee	0xf4eb688f4
+  FeeScalar	absent
+  L1BaseFeeScalar	0x558
+  L1BlobBaseFeeScalar	0xc5fc5
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	absent
+  BlobGasUsed	absent
+```
+
+### 8.2 jovian_da_mix（deposit + 3 transfers）
+
+```
+tx[0] type=0x7e
+  DepositNonce	0x0
+  DepositReceiptVersion	0x1
+  L1GasPrice	absent
+  L1BlobBaseFee	absent
+  L1GasUsed	absent
+  L1Fee	absent
+  FeeScalar	absent
+  L1BaseFeeScalar	absent
+  L1BlobBaseFeeScalar	absent
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	absent
+  BlobGasUsed	absent
+tx[1] type=0x02
+  DepositNonce	absent
+  DepositReceiptVersion	absent
+  L1GasPrice	0x6fc23ac00
+  L1BlobBaseFee	0xf4240
+  L1GasUsed	0x640
+  L1Fee	0xf4eb688f4
+  FeeScalar	absent
+  L1BaseFeeScalar	0x558
+  L1BlobBaseFeeScalar	0xc5fc5
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	0x190
+  BlobGasUsed	0x9c40
+tx[2] type=0x02
+  DepositNonce	absent
+  DepositReceiptVersion	absent
+  L1GasPrice	0x6fc23ac00
+  L1BlobBaseFee	0xf4240
+  L1GasUsed	0x1308
+  L1Fee	0x2e9ee82768
+  FeeScalar	absent
+  L1BaseFeeScalar	0x558
+  L1BlobBaseFeeScalar	0xc5fc5
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	0x190
+  BlobGasUsed	0x1db00
+tx[3] type=0x02
+  DepositNonce	absent
+  DepositReceiptVersion	absent
+  L1GasPrice	0x6fc23ac00
+  L1BlobBaseFee	0xf4240
+  L1GasUsed	0x438d
+  L1Fee	0xa572c76232
+  FeeScalar	absent
+  L1BaseFeeScalar	0x558
+  L1BlobBaseFeeScalar	0xc5fc5
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	0x190
+  BlobGasUsed	0x69780
+```
+
+### 8.3 isthmus_deposit_only（纯 deposit）
+
+```
+tx[0] type=0x7e
+  DepositNonce	0x0
+  DepositReceiptVersion	0x1
+  L1GasPrice	absent
+  L1BlobBaseFee	absent
+  L1GasUsed	absent
+  L1Fee	absent
+  FeeScalar	absent
+  L1BaseFeeScalar	absent
+  L1BlobBaseFeeScalar	absent
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	absent
+  BlobGasUsed	absent
+```
+
+### 8.4 isthmus_fee_env_observer（deposit + 1 transfer，operator scalar 非零）
+
+```
+tx[0] type=0x7e
+  DepositNonce	0x0
+  DepositReceiptVersion	0x1
+  L1GasPrice	absent
+  L1BlobBaseFee	absent
+  L1GasUsed	absent
+  L1Fee	absent
+  FeeScalar	absent
+  L1BaseFeeScalar	absent
+  L1BlobBaseFeeScalar	absent
+  OperatorFeeScalar	absent
+  OperatorFeeConstant	absent
+  DAFootprintGasScalar	absent
+  BlobGasUsed	absent
+tx[1] type=0x02
+  DepositNonce	absent
+  DepositReceiptVersion	absent
+  L1GasPrice	0x6fc23ac00
+  L1BlobBaseFee	0xf4240
+  L1GasUsed	0x640
+  L1Fee	0xf4eb688f4
+  FeeScalar	absent
+  L1BaseFeeScalar	0x558
+  L1BlobBaseFeeScalar	0xc5fc5
+  OperatorFeeScalar	0x1388
+  OperatorFeeConstant	0x1e61
+  DAFootprintGasScalar	absent
+  BlobGasUsed	absent
+```
+
+---
+
+## §9 等价性 gate（OpDualPathEquivalence）
+
+- 命令：opstack-executor-block-tests --run_test=OpDualPathEquivalence
+- 结果：0 DIVERGE, 0 soft 分叉（ALLOWLIST 已清空）
+- 作用：证明 OpBlockInjector（逐笔注入循环）== executeOpBlock（processOpBlock）全语料等价；
+  GASLIMIT 定向向量为修复锚；deposit_basefee 为绿守卫。
+- golden 三方硬断言（作用域 isthmus/jovian 非 contract_create；pre-isthmus + contract_create 软 REPORT）

--- a/opstack-executor/tests/t8n/vectors/manifest.txt
+++ b/opstack-executor/tests/t8n/vectors/manifest.txt
@@ -1,0 +1,177 @@
+# M-B3+M6 block-level vector manifest -- written FIRST from the plan's case
+# table (docs/superpowers/plans/2026-07-11-bcos-evm-ref-op-differential-gate-mb3-m6.md,
+# Step 2, rows 1-14 x fork column), BEFORE generation. Any file listed here
+# that cannot be generated is a STOP (matrix-cell drops need user signoff).
+# Enumeration note: rows 1-9,11,14 are I+J (11 cases x 2 = 22), row 10 is
+# Isthmus-only (+1), rows 12-13 are Jovian-only (+2) = 25 vectors. The plan
+# prose says "26"; the table's fork column enumerates 25 -- the table is
+# binding (see generator/README.md "Corpus enumeration").
+#
+# Current total (2026-08-10): 41 entries (34 corpus + 7 Phase-2 线 A
+# ecotone/fjord formula + upgrade boundaries). The 25-vector count above is
+# the original (M-B3+M6) batch and is retained as a historical record, not
+# rewritten; see the "Corpus augmentation" (+6 -> 31), "Defer-sweep"
+# (+2 -> 33), the appended 34th-intake note, and the Task-4 (+7 -> 41) note
+# below for the deltas that bring the manifest to its present 41-entry state.
+isthmus_deposit_only.json
+jovian_deposit_only.json
+isthmus_transfer_basic.json
+jovian_transfer_basic.json
+isthmus_transfer_multi.json
+jovian_transfer_multi.json
+isthmus_deposit_mint.json
+jovian_deposit_mint.json
+isthmus_deposit_failed.json
+jovian_deposit_failed.json
+isthmus_contract_logs.json
+jovian_contract_logs.json
+isthmus_message_passer_write.json
+jovian_message_passer_write.json
+isthmus_tx_reverted.json
+jovian_tx_reverted.json
+isthmus_setcode_7702.json
+jovian_setcode_7702.json
+isthmus_big_block_130tx.json
+isthmus_system_contracts_real.json
+jovian_system_contracts_real.json
+jovian_first_block.json
+jovian_da_mix.json
+isthmus_fee_env_observer.json
+jovian_fee_env_observer.json
+# Corpus augmentation (spec rev.3): 3 cases x both forks = +6 -> 31 vectors.
+# Written FIRST (before generation), same discipline as above.
+isthmus_contract_create.json
+jovian_contract_create.json
+isthmus_access_list.json
+jovian_access_list.json
+isthmus_setcode_7702_skips.json
+jovian_setcode_7702_skips.json
+# Defer-sweep batch (2026-07-12): 1 case x both forks = +2 -> 33 vectors.
+# Written FIRST (before generation), same discipline as above. Feasibility
+# probed against op-geth @ e8800cffe: genesis flushAlloc commits with
+# deleteEmptyObjects=false (core/genesis.go), so an exists-but-empty alloc
+# account IS materialized in the genesis trie; an in-block zero-value CALL
+# then EIP-161 touch-deletes it at block commit.
+isthmus_empty_account_cleanup.json
+jovian_empty_account_cleanup.json
+# 34th vector intake (2026-08-10, user decision): the W5 commit
+# 205ad9573 added this case to cases.go:538 but it was emitted by
+# --write-cases and never manifested. Appended FIRST per manifest
+# discipline (entries written before generation).
+isthmus_system_call_order_observable.json
+# Phase-2 线 A genesis fork 矩阵（Task 4, 2026-08-10）：+7 -> 41 vectors.
+# 公式边界（formula-boundary）：ecotone/fjord 纯 fork 的 transfer/contract_create
+# 基础对（L1 费公式在 ecotone→fjord 切换：Ecotone 动态标量 vs Fjord 分段常量，
+# 均无 operator-fee/DA 段；属性 calldata 均 164B Ecotone 布局）。
+ecotone_transfer_basic.json
+ecotone_contract_create.json
+fjord_transfer_basic.json
+fjord_contract_create.json
+# 升级边界（upgrade-boundary）：FILENAME 前缀 = genesis 基础 fork，而每个向量的
+# _info.hardfork = 块时 TARGET fork（有意为之：replayer 按 _info.hardfork 选配置；
+# 基础 fork 可从 _info.activations 恢复）。属性布局/extraData 由块时 fork 决定。
+ecotone_upgrade_fjord_activation.json
+fjord_upgrade_isthmus_activation.json
+isthmus_upgrade_jovian_activation.json
+# Phase-2 线 B 预编译矩阵（Task 5, 2026-08-11）：+36 -> 77 vectors.
+# 实测枚举：generator 输出 77 case（41 旧 + 36 新），与 plan 的 34 新增/75 总数
+# 不符（plan 算术 13+14+4+5=36 为实，41+34=75 是笔误）——以生成器实测为准。
+# 基础 7（ecrecover/sha256/ripemd160/identity/expmod/blake2f/point_evaluation）、
+# bn256 5（add/mul/pair_norm + granite/jovian overcap + fjord large_success）、
+# BLS12-381 14（g1add/g1msm/g2add/g2msm/pairing/map_g1/map_g2 + 3 isthmus overcap
+# + 3 jovian overcap + fjord noop）、RIP-7212 4（valid/invalid/wronglen + ecotone
+# noop）、wrapper CALL 语义 5（63of64/returndata/value_revert/value_overcap/eip7702）。
+# wrapper case 名已修复单 fork 前缀（原 Task 4 实现为双前缀 ist…_ist…，见
+# cases_precompile_wrapper.go；修复后与 <fork>_<name>.json 不变量一致）。
+ecotone_precompile_p256_noop.json
+fjord_precompile_bls_noop.json
+fjord_precompile_bn256pair_large_success.json
+fjord_precompile_p256_invalid.json
+fjord_precompile_p256_valid.json
+fjord_precompile_p256_wronglen.json
+granite_precompile_bn256pair_overcap.json
+isthmus_precompile_blake2f.json
+isthmus_precompile_bls_g1add.json
+isthmus_precompile_bls_g1msm.json
+isthmus_precompile_bls_g1msm_overcap.json
+isthmus_precompile_bls_g2add.json
+isthmus_precompile_bls_g2msm.json
+isthmus_precompile_bls_g2msm_overcap.json
+isthmus_precompile_bls_map_g1.json
+isthmus_precompile_bls_map_g2.json
+isthmus_precompile_bls_pairing.json
+isthmus_precompile_bls_pairing_overcap.json
+isthmus_precompile_bn256add.json
+isthmus_precompile_bn256mul.json
+isthmus_precompile_bn256pair_norm.json
+isthmus_precompile_ecrecover.json
+isthmus_precompile_expmod.json
+isthmus_precompile_identity.json
+isthmus_precompile_point_evaluation.json
+isthmus_precompile_ripemd160.json
+isthmus_precompile_sha256.json
+isthmus_precompile_wrap_63of64.json
+isthmus_precompile_wrap_eip7702.json
+isthmus_precompile_wrap_returndata.json
+jovian_precompile_bls_g1msm_overcap.json
+jovian_precompile_bls_g2msm_overcap.json
+jovian_precompile_bls_pairing_overcap.json
+jovian_precompile_bn256pair_overcap.json
+jovian_precompile_wrap_value_overcap.json
+jovian_precompile_wrap_value_revert.json
+
+# Phase-3 enhanced corpus (Task 6): corrupt 12 + static 10 + invalid-tx 18 + chain 6 + legacy 2 = 48 vectors (idempotent; §4c item 3/12 excluded — loader 不可表达)
+invalid_isthmus_blob.json
+invalid_isthmus_chain_3_break.json
+invalid_isthmus_chain_3_fork.json
+invalid_isthmus_empty_auth_list.json
+invalid_isthmus_fee_cap_low.json
+invalid_isthmus_insufficient_funds.json
+invalid_isthmus_intrinsic_gas.json
+invalid_isthmus_nonce_high.json
+invalid_isthmus_nonce_low.json
+invalid_isthmus_sender_no_eoa.json
+invalid_isthmus_setcode_create.json
+invalid_isthmus_transfer_basic_blockHash.json
+invalid_isthmus_transfer_basic_extraData.json
+invalid_isthmus_transfer_basic_gasUsed.json
+invalid_isthmus_transfer_basic_parentHash.json
+invalid_isthmus_transfer_basic_receiptsRoot.json
+invalid_isthmus_transfer_basic_stateRoot.json
+invalid_isthmus_transfer_basic_static_1.json
+invalid_isthmus_transfer_basic_static_10.json
+invalid_isthmus_transfer_basic_static_2.json
+invalid_isthmus_transfer_basic_static_4.json
+invalid_isthmus_transfer_basic_static_5.json
+invalid_isthmus_transfer_basic_static_6.json
+invalid_isthmus_transfer_basic_static_7.json
+invalid_isthmus_transfer_basic_static_8.json
+invalid_isthmus_transfer_basic_static_9.json
+invalid_jovian_blob.json
+invalid_jovian_chain_3_break.json
+invalid_jovian_chain_3_fork.json
+invalid_jovian_empty_auth_list.json
+invalid_jovian_fee_cap_low.json
+invalid_jovian_insufficient_funds.json
+invalid_jovian_intrinsic_gas.json
+invalid_jovian_nonce_high.json
+invalid_jovian_nonce_low.json
+invalid_jovian_sender_no_eoa.json
+invalid_jovian_setcode_create.json
+invalid_jovian_transfer_basic_blockHash.json
+invalid_jovian_transfer_basic_extraData.json
+invalid_jovian_transfer_basic_gasUsed.json
+invalid_jovian_transfer_basic_parentHash.json
+invalid_jovian_transfer_basic_receiptsRoot.json
+invalid_jovian_transfer_basic_stateRoot.json
+invalid_jovian_transfer_basic_static_11.json
+isthmus_chain_3.json
+isthmus_legacy_transfer.json
+jovian_chain_3.json
+jovian_legacy_transfer.json
+
+# Dual-path observer vectors (gaslimit/basefee, bothForks)
+isthmus_deposit_basefee_observer.json
+isthmus_gaslimit_observer.json
+jovian_deposit_basefee_observer.json
+jovian_gaslimit_observer.json


### PR DESCRIPTION
## Summary

Part **4 of 7** — web3 transaction handlers and model.

> **Depends on**: Part 3 (opstack-s03) — opstack-executor module.

## What's in this part
- **Web3TxHandler.cpp** — legacy/EIP2930/EIP1559 codec
- **Web3Transaction.h/cpp** — deposit/EIP4844/EIP7702 transaction types
- **OpBlockExecute.cpp** — block execution implementation
- **ReceiptResponse.cpp / TransactionResponse.cpp** — response updates
- **EthEndpoint.cpp / EngineHelper.cpp** — endpoint and helper updates
- **Types.h** — restored `ExecutionPayload::rawTransactions` field (first consumer: EngineHelper.cpp)

## Verification
- Commit Check: valid insertions = **977** (≤ 1000 limit)

Split from #5429 | Part 4/7