### PR TITLE
Fix FixedBytes FromBinary stripping a leading 0x prefix

### DIFF
--- a/bcos-utilities/bcos-utilities/FixedBytes.h
+++ b/bcos-utilities/bcos-utilities/FixedBytes.h
@@ -115,13 +115,18 @@ public:
     explicit FixedBytes(std::string_view view, StringDataType type,
         DataAlignType _alignType = DataAlignType::AlignRight)
     {
-        if (view.size() >= 2 && (view[0] == '0' && view[1] == 'x'))
-        {
-            view = view.substr(2);
-        }
-
         if (type == FromHex) [[likely]]
         {
+            // Strip an optional "0x" prefix only for hex strings. Binary data
+            // (FromBinary) must NEVER be prefix-stripped: raw bytes may
+            // legitimately start with 0x30 0x78 (ASCII "0x"), and stripping
+            // them would corrupt the value (e.g. a block hash that happens to
+            // begin with 0x3078...).
+            if (view.size() >= 2 && (view[0] == '0' && view[1] == 'x'))
+            {
+                view = view.substr(2);
+            }
+
             if ((view.size() > static_cast<std::string_view::size_type>(N * 2)) ||
                 (view.size() % 2 != 0)) [[unlikely]]
             {

--- a/bcos-utilities/test/unittests/libutilities/TestFixedBytes.cpp
+++ b/bcos-utilities/test/unittests/libutilities/TestFixedBytes.cpp
@@ -53,4 +53,27 @@ BOOST_AUTO_TEST_CASE(fromStringView)
         prefixLeftBytes.begin(), prefixLeftBytes.end(), std::back_inserter(outHex));
     BOOST_CHECK_EQUAL("0x" + outHex, hex);
 }
+
+BOOST_AUTO_TEST_CASE(fromBinaryKeepsLeading0xBytes)
+{
+    // Regression test: FromBinary must NOT strip a leading 0x30 0x78 (ASCII
+    // "0x") from raw binary data. A 32-byte value such as a block hash that
+    // happens to begin with 0x3078... must round-trip intact; previously the
+    // "0x" prefix stripping (intended for hex strings only) corrupted the value
+    // by dropping its first two bytes.
+    std::string raw;
+    const unsigned char prefix[4] = {0x30, 0x78, 0x90, 0xb5};
+    raw.append(reinterpret_cast<const char*>(prefix), sizeof(prefix));
+    raw.append(28, static_cast<char>(0x11));
+
+    bcos::FixedBytes<LENGTH> fb(raw, bcos::FixedBytes<32>::FromBinary);
+    auto bytes = fb.asBytes();
+    BOOST_CHECK_EQUAL(bytes.size(), LENGTH);
+    BOOST_CHECK_EQUAL(bytes[0], 0x30);
+    BOOST_CHECK_EQUAL(bytes[1], 0x78);
+    BOOST_CHECK_EQUAL(bytes[2], 0x90);
+    BOOST_CHECK_EQUAL(bytes[3], 0xb5);
+    BOOST_CHECK_EQUAL(bytes[4], 0x11);
+    BOOST_CHECK_EQUAL(bytes[31], 0x11);
+}
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Fix `FixedBytes`' `FromBinary` constructor incorrectly stripping a leading `0x` (0x30 0x78) from raw binary data.

Single commit, 33 new lines (within the CI `check_commit.sh` 666-line limit). Fully independent — no dependency on other PRs.

## Root cause

`FixedBytes(std::string_view, FromBinary)` unconditionally stripped an `0x` prefix (logic intended only for hex strings). A 32-byte block hash that happens to begin with `0x3078...` lost its first two bytes (right-aligned zero-padded to `0x0000...`), which produced a wrong `BLOCKHASH` opcode result during Sepolia sync.

## Fix

The `0x` prefix stripping now only applies to the `FromHex` path. Regression test `fromBinaryKeepsLeading0xBytes` added.