### PR TITLE
refactor(framework): extract the transaction cost model into TxGasModel.h

### DIFF
--- a/bcos-framework/CMakeLists.txt
+++ b/bcos-framework/CMakeLists.txt
@@ -42,6 +42,13 @@ add_library(bcos-framework STATIC ${BCOS_FRAMEWORK_SOURCES})
 if(FULLNODE)
     target_include_directories(bcos-framework PUBLIC
         $<TARGET_PROPERTY:evmone::evmone,INTERFACE_INCLUDE_DIRECTORIES>)
+    # protocol/TxGasModel.h includes <intx/intx.hpp> to widen balances past u256. intx is a
+    # header-only INTERFACE target, so linking it PUBLIC adds include dirs and no archive to
+    # any consumer's link line -- unlike evmone above, which is why that one is includes-only.
+    # Propagated from here rather than added per-consumer: any module that includes the header
+    # needs it, and a third consumer would otherwise fail to compile.
+    find_package(intx CONFIG REQUIRED)
+    target_link_libraries(bcos-framework PUBLIC intx::intx)
 endif()
 target_include_directories(bcos-framework PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/bcos-framework/bcos-framework/protocol/TxGasModel.h
+++ b/bcos-framework/bcos-framework/protocol/TxGasModel.h
@@ -1,0 +1,171 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file TxGasModel.h
+ * @brief Transaction cost model shared by execution and admission.
+ * @date 2026/8/25
+ */
+
+// The intrinsic-gas formula and the per-transaction gas cap must be computed identically by the
+// executor and by whatever admits a transaction into a pool. When the two drift, admission lets
+// through transactions that execution then fails with OutOfGasLimit -- a block full of
+// deterministically failing transactions. EIP-7623's min_cost and
+// AUTHORIZATION_EMPTY_ACCOUNT_COST both move with hard forks, so a second copy would drift.
+//
+// Lives in bcos-framework (not in the executor) because the admission layer must not link
+// ethereum-executor: EthereumTransition.h drags in EthereumHost.h / EthereumState.h / evmone,
+// and neither txpool nor rpc can reach evmone today. Dependencies here are limited to the evmc
+// and intx headers, both header-only.
+
+#pragma once
+
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-utilities/Common.h"
+#include "bcos-utilities/DataConvertUtility.h"
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <evmc/evmc.hpp>
+#include <intx/intx.hpp>
+#include <optional>
+#include <span>
+
+namespace bcos::protocol
+{
+
+/// EIP-7825: the per-transaction gas cap enforced from Osaka onwards.
+constexpr auto MAX_TX_GAS_LIMIT = 0x1000000;  // 2**24
+
+/// EIP-7702: intrinsic cost charged per authorization-list entry.
+inline constexpr int64_t AUTHORIZATION_EMPTY_ACCOUNT_COST = 25000;
+
+/// Convert bcos::u256 to intx::uint256 (big-endian byte copy into a stack buffer; no string
+/// round-trip, no heap allocation). Single canonical home of this conversion.
+///
+/// Callers widen before arithmetic on purpose: bcos::u256 carries
+/// boost::multiprecision::unchecked, so `gasLimit * gasPrice + value` wraps silently on it,
+/// while intx::umul yields a 512-bit result that cannot.
+inline intx::uint256 toIntxU256(bcos::u256 const& val)
+{
+    std::array<bcos::byte, 32> be{};
+    bcos::toBigEndian(val, be);  // writes 32 big-endian bytes, no allocation.
+    return intx::be::unsafe::load<intx::uint256>(be.data());
+}
+
+/// Resolve the recipient of a bcos Transaction (Ethereum addresses are big-endian and
+/// right-aligned). std::nullopt means contract creation -- returned for an empty `to` or a
+/// malformed non-20-byte value.
+inline std::optional<evmc::address> ethToAddress(Transaction const& tx)
+{
+    auto const& tb = tx.to();
+    if (tb.empty())
+        return std::nullopt;
+
+    const bool has0x = tb.size() >= 2 && tb[0] == '0' && (tb[1] == 'x' || tb[1] == 'X');
+    const bool is40Hex =
+        tb.size() == sizeof(evmc_address) * 2 && std::all_of(tb.begin(), tb.end(), [](char c) {
+            return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+        });
+    if (has0x || is40Hex)
+    {
+        // Hex-string form. Only a well-formed 20-byte address decodes to a valid recipient.
+        if (auto decoded = safeFromHex(tb); decoded && decoded->size() == sizeof(evmc_address))
+        {
+            evmc::address a{};
+            std::copy(decoded->begin(), decoded->end(), a.bytes);
+            return a;
+        }
+        return std::nullopt;
+    }
+    if (tb.size() == sizeof(evmc_address))
+    {
+        // Defensive fallback for raw 20-byte addresses.
+        evmc::address a{};
+        std::copy_n(tb.begin(), sizeof(evmc_address), a.bytes);
+        return a;
+    }
+    // Anything else (short raw bytes, malformed hex) is contract creation.
+    return std::nullopt;
+}
+
+constexpr int64_t num_words(size_t size_in_bytes) noexcept
+{
+    return static_cast<int64_t>((size_in_bytes + 31) / 32);
+}
+
+inline size_t compute_tx_data_tokens(evmc_revision rev, std::span<const uint8_t> data) noexcept
+{
+    const auto num_zero_bytes = static_cast<size_t>(std::ranges::count(data, 0));
+    const auto num_nonzero_bytes = data.size() - num_zero_bytes;
+
+    const size_t nonzero_byte_multiplier = rev >= EVMC_ISTANBUL ? 4 : 17;
+    return (nonzero_byte_multiplier * num_nonzero_bytes) + num_zero_bytes;
+}
+
+inline int64_t compute_access_list_cost(const Web3AccessList& access_list) noexcept
+{
+    static constexpr auto ADDRESS_COST = 2400;
+    static constexpr auto STORAGE_KEY_COST = 1900;
+
+    int64_t cost = 0;
+    for (const auto& entry : access_list)
+        cost += ADDRESS_COST + static_cast<int64_t>(entry.storageKeys.size()) * STORAGE_KEY_COST;
+    return cost;
+}
+
+struct TransactionCost
+{
+    int64_t intrinsic = 0;
+    int64_t min = 0;
+};
+
+/// Compute the transaction intrinsic gas g0 (Yellow Paper, 6.2) and minimal gas (EIP-7623).
+/// Ported from evmone state.cpp.
+inline TransactionCost compute_tx_intrinsic_cost(evmc_revision rev, Transaction const& tx) noexcept
+{
+    static constexpr auto TX_BASE_COST = 21000;
+    static constexpr auto TX_CREATE_COST = 32000;
+    static constexpr auto DATA_TOKEN_COST = 4;
+    static constexpr auto INITCODE_WORD_COST = 2;
+    static constexpr auto TOTAL_COST_FLOOR_PER_TOKEN = 10;
+
+    const auto is_create = !ethToAddress(tx).has_value();
+
+    const auto create_cost = (is_create && rev >= EVMC_HOMESTEAD) ? TX_CREATE_COST : 0;
+
+    const auto data = tx.input();
+    const auto num_tokens = static_cast<int64_t>(
+        compute_tx_data_tokens(rev, std::span<const uint8_t>{data.data(), data.size()}));
+    const auto data_cost = num_tokens * DATA_TOKEN_COST;
+
+    const auto access_list_cost = compute_access_list_cost(tx.web3AccessList());
+
+    const auto auth_list_cost =
+        static_cast<int64_t>(tx.authorizationList().size()) * AUTHORIZATION_EMPTY_ACCOUNT_COST;
+
+    const auto initcode_cost =
+        (is_create && rev >= EVMC_SHANGHAI) ? INITCODE_WORD_COST * num_words(data.size()) : 0;
+
+    const auto intrinsic_cost =
+        TX_BASE_COST + create_cost + data_cost + access_list_cost + auth_list_cost + initcode_cost;
+
+    // EIP-7623: Compute the minimum cost for the transaction. If disabled, just use 0.
+    const auto min_cost =
+        rev >= EVMC_PRAGUE ? TX_BASE_COST + num_tokens * TOTAL_COST_FLOOR_PER_TOKEN : 0;
+
+    return {intrinsic_cost, min_cost};
+}
+
+}  // namespace bcos::protocol

--- a/ethereum-executor/EVMSupport.h
+++ b/ethereum-executor/EVMSupport.h
@@ -17,17 +17,18 @@
 #pragma once
 
 #include "bcos-framework/protocol/Authorization.h"
+#include "bcos-framework/protocol/TxGasModel.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <bcos-codec/rlp/RLPEncode.h>
 #include <algorithm>
 #include <array>
-#include <evmc/evmc.hpp>
-#include <evmone_precompiles/keccak.hpp>
-#include <evmone_precompiles/secp256k1.hpp>
 #include <bit>
 #include <cassert>
 #include <cstdint>
+#include <evmc/evmc.hpp>
+#include <evmone_precompiles/keccak.hpp>
+#include <evmone_precompiles/secp256k1.hpp>
 #include <intx/intx.hpp>
 #include <ios>
 #include <limits>
@@ -40,23 +41,17 @@
 namespace bcos::executor_v1::eth::evm
 {
 
-/// Convert bcos::u256 to intx::uint256 (big-endian byte copy into a stack
-/// buffer; no string round-trip, no heap allocation). Single canonical home of
-/// this conversion.
-inline intx::uint256 toIntxU256(bcos::u256 const& val)
-{
-    std::array<bcos::byte, 32> be{};
-    bcos::toBigEndian(val, be);  // writes 32 big-endian bytes, no allocation.
-    return intx::be::unsafe::load<intx::uint256>(be.data());
-}
+// Defined in bcos-framework/protocol/TxGasModel.h so the admission layer can widen balances
+// with the same conversion the executor uses, without linking ethereum-executor. Re-imported
+// here so the ~20 existing `evm::toIntxU256(...)` call sites are unaffected.
+using bcos::protocol::toIntxU256;
 
 /// Convert intx::uint256 to bcos::u256 (big-endian byte copy; no string
 /// round-trip).
 inline bcos::u256 toBcosU256(intx::uint256 const& val)
 {
     const auto be = intx::be::store<evmc::bytes32>(val);
-    return bcos::fromBigEndian<bcos::u256>(
-        bcos::bytesConstRef(be.bytes, sizeof(be.bytes)));
+    return bcos::fromBigEndian<bcos::u256>(bcos::bytesConstRef(be.bytes, sizeof(be.bytes)));
 }
 
 /// A transaction log entry (ported evmone state::Log).
@@ -179,7 +174,8 @@ constexpr auto GAS_PER_BLOB = 0x20000;  // 2**17
 constexpr auto MAX_TX_BLOB_COUNT = 6;
 
 /// The maximum allowed gas limit for a transaction (EIP-7825).
-constexpr auto MAX_TX_GAS_LIMIT = 0x1000000;  // 2**24
+/// Defined in bcos-framework/protocol/TxGasModel.h -- admission enforces the same cap.
+using bcos::protocol::MAX_TX_GAS_LIMIT;
 
 /// The blob schedule entry for an EVM revision (EIP-7840).
 struct BlobParams
@@ -243,8 +239,7 @@ inline intx::uint256 compute_blob_gas_price(
 
     const auto base_hash = keccak256(evmc::bytes_view{encoded.data(), encoded.size()});
     evmc::address addr;
-    std::copy_n(
-        &base_hash.bytes[sizeof(base_hash) - sizeof(addr)], sizeof(addr), addr.bytes);
+    std::copy_n(&base_hash.bytes[sizeof(base_hash) - sizeof(addr)], sizeof(addr), addr.bytes);
     return addr;
 }
 
@@ -275,8 +270,10 @@ inline constexpr auto SECP256K1N_OVER_2 = evmmax::secp256k1::Curve::ORDER / 2;
 /// EIP-7702 authorization magic byte (prefix of the signing hash).
 inline constexpr uint8_t kSetCodeMagic = 0x05;
 
-/// EIP-7702: The cost of authorization that sets delegation to an account that didn't exist before.
-inline constexpr int64_t AUTHORIZATION_EMPTY_ACCOUNT_COST = 25000;
+/// EIP-7702: The cost of authorization that sets delegation to an account that didn't exist
+/// before. Defined in bcos-framework/protocol/TxGasModel.h -- it is part of the intrinsic-gas
+/// formula, which admission must compute identically.
+using bcos::protocol::AUTHORIZATION_EMPTY_ACCOUNT_COST;
 /// EIP-7702: The cost of authorization that sets delegation to an account that already exists.
 inline constexpr int64_t AUTHORIZATION_BASE_COST = 12500;
 

--- a/ethereum-executor/EthereumTransition.h
+++ b/ethereum-executor/EthereumTransition.h
@@ -11,19 +11,19 @@
 
 #pragma once
 
+#include "EVMSupport.h"
 #include "EthereumHost.h"
 #include "EthereumState.h"
-#include "EVMSupport.h"
 #include "bcos-framework/protocol/LogEntry.h"
 #include "bcos-framework/protocol/TransactionReceipt.h"
 #include "bcos-framework/protocol/TransactionReceiptFactory.h"
 #include "bcos-protocol/TransactionStatus.h"
 #include "bcos-utilities/DataConvertUtility.h"
+#include <algorithm>
 #include <evmc/evmc.hpp>
 #include <evmone/constants.hpp>
 #include <evmone/delegation.hpp>
 #include <evmone_precompiles/secp256k1.hpp>
-#include <algorithm>
 #include <optional>
 #include <span>
 #include <system_error>
@@ -37,10 +37,12 @@ using evm::make_error_code;
 // EIP-7840 blob schedule constants (target, max, base_fee_update_fraction).
 // Shared by EthereumExecutor (blob_gas_left for validation) and the block-info
 // builder (blob_base_fee computation) so the two cannot drift.
-inline constexpr evm::BlobParams PRAGUE_BLOB_PARAMS{
-    .target = 6, .max = 9, .base_fee_update_fraction = 5007716};
-inline constexpr evm::BlobParams CANCUN_BLOB_PARAMS{
-    .target = 3, .max = 6, .base_fee_update_fraction = 3338477};
+inline constexpr evm::BlobParams PRAGUE_BLOB_PARAMS{.target = 6,
+    .max = 9,
+    .base_fee_update_fraction = 5007716};
+inline constexpr evm::BlobParams CANCUN_BLOB_PARAMS{.target = 3,
+    .max = 6,
+    .base_fee_update_fraction = 3338477};
 
 /// The EIP-7840 blob schedule in effect for @p rev (empty for pre-Cancun).
 inline evm::BlobParams blobParamsForRevision(evmc_revision rev) noexcept
@@ -79,43 +81,10 @@ struct EthWithdrawal
     }
 };
 
-/// Resolve the recipient of a bcos Transaction (Ethereum addresses are
-/// big-endian and right-aligned). std::nullopt means contract creation —
-/// returned for an empty `to` or a malformed non-20-byte value.
-inline std::optional<address> ethToAddress(protocol::Transaction const& tx)
-{
-    auto const& tb = tx.to();
-    if (tb.empty())
-        return std::nullopt;
-
-    const bool has0x = tb.size() >= 2 && tb[0] == '0' && (tb[1] == 'x' || tb[1] == 'X');
-    const bool is40Hex = tb.size() == sizeof(evmc_address) * 2 &&
-                         std::all_of(tb.begin(), tb.end(), [](char c) {
-                             return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
-                                    (c >= 'A' && c <= 'F');
-                         });
-    if (has0x || is40Hex)
-    {
-        // Hex-string form. Only a well-formed 20-byte address decodes to a
-        // valid recipient.
-        if (auto decoded = safeFromHex(tb); decoded && decoded->size() == sizeof(evmc_address))
-        {
-            address a{};
-            std::copy(decoded->begin(), decoded->end(), a.bytes);
-            return a;
-        }
-        return std::nullopt;
-    }
-    if (tb.size() == sizeof(evmc_address))
-    {
-        // Defensive fallback for raw 20-byte addresses.
-        address a{};
-        std::copy_n(tb.begin(), sizeof(evmc_address), a.bytes);
-        return a;
-    }
-    // Anything else (short raw bytes, malformed hex) is contract creation.
-    return std::nullopt;
-}
+// ethToAddress is defined in bcos-framework/protocol/TxGasModel.h: the admission layer needs
+// the same `to` decoding to decide create-vs-call, and it cannot link ethereum-executor.
+// Re-imported so unqualified call sites in this header (and in the tests) resolve unchanged.
+using bcos::protocol::ethToAddress;
 
 namespace eth_transition_detail
 {
@@ -126,74 +95,17 @@ inline std::optional<evmc::address> recoverAuthority(protocol::Authorization con
     return evm::recoverAuthority(auth);
 }
 
-constexpr int64_t num_words(size_t size_in_bytes) noexcept
-{
-    return static_cast<int64_t>((size_in_bytes + 31) / 32);
-}
-
-inline size_t compute_tx_data_tokens(evmc_revision rev, std::span<const uint8_t> data) noexcept
-{
-    const auto num_zero_bytes = static_cast<size_t>(std::ranges::count(data, 0));
-    const auto num_nonzero_bytes = data.size() - num_zero_bytes;
-
-    const size_t nonzero_byte_multiplier = rev >= EVMC_ISTANBUL ? 4 : 17;
-    return (nonzero_byte_multiplier * num_nonzero_bytes) + num_zero_bytes;
-}
-
-inline int64_t compute_access_list_cost(const protocol::Web3AccessList& access_list) noexcept
-{
-    static constexpr auto ADDRESS_COST = 2400;
-    static constexpr auto STORAGE_KEY_COST = 1900;
-
-    int64_t cost = 0;
-    for (const auto& entry : access_list)
-        cost += ADDRESS_COST + static_cast<int64_t>(entry.storageKeys.size()) * STORAGE_KEY_COST;
-    return cost;
-}
-
-struct TransactionCost
-{
-    int64_t intrinsic = 0;
-    int64_t min = 0;
-};
-
-/// Compute the transaction intrinsic gas 𝑔₀ (Yellow Paper, 6.2) and minimal gas
-/// (EIP-7623). Ported from evmone state.cpp.
-inline TransactionCost compute_tx_intrinsic_cost(
-    evmc_revision rev, protocol::Transaction const& tx) noexcept
-{
-    static constexpr auto TX_BASE_COST = 21000;    static constexpr auto TX_CREATE_COST = 32000;
-    static constexpr auto DATA_TOKEN_COST = 4;
-    static constexpr auto INITCODE_WORD_COST = 2;
-    static constexpr auto TOTAL_COST_FLOOR_PER_TOKEN = 10;
-
-    const auto is_create = !ethToAddress(tx).has_value();
-
-    const auto create_cost = (is_create && rev >= EVMC_HOMESTEAD) ? TX_CREATE_COST : 0;
-
-    const auto data = tx.input();
-    const auto num_tokens =
-        static_cast<int64_t>(compute_tx_data_tokens(rev, std::span<const uint8_t>{data.data(), data.size()}));
-    const auto data_cost = num_tokens * DATA_TOKEN_COST;
-
-    const auto access_list_cost = compute_access_list_cost(tx.web3AccessList());
-
-    const auto auth_list_cost = static_cast<int64_t>(tx.authorizationList().size()) *
-                                evm::AUTHORIZATION_EMPTY_ACCOUNT_COST;
-
-    const auto initcode_cost = (is_create && rev >= EVMC_SHANGHAI) ?
-                                   INITCODE_WORD_COST * num_words(data.size()) :
-                                   0;
-
-    const auto intrinsic_cost =
-        TX_BASE_COST + create_cost + data_cost + access_list_cost + auth_list_cost + initcode_cost;
-
-    // EIP-7623: Compute the minimum cost for the transaction by. If disabled, just use 0.
-    const auto min_cost =
-        rev >= EVMC_PRAGUE ? TX_BASE_COST + num_tokens * TOTAL_COST_FLOOR_PER_TOKEN : 0;
-
-    return {intrinsic_cost, min_cost};
-}
+// The transaction cost model (num_words / compute_tx_data_tokens / compute_access_list_cost /
+// TransactionCost / compute_tx_intrinsic_cost) lives in bcos-framework/protocol/TxGasModel.h.
+// Admission must reject a transaction whose gasLimit cannot cover the intrinsic cost, and it
+// has to use this exact formula -- a second copy would drift at the next hard fork that moves
+// EIP-7623's min_cost or the authorization-list cost. Re-imported so the call sites below and
+// the qualified `eth_transition_detail::compute_tx_intrinsic_cost` uses resolve unchanged.
+using bcos::protocol::compute_access_list_cost;
+using bcos::protocol::compute_tx_data_tokens;
+using bcos::protocol::compute_tx_intrinsic_cost;
+using bcos::protocol::num_words;
+using bcos::protocol::TransactionCost;
 
 inline evmc_message build_message(
     protocol::Transaction const& tx, int64_t execution_gas_limit) noexcept
@@ -407,10 +319,10 @@ std::variant<EthTxProperties, std::error_code> validateTransaction(EthereumState
     const auto* const senderPtr = state.find(ethSender(tx));
     const auto senderNonce = senderPtr != nullptr ? senderPtr->nonce : 0;
 
-    if (senderPtr != nullptr &&
-        senderPtr->code_hash != EthAccount::EMPTY_CODE_HASH &&
+    if (senderPtr != nullptr && senderPtr->code_hash != EthAccount::EMPTY_CODE_HASH &&
         !evmone::is_code_delegated(state.get_code(ethSender(tx))))
-        return make_error_code(ErrorCode::SENDER_NOT_EOA);  // Origin must not be a contract (EIP-3607).
+        return make_error_code(ErrorCode::SENDER_NOT_EOA);  // Origin must not be a contract
+                                                            // (EIP-3607).
 
     if (senderNonce == EthAccount::NonceMax)  // Nonce value limit (EIP-2681).
         return make_error_code(ErrorCode::NONCE_HAS_MAX_VALUE);
@@ -426,14 +338,12 @@ std::variant<EthTxProperties, std::error_code> validateTransaction(EthereumState
         return make_error_code(ErrorCode::INIT_CODE_SIZE_LIMIT_EXCEEDED);
 
     // Compute and check if sender has enough balance for the theoretical maximum transaction cost.
-    auto max_total_fee =
-        intx::umul(intx::uint256(static_cast<uint64_t>(gasLimit)), maxGasPrice);
+    auto max_total_fee = intx::umul(intx::uint256(static_cast<uint64_t>(gasLimit)), maxGasPrice);
     max_total_fee += evm::toIntxU256(tx.value());
 
     if (txKind == 3)  // blob
     {
-        const auto total_blob_gas =
-            static_cast<uint64_t>(evm::GAS_PER_BLOB) * blobHashes.size();
+        const auto total_blob_gas = static_cast<uint64_t>(evm::GAS_PER_BLOB) * blobHashes.size();
         max_total_fee += intx::uint256(total_blob_gas) * ethMaxBlobGasPrice(tx);
     }
     const auto senderBalance = senderPtr != nullptr ? senderPtr->balance : intx::uint256{};
@@ -528,20 +438,19 @@ task::Task<protocol::TransactionReceipt::Ptr> runTransaction(EthereumState<Stora
     // The NODE's chain id, never tx.chain_id: validate_transaction does not
     // check that field, so passing it would make EIP-7702 step 1 compare sender
     // input against sender input. See the declaration comment in bcos-evm.
-    const auto delegation_refund = eth_transition_detail::processAuthorizationList(state, chainId, tx);
+    const auto delegation_refund =
+        eth_transition_detail::processAuthorizationList(state, chainId, tx);
 
     const auto base_fee = (rev >= EVMC_LONDON) ? block.base_fee : 0;
     const auto max_gas_price = ethMaxGasPrice(tx, callParams);
     const auto max_priority_gas_price = ethMaxPriorityGasPrice(tx, callParams);
-    assert(max_gas_price >= base_fee);                   // Required for valid tx.
-    assert(max_gas_price >= max_priority_gas_price);     // Required for valid tx.
-    const auto priority_gas_price =
-        std::min(max_priority_gas_price, max_gas_price - base_fee);
+    assert(max_gas_price >= base_fee);                // Required for valid tx.
+    assert(max_gas_price >= max_priority_gas_price);  // Required for valid tx.
+    const auto priority_gas_price = std::min(max_priority_gas_price, max_gas_price - base_fee);
     const auto effective_gas_price = base_fee + priority_gas_price;
 
     assert(effective_gas_price <= max_gas_price);  // Required for valid tx.
-    const auto tx_max_cost =
-        intx::uint256(static_cast<uint64_t>(gasLimit)) * effective_gas_price;
+    const auto tx_max_cost = intx::uint256(static_cast<uint64_t>(gasLimit)) * effective_gas_price;
 
     sender_acc.balance -= tx_max_cost;  // Modify sender balance after all checks.
 


### PR DESCRIPTION
### Motivation

Admission and execution have to compute intrinsic gas from the same formula. Today the only implementation that works over `protocol::Transaction` lives inside `ethereum-executor/EthereumTransition.h`, and no admission path can reach it: including that header drags in `EthereumHost.h` / `EthereumState.h` / evmone, and neither `txpool` nor `rpc` links evmone (`ledger` links only `tool protocol-tars codec table bcos-concepts bcos-crypto Boost::serialization`).

Copying the formula into the admission layer is the wrong answer. EIP-7623's `min_cost` and the EIP-7702 `AUTHORIZATION_EMPTY_ACCOUNT_COST` both move with hard forks, so a second copy drifts — and a drift is visible as "admission accepted the transaction, execution returned `OutOfGasLimit`", i.e. a block carrying a deterministically failing transaction. The 512-bit balance widening has the same property: `bcos::u256` carries `boost::multiprecision::unchecked`, so `gasLimit * gasPrice + value` wraps silently on it, while execution already uses `intx::umul`.

This PR only moves code. No behaviour change.

### What changed

New header `bcos-framework/bcos-framework/protocol/TxGasModel.h`, namespace `bcos::protocol`:

| Symbol | Moved from |
|---|---|
| `ethToAddress` | `EthereumTransition.h` |
| `num_words`, `compute_tx_data_tokens`, `compute_access_list_cost` | `EthereumTransition.h` (`eth_transition_detail`) |
| `struct TransactionCost`, `compute_tx_intrinsic_cost` | `EthereumTransition.h` (`eth_transition_detail`) |
| `MAX_TX_GAS_LIMIT`, `AUTHORIZATION_EMPTY_ACCOUNT_COST`, `toIntxU256` | `EVMSupport.h` |

Its dependencies are limited to the header-only evmc and intx headers plus `protocol/Transaction.h` — deliberately nothing from evmone proper.

`bcos-framework` now PUBLIC-links `intx::intx` under `FULLNODE`. `intx` is an INTERFACE target, so this propagates include directories and puts no archive on any consumer's link line — unlike `evmone`, which stays includes-only there for exactly that reason (the existing comment in `bcos-framework/CMakeLists.txt` explains it). Propagating from the framework rather than adding `intx::intx` per consumer means a third module that includes the header compiles instead of failing to.

Both former homes keep their namespaces and re-import the symbols with using-declarations, so **every existing call site is untouched** — including the ~20 `evm::toIntxU256(...)` uses across `ethereum-executor` and `opstack-executor` and the qualified `eth_transition_detail::compute_tx_intrinsic_cost` uses.

### Test

Behaviour-neutral, so the evidence is that the existing suites still pass with the definitions relocated:

```
cmake --build build --target ethereum-executor opstack-executor \
      test-transaction-scheduler test-ethereum-state-smoke     -> all built clean

./build/ethereum-executor/tests/test-ethereum-state-smoke
TestEthereumStateSmoke: all checks passed

./build/transaction-scheduler/tests/test-transaction-scheduler \
      --run_test=TestEthereumExecutorScheduler
*** No errors detected
```

`TestEthereumExecutorScheduler` is the relevant suite: it drives real block execution through `compute_tx_intrinsic_cost`, and its `toDecodingOnlyWellFormedAddresses` case is the direct unit test for the moved `ethToAddress`.