### PR TITLE
Add crypto primitives for the devp2p RLPx transport

### DIFF
--- a/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.cpp
@@ -1,0 +1,89 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AesCtrCipher.cpp
+ * @brief AES-CTR implementation (OpenSSL EVP).
+ * @date 2026/8/18
+ */
+#include "AesCtrCipher.h"
+
+#include <openssl/evp.h>
+#include <stdexcept>
+
+namespace bcos::crypto
+{
+AesCtrCipher::AesCtrCipher(bytesConstRef _key, bytesConstRef _iv, Direction _direction)
+  : m_direction(_direction), m_ctx(EVP_CIPHER_CTX_new())
+{
+    if (m_ctx == nullptr)
+    {
+        throw std::runtime_error("AesCtrCipher: failed to allocate EVP context");
+    }
+    if (_key.size() != 16 && _key.size() != 32)
+    {
+        EVP_CIPHER_CTX_free(m_ctx);
+        throw std::invalid_argument("AesCtrCipher: key must be 16 or 32 bytes");
+    }
+    if (_iv.size() != AES_BLOCK_SIZE)
+    {
+        EVP_CIPHER_CTX_free(m_ctx);
+        throw std::invalid_argument("AesCtrCipher: iv must be 16 bytes");
+    }
+    const EVP_CIPHER* cipher = (_key.size() == 16) ? EVP_aes_128_ctr() : EVP_aes_256_ctr();
+    int ok = (_direction == Direction::Encrypt) ?
+                 EVP_EncryptInit_ex(m_ctx, cipher, nullptr, _key.data(), _iv.data()) :
+                 EVP_DecryptInit_ex(m_ctx, cipher, nullptr, _key.data(), _iv.data());
+    if (ok != 1)
+    {
+        EVP_CIPHER_CTX_free(m_ctx);
+        throw std::runtime_error("AesCtrCipher: init failed");
+    }
+}
+
+AesCtrCipher::~AesCtrCipher()
+{
+    if (m_ctx != nullptr)
+    {
+        EVP_CIPHER_CTX_free(m_ctx);
+    }
+}
+
+bytes AesCtrCipher::update(bytesConstRef _data)
+{
+    bytes out(_data.size());
+    if (_data.empty())
+    {
+        return out;
+    }
+    int outLen = 0;
+    int ok = (m_direction == Direction::Encrypt) ?
+                 EVP_EncryptUpdate(m_ctx, out.data(), &outLen, _data.data(),
+                     static_cast<int>(_data.size())) :
+                 EVP_DecryptUpdate(m_ctx, out.data(), &outLen, _data.data(),
+                     static_cast<int>(_data.size()));
+    if (ok != 1)
+    {
+        throw std::runtime_error("AesCtrCipher: update failed");
+    }
+    out.resize(static_cast<size_t>(outLen));
+    return out;
+}
+
+bytes aesCtrCrypt(bytesConstRef _data, bytesConstRef _key, bytesConstRef _iv)
+{
+    AesCtrCipher cipher(_key, _iv, AesCtrCipher::Direction::Encrypt);
+    return cipher.update(_data);
+}
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.cpp
@@ -36,7 +36,7 @@ AesCtrCipher::AesCtrCipher(bytesConstRef _key, bytesConstRef _iv, Direction _dir
         EVP_CIPHER_CTX_free(m_ctx);
         throw std::invalid_argument("AesCtrCipher: key must be 16 or 32 bytes");
     }
-    if (_iv.size() != AES_BLOCK_SIZE)
+    if (_iv.size() != kAesBlockSize)
     {
         EVP_CIPHER_CTX_free(m_ctx);
         throw std::invalid_argument("AesCtrCipher: iv must be 16 bytes");

--- a/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.cpp
@@ -20,6 +20,7 @@
 #include "AesCtrCipher.h"
 
 #include <openssl/evp.h>
+#include <limits>
 #include <stdexcept>
 
 namespace bcos::crypto
@@ -62,6 +63,12 @@ AesCtrCipher::~AesCtrCipher()
 
 bytes AesCtrCipher::update(bytesConstRef _data)
 {
+    // EVP_*Update takes an int input length; reject sizes that would wrap and
+    // silently produce wrong-length ciphertext.
+    if (_data.size() > static_cast<size_t>(std::numeric_limits<int>::max()))
+    {
+        throw std::invalid_argument("AesCtrCipher::update: input too large");
+    }
     bytes out(_data.size());
     if (_data.empty())
     {

--- a/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.h
+++ b/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.h
@@ -1,0 +1,67 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AesCtrCipher.h
+ * @brief Stateful AES-CTR stream cipher (OpenSSL EVP) — used by RLPx framing
+ *        (AES-256-CTR with the 32-byte aes-secret) and ECIES (AES-128-CTR).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <cstddef>
+
+// Opaque OpenSSL context (avoids leaking openssl/evp.h into consumers).
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+
+namespace bcos::crypto
+{
+constexpr size_t AES_BLOCK_SIZE = 16;
+
+// Round `size` up to the next multiple of the AES block size (16).
+inline size_t aesRoundUpToBlockSize(size_t _size)
+{
+    return (_size + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE * AES_BLOCK_SIZE;
+}
+
+// Stateful AES-CTR stream cipher: the keystream continues across update()
+// calls, so encrypting multiple frames with one instance behaves like a
+// single CTR stream (exactly what RLPx framing needs).
+class AesCtrCipher
+{
+public:
+    enum class Direction
+    {
+        Encrypt,
+        Decrypt,
+    };
+
+    // Key must be 16 (AES-128) or 32 (AES-256) bytes; iv exactly 16 bytes.
+    AesCtrCipher(bytesConstRef _key, bytesConstRef _iv, Direction _direction);
+    ~AesCtrCipher();
+
+    AesCtrCipher(AesCtrCipher const&) = delete;
+    AesCtrCipher& operator=(AesCtrCipher const&) = delete;
+
+    bytes update(bytesConstRef _data);
+
+private:
+    Direction m_direction;
+    EVP_CIPHER_CTX* m_ctx;
+};
+
+// One-shot AES-CTR encrypt/decrypt (identical for CTR mode).
+bytes aesCtrCrypt(bytesConstRef _data, bytesConstRef _key, bytesConstRef _iv);
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.h
+++ b/bcos-crypto/bcos-crypto/encrypt/AesCtrCipher.h
@@ -28,12 +28,16 @@ typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
 
 namespace bcos::crypto
 {
-constexpr size_t AES_BLOCK_SIZE = 16;
+// AES block size in bytes. Named kAesBlockSize (not AES_BLOCK_SIZE) because
+// OpenSSL's <openssl/aes.h> defines an AES_BLOCK_SIZE macro, and macros ignore
+// namespaces — a TU that includes openssl/aes.h before this header would break
+// the build.
+constexpr size_t kAesBlockSize = 16;
 
 // Round `size` up to the next multiple of the AES block size (16).
 inline size_t aesRoundUpToBlockSize(size_t _size)
 {
-    return (_size + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE * AES_BLOCK_SIZE;
+    return (_size + kAesBlockSize - 1) / kAesBlockSize * kAesBlockSize;
 }
 
 // Stateful AES-CTR stream cipher: the keystream continues across update()

--- a/bcos-crypto/bcos-crypto/encrypt/HmacSha256.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/HmacSha256.cpp
@@ -20,6 +20,7 @@
 #include "HmacSha256.h"
 
 #include <openssl/hmac.h>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -43,6 +44,12 @@ bytes hmacSha256Segments(bytesConstRef _key, std::vector<bytesConstRef> const& _
 
     bytes out(EVP_MAX_MD_SIZE);
     unsigned int outLen = 0;
+    // HMAC takes an int key length; reject sizes that would wrap and silently
+    // produce a wrong-length MAC.
+    if (_key.size() > static_cast<size_t>(std::numeric_limits<int>::max()))
+    {
+        throw std::invalid_argument("hmacSha256: key too large");
+    }
     if (HMAC(EVP_sha256(), _key.data(), static_cast<int>(_key.size()), data.data(), data.size(),
             out.data(), &outLen) == nullptr)
     {

--- a/bcos-crypto/bcos-crypto/encrypt/HmacSha256.cpp
+++ b/bcos-crypto/bcos-crypto/encrypt/HmacSha256.cpp
@@ -1,0 +1,70 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HmacSha256.cpp
+ * @brief HMAC-SHA256 implementation (OpenSSL one-shot HMAC).
+ * @date 2026/8/18
+ */
+#include "HmacSha256.h"
+
+#include <openssl/hmac.h>
+#include <stdexcept>
+#include <vector>
+
+namespace bcos::crypto
+{
+namespace
+{
+bytes hmacSha256Segments(bytesConstRef _key, std::vector<bytesConstRef> const& _parts)
+{
+    size_t total = 0;
+    for (auto const& part : _parts)
+    {
+        total += part.size();
+    }
+    bytes data;
+    data.reserve(total);
+    for (auto const& part : _parts)
+    {
+        data.insert(data.end(), part.begin(), part.end());
+    }
+
+    bytes out(EVP_MAX_MD_SIZE);
+    unsigned int outLen = 0;
+    if (HMAC(EVP_sha256(), _key.data(), static_cast<int>(_key.size()), data.data(), data.size(),
+            out.data(), &outLen) == nullptr)
+    {
+        throw std::runtime_error("hmacSha256: HMAC failed");
+    }
+    out.resize(outLen);
+    return out;
+}
+}  // namespace
+
+bytes hmacSha256(bytesConstRef _key, bytesConstRef _data1)
+{
+    return hmacSha256Segments(_key, {_data1});
+}
+
+bytes hmacSha256(bytesConstRef _key, bytesConstRef _data1, bytesConstRef _data2)
+{
+    return hmacSha256Segments(_key, {_data1, _data2});
+}
+
+bytes hmacSha256(bytesConstRef _key, bytesConstRef _data1, bytesConstRef _data2, bytesConstRef _data3)
+{
+    return hmacSha256Segments(_key, {_data1, _data2, _data3});
+}
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/encrypt/HmacSha256.h
+++ b/bcos-crypto/bcos-crypto/encrypt/HmacSha256.h
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HmacSha256.h
+ * @brief HMAC-SHA256 (RFC 2104) — required by RLPx ECIES and frame MACs.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <cstddef>
+
+namespace bcos::crypto
+{
+// HMAC-SHA256 over up to three concatenated data segments (RLPx needs
+// HMAC(km, iv || ciphertext || mac-extra-data)).
+bcos::bytes hmacSha256(bytesConstRef _key, bytesConstRef _data1);
+bcos::bytes hmacSha256(bytesConstRef _key, bytesConstRef _data1, bytesConstRef _data2);
+bcos::bytes hmacSha256(
+    bytesConstRef _key, bytesConstRef _data1, bytesConstRef _data2, bytesConstRef _data3);
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/encrypt/HmacSha256.h
+++ b/bcos-crypto/bcos-crypto/encrypt/HmacSha256.h
@@ -14,7 +14,9 @@
  *  limitations under the License.
  *
  * @file HmacSha256.h
- * @brief HMAC-SHA256 (RFC 2104) — required by RLPx ECIES and frame MACs.
+ * @brief HMAC-SHA256 (RFC 2104) — required by RLPx ECIES handshake message
+ *        authentication. (Note: the RLPx frame egress/ingress MACs are a
+ *        keccak-256 running state, not HMAC-SHA256.)
  * @date 2026/8/18
  */
 #pragma once

--- a/bcos-crypto/bcos-crypto/random/CryptoRandom.cpp
+++ b/bcos-crypto/bcos-crypto/random/CryptoRandom.cpp
@@ -1,0 +1,36 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file CryptoRandom.cpp
+ * @brief Secure random implementation (OpenSSL RAND_bytes).
+ * @date 2026/8/18
+ */
+#include "CryptoRandom.h"
+
+#include <openssl/rand.h>
+#include <stdexcept>
+
+namespace bcos::crypto
+{
+bytes cryptoRandomBytes(size_t _size)
+{
+    bytes out(_size);
+    if (_size > 0 && RAND_bytes(out.data(), static_cast<int>(_size)) != 1)
+    {
+        throw std::runtime_error("cryptoRandomBytes: RAND_bytes failed");
+    }
+    return out;
+}
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/random/CryptoRandom.cpp
+++ b/bcos-crypto/bcos-crypto/random/CryptoRandom.cpp
@@ -20,12 +20,19 @@
 #include "CryptoRandom.h"
 
 #include <openssl/rand.h>
+#include <limits>
 #include <stdexcept>
 
 namespace bcos::crypto
 {
 bytes cryptoRandomBytes(size_t _size)
 {
+    // RAND_bytes takes an int length; reject sizes that would wrap instead of
+    // silently returning uninitialized heap bytes.
+    if (_size > static_cast<size_t>(std::numeric_limits<int>::max()))
+    {
+        throw std::invalid_argument("cryptoRandomBytes: size too large");
+    }
     bytes out(_size);
     if (_size > 0 && RAND_bytes(out.data(), static_cast<int>(_size)) != 1)
     {

--- a/bcos-crypto/bcos-crypto/random/CryptoRandom.h
+++ b/bcos-crypto/bcos-crypto/random/CryptoRandom.h
@@ -1,0 +1,28 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file CryptoRandom.h
+ * @brief Cryptographically secure random bytes (OpenSSL RAND_bytes).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+
+namespace bcos::crypto
+{
+// Cryptographically secure random bytes of the given size.
+bcos::bytes cryptoRandomBytes(size_t _size);
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Ecdh.cpp
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Ecdh.cpp
@@ -1,0 +1,92 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Secp256k1Ecdh.cpp
+ * @brief secp256k1 ECDH implementation (libsecp256k1 ecdh module).
+ * @date 2026/8/18
+ */
+#include "Secp256k1Ecdh.h"
+
+#include <secp256k1.h>
+#include <secp256k1_ecdh.h>
+#include <array>
+#include <cstring>
+#include <stdexcept>
+
+namespace bcos::crypto
+{
+namespace
+{
+secp256k1_context* secp256k1EcdhContext()
+{
+    static secp256k1_context* ctx =
+        secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    return ctx;
+}
+
+// Degenerate hash that copies the x-coordinate — the RLPx ECIES shared secret
+// (matches geth's ecies.GenerateShared and silkworm's ecdh_hash_function_copy_x).
+int ecdhHashFunctionCopyX(
+    unsigned char* _output, const unsigned char* _x32, const unsigned char*, void*)
+{
+    memcpy(_output, _x32, 32);
+    return 1;
+}
+
+bytes secp256k1EcdhImpl(
+    bytesConstRef _publicKey, bytesConstRef _privateKey, secp256k1_ecdh_hash_function _hashFunction)
+{
+    if (_publicKey.size() != 64)
+    {
+        throw std::invalid_argument("secp256k1Ecdh: public key must be 64 bytes");
+    }
+    if (_privateKey.size() != 32)
+    {
+        throw std::invalid_argument("secp256k1Ecdh: private key must be 32 bytes");
+    }
+
+    // The FISCO convention stores the uncompressed point without the 0x04 prefix.
+    std::array<unsigned char, 65> rawPublicKey{};
+    rawPublicKey[0] = 0x04;
+    memcpy(rawPublicKey.data() + 1, _publicKey.data(), 64);
+
+    secp256k1_pubkey publicKey;
+    if (secp256k1_ec_pubkey_parse(
+            secp256k1EcdhContext(), &publicKey, rawPublicKey.data(), rawPublicKey.size()) != 1)
+    {
+        throw std::invalid_argument("secp256k1Ecdh: failed to parse public key");
+    }
+
+    bytes sharedSecret(32, 0);
+    if (secp256k1_ecdh(secp256k1EcdhContext(), sharedSecret.data(), &publicKey,
+            _privateKey.data(), _hashFunction, nullptr) != 1)
+    {
+        throw std::runtime_error("secp256k1Ecdh: ECDH computation failed");
+    }
+    return sharedSecret;
+}
+}  // namespace
+
+bytes secp256k1EcdhCopyX(bytesConstRef _publicKey, bytesConstRef _privateKey)
+{
+    return secp256k1EcdhImpl(_publicKey, _privateKey, ecdhHashFunctionCopyX);
+}
+
+bytes secp256k1EcdhSha256(bytesConstRef _publicKey, bytesConstRef _privateKey)
+{
+    // A null hash function selects libsecp256k1's default SHA-256 KDF.
+    return secp256k1EcdhImpl(_publicKey, _privateKey, nullptr);
+}
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Ecdh.h
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Ecdh.h
@@ -1,0 +1,34 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Secp256k1Ecdh.h
+ * @brief secp256k1 ECDH shared-secret helpers (libsecp256k1) — needed by the
+ *        RLPx ECIES handshake (raw-x shared secret + SHA-256 KDF).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+
+namespace bcos::crypto
+{
+// ECDH shared secret (32 bytes) between `_publicKey` (64-byte uncompressed
+// point without the 0x04 prefix, the FISCO convention) and `_privateKey`
+// (32 bytes). The hash function selects the output:
+//   - secp256k1EcdhCopyX: raw x-coordinate (RLPx ECIES KDF input)
+//   - secp256k1EcdhSha256: sha256(compressedPoint || x) (SEC1 default)
+bcos::bytes secp256k1EcdhCopyX(bytesConstRef _publicKey, bytesConstRef _privateKey);
+bcos::bytes secp256k1EcdhSha256(bytesConstRef _publicKey, bytesConstRef _privateKey);
+}  // namespace bcos::crypto

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Ecdh.h
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Ecdh.h
@@ -28,7 +28,8 @@ namespace bcos::crypto
 // point without the 0x04 prefix, the FISCO convention) and `_privateKey`
 // (32 bytes). The hash function selects the output:
 //   - secp256k1EcdhCopyX: raw x-coordinate (RLPx ECIES KDF input)
-//   - secp256k1EcdhSha256: sha256(compressedPoint || x) (SEC1 default)
+//   - secp256k1EcdhSha256: libsecp256k1's default ECDH hash
+//     (sha256 of the 33-byte compressed point)
 bcos::bytes secp256k1EcdhCopyX(bytesConstRef _publicKey, bytesConstRef _privateKey);
 bcos::bytes secp256k1EcdhSha256(bytesConstRef _publicKey, bytesConstRef _privateKey);
 }  // namespace bcos::crypto

--- a/bcos-crypto/test/unittests/RlpxPrimitivesTest.cpp
+++ b/bcos-crypto/test/unittests/RlpxPrimitivesTest.cpp
@@ -66,6 +66,11 @@ BOOST_AUTO_TEST_CASE(aes256CtrStateful)
     BOOST_CHECK(c1 == bytesConstRef(oneShot.data(), part1.size()).toBytes());
     BOOST_CHECK(
         c2 == bytesConstRef(oneShot.data() + part1.size(), part2.size()).toBytes());
+    // Absolute anchor for AES-256-CTR itself (openssl-verified; NIST SP 800-38A
+    // F.5.5 key, zero IV as used by RLPx): the two blocks above are
+    //   8ea94863ba8fe940fe7032d13083bf7e  3f38940a1579b3875e60c37ceb91dfb5
+    BOOST_CHECK_EQUAL(toHex(oneShot),
+        "8ea94863ba8fe940fe7032d13083bf7e3f38940a1579b3875e60c37ceb91dfb5");
 }
 
 // HMAC-SHA256 against RFC 4231 test case 2.
@@ -96,6 +101,12 @@ BOOST_AUTO_TEST_CASE(ecdhCopyX)
     auto s2 = secp256k1EcdhCopyX(pub1Ref, ref(priv2));
     BOOST_CHECK(s1 == s2);
     BOOST_CHECK_EQUAL(s1.size(), 32u);
+    // Known-answer anchor: the shared point's x-coordinate for these two keys,
+    // computed with an independent implementation (python ecdsa, SECP256k1). A
+    // symmetry-only assertion would stay green for a wrong copy-x (hashed
+    // compressed point, wrong endianness, wrong half).
+    BOOST_CHECK_EQUAL(toHex(s1),
+        "167ccc13ac5e8a26b131c3446030c60fbfac6aa8e31149d0869f93626a4cdf62");
 }
 
 // Secure random bytes differ and are non-trivial.
@@ -105,6 +116,47 @@ BOOST_AUTO_TEST_CASE(randomBytes)
     auto b = cryptoRandomBytes(32);
     BOOST_CHECK(a != b);
     BOOST_CHECK(std::any_of(a.begin(), a.end(), [](byte x) { return x != 0; }));
+}
+
+// The size checks in these primitives are the security boundary for peer-supplied
+// inputs (RLPx frames, ECIES), so the rejection paths must be covered.
+BOOST_AUTO_TEST_CASE(rejectsInvalidInputs)
+{
+    auto key16 = fromHex("2b7e151628aed2a6abf7158809cf4f3c");
+    auto iv16 = bytes(16, 0);
+    auto data = fromHex("0102030405");
+
+    // AES-CTR: key must be 16 or 32 bytes, IV exactly 16.
+    for (auto badKeyLen : {15u, 17u, 31u, 33u})
+    {
+        auto badKey = bytes(badKeyLen, 0xab);
+        BOOST_CHECK_THROW(aesCtrCrypt(ref(data), ref(badKey), ref(iv16)), std::invalid_argument);
+    }
+    for (auto badIvLen : {15u, 17u})
+    {
+        auto badIv = bytes(badIvLen, 0xcd);
+        BOOST_CHECK_THROW(aesCtrCrypt(ref(data), ref(key16), ref(badIv)), std::invalid_argument);
+    }
+
+    // ECDH: public key must be exactly 64 bytes, private key exactly 32.
+    auto priv32 = bytes(32, 0x11);
+    for (auto badPubLen : {63u, 65u})
+    {
+        auto badPub = bytes(badPubLen, 0x04);
+        BOOST_CHECK_THROW(
+            secp256k1EcdhCopyX(ref(badPub), ref(priv32)), std::invalid_argument);
+    }
+    for (auto badPrivLen : {31u, 33u})
+    {
+        auto badPriv = bytes(badPrivLen, 0x11);
+        auto pub = bytes(64, 0x02);
+        BOOST_CHECK_THROW(
+            secp256k1EcdhCopyX(ref(pub), ref(badPriv)), std::invalid_argument);
+    }
+    // Off-curve / out-of-field public key: parsing must reject it.
+    auto offCurvePub = bytes(64, 0x00);
+    BOOST_CHECK_THROW(
+        secp256k1EcdhCopyX(ref(offCurvePub), ref(priv32)), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-crypto/test/unittests/RlpxPrimitivesTest.cpp
+++ b/bcos-crypto/test/unittests/RlpxPrimitivesTest.cpp
@@ -1,0 +1,111 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file RlpxPrimitivesTest.cpp
+ * @brief Tests for the RLPx crypto primitives: AES-128/256-CTR, HMAC-SHA256,
+ *        secp256k1 ECDH, secure random bytes.
+ * @date 2026/8/18
+ */
+#include <bcos-crypto/encrypt/AesCtrCipher.h>
+#include <bcos-crypto/encrypt/HmacSha256.h>
+#include <bcos-crypto/random/CryptoRandom.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Ecdh.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1KeyPair.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::crypto;
+
+namespace bcos
+{
+BOOST_AUTO_TEST_SUITE(RlpxPrimitivesTest)
+
+// AES-128-CTR against a known vector (NIST SP 800-38A F.5.1).
+BOOST_AUTO_TEST_CASE(aes128Ctr)
+{
+    auto key = fromHex("2b7e151628aed2a6abf7158809cf4f3c");
+    auto iv = fromHex("f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+    auto plain = fromHex("6bc1bee22e409f96e93d7e117393172a");
+
+    auto cipher = aesCtrCrypt(ref(plain), ref(key), ref(iv));
+    BOOST_CHECK_EQUAL(toHex(cipher), "874d6191b620e3261bef6864990db6ce");
+
+    auto roundTrip = aesCtrCrypt(ref(cipher), ref(key), ref(iv));
+    BOOST_CHECK(roundTrip == plain);
+}
+
+// Stateful AES-256-CTR: two updates must continue the same keystream.
+BOOST_AUTO_TEST_CASE(aes256CtrStateful)
+{
+    auto key = fromHex("603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4");
+    auto iv = bytes(16, 0);
+    auto part1 = fromHex("6bc1bee22e409f96e93d7e117393172a");
+    auto part2 = fromHex("ae2d8a571e03ac9c9eb76fac45af8e51");
+
+    AesCtrCipher cipher(ref(key), ref(iv), AesCtrCipher::Direction::Encrypt);
+    auto c1 = cipher.update(ref(part1));
+    auto c2 = cipher.update(ref(part2));
+
+    // Single-shot over the concatenation must match.
+    auto joined = part1;
+    joined.insert(joined.end(), part2.begin(), part2.end());
+    auto oneShot = aesCtrCrypt(ref(joined), ref(key), ref(iv));
+    BOOST_CHECK(c1 == bytesConstRef(oneShot.data(), part1.size()).toBytes());
+    BOOST_CHECK(
+        c2 == bytesConstRef(oneShot.data() + part1.size(), part2.size()).toBytes());
+}
+
+// HMAC-SHA256 against RFC 4231 test case 2.
+BOOST_AUTO_TEST_CASE(hmacSha256Vector)
+{
+    auto key = fromHex("4a656665");  // "Jefe"
+    auto data = fromHex("7768617420646f2079612077616e7420666f72206e6f7468696e673f");  // "what do ya want for nothing?"
+
+    auto mac = hmacSha256(ref(key), ref(data));
+    BOOST_CHECK_EQUAL(toHex(mac),
+        "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843");
+}
+
+// secp256k1 ECDH with the raw-x hash against a fixed key pair.
+BOOST_AUTO_TEST_CASE(ecdhCopyX)
+{
+    auto priv1 = fromHex("7ebbc6a8358bc76dd73ebc557056702c8cfc34e5cfcd90eb83af0347575fd2ad");
+    auto priv2 = fromHex("6a3d6396903245bba5837752b9e0348874e72db0c4e11e9c485a81b4ea4353b9");
+
+    auto pub1 = bcos::crypto::secp256k1PriToPub(
+        std::make_shared<bcos::crypto::KeyImpl>(priv1));
+    auto pub2 = bcos::crypto::secp256k1PriToPub(
+        std::make_shared<bcos::crypto::KeyImpl>(priv2));
+
+    bytesConstRef pub1Ref(pub1->data().data(), pub1->data().size());
+    bytesConstRef pub2Ref(pub2->data().data(), pub2->data().size());
+    auto s1 = secp256k1EcdhCopyX(pub2Ref, ref(priv1));
+    auto s2 = secp256k1EcdhCopyX(pub1Ref, ref(priv2));
+    BOOST_CHECK(s1 == s2);
+    BOOST_CHECK_EQUAL(s1.size(), 32u);
+}
+
+// Secure random bytes differ and are non-trivial.
+BOOST_AUTO_TEST_CASE(randomBytes)
+{
+    auto a = cryptoRandomBytes(32);
+    auto b = cryptoRandomBytes(32);
+    BOOST_CHECK(a != b);
+    BOOST_CHECK(std::any_of(a.begin(), a.end(), [](byte x) { return x != 0; }));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos


### PR DESCRIPTION
## Summary

Crypto primitives required by the devp2p RLPx transport (part of the `eth_sync` feature: Ethereum L1 devp2p + block sync support).

Single commit, 561 new lines (within the CI `check_commit.sh` 666-line limit). Fully independent — no dependency on other PRs.

## Contents

- `AesCtrCipher`: AES-CTR stream cipher (RLPx frame encryption, EIP-8)
- `HmacSha256`: HMAC-SHA256 (RLPx MAC ingress/egress authentication)
- `CryptoRandom`: CSPRNG bytes (secp256k1 keygen, nonces)
- `Secp256k1Ecdh`: ECDH key agreement over secp256k1 (RLPx handshake)
- `RlpxPrimitivesTest`: round-trip tests

Follow-up: devp2p core PR (rlpx + sync) builds on this PR + the RLP codecs PR (#5470).