### PR TITLE
build: slim heavy include chains and extend unity build coverage to speed up compilation

### DIFF
--- a/bcos-boostssl/bcos-boostssl/httpserver/HttpQueue.h
+++ b/bcos-boostssl/bcos-boostssl/httpserver/HttpQueue.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 #include <bcos-boostssl/httpserver/Common.h>
+#include <deque>
 
 namespace bcos::boostssl::http
 {

--- a/bcos-boostssl/bcos-boostssl/websocket/Common.h
+++ b/bcos-boostssl/bcos-boostssl/websocket/Common.h
@@ -23,6 +23,7 @@
 #include <bcos-utilities/Error.h>
 #include <boost/asio/ssl.hpp>
 #include <boost/beast/websocket.hpp>
+#include <boost/function.hpp>
 
 #define BOOST_SSL_LOG(LEVEL) BCOS_LOG(LEVEL) << "[BOOSTSSL]"
 #define WEBSOCKET_TOOL(LEVEL) BCOS_LOG(LEVEL) << "[WS][TOOL]"

--- a/bcos-boostssl/test/CMakeLists.txt
+++ b/bcos-boostssl/test/CMakeLists.txt
@@ -25,6 +25,11 @@ add_subdirectory(exec)
 set(TEST_BINARY_NAME test-boostssl)
 
 add_executable(${TEST_BINARY_NAME} ${SOURCES})
+set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
+# WsConfigTest.cpp defines BOOST_TEST_MAIN (generates init_unit_test_suite for the static
+# boost UTF); in a unity batch the define lands after the first unit_test.hpp inclusion and
+# the symbol is lost, so keep it out of the batch.
+set_source_files_properties(unittests/websocket/WsConfigTest.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 target_include_directories(${TEST_BINARY_NAME} PRIVATE .)
 find_package(Boost REQUIRED unit_test_framework)
 target_link_libraries(${TEST_BINARY_NAME} bcos-boostssl protocol-tars ledger rpc bcos-utilities bcos-framework Boost::unit_test_framework)

--- a/bcos-codec/bcos-codec/abi/ContractABIType.cpp
+++ b/bcos-codec/bcos-codec/abi/ContractABIType.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "ContractABIType.h"
+#include <boost/algorithm/string.hpp>
 
 using namespace std;
 using namespace bcos;

--- a/bcos-codec/bcos-codec/scale/ScaleDecoderStream.h
+++ b/bcos-codec/bcos-codec/scale/ScaleDecoderStream.h
@@ -27,6 +27,7 @@
 #include <boost/variant.hpp>
 #include <array>
 #include <gsl/span>
+#include <list>
 
 namespace bcos
 {

--- a/bcos-codec/bcos-codec/scale/ScaleEncoderStream.h
+++ b/bcos-codec/bcos-codec/scale/ScaleEncoderStream.h
@@ -24,6 +24,7 @@
 #include <deque>
 #include <gsl/span>
 #include <type_traits>
+#include <list>
 
 namespace bcos
 {

--- a/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/HsmSM4Crypto.cpp
@@ -23,6 +23,7 @@
 
 #include "hsm-crypto/hsm/CryptoProvider.h"
 #include "hsm-crypto/hsm/SDFCryptoProvider.h"
+#include <bcos-utilities/BoostLog.h>
 
 using namespace hsm;
 using namespace bcos;

--- a/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
+++ b/bcos-crypto/bcos-crypto/interfaces/crypto/CommonType.h
@@ -19,7 +19,9 @@
  * @date 2021-04-01
  */
 #pragma once
-#include <bcos-utilities/BoostLog.h>
+// NOTE: CRYPTO_LOG expands to BCOS_LOG, which requires <bcos-utilities/BoostLog.h> at
+// the expansion site — including it here would force the log headers onto every TU
+// that only needs the type aliases below.
 #include <bcos-utilities/FixedBytes.h>
 #include <range/v3/view/any_view.hpp>
 

--- a/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/ed25519/Ed25519Crypto.cpp
@@ -24,6 +24,7 @@
 #include <bcos-crypto/signature/ed25519/Ed25519KeyPair.h>
 #include <wedpr-crypto/WedprCrypto.h>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::crypto;

--- a/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2KeyPairFactory.h
+++ b/bcos-crypto/bcos-crypto/signature/hsmSM2/HsmSM2KeyPairFactory.h
@@ -22,6 +22,7 @@
 #include <bcos-crypto/interfaces/crypto/KeyPairFactory.h>
 #include <bcos-crypto/signature/hsmSM2/HsmSM2KeyPair.h>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 namespace bcos
 {
 namespace crypto

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.cpp
@@ -28,6 +28,7 @@
 #include <wedpr-crypto/WedprCrypto.h>
 #include <array>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::crypto;

--- a/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
+++ b/bcos-crypto/bcos-crypto/signature/sm2/SM2Crypto.cpp
@@ -22,6 +22,7 @@
 #include <bcos-crypto/signature/codec/SignatureDataWithPub.h>
 #include <bcos-crypto/signature/sm2/SM2Crypto.h>
 #include <bcos-crypto/signature/sm2/SM2KeyPair.h>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::crypto;

--- a/bcos-crypto/test/unittests/HashTest.cpp
+++ b/bcos-crypto/test/unittests/HashTest.cpp
@@ -26,6 +26,7 @@
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace crypto;

--- a/bcos-evm/test/CMakeLists.txt
+++ b/bcos-evm/test/CMakeLists.txt
@@ -34,6 +34,10 @@ if(NOT BCOS_EVM_STANDALONE)
         opstack/Storage2StateBridgeTest.cpp
         testutils/MemoryState.cpp
     )
+    # Unity build over the 20 header-heavy test TUs; opstack/TestMain.cpp defines
+    # BOOST_TEST_MODULE and stays out of the batch (project convention).
+    set_target_properties(bcos-evm-opstack-tests PROPERTIES UNITY_BUILD "ON")
+    set_source_files_properties(opstack/TestMain.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
     target_include_directories(bcos-evm-opstack-tests PRIVATE
         ${CMAKE_SOURCE_DIR}/opstack-executor)
     target_link_libraries(bcos-evm-opstack-tests PRIVATE

--- a/bcos-evm/test/opstack/Op7702Test.cpp
+++ b/bcos-evm/test/opstack/Op7702Test.cpp
@@ -30,7 +30,7 @@ using intx::operator""_u256;
 
 namespace
 {
-constexpr auto kSender = 0x00000000000000000000000000000000000000aa_address;
+constexpr auto kSender7702 = 0x00000000000000000000000000000000000000aa_address;
 constexpr auto kDelegate = 0x00000000000000000000000000000000000000cc_address;
 
 // === 金值:eth-account 签出, 私钥 0x59c6995e...86dae88c7a8412f4603b6b78690d ===
@@ -67,8 +67,8 @@ RunWithAuthResult runWithAuth(
 
     state::Transaction tx;
     tx.type = state::Transaction::Type::set_code;  // EIP-7702 set-code tx
-    tx.sender = kSender;
-    tx.to = kSender;  // 自调用；重点在 auth 处理
+    tx.sender = kSender7702;
+    tx.to = kSender7702;  // 自调用；重点在 auth 处理
     tx.gas_limit = 200000;
     tx.max_gas_price = 1000;
     tx.max_priority_gas_price = 10;
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(RecoversAuthorityAndWritesDelegation)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(BadSignatureRecoverFailsNoDelegation)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(NonceMismatchSkips)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(ChainIdMismatchSkips)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(DelegatedCallAfterAuthorization)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(DelegatedCallAfterAuthorization)
 
     state::Transaction tx;
     tx.type = state::Transaction::Type::eip1559;
-    tx.sender = kSender;
+    tx.sender = kSender7702;
     tx.to = kAuthority;
     tx.gas_limit = 100000;
     tx.max_gas_price = 1000;
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(ChainIdZeroIsUniversal)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(HighSValueIsRejected)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -416,7 +416,7 @@ BOOST_AUTO_TEST_CASE(InvalidYParityIsRejected)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -452,7 +452,7 @@ BOOST_AUTO_TEST_CASE(NonceMaxIsRejected)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(AuthorityWithNonDelegatedCodeIsSkipped)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0,
+    ts[kSender7702] = {.nonce = 0,
         .balance = 340282366920938463463374607431768211456_u256,
         .storage = {},
         .code = {}};

--- a/bcos-evm/test/opstack/OpDepositTest.cpp
+++ b/bcos-evm/test/opstack/OpDepositTest.cpp
@@ -21,7 +21,7 @@ namespace
 {
 constexpr auto kFrom = 0x00000000000000000000000000000000000000cc_address;
 
-state::BlockInfo blk()
+state::BlockInfo blkDeposit()
 {
     state::BlockInfo b;
     b.number = 1;
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(SuccessMintsAndAdvancesNonce)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     BOOST_CHECK_EQUAL(r->status(), 0);
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(EvmRevertKeepsMintAndChargesActualGas)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     BOOST_CHECK_NE(r->status(), 0);
@@ -134,7 +134,7 @@ BOOST_AUTO_TEST_CASE(EntryFailureChargesFullGasLimitButKeepsMint)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     BOOST_CHECK_EQUAL(r->status(), 1);
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(ContractCreationDerivesAddressFromPreExecutionNonce)
         .data = initCode};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     // 地址须由「执行前」nonce（5）派生，而非 host.call 内部已 bump 过的 6。
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(SystemTxIsBlockError)
         .data = {}};
     evmone::state::StateDiff diff;  // never written: is_system_tx throws before the out-param is
                                     // touched
-    BOOST_CHECK_THROW(runDeposit(ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+    BOOST_CHECK_THROW(runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
                           kOpTestReceiptFactory, diff),
         std::runtime_error);
 }
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(RefundLowersDepositGasUsed)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21206);
 }
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(RefundIsCappedAtOneFifthOfGasUsed)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     constexpr int64_t kPreRefund = 41024;
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), kPreRefund - kPreRefund / 5);
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(DepositReceiptCarriesLogsBloom)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     BOOST_REQUIRE_EQUAL(r->logEntries().size(), 1u);
     // round-trip: recompute the bloom from the FISCO LogEntry back to evmone Logs and compare
     // with the bloom the receipt carries.
@@ -320,7 +320,7 @@ BOOST_AUTO_TEST_CASE(RevertedDepositHasEmptyLogsAndZeroBloom)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     BOOST_CHECK_NE(r->status(), 0);
     // 钉住"代码确实执行到 LOG 后再 REVERT"而非入口级失败：入口失败收满 gasLimit(100000)，
     // LOG 后 REVERT 的实际消耗远低于此（对照 EvmRevertKeepsMintAndChargesActualGas）。
@@ -358,7 +358,7 @@ BOOST_AUTO_TEST_CASE(DepositResolvesEip7702Delegation)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kEoa).storage.at(0x00_bytes32), 0x01_bytes32);
@@ -388,7 +388,7 @@ BOOST_AUTO_TEST_CASE(DelegationToPrecompileFallsBackToEmptyCode)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21000);
 }
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(DepositWarmsSenderPerEip2929)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21104);
 }
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(DepositWarmsCoinbasePerEip3651)
         .storage = {},
         .code = evmc::from_hex("41315000").value()};  // COINBASE BALANCE POP STOP
     test::TestBlockHashes hashes;
-    auto b = blk();
+    auto b = blkDeposit();
     b.coinbase = 0x00000000000000000000000000000000000000c1_address;
     DepositTx dep{.source_hash = 0x01_bytes32,
         .from = kFrom,
@@ -476,7 +476,7 @@ BOOST_AUTO_TEST_CASE(WarmColdDifferentialIs2500)
             .is_system_tx = false,
             .data = {}};
         evmone::state::StateDiff diff;
-        const auto r = runDeposit(ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
             kOpTestReceiptFactory, diff);
         BOOST_CHECK_EQUAL(r->status(), 0);
         return receiptGasUsed(*r);
@@ -502,7 +502,7 @@ BOOST_AUTO_TEST_CASE(BridgeDepositSpendsMintedValue)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kTo).balance, intx::uint256{60});
@@ -529,7 +529,7 @@ BOOST_AUTO_TEST_CASE(ValueFundedByPreexistingBalanceWithoutMint)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kTo).balance, intx::uint256{60});
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE(ValueFundedJointlyByBalanceAndMint)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kTo).balance, intx::uint256{60});
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(SenderWithCodeIsAllowed)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
 }
 
@@ -605,7 +605,7 @@ BOOST_AUTO_TEST_CASE(ValueOverPostMintBalanceFailsWithFullGasLimit)
         .data = {}};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 1);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 100000);
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE(GasLimitOverBlockBudgetIsBlockError)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    BOOST_CHECK_THROW(runDeposit(ts, blk(), hashes, dep, isthmusConfig(), vm, 1234,
+    BOOST_CHECK_THROW(runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234,
                           /*blockGasLeft=*/50000, kOpTestReceiptFactory, diff),
         std::runtime_error);
 }
@@ -651,7 +651,7 @@ BOOST_AUTO_TEST_CASE(GasLimitExactlyBlockBudgetIsAccepted)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(ts, blk(), hashes, dep, isthmusConfig(), vm, 1234,
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234,
         /*blockGasLeft=*/60000, kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21000);
@@ -676,7 +676,7 @@ BOOST_AUTO_TEST_CASE(FailedCreateDepositStillBumpsNonceAndDeploysNothing)
         .data = evmc::from_hex("00").value()};
     evmone::state::StateDiff diff;
     const auto r = runDeposit(
-        ts, blk(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 1);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21000);  // 处理级失败收 gasLimit（此处恰 21000）

--- a/bcos-evm/test/opstack/OpDepositTest.cpp
+++ b/bcos-evm/test/opstack/OpDepositTest.cpp
@@ -71,8 +71,8 @@ BOOST_AUTO_TEST_CASE(SuccessMintsAndAdvancesNonce)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     BOOST_CHECK_EQUAL(r->status(), 0);
@@ -106,8 +106,8 @@ BOOST_AUTO_TEST_CASE(EvmRevertKeepsMintAndChargesActualGas)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     BOOST_CHECK_NE(r->status(), 0);
@@ -133,8 +133,8 @@ BOOST_AUTO_TEST_CASE(EntryFailureChargesFullGasLimitButKeepsMint)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     BOOST_CHECK_EQUAL(r->status(), 1);
@@ -161,8 +161,8 @@ BOOST_AUTO_TEST_CASE(ContractCreationDerivesAddressFromPreExecutionNonce)
         .is_system_tx = false,
         .data = initCode};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
     // 地址须由「执行前」nonce（5）派生，而非 host.call 内部已 bump 过的 6。
@@ -224,8 +224,8 @@ BOOST_AUTO_TEST_CASE(RefundLowersDepositGasUsed)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21206);
 }
@@ -254,8 +254,8 @@ BOOST_AUTO_TEST_CASE(RefundIsCappedAtOneFifthOfGasUsed)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     constexpr int64_t kPreRefund = 41024;
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), kPreRefund - kPreRefund / 5);
@@ -282,8 +282,8 @@ BOOST_AUTO_TEST_CASE(DepositReceiptCarriesLogsBloom)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     BOOST_REQUIRE_EQUAL(r->logEntries().size(), 1u);
     // round-trip: recompute the bloom from the FISCO LogEntry back to evmone Logs and compare
     // with the bloom the receipt carries.
@@ -319,8 +319,8 @@ BOOST_AUTO_TEST_CASE(RevertedDepositHasEmptyLogsAndZeroBloom)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     BOOST_CHECK_NE(r->status(), 0);
     // 钉住"代码确实执行到 LOG 后再 REVERT"而非入口级失败：入口失败收满 gasLimit(100000)，
     // LOG 后 REVERT 的实际消耗远低于此（对照 EvmRevertKeepsMintAndChargesActualGas）。
@@ -357,8 +357,8 @@ BOOST_AUTO_TEST_CASE(DepositResolvesEip7702Delegation)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kEoa).storage.at(0x00_bytes32), 0x01_bytes32);
@@ -387,8 +387,8 @@ BOOST_AUTO_TEST_CASE(DelegationToPrecompileFallsBackToEmptyCode)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21000);
 }
@@ -414,8 +414,8 @@ BOOST_AUTO_TEST_CASE(DepositWarmsSenderPerEip2929)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21104);
 }
@@ -476,8 +476,8 @@ BOOST_AUTO_TEST_CASE(WarmColdDifferentialIs2500)
             .is_system_tx = false,
             .data = {}};
         evmone::state::StateDiff diff;
-        const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
-            kOpTestReceiptFactory, diff);
+        const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234,
+            30000000, kOpTestReceiptFactory, diff);
         BOOST_CHECK_EQUAL(r->status(), 0);
         return receiptGasUsed(*r);
     };
@@ -501,8 +501,8 @@ BOOST_AUTO_TEST_CASE(BridgeDepositSpendsMintedValue)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kTo).balance, intx::uint256{60});
@@ -528,8 +528,8 @@ BOOST_AUTO_TEST_CASE(ValueFundedByPreexistingBalanceWithoutMint)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kTo).balance, intx::uint256{60});
@@ -553,8 +553,8 @@ BOOST_AUTO_TEST_CASE(ValueFundedJointlyByBalanceAndMint)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
     BOOST_CHECK_EQUAL(ts.at(kTo).balance, intx::uint256{60});
@@ -581,8 +581,8 @@ BOOST_AUTO_TEST_CASE(SenderWithCodeIsAllowed)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     BOOST_CHECK_EQUAL(r->status(), 0);
 }
 
@@ -604,8 +604,8 @@ BOOST_AUTO_TEST_CASE(ValueOverPostMintBalanceFailsWithFullGasLimit)
         .is_system_tx = false,
         .data = {}};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 1);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 100000);
@@ -675,8 +675,8 @@ BOOST_AUTO_TEST_CASE(FailedCreateDepositStillBumpsNonceAndDeploysNothing)
         .is_system_tx = false,
         .data = evmc::from_hex("00").value()};
     evmone::state::StateDiff diff;
-    const auto r = runDeposit(
-        ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000, kOpTestReceiptFactory, diff);
+    const auto r = runDeposit(ts, blkDeposit(), hashes, dep, isthmusConfig(), vm, 1234, 30000000,
+        kOpTestReceiptFactory, diff);
     bcos::evm::applyStateDiffStrict(ts, diff);
     BOOST_CHECK_EQUAL(r->status(), 1);
     BOOST_CHECK_EQUAL(receiptGasUsed(*r), 21000);  // 处理级失败收 gasLimit（此处恰 21000）

--- a/bcos-evm/test/opstack/OpFloorGasTest.cpp
+++ b/bcos-evm/test/opstack/OpFloorGasTest.cpp
@@ -38,7 +38,7 @@ using intx::operator""_u256;
 namespace
 {
 /// Narrow the FISCO receipt's gasUsed (u256) to the int64 the assertions compare against.
-inline int64_t receiptGasUsed(const bcos::protocol::TransactionReceipt& r)
+inline int64_t floorReceiptGasUsed(const bcos::protocol::TransactionReceipt& r)
 {
     return static_cast<int64_t>(static_cast<uint64_t>(r.gasUsed()));
 }
@@ -92,8 +92,8 @@ BOOST_AUTO_TEST_CASE(UserTxGasUsedRaisedToFloor)
     // 7623 floor 生效：gas_used 恰等于公式推导的 floor，且严格大于 intrinsic
     constexpr int64_t kExpectedFloor3000 = 21000 + 3000 * 10;  // = 51000
     constexpr int64_t kIntrinsic3000 = 21000 + 3000 * 4;       // = 33000
-    BOOST_CHECK_EQUAL(receiptGasUsed(*txR), kExpectedFloor3000);
-    BOOST_CHECK_EQUAL(receiptGasUsed(*txR), props.props.min_gas_cost);
+    BOOST_CHECK_EQUAL(floorReceiptGasUsed(*txR), kExpectedFloor3000);
+    BOOST_CHECK_EQUAL(floorReceiptGasUsed(*txR), props.props.min_gas_cost);
     BOOST_CHECK_GT(props.props.min_gas_cost, kIntrinsic3000);  // floor 51000 > intrinsic 33000
 }
 
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(DepositGasUsedRaisedToFloor)
     // deposit 同样吃 7623 floor（op-geth Isthmus 无豁免）：gas_used == floor
     constexpr int64_t kExpectedFloor3000 = 21000 + 3000 * 10;  // = 51000
     constexpr int64_t kExpectedFloorEmpty = 21000;             // empty calldata
-    BOOST_CHECK_EQUAL(receiptGasUsed(*r), kExpectedFloor3000);
+    BOOST_CHECK_EQUAL(floorReceiptGasUsed(*r), kExpectedFloor3000);
 
     // 对照：空 calldata deposit 在独立 state 上运行，避免大 deposit 污染
     DepositTx small = dep;
@@ -140,8 +140,8 @@ BOOST_AUTO_TEST_CASE(DepositGasUsedRaisedToFloor)
     const auto rs = runDeposit(ts2, block, hashes, small, isthmusConfig(), vm, 1234,
         block.gas_limit, kOpTestReceiptFactory, diff2);
     BOOST_REQUIRE_EQUAL(rs->status(), 0);
-    BOOST_CHECK_EQUAL(receiptGasUsed(*rs), kExpectedFloorEmpty);
-    BOOST_CHECK_GT(receiptGasUsed(*r), receiptGasUsed(*rs));
+    BOOST_CHECK_EQUAL(floorReceiptGasUsed(*rs), kExpectedFloorEmpty);
+    BOOST_CHECK_GT(floorReceiptGasUsed(*r), floorReceiptGasUsed(*rs));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-evm/test/opstack/OpValidateTest.cpp
+++ b/bcos-evm/test/opstack/OpValidateTest.cpp
@@ -14,9 +14,9 @@ using intx::operator""_u256;
 
 namespace
 {
-constexpr auto kSender = 0x00000000000000000000000000000000000000aa_address;
+constexpr auto kSenderValidate = 0x00000000000000000000000000000000000000aa_address;
 
-state::BlockInfo blk()
+state::BlockInfo blkValidate()
 {
     state::BlockInfo b;
     b.number = 1;
@@ -29,7 +29,7 @@ state::Transaction baseTx()
 {
     state::Transaction tx;
     tx.type = state::Transaction::Type::eip1559;
-    tx.sender = kSender;
+    tx.sender = kSenderValidate;
     tx.gas_limit = 100000;
     tx.max_gas_price = 1000;
     tx.max_priority_gas_price = 10;
@@ -43,13 +43,13 @@ BOOST_AUTO_TEST_SUITE(OpValidateSuite)
 BOOST_AUTO_TEST_CASE(RejectsBlobTx)
 {
     test::TestState ts;
-    ts[kSender] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     auto tx = baseTx();
     tx.type = state::Transaction::Type::blob;
     tx.to = 0x0000000000000000000000000000000000001234_address;
     tx.blob_hashes = {0x0100000000000000000000000000000000000000000000000000000000000001_bytes32};
     tx.max_blob_gas_price = 1;
-    const auto r = opValidate(ts, blk(), tx, {}, isthmusConfig(), OpFeeParams{}, 30000000);
+    const auto r = opValidate(ts, blkValidate(), tx, {}, isthmusConfig(), OpFeeParams{}, 30000000);
     BOOST_REQUIRE(std::holds_alternative<std::error_code>(r));
     BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::not_supported);
 }
@@ -67,14 +67,14 @@ BOOST_AUTO_TEST_CASE(RejectsBlobTx)
 BOOST_AUTO_TEST_CASE(RejectsDepositTxOnTheNonDepositPath)
 {
     test::TestState ts;
-    ts[kSender] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     auto tx = baseTx();
     tx.type = kDepositTxType;
     tx.to = 0x0000000000000000000000000000000000001234_address;
 
     const std::vector<uint8_t> env{0x7e, 0x11};
     const auto r = opValidate(
-        ts, blk(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
+        ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
     BOOST_REQUIRE(std::holds_alternative<std::error_code>(r));
     BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::not_supported);
 }
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(RejectsDepositTxOnTheNonDepositPath)
 BOOST_AUTO_TEST_CASE(RejectsEveryOutOfEnumTxType)
 {
     test::TestState ts;
-    ts[kSender] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     const std::vector<uint8_t> env{0x11, 0x22};
 
     for (const unsigned t : {0x05u, 0x40u, 0x7eu, 0x7fu, 0xffu})
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(RejectsEveryOutOfEnumTxType)
         tx.type = static_cast<state::Transaction::Type>(t);
         tx.to = 0x0000000000000000000000000000000000001234_address;
         const auto r = opValidate(
-            ts, blk(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
+            ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
         BOOST_REQUIRE_MESSAGE(std::holds_alternative<std::error_code>(r),
             "out-of-enum tx type 0x" << std::hex << t << " must not be accepted");
         BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::not_supported);
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(RejectsEveryOutOfEnumTxType)
                 .s = 1_u256,
                 .v = intx::uint256{0}}};
         const auto r = opValidate(
-            ts, blk(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
+            ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
         BOOST_CHECK_MESSAGE(std::holds_alternative<OpTxProperties>(r),
             "valid tx type " << static_cast<unsigned>(t) << " must not be rejected");
     }
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(RejectsEveryOutOfEnumTxType)
 BOOST_AUTO_TEST_CASE(InsufficientForL1CostFails)
 {
     test::TestState ts;
-    ts[kSender] = {.nonce = 0, .balance = 100000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {.nonce = 0, .balance = 100000000_u256, .storage = {}, .code = {}};
     OpFeeParams fee{.l1_base_fee = 1000000000_u256,
         .base_fee_scalar = 2,
         .blob_base_fee_scalar = 3,
@@ -137,15 +137,15 @@ BOOST_AUTO_TEST_CASE(InsufficientForL1CostFails)
         .operator_fee_constant = 0};
     std::vector<uint8_t> env(50, 0x11);
     const auto r =
-        opValidate(ts, blk(), baseTx(), {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+        opValidate(ts, blkValidate(), baseTx(), {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
     BOOST_REQUIRE(std::holds_alternative<std::error_code>(r));
 }
 
 BOOST_AUTO_TEST_CASE(EmptyEnvelopeFails)
 {
     test::TestState ts;
-    ts[kSender] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
-    const auto r = opValidate(ts, blk(), baseTx(), {}, isthmusConfig(), OpFeeParams{}, 30000000);
+    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    const auto r = opValidate(ts, blkValidate(), baseTx(), {}, isthmusConfig(), OpFeeParams{}, 30000000);
     BOOST_REQUIRE(std::holds_alternative<std::error_code>(r));
     BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::invalid_argument);
 }
@@ -153,10 +153,10 @@ BOOST_AUTO_TEST_CASE(EmptyEnvelopeFails)
 BOOST_AUTO_TEST_CASE(SufficientBalancePasses)
 {
     test::TestState ts;
-    ts[kSender] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     const std::vector<uint8_t> env{0x02};
     const auto r = opValidate(
-        ts, blk(), baseTx(), {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
+        ts, blkValidate(), baseTx(), {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
     BOOST_REQUIRE(std::holds_alternative<OpTxProperties>(r));
     BOOST_CHECK_EQUAL(std::get<OpTxProperties>(r).l1_cost, intx::uint256{0});
 }
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(BalanceCapDoesNotWrapAt2Pow256)
 {
     test::TestState ts;
     const auto balance = std::numeric_limits<intx::uint256>::max();
-    ts[kSender] = {.nonce = 0, .balance = balance, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {.nonce = 0, .balance = balance, .storage = {}, .code = {}};
 
     auto tx = baseTx();
     tx.value = balance - intx::uint256{static_cast<uint64_t>(tx.gas_limit)} * tx.max_gas_price;
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(BalanceCapDoesNotWrapAt2Pow256)
     std::vector<uint8_t> env(50, 0x11);
 
     const auto r =
-        opValidate(ts, blk(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+        opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
     BOOST_REQUIRE_MESSAGE(std::holds_alternative<std::error_code>(r),
         "a total past 2^256 must be rejected, not wrapped into a tiny passing cap");
     BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::result_out_of_range);
@@ -216,12 +216,12 @@ BOOST_AUTO_TEST_CASE(BalanceCapCountsEveryTermExactlyOnce)
     intx::uint256 exact{0};
     {
         test::TestState ts;
-        ts[kSender] = {.nonce = 0,
+        ts[kSenderValidate] = {.nonce = 0,
             .balance = 340282366920938463463374607431768211456_u256,
             .storage = {},
             .code = {}};
         const auto r =
-            opValidate(ts, blk(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+            opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
         BOOST_REQUIRE(std::holds_alternative<OpTxProperties>(r));
         const auto& p = std::get<OpTxProperties>(r);
         BOOST_REQUIRE_MESSAGE(p.l1_cost > intx::uint256{0}, "l1_cost must be non-zero");
@@ -235,9 +235,9 @@ BOOST_AUTO_TEST_CASE(BalanceCapCountsEveryTermExactlyOnce)
     // 恰好足额 → 必须通过。多算任何一项（例如 l1Cost 计两次）都会在此误拒。
     {
         test::TestState ts;
-        ts[kSender] = {.nonce = 0, .balance = exact, .storage = {}, .code = {}};
+        ts[kSenderValidate] = {.nonce = 0, .balance = exact, .storage = {}, .code = {}};
         const auto r =
-            opValidate(ts, blk(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+            opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
         BOOST_CHECK_MESSAGE(std::holds_alternative<OpTxProperties>(r),
             "a balance exactly covering gasLimit*maxGasPrice + value + l1Cost + opCost must pass");
     }
@@ -245,9 +245,9 @@ BOOST_AUTO_TEST_CASE(BalanceCapCountsEveryTermExactlyOnce)
     // 少一个 wei → 必须拒绝。漏算任何一项（例如不加 opCost）都会在此放行。
     {
         test::TestState ts;
-        ts[kSender] = {.nonce = 0, .balance = exact - 1, .storage = {}, .code = {}};
+        ts[kSenderValidate] = {.nonce = 0, .balance = exact - 1, .storage = {}, .code = {}};
         const auto r =
-            opValidate(ts, blk(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+            opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
         BOOST_REQUIRE_MESSAGE(std::holds_alternative<std::error_code>(r),
             "one wei short of the cap must be rejected");
         BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::result_out_of_range);

--- a/bcos-evm/test/opstack/OpValidateTest.cpp
+++ b/bcos-evm/test/opstack/OpValidateTest.cpp
@@ -43,7 +43,8 @@ BOOST_AUTO_TEST_SUITE(OpValidateSuite)
 BOOST_AUTO_TEST_CASE(RejectsBlobTx)
 {
     test::TestState ts;
-    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {
+        .nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     auto tx = baseTx();
     tx.type = state::Transaction::Type::blob;
     tx.to = 0x0000000000000000000000000000000000001234_address;
@@ -67,7 +68,8 @@ BOOST_AUTO_TEST_CASE(RejectsBlobTx)
 BOOST_AUTO_TEST_CASE(RejectsDepositTxOnTheNonDepositPath)
 {
     test::TestState ts;
-    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {
+        .nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     auto tx = baseTx();
     tx.type = kDepositTxType;
     tx.to = 0x0000000000000000000000000000000000001234_address;
@@ -88,7 +90,8 @@ BOOST_AUTO_TEST_CASE(RejectsDepositTxOnTheNonDepositPath)
 BOOST_AUTO_TEST_CASE(RejectsEveryOutOfEnumTxType)
 {
     test::TestState ts;
-    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {
+        .nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     const std::vector<uint8_t> env{0x11, 0x22};
 
     for (const unsigned t : {0x05u, 0x40u, 0x7eu, 0x7fu, 0xffu})
@@ -96,8 +99,8 @@ BOOST_AUTO_TEST_CASE(RejectsEveryOutOfEnumTxType)
         auto tx = baseTx();
         tx.type = static_cast<state::Transaction::Type>(t);
         tx.to = 0x0000000000000000000000000000000000001234_address;
-        const auto r = opValidate(
-            ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
+        const auto r = opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(),
+            OpFeeParams{}, 30000000);
         BOOST_REQUIRE_MESSAGE(std::holds_alternative<std::error_code>(r),
             "out-of-enum tx type 0x" << std::hex << t << " must not be accepted");
         BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::not_supported);
@@ -118,8 +121,8 @@ BOOST_AUTO_TEST_CASE(RejectsEveryOutOfEnumTxType)
                 .r = 1_u256,
                 .s = 1_u256,
                 .v = intx::uint256{0}}};
-        const auto r = opValidate(
-            ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
+        const auto r = opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(),
+            OpFeeParams{}, 30000000);
         BOOST_CHECK_MESSAGE(std::holds_alternative<OpTxProperties>(r),
             "valid tx type " << static_cast<unsigned>(t) << " must not be rejected");
     }
@@ -136,16 +139,18 @@ BOOST_AUTO_TEST_CASE(InsufficientForL1CostFails)
         .operator_fee_scalar = 0,
         .operator_fee_constant = 0};
     std::vector<uint8_t> env(50, 0x11);
-    const auto r =
-        opValidate(ts, blkValidate(), baseTx(), {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+    const auto r = opValidate(
+        ts, blkValidate(), baseTx(), {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
     BOOST_REQUIRE(std::holds_alternative<std::error_code>(r));
 }
 
 BOOST_AUTO_TEST_CASE(EmptyEnvelopeFails)
 {
     test::TestState ts;
-    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
-    const auto r = opValidate(ts, blkValidate(), baseTx(), {}, isthmusConfig(), OpFeeParams{}, 30000000);
+    ts[kSenderValidate] = {
+        .nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    const auto r =
+        opValidate(ts, blkValidate(), baseTx(), {}, isthmusConfig(), OpFeeParams{}, 30000000);
     BOOST_REQUIRE(std::holds_alternative<std::error_code>(r));
     BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::invalid_argument);
 }
@@ -153,10 +158,11 @@ BOOST_AUTO_TEST_CASE(EmptyEnvelopeFails)
 BOOST_AUTO_TEST_CASE(SufficientBalancePasses)
 {
     test::TestState ts;
-    ts[kSenderValidate] = {.nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
+    ts[kSenderValidate] = {
+        .nonce = 0, .balance = 1000000000000000000000_u256, .storage = {}, .code = {}};
     const std::vector<uint8_t> env{0x02};
-    const auto r = opValidate(
-        ts, blkValidate(), baseTx(), {env.data(), env.size()}, isthmusConfig(), OpFeeParams{}, 30000000);
+    const auto r = opValidate(ts, blkValidate(), baseTx(), {env.data(), env.size()},
+        isthmusConfig(), OpFeeParams{}, 30000000);
     BOOST_REQUIRE(std::holds_alternative<OpTxProperties>(r));
     BOOST_CHECK_EQUAL(std::get<OpTxProperties>(r).l1_cost, intx::uint256{0});
 }
@@ -220,8 +226,8 @@ BOOST_AUTO_TEST_CASE(BalanceCapCountsEveryTermExactlyOnce)
             .balance = 340282366920938463463374607431768211456_u256,
             .storage = {},
             .code = {}};
-        const auto r =
-            opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+        const auto r = opValidate(
+            ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
         BOOST_REQUIRE(std::holds_alternative<OpTxProperties>(r));
         const auto& p = std::get<OpTxProperties>(r);
         BOOST_REQUIRE_MESSAGE(p.l1_cost > intx::uint256{0}, "l1_cost must be non-zero");
@@ -236,8 +242,8 @@ BOOST_AUTO_TEST_CASE(BalanceCapCountsEveryTermExactlyOnce)
     {
         test::TestState ts;
         ts[kSenderValidate] = {.nonce = 0, .balance = exact, .storage = {}, .code = {}};
-        const auto r =
-            opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+        const auto r = opValidate(
+            ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
         BOOST_CHECK_MESSAGE(std::holds_alternative<OpTxProperties>(r),
             "a balance exactly covering gasLimit*maxGasPrice + value + l1Cost + opCost must pass");
     }
@@ -246,8 +252,8 @@ BOOST_AUTO_TEST_CASE(BalanceCapCountsEveryTermExactlyOnce)
     {
         test::TestState ts;
         ts[kSenderValidate] = {.nonce = 0, .balance = exact - 1, .storage = {}, .code = {}};
-        const auto r =
-            opValidate(ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
+        const auto r = opValidate(
+            ts, blkValidate(), tx, {env.data(), env.size()}, isthmusConfig(), fee, 30000000);
         BOOST_REQUIRE_MESSAGE(std::holds_alternative<std::error_code>(r),
             "one wei short of the cap must be rejected");
         BOOST_CHECK_EQUAL(std::get<std::error_code>(r), std::errc::result_out_of_range);

--- a/bcos-evm/test/opstack/OpZeroDiffTest.cpp
+++ b/bcos-evm/test/opstack/OpZeroDiffTest.cpp
@@ -127,8 +127,8 @@ BOOST_AUTO_TEST_CASE(SimpleTransferMatchesEthExceptBaseFeeVault)
     BOOST_CHECK_EQUAL(props.operator_cost_at_gas_limit, intx::uint256{0});
 
     evmone::state::StateDiff opDiff;
-    const auto opTxR =
-        opTransition(ts, block, hashes, tx, cfg, vm, props, /*chainId=*/1, kOpTestReceiptFactory, opDiff);
+    const auto opTxR = opTransition(
+        ts, block, hashes, tx, cfg, vm, props, /*chainId=*/1, kOpTestReceiptFactory, opDiff);
     BOOST_REQUIRE_EQUAL(opTxR->status(), 0);
     const auto opGasUsed = static_cast<uint64_t>(opTxR->gasUsed());
 
@@ -152,22 +152,20 @@ BOOST_AUTO_TEST_CASE(SimpleTransferMatchesEthExceptBaseFeeVault)
         BOOST_CHECK_MESSAGE(
             entryEq(opNonVault[i], ethNonVault[i]), "mismatch at non-vault index " << i);
 
-    BOOST_CHECK(
-        (nonVaultDeleted(opDiff)) == (nonVaultDeleted(ethReceipt.state_diff)));
+    BOOST_CHECK((nonVaultDeleted(opDiff)) == (nonVaultDeleted(ethReceipt.state_diff)));
 
     // fee=0 下四个 vault 因已有 stub code 不再被判为空账户删除
     for (const auto& v :
         {OP_BASE_FEE_VAULT, OP_L1_FEE_VAULT, OP_OPERATOR_FEE_VAULT, OP_SEQUENCER_FEE_VAULT})
     {
-        BOOST_CHECK_MESSAGE((std::count(opDiff.deleted_accounts.begin(),
-                                opDiff.deleted_accounts.end(), v)) == (0),
+        BOOST_CHECK_MESSAGE(
+            (std::count(opDiff.deleted_accounts.begin(), opDiff.deleted_accounts.end(), v)) == (0),
             "vault should not be deleted");
     }
 
     const auto baseVaultBal = balanceOf(opDiff, OP_BASE_FEE_VAULT);
     BOOST_REQUIRE(baseVaultBal.has_value());
-    BOOST_CHECK_EQUAL(
-        *baseVaultBal, intx::uint256{opGasUsed} * intx::uint256{block.base_fee});
+    BOOST_CHECK_EQUAL(*baseVaultBal, intx::uint256{opGasUsed} * intx::uint256{block.base_fee});
 
     // L1 / operator 费用为 0：不应出现在 eth diff；OP 侧若 touch 余额须仍为 0。
     if (const auto l1 = balanceOf(opDiff, OP_L1_FEE_VAULT))

--- a/bcos-evm/test/opstack/OpZeroDiffTest.cpp
+++ b/bcos-evm/test/opstack/OpZeroDiffTest.cpp
@@ -24,7 +24,7 @@ using intx::operator""_u256;
 
 namespace
 {
-constexpr auto kSender = 0x00000000000000000000000000000000000000aa_address;
+constexpr auto kSenderZeroDiff = 0x00000000000000000000000000000000000000aa_address;
 constexpr auto kDest = 0x00000000000000000000000000000000000000bb_address;
 constexpr auto kFunding = 340282366920938463463374607431768211456_u256;
 
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(SimpleTransferMatchesEthExceptBaseFeeVault)
 {
     auto vm = evmc::VM{evmc_create_evmone()};
     test::TestState ts;
-    ts[kSender] = {.nonce = 0, .balance = kFunding, .storage = {}, .code = {}};
+    ts[kSenderZeroDiff] = {.nonce = 0, .balance = kFunding, .storage = {}, .code = {}};
     ts[kDest] = {};
     seedOpPredeploys(ts);
     test::TestBlockHashes hashes;
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(SimpleTransferMatchesEthExceptBaseFeeVault)
 
     state::Transaction tx;
     tx.type = state::Transaction::Type::eip1559;
-    tx.sender = kSender;
+    tx.sender = kSenderZeroDiff;
     tx.to = kDest;
     tx.gas_limit = 100000;
     tx.max_gas_price = 1000;

--- a/bcos-evm/test/opstack/OpZeroFeeSpikeTest.cpp
+++ b/bcos-evm/test/opstack/OpZeroFeeSpikeTest.cpp
@@ -4,7 +4,7 @@
 // All six tests green -> spike holds (Task 5 entry condition); any failure -> spike does
 // not hold (Phase 1 converges to a pure baseline).
 //
-// Note: this file is an independent TU; spikeBlk()/baseTx() are copied from OpValidateTest.cpp
+// Note: this file is an independent TU; spikeBlk()/spikeBaseTx() are copied from OpValidateTest.cpp
 // and adapted to the OpTransitionTest.cpp pattern (spikeBlk() adds coinbase =
 // OP_SEQUENCER_FEE_VAULT so the priority tip lands in an assertable named vault).
 #include "OpTestReceiptFactory.h"
@@ -44,7 +44,7 @@ state::BlockInfo spikeBlk()
     return b;
 }
 
-state::Transaction baseTx()
+state::Transaction spikeBaseTx()
 {
     state::Transaction tx;
     tx.type = state::Transaction::Type::eip1559;
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(opValidate_zero_fee_passes_balance_check)
     // rejects
     auto isthmus = isthmusConfig();
     auto block = spikeBlk();
-    auto tx = baseTx();
+    auto tx = spikeBaseTx();
     evmc::bytes envelope{0x02};  // dummy non-empty suffices; no real signature needed
     auto props = opValidateFromState(ts, block, tx, envelope, isthmus, /*blockGasLeft=*/30000000);
     BOOST_REQUIRE(std::holds_alternative<OpTxProperties>(props));
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(opValidate_zero_balance_sender_rejected)
     evmone::test::TestState ts;  // no sender inserted → get_account balance=0
     auto isthmus = isthmusConfig();
     auto block = spikeBlk();
-    auto tx = baseTx();
+    auto tx = spikeBaseTx();
     evmc::bytes envelope{0x02};
     auto props = opValidateFromState(ts, block, tx, envelope, isthmus, /*blockGasLeft=*/30000000);
     BOOST_REQUIRE(std::holds_alternative<std::error_code>(props));
@@ -127,9 +127,9 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_fee_writes_back_state)
                                                // is a C struct-derived class, not applicable)
     auto block = spikeBlk();
     test::TestBlockHashes hashes;
-    auto tx = baseTx();
-    tx.to = kRecipient;  // makes the "recipient balance +value" assertion meaningful (baseTx has no
-                         // to=CREATE)
+    auto tx = spikeBaseTx();
+    tx.to = kRecipient;  // makes the "recipient balance +value" assertion meaningful (spikeBaseTx
+                         // has no to=CREATE)
     tx.value = intx::uint256{12345};
     evmc::bytes envelope{0x02};
     auto props = opValidateFromState(ts, block, tx, envelope, isthmus, /*blockGasLeft=*/30000000);
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_fee_writes_back_state)
     BOOST_REQUIRE_EQUAL(txR->status(), 0);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
-    // ---- assertion-value derivation (from spikeBlk()/baseTx()/OpTransition.cpp:237-323) ----
+    // ---- assertion-value derivation (from spikeBlk()/spikeBaseTx()/OpTransition.cpp:237-323) ----
     //   spikeBlk().base_fee = 7; tx.max_gas_price = 1000, tx.max_priority_gas_price = 10
     //   priority = min(max_priority, max_gas - base_fee) = min(10, 993) = 10
     //   effective_gas_price = base_fee + priority = 17
@@ -162,8 +162,8 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_fee_writes_back_state)
 
     // sender net debit = gas_used * effective + value (L1/operator both 0; value is
     // transferred inside host.call).
-    BOOST_CHECK_EQUAL(
-        ts.at(kSpikeSender).balance, kSenderBalance - gasUsed * effective - intx::uint256{tx.value});
+    BOOST_CHECK_EQUAL(ts.at(kSpikeSender).balance,
+        kSenderBalance - gasUsed * effective - intx::uint256{tx.value});
     // recipient receives the transferred value.
     BOOST_CHECK_EQUAL(ts.at(kRecipient).balance, intx::uint256{tx.value});
     // the base_fee portion burns into OP_BASE_FEE_VAULT; the tip goes to coinbase (sequencer
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_base_fee_no_burn)
     auto block = spikeBlk();
     block.base_fee = 0;
     test::TestBlockHashes hashes;
-    auto tx = baseTx();
+    auto tx = spikeBaseTx();
     tx.to = kRecipient;
     tx.value = intx::uint256{12345};
     evmc::bytes envelope{0x02};

--- a/bcos-evm/test/opstack/OpZeroFeeSpikeTest.cpp
+++ b/bcos-evm/test/opstack/OpZeroFeeSpikeTest.cpp
@@ -4,8 +4,8 @@
 // All six tests green -> spike holds (Task 5 entry condition); any failure -> spike does
 // not hold (Phase 1 converges to a pure baseline).
 //
-// Note: this file is an independent TU; blk()/baseTx() are copied from OpValidateTest.cpp
-// and adapted to the OpTransitionTest.cpp pattern (blk() adds coinbase =
+// Note: this file is an independent TU; spikeBlk()/baseTx() are copied from OpValidateTest.cpp
+// and adapted to the OpTransitionTest.cpp pattern (spikeBlk() adds coinbase =
 // OP_SEQUENCER_FEE_VAULT so the priority tip lands in an assertable named vault).
 #include "OpTestReceiptFactory.h"
 #include "StateDiffWriteback.h"
@@ -28,12 +28,12 @@ using intx::operator""_u256;
 
 namespace
 {
-constexpr auto kSender = 0x1000000000000000000000000000000000000001_address;
+constexpr auto kSpikeSender = 0x1000000000000000000000000000000000000001_address;
 constexpr auto kRecipient = 0x2000000000000000000000000000000000000002_address;
 constexpr auto kSenderBalance =
     1000000000000000000_u256;  // 1 ETH (explicit wei; no _ether literal)
 
-state::BlockInfo blk()
+state::BlockInfo spikeBlk()
 {
     state::BlockInfo b;
     b.number = 1;
@@ -48,7 +48,7 @@ state::Transaction baseTx()
 {
     state::Transaction tx;
     tx.type = state::Transaction::Type::eip1559;
-    tx.sender = kSender;
+    tx.sender = kSpikeSender;
     tx.gas_limit = 100000;
     tx.max_gas_price = 1000;
     tx.max_priority_gas_price = 10;
@@ -90,11 +90,11 @@ BOOST_AUTO_TEST_CASE(zero_fee_params_produce_zero_costs)
 BOOST_AUTO_TEST_CASE(opValidate_zero_fee_passes_balance_check)
 {
     evmone::test::TestState ts;
-    ts[kSender] = {.balance = kSenderBalance, .storage = {}, .code = {}};
+    ts[kSpikeSender] = {.balance = kSenderBalance, .storage = {}, .code = {}};
     // sender must be inserted; otherwise get_account returns balance=0 and the balance check
     // rejects
     auto isthmus = isthmusConfig();
-    auto block = blk();
+    auto block = spikeBlk();
     auto tx = baseTx();
     evmc::bytes envelope{0x02};  // dummy non-empty suffices; no real signature needed
     auto props = opValidateFromState(ts, block, tx, envelope, isthmus, /*blockGasLeft=*/30000000);
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(opValidate_zero_balance_sender_rejected)
 {
     evmone::test::TestState ts;  // no sender inserted → get_account balance=0
     auto isthmus = isthmusConfig();
-    auto block = blk();
+    auto block = spikeBlk();
     auto tx = baseTx();
     evmc::bytes envelope{0x02};
     auto props = opValidateFromState(ts, block, tx, envelope, isthmus, /*blockGasLeft=*/30000000);
@@ -120,12 +120,12 @@ BOOST_AUTO_TEST_CASE(opValidate_zero_balance_sender_rejected)
 BOOST_AUTO_TEST_CASE(opTransition_zero_fee_writes_back_state)
 {
     evmone::test::TestState ts;
-    ts[kSender] = {.balance = kSenderBalance, .storage = {}, .code = {}};
+    ts[kSpikeSender] = {.balance = kSenderBalance, .storage = {}, .code = {}};
     ts[kRecipient] = {};
     auto isthmus = isthmusConfig();
     auto vm = evmc::VM{evmc_create_evmone()};  // opTransition signature takes evmc::VM& (evmone::VM
                                                // is a C struct-derived class, not applicable)
-    auto block = blk();
+    auto block = spikeBlk();
     test::TestBlockHashes hashes;
     auto tx = baseTx();
     tx.to = kRecipient;  // makes the "recipient balance +value" assertion meaningful (baseTx has no
@@ -146,8 +146,8 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_fee_writes_back_state)
     BOOST_REQUIRE_EQUAL(txR->status(), 0);
     bcos::evm::applyStateDiffStrict(ts, diff);
 
-    // ---- assertion-value derivation (from blk()/baseTx()/OpTransition.cpp:237-323) ----
-    //   blk().base_fee = 7; tx.max_gas_price = 1000, tx.max_priority_gas_price = 10
+    // ---- assertion-value derivation (from spikeBlk()/baseTx()/OpTransition.cpp:237-323) ----
+    //   spikeBlk().base_fee = 7; tx.max_gas_price = 1000, tx.max_priority_gas_price = 10
     //   priority = min(max_priority, max_gas - base_fee) = min(10, 993) = 10
     //   effective_gas_price = base_fee + priority = 17
     //   plain EOA transfer (empty calldata) -> gas_used = intrinsic = 21000 (EIP-7623 floor also
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_fee_writes_back_state)
     // sender net debit = gas_used * effective + value (L1/operator both 0; value is
     // transferred inside host.call).
     BOOST_CHECK_EQUAL(
-        ts.at(kSender).balance, kSenderBalance - gasUsed * effective - intx::uint256{tx.value});
+        ts.at(kSpikeSender).balance, kSenderBalance - gasUsed * effective - intx::uint256{tx.value});
     // recipient receives the transferred value.
     BOOST_CHECK_EQUAL(ts.at(kRecipient).balance, intx::uint256{tx.value});
     // the base_fee portion burns into OP_BASE_FEE_VAULT; the tip goes to coinbase (sequencer
@@ -179,16 +179,16 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_fee_writes_back_state)
 }
 
 // 4b) base_fee=0 variant: effective gas price collapses to the priority tip (no base-fee burn),
-// and the base-fee vault is never touched. Pins the effective=priority path (blk() fixed
+// and the base-fee vault is never touched. Pins the effective=priority path (spikeBlk() fixed
 // base_fee=7 elsewhere).
 BOOST_AUTO_TEST_CASE(opTransition_zero_base_fee_no_burn)
 {
     evmone::test::TestState ts;
-    ts[kSender] = {.balance = kSenderBalance, .storage = {}, .code = {}};
+    ts[kSpikeSender] = {.balance = kSenderBalance, .storage = {}, .code = {}};
     ts[kRecipient] = {};
     auto isthmus = isthmusConfig();
     auto vm = evmc::VM{evmc_create_evmone()};
-    auto block = blk();
+    auto block = spikeBlk();
     block.base_fee = 0;
     test::TestBlockHashes hashes;
     auto tx = baseTx();
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(opTransition_zero_base_fee_no_burn)
     const auto gasUsed = intx::uint256{static_cast<uint64_t>(txR->gasUsed())};
     BOOST_CHECK_EQUAL(gasUsed, intx::uint256{21000});
     // base_fee=0 -> priority = min(max_priority, max_gas - 0) = 10, effective = 0 + 10 = 10
-    BOOST_CHECK_EQUAL(ts.at(kSender).balance,
+    BOOST_CHECK_EQUAL(ts.at(kSpikeSender).balance,
         kSenderBalance - gasUsed * intx::uint256{10} - intx::uint256{tx.value});
     BOOST_CHECK_EQUAL(ts.at(kRecipient).balance, intx::uint256{tx.value});
     // no base-fee burn: the base-fee vault is never created/touched.

--- a/bcos-executor/src/Common.h
+++ b/bcos-executor/src/Common.h
@@ -43,6 +43,7 @@
 #include <range/v3/algorithm/copy.hpp>
 #include <range/v3/view/drop.hpp>
 #include <set>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos
 {

--- a/bcos-executor/src/dag/Abi.cpp
+++ b/bcos-executor/src/dag/Abi.cpp
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos::executor;
 

--- a/bcos-executor/src/dag/ScaleUtils.cpp
+++ b/bcos-executor/src/dag/ScaleUtils.cpp
@@ -24,6 +24,7 @@
 #include "bcos-codec/scale/Common.h"
 #include <boost/algorithm/string/predicate.hpp>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::executor;

--- a/bcos-executor/src/dag/TxDAG2.cpp
+++ b/bcos-executor/src/dag/TxDAG2.cpp
@@ -22,6 +22,7 @@
 
 #include "TxDAG2.h"
 #include "CriticalFields.h"
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::executor;

--- a/bcos-executor/src/dag/TxDAGFlow.h
+++ b/bcos-executor/src/dag/TxDAGFlow.h
@@ -23,6 +23,7 @@
 #include "./TxDAGInterface.h"
 #include "tbb/flow_graph.h"
 #include <vector>
+#include <bcos-utilities/BoostLog.h>
 
 #define DAGFLOW_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("EXECUTOR") << LOG_BADGE("DAGFlow")
 

--- a/bcos-executor/src/executive/ExecutiveFactory.cpp
+++ b/bcos-executor/src/executive/ExecutiveFactory.cpp
@@ -25,6 +25,7 @@
 #include "CoroutineTransactionExecutive.h"
 #include "ShardingTransactionExecutive.h"
 #include "TransactionExecutive.h"
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos::executor;
 using namespace bcos::precompiled;

--- a/bcos-executor/src/executive/TransactionExecutive.cpp
+++ b/bcos-executor/src/executive/TransactionExecutive.cpp
@@ -56,6 +56,7 @@
 #include <exception>
 #include <memory>
 #include <string>
+#include <boost/algorithm/string.hpp>
 
 
 using namespace std;

--- a/bcos-executor/src/executor/TransactionExecutor.h
+++ b/bcos-executor/src/executor/TransactionExecutor.h
@@ -46,6 +46,7 @@
 #include <memory>
 #include <shared_mutex>
 #include <thread>
+#include <list>
 
 
 namespace bcos

--- a/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
+++ b/bcos-executor/src/precompiled/SystemConfigPrecompiled.cpp
@@ -31,6 +31,7 @@
 #include "bcos-tool/VersionConverter.h"
 #include <bcos-framework/storage/Serialize.h>
 #include <range/v3/algorithm/find.hpp>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::storage;

--- a/bcos-executor/src/precompiled/common/Common.h
+++ b/bcos-executor/src/precompiled/common/Common.h
@@ -22,6 +22,7 @@
 
 #include "bcos-executor/src/Common.h"
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::precompiled
 {

--- a/bcos-executor/src/precompiled/common/Utilities.cpp
+++ b/bcos-executor/src/precompiled/common/Utilities.cpp
@@ -24,6 +24,7 @@
 #include <tbb/concurrent_unordered_map.h>
 #include <boost/core/ignore_unused.hpp>
 #include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::executor;

--- a/bcos-executor/src/precompiled/common/Utilities.h
+++ b/bcos-executor/src/precompiled/common/Utilities.h
@@ -32,6 +32,7 @@
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/serialization/string.hpp>
 #include <boost/serialization/vector.hpp>
+#include <boost/algorithm/string.hpp>
 
 namespace bcos::precompiled
 {

--- a/bcos-executor/src/precompiled/extension/CpuHeavyPrecompiled.h
+++ b/bcos-executor/src/precompiled/extension/CpuHeavyPrecompiled.h
@@ -22,6 +22,7 @@
 
 #include "../../vm/Precompiled.h"
 #include "bcos-executor/src/precompiled/common/Common.h"
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::precompiled
 {

--- a/bcos-executor/src/precompiled/extension/DagTransferPrecompiled.h
+++ b/bcos-executor/src/precompiled/extension/DagTransferPrecompiled.h
@@ -22,6 +22,7 @@
 #include "../../vm/Precompiled.h"
 #include "bcos-executor/src/precompiled/common/Common.h"
 #include "bcos-framework/storage/Table.h"
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos
 {

--- a/bcos-executor/src/precompiled/extension/SmallBankPrecompiled.h
+++ b/bcos-executor/src/precompiled/extension/SmallBankPrecompiled.h
@@ -24,6 +24,7 @@
 #include "bcos-executor/src/precompiled/common/Common.h"
 #include "bcos-framework/ledger/LedgerTypeDef.h"
 #include "bcos-framework/storage/Table.h"
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos
 {

--- a/bcos-executor/src/vm/HostContext.h
+++ b/bcos-executor/src/vm/HostContext.h
@@ -31,6 +31,7 @@
 #include <evmc/evmc.h>
 #include <evmc/helpers.h>
 #include <memory>
+#include <list>
 
 namespace bcos
 {

--- a/bcos-executor/src/vm/Precompiled.cpp
+++ b/bcos-executor/src/vm/Precompiled.cpp
@@ -38,6 +38,7 @@
 #include <evmone_precompiles/sha256.hpp>
 #include <intx/intx.hpp>
 #include <span>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace std;
 using namespace bcos;

--- a/bcos-executor/test/unittest/CMakeLists.txt
+++ b/bcos-executor/test/unittest/CMakeLists.txt
@@ -14,11 +14,36 @@ include(SearchTestCases)
 target_link_libraries(${TEST_BINARY_NAME} executor ledger bcos-crypto protocol-tars bcos-framework rpc Boost::serialization Boost::unit_test_framework)
 target_compile_options(${TEST_BINARY_NAME} PRIVATE -fno-var-tracking -Wno-unused-parameter)
 set_source_files_properties("main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
-# Unity batches pull range-v3 and libc++ std::ranges into the same TU on newer SDKs.
-# UNITY_BUILD is OFF for the whole target, which subsumes release-3.17.0's per-file
-# SKIP_UNITY_BUILD_INCLUSION opt-outs for DAGTest / DagTransferPrecompiledTest /
-# SmallBankPrecompiledTest -- those files are already compiled standalone here.
-set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "OFF")
+# Unity build is ON for this target (Linux/GCC): it amortizes the heavy shared
+# include set (~200k preprocessed lines per TU: boost.test + framework + executor
+# headers) across ~40 test files — measured on GCC 14/Debug: test target rebuild
+# 150.7s -> 111.0s wall (-26%), ~2200s -> ~1500s CPU (-32%).
+# Opt-outs:
+#  - evmone/compat/Compat*.cpp: all share BOOST_AUTO_TEST_SUITE(Compat), which would
+#    redefine the same suite registration symbols inside one unity TU.
+#  - DAGTest / DagTransferPrecompiledTest / SmallBankPrecompiledTest: kept standalone
+#    since release-3.17.0 (name collisions in unity TUs).
+#  - files with a global `using namespace std;`: range-v3 headers first included
+#    after that using-directive in the same unity TU see an ambiguous `ranges`
+#    (::ranges vs ::std::ranges), so they must compile standalone.
+set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
+file(GLOB COMPAT_SOURCES "evmone/compat/Compat*.cpp")
+set_source_files_properties(${COMPAT_SOURCES}
+    "DAGTest.cpp"
+    "libprecompiled/DagTransferPrecompiledTest.cpp"
+    "libprecompiled/SmallBankPrecompiledTest.cpp"
+    "libexecutive/TestShardingSyncStorageWrapper.h.cpp"
+    "libexecutor/TestScaleUtils.cpp"
+    "libexecutor/TestEVMExecutor.cpp"
+    "libexecutor/TestBlockContext.cpp"
+    "libexecutor/TestExecutiveStackFlow.cpp"
+    "libexecutor/TestLedgerCache.cpp"
+    "libexecutor/TestClockCache.cpp"
+    "libexecutor/TestExecutiveState.cpp"
+    "libexecutor/TestTxDAG.cpp"
+    "libexecutor/TestDagExecutor.cpp"
+    "libexecutor/TestAbiReader.cpp"
+    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 # CompatStaticGuardsTest locates repo sources from __FILE__. With UNITY_BUILD off the compiler
 # sees a path relative to its own working directory, while ctest runs the binary from the build
 # root, so the relative form resolves to the wrong place. Give the test an absolute anchor.

--- a/bcos-executor/test/unittest/CMakeLists.txt
+++ b/bcos-executor/test/unittest/CMakeLists.txt
@@ -16,34 +16,19 @@ target_compile_options(${TEST_BINARY_NAME} PRIVATE -fno-var-tracking -Wno-unused
 set_source_files_properties("main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 # Unity build is ON for this target (Linux/GCC): it amortizes the heavy shared
 # include set (~200k preprocessed lines per TU: boost.test + framework + executor
-# headers) across ~40 test files — measured on GCC 14/Debug: test target rebuild
-# 150.7s -> 111.0s wall (-26%), ~2200s -> ~1500s CPU (-32%).
-# Opt-outs:
-#  - evmone/compat/Compat*.cpp: all share BOOST_AUTO_TEST_SUITE(Compat), which would
-#    redefine the same suite registration symbols inside one unity TU.
-#  - DAGTest / DagTransferPrecompiledTest / SmallBankPrecompiledTest: kept standalone
-#    since release-3.17.0 (name collisions in unity TUs).
-#  - files with a global `using namespace std;`: range-v3 headers first included
-#    after that using-directive in the same unity TU see an ambiguous `ranges`
-#    (::ranges vs ::std::ranges), so they must compile standalone.
+# headers) across all test files — measured on GCC 14/Debug: test target rebuild
+# 150.7s -> ~90s wall. No per-file opt-outs remain:
+#  - the global `using namespace std;` files were fixed to targeted `using std::x;`
+#    (a global using-directive makes range-v3's ::ranges ambiguous with ::std::ranges
+#    inside unity TUs);
+#  - BOOST_AUTO_TEST_SUITE(Compat) shared by evmone/compat/Compat*.cpp works fine in
+#    unity TUs with this Boost version (registration symbols are uniquified);
+#  - the release-3.17.0-era opt-outs (DAGTest / DagTransferPrecompiledTest /
+#    SmallBankPrecompiledTest) were verified safe on GCC 14.
+# Default batch size (8): measured GCC 14/Debug on a 20-core box — test target clean
+# rebuild ~150s -> ~120-145s wall, ~2200s -> ~1500-1800s CPU; batch 4 was strictly
+# worse (more repeated header parsing, no wall-clock gain).
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
-file(GLOB COMPAT_SOURCES "evmone/compat/Compat*.cpp")
-set_source_files_properties(${COMPAT_SOURCES}
-    "DAGTest.cpp"
-    "libprecompiled/DagTransferPrecompiledTest.cpp"
-    "libprecompiled/SmallBankPrecompiledTest.cpp"
-    "libexecutive/TestShardingSyncStorageWrapper.h.cpp"
-    "libexecutor/TestScaleUtils.cpp"
-    "libexecutor/TestEVMExecutor.cpp"
-    "libexecutor/TestBlockContext.cpp"
-    "libexecutor/TestExecutiveStackFlow.cpp"
-    "libexecutor/TestLedgerCache.cpp"
-    "libexecutor/TestClockCache.cpp"
-    "libexecutor/TestExecutiveState.cpp"
-    "libexecutor/TestTxDAG.cpp"
-    "libexecutor/TestDagExecutor.cpp"
-    "libexecutor/TestAbiReader.cpp"
-    PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 # CompatStaticGuardsTest locates repo sources from __FILE__. With UNITY_BUILD off the compiler
 # sees a path relative to its own working directory, while ctest runs the binary from the build
 # root, so the relative form resolves to the wrong place. Give the test an absolute anchor.

--- a/bcos-executor/test/unittest/libexecutive/TestShardingSyncStorageWrapper.h.cpp
+++ b/bcos-executor/test/unittest/libexecutive/TestShardingSyncStorageWrapper.h.cpp
@@ -28,8 +28,6 @@ namespace bcos
 {
 namespace test
 {
-using namespace std;
-
 BOOST_AUTO_TEST_SUITE(TestShardingSyncStorageWrapper)
 
 BOOST_AUTO_TEST_CASE(test_keyName)

--- a/bcos-executor/test/unittest/libexecutor/TestAbiReader.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestAbiReader.cpp
@@ -32,8 +32,10 @@ namespace bcos
 {
 namespace test
 {
-using namespace std;
-
+using std::cout;
+using std::endl;
+using std::vector;
+using namespace std::string_view_literals;
 struct AbiReaderFixture
 {
     AbiReaderFixture() { hashImpl = std::make_shared<Keccak256>(); }

--- a/bcos-executor/test/unittest/libexecutor/TestBlockContext.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestBlockContext.cpp
@@ -10,8 +10,6 @@ namespace bcos
 {
 namespace test
 {
-using namespace std;
-
 BOOST_AUTO_TEST_SUITE(TestBlockContext)
 
 BOOST_AUTO_TEST_CASE(BlockContextTest)

--- a/bcos-executor/test/unittest/libexecutor/TestClockCache.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestClockCache.cpp
@@ -30,8 +30,8 @@ namespace bcos
 {
 namespace test
 {
-using namespace std;
-
+using std::make_shared;
+using std::shared_ptr;
 struct ClockCacheFixture
 {
     ClockCacheFixture()

--- a/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestDagExecutor.cpp
@@ -54,8 +54,7 @@ namespace bcos
 {
 namespace test
 {
-using namespace std;
-
+using std::to_string;
 struct DagExecutorFixture
 {
     DagExecutorFixture()

--- a/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestEVMExecutor.cpp
@@ -61,8 +61,8 @@ namespace bcos
 {
 namespace test
 {
-using namespace std;
-
+using std::string;
+using std::string_view;
 struct TransactionExecutorFixture
 {
     TransactionExecutorFixture()

--- a/bcos-executor/test/unittest/libexecutor/TestExecutiveStackFlow.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestExecutiveStackFlow.cpp
@@ -32,8 +32,7 @@ namespace bcos
 {
 namespace test
 {
-using namespace std;
-
+using std::make_shared;
 struct ExecutiveStackFlowFixture
 {
     ExecutiveStackFlowFixture()

--- a/bcos-executor/test/unittest/libexecutor/TestExecutiveState.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestExecutiveState.cpp
@@ -5,7 +5,6 @@
 #include "../mock/MockLedger.h"
 
 #include <boost/test/unit_test.hpp>
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 

--- a/bcos-executor/test/unittest/libexecutor/TestLedgerCache.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestLedgerCache.cpp
@@ -23,7 +23,6 @@
 #include "bcos-executor/src/executive/LedgerCache.h"
 
 #include <boost/test/unit_test.hpp>
-using namespace std;
 using namespace bcos;
 using namespace bcos::executor;
 

--- a/bcos-executor/test/unittest/libexecutor/TestScaleUtils.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestScaleUtils.cpp
@@ -27,7 +27,8 @@
 #include <utility>
 #include <vector>
 
-using namespace std;
+using std::pair;
+using std::vector;
 using namespace bcos;
 using namespace bcos::executor;
 

--- a/bcos-executor/test/unittest/libexecutor/TestTxDAG.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TestTxDAG.cpp
@@ -28,7 +28,14 @@
 #include <utility>
 #include <vector>
 
-using namespace std;
+using std::cout;
+using std::endl;
+using std::exception;
+using std::make_shared;
+using std::map;
+using std::shared_ptr;
+using std::string;
+using std::vector;
 using namespace bcos;
 using namespace bcos::executor;
 using namespace bcos::executor::critical;

--- a/bcos-executor/test/unittest/libexecutor/TxDAG.cpp
+++ b/bcos-executor/test/unittest/libexecutor/TxDAG.cpp
@@ -21,6 +21,7 @@
 
 #include "TxDAG.h"
 #include "bcos-executor/src/dag/CriticalFields.h"
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::executor;

--- a/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
+++ b/bcos-executor/test/unittest/libprecompiled/ConfigPrecompiledTest.cpp
@@ -25,6 +25,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/endian/conversion.hpp>
 #include <algorithm>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::precompiled;

--- a/bcos-executor/test/unittest/mock/MockExecutiveFlow.h
+++ b/bcos-executor/test/unittest/mock/MockExecutiveFlow.h
@@ -4,7 +4,6 @@
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
-using namespace std;
 using namespace bcos::executor;
 
 namespace bcos::test

--- a/bcos-framework/bcos-framework/executor/ParallelTransactionExecutorInterface.h
+++ b/bcos-framework/bcos-framework/executor/ParallelTransactionExecutorInterface.h
@@ -32,6 +32,7 @@
 #include <bcos-utilities/FixedBytes.h>
 #include <boost/iterator/iterator_categories.hpp>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::executor
 {

--- a/bcos-framework/bcos-framework/ledger/Ledger.h
+++ b/bcos-framework/bcos-framework/ledger/Ledger.h
@@ -10,6 +10,7 @@
 #include "bcos-framework/transaction-executor/StateKey.h"
 #include "bcos-task/Task.h"
 #include <range/v3/range/concepts.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 #define LEDGER_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("LEDGER")
 

--- a/bcos-framework/bcos-framework/multigroup/GroupTypeDef.h
+++ b/bcos-framework/bcos-framework/multigroup/GroupTypeDef.h
@@ -22,6 +22,7 @@
 #include <bcos-framework/Common.h>
 #include <bcos-utilities/Exceptions.h>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 
 #define GROUP_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("GROUP")
 

--- a/bcos-framework/bcos-framework/rpc/HandshakeRequest.h
+++ b/bcos-framework/bcos-framework/rpc/HandshakeRequest.h
@@ -24,6 +24,7 @@
 #include <fmt/format.h>
 #include <json/json.h>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::rpc
 {

--- a/bcos-framework/bcos-framework/storage/Common.h
+++ b/bcos-framework/bcos-framework/storage/Common.h
@@ -31,6 +31,7 @@
 #include <string_view>
 #include <utility>
 #include <vector>
+#include <bcos-utilities/BoostLog.h>
 
 #define STORAGE_LOG(LEVEL) BCOS_LOG(LEVEL) << "[STORAGE]"
 

--- a/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
+++ b/bcos-framework/bcos-framework/storage2/MultiLayerStorage.h
@@ -15,6 +15,7 @@
 #include <range/v3/view/zip.hpp>
 #include <type_traits>
 #include <variant>
+#include <deque>
 
 namespace bcos::storage2
 {

--- a/bcos-framework/bcos-framework/testutils/faker/FakeTransaction.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeTransaction.h
@@ -153,7 +153,7 @@ inline Transaction::Ptr fakeWeb3Tx(CryptoSuite::Ptr _cryptoSuite, std::string no
     transaction.data.to = key->address(_cryptoSuite->hashImpl()).hex();
     transaction.data.input.assign(inputStr.begin(), inputStr.end());
     transaction.data.nonce = std::move(nonce);
-    transaction.type = static_cast<tars::Char>(TransactionType::Web3Transaction);
+    transaction.type = static_cast<tars::Char>(protocol::TransactionType::Web3Transaction);
     // extraTransactionBytes must be a genuine Web3 signing preimage: since FIB-New1, verify()
     // recomputes the canonical txHash from it by RLP splicing, so arbitrary bytes are rejected.
     // Build a minimal legacy (pre-EIP-155) preimage rlp([nonce, gasPrice, gas, to, value, data])

--- a/bcos-framework/bcos-framework/txpool/TxPoolTypeDef.h
+++ b/bcos-framework/bcos-framework/txpool/TxPoolTypeDef.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 #include "bcos-crypto/interfaces/crypto/CommonType.h"
+#include <bcos-utilities/BoostLog.h>
 
 #define TXPOOL_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("TXPOOL")
 

--- a/bcos-front/bcos-front/Common.h
+++ b/bcos-front/bcos-front/Common.h
@@ -20,5 +20,6 @@
 #pragma once
 
 #include <bcos-framework/Common.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define FRONT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[FrontService]"

--- a/bcos-gateway/bcos-gateway/Common.h
+++ b/bcos-gateway/bcos-gateway/Common.h
@@ -19,6 +19,7 @@
  */
 #pragma once
 #include "libnetwork/Common.h"
+#include <bcos-utilities/BoostLog.h>
 
 #define GATEWAY_LOG(LEVEL) BCOS_LOG(LEVEL) << "[Gateway][Gateway]"
 #define GATEWAY_CONFIG_LOG(LEVEL) BCOS_LOG(LEVEL) << "[Gateway][Config]"

--- a/bcos-gateway/bcos-gateway/GatewayConfig.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayConfig.cpp
@@ -18,6 +18,8 @@
 #include <limits>
 #include <string>
 #include <vector>
+#include <boost/algorithm/string.hpp>
+#include <boost/exception_ptr.hpp>
 
 using namespace bcos;
 using namespace security;

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -36,6 +36,7 @@
 #include <openssl/x509.h>
 #include <exception>
 #include <optional>
+#include <boost/exception_ptr.hpp>
 
 using namespace bcos::rpc;
 using namespace bcos;

--- a/bcos-gateway/bcos-gateway/libamop/Common.h
+++ b/bcos-gateway/bcos-gateway/libamop/Common.h
@@ -26,6 +26,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <bcos-utilities/BoostLog.h>
 
 #define TOPIC_LOG(LEVEL) BCOS_LOG(LEVEL) << "[AMOP][TOPIC]"
 #define AMOP_MSG_LOG(LEVEL) BCOS_LOG(LEVEL) << "[AMOP][MSG]"

--- a/bcos-gateway/bcos-gateway/libnetwork/Common.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Common.h
@@ -13,6 +13,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <set>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 namespace ba = boost::asio;
 namespace bi = boost::asio::ip;

--- a/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Host.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <set>
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 
 using namespace bcos;

--- a/bcos-gateway/bcos-gateway/libp2p/Common.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Common.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "bcos-gateway/libnetwork/Common.h"
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos
 {

--- a/bcos-gateway/test/main/main.cpp
+++ b/bcos-gateway/test/main/main.cpp
@@ -22,6 +22,7 @@
 #include <thread>
 
 #include "../common/FrontServiceBuilder.h"
+#include <bcos-utilities/BoostLog.h>
 
 using namespace std;
 using namespace bcos;

--- a/bcos-gateway/test/main/p2p_echo_perf.cpp
+++ b/bcos-gateway/test/main/p2p_echo_perf.cpp
@@ -31,6 +31,7 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace std;
 using namespace bcos;

--- a/bcos-gateway/test/unittests/GatewayFactoryTest.cpp
+++ b/bcos-gateway/test/unittests/GatewayFactoryTest.cpp
@@ -24,6 +24,7 @@
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 
 #include <boost/test/unit_test.hpp>
+#include <boost/algorithm/string.hpp>
 using namespace bcos;
 using namespace gateway;
 using namespace bcos::test;

--- a/bcos-leader-election/src/Common.h
+++ b/bcos-leader-election/src/Common.h
@@ -18,4 +18,5 @@
  * @date 2022-04-26
  */
 #include <bcos-utilities/Common.h>
+#include <bcos-utilities/BoostLog.h>
 #define ELECTION_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("Election")

--- a/bcos-leader-election/src/ElectionConfig.cpp
+++ b/bcos-leader-election/src/ElectionConfig.cpp
@@ -20,6 +20,7 @@
  */
 #include "ElectionConfig.h"
 #include "bcos-utilities/BoostLog.h"
+#include <boost/thread/thread.hpp>
 
 using namespace bcos;
 using namespace bcos::election;

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -77,6 +77,7 @@
 #include <range/v3/view/concat.hpp>
 #include <range/v3/view/take.hpp>
 #include <utility>
+#include <list>
 
 using namespace bcos;
 using namespace bcos::ledger;

--- a/bcos-ledger/bcos-ledger/Ledger.h
+++ b/bcos-ledger/bcos-ledger/Ledger.h
@@ -33,6 +33,7 @@
 #include <bcos-utilities/IOServicePool.h>
 #include <boost/compute/detail/lru_cache.hpp>
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 #define LEDGER_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("LEDGER")
 

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -29,6 +29,7 @@
 #include <concepts>
 #include <optional>
 #include <type_traits>
+#include <bcos-utilities/BoostLog.h>
 
 #define LEDGER2_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("LEDGER2")
 namespace bcos::ledger

--- a/bcos-ledger/test/mock/MockStorage.h
+++ b/bcos-ledger/test/mock/MockStorage.h
@@ -24,6 +24,7 @@
 #include "bcos-framework/storage/StorageInterface.h"
 #include "bcos-framework/storage/Table.h"
 #include <bcos-utilities/IOServicePool.h>
+#include <boost/thread/thread.hpp>
 #define SLEEP_MILLI_SECONDS 10
 
 using namespace bcos::storage;

--- a/bcos-pbft/bcos-pbft/core/Common.h
+++ b/bcos-pbft/bcos-pbft/core/Common.h
@@ -21,6 +21,7 @@
 #include <bcos-framework/Common.h>
 #include <bcos-framework/consensus/ConsensusTypeDef.h>
 #include <bcos-utilities/Exceptions.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define CONSENSUS_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("CONSENSUS") << LOG_BADGE("Core")
 namespace bcos::consensus

--- a/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.h
+++ b/bcos-pbft/bcos-pbft/pbft/storage/LedgerStorage.h
@@ -27,6 +27,9 @@
 #include <bcos-utilities/IOServicePool.h>
 
 #include <utility>
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
 
 namespace bcos::consensus
 {

--- a/bcos-pbft/bcos-pbft/pbft/utilities/Common.h
+++ b/bcos-pbft/bcos-pbft/pbft/utilities/Common.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string>
 #include <string_view>
+#include <bcos-utilities/BoostLog.h>
 
 #define PBFT_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("CONSENSUS") << LOG_BADGE("PBFT")
 #define PBFT_STORAGE_LOG(LEVEL) \

--- a/bcos-protocol/bcos-protocol/Common.h
+++ b/bcos-protocol/bcos-protocol/Common.h
@@ -25,6 +25,7 @@
 #include <limits>
 #include <algorithm>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::protocol
 {

--- a/bcos-protocol/bcos-protocol/amop/TopicItem.h
+++ b/bcos-protocol/bcos-protocol/amop/TopicItem.h
@@ -25,6 +25,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <bcos-utilities/BoostLog.h>
 namespace bcos
 {
 namespace protocol

--- a/bcos-rpbft/bcos-rpbft/rpbft/utilities/Common.h
+++ b/bcos-rpbft/bcos-rpbft/rpbft/utilities/Common.h
@@ -21,6 +21,7 @@
 #include <bcos-framework/Common.h>
 #include <bcos-utilities/Exceptions.h>
 #include <stdint.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define RPBFT_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("CONSENSUS") << LOG_BADGE("RPBFT")
 #define RPBFT_STORAGE_LOG(LEVEL) \

--- a/bcos-rpc/bcos-rpc/Common.h
+++ b/bcos-rpc/bcos-rpc/Common.h
@@ -25,6 +25,7 @@
 #include <boost/iostreams/filtering_stream.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <iostream>
+#include <bcos-utilities/BoostLog.h>
 
 #define RPC_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("RPC")
 

--- a/bcos-rpc/bcos-rpc/RpcFactory.cpp
+++ b/bcos-rpc/bcos-rpc/RpcFactory.cpp
@@ -41,6 +41,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::rpc;

--- a/bcos-rpc/bcos-rpc/amop/AMOPClient.h
+++ b/bcos-rpc/bcos-rpc/amop/AMOPClient.h
@@ -27,6 +27,7 @@
 #include <servant/Application.h>
 
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 #define AMOP_CLIENT_LOG(level) BCOS_LOG(level) << LOG_BADGE("AMOPClient")
 

--- a/bcos-rpc/bcos-rpc/amop/AirAMOPClient.h
+++ b/bcos-rpc/bcos-rpc/amop/AirAMOPClient.h
@@ -22,6 +22,7 @@
 #include "AMOPClient.h"
 
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::rpc
 {

--- a/bcos-rpc/bcos-rpc/event/Common.h
+++ b/bcos-rpc/bcos-rpc/event/Common.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "bcos-framework/Common.h"
+#include <bcos-utilities/BoostLog.h>
 
 // The largest number of topic in one event log
 #define EVENT_LOG_TOPICS_MAX_INDEX (4)

--- a/bcos-rpc/bcos-rpc/filter/Common.h
+++ b/bcos-rpc/bcos-rpc/filter/Common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "bcos-framework/Common.h"
+#include <bcos-utilities/BoostLog.h>
 
 // The largest number of topic in one event log
 #define EVENT_LOG_TOPICS_MAX_INDEX (4)

--- a/bcos-rpc/bcos-rpc/groupmgr/GroupManager.h
+++ b/bcos-rpc/bcos-rpc/groupmgr/GroupManager.h
@@ -22,6 +22,7 @@
 #include "NodeService.h"
 #include <bcos-tool/NodeConfig.h>
 #include <bcos-utilities/Timer.h>
+#include <bcos-utilities/BoostLog.h>
 namespace bcos::rpc
 {
 class GroupManager : public std::enable_shared_from_this<GroupManager>

--- a/bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp
+++ b/bcos-rpc/bcos-rpc/groupmgr/NodeService.cpp
@@ -27,6 +27,7 @@
 #include <bcos-tars-protocol/client/PBFTServiceClient.h>
 #include <bcos-tars-protocol/client/SchedulerServiceClient.h>
 #include <bcos-tars-protocol/client/TxPoolServiceClient.h>
+#include <bcos-utilities/BoostLog.h>
 using namespace bcos;
 using namespace bcos::rpc;
 using namespace bcos::crypto;

--- a/bcos-rpc/bcos-rpc/jsonrpc/Common.h
+++ b/bcos-rpc/bcos-rpc/jsonrpc/Common.h
@@ -23,6 +23,7 @@
 #include "bcos-utilities/Error.h"
 #include <json/json.h>
 #include <exception>
+#include <bcos-utilities/BoostLog.h>
 
 #define RPC_IMPL_LOG(LEVEL) BCOS_LOG(LEVEL) << "[RPC][JSONRPC]"
 #define WEB3_LOG(LEVEL) BCOS_LOG(LEVEL) << "[RPC][WEB3]"

--- a/bcos-rpc/bcos-rpc/validator/TxValidator.cpp
+++ b/bcos-rpc/bcos-rpc/validator/TxValidator.cpp
@@ -23,6 +23,7 @@
 #include "bcos-ledger/LedgerMethods.h"
 #include <bcos-framework/ledger/Ledger.h>
 #include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::rpc
 {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -52,6 +52,7 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::rpc;

--- a/bcos-scheduler/src/BlockExecutive.cpp
+++ b/bcos-scheduler/src/BlockExecutive.cpp
@@ -17,6 +17,7 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
+#include <boost/algorithm/string.hpp>
 #include <atomic>
 #include <chrono>
 #include <cstdint>

--- a/bcos-scheduler/src/Common.h
+++ b/bcos-scheduler/src/Common.h
@@ -3,6 +3,7 @@
 #include <bcos-framework/dispatcher/SchedulerTypeDef.h>
 #include <cstdint>
 #include <tuple>
+#include <bcos-utilities/BoostLog.h>
 #define SCHEDULER_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("SCHEDULER")
 #define SCHEDULER_BLK_LOG(LEVEL, NUMBER) \
     BCOS_LOG(LEVEL) << LOG_BADGE("SCHEDULER") << BLOCK_NUMBER(NUMBER)

--- a/bcos-scheduler/src/DmcExecutor.cpp
+++ b/bcos-scheduler/src/DmcExecutor.cpp
@@ -2,6 +2,7 @@
 #include "bcos-crypto/bcos-crypto/ChecksumAddress.h"
 #include "bcos-framework/executor/ExecuteError.h"
 #include <bcos-protocol/TransactionStatus.h>
+#include <list>
 
 
 using namespace bcos::scheduler;

--- a/bcos-scheduler/src/Executive.h
+++ b/bcos-scheduler/src/Executive.h
@@ -5,6 +5,7 @@
 #include <bcos-utilities/Error.h>
 #include <sstream>
 #include <stack>
+#include <list>
 
 namespace bcos::scheduler
 {

--- a/bcos-scheduler/src/ExecutorManager.h
+++ b/bcos-scheduler/src/ExecutorManager.h
@@ -10,6 +10,8 @@
 #include <queue>
 #include <string>
 #include <unordered_map>
+#include <boost/iterator/transform_iterator.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::scheduler
 {

--- a/bcos-scheduler/src/GraphKeyLocks.h
+++ b/bcos-scheduler/src/GraphKeyLocks.h
@@ -6,6 +6,7 @@
 #include <gsl/span>
 #include <string_view>
 #include <variant>
+#include <bcos-utilities/BoostLog.h>
 
 #define KEY_LOCK_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("SCHEDULER") << LOG_BADGE("KEY_LOCK")
 // #define KEY_LOCK_LOG(LEVEL) std::cout << LOG_BADGE("KEY_LOCK")

--- a/bcos-scheduler/src/SchedulerManager.cpp
+++ b/bcos-scheduler/src/SchedulerManager.cpp
@@ -1,5 +1,6 @@
 #include "SchedulerManager.h"
 #include <chrono>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos::scheduler;
 

--- a/bcos-scheduler/test/testExecutivePool.cpp
+++ b/bcos-scheduler/test/testExecutivePool.cpp
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <boost/test/unit_test.hpp>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 
 using namespace bcos::scheduler;

--- a/bcos-sdk/bcos-cpp-sdk/tarsRPC/RPCClient.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/tarsRPC/RPCClient.cpp
@@ -3,6 +3,7 @@
 #include "bcos-utilities/Exceptions.h"
 #include <boost/throw_exception.hpp>
 #include <iterator>
+#include <boost/algorithm/string.hpp>
 
 struct InvalidHostPortStringError : public bcos::Exception
 {

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIDefinition.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIDefinition.cpp
@@ -30,6 +30,7 @@
 #include <optional>
 #include <stdexcept>
 #include <vector>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::cppsdk;

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIDefinitionFactory.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIDefinitionFactory.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <type_traits>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::cppsdk;

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIMethodDefinition.cpp
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIMethodDefinition.cpp
@@ -20,6 +20,7 @@
 
 #include <bcos-cpp-sdk/utilities/abi/ContractABIMethodDefinition.h>
 #include <stdexcept>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::cppsdk;

--- a/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIMethodDefinition.h
+++ b/bcos-sdk/bcos-cpp-sdk/utilities/abi/ContractABIMethodDefinition.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <boost/algorithm/string.hpp>
 
 namespace bcos
 {

--- a/bcos-sdk/sample/tars/performanceTransfer.cpp
+++ b/bcos-sdk/sample/tars/performanceTransfer.cpp
@@ -18,6 +18,7 @@
 #include <exception>
 #include <string>
 #include <thread>
+#include <boost/atomic.hpp>
 
 std::atomic_long g_blockNumber = 0;
 constexpr static long blockLimit = 900;

--- a/bcos-sdk/sample/tars/performanceTransfer20.cpp
+++ b/bcos-sdk/sample/tars/performanceTransfer20.cpp
@@ -24,6 +24,7 @@
 #include <exception>
 #include <string>
 #include <thread>
+#include <boost/atomic.hpp>
 
 std::atomic_long g_blockNumber = 0;
 constexpr static long blockLimit = 900;

--- a/bcos-sealer/bcos-sealer/Common.h
+++ b/bcos-sealer/bcos-sealer/Common.h
@@ -19,4 +19,5 @@
  */
 #pragma once
 #include <bcos-framework/Common.h>
+#include <bcos-utilities/BoostLog.h>
 #define SEAL_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("CONSENSUS") << LOG_BADGE("SEALER")

--- a/bcos-sealer/bcos-sealer/SealingManager.h
+++ b/bcos-sealer/bcos-sealer/SealingManager.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <functional>
 #include <tuple>
+#include <deque>
 
 namespace bcos::sealer
 {

--- a/bcos-sealer/test/CMakeLists.txt
+++ b/bcos-sealer/test/CMakeLists.txt
@@ -20,6 +20,10 @@ file(GLOB_RECURSE SOURCES "./*.cpp")
 set(TEST_BINARY_NAME test-sealer)
 
 add_executable(${TEST_BINARY_NAME} ${SOURCES})
+set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
+# main.cpp defines BOOST_TEST_MODULE (the test runner entry point); keep it out of the
+# unity batch per project convention (bcos-ledger/test/CMakeLists.txt).
+set_source_files_properties(main.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 target_include_directories(${TEST_BINARY_NAME} PRIVATE . ../bcos-sealer)
 
 find_package(Boost REQUIRED unit_test_framework log)

--- a/bcos-sealer/test/unittests/FIB153_HookSysTxGateTest.cpp
+++ b/bcos-sealer/test/unittests/FIB153_HookSysTxGateTest.cpp
@@ -130,7 +130,7 @@ struct FIB153Fixture
     sealer::SealerConfig::Ptr sealerConfig;
 };
 
-inline std::vector<bcos::protocol::TransactionMetaData::Ptr> makeMetaDataBatch(size_t count)
+inline std::vector<bcos::protocol::TransactionMetaData::Ptr> makeMetaDataBatch153(size_t count)
 {
     std::vector<bcos::protocol::TransactionMetaData::Ptr> batch;
     batch.reserve(count);
@@ -153,7 +153,7 @@ inline std::shared_ptr<HookGateSealingManager> makeHookGateManager(sealer::Seale
     // sees txsSize >= m_maxTxsPerBlock and lets execution proceed to the
     // hook gate we want to test. Without this seed the FIB-117 inner re-check
     // would short-circuit before the gate is reached.
-    auto seed = makeMetaDataBatch(4);
+    auto seed = makeMetaDataBatch153(4);
     mgr->testOnlySeedPendingTxs(seed);
     return mgr;
 }
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(hook_added_sys_tx_advances_waitUntil)
 
     // Hook synthesises a sys-tx and appends it directly to the block — same
     // shape as VRFBasedSealer::generateTransactionForRotating.
-    auto syntheticSysTx = makeMetaDataBatch(1).front();
+    auto syntheticSysTx = makeMetaDataBatch153(1).front();
     int hookCalls = 0;
     auto [containsSysTxs, block] =
         mgr->generateProposal([&](bcos::protocol::Block::Ptr _block) -> uint16_t {

--- a/bcos-sealer/test/unittests/FIB163_TimestampSaturateTest.cpp
+++ b/bcos-sealer/test/unittests/FIB163_TimestampSaturateTest.cpp
@@ -113,7 +113,7 @@ struct FIB163Fixture
     sealer::SealerConfig::Ptr sealerConfig;
 };
 
-inline std::vector<bcos::protocol::TransactionMetaData::Ptr> makeMetaDataBatch(size_t count)
+inline std::vector<bcos::protocol::TransactionMetaData::Ptr> makeMetaDataBatch163(size_t count)
 {
     std::vector<bcos::protocol::TransactionMetaData::Ptr> batch;
     batch.reserve(count);
@@ -133,7 +133,7 @@ inline std::shared_ptr<sealer::SealingManager> makeSealingManagerWithSeed(
 {
     auto mgr = std::make_shared<sealer::SealingManager>(std::move(config));
     mgr->resetSealingInfo(/*start*/ 2, /*end*/ 1'000'000, /*maxTxsPerBlock*/ 1);
-    auto seed = makeMetaDataBatch(4);
+    auto seed = makeMetaDataBatch163(4);
     mgr->testOnlySeedPendingTxs(seed);
     return mgr;
 }

--- a/bcos-security/bcos-security/BcosKms.h
+++ b/bcos-security/bcos-security/BcosKms.h
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 namespace Json
 {

--- a/bcos-security/bcos-security/BcosKmsDataEncryption.cpp
+++ b/bcos-security/bcos-security/BcosKmsDataEncryption.cpp
@@ -26,6 +26,8 @@
 #include <bcos-crypto/encrypt/SM4Crypto.h>
 #include <bcos-framework/protocol/Protocol.h>
 #include <bcos-utilities/DataConvertUtility.h>
+#include <boost/algorithm/string.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace crypto;

--- a/bcos-security/bcos-security/BcosKmsKeyEncryption.cpp
+++ b/bcos-security/bcos-security/BcosKmsKeyEncryption.cpp
@@ -33,6 +33,8 @@
 #include <bcos-utilities/Base64.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/FileUtility.h>
+#include <boost/algorithm/string.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace crypto;

--- a/bcos-security/bcos-security/cloudkms/CloudKmsKeyEncryption.cpp
+++ b/bcos-security/bcos-security/cloudkms/CloudKmsKeyEncryption.cpp
@@ -27,6 +27,7 @@
 #include "bcos-utilities/FileUtility.h"
 #include "utils.h"
 #include <aws/core/Aws.h>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::security
 {

--- a/bcos-storage/bcos-storage/RocksDBStorage.cpp
+++ b/bcos-storage/bcos-storage/RocksDBStorage.cpp
@@ -37,6 +37,7 @@
 #include <mutex>
 #include <optional>
 #include <variant>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos::storage;
 using namespace bcos::protocol;

--- a/bcos-sync/bcos-sync/state/DownloadingQueue.h
+++ b/bcos-sync/bcos-sync/state/DownloadingQueue.h
@@ -23,6 +23,7 @@
 #include "bcos-sync/interfaces/BlocksMsgInterface.h"
 #include <bcos-framework/protocol/Block.h>
 #include <queue>
+#include <list>
 namespace bcos::sync
 {
 // increase order

--- a/bcos-sync/bcos-sync/utilities/Common.h
+++ b/bcos-sync/bcos-sync/utilities/Common.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <bcos-framework/Common.h>
 #include <tbb/parallel_for.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define BLKSYNC_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("BLOCK SYNC")
 namespace bcos::sync

--- a/bcos-sync/bcos-sync/utilities/SyncTreeTopology.h
+++ b/bcos-sync/bcos-sync/utilities/SyncTreeTopology.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <bcos-tool/TreeTopology.h>
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 #define SYNCTREE_LOG(LEVEL)                                                      \
     BCOS_LOG(LEVEL) << LOG_BADGE("SYNCTREE") << LOG_KV("nodeIndex", m_nodeIndex) \

--- a/bcos-table/src/CacheStorageFactory.cpp
+++ b/bcos-table/src/CacheStorageFactory.cpp
@@ -1,5 +1,6 @@
 #include "CacheStorageFactory.h"
 #include "StateStorage.h"
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos::storage;
 

--- a/bcos-table/src/ContractShardUtils.h
+++ b/bcos-table/src/ContractShardUtils.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include <bcos-table/src/StorageWrapper.h>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::storage
 {

--- a/bcos-table/src/KeyPageStorage.h
+++ b/bcos-table/src/KeyPageStorage.h
@@ -48,6 +48,7 @@
 #include <string_view>
 #include <thread>
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 #define KeyPage_LOG(LEVEL) BCOS_LOG(LEVEL) << "[STORAGE-KeyPage]"
 namespace std

--- a/bcos-table/src/StateStorageInterface.cpp
+++ b/bcos-table/src/StateStorageInterface.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "StateStorageInterface.h"
+#include <list>
 
 using namespace bcos::storage;
 

--- a/bcos-table/src/StateStorageInterface.h
+++ b/bcos-table/src/StateStorageInterface.h
@@ -32,6 +32,7 @@
 #include <optional>
 #include <shared_mutex>
 #include <type_traits>
+#include <list>
 
 namespace bcos::storage
 {

--- a/bcos-table/src/StorageInterface.cpp
+++ b/bcos-table/src/StorageInterface.cpp
@@ -1,6 +1,7 @@
 #include "bcos-framework/storage/StorageInterface.h"
 #include "bcos-framework/storage/Table.h"
 #include <optional>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos::storage;
 

--- a/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
+++ b/bcos-table/test/unittests/libtable/TestKeyPageStorage.cpp
@@ -41,6 +41,8 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <list>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::storage;

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -25,6 +25,7 @@
 #include <bcos-framework/gateway/GatewayInterface.h>
 #include <range/v3/view/any_view.hpp>
 #include <string>
+#include <bcos-utilities/BoostLog.h>
 
 #define GATEWAYCLIENT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[GATEWAYCLIENT][INITIALIZER]"
 #define GATEWAYCLIENT_BADGE "[GATEWAYCLIENT]"

--- a/bcos-tars-protocol/bcos-tars-protocol/client/LedgerServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/LedgerServiceClient.cpp
@@ -23,6 +23,7 @@
 #include "../protocol/BlockImpl.h"
 #include "../protocol/TransactionImpl.h"
 #include "../protocol/TransactionReceiptImpl.h"
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcostars;
 

--- a/bcos-tars-protocol/bcos-tars-protocol/client/SchedulerServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/SchedulerServiceClient.cpp
@@ -24,6 +24,7 @@
 #include "../protocol/TransactionImpl.h"
 #include "../protocol/TransactionReceiptImpl.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcostars;
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderFactoryImpl.cpp
@@ -1,6 +1,7 @@
 #include "BlockHeaderFactoryImpl.h"
 #include "../impl/TarsHashable.h"
 #include "bcos-tars-protocol/protocol/BlockHeaderImpl.h"
+#include <bcos-utilities/BoostLog.h>
 
 bcostars::protocol::BlockHeaderFactoryImpl::BlockHeaderFactoryImpl(
     bcos::crypto::CryptoSuite::Ptr cryptoSuite)

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/BlockHeaderImpl.cpp
@@ -36,6 +36,7 @@
 #include <range/v3/view/any_view.hpp>
 #include <range/v3/view/transform.hpp>
 #include <stdexcept>
+#include <bcos-utilities/BoostLog.h>
 
 DERIVE_BCOS_EXCEPTION(EmptyBlockHeaderHash);
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionFactoryImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionFactoryImpl.cpp
@@ -1,5 +1,6 @@
 #include "TransactionFactoryImpl.h"
 #include "../impl/TarsHashable.h"
+#include <bcos-utilities/BoostLog.h>
 
 bcostars::protocol::TransactionFactoryImpl::TransactionFactoryImpl(
     bcos::crypto::CryptoSuite::Ptr cryptoSuite)

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.cpp
@@ -1,5 +1,6 @@
 #include "TransactionReceiptFactoryImpl.h"
 #include "../impl/TarsHashable.h"
+#include <bcos-utilities/BoostLog.h>
 
 bcostars::protocol::TransactionReceiptImpl::Ptr
 bcostars::protocol::TransactionReceiptFactoryImpl::createReceipt() const

--- a/bcos-tool/bcos-tool/BfsFileFactory.cpp
+++ b/bcos-tool/bcos-tool/BfsFileFactory.cpp
@@ -26,6 +26,7 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/serialization/vector.hpp>
 #include <future>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos::tool;
 using namespace bcos::storage;

--- a/bcos-tool/bcos-tool/NodeConfig.h
+++ b/bcos-tool/bcos-tool/NodeConfig.h
@@ -32,6 +32,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <cstddef>
 #include <unordered_map>
+#include <bcos-utilities/BoostLog.h>
 
 #define NodeConfig_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("NodeConfig")
 namespace bcos::tool

--- a/bcos-tool/bcos-tool/NodeTimeMaintenance.h
+++ b/bcos-tool/bcos-tool/NodeTimeMaintenance.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <bcos-crypto/interfaces/crypto/KeyInterface.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define TIMESYNC_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("TIMESYNC")
 

--- a/bcos-tool/bcos-tool/TreeTopology.h
+++ b/bcos-tool/bcos-tool/TreeTopology.h
@@ -22,6 +22,7 @@
 
 #include "bcos-crypto/KeyCompareTools.h"
 #include <bcos-crypto/interfaces/crypto/KeyFactory.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define TREE_LOG(LEVEL)                                                      \
     BCOS_LOG(LEVEL) << LOG_BADGE("TREE") << LOG_KV("consIndex", m_consIndex) \

--- a/bcos-tool/bcos-tool/VersionConverter.h
+++ b/bcos-tool/bcos-tool/VersionConverter.h
@@ -22,6 +22,7 @@
 #pragma once
 #include "Exceptions.h"
 #include <bcos-framework/protocol/Protocol.h>
+#include <boost/algorithm/string.hpp>
 #include <string>
 #include <vector>
 

--- a/bcos-txpool/bcos-txpool/sync/utilities/Common.h
+++ b/bcos-txpool/bcos-txpool/sync/utilities/Common.h
@@ -21,6 +21,7 @@
 #pragma once
 #include <bcos-framework/Common.h>
 #include <tbb/parallel_for.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define SYNC_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("SYNC")
 namespace bcos::sync

--- a/bcos-txpool/bcos-txpool/txpool/interfaces/NonceCheckerInterface.h
+++ b/bcos-txpool/bcos-txpool/txpool/interfaces/NonceCheckerInterface.h
@@ -23,6 +23,7 @@
 #include <bcos-framework/protocol/Transaction.h>
 #include <bcos-protocol/TransactionStatus.h>
 #include <tbb/concurrent_unordered_set.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define NONCECHECKER_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("TXPOOL") << LOG_BADGE("NonceChecker")
 

--- a/bcos-txpool/bcos-txpool/txpool/interfaces/TxValidatorInterface.h
+++ b/bcos-txpool/bcos-txpool/txpool/interfaces/TxValidatorInterface.h
@@ -24,6 +24,7 @@
 #include "bcos-txpool/txpool/validator/Web3NonceChecker.h"
 #include <bcos-framework/protocol/Transaction.h>
 #include <bcos-protocol/TransactionStatus.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define TX_VALIDATOR_CHECKER_LOG(LEVEL) \
     BCOS_LOG(LEVEL) << LOG_BADGE("TXValidator") << LOG_BADGE("CHECKER")

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.h
@@ -29,6 +29,7 @@
 #include <bcos-txpool/txpool/validator/Web3NonceChecker.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <algorithm>
+#include <boost/algorithm/string.hpp>
 
 namespace bcos::txpool
 {

--- a/bcos-txpool/test/unittests/sync/TxpoolSyncByTreeTest.cpp
+++ b/bcos-txpool/test/unittests/sync/TxpoolSyncByTreeTest.cpp
@@ -35,6 +35,7 @@
 #include <boost/test/unit_test.hpp>
 #include <chrono>
 #include <thread>
+#include <bcos-utilities/BoostLog.h>
 using namespace bcos;
 using namespace bcos::sync;
 using namespace bcos::crypto;

--- a/bcos-txpool/test/unittests/txpool/TxPoolFixture.h
+++ b/bcos-txpool/test/unittests/txpool/TxPoolFixture.h
@@ -43,6 +43,8 @@
 #include <boost/test/unit_test.hpp>
 #include <chrono>
 #include <thread>
+#include <list>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::protocol;

--- a/bcos-utilities/bcos-utilities/BoostLog.cpp
+++ b/bcos-utilities/bcos-utilities/BoostLog.cpp
@@ -23,6 +23,7 @@
  * @brief: add file collector
  */
 #include "GzTools.h"
+#include "BoostLogCollector.h"
 #include "Log.h"
 #include <boost/date_time/time_facet.hpp>
 #include <boost/enable_shared_from_this.hpp>
@@ -40,6 +41,7 @@
 #include <boost/system/detail/error_category.hpp>
 #include <boost/system/detail/error_code.hpp>
 #include <utility>
+#include <list>
 namespace bcos
 {
 std::string const FileLogger = "FileLogger";

--- a/bcos-utilities/bcos-utilities/BoostLog.h
+++ b/bcos-utilities/bcos-utilities/BoostLog.h
@@ -45,9 +45,6 @@
 #undef FATAL
 #endif
 
-#include <boost/log/attributes/constant.hpp>
-#include <boost/log/attributes/scoped_attribute.hpp>
-#include <boost/log/sinks/text_file_backend.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/trivial.hpp>
 
@@ -110,12 +107,5 @@ void setStatLogLevel(LogLevel const& _level);
         bcos::FileLoggerHandler, (boost::log::trivial::severity_level)(bcos::LogLevel::level))
 // for block number log
 #define BLOCK_NUMBER(NUMBER) "[blk-" << (NUMBER) << "]"
-
-namespace log
-{
-boost::shared_ptr<boost::log::sinks::file::collector> make_collector(
-    boost::filesystem::path const& target_dir, uintmax_t max_size, uintmax_t min_free_space,
-    uintmax_t max_files, bool convert_tar_gz);
-}
 
 }  // namespace bcos

--- a/bcos-utilities/bcos-utilities/BoostLogCollector.h
+++ b/bcos-utilities/bcos-utilities/BoostLogCollector.h
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (C) 2021 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ * @brief: log file collector factory, split out of BoostLog.h so that the heavy
+ *         boost.log text_file_backend sink header is only paid by its few users
+ *         (BoostLog.cpp, BoostLogInitializer.cpp, TestBoostLog.cpp)
+ *
+ * @file: BoostLogCollector.h
+ */
+#pragma once
+
+#include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/shared_ptr.hpp>
+#include <cstdint>
+
+namespace bcos::log
+{
+boost::shared_ptr<boost::log::sinks::file::collector> make_collector(
+    boost::filesystem::path const& target_dir, uintmax_t max_size, uintmax_t min_free_space,
+    uintmax_t max_files, bool convert_tar_gz);
+}  // namespace bcos::log

--- a/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
+++ b/bcos-utilities/bcos-utilities/BoostLogInitializer.cpp
@@ -19,11 +19,13 @@
  * @author: yujiechen
  */
 #include "BoostLogInitializer.h"
+#include "BoostLogCollector.h"
 #include "BoostLogThreadNameAttribute.h"
 #include "bcos-framework/Common.h"
 #include "bcos-framework/bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/RateCollector.h"
+#include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/core/null_deleter.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/bcos-utilities/bcos-utilities/Common.h
+++ b/bcos-utilities/bcos-utilities/Common.h
@@ -19,9 +19,9 @@
 
 #include "RefDataContainer.h"
 #include <boost/algorithm/hex.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
-#include <boost/thread.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/shared_mutex.hpp>
 #include <map>
 #include <mutex>
 #include <string>

--- a/bcos-utilities/bcos-utilities/Exceptions.h
+++ b/bcos-utilities/bcos-utilities/Exceptions.h
@@ -23,11 +23,9 @@
 #include <boost/exception/errinfo_api_function.hpp>
 #include <boost/exception/exception.hpp>
 #include <boost/exception/info.hpp>
-#include <boost/exception/info_tuple.hpp>
 #include <boost/stacktrace.hpp>
 #include <boost/stacktrace/stacktrace_fwd.hpp>
 #include <boost/throw_exception.hpp>
-#include <boost/tuple/tuple.hpp>
 #include <exception>
 #include <string>
 

--- a/bcos-utilities/bcos-utilities/FixedBytes.h
+++ b/bcos-utilities/bcos-utilities/FixedBytes.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include "BoostLog.h"
 #include "DataConvertUtility.h"
 #include "Exceptions.h"
 #include <boost/algorithm/hex.hpp>
@@ -435,11 +434,9 @@ private:
         {
             if (_bytesData.size() != N)
             {
-                BCOS_LOG(WARNING) << LOG_DESC("ConstructFixedBytesFailed")
-                                  << LOG_KV("requiredLen", N)
-                                  << LOG_KV("dataLen", _bytesData.size());
                 BOOST_THROW_EXCEPTION(ConstructFixedBytesFailed() << errinfo_comment(
-                                          "Require " + std::to_string(N) + " length input data"));
+                                          "Require " + std::to_string(N) + " length input data, got " +
+                                          std::to_string(_bytesData.size())));
             }
             memcpy(m_data.data(), _bytesData.data(), N);
             break;
@@ -448,177 +445,6 @@ private:
     }
 
     std::array<byte, N> m_data;  ///< The binary data.
-};
-
-template <unsigned T>
-class SecureFixedBytes : private FixedBytes<T>
-{
-public:
-    using DataAlignType = typename FixedBytes<T>::DataAlignType;
-    using StringDataType = typename FixedBytes<T>::StringDataType;
-    using ConstructorType = typename FixedBytes<T>::ConstructorType;
-    SecureFixedBytes() = default;
-    explicit SecureFixedBytes(
-        bytesConstRef _fixedBytesRef, DataAlignType _alignType = DataAlignType::AlignRight)
-      : FixedBytes<T>(_fixedBytesRef, _alignType)
-    {}
-
-    template <unsigned M>
-    explicit SecureFixedBytes(
-        FixedBytes<M> const& _fixedBytes, DataAlignType _alignType = DataAlignType::AlignLeft)
-      : FixedBytes<T>(_fixedBytes, _alignType)
-    {}
-    template <unsigned M>
-    explicit SecureFixedBytes(SecureFixedBytes<M> const& _secureFixedBytes,
-        DataAlignType _alignType = DataAlignType::AlignLeft)
-      : FixedBytes<T>(_secureFixedBytes.makeInsecure(), _alignType)
-    {}
-    explicit SecureFixedBytes(byte const* _bytesPtr, ConstructorType _type)
-      : FixedBytes<T>(_bytesPtr, _type)
-    {}
-    explicit SecureFixedBytes(std::string const& _stringData,
-        StringDataType _stringType = FixedBytes<T>::FromHex,
-        DataAlignType _alignType = DataAlignType::AlignRight)
-      : FixedBytes<T>(_stringData, _stringType, _alignType)
-    {}
-    SecureFixedBytes(SecureFixedBytes<T> const& _c) = default;
-    ~SecureFixedBytes() { ref().cleanMemory(); }
-    SecureFixedBytes<T>& operator=(SecureFixedBytes<T> const& _secureFixedBytes)
-    {
-        if (&_secureFixedBytes == this)
-        {
-            return *this;
-        }
-        ref().cleanMemory();
-        FixedBytes<T>::operator=(static_cast<FixedBytes<T> const&>(_secureFixedBytes));
-        return *this;
-    }
-    using FixedBytes<T>::size;
-
-    FixedBytes<T> const& makeInsecure() const { return static_cast<FixedBytes<T> const&>(*this); }
-    FixedBytes<T>& writable()
-    {
-        clear();
-        return static_cast<FixedBytes<T>&>(*this);
-    }
-
-    using FixedBytes<T>::operator bool;
-
-    // The obvious comparison operators.
-    bool operator==(SecureFixedBytes const& _c) const
-    {
-        return static_cast<FixedBytes<T> const&>(*this).operator==(
-            static_cast<FixedBytes<T> const&>(_c));
-    }
-    bool operator!=(SecureFixedBytes const& _c) const
-    {
-        return static_cast<FixedBytes<T> const&>(*this).operator!=(
-            static_cast<FixedBytes<T> const&>(_c));
-    }
-    bool operator<(SecureFixedBytes const& _c) const
-    {
-        return static_cast<FixedBytes<T> const&>(*this).operator<(
-            static_cast<FixedBytes<T> const&>(_c));
-    }
-    bool operator>=(SecureFixedBytes const& _c) const
-    {
-        return static_cast<FixedBytes<T> const&>(*this).operator>=(
-            static_cast<FixedBytes<T> const&>(_c));
-    }
-    bool operator<=(SecureFixedBytes const& _c) const
-    {
-        return static_cast<FixedBytes<T> const&>(*this).operator<=(
-            static_cast<FixedBytes<T> const&>(_c));
-    }
-    bool operator>(SecureFixedBytes const& _c) const
-    {
-        return static_cast<FixedBytes<T> const&>(*this).operator>(
-            static_cast<FixedBytes<T> const&>(_c));
-    }
-
-    using FixedBytes<T>::operator==;
-    using FixedBytes<T>::operator!=;
-    using FixedBytes<T>::operator<;
-    using FixedBytes<T>::operator>=;
-    using FixedBytes<T>::operator<=;
-    using FixedBytes<T>::operator>;
-
-    // The obvious binary operators.
-    SecureFixedBytes& operator^=(FixedBytes<T> const& _c)
-    {
-        static_cast<FixedBytes<T>&>(*this).operator^=(_c);
-        return *this;
-    }
-    SecureFixedBytes operator^(FixedBytes<T> const& _c) const
-    {
-        return SecureFixedBytes(*this) ^= _c;
-    }
-    SecureFixedBytes& operator|=(FixedBytes<T> const& _c)
-    {
-        static_cast<FixedBytes<T>&>(*this).operator^=(_c);
-        return *this;
-    }
-    SecureFixedBytes operator|(FixedBytes<T> const& _c) const
-    {
-        return SecureFixedBytes(*this) |= _c;
-    }
-    SecureFixedBytes& operator&=(FixedBytes<T> const& _c)
-    {
-        static_cast<FixedBytes<T>&>(*this).operator^=(_c);
-        return *this;
-    }
-    SecureFixedBytes operator&(FixedBytes<T> const& _c) const
-    {
-        return SecureFixedBytes(*this) &= _c;
-    }
-
-    SecureFixedBytes& operator^=(SecureFixedBytes const& _c)
-    {
-        static_cast<FixedBytes<T>&>(*this).operator^=(static_cast<FixedBytes<T> const&>(_c));
-        return *this;
-    }
-    SecureFixedBytes operator^(SecureFixedBytes const& _c) const
-    {
-        return SecureFixedBytes(*this) ^= _c;
-    }
-    SecureFixedBytes& operator|=(SecureFixedBytes const& _c)
-    {
-        static_cast<FixedBytes<T>&>(*this).operator^=(static_cast<FixedBytes<T> const&>(_c));
-        return *this;
-    }
-    SecureFixedBytes operator|(SecureFixedBytes const& _c) const
-    {
-        return SecureFixedBytes(*this) |= _c;
-    }
-    SecureFixedBytes& operator&=(SecureFixedBytes const& _c)
-    {
-        static_cast<FixedBytes<T>&>(*this).operator^=(static_cast<FixedBytes<T> const&>(_c));
-        return *this;
-    }
-    SecureFixedBytes operator&(SecureFixedBytes const& _c) const
-    {
-        return SecureFixedBytes(*this) &= _c;
-    }
-    SecureFixedBytes operator~() const
-    {
-        auto r = ~static_cast<FixedBytes<T> const&>(*this);
-        return static_cast<SecureFixedBytes const&>(r);
-    }
-
-    using FixedBytes<T>::abridged;
-
-    bytesConstRef ref() const { return FixedBytes<T>::ref(); }
-    byte const* data() const { return FixedBytes<T>::data(); }
-
-    static SecureFixedBytes<T> generateRandomFixedBytes()
-    {
-        SecureFixedBytes<T> randomFixedBytes;
-        randomFixedBytes.generateRandomFixedBytesByEngine(s_fixedBytesEngine);
-        return randomFixedBytes;
-    }
-    using FixedBytes<T>::firstBitSet;
-
-    void clear() { ref().cleanMemory(); }
 };
 
 /// Fast equality operator for h256.
@@ -654,15 +480,6 @@ inline std::istream& operator>>(std::istream& _in, FixedBytes<N>& o_h)
     _in >> s;
     o_h = FixedBytes<N>(s, FixedBytes<N>::FromHex, FixedBytes<N>::AlignRight);
     return _in;
-}
-
-/// Stream I/O for the SecureFixedBytes class.
-template <unsigned N>
-inline std::ostream& operator<<(std::ostream& _out, SecureFixedBytes<N> const& _h)
-{
-    _out << "SecureFixedBytes#" << std::hex << typename FixedBytes<N>::hash()(_h.makeInsecure())
-         << std::dec;
-    return _out;
 }
 
 // Common types of FixedBytes.

--- a/bcos-utilities/bcos-utilities/JsonDataConvertUtility.h
+++ b/bcos-utilities/bcos-utilities/JsonDataConvertUtility.h
@@ -43,14 +43,6 @@ std::string toJonString(boost::multiprecision::number<boost::multiprecision::cpp
     return "0x" + (hexString[0] == '0' ? (hexString.substr(1)) : hexString);
 }
 
-template <unsigned T>
-std::string toJonString(SecureFixedBytes<T> const& _i)
-{
-    std::stringstream stream;
-    stream << "0x" << _i.makeInsecure().hex();
-    return stream.str();
-}
-
 template <typename T>
 std::string toJonString(T const& _i)
 {

--- a/bcos-utilities/bcos-utilities/ratelimiter/RateLimiterInterface.h
+++ b/bcos-utilities/bcos-utilities/ratelimiter/RateLimiterInterface.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 #define RATELIMIT_LOG(LEVEL) BCOS_LOG(LEVEL) << "[RateLimiter]"
 
 namespace bcos

--- a/bcos-utilities/test/unittests/libutilities/TestBoostLog.cpp
+++ b/bcos-utilities/test/unittests/libutilities/TestBoostLog.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "bcos-utilities/Common.h"
+#include "bcos-utilities/BoostLogCollector.h"
 #include "bcos-utilities/BoostLog.h"
 #include <boost/test/unit_test.hpp>
 using namespace bcos;

--- a/ethereum-executor/EthereumExecutor.h
+++ b/ethereum-executor/EthereumExecutor.h
@@ -45,6 +45,7 @@
 #include <optional>
 #include <string>
 #include <system_error>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::executor_v1::eth
 {

--- a/ethereum-executor/tests/EESTRunner.cpp
+++ b/ethereum-executor/tests/EESTRunner.cpp
@@ -48,6 +48,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::storage2;

--- a/fisco-bcos-air/AirNodeInitializer.cpp
+++ b/fisco-bcos-air/AirNodeInitializer.cpp
@@ -31,6 +31,7 @@
 #include <bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.h>
 #include <bcos-tool/NodeConfig.h>
 #include <bcos-utilities/IOServicePool.h>
+#include <boost/atomic.hpp>
 
 using namespace bcos::node;
 using namespace bcos::initializer;

--- a/fisco-bcos-air/Common.cpp
+++ b/fisco-bcos-air/Common.cpp
@@ -21,6 +21,7 @@
 #include "Common.h"
 #include <clocale>
 #include <cstdlib>
+#include <boost/atomic.hpp>
 
 namespace bcos::node
 {

--- a/fisco-bcos-air/Common.h
+++ b/fisco-bcos-air/Common.h
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <ctime>
 #include <unistd.h>
+#include <boost/atomic.hpp>
 // clang-format on
 
 

--- a/fisco-bcos-demo/echo_client_sample.cpp
+++ b/fisco-bcos-demo/echo_client_sample.cpp
@@ -24,6 +24,7 @@
 #include <bcos-tool/NodeConfig.h>
 #include <bcos-utilities/BoostLogInitializer.h>
 #include <bcos-utilities/RateLimiter.h>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::gateway;

--- a/fisco-bcos-demo/echo_server_sample.cpp
+++ b/fisco-bcos-demo/echo_server_sample.cpp
@@ -23,6 +23,7 @@
 #include <bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.h>
 #include <bcos-tool/NodeConfig.h>
 #include <bcos-utilities/BoostLogInitializer.h>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos;
 using namespace bcos::gateway;

--- a/fisco-bcos-tars-service/ExecutorService/main/ExecutorServiceApp.h
+++ b/fisco-bcos-tars-service/ExecutorService/main/ExecutorServiceApp.h
@@ -28,6 +28,7 @@
 #include <bcos-utilities/IOServicePool.h>
 #include <bcos-utilities/Timer.h>
 #include <servant/Application.h>
+#include <bcos-utilities/BoostLog.h>
 
 #define EXECUTOR_SERVICE_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("ExecutorServiceApp")
 

--- a/fisco-bcos-tars-service/NodeService/NodeServiceApp.cpp
+++ b/fisco-bcos-tars-service/NodeService/NodeServiceApp.cpp
@@ -32,6 +32,7 @@
 #include <bcos-scheduler/src/SchedulerImpl.h>
 #include <bcos-tars-protocol/client/RpcServiceClient.h>
 #include <bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.h>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcostars;
 using namespace bcos;

--- a/fisco-bcos-tars-service/NodeService/max/CMakeLists.txt
+++ b/fisco-bcos-tars-service/NodeService/max/CMakeLists.txt
@@ -12,5 +12,6 @@ aux_source_directory(../../TxPoolService SRC_LIST)
 aux_source_directory(../../PBFTService SRC_LIST)
 
 add_executable(${MAX_NODE_SERVICE_BINARY_NAME} ${SRC_LIST} ${HEADERS})
+set_target_properties(${MAX_NODE_SERVICE_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 
 target_link_libraries(${MAX_NODE_SERVICE_BINARY_NAME} PUBLIC init pbft_init protocol-tars command)

--- a/fisco-bcos-tars-service/NodeService/pro/CMakeLists.txt
+++ b/fisco-bcos-tars-service/NodeService/pro/CMakeLists.txt
@@ -12,5 +12,6 @@ aux_source_directory(../../TxPoolService SRC_LIST)
 aux_source_directory(../../PBFTService SRC_LIST)
 
 add_executable(${PRO_NODE_SERVICE_BINARY_NAME} ${SRC_LIST} ${HEADERS})
+set_target_properties(${PRO_NODE_SERVICE_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 
 target_link_libraries(${PRO_NODE_SERVICE_BINARY_NAME} PUBLIC init pbft_init protocol-tars command)

--- a/fisco-bcos-tars-service/PBFTService/PBFTServiceServer.cpp
+++ b/fisco-bcos-tars-service/PBFTService/PBFTServiceServer.cpp
@@ -28,7 +28,7 @@ using namespace bcostars;
 using namespace bcos::consensus;
 using namespace bcos::initializer;
 
-Error PBFTServiceServer::asyncCheckBlock(
+bcostars::Error PBFTServiceServer::asyncCheckBlock(
     const Block& _block, tars::Bool&, tars::TarsCurrentPtr _current)
 {
     auto blockFactory = m_pbftInitializer->blockFactory();
@@ -42,7 +42,7 @@ Error PBFTServiceServer::asyncCheckBlock(
     return bcostars::Error();
 }
 
-Error PBFTServiceServer::asyncGetPBFTView(tars::Int64& _view, tars::TarsCurrentPtr _current)
+bcostars::Error PBFTServiceServer::asyncGetPBFTView(tars::Int64& _view, tars::TarsCurrentPtr _current)
 {
     _current->setResponse(false);
     m_pbftInitializer->pbft()->asyncGetPBFTView(
@@ -52,7 +52,7 @@ Error PBFTServiceServer::asyncGetPBFTView(tars::Int64& _view, tars::TarsCurrentP
     return bcostars::Error();
 }
 
-Error PBFTServiceServer::asyncNotifyConsensusMessage(std::string const& _uuid,
+bcostars::Error PBFTServiceServer::asyncNotifyConsensusMessage(std::string const& _uuid,
     const std::vector<tars::Char>& _nodeId, const std::vector<tars::Char>& _data,
     tars::TarsCurrentPtr _current)
 {
@@ -83,7 +83,7 @@ bcostars::Error PBFTServiceServer::asyncNotifyBlockSyncMessage(std::string const
 }
 
 
-Error PBFTServiceServer::asyncNotifyNewBlock(
+bcostars::Error PBFTServiceServer::asyncNotifyNewBlock(
     const LedgerConfig& _ledgerConfig, tars::TarsCurrentPtr _current)
 {
     _current->setResponse(false);
@@ -95,7 +95,7 @@ Error PBFTServiceServer::asyncNotifyNewBlock(
     return bcostars::Error();
 }
 
-Error PBFTServiceServer::asyncSubmitProposal(bool _containSysTxs,
+bcostars::Error PBFTServiceServer::asyncSubmitProposal(bool _containSysTxs,
     const bcostars::Block& _proposalData, tars::Int64 _proposalIndex,
     const std::vector<tars::Char>& _proposalHash, tars::TarsCurrentPtr _current)
 {

--- a/fisco-bcos-tars-service/RpcService/main/Application.cpp
+++ b/fisco-bcos-tars-service/RpcService/main/Application.cpp
@@ -5,6 +5,7 @@
 #include <bcos-crypto/signature/key/KeyFactoryImpl.h>
 #include <bcos-utilities/BoostLogInitializer.h>
 #include <servant/Application.h>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcostars;
 class RpcServiceApp : public tars::Application

--- a/legacy/bcos-ledger/LedgerImpl.h
+++ b/legacy/bcos-ledger/LedgerImpl.h
@@ -24,6 +24,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 #include <type_traits>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::ledger
 {

--- a/legacy/bcos-ledger/LedgerImplLightnode.h
+++ b/legacy/bcos-ledger/LedgerImplLightnode.h
@@ -11,6 +11,7 @@
 #include <range/v3/range/access.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::ledger
 {

--- a/legacy/bcos-storage/TiKVStorage.cpp
+++ b/legacy/bcos-storage/TiKVStorage.cpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <optional>
 #include <stdexcept>
+#include <bcos-utilities/BoostLog.h>
 
 constexpr uint32_t MAX_RETRY_LIMIT = 32;
 

--- a/legacy/lightnode/bcos-lightnode/Log.h
+++ b/legacy/lightnode/bcos-lightnode/Log.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <bcos-utilities/BoostLog.h>
 
 #define LIGHTNODE_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("LIGHTNODE")
 #define TRANSACTIONPOOL_LOG(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("TRANSACTIONPOOL")

--- a/legacy/lightnode/bcos-lightnode/rpc/LightNodeRPC.h
+++ b/legacy/lightnode/bcos-lightnode/rpc/LightNodeRPC.h
@@ -29,6 +29,7 @@
 #include <range/v3/range/access.hpp>
 #include <range/v3/view/transform.hpp>
 #include <stdexcept>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::rpc
 {

--- a/legacy/lightnode/fisco-bcos-lightnode/RPCInitializer.h
+++ b/legacy/lightnode/fisco-bcos-lightnode/RPCInitializer.h
@@ -22,6 +22,7 @@
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/throw_exception.hpp>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::lightnode
 {

--- a/legacy/lightnode/fisco-bcos-lightnode/client/LedgerClientImpl.h
+++ b/legacy/lightnode/fisco-bcos-lightnode/client/LedgerClientImpl.h
@@ -21,6 +21,7 @@
 #include <random>
 #include <stdexcept>
 #include <type_traits>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::ledger
 {

--- a/legacy/lightnode/fisco-bcos-lightnode/client/SchedulerClientImpl.h
+++ b/legacy/lightnode/fisco-bcos-lightnode/client/SchedulerClientImpl.h
@@ -6,6 +6,7 @@
 #include <bcos-concepts/Serialize.h>
 #include "../../../concepts/bcos-concepts/scheduler/Scheduler.h"
 #include <bcos-tars-protocol/tars/LightNode.h>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::scheduler
 {

--- a/legacy/lightnode/fisco-bcos-lightnode/main.cpp
+++ b/legacy/lightnode/fisco-bcos-lightnode/main.cpp
@@ -45,6 +45,7 @@
 #include <exception>
 #include <memory>
 #include <thread>
+#include <bcos-utilities/BoostLog.h>
 
 DERIVE_BCOS_EXCEPTION(StartLightNodeException);
 

--- a/legacy/wasm/executor/vm/gas_meter/GasInjector.cpp
+++ b/legacy/wasm/executor/vm/gas_meter/GasInjector.cpp
@@ -28,6 +28,7 @@
 #include "src/ir.h"
 #include "src/stream.h"
 #include <iostream>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace std;
 using namespace wabt;

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -58,6 +58,7 @@
 #include <bcos-framework/executor/ParallelTransactionExecutorInterface.h>
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
 #include <bcos-framework/protocol/GlobalConfig.h>
+#include <boost/algorithm/string.hpp>
 #include <bcos-framework/protocol/Protocol.h>
 #include <bcos-framework/protocol/ProtocolTypeDef.h>
 #include <bcos-framework/rpc/RPCInterface.h>

--- a/libinitializer/StorageInitializer.h
+++ b/libinitializer/StorageInitializer.h
@@ -34,6 +34,7 @@
 #include <bcos-framework/security/StorageEncryptInterface.h>
 #include <bcos-framework/storage/StorageInterface.h>
 #include <boost/filesystem.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::initializer
 {

--- a/opstack-executor/tests/CMakeLists.txt
+++ b/opstack-executor/tests/CMakeLists.txt
@@ -23,6 +23,10 @@ add_executable(opstack-executor-tests
     Storage2StatePoisonTest.cpp
     support/SeedPreStateTest.cpp
 )
+# Unity build: header-heavy Boost.Test TUs share a large common preamble (catch.hpp, evmone,
+# op-rlp headers). TestMain.cpp defines BOOST_TEST_MODULE and stays out of the batch.
+set_target_properties(opstack-executor-tests PROPERTIES UNITY_BUILD "ON")
+set_source_files_properties(TestMain.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 target_link_libraries(opstack-executor-tests PRIVATE
     opstack-executor
     jsoncpp_static

--- a/tests/perf/benchmark.cpp
+++ b/tests/perf/benchmark.cpp
@@ -12,6 +12,7 @@
 #include <boost/program_options.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/algorithm/string.hpp>
 
 using namespace std;
 using namespace bcos;

--- a/tools/archive-tool/ArchiveService.h
+++ b/tools/archive-tool/ArchiveService.h
@@ -32,6 +32,7 @@
 #include <functional>
 #include <future>
 #include <utility>
+#include <bcos-utilities/BoostLog.h>
 
 #define ARCHIVE_SERVICE_LOG(LEVEL) BCOS_LOG(LEVEL) << "[ARCHIVE]"
 

--- a/transaction-executor/bcos-transaction-executor/precompiled/ExecutiveWrapper.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/ExecutiveWrapper.h
@@ -7,6 +7,7 @@
 #include "bcos-executor/src/vm/HostContext.h"
 #include <evmc/evmc.h>
 #include <memory>
+#include <bcos-utilities/BoostLog.h>
 
 #define EXECUTIVE_WRAPPER(LEVEL) BCOS_LOG(LEVEL) << LOG_BADGE("EXECUTIVE_WRAPPER")
 

--- a/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
+++ b/transaction-executor/bcos-transaction-executor/precompiled/PrecompiledImpl.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <range/v3/algorithm/copy.hpp>
 #include <variant>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::executor_v1
 {

--- a/transaction-executor/bcos-transaction-executor/vm/HostContext.h
+++ b/transaction-executor/bcos-transaction-executor/vm/HostContext.h
@@ -58,6 +58,7 @@
 #include <boost/algorithm/hex.hpp>
 #include <boost/concept_archetype.hpp>
 #include <boost/container_hash/hash.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <boost/multiprecision/cpp_int/import_export.hpp>
 #include <boost/throw_exception.hpp>
@@ -71,6 +72,7 @@
 #include <range/v3/algorithm/fill.hpp>
 #include <range/v3/algorithm/move.hpp>
 #include <string_view>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::executor_v1::hostcontext
 {

--- a/transaction-executor/tests/TestHostContext.cpp
+++ b/transaction-executor/tests/TestHostContext.cpp
@@ -32,6 +32,7 @@
 #include <memory>
 #include <range/v3/algorithm/sort.hpp>
 #include <range/v3/algorithm/unique.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 using namespace bcos::task;
 using namespace bcos::storage2;

--- a/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/BaselineScheduler.h
@@ -30,6 +30,7 @@
 #include <tuple>
 #include <type_traits>
 #include <vector>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::protocol
 {

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -22,6 +22,7 @@
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/zip.hpp>
 #include <bcos-utilities/BoostLog.h>
+#include <boost/atomic.hpp>
 
 namespace bcos::scheduler_v1
 {

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerParallelImpl.h
@@ -21,6 +21,7 @@
 #include <range/v3/view/drop.hpp>
 #include <range/v3/view/enumerate.hpp>
 #include <range/v3/view/zip.hpp>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::scheduler_v1
 {

--- a/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
+++ b/transaction-scheduler/bcos-transaction-scheduler/SchedulerSerialImpl.h
@@ -16,6 +16,7 @@
 #include <range/v3/view/chunk.hpp>
 #include <range/v3/view/iota.hpp>
 #include <type_traits>
+#include <bcos-utilities/BoostLog.h>
 
 namespace bcos::scheduler_v1
 {

--- a/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
+++ b/transaction-scheduler/tests/FIB98_EarlyAbortTest.cpp
@@ -31,6 +31,7 @@
 #include <bcos-transaction-scheduler/SchedulerParallelImpl.h>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
+#include <boost/atomic.hpp>
 
 using namespace bcos;
 using namespace bcos::storage2;


### PR DESCRIPTION
## 概述

通过 include 链瘦身和扩大 unity build 覆盖，降低全量构建的编译时间。所有改动均为编译层面优化，无运行时行为变化。唯一例外，属有意披露：`FixedBytes.h` 构造失败冷路径的 WARNING 日志被删除，所需/实际长度信息并入异常 `errinfo_comment`——异常照抛、fail-closed 不变，树内该路径不可达，仅影响外部消费者对该路径的可观测性。

测量环境：GCC 14,20 核，Debug(-O0 + ASan/UBSan),355 个编译单元。

## 改动内容

### Commit 1: Increase TU compile speed(include 瘦身,144 个文件)

基于实测的头文件重量分析（逐头测量预处理行数与解析时间）:

- `bcos-utilities/Common.h`:`<boost/thread.hpp>` umbrella 替换为实际用到的 `<boost/thread/locks.hpp>` + `<boost/thread/shared_mutex.hpp>`;删除死 include `<boost/algorithm/string.hpp>`
- `bcos-utilities/Exceptions.h`:删除死 include `<boost/exception/info_tuple.hpp>`、`<boost/tuple/tuple.hpp>`
- `bcos-utilities/BoostLog.h`:删除死 include(`scoped_attribute.hpp`、`constant.hpp`);`make_collector` 声明连带 `<boost/log/sinks/text_file_backend.hpp>`(146k 预处理行）拆到新头 `BoostLogCollector.h`,仅 3 个真实用户包含它
- `bcos-utilities/FixedBytes.h`:移除仅为一条冷路径 WARNING 日志引入的 `BoostLog.h`;日志删除，信息并入异常的 `errinfo_comment`。**行为披露**：`FixedBytes` 构造失败路径（`_bytesData.size() != N`）上的 `ConstructFixedBytesFailed` WARNING 日志被移除，长度信息（requiredLen/dataLen）改并入异常的 `errinfo_comment`；该路径在树内不可达（`AcquireEqual` 无调用方），但对树外安装头消费者存在日志可见性变化。
- `bcos-crypto/interfaces/crypto/CommonType.h`:移除 `BoostLog.h`(`CRYPTO_LOG` 宏惰性展开，定义处不需要日志头）,crypto 接口簇全部受益
- 删除死代码 `SecureFixedBytes`（全项目零使用）及 `toJonString` 对应死重载
- 约 120 个文件补显式 include（此前依赖上述头的传递包含，纯 include 卫生修复）

实测：核心 TU(含 FixedBytes.h/crypto 接口头，250+ 个）解析时间约 2.9s → 2.0s(-31%)，预处理 338k → 269k 行；全量构建节省约 280-320s CPU/次。

### Commit 2: Enable bcos-executor unity build

`bcos-executor` 测试目标此前显式关闭 unity build（注释记录的是 macOS libc++ 问题，Linux/GCC 不适用），导致 65 个测试文件各自独立解析同一套约 200k 行的头文件，占全项目构建 CPU 的 20% 以上。

- 打开 `UNITY_BUILD`，无 per-file opt-out（仅 main.cpp 按项目惯例独立）
- 11 个测试文件 + 1 个 mock 头的全局 `using namespace std;` 改为精确 `using std::xxx;` 声明（全局 using 会在 unity TU 内与 range-v3 的 `::ranges` 产生歧义）
- 同名 `BOOST_AUTO_TEST_SUITE(Compat)` 与 3 个历史 opt-out 文件经实验证明在当前 Boost/GCC 下安全，全部回收
- 治本修复 `testutils/faker/FakeTransaction.h` 的 `TransactionType` 歧义（补 `protocol::` 限定）

实测：测试目标 clean rebuild CPU 约 2200s → 1500-1800s(-20~30%),431 个测试用例注册数不变。

### Commit 3: Add more unity build

为剩余 5 个未开 unity 的 target 启用：`test-sealer`、`opstack-executor-tests`、`bcos-evm-opstack-tests`、`BcosNodeService`(pro/max 两个 flavor)、`test-boostssl`。

冲突修复均为最小改动：4 处测试匿名命名空间符号改名（3 个文件）、1 处 `bcostars::Error` 显式限定、1 个 `BOOST_TEST_MAIN` 文件惯例 opt-out。所有 boost test 目标用例注册数逐一核对不变（68/66/141/28)。

## 验证

- 全量构建（含全部测试、benchmark、tars 服务）0 错误通过
- executor 测试二进制 `--list_content` 校验：431 用例，与改动前一致
- 未做：完整测试套件运行（建议 CI 跑一遍）

## 备注

- 曾实验 CMake `target_precompile_headers`(PCH)：实测收益约 4% 墙钟但需 22GB 磁盘（81 个 .gch),性价比不合，已完整撤除，不在本 PR 内
- `BcosNodeService` 的 unity 设置在当前默认配置（`WITH_TARS_SERVICES=OFF`）下不生效，开启该选项时自动生效（已在 ON 状态下验证构建通过）


