### PR TITLE
ci(release): use the Make generator so ExternalProject deps build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,9 @@ jobs:
         run: |
           mkdir -p build
           cd build
-          CC=gcc-14 CXX=g++-14 cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DLINKER=mold -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
+          # No -G Ninja: the GroupSig/Paillier ExternalProjects declare no BUILD_BYPRODUCTS,
+          # so Ninja rejects the deps/lib/*.a link inputs with "no known rule to make it".
+          CC=gcc-14 CXX=g++-14 cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DLINKER=mold -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
       - name: Configure for macOS
         if: startsWith(matrix.os, 'macos-')
         run: |
@@ -116,11 +118,11 @@ jobs:
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           mkdir -p build
           cd build
-          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
+          CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_STATIC=ON -DTESTS=OFF -DWITH_LIGHTNODE=OFF -DWITH_CPPSDK=OFF -DWITH_TIKV=OFF -DWITH_TARS_SERVICES=OFF -DTOOLS=OFF -DVCPKG_TARGET_TRIPLET=${TRIPLET} ..
       - name: Build
         run: |
           cd build
-          cmake --build . --target fisco-bcos
+          cmake --build . --parallel 4
       - name: Package binary
         shell: bash
         run: |


### PR DESCRIPTION
### Problem

The first live run of the reworked release workflow (#5444, exercised via a test tag on a fork) failed on every platform at the very start of the build step:

```
ninja: error: '.../deps/lib/libgroup_sig.a', needed by 'fisco-bcos-air/fisco-bcos', missing and no known rule to make it
```

Root cause: `cmake/ProjectGroupSig.cmake` builds GroupSig/Pbc/PbcSig via `ExternalProject_Add` and wires them up as `IMPORTED` libraries pointing into `deps/lib/`, relying on `add_dependencies` ordering — with **no `BUILD_BYPRODUCTS`**. The Ninja generator statically validates the build graph and refuses link inputs no rule can produce, so `-G Ninja` (introduced in #5444) can never work with these ExternalProjects as-is. The Make generator does not perform this check, which is how every CI build (`workflow.yml` passes no `-G Ninja` on linux/macOS) and every past release build has always run.

### Fix

- Drop `-G Ninja` from both configure steps (with a comment explaining why, so it does not get re-added).
- Build the default target like `workflow.yml` does, instead of `--target fisco-bcos` (single-target builds through the imported-target dependency chain are untested in this repo; with TESTS/LIGHTNODE/TARS all off, `all` is essentially the AIR binary anyway).
- Pass `--parallel 4` — the previous build step ran make single-threaded.

Declaring `BUILD_BYPRODUCTS` on the GroupSig/Paillier ExternalProjects would be the proper long-term fix and would re-enable Ninja, but that touches the build system for all consumers and belongs in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
