### PR TITLE
fix(front): align MAX_PAYLOAD_LENGTH with the gateway 32MB message cap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,9 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          CC=gcc-14 CXX=g++-14 cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DLINKER=mold -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
+          # No -G Ninja: the GroupSig/Paillier ExternalProjects declare no BUILD_BYPRODUCTS,
+          # so Ninja rejects the deps/lib/*.a link inputs with "no known rule to make it".
+          CC=gcc-14 CXX=g++-14 cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DLINKER=mold -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
       - name: Configure for macOS
         if: startsWith(matrix.os, 'macos-')
         run: |
@@ -116,11 +118,11 @@ jobs:
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           mkdir -p build
           cd build
-          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
+          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
       - name: Build
         run: |
           cd build
-          cmake --build . --target fisco-bcos
+          cmake --build . --parallel 4
       - name: Package binary
         shell: bash
         run: |

--- a/bcos-front/bcos-front/FrontMessage.h
+++ b/bcos-front/bcos-front/FrontMessage.h
@@ -32,9 +32,16 @@ enum MessageDecodeStatus
     MESSAGE_INCOMPLETE = 1
 };
 
-// FIB-69: cap legitimate gateway payload size; reject larger frames to prevent resource-
-// exhaustion via 32 MB frames propagating into consensus/sync/txpool.
-constexpr std::size_t MAX_PAYLOAD_LENGTH = 8 * 1024 * 1024;  // 8 MB; << MAX_MESSAGE_LENGTH=32MB
+// FIB-69: cap the payload size accepted from the gateway as a second line of defense.
+// MUST stay equal to gateway MAX_MESSAGE_LENGTH (bcos-gateway/bcos-gateway/Common.h).
+// Honest senders never trip this check: Session::asyncSendMessage rejects messages whose
+// UNCOMPRESSED length exceeds the same 32 MB bound before encoding, so with equal caps a
+// message a peer could legitimately send is always accepted here. The receiver-side
+// P2PMessage::decode() bound only covers the compressed wire bytes (compression is on by
+// default), so this constant is the receiver's only limit on the decompressed payload —
+// which is why the check stays. A smaller cap here silently drops legitimate large
+// messages (e.g. consensus proposals of large blocks) that pass the gateway.
+constexpr std::size_t MAX_PAYLOAD_LENGTH = 32UL * 1024 * 1024;
 
 /// moduleID          :2 bytes
 /// UUID length       :1 bytes

--- a/bcos-front/test/unittests/FIB69_PayloadCapAlignmentTest.cpp
+++ b/bcos-front/test/unittests/FIB69_PayloadCapAlignmentTest.cpp
@@ -1,0 +1,76 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief FIB-69 follow-up: front::MAX_PAYLOAD_LENGTH must stay aligned with the gateway
+ *        message cap. With the caps misaligned (front 8 MB < gateway 32 MB), messages in
+ *        (8 MB, 32 MB] passed P2PMessage::decode() but were silently dropped by
+ *        FrontMessage::decode(), so consensus/sync messages of large blocks never reached
+ *        their module.
+ * @file FIB69_PayloadCapAlignmentTest.cpp
+ */
+
+#include <bcos-front/FrontMessage.h>
+#include <boost/asio/detail/socket_ops.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace bcos::test
+{
+namespace
+{
+
+/// Build a minimal valid FrontMessage wire buffer:
+/// moduleID(2) + uuidLength(1)=0 + ext(2), payload appended by the caller.
+inline bcos::bytes encodeEmptyHeader(uint16_t moduleID)
+{
+    bcos::bytes buf;
+    auto netModuleID = boost::asio::detail::socket_ops::host_to_network_short(moduleID);
+    uint16_t netExt = 0;
+    buf.insert(buf.end(), (bcos::byte*)&netModuleID, (bcos::byte*)&netModuleID + 2);
+    buf.push_back(0);  // uuidLength = 0
+    buf.insert(buf.end(), (bcos::byte*)&netExt, (bcos::byte*)&netExt + 2);
+    return buf;
+}
+
+}  // namespace
+
+// Anchor the alignment: bcos-front must not include bcos-gateway headers, so the gateway's
+// MAX_MESSAGE_LENGTH (bcos-gateway/bcos-gateway/Common.h) is pinned here by value. The
+// mirror assertion pinning the gateway constant lives in
+// bcos-gateway/test/unittests/FIB69_MessageLengthAlignmentTest.cpp; together they make a
+// unilateral change of either side go red.
+static_assert(bcos::front::MAX_PAYLOAD_LENGTH == 32UL * 1024 * 1024,
+    "front::MAX_PAYLOAD_LENGTH must equal gateway MAX_MESSAGE_LENGTH (32 MB); see "
+    "bcos-gateway/bcos-gateway/Common.h");
+
+BOOST_AUTO_TEST_SUITE(FIB69PayloadCapAlignmentTest)
+
+/// Regression for the dead zone: a payload of 8 MB + 1 (beyond the former front cap, within
+/// the gateway cap) must decode successfully and be preserved intact.
+BOOST_AUTO_TEST_CASE(payload_in_former_dead_zone_accepted)
+{
+    constexpr std::size_t formerCap = 8UL * 1024 * 1024;
+    auto header = encodeEmptyHeader(1);
+    bcos::bytes buf = header;
+    buf.resize(header.size() + formerCap + 1, 'P');
+
+    auto msg = std::make_shared<bcos::front::FrontMessage>();
+    auto result = msg->decode(bcos::bytesConstRef(buf.data(), buf.size()));
+    BOOST_CHECK_EQUAL(result, bcos::front::MessageDecodeStatus::MESSAGE_COMPLETE);
+    BOOST_CHECK_EQUAL(msg->payload().size(), formerCap + 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test

--- a/bcos-gateway/bcos-gateway/Common.h
+++ b/bcos-gateway/bcos-gateway/Common.h
@@ -31,7 +31,13 @@ namespace bcos
 {
 namespace gateway
 {
-constexpr uint64_t MAX_MESSAGE_LENGTH = 32 * 1024 * 1024;  ///< The maximum length of data is 100M.
+/// The maximum length of a p2p message is 32 MB. When changing this value, keep
+/// front::MAX_PAYLOAD_LENGTH (bcos-front/bcos-front/FrontMessage.h) equal to it, otherwise
+/// messages in between the two caps pass the gateway but are dropped by the front service.
+/// Note: configuring p2p.allow_max_msg_size above this constant re-opens that gap for
+/// compressible messages (the sender checks the configured bound on the uncompressed size,
+/// while the wire-level decode bound only sees the compressed bytes).
+constexpr uint64_t MAX_MESSAGE_LENGTH = 32 * 1024 * 1024;
 enum GroupType : uint16_t
 {
     // group with at-least one consensus node

--- a/bcos-gateway/test/unittests/FIB69_MessageLengthAlignmentTest.cpp
+++ b/bcos-gateway/test/unittests/FIB69_MessageLengthAlignmentTest.cpp
@@ -1,0 +1,29 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief FIB-69 follow-up: gateway-side tripwire pinning MAX_MESSAGE_LENGTH to 32 MB. The
+ *        mirror assertion pinning front::MAX_PAYLOAD_LENGTH to the same value lives in
+ *        bcos-front/test/unittests/FIB69_PayloadCapAlignmentTest.cpp; front and gateway
+ *        must not include each other's headers, so each side pins its own constant by value.
+ *        Raising one cap without the other silently re-opens the dead zone where messages
+ *        pass the gateway but are dropped by the front service.
+ * @file FIB69_MessageLengthAlignmentTest.cpp
+ */
+
+#include "bcos-gateway/Common.h"
+
+static_assert(bcos::gateway::MAX_MESSAGE_LENGTH == 32UL * 1024 * 1024,
+    "gateway MAX_MESSAGE_LENGTH must stay equal to front::MAX_PAYLOAD_LENGTH (32 MB); see "
+    "bcos-front/bcos-front/FrontMessage.h");

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -34,7 +34,6 @@
     "fakeit",
     "tbb",
     "jsoncpp",
-    "gmp",
     "curl",
     "tomlplusplus",
     {
@@ -74,6 +73,7 @@
         },
         "zstd",
         "cryptopp",
+        "gmp",
         "redis-plus-plus",
         "tarscpp"
       ]


### PR DESCRIPTION
### Problem

FIB-69 introduced `front::MAX_PAYLOAD_LENGTH = 8MB` (`bcos-front/bcos-front/FrontMessage.h`) while the gateway accepts messages up to `MAX_MESSAGE_LENGTH = 32MB` (`bcos-gateway/bcos-gateway/Common.h`, enforced in `P2PMessage::decode()`). Messages whose serialized size falls in (8MB, 32MB] — consensus proposals and sync responses of large blocks — pass the gateway but are silently dropped by `FrontMessage::decode()` on the receiving node (decode returns `MESSAGE_ERROR`, one log line, the module never sees the message). A chain configured with a large `consensus.block_tx_count_limit` stalls once blocks grow past roughly 65k transactions (~130B/tx). This also blocks large-block performance testing.

### Fix

Raise the front cap to 32MB so the two layers agree:

- `FrontMessage.h`: `MAX_PAYLOAD_LENGTH` 8MB → 32MB, with a comment stating the actual invariants: honest senders never trip either check (`Session::asyncSendMessage` bounds the **uncompressed** size before encoding), and the front check remains the receiver's **only** limit on the decompressed payload — the wire-level `P2PMessage::decode()` bound covers compressed bytes only, and compression is on by default (`p2p.enable_compression`, threshold 1KB). The FIB-69 second line of defense is therefore preserved, not weakened.
- `Common.h`: fix the stale comment (the constant is 32MB, not "100M"), cross-anchor `front::MAX_PAYLOAD_LENGTH`, and note that configuring `p2p.allow_max_msg_size` above the constant re-opens the gap for compressible messages.
- Tripwires: front and gateway must not include each other's headers, so each side pins its own constant to 32MB by value with a `static_assert` (`FIB69_PayloadCapAlignmentTest.cpp` / `FIB69_MessageLengthAlignmentTest.cpp`). A unilateral change of either constant now fails compilation of that side's tests.
- Regression test: decoding a payload of 8MB + 1 (inside the former dead zone) must succeed and preserve the payload intact.

Not a hardfork: no block validation, execution, or sync-import path is touched — only the receive-side cap of in-process message routing is widened.

### Verification

- `test-bcos-front` full suite green; `test-bcos-gateway` full suite green (macOS, RelWithDebInfo).
- Red proof: flipping the constant back to 8MB fails compilation via the new `static_assert` (`8388608 == 33554432`); restoring 32MB goes green.
- Repo-wide grep found no other code assuming the 8MB bound (bcos-sync's own decode cap is 256MB; gateway `maxSendDataSize=1MB` is a write-side chunking granularity, unrelated).
- Both new test files additionally compiled standalone with `-fsyntax-only` against the target's exact flags (guards against unity-build include leaks); `clang-format --dry-run --Werror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Also in this PR: release.yml Make-generator fix (commit 97e34ad3e, consolidated from #5466)

The first live run of the #5444 release workflow failed on every platform: `ninja: error: 'deps/lib/libgroup_sig.a' ... missing and no known rule to make it`. The GroupSig ExternalProjects (`cmake/ProjectGroupSig.cmake`) declare no `BUILD_BYPRODUCTS`, which the Ninja generator requires to map the imported `deps/lib/*.a` link inputs onto the ExternalProject step; the Make generator relies on `add_dependencies` ordering only, which is how every CI and past release build has always run. Fix: drop `-G Ninja` from both configure steps, build the default target like `workflow.yml`, and pass `--parallel 4` (the build step previously ran make single-threaded). Verified by a live tag run on a fork (v3.17.0-test.2). Declaring `BUILD_BYPRODUCTS` to re-enable Ninja is left for a separate build-system PR.
