### PR TITLE
feat(opstack): part 4b/5 — admission gates + OP block execution + serialization (split from #5429)

### DIFF
--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -140,8 +140,10 @@ struct ExecutionPayload
     u256 baseFeePerGas = 0;
     h256 blockHash;
     /// Transaction envelopes: each `EngineTransaction::raw` carries the EIP-2718
-    /// encoded bytes (including the OP 0x7E deposit envelope). Single authoritative
-    /// carrier for both generic and OP engine paths.
+    /// encoded bytes (including the OP 0x7E deposit envelope). Wire-replay carrier:
+    /// getPayload must return exactly these raw bytes. The OP execution path reads
+    /// `rawTransactions` below instead (both are populated from the same source bytes
+    /// at the RPC boundary — see EngineHelper.cpp).
     std::vector<EngineTransaction> transactions;
     bytes extraData;
     Address feeRecipient;
@@ -161,10 +163,29 @@ struct ExecutionPayload
     std::optional<bytes> blockAccessList = std::nullopt;
     std::optional<std::uint64_t> slotNumber = std::nullopt;
 
+    /// OP-mode carrier fields (op-validator-loop design §4.2/§5.2). Both are optional and unread
+    /// by the generic (non-OP) engine path — zero behavioral change for existing callers.
+    /// - rawTransactions: the block's transactions as raw EIP-2718 envelope bytes (typed tx
+    ///   MarshalBinary() output, including the OP 0x7E deposit envelope). This is the OP path's
+    ///   only transaction carrier consumed by the OP block executor (`processOpBlock`,
+    ///   opstack-executor/OpBlockExecute.h)
+    ///   (via its `rawTxBytes` parameter) — `transactions` above (bcos::protocol::Transactions)
+    ///   is the generic-path carrier and is not populated/read on the OP path.
+    /// - withdrawalsRoot: OP Isthmus+ extends the payload with an explicit withdrawals-root field
+    ///   (= MessagePasser storage root) that cannot be derived from the (always-empty)
+    ///   `withdrawals` list above — op-geth's NewPayloadV4 requires it on OP chains (design §5.2).
+    /// Invariant: when both carriers are populated, `rawTransactions[i]` and
+    /// `transactions[i].raw` must hold identical bytes (paired push in
+    /// EngineHelper::parseNewPayloadRequest). Every payload therefore stores the tx bytes
+    /// twice, one copy dead per path (generic never reads rawTransactions; OP never reads
+    /// transactions) — intentional, keeps each path's carrier self-contained at the cost of
+    /// one block-sized buffer per NewPayload call.
+    std::optional<std::vector<bytes>> rawTransactions = std::nullopt;
+
     // Required by ExecutionPayloadV4/V5 (OP Stack, Isthmus onwards): storage root of
     // the L2ToL1MessagePasser predeploy. May carry a placeholder until real-value
     // header wiring lands.
-    std::optional<h256> withdrawalsRoot;
+    std::optional<h256> withdrawalsRoot = std::nullopt;
 };
 
 struct NewPayloadRequest

--- a/bcos-framework/bcos-framework/protocol/Transaction.cpp
+++ b/bcos-framework/bcos-framework/protocol/Transaction.cpp
@@ -1,6 +1,7 @@
 #include "bcos-framework/protocol/Transaction.h"
 
 #include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-utilities/BoostLog.h>
 #include <boost/throw_exception.hpp>
 #include <stdexcept>
@@ -121,6 +122,49 @@ void Transaction::verify(crypto::Hash& hashImpl, crypto::SignatureCrypto& signat
     }
 
     auto const signature = signatureData();
+    // Defense-in-depth BEFORE recoverAddress: an explicitly-sized check gives a precise error
+    // (recoverAddress's checkSigLen would throw a generic InvalidSignature for the same input).
+    // All legitimate Web3 signatures are exactly 65 bytes (r||s||v, assembled by
+    // takeToTarsTransaction); a different length means malformed tars deserialization or a
+    // hostile peer. Deposits never legitimately reach verify() — admission rejects 0x7e and
+    // the engine path decodes via decodeDepositEnvelope — so an empty/short signature here is
+    // treated as malformed (fail-closed), never as an unsigned deposit.
+    if (type() == static_cast<uint8_t>(TransactionType::Web3Transaction) && signature.size() != 65)
+        [[unlikely]]
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("EIP-2: Web3 signature must be exactly 65 bytes (v, r, s)"));
+    }
+    // The EIP-2 r/s range and v-domain checks are alloc-free and need only the signature bytes,
+    // so they run BEFORE the EC recovery: hostile peers pay nothing per rejected signature
+    // (same ordering as the RPC decode funnel).
+    if (type() == static_cast<uint8_t>(TransactionType::Web3Transaction))
+    {
+        auto const r = bcos::fromBigEndian<u256>(signature.getCroppedData(0, 32));
+        auto const s = bcos::fromBigEndian<u256>(signature.getCroppedData(32, 32));
+        if (r == 0 || r >= bcos::crypto::c_secp256k1n || s == 0 ||
+            s > bcos::crypto::c_secp256k1nOver2) [[unlikely]]
+        {
+            // n is odd, so n/2 = (n-1)/2; s > (n-1)/2 is equivalent to s >= ceil(n/2),
+            // matching op-geth's secp256k1.IsCanonical check.
+            BOOST_THROW_EXCEPTION(std::invalid_argument(
+                "EIP-2: invalid signature (r out of [1,n-1] or s exceeds secp256k1n/2)"));
+        }
+        // The tars signature byte is the recovery id / yParity — always 0/1 by construction:
+        // LegacyTxHandler::decode normalizes legacy v (27/28 -> v-27, EIP-155 -> (v-35)%2) and
+        // the typed handlers store y_parity; secp256k1Sign stores the raw recid (0/1; 2/3 only
+        // in the rare r < p - n corner where x0 = r + n is the recovered x — such r passes the
+        // r < n check above, so the value needs its own gate). A signature byte > 1 (recid 2/3,
+        // the v=29/30 envelope form) is never produced by the RPC funnel; op-geth rejects the
+        // same in decode and Sender(). Applies to typed AND legacy envelopes — the
+        // envelope-vs-preimage distinction lives in extraTransactionBytes, not in this byte.
+        auto const& env = extraTransactionBytes();
+        if (!env.empty() && signature[64] > 1) [[unlikely]]
+        {
+            BOOST_THROW_EXCEPTION(std::invalid_argument(
+                "EIP-2718/EIP-155: recovery id exceeds 1 in transaction signature"));
+        }
+    }
     auto [recovered, sender] = signatureImpl.recoverAddress(hashImpl, hashResult, signature);
     if (!recovered) [[unlikely]]
     {

--- a/bcos-ledger/bcos-ledger/LedgerMethods.cpp
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.cpp
@@ -486,7 +486,11 @@ bcos::task::Task<void> bcos::ledger::tag_invoke(
     auto auth = sysConfig.getOrDefault(ledger::SystemConfig::auth_check_status, "0");
     ledgerConfig.setAuthCheckStatus(boost::lexical_cast<uint32_t>(auth.first));
     auto [chainId, _] = sysConfig.getOrDefault(ledger::SystemConfig::web3_chain_id, "0");
-    ledgerConfig.setChainId(bcos::toEvmC(boost::lexical_cast<u256>(chainId)));
+    // Shared parse (ledger::parseWeb3ChainId) with the gate consumers; a corrupted config
+    // falls back to chain id 0 rather than throwing out of loadChainConfig (the config is
+    // governed on-chain; 0 keeps the previous "0" default semantics).
+    ledgerConfig.setChainId(
+        bcos::toEvmC(ledger::parseWeb3ChainId(chainId).value_or(bcos::u256{0})));
     ledgerConfig.setBalanceTransfer(
         sysConfig.getOrDefault(ledger::SystemConfig::balance_transfer, "0").first != "0");
 

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -64,25 +64,27 @@ JsonRpcImpl_2_0::JsonRpcImpl_2_0(GroupManager::Ptr _groupManager,
     m_forceSender(std::move(forceSender))
 {
     m_wsService->registerMsgHandler(bcos::protocol::MessageType::RPC_REQUEST,
-        [this](boostssl::ws::WsMessage msg, std::shared_ptr<boostssl::ws::WsSession> session) {
+        [this](std::shared_ptr<boostssl::MessageFace> msg,
+            std::shared_ptr<boostssl::ws::WsSession> session) {
             this->handleRpcRequest(std::move(msg), std::move(session));
         });
 }
 
 void JsonRpcImpl_2_0::handleRpcRequest(
-    boostssl::ws::WsMessage _msg, std::shared_ptr<boostssl::ws::WsSession> _session)
+    std::shared_ptr<boostssl::MessageFace> _msg, std::shared_ptr<boostssl::ws::WsSession> _session)
 {
-    auto buffer = _msg.payload();
+    auto buffer = _msg->payload();
     auto req = std::string_view((const char*)buffer.data(), buffer.size());
 
     auto start = std::chrono::high_resolution_clock::now();
-    auto seq = _msg.seq();
-    auto version = _msg.version();
-    auto ext = _msg.ext();
+    auto seq = _msg->seq();
+    auto version = _msg->version();
+    auto ext = _msg->ext();
 
     auto weakptrSession = std::weak_ptr<boostssl::ws::WsSession>(_session);
+    auto messageFactory = m_wsService->messageFactory();
 
-    onRPCRequest(req, [ext, seq, version, weakptrSession, start](
+    onRPCRequest(req, [ext, seq, version, weakptrSession, messageFactory, start](
                           bcos::bytes resp, boost::beast::http::status) {
         auto session = weakptrSession.lock();
 
@@ -100,11 +102,11 @@ void JsonRpcImpl_2_0::handleRpcRequest(
         if (session->isConnected())
         {
             // TODO: no need to copy resp
-            bcos::boostssl::ws::WsMessage msg;
-            msg.setPayload(std::move(resp));
-            msg.setVersion(version);
-            msg.setSeq(seq);
-            msg.setExt(ext);
+            auto msg = messageFactory->buildMessage();
+            msg->setPayload(std::move(resp));
+            msg->setVersion(version);
+            msg->setSeq(seq);
+            msg->setExt(ext);
             session->asyncSendMessage(msg);
         }
         else
@@ -250,18 +252,66 @@ void bcos::rpc::toJsonResp(Json::Value& jResp, bcos::protocol::Transaction const
         auto extraBytesRef =
             bcos::bytesRef(const_cast<byte*>(transaction.extraTransactionBytes().data()),
                 transaction.extraTransactionBytes().size());
-        codec::rlp::decodeFromPayload(extraBytesRef, web3Tx);
-        jResp["value"] = web3Tx.value.str();
-        jResp["gasLimit"] = web3Tx.gasLimit;
-        if (web3Tx.type >= TransactionType::EIP1559)
+        if (auto error = codec::rlp::decodeFromPayload(extraBytesRef, web3Tx); error != nullptr)
         {
-            jResp["maxPriorityFeePerGas"] = web3Tx.maxPriorityFeePerGas.str();
-            jResp["maxFeePerGas"] = web3Tx.maxFeePerGas.str();
-            jResp["gasPrice"] = "0";
+            // Undecodable web3 payload (corrupt extraTransactionBytes): emit zeroed fields
+            // instead of half-decoded state (same posture as TransactionResponse.cpp).
+            WEB3_LOG(WARNING) << LOG_DESC("JsonRpcImpl: undecodable web3 payload")
+                              << LOG_KV("txHash", transaction.hash().hexPrefixed());
+            jResp["value"] = "0x0";
+            jResp["gasLimit"] = "0x0";
+            jResp["gasPrice"] = "0x0";
         }
         else
         {
-            jResp["gasPrice"] = web3Tx.maxPriorityFeePerGas.str();
+            jResp["value"] = toQuantity(web3Tx.value);
+            jResp["gasLimit"] = web3Tx.gasLimit;
+            // Use explicit range check rather than `>=` so that Deposit (0x7e), which is
+            // numerically larger than all EIP types, is excluded from EIP-1559 field output.
+            // EIP-7702 is a fee-market type, so the upper bound is EIP7702 (matching
+            // TransactionResponse.cpp).
+            if (web3Tx.type >= TransactionType::EIP1559 && web3Tx.type <= TransactionType::EIP7702)
+            {
+                jResp["maxPriorityFeePerGas"] = toQuantity(web3Tx.maxPriorityFeePerGas);
+                jResp["maxFeePerGas"] = toQuantity(web3Tx.maxFeePerGas);
+                jResp["gasPrice"] = "0x0";
+            }
+            else
+            {
+                jResp["gasPrice"] = toQuantity(web3Tx.maxPriorityFeePerGas);
+            }
+        }
+        // accessList (EIP-2930+) and authorizationList (EIP-7702) — same serialization as
+        // TransactionResponse.cpp (geth parity).
+        if (web3Tx.type >= TransactionType::EIP2930 && web3Tx.type <= TransactionType::EIP7702)
+        {
+            jResp["accessList"] = Json::arrayValue;
+            for (const auto& accessList : web3Tx.accessList)
+            {
+                Json::Value access = Json::objectValue;
+                access["address"] = accessList.account.hexPrefixed();
+                access["storageKeys"] = Json::arrayValue;
+                for (const auto& storageKey : accessList.storageKeys)
+                {
+                    access["storageKeys"].append(storageKey.hexPrefixed());
+                }
+                jResp["accessList"].append(std::move(access));
+            }
+        }
+        if (web3Tx.type == TransactionType::EIP7702)
+        {
+            jResp["authorizationList"] = Json::arrayValue;
+            for (const auto& auth : web3Tx.authorizationList)
+            {
+                Json::Value entry = Json::objectValue;
+                entry["chainId"] = toQuantity(auth.chainId);
+                entry["address"] = auth.address.hexPrefixed();
+                entry["nonce"] = toQuantity(auth.nonce);
+                entry["yParity"] = toQuantity(auth.yParity);
+                entry["r"] = toQuantity(auth.r);
+                entry["s"] = toQuantity(auth.s);
+                jResp["authorizationList"].append(std::move(entry));
+            }
         }
     }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -47,6 +47,7 @@
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 #include <cstdint>
@@ -54,7 +55,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::rpc;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -70,7 +70,7 @@ bcos::bytes parseRawTransactionElement(
 ///
 /// The isString() gate is what makes the check complete. jsoncpp's asString() does NOT
 /// reject a number or a bool: it stringifies them (json_value.cpp Value::asString), so
-/// `"gasLimit": 10` used to arrive as "10" and then be read as HEX 0x10 = 16 — a value
+/// `"gasLimit": 10` arrives as "10" and then be read as HEX 0x10 = 16 — a value
 /// forgery worse than the malformed-hex case. Only an array/object throws
 /// Json::LogicError there, which would surface as -32603.
 bcos::u256 parseBigQuantity(Json::Value const& value, std::string_view field)
@@ -331,6 +331,9 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .withdrawals = std::nullopt,
         .blobGasUsed = std::nullopt,
         .excessBlobGas = std::nullopt,
+        .blockAccessList = std::nullopt,
+        .slotNumber = std::nullopt,
+        .rawTransactions = std::nullopt,
         .withdrawalsRoot = std::nullopt,
     };
     if (ep.isMember("extraData"))
@@ -355,13 +358,24 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 InvalidParams, "Expected array of hex strings for executionPayload.transactions"));
         }
-        // Raw EIP-2718 bytes, hex-decoded verbatim. No transaction decoding happens
-        // here — getPayload must later return exactly these bytes.
+        // Raw EIP-2718 bytes, hex-decoded verbatim, kept in BOTH carriers:
+        //   - payload.transactions (EngineTransaction{raw, decoded=nullptr}) — the Engine-API
+        //     wire form; getPayload must later return exactly these raw bytes. No decoding
+        //     happens here — classification/decoding of the raw bytes is the dispatch table's
+        //     job (bcos-framework/engine/RawTransactionDispatch.h), matching upstream.
+        //   - payload.rawTransactions (vector<bytes>) — the OP path's sole tx carrier (raw
+        //     EIP-2718 envelope bytes incl. the 0x7E deposit), consumed by the OP block
+        //     executor (processOpBlock).
         payload.transactions.reserve(ep["transactions"].size());
+        payload.rawTransactions.emplace();
+        payload.rawTransactions->reserve(ep["transactions"].size());
         for (Json::ArrayIndex i = 0; i < ep["transactions"].size(); ++i)
         {
-            payload.transactions.push_back(bcos::engine::EngineTransaction{
-                .raw = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i),
+            auto txData = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i);
+            payload.rawTransactions->push_back(txData);  // keep unconditionally: OP carrier is
+                                                         // decoupled from decode
+            payload.transactions.push_back(engine::EngineTransaction{
+                .raw = std::move(txData),
                 .decoded = nullptr,
             });
         }

--- a/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
@@ -1,0 +1,168 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+// op-geth golden corpus 真实 raw tx（val-loop bcos-evm/test/opstack/t8n/golden/engine/
+// isthmus_access_list.golden.json rawTransactions[0]/[1]，逐字节核验一致）：0x7E deposit +
+// 0x02 EIP-1559 typed。两者经 decodeTransaction 必抛 TarsDecodeMismatch（tars 误解析 RLP）——
+// transactions 填充分支容错跳过，rawTransactions 是 W1 的核心断言对象。
+constexpr std::string_view kDepositRawTx =
+    "0x7ef90104a0ae1a1f61e85683e8084e5004f4c36b050cb2ea1e5f78f1e7d518163ade648a7994deaddeaddeaddead"
+    "deaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be00"
+    "000558000c5fc500000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000006fc23ac0000000000000000000000000000000000000000000000000000000000000f42"
+    "4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000000000000000000000000000";
+constexpr std::string_view kEip1559RawTx =
+    "0x02f8e0822105808405f5e1008477359400830186a094c0de0000000000000000000000000000000000058080f872"
+    "f85994c0de000000000000000000000000000000000005f842a0000000000000000000000000000000000000000000"
+    "0000000000000000000000a00000000000000000000000000000000000000000000000000000000000000005d694dd"
+    "ddddddddddddddddddddddddddddddddddddddc080a0394ee65265d6d1eead7675c85dc4dfa781d7d9b1d27392f51d"
+    "d7feb5d8f2f27ba0434c6ec29d5d0e3b781f461538d61e7120c5f25a33dd5f8a230aa8259dba7d0c";
+constexpr std::string_view kWithdrawalsRoot =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+std::shared_ptr<bcos::protocol::TransactionFactory> makeTxFactory()
+{
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    return std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+}
+
+Json::Value makePayloadParams(
+    std::vector<std::string_view> rawTxs, std::string_view withdrawalsRoot)
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = "0x" + std::string(64, '0');
+    ep["stateRoot"] = "0x" + std::string(64, '0');
+    ep["receiptsRoot"] = "0x" + std::string(64, '0');
+    ep["prevRandao"] = "0x" + std::string(64, '0');
+    ep["gasLimit"] = "0x1c9c380";
+    ep["gasUsed"] = "0x0";
+    ep["baseFeePerGas"] = "0x1";
+    ep["blockHash"] = "0x" + std::string(64, '0');
+    ep["feeRecipient"] = "0x" + std::string(40, '0');
+    ep["timestamp"] = "0x1";
+    ep["blockNumber"] = "0x1";
+    ep["logsBloom"] = "0x" + std::string(512, '0');
+    ep["extraData"] = "0x";
+    ep["withdrawals"] = Json::Value(Json::arrayValue);
+    ep["blobGasUsed"] = "0x0";
+    ep["excessBlobGas"] = "0x0";
+    if (withdrawalsRoot.size())
+    {
+        ep["withdrawalsRoot"] = std::string(withdrawalsRoot);
+    }
+    Json::Value txs(Json::arrayValue);
+    for (auto const& raw : rawTxs)
+    {
+        txs.append(std::string(raw));
+    }
+    ep["transactions"] = txs;
+    // V4 wire shape: [executionPayload, expectedBlobVersionedHashes,
+    // parentBeaconBlockRoot, executionRequests] — parse enforces the full array.
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+    params.append(Json::Value(Json::arrayValue));
+    params.append("0x3333333333333333333333333333333333333333333333333333333333333333");
+    params.append(Json::Value(Json::arrayValue));
+    return params;
+}
+
+BOOST_AUTO_TEST_SUITE(EngineHelperTest)
+
+// rawTransactions 逐字节保留输入；transactions 同步解码。
+BOOST_AUTO_TEST_CASE(parseFillsRawTransactionsPreservingBytes)
+{
+    auto params = makePayloadParams({kDepositRawTx, kEip1559RawTx}, kWithdrawalsRoot);
+    auto factory = makeTxFactory();
+    // 不得抛：transactions 填充分支容错跳过 decode 失败的 typed tx。
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_REQUIRE_EQUAL(request.executionPayload.rawTransactions->size(), 2u);
+    // 逐字节比对：rawTransactions[i] == fromHex(rawTx[i])
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.rawTransactions->at(i) == expect);
+    }
+    // 合并后语义（上游 parse 不解码，解码交给执行时 dispatch table）：transactions 以
+    // EngineTransaction{raw, decoded=nullptr} 携带 wire 字节；rawTransactions 保留 OP 载体。
+    BOOST_REQUIRE_EQUAL(request.executionPayload.transactions.size(), 2u);
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.transactions[i].raw == expect);
+        BOOST_CHECK(request.executionPayload.transactions[i].decoded == nullptr);
+    }
+}
+
+// withdrawalsRoot 正确解析为 h256。
+BOOST_AUTO_TEST_CASE(parseFillsWithdrawalsRoot)
+{
+    auto params = makePayloadParams({kEip1559RawTx}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.withdrawalsRoot.has_value());
+    auto expect = fromHex(kWithdrawalsRoot);
+    BOOST_CHECK_EQUAL(request.executionPayload.withdrawalsRoot->size(), 32u);
+    BOOST_CHECK(std::equal(
+        expect.begin(), expect.end(), request.executionPayload.withdrawalsRoot->begin()));
+}
+
+// withdrawalsRoot 缺省 → nullopt；错长（31/33 字节）→ bcos::rpc::JsonRpcException。
+BOOST_AUTO_TEST_CASE(parseWithdrawalsRootBoundaries)
+{
+    // Missing withdrawalsRoot on V4 is a malformed payload:
+    // -32602 at parse time, not a silent nullopt (the engine-side INVALID-status
+    // rule covers in-process callers).
+    auto noRoot = makePayloadParams({kEip1559RawTx}, "");
+    BOOST_CHECK_EXCEPTION(parseNewPayloadRequest(noRoot, engine::ApiVersion::V4),
+        bcos::rpc::JsonRpcException, [](auto const& e) { return e.code() == InvalidParams; });
+
+    // 31 字节（62 hex）
+    auto badShort = makePayloadParams({kEip1559RawTx}, "0x" + std::string(62, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badShort, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+    // 33 字节（66 hex）
+    auto badLong = makePayloadParams({kEip1559RawTx}, "0x" + std::string(66, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badLong, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+}
+
+// 缺 transactions 键 → rawTransactions 保持 nullopt（OP 校验 :299 仍拒）。
+BOOST_AUTO_TEST_CASE(parseMissingTransactionsLeavesRawNullopt)
+{
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    params[0].removeMember("transactions");
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_CHECK(!request.executionPayload.rawTransactions.has_value());
+}
+
+// transactions 存在但为空数组 → rawTransactions present-and-empty（OP 校验 :299 接受）。
+BOOST_AUTO_TEST_CASE(parseEmptyTransactionsIsPresentAndEmpty)
+{
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_CHECK(request.executionPayload.rawTransactions->empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <boost/test/unit_test.hpp>
 #include <future>
@@ -19,11 +20,70 @@ using namespace bcos::rpc;
 
 namespace bcos::test
 {
+// FakeLedger::asyncGetTransactionReceiptByHash always reports null (FakeLedger.h:360-364), so
+// seeding storage is inert for eth_getTransactionReceipt. This subclass overrides it to return a
+// seeded receipt, and re-seeds the tx-by-hash lookup with a safe implementation: FakeLedger's
+// storeTransactionsAndReceipts dereferences a default-constructed null shared_ptr (txData is never
+// allocated), so the inherited path cannot be used to populate m_txsHashToData.
+class SeedableLedger : public bcos::test::FakeLedger
+{
+public:
+    SeedableLedger(bcos::protocol::BlockFactory::Ptr blockFactory, size_t blockNumber,
+        size_t txsSize, size_t receiptsSize)
+      : bcos::test::FakeLedger(blockFactory, blockNumber, txsSize, receiptsSize),
+        m_blockFactory(std::move(blockFactory))
+    {}
+
+    protocol::TransactionReceipt::Ptr seededReceipt;
+    std::map<crypto::HashType, std::shared_ptr<bcos::bytes>> m_seedTxs;
+
+    void asyncGetTransactionReceiptByHash(crypto::HashType const&, bool,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr, MerkleProofPtr)> callback)
+        override
+    {
+        callback(nullptr, seededReceipt, nullptr);
+    }
+
+    void asyncGetBatchTxsByHashList(crypto::HashListPtr _txHashList, bool,
+        std::function<void(
+            Error::Ptr, TransactionsPtr, std::shared_ptr<std::map<std::string, MerkleProofPtr>>)>
+            _onGetTx) override
+    {
+        auto txs = std::make_shared<Transactions>();
+        for (auto const& hash : *_txHashList)
+        {
+            if (auto it = m_seedTxs.find(hash); it != m_seedTxs.end())
+            {
+                auto tx = m_blockFactory->transactionFactory()->createTransaction(
+                    bcos::ref(*(it->second)), /*checkSig=*/false);
+                txs->emplace_back(tx);
+            }
+        }
+        _onGetTx(nullptr, txs, nullptr);
+    }
+
+    void seedTx(bcos::protocol::Transaction::Ptr tx)
+    {
+        auto txHash = tx->hash();
+        auto txData = std::make_shared<bcos::bytes>();
+        tx->encode(*txData);
+        m_seedTxs[txHash] = std::move(txData);
+    }
+
+private:
+    bcos::protocol::BlockFactory::Ptr m_blockFactory;
+};
+
 // Drives the web3 (eth_/net_/web3_) coroutine endpoints through the real
 // dispatch path. EthEndpoint.cpp (596 lines) was at 24% because the existing
 // Web3RpcTest only touched ~10 of the ~44 registered methods. onRPCRequest
 // runs the handler coroutine to completion and hands back the JSON via a
 // promise, so the whole thing is synchronous from the test's point of view.
+//
+// Assertion discipline (round-7 review Finding A): every case anchors the
+// response SHAPE it actually produces under the fixture — result present with
+// the expected member structure, or error present with the expected code —
+// never the tautological `result || error`.
 class Web3MethodsFixture : public RPCFixture
 {
 public:
@@ -55,6 +115,27 @@ public:
                R"(","params":)" + std::string(params) + "}";
     }
 
+    // Success-path helper: require a non-null result and the given member names.
+    static void requireResultMembers(
+        Json::Value const& resp, std::initializer_list<std::string_view> members)
+    {
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_REQUIRE(!resp["result"].isNull());
+        for (auto const& m : members)
+        {
+            BOOST_CHECK_MESSAGE(resp["result"].isMember(std::string(m)),
+                "result missing member: " + std::string(m));
+        }
+    }
+
+    // Error-path helper: require an error object with the given code.
+    static void requireError(Json::Value const& resp, int code)
+    {
+        BOOST_REQUIRE(resp.isMember("error"));
+        BOOST_REQUIRE(resp["error"].isMember("code"));
+        BOOST_CHECK_EQUAL(resp["error"]["code"].asInt(), code);
+    }
+
     Rpc::Ptr rpc;
     Web3JsonRpcImpl::Ptr web3JsonRpc;
 };
@@ -64,57 +145,84 @@ BOOST_FIXTURE_TEST_SUITE(Web3EthMethodsTest, Web3MethodsFixture)
 BOOST_AUTO_TEST_CASE(getBlockByNumberLatest)
 {
     auto resp = call(req("eth_getBlockByNumber", R"(["latest",false])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {"number", "hash", "transactions", "stateRoot"});
+    BOOST_CHECK(resp["result"]["transactions"].isArray());
     BOOST_CHECK(resp.isMember("id"));
 }
 
 BOOST_AUTO_TEST_CASE(getBlockByNumberFullTxs)
 {
+    // fullTransactions=true: transactions are objects, not hashes.
     auto resp = call(req("eth_getBlockByNumber", R"(["0x1",true])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {"number", "hash", "transactions"});
+    BOOST_REQUIRE(resp["result"]["transactions"].isArray());
+    BOOST_REQUIRE(resp["result"]["transactions"].size() > 0);
+    BOOST_CHECK(resp["result"]["transactions"][0].isMember("hash"));
+    BOOST_CHECK(resp["result"]["transactions"][0].isMember("from"));
+    BOOST_CHECK(resp["result"]["transactions"][0].isMember("input"));
 }
 
 BOOST_AUTO_TEST_CASE(getBlockTransactionCountByNumber)
 {
+    // The fixture ledger has 10 txs in block 1 (FakeLedger(20, 10, 10)).
     auto resp = call(req("eth_getBlockTransactionCountByNumber", R"(["0x1"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {});
+    BOOST_CHECK(resp["result"].isString());
+    BOOST_CHECK_NE(resp["result"].asString(), "");
+    BOOST_CHECK(resp["result"].asString().find("0x") == 0);
 }
 
 BOOST_AUTO_TEST_CASE(getTransactionByHashUnknown)
 {
+    // Unknown hash resolves to result:null (JSON-RPC null, not an error).
     auto resp = call(req("eth_getTransactionByHash",
         R"(["0x0000000000000000000000000000000000000000000000000000000000000001"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    BOOST_CHECK(resp["result"].isNull());
 }
 
 BOOST_AUTO_TEST_CASE(getTransactionReceiptUnknown)
 {
+    // Unknown receipt resolves to result:null (JSON-RPC null, not an error).
     auto resp = call(req("eth_getTransactionReceipt",
         R"(["0x0000000000000000000000000000000000000000000000000000000000000001"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    BOOST_CHECK(resp["result"].isNull());
 }
 
 BOOST_AUTO_TEST_CASE(malformedParamsReportError)
 {
-    // Wrong arity / type should surface a JSON-RPC error, not crash.
+    // Missing params must not crash: EthEndpoint tolerates an absent params
+    // array by falling back to the latest-block default, so the response is a
+    // real block object (probe-verified under the fixture).
     auto resp = call(req("eth_getBlockByNumber", R"([])"));
-    BOOST_CHECK(resp.isMember("error") || resp.isMember("result"));
+    requireResultMembers(resp, {"number", "hash"});
 }
 
 BOOST_AUTO_TEST_CASE(getBlockTransactionCountByNumberEarliestAndPending)
 {
-    for (auto tag : {R"(["earliest"])", R"(["pending"])", R"(["0x0"])"})
+    // "0x0" answers the quantity for block 0 (10 txs in the fixture ledger).
+    auto zero = call(req("eth_getBlockTransactionCountByNumber", R"(["0x0"])"));
+    requireResultMembers(zero, {});
+    BOOST_CHECK(zero["result"].isString());
+    // earliest/pending tags are not quantity-parsable in this implementation
+    // (fromQuantity throws -> internal error), so they must at least surface a
+    // JSON-RPC error response rather than crash the dispatch path.
+    for (auto tag : {R"(["earliest"])", R"(["pending"])"})
     {
         auto resp = call(req("eth_getBlockTransactionCountByNumber", tag));
-        BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+        BOOST_REQUIRE(resp.isMember("error"));
+        BOOST_CHECK(resp["error"].isMember("code"));
         BOOST_CHECK(resp.isMember("id"));
     }
 }
 
 BOOST_AUTO_TEST_CASE(getTransactionByBlockNumberAndIndex)
 {
+    // Out-of-range index (10 txs, index 0 is valid in the fake chain).
     auto resp = call(req("eth_getTransactionByBlockNumberAndIndex", R"(["0x1","0x0"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    BOOST_CHECK(resp["result"].isNull());
 }
 
 BOOST_AUTO_TEST_CASE(callOnSchedulerBackedPath)
@@ -123,7 +231,8 @@ BOOST_AUTO_TEST_CASE(callOnSchedulerBackedPath)
     // receipt), so it should produce a result rather than crash.
     auto resp = call(req("eth_call",
         R"([{"to":"0x1234567890123456789012345678901234567890","data":"0x"},"latest"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {});
+    BOOST_CHECK(resp["result"].isString());
     BOOST_CHECK(resp.isMember("id"));
 }
 
@@ -133,8 +242,7 @@ BOOST_AUTO_TEST_CASE(getBlockByNumberExtendedTags)
              R"(["finalized",false])"})
     {
         auto resp = call(req("eth_getBlockByNumber", tag));
-        BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
-        BOOST_CHECK(resp.isMember("id"));
+        requireResultMembers(resp, {"number", "hash", "transactions"});
     }
 }
 
@@ -144,7 +252,8 @@ BOOST_AUTO_TEST_CASE(getBalanceEmptyStorageReturnsZero)
     // handler yields 0x0 rather than crashing.
     auto resp =
         call(req("eth_getBalance", R"(["0x1234567890123456789012345678901234567890","latest"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {});
+    BOOST_CHECK_EQUAL(resp["result"].asString(), "0x0");
     BOOST_CHECK(resp.isMember("id"));
 }
 
@@ -152,57 +261,71 @@ BOOST_AUTO_TEST_CASE(getTransactionCountEmptyStorage)
 {
     auto resp = call(req(
         "eth_getTransactionCount", R"(["0x1234567890123456789012345678901234567890","latest"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {});
+    BOOST_CHECK_EQUAL(resp["result"].asString(), "0x0");
 }
 
 BOOST_AUTO_TEST_CASE(getStorageAtEmptyStorage)
 {
     auto resp = call(req(
         "eth_getStorageAt", R"(["0x1234567890123456789012345678901234567890","0x0","latest"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {});
+    // Empty storage reads as a full 32-byte zero word.
+    BOOST_CHECK_EQUAL(resp["result"].asString(),
+        "0x0000000000000000000000000000000000000000000000000000000000000000");
 }
 
 BOOST_AUTO_TEST_CASE(uncleMethodsReturnEmpty)
 {
     // BCOS has no uncles; these must answer with null/0x0, not error/crash.
-    for (auto const& r : {req("eth_getUncleCountByBlockNumber", R"(["0x1"])"),
-             req("eth_getUncleByBlockNumberAndIndex", R"(["0x1","0x0"])")})
-    {
-        auto resp = call(r);
-        BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
-        BOOST_CHECK(resp.isMember("id"));
-    }
+    auto count = call(req("eth_getUncleCountByBlockNumber", R"(["0x1"])"));
+    requireResultMembers(count, {});
+    BOOST_CHECK_EQUAL(count["result"].asString(), "0x0");
+
+    auto uncle = call(req("eth_getUncleByBlockNumberAndIndex", R"(["0x1","0x0"])"));
+    BOOST_REQUIRE(uncle.isMember("result"));
+    // BCOS returns no uncles: result is either JSON null or the string "null".
+    BOOST_CHECK(uncle["result"].isNull() || uncle["result"].asString() == "null");
 }
 
 BOOST_AUTO_TEST_CASE(blockAndPendingFiltersRegister)
 {
     // eth_newBlockFilter / eth_newPendingTransactionFilter register an in-memory
-    // filter and return its id.
+    // filter and return its id (a hex quantity string).
     auto blockFilter = call(req("eth_newBlockFilter"));
-    BOOST_CHECK(blockFilter.isMember("result") || blockFilter.isMember("error"));
+    requireResultMembers(blockFilter, {});
+    BOOST_CHECK(blockFilter["result"].isString());
+    BOOST_CHECK_NE(blockFilter["result"].asString(), "");
 
     auto pendingFilter = call(req("eth_newPendingTransactionFilter"));
-    BOOST_CHECK(pendingFilter.isMember("result") || pendingFilter.isMember("error"));
+    requireResultMembers(pendingFilter, {});
+    BOOST_CHECK(pendingFilter["result"].isString());
+    BOOST_CHECK_NE(pendingFilter["result"].asString(), "");
 }
 
 BOOST_AUTO_TEST_CASE(uninstallUnknownFilter)
 {
+    // Uninstalling a filter id that was never registered answers false.
     auto resp = call(req("eth_uninstallFilter", R"(["0x1"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    BOOST_REQUIRE(resp.isMember("result"));
+    BOOST_CHECK_EQUAL(resp["result"].asBool(), false);
 }
 
 BOOST_AUTO_TEST_CASE(newFilterWithParams)
 {
     auto resp = call(req("eth_newFilter",
         R"([{"fromBlock":"0x0","toBlock":"latest","address":"0x1234567890123456789012345678901234567890","topics":[]}])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireResultMembers(resp, {});
+    BOOST_CHECK(resp["result"].isString());
+    BOOST_CHECK_NE(resp["result"].asString(), "");
     BOOST_CHECK(resp.isMember("id"));
 }
 
 BOOST_AUTO_TEST_CASE(getFilterChangesUnknownId)
 {
+    // Unknown filter id is a JSON-RPC error with a method-specific code.
     auto resp = call(req("eth_getFilterChanges", R"(["0x999"])"));
-    BOOST_CHECK(resp.isMember("result") || resp.isMember("error"));
+    requireError(resp, -32000);
 }
 
 BOOST_AUTO_TEST_CASE(sendRawTransactionRejectsBlobTransaction)
@@ -225,8 +348,91 @@ BOOST_AUTO_TEST_CASE(sendRawTransactionGarbageReportsError)
 {
     // Non-decodable raw tx must surface a JSON-RPC error, not crash.
     auto resp = call(req("eth_sendRawTransaction", R"(["0xdeadbeef"])"));
-    BOOST_CHECK(resp.isMember("error") || resp.isMember("result"));
+    requireError(resp, JsonRpcError::InvalidParams);
     BOOST_CHECK(resp.isMember("id"));
+}
+
+BOOST_AUTO_TEST_CASE(getTransactionReceiptHappyPath)
+{
+    // Full read-side happy path (spec §5-5): seed a tx + receipt into a SeedableLedger and drive
+    // eth_getTransactionReceipt / eth_getTransactionByHash through the real dispatch path. The
+    // stock RPCFixture FakeLedger always returns a null receipt, so a subclass is required.
+    auto seedLedger = std::make_shared<SeedableLedger>(m_blockFactory, /*blocks=*/20, 10, 10);
+    seedLedger->setSystemConfig(ledger::SYSTEM_KEY_TX_COUNT_LIMIT, "1000");
+
+    auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
+        "0x1234567890123456789012345678901234567890", bcos::bytes{0x0a}, "0x2", 100, chainId,
+        groupId, 0);
+    BOOST_REQUIRE(tx);
+    // Install a raw 20-byte sender so the read side must checksum the raw bytes.
+    // Mixed-case hex letters (0x5aAe...BeAed) make EIP-55 checksum casing observable (an
+    // all-digit address would make toChecksumAddress a no-op).
+    tx->forceSender(bcos::fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"));
+    seedLedger->seedTx(tx);
+
+    auto receipt = m_blockFactory->receiptFactory()->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", {}, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    BOOST_REQUIRE(receipt);
+    receipt->setTransactionIndex(0);
+    // C4: seed a receipt WITH opStackMeta so eth_getTransactionReceipt must carry the OP extension
+    // fields through the REAL RPC dispatch (unit-testing combineReceiptResponse alone does not
+    // prove the fields survive the full EthEndpoint → JSON round-trip).
+    protocol::OpStackReceiptMeta meta;
+    meta.l1_gas_price = bcos::u256(5);
+    meta.operator_fee_scalar = 2;
+    receipt->setOpStackMeta(std::move(meta));
+    seedLedger->seededReceipt = receipt;
+
+    // Rebuild the RPC stack over the seedable ledger.
+    auto service = std::make_shared<rpc::NodeService>(
+        seedLedger, scheduler, txPool, nullptr, nullptr, m_blockFactory, nullptr);
+    auto seededRpc = factory->buildLocalRpc(groupInfo, service);
+    auto seededWeb3 = seededRpc->web3JsonRpc();
+    BOOST_REQUIRE(seededWeb3 != nullptr);
+
+    auto const txHashHex = tx->hash().hexPrefixed();
+    auto callSeeded = [&](std::string_view request) {
+        std::promise<bcos::bytes> promise;
+        seededWeb3->onRPCRequest(request, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
+        auto jsonBytes = promise.get_future().get();
+        Json::Value value;
+        Json::Reader reader;
+        std::string_view json((char*)jsonBytes.data(), jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    };
+
+    // eth_getTransactionReceipt returns a complete object with the checksummed from.
+    {
+        auto resp = callSeeded(req("eth_getTransactionReceipt", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("transactionHash"));
+        BOOST_CHECK_EQUAL(resp["result"]["transactionHash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("logs"));
+        BOOST_CHECK(resp["result"].isMember("blockNumber"));
+        // C4: OP extension fields survive the full RPC round-trip (not just
+        // combineReceiptResponse).
+        BOOST_CHECK_EQUAL(resp["result"]["l1GasPrice"].asString(), "0x5");
+        BOOST_CHECK_EQUAL(resp["result"]["operatorFeeScalar"].asString(), "0x2");
+        // Pinned against the independently-known EIP-55 vector (NOT derived via the same
+        // toChecksumAddress under test, so a checksum-casing regression is actually caught).
+        BOOST_CHECK_EQUAL(
+            resp["result"]["from"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+    }
+
+    // eth_getTransactionByHash resolves the same tx.
+    {
+        auto resp = callSeeded(req("eth_getTransactionByHash", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("hash"));
+        BOOST_CHECK_EQUAL(resp["result"]["hash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("from"));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-txpool/bcos-txpool/CMakeLists.txt
+++ b/bcos-txpool/bcos-txpool/CMakeLists.txt
@@ -31,5 +31,5 @@ target_include_directories(txpool PUBLIC .
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_CURRENT_BINARY_DIR}/bcos-txpool
     ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(txpool PUBLIC ledger rpc TBB::tbb protobuf::libprotobuf bcos-protocol bcos-utilities tool)
+target_link_libraries(txpool PUBLIC ledger rpc TBB::tbb protobuf::libprotobuf bcos-protocol bcos-utilities tool rlp-protocol)
 set_target_properties(txpool PROPERTIES UNITY_BUILD "ON")

--- a/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
+++ b/bcos-txpool/bcos-txpool/txpool/validator/TxValidator.cpp
@@ -24,8 +24,10 @@
 #include "bcos-framework/protocol/GlobalConfig.h"
 #include "bcos-framework/txpool/Constant.h"
 #include "bcos-ledger/LedgerMethods.h"
+#include "bcos-rlp-protocol/Web3TxEnvelope.h"
 #include "bcos-task/Wait.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-codec/rlp/Common.h>  // BYTES_HEAD_BASE (envelope first-byte classification)
 
 #include <cctype>
 
@@ -60,6 +62,36 @@ TransactionStatus TxValidator::verify(bcos::protocol::Transaction& _tx)
         _tx.type() != static_cast<uint8_t>(TransactionType::Web3Transaction)) [[unlikely]]
     {
         return TransactionStatus::Malformed;
+    }
+    // Reject 0x7e deposit transactions at admission: deposits are unsigned system txs that must
+    // only enter via the engine newPayload path (op-geth txpool: ErrTxTypeNotSupported). Keyed
+    // on the envelope's first byte — not the tars mirror web3TypedTxKind, which is
+    // unauthenticated and can be rewritten (e.g. to 0x02) to skip a mirror-keyed gate.
+    if (_tx.isDepositTx() || (!_tx.extraTransactionBytes().empty() &&
+                                 static_cast<uint8_t>(_tx.extraTransactionBytes()[0]) == 0x7e))
+        [[unlikely]]
+    {
+        return TransactionStatus::Malformed;
+    }
+    // Reject RESERVED type bytes in the signed envelope for Web3 txs (op-geth decodeTyped:
+    // ErrTxTypeNotSupported). Supported typed set is {0x01 EIP-2930, 0x02 EIP-1559, 0x03
+    // EIP-4844, 0x04 EIP-7702} (the bcos::rpc::TransactionType values); 0x7e deposits are
+    // already rejected above. A self-signed envelope with any other first byte < 0x80
+    // (0x05-0x7d / 0x7f) must not enter the pool — the RPC decode rejects the same bytes
+    // (magic_enum::enum_cast), so this closes the wider P2P accept-set. Legacy (>= 0xc0 list
+    // header) is unaffected. Literals, not the rpc enum: txpool must not depend on bcos-rpc.
+    if (_tx.type() == static_cast<uint8_t>(TransactionType::Web3Transaction) &&
+        !_tx.extraTransactionBytes().empty())
+    {
+        auto const firstByte = static_cast<uint8_t>(_tx.extraTransactionBytes()[0]);
+        // Reject reserved EIP-2718 type bytes (0x00 and 0x05-0x7d, excluding 0x01-0x04
+        // which are valid EIP-2930/1559/4844/7702). 0x7E deposits are caught by the check
+        // above; legacy envelopes (>= 0x80) are excluded by the < 0x80 bound.
+        if (firstByte < bcos::codec::rlp::BYTES_HEAD_BASE && firstByte != 0x01 &&
+            firstByte != 0x02 && firstByte != 0x03 && firstByte != 0x04) [[unlikely]]
+        {
+            return TransactionStatus::Malformed;
+        }
     }
     if (_tx.type() == static_cast<uint8_t>(TransactionType::BCOSTransaction))
     {
@@ -290,15 +322,37 @@ task::Task<protocol::TransactionStatus> TxValidator::validateChainId(
     }
     if (auto config = co_await ledger::getSystemConfig(*_ledger, ledger::SYSTEM_KEY_WEB3_CHAIN_ID))
     {
-        auto [chainId, _] = config.value();
-        // if legacy tx, chainId is empty or 0, skip the check
-        if (!_tx.chainId().empty() && _tx.chainId() != "0")
+        auto [chainIdStr, _] = config.value();
+        // Validate against the SIGNED envelope, never the unauthenticated tars mirror
+        // (data.chainID). Typed txs get no "0" exemption (op-geth modernSigner); only
+        // pre-EIP-155 unprotected legacy (v=27/28, no chainId in the envelope) is exempt —
+        // a deliberate divergence: geth/op-geth default rejects unprotected txs at the RPC
+        // layer (AllowUnprotectedTxs=false); accepting them keeps historical-mainnet-tx
+        // fixtures replayable. Part 5 adds the config gate.
+        // Parse as u256 via the shared helper (ledger::parseWeb3ChainId, LedgerTypeDef.h — the
+        // single home for the three chainId-config consumers); a corrupted config rejects txs
+        // instead of throwing out of the coroutine (P2P batchImportTxs has no catch).
+        auto expected = ledger::parseWeb3ChainId(chainIdStr);
+        if (!expected.has_value())
         {
-            // for EIP-155, check chainId
-            if (_tx.chainId() != chainId)
-            {
-                co_return TransactionStatus::InvalidChainId;
-            }
+            co_return TransactionStatus::InvalidChainId;
+        }
+        auto envelopeChainId = _tx.web3ChainIdFromEnvelope();
+        if (envelopeChainId.has_value() && bcos::u256(*envelopeChainId) != *expected)
+        {
+            co_return TransactionStatus::InvalidChainId;
+        }
+        // A typed tx always carries a chainId in the envelope — a missing one means the
+        // preimage is malformed; keep it strict. The typed/legacy decision reads the ENVELOPE
+        // first byte (isTypedWeb3Envelope), never the forgeable mirror web3TypedTxKind(): a
+        // peer can set the mirror kind to 0 to exempt an over-wide/non-integer typed chainId
+        // (web3ChainIdFromEnvelope returns nullopt for it) and defeat the EIP-155 check. The
+        // legacy over-wide case needs no here-gate — verify()'s reassembleWeb3RawTransaction
+        // rejects the same bytes first (throwDecode("legacy chainId") at the width gate).
+        if (!envelopeChainId.has_value() &&
+            bcos::rlp::protocol::isTypedWeb3Envelope(_tx.extraTransactionBytes()))
+        {
+            co_return TransactionStatus::InvalidChainId;
         }
     }
     co_return TransactionStatus::None;

--- a/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/MemoryStorageTest.cpp
@@ -3,6 +3,8 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 #include "bcos-txpool/txpool/storage/MemoryStorage.h"
+#include "bcos-codec/rlp/Common.h"
+#include "bcos-codec/rlp/RLPEncode.h"
 #include "bcos-crypto/hash/Keccak256.h"
 #include "bcos-crypto/interfaces/crypto/CryptoSuite.h"
 #include "bcos-crypto/signature/secp256k1/Secp256k1Crypto.h"
@@ -545,12 +547,22 @@ BOOST_AUTO_TEST_CASE(VerifyAndSubmitTransactionValidationChain)
         storageNoSig.clear();
         const std::string senderHex = "0x1234567890123456789012345678901234567890";
         auto tx7 = makeWeb3Tx("0x3", senderHex, false);
-        // Set an invalid chainId - need to cast to TransactionImpl
         auto tx7Impl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx7);
         if (tx7Impl)
         {
-            std::string invalidChainId = "123";
-            tx7Impl->mutableInner().data.chainID = invalidChainId;
+            // The tars mirror is unauthenticated and must NOT drive the check: set it to a
+            // value that matches the config to prove it is ignored.
+            tx7Impl->mutableInner().data.chainID = "321";
+            // A typed (EIP-1559) signing preimage whose envelope chainId (123) does not match
+            // the configured chain id (321): validateChainId derives the value from the SIGNED
+            // envelope, so this must be rejected regardless of the mirror.
+            tx7Impl->mutableInner().web3TypedTxKind = static_cast<tars::Char>(0x02);
+            bcos::bytes typed{0x02};
+            bcos::codec::rlp::encode(typed, static_cast<uint64_t>(123), static_cast<uint64_t>(0),
+                static_cast<uint64_t>(1), static_cast<uint64_t>(1), static_cast<uint64_t>(21000),
+                bcos::Address("0xdead000000000000000000000000000000000011"),
+                static_cast<uint64_t>(0), bcos::bytes{}, bcos::bytes{});
+            tx7Impl->mutableInner().extraTransactionBytes.assign(typed.begin(), typed.end());
         }
 
         fakeit::When(Method(mockLedger, asyncGetSystemConfigByKey))

--- a/bcos-txpool/test/unittests/txpool/TransactionValidatorTest.cpp
+++ b/bcos-txpool/test/unittests/txpool/TransactionValidatorTest.cpp
@@ -43,6 +43,16 @@ namespace bcos
 {
 namespace test
 {
+namespace
+{
+// Distinct name from Issue5318InvalidToTest.cpp's makeValidator (same unity TU).
+TxValidator::Ptr makeAdmissionValidator(bcos::crypto::CryptoSuite::Ptr cryptoSuite = nullptr)
+{
+    return std::make_shared<TxValidator>(
+        nullptr, nullptr, std::move(cryptoSuite), "group0", "chain0");
+}
+}  // namespace
+
 BOOST_FIXTURE_TEST_SUITE(TxPoolTest, TestPromptFixture)
 BOOST_AUTO_TEST_CASE(testTransactionValidator)
 {
@@ -192,6 +202,344 @@ BOOST_AUTO_TEST_CASE(testValidateBalanceIncludesGasCost)
     }
 
     std::cout << "#### testValidateBalanceIncludesGasCost finish" << std::endl;
+}
+
+// A 0x7e deposit must be rejected at admission even when "self-signed": deposits are unsigned
+// system txs that only enter via the engine newPayload path (op-geth: ErrTxTypeNotSupported).
+BOOST_AUTO_TEST_CASE(testRejectDepositAtAdmission)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto validator = makeAdmissionValidator(cryptoSuite);
+
+    // Build a deposit-shaped tars tx: type=Web3, web3TypedTxKind=0x7e. isDepositTx() must
+    // trigger on web3TypedTxKind alone (never on isSystemTransaction).
+    bcostars::Transaction inner{};
+    inner.type = static_cast<tars::Char>(TransactionType::Web3Transaction);
+    inner.web3TypedTxKind = static_cast<tars::Char>(0x7e);
+    inner.sourceHash = "0x" + std::string(64, 'a');
+    inner.data.input.assign({'x', 'y'});
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [m = std::move(inner)]() mutable { return &m; });
+    BOOST_CHECK(tx->isDepositTx());
+    BOOST_CHECK(validator->verify(*tx) == TransactionStatus::Malformed);
+
+    // A deposit that also claims to be a system tx must still be rejected — isDepositTx()
+    // keys on web3TypedTxKind, not on the system flag.
+    auto systemInner = inner;
+    systemInner.isSystemTransaction = 1;
+    auto systemTx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [m = std::move(systemInner)]() mutable { return &m; });
+    BOOST_CHECK(validator->verify(*systemTx) == TransactionStatus::Malformed);
+
+    // A normal Web3 tx (web3TypedTxKind=0) must NOT be rejected by this gate: the reject
+    // must key on the deposit kind, not on the Web3 type in general. (The full verify() of a
+    // non-deposit Web3 tx — signature recovery + nonce check — is covered by the existing
+    // testTransactionValidator cases; here we only assert the gate's classification.)
+    auto normalInner = inner;
+    normalInner.web3TypedTxKind = 0;
+    auto normalTx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [m = std::move(normalInner)]() mutable { return &m; });
+    BOOST_CHECK(!normalTx->isDepositTx());
+    // The gate is the FIRST check in verify(): a non-deposit Web3 tx must pass it and reach
+    // signature recovery (which fails on an empty signature — InvalidSignature, NOT Malformed).
+    BOOST_CHECK(validator->verify(*normalTx) != TransactionStatus::Malformed);
+
+    // Mirror-rewrite bypass shape: the tars mirror claims a normal type (kind=0x02) while the
+    // envelope is a genuine 0x7e deposit. isDepositTx() (mirror-keyed) says "not a deposit", so
+    // the gate must key on the envelope's first byte and reject this too.
+    {
+        bcostars::Transaction forged = inner;
+        forged.web3TypedTxKind = static_cast<tars::Char>(0x02);  // mirror claims EIP-1559
+        bcos::bytes body;
+        bcos::codec::rlp::encode(body,
+            bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"),
+            bcos::Address("0xdead000000000000000000000000000000000011"),
+            bcos::Address("0x4200000000000000000000000000000000000022"), bcos::bytes{},
+            bcos::bytes{}, static_cast<uint64_t>(500000), static_cast<uint64_t>(0), bcos::bytes{});
+        bcos::bytes envelope{0x7e};
+        bcos::codec::rlp::encodeHeader(envelope, bcos::codec::rlp::Header{true, body.size()});
+        envelope.insert(envelope.end(), body.begin(), body.end());
+        forged.extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        auto forgedTx = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [m = std::move(forged)]() mutable { return &m; });
+        BOOST_CHECK(!forgedTx->isDepositTx());  // mirror says not a deposit
+        BOOST_CHECK(validator->verify(*forgedTx) == TransactionStatus::Malformed);
+    }
+
+    // A kind=0x02 tx with a NON-deposit envelope must pass the deposit gate (rejected later by
+    // signature recovery) — the envelope-byte check must not over-match typed txs.
+    {
+        bcostars::Transaction typed = inner;
+        typed.web3TypedTxKind = static_cast<tars::Char>(0x02);
+        bcos::bytes preimage{0x02};
+        bcos::codec::rlp::encode(preimage, static_cast<uint64_t>(1), static_cast<uint64_t>(0),
+            static_cast<uint64_t>(1), static_cast<uint64_t>(1), static_cast<uint64_t>(21000),
+            bcos::Address("0xdead000000000000000000000000000000000011"), static_cast<uint64_t>(0),
+            bcos::bytes{}, bcos::bytes{});
+        typed.extraTransactionBytes.assign(preimage.begin(), preimage.end());
+        auto typedTx = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [m = std::move(typed)]() mutable { return &m; });
+        BOOST_CHECK(validator->verify(*typedTx) != TransactionStatus::Malformed);
+    }
+}
+
+// chainId is validated from the SIGNED envelope, never the tars mirror: typed txs get no
+// chainId=0 exemption (op-geth); only pre-EIP-155 legacy (no envelope chainId) is exempt.
+BOOST_AUTO_TEST_CASE(testValidateChainIdFromEnvelope)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto keyPair = signatureImpl->generateKeyPair();
+    auto groupId = "group_test_for_txpool";
+    auto chainId = "chain_test_for_txpool";
+    auto blockLimit = 10;
+    auto fakeGateWay = std::make_shared<FakeGateWay>();
+    auto faker = std::make_shared<TxPoolFixture>(
+        keyPair->publicKey(), cryptoSuite, groupId, chainId, blockLimit, fakeGateWay, false, false);
+    faker->init();
+    auto ledger = faker->ledger();
+    auto validator = faker->txpool()->txpoolConfig()->txValidator();
+
+    // Seed the WEB3_CHAIN_ID system config to a known value (123).
+    ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "123");
+
+    // A legacy EIP-155 tx whose envelope chainId (123) matches the config passes even when the
+    // tars mirror lies (chainID="0"): the mirror is unauthenticated and must not be trusted.
+    {
+        auto tx = fakeWeb3Tx(cryptoSuite, "1", keyPair);
+        auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+        // The fake preimage is pre-EIP-155 (6 fields, no chainId tail) → envelope nullopt →
+        // exempt like an unprotected legacy tx.
+        txImpl->mutableInner().data.chainID = "0";  // hostile mirror value
+        auto result = task::syncWait(validator->validateChainId(*tx, ledger));
+        BOOST_CHECK(result == TransactionStatus::None);
+    }
+
+    // A typed tx carries its chainId as RLP field 0 of the signed preimage. Envelope chainId
+    // must match the config exactly — a "0" tars mirror must NOT provide an exemption (op-geth
+    // modernSigner has no chainId=0 exemption for typed txs).
+    auto makeTypedTx = [&](uint64_t envelopeChainId) {
+        bcostars::Transaction inner{};
+        inner.type = static_cast<tars::Char>(TransactionType::Web3Transaction);
+        inner.web3TypedTxKind = static_cast<tars::Char>(0x02);  // EIP-1559
+        // preimage = 0x02 || rlp([chainId, nonce, maxPriority, maxFee, gas, to, value, data, []])
+        // codec::rlp::encode over the variadic list already emits the list header; only the
+        // 0x02 type byte is prepended.
+        bcos::bytes typed{0x02};
+        bcos::codec::rlp::encode(typed, envelopeChainId, static_cast<uint64_t>(0),
+            static_cast<uint64_t>(1), static_cast<uint64_t>(1), static_cast<uint64_t>(21000),
+            bcos::Address("0xdead000000000000000000000000000000000011"), static_cast<uint64_t>(0),
+            bcos::bytes{}, bcos::bytes{});
+        inner.extraTransactionBytes.assign(typed.begin(), typed.end());
+        return std::make_shared<bcostars::protocol::TransactionImpl>(
+            [m = std::move(inner)]() mutable { return &m; });
+    };
+    {
+        auto tx = makeTypedTx(123);
+        auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+        txImpl->mutableInner().data.chainID = "0";  // hostile mirror must not bypass
+        auto result = task::syncWait(validator->validateChainId(*tx, ledger));
+        BOOST_CHECK(result == TransactionStatus::None);  // envelope 123 == config 123
+    }
+    {
+        auto tx = makeTypedTx(456);
+        auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+        txImpl->mutableInner().data.chainID = "123";  // mirror lies to match config
+        auto result = task::syncWait(validator->validateChainId(*tx, ledger));
+        BOOST_CHECK(result == TransactionStatus::InvalidChainId);  // envelope 456 != config
+    }
+
+    // A typed tx whose envelope has no parseable chainId (e.g. a 0x7e deposit envelope with the
+    // kind mirror rewritten to 0x02) → nullopt + kind!=0 → strict InvalidChainId. This is the
+    // mirror-rewrite bypass shape: the deposit gate keys on the envelope first byte, so this
+    // forged tx must be rejected here even if it reached validateChainId.
+    {
+        auto tx = makeTypedTx(123);
+        auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+        // Replace the typed preimage with a genuine 0x7e deposit envelope (8 fields, field 0 =
+        // 32-byte sourceHash → exceeds the uint64 width gate → nullopt).
+        bcostars::Transaction inner = txImpl->mutableInner();
+        inner.web3TypedTxKind = static_cast<tars::Char>(0x02);  // mirror still claims EIP-1559
+        bcos::bytes body;
+        bcos::codec::rlp::encode(body,
+            bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"),
+            bcos::Address("0xdead000000000000000000000000000000000011"),
+            bcos::Address("0x4200000000000000000000000000000000000022"), bcos::bytes{},
+            bcos::bytes{}, static_cast<uint64_t>(500000), static_cast<uint64_t>(0), bcos::bytes{});
+        bcos::bytes envelope{0x7e};
+        bcos::codec::rlp::encodeHeader(envelope, bcos::codec::rlp::Header{true, body.size()});
+        envelope.insert(envelope.end(), body.begin(), body.end());
+        inner.extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        auto forged = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [m = std::move(inner)]() mutable { return &m; });
+        auto result = task::syncWait(validator->validateChainId(*forged, ledger));
+        BOOST_CHECK(result == TransactionStatus::InvalidChainId);
+    }
+
+    // Legacy EIP-155 with a real chainId tail: the envelope chainId (123) is authoritative.
+    {
+        bcostars::Transaction inner{};
+        inner.type = static_cast<tars::Char>(TransactionType::Web3Transaction);
+        inner.web3TypedTxKind = static_cast<tars::Char>(0);  // legacy
+        // preimage = rlp([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]) — 9 fields.
+        auto makeLegacy = [&](uint64_t tailChainId) {
+            bcos::bytes legacy;
+            bcos::codec::rlp::encode(legacy, static_cast<uint64_t>(0), static_cast<uint64_t>(1),
+                static_cast<uint64_t>(21000),
+                bcos::Address("0xdead000000000000000000000000000000000011"),
+                static_cast<uint64_t>(0), bcos::bytes{}, static_cast<uint64_t>(tailChainId),
+                static_cast<uint64_t>(0), static_cast<uint64_t>(0));
+            return legacy;
+        };
+        auto legacyBytes = makeLegacy(123);
+        inner.extraTransactionBytes.assign(legacyBytes.begin(), legacyBytes.end());
+        auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [m = std::move(inner)]() mutable { return &m; });
+        auto result = task::syncWait(validator->validateChainId(*tx, ledger));
+        BOOST_CHECK(result == TransactionStatus::None);  // envelope 123 == config 123
+        auto legacyBytes456 = makeLegacy(456);
+        inner.extraTransactionBytes.assign(legacyBytes456.begin(), legacyBytes456.end());
+        auto tx2 = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [m = std::move(inner)]() mutable { return &m; });
+        auto result2 = task::syncWait(validator->validateChainId(*tx2, ledger));
+        BOOST_CHECK(result2 == TransactionStatus::InvalidChainId);  // envelope 456 != config
+    }
+
+    // Empty config value: no crash — the u256 parse rejects the tx (InvalidChainId). (The
+    // config-absent branch — getSystemConfig nullopt → whole check skipped — is covered by the
+    // pre-existing txpool tests; production always seeds WEB3_CHAIN_ID, default "0".)
+    {
+        ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "");
+        auto tx = makeTypedTx(123);
+        auto result = task::syncWait(validator->validateChainId(*tx, ledger));
+        BOOST_CHECK(result == TransactionStatus::InvalidChainId);
+        ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "123");
+    }
+
+    // Config value larger than uint64::max is a supported chainId (LedgerConfig u256 parse):
+    // no envelope chainId can match → strict InvalidChainId, and no exception escapes.
+    {
+        ledger->setSystemConfig(
+            ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "18446744073709551617");  // 2^64+1
+        auto tx = makeTypedTx(123);
+        BOOST_CHECK_NO_THROW({
+            auto result = task::syncWait(validator->validateChainId(*tx, ledger));
+            BOOST_CHECK(result == TransactionStatus::InvalidChainId);
+        });
+        ledger->setSystemConfig(ledger::SYSTEM_KEY_WEB3_CHAIN_ID, "123");
+    }
+}
+
+// EIP-2 low-s must be enforced on the P2P import path too (Transaction::verify), not only at
+// RPC decode: without the symmetric gate a malleated (high-s) tx imported from a peer would
+// pass admission.
+BOOST_AUTO_TEST_CASE(testVerifyRejectsHighSOnP2P)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto keyPair = signatureImpl->generateKeyPair();
+
+    // A valid Web3 tx with a canonical (low-s) signature.
+    auto tx = fakeWeb3Tx(cryptoSuite, "42", keyPair);
+    BOOST_CHECK_NO_THROW(tx->verify(*hashImpl, *signatureImpl));
+
+    // Malleability flip: s' = n - s is high-s but recovers the same sender. Rebuild the tars
+    // signature r(32)||s(32)||yParity(1) with the flipped s; verify() must reject it even
+    // though the flipped signature still recovers the original sender.
+    auto sigBytes = tx->signatureData().toBytes();
+    BOOST_REQUIRE(sigBytes.size() == 65);
+    bcos::u256 s = bcos::fromBigEndian<bcos::u256>(bcos::bytesConstRef(sigBytes.data() + 32, 32));
+    BOOST_REQUIRE(s <= bcos::crypto::c_secp256k1nOver2);
+    auto flipped = bcos::toBigEndian(bcos::crypto::c_secp256k1n - s);
+    BOOST_REQUIRE(flipped.size() == 32);
+    std::copy(flipped.begin(), flipped.end(), sigBytes.begin() + 32);
+    auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+    BOOST_REQUIRE(txImpl);
+    txImpl->setSignatureData(sigBytes);
+    // Re-taint so verify() re-runs the full recovery + EIP-2 ladder (a prior verify()/forceSender
+    // already cleared the taint; setSignatureData does not reset it).
+    txImpl->clearSenderAndHash();
+
+    BOOST_CHECK_THROW(tx->verify(*hashImpl, *signatureImpl), std::invalid_argument);
+}
+
+// Killer test for the reserved-type-byte admission gate: an envelope whose first byte is a
+// reserved EIP-2718 marker (0x00 / 0x05 / 0x7f) must be Malformed even when the tars mirror
+// claims a supported kind; a genuine 0x02 marker passes the gate (rejected later only by
+// signature recovery, which is not Malformed). Deleting the gate leaves this test red.
+BOOST_AUTO_TEST_CASE(testRejectReservedTypeBytesAtAdmission)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto validator = makeAdmissionValidator(cryptoSuite);
+
+    auto makeTxWithEnvelope = [&](bcos::bytes envelope) {
+        bcostars::Transaction inner{};
+        inner.type = static_cast<tars::Char>(TransactionType::Web3Transaction);
+        inner.web3TypedTxKind = static_cast<tars::Char>(0x02);  // mirror claims EIP-1559
+        inner.extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        return std::make_shared<bcostars::protocol::TransactionImpl>(
+            [m = std::move(inner)]() mutable { return &m; });
+    };
+    // Marker byte followed by an empty RLP list — the gate must reject on the marker alone,
+    // before any decode.
+    for (auto reserved : {0x00, 0x05, 0x7f})
+    {
+        auto tx = makeTxWithEnvelope(bcos::bytes{static_cast<bcos::byte>(reserved), 0xc0});
+        BOOST_CHECK(validator->verify(*tx) == TransactionStatus::Malformed);
+    }
+    auto okTx = makeTxWithEnvelope(bcos::bytes{0x02, 0xc0});
+    BOOST_CHECK(validator->verify(*okTx) != TransactionStatus::Malformed);
+}
+
+// Killer tests for the P2P verify() signature rungs: the 65-byte length check and the
+// recovery-id (sig[64]) > 1 gate. Message-pinned so a wrong-source throw cannot satisfy them.
+BOOST_AUTO_TEST_CASE(testVerifyRejectsMalformedSignatureShapes)
+{
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto signatureImpl = std::make_shared<Secp256k1Crypto>();
+    auto cryptoSuite = std::make_shared<CryptoSuite>(hashImpl, signatureImpl, nullptr);
+    auto keyPair = signatureImpl->generateKeyPair();
+
+    // (a) 64-byte signature: reassembleWeb3RawTransaction (inside calculateHash) rejects the
+    // explicitly-sized form before recovery.
+    {
+        auto tx = fakeWeb3Tx(cryptoSuite, "42", keyPair);
+        BOOST_CHECK_NO_THROW(tx->verify(*hashImpl, *signatureImpl));
+        auto sigBytes = tx->signatureData().toBytes();
+        BOOST_REQUIRE_EQUAL(sigBytes.size(), 65u);
+        sigBytes.pop_back();
+        auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+        BOOST_REQUIRE(txImpl);
+        txImpl->setSignatureData(sigBytes);
+        txImpl->clearSenderAndHash();
+        BOOST_CHECK_EXCEPTION(
+            tx->verify(*hashImpl, *signatureImpl), std::invalid_argument, [](auto const& e) {
+                return std::string(e.what()).find("expect 65") != std::string::npos;
+            });
+    }
+    // (b) recovery id 2 (the v=29/30 envelope form): rejected on the legacy preimage too — the
+    // tars signature byte is always recid/yParity (0/1) by construction, never the legacy v
+    // encoding (27/28/35+).
+    {
+        auto tx = fakeWeb3Tx(cryptoSuite, "43", keyPair);
+        auto sigBytes = tx->signatureData().toBytes();
+        BOOST_REQUIRE_EQUAL(sigBytes.size(), 65u);
+        sigBytes.back() = 2;
+        auto txImpl = std::dynamic_pointer_cast<bcostars::protocol::TransactionImpl>(tx);
+        BOOST_REQUIRE(txImpl);
+        txImpl->setSignatureData(sigBytes);
+        txImpl->clearSenderAndHash();
+        BOOST_CHECK_EXCEPTION(
+            tx->verify(*hashImpl, *signatureImpl), std::invalid_argument, [](auto const& e) {
+                return std::string(e.what()).find("recovery id exceeds 1") != std::string::npos;
+            });
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/CMakeLists.txt
+++ b/opstack-executor/CMakeLists.txt
@@ -4,22 +4,20 @@ find_package(evmone REQUIRED)
 find_package(intx REQUIRED)
 find_package(TBB CONFIG REQUIRED)
 
-add_library(opstack-executor INTERFACE)
-target_include_directories(opstack-executor INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/opstack-executor>)
-# No direct `ledger` / `rlp-protocol` links: header-only usage only (Classify.h), and both drag
-# the bcos-crypto→wedprcrypto chain that breaks libc++ typed catch binary-wide
-# (bcos-rpc/test/CMakeLists.txt:29-34). `ledger` still arrives transitively via bcos-evm-eth.
-target_link_libraries(opstack-executor INTERFACE
+add_library(opstack-executor
+    OpBlockExecute.cpp
+)
+target_include_directories(opstack-executor PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/opstack-executor>)
+target_link_libraries(opstack-executor PUBLIC
     bcos-evm-opstack ethereum-executor bcos-framework bcos-protocol
-    evmone::evmone intx::intx TBB::tbb)
+    ledger evmone::evmone intx::intx TBB::tbb rlp-protocol)
 set_target_properties(opstack-executor PROPERTIES UNITY_BUILD OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    # OP modules deliberately use skipped-field designated initializers and GCC-13
-    # reference-returning helpers (jAt); downgrade only here, not repository-wide.
-    # INTERFACE, not PRIVATE: opstack-executor is a header-only INTERFACE library — the
-    # -Wno-error flags must reach the consumers' translation units, where the templates
-    # are instantiated and the warnings fire.
-    target_compile_options(opstack-executor INTERFACE
+    # OP modules deliberately use skipped-field designated initializers
+    # and GCC-13 reference-returning helpers (jAt); downgrade only here, not repository-wide.
+    target_compile_options(opstack-executor PRIVATE
         -Wno-error=missing-field-initializers -Wno-error=dangling-reference)
 endif()
 

--- a/opstack-executor/OpBlockExecute.cpp
+++ b/opstack-executor/OpBlockExecute.cpp
@@ -1,0 +1,467 @@
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-evm/adapter/StateDiffSanitize.h>
+#include <bcos-evm/opstack/OpFeeParams.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-framework/protocol/LogEntry.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-rlp-protocol/Web3TxEnvelope.h>
+#include <bcos-utilities/DataConvertUtility.h>  // bcos::safeFromQuantity
+#include <opstack-executor/OpBlockExecute.h>
+#include <algorithm>
+#include <bcos-evm/eth/state/state.hpp>  // evmone::state::finalize
+#include <bcos-evm/eth/state/system_contracts.hpp>
+#include <cassert>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <span>
+#include <sstream>
+#include <stdexcept>
+
+// isL1AttributesTx lives in OpBlockExecute.h; narrowGasUsed / hexCumulative live in OpCommon.h
+// (both shared with the per-tx loop — one implementation, no copy drift).
+
+namespace bcos::evm::opstack
+{
+void validateJovianBlockShape(std::span<const OpBlockTx> txs, const OpForkConfig& cfg)
+{
+    if (!cfg.has_da_footprint)  // Jovian-only (op-geth CalcDAFootprint)
+        return;
+    if (txs.empty())  // rejected by processOpBlock anyway
+        return;
+    const auto* firstDep = std::get_if<DepositTx>(&txs[0].tx);
+    if (firstDep == nullptr)
+        return;
+
+    const auto& data = firstDep->data;
+    if (data.size() == IsthmusL1AttributesLen)
+    {
+        // Jovian activation block: Isthmus-length attributes, must be deposits-only.
+        // Matches preBlockOpSteps (last-tx-only check) and op-geth CalcDAFootprint parity:
+        // op-geth checks only the last tx's type byte ("sufficient to check last transaction
+        // because deposits precede non-deposit txs"). Iterating all envelopes would be
+        // stricter than the reference client — a consensus divergence. The deposit-prefix
+        // invariant is enforced by processOpBlock's deposit-first admission gate.
+        if (txs.empty() || !std::holds_alternative<DepositTx>(txs.back().tx))
+            throw engine::OpConsensusError(
+                "op block: unexpected non-deposit transactions in Jovian activation block");
+        return;
+    }
+
+    // Normal Jovian block: L1 attributes must carry the Jovian selector and be ≥ Jovian length.
+    if (data.size() < JovianL1AttributesLen)
+        throw engine::OpConsensusError(
+            "op block: L1 attributes transaction data too short for DA footprint gas scalar");
+    if (!std::equal(
+            JovianL1AttributesSelector.begin(), JovianL1AttributesSelector.end(), data.begin()))
+        throw engine::OpConsensusError(
+            "op block: L1 attributes transaction data does not have Jovian selector");
+}
+
+evmone::state::StateDiff finalizeOpBlock(
+    const evmone::state::StateView& view, const OpForkConfig& cfg, const evmc::address& coinbase)
+{
+    if (!cfg.disable_prague_requests)
+        // OpConsensusError: block-level rejection (INVALID), not a local fault — a bare
+        // runtime_error would escape the INVALID/-32603 classification (OpCommon.h contract).
+        throw engine::OpConsensusError("op finalize: prague requests unsupported on OP chains");
+    return bcos::evm::sanitizeStateDiff(
+        view, evmone::state::finalize(view, cfg.rev, coinbase, std::nullopt, {}, {}));
+}
+
+namespace
+{
+// Block-level execution faults must leave as OpConsensusError (OpBlockExecute.h contract),
+// never a bare std::runtime_error from the bcos-evm transition layer. Same ladder as the
+// per-tx executor path (OpstackExecutor.h rethrowExecError): typed engine errors pass
+// through, everything else is reclassified as a consensus rejection.
+[[noreturn]] void rethrowBlockExecError(std::string_view what)
+{
+    try
+    {
+        throw;
+    }
+    catch (const bcos::evm::engine::OpConsensusError&)
+    {
+        throw;
+    }
+    catch (const bcos::evm::engine::OpStorageError&)
+    {
+        throw;
+    }
+    catch (const bcos::executor_v1::opstack::OpEvmcRevisionNotConfigured&)
+    {
+        throw;  // local misconfiguration, not a consensus rejection
+    }
+    catch (const bcos::executor_v1::opstack::OpForkRevisionMismatch&)
+    {
+        throw;
+    }
+    catch (const std::exception& e)
+    {
+        throw bcos::evm::engine::OpConsensusError(
+            "op block: " + std::string(what) + " failed: " + e.what());
+    }
+    catch (...)
+    {
+        throw bcos::evm::engine::OpConsensusError(
+            "op block: " + std::string(what) + " failed: unknown exception");
+    }
+}
+}  // namespace
+
+OpBlockResult processOpBlock(const evmone::state::StateView& view,
+    const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
+    std::span<const OpBlockTx> txs, const OpForkConfig& cfg, evmc::VM& vm, uint64_t chainId,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory,
+    const std::function<void(const evmone::state::StateDiff&)>& applyDiff)
+{
+    // applyDiff poisons AND rethrows raw (Storage2State.h tripwire); every write-back failure is
+    // a local storage fault, so it must leave as OpStorageError (-32603), never INVALID or a
+    // bare std::runtime_error (same classification as preBlockOpSteps/executeDeposit). The
+    // rethrowBlockExecError ladder passes OpStorageError through unchanged, so callers that
+    // wrap this in the ladder keep the storage classification.
+    auto applyWriteBack = [&applyDiff](evmone::state::StateDiff const& diff) {
+        try
+        {
+            applyDiff(diff);
+        }
+        catch (const std::exception& e)
+        {
+            throw engine::OpStorageError(
+                std::string("op block: state write-back failed: ") + e.what());
+        }
+        catch (...)
+        {
+            throw engine::OpStorageError("op block: state write-back failed: unknown exception");
+        }
+    };
+
+    // Step 1: pre-block system call (4788/2935; gating/skip handled inside evmone).
+    try
+    {
+        applyWriteBack(bcos::evm::sanitizeStateDiff(
+            view, evmone::state::system_call_block_start(view, block, hashes, cfg.rev, vm)));
+    }
+    catch (...)
+    {
+        rethrowBlockExecError("pre-block system call");
+    }
+
+    // Step 2: block-shape admission — aligned with preBlockOpSteps (OpBlockExecute.h) and
+    // op-geth's accept set: an empty block, or a first tx that is not a deposit at all, is a hard
+    // reject (nothing seeds the block's fee/DA context); a first deposit that is not the L1
+    // attributes tx is accepted with a warning (op-geth/op-reth accept at validation).
+    if (txs.empty())
+        throw engine::OpConsensusError("op block: missing L1 attributes deposit (empty block)");
+    const auto* firstDep = std::get_if<DepositTx>(&txs[0].tx);
+    if (firstDep == nullptr)
+        throw engine::OpConsensusError("op block: no deposit transaction to seed the block");
+    // A first deposit that is not the L1 attributes tx is accepted with a warning. Verified
+    // against op-geth rollup_cost.go: the deposit-data shape checks (CalcDAFootprint /
+    // ExtractDAFootprintGasScalar) are Jovian-only — pre-Jovian validation applies none, and
+    // fee params fall back to the stored values on both sides.
+    if (!isL1AttributesTx(*firstDep))
+        BCOS_LOG(WARNING) << LOG_BADGE("OP_BLOCK_EXEC")
+                          << "op block: first tx is a deposit but not the L1 attributes tx — "
+                             "accepted (deliberate demotion, op-geth/op-reth accept at "
+                             "validation)";
+    validateJovianBlockShape(txs, cfg);
+
+    OpBlockResult result;
+    result.receipts.reserve(txs.size());
+    result.txTypes.reserve(txs.size());
+    int64_t blockGasLeft = block.gas_limit;
+    int64_t cumulative = 0;
+    bool seenNonDeposit = false;
+    bool feeLoaded = false;
+    OpFeeParams fee{};
+    // Reused per-block cumulative-gas buffer (appendHexCumulative formats into it; the
+    // per-tx path should not allocate a fresh string per receipt).
+    std::string cumulativeHex;
+    cumulativeHex.reserve(18);  // "0x" + 16 hex digits
+
+    for (const auto& btx : txs)
+    {
+        if (const auto* dep = std::get_if<DepositTx>(&btx.tx))
+        {
+            if (seenNonDeposit)
+                // Deposit ordering is not enforced: op-geth accepts such blocks at validation
+                // (preBlockOpSteps likewise enforces no ordering). Execute in place, observably.
+                BCOS_LOG(WARNING) << LOG_BADGE("OP_BLOCK_EXEC")
+                                  << "op block: deposit after non-deposit tx — accepted "
+                                     "(op-geth parity)";
+            evmone::state::StateDiff diff;
+            bcos::protocol::TransactionReceipt::Ptr receipt;
+            try
+            {
+                receipt = runDeposit(view, block, hashes, *dep, cfg, vm, chainId, blockGasLeft,
+                    receiptFactory, diff);
+            }
+            catch (...)
+            {
+                rethrowBlockExecError("deposit execution");
+            }
+            applyWriteBack(diff);
+            const auto gasUsed = narrowGasUsed(receipt->gasUsed());
+            // Defense-in-depth only: compiles away under NDEBUG (Release). The invariant is
+            // upstream-guaranteed (validate_transaction: gas_limit <= block_gas_left;
+            // gas_used <= gas_limit), so Release behavior is identical either way.
+            assert(gasUsed >= 0 && gasUsed <= blockGasLeft &&
+                   "EVM gas accounting invariant: gasUsed must not exceed remaining block gas");
+            blockGasLeft -= gasUsed;
+            cumulative += gasUsed;
+            appendHexCumulative(static_cast<uint64_t>(cumulative), cumulativeHex);
+            receipt->setCumulativeGasUsed(cumulativeHex);
+            result.receipts.emplace_back(std::move(receipt));
+            result.txTypes.emplace_back(classifyTxType(static_cast<uint8_t>(kDepositTxType)));
+        }
+        else
+        {
+            seenNonDeposit = true;
+            if (!feeLoaded)
+            {
+                // Fee params lazily loaded at the first normal tx (op-geth's per-block cache). DA
+                // scalar reads calldata[176:178] (authoritative even if the attributes deposit
+                // rolled back L1Block slot8); activation block (176B) forces 0.
+                fee = loadOpFeeParams(view);
+                if (cfg.has_da_footprint)
+                {
+                    const auto& attrData = std::get<DepositTx>(txs[0].tx).data;
+                    if (attrData.size() == IsthmusL1AttributesLen)
+                        fee.da_footprint_gas_scalar = 0;
+                    else if (attrData.size() >= JovianL1AttributesLen)
+                    {
+                        fee.da_footprint_gas_scalar = static_cast<uint16_t>(
+                            (static_cast<uint16_t>(attrData[JovianL1AttributesLen - 2]) << 8) |
+                            static_cast<uint16_t>(attrData[JovianL1AttributesLen - 1]));
+                    }
+                }
+                feeLoaded = true;
+            }
+            const auto& tx = std::get<evmone::state::Transaction>(btx.tx);
+            const evmc::bytes_view env{btx.signedEnvelope.data(), btx.signedEnvelope.size()};
+            // op-geth parity: reject txs whose chainId differs from the node's. The comparison
+            // reads the SIGNED envelope, never a forgeable mirror (the evmone tx here may have
+            // been built from the tars mirror by the caller) — web3ChainIdFromEnvelope is the
+            // same walker the admission path uses. nullopt = pre-EIP-155 unprotected legacy
+            // (v=27/28): exempt — unless the envelope is typed, which always carries a chainId
+            // (RLP field 0): nullopt there means an unparseable preimage, not legacy (same
+            // guard as m_prepare / TxValidator / EthEndpoint).
+            if (auto envChainId = bcos::rlp::protocol::web3ChainIdFromEnvelope(
+                    bcos::bytesConstRef(btx.signedEnvelope.data(), btx.signedEnvelope.size()));
+                envChainId.has_value() && *envChainId != chainId)
+            {
+                throw engine::OpConsensusError(
+                    "op block: tx envelope chain_id " + std::to_string(*envChainId) +
+                    " does not match node chainId " + std::to_string(chainId));
+            }
+            else if (!envChainId.has_value() &&
+                     bcos::rlp::protocol::isTypedWeb3Envelope(
+                         bcos::bytesConstRef(btx.signedEnvelope.data(), btx.signedEnvelope.size())))
+            {
+                throw engine::OpConsensusError(
+                    "op block: typed tx envelope is missing a parseable chainId");
+            }
+            auto v = opValidate(view, block, tx, env, cfg, fee, blockGasLeft);
+            if (const auto* err = std::get_if<std::error_code>(&v))
+                // No failed-receipt mechanism for normal txs: void the whole block (op-geth).
+                throw engine::OpConsensusError(
+                    "op block: invalid non-deposit tx: " + err->message());
+            // opTransition charges from props.fee (the validate-time snapshot — no second read).
+            evmone::state::StateDiff diff;
+            bcos::protocol::TransactionReceipt::Ptr receipt;
+            try
+            {
+                receipt = opTransition(view, block, hashes, tx, cfg, vm,
+                    std::get<OpTxProperties>(v), chainId, receiptFactory, diff);
+            }
+            catch (...)
+            {
+                rethrowBlockExecError("transaction execution");
+            }
+            applyWriteBack(diff);
+            const auto gasUsed = narrowGasUsed(receipt->gasUsed());
+            // Defense-in-depth only: compiles away under NDEBUG (Release). The invariant is
+            // upstream-guaranteed (validate_transaction: gas_limit <= block_gas_left;
+            // gas_used <= gas_limit), so Release behavior is identical either way.
+            assert(gasUsed >= 0 && gasUsed <= blockGasLeft &&
+                   "EVM gas accounting invariant: gasUsed must not exceed remaining block gas");
+            blockGasLeft -= gasUsed;
+            cumulative += gasUsed;
+            appendHexCumulative(static_cast<uint64_t>(cumulative), cumulativeHex);
+            receipt->setCumulativeGasUsed(cumulativeHex);
+            result.receipts.emplace_back(std::move(receipt));
+            result.txTypes.emplace_back(classifyTxType(static_cast<uint8_t>(tx.type)));
+        }
+    }
+
+    // Step 4: end-of-block finalize.
+    result.finalizeDiff = finalizeOpBlock(view, cfg, block.coinbase);
+    applyWriteBack(result.finalizeDiff);
+
+    result.gasUsed = cumulative;
+    return result;
+}
+
+// ---- block-header seal ----
+namespace
+{
+/// Parse "0x"-prefixed hex back to uint64 (the EncodeIndex leaf's cumulativeGasUsed). Delegates to
+/// the strict library parser bcos::safeFromQuantity, which rejects overflow.
+[[nodiscard]] uint64_t parseHexUint64(std::string_view s)
+{
+    if (auto v = bcos::safeFromQuantity(s))
+        return *v;
+    throw engine::OpConsensusError(
+        "op block: invalid cumulativeGasUsed in receipt (not hex or overflow): " + std::string(s));
+}
+
+/// RLP list of logs: [address, [topics...], data] each, whole collection wrapped in a list
+/// (byte-identical to evmone's rlp::encode_container over vector<Log>).
+inline void encodeLogsList(bcos::bytes& to, gsl::span<const bcos::protocol::LogEntry> logs)
+{
+    bcos::bytes content;
+    content.reserve(logs.size() * (bcos::Address::SIZE + 4));
+    bcos::bytes entry;
+    bcos::bytes topics;
+    for (const auto& log : logs)
+    {
+        entry.clear();
+        bcos::codec::rlp::encode(entry, log.address());
+        topics.clear();
+        topics.reserve(log.topics().size() * 33);
+        for (const auto& topic : log.topics())
+            bcos::codec::rlp::encode(topics, topic);
+        bcos::codec::rlp::encodeHeader(entry, {.isList = true, .payloadLength = topics.size()});
+        entry.insert(entry.end(), topics.begin(), topics.end());
+        bcos::codec::rlp::encode(entry, log.data());
+        bcos::codec::rlp::encodeHeader(content, {.isList = true, .payloadLength = entry.size()});
+        content.insert(content.end(), entry.begin(), entry.end());
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = content.size()});
+    to.insert(to.end(), content.begin(), content.end());
+}
+}  // namespace
+
+evmone::hash256 opStorageRoot(const std::map<evmc::bytes32, evmc::bytes32>& storage)
+{
+    // Secure trie over the live slot map (key = keccak256(slot), leaf = rlp(trimmed value)).
+    std::map<bcos::h256, bcos::bytes> entries;
+    for (const auto& [key, value] : storage)
+    {
+        if (evmc::is_zero(value))
+            continue;
+        size_t first = 0;
+        while (first < sizeof(value.bytes) && value.bytes[first] == 0)
+        {
+            ++first;
+        }
+        bcos::bytes leaf;
+        bcos::codec::rlp::encode(
+            leaf, bcos::bytesConstRef(value.bytes + first, sizeof(value.bytes) - first));
+        entries[bcos::h256{evmone::keccak256(key).bytes, 32}] = std::move(leaf);
+    }
+    auto result = bcos::ledger::mpt::computeTrieRoot(entries);
+    evmone::hash256 root{};
+    std::memcpy(root.bytes, result.root.data(), sizeof(root.bytes));
+    return root;
+}
+
+bcos::bytes encodeReceiptForRoot(const bcos::protocol::TransactionReceipt& r, uint8_t txType)
+{
+    // RLP bool semantics: true → 0x01, false → 0x80 (raw push; the UnsignedByte encode path
+    // mis-handles bool). Payload = rlp([status, cumGas, bloom, logs]) + (deposit) [nonce, version].
+    const bool success = (r.status() == 0);
+    const uint64_t cumGas = parseHexUint64(r.cumulativeGasUsed());
+    const auto bloom = r.logsBloom();
+    const auto logs = r.logEntries();
+
+    bcos::bytes payload;
+    payload.push_back(success ? 0x01 : 0x80);
+    bcos::codec::rlp::encode(payload, cumGas);
+    bcos::codec::rlp::encode(payload, bloom);
+    encodeLogsList(payload, logs);
+
+    if (txType == static_cast<uint8_t>(kDepositTxType))
+    {
+        // Deposit receipts always carry opStackMeta (runDeposit sets version=1 for every
+        // post-Canyon deposit), so the 0-fill below is unreachable for consensus blocks; it
+        // exists only so a hand-built receipt without meta emits the same-length leaf.
+        const auto& meta = r.opStackMeta();
+        const uint64_t nonce = (meta && meta->deposit_nonce) ? *meta->deposit_nonce : uint64_t{0};
+        const uint64_t version =
+            (meta && meta->deposit_receipt_version) ? *meta->deposit_receipt_version : uint64_t{0};
+        bcos::codec::rlp::encode(payload, nonce);
+        bcos::codec::rlp::encode(payload, version);
+    }
+
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payload.size()});
+    out.insert(out.end(), payload.begin(), payload.end());
+    // typed raw-byte prefix (legacy has none; deposit's 0x7e is the EIP-2718 type byte).
+    if (txType != static_cast<uint8_t>(evmone::state::Transaction::Type::legacy))
+        out.insert(out.begin(), txType);
+    return out;
+}
+
+OpBlockSeal sealOpBlock(const OpBlockResult& result, const OpForkConfig& cfg,
+    const std::map<evmc::bytes32, evmc::bytes32>& messagePasserStorage)
+{
+    OpBlockSeal seal{};
+
+    // receipts-root: var-key trie (key = rlp(index), leaf = EncodeIndex encoding).
+    std::vector<std::pair<bcos::bytes, bcos::bytes>> receiptsEntries;
+    receiptsEntries.reserve(result.receipts.size());
+    for (size_t i = 0; i < result.receipts.size(); ++i)
+    {
+        bcos::bytes key;
+        bcos::codec::rlp::encode(key, static_cast<uint64_t>(i));
+        auto leaf = encodeReceiptForRoot(*result.receipts[i], result.txTypes[i]);
+        receiptsEntries.emplace_back(std::move(key), std::move(leaf));
+    }
+    auto receiptsResult = bcos::ledger::mpt::computeTrieRootVarKey(receiptsEntries);
+    std::memcpy(
+        seal.receiptsRoot.bytes, receiptsResult.root.data(), sizeof(seal.receiptsRoot.bytes));
+
+    // Block-level logsBloom = bitwise-OR of each receipt's 256-byte bloom.
+    for (const auto& r : result.receipts)
+    {
+        const auto bloom = r->logsBloom();
+        for (size_t i = 0; i < 256 && i < bloom.size(); ++i)
+            seal.logsBloom.bytes[i] |= bloom[i];
+    }
+
+    // Isthmus+: withdrawalsRoot = MessagePasser storage root, requestsHash = sha256("").
+    // Pre-Isthmus: withdrawals list is always empty → empty-trie root; no requests field.
+    if (cfg.fork >= OpFork::Isthmus)
+    {
+        seal.withdrawalsRoot = opStorageRoot(messagePasserStorage);
+        seal.requestsHash = OP_EMPTY_REQUESTS_HASH;
+    }
+    else
+    {
+        auto const emptyRoot = bcos::ledger::mpt::emptyRootHash();
+        std::memcpy(
+            seal.withdrawalsRoot.bytes, emptyRoot.data(), sizeof(seal.withdrawalsRoot.bytes));
+    }
+
+    // Jovian: header blobGasUsed slot = DA footprint (Σ da_footprint over non-deposit receipts;
+    // deposits carry nullopt, so summing every receipt is equivalent).
+    if (cfg.has_da_footprint)
+    {
+        uint64_t footprint = 0;
+        for (const auto& r : result.receipts)
+        {
+            const auto& meta = r->opStackMeta();
+            if (meta && meta->da_footprint)
+                footprint += *meta->da_footprint;
+        }
+        seal.blobGasUsed = footprint;
+    }
+    return seal;
+}
+}  // namespace bcos::evm::opstack

--- a/opstack-executor/OpBlockExecute.h
+++ b/opstack-executor/OpBlockExecute.h
@@ -6,6 +6,7 @@
 #include <bcos-evm/opstack/OpTransition.h>  // DepositTx
 #include <bcos-framework/engine/Types.h>
 #include <bcos-framework/protocol/BlockHeader.h>
+#include <bcos-framework/protocol/TransactionReceipt.h>
 #include <bcos-utilities/BoostLog.h>  // BCOS_LOG (demoted-deposit-check observability)
 #include <bcos-utilities/Common.h>
 #include <opstack-executor/OpCommitments.h>  // OpBlockCommitments / payloadBloomToH2048
@@ -18,7 +19,10 @@
 #include <bcos-evm/eth/state/system_contracts.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <map>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -38,22 +42,70 @@ inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6
 {
     return dep.to.has_value() && *dep.to == OP_L1_BLOCK && dep.from == OP_DEPOSITOR;
 }
+
+/// One transaction within a block: deposit or normal tx (a normal tx must carry a signed envelope
+/// for L1 fee calculation).
+struct OpBlockTx
+{
+    std::variant<DepositTx, evmone::state::Transaction> tx;
+    evmc::bytes signedEnvelope;  // empty for deposit
+};
+
+/// Block execution result. txTypes[i] is the EIP-2718 type byte for receipts[i] (the FISCO
+/// receipt has no tx-type slot; sealOpBlock's EncodeIndex leaf needs it).
+struct OpBlockResult
+{
+    std::vector<bcos::protocol::TransactionReceipt::Ptr> receipts;
+    std::vector<uint8_t> txTypes;
+    int64_t gasUsed = 0;
+    evmone::state::StateDiff finalizeDiff;  // end-of-block finalize output
+};
+
+/// Isthmus+ requestsHash = sha256("").
+using evmc::literals::operator""_bytes32;
+inline constexpr auto OP_EMPTY_REQUESTS_HASH =
+    0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_bytes32;
+
+// ---- block execution / seal surface (definitions in OpBlockExecute.cpp) ----
+// Consensus-level rejections throw engine::OpConsensusError (INVALID), never a bare
+// std::runtime_error (OpCommon.h error-channel contract).
+
+/// Jovian-only block-shape validation of the L1 attributes deposit's calldata.
+void validateJovianBlockShape(std::span<const OpBlockTx> txs, const OpForkConfig& cfg);
+
+/// End-of-block finalize (evmone state finalize + StateDiff sanitize).
+evmone::state::StateDiff finalizeOpBlock(
+    const evmone::state::StateView& view, const OpForkConfig& cfg, const evmc::address& coinbase);
+
+/// Block execution: pre-block system call → deposit/normal tx loop → finalize. Admission is
+/// aligned with preBlockOpSteps below (empty block / no leading deposit = hard reject;
+/// non-L1-attributes first deposit and out-of-order deposits = accepted with a warning).
+OpBlockResult processOpBlock(const evmone::state::StateView& view,
+    const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
+    std::span<const OpBlockTx> txs, const OpForkConfig& cfg, evmc::VM& vm, uint64_t chainId,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory,
+    const std::function<void(const evmone::state::StateDiff&)>& applyDiff);
+
+/// Secure-trie root over a live storage slot map (used for the Isthmus+ withdrawalsRoot).
+evmone::hash256 opStorageRoot(const std::map<evmc::bytes32, evmc::bytes32>& storage);
+
+/// Receipt leaf encoding for the receipts-root trie (op-geth receiptRLP / EncodeIndex parity).
+bcos::bytes encodeReceiptForRoot(const bcos::protocol::TransactionReceipt& r, uint8_t txType);
+
+/// Block-header seal: receiptsRoot / logsBloom / withdrawalsRoot / requestsHash / blobGasUsed.
+OpBlockSeal sealOpBlock(const OpBlockResult& result, const OpForkConfig& cfg,
+    const std::map<evmc::bytes32, evmc::bytes32>& messagePasserStorage);
 }  // namespace bcos::evm::opstack
 
 // ---- block-pre steps for the scheduler execution path ----
-//
-// The block-level seal/finalize surface (processOpBlock / validateJovianBlockShape /
-// finalizeOpBlock / opStorageRoot / sealOpBlock / encodeReceiptForRoot / finalizeOpBlockResult /
-// computeOpTxRoot) is deferred to the part that delivers its definitions (part 4/5).
 
 namespace bcos::evm::engine
 {
-/// Block-pre steps shared by the OpScheduler execution path (and previously the retired
-/// runOpBlockInjection): recent-block-hashes construction → system_call_block_start +
-/// write-back → deposit-first content check + Jovian shape → DA footprint gas scalar. Outputs
-/// hashes (emplaced in place — RecentBlockHashes holds a storage reference, not assignable, hence
-/// the std::optional carrier), hashErr, and daFootprintGasScalar via reference params. Throws
-/// OpConsensusError on shape/validation faults.
+/// Block-pre steps for the OP block execution path: recent-block-hashes construction →
+/// system_call_block_start + write-back → deposit-first content check + Jovian shape → DA footprint
+/// gas scalar. Outputs hashes (emplaced in place — RecentBlockHashes holds a storage reference, not
+/// assignable, hence the std::optional carrier), hashErr, and daFootprintGasScalar via reference
+/// params. Throws OpConsensusError on shape/validation faults.
 template <class Storage, class RawTxRange>
 void preBlockOpSteps(Storage& view, bcos::protocol::BlockHeader const& header,
     bcos::evm::opstack::OpForkConfig const& cfg, RawTxRange const& rawTxBytes,

--- a/opstack-executor/OpCommon.h
+++ b/opstack-executor/OpCommon.h
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-// Shared error types + the block-execution result for the OP scheduler, plus the block-context
-// conversion helpers (bcos<->evmc fixed-size conversions / bounds-checked narrowing / FISCO-header
-// -> evmone BlockInfo build). Split out of OpSchedulerSeam.h so dependent layers can throw without
-// depending on the class template. OpBlockSeal lives here too (not in OpBlockExecute.h):
-// OpExecuteBlockResult carries it by value.
+// Shared error types + the block-execution result for the OP block executor, plus the
+// block-context conversion helpers (bcos<->evmc fixed-size conversions / bounds-checked
+// narrowing / FISCO-header -> evmone BlockInfo build), kept class-free so dependent layers can
+// throw without depending on the executor templates. OpBlockSeal lives here too (not in
+// OpBlockExecute.h): OpExecuteBlockResult carries it by value.
 //
 // The six-way commitment comparison surface (OpBlockCommitments / commitmentsOf /
 // payloadBloomToH2048 / mismatchedFieldOf / detail::toBcosH256 / toBcosBloom) lives in
@@ -48,15 +48,36 @@ struct OpBlockSeal
     std::optional<uint64_t> blobGasUsed;
 };
 
-/// "0x" + lowercase hex (op-geth hexutil.Uint64); the value later feeds the receipts-root leaf
-/// encoding that returns with the block-seal wiring (part 5).
-[[nodiscard]] inline std::string hexCumulative(uint64_t cumulative)
+/// "0x" + lowercase hex (op-geth hexutil.Uint64); feeds the receipts-root leaf encoding
+/// (OpBlockExecute.cpp). Formats into `out` (caller-reused per block) instead of allocating a
+/// fresh string per tx — setCumulativeGasUsed copies the value into the receipt anyway, so the
+/// per-tx path should not add another allocation chain on top (toQuantity builds bytes→hex→string).
+inline void appendHexCumulative(uint64_t cumulative, std::string& out)
 {
-    return bcos::toQuantity(cumulative);  // reuse the library quantity formatter
+    out = "0x";
+    // Up to 16 hex digits (uint64 max = 0xffffffffffffffff); the per-tx buffer is reserved once.
+    char buf[16];
+    auto* p = buf + sizeof(buf);
+    do
+    {
+        *--p = "0123456789abcdef"[cumulative & 0xF];
+        cumulative >>= 4;
+    } while (cumulative != 0);
+    out.append(p, buf + sizeof(buf));
 }
 
-/// EIP-2718 tx-type classification, single home for the block-execution sites (the OpScheduler
-/// deposit-classification loop and the part-5 seal wiring's txTypes rebuild) so the mapping can't
+/// Convenience wrapper returning a fresh string (ExecuteContext::finish, a per-tx path that
+/// cannot reuse a block-level buffer).
+[[nodiscard]] inline std::string hexCumulative(uint64_t cumulative)
+{
+    std::string out;
+    out.reserve(18);  // "0x" + 16 hex digits
+    appendHexCumulative(cumulative, out);
+    return out;
+}
+
+/// EIP-2718 tx-type classification, single home for the block-execution sites (the
+/// deposit-classification loop and the seal path's txTypes rebuild) so the mapping can't
 /// drift and silently emit a wrong receiptsRoot leaf. Maps a raw type byte to the per-receipt
 /// type byte:
 /// OP deposit 0x7e (kDepositTxType, OpTransition.h) → itself; legacy (>= 0xc0 RLP list prefix)
@@ -142,8 +163,7 @@ inline uint64_t narrowU256ToU64(const bcos::u256& v, const char* fieldName)
 {
     static const bcos::u256 kMaxU64(std::numeric_limits<uint64_t>::max());
     if (v > kMaxU64)
-        throw OpConsensusError(
-            std::string("OpSchedulerSeam: field exceeds uint64_t range: ") + fieldName);
+        throw OpConsensusError(std::string("op block: field exceeds uint64_t range: ") + fieldName);
     return static_cast<uint64_t>(v);
 }
 
@@ -154,8 +174,7 @@ inline int64_t narrowU256ToI64(const bcos::u256& v, const char* fieldName)
 {
     static const bcos::u256 kMaxI64(std::numeric_limits<int64_t>::max());
     if (v > kMaxI64)
-        throw OpConsensusError(
-            std::string("OpSchedulerSeam: field exceeds int64_t range: ") + fieldName);
+        throw OpConsensusError(std::string("op block: field exceeds int64_t range: ") + fieldName);
     return static_cast<int64_t>(v);
 }
 
@@ -167,7 +186,7 @@ template <class T>
 {
     if (!opt.has_value())
         throw OpConsensusError(
-            std::string("OpSchedulerSeam: missing required header field: ") + fieldName);
+            std::string("op block: missing required header field: ") + fieldName);
     return *opt;
 }
 
@@ -216,15 +235,12 @@ inline evmone::state::BlockInfo toBlockInfo(const bcos::protocol::BlockHeader& e
 
 namespace bcos::evm::opstack
 {
-/// Bounds-checked u256→int64 narrowing (a corrupt receipt must not wrap the gas pool). Throws
-/// engine::OpConsensusError — a bare std::runtime_error would escape the INVALID/-32603
-/// classification this header establishes (see requireHeaderField's comment). Defined after the
-/// engine block because the error types live there.
+/// Bounds-checked u256→int64 narrowing (a corrupt receipt must not wrap the gas pool). Delegates
+/// to engine::detail::narrowU256ToI64 (single home for the u256→int64 ceiling); the receipt-
+/// specific message is folded into the shared "exceeds int64_t range" text so the two cannot
+/// drift in ceiling.
 [[nodiscard]] inline int64_t narrowGasUsed(const bcos::u256& gasUsed)
 {
-    static const bcos::u256 kMaxInt64(std::numeric_limits<int64_t>::max());
-    if (gasUsed > kMaxInt64)
-        throw engine::OpConsensusError("op block: receipt gasUsed exceeds int64_t range");
-    return static_cast<int64_t>(gasUsed);
+    return engine::detail::narrowU256ToI64(gasUsed, "receipt gasUsed");
 }
 }  // namespace bcos::evm::opstack

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -17,6 +17,7 @@
 #include "bcos-framework/protocol/TransactionReceipt.h"
 #include "bcos-framework/protocol/TransactionReceiptFactory.h"
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
+#include "bcos-rlp-protocol/Web3TxEnvelope.h"
 #include "ethereum-executor/EVMSupport.h"  // eth::evm::toIntxU256
 #include "opstack-executor/OpCommon.h"  // detail::narrowU256ToU64 / toEvmcAddress / toEvmcBytes32
 #include "opstack-executor/Storage2State.h"  // Storage2State / SharedErrorSlot
@@ -76,7 +77,12 @@ inline evmone::state::Transaction toEvmoneTransaction(bcos::protocol::Transactio
     }
     auto const& input = tx.input();
     evmTx.data = evmc::bytes(input.begin(), input.end());
-    evmTx.gas_limit = tx.gasLimit();
+    // gasLimit() is already int64_t end-to-end (uint64 decode width-gate -> tars -> int64_t
+    // accessor, Transaction.h), so no narrowing occurs here. The checked helper below only
+    // adds an explicit reject for a negative value (corrupt mirror) — same INVALID/OpConsensusError
+    // class the evmone INTRINSIC_GAS_TOO_LOW path would produce anyway; kept for fail-early.
+    evmTx.gas_limit =
+        bcos::evm::engine::detail::narrowU256ToI64(tx.gasLimit(), "toEvmoneTransaction::gas_limit");
     if (auto gp = tx.gasPrice(); gp.has_value())
         evmTx.max_gas_price = toIntxU256(*gp);
     if (auto mf = tx.maxFeePerGas(); mf.has_value())
@@ -127,6 +133,12 @@ inline evmone::state::Transaction toEvmoneTransaction(bcos::protocol::Transactio
                 std::copy(decoded->begin(), decoded->end(), ta.bytes);
                 evmTx.to = ta;
             }
+            else
+            {
+                BCOS_LOG(WARNING) << LOG_BADGE("OP_EXEC")
+                                  << LOG_DESC("malformed `to` hex — treating as contract creation")
+                                  << LOG_KV("to", tb);
+            }
         }
         else if (tb.size() == sizeof(evmc_address))
         {
@@ -174,7 +186,9 @@ inline evmone::state::Transaction toEvmoneTransaction(bcos::protocol::Transactio
     // ("10" -> 0x10 = 16). Parse chainID as decimal instead. Both are parsed strictly and
     // non-throwing: empty, a double 0x (e.g. "0x0x1a"), a non-numeric value (e.g. a FISCO
     // chain_id like "chain0"), a sign, trailing garbage, or a value above uint64 all fall
-    // through to 0. Note that 0 is NOT a guaranteed rejection:
+    // through to 0. Assumption: no production chain uses chain_id 0 — a malformed parse
+    // producing 0 is rejected at the admission layer (envelope-chainId != node-config), not here.
+    // If chain_id 0 is ever used in production, the fallback-to-zero heuristic must be revisited.
     //   * chain_id 0 never matches a real chain id (and evmone's
     //     validate_transaction does not check chain_id — the signature binds it
     //     upstream, so a malformed chain_id implies an invalid signature that
@@ -367,7 +381,7 @@ public:
     if (auto e = rlp::decode(items, gas); e != nullptr)
         fail("deposit envelope: gas decode failed");
     if (gas > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
-        fail("deposit envelope: gas exceeds int64 range");
+        fail("deposit envelope: gas exceeds int64_t max (would wrap negative on cast)");
     // isSystemTx (uint64): width + canonicality check, then a 0/1 value check (op-geth's
     // decodeBool accepts only the empty item and 0x01). Decoded as uint64 because the FISCO bool
     // overload demands payloadLength == 1 and would reject the empty-item false.
@@ -392,12 +406,13 @@ public:
     return dep;
 }
 
-/// Per-block execution state threaded through ExecuteContext (shared scheduler plan Task 3).
+/// Per-block execution state threaded through ExecuteContext.
 /// fee is loaded lazily on the first NORMAL tx (after the L1 attributes deposit has run);
 /// blockGasLeft / cumulativeGasUsed / seenNonDeposit are mutated per tx; hashes / chainId are
 /// fixed at block construction; daFootprintGasScalar (Jovian) overrides
 /// fee.da_footprint_gas_scalar when set. The first five fields are mutable so a
-/// `BlockContext const*` can write them. Namespace-scope (not nested) so OpScheduler / tests can
+/// `BlockContext const*` can write them. Namespace-scope (not nested) so the block orchestrator /
+/// tests can
 /// value-initialize it (a nested struct's default member initializers are unusable outside
 /// OpstackExecutor's member functions).
 ///
@@ -411,6 +426,7 @@ struct OpBlockExecutionContext
     mutable int64_t blockGasLeft = 0;             // decremented per tx
     mutable int64_t cumulativeGasUsed = 0;        // accumulated across txs
     mutable bool seenNonDeposit = false;          // deposit-after-non-deposit gate
+    mutable std::string cumulativeHex;            // reusable buffer for hexCumulative formatting
     evmone::state::BlockHashes* blockHashes = nullptr;  // built once at block level
     uint64_t chainId = 0;                               // constant for the whole block
     std::optional<uint16_t> daFootprintGasScalar;       // Jovian DA scalar
@@ -555,8 +571,7 @@ public:
                     // A malformed deposit envelope (e.g. a 0x02-envelope whose tars mirror
                     // claims deposit) is a consensus rejection, not an internal error.
                     throw engine::OpConsensusError(
-                        std::string("OpScheduler: deposit envelope validation failed: ") +
-                        e.what());
+                        std::string("op block: deposit envelope validation failed: ") + e.what());
                 }
                 co_return;  // deposit has no opValidate
             }
@@ -581,7 +596,7 @@ public:
             catch (const OpTxValidationFailed& e)
             {
                 throw engine::OpConsensusError(
-                    std::string("OpScheduler: normal tx validation failed: ") + e.what());
+                    std::string("op block: normal tx validation failed: ") + e.what());
             }
         }
         task::Task<void> execute()
@@ -600,7 +615,8 @@ public:
                 try
                 {
                     m_receipt = co_await executor.executeDeposit(storage, blockHeader, m_deposit,
-                        m_ctx->chainId, m_ctx->blockGasLeft, ledgerConfig, m_ctx->blockHashes);
+                        m_ctx->chainId, m_ctx->blockGasLeft, ledgerConfig, call,
+                        m_ctx->blockHashes);
                 }
                 catch (...)
                 {
@@ -634,15 +650,16 @@ public:
             // hexCumulative live in OpCommon.h).
             auto gasUsed = op::narrowGasUsed(receipt->gasUsed());
             m_ctx->cumulativeGasUsed += gasUsed;
-            receipt->setCumulativeGasUsed(op::hexCumulative(m_ctx->cumulativeGasUsed));
+            op::appendHexCumulative(
+                static_cast<uint64_t>(m_ctx->cumulativeGasUsed), m_ctx->cumulativeHex);
+            receipt->setCumulativeGasUsed(m_ctx->cumulativeHex);
             m_ctx->blockGasLeft -= gasUsed;
             co_return receipt;
         }
     };
 
     /// 7-arg form (OP path): the caller owns the BlockContext and must keep it alive across the
-    /// prepare/execute/finish lifecycle (SchedulerSerialImpl forwards the ctx that lives in
-    /// OpScheduler's coroutine frame).
+    /// prepare/execute/finish lifecycle (e.g. in the caller's coroutine frame).
     template <class Storage>
     task::Task<ExecuteContext<Storage>> createExecuteContext(Storage& storage,
         protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
@@ -691,6 +708,13 @@ public:
     {
         (void)contextID;
 
+        // A missing block-hashes source on the block path would silently degrade BLOCKHASH to
+        // zeros — fail loud instead (same guard as executeDeposit below and ExecuteContext::
+        // execute). call=true (eth_call) simulates without a block context, so it is exempt.
+        if (blockHashes == nullptr && !call)
+            throw engine::OpConsensusError(
+                "OpstackExecutor: block execution requires wired RecentBlockHashes");
+
         if (transaction.isDepositTx())
         {
             bcos::evm::opstack::DepositTx dep;
@@ -703,12 +727,12 @@ public:
                 // Same error normalization as ExecuteContext::prepare: a malformed deposit
                 // envelope is a CONSENSUS rejection (INVALID), not an internal error.
                 throw engine::OpConsensusError(
-                    std::string("OpScheduler: deposit envelope validation failed: ") + e.what());
+                    std::string("op block: deposit envelope validation failed: ") + e.what());
             }
             try
             {
-                co_return co_await executeDeposit(
-                    storage, blockHeader, dep, chainId, blockGasLeft, ledgerConfig, blockHashes);
+                co_return co_await executeDeposit(storage, blockHeader, dep, chainId, blockGasLeft,
+                    ledgerConfig, call, blockHashes);
             }
             catch (...)
             {
@@ -734,34 +758,59 @@ public:
         catch (const OpTxValidationFailed& e)
         {
             throw engine::OpConsensusError(
-                std::string("OpScheduler: normal tx validation failed: ") + e.what());
+                std::string("op block: normal tx validation failed: ") + e.what());
         }
         evmone::state::StateDiff diff;
         auto receipt = co_await m_execute(stateView, blockHeader, transaction, ledgerConfig, props,
             diff, chainId, blockGasLeft, blockHashes, &blockInfo);
+        // Read-path poison from validate/transition (stateView is shared by both stages). Checked
+        // BEFORE m_finish: a storage read fault must surface as OpStorageError, never as a
+        // receipt built from defaulted state (same contract as executeDeposit's post-applyDiff
+        // check; with a default-null shared slot this is the only observer of this view).
+        if (stateView.poisoned())
+            throw engine::OpStorageError("normal tx execution poisoned: " + stateView.firstError());
         co_return co_await m_finish(storage, blockHeader, ledgerConfig, receipt, diff);
     }
 
     /// Execute a single OP 0x7E deposit transaction (reuses runDeposit).
+    /// `call` follows the same contract as executeTransaction: eth_call (true) tolerates unset
+    /// optional header fields as 0; block execution (false) requires them (OpCommon.h
+    /// requireHeaderField) — deposits are NOT exempt from the strict-path contract.
     template <class Storage>
     task::Task<protocol::TransactionReceipt::Ptr> executeDeposit(Storage& storage,
         protocol::BlockHeader const& blockHeader, bcos::evm::opstack::DepositTx const& dep,
         uint64_t chainId, int64_t blockGasLeft, ledger::LedgerConfig const& ledgerConfig,
-        evmone::state::BlockHashes const* blockHashes = nullptr)
+        bool call = false, evmone::state::BlockHashes const* blockHashes = nullptr)
     {
         namespace op = bcos::evm::opstack;
 
         checkForkRevision(ledgerConfig);
 
+        // A missing block-hashes source on the block path would silently degrade BLOCKHASH to
+        // zeros — fail loud instead (same guard as the per-tx execute path).
+        if (blockHashes == nullptr && !call)
+            throw engine::OpConsensusError(
+                "OpstackExecutor: block execution requires wired RecentBlockHashes");
+
         auto blockInfo = buildBlockInfo(
-            blockHeader, opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
+            blockHeader, opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)), call);
         bcos::evm::evmstate::Storage2State<Storage> stateView(storage, m_sharedError);
         NullBlockHashes nullBlockHashes;
         auto const& bh = (blockHashes != nullptr) ? *blockHashes : nullBlockHashes;
 
         evmone::state::StateDiff diff;
-        auto receipt = op::runDeposit(stateView, blockInfo, bh, dep, m_forkConfig, m_vm, chainId,
-            blockGasLeft, m_receiptFactory, diff);
+        bcos::protocol::TransactionReceipt::Ptr receipt;
+        try
+        {
+            receipt = op::runDeposit(stateView, blockInfo, bh, dep, m_forkConfig, m_vm, chainId,
+                blockGasLeft, m_receiptFactory, diff);
+        }
+        catch (...)
+        {
+            // Block-level rejections (gas-limit reached, negative gas_used, is_system_tx) leave
+            // as OpConsensusError per the OpBlockExecute.h contract, never a bare runtime_error.
+            rethrowExecError("deposit execution");
+        }
         // runDeposit sanitizes the diff at source (OpTransition.cpp), satisfying applyDiff's
         // precondition. applyDiff poisons AND rethrows raw; every write-back failure is a local
         // storage fault, so it must leave as OpStorageError (-32603), never INVALID.
@@ -783,8 +832,7 @@ public:
         co_return receipt;
     }
 
-    // Block-level finalize (finalizeOpBlock / seal) is deferred to the part that lands the
-    // OpScheduler wiring (part 5).
+    // Block-level finalize: use the finalizeOpBlock free function (OpBlockExecute.h).
 
 private:
     // ---- Shared normal-tx pipeline: three stages (prepare/execute/finish). ----
@@ -816,11 +864,11 @@ private:
         }
         catch (const std::exception& e)
         {
-            throw engine::OpConsensusError("OpScheduler: " + what + " failed: " + e.what());
+            throw engine::OpConsensusError("op block: " + what + " failed: " + e.what());
         }
         catch (...)
         {
-            throw engine::OpConsensusError("OpScheduler: " + what + " failed: unknown exception");
+            throw engine::OpConsensusError("op block: " + what + " failed: unknown exception");
         }
     }
 
@@ -857,31 +905,44 @@ private:
         // executeTransaction) and shared with m_execute; built here only when not supplied.
         auto blockInfo = (prebuiltBlockInfo != nullptr) ?
                              *prebuiltBlockInfo :
+                             // Strict fallback: a missing prebuilt block info must not fail open
+                             // (lenient reads unset header fields as 0); call sites pass the
+                             // prebuilt info, so this branch is defensive only.
                              buildBlockInfo(blockHeader,
-                                 opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
+                                 opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)),
+                                 /*lenientOptionals=*/false);
         auto evmTx = eth::toEvmoneTransaction(transaction);
         // op-geth parity: reject txs whose chainId differs from the node's chainId.
         // op-geth EIP155Signer.Sender / modernSigner.Sender check `tx.ChainId() == chainID`
         // (ErrInvalidChainId) during block processing; FISCO previously accepted any
         // self-consistent chainId (the signature binds the tx's own chainId, so sender recovery
-        // always succeeds). Only legacy UNPROTECTED txs (v=27/28, chain_id==0, Homestead) are
-        // exempt; every other tx (EIP-155 protected legacy + ALL typed txs) must match.
-        // chainId is nullopt only on the eth_call path (lenient, like op-geth eth_call). The
-        // block path always engages it — an engaged 0 (caller forgot the node chainId) rejects
-        // every real tx, so the omission is loud rather than silently disabling the check.
-        // Known residual: chain_id==0 also arises from a v=35/36 EIP-155-protected legacy tx
-        // (chain id 0), which the tars layer collapses onto the same "0" as v=27/28 — such a tx is
-        // exempted here where op-geth's Protected() rejects it. Nil security impact (the signature
-        // is re-encodable as v=27/28); full parity needs a protected flag in the tars Transaction.
+        // always succeeds). The comparison reads the SIGNED envelope (web3ChainIdFromEnvelope),
+        // never the unauthenticated tars mirror data.chainID — the signature binds only the
+        // envelope, so a forged mirror can defeat a mirror-based gate. nullopt = pre-EIP-155
+        // unprotected legacy (6-field, v=27/28, Homestead): exempt — a deliberate divergence
+        // (geth/op-geth default rejects unprotected txs at the RPC layer); every other tx
+        // (EIP-155 protected legacy + ALL typed) must match. chainId is nullopt only on the
+        // eth_call path (lenient, like op-geth eth_call). The block path always engages it —
+        // an engaged 0 (caller forgot the node chainId) rejects every real tx, so the omission
+        // is loud rather than silently disabling the check.
         if (chainId.has_value())
         {
-            // Only legacy UNPROTECTED txs (v=27/28, chain_id==0, Homestead) are exempt.
-            bool const exempt =
-                evmTx.type == evmone::state::Transaction::Type::legacy && evmTx.chain_id == 0;
-            if (!exempt && evmTx.chain_id != *chainId)
+            auto envelopeChainId = transaction.web3ChainIdFromEnvelope();
+            if (envelopeChainId.has_value() && *envelopeChainId != *chainId)
                 throw engine::OpConsensusError(
-                    "OpScheduler: tx chain_id " + std::to_string(evmTx.chain_id) +
+                    "op block: tx envelope chain_id " + std::to_string(*envelopeChainId) +
                     " does not match node chainId " + std::to_string(*chainId));
+            // A typed envelope ALWAYS carries a chainId (RLP field 0). nullopt for a typed
+            // envelope means the preimage is malformed (over-wide/non-integer chainId) — reject
+            // rather than exempt as if it were pre-EIP-155 legacy (a default/nullopt impl would
+            // otherwise silently skip the gate). Only a legacy 6-field envelope legitimately
+            // yields nullopt.
+            if (!envelopeChainId.has_value() &&
+                bcos::rlp::protocol::isTypedWeb3Envelope(transaction.extraTransactionBytes()))
+            {
+                throw engine::OpConsensusError(
+                    "op block: typed tx envelope is missing a parseable chainId");
+            }
         }
         auto envRef = transaction.extraTransactionBytes();
         evmc::bytes_view env{envRef.data(), envRef.size()};
@@ -902,7 +963,7 @@ private:
         bcos::evm::evmstate::Storage2State<Storage>& stateView,
         protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
         ledger::LedgerConfig const& ledgerConfig, bcos::evm::opstack::OpTxProperties const& props,
-        evmone::state::StateDiff& diff, uint64_t chainId = 0, int64_t blockGasLeft = 0,
+        evmone::state::StateDiff& diff, uint64_t chainId, int64_t blockGasLeft,
         evmone::state::BlockHashes const* blockHashes = nullptr,
         evmone::state::BlockInfo const* prebuiltBlockInfo = nullptr)
     {
@@ -911,8 +972,12 @@ private:
         (void)ledgerConfig;
         auto blockInfo = (prebuiltBlockInfo != nullptr) ?
                              *prebuiltBlockInfo :
+                             // Strict fallback: a missing prebuilt block info must not fail open
+                             // (lenient reads unset header fields as 0); call sites pass the
+                             // prebuilt info, so this branch is defensive only.
                              buildBlockInfo(blockHeader,
-                                 opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
+                                 opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)),
+                                 /*lenientOptionals=*/false);
         auto const& evmTx = props.evm_tx;  // reuse the prepare-built tx
 
         NullBlockHashes nullBlockHashes;
@@ -978,8 +1043,7 @@ public:
 
 private:
     protocol::TransactionReceiptFactory::Ptr m_receiptFactory;
-    // Reserved for the part-5 seal wiring (header-commitment hashing); unused since the
-    // write-back moved to Storage2State::applyDiff.
+    // Reserved for header-commitment hashing at block seal; the per-tx path does not use it.
     [[maybe_unused]] crypto::Hash::Ptr m_hashImpl;
     // Value copy, not a reference: OpForkConfig is small (~32B, once per block) and a reference
     // member to a caller's config is the same lifetime footgun class that m_ctx had.

--- a/opstack-executor/Storage2State.h
+++ b/opstack-executor/Storage2State.h
@@ -228,7 +228,8 @@ public:
     /// patterns. opTransition/runDeposit always sanitize before calling; part-3 callers must too.
     ///
     /// Any write-back failure ALSO sets the poison flag before rethrowing. This is error
-    /// CLASSIFICATION, not style: OpSchedulerSeam maps poisoned() -> OpStorageError (-32603) and
+    /// CLASSIFICATION, not style: the block executor maps poisoned() -> OpStorageError (-32603)
+    /// and
     /// anything else -> OpConsensusError (INVALID); every failure here (ghost delete, system-
     /// address routing, contract-② zero-slot leak, nonce/width violations, the storage backend
     /// itself) is a LOCAL fault, and the diff comes from evmone itself (malformed payloads were

--- a/opstack-executor/tests/CMakeLists.txt
+++ b/opstack-executor/tests/CMakeLists.txt
@@ -6,11 +6,13 @@ find_package(jsoncpp CONFIG REQUIRED)
 # TestMain.cpp (the single main for the whole suite — the earlier three-target split left the
 # add_test entries dangling with no add_executable; this restores the wiring with one target).
 #
-# No `ledger` link: header-only usage only (Classify.h), and the ledger→bcos-crypto→wedprcrypto
-# chain breaks libc++ typed catch binary-wide (bcos-rpc/test/CMakeLists.txt:29-34), so
-# exception-type assertions rely on exact-type BOOST_CHECK_THROW.
+# No `ledger` link: header-only usage only (Classify.h). bcos-crypto IS linked and typed
+# exception assertions (e.g. BOOST_CHECK_THROW(..., engine::OpConsensusError)) work — the
+# full suite is green with typed catches enabled.
 add_executable(opstack-executor-tests
     TestMain.cpp
+    OpstackExecutorTest.cpp
+    OpReceiptEncodeTest.cpp
     OpRlpDecodeTest.cpp
     OpDepositEnvelopeTest.cpp
     OpTxConvertTest.cpp
@@ -19,16 +21,35 @@ add_executable(opstack-executor-tests
     OpCommitmentsTest.cpp
     RecentBlockHashesTest.cpp
     PreBlockOpStepsTest.cpp
+    OpBlockProcessTest.cpp
     Storage2StateHelpersTest.cpp
     Storage2StatePoisonTest.cpp
     support/SeedPreStateTest.cpp
 )
-# Unity build: header-heavy Boost.Test TUs share a large common preamble (catch.hpp, evmone,
-# op-rlp headers). TestMain.cpp defines BOOST_TEST_MODULE and stays out of the batch.
-set_target_properties(opstack-executor-tests PROPERTIES UNITY_BUILD "ON")
-set_source_files_properties(TestMain.cpp PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+# OpReceiptEncodeTest diffs the FISCO receipt leaf encoding against evmone's independent
+# evmone::state::rlp_encode (Log / TransactionReceipt overloads). bcos-evm deliberately keeps
+# rlp_encode.cpp out of the production lib (zero production callers — see bcos-evm/CMakeLists.txt),
+# so this test target compiles the package-shipped source itself; its <test/state/...> includes
+# resolve through the pkg-include-shim dir that bcos-evm-eth exposes PUBLIC-ly (transitively on
+# this target via opstack-executor → bcos-evm-opstack).
+get_target_property(_evmone_include_dirs evmone::evmone INTERFACE_INCLUDE_DIRECTORIES)
+list(GET _evmone_include_dirs 0 _evmone_include_dir)
+cmake_path(NORMAL_PATH _evmone_include_dir)
+if(NOT EXISTS "${_evmone_include_dir}/test/utils/rlp_encode.cpp")
+    message(FATAL_ERROR "evmone package does not ship test/utils sources; "
+        "port-version >= 8 of the overlay port is required (${_evmone_include_dir})")
+endif()
+target_sources(opstack-executor-tests PRIVATE "${_evmone_include_dir}/test/utils/rlp_encode.cpp")
+# Vendored upstream source: same warning exemption bcos-evm grants its ported files.
+set_source_files_properties("${_evmone_include_dir}/test/utils/rlp_encode.cpp"
+    PROPERTIES COMPILE_OPTIONS "-Wno-missing-field-initializers")
 target_link_libraries(opstack-executor-tests PRIVATE
     opstack-executor
+    rpc
+    protocol-tars
+    codec
+    bcos-crypto
+    bcos-task
     jsoncpp_static
     Boost::unit_test_framework
 )

--- a/opstack-executor/tests/OpBlockProcessTest.cpp
+++ b/opstack-executor/tests/OpBlockProcessTest.cpp
@@ -1,0 +1,249 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpBlockProcessTest.cpp — direct coverage for the processOpBlock admission boundary (empty
+// block / non-deposit first tx / Jovian activation-block shape), which per-part tests alone
+// cannot reach, plus one deposit-only happy path through the block loop. OpstackExecutorTest
+// drives the per-tx scheduler path (executeTransaction/executeDeposit); it does NOT call
+// processOpBlock, so this file's happy path is the only full-loop coverage.
+
+// BOOST_TEST_MODULE lives in TestMain.cpp (the single main for the whole suite).
+#include <boost/test/unit_test.hpp>
+
+#include "bcos-evm/opstack/OpForkSchedule.h"
+#include "opstack-executor/OpBlockExecute.h"
+#include "opstack-executor/Storage2State.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
+#include <memory>
+
+using namespace bcos;
+using namespace bcos::executor_v1::opstack;
+using namespace evmc::literals;  // _bytes32 / _address
+
+namespace
+{
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+// Jovian activation block: Isthmus-length (176B) L1 attributes, must be deposits-only.
+// Build a deposit whose data is exactly IsthmusL1AttributesLen bytes.
+bcos::evm::opstack::DepositTx makeActivationL1AttributesDeposit()
+{
+    using bcos::evm::opstack::DepositTx;
+    DepositTx dep{
+        .source_hash = 0x01_bytes32,
+        .from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address,
+        .to = 0x4200000000000000000000000000000000000015_address,
+        .mint = intx::uint256{5},
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = evmc::bytes(bcos::evm::opstack::IsthmusL1AttributesLen, uint8_t{0x00}),
+    };
+    return dep;
+}
+
+bcos::evm::opstack::DepositTx makeNormalJovianDeposit()
+{
+    auto dep = makeActivationL1AttributesDeposit();
+    // Normal Jovian: Jovian length + selector + DA scalar bytes.
+    dep.data.assign(bcos::evm::opstack::JovianL1AttributesLen, 0x00);
+    std::copy(bcos::evm::opstack::JovianL1AttributesSelector.begin(),
+        bcos::evm::opstack::JovianL1AttributesSelector.end(), dep.data.begin());
+    return dep;
+}
+
+// A normal (non-deposit) tx — admission rejects it before execution touches its fields.
+bcos::evm::opstack::OpBlockTx makeNormalTx()
+{
+    bcos::evm::opstack::OpBlockTx btx;
+    btx.tx = evmone::state::Transaction{};
+    return btx;
+}
+
+// Admission tests reject before hashes are read.
+struct ZeroBlockHashes final : evmone::state::BlockHashes
+{
+    evmc::bytes32 get_block_hash(int64_t) const noexcept override { return {}; }
+};
+
+struct Fixture
+{
+    std::shared_ptr<crypto::CryptoSuite> cryptoSuite = makeCryptoSuite();
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory{
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)};
+    MutableStorage storage;
+    evmc::VM vm{evmc_create_evmone()};
+    bcos::evm::opstack::OpForkConfig fork = bcos::evm::opstack::jovianConfig();
+
+    evmone::state::BlockInfo makeBlockInfo() const
+    {
+        evmone::state::BlockInfo blk;
+        blk.number = 1;
+        blk.timestamp = 1000;  // seconds (evmone convention)
+        blk.gas_limit = 30'000'000;
+        blk.base_fee = 0;
+        return blk;
+    }
+
+    // Runs processOpBlock and expects a consensus rejection with the given message fragment.
+    // Step 1 (system_call_block_start) runs before shape admission and applies a diff, so only
+    // the rejection is asserted. The message pin distinguishes the shape-level rejection from a
+    // later execution-loop throw (e.g. an invalid non-deposit tx would also throw
+    // OpConsensusError).
+    void expectReject(
+        std::span<const bcos::evm::opstack::OpBlockTx> txs, std::string_view expectMessageContains)
+    {
+        bcos::evm::evmstate::Storage2State<MutableStorage> view(storage, nullptr);
+        auto blk = makeBlockInfo();
+        ZeroBlockHashes hashes{};
+        BOOST_CHECK_EXCEPTION(processOpBlock(view, blk, hashes, txs, fork, vm, /*chainId=*/10,
+                                  receiptFactory, [&](const evmone::state::StateDiff&) {}),
+            bcos::evm::engine::OpConsensusError, [&](auto const& e) {
+                return std::string(e.what()).find(expectMessageContains) != std::string::npos;
+            });
+    }
+};
+}  // namespace
+
+BOOST_FIXTURE_TEST_SUITE(OpBlockProcessTest, Fixture)
+
+// Empty block: nothing seeds the block's fee/DA context — hard reject (op-geth parity).
+BOOST_AUTO_TEST_CASE(EmptyBlockRejected)
+{
+    std::vector<bcos::evm::opstack::OpBlockTx> txs;
+    expectReject(txs, "empty block");
+}
+
+// First tx is not a deposit — hard reject.
+BOOST_AUTO_TEST_CASE(NonDepositFirstTxRejected)
+{
+    std::vector<bcos::evm::opstack::OpBlockTx> txs;
+    txs.push_back(makeNormalTx());
+    expectReject(txs, "no deposit transaction");
+}
+
+// Jovian activation block (Isthmus-length attributes) mixed with a normal tx must be rejected:
+// activation blocks are deposits-only.
+BOOST_AUTO_TEST_CASE(ActivationBlockMixedTxRejected)
+{
+    std::vector<bcos::evm::opstack::OpBlockTx> txs;
+    auto dep = makeActivationL1AttributesDeposit();
+    bcos::evm::opstack::OpBlockTx depTx;
+    depTx.tx = dep;
+    txs.push_back(depTx);
+    txs.push_back(makeNormalTx());
+    expectReject(txs, "Jovian activation block");
+}
+
+// Jovian activation block with interleaved non-deposit but deposit last:
+// op-geth checks only the last tx, so this passes shape validation (last is deposit).
+BOOST_AUTO_TEST_CASE(ActivationBlockDepositNormalDepositLastPassesShape)
+{
+    // Jovian activation block with interleaved non-deposit but deposit last:
+    // op-geth checks only the last tx, so SHAPE validation passes. The block is still
+    // rejected (here by opValidate rejecting the under-specified test tx; the
+    // deposit-after-non-deposit ordering rule is a WARNING-only demotion, not a hard gate) —
+    // the point is that the rejection must NOT carry the Jovian shape message (anchored via
+    // ActivationBlockMixedTxRejected, which does expect it when a normal tx is present and
+    // the LAST tx is normal).
+    std::vector<bcos::evm::opstack::OpBlockTx> txs;
+    auto dep = makeActivationL1AttributesDeposit();
+    bcos::evm::opstack::OpBlockTx depTx;
+    depTx.tx = dep;
+    txs.push_back(depTx);
+    txs.push_back(makeNormalTx());
+    txs.push_back(depTx);  // deposit last — op-geth parity: last-tx-only check passes
+    bcos::evm::evmstate::Storage2State<MutableStorage> view(storage, nullptr);
+    auto blk = makeBlockInfo();
+    ZeroBlockHashes hashes{};
+    BOOST_CHECK_EXCEPTION(processOpBlock(view, blk, hashes, txs, fork, vm, /*chainId=*/10,
+                              receiptFactory, [&](const evmone::state::StateDiff&) {}),
+        bcos::evm::engine::OpConsensusError, [](auto const& e) {
+            return std::string(e.what()).find("Jovian activation block") == std::string::npos;
+        });
+}
+
+// A normal Jovian all-deposit block with the correct selector passes shape validation.
+BOOST_AUTO_TEST_CASE(NormalJovianDepositsOnlyPassesShapeCheck)
+{
+    std::vector<bcos::evm::opstack::OpBlockTx> txs;
+    auto dep = makeNormalJovianDeposit();
+    bcos::evm::opstack::OpBlockTx depTx;
+    depTx.tx = dep;
+    txs.push_back(depTx);
+    bcos::evm::opstack::OpBlockTx depTx2;
+    depTx2.tx = makeNormalJovianDeposit();
+    txs.push_back(depTx2);
+    BOOST_CHECK_NO_THROW(bcos::evm::opstack::validateJovianBlockShape(txs, fork));
+}
+
+// A typed envelope whose chainId field is over-wide (9 bytes) yields nullopt from
+// web3ChainIdFromEnvelope — it must NOT be exempted as pre-EIP-155 legacy here (same
+// typed+nullopt guard as m_prepare / TxValidator / EthEndpoint). Deposit first so the block
+// reaches the execution loop's normal-tx chainId gate.
+BOOST_AUTO_TEST_CASE(TypedEnvelopeUnparseableChainIdRejected)
+{
+    std::vector<bcos::evm::opstack::OpBlockTx> txs;
+    bcos::evm::opstack::OpBlockTx depTx;
+    depTx.tx = makeNormalJovianDeposit();
+    txs.push_back(depTx);
+    auto btx = makeNormalTx();
+    // 0x02 (EIP-1559 marker) || rlp-list([0x89 || 9-byte chainId]).
+    btx.signedEnvelope = {0x02, 0xca, 0x89, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09};
+    txs.push_back(btx);
+    expectReject(txs, "missing a parseable chainId");
+}
+
+// Happy path for the block loop: a Jovian all-deposit block drives processOpBlock end-to-end
+// (system call → deposit txs → finalize) with a real Storage2State-backed applyDiff write-back.
+// Guards the loop's deposit branch (runDeposit + write-back + cumulative-gas formatting + seal
+// inputs) — the admission-reject cases above never reach it.
+BOOST_AUTO_TEST_CASE(DepositOnlyBlockExecutesEndToEnd)
+{
+    Fixture f;
+    std::vector<bcos::evm::opstack::OpBlockTx> txs;
+    auto dep = makeNormalJovianDeposit();
+    bcos::evm::opstack::OpBlockTx depTx;
+    depTx.tx = dep;
+    txs.push_back(depTx);
+    bcos::evm::opstack::OpBlockTx depTx2;
+    depTx2.tx = makeNormalJovianDeposit();
+    txs.push_back(depTx2);
+
+    auto blk = f.makeBlockInfo();
+    ZeroBlockHashes hashes{};
+    bcos::evm::evmstate::Storage2State<MutableStorage> view(f.storage, nullptr);
+    auto result = bcos::evm::opstack::processOpBlock(view, blk, hashes, txs, f.fork, f.vm,
+        /*chainId=*/10, f.receiptFactory,
+        [&view](const evmone::state::StateDiff& diff) { view.applyDiff(diff); });
+    // Two deposits executed: receipts with non-zero gas, cumulative gas monotonic, no
+    // double-spend / crash.
+    BOOST_REQUIRE_EQUAL(result.receipts.size(), 2u);
+    BOOST_REQUIRE_EQUAL(result.txTypes.size(), 2u);
+    BOOST_CHECK(result.txTypes[0] == static_cast<uint8_t>(bcos::evm::opstack::kDepositTxType));
+    BOOST_CHECK_GT(result.gasUsed, 0);
+    BOOST_CHECK_GE(result.receipts[1]->gasUsed(), result.receipts[0]->gasUsed());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpReceiptEncodeTest.cpp
+++ b/opstack-executor/tests/OpReceiptEncodeTest.cpp
@@ -1,0 +1,246 @@
+#include "OpTestReceiptFactory.h"
+#include "TestPrinters.h"
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <opstack-executor/OpBlockExecute.h>  // encodeReceiptForRoot (seal merged here)
+#include <boost/test/unit_test.hpp>
+#include <bcos-evm/eth/state/bloom_filter.hpp>
+#include <sstream>
+#include <test/utils/rlp.hpp>
+#include <test/utils/rlp_encode.hpp>
+
+using namespace bcos::evm::opstack;
+using namespace bcos::evm::opstack::testutil;
+using namespace evmc::literals;
+
+namespace
+{
+/// A deposit receipt projected onto the FISCO receipt: cumulative "0x5208" (21000), 256-zero
+/// bloom, deposit_nonce/version in opStackMeta. `status` is the FISCO status (0 = success).
+bcos::protocol::TransactionReceipt::Ptr minimalDepositReceipt(int32_t status = 0)
+{
+    auto r = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, status, bcos::bytesConstRef{}, /*blockNumber=*/1);
+    r->setCumulativeGasUsed("0x5208");
+    bcos::bytes bloom(256, 0x00);
+    r->setLogsBloom(bcos::ref(bloom));
+    bcos::protocol::OpStackReceiptMeta meta;
+    meta.deposit_nonce = 5;
+    meta.deposit_receipt_version = 1;
+    r->setOpStackMeta(std::move(meta));
+    return r;
+}
+
+/// encodeReceiptForRoot returns bcos::bytes; the assertions below compare against evmc::bytes
+/// fixtures (operator==, .find), so convert once at the call boundary.
+evmc::bytes encodeReceiptEvmc(const bcos::protocol::TransactionReceipt& r, uint8_t txType)
+{
+    const auto encoded = encodeReceiptForRoot(r, txType);
+    return {encoded.begin(), encoded.end()};
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpReceiptEncodeSuite)
+
+// Hand-derived golden fixture byte-by-byte (assertion-numerics discipline: derivation is
+// the anchor; final byte authority belongs to M-B3 differential). RLP list items:
+// status success -> 0x01 (1B); cumGas 21000=0x5208 -> 0x82 52 08 (3B); bloom 256 zero
+// bytes -> 0xb9 0x0100 + 00x256 (259B); logs [] -> 0xc0 (1B); nonce 5 -> 0x05 (1B);
+// version 1 -> 0x01 (1B). Payload = 1+3+259+1+1+1 = 266 = 0x010a -> list header 0xf9 01 0a
+// (3B). Prefix 0x7e. Total 1+3+266 = 270.
+BOOST_AUTO_TEST_CASE(DepositGoldenBytes)
+{
+    const auto enc =
+        encodeReceiptEvmc(*minimalDepositReceipt(), static_cast<uint8_t>(kDepositTxType));
+    evmc::bytes expected{0x7e, 0xf9, 0x01, 0x0a, 0x01, 0x82, 0x52, 0x08, 0xb9, 0x01, 0x00};
+    expected += evmc::bytes(256, 0x00);
+    expected += evmc::bytes{0xc0, 0x05, 0x01};
+    BOOST_REQUIRE_EQUAL(enc.size(), 270u);
+    BOOST_CHECK_EQUAL(enc, expected);
+}
+
+// Failed deposit: status item = empty string 0x80 (op-geth statusEncoding failure branch).
+// rev.2 correction: 0x80 and the success 0x01 are both 1 byte (RLP single-byte
+// optimization yields 0x80 for the empty string, no content); payload stays 266 = 0x010a
+// and total stays 270 — only byte 5 changes 0x01 -> 0x80.
+BOOST_AUTO_TEST_CASE(FailedDepositStatusIsEmptyString)
+{
+    auto dep = minimalDepositReceipt(/*status=*/1);  // FISCO non-zero = failed
+    const auto enc = encodeReceiptEvmc(*dep, static_cast<uint8_t>(kDepositTxType));
+    evmc::bytes expected{0x7e, 0xf9, 0x01, 0x0a, 0x80, 0x82, 0x52, 0x08, 0xb9, 0x01, 0x00};
+    expected += evmc::bytes(256, 0x00);
+    expected += evmc::bytes{0xc0, 0x05, 0x01};
+    BOOST_REQUIRE_EQUAL(enc.size(), 270u);
+    BOOST_CHECK_EQUAL(enc, expected);
+}
+
+// Deposit with logs: the logs segment (incl. the vector-list wrapper) is compared as a
+// whole against evmone's independent encoding; the tail 2 bytes are {nonce, version}.
+// Total-length anchor (rev.2 red-team hardening, closing the wrapper-loss blind spot):
+// the empty-logs version totals 270, where the logs item is 1 byte (0xc0) -> total =
+// 269 + |rlp(logs)| (bloom encoding length is content-independent, always 259; nonce 7
+// and 5 are both 1 byte).
+BOOST_AUTO_TEST_CASE(DepositWithLogEmbedsEncodedLogsAndNonceTail)
+{
+    constexpr auto kAddr = 0x00000000000000000000000000000000000000aa_address;
+    evmone::state::Log evmoneLog{
+        .addr = kAddr, .data = evmc::bytes{0x68, 0x69}, .topics = {0x01_bytes32}};
+
+    // Project the log onto a FISCO LogEntry (raw bytes, same mapping mapOpLogs uses).
+    evmc::bytes32 topicVal = 0x01_bytes32;
+    std::vector<bcos::protocol::LogEntry> logs;
+    logs.emplace_back(bcos::bytes(kAddr.bytes, kAddr.bytes + sizeof(kAddr.bytes)),
+        bcos::h256s{bcos::h256(topicVal.bytes, sizeof(topicVal.bytes))}, bcos::bytes{0x68, 0x69});
+    auto dep = kOpTestReceiptFactory->createReceipt(
+        bcos::u256(21000), std::string{}, logs, /*status=*/0, bcos::bytesConstRef{}, 1);
+    dep->setCumulativeGasUsed("0x5208");
+    const auto bloomF =
+        evmone::state::compute_bloom_filter(std::span<const evmone::state::Log>{&evmoneLog, 1});
+    bcos::bytes bloom(bloomF.bytes, bloomF.bytes + sizeof(bloomF.bytes));
+    dep->setLogsBloom(bcos::ref(bloom));
+    bcos::protocol::OpStackReceiptMeta meta;
+    meta.deposit_nonce = 7;
+    meta.deposit_receipt_version = 1;
+    dep->setOpStackMeta(std::move(meta));
+
+    const auto enc = encodeReceiptEvmc(*dep, static_cast<uint8_t>(kDepositTxType));
+    BOOST_CHECK_EQUAL(enc[0], 0x7e);
+    // evmone's vector<Log> list encoding (independent path) must appear whole — covers the list
+    // wrapper bytes
+    const auto logsBytes = evmone::rlp::encode(std::vector<evmone::state::Log>{evmoneLog});
+    BOOST_CHECK_NE(enc.find(logsBytes), evmc::bytes::npos);
+    BOOST_REQUIRE_EQUAL(enc.size(), 269u + logsBytes.size());
+    BOOST_CHECK_EQUAL(enc[enc.size() - 2], 0x07);  // nonce
+    BOOST_CHECK_EQUAL(enc[enc.size() - 1], 0x01);  // version
+}
+
+// Normal tx: byte-for-byte equivalent to evmone rlp_encode (incl. the typed prefix) —
+// rebuilt from a FISCO receipt and must match evmone's encoding of the same-shaped
+// evmone receipt.
+BOOST_AUTO_TEST_CASE(NormalReceiptMatchesEvmoneEncoding)
+{
+    // evmone reference: eip1559, success, cumGas 42000, empty logs, zero bloom.
+    evmone::state::TransactionReceipt ref;
+    ref.type = evmone::state::Transaction::Type::eip1559;
+    ref.status = EVMC_SUCCESS;
+    ref.cumulative_gas_used = 42000;
+    const auto expected = evmone::state::rlp_encode(ref);
+
+    auto r = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/1);
+    r->setCumulativeGasUsed("0xa410");  // 42000
+    bcos::bytes bloom(256, 0x00);
+    r->setLogsBloom(bcos::ref(bloom));
+    const auto enc =
+        encodeReceiptEvmc(*r, static_cast<uint8_t>(evmone::state::Transaction::Type::eip1559));
+
+    BOOST_CHECK_EQUAL(enc[0], 0x02);  // eip1559 typed prefix
+    BOOST_CHECK_EQUAL(enc, evmc::bytes(expected.begin(), expected.end()));
+}
+
+// legacy (no typed prefix) + access_list prefixes are also byte-identical to evmone
+BOOST_AUTO_TEST_CASE(NormalReceiptLegacyAndAccessListPrefixes)
+{
+    const auto makeFisco = [](uint64_t cumGas) {
+        auto r = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+            std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{}, 1);
+        std::ostringstream oss;
+        oss << "0x" << std::hex << cumGas;
+        r->setCumulativeGasUsed(oss.str());
+        bcos::bytes bloom(256, 0x00);
+        r->setLogsBloom(bcos::ref(bloom));
+        return r;
+    };
+    const auto compareToEvmone = [](const auto& fisco, evmone::state::Transaction::Type type) {
+        evmone::state::TransactionReceipt ref;
+        ref.type = type;
+        ref.status = EVMC_SUCCESS;
+        ref.cumulative_gas_used = 42000;
+        const auto expected = evmone::state::rlp_encode(ref);
+        const auto enc = encodeReceiptEvmc(*fisco, static_cast<uint8_t>(type));
+        BOOST_CHECK_EQUAL(enc, evmc::bytes(expected.begin(), expected.end()));
+    };
+
+    auto legacy = makeFisco(42000);
+    compareToEvmone(legacy, evmone::state::Transaction::Type::legacy);
+    auto accessList = makeFisco(42000);
+    compareToEvmone(accessList, evmone::state::Transaction::Type::access_list);
+}
+
+// Deposit and normal txs must produce different leaves (prefix and tail fields both differ)
+BOOST_AUTO_TEST_CASE(DepositAndNormalLeavesDiffer)
+{
+    const auto depEnc =
+        encodeReceiptEvmc(*minimalDepositReceipt(), static_cast<uint8_t>(kDepositTxType));
+    auto normal = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{}, 1);
+    normal->setCumulativeGasUsed("0x5208");
+    bcos::bytes bloom(256, 0x00);
+    normal->setLogsBloom(bcos::ref(bloom));
+    const auto normalEnc =
+        encodeReceiptEvmc(*normal, static_cast<uint8_t>(evmone::state::Transaction::Type::eip1559));
+    BOOST_CHECK_NE(depEnc, normalEnc);
+}
+
+// End-to-end receiptsRoot equivalence (leaf-level proof): building
+// the root from FISCO receipts via sealOpBlock must be bit-identical to building it from
+// equivalent evmone receipts via evmone rlp_encode. Of sealOpBlock's three subtrees, only
+// the receiptsRoot leaf encoding is reconstructed here (trie construction unchanged), so
+// this case + NormalReceiptMatchesEvmoneEncoding together pin the receiptsRoot byte
+// equivalence.
+BOOST_AUTO_TEST_CASE(SealReceiptsRootMatchesEvmoneReferenceTrie)
+{
+    // FISCO receipt #0: deposit (status 0, cumGas 21000, nonce 5, version 1).
+    auto dep = minimalDepositReceipt();
+    // FISCO receipt #1: eip1559 (status 0, cumGas 42000).
+    auto normal = kOpTestReceiptFactory->createReceipt(bcos::u256(21000), std::string{},
+        std::vector<bcos::protocol::LogEntry>{}, /*status=*/0, bcos::bytesConstRef{}, 1);
+    normal->setCumulativeGasUsed("0xa410");  // 42000
+    bcos::bytes bloom(256, 0x00);
+    normal->setLogsBloom(bcos::ref(bloom));
+
+    bcos::evm::opstack::OpBlockResult result;
+    result.receipts.push_back(dep);
+    result.receipts.push_back(normal);
+    result.txTypes.push_back(static_cast<uint8_t>(kDepositTxType));
+    result.txTypes.push_back(static_cast<uint8_t>(evmone::state::Transaction::Type::eip1559));
+
+    const auto seal =
+        bcos::evm::opstack::sealOpBlock(result, bcos::evm::opstack::isthmusConfig(), {});
+
+    // Reference: equivalent evmone receipts, same leaves via evmone rlp_encode, same trie.
+    evmone::state::TransactionReceipt refDep;
+    refDep.type = kDepositTxType;
+    refDep.status = EVMC_SUCCESS;
+    refDep.cumulative_gas_used = 21000;
+    refDep.logs_bloom_filter = evmone::state::BloomFilter{};
+    const auto depLeaf = evmc::bytes{0x7e} + evmone::rlp::encode_tuple(bool{true}, uint64_t{21000},
+                                                 evmone::bytes_view(refDep.logs_bloom_filter),
+                                                 refDep.logs, uint64_t{5}, uint64_t{1});
+
+    evmone::state::TransactionReceipt refNormal;
+    refNormal.type = evmone::state::Transaction::Type::eip1559;
+    refNormal.status = EVMC_SUCCESS;
+    refNormal.cumulative_gas_used = 42000;
+    refNormal.logs_bloom_filter = evmone::state::BloomFilter{};
+    const auto normalLeaf = evmone::state::rlp_encode(refNormal);
+
+    std::vector<std::pair<bcos::bytes, bcos::bytes>> refEntries;
+    for (size_t i = 0; i < 2; ++i)
+    {
+        bcos::bytes key;
+        bcos::codec::rlp::encode(key, static_cast<uint64_t>(i));
+        const auto& leaf = (i == 0) ? depLeaf : normalLeaf;
+        refEntries.emplace_back(std::move(key), bcos::bytes{leaf.begin(), leaf.end()});
+    }
+    const auto refRoot = bcos::ledger::mpt::computeTrieRootVarKey(refEntries);
+
+    bcos::h256 actual(seal.receiptsRoot.bytes, sizeof(seal.receiptsRoot.bytes));
+    bcos::h256 expected;
+    std::memcpy(expected.mutableData().data(), refRoot.root.data(), sizeof(expected));
+    BOOST_CHECK_EQUAL(actual, expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/OpTestReceiptFactory.h
+++ b/opstack-executor/tests/OpTestReceiptFactory.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// OpTestReceiptFactory — test-side receipt factory. opTransition and
+// runDeposit now inject a bcos::protocol::TransactionReceiptFactory::Ptr (they produce FISCO
+// receipts directly); the tests build the real bcostars implementation over a Keccak256 suite,
+// the same construction bcos-tars-protocol's own TransactionReceiptImplTest uses.
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
+#include <bcos-framework/protocol/TransactionReceiptFactory.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+
+namespace bcos::evm::opstack::testutil
+{
+/// One shared receipt factory for the whole suite (cheap: the factory is stateless beyond the
+/// crypto suite; the receipt objects it creates are independent).
+inline bcos::protocol::TransactionReceiptFactory::Ptr makeOpTestReceiptFactory()
+{
+    auto suite =
+        std::make_shared<bcos::crypto::CryptoSuite>(std::make_shared<bcos::crypto::Keccak256>(),
+            std::make_shared<bcos::crypto::Secp256k1Crypto>(), nullptr);
+    return std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(suite);
+}
+
+/// intx::uint256 → bcos::u256, full-width big-endian conversion (same pattern as the production
+/// helper in OpTransition.cpp; duplicated here so tests can compare opStackMeta fields against
+/// the intx values the fee code computes).
+inline bcos::u256 bcosU256FromIntx(intx::uint256 const& val)
+{
+    auto be = intx::be::store<evmc::uint256be>(val);
+    return bcos::fromBigEndian<bcos::u256>(
+        bcos::bytesConstRef{reinterpret_cast<bcos::byte const*>(be.bytes), sizeof(be.bytes)});
+}
+
+/// One shared factory instance across test TUs (inline variable: one per program, stateless).
+inline const bcos::protocol::TransactionReceiptFactory::Ptr kOpTestReceiptFactory =
+    makeOpTestReceiptFactory();
+}  // namespace bcos::evm::opstack::testutil

--- a/opstack-executor/tests/OpTxConvertTest.cpp
+++ b/opstack-executor/tests/OpTxConvertTest.cpp
@@ -41,6 +41,7 @@ public:
     bcos::bytes m_extraBytes;
 
     uint8_t web3TypedTxKind() const override { return m_kind; }
+    std::optional<uint64_t> web3ChainIdFromEnvelope() const override { return std::nullopt; }
     bcos::bytesConstRef input() const override
     {
         return bcos::bytesConstRef{m_input.data(), m_input.size()};

--- a/opstack-executor/tests/OpstackExecutorTest.cpp
+++ b/opstack-executor/tests/OpstackExecutorTest.cpp
@@ -1,0 +1,1078 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// OpstackExecutorTest.cpp — drives OpstackExecutor over BCOS storage. opTransition/runDeposit
+// produce the final FISCO receipt directly (OP metadata + effective gas price already projected),
+// and the state diff is returned via an out-param. Storage is a plain MutableStorage.
+
+// BOOST_TEST_MODULE lives in TestMain.cpp (the single main for the whole suite).
+#include <boost/test/unit_test.hpp>
+
+#include "bcos-evm/opstack/OpForkSchedule.h"
+#include "bcos-evm/opstack/OpPredeploys.h"
+#include "opstack-executor/OpBlockExecute.h"  // finalizeOpBlock (block-level finalize free fn)
+#include "opstack-executor/OpstackExecutor.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>  // construct a 33-byte-mint envelope for the over-wide test
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/interfaces/crypto/CryptoSuite.h>
+#include <bcos-framework/ledger/EVMAccount.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-tars-protocol/protocol/TransactionReceiptFactoryImpl.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <evmc/evmc.h>
+#include <evmc/evmc.hpp>
+#include <memory>
+
+using namespace bcos;
+using namespace bcos::executor_v1::opstack;
+using namespace evmc::literals;  // _address / _bytes32
+
+namespace
+{
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+
+using MutableStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+
+bcos::crypto::CryptoSuite::Ptr makeCryptoSuite()
+{
+    return std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+}
+
+// Block execution (call=false) builds BlockInfo on the strict path (OpCommon.h
+// requireHeaderField): baseFee / parentBeaconBlockRoot / blobGasUsed must be present even on a
+// minimal test header. Zero values are enough.
+void setRequiredHeaderFields(bcostars::protocol::BlockHeaderImpl& h)
+{
+    h.setBaseFee(bcos::u256(0));
+    h.setParentBeaconBlockRoot(bcos::h256{});
+    h.setBlobGasUsed(bcos::u256(0));
+}
+
+struct Fixture
+{
+    std::shared_ptr<crypto::CryptoSuite> cryptoSuite = std::make_shared<crypto::CryptoSuite>(
+        std::make_shared<crypto::Keccak256>(), nullptr, nullptr);
+    bcos::protocol::TransactionReceiptFactory::Ptr receiptFactory{
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(cryptoSuite)};
+    MutableStorage storage;
+    ledger::LedgerConfig ledgerConfig;
+
+    // Wired block-hashes source for the call=false execute paths: a null one is now a hard
+    // error (RecentBlockHashes guard on executeTransaction/executeDeposit), so every block-path
+    // call site passes a real source. This zero-answering source preserves the old silent
+    // BLOCKHASH-reads-zero semantics while satisfying the fail-loud guard.
+    NullBlockHashes hashes;
+
+    const bcos::evm::opstack::OpForkConfig& fork = bcos::evm::opstack::jovianConfig();
+
+    Fixture()
+    {
+        ledgerConfig.setEVMCRevision(fork.rev);
+        ledgerConfig.setGasLimit({30000000, 0});
+        ledgerConfig.setGasPrice({"0x0", 0});
+    }
+
+    bcostars::protocol::TransactionImpl buildWeb3Tx(uint64_t chainId = 10,
+        bcos::Address to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7"))
+    {
+        // Construct a minimal EIP-2930 Web3 tx directly (nonce=7, gasPrice, gasLimit, to, value,
+        // empty data/accessList, yParity=0, 32-byte r/s) — the v1 raw-RLP fixture no longer
+        // decodes under the v2 Web3Transaction path, so build fields instead of RLP. chainId
+        // defaults to 10 to match every executeTransaction call site below, so the fixture
+        // envelope must carry the same chain id the call passes.
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::EIP2930;
+        w3.chainId = chainId;
+        w3.nonce = 7;
+        w3.maxFeePerGas = bcos::u256(30000000000);  // gasPrice (EIP-2930)
+        w3.maxPriorityFeePerGas = w3.maxFeePerGas;
+        w3.gasLimit = 5000000;
+        w3.to = to;
+        w3.value = bcos::u256(2000000000000000000);  // 2 ETH
+        w3.signatureV = 0;                           // yParity
+        w3.signatureR = bcos::bytes(32, 0x01);       // dummy r/s (unused: evmone skips sig verify)
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        auto const txHash = w3.txHash();
+        tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+        // takeToTarsTransaction stores the signing preimage (Web3Transaction.cpp:220-223);
+        // overwrite with the full EIP-2718 envelope (mirroring EngineServiceImpl buildOpBlock) so
+        // the envelope is canonical wire bytes.
+        auto const envelope = w3.encode();
+        tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    // Legacy UNPROTECTED tx (type=Legacy, pre-EIP-155: NO chainId, v=27/28) — drives the chainId
+    // EXEMPTION branch of m_prepare's envelope check. A genuine pre-EIP-155 tx has chainId=nullopt
+    // (not 0 — chainId=0 is EIP-155 *protected* and would encode v=35/36, not 27/28) and yParity
+    // signatureV=0 (→ v=27 in the signed envelope). The signed envelope is 6-field (no chainId
+    // tail), so web3ChainIdFromEnvelope returns nullopt → exempt.
+    bcostars::protocol::TransactionImpl buildLegacyWeb3Tx()
+    {
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::Legacy;
+        w3.chainId = std::nullopt;  // pre-EIP-155 unprotected — no chainId concept
+        w3.nonce = 7;
+        w3.maxFeePerGas = bcos::u256(30000000000);  // gasPrice (legacy single-price)
+        w3.maxPriorityFeePerGas = w3.maxFeePerGas;
+        w3.gasLimit = 5000000;
+        w3.to = bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7");
+        w3.value = bcos::u256(2000000000000000000);
+        w3.signatureV = 0;  // yParity 0 → v = 27 (pre-EIP-155)
+        w3.signatureR = bcos::bytes(32, 0x01);
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        auto const txHash = w3.txHash();
+        tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+        auto const envelope = w3.encode();
+        tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    // Deposit tx mirror for single-tx deposit dispatch. isSystemTx mirrors the
+    // deposit RLP field (tars field 15), NOT Transaction::systemTx().
+    bcostars::protocol::TransactionImpl buildDepositTx(bool isSystemTx = false)
+    {
+        bcos::rpc::Web3Transaction w3{};
+        w3.type = bcos::rpc::TransactionType::Deposit;
+        w3.sourceHash =
+            bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        w3.from = bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001");
+        w3.to = bcos::Address("0x4200000000000000000000000000000000000015");
+        w3.mint = bcos::u256(5);
+        w3.value = bcos::u256(0);
+        w3.gasLimit = 100000;
+        w3.isSystemTx = isSystemTx;
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        return bcostars::protocol::TransactionImpl([tarsHolder]() { return tarsHolder.get(); });
+    }
+
+    template <class T>
+    static T sync(task::Task<T> t)
+    {
+        return task::syncWait(std::move(t));
+    }
+};
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(OpstackExecutorTestSuite)
+
+BOOST_AUTO_TEST_CASE(ConstructsWithJovianFork)
+{
+    auto rf =
+        std::make_shared<bcostars::protocol::TransactionReceiptFactoryImpl>(makeCryptoSuite());
+    OpstackExecutor executor(rf, makeCryptoSuite()->hashImpl());
+    BOOST_CHECK_NE(&executor.vm(), nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(BuildOpBlockInfoMirrorsBlockPath)
+{
+    // buildBlockInfo must mirror toBlockInfo's field mapping (OpCommon.h:106-121) so eth_call
+    // sees the same block context as block execution: seconds timestamp, header baseFee (via
+    // value_or(0), so optional-less test headers do not throw), and the full field set.
+    auto h = std::make_shared<bcostars::protocol::BlockHeaderImpl>();
+    h->setNumber(7);
+    h->setTimestamp(1'234'567'890);  // ms; block path divides by 1000
+    h->setCoinbase(bcos::Address{"0x00000000000000000000000000000000000000aa"});
+    h->setBaseFee(bcos::u256(1'000'000'000));
+    h->setPrevRandao(
+        bcos::h256{"0xab00000000000000000000000000000000000000000000000000000000000000"});
+    h->setParentBeaconBlockRoot(
+        bcos::h256{"0xcd00000000000000000000000000000000000000000000000000000000000000"});
+    h->setExtraData(bcos::bytes{0xde, 0xad});
+    h->setBlobGasUsed(bcos::u256(0x1234));
+
+    const auto blk = bcos::executor_v1::opstack::OpstackExecutor::buildBlockInfo(*h, 30'000'000);
+    BOOST_CHECK_EQUAL(blk.number, 7);
+    BOOST_CHECK_EQUAL(blk.timestamp, 1'234'567ULL);  // ms -> s
+    BOOST_CHECK_EQUAL(blk.gas_limit, 30'000'000);    // injected gasLimit
+    // intx::uint256 / evmc::bytes / optional<uint64_t> have no operator<< — use plain BOOST_CHECK
+    // (same predicate as EXPECT_EQ, just without value printing on failure).
+    BOOST_CHECK(blk.base_fee == intx::uint256(1'000'000'000));  // header baseFee, NOT 0
+    BOOST_CHECK_EQUAL(blk.prev_randao.bytes[0], 0xab);          // full field set
+    BOOST_CHECK_EQUAL(blk.parent_beacon_block_root.bytes[0], 0xcd);
+    BOOST_CHECK(blk.extra_data == (evmc::bytes{0xde, 0xad}));
+    BOOST_CHECK(blk.blob_gas_used == 0x1234ULL);
+}
+
+BOOST_FIXTURE_TEST_CASE(ExecutesNormalTransferEndToEnd, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        // EIP-3607: evmone validate_transaction rejects a sender whose code_hash !=
+        // EMPTY_CODE_HASH. Seed the canonical empty-code hash so the sender is recognised as an
+        // EOA.
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10, /*blockHashes=*/&hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    // FISCO internal convention: 0 = success (the Ethereum RPC 0<->1 flip happens later).
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    BOOST_CHECK_GE(receipt->gasUsed(), 21000u);
+    BOOST_CHECK_EQUAL(receipt->blockNumber(), 1);
+    BOOST_CHECK(receipt->opStackMeta().has_value());
+}
+
+BOOST_FIXTURE_TEST_CASE(RejectsForkRevisionMismatch, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    ledgerConfig.setEVMCRevision(EVMC_FRONTIER);  // deliberately != fork.rev
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    auto tx = buildWeb3Tx();
+    bcos::evm::opstack::OpFeeParams fee{};
+    BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(storage, blockHeader, tx, 0,
+                          ledgerConfig, false, fee, 30000000, 10, &hashes)),
+        bcos::executor_v1::opstack::OpForkRevisionMismatch);
+}
+
+BOOST_FIXTURE_TEST_CASE(RejectsInvalidTx, Fixture)
+{
+    // Balance 0 sender + value transfer -> validation failure; executeTransaction reclassifies
+    // OpTxValidationFailed to OpConsensusError (INVALID) at the boundary (OpstackExecutor.h
+    // error-normalization contract).
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    // No account created -> balance 0 -> validation fails.
+    bcos::evm::opstack::OpFeeParams fee{};
+    BOOST_CHECK_THROW(task::syncWait(executor.executeTransaction(storage, blockHeader, tx, 0,
+                          ledgerConfig, false, fee, 30000000, 10, &hashes)),
+        bcos::evm::engine::OpConsensusError);
+}
+
+BOOST_FIXTURE_TEST_CASE(ChargesL1AndOperatorFees, Fixture)
+{
+    // Non-zero L1 + operator fee params route through opValidate (pre-charge) -> opTransition
+    // (deriveOpReceiptMeta) and surface in the receipt's opStackMeta.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    fee.l1_base_fee = 1000;
+    fee.base_fee_scalar = 7;
+    fee.blob_base_fee = 2000;
+    fee.blob_base_fee_scalar = 9;
+    fee.operator_fee_scalar = 11;
+    fee.operator_fee_constant = 13;
+
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10, /*blockHashes=*/&hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    // Jovian derives these unconditionally.
+    BOOST_CHECK(meta->l1_fee.has_value());
+    BOOST_CHECK(meta->l1_gas_price.has_value());
+    // operator_fee_scalar filled when has_operator_fee && (scalar != 0 || constant != 0).
+    BOOST_CHECK(meta->operator_fee_scalar.has_value());
+    BOOST_CHECK_EQUAL(*meta->operator_fee_scalar, 11u);
+}
+
+BOOST_FIXTURE_TEST_CASE(ReceiptMetaSurvives, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+
+    auto tx = buildWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    fee.l1_base_fee = 1000;
+    fee.base_fee_scalar = 7;
+
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10, /*blockHashes=*/&hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->l1_gas_price.has_value());
+    BOOST_CHECK(*meta->l1_gas_price == bcos::u256(1000));
+    // v2 deriveOpReceiptMeta derives l1_base_fee_scalar from props.fee (not l1_gas_used, which the
+    // v2 implementation no longer fills); the fee below set base_fee_scalar=7.
+    BOOST_REQUIRE(meta->l1_base_fee_scalar.has_value());
+    BOOST_CHECK_EQUAL(*meta->l1_base_fee_scalar, 7u);
+    // effective_gas_price = base_fee(0) + min(maxPriority, maxFee-0); for this EIP-2930 tx
+    // BCOS2Evmone.h maps max_gas_price = max_priority_gas_price = gasPrice, so effective =
+    // gasPrice = 0x6fc23ac00.
+    BOOST_CHECK_EQUAL(receipt->effectiveGasPrice(), "0x6fc23ac00");
+}
+
+// ---- executeDeposit + finalizeBlock (reuse bcos-evm/opstack runDeposit / finalizeOpBlock) ----
+
+BOOST_FIXTURE_TEST_CASE(ExecutesDepositMint, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto kFrom = 0x000000000000000000000000000000000000dead_address;
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x01_bytes32,
+        .from = kFrom,
+        .to = std::nullopt,  // contract creation
+        .mint = intx::uint256{5},
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, kFrom, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    NullBlockHashes hashes;  // explicit source — a null one on call=false is itself a hard error
+    auto receipt = task::syncWait(executor.executeDeposit(storage, blockHeader, dep,
+        /*chainId=*/10, /*blockGasLeft=*/30000000, ledgerConfig, /*call=*/false, &hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    // mint(5) added to the from balance.
+    ledger::account::EVMAccount<MutableStorage> acc(storage, kFrom, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+    // deposit_nonce == 0, version == 1 (Canyon+).
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->deposit_nonce.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_nonce, 0u);
+    BOOST_REQUIRE(meta->deposit_receipt_version.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_receipt_version, 1u);
+}
+
+BOOST_FIXTURE_TEST_CASE(ExecutesDepositThroughExecuteTransaction, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    constexpr auto from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    // fee default {} — deposit must ignore it (no L1/operator fee). Explicit hashes source:
+    // a null one on call=false is itself a hard error (RecentBlockHashes guard).
+    NullBlockHashes hashes;
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, /*fee=*/{}, /*blockGasLeft=*/30000000,
+        /*chainId=*/10, /*blockHashes=*/&hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    // mint(5) added to from balance (distinguishes deposit from a normal-path run, which mints
+    // nothing).
+    ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+
+    // deposit_nonce == 0, version == 1 (Canyon+).
+    auto meta = receipt->opStackMeta();
+    BOOST_REQUIRE(meta.has_value());
+    BOOST_REQUIRE(meta->deposit_nonce.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_nonce, 0u);
+    BOOST_REQUIRE(meta->deposit_receipt_version.has_value());
+    BOOST_CHECK_EQUAL(*meta->deposit_receipt_version, 1u);
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositLifecycleThroughExecuteContext, Fixture)
+{
+    // Concept lifecycle (createExecuteContext -> prepare -> execute -> finish) on a deposit tx:
+    // the deposit branch must short-circuit opValidate and run executeDeposit, and finish() must
+    // decrement ctx.blockGasLeft + backfill the receipt's cumulativeGasUsed.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    constexpr auto from = 0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+
+    constexpr int64_t kInitialGasLeft = 30000000;
+    OpBlockExecutionContext ctx{};
+    ctx.blockGasLeft = kInitialGasLeft;
+    ctx.chainId = 10;
+    // Block-path execute() fails loud without a block-hashes source (the silent
+    // NullBlockHashes-degradation guard) — wire a real RecentBlockHashes over the fixture
+    // storage (lazy: the deposit never issues BLOCKHASH, so no rows are needed).
+    std::optional<std::string> hashErr;
+    bcos::evm::engine::detail::RecentBlockHashes<MutableStorage> blockHashes(
+        storage, 1, evmc::bytes32{}, &hashErr);
+    ctx.blockHashes = &blockHashes;
+
+    auto context = task::syncWait(executor.createExecuteContext(
+        storage, blockHeader, tx, /*contextID=*/0, ledgerConfig, /*call=*/false, ctx));
+    task::syncWait(context.prepare());
+    task::syncWait(context.execute());
+    auto receipt = task::syncWait(context.finish());
+
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+    // mint(5) applied to the from balance (distinguishes the deposit path from a no-op).
+    ledger::account::EVMAccount<MutableStorage> acc(storage, from, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 5u);
+    // blockGasLeft decremented by the deposit's gasUsed; cumulative gas backfilled on the receipt.
+    auto const gasUsed = bcos::evm::opstack::narrowGasUsed(receipt->gasUsed());
+    BOOST_CHECK_LT(ctx.blockGasLeft, kInitialGasLeft);
+    BOOST_CHECK_EQUAL(ctx.blockGasLeft, kInitialGasLeft - gasUsed);
+    BOOST_CHECK(ctx.cumulativeGasUsed == gasUsed);
+    BOOST_CHECK_EQUAL(
+        std::string(receipt->cumulativeGasUsed()), bcos::evm::opstack::hexCumulative(gasUsed));
+}
+
+// 6-arg createExecuteContext (generic scheduler / concept form) has no BlockContext: the old
+// default-arg footgun left m_ctx pointing at a destroyed temporary. It must now build a null-ctx
+// context whose prepare() throws a clear OpConsensusError instead of UB.
+BOOST_FIXTURE_TEST_CASE(NullContextSixArgFormThrows, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildDepositTx();
+    auto context = task::syncWait(executor.createExecuteContext(
+        storage, blockHeader, tx, /*contextID=*/0, ledgerConfig, /*call=*/false));
+    BOOST_CHECK_THROW(task::syncWait(context.prepare()), bcos::evm::engine::OpConsensusError);
+    BOOST_CHECK_THROW(task::syncWait(context.execute()), bcos::evm::engine::OpConsensusError);
+    BOOST_CHECK_THROW(task::syncWait(context.finish()), bcos::evm::engine::OpConsensusError);
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositGasLimitReachedIsBlockError, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);  // strict path needs these; keep the gas-limit throw as
+                                           // the assertion target
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x02_bytes32,
+        .from = 0x000000000000000000000000000000000000dead_address,
+        .to = 0x0000000000000000000000000000000000000001_address,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    // gas_limit(100000) > blockGasLeft(100): runDeposit's bare rejection is reclassified to
+    // OpConsensusError on the block path (OpBlockExecute.h contract). Pass an explicit hashes
+    // source — a null one on call=false is itself a hard error (RecentBlockHashes guard).
+    NullBlockHashes hashes;
+    BOOST_CHECK_THROW(
+        task::syncWait(executor.executeDeposit(storage, blockHeader, dep,
+            /*chainId=*/10, /*blockGasLeft=*/100, ledgerConfig, /*call=*/false, &hashes)),
+        bcos::evm::engine::OpConsensusError);
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositBlockPathRejectsMissingHeaderFields, Fixture)
+{
+    // Symmetry regression: block-path deposits (call=false, the default) follow the same strict
+    // header contract as normal txs — a header missing baseFee/parentBeaconBlockRoot/blobGasUsed
+    // is INVALID (OpConsensusError), not silently zeroed. Only eth_call (call=true) is lenient.
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);  // deliberately no setRequiredHeaderFields
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x03_bytes32,
+        .from = 0x000000000000000000000000000000000000dead_address,
+        .to = 0x0000000000000000000000000000000000000001_address,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    NullBlockHashes hashes;  // pass explicitly — a null source on call=false
+                             // is itself a hard error (RecentBlockHashes guard)
+    BOOST_CHECK_THROW(
+        task::syncWait(executor.executeDeposit(storage, blockHeader, dep,
+            /*chainId=*/10, /*blockGasLeft=*/30000000, ledgerConfig, /*call=*/false, &hashes)),
+        bcos::evm::engine::OpConsensusError);
+    // eth_call path stays lenient: same header, call=true -> executes with zeroed optionals.
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(
+            storage, 0x000000000000000000000000000000000000dead_address, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+    auto receipt = task::syncWait(executor.executeDeposit(storage, blockHeader, dep,
+        /*chainId=*/10, /*blockGasLeft=*/30000000, ledgerConfig, /*call=*/true));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+}
+
+// Direct anchor for the RecentBlockHashes fail-loud guard (executeDeposit + executeTransaction):
+// a null blockHashes source on call=false is itself a hard error, and the message pins the
+// guard (a regression deleting the guard, or moving the throw, turns this red).
+BOOST_FIXTURE_TEST_CASE(BlockHashesGuardFailsLoud, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    // executeDeposit: call=false + nullptr blockHashes -> OpConsensusError with the guard text.
+    bcos::evm::opstack::DepositTx dep{
+        .source_hash = 0x04_bytes32,
+        .from = 0x000000000000000000000000000000000000dead_address,
+        .to = 0x0000000000000000000000000000000000000001_address,
+        .mint = std::nullopt,
+        .value = intx::uint256{0},
+        .gas_limit = 100000,
+        .is_system_tx = false,
+        .data = {},
+    };
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(executor.executeDeposit(storage, blockHeader, dep, /*chainId=*/10,
+            /*blockGasLeft=*/30000000, ledgerConfig, /*call=*/false, /*blockHashes=*/nullptr)),
+        bcos::evm::engine::OpConsensusError, [](auto const& e) {
+            // Intentional string-pin: the OpConsensusError message is part of the
+            // contract with callers; rewording the message is a breaking change.
+            return std::string(e.what()).find("wired RecentBlockHashes") != std::string::npos;
+        });
+
+    // executeTransaction: same guard on the normal-tx entry.
+    auto tx = buildWeb3Tx();
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(executor.executeTransaction(storage, blockHeader, tx, /*contextID=*/0,
+            ledgerConfig, /*call=*/false, bcos::evm::opstack::OpFeeParams{},
+            /*blockGasLeft=*/30000000, /*chainId=*/10, /*blockHashes=*/nullptr)),
+        bcos::evm::engine::OpConsensusError, [](auto const& e) {
+            // Intentional string-pin: the OpConsensusError message is part of the
+            // contract with callers; rewording the message is a breaking change.
+            return std::string(e.what()).find("wired RecentBlockHashes") != std::string::npos;
+        });
+
+    // call=true (eth_call) stays exempt: a null source simulates without a block context.
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(
+            storage, 0x000000000000000000000000000000000000dead_address, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(0));
+        co_await acc.setNonce("0");
+        co_return;
+    }());
+    auto receipt = task::syncWait(executor.executeDeposit(storage, blockHeader, dep,
+        /*chainId=*/10, /*blockGasLeft=*/30000000, ledgerConfig, /*call=*/true));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+}
+
+BOOST_FIXTURE_TEST_CASE(FinalizeOpBlockNoReward, Fixture)
+{
+    // OP has no block reward: finalizeOpBlock (evmone state finalize + StateDiff sanitize) must
+    // leave the coinbase balance untouched. Drives the OpBlockExecute.h free function.
+    constexpr auto kCoinbase = 0x1111111111111111111111111111111111111111_address;
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, kCoinbase, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256(100));
+        co_return;
+    }());
+
+    bcos::evm::evmstate::Storage2State<MutableStorage> view(storage, {});
+    auto diff = bcos::evm::opstack::finalizeOpBlock(view, fork, kCoinbase);
+    view.applyDiff(std::move(diff));
+
+    ledger::account::EVMAccount<MutableStorage> acc(storage, kCoinbase, false);
+    auto bal = task::syncWait(acc.balance());
+    BOOST_CHECK(bal == 100u);
+}
+
+BOOST_FIXTURE_TEST_CASE(BlockInfoGasLimitUsesHeaderGasLimit, Fixture)
+{
+    // buildBlockInfo's gasLimit takes header.gasLimit (not blockGasLeft). Behavior assertion:
+    // executing a minimal GASLIMIT-reading contract, slot0 must store == header.gasLimit().
+    // Before the fix: executeTransaction's BlockInfo.gasLimit = blockGasLeft (injected value), so
+    // the contract stored blockGasLeft; injecting blockGasLeft(250000) < header.gasLimit(1000000)
+    // went red. After the fix: BlockInfo.gasLimit = header.gasLimit == 1000000 → green.
+    // blockGasLeft must be ≥ tx.gasLimit(200000) (else state.cpp:390 GAS_LIMIT_REACHED rejects at
+    // validation and the test is permanently red) AND < header.gasLimit(1000000) to expose the
+    // fork.
+    constexpr auto kObserver = 0x00000000000000000000000000000000000000aa_address;
+    constexpr auto kSender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    const bcos::bytes kObserverCode{0x45, 0x60, 0x00, 0x55, 0x00};  // GASLIMIT; PUSH1 0; SSTORE;
+                                                                    // STOP
+
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.setGasLimit(bcos::u256(1000000));  // exercises the header-gasLimit path
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+    ledgerConfig.setEVMCRevision(fork.rev);
+
+    // Deploy the GASLIMIT observer contract + fund the sender (mirror the fundAccount pattern).
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> obs(storage, kObserver, false);
+        co_await obs.create();
+        co_await obs.setCode(kObserverCode, "", cryptoSuite->hashImpl()->hash(kObserverCode));
+        co_await obs.setBalance(bcos::u256(0));
+        co_await obs.setNonce("0");
+        ledger::account::EVMAccount<MutableStorage> snd(storage, kSender, false);
+        co_await snd.create();
+        co_await snd.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        co_await snd.setBalance(u256("100000000000000000000"));
+        co_await snd.setNonce("0");
+        co_return;
+    }());
+
+    // EIP-1559 tx calling the observer with empty data, value 0. chainId=10 matches the
+    // executeTransaction call below.
+    bcos::rpc::Web3Transaction w3{};
+    w3.type = bcos::rpc::TransactionType::EIP1559;
+    w3.chainId = 10;
+    w3.nonce = 0;
+    w3.maxFeePerGas = bcos::u256(30000000000);
+    w3.maxPriorityFeePerGas = bcos::u256(0);
+    w3.gasLimit = 200000;
+    w3.to = bcos::Address("0x00000000000000000000000000000000000000aa");
+    w3.value = bcos::u256(0);
+    w3.signatureV = 0;
+    w3.signatureR = bcos::bytes(32, 0x01);
+    w3.signatureS = bcos::bytes(32, 0x02);
+    auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+    auto const txHash = w3.txHash();
+    tarsHolder->extraTransactionHash.assign(txHash.begin(), txHash.end());
+    // Overwrite the signing preimage with the full EIP-2718 envelope.
+    auto const envelope = w3.encode();
+    tarsHolder->extraTransactionBytes.assign(envelope.begin(), envelope.end());
+    bcostars::protocol::TransactionImpl tx([tarsHolder]() { return tarsHolder.get(); });
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(kSender.bytes, kSender.bytes + sizeof(kSender.bytes)));
+
+    bcos::evm::opstack::OpFeeParams fee{};
+    // Inject blockGasLeft=250000 < header.gasLimit=1000000 (≥ tx.gasLimit 200000 passes
+    // validation, < header exposes the GASLIMIT fork) — the key to exposing the fork.
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/250000,
+        /*chainId=*/10, /*blockHashes=*/&hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+    BOOST_CHECK_EQUAL(receipt->status(), 0);
+
+    // Read observer slot0: must == header.gasLimit (1000000), not the injected blockGasLeft.
+    // The storage key is raw 32 bytes (evmc_bytes32{}=32 0x00 bytes); neither
+    // storageEntry("0") nor a hex string reads it. EVMAccount::storage() returns an evmc_bytes32
+    // value (all-zero when unset), not an optional — parse slot.bytes with intx::be::load
+    // (32-byte big-endian), not storageEntry's has_value()/operator->.
+    ledger::account::EVMAccount<MutableStorage> obs(storage, kObserver, false);
+    auto slot = task::syncWait(obs.storage(evmc_bytes32{}));  // EVMAccount.h:210
+    BOOST_CHECK(intx::be::load<intx::uint256>(slot.bytes) == intx::uint256(1000000));
+}
+
+BOOST_FIXTURE_TEST_CASE(DepositIsSystemTransactionGetter, Fixture)
+{
+    auto tx = buildDepositTx(/*isSystemTx=*/true);
+    BOOST_CHECK(tx.isDepositTx());                 // web3TypedTxKind == 0x7e
+    BOOST_CHECK(tx.depositIsSystemTransaction());  // tars field 15 == 1
+
+    auto tx2 = buildDepositTx(/*isSystemTx=*/false);
+    BOOST_CHECK(tx2.isDepositTx());
+    BOOST_CHECK(!tx2.depositIsSystemTransaction());  // tars field 15 == 0
+}
+
+/// Consensus deposit fields MUST come from the signed 0x7E envelope
+/// (decodeDepositEnvelope), never from the unauthenticated tars mirrors. Happy path decodes a
+/// legit buildDepositTx envelope; rejection paths cover a non-0x7e type byte and trailing bytes.
+BOOST_AUTO_TEST_CASE(DecodeDepositEnvelopeFromSignedEnvelope)
+{
+    Fixture f;
+    auto tx = f.buildDepositTx(/*isSystemTx=*/false);
+    auto env = tx.extraTransactionBytes();
+    BOOST_REQUIRE(!env.empty());
+    BOOST_CHECK_EQUAL(env[0], 0x7e);
+
+    auto dep = decodeDepositEnvelope(env);
+    // sourceHash matches the builder's fixed h256.
+    bcos::crypto::HashType sh("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    BOOST_CHECK(std::equal(
+        dep.source_hash.bytes, dep.source_hash.bytes + sizeof(dep.source_hash.bytes), sh.begin()));
+    // from == the builder's dead...0001 address.
+    BOOST_CHECK_EQUAL(bcos::toHexStringWithPrefix(
+                          bcos::bytes(dep.from.bytes, dep.from.bytes + sizeof(dep.from.bytes))),
+        "0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001");
+    BOOST_REQUIRE(dep.to.has_value());
+    BOOST_CHECK_EQUAL(bcos::toHexStringWithPrefix(
+                          bcos::bytes(dep.to->bytes, dep.to->bytes + sizeof(dep.to->bytes))),
+        "0x4200000000000000000000000000000000000015");
+    BOOST_REQUIRE(dep.mint.has_value());
+    BOOST_CHECK(dep.mint.value() == intx::uint256{5});  // intx::uint256 has no ostream<<
+    BOOST_CHECK(dep.value == intx::uint256{0});
+    BOOST_CHECK_EQUAL(dep.gas_limit, 100000);
+    BOOST_CHECK(!dep.is_system_tx);
+    BOOST_CHECK(dep.data.empty());
+
+    // Rejection: a non-0x7e type byte (the 0x02-envelope + 0x7e-mirror attack) must fail loud.
+    bcos::bytes bad(env.begin(), env.end());
+    bad[0] = 0x02;
+    BOOST_CHECK_THROW(
+        [&]() { (void)decodeDepositEnvelope(bcos::ref(bad)); }(), OpTxValidationFailed);
+
+    // Rejection: trailing bytes after the RLP list must be refused (strict, consensus-grade).
+    bcos::bytes trailing(env.begin(), env.end());
+    trailing.push_back(0x00);
+    BOOST_CHECK_THROW(
+        [&]() { (void)decodeDepositEnvelope(bcos::ref(trailing)); }(), OpTxValidationFailed);
+
+    // Rejection: an over-wide integer (33-byte mint) must fail loud —
+    // rlp::decode(UnsignedIntegral) alone would truncate to the low 32 bytes via fromBigEndian.
+    {
+        bcos::bytes body;
+        bcos::codec::rlp::encode(
+            body, bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"));
+        bcos::codec::rlp::encode(body, bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"));
+        bcos::codec::rlp::encode(body, bcos::Address("0x4200000000000000000000000000000000000015"));
+        bcos::codec::rlp::encode(body, bcos::bytes(33, 0xff));  // 33-byte mint -> over-wide
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // value = 0 (empty RLP item)
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // gas = 0
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // isSystemTx = 0
+        bcos::codec::rlp::encode(body, bcos::bytes{});          // data = empty
+        bcos::bytes list;
+        bcos::codec::rlp::encodeHeader(list, bcos::codec::rlp::Header{true, body.size()});
+        list.insert(list.end(), body.begin(), body.end());
+        bcos::bytes overWideEnv{0x7e};
+        overWideEnv.insert(overWideEnv.end(), list.begin(), list.end());
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(overWideEnv)); }(), OpTxValidationFailed);
+    }
+
+    // Rejection: non-canonical integers / int64 range / bool — the width
+    // gate does not cover these, and rlp::decode only rejects one non-canonical form (single-byte
+    // payload < 0x80 via decodeHeader). Build an envelope from raw per-field items so we can feed
+    // encodings RLPEncode would never emit. Field order: sourceHash, from, to, mint, value, gas,
+    // isSystemTx, data.
+    auto canonicalItems = []() {
+        bcos::bytes sh, from, to, mint, value, gas, isSystem, data;
+        bcos::codec::rlp::encode(
+            sh, bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"));
+        bcos::codec::rlp::encode(from, bcos::Address("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001"));
+        bcos::codec::rlp::encode(to, bcos::Address("0x4200000000000000000000000000000000000015"));
+        bcos::codec::rlp::encode(mint, bcos::bytes{5});                // mint = 5 (bare Byte)
+        bcos::codec::rlp::encode(value, bcos::bytes{});                // value = 0 (empty item)
+        bcos::codec::rlp::encode(gas, bcos::bytes{0x01, 0x86, 0xa0});  // gas = 100000
+        bcos::codec::rlp::encode(isSystem, bcos::bytes{});             // isSystemTx = false
+        bcos::codec::rlp::encode(data, bcos::bytes{});                 // data = empty
+        return std::vector<bcos::bytes>{sh, from, to, mint, value, gas, isSystem, data};
+    };
+    auto envelopeFromItems = [](std::vector<bcos::bytes> const& items) {
+        bcos::bytes body;
+        for (auto const& it : items)
+            body.insert(body.end(), it.begin(), it.end());
+        bcos::bytes list;
+        bcos::codec::rlp::encodeHeader(list, bcos::codec::rlp::Header{true, body.size()});
+        list.insert(list.end(), body.begin(), body.end());  // header + payload (the over-wide
+                                                            // block above spells this inline)
+        bcos::bytes env{0x7e};
+        env.insert(env.end(), list.begin(), list.end());
+        return env;
+    };
+
+    // (a) leading-zero multi-byte integer (value = 0x82 0x00 0x05): would fold to 5, but op-geth
+    // rejects it as ErrCanonInt.
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x82, 0x00, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (b) single Byte 0x00 (value): integer zero must be the empty item 0x80 — op-geth ErrCanonInt.
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x00};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (c) gas = uint64 max (0x88 FF..FF): static_cast<int64_t>(gas) would wrap to -1; the decoder
+    // rejects values that exceed int64 range.
+    {
+        auto items = canonicalItems();
+        items[5] = bcos::bytes{0x88, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};  // gas
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (d) isSystemTx = bare Byte 2: != 0 would read true, but op-geth decodeBool accepts only the
+    // empty item (false) and 0x01 (true).
+    {
+        auto items = canonicalItems();
+        items[6] = bcos::bytes{0x02};  // isSystemTx
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (e) non-canonical short string (value = 0x81 0x05): a single-byte payload < 0x80 must be a
+    // bare Byte, not a short string — op-geth ErrCanonInt. This is the integerPayloadLength
+    // `pl==1 && ref[1] < 0x80` arm (decodeHeader's NonCanonicalSize is a second, consistent path).
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0x81, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (f) RLP list as integer (value = 0xc1 0x05): integerPayloadLength returns nullopt for any
+    // list header — a list is never a well-formed integer (op-geth Stream rejects it).
+    {
+        auto items = canonicalItems();
+        items[4] = bcos::bytes{0xc1, 0x05};  // value
+        BOOST_CHECK_THROW(
+            [&]() { (void)decodeDepositEnvelope(bcos::ref(envelopeFromItems(items))); }(),
+            OpTxValidationFailed);
+    }
+    // (g) isSystemTx = bare Byte 1: end-to-end happy path for the true arm (op-geth decodeBool
+    // 0x01 → true) — the builder's isSystemTx=false default never exercises it.
+    {
+        auto items = canonicalItems();
+        items[6] = bcos::bytes{0x01};  // isSystemTx
+        auto dep = decodeDepositEnvelope(bcos::ref(envelopeFromItems(items)));
+        BOOST_CHECK(dep.is_system_tx);
+    }
+}
+
+// chainId-mismatch enforcement: op-geth
+// EIP155Signer/modernSigner reject txs whose chainId differs from the node's (ErrInvalidChainId).
+// Cases (1)(2) need no sender funding: the check runs before opValidate's gates.
+BOOST_FIXTURE_TEST_CASE(ChainIdMismatchEnforced, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);  // strict toBlockInfo path must pass before the gate
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+
+    // (1) protected tx chainId(9) != node chainId(10) -> OpConsensusError. The message pin
+    // distinguishes the chainId gate from an earlier guard (missing header field / blockHashes):
+    // a wrong-source throw fails loudly instead of passing for the wrong reason.
+    {
+        auto tx = buildWeb3Tx(/*chainId=*/9);
+        tx.clearSenderAndHash();
+        tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+        BOOST_CHECK_EXCEPTION(task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+                                  /*contextID=*/0, ledgerConfig, /*call=*/false, fee,
+                                  /*blockGasLeft=*/30000000, /*chainId=*/10,
+                                  /*blockHashes=*/&hashes)),
+            bcos::evm::engine::OpConsensusError, [](auto const& e) {
+                // Intentional string-pin: anchored to the OpConsensusError message
+                // in OpBlockExecute.cpp (chain_id mismatch check).
+                return std::string(e.what()).find("chain_id") != std::string::npos;
+            });
+    }
+    // (2) typed tx chain_id==0 is NOT exempt (modernSigner rejects 0 != node chainId; a
+    // malicious proposer can craft a 0x02 envelope with chain_id 0). Pinned so a future
+    // "chain_id==0 means unprotected" regression fails.
+    {
+        auto tx = buildWeb3Tx(/*chainId=*/0);
+        tx.clearSenderAndHash();
+        tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+        BOOST_CHECK_EXCEPTION(task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+                                  /*contextID=*/0, ledgerConfig, /*call=*/false, fee,
+                                  /*blockGasLeft=*/30000000, /*chainId=*/10,
+                                  /*blockHashes=*/&hashes)),
+            bcos::evm::engine::OpConsensusError, [](auto const& e) {
+                // Intentional string-pin: anchored to the OpConsensusError message
+                // in OpBlockExecute.cpp (chain_id mismatch check).
+                return std::string(e.what()).find("chain_id") != std::string::npos;
+            });
+    }
+}
+
+// legacy v=27/28 unprotected (pre-EIP-155, no chainId in the envelope) IS exempt: no chainId
+// concept, accepted regardless of the node chainId. Runs the FULL path (funded sender) to prove
+// it executes rather than being caught and reclassified.
+BOOST_FIXTURE_TEST_CASE(LegacyUnprotectedChainIdExempt, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    auto tx = buildLegacyWeb3Tx();
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10, /*blockHashes=*/&hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);       // chainId exempt: executes instead of throwing
+    BOOST_CHECK_EQUAL(receipt->status(), 0);  // and succeeds — not reverted-but-accepted
+}
+
+// A transfer to a c_systemTxsAddress (0x...1000)
+// must credit /apps/<1000> — the table the read side and the state root use — not /sys/<1000>.
+// Read back via the same Storage2State /apps/ path the root uses.
+BOOST_FIXTURE_TEST_CASE(TransferToSystemAddressCreditsAppsBalance, Fixture)
+{
+    OpstackExecutor executor{receiptFactory, cryptoSuite->hashImpl(), fork};
+    bcostars::protocol::BlockHeaderImpl blockHeader;
+    blockHeader.setNumber(1);
+    setRequiredHeaderFields(blockHeader);
+    blockHeader.calculateHash(*cryptoSuite->hashImpl());
+
+    constexpr auto sysAddr = 0x0000000000000000000000000000000000001000_address;  // SYS_CONFIG
+    auto tx =
+        buildWeb3Tx(/*chainId=*/10, bcos::Address("0x0000000000000000000000000000000000001000"));
+    constexpr auto sender = 0xe0e794ca86d198042b64285c5ce667aee747509b_address;
+    tx.clearSenderAndHash();
+    tx.forceSender(bcos::bytes(sender.bytes, sender.bytes + sizeof(sender.bytes)));
+
+    task::syncWait([&]() -> task::Task<void> {
+        ledger::account::EVMAccount<MutableStorage> acc(storage, sender, false);
+        co_await acc.create();
+        co_await acc.setBalance(u256("100000000000000000000"));
+        co_await acc.setCode({}, "",
+            bcos::crypto::HashType(
+                "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"));
+        std::string nonceStr(tx.nonce());
+        if (nonceStr.empty())
+            nonceStr = "0";
+        co_await acc.setNonce(nonceStr);
+        co_return;
+    }());
+
+    bcos::evm::opstack::OpFeeParams fee{};  // zero fee
+    auto receipt = task::syncWait(executor.executeTransaction(storage, blockHeader, tx,
+        /*contextID=*/0, ledgerConfig, /*call=*/false, fee, /*blockGasLeft=*/30000000,
+        /*chainId=*/10, /*blockHashes=*/&hashes));
+    BOOST_REQUIRE_NE(receipt, nullptr);
+
+    // The state root reads /apps/ (accountTableName); the credit must be visible there.
+    bcos::evm::evmstate::Storage2State<MutableStorage> view(storage, {});
+    auto acc = view.get_account(sysAddr);
+    BOOST_REQUIRE(acc.has_value());
+    BOOST_CHECK(acc->balance == intx::uint256(2000000000000000000));  // the 2 ETH transfer value
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/SmokeCompileTest.cpp
+++ b/opstack-executor/tests/SmokeCompileTest.cpp
@@ -1,9 +1,10 @@
 // FISCO BCOS
 // SPDX-License-Identifier: Apache-2.0
 
-// SmokeCompileTest — opstack-executor is a pure INTERFACE (header-only) library whose templates
-// compile ONLY at instantiation. This TU includes every public header and EXPLICITLY
-// INSTANTIATES the template surface, so a base-API break fails this build immediately.
+// SmokeCompileTest — opstack-executor's template surface compiles ONLY at instantiation. This TU
+// includes every public header and EXPLICITLY INSTANTIATES the template surface, so a base-API
+// break fails this build immediately. (The library itself is a compiled static library —
+// the non-template OpBlockExecute.cpp is built by the library target, not here.)
 
 #include <opstack-executor/OpBlockExecute.h>
 #include <opstack-executor/OpCommitments.h>
@@ -45,7 +46,7 @@ bcos::executor_v1::opstack::OpstackExecutor::executeTransaction<MutableStorage>(
 template bcos::task::Task<bcos::protocol::TransactionReceipt::Ptr>
 bcos::executor_v1::opstack::OpstackExecutor::executeDeposit<MutableStorage>(MutableStorage&,
     bcos::protocol::BlockHeader const&, bcos::evm::opstack::DepositTx const&, uint64_t, int64_t,
-    bcos::ledger::LedgerConfig const&, evmone::state::BlockHashes const*);
+    bcos::ledger::LedgerConfig const&, bool, evmone::state::BlockHashes const*);
 
 // The block-pre template from OpBlockExecute.h.
 template void bcos::evm::engine::preBlockOpSteps<MutableStorage, std::vector<bcos::bytes>>(

--- a/opstack-executor/tests/StateDiffWriteback.h
+++ b/opstack-executor/tests/StateDiffWriteback.h
@@ -1,0 +1,45 @@
+// Test-only strict StateDiff write-back helper (moved out of bcos-evm/adapter/: all callers
+// are tests, so it does not belong in the production adapter surface).
+#pragma once
+
+#include <evmc/hex.hpp>
+#include <bcos-evm/eth/state/state_diff.hpp>
+// TODO(eth-utils-removal): TestState(eth/utils) -> in-house in-memory ledger; the
+// applyStateDiff/applyStateDiffStrict signatures and the three write-back contracts below
+// (delete / clear slot / conditional overwrite) are preserved unchanged.
+#include <test/utils/test_state.hpp>
+#include <stdexcept>
+
+namespace bcos::evm
+{
+/// v1 write-back seam: apply an evmone StateDiff to the in-memory TestState.
+/// Contract (a real-ledger write-back implementation must satisfy this; the block-level
+/// seam-contract test suite that exercises it is out of this PR's tx-level scope):
+///   1) deleted_accounts must be deleted (not always empty after Cancun: EIP-6780 same-tx
+///      selfdestruct and EIP-161 empty-account erasure both produce deletion entries; the
+///      "always empty" comment in state_diff.hpp is outdated);
+///   2) a modified_storage value of 0 means erase the slot, not store zero;
+///   3) code is overwritten only when has_value().
+/// For a diff sanitized at its production site (see StateDiffSanitize.h), the deleted_accounts
+/// entries are guaranteed to exist in the view.
+inline void applyStateDiff(evmone::test::TestState& state, const evmone::state::StateDiff& diff)
+{
+    state.apply(diff);
+}
+
+/// Consumer-side tripwire: delete-of-nonexistent is precisely the ghost signature
+/// (in the test context the write-back target ≡ view and is applied synchronously; the EIP-6780
+/// class is already stripped at the production site, and cross-tx duplicate deletes are stripped
+/// by the post-prior-tx view sanitize — zero false positives). Any future exit that misses
+/// sanitizing turns the write-back-type tests red immediately, without relying on corpus coverage.
+/// Tests that verify the raw, un-sanitized behavior continue to use the raw applyStateDiff.
+inline void applyStateDiffStrict(
+    evmone::test::TestState& state, const evmone::state::StateDiff& diff)
+{
+    for (const auto& addr : diff.deleted_accounts)
+        if (state.find(addr) == state.end())
+            throw std::runtime_error(
+                "ghost delete reached writeback: " + evmc::hex(evmc::bytes_view(addr)));
+    applyStateDiff(state, diff);
+}
+}  // namespace bcos::evm

--- a/opstack-executor/tests/TestPrinters.h
+++ b/opstack-executor/tests/TestPrinters.h
@@ -1,0 +1,80 @@
+#pragma once
+
+// Boost.Test print_log_value specializations for the types the opstack suites compare with
+// BOOST_CHECK_EQUAL et al. — keeps the rich failure output (both operands printed) that a
+// predicate-form BOOST_CHECK(a == b) would lose. Boost requires operator<< (or this
+// customization point) for every printed operand; gtest printed these via its universal
+// fallback, so the port needs the explicit forms.
+
+#include <boost/test/unit_test.hpp>
+
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-evm/eth/state/transaction.hpp>
+#include <evmc/evmc.hpp>
+#include <evmc/hex.hpp>
+#include <intx/intx.hpp>
+#include <ostream>
+#include <system_error>
+
+namespace boost::test_tools::tt_detail
+{
+template <>
+struct print_log_value<intx::uint256>
+{
+    void operator()(std::ostream& ostr, const intx::uint256& value)
+    {
+        ostr << intx::to_string(value);
+    }
+};
+
+template <>
+struct print_log_value<evmc::address>
+{
+    void operator()(std::ostream& ostr, const evmc::address& value)
+    {
+        ostr << evmc::hex({value.bytes, sizeof(value.bytes)});
+    }
+};
+
+template <>
+struct print_log_value<evmc::bytes32>
+{
+    void operator()(std::ostream& ostr, const evmc::bytes32& value)
+    {
+        ostr << evmc::hex({value.bytes, sizeof(value.bytes)});
+    }
+};
+
+template <>
+struct print_log_value<evmc::bytes>
+{
+    void operator()(std::ostream& ostr, const evmc::bytes& value)
+    {
+        ostr << evmc::hex({value.data(), value.size()});
+    }
+};
+
+template <>
+struct print_log_value<bcos::evm::opstack::OpFork>
+{
+    void operator()(std::ostream& ostr, bcos::evm::opstack::OpFork value)
+    {
+        ostr << static_cast<int>(value);
+    }
+};
+
+template <>
+struct print_log_value<evmone::state::Transaction::Type>
+{
+    void operator()(std::ostream& ostr, evmone::state::Transaction::Type value)
+    {
+        ostr << static_cast<int>(value);
+    }
+};
+
+template <>
+struct print_log_value<std::errc>
+{
+    void operator()(std::ostream& ostr, std::errc value) { ostr << static_cast<int>(value); }
+};
+}  // namespace boost::test_tools::tt_detail


### PR DESCRIPTION
## Summary

Part **4b of 5** — the second half of part 4, split out of #5463 for reviewability. Carries the **P2P/mempool admission gates, the OP block execution engine, and the JSON quantity serialization fixes**. All content is the final reviewed state of #5463 at head `09d44a966` (8 review rounds of fixes preserved verbatim); the tree is byte-identical to that head modulo two clang-format fixes in test files and the gate-limit edit documented below.

> **Stacks on**: part 4a (#5463, web3 tx model + RPC decode funnel). This branch contains 4a's commits underneath, so until #5463 merges the diff below shows both halves — **review only the files listed in this description**; after #5463 merges, GitHub re-targets this PR and the diff collapses to the 26 files listed here.
>
> **Depends on**: part 3 (#5460, merged) — opstack-executor module + scheduler core.

## What's in this part (26 files)

**Transaction verification & admission**
- `Transaction.cpp` (framework) — `verify()` hardening: EIP-2 low-s / r-range / yParity rungs and the 65-byte signature gate (fail-closed, runs *before* `recoverAddress`; deposits never legitimately reach `verify()`)
- `TxValidator.cpp` (txpool) — web3 admission: reserved-type byte gate (only `0x01..0x04` typed + `>=0x80` legacy pass), `0x7e` deposit rejection before verify, envelope-sourced chainId validation (typed envelope with nullopt chainId = reject)
- `MemoryStorageTest.cpp` / `TransactionValidatorTest.cpp` — admission tests incl. killer tests for the reserved-type gate and verify() rungs

**OP block execution engine**
- `OpBlockExecute.cpp/.h` — block execution loop: deposit replay, gas accounting with pre-decrement asserts, Jovian activation shape check (last-tx-only, op-geth `CalcDAFootprint` parity), RLP log-list encoding with hoisted buffers
- `OpstackExecutor.h` — engine-context conversions (`toEvmoneTransaction` gas-limit guard, cumulative-gas hex receipt fields), fork/revision exception pass-through
- `OpCommon.h`, `Storage2State.h` — shared helpers
- 9 test files incl. `OpstackExecutorTest.cpp` (1078 lines), `OpBlockProcessTest.cpp`, `OpReceiptEncodeTest.cpp`

**Engine payload carrier & serialization**
- `engine/Types.h` — `ExecutionPayload::rawTransactions` OP-mode carrier field (unread by the generic engine path)
- `EngineHelper.cpp` + `EngineHelperTest.cpp` — NewPayload request parsing populates both carriers with identical bytes
- `LedgerMethods.cpp` — `loadChainConfig` uses the shared `parseWeb3ChainId` (corrupted config falls back to 0 instead of throwing)
- `JsonRpcImpl_2_0.cpp` + `Web3EthMethodsTest.cpp` — eth_* JSON quantity serialization compliance (hex `value`/`gasPrice`/fee fields) with rewritten schema-anchored endpoint tests

## Behavior changes

Same set as documented on #5463 (items 5–9 there): pool-level rejection of high-s / deposit / wrong-chainId / reserved-type P2P transactions. Mixed-version networks see pool divergence only — no chain split; the same transactions still execute in other nodes' blocks.

## Commit gate

`tools/.ci/check-commit.sh` limit comes back down **1450 → 1000** (edited in part 4a's branch, inherited here): this part measures **418** valid insertions (886 insertions − 1×20 new-file − 247 comment − 39 empty − 132 block − 30 include); part 4a measures **980**. Both halves of the former part 4 fit a 1000 budget.

## Verification

- Tree identity: `git diff 09d44a966 opstack-s04b` = two test-file clang-format fixes + the gate-limit edit only.
- Test suites green at the identical tree (`test-bcos-txpool`, `opstack-executor-tests`, full `test-bcos-rpc`), per the #5463 round-8 head runs.

## Review history

All 8 review rounds and their fixes are documented on #5463 (round 7 full review, model-scope, exec-scope, misc-scope, round 8). This PR carries the exec-scope + misc-scope + admission subset of those fixes; the model-scope subset stays on #5463.

Split from #5429 | Base: release-3.18.0 | Part 4b/5 (stacks on #5463 = part 4a/5)
