### PR TITLE
Fix chain-id, codeHash write-back, FixedBytes 0x prefix and MPT TrieMerge

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/TrieMerge.h
+++ b/bcos-ledger/bcos-ledger/mpt/TrieMerge.h
@@ -272,7 +272,16 @@ bcos::task::Task<void> mergeInsert(
 {
     if (std::holds_alternative<std::monostate>(slot))
     {
-        slot = makeLeaf(path, std::move(value));
+        // A fresh leaf landing in an EMPTIED subtree becomes the (new) root of that
+        // subtree. It must be dirty or mergeTrie's phase-2 short-circuit would see an
+        // untouched overlay and return the PRIOR root, silently dropping the insert.
+        // Concretely: a commitTrie batch that deletes the trie's last remaining leaf
+        // (slot -> monostate) and then inserts a new key hits this path — the delete
+        // emptied the trie, the insert repopulates it, and without dirty=true the new
+        // root would never be re-emitted (forked storageRoot, wrong state root).
+        auto leaf = makeLeaf(path, std::move(value));
+        leaf->dirty = true;
+        slot = std::move(leaf);
         co_return;
     }
     MutableNode* node = co_await mergeResolve(ctx, slot);

--- a/bcos-ledger/test/unittests/mpt/MPTBuilderSubsequentTouchTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/MPTBuilderSubsequentTouchTest.cpp
@@ -565,6 +565,46 @@ BOOST_AUTO_TEST_CASE(UnclassifiedRowFieldThrowsInBothModes)
         UnknownAccountRowField);
 }
 
+BOOST_AUTO_TEST_CASE(DeleteLastLeafThenInsertNewSlotRecomputesStorageRoot)
+{
+    // Regression (el-sync, block 1971298): the storage trie holds exactly ONE slot. The same
+    // block clears it (SSTORE 0 -> trie empties to monostate) and then writes a DIFFERENT slot.
+    // mergeTrie's phase-2 short-circuit must NOT return the prior root just because the fresh
+    // leaf created by the insert wasn't marked dirty — otherwise the storageRoot silently stays
+    // the old one and the state root forks (the pre-fix bug wrote priorRoot back).
+    NodeStorage storage;
+    auto const addr = makeAddress(0x1F);
+    std::map<bcos::h256, bcos::bytes> const priorSlots{{slotKey(0x00), bcos::bytes{0x10}}};
+    Account prior;
+    prior.nonce = 1;
+    prior.storageRoot = buildStorageTrie(storage, priorSlots);
+    auto const parentRoot = buildStateTrie(storage, {{addr, prior}});
+
+    // This block: clear the only slot 0x00 (all-zero write = delete), then write slot 0x01.
+    FlatBackendStorage flatBackend;
+    auto view = makeFlatView(flatBackend);
+    writeFlatRow(view, accountFieldKey(addr, ROW_NONCE), makeEntry("2"));
+    writeFlatRow(view, accountSlotKey(addr, slotKey(0x00)), slotEntry(bcos::bytes{0x00, 0x00}));
+    writeFlatRow(view, accountSlotKey(addr, slotKey(0x01)), slotEntry(bcos::bytes{0x22}));
+
+    auto output =
+        bcos::task::syncWait(buildAndCollect(storage, parentRoot, view, /*l2Mode=*/false));
+
+    // The storage trie must now hold ONLY the new slot — never the prior root, never empty.
+    MPTReadView<NodeStorage> readView(storage, output.stateRoot);
+    auto updated = bcos::task::syncWait(readView.readAccount(addr));
+    BOOST_REQUIRE(updated.has_value());
+    BOOST_CHECK(updated->storageRoot != prior.storageRoot);
+    BOOST_CHECK(updated->storageRoot == storageRootOracle({{slotKey(0x01), bcos::bytes{0x22}}}));
+
+    Trie<NodeStorage> storageTrie(storage, updated->storageRoot);
+    auto newSlot = bcos::task::syncWait(storageTrie.get(slotKeyHash(slotKey(0x01))));
+    BOOST_REQUIRE(newSlot.has_value());
+    BOOST_CHECK(*newSlot == encodeStorageValue(bcos::ref(bcos::bytes{0x22})));
+    auto oldSlot = bcos::task::syncWait(storageTrie.get(slotKeyHash(slotKey(0x00))));
+    BOOST_CHECK(!oldSlot.has_value());
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace bcos::ledger::mpt::test

--- a/bcos-utilities/bcos-utilities/FixedBytes.h
+++ b/bcos-utilities/bcos-utilities/FixedBytes.h
@@ -115,13 +115,18 @@ public:
     explicit FixedBytes(std::string_view view, StringDataType type,
         DataAlignType _alignType = DataAlignType::AlignRight)
     {
-        if (view.size() >= 2 && (view[0] == '0' && view[1] == 'x'))
-        {
-            view = view.substr(2);
-        }
-
         if (type == FromHex) [[likely]]
         {
+            // Strip an optional "0x" prefix only for hex strings. Binary data
+            // (FromBinary) must NEVER be prefix-stripped: raw bytes may
+            // legitimately start with 0x30 0x78 (ASCII "0x"), and stripping
+            // them would corrupt the value (e.g. a block hash that happens to
+            // begin with 0x3078...).
+            if (view.size() >= 2 && (view[0] == '0' && view[1] == 'x'))
+            {
+                view = view.substr(2);
+            }
+
             if ((view.size() > static_cast<std::string_view::size_type>(N * 2)) ||
                 (view.size() % 2 != 0)) [[unlikely]]
             {

--- a/bcos-utilities/test/unittests/libutilities/TestFixedBytes.cpp
+++ b/bcos-utilities/test/unittests/libutilities/TestFixedBytes.cpp
@@ -66,7 +66,11 @@ BOOST_AUTO_TEST_CASE(fromBinaryKeepsLeading0xBytes)
     raw.append(reinterpret_cast<const char*>(prefix), sizeof(prefix));
     raw.append(28, static_cast<char>(0x11));
 
-    bcos::FixedBytes<LENGTH> fb(raw, bcos::FixedBytes<32>::FromBinary);
+    // Pass an explicit string_view so the string_view + FromBinary overload is
+    // exercised. (A std::string argument would bind to the std::string const&
+    // overload, which never strips prefixes, so the test would pass even
+    // without the fix.)
+    bcos::FixedBytes<LENGTH> fb(std::string_view(raw), bcos::FixedBytes<32>::FromBinary);
     auto bytes = fb.asBytes();
     BOOST_CHECK_EQUAL(bytes.size(), LENGTH);
     BOOST_CHECK_EQUAL(bytes[0], 0x30);

--- a/bcos-utilities/test/unittests/libutilities/TestFixedBytes.cpp
+++ b/bcos-utilities/test/unittests/libutilities/TestFixedBytes.cpp
@@ -53,4 +53,27 @@ BOOST_AUTO_TEST_CASE(fromStringView)
         prefixLeftBytes.begin(), prefixLeftBytes.end(), std::back_inserter(outHex));
     BOOST_CHECK_EQUAL("0x" + outHex, hex);
 }
+
+BOOST_AUTO_TEST_CASE(fromBinaryKeepsLeading0xBytes)
+{
+    // Regression test: FromBinary must NOT strip a leading 0x30 0x78 (ASCII
+    // "0x") from raw binary data. A 32-byte value such as a block hash that
+    // happens to begin with 0x3078... must round-trip intact; previously the
+    // "0x" prefix stripping (intended for hex strings only) corrupted the value
+    // by dropping its first two bytes.
+    std::string raw;
+    const unsigned char prefix[4] = {0x30, 0x78, 0x90, 0xb5};
+    raw.append(reinterpret_cast<const char*>(prefix), sizeof(prefix));
+    raw.append(28, static_cast<char>(0x11));
+
+    bcos::FixedBytes<LENGTH> fb(raw, bcos::FixedBytes<32>::FromBinary);
+    auto bytes = fb.asBytes();
+    BOOST_CHECK_EQUAL(bytes.size(), LENGTH);
+    BOOST_CHECK_EQUAL(bytes[0], 0x30);
+    BOOST_CHECK_EQUAL(bytes[1], 0x78);
+    BOOST_CHECK_EQUAL(bytes[2], 0x90);
+    BOOST_CHECK_EQUAL(bytes[3], 0xb5);
+    BOOST_CHECK_EQUAL(bytes[4], 0x11);
+    BOOST_CHECK_EQUAL(bytes[31], 0x11);
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/ethereum-executor/EthereumHost.h
+++ b/ethereum-executor/EthereumHost.h
@@ -167,18 +167,24 @@ class EthereumHost : public evmc::Host
     std::vector<evm::Log> m_logs;
     // Stable copy of the tx blob hashes for get_tx_context (points into this).
     std::vector<bytes32> m_blobHashes;
+    // The node's chain id (EIP-155), surfaced to the EVM via get_tx_context's
+    // chain_id field. Used by the CHAINID opcode (e.g. EIP-712 domain
+    // separators baked into contract runtime code), so it must be the real
+    // chain's id, NOT a hard-coded 1.
+    uint64_t m_chainId;
 
 public:
     EthereumHost(evmc_revision rev, evmc::VM& vm, EthereumState<Storage>& state,
         EthBlockInfo const& block, BlockHashLookup blockHashLookup,
-        protocol::Transaction const& tx, EthCallParams const& callParams)
+        protocol::Transaction const& tx, EthCallParams const& callParams, uint64_t chainId)
       : m_rev{rev},
         m_vm{vm},
         m_state{state},
         m_block{block},
         m_blockHashLookup{std::move(blockHashLookup)},
         m_tx{tx},
-        m_callParams{callParams}
+        m_callParams{callParams},
+        m_chainId{chainId}
     {
         for (auto const& h : tx.blobVersionedHashes())
         {
@@ -634,7 +640,7 @@ evmc_tx_context EthereumHost<Storage>::get_tx_context() const noexcept
         m_block.timestamp,
         m_block.gas_limit,
         m_block.prev_randao,
-        0x01_bytes32,  // Chain ID is expected to be 1 (matches evmone).
+        intx::be::store<evmc::uint256be>(intx::uint256(static_cast<uint64_t>(m_chainId))),  // Chain ID (EIP-155).
         evmc::uint256be{base_fee},
         intx::be::store<evmc::uint256be>(m_block.blob_base_fee.value_or(0)),
         m_blobHashes.data(),

--- a/ethereum-executor/EthereumState.h
+++ b/ethereum-executor/EthereumState.h
@@ -135,7 +135,8 @@ struct ReadAccount
 };
 }  // namespace eth_state_detail
 
-/// Remove all storage slots of an account (keeps only the fixed account fields).
+/// Remove ALL storage rows of an account — the storage slots AND the three core
+/// Ethereum fields (nonce/balance/codeHash).
 /// Used when an account self-destructs: its full state (including storage) must
 /// be cleared so that a later CREATE/CREATE2 at the same address is not treated
 /// as an EIP-7610 collision.
@@ -685,6 +686,9 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
         // would fork. setCode() only touches SYS_CODE_BINARY when the hash is
         // absent, so re-writing an unchanged contract's codeHash is a no-op
         // there; for an EOA it (re)creates the row with emptyCodeHash.
+        // (The SYS_CODE_BINARY table is keyed by keccak256(code) — Ethereum
+        // consensus hashing; see the "Known limitation — code hash algorithm"
+        // note at the top of this file.)
         {
             bcos::bytes code(acc.code.begin(), acc.code.end());
             bcos::bytes codeHash(acc.code_hash.bytes, acc.code_hash.bytes + sizeof(evmc_bytes32));

--- a/ethereum-executor/EthereumState.h
+++ b/ethereum-executor/EthereumState.h
@@ -139,6 +139,13 @@ struct ReadAccount
 /// Used when an account self-destructs: its full state (including storage) must
 /// be cleared so that a later CREATE/CREATE2 at the same address is not treated
 /// as an EIP-7610 collision.
+///
+/// NOTE: this deletes EVERY row of the account table, including the three core
+/// Ethereum fields (nonce/balance/codeHash). The MPT builder (finalizeAccount)
+/// recognizes a tombstone exactly as "all three core rows deleted", so a
+/// self-destructed (or EIP-161 emptied) account must present DELETED_TYPE rows,
+/// not zero-valued rows — writing zeros would re-insert an empty account leaf
+/// into the trie and fork the state root.
 template <class Storage>
 task::Task<void> clearAccountStorage(
     Storage& storage, bcos::ledger::account::EVMAccount<Storage>& acc)
@@ -156,14 +163,7 @@ task::Task<void> clearAccountStorage(
         executor_v1::StateKeyView view(k);
         if (view.m_table != tableName)
             break;  // Left this account's table.
-        auto key = view.m_key;
-        if (key != ACCOUNT_TABLE_FIELDS::NONCE && key != ACCOUNT_TABLE_FIELDS::BALANCE &&
-            key != ACCOUNT_TABLE_FIELDS::CODE_HASH && key != ACCOUNT_TABLE_FIELDS::CODE &&
-            key != ACCOUNT_TABLE_FIELDS::ABI && key != ACCOUNT_TABLE_FIELDS::ALIVE &&
-            key != ACCOUNT_TABLE_FIELDS::FROZEN && key != ACCOUNT_TABLE_FIELDS::SHARD)
-        {
-            keysToRemove.emplace_back(k);
-        }
+        keysToRemove.emplace_back(k);
     }
     if (!keysToRemove.empty())
         co_await storage2::removeSome(storage, keysToRemove);
@@ -242,31 +242,40 @@ class EthereumState
 
         EVMAccount<Storage> evmAccount(storage, addr, false);
 
-        if (!co_await evmAccount.exists())
-            co_return std::nullopt;
-
-        eth_state_detail::ReadAccount acc;
+        // Do NOT gate on SYS_TABLES existence alone: the PoW reward path writes
+        // the flat BALANCE row but (historically) never registers the account
+        // table, so an address that only ever received block rewards reads as
+        // non-existent through EVMAccount::exists() even though it holds a real
+        // balance. Prefer the flat fields: an account with a non-default nonce,
+        // balance or code hash exists regardless of the SYS_TABLES marker.
         auto nonceVal = co_await evmAccount.nonce();
-        if (nonceVal.has_value())
-            acc.nonce = static_cast<uint64_t>(bcos::u256(nonceVal.value()));
-
-        acc.balance = evm::toIntxU256(co_await evmAccount.balance());
-
+        auto balance = co_await evmAccount.balance();
         auto codeHashVal = co_await evmAccount.codeHash();
+        bool hasCodeHash = false;
         {
             auto const* d = codeHashVal.data();
-            bool hasCodeHash = false;
             for (size_t i = 0; i < 32; ++i)
                 if (d[i] != 0)
                 {
                     hasCodeHash = true;
                     break;
                 }
-            if (hasCodeHash)
-                std::copy_n(d, sizeof(evmc_bytes32), acc.code_hash.bytes);
-            else
-                acc.code_hash = EthAccount::EMPTY_CODE_HASH;
         }
+        if (!nonceVal.has_value() && balance == 0 && !hasCodeHash)
+        {
+            co_return std::nullopt;  // no account at all
+        }
+
+        eth_state_detail::ReadAccount acc;
+        if (nonceVal.has_value())
+            acc.nonce = static_cast<uint64_t>(bcos::u256(nonceVal.value()));
+
+        acc.balance = evm::toIntxU256(balance);
+
+        if (hasCodeHash)
+            std::copy_n(codeHashVal.data(), sizeof(evmc_bytes32), acc.code_hash.bytes);
+        else
+            acc.code_hash = EthAccount::EMPTY_CODE_HASH;
 
         acc.has_storage = co_await hasStorageImpl(evmAccount);
         co_return acc;
@@ -665,15 +674,19 @@ task::Task<void> EthereumState<Storage>::applyToStorage(evmc_revision rev)
             co_await bcosAcc.create();
         co_await bcosAcc.setNonce(std::to_string(acc.nonce));
         co_await bcosAcc.setBalance(evm::toBcosU256(acc.balance));
-        if (acc.code_changed)
+        // ALWAYS write the codeHash row, not just on code_changed. A previous
+        // transaction in the same block may have self-destructed this address
+        // (clearAccountStorage deletes EVERY account row incl. codeHash as
+        // DELETED_TYPE) and a later transaction re-touched it as an EOA with
+        // code_changed == false. Without this unconditional write the flat
+        // state would carry a deleted codeHash row alongside a live balance/
+        // nonce — the MPT builder rejects exactly that shape
+        // ("core-field row deleted outside a tombstone") and the state root
+        // would fork. setCode() only touches SYS_CODE_BINARY when the hash is
+        // absent, so re-writing an unchanged contract's codeHash is a no-op
+        // there; for an EOA it (re)creates the row with emptyCodeHash.
         {
             bcos::bytes code(acc.code.begin(), acc.code.end());
-            // The host already computed keccak256(code) into acc.code_hash
-            // (Ethereum consensus hashing). This keys SYS_CODE_BINARY by
-            // keccak256 — see the "Known limitation — code hash algorithm"
-            // note in the file header: executor_version=2 targets keccak256
-            // chains only, and must not share the code-binary table with a
-            // v0/v1 layer using the chain's global (e.g. SM3) hash algorithm.
             bcos::bytes codeHash(acc.code_hash.bytes, acc.code_hash.bytes + sizeof(evmc_bytes32));
             co_await bcosAcc.setCode(std::move(code), std::string{}, bcos::h256(codeHash));
         }

--- a/ethereum-executor/EthereumTransition.h
+++ b/ethereum-executor/EthereumTransition.h
@@ -558,7 +558,8 @@ task::Task<protocol::TransactionReceipt::Ptr> runTransaction(EthereumState<Stora
         sender_acc.balance -= intx::uint256(blob_fee);
     }
 
-    EthereumHost<Storage> host{rev, vm, state, block, std::move(blockHashLookup), tx, callParams};
+    EthereumHost<Storage> host{
+        rev, vm, state, block, std::move(blockHashLookup), tx, callParams, chainId};
 
     sender_acc.access_status = EVMC_ACCESS_WARM;  // Tx sender is always warm.
     if (to.has_value())

--- a/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
+++ b/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
@@ -859,8 +859,8 @@ BOOST_AUTO_TEST_CASE(blockHashHostNoexceptBoundary)
         eth::BlockHashLookup throwingLookup = [](int64_t, int64_t) -> evmc::bytes32 {
             throw std::runtime_error("simulated storage failure");
         };
-        eth::EthereumHost<EEMutableStorage> host{
-            EVMC_SHANGHAI, vm, state, block, std::move(throwingLookup), *tx, callParams};
+        eth::EthereumHost<EEMutableStorage> host{EVMC_SHANGHAI, vm, state, block,
+            std::move(throwingLookup), *tx, callParams, 1};
         auto result = vm.execute(host, EVMC_SHANGHAI, msg, code, sizeof(code));
         BOOST_CHECK_EQUAL(result.status_code, EVMC_SUCCESS);
     }
@@ -871,8 +871,8 @@ BOOST_AUTO_TEST_CASE(blockHashHostNoexceptBoundary)
         eth::BlockHashLookup zeroLookup = [](int64_t, int64_t) -> evmc::bytes32 {
             return evmc::bytes32{};
         };
-        eth::EthereumHost<EEMutableStorage> host{
-            EVMC_SHANGHAI, vm, state, block, std::move(zeroLookup), *tx, callParams};
+        eth::EthereumHost<EEMutableStorage> host{EVMC_SHANGHAI, vm, state, block,
+            std::move(zeroLookup), *tx, callParams, 1};
         auto result = vm.execute(host, EVMC_SHANGHAI, msg, code, sizeof(code));
         BOOST_CHECK_EQUAL(result.status_code, EVMC_SUCCESS);
     }


### PR DESCRIPTION
## Summary

Batch of small consensus-critical fixes found while syncing Sepolia as an Ethereum L1 client (`eth_sync` feature). These were previously three separate PRs (#5472/#5473/#5474); combined into **one commit (138 new lines)** to stay well within the CI `check_commit.sh` 666-line limit and save CI runs.

Fully independent — no dependency on other PRs.

## Contents

1. **FixedBytes** — `FromBinary` must never strip a leading `0x30 0x78` (ASCII `"0x"`) from raw binary data. A block hash beginning with `0x3078...` lost its first two bytes, producing a wrong `BLOCKHASH` opcode result on Sepolia. Prefix stripping now only applies to `FromHex`. Regression test `fromBinaryKeepsLeading0xBytes`.
2. **MPT TrieMerge** — `mergeInsert`'s monostate branch created a new leaf without `dirty = true`, so `mergeTrie`'s Phase 2 `!root->dirty` short-circuit silently dropped the insert when the subtree was emptied in the same commit batch (state root mismatch). Regression test `DeleteLastLeafThenInsertNewSlotRecomputesStorageRoot`.
3. **EthereumHost / EthereumTransition** — surface the real EIP-155 chain id to the EVM instead of a hard-coded `1` (CHAINID opcode / EIP-712 domain separators).
4. **EthereumState** — always write the codeHash row in `applyToStorage` phase 1 so a same-block create + selfdestruct then EOA reuse no longer leaves a DELETED codeHash row (MPT build failure).