### PR TITLE
feat(protocol): add seven admission-stage TransactionStatus codes

### DIFF
--- a/bcos-protocol/bcos-protocol/TransactionStatus.h
+++ b/bcos-protocol/bcos-protocol/TransactionStatus.h
@@ -68,6 +68,21 @@ enum class TransactionStatus : int32_t
     MaxInitCodeSizeExceeded = 10013,
     SenderNoEOA = 10014,
     InsufficientFunds = 10015,
+    /// Envelope type is blob(0x03) / deposit(0x7e) / reserved, or the type is not yet enabled by
+    /// the chain's EVM revision.
+    TxTypeNotSupported = 10016,
+    /// EIP-1559/7702: maxPriorityFeePerGas exceeds maxFeePerGas.
+    TipGreaterThanFeeCap = 10017,
+    /// EIP-7702: a set-code transaction must have a `to` address.
+    CreateSetCodeTx = 10018,
+    /// EIP-7702: the authorization list must not be empty.
+    EmptyAuthorizationList = 10019,
+    /// EIP-2681: the sender account nonce has reached 2^64-1.
+    NonceHasMaxValue = 10020,
+    /// The transaction's fee cap is below the chain's base fee (tx_gas_price).
+    FeeCapLessThanBaseFee = 10021,
+    /// gasLimit exceeds the per-transaction cap (tx_gas_limit, or the Osaka constant cap).
+    MaxGasLimitExceeded = 10022,
 };
 
 inline std::ostream& operator<<(std::ostream& _out, bcos::protocol::TransactionStatus const& _er)
@@ -184,6 +199,27 @@ inline std::ostream& operator<<(std::ostream& _out, bcos::protocol::TransactionS
         break;
     case TransactionStatus::InsufficientFunds:
         _out << "InsufficientFunds";
+        break;
+    case TransactionStatus::TxTypeNotSupported:
+        _out << "TxTypeNotSupported";
+        break;
+    case TransactionStatus::TipGreaterThanFeeCap:
+        _out << "TipGreaterThanFeeCap";
+        break;
+    case TransactionStatus::CreateSetCodeTx:
+        _out << "CreateSetCodeTx";
+        break;
+    case TransactionStatus::EmptyAuthorizationList:
+        _out << "EmptyAuthorizationList";
+        break;
+    case TransactionStatus::NonceHasMaxValue:
+        _out << "NonceHasMaxValue";
+        break;
+    case TransactionStatus::FeeCapLessThanBaseFee:
+        _out << "FeeCapLessThanBaseFee";
+        break;
+    case TransactionStatus::MaxGasLimitExceeded:
+        _out << "MaxGasLimitExceeded";
         break;
     case TransactionStatus::AlreadyInTxPoolAndAccept:
         _out << "AlreadyInTxPoolAndAccept";

--- a/bcos-protocol/test/unittests/TransactionStatusTest.cpp
+++ b/bcos-protocol/test/unittests/TransactionStatusTest.cpp
@@ -61,6 +61,13 @@ constexpr Expectation kExpectations[] = {
     {TransactionStatus::MaxInitCodeSizeExceeded, "MaxInitCodeSizeExceeded"},
     {TransactionStatus::SenderNoEOA, "SenderNoEOA"},
     {TransactionStatus::InsufficientFunds, "InsufficientFunds"},
+    {TransactionStatus::TxTypeNotSupported, "TxTypeNotSupported"},
+    {TransactionStatus::TipGreaterThanFeeCap, "TipGreaterThanFeeCap"},
+    {TransactionStatus::CreateSetCodeTx, "CreateSetCodeTx"},
+    {TransactionStatus::EmptyAuthorizationList, "EmptyAuthorizationList"},
+    {TransactionStatus::NonceHasMaxValue, "NonceHasMaxValue"},
+    {TransactionStatus::FeeCapLessThanBaseFee, "FeeCapLessThanBaseFee"},
+    {TransactionStatus::MaxGasLimitExceeded, "MaxGasLimitExceeded"},
 };
 }  // namespace
 


### PR DESCRIPTION
### Motivation

The transaction admission path is being consolidated into a single validation layer (`bcos-tx-validator`). Several checks that `evmone::state::validate_transaction` performs have no FISCO counterpart today, and the ones that do exist report misleading codes — a fee cap below the base fee currently surfaces as `InsufficientFunds`, which tells the user their balance is short when it is not.

This PR only adds the status codes. It is the first of a series and is deliberately behaviour-neutral: no code path produces any of the new values yet.

### What changed

Seven values appended to `bcos::protocol::TransactionStatus`, numbering continuing from `InsufficientFunds = 10015`:

| Code | Value | Meaning |
|---|---|---|
| `TxTypeNotSupported` | 10016 | blob(0x03) / deposit(0x7e) / reserved envelope type, or a typed tx whose EIP is not enabled by the chain's EVM revision |
| `TipGreaterThanFeeCap` | 10017 | EIP-1559/7702 `maxPriorityFeePerGas > maxFeePerGas` |
| `CreateSetCodeTx` | 10018 | EIP-7702 set-code transaction with an empty `to` |
| `EmptyAuthorizationList` | 10019 | EIP-7702 empty authorization list |
| `NonceHasMaxValue` | 10020 | EIP-2681 sender account nonce at 2^64-1 |
| `FeeCapLessThanBaseFee` | 10021 | fee cap below `tx_gas_price` |
| `MaxGasLimitExceeded` | 10022 | `gasLimit` above the per-transaction cap |

`operator<<` and the `TransactionStatusTest` label table are kept in sync. The `operator<<` switch has a `default` arm, so no other translation unit is affected by the enum growing.

### Test

```
./build/bcos-protocol/test/test-bcos-protocol --run_test=TransactionStatusTest
Running 2 test cases...
*** No errors detected
```

`toStringCoversAllNamedCases` now covers 45 labels; the new entries fail if a value is added to the enum without a printer arm.