### PR TITLE
[eth_sync] Add devp2p block sync core (part 5/9)

### DIFF
--- a/bcos-devp2p/bcos-devp2p/sync/Block.h
+++ b/bcos-devp2p/bcos-devp2p/sync/Block.h
@@ -1,0 +1,66 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Block.h
+ * @brief A complete Ethereum block as assembled by the devp2p downloader.
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "../rlpx/Crypto.h"
+#include <bcos-crypto/interfaces/crypto/CommonType.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <bcos-rlp-protocol/EthWithdrawal.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/FixedBytes.h>
+#include <optional>
+#include <vector>
+
+namespace bcos::devp2p::sync
+{
+// A block downloaded from a peer: the parsed header plus the opaque body
+// elements (transactions/uncles/withdrawals keep their wire encoding so the
+// block can be re-serialized losslessly).
+struct Block
+{
+    bcos::protocol::EthBlockHeaderData header;
+    bcos::h256 hash;       // keccak256(header RLP)
+    bcos::bytes headerRlp;
+    std::vector<bcos::bytes> transactions;   // opaque EIP-2718 encodings
+    std::vector<bcos::bytes> uncles;         // raw header RLP (empty on PoS)
+    std::optional<std::vector<bcos::bytes>> withdrawals;  // raw EIP-4895 RLP, Shanghai+
+
+    uint64_t number() const { return static_cast<uint64_t>(header.number); }
+    bcos::h256 parentHash() const { return header.parentInfo.blockHash; }
+    bool hasWithdrawals() const { return withdrawals.has_value(); }
+};
+
+// Canonical empty-ommers-hash (keccak256(rlp([]))), used on every PoS block.
+inline bcos::h256 emptyOmmersHash()
+{
+    static const bcos::h256 hash = bcos::crypto::keccak256Hash(
+        bcos::bytesConstRef(reinterpret_cast<const bcos::byte*>("\xc0"), 1));
+    return hash;
+}
+
+// keccak256 of the canonical RLP encoding of an Ethereum header.
+inline bcos::h256 headerHash(bcos::protocol::EthBlockHeaderData const& _header)
+{
+    bcos::bytes rlp;
+    bcos::codec::rlp::encode(rlp, _header);
+    return bcos::crypto::keccak256Hash(
+        bcos::bytesConstRef(rlp.data(), rlp.size()));
+}
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/BlockExchange.h
+++ b/bcos-devp2p/bcos-devp2p/sync/BlockExchange.h
@@ -1,0 +1,102 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file BlockExchange.h
+ * @brief Block download orchestration: batches of headers + bodies, anchor
+ *        advancement, per-block callback (port of silkworm's BlockExchange,
+ *        simplified for a single peer / blocking session).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "BodySequence.h"
+#include "HeaderChain.h"
+#include "../rlpx/Session.h"
+#include <functional>
+
+namespace bcos::devp2p::sync
+{
+// Downloads a contiguous range of blocks from a peer by alternating header
+// and body requests, and hands each assembled block to a callback in order.
+class BlockExchange
+{
+public:
+    using BlockCallback = std::function<void(Block const&)>;
+
+    // `_startNumber`: first block to download (nextNumber of the anchor).
+    // `_anchorHash`: hash of the last locally-known block (block startNumber - 1).
+    BlockExchange(uint64_t _startNumber, bcos::h256 _anchorHash,
+        uint64_t _batchSize = 192)
+      : m_headerChain(_startNumber, _anchorHash), m_batchSize(_batchSize)
+    {}
+
+    // Same, but with the known anchor header so downloaded headers are also
+    // validated against Ethereum PoS field rules.
+    BlockExchange(uint64_t _startNumber,
+        bcos::protocol::EthBlockHeaderData _anchorHeader,
+        ChainConfig const& _config = {}, uint64_t _batchSize = 192)
+      : m_headerChain(_startNumber, std::move(_anchorHeader), _config), m_batchSize(_batchSize)
+    {}
+
+    // Synchronously download `_count` blocks and invoke `_onBlock` for each in
+    // ascending order. Throws on protocol/validation errors.
+    void downloadRange(rlpx::Session& _session, uint64_t _count, BlockCallback _onBlock)
+    {
+        uint64_t remaining = _count;
+        while (remaining > 0)
+        {
+            uint64_t amount = std::min(remaining, m_batchSize);
+            auto headers = m_headerChain.requestHeaders(_session, amount);
+            if (headers.empty())
+            {
+                throw std::runtime_error("BlockExchange: peer returned no headers");
+            }
+            // GetBlockBodies may be answered with FEWER bodies than requested:
+            // geth caps the response at its message size limit, so large bodies
+            // truncate it. Pair the returned bodies with the leading headers,
+            // then re-request the remaining headers until all bodies arrive.
+            size_t processed = 0;
+            while (processed < headers.size())
+            {
+                std::vector<HeaderWithHash> pending(headers.begin() +
+                        static_cast<std::ptrdiff_t>(processed),
+                    headers.end());
+                auto blocks = m_bodySequence.requestBodies(_session, pending);
+                if (blocks.empty())
+                {
+                    throw std::runtime_error("BlockExchange: peer returned no bodies");
+                }
+                for (auto const& block : blocks)
+                {
+                    _onBlock(block);
+                }
+                processed += blocks.size();
+            }
+            // `processed` is >= 1 (the first requestBodies returned at least one
+            // body) and <= headers.size().
+            m_headerChain.advance(processed, headers[processed - 1]);
+            remaining -= processed;
+        }
+    }
+
+    uint64_t nextNumber() const { return m_headerChain.nextNumber(); }
+    bcos::h256 headHash() const { return m_headerChain.anchorHash(); }
+
+private:
+    HeaderChain m_headerChain;
+    BodySequence m_bodySequence;
+    uint64_t m_batchSize;
+};
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/BodySequence.cpp
+++ b/bcos-devp2p/bcos-devp2p/sync/BodySequence.cpp
@@ -1,0 +1,125 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file BodySequence.cpp
+ * @brief Block-body download implementation.
+ * @date 2026/8/18
+ */
+#include "BodySequence.h"
+
+#include <stdexcept>
+
+namespace bcos::devp2p::sync
+{
+std::vector<Block> BodySequence::requestBodies(
+    rlpx::Session& _session, std::vector<HeaderWithHash> const& _headers)
+{
+    if (_headers.empty())
+    {
+        return {};
+    }
+
+    eth::GetBlockBodiesMessage request;
+    request.requestId = ++m_requestId;
+    request.hashes.reserve(_headers.size());
+    for (auto const& header : _headers)
+    {
+        request.hashes.push_back(header.hash);
+    }
+    _session.sendMessage(
+        rlpx::Message{static_cast<uint8_t>(eth::frameId(eth::msg::GetBlockBodies)),
+            eth::encodeGetBlockBodies(request)});
+
+    // Peers freely broadcast transactions/new blocks while we wait for the
+    // BlockBodies reply — ignore them (and answer Ping) and keep waiting.
+    int ignoredBroadcasts = 0;
+    std::vector<Block> out;
+    while (true)
+    {
+        auto response = _session.recvMessage();
+        if (response.id == rlpx::baseMsg::Ping)
+        {
+            _session.sendMessage(rlpx::Message{rlpx::baseMsg::Pong, {}});
+            continue;
+        }
+        if (response.id == rlpx::baseMsg::Pong)
+        {
+            continue;
+        }
+        if (response.id != eth::frameId(eth::msg::BlockBodies))
+        {
+            if (response.id == rlpx::baseMsg::Disconnect)
+            {
+                auto disc = rlpx::decodeDisconnect(
+                    bytesConstRef(response.data.data(), response.data.size()));
+                throw std::runtime_error(
+                    "BodySequence: peer disconnected: reason=" +
+                    std::to_string(static_cast<int>(disc.reason)));
+            }
+            if (response.id == eth::frameId(eth::msg::NewBlockHashes) ||
+                response.id == eth::frameId(eth::msg::Transactions) ||
+                response.id == eth::frameId(eth::msg::NewBlock) ||
+                response.id == eth::frameId(eth::msg::NewPooledTransactionHashes))
+            {
+                if (++ignoredBroadcasts > 64)
+                {
+                    throw std::runtime_error(
+                        "BodySequence: too many broadcast messages before BlockBodies");
+                }
+                continue;
+            }
+            throw std::runtime_error("BodySequence: expected BlockBodies, got message id=" +
+                                     std::to_string(response.id));
+        }
+        auto bodies = eth::decodeBlockBodies(
+            bytesConstRef(response.data.data(), response.data.size()));
+        if (bodies.requestId != request.requestId)
+        {
+            throw std::runtime_error("BodySequence: request id mismatch");
+        }
+        // The eth protocol lets a peer answer GetBlockBodies with FEWER bodies
+        // than requested: geth caps the response at its message size limit, so
+        // large bodies (blocks with many transactions/uncles) truncate it. A
+        // partial response pairs bodies[i] with headers[i]; the caller
+        // (BlockExchange) re-requests the remaining headers. An empty response
+        // is a hard error — retrying it would just loop forever.
+        if (bodies.bodies.size() > _headers.size())
+        {
+            throw std::runtime_error("BodySequence: body count overflow (got " +
+                                     std::to_string(bodies.bodies.size()) + ", want " +
+                                     std::to_string(_headers.size()) + ")");
+        }
+        if (bodies.bodies.empty())
+        {
+            throw std::runtime_error("BodySequence: peer returned no bodies");
+        }
+
+        out.reserve(bodies.bodies.size());
+        for (size_t i = 0; i < bodies.bodies.size(); ++i)
+        {
+            Block block;
+            block.header = _headers[i].header;
+            block.hash = _headers[i].hash;
+            block.headerRlp = _headers[i].rlp;
+            block.transactions = bodies.bodies[i].transactions;
+            block.uncles = bodies.bodies[i].uncles;
+            block.withdrawals = bodies.bodies[i].withdrawals;
+            out.push_back(std::move(block));
+        }
+        return out;
+    }
+}
+
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/BodySequence.h
+++ b/bcos-devp2p/bcos-devp2p/sync/BodySequence.h
@@ -1,0 +1,43 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file BodySequence.h
+ * @brief Block-body download and block assembly (eth/66+ GetBlockBodies).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Block.h"
+#include "HeaderChain.h"
+#include "../rlpx/Messages.h"
+#include "../rlpx/Session.h"
+#include "../eth/Protocol.h"
+
+namespace bcos::devp2p::sync
+{
+// Fetches the bodies for a batch of headers and assembles complete blocks.
+// eth/68 returns bodies in the same order as the requested hashes.
+class BodySequence
+{
+public:
+    // Fetch bodies for `_headers` (in order) and assemble complete blocks.
+    // Throws on any protocol violation (request-id mismatch, wrong count).
+    std::vector<Block> requestBodies(
+        rlpx::Session& _session, std::vector<HeaderWithHash> const& _headers);
+
+private:
+    uint64_t m_requestId{0};
+};
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/Bootnodes.h
+++ b/bcos-devp2p/bcos-devp2p/sync/Bootnodes.h
@@ -1,0 +1,144 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file Bootnodes.h
+ * @brief Ethereum L1 EL-mode bootnode configuration: parse geth-style enode://
+ *        URIs and load a bootnodes.json file (a JSON array of enode strings).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "bcos-devp2p/rlpx/Client.h"
+#include <bcos-utilities/DataConvertUtility.h>
+#include <bcos-utilities/Exceptions.h>
+#include <boost/throw_exception.hpp>
+#include <fstream>
+#include <json/json.h>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace bcos::devp2p::sync
+{
+
+/// Parse a geth-style enode URI into a PeerConfig.
+/// Format: enode://<64-byte-hex-pubkey>@<ip>:<tcp-port>[?discport=<udp-port>]
+/// The discovery port suffix is accepted and ignored (we only connect via TCP).
+/// Throws std::invalid_argument on malformed input.
+inline bcos::devp2p::rlpx::PeerConfig parseEnode(std::string const& enode)
+{
+    constexpr std::string_view prefix = "enode://";
+    if (enode.rfind(prefix, 0) != 0)
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("parseEnode: enode must start with 'enode://': " + enode));
+    }
+    auto rest = std::string_view(enode).substr(prefix.size());
+    auto at = rest.find('@');
+    if (at == std::string_view::npos)
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("parseEnode: missing '@' (expected enode://<pubkey>@<host>:<port>): " +
+                                  enode));
+    }
+    auto pubHex = rest.substr(0, at);
+    // 64 hex chars = 32 bytes = 64 hex digits uncompressed X coordinate (secp256k1
+    // uncompressed public key is 64 bytes = 128 hex chars; geth enodes carry the
+    // 64-byte uncompressed key, i.e. 128 hex chars).
+    auto pubBytes = bcos::fromHex(std::string(pubHex));
+    auto endpoint = rest.substr(at + 1);
+    auto q = endpoint.find('?');
+    auto hostPort = endpoint.substr(0, q);
+    auto colon = hostPort.rfind(':');
+    if (colon == std::string_view::npos)
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("parseEnode: missing ':port' in endpoint: " + enode));
+    }
+    auto host = hostPort.substr(0, colon);
+    auto portStr = hostPort.substr(colon + 1);
+    uint16_t port = 0;
+    try
+    {
+        auto parsed = std::stoul(std::string(portStr));
+        if (parsed == 0 || parsed > 65535)
+        {
+            BOOST_THROW_EXCEPTION(std::out_of_range("port"));
+        }
+        port = static_cast<uint16_t>(parsed);
+    }
+    catch (std::exception const&)
+    {
+        BOOST_THROW_EXCEPTION(std::invalid_argument(
+            "parseEnode: invalid port '" + std::string(portStr) + "' in: " + enode));
+    }
+
+    bcos::devp2p::rlpx::PeerConfig config;
+    config.host = std::string(host);
+    config.port = port;
+    config.peerPublicKey = std::move(pubBytes);
+    return config;
+}
+
+/// Load a bootnodes.json file: either a JSON array of enode strings, or an object
+/// {"bootnodes": [ ... ]}. Returns the parsed PeerConfig list (empty file/section
+/// yields an empty list; a missing file throws).
+inline std::vector<bcos::devp2p::rlpx::PeerConfig> loadBootnodes(std::string const& path)
+{
+    std::ifstream in(path);
+    if (!in)
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("loadBootnodes: cannot open bootnodes file: " + path));
+    }
+    std::stringstream ss;
+    ss << in.rdbuf();
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(ss.str(), root))
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("loadBootnodes: invalid JSON in " + path));
+    }
+    Json::Value arr;
+    if (root.isArray())
+    {
+        arr = root;
+    }
+    else if (root.isObject() && root.isMember("bootnodes") && root["bootnodes"].isArray())
+    {
+        arr = root["bootnodes"];
+    }
+    else
+    {
+        BOOST_THROW_EXCEPTION(std::invalid_argument(
+            "loadBootnodes: expected a JSON array of enode strings, or {\"bootnodes\": [...]}: " +
+            path));
+    }
+    std::vector<bcos::devp2p::rlpx::PeerConfig> nodes;
+    nodes.reserve(arr.size());
+    for (auto const& entry : arr)
+    {
+        if (!entry.isString())
+        {
+            BOOST_THROW_EXCEPTION(
+                std::invalid_argument("loadBootnodes: non-string entry in " + path));
+        }
+        nodes.push_back(parseEnode(entry.asString()));
+    }
+    return nodes;
+}
+
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/HeaderChain.cpp
+++ b/bcos-devp2p/bcos-devp2p/sync/HeaderChain.cpp
@@ -1,0 +1,193 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HeaderChain.cpp
+ * @brief Header download implementation.
+ * @date 2026/8/18
+ */
+#include "HeaderChain.h"
+
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <bcos-utilities/DataConvertUtility.h>
+#include <stdexcept>
+
+namespace bcos::devp2p::sync
+{
+HeaderChain::HeaderChain(uint64_t _nextNumber, bcos::h256 _anchorHash,
+    uint64_t _maxHeadersPerRequest)
+  : m_nextNumber(_nextNumber),
+    m_anchorHash(_anchorHash),
+    m_maxHeadersPerRequest(_maxHeadersPerRequest)
+{}
+
+HeaderChain::HeaderChain(uint64_t _nextNumber,
+    bcos::protocol::EthBlockHeaderData _anchorHeader, ChainConfig const& _config,
+    uint64_t _maxHeadersPerRequest)
+  : m_nextNumber(_nextNumber),
+    m_anchorHash(headerHash(_anchorHeader)),
+    m_anchorHeader(std::move(_anchorHeader)),
+    m_config(_config),
+    m_maxHeadersPerRequest(_maxHeadersPerRequest)
+{}
+
+std::vector<HeaderWithHash> HeaderChain::requestHeaders(
+    rlpx::Session& _session, uint64_t _amount)
+{
+    if (_amount == 0)
+    {
+        return {};
+    }
+    _amount = std::min(_amount, m_maxHeadersPerRequest);
+
+    eth::GetBlockHeadersMessage request;
+    request.requestId = ++m_requestId;
+    request.originNumber = m_nextNumber;
+    request.amount = _amount;
+    request.skip = 0;
+    request.reverse = false;
+    auto requestRlp = eth::encodeGetBlockHeaders(request);
+    std::cerr << "[HeaderChain] sent GetBlockHeaders id=" << request.requestId
+              << " origin=" << request.originNumber << " amount=" << _amount
+              << " rlp=" << bcos::toHexStringWithPrefix(requestRlp) << std::endl;
+    _session.sendMessage(
+        rlpx::Message{static_cast<uint8_t>(eth::frameId(eth::msg::GetBlockHeaders)),
+            std::move(requestRlp)});
+
+    // Loop until we get the BlockHeaders response, answering Ping along the way
+    // (peers ping us periodically; ignoring a Ping makes geth mark us "useless").
+    std::vector<HeaderWithHash> out;
+    int ignoredBroadcasts = 0;
+    while (true)
+    {
+        auto response = _session.recvMessage();
+        std::cerr << "[HeaderChain] recv msg id=" << static_cast<int>(response.id)
+                  << " size=" << response.data.size()
+                  << " data=" << bcos::toHexStringWithPrefix(response.data).substr(0, 200)
+                  << std::endl;
+        if (response.id == rlpx::baseMsg::Ping)
+        {
+            // RLPx base protocol: Ping (id 0x02) is answered with Pong (id 0x03).
+            _session.sendMessage(rlpx::Message{rlpx::baseMsg::Pong, {}});
+            std::cerr << "[HeaderChain] answered Ping with Pong" << std::endl;
+            continue;
+        }
+        if (response.id == rlpx::baseMsg::Pong)
+        {
+            continue;  // answer to a Ping we (currently) never send; ignore
+        }
+        if (response.id != eth::frameId(eth::msg::BlockHeaders))
+        {
+            if (response.id == rlpx::baseMsg::Disconnect)
+            {
+                auto disc = rlpx::decodeDisconnect(
+                    bytesConstRef(response.data.data(), response.data.size()));
+                throw std::runtime_error(
+                    "HeaderChain: peer disconnected: reason=" +
+                    std::to_string(static_cast<int>(disc.reason)));
+            }
+            // Peers freely broadcast transactions/new blocks while we are
+            // waiting for the BlockHeaders reply — NewBlockHashes(0x11),
+            // Transactions(0x12), NewBlock(0x17), NewPooledTransactionHashes
+            // (0x18). Ignore them and keep waiting for the response.
+            if (response.id == eth::frameId(eth::msg::NewBlockHashes) ||
+                response.id == eth::frameId(eth::msg::Transactions) ||
+                response.id == eth::frameId(eth::msg::NewBlock) ||
+                response.id == eth::frameId(eth::msg::NewPooledTransactionHashes))
+            {
+                if (++ignoredBroadcasts > 64)
+                {
+                    throw std::runtime_error(
+                        "HeaderChain: too many broadcast messages before BlockHeaders");
+                }
+                continue;
+            }
+            throw std::runtime_error("HeaderChain: expected BlockHeaders, got message id=" +
+                                     std::to_string(response.id));
+        }
+        auto headers = eth::decodeBlockHeaders(
+            bytesConstRef(response.data.data(), response.data.size()));
+        if (headers.requestId != request.requestId)
+        {
+            throw std::runtime_error("HeaderChain: request id mismatch");
+        }
+
+        out.reserve(headers.headers.size());
+        for (size_t i = 0; i < headers.headers.size(); ++i)
+        {
+            HeaderWithHash header;
+            header.rlp = headers.headers[i];
+            bcos::protocol::EthBlockHeader ethHeader;
+            if (auto err = ethHeader.rlpDecode(bytesConstRef(header.rlp.data(), header.rlp.size())))
+        {
+            throw std::runtime_error("HeaderChain: header RLP decode failed");
+        }
+        header.header = ethHeader.data();
+        // The header hash is keccak of the received wire encoding.
+        header.hash = bcos::crypto::keccak256Hash(
+            bytesConstRef(header.rlp.data(), header.rlp.size()));
+
+        // Strictly ascending, contiguous block numbers.
+        if (header.number() != m_nextNumber + i)
+        {
+            throw std::runtime_error("HeaderChain: non-contiguous block numbers (got " +
+                                     std::to_string(header.number()) + ", want " +
+                                     std::to_string(m_nextNumber + i) + ")");
+        }
+        // Parent chain: the first header's parent must be our anchor; the rest
+        // must chain to the previously received header.
+        if (i == 0)
+        {
+            if (header.parentHash() != m_anchorHash)
+            {
+                throw std::runtime_error(
+                    "HeaderChain: parent hash mismatch (fork or reorg)");
+            }
+        }
+        else if (header.parentHash() != out[i - 1].hash)
+        {
+            throw std::runtime_error("HeaderChain: broken parent chain");
+        }
+
+        // When the anchor header is known, validate the Ethereum PoS field
+        // rules against the actual parent header.
+        if (m_anchorHeader.has_value())
+        {
+            auto const& parentHeader =
+                i == 0 ? *m_anchorHeader : out[i - 1].header;
+            auto result = validateHeaderPoS(header.header, parentHeader, m_config);
+            if (!result.valid)
+            {
+                throw std::runtime_error("HeaderChain: PoS validation failed at block " +
+                                         std::to_string(header.number()) + ": " + result.error);
+            }
+        }
+        out.push_back(std::move(header));
+        }
+        return out;
+    }
+}
+
+void HeaderChain::advance(uint64_t _count, HeaderWithHash const& _lastHeader)
+{
+    m_nextNumber += _count;
+    m_anchorHash = _lastHeader.hash;
+    // Keep the anchor header in sync too: the next batch validates its first
+    // header against m_anchorHeader (parent number + 1 check). Stale it and a
+    // multi-batch download (peer has more blocks than one batch) fails with
+    // "header number must equal the parent number + 1".
+    m_anchorHeader = _lastHeader.header;
+}
+
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/HeaderChain.h
+++ b/bcos-devp2p/bcos-devp2p/sync/HeaderChain.h
@@ -1,0 +1,76 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HeaderChain.h
+ * @brief Header download with continuity + parentHash chain validation
+ *        (port of silkworm's sync header chain, simplified for eth/68 sync).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Block.h"
+#include "HeaderValidator.h"
+#include "../rlpx/Messages.h"
+#include "../rlpx/Session.h"
+#include "../eth/Protocol.h"
+
+namespace bcos::devp2p::sync
+{
+// A validated header together with its keccak hash and raw wire encoding.
+struct HeaderWithHash
+{
+    bcos::protocol::EthBlockHeaderData header;
+    bcos::h256 hash;
+    bcos::bytes rlp;
+
+    uint64_t number() const { return static_cast<uint64_t>(header.number); }
+    bcos::h256 parentHash() const { return header.parentInfo.blockHash; }
+};
+
+// Downloads a contiguous run of headers from a peer, validating the ascending
+// block-number sequence, the parentHash chain against a local anchor, and —
+// when the anchor header is known — the per-header Ethereum PoS field rules
+// (EIP-1559 base fee, EIP-4844 blob gas, gas-limit bounds, ...).
+class HeaderChain
+{
+public:
+    HeaderChain(uint64_t _nextNumber, bcos::h256 _anchorHash,
+        uint64_t _maxHeadersPerRequest = 192);
+
+    // With a known anchor header (the local block before nextNumber), every
+    // downloaded header is additionally validated against Ethereum PoS rules.
+    HeaderChain(uint64_t _nextNumber, bcos::protocol::EthBlockHeaderData _anchorHeader,
+        ChainConfig const& _config = {}, uint64_t _maxHeadersPerRequest = 192);
+
+    uint64_t nextNumber() const { return m_nextNumber; }
+    bcos::h256 anchorHash() const { return m_anchorHash; }
+
+    // Request up to `_amount` headers starting at nextNumber. Validates
+    // contiguity, the parent chain and (when the anchor header is known) the
+    // PoS field rules. Throws on any protocol violation.
+    std::vector<HeaderWithHash> requestHeaders(rlpx::Session& _session, uint64_t _amount);
+
+    // Advance the anchor past `_count` downloaded headers.
+    void advance(uint64_t _count, HeaderWithHash const& _lastHeader);
+
+private:
+    uint64_t m_nextNumber;
+    bcos::h256 m_anchorHash;
+    std::optional<bcos::protocol::EthBlockHeaderData> m_anchorHeader;
+    ChainConfig m_config;
+    uint64_t m_maxHeadersPerRequest;
+    uint64_t m_requestId{0};
+};
+}  // namespace bcos::devp2p::sync

--- a/bcos-devp2p/bcos-devp2p/sync/HeaderValidator.h
+++ b/bcos-devp2p/bcos-devp2p/sync/HeaderValidator.h
@@ -1,0 +1,252 @@
+/**
+ *  Copyright (C) 2026 FISCO BCOS.
+ *  SPDX-License-Identifier: Apache-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ * @file HeaderValidator.h
+ * @brief Ethereum PoS header validation (EIP-1559 base fee, EIP-4844 blob gas,
+ *        gas-limit bounds, difficulty/uncle/extra-data rules).
+ * @date 2026/8/18
+ */
+#pragma once
+
+#include "Block.h"
+#include <bcos-rlp-protocol/EthBlockHeader.h>
+#include <bcos-utilities/Common.h>
+#include <string>
+
+namespace bcos::devp2p::sync
+{
+// Consensus constants (EIP-1559 / EIP-4844 / PoS).
+constexpr uint64_t kMinGasLimit = 5000;
+constexpr uint64_t kGasLimitBoundDivisor = 1024;
+constexpr uint64_t kElasticityMultiplier = 2;
+constexpr uint64_t kBaseFeeMaxChangeDenominator = 8;
+constexpr u256 kInitialBaseFee{1000000000};  // 1 gwei
+constexpr uint64_t kMaxExtraDataSize = 32;
+constexpr uint64_t kGasPerBlob = 1U << 17;             // 131072
+constexpr uint64_t kTargetBlobGasPerBlock = 3 * kGasPerBlob;  // 393216
+constexpr uint64_t kMaxBlobGasPerBlock = 6 * kGasPerBlob;     // 786432
+
+// Minimal chain configuration for header validation (timestamp-based forks).
+struct ChainConfig
+{
+    uint64_t chainId{1};
+    // Fork activation timestamps; 0 means "active from genesis".
+    uint64_t londonTime{0};
+    uint64_t shanghaiTime{0};
+    uint64_t cancunTime{0};
+    uint64_t pragueTime{0};
+    // First PoS (merge) block number. Blocks below it are PoW and keep their
+    // PoW difficulty/ommers; blocks at or above it must satisfy PoS rules
+    // (difficulty == 0, no ommers). 0 (default) means "no merge yet": every
+    // block is validated as PoS (the pre-merge-PoW test-chain default).
+    uint64_t mergeBlock{0};
+    u256 initialBaseFee{kInitialBaseFee};
+};
+
+struct HeaderValidationResult
+{
+    bool valid{true};
+    std::string error;
+};
+
+// True if a fork activating at `_forkTime` activates in the block with the
+// given parent/header timestamps.
+inline bool isForkBlock(uint64_t _forkTime, int64_t _parentTimestamp, int64_t _headerTimestamp)
+{
+    if (_forkTime == 0)
+    {
+        return false;  // active from genesis
+    }
+    return static_cast<uint64_t>(_parentTimestamp) < _forkTime &&
+           static_cast<uint64_t>(_headerTimestamp) >= _forkTime;
+}
+
+inline bool isForkActive(uint64_t _forkTime, int64_t _timestamp)
+{
+    return _forkTime == 0 || static_cast<uint64_t>(_timestamp) >= _forkTime;
+}
+
+// EIP-1559: the base fee of the next block (the block after `_parent`).
+inline u256 computeNextBaseFee(bcos::protocol::EthBlockHeaderData const& _parent)
+{
+    auto parentGasTarget = _parent.gasLimit / kElasticityMultiplier;
+    u256 expected = _parent.baseFee.value_or(0);
+    if (_parent.gasUsed == parentGasTarget)
+    {
+        return expected;
+    }
+    if (_parent.gasUsed > parentGasTarget)
+    {
+        auto delta = expected * (_parent.gasUsed - parentGasTarget) / parentGasTarget /
+                     kBaseFeeMaxChangeDenominator;
+        return expected + (delta > 1 ? delta : 1);
+    }
+    auto delta = expected * (parentGasTarget - _parent.gasUsed) / parentGasTarget /
+                 kBaseFeeMaxChangeDenominator;
+    return expected > delta ? expected - delta : 0;
+}
+
+// EIP-4844: the excess blob gas of the next block (the block after `_parent`).
+inline u256 computeNextExcessBlobGas(bcos::protocol::EthBlockHeaderData const& _parent)
+{
+    u256 parentExcess = _parent.excessBlobGas.value_or(0);
+    u256 parentBlobGasUsed = _parent.blobGasUsed.value_or(0);
+    u256 total = parentBlobGasUsed + parentExcess;
+    return total > kTargetBlobGasPerBlock ? total - kTargetBlobGasPerBlock : 0;
+}
+
+namespace detail
+{
+inline std::optional<std::string> validateBaseFee(
+    bcos::protocol::EthBlockHeaderData const& _header,
+    bcos::protocol::EthBlockHeaderData const& _parent, ChainConfig const& _config)
+{
+    bool londonActive = isForkActive(_config.londonTime, _header.timestamp);
+    if (londonActive && !_header.baseFee.has_value())
+    {
+        return "missing baseFeePerGas (London active)";
+    }
+    if (_header.baseFee.has_value() && !_parent.baseFee.has_value())
+    {
+        // Parent pre-London: only valid on the London activation block.
+        if (!isForkBlock(_config.londonTime, _parent.timestamp, _header.timestamp))
+        {
+            return "baseFeePerGas present but the parent is pre-London";
+        }
+        if (*_header.baseFee != _config.initialBaseFee)
+        {
+            return "baseFeePerGas must equal the initial base fee at London";
+        }
+    }
+    else if (_header.baseFee.has_value() && _parent.baseFee.has_value())
+    {
+        if (*_header.baseFee != computeNextBaseFee(_parent))
+        {
+            return "baseFeePerGas does not match the EIP-1559 recomputation";
+        }
+    }
+    return std::nullopt;
+}
+
+inline std::optional<std::string> validateBlobGas(
+    bcos::protocol::EthBlockHeaderData const& _header,
+    bcos::protocol::EthBlockHeaderData const& _parent, ChainConfig const& _config)
+{
+    if (_header.blobGasUsed.has_value())
+    {
+        if (*_header.blobGasUsed > kMaxBlobGasPerBlock ||
+            *_header.blobGasUsed % kGasPerBlob != 0)
+        {
+            return "invalid blobGasUsed";
+        }
+    }
+    if (_header.excessBlobGas.has_value())
+    {
+        if (!_parent.excessBlobGas.has_value())
+        {
+            // Parent pre-Cancun: only valid on the Cancun activation block (excess = 0).
+            if (!isForkBlock(_config.cancunTime, _parent.timestamp, _header.timestamp))
+            {
+                return "excessBlobGas present but the parent is pre-Cancun";
+            }
+            if (*_header.excessBlobGas != 0)
+            {
+                return "excessBlobGas must be zero at Cancun activation";
+            }
+        }
+        else if (*_header.excessBlobGas != computeNextExcessBlobGas(_parent))
+        {
+            return "excessBlobGas does not match the EIP-4844 recomputation";
+        }
+    }
+    return std::nullopt;
+}
+}  // namespace detail
+
+// Validate `_header` against its parent per Ethereum consensus rules.
+// Chain-continuity (number/parentHash) is expected to have been checked by the
+// caller; this focuses on the per-header field rules. Blocks before the merge
+// (PoW, `number < mergeBlock`) follow PoW rules — difficulty is non-zero and
+// ommers are allowed — while merged blocks follow PoS rules.
+inline HeaderValidationResult validateHeaderPoS(
+    bcos::protocol::EthBlockHeaderData const& _header,
+    bcos::protocol::EthBlockHeaderData const& _parent, ChainConfig const& _config)
+{
+    const bool pos = _config.mergeBlock == 0 ||
+                     static_cast<uint64_t>(_header.number) >= _config.mergeBlock;
+    if (pos)
+    {
+        // PoS: difficulty must be zero and no ommers.
+        if (_header.difficulty != 0)
+        {
+            return {false, "PoS difficulty must be zero"};
+        }
+        if (_header.uncleHash != emptyOmmersHash())
+        {
+            return {false, "PoS blocks must have no ommers"};
+        }
+    }
+    else
+    {
+        // PoW: on a plain PoW chain difficulty is always non-zero. EXCEPTION —
+        // Terminal Total Difficulty (TTD): on merge chains (Sepolia: TTD 17e15,
+        // reached at block 1450409), the first block at/after the TTD carries
+        // difficulty 0 while still being pre-merge (PoW) until the merge block
+        // (1735371). So a zero difficulty is legal here; ommers remain allowed.
+    }
+    // Extra-data vanity bound.
+    if (_header.extraData.size() > kMaxExtraDataSize)
+    {
+        return {false, "extraData exceeds the 32-byte PoS bound"};
+    }
+    // Number continuity and strictly-increasing timestamp.
+    if (_header.number != _parent.number + 1)
+    {
+        return {false, "header number must equal the parent number + 1"};
+    }
+    if (_header.timestamp <= _parent.timestamp)
+    {
+        return {false, "timestamp must be strictly greater than the parent"};
+    }
+    // Gas limit bounds: >= MIN_GAS_LIMIT and |Δ| <= parent / 1024.
+    if (_header.gasLimit < kMinGasLimit)
+    {
+        return {false, "gasLimit below the 5000 minimum"};
+    }
+    u256 parentGasLimit = _parent.gasLimit;
+    u256 delta = _header.gasLimit > parentGasLimit ? _header.gasLimit - parentGasLimit :
+                                                     parentGasLimit - _header.gasLimit;
+    if (delta > parentGasLimit / kGasLimitBoundDivisor)
+    {
+        return {false, "gasLimit differs from the parent by more than 1/1024"};
+    }
+    if (_header.gasUsed > _header.gasLimit)
+    {
+        return {false, "gasUsed exceeds gasLimit"};
+    }
+
+    // EIP-1559 base fee and EIP-4844 blob gas.
+    if (auto err = detail::validateBaseFee(_header, _parent, _config))
+    {
+        return {false, *err};
+    }
+    if (auto err = detail::validateBlobGas(_header, _parent, _config))
+    {
+        return {false, *err};
+    }
+
+    return {true, {}};
+}
+}  // namespace bcos::devp2p::sync


### PR DESCRIPTION
## 概述
devp2p 链第五部分：同步下载核心。

## 内容
- **sync/HeaderValidator**: Ethereum PoS 头验证（difficulty/ommers、baseFee/excessBlobGas 重算、fork-gated 字段、时间戳排序）
- **sync/HeaderChain**: GetBlockHeaders 请求循环、连续编号 + parent hash 检查、anchor 追踪
- **sync/BodySequence**: GetBlockBodies 请求、广播过滤、逐块组装
- **sync/BlockExchange**: 编排——下载头、配对 body、按升序逐块回调
- **sync/Bootnodes + sync/Block**: bootnode 列表解析 + Block 结构

## 依赖
依赖 eth 线协议（part 4）。有效行数 ~445（check-commit.sh 算法）。