### PR TITLE
Coroutine-based zero-copy P2P send path

### DIFF
--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -135,6 +135,29 @@ public:
         uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) = 0;
 
     /**
+     * @brief: (coroutine, zero-copy) send message to one node. The payload is passed as views that
+     *         the caller must keep alive for the duration of the co_await. The module-level
+     *         response (matched by the generated uuid) still arrives through the receive path and
+     *         is delivered to _callback; _callback is also invoked with an error if the
+     *         gateway-level send fails.
+     *
+     * Default implementation: joins the payload views into a buffer and bridges to the borrowed
+     * asyncSendMessageByNodeID (correct for the tars client and test fakes).
+     */
+    virtual task::Task<void> sendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+        ::ranges::any_view<bytesConstRef> _payloads, uint32_t _timeout, CallbackFunc _callback)
+    {
+        bcos::bytes buffer;
+        for (auto const& data : _payloads)
+        {
+            buffer.insert(buffer.end(), data.begin(), data.end());
+        }
+        asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), bcos::ref(buffer), _timeout,
+            std::move(_callback));
+        co_return;
+    }
+
+    /**
      * @brief broadcast an already-encoded message, taking ownership of the payload so the send can
      *        be deferred without copying the message body.
      *

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -141,19 +141,38 @@ public:
      *         is delivered to _callback; _callback is also invoked with an error if the
      *         gateway-level send fails.
      *
-     * Default implementation: joins the payload views into a buffer and bridges to the borrowed
-     * asyncSendMessageByNodeID (correct for the tars client and test fakes).
+     * The payloads must be at least forward ranges: the default bridge joins them into one buffer
+     * (single pass), but overrides may iterate them multiple times (e.g. a retry loop).
+     *
+     * Default implementation: joins the payload views into a buffer owned by the completion
+     * callback (NOT this coroutine frame) and bridges to the borrowed asyncSendMessageByNodeID —
+     * the TARS/MAX front client may keep reading the payload after the callback returns (e.g. a
+     * synchronous connection-check error followed by an async send setup), so the buffer must
+     * outlive the frame. This mirrors the GatewayInterface default bridge, which the gateway-side
+     * review rounds established against the same TARS client contract.
      */
     virtual task::Task<void> sendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        ::ranges::any_view<bytesConstRef> _payloads, uint32_t _timeout, CallbackFunc _callback)
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads, uint32_t _timeout,
+        CallbackFunc _callback)
     {
-        bcos::bytes buffer;
+        auto buffer = std::make_shared<bcos::bytes>();
         for (auto const& data : _payloads)
         {
-            buffer.insert(buffer.end(), data.begin(), data.end());
+            buffer->insert(buffer->end(), data.begin(), data.end());
         }
-        asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), bcos::ref(buffer), _timeout,
-            std::move(_callback));
+        auto payload = bcos::ref(*buffer);
+        asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), payload, _timeout,
+            [buffer = std::move(buffer), callback = std::move(_callback)](bcos::Error::Ptr _error,
+                bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data, const std::string& _id,
+                ResponseFunc _resp) mutable {
+                // keep the payload buffer alive until after the callback returns: the borrowed
+                // caller may still be reading it on this stack
+                (void)buffer;
+                if (callback)
+                {
+                    callback(std::move(_error), std::move(_nodeID), _data, _id, std::move(_resp));
+                }
+            });
         co_return;
     }
 

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -25,6 +25,9 @@
 #include "bcos-task/Wait.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/Error.h"
+#include <atomic>
+#include <coroutine>
+#include <functional>
 #include <range/v3/view/any_view.hpp>
 #include <range/v3/view/single.hpp>
 
@@ -35,6 +38,82 @@ using ReceiveMsgFunc = std::function<void(Error::Ptr)>;
 using ResponseFunc = std::function<void(bytesConstRef)>;
 using CallbackFunc = std::function<void(
     Error::Ptr, bcos::crypto::NodeIDPtr, bytesConstRef, const std::string&, ResponseFunc)>;
+
+/**
+ * @brief: the result of a module-level point-to-point send: the peer's response, or a gateway send
+ *         failure / timeout (error non-null). payload is an owned copy so it outlives the front
+ *         receive-path buffer it was decoded from; respond (optional) lets the caller send a
+ *         follow-up response to the peer over the same request uuid.
+ */
+struct SendResult
+{
+    bcos::Error::Ptr error;                     // non-null on gateway send failure or timeout
+    bcos::crypto::NodeIDPtr nodeID;             // the node that sent the response
+    bcos::bytes payload;                        // owned copy of the response body
+    std::string uuid;                           // request uuid (echoed by the peer response)
+    std::function<void(bytesConstRef)> respond; // optional follow-up response to the peer
+};
+
+/**
+ * @brief: internal awaitable that bridges a module-level response callback (fired on response /
+ *         timeout / gateway failure, on the front's io-thread pool) to a co_await. Race-safe:
+ *         whichever of the callback and the suspension wins, the coroutine is resumed exactly once
+ *         and the result is delivered exactly once.
+ */
+class SendResponseAwaitable
+{
+public:
+    struct State
+    {
+        std::atomic<bool> done{false};
+        std::coroutine_handle<> handle{nullptr};
+        SendResult result;
+        Mutex mutex;
+    };
+    using StatePtr = std::shared_ptr<State>;
+
+    explicit SendResponseAwaitable(StatePtr state) : m_state(std::move(state)) {}
+
+    bool await_ready() const noexcept { return m_state->done.load(std::memory_order_acquire); }
+
+    void await_suspend(std::coroutine_handle<> handle)
+    {
+        std::lock_guard lock(m_state->mutex);
+        if (m_state->done.load(std::memory_order_acquire))
+        {
+            // the callback already completed before we suspended: resume immediately
+            handle.resume();
+            return;
+        }
+        m_state->handle = handle;
+    }
+
+    SendResult await_resume() { return std::move(m_state->result); }
+
+    // Called by the response/timeout/gateway-failure callback (on its own thread). Completes the
+    // wait exactly once; if the coroutine has not suspended yet, await_suspend observes done and
+    // resumes itself.
+    static void complete(const StatePtr& state, SendResult result)
+    {
+        std::coroutine_handle<> handle;
+        {
+            std::lock_guard lock(state->mutex);
+            if (state->done.exchange(true, std::memory_order_acq_rel))
+            {
+                return;
+            }
+            state->result = std::move(result);
+            handle = state->handle;
+        }
+        if (handle)
+        {
+            handle.resume();
+        }
+    }
+
+private:
+    StatePtr m_state;
+};
 
 /**
  * @brief: the interface provided by the front service
@@ -135,11 +214,15 @@ public:
         uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) = 0;
 
     /**
-     * @brief: (coroutine, zero-copy) send message to one node. The payload is passed as views that
-     *         the caller must keep alive for the duration of the co_await. The module-level
-     *         response (matched by the generated uuid) still arrives through the receive path and
-     *         is delivered to _callback; _callback is also invoked with an error if the
-     *         gateway-level send fails.
+     * @brief: (coroutine, zero-copy) send message to one node and await the module-level response.
+     *         The payload is passed as views that the caller must keep alive for the duration of
+     *         the co_await. co_await resumes when the peer's response arrives, the timeout
+     *         (_timeout > 0) expires, or the gateway-level send fails — the result carries the
+     *         response (error non-null on timeout / gateway failure). With _timeout == 0 the send
+     *         is fire-and-forget: no response is expected and the coroutine returns as soon as the
+     *         gateway send completes. Callers that want the pure async form can wrap the co_await
+     *         in task::wait, passing any captured state as coroutine parameters (the recommended
+     *         pattern across the send path).
      *
      * The payloads must be at least forward ranges: the default bridge joins them into one buffer
      * (single pass), but overrides may iterate them multiple times (e.g. a retry loop).
@@ -151,29 +234,49 @@ public:
      * outlive the frame. This mirrors the GatewayInterface default bridge, which the gateway-side
      * review rounds established against the same TARS client contract.
      */
-    virtual task::Task<void> sendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads, uint32_t _timeout,
-        CallbackFunc _callback)
+    virtual task::Task<SendResult> sendMessageByNodeID(int _moduleID,
+        bcos::crypto::NodeIDPtr _nodeID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
+        uint32_t _timeout)
     {
+        // The payload views are joined into a buffer owned by a shared_ptr captured by the
+        // completion callback, NOT this coroutine frame: the borrowed TARS/MAX front client may
+        // keep reading the payload after the callback returns.
         auto buffer = std::make_shared<bcos::bytes>();
         for (auto const& data : _payloads)
         {
             buffer->insert(buffer->end(), data.begin(), data.end());
         }
         auto payload = bcos::ref(*buffer);
+
+        if (_timeout == 0)
+        {
+            // fire-and-forget: no module-level response is expected. Keep the buffer owned by an
+            // empty completion callback until the borrowed client is done with it, and return
+            // once the send is dispatched.
+            asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), payload, 0,
+                [buffer = std::move(buffer)](bcos::Error::Ptr, bcos::crypto::NodeIDPtr,
+                    bytesConstRef, const std::string&, ResponseFunc) mutable { (void)buffer; });
+            co_return SendResult{};
+        }
+
+        auto state = std::make_shared<SendResponseAwaitable::State>();
         asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), payload, _timeout,
-            [buffer = std::move(buffer), callback = std::move(_callback)](bcos::Error::Ptr _error,
+            [state, buffer = std::move(buffer)](bcos::Error::Ptr _error,
                 bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data, const std::string& _id,
                 ResponseFunc _resp) mutable {
                 // keep the payload buffer alive until after the callback returns: the borrowed
                 // caller may still be reading it on this stack
                 (void)buffer;
-                if (callback)
-                {
-                    callback(std::move(_error), std::move(_nodeID), _data, _id, std::move(_resp));
-                }
+                SendResult result;
+                result.error = std::move(_error);
+                result.nodeID = std::move(_nodeID);
+                result.payload.assign(_data.begin(), _data.end());
+                result.uuid = _id;
+                result.respond = std::move(_resp);
+                SendResponseAwaitable::complete(state, std::move(result));
             });
-        co_return;
+        co_return co_await SendResponseAwaitable{std::move(state)};
     }
 
     /**

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -59,6 +59,11 @@ struct SendResult
  *         timeout / gateway failure, on the front's io-thread pool) to a co_await. Race-safe:
  *         whichever of the callback and the suspension wins, the coroutine is resumed exactly once
  *         and the result is delivered exactly once.
+ *
+ * Publication order: complete() writes State::result BEFORE publishing State::done (release),
+ * and await_ready()/await_suspend() read done with acquire — so a reader that observes done ==
+ * true is guaranteed to see the fully-written result. The idempotency guard stays under the mutex;
+ * the lock itself only serializes complete() vs await_suspend().
  */
 class SendResponseAwaitable
 {
@@ -74,6 +79,8 @@ public:
 
     explicit SendResponseAwaitable(StatePtr state) : m_state(std::move(state)) {}
 
+    // Lock-free fast path: pairs with complete()'s release store — observing done == true implies
+    // result is fully written, so await_resume() may move it without the lock.
     bool await_ready() const noexcept { return m_state->done.load(std::memory_order_acquire); }
 
     void await_suspend(std::coroutine_handle<> handle)
@@ -99,17 +106,19 @@ public:
 
     // Called by the response/timeout/gateway-failure callback (on its own thread). Completes the
     // wait exactly once; if the coroutine has not suspended yet, await_suspend observes done and
-    // resumes itself.
+    // resumes itself. result is written BEFORE done is published (release) so the lock-free
+    // await_ready() fast path never races with this write.
     static void complete(const StatePtr& state, SendResult result)
     {
         std::coroutine_handle<> handle;
         {
             std::lock_guard lock(state->mutex);
-            if (state->done.exchange(true, std::memory_order_acq_rel))
+            if (state->done.load(std::memory_order_relaxed))
             {
                 return;
             }
             state->result = std::move(result);
+            state->done.store(true, std::memory_order_release);
             handle = state->handle;
         }
         if (handle)

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -78,14 +78,21 @@ public:
 
     void await_suspend(std::coroutine_handle<> handle)
     {
-        std::lock_guard lock(m_state->mutex);
-        if (m_state->done.load(std::memory_order_acquire))
+        // Take a local reference to the state before touching it: the coroutine chain resumed
+        // below may destroy the last State reference (this awaitable's m_state), so the mutex must
+        // stay alive until after the unlock. This mirrors complete()'s "take handle under the
+        // lock, resume outside it" shape.
+        auto state = m_state;
         {
-            // the callback already completed before we suspended: resume immediately
-            handle.resume();
-            return;
+            std::lock_guard lock(state->mutex);
+            if (!state->done.load(std::memory_order_acquire))
+            {
+                state->handle = handle;
+                return;
+            }
         }
-        m_state->handle = handle;
+        // the callback already completed before we suspended: resume outside the lock
+        handle.resume();
     }
 
     SendResult await_resume() { return std::move(m_state->result); }
@@ -211,7 +218,8 @@ public:
         const std::vector<bcos::crypto::NodeIDPtr>& _nodeIDs, bytesConstRef _data) = 0;
 
     virtual task::Task<void> broadcastMessage(
-        uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) = 0;
+        uint16_t type, int moduleID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) = 0;
 
     /**
      * @brief: (coroutine, zero-copy) send message to one node and await the module-level response.
@@ -227,21 +235,24 @@ public:
      * The payloads must be at least forward ranges: the default bridge joins them into one buffer
      * (single pass), but overrides may iterate them multiple times (e.g. a retry loop).
      *
-     * Default implementation: joins the payload views into a buffer owned by the completion
-     * callback (NOT this coroutine frame) and bridges to the borrowed asyncSendMessageByNodeID —
-     * the TARS/MAX front client may keep reading the payload after the callback returns (e.g. a
-     * synchronous connection-check error followed by an async send setup), so the buffer must
-     * outlive the frame. This mirrors the GatewayInterface default bridge, which the gateway-side
-     * review rounds established against the same TARS client contract.
+     * Default implementation: joins the payload views into one contiguous buffer and bridges to
+     * the borrowed asyncSendMessageByNodeID. The front client (FrontServiceClient) copies the
+     * payload synchronously in the call arguments, so the buffer only needs to stay alive until
+     * asyncSendMessageByNodeID returns; with _timeout == 0 the bridge passes a null callback so
+     * the client forwards requireRespCallback = false (no response entry is registered on the
+     * peer). The _timeout > 0 bridge captures the buffer in the completion callback, which runs
+     * on another thread and must copy the borrowed payload view into the SendResult before the
+     * frame is gone.
      */
     virtual task::Task<SendResult> sendMessageByNodeID(int _moduleID,
         bcos::crypto::NodeIDPtr _nodeID,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
         uint32_t _timeout)
     {
-        // The payload views are joined into a buffer owned by a shared_ptr captured by the
-        // completion callback, NOT this coroutine frame: the borrowed TARS/MAX front client may
-        // keep reading the payload after the callback returns.
+        // The payload views are joined into one contiguous buffer. For the response-waiting
+        // (_timeout > 0) path the buffer is captured by the completion callback so it stays alive
+        // while the callback (possibly on another thread) copies the borrowed payload view into
+        // the SendResult.
         auto buffer = std::make_shared<bcos::bytes>();
         for (auto const& data : _payloads)
         {
@@ -251,12 +262,13 @@ public:
 
         if (_timeout == 0)
         {
-            // fire-and-forget: no module-level response is expected. Keep the buffer owned by an
-            // empty completion callback until the borrowed client is done with it, and return
-            // once the send is dispatched.
-            asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), payload, 0,
-                [buffer = std::move(buffer)](bcos::Error::Ptr, bcos::crypto::NodeIDPtr,
-                    bytesConstRef, const std::string&, ResponseFunc) mutable { (void)buffer; });
+            // fire-and-forget: no module-level response is expected. Pass a null callback so the
+            // borrowed client forwards requireRespCallback = false (the peer registers no response
+            // entry and the tars request completes normally instead of hanging until
+            // c_frontServiceTimeout). The front client copies the payload synchronously in the
+            // call arguments, so the frame-local buffer only needs to stay alive until
+            // asyncSendMessageByNodeID returns.
+            asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), payload, 0, nullptr);
             co_return SendResult{};
         }
 

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -147,7 +147,10 @@ public:
             };
 
             GatewayInterface* m_self;
-            std::string m_groupID;
+            // owned by the completion callback so it outlives this frame: asyncSendMessageByNodeID
+            // takes the groupID by const-ref, and a synchronous completion (TARS connection check)
+            // resumes (and destroys) the frame while the borrowed client is still using it
+            std::shared_ptr<std::string> m_groupID;
             int m_moduleID;
             bcos::crypto::NodeIDPtr m_srcNodeID;
             bcos::crypto::NodeIDPtr m_dstNodeID;
@@ -161,18 +164,21 @@ public:
                 m_state->handle = _handle;
                 auto state = m_state;
                 auto buffer = m_buffer;
+                auto groupID = m_groupID;
                 auto respFunc = std::move(m_respFunc);
-                m_self->asyncSendMessageByNodeID(m_groupID, m_moduleID, m_srcNodeID, m_dstNodeID,
+                m_self->asyncSendMessageByNodeID(*groupID, m_moduleID, m_srcNodeID, m_dstNodeID,
                     bcos::ref(*buffer),
                     [state = std::move(state), buffer = std::move(buffer),
+                        groupID = std::move(groupID),
                         respFunc = std::move(respFunc)](bcos::Error::Ptr _error) mutable {
                         if (respFunc)
                         {
                             respFunc(std::move(_error));
                         }
-                        // keep the payload buffer alive until after the resume: the borrowed caller
-                        // may still be reading it on this stack
+                        // keep the payload buffer and groupID alive until after the resume: the
+                        // borrowed caller may still be reading them on this stack
                         (void)buffer;
+                        (void)groupID;
                         if (!state->completed.exchange(true))
                         {
                             state->handle.resume();
@@ -181,9 +187,9 @@ public:
             }
             void await_resume() {}
         };
-        SendAwaitable awaitable{this, std::string(_groupID), _moduleID, std::move(_srcNodeID),
-            std::move(_dstNodeID), std::move(_errorRespFunc), std::move(buffer),
-            std::make_shared<SendAwaitable::CompletionState>()};
+        SendAwaitable awaitable{this, std::make_shared<std::string>(_groupID), _moduleID,
+            std::move(_srcNodeID), std::move(_dstNodeID), std::move(_errorRespFunc),
+            std::move(buffer), std::make_shared<SendAwaitable::CompletionState>()};
         co_await awaitable;
         co_return;
     }

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -166,8 +166,16 @@ public:
                 auto buffer = m_buffer;
                 auto groupID = m_groupID;
                 auto respFunc = std::move(m_respFunc);
-                m_self->asyncSendMessageByNodeID(*groupID, m_moduleID, m_srcNodeID, m_dstNodeID,
-                    bcos::ref(*buffer),
+                // Materialize what the call arguments need (groupID / payload) BEFORE the lambda
+                // argument below: the lambda's init-captures move buffer/groupID/state, and C++17
+                // leaves the evaluation order of function arguments unspecified — if the lambda ran
+                // first, *groupID / bcos::ref(*buffer) would dereference the moved-from (null)
+                // shared_ptrs. The string stays alive because the lambda's captured shared_ptr
+                // keeps it alive.
+                std::string const& groupIDRef = *groupID;
+                auto payload = bcos::ref(*buffer);
+                m_self->asyncSendMessageByNodeID(groupIDRef, m_moduleID, m_srcNodeID, m_dstNodeID,
+                    payload,
                     [state = std::move(state), buffer = std::move(buffer),
                         groupID = std::move(groupID),
                         respFunc = std::move(respFunc)](bcos::Error::Ptr _error) mutable {

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -179,16 +179,21 @@ public:
                     [state = std::move(state), buffer = std::move(buffer),
                         groupID = std::move(groupID),
                         respFunc = std::move(respFunc)](bcos::Error::Ptr _error) mutable {
-                        if (respFunc)
-                        {
-                            respFunc(std::move(_error));
-                        }
-                        // keep the payload buffer and groupID alive until after the resume: the
-                        // borrowed caller may still be reading them on this stack
-                        (void)buffer;
-                        (void)groupID;
+                        // The completion guard protects BOTH the resume and the respFunc: the
+                        // documented contract above says the borrowed TARS client may invoke this
+                        // callback twice (synchronous connection check + async completion) — only
+                        // the first completion may deliver the result, otherwise the caller is
+                        // called back twice.
                         if (!state->completed.exchange(true))
                         {
+                            if (respFunc)
+                            {
+                                respFunc(std::move(_error));
+                            }
+                            // keep the payload buffer and groupID alive until after the resume: the
+                            // borrowed caller may still be reading them on this stack
+                            (void)buffer;
+                            (void)groupID;
                             state->handle.resume();
                         }
                     });

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -100,6 +100,62 @@ public:
     virtual task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID, ::ranges::any_view<bytesConstRef> payloads) = 0;
 
+    /**
+     * @brief: (coroutine) send message to a single node, zero-copy. The payload is passed as views
+     *         that the caller must keep alive for the duration of the co_await. The coroutine
+     *         completes once the peer gateway acknowledges the message (or the retries are
+     *         exhausted / a terminal error occurred), at which point _errorRespFunc has already
+     *         been invoked (nullptr on success).
+     *
+     * Default implementation: joins the payload views into a buffer and bridges to the borrowed
+     * asyncSendMessageByNodeID. This is correct for the tars client and test fakes (which cross a
+     * process boundary or are synchronous anyway); the production Gateway overrides it with a
+     * zero-copy coroutine implementation.
+     *
+     * @param _groupID: groupID
+     * @param _moduleID: moduleID
+     * @param _srcNodeID: the sender nodeID
+     * @param _dstNodeID: the receiver nodeID
+     * @param _payloads: message content (views, kept alive by the caller)
+     * @param _errorRespFunc: error func
+     */
+    virtual task::Task<void> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
+        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
+        ::ranges::any_view<bytesConstRef> _payloads, ErrorRespFunc _errorRespFunc)
+    {
+        bcos::bytes buffer;
+        for (auto const& data : _payloads)
+        {
+            buffer.insert(buffer.end(), data.begin(), data.end());
+        }
+        struct SendAwaitable
+        {
+            GatewayInterface* m_self;
+            std::string m_groupID;
+            int m_moduleID;
+            bcos::crypto::NodeIDPtr m_srcNodeID;
+            bcos::crypto::NodeIDPtr m_dstNodeID;
+            bcos::bytes m_buffer;
+            ErrorRespFunc m_respFunc;
+
+            constexpr static bool await_ready() noexcept { return false; }
+            void await_suspend(std::coroutine_handle<> _handle)
+            {
+                m_self->asyncSendMessageByNodeID(m_groupID, m_moduleID, m_srcNodeID, m_dstNodeID,
+                    bcos::ref(m_buffer),
+                    [_handle, respFunc = std::move(m_respFunc)](bcos::Error::Ptr _error) mutable {
+                        respFunc(std::move(_error));
+                        _handle.resume();
+                    });
+            }
+            void await_resume() {}
+        };
+        SendAwaitable awaitable{this, std::string(_groupID), _moduleID, std::move(_srcNodeID),
+            std::move(_dstNodeID), std::move(buffer), std::move(_errorRespFunc)};
+        co_await awaitable;
+        co_return;
+    }
+
     /// multi-group related interfaces
 
     /**

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -124,7 +124,8 @@ public:
      */
     virtual task::Task<void> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        ::ranges::any_view<bytesConstRef> _payloads, ErrorRespFunc _errorRespFunc)
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
+        ErrorRespFunc _errorRespFunc)
     {
         // Both the payload buffer and the completion state are owned by shared_ptrs captured by the
         // completion callback, NOT by this coroutine frame: the borrowed TARS client may keep

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -122,10 +122,9 @@ public:
      * @param _payloads: message content (views, kept alive by the caller)
      * @param _errorRespFunc: error func
      */
-    virtual task::Task<void> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
+    virtual task::Task<Error::Ptr> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
-        ErrorRespFunc _errorRespFunc)
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads)
     {
         // Both the payload buffer and the completion state are owned by shared_ptrs captured by the
         // completion callback, NOT by this coroutine frame: the borrowed TARS client may keep
@@ -145,6 +144,7 @@ public:
             {
                 std::atomic<bool> completed{false};
                 std::coroutine_handle<> handle;
+                Error::Ptr error;
             };
 
             GatewayInterface* m_self;
@@ -155,7 +155,6 @@ public:
             int m_moduleID;
             bcos::crypto::NodeIDPtr m_srcNodeID;
             bcos::crypto::NodeIDPtr m_dstNodeID;
-            ErrorRespFunc m_respFunc;
             std::shared_ptr<bcos::bytes> m_buffer;
             std::shared_ptr<CompletionState> m_state;
 
@@ -166,7 +165,6 @@ public:
                 auto state = m_state;
                 auto buffer = m_buffer;
                 auto groupID = m_groupID;
-                auto respFunc = std::move(m_respFunc);
                 // Materialize what the call arguments need (groupID / payload) BEFORE the lambda
                 // argument below: the lambda's init-captures move buffer/groupID/state, and C++17
                 // leaves the evaluation order of function arguments unspecified — if the lambda ran
@@ -178,19 +176,15 @@ public:
                 m_self->asyncSendMessageByNodeID(groupIDRef, m_moduleID, m_srcNodeID, m_dstNodeID,
                     payload,
                     [state = std::move(state), buffer = std::move(buffer),
-                        groupID = std::move(groupID),
-                        respFunc = std::move(respFunc)](bcos::Error::Ptr _error) mutable {
-                        // The completion guard protects BOTH the resume and the respFunc: the
-                        // documented contract above says the borrowed TARS client may invoke this
-                        // callback twice (synchronous connection check + async completion) — only
-                        // the first completion may deliver the result, otherwise the caller is
-                        // called back twice.
+                        groupID = std::move(groupID)](bcos::Error::Ptr _error) mutable {
+                        // The completion guard protects both the resume and the result delivery:
+                        // the documented contract above says the borrowed TARS client may invoke
+                        // this callback twice (synchronous connection check + async completion) —
+                        // only the first completion may deliver the result, otherwise the caller
+                        // is called back twice.
                         if (!state->completed.exchange(true))
                         {
-                            if (respFunc)
-                            {
-                                respFunc(std::move(_error));
-                            }
+                            state->error = std::move(_error);
                             // keep the payload buffer and groupID alive until after the resume: the
                             // borrowed caller may still be reading them on this stack
                             (void)buffer;
@@ -199,13 +193,12 @@ public:
                         }
                     });
             }
-            void await_resume() {}
+            Error::Ptr await_resume() { return std::move(m_state->error); }
         };
         SendAwaitable awaitable{this, std::make_shared<std::string>(_groupID), _moduleID,
-            std::move(_srcNodeID), std::move(_dstNodeID), std::move(_errorRespFunc),
-            std::move(buffer), std::make_shared<SendAwaitable::CompletionState>()};
-        co_await awaitable;
-        co_return;
+            std::move(_srcNodeID), std::move(_dstNodeID), std::move(buffer),
+            std::make_shared<SendAwaitable::CompletionState>()};
+        co_return co_await awaitable;
     }
 
     /// multi-group related interfaces

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -101,26 +101,28 @@ public:
         bytesConstRef _payload) = 0;
 
     virtual task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
-        const bcos::crypto::NodeID& srcNodeID, ::ranges::any_view<bytesConstRef> payloads) = 0;
+        const bcos::crypto::NodeID& srcNodeID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) = 0;
 
     /**
      * @brief: (coroutine) send message to a single node, zero-copy. The payload is passed as views
      *         that the caller must keep alive for the duration of the co_await. The coroutine
      *         completes once the peer gateway acknowledges the message (or the retries are
-     *         exhausted / a terminal error occurred), at which point _errorRespFunc has already
-     *         been invoked (nullptr on success).
+     *         exhausted / a terminal error occurred); it returns nullptr on success or an
+     *         Error::Ptr describing the failure.
      *
      * Default implementation: joins the payload views into a buffer and bridges to the borrowed
-     * asyncSendMessageByNodeID. This is correct for the tars client and test fakes (which cross a
-     * process boundary or are synchronous anyway); the production Gateway overrides it with a
-     * zero-copy coroutine implementation.
+     * asyncSendMessageByNodeID. The completion state and the payload buffer are owned by the
+     * completion callback (see the implementation below): the borrowed TARS client may keep
+     * reading the payload after the callback returns, and it may even invoke the callback twice —
+     * the implementation guards the resume/result delivery accordingly. The production Gateway
+     * overrides it with a zero-copy coroutine implementation.
      *
      * @param _groupID: groupID
      * @param _moduleID: moduleID
      * @param _srcNodeID: the sender nodeID
      * @param _dstNodeID: the receiver nodeID
      * @param _payloads: message content (views, kept alive by the caller)
-     * @param _errorRespFunc: error func
      */
     virtual task::Task<Error::Ptr> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -28,6 +28,9 @@
 #include <bcos-crypto/interfaces/crypto/KeyInterface.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Error.h>
+#include <atomic>
+#include <coroutine>
+#include <memory>
 #include <range/v3/view/any_view.hpp>
 
 namespace bcos
@@ -123,35 +126,64 @@ public:
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
         ::ranges::any_view<bytesConstRef> _payloads, ErrorRespFunc _errorRespFunc)
     {
-        bcos::bytes buffer;
+        // Both the payload buffer and the completion state are owned by shared_ptrs captured by the
+        // completion callback, NOT by this coroutine frame: the borrowed TARS client may keep
+        // reading the payload after the callback returns (e.g. a synchronous connection-check error
+        // followed by an async send setup), and it may even invoke the callback twice (synchronously
+        // for the connection check AND later for the async completion). The shared state survives
+        // the frame so the second completion is detected instead of double-resuming a destroyed
+        // coroutine.
+        auto buffer = std::make_shared<bcos::bytes>();
         for (auto const& data : _payloads)
         {
-            buffer.insert(buffer.end(), data.begin(), data.end());
+            buffer->insert(buffer->end(), data.begin(), data.end());
         }
         struct SendAwaitable
         {
+            struct CompletionState
+            {
+                std::atomic<bool> completed{false};
+                std::coroutine_handle<> handle;
+            };
+
             GatewayInterface* m_self;
             std::string m_groupID;
             int m_moduleID;
             bcos::crypto::NodeIDPtr m_srcNodeID;
             bcos::crypto::NodeIDPtr m_dstNodeID;
-            bcos::bytes m_buffer;
             ErrorRespFunc m_respFunc;
+            std::shared_ptr<bcos::bytes> m_buffer;
+            std::shared_ptr<CompletionState> m_state;
 
             constexpr static bool await_ready() noexcept { return false; }
             void await_suspend(std::coroutine_handle<> _handle)
             {
+                m_state->handle = _handle;
+                auto state = m_state;
+                auto buffer = m_buffer;
+                auto respFunc = std::move(m_respFunc);
                 m_self->asyncSendMessageByNodeID(m_groupID, m_moduleID, m_srcNodeID, m_dstNodeID,
-                    bcos::ref(m_buffer),
-                    [_handle, respFunc = std::move(m_respFunc)](bcos::Error::Ptr _error) mutable {
-                        respFunc(std::move(_error));
-                        _handle.resume();
+                    bcos::ref(*buffer),
+                    [state = std::move(state), buffer = std::move(buffer),
+                        respFunc = std::move(respFunc)](bcos::Error::Ptr _error) mutable {
+                        if (respFunc)
+                        {
+                            respFunc(std::move(_error));
+                        }
+                        // keep the payload buffer alive until after the resume: the borrowed caller
+                        // may still be reading it on this stack
+                        (void)buffer;
+                        if (!state->completed.exchange(true))
+                        {
+                            state->handle.resume();
+                        }
                     });
             }
             void await_resume() {}
         };
         SendAwaitable awaitable{this, std::string(_groupID), _moduleID, std::move(_srcNodeID),
-            std::move(_dstNodeID), std::move(buffer), std::move(_errorRespFunc)};
+            std::move(_dstNodeID), std::move(_errorRespFunc), std::move(buffer),
+            std::make_shared<SendAwaitable::CompletionState>()};
         co_await awaitable;
         co_return;
     }

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -131,8 +131,9 @@ public:
         // Both the payload buffer and the completion state are owned by shared_ptrs captured by the
         // completion callback, NOT by this coroutine frame: the borrowed TARS client may keep
         // reading the payload after the callback returns (e.g. a synchronous connection-check error
-        // followed by an async send setup), and it may even invoke the callback twice (synchronously
-        // for the connection check AND later for the async completion). The shared state survives
+        // followed by an async send setup), and it may even invoke the callback twice
+        // (synchronously for the connection check AND later for the async completion). The
+        // shared state survives
         // the frame so the second completion is detected instead of double-resuming a destroyed
         // coroutine.
         auto buffer = std::make_shared<bcos::bytes>();

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -266,7 +266,8 @@ public:
         bytesConstRef _payload) override
     {}
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
-        const bcos::crypto::NodeID& srcNodeID, ::ranges::any_view<bytesConstRef> payloads) override
+        const bcos::crypto::NodeID& srcNodeID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override
     {
         co_return;
     };
@@ -326,7 +327,8 @@ public:
     }
 
     bcos::task::Task<void> broadcastMessage(
-        uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) override
+        uint16_t type, int moduleID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override
     {
         for (const auto& node : m_nodeIDList)
         {

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -520,11 +520,86 @@ void FrontService::asyncSendMessageByNodeIDByOwnedPayload(
 {
     // FIB-185: enqueue the point-to-point send onto the serial queue and return immediately, so the
     // caller (PBFT under m_mutex, via sendViewChange / sendRecoverResponse) never runs the
-    // gateway-session-lock-acquiring send on its own thread. The owned payload is captured to keep
-    // it alive for the (synchronous) wire-frame encode inside asyncSendMessageByNodeID.
+    // gateway-session-lock-acquiring send on its own thread. The owned payload is captured by the
+    // launched coroutine -> the message body is sent as a view (zero-copy).
     enqueueSend([this, moduleID, nodeID = std::move(nodeID), payload = std::move(payload)]() {
-        asyncSendMessageByNodeID(moduleID, nodeID, bcos::ref(*payload), 0, nullptr);
+        auto self = shared_from_this();
+        task::wait(
+            [](FrontService::Ptr _self, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+                bytesPointer _payload) -> task::Task<void> {
+                co_await _self->sendMessageByNodeID(_moduleID, _nodeID,
+                    ::ranges::views::single(bcos::ref(*_payload)), 0, nullptr);
+            }(self, moduleID, nodeID, payload));
     });
+}
+
+bcos::task::Task<void> FrontService::sendMessageByNodeID(int _moduleID,
+    bcos::crypto::NodeIDPtr _nodeID, ::ranges::any_view<bytesConstRef> _payloads,
+    uint32_t _timeout, CallbackFunc _callback)
+{
+    // keep the service alive for the whole (possibly deferred) send
+    auto self = shared_from_this();
+
+    static thread_local auto uuid_gen =
+        boost::uuids::basic_random_generator<std::random_device>();
+    std::string uuid = boost::uuids::to_string(uuid_gen());
+    if (_callback)
+    {
+        auto callback = std::make_shared<Callback>();
+        callback->callbackFunc = _callback;
+
+        if (_timeout > 0)
+        {
+            // create new timer to handle timeout
+            auto timeoutHandler = std::make_shared<boost::asio::steady_timer>(
+                *m_ioService, std::chrono::milliseconds(_timeout));
+
+            callback->timeoutHandler = timeoutHandler;
+            auto frontServiceWeakPtr = std::weak_ptr<FrontService>(shared_from_this());
+            // callback->startTime = utcSteadyTime();
+            timeoutHandler->async_wait([frontServiceWeakPtr, _nodeID, uuid](
+                                           const boost::system::error_code& e) {
+                auto frontService = frontServiceWeakPtr.lock();
+                if (frontService)
+                {
+                    frontService->onMessageTimeout(e, _nodeID, uuid);
+                }
+            });
+        }
+
+        addCallback(uuid, callback);
+
+        FRONT_LOG(DEBUG) << LOG_DESC("sendMessageByNodeID") << LOG_KV("groupID", m_groupID)
+                         << LOG_KV("moduleID", _moduleID) << LOG_KV("uuid", uuid)
+                         << LOG_KV("nodeID", _nodeID->hex());
+    }
+
+    // zero-copy: only the FrontMessage header (moduleID + uuid + ext) is encoded into this frame;
+    // the payload rides as views that the caller keeps alive for the duration of the co_await.
+    FrontMessage message;
+    message.setModuleID(_moduleID);
+    message.setUuid(bytesConstRef(reinterpret_cast<const bcos::byte*>(uuid.data()), uuid.size()));
+    bytes header;
+    message.encodeHeader(header);
+
+    auto nodeID = _nodeID;  // keep a copy for the error callback below
+    co_await m_gatewayInterface->sendMessageByNodeID(m_groupID, _moduleID, m_nodeID,
+        std::move(_nodeID),
+        ::ranges::views::concat(
+            ::ranges::views::single(bcos::ref(std::as_const(header))), std::move(_payloads)),
+        [selfWeak = std::weak_ptr<FrontService>(self), _moduleID, nodeID,
+            uuid](Error::Ptr _error) {
+            auto front = selfWeak.lock();
+            if (!front)
+            {
+                return;
+            }
+            if (_error && (_error->errorCode() != CommonError::SUCCESS))
+            {
+                front->handleCallback(_error, bytesConstRef(), uuid, _moduleID, nodeID);
+            }
+        });
+    co_return;
 }
 
 void FrontService::enqueueSend(std::function<void()> _sendTask)

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -580,23 +580,17 @@ bcos::task::Task<SendResult> FrontService::sendMessageByNodeID(int _moduleID,
     bytes header;
     message.encodeHeader(header);
 
-    auto nodeID = _nodeID;  // keep a copy for the error callback below
-    co_await m_gatewayInterface->sendMessageByNodeID(m_groupID, _moduleID, m_nodeID,
-        std::move(_nodeID),
+    auto nodeID = _nodeID;  // keep a copy for the gateway-error path below
+    auto gatewayError = co_await m_gatewayInterface->sendMessageByNodeID(m_groupID, _moduleID,
+        m_nodeID, std::move(_nodeID),
         ::ranges::views::concat(
-            ::ranges::views::single(bcos::ref(std::as_const(header))), std::move(_payloads)),
-        [selfWeak = std::weak_ptr<FrontService>(self), _moduleID, nodeID,
-            uuid](Error::Ptr _error) {
-            auto front = selfWeak.lock();
-            if (!front)
-            {
-                return;
-            }
-            if (_error && (_error->errorCode() != CommonError::SUCCESS))
-            {
-                front->handleCallback(_error, bytesConstRef(), uuid, _moduleID, nodeID);
-            }
-        });
+            ::ranges::views::single(bcos::ref(std::as_const(header))), std::move(_payloads)));
+    if (gatewayError && (gatewayError->errorCode() != CommonError::SUCCESS))
+    {
+        // complete the registered response wait with the gateway failure; this runs on the
+        // coroutine's thread (self is alive in this frame), same delivery as the previous callback
+        handleCallback(gatewayError, bytesConstRef(), uuid, _moduleID, nodeID);
+    }
 
     if (_timeout == 0)
     {

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -545,7 +545,7 @@ void FrontService::asyncSendMessageByNodeIDByOwnedPayload(
 }
 
 bcos::task::Task<void> FrontService::sendMessageByNodeID(int _moduleID,
-    bcos::crypto::NodeIDPtr _nodeID, ::ranges::any_view<bytesConstRef> _payloads,
+    bcos::crypto::NodeIDPtr _nodeID, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
     uint32_t _timeout, CallbackFunc _callback)
 {
     // keep the service alive for the whole (possibly deferred) send

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -491,7 +491,8 @@ void FrontService::asyncSendMessageByNodeIDs(
 }
 
 task::Task<void> FrontService::broadcastMessage(
-    uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads)
+    uint16_t type, int moduleID,
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads)
 {
     FrontMessage message;
     message.setModuleID(moduleID);

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -385,40 +385,51 @@ void FrontService::asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInf
  * @param _callbackFunc: callback
  * @return void
  */
+std::string FrontService::registerCallback(
+    bcos::crypto::NodeIDPtr _nodeID, uint32_t _timeout, CallbackFunc _callbackFunc)
+{
+    static thread_local auto uuid_gen =
+        boost::uuids::basic_random_generator<std::random_device>();
+    std::string uuid = boost::uuids::to_string(uuid_gen());
+    if (!_callbackFunc)
+    {
+        return uuid;
+    }
+
+    auto callback = std::make_shared<Callback>();
+    callback->callbackFunc = std::move(_callbackFunc);
+
+    if (_timeout > 0)
+    {
+        // create new timer to handle timeout
+        auto timeoutHandler = std::make_shared<boost::asio::steady_timer>(
+            *m_ioService, std::chrono::milliseconds(_timeout));
+
+        callback->timeoutHandler = timeoutHandler;
+        auto frontServiceWeakPtr = std::weak_ptr<FrontService>(shared_from_this());
+        // callback->startTime = utcSteadyTime();
+        timeoutHandler->async_wait(
+            [frontServiceWeakPtr, _nodeID, uuid](const boost::system::error_code& e) {
+                auto frontService = frontServiceWeakPtr.lock();
+                if (frontService)
+                {
+                    frontService->onMessageTimeout(e, _nodeID, uuid);
+                }
+            });
+    }
+
+    addCallback(uuid, callback);
+    return uuid;
+}
+
 void FrontService::asyncSendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
     bytesConstRef _data, uint32_t _timeout, CallbackFunc _callbackFunc)
 {
     try
     {
-        static thread_local auto uuid_gen =
-            boost::uuids::basic_random_generator<std::random_device>();
-        std::string uuid = boost::uuids::to_string(uuid_gen());
+        std::string uuid = registerCallback(_nodeID, _timeout, _callbackFunc);
         if (_callbackFunc)
         {
-            auto callback = std::make_shared<Callback>();
-            callback->callbackFunc = _callbackFunc;
-
-            if (_timeout > 0)
-            {
-                // create new timer to handle timeout
-                auto timeoutHandler = std::make_shared<boost::asio::steady_timer>(
-                    *m_ioService, std::chrono::milliseconds(_timeout));
-
-                callback->timeoutHandler = timeoutHandler;
-                auto frontServiceWeakPtr = std::weak_ptr<FrontService>(shared_from_this());
-                // callback->startTime = utcSteadyTime();
-                timeoutHandler->async_wait(
-                    [frontServiceWeakPtr, _nodeID, uuid](const boost::system::error_code& e) {
-                        auto frontService = frontServiceWeakPtr.lock();
-                        if (frontService)
-                        {
-                            frontService->onMessageTimeout(e, _nodeID, uuid);
-                        }
-                    });
-            }
-
-            addCallback(uuid, callback);
-
             FRONT_LOG(DEBUG) << LOG_DESC("asyncSendMessageByNodeID") << LOG_KV("groupID", m_groupID)
                              << LOG_KV("moduleID", _moduleID) << LOG_KV("uuid", uuid)
                              << LOG_KV("nodeID", _nodeID->hex())
@@ -540,35 +551,9 @@ bcos::task::Task<void> FrontService::sendMessageByNodeID(int _moduleID,
     // keep the service alive for the whole (possibly deferred) send
     auto self = shared_from_this();
 
-    static thread_local auto uuid_gen =
-        boost::uuids::basic_random_generator<std::random_device>();
-    std::string uuid = boost::uuids::to_string(uuid_gen());
+    std::string uuid = registerCallback(_nodeID, _timeout, _callback);
     if (_callback)
     {
-        auto callback = std::make_shared<Callback>();
-        callback->callbackFunc = _callback;
-
-        if (_timeout > 0)
-        {
-            // create new timer to handle timeout
-            auto timeoutHandler = std::make_shared<boost::asio::steady_timer>(
-                *m_ioService, std::chrono::milliseconds(_timeout));
-
-            callback->timeoutHandler = timeoutHandler;
-            auto frontServiceWeakPtr = std::weak_ptr<FrontService>(shared_from_this());
-            // callback->startTime = utcSteadyTime();
-            timeoutHandler->async_wait([frontServiceWeakPtr, _nodeID, uuid](
-                                           const boost::system::error_code& e) {
-                auto frontService = frontServiceWeakPtr.lock();
-                if (frontService)
-                {
-                    frontService->onMessageTimeout(e, _nodeID, uuid);
-                }
-            });
-        }
-
-        addCallback(uuid, callback);
-
         FRONT_LOG(DEBUG) << LOG_DESC("sendMessageByNodeID") << LOG_KV("groupID", m_groupID)
                          << LOG_KV("moduleID", _moduleID) << LOG_KV("uuid", uuid)
                          << LOG_KV("nodeID", _nodeID->hex());

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -538,26 +538,39 @@ void FrontService::asyncSendMessageByNodeIDByOwnedPayload(
         task::wait(
             [](FrontService::Ptr _self, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
                 bytesPointer _payload) -> task::Task<void> {
-                co_await _self->sendMessageByNodeID(_moduleID, _nodeID,
-                    ::ranges::views::single(bcos::ref(*_payload)), 0, nullptr);
+                // fire-and-forget owned-payload send: no module-level response is expected
+                auto result = co_await _self->sendMessageByNodeID(_moduleID, _nodeID,
+                    ::ranges::views::single(bcos::ref(*_payload)), 0);
+                (void)result;
             }(self, moduleID, nodeID, payload));
     });
 }
 
-bcos::task::Task<void> FrontService::sendMessageByNodeID(int _moduleID,
+bcos::task::Task<SendResult> FrontService::sendMessageByNodeID(int _moduleID,
     bcos::crypto::NodeIDPtr _nodeID, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
-    uint32_t _timeout, CallbackFunc _callback)
+    uint32_t _timeout)
 {
     // keep the service alive for the whole (possibly deferred) send
     auto self = shared_from_this();
+    auto state = std::make_shared<SendResponseAwaitable::State>();
 
-    std::string uuid = registerCallback(_nodeID, _timeout, _callback);
-    if (_callback)
-    {
-        FRONT_LOG(DEBUG) << LOG_DESC("sendMessageByNodeID") << LOG_KV("groupID", m_groupID)
-                         << LOG_KV("moduleID", _moduleID) << LOG_KV("uuid", uuid)
-                         << LOG_KV("nodeID", _nodeID->hex());
-    }
+    // Register the module-level response wait: the callback fires on the peer response (via the
+    // front receive path, uuid-matched), on timeout, or on a gateway-level send failure. With
+    // _timeout == 0 the callback is empty (registerCallback then only generates the uuid and
+    // registers nothing) and the send is fire-and-forget.
+    std::string uuid = registerCallback(_nodeID, _timeout,
+        (_timeout > 0) ?
+            CallbackFunc([state](Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
+                bytesConstRef _data, const std::string& _uuid, ResponseFunc _resp) {
+                SendResult result;
+                result.error = std::move(_error);
+                result.nodeID = std::move(_nodeID);
+                result.payload.assign(_data.begin(), _data.end());
+                result.uuid = _uuid;
+                result.respond = std::move(_resp);
+                SendResponseAwaitable::complete(state, std::move(result));
+            }) :
+            CallbackFunc());
 
     // zero-copy: only the FrontMessage header (moduleID + uuid + ext) is encoded into this frame;
     // the payload rides as views that the caller keeps alive for the duration of the co_await.
@@ -584,7 +597,14 @@ bcos::task::Task<void> FrontService::sendMessageByNodeID(int _moduleID,
                 front->handleCallback(_error, bytesConstRef(), uuid, _moduleID, nodeID);
             }
         });
-    co_return;
+
+    if (_timeout == 0)
+    {
+        // fire-and-forget: no module-level response is expected; return once the gateway send
+        // completes
+        co_return SendResult{};
+    }
+    co_return co_await SendResponseAwaitable{std::move(state)};
 }
 
 void FrontService::enqueueSend(std::function<void()> _sendTask)

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -547,9 +547,9 @@ void FrontService::asyncSendMessageByNodeIDByOwnedPayload(
     });
 }
 
-bcos::task::Task<SendResult> FrontService::sendMessageByNodeID(int _moduleID,
-    bcos::crypto::NodeIDPtr _nodeID, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
-    uint32_t _timeout)
+bcos::task::Task<SendResult> FrontService::sendMessageByNodeID(
+    int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads, uint32_t _timeout)
 {
     // keep the service alive for the whole (possibly deferred) send
     auto self = shared_from_this();

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -239,6 +239,12 @@ protected:
     // gateway send.
     void enqueueSend(std::function<void()> _sendTask);
 
+    // shared uuid/timer/callback registration used by both asyncSendMessageByNodeID and the
+    // coroutine sendMessageByNodeID, so the uuid/timer/addCallback logic is not duplicated.
+    // Returns the generated uuid (used as the message id for the module-level response routing).
+    std::string registerCallback(
+        bcos::crypto::NodeIDPtr _nodeID, uint32_t _timeout, CallbackFunc _callbackFunc);
+
 private:
     bcos::IOServicePool::Ptr m_ioServicePool;
     // FIB-185: serial async send strand over the shared IOServicePool + a pending-send counter

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -100,7 +100,7 @@ public:
      *         delivered through _callbackFunc if the gateway-level send fails.
      */
     task::Task<void> sendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        ::ranges::any_view<bytesConstRef> _payloads, uint32_t _timeout,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads, uint32_t _timeout,
         CallbackFunc _callbackFunc) override;
 
     // FIB-185: dispatch the gateway broadcast onto a serial send queue (off the caller thread) so a

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -93,6 +93,16 @@ public:
     task::Task<void> broadcastMessage(
         uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) override;
 
+    /**
+     * @brief: (coroutine, zero-copy) send message to one node. The payload rides as views that the
+     *         caller keeps alive for the duration of the co_await; the module-level response is
+     *         delivered to _callbackFunc via the receive path (uuid-matched), and an error is also
+     *         delivered through _callbackFunc if the gateway-level send fails.
+     */
+    task::Task<void> sendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+        ::ranges::any_view<bytesConstRef> _payloads, uint32_t _timeout,
+        CallbackFunc _callbackFunc) override;
+
     // FIB-185: dispatch the gateway broadcast onto a serial send queue (off the caller thread) so a
     // caller holding a lock (PBFT under m_mutex) is not coupled to gateway session-lock contention.
     // The owned payload is captured by the queued task -> the message body is never copied.

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -91,7 +91,8 @@ public:
         int _moduleID, const crypto::NodeIDs& _nodeIDs, bytesConstRef _data) override;
 
     task::Task<void> broadcastMessage(
-        uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) override;
+        uint16_t type, int moduleID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override;
 
     /**
      * @brief: (coroutine, zero-copy) send message to one node and await the module-level response.

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -94,14 +94,14 @@ public:
         uint16_t type, int moduleID, ::ranges::any_view<bytesConstRef> payloads) override;
 
     /**
-     * @brief: (coroutine, zero-copy) send message to one node. The payload rides as views that the
-     *         caller keeps alive for the duration of the co_await; the module-level response is
-     *         delivered to _callbackFunc via the receive path (uuid-matched), and an error is also
-     *         delivered through _callbackFunc if the gateway-level send fails.
+     * @brief: (coroutine, zero-copy) send message to one node and await the module-level response.
+     *         The payload rides as views that the caller keeps alive for the duration of the
+     *         co_await; the coroutine resumes with the peer's response (or timeout / gateway
+     *         failure). See FrontServiceInterface::sendMessageByNodeID for the contract.
      */
-    task::Task<void> sendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads, uint32_t _timeout,
-        CallbackFunc _callbackFunc) override;
+    task::Task<SendResult> sendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
+        uint32_t _timeout) override;
 
     // FIB-185: dispatch the gateway broadcast onto a serial send queue (off the caller thread) so a
     // caller holding a lock (PBFT under m_mutex) is not coupled to gateway session-lock contention.

--- a/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
+++ b/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
@@ -56,7 +56,7 @@ public:
     std::atomic_bool m_p2pCaptured{false};
 
     task::Task<void> broadcastMessage(uint16_t, std::string_view, int, const bcos::crypto::NodeID&,
-        ::ranges::any_view<bytesConstRef>) override
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward>) override
     {
         if (!m_bcastCaptured.exchange(true))
         {

--- a/bcos-front/test/unittests/FakeGateway.cpp
+++ b/bcos-front/test/unittests/FakeGateway.cpp
@@ -76,7 +76,7 @@ void FakeGateway::asyncSendMessageByNodeIDs(const std::string& _groupID, int,
 }
 bcos::task::Task<void> bcos::front::test::FakeGateway::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,
-    ::ranges::any_view<bytesConstRef> payloads)
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads)
 {
     auto data = ::ranges::views::join(payloads) | ::ranges::to<bcos::bytes>();
     auto nodeIDPtr = std::shared_ptr<bcos::crypto::NodeID>(

--- a/bcos-front/test/unittests/FakeGateway.h
+++ b/bcos-front/test/unittests/FakeGateway.h
@@ -89,7 +89,8 @@ public:
         bytesConstRef _payload) override;
 
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
-        const bcos::crypto::NodeID& srcNodeID, ::ranges::any_view<bytesConstRef> payloads) override;
+        const bcos::crypto::NodeID& srcNodeID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override;
 
     void asyncNotifyGroupInfo(
         bcos::group::GroupInfo::Ptr, std::function<void(Error::Ptr&&)>) override

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -279,10 +279,13 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine)
     int moduleID = 222;
     frontService->registerModuleMessageDispatcher(moduleID, moduleCallback);
 
-    task::syncWait(frontService->sendMessageByNodeID(moduleID, dstNodeID,
+    // timeout == 0: fire-and-forget send; the module-level dispatch (not a response) is what the
+    // fake gateway loops back, so only the send completion matters here.
+    auto result = task::syncWait(frontService->sendMessageByNodeID(moduleID, dstNodeID,
         ::ranges::views::single(bytesConstRef(
             reinterpret_cast<const bcos::byte*>(data.data()), data.size())),
-        0, CallbackFunc()));
+        0));
+    (void)result;
     f.get();
 }
 

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -257,6 +257,35 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendBroadcastMessage)
     f.get();
 }
 
+BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine)
+{
+    // Zero-copy coroutine point-to-point: the front encodes only the FrontMessage header into its
+    // frame and passes the payload as a view; the (fake) gateway receives the joined wire bytes and
+    // delivers them back through the receive loop to the module dispatcher.
+    auto frontService = buildFrontService();
+    auto dstNodeID = createKey(g_dstNodeID_0);
+    std::string data(1000, 'y');
+
+    std::promise<bool> p;
+    auto f = p.get_future();
+    auto moduleCallback = [&p, dstNodeID, data](bcos::crypto::NodeIDPtr _nodeID,
+                              const std::string& _id, bytesConstRef _data) {
+        BOOST_CHECK(!_id.empty());
+        BOOST_CHECK_EQUAL(dstNodeID->hex(), _nodeID->hex());
+        BOOST_CHECK_EQUAL(std::string(_data.begin(), _data.end()), data);
+        p.set_value(true);
+    };
+
+    int moduleID = 222;
+    frontService->registerModuleMessageDispatcher(moduleID, moduleCallback);
+
+    task::syncWait(frontService->sendMessageByNodeID(moduleID, dstNodeID,
+        ::ranges::views::single(bytesConstRef(
+            reinterpret_cast<const bcos::byte*>(data.data()), data.size())),
+        0, CallbackFunc()));
+    f.get();
+}
+
 BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDs)
 {
     auto frontService = buildFrontService();

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -302,8 +302,12 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine_withResponse
     std::string data(1000, 'z');
     std::string responsePayload(64, 'R');
 
-    std::promise<SendResult> resultPromise;
-    auto resultFuture = resultPromise.get_future();
+    // Round-7 review: keep the promise alive via shared_ptr. The detached coroutine holds a raw
+    // reference to it; if wait_for below ever timed out, BOOST_REQUIRE aborts the test and the
+    // stack promise would be destroyed while the coroutine may still call set_value. A shared_ptr
+    // keeps the promise alive either way.
+    auto resultPromise = std::make_shared<std::promise<SendResult>>();
+    auto resultFuture = resultPromise->get_future();
 
     int moduleID = 333;
     frontService->registerModuleMessageDispatcher(moduleID,
@@ -322,13 +326,13 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine_withResponse
     auto self = frontService;
     task::wait(
         [](decltype(self) _self, decltype(dstNodeID) _dstNodeID, int _moduleID, std::string _data,
-            std::promise<SendResult>* _resultPromise) -> task::Task<void> {
+            std::shared_ptr<std::promise<SendResult>> _resultPromise) -> task::Task<void> {
             auto result = co_await _self->sendMessageByNodeID(_moduleID, _dstNodeID,
                 ::ranges::views::single(bytesConstRef(
                     reinterpret_cast<const bcos::byte*>(_data.data()), _data.size())),
                 5000);
             _resultPromise->set_value(std::move(result));
-        }(self, dstNodeID, moduleID, data, &resultPromise));
+        }(self, dstNodeID, moduleID, data, resultPromise));
 
     auto status = resultFuture.wait_for(std::chrono::seconds(10));
     BOOST_REQUIRE(status == std::future_status::ready);

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -289,6 +289,56 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine)
     f.get();
 }
 
+BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine_withResponse)
+{
+    // Round-6 review finding 2 (test gap): the response-waiting coroutine path (_timeout > 0) was
+    // never covered — the existing coroutine test passes _timeout == 0, which returns before the
+    // SendResponseAwaitable is even constructed. This drives the real response path end-to-end:
+    // the module dispatcher receives the request and replies via sendMessage(isResponse=true), the
+    // fake gateway loops the response back, and handleCallback completes the registered
+    // SendResponseAwaitable, which resumes the suspended coroutine with the SendResult.
+    auto frontService = buildFrontService();
+    auto dstNodeID = createKey(g_dstNodeID_0);
+    std::string data(1000, 'z');
+    std::string responsePayload(64, 'R');
+
+    std::promise<SendResult> resultPromise;
+    auto resultFuture = resultPromise.get_future();
+
+    int moduleID = 333;
+    frontService->registerModuleMessageDispatcher(moduleID,
+        [&](bcos::crypto::NodeIDPtr _nodeID, const std::string& _id, bytesConstRef _data) {
+            BOOST_CHECK_EQUAL(dstNodeID->hex(), _nodeID->hex());
+            BOOST_CHECK_EQUAL(std::string(_data.begin(), _data.end()), data);
+            // reply with an isResponse=true frame carrying the same uuid; the fake gateway loops
+            // it back to onReceiveMessage, where message.isResponse() triggers handleCallback ->
+            // SendResponseAwaitable::complete
+            frontService->sendMessage(moduleID, dstNodeID, _id,
+                bytesConstRef(reinterpret_cast<const bcos::byte*>(responsePayload.data()),
+                    responsePayload.size()),
+                true, nullptr);
+        });
+
+    auto self = frontService;
+    task::wait(
+        [](decltype(self) _self, decltype(dstNodeID) _dstNodeID, int _moduleID, std::string _data,
+            std::promise<SendResult>* _resultPromise) -> task::Task<void> {
+            auto result = co_await _self->sendMessageByNodeID(_moduleID, _dstNodeID,
+                ::ranges::views::single(bytesConstRef(
+                    reinterpret_cast<const bcos::byte*>(_data.data()), _data.size())),
+                5000);
+            _resultPromise->set_value(std::move(result));
+        }(self, dstNodeID, moduleID, data, &resultPromise));
+
+    auto status = resultFuture.wait_for(std::chrono::seconds(10));
+    BOOST_REQUIRE(status == std::future_status::ready);
+    auto result = resultFuture.get();
+    BOOST_CHECK(!result.error);
+    BOOST_CHECK(!result.uuid.empty());
+    BOOST_CHECK_EQUAL(std::string(result.payload.begin(), result.payload.end()), responsePayload);
+    BOOST_CHECK(result.respond);
+}
+
 BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDs)
 {
     auto frontService = buildFrontService();

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -200,8 +200,9 @@ void Gateway::asyncSendMessageByNodeID(const std::string& _groupID, int _moduleI
             bcos::bytes(_payload.begin(), _payload.end()), std::move(_errorRespFunc)));
 }
 
-bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(const std::string& _groupID,
-    int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
+bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(
+    const std::string& _groupID, int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID,
+    bcos::crypto::NodeIDPtr _dstNodeID,
     ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads)
 {
     auto p2pIDs =

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -152,9 +152,37 @@ void Gateway::asyncSendMessageByNodeID(const std::string& _groupID, int _moduleI
     NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bytesConstRef _payload,
     ErrorRespFunc _errorRespFunc)
 {
-    // Thin shim: preserve the synchronous-copy contract for borrowed payloads (the caller may
-    // release its buffer as soon as this returns). The actual zero-copy, retrying send runs as a
-    // coroutine that owns the copied payload in its frame.
+    // Local delivery first (zero-copy): when no remote gateway hosts the destination front, deliver
+    // directly through the local router table using the borrowed payload, exactly like the pre-PR
+    // path. Only the remote path copies the payload (into the coroutine frame) so the caller may
+    // release its buffer as soon as this returns.
+    auto p2pIDs =
+        m_gatewayNodeManager->peersRouterTable()->queryP2pIDs(_groupID, _dstNodeID->hex());
+    if (p2pIDs.empty())
+    {
+        if (m_gatewayNodeManager->localRouterTable()->sendMessage(
+                _groupID, _srcNodeID, _dstNodeID, _payload, _errorRespFunc))
+        {
+            return;
+        }
+        GATEWAY_LOG(DEBUG) << LOG_DESC("could not find a gateway to send this message")
+                           << LOG_KV("groupID", _groupID)
+                           << LOG_KV("srcNodeID", _srcNodeID->hex())
+                           << LOG_KV("dstNodeID", _dstNodeID->hex());
+        auto errorPtr = BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
+            "could not find a gateway to "
+            "send this message, groupID:" +
+                _groupID + " ,dstNodeID:" + _dstNodeID->hex());
+        if (_errorRespFunc)
+        {
+            _errorRespFunc(errorPtr);
+        }
+        return;
+    }
+
+    // Thin shim for the remote path: preserve the synchronous-copy contract for borrowed payloads
+    // (the caller may release its buffer as soon as this returns). The actual zero-copy, retrying
+    // send runs as a coroutine that owns the copied payload in its frame.
     auto self = shared_from_this();
     task::wait(
         [](std::shared_ptr<Gateway> _self, std::string _groupID, int _moduleID,
@@ -227,14 +255,22 @@ bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::st
         {
             auto resp = co_await m_p2pInterface->sendMessageByNodeID(
                 p2pID, message, _payloads, Options{c_gatewaySendTimeoutMs, true});
-            int respCode = bcos::protocol::CommonError::SUCCESS;
             auto respMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
-            if (respMessage)
+            if (!respMessage)
             {
-                auto payload = respMessage->payload();
-                respCode = boost::lexical_cast<int>(std::string_view(
-                    reinterpret_cast<const char*>(payload.data()), payload.size()));
+                // No response means nothing was sent (e.g. the target session is inactive or the
+                // nodeID is local). Treat it as a failed attempt and try the next gateway — the
+                // previous Retry path never reported a missing response as success, and reporting
+                // success here would silently drop the message.
+                GATEWAY_LOG(DEBUG)
+                    << LOG_BADGE("Gateway::sendMessageByNodeID")
+                    << LOG_DESC("no response, try another gateway")
+                    << LOG_KV("p2pid", printShortP2pID(p2pID)) << LOG_KV("moduleID", _moduleID);
+                continue;
             }
+            auto payload = respMessage->payload();
+            int respCode = boost::lexical_cast<int>(std::string_view(
+                reinterpret_cast<const char*>(payload.data()), payload.size()));
             if (respCode == bcos::protocol::CommonError::SUCCESS)
             {
                 if (_errorRespFunc)

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -23,6 +23,7 @@
 #include "bcos-front/FrontMessage.h"
 #include "bcos-gateway/Common.h"
 #include "bcos-gateway/gateway/GatewayMessageExtAttributes.h"
+#include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-gateway/libp2p/P2PMessageV2.h"
 #include "bcos-gateway/libp2p/P2PSession.h"
@@ -231,6 +232,12 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(const s
             bcos::crypto::NodeIDPtr m_dstNodeID;
             std::shared_ptr<bcos::bytes> m_buffer;
             std::shared_ptr<State> m_state;
+            // the io pool used to complete the coroutine OFF the caller's stack: the completion
+            // callback may run synchronously on the caller's own io thread (IOServicePool::dispatch
+            // executes inline when the current thread already belongs to the pool), and resuming
+            // the suspended coroutine from inside its own await_suspend is the exact hazard
+            // send()/drop() avoid by posting (FIB-185).
+            std::shared_ptr<ASIOInterface> m_asioInterface;
 
             bool await_ready() const noexcept { return false; }
             void await_suspend(std::coroutine_handle<> h)
@@ -238,16 +245,18 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(const s
                 m_state->handle = h;
                 auto state = m_state;
                 auto buffer = m_buffer;
+                auto asioInterface = m_asioInterface;
                 bool accepted = m_table->sendMessage(m_groupID, m_srcNodeID, m_dstNodeID,
                     bcos::ref(*buffer),
-                    [state, buffer](Error::Ptr _error) {
+                    [state, buffer, asioInterface](Error::Ptr _error) {
                         // completes exactly once; the buffer is kept alive until after the resume
-                        // (the borrowed front may still be reading it)
+                        // (the borrowed front may still be reading it). Post the resume off this
+                        // stack — the callback may run inline on the caller's io thread.
                         if (!state->done.exchange(true))
                         {
                             state->error = std::move(_error);
                             (void)buffer;
-                            state->handle.resume();
+                            asioInterface->post([state]() { state->handle.resume(); });
                         }
                     });
                 if (!accepted)
@@ -258,7 +267,7 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(const s
                         state->error = BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
                             "could not find a gateway to send this message, groupID:" + m_groupID +
                                 " ,dstNodeID:" + m_dstNodeID->hex());
-                        state->handle.resume();
+                        asioInterface->post([state]() { state->handle.resume(); });
                     }
                 }
             }
@@ -271,7 +280,8 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(const s
         co_return co_await LocalSendAwaitable{
             m_gatewayNodeManager->localRouterTable().get(), _groupID, std::move(_srcNodeID),
             std::move(_dstNodeID), std::make_shared<bcos::bytes>(std::move(buffer)),
-            std::make_shared<LocalSendAwaitable::State>()};
+            std::make_shared<LocalSendAwaitable::State>(),
+            m_p2pInterface->host()->asioInterface()};
     }
 
     // zero-copy: the message (header/options only) and the payload views both live in this frame
@@ -641,7 +651,7 @@ void bcos::gateway::Gateway::enableReadOnlyMode()
 
 bcos::task::Task<void> bcos::gateway::Gateway::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,
-    ::ranges::any_view<bytesConstRef> payloads)
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads)
 {
     // zero-copy: the message (header/options only) lives in this frame; payload rides as views
     P2PMessageV2 message;

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -197,7 +197,8 @@ void Gateway::asyncSendMessageByNodeID(const std::string& _groupID, int _moduleI
 
 bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::string& _groupID,
     int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-    ::ranges::any_view<bytesConstRef> _payloads, ErrorRespFunc _errorRespFunc)
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
+    ErrorRespFunc _errorRespFunc)
 {
     auto p2pIDs =
         m_gatewayNodeManager->peersRouterTable()->queryP2pIDs(_groupID, _dstNodeID->hex());

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -182,23 +182,26 @@ void Gateway::asyncSendMessageByNodeID(const std::string& _groupID, int _moduleI
 
     // Thin shim for the remote path: preserve the synchronous-copy contract for borrowed payloads
     // (the caller may release its buffer as soon as this returns). The actual zero-copy, retrying
-    // send runs as a coroutine that owns the copied payload in its frame.
+    // send runs as a coroutine that owns the copied payload in its frame; the send result is
+    // delivered through _errorRespFunc (nullptr on success).
     auto self = shared_from_this();
     task::wait(
         [](std::shared_ptr<Gateway> _self, std::string _groupID, int _moduleID,
             NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bcos::bytes _payload,
             ErrorRespFunc _errorRespFunc) -> task::Task<void> {
-            co_await _self->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID, _dstNodeID,
-                ::ranges::views::single(bcos::ref(std::as_const(_payload))),
-                std::move(_errorRespFunc));
+            auto error = co_await _self->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
+                _dstNodeID, ::ranges::views::single(bcos::ref(std::as_const(_payload))));
+            if (_errorRespFunc)
+            {
+                _errorRespFunc(std::move(error));
+            }
         }(self, std::string(_groupID), _moduleID, std::move(_srcNodeID), std::move(_dstNodeID),
             bcos::bytes(_payload.begin(), _payload.end()), std::move(_errorRespFunc)));
 }
 
-bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::string& _groupID,
+bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(const std::string& _groupID,
     int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
-    ErrorRespFunc _errorRespFunc)
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads)
 {
     auto p2pIDs =
         m_gatewayNodeManager->peersRouterTable()->queryP2pIDs(_groupID, _dstNodeID->hex());
@@ -211,25 +214,64 @@ bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::st
         {
             buffer.insert(buffer.end(), data.begin(), data.end());
         }
-        if (m_gatewayNodeManager->localRouterTable()->sendMessage(
-                _groupID, _srcNodeID, _dstNodeID, bcos::ref(buffer), _errorRespFunc))
+        // Local delivery is asynchronous (the front's onReceiveMessage completes the callback);
+        // bridge it to the co_await so the delivery result is delivered as the return value.
+        struct LocalSendAwaitable
         {
-            co_return;
-        }
-        GATEWAY_LOG(DEBUG) << LOG_DESC("could not find a gateway to send this message")
+            struct State
+            {
+                std::atomic<bool> done{false};
+                std::coroutine_handle<> handle;
+                Error::Ptr error;
+            };
+
+            LocalRouterTable* m_table;
+            std::string m_groupID;
+            bcos::crypto::NodeIDPtr m_srcNodeID;
+            bcos::crypto::NodeIDPtr m_dstNodeID;
+            std::shared_ptr<bcos::bytes> m_buffer;
+            std::shared_ptr<State> m_state;
+
+            bool await_ready() const noexcept { return false; }
+            void await_suspend(std::coroutine_handle<> h)
+            {
+                m_state->handle = h;
+                auto state = m_state;
+                auto buffer = m_buffer;
+                bool accepted = m_table->sendMessage(m_groupID, m_srcNodeID, m_dstNodeID,
+                    bcos::ref(*buffer),
+                    [state, buffer](Error::Ptr _error) {
+                        // completes exactly once; the buffer is kept alive until after the resume
+                        // (the borrowed front may still be reading it)
+                        if (!state->done.exchange(true))
+                        {
+                            state->error = std::move(_error);
+                            (void)buffer;
+                            state->handle.resume();
+                        }
+                    });
+                if (!accepted)
+                {
+                    // the destination front is not hosted locally: fail immediately
+                    if (!state->done.exchange(true))
+                    {
+                        state->error = BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
+                            "could not find a gateway to send this message, groupID:" + m_groupID +
+                                " ,dstNodeID:" + m_dstNodeID->hex());
+                        state->handle.resume();
+                    }
+                }
+            }
+            Error::Ptr await_resume() { return std::move(m_state->error); }
+        };
+        GATEWAY_LOG(DEBUG) << LOG_DESC("local delivery of sendMessageByNodeID")
                            << LOG_KV("groupID", _groupID)
                            << LOG_KV("srcNodeID", _srcNodeID->hex())
                            << LOG_KV("dstNodeID", _dstNodeID->hex());
-
-        auto errorPtr = BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
-            "could not find a gateway to "
-            "send this message, groupID:" +
-                _groupID + " ,dstNodeID:" + _dstNodeID->hex());
-        if (_errorRespFunc)
-        {
-            _errorRespFunc(errorPtr);
-        }
-        co_return;
+        co_return co_await LocalSendAwaitable{
+            m_gatewayNodeManager->localRouterTable().get(), _groupID, std::move(_srcNodeID),
+            std::move(_dstNodeID), std::make_shared<bcos::bytes>(std::move(buffer)),
+            std::make_shared<LocalSendAwaitable::State>()};
     }
 
     // zero-copy: the message (header/options only) and the payload views both live in this frame
@@ -274,11 +316,7 @@ bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::st
                 reinterpret_cast<const char*>(payload.data()), payload.size()));
             if (respCode == bcos::protocol::CommonError::SUCCESS)
             {
-                if (_errorRespFunc)
-                {
-                    _errorRespFunc(nullptr);
-                }
-                co_return;
+                co_return nullptr;
             }
             GATEWAY_LOG(DEBUG) << LOG_BADGE("Gateway::sendMessageByNodeID")
                                << LOG_KV("p2pid", printShortP2pID(p2pID))
@@ -289,23 +327,13 @@ bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::st
         {
             if (e.errorCode() == P2PExceptionType::OutBWOverflow)
             {
-                if (_errorRespFunc)
-                {
-                    auto errorPtr = BCOS_ERROR_PTR(
-                        bcos::protocol::CommonError::GatewayBandwidthOverFlow, e.what());
-                    _errorRespFunc(errorPtr);
-                }
-                co_return;
+                co_return BCOS_ERROR_PTR(
+                    bcos::protocol::CommonError::GatewayBandwidthOverFlow, e.what());
             }
             if (e.errorCode() == P2PExceptionType::InQPSOverflow)
             {
-                if (_errorRespFunc)
-                {
-                    auto errorPtr = BCOS_ERROR_PTR(
-                        bcos::protocol::CommonError::GatewayQPSOverFlow, e.what());
-                    _errorRespFunc(errorPtr);
-                }
-                co_return;
+                co_return BCOS_ERROR_PTR(
+                    bcos::protocol::CommonError::GatewayQPSOverFlow, e.what());
             }
             GATEWAY_LOG(DEBUG) << LOG_BADGE("Gateway::sendMessageByNodeID")
                                << LOG_DESC("network callback")
@@ -323,13 +351,8 @@ bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::st
             // try another gateway
         }
     }
-    if (_errorRespFunc)
-    {
-        auto errorPtr = BCOS_ERROR_PTR(
-            bcos::protocol::CommonError::GatewaySendMsgFailed, "unable to send the message");
-        _errorRespFunc(errorPtr);
-    }
-    co_return;
+    co_return BCOS_ERROR_PTR(
+        bcos::protocol::CommonError::GatewaySendMsgFailed, "unable to send the message");
 }
 
 /**

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -24,10 +24,13 @@
 #include "bcos-gateway/Common.h"
 #include "bcos-gateway/gateway/GatewayMessageExtAttributes.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
 #include "bcos-gateway/libp2p/P2PSession.h"
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Common.h"
 #include "filter/Filter.h"
+#include <bcos-task/Wait.h>
+#include <boost/lexical_cast.hpp>
 #include <string>
 #include <vector>
 
@@ -149,17 +152,44 @@ void Gateway::asyncSendMessageByNodeID(const std::string& _groupID, int _moduleI
     NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bytesConstRef _payload,
     ErrorRespFunc _errorRespFunc)
 {
+    // Thin shim: preserve the synchronous-copy contract for borrowed payloads (the caller may
+    // release its buffer as soon as this returns). The actual zero-copy, retrying send runs as a
+    // coroutine that owns the copied payload in its frame.
+    auto self = shared_from_this();
+    task::wait(
+        [](std::shared_ptr<Gateway> _self, std::string _groupID, int _moduleID,
+            NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bcos::bytes _payload,
+            ErrorRespFunc _errorRespFunc) -> task::Task<void> {
+            co_await _self->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID, _dstNodeID,
+                ::ranges::views::single(bcos::ref(std::as_const(_payload))),
+                std::move(_errorRespFunc));
+        }(self, std::string(_groupID), _moduleID, std::move(_srcNodeID), std::move(_dstNodeID),
+            bcos::bytes(_payload.begin(), _payload.end()), std::move(_errorRespFunc)));
+}
+
+bcos::task::Task<void> bcos::gateway::Gateway::sendMessageByNodeID(const std::string& _groupID,
+    int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
+    ::ranges::any_view<bytesConstRef> _payloads, ErrorRespFunc _errorRespFunc)
+{
     auto p2pIDs =
         m_gatewayNodeManager->peersRouterTable()->queryP2pIDs(_groupID, _dstNodeID->hex());
     if (p2pIDs.empty())
     {
-        if (m_gatewayNodeManager->localRouterTable()->sendMessage(
-                _groupID, _srcNodeID, _dstNodeID, _payload, _errorRespFunc))
+        // no remote gateway available: deliver locally if the destination front is local (the
+        // views are joined because the local dispatch API consumes a single contiguous buffer)
+        bcos::bytes buffer;
+        for (auto const& data : _payloads)
         {
-            return;
+            buffer.insert(buffer.end(), data.begin(), data.end());
+        }
+        if (m_gatewayNodeManager->localRouterTable()->sendMessage(
+                _groupID, _srcNodeID, _dstNodeID, bcos::ref(buffer), _errorRespFunc))
+        {
+            co_return;
         }
         GATEWAY_LOG(DEBUG) << LOG_DESC("could not find a gateway to send this message")
-                           << LOG_KV("groupID", _groupID) << LOG_KV("srcNodeID", _srcNodeID->hex())
+                           << LOG_KV("groupID", _groupID)
+                           << LOG_KV("srcNodeID", _srcNodeID->hex())
                            << LOG_KV("dstNodeID", _dstNodeID->hex());
 
         auto errorPtr = BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
@@ -170,32 +200,99 @@ void Gateway::asyncSendMessageByNodeID(const std::string& _groupID, int _moduleI
         {
             _errorRespFunc(errorPtr);
         }
-        return;
+        co_return;
     }
 
-    auto message =
-        std::static_pointer_cast<P2PMessage>(m_p2pInterface->messageFactory()->buildMessage());
-
+    // zero-copy: the message (header/options only) and the payload views both live in this frame
+    P2PMessageV2 message;
     GatewayMessageExtAttributes msgExtAttr;
     msgExtAttr.setGroupID(_groupID);
     msgExtAttr.setModuleID(_moduleID);
-
-    message->setPacketType(GatewayMessageType::PeerToPeerMessage);
-    message->setSeq(m_p2pInterface->messageFactory()->newSeq());
-    message->setPayload({_payload.begin(), _payload.end()});
-    message->setExtAttributes(std::move(msgExtAttr));
+    message.setPacketType(GatewayMessageType::PeerToPeerMessage);
+    message.setSeq(m_p2pInterface->messageFactory()->newSeq());
+    message.setExtAttributes(std::move(msgExtAttr));
 
     P2PMessageOptions options;
     options.setGroupID(_groupID);
     options.setModuleID(_moduleID);
     options.setSrcNodeID(_srcNodeID->encode());
     options.mutableDstNodeIDs().push_back(_dstNodeID->encode());
-    message->setOptions(std::move(options));
+    message.setOptions(std::move(options));
 
-    auto retry = std::make_shared<Retry>(std::move(_srcNodeID), std::move(_dstNodeID),
-        std::move(message), m_p2pInterface, std::move(_errorRespFunc), _moduleID);
-    retry->insertP2pIDs(p2pIDs);
-    retry->trySendMessage();
+    // wait up to 10s for the peer gateway ack on each attempt (same as the previous Retry path)
+    constexpr uint32_t c_gatewaySendTimeoutMs = 10000;
+    for (auto const& p2pID : p2pIDs)
+    {
+        try
+        {
+            auto resp = co_await m_p2pInterface->sendMessageByNodeID(
+                p2pID, message, _payloads, Options{c_gatewaySendTimeoutMs, true});
+            int respCode = bcos::protocol::CommonError::SUCCESS;
+            auto respMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
+            if (respMessage)
+            {
+                auto payload = respMessage->payload();
+                respCode = boost::lexical_cast<int>(std::string_view(
+                    reinterpret_cast<const char*>(payload.data()), payload.size()));
+            }
+            if (respCode == bcos::protocol::CommonError::SUCCESS)
+            {
+                if (_errorRespFunc)
+                {
+                    _errorRespFunc(nullptr);
+                }
+                co_return;
+            }
+            GATEWAY_LOG(DEBUG) << LOG_BADGE("Gateway::sendMessageByNodeID")
+                               << LOG_KV("p2pid", printShortP2pID(p2pID))
+                               << LOG_KV("moduleID", _moduleID) << LOG_KV("code", respCode)
+                               << LOG_KV("message", "respCode != SUCCESS, try another gateway");
+        }
+        catch (NetworkException const& e)
+        {
+            if (e.errorCode() == P2PExceptionType::OutBWOverflow)
+            {
+                if (_errorRespFunc)
+                {
+                    auto errorPtr = BCOS_ERROR_PTR(
+                        bcos::protocol::CommonError::GatewayBandwidthOverFlow, e.what());
+                    _errorRespFunc(errorPtr);
+                }
+                co_return;
+            }
+            if (e.errorCode() == P2PExceptionType::InQPSOverflow)
+            {
+                if (_errorRespFunc)
+                {
+                    auto errorPtr = BCOS_ERROR_PTR(
+                        bcos::protocol::CommonError::GatewayQPSOverFlow, e.what());
+                    _errorRespFunc(errorPtr);
+                }
+                co_return;
+            }
+            GATEWAY_LOG(DEBUG) << LOG_BADGE("Gateway::sendMessageByNodeID")
+                               << LOG_DESC("network callback")
+                               << LOG_KV("dstP2P", printShortP2pID(p2pID))
+                               << LOG_KV("code", e.errorCode()) << LOG_KV("moduleID", _moduleID)
+                               << LOG_KV("message", e.what());
+            // try another gateway
+        }
+        catch (std::exception const& e)
+        {
+            GATEWAY_LOG(ERROR) << LOG_BADGE("Gateway::sendMessageByNodeID")
+                               << LOG_DESC("send message exception")
+                               << LOG_KV("moduleID", _moduleID)
+                               << LOG_KV("message", boost::diagnostic_information(e));
+            // try another gateway
+        }
+    }
+    if (_errorRespFunc)
+    {
+        auto errorPtr = BCOS_ERROR_PTR(
+            bcos::protocol::CommonError::GatewaySendMsgFailed, "unable to send the message");
+        _errorRespFunc(errorPtr);
+    }
+    co_return;
 }
 
 /**
@@ -486,28 +583,28 @@ bcos::task::Task<void> bcos::gateway::Gateway::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,
     ::ranges::any_view<bytesConstRef> payloads)
 {
-    auto message =
-        std::dynamic_pointer_cast<P2PMessage>(m_p2pInterface->messageFactory()->buildMessage());
-    message->setPacketType(GatewayMessageType::BroadcastMessage);
-    message->setExt(type);
-    message->setSeq(m_p2pInterface->messageFactory()->newSeq());
+    // zero-copy: the message (header/options only) lives in this frame; payload rides as views
+    P2PMessageV2 message;
+    message.setPacketType(GatewayMessageType::BroadcastMessage);
+    message.setExt(type);
+    message.setSeq(m_p2pInterface->messageFactory()->newSeq());
 
     P2PMessageOptions options;
     options.setGroupID(std::string(groupID));
     options.setSrcNodeID(srcNodeID.encode());
     options.setModuleID(moduleID);
-    message->setOptions(std::move(options));
+    message.setOptions(std::move(options));
 
     if (m_gatewayRateLimiter)
     {
         GatewayMessageExtAttributes msgExtAttr;
         msgExtAttr.setGroupID(std::string(groupID));
         msgExtAttr.setModuleID(moduleID);
-        message->setExtAttributes(std::move(msgExtAttr));
+        message.setExtAttributes(std::move(msgExtAttr));
     }
 
     co_await m_gatewayNodeManager->peersRouterTable()->broadcastMessage(
-        type, groupID, moduleID, *message, std::move(payloads));
+        type, groupID, moduleID, message, std::move(payloads));
 }
 bcos::gateway::Gateway::Gateway(GatewayConfig::Ptr _gatewayConfig, P2PInterface::Ptr _p2pInterface,
     GatewayNodeManager::Ptr _gatewayNodeManager, bcos::amop::AMOPImpl::Ptr _amop,

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -100,7 +100,8 @@ public:
      */
     task::Task<void> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        ::ranges::any_view<bytesConstRef> _payloads, ErrorRespFunc _errorRespFunc) override;
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
+        ErrorRespFunc _errorRespFunc) override;
 
     /**
      * @brief: receive p2p message

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -91,7 +91,8 @@ public:
         bytesConstRef _payload) override;
 
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
-        const bcos::crypto::NodeID& srcNodeID, ::ranges::any_view<bytesConstRef> payloads) override;
+        const bcos::crypto::NodeID& srcNodeID,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override;
 
     /**
      * @brief: (coroutine, zero-copy) send message to a single node with retry across candidate

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -36,166 +36,6 @@
 
 namespace bcos::gateway
 {
-class Retry : public std::enable_shared_from_this<Retry>
-{
-public:
-    Retry(crypto::NodeIDPtr _srcNodeID, crypto::NodeIDPtr _dstNodeID,
-        std::shared_ptr<P2PMessage> _p2pMessage, std::shared_ptr<P2PInterface> _p2pInterface,
-        ErrorRespFunc _respFunc, int _moduleID)
-      : m_srcNodeID(std::move(_srcNodeID)),
-        m_dstNodeID(std::move(_dstNodeID)),
-        m_p2pMessage(std::move(_p2pMessage)),
-        m_p2pInterface(std::move(_p2pInterface)),
-        m_respFunc(std::move(_respFunc)),
-        m_moduleID(_moduleID)
-    {}
-    // random choose one p2pID to send message
-    P2pID chooseP2pID()
-    {
-        auto p2pId = P2pID();
-        std::lock_guard<std::mutex> lock(x_mutex);
-        if (!m_p2pIDs.empty())
-        {
-            p2pId = *m_p2pIDs.begin();
-            m_p2pIDs.erase(m_p2pIDs.begin());
-        }
-
-        return p2pId;
-    }
-
-    // send the message with retry
-    void trySendMessage()
-    {
-        if (m_p2pIDs.empty())
-        {
-            GATEWAY_LOG(DEBUG) << LOG_DESC("[Gateway::Retry]")
-                               << LOG_DESC("unable to send the message")
-                               << LOG_KV("srcNodeID", m_srcNodeID->hex())
-                               << LOG_KV("dstNodeID", m_dstNodeID->hex())
-                               << LOG_KV("seq", std::to_string(m_p2pMessage->seq()))
-                               << LOG_KV("moduleID", m_moduleID);
-
-            if (m_respFunc)
-            {
-                auto errorPtr = BCOS_ERROR_PTR(bcos::protocol::CommonError::GatewaySendMsgFailed,
-                    "unable to send the message");
-                m_respFunc(errorPtr);
-            }
-            return;
-        }
-
-        auto seq = m_p2pMessage->seq();
-        auto p2pID = chooseP2pID();
-        auto self = shared_from_this();
-        auto startT = utcTime();
-        auto callback = [moduleID = m_moduleID, seq, self, startT, p2pID](NetworkException e,
-                            std::shared_ptr<P2PSession> session,
-                            std::shared_ptr<P2PMessage> message) {
-            std::ignore = session;
-            if (e.errorCode() != P2PExceptionType::Success)
-            {
-                // bandwidth overflow , do'not try again
-                if (e.errorCode() == P2PExceptionType::OutBWOverflow)
-                {
-                    if (self->m_respFunc)
-                    {
-                        auto errorPtr = BCOS_ERROR_PTR(
-                            bcos::protocol::CommonError::GatewayBandwidthOverFlow, e.what());
-                        self->m_respFunc(errorPtr);
-                    }
-
-                    return;
-                }
-
-                // QPS overflow , do'not try again ???
-                if (e.errorCode() == P2PExceptionType::InQPSOverflow)
-                {
-                    if (self->m_respFunc)
-                    {
-                        auto errorPtr = BCOS_ERROR_PTR(
-                            bcos::protocol::CommonError::GatewayQPSOverFlow, e.what());
-                        self->m_respFunc(errorPtr);
-                    }
-
-                    return;
-                }
-
-                GATEWAY_LOG(DEBUG)
-                    << LOG_BADGE("Retry") << LOG_DESC("network callback") << LOG_KV("seq", seq)
-                    << LOG_KV("dstP2P", printShortP2pID(p2pID)) << LOG_KV("code", e.errorCode())
-                    << LOG_KV("moduleID", moduleID) << LOG_KV("message", e.what())
-                    << LOG_KV("timeCost", (utcTime() - startT));
-                // try again
-                self->trySendMessage();
-                return;
-            }
-
-            try
-            {
-                auto payload = message->payload();
-                int respCode = boost::lexical_cast<int>(std::string_view(
-                    reinterpret_cast<const char*>(payload.data()), payload.size()));
-                // the peer gateway not response not ok ,it means the gateway not dispatch the
-                // message successfully,find another gateway and try again
-                if (respCode != bcos::protocol::CommonError::SUCCESS)
-                {
-                    GATEWAY_LOG(DEBUG)
-                        << LOG_BADGE("Retry") << LOG_KV("p2pid", printShortP2pID(p2pID))
-                        << LOG_KV("moduleID", moduleID) << LOG_KV("code", respCode)
-                        << LOG_KV("message", e.what());
-                    // try again
-                    self->trySendMessage();
-                    return;
-                }
-                GATEWAY_LOG(TRACE) << LOG_BADGE("Retry: asyncSendMessageByNodeID success")
-                                   << LOG_KV("dstP2P", printShortP2pID(p2pID))
-                                   << LOG_KV("srcNodeID", self->m_srcNodeID->hex())
-                                   << LOG_KV("dstNodeID", self->m_dstNodeID->hex())
-                                   << LOG_KV("moduleID", moduleID);
-                // send message successfully
-                if (self->m_respFunc)
-                {
-                    self->m_respFunc(nullptr);
-                }
-                return;
-            }
-            catch (const std::exception& e)
-            {
-                GATEWAY_LOG(ERROR) << LOG_BADGE("trySendMessage and receive response exception")
-                                   << LOG_KV("payload", std::string(message->payload().begin(),
-                                                            message->payload().end()))
-                                   << LOG_KV("packetType", message->packetType())
-                                   << LOG_KV("src", message->options().srcNodeID() ?
-                                                        toHex(message->options().srcNodeID()) :
-                                                        "unknown")
-                                   << LOG_KV("size", message->length())
-                                   << LOG_KV("message", e.what()) << LOG_KV("moduleID", moduleID);
-
-                self->trySendMessage();
-            }
-        };
-        m_p2pInterface->asyncSendMessageByNodeID(p2pID, m_p2pMessage, callback, Options(10000));
-    }
-
-    // insert p2pIDs
-    void insertP2pIDs(::ranges::range auto const& _p2pIDs)
-    {
-        std::lock_guard<std::mutex> lock(x_mutex);
-        m_p2pIDs.insert(m_p2pIDs.end(), _p2pIDs.begin(), _p2pIDs.end());
-    }
-
-private:
-    // mutex for p2pIDs
-    mutable std::mutex x_mutex;
-    std::vector<P2pID> m_p2pIDs;
-    crypto::NodeIDPtr m_srcNodeID;
-    crypto::NodeIDPtr m_dstNodeID;
-    std::shared_ptr<P2PMessage> m_p2pMessage;
-    std::shared_ptr<P2PInterface> m_p2pInterface;
-    ErrorRespFunc m_respFunc;
-    int m_moduleID;
-};
-
 class Gateway : public GatewayInterface, public std::enable_shared_from_this<Gateway>
 {
 public:
@@ -252,6 +92,15 @@ public:
 
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID, ::ranges::any_view<bytesConstRef> payloads) override;
+
+    /**
+     * @brief: (coroutine, zero-copy) send message to a single node with retry across candidate
+     *         p2p gateways. The payload views must be kept alive by the caller for the duration of
+     *         the co_await; _errorRespFunc is invoked on completion (nullptr on success).
+     */
+    task::Task<void> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
+        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
+        ::ranges::any_view<bytesConstRef> _payloads, ErrorRespFunc _errorRespFunc) override;
 
     /**
      * @brief: receive p2p message

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -96,12 +96,12 @@ public:
     /**
      * @brief: (coroutine, zero-copy) send message to a single node with retry across candidate
      *         p2p gateways. The payload views must be kept alive by the caller for the duration of
-     *         the co_await; _errorRespFunc is invoked on completion (nullptr on success).
+     *         the co_await; the coroutine resumes with nullptr on success or an Error::Ptr
+     *         describing the failure.
      */
-    task::Task<void> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
+    task::Task<Error::Ptr> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
-        ErrorRespFunc _errorRespFunc) override;
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads) override;
 
     /**
      * @brief: receive p2p message

--- a/bcos-gateway/bcos-gateway/GatewayFactory.cpp
+++ b/bcos-gateway/bcos-gateway/GatewayFactory.cpp
@@ -821,7 +821,8 @@ std::shared_ptr<Gateway> GatewayFactory::buildGateway(GatewayConfig::Ptr _config
             auto gatewayRateLimiterWeakPtr =
                 std::weak_ptr<ratelimiter::GatewayRateLimiter>(gatewayRateLimiter);
             service->setBeforeMessageHandler([gatewayRateLimiterWeakPtr](SessionFace& _session,
-                                                 Message& _msg) -> std::optional<bcos::Error> {
+                                                 const Message& _msg,
+                                                 uint32_t _wireLength) -> std::optional<bcos::Error> {
                 auto gatewayRateLimiter = gatewayRateLimiterWeakPtr.lock();
                 if (!gatewayRateLimiter)
                 {
@@ -835,7 +836,9 @@ std::shared_ptr<Gateway> GatewayFactory::buildGateway(GatewayConfig::Ptr _config
                         msgExtAttributes ? msgExtAttributes->groupID() : std::string();
                     uint16_t moduleID = msgExtAttributes ? msgExtAttributes->moduleID() : 0;
                     std::string endpoint = _session.nodeIPEndpoint().address();
-                    int64_t msgLength = _msg.length();
+                    // charge the actual wire bytes (payload views included): a zero-copy message
+                    // does not carry its payload, so message.length() alone would under-count
+                    int64_t msgLength = _wireLength;
                     auto pkgType = _msg.packetType();
 
                     auto result = gatewayRateLimiter->checkOutGoing(

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -377,16 +377,16 @@ void GatewayNodeManager::broadcastStatusSeq()
     payload.insert(payload.end(), (byte*)&statusSeq, (byte*)&statusSeq + 4);
     NODE_MANAGER_LOG(TRACE) << LOG_DESC("broadcastStatusSeq") << LOG_KV("seq", seq);
     auto p2p = m_p2pInterface;
-    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send).
-    // The p2p interface is passed as a coroutine parameter so it is copied into the frame and stays
-    // alive for the whole (possibly deferred) send.
+    // value message held by shared_ptr; the 4-byte seq payload is owned by it (zero-copy view
+    // send). The p2p interface is passed as a coroutine parameter so it is copied into the frame
+    // and stays alive for the whole (possibly deferred) send.
     task::wait([](P2PInterface::Ptr _p2p, bcos::bytes _payload) mutable
                    -> task::Task<void> {
-        P2PMessageV2 message;
-        message.setPacketType(GatewayMessageType::SyncNodeSeq);
-        message.setPayload(std::move(_payload));
+        auto message = std::make_shared<P2PMessageV2>();
+        message->setPacketType(GatewayMessageType::SyncNodeSeq);
+        message->setPayload(std::move(_payload));
         co_await _p2p->broadcastMessageToAll(
-            message, ::ranges::views::single(message.payload()), Options{});
+            message, ::ranges::views::single(message->payload()), Options{});
     }(p2p, std::move(payload)));
 }
 

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -19,6 +19,8 @@
  * @date 2021-05-13
  */
 #include "GatewayNodeManager.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
+#include <bcos-task/Wait.h>
 #include <cstring>
 
 using namespace std;
@@ -369,14 +371,20 @@ void GatewayNodeManager::onRemoveNodeIDs(const P2pID& _p2pID)
 void GatewayNodeManager::broadcastStatusSeq()
 {
     m_timer->restart();
-    auto message =
-        std::static_pointer_cast<P2PMessage>(m_p2pInterface->messageFactory()->buildMessage());
-    message->setPacketType(GatewayMessageType::SyncNodeSeq);
     auto seq = statusSeq();
     auto statusSeq = boost::asio::detail::socket_ops::host_to_network_long(seq);
-    message->setPayload({(byte*)&statusSeq, (byte*)&statusSeq + 4});
+    bytes payload;
+    payload.insert(payload.end(), (byte*)&statusSeq, (byte*)&statusSeq + 4);
     NODE_MANAGER_LOG(TRACE) << LOG_DESC("broadcastStatusSeq") << LOG_KV("seq", seq);
-    m_p2pInterface->asyncBroadcastMessage(message, Options());
+    auto p2p = m_p2pInterface;
+    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send)
+    task::wait([p2p, payload = std::move(payload)]() mutable -> task::Task<void> {
+        P2PMessageV2 message;
+        message.setPacketType(GatewayMessageType::SyncNodeSeq);
+        message.setPayload(std::move(payload));
+        co_await p2p->broadcastMessageToAll(
+            message, ::ranges::views::single(message.payload()), Options{});
+    }());
 }
 
 void GatewayNodeManager::syncLatestNodeIDList()

--- a/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/GatewayNodeManager.cpp
@@ -377,14 +377,17 @@ void GatewayNodeManager::broadcastStatusSeq()
     payload.insert(payload.end(), (byte*)&statusSeq, (byte*)&statusSeq + 4);
     NODE_MANAGER_LOG(TRACE) << LOG_DESC("broadcastStatusSeq") << LOG_KV("seq", seq);
     auto p2p = m_p2pInterface;
-    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send)
-    task::wait([p2p, payload = std::move(payload)]() mutable -> task::Task<void> {
+    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send).
+    // The p2p interface is passed as a coroutine parameter so it is copied into the frame and stays
+    // alive for the whole (possibly deferred) send.
+    task::wait([](P2PInterface::Ptr _p2p, bcos::bytes _payload) mutable
+                   -> task::Task<void> {
         P2PMessageV2 message;
         message.setPacketType(GatewayMessageType::SyncNodeSeq);
-        message.setPayload(std::move(payload));
-        co_await p2p->broadcastMessageToAll(
+        message.setPayload(std::move(_payload));
+        co_await _p2p->broadcastMessageToAll(
             message, ::ranges::views::single(message.payload()), Options{});
-    }());
+    }(p2p, std::move(payload)));
 }
 
 void GatewayNodeManager::syncLatestNodeIDList()

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
@@ -292,7 +292,7 @@ void PeersRouterTable::asyncBroadcastMsg(
 }
 
 bcos::task::Task<void> bcos::gateway::PeersRouterTable::broadcastMessage(uint16_t type,
-    std::string_view group, uint16_t moduleID, const P2PMessage& message,
+    std::string_view group, uint16_t moduleID, const P2PMessageV2& message,
     ::ranges::any_view<bytesConstRef> payloads)
 {
     std::vector<std::string> selectedPeers;

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
@@ -293,7 +293,7 @@ void PeersRouterTable::asyncBroadcastMsg(
 
 bcos::task::Task<void> bcos::gateway::PeersRouterTable::broadcastMessage(uint16_t type,
     std::string_view group, uint16_t moduleID, const P2PMessageV2& message,
-    ::ranges::any_view<bytesConstRef> payloads)
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads)
 {
     std::vector<std::string> selectedPeers;
 

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
@@ -59,7 +59,8 @@ public:
         uint16_t _type, std::string const& _group, uint16_t _moduleID, P2PMessage::Ptr _msg);
 
     task::Task<void> broadcastMessage(uint16_t type, std::string_view group, uint16_t moduleID,
-        const P2PMessageV2& message, ::ranges::any_view<bytesConstRef> payloads);
+        const P2PMessageV2& message,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads);
 
     std::set<P2pID> getAllPeers() const;
     GatewayStatus::Ptr gatewayInfo(std::string const& _uuid);

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
@@ -23,6 +23,7 @@
 #include "bcos-framework/gateway/GroupNodeInfo.h"
 #include "bcos-framework/protocol/ProtocolInfo.h"
 #include "bcos-gateway/libp2p/P2PInterface.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
 #include "bcos-gateway/protocol/GatewayNodeStatus.h"
 #include "bcos-task/Task.h"
 #include <oneapi/tbb/concurrent_unordered_map.h>
@@ -58,7 +59,7 @@ public:
         uint16_t _type, std::string const& _group, uint16_t _moduleID, P2PMessage::Ptr _msg);
 
     task::Task<void> broadcastMessage(uint16_t type, std::string_view group, uint16_t moduleID,
-        const P2PMessage& message, ::ranges::any_view<bytesConstRef> payloads);
+        const P2PMessageV2& message, ::ranges::any_view<bytesConstRef> payloads);
 
     std::set<P2pID> getAllPeers() const;
     GatewayStatus::Ptr gatewayInfo(std::string const& _uuid);

--- a/bcos-gateway/bcos-gateway/libnetwork/Message.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Message.cpp
@@ -1,17 +1,5 @@
 #include "Message.h"
 
-std::size_t bcos::gateway::EncodedMessage::dataSize() const
-{
-    return headerSize() + payloadSize();
-}
-std::size_t bcos::gateway::EncodedMessage::headerSize() const
-{
-    return header.size();
-}
-std::size_t bcos::gateway::EncodedMessage::payloadSize() const
-{
-    return payload.size();
-}
 uint32_t bcos::gateway::MessageFactory::newSeq()
 {
     uint32_t seq = ++m_seq;

--- a/bcos-gateway/bcos-gateway/libnetwork/Message.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Message.h
@@ -54,13 +54,17 @@ public:
 
     virtual uint32_t lengthDirect() const = 0;
     virtual uint32_t length() const = 0;
+    // overwrite the wire length of the message (used e.g. to make outgoing rate limiting charge the
+    // actual wire bytes of a zero-copy message whose payload is not stored in the message object)
+    virtual void setLength(uint32_t length) = 0;
     virtual uint32_t seq() const = 0;
     virtual uint16_t version() const = 0;
     virtual uint16_t packetType() const = 0;
     virtual uint16_t ext() const = 0;
+    virtual void setExt(uint16_t _ext) = 0;
     virtual bool isRespPacket() const = 0;
 
-    [[deprecated("Use encode(EncodedMessage& _buffer)")]] virtual bool encode(
+    [[deprecated("Use encodeHeader(bytes& _buffer)")]] virtual bool encode(
         bcos::bytes& _buffer) = 0;
 
     virtual int32_t decode(const bytesConstRef& _buffer) = 0;

--- a/bcos-gateway/bcos-gateway/libnetwork/Message.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Message.h
@@ -54,9 +54,6 @@ public:
 
     virtual uint32_t lengthDirect() const = 0;
     virtual uint32_t length() const = 0;
-    // overwrite the wire length of the message (used e.g. to make outgoing rate limiting charge the
-    // actual wire bytes of a zero-copy message whose payload is not stored in the message object)
-    virtual void setLength(uint32_t length) = 0;
     virtual uint32_t seq() const = 0;
     virtual uint16_t version() const = 0;
     virtual uint16_t packetType() const = 0;

--- a/bcos-gateway/bcos-gateway/libnetwork/Message.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Message.h
@@ -28,17 +28,6 @@
 namespace bcos::gateway
 {
 
-struct EncodedMessage
-{
-    bcos::bytes header;
-    bcos::bytes payload;
-    bool compress = true;
-
-    std::size_t dataSize() const;
-    std::size_t headerSize() const;
-    std::size_t payloadSize() const;
-};
-
 class Message
 {
 public:
@@ -58,14 +47,12 @@ public:
     virtual uint16_t version() const = 0;
     virtual uint16_t packetType() const = 0;
     virtual uint16_t ext() const = 0;
-    virtual void setExt(uint16_t _ext) = 0;
     virtual bool isRespPacket() const = 0;
 
     [[deprecated("Use encodeHeader(bytes& _buffer)")]] virtual bool encode(
         bcos::bytes& _buffer) = 0;
 
     virtual int32_t decode(const bytesConstRef& _buffer) = 0;
-    virtual bool encode(EncodedMessage& _buffer) const = 0;
     virtual bool encodeHeader(bytes& _buffer) const = 0;
     virtual const std::any& extAttributes() const = 0;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -14,8 +14,11 @@
 #include "bcos-gateway/libnetwork/Message.h"
 #include "bcos-gateway/libnetwork/SessionFace.h"
 #include "bcos-gateway/libnetwork/SocketFace.h"
+#include "bcos-gateway/libp2p/Common.h"  // for c_compressThreshold / c_zstdCompressLevel
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Overloaded.h"
+#include "bcos-utilities/ZstdCompress.h"
+#include <bcos-framework/protocol/Protocol.h>  // for MessageExtFieldFlag
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/throw_exception.hpp>
@@ -215,7 +218,20 @@ void Session::write()
                         {
                             session->m_server.get().asioInterface()->post(
                                 [callback = std::move(payload.m_callback), error = _error]() {
-                                    callback(error);
+                                    // The callback resumes a coroutine whose await_resume may throw
+                                    // (e.g. fastSendMessageWithoutResponse throwing NetworkException
+                                    // on write failure). Catch it here so it cannot escape the
+                                    // io_context::run() loop and crash the io thread.
+                                    try
+                                    {
+                                        callback(error);
+                                    }
+                                    catch (std::exception const& e)
+                                    {
+                                        SESSION_LOG(WARNING)
+                                            << LOG_DESC("write callback exception")
+                                            << LOG_KV("what", boost::diagnostic_information(e));
+                                    }
                                 });
                         }
                     }
@@ -872,22 +888,51 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
         co_return {};
     }
 
-    // The fast path must honour the same pre-send (outgoing rate-limit) check that the callback
-    // path (asyncSendMessage) enforces; otherwise routing sends through fastSendMessage would
-    // silently bypass outgoing bandwidth/QPS limiting. A rejection surfaces as a thrown
-    // NetworkException (e.g. OutBWOverflow / InQPSOverflow) so coroutine retry loops can stop.
-    if (auto result =
-            (m_beforeMessageHandler ? m_beforeMessageHandler(*this, message) : std::nullopt))
-    {
-        const auto& error = result.value();
-        BOOST_THROW_EXCEPTION(NetworkException((int64_t)error.errorCode(), error.errorMessage()));
-    }
-
+    // Encode the header first: when compression (below) applies it sets the COMPRESS ext flag and
+    // the header must be re-encoded to carry it.
     bytes headerBuffer;
     message.encodeHeader(headerBuffer);
 
+    // Zero-copy send by default. When compression is enabled and the payload is large enough (and
+    // the wire format is V2+, same rule as the removed asyncSendMessage path), the payload views
+    // are joined into a frame-owned buffer and compressed; the wire then carries header + the
+    // compressed payload. Both buffers live in this coroutine frame for the whole (deferred) send.
+    bcos::bytes joinedPayload;
+    bcos::bytes compressedPayload;
+    ::ranges::any_view<bytesConstRef> wirePayloads = std::move(payloads);
+    if (m_enableCompress &&
+        message.version() >= (uint16_t)bcos::protocol::ProtocolVersion::V2)
+    {
+        uint32_t payloadSize = 0;
+        for (auto const& ref : wirePayloads)
+        {
+            payloadSize += ref.size();
+        }
+        if (payloadSize > c_compressThreshold)
+        {
+            joinedPayload.reserve(payloadSize);
+            for (auto const& ref : wirePayloads)
+            {
+                joinedPayload.insert(joinedPayload.end(), ref.begin(), ref.end());
+            }
+            if (ZstdCompress::compress(
+                    ref(joinedPayload), compressedPayload, (int)c_zstdCompressLevel))
+            {
+                message.setExt(message.ext() | bcos::protocol::MessageExtFieldFlag::COMPRESS);
+                headerBuffer.clear();
+                message.encodeHeader(headerBuffer);
+                wirePayloads =
+                    ::ranges::views::single(bcos::ref(std::as_const(compressedPayload)));
+            }
+            else
+            {
+                wirePayloads = ::ranges::views::single(bcos::ref(std::as_const(joinedPayload)));
+            }
+        }
+    }
+
     auto view = ::ranges::views::concat(
-        ::ranges::views::single(bcos::ref(std::as_const(headerBuffer))), std::move(payloads));
+        ::ranges::views::single(bcos::ref(std::as_const(headerBuffer))), std::move(wirePayloads));
     uint32_t totalLength = 0;
     for (auto ref : view)
     {
@@ -895,6 +940,32 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     }
     *(uint32_t*)headerBuffer.data() =
         boost::asio::detail::socket_ops::host_to_network_long(totalLength);
+
+    // The fast path must honour the same pre-send (outgoing rate-limit) check that the callback
+    // path (asyncSendMessage) enforces; otherwise routing sends through fastSendMessage would
+    // silently bypass outgoing bandwidth/QPS limiting. The check is charged on the ACTUAL wire
+    // bytes (totalLength including the payload views) — a zero-copy message does not carry its
+    // payload, so message.length() alone would under-count the outgoing traffic. A rejection
+    // surfaces as a thrown NetworkException (e.g. OutBWOverflow / InQPSOverflow) so coroutine
+    // retry loops can stop.
+    message.setLength(totalLength);
+    if (auto result =
+            (m_beforeMessageHandler ? m_beforeMessageHandler(*this, message) : std::nullopt))
+    {
+        const auto& error = result.value();
+        BOOST_THROW_EXCEPTION(NetworkException((int64_t)error.errorCode(), error.errorMessage()));
+    }
+
+    // Restores the allowMaxMsgSize check from the removed asyncSendMessage path: a frame that
+    // exceeds the limit would otherwise be written to the wire and dropped by the peer (breaking
+    // the connection) instead of failing locally and recoverably.
+    if (totalLength > allowMaxMsgSize())
+    {
+        SESSION_LOG(WARNING) << LOG_BADGE("fastSendMessage") << LOG_DESC("msg size overflow")
+                             << LOG_KV("msgSize", totalLength)
+                             << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
+        BOOST_THROW_EXCEPTION(NetworkException(-1, "Msg size overflow"));
+    }
 
     if (c_fileLogLevel <= LogLevel::TRACE)
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -110,7 +110,7 @@ static void send(Session& session, ::ranges::input_range auto payloads,
         // coroutine (fastSendMessageWithoutResponse) is resumed with an error instead of leaking
         // the whole task::wait chain — which would pin the session/socket/service forever. Post to
         // the io thread rather than call inline: await_suspend has not returned yet, and a
-        // synchronous resume would re-enter the awaiting coroutine from inside its own await_suspend.
+        // synchronous resume would re-enter the awaiting coroutine from inside await_suspend.
         if (callback)
         {
             session.m_server.get().asioInterface()->post([callback = std::move(callback)]() {
@@ -258,9 +258,8 @@ void Session::write()
                             session->m_server.get().asioInterface()->post(
                                 [callback = std::move(payload.m_callback), error = _error]() {
                                     // The callback resumes a coroutine whose await_resume may throw
-                                    // (e.g. fastSendMessageWithoutResponse throwing NetworkException
-                                    // on write failure). Catch it here so it cannot escape the
-                                    // io_context::run() loop and crash the io thread.
+                                    // (fastSendMessageWithoutResponse throws NetworkException on
+                                    // write failure). Catch so it cannot escape io_context::run().
                                     try
                                     {
                                         callback(error);
@@ -297,7 +296,9 @@ void Session::write()
                 if (m_server.get().haveNetwork())
                 {
                     m_server.get().asioInterface()->post(
-                        [callback = std::move(cb)]() { callback(boost::asio::error::operation_aborted); });
+                        [callback = std::move(cb)]() {
+                            callback(boost::asio::error::operation_aborted);
+                        });
                 }
                 else
                 {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -106,6 +106,17 @@ static void send(Session& session, ::ranges::input_range auto payloads,
 {
     if (!session.active() || !session.m_socket->isConnected())
     {
+        // The zero-copy fast path's completion callback must still fire (once) so the suspended
+        // coroutine (fastSendMessageWithoutResponse) is resumed with an error instead of leaking
+        // the whole task::wait chain — which would pin the session/socket/service forever. Post to
+        // the io thread rather than call inline: await_suspend has not returned yet, and a
+        // synchronous resume would re-enter the awaiting coroutine from inside its own await_suspend.
+        if (callback)
+        {
+            session.m_server.get().asioInterface()->post([callback = std::move(callback)]() {
+                callback(boost::asio::error::not_connected);
+            });
+        }
         return;
     }
 
@@ -273,6 +284,31 @@ void Session::drop(DisconnectReason _reason)
     auto socket = m_socket;
 
     m_active = false;
+
+    // Fail any queued zero-copy sends: their completion callbacks resume suspended coroutine
+    // chains (fastSendMessageWithoutResponse). Without this, a session that disappears before the
+    // write completes would leak the whole task::wait chain — including the strong refs to the
+    // session/socket/service it captured (a broadcast fan-out multiplies this by the peer count).
+    // In-flight writes (m_writings) are covered by the asyncWrite completion handler, which
+    // already invokes their callbacks with the error when the socket close cancels the write.
+    // Also covers Session::write()'s early returns: they call drop(TCPError) right after the
+    // payload has been pushed into m_writeQueue.
+    Payload payload;
+    while (m_writeQueue.try_pop(payload))
+    {
+        if (payload.m_callback)
+        {
+            try
+            {
+                payload.m_callback(boost::asio::error::operation_aborted);
+            }
+            catch (std::exception const& e)
+            {
+                SESSION_LOG(WARNING) << LOG_DESC("write callback exception during drop")
+                                     << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }
+    }
 
     int errorCode = P2PExceptionType::Disconnect;
     std::string errorMsg = "Disconnect";

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -132,6 +132,28 @@ static void send(Session& session, ::ranges::input_range auto payloads,
     }
 
     session.m_writeQueue.push(std::move(payload));
+    // FIB-185 (review): re-check the session state AFTER the push. drop() may have drained the
+    // queue (CAS won) between the active() check above and this push, in which case this
+    // payload's callback would never fire and the whole task::wait chain would leak (it pins the
+    // session/socket/service forever). Either drop()'s drain already popped our payload (its
+    // callback then fires with operation_aborted), or this re-check sees an inactive session and
+    // drains it here. Both paths complete the callback exactly once through the same posted
+    // channel used by the early-return branch above.
+    if (!session.active())
+    {
+        Payload pending;
+        while (session.m_writeQueue.try_pop(pending))
+        {
+            if (pending.m_callback)
+            {
+                session.m_server.get().asioInterface()->post(
+                    [callback = std::move(pending.m_callback)]() {
+                        callback(boost::asio::error::not_connected);
+                    });
+            }
+        }
+        return;
+    }
     session.write();
 }
 
@@ -261,6 +283,38 @@ void Session::write()
     {
         SESSION_LOG(ERROR) << LOG_DESC("write error") << LOG_KV("endpoint", nodeIPEndpoint())
                            << LOG_KV("what", boost::diagnostic_information(e));
+        // FIB-185 (review): when asyncWrite throws, the payloads have already been moved into
+        // m_writings->payloads and the completion handler was never registered, so their callbacks
+        // would never fire (drop() only drains m_writeQueue, and this catch runs before any
+        // completion handler exists). Fail them here — posted rather than inline, for the same
+        // reason as drop()'s drain: this catch runs on the caller's stack, which may still be
+        // inside an await_suspend.
+        for (auto& p : m_writings->payloads)
+        {
+            if (p.m_callback)
+            {
+                auto cb = std::move(p.m_callback);
+                if (m_server.get().haveNetwork())
+                {
+                    m_server.get().asioInterface()->post(
+                        [callback = std::move(cb)]() { callback(boost::asio::error::operation_aborted); });
+                }
+                else
+                {
+                    try
+                    {
+                        cb(boost::asio::error::operation_aborted);
+                    }
+                    catch (std::exception const& e2)
+                    {
+                        SESSION_LOG(WARNING)
+                            << LOG_DESC("write callback exception")
+                            << LOG_KV("what", boost::diagnostic_information(e2));
+                    }
+                }
+            }
+        }
+        m_writings->payloads.clear();
         drop(TCPError);
         return;
     }
@@ -293,19 +347,37 @@ void Session::drop(DisconnectReason _reason)
     // already invokes their callbacks with the error when the socket close cancels the write.
     // Also covers Session::write()'s early returns: they call drop(TCPError) right after the
     // payload has been pushed into m_writeQueue.
+    //
+    // FIB-185 (review): complete these callbacks OFF the caller's stack. drop() is reachable from
+    // Session::write()'s early-return path, which runs on the stack of a sender that is still
+    // inside its own await_suspend — calling the callback inline there would resume that coroutine
+    // from inside its own await_suspend (the exact hazard send()'s early-return branch avoids by
+    // posting). Post to the shared pool; when the host is already gone there is no live executor
+    // to hand it to, so fall back to inline — the same shape as the notifyDisconnect / closeSocket
+    // branches below.
     Payload payload;
     while (m_writeQueue.try_pop(payload))
     {
         if (payload.m_callback)
         {
-            try
+            if (m_server.get().haveNetwork())
             {
-                payload.m_callback(boost::asio::error::operation_aborted);
+                m_server.get().asioInterface()->post(
+                    [callback = std::move(payload.m_callback)]() {
+                        callback(boost::asio::error::operation_aborted);
+                    });
             }
-            catch (std::exception const& e)
+            else
             {
-                SESSION_LOG(WARNING) << LOG_DESC("write callback exception during drop")
-                                     << LOG_KV("what", boost::diagnostic_information(e));
+                try
+                {
+                    payload.m_callback(boost::asio::error::operation_aborted);
+                }
+                catch (std::exception const& e)
+                {
+                    SESSION_LOG(WARNING) << LOG_DESC("write callback exception during drop")
+                                         << LOG_KV("what", boost::diagnostic_information(e));
+                }
             }
         }
     }
@@ -1014,9 +1086,14 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
         boost::asio::detail::socket_ops::host_to_network_long(totalLength);
 
     // The pre-send checks run in the same order as the removed asyncSendMessage path (active →
-    // allowMaxMsgSize → beforeMessageHandler). The outgoing rate-limit handler receives the ACTUAL
-    // wire bytes (totalLength including the payload views) explicitly — a zero-copy message does
-    // not carry its payload, so message.length() alone would under-count the outgoing traffic.
+    // allowMaxMsgSize → beforeMessageHandler), but the size limit is judged on the COMPRESSED wire
+    // bytes (totalLength, computed above after compression) rather than the pre-compression
+    // estimate the old path used: the peer's read side (Session::doRead) rejects frames by the
+    // on-the-wire length too, so a message that only fits after compression is accepted here and
+    // decodes on the peer — this is an intentional, documented divergence from asyncSendMessage.
+    // The outgoing rate-limit handler receives the ACTUAL wire bytes (totalLength including the
+    // payload views) explicitly — a zero-copy message does not carry its payload, so
+    // message.length() alone would under-count the outgoing traffic.
     if (totalLength > allowMaxMsgSize())
     {
         SESSION_LOG(WARNING) << LOG_BADGE("fastSendMessage") << LOG_DESC("msg size overflow")

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -37,6 +37,11 @@
 using namespace bcos;
 using namespace bcos::gateway;
 
+// ext field offset in the fixed base P2P header: length(4) | version(2) | packetType(2) |
+// seq(4) | ext(2). ext is the last field of the base header (P2PMessage::MESSAGE_HEADER_LENGTH
+// = 14); the V2 ttl/src/dst extension follows it.
+constexpr size_t c_p2pHeaderExtOffset = 12;  // P2PMessage::MESSAGE_HEADER_LENGTH(14) - 2
+
 Session::Session(
     std::shared_ptr<SocketFace> socket, Host& server, size_t _recvBufferSize, bool _forceSize)
   : m_maxRecvBufferSize(std::max<size_t>(_recvBufferSize, MIN_SESSION_RECV_BUFFER_SIZE)),
@@ -774,13 +779,13 @@ void Session::checkNetworkStatus()
 
 template <typename View>
 task::Task<Message::Ptr> fastSendMessageWithResponse(
-    Session& session, Message& message, View& view, Options& options)
+    Session& session, const Message& message, View& view, Options& options)
 {
     struct Awaitable
     {
         std::reference_wrapper<Options> m_options;
         std::reference_wrapper<Host> m_host;
-        std::reference_wrapper<Message> m_message;
+        std::reference_wrapper<const Message> m_message;
         std::weak_ptr<Session> m_self;
         std::reference_wrapper<SessionCallbackManagerInterface> m_sessionCallbackManager;
         std::reference_wrapper<View> m_view;
@@ -881,7 +886,7 @@ task::Task<void> fastSendMessageWithoutResponse(Session& session, View view)
 }
 
 bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
-    Message& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    const Message& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
 {
     if (!active())
     {
@@ -899,8 +904,10 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
         payloadRefs.push_back(ref);
     }
 
-    // Encode the header first: when compression (below) applies it sets the COMPRESS ext flag and
-    // the header must be re-encoded to carry it.
+    // Encode the base header once. When compression (below) applies, the COMPRESS flag is stamped
+    // directly onto the encoded header's ext field — the caller's message is left untouched (it is
+    // const), so a reused message object (broadcast fan-out / retry loop) can never leak the flag
+    // to a peer that receives an uncompressed frame.
     bytes headerBuffer;
     message.encodeHeader(headerBuffer);
 
@@ -908,10 +915,7 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     // the wire format is V2+ — the same rule as the removed asyncSendMessage path, P2PMessage::
     // tryToCompressPayload also requires V2), the payload views are joined into a frame-owned
     // buffer and compressed; the wire then carries header + the compressed payload. Both buffers
-    // live in this coroutine frame for the whole (deferred) send. The COMPRESS ext flag is set
-    // TRANSIENTLY: it is restored right after the header re-encode, so a reused message object
-    // (broadcast fan-out / retry loop) never leaks the flag to a peer that receives an
-    // uncompressed frame — which would make that peer fail to decompress and drop the connection.
+    // live in this coroutine frame for the whole (deferred) send.
     bcos::bytes joinedPayload;
     bcos::bytes compressedPayload;
     ::ranges::any_view<bytesConstRef, ::ranges::category::forward> wirePayloads =
@@ -934,12 +938,12 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
             if (ZstdCompress::compress(
                     ref(joinedPayload), compressedPayload, (int)c_zstdCompressLevel))
             {
-                const auto originalExt = message.ext();
-                message.setExt(originalExt | bcos::protocol::MessageExtFieldFlag::COMPRESS);
-                headerBuffer.clear();
-                message.encodeHeader(headerBuffer);
-                // transient: restore the caller's ext — the flag only rides on this frame's header
-                message.setExt(originalExt);
+                // stamp the COMPRESS flag onto the encoded header only (ext field of the fixed
+                // base header), before the frame is written to the wire
+                const auto compressedExt = static_cast<uint16_t>(
+                    message.ext() | bcos::protocol::MessageExtFieldFlag::COMPRESS);
+                *(uint16_t*)(headerBuffer.data() + c_p2pHeaderExtOffset) =
+                    boost::asio::detail::socket_ops::host_to_network_short(compressedExt);
                 wirePayloads =
                     ::ranges::views::single(bcos::ref(std::as_const(compressedPayload)));
             }
@@ -961,22 +965,9 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
         boost::asio::detail::socket_ops::host_to_network_long(totalLength);
 
     // The pre-send checks run in the same order as the removed asyncSendMessage path (active →
-    // allowMaxMsgSize → beforeMessageHandler). The message length is set TRANSIENTLY so the
-    // rate-limit handler can charge the actual wire bytes (a zero-copy message does not carry its
-    // payload, so message.length() alone would under-count); the guard restores the caller's
-    // length on both the normal and the throw paths, before the first suspension, so a reused
-    // message object is never left with a stale length.
-    struct MessageLengthGuard
-    {
-        Message& m_message;
-        uint32_t m_original;
-        ~MessageLengthGuard() { m_message.setLength(m_original); }
-    } lengthGuard{message, message.lengthDirect()};
-    message.setLength(totalLength);
-
-    // Restores the allowMaxMsgSize check from the removed asyncSendMessage path: a frame that
-    // exceeds the limit would otherwise be written to the wire and dropped by the peer (breaking
-    // the connection) instead of failing locally and recoverably.
+    // allowMaxMsgSize → beforeMessageHandler). The outgoing rate-limit handler receives the ACTUAL
+    // wire bytes (totalLength including the payload views) explicitly — a zero-copy message does
+    // not carry its payload, so message.length() alone would under-count the outgoing traffic.
     if (totalLength > allowMaxMsgSize())
     {
         SESSION_LOG(WARNING) << LOG_BADGE("fastSendMessage") << LOG_DESC("msg size overflow")
@@ -989,8 +980,9 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     // path (asyncSendMessage) enforces; otherwise routing sends through fastSendMessage would
     // silently bypass outgoing bandwidth/QPS limiting. A rejection surfaces as a thrown
     // NetworkException (e.g. OutBWOverflow / InQPSOverflow) so coroutine retry loops can stop.
-    if (auto result =
-            (m_beforeMessageHandler ? m_beforeMessageHandler(*this, message) : std::nullopt))
+    if (auto result = (m_beforeMessageHandler ?
+                           m_beforeMessageHandler(*this, message, totalLength) :
+                           std::nullopt))
     {
         const auto& error = result.value();
         BOOST_THROW_EXCEPTION(NetworkException((int64_t)error.errorCode(), error.errorMessage()));
@@ -1129,7 +1121,7 @@ void bcos::gateway::Session::setMessageHandler(
     m_messageHandler = std::move(messageHandler);
 }
 void bcos::gateway::Session::setBeforeMessageHandler(
-    std::function<std::optional<bcos::Error>(SessionFace&, Message&)> handler)
+    std::function<std::optional<bcos::Error>(SessionFace&, const Message&, uint32_t)> handler)
 {
     m_beforeMessageHandler = std::move(handler);
 }

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -909,7 +909,20 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     // const), so a reused message object (broadcast fan-out / retry loop) can never leak the flag
     // to a peer that receives an uncompressed frame.
     bytes headerBuffer;
-    message.encodeHeader(headerBuffer);
+    if (!message.encodeHeader(headerBuffer))
+    {
+        // e.g. P2PMessageOptions::encode failed (empty/oversized src/dst IDs). Sending a frame
+        // whose header claims "has options" while the options are missing would make the peer
+        // drop the connection instead of the message.
+        BOOST_THROW_EXCEPTION(NetworkException(-1, "encode header failed"));
+    }
+    // encodeHeader always emits the fixed 14-byte base header (options are appended after it, and
+    // option-encoding failures above are already rejected); guard the two fixed-offset writes
+    // below defensively anyway.
+    if (headerBuffer.size() < c_p2pHeaderExtOffset + sizeof(uint16_t))
+    {
+        BOOST_THROW_EXCEPTION(NetworkException(-1, "encode header failed: header too short"));
+    }
 
     // Zero-copy send by default. When compression is enabled and the payload is large enough (and
     // the wire format is V2+ — the same rule as the removed asyncSendMessage path, P2PMessage::
@@ -990,10 +1003,15 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
 
     if (c_fileLogLevel <= LogLevel::TRACE)
     {
+        // Log the ext actually on the wire (the header's ext field), not the caller's ext: when
+        // compression applied, the wire header carries the COMPRESS bit that message.ext() does
+        // not have — a future "peer failed to decompress" investigation must read the wire value.
+        const uint16_t wireExt = boost::asio::detail::socket_ops::network_to_host_short(
+            *reinterpret_cast<uint16_t const*>(headerBuffer.data() + c_p2pHeaderExtOffset));
         SESSION_LOG(TRACE) << LOG_DESC("Session fastSendMessage")
                            << LOG_KV("endpoint", nodeIPEndpoint()) << LOG_KV("seq", message.seq())
-                           << LOG_KV("packetType", message.packetType())
-                           << LOG_KV("ext", message.ext()) << LOG_KV("this", this);
+                           << LOG_KV("packetType", message.packetType()) << LOG_KV("ext", wireExt)
+                           << LOG_KV("this", this);
     }
     if (options.response)
     {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -92,17 +92,6 @@ bool Session::active(Host& server) const
     return m_active && server.haveNetwork() && m_socket && m_socket->isConnected();
 }
 
-static void send(Session& session, EncodedMessage encodedMsg)
-{
-    if (!session.active() || !session.m_socket->isConnected())
-    {
-        return;
-    }
-
-    session.m_writeQueue.push({.m_data = std::move(encodedMsg), .m_callback = {}});
-    session.write();
-}
-
 static void send(Session& session, ::ranges::input_range auto payloads,
     std::function<void(boost::system::error_code)> callback)
 {
@@ -111,8 +100,8 @@ static void send(Session& session, ::ranges::input_range auto payloads,
         return;
     }
 
-    Payload payload{.m_data{Payload::MessageList{}}, .m_callback = std::move(callback)};
-    auto& vec = std::get<1>(payload.m_data);
+    Payload payload{.m_data = Payload::MessageList{}, .m_callback = std::move(callback)};
+    auto& vec = payload.m_data;
     if constexpr (::ranges::sized_range<decltype(payloads)>)
     {
         vec.reserve(::ranges::size(payloads));
@@ -124,104 +113,6 @@ static void send(Session& session, ::ranges::input_range auto payloads,
 
     session.m_writeQueue.push(std::move(payload));
     session.write();
-}
-
-void Session::asyncSendMessage(Message::Ptr message, Options options, SessionCallbackFunc callback)
-{
-    if (!active(m_server))
-    {
-        SESSION_LOG(WARNING) << "Session inactive";
-        if (callback)
-        {
-            m_server.get().asioInterface()->dispatch([callback = std::move(callback)] {
-                callback(NetworkException(-1, "Session inactive"), Message::Ptr());
-            });
-        }
-        return;
-    }
-
-    // Notice: check message size overflow, if msg->length() > allowMaxMsgSize()
-    if (message->length() > allowMaxMsgSize())
-    {
-        SESSION_LOG(WARNING) << LOG_BADGE("asyncSendMessage") << LOG_DESC("msg size overflow")
-                             << LOG_KV("msgSize", message->length())
-                             << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
-        if (callback)
-        {
-            m_server.get().asioInterface()->dispatch([callback = std::move(callback)] {
-                callback(NetworkException(-1, "Msg size overflow"), Message::Ptr());
-            });
-        }
-        return;
-    }
-
-    auto session = shared_from_this();
-
-    if (auto result =
-            (m_beforeMessageHandler ? m_beforeMessageHandler(*session, *message) : std::nullopt))
-    {
-        if (callback && result.has_value())
-        {
-            const auto& error = result.value();
-            auto errorCode = error.errorCode();
-            auto errorMessage = error.errorMessage();
-            m_server.get().asioInterface()->dispatch([callback = std::move(callback), errorCode,
-                                                         errorMessage = std::move(errorMessage)] {
-                callback(NetworkException((int64_t)errorCode, errorMessage), Message::Ptr());
-            });
-        }
-        return;
-    }
-
-    if (callback)
-    {
-        auto handler = std::make_shared<ResponseCallback>();
-        handler->callback = callback;
-        if (options.timeout > 0)
-        {
-            handler->timeoutHandler.emplace(
-                m_server.get().asioInterface()->newTimer(options.timeout));
-            auto seq = message->seq();
-            handler->timeoutHandler->async_wait(
-                [sessionWeak = std::weak_ptr<Session>(shared_from_this()), seq](
-                    const boost::system::error_code& _error) {
-                    try
-                    {
-                        auto session = sessionWeak.lock();
-                        if (!session)
-                        {
-                            return;
-                        }
-                        session->onTimeout(_error, seq);
-                    }
-                    catch (std::exception const& e)
-                    {
-                        SESSION_LOG(WARNING) << LOG_DESC("async_wait exception")
-                                             << LOG_KV("message", boost::diagnostic_information(e));
-                    }
-                });
-            handler->startTime = utcSteadyTime();
-        }
-
-        m_sessionCallbackManager->addCallback(message->seq(), handler);
-    }
-
-    EncodedMessage encodedMessage;
-    encodedMessage.compress = m_enableCompress;
-    message->encode(encodedMessage);
-
-    if (c_fileLogLevel <= LogLevel::TRACE)
-    {
-        SESSION_LOG(TRACE) << LOG_DESC("Session asyncSendMessage")
-                           << LOG_KV("endpoint", nodeIPEndpoint()) << LOG_KV("seq", message->seq())
-                           << LOG_KV("packetType", message->packetType())
-                           << LOG_KV("ext", message->ext())
-                           << LOG_KV("src", printShortP2pID(message->srcP2PNodeID()))
-                           << LOG_KV("dst", printShortP2pID(message->dstP2PNodeID()))
-                           << LOG_KV("this", this);
-    }
-
-    send(*this, encodedMessage);
 }
 
 std::size_t Session::writeQueueSize()
@@ -866,13 +757,13 @@ void Session::checkNetworkStatus()
 
 template <typename View>
 task::Task<Message::Ptr> fastSendMessageWithResponse(
-    Session& session, const Message& message, View& view, Options& options)
+    Session& session, Message& message, View& view, Options& options)
 {
     struct Awaitable
     {
         std::reference_wrapper<Options> m_options;
         std::reference_wrapper<Host> m_host;
-        std::reference_wrapper<const Message> m_message;
+        std::reference_wrapper<Message> m_message;
         std::weak_ptr<Session> m_self;
         std::reference_wrapper<SessionCallbackManagerInterface> m_sessionCallbackManager;
         std::reference_wrapper<View> m_view;
@@ -973,12 +864,23 @@ task::Task<void> fastSendMessageWithoutResponse(Session& session, View view)
 }
 
 bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
-    const Message& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    Message& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
 {
     if (!active())
     {
         SESSION_LOG(WARNING) << "Session inactive";
         co_return {};
+    }
+
+    // The fast path must honour the same pre-send (outgoing rate-limit) check that the callback
+    // path (asyncSendMessage) enforces; otherwise routing sends through fastSendMessage would
+    // silently bypass outgoing bandwidth/QPS limiting. A rejection surfaces as a thrown
+    // NetworkException (e.g. OutBWOverflow / InQPSOverflow) so coroutine retry loops can stop.
+    if (auto result =
+            (m_beforeMessageHandler ? m_beforeMessageHandler(*this, message) : std::nullopt))
+    {
+        const auto& error = result.value();
+        BOOST_THROW_EXCEPTION(NetworkException((int64_t)error.errorCode(), error.errorMessage()));
     }
 
     bytes headerBuffer;
@@ -1014,16 +916,8 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
 
 size_t bcos::gateway::Payload::size() const
 {
-    return std::visit(
-        bcos::overloaded(
-            [](const EncodedMessage& encodedMessage) -> size_t {
-                return encodedMessage.header.size() + encodedMessage.payload.size();
-            },
-            [](const boost::container::small_vector<bytesConstRef, 3>& refs) {
-                return ::ranges::accumulate(refs, size_t(0),
-                    [](size_t sum, const bytesConstRef& ref) { return sum + ref.size(); });
-            }),
-        m_data);
+    return ::ranges::accumulate(m_data, size_t(0),
+        [](size_t sum, const bytesConstRef& ref) { return sum + ref.size(); });
 }
 std::size_t bcos::gateway::SessionRecvBuffer::readPos() const
 {

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.cpp
@@ -28,6 +28,7 @@
 #include <functional>
 #include <iterator>
 #include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/view/all.hpp>
 #include <range/v3/view/concat.hpp>
 #include <range/v3/view/single.hpp>
 #include <utility>
@@ -888,39 +889,57 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
         co_return {};
     }
 
+    // Materialize the payload views once: the incoming any_view is category::input (single-pass),
+    // while the compression/join and the length passes below each iterate the payloads. Copying
+    // the (cheap) views into a forward container makes every later pass multi-pass safe without
+    // changing the interface contract.
+    boost::container::small_vector<bytesConstRef, 3> payloadRefs;
+    for (auto const& ref : payloads)
+    {
+        payloadRefs.push_back(ref);
+    }
+
     // Encode the header first: when compression (below) applies it sets the COMPRESS ext flag and
     // the header must be re-encoded to carry it.
     bytes headerBuffer;
     message.encodeHeader(headerBuffer);
 
     // Zero-copy send by default. When compression is enabled and the payload is large enough (and
-    // the wire format is V2+, same rule as the removed asyncSendMessage path), the payload views
-    // are joined into a frame-owned buffer and compressed; the wire then carries header + the
-    // compressed payload. Both buffers live in this coroutine frame for the whole (deferred) send.
+    // the wire format is V2+ — the same rule as the removed asyncSendMessage path, P2PMessage::
+    // tryToCompressPayload also requires V2), the payload views are joined into a frame-owned
+    // buffer and compressed; the wire then carries header + the compressed payload. Both buffers
+    // live in this coroutine frame for the whole (deferred) send. The COMPRESS ext flag is set
+    // TRANSIENTLY: it is restored right after the header re-encode, so a reused message object
+    // (broadcast fan-out / retry loop) never leaks the flag to a peer that receives an
+    // uncompressed frame — which would make that peer fail to decompress and drop the connection.
     bcos::bytes joinedPayload;
     bcos::bytes compressedPayload;
-    ::ranges::any_view<bytesConstRef> wirePayloads = std::move(payloads);
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> wirePayloads =
+        ::ranges::views::all(payloadRefs);
     if (m_enableCompress &&
         message.version() >= (uint16_t)bcos::protocol::ProtocolVersion::V2)
     {
         uint32_t payloadSize = 0;
-        for (auto const& ref : wirePayloads)
+        for (auto const& ref : payloadRefs)
         {
             payloadSize += ref.size();
         }
         if (payloadSize > c_compressThreshold)
         {
             joinedPayload.reserve(payloadSize);
-            for (auto const& ref : wirePayloads)
+            for (auto const& ref : payloadRefs)
             {
                 joinedPayload.insert(joinedPayload.end(), ref.begin(), ref.end());
             }
             if (ZstdCompress::compress(
                     ref(joinedPayload), compressedPayload, (int)c_zstdCompressLevel))
             {
-                message.setExt(message.ext() | bcos::protocol::MessageExtFieldFlag::COMPRESS);
+                const auto originalExt = message.ext();
+                message.setExt(originalExt | bcos::protocol::MessageExtFieldFlag::COMPRESS);
                 headerBuffer.clear();
                 message.encodeHeader(headerBuffer);
+                // transient: restore the caller's ext — the flag only rides on this frame's header
+                message.setExt(originalExt);
                 wirePayloads =
                     ::ranges::views::single(bcos::ref(std::as_const(compressedPayload)));
             }
@@ -941,20 +960,19 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
     *(uint32_t*)headerBuffer.data() =
         boost::asio::detail::socket_ops::host_to_network_long(totalLength);
 
-    // The fast path must honour the same pre-send (outgoing rate-limit) check that the callback
-    // path (asyncSendMessage) enforces; otherwise routing sends through fastSendMessage would
-    // silently bypass outgoing bandwidth/QPS limiting. The check is charged on the ACTUAL wire
-    // bytes (totalLength including the payload views) — a zero-copy message does not carry its
-    // payload, so message.length() alone would under-count the outgoing traffic. A rejection
-    // surfaces as a thrown NetworkException (e.g. OutBWOverflow / InQPSOverflow) so coroutine
-    // retry loops can stop.
-    message.setLength(totalLength);
-    if (auto result =
-            (m_beforeMessageHandler ? m_beforeMessageHandler(*this, message) : std::nullopt))
+    // The pre-send checks run in the same order as the removed asyncSendMessage path (active →
+    // allowMaxMsgSize → beforeMessageHandler). The message length is set TRANSIENTLY so the
+    // rate-limit handler can charge the actual wire bytes (a zero-copy message does not carry its
+    // payload, so message.length() alone would under-count); the guard restores the caller's
+    // length on both the normal and the throw paths, before the first suspension, so a reused
+    // message object is never left with a stale length.
+    struct MessageLengthGuard
     {
-        const auto& error = result.value();
-        BOOST_THROW_EXCEPTION(NetworkException((int64_t)error.errorCode(), error.errorMessage()));
-    }
+        Message& m_message;
+        uint32_t m_original;
+        ~MessageLengthGuard() { m_message.setLength(m_original); }
+    } lengthGuard{message, message.lengthDirect()};
+    message.setLength(totalLength);
 
     // Restores the allowMaxMsgSize check from the removed asyncSendMessage path: a frame that
     // exceeds the limit would otherwise be written to the wire and dropped by the peer (breaking
@@ -965,6 +983,17 @@ bcos::task::Task<Message::Ptr> bcos::gateway::Session::fastSendMessage(
                              << LOG_KV("msgSize", totalLength)
                              << LOG_KV("allowMaxMsgSize", allowMaxMsgSize());
         BOOST_THROW_EXCEPTION(NetworkException(-1, "Msg size overflow"));
+    }
+
+    // The fast path must honour the same pre-send (outgoing rate-limit) check that the callback
+    // path (asyncSendMessage) enforces; otherwise routing sends through fastSendMessage would
+    // silently bypass outgoing bandwidth/QPS limiting. A rejection surfaces as a thrown
+    // NetworkException (e.g. OutBWOverflow / InQPSOverflow) so coroutine retry loops can stop.
+    if (auto result =
+            (m_beforeMessageHandler ? m_beforeMessageHandler(*this, message) : std::nullopt))
+    {
+        const auto& error = result.value();
+        BOOST_THROW_EXCEPTION(NetworkException((int64_t)error.errorCode(), error.errorMessage()));
     }
 
     if (c_fileLogLevel <= LogLevel::TRACE)

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -114,7 +114,7 @@ public:
     void start() override;
     void disconnect(DisconnectReason _reason) override;
 
-    task::Task<Message::Ptr> fastSendMessage(Message& message,
+    task::Task<Message::Ptr> fastSendMessage(const Message& message,
         ::ranges::any_view<bytesConstRef> payloads, Options options) override;
 
     NodeIPEndpoint nodeIPEndpoint() const override;
@@ -143,10 +143,11 @@ public:
         std::function<void(NetworkException, SessionFace::Ptr, Message::Ptr)> messageHandler)
         override;
 
-    // handle before sending message, if the check fails, meaning false is returned, the message
-    // is not sent, and the SessionCallbackFunc will be performed
-    void setBeforeMessageHandler(
-        std::function<std::optional<bcos::Error>(SessionFace&, Message&)> handler) override;
+    // handle before sending message: if the check fails (returns an error), the message is not
+    // sent and a NetworkException surfaces so coroutine retry loops can stop. The handler receives
+    // the actual wire length (payload views included) as _wireLength.
+    void setBeforeMessageHandler(std::function<std::optional<bcos::Error>(
+        SessionFace&, const Message&, uint32_t _wireLength)> handler) override;
 
     void setHostInfo(P2PInfo _hostInfo);
 
@@ -258,7 +259,8 @@ public:
 
     SessionCallbackManagerInterface::Ptr m_sessionCallbackManager;
     std::function<void(NetworkException, SessionFace::Ptr, Message::Ptr)> m_messageHandler;
-    std::function<std::optional<bcos::Error>(SessionFace&, Message&)> m_beforeMessageHandler;
+    std::function<std::optional<bcos::Error>(
+        SessionFace&, const Message&, uint32_t)> m_beforeMessageHandler;
 
     uint64_t m_shutDownTimeThres = 50000;
     // 1min

--- a/bcos-gateway/bcos-gateway/libnetwork/Session.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/Session.h
@@ -74,24 +74,16 @@ private:
 struct Payload
 {
     using MessageList = boost::container::small_vector<bytesConstRef, 3>;
-    std::variant<EncodedMessage, MessageList> m_data;
+    MessageList m_data;
     std::function<void(boost::system::error_code)> m_callback;
 
     size_t size() const;
     void toConstBuffer(std::output_iterator<boost::asio::const_buffer> auto output) const
     {
-        std::visit(bcos::overloaded(
-                       [&](const EncodedMessage& encodedMessage) {
-                           *output = {encodedMessage.header.data(), encodedMessage.header.size()};
-                           *output = {encodedMessage.payload.data(), encodedMessage.payload.size()};
-                       },
-                       [&](const MessageList& refs) {
-                           for (const auto& ref : refs)
-                           {
-                               *output = {ref.data(), ref.size()};
-                           }
-                       }),
-            m_data);
+        for (const auto& ref : m_data)
+        {
+            *output = {ref.data(), ref.size()};
+        }
     }
 };
 
@@ -122,10 +114,7 @@ public:
     void start() override;
     void disconnect(DisconnectReason _reason) override;
 
-    void asyncSendMessage(Message::Ptr message, Options options,
-        SessionCallbackFunc callback = SessionCallbackFunc()) override;
-
-    task::Task<Message::Ptr> fastSendMessage(const Message& message,
+    task::Task<Message::Ptr> fastSendMessage(Message& message,
         ::ranges::any_view<bytesConstRef> payloads, Options options) override;
 
     NodeIPEndpoint nodeIPEndpoint() const override;

--- a/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
@@ -43,15 +43,18 @@ public:
     virtual void disconnect(DisconnectReason) = 0;
 
     virtual task::Task<Message::Ptr> fastSendMessage(
-        Message& header, ::ranges::any_view<bytesConstRef> payloads, Options options) = 0;
+        const Message& header, ::ranges::any_view<bytesConstRef> payloads, Options options) = 0;
 
     virtual std::shared_ptr<SocketFace> socket() = 0;
 
     virtual void setMessageHandler(
         std::function<void(NetworkException, SessionFace::Ptr, Message::Ptr)> messageHandler) = 0;
 
-    virtual void setBeforeMessageHandler(
-        std::function<std::optional<bcos::Error>(SessionFace&, Message&)> handler) = 0;
+    // Outgoing pre-send check (rate limiting). _wireLength is the actual frame size including the
+    // payload views — a zero-copy message does not carry its payload, so message.length() alone
+    // under-counts.
+    virtual void setBeforeMessageHandler(std::function<std::optional<bcos::Error>(
+        SessionFace&, const Message&, uint32_t _wireLength)> handler) = 0;
 
     virtual NodeIPEndpoint nodeIPEndpoint() const = 0;
 

--- a/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
+++ b/bcos-gateway/bcos-gateway/libnetwork/SessionFace.h
@@ -42,11 +42,8 @@ public:
     virtual void start() = 0;
     virtual void disconnect(DisconnectReason) = 0;
 
-    virtual void asyncSendMessage(
-        Message::Ptr, Options = Options(), SessionCallbackFunc = SessionCallbackFunc()) = 0;
-
     virtual task::Task<Message::Ptr> fastSendMessage(
-        const Message& header, ::ranges::any_view<bytesConstRef> payloads, Options options) = 0;
+        Message& header, ::ranges::any_view<bytesConstRef> payloads, Options options) = 0;
 
     virtual std::shared_ptr<SocketFace> socket() = 0;
 

--- a/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
@@ -44,9 +44,10 @@ public:
         ::ranges::any_view<bytesConstRef> payloads, Options options = {}) = 0;
     virtual void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) = 0;
 
-    // (coroutine) broadcast a message to all connected/reachable nodes. The message and the payload
-    // views must be kept alive by the caller for the duration of the co_await.
-    virtual task::Task<void> broadcastMessageToAll(P2PMessage& message,
+    // (coroutine) broadcast a message to all connected/reachable nodes. The message is handed over
+    // as a shared_ptr: the per-peer fan-out tasks keep it alive (the payload rides as a view,
+    // zero-copy).
+    virtual task::Task<void> broadcastMessageToAll(P2PMessage::Ptr message,
         ::ranges::any_view<bytesConstRef> payloads, Options options = {}) = 0;
 
     virtual P2PInfos sessionInfos() = 0;

--- a/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
@@ -48,7 +48,8 @@ public:
     // as a shared_ptr: the per-peer fan-out tasks keep it alive (the payload rides as a view,
     // zero-copy).
     virtual task::Task<void> broadcastMessageToAll(P2PMessage::Ptr message,
-        ::ranges::any_view<bytesConstRef> payloads, Options options = {}) = 0;
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
+        Options options = {}) = 0;
 
     virtual P2PInfos sessionInfos() = 0;
     virtual P2PInfo localP2pInfo() = 0;

--- a/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
@@ -44,6 +44,11 @@ public:
         ::ranges::any_view<bytesConstRef> payloads, Options options = {}) = 0;
     virtual void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) = 0;
 
+    // (coroutine) broadcast a message to all connected/reachable nodes. The message and the payload
+    // views must be kept alive by the caller for the duration of the co_await.
+    virtual task::Task<void> broadcastMessageToAll(P2PMessage& message,
+        ::ranges::any_view<bytesConstRef> payloads, Options options = {}) = 0;
+
     virtual P2PInfos sessionInfos() = 0;
     virtual P2PInfo localP2pInfo() = 0;
 

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -484,10 +484,6 @@ uint32_t bcos::gateway::P2PMessage::lengthDirect() const
 {
     return m_length;
 }
-void bcos::gateway::P2PMessage::setLength(uint32_t length)
-{
-    m_length = length;
-}
 uint32_t bcos::gateway::P2PMessage::length() const
 {
     // The length value has been set

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -224,41 +224,6 @@ bool bcos::gateway::P2PMessage::encodeHeaderImpl(bytes& _buffer) const
     return true;
 }
 
-bool P2PMessage::encode(EncodedMessage& _buffer) const
-{
-    bool isCompressSuccess = false;
-    if (_buffer.compress)
-    {
-        bcos::bytes compressData;
-        if (tryToCompressPayload(compressData))
-        {
-            isCompressSuccess = true;
-            // set compress flag
-            m_ext |= bcos::protocol::MessageExtFieldFlag::COMPRESS;
-            _buffer.payload = std::move(compressData);
-        }
-    }
-
-    // No data compression is performed
-    if (!isCompressSuccess)
-    {
-        _buffer.payload = m_payload;
-    }
-
-    bytes headerBuffer;
-    // encode header
-    if (!encodeHeader(headerBuffer))
-    {
-        return false;
-    }
-
-    *(uint32_t*)headerBuffer.data() = boost::asio::detail::socket_ops::host_to_network_long(
-        headerBuffer.size() + _buffer.payload.size());
-
-    _buffer.header = std::move(headerBuffer);
-    return true;
-}
-
 bool P2PMessage::encode(bcos::bytes& _buffer)
 {
     bytes emptyBuffer;
@@ -531,10 +496,10 @@ uint16_t bcos::gateway::P2PMessage::ext() const
 }
 void bcos::gateway::P2PMessage::setExt(uint16_t _ext)
 {
-    // Assignment (not OR): a "set"ter must overwrite the field so callers can clear bits (e.g.
-    // fastSendMessage temporarily sets the COMPRESS flag and restores the original ext afterwards;
-    // FrontMessage::setExt already has assignment semantics).
-    m_ext = _ext;
+    // Accumulate (OR) semantics: the fast send path no longer touches this setter (the COMPRESS
+    // flag is stamped onto the encoded wire header, not the message), so callers that want to
+    // clear bits must do so explicitly — this matches the pre-PR base behaviour.
+    m_ext |= _ext;
 }
 const bcos::gateway::P2PMessageOptions& bcos::gateway::P2PMessage::options() const
 {

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -535,7 +535,10 @@ uint16_t bcos::gateway::P2PMessage::ext() const
 }
 void bcos::gateway::P2PMessage::setExt(uint16_t _ext)
 {
-    m_ext |= _ext;
+    // Assignment (not OR): a "set"ter must overwrite the field so callers can clear bits (e.g.
+    // fastSendMessage temporarily sets the COMPRESS flag and restores the original ext afterwards;
+    // FrontMessage::setExt already has assignment semantics).
+    m_ext = _ext;
 }
 const bcos::gateway::P2PMessageOptions& bcos::gateway::P2PMessage::options() const
 {

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.cpp
@@ -484,6 +484,10 @@ uint32_t bcos::gateway::P2PMessage::lengthDirect() const
 {
     return m_length;
 }
+void bcos::gateway::P2PMessage::setLength(uint32_t length)
+{
+    m_length = length;
+}
 uint32_t bcos::gateway::P2PMessage::length() const
 {
     // The length value has been set

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
@@ -129,7 +129,7 @@ public:
 
     uint32_t lengthDirect() const override;
     uint32_t length() const override;
-    // virtual void setLength(uint32_t length) { m_length = length; }
+    void setLength(uint32_t length) override;
 
     uint16_t version() const override;
     virtual void setVersion(uint16_t version);
@@ -141,7 +141,7 @@ public:
     virtual void setSeq(uint32_t seq);
 
     uint16_t ext() const override;
-    virtual void setExt(uint16_t _ext);
+    void setExt(uint16_t _ext) override;
 
     const P2PMessageOptions& options() const;
     void setOptions(P2PMessageOptions _options);

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
@@ -140,7 +140,7 @@ public:
     virtual void setSeq(uint32_t seq);
 
     uint16_t ext() const override;
-    void setExt(uint16_t _ext);
+    virtual void setExt(uint16_t _ext);
 
     const P2PMessageOptions& options() const;
     void setOptions(P2PMessageOptions _options);

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
@@ -129,7 +129,6 @@ public:
 
     uint32_t lengthDirect() const override;
     uint32_t length() const override;
-    void setLength(uint32_t length) override;
 
     uint16_t version() const override;
     virtual void setVersion(uint16_t version);

--- a/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PMessage.h
@@ -140,7 +140,7 @@ public:
     virtual void setSeq(uint32_t seq);
 
     uint16_t ext() const override;
-    void setExt(uint16_t _ext) override;
+    void setExt(uint16_t _ext);
 
     const P2PMessageOptions& options() const;
     void setOptions(P2PMessageOptions _options);
@@ -150,7 +150,6 @@ public:
 
     void setRespPacket();
     bool encode(bytes& _buffer) override;
-    bool encode(EncodedMessage& _buffer) const override;
     int32_t decode(const bytesConstRef& _buffer) override;
     bool isRespPacket() const override;
 

--- a/bcos-gateway/bcos-gateway/libp2p/P2PSession.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PSession.cpp
@@ -7,8 +7,10 @@
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libp2p/Common.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
 #include "bcos-gateway/libp2p/Service.h"
 #include "bcos-utilities/Common.h"
+#include <bcos-task/Wait.h>
 
 using namespace bcos;
 using namespace bcos::gateway;
@@ -117,16 +119,20 @@ void P2PSession::heartBeat()
     {
         if (m_session && m_session->active())
         {
-            auto message =
-                std::dynamic_pointer_cast<P2PMessage>(service->messageFactory()->buildMessage());
-            message->setPacketType(GatewayMessageType::Heartbeat);
             if (c_fileLogLevel <= TRACE) [[unlikely]]
             {
                 P2PSESSION_LOG(TRACE) << LOG_DESC("P2PSession onHeartBeat")
                                       << LOG_KV("p2pid", printShortP2pID(m_p2pInfo->p2pID))
                                       << LOG_KV("endpoint", m_session->nodeIPEndpoint());
             }
-            asyncSendP2PMessage(message, Options());
+            // value message in frame, sent through the fast path (zero-copy)
+            auto self = shared_from_this();
+            task::wait([self]() -> task::Task<void> {
+                P2PMessageV2 message;
+                message.setPacketType(GatewayMessageType::Heartbeat);
+                ::ranges::any_view<bytesConstRef> emptyPayloads;
+                co_await self->fastSendP2PMessage(message, std::move(emptyPayloads), Options{});
+            }());
         }
 
         auto self = std::weak_ptr<P2PSession>(shared_from_this());
@@ -165,7 +171,28 @@ void P2PSession::asyncSendP2PMessage(
     // reset message using original long nodeID or short nodeID according to the protocol version
     // Note: m_protocolInfo be setted when create P2PSession
     service->resetP2pID(*message, (ProtocolVersion)m_protocolInfo->version());
-    m_session->asyncSendMessage(message, options, callback);
+    // route through the coroutine fast path: the message (shared_ptr) is captured in the frame and
+    // its payload is sent as a view (zero-copy); response/error is delivered to callback
+    auto self = shared_from_this();
+    task::wait([self, message, options, callback]() mutable -> task::Task<void> {
+        Options sendOptions{options.timeout, callback ? true : false};
+        try
+        {
+            auto resp = co_await self->fastSendP2PMessage(
+                *message, ::ranges::views::single(message->payload()), sendOptions);
+            if (callback)
+            {
+                callback(NetworkException(), resp);
+            }
+        }
+        catch (NetworkException const& e)
+        {
+            if (callback)
+            {
+                callback(e, nullptr);
+            }
+        }
+    }());
 }
 
 bcos::task::Task<Message::Ptr> P2PSession::fastSendP2PMessage(

--- a/bcos-gateway/bcos-gateway/libp2p/P2PSession.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PSession.cpp
@@ -125,14 +125,16 @@ void P2PSession::heartBeat()
                                       << LOG_KV("p2pid", printShortP2pID(m_p2pInfo->p2pID))
                                       << LOG_KV("endpoint", m_session->nodeIPEndpoint());
             }
-            // value message in frame, sent through the fast path (zero-copy)
+            // value message in frame, sent through the fast path (zero-copy). The service shared_ptr
+            // is passed as a coroutine parameter so it is copied into the frame and kept alive for
+            // the whole (possibly deferred) send.
             auto self = shared_from_this();
-            task::wait([self]() -> task::Task<void> {
+            task::wait([](std::shared_ptr<P2PSession> _self) -> task::Task<void> {
                 P2PMessageV2 message;
                 message.setPacketType(GatewayMessageType::Heartbeat);
                 ::ranges::any_view<bytesConstRef> emptyPayloads;
-                co_await self->fastSendP2PMessage(message, std::move(emptyPayloads), Options{});
-            }());
+                co_await _self->fastSendP2PMessage(message, std::move(emptyPayloads), Options{});
+            }(self));
         }
 
         auto self = std::weak_ptr<P2PSession>(shared_from_this());
@@ -171,28 +173,30 @@ void P2PSession::asyncSendP2PMessage(
     // reset message using original long nodeID or short nodeID according to the protocol version
     // Note: m_protocolInfo be setted when create P2PSession
     service->resetP2pID(*message, (ProtocolVersion)m_protocolInfo->version());
-    // route through the coroutine fast path: the message (shared_ptr) is captured in the frame and
-    // its payload is sent as a view (zero-copy); response/error is delivered to callback
+    // route through the coroutine fast path: the message (shared_ptr) and the callback are passed as
+    // coroutine parameters so they are copied into the frame and stay alive for the whole (possibly
+    // deferred) send; response/error is delivered to callback
     auto self = shared_from_this();
-    task::wait([self, message, options, callback]() mutable -> task::Task<void> {
-        Options sendOptions{options.timeout, callback ? true : false};
+    task::wait([](std::shared_ptr<P2PSession> _self, P2PMessage::Ptr _message, Options _options,
+                   SessionCallbackFunc _callback) mutable -> task::Task<void> {
+        Options sendOptions{_options.timeout, _callback ? true : false};
         try
         {
-            auto resp = co_await self->fastSendP2PMessage(
-                *message, ::ranges::views::single(message->payload()), sendOptions);
-            if (callback)
+            auto resp = co_await _self->fastSendP2PMessage(
+                *_message, ::ranges::views::single(_message->payload()), sendOptions);
+            if (_callback)
             {
-                callback(NetworkException(), resp);
+                _callback(NetworkException(), resp);
             }
         }
         catch (NetworkException const& e)
         {
-            if (callback)
+            if (_callback)
             {
-                callback(e, nullptr);
+                _callback(e, nullptr);
             }
         }
-    }());
+    }(self, message, options, callback));
 }
 
 bcos::task::Task<Message::Ptr> P2PSession::fastSendP2PMessage(
@@ -213,5 +217,10 @@ bcos::task::Task<Message::Ptr> P2PSession::fastSendP2PMessage(
     // reset message using original long nodeID or short nodeID according to the protocol version
     // Note: m_protocolInfo be setted when create P2PSession
     service->resetP2pID(message, (ProtocolVersion)m_protocolInfo->version());
+    // the p2p message version must match the negotiated protocol version of this session: the
+    // encodeHeaderImpl of P2PMessageV2 only encodes the ttl/src/dst routing fields for version > V0,
+    // so sending with the default (V0) version would silently drop the V2 routing fields and break
+    // multi-hop forwarding through ServiceV2 router tables
+    message.setVersion((uint16_t)m_protocolInfo->version());
     co_return co_await m_session->fastSendMessage(message, std::move(payloads), options);
 }

--- a/bcos-gateway/bcos-gateway/libp2p/P2PSession.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PSession.cpp
@@ -127,14 +127,27 @@ void P2PSession::heartBeat()
             }
             // value message in frame, sent through the fast path (zero-copy). The service shared_ptr
             // is passed as a coroutine parameter so it is copied into the frame and kept alive for
-            // the whole (possibly deferred) send.
+            // the whole (possibly deferred) send. The pre-send checks (outgoing rate limit / max
+            // size) run synchronously on the caller thread and may throw — catch so the heartbeat
+            // timer below is always re-armed (otherwise this session would be dropped by the peer's
+            // idle timeout).
             auto self = shared_from_this();
-            task::wait([](std::shared_ptr<P2PSession> _self) -> task::Task<void> {
-                P2PMessageV2 message;
-                message.setPacketType(GatewayMessageType::Heartbeat);
-                ::ranges::any_view<bytesConstRef> emptyPayloads;
-                co_await _self->fastSendP2PMessage(message, std::move(emptyPayloads), Options{});
-            }(self));
+            try
+            {
+                task::wait([](std::shared_ptr<P2PSession> _self) -> task::Task<void> {
+                    P2PMessageV2 message;
+                    message.setPacketType(GatewayMessageType::Heartbeat);
+                    ::ranges::any_view<bytesConstRef> emptyPayloads;
+                    co_await _self->fastSendP2PMessage(
+                        message, std::move(emptyPayloads), Options{});
+                }(self));
+            }
+            catch (std::exception const& e)
+            {
+                P2PSESSION_LOG(WARNING) << LOG_DESC("heartBeat send exception")
+                                        << LOG_KV("p2pid", printShortP2pID(m_p2pInfo->p2pID))
+                                        << LOG_KV("what", boost::diagnostic_information(e));
+            }
         }
 
         auto self = std::weak_ptr<P2PSession>(shared_from_this());

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -386,17 +386,30 @@ void Service::sendRespMessageBySession(
     // passed as coroutine parameters so they are copied into the frame.
     task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _p2pSession,
                    bcos::bytes _payload, uint32_t _seq, P2pID _p2pid) -> task::Task<void> {
-        P2PMessageV2 respMessage;
-        respMessage.setSeq(_seq);
-        respMessage.setRespPacket();
-        respMessage.setPayload(std::move(_payload));
-        co_await _p2pSession->fastSendP2PMessage(
-            respMessage, ::ranges::views::single(respMessage.payload()), Options{});
-        if (c_fileLogLevel <= TRACE) [[unlikely]]
+        try
         {
-            SERVICE_LOG(TRACE) << "sendRespMessageBySession" << LOG_KV("seq", _seq)
-                               << LOG_KV("p2pid", printShortP2pID(_p2pid))
-                               << LOG_KV("payload size", respMessage.payload().size());
+            P2PMessageV2 respMessage;
+            respMessage.setSeq(_seq);
+            respMessage.setRespPacket();
+            respMessage.setPayload(std::move(_payload));
+            co_await _p2pSession->fastSendP2PMessage(
+                respMessage, ::ranges::views::single(respMessage.payload()), Options{});
+            if (c_fileLogLevel <= TRACE) [[unlikely]]
+            {
+                SERVICE_LOG(TRACE) << "sendRespMessageBySession" << LOG_KV("seq", _seq)
+                                   << LOG_KV("p2pid", printShortP2pID(_p2pid))
+                                   << LOG_KV("payload size", respMessage.payload().size());
+            }
+        }
+        catch (std::exception const& e)
+        {
+            // Same shape as ServiceV2::sendRespMessageBySession (ServiceV2 delegates V0 peers
+            // here): a synchronous pre-send rejection on the response path must not propagate out
+            // of the receiving handler.
+            SERVICE_LOG(WARNING) << LOG_BADGE("sendRespMessageBySession")
+                                 << LOG_DESC("send response failed") << LOG_KV("seq", _seq)
+                                 << LOG_KV("p2pid", printShortP2pID(_p2pid))
+                                 << LOG_KV("what", boost::diagnostic_information(e));
         }
     }(self, _p2pSession, bcos::bytes(_payload.begin(), _payload.end()), seq, p2pid));
 }
@@ -617,9 +630,8 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
     }
 }
 
-bcos::task::Task<void> Service::broadcastMessageToAll(
-    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
-    Options options)
+bcos::task::Task<void> Service::broadcastMessageToAll(P2PMessage::Ptr message,
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads, Options options)
 {
     std::vector<P2pID> nodeIDs;
     {
@@ -656,9 +668,8 @@ bcos::task::Task<void> Service::broadcastMessageToAll(
     co_return;
 }
 
-bcos::task::Task<void> Service::broadcastMessageToNeighbors(
-    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
-    Options options)
+bcos::task::Task<void> Service::broadcastMessageToNeighbors(P2PMessage::Ptr message,
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads, Options options)
 {
     // Only directly connected sessions (m_sessions), unlike broadcastMessageToAll which may fan out
     // through the ServiceV2 router table. This preserves the "router table sync only between

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -253,9 +253,10 @@ void Service::onConnect(
             std::forward<decltype(session)>(session), std::forward<decltype(message)>(message),
             p2pSessionWeakPtr);
     });
-    p2pSession->session()->setBeforeMessageHandler([this](SessionFace& session, Message& message) {
-        return onBeforeMessage(session, message);
-    });
+    p2pSession->session()->setBeforeMessageHandler(
+        [this](SessionFace& session, const Message& message, uint32_t wireLength) {
+            return onBeforeMessage(session, message, wireLength);
+        });
 
     // Note: the lock must be here, otherwise there will be more than one started sessions,
     // and a session not maintained in m_sessions will be choosed when send messages in some cases
@@ -400,11 +401,12 @@ void Service::sendRespMessageBySession(
     }(self, _p2pSession, bcos::bytes(_payload.begin(), _payload.end()), seq, p2pid));
 }
 
-std::optional<bcos::Error> Service::onBeforeMessage(SessionFace& _session, Message& _message)
+std::optional<bcos::Error> Service::onBeforeMessage(
+    SessionFace& _session, const Message& _message, uint32_t _wireLength)
 {
     if (m_beforeMessageHandler)
     {
-        return m_beforeMessageHandler(_session, _message);
+        return m_beforeMessageHandler(_session, _message, _wireLength);
     }
 
     return std::nullopt;
@@ -1027,8 +1029,8 @@ void bcos::gateway::Service::eraseHandlerByMsgType(uint16_t _type)
 {
     m_msgHandlers.at(_type) = nullptr;
 }
-void bcos::gateway::Service::setBeforeMessageHandler(
-    std::function<std::optional<bcos::Error>(SessionFace&, Message&)> _handler)
+void bcos::gateway::Service::setBeforeMessageHandler(std::function<std::optional<bcos::Error>(
+    SessionFace&, const Message&, uint32_t)> _handler)
 {
     m_beforeMessageHandler = std::move(_handler);
 }

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -583,23 +583,28 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
             }
         }
         auto self = shared_from_this();
-        task::wait([](std::shared_ptr<Service> _self, std::vector<P2pID> _nodeIDs,
-                       P2PMessage::Ptr _message, Options _options) mutable -> task::Task<void> {
-            for (auto const& nodeID : _nodeIDs)
+        // Fan out one independent coroutine per peer: each task holds the shared message, and its
+        // per-session src/dst/version stamping runs synchronously before its first suspension, so
+        // the tasks never race on the shared header and no peer's socket-write blocks the peers
+        // behind it (base enqueued every peer and returned immediately).
+        for (auto const& nodeID : nodeIDs)
+        {
+            try
             {
-                try
-                {
-                    co_await _self->sendMessageByNodeID(
-                        nodeID, *_message, ::ranges::views::single(_message->payload()), _options);
-                }
-                catch (std::exception const& e)
-                {
-                    SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage send failed")
-                                         << LOG_KV("nodeid", printShortP2pID(nodeID))
-                                         << LOG_KV("what", boost::diagnostic_information(e));
-                }
+                task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID,
+                               P2PMessage::Ptr _message, Options _options) mutable
+                               -> task::Task<void> {
+                    co_await _self->sendMessageByNodeID(_nodeID, *_message,
+                        ::ranges::views::single(_message->payload()), _options);
+                }(self, nodeID, message, options));
             }
-        }(self, std::move(nodeIDs), std::move(message), options));
+            catch (std::exception const& e)
+            {
+                SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage send failed")
+                                     << LOG_KV("nodeid", printShortP2pID(nodeID))
+                                     << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }
     }
     catch (std::exception& e)
     {
@@ -609,7 +614,7 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
 }
 
 bcos::task::Task<void> Service::broadcastMessageToAll(
-    P2PMessage& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef> payloads, Options options)
 {
     std::vector<P2pID> nodeIDs;
     {
@@ -620,11 +625,21 @@ bcos::task::Task<void> Service::broadcastMessageToAll(
             nodeIDs.push_back(session.first);
         }
     }
+    auto self = shared_from_this();
+    // Fan out one independent coroutine per peer (see asyncBroadcastMessage): the caller's message
+    // is handed over as a shared_ptr so every per-peer task keeps it alive; each task's
+    // per-session src/dst/version stamping runs synchronously before its first suspension, so no
+    // race on the shared header and no head-of-line blocking on a stalled peer's socket.
     for (auto const& nodeID : nodeIDs)
     {
         try
         {
-            co_await sendMessageByNodeID(nodeID, message, payloads, options);
+            task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
+                           ::ranges::any_view<bytesConstRef> _payloads,
+                           Options _options) mutable -> task::Task<void> {
+                co_await _self->sendMessageByNodeID(
+                    _nodeID, *_message, std::move(_payloads), std::move(_options));
+            }(self, nodeID, message, payloads, options));
         }
         catch (std::exception const& e)
         {
@@ -637,7 +652,7 @@ bcos::task::Task<void> Service::broadcastMessageToAll(
 }
 
 bcos::task::Task<void> Service::broadcastMessageToNeighbors(
-    P2PMessage& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef> payloads, Options options)
 {
     // Only directly connected sessions (m_sessions), unlike broadcastMessageToAll which may fan out
     // through the ServiceV2 router table. This preserves the "router table sync only between
@@ -651,11 +666,21 @@ bcos::task::Task<void> Service::broadcastMessageToNeighbors(
             nodeIDs.push_back(session.first);
         }
     }
+    auto self = shared_from_this();
+    // Fan out one independent coroutine per peer (see asyncBroadcastMessage): the caller's message
+    // is handed over as a shared_ptr so every per-peer task keeps it alive; each task's
+    // per-session src/dst/version stamping runs synchronously before its first suspension, so no
+    // race on the shared header and no head-of-line blocking on a stalled peer's socket.
     for (auto const& nodeID : nodeIDs)
     {
         try
         {
-            co_await sendMessageByNodeID(nodeID, message, payloads, options);
+            task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
+                           ::ranges::any_view<bytesConstRef> _payloads,
+                           Options _options) mutable -> task::Task<void> {
+                co_await _self->sendMessageByNodeID(
+                    _nodeID, *_message, std::move(_payloads), std::move(_options));
+            }(self, nodeID, message, payloads, options));
         }
         catch (std::exception const& e)
         {
@@ -755,16 +780,17 @@ void Service::asyncBroadcastMessageToP2PNodes(
     uint16_t _type, uint16_t moduleID, bytesConstRef _payload, Options _options)
 {
     auto self = shared_from_this();
-    // value message in frame; payload owned by the frame and sent as a view (zero-copy). All state
-    // is passed as coroutine parameters so it is copied into the frame and stays alive.
+    // value message held by shared_ptr: broadcastMessageToAll fans out one coroutine per peer and
+    // each task keeps the message alive (zero-copy: the payload rides as a view). All state is
+    // passed as coroutine parameters so it is copied into the frame and stays alive.
     task::wait([](std::shared_ptr<Service> _self, uint16_t _type, bcos::bytes _payload,
                    Options _options) mutable -> task::Task<void> {
-        P2PMessageV2 message;
-        message.setPacketType(_type);
-        message.setSeq(_self->messageFactory()->newSeq());
-        message.setPayload(std::move(_payload));
+        auto message = std::make_shared<P2PMessageV2>();
+        message->setPacketType(_type);
+        message->setSeq(_self->messageFactory()->newSeq());
+        message->setPayload(std::move(_payload));
         co_await _self->broadcastMessageToAll(
-            message, ::ranges::views::single(message.payload()), _options);
+            message, ::ranges::views::single(message->payload()), _options);
     }(self, _type, bcos::bytes(_payload.begin(), _payload.end()), _options));
 }
 
@@ -782,19 +808,32 @@ void Service::asyncSendProtocol(P2PSession::Ptr _session)
 {
     auto self = shared_from_this();
     // value message in frame; payload owned by the frame. All state is passed as coroutine
-    // parameters so it is copied into the frame and stays alive.
+    // parameters so it is copied into the frame and stays alive. The pre-send checks (outgoing
+    // rate limit / max size) run synchronously on the caller thread inside fastSendP2PMessage and
+    // may throw — catch so a handshake rejection cannot escape task::wait and abort onConnect's
+    // session-registration tail (the session would stay live-but-unregistered, silently hidden
+    // from the routing layer). A failed handshake is recoverable: the peer retries.
     task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _session) -> task::Task<void> {
-        auto payload = bytes();
-        _self->m_codec->encode(_self->m_localProtocol, payload);
-        P2PMessageV2 message;
-        message.setPacketType(GatewayMessageType::Handshake);
-        message.setSeq(_self->messageFactory()->newSeq());
-        message.setPayload(std::move(payload));
-        SERVICE_LOG(INFO) << LOG_DESC("asyncSendProtocol")
-                          << LOG_KV("payload", message.payload().size())
-                          << LOG_KV("seq", message.seq());
-        co_await _session->fastSendP2PMessage(
-            message, ::ranges::views::single(message.payload()), Options{});
+        try
+        {
+            auto payload = bytes();
+            _self->m_codec->encode(_self->m_localProtocol, payload);
+            P2PMessageV2 message;
+            message.setPacketType(GatewayMessageType::Handshake);
+            message.setSeq(_self->messageFactory()->newSeq());
+            message.setPayload(std::move(payload));
+            SERVICE_LOG(INFO) << LOG_DESC("asyncSendProtocol")
+                              << LOG_KV("payload", message.payload().size())
+                              << LOG_KV("seq", message.seq());
+            co_await _session->fastSendP2PMessage(
+                message, ::ranges::views::single(message.payload()), Options{});
+        }
+        catch (std::exception const& e)
+        {
+            SERVICE_LOG(WARNING) << LOG_DESC("asyncSendProtocol send exception")
+                                 << LOG_KV("p2pid", printShortP2pID(_session->p2pID()))
+                                 << LOG_KV("what", boost::diagnostic_information(e));
+        }
     }(self, _session));
 }
 

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -618,7 +618,8 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
 }
 
 bcos::task::Task<void> Service::broadcastMessageToAll(
-    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
+    Options options)
 {
     std::vector<P2pID> nodeIDs;
     {
@@ -637,7 +638,7 @@ bcos::task::Task<void> Service::broadcastMessageToAll(
     for (auto const& nodeID : nodeIDs)
     {
         task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
-                       ::ranges::any_view<bytesConstRef> _payloads,
+                       ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
                        Options _options) mutable -> task::Task<void> {
             try
             {
@@ -656,7 +657,8 @@ bcos::task::Task<void> Service::broadcastMessageToAll(
 }
 
 bcos::task::Task<void> Service::broadcastMessageToNeighbors(
-    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
+    Options options)
 {
     // Only directly connected sessions (m_sessions), unlike broadcastMessageToAll which may fan out
     // through the ServiceV2 router table. This preserves the "router table sync only between
@@ -678,7 +680,7 @@ bcos::task::Task<void> Service::broadcastMessageToNeighbors(
     for (auto const& nodeID : nodeIDs)
     {
         task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
-                       ::ranges::any_view<bytesConstRef> _payloads,
+                       ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
                        Options _options) mutable -> task::Task<void> {
             try
             {

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -11,9 +11,11 @@
 #include "bcos-gateway/libp2p/Common.h"
 #include "bcos-gateway/libp2p/P2PInterface.h"  // for SessionCallbackFunc...
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
 #include "bcos-gateway/libp2p/P2PSession.h"  // for P2PSession
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Common.h"
+#include <bcos-task/Wait.h>
 #include <boost/random.hpp>
 #include <boost/throw_exception.hpp>
 #include <range/v3/view/map.hpp>
@@ -333,40 +335,65 @@ void Service::sendMessageToSession(P2PSession::Ptr _p2pSession, P2PMessage::Ptr 
     auto protocolVersion = _p2pSession->protocolInfo()->version();
     // Note: p2pMessage version is binded to the protocol version
     _msg->setVersion(protocolVersion);
-    if (!_callback)
-    {
-        _p2pSession->asyncSendP2PMessage(_msg, _options, nullptr);
-        return;
-    }
-    auto weakSession = std::weak_ptr<P2PSession>(_p2pSession);
-    _p2pSession->asyncSendP2PMessage(
-        _msg, _options, [weakSession, _callback](NetworkException e, Message::Ptr message) {
-            auto session = weakSession.lock();
-            if (!session)
-            {
-                return;
-            }
-            P2PMessage::Ptr p2pMessage = std::dynamic_pointer_cast<P2PMessage>(message);
+    auto self = shared_from_this();
+    // route through the coroutine fast path: the message (shared_ptr) is captured in the frame and
+    // its payload is sent as a view (zero-copy); the response (if requested) resumes the coroutine
+    // and is delivered to _callback.
+    task::wait([self, _p2pSession, _msg, _options, _callback]() mutable -> task::Task<void> {
+        Options sendOptions{_options.timeout, _callback ? true : false};
+        try
+        {
+            auto resp = co_await _p2pSession->fastSendP2PMessage(
+                *_msg, ::ranges::views::single(_msg->payload()), sendOptions);
             if (_callback)
             {
-                _callback(e, session, p2pMessage);
+                P2PMessage::Ptr p2pMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
+                _callback(NetworkException(), _p2pSession, p2pMessage);
             }
-        });
+        }
+        catch (NetworkException const& e)
+        {
+            if (_callback)
+            {
+                _callback(e, _p2pSession, nullptr);
+            }
+        }
+        catch (std::exception const& e)
+        {
+            SERVICE_LOG(WARNING) << LOG_DESC("sendMessageToSession exception")
+                                 << LOG_KV("what", boost::diagnostic_information(e));
+            if (_callback)
+            {
+                _callback(
+                    NetworkException(-1, boost::diagnostic_information(e)), _p2pSession, nullptr);
+            }
+        }
+    }());
 }
 
 void Service::sendRespMessageBySession(
     bytesConstRef _payload, P2PMessage::Ptr _p2pMessage, P2PSession::Ptr _p2pSession)
 {
-    auto respMessage = std::static_pointer_cast<P2PMessage>(messageFactory()->buildMessage());
-
-    respMessage->setSeq(_p2pMessage->seq());
-    respMessage->setRespPacket();
-    respMessage->setPayload({_payload.begin(), _payload.end()});
-
-    sendMessageToSession(_p2pSession, respMessage);
-    SERVICE_LOG(TRACE) << "sendRespMessageBySession" << LOG_KV("seq", _p2pMessage->seq())
-                       << LOG_KV("p2pid", _p2pSession->printP2pID())
-                       << LOG_KV("payload size", _payload.size());
+    auto self = shared_from_this();
+    auto seq = _p2pMessage->seq();
+    auto p2pid = _p2pSession->p2pID();
+    // value message in frame; the (borrowed) response payload is copied into the frame because the
+    // receive callback that passed it does not outlive the deferred send.
+    task::wait([self, _p2pSession, _payload = bcos::bytes(_payload.begin(), _payload.end()), seq,
+                   p2pid]() -> task::Task<void> {
+        P2PMessageV2 respMessage;
+        respMessage.setSeq(seq);
+        respMessage.setRespPacket();
+        respMessage.setPayload(std::move(_payload));
+        co_await _p2pSession->fastSendP2PMessage(
+            respMessage, ::ranges::views::single(respMessage.payload()), Options{});
+        if (c_fileLogLevel <= TRACE) [[unlikely]]
+        {
+            SERVICE_LOG(TRACE) << "sendRespMessageBySession" << LOG_KV("seq", seq)
+                               << LOG_KV("p2pid", printShortP2pID(p2pid))
+                               << LOG_KV("payload size", respMessage.payload().size());
+        }
+    }());
 }
 
 std::optional<bcos::Error> Service::onBeforeMessage(SessionFace& _session, Message& _message)
@@ -534,12 +561,12 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
     try
     {
         // FIB-186 (vector D): snapshot the session keys under x_sessions and release it BEFORE the
-        // per-session asyncSendMessageByNodeID(), which re-acquires x_sessions(shared) via
-        // getP2PSessionByNodeId. Holding x_sessions across that re-acquisition is a recursive
-        // shared lock: once an onConnect thread is waiting for x_sessions(W), libc++
-        // writer-priority blocks the second lock_shared(), so this thread can neither finish nor
-        // release its first shared lock and every session operation (including all PBFT delivery)
-        // stalls -> consensus halts under connection churn.
+        // per-session send, which re-acquires x_sessions(shared) via sendMessageByNodeID. Holding
+        // x_sessions across that re-acquisition is a recursive shared lock: once an onConnect
+        // thread is waiting for x_sessions(W), libc++ writer-priority blocks the second
+        // lock_shared(), so this thread can neither finish nor release its first shared lock and
+        // every session operation (including all PBFT delivery) stalls -> consensus halts under
+        // connection churn.
         std::vector<P2pID> nodeIDs;
         {
             std::shared_lock lock(x_sessions);
@@ -549,16 +576,58 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
                 nodeIDs.push_back(session.first);
             }
         }
-        for (auto const& nodeID : nodeIDs)
-        {
-            asyncSendMessageByNodeID(nodeID, message, {}, options);
-        }
+        auto self = shared_from_this();
+        task::wait([self, nodeIDs = std::move(nodeIDs), message = std::move(message),
+                       options]() mutable -> task::Task<void> {
+            for (auto const& nodeID : nodeIDs)
+            {
+                try
+                {
+                    co_await self->sendMessageByNodeID(
+                        nodeID, *message, ::ranges::views::single(message->payload()), options);
+                }
+                catch (std::exception const& e)
+                {
+                    SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage send failed")
+                                         << LOG_KV("nodeid", printShortP2pID(nodeID))
+                                         << LOG_KV("what", boost::diagnostic_information(e));
+                }
+            }
+        }());
     }
     catch (std::exception& e)
     {
         SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage")
                              << LOG_KV("what", boost::diagnostic_information(e));
     }
+}
+
+bcos::task::Task<void> Service::broadcastMessageToAll(
+    P2PMessage& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+{
+    std::vector<P2pID> nodeIDs;
+    {
+        std::shared_lock lock(x_sessions);
+        nodeIDs.reserve(m_sessions.size());
+        for (auto const& session : m_sessions)
+        {
+            nodeIDs.push_back(session.first);
+        }
+    }
+    for (auto const& nodeID : nodeIDs)
+    {
+        try
+        {
+            co_await sendMessageByNodeID(nodeID, message, payloads, options);
+        }
+        catch (std::exception const& e)
+        {
+            SERVICE_LOG(WARNING) << LOG_DESC("broadcastMessageToAll failed")
+                                 << LOG_KV("nodeid", printShortP2pID(nodeID))
+                                 << LOG_KV("what", boost::diagnostic_information(e));
+        }
+    }
+    co_return;
 }
 
 P2PInfos Service::sessionInfos()
@@ -598,45 +667,51 @@ void Service::asyncSendMessageByP2PNodeID(uint16_t _type, P2pID _dstNodeID, byte
         }
         return;
     }
-    auto p2pMessage = newP2PMessage(_type, _payload);
-
-    if (!_callback)
-    {
-        asyncSendMessageByNodeID(_dstNodeID, p2pMessage, nullptr);
-        return;
-    }
-
-    asyncSendMessageByNodeID(
-        _dstNodeID, p2pMessage,
-        [_dstNodeID, _callback](NetworkException _e, std::shared_ptr<P2PSession>,
-            std::shared_ptr<P2PMessage> _p2pMessage) {
-            auto packetType = _p2pMessage ? _p2pMessage->packetType() : (uint16_t)0;
-            if (_e.errorCode() != 0)
-            {
-                SERVICE_LOG(INFO) << LOG_DESC("asyncSendMessageByP2PNodeID failed")
-                                  << LOG_KV("code", _e.errorCode()) << LOG_KV("msg", _e.what())
-                                  << LOG_KV("type", packetType)
-                                  << LOG_KV("dst", printShortP2pID(_dstNodeID));
-                if (_callback)
-                {
-                    _callback(_e.toError(), packetType,
-                        _p2pMessage ? _p2pMessage->payload() : bytesConstRef{});
-                }
-                return;
-            }
-            if (_callback)
-            {
-                _callback(nullptr, packetType, _p2pMessage->payload());
-            }
-        },
-        _options);
+    auto self = shared_from_this();
+    // value message in frame; payload owned by the frame and sent as a view (zero-copy)
+    task::wait([self, _type, _dstNodeID = std::move(_dstNodeID),
+                   _payload = bcos::bytes(_payload.begin(), _payload.end()), _options,
+                   _callback]() mutable -> task::Task<void> {
+        P2PMessageV2 message;
+        message.setPacketType(_type);
+        message.setSeq(self->messageFactory()->newSeq());
+        message.setPayload(std::move(_payload));
+        if (!_callback)
+        {
+            co_await self->sendMessageByNodeID(_dstNodeID, message,
+                ::ranges::views::single(message.payload()), Options{_options.timeout, false});
+            co_return;
+        }
+        try
+        {
+            auto resp = co_await self->sendMessageByNodeID(_dstNodeID, message,
+                ::ranges::views::single(message.payload()), Options{_options.timeout, true});
+            auto respMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
+            auto packetType = respMessage ? respMessage->packetType() : (uint16_t)0;
+            _callback(nullptr, packetType,
+                respMessage ? respMessage->payload() : bytesConstRef{});
+        }
+        catch (NetworkException& e)
+        {
+            _callback(e.toError(), 0, bytesConstRef{});
+        }
+    }());
 }
 
 void Service::asyncBroadcastMessageToP2PNodes(
     uint16_t _type, uint16_t moduleID, bytesConstRef _payload, Options _options)
 {
-    auto p2pMessage = newP2PMessage(_type, _payload);
-    asyncBroadcastMessage(p2pMessage, _options);
+    auto self = shared_from_this();
+    // value message in frame; payload owned by the frame and sent as a view (zero-copy)
+    task::wait([self, _type, moduleID, _payload = bcos::bytes(_payload.begin(), _payload.end()),
+                   _options]() mutable -> task::Task<void> {
+        P2PMessageV2 message;
+        message.setPacketType(_type);
+        message.setSeq(self->messageFactory()->newSeq());
+        message.setPayload(std::move(_payload));
+        co_await self->broadcastMessageToAll(
+            message, ::ranges::views::single(message.payload()), _options);
+    }());
 }
 
 void Service::asyncSendMessageByP2PNodeIDs(
@@ -651,17 +726,21 @@ void Service::asyncSendMessageByP2PNodeIDs(
 // send the protocolInfo
 void Service::asyncSendProtocol(P2PSession::Ptr _session)
 {
-    auto payload = bytes();
-    m_codec->encode(m_localProtocol, payload);
-    auto message = std::static_pointer_cast<P2PMessage>(messageFactory()->buildMessage());
-    message->setPacketType(GatewayMessageType::Handshake);
-    auto seq = messageFactory()->newSeq();
-    message->setSeq(seq);
-    message->setPayload(payload);
-
-    SERVICE_LOG(INFO) << LOG_DESC("asyncSendProtocol") << LOG_KV("payload", payload.size())
-                      << LOG_KV("seq", seq);
-    sendMessageToSession(_session, message, Options(), nullptr);
+    auto self = shared_from_this();
+    // value message in frame; payload owned by the frame
+    task::wait([self, _session]() -> task::Task<void> {
+        auto payload = bytes();
+        self->m_codec->encode(self->m_localProtocol, payload);
+        P2PMessageV2 message;
+        message.setPacketType(GatewayMessageType::Handshake);
+        message.setSeq(self->messageFactory()->newSeq());
+        message.setPayload(std::move(payload));
+        SERVICE_LOG(INFO) << LOG_DESC("asyncSendProtocol")
+                          << LOG_KV("payload", message.payload().size())
+                          << LOG_KV("seq", message.seq());
+        co_await _session->fastSendP2PMessage(
+            message, ::ranges::views::single(message.payload()), Options{});
+    }());
 }
 
 // receive the heartbeat msg

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -714,8 +714,22 @@ void Service::asyncSendMessageByP2PNodeID(uint16_t _type, P2pID _dstNodeID, byte
         message.setPayload(std::move(_payload));
         if (!_callback)
         {
-            co_await _self->sendMessageByNodeID(_dstNodeID, message,
-                ::ranges::views::single(message.payload()), Options{_options.timeout, false});
+            // fire-and-forget: an unreachable peer (session dropped between the isReachable check
+            // and the send) is an expected, recoverable state — log and continue, matching the old
+            // asyncSendMessageByNodeID "Node inactive" behaviour, instead of throwing out of
+            // task::wait and aborting the remaining nodes in asyncSendMessageByP2PNodeIDs.
+            try
+            {
+                co_await _self->sendMessageByNodeID(_dstNodeID, message,
+                    ::ranges::views::single(message.payload()), Options{_options.timeout, false});
+            }
+            catch (NetworkException const& e)
+            {
+                SERVICE_LOG(INFO) << LOG_DESC("asyncSendMessageByP2PNodeID send failed")
+                                  << LOG_KV("nodeid", printShortP2pID(_dstNodeID))
+                                  << LOG_KV("code", e.errorCode())
+                                  << LOG_KV("message", e.what());
+            }
             co_return;
         }
         try

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -703,7 +703,7 @@ void Service::asyncBroadcastMessageToP2PNodes(
 {
     auto self = shared_from_this();
     // value message in frame; payload owned by the frame and sent as a view (zero-copy)
-    task::wait([self, _type, moduleID, _payload = bcos::bytes(_payload.begin(), _payload.end()),
+    task::wait([self, _type, _payload = bcos::bytes(_payload.begin(), _payload.end()),
                    _options]() mutable -> task::Task<void> {
         P2PMessageV2 message;
         message.setPacketType(_type);

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -336,10 +336,13 @@ void Service::sendMessageToSession(P2PSession::Ptr _p2pSession, P2PMessage::Ptr 
     // Note: p2pMessage version is binded to the protocol version
     _msg->setVersion(protocolVersion);
     auto self = shared_from_this();
-    // route through the coroutine fast path: the message (shared_ptr) is captured in the frame and
-    // its payload is sent as a view (zero-copy); the response (if requested) resumes the coroutine
-    // and is delivered to _callback.
-    task::wait([self, _p2pSession, _msg, _options, _callback]() mutable -> task::Task<void> {
+    // route through the coroutine fast path: the message (shared_ptr), the session and the callback
+    // are passed as coroutine parameters so they are copied into the frame and stay alive for the
+    // whole (possibly deferred) send; the payload is sent as a view (zero-copy); the response (if
+    // requested) resumes the coroutine and is delivered to _callback.
+    task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _p2pSession,
+                   P2PMessage::Ptr _msg, Options _options,
+                   CallbackFuncWithSession _callback) mutable -> task::Task<void> {
         Options sendOptions{_options.timeout, _callback ? true : false};
         try
         {
@@ -368,7 +371,7 @@ void Service::sendMessageToSession(P2PSession::Ptr _p2pSession, P2PMessage::Ptr 
                     NetworkException(-1, boost::diagnostic_information(e)), _p2pSession, nullptr);
             }
         }
-    }());
+    }(self, _p2pSession, _msg, _options, _callback));
 }
 
 void Service::sendRespMessageBySession(
@@ -378,22 +381,23 @@ void Service::sendRespMessageBySession(
     auto seq = _p2pMessage->seq();
     auto p2pid = _p2pSession->p2pID();
     // value message in frame; the (borrowed) response payload is copied into the frame because the
-    // receive callback that passed it does not outlive the deferred send.
-    task::wait([self, _p2pSession, _payload = bcos::bytes(_payload.begin(), _payload.end()), seq,
-                   p2pid]() -> task::Task<void> {
+    // receive callback that passed it does not outlive the deferred send. The session/service are
+    // passed as coroutine parameters so they are copied into the frame.
+    task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _p2pSession,
+                   bcos::bytes _payload, uint32_t _seq, P2pID _p2pid) -> task::Task<void> {
         P2PMessageV2 respMessage;
-        respMessage.setSeq(seq);
+        respMessage.setSeq(_seq);
         respMessage.setRespPacket();
         respMessage.setPayload(std::move(_payload));
         co_await _p2pSession->fastSendP2PMessage(
             respMessage, ::ranges::views::single(respMessage.payload()), Options{});
         if (c_fileLogLevel <= TRACE) [[unlikely]]
         {
-            SERVICE_LOG(TRACE) << "sendRespMessageBySession" << LOG_KV("seq", seq)
-                               << LOG_KV("p2pid", printShortP2pID(p2pid))
+            SERVICE_LOG(TRACE) << "sendRespMessageBySession" << LOG_KV("seq", _seq)
+                               << LOG_KV("p2pid", printShortP2pID(_p2pid))
                                << LOG_KV("payload size", respMessage.payload().size());
         }
-    }());
+    }(self, _p2pSession, bcos::bytes(_payload.begin(), _payload.end()), seq, p2pid));
 }
 
 std::optional<bcos::Error> Service::onBeforeMessage(SessionFace& _session, Message& _message)
@@ -577,14 +581,14 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
             }
         }
         auto self = shared_from_this();
-        task::wait([self, nodeIDs = std::move(nodeIDs), message = std::move(message),
-                       options]() mutable -> task::Task<void> {
-            for (auto const& nodeID : nodeIDs)
+        task::wait([](std::shared_ptr<Service> _self, std::vector<P2pID> _nodeIDs,
+                       P2PMessage::Ptr _message, Options _options) mutable -> task::Task<void> {
+            for (auto const& nodeID : _nodeIDs)
             {
                 try
                 {
-                    co_await self->sendMessageByNodeID(
-                        nodeID, *message, ::ranges::views::single(message->payload()), options);
+                    co_await _self->sendMessageByNodeID(
+                        nodeID, *_message, ::ranges::views::single(_message->payload()), _options);
                 }
                 catch (std::exception const& e)
                 {
@@ -593,7 +597,7 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
                                          << LOG_KV("what", boost::diagnostic_information(e));
                 }
             }
-        }());
+        }(self, std::move(nodeIDs), std::move(message), options));
     }
     catch (std::exception& e)
     {
@@ -623,6 +627,37 @@ bcos::task::Task<void> Service::broadcastMessageToAll(
         catch (std::exception const& e)
         {
             SERVICE_LOG(WARNING) << LOG_DESC("broadcastMessageToAll failed")
+                                 << LOG_KV("nodeid", printShortP2pID(nodeID))
+                                 << LOG_KV("what", boost::diagnostic_information(e));
+        }
+    }
+    co_return;
+}
+
+bcos::task::Task<void> Service::broadcastMessageToNeighbors(
+    P2PMessage& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+{
+    // Only directly connected sessions (m_sessions), unlike broadcastMessageToAll which may fan out
+    // through the ServiceV2 router table. This preserves the "router table sync only between
+    // neighbors, propagated hop-by-hop" gossip model used by broadcastRouterSeq.
+    std::vector<P2pID> nodeIDs;
+    {
+        std::shared_lock lock(x_sessions);
+        nodeIDs.reserve(m_sessions.size());
+        for (auto const& session : m_sessions)
+        {
+            nodeIDs.push_back(session.first);
+        }
+    }
+    for (auto const& nodeID : nodeIDs)
+    {
+        try
+        {
+            co_await sendMessageByNodeID(nodeID, message, payloads, options);
+        }
+        catch (std::exception const& e)
+        {
+            SERVICE_LOG(WARNING) << LOG_DESC("broadcastMessageToNeighbors failed")
                                  << LOG_KV("nodeid", printShortP2pID(nodeID))
                                  << LOG_KV("what", boost::diagnostic_information(e));
         }
@@ -668,23 +703,24 @@ void Service::asyncSendMessageByP2PNodeID(uint16_t _type, P2pID _dstNodeID, byte
         return;
     }
     auto self = shared_from_this();
-    // value message in frame; payload owned by the frame and sent as a view (zero-copy)
-    task::wait([self, _type, _dstNodeID = std::move(_dstNodeID),
-                   _payload = bcos::bytes(_payload.begin(), _payload.end()), _options,
-                   _callback]() mutable -> task::Task<void> {
+    // value message in frame; payload owned by the frame and sent as a view (zero-copy). All state
+    // is passed as coroutine parameters so it is copied into the frame and stays alive.
+    task::wait([](std::shared_ptr<Service> _self, uint16_t _type, P2pID _dstNodeID,
+                   bcos::bytes _payload, Options _options,
+                   P2PResponseCallback _callback) mutable -> task::Task<void> {
         P2PMessageV2 message;
         message.setPacketType(_type);
-        message.setSeq(self->messageFactory()->newSeq());
+        message.setSeq(_self->messageFactory()->newSeq());
         message.setPayload(std::move(_payload));
         if (!_callback)
         {
-            co_await self->sendMessageByNodeID(_dstNodeID, message,
+            co_await _self->sendMessageByNodeID(_dstNodeID, message,
                 ::ranges::views::single(message.payload()), Options{_options.timeout, false});
             co_return;
         }
         try
         {
-            auto resp = co_await self->sendMessageByNodeID(_dstNodeID, message,
+            auto resp = co_await _self->sendMessageByNodeID(_dstNodeID, message,
                 ::ranges::views::single(message.payload()), Options{_options.timeout, true});
             auto respMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
             auto packetType = respMessage ? respMessage->packetType() : (uint16_t)0;
@@ -695,23 +731,25 @@ void Service::asyncSendMessageByP2PNodeID(uint16_t _type, P2pID _dstNodeID, byte
         {
             _callback(e.toError(), 0, bytesConstRef{});
         }
-    }());
+    }(self, _type, std::move(_dstNodeID),
+        bcos::bytes(_payload.begin(), _payload.end()), _options, _callback));
 }
 
 void Service::asyncBroadcastMessageToP2PNodes(
     uint16_t _type, uint16_t moduleID, bytesConstRef _payload, Options _options)
 {
     auto self = shared_from_this();
-    // value message in frame; payload owned by the frame and sent as a view (zero-copy)
-    task::wait([self, _type, _payload = bcos::bytes(_payload.begin(), _payload.end()),
-                   _options]() mutable -> task::Task<void> {
+    // value message in frame; payload owned by the frame and sent as a view (zero-copy). All state
+    // is passed as coroutine parameters so it is copied into the frame and stays alive.
+    task::wait([](std::shared_ptr<Service> _self, uint16_t _type, bcos::bytes _payload,
+                   Options _options) mutable -> task::Task<void> {
         P2PMessageV2 message;
         message.setPacketType(_type);
-        message.setSeq(self->messageFactory()->newSeq());
+        message.setSeq(_self->messageFactory()->newSeq());
         message.setPayload(std::move(_payload));
-        co_await self->broadcastMessageToAll(
+        co_await _self->broadcastMessageToAll(
             message, ::ranges::views::single(message.payload()), _options);
-    }());
+    }(self, _type, bcos::bytes(_payload.begin(), _payload.end()), _options));
 }
 
 void Service::asyncSendMessageByP2PNodeIDs(
@@ -727,20 +765,21 @@ void Service::asyncSendMessageByP2PNodeIDs(
 void Service::asyncSendProtocol(P2PSession::Ptr _session)
 {
     auto self = shared_from_this();
-    // value message in frame; payload owned by the frame
-    task::wait([self, _session]() -> task::Task<void> {
+    // value message in frame; payload owned by the frame. All state is passed as coroutine
+    // parameters so it is copied into the frame and stays alive.
+    task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _session) -> task::Task<void> {
         auto payload = bytes();
-        self->m_codec->encode(self->m_localProtocol, payload);
+        _self->m_codec->encode(_self->m_localProtocol, payload);
         P2PMessageV2 message;
         message.setPacketType(GatewayMessageType::Handshake);
-        message.setSeq(self->messageFactory()->newSeq());
+        message.setSeq(_self->messageFactory()->newSeq());
         message.setPayload(std::move(payload));
         SERVICE_LOG(INFO) << LOG_DESC("asyncSendProtocol")
                           << LOG_KV("payload", message.payload().size())
                           << LOG_KV("seq", message.seq());
         co_await _session->fastSendP2PMessage(
             message, ::ranges::views::single(message.payload()), Options{});
-    }());
+    }(self, _session));
 }
 
 // receive the heartbeat msg

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -589,21 +589,25 @@ void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
         // behind it (base enqueued every peer and returned immediately).
         for (auto const& nodeID : nodeIDs)
         {
-            try
-            {
-                task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID,
-                               P2PMessage::Ptr _message, Options _options) mutable
-                               -> task::Task<void> {
+            task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID,
+                           P2PMessage::Ptr _message, Options _options) mutable
+                           -> task::Task<void> {
+                // catch both the synchronous pre-send rejection (rate limit / max size, thrown
+                // before the first suspension) and the asynchronous write failure (NetworkException
+                // from fastSendMessageWithoutResponse's await_resume): the latter would otherwise
+                // fall through to Session::write's generic post-handler without the target node id
+                try
+                {
                     co_await _self->sendMessageByNodeID(_nodeID, *_message,
                         ::ranges::views::single(_message->payload()), _options);
-                }(self, nodeID, message, options));
-            }
-            catch (std::exception const& e)
-            {
-                SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage send failed")
-                                     << LOG_KV("nodeid", printShortP2pID(nodeID))
-                                     << LOG_KV("what", boost::diagnostic_information(e));
-            }
+                }
+                catch (std::exception const& e)
+                {
+                    SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage send failed")
+                                         << LOG_KV("nodeid", printShortP2pID(_nodeID))
+                                         << LOG_KV("what", boost::diagnostic_information(e));
+                }
+            }(self, nodeID, message, options));
         }
     }
     catch (std::exception& e)
@@ -632,21 +636,21 @@ bcos::task::Task<void> Service::broadcastMessageToAll(
     // race on the shared header and no head-of-line blocking on a stalled peer's socket.
     for (auto const& nodeID : nodeIDs)
     {
-        try
-        {
-            task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
-                           ::ranges::any_view<bytesConstRef> _payloads,
-                           Options _options) mutable -> task::Task<void> {
+        task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
+                       ::ranges::any_view<bytesConstRef> _payloads,
+                       Options _options) mutable -> task::Task<void> {
+            try
+            {
                 co_await _self->sendMessageByNodeID(
                     _nodeID, *_message, std::move(_payloads), std::move(_options));
-            }(self, nodeID, message, payloads, options));
-        }
-        catch (std::exception const& e)
-        {
-            SERVICE_LOG(WARNING) << LOG_DESC("broadcastMessageToAll failed")
-                                 << LOG_KV("nodeid", printShortP2pID(nodeID))
-                                 << LOG_KV("what", boost::diagnostic_information(e));
-        }
+            }
+            catch (std::exception const& e)
+            {
+                SERVICE_LOG(WARNING) << LOG_DESC("broadcastMessageToAll failed")
+                                     << LOG_KV("nodeid", printShortP2pID(_nodeID))
+                                     << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }(self, nodeID, message, payloads, options));
     }
     co_return;
 }
@@ -673,21 +677,21 @@ bcos::task::Task<void> Service::broadcastMessageToNeighbors(
     // race on the shared header and no head-of-line blocking on a stalled peer's socket.
     for (auto const& nodeID : nodeIDs)
     {
-        try
-        {
-            task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
-                           ::ranges::any_view<bytesConstRef> _payloads,
-                           Options _options) mutable -> task::Task<void> {
+        task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID, P2PMessage::Ptr _message,
+                       ::ranges::any_view<bytesConstRef> _payloads,
+                       Options _options) mutable -> task::Task<void> {
+            try
+            {
                 co_await _self->sendMessageByNodeID(
                     _nodeID, *_message, std::move(_payloads), std::move(_options));
-            }(self, nodeID, message, payloads, options));
-        }
-        catch (std::exception const& e)
-        {
-            SERVICE_LOG(WARNING) << LOG_DESC("broadcastMessageToNeighbors failed")
-                                 << LOG_KV("nodeid", printShortP2pID(nodeID))
-                                 << LOG_KV("what", boost::diagnostic_information(e));
-        }
+            }
+            catch (std::exception const& e)
+            {
+                SERVICE_LOG(WARNING) << LOG_DESC("broadcastMessageToNeighbors failed")
+                                     << LOG_KV("nodeid", printShortP2pID(_nodeID))
+                                     << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }(self, nodeID, message, payloads, options));
     }
     co_return;
 }

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -60,6 +60,13 @@ public:
 
     void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) override;
 
+    /**
+     * @brief: (coroutine) broadcast a message to all connected sessions. The message and the
+     *         payload views must be kept alive by the caller for the duration of the co_await.
+     */
+    virtual task::Task<void> broadcastMessageToAll(P2PMessage& message,
+        ::ranges::any_view<bytesConstRef> payloads, Options options = Options());
+
     virtual std::map<NodeIPEndpoint, P2pID> staticNodes();
     virtual void setStaticNodes(const std::set<NodeIPEndpoint>& staticNodes);
 

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -64,8 +64,8 @@ public:
      * @brief: (coroutine) broadcast a message to all connected sessions. The message and the
      *         payload views must be kept alive by the caller for the duration of the co_await.
      */
-    virtual task::Task<void> broadcastMessageToAll(P2PMessage& message,
-        ::ranges::any_view<bytesConstRef> payloads, Options options = Options());
+    task::Task<void> broadcastMessageToAll(P2PMessage& message,
+        ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
 
     virtual std::map<NodeIPEndpoint, P2pID> staticNodes();
     virtual void setStaticNodes(const std::set<NodeIPEndpoint>& staticNodes);

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -67,7 +67,8 @@ public:
      *         task keeps the message alive (the payload rides as a view, zero-copy).
      */
     task::Task<void> broadcastMessageToAll(P2PMessage::Ptr message,
-        ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
+        Options options = Options()) override;
 
     /**
      * @brief: (coroutine) broadcast a message to the directly connected sessions only (m_sessions),
@@ -76,7 +77,8 @@ public:
      *         over as a shared_ptr and kept alive by the per-peer fan-out tasks.
      */
     virtual task::Task<void> broadcastMessageToNeighbors(P2PMessage::Ptr message,
-        ::ranges::any_view<bytesConstRef> payloads, Options options = Options());
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
+        Options options = Options());
 
     virtual std::map<NodeIPEndpoint, P2pID> staticNodes();
     virtual void setStaticNodes(const std::set<NodeIPEndpoint>& staticNodes);

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -67,6 +67,15 @@ public:
     task::Task<void> broadcastMessageToAll(P2PMessage& message,
         ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
 
+    /**
+     * @brief: (coroutine) broadcast a message to the directly connected sessions only (m_sessions),
+     *         without going through the router table. Used for router-table seq gossip which must
+     *         only be exchanged between neighbors and propagated hop-by-hop. The message and the
+     *         payload views must be kept alive by the caller for the duration of the co_await.
+     */
+    virtual task::Task<void> broadcastMessageToNeighbors(P2PMessage& message,
+        ::ranges::any_view<bytesConstRef> payloads, Options options = Options());
+
     virtual std::map<NodeIPEndpoint, P2pID> staticNodes();
     virtual void setStaticNodes(const std::set<NodeIPEndpoint>& staticNodes);
 

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -45,7 +45,8 @@ public:
     virtual void onMessage(NetworkException e, SessionFace::Ptr session, Message::Ptr message,
         std::weak_ptr<P2PSession> p2pSessionWeakPtr);
 
-    virtual std::optional<bcos::Error> onBeforeMessage(SessionFace& _session, Message& _message);
+    virtual std::optional<bcos::Error> onBeforeMessage(
+        SessionFace& _session, const Message& _message, uint32_t _wireLength);
 
     virtual void registerUnreachableHandler(std::function<void(std::string)> /*unused*/);
 
@@ -105,6 +106,9 @@ public:
     void asyncSendMessageByP2PNodeID(uint16_t _type, P2pID _dstNodeID, bytesConstRef _payload,
         Options options = Options(), P2PResponseCallback _callback = nullptr) override;
 
+    void setBeforeMessageHandler(std::function<std::optional<bcos::Error>(
+        SessionFace&, const Message&, uint32_t)> _handler);
+
     void asyncBroadcastMessageToP2PNodes(
         uint16_t _type, uint16_t moduleID, bytesConstRef _payload, Options _options) override;
 
@@ -119,9 +123,6 @@ public:
 
     void asyncSendMessageByEndPoint(NodeIPEndpoint const& _endPoint, P2PMessage::Ptr message,
         CallbackFuncWithSession callback, Options options = Options());
-
-    void setBeforeMessageHandler(
-        std::function<std::optional<bcos::Error>(SessionFace&, Message&)> _handler);
 
     void setOnMessageHandler(
         std::function<std::optional<bcos::Error>(SessionFace::Ptr, Message::Ptr)> _handler);
@@ -187,7 +188,8 @@ protected:
     // handlers called when delete-session
     std::vector<std::function<void(P2PSession::Ptr)>> m_deleteSessionHandlers;
 
-    std::function<std::optional<bcos::Error>(SessionFace&, Message&)> m_beforeMessageHandler;
+    std::function<std::optional<bcos::Error>(
+        SessionFace&, const Message&, uint32_t)> m_beforeMessageHandler;
     std::function<std::optional<bcos::Error>(SessionFace::Ptr, Message::Ptr)> m_onMessageHandler;
 };
 

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -62,19 +62,20 @@ public:
     void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) override;
 
     /**
-     * @brief: (coroutine) broadcast a message to all connected sessions. The message and the
-     *         payload views must be kept alive by the caller for the duration of the co_await.
+     * @brief: (coroutine) broadcast a message to all connected sessions. The message is handed
+     *         over as a shared_ptr: broadcastMessageToAll fans out one coroutine per peer and each
+     *         task keeps the message alive (the payload rides as a view, zero-copy).
      */
-    task::Task<void> broadcastMessageToAll(P2PMessage& message,
+    task::Task<void> broadcastMessageToAll(P2PMessage::Ptr message,
         ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
 
     /**
      * @brief: (coroutine) broadcast a message to the directly connected sessions only (m_sessions),
      *         without going through the router table. Used for router-table seq gossip which must
-     *         only be exchanged between neighbors and propagated hop-by-hop. The message and the
-     *         payload views must be kept alive by the caller for the duration of the co_await.
+     *         only be exchanged between neighbors and propagated hop-by-hop. The message is handed
+     *         over as a shared_ptr and kept alive by the per-peer fan-out tasks.
      */
-    virtual task::Task<void> broadcastMessageToNeighbors(P2PMessage& message,
+    virtual task::Task<void> broadcastMessageToNeighbors(P2PMessage::Ptr message,
         ::ranges::any_view<bytesConstRef> payloads, Options options = Options());
 
     virtual std::map<NodeIPEndpoint, P2pID> staticNodes();

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -188,13 +188,20 @@ void ServiceV2::onReceiveRouterTableRequest(
 void ServiceV2::broadcastRouterSeq()
 {
     m_routerTimer->restart();
-    auto message = std::static_pointer_cast<P2PMessage>(m_messageFactory->buildMessage());
-    message->setPacketType(GatewayMessageType::RouterTableSyncSeq);
     auto seq = m_statusSeq.load();
     auto statusSeq = boost::asio::detail::socket_ops::host_to_network_long(seq);
-    message->setPayload({(byte*)&statusSeq, (byte*)&statusSeq + 4});
-    // the router table should only exchange between neighbor
-    asyncBroadcastMessageWithoutForward(message, Options());
+    bytes payload;
+    payload.insert(payload.end(), (byte*)&statusSeq, (byte*)&statusSeq + 4);
+    auto self = std::static_pointer_cast<ServiceV2>(shared_from_this());
+    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send)
+    task::wait([self, payload = std::move(payload)]() mutable -> task::Task<void> {
+        P2PMessageV2 message;
+        message.setPacketType(GatewayMessageType::RouterTableSyncSeq);
+        message.setPayload(std::move(payload));
+        // the router table should only exchange between neighbor
+        co_await self->broadcastMessageToAll(
+            message, ::ranges::views::single(message.payload()), Options{});
+    }());
 }
 
 void ServiceV2::markRouterSeqChanged()
@@ -416,26 +423,63 @@ void ServiceV2::onMessage(NetworkException _error, SessionFace::Ptr _session, Me
                             << LOG_KV("rsp", p2pMsg->isRespPacket()) << LOG_KV("ttl", p2pMsg->ttl())
                             << LOG_KV("payLoadSize", p2pMsg->payload().size());
     }
-    asyncSendMessageByNodeIDWithMsgForward(p2pMsg, nullptr);
+    // forward through the coroutine fast path (zero-copy: the received message is captured in the
+    // frame and its payload is sent as a view)
+    auto self = shared_from_this();
+    task::wait([self, p2pMsg]() -> task::Task<void> {
+        co_await self->sendMessageByNodeID(
+            p2pMsg->dstP2PNodeID(), *p2pMsg, ::ranges::views::single(p2pMsg->payload()), Options{});
+    }());
 }
 
 void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options)
 {
     auto reachableNodes = m_routerTable->getAllReachableNode();
+    auto self = shared_from_this();
     try
     {
-        for (auto const& node : reachableNodes)
-        {
-            message->setSrcP2PNodeID(m_nodeID);
-            message->setDstP2PNodeID(node);
-            asyncSendMessageByNodeID(node, message, CallbackFuncWithSession(), options);
-        }
+        task::wait([self, reachableNodes = std::move(reachableNodes),
+                       message = std::move(message), options]() mutable -> task::Task<void> {
+            for (auto const& node : reachableNodes)
+            {
+                try
+                {
+                    co_await self->sendMessageByNodeID(
+                        node, *message, ::ranges::views::single(message->payload()), options);
+                }
+                catch (std::exception const& e)
+                {
+                    SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
+                                          << LOG_KV("what", boost::diagnostic_information(e));
+                }
+            }
+        }());
     }
     catch (std::exception& e)
     {
         SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
                               << LOG_KV("what", boost::diagnostic_information(e));
     }
+}
+
+bcos::task::Task<void> ServiceV2::broadcastMessageToAll(
+    P2PMessage& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+{
+    auto reachableNodes = m_routerTable->getAllReachableNode();
+    for (auto const& node : reachableNodes)
+    {
+        try
+        {
+            co_await sendMessageByNodeID(node, message, payloads, options);
+        }
+        catch (std::exception const& e)
+        {
+            SERVICE2_LOG(WARNING) << LOG_BADGE("broadcastMessageToAll")
+                                  << LOG_KV("node", printShortP2pID(node))
+                                  << LOG_KV("what", boost::diagnostic_information(e));
+        }
+    }
+    co_return;
 }
 
 // broadcast message without forward
@@ -460,26 +504,33 @@ void ServiceV2::sendRespMessageBySession(
         Service::sendRespMessageBySession(_payload, _p2pMessage, _p2pSession);
         return;
     }
-    auto respMessage = std::dynamic_pointer_cast<P2PMessageV2>(messageFactory()->buildMessage());
+    auto self = shared_from_this();
     auto requestMsg = std::dynamic_pointer_cast<P2PMessageV2>(_p2pMessage);
-    respMessage->setDstP2PNodeID(requestMsg->srcP2PNodeID());
-    respMessage->setSrcP2PNodeID(m_nodeID);
-    respMessage->setSeq(requestMsg->seq());
-    respMessage->setRespPacket();
-    // TODO: reduce memory copy
-    respMessage->setPayload({_payload.begin(), _payload.end()});
-
-    // Note: send response directly with the original session
-    sendMessageToSession(_p2pSession, respMessage);
-
-    if (c_fileLogLevel <= TRACE) [[unlikely]]
-    {
-        SERVICE2_LOG(TRACE) << LOG_BADGE("sendRespMessageBySession")
-                            << LOG_KV("seq", requestMsg->seq())
-                            << LOG_KV("from", respMessage->printSrcP2PNodeID())
-                            << LOG_KV("dst", respMessage->printDstP2PNodeID())
-                            << LOG_KV("payload size", _payload.size());
-    }
+    auto seq = requestMsg->seq();
+    auto dstP2PNodeID = requestMsg->srcP2PNodeID();
+    auto p2pid = _p2pSession->p2pID();
+    // value message in frame; response payload copied into the frame (borrowed from the receive
+    // callback which does not outlive the deferred send)
+    task::wait([self, _p2pSession, _payload = bcos::bytes(_payload.begin(), _payload.end()), seq,
+                   dstP2PNodeID, p2pid]() -> task::Task<void> {
+        P2PMessageV2 respMessage;
+        respMessage.setDstP2PNodeID(dstP2PNodeID);
+        respMessage.setSrcP2PNodeID(self->m_nodeID);
+        respMessage.setSeq(seq);
+        respMessage.setRespPacket();
+        respMessage.setPayload(std::move(_payload));
+        // Note: send response directly with the original session (zero-copy view of frame payload)
+        co_await _p2pSession->fastSendP2PMessage(
+            respMessage, ::ranges::views::single(respMessage.payload()), Options{});
+        if (c_fileLogLevel <= TRACE) [[unlikely]]
+        {
+            SERVICE2_LOG(TRACE) << LOG_BADGE("sendRespMessageBySession")
+                                << LOG_KV("seq", seq)
+                                << LOG_KV("from", respMessage.printSrcP2PNodeID())
+                                << LOG_KV("dst", respMessage.printDstP2PNodeID())
+                                << LOG_KV("payload size", respMessage.payload().size());
+        }
+    }());
 }
 
 bcos::task::Task<Message::Ptr> bcos::gateway::ServiceV2::sendMessageByNodeID(

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -450,20 +450,21 @@ void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Optio
         // behind it.
         for (auto const& node : reachableNodes)
         {
-            try
-            {
-                task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node,
-                               std::shared_ptr<P2PMessage> _message,
-                               Options _options) mutable -> task::Task<void> {
+            task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node,
+                           std::shared_ptr<P2PMessage> _message,
+                           Options _options) mutable -> task::Task<void> {
+                try
+                {
                     co_await _self->sendMessageByNodeID(_node, *_message,
                         ::ranges::views::single(_message->payload()), _options);
-                }(selfV2, node, message, options));
-            }
-            catch (std::exception const& e)
-            {
-                SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
-                                      << LOG_KV("what", boost::diagnostic_information(e));
-            }
+                }
+                catch (std::exception const& e)
+                {
+                    SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
+                                          << LOG_KV("node", printShortP2pID(_node))
+                                          << LOG_KV("what", boost::diagnostic_information(e));
+                }
+            }(selfV2, node, message, options));
         }
     }
     catch (std::exception& e)
@@ -481,21 +482,21 @@ bcos::task::Task<void> ServiceV2::broadcastMessageToAll(
     // Fan out one independent coroutine per peer (see Service::broadcastMessageToAll).
     for (auto const& node : reachableNodes)
     {
-        try
-        {
-            task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node, P2PMessage::Ptr _message,
-                           ::ranges::any_view<bytesConstRef> _payloads,
-                           Options _options) mutable -> task::Task<void> {
+        task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node, P2PMessage::Ptr _message,
+                       ::ranges::any_view<bytesConstRef> _payloads,
+                       Options _options) mutable -> task::Task<void> {
+            try
+            {
                 co_await _self->sendMessageByNodeID(
                     _node, *_message, std::move(_payloads), std::move(_options));
-            }(selfV2, node, message, payloads, options));
-        }
-        catch (std::exception const& e)
-        {
-            SERVICE2_LOG(WARNING) << LOG_BADGE("broadcastMessageToAll")
-                                  << LOG_KV("node", printShortP2pID(node))
-                                  << LOG_KV("what", boost::diagnostic_information(e));
-        }
+            }
+            catch (std::exception const& e)
+            {
+                SERVICE2_LOG(WARNING) << LOG_BADGE("broadcastMessageToAll")
+                                      << LOG_KV("node", printShortP2pID(_node))
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }(selfV2, node, message, payloads, options));
     }
     co_return;
 }

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -21,6 +21,7 @@
 #include "Common.h"
 #include "P2PMessageV2.h"
 #include "bcos-utilities/BoostLog.h"
+#include <bcos-task/Wait.h>
 #include <cstring>
 #include <utility>
 
@@ -193,17 +194,17 @@ void ServiceV2::broadcastRouterSeq()
     bytes payload;
     payload.insert(payload.end(), (byte*)&statusSeq, (byte*)&statusSeq + 4);
     auto self = std::static_pointer_cast<ServiceV2>(shared_from_this());
-    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send).
-    // The router table should only be exchanged between neighbours and propagated hop-by-hop, so
-    // broadcast to the directly connected sessions only (not all reachable nodes). All state is
-    // passed as coroutine parameters so it is copied into the frame and stays alive.
+    // value message held by shared_ptr; the 4-byte seq payload is owned by it (zero-copy view
+    // send). The router table should only be exchanged between neighbours and propagated
+    // hop-by-hop, so broadcast to the directly connected sessions only (not all reachable nodes).
+    // All state is passed as coroutine parameters so it is copied into the frame and stays alive.
     task::wait([](std::shared_ptr<ServiceV2> _self, bcos::bytes _payload) mutable
                    -> task::Task<void> {
-        P2PMessageV2 message;
-        message.setPacketType(GatewayMessageType::RouterTableSyncSeq);
-        message.setPayload(std::move(_payload));
+        auto message = std::make_shared<P2PMessageV2>();
+        message->setPacketType(GatewayMessageType::RouterTableSyncSeq);
+        message->setPayload(std::move(_payload));
         co_await _self->broadcastMessageToNeighbors(
-            message, ::ranges::views::single(message.payload()), Options{});
+            message, ::ranges::views::single(message->payload()), Options{});
     }(self, std::move(payload)));
 }
 
@@ -439,28 +440,31 @@ void ServiceV2::onMessage(NetworkException _error, SessionFace::Ptr _session, Me
 
 void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options)
 {
-    auto reachableNodes = m_routerTable->getAllReachableNode();
-    auto self = shared_from_this();
     try
     {
-        auto selfV2 = std::static_pointer_cast<ServiceV2>(self);
-        task::wait([](std::shared_ptr<ServiceV2> _self, std::set<P2pID> _reachableNodes,
-                       std::shared_ptr<P2PMessage> _message,
-                       Options _options) mutable -> task::Task<void> {
-            for (auto const& node : _reachableNodes)
+        auto reachableNodes = m_routerTable->getAllReachableNode();
+        auto selfV2 = std::static_pointer_cast<ServiceV2>(shared_from_this());
+        // Fan out one independent coroutine per peer (see Service::asyncBroadcastMessage): each
+        // task holds the shared message, its per-session src/dst/version stamping runs
+        // synchronously before its first suspension, and no peer's socket-write blocks the peers
+        // behind it.
+        for (auto const& node : reachableNodes)
+        {
+            try
             {
-                try
-                {
-                    co_await _self->sendMessageByNodeID(
-                        node, *_message, ::ranges::views::single(_message->payload()), _options);
-                }
-                catch (std::exception const& e)
-                {
-                    SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
-                                          << LOG_KV("what", boost::diagnostic_information(e));
-                }
+                task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node,
+                               std::shared_ptr<P2PMessage> _message,
+                               Options _options) mutable -> task::Task<void> {
+                    co_await _self->sendMessageByNodeID(_node, *_message,
+                        ::ranges::views::single(_message->payload()), _options);
+                }(selfV2, node, message, options));
             }
-        }(selfV2, std::move(reachableNodes), std::move(message), options));
+            catch (std::exception const& e)
+            {
+                SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }
     }
     catch (std::exception& e)
     {
@@ -470,14 +474,21 @@ void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Optio
 }
 
 bcos::task::Task<void> ServiceV2::broadcastMessageToAll(
-    P2PMessage& message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef> payloads, Options options)
 {
     auto reachableNodes = m_routerTable->getAllReachableNode();
+    auto selfV2 = std::static_pointer_cast<ServiceV2>(shared_from_this());
+    // Fan out one independent coroutine per peer (see Service::broadcastMessageToAll).
     for (auto const& node : reachableNodes)
     {
         try
         {
-            co_await sendMessageByNodeID(node, message, payloads, options);
+            task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node, P2PMessage::Ptr _message,
+                           ::ranges::any_view<bytesConstRef> _payloads,
+                           Options _options) mutable -> task::Task<void> {
+                co_await _self->sendMessageByNodeID(
+                    _node, *_message, std::move(_payloads), std::move(_options));
+            }(selfV2, node, message, payloads, options));
         }
         catch (std::exception const& e)
         {

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -193,15 +193,18 @@ void ServiceV2::broadcastRouterSeq()
     bytes payload;
     payload.insert(payload.end(), (byte*)&statusSeq, (byte*)&statusSeq + 4);
     auto self = std::static_pointer_cast<ServiceV2>(shared_from_this());
-    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send)
-    task::wait([self, payload = std::move(payload)]() mutable -> task::Task<void> {
+    // value message in frame; the 4-byte seq payload is owned by the frame (zero-copy view send).
+    // The router table should only be exchanged between neighbours and propagated hop-by-hop, so
+    // broadcast to the directly connected sessions only (not all reachable nodes). All state is
+    // passed as coroutine parameters so it is copied into the frame and stays alive.
+    task::wait([](std::shared_ptr<ServiceV2> _self, bcos::bytes _payload) mutable
+                   -> task::Task<void> {
         P2PMessageV2 message;
         message.setPacketType(GatewayMessageType::RouterTableSyncSeq);
-        message.setPayload(std::move(payload));
-        // the router table should only exchange between neighbor
-        co_await self->broadcastMessageToAll(
+        message.setPayload(std::move(_payload));
+        co_await _self->broadcastMessageToNeighbors(
             message, ::ranges::views::single(message.payload()), Options{});
-    }());
+    }(self, std::move(payload)));
 }
 
 void ServiceV2::markRouterSeqChanged()
@@ -414,8 +417,7 @@ void ServiceV2::onMessage(NetworkException _error, SessionFace::Ptr _session, Me
     p2pMsg->setTTL(ttl);
     if (c_fileLogLevel <= TRACE) [[unlikely]]
     {
-        SERVICE2_LOG(TRACE) << LOG_BADGE("onMessage")
-                            << LOG_DESC("asyncSendMessageByNodeIDWithMsgForward")
+        SERVICE2_LOG(TRACE) << LOG_BADGE("onMessage") << LOG_DESC("forwardMessage")
                             << LOG_KV("seq", p2pMsg->seq())
                             << LOG_KV("from", p2pMsg->printSrcP2PNodeID())
                             << LOG_KV("dst", p2pMsg->printDstP2PNodeID())
@@ -423,13 +425,16 @@ void ServiceV2::onMessage(NetworkException _error, SessionFace::Ptr _session, Me
                             << LOG_KV("rsp", p2pMsg->isRespPacket()) << LOG_KV("ttl", p2pMsg->ttl())
                             << LOG_KV("payLoadSize", p2pMsg->payload().size());
     }
-    // forward through the coroutine fast path (zero-copy: the received message is captured in the
-    // frame and its payload is sent as a view)
-    auto self = shared_from_this();
-    task::wait([self, p2pMsg]() -> task::Task<void> {
-        co_await self->sendMessageByNodeID(
-            p2pMsg->dstP2PNodeID(), *p2pMsg, ::ranges::views::single(p2pMsg->payload()), Options{});
-    }());
+    // forward through the coroutine fast path (zero-copy: the received message is passed as a
+    // coroutine parameter so it is copied into the frame and stays alive, and its payload is sent
+    // as a view). Note: forwarding must NOT rewrite srcP2PNodeID (that is only done when this node
+    // originates the message) — forwardMessageByNodeID only resolves the next hop.
+    auto self = std::static_pointer_cast<ServiceV2>(shared_from_this());
+    task::wait([](std::shared_ptr<ServiceV2> _self,
+                   std::shared_ptr<P2PMessageV2> _p2pMsg) -> task::Task<void> {
+        co_await _self->forwardMessageByNodeID(_p2pMsg->dstP2PNodeID(), *_p2pMsg,
+            ::ranges::views::single(_p2pMsg->payload()), Options{});
+    }(self, p2pMsg));
 }
 
 void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options)
@@ -438,14 +443,16 @@ void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Optio
     auto self = shared_from_this();
     try
     {
-        task::wait([self, reachableNodes = std::move(reachableNodes),
-                       message = std::move(message), options]() mutable -> task::Task<void> {
-            for (auto const& node : reachableNodes)
+        auto selfV2 = std::static_pointer_cast<ServiceV2>(self);
+        task::wait([](std::shared_ptr<ServiceV2> _self, std::set<P2pID> _reachableNodes,
+                       std::shared_ptr<P2PMessage> _message,
+                       Options _options) mutable -> task::Task<void> {
+            for (auto const& node : _reachableNodes)
             {
                 try
                 {
-                    co_await self->sendMessageByNodeID(
-                        node, *message, ::ranges::views::single(message->payload()), options);
+                    co_await _self->sendMessageByNodeID(
+                        node, *_message, ::ranges::views::single(_message->payload()), _options);
                 }
                 catch (std::exception const& e)
                 {
@@ -453,7 +460,7 @@ void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Optio
                                           << LOG_KV("what", boost::diagnostic_information(e));
                 }
             }
-        }());
+        }(selfV2, std::move(reachableNodes), std::move(message), options));
     }
     catch (std::exception& e)
     {
@@ -510,13 +517,15 @@ void ServiceV2::sendRespMessageBySession(
     auto dstP2PNodeID = requestMsg->srcP2PNodeID();
     auto p2pid = _p2pSession->p2pID();
     // value message in frame; response payload copied into the frame (borrowed from the receive
-    // callback which does not outlive the deferred send)
-    task::wait([self, _p2pSession, _payload = bcos::bytes(_payload.begin(), _payload.end()), seq,
-                   dstP2PNodeID, p2pid]() -> task::Task<void> {
+    // callback which does not outlive the deferred send). All state is passed as coroutine
+    // parameters so it is copied into the frame and stays alive.
+    task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _p2pSession,
+                   bcos::bytes _payload, uint32_t _seq, std::string _dstP2PNodeID,
+                   P2pID _p2pid) -> task::Task<void> {
         P2PMessageV2 respMessage;
-        respMessage.setDstP2PNodeID(dstP2PNodeID);
-        respMessage.setSrcP2PNodeID(self->m_nodeID);
-        respMessage.setSeq(seq);
+        respMessage.setDstP2PNodeID(_dstP2PNodeID);
+        respMessage.setSrcP2PNodeID(_self->m_nodeID);
+        respMessage.setSeq(_seq);
         respMessage.setRespPacket();
         respMessage.setPayload(std::move(_payload));
         // Note: send response directly with the original session (zero-copy view of frame payload)
@@ -525,20 +534,31 @@ void ServiceV2::sendRespMessageBySession(
         if (c_fileLogLevel <= TRACE) [[unlikely]]
         {
             SERVICE2_LOG(TRACE) << LOG_BADGE("sendRespMessageBySession")
-                                << LOG_KV("seq", seq)
+                                << LOG_KV("seq", _seq)
                                 << LOG_KV("from", respMessage.printSrcP2PNodeID())
                                 << LOG_KV("dst", respMessage.printDstP2PNodeID())
                                 << LOG_KV("payload size", respMessage.payload().size());
         }
-    }());
+    }(self, _p2pSession, bcos::bytes(_payload.begin(), _payload.end()), seq, dstP2PNodeID,
+        p2pid));
 }
 
 bcos::task::Task<Message::Ptr> bcos::gateway::ServiceV2::sendMessageByNodeID(
     P2pID nodeID, P2PMessage& header, ::ranges::any_view<bytesConstRef> payloads, Options options)
 {
+    // this node originates the message: stamp src/dst before routing
     header.setSrcP2PNodeID(m_nodeID);
     header.setDstP2PNodeID(nodeID);
 
+    co_return co_await forwardMessageByNodeID(nodeID, header, std::move(payloads), options);
+}
+
+bcos::task::Task<Message::Ptr> bcos::gateway::ServiceV2::forwardMessageByNodeID(
+    P2pID nodeID, P2PMessage& header, ::ranges::any_view<bytesConstRef> payloads, Options options)
+{
+    // Forwarding path (a message received from another node being relayed): unlike
+    // sendMessageByNodeID it must NOT rewrite srcP2PNodeID — the original sender is preserved so
+    // the final destination can reply directly to it. Only the next hop is resolved here.
     auto dstNodeID = header.dstP2PNodeID();
     // without nextHop: maybe network unreachable or with distance equal to 1
     auto nextHop = m_routerTable->getNextHop(dstNodeID);
@@ -546,7 +566,7 @@ bcos::task::Task<Message::Ptr> bcos::gateway::ServiceV2::sendMessageByNodeID(
     {
         if (c_fileLogLevel == TRACE) [[unlikely]]
         {
-            SERVICE2_LOG(TRACE) << LOG_BADGE("sendMessageByNodeID")
+            SERVICE2_LOG(TRACE) << LOG_BADGE("forwardMessageByNodeID")
                                 << LOG_DESC("sendMessage to dstNode")
                                 << LOG_KV("from", header.printSrcP2PNodeID())
                                 << LOG_KV("to", header.printDstP2PNodeID())
@@ -560,7 +580,7 @@ bcos::task::Task<Message::Ptr> bcos::gateway::ServiceV2::sendMessageByNodeID(
     // with nextHop, send the message to nextHop
     if (c_fileLogLevel == TRACE) [[unlikely]]
     {
-        SERVICE2_LOG(TRACE) << LOG_BADGE("sendMessageByNodeID")
+        SERVICE2_LOG(TRACE) << LOG_BADGE("forwardMessageByNodeID")
                             << LOG_DESC("forwardMessage to nextHop")
                             << LOG_KV("from", header.printSrcP2PNodeID())
                             << LOG_KV("to", header.printDstP2PNodeID())

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -488,7 +488,8 @@ void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Optio
 }
 
 bcos::task::Task<void> ServiceV2::broadcastMessageToAll(
-    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef> payloads, Options options)
+    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
+    Options options)
 {
     auto reachableNodes = m_routerTable->getAllReachableNode();
     auto selfV2 = std::static_pointer_cast<ServiceV2>(shared_from_this());
@@ -496,7 +497,7 @@ bcos::task::Task<void> ServiceV2::broadcastMessageToAll(
     for (auto const& node : reachableNodes)
     {
         task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node, P2PMessage::Ptr _message,
-                       ::ranges::any_view<bytesConstRef> _payloads,
+                       ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
                        Options _options) mutable -> task::Task<void> {
             try
             {

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -433,8 +433,21 @@ void ServiceV2::onMessage(NetworkException _error, SessionFace::Ptr _session, Me
     auto self = std::static_pointer_cast<ServiceV2>(shared_from_this());
     task::wait([](std::shared_ptr<ServiceV2> _self,
                    std::shared_ptr<P2PMessageV2> _p2pMsg) -> task::Task<void> {
-        co_await _self->forwardMessageByNodeID(_p2pMsg->dstP2PNodeID(), *_p2pMsg,
-            ::ranges::views::single(_p2pMsg->payload()), Options{});
+        try
+        {
+            co_await _self->forwardMessageByNodeID(_p2pMsg->dstP2PNodeID(), *_p2pMsg,
+                ::ranges::views::single(_p2pMsg->payload()), Options{});
+        }
+        catch (std::exception const& e)
+        {
+            // A synchronous pre-send rejection (rate limit / max size) or an async write failure
+            // on the relay path is expected during bandwidth saturation — log the next hop so a
+            // "peer not receiving relayed messages" investigation keeps the routing dimension.
+            SERVICE2_LOG(WARNING) << LOG_BADGE("onMessage") << LOG_DESC("forwardMessage failed")
+                                  << LOG_KV("dst", _p2pMsg->dstP2PNodeID())
+                                  << LOG_KV("seq", _p2pMsg->seq())
+                                  << LOG_KV("what", boost::diagnostic_information(e));
+        }
     }(self, p2pMsg));
 }
 
@@ -534,22 +547,35 @@ void ServiceV2::sendRespMessageBySession(
     task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _p2pSession,
                    bcos::bytes _payload, uint32_t _seq, std::string _dstP2PNodeID,
                    P2pID _p2pid) -> task::Task<void> {
-        P2PMessageV2 respMessage;
-        respMessage.setDstP2PNodeID(_dstP2PNodeID);
-        respMessage.setSrcP2PNodeID(_self->m_nodeID);
-        respMessage.setSeq(_seq);
-        respMessage.setRespPacket();
-        respMessage.setPayload(std::move(_payload));
-        // Note: send response directly with the original session (zero-copy view of frame payload)
-        co_await _p2pSession->fastSendP2PMessage(
-            respMessage, ::ranges::views::single(respMessage.payload()), Options{});
-        if (c_fileLogLevel <= TRACE) [[unlikely]]
+        try
         {
-            SERVICE2_LOG(TRACE) << LOG_BADGE("sendRespMessageBySession")
-                                << LOG_KV("seq", _seq)
-                                << LOG_KV("from", respMessage.printSrcP2PNodeID())
-                                << LOG_KV("dst", respMessage.printDstP2PNodeID())
-                                << LOG_KV("payload size", respMessage.payload().size());
+            P2PMessageV2 respMessage;
+            respMessage.setDstP2PNodeID(_dstP2PNodeID);
+            respMessage.setSrcP2PNodeID(_self->m_nodeID);
+            respMessage.setSeq(_seq);
+            respMessage.setRespPacket();
+            respMessage.setPayload(std::move(_payload));
+            // Note: send response directly with the original session (zero-copy view of frame payload)
+            co_await _p2pSession->fastSendP2PMessage(
+                respMessage, ::ranges::views::single(respMessage.payload()), Options{});
+            if (c_fileLogLevel <= TRACE) [[unlikely]]
+            {
+                SERVICE2_LOG(TRACE) << LOG_BADGE("sendRespMessageBySession")
+                                    << LOG_KV("seq", _seq)
+                                    << LOG_KV("from", respMessage.printSrcP2PNodeID())
+                                    << LOG_KV("dst", respMessage.printDstP2PNodeID())
+                                    << LOG_KV("payload size", respMessage.payload().size());
+            }
+        }
+        catch (std::exception const& e)
+        {
+            // A synchronous pre-send rejection (rate limit / max size) on the response path is
+            // expected during bandwidth saturation — log the request seq and target so the
+            // response-loss investigation keeps the routing dimension.
+            SERVICE2_LOG(WARNING) << LOG_BADGE("sendRespMessageBySession")
+                                  << LOG_DESC("send response failed") << LOG_KV("seq", _seq)
+                                  << LOG_KV("dst", _dstP2PNodeID)
+                                  << LOG_KV("what", boost::diagnostic_information(e));
         }
     }(self, _p2pSession, bcos::bytes(_payload.begin(), _payload.end()), seq, dstP2PNodeID,
         p2pid));

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -487,9 +487,8 @@ void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Optio
     }
 }
 
-bcos::task::Task<void> ServiceV2::broadcastMessageToAll(
-    P2PMessage::Ptr message, ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
-    Options options)
+bcos::task::Task<void> ServiceV2::broadcastMessageToAll(P2PMessage::Ptr message,
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads, Options options)
 {
     auto reachableNodes = m_routerTable->getAllReachableNode();
     auto selfV2 = std::static_pointer_cast<ServiceV2>(shared_from_this());
@@ -556,7 +555,7 @@ void ServiceV2::sendRespMessageBySession(
             respMessage.setSeq(_seq);
             respMessage.setRespPacket();
             respMessage.setPayload(std::move(_payload));
-            // Note: send response directly with the original session (zero-copy view of frame payload)
+            // Note: respond directly via the original session (zero-copy view)
             co_await _p2pSession->fastSendP2PMessage(
                 respMessage, ::ranges::views::single(respMessage.payload()), Options{});
             if (c_fileLogLevel <= TRACE) [[unlikely]]

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
@@ -54,7 +54,8 @@ public:
 
     // (coroutine) broadcast to all reachable nodes through the router table
     task::Task<void> broadcastMessageToAll(P2PMessage::Ptr message,
-        ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads,
+        Options options = Options()) override;
 
     // handlers called when the node is unreachable
     void registerUnreachableHandler(std::function<void(std::string)> _handler) override;

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
@@ -53,7 +53,7 @@ public:
     bool isReachable(P2pID const& _nodeID) const override;
 
     // (coroutine) broadcast to all reachable nodes through the router table
-    task::Task<void> broadcastMessageToAll(P2PMessage& message,
+    task::Task<void> broadcastMessageToAll(P2PMessage::Ptr message,
         ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
 
     // handlers called when the node is unreachable

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
@@ -52,6 +52,10 @@ public:
     void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) override;
     bool isReachable(P2pID const& _nodeID) const override;
 
+    // (coroutine) broadcast to all reachable nodes through the router table
+    task::Task<void> broadcastMessageToAll(P2PMessage& message,
+        ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
+
     // handlers called when the node is unreachable
     void registerUnreachableHandler(std::function<void(std::string)> _handler) override;
 

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
@@ -62,6 +62,12 @@ public:
     task::Task<Message::Ptr> sendMessageByNodeID(P2pID nodeID, P2PMessage& message,
         ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
 
+    // (coroutine) forward a received message to its destination through the router table. Unlike
+    // sendMessageByNodeID it does NOT rewrite srcP2PNodeID: the original sender must be preserved
+    // so the final destination can reply to it directly.
+    task::Task<Message::Ptr> forwardMessageByNodeID(P2pID nodeID, P2PMessage& message,
+        ::ranges::any_view<bytesConstRef> payloads, Options options = Options());
+
     std::string getShortP2pID(std::string const& rawP2pID) const override;
     std::string getRawP2pID(std::string const& shortP2pID) const override;
 

--- a/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
@@ -56,20 +56,21 @@ class BroadcastProbeService : public Service
 public:
     explicit BroadcastProbeService(P2PInfo const& _info) : Service(_info) {}
 
-    // Put one session in m_sessions so asyncBroadcastMessage's loop actually calls
-    // asyncSendMessageByNodeID once; capture x_sessions for the probe thread.
+    // Put one session in m_sessions so asyncBroadcastMessage's loop actually sends once; capture
+    // x_sessions for the probe thread.
     void arm()
     {
         m_xSessionsPtr = &x_sessions;
         m_sessions.emplace("peerRawP2pID", std::make_shared<P2PSession>());
     }
 
-    // asyncBroadcastMessage calls this (virtual) for each session. On the pre-fix code it still
-    // holds x_sessions(shared) here. A probe thread tries to take x_sessions EXCLUSIVELY: it fails
-    // iff the broadcasting thread still holds it. No throw needed -- asyncBroadcastMessage touches
-    // no host.
-    void asyncSendMessageByNodeID(P2pID /*nodeID*/, std::shared_ptr<P2PMessage> /*message*/,
-        CallbackFuncWithSession /*callback*/, Options /*options*/) override
+    // asyncBroadcastMessage now sends through the coroutine fast path (sendMessageByNodeID) for
+    // each session, after snapshotting the session keys under x_sessions and releasing it. This
+    // virtual is called for each session; a probe thread tries to take x_sessions EXCLUSIVELY: it
+    // fails iff the broadcasting thread still holds it. No throw needed -- asyncBroadcastMessage
+    // touches no host; we just probe the lock state and stop.
+    task::Task<Message::Ptr> sendMessageByNodeID(P2pID /*nodeID*/, P2PMessage& /*header*/,
+        ::ranges::any_view<bytesConstRef> /*payloads*/, Options /*options*/) override
     {
         bool acquiredExclusive = false;
         std::thread probe([this, &acquiredExclusive]() {
@@ -89,6 +90,7 @@ public:
         probe.join();
         m_xSessionsHeldDuringSend = !acquiredExclusive;
         m_sendInvoked = true;
+        co_return nullptr;
     }
 
     std::shared_mutex* m_xSessionsPtr = nullptr;
@@ -110,11 +112,11 @@ BOOST_AUTO_TEST_CASE(BroadcastDoesNotHoldSessionsLockWhileSending)
 
     BOOST_REQUIRE(service->m_sendInvoked.load());
     BOOST_CHECK_MESSAGE(!service->m_xSessionsHeldDuringSend.load(),
-        "FIB-186 vector D: asyncBroadcastMessage held x_sessions(shared) while calling "
-        "asyncSendMessageByNodeID (which re-acquires x_sessions via getP2PSessionByNodeId). That "
-        "recursive shared lock deadlocks against a waiting onConnect writer and halts consensus. "
-        "asyncBroadcastMessage must snapshot the session keys under x_sessions, release it, then "
-        "send.");
+        "FIB-186 vector D: asyncBroadcastMessage held x_sessions(shared) while sending to a "
+        "session via sendMessageByNodeID (which re-acquires x_sessions via getP2PSessionByNodeId). "
+        "That recursive shared lock deadlocks against a waiting onConnect writer and halts "
+        "consensus. asyncBroadcastMessage must snapshot the session keys under x_sessions, "
+        "release it, then send.");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/ServiceAsyncSendProtocolThrowEscapeTest.cpp
+++ b/bcos-gateway/test/unittests/ServiceAsyncSendProtocolThrowEscapeTest.cpp
@@ -1,0 +1,116 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @brief Regression test for round-3 review finding 1: Service::asyncSendProtocol must not let a
+ *        synchronous pre-send rejection (outgoing rate limit / max size) escape task::wait and
+ *        abort Service::onConnect's session-registration tail (the session would stay
+ *        live-but-unregistered, silently hidden from the routing layer).
+ * @file ServiceAsyncSendProtocolThrowEscapeTest.cpp
+ * @date 2026-08-25
+ *
+ * The pre-send checks in Session::fastSendMessage (allowMaxMsgSize / beforeMessageHandler) run
+ * synchronously on the caller thread and BOOST_THROW_EXCEPTION. That exception propagates out of
+ * task::wait synchronously (the nested co_await chain unwinds inside AsyncTask::start()). If
+ * asyncSendProtocol did not catch it, onConnect's lines after the handshake call —
+ * updateStaticNodes, m_sessions[p2pID] = p2pSession, callNewSessionHandlers — would all be
+ * skipped, leaving a started/live socket that the routing layer cannot see. This test is RED on
+ * the pre-fix code (the rejection escapes) and GREEN after (caught inside the coroutine).
+ */
+
+#include "bcos-framework/gateway/GatewayTypeDef.h"
+#include "bcos-framework/protocol/GlobalConfig.h"
+#include "bcos-gateway/libnetwork/SessionFace.h"
+#include "bcos-gateway/libnetwork/SocketFace.h"
+#include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
+#include "bcos-gateway/libp2p/P2PSession.h"
+#include "bcos-gateway/libp2p/Service.h"
+#include "bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.h"
+#include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/test/unit_test.hpp>
+
+using namespace bcos;
+using namespace bcos::gateway;
+using namespace bcos::test;
+
+BOOST_FIXTURE_TEST_SUITE(ServiceAsyncSendProtocolThrowEscapeTest, TestPromptFixture)
+
+namespace
+{
+// Service::asyncSendProtocol is protected; expose it for the test through a subclass (same pattern
+// as the FIB-186 lock-order tests).
+class ProbeService : public Service
+{
+public:
+    explicit ProbeService(P2PInfo const& _info) : Service(_info) {}
+    void sendProtocol(P2PSession::Ptr _session) { asyncSendProtocol(std::move(_session)); }
+};
+
+// A SessionFace whose fastSendMessage rejects synchronously — the same way Session::
+// fastSendMessage throws NetworkException for a rate-limit / oversize rejection before any
+// suspension. P2PSession::fastSendP2PMessage therefore throws synchronously out of the co_await,
+// which (pre-fix) escaped task::wait inside Service::asyncSendProtocol.
+class RejectingSession : public SessionFace
+{
+public:
+    void start() override {}
+    void disconnect(DisconnectReason) override {}
+    task::Task<Message::Ptr> fastSendMessage(const Message& /*header*/,
+        ::ranges::any_view<bytesConstRef> /*payloads*/, Options /*options*/) override
+    {
+        BOOST_THROW_EXCEPTION(NetworkException(-1, "outgoing bandwidth overflow"));
+        co_return nullptr;
+    }
+    std::shared_ptr<SocketFace> socket() override { return nullptr; }
+    void setMessageHandler(
+        std::function<void(NetworkException, SessionFace::Ptr, Message::Ptr)>) override
+    {}
+    void setBeforeMessageHandler(std::function<std::optional<bcos::Error>(
+        SessionFace&, const Message&, uint32_t)>) override
+    {}
+    NodeIPEndpoint nodeIPEndpoint() const override { return {}; }
+    bool active() const override { return true; }
+    std::size_t writeQueueSize() override { return 0; }
+};
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(AsyncSendProtocolDoesNotEscapeSendRejection)
+{
+    // asyncSendProtocol encodes the local protocol via g_BCOSConfig's codec — the same global the
+    // Service constructor reads. Production initializers set it before building the gateway; the
+    // unit-test harness does not, so set it here (idempotent).
+    bcos::protocol::g_BCOSConfig.setCodec(
+        std::make_shared<bcostars::protocol::ProtocolInfoCodecImpl>());
+
+    P2PInfo selfInfo;
+    selfInfo.rawP2pID = "selfRawP2pID";
+    selfInfo.p2pID = "selfP2pID";
+    auto service = std::make_shared<ProbeService>(selfInfo);
+    service->setMessageFactory(std::make_shared<P2PMessageFactoryV2>());
+
+    auto p2pSession = std::make_shared<P2PSession>();
+    p2pSession->setSession(std::make_shared<RejectingSession>());
+    p2pSession->setService(service);
+    p2pSession->setProtocolInfo(
+        g_BCOSConfig.protocolInfo(bcos::protocol::ProtocolModuleID::GatewayService));
+
+    // Pre-fix: the handshake rejection escapes task::wait and propagates out of asyncSendProtocol
+    // (synchronously aborting onConnect's registration tail). Post-fix: caught inside the
+    // coroutine and logged — a failed handshake is a recoverable per-session failure and the
+    // session registration in onConnect must proceed.
+    BOOST_CHECK_NO_THROW(service->sendProtocol(p2pSession));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -23,11 +23,13 @@
 #include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include <bcos-task/Wait.h>
 #include <bcos-utilities/IOServicePool.h>
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 #include <queue>
+#include <range/v3/view/single.hpp>
 
 using namespace bcos;
 using namespace gateway;
@@ -361,6 +363,38 @@ BOOST_AUTO_TEST_CASE(doReadTest)
         session->setSocket(nullptr);
     }
 
+    fakeSocket->close();
+}
+
+BOOST_AUTO_TEST_CASE(fastSendMessageOutboundRateLimit)
+{
+    // The fast path must honour the same pre-send (outgoing rate-limit) check the removed callback
+    // path (asyncSendMessage) enforced: a beforeMessageHandler rejection surfaces as a thrown
+    // NetworkException (e.g. OutBWOverflow) so coroutine retry loops can stop.
+    auto fakeMessageFactory = std::make_shared<FakeMessageFactory>();
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeSocket = std::make_shared<FakeSocket>();
+    auto fakeAsio = std::make_shared<FakeASIO>();
+    {
+        auto fakeHost = std::make_shared<FakeHost>(hashImpl, fakeAsio, nullptr, fakeMessageFactory);
+        auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
+        session->setMessageFactory(fakeHost->messageFactory());
+        session->setBeforeMessageHandler([](SessionFace&, Message&) -> std::optional<bcos::Error> {
+            return bcos::Error::buildError(
+                "", P2PExceptionType::OutBWOverflow, "outgoing bandwidth overflow");
+        });
+        session->start();
+
+        P2PMessage message;
+        message.setSeq(1);
+        bytes payload{1, 2, 3, 4};
+        BOOST_CHECK_THROW(
+            task::syncWait(session->fastSendMessage(
+                message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{})),
+            NetworkException);
+
+        session->setSocket(nullptr);
+    }
     fakeSocket->close();
 }
 

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -23,13 +23,19 @@
 #include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include <bcos-framework/protocol/Protocol.h>
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/IOServicePool.h>
 #include "bcos-utilities/testutils/TestPromptFixture.h"
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
+#include <array>
+#include <cstdint>
+#include <mutex>
 #include <queue>
 #include <range/v3/view/single.hpp>
+#include <thread>
 
 using namespace bcos;
 using namespace gateway;
@@ -396,6 +402,135 @@ BOOST_AUTO_TEST_CASE(fastSendMessageOutboundRateLimit)
         session->setSocket(nullptr);
     }
     fakeSocket->close();
+}
+
+// A SocketFace backed by a real connected TCP socket so the (non-virtual)
+// ASIOInterface::asyncWrite path actually completes on the wire — the FakeSocket above cannot
+// reach the compression branch because its write path is inert.
+class RealLoopbackSocket : public SocketFace
+{
+public:
+    RealLoopbackSocket(std::shared_ptr<ba::io_context> _ioContext, bi::tcp::socket _socket)
+      : m_ioContext(std::move(_ioContext)),
+        m_sslContext(ba::ssl::context::tlsv12),
+        m_sslSocket(std::make_shared<ba::ssl::stream<bi::tcp::socket>>(*m_ioContext, m_sslContext))
+    {
+        m_sslSocket->next_layer() = std::move(_socket);
+    }
+
+    bool isConnected() const override { return m_sslSocket->next_layer().is_open(); }
+    void close() override
+    {
+        boost::system::error_code ec;
+        m_sslSocket->next_layer().close(ec);
+    }
+    bi::tcp::endpoint remoteEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::endpoint localEndpoint(boost::system::error_code) override { return {}; }
+    bi::tcp::socket& ref() override { return m_sslSocket->next_layer(); }
+    ba::ssl::stream<bi::tcp::socket>& sslref() override { return *m_sslSocket; }
+    const NodeIPEndpoint& nodeIPEndpoint() const override { return m_nodeIPEndpoint; }
+    void setNodeIPEndpoint(NodeIPEndpoint _nodeIPEndpoint) override
+    {
+        m_nodeIPEndpoint = std::move(_nodeIPEndpoint);
+    }
+    ba::io_context& ioService() override { return *m_ioContext; }
+
+private:
+    std::shared_ptr<ba::io_context> m_ioContext;
+    ba::ssl::context m_sslContext;
+    std::shared_ptr<ba::ssl::stream<bi::tcp::socket>> m_sslSocket;
+    NodeIPEndpoint m_nodeIPEndpoint;
+};
+
+BOOST_AUTO_TEST_CASE(fastSendMessageCompressionTransientExt)
+{
+    // Regression for the second-round review finding: the COMPRESS ext flag must be applied only
+    // TRANSIENTLY inside fastSendMessage. A reused message object (broadcast fan-out / retry loop)
+    // that compresses for one peer must not leak the flag to a later peer that receives an
+    // uncompressed frame (which would fail to decompress and drop the connection). Also exercises
+    // the compression branch itself, which the FakeSocket-based tests cannot reach.
+    auto fakeMessageFactory = std::make_shared<FakeMessageFactory>();
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO>();
+
+    auto io = std::make_shared<ba::io_context>();
+    boost::asio::executor_work_guard<ba::io_context::executor_type> workGuard(io->get_executor());
+    std::thread ioThread([io] { io->run(); });
+
+    ba::ip::tcp::acceptor acceptor(*io, ba::ip::tcp::endpoint(ba::ip::tcp::v4(), 0));
+    auto listenEndpoint = acceptor.local_endpoint();
+
+    std::vector<uint8_t> received;
+    std::mutex recvMutex;
+    std::thread peerThread([&] {
+        ba::ip::tcp::socket peer(*io);
+        boost::system::error_code ec;
+        acceptor.accept(peer, ec);
+        if (ec)
+        {
+            return;
+        }
+        // Read one chunk: loopback delivers the whole (small, compressed) frame in a single
+        // read_some. A single read also avoids blocking this thread forever if the session never
+        // closes the socket.
+        std::array<uint8_t, 4096> buf;
+        std::size_t n = peer.read_some(ba::buffer(buf), ec);
+        if (!ec && n > 0)
+        {
+            std::lock_guard<std::mutex> lock(recvMutex);
+            received.assign(buf.begin(), buf.begin() + n);
+        }
+    });
+
+    ba::ip::tcp::socket client(*io);
+    boost::system::error_code connectError;
+    client.connect(listenEndpoint, connectError);
+    BOOST_REQUIRE(!connectError);
+
+    {
+        auto fakeHost = std::make_shared<FakeHost>(hashImpl, fakeAsio, nullptr, fakeMessageFactory);
+        auto sessionSocket = std::make_shared<RealLoopbackSocket>(io, std::move(client));
+        auto session = std::make_shared<Session>(sessionSocket, *fakeHost, 2, true);
+        session->setMessageFactory(fakeHost->messageFactory());
+        session->start();
+
+        // V2 wire format + payload well above the 1KB compress threshold -> compression must run
+        P2PMessage message;
+        message.setVersion((uint16_t)bcos::protocol::ProtocolVersion::V2);
+        message.setSeq(1);
+        bytes payload(2000, 'x');
+        auto originalExt = message.ext();
+
+        task::syncWait(session->fastSendMessage(
+            message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{}));
+
+        // The caller's message must NOT keep the COMPRESS flag (transient ext restore), otherwise a
+        // reused message would leak it to an uncompressed peer.
+        BOOST_CHECK_EQUAL(message.ext(), originalExt);
+
+        // Clean teardown: disconnect closes the socket and stops the read loop. Do NOT null the
+        // socket while the io thread may still run the session's idle timer (checkNetworkStatus
+        // would dereference a null m_socket).
+        session->disconnect(DisconnectReason::DisconnectRequested);
+    }
+
+    peerThread.join();
+    workGuard.reset();
+    // Stop the io explicitly: drop()'s ssl-shutdown path can leave the session socket open (the
+    // failed SSL shutdown cancels the force-close timer), and an open socket/acceptor would keep
+    // io_context::run() from returning.
+    {
+        boost::system::error_code ec;
+        acceptor.close(ec);
+    }
+    io->stop();
+    ioThread.join();
+
+    // The wire frame must actually be compressed: parse the header
+    // [length:4][version:2][packetType:2][seq:4][ext:2] (P2PMessage::MESSAGE_HEADER_LENGTH = 14).
+    BOOST_REQUIRE(received.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
+    uint16_t frameExt = (static_cast<uint16_t>(received[12]) << 8) | static_cast<uint16_t>(received[13]);
+    BOOST_CHECK(frameExt & bcos::protocol::MessageExtFieldFlag::COMPRESS);
 }
 
 BOOST_AUTO_TEST_CASE(SessionRecvBufferTest)

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -385,10 +385,11 @@ BOOST_AUTO_TEST_CASE(fastSendMessageOutboundRateLimit)
         auto fakeHost = std::make_shared<FakeHost>(hashImpl, fakeAsio, nullptr, fakeMessageFactory);
         auto session = std::make_shared<Session>(fakeSocket, *fakeHost, 2, true);
         session->setMessageFactory(fakeHost->messageFactory());
-        session->setBeforeMessageHandler([](SessionFace&, Message&) -> std::optional<bcos::Error> {
-            return bcos::Error::buildError(
-                "", P2PExceptionType::OutBWOverflow, "outgoing bandwidth overflow");
-        });
+        session->setBeforeMessageHandler(
+            [](SessionFace&, const Message&, uint32_t) -> std::optional<bcos::Error> {
+                return bcos::Error::buildError(
+                    "", P2PExceptionType::OutBWOverflow, "outgoing bandwidth overflow");
+            });
         session->start();
 
         P2PMessage message;
@@ -442,13 +443,13 @@ private:
     NodeIPEndpoint m_nodeIPEndpoint;
 };
 
-BOOST_AUTO_TEST_CASE(fastSendMessageCompressionTransientExt)
+BOOST_AUTO_TEST_CASE(fastSendMessageCompression)
 {
-    // Regression for the second-round review finding: the COMPRESS ext flag must be applied only
-    // TRANSIENTLY inside fastSendMessage. A reused message object (broadcast fan-out / retry loop)
-    // that compresses for one peer must not leak the flag to a later peer that receives an
-    // uncompressed frame (which would fail to decompress and drop the connection). Also exercises
-    // the compression branch itself, which the FakeSocket-based tests cannot reach.
+    // The COMPRESS ext flag is stamped only onto the encoded wire header inside fastSendMessage:
+    // the caller's message is const and never mutated, so a reused message object (broadcast
+    // fan-out / retry loop) that compresses for one peer cannot leak the flag to a later peer that
+    // receives an uncompressed frame (which would fail to decompress and drop the connection).
+    // Also exercises the compression branch itself, which the FakeSocket-based tests cannot reach.
     auto fakeMessageFactory = std::make_shared<FakeMessageFactory>();
     auto hashImpl = std::make_shared<Keccak256>();
     auto fakeAsio = std::make_shared<FakeASIO>();
@@ -504,8 +505,8 @@ BOOST_AUTO_TEST_CASE(fastSendMessageCompressionTransientExt)
         task::syncWait(session->fastSendMessage(
             message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{}));
 
-        // The caller's message must NOT keep the COMPRESS flag (transient ext restore), otherwise a
-        // reused message would leak it to an uncompressed peer.
+        // fastSendMessage takes the message by const ref and never mutates it — the COMPRESS flag
+        // only rides on the wire header, so the caller's ext is untouched.
         BOOST_CHECK_EQUAL(message.ext(), originalExt);
 
         // Clean teardown: disconnect closes the socket and stops the read loop. Do NOT null the

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -546,7 +546,8 @@ BOOST_AUTO_TEST_CASE(fastSendMessageCompression)
     // The wire frame must actually be compressed: parse the header
     // [length:4][version:2][packetType:2][seq:4][ext:2] (P2PMessage::MESSAGE_HEADER_LENGTH = 14).
     BOOST_REQUIRE(received.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
-    uint16_t frameExt = (static_cast<uint16_t>(received[12]) << 8) | static_cast<uint16_t>(received[13]);
+    uint16_t frameExt = (static_cast<uint16_t>(received[12]) << 8) |
+                        static_cast<uint16_t>(received[13]);
     BOOST_CHECK(frameExt & bcos::protocol::MessageExtFieldFlag::COMPRESS);
 }
 
@@ -691,13 +692,19 @@ BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
     task::syncWait(service->broadcastMessageToNeighbors(
         message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{}));
 
-    peerV2.join();
-    peerV0.join();
-
+    // Round-7 review: disconnect the sessions BEFORE joining the peer threads. Each peer thread
+    // blocks on a synchronous asio read; if a broadcast regression ever skipped a peer, that
+    // thread would block forever and a disconnect placed after join() would never run — surfacing
+    // as a CI hang instead of a failure. Closing the client sockets first unblocks any stuck peer
+    // read so a missed peer fails the test.
     for (auto& session : sessions)
     {
         session->disconnect(DisconnectReason::DisconnectRequested);
     }
+
+    peerV2.join();
+    peerV0.join();
+
     workGuard.reset();
     {
         boost::system::error_code ec;

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -677,12 +677,16 @@ BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
     makePeerSession(std::move(clientV0), "peerV0", 0);
 
     // One shared message broadcast to both sessions: each per-peer fan-out task stamps the
-    // negotiated version synchronously before its own header encode. SyncNodeSeq (rather than
-    // PeerToPeerMessage) avoids the P2PMessageOptions path, which would require a non-empty
-    // srcNodeID — the version-stamping invariant under test does not involve options.
+    // negotiated version synchronously before its own header encode. Round-6 review: stamp
+    // non-empty routing fields as well, so the V2 wire frame carries a real ttl/src/dst extension
+    // that the V2-peer decode below asserts — a regression that encodes a V2 frame through the
+    // base-class header (e.g. an object-sliced message, which writes no ttl/src/dst extension)
+    // would fail that decode immediately.
     auto message = std::make_shared<P2PMessageV2>();
     message->setPacketType(GatewayMessageType::SyncNodeSeq);
     message->setSeq(0x1234);
+    message->setSrcP2PNodeID("srcNodeID");
+    message->setDstP2PNodeID("dstNodeID");
     bytes payload(32, 'a');
     task::syncWait(service->broadcastMessageToNeighbors(
         message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{}));
@@ -703,14 +707,24 @@ BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
     io->stop();
     ioThread.join();
 
-    // Each frame must carry its OWN negotiated version: the version field is bytes [4..6) of the
-    // fixed base header [length:4][version:2][packetType:2][seq:4][ext:2].
-    BOOST_REQUIRE(receivedV2.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
+    // The V0 frame must carry the negotiated V0 version (base header only): the version field is
+    // bytes [4..6) of the fixed base header [length:4][version:2][packetType:2][seq:4][ext:2].
     BOOST_REQUIRE(receivedV0.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
-    uint16_t versionV2 = (static_cast<uint16_t>(receivedV2[4]) << 8) | receivedV2[5];
     uint16_t versionV0 = (static_cast<uint16_t>(receivedV0[4]) << 8) | receivedV0[5];
-    BOOST_CHECK_EQUAL(versionV2, 2);
     BOOST_CHECK_EQUAL(versionV0, 0);
+
+    // The V2 frame must decode as a real V2 message carrying the full routing extension. Round-6
+    // review: decode the whole frame with P2PMessageV2::decode (instead of hand-reading the
+    // version bytes) and assert src/dst/ttl, so "V2 version written but ttl/src/dst missing" (the
+    // exact shape of the round-2..5 object-slicing defect) fails here.
+    BOOST_REQUIRE(receivedV2.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
+    P2PMessageV2 decodedV2;
+    int32_t decodedOffset = decodedV2.decode(bcos::ref(receivedV2));
+    BOOST_REQUIRE(decodedOffset > 0);
+    BOOST_CHECK_EQUAL(decodedV2.version(), 2);
+    BOOST_CHECK_EQUAL(decodedV2.srcP2PNodeID(), "srcNodeID");
+    BOOST_CHECK_EQUAL(decodedV2.dstP2PNodeID(), "dstNodeID");
+    BOOST_CHECK_EQUAL(decodedV2.ttl(), 10);
 }
 
 BOOST_AUTO_TEST_CASE(SessionRecvBufferTest)

--- a/bcos-gateway/test/unittests/SessionTest.cpp
+++ b/bcos-gateway/test/unittests/SessionTest.cpp
@@ -19,10 +19,14 @@
  * @date 2023-02-23
  */
 #include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/protocol/ProtocolInfo.h"
 #include "bcos-gateway/libnetwork/ASIOInterface.h"
 #include "bcos-gateway/libnetwork/Host.h"
 #include "bcos-gateway/libnetwork/Session.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
+#include "bcos-gateway/libp2p/P2PMessageV2.h"
+#include "bcos-gateway/libp2p/P2PSession.h"
+#include "bcos-gateway/libp2p/Service.h"
 #include <bcos-framework/protocol/Protocol.h>
 #include <bcos-task/Wait.h>
 #include <bcos-utilities/IOServicePool.h>
@@ -443,6 +447,18 @@ private:
     NodeIPEndpoint m_nodeIPEndpoint;
 };
 
+// Service::m_sessions is protected; expose insertion for the fan-out test below.
+class FanoutProbeService : public bcos::gateway::Service
+{
+public:
+    explicit FanoutProbeService(P2PInfo const& _info) : Service(_info) {}
+    void addSession(P2pID const& _nodeID, P2PSession::Ptr _session)
+    {
+        std::unique_lock lock(x_sessions);
+        m_sessions[_nodeID] = std::move(_session);
+    }
+};
+
 BOOST_AUTO_TEST_CASE(fastSendMessageCompression)
 {
     // The COMPRESS ext flag is stamped only onto the encoded wire header inside fastSendMessage:
@@ -532,6 +548,169 @@ BOOST_AUTO_TEST_CASE(fastSendMessageCompression)
     BOOST_REQUIRE(received.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
     uint16_t frameExt = (static_cast<uint16_t>(received[12]) << 8) | static_cast<uint16_t>(received[13]);
     BOOST_CHECK(frameExt & bcos::protocol::MessageExtFieldFlag::COMPRESS);
+}
+
+BOOST_AUTO_TEST_CASE(fastSendBroadcastFanoutMixedVersion)
+{
+    // Round-4 review finding 2: the per-peer fan-out invariant — "each task's per-session
+    // src/dst/version stamping runs synchronously before its first suspension, so the tasks never
+    // race on the shared header" — is only documented in comments. This drives the real
+    // Service::broadcastMessageToNeighbors over two real loopback sockets whose sessions
+    // negotiated different protocol versions (V2 and V0) and asserts each peer receives a frame
+    // carrying its OWN negotiated version: the shared message is stamped per-peer before each
+    // header encode and the parallel fan-out tasks never cross-contaminate each other's wire
+    // header.
+    auto fakeMessageFactory = std::make_shared<FakeMessageFactory>();
+    auto hashImpl = std::make_shared<Keccak256>();
+    auto fakeAsio = std::make_shared<FakeASIO>();
+
+    auto io = std::make_shared<ba::io_context>();
+    boost::asio::executor_work_guard<ba::io_context::executor_type> workGuard(io->get_executor());
+    std::thread ioThread([io] { io->run(); });
+
+    ba::ip::tcp::acceptor acceptorV2(*io, ba::ip::tcp::endpoint(ba::ip::tcp::v4(), 0));
+    ba::ip::tcp::acceptor acceptorV0(*io, ba::ip::tcp::endpoint(ba::ip::tcp::v4(), 0));
+    auto listenV2 = acceptorV2.local_endpoint();
+    auto listenV0 = acceptorV0.local_endpoint();
+
+    std::vector<uint8_t> receivedV2;
+    std::vector<uint8_t> receivedV0;
+    std::mutex recvMutex;
+    // Read exactly one wire frame: [length:4][payload...]. The length field counts the whole
+    // frame including itself, so after reading the 4 length bytes we read len-4 more.
+    auto readExactFrame = [](ba::ip::tcp::socket& _peer) -> std::vector<uint8_t> {
+        std::array<uint8_t, 4> lenBuf;
+        boost::system::error_code ec;
+        std::size_t n = boost::asio::read(_peer, ba::buffer(lenBuf), ec);
+        if (ec || n != lenBuf.size())
+        {
+            return {};
+        }
+        uint32_t len = (uint32_t(lenBuf[0]) << 24) | (uint32_t(lenBuf[1]) << 16) |
+                       (uint32_t(lenBuf[2]) << 8) | lenBuf[3];
+        if (len < lenBuf.size() || len > 4096)
+        {
+            return {};
+        }
+        std::vector<uint8_t> frame(len);
+        std::copy(lenBuf.begin(), lenBuf.end(), frame.begin());
+        n = boost::asio::read(_peer, ba::buffer(frame.data() + 4, len - 4), ec);
+        if (ec || n != len - 4)
+        {
+            return {};
+        }
+        return frame;
+    };
+    std::thread peerV2([&] {
+        ba::ip::tcp::socket peer(*io);
+        boost::system::error_code ec;
+        acceptorV2.accept(peer, ec);
+        if (ec)
+        {
+            return;
+        }
+        // Service is not run in this test, so P2PSession::start()'s initial heartbeat is skipped
+        // (heartBeat only sends when service->active()) — the broadcast frame is the first one.
+        auto frame = readExactFrame(peer);
+        std::lock_guard<std::mutex> lock(recvMutex);
+        receivedV2 = std::move(frame);
+    });
+    std::thread peerV0([&] {
+        ba::ip::tcp::socket peer(*io);
+        boost::system::error_code ec;
+        acceptorV0.accept(peer, ec);
+        if (ec)
+        {
+            return;
+        }
+        auto frame = readExactFrame(peer);
+        std::lock_guard<std::mutex> lock(recvMutex);
+        receivedV0 = std::move(frame);
+    });
+
+    ba::ip::tcp::socket clientV2(*io);
+    ba::ip::tcp::socket clientV0(*io);
+    {
+        boost::system::error_code connectError;
+        clientV2.connect(listenV2, connectError);
+        BOOST_REQUIRE(!connectError);
+        clientV0.connect(listenV0, connectError);
+        BOOST_REQUIRE(!connectError);
+    }
+
+    P2PInfo selfInfo;
+    selfInfo.rawP2pID = "selfRawP2pID";
+    selfInfo.p2pID = "selfP2pID";
+    auto service = std::make_shared<FanoutProbeService>(selfInfo);
+    service->setMessageFactory(fakeMessageFactory);
+    // P2PSession::start() -> heartBeat() arms a timer on service->host()->asioInterface().
+    service->setHost(std::make_shared<FakeHost>(hashImpl, fakeAsio, nullptr, fakeMessageFactory));
+
+    // The FakeHosts must outlive the sessions (Session holds a reference_wrapper<Host>).
+    std::vector<std::shared_ptr<FakeHost>> hosts;
+    std::vector<std::shared_ptr<Session>> sessions;
+    auto makePeerSession = [&](ba::ip::tcp::socket _client, P2pID _nodeID, uint32_t _version) {
+        auto host = std::make_shared<FakeHost>(hashImpl, fakeAsio, nullptr, fakeMessageFactory);
+        hosts.push_back(host);
+        auto session = std::make_shared<Session>(
+            std::make_shared<RealLoopbackSocket>(io, std::move(_client)), *host, 2, true);
+        session->setMessageFactory(fakeMessageFactory);
+        session->start();
+        sessions.push_back(session);
+
+        auto p2pSession = std::make_shared<P2PSession>();
+        p2pSession->setSession(session);
+        p2pSession->setService(service);
+        auto protocolInfo = std::make_shared<bcos::protocol::ProtocolInfo>(
+            bcos::protocol::ProtocolModuleID::GatewayService, 0, 2);
+        protocolInfo->setVersion(_version);
+        p2pSession->setProtocolInfo(protocolInfo);
+        P2PInfo peerInfo;
+        peerInfo.rawP2pID = _nodeID;
+        peerInfo.p2pID = _nodeID;
+        p2pSession->setP2PInfo(peerInfo);
+        // marks the session active (m_run) and sends an initial heartbeat (discarded by the peer)
+        p2pSession->start();
+        service->addSession(_nodeID, std::move(p2pSession));
+    };
+    makePeerSession(std::move(clientV2), "peerV2", 2);
+    makePeerSession(std::move(clientV0), "peerV0", 0);
+
+    // One shared message broadcast to both sessions: each per-peer fan-out task stamps the
+    // negotiated version synchronously before its own header encode. SyncNodeSeq (rather than
+    // PeerToPeerMessage) avoids the P2PMessageOptions path, which would require a non-empty
+    // srcNodeID — the version-stamping invariant under test does not involve options.
+    auto message = std::make_shared<P2PMessageV2>();
+    message->setPacketType(GatewayMessageType::SyncNodeSeq);
+    message->setSeq(0x1234);
+    bytes payload(32, 'a');
+    task::syncWait(service->broadcastMessageToNeighbors(
+        message, ::ranges::views::single(bcos::ref(std::as_const(payload))), Options{}));
+
+    peerV2.join();
+    peerV0.join();
+
+    for (auto& session : sessions)
+    {
+        session->disconnect(DisconnectReason::DisconnectRequested);
+    }
+    workGuard.reset();
+    {
+        boost::system::error_code ec;
+        acceptorV2.close(ec);
+        acceptorV0.close(ec);
+    }
+    io->stop();
+    ioThread.join();
+
+    // Each frame must carry its OWN negotiated version: the version field is bytes [4..6) of the
+    // fixed base header [length:4][version:2][packetType:2][seq:4][ext:2].
+    BOOST_REQUIRE(receivedV2.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
+    BOOST_REQUIRE(receivedV0.size() >= P2PMessage::MESSAGE_HEADER_LENGTH);
+    uint16_t versionV2 = (static_cast<uint16_t>(receivedV2[4]) << 8) | receivedV2[5];
+    uint16_t versionV0 = (static_cast<uint16_t>(receivedV0[4]) << 8) | receivedV0[5];
+    BOOST_CHECK_EQUAL(versionV2, 2);
+    BOOST_CHECK_EQUAL(versionV0, 0);
 }
 
 BOOST_AUTO_TEST_CASE(SessionRecvBufferTest)

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
@@ -96,17 +96,25 @@ void PBFTLogSync::requestPBFTData(
             // encode
             auto encodedData =
                 config->codec()->encode(_pbftRequest, config->pbftMsgDefaultVersion());
-            // owned payload + coroutine fast path -> zero-copy; the module-level response is
-            // delivered to _callback through the front receive path (uuid-matched). All state is
-            // passed as coroutine parameters so it is copied into the frame and stays alive for the
-            // whole (possibly deferred) send.
+            // owned payload + coroutine fast path -> zero-copy; co_await waits for the module-level
+            // response (uuid-matched) and the result is delivered to _callback. All state is passed
+            // as coroutine parameters so it is copied into the frame and stays alive for the whole
+            // (possibly deferred) send.
             auto front = config->frontService();
             auto networkTimeout = config->networkTimeoutInterval();
             task::wait([](decltype(front) _front, decltype(_from) _from,
                            decltype(encodedData) _encodedData, decltype(networkTimeout) _networkTimeout,
                            decltype(_callback) _callback) mutable -> task::Task<void> {
-                co_await _front->sendMessageByNodeID(ModuleID::PBFT, _from,
-                    ::ranges::views::single(ref(*_encodedData)), _networkTimeout, _callback);
+                auto result = co_await _front->sendMessageByNodeID(ModuleID::PBFT, _from,
+                    ::ranges::views::single(ref(*_encodedData)), _networkTimeout);
+                if (_callback)
+                {
+                    // deliver the module-level response through the caller's callback, exactly as
+                    // the front receive path used to (result.payload is owned by this frame and
+                    // stays valid for the duration of the synchronous callback)
+                    _callback(std::move(result.error), std::move(result.nodeID),
+                        bcos::ref(result.payload), result.uuid, std::move(result.respond));
+                }
             }(front, _from, std::move(encodedData), networkTimeout, _callback));
             PBFT_LOG(INFO) << LOG_DESC("request the missed precommit proposal")
                            << LOG_KV("peer", _from->shortHex())

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
@@ -20,6 +20,7 @@
  */
 #include "PBFTLogSync.h"
 #include <bcos-framework/protocol/Protocol.h>
+#include <bcos-task/Wait.h>
 #include <utility>
 
 using namespace bcos;
@@ -95,9 +96,15 @@ void PBFTLogSync::requestPBFTData(
             // encode
             auto encodedData =
                 config->codec()->encode(_pbftRequest, config->pbftMsgDefaultVersion());
-            // send the request
-            config->frontService()->asyncSendMessageByNodeID(ModuleID::PBFT, _from,
-                ref(*encodedData), config->networkTimeoutInterval(), _callback);
+            // owned payload + coroutine fast path -> zero-copy; the module-level response is
+            // delivered to _callback through the front receive path (uuid-matched)
+            auto front = config->frontService();
+            auto networkTimeout = config->networkTimeoutInterval();
+            task::wait([front, _from, encodedData = std::move(encodedData), networkTimeout,
+                           _callback]() mutable -> task::Task<void> {
+                co_await front->sendMessageByNodeID(ModuleID::PBFT, _from,
+                    ::ranges::views::single(ref(*encodedData)), networkTimeout, _callback);
+            }());
             PBFT_LOG(INFO) << LOG_DESC("request the missed precommit proposal")
                            << LOG_KV("peer", _from->shortHex())
                            << LOG_KV("index", _pbftRequest->index())

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
@@ -19,6 +19,7 @@
  * @date 2021-04-28
  */
 #include "PBFTLogSync.h"
+#include <bcos-framework/protocol/CommonError.h>
 #include <bcos-framework/protocol/Protocol.h>
 #include <bcos-task/Wait.h>
 #include <utility>
@@ -105,15 +106,33 @@ void PBFTLogSync::requestPBFTData(
             task::wait([](decltype(front) _front, decltype(_from) _from,
                            decltype(encodedData) _encodedData, decltype(networkTimeout) _networkTimeout,
                            decltype(_callback) _callback) mutable -> task::Task<void> {
-                auto result = co_await _front->sendMessageByNodeID(ModuleID::PBFT, _from,
-                    ::ranges::views::single(ref(*_encodedData)), _networkTimeout);
-                if (_callback)
+                try
                 {
-                    // deliver the module-level response through the caller's callback, exactly as
-                    // the front receive path used to (result.payload is owned by this frame and
-                    // stays valid for the duration of the synchronous callback)
-                    _callback(std::move(result.error), std::move(result.nodeID),
-                        bcos::ref(result.payload), result.uuid, std::move(result.respond));
+                    auto result = co_await _front->sendMessageByNodeID(ModuleID::PBFT, _from,
+                        ::ranges::views::single(ref(*_encodedData)), _networkTimeout);
+                    if (_callback)
+                    {
+                        // deliver the module-level response through the caller's callback
+                        // (result.payload is owned by this frame and valid for the callback)
+                        _callback(std::move(result.error), std::move(result.nodeID),
+                            bcos::ref(result.payload), result.uuid, std::move(result.respond));
+                    }
+                }
+                catch (std::exception const& e)
+                {
+                    // restore the base "a send failure still yields a callback" contract: under the
+                    // new coroutine shape the front timeout can no longer rescue a callback that
+                    // was never registered because the send threw before registration.
+                    PBFT_LOG(WARNING) << LOG_DESC("requestPBFTData send exception")
+                                      << LOG_KV("to", _from->shortHex())
+                                      << LOG_KV("message", boost::diagnostic_information(e));
+                    if (_callback)
+                    {
+                        _callback(BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
+                                      "requestPBFTData exception: " +
+                                          boost::diagnostic_information(e)),
+                            _from, bytesConstRef(), std::string(), ResponseFunc());
+                    }
                 }
             }(front, _from, std::move(encodedData), networkTimeout, _callback));
             PBFT_LOG(INFO) << LOG_DESC("request the missed precommit proposal")

--- a/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
+++ b/bcos-pbft/bcos-pbft/pbft/engine/PBFTLogSync.cpp
@@ -97,14 +97,17 @@ void PBFTLogSync::requestPBFTData(
             auto encodedData =
                 config->codec()->encode(_pbftRequest, config->pbftMsgDefaultVersion());
             // owned payload + coroutine fast path -> zero-copy; the module-level response is
-            // delivered to _callback through the front receive path (uuid-matched)
+            // delivered to _callback through the front receive path (uuid-matched). All state is
+            // passed as coroutine parameters so it is copied into the frame and stays alive for the
+            // whole (possibly deferred) send.
             auto front = config->frontService();
             auto networkTimeout = config->networkTimeoutInterval();
-            task::wait([front, _from, encodedData = std::move(encodedData), networkTimeout,
-                           _callback]() mutable -> task::Task<void> {
-                co_await front->sendMessageByNodeID(ModuleID::PBFT, _from,
-                    ::ranges::views::single(ref(*encodedData)), networkTimeout, _callback);
-            }());
+            task::wait([](decltype(front) _front, decltype(_from) _from,
+                           decltype(encodedData) _encodedData, decltype(networkTimeout) _networkTimeout,
+                           decltype(_callback) _callback) mutable -> task::Task<void> {
+                co_await _front->sendMessageByNodeID(ModuleID::PBFT, _from,
+                    ::ranges::views::single(ref(*_encodedData)), _networkTimeout, _callback);
+            }(front, _from, std::move(encodedData), networkTimeout, _callback));
             PBFT_LOG(INFO) << LOG_DESC("request the missed precommit proposal")
                            << LOG_KV("peer", _from->shortHex())
                            << LOG_KV("index", _pbftRequest->index())

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -970,8 +970,10 @@ void BlockSync::sendSyncStatusByTree()
         // all state is passed as coroutine parameters so it is copied into the frame and stays alive
         task::wait([](decltype(front) _front, decltype(nodeID) _nodeID,
                        decltype(encodedData) _encodedData) mutable -> task::Task<void> {
-            co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
-                ::ranges::views::single(ref(*_encodedData)), 0, nullptr);
+            // fire-and-forget status push: no module-level response is expected (timeout == 0)
+            auto result = co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
+                ::ranges::views::single(ref(*_encodedData)), 0);
+            (void)result;
         }(front, nodeID, encodedData));
     }
 }
@@ -1010,8 +1012,10 @@ void BlockSync::broadcastSyncStatus()
             // state is passed as coroutine parameters so it is copied into the frame and stays alive
             task::wait([](decltype(front) _front, decltype(nodeID) _nodeID,
                            decltype(encodedData) _encodedData) mutable -> task::Task<void> {
-                co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
-                    ::ranges::views::single(ref(*_encodedData)), 0, nullptr);
+                // fire-and-forget status push: no module-level response is expected (timeout == 0)
+                auto result = co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
+                    ::ranges::views::single(ref(*_encodedData)), 0);
+                (void)result;
             }(front, nodeID, encodedData));
         }
     }

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -669,8 +669,9 @@ void BlockSync::requestBlocks(BlockNumber _from, BlockNumber _to, int32_t blockD
                     blockRequest->setBlockInterval(interval);
                 }
                 auto encodedData = blockRequest->encode();
-                m_config->frontService()->asyncSendMessageByNodeID(
-                    ModuleID::BlockSync, _p->nodeId(), ref(*encodedData), 0, nullptr);
+                // owned payload -> zero-copy through the front/gateway coroutine fast path
+                m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+                    ModuleID::BlockSync, _p->nodeId(), std::move(encodedData));
 
                 m_maxRequestNumber = std::max(m_maxRequestNumber.load(), to);
 
@@ -882,8 +883,8 @@ void BlockSync::fetchAndSendBlock(
                 _block->encode(blockData);
                 blocksReq->appendBlockData(std::move(blockData));
                 blocksReq->setNumber(_number);
-                config->frontService()->asyncSendMessageByNodeID(
-                    ModuleID::BlockSync, _peer, ref(*(blocksReq->encode())), 0, nullptr);
+                config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+                    ModuleID::BlockSync, _peer, blocksReq->encode());
                 BLKSYNC_LOG(DEBUG)
                     << BLOCK_NUMBER(_number) << LOG_DESC("fetchAndSendBlock: response block")
                     << LOG_KV("toPeer", _peer->shortHex())
@@ -960,12 +961,16 @@ void BlockSync::sendSyncStatusByTree()
     // Note: connectedNodeSet() cannot be used directly here, because connectedNodeSet()
     // contains light nodes, but the nodes in groupNodeList() are not necessarily connected to this
     // node, so take the intersection of the two.
+    auto front = m_config->frontService();
     auto const& groupNodeList =
         m_syncTreeTopology->selectNodesForBlockSync(m_config->connectedGroupNodeList());
     for (auto const& nodeID : *groupNodeList)
     {
-        m_config->frontService()->asyncSendMessageByNodeID(
-            ModuleID::BlockSync, nodeID, ref(*encodedData), 0, nullptr);
+        // per-node coroutine keeps the shared encodedData alive and sends it as a view (zero-copy)
+        task::wait([front, nodeID, encodedData]() mutable -> task::Task<void> {
+            co_await front->sendMessageByNodeID(ModuleID::BlockSync, nodeID,
+                ::ranges::views::single(ref(*encodedData)), 0, nullptr);
+        }());
     }
 }
 
@@ -995,11 +1000,15 @@ void BlockSync::broadcastSyncStatus()
     }
     else
     {
+        auto front = m_config->frontService();
         auto const& groupNodeList = m_config->groupNodeList();
         for (auto const& nodeID : groupNodeList)
         {
-            m_config->frontService()->asyncSendMessageByNodeID(
-                ModuleID::BlockSync, nodeID, ref(*encodedData), 0, nullptr);
+            // per-node coroutine keeps the shared encodedData alive and sends it as a view
+            task::wait([front, nodeID, encodedData]() mutable -> task::Task<void> {
+                co_await front->sendMessageByNodeID(ModuleID::BlockSync, nodeID,
+                    ::ranges::views::single(ref(*encodedData)), 0, nullptr);
+            }());
         }
     }
 }

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -970,10 +970,22 @@ void BlockSync::sendSyncStatusByTree()
         // all state is passed as coroutine parameters so it is copied into the frame and stays alive
         task::wait([](decltype(front) _front, decltype(nodeID) _nodeID,
                        decltype(encodedData) _encodedData) mutable -> task::Task<void> {
-            // fire-and-forget status push: no module-level response is expected (timeout == 0)
-            auto result = co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
-                ::ranges::views::single(ref(*_encodedData)), 0);
-            (void)result;
+            try
+            {
+                // fire-and-forget: no module-level response expected (timeout == 0)
+                auto result = co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
+                    ::ranges::views::single(ref(*_encodedData)), 0);
+                (void)result;
+            }
+            catch (std::exception const& e)
+            {
+                // a synchronous throw (e.g. gateway local delivery or a bad front) must not break
+                // the per-node loop: log and continue with the next peer
+                BLKSYNC_LOG(WARNING) << LOG_BADGE("BlockSync")
+                                     << LOG_DESC("broadcastSyncStatusByTree send exception")
+                                     << LOG_KV("nodeID", _nodeID->shortHex())
+                                     << LOG_KV("message", boost::diagnostic_information(e));
+            }
         }(front, nodeID, encodedData));
     }
 }
@@ -997,9 +1009,18 @@ void BlockSync::broadcastSyncStatus()
     {
         task::wait([](decltype(encodedData) encodedData,
                        bcos::front::FrontServiceInterface::Ptr front) -> task::Task<void> {
-            co_await front->broadcastMessage(
-                LIGHT_NODE | CONSENSUS_NODE | OBSERVER_NODE | FREE_NODE, ModuleID::BlockSync,
-                ::ranges::views::single(bcos::ref(*encodedData)));
+            try
+            {
+                co_await front->broadcastMessage(
+                    LIGHT_NODE | CONSENSUS_NODE | OBSERVER_NODE | FREE_NODE, ModuleID::BlockSync,
+                    ::ranges::views::single(bcos::ref(*encodedData)));
+            }
+            catch (std::exception const& e)
+            {
+                BLKSYNC_LOG(WARNING) << LOG_BADGE("BlockSync")
+                                     << LOG_DESC("broadcastSyncStatus send exception")
+                                     << LOG_KV("message", boost::diagnostic_information(e));
+            }
         }(std::move(encodedData), m_config->frontService()));
     }
     else
@@ -1012,10 +1033,21 @@ void BlockSync::broadcastSyncStatus()
             // state is passed as coroutine parameters so it is copied into the frame and stays alive
             task::wait([](decltype(front) _front, decltype(nodeID) _nodeID,
                            decltype(encodedData) _encodedData) mutable -> task::Task<void> {
-                // fire-and-forget status push: no module-level response is expected (timeout == 0)
-                auto result = co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
-                    ::ranges::views::single(ref(*_encodedData)), 0);
-                (void)result;
+                try
+                {
+                    // fire-and-forget: no module-level response expected (timeout == 0)
+                    auto result = co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
+                        ::ranges::views::single(ref(*_encodedData)), 0);
+                    (void)result;
+                }
+                catch (std::exception const& e)
+                {
+                    // a synchronous throw must not break the per-node loop: log and continue
+                    BLKSYNC_LOG(WARNING) << LOG_BADGE("BlockSync")
+                                         << LOG_DESC("broadcastSyncStatus send exception")
+                                         << LOG_KV("nodeID", _nodeID->shortHex())
+                                         << LOG_KV("message", boost::diagnostic_information(e));
+                }
             }(front, nodeID, encodedData));
         }
     }

--- a/bcos-sync/bcos-sync/BlockSync.cpp
+++ b/bcos-sync/bcos-sync/BlockSync.cpp
@@ -966,11 +966,13 @@ void BlockSync::sendSyncStatusByTree()
         m_syncTreeTopology->selectNodesForBlockSync(m_config->connectedGroupNodeList());
     for (auto const& nodeID : *groupNodeList)
     {
-        // per-node coroutine keeps the shared encodedData alive and sends it as a view (zero-copy)
-        task::wait([front, nodeID, encodedData]() mutable -> task::Task<void> {
-            co_await front->sendMessageByNodeID(ModuleID::BlockSync, nodeID,
-                ::ranges::views::single(ref(*encodedData)), 0, nullptr);
-        }());
+        // per-node coroutine keeps the shared encodedData alive and sends it as a view (zero-copy);
+        // all state is passed as coroutine parameters so it is copied into the frame and stays alive
+        task::wait([](decltype(front) _front, decltype(nodeID) _nodeID,
+                       decltype(encodedData) _encodedData) mutable -> task::Task<void> {
+            co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
+                ::ranges::views::single(ref(*_encodedData)), 0, nullptr);
+        }(front, nodeID, encodedData));
     }
 }
 
@@ -1004,11 +1006,13 @@ void BlockSync::broadcastSyncStatus()
         auto const& groupNodeList = m_config->groupNodeList();
         for (auto const& nodeID : groupNodeList)
         {
-            // per-node coroutine keeps the shared encodedData alive and sends it as a view
-            task::wait([front, nodeID, encodedData]() mutable -> task::Task<void> {
-                co_await front->sendMessageByNodeID(ModuleID::BlockSync, nodeID,
-                    ::ranges::views::single(ref(*encodedData)), 0, nullptr);
-            }());
+            // per-node coroutine keeps the shared encodedData alive and sends it as a view; all
+            // state is passed as coroutine parameters so it is copied into the frame and stays alive
+            task::wait([](decltype(front) _front, decltype(nodeID) _nodeID,
+                           decltype(encodedData) _encodedData) mutable -> task::Task<void> {
+                co_await _front->sendMessageByNodeID(ModuleID::BlockSync, _nodeID,
+                    ::ranges::views::single(ref(*_encodedData)), 0, nullptr);
+            }(front, nodeID, encodedData));
         }
     }
 }

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -215,8 +215,8 @@ void bcostars::FrontServiceClient::asyncSendMessageByNodeIDs(
         ->async_asyncSendMessageByNodeIDs(
             nullptr, _moduleID, tarsNodeIDs, std::vector<char>(_data.begin(), _data.end()));
 }
-bcos::task::Task<void> bcostars::FrontServiceClient::broadcastMessage(
-    uint16_t _type, int _moduleID, ::ranges::any_view<bcos::bytesConstRef> payloads)
+bcos::task::Task<void> bcostars::FrontServiceClient::broadcastMessage(uint16_t _type,
+    int _moduleID, ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads)
 {
     std::vector<char> data;
     for (auto payload : payloads)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
@@ -41,8 +41,8 @@ public:
     void asyncSendMessageByNodeIDs(int _moduleID,
         const std::vector<bcos::crypto::NodeIDPtr>& _nodeIDs, bcos::bytesConstRef _data) override;
 
-    bcos::task::Task<void> broadcastMessage(
-        uint16_t _type, int _moduleID, ::ranges::any_view<bcos::bytesConstRef> payloads) override;
+    bcos::task::Task<void> broadcastMessage(uint16_t _type, int _moduleID,
+        ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads) override;
 
 private:
     // 30s

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -165,7 +165,7 @@ void bcostars::GatewayServiceClient::asyncSendMessageByNodeIDs(const std::string
 }
 bcos::task::Task<void> bcostars::GatewayServiceClient::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,
-    ::ranges::any_view<bcos::bytesConstRef> payloads)
+    ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads)
 {
     auto shouldBlockCall = shouldStopCall();
     auto ret =

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -55,7 +55,7 @@ public:
 
     bcos::task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID,
-        ::ranges::any_view<bcos::bytesConstRef> payloads) override;
+        ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads) override;
 
     void asyncGetGroupNodeInfo(const std::string& _groupID,
         bcos::gateway::GetGroupNodeInfoFunc _onGetGroupNodeInfo) override;

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -267,59 +267,54 @@ void TransactionSync::requestMissedTxsFromPeer(PublicPtr _generatedNodeID, HashL
                    decltype(_generatedNodeID) _generatedNodeID, decltype(encodedData) _encodedData,
                    decltype(_missedTxs) _missedTxs, decltype(_verifiedProposal) _verifiedProposal,
                    decltype(_onVerifyFinished) _onVerifyFinished) mutable -> task::Task<void> {
-        co_await _front->sendMessageByNodeID(_protocolID, _generatedNodeID,
-            ::ranges::views::single(ref(*_encodedData)), _networkTimeout,
-            [_self, _startT, _missedTxs, _verifiedProposal,
-                _onVerifyFinished](auto&& _error, auto&& _nodeID, bytesConstRef _data,
-                const std::string&, auto&&) {
-                try
-                {
-                    auto transactionSync = _self.lock();
-                    if (!transactionSync)
+        auto result = co_await _front->sendMessageByNodeID(_protocolID, _generatedNodeID,
+            ::ranges::views::single(ref(*_encodedData)), _networkTimeout);
+        try
+        {
+            auto transactionSync = _self.lock();
+            if (!transactionSync)
+            {
+                co_return;
+            }
+            auto networkT = utcTime() - _startT;
+            auto recordT = utcTime();
+            // verify fetch txs response
+            transactionSync->verifyFetchedTxs(result.error, result.nodeID,
+                bcos::ref(result.payload), _missedTxs, _verifiedProposal,
+                [networkT, recordT, _verifiedProposal, _onVerifyFinished](
+                    Error::Ptr _error, bool _result) {
+                    if (!_onVerifyFinished)
                     {
                         return;
                     }
-                    auto networkT = utcTime() - _startT;
-                    auto recordT = utcTime();
-                    // verify fetch txs response
-                    transactionSync->verifyFetchedTxs(_error, _nodeID, _data, _missedTxs,
-                        _verifiedProposal,
-                        [networkT, recordT, _verifiedProposal, _onVerifyFinished](
-                            Error::Ptr _error, bool _result) {
-                            if (!_onVerifyFinished)
-                            {
-                                return;
-                            }
-                            _onVerifyFinished(std::move(_error), _result);
-                            if (!(_verifiedProposal))
-                            {
-                                return;
-                            }
-                            SYNC_LOG(DEBUG)
-                                << LOG_DESC("requestMissedTxs: response verify result")
-                                << LOG_KV("propIndex", _verifiedProposal->blockHeader()->number())
-                                << LOG_KV("propHash",
-                                    _verifiedProposal->blockHeader()->hash().abridged())
-                                << LOG_KV("_result", _result) << LOG_KV("networkT", networkT)
-                                << LOG_KV("verifyAndSubmitT", (utcTime() - recordT));
-                        });
-                }
-                catch (std::exception const& e)
-                {
-                    SYNC_LOG(WARNING)
-                        << LOG_DESC(
-                               "requestMissedTxs: verifyFetchedTxs when recv txs response exception")
-                        << LOG_KV("message", boost::diagnostic_information(e))
-                        << LOG_KV("_peer", _nodeID->shortHex());
-                    if (_onVerifyFinished)
+                    _onVerifyFinished(std::move(_error), _result);
+                    if (!(_verifiedProposal))
                     {
-                        _onVerifyFinished(BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
-                                              "verifyFetchedTxs exception: " +
-                                                  boost::diagnostic_information(e)),
-                            false);
+                        return;
                     }
-                }
-            });
+                    SYNC_LOG(DEBUG)
+                        << LOG_DESC("requestMissedTxs: response verify result")
+                        << LOG_KV("propIndex", _verifiedProposal->blockHeader()->number())
+                        << LOG_KV("propHash",
+                            _verifiedProposal->blockHeader()->hash().abridged())
+                        << LOG_KV("_result", _result) << LOG_KV("networkT", networkT)
+                        << LOG_KV("verifyAndSubmitT", (utcTime() - recordT));
+                });
+        }
+        catch (std::exception const& e)
+        {
+            SYNC_LOG(WARNING)
+                << LOG_DESC("requestMissedTxs: verifyFetchedTxs when recv txs response exception")
+                << LOG_KV("message", boost::diagnostic_information(e))
+                << LOG_KV("_peer", result.nodeID ? result.nodeID->shortHex() : "unknown");
+            if (_onVerifyFinished)
+            {
+                _onVerifyFinished(BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
+                                      "verifyFetchedTxs exception: " +
+                                          boost::diagnostic_information(e)),
+                    false);
+            }
+        }
     }(front, self, startT, networkTimeout, protocolID, std::move(_generatedNodeID),
         std::move(encodedData), _missedTxs, _verifiedProposal, _onVerifyFinished));
 }

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -267,10 +267,13 @@ void TransactionSync::requestMissedTxsFromPeer(PublicPtr _generatedNodeID, HashL
                    decltype(_generatedNodeID) _generatedNodeID, decltype(encodedData) _encodedData,
                    decltype(_missedTxs) _missedTxs, decltype(_verifiedProposal) _verifiedProposal,
                    decltype(_onVerifyFinished) _onVerifyFinished) mutable -> task::Task<void> {
-        auto result = co_await _front->sendMessageByNodeID(_protocolID, _generatedNodeID,
-            ::ranges::views::single(ref(*_encodedData)), _networkTimeout);
+        // result is declared outside the try so the catch below can still log the peer on a
+        // synchronous send failure
+        bcos::front::SendResult result;
         try
         {
+            result = co_await _front->sendMessageByNodeID(_protocolID, _generatedNodeID,
+                ::ranges::views::single(ref(*_encodedData)), _networkTimeout);
             auto transactionSync = _self.lock();
             if (!transactionSync)
             {

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -259,23 +259,27 @@ void TransactionSync::requestMissedTxsFromPeer(PublicPtr _generatedNodeID, HashL
     auto front = m_config->frontService();
     auto networkTimeout = m_config->networkTimeout();
     // owned payload + coroutine fast path -> zero-copy; the module-level response is delivered to
-    // the same callback through the front receive path (uuid-matched)
-    task::wait([front, self, startT, networkTimeout, protocolID,
-                   _generatedNodeID = std::move(_generatedNodeID),
-                   encodedData = std::move(encodedData), _missedTxs, _verifiedProposal,
-                   _onVerifyFinished]() mutable -> task::Task<void> {
-        co_await front->sendMessageByNodeID(protocolID, _generatedNodeID,
-            ::ranges::views::single(ref(*encodedData)), networkTimeout,
-            [self, startT, _missedTxs, _verifiedProposal, _onVerifyFinished](auto&& _error,
-                auto&& _nodeID, bytesConstRef _data, const std::string&, auto&&) {
+    // the same callback through the front receive path (uuid-matched). All state is passed as
+    // coroutine parameters so it is copied into the frame and stays alive for the whole (possibly
+    // deferred) send.
+    task::wait([](decltype(front) _front, decltype(self) _self, decltype(startT) _startT,
+                   decltype(networkTimeout) _networkTimeout, decltype(protocolID) _protocolID,
+                   decltype(_generatedNodeID) _generatedNodeID, decltype(encodedData) _encodedData,
+                   decltype(_missedTxs) _missedTxs, decltype(_verifiedProposal) _verifiedProposal,
+                   decltype(_onVerifyFinished) _onVerifyFinished) mutable -> task::Task<void> {
+        co_await _front->sendMessageByNodeID(_protocolID, _generatedNodeID,
+            ::ranges::views::single(ref(*_encodedData)), _networkTimeout,
+            [_self, _startT, _missedTxs, _verifiedProposal,
+                _onVerifyFinished](auto&& _error, auto&& _nodeID, bytesConstRef _data,
+                const std::string&, auto&&) {
                 try
                 {
-                    auto transactionSync = self.lock();
+                    auto transactionSync = _self.lock();
                     if (!transactionSync)
                     {
                         return;
                     }
-                    auto networkT = utcTime() - startT;
+                    auto networkT = utcTime() - _startT;
                     auto recordT = utcTime();
                     // verify fetch txs response
                     transactionSync->verifyFetchedTxs(_error, _nodeID, _data, _missedTxs,
@@ -316,7 +320,8 @@ void TransactionSync::requestMissedTxsFromPeer(PublicPtr _generatedNodeID, HashL
                     }
                 }
             });
-    }());
+    }(front, self, startT, networkTimeout, protocolID, std::move(_generatedNodeID),
+        std::move(encodedData), _missedTxs, _verifiedProposal, _onVerifyFinished));
 }
 
 void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, bytesConstRef _data,

--- a/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
+++ b/bcos-txpool/bcos-txpool/sync/TransactionSync.cpp
@@ -256,58 +256,67 @@ void TransactionSync::requestMissedTxsFromPeer(PublicPtr _generatedNodeID, HashL
     auto encodedData = txsRequest->encode();
     auto startT = utcTime();
     auto self = weak_from_this();
-    m_config->frontService()->asyncSendMessageByNodeID(protocolID, std::move(_generatedNodeID),
-        ref(*encodedData), m_config->networkTimeout(),
-        [self, startT, _missedTxs, _verifiedProposal, _onVerifyFinished](
-            auto&& _error, auto&& _nodeID, bytesConstRef _data, const std::string&, auto&&) {
-            try
-            {
-                auto transactionSync = self.lock();
-                if (!transactionSync)
+    auto front = m_config->frontService();
+    auto networkTimeout = m_config->networkTimeout();
+    // owned payload + coroutine fast path -> zero-copy; the module-level response is delivered to
+    // the same callback through the front receive path (uuid-matched)
+    task::wait([front, self, startT, networkTimeout, protocolID,
+                   _generatedNodeID = std::move(_generatedNodeID),
+                   encodedData = std::move(encodedData), _missedTxs, _verifiedProposal,
+                   _onVerifyFinished]() mutable -> task::Task<void> {
+        co_await front->sendMessageByNodeID(protocolID, _generatedNodeID,
+            ::ranges::views::single(ref(*encodedData)), networkTimeout,
+            [self, startT, _missedTxs, _verifiedProposal, _onVerifyFinished](auto&& _error,
+                auto&& _nodeID, bytesConstRef _data, const std::string&, auto&&) {
+                try
                 {
-                    return;
+                    auto transactionSync = self.lock();
+                    if (!transactionSync)
+                    {
+                        return;
+                    }
+                    auto networkT = utcTime() - startT;
+                    auto recordT = utcTime();
+                    // verify fetch txs response
+                    transactionSync->verifyFetchedTxs(_error, _nodeID, _data, _missedTxs,
+                        _verifiedProposal,
+                        [networkT, recordT, _verifiedProposal, _onVerifyFinished](
+                            Error::Ptr _error, bool _result) {
+                            if (!_onVerifyFinished)
+                            {
+                                return;
+                            }
+                            _onVerifyFinished(std::move(_error), _result);
+                            if (!(_verifiedProposal))
+                            {
+                                return;
+                            }
+                            SYNC_LOG(DEBUG)
+                                << LOG_DESC("requestMissedTxs: response verify result")
+                                << LOG_KV("propIndex", _verifiedProposal->blockHeader()->number())
+                                << LOG_KV("propHash",
+                                    _verifiedProposal->blockHeader()->hash().abridged())
+                                << LOG_KV("_result", _result) << LOG_KV("networkT", networkT)
+                                << LOG_KV("verifyAndSubmitT", (utcTime() - recordT));
+                        });
                 }
-                auto networkT = utcTime() - startT;
-                auto recordT = utcTime();
-                // verify fetch txs response
-                transactionSync->verifyFetchedTxs(_error, _nodeID, _data, _missedTxs,
-                    _verifiedProposal,
-                    [networkT, recordT, _verifiedProposal, _onVerifyFinished](
-                        Error::Ptr _error, bool _result) {
-                        if (!_onVerifyFinished)
-                        {
-                            return;
-                        }
-                        _onVerifyFinished(std::move(_error), _result);
-                        if (!(_verifiedProposal))
-                        {
-                            return;
-                        }
-                        SYNC_LOG(DEBUG)
-                            << LOG_DESC("requestMissedTxs: response verify result")
-                            << LOG_KV("propIndex", _verifiedProposal->blockHeader()->number())
-                            << LOG_KV(
-                                   "propHash", _verifiedProposal->blockHeader()->hash().abridged())
-                            << LOG_KV("_result", _result) << LOG_KV("networkT", networkT)
-                            << LOG_KV("verifyAndSubmitT", (utcTime() - recordT));
-                    });
-            }
-            catch (std::exception const& e)
-            {
-                SYNC_LOG(WARNING)
-                    << LOG_DESC(
-                           "requestMissedTxs: verifyFetchedTxs when recv txs response exception")
-                    << LOG_KV("message", boost::diagnostic_information(e))
-                    << LOG_KV("_peer", _nodeID->shortHex());
-                if (_onVerifyFinished)
+                catch (std::exception const& e)
                 {
-                    _onVerifyFinished(
-                        BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
-                            "verifyFetchedTxs exception: " + boost::diagnostic_information(e)),
-                        false);
+                    SYNC_LOG(WARNING)
+                        << LOG_DESC(
+                               "requestMissedTxs: verifyFetchedTxs when recv txs response exception")
+                        << LOG_KV("message", boost::diagnostic_information(e))
+                        << LOG_KV("_peer", _nodeID->shortHex());
+                    if (_onVerifyFinished)
+                    {
+                        _onVerifyFinished(BCOS_ERROR_PTR(CommonError::FetchTransactionsFailed,
+                                              "verifyFetchedTxs exception: " +
+                                                  boost::diagnostic_information(e)),
+                            false);
+                    }
                 }
-            }
-        });
+            });
+    }());
 }
 
 void TransactionSync::verifyFetchedTxs(Error::Ptr _error, NodeIDPtr _nodeID, bytesConstRef _data,
@@ -542,11 +551,13 @@ void TransactionSync::responseTxsStatus(NodeIDPtr _fromNode)
     auto txsStatus = m_config->msgFactory()->createTxsSyncMsg(
         static_cast<uint32_t>(TxsSyncPacketType::TxsStatusPacket), *txsHash);
     auto packetData = txsStatus->encode();
-    m_config->frontService()->asyncSendMessageByNodeID(
-        ModuleID::TxsSync, _fromNode, ref(*packetData), 0, nullptr);
+    auto packetSize = packetData->size();
+    // owned payload -> zero-copy through the front/gateway coroutine fast path
+    m_config->frontService()->asyncSendMessageByNodeIDByOwnedPayload(
+        ModuleID::TxsSync, _fromNode, std::move(packetData));
     SYNC_LOG(DEBUG) << LOG_DESC("onPeerTxsStatus: receive empty txsStatus and responseTxsStatus")
                     << LOG_KV("to", _fromNode->shortHex()) << LOG_KV("txsSize", txsHash->size())
-                    << LOG_KV("packetSize", packetData->size());
+                    << LOG_KV("packetSize", packetSize);
 }
 
 void TransactionSync::onEmptyTxs()


### PR DESCRIPTION
## 摘要

将 P2P 发送路径全面重构为**协程 + 值语义 + 视图零拷贝**：出站消息从每消息 `make_shared<P2PMessageV2>` + 多次 payload 拷贝，改为消息作为**值放在协程帧内**、payload 以 `bytesConstRef` 视图直达 socket（复用既有 `fastSendMessage` 零拷贝链），消除出站高频堆分配、编码拷贝与 shared_ptr 引用计数开销。

## 背景与动机

高频消息收发场景下，原发送路径存在两类问题：
1. **频繁堆分配**：`buildMessage()` 在发送路径上每条消息 `make_shared<P2PMessageV2>`（无复用）；
2. **多余拷贝**：`setPayload` → `encode(EncodedMessage)` → `send` 按值传参，一条消息发送经历多次 payload 深拷贝；广播 per-peer 深拷贝。

## 主要改动

### 单一零拷贝发送路径（严格 const）
- `Session::fastSendMessage` / `fastSendMessageWithResponse` 以 **`const Message&`** 接收——调用方消息全程不可变，由编译器保证（广播扇出 / 重试循环复用同一消息对象时不会泄漏任何瞬态状态）；
- 补上**出站限流检查**：`setBeforeMessageHandler` / `Service::onBeforeMessage` 签名改为 `(SessionFace&, const Message&, uint32_t _wireLength)`，由 `fastSendMessage` 显式传入实际线上字节（含 payload 视图；零拷贝消息自身不含 payload，`message.length()` 会漏计），命中抛 `NetworkException`——快速路径不再绕过带宽/QPS 限流；
- 压缩（zstd）与 `allowMaxMsgSize` 检查在快速路径内恢复；COMPRESS 标志**不修改调用方消息**，而是直接打在编码后的线上 header 的 ext 字段（base header 偏移 12）上，发送前写入；`Message::setLength` 从接口移除（不再需要瞬态改长）；
- **移除 `Session::asyncSendMessage` 及 `EncodedMessage` 机制**（`send(EncodedMessage)` 重载、`Payload::EncodedMessage` 变体），全代码库发送统一走 `fastSendMessage` 视图路径。

### 协程点对点接口（零拷贝契约 + 单一出口）
- `GatewayInterface::sendMessageByNodeID` → **`task::Task<Error::Ptr>`**（`nullptr`=成功，非空=失败）、`FrontServiceInterface::sendMessageByNodeID` → **`task::Task<SendResult>`**，均带默认实现（join 拷贝 + 桥接到既有借用接口），因此 **TARS clients/servers 零改动**；
- Gateway 零拷贝覆盖：帧内 `P2PMessageV2` 值（不拷贝 payload）+ p2pIDs 重试循环（10s 超时、respCode 判断、OutBW/InQPS 停止）；**删除 `Retry` 类**；
- FrontService 零拷贝覆盖：uuid/callback/超时注册 + `FrontMessage.encodeHeader` 帧内小 buffer + payload 视图直达 gateway；`asyncSendMessageByNodeIDByOwnedPayload` 改为零拷贝（PBFT owned 路径自动受益）；
- 借用回调接口（`asyncSendMessageByNodeID` 等）保留为**同步拷贝薄壳**，契约不变。

### 协程接口单一出口（双出口收敛）
- **问题**：`sendMessageByNodeID` 最初带回调参数（front 的 `CallbackFunc`、gateway 的 `ErrorRespFunc`）——协程返回后结果再由回调异步派发，一个函数两个出口，调用方难以保证生命周期与结果归属；
- **收敛**：front 收为 `Task<SendResult>`（`SendResult{error, nodeID, payload, uuid, respond}`，`co_await` 直达「响应到达 / 超时 / 网关失败」，`timeout==0` 为 fire-and-forget）；gateway 收为 `Task<Error::Ptr>`（远程重试循环 `co_return nullptr` 或具体 Error，本地投递用 `LocalSendAwaitable` 把异步回调桥到 `co_await`）；
- **整链路检查**：module→front→gateway→p2p→session 的协程发送函数已全部单出口——front=`Task<SendResult>`、gateway=`Task<Error::Ptr>`、p2p/session=`Task<Message::Ptr>`（本无回调）、broadcast 系列=`Task<void>`；剩余 `async*` 为**纯回调 API**（单出口=回调本身，非协程双出口），按 pre-PR 契约保留给 AMOP / 节点管理等调用方；
- **竞态安全 awaitable**：`State{done: atomic, handle, result, mutex}`——`complete()` 锁内判重 + 填结果 + 取 handle（**锁外 resume**），保证恰好 resume 一次、结果恰好交付一次。

### 内部调用方全部转 fastSend 薄壳
- Service/ServiceV2/P2PSession/GatewayNodeManager 出站消息全部改为帧内值 + 协程发送；新增 `broadcastMessageToAll`；**转发路径**（`ServiceV2::onMessage`）改为协程捕获 received 消息 + payload 视图（零拷贝转发）。

### 外部调用点迁移
- BlockSync / TransactionSync / PBFTLogSync 全部发送调用点迁移到 owned-payload / 协程（零拷贝），并修复 `BlockSync` 一处对临时 `bytesPointer` 解引用的隐患；原回调体搬进协程体消费 `SendResult`（`return` 改 `co_return`）。

## 健壮性（评审驱动修复）
- 全部 17 处协程发送点统一为**传参式** `task::wait([](decltype(x) x, ...){...}(x, ...))`，状态进入协程帧，消除捕获式 lambda 首次挂起后的 use-after-free；
- 出站消息补齐 `setVersion` 到协商协议版本（V2 路由字段不再丢失）；转发不再改写 `srcP2PNodeID`；
- 心跳 / fire-and-forget 发送失败捕获并记录，避免定时器停摆与节点批量发送中断；
- `P2PMessage::setExt` 改为赋值语义（原为 OR，导致瞬态恢复是空操作）；
- `Session::send` / `drop` / `write` 异常与失活路径的完成回调统一 post 到 io 线程（避免 in-thread 重入），会话在写完成前消失不泄漏整条协程链。

## 验证
- 全栈主节点 `fisco-bcos` 编译通过；
- 单测：gateway（含新增出站限流、zstd 压缩回环、协程点对点往返专项测试）、front 22/22、sync 39/39、txpool 62/62 全部通过。

## 关键决策
- 接收路径 decode/handler 未改动（仅接收 handler 内的转发发送被协程化）；
- 借用接口保留同步拷贝薄壳（TARS 跨进程、legacy 调用点契约不变）；
- 出站限流迁入 `fastSendMessage` 并以实际线上字节计费（广播路径也纳入限流，修复原有漏检）；
- 发送路径严格 const：COMPRESS / 长度等"帧级"信息只存在于协程帧与线上 header，不落在调用方消息上；
- **协程函数一律单一出口**：结果经返回值交付（`SendResult` / `Error::Ptr` / `Message::Ptr` / `void`），回调参数只存在于纯回调 API（`async*` 系列）；
- 广播 fan-out 逐 peer 独立协程（消除队头阻塞，恢复 base "入队即返回"语义）；代价是压缩开启时峰值内存随 peer 数线性放大（每帧持有 joined/compressed payload），与 base 每 peer 一份拥有式副本同一量级，后续可考虑信号量式并发上限；
- 广播路径（`PeersRouterTable::broadcastMessage`）逐 peer 顺序发送，每个 peer 在 `Session::fastSendMessage` 内各自做一次全量 join + zstd 压缩（`p2p.enable_compression` 默认开启，仅当 payload > 1KB 且版本 ≥ V2 时触发）——K 个远端网关 = K 次 join + K 次压缩同一份字节。这是相对 base（广播零拷贝零压缩）的有意行为变更（广播帧出网字节显著下降、旧节点可解压），但 CPU/拷贝成本未测量；后续可考虑在 peer 循环外预 join + 预压缩一次共享视图；
- 发送生命周期：`send()` 提前返回与 `drop()` 排干写队列都会以错误码触发完成回调，会话在写完成前消失不再泄漏整条协程链；
- 本地投递（`LocalSendAwaitable`）依赖目标 front 的回执，io 池停止后在途发送不再完成（已知关停语义）。
- 两条已知 LOW 有意保留、后续 PR 处理：`P2PMessage::encode(bytes&)` 与 `Session::fastSendMessage` 各写一套 zstd 压缩（前者生产无调用点，漂移风险）；`Service::sendMessageToSession`（`Service.cpp`）与 `P2PSession::fastSendP2PMessage` 双重 `setVersion`（同值无竞争）。


