### PR TITLE
feat(rpc): add Eth/Engine RPC surface for OP payloads

### DIFF
--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EndpointsMapping.cpp
@@ -83,6 +83,7 @@ void EndpointsMapping::addEthHandlers()
     m_handlers[methodString(EthMethod::eth_mining)] = &Endpoints::mining;
     m_handlers[methodString(EthMethod::eth_hashrate)] = &Endpoints::hashrate;
     m_handlers[methodString(EthMethod::eth_gasPrice)] = &Endpoints::gasPrice;
+    m_handlers[methodString(EthMethod::eth_feeHistory)] = &Endpoints::feeHistory;
     m_handlers[methodString(EthMethod::eth_accounts)] = &Endpoints::accounts;
     m_handlers[methodString(EthMethod::eth_blockNumber)] = &Endpoints::blockNumber;
     m_handlers[methodString(EthMethod::eth_getBalance)] = &Endpoints::getBalance;
@@ -116,6 +117,7 @@ void EndpointsMapping::addEthHandlers()
     m_handlers[methodString(EthMethod::eth_getLogs)] = &Endpoints::getLogs;
     m_handlers[methodString(EthMethod::eth_maxPriorityFeePerGas)] = &Endpoints::maxPriorityFeePerGas;
     m_handlers[methodString(EthMethod::eth_getProof)] = &Endpoints::getProof;
+    m_handlers[methodString(EthMethod::miner_setMaxDASize)] = &Endpoints::setMaxDASize;
     // clang-format on
 }
 

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -21,12 +21,27 @@
 #include "EngineEndpoint.h"
 #include <bcos-rpc/jsonrpc/Common.h>
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h>
 #include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 
 using namespace bcos;
 using namespace bcos::rpc;
 
+namespace
+{
+/// Convert an engine-service exception into the JSON-RPC error the Engine API assigns to the
+/// condition. bcos::Exception-derived engine errors previously escaped to Web3JsonRpcImpl's
+/// catch(...) and came back as -32603; converting at the endpoint keeps Web3JsonRpcImpl generic.
+[[noreturn]] void rethrowAsJsonRpcError(bcos::Exception const& e)
+{
+    // bcos::Error stores its message in errorMessage() (not what()); fall back so a
+    // storage/service fault never surfaces as -32603 with an empty message.
+    auto msg = dynamic_cast<bcos::Error const*>(&e);
+    auto message = msg ? msg->errorMessage() : std::string(e.what());
+    throw JsonRpcException(mapEngineErrorCode(e), std::move(message));
+}
+}  // namespace
 
 EngineEndpoint::EngineEndpoint(NodeService::Ptr nodeService) : m_nodeService(std::move(nodeService))
 {}
@@ -117,11 +132,13 @@ task::Task<void> EngineEndpoint::forkchoiceUpdatedV3(
     co_await handleForkchoiceUpdated(engine::ApiVersion::V3, request, response);
 }
 
-task::Task<void> EngineEndpoint::forkchoiceUpdatedV4(const Json::Value&, Json::Value& response)
+task::Task<void> EngineEndpoint::forkchoiceUpdatedV4(
+    const Json::Value& request, Json::Value& response)
 {
-    // Prague forkchoiceUpdated shape; not implemented (Karst builds payloads on V3).
-    buildUnimplementedVersionError("engine_forkchoiceUpdatedV4", response);
-    co_return;
+    // Tier-2 (08-19): the OP face is Isthmus+/V4-only — the engine's attribute-driven build and
+    // the newPayload path both gate on V4, so the RPC surface serves it (Prague payload shape;
+    // executionRequests stays empty on this chain).
+    co_await handleForkchoiceUpdated(engine::ApiVersion::V4, request, response);
 }
 
 task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
@@ -136,13 +153,16 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
 
     auto forkchoiceState = parseForkchoiceState(request);
     auto payloadAttrs = parsePayloadAttributes(request, version);
-    // TODO: engineService->updateForkchoice() MUST throw JsonRpcException in these cases:
-    //   -38002 InvalidForkchoiceState: headBlockHash is VALID but finalizedBlockHash/safeBlockHash
-    //   not in chain -38003 InvalidPayloadAttributes: payloadAttributes.timestamp <=
-    //   headBlockHash.timestamp -38005 UnsupportedFork: timestamp out of fork window (V2/V3
-    //   specific) -38006 TooDeepReorg: reorg depth exceeds limitation
-    auto engineResult = co_await engineService->updateForkchoice(forkchoiceState,
-        payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
+    bcos::engine::ForkchoiceUpdatedResult engineResult;
+    try
+    {
+        engineResult = co_await engineService->updateForkchoice(forkchoiceState,
+            payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
+    }
+    catch (bcos::Exception const& e)
+    {
+        rethrowAsJsonRpcError(e);
+    }
     auto jsonResult = combineForkchoiceUpdatedResult(engineResult, version);
     buildJsonContent(jsonResult, response);
 }
@@ -194,30 +214,15 @@ task::Task<void> EngineEndpoint::handleGetPayload(
             JsonRpcException(InvalidParams, "engine_getPayload expects [payloadId]"));
     }
     engine::PayloadID payloadId = request[0u].asString();
-    engine::GetPayloadResult engineResult;
+    bcos::engine::GetPayloadResult engineResult;
     try
     {
         engineResult =
             co_await engineService->getPayload(payloadId, static_cast<uint32_t>(version));
     }
-    catch (engine::UnknownPayload const&)
+    catch (bcos::Exception const& e)
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnknownPayload,
-            "Unknown payload: no build process identified by the given payloadId"));
-    }
-    catch (engine::IncompatiblePayloadVersion const&)
-    {
-        // The build behind this payloadId is outside the requested method's version
-        // window: either a version mismatch between the forkchoiceUpdated that built it
-        // and the getPayload asking for it, or a re-query AFTER the payload was committed
-        // through newPayload (a commit rewrites the cache entry with the newPayload
-        // version — PayloadEntry::version, EngineServiceImpl.h — so it no longer matches
-        // getPayloadV5's V3-build window). The mapping is -38005 to match op-geth, whose
-        // getPayload helper answers engine.UnsupportedFork when the payloadId's encoded
-        // build version is outside the method's allowed set (eth/catalyst/api.go:531-533,
-        // GetPayloadV5 allowing only PayloadV3).
-        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnsupportedFork,
-            "Unsupported fork: payload was built by a different method version"));
+        rethrowAsJsonRpcError(e);
     }
     if (!engineResult)
     {
@@ -261,11 +266,16 @@ task::Task<void> EngineEndpoint::handleNewPayload(
     }
 
     auto newPayloadReq = parseNewPayloadRequest(request, version);
-    // TODO: engineService->newPayload() MUST throw JsonRpcException in these cases:
-    //   -32602 InvalidParams: wrong version of ExecutionPayload structure (V2)
-    //   -38005 UnsupportedFork: timestamp out of fork window (V2/V3)
-    auto engineResult =
-        co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
+    bcos::engine::PayloadStatus engineResult;
+    try
+    {
+        engineResult =
+            co_await engineService->newPayload(newPayloadReq, static_cast<uint32_t>(version));
+    }
+    catch (bcos::Exception const& e)
+    {
+        rethrowAsJsonRpcError(e);
+    }
     auto result = serializePayloadStatus(engineResult, version);
     buildJsonContent(result, response);
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -28,15 +28,19 @@
 #include "bcos-protocol/TransactionStatus.h"
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-crypto/hash/Keccak256.h>
+
 #include <bcos-executor/src/Common.h>
+#include <bcos-framework/engine/OpBaseFee.h>
 #include <bcos-framework/executor/PrecompiledTypeDef.h>
 #include <bcos-framework/storage/LegacyStorageMethods.h>
 #include <bcos-framework/storage2/Storage.h>
 #include <bcos-framework/transaction-executor/StateKey.h>
 #include <bcos-ledger/mpt/Constants.h>
+#include <bcos-ledger/mpt/FlatProof.h>
 #include <bcos-ledger/mpt/MPTReadView.h>
 #include <bcos-ledger/mpt/Proof.h>
 #include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-rlp-protocol/Web3TxEnvelope.h>  // isTypedWeb3Envelope (envelope-sourced chainId gate)
 #include <bcos-rpc/Common.h>
 #include <bcos-rpc/util.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
@@ -46,8 +50,13 @@
 #include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
+#include <algorithm>
+#include <array>
 #include <cstdint>
+#include <limits>
+#include <optional>
 #include <span>
 #include <string>
 #include <variant>
@@ -55,6 +64,55 @@
 
 using namespace bcos;
 using namespace bcos::rpc;
+
+namespace
+{
+// op-geth eth_call revert semantics (internal/ethapi): a reverted call is a JSON-RPC
+// error with code 3 and message "execution reverted"; when the revert data carries a
+// solidity Error(string) (selector 0x08c379a0) the decoded reason is appended.
+// A bare receipt status as the code and an empty message is unusable by clients.
+constexpr int32_t c_executionReverted = 3;
+
+std::string decodeRevertMessage(std::string_view outputHex)
+{
+    // std::string_view for the constexpr (a constexpr std::string is not a constant
+    // expression under gcc-14 -Werror: it refers to a result of operator new); every
+    // use converts explicitly so no compiler's implicit-conversion leniency is relied on.
+    static constexpr std::string_view kReverted = "execution reverted";
+    auto bytes = fromHexWithPrefix(outputHex);
+    // Error(string): selector(4) || offset==32 (32) || length (32) || payload
+    if (bytes.size() < 4U + 32U + 32U ||
+        !std::equal(bytes.begin(), bytes.begin() + 4,
+            std::array<bcos::byte, 4>{0x08, 0xc3, 0x79, 0xa0}.begin()))
+    {
+        return std::string(kReverted);
+    }
+    auto word = [&bytes](std::size_t offset) {
+        std::size_t value = 0;
+        for (std::size_t i = 0; i < 32; ++i)
+        {
+            if (value > (std::numeric_limits<std::size_t>::max() >> 8))
+            {
+                return std::numeric_limits<std::size_t>::max();
+            }
+            value = (value << 8) | static_cast<std::uint8_t>(bytes[offset + i]);
+        }
+        return value;
+    };
+    if (word(4) != 32)
+    {
+        return std::string(kReverted);
+    }
+    auto length = word(36);
+    if (length > bytes.size() - (4U + 32U + 32U))
+    {
+        return std::string(kReverted);
+    }
+    auto reason = std::string(
+        reinterpret_cast<char const*>(bytes.data() + 68), static_cast<std::size_t>(length));
+    return std::string(kReverted) + ": " + reason;
+}
+}  // namespace
 
 task::Task<void> EthEndpoint::protocolVersion(const Json::Value&, Json::Value&)
 {
@@ -122,11 +180,72 @@ task::Task<void> EthEndpoint::hashrate(const Json::Value&, Json::Value& response
     buildJsonContent(result, response);
     co_return;
 }
+task::Task<void> EthEndpoint::setMaxDASize(const Json::Value& request, Json::Value& response)
+{
+    // miner_setMaxDASize(maxCanonTxSize, maxBlockSize): the OP Stack batcher's DA throttling
+    // calls this on every L2 endpoint and treats "method not found" as fatal ("either enable
+    // it or disable throttling"). The caps land in the DACaps instance SHARED with the
+    // engine's OP build path (NodeService::daCaps — one instance, created by the Initializer):
+    // buildOpPayload drops sealed envelopes over maxTxSize and truncates block assembly at
+    // maxBlockSize. Without a shared instance (tars nodes, fixtures) a detached local one
+    // records+logs only.
+    if (!request.isArray() || request.size() != 2U)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams,
+            "miner_setMaxDASize expects exactly two quantities: maxTxSize, maxBlockSize"));
+    }
+    uint64_t maxTxSize = 0;
+    uint64_t maxBlockSize = 0;
+    try
+    {
+        maxTxSize = fromQuantity(std::string(toView(request[0U])));
+        maxBlockSize = fromQuantity(std::string(toView(request[1U])));
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(
+            InvalidParams, "miner_setMaxDASize quantities must be 0x-prefixed hex"));
+    }
+    auto& caps = daCaps();
+    caps.maxTxSize.store(maxTxSize, std::memory_order_relaxed);
+    caps.maxBlockSize.store(maxBlockSize, std::memory_order_relaxed);
+    WEB3_LOG(INFO) << LOG_BADGE("setMaxDASize") << LOG_KV("maxTxSize", maxTxSize)
+                   << LOG_KV("maxBlockSize", maxBlockSize)
+                   << LOG_KV("sharedWithEngine", m_nodeService->daCaps() ? "yes" : "no");
+    Json::Value result = true;
+    buildJsonContent(result, response);
+    co_return;
+}
 task::Task<void> EthEndpoint::gasPrice(const Json::Value&, Json::Value& response)
 {
-    // result: gasPrice(QTY)
+    // eth_gasPrice is a SUGGESTION for pricing legacy (type 0) transactions, not a chain
+    // parameter. op-geth (internal/ethapi/api.go GasPrice) computes it as suggested-tip +
+    // current-head-baseFee, and mainstream clients rely on the implicit contract that the
+    // value is >= the head baseFee: foundry's `cast send --legacy` signs with whatever
+    // this returns, and a below-baseFee legacy tx is silently rejected at seal time and
+    // evicted from the pool ("broadcast accepted, never confirmed").
+    //
+    // Chain-mode dispatch is intrinsic rather than configured: EIP-1559 chains (the OP
+    // path) always carry baseFee on the header, PBFT headers never write the tars field.
+    // The suggested tip reuses this node's eth_maxPriorityFeePerGas value (currently 0) —
+    // a single source of truth, and honest for our inert tip market: op-geth's OP-mode
+    // oracle likewise serves a constant floor (0.001 gwei) because with a single block
+    // builder tips do not affect inclusion while blocks have capacity. Its
+    // capacity-heuristic escalation (median-tip * 1.1 when the last block was full) is a
+    // deliberate omission here, to be revisited if this chain ever runs congested.
     auto const ledger = m_nodeService->ledger();
-    // TODO)): gas price can wrap in a class
+    if (auto const latest = co_await ledger::getCurrentBlockNumber(*ledger); latest >= 0)
+    {
+        auto block = co_await ledger::getBlockData(*ledger, latest, bcos::ledger::HEADER);
+        if (auto const& baseFee = block->blockHeader()->baseFee(); baseFee.has_value())
+        {
+            Json::Value result = toQuantity(*baseFee);
+            buildJsonContent(result, response);
+            co_return;
+        }
+    }
+    // Legacy PBFT path (headers without baseFee): keep serving the static
+    // SYSTEM_KEY_TX_GAS_PRICE knob so those chains' output stays byte-identical.
     auto config = co_await ledger::getSystemConfig(*ledger, ledger::SYSTEM_KEY_TX_GAS_PRICE);
     Json::Value result;
     if (config.has_value())
@@ -140,6 +259,133 @@ task::Task<void> EthEndpoint::gasPrice(const Json::Value&, Json::Value& response
         result = "0x0";
     }
     buildJsonContent(result, response);
+    co_return;
+}
+
+namespace
+{
+// OP-stack Holocene/Jovian next-baseFee prediction for eth_feeHistory's trailing entry.
+// predictNextBaseFee was a hand-mirrored port of the engine's calcOpBaseFee;
+// both layers now share ONE implementation: bcos-framework/engine/OpBaseFee.h
+// (linked by both bcos-engine and bcos-rpc). The RPC's fork detection stays
+// local — extraData length sniffing (>= 17 bytes => Jovian tail) — and feeds
+// the shared formula's parentIsJovian parameter.
+
+bool jovianFromExtraData(bcos::protocol::BlockHeader const& parent)
+{
+    return parent.extraData().size() >= 17;
+}
+}  // namespace
+
+task::Task<void> EthEndpoint::feeHistory(const Json::Value& request, Json::Value& response)
+{
+    // params: [blockCount(QTY), newestBlock(QTY|TAG), rewardPercentiles?(array of numbers)]
+    // result: {oldestBlock(QTY), baseFeePerGas(QTY[], resolved+1 entries with the trailing
+    //          predicted next base fee), gasUsedRatio(number[]), reward?(QTY[][])}
+    // (execution-apis fee_history). Foundry/alloy's EIP-1559 fee suggestion calls this on
+    // every send, so its absence breaks every default-fee cast send against the node.
+    uint64_t blockCount = 0;
+    try
+    {
+        blockCount = fromQuantity(std::string(toView(request[0U])));
+    }
+    catch (...)
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid blockCount"));
+    }
+    if (blockCount < 1 || blockCount > 1024)
+    {
+        BOOST_THROW_EXCEPTION(
+            JsonRpcException(InvalidParams, "blockCount must be between 1 and 1024"));
+    }
+    std::vector<double> percentiles;
+    if (request.size() > 2 && !request[2U].isNull())
+    {
+        if (!request[2U].isArray())
+        {
+            BOOST_THROW_EXCEPTION(
+                JsonRpcException(InvalidParams, "rewardPercentiles must be an array"));
+        }
+        for (auto const& p : request[2U])
+        {
+            if (!p.isNumeric())
+            {
+                BOOST_THROW_EXCEPTION(
+                    JsonRpcException(InvalidParams, "rewardPercentiles entries must be numbers"));
+            }
+            percentiles.push_back(p.asDouble());
+        }
+    }
+    auto const [newestNumber, _] = co_await getBlockNumberByTag(toView(request[1U]));
+    auto const newest = static_cast<uint64_t>(newestNumber);
+    auto const oldest = newest >= blockCount - 1 ? newest - (blockCount - 1) : 0;
+
+    auto const ledger = m_nodeService->ledger();
+    Json::Value result;
+    result["oldestBlock"] = toQuantity(oldest);
+    result["baseFeePerGas"] = Json::arrayValue;
+    result["gasUsedRatio"] = Json::arrayValue;
+    auto const wantReward = !percentiles.empty();
+    if (wantReward)
+    {
+        result["reward"] = Json::arrayValue;
+    }
+    protocol::BlockHeader::Ptr newestHeader;
+    for (auto n = oldest; n <= newest; ++n)
+    {
+        auto block = co_await ledger::getBlockData(
+            *ledger, static_cast<protocol::BlockNumber>(n), bcos::ledger::HEADER);
+        auto const& header = block->blockHeader();
+        auto const baseFee = header->baseFee().value_or(bcos::u256(0));
+        auto const gasLimit = static_cast<uint64_t>(header->gasLimit());
+        auto const gasUsed = static_cast<uint64_t>(header->gasUsed());
+        result["baseFeePerGas"].append(toQuantity(baseFee));
+        result["gasUsedRatio"].append(
+            gasLimit > 0 ? Json::Value(double(gasUsed) / double(gasLimit)) : Json::Value(0.0));
+        if (wantReward)
+        {
+            // Per-tx priority fee = effectiveGasPrice - baseFee (0 for legacy txs paying
+            // exactly baseFee); the percentile entry selects from the sorted list the way
+            // geth's feeHistory does (floor index, clamped).
+            auto receiptsBlock = co_await ledger::getBlockData(
+                *ledger, static_cast<protocol::BlockNumber>(n), bcos::ledger::RECEIPTS);
+            std::vector<bcos::u256> priorities;
+            for (auto const& receipt : receiptsBlock->receipts())
+            {
+                auto const& effective = receipt->effectiveGasPrice();
+                if (effective.empty())
+                {
+                    continue;
+                }
+                bcos::u256 effectiveFee{std::string(effective)};
+                priorities.push_back(
+                    effectiveFee > baseFee ? effectiveFee - baseFee : bcos::u256(0));
+            }
+            std::sort(priorities.begin(), priorities.end());
+            Json::Value rewards(Json::arrayValue);
+            for (auto const p : percentiles)
+            {
+                auto index = priorities.empty() ?
+                                 std::size_t(0) :
+                                 static_cast<std::size_t>(priorities.size() * p / 100.0);
+                if (index >= priorities.size())
+                {
+                    index = priorities.size() - 1;
+                }
+                rewards.append(toQuantity(priorities.empty() ? bcos::u256(0) : priorities[index]));
+            }
+            result["reward"].append(std::move(rewards));
+        }
+        newestHeader = header;
+    }
+    // Trailing entry: the predicted base fee of newest+1 from newest's own header.
+    if (newestHeader)
+    {
+        result["baseFeePerGas"].append(toQuantity(
+            bcos::engine::calcOpBaseFee(*newestHeader, jovianFromExtraData(*newestHeader))));
+    }
+    buildJsonContent(result, response);
+    co_return;
 }
 task::Task<void> EthEndpoint::accounts(const Json::Value&, Json::Value& response)
 {
@@ -192,7 +438,7 @@ bcos::task::Task<HistoricalMptContext> resolveHistoricalMptContext(
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
     }
-    // Round-2 Finding K: an empty state root (block 0 / empty blocks / pre-MPT blocks) is a
+    // An empty state root (block 0 / empty blocks / pre-MPT blocks) is a
     // legal "no accounts" root, not a missing node row — skip the root-presence check and let
     // MPTReadView (which handles emptyRootHash as "no accounts") plus the scenario flag decide
     // how absence reads: scenario B -> zero; scenario A -> honest dormant-account error.
@@ -283,8 +529,7 @@ static std::string storageValueToData(std::string_view value)
 {
     bcos::bytes word(32, 0);
     auto const copyLen = (std::min)(value.size(), word.size());
-    std::copy_n(
-        value.data(), copyLen, word.end() - static_cast<std::ptrdiff_t>(copyLen));
+    std::copy_n(value.data(), copyLen, word.end() - static_cast<std::ptrdiff_t>(copyLen));
     return toHex(word, "0x");
 }
 
@@ -301,8 +546,7 @@ task::Task<void> EthEndpoint::getStorageAt(const Json::Value& request, Json::Val
     boost::algorithm::to_lower(addressStr);
     auto position = toView(request[1u]);
     std::string positionStr = std::string(
-        (position.starts_with("0x") || position.starts_with("0X")) ? position.substr(2) :
-                                                                    position);
+        (position.starts_with("0x") || position.starts_with("0X")) ? position.substr(2) : position);
     if (position.size() % 2 != 0)
     {
         positionStr.insert(0, "0");
@@ -727,9 +971,11 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     auto rawTx = toView(request[0U]);
     auto rawTxBytes = fromHexWithPrefix(rawTx);
     auto bytesRef = bcos::ref(rawTxBytes);
-    // Authoritative first-byte dispatch (RawTransactionDispatch.h). L2 never admits blob
-    // (type-3) transactions, and deposits (0x7e) can only be injected by the consensus
-    // layer through the Engine API, never through the public transaction pool.
+    // Authoritative first-byte dispatch (RawTransactionDispatch.h). FISCO's OP policy rejects
+    // blob (type-3) at the gate — op-geth's decodeTyped accepts them, so this is a deliberate
+    // acceptance divergence, not a reference check (see the blob-rejection note in
+    // RawTransactionDispatch.h). Deposits (0x7e) can only be injected by the consensus layer
+    // through the Engine API, never through the public transaction pool.
     switch (engine::dispatchRawTransaction(bytesRef))
     {
     case engine::RawTransactionKind::Blob:
@@ -745,6 +991,15 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
     if (auto const error = codec::rlp::decode(bytesRef, web3Tx); error != nullptr) [[unlikely]]
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, error->errorMessage()));
+    }
+    // Defense-in-depth: the first-byte dispatch above already rejects 0x7e, and decode cannot
+    // produce type==Deposit from any other first byte. op-geth likewise rejects Deposit from
+    // eth_sendRawTransaction (ErrTxTypeNotSupported); deposits only enter via the
+    // derivation/engine path, never from a client RPC submission.
+    if (web3Tx.type == TransactionType::Deposit) [[unlikely]]
+    {
+        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams,
+            "Deposit (0x7e) transactions are not supported via eth_sendRawTransaction"));
     }
     auto encodeTxHash = web3Tx.txHash();
 
@@ -784,17 +1039,52 @@ task::Task<void> EthEndpoint::sendRawTransaction(const Json::Value& request, Jso
         // unparseable-nonce transactions). ChainId IS checked because dropping it would
         // disable EIP-155 replay protection: a transaction signed for another chain would
         // execute here and consume the sender's nonce.
-        if (auto chainIdConfig = co_await ledger::getSystemConfig(
-                *m_nodeService->ledger(), ledger::SYSTEM_KEY_WEB3_CHAIN_ID))
+        auto chainIdConfig = co_await ledger::getSystemConfig(
+            *m_nodeService->ledger(), ledger::SYSTEM_KEY_WEB3_CHAIN_ID);
+        if (!chainIdConfig)
         {
-            auto [chainId, _] = chainIdConfig.value();
-            // Legacy txs carry an empty/"0" chainId and are exempt (matches
-            // TxValidator::validateChainId).
-            if (!tx->chainId().empty() && tx->chainId() != "0" && tx->chainId() != chainId)
+            // Fail closed when web3_chain_id is unconfigured: without a node chainId to
+            // compare against, an EIP-155 tx signed for a foreign chain would execute here
+            // and consume the sender's nonce (EIP-155 replay-protection bypass). op-geth
+            // always has a genesis chainId, so it has no such open default. Only pre-EIP-155
+            // legacy (no chainId in the envelope) is exempt — there is nothing to compare.
+            auto const envelopeChainId = tx->web3ChainIdFromEnvelope();
+            if (envelopeChainId.has_value() ||
+                bcos::rlp::protocol::isTypedWeb3Envelope(tx->extraTransactionBytes()))
+            {
+                WEB3_LOG(WARNING) << LOG_DESC("sendRawTransaction: web3_chain_id not configured")
+                                  << LOG_KV("txChainId", tx->chainId());
+                BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "invalid chainId"));
+            }
+        }
+        else
+        {
+            auto [chainIdStr, _] = chainIdConfig.value();
+            // Validate against the SIGNED envelope like TxValidator::validateChainId: typed
+            // txs get no "0" exemption (op-geth modernSigner); only pre-EIP-155 legacy (no
+            // chainId in the envelope) is exempt — a deliberate divergence (geth/op-geth
+            // default rejects unprotected txs at the RPC layer; part 5 adds the config gate).
+            // Parse as u256 via the shared helper (ledger::parseWeb3ChainId); a corrupted
+            // config rejects the tx.
+            auto expected = ledger::parseWeb3ChainId(chainIdStr);
+            if (!expected.has_value())
+            {
+                BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "invalid chainId"));
+            }
+            auto const envelopeChainId = tx->web3ChainIdFromEnvelope();
+            if (envelopeChainId.has_value() && bcos::u256(*envelopeChainId) != *expected)
             {
                 WEB3_LOG(WARNING) << LOG_DESC("sendRawTransaction chainId mismatch")
                                   << LOG_KV("txChainId", tx->chainId())
-                                  << LOG_KV("nodeChainId", chainId);
+                                  << LOG_KV("nodeChainId", chainIdStr);
+                BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "invalid chainId"));
+            }
+            // Same typed-envelope guard as TxValidator::validateChainId: a typed tx whose
+            // chainId field cannot be parsed (nullopt) gets no "0" exemption — a malformed
+            // typed envelope is rejected here rather than deferring to signature recovery.
+            if (!envelopeChainId.has_value() &&
+                bcos::rlp::protocol::isTypedWeb3Envelope(tx->extraTransactionBytes()))
+            {
                 BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "invalid chainId"));
             }
         }
@@ -913,9 +1203,11 @@ task::Task<void> EthEndpoint::call(
                     else
                     {
                         // https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_call#returns
+                        // Reverted call -> op-geth style error: code 3 "execution reverted"
+                        // with the Error(string) reason decoded into the message.
                         Json::Value jsonResult = Json::objectValue;
-                        jsonResult["code"] = result->status();
-                        jsonResult["message"] = result->message();
+                        jsonResult["code"] = c_executionReverted;
+                        jsonResult["message"] = decodeRevertMessage(output);
                         jsonResult["data"] = output;
                         m_response["jsonrpc"] = "2.0";
                         m_response["error"] = std::move(jsonResult);
@@ -966,19 +1258,76 @@ task::Task<void> EthEndpoint::estimateGas(const Json::Value& request, Json::Valu
                         << LOG_KV("blockTag", blockTag) << LOG_KV("blockNumber", blockNumber);
     }
 
+    // op-geth's estimator answers the smallest gas limit at which the call still
+    // succeeds, found by simulating at candidate limits. The run below executes
+    // at the gas-less default cap (CallRequest defaults an absent gas field to
+    // 30M), so its gasUsed is mere consumption. A tx that hops through a proxy
+    // DELEGATECALL or any internal CALL retains 1/64 of the available gas at
+    // each hop (EIP-150), making the minimum viable limit strictly greater than
+    // the consumed gas — measured on the C2 devnet, the MessagePasser withdrawal
+    // (proxy predeploy) consumed 59186 but reverted on-chain at exactly that
+    // limit, while direct (non-proxy) calls are exact. So re-simulate at
+    // gasUsed first, and when that fails binary-search upward for the smallest
+    // viable limit, mirroring op-geth. Only object-form params carry an
+    // overridable gas field; a raw signed tx embeds its own.
+    auto const objectForm = tx.isObject();
+    auto const effectiveFirstRunLimit = [&]() -> u256 {
+        if (objectForm && tx.isMember("gas"))
+        {
+            try
+            {
+                return u256(fromQuantity(tx["gas"].asString()));
+            }
+            catch (...)
+            {}
+        }
+        return u256(30'000'000);
+    }();
+
     u256 gasUsed;
     Json::Value callResponse;
     co_await call(request, callResponse, std::addressof(gasUsed), true);
 
-    if (!callResponse.isMember("error"))
-    {
-        Json::Value result = toQuantity(gasUsed);
-        buildJsonContent(result, response);
-    }
-    else
+    if (callResponse.isMember("error"))
     {
         response = std::move(callResponse);
+        co_return;
     }
+
+    auto estimate = gasUsed;
+    if (objectForm && !co_await simulateAtGasLimit(request, estimate))
+    {
+        auto lowerBound = estimate;  // known-bad
+        auto upperBound = effectiveFirstRunLimit > lowerBound ?
+                              effectiveFirstRunLimit :
+                              lowerBound + 1;  // the first run succeeded at its own limit
+        while (upperBound - lowerBound > 1)
+        {
+            auto const mid = lowerBound + (upperBound - lowerBound) / 2;
+            if (co_await simulateAtGasLimit(request, mid))
+            {
+                upperBound = mid;
+            }
+            else
+            {
+                lowerBound = mid;
+            }
+        }
+        estimate = upperBound;
+    }
+
+    Json::Value result = toQuantity(estimate);
+    buildJsonContent(result, response);
+}
+
+task::Task<bool> EthEndpoint::simulateAtGasLimit(const Json::Value& request, u256 limit)
+{
+    Json::Value bounded = request;
+    bounded[0U]["gas"] = toQuantity(limit);
+    Json::Value callResponse;
+    u256 gasUsed;
+    co_await call(bounded, callResponse, std::addressof(gasUsed), true);
+    co_return !callResponse.isMember("error");
 }
 task::Task<void> EthEndpoint::getBlockByHash(const Json::Value& request, Json::Value& response)
 {
@@ -996,6 +1345,13 @@ task::Task<void> EthEndpoint::getBlockByHash(const Json::Value& request, Json::V
         flag |= fullTransaction ? bcos::ledger::TRANSACTIONS : bcos::ledger::TRANSACTIONS_HASH;
         auto block = co_await ledger::getBlockData(*ledger, number, flag);
         combineBlockResponse(result, *block, fullTransaction);
+        // Same canonical-hash override as getBlockByNumber: OP blocks' hash is the announced
+        // (registered) one, not the stored tars header's own derivation.
+        if (auto canonicalHash = co_await ledger::getBlockHash(*ledger, number);
+            canonicalHash != crypto::HashType{})
+        {
+            result["hash"] = canonicalHash.hexPrefixed();
+        }
     }
     catch (std::exception const& e)
     {
@@ -1020,6 +1376,14 @@ task::Task<void> EthEndpoint::getBlockByNumber(const Json::Value& request, Json:
         flag |= fullTransaction ? bcos::ledger::TRANSACTIONS : bcos::ledger::TRANSACTIONS_HASH;
         auto block = co_await ledger::getBlockData(*ledger, blockNumber, flag);
         combineBlockResponse(result, *block, fullTransaction);
+        // OP blocks' canonical hash is the announced one (keccak of the 21-field RLP header)
+        // registered in s_number_2_hash; the stored tars header's hash() is a different
+        // derivation and would break parentHash chains and byHash round-trips at the RPC.
+        if (auto canonicalHash = co_await ledger::getBlockHash(*ledger, blockNumber);
+            canonicalHash != crypto::HashType{})
+        {
+            result["hash"] = canonicalHash.hexPrefixed();
+        }
     }
     catch (std::exception const& e)
     {
@@ -1121,7 +1485,9 @@ task::Task<void> EthEndpoint::getTransactionByBlockNumberAndIndex(
             BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Invalid transaction index!"));
         }
         auto receipt = co_await ledger::getReceipt(*ledger, txHash);
-        auto blockHash = block->blockHeader()->hash();
+        // OP headers hash as keccak(encodeOpHeader), not the tars dataHash fallback — same fix
+        // as combineBlockResponse (R1).
+        auto blockHash = bcos::rpc::opAwareBlockHash(*block->blockHeader());
         combineTxResponse(result, *(*tx)[0], *receipt, blockHash);
     }
     catch (std::exception const& e)
@@ -1185,8 +1551,8 @@ task::Task<void> EthEndpoint::newFilter(const Json::Value& request, Json::Value&
     auto const ledger = m_nodeService->ledger();
     auto const latest = co_await ledger::getCurrentBlockNumber(*ledger);
     auto params = m_filterSystem->requestFactory()->create();
-    params->fromJson(jParams, latest, m_nodeService->safeBlockDepth(),
-        m_nodeService->finalizedBlockDepth());
+    params->fromJson(
+        jParams, latest, m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
     Json::Value result = co_await m_filterSystem->newFilter(params);
     buildJsonContent(result, response);
 }
@@ -1234,8 +1600,8 @@ task::Task<void> EthEndpoint::getLogs(const Json::Value& request, Json::Value& r
     auto const ledger = m_nodeService->ledger();
     auto const latest = co_await ledger::getCurrentBlockNumber(*ledger);
     auto params = m_filterSystem->requestFactory()->create();
-    params->fromJson(jParams, latest, m_nodeService->safeBlockDepth(),
-        m_nodeService->finalizedBlockDepth());
+    params->fromJson(
+        jParams, latest, m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
     Json::Value result = co_await m_filterSystem->getLogs(params);
     buildJsonContent(result, response);
 }
@@ -1244,8 +1610,28 @@ task::Task<std::tuple<protocol::BlockNumber, bool>> EthEndpoint::getBlockNumberB
 {
     auto ledger = m_nodeService->ledger();
     auto latest = co_await ledger::getCurrentBlockNumber(*ledger);
-    auto [number, _] = bcos::rpc::getBlockNumberByTag(latest, blockTag,
-        m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
+    // D2: safe/finalized route to the engine's FCU-tracked numbers (op-node
+    // L2BlockRefByLabel contract). With an engine service present but nothing tracked yet,
+    // op-geth semantics are "not found": getBlockByNumber's catch turns the throw into a
+    // JSON null result, while tag-taking state endpoints surface it as a JSON-RPC error.
+    // Nodes without an engine service (PBFT) keep the historical latest aliasing.
+    if (blockTag == SafeBlock || blockTag == FinalizedBlock)
+    {
+        auto& engineService = m_nodeService->engineService();
+        if (engineService)
+        {
+            auto tracked = (blockTag == SafeBlock) ? engineService->getSafeBlockNumber() :
+                                                     engineService->getFinalizedBlockNumber();
+            if (tracked.has_value())
+            {
+                co_return std::make_tuple(*tracked, *tracked == latest);
+            }
+            BOOST_THROW_EXCEPTION(JsonRpcException(
+                Web3DefaultError, std::string(blockTag) + " block head is not tracked yet"));
+        }
+    }
+    auto [number, _] = bcos::rpc::getBlockNumberByTag(
+        latest, blockTag, m_nodeService->safeBlockDepth(), m_nodeService->finalizedBlockDepth());
     co_return std::make_tuple(number, std::cmp_equal(latest, number));
 }
 
@@ -1293,7 +1679,7 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
         }
     }
     auto const blockTag = toView(request[2U]);
-    auto [blockNumber, _] = co_await getBlockNumberByTag(blockTag);
+    auto [blockNumber, isLatest] = co_await getBlockNumberByTag(blockTag);
     if (c_fileLogLevel == TRACE)
     {
         WEB3_LOG(TRACE) << "eth_getProof" << LOG_KV("address", address.hexPrefixed())
@@ -1308,37 +1694,117 @@ task::Task<void> EthEndpoint::getProof(const Json::Value& request, Json::Value& 
     {
         BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Block not found"));
     }
-    auto const stateRoot = block->blockHeader()->stateRoot();
+    auto stateRoot = block->blockHeader()->stateRoot();
 
-    // The MPT node reader is wired by the AIR initializer (AirNodeInitializer); unset means
-    // this node has no local path to MPT node rows (e.g. a tars-built NodeService) — a
-    // deployment matter, hence -32603 rather than -32004.
-    auto const mptReader = m_nodeService->mptNodeReader();
-    if (!mptReader) [[unlikely]]
+    ledger::mpt::EIP1186Proof proof;
+    if (block->blockHeader()->baseFee().has_value())
     {
-        BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
+        // OP-stack execution path: its headers always carry baseFee (PBFT headers never write
+        // the tars field — the same discriminator gasPrice/feeHistory use). Pre-①a that path
+        // computed each block's stateRoot from the flat state at seal time and persisted no
+        // MPT node rows. With ①a (feature_l2_ethereum_compat: OpScheduler's incremental
+        // buildAndCollect at commit + the l2EthereumCompat genesis import) runtime blocks DO
+        // persist their trie nodes, so try the node-backed proof FIRST — it serves ANY height
+        // (historical tags included, which the one-version flat plane below cannot) and is
+        // O(path). Roots without rows (a chain segment produced before ①a landed) report
+        // BlockNotCommitted and fall through to the flat rebuild, preserving the latest-only
+        // contract for those segments.
+        bool servedFromNodes = false;
+        if (auto const mptReader = m_nodeService->mptNodeReader())
+        {
+            auto const fullTrie = co_await ledger::getFeature(
+                *ledger, ledger::Features::Flag::feature_l2_ethereum_compat, blockNumber);
+            auto result = co_await ledger::mpt::generateProof(
+                *mptReader, stateRoot, address, std::span<h256 const>(slots), fullTrie);
+            if (auto* built = std::get_if<ledger::mpt::EIP1186Proof>(&result))
+            {
+                proof = std::move(*built);
+                servedFromNodes = true;
+            }
+            else if (std::get<ledger::mpt::ProofErrorCode>(result) !=
+                     ledger::mpt::ProofErrorCode::BlockNotCommitted)
+            {
+                BOOST_THROW_EXCEPTION(JsonRpcException(
+                    EthGetProofUnavailable, "Account not in trie (dormant in scenario A)"));
+            }
+        }
+        if (!servedFromNodes)
+        {
+            // Flat-state fallback: rebuild the trie from the committed flat plane, gated on the
+            // requested block's root (generateProofFromFlat's RootMismatch check).
+            auto const& stateProvider = m_nodeService->stateStorageProvider();
+            if (!stateProvider) [[unlikely]]
+            {
+                BOOST_THROW_EXCEPTION(
+                    JsonRpcException(InternalError, "Flat state reader not wired on this node"));
+            }
+            for (int attempt = 0;; ++attempt)
+            {
+                auto view = stateProvider();
+                auto opResult = co_await ledger::mpt::generateProofFromFlat(
+                    *view, stateRoot, address, std::span<h256 const>(slots));
+                if (auto* built = std::get_if<ledger::mpt::EIP1186Proof>(&opResult))
+                {
+                    proof = std::move(*built);
+                    break;
+                }
+                auto const code = std::get<ledger::mpt::ProofErrorCode>(opResult);
+                if (code == ledger::mpt::ProofErrorCode::RootMismatch && isLatest && attempt < 2)
+                {
+                    // A block committed between the tag resolution and the view fork makes the
+                    // header and the flat plane disagree by one version. Re-resolve and rebuild;
+                    // an explicit older block/tag keeps failing — the flat plane holds exactly one
+                    // state version (latest committed), and a mismatch there is the honest answer.
+                    std::tie(blockNumber, isLatest) = co_await getBlockNumberByTag(blockTag);
+                    auto reblock =
+                        co_await ledger::getBlockData(*ledger, blockNumber, bcos::ledger::HEADER);
+                    if (!reblock || !reblock->blockHeader()) [[unlikely]]
+                    {
+                        BOOST_THROW_EXCEPTION(JsonRpcException(InvalidParams, "Block not found"));
+                    }
+                    stateRoot = reblock->blockHeader()->stateRoot();
+                    continue;
+                }
+                BOOST_THROW_EXCEPTION(JsonRpcException(EthGetProofUnavailable,
+                    code == ledger::mpt::ProofErrorCode::RootMismatch ?
+                        "Requested block state is not available (OP path serves the latest "
+                        "committed state only)" :
+                        "Account not in trie (dormant in scenario A)"));
+            }
+        }
     }
-
-    // The exclusion-vs-cold-slot distinction is mode-driven (spec §5.9): only under
-    // feature_l2_ethereum_compat (scenario B) are the storage tries complete, making an
-    // exclusion walk a provable zero. Otherwise (scenario A) the trie omits slots never
-    // written after MPT activation, and generateProof marks such slots inMPT=false instead
-    // of emitting a lying value-0 exclusion proof. Single-flag read (one SYS_CONFIG row,
-    // same helper as resolveHistoricalMptContext); degrades to false (honest scenario-A
-    // behavior) on fetch failure.
-    auto const fullTrie = co_await ledger::getFeature(
-        *ledger, ledger::Features::Flag::feature_l2_ethereum_compat, blockNumber);
-
-    auto result = co_await ledger::mpt::generateProof(
-        *mptReader, stateRoot, address, std::span<h256 const>(slots), fullTrie);
-    if (auto const* errorCode = std::get_if<ledger::mpt::ProofErrorCode>(&result))
+    else
     {
-        auto const* message = (*errorCode == ledger::mpt::ProofErrorCode::AccountNotInMPT) ?
-                                  "Account not in trie (dormant in scenario A)" :
-                                  "Block stateRoot not in MPT node storage";
-        BOOST_THROW_EXCEPTION(JsonRpcException(EthGetProofUnavailable, message));
+        // The MPT node reader is wired by the AIR initializer (AirNodeInitializer); unset means
+        // this node has no local path to MPT node rows (e.g. a tars-built NodeService) — a
+        // deployment matter, hence -32603 rather than -32004.
+        auto const mptReader = m_nodeService->mptNodeReader();
+        if (!mptReader) [[unlikely]]
+        {
+            BOOST_THROW_EXCEPTION(JsonRpcException(InternalError, "MPT not enabled on this node"));
+        }
+
+        // The exclusion-vs-cold-slot distinction is mode-driven (spec §5.9): only under
+        // feature_l2_ethereum_compat (scenario B) are the storage tries complete, making an
+        // exclusion walk a provable zero. Otherwise (scenario A) the trie omits slots never
+        // written after MPT activation, and generateProof marks such slots inMPT=false instead
+        // of emitting a lying value-0 exclusion proof. Single-flag read (one SYS_CONFIG row,
+        // same helper as resolveHistoricalMptContext); degrades to false (honest scenario-A
+        // behavior) on fetch failure.
+        auto const fullTrie = co_await ledger::getFeature(
+            *ledger, ledger::Features::Flag::feature_l2_ethereum_compat, blockNumber);
+
+        auto result = co_await ledger::mpt::generateProof(
+            *mptReader, stateRoot, address, std::span<h256 const>(slots), fullTrie);
+        if (auto const* errorCode = std::get_if<ledger::mpt::ProofErrorCode>(&result))
+        {
+            auto const* message = (*errorCode == ledger::mpt::ProofErrorCode::AccountNotInMPT) ?
+                                      "Account not in trie (dormant in scenario A)" :
+                                      "Block stateRoot not in MPT node storage";
+            BOOST_THROW_EXCEPTION(JsonRpcException(EthGetProofUnavailable, message));
+        }
+        proof = std::move(std::get<ledger::mpt::EIP1186Proof>(result));
     }
-    auto& proof = std::get<ledger::mpt::EIP1186Proof>(result);
 
     Json::Value output = Json::objectValue;
     output["address"] = address.hexPrefixed();
@@ -1414,3 +1880,23 @@ bcos::rpc::EthEndpoint::EthEndpoint(
     m_filterSystem(std::move(filterSystem)),
     m_syncTransaction(syncTransaction)
 {}
+
+// Lazy shared-cap resolution: prefer the engine-shared instance from NodeService;
+// fall back to a detached local one so unset wiring (tars nodes, unit fixtures)
+// still records+logs instead of crashing.
+bcos::engine::DACaps& EthEndpoint::daCaps()
+{
+    if (m_daCaps)
+    {
+        return *m_daCaps;
+    }
+    if (auto shared = m_nodeService->daCaps(); shared)
+    {
+        m_daCaps = std::move(shared);
+    }
+    else
+    {
+        m_daCaps = std::make_shared<bcos::engine::DACaps>();
+    }
+    return *m_daCaps;
+}

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.h
@@ -19,11 +19,14 @@
  */
 
 #pragma once
+#include <bcos-framework/engine/DACaps.h>
 #include <bcos-framework/ledger/Ledger.h>
 #include <bcos-rpc/groupmgr/GroupManager.h>
 #include <bcos-rpc/jsonrpc/JsonRpcInterface.h>
 #include <bcos-rpc/web3jsonrpc/Web3FilterSystem.h>
 #include <json/json.h>
+
+#include <atomic>
 
 namespace bcos::rpc
 {
@@ -44,6 +47,7 @@ public:
     task::Task<void> mining(const Json::Value&, Json::Value&);
     task::Task<void> hashrate(const Json::Value&, Json::Value&);
     task::Task<void> gasPrice(const Json::Value&, Json::Value&);
+    task::Task<void> feeHistory(const Json::Value&, Json::Value&);
     task::Task<void> accounts(const Json::Value&, Json::Value&);
     task::Task<void> blockNumber(const Json::Value&, Json::Value&);
     task::Task<void> getBalance(const Json::Value&, Json::Value&);
@@ -79,13 +83,26 @@ public:
         std::string_view blockTag);
     task::Task<void> maxPriorityFeePerGas(const Json::Value&, Json::Value&);
     task::Task<void> getProof(const Json::Value&, Json::Value&);
+    task::Task<void> setMaxDASize(const Json::Value&, Json::Value&);
 
 private:
     NodeService::Ptr m_nodeService;
     FilterSystem::Ptr m_filterSystem;
     bool m_syncTransaction;
 
+    /// Shared DA throttling caps with the engine's OP build path (see NodeService::
+    /// setDACaps). miner_setMaxDASize writes here; the engine's buildOpPayload filters
+    /// oversized sealed txs (maxTxSize) and truncates block assembly (maxBlockSize).
+    /// When NodeService carries no shared instance (tars-built nodes, unit fixtures) a
+    /// detached local instance is created — recorded and logged, never consumed.
+    std::shared_ptr<bcos::engine::DACaps> m_daCaps;
+    bcos::engine::DACaps& daCaps();
+
     task::Task<void> call(const Json::Value&, Json::Value&, u256* gasUsed, bool isEstimate);
+
+    // Runs an eth_call with the gas field pinned to @p limit; true when the
+    // simulation succeeds (estimateGas' minimum-viable-limit search).
+    task::Task<bool> simulateAtGasLimit(const Json::Value& request, u256 limit);
 };
 
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthMethods.h
@@ -52,6 +52,7 @@ enum class EthMethod
     eth_mining,
     eth_hashrate,
     eth_gasPrice,
+    eth_feeHistory,
     eth_accounts,
     eth_blockNumber,
     eth_getBalance,
@@ -84,7 +85,8 @@ enum class EthMethod
     eth_getFilterLogs,
     eth_getLogs,
     eth_maxPriorityFeePerGas,
-    eth_getProof
+    eth_getProof,
+    miner_setMaxDASize
 };
 
 [[maybe_unused]] static std::string methodString(EthMethod _method)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -1,15 +1,25 @@
 #include "BlockResponse.h"
 #include "Log.h"
 
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <bcos-utilities/Bloom.h>
 
 #include <range/v3/view/enumerate.hpp>
+
+bcos::crypto::HashType bcos::rpc::opAwareBlockHash(const bcos::protocol::BlockHeader& header)
+{
+    if (!header.withdrawalsRoot().has_value())
+    {
+        return header.hash();
+    }
+    return bcos::protocol::EthBlockHeader::computeHash(header);
+}
 
 void bcos::rpc::combineBlockResponse(
     Json::Value& result, const bcos::protocol::Block& block, bool fullTxs)
 {
     auto blockHeader = block.blockHeader();
-    auto blockHash = blockHeader->hash();
+    auto blockHash = opAwareBlockHash(*blockHeader);
     auto blockNumber = blockHeader->number();
     result["number"] = toQuantity(blockNumber);
     result["hash"] = blockHash.hexPrefixed();
@@ -50,12 +60,27 @@ void bcos::rpc::combineBlockResponse(
         result["miner"] = "0x0000000000000000000000000000000000000000";
         result["parentHash"] = "0x0000000000000000000000000000000000000000000000000000000000000000";
     }
+    // Engine-built blocks (OP sequencer path) have an empty sealerList — the miner/coinbase
+    // is the execution payload's feeRecipient, which is stored in the header's coinbase()
+    // field (set by rebuildOpEthHeader from the payload attributes). Clients like alloy/cast
+    // require this field for deserialization; without it eth_getBlockByNumber fails.
+    if (!result.isMember("miner"))
+    {
+        auto coinbase = blockHeader->coinbase();
+        auto coinbaseString = coinbase.hex();
+        auto coinbaseHash = crypto::keccak256Hash(bytesConstRef(coinbaseString)).hex();
+        toChecksumAddress(coinbaseString, coinbaseHash);
+        result["miner"] = "0x" + coinbaseString;
+    }
     result["difficulty"] = "0x0";
     result["totalDifficulty"] = "0x0";
     result["extraData"] = toHexStringWithPrefix(blockHeader->extraData());
     result["size"] = toQuantity(block.size());
-    // TODO: change it wen block gas limit apply
-    result["gasLimit"] = toQuantity(30000000ULL);
+    // gasLimit: engine-built/genesis blocks carry the real limit in the header (OP newPayload
+    // via rebuildOpEthHeader, genesis via applyEthGenesisHeader); PBFT blocks never write it
+    // (tars field empty -> u256(0)) and keep the legacy 30M so their output is byte-identical.
+    auto gasLimit = blockHeader->gasLimit();
+    result["gasLimit"] = (gasLimit == 0) ? toQuantity(30000000ULL) : toQuantity(gasLimit);
     result["gasUsed"] = toQuantity((uint64_t)blockHeader->gasUsed());
     result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);  // to seconds
     if (fullTxs)
@@ -79,12 +104,64 @@ void bcos::rpc::combineBlockResponse(
         result["transactions"] = std::move(txHashesList);
     }
     result["uncles"] = Json::Value(Json::arrayValue);
-    result["mixHash"] = crypto::HashType().hexPrefixed();
-    result["baseFeePerGas"] = "0x0";
+    // mixHash is the header's prevRandao slot. OP headers store the payload attributes'
+    // prevRandao there (op-node sets keccak256(L1 block hash)) and the blockHash covers it,
+    // so serving a fabricated zero breaks hash-recomputing clients (go-ethereum's ethclient,
+    // op-batcher, ...) — they derive a different hash and reject the chain ("block does not
+    // extend existing chain"). PBFT headers never write the tars field (empty -> zero h256),
+    // keeping their output byte-identical.
+    result["mixHash"] = blockHeader->prevRandao().hexPrefixed();
+    // baseFeePerGas: OP headers (engine-built / newPayload-rebuilt) carry the real EIP-1559
+    // value; PBFT headers never write the tars field (nullopt, or 0) and keep the legacy 0x0
+    // so their output stays byte-identical — same pattern as gasLimit above.
+    if (auto baseFee = blockHeader->baseFee(); baseFee.has_value() && *baseFee != 0)
+    {
+        result["baseFeePerGas"] = toQuantity(*baseFee);
+    }
+    else
+    {
+        result["baseFeePerGas"] = "0x0";
+    }
     result["withdrawals"] = Json::Value(Json::arrayValue);
-    // empty withdrawals trie root hash
-    result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
-    result["blobGasUsed"] = "0x0";
+    // Isthmus+: the header carries the MessagePasser storage root as withdrawalsRoot (the OP
+    // semantic — set by the executed seal and rebuilt by the engine); pre-Isthmus/PBFT headers
+    // have no value (nullopt) and keep the legacy zero.
+    if (auto withdrawalsRoot = blockHeader->withdrawalsRoot(); withdrawalsRoot.has_value())
+    {
+        result["withdrawalsRoot"] = withdrawalsRoot->hexPrefixed();
+    }
+    else
+    {
+        result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
+    }
+    // blobGasUsed: pre-Jovian OP headers store 0 (identical output); Jovian reuses the header
+    // slot for the DA footprint, which the RPC must surface. PBFT headers never write the
+    // tars field (nullopt) and keep the legacy 0x0. excessBlobGas stays the constant 0: OP
+    // Stack chains serve no blobs and no header field carries it.
+    if (auto blobGasUsed = blockHeader->blobGasUsed(); blobGasUsed.has_value())
+    {
+        result["blobGasUsed"] = toQuantity(*blobGasUsed);
+    }
+    else
+    {
+        result["blobGasUsed"] = "0x0";
+    }
     result["excessBlobGas"] = "0x0";
-    result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
+    // EIP-4788: pre-Cancun/PBFT headers have no PBBR (accessor returns nullopt when the
+    // tars field is < 32 bytes) -> zero, symmetric with withdrawalsRoot above.
+    if (auto parentBeaconRoot = blockHeader->parentBeaconBlockRoot(); parentBeaconRoot.has_value())
+    {
+        result["parentBeaconBlockRoot"] = parentBeaconRoot->hexPrefixed();
+    }
+    else
+    {
+        result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
+    }
+    // EIP-7685 requestsHash: Isthmus+ OP headers carry sha256('') (set by the seal and rebuilt
+    // by the engine); PBFT/pre-Isthmus headers have no value (nullopt) and keep the field
+    // absent -- symmetric with op-geth (internal/ethapi/api.go:1092-1094, omitempty).
+    if (auto requestsHash = blockHeader->requestsHash(); requestsHash.has_value())
+    {
+        result["requestsHash"] = requestsHash->hexPrefixed();
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.h
@@ -30,4 +30,11 @@ namespace bcos::rpc
 {
 void combineBlockResponse(
     Json::Value& result, const bcos::protocol::Block& block, bool fullTxs = false);
+
+/// OP-aware block hash. OP headers (Isthmus+ always carry `withdrawalsRoot`; FISCO non-OP
+/// headers never do) hash as keccak(encodeOpHeader) with the post-merge protocol constants — the
+/// hash the OP block tables (`s_number_2_hash`) and op-node agree on — instead of the tars
+/// `dataHash` fallback (which the read path re-derives as a FISCO tars hash). Shared by
+/// `combineBlockResponse` and `getTransactionByBlockNumberAndIndex` so both read paths agree.
+bcos::crypto::HashType opAwareBlockHash(const bcos::protocol::BlockHeader& header);
 }  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/CallRequest.cpp
@@ -19,8 +19,11 @@
  */
 
 #include "CallRequest.h"
+#include "Web3Transaction.h"
+#include "bcos-crypto/ChecksumAddress.h"
 #include "bcos-executor/src/precompiled/common/Utilities.h"
 #include "bcos-task/Wait.h"
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <algorithm>
 
 using namespace bcos;
@@ -61,6 +64,71 @@ bcos::protocol::Transaction::Ptr CallRequest::takeToTransaction(
                 }
             }
         }
+    }
+    // The OP-line call pipeline (OpstackExecutor::m_prepare → opValidate) prices every call
+    // through the transaction's RLP envelope bytes and rejects an empty envelope with EINVAL
+    // ("Invalid argument" at the RPC) — so build the simulation tx via
+    // Web3Transaction::takeToTarsTransaction, which stores the envelope in
+    // extraTransactionBytes. Unsigned legacy shape: chainId stays nullopt (pre-EIP-155
+    // exemption from the node chain-id check), dummy r/s mirror the scheduler-test fixture
+    // (the sender is forced below regardless). gasPrice defaults to 2 gwei when the request
+    // omits pricing so the fee-cap check against a nonzero block base fee (genesis: 1e9)
+    // does not reject pricing-less simulations — op-geth skips fee validation for eth_call
+    // entirely (known divergence).
+    auto quantity = [](std::optional<std::string> const& s) -> std::optional<u256> {
+        if (!s || s->empty())
+        {
+            return std::nullopt;
+        }
+        try
+        {
+            return fromBigQuantity(*s);
+        }
+        catch (...)
+        {
+            return std::nullopt;
+        }
+    };
+    try
+    {
+        Web3Transaction w3{};
+        w3.type = TransactionType::Legacy;
+        w3.chainId = std::nullopt;
+        if (!to.empty())
+        {
+            w3.to = Address(to);
+        }
+        w3.data = data;
+        w3.value = quantity(value).value_or(u256(0));
+        w3.nonce = 0;
+        // op-geth caps a gas-less eth_call at its RPC gas cap; default to the 30M block-gas
+        // convention so a pricing-less simulation passes the intrinsic-gas check.
+        w3.gasLimit = gas.value_or(30'000'000);
+        w3.maxPriorityFeePerGas =
+            quantity(gasPrice).value_or(quantity(maxFeePerGas).value_or(u256(2'000'000'000)));
+        w3.signatureV = 0;
+        w3.signatureR = bcos::bytes(32, 0x01);
+        w3.signatureS = bcos::bytes(32, 0x02);
+        auto tarsHolder = std::make_shared<bcostars::Transaction>(w3.takeToTarsTransaction());
+        // takeToTarsTransaction renders the numeric nonce; restore the passthrough semantics
+        // the RPC contract has (converted hex quantity, or empty when unknown — the executor
+        // then falls back to the sender's state nonce).
+        tarsHolder->data.nonce = nonce;
+        auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+            [tarsHolder]() { return tarsHolder.get(); });
+        if (from.has_value())
+        {
+            if (auto const sender = safeFromHexWithPrefix(from.value()))
+            {
+                tx->forceSender(sender.value());
+            }
+        }
+        return tx;
+    }
+    catch (...)
+    {
+        // noexcept guard: any conversion surprise falls back to the plain factory tx (the
+        // pre-envelope behavior) rather than aborting the RPC.
     }
     auto tx = factory->createTransaction(1, std::move(this->to), this->data, nonce, 0, {}, {}, 0,
         "", value.value_or(""), gasPrice.value_or(""), gas.value_or(0), maxFeePerGas.value_or(""),

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/DepositTransaction.cpp
@@ -143,8 +143,10 @@ void bcos::rpc::combineDepositTxResponse(Json::Value& result, const DepositTrans
         // op-geth emits isSystemTx only when true.
         result["isSystemTx"] = true;
     }
-    // Deposits carry no nonce (the deposit nonce lives in the receipt), no gas price and
-    // no signature; op-geth emits zero quantities for these.
+    // Deposits carry no nonce field of their own (the deposit nonce lives in the receipt —
+    // combineTxResponse overwrites this 0x0 with the receipt's depositNonce for mined
+    // deposits, Regolith+ semantics), no gas price and no signature; op-geth emits zero
+    // quantities for these when the receipt is unavailable.
     result["nonce"] = "0x0";
     result["gasPrice"] = "0x0";
     result["v"] = "0x0";

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -2,9 +2,9 @@
 #include "Log.h"
 #include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
-#include <bcos-crypto/hash/Keccak256.h>
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-crypto/hash/Keccak256.h>
 #include <cstdint>
 
 void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::TransactionReceipt& receipt,
@@ -18,7 +18,14 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     result["status"] = toQuantity(status);
     auto txHashHex = tx.hash().hexPrefixed();
     result["transactionHash"] = txHashHex;
-    auto cumulativeGasUsed = safeCastToU256(receipt.cumulativeGasUsed());
+    // OP receipts store cumulativeGasUsed as "0x" + lowercase hex (op-geth hexutil.Uint64,
+    // hexCumulative in OpBlockExecute.cpp). safeCastToU256's boost::lexical_cast parses in
+    // decimal and rejects the 0x prefix, yielding 0 — so parse via direct u256 construction,
+    // which auto-detects the base (0x → hex, otherwise decimal) for both OP and ethereum receipts.
+    bcos::u256 cumulativeGasUsed{};
+    auto const& cgs = receipt.cumulativeGasUsed();
+    if (!cgs.empty())
+        cumulativeGasUsed = bcos::u256(std::string(cgs));
     size_t logIndex = receipt.logIndex();
     auto transactionIndex = toQuantity(receipt.transactionIndex());
     result["transactionIndex"] = transactionIndex;
@@ -27,6 +34,9 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     auto blockNumber = receipt.blockNumber();
     result["blockNumber"] = toQuantity(blockNumber);
     auto from = toHex(tx.sender());
+    // EIP-55 checksum needs keccak256(address) per recipient; RPC read path (not consensus),
+    // so the 3-4 hashes per receipt are acceptable — caching here would need shared-state
+    // synchronization for a marginal win (see review Finding J).
     toChecksumAddress(from, bcos::crypto::keccak256Hash(bcos::bytesConstRef(from)).hex());
     result["from"] = "0x" + std::move(from);
     if (tx.to().empty())
@@ -58,12 +68,10 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
     result["logs"] = Json::arrayValue;
     auto* mutableReceipt = std::addressof(receipt);
     auto receiptLog = mutableReceipt->takeLogEntries();
-    Logs logs;
-    logs.reserve(receiptLog.size());
     for (size_t i = 0; i < receiptLog.size(); i++)
     {
         Json::Value log;
-        auto address = std::string(receiptLog[i].address());
+        auto address = toLogAddressHex(receiptLog[i].address());
         toChecksumAddress(address, bcos::crypto::keccak256Hash(bcos::bytesConstRef(address)).hex());
         log["address"] = "0x" + std::move(address);
         log["topics"] = Json::arrayValue;
@@ -75,24 +83,60 @@ void bcos::rpc::combineReceiptResponse(Json::Value& result, protocol::Transactio
         log["logIndex"] = toQuantity(logIndex + i);
         log["blockNumber"] = toQuantity(blockNumber);
         log["blockHash"] = blockHashHex;
-        log["transactionIndex"] = toQuantity(transactionIndex);
+        // transactionIndex is already the quantity string computed above; re-running it
+        // through toQuantity would hit the Binary overload (string is a contiguous range)
+        // and hex-encode the ASCII bytes ("0x1" -> "0x307831").
+        log["transactionIndex"] = transactionIndex;
         log["transactionHash"] = txHashHex;
         log["removed"] = false;
         result["logs"].append(std::move(log));
-        rpc::Log logObj{.address = receiptLog[i].takeAddress(),
-            .topics = receiptLog[i].takeTopics(),
-            .data = receiptLog[i].takeData()};
-        logs.push_back(std::move(logObj));
     }
     result["logsBloom"] = toHexStringWithPrefix(receipt.logsBloom());
+    // EIP-2718 tx type: for a Web3 tx the authoritative kind is the `web3TypedTxKind` tars slot,
+    // populated by Web3Transaction::takeToTarsTransaction for EVERY Web3 kind (Legacy=0,
+    // EIP-2930=1, EIP-1559=2, EIP-4844=3, Deposit=0x7e). Byte-sniffing extraTransactionBytes was
+    // wrong for typed non-deposit txs: the write side stores encodeForSign() there (RLP WITHOUT
+    // the type byte, first byte is a 0xC0+ list header), so the old `< BYTES_HEAD_BASE` sniff
+    // collapsed EIP-2930/1559/4844 receipts into Legacy 0x0 — while eth_getTransactionByHash
+    // correctly reported 0x01/0x02/0x03. For non-Web3 (BCOS) txs web3TypedTxKind() is 0 == Legacy,
+    // matching the old empty-extraTransactionBytes path.
     auto type = TransactionType::Legacy;
-    if (!tx.extraTransactionBytes().empty())
+    if (tx.type() == bcos::protocol::TransactionType::Web3Transaction)
     {
-        if (auto firstByte = tx.extraTransactionBytes()[0];
-            firstByte < bcos::codec::rlp::BYTES_HEAD_BASE)
-        {
-            type = static_cast<TransactionType>(firstByte);
-        }
+        // web3TypedTxKind is a display-grade mirror byte — value-domain check rather than a bare
+        // static_cast so a forged/unknown kind renders as Legacy instead of a garbage number.
+        type = magic_enum::enum_cast<TransactionType>(tx.web3TypedTxKind()).value_or(type);
     }
     result["type"] = toQuantity(static_cast<uint64_t>(type));
+    // OP extension fields (aligned with op-geth MarshalReceipt). Empty opStackMeta → no output
+    // (never zero/default values); each field is null-checked independently and never throws (D7).
+    if (auto meta = receipt.opStackMeta())
+    {
+        if (meta->l1_gas_price)
+            result["l1GasPrice"] = toQuantity(*meta->l1_gas_price);
+        if (meta->l1_gas_used)
+            result["l1GasUsed"] = toQuantity(*meta->l1_gas_used);
+        if (meta->l1_fee)
+            result["l1Fee"] = toQuantity(*meta->l1_fee);
+        if (meta->l1_blob_base_fee)
+            result["l1BlobBaseFee"] = toQuantity(*meta->l1_blob_base_fee);
+        if (meta->l1_base_fee_scalar)
+            result["l1BaseFeeScalar"] = toQuantity(*meta->l1_base_fee_scalar);
+        if (meta->l1_blob_base_fee_scalar)
+            result["l1BlobBaseFeeScalar"] = toQuantity(*meta->l1_blob_base_fee_scalar);
+        if (meta->operator_fee_scalar)
+            result["operatorFeeScalar"] = toQuantity(*meta->operator_fee_scalar);
+        if (meta->operator_fee_constant)
+            result["operatorFeeConstant"] = toQuantity(*meta->operator_fee_constant);
+        if (meta->da_footprint_gas_scalar)
+            result["daFootprintGasScalar"] = toQuantity(*meta->da_footprint_gas_scalar);
+        if (meta->da_footprint)
+            result["blobGasUsed"] = toQuantity(*meta->da_footprint);  // Jovian reuses da_footprint
+        if (meta->deposit_nonce)
+            result["depositNonce"] = toQuantity(*meta->deposit_nonce);
+        if (meta->deposit_receipt_version)
+            result["depositReceiptVersion"] = toQuantity(*meta->deposit_receipt_version);
+        if (meta->operator_fee)
+            result["operatorFee"] = toQuantity(*meta->operator_fee);  // FISCO extension
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -2,6 +2,7 @@
 #include "bcos-rpc/web3jsonrpc/model/DepositTransaction.h"
 #include "bcos-rpc/web3jsonrpc/model/Web3Transaction.h"
 #include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-rpc/jsonrpc/Common.h>  // WEB3_LOG
 
 void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Transaction& tx,
     const protocol::TransactionReceipt& receipt, const crypto::HashType& blockHash)
@@ -12,6 +13,28 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
     {
         auto gasPrice = receipt.effectiveGasPrice();
         result["gasPrice"] = std::string{gasPrice.empty() ? "0x0" : gasPrice};
+    }
+
+    // OP Stack deposit (0x7e): the tx JSON nonce must reflect the deposit's actual
+    // execution nonce (Regolith+ semantics — the deposit nonce lives in the receipt,
+    // deposits carry no nonce field of their own). The base combineTxResponse above
+    // emits 0x0; overwrite it with the receipt's depositNonce when present, so
+    // contract-address derivation (keccak(rlp([sender, nonce]))[12:]) and wallets see
+    // the value op-geth reports. Without the meta the deposit was never executed (or is
+    // a pre-Regolith block) and 0x0 stands.
+    if (auto extraBytes = tx.extraTransactionBytes();
+        !extraBytes.empty() && extraBytes[0] == c_depositTxType)
+    {
+        if (auto meta = receipt.opStackMeta(); meta.has_value() && meta->deposit_nonce)
+        {
+            result["nonce"] = toQuantity(*meta->deposit_nonce);
+            // op-geth also surfaces depositReceiptVersion on the tx object
+            // (internal/ethapi/api.go:1210-1213); absent without the meta.
+            if (meta->deposit_receipt_version)
+            {
+                result["depositReceiptVersion"] = toQuantity(*meta->deposit_receipt_version);
+            }
+        }
     }
 }
 
@@ -87,20 +110,38 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
         Web3Transaction web3Tx;
         auto extraBytesRef = bcos::bytesRef(const_cast<byte*>(tx.extraTransactionBytes().data()),
             tx.extraTransactionBytes().size());
-        codec::rlp::decodeFromPayload(extraBytesRef, web3Tx);
+        if (auto error = codec::rlp::decodeFromPayload(extraBytesRef, web3Tx); error != nullptr)
+        {
+            // Undecodable web3 payload (corrupt extraTransactionBytes, or a tars mirror that
+            // diverged from the envelope): never serialize half-decoded state. Emit zeroed
+            // web3 fields instead (same posture as the deposit fallback above) and log once.
+            WEB3_LOG(WARNING) << LOG_DESC("TransactionResponse: undecodable web3 payload")
+                              << LOG_KV("hash", tx.hash().hexPrefixed())
+                              << LOG_KV("reason", error->errorMessage());
+            result["nonce"] = "0x0";
+            result["type"] = toQuantity(0);
+            result["value"] = "0x0";
+            result["chainId"] = toQuantity(0);
+            result["v"] = "0x0";
+            result["r"] = "0x0";
+            result["s"] = "0x0";
+            return;
+        }
         result["nonce"] = toQuantity(web3Tx.nonce);
         result["type"] = toQuantity(static_cast<uint8_t>(web3Tx.type));
         result["value"] = toQuantity(web3Tx.value);
-        if (web3Tx.type >= TransactionType::EIP2930)
+        // Use explicit range checks rather than `>=` so that Deposit (0x7e), which is numerically
+        // larger than all EIP types, is excluded from EIP-specific field output. EIP-7702 is a
+        // fee-market type with an access list, so the upper bound is EIP7702 (matching
+        // takeToTarsTransaction on the write side).
+        if (web3Tx.type >= TransactionType::EIP2930 && web3Tx.type <= TransactionType::EIP7702)
         {
             result["accessList"] = Json::arrayValue;
-            result["accessList"].resize(web3Tx.accessList.size());
             for (auto& accessList : web3Tx.accessList)
             {
                 Json::Value access = Json::objectValue;
                 access["address"] = accessList.account.hexPrefixed();
                 access["storageKeys"] = Json::arrayValue;
-                access["storageKeys"].resize(accessList.storageKeys.size());
                 for (const auto& j : accessList.storageKeys)
                 {
                     Json::Value storageKey = j.hexPrefixed();
@@ -109,25 +150,62 @@ void bcos::rpc::combineTxResponse(Json::Value& result, const bcos::protocol::Tra
                 result["accessList"].append(std::move(access));
             }
         }
-        if (web3Tx.type >= TransactionType::EIP1559)
+        if (web3Tx.type >= TransactionType::EIP1559 && web3Tx.type <= TransactionType::EIP7702)
         {
             result["maxPriorityFeePerGas"] = toQuantity(web3Tx.maxPriorityFeePerGas);
             result["maxFeePerGas"] = toQuantity(web3Tx.maxFeePerGas);
         }
         result["chainId"] = toQuantity(web3Tx.chainId.value_or(0));
-        if (web3Tx.type >= TransactionType::EIP4844)
+        // Legacy transactions encode v as the EIP-155 value chainId*2+35+parity (27+parity
+        // pre-EIP-155); typed transactions use the plain y-parity. Clients like op-geth's
+        // types.NewTx reject a legacy v < 35 when chainId is set, so the full value must be
+        // reconstructed from the stored parity byte — the storage layer keeps only the parity.
+        if (web3Tx.type == TransactionType::Legacy)
         {
-            result["maxFeePerBlobGas"] = web3Tx.maxFeePerBlobGas.str();
+            if (web3Tx.chainId.has_value() && web3Tx.chainId.value() != 0)
+            {
+                result["v"] =
+                    toQuantity(u256(web3Tx.chainId.value()) * 2 + 35 + tx.signatureData()[64]);
+            }
+            else
+            {
+                result["v"] = toQuantity(27 + tx.signatureData()[64]);
+            }
+        }
+        if (web3Tx.type == TransactionType::EIP4844)
+        {
+            result["maxFeePerBlobGas"] = toQuantity(web3Tx.maxFeePerBlobGas);
             result["blobVersionedHashes"] = Json::arrayValue;
-            result["blobVersionedHashes"].resize(web3Tx.blobVersionedHashes.size());
             for (const auto& blobVersionedHashe : web3Tx.blobVersionedHashes)
             {
                 Json::Value hash = blobVersionedHashe.hexPrefixed();
                 result["blobVersionedHashes"].append(std::move(hash));
             }
         }
+        if (web3Tx.type == TransactionType::EIP7702)
+        {
+            // geth parity: each entry serializes as
+            // {chainId, address, nonce, yParity, r, s} with hex-quantity scalars.
+            result["authorizationList"] = Json::arrayValue;
+            for (const auto& auth : web3Tx.authorizationList)
+            {
+                Json::Value entry = Json::objectValue;
+                entry["chainId"] = toQuantity(auth.chainId);
+                entry["address"] = auth.address.hexPrefixed();
+                entry["nonce"] = toQuantity(auth.nonce);
+                entry["yParity"] = toQuantity(auth.yParity);
+                entry["r"] = toQuantity(auth.r);
+                entry["s"] = toQuantity(auth.s);
+                result["authorizationList"].append(std::move(entry));
+            }
+        }
     }
     result["r"] = toQuantity(tx.signatureData().getCroppedData(0, 32));
     result["s"] = toQuantity(tx.signatureData().getCroppedData(32, 32));
-    result["v"] = toQuantity(tx.signatureData().getCroppedData(64, 1));
+    // v: set for legacy transactions above (EIP-155 reconstruction); everything else
+    // reports the stored y-parity byte directly.
+    if (!result.isMember("v"))
+    {
+        result["v"] = toQuantity(tx.signatureData().getCroppedData(64, 1));
+    }
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/Common.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/Common.h
@@ -21,9 +21,36 @@
 #pragma once
 
 #include <bcos-rpc/Common.h>
+#include <bcos-utilities/DataConvertUtility.h>
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <string>
+#include <string_view>
 
 namespace bcos::rpc
 {
+/// Normalize a protocol::LogEntry address view to 40-char lowercase hex (no 0x prefix).
+/// Producers are inconsistent: the OP execution path stores the 20 raw address bytes,
+/// while legacy paths store the ASCII hex string (with or without 0x). Length 20 is
+/// unambiguous (a hex-string form is 40/42 chars), so branch on it.
+inline std::string toLogAddressHex(std::string_view address)
+{
+    if (address.size() == 20)
+    {
+        auto hex = bcos::toHex(address);
+        boost::algorithm::to_lower(hex);
+        return hex;
+    }
+    std::string_view view = address;
+    if (view.starts_with("0x") || view.starts_with("0X"))
+    {
+        view.remove_prefix(2);
+    }
+    std::string hex{view};
+    boost::algorithm::to_lower(hex);
+    return hex;
+}
+
 constexpr const uint64_t LowestGasPrice{21000};
 constexpr const uint64_t LowestGasUsed{21000};
 enum Web3JsonRpcError : int32_t

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h
@@ -1,0 +1,54 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EngineErrorMapper.h
+ * @brief Map engine-service exceptions to the execution-apis JSON-RPC error codes
+ */
+
+#pragma once
+
+#include "bcos-rpc/web3jsonrpc/utils/Common.h"  // EngineError
+#include <bcos-framework/engine/Errors.h>
+#include <bcos-rpc/jsonrpc/Common.h>  // JsonRpcError::InternalError
+#include <bcos-utilities/Exceptions.h>
+
+namespace bcos::rpc
+{
+/// Map engine-service exceptions to the execution-apis JSON-RPC error codes the Engine API
+/// assigns (specs.optimism.io exec-engine.md references the execution-apis error table).
+/// Unmapped conditions stay -32603 InternalError: a mapped code must be unambiguous.
+/// `bcos::Error` (storage/service faults) intentionally maps to InternalError.
+inline int32_t mapEngineErrorCode(bcos::Exception const& e) noexcept
+{
+    if (dynamic_cast<bcos::engine::UnsupportedFork const*>(&e) ||
+        dynamic_cast<bcos::engine::IncompatiblePayloadVersion const*>(&e))
+    {
+        return EngineError::UnsupportedFork;  // -38005
+    }
+    if (dynamic_cast<bcos::engine::UnknownPayload const*>(&e))
+    {
+        return EngineError::UnknownPayload;  // -38001
+    }
+    if (dynamic_cast<bcos::engine::InvalidForkchoiceState const*>(&e))
+    {
+        return EngineError::InvalidForkchoiceState;  // -38002
+    }
+    if (dynamic_cast<bcos::engine::UnsupportedOpPayloadAttributes const*>(&e))
+    {
+        return EngineError::InvalidPayloadAttributes;  // -38003
+    }
+    return InternalError;  // -32603
+}
+}  // namespace bcos::rpc

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -331,6 +331,9 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
         .withdrawals = std::nullopt,
         .blobGasUsed = std::nullopt,
         .excessBlobGas = std::nullopt,
+        .blockAccessList = std::nullopt,
+        .slotNumber = std::nullopt,
+        .rawTransactions = std::nullopt,
         .withdrawalsRoot = std::nullopt,
     };
     if (ep.isMember("extraData"))
@@ -355,13 +358,23 @@ bcos::engine::NewPayloadRequest bcos::rpc::parseNewPayloadRequest(
             BOOST_THROW_EXCEPTION(JsonRpcException(
                 InvalidParams, "Expected array of hex strings for executionPayload.transactions"));
         }
-        // Raw EIP-2718 bytes, hex-decoded verbatim. No transaction decoding happens
-        // here — getPayload must later return exactly these bytes.
+        // Raw EIP-2718 bytes, hex-decoded verbatim, kept in BOTH carriers:
+        //   - payload.transactions (EngineTransaction{raw, decoded=nullptr}) — the Engine-API
+        //     wire form; getPayload must later return exactly these raw bytes. No decoding
+        //     happens here — classification/decoding of the raw bytes is the dispatch table's
+        //     job (bcos-framework/engine/RawTransactionDispatch.h), matching upstream.
+        //   - payload.rawTransactions (vector<bytes>) — the OP path's sole tx carrier (raw
+        //     EIP-2718 envelope bytes incl. the 0x7E deposit), consumed by OpSchedulerSeam.
         payload.transactions.reserve(ep["transactions"].size());
+        payload.rawTransactions.emplace();
+        payload.rawTransactions->reserve(ep["transactions"].size());
         for (Json::ArrayIndex i = 0; i < ep["transactions"].size(); ++i)
         {
-            payload.transactions.push_back(bcos::engine::EngineTransaction{
-                .raw = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i),
+            auto txData = parseRawTransactionElement(ep["transactions"][i], "executionPayload", i);
+            payload.rawTransactions->push_back(txData);  // keep unconditionally: OP carrier is
+                                                         // decoupled from decode
+            payload.transactions.push_back(engine::EngineTransaction{
+                .raw = std::move(txData),
                 .decoded = nullptr,
             });
         }
@@ -822,5 +835,12 @@ void bcos::rpc::combineGetPayloadResponse(Json::Value& _result,
     if (_response->parentBeaconBlockRoot.has_value())
     {
         _result["parentBeaconBlockRoot"] = _response->parentBeaconBlockRoot->hexPrefixed();
+    }
+    // V4 (Prague payload shape): executionRequests is a required member of the response. This
+    // chain produces none (no deposit/consolidation requests), so an empty list is the honest
+    // payload — op-geth's own no-request blocks serialize the same shape.
+    if (version == engine::ApiVersion::V4)
+    {
+        _result["executionRequests"] = Json::Value(Json::arrayValue);
     }
 }

--- a/bcos-rpc/test/unittests/rpc/EngineErrorMapperTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineErrorMapperTest.cpp
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file EngineErrorMapperTest.cpp
+ * @brief Unit tests for the engine-exception -> execution-apis JSON-RPC error-code mapping
+ */
+
+#include <bcos-framework/engine/Errors.h>
+#include <bcos-rpc/web3jsonrpc/utils/Common.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineErrorMapper.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+BOOST_AUTO_TEST_SUITE(EngineErrorMapperTest)
+
+BOOST_AUTO_TEST_CASE(mapsEngineExceptionTypesToExecutionApiCodes)
+{
+    // execution-apis codes (exec-engine.md references execution-apis error table).
+    BOOST_CHECK_EQUAL(
+        mapEngineErrorCode(bcos::engine::UnsupportedFork{}), EngineError::UnsupportedFork);
+    BOOST_CHECK_EQUAL(mapEngineErrorCode(bcos::engine::IncompatiblePayloadVersion{}),
+        EngineError::UnsupportedFork);
+    BOOST_CHECK_EQUAL(
+        mapEngineErrorCode(bcos::engine::UnknownPayload{}), EngineError::UnknownPayload);
+    BOOST_CHECK_EQUAL(mapEngineErrorCode(bcos::engine::InvalidForkchoiceState{}),
+        EngineError::InvalidForkchoiceState);
+    BOOST_CHECK_EQUAL(mapEngineErrorCode(bcos::engine::UnsupportedOpPayloadAttributes{}),
+        EngineError::InvalidPayloadAttributes);
+    // Everything not enumerated stays the generic internal error.
+    BOOST_CHECK_EQUAL(mapEngineErrorCode(bcos::engine::OpExecutionInternalError{}), InternalError);
+    BOOST_CHECK_EQUAL(
+        mapEngineErrorCode(bcos::engine::UnsupportedEngineApiVersion{}), InternalError);
+    BOOST_CHECK_EQUAL(mapEngineErrorCode(bcos::Error{BCOS_ERROR(1, "x")}), InternalError);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineHelperTest.cpp
@@ -1,0 +1,170 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-crypto/signature/key/KeyFactoryImpl.h>
+#include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>
+#include <bcos-tars-protocol/protocol/TransactionFactoryImpl.h>
+#include <json/json.h>
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::rpc;
+
+namespace bcos::test
+{
+// op-geth golden corpus 真实 raw tx（val-loop bcos-evm/test/opstack/t8n/golden/engine/
+// isthmus_access_list.golden.json rawTransactions[0]/[1]，逐字节核验一致）：0x7E deposit +
+// 0x02 EIP-1559 typed。两者经 decodeTransaction 必抛 TarsDecodeMismatch（tars 误解析 RLP）——
+// transactions 填充分支容错跳过，rawTransactions 是 W1 的核心断言对象。
+constexpr std::string_view kDepositRawTx =
+    "0x7ef90104a0ae1a1f61e85683e8084e5004f4c36b050cb2ea1e5f78f1e7d518163ade648a7994deaddeaddeaddead"
+    "deaddeaddeaddeaddead00019442000000000000000000000000000000000000158080830f424080b8b0098999be00"
+    "000558000c5fc500000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000006fc23ac0000000000000000000000000000000000000000000000000000000000000f42"
+    "4000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    "000000000000000000000000000000000000000000000000000000000000";
+constexpr std::string_view kEip1559RawTx =
+    "0x02f8e0822105808405f5e1008477359400830186a094c0de0000000000000000000000000000000000058080f872"
+    "f85994c0de000000000000000000000000000000000005f842a0000000000000000000000000000000000000000000"
+    "0000000000000000000000a00000000000000000000000000000000000000000000000000000000000000005d694dd"
+    "ddddddddddddddddddddddddddddddddddddddc080a0394ee65265d6d1eead7675c85dc4dfa781d7d9b1d27392f51d"
+    "d7feb5d8f2f27ba0434c6ec29d5d0e3b781f461538d61e7120c5f25a33dd5f8a230aa8259dba7d0c";
+constexpr std::string_view kWithdrawalsRoot =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+std::shared_ptr<bcos::protocol::TransactionFactory> makeTxFactory()
+{
+    auto cryptoSuite = std::make_shared<bcos::crypto::CryptoSuite>(
+        std::make_shared<bcos::crypto::Keccak256>(), nullptr, nullptr);
+    return std::make_shared<bcostars::protocol::TransactionFactoryImpl>(cryptoSuite);
+}
+
+Json::Value makePayloadParams(
+    std::vector<std::string_view> rawTxs, std::string_view withdrawalsRoot)
+{
+    Json::Value ep(Json::objectValue);
+    ep["parentHash"] = "0x" + std::string(64, '0');
+    ep["stateRoot"] = "0x" + std::string(64, '0');
+    ep["receiptsRoot"] = "0x" + std::string(64, '0');
+    ep["prevRandao"] = "0x" + std::string(64, '0');
+    ep["gasLimit"] = "0x1c9c380";
+    ep["gasUsed"] = "0x0";
+    ep["baseFeePerGas"] = "0x1";
+    ep["blockHash"] = "0x" + std::string(64, '0');
+    ep["feeRecipient"] = "0x" + std::string(40, '0');
+    ep["timestamp"] = "0x1";
+    ep["blockNumber"] = "0x1";
+    ep["logsBloom"] = "0x" + std::string(512, '0');
+    ep["extraData"] = "0x";
+    ep["withdrawals"] = Json::Value(Json::arrayValue);
+    ep["blobGasUsed"] = "0x0";  // V4 field-shape requirement (Isthmus+ fields)
+    ep["excessBlobGas"] = "0x0";
+    if (withdrawalsRoot.size())
+    {
+        ep["withdrawalsRoot"] = std::string(withdrawalsRoot);
+    }
+    Json::Value txs(Json::arrayValue);
+    for (auto const& raw : rawTxs)
+    {
+        txs.append(std::string(raw));
+    }
+    ep["transactions"] = txs;
+    Json::Value params(Json::arrayValue);
+    params.append(ep);
+    // V4 param shape: [executionPayload, expectedBlobVersionedHashes, parentBeaconBlockRoot,
+    // executionRequests] — requireNewPayloadV4ParamShape rejects a 1-element params array.
+    params.append(Json::Value(Json::arrayValue));  // expectedBlobVersionedHashes: none
+    params.append("0x" + std::string(64, '0'));    // parentBeaconBlockRoot
+    params.append(Json::Value(Json::arrayValue));  // executionRequests: empty
+    return params;
+}
+
+BOOST_AUTO_TEST_SUITE(EngineHelperTest)
+
+// rawTransactions 逐字节保留输入；transactions 同步解码。
+BOOST_AUTO_TEST_CASE(parseFillsRawTransactionsPreservingBytes)
+{
+    auto params = makePayloadParams({kDepositRawTx, kEip1559RawTx}, kWithdrawalsRoot);
+    auto factory = makeTxFactory();
+    // 不得抛：transactions 填充分支容错跳过 decode 失败的 typed tx。
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_REQUIRE_EQUAL(request.executionPayload.rawTransactions->size(), 2u);
+    // 逐字节比对：rawTransactions[i] == fromHex(rawTx[i])
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.rawTransactions->at(i) == expect);
+    }
+    // 合并后语义（上游 parse 不解码，解码交给执行时 dispatch table）：transactions 以
+    // EngineTransaction{raw, decoded=nullptr} 携带 wire 字节；rawTransactions 保留 OP 载体。
+    BOOST_REQUIRE_EQUAL(request.executionPayload.transactions.size(), 2u);
+    for (int i = 0; i < 2; ++i)
+    {
+        auto expect =
+            fromHex(kDepositRawTx == params[0]["transactions"][i].asString() ? kDepositRawTx :
+                                                                               kEip1559RawTx);
+        BOOST_CHECK(request.executionPayload.transactions[i].raw == expect);
+        BOOST_CHECK(request.executionPayload.transactions[i].decoded == nullptr);
+    }
+}
+
+// withdrawalsRoot 正确解析为 h256。
+BOOST_AUTO_TEST_CASE(parseFillsWithdrawalsRoot)
+{
+    auto params = makePayloadParams({kEip1559RawTx}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.withdrawalsRoot.has_value());
+    auto expect = fromHex(kWithdrawalsRoot);
+    BOOST_CHECK_EQUAL(request.executionPayload.withdrawalsRoot->size(), 32u);
+    BOOST_CHECK(std::equal(
+        expect.begin(), expect.end(), request.executionPayload.withdrawalsRoot->begin()));
+}
+
+// withdrawalsRoot 缺省 → V4 形状校验拒绝（Isthmus 必填字段）；错长（31/33 字节）→
+// bcos::rpc::JsonRpcException。
+BOOST_AUTO_TEST_CASE(parseWithdrawalsRootBoundaries)
+{
+    // V4 shape validation requires withdrawalsRoot as a hex string (Isthmus contract) — a
+    // missing key is a shape rejection, not a silent nullopt.
+    auto noRoot = makePayloadParams({kEip1559RawTx}, "");
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(noRoot, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+
+    // 31 字节（62 hex）
+    auto badShort = makePayloadParams({kEip1559RawTx}, "0x" + std::string(62, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badShort, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+    // 33 字节（66 hex）
+    auto badLong = makePayloadParams({kEip1559RawTx}, "0x" + std::string(66, '1'));
+    BOOST_CHECK_THROW(
+        parseNewPayloadRequest(badLong, engine::ApiVersion::V4), bcos::rpc::JsonRpcException);
+}
+
+// 缺 transactions 键 → rawTransactions 保持 nullopt（OP 校验 :299 仍拒）。
+BOOST_AUTO_TEST_CASE(parseMissingTransactionsLeavesRawNullopt)
+{
+    // withdrawalsRoot 必须给合法值：V4 形状校验（Isthmus 必填）会先于本测试关注的
+    // transactions 缺省语义拒绝缺根载荷。
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    params[0].removeMember("transactions");
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_CHECK(!request.executionPayload.rawTransactions.has_value());
+}
+
+// transactions 存在但为空数组 → rawTransactions present-and-empty（OP 校验 :299 接受）。
+BOOST_AUTO_TEST_CASE(parseEmptyTransactionsIsPresentAndEmpty)
+{
+    auto params = makePayloadParams({}, kWithdrawalsRoot);
+    auto request = parseNewPayloadRequest(params, engine::ApiVersion::V4);
+    BOOST_REQUIRE(request.executionPayload.rawTransactions.has_value());
+    BOOST_CHECK(request.executionPayload.rawTransactions->empty());
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+}  // namespace bcos::test

--- a/bcos-rpc/test/unittests/rpc/EthEndpointSystemConfigTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EthEndpointSystemConfigTest.cpp
@@ -50,8 +50,9 @@ public:
         Json::Value value;
         Json::Reader reader;
         std::promise<bcos::bytes> promise;
-        web3JsonRpc->onRPCRequest(
-            req, [&promise](bcos::bytes resp, boost::beast::http::status) { promise.set_value(std::move(resp)); });
+        web3JsonRpc->onRPCRequest(req, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
         auto jsonBytes = promise.get_future().get();
         std::string_view json((char*)jsonBytes.data(), (char*)jsonBytes.data() + jsonBytes.size());
         reader.parse(json.begin(), json.end(), value);

--- a/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3EthMethodsTest.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "../common/RPCFixture.h"
+#include <bcos-crypto/ChecksumAddress.h>
 #include <bcos-rpc/web3jsonrpc/Web3JsonRpcImpl.h>
 #include <boost/test/unit_test.hpp>
 #include <future>
@@ -19,6 +20,60 @@ using namespace bcos::rpc;
 
 namespace bcos::test
 {
+// FakeLedger::asyncGetTransactionReceiptByHash always reports null (FakeLedger.h:360-364), so
+// seeding storage is inert for eth_getTransactionReceipt. This subclass overrides it to return a
+// seeded receipt, and re-seeds the tx-by-hash lookup with a safe implementation: FakeLedger's
+// storeTransactionsAndReceipts dereferences a default-constructed null shared_ptr (txData is never
+// allocated), so the inherited path cannot be used to populate m_txsHashToData.
+class SeedableLedger : public bcos::test::FakeLedger
+{
+public:
+    SeedableLedger(bcos::protocol::BlockFactory::Ptr blockFactory, size_t blockNumber,
+        size_t txsSize, size_t receiptsSize)
+      : bcos::test::FakeLedger(blockFactory, blockNumber, txsSize, receiptsSize),
+        m_blockFactory(std::move(blockFactory))
+    {}
+
+    protocol::TransactionReceipt::Ptr seededReceipt;
+    std::map<crypto::HashType, std::shared_ptr<bcos::bytes>> m_seedTxs;
+
+    void asyncGetTransactionReceiptByHash(crypto::HashType const&, bool,
+        std::function<void(Error::Ptr, protocol::TransactionReceipt::Ptr, MerkleProofPtr)> callback)
+        override
+    {
+        callback(nullptr, seededReceipt, nullptr);
+    }
+
+    void asyncGetBatchTxsByHashList(crypto::HashListPtr _txHashList, bool,
+        std::function<void(
+            Error::Ptr, TransactionsPtr, std::shared_ptr<std::map<std::string, MerkleProofPtr>>)>
+            _onGetTx) override
+    {
+        auto txs = std::make_shared<Transactions>();
+        for (auto const& hash : *_txHashList)
+        {
+            if (auto it = m_seedTxs.find(hash); it != m_seedTxs.end())
+            {
+                auto tx = m_blockFactory->transactionFactory()->createTransaction(
+                    bcos::ref(*(it->second)), /*checkSig=*/false);
+                txs->emplace_back(tx);
+            }
+        }
+        _onGetTx(nullptr, txs, nullptr);
+    }
+
+    void seedTx(bcos::protocol::Transaction::Ptr tx)
+    {
+        auto txHash = tx->hash();
+        auto txData = std::make_shared<bcos::bytes>();
+        tx->encode(*txData);
+        m_seedTxs[txHash] = std::move(txData);
+    }
+
+private:
+    bcos::protocol::BlockFactory::Ptr m_blockFactory;
+};
+
 // Drives the web3 (eth_/net_/web3_) coroutine endpoints through the real
 // dispatch path. EthEndpoint.cpp (596 lines) was at 24% because the existing
 // Web3RpcTest only touched ~10 of the ~44 registered methods. onRPCRequest
@@ -227,6 +282,89 @@ BOOST_AUTO_TEST_CASE(sendRawTransactionGarbageReportsError)
     auto resp = call(req("eth_sendRawTransaction", R"(["0xdeadbeef"])"));
     BOOST_CHECK(resp.isMember("error") || resp.isMember("result"));
     BOOST_CHECK(resp.isMember("id"));
+}
+
+BOOST_AUTO_TEST_CASE(getTransactionReceiptHappyPath)
+{
+    // Full read-side happy path (spec §5-5): seed a tx + receipt into a SeedableLedger and drive
+    // eth_getTransactionReceipt / eth_getTransactionByHash through the real dispatch path. The
+    // stock RPCFixture FakeLedger always returns a null receipt, so a subclass is required.
+    auto seedLedger = std::make_shared<SeedableLedger>(m_blockFactory, /*blocks=*/20, 10, 10);
+    seedLedger->setSystemConfig(ledger::SYSTEM_KEY_TX_COUNT_LIMIT, "1000");
+
+    auto tx = m_blockFactory->transactionFactory()->createTransaction(0,
+        "0x1234567890123456789012345678901234567890", bcos::bytes{0x0a}, "0x2", 100, chainId,
+        groupId, 0);
+    BOOST_REQUIRE(tx);
+    // D8 (review ①): install a raw 20-byte sender so the read side must checksum the raw bytes.
+    // Mixed-case hex letters (0x5aAe...BeAed) make EIP-55 checksum casing observable (an
+    // all-digit address would make toChecksumAddress a no-op).
+    tx->forceSender(bcos::fromHex("5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"));
+    seedLedger->seedTx(tx);
+
+    auto receipt = m_blockFactory->receiptFactory()->createReceipt(bcos::u256(21000),
+        "0x1234567890123456789012345678901234567890", {}, /*status=*/0, bcos::bytesConstRef{},
+        /*blockNumber=*/12);
+    BOOST_REQUIRE(receipt);
+    receipt->setTransactionIndex(0);
+    // C4: seed a receipt WITH opStackMeta so eth_getTransactionReceipt must carry the OP extension
+    // fields through the REAL RPC dispatch (unit-testing combineReceiptResponse alone does not
+    // prove the fields survive the full EthEndpoint → JSON round-trip).
+    protocol::OpStackReceiptMeta meta;
+    meta.l1_gas_price = bcos::u256(5);
+    meta.operator_fee_scalar = 2;
+    receipt->setOpStackMeta(std::move(meta));
+    seedLedger->seededReceipt = receipt;
+
+    // Rebuild the RPC stack over the seedable ledger.
+    auto service = std::make_shared<rpc::NodeService>(
+        seedLedger, scheduler, txPool, nullptr, nullptr, m_blockFactory, nullptr);
+    auto seededRpc = factory->buildLocalRpc(groupInfo, service);
+    auto seededWeb3 = seededRpc->web3JsonRpc();
+    BOOST_REQUIRE(seededWeb3 != nullptr);
+
+    auto const txHashHex = tx->hash().hexPrefixed();
+    auto callSeeded = [&](std::string_view request) {
+        std::promise<bcos::bytes> promise;
+        seededWeb3->onRPCRequest(request, [&promise](bcos::bytes resp, boost::beast::http::status) {
+            promise.set_value(std::move(resp));
+        });
+        auto jsonBytes = promise.get_future().get();
+        Json::Value value;
+        Json::Reader reader;
+        std::string_view json((char*)jsonBytes.data(), jsonBytes.size());
+        reader.parse(json.begin(), json.end(), value);
+        return value;
+    };
+
+    // eth_getTransactionReceipt returns a complete object with the checksummed from (review ①).
+    {
+        auto resp = callSeeded(req("eth_getTransactionReceipt", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("transactionHash"));
+        BOOST_CHECK_EQUAL(resp["result"]["transactionHash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("logs"));
+        BOOST_CHECK(resp["result"].isMember("blockNumber"));
+        // C4: OP extension fields survive the full RPC round-trip (not just
+        // combineReceiptResponse).
+        BOOST_CHECK_EQUAL(resp["result"]["l1GasPrice"].asString(), "0x5");
+        BOOST_CHECK_EQUAL(resp["result"]["operatorFeeScalar"].asString(), "0x2");
+        // Pinned against the independently-known EIP-55 vector (NOT derived via the same
+        // toChecksumAddress under test, so a checksum-casing regression is actually caught).
+        BOOST_CHECK_EQUAL(
+            resp["result"]["from"].asString(), "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
+    }
+
+    // eth_getTransactionByHash resolves the same tx.
+    {
+        auto resp = callSeeded(req("eth_getTransactionByHash", "[\"" + txHashHex + "\"]"));
+        BOOST_REQUIRE(resp.isMember("result"));
+        BOOST_CHECK(!resp["result"].isNull());
+        BOOST_CHECK(resp["result"].isMember("hash"));
+        BOOST_CHECK_EQUAL(resp["result"]["hash"].asString(), txHashHex);
+        BOOST_CHECK(resp["result"].isMember("from"));
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- Independent extract from #5481: `EthEndpoint`, `EngineEndpoint`, and receipt/block/call JSON shaping.
- Decode types (`Web3TxHandler` / envelope) are not in this PR. Full compile of the new endpoint code expects the Web3 tx-model PR.
- Insert-limit for this slice alone is ≈ 449.

## Test plan
- [ ] Diff is limited to web3jsonrpc endpoints/utils/response models + listed RPC tests.
- [ ] No executor / engine service / t8n / e2e.
- [ ] Review against the companion tx-model PR for Handler API alignment.
- [ ] CI insert-limit should pass; compile may fail until the tx-model PR is present.


Made with [Cursor](https://cursor.com)