### PR TITLE
Fix MPT TrieMerge losing inserts on an emptied subtree

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/TrieMerge.h
+++ b/bcos-ledger/bcos-ledger/mpt/TrieMerge.h
@@ -272,7 +272,16 @@ bcos::task::Task<void> mergeInsert(
 {
     if (std::holds_alternative<std::monostate>(slot))
     {
-        slot = makeLeaf(path, std::move(value));
+        // A fresh leaf landing in an EMPTIED subtree becomes the (new) root of that
+        // subtree. It must be dirty or mergeTrie's phase-2 short-circuit would see an
+        // untouched overlay and return the PRIOR root, silently dropping the insert.
+        // Concretely: a commitTrie batch that deletes the trie's last remaining leaf
+        // (slot -> monostate) and then inserts a new key hits this path — the delete
+        // emptied the trie, the insert repopulates it, and without dirty=true the new
+        // root would never be re-emitted (forked storageRoot, wrong state root).
+        auto leaf = makeLeaf(path, std::move(value));
+        leaf->dirty = true;
+        slot = std::move(leaf);
         co_return;
     }
     MutableNode* node = co_await mergeResolve(ctx, slot);

--- a/bcos-ledger/test/unittests/mpt/MPTBuilderSubsequentTouchTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTBuilderSubsequentTouchTest.cpp
@@ -565,6 +565,46 @@ BOOST_AUTO_TEST_CASE(UnclassifiedRowFieldThrowsInBothModes)
         UnknownAccountRowField);
 }
 
+BOOST_AUTO_TEST_CASE(DeleteLastLeafThenInsertNewSlotRecomputesStorageRoot)
+{
+    // Regression (el-sync, block 1971298): the storage trie holds exactly ONE slot. The same
+    // block clears it (SSTORE 0 -> trie empties to monostate) and then writes a DIFFERENT slot.
+    // mergeTrie's phase-2 short-circuit must NOT return the prior root just because the fresh
+    // leaf created by the insert wasn't marked dirty — otherwise the storageRoot silently stays
+    // the old one and the state root forks (the pre-fix bug wrote priorRoot back).
+    NodeStorage storage;
+    auto const addr = makeAddress(0x1F);
+    std::map<bcos::h256, bcos::bytes> const priorSlots{{slotKey(0x00), bcos::bytes{0x10}}};
+    Account prior;
+    prior.nonce = 1;
+    prior.storageRoot = buildStorageTrie(storage, priorSlots);
+    auto const parentRoot = buildStateTrie(storage, {{addr, prior}});
+
+    // This block: clear the only slot 0x00 (all-zero write = delete), then write slot 0x01.
+    FlatBackendStorage flatBackend;
+    auto view = makeFlatView(flatBackend);
+    writeFlatRow(view, accountFieldKey(addr, ROW_NONCE), makeEntry("2"));
+    writeFlatRow(view, accountSlotKey(addr, slotKey(0x00)), slotEntry(bcos::bytes{0x00, 0x00}));
+    writeFlatRow(view, accountSlotKey(addr, slotKey(0x01)), slotEntry(bcos::bytes{0x22}));
+
+    auto output =
+        bcos::task::syncWait(buildAndCollect(storage, parentRoot, view, /*l2Mode=*/false));
+
+    // The storage trie must now hold ONLY the new slot — never the prior root, never empty.
+    MPTReadView<NodeStorage> readView(storage, output.stateRoot);
+    auto updated = bcos::task::syncWait(readView.readAccount(addr));
+    BOOST_REQUIRE(updated.has_value());
+    BOOST_CHECK(updated->storageRoot != prior.storageRoot);
+    BOOST_CHECK(updated->storageRoot == storageRootOracle({{slotKey(0x01), bcos::bytes{0x22}}}));
+
+    Trie<NodeStorage> storageTrie(storage, updated->storageRoot);
+    auto newSlot = bcos::task::syncWait(storageTrie.get(slotKeyHash(slotKey(0x01))));
+    BOOST_REQUIRE(newSlot.has_value());
+    BOOST_CHECK(*newSlot == encodeStorageValue(bcos::ref(bcos::bytes{0x22})));
+    auto oldSlot = bcos::task::syncWait(storageTrie.get(slotKeyHash(slotKey(0x00))));
+    BOOST_CHECK(!oldSlot.has_value());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace bcos::ledger::mpt::test


### PR DESCRIPTION
## Summary

Fix `MPTBuilder`/`TrieMerge` silently dropping an insert when the target subtree had just been emptied within the same commit batch.

Single commit, 50 new lines (within the CI `check_commit.sh` 666-line limit). Fully independent — no dependency on other PRs.

## Root cause

`mergeInsert`'s monostate branch created a new leaf without setting `dirty = true`, so `mergeTrie`'s Phase 2 `!root->dirty` short-circuit skipped the storage-root recompute and the insert was lost (state root mismatch on the live chain: delete-last-leaf then insert-new-slot in one block).

## Fix

Set `leaf->dirty = true` when inserting into an emptied subtree. Regression test `DeleteLastLeafThenInsertNewSlotRecomputesStorageRoot` added.