### PR TITLE
feat(opstack): add executor block path without OpScheduler

### DIFF
--- a/bcos-evm/bcos-evm/opstack/OpHost.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpHost.cpp
@@ -96,7 +96,9 @@ evmc_tx_context OpHost::get_tx_context() const noexcept
         m_block.prev_randao,
         intx::be::store<evmc::uint256be>(intx::uint256{m_chain_id}),
         intx::be::store<evmc::uint256be>(intx::uint256{m_block.base_fee}),
-        intx::be::store<evmc::uint256be>(m_block.blob_base_fee.value_or(0)),
+        // OP Stack Ecotone+: the L2 serves no blobs, so BLOBBASEFEE (0x4a) must always push 1
+        // (EIP-4844 MIN_BLOB_GASPRICE) — never the L1 blob market price, and never 0.
+        intx::be::store<evmc::uint256be>(m_block.blob_base_fee.value_or(1)),
         m_tx.blob_hashes.data(),
         m_tx.blob_hashes.size(),
         nullptr,

--- a/bcos-evm/bcos-evm/opstack/OpTransition.cpp
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <bcos-evm/eth/state/bloom_filter.hpp>
 #include <bcos-evm/eth/state/errors.hpp>
+#include <bcos-evm/eth/state/hash_utils.hpp>
 #include <bcos-evm/eth/state/host.hpp>
 #include <cassert>
 // TODO(eth-utils-removal): several sections of this file are copied verbatim from
@@ -371,7 +372,7 @@ bcos::protocol::TransactionReceipt::Ptr opTransition(const evmone::state::StateV
 std::variant<OpTxProperties, std::error_code> opValidate(const evmone::state::StateView& view,
     const evmone::state::BlockInfo& block, const evmone::state::Transaction& tx,
     evmc::bytes_view signedTxEnvelope, const OpForkConfig& cfg, const OpFeeParams& fee,
-    int64_t blockGasLeft)
+    int64_t blockGasLeft, bool skipBalanceCheck)
 {
     // Whitelist, not a blacklist. Transaction::Type has uint8_t as its underlying type and
     // validate_transaction's type switch (state.cpp:365-383) carries no default label, so EVERY
@@ -392,7 +393,8 @@ std::variant<OpTxProperties, std::error_code> opValidate(const evmone::state::St
     if (signedTxEnvelope.empty())
         return make_error_code(std::errc::invalid_argument);
 
-    auto base = evmone::state::validate_transaction(view, block, tx, cfg.rev, blockGasLeft, 0);
+    auto base = evmone::state::validate_transaction(
+        view, block, tx, cfg.rev, blockGasLeft, 0, skipBalanceCheck);
     if (auto* err = std::get_if<std::error_code>(&base))
         return *err;
 
@@ -421,7 +423,11 @@ std::variant<OpTxProperties, std::error_code> opValidate(const evmone::state::St
     maxCost += tx.value;
     maxCost += l1Cost;
     maxCost += opCost;
-    if (intx::uint512{balance} < maxCost)
+    // Balance cap for real transactions. Simulations (eth_call/estimateGas) skip it: op-geth
+    // never balance-validates a call — its simulated sender (the request's `from`, or the
+    // dummy-signature recovery when absent) routinely carries no funds, and the check would
+    // reject read-only contract probes the chain should answer.
+    if (!skipBalanceCheck && intx::uint512{balance} < maxCost)
         return make_error_code(std::errc::result_out_of_range);
 
     OpTxProperties props{std::get<evmone::state::TransactionProperties>(base), l1Cost, opCost, fee,

--- a/bcos-evm/bcos-evm/opstack/OpTransition.h
+++ b/bcos-evm/bcos-evm/opstack/OpTransition.h
@@ -62,7 +62,8 @@ struct OpTxProperties
 [[nodiscard]] std::variant<OpTxProperties, std::error_code> opValidate(
     const evmone::state::StateView& view, const evmone::state::BlockInfo& block,
     const evmone::state::Transaction& tx, evmc::bytes_view signedTxEnvelope,
-    const OpForkConfig& cfg, const OpFeeParams& fee, int64_t blockGasLeft);
+    const OpForkConfig& cfg, const OpFeeParams& fee, int64_t blockGasLeft,
+    bool skipBalanceCheck = false);
 
 /// Pairing constraint: the *FromState functions must be used as a pair; they must not be
 /// interleaved with the injection-style ones (opValidate/opTransition).

--- a/bcos-evm/bcos-evm/opstack/RollupCost.cpp
+++ b/bcos-evm/bcos-evm/opstack/RollupCost.cpp
@@ -224,4 +224,10 @@ intx::uint256 computeOperatorCost(
 {
     return computeOperatorCost(params, gas, cfg.has_jovian_operator_formula);
 }
+
+intx::uint256 computeChargedOperatorCost(
+    const OpFeeParams& params, uint64_t gas, const OpForkConfig& cfg) noexcept
+{
+    return cfg.has_operator_fee ? computeOperatorCost(params, gas, cfg) : intx::uint256{0};
+}
 }  // namespace bcos::evm::opstack

--- a/bcos-evm/bcos-evm/opstack/RollupCost.h
+++ b/bcos-evm/bcos-evm/opstack/RollupCost.h
@@ -59,4 +59,10 @@ intx::uint256 computeOperatorCost(
     const OpFeeParams& params, uint64_t gas, bool jovianFormula) noexcept;
 intx::uint256 computeOperatorCost(
     const OpFeeParams& params, uint64_t gas, const OpForkConfig& cfg) noexcept;
+
+/// Charged operator fee, mirroring the block-transition gate (OpTransition.cpp:395):
+/// has_operator_fee ? computeOperatorCost(...) : 0. The fork-level 0-gate lives here for
+/// callers (runners / tests) that must not re-implement the block-transition decision.
+intx::uint256 computeChargedOperatorCost(
+    const OpFeeParams& params, uint64_t gas, const OpForkConfig& cfg) noexcept;
 }  // namespace bcos::evm::opstack

--- a/opstack-executor/CMakeLists.txt
+++ b/opstack-executor/CMakeLists.txt
@@ -4,22 +4,26 @@ find_package(evmone REQUIRED)
 find_package(intx REQUIRED)
 find_package(TBB CONFIG REQUIRED)
 
-add_library(opstack-executor INTERFACE)
-target_include_directories(opstack-executor INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/opstack-executor>)
-# No direct `ledger` / `rlp-protocol` links: header-only usage only (Classify.h), and both drag
-# the bcos-crypto→wedprcrypto chain that breaks libc++ typed catch binary-wide
-# (bcos-rpc/test/CMakeLists.txt:29-34). `ledger` still arrives transitively via bcos-evm-eth.
-target_link_libraries(opstack-executor INTERFACE
+add_library(opstack-executor
+    OpBlockExecute.cpp
+)
+target_include_directories(opstack-executor PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include/opstack-executor>)
+# No direct `ledger` / `rlp-protocol` links: both drag the bcos-crypto→wedprcrypto chain
+# that breaks libc++ typed catch binary-wide (bcos-rpc/test/CMakeLists.txt:29-34).
+# `ledger` still arrives transitively via bcos-evm-eth. ①a's new headers (mpt/MPTBuilder.h,
+# transaction-scheduler/HistoricalCallStorage.h) follow the same rule — include paths and
+# buildAndCollect symbols arrive transitively (SchedulerSerialImpl.h precedent).
+target_link_libraries(opstack-executor PUBLIC
     bcos-evm-opstack ethereum-executor bcos-framework bcos-protocol
     evmone::evmone intx::intx TBB::tbb)
 set_target_properties(opstack-executor PROPERTIES UNITY_BUILD OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-    # OP modules deliberately use skipped-field designated initializers and GCC-13
-    # reference-returning helpers (jAt); downgrade only here, not repository-wide.
-    # INTERFACE, not PRIVATE: opstack-executor is a header-only INTERFACE library — the
-    # -Wno-error flags must reach the consumers' translation units, where the templates
-    # are instantiated and the warnings fire.
-    target_compile_options(opstack-executor INTERFACE
+    # kyonRay review #5429 K5: OP modules deliberately use skipped-field designated initializers
+    # and GCC-13 reference-returning helpers (jAt); downgrade only here, not repository-wide.
+    # PRIVATE: opstack-executor is a compiled library; the -Wno-error flags apply to its own TU.
+    target_compile_options(opstack-executor PRIVATE
         -Wno-error=missing-field-initializers -Wno-error=dangling-reference)
 endif()
 

--- a/opstack-executor/OpBlockExecute.cpp
+++ b/opstack-executor/OpBlockExecute.cpp
@@ -1,0 +1,334 @@
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-evm/adapter/StateDiffSanitize.h>
+#include <bcos-evm/opstack/OpFeeParams.h>
+#include <bcos-evm/opstack/OpPredeploys.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-framework/protocol/LogEntry.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-utilities/DataConvertUtility.h>  // bcos::safeFromQuantity (parseHexUint64 reuse, review #5429 T)
+#include <opstack-executor/OpBlockExecute.h>
+#include <algorithm>
+#include <bcos-evm/eth/state/state.hpp>  // evmone::state::finalize
+#include <bcos-evm/eth/state/system_contracts.hpp>
+#include <cstring>
+#include <functional>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+
+// isL1AttributesTx lives in OpBlockExecute.h; narrowGasUsed / hexCumulative live in OpCommon.h
+// (both shared with the per-tx loop — one implementation, no copy drift).
+
+namespace bcos::evm::opstack
+{
+void validateJovianBlockShape(std::span<const OpBlockTx> txs, const OpForkConfig& cfg)
+{
+    if (!cfg.has_da_footprint)  // Jovian-only (op-geth CalcDAFootprint)
+        return;
+    if (txs.empty())  // rejected by processOpBlock anyway
+        return;
+    const auto* firstDep = std::get_if<DepositTx>(&txs[0].tx);
+    if (firstDep == nullptr)
+        return;
+
+    const auto& data = firstDep->data;
+    if (data.size() == IsthmusL1AttributesLen)
+    {
+        // Jovian activation block: Isthmus-length attributes, must be deposits-only (op-geth
+        // rollup_cost.go:568-576). Checking the last tx suffices (deposits always precede
+        // non-deposits).
+        if (!std::holds_alternative<DepositTx>(txs.back().tx))
+            throw std::runtime_error(
+                "op block: unexpected non-deposit transactions in Jovian activation block");
+        return;
+    }
+
+    // Normal Jovian block: L1 attributes must carry the Jovian selector and be ≥ Jovian length.
+    if (data.size() < JovianL1AttributesLen)
+        throw std::runtime_error(
+            "op block: L1 attributes transaction data too short for DA footprint gas scalar");
+    if (!std::equal(
+            JovianL1AttributesSelector.begin(), JovianL1AttributesSelector.end(), data.begin()))
+        throw std::runtime_error(
+            "op block: L1 attributes transaction data does not have Jovian selector");
+}
+
+evmone::state::StateDiff finalizeOpBlock(
+    const evmone::state::StateView& view, const OpForkConfig& cfg, const evmc::address& coinbase)
+{
+    if (!cfg.disable_prague_requests)
+        // runtime_error (not logic_error): block-level rejection (INVALID), not a local fault.
+        throw std::runtime_error("op finalize: prague requests unsupported on OP chains");
+    return bcos::evm::sanitizeStateDiff(
+        view, evmone::state::finalize(view, cfg.rev, coinbase, std::nullopt, {}, {}));
+}
+
+OpBlockResult processOpBlock(const evmone::state::StateView& view,
+    const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
+    std::span<const OpBlockTx> txs, const OpForkConfig& cfg, evmc::VM& vm, uint64_t chainId,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory,
+    const std::function<void(const evmone::state::StateDiff&)>& applyDiff)
+{
+    // Step 1: pre-block system call (4788/2935; gating/skip handled inside evmone).
+    applyDiff(bcos::evm::sanitizeStateDiff(
+        view, evmone::state::system_call_block_start(view, block, hashes, cfg.rev, vm)));
+
+    // Step 2: first tx must be the L1 attributes deposit (stricter-than-spec) + Jovian shape.
+    if (txs.empty())
+        throw std::runtime_error("op block: missing L1 attributes deposit (empty block)");
+    const auto* firstDep = std::get_if<DepositTx>(&txs[0].tx);
+    if (firstDep == nullptr || !isL1AttributesTx(*firstDep))
+        throw std::runtime_error("op block: first tx is not the L1 attributes deposit");
+    validateJovianBlockShape(txs, cfg);
+
+    OpBlockResult result;
+    result.receipts.reserve(txs.size());
+    result.txTypes.reserve(txs.size());
+    int64_t blockGasLeft = block.gas_limit;
+    int64_t cumulative = 0;
+    bool seenNonDeposit = false;
+    bool feeLoaded = false;
+    OpFeeParams fee{};
+
+    size_t transactionIndex = 0;
+    for (const auto& btx : txs)
+    {
+        if (const auto* dep = std::get_if<DepositTx>(&btx.tx))
+        {
+            if (seenNonDeposit)
+                throw std::runtime_error("op block: deposit after non-deposit tx");
+            evmone::state::StateDiff diff;
+            auto receipt = runDeposit(
+                view, block, hashes, *dep, cfg, vm, chainId, blockGasLeft, receiptFactory, diff);
+            applyDiff(diff);
+            const auto gasUsed = narrowGasUsed(receipt->gasUsed());
+            blockGasLeft -= gasUsed;
+            cumulative += gasUsed;
+            // Decimal storage + the receipt's block index: the RPC read path lexical_casts
+            // decimal only and serves transactionIndex from the receipt (Tier-2 Phase B).
+            receipt->setCumulativeGasUsed(decimalCumulative(static_cast<uint64_t>(cumulative)));
+            receipt->setTransactionIndex(transactionIndex++);
+            result.receipts.emplace_back(std::move(receipt));
+            result.txTypes.emplace_back(classifyTxType(static_cast<uint8_t>(kDepositTxType)));
+        }
+        else
+        {
+            seenNonDeposit = true;
+            if (!feeLoaded)
+            {
+                // Fee params lazily loaded at the first normal tx (op-geth's per-block cache). DA
+                // scalar reads calldata[176:178] (authoritative even if the attributes deposit
+                // rolled back L1Block slot8); activation block (176B) forces 0.
+                fee = loadOpFeeParams(view);
+                if (cfg.has_da_footprint)
+                {
+                    const auto& attrData = std::get<DepositTx>(txs[0].tx).data;
+                    if (attrData.size() == IsthmusL1AttributesLen)
+                        fee.da_footprint_gas_scalar = 0;
+                    else if (attrData.size() >= JovianL1AttributesLen)
+                    {
+                        fee.da_footprint_gas_scalar = static_cast<uint16_t>(
+                            (static_cast<uint16_t>(attrData[JovianL1AttributesLen - 2]) << 8) |
+                            static_cast<uint16_t>(attrData[JovianL1AttributesLen - 1]));
+                    }
+                }
+                feeLoaded = true;
+            }
+            const auto& tx = std::get<evmone::state::Transaction>(btx.tx);
+            const evmc::bytes_view env{btx.signedEnvelope.data(), btx.signedEnvelope.size()};
+            auto v = opValidate(view, block, tx, env, cfg, fee, blockGasLeft);
+            if (const auto* err = std::get_if<std::error_code>(&v))
+                // No failed-receipt mechanism for normal txs: void the whole block (op-geth).
+                throw std::runtime_error("op block: invalid non-deposit tx: " + err->message());
+            // opTransition charges from props.fee (the validate-time snapshot — no second read).
+            evmone::state::StateDiff diff;
+            auto receipt = opTransition(view, block, hashes, tx, cfg, vm,
+                std::get<OpTxProperties>(v), chainId, receiptFactory, diff);
+            applyDiff(diff);
+            const auto gasUsed = narrowGasUsed(receipt->gasUsed());
+            blockGasLeft -= gasUsed;
+            cumulative += gasUsed;
+            receipt->setCumulativeGasUsed(decimalCumulative(static_cast<uint64_t>(cumulative)));
+            receipt->setTransactionIndex(transactionIndex++);
+            result.receipts.emplace_back(std::move(receipt));
+            result.txTypes.emplace_back(classifyTxType(static_cast<uint8_t>(tx.type)));
+        }
+    }
+
+    // Step 4: end-of-block finalize.
+    result.finalizeDiff = finalizeOpBlock(view, cfg, block.coinbase);
+    applyDiff(result.finalizeDiff);
+
+    result.gasUsed = cumulative;
+    return result;
+}
+
+// ---- block-header seal ----
+namespace
+{
+/// Parse "0x"-prefixed hex back to uint64 (the EncodeIndex leaf's cumulativeGasUsed). Delegates to
+/// the strict library parser bcos::safeFromQuantity — the previous hand-rolled loop silently
+/// wrapped >16-hex-digit input, where the library rejects overflow (review #5429 T).
+[[nodiscard]] uint64_t parseHexUint64(std::string_view s)
+{
+    // Tier-2 Phase B: the stored field is now DECIMAL (tars convention); the historical hex
+    // form (hexCumulative, pre-Phase-B blocks) stays parseable. Dispatch on the prefix —
+    // safeFromQuantity accepts a BARE-digit string as hex ("22760" -> 0x22760), so a decimal
+    // value must never reach it.
+    if (s.size() > 1 && (s[0] == '0') && (s[1] == 'x' || s[1] == 'X'))
+    {
+        if (auto v = bcos::safeFromQuantity(s))
+            return *v;
+    }
+    else
+    {
+        try
+        {
+            return boost::lexical_cast<uint64_t>(s);
+        }
+        catch (const boost::bad_lexical_cast&)
+        {}
+    }
+    throw std::runtime_error(
+        "op block: invalid cumulativeGasUsed in receipt (not hex or decimal): " + std::string(s));
+}
+
+/// RLP list of logs: [address, [topics...], data] each, whole collection wrapped in a list
+/// (byte-identical to evmone's rlp::encode_container over vector<Log>).
+inline void encodeLogsList(bcos::bytes& to, gsl::span<const bcos::protocol::LogEntry> logs)
+{
+    bcos::bytes content;
+    for (const auto& log : logs)
+    {
+        bcos::bytes entry;
+        bcos::codec::rlp::encode(entry, log.address());
+        bcos::bytes topics;
+        for (const auto& topic : log.topics())
+            bcos::codec::rlp::encode(topics, topic);
+        bcos::codec::rlp::encodeHeader(entry, {.isList = true, .payloadLength = topics.size()});
+        entry.insert(entry.end(), topics.begin(), topics.end());
+        bcos::codec::rlp::encode(entry, log.data());
+        bcos::codec::rlp::encodeHeader(content, {.isList = true, .payloadLength = entry.size()});
+        content.insert(content.end(), entry.begin(), entry.end());
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = content.size()});
+    to.insert(to.end(), content.begin(), content.end());
+}
+}  // namespace
+
+evmone::hash256 opStorageRoot(const std::map<evmc::bytes32, evmc::bytes32>& storage)
+{
+    // Secure trie over the live slot map (key = keccak256(slot), leaf = rlp(trimmed value)).
+    std::map<bcos::h256, bcos::bytes> entries;
+    for (const auto& [key, value] : storage)
+    {
+        if (evmc::is_zero(value))
+            continue;
+        size_t first = 0;
+        while (first < sizeof(value.bytes) && value.bytes[first] == 0)
+        {
+            ++first;
+        }
+        bcos::bytes leaf;
+        bcos::codec::rlp::encode(
+            leaf, bcos::bytes(value.bytes + first, value.bytes + sizeof(value.bytes)));
+        entries[bcos::h256{evmone::keccak256(key).bytes, 32}] = std::move(leaf);
+    }
+    auto result = bcos::ledger::mpt::computeTrieRoot(entries);
+    evmone::hash256 root{};
+    std::memcpy(root.bytes, result.root.data(), sizeof(root.bytes));
+    return root;
+}
+
+evmc::bytes encodeReceiptForRoot(const bcos::protocol::TransactionReceipt& r, uint8_t txType)
+{
+    // RLP bool semantics: true → 0x01, false → 0x80 (raw push; the UnsignedByte encode path
+    // mis-handles bool). Payload = rlp([status, cumGas, bloom, logs]) + (deposit) [nonce, version].
+    const bool success = (r.status() == 0);
+    const uint64_t cumGas = parseHexUint64(r.cumulativeGasUsed());
+    const auto bloom = r.logsBloom();
+    const auto logs = r.logEntries();
+
+    bcos::bytes payload;
+    payload.push_back(success ? 0x01 : 0x80);
+    bcos::codec::rlp::encode(payload, cumGas);
+    bcos::codec::rlp::encode(payload, bloom);
+    encodeLogsList(payload, logs);
+
+    if (txType == static_cast<uint8_t>(kDepositTxType))
+    {
+        const auto& meta = r.opStackMeta();
+        const uint64_t nonce = (meta && meta->deposit_nonce) ? *meta->deposit_nonce : uint64_t{0};
+        const uint64_t version =
+            (meta && meta->deposit_receipt_version) ? *meta->deposit_receipt_version : uint64_t{0};
+        bcos::codec::rlp::encode(payload, nonce);
+        bcos::codec::rlp::encode(payload, version);
+    }
+
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payload.size()});
+    out.insert(out.end(), payload.begin(), payload.end());
+    // typed raw-byte prefix (legacy has none; deposit's 0x7e is the EIP-2718 type byte).
+    if (txType != static_cast<uint8_t>(evmone::state::Transaction::Type::legacy))
+        out.insert(out.begin(), txType);
+    return evmc::bytes(out.begin(), out.end());
+}
+
+OpBlockSeal sealOpBlock(const OpBlockResult& result, const OpForkConfig& cfg,
+    const std::map<evmc::bytes32, evmc::bytes32>& messagePasserStorage)
+{
+    OpBlockSeal seal{};
+
+    // receipts-root: var-key trie (key = rlp(index), leaf = EncodeIndex encoding).
+    std::vector<std::pair<bcos::bytes, bcos::bytes>> receiptsEntries;
+    receiptsEntries.reserve(result.receipts.size());
+    for (size_t i = 0; i < result.receipts.size(); ++i)
+    {
+        bcos::bytes key;
+        bcos::codec::rlp::encode(key, static_cast<uint64_t>(i));
+        auto const leaf = encodeReceiptForRoot(*result.receipts[i], result.txTypes[i]);
+        receiptsEntries.emplace_back(std::move(key), bcos::bytes{leaf.begin(), leaf.end()});
+    }
+    auto receiptsResult = bcos::ledger::mpt::computeTrieRootVarKey(receiptsEntries);
+    std::memcpy(
+        seal.receiptsRoot.bytes, receiptsResult.root.data(), sizeof(seal.receiptsRoot.bytes));
+
+    // Block-level logsBloom = bitwise-OR of each receipt's 256-byte bloom.
+    for (const auto& r : result.receipts)
+    {
+        const auto bloom = r->logsBloom();
+        for (size_t i = 0; i < 256 && i < bloom.size(); ++i)
+            seal.logsBloom.bytes[i] |= bloom[i];
+    }
+
+    // Isthmus+: withdrawalsRoot = MessagePasser storage root, requestsHash = sha256("").
+    // Pre-Isthmus: withdrawals list is always empty → empty-trie root; no requests field.
+    if (cfg.fork >= OpFork::Isthmus)
+    {
+        seal.withdrawalsRoot = opStorageRoot(messagePasserStorage);
+        seal.requestsHash = OP_EMPTY_REQUESTS_HASH;
+    }
+    else
+    {
+        auto const emptyRoot = bcos::ledger::mpt::emptyRootHash();
+        std::memcpy(
+            seal.withdrawalsRoot.bytes, emptyRoot.data(), sizeof(seal.withdrawalsRoot.bytes));
+    }
+
+    // Jovian: header blobGasUsed slot = DA footprint (Σ da_footprint over non-deposit receipts;
+    // deposits carry nullopt, so summing every receipt is equivalent).
+    if (cfg.has_da_footprint)
+    {
+        uint64_t footprint = 0;
+        for (const auto& r : result.receipts)
+        {
+            const auto& meta = r->opStackMeta();
+            if (meta && meta->da_footprint)
+                footprint += *meta->da_footprint;
+        }
+        seal.blobGasUsed = footprint;
+    }
+    return seal;
+}
+}  // namespace bcos::evm::opstack

--- a/opstack-executor/OpBlockExecute.h
+++ b/opstack-executor/OpBlockExecute.h
@@ -1,30 +1,80 @@
 #pragma once
 
+#include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-evm/adapter/StateDiffSanitize.h>
+#include <bcos-evm/adapter/StateRootCompute.h>
+#include <bcos-evm/opstack/OpFeeParams.h>
 #include <bcos-evm/opstack/OpForkSchedule.h>
 #include <bcos-evm/opstack/OpPredeploys.h>
-#include <bcos-evm/opstack/OpTransition.h>  // DepositTx
+#include <bcos-evm/opstack/OpTransition.h>
 #include <bcos-framework/engine/Types.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/protocol/BlockFactory.h>
 #include <bcos-framework/protocol/BlockHeader.h>
-#include <bcos-utilities/BoostLog.h>  // BCOS_LOG (demoted-deposit-check observability)
+#include <bcos-framework/protocol/Transaction.h>
+#include <bcos-framework/protocol/TransactionReceipt.h>
+#include <bcos-ledger/mpt/HashBuilder.h>
+#include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/BoostLog.h>  // BCOS_LOG (finding-D demoted-deposit-check observability)
 #include <bcos-utilities/Common.h>
-#include <opstack-executor/OpCommitments.h>  // OpBlockCommitments / payloadBloomToH2048
-#include <opstack-executor/OpCommon.h>       // toBlockInfo / narrowU256ToU64 / toEvmcBytes32
+#include <opstack-executor/OpCommitments.h>  // OpBlockCommitments / payloadBloomToH2048 / toBcosH256
+#include <opstack-executor/OpCommon.h>  // toBlockInfo / narrowU256ToU64 / toEvmcBytes32 / OpBlockSeal
 #include <opstack-executor/OpstackExecutor.h>
 #include <opstack-executor/RecentBlockHashes.h>
 #include <opstack-executor/Storage2State.h>
 #include <algorithm>
 #include <array>
+#include <bcos-evm/eth/state/bloom_filter.hpp>
 #include <bcos-evm/eth/state/system_contracts.hpp>
+#include <bcos-evm/eth/state/transaction.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <map>
+#include <memory>
 #include <optional>
+#include <span>
+#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace bcos::evm::opstack
 {
+/// One transaction within a block: deposit or normal tx (a normal tx must carry a signed envelope
+/// for L1 fee calculation).
+struct OpBlockTx
+{
+    std::variant<DepositTx, evmone::state::Transaction> tx;
+    evmc::bytes signedEnvelope;  // empty for deposit
+};
+
+/// Block execution result. txTypes[i] is the EIP-2718 type byte for receipts[i] (the FISCO
+/// receipt has no tx-type slot; sealOpBlock's EncodeIndex leaf needs it).
+struct OpBlockResult
+{
+    std::vector<bcos::protocol::TransactionReceipt::Ptr> receipts;
+    std::vector<uint8_t> txTypes;
+    int64_t gasUsed = 0;
+    evmone::state::StateDiff finalizeDiff;  // end-of-block finalize output
+};
+
+/// Execute a whole block (system_call → L1 deposit → fee → per-tx → finalize). **Discard-writes
+/// contract**: on any throw the caller must discard all writes already applied (op-geth Process
+/// semantics). Throws std::runtime_error on block-level errors.
+OpBlockResult processOpBlock(const evmone::state::StateView& view,
+    const evmone::state::BlockInfo& block, const evmone::state::BlockHashes& hashes,
+    std::span<const OpBlockTx> txs, const OpForkConfig& cfg, evmc::VM& vm, uint64_t chainId,
+    const bcos::protocol::TransactionReceiptFactory::Ptr& receiptFactory,
+    const std::function<void(const evmone::state::StateDiff&)>& applyDiff);
+
+
 // ---- Jovian L1-attributes block shape ----
 // The L1-attributes deposit's calldata is 176B on the Jovian activation block, 178B with the
 // Jovian selector thereafter.
@@ -32,25 +82,139 @@ inline constexpr std::size_t IsthmusL1AttributesLen = 176;
 inline constexpr std::size_t JovianL1AttributesLen = 178;
 inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6, 0xbe, 0x2b};
 
+/// Validate the Jovian L1-attributes block shape (selector/length + activation deposits-only).
+/// No-op pre-Jovian. Throws std::runtime_error.
+void validateJovianBlockShape(std::span<const OpBlockTx> txs, const OpForkConfig& cfg);
+
+// ---- shared per-receipt helpers (one implementation shared with the per-tx loop) ----
+
+
 /// Stricter-than-spec content check for the L1 attributes deposit (to==OP_L1_BLOCK &&
 /// from==OP_DEPOSITOR); rejects hand-crafted payloads.
 [[nodiscard]] inline bool isL1AttributesTx(const DepositTx& dep) noexcept
 {
     return dep.to.has_value() && *dep.to == OP_L1_BLOCK && dep.from == OP_DEPOSITOR;
 }
+
+/// Block finalize: no ommers / block reward; Prague requests suppressed (false throws).
+evmone::state::StateDiff finalizeOpBlock(
+    const evmone::state::StateView& view, const OpForkConfig& cfg, const evmc::address& coinbase);
+
+// ---- seal: header commitment functions (OpBlockSeal struct lives in OpCommon.h) ----
+using evmc::literals::operator""_bytes32;
+
+/// Isthmus+ requestsHash = sha256("").
+inline constexpr auto OP_EMPTY_REQUESTS_HASH =
+    0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855_bytes32;
+
+/// Single-account storage root (secure trie: key = keccak256(slot), value = rlp(trimmed)).
+[[nodiscard]] evmone::hash256 opStorageRoot(const std::map<evmc::bytes32, evmc::bytes32>& storage);
+
+/// Compute the header commitments; messagePasserStorage = post-finalize MessagePasser snapshot.
+[[nodiscard]] OpBlockSeal sealOpBlock(const OpBlockResult& result, const OpForkConfig& cfg,
+    const std::map<evmc::bytes32, evmc::bytes32>& messagePasserStorage);
+
+/// Receipts-root leaf, byte-for-byte op-geth `Receipts.EncodeIndex` semantics:
+/// deposit 0x7E || rlp([status, cumGas, bloom, logs, nonce, version]);
+/// normal  typed prefix + rlp([status, cumGas, bloom, logs]).
+[[nodiscard]] evmc::bytes encodeReceiptForRoot(
+    const bcos::protocol::TransactionReceipt& r, uint8_t txType);
 }  // namespace bcos::evm::opstack
 
-// ---- block-pre steps for the scheduler execution path ----
-//
-// The block-level seal/finalize surface (processOpBlock / validateJovianBlockShape /
-// finalizeOpBlock / opStorageRoot / sealOpBlock / encodeReceiptForRoot / finalizeOpBlockResult /
-// computeOpTxRoot) is deferred to the part that delivers its definitions (part 4/5).
+// ---- block registration + execution ----
 
 namespace bcos::evm::engine
 {
+// DepositTx is built from the block's tars Transaction objects (OpstackExecutor::
+// depositFromTransaction, OpstackExecutor.h) — no raw-envelope RLP parse.
+
+// Forward-declared; defined at the end of this block.
+template <class RawTxRange>
+[[nodiscard]] bcos::h256 computeOpTxRoot(RawTxRange const& rawTxBytes);
+
+/// Block-level finalization shared between the injection loop and the shared scheduler path:
+/// finalizeBlock (MessagePasser snapshot) → seal → stateRoot → txRoot. txTypes are rebuilt from
+/// rawTxBytes[i][0] (the FISCO receipt has no tx-type slot; sealOpBlock's EncodeIndex receipts-root
+/// leaf needs the EIP-2718 type byte — mirror of the per-tx loop's classification). hashErr is
+/// checked here (poisoned block-hash lookup → OpStorageError). **cumulativeGasUsed backfill is NOT
+/// in scope** (it stays in the per-tx loop / ExecuteContext::finish).
+///
+/// @p skipStateRootBuild (①a incremental MPT): when true, the full two-layer rebuild is
+/// skipped and the result's stateRoot is left EMPTY — the caller replaces it with the
+/// incremental buildAndCollect root over the block delta (OpScheduler::execute). Only legal
+/// when the caller's view top mutable layer is exactly this block's delta over a committed
+/// parent. When false the root is computed ROOT-ONLY (nodes never retained — node persistence
+/// lives in buildAndCollect / the genesis import, not here).
+template <class Storage, class RawTxRange>
+OpExecuteBlockResult finalizeOpBlockResult(bcos::executor_v1::opstack::OpstackExecutor& executor,
+    Storage& view, bcos::protocol::BlockHeader const& header,
+    bcos::ledger::LedgerConfig const& ledgerConfig, bcos::evm::opstack::OpForkConfig const& cfg,
+    std::vector<bcos::protocol::TransactionReceipt::Ptr> const& receipts,
+    RawTxRange const& rawTxBytes, int64_t cumulative, std::optional<std::string> const& hashErr,
+    bool skipStateRootBuild = false)
+{
+    namespace op = bcos::evm::opstack;
+    namespace detail = bcos::evm::engine::detail;
+
+    bcos::task::syncWait(executor.finalizeBlock(view, header, ledgerConfig));
+
+    // Rebuild txTypes via the shared classifyTxType helper (single home for the EIP-2718
+    // classification so the deposit loop / this rebuild / processOpBlock can't drift).
+    std::vector<uint8_t> txTypes;
+    txTypes.reserve(rawTxBytes.size());
+    for (std::size_t i = 0; i < rawTxBytes.size(); ++i)
+    {
+        if (rawTxBytes[i].empty())  // defensive: the per-tx loop already rejects empty envelopes
+            throw OpConsensusError("op block: empty envelope");
+        txTypes.emplace_back(op::classifyTxType(rawTxBytes[i][0]));
+    }
+
+    op::OpBlockResult result;
+    result.receipts = receipts;
+    result.txTypes = std::move(txTypes);
+    result.gasUsed = cumulative;
+    if (hashErr.has_value())
+        throw OpStorageError("block-hash lookup failed: " + *hashErr);
+
+    // Commitments: MessagePasser snapshot → seal → stateRoot → txRoot.
+    std::map<evmc::bytes32, evmc::bytes32> mpStorage;
+    bcos::evm::evmstate::Storage2State<Storage> bridge(view, executor.sharedError());
+    bridge.visitAccounts([&](auto const& acc) {
+        if (acc.addr == op::OP_L2_TO_L1_MESSAGE_PASSER)
+        {
+            mpStorage = acc.storage;
+            return false;
+        }
+        return true;
+    });
+    if (bridge.poisoned())
+        throw OpStorageError("poisoned: " + std::string(bridge.firstError()));
+    auto seal = op::sealOpBlock(result, cfg, mpStorage);
+    bcos::h256 stateRoot;
+    if (!skipStateRootBuild)
+    {
+        auto const root = bcos::evm::stateRootOf(bridge);  // root-only; nodes not needed here
+        if (bridge.poisoned())
+            throw OpStorageError("poisoned after stateRootOf: " + std::string(bridge.firstError()));
+        stateRoot = detail::toBcosH256(root);
+    }
+    auto txRoot = computeOpTxRoot(rawTxBytes);
+    return OpExecuteBlockResult{
+        std::move(result.receipts), seal, stateRoot, static_cast<uint64_t>(cumulative), txRoot};
+}
+
+// ---- block execution: block-pre steps + per-transaction execution ----
+//
+// runOpBlockInjection (the linear per-tx injection loop) was retired in Task 5 — its three
+// responsibilities now live in: preBlockOpSteps (below, block-pre) +
+// SchedulerSerialImpl(serial=true) (per-tx loop, driven by OpScheduler::execute) +
+// finalizeOpBlockResult (block-post). executeDeposit survives on OpstackExecutor (eth_call uses it
+// directly).
+
 /// Block-pre steps shared by the OpScheduler execution path (and previously the retired
 /// runOpBlockInjection): recent-block-hashes construction → system_call_block_start +
 /// write-back → deposit-first content check + Jovian shape → DA footprint gas scalar. Outputs
+
 /// hashes (emplaced in place — RecentBlockHashes holds a storage reference, not assignable, hence
 /// the std::optional carrier), hashErr, and daFootprintGasScalar via reference params. Throws
 /// OpConsensusError on shape/validation faults.
@@ -101,9 +265,11 @@ void preBlockOpSteps(Storage& view, bcos::protocol::BlockHeader const& header,
     // L1-attributes deposit seeds the block's fee/DA context and deposits[0] is read below.
     if (rawTxBytes[0].empty() || rawTxBytes[0][0] != kDepositTypeByte || deposits.empty())
         throw OpConsensusError("op block: no deposit transaction to seed the block");
-    // L1-attributes content check — demoted from a hard reject to an observable log:
-    // op-geth/op-reth parse the first tx as the L1 info (extract_l1_info) without validating it
-    // is the L1-attributes tx, so both reference clients accept such a block.
+    // L1-attributes content check — demoted from a hard reject to an observable log (finding D
+    // #5429): op-geth/op-reth parse the first tx as the L1 info (extract_l1_info) without
+    // validating it is the L1-attributes tx, so a block whose first deposit is not the canonical
+    // L1-attributes one is accepted by both reference clients. FISCO keeps it observable
+    // (WARNING) without diverging on acceptance.
     if (!op::isL1AttributesTx(deposits[0]))
         BCOS_LOG(WARNING) << LOG_BADGE("OP_BLOCK_EXEC")
                           << "op block: first tx is a deposit but not the L1 attributes tx — "
@@ -139,7 +305,7 @@ void preBlockOpSteps(Storage& view, bcos::protocol::BlockHeader const& header,
         }
     }
 
-    // (3) DA scalar: Jovian extracts big-endian uint16 from deposits[0].data[176:178]; the
+    // (3) DA scalar (H1c): Jovian extracts big-endian uint16 from deposits[0].data[176:178]; the
     // 176B Isthmus activation attributes → 0.
     if (cfg.has_da_footprint)
     {
@@ -178,5 +344,25 @@ inline OpBlockCommitments announcedCommitmentsOf(const bcos::engine::ExecutionPa
         .requestsHash = ethHeader.requestsHash(),
     };
     return out;
+}
+
+/// transactionsRoot over raw EIP-2718 envelopes (trie key = rlp(index), value = raw wire bytes).
+/// Matches op-geth's DeriveSha because the raw-tx decoders reject non-canonical encodings
+/// (assertCanonicalRoundTrip fails closed if that lapses). Two call sites: the engine's
+/// pre-execution blockHash check and finalizeOpBlockResult's txRoot.
+template <class RawTxRange>
+[[nodiscard]] bcos::h256 computeOpTxRoot(RawTxRange const& rawTxBytes)
+{
+    std::vector<std::pair<bcos::bytes, bcos::bytes>> entries;
+    entries.reserve(rawTxBytes.size());
+    uint64_t index = 0;
+    for (auto const& rawItem : rawTxBytes)
+    {
+        bcos::bytes key;
+        bcos::codec::rlp::encode(key, index);
+        entries.emplace_back(std::move(key), bcos::bytes(std::begin(rawItem), std::end(rawItem)));
+        ++index;
+    }
+    return bcos::ledger::mpt::computeTrieRootVarKey(entries).root;
 }
 }  // namespace bcos::evm::engine

--- a/opstack-executor/OpCommon.h
+++ b/opstack-executor/OpCommon.h
@@ -15,7 +15,7 @@
 #include <bcos-framework/protocol/BlockHeader.h>
 #include <bcos-framework/protocol/TransactionReceipt.h>
 #include <bcos-utilities/Common.h>
-#include <bcos-utilities/DataConvertUtility.h>  // bcos::toQuantity (hexCumulative reuse)
+#include <bcos-utilities/DataConvertUtility.h>  // bcos::toQuantity (hexCumulative reuse, review #5429 R)
 #include <bcos-utilities/FixedBytes.h>
 #include <bcos-evm/eth/state/block.hpp>
 #include <bcos-evm/eth/state/bloom_filter.hpp>
@@ -48,17 +48,34 @@ struct OpBlockSeal
     std::optional<uint64_t> blobGasUsed;
 };
 
-/// "0x" + lowercase hex (op-geth hexutil.Uint64); the value later feeds the receipts-root leaf
-/// encoding that returns with the block-seal wiring (part 5).
-[[nodiscard]] inline std::string hexCumulative(uint64_t cumulative)
+/// Bounds-checked u256→int64 narrowing (a corrupt receipt must not wrap the gas pool).
+[[nodiscard]] inline int64_t narrowGasUsed(const bcos::u256& gasUsed)
 {
-    return bcos::toQuantity(cumulative);  // reuse the library quantity formatter
+    static const bcos::u256 kMaxInt64(std::numeric_limits<int64_t>::max());
+    if (gasUsed > kMaxInt64)
+        throw std::runtime_error("op block: receipt gasUsed exceeds int64_t range");
+    return static_cast<int64_t>(gasUsed);
 }
 
-/// EIP-2718 tx-type classification, single home for the block-execution sites (the OpScheduler
-/// deposit-classification loop and the part-5 seal wiring's txTypes rebuild) so the mapping can't
-/// drift and silently emit a wrong receiptsRoot leaf. Maps a raw type byte to the per-receipt
-/// type byte:
+/// "0x" + lowercase hex (op-geth hexutil.Uint64); parsed back by encodeReceiptForRoot.
+[[nodiscard]] inline std::string hexCumulative(uint64_t cumulative)
+{
+    return bcos::toQuantity(cumulative);  // reuse the library quantity formatter (review #5429 R)
+}
+
+/// Plain DECIMAL string — the tars receipt field's de-facto convention (the generic line's
+/// BaselineScheduler writes u256.str(), and the RPC read path's safeCastToU256 lexical_casts
+/// decimal only, so a hex string serialises as cumulativeGasUsed=0x0). The receipts-root
+/// encoder's parser accepts both formats (OpBlockExecute.cpp parseHexUint64).
+[[nodiscard]] inline std::string decimalCumulative(uint64_t cumulative)
+{
+    return std::to_string(cumulative);
+}
+
+/// EIP-2718 tx-type classification, single home for the three block-execution sites (the
+/// OpScheduler deposit-classification loop, finalizeOpBlockResult's txTypes rebuild, and
+/// processOpBlock's variant branch) so the mapping can't drift and silently emit a wrong
+/// receiptsRoot leaf. Maps a raw type byte to the value stored in OpBlockResult.txTypes:
 /// OP deposit 0x7e (kDepositTxType, OpTransition.h) → itself; legacy (>= 0xc0 RLP list prefix)
 /// → 0; typed (0x01/0x02/0x04) → its own type byte. Unknown bytes (< 0xc0, not deposit) pass
 /// through unchanged — callers that must reject them (the deposit loop) keep their own guard.
@@ -81,8 +98,8 @@ struct OpBlockSeal
 namespace bcos::evm::engine
 {
 /// Thrown for anything OP block execution classifies as a consensus-level rejection (error
-/// table): malformed/undecodable raw tx bytes, the block-shape semantic throws
-/// (empty block, missing L1 attributes deposit, gas-pool overrun, ...). Maps to INVALID
+/// table): malformed/undecodable raw tx bytes, processOpBlock's own semantic throws
+/// (empty block, first tx not the L1 attributes deposit, gas-pool overrun, ...). Maps to INVALID
 /// on the caller side, never -32603.
 struct OpConsensusError : std::runtime_error
 {
@@ -171,6 +188,7 @@ template <class T>
     return *opt;
 }
 
+
 /// Build the OP block context from a FISCO header. `gasLimitOverride` injects the head block's
 /// gasLimit as blockGasLeft (a minimal test header may leave gasLimit==0); `lenientOptionals`
 /// tolerates unset optional header fields as 0 (eth_call path), while block execution uses
@@ -213,18 +231,3 @@ inline evmone::state::BlockInfo toBlockInfo(const bcos::protocol::BlockHeader& e
 }
 }  // namespace detail
 }  // namespace bcos::evm::engine
-
-namespace bcos::evm::opstack
-{
-/// Bounds-checked u256→int64 narrowing (a corrupt receipt must not wrap the gas pool). Throws
-/// engine::OpConsensusError — a bare std::runtime_error would escape the INVALID/-32603
-/// classification this header establishes (see requireHeaderField's comment). Defined after the
-/// engine block because the error types live there.
-[[nodiscard]] inline int64_t narrowGasUsed(const bcos::u256& gasUsed)
-{
-    static const bcos::u256 kMaxInt64(std::numeric_limits<int64_t>::max());
-    if (gasUsed > kMaxInt64)
-        throw engine::OpConsensusError("op block: receipt gasUsed exceeds int64_t range");
-    return static_cast<int64_t>(gasUsed);
-}
-}  // namespace bcos::evm::opstack

--- a/opstack-executor/OpDepositEncode.h
+++ b/opstack-executor/OpDepositEncode.h
@@ -1,0 +1,22 @@
+#pragma once
+// Deposit-envelope encoder (promoted from test support 08-19: the Tier-2 attribute-driven
+// OP build synthesizes the L1-attributes deposit envelope in the engine).
+#include <opstack-executor/RlpEncodeTuple.h>
+#include <bcos-evm/opstack/OpTransition.h>
+#include <bcos-utilities/Common.h>
+#include <evmc/evmc.hpp>
+
+// 0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTransaction, data]).
+inline bcos::bytes encodeDepositEnvelope(const bcos::evm::opstack::DepositTx& d)
+{
+    using bcos::evm::eth::detail::encodeTuple;
+    auto body = encodeTuple(evmc::bytes_view(d.source_hash), evmc::bytes_view(d.from),
+        d.to.has_value() ? evmc::bytes_view(*d.to) : evmc::bytes_view{}, d.mint.value_or(0),
+        d.value, static_cast<uint64_t>(d.gas_limit),
+        static_cast<uint64_t>(d.is_system_tx ? 1 : 0), d.data);
+    bcos::bytes out;
+    out.reserve(body.size() + 1);
+    out.push_back(0x7e);
+    out.insert(out.end(), body.begin(), body.end());
+    return out;
+}

--- a/opstack-executor/OpSchedulerSeam.h
+++ b/opstack-executor/OpSchedulerSeam.h
@@ -1,0 +1,150 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+// OpSchedulerSeam — the engine-facing seam shim for OP mode. `executeBlock` exists only to
+// satisfy the scheduler_v1::TransactionScheduler concept check (OP mode never calls it — throws
+// immediately). A pure template header, no .cpp.
+
+#include <bcos-evm/opstack/OpForkSchedule.h>
+#include <bcos-framework/ledger/LedgerConfig.h>
+#include <bcos-framework/protocol/BlockHeader.h>
+#include <bcos-framework/protocol/TransactionReceipt.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <opstack-executor/OpBlockExecute.h>  // computeOpTxRoot / announcedCommitmentsOf
+#include <opstack-executor/OpCommitments.h>  // OpBlockCommitments / commitmentsOf / mismatchedFieldOf
+#include <opstack-executor/OpCommon.h>
+#include <opstack-executor/OpDepositEncode.h>  // encodeDepositEnvelope (Tier-2 build)
+#include <cstdint>
+#include <optional>
+#include <range/v3/range/concepts.hpp>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace bcos::evm::engine
+{
+
+/// The OP block-execution environment was folded into `protocol::BlockHeader` (it now carries all
+/// former OpBlockEnv fields); the engine fills one header object and the decoders read the
+/// accessors directly.
+
+namespace detail
+{
+}  // namespace detail
+/// OP scheduler component: a pure engine-facing seam shim, constructed once per OpForkFlags
+/// combination (composition-root-owned). It only re-publishes the seam surface the engine reaches
+/// as dependent names on `SchedulerType`.
+template <class Storage>
+class OpSchedulerSeam
+{
+public:
+    explicit OpSchedulerSeam(bcos::evm::opstack::OpForkFlags forkFlags) : m_forkFlags(forkFlags) {}
+
+    // ---- engine-facing seam surface ----
+    //
+    // The engine's newPayload OP branch reaches every name below as a dependent name on its
+    // `SchedulerType` template parameter — the only channel available (the engine must not include
+    // anything from bcos-evm). The definitions live in OpCommon.h / OpBlockExecute.h; this block
+    // re-publishes them under the class scope the engine can reach.
+
+    /// The block-execution environment the engine fills in from the payload — the FISCO
+    /// protocol::BlockHeader itself.
+    using BlockEnv = bcos::protocol::BlockHeader;
+    /// What executeOpBlock returns.
+    using ExecuteResult = OpExecuteBlockResult;
+    /// Consensus-level rejection → engine maps to INVALID.
+    using ConsensusError = OpConsensusError;
+    /// Storage-layer failure → engine maps to JSON-RPC -32603, never INVALID.
+    using StorageError = OpStorageError;
+    /// s_eth_hash_2_rawtx. No longer written (registerOpBlock writes SYS_HASH_2_TX via
+    /// opEnvelopeToTars); kept only for read-side test assertions.
+    static constexpr std::string_view c_ethRawTxTable = SYS_ETH_HASH_2_RAWTX;
+
+    /// The six-way comparison surface (plus the two seal-only outputs) in bcos:: types.
+    static OpBlockCommitments commitmentsOf(const OpExecuteBlockResult& result)
+    {
+        return bcos::evm::engine::commitmentsOf(
+            result.seal, result.stateRoot, result.gasUsed, result.txRoot);
+    }
+
+    /// Announced-side projection for the six-field comparison (re-published as a dependent name).
+    static bcos::evm::engine::OpBlockCommitments announcedCommitmentsOf(
+        const bcos::engine::ExecutionPayload& payload, const bcos::h256& transactionsRoot,
+        const bcos::protocol::BlockHeader& ethHeader)
+    {
+        return bcos::evm::engine::announcedCommitmentsOf(payload, transactionsRoot, ethHeader);
+    }
+
+    /// First mismatching field name, or nullopt (re-published as a dependent name).
+    static std::optional<std::string> mismatchedFieldOf(
+        const OpBlockCommitments& computed, const OpBlockCommitments& announced)
+    {
+        return bcos::evm::engine::mismatchedFieldOf(computed, announced);
+    }
+
+    /// transactionsRoot over raw EIP-2718 envelopes — the engine needs it before execution to
+    /// reconstruct the header for the blockHash check (ExecutionPayload carries no such field).
+    static bcos::h256 computeTxRoot(::ranges::input_range auto const& rawTxBytes)
+    {
+        return computeOpTxRoot(rawTxBytes);
+    }
+
+    /// Jovian activation predicate (feature-op_jovian). The engine needs it for fork-dependent
+    /// static checks: the header's blobGasUsed slot must be 0 under Isthmus, but under Jovian it is
+    /// the DA footprint (validated by seal comparison instead); base-fee derivation branches on it.
+    /// There is no isIsthmusActiveAt anymore — OP mode itself IS the Isthmus+ admission check
+    /// (executor_version>=3), and the -38005 gate no longer re-derives the fork from a timestamp.
+    [[nodiscard]] bool isJovianActive() const noexcept { return m_forkFlags.jovianActive; }
+
+    OpSchedulerSeam(const OpSchedulerSeam&) = delete;
+    OpSchedulerSeam(OpSchedulerSeam&&) = delete;
+    OpSchedulerSeam& operator=(const OpSchedulerSeam&) = delete;
+    OpSchedulerSeam& operator=(OpSchedulerSeam&&) = delete;
+    ~OpSchedulerSeam() = default;
+
+    /// Concept-check only — OP mode never calls this. Throws before any co_await/co_return: safe
+    /// because the Task coroutine body does not run until the coroutine is actually resumed.
+    task::Task<std::vector<bcos::protocol::TransactionReceipt::Ptr>> executeBlock(
+        Storage& /*storage*/, auto& /*executor*/,
+        bcos::protocol::BlockHeader const& /*blockHeader*/,
+        ::ranges::input_range auto const& /*transactions*/,
+        bcos::ledger::LedgerConfig const& /*ledgerConfig*/)
+    {
+        throw std::logic_error("OpSchedulerSeam::executeBlock: not supported in OP mode");
+        co_return {};  // unreachable; satisfies the coroutine's declared return type
+    }
+
+    /// Tier-2 attribute-driven build: the mandatory L1-attributes deposit envelope (OP blocks
+    /// hard-require a leading deposit). Phase-A field values are zeros (fixture chain without
+    /// an L1): Isthmus shape = 176 zero bytes; Jovian = selector(0x3db6be2b) + zeros to 178.
+    /// The deposit's execution against the Ecotone-era genesis L1Block reverts and is
+    /// tolerated (documented predeploy-matrix divergence).
+    static bcos::bytes synthesizeL1AttributesEnvelope(bool jovianActive)
+    {
+        namespace op = bcos::evm::opstack;
+        evmc::bytes data(op::IsthmusL1AttributesLen, 0);
+        if (jovianActive)
+        {
+            data.resize(op::JovianL1AttributesLen, 0);
+            std::copy(op::JovianL1AttributesSelector.begin(), op::JovianL1AttributesSelector.end(),
+                data.begin());
+        }
+        op::DepositTx deposit{.source_hash = evmc::bytes32{},
+            .from = op::OP_DEPOSITOR,
+            .to = op::OP_L1_BLOCK,
+            .mint = std::nullopt,
+            .value = intx::uint256{0},
+            .gas_limit = 1'000'000,
+            .is_system_tx = false,
+            .data = std::move(data)};
+        return encodeDepositEnvelope(deposit);
+    }
+
+private:
+    bcos::evm::opstack::OpForkFlags m_forkFlags;
+};
+
+}  // namespace bcos::evm::engine

--- a/opstack-executor/OpstackExecutor.h
+++ b/opstack-executor/OpstackExecutor.h
@@ -3,8 +3,9 @@
 ///
 /// Implements the bcos::executor_v1::TransactionExecutor concept (ExecuteContext with
 /// prepare/execute/finish): opValidate + opTransition for NORMAL transactions, runDeposit for
-/// 0x7E deposits. The caller passes an already-decoded DepositTx. Storage-backed StateView and
-/// state-diff writeback (Storage2State::applyDiff) are shared with the base module.
+/// 0x7E deposits, finalizeOpBlock for block finalize. The caller passes an already-decoded
+/// DepositTx. Storage-backed StateView and state-diff writeback (Storage2State::applyDiff) are
+/// shared with the base module.
 
 #pragma once
 
@@ -16,7 +17,7 @@
 #include "bcos-framework/protocol/Transaction.h"
 #include "bcos-framework/protocol/TransactionReceipt.h"
 #include "bcos-framework/protocol/TransactionReceiptFactory.h"
-#include "bcos-framework/transaction-executor/TransactionExecutor.h"
+#include "bcos-task/TBBWait.h"
 #include "ethereum-executor/EVMSupport.h"  // eth::evm::toIntxU256
 #include "opstack-executor/OpCommon.h"  // detail::narrowU256ToU64 / toEvmcAddress / toEvmcBytes32
 #include "opstack-executor/Storage2State.h"  // Storage2State / SharedErrorSlot
@@ -35,6 +36,15 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace bcos::evm::opstack
+{
+// Defined in OpBlockExecute.cpp — forward-declared here to avoid including OpBlockExecute.h
+// (which includes this header).
+evmone::state::StateDiff finalizeOpBlock(
+    const evmone::state::StateView& view, const OpForkConfig& cfg, const evmc::address& coinbase);
+}  // namespace bcos::evm::opstack
+
 
 namespace bcos::executor_v1::eth
 {
@@ -149,11 +159,17 @@ inline evmone::state::Transaction toEvmoneTransaction(bcos::protocol::Transactio
     for (auto const& entry : tx.web3AccessList())
     {
         evmc_address addr{};
+        if (entry.account.size() < sizeof(evmc_address))
+            throw bcos::evm::engine::OpConsensusError(
+                "toEvmoneTransaction: access-list account address too short");
         std::copy_n(entry.account.begin(), sizeof(evmc_address), addr.bytes);
         std::vector<evmc::bytes32> keys;
         for (auto const& sk : entry.storageKeys)
         {
             evmc_bytes32 key{};
+            if (sk.size() < sizeof(evmc_bytes32))
+                throw bcos::evm::engine::OpConsensusError(
+                    "toEvmoneTransaction: access-list storage key too short");
             std::copy_n(sk.begin(), sizeof(evmc_bytes32), key.bytes);
             keys.push_back(key);
         }
@@ -162,6 +178,9 @@ inline evmone::state::Transaction toEvmoneTransaction(bcos::protocol::Transactio
     for (auto const& h : tx.blobVersionedHashes())
     {
         evmc_bytes32 hash{};
+        if (h.size() < sizeof(evmc_bytes32))
+            throw bcos::evm::engine::OpConsensusError(
+                "toEvmoneTransaction: blob versioned hash too short");
         std::copy_n(h.begin(), sizeof(evmc_bytes32), hash.bytes);
         evmTx.blob_hashes.push_back(hash);
     }
@@ -201,6 +220,9 @@ inline evmone::state::Transaction toEvmoneTransaction(bcos::protocol::Transactio
         evmone::state::Authorization ea{};
         // AuthorizationEntry: all fields are numeric (uint64_t, u256, Address, uint8_t)
         ea.chain_id = toIntxU256(bcos::u256(auth.chainId));
+        if (auth.address.size() < sizeof(evmc_address))
+            throw bcos::evm::engine::OpConsensusError(
+                "toEvmoneTransaction: authorization entry address too short");
         std::copy_n(auth.address.begin(), sizeof(evmc_address), ea.addr.bytes);
         ea.nonce = auth.nonce;
         if (auth.signer.size() == sizeof(evmc_address))
@@ -239,12 +261,13 @@ public:
     evmc::bytes32 get_block_hash(int64_t) const noexcept override { return {}; }
 };
 
-/// Strict 0x7E deposit envelope decode (consensus-grade).
+/// Strict 0x7E deposit envelope decode (consensus-grade, kyonRay review #5429 K3).
 /// `0x7e || rlp([sourceHash, from, to, mint, value, gas, isSystemTx, data])`. Deposit fields fed
-/// to execution are re-derived HERE from the L1-derived envelope — never from the unauthenticated
-/// tars mirrors (Transaction.tars field 8+), which a peer can forge to mint arbitrary value.
-/// Unlike the RPC display-grade decoder, this rejects a non-0x7e type byte, malformed RLP,
-/// trailing bytes after the list and over-wide fields.
+/// to execution are re-derived HERE from the signed envelope — never from the unauthenticated tars
+/// mirrors (Transaction.tars field 8+) — because a peer-controlled mirror can mint arbitrary value
+/// (deposits are unsigned by design; authenticity comes from the L1-derived envelope). Unlike the
+/// RPC display-grade decoder, this rejects a non-0x7e type byte, malformed RLP, trailing bytes
+/// after the list and over-wide fields. One RLP decode per deposit (blocks carry one or two).
 [[nodiscard]] inline bcos::evm::opstack::DepositTx decodeDepositEnvelope(bcos::bytesConstRef env)
 {
     namespace op = bcos::evm::opstack;
@@ -252,11 +275,16 @@ public:
     auto fail = [](std::string const& msg) {
         BOOST_THROW_EXCEPTION(OpTxValidationFailed{} << bcos::errinfo_comment(msg));
     };
-    // Gate an integer RLP item for width AND canonicality: rlp::decode(UnsignedIntegral) does
-    // not bound the payload to the target width (fromBigEndian folds excess high bytes), and of
-    // the non-canonical forms it only rejects a single-byte payload < 0x80. op-geth additionally
-    // rejects the bare byte 0x00 (canonical zero is the empty item 0x80) and multi-byte payloads
-    // with a leading zero. Returns the payload length, or nullopt if not a canonical integer.
+    // Gate an integer RLP item for width AND canonicality (kyonRay review #5429 round 3):
+    // rlp::decode(UnsignedIntegral) does not check the payload length against the target width —
+    // fromBigEndian folds excess high bytes, so a 33-byte mint would silently truncate to its low
+    // 32 bytes — and of the non-canonical forms it only rejects a single-byte payload < 0x80 (via
+    // decodeHeader). op-geth's Stream.uint / decodeBigInt additionally return ErrCanonInt /
+    // ErrCanonSize for the single Byte 0x00 (integer zero must be the empty item 0x80) and for any
+    // multi-byte payload with a leading zero byte. Return the payload length of the integer at
+    // `ref`'s front, or nullopt if it is not a canonical well-formed integer (RLP list / truncated
+    // length prefix / non-canonical). FISCO's own RLPEncode always writes minimal encodings, so
+    // only externally-supplied bytes are affected.
     auto integerPayloadLength = [&](bcos::bytesConstRef const& ref) -> std::optional<size_t> {
         if (ref.empty())
             return std::nullopt;
@@ -264,7 +292,7 @@ public:
         if (b < 0x80)
         {
             // Byte item: 0x00 is non-canonical (integer zero must be the empty item 0x80).
-            return b == 0 ? std::nullopt : std::optional<size_t>{1};
+            return b == 0 ? std::nullopt : std::optional<size_t>{0};
         }
         if (b <= 0xb7)
         {  // short string
@@ -360,17 +388,20 @@ public:
         fail("deposit envelope: value non-canonical or over-wide (>32 bytes)");
     if (auto e = rlp::decode(items, value); e != nullptr)
         fail("deposit envelope: value decode failed");
-    // gas (uint64): width + canonicality check, then int64 range. A uint64 above INT64_MAX
-    // would silently wrap dep.gas_limit's static_cast<int64_t>(gas) — reject at the decoder.
+    // gas (uint64): width + canonicality check, then int64 range. A uint64 that exceeds
+    // INT64_MAX would silently wrap dep.gas_limit's static_cast<int64_t>(gas) to -1 — reject at
+    // the decoder, not downstream (kyonRay review #5429 round 3).
     if (auto pl = integerPayloadLength(items); !pl || *pl > 8)
         fail("deposit envelope: gas non-canonical or over-wide (>8 bytes)");
     if (auto e = rlp::decode(items, gas); e != nullptr)
         fail("deposit envelope: gas decode failed");
     if (gas > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
         fail("deposit envelope: gas exceeds int64 range");
-    // isSystemTx (uint64): width + canonicality check, then a 0/1 value check (op-geth's
-    // decodeBool accepts only the empty item and 0x01). Decoded as uint64 because the FISCO bool
-    // overload demands payloadLength == 1 and would reject the empty-item false.
+    // isSystemTx (uint64): width + canonicality check, then a 0/1 value check. op-geth's
+    // decodeBool accepts only the empty item (false) and 0x01 (true) and errors on any other
+    // value ("rlp: invalid boolean"). Decoded as uint64 — the FISCO bool overload demands
+    // payloadLength == 1 and would reject the empty-item false — so the 0/1 check is explicit
+    // (kyonRay review #5429 round 3).
     if (auto pl = integerPayloadLength(items); !pl || *pl > 8)
         fail("deposit envelope: isSystemTx non-canonical or over-wide (>8 bytes)");
     if (auto e = rlp::decode(items, isSystemTxValue); e != nullptr)
@@ -406,14 +437,15 @@ public:
 /// Correctness relies on a serial driver (SchedulerSerialImpl).
 struct OpBlockExecutionContext
 {
-    mutable bcos::evm::opstack::OpFeeParams fee;  // lazy-loaded once per block + DA scalar override
-    mutable bool feeLoaded = false;               // fee lazy-load flag
-    mutable int64_t blockGasLeft = 0;             // decremented per tx
-    mutable int64_t cumulativeGasUsed = 0;        // accumulated across txs
-    mutable bool seenNonDeposit = false;          // deposit-after-non-deposit gate
-    evmone::state::BlockHashes* blockHashes = nullptr;  // built once at block level
-    uint64_t chainId = 0;                               // constant for the whole block
-    std::optional<uint16_t> daFootprintGasScalar;       // Jovian DA scalar
+    mutable bcos::evm::opstack::OpFeeParams fee;        // lazy-load + DA scalar override (H1/H1c)
+    mutable bool feeLoaded = false;                     // fee lazy-load flag (H1)
+    mutable int64_t blockGasLeft = 0;                   // decremented per tx
+    mutable int64_t cumulativeGasUsed = 0;              // accumulated across txs (H4)
+    mutable size_t transactionIndex = 0;                // per-tx receipt index (Tier-2 Phase B)
+    mutable bool seenNonDeposit = false;                // deposit-after-non-deposit gate (M2)
+    evmone::state::BlockHashes* blockHashes = nullptr;  // built once at block level (H3)
+    uint64_t chainId = 0;                               // constant (H3)
+    std::optional<uint16_t> daFootprintGasScalar;       // Jovian DA scalar (H1c)
 };
 
 /// The OP transaction executor. Discard-writes contract: on any throw out of
@@ -490,8 +522,10 @@ public:
         // BlockInfo built once in prepare() and reused by execute() (same inputs, same value).
         std::optional<evmone::state::BlockInfo> m_blockInfo;
 
-        // One state view per tx shared across prepare/execute, so the validate-phase read cache
-        // (m_accountCache/m_codeCache) hits in the transition stage. Non-movable, hence unique_ptr.
+        // Shared state view built ONCE per tx and threaded across prepare/execute (review #5429 Q):
+        // m_prepare and m_execute used to construct their own Storage2State, discarding the
+        // validate-phase read cache (m_accountCache/m_codeCache) and re-reading sender/L1Block cold
+        // in the transition stage. Non-movable by design, hence held by unique_ptr.
         std::unique_ptr<bcos::evm::evmstate::Storage2State<Storage>> stateView;
 
         // Shared per-block context; the mutable fields above are written through this const
@@ -539,9 +573,11 @@ public:
             if (transaction.isDepositTx())
             {
                 if (m_ctx->seenNonDeposit)
-                    // Deposit order gate — demoted from a hard reject to an observable log:
-                    // op-geth/op-reth enforce deposit-first only at the sequencer, not at
-                    // validation, so both reference clients accept such a block.
+                    // M2 order gate — demoted from a hard reject to an observable log (finding D
+                    // #5429): op-geth/op-reth enforce deposit-first only at the sequencer
+                    // (construction), not at validation, so a block with a deposit after a
+                    // non-deposit is accepted by both reference clients. FISCO keeps the
+                    // invariant observable (WARNING) without diverging on acceptance.
                     BCOS_LOG(WARNING) << LOG_BADGE("OPSTACK")
                                       << "deposit after non-deposit in block — accepted "
                                          "(deliberate demotion, op-geth/op-reth accept at "
@@ -552,8 +588,9 @@ public:
                 }
                 catch (const OpTxValidationFailed& e)
                 {
-                    // A malformed deposit envelope (e.g. a 0x02-envelope whose tars mirror
-                    // claims deposit) is a consensus rejection, not an internal error.
+                    // kyonRay review #5429 #2: a malformed deposit envelope (e.g. a 0x02-envelope
+                    // whose tars mirror claims deposit) is a CONSENSUS rejection, not an internal
+                    // error — reclassify so the block surfaces as INVALID instead of -32603.
                     throw engine::OpConsensusError(
                         std::string("OpScheduler: deposit envelope validation failed: ") +
                         e.what());
@@ -562,26 +599,30 @@ public:
             }
             m_ctx->seenNonDeposit = true;
             if (!m_ctx->feeLoaded)
-            {  // Fee lazy load (after the L1 attributes deposit has executed)
+            {  // H1 fee lazy load (after the L1 attributes deposit has executed)
                 namespace op = bcos::evm::opstack;
                 m_ctx->fee = op::loadOpFeeParams(*stateView);
-                if (m_ctx->daFootprintGasScalar)  // DA scalar override
+                if (m_ctx->daFootprintGasScalar)  // H1c DA scalar override
                     m_ctx->fee.da_footprint_gas_scalar = *m_ctx->daFootprintGasScalar;
                 m_ctx->feeLoaded = true;
             }
             m_blockInfo = buildBlockInfo(blockHeader,
                 opBlockGasLimit(blockHeader, static_cast<uint64_t>(m_ctx->blockGasLeft)), call);
             try
-            {  // Error normalization: validation failure -> consensus rejection
+            {  // M1 normalization: validation failure -> consensus rejection
                 m_props = co_await executor.m_prepare(*stateView, blockHeader, transaction,
                     ledgerConfig, m_ctx->fee, m_ctx->blockGasLeft,
                     call ? std::optional<uint64_t>{} : std::optional<uint64_t>(m_ctx->chainId),
-                    &*m_blockInfo);
+                    &*m_blockInfo, call);
             }
             catch (const OpTxValidationFailed& e)
             {
+                // The offending tx's hash rides in the message (bcos::Error carries a string
+                // only across the delegate boundary): the engine's OP build loop parses it to
+                // evict the culprit from the pool instead of failing every subsequent build.
                 throw engine::OpConsensusError(
-                    std::string("OpScheduler: normal tx validation failed: ") + e.what());
+                    std::string("OpScheduler: normal tx validation failed: ") + e.what() +
+                    " [tx=0x" + transaction.hash().hex() + "]");
             }
         }
         task::Task<void> execute()
@@ -612,7 +653,7 @@ public:
             {
                 m_receipt = co_await executor.m_execute(*stateView, blockHeader, transaction,
                     ledgerConfig, m_props, m_diff, m_ctx->chainId, m_ctx->blockGasLeft,
-                    m_ctx->blockHashes,  // built once at block level
+                    m_ctx->blockHashes,  // H3
                     m_blockInfo.has_value() ? &*m_blockInfo : nullptr);
             }
         }
@@ -630,11 +671,14 @@ public:
                 receipt = co_await executor.m_finish(
                     storage, blockHeader, ledgerConfig, m_receipt, m_diff);
             }
-            // Sole owner of cumulative-gas backfill + blockGasLeft decrement (narrowGasUsed /
-            // hexCumulative live in OpCommon.h).
+            // H4: sole owner of cumulative-gas backfill + blockGasLeft decrement (narrowGasUsed /
+            // decimalCumulative live in OpCommon.h). Decimal + the block index — the RPC read
+            // path lexical_casts decimal only and serves transactionIndex from the receipt.
             auto gasUsed = op::narrowGasUsed(receipt->gasUsed());
             m_ctx->cumulativeGasUsed += gasUsed;
-            receipt->setCumulativeGasUsed(op::hexCumulative(m_ctx->cumulativeGasUsed));
+            receipt->setCumulativeGasUsed(
+                op::decimalCumulative(static_cast<uint64_t>(m_ctx->cumulativeGasUsed)));
+            receipt->setTransactionIndex(m_ctx->transactionIndex++);
             m_ctx->blockGasLeft -= gasUsed;
             co_return receipt;
         }
@@ -662,6 +706,7 @@ public:
         int contextID, ledger::LedgerConfig const& ledgerConfig, bool call,
         BlockContext const&& blockCtx) = delete;
 
+
     /// 6-arg form (generic scheduler + the TransactionExecutor concept probe): no BlockContext is
     /// available, so m_ctx is null and any prepare/execute/finish throws. The previous default
     /// argument `= BlockContext{}` bound a temporary to the const-ref parameter whose lifetime
@@ -677,7 +722,22 @@ public:
             *this, storage, blockHeader, transaction, contextID, ledgerConfig, call, nullptr};
     }
 
-    /// Execute a single OP normal transaction (injection-style).
+    /// 6-arg form matching the TransactionExecutor concept probe (TransactionExecutor.h:18).
+    /// OP is never driven through this form — SchedulerSerialImpl's pipeline uses
+    /// createExecuteContext + prepare/execute/finish — but the concept requires executeTransaction
+    /// to exist with this exact signature. Throws if actually called (same guard as the 6-arg
+    /// createExecuteContext: no BlockContext means no fee / blockGasLeft / chainId / blockHashes).
+    template <class Storage>
+    task::Task<protocol::TransactionReceipt::Ptr> executeTransaction(Storage& /*storage*/,
+        protocol::BlockHeader const& /*blockHeader*/, protocol::Transaction const& /*transaction*/,
+        int /*contextID*/, ledger::LedgerConfig const& /*ledgerConfig*/, bool /*call*/)
+    {
+        throw engine::OpConsensusError(
+            "OpstackExecutor: executeTransaction 6-arg form is unsupported for OP execution "
+            "(use createExecuteContext + prepare/execute/finish instead)");
+    }
+
+    /// Execute a single OP normal transaction (injection-style, mirroring processOpBlock).
     /// Orchestrator supplies fee, decrementing blockGasLeft, chainId, and real block hashes.
     /// All trailing params are required: these are coroutines (task::Task is lazy — the body runs
     /// after the call expression), so a defaulted `const& fee = {}` would bind a temporary that is
@@ -720,16 +780,16 @@ public:
         // eth_call (call=true) simulates without chain binding — op-geth eth_call is lenient about
         // chainId; block execution (call=false) enforces tx.chainId == node chainId (the op-geth
         // EIP155Signer/modernSigner ErrInvalidChainId check).
-        // One shared state view for prepare+execute: the validate-phase account/fee reads
-        // cache-hit in the transition stage.
+        // One shared state view for prepare+execute (review #5429 Q): validates and transitions on
+        // the same instance so the validate-phase account/fee reads cache-hit in the transition.
         bcos::evm::evmstate::Storage2State<Storage> stateView(storage, m_sharedError);
         auto blockInfo = buildBlockInfo(
             blockHeader, opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)), call);
         bcos::evm::opstack::OpTxProperties props;
         try
-        {  // Error normalization (same as ExecuteContext::prepare): validation failure -> INVALID
+        {  // M1 normalization: validation failure -> consensus rejection
             props = co_await m_prepare(stateView, blockHeader, transaction, ledgerConfig, fee,
-                blockGasLeft, call ? std::optional<uint64_t>{} : chainId, &blockInfo);
+                blockGasLeft, call ? std::optional<uint64_t>{} : chainId, &blockInfo, call);
         }
         catch (const OpTxValidationFailed& e)
         {
@@ -783,8 +843,39 @@ public:
         co_return receipt;
     }
 
-    // Block-level finalize (finalizeOpBlock / seal) is deferred to the part that lands the
-    // OpScheduler wiring (part 5).
+    /// OP block-level finalize (no block reward, via finalizeOpBlock).
+    template <class Storage>
+    task::Task<void> finalizeBlock(Storage& storage, protocol::BlockHeader const& blockHeader,
+        ledger::LedgerConfig const& ledgerConfig)
+    {
+        namespace op = bcos::evm::opstack;
+
+        checkForkRevision(ledgerConfig);
+
+        bcos::evm::evmstate::Storage2State<Storage> stateView(storage, m_sharedError);
+        evmc_address coinbase{};
+        auto const& cb = blockHeader.coinbase();
+        if (cb.size() == sizeof(evmc_address))
+            std::copy_n(cb.begin(), sizeof(evmc_address), coinbase.bytes);
+
+        auto diff = op::finalizeOpBlock(stateView, m_forkConfig, coinbase);
+        // finalizeOpBlock sanitizes the diff; applyDiff poisons AND rethrows.
+        try
+        {
+            stateView.applyDiff(diff);
+        }
+        catch (const std::exception& e)
+        {
+            throw engine::OpStorageError(std::string("finalize write-back failed: ") + e.what());
+        }
+        catch (...)
+        {
+            throw engine::OpStorageError("finalize write-back failed: unknown exception");
+        }
+        if (stateView.poisoned())
+            throw engine::OpStorageError("finalize write-back poisoned: " + stateView.firstError());
+        co_return;
+    }
 
 private:
     // ---- Shared normal-tx pipeline: three stages (prepare/execute/finish). ----
@@ -838,6 +929,7 @@ private:
                                       "OP fork revision does not match ledger evmcRevision"));
     }
 
+
     // Stage 1 — validate: fork/evmc revision check, block info + evmone tx + signed envelope, then
     // injection-style opValidate (props.fee snapshotted for the transition stage).
     template <class Storage>
@@ -846,7 +938,7 @@ private:
         protocol::BlockHeader const& blockHeader, protocol::Transaction const& transaction,
         ledger::LedgerConfig const& ledgerConfig, bcos::evm::opstack::OpFeeParams const& fee,
         int64_t blockGasLeft, std::optional<uint64_t> chainId,
-        evmone::state::BlockInfo const* prebuiltBlockInfo)
+        evmone::state::BlockInfo const* prebuiltBlockInfo, bool skipBalanceCheck = false)
     {
         namespace op = bcos::evm::opstack;
         namespace eth = bcos::executor_v1::eth;
@@ -860,13 +952,13 @@ private:
                              buildBlockInfo(blockHeader,
                                  opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
         auto evmTx = eth::toEvmoneTransaction(transaction);
-        // op-geth parity: reject txs whose chainId differs from the node's chainId.
-        // op-geth EIP155Signer.Sender / modernSigner.Sender check `tx.ChainId() == chainID`
-        // (ErrInvalidChainId) during block processing; FISCO previously accepted any
-        // self-consistent chainId (the signature binds the tx's own chainId, so sender recovery
-        // always succeeds). Only legacy UNPROTECTED txs (v=27/28, chain_id==0, Homestead) are
-        // exempt; every other tx (EIP-155 protected legacy + ALL typed txs) must match.
-        // chainId is nullopt only on the eth_call path (lenient, like op-geth eth_call). The
+        // op-geth parity (morebtcg review #5429): reject txs whose chainId differs from the node's
+        // chainId. op-geth EIP155Signer.Sender / modernSigner.Sender check
+        // `tx.ChainId() == chainID` (ErrInvalidChainId) during block processing; FISCO previously
+        // accepted any self-consistent chainId (the signature binds the tx's own chainId, so
+        // sender recovery always succeeds). Only legacy UNPROTECTED txs (v=27/28, chain_id==0,
+        // Homestead) are exempt; every other tx (EIP-155 protected legacy + ALL typed txs) must
+        // match. chainId is nullopt only on the eth_call path (lenient, like op-geth eth_call). The
         // block path always engages it — an engaged 0 (caller forgot the node chainId) rejects
         // every real tx, so the omission is loud rather than silently disabling the check.
         // Known residual: chain_id==0 also arises from a v=35/36 EIP-155-protected legacy tx
@@ -886,10 +978,23 @@ private:
         auto envRef = transaction.extraTransactionBytes();
         evmc::bytes_view env{envRef.data(), envRef.size()};
 
-        auto validated =
-            op::opValidate(stateView, blockInfo, evmTx, env, m_forkConfig, fee, blockGasLeft);
+        // skipBalanceCheck: eth_call/estimateGas simulations must not balance-validate —
+        // op-geth never balance-validates a call (its simulated sender routinely carries no
+        // funds). opValidate's flag was designed for exactly this but was never wired to the
+        // call path, so every eth_call failed validation and surfaced as an opaque "unknown
+        // exception" at the RPC boundary (see OpScheduler::call).
+        auto validated = op::opValidate(
+            stateView, blockInfo, evmTx, env, m_forkConfig, fee, blockGasLeft, skipBalanceCheck);
         if (auto const* err = std::get_if<std::error_code>(&validated))
+        {
+            BCOS_LOG(WARNING) << LOG_BADGE("OPSTACK") << LOG_DESC("opValidate failed")
+                              << LOG_KV("reason", err->message())
+                              << LOG_KV("sender",
+                                     bcos::toHex(std::span<uint8_t const>(evmTx.sender.bytes, 20)))
+                              << LOG_KV("nonce", evmTx.nonce)
+                              << LOG_KV("skipBalanceCheck", skipBalanceCheck);
             BOOST_THROW_EXCEPTION(OpTxValidationFailed{} << bcos::errinfo_comment(err->message()));
+        }
         auto props = std::move(std::get<op::OpTxProperties>(validated));
         props.evm_tx = std::move(evmTx);  // carry the built tx to m_execute (build once, not twice)
         co_return props;
@@ -913,7 +1018,7 @@ private:
                              *prebuiltBlockInfo :
                              buildBlockInfo(blockHeader,
                                  opBlockGasLimit(blockHeader, static_cast<uint64_t>(blockGasLeft)));
-        auto const& evmTx = props.evm_tx;  // reuse the prepare-built tx
+        auto const& evmTx = props.evm_tx;  // reuse the prepare-built tx (review finding F)
 
         NullBlockHashes nullBlockHashes;
         auto const& bh = (blockHashes != nullptr) ? *blockHashes : nullBlockHashes;
@@ -966,10 +1071,13 @@ private:
     }
 
     /// Build a DepositTx from a protocol::Transaction whose isDepositTx() is true, re-deriving the
-    /// deposit fields from the L1-derived 0x7E envelope (tx.extraTransactionBytes) — NEVER from the
-    /// unauthenticated tars mirrors: those are display-only, and a peer-controlled mirror can mint
-    /// arbitrary value (deposits are unsigned by design). The strict decode rejects
-    /// envelope/mirror mismatch.
+    /// deposit fields from the signed 0x7E envelope (tx.extraTransactionBytes) — NEVER from the
+    /// unauthenticated tars mirrors (kyonRay review #5429 K3). The tars mirrors are display-only:
+    /// a peer-controlled mirror can mint arbitrary value (deposits are unsigned by design;
+    /// authenticity comes from the L1-derived envelope). On the engine newPayload path the mirrors
+    /// happen to be self-consistent (opEnvelopeToTars derives them in-process), but with OP mode
+    /// behind MultiVersionScheduler slot 3 any future wiring that feeds wire-decoded tars into
+    /// OpScheduler must not be able to mint. The strict decode rejects envelope/mirror mismatch.
 public:
     static bcos::evm::opstack::DepositTx depositFromTransaction(protocol::Transaction const& tx)
     {

--- a/opstack-executor/ReorgUndo.h
+++ b/opstack-executor/ReorgUndo.h
@@ -1,0 +1,184 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+// ReorgUndo — the per-height undo journal behind one-level tip rollback (S-DRV-6/7 stage 1).
+//
+// The engine's execution base is the MLS layer stack's top — after a block commits, the
+// backend IS that block's state; the parent's flat values of every key the block wrote are
+// overwritten and gone (the MPT plane keeps them provable, but has no preimage enumeration
+// to rebuild a flat base from). A reorg sibling at the committed tip's own height therefore
+// has no execution base — unless the parent's values were journaled when the block committed.
+//
+// That journal is ReorgUndoBlob: for every state-plane key the block's delta layer touched
+// (the "/mpt/" node table excluded — content-addressed, append-only, never overwritten), the
+// value the key held BEFORE the block, plus the block's tx counters (total_transaction_count
+// compensation). Stored as one SYS_REORG_UNDO row keyed by the block's decimal height.
+//
+// Consumption (OpScheduler): the sibling's execute pre-writes the rows into its view's
+// mutable layer — that single act is simultaneously the read shadow (mutable layer is
+// consulted first, tombstones hide backend rows) and the write-back (the rows merge into the
+// backend with the block's own delta, so keys the sibling does not touch return to their
+// parent values). Capture: at every commit, the delta layer is enumerated and each key's
+// pre-block value is read from a committed view — for a ROLLBACK commit the replaced tip's
+// journal supplies the parent values instead, because the backend still holds the replaced
+// block's writes until the merge.
+
+#include <bcos-framework/ledger/LedgerTypeDef.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bcos::executor_v1::opstack
+{
+
+/// One undo entry: the value `key` held before the journaled block's delta layer wrote it.
+/// nullopt = the key did not exist; restoring it must delete the row.
+struct ReorgUndoRow
+{
+    executor_v1::StateKey key;
+    std::optional<storage::Entry> oldValue;
+};
+
+struct ReorgUndoBlob
+{
+    /// The journaled block's transaction counters, for total/failed count compensation when a
+    /// sibling overwrites the height (prewrite adds counters on top of the ledger's stored
+    /// totals, which already include the replaced block's contribution).
+    int64_t txCount = 0;
+    int64_t failedCount = 0;
+    std::vector<ReorgUndoRow> rows;
+};
+
+/// Wire format (version 1, little-endian, no padding):
+///   u8 version | u64 txCount | u64 failedCount | u32 rowCount
+///   per row: u32 keyLen | key | u8 hasOld | (u32 oldLen | old)?
+class ReorgUndoCodec
+{
+public:
+    static constexpr uint8_t kVersion = 1;
+
+    static bcos::bytes encode(ReorgUndoBlob const& blob)
+    {
+        bcos::bytes out;
+        auto pushU64 = [&out](uint64_t v) {
+            for (unsigned i = 0; i < sizeof(v); ++i)
+            {
+                out.push_back(static_cast<bcos::byte>(v >> (i * 8)));
+            }
+        };
+        auto pushU32 = [&out](uint32_t v) {
+            for (unsigned i = 0; i < sizeof(v); ++i)
+            {
+                out.push_back(static_cast<bcos::byte>(v >> (i * 8)));
+            }
+        };
+
+        out.push_back(kVersion);
+        pushU64(static_cast<uint64_t>(blob.txCount));
+        pushU64(static_cast<uint64_t>(blob.failedCount));
+        if (blob.rows.size() > std::numeric_limits<uint32_t>::max())
+        {
+            throw std::runtime_error("ReorgUndo: row count overflows u32");
+        }
+        pushU32(static_cast<uint32_t>(blob.rows.size()));
+        for (auto const& row : blob.rows)
+        {
+            auto const& keyBytes = row.key.m_tableAndKey;
+            if (keyBytes.size() > std::numeric_limits<uint32_t>::max())
+            {
+                throw std::runtime_error("ReorgUndo: key length overflows u32");
+            }
+            pushU32(static_cast<uint32_t>(keyBytes.size()));
+            out.insert(out.end(), keyBytes.begin(), keyBytes.end());
+            if (row.oldValue.has_value())
+            {
+                out.push_back(1);
+                auto value = (*row.oldValue).get();
+                if (value.size() > std::numeric_limits<uint32_t>::max())
+                {
+                    throw std::runtime_error("ReorgUndo: value length overflows u32");
+                }
+                pushU32(static_cast<uint32_t>(value.size()));
+                out.insert(out.end(), value.begin(), value.end());
+            }
+            else
+            {
+                out.push_back(0);
+            }
+        }
+        return out;
+    }
+
+    static ReorgUndoBlob decode(std::string_view data)
+    {
+        auto cursor = data.begin();
+        auto remaining = [&data, &cursor]() -> size_t {
+            return static_cast<size_t>(std::distance(cursor, data.end()));
+        };
+        auto take = [&cursor, &remaining](size_t n) -> std::string_view {
+            if (remaining() < n)
+            {
+                throw std::runtime_error("ReorgUndo: truncated blob");
+            }
+            auto begin = cursor;
+            std::advance(cursor, static_cast<std::ptrdiff_t>(n));
+            return {&*begin, n};
+        };
+        auto takeU8 = [&take]() -> uint8_t { return static_cast<uint8_t>(take(1)[0]); };
+        auto takeU32 = [&take]() -> uint32_t {
+            auto bytes = take(4);
+            uint32_t value = 0;
+            for (unsigned i = 0; i < 4; ++i)
+            {
+                value |= static_cast<uint32_t>(static_cast<uint8_t>(bytes[i])) << (i * 8);
+            }
+            return value;
+        };
+        auto takeU64 = [&take]() -> uint64_t {
+            auto bytes = take(8);
+            uint64_t value = 0;
+            for (unsigned i = 0; i < 8; ++i)
+            {
+                value |= static_cast<uint64_t>(static_cast<uint8_t>(bytes[i])) << (i * 8);
+            }
+            return value;
+        };
+
+        if (takeU8() != kVersion)
+        {
+            throw std::runtime_error("ReorgUndo: unsupported blob version");
+        }
+        ReorgUndoBlob blob;
+        blob.txCount = static_cast<int64_t>(takeU64());
+        blob.failedCount = static_cast<int64_t>(takeU64());
+        auto rowCount = takeU32();
+        blob.rows.reserve(rowCount);
+        for (uint32_t i = 0; i < rowCount; ++i)
+        {
+            auto keyLen = takeU32();
+            auto keyBytes = take(keyLen);
+            ReorgUndoRow row{executor_v1::StateKey{std::string(keyBytes)}, std::nullopt};
+            if (takeU8() != 0)
+            {
+                auto valueLen = takeU32();
+                auto valueBytes = take(valueLen);
+                storage::Entry entry;
+                entry.set(std::string(valueBytes));
+                row.oldValue.emplace(std::move(entry));
+            }
+            blob.rows.push_back(std::move(row));
+        }
+        return blob;
+    }
+};
+
+}  // namespace bcos::executor_v1::opstack

--- a/opstack-executor/RlpEncodeTuple.h
+++ b/opstack-executor/RlpEncodeTuple.h
@@ -1,0 +1,141 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+// Canonical RLP tuple encoder (promoted from test support 08-19: production consumer is
+// OpDepositEncode.h via the engine's Tier-2 OP build) (bcos::evm::eth::detail::encodeTuple) used
+// by OpDepositEncode.h (0x7e deposit-envelope encoding).
+//
+// Byte-for-byte equivalents of the evmone *test-only* RLP encoder (test/utils/rlp.hpp +
+// test/utils/rlp_encode.hpp), rebuilt on the production bcos-codec encoder. `encodeTuple` mirrors
+// evmone::rlp::encode_tuple. Lives in the opstack test tree because it has no production consumer.
+// (a list header + each element's canonical RLP); the element dispatch (`encodeRlp`) covers
+// exactly the types the consumers need — unsigned scalars, intx::uint256, fixed-width evmc
+// bytes, and the access/authorization lists. Equivalence to evmone is asserted by the
+// 125-vector golden corpus plus the whole-envelope `assertCanonicalRoundTrip` in OpTxDecode.h.
+
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-evm/eth/state/transaction.hpp>
+#include <concepts>
+#include <cstdint>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+#include <utility>
+#include <vector>
+
+namespace bcos::evm::eth::detail
+{
+/// RLP integer scalar for intx::uint256 (bcos-codec has no intx overload): 0 -> 0x80, otherwise
+/// minimal big-endian + length prefix — identical to evmone::rlp::encode(const intx::uint256&).
+inline void encodeRlp(bcos::bytes& to, const intx::uint256& x)
+{
+    if (x == 0)
+    {
+        to.push_back(bcos::codec::rlp::BYTES_HEAD_BASE);
+        return;
+    }
+    uint8_t be[sizeof(intx::uint256)]{};
+    intx::be::store(be, x);
+    size_t first = 0;
+    while (be[first] == 0)
+        ++first;
+    const size_t len = sizeof(intx::uint256) - first;
+    if (len == 1 && be[first] < bcos::codec::rlp::BYTES_HEAD_BASE)
+    {
+        to.push_back(be[first]);
+        return;
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = false, .payloadLength = len});
+    to.insert(to.end(), be + first, be + sizeof(intx::uint256));
+}
+
+/// Unsigned integer scalars (bcos-codec's UnsignedByte path already matches evmone for these).
+/// Promoted to uint64_t first: the uint8_t path would instantiate the byte overload of
+/// bcos::toCompactBigEndian, which is declared inline in the header but defined in a .cpp —
+/// -Werror,-Wundefined-inline fires in any TU that instantiates it. uint64_t is byte-identical
+/// RLP for every scalar the consumers produce (evmone promotes uint8_t to uint64_t the same way).
+inline void encodeRlp(bcos::bytes& to, std::unsigned_integral auto v) noexcept
+{
+    bcos::codec::rlp::encode(to, static_cast<uint64_t>(v));
+}
+
+inline void encodeRlp(bcos::bytes& to, evmc::bytes_view v)
+{
+    bcos::codec::rlp::encode(to, bcos::bytesConstRef(v.data(), v.size()));
+}
+
+inline void encodeRlp(bcos::bytes& to, const evmc::bytes& b)
+{
+    encodeRlp(to, evmc::bytes_view(b.data(), b.size()));
+}
+
+inline void encodeRlp(bcos::bytes& to, const evmc::address& a)
+{
+    encodeRlp(to, evmc::bytes_view(a));
+}
+
+inline void encodeRlp(bcos::bytes& to, const evmc::bytes32& h)
+{
+    encodeRlp(to, evmc::bytes_view(h));
+}
+
+inline void encodeRlp(bcos::bytes& to, const std::vector<evmc::bytes32>& keys)
+{
+    bcos::bytes payload;
+    for (const auto& key : keys)
+        encodeRlp(payload, key);
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = payload.size()});
+    to.insert(to.end(), payload.begin(), payload.end());
+}
+
+/// Access list: rlp([ [address, [storageKey...]], ... ]) — each pair encodes as an RLP list of
+/// (address, keys-list), matching evmone's pair overload.
+inline void encodeRlp(bcos::bytes& to, const evmone::state::AccessList& al)
+{
+    bcos::bytes payload;
+    for (const auto& [addr, keys] : al)
+    {
+        bcos::bytes item;
+        encodeRlp(item, addr);
+        encodeRlp(item, keys);
+        bcos::codec::rlp::encodeHeader(payload, {.isList = true, .payloadLength = item.size()});
+        payload.insert(payload.end(), item.begin(), item.end());
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = payload.size()});
+    to.insert(to.end(), payload.begin(), payload.end());
+}
+
+/// EIP-7702 authorization list: rlp([ [chainId, address, nonce, v, r, s], ... ]) — same field
+/// order as evmone::state::rlp_encode(const Authorization&).
+inline void encodeRlp(bcos::bytes& to, const evmone::state::AuthorizationList& al)
+{
+    bcos::bytes payload;
+    for (const auto& auth : al)
+    {
+        bcos::bytes item;
+        encodeRlp(item, auth.chain_id);
+        encodeRlp(item, auth.addr);
+        encodeRlp(item, auth.nonce);
+        encodeRlp(item, auth.v);
+        encodeRlp(item, auth.r);
+        encodeRlp(item, auth.s);
+        bcos::codec::rlp::encodeHeader(payload, {.isList = true, .payloadLength = item.size()});
+        payload.insert(payload.end(), item.begin(), item.end());
+    }
+    bcos::codec::rlp::encodeHeader(to, {.isList = true, .payloadLength = payload.size()});
+    to.insert(to.end(), payload.begin(), payload.end());
+}
+
+/// evmone::rlp::encode_tuple equivalent: RLP-list-encodes the heterogeneous args. Returns
+/// evmc::bytes so call sites keep `evmc::bytes{0x02} + encodeTuple(...)` concatenation intact.
+template <typename... Args>
+inline evmc::bytes encodeTuple(const Args&... args)
+{
+    bcos::bytes payload;
+    (encodeRlp(payload, args), ...);
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payload.size()});
+    out.insert(out.end(), payload.begin(), payload.end());
+    return evmc::bytes(out.begin(), out.end());
+}
+}  // namespace bcos::evm::eth::detail

--- a/opstack-executor/Storage2State.h
+++ b/opstack-executor/Storage2State.h
@@ -104,6 +104,10 @@ public:
         {
             poison(e.what());
         }
+        catch (const std::logic_error& e)
+        {
+            poison(e.what());
+        }
         catch (const std::exception& e)
         {
             poison(e.what());
@@ -128,6 +132,10 @@ public:
         }
         // Exception-matching ladder; see get_account's comment.
         catch (const std::runtime_error& e)
+        {
+            poison(e.what());
+        }
+        catch (const std::logic_error& e)
         {
             poison(e.what());
         }
@@ -157,6 +165,10 @@ public:
         }
         // Exception-matching ladder; see get_account's comment.
         catch (const std::runtime_error& e)
+        {
+            poison(e.what());
+        }
+        catch (const std::logic_error& e)
         {
             poison(e.what());
         }
@@ -256,6 +268,11 @@ public:
             poison(e.what());
             throw;
         }
+        catch (const std::logic_error& e)
+        {
+            poison(e.what());
+            throw;
+        }
         catch (const std::exception& e)
         {
             poison(e.what());
@@ -307,6 +324,10 @@ public:
         // four read methods: visitAccounts is on the mandatory stateRootOf path — its poison
         // message is the only clue for triaging a -32603.
         catch (const std::runtime_error& e)
+        {
+            poison(e.what());
+        }
+        catch (const std::logic_error& e)
         {
             poison(e.what());
         }

--- a/opstack-executor/Storage2StateHelpers.h
+++ b/opstack-executor/Storage2StateHelpers.h
@@ -104,7 +104,6 @@ inline std::optional<evmc::address> addressFromTableName(std::string_view tableK
 /// the OP execution world.
 inline std::string accountTableName(const evmc::address& addr)
 {
-    // bytesConstRef 构造默认 AlignRight——20 字节地址恰为 20 字节，对齐不影响结果。
     return bcos::ledger::mpt::accountTableName(
         bcos::Address{bcos::bytesConstRef{addr.bytes, sizeof(addr.bytes)}});
 }


### PR DESCRIPTION
## Summary
- Independent extract from #5481: `OpstackExecutor`, `OpBlockExecute`, storage adapters, and small `bcos-evm/opstack` deltas.
- `OpScheduler.h` is intentionally omitted: that single new header is ~1174 valid insertions and cannot pass the 1024 limit on its own. Leave it on #5468 / a later split.
- Engine service wiring is a separate PR.

## Test plan
- [ ] Diff has no `OpScheduler.h`, no EngineService, no t8n/e2e.
- [ ] CI insert-limit should pass for this slice.
- [ ] Node compile is not expected to be green until `OpScheduler.h` and the engine wiring PR land.


Made with [Cursor](https://cursor.com)