### PR TITLE
ci(engine-test): fix Lodestar install failure from pnpm ignored build scripts

### DIFF
--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -719,6 +719,11 @@ packages:
   - "."
 overrides:
   snappy: 7.3.3
+# pnpm >= 10.16 blocks dependency build scripts by default and fails the
+# install with ERR_PNPM_IGNORED_BUILDS. classic-level (Lodestar's native
+# LevelDB binding) must run its prebuild-install script to be usable.
+onlyBuiltDependencies:
+  - classic-level
 WS_EOF
         if ! (cd "${LODESTAR_DIR}" && pnpm install --reporter=append-only) > "${LODESTAR_OUT}" 2>&1; then
             log_info "Lodestar install output (last 20 lines):"


### PR DESCRIPTION
## 问题

CI `Build (ubuntu-24.04)` 在 engine integration test 的 Step 5 (Lodestar dev mode) 失败，例如 https://github.com/FISCO-BCOS/FISCO-BCOS/actions/runs/33036223569/job/98411025708:

```
Error: ERR_PNPM_IGNORED_BUILDS
  × installing dependencies
  ╰─▶ Ignored build scripts: classic-level@1.4.1, classic-level@3.0.0
❌ FAILED: Lodestar install failed
```

新版 pnpm (>= 10.16) 默认禁止依赖的 build scripts（安全加固），未在白名单内直接报错退出。Lodestar 的传递依赖 `classic-level` 是原生 LevelDB 绑定，必须运行 prebuild-install 脚本，因此 `pnpm install` 失败导致整个测试步骤失败。与 PR 代码无关，属 runner 环境 pnpm 版本漂移。

## 修复

在 `tools/engine_integration_test.sh` 生成的 `pnpm-workspace.yaml` 中加入：

```yaml
onlyBuiltDependencies:
  - classic-level
```

允许 `classic-level` 执行其 build script，安装即可通过。