### PR TITLE
feat(mempool): add MemPoolImpl::tryAdd with an explicit exit contract

### DIFF
--- a/mempool/CMakeLists.txt
+++ b/mempool/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(mempool ${SRC_LIST} ${HEADERS})
 target_include_directories(mempool PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-mempool>)
-target_link_libraries(mempool PUBLIC bcos-framework ledger bcos-utilities TBB::tbb)
+target_link_libraries(mempool PUBLIC bcos-framework bcos-protocol ledger bcos-utilities TBB::tbb)
 set_target_properties(mempool PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/mempool/bcos-mempool/MemPoolImpl.cpp
+++ b/mempool/bcos-mempool/MemPoolImpl.cpp
@@ -49,7 +49,26 @@ void bcos::txpool::MemPoolImpl::add(protocol::Transaction::Ptr transaction)
     {
         return;
     }
+    addImpl(std::move(transaction), /*replaceOnNonceConflict=*/true);
+}
 
+bcos::protocol::TransactionStatus bcos::txpool::MemPoolImpl::tryAdd(
+    protocol::Transaction::Ptr transaction)
+{
+    std::unique_lock lock(m_mutex);
+    if (!transaction) [[unlikely]]
+    {
+        // Unlike add(), which returns silently, this is reported: a caller that hands the pool
+        // a null pointer has a bug, and swallowing it here makes that bug look like a rejected
+        // transaction.
+        bcos::throwTrace(NullTransaction{});
+    }
+    return addImpl(std::move(transaction), /*replaceOnNonceConflict=*/false);
+}
+
+bcos::protocol::TransactionStatus bcos::txpool::MemPoolImpl::addImpl(
+    protocol::Transaction::Ptr transaction, bool replaceOnNonceConflict)
+{
     if (transaction->tainted()) [[unlikely]]
     {
         bcos::throwTrace(InvalidTaintedTransaction{});
@@ -79,12 +98,12 @@ void bcos::txpool::MemPoolImpl::add(protocol::Transaction::Ptr transaction)
     {
         MEMPOOL_LOG(WARNING) << LOG_DESC("MemPoolImpl::add: get hash failed, skip")
                              << LOG_KV("reason", boost::diagnostic_information(e));
-        return;
+        return protocol::TransactionStatus::Malformed;
     }
 
     if (auto it = hashIndex.find(hash); it != hashIndex.end())
     {
-        return;
+        return protocol::TransactionStatus::AlreadyInTxPool;
     }
 
     try
@@ -95,6 +114,10 @@ void bcos::txpool::MemPoolImpl::add(protocol::Transaction::Ptr transaction)
             it != nonceIndex.end() && it->sender() == transactionData.sender() &&
             it->nonce() == transactionData.nonce())
         {
+            if (!replaceOnNonceConflict)
+            {
+                return protocol::TransactionStatus::NonceCheckFail;
+            }
             nonceIndex.replace(it, std::move(transactionData));
         }
         else
@@ -106,5 +129,7 @@ void bcos::txpool::MemPoolImpl::add(protocol::Transaction::Ptr transaction)
     {
         MEMPOOL_LOG(WARNING) << LOG_DESC("MemPoolImpl::add: invalid nonce, skip")
                              << LOG_KV("reason", boost::diagnostic_information(e));
+        return protocol::TransactionStatus::NonceCheckFail;
     }
+    return protocol::TransactionStatus::None;
 }

--- a/mempool/bcos-mempool/MemPoolImpl.h
+++ b/mempool/bcos-mempool/MemPoolImpl.h
@@ -4,6 +4,7 @@
 #include "bcos-framework/ledger/EVMAccount.h"
 #include "bcos-framework/storage2/Storage.h"
 #include "bcos-framework/transaction-executor/StateKey.h"
+#include "bcos-protocol/TransactionStatus.h"
 #include "bcos-task/Wait.h"
 #include "bcos-utilities/Exceptions.h"
 #include <boost/multi_index/composite_key.hpp>
@@ -24,6 +25,7 @@ namespace bcos::txpool
 DERIVE_BCOS_EXCEPTION(InvalidNonce);
 DERIVE_BCOS_EXCEPTION(InvalidTaintedTransaction);
 DERIVE_BCOS_EXCEPTION(InvalidBlobTransaction);
+DERIVE_BCOS_EXCEPTION(NullTransaction);
 
 struct TransactionData
 {
@@ -121,6 +123,12 @@ private:
     }
 
     void add(protocol::Transaction::Ptr transaction);
+
+    // Shared body of add() and tryAdd(). The caller must already hold m_mutex and must have
+    // rejected a null transaction. The two entries differ only in what happens when
+    // (sender, nonce) is already taken, hence the flag rather than a second copy.
+    protocol::TransactionStatus addImpl(
+        protocol::Transaction::Ptr transaction, bool replaceOnNonceConflict);
     void removeBySenderNonces(SenderNonces auto senderNonces)
     {
         auto& senderNonceIndex = m_transactions.get<0>();
@@ -145,6 +153,30 @@ public:
             add(std::forward<decltype(transaction)>(transaction));
         }
     }
+
+    /// Admit one transaction, reporting why it was not admitted.
+    ///
+    /// add() cannot serve an RPC entry point: it returns void and four of its exits are silent
+    /// (null input, hash() throwing, duplicate hash, unparsable nonce), so a caller that replies
+    /// with the transaction hash right after calling it answers with a hash for a transaction
+    /// that never entered the pool -- the user then polls for a receipt until timeout.
+    ///
+    /// Exit contract:
+    ///   null transaction              throws NullTransaction (a caller bug, not a tx defect)
+    ///   tainted()                     throws InvalidTaintedTransaction  (as add())
+    ///   blob envelope                 throws InvalidBlobTransaction     (as add())
+    ///   hash() throws                 Malformed
+    ///   hash already pooled           AlreadyInTxPool
+    ///   (sender, nonce) already taken NonceCheckFail -- rejects, does NOT replace
+    ///   nonce not representable       NonceCheckFail
+    ///   admitted                      None
+    ///
+    /// The nonce-conflict arm is the one behavioural difference from add(), which replaces the
+    /// resident transaction. Rejecting matches the legacy pool's first-come-first-served rule
+    /// (MemoryStorage's FIB-51 atomic check-and-reserve) and makes the check-and-insert a single
+    /// critical section, so two concurrent submissions of the same (sender, nonce) cannot both
+    /// succeed.
+    protocol::TransactionStatus tryAdd(protocol::Transaction::Ptr transaction);
 
     void seal(int64_t limit,
         storage2::ReadWriteStorage<executor_v1::StateKeyView, executor_v1::StateValue> auto& state,

--- a/mempool/test/unittests/mempool/MemPoolTryAddTest.cpp
+++ b/mempool/test/unittests/mempool/MemPoolTryAddTest.cpp
@@ -1,0 +1,223 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MemPoolTryAddTest.cpp
+ * @brief Exit contract of MemPoolImpl::tryAdd (every arm, including the four that add()
+ *        reports silently) plus the concurrent same-(sender, nonce) case.
+ */
+
+#include "bcos-mempool/MemPoolImpl.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-utilities/Common.h>
+#include <boost/test/unit_test.hpp>
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace bcos;
+using namespace bcos::txpool;
+using namespace bcos::protocol;
+using namespace bcos::crypto;
+
+namespace bcos::test
+{
+// Distinct names throughout: this file is unity-built into the same translation unit as
+// MemPoolImplTest.cpp, so an anonymous namespace would not isolate it.
+class TryAddTransaction : public bcostars::protocol::TransactionImpl
+{
+public:
+    void markClean() { setTainted(false); }
+    void markTainted() { setTainted(true); }
+};
+
+static bytes tryAddToBytes(std::string_view str)
+{
+    return {reinterpret_cast<const byte*>(str.data()),
+        reinterpret_cast<const byte*>(str.data()) + str.size()};
+}
+
+/// A BCOS transaction with a computed dataHash, untainted, ready to be admitted.
+///
+/// @p payload distinguishes two transactions that share a (sender, nonce). It has to be applied
+/// before calculateHash: TarsHashable.h returns the cached dataHash once it is set, so mutating
+/// the struct and re-hashing afterwards leaves the hash untouched -- and two same-hash
+/// transactions collide in the hash index, never reaching the (sender, nonce) index this suite
+/// is about.
+static std::shared_ptr<TryAddTransaction> tryAddMakeTx(
+    std::string_view sender, int64_t nonce, std::string_view payload = {})
+{
+    auto tx = std::make_shared<TryAddTransaction>();
+    tx->mutableInner().data.to.assign(sender.begin(), sender.end());
+    tx->mutableInner().data.input.assign(payload.begin(), payload.end());
+    tx->setNonce(std::to_string(nonce));
+    tx->forceSender(tryAddToBytes(sender));
+    Keccak256 hasher;
+    tx->calculateHash(hasher);
+    tx->markClean();
+    tx->setImportTime(nonce);
+    return tx;
+}
+
+BOOST_AUTO_TEST_SUITE(MemPoolTryAddTest)
+
+BOOST_AUTO_TEST_CASE(admittedReturnsNone)
+{
+    MemPoolImpl pool;
+    BOOST_CHECK(pool.tryAdd(tryAddMakeTx("sender_aaaaaaaaaaaa", 1)) == TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(nullTransactionThrows)
+{
+    MemPoolImpl pool;
+    // add() returns silently here; tryAdd reports it, because a null pointer is a caller bug
+    // and must not be indistinguishable from a rejected transaction.
+    BOOST_CHECK_THROW(pool.tryAdd(nullptr), NullTransaction);
+}
+
+BOOST_AUTO_TEST_CASE(taintedTransactionThrows)
+{
+    MemPoolImpl pool;
+    auto tx = tryAddMakeTx("sender_bbbbbbbbbbbb", 1);
+    tx->markTainted();  // signature not verified yet
+    BOOST_CHECK_THROW(pool.tryAdd(tx), InvalidTaintedTransaction);
+}
+
+BOOST_AUTO_TEST_CASE(blobEnvelopeThrows)
+{
+    MemPoolImpl pool;
+    auto tx = tryAddMakeTx("sender_cccccccccccc", 1);
+    tx->mutableInner().type = static_cast<char>(TransactionType::Web3Transaction);
+    // EIP-2718 type byte 0x03 = blob (EIP-4844); never admissible on this chain.
+    tx->mutableInner().extraTransactionBytes = {0x03, 0x01, 0x02};
+    tx->mutableInner().extraTransactionHash.assign(32, 0x11);
+    BOOST_CHECK_THROW(pool.tryAdd(tx), InvalidBlobTransaction);
+}
+
+BOOST_AUTO_TEST_CASE(unhashableTransactionReturnsMalformed)
+{
+    MemPoolImpl pool;
+    auto tx = std::make_shared<TryAddTransaction>();
+    tx->setNonce("1");
+    tx->forceSender(tryAddToBytes("sender_dddddddddddd"));
+    tx->markClean();
+    // Neither dataHash nor extraTransactionHash set -> hash() throws EmptyTransactionHash.
+    // add() swallows this and returns, so its caller cannot tell the transaction was dropped.
+    BOOST_CHECK(pool.tryAdd(tx) == TransactionStatus::Malformed);
+}
+
+BOOST_AUTO_TEST_CASE(duplicateHashReturnsAlreadyInTxPool)
+{
+    MemPoolImpl pool;
+    auto first = tryAddMakeTx("sender_eeeeeeeeeeee", 1);
+    BOOST_CHECK(pool.tryAdd(first) == TransactionStatus::None);
+    // Same bytes -> same dataHash.
+    BOOST_CHECK(
+        pool.tryAdd(tryAddMakeTx("sender_eeeeeeeeeeee", 1)) == TransactionStatus::AlreadyInTxPool);
+}
+
+BOOST_AUTO_TEST_CASE(nonceConflictRejectsAndKeepsTheResident)
+{
+    MemPoolImpl pool;
+    auto resident = tryAddMakeTx("sender_ffffffffffff", 7);
+    BOOST_CHECK(pool.tryAdd(resident) == TransactionStatus::None);
+
+    // Same (sender, nonce), different content -> different hash, so this is not caught by the
+    // hash index. add() would replace the resident; tryAdd rejects, first come first served.
+    auto challenger = tryAddMakeTx("sender_ffffffffffff", 7, "challenger");
+    BOOST_REQUIRE(challenger->hash() != resident->hash());
+
+    BOOST_CHECK(pool.tryAdd(challenger) == TransactionStatus::NonceCheckFail);
+
+    // The resident is still the one in the pool. get() returns one slot per requested hash and
+    // leaves it null on a miss, so absence is `== nullptr`, not an empty vector.
+    auto got = pool.get(std::vector<HashType>{resident->hash(), challenger->hash()});
+    BOOST_REQUIRE_EQUAL(got.size(), 2U);
+    BOOST_REQUIRE(got[0] != nullptr);
+    BOOST_CHECK(got[0]->hash() == resident->hash());
+    BOOST_CHECK(got[1] == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(unparsableNonceReturnsNonceCheckFail)
+{
+    MemPoolImpl pool;
+    auto tx = tryAddMakeTx("sender_gggggggggggg", 1);
+    tx->setNonce("not-a-number");
+    BOOST_CHECK(pool.tryAdd(tx) == TransactionStatus::NonceCheckFail);
+}
+
+BOOST_AUTO_TEST_CASE(addStillReplacesOnNonceConflict)
+{
+    // Guard: tryAdd's reject-on-conflict rule must not have leaked into add(), whose existing
+    // in-process callers (EngineServiceImpl) rely on replacement.
+    MemPoolImpl pool;
+    auto resident = tryAddMakeTx("sender_hhhhhhhhhhhh", 3);
+    auto challenger = tryAddMakeTx("sender_hhhhhhhhhhhh", 3, "challenger");
+    BOOST_REQUIRE(challenger->hash() != resident->hash());
+
+    pool.add(std::vector<Transaction::Ptr>{resident});
+    pool.add(std::vector<Transaction::Ptr>{challenger});
+
+    auto got = pool.get(std::vector<HashType>{resident->hash(), challenger->hash()});
+    BOOST_REQUIRE_EQUAL(got.size(), 2U);
+    BOOST_CHECK(got[0] == nullptr);  // replaced
+    BOOST_REQUIRE(got[1] != nullptr);
+    BOOST_CHECK(got[1]->hash() == challenger->hash());
+}
+
+BOOST_AUTO_TEST_CASE(concurrentSameSenderNonceAdmitsExactlyOne)
+{
+    // The check-and-insert has to be one critical section. "Query the pool, then call the void
+    // add()" is check-then-act: both threads pass the query and the second silently replaces
+    // the first, so counting pool entries alone (1 either way) cannot tell the two apart --
+    // the assertion that matters is that exactly one caller was told NonceCheckFail.
+    constexpr int kRounds = 200;
+    for (int round = 0; round < kRounds; ++round)
+    {
+        MemPoolImpl pool;
+        auto sender = "sender_conc_" + std::to_string(round);
+        auto left = tryAddMakeTx(sender, 5, "left");
+        auto right = tryAddMakeTx(sender, 5, "right");
+        // Distinct hashes on purpose: with equal hashes the loser would be rejected by the hash
+        // index instead of the (sender, nonce) index, and this case would pass without ever
+        // exercising the atomic check-and-reserve it is meant to cover.
+        BOOST_REQUIRE(left->hash() != right->hash());
+
+        std::atomic<int> admitted{0};
+        std::atomic<int> rejected{0};
+        auto submit = [&](Transaction::Ptr tx) {
+            if (pool.tryAdd(std::move(tx)) == TransactionStatus::None)
+            {
+                ++admitted;
+            }
+            else
+            {
+                ++rejected;
+            }
+        };
+        std::thread t1(submit, left);
+        std::thread t2(submit, right);
+        t1.join();
+        t2.join();
+
+        BOOST_REQUIRE_EQUAL(admitted.load(), 1);
+        BOOST_REQUIRE_EQUAL(rejected.load(), 1);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace bcos::test


### PR DESCRIPTION
### Motivation

`MemPoolImpl::add` returns `void`, and four of its exits are silent: a null input (`MemPoolImpl.cpp:48-51`), `hash()` throwing (`:78-83`), a duplicate hash (`:85-88`), and an unparsable nonce (`:105-109`) all just return.

An RPC entry point cannot be built on that. `eth_sendRawTransaction` replies with the transaction hash immediately after calling `add`, so any of those four paths answers the user with a hash for a transaction that **never entered the pool** — they then poll for a receipt until timeout with no error to explain it.

There is a second problem in the same function. On a `(sender, nonce)` collision `add` *replaces* the resident transaction (`:93-99`, `nonceIndex.replace`). "Query the pool, then call the void `add`" is check-then-act: two concurrent submissions of the same `(sender, nonce)` both pass the query and the second silently displaces the first. The legacy pool already fixed the equivalent hole — `MemoryStorage.cpp:456-476` notes that FIB-51 replaced a separate `checkNonce()` + `insert()` with an atomic check-and-reserve for exactly this reason.

### What changed

New public `MemPoolImpl::tryAdd(protocol::Transaction::Ptr) -> protocol::TransactionStatus`:

| Situation | `add` today | `tryAdd` |
|---|---|---|
| null transaction | silent return | throws `NullTransaction` (caller bug, not a tx defect) |
| `tainted()` | throws `InvalidTaintedTransaction` | same |
| blob envelope | throws `InvalidBlobTransaction` | same |
| `hash()` throws | silent return | `Malformed` |
| hash already pooled | silent return | `AlreadyInTxPool` |
| `(sender, nonce)` taken | **replaces the resident** | `NonceCheckFail` — rejects |
| nonce not representable | silent return | `NonceCheckFail` |
| admitted | — | `None` |

The nonce-conflict arm is the only behavioural difference. Rejecting matches the legacy pool's first-come-first-served rule, and since check and insert are in one critical section, two concurrent submissions of the same `(sender, nonce)` cannot both succeed.

`add` itself is untouched — `EngineServiceImpl` and the other in-process callers rely on replacement and are unaffected. The two entries share a private `addImpl` and differ only in that flag.

**No public pool interface changes.** `NodeService::memPool()` hands out the concrete `MemPoolImpl*` (`NodeService.h:91`), so nothing has to reach `tryAdd` through `AnyMemPoolFacade`. The `MemPool` concept and the four `PRO_DEF_MEM_DISPATCH` entries are byte-identical.

`mempool` now links `bcos-protocol` (an INTERFACE target) for `TransactionStatus.h`.

### Test

```
./build/mempool/test/test-bcos-mempool
*** No errors detected
```

10 new `MemPoolTryAddTest` cases — one per exit above, plus `addStillReplacesOnNonceConflict` guarding that the new rule did not leak into `add`, plus a 200-round two-thread case asserting exactly one `None` and one `NonceCheckFail`.

Worth flagging for review: an earlier draft of the concurrency case **passed for the wrong reason**. `TarsHashable.h:32` returns the cached `dataHash` once it is set, so building two transactions by mutating one after hashing gives them the *same* hash — the loser was then rejected by the hash index and the `(sender, nonce)` path was never exercised. The helper now applies the distinguishing payload before hashing, and both the conflict and concurrency cases `BOOST_REQUIRE` that the hashes differ so the setup cannot silently degrade again.