### PR TITLE
[eth_sync] Add devp2p RLPx message, session and client layer (part 3/9)

### DIFF
--- a/bcos-devp2p/bcos-devp2p/rlpx/Client.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Client.cpp
@@ -1,0 +1,210 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Client.cpp
+ * @brief RLPx client/server implementation: handshake + Hello + eth Status.
+ * @date 2026/8/18
+ */
+#include "Client.h"
+
+#include "Framing.h"
+#include "Messages.h"
+#include "../eth/Protocol.h"
+#include <cctype>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// Build the framing cipher from the handshake keys and wrap a session.
+Session makeSession(Socket&& _socket, AuthKeys const& _keys, bool _isInitiator)
+{
+    FramingCipher::KeyMaterial keyMaterial;
+    keyMaterial.ephemeralSharedSecret = EciesCipher::computeSharedSecret(
+        bytesConstRef(_keys.peerEphemeralPublicKey.data(), _keys.peerEphemeralPublicKey.size()),
+        bytesConstRef(_keys.ephemeralPrivateKey.data(), _keys.ephemeralPrivateKey.size()));
+    keyMaterial.isInitiator = _isInitiator;
+    keyMaterial.initiatorNonce = _keys.initiatorNonce;
+    keyMaterial.recipientNonce = _keys.recipientNonce;
+    keyMaterial.initiatorFirstMessageData = _keys.initiatorFirstMessageData;
+    keyMaterial.recipientFirstMessageData = _keys.recipientFirstMessageData;
+    return Session(std::move(_socket), FramingCipher(keyMaterial));
+}
+
+// Shared Hello/Status exchange once the encrypted session exists.
+EstablishedSession exchangeHandshake(
+    Session&& _session, EccKeyPair const& _keyPair, PeerConfig const& _config)
+{
+    auto session = std::move(_session);
+
+    // --- Hello exchange ---
+    HelloMessage hello;
+    hello.version = 5;
+    hello.clientId = _config.clientId;
+    for (auto const& cap : eth::ethCapabilities())
+    {
+        hello.capabilities.push_back(cap);
+    }
+    hello.listenPort = _config.listenPort;
+    hello.id = _keyPair.publicKey();
+
+    session.sendMessage(Message{baseMsg::Hello, encodeHello(hello)});
+    auto helloMsg = session.recvMessage();
+    if (helloMsg.id != baseMsg::Hello)
+    {
+        if (helloMsg.id == baseMsg::Disconnect)
+        {
+            auto disc = decodeDisconnect(bytesConstRef(helloMsg.data.data(), helloMsg.data.size()));
+            throw std::runtime_error(
+                "exchangeHandshake: peer disconnected during Hello: reason=" +
+                std::to_string(static_cast<int>(disc.reason)));
+        }
+        throw std::runtime_error("exchangeHandshake: expected Hello, got message id=" +
+                                 std::to_string(helloMsg.id));
+    }
+    auto peerHello = decodeHello(bytesConstRef(helloMsg.data.data(), helloMsg.data.size()));
+    // Negotiate the highest eth version the peer supports from {68, 69}.
+    uint8_t negotiatedEth = 0;
+    for (auto const& cap : peerHello.capabilities)
+    {
+        if (cap.name == "eth" && (cap.version == 68 || cap.version == 69))
+        {
+            negotiatedEth = std::max(negotiatedEth, cap.version);
+        }
+    }
+    if (negotiatedEth == 0)
+    {
+        throw std::runtime_error("exchangeHandshake: no common eth capability with peer");
+    }
+    // Diagnostics: the negotiated capability layout determines every eth frame id.
+    std::cerr << "[handshake] peer client=\"" << peerHello.clientId << "\" caps:";
+    for (auto const& cap : peerHello.capabilities)
+    {
+        std::cerr << " " << cap.name << "/" << static_cast<int>(cap.version);
+    }
+    std::cerr << " (our caps:";
+    for (auto const& cap : hello.capabilities)
+    {
+        std::cerr << " " << cap.name << "/" << static_cast<int>(cap.version);
+    }
+    std::cerr << ") negotiated eth/" << static_cast<int>(negotiatedEth) << std::endl;
+
+    // Both peers send Hello with version >= 5 → enable snappy on the session.
+    // Raw snappy is varint-prefixed + block, wire-identical across geth/erigon/
+    // reth/ethrex (Go snappy.Decode and Rust snap::raw are the same format).
+    session.enableCompression();
+
+    // --- eth Status exchange ---
+    eth::StatusMessage status;
+    status.protocolVersion = negotiatedEth;
+    status.networkId = _config.networkId;
+    status.genesisHash = _config.genesisHash;
+    status.forkId = _config.forkId;
+    if (negotiatedEth >= 69)
+    {
+        // EIP-8085: advertise our (genesis-only) block range.
+        status.eip8085 = true;
+        status.earliestBlock = 0;
+        status.latestBlock = 0;
+        status.latestBlockHash = _config.genesisHash;
+    }
+    else
+    {
+        status.headHash = _config.headHash;
+        status.totalDifficulty = _config.totalDifficulty;
+    }
+
+    session.sendMessage(
+        Message{static_cast<uint8_t>(eth::frameId(eth::msg::Status)), encodeStatus(status)});
+
+    auto statusMsg = session.recvMessage();
+    if (statusMsg.id != eth::frameId(eth::msg::Status))
+    {
+        if (statusMsg.id == baseMsg::Disconnect)
+        {
+            try
+            {
+                auto disc = decodeDisconnect(
+                    bytesConstRef(statusMsg.data.data(), statusMsg.data.size()));
+                std::cerr << "[handshake] peer (\"" << peerHello.clientId
+                          << "\") disconnected during Status: reason="
+                          << static_cast<int>(disc.reason) << std::endl;
+            }
+            catch (std::exception const& e)
+            {
+                std::cerr << "[handshake] peer (\"" << peerHello.clientId
+                          << "\") disconnected during Status (reason undecodable): "
+                          << e.what() << std::endl;
+            }
+        }
+        throw std::runtime_error("exchangeHandshake: expected eth Status, got message id=" +
+                                 std::to_string(statusMsg.id));
+    }
+    auto peerStatus =
+        eth::decodeStatus(bytesConstRef(statusMsg.data.data(), statusMsg.data.size()));
+
+    // Verify the peer is on our chain — only when the local config actually
+    // pins a genesis hash (the server side accepts whatever the client sends).
+    if (_config.genesisHash != bcos::h256{} &&
+        peerStatus.genesisHash != _config.genesisHash)
+    {
+        throw std::runtime_error(
+            "exchangeHandshake: peer genesis hash mismatch (different chain)");
+    }
+    return EstablishedSession(std::move(session), std::move(peerHello), std::move(peerStatus));
+}
+}  // namespace
+
+RlpxClient::RlpxClient(EccKeyPair _keyPair, PeerConfig _config)
+  : m_keyPair(std::move(_keyPair)), m_config(std::move(_config))
+{}
+
+EstablishedSession RlpxClient::connect()
+{
+    Socket socket;
+    socket.connect(m_config.host, m_config.port);
+
+    Handshake handshake(m_keyPair, /* isInitiator = */ true,
+        bytesConstRef(m_config.peerPublicKey.data(), m_config.peerPublicKey.size()));
+    auto authKeys = handshake.execute(socket);
+
+    auto session = makeSession(std::move(socket), authKeys, /* isInitiator = */ true);
+    return exchangeHandshake(std::move(session), m_keyPair, m_config);
+}
+
+RlpxServer::RlpxServer(EccKeyPair _keyPair, uint16_t _port, PeerConfig _config)
+  : m_keyPair(std::move(_keyPair)), m_config(std::move(_config)), m_listener(_port)
+{}
+
+EstablishedSession RlpxServer::accept()
+{
+    auto socket = m_listener.accept();
+
+    Handshake handshake(m_keyPair, /* isInitiator = */ false);
+    auto authKeys = handshake.execute(socket);
+
+    auto session = makeSession(std::move(socket), authKeys, /* isInitiator = */ false);
+
+    if (m_config.clientId.empty())
+    {
+        m_config.clientId = "FISCO-BCOS-devp2p-server/v0.1.0";
+    }
+    return exchangeHandshake(std::move(session), m_keyPair, m_config);
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Client.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Client.h
@@ -1,0 +1,97 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Client.h
+ * @brief RLPx client: connect, encrypted handshake, Hello/Status exchange with
+ *        a peer, then hand over an established Session to the sync layer.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Crypto.h"
+#include "Handshake.h"
+#include "Messages.h"
+#include "Session.h"
+#include "Socket.h"
+#include "../eth/ForkId.h"
+#include "../eth/Protocol.h"
+#include <bcos-utilities/FixedBytes.h>
+#include <string>
+
+namespace bcos::devp2p::rlpx
+{
+// Connection parameters for a sync peer.
+struct PeerConfig
+{
+    std::string host;
+    uint16_t port{30303};
+    // 64-byte uncompressed public key of the peer (used for the ECIES handshake).
+    bcos::bytes peerPublicKey;
+    std::string clientId{"FISCO-BCOS-devp2p/v0.1.0"};
+    uint64_t listenPort{0};
+    uint64_t networkId{1};
+    bcos::h256 genesisHash;
+    bcos::h256 headHash;
+    bcos::bytes totalDifficulty;  // minimal big-endian u256
+    bcos::devp2p::eth::ForkId forkId;
+};
+
+// The result of a successful connection: the encrypted session plus the
+// peer's advertised identity and status.
+struct EstablishedSession
+{
+    Session session;
+    HelloMessage peerHello;
+    bcos::devp2p::eth::StatusMessage peerStatus;
+
+    EstablishedSession(Session&& _session, HelloMessage _hello,
+        bcos::devp2p::eth::StatusMessage _status)
+      : session(std::move(_session)), peerHello(std::move(_hello)), peerStatus(std::move(_status))
+    {}
+};
+
+class RlpxClient
+{
+public:
+    // _keyPair is this node's identity key (used for the ECIES handshake).
+    RlpxClient(EccKeyPair _keyPair, PeerConfig _config);
+
+    // Connect, perform the encrypted handshake, exchange Hello + eth Status,
+    // and return an established session (snappy enabled after Hello).
+    EstablishedSession connect();
+
+private:
+    EccKeyPair m_keyPair;
+    PeerConfig m_config;
+};
+
+// Minimal server side used by tests: accept + handshake + Hello/Status exchange.
+class RlpxServer
+{
+public:
+    RlpxServer(EccKeyPair _keyPair, uint16_t _port, PeerConfig _config = {});
+
+    // Block until a client completes the full handshake/hello/status exchange.
+    EstablishedSession accept();
+
+    // The port this server listens on (valid once constructed).
+    uint16_t port() const { return m_listener.port(); }
+
+private:
+    EccKeyPair m_keyPair;
+    PeerConfig m_config;
+    TcpListener m_listener;
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.cpp
@@ -1,0 +1,301 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MessageCodec.cpp
+ * @brief Message <-> frame payload codec implementation.
+ * @date 2026/8/18
+ */
+#include "MessageCodec.h"
+
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <cstring>
+#include <iostream>
+#include <stdexcept>
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// --- Raw snappy (the wire format geth/erigon/reth/ethrex all use for devp2p
+// frame compression). The snappy "raw block" format is:
+//
+//   raw-block = uvarint(uncompressed-length) || sequence-of-tags
+//
+// Each tag byte is split as:  type = tag & 3   (LOW two bits)
+//                             data = tag >> 2  (high six bits)
+//   literal (type 0) : len = data + 1          (data < 60); if data in 60..63,
+//                      len = 1 + LE(data-59 length bytes), then the bytes.
+//   copy-1  (type 1) : len = (data & 7) + 4, offset = ((data >> 3) << 8) | next
+//   copy-2  (type 2) : len = data + 1,      offset = next 2 bytes LE
+//   copy-4  (type 3) : len = data + 1,      offset = next 4 bytes LE
+//
+// This is exactly what the vcpkg snappy port (RawCompress/RawUncompress), Go's
+// snappy.Decode (geth) and Rust snap::raw (ethrex) emit/consume.
+void appendUvarint(bcos::bytes& _out, uint64_t _value)
+{
+    while (_value >= 0x80)
+    {
+        _out.push_back(static_cast<bcos::byte>((_value & 0x7F) | 0x80));
+        _value >>= 7;
+    }
+    _out.push_back(static_cast<bcos::byte>(_value));
+}
+
+uint64_t readUvarint(bytesConstRef _data, size_t& _pos)
+{
+    uint64_t value = 0;
+    uint32_t shift = 0;
+    while (true)
+    {
+        if (_pos >= _data.size())
+        {
+            throw std::runtime_error("MessageCodec: truncated snappy varint");
+        }
+        uint8_t const b = _data[_pos++];
+        value |= static_cast<uint64_t>(b & 0x7F) << shift;
+        if ((b & 0x80) == 0)
+        {
+            return value;
+        }
+        shift += 7;
+        if (shift >= 64)
+        {
+            throw std::runtime_error("MessageCodec: snappy varint overflow");
+        }
+    }
+}
+
+bcos::bytes rawSnappyBlockCompress(bytesConstRef _data)
+{
+    // Literal-only encoding: always valid, trivially correct for any input. devp2p
+    // messages are small; skipping actual back-referencing costs nothing for sync.
+    bcos::bytes out;
+    size_t const n = _data.size();
+    if (n == 0)
+    {
+        return out;  // empty block
+    }
+    uint64_t const lenMinus1 = n - 1;
+    if (lenMinus1 < 60)
+    {
+        out.push_back(static_cast<bcos::byte>((lenMinus1 << 2)));  // literal tag
+    }
+    else
+    {
+        size_t lenBytes;
+        if (lenMinus1 <= 0xFF)
+        {
+            lenBytes = 1;
+        }
+        else if (lenMinus1 <= 0xFFFF)
+        {
+            lenBytes = 2;
+        }
+        else if (lenMinus1 <= 0xFFFFFF)
+        {
+            lenBytes = 3;
+        }
+        else
+        {
+            lenBytes = 4;
+        }
+        out.push_back(static_cast<bcos::byte>(((59 + lenBytes) << 2)));  // 60..63
+        for (size_t i = 0; i < lenBytes; ++i)
+        {
+            out.push_back(static_cast<bcos::byte>((lenMinus1 >> (8 * i)) & 0xFF));
+        }
+    }
+    out.insert(out.end(), _data.begin(), _data.end());
+    return out;
+}
+
+// Decodes one raw block starting at _pos; advances _pos to the end of the block.
+bcos::bytes rawSnappyDecompressBlock(bytesConstRef _data, size_t& _pos, size_t _maxOutput)
+{
+    bcos::bytes out;
+    size_t const n = _data.size();
+    auto need = [&](size_t k) {
+        if (_pos + k > n)
+        {
+            throw std::runtime_error("MessageCodec: truncated snappy data");
+        }
+    };
+    while (_pos < n)
+    {
+        uint8_t const tag = _data[_pos++];
+        uint8_t const type = tag & 0x3;       // LOW two bits select the element type
+        uint8_t const dataBits = tag >> 2;    // high six bits carry len/offset info
+        if (type == 0)  // literal
+        {
+            size_t len = dataBits + 1;
+            if (dataBits >= 60)
+            {
+                size_t const lenBytes = dataBits - 59;  // 60->1, 61->2, 62->3, 63->4
+                need(lenBytes);
+                uint64_t value = 0;
+                for (size_t i = 0; i < lenBytes; ++i)
+                {
+                    value |= static_cast<uint64_t>(_data[_pos + i]) << (8 * i);
+                }
+                _pos += lenBytes;
+                len = static_cast<size_t>(value) + 1;
+            }
+            if (out.size() + len > _maxOutput || _pos + len > n)
+            {
+                throw std::runtime_error("MessageCodec: snappy literal exceeds limits");
+            }
+            out.insert(out.end(), _data.begin() + _pos, _data.begin() + _pos + len);
+            _pos += len;
+        }
+        else
+        {
+            size_t len;
+            size_t offset;
+            if (type == 1)  // copy-1: 3-bit length + 5-bit offset
+            {
+                len = (dataBits & 0x7) + 4;
+                need(1);
+                offset = (static_cast<size_t>(dataBits >> 3) << 8) | _data[_pos++];
+            }
+            else if (type == 2)  // copy-2
+            {
+                len = dataBits + 1;
+                need(2);
+                offset = static_cast<size_t>(_data[_pos]) |
+                         (static_cast<size_t>(_data[_pos + 1]) << 8);
+                _pos += 2;
+            }
+            else  // copy-4
+            {
+                len = dataBits + 1;
+                need(4);
+                offset = static_cast<size_t>(_data[_pos]) |
+                         (static_cast<size_t>(_data[_pos + 1]) << 8) |
+                         (static_cast<size_t>(_data[_pos + 2]) << 16) |
+                         (static_cast<size_t>(_data[_pos + 3]) << 24);
+                _pos += 4;
+            }
+            if (offset == 0 || offset > out.size() || out.size() + len > _maxOutput)
+            {
+                throw std::runtime_error("MessageCodec: invalid snappy copy");
+            }
+            for (size_t i = 0; i < len; ++i)
+            {
+                out.push_back(out[out.size() - offset]);
+            }
+        }
+    }
+    return out;
+}
+
+bcos::bytes rawSnappyCompress(bytesConstRef _data)
+{
+    bcos::bytes block = rawSnappyBlockCompress(_data);
+    bcos::bytes out;
+    appendUvarint(out, _data.size());
+    out.insert(out.end(), block.begin(), block.end());
+    return out;
+}
+
+bcos::bytes rawSnappyDecompress(bytesConstRef _data, size_t _maxOutput)
+{
+    size_t pos = 0;
+    uint64_t const declared = readUvarint(_data, pos);
+    if (declared > _maxOutput)
+    {
+        throw std::runtime_error("MessageCodec: snappy declared length exceeds limits");
+    }
+    bcos::bytes out = rawSnappyDecompressBlock(_data, pos, _maxOutput);
+    if (out.size() != declared)
+    {
+        throw std::runtime_error("MessageCodec: snappy declared length mismatch");
+    }
+    return out;
+}
+}  // namespace
+
+bcos::bytes MessageCodec::encode(Message const& _message) const
+{
+    bcos::bytes frameData;
+    frameData.reserve(_message.data.size() + 1);
+    // Encode as a 64-bit value: RLP(uint8_t) hits a missing toCompactBigEndian(byte)
+    // overload, and the resulting encoding is identical for ids < 0x80.
+    bcos::codec::rlp::encode(frameData, static_cast<uint64_t>(_message.id));
+    if (!m_compressionEnabled)
+    {
+        frameData.insert(frameData.end(), _message.data.begin(), _message.data.end());
+    }
+    else
+    {
+        auto compressed = rawSnappyCompress(
+            bytesConstRef(_message.data.data(), _message.data.size()));
+        frameData.insert(frameData.end(), compressed.begin(), compressed.end());
+    }
+    std::cerr << "[codec] send id=" << static_cast<int>(_message.id)
+              << " compress=" << (m_compressionEnabled ? 1 : 0)
+              << " frame=" << bcos::toHexStringWithPrefix(frameData).substr(0, 120)
+              << std::endl;
+    return frameData;
+}
+
+Message MessageCodec::decode(bytesConstRef _frameData) const
+{
+    if (_frameData.empty())
+    {
+        throw std::runtime_error("MessageCodec: frame data too short");
+    }
+    std::cerr << "[codec] recv full=" << bcos::toHexStringWithPrefix(_frameData).substr(0, 200)
+              << " compress=" << (m_compressionEnabled ? 1 : 0) << std::endl;
+    Message message;
+    // The message id is RLP-encoded (RLP(0) == 0x80), so decode it properly.
+    {
+        bcos::bytesRef view(
+            const_cast<bcos::byte*>(_frameData.data()), _frameData.size());
+        if (auto err = bcos::codec::rlp::decode(view, message.id))
+        {
+            throw std::runtime_error("MessageCodec: failed to decode message id");
+        }
+        auto payload = _frameData.getCroppedData(_frameData.size() - view.size());
+        if (!m_compressionEnabled)
+        {
+            message.data.assign(payload.begin(), payload.end());
+        }
+        else
+        {
+            message.data = rawSnappyDecompress(payload, kMaxFrameSize);
+        }
+        // Diagnostics: dump complete BlockHeaders payloads to a file so the
+        // wire format can be analysed offline.
+        if (message.id == 20 && message.data.size() > 10000)
+        {
+            FILE* f = std::fopen("/home/more/tmp/blkheaders.bin", "wb");
+            if (f)
+            {
+                std::fwrite(message.data.data(), 1, message.data.size(), f);
+                std::fclose(f);
+                std::cerr << "[codec] WROTE blkheaders.bin size=" << message.data.size()
+                          << std::endl;
+            }
+        }
+        std::cerr << "[codec] recv id=" << static_cast<int>(message.id)
+                  << " compress=" << (m_compressionEnabled ? 1 : 0)
+                  << " raw=" << bcos::toHexStringWithPrefix(payload).substr(0, 96)
+                  << " data=" << bcos::toHexStringWithPrefix(message.data).substr(0, 96)
+                  << std::endl;
+    }
+    return message;
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/MessageCodec.h
@@ -1,0 +1,49 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file MessageCodec.h
+ * @brief RLPx message <-> frame payload codec (message id RLP + optional snappy),
+ *        ported from silkworm sentry/rlpx/framing/message_frame_codec.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+
+namespace bcos::devp2p::rlpx
+{
+// A decoded RLPx message.
+struct Message
+{
+    uint8_t id{0};       // message code
+    bcos::bytes data;    // RLP-encoded payload
+};
+
+// Encodes/decodes a Message into/from a frame payload:
+//   frame-data = RLP(id) || (snappy(data) | data)
+class MessageCodec
+{
+public:
+    static constexpr size_t kMaxFrameSize = 16 << 20;  // 16 MiB
+
+    bcos::bytes encode(Message const& _message) const;
+    Message decode(bytesConstRef _frameData) const;
+
+    void enableCompression() { m_compressionEnabled = true; }
+
+private:
+    bool m_compressionEnabled{false};
+};
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.cpp
@@ -1,0 +1,203 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Messages.cpp
+ * @brief devp2p base-protocol message RLP codecs.
+ * @date 2026/8/18
+ */
+#include "Messages.h"
+
+#include <bcos-codec/rlp/Common.h>
+#include <bcos-codec/rlp/RLPDecode.h>
+#include <bcos-codec/rlp/RLPEncode.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <stdexcept>
+#include <vector>
+
+namespace bcos::devp2p::rlpx
+{
+namespace
+{
+// Encode a pre-built payload as an RLP item (list or string).
+void appendEncoded(bcos::bytes& _to, bcos::bytes const& _item)
+{
+    _to.insert(_to.end(), _item.begin(), _item.end());
+}
+
+bcos::bytes encodeUint(uint64_t _value)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _value);
+    return out;
+}
+
+bcos::bytes encodeString(bytesConstRef _data)
+{
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, _data);
+    return out;
+}
+
+// Expects a list at `_view` and returns a view over its payload.
+bcos::bytesRef takeListPayload(bcos::bytesRef& _view)
+{
+    auto [error, header] = bcos::codec::rlp::decodeHeader(_view);
+    if (error || !header.isList)
+    {
+        throw std::runtime_error("rlpx: expected an RLP list");
+    }
+    bcos::bytesRef payload(_view.data(), header.payloadLength);
+    _view = bcos::bytesRef(
+        _view.data() + header.payloadLength, _view.size() - header.payloadLength);
+    return payload;
+}
+}  // namespace
+
+bcos::bytes encodeHello(HelloMessage const& _msg)
+{
+    // caps payload: each cap = [name, version]
+    bcos::bytes capsPayload;
+    for (auto const& cap : _msg.capabilities)
+    {
+        bcos::codec::rlp::encode(
+            capsPayload, cap.name, static_cast<uint64_t>(cap.version));
+    }
+    bcos::bytes capsList;
+    bcos::codec::rlp::encodeHeader(
+        capsList, {.isList = true, .payloadLength = capsPayload.size()});
+    appendEncoded(capsList, capsPayload);
+
+    bcos::bytes versionItem = encodeUint(_msg.version);
+    bcos::bytes nameItem = encodeString(bytesConstRef(
+        (const bcos::byte*)_msg.clientId.data(), _msg.clientId.size()));
+    bcos::bytes portItem = encodeUint(_msg.listenPort);
+    bcos::bytes idItem = encodeString(bytesConstRef(_msg.id.data(), _msg.id.size()));
+
+    size_t payloadLength =
+        versionItem.size() + nameItem.size() + capsList.size() + portItem.size() + idItem.size();
+    bcos::bytes out;
+    bcos::codec::rlp::encodeHeader(out, {.isList = true, .payloadLength = payloadLength});
+    appendEncoded(out, versionItem);
+    appendEncoded(out, nameItem);
+    appendEncoded(out, capsList);
+    appendEncoded(out, portItem);
+    appendEncoded(out, idItem);
+    return out;
+}
+
+HelloMessage decodeHello(bytesConstRef _data)
+{
+    HelloMessage msg;
+    bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+    auto items = takeListPayload(view);
+
+    uint64_t version = 0;
+    if (auto err = bcos::codec::rlp::decode(items, version))
+    {
+        throw std::runtime_error("decodeHello: version decode failed");
+    }
+    msg.version = version;
+
+    if (auto err = bcos::codec::rlp::decode(items, msg.clientId))
+    {
+        throw std::runtime_error("decodeHello: clientId decode failed");
+    }
+
+    // caps list
+    auto capsPayload = takeListPayload(items);
+    while (!capsPayload.empty())
+    {
+        auto capItems = takeListPayload(capsPayload);
+        Capability cap;
+        if (auto err = bcos::codec::rlp::decode(capItems, cap.name))
+        {
+            throw std::runtime_error("decodeHello: cap name decode failed");
+        }
+        uint64_t capVersion = 0;
+        if (auto err = bcos::codec::rlp::decode(capItems, capVersion))
+        {
+            throw std::runtime_error("decodeHello: cap version decode failed");
+        }
+        cap.version = static_cast<uint8_t>(capVersion);
+        msg.capabilities.push_back(std::move(cap));
+    }
+
+    uint64_t listenPort = 0;
+    if (auto err = bcos::codec::rlp::decode(items, listenPort))
+    {
+        throw std::runtime_error("decodeHello: listenPort decode failed");
+    }
+    msg.listenPort = listenPort;
+
+    if (auto err = bcos::codec::rlp::decode(items, msg.id))
+    {
+        throw std::runtime_error("decodeHello: id decode failed");
+    }
+    return msg;
+}
+
+bcos::bytes encodeDisconnect(DisconnectMessage const& _msg)
+{
+    // geth wire format: disconnectMsg = [reason] — a one-element RLP list, NOT a
+    // bare integer. (We encode/disconnect with a bare integer before this fix, which
+    // made real geth peers reject the message and made decodeDisconnect fail on
+    // real Disconnect frames.)
+    bcos::bytes out;
+    bcos::codec::rlp::encode(out, std::vector<uint64_t>{static_cast<uint64_t>(_msg.reason)});
+    return out;
+}
+
+DisconnectMessage decodeDisconnect(bytesConstRef _data)
+{
+    DisconnectMessage msg;
+    // Wire format varies by client: geth/erigon send the EIP-8 list form [reason],
+    // while some clients (e.g. ethrex) send a bare integer. Accept both.
+    {
+        bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+        std::vector<uint64_t> reasons;
+        if (auto err = bcos::codec::rlp::decode(view, reasons); err == nullptr)
+        {
+            msg.reason = reasons.empty() ? DisconnectReason::DisconnectRequested :
+                                           static_cast<DisconnectReason>(reasons[0]);
+            return msg;
+        }
+    }
+    {
+        bcos::bytesRef view(const_cast<bcos::byte*>(_data.data()), _data.size());
+        uint64_t reason = 0;
+        if (auto err = bcos::codec::rlp::decode(view, reason); err == nullptr)
+        {
+            msg.reason = static_cast<DisconnectReason>(reason);
+            return msg;
+        }
+    }
+    throw std::runtime_error("decodeDisconnect: reason decode failed payload=" +
+                             bcos::toHexStringWithPrefix(
+                                 bcos::bytes(_data.begin(), _data.end())));
+}
+
+bcos::bytes encodePing()
+{
+    // Ping payload is the empty list: 0xc0.
+    return bcos::bytes{0xc0};
+}
+
+bcos::bytes encodePong()
+{
+    // Pong payload is the empty list: 0xc0.
+    return bcos::bytes{0xc0};
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Messages.h
@@ -1,0 +1,86 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Messages.h
+ * @brief devp2p base-protocol messages: Hello, Disconnect, Ping, Pong.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include <bcos-utilities/Common.h>
+#include <string>
+#include <vector>
+
+namespace bcos::devp2p::rlpx
+{
+// devp2p base-protocol message codes (shared by every capability).
+namespace baseMsg
+{
+constexpr uint8_t Hello = 0x00;
+constexpr uint8_t Disconnect = 0x01;
+constexpr uint8_t Ping = 0x02;
+constexpr uint8_t Pong = 0x03;
+}  // namespace baseMsg
+
+// Reason codes of the Disconnect message (EIP-8 / devp2p).
+enum class DisconnectReason : uint8_t
+{
+    DisconnectRequested = 0x00,
+    TcpSubsystemError = 0x01,
+    ProtocolBreach = 0x02,
+    UselessPeer = 0x03,
+    TooManyPeers = 0x04,
+    AlreadyConnected = 0x05,
+    IncompatibleP2pProtocolVersion = 0x06,
+    NullNodeIdentity = 0x07,
+    ClientQuitting = 0x08,
+    UnexpectedIdentity = 0x09,
+    LocalIdentity = 0x0a,
+    PingTimeout = 0x0b,
+    Unknown = 0x10,
+};
+
+struct Capability
+{
+    std::string name;
+    uint8_t version{0};
+};
+
+// RLP: [version, name, [[name, version], ...], listenPort, id]
+struct HelloMessage
+{
+    uint64_t version{5};
+    std::string clientId;
+    std::vector<Capability> capabilities;
+    uint64_t listenPort{0};
+    bcos::bytes id;  // 64-byte secp256k1 public key
+};
+
+bcos::bytes encodeHello(HelloMessage const& _msg);
+HelloMessage decodeHello(bytesConstRef _data);
+
+// RLP: [reason]
+struct DisconnectMessage
+{
+    DisconnectReason reason{DisconnectReason::DisconnectRequested};
+};
+
+bcos::bytes encodeDisconnect(DisconnectMessage const& _msg);
+DisconnectMessage decodeDisconnect(bytesConstRef _data);
+
+// Ping/Pong are the empty list RLP: 0xc0.
+bcos::bytes encodePing();
+bcos::bytes encodePong();
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Session.cpp
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Session.cpp
@@ -1,0 +1,52 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Session.cpp
+ * @brief RLPx session implementation.
+ * @date 2026/8/18
+ */
+#include "Session.h"
+
+#include <stdexcept>
+
+namespace bcos::devp2p::rlpx
+{
+Session::Session(Socket&& _socket, FramingCipher _cipher)
+  : m_socket(std::move(_socket)), m_cipher(std::move(_cipher))
+{}
+
+void Session::sendMessage(Message const& _message)
+{
+    auto frameData = m_codec.encode(_message);
+    auto encrypted = m_cipher.encryptFrame(std::move(frameData));
+    m_socket.sendAll(bytesConstRef(encrypted.data(), encrypted.size()));
+}
+
+Message Session::recvMessage()
+{
+    auto header = m_socket.recvFixed(FramingCipher::headerSize());
+    size_t frameSize = m_cipher.decryptHeader(bytesConstRef(header.data(), header.size()));
+    if (frameSize > MessageCodec::kMaxFrameSize)
+    {
+        throw std::runtime_error("Session: frame too large");
+    }
+
+    auto encrypted = m_socket.recvFixed(FramingCipher::frameSize(frameSize));
+    auto frameData = m_cipher.decryptFrame(
+        bytesConstRef(encrypted.data(), encrypted.size()), frameSize);
+    return m_codec.decode(bytesConstRef(frameData.data(), frameData.size()));
+}
+
+}  // namespace bcos::devp2p::rlpx

--- a/bcos-devp2p/bcos-devp2p/rlpx/Session.h
+++ b/bcos-devp2p/bcos-devp2p/rlpx/Session.h
@@ -1,0 +1,46 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Session.h
+ * @brief An established RLPx session: framed, encrypted message exchange over a
+ *        socket (port of silkworm MessageStream over geth-compatible framing).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Framing.h"
+#include "MessageCodec.h"
+#include "Socket.h"
+
+namespace bcos::devp2p::rlpx
+{
+// Sends/receives framed + encrypted messages over a connected socket.
+// Owns the socket so that the session can outlive the connection setup scope.
+class Session
+{
+public:
+    Session(Socket&& _socket, FramingCipher _cipher);
+
+    void sendMessage(Message const& _message);
+    Message recvMessage();
+
+    void enableCompression() { m_codec.enableCompression(); }
+
+private:
+    Socket m_socket;
+    FramingCipher m_cipher;
+    MessageCodec m_codec;
+};
+}  // namespace bcos::devp2p::rlpx


### PR DESCRIPTION
## 概述
devp2p RLPx 传输层第三部分：消息、会话与客户端。

## 内容
- **rlpx/MessageCodec**: RLPx 消息帧——帧头/帧尾 MAC、per-cap 消息 id 映射、Snappy 解压
- **rlpx/Messages**: RLPx 基础协议消息（Hello/Disconnect/Ping/Pong）+ eth capability 消息 id
- **rlpx/Session**: 单 peer 逻辑会话——握手、帧消息读写、keepalive ping
- **rlpx/Client**: 高层 RLPx 客户端——拨号、握手、发送 Status、暴露已建立会话

## 依赖
依赖 part 1-2。有效行数 ~490（check-commit.sh 算法）。