### PR TITLE
feat(tx-validator): make the signed envelope authoritative for Web3 transactions

### DIFF
--- a/bcos-protocol/bcos-protocol/TransactionStatus.h
+++ b/bcos-protocol/bcos-protocol/TransactionStatus.h
@@ -69,6 +69,23 @@ enum class TransactionStatus : int32_t
     SenderNoEOA = 10014,
     InsufficientFunds = 10015,
     BlobTxNotAllowed = 10016,  ///< blob (EIP-4844) txs parse but are never admitted on L2
+    /// Envelope type is deposit(0x7e) or reserved, or the type is not yet enabled by the chain's
+    /// EVM revision. Blob envelopes have their own code above; they are refused by the same
+    /// classifier but the distinction is worth keeping, since a blob is well-formed and simply
+    /// not admitted here.
+    TxTypeNotSupported = 10017,
+    /// EIP-1559/7702: maxPriorityFeePerGas exceeds maxFeePerGas.
+    TipGreaterThanFeeCap = 10018,
+    /// EIP-7702: a set-code transaction must have a `to` address.
+    CreateSetCodeTx = 10019,
+    /// EIP-7702: the authorization list must not be empty.
+    EmptyAuthorizationList = 10020,
+    /// EIP-2681: the sender account nonce has reached 2^64-1.
+    NonceHasMaxValue = 10021,
+    /// The transaction's fee cap is below the chain's base fee (tx_gas_price).
+    FeeCapLessThanBaseFee = 10022,
+    /// gasLimit exceeds the per-transaction cap (tx_gas_limit, or the Osaka constant cap).
+    MaxGasLimitExceeded = 10023,
 };
 
 inline std::ostream& operator<<(std::ostream& _out, bcos::protocol::TransactionStatus const& _er)
@@ -188,6 +205,27 @@ inline std::ostream& operator<<(std::ostream& _out, bcos::protocol::TransactionS
         break;
     case TransactionStatus::InsufficientFunds:
         _out << "InsufficientFunds";
+        break;
+    case TransactionStatus::TxTypeNotSupported:
+        _out << "TxTypeNotSupported";
+        break;
+    case TransactionStatus::TipGreaterThanFeeCap:
+        _out << "TipGreaterThanFeeCap";
+        break;
+    case TransactionStatus::CreateSetCodeTx:
+        _out << "CreateSetCodeTx";
+        break;
+    case TransactionStatus::EmptyAuthorizationList:
+        _out << "EmptyAuthorizationList";
+        break;
+    case TransactionStatus::NonceHasMaxValue:
+        _out << "NonceHasMaxValue";
+        break;
+    case TransactionStatus::FeeCapLessThanBaseFee:
+        _out << "FeeCapLessThanBaseFee";
+        break;
+    case TransactionStatus::MaxGasLimitExceeded:
+        _out << "MaxGasLimitExceeded";
         break;
     case TransactionStatus::AlreadyInTxPoolAndAccept:
         _out << "AlreadyInTxPoolAndAccept";

--- a/bcos-protocol/test/unittests/TransactionStatusTest.cpp
+++ b/bcos-protocol/test/unittests/TransactionStatusTest.cpp
@@ -61,6 +61,15 @@ constexpr Expectation kExpectations[] = {
     {TransactionStatus::MaxInitCodeSizeExceeded, "MaxInitCodeSizeExceeded"},
     {TransactionStatus::SenderNoEOA, "SenderNoEOA"},
     {TransactionStatus::InsufficientFunds, "InsufficientFunds"},
+    // #5520 added the code and its operator<< case but no expectation here.
+    {TransactionStatus::BlobTxNotAllowed, "BlobTxNotAllowed"},
+    {TransactionStatus::TxTypeNotSupported, "TxTypeNotSupported"},
+    {TransactionStatus::TipGreaterThanFeeCap, "TipGreaterThanFeeCap"},
+    {TransactionStatus::CreateSetCodeTx, "CreateSetCodeTx"},
+    {TransactionStatus::EmptyAuthorizationList, "EmptyAuthorizationList"},
+    {TransactionStatus::NonceHasMaxValue, "NonceHasMaxValue"},
+    {TransactionStatus::FeeCapLessThanBaseFee, "FeeCapLessThanBaseFee"},
+    {TransactionStatus::MaxGasLimitExceeded, "MaxGasLimitExceeded"},
 };
 }  // namespace
 

--- a/bcos-tx-validator/CMakeLists.txt
+++ b/bcos-tx-validator/CMakeLists.txt
@@ -15,12 +15,24 @@ target_include_directories(bcos-tx-validator PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-tx-validator>)
 
-# The nonce checkers moved here from bcos-txpool: they are admission state, and the pool is not
-# the only ingress that needs them. Deliberately NOT linking any transaction pool -- the
-# dependency runs the other way, and a cycle would make the split pointless.
+# rlp-protocol decodes the signed envelope; protocol-tars is where the mirror lives and is the
+# only way to write it -- protocol::Transaction exposes no setter for a business field, by
+# design (it is an immutable-after-signing value object). `ledger` supplies getSystemConfig and
+# LedgerMethods; TBB backs the nonce checkers' BucketMap.
+#
+# Deliberately NOT linking either transaction pool: the nonce checkers live here now and the
+# dependency runs one way, from the pools to this module. A cycle would make the split
+# pointless. No intx either: the 512-bit balance arithmetic uses bcos::u512 from
+# bcos-utilities, which bcos-framework already propagates.
 target_link_libraries(bcos-tx-validator PUBLIC
-    bcos-framework bcos-protocol ledger TBB::tbb)
+    bcos-framework bcos-protocol bcos-crypto ledger rlp-protocol protocol-tars TBB::tbb)
 set_target_properties(bcos-tx-validator PROPERTIES UNITY_BUILD "ON")
+
+if(TESTS)
+    enable_testing()
+    set(CTEST_OUTPUT_ON_FAILURE TRUE)
+    add_subdirectory(test)
+endif()
 
 include(GNUInstallDirs)
 install(TARGETS bcos-tx-validator EXPORT fiscobcosTargets ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/bcos-tx-validator/bcos-tx-validator/Normalize.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/Normalize.cpp
@@ -1,0 +1,205 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Normalize.cpp
+ * @date 2026/8/25
+ */
+
+#include "bcos-tx-validator/Normalize.h"
+#include "bcos-crypto/hash/Keccak256.h"
+#include "bcos-framework/engine/RawTransactionDispatch.h"
+#include "bcos-framework/protocol/Protocol.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include "bcos-tars-protocol/protocol/Web3RawTransaction.h"
+#include "bcos-utilities/BoostLog.h"
+#include <boost/exception/diagnostic_information.hpp>
+#include <cstring>
+
+using namespace bcos;
+using namespace bcos::protocol;
+
+namespace bcos::txvalidator
+{
+namespace
+{
+constexpr auto kBcosType = static_cast<uint8_t>(TransactionType::BCOSTransaction);
+constexpr auto kWeb3Type = static_cast<uint8_t>(TransactionType::Web3Transaction);
+
+/// keccak256 of the re-assembled signed transaction, i.e. the canonical Ethereum tx hash.
+/// Derived only from the envelope and the signature, never from the mirror -- which is the whole
+/// point: it is a value the forger cannot move without invalidating the signature.
+std::optional<crypto::HashType> canonicalHash(Transaction const& tx)
+{
+    try
+    {
+        auto raw = bcostars::protocol::reassembleWeb3RawTransaction(
+            tx.extraTransactionBytes(), tx.signatureData());
+        return crypto::keccak256Hash(bcos::ref(raw));
+    }
+    catch (std::exception const& e)
+    {
+        // A malformed envelope or a signature that is not 65 bytes. Both mean the transaction
+        // cannot be authenticated at all.
+        BCOS_LOG(DEBUG) << LOG_BADGE("TXVALIDATOR") << LOG_DESC("canonical hash recompute failed")
+                        << LOG_KV("reason", boost::diagnostic_information(e));
+        return std::nullopt;
+    }
+}
+}  // namespace
+
+TransactionStatus normalize(Transaction& tx)
+{
+    // Step 0 -- outer type whitelist. An outer `type` outside the known set is neither a valid
+    // BCOS transaction nor something to run Web3 normalization on; letting it through would
+    // carry undefined semantics down the whole pipeline.
+    auto const outerType = tx.type();
+    if (outerType != kBcosType && outerType != kWeb3Type) [[unlikely]]
+    {
+        return TransactionStatus::Malformed;
+    }
+    if (outerType == kBcosType)
+    {
+        // dataHash covers TransactionData (field 1), so the fields the signature protects and
+        // the fields execution reads are the same bytes there.
+        //
+        // It does NOT cover the outer fields. `attribute` (field 5) in particular sits outside
+        // it and BlockExecutive reads it to route into the Liquid path and to change DAG
+        // scheduling -- the same field this function zeroes for Web3 below. That is a
+        // pre-existing exposure for BCOS transactions, not one this module introduces, and it is
+        // left alone deliberately: the SDK legitimately sets `attribute` on BCOS transactions,
+        // so zeroing it here would break them. Stated rather than papered over.
+        return TransactionStatus::None;
+    }
+
+    // Step 1 -- classify the SIGNED envelope. Before the decode on purpose: the decoder's
+    // magic_enum::enum_cast does not know 0x7e, so a deposit would come back as Malformed rather
+    // than TxTypeNotSupported. 0x03 has the opposite problem -- it IS in the enum (EIP4844), so
+    // the decoder would happily accept it instead of reporting BlobTxNotAllowed. Neither is
+    // fixable by tuning decoder error codes.
+    auto const payload = tx.extraTransactionBytes();
+    switch (engine::dispatchRawTransaction(payload))
+    {
+    case engine::RawTransactionKind::Blob:
+        // Same classifier and same verdict as the pool-side gate #5520 added, so the same code:
+        // a blob envelope is well-formed and simply never admitted here.
+        return TransactionStatus::BlobTxNotAllowed;
+    case engine::RawTransactionKind::Deposit:
+        // Deposits reach a node through the Engine newPayload path, where their trust anchor is
+        // sourceHash. One arriving through a transaction pool is forged by construction: it
+        // carries no signature and the pool never checks sourceHash.
+        //
+        // #5520's gate reports this as InvalidChainId, reached through the chainId classifier
+        // rather than this one. That is a less accurate answer -- its own comment says deposits
+        // have no chainId -- so this reports the type, not a chainId that was never there. The
+        // wiring PR that replaces that gate carries the change in observable status.
+        return TransactionStatus::TxTypeNotSupported;
+    case engine::RawTransactionKind::Unsupported:
+        return TransactionStatus::Malformed;
+    default:
+        break;
+    }
+
+    // Step 2 -- the wire-supplied hash, before anything can overwrite it.
+    //
+    // Pointer cast, not a reference cast: normalize() is reachable from admit(), whose contract
+    // is "return a status; throw only when the data needed to decide is unavailable". A
+    // reference cast against a Transaction that is not the tars implementation (another
+    // implementation, a test double) throws std::bad_cast, and neither admit() nor
+    // TransactionSync::importDownloadedTxs catches it -- a type mismatch would terminate the
+    // process instead of rejecting one transaction. The same pointer is reused for the commit
+    // below, so the cast happens once.
+    auto* impl = dynamic_cast<bcostars::protocol::TransactionImpl*>(&tx);
+    if (impl == nullptr) [[unlikely]]
+    {
+        // Web3 normalization needs the tars mirror; without it there is nothing to reconcile
+        // the signed envelope against, so fail closed rather than admit an unchecked mirror.
+        return TransactionStatus::Malformed;
+    }
+    auto const wireHash = impl->inner().extraTransactionHash;
+
+    // Step 3 -- decode the envelope. This is the authoritative content of the transaction.
+    rpc::Web3Transaction decoded;
+    auto payloadRef = bcos::bytesRef(const_cast<bcos::byte*>(payload.data()), payload.size());
+    if (auto error = codec::rlp::decodeFromPayload(payloadRef, decoded); error != nullptr)
+        [[unlikely]]
+    {
+        return TransactionStatus::Malformed;
+    }
+
+    // Step 4 -- recompute and compare. Still no mutation.
+    auto const recomputed = canonicalHash(tx);
+    if (!recomputed.has_value()) [[unlikely]]
+    {
+        return TransactionStatus::InvalidSignature;
+    }
+    // memcmp, not std::equal: the tars field is vector<tars::Char> (SIGNED char) while the hash
+    // is unsigned bytes. An element-wise == promotes both to int, so every byte >= 0x80 compares
+    // negative-against-positive and no genuine hash would ever match.
+    if (!wireHash.empty() &&
+        (wireHash.size() != recomputed->size() ||
+            std::memcmp(wireHash.data(), recomputed->data(), wireHash.size()) != 0)) [[unlikely]]
+    {
+        // The peer committed to a different transaction than the one it sent.
+        return TransactionStatus::InvalidSignature;
+    }
+
+    // Step 5 -- commit. Everything below is infallible.
+    auto& mutableInner = impl->mutableInner();
+
+    // takeToTarsTransaction produces a fresh struct whose `data` holds exactly the envelope's
+    // values and leaves every other TransactionData field default-constructed. Moving the whole
+    // sub-struct therefore covers both buckets at once -- authoritative fields get the signed
+    // value, and the ones a Web3 transaction must not carry (abi, extension, groupID,
+    // blockLimit, version, maxFeePerBlobGas, blobVersionedHashes) go back to their defaults.
+    // Assigning field by field would silently miss the next field added to TransactionData,
+    // which is exactly how #5364 came about.
+    auto rebuilt = decoded.takeToTarsTransaction();
+    mutableInner.data = std::move(rebuilt.data);
+    mutableInner.web3TypedTxKind = rebuilt.web3TypedTxKind;
+
+    // Outer fields that are not covered by the signature and that a Web3 transaction has no
+    // legitimate use for. `attribute` is the one with execution consequences: BlockExecutive
+    // reads LIQUID_SCALE_CODEC / LIQUID_CREATE to route a transaction into the Liquid path and
+    // setCreate, and DAG to change parallel scheduling. takeToTarsTransaction never sets it, so
+    // for anything that arrived over RPC this is already 0 and zeroing is a no-op; for anything
+    // that arrived over P2P it closes a path to changing execution semantics.
+    mutableInner.attribute = 0;
+    mutableInner.extraData.clear();
+    // Deposit-only mirrors. Deposits are rejected in step 1, so these can only be leftovers.
+    mutableInner.sourceHash.clear();
+    mutableInner.mint.clear();
+    mutableInner.isSystemTransaction = 0;
+
+    mutableInner.extraTransactionHash.assign(recomputed->begin(), recomputed->end());
+    // Dead for Web3 -- hash() reads extraTransactionHash, not this -- but it is an arbitrary,
+    // unsigned, uncharged byte string that would otherwise ride into a block and into storage.
+    // Cleared rather than left, so that every one of the 14 outer fields is accounted for below.
+    mutableInner.dataHash.clear();
+
+    // Every outer field of bcostars::Transaction is accounted for, because the argument for
+    // rebuilding rather than field-by-field assignment is that enumeration is what rots:
+    //
+    //   rebuilt from the envelope: data (1), extraTransactionHash (11), web3TypedTxKind (12)
+    //   reset:                     attribute (5), extraData (8), dataHash (2), sourceHash (13),
+    //                              mint (14), isSystemTransaction (15)
+    //   preserved:                 signature (3), importTime (4), sender (7), type (9),
+    //                              extraTransactionBytes (10) -- the authority itself
+    //
+    // plus the C++-side pool/consensus bookkeeping, none of which lives in the tars struct.
+    return TransactionStatus::None;
+}
+
+}  // namespace bcos::txvalidator

--- a/bcos-tx-validator/bcos-tx-validator/Normalize.cpp
+++ b/bcos-tx-validator/bcos-tx-validator/Normalize.cpp
@@ -126,13 +126,27 @@ TransactionStatus normalize(Transaction& tx)
     {
         // Web3 normalization needs the tars mirror; without it there is nothing to reconcile
         // the signed envelope against, so fail closed rather than admit an unchecked mirror.
+        //
+        // The only branch here that logs, and the only one that is not about the input: every
+        // other rejection returns a distinct status the caller reports. This one means some
+        // caller is passing a Transaction implementation this module cannot read, which would
+        // otherwise present as every transaction failing as Malformed with nothing to debug.
+        BCOS_LOG(WARNING) << LOG_BADGE("TXVALIDATOR")
+                          << LOG_DESC("normalize() got a non-tars Transaction; wiring error");
         return TransactionStatus::Malformed;
     }
     auto const wireHash = impl->inner().extraTransactionHash;
 
     // Step 3 -- decode the envelope. This is the authoritative content of the transaction.
+    // Decoded from a COPY, not through a const_cast over tx.extraTransactionBytes(). That
+    // buffer is the only thing the signature covers, and decodeFromPayload takes a mutable
+    // bytesRef because decodeHeader crops the header off the cursor as it parses --
+    // reassembleWeb3RawTransaction copies for the same reason and says so. The copy is paid for
+    // again inside canonicalHash() on the next line; this adds one buffer, not a new order of
+    // cost.
     rpc::Web3Transaction decoded;
-    auto payloadRef = bcos::bytesRef(const_cast<bcos::byte*>(payload.data()), payload.size());
+    bcos::bytes preimage(payload.begin(), payload.end());
+    auto payloadRef = bcos::bytesRef(preimage.data(), preimage.size());
     if (auto error = codec::rlp::decodeFromPayload(payloadRef, decoded); error != nullptr)
         [[unlikely]]
     {

--- a/bcos-tx-validator/bcos-tx-validator/Normalize.h
+++ b/bcos-tx-validator/bcos-tx-validator/Normalize.h
@@ -75,11 +75,32 @@ namespace bcos::txvalidator
 /// matters: a half-normalized transaction whose mirror was overwritten but whose hash check then
 /// failed would otherwise be handed back to a caller holding only a status code.
 ///
-/// CALL ORDERING (P2P)
+/// WHERE TO CALL IT
 ///
-/// On the sync path this must run BEFORE Transaction::clearSenderAndHash(), which zeroes
-/// extraTransactionHash. Run afterwards, step 4 compares against an empty value and always
-/// passes -- and P2P is the only attack surface for a forged hash.
+/// On the untrusted ingress -- the peer-response path in bcos-txpool's TransactionSync -- and
+/// before ANY read of tx->hash() there, because for a Web3 transaction TransactionImpl::hash()
+/// returns the peer-supplied extraTransactionHash verbatim. There are two such reads, in this
+/// order:
+///
+///   1. verifyFetchedTxs, `expectedHash != tx->hash()` -- the gate that checks the peer sent
+///      the transactions we asked for.
+///   2. importDownloadedTxs, `m_config->txpoolStorage()->exists(tx->hash())` -- the dedup
+///      lookup, nine lines above the clearSenderAndHash() that drops the wire hash.
+///
+/// So the call site is in verifyFetchedTxs, ahead of (1) -- not inside importDownloadedTxs,
+/// which would still let a forged hash through (1). Naming clearSenderAndHash() as the
+/// constraint is likewise not enough: normalize() placed between (2) and it satisfies "before
+/// clearSenderAndHash" while (2) still keys on a hash the peer chose. Once clearSenderAndHash()
+/// has run there is nothing left for step 4 to compare against.
+///
+/// importDownloadedTxs is also reached from onGetMissedTxsFromLedger, where the transactions
+/// come from the local ledger and none of this applies.
+///
+/// Not on the RPC ingress. There the tars mirror was built by takeToTarsTransaction() from
+/// these exact envelope bytes inside the same call, so steps 3-5 provably reproduce what is
+/// already in the struct -- a second RLP decode, a second keccak256 and a full re-projection
+/// for a no-op. The forgery this defends against needs an attacker who can hand over a mirror
+/// and an envelope that disagree, which the RPC path does not let anyone do.
 ///
 /// @return None on success. Otherwise the transaction is unchanged.
 protocol::TransactionStatus normalize(protocol::Transaction& tx);

--- a/bcos-tx-validator/bcos-tx-validator/Normalize.h
+++ b/bcos-tx-validator/bcos-tx-validator/Normalize.h
@@ -1,0 +1,87 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Normalize.h
+ * @brief Make a Web3 transaction's tars mirror equal to what its signature actually covers.
+ * @date 2026/8/25
+ */
+
+#pragma once
+
+#include "bcos-framework/protocol/Transaction.h"
+#include "bcos-protocol/TransactionStatus.h"
+
+namespace bcos::txvalidator
+{
+
+/// Rebuild a Web3 transaction's unauthenticated tars mirror from its signed envelope, and
+/// reject it if the wire-supplied transaction hash disagrees with the recomputed one.
+///
+/// WHY THIS EXISTS
+///
+/// A Web3 transaction's signature covers only `extraTransactionBytes` (tars field 10) --
+/// Transaction::verify() hashes exactly those bytes. Execution, however, reads the tars mirror:
+/// EthereumTransition's build_message takes tx.to() / tx.input() / tx.value(), all of which
+/// resolve to m_inner()->data.*. Nothing compares the two.
+///
+/// So a peer can take a victim's real transaction, keep field 3 (signature) and field 10
+/// (envelope) byte-for-byte, and rewrite data.to and data.value. Signature recovery still yields
+/// the victim; the canonical tx hash, being derived from the envelope, is still identical to the
+/// honest transaction's. The funds move to the attacker. The identical hash has a second effect:
+/// nodes that already cached the honest copy keep theirs (MemoryStorage dedups by hash) while
+/// nodes that did not accept the forgery -- the same hash executing two different transfers, i.e.
+/// a stateRoot split.
+///
+/// The same rewrite applies to web3TypedTxKind (mis-declaring a 1559 envelope as legacy to dodge
+/// type-keyed checks) and to `attribute`, whose LIQUID_SCALE_CODEC / LIQUID_CREATE / DAG bits
+/// change how BlockExecutive schedules and executes the transaction.
+///
+/// Issue #5364 is the narrow case of this for data.accessList, where the consequence is only gas
+/// divergence.
+///
+/// WHAT IT DOES
+///
+/// Six steps, order fixed:
+///   0. Outer tars `type` whitelist. BCOS transactions return None here and are not touched --
+///      their dataHash already covers the whole TransactionData, so signature and execution read
+///      the same bytes.
+///   1. Classify the envelope through engine::dispatchRawTransaction. Blob / deposit ->
+///      TxTypeNotSupported; unsupported or empty -> Malformed. This must run BEFORE the decode:
+///      the decoder does not know 0x7e, so classifying afterwards would report a deposit as
+///      Malformed instead.
+///   2. Read the wire-supplied extraTransactionHash.
+///   3. Decode the signed envelope.
+///   4. Recompute the canonical tx hash from (envelope, signature) and compare. A mismatch is
+///      InvalidSignature. An empty wire hash is accepted and filled in -- an older peer may
+///      simply not have set it (the BCOS branch in TransactionFactoryImpl has the same
+///      exemption).
+///   5. Only now write anything: replace the whole TransactionData with the values decoded from
+///      the envelope, zero the fields a Web3 transaction has no business carrying, and keep the
+///      local bookkeeping (signature, sender, importTime, type, batch state).
+///
+/// Steps 0-4 do not modify @p tx at all, so a rejected transaction is left byte-identical. That
+/// matters: a half-normalized transaction whose mirror was overwritten but whose hash check then
+/// failed would otherwise be handed back to a caller holding only a status code.
+///
+/// CALL ORDERING (P2P)
+///
+/// On the sync path this must run BEFORE Transaction::clearSenderAndHash(), which zeroes
+/// extraTransactionHash. Run afterwards, step 4 compares against an empty value and always
+/// passes -- and P2P is the only attack surface for a forged hash.
+///
+/// @return None on success. Otherwise the transaction is unchanged.
+protocol::TransactionStatus normalize(protocol::Transaction& tx);
+
+}  // namespace bcos::txvalidator

--- a/bcos-tx-validator/test/CMakeLists.txt
+++ b/bcos-tx-validator/test/CMakeLists.txt
@@ -1,0 +1,21 @@
+#------------------------------------------------------------------------------
+# Top-level CMake file for ut of bcos-tx-validator
+# ------------------------------------------------------------------------------
+# Copyright (C) 2026 FISCO BCOS.
+# SPDX-License-Identifier: Apache-2.0
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# ------------------------------------------------------------------------------
+file(GLOB_RECURSE SOURCES "unittests/*.cpp" "unittests/*.h")
+
+set(TEST_BINARY_NAME test-bcos-tx-validator)
+
+find_package(Boost REQUIRED unit_test_framework)
+
+add_executable(${TEST_BINARY_NAME} ${SOURCES})
+target_include_directories(${TEST_BINARY_NAME} PRIVATE . ${CMAKE_SOURCE_DIR})
+target_link_libraries(${TEST_BINARY_NAME} bcos-tx-validator Boost::unit_test_framework)
+add_test(NAME ${TEST_BINARY_NAME} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY} COMMAND ${TEST_BINARY_NAME})

--- a/bcos-tx-validator/test/unittests/NormalizeTest.cpp
+++ b/bcos-tx-validator/test/unittests/NormalizeTest.cpp
@@ -1,0 +1,361 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file NormalizeTest.cpp
+ * @brief Field-by-field forgery of the tars mirror on a genuinely signed transaction.
+ *
+ * Every case starts from a real signed raw transaction, projects it to tars exactly the way the
+ * RPC ingress path does, then rewrites ONE mirror field -- which is precisely what a malicious
+ * peer can do over P2P while leaving the signature and the signed envelope untouched.
+ *
+ * These cases cannot be written through the RPC entry point: a transaction that arrives there
+ * has its mirror built from the envelope, so mirror and envelope agree by construction and there
+ * is nothing to detect. The tars struct has to be built directly.
+ */
+
+#include "bcos-tx-validator/Normalize.h"
+#include "bcos-rlp-protocol/Web3Transaction.h"
+#include "bcos-tars-protocol/protocol/TransactionImpl.h"
+#include <bcos-crypto/hash/Keccak256.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <boost/test/unit_test.hpp>
+#include <memory>
+#include <string>
+
+using namespace bcos;
+using namespace bcos::protocol;
+using namespace bcos::txvalidator;
+
+namespace bcos::test
+{
+namespace
+{
+// Real signed transactions (same vectors the RLP suite round-trips).
+// EIP-1559, chainId 5, carries a non-empty accessList and an authorization-free payload.
+constexpr std::string_view kRaw1559 =
+    "0x02f8f805078502540be4008506fc23ac008357b58494811a752c8cd697e3cb27279c330ed1ada745a8d7881bc"
+    "16d674ec80000906ebaf477f83e051589c1188bcc6ddccdf872f85994de0b295669a9fd93d5f28d9ec85e40f4cb"
+    "697baef842a00000000000000000000000000000000000000000000000000000000000000003a0000000000000"
+    "0000000000000000000000000000000000000000000000000007d694bb9bc244d798123fde783fcc1c72d3bb8c"
+    "189413c080a036b241b061a36a32ab7fe86c7aa9eb592dd59018cd0443adc0903590c16b02b0a05edcc541b4741"
+    "c5cc6dd347c5ed9577ef293a62787b4510465fadbfe39ee4094";
+// Legacy EIP-155.
+constexpr std::string_view kRawLegacy =
+    "0xf89b0c8504a817c80082520894727fc6a68321b754475c668a6abfb6e9e71c169a888ac7230489e80000afa905"
+    "9cbb000000000213ed0f886efd100b67c7e4ec0a85a7d20dc971600000000000000000000015af1d78b58c40002"
+    "6a0be67e0a07db67da8d446f76add590e54b6e92cb6b8f9835aeb67540579a27717a02d690516512020171c1ec8"
+    "70f6ff45398cc8609250326be89915fb538e7bd718";
+
+/// Project a signed raw transaction to tars the way the RPC ingress does, then fill
+/// extraTransactionHash with the canonical hash (what calculateHash does on that path).
+std::shared_ptr<bcostars::protocol::TransactionImpl> makeSignedTx(std::string_view rawHex)
+{
+    auto raw = fromHexWithPrefix(rawHex);
+    auto ref = bcos::ref(raw);
+    rpc::Web3Transaction web3;
+    auto err = codec::rlp::decode(ref, web3);
+    BOOST_REQUIRE_MESSAGE(err == nullptr, "fixture must decode");
+
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>(
+        [inner = web3.takeToTarsTransaction()]() mutable { return &inner; });
+    crypto::Keccak256 hasher;
+    tx->calculateHash(hasher);
+    BOOST_REQUIRE(!tx->inner().extraTransactionHash.empty());
+    return tx;
+}
+
+std::string hexOf(std::vector<tars::Char> const& v)
+{
+    return toHex(std::string_view{v.data(), v.size()});
+}
+}  // namespace
+
+BOOST_AUTO_TEST_SUITE(NormalizeTest)
+
+// ---------------------------------------------------------------- mirror rewrites
+
+BOOST_AUTO_TEST_CASE(forgedRecipientIsReplacedByTheSignedOne)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto honestTo = tx->inner().data.to;
+    BOOST_REQUIRE(!honestTo.empty());
+
+    // The attack: keep signature and envelope, redirect the funds.
+    tx->mutableInner().data.to = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.to, honestTo);
+}
+
+BOOST_AUTO_TEST_CASE(forgedValueIsReplacedByTheSignedOne)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto honestValue = tx->inner().data.value;
+    tx->mutableInner().data.value = "0xffffffffffffffffffffffff";
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.value, honestValue);
+}
+
+BOOST_AUTO_TEST_CASE(forgedCalldataIsReplacedByTheSignedOne)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto honestInput = hexOf(tx->inner().data.input);
+    tx->mutableInner().data.input = {'\xca', '\xfe'};
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(hexOf(tx->inner().data.input), honestInput);
+}
+
+BOOST_AUTO_TEST_CASE(forgedNonceAndGasLimitAreReplacedByTheSignedOnes)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto honestNonce = tx->inner().data.nonce;
+    const auto honestGasLimit = tx->inner().data.gasLimit;
+    tx->mutableInner().data.nonce = "0x7fffffff";
+    tx->mutableInner().data.gasLimit = 1;
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.nonce, honestNonce);
+    BOOST_CHECK_EQUAL(tx->inner().data.gasLimit, honestGasLimit);
+}
+
+BOOST_AUTO_TEST_CASE(forgedFeeFieldsAreReplacedByTheSignedOnes)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto honestCap = tx->inner().data.maxFeePerGas;
+    const auto honestTip = tx->inner().data.maxPriorityFeePerGas;
+    tx->mutableInner().data.maxFeePerGas = "0x1";
+    tx->mutableInner().data.maxPriorityFeePerGas = "0x1";
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.maxFeePerGas, honestCap);
+    BOOST_CHECK_EQUAL(tx->inner().data.maxPriorityFeePerGas, honestTip);
+}
+
+// Issue #5364: the canonical txHash does not commit to data.accessList, so a peer can rewrite it
+// and change which slots are pre-warmed under EIP-2929 -- gas divergence between nodes.
+BOOST_AUTO_TEST_CASE(forgedAccessListIsReplacedByTheSignedOne)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto honestSize = tx->inner().data.accessList.size();
+    BOOST_REQUIRE_GT(honestSize, 0U);  // the fixture must actually carry one
+
+    bcostars::Web3AccessListEntry forged;
+    forged.account = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    tx->mutableInner().data.accessList = {forged};
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.accessList.size(), honestSize);
+    BOOST_CHECK(tx->inner().data.accessList[0].account != forged.account);
+}
+
+// The other half of #5364: an older peer that simply never populated the mirror field. Rebuilding
+// restores it; a field-by-field "mirror must equal envelope, else reject" check would drop the
+// transaction instead.
+BOOST_AUTO_TEST_CASE(strippedAccessListIsRestoredNotRejected)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto honestSize = tx->inner().data.accessList.size();
+    tx->mutableInner().data.accessList.clear();
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.accessList.size(), honestSize);
+}
+
+// Mis-declaring a 1559 envelope as legacy would dodge every check keyed on the mirror kind
+// (tip-vs-cap above all).
+BOOST_AUTO_TEST_CASE(forgedTypedKindIsReplacedByTheSignedOne)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    BOOST_REQUIRE_EQUAL(static_cast<int>(tx->inner().web3TypedTxKind), 2);
+    tx->mutableInner().web3TypedTxKind = 0;
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(static_cast<int>(tx->inner().web3TypedTxKind), 2);
+}
+
+// attribute is the one unsigned outer field with execution consequences: BlockExecutive routes on
+// LIQUID_SCALE_CODEC / LIQUID_CREATE and schedules on DAG.
+BOOST_AUTO_TEST_CASE(forgedAttributeIsZeroed)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    tx->mutableInner().attribute =
+        static_cast<int32_t>(Transaction::Attribute::LIQUID_SCALE_CODEC) |
+        static_cast<int32_t>(Transaction::Attribute::LIQUID_CREATE) |
+        static_cast<int32_t>(Transaction::Attribute::DAG);
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().attribute, 0);
+}
+
+// ---------------------------------------------------------------- hash commitment
+
+BOOST_AUTO_TEST_CASE(forgedWireHashIsRejected)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    // Claiming some other transaction's hash lets a peer slip this one past a hash-keyed
+    // dedup/skip check (TransactionSync consults exists(tx->hash()) before verifying).
+    tx->mutableInner().extraTransactionHash.assign(32, '\x11');
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::InvalidSignature);
+}
+
+BOOST_AUTO_TEST_CASE(absentWireHashIsFilledInNotRejected)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto canonical = tx->inner().extraTransactionHash;
+    tx->mutableInner().extraTransactionHash.clear();
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK(tx->inner().extraTransactionHash == canonical);
+}
+
+BOOST_AUTO_TEST_CASE(corruptedEnvelopeIsRejected)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    auto& payload = tx->mutableInner().extraTransactionBytes;
+    payload.back() = static_cast<tars::Char>(payload.back() ^ 0x01);
+
+    BOOST_CHECK(normalize(*tx) != TransactionStatus::None);
+}
+
+BOOST_AUTO_TEST_CASE(emptyEnvelopeOnAWeb3TransactionIsRejected)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    tx->mutableInner().extraTransactionBytes.clear();
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::Malformed);
+}
+
+// ---------------------------------------------------------------- preserved state
+
+BOOST_AUTO_TEST_CASE(signatureSurvivesNormalization)
+{
+    // decodeFromPayload runs with withSignature=false, so the decoded payload carries no
+    // signature at all. Anything that rebuilt the whole tars struct from it would destroy the
+    // signature of every transaction it touched.
+    auto tx = makeSignedTx(kRaw1559);
+    const auto before = tx->inner().signature;
+    BOOST_REQUIRE(!before.empty());
+    tx->mutableInner().data.to = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK(tx->inner().signature == before);
+}
+
+BOOST_AUTO_TEST_CASE(localBookkeepingSurvivesNormalization)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    tx->setImportTime(4242);
+    const auto envelope = tx->inner().extraTransactionBytes;
+    const auto outerType = tx->inner().type;
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().importTime, 4242);
+    BOOST_CHECK(tx->inner().extraTransactionBytes == envelope);
+    BOOST_CHECK_EQUAL(tx->inner().type, outerType);
+}
+
+// A rejected transaction must come back untouched: the caller only receives a status code, so a
+// half-rebuilt mirror would be invisible to it.
+BOOST_AUTO_TEST_CASE(rejectedTransactionIsLeftUnmodified)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    const auto forgedTo = std::string{"0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"};
+    tx->mutableInner().data.to = forgedTo;
+    tx->mutableInner().extraTransactionHash.assign(32, '\x11');
+
+    BOOST_REQUIRE(normalize(*tx) == TransactionStatus::InvalidSignature);
+    // Still the forged value -- nothing was committed.
+    BOOST_CHECK_EQUAL(tx->inner().data.to, forgedTo);
+    BOOST_CHECK_EQUAL(hexOf(tx->inner().extraTransactionHash), std::string(64, '1'));
+}
+
+// ---------------------------------------------------------------- type gate
+
+BOOST_AUTO_TEST_CASE(depositEnvelopeIsRejectedAsUnsupportedType)
+{
+    // A deposit reaching a pool is forged by construction: it has no signature, its trust anchor
+    // is sourceHash, and no pool path checks that. Classification runs before the decode
+    // precisely so this reports TxTypeNotSupported and not Malformed -- the decoder does not
+    // know 0x7e.
+    auto tx = makeSignedTx(kRaw1559);
+    tx->mutableInner().extraTransactionBytes[0] = static_cast<tars::Char>(0x7e);
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::TxTypeNotSupported);
+}
+
+BOOST_AUTO_TEST_CASE(blobEnvelopeIsRejectedAsBlobTxNotAllowed)
+{
+    // The mirror image of the deposit case: 0x03 IS in bcos::rpc::TransactionType (EIP4844), so
+    // the decoder would accept it. Only a gate ahead of the decode catches both. The code is
+    // the dedicated one #5520 introduced for exactly this verdict, not the generic type gate --
+    // both gates run the same classifier and must not disagree on what to report.
+    auto tx = makeSignedTx(kRaw1559);
+    tx->mutableInner().extraTransactionBytes[0] = static_cast<tars::Char>(0x03);
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::BlobTxNotAllowed);
+}
+
+BOOST_AUTO_TEST_CASE(reservedEnvelopeTypeIsRejectedAsMalformed)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    tx->mutableInner().extraTransactionBytes[0] = static_cast<tars::Char>(0x7f);
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::Malformed);
+}
+
+BOOST_AUTO_TEST_CASE(unknownOuterTypeIsRejected)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    tx->mutableInner().type = static_cast<tars::Char>(42);
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::Malformed);
+}
+
+// ---------------------------------------------------------------- legacy / BCOS
+
+BOOST_AUTO_TEST_CASE(legacyTransactionNormalizesAndDetectsForgery)
+{
+    auto tx = makeSignedTx(kRawLegacy);
+    const auto honestTo = tx->inner().data.to;
+    tx->mutableInner().data.to = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.to, honestTo);
+}
+
+BOOST_AUTO_TEST_CASE(bcosTransactionIsNotTouched)
+{
+    // A BCOS transaction's dataHash covers the whole TransactionData, so signature and execution
+    // already read the same bytes; normalization must leave it completely alone.
+    auto tx = std::make_shared<bcostars::protocol::TransactionImpl>();
+    tx->mutableInner().type = static_cast<tars::Char>(TransactionType::BCOSTransaction);
+    tx->mutableInner().data.to = "0x1234567890123456789012345678901234567890";
+    tx->mutableInner().data.groupID = "group0";
+    tx->mutableInner().data.blockLimit = 500;
+    tx->mutableInner().attribute = 4;
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+    BOOST_CHECK_EQUAL(tx->inner().data.groupID, "group0");
+    BOOST_CHECK_EQUAL(tx->inner().data.blockLimit, 500);
+    BOOST_CHECK_EQUAL(tx->inner().attribute, 4);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+
+}  // namespace bcos::test

--- a/bcos-tx-validator/test/unittests/NormalizeTest.cpp
+++ b/bcos-tx-validator/test/unittests/NormalizeTest.cpp
@@ -201,6 +201,55 @@ BOOST_AUTO_TEST_CASE(forgedAttributeIsZeroed)
     BOOST_CHECK_EQUAL(tx->inner().attribute, 0);
 }
 
+// The rest of the unsigned surface, in one case. attribute above has execution consequences and
+// earns its own test; these do not individually, but together they are the whole argument for
+// moving the `data` sub-struct wholesale instead of assigning field by field -- the fields a
+// Web3 envelope never carries have to come back as defaults, and nothing else pins that. A later
+// "optimisation" into field-by-field assignment would leave every one of them standing, which is
+// exactly how #5364 happened.
+BOOST_AUTO_TEST_CASE(unsignedLeftoverFieldsAreAllReset)
+{
+    auto tx = makeSignedTx(kRaw1559);
+    auto& inner = tx->mutableInner();
+
+    // Outer fields, cleared explicitly by the commit step.
+    inner.extraData = "leftover";
+    inner.dataHash.assign(32, 0x11);
+    inner.sourceHash = "0xdeadbeef";
+    inner.mint = "1000000";
+    inner.isSystemTransaction = 1;
+
+    // TransactionData fields a Web3 envelope has no slot for: these are reset only as a
+    // consequence of replacing the whole sub-struct.
+    inner.data.groupID = "forged-group";
+    inner.data.blockLimit = 12345;
+    inner.data.abi = "[{\"forged\":true}]";
+    inner.data.extension.assign(8, 0x22);
+    inner.data.version = 7;
+    inner.data.maxFeePerBlobGas = "999";
+    // Carried only for legacy/2930 envelopes; kRaw1559 writes maxFeePerGas instead.
+    inner.data.gasPrice = "0xdeadbeef";
+    inner.data.blobVersionedHashes.emplace_back(32, 0x33);
+
+    BOOST_CHECK(normalize(*tx) == TransactionStatus::None);
+
+    auto const& out = tx->inner();
+    BOOST_CHECK(out.extraData.empty());
+    BOOST_CHECK(out.dataHash.empty());
+    BOOST_CHECK(out.sourceHash.empty());
+    BOOST_CHECK(out.mint.empty());
+    BOOST_CHECK_EQUAL(out.isSystemTransaction, 0);
+
+    BOOST_CHECK(out.data.groupID.empty());
+    BOOST_CHECK_EQUAL(out.data.blockLimit, 0);
+    BOOST_CHECK(out.data.abi.empty());
+    BOOST_CHECK(out.data.extension.empty());
+    BOOST_CHECK_EQUAL(out.data.version, 0);
+    BOOST_CHECK(out.data.maxFeePerBlobGas.empty());
+    BOOST_CHECK(out.data.gasPrice.empty());
+    BOOST_CHECK(out.data.blobVersionedHashes.empty());
+}
+
 // ---------------------------------------------------------------- hash commitment
 
 BOOST_AUTO_TEST_CASE(forgedWireHashIsRejected)

--- a/bcos-tx-validator/test/unittests/main.cpp
+++ b/bcos-tx-validator/test/unittests/main.cpp
@@ -1,0 +1,12 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+#define BOOST_TEST_MAIN
+#define BOOST_TEST_MODULE FISCO_BCOS_TxValidator_Tests
+#include <boost/test/unit_test.hpp>


### PR DESCRIPTION
### What

Makes the signed RLP envelope authoritative for Web3 transactions, and adds the `bcos-tx-validator` module skeleton those checks live in.

First of three PRs building the admission layer. **No caller is wired up**, so nothing changes at runtime yet.

### The problem

A Web3 transaction travels as two things: the signed RLP envelope, and a tars "mirror" of its fields that the rest of the node actually reads. Only the envelope is covered by the signature.

Nothing today checks that the mirror agrees with the envelope. A peer can ship a mirror saying whatever it likes — a different recipient, a different value, a different nonce — alongside a perfectly valid signature over entirely different content, and the pool believes the mirror.

### The fix

`normalize()` rebuilds the mirror fields from the envelope before anything reads them, so the signed values win.

It runs unconditionally and ahead of every other check, and it is deliberately **not** one of the routable checks that the follow-up PR introduces: no admission context may switch it off, and no mirror-reading check can be ordered ahead of it.

`dataHash` is cleared along with the other outer fields. It is dead for Web3 — `hash()` reads `extraTransactionHash` — but it is an arbitrary, unsigned, uncharged byte string that would otherwise ride into a block and into storage. The comment now accounts for all 14 outer fields explicitly (rebuilt / reset / preserved), because "enumeration rots" is the argument for rebuilding in the first place.

The BCOS early return is left as-is behaviourally, but its stated reason is corrected: `dataHash` covers `TransactionData`, **not** the outer fields, and `attribute` sits outside it while `BlockExecutive` reads it to route into the Liquid path and change DAG scheduling. That is a pre-existing exposure this PR does not introduce and does not fix — the SDK legitimately sets `attribute` on BCOS transactions, so zeroing it here would break them.

### Also here

Seven admission-stage codes on `TransactionStatus`, because `normalize()` is the first thing that needs them: a rejection should report which rule fired rather than collapsing into a generic failure.

### Follow-ups

- the (kind × context × policy) routing table
- `verify()` itself
- two wiring PRs, one per transaction pool

### Test

`NormalizeTest` covers the mirror/envelope disagreement cases directly.

Local run on this commit: full build clean (0 errors); `test-bcos-tx-validator` and `test-bcos-protocol` report `No errors detected`.


---

### Rebased onto #5520 (2026-09-01)

#5520 landed `BlobTxNotAllowed = 10016` while this branch was claiming the same
value for `TxTypeNotSupported`. That was the only conflict. Resolved by keeping
#5520's code at 10016 and renumbering this PR's seven to 10017–10023.

Two things came out of the collision that are not just renumbering:

- **The blob verdict now uses #5520's code, not a second one of ours.**
  #5520 put a gate into the pool-side validator that runs the *same*
  `engine::dispatchRawTransaction` classifier this module's step 1 runs, and
  gave the blob case a dedicated status. Reporting the same condition under two
  different codes is exactly what the new status codes exist to avoid, so
  `normalize()` returns `BlobTxNotAllowed` for a blob envelope.
- **Deposits deliberately still report `TxTypeNotSupported`.** #5520's gate
  reaches deposits through the chainId classifier and reports `InvalidChainId`,
  while its own comment says deposits have no chainId. This reports the type
  rather than a chainId that was never there; the wiring PR that replaces that
  gate carries the observable change.

`BlobTxNotAllowed` also gains an expectation in `TransactionStatusTest` — #5520
added the code and its `operator<<` case but no test row.
