### PR TITLE
Engine: honor attributes.gasLimit, commit the real Isthmus withdrawalsRoot, add block-start system calls

### DIFF
--- a/bcos-ledger/bcos-ledger/mpt/AccountStorageRoot.h
+++ b/bcos-ledger/bcos-ledger/mpt/AccountStorageRoot.h
@@ -1,0 +1,131 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AccountStorageRoot.h
+ * @brief One account's Ethereum storage-trie root, computed from the flat KV state
+ */
+#pragma once
+
+#include "Classify.h"
+#include "Constants.h"
+#include "HashBuilder.h"
+#include "StorageValueCodec.h"
+#include <bcos-crypto/hasher/OpenSSLHasher.h>
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Task.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <map>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace bcos::ledger::mpt
+{
+
+/// The Ethereum storage-trie root of ONE account, built from every live storage slot the flat
+/// state currently holds for it. Unlike MPTBuilder's per-block path, which merges a change-set
+/// onto a parent trie version and needs the MPT node store, this reads only the flat KV and
+/// rebuilds the trie from scratch: it answers "what is this account's storage root right now"
+/// for a caller that keeps no trie of its own.
+///
+/// Its one production caller today is the OP Stack Isthmus header field withdrawalsRoot, which
+/// the spec defines as the storage root of the L2ToL1MessagePasser predeploy
+/// (op-geth params/protocol_params.go:31, validation side block_validator.go:190-198). The
+/// function itself knows nothing about OP — the caller supplies the address.
+///
+/// Construction (identical to MPTBuilder's storage level, and to bcos::evm::accountStorageRoot
+/// on the evmone side): a secure trie whose key is slotKeyHash(slot) = keccak256(32-byte slot
+/// key) and whose value is encodeStorageValue(value) = RLP of the value with leading zero bytes
+/// trimmed. Slots that trim to nothing (an all-zero value) are NOT part of the trie — zero is
+/// Ethereum's "the slot does not exist" — and neither are tombstoned rows. An account with no
+/// live slot yields emptyRootHash(), not a zero h256.
+///
+/// The scan is a prefix range over @p flatView seeded with RANGE_SEEK, so it touches this
+/// account's rows only, not the whole state. It reads through the view, so a slot written
+/// earlier in the same block (the fork view's mutable layer) shadows the committed value — the
+/// merge-sort iterator returns the highest-priority layer's row for a duplicated key
+/// (MultiLayerStorage.h View::Iterator::next).
+///
+/// Requires every layer of @p flatView to yield keys in ascending order from the seek point,
+/// which is what lets the loop stop at the first row of the next table. Production satisfies
+/// this — the delta layer is a single-bucket ORDERED MemoryStorage and the backend a RocksDB
+/// cursor. A CONCURRENT MemoryStorage does NOT: its Iterator seeks bucket 0 only and then
+/// walks the remaining buckets from their start (MemoryStorage.h Iterator::seek / next), so a
+/// scan over one would stop early and return a partial root. The same precondition already
+/// governs the two other prefix scans over an account table, EthereumState::
+/// clearAccountStorage and Storage2State::fetchAllStorage.
+///
+/// Cost: O(live slots of this account) per call, with no incremental reuse across blocks. For
+/// the L2ToL1MessagePasser that count is the number of withdrawals the chain has ever initiated
+/// (currently zero, since no L2->L1 message path is wired). Making this incremental belongs with
+/// the MPT work that owns a persistent trie per account, not here.
+///
+/// @param flatView an executor-shaped flat state (StateKey rows) supporting a seeded range
+/// @param addr     the account whose storage trie is wanted
+template <class FlatView>
+bcos::task::Task<bcos::h256> accountStorageRootFromFlat(
+    FlatView& flatView, bcos::Address const& addr)
+{
+    auto const table = accountTableName(addr);
+    bcos::crypto::hasher::openssl::OpenSSL_Keccak256_Hasher hasher;
+    std::map<bcos::h256, bcos::bytes> entries;
+
+    auto iterator = co_await bcos::storage2::range(flatView, bcos::storage2::RANGE_SEEK,
+        bcos::executor_v1::StateKey{table, std::string_view{}});
+    while (auto keyValue = co_await iterator.next())
+    {
+        auto const& [stateKey, dataValue] = *keyValue;
+        bcos::executor_v1::StateKeyView const keyView{stateKey};
+        if (keyView.m_table != table)
+        {
+            // The seek landed at or before this account's first row; a different table name
+            // means the prefix range is over.
+            break;
+        }
+        if (classifyRowKey(keyView.m_key) != RowKind::StorageSlot)
+        {
+            // nonce / balance / codeHash / code / BCOS extension rows: none belong to the
+            // storage trie. Unlike MPTBuilder this does not throw on an unclassified field —
+            // this function commits nothing and forks nothing, so an unknown row is simply
+            // not a storage slot.
+            continue;
+        }
+        // A tombstoned (deleted) or absent row must not resurrect the slot.
+        auto const* entry = std::get_if<bcos::storage::Entry>(std::addressof(dataValue));
+        if (entry == nullptr)
+        {
+            continue;
+        }
+        std::string_view const raw = entry->get();
+        auto encoded = encodeStorageValue(
+            bcos::bytesConstRef(reinterpret_cast<bcos::byte const*>(raw.data()), raw.size()));
+        if (encoded.empty())
+        {
+            continue;  // all-zero value: the slot is not in the trie
+        }
+        auto const slot = bcos::h256(bcos::bytesConstRef(
+            reinterpret_cast<bcos::byte const*>(keyView.m_key.data()), keyView.m_key.size()));
+        entries.emplace(slotKeyHash(slot, hasher), std::move(encoded));
+    }
+
+    // computeTrieRoot over an empty map is emptyRootHash() by construction, which is exactly
+    // the "no live slots" answer Ethereum expects.
+    co_return computeTrieRoot(entries).root;
+}
+
+}  // namespace bcos::ledger::mpt

--- a/bcos-ledger/test/unittests/mpt/AccountStorageRootTest.cpp
+++ b/bcos-ledger/test/unittests/mpt/AccountStorageRootTest.cpp
@@ -1,0 +1,208 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file AccountStorageRootTest.cpp
+ * @brief accountStorageRootFromFlat: an account's storage-trie root rebuilt from the flat KV.
+ *        The three-slot root is pinned against an INDEPENDENT offline reference produced by
+ *        tools/opstack-genesis/gen_storage_root_fixture.py (its own RLP + trie, sharing only
+ *        the keccak256 primitive), so a self-consistent-but-wrong C++ trie cannot pass.
+ */
+#include "TestHelpers.h"
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-ledger/mpt/AccountStorageRoot.h>
+#include <bcos-ledger/mpt/Classify.h>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/Common.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <boost/test/unit_test.hpp>
+#include <string>
+#include <string_view>
+
+namespace bcos::ledger::mpt::test
+{
+
+BOOST_AUTO_TEST_SUITE(AccountStorageRootSuite)
+
+namespace
+{
+// `asr*` name prefixes avoid an anonymous-namespace ODR clash with the other mpt test files
+// under UNITY_BUILD.
+
+/// The account whose storage trie every case below builds. Byte value is irrelevant to the
+/// function — the OP L2ToL1MessagePasser identity lives in the engine, not here.
+bcos::Address asrAccount()
+{
+    return makeAddress(0x42);
+}
+
+/// A 32-byte big-endian slot key / value for a small integer.
+bcos::h256 asrWord(uint64_t value)
+{
+    bcos::h256 out{};
+    for (size_t i = 0; i < sizeof(value); ++i)
+    {
+        out.data()[bcos::h256::SIZE - 1 - i] = static_cast<bcos::byte>(value >> (8 * i));
+    }
+    return out;
+}
+
+bcos::h256 asrAllOnes()
+{
+    bcos::h256 out{};
+    for (size_t i = 0; i < bcos::h256::SIZE; ++i)
+    {
+        out.data()[i] = static_cast<bcos::byte>(0xFF);
+    }
+    return out;
+}
+
+/// The executor writes a slot value as its 32 RAW bytes (EVMAccount::setStorage).
+bcos::storage::Entry asrSlotEntry(bcos::h256 const& value)
+{
+    return makeEntry(std::string_view{
+        reinterpret_cast<char const*>(value.data()), static_cast<size_t>(bcos::h256::SIZE)});
+}
+
+void asrWriteSlot(auto& target, bcos::h256 const& slot, bcos::h256 const& value)
+{
+    writeFlatRow(target, accountSlotKey(asrAccount(), slot), asrSlotEntry(value));
+}
+
+bcos::h256 asrRootOf(FlatStateView& view)
+{
+    return bcos::task::syncWait(accountStorageRootFromFlat(view, asrAccount()));
+}
+
+/// gen_storage_root_fixture.py, fixture "three_slots":
+///   slot 0x00..00 -> 1, slot 0x00..01 -> 0xdeadbeef, slot 0xff..ff -> 0xff
+bcos::h256 const c_threeSlotsRoot{
+    std::string_view{"7ce94a4a60783202e726bea0fb63adadfb79ee7903d3b30af81c4b5530b9bff5"},
+    bcos::h256::FromHex};
+/// gen_storage_root_fixture.py, fixture "single_slot": slot 0x00..00 -> 1.
+bcos::h256 const c_singleSlotRoot{
+    std::string_view{"821e2556a290c86405f8160a2d662042a431ba456b9db265c79bb837c04be5f0"},
+    bcos::h256::FromHex};
+
+/// Seed the fixture's three slots into @p target (a delta layer or a backend).
+void asrSeedThreeSlots(auto& target)
+{
+    asrWriteSlot(target, asrWord(0), asrWord(1));
+    asrWriteSlot(target, asrWord(1), asrWord(0xDEADBEEF));
+    asrWriteSlot(target, asrAllOnes(), asrWord(0xFF));
+}
+}  // namespace
+
+// An account with no storage row at all has the EMPTY TRIE root, not a zero h256. The
+// difference matters on the wire: a zero withdrawalsRoot is not a state any Ethereum client
+// would produce, so serving one is indistinguishable from a broken CL's submission.
+BOOST_AUTO_TEST_CASE(no_slots_yields_empty_trie_root)
+{
+    FlatBackendStorage backend;
+    auto view = makeFlatView(backend);
+    BOOST_CHECK_EQUAL(asrRootOf(view), emptyRootHash());
+    BOOST_CHECK_NE(asrRootOf(view), bcos::h256{});
+}
+
+// nonce / balance / codeHash / code rows are not storage slots and must leave the trie empty.
+BOOST_AUTO_TEST_CASE(account_field_rows_are_not_slots)
+{
+    FlatBackendStorage backend;
+    auto view = makeFlatView(backend);
+    writeFlatRow(mutableStorage(view), accountFieldKey(asrAccount(), ROW_NONCE), makeEntry("7"));
+    writeFlatRow(
+        mutableStorage(view), accountFieldKey(asrAccount(), ROW_BALANCE), makeEntry("1000"));
+    writeFlatRow(mutableStorage(view), accountFieldKey(asrAccount(), ROW_CODE), makeEntry("\x60"));
+    BOOST_CHECK_EQUAL(asrRootOf(view), emptyRootHash());
+}
+
+// The load-bearing vector: three slots, root pinned against the offline python reference.
+BOOST_AUTO_TEST_CASE(three_slots_match_offline_reference)
+{
+    FlatBackendStorage backend;
+    auto view = makeFlatView(backend);
+    asrSeedThreeSlots(mutableStorage(view));
+    BOOST_CHECK_EQUAL(asrRootOf(view), c_threeSlotsRoot);
+}
+
+// A slot whose value is all zeros is NOT in the trie (Ethereum: zero == does not exist), so
+// adding one leaves the three-slot root untouched.
+BOOST_AUTO_TEST_CASE(zero_valued_slot_is_not_in_the_trie)
+{
+    FlatBackendStorage backend;
+    auto view = makeFlatView(backend);
+    asrSeedThreeSlots(mutableStorage(view));
+    asrWriteSlot(mutableStorage(view), asrWord(2), asrWord(0));
+    BOOST_CHECK_EQUAL(asrRootOf(view), c_threeSlotsRoot);
+}
+
+// Slots committed in the parent state are read through the view, and a row rewritten in this
+// block's delta shadows the committed one — the merge-sort iterator returns the delta's value
+// for a duplicated key.
+BOOST_AUTO_TEST_CASE(delta_layer_shadows_the_committed_slot)
+{
+    FlatBackendStorage backend;
+    asrWriteSlot(backend, asrWord(0), asrWord(1));
+    asrWriteSlot(backend, asrWord(1), asrWord(0xDEADBEEF));
+    asrWriteSlot(backend, asrAllOnes(), asrWord(0xFF));
+    {
+        auto committedView = makeFlatView(backend);
+        BOOST_CHECK_EQUAL(asrRootOf(committedView), c_threeSlotsRoot);
+    }
+
+    // This block zeroes the two extra slots: what remains is the single-slot fixture.
+    auto view = makeFlatView(backend);
+    asrWriteSlot(mutableStorage(view), asrWord(1), asrWord(0));
+    asrWriteSlot(mutableStorage(view), asrAllOnes(), asrWord(0));
+    BOOST_CHECK_EQUAL(asrRootOf(view), c_singleSlotRoot);
+}
+
+// A logically deleted slot row must not resurrect the slot.
+BOOST_AUTO_TEST_CASE(deleted_slot_row_leaves_the_trie)
+{
+    FlatBackendStorage backend;
+    asrWriteSlot(backend, asrWord(0), asrWord(1));
+    asrWriteSlot(backend, asrWord(1), asrWord(0xDEADBEEF));
+    asrWriteSlot(backend, asrAllOnes(), asrWord(0xFF));
+
+    auto view = makeFlatView(backend);
+    deleteFlatRowLogically(view, accountSlotKey(asrAccount(), asrWord(1)));
+    deleteFlatRowLogically(view, accountSlotKey(asrAccount(), asrAllOnes()));
+    BOOST_CHECK_EQUAL(asrRootOf(view), c_singleSlotRoot);
+}
+
+// Another account's slots never enter this account's trie: the scan is a prefix range over
+// one table, and a neighbouring /apps/ table ends it.
+BOOST_AUTO_TEST_CASE(other_accounts_slots_are_excluded)
+{
+    FlatBackendStorage backend;
+    auto view = makeFlatView(backend);
+    asrSeedThreeSlots(mutableStorage(view));
+    for (auto firstByte : {bcos::byte{0x01}, bcos::byte{0x41}, bcos::byte{0x43}, bcos::byte{0xFE}})
+    {
+        auto const other = makeAddress(firstByte);
+        writeFlatRow(mutableStorage(view),
+            bcos::executor_v1::StateKey{accountTableName(other),
+                std::string_view{
+                    reinterpret_cast<char const*>(asrWord(0).data()), bcos::h256::SIZE}},
+            asrSlotEntry(asrWord(0x99)));
+    }
+    BOOST_CHECK_EQUAL(asrRootOf(view), c_threeSlotsRoot);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::ledger::mpt::test

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -82,8 +82,15 @@ void bcos::rpc::combineBlockResponse(
     result["mixHash"] = crypto::HashType().hexPrefixed();
     result["baseFeePerGas"] = "0x0";
     result["withdrawals"] = Json::Value(Json::arrayValue);
-    // empty withdrawals trie root hash
-    result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
+    // Isthmus (OP Stack) defines this field as the L2ToL1MessagePasser predeploy's storage
+    // root, NOT a withdrawals trie root — the L1 accounting lives in that account's storage
+    // and there are no withdrawal operations to build a trie over. A header that carries the
+    // computed value (every V3+ payload this node builds — EngineServiceImpl.h
+    // fillWithdrawalsRoot) reports it, so eth_getBlockBy* and engine_getPayload agree on the
+    // same block. Headers without the field — pre-Isthmus blocks and every block produced
+    // outside the Engine path — keep answering the zero hash they always did.
+    result["withdrawalsRoot"] =
+        blockHeader->withdrawalsRoot().value_or(crypto::HashType()).hexPrefixed();
     result["blobGasUsed"] = "0x0";
     result["excessBlobGas"] = "0x0";
     result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -575,15 +575,18 @@ std::optional<bcos::engine::PayloadAttributes> bcos::rpc::parsePayloadAttributes
     // forged value) and report malformed input as std::invalid_argument, which the RPC
     // entry point would surface as -32603 InternalError.
     //
-    // KNOWN GAP: gasLimit is parsed and carried on PayloadAttributes but buildPayload
-    // IGNORES it — the built block's gas limit always comes from this chain's own
-    // SystemConfig (EngineServiceImpl.h, ledgerConfig.gasLimit()). op-geth does the
-    // opposite: the attribute is mandatory on an OP chain (checkOptimismPayloadAttributes,
-    // eth/catalyst/api_optimism.go:41-43, else -38003) and sets header.GasLimit verbatim
-    // (miner/worker.go:362-363), and op-node always sends it from the L1 SystemConfig
-    // (op-node/rollup/derive/attributes.go:207-215). Honouring it changes what block this
-    // node produces, which belongs to the header-fields work rather than to this
-    // method-surface change.
+    // gasLimit is honoured: buildPayload takes it as the built block's gas limit AND as the
+    // block's execution budget (EngineServiceImpl.h, the ledgerConfig.setGasLimit override).
+    // op-node always sends it from the L1 SystemConfig
+    // (op-node/rollup/derive/attributes.go:207-215) and op-geth writes it verbatim into
+    // header.GasLimit (miner/worker.go:362-363).
+    //
+    // One deliberate difference from op-geth: an ABSENT gasLimit is not rejected here.
+    // op-geth's -38003 (checkOptimismPayloadAttributes, eth/catalyst/api_optimism.go:41-43)
+    // guards attributes that are OP attributes by construction, whereas this same struct
+    // also carries the vanilla V1/V2/V3 attributes that never have the field — including the
+    // ones this node's own built-in single-node CL sends — so buildPayload falls back to the
+    // chain's SystemConfig instead. An out-of-range value IS rejected, below.
     if (pa.isMember("gasLimit") && !pa["gasLimit"].isNull())
     {
         attrs.gasLimit = parseQuantity(pa["gasLimit"], "payloadAttributes.gasLimit");

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/utils/EngineHelper.cpp
@@ -743,8 +743,9 @@ Json::Value bcos::rpc::serializeExecutionPayload(
     // V4+ only (Isthmus): a required field of the payload shape, never emitted in V1-V3.
     // Absence here is an internal invariant violation, not a client error: every payload
     // that can reach a V4+ serialization was either built locally (buildPayload sets the
-    // field for V3+ builds, currently to the documented zero placeholder — see
-    // EngineServiceImpl.h) or parsed from a V4 request (where the field is mandatory).
+    // field for V3+ builds, to the L2ToL1MessagePasser storage root — see
+    // EngineServiceImpl.h fillWithdrawalsRoot) or parsed from a V4 request (where the field
+    // is mandatory).
     // Fail loudly rather than emitting a zero root the CL would take for a real
     // L2ToL1MessagePasser storage root.
     if (version >= engine::ApiVersion::V4)

--- a/bcos-single-consensus/bcos-single-consensus/SingleNodeConsensus.cpp
+++ b/bcos-single-consensus/bcos-single-consensus/SingleNodeConsensus.cpp
@@ -214,13 +214,13 @@ bool SingleNodeConsensus::produceBlock()
     // stays in the internal millisecond unit — the Engine wire's seconds<->ms conversion
     // lives in the RPC serialization layer only.
     //
-    // TODO(C4 header fields): the zero parentBeaconBlockRoot here, and the zero
-    // withdrawalsRoot the EngineService stamps onto the payload it builds from these
-    // attributes (see the placeholder note in EngineServiceImpl.h buildPayload), are
-    // built-in-CL stand-ins, NOT production semantics. Because they are zero, a payload
-    // produced by this driver is byte-indistinguishable from one a broken or malicious
-    // external CL would submit with zero roots. Do not read this file as evidence that
-    // zero roots are acceptable on a real chain.
+    // TODO(C4 header fields): the zero parentBeaconBlockRoot here is a built-in-CL stand-in,
+    // NOT production semantics — this driver has no beacon chain to read a real root from,
+    // so a payload it produces is byte-indistinguishable from one a broken or malicious
+    // external CL would submit with a zero root. Do not read this file as evidence that a
+    // zero beacon root is acceptable on a real chain. (The payload's withdrawalsRoot is no
+    // longer in that category: the EngineService now computes the real L2ToL1MessagePasser
+    // storage root — EngineServiceImpl.h fillWithdrawalsRoot.)
     payloadAttributes.withdrawals = std::vector<bcos::engine::WithdrawalV1>{};
     payloadAttributes.parentBeaconBlockRoot = bcos::h256{};
 

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -19,6 +19,8 @@
 #include "EngineServiceImpl.h"
 #include "bcos-framework/engine/RawTransactionDispatch.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <cstdint>
+#include <limits>
 
 namespace
 {
@@ -167,6 +169,20 @@ std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     if (version == 3 && !payloadAttributes.parentBeaconBlockRoot.has_value())
     {
         return std::string("parentBeaconBlockRoot must be a 32-byte hash for V3");
+    }
+    // gasLimit is a Uint64Quantity on the wire, but every consumer of the value the build
+    // hands down is int64: TransactionExecutorImpl.h:53 narrows it with a bare
+    // static_cast<int64_t> into the EVM message's gas field, and evmone's BlockInfo::gas_limit
+    // is int64 as well. Left unbounded, 2^63 or more arrives at the executor as a NEGATIVE
+    // gas budget. Before this attribute existed the tuple's only source was SystemConfig,
+    // whose own path is int64 end to end (SystemConfigPrecompiled's defaultCmp), so the
+    // narrowing was unreachable; this is a new wire-facing entry point and has to bound
+    // itself. The bound is the executor's actual width, not an invented consensus rule.
+    if (payloadAttributes.gasLimit.has_value() &&
+        *payloadAttributes.gasLimit >
+            static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()))
+    {
+        return std::string("gasLimit exceeds the int64 range the execution layer uses");
     }
     return std::nullopt;
 }

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -31,6 +31,7 @@
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-ledger/LedgerMethods.h"
+#include "bcos-ledger/mpt/AccountStorageRoot.h"
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
@@ -59,6 +60,12 @@ namespace bcos::engine
 {
 // UnsupportedEngineApiVersion / UnknownPayload / IncompatiblePayloadVersion moved to
 // bcos-framework/engine/Types.h so the RPC endpoint can map them to Engine error codes.
+/// The L2ToL1MessagePasser predeploy. Isthmus defines the block header's withdrawalsRoot as
+/// this account's storage root; mirrors bcos::evm::opstack::OP_L2_TO_L1_MESSAGE_PASSER, spelled
+/// out here because bcos-engine does not link bcos-evm.
+inline const bcos::Address c_l2ToL1MessagePasser{
+    std::string_view{"4200000000000000000000000000000000000016"}, bcos::Address::FromHex};
+
 DERIVE_BCOS_EXCEPTION(GlobalStateStorageNotConfigured);
 DERIVE_BCOS_EXCEPTION(UnknownForkchoiceHeadBlock);
 DERIVE_BCOS_EXCEPTION(InvalidForkchoiceState);
@@ -729,30 +736,10 @@ private:
         {
             executionPayload.blobGasUsed = u256(0);
             executionPayload.excessBlobGas = u256(0);
-            // Isthmus payload shape (V4/V5, fed by forkchoiceUpdatedV3 on Karst): the
-            // field must be present so getPayloadV5 -> newPayloadV4 round-trips.
-            //
-            // TODO(C4 header fields): this is a zero PLACEHOLDER, not a computed value.
-            // On OP Stack withdrawalsRoot is the storage root of the L2ToL1MessagePasser
-            // predeploy and is what L1 withdrawal proofs are checked against, so until
-            // the real header wiring lands, validateExecutionPayload can only check that
-            // the field is present — never that its value is right, and a malicious CL
-            // submitting a zero root is indistinguishable from this node's own builds.
-            //
-            // This is a KNOWN UNCONTAINED gap, not a test-harness-only one. The
-            // [op_engine_rpc] guard in libinitializer/Initializer.cpp REQUIRES
-            // executor_version >= 2 (it throws for executor_version < 2 unless the
-            // test-only escape hatch unsafe_allow_v1_executor is set); it does not keep
-            // this code off a production endpoint. EngineServiceInitializer::build
-            // instantiates this same template for the v2 EthereumExecutor, so the
-            // intended production configuration — executor_version >= 2 with
-            // [op_engine_rpc] enabled — serves exactly this placeholder: FCU V3 stamps it
-            // here, getPayloadV5 serializes it, and newPayloadV4 accepts it on presence
-            // alone. Until C4 computes and verifies the real L2ToL1MessagePasser storage
-            // root, no L1 withdrawal proof may be taken against a root produced by this
-            // node. The v2 instantiation serving the zero root is pinned by
-            // TestEthereumExecutorScheduler/engineServiceKarstServesZeroWithdrawalsRoot,
-            // which has to be updated when the real value lands.
+            // Isthmus payload shape (V4/V5, fed by forkchoiceUpdatedV3 on Karst): the field
+            // must be present so getPayloadV5 -> newPayloadV4 round-trips. Presence is all
+            // that is decided here — fillWithdrawalsRoot() computes the value once the
+            // block's transactions have run, on either return path below.
             executionPayload.withdrawalsRoot = h256{};
         }
 
@@ -810,6 +797,7 @@ private:
             executionPayload.receiptsRoot = h256{};
             executionPayload.gasUsed = 0;
             executionPayload.blockHash = emptyHeader->hash();
+            co_await fillWithdrawalsRoot(executionPayload, view);
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
                 .header = std::move(emptyHeader),
                 .receipts = {}};
@@ -932,10 +920,28 @@ private:
         executionPayload.blockHash = blockHeader->hash();
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
         executionPayload.logsBloom = logsBloom;
+        co_await fillWithdrawalsRoot(executionPayload, view);
 
         co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
             .header = std::move(blockHeader),
             .receipts = std::move(receipts)};
+    }
+
+    /// Isthmus (OP Stack) withdrawalsRoot: the storage root of the L2ToL1MessagePasser
+    /// predeploy, which is what L1 withdrawal proofs are checked against (op-geth
+    /// params/protocol_params.go:31, block_validator.go:190-198). Runs after the block's
+    /// transactions so a withdrawal initiated in THIS block is already in the root; @p view
+    /// is the executed fork view, so committed slots and this block's writes are both seen.
+    ///
+    /// No-op for a payload whose shape has no such field (V1/V2 builds leave it nullopt),
+    /// which is what keeps this one call usable on both return paths of buildPayload.
+    task::Task<void> fillWithdrawalsRoot(ExecutionPayload& executionPayload, ViewType& view) const
+    {
+        if (executionPayload.withdrawalsRoot.has_value())
+        {
+            executionPayload.withdrawalsRoot =
+                co_await ledger::mpt::accountStorageRootFromFlat(view, c_l2ToL1MessagePasser);
+        }
     }
 
     /// Compute state root by iterating over storage and XOR-ing entry hashes.

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -61,8 +61,12 @@ namespace bcos::engine
 // UnsupportedEngineApiVersion / UnknownPayload / IncompatiblePayloadVersion moved to
 // bcos-framework/engine/Types.h so the RPC endpoint can map them to Engine error codes.
 /// The L2ToL1MessagePasser predeploy. Isthmus defines the block header's withdrawalsRoot as
-/// this account's storage root; mirrors bcos::evm::opstack::OP_L2_TO_L1_MESSAGE_PASSER, spelled
-/// out here because bcos-engine does not link bcos-evm.
+/// this account's storage root. Second spelling of the same consensus-critical address as
+/// bcos::evm::opstack::OP_L2_TO_L1_MESSAGE_PASSER (OpPredeploys.h), duplicated to keep
+/// bcos-engine off the bcos-evm include graph — that header would be includable (it is
+/// header-only over evmc), the separation is a deliberate choice, not a build constraint.
+/// The two must not drift; #5468 wires the validation side that compares roots derived
+/// through both, which is where a cross-assertion belongs.
 inline const bcos::Address c_l2ToL1MessagePasser{
     std::string_view{"4200000000000000000000000000000000000016"}, bcos::Address::FromHex};
 
@@ -765,7 +769,19 @@ private:
         // built-in single-node CL (SingleNodeConsensus::produceBlock) and the V2/V3 cases in
         // tools/engine_integration_test.sh — so rejecting on absence would stop block
         // production on this node's own driver. Making it mandatory belongs with the
-        // OP-only attributes flavour, not with this shared struct.
+        // OP-only attributes flavour, not with this shared struct. An out-of-range value IS
+        // rejected, one layer up in detail::validatePayloadAttributes — the executor narrows
+        // this budget to int64.
+        //
+        // Consequence to carry forward: once the CL dictates the gas limit, the value no
+        // longer lives on the chain's SystemConfig. The built header records it
+        // (BlockHeader::gasLimit), but ledger::getLedgerConfig — where every existing caller
+        // reads a block's gas budget from — still answers from SystemConfig. Any future path
+        // that RE-EXECUTES a block (verification, sync, the OpScheduler rewrite in #5468)
+        // must take the budget from that block's own header rather than from
+        // getLedgerConfig, or the replay runs on a different budget than the build did and
+        // can land on a different stateRoot. No such path exists today: newPayload only
+        // caches an externally submitted payload, it never re-executes one.
         if (payloadAttributes.gasLimit.has_value())
         {
             ledgerConfig.setGasLimit({*payloadAttributes.gasLimit, nextBlockNumber});
@@ -792,12 +808,13 @@ private:
             emptyHeader->setReceiptsRoot(h256{});
             emptyHeader->setTxsRoot(h256{});
             emptyHeader->setGasUsed(0);
+            // Before calculateHash: the root is a header field the block hash commits to.
+            co_await fillWithdrawalsRoot(executionPayload, *emptyHeader, view);
             emptyHeader->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
             executionPayload.stateRoot = emptyHeader->stateRoot();
             executionPayload.receiptsRoot = h256{};
             executionPayload.gasUsed = 0;
             executionPayload.blockHash = emptyHeader->hash();
-            co_await fillWithdrawalsRoot(executionPayload, view);
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
                 .header = std::move(emptyHeader),
                 .receipts = {}};
@@ -911,6 +928,8 @@ private:
         blockHeader->setReceiptsRoot(receiptRoot);
         blockHeader->setTxsRoot(txRoot);
         blockHeader->setGasUsed(totalGasUsed);
+        // Before calculateHash: the root is a header field the block hash commits to.
+        co_await fillWithdrawalsRoot(executionPayload, *blockHeader, view);
         blockHeader->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
 
         // Step 2i: Fill the execution payload with real values
@@ -920,7 +939,6 @@ private:
         executionPayload.blockHash = blockHeader->hash();
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
         executionPayload.logsBloom = logsBloom;
-        co_await fillWithdrawalsRoot(executionPayload, view);
 
         co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
             .header = std::move(blockHeader),
@@ -933,15 +951,34 @@ private:
     /// transactions so a withdrawal initiated in THIS block is already in the root; @p view
     /// is the executed fork view, so committed slots and this block's writes are both seen.
     ///
+    /// Writes the value into BOTH carriers, and both writes are load-bearing:
+    ///  - @p executionPayload is what getPayload serves to the CL;
+    ///  - @p header is what commits to the value. BlockHeaderImpl::setWithdrawalsRoot fills
+    ///    the tars field the NON_ETH calculateHash() digests, so this MUST run before
+    ///    calculateHash() or the root would be a field the blockHash does not commit to —
+    ///    and it is also the only carrier newPayload persists (handleNewPayload writes
+    ///    PayloadEntry::header, not the ExecutionPayload), so the eth_getBlockBy* answer
+    ///    comes from here too.
+    ///
     /// No-op for a payload whose shape has no such field (V1/V2 builds leave it nullopt),
     /// which is what keeps this one call usable on both return paths of buildPayload.
-    task::Task<void> fillWithdrawalsRoot(ExecutionPayload& executionPayload, ViewType& view) const
+    ///
+    /// Only the BUILD side is covered. handleNewPayload still accepts an externally
+    /// submitted withdrawalsRoot on presence alone — validateExecutionPayload cannot
+    /// re-derive it, because an external payload is never executed here — so a value this
+    /// node did not build carries no guarantee, and no L1 withdrawal proof may be taken
+    /// against one. Re-deriving it belongs with the block re-execution path (#5468).
+    task::Task<void> fillWithdrawalsRoot(ExecutionPayload& executionPayload,
+        bcos::protocol::BlockHeader& header, ViewType& view) const
     {
-        if (executionPayload.withdrawalsRoot.has_value())
+        if (!executionPayload.withdrawalsRoot.has_value())
         {
-            executionPayload.withdrawalsRoot =
-                co_await ledger::mpt::accountStorageRootFromFlat(view, c_l2ToL1MessagePasser);
+            co_return;
         }
+        auto const root =
+            co_await ledger::mpt::accountStorageRootFromFlat(view, c_l2ToL1MessagePasser);
+        executionPayload.withdrawalsRoot = root;
+        header.setWithdrawalsRoot(root);
     }
 
     /// Compute state root by iterating over storage and XOR-ing entry hashes.

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -762,6 +762,28 @@ private:
         co_await ledger::getLedgerConfig(view, ledgerConfig, nextBlockNumber - 1, *m_blockFactory);
         auto blockVersion = ledgerConfig.compatibilityVersion();
 
+        // OP Stack: attributes.gasLimit is the block gas limit the L1 SystemConfig dictates
+        // through the CL. op-geth writes it verbatim into header.GasLimit
+        // (miner/worker.go:362-363). Overriding ledgerConfig here — rather than only the
+        // header field — is what makes it the EXECUTION budget as well: the block gas limit
+        // reaches evmone through std::get<0>(ledgerConfig.gasLimit()) at
+        // EthereumExecutor.cpp:23 (BlockInfo::gas_limit) and HostContext::blockGasLimit(),
+        // both fed by the ledgerConfig passed to executeBlock below. The header and payload
+        // fields read the same tuple, so this single assignment carries all three.
+        //
+        // Absent = keep the chain's own SystemConfig value. op-geth's OP path rejects a nil
+        // gasLimit with -38003 (eth/catalyst/api_optimism.go:41-43), but that check guards
+        // attributes that are OP attributes by construction. Here the same PayloadAttributes
+        // struct also serves the vanilla V1/V2/V3 callers that never send the field — the
+        // built-in single-node CL (SingleNodeConsensus::produceBlock) and the V2/V3 cases in
+        // tools/engine_integration_test.sh — so rejecting on absence would stop block
+        // production on this node's own driver. Making it mandatory belongs with the
+        // OP-only attributes flavour, not with this shared struct.
+        if (payloadAttributes.gasLimit.has_value())
+        {
+            ledgerConfig.setGasLimit({*payloadAttributes.gasLimit, nextBlockNumber});
+        }
+
         // Fill gasLimit from ledger config (FISCO-BCOS does not use EIP-1559 baseFeePerGas,
         // and logsBloom is not part of BlockHeader hash computation in FISCO-BCOS).
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -1128,6 +1128,44 @@ BOOST_AUTO_TEST_CASE(karst_v3_build_v5_get_v4_commit_round_trip)
         static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
 }
 
+// OP Stack: attributes.gasLimit is the L1 SystemConfig gas limit relayed by the CL, and
+// op-geth writes it verbatim into the built header (miner/worker.go:362-363). Two builds
+// differing ONLY in the attribute must come out with the gas limit each asked for; an
+// attribute-less build keeps falling back to this chain's own SystemConfig value.
+BOOST_AUTO_TEST_CASE(attributes_gas_limit_is_honored)
+{
+    constexpr std::uint64_t c_firstGasLimit = 30'000'000;
+    constexpr std::uint64_t c_secondGasLimit = 50'000'000;
+
+    auto buildWith = [](std::optional<std::uint64_t> gasLimit) {
+        MemPoolImpl memPool;
+        RealGlobalStateStorageFixture globalStateStorageFixture;
+        auto forkchoiceState = makeForkchoiceState();
+        setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+            c_initialBlockNumber, c_initialBlockNumber);
+        auto payloadAttributes = makeKarstPayloadAttributes();
+        payloadAttributes.gasLimit = gasLimit;
+        auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+        auto result =
+            task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+        BOOST_REQUIRE(result.payloadId.has_value());
+        auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 5));
+        BOOST_REQUIRE(payload);
+        return payload->executionPayload.gasLimit;
+    };
+
+    BOOST_CHECK_EQUAL(buildWith(c_firstGasLimit), u256(c_firstGasLimit));
+    BOOST_CHECK_EQUAL(buildWith(c_secondGasLimit), u256(c_secondGasLimit));
+    // Absent attribute: the value getLedgerConfig read from this chain's SystemConfig —
+    // 0 on the bare fixture, which has no tx_gas_limit row. What matters is that it is
+    // neither of the two attribute values, i.e. the attribute is the only thing that
+    // moved the built gas limit above.
+    auto fallback = buildWith(std::nullopt);
+    BOOST_CHECK_NE(fallback, u256(c_firstGasLimit));
+    BOOST_CHECK_NE(fallback, u256(c_secondGasLimit));
+}
+
 BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)
 {
     MemPoolImpl memPool;

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -117,6 +117,15 @@ using RealGlobalStateMutableStorage = bcos::storage2::memory_storage::MemoryStor
     bcos::executor_v1::StateKey, bcos::executor_v1::StateValue,
     bcos::storage2::memory_storage::Attribute(bcos::storage2::memory_storage::ORDERED |
                                               bcos::storage2::memory_storage::LOGICAL_DELETION)>;
+// CONCURRENT is what makes the two-source MemoryStorage::merge (state delta + prewrite batch)
+// resolve for mergeBackStorage; production reaches the same merge through RocksDB. Note the
+// shape difference it buys: a CONCURRENT MemoryStorage shards into hardware_concurrency()*2+1
+// buckets and its Iterator seeks only bucket 0, then walks the remaining buckets from their
+// start (MemoryStorage.h Iterator::seek / next), so a prefix range over THIS layer is not the
+// ordered cursor a RocksDB backend gives. Tests that need an ordered prefix scan of account
+// rows therefore seed through a pushed view layer (ORDERED, single bucket) rather than by
+// writing straight into this backend — see
+// withdrawals_root_is_the_message_passer_storage_root.
 using RealGlobalStateBackendStorage =
     bcos::storage2::memory_storage::MemoryStorage<bcos::executor_v1::StateKey,
         bcos::executor_v1::StateValue,
@@ -741,14 +750,14 @@ BOOST_AUTO_TEST_CASE(payload_carries_parent_beacon_block_root_and_withdrawals_ro
     BOOST_REQUIRE(result.payloadId.has_value());
 
     // buildPayload stored the attributes' beacon root in the payload cache; getPayload
-    // must return it. withdrawalsRoot carries the zero placeholder on V3+ builds (B4:
-    // required for the getPayloadV5 -> newPayloadV4 round trip) until real-value header
-    // wiring lands.
+    // must return it. withdrawalsRoot is the L2ToL1MessagePasser storage root — this
+    // fixture never writes a slot for that predeploy, so it is the EMPTY TRIE root, not a
+    // zero h256 (a zero root would mean "no trie", which is not an Ethereum state).
     auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
     BOOST_REQUIRE(payload->parentBeaconBlockRoot.has_value());
     BOOST_CHECK_EQUAL(*payload->parentBeaconBlockRoot, *payloadAttributes.parentBeaconBlockRoot);
     BOOST_REQUIRE(payload->executionPayload.withdrawalsRoot.has_value());
-    BOOST_CHECK_EQUAL(*payload->executionPayload.withdrawalsRoot, h256{});
+    BOOST_CHECK_EQUAL(*payload->executionPayload.withdrawalsRoot, ledger::mpt::emptyRootHash());
 
     // newPayload carries both fields back in; the committed cache entry keeps them.
     // This exercises the structure layer only: withdrawalsRoot is set directly on the
@@ -1164,6 +1173,74 @@ BOOST_AUTO_TEST_CASE(attributes_gas_limit_is_honored)
     auto fallback = buildWith(std::nullopt);
     BOOST_CHECK_NE(fallback, u256(c_firstGasLimit));
     BOOST_CHECK_NE(fallback, u256(c_secondGasLimit));
+}
+
+// Isthmus: the header's withdrawalsRoot IS the L2ToL1MessagePasser storage root, which is
+// what L1 withdrawal proofs are checked against. Seed three slots for that predeploy and the
+// served root must be the trie over exactly those slots — pinned against the offline python
+// reference in tools/opstack-genesis/gen_storage_root_fixture.py ("three_slots"), the same
+// vector AccountStorageRootSuite uses one layer down.
+BOOST_AUTO_TEST_CASE(withdrawals_root_is_the_message_passer_storage_root)
+{
+    auto const word = [](std::uint64_t value) {
+        h256 out{};
+        for (size_t i = 0; i < sizeof(value); ++i)
+        {
+            out.data()[h256::SIZE - 1 - i] = static_cast<bcos::byte>(value >> (8 * i));
+        }
+        return out;
+    };
+    h256 allOnes{};
+    for (size_t i = 0; i < h256::SIZE; ++i)
+    {
+        allOnes.data()[i] = static_cast<bcos::byte>(0xFF);
+    }
+    auto const threeSlotsRoot =
+        h256(std::string_view{"7ce94a4a60783202e726bea0fb63adadfb79ee7903d3b30af81c4b5530b9bff5"},
+            h256::FromHex);
+
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+
+    // Seed the predeploy's slots through a pushed view layer, which is where a previously
+    // executed block's writes live before they are merged back. That layer is ORDERED and
+    // single-bucket, so the prefix range over the account table behaves the way it does
+    // against a production RocksDB backend — see the RealGlobalStateBackendStorage note.
+    auto const table = ledger::mpt::accountTableName(c_l2ToL1MessagePasser);
+    auto seedView = globalStateStorageFixture.storage.fork();
+    seedView.newMutable();
+    auto const writeSlot = [&](const h256& slot, const h256& value) {
+        storage::Entry entry;
+        entry.set(std::string(
+            reinterpret_cast<const char*>(value.data()), static_cast<size_t>(h256::SIZE)));
+        task::syncWait(storage2::writeOne(mutableStorage(seedView),
+            bcos::executor_v1::StateKey{
+                table, std::string_view{reinterpret_cast<const char*>(slot.data()),
+                           static_cast<size_t>(h256::SIZE)}},
+            std::move(entry)));
+    };
+    writeSlot(word(0), word(1));
+    writeSlot(word(1), word(0xDEADBEEF));
+    writeSlot(allOnes, word(0xFF));
+    // A zero-valued slot is not part of the trie, so it must not move the root.
+    writeSlot(word(2), word(0));
+    globalStateStorageFixture.storage.pushView(std::move(seedView));
+
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 5));
+    BOOST_REQUIRE(payload);
+    BOOST_REQUIRE(payload->executionPayload.withdrawalsRoot.has_value());
+    BOOST_CHECK_EQUAL(*payload->executionPayload.withdrawalsRoot, threeSlotsRoot);
+    // Not the empty-trie root: this account really has slots, so the two must differ.
+    BOOST_CHECK_NE(*payload->executionPayload.withdrawalsRoot, ledger::mpt::emptyRootHash());
 }
 
 BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -24,6 +24,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
+#include <cstdint>
+#include <limits>
 
 using namespace bcos;
 using namespace bcos::engine;
@@ -1116,7 +1118,7 @@ BOOST_AUTO_TEST_CASE(karst_v3_build_v5_get_v4_commit_round_trip)
     auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 5));
     BOOST_REQUIRE(payload);
     // V5 response shape: executionRequests present-but-empty, blobs bundle three empty
-    // arrays, shouldOverrideBuilder=false, Isthmus withdrawalsRoot placeholder present.
+    // arrays, shouldOverrideBuilder=false, Isthmus withdrawalsRoot present.
     BOOST_REQUIRE(payload->executionRequests.has_value());
     BOOST_CHECK(payload->executionRequests->empty());
     BOOST_REQUIRE(payload->blobsBundle.has_value());
@@ -1241,6 +1243,55 @@ BOOST_AUTO_TEST_CASE(withdrawals_root_is_the_message_passer_storage_root)
     BOOST_CHECK_EQUAL(*payload->executionPayload.withdrawalsRoot, threeSlotsRoot);
     // Not the empty-trie root: this account really has slots, so the two must differ.
     BOOST_CHECK_NE(*payload->executionPayload.withdrawalsRoot, ledger::mpt::emptyRootHash());
+
+    // The root must also be on the built HEADER, which is the carrier that commits to it:
+    // BlockHeaderImpl::setWithdrawalsRoot fills the tars field the NON_ETH calculateHash()
+    // digests, and it is the only carrier newPayload persists to the ledger. Committing the
+    // payload and re-reading the block proves both — the served blockHash was computed with
+    // the root in place, and eth_getBlockBy* (which reads the persisted header) can answer
+    // the same value the CL was given.
+    globalStateStorageFixture.setBlockNumber(
+        payload->executionPayload.blockHash, c_initialBlockNumber + 1);
+    NewPayloadRequest request;
+    request.executionPayload = payload->executionPayload;
+    request.parentBeaconBlockRoot = payload->parentBeaconBlockRoot;
+    request.executionRequests = std::vector<bytes>{};
+    auto status = task::syncWait(engineService.newPayload(request, 4));
+    BOOST_CHECK_EQUAL(
+        static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
+}
+
+// The gas limit reaches the executor as an int64 (TransactionExecutorImpl.h:53 narrows it
+// with a bare static_cast), so a Uint64Quantity above INT64_MAX would arrive as a NEGATIVE
+// gas budget. The attribute is the only wire-facing source of that tuple, so it carries the
+// bound; the FCU is answered INVALID rather than building a block on a negative budget.
+BOOST_AUTO_TEST_CASE(attributes_gas_limit_above_int64_is_rejected)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto payloadAttributes = makeKarstPayloadAttributes();
+    payloadAttributes.gasLimit =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1;
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Invalid));
+    BOOST_CHECK(!result.payloadId.has_value());
+    BOOST_REQUIRE(result.payloadStatus.validationError.has_value());
+    BOOST_CHECK(result.payloadStatus.validationError->find("gasLimit") != std::string::npos);
+
+    // The largest value that still fits builds normally — the bound is the executor's width,
+    // not a smaller invented one.
+    payloadAttributes.gasLimit =
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+    auto accepted =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(accepted.payloadId.has_value());
 }
 
 BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)

--- a/opstack-executor/OpBlockExecute.h
+++ b/opstack-executor/OpBlockExecute.h
@@ -48,9 +48,57 @@ inline constexpr std::array<uint8_t, 4> JovianL1AttributesSelector = {0x3d, 0xb6
 
 namespace bcos::evm::engine
 {
+/// The block-level system calls that run once per block, before the first transaction:
+/// EIP-4788 (Ecotone/Cancun) stores the parent beacon block root in the beacon-roots ring
+/// buffer at 0x000F3df6…, EIP-2935 (Isthmus/Prague) stores the parent block hash in the
+/// history ring buffer at 0x0000F908…2935. Both are ordinary EVM calls from the system sender
+/// 0xff…fe whose state diff belongs to the block, and the registry deciding which of them the
+/// active revision runs lives in bcos-evm (system_contracts.cpp STORAGE_SYSTEM_CONTRACTS) —
+/// nothing about them is re-implemented here.
+///
+/// This is deliberately pipeline-agnostic: it takes a storage view, a BlockInfo and a
+/// BlockHashes and applies the diff, with no dependency on how the block is scheduled. The
+/// block pipeline is being rewritten (OpScheduler), so the call site that runs it per produced
+/// block is NOT wired here — wiring is deferred until that lands. preBlockOpSteps below is its
+/// one caller today.
+///
+/// A no-op when the revision has no system contract yet, or when the target account has no
+/// code — EIP-4788 requires the call to fail silently in that case, and an empty state (a
+/// chain whose genesis never allocated the predeploys) therefore runs this unchanged.
+///
+/// @throws OpStorageError when the write-back fails or the bridge is poisoned (a local storage
+/// fault, never a consensus verdict).
+template <class Storage>
+void applyBlockStartSystemCalls(bcos::evm::evmstate::Storage2State<Storage>& stateView,
+    const evmone::state::BlockInfo& blk, const evmone::state::BlockHashes& hashes,
+    evmc_revision rev, evmc::VM& vm)
+{
+    // The diff is sanitized first — applyDiff's precondition. applyDiff poisons AND rethrows
+    // raw; a write-back failure is a local storage fault, so it leaves as OpStorageError,
+    // never a bare runtime_error.
+    auto sysDiff = evmone::state::system_call_block_start(stateView, blk, hashes, rev, vm);
+    try
+    {
+        stateView.applyDiff(bcos::evm::sanitizeStateDiff(stateView, std::move(sysDiff)));
+    }
+    catch (const std::exception& e)
+    {
+        throw OpStorageError(std::string("pre-block system-call write-back failed: ") + e.what());
+    }
+    catch (...)
+    {
+        throw OpStorageError("pre-block system-call write-back failed: unknown exception");
+    }
+    // Read-path poison from the system call with applyDiff returning normally — same check as
+    // the deposit/tx write-back paths in OpstackExecutor; without it a storage fault here would
+    // silently execute as zero-value reads and surface later as a stateRoot mismatch.
+    if (stateView.poisoned())
+        throw OpStorageError("pre-block system-call poisoned: " + stateView.firstError());
+}
+
 /// Block-pre steps shared by the OpScheduler execution path (and previously the retired
-/// runOpBlockInjection): recent-block-hashes construction → system_call_block_start +
-/// write-back → deposit-first content check + Jovian shape → DA footprint gas scalar. Outputs
+/// runOpBlockInjection): recent-block-hashes construction → applyBlockStartSystemCalls →
+/// deposit-first content check + Jovian shape → DA footprint gas scalar. Outputs
 /// hashes (emplaced in place — RecentBlockHashes holds a storage reference, not assignable, hence
 /// the std::optional carrier), hashErr, and daFootprintGasScalar via reference params. Throws
 /// OpConsensusError on shape/validation faults.
@@ -69,28 +117,8 @@ void preBlockOpSteps(Storage& view, bcos::protocol::BlockHeader const& header,
         view, blk.number, detail::toEvmcBytes32(header.parentInfo().blockHash), &hashErr);
     bcos::evm::evmstate::Storage2State<Storage> stateView(view, executor.sharedError());
 
-    // (1) Pre-block system call; write back through the bridge (the diff is sanitized first —
-    // applyDiff's precondition). applyDiff poisons AND rethrows raw; a write-back failure is a
-    // local storage fault, so it leaves as OpStorageError, never a bare runtime_error.
-    auto sysDiff =
-        evmone::state::system_call_block_start(stateView, blk, *hashes, cfg.rev, executor.vm());
-    try
-    {
-        stateView.applyDiff(bcos::evm::sanitizeStateDiff(stateView, std::move(sysDiff)));
-    }
-    catch (const std::exception& e)
-    {
-        throw OpStorageError(std::string("pre-block system-call write-back failed: ") + e.what());
-    }
-    catch (...)
-    {
-        throw OpStorageError("pre-block system-call write-back failed: unknown exception");
-    }
-    // Read-path poison from the system call with applyDiff returning normally — same check as
-    // the deposit/tx write-back paths in OpstackExecutor; without it a storage fault here would
-    // silently execute as zero-value reads and surface later as a stateRoot mismatch.
-    if (stateView.poisoned())
-        throw OpStorageError("pre-block system-call poisoned: " + stateView.firstError());
+    // (1) Pre-block system calls (EIP-4788 / EIP-2935); write back through the bridge.
+    applyBlockStartSystemCalls(stateView, blk, *hashes, cfg.rev, executor.vm());
 
     // (2) deposit-first content check + Jovian shape (type-byte classification, no raw-tx parse).
     constexpr uint8_t kDepositTypeByte = 0x7e;

--- a/opstack-executor/tests/BlockStartSystemCallsTest.cpp
+++ b/opstack-executor/tests/BlockStartSystemCallsTest.cpp
@@ -1,0 +1,261 @@
+// FISCO BCOS
+// SPDX-License-Identifier: Apache-2.0
+
+// BlockStartSystemCallsTest — runtime coverage for applyBlockStartSystemCalls
+// (OpBlockExecute.h): the once-per-block EIP-4788 and EIP-2935 system calls actually run, their
+// state diff lands in the block's storage, and the two ring buffers end up holding the values
+// the EIPs specify.
+//
+// The other opstack tests run these calls against an EMPTY storage, where they are a no-op (no
+// code at the system-contract addresses), so nothing so far exercised the ring buffers. Here
+// the two predeploys are seeded with their CANONICAL deployed runtime bytecode, taken verbatim
+// from the EIP texts, and the assertions read the resulting slots back:
+//   EIP-4788 at 0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02
+//     slot[timestamp % 8191]        = timestamp
+//     slot[timestamp % 8191 + 8191] = parent_beacon_block_root
+//   EIP-2935 at 0x0000F90827F1C53A10CB7A02335B175320002935
+//     slot[(number - 1) % 8191]     = parent block hash
+// A wrong bytecode literal cannot produce a false pass: the contract would revert or write
+// nothing, and the expected slot would read back as zero.
+//
+// WIRING NOTE: applyBlockStartSystemCalls is deliberately pipeline-agnostic and is not yet run
+// per produced block. The block pipeline is being rewritten (OpScheduler), so the per-block
+// call site is deferred until that lands; this file pins the unit so the wiring only has to
+// choose where to call it.
+
+#include <opstack-executor/OpBlockExecute.h>
+#include <opstack-executor/OpstackExecutor.h>
+#include <opstack-executor/RecentBlockHashes.h>
+#include <opstack-executor/Storage2State.h>
+#include <opstack-executor/Storage2StateHelpers.h>
+
+#include <bcos-framework/storage/Entry.h>
+#include <bcos-framework/storage2/MemoryStorage.h>
+#include <bcos-framework/storage2/Storage.h>
+#include <bcos-framework/transaction-executor/StateKey.h>
+#include <bcos-task/Wait.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <evmc/evmc.hpp>
+
+#include <bcos-evm/eth/state/state_diff.hpp>
+#include <bcos-evm/eth/state/system_contracts.hpp>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+using bcos::executor_v1::StateKey;
+using bcos::executor_v1::StateKeyView;
+using bcos::executor_v1::StateValue;
+namespace memory_storage = bcos::storage2::memory_storage;
+namespace engine = bcos::evm::engine;
+namespace op = bcos::evm::opstack;
+
+namespace
+{
+// `bss*` name prefixes avoid an anonymous-namespace ODR clash with the other opstack test files.
+using BssStorage = memory_storage::MemoryStorage<StateKey, StateValue,
+    memory_storage::Attribute(memory_storage::ORDERED | memory_storage::LOGICAL_DELETION)>;
+
+/// HISTORY_BUFFER_LENGTH (EIP-4788) == HISTORY_SERVE_WINDOW (EIP-2935).
+constexpr uint64_t c_ringLength = 8191;
+
+/// Deployed runtime bytecode of the beacon roots contract, verbatim from EIP-4788.
+constexpr std::string_view c_beaconRootsCode =
+    "3373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f358015604957"
+    "62001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff420642815"
+    "55f359062001fff015500";
+/// Deployed runtime bytecode of the history storage contract, verbatim from EIP-2935 (the
+/// deployment prefix 0x60538060095f395ff3 of the EIP's init code is stripped: 0x53 == 83 bytes
+/// of runtime code follow it).
+constexpr std::string_view c_historyStorageCode =
+    "3373fffffffffffffffffffffffffffffffffffffffe14604657602036036042575f356001430381116042"
+    "57611fff81430311604257611fff9006545f5260205ff35b5f5ffd5b5f35611fff60014303065500";
+
+evmc::bytes bssCode(std::string_view hex)
+{
+    auto const bytes = bcos::fromHex(hex);
+    return {bytes.begin(), bytes.end()};
+}
+
+evmc::bytes32 bssWord(uint64_t value)
+{
+    evmc::bytes32 out{};
+    for (size_t i = 0; i < sizeof(value); ++i)
+    {
+        out.bytes[sizeof(out.bytes) - 1 - i] = static_cast<uint8_t>(value >> (8 * i));
+    }
+    return out;
+}
+
+evmc::bytes32 bssMarkedHash(uint8_t marker)
+{
+    evmc::bytes32 out{};
+    for (size_t i = 0; i < sizeof(out.bytes); ++i)
+    {
+        out.bytes[i] = static_cast<uint8_t>(marker + i);
+    }
+    return out;
+}
+
+/// Seed one account with code (nonce 0, balance 0), through the same bridge the production
+/// write-back uses. seeding=true exempts the EIP-161 empty-account guard.
+void bssSeedCode(BssStorage& storage, const evmc::address& addr, evmc::bytes code)
+{
+    evmone::state::StateDiff diff;
+    evmone::state::StateDiff::Entry entry;
+    entry.addr = addr;
+    entry.nonce = 0;
+    entry.balance = 0;
+    entry.code = std::move(code);
+    diff.modified_accounts.push_back(std::move(entry));
+
+    bcos::evm::evmstate::Storage2State<BssStorage> bridge(storage);
+    bridge.applyDiff(diff, /*seeding=*/true);
+    BOOST_REQUIRE_MESSAGE(!bridge.poisoned(), "seed poisoned: " + std::string(bridge.firstError()));
+}
+
+/// Read one storage slot back out of the flat state (zero when the row is absent).
+evmc::bytes32 bssReadSlot(BssStorage& storage, const evmc::address& addr, const evmc::bytes32& slot)
+{
+    auto entry = bcos::task::syncWait(bcos::storage2::readOne(storage,
+        StateKeyView{bcos::evm::evmstate::accountTableName(addr),
+            std::string_view{reinterpret_cast<const char*>(slot.bytes), sizeof(slot.bytes)}}));
+    if (!entry.has_value())
+    {
+        return evmc::bytes32{};
+    }
+    auto const value = entry->get();
+    BOOST_REQUIRE_EQUAL(value.size(), sizeof(evmc::bytes32::bytes));
+    evmc::bytes32 out{};
+    std::memcpy(out.bytes, value.data(), sizeof(out.bytes));
+    return out;
+}
+
+std::string bssHex(const evmc::bytes32& value)
+{
+    return bcos::toHex(bcos::bytesConstRef(value.bytes, sizeof(value.bytes)));
+}
+
+struct BssFixture
+{
+    BssStorage storage;
+    bcos::executor_v1::opstack::OpstackExecutor executor{nullptr, nullptr};
+
+    static constexpr int64_t c_blockNumber = 1000;
+    static constexpr uint64_t c_timestampSeconds = 1'700'000'123;
+
+    evmc::bytes32 parentBeaconRoot = bssMarkedHash(0x10);
+    evmc::bytes32 parentHash = bssMarkedHash(0x80);
+
+    void run(evmc_revision rev)
+    {
+        evmone::state::BlockInfo blk{};
+        blk.number = c_blockNumber;
+        blk.timestamp = static_cast<int64_t>(c_timestampSeconds);
+        blk.gas_limit = 30'000'000;
+        blk.parent_beacon_block_root = parentBeaconRoot;
+
+        std::optional<std::string> hashErr;
+        engine::detail::RecentBlockHashes<BssStorage> hashes(
+            storage, c_blockNumber, parentHash, &hashErr);
+
+        bcos::evm::evmstate::Storage2State<BssStorage> stateView(storage, executor.sharedError());
+        engine::applyBlockStartSystemCalls(stateView, blk, hashes, rev, executor.vm());
+        BOOST_REQUIRE(!hashErr.has_value());
+    }
+
+    void seedBeaconRoots()
+    {
+        bssSeedCode(storage, evmone::state::BEACON_ROOTS_ADDRESS, bssCode(c_beaconRootsCode));
+    }
+    void seedHistoryStorage()
+    {
+        bssSeedCode(storage, evmone::state::HISTORY_STORAGE_ADDRESS, bssCode(c_historyStorageCode));
+    }
+};
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(BlockStartSystemCallsTest)
+
+// EIP-4788: the beacon-roots contract keeps two ring buffers of HISTORY_BUFFER_LENGTH entries,
+// the timestamp at `timestamp % 8191` and the root at `timestamp % 8191 + 8191`.
+BOOST_AUTO_TEST_CASE(BeaconRootsRingBufferSlots)
+{
+    BssFixture f;
+    f.seedBeaconRoots();
+    f.run(EVMC_CANCUN);
+
+    auto const index = BssFixture::c_timestampSeconds % c_ringLength;
+    auto const timestampSlot =
+        bssReadSlot(f.storage, evmone::state::BEACON_ROOTS_ADDRESS, bssWord(index));
+    auto const rootSlot =
+        bssReadSlot(f.storage, evmone::state::BEACON_ROOTS_ADDRESS, bssWord(index + c_ringLength));
+    BOOST_CHECK_EQUAL(bssHex(timestampSlot), bssHex(bssWord(BssFixture::c_timestampSeconds)));
+    BOOST_CHECK_EQUAL(bssHex(rootSlot), bssHex(f.parentBeaconRoot));
+}
+
+// EIP-2935: the history contract stores the PARENT block hash at `(number - 1) % 8191`.
+// Isthmus maps to EVMC_PRAGUE, the revision the contract is registered from.
+BOOST_AUTO_TEST_CASE(HistoryStorageRingBufferSlot)
+{
+    BssFixture f;
+    f.seedHistoryStorage();
+    f.run(EVMC_PRAGUE);
+
+    auto const index = static_cast<uint64_t>(BssFixture::c_blockNumber - 1) % c_ringLength;
+    auto const slot =
+        bssReadSlot(f.storage, evmone::state::HISTORY_STORAGE_ADDRESS, bssWord(index));
+    BOOST_CHECK_EQUAL(bssHex(slot), bssHex(f.parentHash));
+}
+
+// Both contracts seeded, one Prague call: each writes its own ring buffer, neither disturbs the
+// other's.
+BOOST_AUTO_TEST_CASE(PragueRunsBothContracts)
+{
+    BssFixture f;
+    f.seedBeaconRoots();
+    f.seedHistoryStorage();
+    f.run(EVMC_PRAGUE);
+
+    auto const beaconIndex = BssFixture::c_timestampSeconds % c_ringLength;
+    BOOST_CHECK_EQUAL(bssHex(bssReadSlot(f.storage, evmone::state::BEACON_ROOTS_ADDRESS,
+                          bssWord(beaconIndex + c_ringLength))),
+        bssHex(f.parentBeaconRoot));
+    auto const historyIndex = static_cast<uint64_t>(BssFixture::c_blockNumber - 1) % c_ringLength;
+    BOOST_CHECK_EQUAL(bssHex(bssReadSlot(f.storage, evmone::state::HISTORY_STORAGE_ADDRESS,
+                          bssWord(historyIndex))),
+        bssHex(f.parentHash));
+}
+
+// Revision gating: EIP-2935 is registered from Prague, so a Cancun block must leave the history
+// ring buffer untouched even with the contract deployed.
+BOOST_AUTO_TEST_CASE(CancunDoesNotRunHistoryStorage)
+{
+    BssFixture f;
+    f.seedBeaconRoots();
+    f.seedHistoryStorage();
+    f.run(EVMC_CANCUN);
+
+    auto const historyIndex = static_cast<uint64_t>(BssFixture::c_blockNumber - 1) % c_ringLength;
+    BOOST_CHECK_EQUAL(bssHex(bssReadSlot(f.storage, evmone::state::HISTORY_STORAGE_ADDRESS,
+                          bssWord(historyIndex))),
+        bssHex(evmc::bytes32{}));
+}
+
+// EIP-4788: "if no code exists at BEACON_ROOTS_ADDRESS, the call must fail silently". A chain
+// whose genesis never allocated the predeploys therefore runs this step as a no-op rather than
+// faulting — which is exactly why the pre-existing opstack tests, over an empty storage, never
+// exercised the ring buffers above.
+BOOST_AUTO_TEST_CASE(NoCodeAtPredeploysIsANoOp)
+{
+    BssFixture f;
+    BOOST_CHECK_NO_THROW(f.run(EVMC_PRAGUE));
+    auto const beaconIndex = BssFixture::c_timestampSeconds % c_ringLength;
+    BOOST_CHECK_EQUAL(bssHex(bssReadSlot(f.storage, evmone::state::BEACON_ROOTS_ADDRESS,
+                          bssWord(beaconIndex + c_ringLength))),
+        bssHex(evmc::bytes32{}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/opstack-executor/tests/CMakeLists.txt
+++ b/opstack-executor/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(opstack-executor-tests
     OpCommitmentsTest.cpp
     RecentBlockHashesTest.cpp
     PreBlockOpStepsTest.cpp
+    BlockStartSystemCallsTest.cpp
     Storage2StateHelpersTest.cpp
     Storage2StatePoisonTest.cpp
     support/SeedPreStateTest.cpp

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -368,6 +368,24 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
         return False
     _log_info(f"block timestamp = {block_seconds} (sent {sent_seconds})")
 
+    # The two faces of the same block must agree on withdrawalsRoot. engine_getPayloadV5
+    # serves it out of the built ExecutionPayload; eth_getBlockByNumber reads it off the
+    # persisted header. They only match if buildPayload wrote the computed root onto the
+    # header (and therefore into the blockHash) rather than only onto the payload.
+    if committed_block.get("withdrawalsRoot", "").lower() != payload["withdrawalsRoot"].lower():
+        _log_fail(
+            "eth_getBlockByNumber and engine_getPayloadV5 disagree on withdrawalsRoot for "
+            f"the same block: {committed_block.get('withdrawalsRoot')} vs "
+            f"{payload['withdrawalsRoot']}"
+        )
+        return False
+    # No L2->L1 message path is wired, so the L2ToL1MessagePasser has no storage: the root
+    # is the EMPTY TRIE root. A zero hash here would mean the field is not being computed.
+    if int(payload["withdrawalsRoot"], 16) == 0:
+        _log_fail("withdrawalsRoot is the zero hash, not a trie root")
+        return False
+    _log_info(f"withdrawalsRoot = {payload['withdrawalsRoot']} (agreed on both faces)")
+
     _log_pass()
     return True
 

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -65,8 +65,8 @@ EXPECTED_CAPABILITIES = {
 # The one genuinely unimplemented version: routable, answers -38005, never advertised.
 UNIMPLEMENTED_METHODS = ("engine_forkchoiceUpdatedV4",)
 
-# The gas limit sent in payloadAttributes. See test_negative_cases / the note below: this
-# node currently IGNORES it and takes the gas limit from its own SystemConfig.
+# The gas limit sent in payloadAttributes. The node honours it verbatim as the built block's
+# gas limit (and as the block's execution budget) — see test_attributes_gas_limit_is_honored.
 ATTRS_GAS_LIMIT = "0x1c9c380"
 
 # ---- Minimal RLP encoder (enough for the deposit fixture) ----
@@ -304,6 +304,13 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
         _log_fail("executionPayload missing withdrawalsRoot (Isthmus V4 shape)")
         return False
 
+    # The gas limit the CL dictated in payloadAttributes must be the built block's.
+    if int(payload["gasLimit"], 16) != int(ATTRS_GAS_LIMIT, 16):
+        _log_fail(
+            f"built gasLimit {payload['gasLimit']} != the attribute we sent {ATTRS_GAS_LIMIT}"
+        )
+        return False
+
     # Unit check, wire side: the Engine boundary speaks Unix SECONDS in both directions.
     # This catches a ONE-SIDED break only (parse or serialize, not both): removing the
     # conversion from both cancels out on the wire and leaves this equality holding. The
@@ -415,18 +422,16 @@ def run_v2_block_flow() -> None:
     _log_pass()
 
 
-def test_attributes_gas_limit_is_ignored() -> None:
-    """KNOWN GAP pin: payloadAttributes.gasLimit does not reach the built block.
+def test_attributes_gas_limit_is_honored() -> None:
+    """payloadAttributes.gasLimit becomes the built block's gas limit.
 
     On OP Stack the CL relays the L1 SystemConfig gas limit in this attribute and op-geth
-    honours it verbatim (miner/worker.go prepareWork), rejecting the FCU outright when it
-    is absent (api_optimism.go checkOptimismPayloadAttributes). This node instead always
-    takes the gas limit from its own SystemConfig, so two builds that differ ONLY in the
-    attribute come out with the same gasLimit. Wiring the attribute in changes block
-    production and is left to the header-fields work; this check turns red the day it
-    happens, so the gap cannot be forgotten.
+    writes it verbatim into the header (miner/worker.go prepareWork). Two builds that
+    differ ONLY in the attribute must therefore come out with the gasLimit each asked for.
+    An absent attribute keeps falling back to this chain's own SystemConfig value, which is
+    what the vanilla V1/V2/V3 callers (and this node's built-in single-node CL) rely on.
     """
-    _log_test("payloadAttributes.gasLimit is ignored (known gap)")
+    _log_test("payloadAttributes.gasLimit is honored")
 
     head_hash = get_head_hash()
     fc_state = {
@@ -452,15 +457,18 @@ def test_attributes_gas_limit_is_ignored() -> None:
         result = rpc_result("engine_getPayloadV5", [payload_id])
         return result["executionPayload"]["gasLimit"]
 
+    second_sent = "0x2faf080"
     first = build_with(ATTRS_GAS_LIMIT)
-    second = build_with("0x2faf080")
-    if first != second:
+    second = build_with(second_sent)
+    # Compare numerically: the node serializes the quantity minimally, which need not be
+    # the exact hex spelling that was sent.
+    if int(first, 16) != int(ATTRS_GAS_LIMIT, 16) or int(second, 16) != int(second_sent, 16):
         _log_fail(
-            "payloadAttributes.gasLimit now affects the built block "
-            f"({first} vs {second}) — the known gap is closed, update this test"
+            "payloadAttributes.gasLimit did not reach the built block "
+            f"(sent {ATTRS_GAS_LIMIT}/{second_sent}, built {first}/{second})"
         )
         return
-    _log_info(f"built gasLimit = {first} for both attribute values (from SystemConfig)")
+    _log_info(f"built gasLimit = {first} / {second} for the two attribute values")
     _log_pass()
 
 
@@ -574,8 +582,8 @@ def main() -> int:
         # 6. The pre-Karst surface is still live.
         run_v2_block_flow()
 
-        # 7. Known gap: attributes.gasLimit does not reach the built block.
-        test_attributes_gas_limit_is_ignored()
+        # 7. attributes.gasLimit reaches the built block.
+        test_attributes_gas_limit_is_honored()
 
         # 8. Error semantics.
         test_negative_cases()

--- a/tools/opstack-genesis/gen_storage_root_fixture.py
+++ b/tools/opstack-genesis/gen_storage_root_fixture.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# Copyright (c) FISCO-BCOS, Apache-2.0
+"""Reference Ethereum storage-trie roots for the C++ withdrawalsRoot tests.
+
+Independent of the C++ MPT (bcos-ledger/mpt): a minimal RLP encoder and a
+from-scratch secure-trie builder live here, keccak256 is imported from
+build-allocs.py (itself pinned by standard vectors). The C++ unit tests
+hardcode the roots this script prints — if the two implementations ever
+disagree, the C++ test fails and the discrepancy must be investigated, not
+the fixture regenerated blindly. Same contract as gen_eth_header_fixture.py.
+
+A storage trie is a SECURE trie over one account's live slots:
+  key   = keccak256(32-byte slot key)
+  value = RLP(slot value with leading zero bytes trimmed)
+A slot whose value trims to nothing (all zeros) is not in the trie at all.
+An account with no live slot has the empty-trie root
+0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421.
+
+Usage:
+  python3 gen_storage_root_fixture.py
+"""
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "build_allocs", str(Path(__file__).parent / "build-allocs.py"))
+_build_allocs = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_build_allocs)
+keccak256 = _build_allocs.keccak256
+
+
+# ---- minimal RLP ----
+
+def _encode_length(length, offset):
+    if length < 56:
+        return bytes([offset + length])
+    as_bytes = length.to_bytes((length.bit_length() + 7) // 8, "big")
+    return bytes([offset + 55 + len(as_bytes)]) + as_bytes
+
+
+def rlp_bytes(payload):
+    """RLP of a byte string."""
+    if len(payload) == 1 and payload[0] < 0x80:
+        return payload
+    return _encode_length(len(payload), 0x80) + payload
+
+
+def rlp_list(payload):
+    """RLP list header for an already-concatenated item payload."""
+    return _encode_length(len(payload), 0xC0) + payload
+
+
+# ---- minimal Merkle-Patricia trie ----
+
+def _nibbles(key):
+    out = []
+    for byte in key:
+        out.append(byte >> 4)
+        out.append(byte & 0x0F)
+    return out
+
+
+def _hex_prefix(nibbles, is_leaf):
+    flag = 2 if is_leaf else 0
+    if len(nibbles) % 2 == 1:
+        head = [(flag + 1) * 16 + nibbles[0]]
+        rest = nibbles[1:]
+    else:
+        head = [flag * 16]
+        rest = nibbles
+    out = bytearray(head)
+    for i in range(0, len(rest), 2):
+        out.append(rest[i] * 16 + rest[i + 1])
+    return bytes(out)
+
+
+def _node_ref(node_rlp):
+    """How a parent splices a child: inline when short, keccak hash otherwise."""
+    if len(node_rlp) < 32:
+        return node_rlp
+    return rlp_bytes(keccak256(node_rlp))
+
+
+def _build(pairs):
+    """pairs: list of (nibble list, value bytes), sorted by nibble path, unique."""
+    if len(pairs) == 1:
+        path, value = pairs[0]
+        return rlp_list(rlp_bytes(_hex_prefix(path, True)) + rlp_bytes(value))
+
+    shortest = min(len(path) for path, _ in pairs)
+    common = 0
+    while common < shortest and len({path[common] for path, _ in pairs}) == 1:
+        common += 1
+    if common > 0:
+        prefix = pairs[0][0][:common]
+        inner = _build([(path[common:], value) for path, value in pairs])
+        return rlp_list(rlp_bytes(_hex_prefix(prefix, False)) + _node_ref(inner))
+
+    slots = [[] for _ in range(16)]
+    branch_value = b""
+    for path, value in pairs:
+        if not path:
+            branch_value = value
+        else:
+            slots[path[0]].append((path[1:], value))
+    payload = b""
+    for group in slots:
+        payload += _node_ref(_build(group)) if group else rlp_bytes(b"")
+    payload += rlp_bytes(branch_value)
+    return rlp_list(payload)
+
+
+def storage_root(slots):
+    """slots: dict of 32-byte slot key -> 32-byte value. Returns the 32-byte root."""
+    entries = {}
+    for slot, value in slots.items():
+        trimmed = value.lstrip(b"\x00")
+        if not trimmed:
+            continue  # a zero slot is not in the trie
+        entries[keccak256(slot)] = rlp_bytes(trimmed)
+    if not entries:
+        return keccak256(rlp_bytes(b""))
+    pairs = [(_nibbles(key), value) for key, value in sorted(entries.items())]
+    return keccak256(_build(pairs))
+
+
+def word(value_int):
+    return value_int.to_bytes(32, "big")
+
+
+# ---- the fixtures the C++ tests hardcode ----
+
+FIXTURES = {
+    # AccountStorageRootTest/three_slots_match_offline_reference and the engine-side
+    # EngineServiceTest/withdrawals_root_is_the_message_passer_storage_root.
+    "three_slots": {
+        word(0): word(1),
+        word(1): word(0xDEADBEEF),
+        bytes([0xFF] * 32): word(0xFF),
+    },
+    # Adding an all-zero slot must not change the root (zero == not in the trie).
+    "three_slots_plus_zero": {
+        word(0): word(1),
+        word(1): word(0xDEADBEEF),
+        bytes([0xFF] * 32): word(0xFF),
+        word(2): word(0),
+    },
+    "single_slot": {word(0): word(1)},
+    "empty": {},
+}
+
+
+def main():
+    for name, slots in FIXTURES.items():
+        print(f"{name:24s} 0x{storage_root(slots).hex()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
+++ b/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
@@ -859,8 +859,8 @@ BOOST_AUTO_TEST_CASE(blockHashHostNoexceptBoundary)
         eth::BlockHashLookup throwingLookup = [](int64_t, int64_t) -> evmc::bytes32 {
             throw std::runtime_error("simulated storage failure");
         };
-        eth::EthereumHost<EEMutableStorage> host{EVMC_SHANGHAI, vm, state, block,
-            std::move(throwingLookup), *tx, callParams, 1};
+        eth::EthereumHost<EEMutableStorage> host{
+            EVMC_SHANGHAI, vm, state, block, std::move(throwingLookup), *tx, callParams, 1};
         auto result = vm.execute(host, EVMC_SHANGHAI, msg, code, sizeof(code));
         BOOST_CHECK_EQUAL(result.status_code, EVMC_SUCCESS);
     }
@@ -871,8 +871,8 @@ BOOST_AUTO_TEST_CASE(blockHashHostNoexceptBoundary)
         eth::BlockHashLookup zeroLookup = [](int64_t, int64_t) -> evmc::bytes32 {
             return evmc::bytes32{};
         };
-        eth::EthereumHost<EEMutableStorage> host{EVMC_SHANGHAI, vm, state, block,
-            std::move(zeroLookup), *tx, callParams, 1};
+        eth::EthereumHost<EEMutableStorage> host{
+            EVMC_SHANGHAI, vm, state, block, std::move(zeroLookup), *tx, callParams, 1};
         auto result = vm.execute(host, EVMC_SHANGHAI, msg, code, sizeof(code));
         BOOST_CHECK_EQUAL(result.status_code, EVMC_SUCCESS);
     }
@@ -1215,14 +1215,16 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
 // op_engine_rpc, so this — not the v1 escape hatch the integration script drives — is the
 // configuration external CLs talk to.
 //
-// What it pins is a known defect, deliberately: buildPayload stamps withdrawalsRoot with a
-// zero PLACEHOLDER (EngineServiceImpl.h, TODO(C4 header fields)) instead of the
-// L2ToL1MessagePasser storage root, getPayloadV5 serves that zero, and newPayloadV4 accepts
-// it because validateExecutionPayload can only check presence. Nothing about the executor
-// version changes that — buildPayload has no executor-version branch. When C4 computes the
-// real root this test MUST fail and be rewritten to assert the computed value; until then it
-// keeps the gap visible instead of letting the v2 path look covered.
-BOOST_AUTO_TEST_CASE(engineServiceKarstServesZeroWithdrawalsRoot)
+// What it pins is the withdrawalsRoot a v2 node actually serves. Isthmus defines it as the
+// L2ToL1MessagePasser storage root; this fixture writes no slot for that predeploy, so the
+// answer must be the EMPTY TRIE root — NOT a zero h256, which is what buildPayload used to
+// stamp as a placeholder and which no Ethereum client would ever produce. The value-level
+// vectors (2-3 seeded slots against an offline reference) live one layer down in
+// AccountStorageRootSuite and in EngineServiceTest; what this case adds is that the same
+// value reaches the wire through the production assembly (real EthereumExecutor +
+// SchedulerSerialImpl, executor_version = 2) and survives the FCU V3 -> getPayloadV5 ->
+// newPayloadV4 round trip.
+BOOST_AUTO_TEST_CASE(engineServiceKarstServesEmptyWithdrawalsRoot)
 {
     task::syncWait([&, this]() -> task::Task<void> {
         auto ioServicePool = std::make_shared<bcos::IOServicePool>(1, "testEngineKarst");
@@ -1270,16 +1272,19 @@ BOOST_AUTO_TEST_CASE(engineServiceKarstServesZeroWithdrawalsRoot)
 
         auto payload = co_await engineService.getPayload(*fcResult.payloadId, 5);
         BOOST_REQUIRE(payload);
-        // The zero placeholder, served verbatim to the CL by a v2 node.
+        // The real value for an L2ToL1MessagePasser with no slots: the empty trie root.
         BOOST_REQUIRE(payload->executionPayload.withdrawalsRoot.has_value());
-        BOOST_CHECK_EQUAL(*payload->executionPayload.withdrawalsRoot, bcos::h256{});
+        BOOST_CHECK_EQUAL(
+            *payload->executionPayload.withdrawalsRoot, bcos::ledger::mpt::emptyRootHash());
+        BOOST_CHECK_NE(*payload->executionPayload.withdrawalsRoot, bcos::h256{});
 
         bcos::engine::NewPayloadRequest request;
         request.executionPayload = payload->executionPayload;
         request.parentBeaconBlockRoot = payload->parentBeaconBlockRoot;
         request.executionRequests = std::vector<bcos::bytes>{};
         auto status = co_await engineService.newPayload(request, 4);
-        // Rubber-stamped: presence is all newPayloadV4 can check today.
+        // Accepted on presence alone: validateExecutionPayload still cannot re-derive a
+        // submitted payload's root, so an externally supplied withdrawalsRoot is unchecked.
         BOOST_CHECK_EQUAL(static_cast<int>(status.status),
             static_cast<int>(bcos::engine::PayloadValidationStatus::Valid));
     }());


### PR DESCRIPTION
## What

Three block-level gaps that no other PR in the OP series covers, each independently useful:

1. **`payloadAttributes.gasLimit` is honored** instead of ignored.
2. **`withdrawalsRoot` carries the real Isthmus value** instead of a placeholder.
3. **EIP-4788 / EIP-2935 block-start system calls exist as a callable, pipeline-agnostic unit** — deliberately not wired per block yet (see below).

### 1. Honor `payloadAttributes.gasLimit`

On an OP chain the CL owns the gas limit: op-geth requires the field (`eth/catalyst/api_optimism.go:41-43` answers -38003 on nil) and writes it verbatim into the header (`miner/worker.go:362-363`), while op-node always supplies it from the L1 SystemConfig. This node took its gas limit from its own on-chain config and silently ignored the attribute, so a SystemConfig gas-limit change on L1 would never reach the produced blocks.

The value now overrides the ledger config tuple rather than only the header field, because the header, the payload and **the execution budget** all read the same `std::get<0>(ledgerConfig.gasLimit())` (`ethereum-executor/EthereumExecutor.cpp` → `BlockInfo::gas_limit`, and `HostContext.h` for the per-transaction budget). Patching only the header would have produced a block whose declared limit and actual execution budget disagree.

**Deliberate deviation from op-geth:** an absent `gasLimit` is not rejected. This node's own single-node driver (`SingleNodeConsensus.cpp`) and the Engine API integration script both omit the field, so a hard requirement would stop local block production; absent means "fall back to the chain config", as before. An out-of-range value is rejected in `validatePayloadAttributes`.

### 2. Real `withdrawalsRoot`

From Isthmus, an L2 header's `withdrawalsRoot` is the storage root of the `L2ToL1MessagePasser` predeploy (`0x4200000000000000000000000000000000000016`), not a withdrawals-list root. This node served a zero root, which a validating peer or an op-reth cross-check would reject outright.

The computation lives in a new standalone helper (`bcos-ledger/bcos-ledger/mpt/AccountStorageRoot.h`) that scans that account's live slots from the flat KV and builds the secure storage trie by reusing the existing MPT machinery (`computeTrieRoot`, `slotKeyHash`, `encodeStorageValue`, `Classify.h`) — no trie code was rewritten. The layer split is deliberate: `bcos-ledger/mpt` already owns flat-KV→MPT translation, while the OP-specific knowledge of *which* account matters stays in the engine. An empty account yields the empty trie root, not zero.

**Consensus-visible consequence:** the field is now written into the header before `calculateHash()`, so **the block hash of V3+ payloads this node builds changes**. That is the point — the previous revision of this branch computed the root but attached it to the payload only, after hashing, which left the field out of the block hash, dropped on commit, and made `engine_getPayloadV5` and `eth_getBlockByHash` disagree on the same block. Pre-push review caught it; the E2E now asserts the two read paths agree.

### 3. Block-start system calls as a unit

Ecotone runs EIP-4788 (beacon root) and Isthmus runs EIP-2935 (block hash history) once per block, before the first transaction, as a system-caller state diff. The logic already existed inside the EEST execution path (`bcos-evm/eth/state/system_contracts.cpp`, driven by `preBlockOpSteps`); it is lifted verbatim into `applyBlockStartSystemCalls` (`opstack-executor/OpBlockExecute.h`) so it can be driven by a block pipeline.

**Per-block wiring is intentionally deferred to #5468**, which rewrites that pipeline (OpScheduler): wiring it here would guarantee a rework. The unit and its tests stand on their own — they deploy the canonical EIP runtime bytecode and read the ring-buffer slots back (`timestamp % 8191`, `blockNumber % 8191`), with a paired no-code case so a wrong address or a wrong slot cannot pass silently.

## Verification

- Full `ctest -j`: **1946/1948**. The two failures are `ComputeTrieRootSuite/VarKey*` aborting in `HexPrefix.cpp`, pre-existing on the base (from #5290); neither that test file nor any trie internal is in this diff.
- Two pinning tests flipped: `test_attributes_gas_limit_is_ignored` → `_is_honored` (two different attribute values produce two different block gas limits), and `engineServiceKarstServesZeroWithdrawalsRoot` → `...ServesEmptyWithdrawalsRoot`.
- Cross-implementation vector: `tools/opstack-genesis/gen_storage_root_fixture.py` is a standalone python MPT that generates the reference roots; the three-slot vector and the well-known single-slot vector match the C++ result at both the ledger and the engine layer.
- `tools/engine_integration_test.sh`: 12/12 shell + 21/21 python, now additionally asserting that `eth_getBlockByNumber` and `engine_getPayloadV5` report the same non-zero `withdrawalsRoot`.
- New suites: `AccountStorageRootSuite` (6), `BlockStartSystemCallsTest` (5), plus the gas-limit and withdrawals-root engine cases.

## Coordination

- **#5446** (real Ethereum headers in EngineService) fills `withdrawalsRoot` with the empty-trie placeholder and says the real computation is left to a follow-up — this is that follow-up. Whichever lands first, the other rebases; if #5446 goes first, this branch simply replaces the placeholder line.
- **#5468** (part 5/5) rewrites the block pipeline and is the intended consumer of unit 3.

## Left open

- The "secure trie over one account's live slots" rule now has three implementations in the tree (`bcos-evm/adapter/StateRootCompute.cpp`, `OpBlockSeal.cpp::opStorageRoot`, and this one); `opstack-executor/OpCommitments.h` will eventually compare two of them, so a cross-check test belongs with #5468.
- `accountStorageRootFromFlat` is O(live slots) per block with no cross-block reuse — zero cost today, growing with total withdrawals once the L2→L1 path is live. Incremental maintenance belongs to the MPT lane.
- `handleNewPayload` still accepts an externally supplied `withdrawalsRoot` on presence alone; validating it belongs to the re-execution path in #5468.
- Any future block re-execution must read its gas budget from `header.gasLimit` rather than the ledger config.
