### PR TITLE
refactor(rlp-protocol): move the Web3 transaction RLP model out of bcos-rpc

### DIFF
--- a/bcos-executor/src/Web3AccessListResolver.cpp
+++ b/bcos-executor/src/Web3AccessListResolver.cpp
@@ -3,7 +3,7 @@
 #include "bcos-codec/rlp/RLPDecode.h"
 #include "bcos-framework/protocol/Transaction.h"
 #include "bcos-framework/protocol/Web3AccessList.h"
-#include "bcos-rpc/web3jsonrpc/model/Web3Transaction.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
 #include "bcos-utilities/BoostLog.h"
 #include "bcos-utilities/Common.h"
 

--- a/bcos-executor/test/unittest/Web3AccessListResolverTest.cpp
+++ b/bcos-executor/test/unittest/Web3AccessListResolverTest.cpp
@@ -5,7 +5,7 @@
 
 #include "../src/Web3AccessListResolver.h"
 #include <bcos-codec/rlp/RLPDecode.h>
-#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <boost/test/unit_test.hpp>

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.cpp
@@ -18,13 +18,12 @@
  * @date 2024/4/8
  */
 
-#include "Web3Transaction.h"
-#include "Web3TxHandler.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-rlp-protocol/Web3TxHandler.h"
 #include "bcos-utilities/Common.h"
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
 #include <bcos-framework/protocol/Transaction.h>
-#include <bcos-rpc/jsonrpc/Common.h>
 #include <bcos-utilities/DataConvertUtility.h>  // bcos::fromBigEndian
 #include <limits>
 #include <range/v3/algorithm/find_if.hpp>
@@ -151,132 +150,6 @@ bcos::crypto::HashType Web3Transaction::hashForSign() const
     return bcos::crypto::keccak256Hash(bcos::ref(encodeForSign));
 }
 
-bcostars::Transaction Web3Transaction::takeToTarsTransaction()
-{
-    if (type == TransactionType::Deposit)
-    {
-        bcostars::Transaction tarsTx{};
-        tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
-        tarsTx.web3TypedTxKind =
-            static_cast<tars::Char>(static_cast<uint8_t>(TransactionType::Deposit));
-        tarsTx.sourceHash = sourceHash.hex();
-        tarsTx.sender.assign(from.begin(), from.end());
-        // 0x-prefixed, matching the read side u256(...) (parsed in TransactionImpl.cpp mint())
-        tarsTx.mint = bcos::toQuantity(mint);
-        tarsTx.isSystemTransaction = isSystemTx ? 1 : 0;
-        // Full 0x7E envelope (encode()); extraTransactionHash = keccak of it verbatim so
-        // deposits are indexable by hash (eth_getTransactionByHash/Receipt) like any other tx.
-        auto encoded = encode();
-        tarsTx.extraTransactionBytes.reserve(encoded.size());
-        ::ranges::move(encoded, std::back_inserter(tarsTx.extraTransactionBytes));
-        auto const hash = bcos::crypto::keccak256Hash(bcos::ref(encoded));
-        tarsTx.extraTransactionHash.assign(hash.begin(), hash.end());
-        // Generic fields (so consumers on the tars generic read path don't see empty values)
-        tarsTx.data.to = to.has_value() ? to->hexPrefixed() : "";
-        tarsTx.data.input.reserve(data.size());
-        ::ranges::move(data, std::back_inserter(tarsTx.data.input));
-        tarsTx.data.value = bcos::toQuantity(value);
-        tarsTx.data.gasLimit = gasLimit;
-        tarsTx.data.nonce = "0x0";  // deposit nonce is always 0
-        tarsTx.data.chainID = "0";
-        return tarsTx;
-    }
-    bcostars::Transaction tarsTx{};
-    tarsTx.data.to = (this->to.has_value()) ? this->to.value().hexPrefixed() : "";
-    tarsTx.data.input.reserve(this->data.size());
-    ::ranges::move(this->data, std::back_inserter(tarsTx.data.input));
-
-    tarsTx.data.value = "0x" + this->value.str(0, std::ios_base::hex);
-    tarsTx.data.gasLimit = this->gasLimit;
-    // Use explicit range check rather than `>=` so that Deposit (0x7e) is excluded;
-    // EIP7702 is fee-market (maxFeePerGas/maxPriorityFeePerGas) so it is included
-    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559) &&
-        static_cast<uint8_t>(this->type) <= static_cast<uint8_t>(TransactionType::EIP7702))
-    {
-        tarsTx.data.maxFeePerGas = "0x" + this->maxFeePerGas.str(0, std::ios_base::hex);
-        tarsTx.data.maxPriorityFeePerGas =
-            "0x" + this->maxPriorityFeePerGas.str(0, std::ios_base::hex);
-    }
-    else
-    {
-        tarsTx.data.gasPrice = "0x" + this->maxPriorityFeePerGas.str(0, std::ios_base::hex);
-    }
-    tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
-    tarsTx.web3TypedTxKind = static_cast<tars::Char>(static_cast<uint8_t>(this->type));
-    if (!this->accessList.empty())
-    {
-        tarsTx.data.accessList.reserve(this->accessList.size());
-        for (auto const& entry : this->accessList)
-        {
-            bcostars::Web3AccessListEntry tarsEntry;
-            tarsEntry.account = entry.account.hex();
-            for (auto const& key : entry.storageKeys)
-            {
-                tarsEntry.storageKeys.emplace_back(key.begin(), key.end());
-            }
-            tarsTx.data.accessList.emplace_back(std::move(tarsEntry));
-        }
-    }
-
-    // EIP-4844 blob fields: without these the executor sees a type-3 tx with 0
-    // blobs, so no blob gas is charged (EEST test_blob_gas_subtraction fails).
-    if (this->maxFeePerBlobGas > 0)
-    {
-        tarsTx.data.maxFeePerBlobGas = "0x" + this->maxFeePerBlobGas.str(0, std::ios_base::hex);
-    }
-    for (auto const& h : this->blobVersionedHashes)
-    {
-        tarsTx.data.blobVersionedHashes.emplace_back(h.begin(), h.end());
-    }
-
-    // EIP-7702 authorization list (set_code tx, Prague+). The executor
-    // (bcosTransactionToEvmone) reads tx.authorizationList() from these entries.
-    if (!this->authorizationList.empty())
-    {
-        tarsTx.data.authorizationList.reserve(this->authorizationList.size());
-        for (auto const& entry : this->authorizationList)
-        {
-            bcostars::AuthorizationEntry tarsEntry;
-            // EIP-7702 chain_id is a 256-bit value (see Web3Transaction.h — it is part of
-            // the signed payload and must not be narrowed for the signing hash), but the
-            // protocol::Authorization / tars field can only carry 64 bits. No chain id above
-            // 64 bits can be this chain, so map EVERY such chain_id to UINT64_MAX — a value
-            // that is neither a real chain id nor the 0 = "any chain" wildcard — and let
-            // evmone skip the authorization on chain-id mismatch. (Mapping the low 64 bits
-            // instead would be unsafe: 2**64 + 1 truncates to 1 = Ethereum mainnet.) The
-            // entry must still be KEPT in the list: a set_code transaction with an empty
-            // authorization list is rejected by the executor, and dropping it would change
-            // the signing hash.
-            tarsEntry.chainID =
-                static_cast<int64_t>(entry.chainId > std::numeric_limits<uint64_t>::max() ?
-                                         UINT64_MAX :
-                                         static_cast<uint64_t>(entry.chainId));
-            tarsEntry.address = entry.address.hex();  // 40-char hex, no 0x prefix
-            tarsEntry.nonce = static_cast<int64_t>(entry.nonce);
-            tarsEntry.v = static_cast<tars::Char>(entry.yParity);
-            tarsEntry.r = "0x" + entry.r.str(0, std::ios_base::hex);
-            tarsEntry.s = "0x" + entry.s.str(0, std::ios_base::hex);
-            tarsTx.data.authorizationList.emplace_back(std::move(tarsEntry));
-        }
-    }
-
-    // Only call encodeForSign() once, store in extraTransactionBytes for TxValidator::verify()
-    auto encodedForSign = this->encodeForSign();
-    tarsTx.extraTransactionBytes.reserve(encodedForSign.size());
-    ::ranges::move(encodedForSign, std::back_inserter(tarsTx.extraTransactionBytes));
-
-    // FISCO BCOS signature is r||s||v
-    tarsTx.signature.reserve(crypto::SECP256K1_SIGNATURE_LEN);
-    ::ranges::move(this->signatureR, std::back_inserter(tarsTx.signature));
-    ::ranges::move(this->signatureS, std::back_inserter(tarsTx.signature));
-    tarsTx.signature.push_back(static_cast<tars::Char>(this->signatureV));
-
-    tarsTx.data.nonce = toQuantity(this->nonce);
-    tarsTx.data.chainID = std::to_string(this->chainId.value_or(0));
-
-    // dataHash and sender left empty — TxValidator::verify() computes them
-    return tarsTx;
-}
 std::ostream& operator<<(std::ostream& _out, const TransactionType& _in)
 {
     _out << magic_enum::enum_name(_in);

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.h
@@ -19,19 +19,27 @@
  */
 
 #pragma once
-#include "bcos-tars-protocol/protocol/TransactionImpl.h"
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-crypto/interfaces/crypto/CommonType.h>
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>
-#include <bcos-rpc/web3jsonrpc/utils/util.h>
-#include <bcos-tars-protocol/protocol/BlockFactoryImpl.h>
 #include <bcos-utilities/FixedBytes.h>
 #include <magic_enum/magic_enum.hpp>
 #include <optional>
 #include <ostream>
 #include <string_view>
+
+// Forward declaration only. takeToTarsTransaction() is the single member that touches tars, and
+// its definition lives in bcos-tars-protocol (protocol/Web3TarsBridge.cpp), which already links
+// rlp-protocol. Declaring the return type here rather than including the generated tars header
+// is what keeps this module free of any tars dependency, so modules below bcos-rpc -- the
+// admission layer above all -- can decode a signed Web3 envelope.
+namespace bcostars
+{
+struct Transaction;
+}
+
 namespace bcos
 {
 namespace rpc

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxHandler.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxHandler.cpp
@@ -1,6 +1,6 @@
-// bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.cpp
+// bcos-rlp-protocol/bcos-rlp-protocol/Web3TxHandler.cpp
 #include "Web3TxHandler.h"
-#include "Web3Transaction.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
 #include <bcos-utilities/DataConvertUtility.h>
 #include <bcos-utilities/Log.h>
 #include <cstddef>  // std::ptrdiff_t (ListEnd pointer arithmetic)

--- a/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxHandler.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/Web3TxHandler.h
@@ -1,4 +1,4 @@
-// bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3TxHandler.h
+// bcos-rlp-protocol/bcos-rlp-protocol/Web3TxHandler.h
 // ⚠️ isSystemTransaction encoding workaround: DepositTxHandler::encode() encodes it as uint32_t
 // (not uint8_t) because RLPEncode.h's generic uint8_t encoding odr-uses the non-template
 // toCompactBigEndian(byte, unsigned), defined only in DataConvertUtility.cpp (a pre-existing

--- a/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
+++ b/bcos-rpc/bcos-rpc/jsonrpc/JsonRpcImpl_2_0.cpp
@@ -28,9 +28,9 @@
 #include "bcos-framework/protocol/TransactionReceipt.h"
 #include "bcos-ledger/LedgerMethods.h"
 #include "bcos-protocol/TransactionStatus.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
 #include "bcos-rpc/jsonrpc/Common.h"
 #include "bcos-rpc/validator/CallValidator.h"
-#include "bcos-rpc/web3jsonrpc/model/Web3Transaction.h"
 #include "bcos-utilities/BoostLog.h"
 #include <json/value.h>
 #include <boost/algorithm/hex.hpp>

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EthEndpoint.cpp
@@ -37,6 +37,7 @@
 #include <bcos-ledger/mpt/MPTReadView.h>
 #include <bcos-ledger/mpt/Proof.h>
 #include <bcos-ledger/mpt/StorageValueCodec.h>
+#include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-rlp-protocol/Web3TxEnvelope.h>  // isTypedWeb3Envelope (envelope-sourced chainId gate)
 #include <bcos-rpc/Common.h>
 #include <bcos-rpc/util.h>
@@ -44,9 +45,9 @@
 #include <bcos-rpc/web3jsonrpc/model/CallRequest.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
-#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
 #include <bcos-rpc/web3jsonrpc/utils/util.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
+#include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/throw_exception.hpp>
 #include <cstdint>
@@ -54,7 +55,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-#include <boost/algorithm/string.hpp>
 
 using namespace bcos;
 using namespace bcos::rpc;

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/ReceiptResponse.cpp
@@ -1,7 +1,7 @@
 #include "ReceiptResponse.h"
 #include "Log.h"
-#include "Web3Transaction.h"
 #include "bcos-crypto/ChecksumAddress.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/DataConvertUtility.h"
 #include <bcos-crypto/hash/Keccak256.h>

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/TransactionResponse.cpp
@@ -1,6 +1,6 @@
 #include "TransactionResponse.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
 #include "bcos-rpc/web3jsonrpc/model/DepositTransaction.h"
-#include "bcos-rpc/web3jsonrpc/model/Web3Transaction.h"
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-rpc/jsonrpc/Common.h>  // WEB3_LOG
 

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -10,10 +10,10 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-crypto/ChecksumAddress.h>
+#include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-rpc/web3jsonrpc/model/BlockResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/ReceiptResponse.h>
 #include <bcos-rpc/web3jsonrpc/model/TransactionResponse.h>
-#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
 #include <bcos-utilities/DataConvertUtility.h>
 #include <boost/test/unit_test.hpp>
 

--- a/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3RpcTest.cpp
@@ -24,11 +24,11 @@
 #include <bcos-framework/engine/AnyEngineService.h>
 #include <bcos-framework/testutils/faker/FakeLedger.h>
 #include <bcos-mempool/MemPoolImpl.h>
+#include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-rpc/filter/LogMatcher.h>
 #include <bcos-rpc/jwtAuth/JwtConfig.h>
 #include <bcos-rpc/jwtAuth/JwtVerifier.h>
 #include <bcos-rpc/web3jsonrpc/model/Web3FilterRequest.h>
-#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
 #include <bcos-task/Task.h>
 #include <boost/test/unit_test.hpp>
 #include <atomic>
@@ -626,21 +626,21 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadVersion.has_value());
     BOOST_TEST(*testEngineService.m_state->capturedNewPayloadVersion == 4);
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload
-                      .withdrawalsRoot.has_value());
+            .withdrawalsRoot.has_value());
     BOOST_REQUIRE(
         testEngineService.m_state->capturedNewPayloadRequest->executionRequests.has_value());
     BOOST_TEST(testEngineService.m_state->capturedNewPayloadRequest->executionRequests->empty());
     BOOST_TEST(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.transactions
                    .size() == 1);
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals
-                      .has_value());
+            .has_value());
     BOOST_TEST(
         testEngineService.m_state->capturedNewPayloadRequest->executionPayload.withdrawals->front()
             .amount == expectedLargeValue);
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed
-                      .has_value());
+            .has_value());
     BOOST_REQUIRE(testEngineService.m_state->capturedNewPayloadRequest->executionPayload
-                      .excessBlobGas.has_value());
+            .excessBlobGas.has_value());
     BOOST_TEST(
         *testEngineService.m_state->capturedNewPayloadRequest->executionPayload.blobGasUsed ==
         expectedLargeValue);
@@ -650,8 +650,8 @@ BOOST_AUTO_TEST_CASE(handleEngineV2PayloadParsingAndSerializationTest)
 
     // Raw-bytes carrier: newPayload preserves the wire bytes verbatim (no decoding).
     BOOST_TEST(toHexStringWithPrefix(testEngineService.m_state->capturedNewPayloadRequest
-                                         ->executionPayload.transactions.front()
-                                         .raw) == encodedTxHex);
+                       ->executionPayload.transactions.front()
+                       .raw) == encodedTxHex);
 
     testEngineService.m_state->getPayloadResult->executionPayload =
         testEngineService.m_state->capturedNewPayloadRequest->executionPayload;

--- a/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3TypeTest.cpp
@@ -20,9 +20,9 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-crypto/signature/secp256k1/Secp256k1Crypto.h>  // c_secp256k1n* + Secp256k1Crypto
+#include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-rlp-protocol/Web3TxEnvelope.h>  // web3ChainIdFromEnvelope (F4 unit tests)
-#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
-#include <bcos-rpc/web3jsonrpc/model/Web3TxHandler.h>
+#include <bcos-rlp-protocol/Web3TxHandler.h>
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/TransactionImpl.cpp
@@ -92,7 +92,7 @@ bcos::bytes bcostars::protocol::reassembleWeb3RawTransaction(
     bcos::bytesConstRef payload, bcos::bytesConstRef signature)
 {
     // The byte-splice logic mirrors Web3Transaction::encode() / txHash() in
-    // bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.h (the reference implementation used
+    // bcos-rlp-protocol/bcos-rlp-protocol/Web3Transaction.h (the reference implementation used
     // on the RPC ingress path). Keep the two in sync when adding new transaction types.
     //
     // NB: rlp free functions are fully qualified below -- TransactionImpl has member encode()/

--- a/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/protocol/Web3TarsBridge.cpp
@@ -1,0 +1,167 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Web3TarsBridge.cpp
+ * @brief Web3Transaction -> bcostars::Transaction projection.
+ * @date 2026/8/25
+ */
+
+// Web3Transaction lives in bcos-rlp-protocol, which must stay free of tars so that modules below
+// bcos-rpc can decode a signed Web3 envelope. takeToTarsTransaction() is its one member that
+// touches tars, so the declaration stays with the class (over a forward-declared
+// bcostars::Transaction) and the definition lives here, in the module that owns the tars types.
+// protocol-tars already links rlp-protocol, and every caller of this function necessarily links
+// protocol-tars -- it is what gives them a bcostars::Transaction to receive.
+//
+// Body moved verbatim from bcos-rpc/bcos-rpc/web3jsonrpc/model/Web3Transaction.cpp.
+
+#include "bcos-framework/protocol/Transaction.h"  // bcos::protocol::TransactionType
+#include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-tars-protocol/tars/Transaction.h"
+#include "bcos-utilities/Common.h"
+#include "bcos-utilities/DataConvertUtility.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <iterator>
+#include <range/v3/algorithm/move.hpp>
+
+namespace bcos::rpc
+{
+bcostars::Transaction Web3Transaction::takeToTarsTransaction()
+{
+    if (type == TransactionType::Deposit)
+    {
+        bcostars::Transaction tarsTx{};
+        tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+        tarsTx.web3TypedTxKind =
+            static_cast<tars::Char>(static_cast<uint8_t>(TransactionType::Deposit));
+        tarsTx.sourceHash = sourceHash.hex();
+        tarsTx.sender.assign(from.begin(), from.end());
+        // 0x-prefixed, matching the read side u256(...) (parsed in TransactionImpl.cpp mint())
+        tarsTx.mint = bcos::toQuantity(mint);
+        tarsTx.isSystemTransaction = isSystemTx ? 1 : 0;
+        // Full 0x7E envelope (encode()); extraTransactionHash = keccak of it verbatim so
+        // deposits are indexable by hash (eth_getTransactionByHash/Receipt) like any other tx.
+        auto encoded = encode();
+        tarsTx.extraTransactionBytes.reserve(encoded.size());
+        ::ranges::move(encoded, std::back_inserter(tarsTx.extraTransactionBytes));
+        auto const hash = bcos::crypto::keccak256Hash(bcos::ref(encoded));
+        tarsTx.extraTransactionHash.assign(hash.begin(), hash.end());
+        // Generic fields (so consumers on the tars generic read path don't see empty values)
+        tarsTx.data.to = to.has_value() ? to->hexPrefixed() : "";
+        tarsTx.data.input.reserve(data.size());
+        ::ranges::move(data, std::back_inserter(tarsTx.data.input));
+        tarsTx.data.value = bcos::toQuantity(value);
+        tarsTx.data.gasLimit = gasLimit;
+        tarsTx.data.nonce = "0x0";  // deposit nonce is always 0
+        tarsTx.data.chainID = "0";
+        return tarsTx;
+    }
+    bcostars::Transaction tarsTx{};
+    tarsTx.data.to = (this->to.has_value()) ? this->to.value().hexPrefixed() : "";
+    tarsTx.data.input.reserve(this->data.size());
+    ::ranges::move(this->data, std::back_inserter(tarsTx.data.input));
+
+    tarsTx.data.value = "0x" + this->value.str(0, std::ios_base::hex);
+    tarsTx.data.gasLimit = this->gasLimit;
+    // Use explicit range check rather than `>=` so that Deposit (0x7e) is excluded;
+    // EIP7702 is fee-market (maxFeePerGas/maxPriorityFeePerGas) so it is included
+    if (static_cast<uint8_t>(this->type) >= static_cast<uint8_t>(TransactionType::EIP1559) &&
+        static_cast<uint8_t>(this->type) <= static_cast<uint8_t>(TransactionType::EIP7702))
+    {
+        tarsTx.data.maxFeePerGas = "0x" + this->maxFeePerGas.str(0, std::ios_base::hex);
+        tarsTx.data.maxPriorityFeePerGas =
+            "0x" + this->maxPriorityFeePerGas.str(0, std::ios_base::hex);
+    }
+    else
+    {
+        tarsTx.data.gasPrice = "0x" + this->maxPriorityFeePerGas.str(0, std::ios_base::hex);
+    }
+    tarsTx.type = static_cast<tars::Char>(bcos::protocol::TransactionType::Web3Transaction);
+    tarsTx.web3TypedTxKind = static_cast<tars::Char>(static_cast<uint8_t>(this->type));
+    if (!this->accessList.empty())
+    {
+        tarsTx.data.accessList.reserve(this->accessList.size());
+        for (auto const& entry : this->accessList)
+        {
+            bcostars::Web3AccessListEntry tarsEntry;
+            tarsEntry.account = entry.account.hex();
+            for (auto const& key : entry.storageKeys)
+            {
+                tarsEntry.storageKeys.emplace_back(key.begin(), key.end());
+            }
+            tarsTx.data.accessList.emplace_back(std::move(tarsEntry));
+        }
+    }
+
+    // EIP-4844 blob fields: without these the executor sees a type-3 tx with 0
+    // blobs, so no blob gas is charged (EEST test_blob_gas_subtraction fails).
+    if (this->maxFeePerBlobGas > 0)
+    {
+        tarsTx.data.maxFeePerBlobGas = "0x" + this->maxFeePerBlobGas.str(0, std::ios_base::hex);
+    }
+    for (auto const& h : this->blobVersionedHashes)
+    {
+        tarsTx.data.blobVersionedHashes.emplace_back(h.begin(), h.end());
+    }
+
+    // EIP-7702 authorization list (set_code tx, Prague+). The executor
+    // (bcosTransactionToEvmone) reads tx.authorizationList() from these entries.
+    if (!this->authorizationList.empty())
+    {
+        tarsTx.data.authorizationList.reserve(this->authorizationList.size());
+        for (auto const& entry : this->authorizationList)
+        {
+            bcostars::AuthorizationEntry tarsEntry;
+            // EIP-7702 chain_id is a 256-bit value (see Web3Transaction.h — it is part of
+            // the signed payload and must not be narrowed for the signing hash), but the
+            // protocol::Authorization / tars field can only carry 64 bits. No chain id above
+            // 64 bits can be this chain, so map EVERY such chain_id to UINT64_MAX — a value
+            // that is neither a real chain id nor the 0 = "any chain" wildcard — and let
+            // evmone skip the authorization on chain-id mismatch. (Mapping the low 64 bits
+            // instead would be unsafe: 2**64 + 1 truncates to 1 = Ethereum mainnet.) The
+            // entry must still be KEPT in the list: a set_code transaction with an empty
+            // authorization list is rejected by the executor, and dropping it would change
+            // the signing hash.
+            tarsEntry.chainID =
+                static_cast<int64_t>(entry.chainId > std::numeric_limits<uint64_t>::max() ?
+                                         UINT64_MAX :
+                                         static_cast<uint64_t>(entry.chainId));
+            tarsEntry.address = entry.address.hex();  // 40-char hex, no 0x prefix
+            tarsEntry.nonce = static_cast<int64_t>(entry.nonce);
+            tarsEntry.v = static_cast<tars::Char>(entry.yParity);
+            tarsEntry.r = "0x" + entry.r.str(0, std::ios_base::hex);
+            tarsEntry.s = "0x" + entry.s.str(0, std::ios_base::hex);
+            tarsTx.data.authorizationList.emplace_back(std::move(tarsEntry));
+        }
+    }
+
+    // Only call encodeForSign() once, store in extraTransactionBytes for TxValidator::verify()
+    auto encodedForSign = this->encodeForSign();
+    tarsTx.extraTransactionBytes.reserve(encodedForSign.size());
+    ::ranges::move(encodedForSign, std::back_inserter(tarsTx.extraTransactionBytes));
+
+    // FISCO BCOS signature is r||s||v
+    tarsTx.signature.reserve(crypto::SECP256K1_SIGNATURE_LEN);
+    ::ranges::move(this->signatureR, std::back_inserter(tarsTx.signature));
+    ::ranges::move(this->signatureS, std::back_inserter(tarsTx.signature));
+    tarsTx.signature.push_back(static_cast<tars::Char>(this->signatureV));
+
+    tarsTx.data.nonce = toQuantity(this->nonce);
+    tarsTx.data.chainID = std::to_string(this->chainId.value_or(0));
+
+    // dataHash and sender left empty — TxValidator::verify() computes them
+    return tarsTx;
+}
+}  // namespace bcos::rpc

--- a/transaction-executor/tests/Web3AccessListResolverTest.cpp
+++ b/transaction-executor/tests/Web3AccessListResolverTest.cpp
@@ -14,7 +14,7 @@
 #include <bcos-codec/rlp/RLPDecode.h>
 #include <bcos-crypto/hash/Keccak256.h>
 #include <bcos-framework/storage2/MemoryStorage.h>
-#include <bcos-rpc/web3jsonrpc/model/Web3Transaction.h>
+#include <bcos-rlp-protocol/Web3Transaction.h>
 #include <bcos-tars-protocol/protocol/BlockHeaderImpl.h>
 #include <bcos-tars-protocol/protocol/TransactionImpl.h>
 #include <bcos-utilities/DataConvertUtility.h>


### PR DESCRIPTION
### Motivation

The transaction admission layer has to decode a signed Web3 envelope (`extraTransactionBytes`) to check anything about a Web3 transaction. Today the only decoder lives in `bcos-rpc`, and `rpc` links `txpool` — so nothing `txpool` links can reach it without a dependency cycle.

`Web3Transaction` is the Ethereum-transaction counterpart of `EthBlockHeader`, which already sits in `bcos-rlp-protocol` under the file comment *"Pure RLP bridge"*. That module links only `bcos-crypto codec bcos-framework` and has no tars dependency, which is exactly the property the admission layer needs.

This PR only moves code. No behaviour change.

### What changed

Moved verbatim — git records all four as renames:

| File | From | To |
|---|---|---|
| `Web3Transaction.{h,cpp}` | `bcos-rpc/web3jsonrpc/model` | `bcos-rlp-protocol` |
| `Web3TxHandler.{h,cpp}` | `bcos-rpc/web3jsonrpc/model` | `bcos-rlp-protocol` |

`Web3TxHandler` was already free of tars and rpc dependencies (added in #5463), so it moved as-is.

`Web3Transaction` had exactly one member touching tars: `takeToTarsTransaction()`. Rather than rewrite it into a free function and change every call site, **its declaration stays with the class** over a forward-declared `bcostars::Transaction`, and the body moves verbatim to `bcos-tars-protocol/protocol/Web3TarsBridge.cpp`. `protocol-tars` already links `rlp-protocol`, and every caller of that function necessarily links `protocol-tars` — that is what gives them a `bcostars::Transaction` to receive. So `web3Tx.takeToTarsTransaction()` still compiles unchanged everywhere, and `bcos-rlp-protocol` gains no tars dependency: it carries a forward declaration and nothing more.

Consumers only change their include path (7 files). Two stale path comments are updated, and the `#include <bcos-rpc/jsonrpc/Common.h>` the moved `.cpp` no longer needs is dropped.

Two deliberate deviations worth calling out:

- **Filenames keep the `Web3*` spelling.** Renaming on top of moving would defeat git's rename detection and make the diff unreviewable — and `Web3TxEnvelope.{h,cpp}` already uses this spelling in the same directory.
- **`Web3TypeTest.cpp` stays in `bcos-rpc/test`.** It is a `BOOST_FIXTURE_TEST_SUITE` over `RPCFixture`, so moving it would drag the whole rpc stack into the rlp-protocol test target. It already exercises the moved code through the new include path, which is the evidence that matters.

### Test

Behaviour-neutral, so the evidence is that the existing suites pass with the code relocated:

```
cmake --build build --target rpc protocol-tars rlp-protocol executor \
      test-bcos-rpc test-bcos-rlp-protocol          -> all built clean

./build/bcos-rpc/test/test-bcos-rpc                   -> No errors detected
./build/bcos-rlp-protocol/test/test-bcos-rlp-protocol -> No errors detected
```

`test-bcos-rpc` includes `testWeb3Type` (952 lines of encode/decode/signature vectors) and `Web3ResponseTest`, which drives `takeToTarsTransaction` for every Web3 kind — i.e. both halves of the split are covered.

Each moved and new `.cpp` was additionally compiled **standalone** with its target's real flags, bypassing the unity batching that can hide a missing include. That check caught a missing `bcos-framework/protocol/Transaction.h` in `Web3TarsBridge.cpp` (fixed here) — the normal build was green without it, because CMake had batched the file with siblings that already pulled that header in.

The same check reports a **pre-existing** failure for `Web3TxHandler.cpp`: it does not compile standalone on the base commit either (an ADL issue reaching `bcos-codec`'s `lengthOfItems`, i.e. it only ever compiles inside a unity batch). Untouched by this move and deliberately left alone here.

### Note on overlap

`#5477` hardens the old `TxValidator` with envelope-keyed deposit / reserved-type / chainId gates. It touches different files and does not conflict with this move.