### PR TITLE
feat(rpc): add Web3 tx envelope, handler, and chainId wiring

### DIFF
--- a/bcos-codec/bcos-codec/rlp/RLPDecode.h
+++ b/bcos-codec/bcos-codec/rlp/RLPDecode.h
@@ -25,6 +25,7 @@
 #include <bcos-utilities/DataConvertUtility.h>
 #include <algorithm>
 #include <cstring>
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -228,6 +229,14 @@ inline bcos::Error::UniquePtr decode(bytesRef& from, UnsignedIntegral auto& to) 
     if (header.isList)
     {
         return BCOS_ERROR_UNIQUE_PTR(DecodingError::UnexpectedList, "Unexpected list");
+    }
+    // Reject integers wider than the target type instead of silently truncating via fromBigEndian
+    // (op-geth parity). Use digits/8, NOT sizeof(T): boost u256 has sizeof 48 but 32 payload bytes.
+    constexpr auto maxBytes = std::numeric_limits<std::decay_t<decltype(to)>>::digits / 8;
+    if (header.payloadLength > maxBytes)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(DecodingError::UnexpectedLength,
+            "integer wider than target type");
     }
     to = fromBigEndian<std::decay_t<decltype(to)>, bcos::bytesRef>(
         from.getCroppedData(0, header.payloadLength));

--- a/bcos-codec/test/unittests/RLPTest.cpp
+++ b/bcos-codec/test/unittests/RLPTest.cpp
@@ -72,6 +72,9 @@ static T decode(std::string_view hex, int32_t expectedErrorCode = 0)
     }
     else
     {
+        // A regression where decode fails but error is null would be a null deref below — assert
+        // the error exists first so the failure is readable, not a UB crash.
+        BOOST_REQUIRE(error);
         BOOST_CHECK_EQUAL(error->errorCode(), expectedErrorCode);
     }
     return result;
@@ -91,6 +94,7 @@ static std::tuple<T, T2> decode(std::string_view hex, int32_t expectedErrorCode 
     }
     else
     {
+        BOOST_REQUIRE(error);
         BOOST_CHECK_EQUAL(error->errorCode(), expectedErrorCode);
     }
     return {std::move(r1), std::move(r2)};
@@ -247,7 +251,10 @@ BOOST_AUTO_TEST_CASE(uintDecode)
     decode<uint64_t>("C0", UnexpectedList);
     decode<uint64_t>("8105", NonCanonicalSize);
     decode<uint64_t>("B8020004", NonCanonicalSize);
-    decode<uint64_t>("8AFFFFFFFFFFFFFFFFFF7C", Overflow);
+    // 10-byte payload into uint64: the width gate rejects it (UnexpectedLength). Note the old
+    // "Overflow" expectation was a silent no-op — DecodingError::Overflow == 0, so the helper
+    // treated it as "expect success" and the wide value was silently truncated.
+    decode<uint64_t>("8AFFFFFFFFFFFFFFFFFF7C", UnexpectedLength);
 }
 
 BOOST_AUTO_TEST_CASE(uint256Decode)
@@ -273,8 +280,9 @@ BOOST_AUTO_TEST_CASE(uint256Decode)
     decode<u256>("C0"sv, UnexpectedList);
     decode<u256>("8105"sv, NonCanonicalSize);
     decode<u256>("B8020004"sv, NonCanonicalSize);
+    // 33-byte payload into u256: rejected by the width gate (was silently truncated before).
     decode<u256>(
-        "A101000000000000000000000000000000000000008B000000000000000000000000"sv, Overflow);
+        "A101000000000000000000000000000000000000008B000000000000000000000000"sv, UnexpectedLength);
 }
 
 BOOST_AUTO_TEST_CASE(vectorsDecode)

--- a/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.h
+++ b/bcos-crypto/bcos-crypto/signature/secp256k1/Secp256k1Crypto.h
@@ -30,6 +30,14 @@ constexpr int SECP256K1_SIGNATURE_LEN = 65;
 constexpr int SECP256K1_UNCOMPRESS_PUBLICKEY_LEN = 65;
 constexpr int SECP256K1_PUBLICKEY_LEN = 64;
 constexpr int SECP256K1_SIGNATURE_V = 64;
+
+// secp256k1 group order n and n/2 (boost-u256 form) — single home for the EIP-2 low-s gates
+// (RPC decode in Web3Transaction.cpp; the P2P verify gate in Transaction.cpp lands with part
+// 4b, PR #5477) so the two thresholds cannot drift apart.
+inline const u256 c_secp256k1n(
+    "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
+inline const u256 c_secp256k1nOver2 = c_secp256k1n / 2;
+
 std::shared_ptr<bytes> secp256k1Sign(const KeyPairInterface& _keyPair, const HashType& _hash);
 bool secp256k1Verify(const PublicPtr& _pubKey, const HashType& _hash, bytesConstRef _signatureData);
 std::unique_ptr<KeyPairInterface> secp256k1GenerateKeyPair();

--- a/bcos-framework/bcos-framework/protocol/Transaction.h
+++ b/bcos-framework/bcos-framework/protocol/Transaction.h
@@ -29,6 +29,8 @@
 #include <concepts>
 #include <functional>
 #include <iosfwd>
+#include <optional>
+#include <string_view>
 #include <utility>
 
 namespace bcostars::protocol
@@ -91,6 +93,15 @@ public:
     /// EIP-2718 typed tx kind when type()==Web3Transaction (see bcos::rpc::TransactionType). 0 if
     /// unset.
     virtual uint8_t web3TypedTxKind() const { return 0; }
+    /// Chain id from the SIGNED envelope (extraTransactionBytes), never the tars mirror
+    /// (data.chainID): typed = RLP field 0 of the preimage; legacy = EIP-155 tail (nullopt =
+    /// pre-EIP-155 unprotected, v=27/28). Default nullopt keeps the framework core free of
+    /// RLP/codec and preserves source compatibility for out-of-tree implementers; the force is
+    /// semantic, not structural — Web3-capable impls override (TransactionImpl does). The
+    /// envelope-keyed gates (TxValidator::validateChainId, OpstackExecutor::m_prepare)
+    /// rejecting a typed envelope that yields nullopt land with part 4b (PR #5477); in this
+    /// tree EthEndpoint's mempool gate is the enforcer.
+    virtual std::optional<uint64_t> web3ChainIdFromEnvelope() const { return std::nullopt; }
     /// deposit-only (0x7e) tx metadata (OP Stack). Empty/false when not a deposit.
     virtual std::string_view sourceHash() const { return {}; }
     virtual u256 mint() const { return {}; }

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxEnvelope.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxEnvelope.cpp
@@ -1,0 +1,140 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Web3TxEnvelope.cpp
+ * @brief Signed-envelope walkers for Web3 transactions
+ * @date 2026/8/21
+ */
+#include "Web3TxEnvelope.h"
+
+#include <bcos-codec/rlp/RLPDecode.h>
+
+namespace bcos::rlp::protocol
+{
+std::optional<uint64_t> web3ChainIdFromEnvelope(bcos::bytesConstRef payload)
+{
+    if (payload.empty()) [[unlikely]]
+    {
+        return std::nullopt;
+    }
+    auto const firstByte = payload[0];
+    // decode() requires a mutable bytesRef cursor even for read-only parsing; the cast is safe
+    // because this function never writes through the cursor — only reads via decodeHeader/decode.
+    bcos::bytesRef cursor(const_cast<bcos::byte*>(payload.data()), payload.size());
+    // 0x7E (Deposit) has no chainId field — field 0 is sourceHash (h256). A naive typed-tx
+    // decode would fail the uint64_t width gate on sourceHash and return nullopt, which is
+    // misleading (nullopt is documented as "pre-EIP-155 unprotected legacy"). Return early
+    // so callers that gate on nullopt+isTyped see a clean signal.
+    if (firstByte == 0x7E) [[unlikely]]
+    {
+        return std::nullopt;
+    }
+    if (firstByte > 0 && firstByte < bcos::codec::rlp::BYTES_HEAD_BASE)
+    {
+        // Typed (EIP-2718: 0x01-0x04): chainId is RLP field 0 of the inner list.
+        cursor = cursor.getCroppedData(1);
+        auto&& [error, header] = bcos::codec::rlp::decodeHeader(cursor);
+        if (error || !header.isList || header.payloadLength > cursor.size()) [[unlikely]]
+        {
+            return std::nullopt;
+        }
+        uint64_t chainId = 0;
+        if (auto e = bcos::codec::rlp::decode(cursor, chainId); e != nullptr) [[unlikely]]
+        {
+            return std::nullopt;
+        }
+        return chainId;
+    }
+    // Legacy: walk the first 6 fields. The tail after them is one of two forms:
+    //   preimage  EIP-155: [..6 fields, chainId, 0, 0]  (admission path — takeToTarsTransaction
+    //             stores encodeForSign())
+    //   full      envelope: [..6 fields, v, r, s]       (block path — engine SEV-8 feeds the
+    //             raw signed envelope)
+    // In the preimage form field 7 IS the chainId and fields 8/9 are the empty 0,0 placeholders;
+    // in the full form field 7 is v (27/28 unprotected, or chainId*2+35+yParity) and fields 8/9
+    // are the non-empty r/s scalars (EIP-2 keeps r,s in [1,n-1], never empty). Distinguish by
+    // whether field 8 is an empty byte string.
+    auto&& [error, header] = bcos::codec::rlp::decodeHeader(cursor);
+    if (error || !header.isList || header.payloadLength > cursor.size()) [[unlikely]]
+    {
+        return std::nullopt;
+    }
+    bcos::bytesRef walker(cursor.data(), header.payloadLength);
+    for (int i = 0; i < 6; ++i)
+    {
+        auto [fieldError, fieldHeader] = bcos::codec::rlp::decodeHeader(walker);
+        if (fieldError || fieldHeader.payloadLength > walker.size()) [[unlikely]]
+        {
+            return std::nullopt;
+        }
+        walker = walker.getCroppedData(fieldHeader.payloadLength);
+    }
+    if (walker.empty())
+    {
+        // pre-EIP-155 unprotected legacy (6-field preimage, v=27/28): no chainId, exempt —
+        // op-geth HomesteadSigner.
+        return std::nullopt;
+    }
+    // Peek field 8 (without consuming field 7 yet) to classify preimage vs full envelope.
+    // Only field 8 is checked here — field 9 validation is deferred to
+    // reassembleWeb3RawTransaction (which validates the full 0,0 tail). This keeps the
+    // walker simple and avoids cursor arithmetic pitfalls with multi-field lookahead.
+    // field7Item keeps the WHOLE field-7 item (header + payload): decodeHeader below advances
+    // walker to the payload start, and decoding that payload as a fresh item mis-reads any
+    // multi-byte chainId/v (e.g. chainId 8453 -> 33) or classifies it as a list header
+    // (chainId 200 -> nullopt -> bogus "unprotected" exemption). Decode from the item start.
+    bcos::bytesRef field7Item = walker;
+    auto [field7Error, field7Header] = bcos::codec::rlp::decodeHeader(walker);
+    if (field7Error || field7Header.payloadLength > walker.size()) [[unlikely]]
+    {
+        return std::nullopt;
+    }
+    bcos::bytesRef afterField7 = walker.getCroppedData(field7Header.payloadLength);
+    bool const isPreimageTail = [&] {
+        if (afterField7.empty()) [[unlikely]]
+        {
+            return false;  // no 0,0 placeholders — treat as full form (or malformed)
+        }
+        auto [field8Error, field8Header] = bcos::codec::rlp::decodeHeader(afterField7);
+        return field8Error == nullptr && !field8Header.isList && field8Header.payloadLength == 0;
+    }();
+    if (isPreimageTail)
+    {
+        // preimage form: field 7 is the EIP-155 chainId.
+        uint64_t chainId = 0;
+        if (auto e = bcos::codec::rlp::decode(field7Item, chainId); e != nullptr) [[unlikely]]
+        {
+            return std::nullopt;
+        }
+        return chainId;
+    }
+    // Full envelope: field 7 is v. 27/28 = pre-EIP-155 unprotected (exempt); >= 35 = EIP-155
+    // protected, chainId = (v - 35) >> 1. Anything else (0/1, 29-34) is malformed.
+    uint64_t v = 0;
+    if (auto e = bcos::codec::rlp::decode(field7Item, v); e != nullptr) [[unlikely]]
+    {
+        return std::nullopt;
+    }
+    if (v == 27 || v == 28)
+    {
+        return std::nullopt;
+    }
+    if (v >= 35)
+    {
+        return (v - 35) >> 1;
+    }
+    return std::nullopt;
+}
+}  // namespace bcos::rlp::protocol

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxEnvelope.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxEnvelope.h
@@ -1,0 +1,45 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Web3TxEnvelope.h
+ * @brief Signed-envelope walkers for Web3 transactions (chainId / typed-vs-legacy)
+ * @date 2026/8/21
+ */
+#pragma once
+
+#include "bcos-utilities/Common.h"
+#include <bcos-codec/rlp/Common.h>
+#include <optional>
+
+namespace bcos::rlp::protocol
+{
+/// Chain id from a Web3 transaction's SIGNED envelope (extraTransactionBytes), never the
+/// unauthenticated tars mirror. The signature binds only the envelope bytes, so a mirror field
+/// is forgeable by a malicious peer/proposer; the envelope is authoritative.
+///   typed (first byte < 0x80): chainId = RLP field 0 of the inner list;
+///   legacy: walk the first 6 fields; if a 7th is present it is the EIP-155 chainId.
+/// nullopt = pre-EIP-155 unprotected legacy (6-field, v=27/28, no chainId tail) or a malformed
+/// preimage. A malformed tail is normally rejected upstream by reassembleWeb3RawTransaction /
+/// verify() — keep the walkers' strictness in sync if that ordering ever changes.
+/// @param payload the signed envelope bytes (type byte included for typed txs)
+[[nodiscard]] std::optional<uint64_t> web3ChainIdFromEnvelope(bcos::bytesConstRef payload);
+
+/// True if the envelope's first byte is a typed-transaction marker (EIP-2718: type byte < 0x80).
+/// Used to key typed/legacy decisions on the envelope rather than the forgeable mirror kind.
+[[nodiscard]] inline bool isTypedWeb3Envelope(bcos::bytesConstRef payload) noexcept
+{
+    return !payload.empty() && payload[0] > 0 && payload[0] < bcos::codec::rlp::BYTES_HEAD_BASE;
+}
+}  // namespace bcos::rlp::protocol

--- a/bcos-rpc/CMakeLists.txt
+++ b/bcos-rpc/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(tarscpp REQUIRED)
 add_library(rpc ${SRCS} ${HEADERS})
 target_include_directories(rpc PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-target_link_libraries(rpc PUBLIC bcos-boostssl ledger codec bcos-crypto protocol-tars mempool jsoncpp_static jwt-cpp::jwt-cpp tarscpp::tarsservant tarscpp::tarsutil)
+target_link_libraries(rpc PUBLIC bcos-boostssl ledger codec bcos-crypto rlp-protocol protocol-tars mempool jsoncpp_static jwt-cpp::jwt-cpp tarscpp::tarsservant tarscpp::tarsutil)
 add_dependencies(rpc BuildInfo.h)
 set_target_properties(rpc PROPERTIES UNITY_BUILD "ON")
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp
@@ -19,101 +19,123 @@
  */
 
 #include "Web3Transaction.h"
+#include "Web3TxHandler.h"
 #include "bcos-utilities/Common.h"
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-framework/protocol/Transaction.h>
+#include <bcos-rpc/jsonrpc/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>  // bcos::fromBigEndian
+#include <limits>
 #include <range/v3/algorithm/find_if.hpp>
 #include <range/v3/algorithm/move.hpp>
-#include <limits>
 #include <utility>
 
 namespace bcos
 {
+namespace
+{
+// EIP-2 canonical-s guard: s > n/2 is "malleable" — flipping s -> n - s recovers the same
+// sender, so op-geth rejects it at both admission and block processing. Threshold shared via
+// Secp256k1Crypto.h (c_secp256k1n / c_secp256k1nOver2).
+
+/// Returns a decode error if r/s fall outside EIP-2's valid range (r,s in [1, n-1], s <= n/2),
+/// else nullptr. r/s are the raw 32-byte big-endian scalars (already zero-padded by the handler).
+bcos::Error::UniquePtr checkEip2Signature(
+    bcos::bytes const& signatureR, bcos::bytes const& signatureS)
+{
+    // Width gate first: padSignature only zero-pads shorter input, and fromBigEndian truncates
+    // wider input — without this a 33-byte 0x00||r would pass the range check below on truncation,
+    // where op-geth rejects >256-bit scalars at RLP decode.
+    if (signatureR.size() > 32 || signatureS.size() > 32)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+            "EIP-2: invalid signature (r/s wider than 32 bytes)");
+    }
+    // r/s are raw 32-byte big-endian scalars — decode in place instead of round-tripping through a
+    // "0x"+hex string + u256 parse (4 heap allocations per tx on the shared decode funnel).
+    const u256 r = bcos::fromBigEndian<u256>(signatureR);
+    const u256 s = bcos::fromBigEndian<u256>(signatureS);
+    if (r == 0 || r >= bcos::crypto::c_secp256k1n || s == 0 || s >= bcos::crypto::c_secp256k1n ||
+        s > bcos::crypto::c_secp256k1nOver2)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+            "EIP-2: invalid signature (r/s out of [1,n-1], or s exceeds secp256k1n/2 — "
+            "malleable signature)");
+    }
+    return nullptr;
+}
+}  // namespace
+
 namespace rpc
 {
+// These three using-declarations are NOT dead: they are the ADL bridge that lets the generic
+// codec templates (RLPEncode.h encodeItems/Common.h lengthOfItems/RLPDecode.h decodeItems) find
+// the AccessListEntry/Web3Transaction overloads defined at the bottom of this file. Those overloads
+// live in namespace codec::rlp, which is not an associated namespace of bcos::rpc::AccessListEntry;
+// without the using-declaration the unity build fails with "neither visible in the template
+// definition nor found by argument-dependent lookup". Keep the three in sync with the overloads.
 using codec::rlp::decode;
 using codec::rlp::encode;
-using codec::rlp::header;
 using codec::rlp::length;
-
-static bytesConstRef getSignatureRef(bytesConstRef input)
-{
-    const auto* it = ::ranges::find_if(input, [](byte b) { return b != 0; });
-    return {it, input.size() - (it - input.begin())};
-}
 
 bcos::bytes Web3Transaction::encodeForSign() const
 {
-    bcos::bytes out;
-    if (type == TransactionType::Legacy)
+    // Delegate to handler: signing preimage (RLP without type byte, without signature)
+    return handlerFor(type).encodeForSign(*this);
+}
+
+bcos::bytes Web3Transaction::encode() const
+{
+    // Full RLP (with type byte, typed transaction)
+    return handlerFor(type).encode(*this);
+}
+
+bcos::Error::UniquePtr Web3Transaction::decode(bcos::bytesRef& in, bool withSig)
+{
+    if (in.empty())
     {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data])
-        codec::rlp::encodeHeader(out, codec::rlp::headerForSign(*this));
-        codec::rlp::encode(out, nonce);
-        // for legacy tx, it means gas price
-        codec::rlp::encode(out, maxFeePerGas);
-        codec::rlp::encode(out, gasLimit);
-        if (to.has_value())
-        {
-            codec::rlp::encode(out, to.value().ref());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        codec::rlp::encode(out, value);
-        codec::rlp::encode(out, data);
-        if (chainId)
-        {
-            // EIP-155
-            codec::rlp::encode(out, chainId.value());
-            codec::rlp::encode(out, 0U);
-            codec::rlp::encode(out, 0U);
-        }
+        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InputTooShort, "Input too short");
+    }
+    const auto firstByte = in[0];
+    // A valid transaction body is always an RLP list (≥0xC0). Use >= LIST_HEAD_BASE rather than
+    // >= BYTES_HEAD_BASE: the latter would misclassify 0x80-0xBF short-string headers as Legacy.
+    // A typed tx's type byte (0x01-0x04) is below 0xC0 and goes through the enum_cast dispatch
+    // below.
+    if (firstByte >= codec::rlp::LIST_HEAD_BASE)
+    {
+        // Legacy: no type byte
+        type = TransactionType::Legacy;
     }
     else
     {
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes])
-        out.push_back(static_cast<byte>(type));
-        codec::rlp::encodeHeader(out, codec::rlp::headerForSign(*this));
-        codec::rlp::encode(out, chainId.value_or(0));
-        codec::rlp::encode(out, nonce);
-        if (type != TransactionType::EIP2930)
+        auto txType = magic_enum::enum_cast<TransactionType>(firstByte);
+        if (!txType.has_value())
         {
-            codec::rlp::encode(out, maxPriorityFeePerGas);
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
         }
-        // for EIP2930 it means gasPrice; for EIP1559 and EIP4844, it means max priority fee per gas
-        codec::rlp::encode(out, maxFeePerGas);
-        codec::rlp::encode(out, gasLimit);
-        if (to.has_value())
-        {
-            codec::rlp::encode(out, to.value().ref());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        codec::rlp::encode(out, value);
-        codec::rlp::encode(out, data);
-        codec::rlp::encode(out, accessList);
-        if (type == TransactionType::EIP4844)
-        {
-            codec::rlp::encode(out, maxFeePerBlobGas);
-            codec::rlp::encode(out, blobVersionedHashes);
-        }
-        if (type == TransactionType::EIP7702)
-        {
-            codec::rlp::encode(out, authorizationList);
-        }
+        type = txType.value();
     }
-    return out;
+    // ⚠️ Do not pre-strip the type byte: the typed handler consumes the envelope itself (see the
+    // Web3TxHandler.h decode contract); stripping it again here would skip the list header a second
+    // time and fail every typed tx decode.
+    auto err = handlerFor(type).decode(in, *this, withSig);
+    if (err == nullptr && !in.empty())
+    {
+        return BCOS_ERROR_UNIQUE_PTR(
+            codec::rlp::DecodingError::InputTooLong, "Trailing bytes after RLP list");
+    }
+    // EIP-2: reject malleable (high-s) signatures at decode time. This member is the shared funnel
+    // for BOTH OP paths — eth_sendRawTransaction (EthEndpoint.cpp) and engine newPayload (the
+    // decode path feeding block execution, part 5/5) — so the check covers admission AND block
+    // processing, matching op-geth. Deposits (0x7e) are unsigned; the EIP-7702 authorization
+    // entries are gated separately (Eip7702Recover.h) and left untouched here.
+    if (err == nullptr && withSig && type != TransactionType::Deposit)
+    {
+        err = checkEip2Signature(signatureR, signatureS);
+    }
+    return err;
 }
 
 bcos::crypto::HashType Web3Transaction::txHash() const
@@ -131,6 +153,34 @@ bcos::crypto::HashType Web3Transaction::hashForSign() const
 
 bcostars::Transaction Web3Transaction::takeToTarsTransaction()
 {
+    if (type == TransactionType::Deposit)
+    {
+        bcostars::Transaction tarsTx{};
+        tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+        tarsTx.web3TypedTxKind =
+            static_cast<tars::Char>(static_cast<uint8_t>(TransactionType::Deposit));
+        tarsTx.sourceHash = sourceHash.hex();
+        tarsTx.sender.assign(from.begin(), from.end());
+        // 0x-prefixed, matching the read side u256(...) (parsed in TransactionImpl.cpp mint())
+        tarsTx.mint = bcos::toQuantity(mint);
+        tarsTx.isSystemTransaction = isSystemTx ? 1 : 0;
+        // Full 0x7E envelope (encode()); extraTransactionHash = keccak of it verbatim so
+        // deposits are indexable by hash (eth_getTransactionByHash/Receipt) like any other tx.
+        auto encoded = encode();
+        tarsTx.extraTransactionBytes.reserve(encoded.size());
+        ::ranges::move(encoded, std::back_inserter(tarsTx.extraTransactionBytes));
+        auto const hash = bcos::crypto::keccak256Hash(bcos::ref(encoded));
+        tarsTx.extraTransactionHash.assign(hash.begin(), hash.end());
+        // Generic fields (so consumers on the tars generic read path don't see empty values)
+        tarsTx.data.to = to.has_value() ? to->hexPrefixed() : "";
+        tarsTx.data.input.reserve(data.size());
+        ::ranges::move(data, std::back_inserter(tarsTx.data.input));
+        tarsTx.data.value = bcos::toQuantity(value);
+        tarsTx.data.gasLimit = gasLimit;
+        tarsTx.data.nonce = "0x0";  // deposit nonce is always 0
+        tarsTx.data.chainID = "0";
+        return tarsTx;
+    }
     bcostars::Transaction tarsTx{};
     tarsTx.data.to = (this->to.has_value()) ? this->to.value().hexPrefixed() : "";
     tarsTx.data.input.reserve(this->data.size());
@@ -138,7 +188,10 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
 
     tarsTx.data.value = "0x" + this->value.str(0, std::ios_base::hex);
     tarsTx.data.gasLimit = this->gasLimit;
-    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559))
+    // Use explicit range check rather than `>=` so that Deposit (0x7e) is excluded;
+    // EIP7702 is fee-market (maxFeePerGas/maxPriorityFeePerGas) so it is included
+    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559) &&
+        static_cast<uint8_t>(this->type) <= static_cast<uint8_t>(TransactionType::EIP7702))
     {
         tarsTx.data.maxFeePerGas = "0x" + this->maxFeePerGas.str(0, std::ios_base::hex);
         tarsTx.data.maxPriorityFeePerGas =
@@ -194,10 +247,10 @@ bcostars::Transaction Web3Transaction::takeToTarsTransaction()
             // entry must still be KEPT in the list: a set_code transaction with an empty
             // authorization list is rejected by the executor, and dropping it would change
             // the signing hash.
-            tarsEntry.chainID = static_cast<int64_t>(
-                entry.chainId > std::numeric_limits<uint64_t>::max() ?
-                    UINT64_MAX :
-                    static_cast<uint64_t>(entry.chainId));
+            tarsEntry.chainID =
+                static_cast<int64_t>(entry.chainId > std::numeric_limits<uint64_t>::max() ?
+                                         UINT64_MAX :
+                                         static_cast<uint64_t>(entry.chainId));
             tarsEntry.address = entry.address.hex();  // 40-char hex, no 0x prefix
             tarsEntry.nonce = static_cast<int64_t>(entry.nonce);
             tarsEntry.v = static_cast<tars::Char>(entry.yParity);
@@ -240,6 +293,9 @@ uint64_t Web3Transaction::getSignatureV() const
 }
 std::string Web3Transaction::sender() const
 {
+    // deposit (0x7e): unsigned, so sender is taken directly from the from field
+    if (type == TransactionType::Deposit)
+        return toHexStringWithPrefix(from);
     bcos::bytes sign{};
     sign.reserve(crypto::SECP256K1_SIGNATURE_LEN);
     sign.insert(sign.end(), signatureR.begin(), signatureR.end());
@@ -255,6 +311,19 @@ std::string Web3Transaction::sender() const
 std::string Web3Transaction::toString() const noexcept
 {
     std::stringstream stringstream{};
+    // sender() runs EC recovery, which throws InvalidSignature when the (r,s) pair is not on
+    // the curve — legal input for a tx that only passed the range checks at decode. A display
+    // helper must not let that escape the noexcept border (std::terminate at the TRACE log
+    // call site in EthEndpoint).
+    std::string senderText;
+    try
+    {
+        senderText = this->sender();
+    }
+    catch (const std::exception&)
+    {
+        senderText = "unrecoverable";
+    }
     stringstream << " chainId: " << this->chainId.value_or(0) << " hash:" << this->txHash().hex()
                  << " type: " << static_cast<uint16_t>(this->type)
                  << " to: " << this->to.value_or(Address()).hex() << " data: " << toHex(this->data)
@@ -264,7 +333,7 @@ std::string Web3Transaction::toString() const noexcept
                  << " maxFeePerGas: " << this->maxFeePerGas
                  << " maxFeePerBlobGas: " << this->maxFeePerBlobGas
                  << " blobVersionedHashes: " << this->blobVersionedHashes
-                 << " sender: " << this->sender() << " signatureR: " << toHex(this->signatureR)
+                 << " sender: " << senderText << " signatureR: " << toHex(this->signatureR)
                  << " signatureS: " << toHex(this->signatureS)
                  << " signatureV: " << this->signatureV;
     return stringstream.str();
@@ -274,185 +343,28 @@ std::string Web3Transaction::toString() const noexcept
 namespace codec::rlp
 {
 using namespace bcos::rpc;
-Header header(const AccessListEntry& entry) noexcept
-{
-    auto len = length(entry.storageKeys);
-    return {.isList = true, .payloadLength = Address::SIZE + 1 + len};
-}
-
-size_t length(AccessListEntry const& entry) noexcept
-{
-    auto head = header(entry);
-    return lengthOfLength(head.payloadLength) + head.payloadLength;
-}
-
-Header header(const AuthorizationListEntry& entry) noexcept
-{
-    auto len = codec::rlp::length(entry.chainId) + Address::SIZE + 1 +
-               codec::rlp::length(entry.nonce) +
-               codec::rlp::length(static_cast<uint64_t>(entry.yParity)) +
-               codec::rlp::length(entry.r) + codec::rlp::length(entry.s);
-    return {.isList = true, .payloadLength = len};
-}
-
-size_t length(AuthorizationListEntry const& entry) noexcept
-{
-    auto head = header(entry);
-    return lengthOfLength(head.payloadLength) + head.payloadLength;
-}
-
-void encode(bcos::bytes& out, const AuthorizationListEntry& entry) noexcept
-{
-    encodeHeader(out, header(entry));
-    encode(out, entry.chainId);
-    encode(out, entry.address.ref());
-    encode(out, entry.nonce);
-    encode(out, static_cast<uint64_t>(entry.yParity));
-    encode(out, entry.r);
-    encode(out, entry.s);
-}
-Header headerTxBase(const Web3Transaction& tx) noexcept
-{
-    Header h{.isList = true};
-
-    if (tx.type != TransactionType::Legacy)
-    {
-        h.payloadLength += length(tx.chainId.value_or(0));
-    }
-
-    h.payloadLength += length(tx.nonce);
-    if (tx.type == TransactionType::EIP1559 || tx.type == TransactionType::EIP4844 ||
-        tx.type == TransactionType::EIP7702)
-    {
-        h.payloadLength += length(tx.maxPriorityFeePerGas);
-    }
-    h.payloadLength += length(tx.maxFeePerGas);
-    h.payloadLength += length(tx.gasLimit);
-    h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
-    h.payloadLength += length(tx.value);
-    h.payloadLength += length(tx.data);
-
-    if (tx.type != TransactionType::Legacy)
-    {
-        h.payloadLength += codec::rlp::length(tx.accessList);
-        if (tx.type == TransactionType::EIP4844)
-        {
-            h.payloadLength += length(tx.maxFeePerBlobGas);
-            h.payloadLength += length(tx.blobVersionedHashes);
-        }
-        if (tx.type == TransactionType::EIP7702)
-        {
-            h.payloadLength += codec::rlp::length(tx.authorizationList);
-        }
-    }
-
-    return h;
-}
-Header header(Web3Transaction const& tx) noexcept
-{
-    auto header = headerTxBase(tx);
-    header.payloadLength += (tx.type == TransactionType::Legacy) ? length(tx.getSignatureV()) : 1;
-    header.payloadLength += length(getSignatureRef(ref(tx.signatureR)));
-    header.payloadLength += length(getSignatureRef(ref(tx.signatureS)));
-    return header;
-}
-Header headerForSign(Web3Transaction const& tx) noexcept
-{
-    auto header = headerTxBase(tx);
-    if (tx.type == TransactionType::Legacy && tx.chainId)
-    {
-        header.payloadLength += length(tx.chainId.value()) + 2;
-    }
-    return header;
-}
 size_t length(Web3Transaction const& tx) noexcept
 {
-    auto head = header(tx);
+    auto head = handlerFor(tx.type).header(tx);
     auto len = lengthOfLength(head.payloadLength) + head.payloadLength;
     len = (tx.type == TransactionType::Legacy) ? len : lengthOfLength(len + 1) + len + 1;
     return len;
 }
-void encode(bcos::bytes& out, const AccessListEntry& entry) noexcept
-{
-    encodeHeader(out, header(entry));
-    encode(out, entry.account.ref());
-    encode(out, entry.storageKeys);
-}
 void encode(bcos::bytes& out, const Web3Transaction& tx) noexcept
 {
-    if (tx.type == TransactionType::Legacy)
+    // Append semantics like every other codec::rlp::encode(out, x) overload — encodeItems /
+    // list-encoding chains depend on it, and an overwrite would silently drop previously
+    // encoded elements. The handler returns a complete buffer: move it when out is empty
+    // (the current callers) to avoid a copy, otherwise append.
+    auto encoded = handlerFor(tx.type).encode(tx);
+    if (out.empty())
     {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
-        encodeHeader(out, header(tx));
-        encode(out, tx.nonce);
-        // for legacy tx, it means gas price
-        encode(out, tx.maxFeePerGas);
-        encode(out, tx.gasLimit);
-        if (tx.to.has_value())
-        {
-            encode(out, tx.to.value());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        encode(out, tx.value);
-        encode(out, tx.data);
-        encode(out, tx.getSignatureV());
-        encode(out, getSignatureRef(ref(tx.signatureR)));
-        encode(out, getSignatureRef(ref(tx.signatureS)));
+        out = std::move(encoded);
     }
     else
     {
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
-        // signatureYParity, signatureR, signatureS])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
-        // signature_s])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
-        // signature_y_parity, signature_r, signature_s])
-        out.push_back(static_cast<bcos::byte>(tx.type));
-        encodeHeader(out, header(tx));
-        encode(out, tx.chainId.value_or(0));
-        encode(out, tx.nonce);
-        if (tx.type != TransactionType::EIP2930)
-        {
-            encode(out, tx.maxPriorityFeePerGas);
-        }
-        // for EIP2930 it means gasPrice; for EIP1559 and EIP4844, it means max priority fee per gas
-        encode(out, tx.maxFeePerGas);
-        encode(out, tx.gasLimit);
-        if (tx.to.has_value())
-        {
-            encode(out, tx.to.value());
-        }
-        else
-        {
-            out.push_back(codec::rlp::BYTES_HEAD_BASE);
-        }
-        encode(out, tx.value);
-        encode(out, tx.data);
-        encode(out, tx.accessList);
-        if (tx.type == TransactionType::EIP4844)
-        {
-            encode(out, tx.maxFeePerBlobGas);
-            encode(out, tx.blobVersionedHashes);
-        }
-        if (tx.type == TransactionType::EIP7702)
-        {
-            encode(out, tx.authorizationList);
-        }
-        encode(out, tx.signatureV);
-        encode(out, getSignatureRef(ref(tx.signatureR)));
-        encode(out, getSignatureRef(ref(tx.signatureS)));
+        out.insert(out.end(), encoded.begin(), encoded.end());
     }
-}
-bcos::Error::UniquePtr decode(bcos::bytesRef& in, AccessListEntry& out) noexcept
-{
-    return decode(in, out.account, out.storageKeys);
 }
 
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, AuthorizationListEntry& out) noexcept
@@ -502,210 +414,21 @@ bcos::Error::UniquePtr decode(bcos::bytesRef& in, AuthorizationListEntry& out) n
 }
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, Web3Transaction& out) noexcept
 {
-    return decodeTransaction(in, out, true);
+    return out.decode(in, true);
 }
 
 bcos::Error::UniquePtr decodeFromPayload(bcos::bytesRef& in, rpc::Web3Transaction& out) noexcept
 {
-    return decodeTransaction(in, out, false);
+    return out.decode(in, false);
 }
 
 bcos::Error::UniquePtr decodeTransaction(
     bcos::bytesRef& in, rpc::Web3Transaction& out, bool withSignature) noexcept
 {
-    if (in.empty())
-    {
-        return BCOS_ERROR_UNIQUE_PTR(InputTooShort, "Input too short");
-    }
-    Error::UniquePtr decodeError = nullptr;
-    if (auto const& firstByte = in[0]; 0 < firstByte && firstByte < BYTES_HEAD_BASE)
-    {
-        // EIP-2718: Transaction Type
-        // EIP2930: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
-        // signatureYParity, signatureR, signatureS])
-
-        // EIP1559: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
-        // signature_s])
-
-        // EIP4844: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
-        // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
-        // signature_y_parity, signature_r, signature_s])
-
-        const auto txType = magic_enum::enum_cast<TransactionType>(firstByte);
-        if (!txType.has_value())
-        {
-            return BCOS_ERROR_UNIQUE_PTR(
-                DecodingError::UnsupportedTransactionType, "Unsupported transaction type");
-        }
-        out.type = txType.value();
-        in = in.getCroppedData(1);
-        auto&& [e, header] = decodeHeader(in);
-        if (e != nullptr)
-        {
-            return std::move(e);
-        }
-        if (!header.isList)
-        {
-            return BCOS_ERROR_UNIQUE_PTR(UnexpectedString, "Unexpected String");
-        }
-        uint64_t chainId = 0;
-        if (auto error = decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
-            error != nullptr)
-        {
-            return error;
-        }
-        out.chainId.emplace(chainId);
-        if (out.type == TransactionType::EIP2930)
-        {
-            out.maxFeePerGas = out.maxPriorityFeePerGas;
-        }
-        else if (auto error = decode(in, out.maxFeePerGas); error != nullptr)
-        {
-            return error;
-        }
-
-        if (auto error = decode(in, out.gasLimit); error != nullptr)
-        {
-            return error;
-        }
-
-        if (in[0] == BYTES_HEAD_BASE)
-        {
-            out.to = std::nullopt;
-            in = in.getCroppedData(1);
-        }
-        else
-        {
-            Address addr{};
-            if (auto error = decode(in, addr); error != nullptr)
-            {
-                return error;
-            }
-            out.to.emplace(addr);
-        }
-
-        if (auto error = decodeItems(in, out.value, out.data, out.accessList); error != nullptr)
-        {
-            return error;
-        }
-
-        if (out.type == TransactionType::EIP4844)
-        {
-            if (auto error = decodeItems(in, out.maxFeePerBlobGas, out.blobVersionedHashes);
-                error != nullptr)
-            {
-                return error;
-            }
-        }
-        if (out.type == TransactionType::EIP7702)
-        {
-            if (auto error = decode(in, out.authorizationList); error != nullptr)
-            {
-                return error;
-            }
-        }
-        if (withSignature)
-        {
-            decodeError = decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
-        }
-    }
-    else
-    {
-        // rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
-        auto&& [error, header] = decodeHeader(in);
-        if (error != nullptr)
-        {
-            return std::move(error);
-        }
-        if (!header.isList)
-        {
-            return BCOS_ERROR_UNIQUE_PTR(UnexpectedList, "Unexpected list");
-        }
-        out.type = TransactionType::Legacy;
-        if (decodeError = decodeItems(in, out.nonce, out.maxPriorityFeePerGas);
-            decodeError != nullptr)
-        {
-            return decodeError;
-        }
-        out.maxFeePerGas = out.maxPriorityFeePerGas;
-
-        if (decodeError = decode(in, out.gasLimit); decodeError != nullptr)
-        {
-            return decodeError;
-        }
-
-        if (in[0] == BYTES_HEAD_BASE)
-        {
-            out.to = std::nullopt;
-            in = in.getCroppedData(1);
-        }
-        else
-        {
-            Address addr{};
-            if (decodeError = decode(in, addr); decodeError != nullptr)
-            {
-                return decodeError;
-            }
-            out.to.emplace(addr);
-        }
-
-        decodeError = decodeItems(in, out.value, out.data);
-        if (withSignature)
-        {
-            if (decodeError = decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
-                decodeError != nullptr)
-            {
-                return decodeError;
-            }
-            // TODO: EIP-155 chainId decode from encoded bytes for sign
-            auto v = out.signatureV;
-            if (v == 27 || v == 28)
-            {
-                // pre EIP-155
-                out.chainId = std::nullopt;
-                out.signatureV = v - 27;
-            }
-            else if (v == 0 || v == 1)
-            {
-                out.chainId = std::nullopt;
-                return decodeError;
-            }
-            else if (v < 35)
-            {
-                return BCOS_ERROR_UNIQUE_PTR(InvalidVInSignature, "Invalid V in signature");
-            }
-            else
-            {
-                // https://eips.ethereum.org/EIPS/eip-155
-                // Find chain_id and y_parity ∈ {0, 1} such that
-                // v = chain_id * 2 + 35 + y_parity
-                out.signatureV = (v - 35) % 2;
-                out.chainId = ((v - 35) >> 1);
-            }
-        }
-        else
-        {
-            uint64_t chainId = 0;
-            decodeError = decode(in, chainId);
-            out.chainId.emplace(chainId);
-        }
-    }
-    if (withSignature)
-    {
-        // rehandle signature and chainId
-        if (out.signatureR.size() < crypto::SECP256K1_SIGNATURE_R_LEN)
-        {
-            out.signatureR.insert(out.signatureR.begin(),
-                crypto::SECP256K1_SIGNATURE_R_LEN - out.signatureR.size(), 0);
-        }
-        if (out.signatureS.size() < crypto::SECP256K1_SIGNATURE_S_LEN)
-        {
-            out.signatureS.insert(out.signatureS.begin(),
-                crypto::SECP256K1_SIGNATURE_S_LEN - out.signatureS.size(), bcos::byte(0));
-        }
-    }
-    return decodeError;
+    // Kept as the entry point (the call target of decodeOpEnvelope/decodeOpEnvelopeWithSig,
+    // EthEndpoint.cpp:73); it now delegates to the member function so the new handler dispatch
+    // path is used.
+    return out.decode(in, withSignature);
 }
 }  // namespace codec::rlp
 }  // namespace bcos

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.h
@@ -29,7 +29,9 @@
 #include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <magic_enum/magic_enum.hpp>
+#include <optional>
 #include <ostream>
+#include <string_view>
 namespace bcos
 {
 namespace rpc
@@ -39,10 +41,11 @@ namespace rpc
 enum class TransactionType : uint8_t
 {
     Legacy = 0,
-    EIP2930 = 1,  // https://eips.ethereum.org/EIPS/eip-2930
-    EIP1559 = 2,  // https://eips.ethereum.org/EIPS/eip-1559
-    EIP4844 = 3,  // https://eips.ethereum.org/EIPS/eip-4844
-    EIP7702 = 4,  // https://eips.ethereum.org/EIPS/eip-7702
+    EIP2930 = 1,     // https://eips.ethereum.org/EIPS/eip-2930
+    EIP1559 = 2,     // https://eips.ethereum.org/EIPS/eip-1559
+    EIP4844 = 3,     // https://eips.ethereum.org/EIPS/eip-4844
+    EIP7702 = 4,     // https://eips.ethereum.org/EIPS/eip-7702
+    Deposit = 0x7e,  // deposit-only system tx (OP Stack)
 };
 
 constexpr auto operator<=>(TransactionType const& ltype, auto rtype)
@@ -78,11 +81,11 @@ struct AuthorizationListEntry
     uint8_t yParity{0};
     u256 r{0};
     u256 s{0};
-    friend bool operator==(const AuthorizationListEntry& lhs, const AuthorizationListEntry& rhs) noexcept
+    friend bool operator==(
+        const AuthorizationListEntry& lhs, const AuthorizationListEntry& rhs) noexcept
     {
-        return lhs.chainId == rhs.chainId && lhs.address == rhs.address &&
-               lhs.nonce == rhs.nonce && lhs.yParity == rhs.yParity && lhs.r == rhs.r &&
-               lhs.s == rhs.s;
+        return lhs.chainId == rhs.chainId && lhs.address == rhs.address && lhs.nonce == rhs.nonce &&
+               lhs.yParity == rhs.yParity && lhs.r == rhs.r && lhs.s == rhs.s;
     }
 };
 
@@ -98,6 +101,10 @@ public:
 
     // encode for sign, rlp(tx_payload)
     bcos::bytes encodeForSign() const;
+    // full RLP (with type byte) — delegates to handlerFor(type).encode
+    bcos::bytes encode() const;
+    // Decode — delegates to handlerFor(type).decode, propagating decode errors
+    bcos::Error::UniquePtr decode(bcos::bytesRef& in, bool withSig = true);
     // tx hash = keccak256(rlp(tx_payload,v,r,s))
     bcos::crypto::HashType txHash() const;
     // hash for sign = keccak256(rlp(tx_payload))
@@ -122,12 +129,21 @@ public:
     // EIP-4844: Shard Blob Transactions
     u256 maxFeePerBlobGas{0};
     h256s blobVersionedHashes;
+    // deposit-only (0x7e)
+    h256 sourceHash;
+    Address from;
+    u256 mint{0};
+    bool isSystemTx{false};
     // TODO)) blob
     // EIP-7702: Set Code Transactions (Prague+)
     std::vector<AuthorizationListEntry> authorizationList;
     bcos::bytes signatureR;
     bcos::bytes signatureS;
     uint64_t signatureV{0};
+    /// Full raw EIP-2718 envelope bytes as received by eth_sendRawTransaction (with type byte +
+    /// signature). Empty when decoded from a block body rather than a client submission; OP block
+    /// building (sequencer) needs it verbatim to reproduce the exact tx the user signed.
+    bcos::bytes rawTransactionBytes;
 };
 }  // namespace rpc
 namespace codec::rlp
@@ -141,9 +157,6 @@ void encode(bcos::bytes& out, const rpc::AuthorizationListEntry&) noexcept;
 size_t length(const rpc::AuthorizationListEntry&) noexcept;
 
 size_t length(const rpc::Web3Transaction&) noexcept;
-Header headerForSign(const rpc::Web3Transaction& tx) noexcept;
-Header headerTxBase(const rpc::Web3Transaction& tx) noexcept;
-Header header(const rpc::Web3Transaction& tx) noexcept;
 void encode(bcos::bytes& out, const rpc::Web3Transaction&) noexcept;
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, rpc::AccessListEntry&) noexcept;
 bcos::Error::UniquePtr decode(bcos::bytesRef& in, rpc::AuthorizationListEntry&) noexcept;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
@@ -1,0 +1,1417 @@
+// bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
+#include "Web3TxHandler.h"
+#include "Web3Transaction.h"
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Log.h>
+#include <cstddef>  // std::ptrdiff_t (ListEnd pointer arithmetic)
+#include <cstdint>
+
+// These using-declarations are NOT dead: they are the ADL bridge that lets the generic codec
+// templates (RLPEncode.h encodeItems / Common.h lengthOfItems / RLPDecode.h decodeItems) find the
+// AccessListEntry overloads defined at the bottom of this file. Those overloads live in namespace
+// codec::rlp, which is not an associated namespace of bcos::rpc::AccessListEntry; without the
+// using-declaration a standalone TU (or a unity-batch reorder) fails with "neither visible in the
+// template definition nor found by argument-dependent lookup". Keep the three in sync with the
+// overloads.
+using bcos::codec::rlp::decode;
+using bcos::codec::rlp::encode;
+using bcos::codec::rlp::length;
+
+namespace bcos::rpc
+{
+namespace
+{
+// Strip leading zero bytes from signature data (R/S) to keep RLP encoding canonical.
+// Note: cannot be named getSignatureRef — it would collide with the same-named static
+// function in Web3Transaction.cpp under unity build (same TU); the logic is fully equivalent.
+bcos::bytesConstRef trimLeadingZeroBytes(bcos::bytesConstRef input) noexcept
+{
+    size_t i = 0;
+    while (i < input.size() && input[i] == bcos::byte{0})
+    {
+        ++i;
+    }
+    return {input.data() + i, input.size() - i};
+}
+
+// Signature length padding matching the end of decodeTransaction (32 bytes each for R/S).
+void padSignature(bcos::bytes& signatureR, bcos::bytes& signatureS) noexcept
+{
+    if (signatureR.size() < bcos::crypto::SECP256K1_SIGNATURE_R_LEN)
+    {
+        signatureR.insert(signatureR.begin(),
+            bcos::crypto::SECP256K1_SIGNATURE_R_LEN - signatureR.size(), bcos::byte{0});
+    }
+    if (signatureS.size() < bcos::crypto::SECP256K1_SIGNATURE_S_LEN)
+    {
+        signatureS.insert(signatureS.begin(),
+            bcos::crypto::SECP256K1_SIGNATURE_S_LEN - signatureS.size(), bcos::byte{0});
+    }
+}
+
+// ⚠️ decode contract: each handler's decode is self-contained (consumes the envelope itself —
+// Legacy: RLP list header; typed: type byte + RLP list header), copied field-by-field from the
+// corresponding branch of Web3Transaction.cpp decodeTransaction. The dispatcher
+// (Web3Transaction::decode member) should determine the type from the first byte, set out.type,
+// then call handlerFor(type).decode(in, out, withSig), and must not consume the type byte first.
+
+struct LegacyTxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        // for legacy tx, it means gas price
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        return h;
+    }
+
+    // Signing preimage: rlp([nonce, gasPrice, gasLimit, to, value, data]) + EIP-155 chainId tail
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = headerTxBase(tx);
+        if (tx.chainId)
+        {
+            // EIP-155: chainId and the two trailing 0 placeholders
+            head.payloadLength += codec::rlp::length(tx.chainId.value()) + 2;
+        }
+        // header() already computed the exact payload size; reserve it so the incremental
+        // encode(out, ...) appends never reallocate (hot path: takeToTarsTransaction per tx).
+        out.reserve(codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.nonce);
+        // for legacy tx, it means gas price
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        if (tx.chainId)
+        {
+            // EIP-155
+            codec::rlp::encode(out, tx.chainId.value());
+            codec::rlp::encode(out, 0U);
+            codec::rlp::encode(out, 0U);
+        }
+        return out;
+    }
+
+    // Full RLP (no type byte): rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = header(tx);
+        out.reserve(codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.nonce);
+        // for legacy tx, it means gas price
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.getSignatureV());
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation): base fields + signature length (Legacy special: signatureV
+    // uses getSignatureV())
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += codec::rlp::length(tx.getSignatureV());
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        auto&& [error, head] = codec::rlp::decodeHeader(in);
+        if (error != nullptr)
+        {
+            return std::move(error);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedList, "legacy tx: expected RLP list");
+        }
+        // Fields must stay within the declared list payload (op-geth ListEnd parity).
+        bcos::byte* const payloadStart = in.data();
+        auto const payloadLength = head.payloadLength;
+        out.type = TransactionType::Legacy;
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (decodeError = codec::rlp::decodeItems(in, out.nonce, out.maxPriorityFeePerGas);
+            decodeError != nullptr)
+        {
+            return decodeError;
+        }
+        out.maxFeePerGas = out.maxPriorityFeePerGas;
+
+        if (decodeError = codec::rlp::decode(in, out.gasLimit); decodeError != nullptr)
+        {
+            return decodeError;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (decodeError = codec::rlp::decode(in, addr); decodeError != nullptr)
+            {
+                return decodeError;
+            }
+            out.to.emplace(addr);
+        }
+
+        // ⚠️ Check value/data decode errors immediately: if deferred to the withSig branch,
+        // a later successful signature decode would overwrite decodeError and misjudge
+        // malformed input as valid.
+        if (auto err = codec::rlp::decodeItems(in, out.value, out.data); err != nullptr)
+        {
+            return err;
+        }
+        if (withSig)
+        {
+            if (decodeError =
+                    codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+                decodeError != nullptr)
+            {
+                return decodeError;
+            }
+            // TODO: EIP-155 chainId decode from encoded bytes for sign
+            auto v = out.signatureV;
+            if (v == 27 || v == 28)
+            {
+                // pre EIP-155
+                out.chainId = std::nullopt;
+                out.signatureV = v - 27;
+            }
+            else if (v == 0 || v == 1)
+            {
+                // pre-EIP-155 v must be 27/28; v=0/1 is an invalid signature (treated the same as
+                // v<35). The original implementation returned decodeError(nullptr), which callers
+                // treated as success — changed to report an explicit error.
+                out.chainId = std::nullopt;
+                return BCOS_ERROR_UNIQUE_PTR(
+                    codec::rlp::DecodingError::InvalidVInSignature, "Invalid V in signature");
+            }
+            else if (v < 35)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(
+                    codec::rlp::DecodingError::InvalidVInSignature, "Invalid V in signature");
+            }
+            else
+            {
+                // https://eips.ethereum.org/EIPS/eip-155
+                // Find chain_id and y_parity ∈ {0, 1} such that
+                // v = chain_id * 2 + 35 + y_parity
+                out.signatureV = (v - 35) % 2;
+                out.chainId = ((v - 35) >> 1);
+            }
+        }
+        else
+        {
+            if (in.empty())
+            {
+                // Pre-EIP-155 6-field signing preimage: no chainId tail at all.
+                out.chainId = std::nullopt;
+            }
+            else
+            {
+                // The tail is either the signing preimage's (chainId, 0, 0) — the txpool
+                // stage stores encodeForSign() — or the sealed-block wire envelope's (v, r, s)
+                // (buildOpBlock, SEV-8, overwrites extraTransactionBytes with the full
+                // envelope). Discriminate by the two trailer items: empty-empty is the
+                // preimage; anything else is a wire envelope whose item7 is the EIP-155 v
+                // (27/28 pre-EIP-155, >= 35 EIP-155). A 7/8-field preimage (chainId without
+                // both placeholders) is malformed (op-geth preimages are 6 or 9 fields) — no
+                // "placeholders optional" leniency — and dies with InputTooShort below.
+                // Zero-copy trailer views (bcos::bytes would heap-allocate per decode).
+                // chainId is width-gated to uint64 by the shared RLP UnsignedIntegral gate
+                // (RLPDecode.h) — chainIds >2^64-1 are rejected rather than truncated.
+                uint64_t item7 = 0;
+                bcos::bytesRef item8;
+                bcos::bytesRef item9;
+                if (decodeError = codec::rlp::decodeItems(in, item7, item8, item9);
+                    decodeError != nullptr)
+                {
+                    return decodeError;
+                }
+                if (item8.empty() && item9.empty())
+                {
+                    // EIP-155 signing preimage tail: chainId with the two r/s placeholders.
+                    out.chainId.emplace(item7);
+                }
+                else
+                {
+                    // Wire envelope: item7 is v; the signed chainId field exists only in the
+                    // preimage layout, so derive it from v. r/s are consumed above as scratch
+                    // for no-sig readers, which source the signature from the tars blob.
+                    if (item7 == 27 || item7 == 28)
+                    {
+                        out.chainId = std::nullopt;  // pre-EIP-155 wire envelope
+                    }
+                    else if (item7 < 35)
+                    {
+                        return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                            "Invalid V in signature");
+                    }
+                    else
+                    {
+                        out.chainId.emplace((item7 - 35) >> 1);  // EIP-155 wire envelope
+                    }
+                }
+            }
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        // ListEnd parity (op-geth List/ListEnd): fields must consume exactly the declared
+        // payload — over-consumption (fields crossing the boundary) AND under-consumption
+        // (trailing bytes inside the payload) are both rejected here (data() is null only
+        // after a failed decode).
+        if (in.data() != nullptr &&
+            in.data() - payloadStart != static_cast<std::ptrdiff_t>(payloadLength))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedListElements,
+                "legacy tx: fields exceed the declared RLP list payload length");
+        }
+        return decodeError;
+    }
+};
+
+struct EIP2930TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        // EIP2930 does not encode maxPriorityFeePerGas; gasPrice is carried by maxFeePerGas
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        return h;
+    }
+
+    // Signing preimage: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data,
+    // accessList])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = headerTxBase(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP2930));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        // for EIP2930 it means gasPrice
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        return out;
+    }
+
+    // Full RLP: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
+    // signatureYParity, signatureR, signatureS])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = header(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP2930));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        // for EIP2930 it means gasPrice
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation): base fields + 1 (signatureV y-parity after the type byte) +
+    // signature length
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
+    // yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP2930))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP2930;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        // Fields must stay within the declared list payload (op-geth ListEnd parity).
+        bcos::byte* const payloadStart = in.data();
+        auto const payloadLength = head.payloadLength;
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        // EIP2930: gasPrice is carried in maxFeePerGas
+        out.maxFeePerGas = out.maxPriorityFeePerGas;
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig || !in.empty())
+        {
+            // withSig decodes the wire envelope's trailing (yParity, r, s). The no-sig decode
+            // may meet them too: sealed OP blocks overwrite extraTransactionBytes with the
+            // full envelope (buildOpBlock, SEV-8) while the txpool stage stores the signing
+            // preimage — consuming the optional trailer lets both layouts pass the trailing-
+            // bytes check. The consumed values are scratch for no-sig readers, which source
+            // the signature from the tars signature blob.
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        // Return the first decode error before ListEnd parity — if decodeItems(v,r,s)
+        // failed, the cursor may be mid-field and ListEnd would report a misleading
+        // "fields exceed payload" instead of the real root cause.
+        if (decodeError != nullptr)
+        {
+            return decodeError;
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        // op-geth ListEnd parity: reject if fields crossed the declared payload boundary.
+        if (in.data() != nullptr &&
+            in.data() - payloadStart != static_cast<std::ptrdiff_t>(payloadLength))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedListElements,
+                "EIP2930 tx: fields exceed the declared RLP list payload length");
+        }
+        return decodeError;
+    }
+};
+
+struct EIP1559TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        return h;
+    }
+
+    // Signing preimage: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = headerTxBase(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP1559));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        return out;
+    }
+
+    // Full RLP: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, signature_y_parity, signature_r,
+    // signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = header(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP1559));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x02 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // destination, amount, data, access_list, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP1559))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP1559;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        // Fields must stay within the declared list payload (op-geth ListEnd parity).
+        bcos::byte* const payloadStart = in.data();
+        auto const payloadLength = head.payloadLength;
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig || !in.empty())
+        {
+            // withSig decodes the wire envelope's trailing (yParity, r, s). The no-sig decode
+            // may meet them too: sealed OP blocks overwrite extraTransactionBytes with the
+            // full envelope (buildOpBlock, SEV-8) while the txpool stage stores the signing
+            // preimage — consuming the optional trailer lets both layouts pass the trailing-
+            // bytes check. The consumed values are scratch for no-sig readers, which source
+            // the signature from the tars signature blob.
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        // Return the first decode error before ListEnd parity — if decodeItems(v,r,s)
+        // failed, the cursor may be mid-field and ListEnd would report a misleading
+        // "fields exceed payload" instead of the real root cause.
+        if (decodeError != nullptr)
+        {
+            return decodeError;
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        // op-geth ListEnd parity: reject if fields crossed the declared payload boundary.
+        if (in.data() != nullptr &&
+            in.data() - payloadStart != static_cast<std::ptrdiff_t>(payloadLength))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedListElements,
+                "EIP1559 tx: fields exceed the declared RLP list payload length");
+        }
+        return decodeError;
+    }
+};
+
+struct DepositTxHandler : Web3TxHandler
+{
+    // Full RLP: 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])
+    // — self-contained inline (consistent with the other typed handlers in this file); the 8-field
+    // unsigned layout's field order/types verified against op-geth DepositTx; field-by-field
+    // layout and to-nilability behaviour cross-checked against op-geth's deposit encoding.
+    // `to` nilability changes the RLP shape (empty string vs 20-byte address),
+    // so the contract-creation branch must be encoded separately.
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        out.push_back(static_cast<bcos::byte>(TransactionType::Deposit));
+        // isSystemTransaction uses uint32_t (not uint8_t): RLPEncode.h's uint8_t generic scalar
+        // encoding odr-uses the non-template toCompactBigEndian(byte, unsigned) overload, whose
+        // only definition lives in DataConvertUtility.cpp rather than a header (a pre-existing
+        // bcos-utilities header/library boundary defect); uint32_t only matches in-header
+        // templates and produces identical bytes.
+        const uint32_t isSystemTransactionByte = tx.isSystemTx ? 1 : 0;
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.sourceHash, tx.from, *tx.to, tx.mint, tx.value, tx.gasLimit,
+                isSystemTransactionByte, tx.data);
+        }
+        else
+        {
+            codec::rlp::encode(out, tx.sourceHash, tx.from, bcos::bytesConstRef{}, tx.mint,
+                tx.value, tx.gasLimit, isSystemTransactionByte, tx.data);
+        }
+        return out;
+    }
+
+    // deposit has no signature: the signing preimage is the full envelope (aligned with
+    // op-geth DepositTx.SigningHash, used for extraTransactionBytes).
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override { return encode(tx); }
+
+    // RLP header (length computation): sum of the 8 field lengths (excluding the type byte —
+    // consistent with the other typed handlers).
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.sourceHash);  // h256
+        h.payloadLength += codec::rlp::length(tx.from);        // Address
+        // to (optional Address): empty string 0x80 takes 1 byte, or 20-byte address + 1-byte length
+        // header
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.mint);      // u256
+        h.payloadLength += codec::rlp::length(tx.value);     // u256
+        h.payloadLength += codec::rlp::length(tx.gasLimit);  // uint64
+        h.payloadLength += 1;  // isSystemTransaction (0x80 empty string or 0x01)
+        h.payloadLength += codec::rlp::length(tx.data);  // bytes
+        return h;
+    }
+
+    // Decode: 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])
+    // ⚠️ decode contract: typed handler is self-contained (consumes the type byte + list header
+    // itself); the dispatcher (Web3Transaction::decode) does not trim the type byte first.
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool /*withSig*/) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::Deposit))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::Deposit;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "deposit: expected RLP list");
+        }
+        // Fields must stay within the declared list payload (op-geth ListEnd parity).
+        bcos::byte* const payloadStart = in.data();
+        auto const payloadLength = head.payloadLength;
+        // Check and propagate errors on every field decode (must not swallow silently)
+        if (auto err = codec::rlp::decode(in, out.sourceHash); err != nullptr)
+            return err;  // h256
+        if (auto err = codec::rlp::decode(in, out.from); err != nullptr)
+            return err;  // Address
+        // to (optional Address; empty string 0x80 = nullopt contract creation)
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto err = codec::rlp::decode(in, addr); err != nullptr)
+                return err;
+            out.to.emplace(addr);
+        }
+        // Width note: this layer is display-grade — mint/value/gas go through the shared RLP
+        // UnsignedIntegral width gate (RLPDecode.h: payloadLength > digits/8 → UnexpectedLength),
+        // so over-wide integers are REJECTED here too, matching the consensus path's accept set
+        // (no silent truncation). Only non-canonical prefixes (leading zeros / bare 0x00) remain
+        // display-layer-tolerant; the consensus path additionally rejects those via
+        // decodeDepositEnvelope (OpstackExecutor.h, integerPayloadLength canonicality checks).
+        if (auto err = codec::rlp::decode(in, out.mint); err != nullptr)
+            return err;  // u256
+        if (auto err = codec::rlp::decode(in, out.value); err != nullptr)
+            return err;  // u256
+        if (auto err = codec::rlp::decode(in, out.gasLimit); err != nullptr)
+            return err;  // uint64
+        // ⚠️ isSystemTransaction cannot use codec::rlp::decode(bool) (RLPDecode.h:200-217
+        // requires payloadLength==1 and would report UnexpectedLength for the golden 0x80 empty
+        // string). Byte semantics are required: empty string 0x80 → false (op-geth RLP nil);
+        // single byte 0x01 → true; anything else is an error.
+        {
+            // Zero-copy view into the input (not bcos::bytes, which heap-allocates per decode).
+            bcos::bytesRef raw{};
+            if (auto err = codec::rlp::decode(in, raw); err != nullptr)
+                return err;
+            if (raw.empty())
+            {
+                out.isSystemTx = false;
+            }
+            else if (raw.size() == 1 && raw[0] == 1)
+            {
+                out.isSystemTx = true;
+            }
+            else
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedLength,
+                    "deposit: invalid isSystemTransaction value");
+            }
+        }
+        if (auto err = codec::rlp::decode(in, out.data); err != nullptr)
+            return err;  // bytes
+        out.nonce = 0;   // deposit nonce is always 0
+        // op-geth ListEnd parity: reject if fields crossed the declared payload boundary.
+        if (in.data() != nullptr &&
+            in.data() - payloadStart != static_cast<std::ptrdiff_t>(payloadLength))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedListElements,
+                "deposit tx: fields exceed the declared RLP list payload length");
+        }
+        return nullptr;
+    }
+};
+
+struct EIP4844TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerBlobGas);
+        h.payloadLength += codec::rlp::length(tx.blobVersionedHashes);
+        return h;
+    }
+
+    // Signing preimage: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = headerTxBase(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP4844));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.maxFeePerBlobGas);
+        codec::rlp::encode(out, tx.blobVersionedHashes);
+        return out;
+    }
+
+    // Full RLP: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes,
+    // signature_y_parity, signature_r, signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = header(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP4844));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.maxFeePerBlobGas);
+        codec::rlp::encode(out, tx.blobVersionedHashes);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP4844))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP4844;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        // Fields must stay within the declared list payload (op-geth ListEnd parity).
+        bcos::byte* const payloadStart = in.data();
+        auto const payloadLength = head.payloadLength;
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.maxFeePerBlobGas, out.blobVersionedHashes);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig || !in.empty())
+        {
+            // withSig decodes the wire envelope's trailing (yParity, r, s). The no-sig decode
+            // may meet them too: sealed OP blocks overwrite extraTransactionBytes with the
+            // full envelope (buildOpBlock, SEV-8) while the txpool stage stores the signing
+            // preimage — consuming the optional trailer lets both layouts pass the trailing-
+            // bytes check. The consumed values are scratch for no-sig readers, which source
+            // the signature from the tars signature blob.
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        // Return the first decode error before ListEnd parity — if decodeItems(v,r,s)
+        // failed, the cursor may be mid-field and ListEnd would report a misleading
+        // "fields exceed payload" instead of the real root cause.
+        if (decodeError != nullptr)
+        {
+            return decodeError;
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        // op-geth ListEnd parity: reject if fields crossed the declared payload boundary.
+        if (in.data() != nullptr &&
+            in.data() - payloadStart != static_cast<std::ptrdiff_t>(payloadLength))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedListElements,
+                "EIP4844 tx: fields exceed the declared RLP list payload length");
+        }
+        return decodeError;
+    }
+};
+
+struct EIP7702TxHandler : Web3TxHandler
+{
+    static codec::rlp::Header headerTxBase(const Web3Transaction& tx) noexcept
+    {
+        codec::rlp::Header h{.isList = true};
+        h.payloadLength += codec::rlp::length(tx.chainId.value_or(0));
+        h.payloadLength += codec::rlp::length(tx.nonce);
+        h.payloadLength += codec::rlp::length(tx.maxPriorityFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.maxFeePerGas);
+        h.payloadLength += codec::rlp::length(tx.gasLimit);
+        h.payloadLength += (tx.to.has_value()) ? (Address::SIZE + 1) : 1;
+        h.payloadLength += codec::rlp::length(tx.value);
+        h.payloadLength += codec::rlp::length(tx.data);
+        h.payloadLength += codec::rlp::length(tx.accessList);
+        h.payloadLength += codec::rlp::length(tx.authorizationList);
+        return h;
+    }
+
+    // Signing preimage: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, authorization_list])
+    bcos::bytes encodeForSign(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = headerTxBase(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP7702));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value().ref());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.authorizationList);
+        return out;
+    }
+
+    // Full RLP: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas,
+    // gas_limit, destination, amount, data, access_list, authorization_list, signature_y_parity,
+    // signature_r, signature_s])
+    bcos::bytes encode(const Web3Transaction& tx) const override
+    {
+        bcos::bytes out;
+        auto head = header(tx);
+        out.reserve(1 + codec::rlp::lengthOfLength(head.payloadLength) + head.payloadLength);
+        out.push_back(static_cast<bcos::byte>(TransactionType::EIP7702));
+        codec::rlp::encodeHeader(out, head);
+        codec::rlp::encode(out, tx.chainId.value_or(0));
+        codec::rlp::encode(out, tx.nonce);
+        codec::rlp::encode(out, tx.maxPriorityFeePerGas);
+        codec::rlp::encode(out, tx.maxFeePerGas);
+        codec::rlp::encode(out, tx.gasLimit);
+        if (tx.to.has_value())
+        {
+            codec::rlp::encode(out, tx.to.value());
+        }
+        else
+        {
+            out.push_back(codec::rlp::BYTES_HEAD_BASE);
+        }
+        codec::rlp::encode(out, tx.value);
+        codec::rlp::encode(out, tx.data);
+        codec::rlp::encode(out, tx.accessList);
+        codec::rlp::encode(out, tx.authorizationList);
+        codec::rlp::encode(out, tx.signatureV);
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        codec::rlp::encode(out, trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return out;
+    }
+
+    // RLP header (length computation)
+    codec::rlp::Header header(const Web3Transaction& tx) const override
+    {
+        auto h = headerTxBase(tx);
+        h.payloadLength += 1;
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureR)));
+        h.payloadLength += codec::rlp::length(trimLeadingZeroBytes(bcos::ref(tx.signatureS)));
+        return h;
+    }
+
+    // Decode: 0x04 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
+    // destination, amount, data, access_list, authorization_list, yParity, r, s])
+    bcos::Error::UniquePtr decode(
+        bcos::bytesRef& in, Web3Transaction& out, bool withSig) const override
+    {
+        if (in.empty())
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] != static_cast<bcos::byte>(TransactionType::EIP7702))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnsupportedTransactionType,
+                "Unsupported transaction type");
+        }
+        out.type = TransactionType::EIP7702;
+        in = in.getCroppedData(1);
+        auto&& [e, head] = codec::rlp::decodeHeader(in);
+        if (e != nullptr)
+        {
+            return std::move(e);
+        }
+        if (!head.isList)
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnexpectedString, "Unexpected String");
+        }
+        // Fields must stay within the declared list payload (op-geth ListEnd parity).
+        bcos::byte* const payloadStart = in.data();
+        auto const payloadLength = head.payloadLength;
+        uint64_t chainId = 0;
+        if (auto error = codec::rlp::decodeItems(in, chainId, out.nonce, out.maxPriorityFeePerGas);
+            error != nullptr)
+        {
+            return error;
+        }
+        out.chainId.emplace(chainId);
+        if (auto error = codec::rlp::decode(in, out.maxFeePerGas); error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.gasLimit); error != nullptr)
+        {
+            return error;
+        }
+
+        if (in.empty()) [[unlikely]]
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::InputTooShort, "Input too short");
+        }
+        if (in[0] == codec::rlp::BYTES_HEAD_BASE)
+        {
+            out.to = std::nullopt;
+            in = in.getCroppedData(1);
+        }
+        else
+        {
+            Address addr{};
+            if (auto error = codec::rlp::decode(in, addr); error != nullptr)
+            {
+                return error;
+            }
+            out.to.emplace(addr);
+        }
+
+        if (auto error = codec::rlp::decodeItems(in, out.value, out.data, out.accessList);
+            error != nullptr)
+        {
+            return error;
+        }
+
+        if (auto error = codec::rlp::decode(in, out.authorizationList); error != nullptr)
+        {
+            return error;
+        }
+
+        bcos::Error::UniquePtr decodeError = nullptr;
+        if (withSig || !in.empty())
+        {
+            // withSig decodes the wire envelope's trailing (yParity, r, s). The no-sig decode
+            // may meet them too: sealed OP blocks overwrite extraTransactionBytes with the
+            // full envelope (buildOpBlock, SEV-8) while the txpool stage stores the signing
+            // preimage — consuming the optional trailer lets both layouts pass the trailing-
+            // bytes check. The consumed values are scratch for no-sig readers, which source
+            // the signature from the tars signature blob.
+            decodeError =
+                codec::rlp::decodeItems(in, out.signatureV, out.signatureR, out.signatureS);
+            // For EIP-2718 typed txs the v field is y_parity (0 or 1): signatureV > 1 is invalid
+            // input (same for EIP-2930/1559/4844/7702); silently accepting it would hide bad
+            // transactions.
+            if (decodeError == nullptr && out.signatureV > 1)
+            {
+                return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::InvalidVInSignature,
+                    "typed tx y_parity must be 0 or 1");
+            }
+        }
+        // Return the first decode error before ListEnd parity — if decodeItems(v,r,s)
+        // failed, the cursor may be mid-field and ListEnd would report a misleading
+        // "fields exceed payload" instead of the real root cause.
+        if (decodeError != nullptr)
+        {
+            return decodeError;
+        }
+        if (withSig)
+        {
+            // rehandle signature and chainId
+            padSignature(out.signatureR, out.signatureS);
+        }
+        // op-geth ListEnd parity: reject if fields crossed the declared payload boundary.
+        if (in.data() != nullptr &&
+            in.data() - payloadStart != static_cast<std::ptrdiff_t>(payloadLength))
+        {
+            return BCOS_ERROR_UNIQUE_PTR(codec::rlp::DecodingError::UnexpectedListElements,
+                "EIP7702 tx: fields exceed the declared RLP list payload length");
+        }
+        return decodeError;
+    }
+};
+}  // namespace
+
+Web3TxHandler& handlerFor(TransactionType type)
+{
+    static LegacyTxHandler legacy;
+    static EIP2930TxHandler eip2930;
+    static EIP1559TxHandler eip1559;
+    static EIP4844TxHandler eip4844;
+    static DepositTxHandler deposit;
+    static EIP7702TxHandler eip7702;
+    switch (type)
+    {
+    case TransactionType::Legacy:
+        return legacy;
+    case TransactionType::EIP2930:
+        return eip2930;
+    case TransactionType::EIP1559:
+        return eip1559;
+    case TransactionType::EIP4844:
+        return eip4844;
+    case TransactionType::Deposit:
+        return deposit;
+    case TransactionType::EIP7702:
+        return eip7702;
+    default:
+        break;
+    }
+    // Unknown TransactionType: a new enum value was added without updating this switch. Return a
+    // no-op sentinel handler instead of falling back to Legacy (which would silently decode/encode
+    // as the wrong format producing garbage fields); encode/encodeForSign return empty bytes
+    // (fail-safe) and decode returns UnsupportedTransactionType.
+    // ERROR, not FATAL: the fatal level makes the log sink call std::abort(), which would kill
+    // the process instead of degrading to the fail-safe sentinel below.
+    BCOS_LOG(ERROR) << "handlerFor: unhandled TransactionType " << static_cast<int>(type)
+                    << " — update the switch to handle the new type";
+    static struct : Web3TxHandler
+    {
+        bcos::bytes encodeForSign(const Web3Transaction&) const override { return {}; }
+        bcos::bytes encode(const Web3Transaction&) const override { return {}; }
+        codec::rlp::Header header(const Web3Transaction&) const override
+        {
+            return {.isList = true, .payloadLength = 0};
+        }
+        bcos::Error::UniquePtr decode(bcos::bytesRef&, Web3Transaction&, bool) const override
+        {
+            return BCOS_ERROR_UNIQUE_PTR(
+                codec::rlp::DecodingError::UnsupportedTransactionType, "Unknown transaction type");
+        }
+    } sentinel;
+    return sentinel;
+}
+}  // namespace bcos::rpc
+
+// AccessListEntry RLP codec overloads — defined here (not in Web3Transaction.cpp) because the
+// handlers are the primary consumer: they encode/decode tx.accessList. The three using-declarations
+// above make these visible at the template POI so the generic codec can find them.
+namespace bcos::codec::rlp
+{
+using namespace bcos::rpc;
+Header header(const AccessListEntry& entry) noexcept
+{
+    auto len = length(entry.storageKeys);
+    return {.isList = true, .payloadLength = Address::SIZE + 1 + len};
+}
+
+size_t length(AccessListEntry const& entry) noexcept
+{
+    auto head = header(entry);
+    return lengthOfLength(head.payloadLength) + head.payloadLength;
+}
+
+void encode(bcos::bytes& out, const AccessListEntry& entry) noexcept
+{
+    encodeHeader(out, header(entry));
+    encode(out, entry.account.ref());
+    encode(out, entry.storageKeys);
+}
+
+bcos::Error::UniquePtr decode(bcos::bytesRef& in, AccessListEntry& out) noexcept
+{
+    return decode(in, out.account, out.storageKeys);
+}
+
+Header header(const AuthorizationListEntry& entry) noexcept
+{
+    auto len = codec::rlp::length(entry.chainId) + Address::SIZE + 1 +
+               codec::rlp::length(entry.nonce) +
+               codec::rlp::length(static_cast<uint64_t>(entry.yParity)) +
+               codec::rlp::length(entry.r) + codec::rlp::length(entry.s);
+    return {.isList = true, .payloadLength = len};
+}
+
+size_t length(AuthorizationListEntry const& entry) noexcept
+{
+    auto head = header(entry);
+    return lengthOfLength(head.payloadLength) + head.payloadLength;
+}
+
+void encode(bcos::bytes& out, const AuthorizationListEntry& entry) noexcept
+{
+    encodeHeader(out, header(entry));
+    encode(out, entry.chainId);
+    encode(out, entry.address.ref());
+    encode(out, entry.nonce);
+    encode(out, static_cast<uint64_t>(entry.yParity));
+    encode(out, entry.r);
+    encode(out, entry.s);
+}
+}  // namespace bcos::codec::rlp

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.h
@@ -1,0 +1,47 @@
+// bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.h
+// ⚠️ isSystemTransaction encoding workaround: DepositTxHandler::encode() encodes it as uint32_t
+// (not uint8_t) because RLPEncode.h's generic uint8_t encoding odr-uses the non-template
+// toCompactBigEndian(byte, unsigned), defined only in DataConvertUtility.cpp (a pre-existing
+// bcos-utilities header/library boundary defect). uint32_t matches in-header templates and emits
+// the identical 1-byte RLP (0x80 or 0x01); switch back to uint8_t once the defect is fixed.
+#pragma once
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/Error.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <json/json.h>
+#include <cstdint>
+
+namespace bcos::rpc
+{
+class Web3Transaction;
+// TransactionType is defined in Web3Transaction.h (enum class : uint8_t); forward-declare the
+// underlying type so handlerFor can be declared without pulling in the whole header.
+enum class TransactionType : uint8_t;
+// NOTE: Header is actually bcos::codec::rlp::Header (Common.h:45), so it must be included, not
+// forward-declared. The include must stay OUTSIDE the namespace: expanding Common.h inside
+// namespace bcos::rpc would resolve `namespace bcos::codec::rlp` as a nested
+// bcos::rpc::bcos::codec::rlp, polluting the namespace.
+
+struct Web3TxHandler
+{
+    virtual ~Web3TxHandler() = default;
+    // Signing preimage (RLP without type byte or signature)
+    virtual bcos::bytes encodeForSign(const Web3Transaction&) const = 0;
+    // Full RLP (with type byte for typed transactions)
+    virtual bcos::bytes encode(const Web3Transaction&) const = 0;
+    // RLP header (length computation)
+    virtual bcos::codec::rlp::Header header(const Web3Transaction&) const = 0;
+    // Decode (populates Web3Transaction; withSig controls whether the signature is parsed).
+    // ⚠️ Returns Error::UniquePtr (not void): decode errors must propagate, not be silently
+    // swallowed.
+    virtual bcos::Error::UniquePtr decode(
+        bcos::bytesRef&, Web3Transaction&, bool withSig) const = 0;
+};
+
+// Dispatch by type via a switch over the known type bytes. Unknown types get a fail-loud
+// no-op sentinel (encode returns empty, decode reports UnsupportedTransactionType, ERROR log) —
+// deliberately NOT a Legacy fallback: silently coding a typed payload as legacy would produce
+// garbage fields (see Web3TxHandler.cpp's sentinel note).
+Web3TxHandler& handlerFor(TransactionType type);
+}  // namespace bcos::rpc

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -9,9 +9,12 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-utilities/DataConvertUtility.h>
 
 #include <boost/test/unit_test.hpp>
 using namespace bcos;
@@ -21,6 +24,28 @@ namespace bcos::test
 {
 namespace
 {
+// Local factories — Web3ResponseTest.cpp has no makeReceipt/makeWeb3Tx helpers; these mirror the
+// construction in combineReceiptResponseShapesReceipt so the OP-field / deposit / 4844 tests below
+// can stay compact.
+bcos::protocol::TransactionReceipt::Ptr makeReceipt(bcos::protocol::BlockFactory::Ptr blockFactory)
+{
+    auto receiptFactory = blockFactory->receiptFactory();
+    std::vector<bcos::protocol::LogEntry> logs;
+    auto receipt = receiptFactory->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", logs, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    receipt->setTransactionIndex(0);
+    return receipt;
+}
+
+bcos::protocol::Transaction::Ptr makeWeb3Tx(bcos::protocol::BlockFactory::Ptr blockFactory,
+    std::string const& chainId, std::string const& groupId)
+{
+    auto txFactory = blockFactory->transactionFactory();
+    return txFactory->createTransaction(0, "0x1234567890123456789012345678901234567890",
+        bcos::bytes{0x0a}, "0x2", 100, chainId, groupId, 0);
+}
+
 // calculateHash routes headers with ethBlockVersion != NON_ETH through
 // EthBlockHeader::validate, which demands every mandatory and fork-gated PRAGUE field —
 // fill them all so the header hashes. Distinctively named for unity-build safety.
@@ -72,6 +97,52 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
     BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x0");
     BOOST_CHECK(result.isMember("withdrawalsRoot"));
     BOOST_CHECK(result.isMember("logsBloom"));
+}
+
+// D2 U1/U2: gasLimit / parentBeaconBlockRoot read from the header with PBFT-compat fallbacks
+BOOST_AUTO_TEST_CASE(combineBlockResponseGasLimitAndParentBeaconBlockRoot)
+{
+    // Unset header fields (PBFT-style: no production path writes them) -> legacy fallbacks
+    {
+        auto block = m_blockFactory->createBlock();
+        auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+        header->setNumber(1);
+        header->setGasUsed(u256(0));
+        header->setTimestamp(1000);
+        header->calculateHash(*hashImpl);
+        block->setBlockHeader(header);
+
+        Json::Value result(Json::objectValue);
+        combineBlockResponse(result, *block, /*fullTxs=*/false);
+        BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30M fallback
+        BOOST_CHECK_EQUAL(result["parentBeaconBlockRoot"].asString(),
+            "0x0000000000000000000000000000000000000000000000000000000000000000");
+        BOOST_CHECK(!result.isMember("requestsHash"));  // PBFT/unset -> absent (op-geth omitempty)
+    }
+    // Set header fields (engine-built block: rebuildOpEthHeader / applyEthGenesisHeader)
+    // -> exact round-trip
+    {
+        auto block = m_blockFactory->createBlock();
+        auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+        header->setNumber(2);
+        header->setGasUsed(u256(21000));
+        header->setTimestamp(2000);
+        header->setGasLimit(u256(3000000000));
+        header->setParentBeaconBlockRoot(
+            crypto::HashType("0x1111111111111111111111111111111111111111111111111111111111111111"));
+        header->setRequestsHash(
+            crypto::HashType("0x2222222222222222222222222222222222222222222222222222222222222222"));
+        header->calculateHash(*hashImpl);
+        block->setBlockHeader(header);
+
+        Json::Value result(Json::objectValue);
+        combineBlockResponse(result, *block, /*fullTxs=*/false);
+        BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0xb2d05e00");  // 3e9 round-trip
+        BOOST_CHECK_EQUAL(result["parentBeaconBlockRoot"].asString(),
+            "0x1111111111111111111111111111111111111111111111111111111111111111");
+        BOOST_CHECK_EQUAL(result["requestsHash"].asString(),
+            "0x2222222222222222222222222222222222222222222222222222222222222222");
+    }
 }
 
 BOOST_AUTO_TEST_CASE(combineBlockResponseNonGenesisComputesMiner)
@@ -202,6 +273,59 @@ BOOST_AUTO_TEST_CASE(combineTxResponseShapesTransaction)
     BOOST_CHECK(result.isMember("input"));
 }
 
+BOOST_AUTO_TEST_CASE(combineTxResponseDepositNonceFromReceiptMeta)
+{
+    // MJ-5: a deposit tx's JSON nonce must reflect the receipt's depositNonce
+    // (Regolith+ semantics — deposits carry no nonce field of their own; the value
+    // lives in the receipt and drives contract-address derivation). Without a meta
+    // the 0x0 default from combineDepositTxResponse stands.
+    auto txFactory = m_blockFactory->transactionFactory();
+
+    // Build a deposit tx whose extraTransactionBytes starts with the 0x7e type byte.
+    bcos::rpc::Web3Transaction web3Deposit;
+    web3Deposit.type = bcos::rpc::TransactionType::Deposit;
+    web3Deposit.from = bcos::Address("0xdead000000000000000000000000000000000011");
+    web3Deposit.sourceHash =
+        bcos::h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    web3Deposit.mint = bcos::u256("0x16345785d8a0000");
+    web3Deposit.nonce = 0;
+    web3Deposit.isSystemTx = false;
+    auto tarsTx = web3Deposit.takeToTarsTransaction();
+    bcos::h256 arbitraryHash("0303030303030303030303030303030303030303030303030303030303030303");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    auto receipt = makeReceipt(m_blockFactory);
+    protocol::OpStackReceiptMeta meta;
+    meta.deposit_nonce = 18;
+    meta.deposit_receipt_version = 1;
+    receipt->setOpStackMeta(std::move(meta));
+
+    bcos::crypto::HashType blockHash;
+    blockHash[0] = 0x77;
+
+    Json::Value result(Json::objectValue);
+    combineTxResponse(result, *tx, *receipt, blockHash);
+    BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x12");  // 18 = depositNonce
+    // MN-6: the tx JSON surfaces depositReceiptVersion from the meta like op-geth does
+    // (internal/ethapi/api.go:1210-1213); 1 == Regolith receipt version.
+    BOOST_CHECK_EQUAL(result["depositReceiptVersion"].asString(), "0x1");
+
+    // Without a meta (or without deposit_nonce) the 0x0 default stands.
+    auto receipt2 = makeReceipt(m_blockFactory);
+    Json::Value result2(Json::objectValue);
+    combineTxResponse(result2, *tx, *receipt2, blockHash);
+    BOOST_CHECK_EQUAL(result2["nonce"].asString(), "0x0");
+    BOOST_CHECK(!result2.isMember("depositReceiptVersion"));
+
+    // The no-receipt overload keeps the 0x0 default too.
+    Json::Value result3(Json::objectValue);
+    combineTxResponse(result3, *tx, /*transactionIndex=*/0, /*blockNumber=*/12, blockHash);
+    BOOST_CHECK_EQUAL(result3["nonce"].asString(), "0x0");
+}
+
 BOOST_AUTO_TEST_CASE(combineReceiptResponseShapesReceipt)
 {
     auto txFactory = m_blockFactory->transactionFactory();
@@ -230,6 +354,351 @@ BOOST_AUTO_TEST_CASE(combineReceiptResponseShapesReceipt)
     BOOST_CHECK(result.isMember("gasUsed"));
     BOOST_CHECK(result.isMember("logs"));
     BOOST_CHECK(result["logs"].isArray());
+}
+
+BOOST_AUTO_TEST_CASE(combineReceiptResponseEmitsOpExtensionFieldsFromMeta)
+{
+    auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+    BOOST_REQUIRE(tx);
+    // D8 (review ①): non-deposit from must be the checksum of the RAW sender bytes. Install a raw
+    // 20-byte sender; if the read side re-encoded a hex-string (double-encoded) sender this
+    // assertion would fail — that is exactly the bug review ① caught on the write side. The
+    // address carries mixed-case hex letters (0x5aAe...BeAed) so EIP-55 checksum casing is
+    // actually observable — an all-digit address makes toChecksumAddress a no-op and could never
+    // regress-catch.
+    tx->forceSender(bcos::fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"));
+
+    auto receipt = makeReceipt(m_blockFactory);
+    BOOST_REQUIRE(receipt);
+    protocol::OpStackReceiptMeta meta;
+    // D2 (P4-1): ALL 13 mappings positively asserted — a wrong JSON key or value on any field
+    // would otherwise pass (empty-meta test only proves absence-when-empty). Distinct values so
+    // cross-field mixups are caught too.
+    meta.l1_gas_price = bcos::u256(5);
+    meta.l1_gas_used = 6;
+    meta.l1_fee = bcos::u256(10);
+    meta.l1_blob_base_fee = bcos::u256(11);
+    meta.l1_base_fee_scalar = 12;
+    meta.l1_blob_base_fee_scalar = 13;
+    meta.operator_fee_scalar = 14;
+    meta.operator_fee_constant = 15;
+    meta.da_footprint_gas_scalar = 16;
+    meta.da_footprint = 17;
+    meta.deposit_nonce = 18;
+    meta.deposit_receipt_version = 19;
+    meta.operator_fee = bcos::u256(20);
+    receipt->setOpStackMeta(std::move(meta));
+
+    bcos::crypto::HashType blockHash;
+    blockHash[0] = 0x99;
+
+    Json::Value result = Json::objectValue;
+    combineReceiptResponse(result, *receipt, *tx, blockHash);
+
+    BOOST_CHECK_EQUAL(result["l1GasPrice"].asString(), "0x5");
+    BOOST_CHECK_EQUAL(result["l1GasUsed"].asString(), "0x6");
+    BOOST_CHECK_EQUAL(result["l1Fee"].asString(), "0xa");
+    BOOST_CHECK_EQUAL(result["l1BlobBaseFee"].asString(), "0xb");
+    BOOST_CHECK_EQUAL(result["l1BaseFeeScalar"].asString(), "0xc");
+    BOOST_CHECK_EQUAL(result["l1BlobBaseFeeScalar"].asString(), "0xd");
+    BOOST_CHECK_EQUAL(result["operatorFeeScalar"].asString(), "0xe");
+    BOOST_CHECK_EQUAL(result["operatorFeeConstant"].asString(), "0xf");
+    BOOST_CHECK_EQUAL(result["daFootprintGasScalar"].asString(), "0x10");
+    BOOST_CHECK_EQUAL(result["blobGasUsed"].asString(), "0x11");  // ← da_footprint (Jovian 复用)
+    BOOST_CHECK_EQUAL(result["depositNonce"].asString(), "0x12");
+    BOOST_CHECK_EQUAL(result["depositReceiptVersion"].asString(), "0x13");
+    BOOST_CHECK_EQUAL(result["operatorFee"].asString(), "0x14");  // FISCO 扩展
+    // from = checksum of the raw sender bytes (review ①). Pinned against the independently-known
+    // EIP-55 vector 0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed (deliberately NOT derived via the
+    // same toChecksumAddress under test, so a checksum-casing regression is actually caught).
+    BOOST_CHECK_EQUAL(result["from"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+}
+
+// Important #1 (whole-branch review): receipt `type` for a Web3 tx must equal the EIP-2718 kind
+// byte. The write side stores encodeForSign() (RLP WITHOUT the type byte) in extraTransactionBytes
+// for typed non-deposit txs, so byte-sniffing extraTransactionBytes collapsed EIP-2930/1559/4844
+// receipts into Legacy 0x0 while eth_getTransactionByHash reported the correct kind.
+// combineReceiptResponse now reads the `web3TypedTxKind` tars slot (populated by
+// takeToTarsTransaction for every Web3 kind).
+BOOST_AUTO_TEST_CASE(combineReceiptResponseTypedTxKindType)
+{
+    auto makeWeb3TarsTx = [&](bcos::rpc::Web3Transaction web3Tx) {
+        auto tarsTx = web3Tx.takeToTarsTransaction();
+        // D4: manual extraTransactionHash so combineReceiptResponse:19 tx.hash() does not throw.
+        bcos::h256 arbitraryHash(
+            "0303030303030303030303030303030303030303030303030303030303030303");
+        tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+        return std::make_shared<bcostars::protocol::TransactionImpl>(
+            [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+    };
+
+    // EIP-1559 (0x02): previously misreported as 0x0 Legacy by the byte-sniff.
+    {
+        bcos::rpc::Web3Transaction web3Tx;
+        web3Tx.type = bcos::rpc::TransactionType::EIP1559;
+        web3Tx.chainId = 1;
+        web3Tx.nonce = 0;
+        web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+        web3Tx.maxFeePerGas = bcos::u256(2);
+        web3Tx.gasLimit = 21000;
+        web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+        web3Tx.value = bcos::u256(0);
+        web3Tx.signatureR = bcos::bytes(32, 0x11);
+        web3Tx.signatureS = bcos::bytes(32, 0x22);
+        web3Tx.signatureV = 0;
+        auto tx = makeWeb3TarsTx(std::move(web3Tx));
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x2");
+    }
+    // Deposit (0x7e): full envelope stored, kind slot set to Deposit.
+    {
+        bcos::rpc::Web3Transaction web3Deposit;
+        web3Deposit.type = bcos::rpc::TransactionType::Deposit;
+        web3Deposit.from = bcos::Address("0xdead000000000000000000000000000000000011");
+        web3Deposit.sourceHash =
+            bcos::h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        web3Deposit.mint = bcos::u256("0x16345785d8a0000");
+        web3Deposit.nonce = 0;
+        web3Deposit.isSystemTx = true;
+        auto tx = makeWeb3TarsTx(std::move(web3Deposit));
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    }
+    // Legacy BCOSTransaction: web3TypedTxKind() is 0 == Legacy → 0x0.
+    {
+        auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x0");
+    }
+    // Divergence pin: a legacy-shaped envelope (first byte is the RLP list header — a byte-sniff
+    // implementation would report Legacy) whose web3TypedTxKind slot is forged to EIP-1559. The
+    // response must follow the kind slot (0x2), not the envelope's first byte (0x0). The three
+    // cases above cannot distinguish the two implementations — typed/deposit envelopes keep their
+    // type byte, so byte-sniffing renders identical output.
+    {
+        bcos::rpc::Web3Transaction legacyTx;
+        legacyTx.type = bcos::rpc::TransactionType::Legacy;
+        legacyTx.chainId = 1;
+        legacyTx.nonce = 0;
+        legacyTx.maxPriorityFeePerGas = bcos::u256(1);
+        legacyTx.maxFeePerGas = bcos::u256(2);
+        legacyTx.gasLimit = 21000;
+        legacyTx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+        legacyTx.value = bcos::u256(0);
+        legacyTx.signatureR = bcos::bytes(32, 0x11);
+        legacyTx.signatureS = bcos::bytes(32, 0x22);
+        legacyTx.signatureV = 0;
+        auto tarsTx = legacyTx.takeToTarsTransaction();
+        tarsTx.web3TypedTxKind = static_cast<tars::Char>(bcos::rpc::TransactionType::EIP1559);
+        bcos::h256 arbitraryHash(
+            "0404040404040404040404040404040404040404040404040404040404040404");
+        tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+        auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+        auto receipt = makeReceipt(m_blockFactory);
+        Json::Value result = Json::objectValue;
+        combineReceiptResponse(result, *receipt, *tx, bcos::crypto::HashType{});
+        BOOST_CHECK_EQUAL(result["type"].asString(), "0x2");
+    }
+}
+
+BOOST_AUTO_TEST_CASE(combineReceiptResponseOmitsOpFieldsWhenMetaEmpty)
+{
+    auto tx = makeWeb3Tx(m_blockFactory, chainId, groupId);
+    BOOST_REQUIRE(tx);
+    auto receipt = makeReceipt(m_blockFactory);
+    BOOST_REQUIRE(receipt);
+
+    bcos::crypto::HashType blockHash;
+    Json::Value result = Json::objectValue;
+    combineReceiptResponse(result, *receipt, *tx, blockHash);
+
+    // Empty opStackMeta → NO OP fields at all (no zero/default placeholders).
+    BOOST_CHECK(!result.isMember("l1GasPrice"));
+    BOOST_CHECK(!result.isMember("l1Fee"));
+    BOOST_CHECK(!result.isMember("l1GasUsed"));
+    BOOST_CHECK(!result.isMember("l1BlobBaseFee"));
+    BOOST_CHECK(!result.isMember("l1BaseFeeScalar"));
+    BOOST_CHECK(!result.isMember("l1BlobBaseFeeScalar"));
+    BOOST_CHECK(!result.isMember("operatorFeeScalar"));
+    BOOST_CHECK(!result.isMember("operatorFeeConstant"));
+    BOOST_CHECK(!result.isMember("daFootprintGasScalar"));
+    BOOST_CHECK(!result.isMember("blobGasUsed"));
+    BOOST_CHECK(!result.isMember("depositNonce"));
+    BOOST_CHECK(!result.isMember("depositReceiptVersion"));
+    BOOST_CHECK(!result.isMember("operatorFee"));
+}
+
+// Read-side deposit (0x7e) transaction shape. takeToTarsTransaction() does NOT fill
+// extraTransactionHash (review ③/D4), and combineTxResponse:44 calls tx.hash() which throws
+// EmptyTransactionHash on an empty one — so the test must install arbitrary 32 bytes.
+BOOST_AUTO_TEST_CASE(combineTxResponseDepositMinimalFields)
+{
+    bcos::rpc::Web3Transaction web3Deposit;
+    web3Deposit.type = bcos::rpc::TransactionType::Deposit;
+    web3Deposit.from = bcos::Address("0xdead000000000000000000000000000000000011");
+    web3Deposit.sourceHash =
+        bcos::h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    web3Deposit.mint = bcos::u256("0x16345785d8a0000");
+    web3Deposit.nonce = 0;
+    web3Deposit.isSystemTx = true;
+
+    auto tarsTx = web3Deposit.takeToTarsTransaction();
+    // D4 (review ③): manual extraTransactionHash so combineTxResponse:44 does not throw.
+    bcos::h256 arbitraryHash("0101010101010101010101010101010101010101010101010101010101010101");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+    bcostars::protocol::TransactionImpl txImpl(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    Json::Value result = Json::objectValue;
+    combineTxResponse(
+        result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+    BOOST_CHECK(result.isMember("nonce"));  // deposit nonce=0
+    BOOST_CHECK_EQUAL(result["type"].asString(), "0x7e");
+    // Deposit (0x7e) is numerically larger than every EIP type, so the explicit range checks at
+    // TransactionResponse.cpp:68/:86 exclude it from accessList / blob fields.
+    BOOST_CHECK(!result.isMember("accessList"));
+    BOOST_CHECK(!result.isMember("blobVersionedHashes"));
+}
+
+// Read-side EIP-4844 blob transaction: blobVersionedHashes / maxFeePerBlobGas branches.
+BOOST_AUTO_TEST_CASE(combineTxResponseBlob4844)
+{
+    bcos::rpc::Web3Transaction web3Tx;
+    web3Tx.type = bcos::rpc::TransactionType::EIP4844;
+    web3Tx.chainId = 1;
+    web3Tx.nonce = 0;
+    web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+    web3Tx.maxFeePerGas = bcos::u256(2);
+    web3Tx.gasLimit = 21000;
+    web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+    web3Tx.value = bcos::u256(0);
+    web3Tx.maxFeePerBlobGas = bcos::u256(3);
+    web3Tx.blobVersionedHashes = {
+        bcos::h256("c6bdd1de713471bd6cfa62dd8b5a5b42969ed09e26212d3377f3f8426d8ec210")};
+    web3Tx.signatureR = bcos::bytes(32, 0x11);
+    web3Tx.signatureS = bcos::bytes(32, 0x22);
+    web3Tx.signatureV = 0;
+
+    auto tarsTx = web3Tx.takeToTarsTransaction();
+    // D4 (review ③): manual extraTransactionHash so combineTxResponse:44 does not throw.
+    bcos::h256 arbitraryHash("0202020202020202020202020202020202020202020202020202020202020202");
+    tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+    bcostars::protocol::TransactionImpl txImpl(
+        [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+    Json::Value result = Json::objectValue;
+    combineTxResponse(
+        result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+    // Length- and value-pinned: a reintroduced resize()+append() on blobVersionedHashes (the
+    // 2N-array bug class) or reverting maxFeePerBlobGas to decimal .str() fails these.
+    BOOST_REQUIRE(result.isMember("blobVersionedHashes"));
+    BOOST_REQUIRE_EQUAL(result["blobVersionedHashes"].size(), 1u);
+    BOOST_CHECK_EQUAL(result["blobVersionedHashes"][0].asString(),
+        "0xc6bdd1de713471bd6cfa62dd8b5a5b42969ed09e26212d3377f3f8426d8ec210");
+    BOOST_REQUIRE(result.isMember("maxFeePerBlobGas"));
+    BOOST_CHECK_EQUAL(result["maxFeePerBlobGas"].asString(), "0x3");
+}
+
+// Positive serialization test for the EIP-2930 accessList and EIP-7702 authorizationList
+// branches of combineTxResponse (TransactionResponse.cpp:82-148). A wrong key name or a
+// hex-prefix/quantity drift on either list would pass a coverage-by-absence test — these
+// assertions pin the exact output shape the write side (takeToTarsTransaction) mirrors.
+BOOST_AUTO_TEST_CASE(combineTxResponseAccessAndAuthLists)
+{
+    // EIP-2930: accessList {address, storageKeys} with hex-prefixed keys.
+    {
+        bcos::rpc::Web3Transaction web3Tx;
+        web3Tx.type = bcos::rpc::TransactionType::EIP2930;
+        web3Tx.chainId = 1;
+        web3Tx.nonce = 0;
+        web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+        web3Tx.maxFeePerGas = bcos::u256(2);
+        web3Tx.gasLimit = 21000;
+        web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+        web3Tx.value = bcos::u256(0);
+        web3Tx.accessList = {{bcos::Address("0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae"),
+            {bcos::crypto::HashType(
+                "0x0000000000000000000000000000000000000000000000000000000000000003")}}};
+        web3Tx.signatureR = bcos::bytes(32, 0x11);
+        web3Tx.signatureS = bcos::bytes(32, 0x22);
+        web3Tx.signatureV = 0;
+
+        auto tarsTx = web3Tx.takeToTarsTransaction();
+        bcos::h256 arbitraryHash(
+            "0303030303030303030303030303030303030303030303030303030303030303");
+        tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+        bcostars::protocol::TransactionImpl txImpl(
+            [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+        Json::Value result = Json::objectValue;
+        combineTxResponse(
+            result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+        BOOST_REQUIRE(result.isMember("accessList"));
+        BOOST_REQUIRE(result["accessList"].isArray());
+        BOOST_REQUIRE_EQUAL(result["accessList"].size(), 1u);
+        BOOST_CHECK_EQUAL(result["accessList"][0]["address"].asString(),
+            "0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae");
+        BOOST_REQUIRE(result["accessList"][0]["storageKeys"].isArray());
+        BOOST_REQUIRE_EQUAL(result["accessList"][0]["storageKeys"].size(), 1u);
+        BOOST_CHECK_EQUAL(result["accessList"][0]["storageKeys"][0].asString(),
+            "0x0000000000000000000000000000000000000000000000000000000000000003");
+    }
+
+    // EIP-7702: authorizationList {chainId, address, nonce, yParity, r, s} — hex-quantity
+    // scalars, hex-prefixed address.
+    {
+        bcos::rpc::Web3Transaction web3Tx;
+        web3Tx.type = bcos::rpc::TransactionType::EIP7702;
+        web3Tx.chainId = 1;
+        web3Tx.nonce = 0;
+        web3Tx.maxPriorityFeePerGas = bcos::u256(1);
+        web3Tx.maxFeePerGas = bcos::u256(2);
+        web3Tx.gasLimit = 21000;
+        web3Tx.to.emplace(bcos::Address("0x1234567890123456789012345678901234567890"));
+        web3Tx.value = bcos::u256(0);
+        web3Tx.authorizationList = {
+            {bcos::u256(0x1234), bcos::Address("0xaaaa0000000000000000000000000000000000bb"),
+                /*nonce=*/7, /*yParity=*/1, bcos::u256(0x101), bcos::u256(0x202)}};
+        web3Tx.signatureR = bcos::bytes(32, 0x11);
+        web3Tx.signatureS = bcos::bytes(32, 0x22);
+        web3Tx.signatureV = 0;
+
+        auto tarsTx = web3Tx.takeToTarsTransaction();
+        bcos::h256 arbitraryHash(
+            "0404040404040404040404040404040404040404040404040404040404040404");
+        tarsTx.extraTransactionHash.assign(arbitraryHash.begin(), arbitraryHash.end());
+        bcostars::protocol::TransactionImpl txImpl(
+            [tarsTx = std::move(tarsTx)]() mutable { return &tarsTx; });
+
+        Json::Value result = Json::objectValue;
+        combineTxResponse(
+            result, txImpl, /*transactionIndex=*/3u, /*blockNumber=*/12, bcos::crypto::HashType{});
+
+        BOOST_REQUIRE(result.isMember("authorizationList"));
+        BOOST_REQUIRE(result["authorizationList"].isArray());
+        BOOST_REQUIRE_EQUAL(result["authorizationList"].size(), 1u);
+        auto const& auth = result["authorizationList"][0];
+        BOOST_CHECK_EQUAL(auth["chainId"].asString(), "0x1234");
+        BOOST_CHECK_EQUAL(auth["address"].asString(), "0xaaaa0000000000000000000000000000000000bb");
+        BOOST_CHECK_EQUAL(auth["nonce"].asString(), "0x7");
+        BOOST_CHECK_EQUAL(auth["yParity"].asString(), "0x1");
+        BOOST_CHECK_EQUAL(auth["r"].asString(), "0x101");
+        BOOST_CHECK_EQUAL(auth["s"].asString(), "0x202");
+        // Blob fields are EIP-4844-only (== EIP4844 narrowing, TransactionResponse.cpp:136): a
+        // regression to >= EIP4844 would leak maxFeePerBlobGas/blobVersionedHashes onto 7702.
+        BOOST_CHECK(!result.isMember("maxFeePerBlobGas"));
+        BOOST_CHECK(!result.isMember("blobVersionedHashes"));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -21,21 +21,22 @@
 
 #include "../common/RPCFixture.h"
 #include "bcos-utilities/DataConvertUtility.h"
-#include <ostream>
-#include <chrono>
 #include <bcos-framework/engine/AnyEngineService.h>
 #include <bcos-framework/testutils/faker/FakeLedger.h>
+#include <bcos-mempool/MemPoolImpl.h>
 #include <bcos-rpc/filter/LogMatcher.h>
 #include <bcos-rpc/jwtAuth/JwtConfig.h>
 #include <bcos-rpc/jwtAuth/JwtVerifier.h>
 #include <bcos-rpc/web3jsonrpc/model/Web3FilterRequest.h>
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
 #include <bcos-task/Task.h>
+#include <boost/test/unit_test.hpp>
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <memory>
+#include <ostream>
 #include <string_view>
-#include <boost/test/unit_test.hpp>
 
 using namespace bcos;
 using namespace bcos::rpc;
@@ -59,6 +60,8 @@ public:
         std::optional<std::uint32_t> capturedNewPayloadVersion;
         std::optional<engine::PayloadID> capturedPayloadId;
         std::optional<std::uint32_t> capturedGetPayloadVersion;
+        std::optional<bcos::protocol::BlockNumber> safeBlockNumber;
+        std::optional<bcos::protocol::BlockNumber> finalizedBlockNumber;
     };
     std::shared_ptr<State> m_state = std::make_shared<State>();
 
@@ -91,10 +94,13 @@ public:
         co_return m_state->payloadStatusResult;
     }
 
-    std::optional<bcos::protocol::BlockNumber> getSafeBlockNumber() const { return std::nullopt; }
+    std::optional<bcos::protocol::BlockNumber> getSafeBlockNumber() const
+    {
+        return m_state->safeBlockNumber;
+    }
     std::optional<bcos::protocol::BlockNumber> getFinalizedBlockNumber() const
     {
-        return std::nullopt;
+        return m_state->finalizedBlockNumber;
     }
 };
 
@@ -207,6 +213,18 @@ BOOST_AUTO_TEST_CASE(handleValidTest)
         BOOST_TEST(fromQuantity(response["result"].asString()) == 0);
     }
 
+    // method eth_gasPrice — config absent: no tx_gas_price entry in the (fresh-fixture)
+    // ledger, the handler must fall back to "0x0" (EthEndpoint::gasPrice). op-geth's
+    // gasPrice is head.baseFee + tip (>= 1e6 wei, never 0) — divergence D-GP-1,
+    // docs/2026-08-18-rpc-parity-gasprice-withdrawals.md.
+    {
+        const auto request =
+            R"({"jsonrpc":"2.0","id":541320, "method":"eth_gasPrice","params":[]})";
+        auto response = onRPCRequestWrapper(request);
+        validRespCheck(response);
+        BOOST_TEST(response["result"].asString() == "0x0");
+    }
+
     // method eth_gasPrice
     {
         m_ledger->setSystemConfig(SYSTEM_KEY_TX_GAS_PRICE, "0x99e670");
@@ -288,6 +306,34 @@ BOOST_AUTO_TEST_CASE(handleValidTest)
             R"({"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"from":"0x2a09be8823b80f337170650802d1a0f8a99fe2d8","data":"0x608060405234801561000f575f5ffd5b5060408051808201909152600b81526a12195b1b1bc815dbdc9b1960aa1b60208201525f9061003e90826100dc565b50610196565b634e487b7160e01b5f52604160045260245ffd5b600181811c9082168061006c57607f821691505b60208210810361008a57634e487b7160e01b5f52602260045260245ffd5b50919050565b601f8211156100d757805f5260205f20601f840160051c810160208510156100b55750805b601f840160051c820191505b818110156100d4575f81556001016100c1565b50505b505050565b81516001600160401b038111156100f5576100f5610044565b610109816101038454610058565b84610090565b6020601f82116001811461013b575f83156101245750848201515b5f19600385901b1c1916600184901b1784556100d4565b5f84815260208120601f198516915b8281101561016a578785015182556020948501946001909201910161014a565b508482101561018757868401515f19600387901b60f8161c191681555b50505050600190811b01905550565b61037a806101a35f395ff3fe608060405234801561000f575f5ffd5b5060043610610034575f3560e01c80634ed3885e146100385780636d4ce63c1461004d575b5f5ffd5b61004b61004636600461011d565b61006b565b005b61005561007a565b60405161006291906101d0565b60405180910390f35b5f6100768282610289565b5050565b60605f805461008890610205565b80601f01602080910402602001604051908101604052809291908181526020018280546100b490610205565b80156100ff5780601f106100d6576101008083540402835291602001916100ff565b820191905f5260205f20905b8154815290600101906020018083116100e257829003601f168201915b5050505050905090565b634e487b7160e01b5f52604160045260245ffd5b5f6020828403121561012d575f5ffd5b813567ffffffffffffffff811115610143575f5ffd5b8201601f81018413610153575f5ffd5b803567ffffffffffffffff81111561016d5761016d610109565b604051601f8201601f19908116603f0116810167ffffffffffffffff8111828210171561019c5761019c610109565b6040528181528282016020018610156101b3575f5ffd5b816020840160208301375f91810160200191909152949350505050565b602081525f82518060208401528060208501604085015e5f604082850101526040601f19601f83011684010191505092915050565b600181811c9082168061021957607f821691505b60208210810361023757634e487b7160e01b5f52602260045260245ffd5b50919050565b601f82111561028457805f5260205f20601f840160051c810160208510156102625750805b601f840160051c820191505b81811015610281575f815560010161026e565b50505b505050565b815167ffffffffffffffff8111156102a3576102a3610109565b6102b7816102b18454610205565b8461023d565b6020601f8211600181146102e9575f83156102d25750848201515b5f19600385901b1c1916600184901b178455610281565b5f84815260208120601f198516915b8281101561031857878501518255602094850194600190920191016102f8565b508482101561033557868401515f19600387901b60f8161c191681555b50505050600190811b0190555056fea2646970667358221220a57cc7c4c4b178df95e2a8c140734de9e3c49c8623eccd4425c20df3902a074f64736f6c634300081c0033"},"pending"],"id":4}))"s;
         response = onRPCRequestWrapper(request2);
         validRespCheck(response);
+    }
+
+    // eth_estimateGas must answer the minimum Viable gas limit, not the raw
+    // consumption measured under the gas-less default cap. Regression (08-24,
+    // C2 devnet): the MessagePasser withdrawal hops through a proxy
+    // DELEGATECALL, which retains 1/64 of the gas at the hop (EIP-150) — the
+    // tx consumed 59186 but reverted on-chain at exactly that limit. The fake
+    // scheduler below reproduces that shape: consumption 59186, viable only
+    // at >= 59926 — the estimate must land on 59926, and a follow-up
+    // at-limit eth_call shape (direct call, always viable) returns the
+    // consumption unchanged.
+    {
+        scheduler->viableGas = 59926;
+        scheduler->consumedGas = 59186;
+        auto request =
+            R"({"jsonrpc":"2.0","method":"eth_estimateGas","params":[{"from":"0x2a09be8823b80f337170650802d1a0f8a99fe2d8","to":"0x4200000000000000000000000000000000000016","data":"0xc2b3e5ac"},"pending"],"id":5})";
+        auto response = onRPCRequestWrapper(request);
+        validRespCheck(response);
+        BOOST_TEST(fromQuantity(response["result"].asString()) == 59926);
+
+        // Direct-call shape: every limit is viable, so the estimate is the
+        // consumption itself (fast path — no search needed).
+        scheduler->viableGas = 0;
+        response = onRPCRequestWrapper(request);
+        validRespCheck(response);
+        BOOST_TEST(fromQuantity(response["result"].asString()) == 59186);
+
+        scheduler->viableGas.reset();
     }
 }
 
@@ -460,6 +506,68 @@ BOOST_AUTO_TEST_CASE(handleEIP1559TxTest)
     // clang-format on
 }
 
+// Single-node mempool path (NodeService::memPool wired): the chainId gate must FAIL CLOSED
+// when SYSTEM_KEY_WEB3_CHAIN_ID is unconfigured — EIP-155-protected and typed txs are
+// rejected (without a node chainId to compare against, accepting them would disable EIP-155
+// replay protection), while pre-EIP-155 legacy stays exempt (nothing to compare).
+BOOST_AUTO_TEST_CASE(handleMempoolChainIdGateUnconfiguredTest)
+{
+    bcos::txpool::MemPoolImpl memPool;
+    nodeService->setMemPool(memPool);
+    // Fresh fixture: web3_chain_id is NOT set — getSystemConfig returns nullopt.
+    auto submit = [&](std::string const& rawTx) {
+        const std::string request =
+            R"({"jsonrpc":"2.0","id":1132123, "method":"eth_sendRawTransaction","params":[")" +
+            rawTx + R"("]})";
+        return onRPCRequestWrapper(request);
+    };
+    // EIP-155 protected legacy (chainId=1, v=38; etherscan 0x6f55e1...): rejected.
+    {
+        auto response = submit(
+            "0xf902ee83031ae9850256506a88831b40d094d56e4eab23cb81f43168f9f45211eb027b9ac7cc80b90284"
+            "b143044b000000000000000000000000000000000000000000000000000000000000002000000000000000"
+            "00000000000000000000000000000000000000000000000001000000000000000000000000000000000000"
+            "00000000000000000000000000200000000000000000000000000000000000000000000000000000000000"
+            "0000650000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e20000000000000000"
+            "0000000000000000000000000000000000000000000000a000000000000000000000000000000000000000"
+            "000000000000000000661d0843000000000000000000000000000000000000000000000000000000000000"
+            "01600000000000000000000000000000000000000000000000000000000000000084704316e50000000000"
+            "00000000000000000000000000000000000000000000000000006e740e551c6ee78d757128b8e476b390f8"
+            "91c54e96538e1bb4469a62105220215a000000000000000000000000000000000000000000000000000000"
+            "0000000014740e551c6ee78d757128b8e476b390f891c54e96538e1bb4469a62105220215a000000000000"
+            "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+            "0000000000000000000082ce44cffc92754f8825e1c60cadc5f54a504b769ee616e9f28a9797c2a4b84d11"
+            "542a1aa4a06a6aa60ee062a36c4fb467145b8914959e42323a13068e2475bff41c67af8dd96034675776cb"
+            "78036711c1f320b82085df5ee005ffca77959f29a0a07a226241787f06b57483d509e0befd84e5ac84d960"
+            "e881c7b0853ee1d7c63dff1b00000000000000000000000000000000000000000000000000000000000026"
+            "a04932608e9743aaa76626f082cedb5da11ff8a1ebe6b5a62a372c81393b5912aea012f36de80608ba3b0f"
+            "72f3e8f299379ce2802e64b1cbb55275ad9aaa81190b44");
+        BOOST_TEST(response.isMember("error"));
+        BOOST_TEST(response["error"]["code"].asInt() == InvalidParams);
+        BOOST_TEST(response["error"]["message"].asString() == "invalid chainId");
+    }
+    // Typed EIP-1559 (chainId=1; etherscan 0x5b2f24...): rejected via the typed-envelope guard.
+    {
+        auto response = submit(
+            "0x02f871018308b3e6808501cd2ec1d7826ac194ba1951df0c0a52af23857c5ab48b4c43a57e7ed1872700"
+            "f2d0ba3db080c001a069be171dfa805790a28f1bfcd131eb2aa8f345f601c4a3659de4ae8d624a7b89a06e"
+            "0f6ed7d035397547aeac0e5130847570f4b607350f71c1391b7cb7f9dd604c");
+        BOOST_TEST(response.isMember("error"));
+        BOOST_TEST(response["error"]["code"].asInt() == InvalidParams);
+        BOOST_TEST(response["error"]["message"].asString() == "invalid chainId");
+    }
+    // Pre-EIP-155 legacy (v=28; etherscan 0xf6ecaf...): exempt — accepted into the mempool.
+    {
+        auto response = submit(
+            "0xf86c808504a817c800825208945dc98fe6cd853f7f5a44399cfb1c60682d5d62ef887bd0a2ecdb872000"
+            "801ca0e90ef078b60e3a186fae6071c92dbfec1256f423f5a40cd5cba69ca423eb4e44a028e14398b1a105"
+            "9388cbc5eb03cfcb6f9493bdd1efd6a17e54dcabbb2eaace16");
+        validRespCheck(response);
+        BOOST_TEST(response["result"].asString() ==
+                   "0xf6ecaffaf808cdfe1d9ef02ec461f2ab5674f72f9c6f954743e0c2d74608b751");
+    }
+}
+
 BOOST_AUTO_TEST_CASE(handleEIP4844TxTest)
 {
     // L2 (OP Stack, Ecotone onwards) never admits blob transactions:
@@ -563,21 +671,21 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadVersion.has_value());
     BOOST_TEST(*testEngineService.m_state->capturedNewPayloadVersion == 4);
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload
-            .withdrawalsRoot.has_value());
+                      .withdrawalsRoot.has_value());
     BOOST_REQUIRE(
         testEngineService.m_state->capturedNewPayloadRequest->executionRequests.has_value());
     BOOST_TEST(testEngineService.m_state->capturedNewPayloadRequest->executionRequests->empty());
     BOOST_TEST(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.transactions
                    .size() == 1);
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals
-            .has_value());
+                      .has_value());
     BOOST_TEST(
         testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals->front()
             .amount == expectedLargeValue);
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed
-            .has_value());
+                      .has_value());
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload
-            .excessBlobGas.has_value());
+                      .excessBlobGas.has_value());
     BOOST_TEST(
         *testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed ==
         expectedLargeValue);
@@ -587,8 +695,8 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
 
     // Raw-bytes carrier: newPayload preserves the wire bytes verbatim (no decoding).
     BOOST_TEST(toHexStringWithPrefix(testEngineService.m_state->capturedNewPayloadRequest
-                       ->executionPayload.transactions.front()
-                       .raw) == encodedTxHex);
+                                         ->executionPayload.transactions.front()
+                                         .raw) == encodedTxHex);
 
     testEngineService.m_state->getPayloadResult->executionPayload =
         testEngineService.m_state->capturedNewPayloadRequest->executionPayload;
@@ -629,6 +737,61 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
     BOOST_TEST(!oldVersionResponse["result"].isMember("executionRequests"));
 }
 
+// D2 U3-U6: safe/finalized tag routing at the EthEndpoint layer.
+// - engine service absent (PBFT): tags keep the historical latest aliasing
+// - engine present + untracked: strict op-geth semantics -> null block
+// - engine present + tracked: routes to the tracked number (distinguished from the
+//   latest-fallback by a tracked number the ledger cannot serve -> null)
+BOOST_AUTO_TEST_CASE(safeFinalizedTagRoutingTest)
+{
+    // Self-calibrate: what "latest" resolves to on this fixture.
+    auto latestResp = onRPCRequestWrapper(
+        R"({"jsonrpc":"2.0","id":1,"method":"eth_getBlockByNumber","params":["latest",false]})");
+    BOOST_REQUIRE(!latestResp["result"].isNull());
+    auto const latestNumber = latestResp["result"]["number"].asString();
+    auto const latestNumeric = std::stoll(latestNumber.substr(2), nullptr, 16);
+
+    // U5+U6: no engine service wired (fixture default) -> safe/finalized/pending alias latest
+    for (auto tag : {"safe", "finalized", "pending"})
+    {
+        auto resp = onRPCRequestWrapper(
+            R"({"jsonrpc":"2.0","id":2,"method":"eth_getBlockByNumber","params":[")" +
+            std::string(tag) + R"(",false]})");
+        BOOST_CHECK_MESSAGE(
+            !resp["result"].isNull() && resp["result"]["number"].asString() == latestNumber,
+            tag + std::string(" aliases latest when no engine service is wired"));
+    }
+
+    // Engine wired, untracked -> null block (op-geth "safe head not known" -> NotFound)
+    TestEngineService testEngineService;
+    nodeService->engineService() =
+        std::make_shared<bcos::engine::AnyEngineService>(testEngineService);
+    for (auto tag : {"safe", "finalized"})
+    {
+        auto resp = onRPCRequestWrapper(
+            R"({"jsonrpc":"2.0","id":3,"method":"eth_getBlockByNumber","params":[")" +
+            std::string(tag) + R"(",false]})");
+        BOOST_CHECK_MESSAGE(resp["result"].isNull(),
+            tag + std::string(" returns null when untracked (strict op-geth semantics)"));
+    }
+
+    // Engine wired, tracked to a number the ledger cannot serve (FakeLedger tops out at
+    // 20 blocks; latest+1000 is far beyond) -> null (proves routing: a latest-fallback
+    // would return the latest block instead)
+    testEngineService.m_state->safeBlockNumber = latestNumeric + 1000;
+    auto resp = onRPCRequestWrapper(
+        R"({"jsonrpc":"2.0","id":4,"method":"eth_getBlockByNumber","params":["safe",false]})");
+    BOOST_CHECK(resp["result"].isNull());
+
+    // Positive routing: tracked to a servable number (== latest) -> that block, non-null.
+    // Catches an inverted has_value() regression (an always-throw passes the phases above).
+    testEngineService.m_state->safeBlockNumber = latestNumeric;
+    resp = onRPCRequestWrapper(
+        R"({"jsonrpc":"2.0","id":5,"method":"eth_getBlockByNumber","params":["safe",false]})");
+    BOOST_CHECK(!resp["result"].isNull());
+    BOOST_CHECK(resp["result"]["number"].asString() == latestNumber);
+}
+
 BOOST_AUTO_TEST_CASE(logMatcherTest)
 {
     // clang-format off
@@ -654,11 +817,19 @@ BOOST_AUTO_TEST_CASE(logMatcherTest)
         protocol::LogEntry log2(address1, {C, D}, bytes());
         auto params1 = std::make_shared<Web3FilterRequest>();
         auto params2 = std::make_shared<Web3FilterRequest>();
+        auto params3 = std::make_shared<Web3FilterRequest>();
         params2->addAddress(toHexStringWithPrefix(address1));
+        params3->addAddress(toHexStringWithPrefix(address2));
         BOOST_TEST(matcher.matches(params1, log1));
         BOOST_TEST(matcher.matches(params1, log2));
-        BOOST_TEST(!matcher.matches(params2, log1));
-        BOOST_TEST(!matcher.matches(params2, log2));
+        // Address filtering: the log side carries the address as raw bytes (OP executor) while
+        // the request side keeps the user's hex string — since the LogMatcher normalization fix
+        // the identical address must MATCH (these two assertions used to pin the pre-fix bug
+        // where a raw-bytes address could never match a hex filter).
+        BOOST_TEST(matcher.matches(params2, log1));
+        BOOST_TEST(matcher.matches(params2, log2));
+        // A different address still must not match.
+        BOOST_TEST(!matcher.matches(params3, log1));
     }
     // 2.[A] "A in first position (and anything after)"
     {

--- a/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
@@ -19,7 +19,11 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>  // c_secp256k1n* + Secp256k1Crypto
+#include <bcos-rlp-protocol/Web3TxEnvelope.h>  // web3ChainIdFromEnvelope (F4 unit tests)
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-rpc/web3jsonrpc/model/Web3TxHandler.h>
+#include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 
 using namespace bcos;
@@ -72,6 +76,86 @@ BOOST_AUTO_TEST_CASE(testLegacyTransactionDecode)
     codec::rlp::encode(encoded, tx);
     auto rawTx2 = toHexStringWithPrefix(encoded);
     BOOST_CHECK_EQUAL(rawTx, rawTx2);
+}
+
+// kyonRay R3 #1: codec::rlp::encode(out, Web3Transaction) must APPEND to a non-empty buffer
+// (the accumulate-into-buffer contract every other encode(out, x) overload provides; part-5
+// rawTransactions list encoding depends on it). A regression to overwrite semantics would
+// silently drop the first element.
+BOOST_AUTO_TEST_CASE(testEncodeAppendsToNonEmptyBuffer)
+{
+    namespace rlp = bcos::codec::rlp;
+    auto makeTx = [&](uint64_t nonce) {
+        Web3Transaction tx;
+        tx.type = rpc::TransactionType::Legacy;
+        tx.chainId = 1;
+        tx.nonce = nonce;
+        tx.maxPriorityFeePerGas = bcos::u256(10);
+        tx.maxFeePerGas = bcos::u256(10);
+        tx.gasLimit = 21000;
+        tx.to.emplace(Address("0x0100000000000000000000000000000000000001"));
+        tx.value = bcos::u256(0);
+        return tx;
+    };
+    auto a = makeTx(0);
+    auto b = makeTx(1);
+
+    bcos::bytes out;
+    rlp::encode(out, a);
+    auto aLen = out.size();
+    rlp::encode(out, b);  // must append after a
+
+    bcos::bytes aloneA;
+    rlp::encode(aloneA, a);
+    BOOST_REQUIRE_EQUAL(aLen, aloneA.size());
+    // The second encode must not clobber the first element's bytes.
+    BOOST_CHECK_EQUAL_COLLECTIONS(out.begin(), out.begin() + aLen, aloneA.begin(), aloneA.end());
+    // And both elements are present (length is the sum).
+    bcos::bytes aloneB;
+    rlp::encode(aloneB, b);
+    BOOST_CHECK_EQUAL(out.size(), aloneA.size() + aloneB.size());
+}
+
+// Legacy v values outside the legal set must be rejected with InvalidVInSignature:
+// v=0/1 (previously silently accepted as a no-op) and v=29-34 (not 27/28, not >=35).
+BOOST_AUTO_TEST_CASE(testLegacyInvalidVRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    auto makeLegacy = [&](uint64_t v) {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));
+        rlp::encode(items, static_cast<uint64_t>(10));
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, Address("0x0100000000000000000000000000000000000001"));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes{});
+        rlp::encode(items, v);
+        rlp::encode(items, bcos::bytes(32, 0x11));  // r
+        rlp::encode(items, bcos::bytes(32, 0x22));  // s
+        bcos::bytes env;
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        return env;
+    };
+    for (uint64_t v : {0ull, 1ull, 29ull, 30ull, 34ull})
+    {
+        auto bytes = makeLegacy(v);
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto e = rlp::decode(bRef, tx);
+        BOOST_REQUIRE(e != nullptr);
+        BOOST_CHECK_EQUAL(
+            e->errorCode(), static_cast<int64_t>(rlp::DecodingError::InvalidVInSignature));
+    }
+    // Control: v=27 (pre-EIP-155) and v=35 (chainId 0) decode fine.
+    for (uint64_t v : {27ull, 35ull})
+    {
+        auto bytes = makeLegacy(v);
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto e = rlp::decode(bRef, tx);
+        BOOST_CHECK(e == nullptr);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(testConstructTx)
@@ -128,6 +212,9 @@ BOOST_AUTO_TEST_CASE(testEIP2930Transaction)
     BOOST_CHECK_EQUAL(tx.value, 2000000000000000000ull);
     BOOST_CHECK_EQUAL(toHex(tx.data), "6ebaf477f83e051589c1188bcc6ddccd");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-2930 sample carries yParity=0.
+    BOOST_CHECK_EQUAL(tx.signatureV, 0u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -161,6 +248,9 @@ BOOST_AUTO_TEST_CASE(testEIP1559Transaction)
     BOOST_CHECK_EQUAL(tx.value, 2000000000000000000ull);
     BOOST_CHECK_EQUAL(toHex(tx.data), "6ebaf477f83e051589c1188bcc6ddccd");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-1559 sample carries yParity=0.
+    BOOST_CHECK_EQUAL(tx.signatureV, 0u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -239,6 +329,9 @@ BOOST_AUTO_TEST_CASE(testEIP4844Transaction)
     BOOST_CHECK_EQUAL(toHex(tx.blobVersionedHashes[1]),
         "8aaeccaf3873d07cef005aca28c39f8a9f8bdb1ec8d79ffc25afc0a4fa2ab736");
     BOOST_CHECK_EQUAL(tx.getSignatureV(), tx.chainId.value() * 2 + 35 + 1);
+    // C2 (W8 review): typed-tx signatureV is the raw y_parity, restricted to 0/1. This
+    // EIP-4844 sample carries yParity=1 (hence the +1 in getSignatureV above).
+    BOOST_CHECK_EQUAL(tx.signatureV, 1u);
     BOOST_CHECK_EQUAL(
         toHex(tx.signatureR), "36b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0");
     BOOST_CHECK_EQUAL(
@@ -249,6 +342,122 @@ BOOST_AUTO_TEST_CASE(testEIP4844Transaction)
     codec::rlp::encode(encoded, tx);
     auto rawTx2 = toHexStringWithPrefix(encoded);
     BOOST_CHECK_EQUAL(rawTx, rawTx2);
+}
+
+// C2 (W8 review): typed-tx yParity is restricted to 0/1 (Web3TxHandler rejects signatureV > 1 with
+// InvalidVInSignature). Flip the yParity wire byte of each legal typed-tx sample to 0x02
+// (single-byte self-encoding — same wire length, outer RLP prefix unaffected) and assert the
+// decoder rejects it. Wire offsets are RLP-decoding-verified: EIP-2930 field[8] at 178,
+// EIP-1559 field[9] at 184, EIP-4844 field[11] at 232.
+BOOST_AUTO_TEST_CASE(typedTxYParityOverOneRejected)
+{
+    auto byteAt = [](std::string_view hex, std::size_t byteOffset) -> int {
+        auto nibble = [](char c) -> int {
+            if (c >= '0' && c <= '9')
+            {
+                return c - '0';
+            }
+            if (c >= 'a' && c <= 'f')
+            {
+                return c - 'a' + 10;
+            }
+            return c - 'A' + 10;
+        };
+        auto pos = 2 + byteOffset * 2;  // skip "0x"
+        return nibble(hex[pos]) * 16 + nibble(hex[pos + 1]);
+    };
+    auto flipByteToTwo = [](std::string_view hex, std::size_t byteOffset) {
+        std::string out(hex);
+        auto pos = 2 + byteOffset * 2;  // skip "0x"
+        out[pos] = '0';
+        out[pos + 1] = '2';
+        return out;
+    };
+
+    // clang-format off
+    constexpr std::string_view kEIP2930RawTx = "0x01f8f205078506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7881bc16d674ec80000906ebaf477f83e051589c1188bcc6ddccdf872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c080a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    constexpr std::string_view kEIP1559RawTx = "0x02f8f805078502540be4008506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7881bc16d674ec80000906ebaf477f83e051589c1188bcc6ddccdf872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c080a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    constexpr std::string_view kEIP4844RawTx = "0x03f9012705078502540be4008506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7808204f7f872f85994de0b295669a9fd93d5f28d9ec85e40f4cb697baef842a00000000000000000000000000000000000000000000000000000000000000003a00000000000000000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c189413c07bf842a0c6bdd1de713471bd6cfa62dd8b5a5b42969ed09e26212d3377f3f8426d8ec210a08aaeccaf3873d07cef005aca28c39f8a9f8bdb1ec8d79ffc25afc0a4fa2ab73601a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+    // clang-format on
+
+    struct Sample
+    {
+        std::string_view rawTx;
+        std::size_t yParityOffset;
+        int expectedYParityByte;  // the RLP-encoded yParity currently at the offset
+    };
+    const Sample samples[] = {
+        {kEIP2930RawTx, 178, 0x80},
+        {kEIP1559RawTx, 184, 0x80},
+        {kEIP4844RawTx, 232, 0x01},
+    };
+    for (const auto& sample : samples)
+    {
+        // Guard: fail loudly if a wire offset is stale — never silently test the wrong byte.
+        BOOST_CHECK_MESSAGE(
+            byteAt(sample.rawTx, sample.yParityOffset) == sample.expectedYParityByte,
+            "yParity wire byte mismatch at offset " << sample.yParityOffset);
+
+        auto bytes = fromHexWithPrefix(flipByteToTwo(sample.rawTx, sample.yParityOffset));
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto e = codec::rlp::decode(bRef, tx);
+        BOOST_REQUIRE_MESSAGE(
+            e != nullptr, "yParity=2 must be rejected (offset " << sample.yParityOffset << ')');
+        if (e != nullptr)
+        {
+            BOOST_CHECK_EQUAL(e->errorCode(),
+                static_cast<int64_t>(codec::rlp::DecodingError::InvalidVInSignature));
+        }
+    }
+}
+
+// EIP-2 canonical-s: a malleable (high-s) signature must be rejected at decode — the shared
+// funnel for eth_sendRawTransaction (EthEndpoint); the engine newPayload path decodes through
+// the same funnel once part 5 wires it. Flipping s -> n - s recovers the same sender and would
+// otherwise execute byte-for-byte identically.
+BOOST_AUTO_TEST_CASE(highSsignatureRejectedAtDecode)
+{
+    Web3Transaction tx;
+    tx.value = 1000000000000000000;
+    tx.type = rpc::TransactionType::Legacy;
+    tx.data = {};
+    tx.to = Address("0x1e58529dAA467406645d0f4B63dec96CA0b87d70");
+    tx.nonce = 19;
+    tx.gasLimit = 210000;
+    tx.maxFeePerGas = 20000000000;
+    tx.maxPriorityFeePerGas = 20000000000;
+    tx.chainId = 31337;
+
+    auto signData = tx.encodeForSign();
+    std::string priv = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    auto key = std::make_shared<KeyImpl>(fromHex(priv));
+    auto newHash = crypto::keccak256Hash(ref(signData));
+    auto signatureImpl = bcos::crypto::Secp256k1Crypto();
+    auto keyPair = std::make_unique<Secp256k1KeyPair>(key);
+    auto signature = signatureImpl.sign(*keyPair, newHash, false);
+    tx.signatureR = {signature->begin(), signature->begin() + 32};
+    tx.signatureS = {signature->begin() + 32, signature->begin() + 64};
+    tx.signatureV = signature->back();
+
+    // Guard: libsecp256k1 signs canonical low-s — confirm before flipping, so a future
+    // libsecp256k1 behavior change fails loudly instead of silently weakening the test.
+    const u256 s = u256("0x" + toHex(tx.signatureS));
+    BOOST_REQUIRE(s <= bcos::crypto::c_secp256k1nOver2);
+
+    // Malleability flip: s' = n - s is high-s but recovers the same sender.
+    tx.signatureS = toBigEndian(bcos::crypto::c_secp256k1n - s);
+    const u256 flipped = u256("0x" + toHex(tx.signatureS));
+    BOOST_REQUIRE(flipped > bcos::crypto::c_secp256k1nOver2);
+
+    bcos::bytes encoded;
+    codec::rlp::encode(encoded, tx);
+    auto bRef = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto e = codec::rlp::decode(bRef, decoded);
+    BOOST_REQUIRE(e != nullptr);
+    BOOST_CHECK_EQUAL(
+        e->errorCode(), static_cast<int64_t>(codec::rlp::DecodingError::InvalidVInSignature));
 }
 
 BOOST_AUTO_TEST_CASE(testEIP7702Transaction)
@@ -296,6 +505,78 @@ BOOST_AUTO_TEST_CASE(testEIP7702Transaction)
     // and compare the recovered sender to the fixture's sender below.
     BOOST_CHECK_EQUAL(signHash.size(), 66);
     BOOST_CHECK_EQUAL(tx.sender(), "0x1a2e20b2fb1346f5751ec4d05f1964042f06c072");
+}
+
+// EIP-7702 authorization yParity is a uint8 on op-geth's side: an encoding wider than one byte
+// is a decode rejection there (Go rlp ErrCanonSize), while the generic UnsignedIntegral decode
+// would fold wider payloads via fromBigEndian — accepting two encodings of one tx, i.e. a
+// block-hash ambiguity / consensus split. The shared RLP width gate (RLPDecode.h: digits/8)
+// rejects payloads wider than the target type, so a >1-byte yParity fails decode with
+// "integer wider than target type". Canonicality (bare 0x00 for zero) is deliberately NOT
+// enforced at this display layer — 0x00 decodes to yParity 0, and the value-RANGE case
+// (yParity in [2,255]) is likewise accepted because EIP-7702 requires the authorization to be
+// *skipped* at execution, not rejected.
+BOOST_AUTO_TEST_CASE(authYParityOverWideRejected)
+{
+    // Entry layout [chainId, address, nonce, yParity, r, s]; all other fields canonical zero /
+    // fixed address. yParity slot is swapped per case.
+    auto makeEntry = [](std::vector<bcos::byte> yParityEncoding) {
+        std::vector<bcos::byte> payload;
+        payload.push_back(0x80);  // chainId = 0
+        payload.push_back(0x94);  // address: 20-byte string
+        payload.insert(payload.end(), 20, 0x00);
+        payload.push_back(0x80);  // nonce = 0
+        payload.insert(payload.end(), yParityEncoding.begin(), yParityEncoding.end());
+        payload.push_back(0x80);  // r = 0
+        payload.push_back(0x80);  // s = 0
+        bcos::bytes entry;
+        entry.push_back(static_cast<bcos::byte>(0xc0 + payload.size()));
+        entry.insert(entry.end(), payload.begin(), payload.end());
+        return entry;
+    };
+    auto decodeEntry = [](bcos::bytes entry) {
+        auto in = bcos::ref(entry);
+        AuthorizationListEntry out{};
+        auto e = codec::rlp::decode(in, out);
+        return std::make_pair(std::move(e), out);
+    };
+
+    // Over-wide: 0x82 0x01 0x00 = RLP string with 2-byte payload (value 256) → rejected by the
+    // shared width gate.
+    {
+        auto [e, out] = decodeEntry(makeEntry({0x82, 0x01, 0x00}));
+        BOOST_CHECK(e != nullptr);
+        if (e)
+        {
+            BOOST_CHECK(e->errorMessage().find("wider than target type") != std::string::npos);
+        }
+    }
+    // Bare 0x00 (non-canonical zero) is display-layer TOLERATED: it decodes to yParity 0. The
+    // consensus path enforces integer canonicality separately (decodeDepositEnvelope-style
+    // integerPayloadLength checks); this layer must only reject WIDTH.
+    {
+        auto [e, out] = decodeEntry(makeEntry({0x00}));
+        BOOST_REQUIRE(e == nullptr);
+        BOOST_CHECK_EQUAL(out.yParity, 0);
+    }
+    // Boundary: canonical single-item encodings still decode — 0x80 → 0, 0x01 → 1.
+    {
+        auto [e, out] = decodeEntry(makeEntry({0x80}));
+        BOOST_REQUIRE(e == nullptr);
+        BOOST_CHECK_EQUAL(out.yParity, 0);
+    }
+    {
+        auto [e, out] = decodeEntry(makeEntry({0x01}));
+        BOOST_REQUIRE(e == nullptr);
+        BOOST_CHECK_EQUAL(out.yParity, 1);
+    }
+    // Value-RANGE case: yParity=2 decodes fine (execution skips the authorization); only the
+    // encoding WIDTH is a decode error. Pins the width-vs-range boundary.
+    {
+        auto [e, out] = decodeEntry(makeEntry({0x02}));
+        BOOST_REQUIRE(e == nullptr);
+        BOOST_CHECK_EQUAL(out.yParity, 2);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(recoverAddress)
@@ -444,6 +725,749 @@ BOOST_AUTO_TEST_CASE(EIP4844Recover)
     BOOST_CHECK(re);
     auto address = toHexStringWithPrefix(addr);
     BOOST_CHECK_EQUAL(address, "0xc1b634853cb333d3ad8663715b08f41a3aec47cc");
+}
+
+// Deposit encode→decode roundtrip locks the uint32_t isSystemTransaction workaround
+// (see Web3TxHandler.h header comment) — when the underlying ODR defect is fixed and
+// the field switches back to uint8_t, this test ensures the encoded byte does not
+// silently regress.
+BOOST_AUTO_TEST_CASE(depositRoundtrip)
+{
+    Web3Transaction deposit;
+    deposit.type = rpc::TransactionType::Deposit;
+    deposit.sourceHash = h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+    deposit.from = Address("0xdead000000000000000000000000000000000011");
+    deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+    deposit.mint = u256("0x16345785d8a0000");
+    deposit.value = u256(0);
+    deposit.gasLimit = 1000000;
+    deposit.isSystemTx = true;
+    deposit.data = bcos::bytes{};
+
+    // Encode → decode roundtrip
+    auto encoded = deposit.encode();
+    auto ref = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto err = decoded.decode(ref, false);  // withSig=false, deposit has no signature
+    BOOST_REQUIRE(err == nullptr);
+
+    BOOST_CHECK(decoded.type == rpc::TransactionType::Deposit);
+    BOOST_CHECK(decoded.isSystemTx);
+    BOOST_CHECK_EQUAL(decoded.sourceHash.hex(), deposit.sourceHash.hex());
+    BOOST_CHECK_EQUAL(decoded.from.hexPrefixed(), deposit.from.hexPrefixed());
+    BOOST_CHECK(decoded.to.has_value());
+    BOOST_CHECK_EQUAL(decoded.to->hexPrefixed(), deposit.to->hexPrefixed());
+    BOOST_CHECK_EQUAL(decoded.mint, deposit.mint);
+    BOOST_CHECK_EQUAL(decoded.value, deposit.value);
+    BOOST_CHECK_EQUAL(decoded.gasLimit, deposit.gasLimit);
+
+    // Also round-trip the system-tx=false case
+    Web3Transaction nonSysDeposit;
+    nonSysDeposit.type = rpc::TransactionType::Deposit;
+    nonSysDeposit.sourceHash =
+        h256("7bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8");
+    nonSysDeposit.from = Address("0xdead000000000000000000000000000000000011");
+    nonSysDeposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+    nonSysDeposit.mint = u256(100);
+    nonSysDeposit.value = u256(0);
+    nonSysDeposit.gasLimit = 500000;
+    nonSysDeposit.isSystemTx = false;
+    nonSysDeposit.data = bcos::bytes{};
+
+    auto encoded2 = nonSysDeposit.encode();
+    auto ref2 = bcos::ref(encoded2);
+    Web3Transaction decoded2;
+    err = decoded2.decode(ref2, false);
+    BOOST_REQUIRE(err == nullptr);
+
+    BOOST_CHECK(decoded2.type == rpc::TransactionType::Deposit);
+    BOOST_CHECK(!decoded2.isSystemTx);
+    BOOST_CHECK_EQUAL(decoded2.mint, nonSysDeposit.mint);
+}
+
+// The sendRawTransaction guard in EthEndpoint.cpp checks web3Tx.type == Deposit after decoding the
+// raw bytes. The guard itself is a simple `if` + throw; the decode → type-detection path is the
+// test that verifies a valid 0x7E envelope is correctly identified. An RPC-level test would need
+// the full EthEndpoint fixture (future work).
+BOOST_AUTO_TEST_CASE(decodeDepositIdentifiesTypeForSendRawGuard)
+{
+    Web3Transaction deposit;
+    deposit.type = rpc::TransactionType::Deposit;
+    deposit.sourceHash = h256("0xabcd000000000000000000000000000000000000000000000000000000000000");
+    deposit.from = Address("0xdead000000000000000000000000000000000099");
+    deposit.to.emplace(Address("0x4200000000000000000000000000000000000011"));
+    deposit.mint = u256(1);
+    deposit.value = u256(0);
+    deposit.gasLimit = 21000;
+    deposit.isSystemTx = false;
+    deposit.data = bcos::bytes{};
+
+    auto encoded = deposit.encode();
+    BOOST_REQUIRE(!encoded.empty());
+
+    // The raw envelope must start with 0x7E (EIP-2718 type byte)
+    BOOST_CHECK_EQUAL(
+        static_cast<uint8_t>(encoded[0]), static_cast<uint8_t>(rpc::TransactionType::Deposit));
+
+    // Decode through the public codec entry point — this is the path EthEndpoint calls
+    // (codec::rlp::decode → Web3Transaction::decode) before the type-guard check.
+    auto ref = bcos::ref(encoded);
+    Web3Transaction decoded;
+    auto err = bcos::codec::rlp::decode(ref, decoded);
+    BOOST_REQUIRE(err == nullptr);
+    BOOST_CHECK(decoded.type == rpc::TransactionType::Deposit);
+    // A real sendRawTransaction call would now hit: if (web3Tx.type == Deposit) → throw
+    // InvalidParams
+}
+
+// Golden-vector deposit encoding: encode known deposit txs and compare byte-for-byte
+// against independently-verified RLP output (cross-validated against the OP Stack deposit
+// spec: 0x7E || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data])).
+// The golden hex strings were verified against an independent oracle and op-geth-shaped
+// vectors. If a future change alters the deposit encoding, this test breaks — that's
+// intentional. The 0x80 vs 0x01 isSystemTx distinction is the op-geth convention the
+// uint32_t workaround (see Web3TxHandler.h header comment) exists to preserve.
+BOOST_AUTO_TEST_CASE(depositGoldenEncoding)
+{
+    // isSystemTx=true: 0x7E || rlp([33b sourceHash, 21b from, 21b to, 9b mint,
+    //                          1b value(0), 4b gas, 1b isSystemTx(0x01), 1b data(empty)])
+    // gas = 0x0f4240 = 1000000
+    {
+        Web3Transaction deposit;
+        deposit.type = rpc::TransactionType::Deposit;
+        deposit.sourceHash =
+            h256("6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7");
+        deposit.from = Address("0xdead000000000000000000000000000000000011");
+        deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+        deposit.mint = u256("0x16345785d8a0000");
+        deposit.value = u256(0);
+        deposit.gasLimit = 1000000;
+        deposit.isSystemTx = true;
+        deposit.data = bcos::bytes{};
+
+        auto encoded = deposit.encode();
+        BOOST_CHECK_EQUAL(toHex(encoded),
+            "7ef85ba06ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"
+            "94dead000000000000000000000000000000000011"
+            "944200000000000000000000000000000000000022"
+            "88016345785d8a0000"
+            "80"
+            "830f4240"
+            "01"
+            "80");
+    }
+
+    // isSystemTx=false: 0x7E || rlp([33b sourceHash, 21b from, 21b to, 1b mint(0x64=100),
+    //                              1b value(0), 4b gas, 1b isSystemTx(0x80), 1b data(empty)])
+    // gas = 0x07a120 = 500000, list header 0xf853 (shorter: mint is 1 byte vs 9)
+    {
+        Web3Transaction deposit;
+        deposit.type = rpc::TransactionType::Deposit;
+        deposit.sourceHash =
+            h256("7bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8");
+        deposit.from = Address("0xdead000000000000000000000000000000000011");
+        deposit.to.emplace(Address("0x4200000000000000000000000000000000000022"));
+        deposit.mint = u256(100);
+        deposit.value = u256(0);
+        deposit.gasLimit = 500000;
+        deposit.isSystemTx = false;
+        deposit.data = bcos::bytes{};
+
+        auto encoded = deposit.encode();
+        BOOST_CHECK_EQUAL(toHex(encoded),
+            "7ef853a07bc967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d8"
+            "94dead000000000000000000000000000000000011"
+            "944200000000000000000000000000000000000022"
+            "64"
+            "80"
+            "8307a120"
+            "80"
+            "80");
+    }
+}
+
+// The six codecs must enforce the declared RLP list payload boundary (op-geth List/ListEnd
+// parity): a list header that under-declares its payload must not let field decoding cross
+// into the trailing bytes and read them as fields. Build a valid legacy envelope, then shrink
+// the outer list header's declared length so the fields overflow it — decode must fail.
+BOOST_AUTO_TEST_CASE(testRejectPayloadLengthOverflow)
+{
+    // A valid legacy pre-EIP-155 envelope (same raw tx as testLegacyTransactionDecode). The
+    // outer list header 0xf8 0x9b declares a 0x9b-byte payload that exactly covers the 9 items.
+    auto bytes = fromHexWithPrefix(
+        "0xf89b0c8504a817c80082520894727fc6a68321b754475c668a6abfb6e9e71c169a888ac7230489e80000afa9"
+        "059cbb000000000213ed0f886efd100b67c7e4ec0a85a7d20dc971600000000000000000000015af1d78b58c40"
+        "0026a0be67e0a07db67da8d446f76add590e54b6e92cb6b8f9835aeb67540579a27717a02d690516512020171c"
+        "1ec870f6ff45398cc8609250326be89915fb538e7bd718");
+    auto bRef = bcos::ref(bytes);
+    Web3Transaction tx{};
+    BOOST_REQUIRE(codec::rlp::decode(bRef, tx) == nullptr);
+
+    // Corrupt the declared payload length to 0x9a (one byte short): the nine fields' bytes now
+    // overflow the declared boundary by one byte. The decoder must reject (fields cross the
+    // declared payload — op-geth ListEnd errNotAtEOL), not silently read the trailing byte as
+    // part of a field.
+    bytes[1] = static_cast<byte>(0x9a);
+    auto badRef = bcos::ref(bytes);
+    Web3Transaction badTx{};
+    auto e = codec::rlp::decode(badRef, badTx);
+    BOOST_REQUIRE(e != nullptr);
+    // Anchor the classification: fields cross the declared list boundary (op-geth ListEnd
+    // errNotAtEOL), not a generic decode failure.
+    BOOST_CHECK_EQUAL(
+        e->errorCode(), static_cast<int64_t>(codec::rlp::DecodingError::UnexpectedListElements));
+}
+
+// Same payload-length overflow check, but exercising an EIP-1559 typed tx codec.
+BOOST_AUTO_TEST_CASE(testRejectPayloadLengthOverflowEIP1559)
+{
+    namespace rlp = bcos::codec::rlp;
+    // Build a minimal valid EIP-1559 envelope.
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));           // chainId
+    rlp::encode(items, static_cast<uint64_t>(0));           // nonce
+    rlp::encode(items, static_cast<uint64_t>(1000000000));  // maxPriorityFeePerGas
+    rlp::encode(items, static_cast<uint64_t>(2000000000));  // maxFeePerGas
+    rlp::encode(items, static_cast<uint64_t>(21000));       // gasLimit
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));  // value
+    rlp::encode(items, bcos::bytes{});             // data
+    items.push_back(rlp::LIST_HEAD_BASE);          // empty accessList
+    rlp::encode(items, static_cast<uint64_t>(0));  // yParity
+    rlp::encode(items, bcos::bytes(32, 0x11));     // r
+    rlp::encode(items, bcos::bytes(32, 0x22));     // s
+
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+    rlp::encodeHeader(envelope, {.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    // Verify it decodes cleanly first.
+    {
+        auto ref = bcos::ref(envelope);
+        Web3Transaction tx{};
+        BOOST_REQUIRE(rlp::decode(ref, tx) == nullptr);
+    }
+    // Shrink the declared payload length by 1: fields now overflow by one byte.
+    // byte 0 = type (0x02), byte 1 = long-list mode byte (0xf8), byte 2 = the actual payload
+    // length. Corrupting byte 2 (NOT byte 1 — decrementing the mode byte 0xf8 -> 0xf7 would
+    // flip the header to short-list mode and misalign the whole field stream, firing the
+    // Address width gate instead) keeps the long-list header intact: all fields decode
+    // cleanly and the ListEnd parity check rejects, mirroring the legacy case.
+    envelope[2] = envelope[2] - 1;
+    auto badRef = bcos::ref(envelope);
+    Web3Transaction badTx{};
+    auto e = rlp::decode(badRef, badTx);
+    BOOST_REQUIRE(e != nullptr);
+    // Fields consume one byte more than the declared payload — the EIP-1559 ListEnd parity
+    // (same op-geth errNotAtEOL parity as the legacy test above).
+    BOOST_CHECK_EQUAL(
+        e->errorCode(), static_cast<int64_t>(codec::rlp::DecodingError::UnexpectedListElements));
+}
+
+// RLPDecode.h must reject integers wider than the target type (op-geth rlp uint overflow /
+// op-reth Error::Overflow parity) instead of truncating via fromBigEndian: a 9-byte uint64
+// or a 33-byte u256 is malformed input, never silently narrowed.
+BOOST_AUTO_TEST_CASE(testRejectOverwideInteger)
+{
+    namespace rlp = bcos::codec::rlp;
+
+    // uint64 with 9 payload bytes: 0x89 + 9 bytes.
+    {
+        bcos::bytes raw{0x89, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+        auto ref = bcos::ref(raw);
+        uint64_t v = 0;
+        auto e = rlp::decode(ref, v);
+        BOOST_CHECK(e != nullptr);
+    }
+    // u256 with 33 payload bytes (header 0xa1 + 33B): must be rejected, not truncated.
+    {
+        bcos::bytes raw(34, 0x00);
+        raw[0] = 0xa1;  // long-string header, 33-byte payload
+        raw[1] = 0x01;  // leading non-zero so it is not a canonical-size violation
+        auto ref = bcos::ref(raw);
+        bcos::u256 v = 0;
+        auto e = rlp::decode(ref, v);
+        BOOST_CHECK(e != nullptr);
+    }
+    // A canonical 8-byte uint64 still decodes fine (no regression).
+    {
+        bcos::bytes raw{0x88, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2a};  // 42
+        auto ref = bcos::ref(raw);
+        uint64_t v = 0;
+        BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
+        BOOST_CHECK_EQUAL(v, 42);
+    }
+    // A canonical 32-byte u256 still decodes fine (guards the maxBytes formula against a
+    // sizeof(T)-based regression: sizeof(u256) == 48, which would reject legal 32-byte values).
+    {
+        bcos::bytes raw(33, 0x00);
+        raw[0] = 0xa0;   // long-string header, 32-byte payload
+        raw[32] = 0x01;  // least-significant payload byte -> value 1
+        auto ref = bcos::ref(raw);
+        bcos::u256 v = 0;
+        BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
+        BOOST_CHECK(v == 1);
+    }
+    // Narrow integers: 5-byte uint32 rejected, canonical 4-byte accepted.
+    {
+        bcos::bytes raw{0x85, 0x01, 0x00, 0x00, 0x00, 0x00};
+        auto ref = bcos::ref(raw);
+        uint32_t v = 0;
+        BOOST_CHECK(rlp::decode(ref, v) != nullptr);
+    }
+    {
+        bcos::bytes raw{0x84, 0x00, 0x00, 0x00, 0x2a};  // 42
+        auto ref = bcos::ref(raw);
+        uint32_t v = 0;
+        BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
+        BOOST_CHECK_EQUAL(v, 42);
+    }
+    // 3-byte uint16 rejected, canonical 2-byte accepted.
+    {
+        bcos::bytes raw{0x83, 0x01, 0x00, 0x00};
+        auto ref = bcos::ref(raw);
+        uint16_t v = 0;
+        BOOST_CHECK(rlp::decode(ref, v) != nullptr);
+    }
+    {
+        bcos::bytes raw{0x82, 0x00, 0x2a};  // 42
+        auto ref = bcos::ref(raw);
+        uint16_t v = 0;
+        BOOST_REQUIRE(rlp::decode(ref, v) == nullptr);
+        BOOST_CHECK_EQUAL(v, 42);
+    }
+}
+
+// Legacy signing-preimage tail strictness (Web3TxHandler legacy handler, withSig=false):
+// op-geth preimages are exactly 6 fields (pre-EIP-155) or 9 fields (EIP-155 chainId,0,0 tail).
+// A 7- or 8-field preimage (chainId without both placeholders) is malformed — no
+// "placeholders optional" leniency. Regression pin for the unconditional placeholder
+// consumption at Web3TxHandler.cpp (the N2 tightening).
+BOOST_AUTO_TEST_CASE(testLegacyTailFieldCountRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    // Each variant encodes ONE RLP list with the given field count (the variadic rlp::encode
+    // emits a list header + all items in a single call — splitting the call would append items
+    // OUTSIDE the list).
+    auto make9 = [] {
+        bcos::bytes legacy;
+        rlp::encode(legacy, static_cast<uint64_t>(0), static_cast<uint64_t>(1),
+            static_cast<uint64_t>(21000),
+            bcos::Address("0xdead000000000000000000000000000000000011"), static_cast<uint64_t>(0),
+            bcos::bytes{}, static_cast<uint64_t>(123), static_cast<uint64_t>(0),
+            static_cast<uint64_t>(0));  // [..6 fields, chainId, 0, 0]
+        return legacy;
+    };
+    auto make8 = [] {
+        bcos::bytes legacy;
+        rlp::encode(legacy, static_cast<uint64_t>(0), static_cast<uint64_t>(1),
+            static_cast<uint64_t>(21000),
+            bcos::Address("0xdead000000000000000000000000000000000011"), static_cast<uint64_t>(0),
+            bcos::bytes{}, static_cast<uint64_t>(123), static_cast<uint64_t>(0));  // chainId, 0
+        return legacy;
+    };
+    auto make7 = [] {
+        bcos::bytes legacy;
+        rlp::encode(legacy, static_cast<uint64_t>(0), static_cast<uint64_t>(1),
+            static_cast<uint64_t>(21000),
+            bcos::Address("0xdead000000000000000000000000000000000011"), static_cast<uint64_t>(0),
+            bcos::bytes{}, static_cast<uint64_t>(123));  // chainId only
+        return legacy;
+    };
+    auto make6 = [] {
+        bcos::bytes legacy;
+        rlp::encode(legacy, static_cast<uint64_t>(0), static_cast<uint64_t>(1),
+            static_cast<uint64_t>(21000),
+            bcos::Address("0xdead000000000000000000000000000000000011"), static_cast<uint64_t>(0),
+            bcos::bytes{});
+        return legacy;
+    };
+    // 9 fields (chainId,0,0): accepted, chainId recovered.
+    {
+        auto bytes = make9();
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        BOOST_REQUIRE(rlp::decodeFromPayload(bRef, tx) == nullptr);
+        BOOST_CHECK(tx.type == rpc::TransactionType::Legacy);
+        BOOST_REQUIRE(tx.chainId.has_value());
+        BOOST_CHECK_EQUAL(tx.chainId.value(), 123);
+    }
+    // 8 fields (chainId, 0, missing second placeholder): rejected.
+    // The tail gate consumes exactly two placeholders; the second decode runs out of
+    // input, so the error class is InputTooShort — anchored so a refactor that drops the
+    // placeholder consumption (accepting 7/8-field preimages) cannot hide behind a
+    // coincidental parse error.
+    {
+        auto bytes = make8();
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto err = rlp::decodeFromPayload(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+        BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InputTooShort));
+    }
+    // 7 fields (chainId only): rejected, same InputTooShort class (placeholder 1 of 2).
+    {
+        auto bytes = make7();
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        auto err = rlp::decodeFromPayload(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+        BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InputTooShort));
+    }
+    // 6 fields (no tail): accepted as pre-EIP-155 (chainId nullopt) — the exemption boundary.
+    {
+        auto bytes = make6();
+        auto bRef = bcos::ref(bytes);
+        Web3Transaction tx{};
+        BOOST_REQUIRE(rlp::decodeFromPayload(bRef, tx) == nullptr);
+        BOOST_CHECK(!tx.chainId.has_value());
+    }
+}
+
+// EIP-2 width gate: a 33-byte 0x00||r / 0x00||s signature (the truncation-bypass shape) must be
+// rejected at the decode funnel (checkEip2Signature, Web3Transaction.cpp:50-54). padSignature
+// only zero-pads shorter input and fromBigEndian truncates wider — without the explicit >32
+// gate, 0x00||r would narrow to a legal r and pass. Pinned so removing the gate turns this red.
+BOOST_AUTO_TEST_CASE(testWideSignatureRejectedAtDecode)
+{
+    namespace rlp = bcos::codec::rlp;
+    // EIP-2930 envelope with a 33-byte r (leading zero). Fields: chainId, nonce, gasPrice,
+    // gasLimit, to, value, data, accessList(empty), then yParity/r/s. Signature field r = 33
+    // bytes. Built as bare items + one list header (the variadic rlp::encode would wrap each
+    // call in its own list); the empty accessList is the RLP empty-list byte 0xc0.
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));            // chainId
+    rlp::encode(items, static_cast<uint64_t>(0));            // nonce
+    rlp::encode(items, static_cast<uint64_t>(30000000000));  // gasPrice
+    rlp::encode(items, static_cast<uint64_t>(5000000));      // gasLimit
+    rlp::encode(items, bcos::Address("0x811a752c8cd697e3cb27279c330ed1ada745a8d7"));
+    rlp::encode(items, static_cast<uint64_t>(0));  // value
+    rlp::encode(items, bcos::bytes{});             // data (empty)
+    items.push_back(codec::rlp::LIST_HEAD_BASE);   // 0xc0: empty accessList
+    rlp::encode(items, static_cast<uint64_t>(0));  // yParity
+    bcos::bytes wideR(33, 0x00);
+    wideR[32] = 0x01;  // 0x00 || 0x...01 — would truncate to r=1 (legal) without the width gate.
+    rlp::encode(items, wideR);
+    rlp::encode(items, bcos::bytes(32, 0x02));  // s
+
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP2930));
+    codec::rlp::encodeHeader(
+        envelope, codec::rlp::Header{.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    // The width gate reports the EIP-2 signature error class, not a generic decode failure.
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+}
+
+// Typed tx with chainId=0 must decode with chainId present (not nullopt).
+// A nullopt here would let the executor's chainId gate pass the tx unchecked (op-geth
+// modernSigner rejects chainId 0 != node-config; the decode layer must preserve the value).
+BOOST_AUTO_TEST_CASE(testTypedTxChainIdZeroDecodes)
+{
+    namespace rlp = bcos::codec::rlp;
+    // EIP-1559 envelope: type 0x02 || rlp([chainId=0, nonce, maxPriorityFee, maxFee, gasLimit,
+    // to, value, data, accessList, yParity=0, r, s]). ChainId field is explicitly zero.
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(0));           // chainId = 0
+    rlp::encode(items, static_cast<uint64_t>(0));           // nonce
+    rlp::encode(items, static_cast<uint64_t>(1000000000));  // maxPriorityFeePerGas
+    rlp::encode(items, static_cast<uint64_t>(1000000000));  // maxFeePerGas
+    rlp::encode(items, static_cast<uint64_t>(21000));       // gasLimit
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));  // value
+    rlp::encode(items, bcos::bytes{});             // data
+    items.push_back(rlp::LIST_HEAD_BASE);          // empty accessList (0xc0)
+    rlp::encode(items, static_cast<uint64_t>(0));  // yParity
+    rlp::encode(items, bcos::bytes(32, 0x11));     // r
+    rlp::encode(items, bcos::bytes(32, 0x22));     // s
+
+    // Wrap in an RLP list header (the handler expects type-byte + list-header + fields).
+    rlp::Header listHeader{.isList = true, .payloadLength = items.size()};
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+    rlp::encodeHeader(envelope, listHeader);
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err == nullptr);
+    BOOST_CHECK(tx.type == rpc::TransactionType::EIP1559);
+    // chainId=0 is explicitly decoded (not nullopt).
+    BOOST_REQUIRE(tx.chainId.has_value());
+    BOOST_CHECK_EQUAL(tx.chainId.value(), 0u);
+    BOOST_CHECK_EQUAL(tx.signatureV, 0u);
+}
+
+// F7: Trailing bytes after a valid RLP envelope must be rejected by Web3Transaction::decode.
+// The outer guard in decode() checks !in.empty() after the handler returns success.
+BOOST_AUTO_TEST_CASE(testTrailingBytesAfterEnvelopeRejected)
+{
+    namespace rlp = bcos::codec::rlp;
+    // Build a valid EIP-1559 envelope (same as testTypedTxChainIdZeroDecodes).
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, static_cast<uint64_t>(1000000000));
+    rlp::encode(items, static_cast<uint64_t>(1000000000));
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes{});
+    items.push_back(rlp::LIST_HEAD_BASE);
+    rlp::encode(items, static_cast<uint64_t>(0));
+    rlp::encode(items, bcos::bytes(32, 0x11));
+    rlp::encode(items, bcos::bytes(32, 0x22));
+
+    bcos::bytes envelope;
+    envelope.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+    rlp::encodeHeader(envelope, {.isList = true, .payloadLength = items.size()});
+    envelope.insert(envelope.end(), items.begin(), items.end());
+
+    // Append a trailing byte — the handler will consume the envelope but leave 0x00 unconsumed.
+    envelope.push_back(0x00);
+    auto bRef = bcos::ref(envelope);
+    Web3Transaction tx{};
+    auto err = rlp::decode(bRef, tx);
+    BOOST_REQUIRE(err != nullptr);
+    BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InputTooLong));
+}
+
+// F5: EIP-7702 negative decode tests — yParity > 1, truncated input, empty input.
+BOOST_AUTO_TEST_CASE(testEIP7702NegativeDecodes)
+{
+    namespace rlp = bcos::codec::rlp;
+    // Valid EIP-7702 envelope (from testEIP7702Transaction) — reuse for yParity=2 mutation.
+    constexpr std::string_view rawTx =
+        "0x04f8fd824ee88080078401000001947050718520e6e10e77224126e185e63a87e88af68080f838f794"
+        "7050718520e6e10e77224126e185e63a87e88af6e1a00000000000000000000000000000000000000000"
+        "000000000000000000000000f85cf85a809400000000000000000000000000000000000000008080a05817"
+        "035c2e62f46823f5385b1d8b81d119ba4c6233929476f4fccbeaef0333e1a058434bf27df5285158b8059"
+        "67729a7a200891c29d2385ee324f481de9a4758f801a0f446323d6852d7c33ae025557ddc82fad0a466d9"
+        "32d59055dad01a9c9962aa4aa055cf0699636222c56fc0ad8695c8edef3af0b881616b7811b403755f0ea"
+        "463eb";
+    auto bytes = fromHexWithPrefix(rawTx);
+
+    // (a) yParity=2: build a minimal EIP-7702 envelope with yParity=2 (invalid).
+    // EIP-7702 field order: chainId, nonce, maxPrio, maxFee, gasLimit, to, value, data,
+    // accessList, authorizationList, yParity, r, s.
+    {
+        bcos::bytes items2;
+        rlp::encode(items2, static_cast<uint64_t>(1));
+        rlp::encode(items2, static_cast<uint64_t>(0));
+        rlp::encode(items2, static_cast<uint64_t>(1000000000));
+        rlp::encode(items2, static_cast<uint64_t>(1000000000));
+        rlp::encode(items2, static_cast<uint64_t>(21000));
+        rlp::encode(items2, bcos::Address("0x1111111111111111111111111111111111111111"));
+        rlp::encode(items2, static_cast<uint64_t>(0));
+        rlp::encode(items2, bcos::bytes{});
+        items2.push_back(rlp::LIST_HEAD_BASE);          // empty accessList (0xc0)
+        items2.push_back(rlp::LIST_HEAD_BASE);          // empty authorizationList (0xc0)
+        rlp::encode(items2, static_cast<uint64_t>(2));  // yParity = 2 (invalid)
+        rlp::encode(items2, bcos::bytes(32, 0x11));
+        rlp::encode(items2, bcos::bytes(32, 0x22));
+        bcos::bytes env;
+        env.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP7702));
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items2.size()});
+        env.insert(env.end(), items2.begin(), items2.end());
+        auto bRef = bcos::ref(env);
+        Web3Transaction tx{};
+        auto err = rlp::decode(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+        BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InvalidVInSignature));
+    }
+
+    // (b) Empty input for EIP-7702 handler.
+    {
+        bcos::bytes empty{static_cast<byte>(bcos::rpc::TransactionType::EIP7702)};
+        auto bRef = bcos::ref(empty);
+        Web3Transaction tx{};
+        auto err = rlp::decode(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+        BOOST_CHECK(err->errorCode() == static_cast<int>(rlp::DecodingError::InputTooShort));
+    }
+
+    // (c) Truncated EIP-7702 envelope (type byte + partial list).
+    {
+        bcos::bytes trunc{static_cast<byte>(bcos::rpc::TransactionType::EIP7702), 0xc2, 0x01, 0x02};
+        auto bRef = bcos::ref(trunc);
+        Web3Transaction tx{};
+        auto err = rlp::decode(bRef, tx);
+        BOOST_REQUIRE(err != nullptr);
+    }
+}
+
+// F4: web3ChainIdFromEnvelope — dedicated unit tests for all envelope forms.
+// This function is called in TxValidator and EthEndpoint admission paths; regressions here
+// could silently break the chainId gate. Test all legacy forms (6/7/8/9-field) plus typed.
+BOOST_AUTO_TEST_CASE(testWeb3ChainIdFromEnvelope)
+{
+    namespace rlp = bcos::codec::rlp;
+    namespace envelope = bcos::rlp::protocol;
+
+    // (a) Typed EIP-1559 envelope: chainId is field 0 of inner list.
+    {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(42));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, static_cast<uint64_t>(1000000000));
+        rlp::encode(items, static_cast<uint64_t>(1000000000));
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, bcos::Address("0x1111111111111111111111111111111111111111"));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes{});
+        items.push_back(rlp::LIST_HEAD_BASE);
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes(32, 0x11));
+        rlp::encode(items, bcos::bytes(32, 0x22));
+
+        bcos::bytes env;
+        env.push_back(static_cast<byte>(bcos::rpc::TransactionType::EIP1559));
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(result.value(), 42u);
+    }
+
+    // Legacy envelope builders — preimage [6 fields, chainId, 0, 0] (the admission path
+    // stores encodeForSign()), full-envelope [6 fields, v, r, s] (raw signed envelope),
+    // and the 6-field pre-EIP-155 preimage.
+    auto makePreimage = [&](uint64_t chainId) {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));   // nonce
+        rlp::encode(items, static_cast<uint64_t>(10));  // gasPrice
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, bcos::Address("0x0100000000000000000000000000000000000001"));
+        rlp::encode(items, static_cast<uint64_t>(0));  // value
+        rlp::encode(items, bcos::bytes{});             // data
+        rlp::encode(items, chainId);                   // field 7 = EIP-155 chainId
+        rlp::encode(items, static_cast<uint64_t>(0));  // field 8 = 0 placeholder
+        rlp::encode(items, static_cast<uint64_t>(0));  // field 9 = 0 placeholder
+        bcos::bytes env;
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        return env;
+    };
+    auto makeFullEnvelope = [&](uint64_t v) {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));
+        rlp::encode(items, static_cast<uint64_t>(10));
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, bcos::Address("0x0100000000000000000000000000000000000001"));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes{});
+        rlp::encode(items, v);                         // field 7 = v
+        rlp::encode(items, static_cast<uint64_t>(1));  // field 8 = r (non-empty)
+        rlp::encode(items, static_cast<uint64_t>(1));  // field 9 = s (non-empty)
+        bcos::bytes env;
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        return env;
+    };
+    auto makeBareSixField = [&]() {
+        bcos::bytes items;
+        rlp::encode(items, static_cast<uint64_t>(1));
+        rlp::encode(items, static_cast<uint64_t>(10));
+        rlp::encode(items, static_cast<uint64_t>(21000));
+        rlp::encode(items, bcos::Address("0x0100000000000000000000000000000000000001"));
+        rlp::encode(items, static_cast<uint64_t>(0));
+        rlp::encode(items, bcos::bytes{});
+        bcos::bytes env;
+        rlp::encodeHeader(env, {.isList = true, .payloadLength = items.size()});
+        env.insert(env.end(), items.begin(), items.end());
+        return env;
+    };
+
+    // (b) Preimage, single-byte chainId.
+    {
+        auto env = makePreimage(42);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(result.value(), 42u);
+    }
+    // (c) Preimage, multi-byte chainId — regression pin for the field-7 re-parse bug
+    // (payload was decoded as a fresh RLP item; chainId 8453 mis-read as 33).
+    {
+        auto env = makePreimage(8453);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(result.value(), 8453u);
+    }
+    // (d) Preimage, chainId whose payload first byte is a list header (200 = 0xC8) —
+    // previously decode-failed to nullopt, a bogus "unprotected" exemption.
+    {
+        auto env = makePreimage(200);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(result.value(), 200u);
+    }
+    // (d2) Preimage, chainId 255 (0x81 0xFF): payload first byte is a LONG-list header —
+    // a distinct pre-fix misclassification branch (lenOfLen path), same regression family.
+    {
+        auto env = makePreimage(255);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(result.value(), 255u);
+    }
+    // (e) 6-field pre-EIP-155 preimage (no chainId) → nullopt (unprotected exemption).
+    {
+        auto env = makeBareSixField();
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_CHECK(!result.has_value());
+    }
+    // (f) Full envelope v=27/28 (unprotected) → nullopt. Both arms of the exemption.
+    {
+        auto env = makeFullEnvelope(27);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_CHECK(!result.has_value());
+    }
+    {
+        auto env = makeFullEnvelope(28);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_CHECK(!result.has_value());
+    }
+    // (g) Full envelope v=37 → chainId 1.
+    {
+        auto env = makeFullEnvelope(37);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(result.value(), 1u);
+    }
+    // (h) Full envelope v=235 (multi-byte) → chainId 100.
+    {
+        auto env = makeFullEnvelope(235);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_REQUIRE(result.has_value());
+        BOOST_CHECK_EQUAL(result.value(), 100u);
+    }
+    // (i) Malformed v=30 → nullopt.
+    {
+        auto env = makeFullEnvelope(30);
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(env));
+        BOOST_CHECK(!result.has_value());
+    }
+
+    // (j) Empty input → nullopt.
+    {
+        bcos::bytes empty;
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(empty));
+        BOOST_CHECK(!result.has_value());
+    }
+
+    // (k) Deposit (0x7E) → nullopt (no chainId field; field 0 is sourceHash).
+    {
+        bcos::bytes deposit;
+        deposit.push_back(static_cast<byte>(bcos::rpc::TransactionType::Deposit));
+        auto result = envelope::web3ChainIdFromEnvelope(bcos::ref(deposit));
+        BOOST_CHECK(!result.has_value());
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
@@ -29,11 +29,15 @@
 #include <bcos-concepts/Hash.h>
 #include <bcos-concepts/Serialize.h>
 #include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-rlp-protocol/Web3TxEnvelope.h>
 #include <bcos-utilities/BoostLog.h>
 #include <boost/throw_exception.hpp>
+#include <algorithm>
+#include <array>
 #include <cstring>
 #include <exception>
 #include <set>
+#include <utility>
 
 DERIVE_BCOS_EXCEPTION(EmptyTransactionHash);
 
@@ -150,6 +154,47 @@ bcos::bytes bcostars::protocol::reassembleWeb3RawTransaction(
         {
             throwDecode("typed body");
         }
+        // Dual layout: the stored bytes are the signing preimage (type || fields) or — for
+        // sealed OP blocks, whose extraTransactionBytes the engine overwrote with the full
+        // envelope — the wire form (type || fields || yParity,r,s). The per-type field
+        // count is fixed, so counting the list items discriminates unambiguously; a wire
+        // payload is already the assembled form and is returned verbatim.
+        {
+            static constexpr std::array<std::pair<uint8_t, std::size_t>, 4> c_typedFieldCounts{{
+                {0x01, 8},   // EIP-2930
+                {0x02, 9},   // EIP-1559
+                {0x03, 10},  // EIP-4844
+                {0x04, 11},  // EIP-7702
+            }};
+            auto const* expected =
+                std::find_if(c_typedFieldCounts.begin(), c_typedFieldCounts.end(),
+                    [txType](auto const& entry) { return entry.first == txType; });
+            if (!expected) [[unlikely]]
+            {
+                throwDecode("typed unknown type");
+            }
+            std::size_t itemCount = 0;
+            bcos::bytesRef counter(cursor.data(), header.payloadLength);
+            while (!counter.empty())
+            {
+                auto [countError, itemHeader] = bcos::codec::rlp::decodeHeader(counter);
+                if (countError || itemHeader.payloadLength > counter.size()) [[unlikely]]
+                {
+                    throwDecode("typed item count");
+                }
+                counter = counter.getCroppedData(itemHeader.payloadLength);
+                ++itemCount;
+            }
+            if (itemCount == expected->second + 3) [[unlikely]]
+            {
+                // wire form: already signed
+                return buffer;
+            }
+            if (itemCount != expected->second) [[unlikely]]
+            {
+                throwDecode("typed item count");
+            }
+        }
         bcos::bytesConstRef fields(cursor.data(), header.payloadLength);
 
         bcos::bytes sig;
@@ -201,30 +246,42 @@ bcos::bytes bcostars::protocol::reassembleWeb3RawTransaction(
         }
         else
         {
-            // EIP-155: item 7 is the signed chainId (items 8,9 are the 0,0 placeholders). Read
-            // chainId from the preimage itself -- that is the value the sender actually signed, so
-            // it is authoritative even though the whole tx arrived from an untrusted peer.
-            uint64_t chainId = 0;
-            if (auto chainIdError = bcos::codec::rlp::decode(walker, chainId)) [[unlikely]]
+            // Dual layout: the trailer is either the preimage's (chainId, 0, 0) or — for
+            // sealed OP blocks, whose extraTransactionBytes the engine overwrote with the
+            // full envelope — the wire (v, r, s). RLP encodes the integer 0 as an empty
+            // payload while secp256k1 r/s never are, so emptiness of items 8/9
+            // discriminates the two shapes unambiguously.
+            uint64_t item7 = 0;
+            bcos::bytes item8, item9;
+            if (auto trailerError = bcos::codec::rlp::decodeItems(walker, item7, item8, item9);
+                trailerError) [[unlikely]]
             {
-                throwDecode("legacy chainId");
-            }
-            // The preimage must end with exactly chainId,0,0 -- reject 7/8-item lists and
-            // non-zero trailers rather than misreading item 7 of some other shape as a chainId.
-            for (int i = 0; i < 2; ++i)
-            {
-                uint64_t zero = 0;
-                if (auto zeroError = bcos::codec::rlp::decode(walker, zero); zeroError || zero != 0)
-                    [[unlikely]]
-                {
-                    throwDecode("legacy trailing zeros");
-                }
+                throwDecode("legacy trailer");
             }
             if (!walker.empty()) [[unlikely]]
             {
                 throwDecode("legacy trailing garbage");
             }
-            v = chainId * 2 + 35 + yParity;
+            if (item8.empty() && item9.empty())
+            {
+                // preimage: item7 is the signed chainId (items 8,9 are the 0,0
+                // placeholders). It is what the sender actually signed, so it is
+                // authoritative even though the whole tx arrived from an untrusted peer.
+                v = item7 * 2 + 35 + yParity;
+            }
+            else
+            {
+                // wire: item7 is the EIP-155 v. Cross-check the trailer's r/s against the
+                // tars signature before adopting its v — the reassembled form must be the
+                // canonical assembly of (fields, tars signature), not just any stored
+                // bytes that happen to end in a signature-shaped trailer.
+                if (!std::equal(item8.begin(), item8.end(), r.begin(), r.end()) ||
+                    !std::equal(item9.begin(), item9.end(), s.begin(), s.end())) [[unlikely]]
+                {
+                    throwDecode("legacy signature mismatch");
+                }
+                v = item7;
+            }
         }
 
         bcos::bytes sig;
@@ -250,6 +307,15 @@ void bcostars::protocol::TransactionImpl::calculateHash(const bcos::crypto::Hash
     // The recompute is a byte splice plus one keccak, cheap enough to always run.
     if (type() == static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction))
     {
+        // Deposit (0x7e): unsigned — extraTransactionBytes already IS the full 0x7e envelope
+        // (stored by takeToTarsTransaction as encode()), so the hash is keccak of it verbatim;
+        // reassembleWeb3RawTransaction cannot be used (it needs a 65-byte signature).
+        if (isDepositTx())
+        {
+            auto const depositHash = bcos::crypto::keccak256Hash(extraTransactionBytes());
+            m_inner()->extraTransactionHash.assign(depositHash.begin(), depositHash.end());
+            return;
+        }
         auto const canonicalTxHash = bcos::crypto::keccak256Hash(
             bcos::ref(reassembleWeb3RawTransaction(extraTransactionBytes(), signatureData())));
         m_inner()->extraTransactionHash.assign(canonicalTxHash.begin(), canonicalTxHash.end());
@@ -413,6 +479,22 @@ uint8_t bcostars::protocol::TransactionImpl::web3TypedTxKind() const
     return static_cast<uint8_t>(m_inner()->web3TypedTxKind);
 }
 
+std::optional<uint64_t> bcostars::protocol::TransactionImpl::web3ChainIdFromEnvelope() const
+{
+    // chainId admission must come from the SIGNED envelope, not the tars mirror (data.chainID):
+    // the signature binds only extraTransactionBytes + signatureData. extraTransactionBytes is
+    // the signing preimage: typed = type byte || rlp([chainId, ...]); legacy = 6 fields or
+    // [...6 fields, chainId, 0, 0]. nullopt means a pre-EIP-155 legacy preimage (no chainId
+    // tail) — a malformed tail (unparseable field 7) also yields nullopt, but is unreachable
+    // through TxValidator: verify() rejects the same bytes first via reassembleWeb3RawTransaction
+    // (the walker is shared with the block path — see Web3TxEnvelope.h — keep one home).
+    if (type() != static_cast<uint8_t>(bcos::protocol::TransactionType::Web3Transaction))
+    {
+        return std::nullopt;
+    }
+    return bcos::rlp::protocol::web3ChainIdFromEnvelope(extraTransactionBytes());
+}
+
 std::string_view bcostars::protocol::TransactionImpl::sourceHash() const
 {
     // Unprefixed hex (the asymmetry with mint()'s "0x"+hex is by design: sourceHash is a hash
@@ -431,7 +513,7 @@ bcos::u256 bcostars::protocol::TransactionImpl::mint() const
     // may lack the prefix. bcos::u256("100") without 0x-parses as decimal 100, not 0x100=256
     // (a silent value error for a value-bearing field). Always force a 0x prefix so the
     // identity "mint stored = mint parsed" holds regardless of input form.
-    // Invalid hex from corrupt data must not throw through the const getter — the length
+    // Invalid hex from corrupt data must not throw through the const getter -- the length
     // guard handles over-wide values (u256 uses boost unchecked backend which silently
     // truncates >256 bits), and try/catch handles remaining corrupt/non-hex input; both
     // fall back to 0, consistent with the empty-string case.
@@ -442,7 +524,7 @@ bcos::u256 bcostars::protocol::TransactionImpl::mint() const
     {
         auto const& s = m_inner()->mint;
         // bcos::u256 (boost unchecked backend) silently truncates >256-bit values rather
-        // than throwing — catch over-wide hex explicitly before the parse: with a 0x/0X
+        // than throwing -- catch over-wide hex explicitly before the parse: with a 0x/0X
         // prefix, valid is at most 66 chars (2 prefix + 64 hex digits); without, at most 64.
         auto const hasPrefix = s.starts_with("0x") || s.starts_with("0X");
         auto const hexLen = hasPrefix ? s.size() - 2 : s.size();

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.h
@@ -33,6 +33,8 @@
 #include "bcos-tars-protocol/tars/Transaction.h"
 #include "bcos-utilities/Common.h"
 #include <memory>
+#include <optional>
+#include <string_view>
 
 namespace bcostars::protocol
 {
@@ -93,6 +95,7 @@ public:
     uint8_t type() const override;
     bcos::bytesConstRef extraTransactionBytes() const override;
     uint8_t web3TypedTxKind() const override;
+    std::optional<uint64_t> web3ChainIdFromEnvelope() const override;
     std::string_view sourceHash() const override;
     bcos::u256 mint() const override;
     bool isDepositTx() const override;

--- a/bcos-tars-protocol/bcos-tars-protocol/tars/Transaction.tars
+++ b/bcos-tars-protocol/bcos-tars-protocol/tars/Transaction.tars
@@ -62,5 +62,12 @@ module bcostars {
         13 optional string          sourceHash;          // deposit source hash(hex)
         14 optional string          mint;                // deposit mint(hex string)
         15 optional byte            isSystemTransaction; // bool flag
+        /// Full raw EIP-2718 envelope bytes as received by eth_sendRawTransaction (NOT
+        /// extraTransactionBytes, which is encodeForSign() without the signature). OP block
+        /// building (sequencer) consumes this verbatim as the block's raw transaction list —
+        /// execution must see exactly the bytes the user submitted, so the node re-serializing
+        /// from fields would break the txRoot/blockHash against op-geth. Empty for txs that
+        /// entered via non-web3 paths (never sealed into an OP block).
+        16 optional vector<byte>    rawTransactionBytes;
     };
 };

--- a/bcos-tars-protocol/test/TransactionFactoryImplTest.cpp
+++ b/bcos-tars-protocol/test/TransactionFactoryImplTest.cpp
@@ -10,6 +10,8 @@
 
 #include "bcos-tars-protocol/protocol/TransactionFactoryImpl.h"
 #include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <boost/test/unit_test.hpp>
@@ -303,7 +305,7 @@ BOOST_AUTO_TEST_CASE(depositMetadataAccessors)
     BOOST_CHECK_EQUAL(noMint->mint(), u256(0));
     BOOST_CHECK(noMint->sourceHash().empty());
 
-    // Over-wide mint (>64 hex digits / >66 with 0x prefix) must return 0 — bcos::u256's
+    // Over-wide mint (>64 hex digits / >66 with 0x prefix) must return 0 -- bcos::u256's
     // boost unchecked backend silently truncates >256 bits, so the length guard must catch
     // it before the parse (Shichen-Wu review #5434).
     auto wideMint = std::make_shared<TransactionImpl>();
@@ -314,7 +316,7 @@ BOOST_AUTO_TEST_CASE(depositMetadataAccessors)
     BOOST_CHECK(wideMint->isDepositTx());
     BOOST_CHECK_EQUAL(wideMint->mint(), u256(0));
 
-    // Exactly 64 hex digits (256-bit max) parses normally — the guard must not be off-by-one.
+    // Exactly 64 hex digits (256-bit max) parses normally -- the guard must not be off-by-one.
     auto maxMint = std::make_shared<TransactionImpl>();
     maxMint->mutableInner().type =
         static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
@@ -341,6 +343,78 @@ BOOST_AUTO_TEST_CASE(depositMetadataAccessors)
         static_cast<tars::Char>(bcos::protocol::TransactionType::BCOSTransaction);
     forgedBcos->mutableInner().web3TypedTxKind = static_cast<tars::Char>(0x7e);
     BOOST_CHECK(!forgedBcos->isDepositTx());
+}
+
+// Deposit hash: the canonical txHash of a 0x7e tx is keccak256 of the full envelope (type byte
+// + RLP fields) — op-geth DepositTx.Hash() / op-reth TxDeposit::tx_hash(). calculateHash must
+// handle the deposit branch (deposits carry no signature, so the normal reassemble path would
+// throw on the missing 65-byte signature). Fill extraTransactionBytes with a real envelope and
+// check extraTransactionHash equals keccak of those bytes verbatim.
+BOOST_AUTO_TEST_CASE(depositHashIsKeccakOfEnvelope)
+{
+    auto suite = makeSuite();
+    auto tx = std::make_shared<TransactionImpl>();
+    auto& inner = tx->mutableInner();
+    inner.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+    inner.web3TypedTxKind = static_cast<tars::Char>(0x7e);
+    // A minimal but well-formed 0x7e envelope: rlp([sourceHash, from, to, mint, value, gas,
+    // isSystemTx, data]) preceded by the type byte.
+    bcos::bytes body;
+    bcos::codec::rlp::encode(body,
+        bcos::h256("0x6ab967dfdd3aa359031bef6965cca32ed9a21ea969f7aeee2e58817142a645d7"),
+        bcos::Address("0xdead000000000000000000000000000000000011"),
+        bcos::Address("0x4200000000000000000000000000000000000022"), bcos::bytes{}, bcos::bytes{},
+        static_cast<uint64_t>(500000), static_cast<uint64_t>(0), bcos::bytes{});
+    bcos::bytes envelope{0x7e};
+    bcos::codec::rlp::encodeHeader(envelope, bcos::codec::rlp::Header{true, body.size()});
+    envelope.insert(envelope.end(), body.begin(), body.end());
+    inner.extraTransactionBytes.assign(envelope.begin(), envelope.end());
+
+    tx->calculateHash(*suite->hashImpl());
+    auto const expect = bcos::crypto::keccak256Hash(bcos::ref(envelope));
+    BOOST_CHECK(tx->hash() == expect);
+    BOOST_CHECK_EQUAL(bcos::toHex(tx->hash().asBytes()), bcos::toHex(expect.asBytes()));
+}
+
+// web3ChainIdFromEnvelope must read the SIGNED envelope (extraTransactionBytes), never the
+// forgeable tars mirror (data.chainID) — a regression swapping to the mirror would pass every
+// other test in this file. Envelope carries a legacy EIP-155 preimage with chainId 42; the
+// mirror is deliberately forged to 999.
+BOOST_AUTO_TEST_CASE(web3ChainIdFromEnvelopeReadsEnvelopeNotTarsMirror)
+{
+    auto suite = makeSuite();
+    namespace rlp = bcos::codec::rlp;
+
+    bcos::bytes items;
+    rlp::encode(items, static_cast<uint64_t>(1));   // nonce
+    rlp::encode(items, static_cast<uint64_t>(10));  // gasPrice
+    rlp::encode(items, static_cast<uint64_t>(21000));
+    rlp::encode(items, bcos::bytes(20, 0x01));
+    rlp::encode(items, static_cast<uint64_t>(0));   // value
+    rlp::encode(items, bcos::bytes{});              // data
+    rlp::encode(items, static_cast<uint64_t>(42));  // field 7 = EIP-155 chainId
+    rlp::encode(items, static_cast<uint64_t>(0));   // 0 placeholder
+    rlp::encode(items, static_cast<uint64_t>(0));   // 0 placeholder
+    bcos::bytes env;
+    rlp::encodeHeader(env, rlp::Header{true, items.size()});
+    env.insert(env.end(), items.begin(), items.end());
+
+    auto tx = std::make_shared<TransactionImpl>();
+    auto& inner = tx->mutableInner();
+    inner.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+    inner.data.chainID = "999";  // forged string mirror — must NOT be consulted
+    inner.extraTransactionBytes.assign(env.begin(), env.end());
+
+    auto chainId = tx->web3ChainIdFromEnvelope();
+    BOOST_REQUIRE(chainId.has_value());
+    BOOST_CHECK_EQUAL(chainId.value(), 42u);
+
+    // Non-Web3 transactions return nullopt regardless of the envelope content.
+    auto legacy = std::make_shared<TransactionImpl>();
+    auto& legacyInner = legacy->mutableInner();
+    legacyInner.type = static_cast<tars::Char>(bcos::protocol::TransactionType::BCOSTransaction);
+    legacyInner.extraTransactionBytes.assign(env.begin(), env.end());
+    BOOST_CHECK(!legacy->web3ChainIdFromEnvelope().has_value());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Independent extract from #5481: signed-envelope decode (`Web3TxEnvelope`), `Web3TxHandler`, `Web3Transaction`, and `TransactionImpl` chainId.
- Eth/Engine RPC surface is a separate PR so this stays under the 1024 valid-insert limit (decode-core ≈ 949).
- Does not update #5463; that PR remains the earlier part-4a slice.

## Test plan
- [ ] Diff is limited to envelope/handler/tx model + RLP width gate + listed Web3 unit tests.
- [ ] No `EthEndpoint` / `EngineEndpoint` / `OpScheduler` / e2e / t8n.
- [ ] `rpc` links `rlp-protocol`; `Web3TxHandler.cpp` is picked up by the existing glob.
- [ ] CI insert-limit on counted src should pass.


Made with [Cursor](https://cursor.com)