### PR TITLE
Remove async sendMessage APIs, migrate all send paths to coroutines

### DIFF
--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -285,7 +285,8 @@ public:
     virtual void asyncSendMessageByNodeIDByOwnedPayload(
         int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload)
     {
-        task::wait([](FrontServiceInterface::Ptr self, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+        task::wait([](FrontServiceInterface::Ptr self, int _moduleID,
+                       bcos::crypto::NodeIDPtr _nodeID,
                        bytesPointer _payload) -> task::Task<void> {
             co_await self->sendMessageByNodeID(_moduleID, std::move(_nodeID),
                 ::ranges::views::single(bcos::ref(*_payload)), 0);

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -193,18 +193,6 @@ public:
         ReceiveMsgFunc _receiveMsgCallback) = 0;
 
     /**
-     * @brief: send message to node
-     * @param _moduleID: moduleID
-     * @param _nodeID: the receiver nodeID
-     * @param _data: message
-     * @param _timeout: the timeout value of async function, in milliseconds.
-     * @param _callback: callback
-     * @return void
-     */
-    virtual void asyncSendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        bytesConstRef _data, uint32_t _timeout, CallbackFunc _callback) = 0;
-
-    /**
      * @brief: send response
      * @param _id: the request id
      * @param _moduleID: moduleID
@@ -215,16 +203,6 @@ public:
     virtual void asyncSendResponse(const std::string& _id, int _moduleID,
         bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data,
         ReceiveMsgFunc _receiveMsgCallback) = 0;
-
-    /**
-     * @brief: send messages to multiple nodes
-     * @param _moduleID: moduleID
-     * @param _nodeIDs: the receiver nodeIDs
-     * @param _data: message
-     * @return void
-     */
-    virtual void asyncSendMessageByNodeIDs(int _moduleID,
-        const std::vector<bcos::crypto::NodeIDPtr>& _nodeIDs, bytesConstRef _data) = 0;
 
     virtual task::Task<void> broadcastMessage(
         uint16_t type, int moduleID,
@@ -241,64 +219,18 @@ public:
      *         in task::wait, passing any captured state as coroutine parameters (the recommended
      *         pattern across the send path).
      *
-     * The payloads must be at least forward ranges: the default bridge joins them into one buffer
-     * (single pass), but overrides may iterate them multiple times (e.g. a retry loop).
+     * The payloads must be at least forward ranges: implementations may iterate them multiple
+     * times (e.g. a retry loop).
      *
-     * Default implementation: joins the payload views into one contiguous buffer and bridges to
-     * the borrowed asyncSendMessageByNodeID. The front client (FrontServiceClient) copies the
-     * payload synchronously in the call arguments, so the buffer only needs to stay alive until
-     * asyncSendMessageByNodeID returns; with _timeout == 0 the bridge passes a null callback so
-     * the client forwards requireRespCallback = false (no response entry is registered on the
-     * peer). The _timeout > 0 bridge captures the buffer in the completion callback, which runs
-     * on another thread and must copy the borrowed payload view into the SendResult before the
-     * frame is gone.
+     * @param _moduleID: moduleID
+     * @param _nodeID: the receiver nodeID
+     * @param _payloads: message content (views, kept alive by the caller)
+     * @param _timeout: the module-response timeout in milliseconds; 0 = fire-and-forget
      */
     virtual task::Task<SendResult> sendMessageByNodeID(int _moduleID,
         bcos::crypto::NodeIDPtr _nodeID,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
-        uint32_t _timeout)
-    {
-        // The payload views are joined into one contiguous buffer. For the response-waiting
-        // (_timeout > 0) path the buffer is captured by the completion callback so it stays alive
-        // while the callback (possibly on another thread) copies the borrowed payload view into
-        // the SendResult.
-        auto buffer = std::make_shared<bcos::bytes>();
-        for (auto const& data : _payloads)
-        {
-            buffer->insert(buffer->end(), data.begin(), data.end());
-        }
-        auto payload = bcos::ref(*buffer);
-
-        if (_timeout == 0)
-        {
-            // fire-and-forget: no module-level response is expected. Pass a null callback so the
-            // borrowed client forwards requireRespCallback = false (the peer registers no response
-            // entry and the tars request completes normally instead of hanging until
-            // c_frontServiceTimeout). The front client copies the payload synchronously in the
-            // call arguments, so the frame-local buffer only needs to stay alive until
-            // asyncSendMessageByNodeID returns.
-            asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), payload, 0, nullptr);
-            co_return SendResult{};
-        }
-
-        auto state = std::make_shared<SendResponseAwaitable::State>();
-        asyncSendMessageByNodeID(_moduleID, std::move(_nodeID), payload, _timeout,
-            [state, buffer = std::move(buffer)](bcos::Error::Ptr _error,
-                bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data, const std::string& _id,
-                ResponseFunc _resp) mutable {
-                // keep the payload buffer alive until after the callback returns: the borrowed
-                // caller may still be reading it on this stack
-                (void)buffer;
-                SendResult result;
-                result.error = std::move(_error);
-                result.nodeID = std::move(_nodeID);
-                result.payload.assign(_data.begin(), _data.end());
-                result.uuid = _id;
-                result.respond = std::move(_resp);
-                SendResponseAwaitable::complete(state, std::move(result));
-            });
-        co_return co_await SendResponseAwaitable{std::move(state)};
-    }
+        uint32_t _timeout) = 0;
 
     /**
      * @brief broadcast an already-encoded message, taking ownership of the payload so the send can
@@ -338,7 +270,8 @@ public:
      * the gateway send off the caller thread (PBFT under m_mutex must not contend the gateway
      * session lock; sendViewChange / sendRecoverResponse run there). Point-to-point sends encode
      * the wire frame anyway, so this is not zero-copy; owning the payload only keeps it alive
-     * across the deferred encode. The default implementation bridges to asyncSendMessageByNodeID.
+     * across the deferred encode. The default implementation bridges to the coroutine
+     * sendMessageByNodeID (fire-and-forget).
      *
      * @param moduleID: moduleID
      * @param nodeID: the receiver nodeID
@@ -347,7 +280,11 @@ public:
     virtual void asyncSendMessageByNodeIDByOwnedPayload(
         int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload)
     {
-        asyncSendMessageByNodeID(moduleID, std::move(nodeID), bcos::ref(*payload), 0, nullptr);
+        task::wait([](FrontServiceInterface* self, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+                       bytesPointer _payload) -> task::Task<void> {
+            co_await self->sendMessageByNodeID(_moduleID, std::move(_nodeID),
+                ::ranges::views::single(bcos::ref(*_payload)), 0);
+        }(this, moduleID, std::move(nodeID), std::move(payload)));
     }
 
     /**

--- a/bcos-framework/bcos-framework/front/FrontServiceInterface.h
+++ b/bcos-framework/bcos-framework/front/FrontServiceInterface.h
@@ -133,8 +133,13 @@ private:
 
 /**
  * @brief: the interface provided by the front service
+ *
+ * enable_shared_from_this lets the owned-payload bridges (asyncBroadcastMessageByOwnedPayload /
+ * asyncSendMessageByNodeIDByOwnedPayload) pass an owning Ptr as the coroutine parameter, so the
+ * front object (FrontService / FrontServiceClient / test fakes, all shared_ptr-owned) stays alive
+ * for the whole detached send instead of holding a raw `this`.
  */
-class FrontServiceInterface
+class FrontServiceInterface : public std::enable_shared_from_this<FrontServiceInterface>
 {
 public:
     using Ptr = std::shared_ptr<FrontServiceInterface>;
@@ -255,11 +260,11 @@ public:
     virtual void asyncBroadcastMessageByOwnedPayload(
         uint16_t type, int moduleID, bytesPointer payload)
     {
-        task::wait([](FrontServiceInterface* self, uint16_t _type, int _moduleID,
+        task::wait([](FrontServiceInterface::Ptr self, uint16_t _type, int _moduleID,
                        bytesPointer _payload) -> task::Task<void> {
             co_await self->broadcastMessage(
                 _type, _moduleID, ::ranges::views::single(bcos::ref(*_payload)));
-        }(this, type, moduleID, std::move(payload)));
+        }(shared_from_this(), type, moduleID, std::move(payload)));
     }
 
     /**
@@ -280,11 +285,11 @@ public:
     virtual void asyncSendMessageByNodeIDByOwnedPayload(
         int moduleID, bcos::crypto::NodeIDPtr nodeID, bytesPointer payload)
     {
-        task::wait([](FrontServiceInterface* self, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+        task::wait([](FrontServiceInterface::Ptr self, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
                        bytesPointer _payload) -> task::Task<void> {
             co_await self->sendMessageByNodeID(_moduleID, std::move(_nodeID),
                 ::ranges::views::single(bcos::ref(*_payload)), 0);
-        }(this, moduleID, std::move(nodeID), std::move(payload)));
+        }(shared_from_this(), moduleID, std::move(nodeID), std::move(payload)));
     }
 
     /**

--- a/bcos-framework/bcos-framework/gateway/GatewayInterface.h
+++ b/bcos-framework/bcos-framework/gateway/GatewayInterface.h
@@ -28,8 +28,6 @@
 #include <bcos-crypto/interfaces/crypto/KeyInterface.h>
 #include <bcos-utilities/Common.h>
 #include <bcos-utilities/Error.h>
-#include <atomic>
-#include <coroutine>
 #include <memory>
 #include <range/v3/view/any_view.hpp>
 
@@ -82,23 +80,6 @@ public:
      * @param _payload: message content
      * @return void
      */
-    virtual void asyncSendMessageByNodeID(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        bytesConstRef _payload, ErrorRespFunc _errorRespFunc) = 0;
-
-    /**
-     * @brief: send message to multiple nodes
-     * @param _groupID: groupID
-     * @param _moduleID: moduleID
-     * @param _srcNodeID: the sender nodeID
-     * @param _nodeIDs: the receiver nodeIDs
-     * @param _payload: message content
-     * @param _errorRespFunc: error func
-     * @return void
-     */
-    virtual void asyncSendMessageByNodeIDs(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, const bcos::crypto::NodeIDs& _dstNodeIDs,
-        bytesConstRef _payload) = 0;
 
     virtual task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID,
@@ -111,13 +92,6 @@ public:
      *         exhausted / a terminal error occurred); it returns nullptr on success or an
      *         Error::Ptr describing the failure.
      *
-     * Default implementation: joins the payload views into a buffer and bridges to the borrowed
-     * asyncSendMessageByNodeID. The completion state and the payload buffer are owned by the
-     * completion callback (see the implementation below): the borrowed TARS client may keep
-     * reading the payload after the callback returns, and it may even invoke the callback twice —
-     * the implementation guards the resume/result delivery accordingly. The production Gateway
-     * overrides it with a zero-copy coroutine implementation.
-     *
      * @param _groupID: groupID
      * @param _moduleID: moduleID
      * @param _srcNodeID: the sender nodeID
@@ -126,83 +100,7 @@ public:
      */
     virtual task::Task<Error::Ptr> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads)
-    {
-        // Both the payload buffer and the completion state are owned by shared_ptrs captured by the
-        // completion callback, NOT by this coroutine frame: the borrowed TARS client may keep
-        // reading the payload after the callback returns (e.g. a synchronous connection-check error
-        // followed by an async send setup), and it may even invoke the callback twice
-        // (synchronously for the connection check AND later for the async completion). The
-        // shared state survives
-        // the frame so the second completion is detected instead of double-resuming a destroyed
-        // coroutine.
-        auto buffer = std::make_shared<bcos::bytes>();
-        for (auto const& data : _payloads)
-        {
-            buffer->insert(buffer->end(), data.begin(), data.end());
-        }
-        struct SendAwaitable
-        {
-            struct CompletionState
-            {
-                std::atomic<bool> completed{false};
-                std::coroutine_handle<> handle;
-                Error::Ptr error;
-            };
-
-            GatewayInterface* m_self;
-            // owned by the completion callback so it outlives this frame: asyncSendMessageByNodeID
-            // takes the groupID by const-ref, and a synchronous completion (TARS connection check)
-            // resumes (and destroys) the frame while the borrowed client is still using it
-            std::shared_ptr<std::string> m_groupID;
-            int m_moduleID;
-            bcos::crypto::NodeIDPtr m_srcNodeID;
-            bcos::crypto::NodeIDPtr m_dstNodeID;
-            std::shared_ptr<bcos::bytes> m_buffer;
-            std::shared_ptr<CompletionState> m_state;
-
-            constexpr static bool await_ready() noexcept { return false; }
-            void await_suspend(std::coroutine_handle<> _handle)
-            {
-                m_state->handle = _handle;
-                auto state = m_state;
-                auto buffer = m_buffer;
-                auto groupID = m_groupID;
-                // Materialize what the call arguments need (groupID / payload) BEFORE the lambda
-                // argument below: the lambda's init-captures move buffer/groupID/state, and C++17
-                // leaves the evaluation order of function arguments unspecified — if the lambda ran
-                // first, *groupID / bcos::ref(*buffer) would dereference the moved-from (null)
-                // shared_ptrs. The string stays alive because the lambda's captured shared_ptr
-                // keeps it alive.
-                std::string const& groupIDRef = *groupID;
-                auto payload = bcos::ref(*buffer);
-                m_self->asyncSendMessageByNodeID(groupIDRef, m_moduleID, m_srcNodeID, m_dstNodeID,
-                    payload,
-                    [state = std::move(state), buffer = std::move(buffer),
-                        groupID = std::move(groupID)](bcos::Error::Ptr _error) mutable {
-                        // The completion guard protects both the resume and the result delivery:
-                        // the documented contract above says the borrowed TARS client may invoke
-                        // this callback twice (synchronous connection check + async completion) —
-                        // only the first completion may deliver the result, otherwise the caller
-                        // is called back twice.
-                        if (!state->completed.exchange(true))
-                        {
-                            state->error = std::move(_error);
-                            // keep the payload buffer and groupID alive until after the resume: the
-                            // borrowed caller may still be reading them on this stack
-                            (void)buffer;
-                            (void)groupID;
-                            state->handle.resume();
-                        }
-                    });
-            }
-            Error::Ptr await_resume() { return std::move(m_state->error); }
-        };
-        SendAwaitable awaitable{this, std::make_shared<std::string>(_groupID), _moduleID,
-            std::move(_srcNodeID), std::move(_dstNodeID), std::move(buffer),
-            std::make_shared<SendAwaitable::CompletionState>()};
-        co_return co_await awaitable;
-    }
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads) = 0;
 
     /// multi-group related interfaces
 

--- a/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
+++ b/bcos-framework/bcos-framework/testutils/faker/FakeFrontService.h
@@ -238,13 +238,20 @@ public:
         m_gateWay->addConsensusInterface(std::move(_nodeId), std::move(_consensusInterface));
     }
 
-    void asyncSendMessageByNodeID(const std::string&, int _moduleID,
+    bcos::task::Task<Error::Ptr> sendMessageByNodeID(const std::string&, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        bytesConstRef _payload, gateway::ErrorRespFunc _errorRespFunc) override
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads) override
     {
-        m_gateWay->asyncSendMessageByNodeID(_moduleID, _srcNodeID, _dstNodeID, _payload, 0,
-            [func = std::move(_errorRespFunc)](Error::Ptr _e, const bcos::crypto::NodeIDPtr&,
-                bytesConstRef, const std::string&, const ResponseFunc&) { func(std::move(_e)); });
+        bytes buffer;
+        for (auto const& data : _payloads)
+        {
+            buffer.insert(buffer.end(), data.begin(), data.end());
+        }
+        // simulate the gateway delivering the message to the local front (no remote gateway)
+        m_gateWay->asyncSendMessageByNodeID(_moduleID, _srcNodeID, _dstNodeID, bcos::ref(buffer), 0,
+            [](Error::Ptr, const bcos::crypto::NodeIDPtr&, bytesConstRef, const std::string&,
+                const ResponseFunc&) {});
+        co_return nullptr;
     }
 
     void asyncSendResponse(const std::string& _id, int _moduleId, NodeIDPtr _nodeID,
@@ -260,10 +267,6 @@ public:
     void asyncGetPeers(
         std::function<void(Error::Ptr, gateway::GatewayInfo::Ptr, gateway::GatewayInfosPtr)>
             _callback) override
-    {}
-    void asyncSendMessageByNodeIDs(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, const NodeIDs& _dstNodeIDs,
-        bytesConstRef _payload) override
     {}
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID,
@@ -313,19 +316,6 @@ public:
     void onReceiveMessage(
         const std::string&, const NodeIDPtr&, bytesConstRef, ReceiveMsgFunc) override
     {}
-    void asyncSendMessageByNodeIDs(
-        int _moduleId, const std::vector<NodeIDPtr>& _nodeIdList, bytesConstRef _data) override
-    {
-        for (const auto& node : _nodeIdList)
-        {
-            if (node->data() == m_nodeId->data())
-            {
-                continue;
-            }
-            asyncSendMessageByNodeID(_moduleId, node, _data, 0, nullptr);
-        }
-    }
-
     bcos::task::Task<void> broadcastMessage(
         uint16_t type, int moduleID,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override
@@ -341,7 +331,8 @@ public:
             {
                 buffer.insert(buffer.end(), view.begin(), view.end());
             }
-            asyncSendMessageByNodeID(moduleID, node, bcos::ref(buffer), 0, nullptr);
+            co_await sendMessageByNodeID(
+                moduleID, node, ::ranges::views::single(bcos::ref(buffer)), 0);
         }
         co_return;
     }
@@ -365,13 +356,43 @@ public:
         }
     }
 
-    void asyncSendMessageByNodeID(int _moduleId, NodeIDPtr _nodeId, bytesConstRef _data,
-        uint32_t _timeout, CallbackFunc _responseCallback) override
+    bcos::task::Task<SendResult> sendMessageByNodeID(int _moduleId,
+        bcos::crypto::NodeIDPtr _nodeId,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads,
+        uint32_t _timeout) override
     {
+        bytes buffer;
+        for (auto view : _payloads)
+        {
+            buffer.insert(buffer.end(), view.begin(), view.end());
+        }
+        SendResult result;
         if (m_fakeGateWay)
         {
-            m_fakeGateWay->asyncSendMessageByNodeID(
-                _moduleId, m_nodeId, _nodeId, _data, _timeout, _responseCallback);
+            if (_timeout == 0)
+            {
+                // fire-and-forget: no module-level response expected
+                m_fakeGateWay->asyncSendMessageByNodeID(
+                    _moduleId, m_nodeId, _nodeId, bcos::ref(buffer), 0, nullptr);
+            }
+            else
+            {
+                // bridge the fake gateway's module-level callback to the co_await
+                auto state = std::make_shared<SendResponseAwaitable::State>();
+                m_fakeGateWay->asyncSendMessageByNodeID(_moduleId, m_nodeId, _nodeId,
+                    bcos::ref(buffer), _timeout,
+                    [state](Error::Ptr _error, const bcos::crypto::NodeIDPtr& _nodeID,
+                        bytesConstRef _data, const std::string& _id, const ResponseFunc& _resp) {
+                        SendResult r;
+                        r.error = std::move(_error);
+                        r.nodeID = _nodeID;
+                        r.payload.assign(_data.begin(), _data.end());
+                        r.uuid = _id;
+                        r.respond = _resp;
+                        SendResponseAwaitable::complete(state, std::move(r));
+                    });
+                result = co_await SendResponseAwaitable{std::move(state)};
+            }
         }
 
         if (m_nodeId2AsyncSendSize.contains(_nodeId))
@@ -383,6 +404,7 @@ public:
             m_nodeId2AsyncSendSize[_nodeId] = 1;
         }
         m_totalSendMsgSize++;
+        co_return result;
     }
 
     size_t getAsyncSendSizeByNodeID(NodeIDPtr _nodeId)

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -249,7 +249,8 @@ void FrontService::start()
     m_run = true;
 
     // try to getNodeIDs from gateway
-    auto self = std::weak_ptr<FrontService>(shared_from_this());
+    auto self = std::weak_ptr<FrontService>(
+        std::static_pointer_cast<FrontService>(shared_from_this()));
     m_gatewayInterface->asyncGetGroupNodeInfo(m_groupID,
         [self](const Error::Ptr& _error, const bcos::gateway::GroupNodeInfo::Ptr& _groupNodeInfo) {
             if (_error)
@@ -406,7 +407,8 @@ std::string FrontService::registerCallback(
             *m_ioService, std::chrono::milliseconds(_timeout));
 
         callback->timeoutHandler = timeoutHandler;
-        auto frontServiceWeakPtr = std::weak_ptr<FrontService>(shared_from_this());
+        auto frontServiceWeakPtr = std::weak_ptr<FrontService>(
+            std::static_pointer_cast<FrontService>(shared_from_this()));
         // callback->startTime = utcSteadyTime();
         timeoutHandler->async_wait(
             [frontServiceWeakPtr, _nodeID, uuid](const boost::system::error_code& e) {
@@ -479,7 +481,7 @@ void FrontService::asyncSendMessageByNodeIDByOwnedPayload(
     // gateway-session-lock-acquiring send on its own thread. The owned payload is captured by the
     // launched coroutine -> the message body is sent as a view (zero-copy).
     enqueueSend([this, moduleID, nodeID = std::move(nodeID), payload = std::move(payload)]() {
-        auto self = shared_from_this();
+        auto self = std::static_pointer_cast<FrontService>(shared_from_this());
         task::wait(
             [](FrontService::Ptr _self, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
                 bytesPointer _payload) -> task::Task<void> {
@@ -602,7 +604,7 @@ void FrontService::enqueueSend(std::function<void()> _sendTask)
     // for the send and no-ops once it is gone. (A shared_ptr capture would also form a cycle:
     // FrontService -> Strand -> queued task -> FrontService.)
     m_sendStrand->post([weak = weak_from_this(), task = std::move(_sendTask)]() mutable {
-        if (auto self = weak.lock())
+        if (auto self = std::static_pointer_cast<FrontService>(weak.lock()))
         {
             // this task no longer occupies queue space; decrement before running so the counter
             // reflects queued depth while a blocking gateway send is in flight
@@ -637,7 +639,7 @@ void FrontService::onReceiveGroupNodeInfo(const std::string& _groupID,
     auto self = weak_from_this();
     dispatchTo(
         *m_ioServicePool, [self, _groupID, _groupNodeInfo = std::move(_groupNodeInfo)]() mutable {
-            if (auto frontService = self.lock())
+            if (auto frontService = std::static_pointer_cast<FrontService>(self.lock()))
             {
                 frontService->notifyGroupNodeInfo(_groupID, _groupNodeInfo);
             }
@@ -714,7 +716,8 @@ void FrontService::handleCallback(bcos::Error::Ptr _error, bytesConstRef _payLoa
     {
         return;
     }
-    auto frontServiceWeakPtr = std::weak_ptr<FrontService>(shared_from_this());
+    auto frontServiceWeakPtr = std::weak_ptr<FrontService>(
+        std::static_pointer_cast<FrontService>(shared_from_this()));
     auto respFunc = [frontServiceWeakPtr, _moduleID, _nodeID, _uuid](bytesConstRef _data) {
         auto frontService = frontServiceWeakPtr.lock();
         if (frontService)
@@ -854,27 +857,30 @@ void FrontService::sendMessage(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
         message.setResponse();
     }
 
-    // zero-copy: only the header is encoded; the payload rides as a view that stays alive for the
-    // (blocking) co_await below
+    // header + payload must both outlive the non-blocking task::wait: copy them into owned
+    // buffers held by the coroutine frame (sendMessage is the bridge from borrowed-callback APIs,
+    // so it cannot preserve zero-copy)
     bytes header;
     message.encodeHeader(header);
 
-    // bridge the coroutine gateway send to the borrowed callback
     auto gateway = m_gatewayInterface;
     auto hdr = std::make_shared<bytes>(std::move(header));
+    auto payload = std::make_shared<bytes>(_data.begin(), _data.end());
     task::wait([](gateway::GatewayInterface::Ptr _gateway, std::string _groupID, int _moduleID,
                    bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _nodeID,
-                   std::shared_ptr<bytes> _hdr, bytesConstRef _data,
+                   std::shared_ptr<bytes> _hdr, std::shared_ptr<bytes> _payload,
                    ReceiveMsgFunc _receiveMsgCallback) -> task::Task<void> {
         auto error = co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
             std::move(_nodeID),
             ::ranges::views::concat(::ranges::views::single(bcos::ref(std::as_const(*_hdr))),
-                ::ranges::views::single(_data)));
+                ::ranges::views::single(
+                    bytesConstRef(_payload->data(), _payload->size()))));
         if (_receiveMsgCallback)
         {
             _receiveMsgCallback(std::move(error));
         }
-    }(gateway, m_groupID, _moduleID, m_nodeID, std::move(_nodeID), hdr, _data, _receiveMsgCallback));
+    }(gateway, m_groupID, _moduleID, m_nodeID, std::move(_nodeID), hdr, payload,
+        _receiveMsgCallback));
 }
 
 /**

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -542,8 +542,14 @@ bcos::task::Task<SendResult> FrontService::sendMessageByNodeID(
     if (_timeout == 0)
     {
         // fire-and-forget: no module-level response is expected; return once the gateway send
-        // completes
-        co_return SendResult{};
+        // completes. Propagate the gateway failure (when any) so the TARS fire-and-forget reply
+        // carries a truthful error code instead of always reporting SUCCESS. nodeID/uuid stay
+        // default (the TARS server echoes the request nodeID/seq in that case).
+        SendResult result;
+        result.error = (gatewayError && gatewayError->errorCode() != CommonError::SUCCESS) ?
+            gatewayError :
+            nullptr;
+        co_return result;
     }
     co_return co_await SendResponseAwaitable{std::move(state)};
 }

--- a/bcos-front/bcos-front/FrontService.cpp
+++ b/bcos-front/bcos-front/FrontService.cpp
@@ -422,46 +422,6 @@ std::string FrontService::registerCallback(
     return uuid;
 }
 
-void FrontService::asyncSendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-    bytesConstRef _data, uint32_t _timeout, CallbackFunc _callbackFunc)
-{
-    try
-    {
-        std::string uuid = registerCallback(_nodeID, _timeout, _callbackFunc);
-        if (_callbackFunc)
-        {
-            FRONT_LOG(DEBUG) << LOG_DESC("asyncSendMessageByNodeID") << LOG_KV("groupID", m_groupID)
-                             << LOG_KV("moduleID", _moduleID) << LOG_KV("uuid", uuid)
-                             << LOG_KV("nodeID", _nodeID->hex())
-                             << LOG_KV("data.size()", _data.size()) << LOG_KV("timeout", _timeout);
-        }  // if (_callback)
-
-        auto self = weak_from_this();
-        sendMessage(_moduleID, _nodeID, uuid, _data, false,
-            [self, _moduleID, _nodeID, uuid](const Error::Ptr& _error) {
-                auto front = self.lock();
-                if (!front)
-                {
-                    return;
-                }
-                if (_error && (_error->errorCode() != CommonError::SUCCESS))
-                {
-                    /*
-                    FRONT_LOG(ERROR) << LOG_BADGE("sendMessage callback") << LOG_KV("uuid", uuid)
-                                     << LOG_KV("errorCode", _error->errorCode())
-                                     << LOG_KV("errorMessage", _error->errorMessage());
-                */
-                    front->handleCallback(_error, bytesConstRef(), uuid, _moduleID, _nodeID);
-                }
-            });
-    }
-    catch (std::exception& e)
-    {
-        FRONT_LOG(ERROR) << LOG_BADGE("asyncSendMessageByNodeID")
-                         << LOG_KV("failed", boost::diagnostic_information(e));
-    }
-}
-
 /**
  * @brief: send response
  * @param _id: the request uuid
@@ -472,22 +432,6 @@ void FrontService::asyncSendResponse(const std::string& _id, int _moduleID,
     bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback)
 {
     sendMessage(_moduleID, _nodeID, _id, _data, true, _receiveMsgCallback);
-}
-
-/**
- * @brief: send message to multiple nodes
- * @param _moduleID: moduleID
- * @param _nodeIDs: the receiver nodeIDs
- * @param _data: send message data
- * @return void
- */
-void FrontService::asyncSendMessageByNodeIDs(
-    int _moduleID, const crypto::NodeIDs& _nodeIDs, bytesConstRef _data)
-{
-    for (const auto& _nodeID : _nodeIDs)
-    {
-        asyncSendMessageByNodeID(_moduleID, _nodeID, _data, 0, CallbackFunc());
-    }
 }
 
 task::Task<void> FrontService::broadcastMessage(
@@ -905,23 +849,32 @@ void FrontService::sendMessage(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
     FrontMessage message;
     message.setModuleID(_moduleID);
     message.setUuid(bytesConstRef(reinterpret_cast<const bcos::byte*>(_uuid.data()), _uuid.size()));
-    message.setPayload(_data);
     if (isResponse)
     {
         message.setResponse();
     }
 
-    bytes buffer;
-    message.encode(buffer);
+    // zero-copy: only the header is encoded; the payload rides as a view that stays alive for the
+    // (blocking) co_await below
+    bytes header;
+    message.encodeHeader(header);
 
-    // call gateway interface to send the message
-    m_gatewayInterface->asyncSendMessageByNodeID(m_groupID, _moduleID, m_nodeID, std::move(_nodeID),
-        bytesConstRef(buffer.data(), buffer.size()), [_receiveMsgCallback](Error::Ptr _error) {
-            if (_receiveMsgCallback)
-            {
-                _receiveMsgCallback(std::move(_error));
-            }
-        });
+    // bridge the coroutine gateway send to the borrowed callback
+    auto gateway = m_gatewayInterface;
+    auto hdr = std::make_shared<bytes>(std::move(header));
+    task::wait([](gateway::GatewayInterface::Ptr _gateway, std::string _groupID, int _moduleID,
+                   bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _nodeID,
+                   std::shared_ptr<bytes> _hdr, bytesConstRef _data,
+                   ReceiveMsgFunc _receiveMsgCallback) -> task::Task<void> {
+        auto error = co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
+            std::move(_nodeID),
+            ::ranges::views::concat(::ranges::views::single(bcos::ref(std::as_const(*_hdr))),
+                ::ranges::views::single(_data)));
+        if (_receiveMsgCallback)
+        {
+            _receiveMsgCallback(std::move(error));
+        }
+    }(gateway, m_groupID, _moduleID, m_nodeID, std::move(_nodeID), hdr, _data, _receiveMsgCallback));
 }
 
 /**

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -58,18 +58,6 @@ public:
      */
     void asyncGetGroupNodeInfo(GetGroupNodeInfoFunc _onGetGroupNodeInfoFunc) override;
     /**
-     * @brief: send message
-     * @param _moduleID: moduleID
-     * @param _nodeID: the receiver nodeID
-     * @param _data: send message data
-     * @param _timeout: timeout, in milliseconds.
-     * @param _callbackFunc: callback
-     * @return void
-     */
-    void asyncSendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        bytesConstRef _data, uint32_t _timeout, CallbackFunc _callbackFunc) override;
-
-    /**
      * @brief: send response
      * @param _id: the request id
      * @param _moduleID: moduleID
@@ -79,16 +67,6 @@ public:
      */
     void asyncSendResponse(const std::string& _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
         bytesConstRef _data, ReceiveMsgFunc _receiveMsgCallback) override;
-
-    /**
-     * @brief: send message to multiple nodes
-     * @param _moduleID: moduleID
-     * @param _nodeIDs: the receiver nodeIDs
-     * @param _data: send message data
-     * @return void
-     */
-    void asyncSendMessageByNodeIDs(
-        int _moduleID, const crypto::NodeIDs& _nodeIDs, bytesConstRef _data) override;
 
     task::Task<void> broadcastMessage(
         uint16_t type, int moduleID,

--- a/bcos-front/bcos-front/FrontService.h
+++ b/bcos-front/bcos-front/FrontService.h
@@ -31,7 +31,7 @@
 
 namespace bcos::front
 {
-class FrontService : public FrontServiceInterface, public std::enable_shared_from_this<FrontService>
+class FrontService : public FrontServiceInterface
 {
 public:
     using Ptr = std::shared_ptr<FrontService>;

--- a/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
+++ b/bcos-front/test/unittests/FIB185_AsyncSendOffCallerThreadTest.cpp
@@ -66,14 +66,16 @@ public:
         co_return;
     }
 
-    void asyncSendMessageByNodeID(const std::string&, int, bcos::crypto::NodeIDPtr,
-        bcos::crypto::NodeIDPtr, bytesConstRef, bcos::gateway::ErrorRespFunc) override
+    task::Task<Error::Ptr> sendMessageByNodeID(const std::string&, int, bcos::crypto::NodeIDPtr,
+        bcos::crypto::NodeIDPtr,
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward>) override
     {
         if (!m_p2pCaptured.exchange(true))
         {
             m_p2pRanOn.set_value(std::this_thread::get_id());
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(c_blockMs));
+        co_return nullptr;
     }
 };
 

--- a/bcos-front/test/unittests/FakeGateway.cpp
+++ b/bcos-front/test/unittests/FakeGateway.cpp
@@ -38,41 +38,25 @@ using namespace bcos::gateway;
  * @param _callback: callback
  * @return void
  */
-void FakeGateway::asyncSendMessageByNodeID(const std::string& _groupID, int,
-    bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID, bytesConstRef _payload,
-    bcos::gateway::ErrorRespFunc _errorRespFunc)
+bcos::task::Task<bcos::Error::Ptr> bcos::front::test::FakeGateway::sendMessageByNodeID(
+    const std::string& _groupID, int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID,
+    bcos::crypto::NodeIDPtr _dstNodeID,
+    ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads)
 {
+    bcos::bytes buffer;
+    for (auto const& data : _payloads)
+    {
+        buffer.insert(buffer.end(), data.begin(), data.end());
+    }
     if (auto frontService = m_frontService.lock())
     {
-        frontService->onReceiveMessage(_groupID, _dstNodeID, _payload, _errorRespFunc);
+        frontService->onReceiveMessage(
+            _groupID, _dstNodeID, bcos::ref(buffer), bcos::gateway::ErrorRespFunc());
     }
 
-    FRONT_LOG(DEBUG) << "[FakeGateway] asyncSendMessageByNodeID" << LOG_KV("groupID", _groupID)
+    FRONT_LOG(DEBUG) << "[FakeGateway] sendMessageByNodeID" << LOG_KV("groupID", _groupID)
                      << LOG_KV("nodeID", _srcNodeID->hex()) << LOG_KV("nodeID", _dstNodeID->hex());
-}
-
-/**
- * @brief: send message to multiple nodes
- * @param _groupID: groupID
- * @param _moduleID: moduleID
- * @param _nodeIDs: the receiver nodeIDs
- * @param _payload: message content
- * @return void
- */
-void FakeGateway::asyncSendMessageByNodeIDs(const std::string& _groupID, int,
-    bcos::crypto::NodeIDPtr _srcNodeID, const bcos::crypto::NodeIDs& _dstNodeIDs,
-    bytesConstRef _payload)
-{
-    if (!_dstNodeIDs.empty())
-    {
-        if (auto frontService = m_frontService.lock())
-        {
-            frontService->onReceiveMessage(
-                _groupID, _srcNodeID, _payload, bcos::gateway::ErrorRespFunc());
-        }
-    }
-
-    FRONT_LOG(DEBUG) << "[FakeGateway] asyncSendMessageByNodeIDs" << LOG_KV("groupID", _groupID);
+    co_return nullptr;
 }
 bcos::task::Task<void> bcos::front::test::FakeGateway::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,

--- a/bcos-front/test/unittests/FakeGateway.cpp
+++ b/bcos-front/test/unittests/FakeGateway.cpp
@@ -48,6 +48,10 @@ bcos::task::Task<bcos::Error::Ptr> bcos::front::test::FakeGateway::sendMessageBy
     {
         buffer.insert(buffer.end(), data.begin(), data.end());
     }
+    if (m_sendError)
+    {
+        co_return m_sendError;
+    }
     if (auto frontService = m_frontService.lock())
     {
         frontService->onReceiveMessage(

--- a/bcos-front/test/unittests/FakeGateway.h
+++ b/bcos-front/test/unittests/FakeGateway.h
@@ -42,6 +42,11 @@ public:
         m_frontService = _frontService;
     }
 
+    // when non-null, sendMessageByNodeID returns this error instead of delivering locally (lets
+    // tests exercise gateway-send-failure propagation into the coroutine send result)
+    Error::Ptr m_sendError;
+    void setSendError(Error::Ptr _error) { m_sendError = std::move(_error); }
+
     /**
      * @brief: start/stop service
      */

--- a/bcos-front/test/unittests/FakeGateway.h
+++ b/bcos-front/test/unittests/FakeGateway.h
@@ -63,30 +63,17 @@ public:
     }
 
     /**
-     * @brief: send message to a single node
+     * @brief: (coroutine) send message to a single node
      * @param _groupID: groupID
      * @param _moduleID: moduleID
      * @param _srcNodeID: the sender nodeID
      * @param _dstNodeID: the receiver nodeID
-     * @param _payload: message content
+     * @param _payloads: message content (views)
      * @return void
      */
-    void asyncSendMessageByNodeID(const std::string& _groupID, int _moduleID,
+    task::Task<Error::Ptr> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
         bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        bytesConstRef _payload, bcos::gateway::ErrorRespFunc _errorRespFunc) override;
-
-    /**
-     * @brief: send message to multiple nodes
-     * @param _groupID: groupID
-     * @param _moduleID: moduleID
-     * @param _srcNodeID: the sender nodeID
-     * @param _nodeIDs: the receiver nodeIDs
-     * @param _payload: message content
-     * @return void
-     */
-    void asyncSendMessageByNodeIDs(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, const bcos::crypto::NodeIDs& _dstNodeIDs,
-        bytesConstRef _payload) override;
+        ::ranges::any_view<bytesConstRef, ::ranges::category::forward> _payloads) override;
 
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID,

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -112,6 +112,26 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_fireAndForget)
     f.get();
 }
 
+BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_fireAndForget_propagatesGatewayError)
+{
+    // Round-8 review: the fire-and-forget branch (_timeout == 0) previously returned SendResult{}
+    // even when the gateway send failed, so the TARS fire-and-forget reply always encoded SUCCESS.
+    // The gateway failure must now be propagated in SendResult::error.
+    auto frontService = buildFrontService();
+    auto gateway = std::static_pointer_cast<FakeGateway>(frontService->gatewayInterface());
+    gateway->setSendError(BCOS_ERROR_PTR(12345, "gateway send failed"));
+
+    auto dstNodeID = createKey(g_dstNodeID_0);
+    std::string data(100, 'x');
+    auto result = task::syncWait(frontService->sendMessageByNodeID(111, dstNodeID,
+        ::ranges::views::single(bytesConstRef((unsigned char*)data.data(), data.size())), 0));
+    BOOST_REQUIRE(result.error);
+    BOOST_CHECK_EQUAL(result.error->errorCode(), 12345);
+    // nodeID/uuid stay default so the TARS server echoes the request nodeID/seq
+    BOOST_CHECK(!result.nodeID);
+    BOOST_CHECK(result.uuid.empty());
+}
+
 BOOST_AUTO_TEST_CASE(testFrontService_onRecieveNodeIDsAnd)
 {
     auto frontService = buildFrontService();

--- a/bcos-front/test/unittests/FrontServiceTest.cpp
+++ b/bcos-front/test/unittests/FrontServiceTest.cpp
@@ -31,6 +31,7 @@
 #include <bcos-utilities/testutils/TestPromptFixture.h>
 #include <boost/test/unit_test.hpp>
 #include <range/v3/view/single.hpp>
+#include <thread>
 
 using namespace bcos;
 using namespace bcos::test;
@@ -80,7 +81,7 @@ BOOST_AUTO_TEST_CASE(testFrontService_buildFrontService)
     BOOST_CHECK(frontService->moduleID2MessageDispatcher().empty());
 }
 
-BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeID_withoutCallback)
+BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_fireAndForget)
 {
     auto frontService = buildFrontService();
     auto gateway = std::static_pointer_cast<FakeGateway>(frontService->gatewayInterface());
@@ -103,8 +104,10 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeID_withoutCallback)
     BOOST_CHECK(frontService->moduleID2MessageDispatcher().find(moduleID) !=
                 frontService->moduleID2MessageDispatcher().end());
 
-    frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-        bytesConstRef((unsigned char*)data.data(), data.size()), 0, CallbackFunc());
+    // fire-and-forget coroutine send (timeout == 0): the module dispatcher is invoked via the fake
+    // gateway's local delivery
+    task::syncWait(frontService->sendMessageByNodeID(moduleID, dstNodeID,
+        ::ranges::views::single(bytesConstRef((unsigned char*)data.data(), data.size())), 0));
     BOOST_CHECK(frontService->callback().empty());
     f.get();
 }
@@ -152,44 +155,49 @@ BOOST_AUTO_TEST_CASE(testFrontService_onRecieveNodeIDsAnd)
     }
 }
 
-BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeID_callback)
+BOOST_AUTO_TEST_CASE(testFrontService_asyncSendResponse_coroutine)
 {
     auto frontService = buildFrontService();
-    auto gateway = std::static_pointer_cast<FakeGateway>(frontService->gatewayInterface());
-
     auto dstNodeID = createKey(g_dstNodeID_0);
     std::string data(100000, '#');
     int moduleID = 12345;
 
-    {
-        std::promise<bool> p;
-        auto f = p.get_future();
-        auto callback = [dstNodeID, data, &p](Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
-                            bytesConstRef _data, const std::string& _uuid,
-                            std::function<void(bytesConstRef _respData)> _respFunc) {
-            (void)_uuid;
-            (void)_respFunc;
-            BOOST_CHECK(_error == nullptr);
-            BOOST_CHECK_EQUAL(dstNodeID->hex(), _nodeID->hex());
-            BOOST_CHECK_EQUAL(std::string(_data.begin(), _data.end()), data);
-            p.set_value(true);
-        };
-        frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()), 0, callback);
-        BOOST_CHECK(!frontService->callback().empty());
-        auto uuid = frontService->callback().begin()->first;
-        frontService->asyncSendResponse(uuid, moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()),
-            [](Error::Ptr _error) { (void)_error; });
-        f.get();
-        BOOST_CHECK(frontService->callback().empty());
-    }
+    // the module dispatcher replies through the (kept) asyncSendResponse API, which is now a thin
+    // wrapper over the coroutine sendMessage(isResponse=true)
+    auto resultPromise = std::make_shared<std::promise<SendResult>>();
+    auto resultFuture = resultPromise->get_future();
+    frontService->registerModuleMessageDispatcher(moduleID,
+        [frontService, dstNodeID, moduleID, data](bcos::crypto::NodeIDPtr _nodeID,
+            const std::string& _id, bytesConstRef _data) {
+            (void)_nodeID;
+            (void)_data;
+            frontService->asyncSendResponse(_id, moduleID, dstNodeID,
+                bytesConstRef((unsigned char*)data.data(), data.size()),
+                [](Error::Ptr _error) { (void)_error; });
+        });
+
+    auto self = frontService;
+    task::wait(
+        [](decltype(self) _self, decltype(dstNodeID) _dstNodeID, int _moduleID, std::string _data,
+            std::shared_ptr<std::promise<SendResult>> _resultPromise) -> task::Task<void> {
+            auto result = co_await _self->sendMessageByNodeID(_moduleID, _dstNodeID,
+                ::ranges::views::single(bytesConstRef(
+                    reinterpret_cast<const bcos::byte*>(_data.data()), _data.size())),
+                5000);
+            _resultPromise->set_value(std::move(result));
+        }(self, dstNodeID, moduleID, data, resultPromise));
+
+    auto status = resultFuture.wait_for(std::chrono::seconds(10));
+    BOOST_REQUIRE(status == std::future_status::ready);
+    auto result = resultFuture.get();
+    BOOST_CHECK(!result.error);
+    BOOST_CHECK_EQUAL(std::string(result.payload.begin(), result.payload.end()), data);
+    BOOST_CHECK(frontService->callback().empty());
 }
 
-BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDcmak_timeout)
+BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_timeout)
 {
     auto frontService = buildFrontService();
-    auto gateway = std::static_pointer_cast<FakeGateway>(frontService->gatewayInterface());
 
     int moduleID = 222;
     auto dstNodeID = createKey(g_dstNodeID_0);
@@ -197,34 +205,12 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDcmak_timeout)
 
     BOOST_CHECK(frontService->callback().empty());
 
-    // Use shared_ptr for barrier so it stays alive even if the lambda
-    // outlives this scope (defensive against delayed dispatch).
-    auto barrier = std::make_shared<std::promise<void>>();
-    std::future<void> barrier_future = barrier->get_future();
-    {
-        auto callback = [barrier](Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
-                            bytesConstRef _data, const std::string& _uuid,
-                            std::function<void(bytesConstRef _respData)> _respFunc) {
-            (void)_nodeID;
-            (void)_data;
-            (void)_respFunc;
-            (void)_uuid;
-            BOOST_CHECK_EQUAL(_error->errorCode(), bcos::protocol::CommonError::TIMEOUT);
-            barrier->set_value();
-        };
+    auto result = task::syncWait(frontService->sendMessageByNodeID(moduleID, dstNodeID,
+        ::ranges::views::single(bytesConstRef((unsigned char*)data.data(), data.size())), 2000));
 
-        frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()), 2000, callback);
-
-        BOOST_CHECK(frontService->callback().size() == 1);
-        // Use wait_for with a generous timeout (10 s, 5× the msg timeout) so that
-        // a stuck IO thread or a dropped timer does not hang the test indefinitely.
-        // Similar guard already present in testFrontService_onRecieveNodeIDsAnd.
-        auto status = barrier_future.wait_for(std::chrono::seconds(10));
-        BOOST_CHECK_MESSAGE(status == std::future_status::ready,
-            "Timed out waiting for asyncSendMessageByNodeID timeout callback");
-        BOOST_CHECK(frontService->callback().empty());
-    }
+    BOOST_REQUIRE(result.error);
+    BOOST_CHECK_EQUAL(result.error->errorCode(), bcos::protocol::CommonError::TIMEOUT);
+    BOOST_CHECK(frontService->callback().empty());
 }
 
 BOOST_AUTO_TEST_CASE(testFrontService_asyncSendBroadcastMessage)
@@ -343,7 +329,7 @@ BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_coroutine_withResponse
     BOOST_CHECK(result.respond);
 }
 
-BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDs)
+BOOST_AUTO_TEST_CASE(testFrontService_sendMessageByNodeID_toNode)
 {
     auto frontService = buildFrontService();
     auto gateway = std::static_pointer_cast<FakeGateway>(frontService->gatewayInterface());
@@ -366,8 +352,8 @@ BOOST_AUTO_TEST_CASE(testFrontService_asyncSendMessageByNodeIDs)
     BOOST_CHECK(frontService->moduleID2MessageDispatcher().find(moduleID) !=
                 frontService->moduleID2MessageDispatcher().end());
 
-    frontService->asyncSendMessageByNodeIDs(moduleID, bcos::crypto::NodeIDs{dstNodeID},
-        bytesConstRef((unsigned char*)data.data(), data.size()));
+    task::syncWait(frontService->sendMessageByNodeID(moduleID, dstNodeID,
+        ::ranges::views::single(bytesConstRef((unsigned char*)data.data(), data.size())), 0));
 
     BOOST_CHECK(frontService->callback().empty());
     f.get();
@@ -387,30 +373,28 @@ BOOST_AUTO_TEST_CASE(testFrontService_loopTimeout)
     std::vector<std::promise<void>> barriers;
     barriers.resize(1000);
 
+    std::vector<std::thread> senders;
+    senders.reserve(barriers.size());
     for (auto& barrier : barriers)
     {
-        Error::Ptr _error;
-        auto callback = [&](Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID, bytesConstRef _data,
-                            const std::string& _uuid,
-                            std::function<void(bytesConstRef _respData)> _respFunc) {
-            (void)_nodeID;
-            (void)_data;
-            (void)_uuid;
-            (void)_respFunc;
-            assert(_error->errorCode() == bcos::protocol::CommonError::TIMEOUT);
+        senders.emplace_back([frontService, moduleID, dstNodeID, data, &barrier]() {
+            auto result = task::syncWait(frontService->sendMessageByNodeID(moduleID, dstNodeID,
+                ::ranges::views::single(
+                    bytesConstRef((unsigned char*)data.data(), data.size())),
+                2000));
+            BOOST_CHECK(result.error);
+            if (result.error)
+            {
+                BOOST_CHECK_EQUAL(
+                    result.error->errorCode(), bcos::protocol::CommonError::TIMEOUT);
+            }
             barrier.set_value();
-        };
-
-        frontService->asyncSendMessageByNodeID(moduleID, dstNodeID,
-            bytesConstRef((unsigned char*)data.data(), data.size()), 2000, callback);
+        });
     }
 
-    BOOST_CHECK(frontService->callback().size() == barriers.size());
-
-    for (auto& barrier : barriers)
+    for (auto& t : senders)
     {
-        std::future<void> barrier_future = barrier.get_future();
-        barrier_future.wait();
+        t.join();
     }
 
     BOOST_CHECK(frontService->callback().empty());

--- a/bcos-gateway/bcos-gateway/Gateway.cpp
+++ b/bcos-gateway/bcos-gateway/Gateway.cpp
@@ -139,67 +139,6 @@ void Gateway::asyncGetGroupNodeInfo(
 }
 
 
-/**
- * @brief: send message
- * @param _groupID: groupID
- * @param _moduleID: moduleID
- * @param _srcNodeID: the sender nodeID
- * @param _dstNodeID: the receiver nodeID
- * @param _payload: message payload
- * @param _errorRespFunc: error func
- * @return void
- */
-void Gateway::asyncSendMessageByNodeID(const std::string& _groupID, int _moduleID,
-    NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bytesConstRef _payload,
-    ErrorRespFunc _errorRespFunc)
-{
-    // Local delivery first (zero-copy): when no remote gateway hosts the destination front, deliver
-    // directly through the local router table using the borrowed payload, exactly like the pre-PR
-    // path. Only the remote path copies the payload (into the coroutine frame) so the caller may
-    // release its buffer as soon as this returns.
-    auto p2pIDs =
-        m_gatewayNodeManager->peersRouterTable()->queryP2pIDs(_groupID, _dstNodeID->hex());
-    if (p2pIDs.empty())
-    {
-        if (m_gatewayNodeManager->localRouterTable()->sendMessage(
-                _groupID, _srcNodeID, _dstNodeID, _payload, _errorRespFunc))
-        {
-            return;
-        }
-        GATEWAY_LOG(DEBUG) << LOG_DESC("could not find a gateway to send this message")
-                           << LOG_KV("groupID", _groupID)
-                           << LOG_KV("srcNodeID", _srcNodeID->hex())
-                           << LOG_KV("dstNodeID", _dstNodeID->hex());
-        auto errorPtr = BCOS_ERROR_PTR(CommonError::NotFoundFrontServiceSendMsg,
-            "could not find a gateway to "
-            "send this message, groupID:" +
-                _groupID + " ,dstNodeID:" + _dstNodeID->hex());
-        if (_errorRespFunc)
-        {
-            _errorRespFunc(errorPtr);
-        }
-        return;
-    }
-
-    // Thin shim for the remote path: preserve the synchronous-copy contract for borrowed payloads
-    // (the caller may release its buffer as soon as this returns). The actual zero-copy, retrying
-    // send runs as a coroutine that owns the copied payload in its frame; the send result is
-    // delivered through _errorRespFunc (nullptr on success).
-    auto self = shared_from_this();
-    task::wait(
-        [](std::shared_ptr<Gateway> _self, std::string _groupID, int _moduleID,
-            NodeIDPtr _srcNodeID, NodeIDPtr _dstNodeID, bcos::bytes _payload,
-            ErrorRespFunc _errorRespFunc) -> task::Task<void> {
-            auto error = co_await _self->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
-                _dstNodeID, ::ranges::views::single(bcos::ref(std::as_const(_payload))));
-            if (_errorRespFunc)
-            {
-                _errorRespFunc(std::move(error));
-            }
-        }(self, std::string(_groupID), _moduleID, std::move(_srcNodeID), std::move(_dstNodeID),
-            bcos::bytes(_payload.begin(), _payload.end()), std::move(_errorRespFunc)));
-}
-
 bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(
     const std::string& _groupID, int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID,
     bcos::crypto::NodeIDPtr _dstNodeID,
@@ -364,34 +303,6 @@ bcos::task::Task<Error::Ptr> bcos::gateway::Gateway::sendMessageByNodeID(
     }
     co_return BCOS_ERROR_PTR(
         bcos::protocol::CommonError::GatewaySendMsgFailed, "unable to send the message");
-}
-
-/**
- * @brief: send message to multiple nodes
- * @param _groupID: groupID
- * @param _moduleID: moduleID
- * @param _srcNodeID: the sender nodeID
- * @param _nodeIDs: the receiver nodeIDs
- * @param _payload: message content
- * @return void
- */
-void Gateway::asyncSendMessageByNodeIDs(const std::string& _groupID, int _moduleID,
-    NodeIDPtr _srcNodeID, const NodeIDs& _dstNodeIDs, bytesConstRef _payload)
-{
-    for (auto dstNodeID : _dstNodeIDs)
-    {
-        asyncSendMessageByNodeID(_groupID, _moduleID, _srcNodeID, dstNodeID, _payload,
-            [_groupID, _srcNodeID, dstNodeID](Error::Ptr _error) {
-                if (!_error)
-                {
-                    return;
-                }
-                GATEWAY_LOG(TRACE)
-                    << LOG_DESC("asyncSendMessageByNodeIDs callback") << LOG_KV("groupID", _groupID)
-                    << LOG_KV("srcNodeID", _srcNodeID->hex())
-                    << LOG_KV("dstNodeID", dstNodeID->hex()) << LOG_KV("code", _error->errorCode());
-            });
-    }
 }
 
 /**

--- a/bcos-gateway/bcos-gateway/Gateway.h
+++ b/bcos-gateway/bcos-gateway/Gateway.h
@@ -64,20 +64,6 @@ public:
     void asyncGetGroupNodeInfo(
         const std::string& _groupID, GetGroupNodeInfoFunc _onGetGroupNodeInfo) override;
     /**
-     * @brief: send message
-     * @param _groupID: groupID
-     * @param _moduleID: moduleID
-     * @param _srcNodeID: the sender nodeID
-     * @param _dstNodeID: the receiver nodeID
-     * @param _payload: message payload
-     * @param _errorRespFunc: error func
-     * @return void
-     */
-    void asyncSendMessageByNodeID(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        bytesConstRef _payload, ErrorRespFunc _errorRespFunc) override;
-
-    /**
      * @brief: send message to multiple nodes
      * @param _groupID: groupID
      * @param _moduleID: moduleID
@@ -86,10 +72,6 @@ public:
      * @param _payload: message payload
      * @return void
      */
-    void asyncSendMessageByNodeIDs(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, const bcos::crypto::NodeIDs& _nodeIDs,
-        bytesConstRef _payload) override;
-
     task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads) override;

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.cpp
@@ -263,34 +263,6 @@ void PeersRouterTable::removeNodeFromGatewayInfo(P2pID const& _p2pID)
     }
 }
 
-// broadcast message to given group
-void PeersRouterTable::asyncBroadcastMsg(
-    uint16_t _type, std::string const& _groupID, uint16_t _moduleID, P2PMessage::Ptr _msg)
-{
-    size_t sendedCount = 0;
-    for (auto const& it : m_gatewayInfos)
-    {
-        // not broadcast message to the gateway-self
-        if (std::string p2pNodeID; it.first != m_uuid && it.second &&
-                                   it.second->randomChooseP2PNode(p2pNodeID, _type, _groupID))
-        {
-            if (c_fileLogLevel <= TRACE) [[unlikely]]
-            {
-                ROUTER_LOG(TRACE) << LOG_BADGE("PeersRouterTable") << LOG_DESC("asyncBroadcastMsg")
-                                  << LOG_KV("nodeType", _type) << LOG_KV("moduleID", _moduleID)
-                                  << LOG_KV("dst", printShortP2pID(p2pNodeID));
-            }
-            m_p2pInterface->asyncSendMessageByNodeID(p2pNodeID, _msg, {});
-            ++sendedCount;
-        }
-    }
-    ROUTER_LOG(TRACE) << LOG_BADGE("PeersRouterTable")
-                      << LOG_DESC("asyncBroadcastMsg: randomChooseP2PNode")
-                      << LOG_KV("nodeType", _type) << LOG_KV("moduleID", _moduleID)
-                      << LOG_KV("payloadSize", _msg->payload().size())
-                      << LOG_KV("peersSize", sendedCount);
-}
-
 bcos::task::Task<void> bcos::gateway::PeersRouterTable::broadcastMessage(uint16_t type,
     std::string_view group, uint16_t moduleID, const P2PMessageV2& message,
     ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads)

--- a/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
+++ b/bcos-gateway/bcos-gateway/gateway/PeersRouterTable.h
@@ -55,9 +55,6 @@ public:
     using Group2NodeIDListType = std::map<std::string, std::map<std::string, uint32_t>>;
     Group2NodeIDListType peersNodeIDList(P2pID const& _p2pNodeID) const;
 
-    void asyncBroadcastMsg(
-        uint16_t _type, std::string const& _group, uint16_t _moduleID, P2PMessage::Ptr _msg);
-
     task::Task<void> broadcastMessage(uint16_t type, std::string_view group, uint16_t moduleID,
         const P2PMessageV2& message,
         ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads);

--- a/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
+++ b/bcos-gateway/bcos-gateway/libamop/AMOPImpl.cpp
@@ -380,7 +380,7 @@ void AMOPImpl::asyncSendMessageByTopic(const std::string& _topic, bcos::bytesCon
                     {
                         AMOP_LOG(DEBUG)
                             << LOG_BADGE("RetrySender::sendMessage")
-                            << LOG_DESC("asyncSendMessageByNodeID callback response failed")
+                            << LOG_DESC("asyncSendMessageByP2PNodeID callback response failed")
                             << LOG_KV("nodeID", printShortP2pID(choosedNodeID))
                             << LOG_KV("code", _error->errorCode())
                             << LOG_KV("msg", _error->errorMessage());
@@ -545,8 +545,31 @@ void AMOPImpl::dispatcherAMOPMessage(
                 responseP2PMsg->setRespPacket();
                 responseP2PMsg->setPayload(*_responseData);
                 responseP2PMsg->setPacketType(_type);
-                m_network->asyncSendMessageByNodeID(
-                    responseP2PMsg->dstP2PNodeID(), responseP2PMsg, nullptr);
+                // send the AMOP response through the coroutine fast path: the message is passed as
+                // a coroutine parameter so it is copied into the frame and stays alive for the
+                // (possibly deferred) send; its payload rides as a view (zero-copy).
+                auto network = m_network;
+                task::wait([](P2PInterface::Ptr _network,
+                               std::shared_ptr<P2PMessage> _responseP2PMsg) -> task::Task<void> {
+                    try
+                    {
+                        co_await _network->sendMessageByNodeID(_responseP2PMsg->dstP2PNodeID(),
+                            *_responseP2PMsg,
+                            ::ranges::views::single(_responseP2PMsg->payload()), Options{});
+                    }
+                    catch (std::exception const& e)
+                    {
+                        // A synchronous pre-send rejection (rate limit / max size) or an async
+                        // write failure on the AMOP response path is expected during bandwidth
+                        // saturation — log the dst and seq so the response-loss investigation
+                        // keeps the routing dimension.
+                        AMOP_LOG(WARNING) << LOG_BADGE("onReceiveAMOPMessage")
+                                          << LOG_DESC("send response failed")
+                                          << LOG_KV("seq", _responseP2PMsg->seq())
+                                          << LOG_KV("dst", _responseP2PMsg->dstP2PNodeID())
+                                          << LOG_KV("what", boost::diagnostic_information(e));
+                    }
+                }(network, responseP2PMsg));
             });
         break;
     case AMOPMessage::Type::AMOPBroadcast:

--- a/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
+++ b/bcos-gateway/bcos-gateway/libp2p/P2PInterface.h
@@ -38,11 +38,8 @@ public:
 
     virtual P2pID id() const = 0;
 
-    virtual void asyncSendMessageByNodeID(P2pID nodeID, std::shared_ptr<P2PMessage> message,
-        CallbackFuncWithSession callback, Options options = {}) = 0;
     virtual task::Task<Message::Ptr> sendMessageByNodeID(P2pID nodeID, P2PMessage& header,
         ::ranges::any_view<bytesConstRef> payloads, Options options = {}) = 0;
-    virtual void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) = 0;
 
     // (coroutine) broadcast a message to all connected/reachable nodes. The message is handed over
     // as a shared_ptr: the per-peer fan-out tasks keep it alive (the payload rides as a view,

--- a/bcos-gateway/bcos-gateway/libp2p/Service.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.cpp
@@ -330,51 +330,6 @@ void Service::onDisconnect(NetworkException e, P2PSession::Ptr p2pSession)
     // heartBeat();
 }
 
-void Service::sendMessageToSession(P2PSession::Ptr _p2pSession, P2PMessage::Ptr _msg,
-    Options _options, CallbackFuncWithSession _callback)
-{
-    auto protocolVersion = _p2pSession->protocolInfo()->version();
-    // Note: p2pMessage version is binded to the protocol version
-    _msg->setVersion(protocolVersion);
-    auto self = shared_from_this();
-    // route through the coroutine fast path: the message (shared_ptr), the session and the callback
-    // are passed as coroutine parameters so they are copied into the frame and stay alive for the
-    // whole (possibly deferred) send; the payload is sent as a view (zero-copy); the response (if
-    // requested) resumes the coroutine and is delivered to _callback.
-    task::wait([](std::shared_ptr<Service> _self, P2PSession::Ptr _p2pSession,
-                   P2PMessage::Ptr _msg, Options _options,
-                   CallbackFuncWithSession _callback) mutable -> task::Task<void> {
-        Options sendOptions{_options.timeout, _callback ? true : false};
-        try
-        {
-            auto resp = co_await _p2pSession->fastSendP2PMessage(
-                *_msg, ::ranges::views::single(_msg->payload()), sendOptions);
-            if (_callback)
-            {
-                P2PMessage::Ptr p2pMessage = std::dynamic_pointer_cast<P2PMessage>(resp);
-                _callback(NetworkException(), _p2pSession, p2pMessage);
-            }
-        }
-        catch (NetworkException const& e)
-        {
-            if (_callback)
-            {
-                _callback(e, _p2pSession, nullptr);
-            }
-        }
-        catch (std::exception const& e)
-        {
-            SERVICE_LOG(WARNING) << LOG_DESC("sendMessageToSession exception")
-                                 << LOG_KV("what", boost::diagnostic_information(e));
-            if (_callback)
-            {
-                _callback(
-                    NetworkException(-1, boost::diagnostic_information(e)), _p2pSession, nullptr);
-            }
-        }
-    }(self, _p2pSession, _msg, _options, _callback));
-}
-
 void Service::sendRespMessageBySession(
     bytesConstRef _payload, P2PMessage::Ptr _p2pMessage, P2PSession::Ptr _p2pSession)
 {
@@ -516,120 +471,6 @@ void Service::onMessage(NetworkException e, SessionFace::Ptr session, Message::P
     }
 }
 
-void Service::asyncSendMessageByEndPoint(NodeIPEndpoint const& _endpoint, P2PMessage::Ptr message,
-    CallbackFuncWithSession callback, Options options)
-{
-    std::shared_lock lock(x_sessions);
-    for (auto const& it : m_sessions)
-    {
-        if (it.second->session()->nodeIPEndpoint() == _endpoint)
-        {
-            sendMessageToSession(it.second, message, options, callback);
-            break;
-        }
-    }
-}
-
-void Service::asyncSendMessageByNodeID(
-    P2pID nodeID, P2PMessage::Ptr message, CallbackFuncWithSession callback, Options options)
-{
-    try
-    {
-        if (nodeID == id())
-        {
-            // ignore myself
-            return;
-        }
-
-        auto session = getP2PSessionByNodeId(nodeID);
-        if (session && session->active())
-        {
-            if (message->seq() == 0)
-            {
-                message->setSeq(m_messageFactory->newSeq());
-            }
-            // for compatibility_version consideration
-            sendMessageToSession(std::move(session), message, options, callback);
-        }
-        else
-        {
-            if (callback)
-            {
-                NetworkException e(-1, "send message failed for no network established");
-                callback(e, nullptr, nullptr);
-            }
-            SERVICE_LOG(INFO) << "Node inactive" << LOG_KV("nodeid", printShortP2pID(nodeID));
-        }
-    }
-    catch (std::exception& e)
-    {
-        SERVICE_LOG(ERROR) << "asyncSendMessageByNodeID"
-                           << LOG_KV("nodeid", printShortP2pID(nodeID))
-                           << LOG_KV("what", boost::diagnostic_information(e));
-
-        if (callback)
-        {
-            callback(
-                NetworkException(Disconnect, "Disconnect"), P2PSession::Ptr(), P2PMessage::Ptr());
-        }
-    }
-}
-
-void Service::asyncBroadcastMessage(P2PMessage::Ptr message, Options options)
-{
-    try
-    {
-        // FIB-186 (vector D): snapshot the session keys under x_sessions and release it BEFORE the
-        // per-session send, which re-acquires x_sessions(shared) via sendMessageByNodeID. Holding
-        // x_sessions across that re-acquisition is a recursive shared lock: once an onConnect
-        // thread is waiting for x_sessions(W), libc++ writer-priority blocks the second
-        // lock_shared(), so this thread can neither finish nor release its first shared lock and
-        // every session operation (including all PBFT delivery) stalls -> consensus halts under
-        // connection churn.
-        std::vector<P2pID> nodeIDs;
-        {
-            std::shared_lock lock(x_sessions);
-            nodeIDs.reserve(m_sessions.size());
-            for (auto const& session : m_sessions)
-            {
-                nodeIDs.push_back(session.first);
-            }
-        }
-        auto self = shared_from_this();
-        // Fan out one independent coroutine per peer: each task holds the shared message, and its
-        // per-session src/dst/version stamping runs synchronously before its first suspension, so
-        // the tasks never race on the shared header and no peer's socket-write blocks the peers
-        // behind it (base enqueued every peer and returned immediately).
-        for (auto const& nodeID : nodeIDs)
-        {
-            task::wait([](std::shared_ptr<Service> _self, P2pID _nodeID,
-                           P2PMessage::Ptr _message, Options _options) mutable
-                           -> task::Task<void> {
-                // catch both the synchronous pre-send rejection (rate limit / max size, thrown
-                // before the first suspension) and the asynchronous write failure (NetworkException
-                // from fastSendMessageWithoutResponse's await_resume): the latter would otherwise
-                // fall through to Session::write's generic post-handler without the target node id
-                try
-                {
-                    co_await _self->sendMessageByNodeID(_nodeID, *_message,
-                        ::ranges::views::single(_message->payload()), _options);
-                }
-                catch (std::exception const& e)
-                {
-                    SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage send failed")
-                                         << LOG_KV("nodeid", printShortP2pID(_nodeID))
-                                         << LOG_KV("what", boost::diagnostic_information(e));
-                }
-            }(self, nodeID, message, options));
-        }
-    }
-    catch (std::exception& e)
-    {
-        SERVICE_LOG(WARNING) << LOG_DESC("asyncBroadcastMessage")
-                             << LOG_KV("what", boost::diagnostic_information(e));
-    }
-}
-
 bcos::task::Task<void> Service::broadcastMessageToAll(P2PMessage::Ptr message,
     ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads, Options options)
 {
@@ -643,8 +484,8 @@ bcos::task::Task<void> Service::broadcastMessageToAll(P2PMessage::Ptr message,
         }
     }
     auto self = shared_from_this();
-    // Fan out one independent coroutine per peer (see asyncBroadcastMessage): the caller's message
-    // is handed over as a shared_ptr so every per-peer task keeps it alive; each task's
+    // Fan out one independent coroutine per peer (see broadcastMessageToNeighbors): the caller's
+    // message is handed over as a shared_ptr so every per-peer task keeps it alive; each task's
     // per-session src/dst/version stamping runs synchronously before its first suspension, so no
     // race on the shared header and no head-of-line blocking on a stalled peer's socket.
     for (auto const& nodeID : nodeIDs)
@@ -684,7 +525,7 @@ bcos::task::Task<void> Service::broadcastMessageToNeighbors(P2PMessage::Ptr mess
         }
     }
     auto self = shared_from_this();
-    // Fan out one independent coroutine per peer (see asyncBroadcastMessage): the caller's message
+    // Fan out one independent coroutine per peer: the caller's message
     // is handed over as a shared_ptr so every per-peer task keeps it alive; each task's
     // per-session src/dst/version stamping runs synchronously before its first suspension, so no
     // race on the shared header and no head-of-line blocking on a stalled peer's socket.
@@ -759,9 +600,10 @@ void Service::asyncSendMessageByP2PNodeID(uint16_t _type, P2pID _dstNodeID, byte
         if (!_callback)
         {
             // fire-and-forget: an unreachable peer (session dropped between the isReachable check
-            // and the send) is an expected, recoverable state — log and continue, matching the old
-            // asyncSendMessageByNodeID "Node inactive" behaviour, instead of throwing out of
-            // task::wait and aborting the remaining nodes in asyncSendMessageByP2PNodeIDs.
+            // and the send) is an expected, recoverable state — log and continue. sendMessageByNodeID
+            // throws NetworkException for an inactive session instead of invoking a callback, so
+            // catching it here keeps task::wait from unwinding and aborting the remaining nodes in
+            // asyncSendMessageByP2PNodeIDs.
             try
             {
                 co_await _self->sendMessageByNodeID(_dstNodeID, message,

--- a/bcos-gateway/bcos-gateway/libp2p/Service.h
+++ b/bcos-gateway/bcos-gateway/libp2p/Service.h
@@ -53,13 +53,8 @@ public:
     void sendRespMessageBySession(
         bytesConstRef _payload, P2PMessage::Ptr _p2pMessage, P2PSession::Ptr _p2pSession) override;
 
-    void asyncSendMessageByNodeID(P2pID nodeID, std::shared_ptr<P2PMessage> message,
-        CallbackFuncWithSession callback, Options options = Options()) override;
-
     task::Task<Message::Ptr> sendMessageByNodeID(P2pID nodeID, P2PMessage& header,
         ::ranges::any_view<bytesConstRef> payloads, Options options = Options()) override;
-
-    void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) override;
 
     /**
      * @brief: (coroutine) broadcast a message to all connected sessions. The message is handed
@@ -124,9 +119,6 @@ public:
 
     void eraseHandlerByMsgType(uint16_t _type) override;
 
-    void asyncSendMessageByEndPoint(NodeIPEndpoint const& _endPoint, P2PMessage::Ptr message,
-        CallbackFuncWithSession callback, Options options = Options());
-
     void setOnMessageHandler(
         std::function<std::optional<bcos::Error>(SessionFace::Ptr, Message::Ptr)> _handler);
 
@@ -140,8 +132,6 @@ public:
 
 protected:
     std::shared_ptr<P2PSession> getP2PSessionByNodeIdWithoutLock(P2pID const& _nodeID) const;
-    virtual void sendMessageToSession(P2PSession::Ptr _p2pSession, P2PMessage::Ptr _msg,
-        Options = Options(), CallbackFuncWithSession = CallbackFuncWithSession());
 
     std::shared_ptr<P2PMessage> newP2PMessage(uint16_t _type, bytesConstRef _payload);
     // handshake protocol

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.cpp
@@ -322,49 +322,6 @@ bool ServiceV2::eraseSeq(std::string const& _p2pNodeID)
     return true;
 }
 
-void ServiceV2::asyncSendMessageByNodeIDWithMsgForward(
-    std::shared_ptr<P2PMessage> _message, CallbackFuncWithSession _callback, Options _options)
-{
-    auto dstNodeID = _message->dstP2PNodeID();
-    // without nextHop: maybe network unreachable or with distance equal to 1
-    auto nextHop = m_routerTable->getNextHop(dstNodeID);
-    if (nextHop.empty())
-    {
-        if (c_fileLogLevel == TRACE) [[unlikely]]
-        {
-            SERVICE2_LOG(TRACE) << LOG_BADGE("asyncSendMessageByNodeIDWithMsgForward")
-                                << LOG_DESC("sendMessage to dstNode")
-                                << LOG_KV("from", _message->printSrcP2PNodeID())
-                                << LOG_KV("to", _message->printDstP2PNodeID())
-                                << LOG_KV("type", _message->packetType())
-                                << LOG_KV("seq", _message->seq())
-                                << LOG_KV("rsp", _message->isRespPacket());
-        }
-        return Service::asyncSendMessageByNodeID(dstNodeID, _message, _callback, _options);
-    }
-    // with nextHop, send the message to nextHop
-    if (c_fileLogLevel == TRACE) [[unlikely]]
-    {
-        SERVICE2_LOG(TRACE) << LOG_BADGE("asyncSendMessageByNodeIDWithMsgForward")
-                            << LOG_DESC("forwardMessage to nextHop")
-                            << LOG_KV("from", _message->printSrcP2PNodeID())
-                            << LOG_KV("to", _message->printDstP2PNodeID())
-                            << LOG_KV("nextHop", printShortP2pID(nextHop))
-                            << LOG_KV("type", _message->packetType())
-                            << LOG_KV("seq", _message->seq())
-                            << LOG_KV("rsp", _message->isRespPacket());
-    }
-    return Service::asyncSendMessageByNodeID(nextHop, _message, _callback, _options);
-}
-
-void ServiceV2::asyncSendMessageByNodeID(P2pID _nodeID, std::shared_ptr<P2PMessage> _message,
-    CallbackFuncWithSession _callback, Options _options)
-{
-    _message->setSrcP2PNodeID(m_nodeID);
-    _message->setDstP2PNodeID(_nodeID);
-    asyncSendMessageByNodeIDWithMsgForward(_message, _callback, _options);
-}
-
 void ServiceV2::onMessage(NetworkException _error, SessionFace::Ptr _session, Message::Ptr _message,
     std::weak_ptr<P2PSession> _p2pSessionWeakPtr)
 {
@@ -451,42 +408,6 @@ void ServiceV2::onMessage(NetworkException _error, SessionFace::Ptr _session, Me
     }(self, p2pMsg));
 }
 
-void ServiceV2::asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options)
-{
-    try
-    {
-        auto reachableNodes = m_routerTable->getAllReachableNode();
-        auto selfV2 = std::static_pointer_cast<ServiceV2>(shared_from_this());
-        // Fan out one independent coroutine per peer (see Service::asyncBroadcastMessage): each
-        // task holds the shared message, its per-session src/dst/version stamping runs
-        // synchronously before its first suspension, and no peer's socket-write blocks the peers
-        // behind it.
-        for (auto const& node : reachableNodes)
-        {
-            task::wait([](std::shared_ptr<ServiceV2> _self, P2pID _node,
-                           std::shared_ptr<P2PMessage> _message,
-                           Options _options) mutable -> task::Task<void> {
-                try
-                {
-                    co_await _self->sendMessageByNodeID(_node, *_message,
-                        ::ranges::views::single(_message->payload()), _options);
-                }
-                catch (std::exception const& e)
-                {
-                    SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
-                                          << LOG_KV("node", printShortP2pID(_node))
-                                          << LOG_KV("what", boost::diagnostic_information(e));
-                }
-            }(selfV2, node, message, options));
-        }
-    }
-    catch (std::exception& e)
-    {
-        SERVICE2_LOG(WARNING) << LOG_BADGE("asyncBroadcastMessage")
-                              << LOG_KV("what", boost::diagnostic_information(e));
-    }
-}
-
 bcos::task::Task<void> ServiceV2::broadcastMessageToAll(P2PMessage::Ptr message,
     ::ranges::any_view<bytesConstRef, ::ranges::category::forward> payloads, Options options)
 {
@@ -512,13 +433,6 @@ bcos::task::Task<void> ServiceV2::broadcastMessageToAll(P2PMessage::Ptr message,
         }(selfV2, node, message, payloads, options));
     }
     co_return;
-}
-
-// broadcast message without forward
-void ServiceV2::asyncBroadcastMessageWithoutForward(
-    std::shared_ptr<P2PMessage> message, Options options)
-{
-    Service::asyncBroadcastMessage(std::move(message), options);
 }
 
 bool ServiceV2::isReachable(P2pID const& _nodeID) const

--- a/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
+++ b/bcos-gateway/bcos-gateway/libp2p/ServiceV2.h
@@ -42,14 +42,10 @@ public:
     void start() override;
     void stop() override;
 
-    void asyncSendMessageByNodeID(P2pID nodeID, std::shared_ptr<P2PMessage> message,
-        CallbackFuncWithSession callback, Options options = Options()) override;
-
     void onMessage(NetworkException _error, SessionFace::Ptr session, Message::Ptr message,
         std::weak_ptr<P2PSession> p2pSessionWeakPtr) override;
     void sendRespMessageBySession(
         bytesConstRef _payload, P2PMessage::Ptr _p2pMessage, P2PSession::Ptr _p2pSession) override;
-    void asyncBroadcastMessage(std::shared_ptr<P2PMessage> message, Options options) override;
     bool isReachable(P2pID const& _nodeID) const override;
 
     // (coroutine) broadcast to all reachable nodes through the router table
@@ -97,12 +93,6 @@ protected:
     virtual void onEraseSession(P2PSession::Ptr _session);
     bool tryToUpdateSeq(std::string const& _p2pNodeID, uint32_t _seq);
     bool eraseSeq(std::string const& _p2pNodeID);
-
-    virtual void asyncSendMessageByNodeIDWithMsgForward(std::shared_ptr<P2PMessage> _message,
-        CallbackFuncWithSession _callback, Options options = Options());
-
-    virtual void asyncBroadcastMessageWithoutForward(
-        std::shared_ptr<P2PMessage> message, Options options);
 
     void updateP2pInfo(P2PInfo const& p2pInfo);
     void tryToUpdateRawP2pInfo(P2PInfo const& p2pInfo);

--- a/bcos-gateway/test/integtests/GatewayTest.cpp
+++ b/bcos-gateway/test/integtests/GatewayTest.cpp
@@ -21,8 +21,10 @@
 
 #include "../common/FrontServiceBuilder.h"
 #include "bcos-framework/protocol/CommonError.h"
+#include "bcos-task/Wait.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <boost/test/unit_test.hpp>
+#include <range/v3/view/single.hpp>
 
 using namespace bcos;
 using namespace bcos::test;
@@ -84,24 +86,14 @@ BOOST_AUTO_TEST_CASE(test_FrontServiceEcho)
 
                 auto payload = bcos::bytesConstRef((bcos::byte*)sendStr.data(), sendStr.size());
 
-                std::promise<bool> p;
-                auto f = p.get_future();
+                auto result = task::syncWait(frontService->sendMessageByNodeID(
+                    bcos::protocol::ModuleID::AMOP, nodeID, ::ranges::views::single(payload),
+                    10000));
 
-                frontService->asyncSendMessageByNodeID(bcos::protocol::ModuleID::AMOP, nodeID,
-                    payload, 10000,
-                    [sendStr, &p](Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
-                        bytesConstRef _data, const std::string& _id,
-                        bcos::front::ResponseFunc _respFunc) {
-                        p.set_value(true);
-                        (void)_respFunc;
-                        (void)_nodeID;
-                        BOOST_CHECK(!_id.empty());
-                        BOOST_CHECK(_error == nullptr);
-                        std::string retStr = std::string(_data.begin(), _data.end());
-                        BOOST_CHECK_EQUAL(sendStr, retStr);
-                    });
-
-                f.get();
+                BOOST_CHECK(!result.uuid.empty());
+                BOOST_CHECK(result.error == nullptr);
+                std::string retStr(result.payload.begin(), result.payload.end());
+                BOOST_CHECK_EQUAL(sendStr, retStr);
             }
         });
     }
@@ -127,25 +119,14 @@ BOOST_AUTO_TEST_CASE(test_FrontServiceTimeout)
 
                 auto payload = bcos::bytesConstRef((bcos::byte*)sendStr.data(), sendStr.size());
 
-                std::promise<bool> p;
-                auto f = p.get_future();
+                auto result = task::syncWait(frontService->sendMessageByNodeID(
+                    bcos::protocol::ModuleID::AMOP + 1, nodeID, ::ranges::views::single(payload),
+                    10000));
 
-                frontService->asyncSendMessageByNodeID(bcos::protocol::ModuleID::AMOP + 1, nodeID,
-                    payload, 10000,
-                    [sendStr, &p](Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
-                        bytesConstRef _data, const std::string& _id,
-                        bcos::front::ResponseFunc _respFunc) {
-                        p.set_value(true);
-                        (void)_respFunc;
-                        (void)_nodeID;
-                        (void)_data;
-                        BOOST_CHECK(!_id.empty());
-                        BOOST_CHECK(_error != nullptr);
-                        BOOST_CHECK_EQUAL(
-                            _error->errorCode(), bcos::protocol::CommonError::TIMEOUT);
-                    });
-
-                f.get();
+                BOOST_CHECK(!result.uuid.empty());
+                BOOST_CHECK(result.error != nullptr);
+                BOOST_CHECK_EQUAL(
+                    result.error->errorCode(), bcos::protocol::CommonError::TIMEOUT);
             }
         });
     }

--- a/bcos-gateway/test/main/main.cpp
+++ b/bcos-gateway/test/main/main.cpp
@@ -22,7 +22,9 @@
 #include <thread>
 
 #include "../common/FrontServiceBuilder.h"
+#include <bcos-task/Wait.h>
 #include <bcos-utilities/BoostLog.h>
+#include <range/v3/view/single.hpp>
 
 using namespace std;
 using namespace bcos;
@@ -91,35 +93,32 @@ int main(int argc, const char** argv)
 
                         auto payload = bytesConstRef((bcos::byte*)randStr.data(), randStr.size());
 
-                        frontService->asyncSendMessageByNodeID(bcos::protocol::ModuleID::AMOP,
-                            nodeID, payload, 0,
-                            [randStr](Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
-                                bytesConstRef _data, const std::string& _id,
-                                bcos::front::ResponseFunc _respFunc) {
-                                (void)_respFunc;
-                                if (_error && (_error->errorCode() != 0))
-                                {
-                                    GATEWAY_MAIN_LOG(ERROR)
-                                        << LOG_DESC("request error") << LOG_KV("to", _nodeID->hex())
-                                        << LOG_KV("id", _id);
-                                    return;
-                                }
+                        auto result = task::syncWait(frontService->sendMessageByNodeID(
+                            bcos::protocol::ModuleID::AMOP, nodeID,
+                            ::ranges::views::single(payload), 10000));
 
-                                std::string retMsg = std::string(_data.begin(), _data.end());
-                                if (retMsg == randStr)
-                                {
-                                    GATEWAY_MAIN_LOG(INFO)
-                                        << LOG_DESC("response ok") << LOG_KV("from", _nodeID->hex())
-                                        << LOG_KV("id", _id);
-                                }
-                                else
-                                {
-                                    GATEWAY_MAIN_LOG(ERROR)
-                                        << LOG_DESC("response error")
-                                        << LOG_KV("from", _nodeID->hex()) << LOG_KV("id", _id)
-                                        << LOG_KV("req", randStr) << LOG_KV("rep", retMsg);
-                                }
-                            });
+                        if (result.error && (result.error->errorCode() != 0))
+                        {
+                            GATEWAY_MAIN_LOG(ERROR)
+                                << LOG_DESC("request error") << LOG_KV("to", nodeID->hex())
+                                << LOG_KV("id", result.uuid);
+                            continue;
+                        }
+
+                        std::string retMsg(result.payload.begin(), result.payload.end());
+                        if (retMsg == randStr)
+                        {
+                            GATEWAY_MAIN_LOG(INFO)
+                                << LOG_DESC("response ok") << LOG_KV("from", nodeID->hex())
+                                << LOG_KV("id", result.uuid);
+                        }
+                        else
+                        {
+                            GATEWAY_MAIN_LOG(ERROR)
+                                << LOG_DESC("response error") << LOG_KV("from", nodeID->hex())
+                                << LOG_KV("id", result.uuid) << LOG_KV("req", randStr)
+                                << LOG_KV("rep", retMsg);
+                        }
                     }
                 });
         }

--- a/bcos-gateway/test/main/p2p_echo_perf.cpp
+++ b/bcos-gateway/test/main/p2p_echo_perf.cpp
@@ -22,6 +22,7 @@
 #include "bcos-gateway/libnetwork/Common.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-tars-protocol/protocol/ProtocolInfoCodecImpl.h"
+#include "bcos-task/Wait.h"
 #include "bcos-utilities/BoostLogInitializer.h"
 #include "bcos-utilities/Common.h"
 #include "bcos-utilities/RateCollector.h"
@@ -171,28 +172,23 @@ int main(int argc, const char** argv)
                 message->setSeq(messageFactory->newSeq());
                 timeWindowRateLimiter->acquire(1);
                 reporter->update(message->length(), true);
-                service->asyncSendMessageByNodeID(p2pID, message,
-                    [reporter](NetworkException _e, std::shared_ptr<P2PSession> _session,
-                        std::shared_ptr<P2PMessage> _message) {
-                        if (_e.errorCode() != P2PExceptionType::Success)
-                        {
-                            std::cerr << "\t[Client] recv exception, error code: " << _e.errorCode()
-                                      << " ,error message: " << _e.what() << std::endl;
-                            return;
-                        }
-
-                        // std::cerr << "\t[Client] recv response from server: "
-                        //           << std::string(
-                        //                  _message->payload().begin(),
-                        //                  _message->payload().end())
-                        //           << std::endl;
-                        // auto readPayload = _message->readPayload();
-                        // auto refBuffer = readPayload->asRefBuffer();
-
-                        // std::cerr << "\t[Client] recv response from server: "
-                        //           << std::string(refBuffer.begin(), refBuffer.end()) <<
-                        //           std::endl;
-                    });
+                // send through the coroutine fast path and wait for the echo response (replaces
+                // the removed asyncSendMessageByNodeID callback path): the message is passed as a
+                // coroutine parameter so it is copied into the frame and stays alive for the whole
+                // (possibly deferred) send.
+                task::wait([](P2PInterface::Ptr _service, P2pID _p2pID, P2PMessage::Ptr _message)
+                               -> task::Task<void> {
+                    try
+                    {
+                        co_await _service->sendMessageByNodeID(_p2pID, *_message,
+                            ::ranges::views::single(_message->payload()), Options{0, true});
+                    }
+                    catch (NetworkException const& e)
+                    {
+                        std::cerr << "\t[Client] recv exception, error code: " << e.errorCode()
+                                  << " ,error message: " << e.what() << std::endl;
+                    }
+                }(service, p2pID, message));
                 // std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
         }

--- a/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
+++ b/bcos-gateway/test/unittests/FIB186_BroadcastLockOrderTest.cpp
@@ -14,12 +14,12 @@
  *  limitations under the License.
  *
  * @brief Regression test for FIB-186 vector D: the recursive x_sessions shared-lock deadlock in
- *        Service::asyncBroadcastMessage.
+ *        Service::broadcastMessageToAll (previously Service::asyncBroadcastMessage).
  * @file FIB186_BroadcastLockOrderTest.cpp
  * @date 2026-07-21
  *
- * asyncBroadcastMessage held x_sessions(shared) while looping over m_sessions and calling
- * asyncSendMessageByNodeID(), which re-acquires x_sessions(shared) via getP2PSessionByNodeId. That
+ * broadcastMessageToAll held x_sessions(shared) while looping over m_sessions and calling
+ * sendMessageByNodeID(), which re-acquires x_sessions(shared) via getP2PSessionByNodeId. That
  * is a RECURSIVE shared lock. std::shared_mutex is not recursive under a waiting writer: as soon as
  * an onConnect thread is blocked on x_sessions(W), libc++ writer-priority blocks the second
  * lock_shared(), so the broadcasting thread can neither finish nor release its first shared lock
@@ -29,14 +29,15 @@
  * recovery).
  *
  * The fix snapshots the session keys under x_sessions, releases it, then sends. This test drives
- * the real Service::asyncBroadcastMessage and asserts x_sessions is not held while it calls
- * asyncSendMessageByNodeID. It is RED on the pre-fix code and GREEN after.
+ * the real Service::broadcastMessageToAll and asserts x_sessions is not held while it calls
+ * sendMessageByNodeID. It is RED on the pre-fix code and GREEN after.
  */
 
 #include "bcos-framework/gateway/GatewayTypeDef.h"
 #include "bcos-gateway/libp2p/P2PMessage.h"
 #include "bcos-gateway/libp2p/P2PSession.h"
 #include "bcos-gateway/libp2p/Service.h"
+#include "bcos-task/Wait.h"
 #include "bcos-utilities/testutils/TestPromptFixture.h"
 #include <boost/test/unit_test.hpp>
 #include <atomic>
@@ -56,7 +57,7 @@ class BroadcastProbeService : public Service
 public:
     explicit BroadcastProbeService(P2PInfo const& _info) : Service(_info) {}
 
-    // Put one session in m_sessions so asyncBroadcastMessage's loop actually sends once; capture
+    // Put one session in m_sessions so broadcastMessageToAll's loop actually sends once; capture
     // x_sessions for the probe thread.
     void arm()
     {
@@ -64,10 +65,10 @@ public:
         m_sessions.emplace("peerRawP2pID", std::make_shared<P2PSession>());
     }
 
-    // asyncBroadcastMessage now sends through the coroutine fast path (sendMessageByNodeID) for
+    // broadcastMessageToAll sends through the coroutine fast path (sendMessageByNodeID) for
     // each session, after snapshotting the session keys under x_sessions and releasing it. This
     // virtual is called for each session; a probe thread tries to take x_sessions EXCLUSIVELY: it
-    // fails iff the broadcasting thread still holds it. No throw needed -- asyncBroadcastMessage
+    // fails iff the broadcasting thread still holds it. No throw needed -- broadcastMessageToAll
     // touches no host; we just probe the lock state and stop.
     task::Task<Message::Ptr> sendMessageByNodeID(P2pID /*nodeID*/, P2PMessage& /*header*/,
         ::ranges::any_view<bytesConstRef> /*payloads*/, Options /*options*/) override
@@ -108,14 +109,18 @@ BOOST_AUTO_TEST_CASE(BroadcastDoesNotHoldSessionsLockWhileSending)
     service->arm();
 
     auto message = std::make_shared<P2PMessage>();
-    service->asyncBroadcastMessage(message, Options());
+    task::wait([](std::shared_ptr<BroadcastProbeService> _service, P2PMessage::Ptr _message)
+                   -> task::Task<void> {
+        co_await _service->broadcastMessageToAll(
+            _message, ::ranges::views::single(_message->payload()), Options{});
+    }(service, message));
 
     BOOST_REQUIRE(service->m_sendInvoked.load());
     BOOST_CHECK_MESSAGE(!service->m_xSessionsHeldDuringSend.load(),
-        "FIB-186 vector D: asyncBroadcastMessage held x_sessions(shared) while sending to a "
+        "FIB-186 vector D: broadcastMessageToAll held x_sessions(shared) while sending to a "
         "session via sendMessageByNodeID (which re-acquires x_sessions via getP2PSessionByNodeId). "
         "That recursive shared lock deadlocks against a waiting onConnect writer and halts "
-        "consensus. asyncBroadcastMessage must snapshot the session keys under x_sessions, "
+        "consensus. broadcastMessageToAll must snapshot the session keys under x_sessions, "
         "release it, then send.");
 }
 

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -213,7 +213,7 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
         FrontServiceClient* m_self;
         int m_moduleID;
         bcos::crypto::NodeIDPtr m_nodeID;
-        std::shared_ptr<bcos::bytes> m_buffer;
+        std::shared_ptr<std::vector<char>> m_buffer;
         uint32_t m_timeout;
         std::shared_ptr<CompletionState> m_state;
 
@@ -226,15 +226,16 @@ bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMess
             auto nodeIDData = m_nodeID->data();
             m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
                 ->async_asyncSendMessageByNodeID(new Callback(state, m_self), m_moduleID,
-                    std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
-                    std::vector<char>(m_buffer->begin(), m_buffer->end()), m_timeout,
+                    std::vector<char>(nodeIDData.begin(), nodeIDData.end()), *m_buffer, m_timeout,
                     (m_timeout > 0));
         }
 
         bcos::front::SendResult await_resume() { return std::move(m_state->result); }
     };
 
-    auto buffer = std::make_shared<bcos::bytes>();
+    // materialise the joined payload directly as the std::vector<char> the RPC argument needs —
+    // a single pass and one allocation, no second copy in await_suspend
+    auto buffer = std::make_shared<std::vector<char>>();
     for (auto const& data : _payloads)
     {
         buffer->insert(buffer->end(), data.begin(), data.end());

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.cpp
@@ -145,52 +145,103 @@ void bcostars::FrontServiceClient::onReceiveBroadcastMessage(const std::string& 
             std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
             std::vector<char>(_data.begin(), _data.end()));
 }
-void bcostars::FrontServiceClient::asyncSendMessageByNodeID(int _moduleID,
-    bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data, uint32_t _timeout,
-    bcos::front::CallbackFunc _callback)
+bcos::task::Task<bcos::front::SendResult> bcostars::FrontServiceClient::sendMessageByNodeID(
+    int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
+    ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> _payloads,
+    uint32_t _timeout)
 {
-    class Callback : public FrontServicePrxCallback
+    struct SendAwaitable
     {
-    public:
-        Callback(bcos::front::CallbackFunc callback, FrontServiceClient* self)
-          : m_callback(callback), m_self(self)
-        {}
-
-        void callback_asyncSendMessageByNodeID(const bcostars::Error& ret,
-            const std::vector<tars::Char>& responseNodeID,
-            const std::vector<tars::Char>& responseData, const std::string& seq) override
+        struct CompletionState
         {
-            if (!m_callback)
-            {
-                return;
-            }
-            auto bcosNodeID = m_self->m_keyFactory->createKey(
-                bcos::bytesConstRef((bcos::byte*)responseNodeID.data(), responseNodeID.size()));
-            m_callback(toBcosError(ret), bcosNodeID,
-                bcos::bytesConstRef((bcos::byte*)responseData.data(), responseData.size()), seq,
-                bcos::front::ResponseFunc());
-        }
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::front::SendResult result;
+        };
 
-        void callback_asyncSendMessageByNodeID_exception(tars::Int32 ret) override
+        class Callback : public FrontServicePrxCallback
         {
-            if (!m_callback)
-            {
-                return;
-            }
-            m_callback(
-                toBcosError(ret), nullptr, bcos::bytesConstRef(), "", bcos::front::ResponseFunc());
-        }
+        public:
+            Callback(std::shared_ptr<CompletionState> state, FrontServiceClient* self)
+              : m_state(std::move(state)), m_self(self)
+            {}
 
-    private:
-        bcos::front::CallbackFunc m_callback;
+            void callback_asyncSendMessageByNodeID(const bcostars::Error& ret,
+                const std::vector<tars::Char>& responseNodeID,
+                const std::vector<tars::Char>& responseData, const std::string& seq) override
+            {
+                complete(ret, responseNodeID, responseData, seq);
+            }
+
+            void callback_asyncSendMessageByNodeID_exception(tars::Int32 ret) override
+            {
+                bcos::front::SendResult result;
+                result.error = toBcosError(ret);
+                completeResult(std::move(result));
+            }
+
+        private:
+            void complete(const bcostars::Error& ret,
+                const std::vector<tars::Char>& responseNodeID,
+                const std::vector<tars::Char>& responseData, const std::string& seq)
+            {
+                bcos::front::SendResult result;
+                result.error = toBcosError(ret);
+                if (!responseNodeID.empty())
+                {
+                    result.nodeID = m_self->m_keyFactory->createKey(bcos::bytesConstRef(
+                        (const bcos::byte*)responseNodeID.data(), responseNodeID.size()));
+                }
+                result.payload.assign(responseData.begin(), responseData.end());
+                result.uuid = seq;
+                completeResult(std::move(result));
+            }
+
+            void completeResult(bcos::front::SendResult result)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->result = std::move(result);
+                    m_state->handle.resume();
+                }
+            }
+
+            std::shared_ptr<CompletionState> m_state;
+            FrontServiceClient* m_self;
+        };
+
         FrontServiceClient* m_self;
+        int m_moduleID;
+        bcos::crypto::NodeIDPtr m_nodeID;
+        std::shared_ptr<bcos::bytes> m_buffer;
+        uint32_t m_timeout;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        void await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto nodeIDData = m_nodeID->data();
+            m_self->m_proxy->tars_set_timeout(m_self->c_frontServiceTimeout)
+                ->async_asyncSendMessageByNodeID(new Callback(state, m_self), m_moduleID,
+                    std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
+                    std::vector<char>(m_buffer->begin(), m_buffer->end()), m_timeout,
+                    (m_timeout > 0));
+        }
+
+        bcos::front::SendResult await_resume() { return std::move(m_state->result); }
     };
 
-    auto nodeIDData = _nodeID->data();
-    m_proxy->tars_set_timeout(c_frontServiceTimeout)
-        ->async_asyncSendMessageByNodeID(new Callback(_callback, this), _moduleID,
-            std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
-            std::vector<char>(_data.begin(), _data.end()), _timeout, (_callback ? true : false));
+    auto buffer = std::make_shared<bcos::bytes>();
+    for (auto const& data : _payloads)
+    {
+        buffer->insert(buffer->end(), data.begin(), data.end());
+    }
+    SendAwaitable awaitable{this, _moduleID, std::move(_nodeID), std::move(buffer), _timeout,
+        std::make_shared<SendAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
 void bcostars::FrontServiceClient::asyncSendResponse(const std::string& _id, int _moduleID,
     bcos::crypto::NodeIDPtr _nodeID, bcos::bytesConstRef _data,
@@ -200,20 +251,6 @@ void bcostars::FrontServiceClient::asyncSendResponse(const std::string& _id, int
     m_proxy->tars_set_timeout(c_frontServiceTimeout)
         ->asyncSendResponse(_id, _moduleID, std::vector<char>(nodeIDData.begin(), nodeIDData.end()),
             std::vector<char>(_data.begin(), _data.end()));
-}
-void bcostars::FrontServiceClient::asyncSendMessageByNodeIDs(
-    int _moduleID, const std::vector<bcos::crypto::NodeIDPtr>& _nodeIDs, bcos::bytesConstRef _data)
-{
-    std::vector<std::vector<char>> tarsNodeIDs;
-    tarsNodeIDs.reserve(_nodeIDs.size());
-    for (auto const& it : _nodeIDs)
-    {
-        auto nodeIDData = it->data();
-        tarsNodeIDs.emplace_back(nodeIDData.begin(), nodeIDData.end());
-    }
-    m_proxy->tars_set_timeout(c_frontServiceTimeout)
-        ->async_asyncSendMessageByNodeIDs(
-            nullptr, _moduleID, tarsNodeIDs, std::vector<char>(_data.begin(), _data.end()));
 }
 bcos::task::Task<void> bcostars::FrontServiceClient::broadcastMessage(uint16_t _type,
     int _moduleID, ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads)

--- a/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/FrontServiceClient.h
@@ -31,15 +31,15 @@ public:
     void onReceiveBroadcastMessage(const std::string& _groupID, bcos::crypto::NodeIDPtr _nodeID,
         bcos::bytesConstRef _data, bcos::front::ReceiveMsgFunc _receiveMsgCallback) override;
 
-    // Note: the _callback maybe null in some cases
-    void asyncSendMessageByNodeID(int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
-        bcos::bytesConstRef _data, uint32_t _timeout, bcos::front::CallbackFunc _callback) override;
-
     void asyncSendResponse(const std::string& _id, int _moduleID, bcos::crypto::NodeIDPtr _nodeID,
         bcos::bytesConstRef _data, bcos::front::ReceiveMsgFunc _receiveMsgCallback) override;
 
-    void asyncSendMessageByNodeIDs(int _moduleID,
-        const std::vector<bcos::crypto::NodeIDPtr>& _nodeIDs, bcos::bytesConstRef _data) override;
+    // (coroutine) send message to one node and await the module-level response via the
+    // front-service RPC
+    bcos::task::Task<bcos::front::SendResult> sendMessageByNodeID(int _moduleID,
+        bcos::crypto::NodeIDPtr _nodeID,
+        ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> _payloads,
+        uint32_t _timeout) override;
 
     bcos::task::Task<void> broadcastMessage(uint16_t _type, int _moduleID,
         ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> payloads) override;

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -90,47 +90,48 @@ bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::sendMessageBy
         int m_moduleID;
         bcos::crypto::NodeIDPtr m_srcNodeID;
         bcos::crypto::NodeIDPtr m_dstNodeID;
-        std::shared_ptr<bcos::bytes> m_buffer;
+        std::shared_ptr<std::vector<char>> m_buffer;
         std::shared_ptr<CompletionState> m_state;
 
         constexpr static bool await_ready() noexcept { return false; }
 
-        void await_suspend(std::coroutine_handle<> _handle)
+        // Returns false (no suspension) on a synchronous connection-check failure so the coroutine
+        // is never resumed from inside await_suspend — resuming a coroutine that is still executing
+        // await_suspend is undefined behaviour. Returns true (suspend) once the RPC is in flight.
+        bool await_suspend(std::coroutine_handle<> _handle)
         {
             m_state->handle = _handle;
             auto state = m_state;
             auto buffer = m_buffer;
-            // A synchronous connection-check failure completes the coroutine exactly once (the
-            // completion guard also protects against the async TARS callback arriving later).
             auto shouldBlockCall = m_self->shouldStopCall();
             auto ret = checkConnection(m_self->c_moduleName, "asyncSendMessageByNodeID",
                 m_self->m_prx,
                 [state, buffer](bcos::Error::Ptr _error) {
-                    if (!state->completed.exchange(true))
-                    {
-                        state->error = std::move(_error);
-                        (void)buffer;
-                        state->handle.resume();
-                    }
+                    // connection-check failure: record the error; await_suspend returns false so
+                    // the coroutine continues on this thread and await_resume delivers it
+                    state->error = std::move(_error);
+                    (void)buffer;
                 },
                 shouldBlockCall);
             if (!ret && shouldBlockCall)
             {
-                return;
+                return false;
             }
             auto srcNodeID = m_srcNodeID->data();
             auto destNodeID = m_dstNodeID->data();
             m_self->m_prx->tars_set_timeout(m_self->c_networkTimeout)
                 ->async_asyncSendMessageByNodeID(new Callback(state), m_groupID, m_moduleID,
                     std::vector<char>(srcNodeID.begin(), srcNodeID.end()),
-                    std::vector<char>(destNodeID.begin(), destNodeID.end()),
-                    std::vector<char>(buffer->begin(), buffer->end()));
+                    std::vector<char>(destNodeID.begin(), destNodeID.end()), *buffer);
+            return true;
         }
 
         bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
     };
 
-    auto buffer = std::make_shared<bcos::bytes>();
+    // materialise the joined payload directly as the std::vector<char> the RPC argument needs —
+    // a single pass and one allocation, no second copy in await_suspend
+    auto buffer = std::make_shared<std::vector<char>>();
     for (auto const& data : _payloads)
     {
         buffer->insert(buffer->end(), data.begin(), data.end());

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.cpp
@@ -43,50 +43,101 @@ void bcostars::GatewayServiceClient::setKeyFactory(bcos::crypto::KeyFactory::Ptr
 {
     m_keyFactory = std::move(keyFactory);
 }
-void bcostars::GatewayServiceClient::asyncSendMessageByNodeID(const std::string& _groupID,
-    int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-    bcos::bytesConstRef _payload, bcos::gateway::ErrorRespFunc _errorRespFunc)
+bcos::task::Task<bcos::Error::Ptr> bcostars::GatewayServiceClient::sendMessageByNodeID(
+    const std::string& _groupID, int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID,
+    bcos::crypto::NodeIDPtr _dstNodeID,
+    ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> _payloads)
 {
-    class Callback : public bcostars::GatewayServicePrxCallback
+    struct SendAwaitable
     {
-    public:
-        Callback(bcos::gateway::ErrorRespFunc callback) : m_callback(callback) {}
-
-        void callback_asyncSendMessageByNodeID(const bcostars::Error& ret) override
+        struct CompletionState
         {
-            s_tarsTimeoutCount.store(0);
-            m_callback(toBcosError(ret));
-        }
-        void callback_asyncSendMessageByNodeID_exception(tars::Int32 ret) override
-        {
-            s_tarsTimeoutCount++;
-            m_callback(toBcosError(ret));
-        }
+            std::atomic<bool> completed{false};
+            std::coroutine_handle<> handle;
+            bcos::Error::Ptr error;
+        };
 
-    private:
-        bcos::gateway::ErrorRespFunc m_callback;
-    };
-    auto shouldBlockCall = shouldStopCall();
-    auto ret = checkConnection(
-        c_moduleName, "asyncSendMessageByNodeID", m_prx,
-        [_errorRespFunc](bcos::Error::Ptr _error) {
-            if (_errorRespFunc)
+        class Callback : public bcostars::GatewayServicePrxCallback
+        {
+        public:
+            explicit Callback(std::shared_ptr<CompletionState> state) : m_state(std::move(state)) {}
+
+            void callback_asyncSendMessageByNodeID(const bcostars::Error& ret) override
             {
-                _errorRespFunc(_error);
+                s_tarsTimeoutCount.store(0);
+                complete(toBcosError(ret));
             }
-        },
-        shouldBlockCall);
-    if (!ret && shouldBlockCall)
+            void callback_asyncSendMessageByNodeID_exception(tars::Int32 ret) override
+            {
+                s_tarsTimeoutCount++;
+                complete(toBcosError(ret));
+            }
+
+        private:
+            void complete(bcos::Error::Ptr error)
+            {
+                if (!m_state->completed.exchange(true))
+                {
+                    m_state->error = std::move(error);
+                    m_state->handle.resume();
+                }
+            }
+            std::shared_ptr<CompletionState> m_state;
+        };
+
+        GatewayServiceClient* m_self;
+        std::string m_groupID;
+        int m_moduleID;
+        bcos::crypto::NodeIDPtr m_srcNodeID;
+        bcos::crypto::NodeIDPtr m_dstNodeID;
+        std::shared_ptr<bcos::bytes> m_buffer;
+        std::shared_ptr<CompletionState> m_state;
+
+        constexpr static bool await_ready() noexcept { return false; }
+
+        void await_suspend(std::coroutine_handle<> _handle)
+        {
+            m_state->handle = _handle;
+            auto state = m_state;
+            auto buffer = m_buffer;
+            // A synchronous connection-check failure completes the coroutine exactly once (the
+            // completion guard also protects against the async TARS callback arriving later).
+            auto shouldBlockCall = m_self->shouldStopCall();
+            auto ret = checkConnection(m_self->c_moduleName, "asyncSendMessageByNodeID",
+                m_self->m_prx,
+                [state, buffer](bcos::Error::Ptr _error) {
+                    if (!state->completed.exchange(true))
+                    {
+                        state->error = std::move(_error);
+                        (void)buffer;
+                        state->handle.resume();
+                    }
+                },
+                shouldBlockCall);
+            if (!ret && shouldBlockCall)
+            {
+                return;
+            }
+            auto srcNodeID = m_srcNodeID->data();
+            auto destNodeID = m_dstNodeID->data();
+            m_self->m_prx->tars_set_timeout(m_self->c_networkTimeout)
+                ->async_asyncSendMessageByNodeID(new Callback(state), m_groupID, m_moduleID,
+                    std::vector<char>(srcNodeID.begin(), srcNodeID.end()),
+                    std::vector<char>(destNodeID.begin(), destNodeID.end()),
+                    std::vector<char>(buffer->begin(), buffer->end()));
+        }
+
+        bcos::Error::Ptr await_resume() { return std::move(m_state->error); }
+    };
+
+    auto buffer = std::make_shared<bcos::bytes>();
+    for (auto const& data : _payloads)
     {
-        return;
+        buffer->insert(buffer->end(), data.begin(), data.end());
     }
-    auto srcNodeID = _srcNodeID->data();
-    auto destNodeID = _dstNodeID->data();
-    m_prx->tars_set_timeout(c_networkTimeout)
-        ->async_asyncSendMessageByNodeID(new Callback(_errorRespFunc), _groupID, _moduleID,
-            std::vector<char>(srcNodeID.begin(), srcNodeID.end()),
-            std::vector<char>(destNodeID.begin(), destNodeID.end()),
-            std::vector<char>(_payload.begin(), _payload.end()));
+    SendAwaitable awaitable{this, _groupID, _moduleID, std::move(_srcNodeID), std::move(_dstNodeID),
+        std::move(buffer), std::make_shared<SendAwaitable::CompletionState>()};
+    co_return co_await awaitable;
 }
 void bcostars::GatewayServiceClient::asyncGetPeers(std::function<void(
         bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr, bcos::gateway::GatewayInfosPtr)>
@@ -140,28 +191,6 @@ void bcostars::GatewayServiceClient::asyncGetPeers(std::function<void(
         return;
     }
     m_prx->async_asyncGetPeers(new Callback(_callback));
-}
-void bcostars::GatewayServiceClient::asyncSendMessageByNodeIDs(const std::string& _groupID,
-    int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID, const bcos::crypto::NodeIDs& _dstNodeIDs,
-    bcos::bytesConstRef _payload)
-{
-    std::vector<std::vector<char>> tarsNodeIDs;
-    for (auto const& it : _dstNodeIDs)
-    {
-        auto nodeID = it->data();
-        tarsNodeIDs.emplace_back(nodeID.begin(), nodeID.end());
-    }
-    auto shouldBlockCall = shouldStopCall();
-    auto ret =
-        checkConnection(c_moduleName, "asyncSendMessageByNodeIDs", m_prx, nullptr, shouldBlockCall);
-    if (!ret && shouldBlockCall)
-    {
-        return;
-    }
-    auto srcNodeID = _srcNodeID->data();
-    m_prx->async_asyncSendMessageByNodeIDs(nullptr, _groupID, _moduleID,
-        std::vector<char>(srcNodeID.begin(), srcNodeID.end()), tarsNodeIDs,
-        std::vector<char>(_payload.begin(), _payload.end()));
 }
 bcos::task::Task<void> bcostars::GatewayServiceClient::broadcastMessage(uint16_t type,
     std::string_view groupID, int moduleID, const bcos::crypto::NodeID& srcNodeID,

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -41,17 +41,14 @@ public:
 
     void setKeyFactory(bcos::crypto::KeyFactory::Ptr keyFactory);
 
-    void asyncSendMessageByNodeID(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
-        bcos::bytesConstRef _payload, bcos::gateway::ErrorRespFunc _errorRespFunc) override;
-
     void asyncGetPeers(std::function<void(
             bcos::Error::Ptr, bcos::gateway::GatewayInfo::Ptr, bcos::gateway::GatewayInfosPtr)>
             _callback) override;
 
-    void asyncSendMessageByNodeIDs(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, const bcos::crypto::NodeIDs& _dstNodeIDs,
-        bcos::bytesConstRef _payload) override;
+    // (coroutine) send message to a single node by awaiting the gateway-service RPC
+    bcos::task::Task<bcos::Error::Ptr> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
+        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
+        ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> _payloads) override;
 
     bcos::task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,
         const bcos::crypto::NodeID& srcNodeID,

--- a/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
+++ b/bcos-tars-protocol/bcos-tars-protocol/client/GatewayServiceClient.h
@@ -46,8 +46,8 @@ public:
             _callback) override;
 
     // (coroutine) send message to a single node by awaiting the gateway-service RPC
-    bcos::task::Task<bcos::Error::Ptr> sendMessageByNodeID(const std::string& _groupID, int _moduleID,
-        bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
+    bcos::task::Task<bcos::Error::Ptr> sendMessageByNodeID(const std::string& _groupID,
+        int _moduleID, bcos::crypto::NodeIDPtr _srcNodeID, bcos::crypto::NodeIDPtr _dstNodeID,
         ::ranges::any_view<bcos::bytesConstRef, ::ranges::category::forward> _payloads) override;
 
     bcos::task::Task<void> broadcastMessage(uint16_t type, std::string_view groupID, int moduleID,

--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -207,18 +207,23 @@ task::Task<void> TxPool::broadcastTransactionBufferByTree(
                                   << LOG_KV("selectSize", selectedNode->size())
                                   << LOG_KV("selectedNode", selectedNodeList.str());
             }
+            // fire-and-forget: task::wait is non-blocking (it starts an AsyncTask and returns), so
+            // the coroutine frame must own every buffer the send reads. Copy the payload once and
+            // share it across all destination sends.
+            auto owned = std::make_shared<bcos::bytes>(_data.begin(), _data.end());
             for (const auto& node : (*selectedNode))
             {
-                // fire-and-forget point-to-point send through the coroutine fast path: the
-                // borrowed payload view stays alive for the (blocking) co_await
                 task::wait([](bcos::front::FrontServiceInterface::Ptr _frontService, int _moduleID,
                                bcos::crypto::NodeIDPtr _nodeID,
-                               bytesConstRef _data) -> task::Task<void> {
+                               std::shared_ptr<bcos::bytes> _owned) -> task::Task<void> {
                     auto result = co_await _frontService->sendMessageByNodeID(_moduleID,
-                        std::move(_nodeID), ::ranges::views::single(_data), 0);
+                        std::move(_nodeID),
+                        ::ranges::views::single(
+                            bytesConstRef(_owned->data(), _owned->size())),
+                        0);
                     (void)result;
                 }(m_transactionSync->config()->frontService(), protocol::TREE_PUSH_TRANSACTION,
-                    node, _data));
+                    node, owned));
             }
         }
     }

--- a/bcos-txpool/bcos-txpool/TxPool.cpp
+++ b/bcos-txpool/bcos-txpool/TxPool.cpp
@@ -209,8 +209,16 @@ task::Task<void> TxPool::broadcastTransactionBufferByTree(
             }
             for (const auto& node : (*selectedNode))
             {
-                m_transactionSync->config()->frontService()->asyncSendMessageByNodeID(
-                    protocol::TREE_PUSH_TRANSACTION, node, _data, 0, front::CallbackFunc());
+                // fire-and-forget point-to-point send through the coroutine fast path: the
+                // borrowed payload view stays alive for the (blocking) co_await
+                task::wait([](bcos::front::FrontServiceInterface::Ptr _frontService, int _moduleID,
+                               bcos::crypto::NodeIDPtr _nodeID,
+                               bytesConstRef _data) -> task::Task<void> {
+                    auto result = co_await _frontService->sendMessageByNodeID(_moduleID,
+                        std::move(_nodeID), ::ranges::views::single(_data), 0);
+                    (void)result;
+                }(m_transactionSync->config()->frontService(), protocol::TREE_PUSH_TRANSACTION,
+                    node, _data));
             }
         }
     }

--- a/fisco-bcos-tars-service/FrontService/FrontServiceServer.cpp
+++ b/fisco-bcos-tars-service/FrontService/FrontServiceServer.cpp
@@ -48,31 +48,38 @@ bcostars::Error FrontServiceServer::asyncSendMessageByNodeID(tars::Int32 moduleI
 
     auto bcosNodeID = m_frontServiceInitializer->keyFactory()->createKey(
         bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size()));
-    if (requireRespCallback)
-    {
-        m_frontServiceInitializer->front()->asyncSendMessageByNodeID(moduleID, bcosNodeID,
-            bcos::bytesConstRef((bcos::byte*)data.data(), data.size()), timeout,
-            [current](bcos::Error::Ptr _error, bcos::crypto::NodeIDPtr _nodeID,
-                bcos::bytesConstRef _data, const std::string& _id,
-                bcos::front::ResponseFunc _respFunc) {
-                boost::ignore_unused(_respFunc);
-                auto encodedNodeID = _nodeID->encode();
-                async_response_asyncSendMessageByNodeID(current, toTarsError(_error),
-                    std::vector<char>(encodedNodeID.begin(), encodedNodeID.end()),
-                    std::vector<char>(_data.begin(), _data.end()), _id);
-            });
-    }
-    else
-    {
-        m_frontServiceInitializer->front()->asyncSendMessageByNodeID(moduleID, bcosNodeID,
-            bcos::bytesConstRef((bcos::byte*)data.data(), data.size()), timeout, nullptr);
+    auto front = m_frontServiceInitializer->front();
+    // keep the payload and the request nodeID alive by passing them as coroutine parameters (they
+    // are copied into the frame and stay alive for the whole send)
+    auto payloadData = std::make_shared<std::vector<tars::Char>>(data);
+    auto requestNodeID = std::make_shared<std::vector<tars::Char>>(nodeID);
 
-        // response directly
-        bcos::bytesConstRef respData;
-        async_response_asyncSendMessageByNodeID(current, toTarsError<bcos::Error::Ptr>(nullptr),
-            std::vector<char>(nodeID.begin(), nodeID.end()),
-            std::vector<char>(respData.begin(), respData.end()), seq);
-    }
+    bcos::task::wait([](auto _front, auto _moduleID, auto _bcosNodeID, auto _payloadData,
+                         auto _requestNodeID, auto _timeout, auto _requireRespCallback,
+                         auto _current) -> bcos::task::Task<void> {
+        // requireRespCallback == false maps to a fire-and-forget send (timeout 0); the send result
+        // (module response, timeout or gateway failure) is delivered through the async RPC response
+        auto result = co_await _front->sendMessageByNodeID(_moduleID, _bcosNodeID,
+            ::ranges::views::single(bcos::bytesConstRef(
+                (const bcos::byte*)_payloadData->data(), _payloadData->size())),
+            _requireRespCallback ? _timeout : 0);
+
+        bcos::bytes encodedNodeID;
+        if (result.nodeID)
+        {
+            encodedNodeID = result.nodeID->encode();
+        }
+        else
+        {
+            // fire-and-forget (or failed) send: echo the request nodeID, matching the previous
+            // handler behaviour
+            encodedNodeID.assign(_requestNodeID->begin(), _requestNodeID->end());
+        }
+        async_response_asyncSendMessageByNodeID(_current, toTarsError(result.error),
+            std::vector<char>(encodedNodeID.begin(), encodedNodeID.end()),
+            std::vector<char>(result.payload.begin(), result.payload.end()), result.uuid);
+    }(front, moduleID, bcosNodeID, payloadData, requestNodeID, timeout, requireRespCallback,
+        current));
 
     return bcostars::Error();
 }
@@ -88,9 +95,18 @@ void FrontServiceServer::asyncSendMessageByNodeIDs(tars::Int32 moduleID,
         bcosNodeIDs.push_back(m_frontServiceInitializer->keyFactory()->createKey(
             bcos::bytesConstRef((bcos::byte*)it.data(), it.size())));
     }
-
-    m_frontServiceInitializer->front()->asyncSendMessageByNodeIDs(
-        moduleID, bcosNodeIDs, bcos::bytesConstRef((bcos::byte*)data.data(), data.size()));
+    auto front = m_frontServiceInitializer->front();
+    auto payloadData = std::make_shared<std::vector<tars::Char>>(data);
+    bcos::task::wait([](auto _front, auto _moduleID, auto _bcosNodeIDs,
+                         auto _payloadData) -> bcos::task::Task<void> {
+        for (auto const& nodeID : _bcosNodeIDs)
+        {
+            co_await _front->sendMessageByNodeID(_moduleID, nodeID,
+                ::ranges::views::single(bcos::bytesConstRef(
+                    (const bcos::byte*)_payloadData->data(), _payloadData->size())),
+                0);
+        }
+    }(front, moduleID, bcosNodeIDs, payloadData));
 }
 
 bcostars::Error FrontServiceServer::asyncSendResponse(const std::string& id, tars::Int32 moduleID,

--- a/fisco-bcos-tars-service/FrontService/FrontServiceServer.cpp
+++ b/fisco-bcos-tars-service/FrontService/FrontServiceServer.cpp
@@ -2,6 +2,7 @@
 #include "../Common/TarsUtils.h"
 #include "bcos-task/Wait.h"
 #include <bcos-tars-protocol/protocol/GroupNodeInfoImpl.h>
+#include <boost/exception/diagnostic_information.hpp>
 
 using namespace bcostars;
 
@@ -49,37 +50,58 @@ bcostars::Error FrontServiceServer::asyncSendMessageByNodeID(tars::Int32 moduleI
     auto bcosNodeID = m_frontServiceInitializer->keyFactory()->createKey(
         bcos::bytesConstRef((bcos::byte*)nodeID.data(), nodeID.size()));
     auto front = m_frontServiceInitializer->front();
-    // keep the payload and the request nodeID alive by passing them as coroutine parameters (they
-    // are copied into the frame and stay alive for the whole send)
+    // keep the payload, the request nodeID and the request seq alive by passing them as coroutine
+    // parameters (they are copied into the frame and stay alive for the whole send)
     auto payloadData = std::make_shared<std::vector<tars::Char>>(data);
     auto requestNodeID = std::make_shared<std::vector<tars::Char>>(nodeID);
+    auto requestSeq = std::make_shared<std::string>(seq);
 
     bcos::task::wait([](auto _front, auto _moduleID, auto _bcosNodeID, auto _payloadData,
-                         auto _requestNodeID, auto _timeout, auto _requireRespCallback,
-                         auto _current) -> bcos::task::Task<void> {
-        // requireRespCallback == false maps to a fire-and-forget send (timeout 0); the send result
-        // (module response, timeout or gateway failure) is delivered through the async RPC response
-        auto result = co_await _front->sendMessageByNodeID(_moduleID, _bcosNodeID,
-            ::ranges::views::single(bcos::bytesConstRef(
-                (const bcos::byte*)_payloadData->data(), _payloadData->size())),
-            _requireRespCallback ? _timeout : 0);
+                         auto _requestNodeID, auto _requestSeq, auto _timeout,
+                         auto _requireRespCallback, auto _current) -> bcos::task::Task<void> {
+        try
+        {
+            // requireRespCallback == false maps to a fire-and-forget send (timeout 0); the send
+            // result (module response, timeout or gateway failure) is delivered through the async
+            // RPC response
+            auto result = co_await _front->sendMessageByNodeID(_moduleID, _bcosNodeID,
+                ::ranges::views::single(bcos::bytesConstRef(
+                    (const bcos::byte*)_payloadData->data(), _payloadData->size())),
+                _requireRespCallback ? _timeout : 0);
 
-        bcos::bytes encodedNodeID;
-        if (result.nodeID)
-        {
-            encodedNodeID = result.nodeID->encode();
+            bcos::bytes encodedNodeID;
+            if (result.nodeID)
+            {
+                encodedNodeID = result.nodeID->encode();
+            }
+            else
+            {
+                // fire-and-forget (or failed) send: echo the request nodeID, matching the previous
+                // handler behaviour
+                encodedNodeID.assign(_requestNodeID->begin(), _requestNodeID->end());
+            }
+            // fire-and-forget sends return an empty uuid: echo the request seq so clients that
+            // correlate responses by seq still get a correlation ID
+            std::string replySeq = result.uuid.empty() ? *_requestSeq : result.uuid;
+            async_response_asyncSendMessageByNodeID(_current, toTarsError(result.error),
+                std::vector<char>(encodedNodeID.begin(), encodedNodeID.end()),
+                std::vector<char>(result.payload.begin(), result.payload.end()), replySeq);
         }
-        else
+        catch (std::exception const& e)
         {
-            // fire-and-forget (or failed) send: echo the request nodeID, matching the previous
-            // handler behaviour
-            encodedNodeID.assign(_requestNodeID->begin(), _requestNodeID->end());
+            // ensure the RPC is always answered: current->setResponse(false) already disabled the
+            // automatic reply, so an exception before async_response would leave the caller blocked
+            FRONTSERVICE_LOG(WARNING) << LOG_DESC("asyncSendMessageByNodeID send exception")
+                                      << LOG_KV("moduleID", _moduleID)
+                                      << LOG_KV("nodeID", _bcosNodeID->hex())
+                                      << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_asyncSendMessageByNodeID(_current,
+                toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))),
+                std::vector<char>(_requestNodeID->begin(), _requestNodeID->end()),
+                std::vector<tars::Char>(), *_requestSeq);
         }
-        async_response_asyncSendMessageByNodeID(_current, toTarsError(result.error),
-            std::vector<char>(encodedNodeID.begin(), encodedNodeID.end()),
-            std::vector<char>(result.payload.begin(), result.payload.end()), result.uuid);
-    }(front, moduleID, bcosNodeID, payloadData, requestNodeID, timeout, requireRespCallback,
-        current));
+    }(front, moduleID, bcosNodeID, payloadData, requestNodeID, requestSeq, timeout,
+        requireRespCallback, current));
 
     return bcostars::Error();
 }
@@ -97,16 +119,29 @@ void FrontServiceServer::asyncSendMessageByNodeIDs(tars::Int32 moduleID,
     }
     auto front = m_frontServiceInitializer->front();
     auto payloadData = std::make_shared<std::vector<tars::Char>>(data);
-    bcos::task::wait([](auto _front, auto _moduleID, auto _bcosNodeIDs,
-                         auto _payloadData) -> bcos::task::Task<void> {
-        for (auto const& nodeID : _bcosNodeIDs)
-        {
-            co_await _front->sendMessageByNodeID(_moduleID, nodeID,
-                ::ranges::views::single(bcos::bytesConstRef(
-                    (const bcos::byte*)_payloadData->data(), _payloadData->size())),
-                0);
-        }
-    }(front, moduleID, bcosNodeIDs, payloadData));
+    // fan out one detached task::wait per destination (sharing the owned payload), so a slow or
+    // unreachable destination does not head-of-line-block the others; each send is wrapped in
+    // try/catch so an exception cannot leak out of a TARS/ASIO completion handler
+    for (auto const& nodeID : bcosNodeIDs)
+    {
+        bcos::task::wait([](auto _front, auto _moduleID, auto _nodeID,
+                             auto _payloadData) -> bcos::task::Task<void> {
+            try
+            {
+                co_await _front->sendMessageByNodeID(_moduleID, _nodeID,
+                    ::ranges::views::single(bcos::bytesConstRef(
+                        (const bcos::byte*)_payloadData->data(), _payloadData->size())),
+                    0);
+            }
+            catch (std::exception const& e)
+            {
+                FRONTSERVICE_LOG(WARNING)
+                    << LOG_DESC("asyncSendMessageByNodeIDs send exception")
+                    << LOG_KV("moduleID", _moduleID) << LOG_KV("nodeID", _nodeID->hex())
+                    << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }(front, moduleID, nodeID, payloadData));
+    }
 }
 
 bcostars::Error FrontServiceServer::asyncSendResponse(const std::string& id, tars::Int32 moduleID,

--- a/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
+++ b/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
@@ -117,12 +117,20 @@ bcostars::Error bcostars::GatewayServiceServer::asyncSendMessageByNodeID(const s
         bcos::bytesConstRef((const bcos::byte*)srcNodeID.data(), srcNodeID.size()));
     auto bcosDstNodeID = keyFactory->createKey(
         bcos::bytesConstRef((const bcos::byte*)dstNodeID.data(), dstNodeID.size()));
-
-    m_gatewayInitializer->gateway()->asyncSendMessageByNodeID(groupID, moduleID, bcosSrcNodeID,
-        bcosDstNodeID, bcos::bytesConstRef((const bcos::byte*)payload.data(), payload.size()),
-        [current](bcos::Error::Ptr error) {
-            async_response_asyncSendMessageByNodeID(current, toTarsError(error));
-        });
+    auto gateway = m_gatewayInitializer->gateway();
+    // keep the payload alive and pass all state as coroutine parameters so it is copied into the
+    // frame and stays alive for the whole (possibly deferred) send; the send result is delivered
+    // through the async RPC response
+    auto payloadData = std::make_shared<std::vector<tars::Char>>(payload);
+    bcos::task::wait([](auto _gateway, auto _groupID, auto _moduleID, auto _srcNodeID,
+                         auto _dstNodeID, auto _payloadData,
+                         auto _current) -> bcos::task::Task<void> {
+        auto error = co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
+            _dstNodeID,
+            ::ranges::views::single(bcos::bytesConstRef(
+                (const bcos::byte*)_payloadData->data(), _payloadData->size())));
+        async_response_asyncSendMessageByNodeID(_current, toTarsError(error));
+    }(gateway, groupID, moduleID, bcosSrcNodeID, bcosDstNodeID, payloadData, current));
     return {};
 }
 bcostars::Error bcostars::GatewayServiceServer::asyncSendMessageByNodeIDs(
@@ -142,8 +150,17 @@ bcostars::Error bcostars::GatewayServiceServer::asyncSendMessageByNodeIDs(
             keyFactory->createKey(bcos::bytesConstRef((const bcos::byte*)it.data(), it.size())));
     }
 
-    m_gatewayInitializer->gateway()->asyncSendMessageByNodeIDs(groupID, moduleID, bcosSrcNodeID,
-        nodeIDs, bcos::bytesConstRef((const bcos::byte*)payload.data(), payload.size()));
+    auto gateway = m_gatewayInitializer->gateway();
+    auto payloadData = std::make_shared<std::vector<tars::Char>>(payload);
+    bcos::task::wait([](auto _gateway, auto _groupID, auto _moduleID, auto _srcNodeID,
+                         auto _nodeIDs, auto _payloadData) -> bcos::task::Task<void> {
+        for (auto const& dstNodeID : _nodeIDs)
+        {
+            co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID, dstNodeID,
+                ::ranges::views::single(bcos::bytesConstRef(
+                    (const bcos::byte*)_payloadData->data(), _payloadData->size())));
+        }
+    }(gateway, groupID, moduleID, bcosSrcNodeID, nodeIDs, payloadData));
 
     async_response_asyncSendMessageByNodeIDs(current, toTarsError<bcos::Error::Ptr>(nullptr));
     return bcostars::Error();

--- a/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
+++ b/fisco-bcos-tars-service/GatewayService/GatewayServiceServer.cpp
@@ -1,6 +1,7 @@
 #include "GatewayServiceServer.h"
 #include "bcos-task/Wait.h"
 #include <bcos-tars-protocol/Common.h>
+#include <boost/exception/diagnostic_information.hpp>
 using namespace bcostars;
 bcostars::Error GatewayServiceServer::asyncNotifyGroupInfo(
     const bcostars::GroupInfo& groupInfo, tars::TarsCurrentPtr current)
@@ -120,16 +121,30 @@ bcostars::Error bcostars::GatewayServiceServer::asyncSendMessageByNodeID(const s
     auto gateway = m_gatewayInitializer->gateway();
     // keep the payload alive and pass all state as coroutine parameters so it is copied into the
     // frame and stays alive for the whole (possibly deferred) send; the send result is delivered
-    // through the async RPC response
+    // through the async RPC response. try/catch guarantees the RPC is always answered even if the
+    // send throws (current->setResponse(false) already disabled the automatic reply).
     auto payloadData = std::make_shared<std::vector<tars::Char>>(payload);
     bcos::task::wait([](auto _gateway, auto _groupID, auto _moduleID, auto _srcNodeID,
                          auto _dstNodeID, auto _payloadData,
                          auto _current) -> bcos::task::Task<void> {
-        auto error = co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
-            _dstNodeID,
-            ::ranges::views::single(bcos::bytesConstRef(
-                (const bcos::byte*)_payloadData->data(), _payloadData->size())));
-        async_response_asyncSendMessageByNodeID(_current, toTarsError(error));
+        try
+        {
+            auto error = co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID,
+                _dstNodeID,
+                ::ranges::views::single(bcos::bytesConstRef(
+                    (const bcos::byte*)_payloadData->data(), _payloadData->size())));
+            async_response_asyncSendMessageByNodeID(_current, toTarsError(error));
+        }
+        catch (std::exception const& e)
+        {
+            GATEWAYSERVICE_LOG(WARNING) << LOG_DESC("asyncSendMessageByNodeID send exception")
+                                        << LOG_KV("groupID", _groupID)
+                                        << LOG_KV("moduleID", _moduleID)
+                                        << LOG_KV("dst", _dstNodeID->hex())
+                                        << LOG_KV("what", boost::diagnostic_information(e));
+            async_response_asyncSendMessageByNodeID(
+                _current, toTarsError(BCOS_ERROR_PTR(-1, boost::diagnostic_information(e))));
+        }
     }(gateway, groupID, moduleID, bcosSrcNodeID, bcosDstNodeID, payloadData, current));
     return {};
 }
@@ -152,15 +167,29 @@ bcostars::Error bcostars::GatewayServiceServer::asyncSendMessageByNodeIDs(
 
     auto gateway = m_gatewayInitializer->gateway();
     auto payloadData = std::make_shared<std::vector<tars::Char>>(payload);
-    bcos::task::wait([](auto _gateway, auto _groupID, auto _moduleID, auto _srcNodeID,
-                         auto _nodeIDs, auto _payloadData) -> bcos::task::Task<void> {
-        for (auto const& dstNodeID : _nodeIDs)
-        {
-            co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID, dstNodeID,
-                ::ranges::views::single(bcos::bytesConstRef(
-                    (const bcos::byte*)_payloadData->data(), _payloadData->size())));
-        }
-    }(gateway, groupID, moduleID, bcosSrcNodeID, nodeIDs, payloadData));
+    // fan out one detached task::wait per destination (sharing the owned payload), so a slow or
+    // unreachable destination does not head-of-line-block the others; each send is wrapped in
+    // try/catch so an exception cannot leak out of a TARS/ASIO completion handler
+    for (auto const& dstNodeID : nodeIDs)
+    {
+        bcos::task::wait([](auto _gateway, auto _groupID, auto _moduleID, auto _srcNodeID,
+                             auto _dstNodeID, auto _payloadData) -> bcos::task::Task<void> {
+            try
+            {
+                co_await _gateway->sendMessageByNodeID(_groupID, _moduleID, _srcNodeID, _dstNodeID,
+                    ::ranges::views::single(bcos::bytesConstRef(
+                        (const bcos::byte*)_payloadData->data(), _payloadData->size())));
+            }
+            catch (std::exception const& e)
+            {
+                GATEWAYSERVICE_LOG(WARNING)
+                    << LOG_DESC("asyncSendMessageByNodeIDs send exception")
+                    << LOG_KV("groupID", _groupID) << LOG_KV("moduleID", _moduleID)
+                    << LOG_KV("dst", _dstNodeID->hex())
+                    << LOG_KV("what", boost::diagnostic_information(e));
+            }
+        }(gateway, groupID, moduleID, bcosSrcNodeID, dstNodeID, payloadData));
+    }
 
     async_response_asyncSendMessageByNodeIDs(current, toTarsError<bcos::Error::Ptr>(nullptr));
     return bcostars::Error();

--- a/legacy/lightnode/fisco-bcos-lightnode/client/P2PClientImpl.h
+++ b/legacy/lightnode/fisco-bcos-lightnode/client/P2PClientImpl.h
@@ -9,6 +9,7 @@
 #include <bcos-framework/gateway/GatewayInterface.h>
 #include <bcos-framework/protocol/Protocol.h>
 #include <bcos-task/Task.h>
+#include <range/v3/view/single.hpp>
 #include <random>
 
 namespace bcos::p2p
@@ -35,67 +36,21 @@ public:
         bcos::bytes requestBuffer;
         bcos::concepts::serialize::encode(request, requestBuffer);
 
-        using ResponseType = std::remove_cvref_t<decltype(response)>;
-        struct Awaitable
+        LIGHTNODE_LOG(DEBUG) << "P2P client send message: " << moduleID << " | "
+                             << nodeID->hex() << " | " << requestBuffer.size();
+        auto result = co_await m_front->sendMessageByNodeID(moduleID, nodeID,
+            ::ranges::views::single(bcos::ref(requestBuffer)), 30000);
+        LIGHTNODE_LOG(DEBUG) << "P2P client receive message: " << moduleID << " | "
+                             << nodeID->hex() << " | " << result.payload.size() << " | "
+                             << (result.error ? result.error->errorCode() : 0) << " | "
+                             << (result.error ? result.error->errorMessage() : "");
+        if (result.error)
         {
-            Awaitable(bcos::front::FrontServiceInterface::Ptr& front, int moduleID,
-                crypto::NodeIDPtr nodeID, bcos::bytes buffer, ResponseType& response)
-              : m_front(front),
-                m_moduleID(moduleID),
-                m_nodeID(std::move(nodeID)),
-                m_requestBuffer(std::move(buffer)),
-                m_response(response)
-            {}
-            constexpr bool await_ready() const { return false; }
-
-            void await_suspend(std::coroutine_handle<task::Task<void>::promise_type> handle)
-            {
-                LIGHTNODE_LOG(DEBUG) << "P2P client send message: " << m_moduleID << " | "
-                                     << m_nodeID->hex() << " | " << m_requestBuffer.size();
-                bcos::concepts::getRef(m_front).asyncSendMessageByNodeID(m_moduleID, m_nodeID,
-                    bcos::ref(m_requestBuffer), 30000,
-                    [m_handle = std::move(handle), this](Error::Ptr error, bcos::crypto::NodeIDPtr,
-                        bytesConstRef data, const std::string&, front::ResponseFunc) mutable {
-                        LIGHTNODE_LOG(DEBUG) << "P2P client receive message: " << m_moduleID
-                                             << " | " << m_nodeID->hex() << " | " << data.size()
-                                             << " | " << (error ? error->errorCode() : 0) << " | "
-                                             << (error ? error->errorMessage() : "");
-                        if (!error)
-                        {
-                            bcos::concepts::serialize::decode(data, m_response);
-                            LIGHTNODE_LOG(DEBUG) << LOG_DESC("P2P client receive message success: ")
-                                                 << LOG_KV("data size", data.size());
-                        }
-                        else
-                        {
-                            m_error = std::move(error);
-                        }
-
-                        m_handle.resume();
-                    });
-            }
-
-            constexpr void await_resume() const
-            {
-                if (m_error)
-                {
-                    BOOST_THROW_EXCEPTION(*m_error);
-                }
-            }
-
-            // Request params
-            bcos::front::FrontServiceInterface::Ptr& m_front;
-            int m_moduleID;
-            crypto::NodeIDPtr m_nodeID;
-            bcos::bytes m_requestBuffer;
-
-            // Response params
-            Error::Ptr m_error;
-            ResponseType& m_response;
-        };
-
-        auto awaitable = Awaitable(m_front, moduleID, nodeID, std::move(requestBuffer), response);
-        co_await awaitable;
+            BOOST_THROW_EXCEPTION(*result.error);
+        }
+        bcos::concepts::serialize::decode(bcos::ref(result.payload), response);
+        LIGHTNODE_LOG(DEBUG) << LOG_DESC("P2P client receive message success: ")
+                             << LOG_KV("data size", result.payload.size());
     }
 
     task::Task<crypto::NodeIDPtr> randomSelectNode()


### PR DESCRIPTION
## 摘要

将发送路径中的 async 版本 `sendMessage` 全部移除，统一收敛到协程 `sendMessageByNodeID`，消除"协程 + async 回调"双实现并存的状态。

## 背景与动机

协程版零拷贝发送路径（#5492）落地后，async 版本的 `sendMessage` 变为薄壳或重复实现。为收敛发送路径、避免两套 API 并存带来的维护成本与行为漂移，本 PR 将剩余 async 发送方法全部迁移到协程版本：

1. **框架接口层**：移除 `GatewayInterface::asyncSendMessageByNodeID/asyncSendMessageByNodeIDs` 与 `FrontServiceInterface::asyncSendMessageByNodeID/asyncSendMessageByNodeIDs`，对应协程方法改为**纯虚**，由各实现类提供协程实现；
2. **libp2p 层**：移除 `Service/ServiceV2/P2PInterface` 的全部 async 发送（`asyncSendMessageByNodeID`、`asyncBroadcastMessage`、`asyncSendMessageByEndPoint`、`sendMessageToSession` 等）及 `PeersRouterTable::asyncBroadcastMsg` 死代码；
3. **调用方迁移**：`FrontService::sendMessage` 桥接到 `m_gatewayInterface->sendMessageByNodeID`（`task::wait`）；`TxPool` 树形广播、legacy lightnode 改用协程；AMOP 响应发送迁移到协程；
4. **TARS 层**：`.tars` 线协议保持不变；TARS 客户端（`GatewayServiceClient`/`FrontServiceClient`）在协程 `sendMessageByNodeID` 内 await RPC 回调；TARS 服务端处理器保留 RPC 签名，内部用 `task::wait` + 协程桥接；
5. **测试**：`FakeGateway`/`FakeFrontService`/`FakeGateWayWrapper` 提供协程实现；`FrontServiceTest`、`GatewayTest`、`FIB185`/`FIB186` 等迁移到协程 API。

## 关键设计

- 协程 lambda 一律**传参式** `task::wait([](auto x, ...) -> Task<void> {...}(x, ...))`，状态进入协程帧，避免捕获式 lambda 首次挂起后的 use-after-free；
- `task::wait` 是非阻塞的（fire-and-forget，等价 `AsyncTask::start()`），因此 fire-and-forget 协程帧必须**持有发送读取的所有 buffer**：`FrontService::sendMessage` 与 `TxPool` 树形广播在进入 `task::wait` 前将 header/payload 物化为 `shared_ptr` 并作为协程参数传入；`FrontServiceInterface` 改为继承 `std::enable_shared_from_this`，owned-payload 桥接以 `shared_from_this()` 传递，避免 detached 协程持有裸 `this`；
- `asyncSendResponse`（响应发送）保留：它是独立于 sendMessage 的响应 API，仍被 PBFT/sync/txpool 及 TARS `FrontServiceServer` 使用，现为 `sendMessage(isResponse=true)` 的薄壳；
- **TARS 响应时序说明**：服务端桥接在 F&F（fire-and-forget，`requireRespCallback==false`）场景下会**等待 gateway send 完成后再 `async_response`**，因此 reply 中的错误码才有意义（基线是入队后立即回复）；F&F 回复回显请求的 `seq`，客户端可按 seq 关联。多目标发送（`asyncSendMessageByNodeIDs`）为每个目标启动独立的 detached `task::wait`（共享同一 owned payload），互不阻塞，避免慢节点 head-of-line 阻塞整个 fanout。

## 验证

- `fisco-bcos` 完整节点编译通过；
- 单测：front / gateway / txpool / sync / pbft / rpc / rpbft 全部通过；
- pbft 用例需 `ASAN_OPTIONS=detect_container_overflow=0`（protobuf SooRep 与 ASan 的已知误报，与本次改动无关）。
