### PR TITLE
feat(EthBlockHeader): Serve real Ethereum header fields via eth\_ RPC and finalize Engine-built blocks with RLP hashes

### DIFF
--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -54,6 +54,10 @@ using PayloadID = std::string;
 DERIVE_BCOS_EXCEPTION(UnsupportedEngineApiVersion);
 DERIVE_BCOS_EXCEPTION(UnknownPayload);
 DERIVE_BCOS_EXCEPTION(IncompatiblePayloadVersion);
+/// A request whose attribute shape cannot express the chain fork the header must be
+/// hashed as (e.g. forkchoiceUpdatedV2 on a CANCUN chain). Maps to -38005 Unsupported
+/// fork, matching geth's answer for the same CL/chain mismatch.
+DERIVE_BCOS_EXCEPTION(UnsupportedFork);
 
 struct WithdrawalV1
 {

--- a/bcos-framework/bcos-framework/engine/Types.h
+++ b/bcos-framework/bcos-framework/engine/Types.h
@@ -51,13 +51,12 @@ using PayloadID = std::string;
 /// Engine API error conditions shared by the service implementation and the RPC
 /// endpoint layer, which maps them to Engine API error codes: UnknownPayload ->
 /// -38001, the two version mismatches -> -38005 Unsupported fork.
+/// UnsupportedFork lives in Errors.h (same namespace); a request whose attribute
+/// shape cannot express the chain fork is thrown by EngineService buildPayload and
+/// mapped to -38005 by the endpoint.
 DERIVE_BCOS_EXCEPTION(UnsupportedEngineApiVersion);
 DERIVE_BCOS_EXCEPTION(UnknownPayload);
 DERIVE_BCOS_EXCEPTION(IncompatiblePayloadVersion);
-/// A request whose attribute shape cannot express the chain fork the header must be
-/// hashed as (e.g. forkchoiceUpdatedV2 on a CANCUN chain). Maps to -38005 Unsupported
-/// fork, matching geth's answer for the same CL/chain mismatch.
-DERIVE_BCOS_EXCEPTION(UnsupportedFork);
 
 struct WithdrawalV1
 {

--- a/bcos-ledger/bcos-ledger/Ledger.cpp
+++ b/bcos-ledger/bcos-ledger/Ledger.cpp
@@ -2314,6 +2314,10 @@ bool Ledger::buildGenesisBlock(
         // (asyncCreateTable rejects an existing table on the next attempt).
         auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
         header->setNumber(0);
+        // Genesis deliberately leaves parentInfo unset: parentInfo() reads back the default
+        // zero hash (BlockHeaderImpl returns {} for an empty list), which is exactly the
+        // value a genesis block must carry. Keeping it data-driven rather than forcing a
+        // zero here means the RLP genesis hash is invariant regardless of representation.
         if (versionNumber >= protocol::BlockVersion::V3_1_VERSION)
         {
             header->setVersion(versionNumber);

--- a/bcos-ledger/bcos-ledger/LedgerMethods.cpp
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.cpp
@@ -505,10 +505,12 @@ bcos::task::Task<void> bcos::ledger::tag_invoke(
     // (executor_version=2); v0/v1 schedulers never read evmcRevision()/evmcRevisionForBlock(),
     // so a non-v2 chain is left untouched (no implicit default injection, which would be an
     // unnoticed behavior change if a future v0/v1 path started reading it). For v2, an
-    // explicitly configured revision was persisted at genesis (Ledger::buildGenesisBlock);
-    // the fallback here covers a v2 genesis without one (defensive — NodeConfig::loadExecutorConfig
-    // requires an explicit revision for executor_version=2, so this default only fires on
-    // corrupt/legacy state).
+    // explicitly configured revision was persisted at genesis (Ledger::buildGenesisBlock).
+    // A v2 chain WITHOUT one stays UNCONFIGURED here (no binary-side default injected): the
+    // consumers fail closed — EthereumExecutor throws EvmcRevisionNotConfigured and
+    // EngineService buildPayload throws UnsupportedFork — rather than hash state or block
+    // headers under a fork the chain never configured. The initializer already refuses to
+    // boot such a chain, so this branch only fires on corrupt/legacy state.
     //
     // No per-call logging here: getLedgerConfig sits on the per-block / per-RPC hot path.
     // The effective revision is parsed and logged once at startup (Initializer), which the
@@ -520,10 +522,6 @@ bcos::task::Task<void> bcos::ledger::tag_invoke(
             // A corrupt persisted value halts loudly (InvalidEVMCRevisionConfig) instead of
             // silently running a compile-time default that could differ between binaries.
             ledger::applyEVMCRevisionConfig(ledgerConfig, evmcRevision.value().first);
-        }
-        else
-        {
-            ledgerConfig.setEVMCRevision(ledger::EVMC_REVISION_DEFAULT);
         }
     }
 }

--- a/bcos-ledger/bcos-ledger/LedgerMethods.h
+++ b/bcos-ledger/bcos-ledger/LedgerMethods.h
@@ -409,10 +409,12 @@ task::Task<void> tag_invoke(ledger::tag_t<getLedgerConfig> /*unused*/, auto& sto
     // (executor_version=2); v0/v1 schedulers never read evmcRevision()/evmcRevisionForBlock(),
     // so a non-v2 chain is left untouched (no implicit default injection, which would be an
     // unnoticed behavior change if a future v0/v1 path started reading it). For v2, an
-    // explicitly configured revision was persisted at genesis (Ledger::buildGenesisBlock);
-    // the fallback here covers a v2 genesis without one (defensive — NodeConfig::loadExecutorConfig
-    // requires an explicit revision for executor_version=2, so this default only fires on
-    // corrupt/legacy state).
+    // explicitly configured revision was persisted at genesis (Ledger::buildGenesisBlock).
+    // A v2 chain WITHOUT one stays UNCONFIGURED here (no binary-side default injected): the
+    // consumers fail closed — EthereumExecutor throws EvmcRevisionNotConfigured and
+    // EngineService buildPayload throws UnsupportedFork — rather than hash state or block
+    // headers under a fork the chain never configured. The initializer already refuses to
+    // boot such a chain, so this branch only fires on corrupt/legacy state.
     //
     // No per-call logging here: getLedgerConfig sits on the per-block / per-RPC hot path.
     // The effective revision is parsed and logged once at startup (Initializer), which the
@@ -424,10 +426,6 @@ task::Task<void> tag_invoke(ledger::tag_t<getLedgerConfig> /*unused*/, auto& sto
             // A corrupt persisted value halts loudly (InvalidEVMCRevisionConfig) instead of
             // silently running a compile-time default that could differ between binaries.
             ledger::applyEVMCRevisionConfig(ledgerConfig, evmcRevision.value().first);
-        }
-        else
-        {
-            ledgerConfig.setEVMCRevision(ledger::EVMC_REVISION_DEFAULT);
         }
     }
 }

--- a/bcos-ledger/test/unittests/ledger/test_GenesisEthHeader.cpp
+++ b/bcos-ledger/test/unittests/ledger/test_GenesisEthHeader.cpp
@@ -137,9 +137,8 @@ BOOST_AUTO_TEST_CASE(BuildsRlpHashMatchingPythonReference)
         // The stored header keeps its Ethereum identity across encode/decode.
         BOOST_CHECK(header->ethBlockVersion() == EthBlockVersion::PRAGUE);
         BOOST_CHECK_EQUAL(header->stateRoot().hex(), std::string(c_emptyTrieRoot));
-        // B0's internal timestamp is milliseconds everywhere; the artifact's
-        // seconds value is multiplied by 1000 on the way in.
-        BOOST_CHECK_EQUAL(header->timestamp(), int64_t{0x689d5c00} * 1000);
+        // B0 timestamp is the artifact's, converted to BlockHeader milliseconds.
+        BOOST_CHECK_EQUAL(header->timestamp(), 0x689d5c00 * 1000LL);
 
         // The FISCO genesis pin moved to SYS_CONFIG.
         auto pinEntry = co_await storage2::readOne(

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -345,6 +345,8 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     m_data.gasLimit = _header.gasLimit();
     m_data.gasUsed = _header.gasUsed();
     m_data.number = _header.number();
+    // EthBlockHeaderData::timestamp is wire seconds (ms /1000); the only conversion point
+    // to/from the internal BlockHeader milliseconds domain is the tar boundary.
     m_data.timestamp = _header.timestamp() / 1000;
     m_data.prevRandao = _header.prevRandao();
     m_data.nonce = _header.nonce();
@@ -395,9 +397,10 @@ void EthBlockHeader::rlpEncode(bcos::bytes& out) const
     // toTarsHeader ×1000).
     //
     // Defense-in-depth: a negative number/timestamp would wrap into a huge u64 on the
-    // static_cast below, silently corrupting the RLP. calculateRLPHash guards via
-    // validateHeader, but rlpEncode is public — reject here so a direct caller cannot
-    // produce a wrong encoding.
+    // encode below, silently corrupting the RLP. calculateRLPHash guards via validateHeader,
+    // but rlpEncode is public — reject here so a direct caller cannot produce a wrong
+    // encoding. The field order itself is delegated to the EthBlockHeaderData codec (shared
+    // with EthBlockBody).
     if (m_data.number < 0)
     {
         BOOST_THROW_EXCEPTION(std::invalid_argument("number must be non-negative"));
@@ -406,13 +409,7 @@ void EthBlockHeader::rlpEncode(bcos::bytes& out) const
     {
         BOOST_THROW_EXCEPTION(std::invalid_argument("timestamp must be non-negative"));
     }
-    codec::rlp::encode(out, m_data.parentInfo.blockHash, m_data.uncleHash, m_data.coinbase,
-        m_data.stateRoot, m_data.txsRoot, m_data.receiptsRoot,
-        bcos::bytesConstRef(m_data.logsBloom.data(), m_data.logsBloom.size()), m_data.difficulty,
-        static_cast<uint64_t>(m_data.number), m_data.gasLimit, m_data.gasUsed,
-        static_cast<uint64_t>(m_data.timestamp), m_data.extraData, m_data.prevRandao, m_data.nonce,
-        m_data.baseFee, m_data.withdrawalsHash, m_data.blobGasUsed, m_data.excessBlobGas,
-        m_data.parentBeaconRoot, m_data.requestsHash);
+    codec::rlp::encode(out, m_data);
 }
 
 bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
@@ -427,25 +424,14 @@ bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
     // take the view directly; the const_cast is confined to this read-only entry point.
     bytesRef out(const_cast<bcos::byte*>(data.data()), data.size());
 
+    // The EthBlockHeaderData codec decodes the full 21-field list and bounds number /
+    // timestamp to int64 (rejecting over-wide wire scalars). m_data.timestamp is the wire
+    // SECONDS value; the ×1000 to internal milliseconds happens at the tar boundary.
     auto error = codec::rlp::decode(out, m_data);
     if (error)
     {
         return error;
     }
-
-    m_data.number = static_cast<int64_t>(_number);
-
-    // The wire timestamp is seconds; the internal EthBlockHeaderData domain is also seconds
-    // for every version — no conversion here. Bound by int64 so a hostile wire value cannot
-    // wrap on the cast. The seconds->milliseconds conversion (×1000) happens only at the
-    // EthBlockHeader->BlockHeader boundary (toTarsHeader), where an
-    // overflow check guards the multiplication.
-    if (_timestamp > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
-    {
-        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
-            "EthBlockHeader: timestamp out of representable range");
-    }
-    m_data.timestamp = static_cast<int64_t>(_timestamp);
 
     // Optional fork fields are decoded positionally, so the set of present optionals is
     // always a contiguous prefix — a later field can only be present if the view was still
@@ -483,9 +469,9 @@ bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
 namespace bcos::codec::rlp
 {
 // EthBlockHeaderData codec: the single source of truth for the 21-field canonical header
-// order. Reused by EthBlockHeader::rlpEncode/rlpDecode (which delegate here) and by
-// EthBlock for ommers. The timestamp here is the WIRE domain (seconds); the ms bridge
-// lives in EthBlockHeader::rlpEncode/rlpDecode.
+// order, shared by EthBlockHeader::rlpEncode/rlpDecode (which delegate here) and by
+// EthBlockBody (which embeds a header and an ommers list). The timestamp here is the WIRE
+// domain (seconds); the ms bridge lives at the EthBlockHeader<->BlockHeader boundary.
 size_t length(const protocol::EthBlockHeaderData& _header) noexcept
 {
     return length(_header.parentInfo.blockHash, _header.uncleHash, _header.coinbase,
@@ -520,8 +506,8 @@ bcos::Error::UniquePtr decode(bcos::bytesRef& _in, protocol::EthBlockHeaderData&
         return err;
     }
     // Block number is internal int64; reject wire values above INT64_MAX instead
-    // of narrowing into a negative number (decodeTarsHeader skips validation and
-    // downstream code assumes a non-negative BlockNumber).
+    // of narrowing into a negative number (downstream code assumes a non-negative
+    // BlockNumber).
     if (number > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
     {
         return BCOS_ERROR_UNIQUE_PTR(

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -447,8 +447,10 @@ bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
     // The shared scalar codec now fails closed on over-wide uint payloads (> target width),
     // so a malformed header is rejected here at decode time instead of being accepted and
     // later normalised when hashing the canonical re-encoding. Leading zeros are still
-    // accepted by the codec; the canonical re-encode below is what guards the hash against
-    // them.
+    // accepted by the codec (the shared UnsignedIntegral walker in RLPDecode.h has no
+    // CanonInt check — geth rejects ErrCanonInt); the canonical re-encode below is what
+    // guards the hash against them. FOLLOW-UP: reject leading-zero integers in the shared
+    // decoder (ywy F4; shared codec, outside this PR's file set).
     //
     // The codec's decode only advances a view cursor and never writes the buffer, so
     // take the view directly; the const_cast is confined to this read-only entry point.

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -45,6 +45,18 @@ bcos::Error::UniquePtr EthBlockHeader::calculateRLPHash(bcos::protocol::BlockHea
     return nullptr;
 }
 
+bcos::crypto::HashType EthBlockHeader::computeHash(
+    const bcos::protocol::BlockHeader& header) noexcept(false)
+{
+    // No validateHeader here (unlike calculateRLPHash): this is the block-identity hash
+    // for FISCO-native/OP headers (EthBlockVersion::NON_ETH) that validateHeader rejects.
+    // The ctor performs the ms->s conversion and throws on a sub-second timestamp.
+    EthBlockHeader ethHeader(header);
+    bcos::bytes encoded;
+    ethHeader.rlpEncode(encoded);
+    return bcos::crypto::keccak256Hash(bcos::ref(encoded));
+}
+
 bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data)
 {

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -405,6 +405,12 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     // Required fields — converted directly, with defensive defaults for empty fields so
     // constructing from an incomplete header never crashes (validation is the caller's job,
     // e.g. via calculateRLPHash -> validateHeader).
+    // ETH-version headers carry the timestamp in SECONDS in EthBlockHeaderData: the header
+    // (milliseconds) is divided by 1000. NON_ETH headers keep MILLISECONDS in
+    // EthBlockHeaderData — rlpEncode's /1000 then produces the seconds the RLP field carries,
+    // so the header timestamp is passed through unchanged. m_version must be set first since
+    // the conversion keys off it.
+    m_version = _header.ethBlockVersion();
     auto parent = _header.parentInfo();
     m_data.parentInfo.blockNumber = parent.blockNumber;
     m_data.parentInfo.blockHash = parent.blockHash;
@@ -418,7 +424,8 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     m_data.gasLimit = _header.gasLimit();
     m_data.gasUsed = _header.gasUsed();
     m_data.number = _header.number();
-    m_data.timestamp = _header.timestamp() / 1000;
+    m_data.timestamp = (m_version == EthBlockVersion::NON_ETH) ? _header.timestamp() :
+                                                                 _header.timestamp() / 1000;
     m_data.prevRandao = _header.prevRandao();
     m_data.nonce = _header.nonce();
 
@@ -458,8 +465,6 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     {
         m_data.requestsHash = _header.requestsHash();
     }
-
-    m_version = _header.ethBlockVersion();
 }
 
 void EthBlockHeader::rlpEncode(bcos::bytes& out) const

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -157,87 +157,6 @@ bcos::Error::UniquePtr EthBlockHeader::toEthBlockHeader(
     return nullptr;
 }
 
-bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
-    bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data)
-{
-    if (header == nullptr)
-    {
-        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeaderType),
-            "EthBlockHeader: header is null");
-    }
-
-    // Reset the destination first so reusing a header (previously holding higher-version
-    // optional fields) cannot leak stale values into this decode.
-    header->clear();
-
-    EthBlockHeader ethHeader;
-    // Call rlpDecode directly (not via toEthBlockHeader) so a timestamp-overflow
-    // InvalidHeader error surfaces with its original code instead of being re-wrapped
-    // as RlpDecodeFailed.
-    if (auto err = ethHeader.rlpDecode(_data))
-    {
-        return err;
-    }
-
-    // Same field projection as toTarsHeader, but deliberately WITHOUT validateHeader:
-    // this path serves FISCO-native/OP (NON_ETH) headers that validateHeader rejects.
-    header->setParentInfo(ethHeader.data().parentInfo);
-    header->setCoinbase(ethHeader.data().coinbase);
-    header->setUncleHash(ethHeader.data().uncleHash);
-    header->setStateRoot(ethHeader.data().stateRoot);
-    header->setTxsRoot(ethHeader.data().txsRoot);
-    header->setReceiptsRoot(ethHeader.data().receiptsRoot);
-    header->setDifficulty(ethHeader.data().difficulty);
-    header->setGasLimit(ethHeader.data().gasLimit);
-    header->setGasUsed(ethHeader.data().gasUsed);
-    header->setNumber(ethHeader.data().number);
-    // EthBlockHeaderData stores SECONDS; the internal BlockHeader stores MILLISECONDS.
-    // Bound by int64 before the ×1000 so a hostile wire value cannot trigger signed
-    // overflow on the conversion.
-    if (ethHeader.data().timestamp > std::numeric_limits<int64_t>::max() / 1000)
-    {
-        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
-            "EthBlockHeader: timestamp out of representable millisecond range");
-    }
-    header->setTimestamp(ethHeader.data().timestamp * 1000);
-    header->setPrevRandao(ethHeader.data().prevRandao);
-    header->setNonce(ethHeader.data().nonce);
-    header->setExtraData(ethHeader.data().extraData);
-    header->setLogsBloom(
-        bcos::bytesConstRef(ethHeader.data().logsBloom.data(), ethHeader.data().logsBloom.size()));
-
-    if (ethHeader.data().baseFee.has_value())
-    {
-        header->setBaseFee(*ethHeader.data().baseFee);
-    }
-    if (ethHeader.data().withdrawalsHash.has_value())
-    {
-        header->setWithdrawalsRoot(*ethHeader.data().withdrawalsHash);
-    }
-    if (ethHeader.data().blobGasUsed.has_value())
-    {
-        header->setBlobGasUsed(*ethHeader.data().blobGasUsed);
-    }
-    if (ethHeader.data().excessBlobGas.has_value())
-    {
-        header->setExcessBlobGas(*ethHeader.data().excessBlobGas);
-    }
-    if (ethHeader.data().parentBeaconRoot.has_value())
-    {
-        header->setParentBeaconBlockRoot(*ethHeader.data().parentBeaconRoot);
-    }
-    if (ethHeader.data().requestsHash.has_value())
-    {
-        header->setRequestsHash(*ethHeader.data().requestsHash);
-    }
-
-    // Unlike toTarsHeader, the version is PINNED to NON_ETH (not copied): this decode path
-    // serves FISCO-native/OP headers, whose hashing stays on the Tars side, not the RLP
-    // bridge. No RLP hash is injected for the same reason.
-    header->setEthBlockVersion(EthBlockVersion::NON_ETH);
-    return nullptr;
-}
-
 // Validate that the header carries every field its EthBlockVersion requires.
 // can be removed if we can guarantee the header is always valid.
 bool EthBlockHeader::validateHeader(
@@ -473,7 +392,7 @@ void EthBlockHeader::rlpEncode(bcos::bytes& out) const
     // Timestamp domain model: EthBlockHeaderData stores SECONDS (the Ethereum RLP domain);
     // the RLP surface carries seconds directly — no conversion here. The ms->s conversion
     // happens only at the EthBlockHeader<->BlockHeader boundary (constructor /1000,
-    // toTarsHeader/decodeTarsHeader ×1000).
+    // toTarsHeader ×1000).
     //
     // Defense-in-depth: a negative number/timestamp would wrap into a huge u64 on the
     // static_cast below, silently corrupting the RLP. calculateRLPHash guards via
@@ -519,7 +438,7 @@ bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
     // The wire timestamp is seconds; the internal EthBlockHeaderData domain is also seconds
     // for every version — no conversion here. Bound by int64 so a hostile wire value cannot
     // wrap on the cast. The seconds->milliseconds conversion (×1000) happens only at the
-    // EthBlockHeader->BlockHeader boundary (toTarsHeader / decodeTarsHeader), where an
+    // EthBlockHeader->BlockHeader boundary (toTarsHeader), where an
     // overflow check guards the multiplication.
     if (_timestamp > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
     {

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -250,7 +250,8 @@ bool EthBlockHeader::validateHeader(
     // ctor+rlpEncode callers that skip validateHeader.
     if (_header.timestamp() % 1000 != 0)
     {
-        return invalid("EthBlockHeader: timestamp must be a whole number of seconds");
+        return invalid("EthBlockHeader: timestamp must be a whole number of seconds, got " +
+                       std::to_string(_header.timestamp()) + " ms");
     }
 
     // Fork-gated optional fields: a version N header must carry every field introduced by
@@ -356,8 +357,9 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     // the calculateRLPHash path, and this covers every direct ctor+rlpEncode caller.
     if (_header.timestamp() % 1000 != 0)
     {
-        BOOST_THROW_EXCEPTION(
-            std::invalid_argument("timestamp must be a whole number of seconds"));
+        BOOST_THROW_EXCEPTION(std::invalid_argument(
+            "timestamp must be a whole number of seconds, got " +
+            std::to_string(_header.timestamp()) + " ms"));
     }
     m_version = _header.ethBlockVersion();
     auto parent = _header.parentInfo();

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -145,6 +145,18 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     return nullptr;
 }
 
+bcos::Error::UniquePtr EthBlockHeader::toEthBlockHeader(
+    EthBlockHeader& ethHeader, bcos::bytesConstRef _data)
+{
+    auto err = ethHeader.rlpDecode(_data);
+    if (err)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::RlpDecodeFailed),
+            "EthBlockHeader: rlpDecode failed: " + err->errorMessage());
+    }
+    return nullptr;
+}
+
 bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data)
 {
@@ -223,18 +235,6 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     // serves FISCO-native/OP headers, whose hashing stays on the Tars side, not the RLP
     // bridge. No RLP hash is injected for the same reason.
     header->setEthBlockVersion(EthBlockVersion::NON_ETH);
-    return nullptr;
-}
-
-bcos::Error::UniquePtr EthBlockHeader::toEthBlockHeader(
-    EthBlockHeader& ethHeader, bcos::bytesConstRef _data)
-{
-    auto err = ethHeader.rlpDecode(_data);
-    if (err)
-    {
-        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::RlpDecodeFailed),
-            "EthBlockHeader: rlpDecode failed: " + err->errorMessage());
-    }
     return nullptr;
 }
 
@@ -474,6 +474,19 @@ void EthBlockHeader::rlpEncode(bcos::bytes& out) const
     // the RLP surface carries seconds directly — no conversion here. The ms->s conversion
     // happens only at the EthBlockHeader<->BlockHeader boundary (constructor /1000,
     // toTarsHeader/decodeTarsHeader ×1000).
+    //
+    // Defense-in-depth: a negative number/timestamp would wrap into a huge u64 on the
+    // static_cast below, silently corrupting the RLP. calculateRLPHash guards via
+    // validateHeader, but rlpEncode is public — reject here so a direct caller cannot
+    // produce a wrong encoding.
+    if (m_data.number < 0)
+    {
+        BOOST_THROW_EXCEPTION(std::invalid_argument("number must be non-negative"));
+    }
+    if (m_data.timestamp < 0)
+    {
+        BOOST_THROW_EXCEPTION(std::invalid_argument("timestamp must be non-negative"));
+    }
     codec::rlp::encode(out, m_data.parentInfo.blockHash, m_data.uncleHash, m_data.coinbase,
         m_data.stateRoot, m_data.txsRoot, m_data.receiptsRoot,
         bcos::bytesConstRef(m_data.logsBloom.data(), m_data.logsBloom.size()), m_data.difficulty,

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -90,8 +90,7 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
-    // rlpDecode already converted the wire's seconds into internal milliseconds.
-    header->setTimestamp(ethHeader.timestampMs());
+    header->setTimestamp(ethHeader.data().timestamp * 1000);
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
     header->setExtraData(ethHeader.data().extraData);
@@ -419,8 +418,7 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     m_data.gasLimit = _header.gasLimit();
     m_data.gasUsed = _header.gasUsed();
     m_data.number = _header.number();
-    m_timestampMs = _header.timestamp();
-    m_data.timestamp = _header.timestamp() / 1000;  // internal ms -> wire seconds
+    m_data.timestamp = _header.timestamp() / 1000;
     m_data.prevRandao = _header.prevRandao();
     m_data.nonce = _header.nonce();
 

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -83,6 +83,11 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     if (ethHeader.data().timestamp >
         std::numeric_limits<int64_t>::max() / 1000)
     {
+        // Leave the destination in the same defined empty state as the validateHeader
+        // failure path below: the fields above are already written, so without a clear a
+        // caller that checks the error but reuses the header could observe a half-populated
+        // header from rejected hostile input.
+        header->clear();
         return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
             "EthBlockHeader: timestamp out of representable millisecond range");
     }
@@ -226,10 +231,11 @@ bool EthBlockHeader::validateHeader(
     {
         return invalid("EthBlockHeader: invalid timestamp");
     }
-    // Internal timestamps are milliseconds and must be whole seconds so rlpEncode's /1000 is
-    // lossless. Rejecting here keeps the calculateRLPHash path on its Error-return contract
-    // (and BlockHeaderImpl::calculateHash's clear-on-failure promise) for a wire-supplied
-    // sub-second value — rlpEncode's throw then only backstops validate-skipping callers.
+    // Internal timestamps are milliseconds and must be whole seconds so the ms->s
+    // conversion (constructor /1000) is lossless. Rejecting here keeps the calculateRLPHash
+    // path on its Error-return contract (and BlockHeaderImpl::calculateHash's
+    // clear-on-failure promise); the constructor throws the same condition for direct
+    // ctor+rlpEncode callers that skip validateHeader.
     if (_header.timestamp() % 1000 != 0)
     {
         return invalid("EthBlockHeader: timestamp must be a whole number of seconds");
@@ -329,8 +335,18 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     // constructing from an incomplete header never crashes (validation is the caller's job,
     // e.g. via calculateRLPHash -> validateHeader).
     // Timestamp domain model: EthBlockHeaderData carries SECONDS (the Ethereum RLP domain);
-    // the internal BlockHeader stores MILLISECONDS. Convert unconditionally at this bridge
-    // (ms /1000) for every version — no per-version branching.
+    // the internal BlockHeader stores MILLISECONDS. The ms->s conversion happens exactly
+    // here (constructor) and the inverse at the tar boundary (toTarsHeader ×1000).
+    //
+    // A sub-second millisecond value (e.g. 1001 ms) would silently floor to a whole second
+    // and corrupt the RLP hash input. rlpEncode no longer rejects it (only negatives), so
+    // reject it at this sole ms->s conversion point — validateHeader's %1000 gate covers
+    // the calculateRLPHash path, and this covers every direct ctor+rlpEncode caller.
+    if (_header.timestamp() % 1000 != 0)
+    {
+        BOOST_THROW_EXCEPTION(
+            std::invalid_argument("timestamp must be a whole number of seconds"));
+    }
     m_version = _header.ethBlockVersion();
     auto parent = _header.parentInfo();
     m_data.parentInfo.blockNumber = parent.blockNumber;

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.cpp
@@ -45,19 +45,6 @@ bcos::Error::UniquePtr EthBlockHeader::calculateRLPHash(bcos::protocol::BlockHea
     return nullptr;
 }
 
-// Precondition: the header's timestamp (internal milliseconds, every version) must be a
-// whole number of seconds (ms divisible by 1000). Sub-second timestamps produce an RLP
-// hash that cannot be reproduced from the decoded form. Throws std::invalid_argument on
-// violation.
-bcos::crypto::HashType EthBlockHeader::computeHash(
-    const bcos::protocol::BlockHeader& header) noexcept(false)
-{
-    EthBlockHeader ethHeader(header);
-    bcos::bytes encoded;
-    ethHeader.rlpEncode(encoded);
-    return bcos::crypto::keccak256Hash(bcos::ref(encoded));
-}
-
 bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data)
 {
@@ -90,6 +77,15 @@ bcos::Error::UniquePtr EthBlockHeader::toTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
+    // EthBlockHeaderData stores SECONDS; the internal BlockHeader stores MILLISECONDS.
+    // Bound by int64 before the ×1000 so a hostile wire value cannot trigger signed
+    // overflow on the conversion.
+    if (ethHeader.data().timestamp >
+        std::numeric_limits<int64_t>::max() / 1000)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
+            "EthBlockHeader: timestamp out of representable millisecond range");
+    }
     header->setTimestamp(ethHeader.data().timestamp * 1000);
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
@@ -157,28 +153,22 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
         return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeaderType),
             "EthBlockHeader: header is null");
     }
+
+    // Reset the destination first so reusing a header (previously holding higher-version
+    // optional fields) cannot leak stale values into this decode.
     header->clear();
 
     EthBlockHeader ethHeader;
+    // Call rlpDecode directly (not via toEthBlockHeader) so a timestamp-overflow
+    // InvalidHeader error surfaces with its original code instead of being re-wrapped
+    // as RlpDecodeFailed.
     if (auto err = ethHeader.rlpDecode(_data))
     {
         return err;
     }
 
-    // Like toTarsHeader's field writes but WITHOUT validateHeader — usable for FISCO-native/OP
-    // (NON_ETH) headers that validateHeader rejects. TWO DELIBERATE omissions from toTarsHeader:
-    //   1. ethBlockVersion is pinned to NON_ETH here instead of copying ethHeader.version()
-    //      (which after rlpDecode is derived from the optional-field cascade). Headers decoded
-    //      through this path are FISCO-native/OP, and downstream routing (e.g.
-    //      BlockHeaderImpl::calculateHash) keys off the version — write it explicitly instead
-    //      of relying on header->clear() leaving the tars field at its default 0 happening to
-    //      equal NON_ETH. The timestamp domain does NOT depend on this pin: internal is always
-    //      milliseconds, and rlpDecode/rlpEncode convert unconditionally for every version.
-    //   2. rlpHash is NOT set (toTarsHeader writes it via rlpEncode+keccak256). Callers
-    //      that need the block hash should call computeHash() or calculateRLPHash() explicitly —
-    //      computing it here would force a full re-encode for every decode, even when the caller
-    //      only needs field access.
-    header->setEthBlockVersion(bcos::protocol::EthBlockVersion::NON_ETH);
+    // Same field projection as toTarsHeader, but deliberately WITHOUT validateHeader:
+    // this path serves FISCO-native/OP (NON_ETH) headers that validateHeader rejects.
     header->setParentInfo(ethHeader.data().parentInfo);
     header->setCoinbase(ethHeader.data().coinbase);
     header->setUncleHash(ethHeader.data().uncleHash);
@@ -189,12 +179,21 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     header->setGasLimit(ethHeader.data().gasLimit);
     header->setGasUsed(ethHeader.data().gasUsed);
     header->setNumber(ethHeader.data().number);
-    header->setTimestamp(ethHeader.timestampMs());  // already ms (rlpDecode converted)
+    // EthBlockHeaderData stores SECONDS; the internal BlockHeader stores MILLISECONDS.
+    // Bound by int64 before the ×1000 so a hostile wire value cannot trigger signed
+    // overflow on the conversion.
+    if (ethHeader.data().timestamp > std::numeric_limits<int64_t>::max() / 1000)
+    {
+        return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
+            "EthBlockHeader: timestamp out of representable millisecond range");
+    }
+    header->setTimestamp(ethHeader.data().timestamp * 1000);
     header->setPrevRandao(ethHeader.data().prevRandao);
     header->setNonce(ethHeader.data().nonce);
     header->setExtraData(ethHeader.data().extraData);
     header->setLogsBloom(
         bcos::bytesConstRef(ethHeader.data().logsBloom.data(), ethHeader.data().logsBloom.size()));
+
     if (ethHeader.data().baseFee.has_value())
     {
         header->setBaseFee(*ethHeader.data().baseFee);
@@ -219,6 +218,11 @@ bcos::Error::UniquePtr EthBlockHeader::decodeTarsHeader(
     {
         header->setRequestsHash(*ethHeader.data().requestsHash);
     }
+
+    // Unlike toTarsHeader, the version is PINNED to NON_ETH (not copied): this decode path
+    // serves FISCO-native/OP headers, whose hashing stays on the Tars side, not the RLP
+    // bridge. No RLP hash is injected for the same reason.
+    header->setEthBlockVersion(EthBlockVersion::NON_ETH);
     return nullptr;
 }
 
@@ -405,11 +409,9 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     // Required fields — converted directly, with defensive defaults for empty fields so
     // constructing from an incomplete header never crashes (validation is the caller's job,
     // e.g. via calculateRLPHash -> validateHeader).
-    // ETH-version headers carry the timestamp in SECONDS in EthBlockHeaderData: the header
-    // (milliseconds) is divided by 1000. NON_ETH headers keep MILLISECONDS in
-    // EthBlockHeaderData — rlpEncode's /1000 then produces the seconds the RLP field carries,
-    // so the header timestamp is passed through unchanged. m_version must be set first since
-    // the conversion keys off it.
+    // Timestamp domain model: EthBlockHeaderData carries SECONDS (the Ethereum RLP domain);
+    // the internal BlockHeader stores MILLISECONDS. Convert unconditionally at this bridge
+    // (ms /1000) for every version — no per-version branching.
     m_version = _header.ethBlockVersion();
     auto parent = _header.parentInfo();
     m_data.parentInfo.blockNumber = parent.blockNumber;
@@ -424,8 +426,7 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
     m_data.gasLimit = _header.gasLimit();
     m_data.gasUsed = _header.gasUsed();
     m_data.number = _header.number();
-    m_data.timestamp = (m_version == EthBlockVersion::NON_ETH) ? _header.timestamp() :
-                                                                 _header.timestamp() / 1000;
+    m_data.timestamp = _header.timestamp() / 1000;
     m_data.prevRandao = _header.prevRandao();
     m_data.nonce = _header.nonce();
 
@@ -469,24 +470,17 @@ EthBlockHeader::EthBlockHeader(const bcos::protocol::BlockHeader& _header)
 
 void EthBlockHeader::rlpEncode(bcos::bytes& out) const
 {
-    // Timestamp domain model: internal (m_data mirrors the internal BlockHeader) is always
-    // milliseconds; the RLP surface always carries seconds. The EthBlockHeaderData codec
-    // works in wire seconds, so convert here before delegating — the field ORDER itself
-    // lives in exactly one place (the codec overloads below).
-    //
-    // Integer division is lossy for sub-second precision (1001 ms → 1 s). Every producer
-    // that reaches this bridge carries whole-second milliseconds by construction (the
-    // Engine API boundary, the eth-genesis path and rlpDecode all multiply seconds by
-    // 1000); sub-second input would produce an RLP hash not reproducible from the decoded
-    // form. Throw (not assert — assert is compiled out under NDEBUG).
-    if (m_timestampMs % 1000 != 0)
-    {
-        BOOST_THROW_EXCEPTION(std::invalid_argument(
-            "timestamp must be a whole number of seconds (ms divisible by 1000)"));
-    }
-    // m_data.timestamp is already wire seconds (the codec's domain); the internal
-    // millisecond value lives in m_timestampMs. Encode directly — no copy, no conversion.
-    codec::rlp::encode(out, m_data);
+    // Timestamp domain model: EthBlockHeaderData stores SECONDS (the Ethereum RLP domain);
+    // the RLP surface carries seconds directly — no conversion here. The ms->s conversion
+    // happens only at the EthBlockHeader<->BlockHeader boundary (constructor /1000,
+    // toTarsHeader/decodeTarsHeader ×1000).
+    codec::rlp::encode(out, m_data.parentInfo.blockHash, m_data.uncleHash, m_data.coinbase,
+        m_data.stateRoot, m_data.txsRoot, m_data.receiptsRoot,
+        bcos::bytesConstRef(m_data.logsBloom.data(), m_data.logsBloom.size()), m_data.difficulty,
+        static_cast<uint64_t>(m_data.number), m_data.gasLimit, m_data.gasUsed,
+        static_cast<uint64_t>(m_data.timestamp), m_data.extraData, m_data.prevRandao, m_data.nonce,
+        m_data.baseFee, m_data.withdrawalsHash, m_data.blobGasUsed, m_data.excessBlobGas,
+        m_data.parentBeaconRoot, m_data.requestsHash);
 }
 
 bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
@@ -507,17 +501,19 @@ bcos::Error::UniquePtr EthBlockHeader::rlpDecode(bcos::bytesConstRef data)
         return error;
     }
 
-    // The wire timestamp is seconds; the internal domain (m_timestampMs) is milliseconds
-    // — convert unconditionally, bounded by int64 first so a hostile wire value cannot
-    // trigger signed overflow on the ×1000.
-    constexpr auto c_maxWireTimestampSeconds =
-        static_cast<uint64_t>(std::numeric_limits<int64_t>::max() / 1000);
-    if (static_cast<uint64_t>(m_data.timestamp) > c_maxWireTimestampSeconds)
+    m_data.number = static_cast<int64_t>(_number);
+
+    // The wire timestamp is seconds; the internal EthBlockHeaderData domain is also seconds
+    // for every version — no conversion here. Bound by int64 so a hostile wire value cannot
+    // wrap on the cast. The seconds->milliseconds conversion (×1000) happens only at the
+    // EthBlockHeader->BlockHeader boundary (toTarsHeader / decodeTarsHeader), where an
+    // overflow check guards the multiplication.
+    if (_timestamp > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
     {
         return BCOS_ERROR_UNIQUE_PTR(static_cast<int32_t>(EthBlockHeaderError::InvalidHeader),
-            "EthBlockHeader: timestamp out of representable millisecond range");
+            "EthBlockHeader: timestamp out of representable range");
     }
-    m_timestampMs = m_data.timestamp * 1000;
+    m_data.timestamp = static_cast<int64_t>(_timestamp);
 
     // Optional fork fields are decoded positionally, so the set of present optionals is
     // always a contiguous prefix — a later field can only be present if the view was still

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
@@ -128,13 +128,8 @@ public:
 
     const EthBlockHeaderData& data() const { return m_data; }
 
-    // Internal-domain (milliseconds) timestamp, mirroring the base BlockHeader. The
-    // EthBlockHeaderData::timestamp member above is always wire seconds.
-    int64_t timestampMs() const { return m_timestampMs; }
-
 private:
     EthBlockHeaderData m_data;
-    int64_t m_timestampMs{0};
     EthBlockVersion m_version{EthBlockVersion::NON_ETH};
 };
 
@@ -144,8 +139,7 @@ namespace bcos::codec::rlp
 {
 // Codec overloads for the pure-data header struct, so EthBlockHeaderData can be embedded in
 // larger Ethereum structures (block bodies, uncle lists, ...) with the same canonical field
-// order as EthBlockHeader::rlpEncode/rlpDecode. EthBlockHeader::rlpEncode/rlpDecode delegate
-// here, so the field order lives in exactly one place.
+// order as EthBlockHeader::rlpEncode/rlpDecode.
 size_t length(const protocol::EthBlockHeaderData& _headerData) noexcept;
 void encode(bcos::bytes& _out, const protocol::EthBlockHeaderData& _headerData) noexcept;
 bcos::Error::UniquePtr decode(

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
@@ -54,10 +54,9 @@ struct EthBlockHeaderData
     bcos::Address coinbase;
     bcos::h64 nonce;
     int64_t number{0};
-    // WIRE SECONDS, unconditionally — the same unit in every owner (the EthBlockHeaderData
-    // codec, EthBlock, ommers, and EthBlockHeader::data()). The internal BlockHeader's
-    // millisecond timestamp lives in EthBlockHeader::m_timestampMs and is converted to/from
-    // this field only at the rlpEncode/rlpDecode bridge (rlpEncode /1000, rlpDecode ×1000).
+    // Always SECONDS — mirrors the Ethereum RLP domain for every version. The internal
+    // BlockHeader (BlockHeaderImpl/tars) stores MILLISECONDS; the bridge converts only at
+    // the EthBlockHeader<->BlockHeader boundary (constructor /1000, toTarsHeader ×1000).
     int64_t timestamp{0};
 
     // Optional fields (16–23)
@@ -121,26 +120,18 @@ public:
     //    base-class header via setRLPHash.
     static bcos::Error::UniquePtr toTarsHeader(
         bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data);
+    /// Decode an RLP header into the caller-provided EthBlockHeader (no header projection;
+    /// EthBlockHeaderData keeps the RLP domain — timestamp in seconds).
+    static bcos::Error::UniquePtr toEthBlockHeader(
+        EthBlockHeader& ethHeader, bcos::bytesConstRef _data);
     /// Like toTarsHeader but WITHOUT validateHeader — usable for FISCO-native/OP (NON_ETH)
     /// headers that validateHeader rejects. Unlike toTarsHeader, ethBlockVersion is PINNED to
     /// NON_ETH (not copied). The produced header's timestamp is MILLISECONDS like every other
-    /// internal header (the RLP surface's seconds are converted by rlpDecode, unconditionally
-    /// for every version).
+    /// internal header (EthBlockHeaderData stores seconds; the ×1000 conversion to the
+    /// internal BlockHeader domain happens here, unconditionally for every version).
     static bcos::Error::UniquePtr decodeTarsHeader(
         bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data);
-    static bcos::Error::UniquePtr toEthBlockHeader(
-        EthBlockHeader& ethHeader, bcos::bytesConstRef _data);
     static bcos::Error::UniquePtr calculateRLPHash(bcos::protocol::BlockHeader& header);
-    /// Compute keccak256(rlp(header)) WITHOUT validation or state mutation — usable for
-    /// FISCO-native/OP headers (EthBlockVersion::NON_ETH) that calculateRLPHash's
-    /// validateHeader rejects. Returns the 32-byte Ethereum block hash.
-    /// The header's timestamp is internal milliseconds (every version); the RLP surface
-    /// carries seconds, converted at the rlpEncode/rlpDecode bridge — rlpEncode throws
-    /// std::invalid_argument if the internal timestamp is not a whole number of seconds.
-    /// Callers that cannot tolerate exceptions should use calculateRLPHash (which returns
-    /// Error::UniquePtr) instead.
-    static bcos::crypto::HashType computeHash(const bcos::protocol::BlockHeader& header) noexcept(
-        false);
 
     const EthBlockHeaderData& data() const { return m_data; }
 

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
@@ -124,13 +124,6 @@ public:
     /// EthBlockHeaderData keeps the RLP domain — timestamp in seconds).
     static bcos::Error::UniquePtr toEthBlockHeader(
         EthBlockHeader& ethHeader, bcos::bytesConstRef _data);
-    /// Like toTarsHeader but WITHOUT validateHeader — usable for FISCO-native/OP (NON_ETH)
-    /// headers that validateHeader rejects. Unlike toTarsHeader, ethBlockVersion is PINNED to
-    /// NON_ETH (not copied). The produced header's timestamp is MILLISECONDS like every other
-    /// internal header (EthBlockHeaderData stores seconds; the ×1000 conversion to the
-    /// internal BlockHeader domain happens here, unconditionally for every version).
-    static bcos::Error::UniquePtr decodeTarsHeader(
-        bcos::protocol::BlockHeader::Ptr header, bcos::bytesConstRef _data);
     static bcos::Error::UniquePtr calculateRLPHash(bcos::protocol::BlockHeader& header);
 
     const EthBlockHeaderData& data() const { return m_data; }

--- a/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
+++ b/bcos-rlp-protocol/bcos-rlp-protocol/EthBlockHeader.h
@@ -125,6 +125,16 @@ public:
     static bcos::Error::UniquePtr toEthBlockHeader(
         EthBlockHeader& ethHeader, bcos::bytesConstRef _data);
     static bcos::Error::UniquePtr calculateRLPHash(bcos::protocol::BlockHeader& header);
+    /// Compute keccak256(rlp(header)) WITHOUT validation or state mutation — usable for
+    /// FISCO-native/OP headers (EthBlockVersion::NON_ETH) that calculateRLPHash's
+    /// validateHeader rejects. Returns the 32-byte Ethereum block hash.
+    /// The header's timestamp is internal milliseconds (every version); the RLP surface
+    /// carries seconds, converted at the bridge — the EthBlockHeader(BlockHeader) ctor
+    /// divides by 1000 and throws std::invalid_argument on a sub-second value, so a
+    /// non-whole-second timestamp fails loudly here. Callers that cannot tolerate
+    /// exceptions should use calculateRLPHash (which returns Error::UniquePtr) instead.
+    static bcos::crypto::HashType computeHash(const bcos::protocol::BlockHeader& header) noexcept(
+        false);
 
     const EthBlockHeaderData& data() const { return m_data; }
 

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -695,36 +695,5 @@ BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
     BOOST_CHECK_THROW(header->hash(), std::exception);
 }
 
-// decodeTarsHeader pins ethBlockVersion to NON_ETH explicitly instead of relying on the tars
-// default 0 happening to equal it. The pin holds even when the destination header carried a
-// real ETH version before the decode. EthBlockHeaderData carries SECONDS (the RLP domain);
-// decodeTarsHeader converts to the internal BlockHeader milliseconds (×1000), so the decoded
-// header's timestamp equals the ms source's and the seconds↔ms round-trip reproduces the
-// input RLP byte-for-byte regardless of the pinned version.
-BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
-{
-    auto source = makeEthHeader(EthBlockVersion::PRAGUE);
-    EthBlockHeader sourceBridge(*source);
-    bytes rlp;
-    sourceBridge.rlpEncode(rlp);
-
-    auto decoded = makeEthHeader(EthBlockVersion::PRAGUE);  // nonzero version pre-decode
-    bcos::Error::UniquePtr error;
-    error = EthBlockHeader::decodeTarsHeader(decoded, bcos::ref(rlp));
-    BOOST_CHECK(!error);
-    BOOST_CHECK(decoded->ethBlockVersion() == EthBlockVersion::NON_ETH);
-    // decodeTarsHeader writes the RLP seconds ×1000 into the header (milliseconds); source's
-    // header timestamp is already milliseconds, so the two must be equal — NOT ×1000 again.
-    BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp());
-
-    // Re-encoding the decoded header must reproduce the input RLP: ×1000 on the
-    // EthBlockHeader->BlockHeader boundary, /1000 on the BlockHeader->EthBlockHeader
-    // boundary — the unconditional inverse pair of the bridge.
-    EthBlockHeader roundTrip(*decoded);
-    bytes reencoded;
-    roundTrip.rlpEncode(reencoded);
-    BOOST_CHECK(reencoded == rlp);
-}
-
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -670,5 +670,32 @@ BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
     BOOST_CHECK_THROW(header->hash(), std::exception);
 }
 
+// A wire header whose seconds timestamp would overflow int64 milliseconds must be rejected
+// by toTarsHeader's ×1000 conversion (seconds fit int64 but seconds*1000 does not). The
+// destination header must be cleared on this failure so a reused header cannot retain a
+// half-populated state.
+BOOST_AUTO_TEST_CASE(toTarsHeaderRejectsOverflowingTimestamp)
+{
+    auto header = makeEthHeader();
+    EthBlockHeader ethHeader(*header);
+    auto const& d = ethHeader.data();
+    // INT64_MAX seconds: fits int64 but ×1000 overflows the millisecond domain.
+    constexpr uint64_t hostileTimestamp = 0x7FFFFFFFFFFFFFFFULL;
+
+    bytes rlp;
+    codec::rlp::encode(rlp, d.parentInfo.blockHash, d.uncleHash, d.coinbase, d.stateRoot, d.txsRoot,
+        d.receiptsRoot, bcos::bytesConstRef(d.logsBloom.data(), d.logsBloom.size()), d.difficulty,
+        static_cast<uint64_t>(d.number), d.gasLimit, d.gasUsed, hostileTimestamp, d.extraData,
+        d.prevRandao, d.nonce, d.baseFee, d.withdrawalsHash, d.blobGasUsed, d.excessBlobGas,
+        d.parentBeaconRoot, d.requestsHash);
+
+    auto decodedHeader = makeEthHeader();
+    auto error = EthBlockHeader::toTarsHeader(decodedHeader, bcos::ref(rlp));
+    BOOST_REQUIRE(error != nullptr);
+    BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
+    // The destination must be empty on failure, matching the validateHeader error path.
+    BOOST_CHECK_EQUAL(decodedHeader->number(), 0);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 }  // namespace bcos::test

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -272,6 +272,25 @@ BOOST_AUTO_TEST_CASE(incompleteHeaderReportsError)
     BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
 }
 
+// calculateRLPHash rejects a NON_ETH header outright — that is exactly what computeHash
+// exists for (computeHash skips validateHeader so FISCO-native/OP headers can be hashed).
+// Pin the rejection so the two entry points stay distinct.
+BOOST_AUTO_TEST_CASE(calculateRLPHashRejectsNonEthHeader)
+{
+    auto header = makeEthHeader();
+    header->setEthBlockVersion(EthBlockVersion::NON_ETH);
+
+    bcos::Error::UniquePtr error;
+    error = bcos::protocol::EthBlockHeader::calculateRLPHash(*header);
+    BOOST_REQUIRE(error != nullptr);
+    BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
+    BOOST_CHECK_NE(std::string(error->errorMessage()).find("not an Ethereum header"),
+        std::string::npos);
+    // computeHash, by contrast, hashes without validation.
+    BOOST_CHECK_NO_THROW(
+        bcos::protocol::EthBlockHeader::computeHash(*header));
+}
+
 // A truncated RLP header (fields stop mid-cascade) must decode cleanly instead of throwing
 // on an empty optional.
 BOOST_AUTO_TEST_CASE(decodeTruncatedCascadeNoCrash)
@@ -695,6 +714,24 @@ BOOST_AUTO_TEST_CASE(toTarsHeaderRejectsOverflowingTimestamp)
     BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
     // The destination must be empty on failure, matching the validateHeader error path.
     BOOST_CHECK_EQUAL(decodedHeader->number(), 0);
+}
+
+// The constructor's sub-second guard is the sole protection for direct ctor+rlpEncode
+// callers (EthBlockHeader::computeHash — the OP scheduler's block-identity hash — is one):
+// rlpEncode rejects negatives only, so a non-whole-second millisecond timestamp would
+// silently floor and corrupt the hash input. Pin the throw.
+BOOST_AUTO_TEST_CASE(constructorRejectsSubSecondTimestamp)
+{
+    auto header = makeEthHeader();
+    header->setTimestamp(1001);  // 1s + 1ms
+
+    BOOST_CHECK_THROW(EthBlockHeader ethHeader(*header), std::invalid_argument);
+    // validateHeader reports the same condition through its Error-return contract.
+    bcos::Error::UniquePtr error;
+    BOOST_CHECK(!EthBlockHeader::validateHeader(*header, error));
+    BOOST_REQUIRE(error != nullptr);
+    BOOST_CHECK_NE(std::string(error->errorMessage()).find("whole number of seconds"),
+        std::string::npos);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -95,9 +95,9 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     // header -> Eth
     EthBlockHeader ethHeader(*header);
     BOOST_CHECK_EQUAL(ethHeader.data().number, 77);
-    // The codec struct is wire seconds; the internal millisecond domain lives in timestampMs().
-    BOOST_CHECK_EQUAL(ethHeader.data().timestamp, 1700000000);
-    BOOST_CHECK_EQUAL(ethHeader.timestampMs(), 1700000000000LL);
+    // The bridge struct mirrors the Ethereum RLP domain (seconds); the internal BlockHeader
+    // milliseconds are converted at construction (ms -> s).
+    BOOST_CHECK_EQUAL(ethHeader.data().timestamp, 1700000000LL);
     BOOST_CHECK_EQUAL(ethHeader.data().gasLimit, u256(30000000));
     BOOST_CHECK_EQUAL(ethHeader.data().gasUsed, u256(21000));
     BOOST_CHECK_EQUAL(ethHeader.data().uncleHash,
@@ -118,9 +118,8 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     ethError = EthBlockHeader::toEthBlockHeader(decodedEth, bcos::ref(rlp));
     BOOST_CHECK(!ethError);
     BOOST_CHECK_EQUAL(decodedEth.data().number, 77);
-    // rlpDecode converts the wire's seconds back into internal milliseconds.
-    BOOST_CHECK_EQUAL(decodedEth.data().timestamp, 1700000000);
-    BOOST_CHECK_EQUAL(decodedEth.timestampMs(), 1700000000000LL);
+    // rlpDecode keeps the wire's seconds directly in EthBlockHeaderData (no ms conversion).
+    BOOST_CHECK_EQUAL(decodedEth.data().timestamp, 1700000000LL);
     BOOST_CHECK_EQUAL(decodedEth.data().gasLimit, u256(30000000));
     BOOST_CHECK_EQUAL(decodedEth.data().gasUsed, u256(21000));
     BOOST_CHECK(decodedEth.data().baseFee.has_value());
@@ -658,9 +657,8 @@ BOOST_AUTO_TEST_CASE(toTarsHeaderClearsResidual)
 }
 
 // A wire header whose seconds timestamp would overflow int64 milliseconds must be rejected
-// by the decode bridge (rlpDecode) before its x1000 conversion, surfacing through
-// decodeTarsHeader as an error (regression for the seconds->ms bridge). INT64_MAX seconds
-// passes the codec's int64 width gate (round-6) but has no int64 millisecond representation.
+// by the decode path — rlpDecode rejects a seconds value that cannot fit int64 (2^63), so
+// decodeTarsHeader surfaces the InvalidHeader error before its ×1000 ms conversion.
 BOOST_AUTO_TEST_CASE(decodeTarsHeaderRejectsOverflowingTimestamp)
 {
     // Re-encode a valid header's fields with a hostile timestamp: INT64_MAX encodes fine as a
@@ -699,10 +697,10 @@ BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)
 
 // decodeTarsHeader pins ethBlockVersion to NON_ETH explicitly instead of relying on the tars
 // default 0 happening to equal it. The pin holds even when the destination header carried a
-// real ETH version before the decode. Internal timestamps are milliseconds for every version
-// (the RLP surface is seconds, converted unconditionally by rlpDecode/rlpEncode), so the
-// decoded header's timestamp equals the ms source's and the seconds↔ms round-trip reproduces
-// the input RLP byte-for-byte regardless of the pinned version.
+// real ETH version before the decode. EthBlockHeaderData carries SECONDS (the RLP domain);
+// decodeTarsHeader converts to the internal BlockHeader milliseconds (×1000), so the decoded
+// header's timestamp equals the ms source's and the seconds↔ms round-trip reproduces the
+// input RLP byte-for-byte regardless of the pinned version.
 BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
 {
     auto source = makeEthHeader(EthBlockVersion::PRAGUE);
@@ -719,8 +717,9 @@ BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
     // header timestamp is already milliseconds, so the two must be equal — NOT ×1000 again.
     BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp());
 
-    // Re-encoding the decoded header must reproduce the input RLP: ×1000 on decode, /1000 on
-    // encode — the unconditional inverse pair at the RLP bridge.
+    // Re-encoding the decoded header must reproduce the input RLP: ×1000 on the
+    // EthBlockHeader->BlockHeader boundary, /1000 on the BlockHeader->EthBlockHeader
+    // boundary — the unconditional inverse pair of the bridge.
     EthBlockHeader roundTrip(*decoded);
     bytes reencoded;
     roundTrip.rlpEncode(reencoded);

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -656,31 +656,6 @@ BOOST_AUTO_TEST_CASE(toTarsHeaderClearsResidual)
     BOOST_CHECK(reused->ethBlockVersion() == EthBlockVersion::PRE_LONDON);
 }
 
-// A wire header whose seconds timestamp would overflow int64 milliseconds must be rejected
-// by the decode path — rlpDecode rejects a seconds value that cannot fit int64 (2^63), so
-// decodeTarsHeader surfaces the InvalidHeader error before its ×1000 ms conversion.
-BOOST_AUTO_TEST_CASE(decodeTarsHeaderRejectsOverflowingTimestamp)
-{
-    // Re-encode a valid header's fields with a hostile timestamp: INT64_MAX encodes fine as a
-    // uint64 RLP scalar but ×1000 has no int64 millisecond representation.
-    auto header = makeEthHeader();
-    EthBlockHeader ethHeader(*header);
-    auto const& d = ethHeader.data();
-    constexpr uint64_t hostileTimestamp = 0x7FFFFFFFFFFFFFFFULL;
-
-    bytes rlp;
-    codec::rlp::encode(rlp, d.parentInfo.blockHash, d.uncleHash, d.coinbase, d.stateRoot, d.txsRoot,
-        d.receiptsRoot, bcos::bytesConstRef(d.logsBloom.data(), d.logsBloom.size()), d.difficulty,
-        static_cast<uint64_t>(d.number), d.gasLimit, d.gasUsed, hostileTimestamp, d.extraData,
-        d.prevRandao, d.nonce, d.baseFee, d.withdrawalsHash, d.blobGasUsed, d.excessBlobGas,
-        d.parentBeaconRoot, d.requestsHash);
-
-    auto decodedHeader = makeEthHeader();
-    auto error = EthBlockHeader::decodeTarsHeader(decodedHeader, bcos::ref(rlp));
-    BOOST_REQUIRE(error != nullptr);
-    BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
-}
-
 // An invalid Eth header: calculateHash clears dataHash, so hash() must throw
 // EmptyBlockHeaderHash (regression for the FIB-130 clear-on-failure behaviour).
 BOOST_AUTO_TEST_CASE(calculateHashClearsOnInvalid)

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -270,6 +270,10 @@ BOOST_AUTO_TEST_CASE(incompleteHeaderReportsError)
     error = bcos::protocol::EthBlockHeader::calculateRLPHash(*header);
     BOOST_CHECK(error != nullptr);
     BOOST_CHECK_EQUAL(error->errorCode(), static_cast<int32_t>(EthBlockHeaderError::InvalidHeader));
+    // Pin the distinguishing message, not just the error type: a swapped gate that keeps
+    // InvalidHeader must still fail (T3).
+    BOOST_CHECK_NE(std::string(error->errorMessage()).find("missing or bad stateRoot"),
+        std::string::npos);
 }
 
 // calculateRLPHash rejects a NON_ETH header outright — that is exactly what computeHash

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -41,7 +41,9 @@ static bcos::protocol::BlockHeader::Ptr makeEthHeader(
     auto tars = std::make_shared<bcostars::BlockHeader>();
     auto& data = tars->data;
     data.blockNumber = 77;
-    data.timestamp = 1700000000000LL;  // internal domain: milliseconds (whole seconds)
+    // BlockHeader stores the timestamp in MILLISECONDS; EthBlockHeaderData (the RLP
+    // domain) stores seconds. The bridge converts at construction (ms -> s).
+    data.timestamp = 1700000000 * 1000LL;
     data.gasLimit = "30000000";
     data.gasUsed = "21000";
     data.coinbase.assign(20, static_cast<char>(0xab));
@@ -140,12 +142,13 @@ BOOST_AUTO_TEST_CASE(rlpEncodeDecodeRoundTrip)
     decodedEth.rlpEncode(rlpReencoded);
     BOOST_CHECK(rlp == rlpReencoded);
 
-    // Static: decode RLP into a caller-provided base-class header
+    // Static: decode RLP into a caller-provided base-class header. The RLP carries seconds,
+    // the bridge converts to BlockHeader milliseconds.
     auto decodedHeader = makeEthHeader();
     ethError = EthBlockHeader::toTarsHeader(decodedHeader, bcos::ref(rlp));
     BOOST_CHECK(!ethError);
     BOOST_CHECK_EQUAL(decodedHeader->number(), 77);
-    BOOST_CHECK_EQUAL(decodedHeader->timestamp(), 1700000000000LL);
+    BOOST_CHECK_EQUAL(decodedHeader->timestamp(), 1700000000 * 1000LL);
     BOOST_CHECK_EQUAL(decodedHeader->gasLimit(), u256(30000000));
     BOOST_CHECK_EQUAL(decodedHeader->gasUsed(), u256(21000));
     // The converted header must be marked as an Eth header
@@ -438,9 +441,9 @@ BOOST_AUTO_TEST_CASE(goldenMainnetCancunHeader)
     BOOST_REQUIRE(impl != nullptr);
     auto& data = impl->inner().data;
     data.blockNumber = 19800000;
-    // On-chain seconds 1714865051, stored in the internal millisecond domain; the RLP
-    // bridge divides back to seconds, so the golden hash/bytes below stay byte-identical.
-    data.timestamp = 1714865051000LL;
+    // BlockHeader milliseconds; the bridge converts to seconds for the RLP encoding, which
+    // must reproduce the on-chain 1714865051 second timestamp.
+    data.timestamp = 1714865051 * 1000LL;
     data.gasLimit = "30000000";
     data.gasUsed = "8020412";
     data.baseFee = "5007423601";

--- a/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
+++ b/bcos-rlp-protocol/test/unittests/EthBlockHeaderTest.cpp
@@ -715,6 +715,8 @@ BOOST_AUTO_TEST_CASE(decodeTarsHeaderPinsNonEthVersion)
     error = EthBlockHeader::decodeTarsHeader(decoded, bcos::ref(rlp));
     BOOST_CHECK(!error);
     BOOST_CHECK(decoded->ethBlockVersion() == EthBlockVersion::NON_ETH);
+    // decodeTarsHeader writes the RLP seconds ×1000 into the header (milliseconds); source's
+    // header timestamp is already milliseconds, so the two must be equal — NOT ×1000 again.
     BOOST_CHECK_EQUAL(decoded->timestamp(), source->timestamp());
 
     // Re-encoding the decoded header must reproduce the input RLP: ×1000 on decode, /1000 on

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -147,15 +147,17 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
         engineResult = co_await engineService->updateForkchoice(forkchoiceState,
             payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
     }
-    catch (engine::UnsupportedFork const&)
+    catch (engine::UnsupportedFork const& e)
     {
-        // The request's attribute shape cannot express the chain's fork era (e.g. a V2
-        // forkchoiceUpdated on a CANCUN+ chain). geth answers -38005 Unsupported fork for
-        // the same CL/chain mismatch; the service layer throws UnsupportedFork so this
-        // stays a diagnosable fork error instead of a generic -32603 InternalError.
+        // The request's attribute shape cannot express the chain's fork era, or the chain
+        // lacks an on-chain EVM revision entirely. geth answers -38005 Unsupported fork
+        // for the same CL/chain mismatch; the service layer throws UnsupportedFork so this
+        // stays a diagnosable fork error instead of a generic -32603 InternalError. Keep
+        // the exception's errinfo_comment so the operator can tell which gate fired — the
+        // missing-revision case is a NODE-side misconfiguration and the generic shape
+        // message would wrongly point at the CL.
         BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnsupportedFork,
-            "Unsupported fork: the requested attribute shape does not match the chain's "
-            "EVM revision"));
+            std::string("Unsupported fork: ") + e.what()));
     }
     auto jsonResult = combineForkchoiceUpdatedResult(engineResult, version);
     buildJsonContent(jsonResult, response);

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -141,8 +141,22 @@ task::Task<void> EngineEndpoint::handleForkchoiceUpdated(
     //   not in chain -38003 InvalidPayloadAttributes: payloadAttributes.timestamp <=
     //   headBlockHash.timestamp -38005 UnsupportedFork: timestamp out of fork window (V2/V3
     //   specific) -38006 TooDeepReorg: reorg depth exceeds limitation
-    auto engineResult = co_await engineService->updateForkchoice(forkchoiceState,
-        payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
+    engine::ForkchoiceUpdatedResult engineResult;
+    try
+    {
+        engineResult = co_await engineService->updateForkchoice(forkchoiceState,
+            payloadAttrs.has_value() ? &*payloadAttrs : nullptr, static_cast<uint32_t>(version));
+    }
+    catch (engine::UnsupportedFork const&)
+    {
+        // The request's attribute shape cannot express the chain's fork era (e.g. a V2
+        // forkchoiceUpdated on a CANCUN+ chain). geth answers -38005 Unsupported fork for
+        // the same CL/chain mismatch; the service layer throws UnsupportedFork so this
+        // stays a diagnosable fork error instead of a generic -32603 InternalError.
+        BOOST_THROW_EXCEPTION(JsonRpcException(EngineError::UnsupportedFork,
+            "Unsupported fork: the requested attribute shape does not match the chain's "
+            "EVM revision"));
+    }
     auto jsonResult = combineForkchoiceUpdatedResult(engineResult, version);
     buildJsonContent(jsonResult, response);
 }

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/endpoints/EngineEndpoint.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "EngineEndpoint.h"
+#include <bcos-framework/engine/Errors.h>
 #include <bcos-rpc/jsonrpc/Common.h>
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <bcos-rpc/web3jsonrpc/utils/EngineHelper.h>

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -2,6 +2,7 @@
 #include "Log.h"
 
 #include <bcos-framework/protocol/Protocol.h>
+#include <bcos-ledger/mpt/Constants.h>
 #include <bcos-utilities/Bloom.h>
 
 #include <range/v3/view/enumerate.hpp>
@@ -17,6 +18,11 @@ void bcos::rpc::combineBlockResponse(
 
     result["number"] = toQuantity(blockNumber);
     result["hash"] = blockHash.hexPrefixed();
+    // Genesis headers never carry parentInfo: BlockHeaderImpl::parentInfo() returns the
+    // zero hash for an empty list, so reading it verbatim reproduces the historical
+    // forced-zero behavior. This relies on every genesis build path leaving parentInfo
+    // unset (Ledger.cpp documents this invariant); a future artifact that carries a
+    // non-zero parent would surface here as a changed RPC value.
     result["parentHash"] = blockHeader->parentInfo().blockHash.hexPrefixed();
 
     if (isEth)
@@ -105,10 +111,13 @@ void bcos::rpc::combineBlockResponse(
         // header (only its trie root is); emit the always-empty list so Shanghai-shaped
         // clients keep working, and the root verbatim from the header.
         result["withdrawals"] = Json::Value(Json::arrayValue);
-        if (auto root = blockHeader->withdrawalsRoot())
-        {
-            result["withdrawalsRoot"] = root->hexPrefixed();
-        }
+        // geth emits withdrawalsRoot unconditionally for Shanghai+ blocks. The engine
+        // build path always sets it (finalizeEthBlockHeader uses the empty-trie root), so
+        // the absent case only arises for non-engine producers — emit the canonical
+        // empty-trie root to keep the response shape unconditional for the fork.
+        result["withdrawalsRoot"] =
+            blockHeader->withdrawalsRoot().value_or(bcos::ledger::mpt::emptyRootHash())
+                .hexPrefixed();
     }
     if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
     {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -77,9 +77,8 @@ void bcos::rpc::combineBlockResponse(
     result["size"] = toQuantity(block.size());
     result["gasLimit"] = toQuantity(blockHeader->gasLimit());
     result["gasUsed"] = toQuantity(static_cast<uint64_t>(blockHeader->gasUsed()));
-    // Eth headers carry the timestamp in seconds already; FISCO headers in milliseconds.
-    result["timestamp"] = toQuantity(
-        isEth ? blockHeader->timestamp() : blockHeader->timestamp() / 1000);
+    // BlockHeader stores the timestamp in milliseconds; the eth_* RPC emits seconds.
+    result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);
 
     // Fork-gated Ethereum fields: only defined for the fork that introduced them.
     auto versionAtLeast = [&](bcos::protocol::EthBlockVersion fork) {

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -21,7 +21,8 @@ void bcos::rpc::combineBlockResponse(
 
     if (isEth)
     {
-        // Ethereum header: every field is taken verbatim from the header.
+        // Ethereum header: header-carried fields are taken from the header. The block-body
+        // fields (withdrawals list, totalDifficulty) remain placeholders below.
         result["nonce"] = blockHeader->nonce().hexPrefixed();
         result["sha3Uncles"] = blockHeader->uncleHash().hexPrefixed();
         // EIP-55 checksummed address, matching geth's eth_getBlock* output.

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -24,7 +24,11 @@ void bcos::rpc::combineBlockResponse(
         // Ethereum header: every field is taken verbatim from the header.
         result["nonce"] = blockHeader->nonce().hexPrefixed();
         result["sha3Uncles"] = blockHeader->uncleHash().hexPrefixed();
-        result["miner"] = blockHeader->coinbase().hexPrefixed();
+        // EIP-55 checksummed address, matching geth's eth_getBlock* output.
+        auto minerAddr = blockHeader->coinbase().hex();
+        auto minerAddrHash = crypto::keccak256Hash(bytesConstRef(minerAddr)).hex();
+        toChecksumAddress(minerAddr, minerAddrHash);
+        result["miner"] = "0x" + minerAddr;
         result["difficulty"] = toQuantity(blockHeader->difficulty());
         result["mixHash"] = blockHeader->prevRandao().hexPrefixed();
     }
@@ -75,20 +79,26 @@ void bcos::rpc::combineBlockResponse(
     result["totalDifficulty"] = "0x0";
     result["extraData"] = toHexStringWithPrefix(blockHeader->extraData());
     result["size"] = toQuantity(block.size());
-    result["gasLimit"] = toQuantity(blockHeader->gasLimit());
+    // Native FISCO-BCOS blocks never call setGasLimit, so the header field reads back as 0;
+    // keep the historical fixed value for NON_ETH blocks (the Ethereum-compatible gas limit),
+    // and the real header value for Eth blocks (where buildPayload always sets it).
+    result["gasLimit"] = toQuantity(
+        isEth ? blockHeader->gasLimit() : bcos::u256(30000000));
     result["gasUsed"] = toQuantity(static_cast<uint64_t>(blockHeader->gasUsed()));
     // BlockHeader stores the timestamp in milliseconds; the eth_* RPC emits seconds.
     result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);
 
-    // Fork-gated Ethereum fields: only defined for the fork that introduced them.
+    // Fork-gated Ethereum fields: only defined for the fork that introduced them. Eth blocks
+    // read the values from the header; native NON_ETH blocks keep the historical fixed mock
+    // values so their RPC shape is unchanged.
     auto versionAtLeast = [&](bcos::protocol::EthBlockVersion fork) {
-        return isEth && static_cast<uint8_t>(ethVersion) >= static_cast<uint8_t>(fork);
+        return static_cast<uint8_t>(ethVersion) >= static_cast<uint8_t>(fork);
     };
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::LONDON))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::LONDON))
     {
         result["baseFeePerGas"] = toQuantity(blockHeader->baseFee().value_or(bcos::u256(0)));
     }
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::SHANGHAI))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::SHANGHAI))
     {
         // The withdrawals operation list is a block-body field and is not persisted in the
         // header (only its trie root is); emit the always-empty list so Shanghai-shaped
@@ -99,7 +109,7 @@ void bcos::rpc::combineBlockResponse(
             result["withdrawalsRoot"] = root->hexPrefixed();
         }
     }
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
     {
         if (auto blobGasUsed = blockHeader->blobGasUsed())
         {
@@ -114,12 +124,23 @@ void bcos::rpc::combineBlockResponse(
             result["parentBeaconBlockRoot"] = beaconRoot->hexPrefixed();
         }
     }
-    if (versionAtLeast(bcos::protocol::EthBlockVersion::PRAGUE))
+    if (isEth && versionAtLeast(bcos::protocol::EthBlockVersion::PRAGUE))
     {
         if (auto requestsHash = blockHeader->requestsHash())
         {
             result["requestsHash"] = requestsHash->hexPrefixed();
         }
+    }
+    if (!isEth)
+    {
+        // Native FISCO-BCOS blocks keep their pre-existing Ethereum-compatible mock shape.
+        result["baseFeePerGas"] = "0x0";
+        result["withdrawals"] = Json::Value(Json::arrayValue);
+        // empty withdrawals trie root hash
+        result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
+        result["blobGasUsed"] = "0x0";
+        result["excessBlobGas"] = "0x0";
+        result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
     }
 
     if (fullTxs)

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -65,19 +65,9 @@ void bcos::rpc::combineBlockResponse(
         }
     }
 
-    rpc::Logs logs;
-    for (auto receipt : block.receipts())
-    {
-        for (auto const& log : receipt->logEntries())
-        {
-            rpc::Log logObj{
-                .address = bcos::bytes(log.address().begin(), log.address().end()),
-                .topics = bcos::h256s(log.topics().begin(), log.topics().end()),
-                .data = bcos::bytes(log.data().begin(), log.data().end()),
-            };
-            logs.push_back(std::move(logObj));
-        }
-    }
+    // logsBloom: the Eth branch reads the header's bloom (part of the RLP hash), the
+    // NON_ETH branch the block's own bloom. A per-log copy was previously built here and
+    // never read; removed.
     result["logsBloom"] = toPaddingHexStringWithPrefix(
         BloomBytesSize, isEth ? blockHeader->logsBloom() : block.logsBloom());
     result["transactionsRoot"] = blockHeader->txsRoot().hexPrefixed();

--- a/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
+++ b/bcos-rpc/bcos-rpc/web3jsonrpc/model/BlockResponse.cpp
@@ -1,6 +1,7 @@
 #include "BlockResponse.h"
 #include "Log.h"
 
+#include <bcos-framework/protocol/Protocol.h>
 #include <bcos-utilities/Bloom.h>
 
 #include <range/v3/view/enumerate.hpp>
@@ -11,12 +12,48 @@ void bcos::rpc::combineBlockResponse(
     auto blockHeader = block.blockHeader();
     auto blockHash = blockHeader->hash();
     auto blockNumber = blockHeader->number();
+    auto const ethVersion = blockHeader->ethBlockVersion();
+    auto const isEth = ethVersion != bcos::protocol::EthBlockVersion::NON_ETH;
+
     result["number"] = toQuantity(blockNumber);
     result["hash"] = blockHash.hexPrefixed();
     result["parentHash"] = blockHeader->parentInfo().blockHash.hexPrefixed();
-    result["nonce"] = "0x0000000000000000";
-    // empty uncle hash: keccak256(RLP([]))
-    result["sha3Uncles"] = "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
+
+    if (isEth)
+    {
+        // Ethereum header: every field is taken verbatim from the header.
+        result["nonce"] = blockHeader->nonce().hexPrefixed();
+        result["sha3Uncles"] = blockHeader->uncleHash().hexPrefixed();
+        result["miner"] = blockHeader->coinbase().hexPrefixed();
+        result["difficulty"] = toQuantity(blockHeader->difficulty());
+        result["mixHash"] = blockHeader->prevRandao().hexPrefixed();
+    }
+    else
+    {
+        // FISCO-BCOS header: fixed Ethereum-compatible empty values, miner derived from
+        // the sealer list (FISCO headers carry no coinbase).
+        result["nonce"] = "0x0000000000000000";
+        // empty uncle hash: keccak256(RLP([]))
+        result["sha3Uncles"] =
+            "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347";
+        result["difficulty"] = "0x0";
+        result["mixHash"] = crypto::HashType().hexPrefixed();
+        if (blockNumber == 0)
+        {
+            result["miner"] = "0x0000000000000000000000000000000000000000";
+        }
+        else if (std::cmp_greater(blockHeader->sealerList().size(), blockHeader->sealer()))
+        {
+            auto pk = blockHeader->sealerList()[blockHeader->sealer()];
+            auto hash = crypto::keccak256Hash(bcos::ref(pk));
+            Address address = right160(hash);
+            auto addrString = address.hex();
+            auto addrHash = crypto::keccak256Hash(bytesConstRef(addrString)).hex();
+            toChecksumAddress(addrString, addrHash);
+            result["miner"] = "0x" + addrString;
+        }
+    }
+
     rpc::Logs logs;
     for (auto receipt : block.receipts())
     {
@@ -30,34 +67,62 @@ void bcos::rpc::combineBlockResponse(
             logs.push_back(std::move(logObj));
         }
     }
-    result["logsBloom"] = toPaddingHexStringWithPrefix(BloomBytesSize, block.logsBloom());
+    result["logsBloom"] = toPaddingHexStringWithPrefix(
+        BloomBytesSize, isEth ? blockHeader->logsBloom() : block.logsBloom());
     result["transactionsRoot"] = blockHeader->txsRoot().hexPrefixed();
     result["stateRoot"] = blockHeader->stateRoot().hexPrefixed();
     result["receiptsRoot"] = blockHeader->receiptsRoot().hexPrefixed();
-    if (std::cmp_greater(blockHeader->sealerList().size(), blockHeader->sealer()))
-    {
-        auto pk = blockHeader->sealerList()[blockHeader->sealer()];
-        auto hash = crypto::keccak256Hash(bcos::ref(pk));
-        Address address = right160(hash);
-        auto addrString = address.hex();
-        auto addrHash = crypto::keccak256Hash(bytesConstRef(addrString)).hex();
-        toChecksumAddress(addrString, addrHash);
-        result["miner"] = "0x" + addrString;
-    }
-    // genesis block
-    if (blockHeader->number() == 0)
-    {
-        result["miner"] = "0x0000000000000000000000000000000000000000";
-        result["parentHash"] = "0x0000000000000000000000000000000000000000000000000000000000000000";
-    }
-    result["difficulty"] = "0x0";
     result["totalDifficulty"] = "0x0";
     result["extraData"] = toHexStringWithPrefix(blockHeader->extraData());
     result["size"] = toQuantity(block.size());
-    // TODO: change it wen block gas limit apply
-    result["gasLimit"] = toQuantity(30000000ULL);
-    result["gasUsed"] = toQuantity((uint64_t)blockHeader->gasUsed());
-    result["timestamp"] = toQuantity(blockHeader->timestamp() / 1000);  // to seconds
+    result["gasLimit"] = toQuantity(blockHeader->gasLimit());
+    result["gasUsed"] = toQuantity(static_cast<uint64_t>(blockHeader->gasUsed()));
+    // Eth headers carry the timestamp in seconds already; FISCO headers in milliseconds.
+    result["timestamp"] = toQuantity(
+        isEth ? blockHeader->timestamp() : blockHeader->timestamp() / 1000);
+
+    // Fork-gated Ethereum fields: only defined for the fork that introduced them.
+    auto versionAtLeast = [&](bcos::protocol::EthBlockVersion fork) {
+        return isEth && static_cast<uint8_t>(ethVersion) >= static_cast<uint8_t>(fork);
+    };
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::LONDON))
+    {
+        result["baseFeePerGas"] = toQuantity(blockHeader->baseFee().value_or(bcos::u256(0)));
+    }
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::SHANGHAI))
+    {
+        // The withdrawals operation list is a block-body field and is not persisted in the
+        // header (only its trie root is); emit the always-empty list so Shanghai-shaped
+        // clients keep working, and the root verbatim from the header.
+        result["withdrawals"] = Json::Value(Json::arrayValue);
+        if (auto root = blockHeader->withdrawalsRoot())
+        {
+            result["withdrawalsRoot"] = root->hexPrefixed();
+        }
+    }
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::CANCUN))
+    {
+        if (auto blobGasUsed = blockHeader->blobGasUsed())
+        {
+            result["blobGasUsed"] = toQuantity(*blobGasUsed);
+        }
+        if (auto excessBlobGas = blockHeader->excessBlobGas())
+        {
+            result["excessBlobGas"] = toQuantity(*excessBlobGas);
+        }
+        if (auto beaconRoot = blockHeader->parentBeaconBlockRoot())
+        {
+            result["parentBeaconBlockRoot"] = beaconRoot->hexPrefixed();
+        }
+    }
+    if (versionAtLeast(bcos::protocol::EthBlockVersion::PRAGUE))
+    {
+        if (auto requestsHash = blockHeader->requestsHash())
+        {
+            result["requestsHash"] = requestsHash->hexPrefixed();
+        }
+    }
+
     if (fullTxs)
     {
         Json::Value txList = Json::arrayValue;
@@ -79,12 +144,4 @@ void bcos::rpc::combineBlockResponse(
         result["transactions"] = std::move(txHashesList);
     }
     result["uncles"] = Json::Value(Json::arrayValue);
-    result["mixHash"] = crypto::HashType().hexPrefixed();
-    result["baseFeePerGas"] = "0x0";
-    result["withdrawals"] = Json::Value(Json::arrayValue);
-    // empty withdrawals trie root hash
-    result["withdrawalsRoot"] = crypto::HashType().hexPrefixed();
-    result["blobGasUsed"] = "0x0";
-    result["excessBlobGas"] = "0x0";
-    result["parentBeaconBlockRoot"] = crypto::HashType().hexPrefixed();
 }

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -55,6 +55,7 @@ public:
         std::optional<engine::NewPayloadRequest> capturedNewPayloadRequest;
         std::optional<std::uint32_t> capturedNewPayloadVersion;
         bool throwUnknownPayload = false;
+        bool throwUnsupportedFork = false;
     };
     std::shared_ptr<State> m_state = std::make_shared<State>();
 
@@ -72,6 +73,10 @@ public:
     {
         m_state->capturedForkchoiceState = forkchoiceState;
         m_state->capturedForkchoiceVersion = static_cast<int>(version);
+        if (m_state->throwUnsupportedFork)
+        {
+            BOOST_THROW_EXCEPTION(engine::UnsupportedFork{});
+        }
         co_return m_state->forkchoiceUpdatedResult;
     }
 
@@ -228,6 +233,32 @@ BOOST_AUTO_TEST_CASE(forkchoiceUpdatedV4)
     BOOST_CHECK(response.isMember("error"));
     BOOST_CHECK_EQUAL(response["error"]["code"].asInt(), EngineError::UnsupportedFork);
     BOOST_CHECK(!mockService.m_state->capturedForkchoiceVersion.has_value());
+}
+
+// A service-layer UnsupportedFork (e.g. the chain-fork vs attribute-shape gate in
+// buildPayload) must surface as -38005, not as a generic -32603 InternalError.
+BOOST_AUTO_TEST_CASE(forkchoiceUpdatedUnsupportedForkMapsTo38005)
+{
+    mockService.m_state->throwUnsupportedFork = true;
+
+    Json::Value params(Json::arrayValue);
+    Json::Value fc;
+    fc["headBlockHash"] = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    fc["safeBlockHash"] = "0x2222222222222222222222222222222222222222222222222222222222222222";
+    fc["finalizedBlockHash"] = "0x3333333333333333333333333333333333333333333333333333333333333333";
+    params.append(fc);
+    Json::Value attrs;
+    attrs["timestamp"] = "0x1";
+    attrs["prevRandao"] = "0x4444444444444444444444444444444444444444444444444444444444444444";
+    attrs["suggestedFeeRecipient"] = "0x5555555555555555555555555555555555555555";
+    params.append(attrs);
+
+    Json::Value response;
+    // The service's typed UnsupportedFork surfaces as Engine error -38005, not -32603.
+    BOOST_CHECK_EXCEPTION(CALL_ENGINE(forkchoiceUpdatedV2, params, response), JsonRpcException,
+        [](JsonRpcException const& e) { return e.code() == EngineError::UnsupportedFork; });
+    BOOST_REQUIRE(mockService.m_state->capturedForkchoiceVersion.has_value());
+    BOOST_CHECK_EQUAL(*mockService.m_state->capturedForkchoiceVersion, 2);
 }
 
 BOOST_AUTO_TEST_CASE(getPayloadV1)

--- a/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/EngineRpcTest.cpp
@@ -19,6 +19,7 @@
 
 #include "../common/RPCFixture.h"
 #include <bcos-framework/engine/AnyEngineService.h>
+#include <bcos-framework/engine/Errors.h>
 #include <bcos-rpc/web3jsonrpc/endpoints/Endpoints.h>
 #include <bcos-rpc/web3jsonrpc/utils/Common.h>
 #include <bcos-task/Wait.h>

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -95,9 +95,15 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
     BOOST_CHECK_EQUAL(result["uncles"].size(), 0U);
     // fullTxs=false → transactions is an array of hashes (empty here).
     BOOST_CHECK(result["transactions"].isArray());
-    // A FISCO (NON_ETH) header carries none of the Eth fork-gated fields.
-    BOOST_CHECK(!result.isMember("baseFeePerGas"));
-    BOOST_CHECK(!result.isMember("withdrawalsRoot"));
+    // Native FISCO (NON_ETH) blocks keep the historical Ethereum-compatible mock shape:
+    // baseFeePerGas / withdrawals / blob fields are present with fixed values, and gasLimit
+    // falls back to the fixed 30000000 (native headers never set it).
+    BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000
+    BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x0");
+    BOOST_CHECK(result.isMember("withdrawalsRoot"));
+    BOOST_CHECK(result.isMember("blobGasUsed"));
+    BOOST_CHECK(result.isMember("excessBlobGas"));
+    BOOST_CHECK(result.isMember("parentBeaconBlockRoot"));
     BOOST_CHECK(result.isMember("logsBloom"));
 }
 
@@ -253,9 +259,12 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     Json::Value result(Json::objectValue);
     combineBlockResponse(result, *block, /*fullTxs=*/false);
 
-    // Header-derived Eth fields, not mock constants.
-    BOOST_CHECK_EQUAL(result["miner"].asString(),
-        "0x1234567890abcdef1234567890abcdef12345678");
+    // Header-derived Eth fields, not mock constants. miner is the EIP-55 checksummed coinbase.
+    auto minerAddr = bcos::Address("1234567890abcdef1234567890abcdef12345678").hex();
+    auto minerAddrHash = bcos::crypto::keccak256Hash(bcos::bytesConstRef(minerAddr)).hex();
+    toChecksumAddress(minerAddr, minerAddrHash);
+    BOOST_CHECK_EQUAL(result["miner"].asString(), "0x" + minerAddr);
+    BOOST_CHECK_NE(result["miner"].asString(), "0x1234567890abcdef1234567890abcdef12345678");
     BOOST_CHECK_EQUAL(result["sha3Uncles"].asString(),
         "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
     BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0000000000000000");

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -95,8 +95,9 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseGenesisBlock)
     BOOST_CHECK_EQUAL(result["uncles"].size(), 0U);
     // fullTxs=false → transactions is an array of hashes (empty here).
     BOOST_CHECK(result["transactions"].isArray());
-    BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x0");
-    BOOST_CHECK(result.isMember("withdrawalsRoot"));
+    // A FISCO (NON_ETH) header carries none of the Eth fork-gated fields.
+    BOOST_CHECK(!result.isMember("baseFeePerGas"));
+    BOOST_CHECK(!result.isMember("withdrawalsRoot"));
     BOOST_CHECK(result.isMember("logsBloom"));
 }
 
@@ -205,6 +206,76 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseFullTxsEmptyList)
     // fullTxs=true with no transactions → still an (empty) array.
     BOOST_REQUIRE(result["transactions"].isArray());
     BOOST_CHECK_EQUAL(result["transactions"].size(), 0U);
+}
+
+BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
+{
+    auto block = m_blockFactory->createBlock();
+    auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
+    // An Eth CANCUN header: all fork-gated fields come from the header, the timestamp is
+    // stored in seconds and emitted as-is.
+    header->setNumber(7);
+    header->setTimestamp(1700000000);  // already seconds
+    header->setEthBlockVersion(bcos::protocol::EthBlockVersion::CANCUN);
+    header->setParentInfo(
+        bcos::protocol::ParentInfo{.blockNumber = 6,
+            .blockHash = bcos::crypto::HashType(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
+    header->setUncleHash(
+        bcos::crypto::HashType("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
+    header->setDifficulty(bcos::u256(0));
+    header->setNonce(bcos::h64(0));
+    header->setPrevRandao(
+        bcos::h256("1111111111111111111111111111111111111111111111111111111111111111"));
+    header->setGasLimit(bcos::u256(30000000));
+    header->setGasUsed(bcos::u256(21000));
+    // Required non-optional Eth fields so calculateHash can recompute the RLP hash.
+    header->setStateRoot(
+        bcos::h256("4444444444444444444444444444444444444444444444444444444444444444"));
+    header->setTxsRoot(
+        bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
+    header->setReceiptsRoot(
+        bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
+    bcos::Bloom bloom;
+    bloom[0] = 0xab;
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    header->setBaseFee(bcos::u256(1000000000));
+    header->setWithdrawalsRoot(
+        bcos::h256("2222222222222222222222222222222222222222222222222222222222222222"));
+    header->setBlobGasUsed(bcos::u256(0));
+    header->setExcessBlobGas(bcos::u256(0));
+    header->setParentBeaconBlockRoot(
+        bcos::h256("3333333333333333333333333333333333333333333333333333333333333333"));
+    header->calculateHash(*hashImpl);
+    block->setBlockHeader(header);
+
+    Json::Value result(Json::objectValue);
+    combineBlockResponse(result, *block, /*fullTxs=*/false);
+
+    // Header-derived Eth fields, not mock constants.
+    BOOST_CHECK_EQUAL(result["miner"].asString(),
+        "0x1234567890abcdef1234567890abcdef12345678");
+    BOOST_CHECK_EQUAL(result["sha3Uncles"].asString(),
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0000000000000000");
+    BOOST_CHECK_EQUAL(result["mixHash"].asString(),
+        "0x1111111111111111111111111111111111111111111111111111111111111111");
+    // Eth timestamp is already in seconds: emitted without /1000.
+    BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x6553f100");
+    // gasLimit/gasUsed come from the header.
+    BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000
+    BOOST_CHECK_EQUAL(result["gasUsed"].asString(), "0x5208");      // 21000
+    // CANCUN fork-gated fields: present.
+    BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x3b9aca00");  // 1000000000
+    BOOST_CHECK_EQUAL(result["withdrawalsRoot"].asString(),
+        "0x2222222222222222222222222222222222222222222222222222222222222222");
+    BOOST_CHECK(result.isMember("blobGasUsed"));
+    BOOST_CHECK(result.isMember("excessBlobGas"));
+    BOOST_CHECK_EQUAL(result["parentBeaconBlockRoot"].asString(),
+        "0x3333333333333333333333333333333333333333333333333333333333333333");
+    // PRAGUE-only field: not defined for a CANCUN header.
+    BOOST_CHECK(!result.isMember("requestsHash"));
 }
 
 BOOST_AUTO_TEST_CASE(combineTxResponseShapesTransaction)

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -297,6 +297,136 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     BOOST_CHECK_EQUAL(specAddr, "5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
 }
 
+// Build an Eth header with the given fork marker plus the fork-gated fields that fork
+// would carry, so the RPC response shape can be asserted per fork.
+static std::shared_ptr<bcos::protocol::Block> makeEthHeaderBlock(
+    std::shared_ptr<bcos::protocol::BlockFactory> const& blockFactory,
+    std::shared_ptr<bcos::crypto::Hash> const& hashImpl, bcos::protocol::EthBlockVersion version,
+    std::optional<bcos::u256> baseFee, std::optional<bcos::h256> withdrawalsRoot,
+    std::optional<bcos::u256> blobGasUsed, std::optional<bcos::u256> excessBlobGas,
+    std::optional<bcos::h256> parentBeaconBlockRoot, std::optional<bcos::h256> requestsHash)
+{
+    auto block = blockFactory->createBlock();
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setNumber(7);
+    header->setTimestamp(1700000000 * 1000LL);  // BlockHeader milliseconds == 1700000000 s
+    header->setEthBlockVersion(version);
+    header->setParentInfo(
+        bcos::protocol::ParentInfo{.blockNumber = 6,
+            .blockHash = bcos::crypto::HashType(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")});
+    header->setUncleHash(bcos::crypto::HashType(
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
+    header->setDifficulty(bcos::u256(0));
+    header->setNonce(bcos::h64(0));
+    header->setPrevRandao(
+        bcos::h256("1111111111111111111111111111111111111111111111111111111111111111"));
+    header->setGasLimit(bcos::u256(30000000));
+    header->setGasUsed(bcos::u256(21000));
+    header->setStateRoot(
+        bcos::h256("4444444444444444444444444444444444444444444444444444444444444444"));
+    header->setTxsRoot(
+        bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
+    header->setReceiptsRoot(
+        bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
+    bcos::Bloom bloom;
+    bloom[0] = 0xab;
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    if (baseFee)
+    {
+        header->setBaseFee(*baseFee);
+    }
+    if (withdrawalsRoot)
+    {
+        header->setWithdrawalsRoot(*withdrawalsRoot);
+    }
+    if (blobGasUsed)
+    {
+        header->setBlobGasUsed(*blobGasUsed);
+    }
+    if (excessBlobGas)
+    {
+        header->setExcessBlobGas(*excessBlobGas);
+    }
+    if (parentBeaconBlockRoot)
+    {
+        header->setParentBeaconBlockRoot(*parentBeaconBlockRoot);
+    }
+    if (requestsHash)
+    {
+        header->setRequestsHash(*requestsHash);
+    }
+    header->calculateHash(*hashImpl);
+    block->setBlockHeader(header);
+    return block;
+}
+
+// The fork-gated key matrix must match geth's eth_getBlock* shape exactly: LONDON has only
+// baseFeePerGas; SHANGHAI adds withdrawals/withdrawalsRoot; CANCUN adds the blob trio;
+// PRAGUE adds requestsHash. A wrong presence/absence on any fork must fail here.
+BOOST_AUTO_TEST_CASE(combineBlockResponseEthForkShapesGateKeys)
+{
+    using bcos::protocol::EthBlockVersion;
+
+    struct Case
+    {
+        EthBlockVersion version;
+        bool expectBaseFee;
+        bool expectWithdrawals;
+        bool expectBlobTrio;
+        bool expectRequestsHash;
+    };
+    std::vector<Case> const cases{
+        {EthBlockVersion::LONDON, true, false, false, false},
+        {EthBlockVersion::SHANGHAI, true, true, false, false},
+        {EthBlockVersion::CANCUN, true, true, true, false},
+        {EthBlockVersion::PRAGUE, true, true, true, true},
+    };
+
+    for (auto const& c : cases)
+    {
+        // The header must carry exactly the fields its fork permits: validateHeader
+        // forbids a field the version does not know (e.g. withdrawalsRoot on LONDON).
+        auto baseFee = bcos::u256(1000000000);
+        std::optional<bcos::h256> withdrawalsRoot;
+        std::optional<bcos::u256> blobGasUsed;
+        std::optional<bcos::u256> excessBlobGas;
+        std::optional<bcos::h256> parentBeaconBlockRoot;
+        std::optional<bcos::h256> requestsHash;
+        if (c.expectWithdrawals)
+        {
+            withdrawalsRoot = bcos::h256(
+                "2222222222222222222222222222222222222222222222222222222222222222");
+        }
+        if (c.expectBlobTrio)
+        {
+            blobGasUsed = bcos::u256(0);
+            excessBlobGas = bcos::u256(0);
+            parentBeaconBlockRoot = bcos::h256(
+                "3333333333333333333333333333333333333333333333333333333333333333");
+        }
+        if (c.expectRequestsHash)
+        {
+            requestsHash = bcos::h256(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        }
+        auto block = makeEthHeaderBlock(m_blockFactory, hashImpl, c.version, baseFee,
+            withdrawalsRoot, blobGasUsed, excessBlobGas, parentBeaconBlockRoot, requestsHash);
+
+        Json::Value result(Json::objectValue);
+        combineBlockResponse(result, *block, /*fullTxs=*/false);
+
+        BOOST_CHECK_EQUAL(result.isMember("baseFeePerGas"), c.expectBaseFee);
+        BOOST_CHECK_EQUAL(result.isMember("withdrawals"), c.expectWithdrawals);
+        BOOST_CHECK_EQUAL(result.isMember("withdrawalsRoot"), c.expectWithdrawals);
+        BOOST_CHECK_EQUAL(result.isMember("blobGasUsed"), c.expectBlobTrio);
+        BOOST_CHECK_EQUAL(result.isMember("excessBlobGas"), c.expectBlobTrio);
+        BOOST_CHECK_EQUAL(result.isMember("parentBeaconBlockRoot"), c.expectBlobTrio);
+        BOOST_CHECK_EQUAL(result.isMember("requestsHash"), c.expectRequestsHash);
+    }
+}
+
 BOOST_AUTO_TEST_CASE(combineTxResponseShapesTransaction)
 {
     auto txFactory = m_blockFactory->transactionFactory();

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -275,6 +275,8 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     // gasLimit/gasUsed come from the header.
     BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000
     BOOST_CHECK_EQUAL(result["gasUsed"].asString(), "0x5208");      // 21000
+    // Eth blocks take logsBloom from the header (bloom[0] = 0xab), not from the block body.
+    BOOST_CHECK(result["logsBloom"].asString().starts_with("0xab"));
     // CANCUN fork-gated fields: present.
     BOOST_CHECK_EQUAL(result["baseFeePerGas"].asString(), "0x3b9aca00");  // 1000000000
     BOOST_CHECK_EQUAL(result["withdrawalsRoot"].asString(),
@@ -285,6 +287,14 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
         "0x3333333333333333333333333333333333333333333333333333333333333333");
     // PRAGUE-only field: not defined for a CANCUN header.
     BOOST_CHECK(!result.isMember("requestsHash"));
+
+    // Independent EIP-55 oracle: the checksum above recomputes via the same
+    // toChecksumAddress as the implementation, so pin one official EIP-55 spec vector
+    // (the spec's first example) to catch a wrong checksum algorithm.
+    std::string specAddr = "5aaeb6053f3e94c9b9a09f33669435e7ef1beaed";
+    auto specHash = bcos::crypto::keccak256Hash(bcos::bytesConstRef(specAddr)).hex();
+    toChecksumAddress(specAddr, specHash);
+    BOOST_CHECK_EQUAL(specAddr, "5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed");
 }
 
 BOOST_AUTO_TEST_CASE(combineTxResponseShapesTransaction)

--- a/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
+++ b/bcos-rpc/test/unittests/rpc/Web3ResponseTest.cpp
@@ -213,9 +213,9 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     auto block = m_blockFactory->createBlock();
     auto header = m_blockFactory->blockHeaderFactory()->createBlockHeader();
     // An Eth CANCUN header: all fork-gated fields come from the header, the timestamp is
-    // stored in seconds and emitted as-is.
+    // stored in BlockHeader milliseconds and emitted as seconds (/1000).
     header->setNumber(7);
-    header->setTimestamp(1700000000);  // already seconds
+    header->setTimestamp(1700000000 * 1000LL);  // BlockHeader milliseconds == 1700000000 s
     header->setEthBlockVersion(bcos::protocol::EthBlockVersion::CANCUN);
     header->setParentInfo(
         bcos::protocol::ParentInfo{.blockNumber = 6,
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(combineBlockResponseEthHeaderReadsFieldsFromHeader)
     BOOST_CHECK_EQUAL(result["nonce"].asString(), "0x0000000000000000");
     BOOST_CHECK_EQUAL(result["mixHash"].asString(),
         "0x1111111111111111111111111111111111111111111111111111111111111111");
-    // Eth timestamp is already in seconds: emitted without /1000.
+    // Eth timestamp: header milliseconds /1000 = seconds.
     BOOST_CHECK_EQUAL(result["timestamp"].asString(), "0x6553f100");
     // gasLimit/gasUsed come from the header.
     BOOST_CHECK_EQUAL(result["gasLimit"].asString(), "0x1c9c380");  // 30000000

--- a/bcos-single-consensus/bcos-single-consensus/SingleNodeConsensus.cpp
+++ b/bcos-single-consensus/bcos-single-consensus/SingleNodeConsensus.cpp
@@ -176,10 +176,32 @@ void SingleNodeConsensus::resolveInitialHead()
     }
     m_headNumber = headNumber;
     m_headHash = task::syncWait(ledger::getBlockHash(*m_ledger, headNumber));
+
+    // Seed m_lastTimestamp from the head header's timestamp (whole-second milliseconds)
+    // so a restart in the same wall-clock second as the parent cannot reseal
+    // parent.timestamp: EIP-2 requires strictly increasing block timestamps, and
+    // produceBlock only steps +1000ms from m_lastTimestamp. Without the seed, a restart
+    // within the parent block's second makes the first produced block share the parent's
+    // timestamp. A legacy genesis without [eth_genesis_header] has timestamp 0, which
+    // seeds to the same default and changes nothing.
+    auto headerPromise =
+        std::make_shared<CallbackPromise<std::tuple<Error::Ptr, protocol::Block::Ptr>>>();
+    m_ledger->asyncGetBlockDataByNumber(headNumber, ledger::HEADER,
+        [headerPromise](Error::Ptr _error, protocol::Block::Ptr _block) {
+            headerPromise->setValue(std::make_tuple(std::move(_error), std::move(_block)));
+        });
+    auto [headHeaderError, headBlock] = headerPromise->wait(m_running);
+    if (!headHeaderError && headBlock && headBlock->blockHeader())
+    {
+        m_lastTimestamp =
+            static_cast<std::uint64_t>(headBlock->blockHeader()->timestamp());
+    }
+
     m_headInitialized = true;
     SINGLE_CONSENSUS_LOG(INFO) << LOG_DESC("Resolved initial head")
                                << LOG_KV("number", m_headNumber)
-                               << LOG_KV("hash", m_headHash.hexPrefixed());
+                               << LOG_KV("hash", m_headHash.hexPrefixed())
+                               << LOG_KV("lastTimestampMs", m_lastTimestamp);
 }
 
 bool SingleNodeConsensus::produceBlock()

--- a/bcos-single-consensus/bcos-single-consensus/SingleNodeConsensus.cpp
+++ b/bcos-single-consensus/bcos-single-consensus/SingleNodeConsensus.cpp
@@ -139,7 +139,10 @@ void SingleNodeConsensus::loop()
         }
         catch (...)
         {
-            SINGLE_CONSENSUS_LOG(ERROR) << LOG_DESC("produceBlock iteration threw (unknown)");
+            SINGLE_CONSENSUS_LOG(ERROR)
+                << LOG_DESC("produceBlock iteration threw (unknown)")
+                << LOG_KV("diagnostic",
+                    boost::current_exception_diagnostic_information());
         }
         // Drain the mempool as fast as possible when transactions are available (a tx is
         // sealed immediately after submission instead of waiting for the next interval
@@ -191,18 +194,26 @@ bool SingleNodeConsensus::produceBlock()
     // seconds, matching EEST's currentTimestamp unit). fixed_timestamp (seconds) is pinned by
     // the harness so the produced block's timestamp matches the fixture; 0 = wall clock.
     //
-    // EIP-2 requires strictly increasing block timestamps, so both modes enforce
-    // monotonicity: a fixed timestamp is bumped by the block number (consecutive blocks,
-    // including empty ones, must never share the same value), and wall-clock mode never goes
-    // backwards relative to the last produced block. utcTime() already returns milliseconds
-    // (bcos-utilities/Common.cpp, despite the header comment saying "seconds") — do NOT
-    // multiply by 1000, which would make the block timestamp ~1.786e15 -> year 58577 in the
-    // EVM (block.timestamp / base fee schedules etc).
+    // Ethereum block timestamps are second-granular: BlockHeader stores milliseconds, so the
+    // value must be a whole-second multiple — the Eth RLP bridge (EthBlockHeader ctor) rejects
+    // sub-second ms, and the produced header is hashed as an Eth header. EIP-2 requires
+    // strictly increasing block timestamps, so both modes round down to a whole second and
+    // then enforce monotonicity in whole-second steps (a fixed timestamp is used verbatim for
+    // the first block so EEST's expected block.timestamp == currentTimestamp holds; later
+    // blocks step +1s).
+    //
+    // utcTime() already returns milliseconds (bcos-utilities/Common.cpp, despite the header
+    // comment saying "seconds") — do NOT multiply by 1000, which would make the block
+    // timestamp ~1.786e15 -> year 58577 in the EVM (block.timestamp / base fee schedules etc).
     auto const nowMs = static_cast<std::uint64_t>(utcTime());
-    std::uint64_t const timestamp =
-        m_fixedTimestamp > 0 ?
-            m_fixedTimestamp * 1000 + static_cast<std::uint64_t>(m_headNumber + 1) :
-            std::max(nowMs, m_lastTimestamp + 1);
+    auto const wholeSecondMs = [&]() -> std::uint64_t {
+        if (m_fixedTimestamp > 0)
+        {
+            return m_fixedTimestamp * 1000;
+        }
+        return nowMs / 1000 * 1000;
+    }();
+    std::uint64_t const timestamp = std::max(wholeSecondMs, m_lastTimestamp + 1000);
     m_lastTimestamp = timestamp;
     bcos::engine::PayloadAttributes payloadAttributes;
     payloadAttributes.prevRandao = m_prevRandao;

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(engine ${SRC_LIST})
 target_include_directories(engine PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-engine>)
-target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger rlp-protocol)
+target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger PRIVATE rlp-protocol)
 set_target_properties(engine PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(engine ${SRC_LIST})
 target_include_directories(engine PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/bcos-engine>)
-target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger)
+target_link_libraries(engine PUBLIC bcos-framework bcos-task bcos-utilities ledger rlp-protocol)
 set_target_properties(engine PROPERTIES UNITY_BUILD "ON")
 
 if (TESTS)

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -60,6 +60,11 @@ std::vector<std::string> bcos::engine::detail::supportedCapabilities()
     // here would also break the pre-Karst callers this node still serves — the v1 Engine
     // API harness behind unsafe_allow_v1_executor and the V1-V3 integration suites.
     //
+    // Note: serving a method VERSION is not the same as being able to BUILD with it.
+    // buildPayload requires an on-chain EVM revision (executor_version >= 2); the
+    // unsafe_allow_v1_executor harness (executor_version < 2) can no longer build any
+    // payload, only answer capability/state queries.
+    //
     // forkchoiceUpdatedV4 is the one absentee, and genuinely so: the forkchoice version
     // window tops out at V3 (isForkchoiceVersionSupported), so the endpoint answers
     // -38005. getPayloadV5 and newPayloadV4 were added by B4.
@@ -446,9 +451,21 @@ std::optional<std::string> bcos::engine::detail::validateExecutionPayload(
     // Isthmus: an ExecutionPayloadV4 always carries the L2ToL1MessagePasser storage root.
     // Pre-V4 payloads with the field present are tolerated (mirrors the parse side, which
     // ignores it below V4 the way op-geth's NewPayloadV3 performs no withdrawalsRoot check).
-    if (version >= 4 && !executionPayload.withdrawalsRoot.has_value())
+    // The submitted root must equal the value this node itself commits (withdrawalsRootFor
+    // — currently the empty-trie placeholder): a CL submitting a foreign root under the
+    // blockHash this node minted would otherwise commit a header hash nobody can reproduce.
+    if (version >= 4)
     {
-        return std::string("withdrawalsRoot is required for ExecutionPayloadV4 and later");
+        if (!executionPayload.withdrawalsRoot.has_value())
+        {
+            return std::string("withdrawalsRoot is required for ExecutionPayloadV4 and later");
+        }
+        auto expectedRoot = withdrawalsRootFor(executionPayload);
+        if (*executionPayload.withdrawalsRoot != expectedRoot)
+        {
+            return std::string("withdrawalsRoot does not match the value this node commits "
+                                "for the built header");
+        }
     }
     // extraData is a V1-onwards field, so this applies at every newPayload version.
     // Since this PR makes extraData part of the block hash, an unchecked extraData is
@@ -529,10 +546,11 @@ void bcos::engine::detail::finalizeEthBlockHeader(bcos::protocol::BlockHeader& h
     header.setBaseFee(payload.baseFeePerGas);
 
     // SHANGHAI+ : withdrawalsRoot. The withdrawals trie root is not computed yet, so the
-    // empty-trie root is used as a placeholder.
+    // empty-trie root is used as a placeholder (same bytes as the served payload — see
+    // withdrawalsRootFor).
     if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI)
     {
-        header.setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
+        header.setWithdrawalsRoot(bcos::engine::detail::withdrawalsRootFor(payload));
     }
 
     // CANCUN+ : blob gas fields and parent beacon block root. buildPayload always fills the

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -318,6 +318,17 @@ std::optional<std::string> bcos::engine::detail::validatePayloadAttributes(
     {
         return std::string("withdrawals are required for PayloadAttributesV2 and V3");
     }
+    if (version >= 2 && payloadAttributes.withdrawals.has_value() &&
+        !payloadAttributes.withdrawals->empty())
+    {
+        // The withdrawals trie root is not computed yet (finalizeEthBlockHeader commits
+        // the empty-trie root as a placeholder), so a non-empty list would hash a root
+        // that differs from what geth derives (DeriveSha(withdrawals)) and every peer
+        // would reject the block. Reject the pairing until the real root is computed.
+        return std::string(
+            "non-empty withdrawals are not supported until the withdrawals trie root is "
+            "computed");
+    }
     if (version == 3 && !payloadAttributes.parentBeaconBlockRoot.has_value())
     {
         return std::string("parentBeaconBlockRoot must be a 32-byte hash for V3");

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -471,8 +471,15 @@ bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(std::ui
         return bcos::protocol::EthBlockVersion::SHANGHAI;
     case static_cast<std::uint32_t>(ApiVersion::V3):
         return bcos::protocol::EthBlockVersion::CANCUN;
+    case static_cast<std::uint32_t>(ApiVersion::V4):
+        return bcos::protocol::EthBlockVersion::PRAGUE;
     default:
-        return bcos::protocol::EthBlockVersion::PRAGUE;  // V4+
+        // A version beyond the known fork window must fail loudly here rather than being
+        // silently mapped to PRAGUE: the fork marker decides the RLP hash, so a wrong mapping
+        // would corrupt every block built under the unknown version.
+        BOOST_THROW_EXCEPTION(
+            UnsupportedEngineApiVersion{} << bcos::errinfo_comment{
+                "EngineService: unsupported Engine API version " + std::to_string(version)});
     }
 }
 
@@ -509,6 +516,15 @@ void bcos::engine::detail::finalizeEthBlockHeader(bcos::protocol::BlockHeader& h
         header.setBlobGasUsed(payload.blobGasUsed.value_or(bcos::u256(0)));
         header.setExcessBlobGas(payload.excessBlobGas.value_or(bcos::u256(0)));
         header.setParentBeaconBlockRoot(parentBeaconBlockRoot.value_or(bcos::h256{}));
+    }
+
+    // PRAGUE (V4): EIP-7685 execution-requests hash. FISCO-BCOS produces no execution
+    // requests, so the canonical empty-requests hash (sha256 of the empty input,
+    // 0xe3b0c442…) is used — the value the RLP hash must carry to validate as PRAGUE.
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V4))
+    {
+        header.setRequestsHash(bcos::crypto::HashType(
+            "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
     }
 
     // Mark the header as an Eth header, then compute and inject its RLP hash.

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -24,6 +24,8 @@
 #include <span>
 #include <stdexcept>
 #include <utility>
+#include <bcos-ledger/mpt/Constants.h>
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 
 namespace
 {
@@ -457,4 +459,63 @@ std::optional<std::string> bcos::engine::detail::compareWithBuiltPayload(
             "submitted blockHash");
     }
     return std::nullopt;
+}
+
+bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(std::uint32_t version)
+{
+    switch (version)
+    {
+    case static_cast<std::uint32_t>(ApiVersion::V1):
+        return bcos::protocol::EthBlockVersion::LONDON;
+    case static_cast<std::uint32_t>(ApiVersion::V2):
+        return bcos::protocol::EthBlockVersion::SHANGHAI;
+    case static_cast<std::uint32_t>(ApiVersion::V3):
+        return bcos::protocol::EthBlockVersion::CANCUN;
+    default:
+        return bcos::protocol::EthBlockVersion::PRAGUE;  // V4+
+    }
+}
+
+void bcos::engine::detail::finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
+    const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
+    std::uint32_t version)
+{
+    // Post-merge constants: the empty-ommers hash (keccak256(rlp([]))), difficulty 0 and nonce 0
+    // are fixed on every PoS Ethereum block.
+    static const auto kEmptyOmmersHash = bcos::crypto::HashType(
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    header.setUncleHash(kEmptyOmmersHash);
+    header.setDifficulty(bcos::u256(0));
+    header.setNonce(bcos::h64(0));
+
+    // The header itself must carry the 256-byte bloom: calculateRLPHash reads it from the header
+    // (handleNewPayload sets it on the block wrapper separately).
+    header.setLogsBloom(bcos::bytesConstRef(payload.logsBloom.data(), payload.logsBloom.size()));
+
+    // EIP-1559 base fee (LONDON+). FISCO-BCOS does not compute a real base fee yet, so this is
+    // whatever buildPayload placed in the payload (currently 0).
+    header.setBaseFee(payload.baseFeePerGas);
+
+    // SHANGHAI+ (V2): withdrawalsRoot. The withdrawals trie root is not computed yet, so the
+    // empty-trie root is used as a placeholder.
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V2))
+    {
+        header.setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
+    }
+
+    // CANCUN+ (V3): blob gas fields and parent beacon block root.
+    if (version >= static_cast<std::uint32_t>(ApiVersion::V3))
+    {
+        header.setBlobGasUsed(payload.blobGasUsed.value_or(bcos::u256(0)));
+        header.setExcessBlobGas(payload.excessBlobGas.value_or(bcos::u256(0)));
+        header.setParentBeaconBlockRoot(parentBeaconBlockRoot.value_or(bcos::h256{}));
+    }
+
+    // Mark the header as an Eth header, then compute and inject its RLP hash.
+    header.setEthBlockVersion(ethBlockVersionFor(version));
+    if (auto error = bcos::protocol::EthBlockHeader::calculateRLPHash(header))
+    {
+        BOOST_THROW_EXCEPTION(std::runtime_error{
+            "EngineService: failed to compute Eth RLP hash: " + error->errorMessage()});
+    }
 }

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -480,9 +480,20 @@ bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(evmc_re
     case EVMC_OSAKA:
         return bcos::protocol::EthBlockVersion::PRAGUE;
     default:
-        // FRONTIER..BERLIN cannot appear on a PoS/Engine chain; keeping the minimal
-        // post-merge shape is safe and fail-closed for any misconfiguration.
-        return bcos::protocol::EthBlockVersion::LONDON;
+        // Asymmetric arm: revisions strictly below LONDON (FRONTIER..BERLIN) cannot
+        // appear on a PoS/Engine chain, so the minimal post-merge shape is a defensible
+        // floor. Any revision ABOVE the highest mapped one — a future EVMC bump adding a
+        // revision after OSAKA — must fail loudly instead of hashing under the wrong fork
+        // rules: that would drop withdrawalsRoot, the blob trio and requestsHash from the
+        // RLP with no diagnostic, and every peer recomputing under the chain's real fork
+        // would reject the block.
+        if (rev < EVMC_LONDON)
+        {
+            return bcos::protocol::EthBlockVersion::LONDON;
+        }
+        BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
+            "EngineService: unsupported EVM revision " + std::to_string(static_cast<int>(rev)) +
+            " for Eth header fork derivation"});
     }
 }
 

--- a/engine/bcos-engine/EngineServiceImpl.cpp
+++ b/engine/bcos-engine/EngineServiceImpl.cpp
@@ -461,31 +461,34 @@ std::optional<std::string> bcos::engine::detail::compareWithBuiltPayload(
     return std::nullopt;
 }
 
-bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(std::uint32_t version)
+bcos::protocol::EthBlockVersion bcos::engine::detail::ethBlockVersionFor(evmc_revision rev)
 {
-    switch (version)
+    // Map the chain's EVM revision to the header fork era. PoS/Engine blocks are always
+    // LONDON-shaped or later; revisions below LONDON cannot occur on this path and are
+    // mapped to LONDON (the minimal post-merge shape). OSAKA has no distinct EthBlockVersion
+    // enumerator — its header RLP carries no new fields beyond PRAGUE, so it maps to PRAGUE.
+    switch (rev)
     {
-    case static_cast<std::uint32_t>(ApiVersion::V1):
+    case EVMC_LONDON:
+    case EVMC_PARIS:
         return bcos::protocol::EthBlockVersion::LONDON;
-    case static_cast<std::uint32_t>(ApiVersion::V2):
+    case EVMC_SHANGHAI:
         return bcos::protocol::EthBlockVersion::SHANGHAI;
-    case static_cast<std::uint32_t>(ApiVersion::V3):
+    case EVMC_CANCUN:
         return bcos::protocol::EthBlockVersion::CANCUN;
-    case static_cast<std::uint32_t>(ApiVersion::V4):
+    case EVMC_PRAGUE:
+    case EVMC_OSAKA:
         return bcos::protocol::EthBlockVersion::PRAGUE;
     default:
-        // A version beyond the known fork window must fail loudly here rather than being
-        // silently mapped to PRAGUE: the fork marker decides the RLP hash, so a wrong mapping
-        // would corrupt every block built under the unknown version.
-        BOOST_THROW_EXCEPTION(
-            UnsupportedEngineApiVersion{} << bcos::errinfo_comment{
-                "EngineService: unsupported Engine API version " + std::to_string(version)});
+        // FRONTIER..BERLIN cannot appear on a PoS/Engine chain; keeping the minimal
+        // post-merge shape is safe and fail-closed for any misconfiguration.
+        return bcos::protocol::EthBlockVersion::LONDON;
     }
 }
 
 void bcos::engine::detail::finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
     const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
-    std::uint32_t version)
+    bcos::protocol::EthBlockVersion forkVersion)
 {
     // Post-merge constants: the empty-ommers hash (keccak256(rlp([]))), difficulty 0 and nonce 0
     // are fixed on every PoS Ethereum block.
@@ -503,32 +506,35 @@ void bcos::engine::detail::finalizeEthBlockHeader(bcos::protocol::BlockHeader& h
     // whatever buildPayload placed in the payload (currently 0).
     header.setBaseFee(payload.baseFeePerGas);
 
-    // SHANGHAI+ (V2): withdrawalsRoot. The withdrawals trie root is not computed yet, so the
+    // SHANGHAI+ : withdrawalsRoot. The withdrawals trie root is not computed yet, so the
     // empty-trie root is used as a placeholder.
-    if (version >= static_cast<std::uint32_t>(ApiVersion::V2))
+    if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI)
     {
         header.setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
     }
 
-    // CANCUN+ (V3): blob gas fields and parent beacon block root.
-    if (version >= static_cast<std::uint32_t>(ApiVersion::V3))
+    // CANCUN+ : blob gas fields and parent beacon block root. buildPayload always fills the
+    // blob pair for the V3+ payload shape (and validatePayloadAttributes requires the beacon
+    // root), so require the values instead of defaulting to zero — a missing field must not
+    // silently hash as an explicit zero (absent and present-zero would share one sentinel).
+    if (forkVersion >= bcos::protocol::EthBlockVersion::CANCUN)
     {
-        header.setBlobGasUsed(payload.blobGasUsed.value_or(bcos::u256(0)));
-        header.setExcessBlobGas(payload.excessBlobGas.value_or(bcos::u256(0)));
-        header.setParentBeaconBlockRoot(parentBeaconBlockRoot.value_or(bcos::h256{}));
+        header.setBlobGasUsed(payload.blobGasUsed.value());
+        header.setExcessBlobGas(payload.excessBlobGas.value());
+        header.setParentBeaconBlockRoot(parentBeaconBlockRoot.value());
     }
 
-    // PRAGUE (V4): EIP-7685 execution-requests hash. FISCO-BCOS produces no execution
+    // PRAGUE : EIP-7685 execution-requests hash. FISCO-BCOS produces no execution
     // requests, so the canonical empty-requests hash (sha256 of the empty input,
     // 0xe3b0c442…) is used — the value the RLP hash must carry to validate as PRAGUE.
-    if (version >= static_cast<std::uint32_t>(ApiVersion::V4))
+    if (forkVersion >= bcos::protocol::EthBlockVersion::PRAGUE)
     {
         header.setRequestsHash(bcos::crypto::HashType(
             "0xe3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
     }
 
     // Mark the header as an Eth header, then compute and inject its RLP hash.
-    header.setEthBlockVersion(ethBlockVersionFor(version));
+    header.setEthBlockVersion(forkVersion);
     if (auto error = bcos::protocol::EthBlockHeader::calculateRLPHash(header))
     {
         BOOST_THROW_EXCEPTION(std::runtime_error{

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -90,6 +90,16 @@ bcos::bytes encodeOptimismExtraData(const PayloadAttributes& payloadAttributes);
 std::optional<std::string> validateExecutionPayload(
     const ExecutionPayload& executionPayload, std::uint32_t version);
 
+/// The withdrawals trie root this node commits for a block: the empty-trie root while the
+/// list is empty (matching geth's DeriveSha([])), and — when MPT work lands — the
+/// L2ToL1MessagePasser storage root on Isthmus. Non-empty lists are rejected earlier in
+/// validatePayloadAttributes; the hashed header and the served ExecutionPayload both call
+/// this helper so they always carry the same 32 bytes.
+inline bcos::h256 withdrawalsRootFor(const ExecutionPayload& /*payload*/)
+{
+    return bcos::ledger::mpt::emptyRootHash();
+}
+
 /// Compares a payload the CL submitted through newPayload against the one this node
 /// built and handed out under the same blockHash.
 ///
@@ -420,10 +430,12 @@ private:
 
     /// Per-method Engine API version windows. forkchoiceUpdated tops out at V3 (the
     /// version Karst payload building runs on), newPayload at V4 (Isthmus payload with
-    /// executionRequests), getPayload at V5 (Osaka response shape). Every version from V1
-    /// up is served: adapting to Karst does not make the older versions incompatible, and
-    /// the V1-V3 callers (the unsafe_allow_v1_executor harness, the integration suites)
-    /// keep working.
+    /// executionRequests), getPayload at V5 (Osaka response shape). The windows span V1
+    /// up: adapting to Karst does not make the older versions incompatible at the window
+    /// level. BUILDING a payload however requires an on-chain EVM revision and therefore
+    /// executor_version >= 2 — buildPayload's fork/version gates reject a method version
+    /// whose response shape the chain fork cannot fill, so the unsafe_allow_v1_executor
+    /// escape hatch (executor_version < 2) can no longer build any payload.
     static bool isForkchoiceVersionSupported(std::uint32_t version)
     {
         return version >= static_cast<std::uint32_t>(ApiVersion::V1) &&
@@ -726,7 +738,7 @@ private:
 
     bcos::task::Task<BuildPayloadResult> buildPayload(const ForkchoiceState& forkchoiceState,
         const PayloadAttributes& payloadAttributes, const PayloadID& payloadId,
-        std::uint32_t version [[maybe_unused]], bcos::protocol::BlockNumber nextBlockNumber,
+        std::uint32_t version, bcos::protocol::BlockNumber nextBlockNumber,
         std::vector<protocol::Transaction::Ptr> sealedTxs, ViewType& view) const
     {
         // Dual carrier: every sealed transaction is stored with both its raw EIP-2718
@@ -864,6 +876,29 @@ private:
                 "EngineService: chain EVM revision requires the V2 payload attributes "
                 "(withdrawals); forkchoiceUpdated must be called at version >= 2"});
         }
+        // The reverse direction: a method version NEWER than the chain fork cannot be
+        // served either. The served ExecutionPayload shape is contracted by the method the
+        // CL called (getPayloadV3 requires the blob pair, getPayloadV2 requires
+        // withdrawals), while the payload fields are filled by the chain-derived
+        // forkVersion — so a V3 FCU on a SHANGHAI chain would build a payload whose
+        // required fields are absent, and serializeExecutionPayload would silently omit
+        // them. Same class of truncated response the V4/V5 windows already guard against.
+        if (version >= static_cast<std::uint32_t>(ApiVersion::V3) &&
+            forkVersion < bcos::protocol::EthBlockVersion::CANCUN)
+        {
+            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: forkchoiceUpdatedV3 requires a CANCUN-or-later chain fork; "
+                "chain EVM revision maps to " +
+                std::to_string(static_cast<int>(forkVersion))});
+        }
+        if (version >= static_cast<std::uint32_t>(ApiVersion::V2) &&
+            forkVersion < bcos::protocol::EthBlockVersion::SHANGHAI)
+        {
+            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: forkchoiceUpdatedV2 requires a SHANGHAI-or-later chain "
+                "fork; chain EVM revision maps to " +
+                std::to_string(static_cast<int>(forkVersion))});
+        }
 
         // The payload SHAPE also follows the chain fork, not the request's method version
         // (geth's config.LatestFork(timestamp) analog): a CANCUN chain built through a V1/V2
@@ -881,12 +916,13 @@ private:
             // Isthmus payload shape (V4/V5, fed by forkchoiceUpdatedV3 on Karst): the
             // field must be present so getPayloadV5 -> newPayloadV4 round-trips.
             //
-            // TODO(C4 header fields): this is a zero PLACEHOLDER, not a computed value.
-            // On OP Stack withdrawalsRoot is the storage root of the L2ToL1MessagePasser
-            // predeploy and is what L1 withdrawal proofs are checked against, so until
-            // the real header wiring lands, validateExecutionPayload can only check that
-            // the field is present — never that its value is right, and a malicious CL
-            // submitting a zero root is indistinguishable from this node's own builds.
+            // TODO(C4 header fields): the served root is a placeholder, not a computed
+            // value. On OP Stack withdrawalsRoot is the storage root of the
+            // L2ToL1MessagePasser predeploy and is what L1 withdrawal proofs are checked
+            // against; until the real header wiring lands, validateExecutionPayload can
+            // only check the placeholder equals the value this node itself commits (both
+            // go through detail::withdrawalsRootFor), so a CL submitting the same
+            // placeholder round-trips while a foreign root is rejected.
             //
             // This is a KNOWN UNCONTAINED gap, not a test-harness-only one. The
             // [op_engine_rpc] guard in libinitializer/Initializer.cpp REQUIRES
@@ -903,10 +939,11 @@ private:
             // TestEthereumExecutorScheduler/engineServiceKarstServesZeroWithdrawalsRoot,
             // which has to be updated when the real value lands.
             //
-            // The served payload value and the hashed header value must agree (both the
-            // empty-trie root): a consumer rebuilding the header from the payload's
-            // withdrawalsRoot field must reproduce blockHash.
-            executionPayload.withdrawalsRoot = bcos::ledger::mpt::emptyRootHash();
+            // The served payload value and the hashed header value must agree (both go
+            // through withdrawalsRootFor): a consumer rebuilding the header from the
+            // payload's withdrawalsRoot field must reproduce blockHash.
+            executionPayload.withdrawalsRoot = bcos::engine::detail::withdrawalsRootFor(
+                executionPayload);
         }
 
         // Fill gasLimit from ledger config. baseFeePerGas is carried in the payload (currently

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -95,6 +95,9 @@ std::optional<std::string> validateExecutionPayload(
 /// L2ToL1MessagePasser storage root on Isthmus. Non-empty lists are rejected earlier in
 /// validatePayloadAttributes; the hashed header and the served ExecutionPayload both call
 /// this helper so they always carry the same 32 bytes.
+/// FOLLOW-UP (ywy F8): the Isthmus branch is a placeholder pending C4 — a real
+/// L2ToL1MessagePasser storage root would make locally built hashes diverge from op-geth
+/// after the first L1 message; until then newPayloadV4 rejects any root other than this.
 inline bcos::h256 withdrawalsRootFor(const ExecutionPayload& /*payload*/)
 {
     return bcos::ledger::mpt::emptyRootHash();
@@ -118,6 +121,9 @@ inline bcos::h256 withdrawalsRootFor(const ExecutionPayload& /*payload*/)
 ///    locally built payload and asserting VALID. Tightening the body half means
 ///    changing that contract first, which belongs with #5468 (the work that makes
 ///    externally supplied payload bodies verifiable at all).
+/// FOLLOW-UP (ywy F5): a full re-derivation of keccak256(rlp(header)) from the submitted
+/// payload on every newPayload is tracked in #5468; the cache-miss path still answers
+/// VALID without execute/store.
 ///
 /// extraData is in scope here because this change puts it into the block hash, so
 /// leaving it unchecked would leave a hash input unchecked.
@@ -580,58 +586,7 @@ private:
             }
         }
 
-        std::unique_lock lock(x_state);
-        auto parentKnown = request.executionPayload.parentHash == m_forkchoiceState.headBlockHash ||
-                           m_blockHashToPayloadId.contains(request.executionPayload.parentHash);
-        if (!parentKnown)
-        {
-            co_return makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
-        }
-
-        auto payloadIdIt = m_blockHashToPayloadId.find(request.executionPayload.blockHash);
         PayloadID payloadId;
-        if (payloadIdIt == m_blockHashToPayloadId.end())
-        {
-            payloadId = nextPayloadID();
-            m_blockHashToPayloadId.emplace(request.executionPayload.blockHash, payloadId);
-        }
-        else
-        {
-            payloadId = payloadIdIt->second;
-            // Local-build hit: the CL is handing back a payload this node built. op-geth
-            // needs no such comparison because it re-derives the block hash from the
-            // payload fields it received and answers INVALID_BLOCK_HASH when the two
-            // disagree (beacon/engine/types.go:287-288, reached from
-            // eth/catalyst/api.go:831). This service cannot re-derive an Ethereum block
-            // hash from an ExecutionPayload, so it compares against what it handed out
-            // instead. Without this a CL could alter the extraData, keep the blockHash it
-            // was given, and have the node commit its own (different) header while
-            // answering VALID — the submitted payload never checked. Only extraData is
-            // compared; the transaction list stays out of scope for the contract reason
-            // spelled out on compareWithBuiltPayload.
-            //
-            // Every cache hit is compared, including a re-submission of an already
-            // committed block (whose entry no longer carries a header). An honest
-            // idempotent re-submit is byte-identical and passes; gating on the header
-            // would let a second, altered submission of the same blockHash overwrite the
-            // cached payload and still be answered VALID. op-geth likewise re-derives the
-            // hash on every newPayload, committed or not.
-            //
-            // SCOPE: payloads this node did NOT build (lookup miss) are a separate,
-            // pre-existing gap — they are answered VALID without being executed or
-            // stored at all. That is tracked as #5468 and deliberately not addressed
-            // here.
-            if (auto builtIt = m_payloadCache.find(payloadId); builtIt != m_payloadCache.end())
-            {
-                if (auto mismatch = detail::compareWithBuiltPayload(
-                        request.executionPayload, builtIt->second.executionPayload))
-                {
-                    co_return makeStatus(
-                        PayloadValidationStatus::InvalidBlockHash, std::nullopt, mismatch);
-                }
-            }
-        }
-
         PayloadEntry entry{
             .version = version,
             .executionPayload = request.executionPayload,
@@ -648,77 +603,152 @@ private:
             entry.blobsBundle = BlobsBundleV1{};
         }
 
-        // If this payload was built locally (via updateForkchoice), commit the view's
-        // state changes to storage. Externally received payloads have no view to commit.
-        // NOTE: mergeView() exists (MultiLayerStorage.h) but is intentionally
-        // non-atomic (pushView and mergeBackStorage are independent critical
-        // sections). Using bare pushView here keeps the state change immediate;
-        // mergeBackStorage follows in the co_await block below.
-        auto it = m_payloadCache.find(payloadId);
-        if (it != m_payloadCache.end() && it->second.view)
+        // Commit I/O (ledger persist + state merge) is performed WITHOUT x_state held: a
+        // POSIX mutex must not be locked across a coroutine suspension point, because the
+        // resume can land on a different thread (the FCU path avoids the same hazard).
+        // The locked region below only validates, resolves and prepares; the co_awaits
+        // follow after the lock is released; the cache publish re-acquires it.
+        bool commitState = false;
+        bool persistLedger = false;
+        typename GlobalStateStorageType::MutableStorage prewriteStorage;
+        protocol::Block::Ptr persistBlock;
+        std::shared_ptr<protocol::ConstTransactions> blockTxs;
         {
-            m_globalStateStorage.get().pushView(std::move(*it->second.view));
-            if (m_ledger && it->second.header)
+            std::unique_lock lock(x_state);
+            auto parentKnown =
+                request.executionPayload.parentHash == m_forkchoiceState.headBlockHash ||
+                m_blockHashToPayloadId.contains(request.executionPayload.parentHash);
+            if (!parentKnown)
             {
-                // Locally built payload: persist the ledger block tables atomically with
-                // the state merge, using the same FIB-104 prewriteBlockToBuffer pattern the
-                // BaselineScheduler commit path uses. Without these rows a produced block is
-                // invisible to eth_getBlockByNumber / eth_getBlockByHash /
-                // eth_getTransactionReceipt and to ledger::getBlockHash / getCurrentBlockNumber.
-                typename GlobalStateStorageType::MutableStorage prewriteStorage;
-                auto block = m_blockFactory->createBlock();
-                block->setBlockHeader(it->second.header);
-                // Persist the block-level logsBloom (computed in buildPayload from the
-                // per-receipt blooms). Without it every block produced by this driver
-                // answers eth_getBlockByNumber with 256 zero bytes — the legacy
-                // BaselineScheduler commit path sets the block bloom before commit, so
-                // this restores parity with that path (eth_getLogs uses it as a filter).
-                auto const& bloom = it->second.executionPayload.logsBloom;
-                block->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
-                // Raw-only entries (forced transactions) carry no decoded form and are
-                // not modeled as ledger transactions until execution wiring lands; the
-                // persisted transaction list therefore matches the receipts list, which
-                // also only covers the executed (decoded) subset.
-                for (auto const& tx : it->second.executionPayload.transactions)
-                {
-                    if (tx.decoded)
-                    {
-                        block->appendTransaction(tx.decoded);
-                    }
-                }
-                for (auto const& receipt : it->second.receipts)
-                {
-                    block->appendReceipt(receipt);
-                }
-                auto blockTxs = std::make_shared<protocol::ConstTransactions>(
-                    it->second.executionPayload.transactions |
-                    ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
-                    ::ranges::views::transform([](auto const& tx) {
-                        return protocol::Transaction::ConstPtr(tx.decoded);
-                    }) |
-                    ::ranges::to<std::vector>());
-                co_await ledger::prewriteBlockToBuffer(*m_ledger, blockTxs, block, prewriteStorage);
-                co_await m_globalStateStorage.get().mergeBackStorage(prewriteStorage);
+                co_return makeStatus(PayloadValidationStatus::Syncing, std::nullopt, std::nullopt);
+            }
+
+            auto payloadIdIt = m_blockHashToPayloadId.find(request.executionPayload.blockHash);
+            if (payloadIdIt == m_blockHashToPayloadId.end())
+            {
+                payloadId = nextPayloadID();
+                m_blockHashToPayloadId.emplace(request.executionPayload.blockHash, payloadId);
             }
             else
             {
-                co_await m_globalStateStorage.get().mergeBackStorage();
+                payloadId = payloadIdIt->second;
+                // Local-build hit: the CL is handing back a payload this node built. op-geth
+                // needs no such comparison because it re-derives the block hash from the
+                // payload fields it received and answers INVALID_BLOCK_HASH when the two
+                // disagree (beacon/engine/types.go:287-288, reached from
+                // eth/catalyst/api.go:831). This service cannot re-derive an Ethereum block
+                // hash from an ExecutionPayload, so it compares against what it handed out
+                // instead. Without this a CL could alter the extraData, keep the blockHash it
+                // was given, and have the node commit its own (different) header while
+                // answering VALID — the submitted payload never checked. Only extraData is
+                // compared; the transaction list stays out of scope for the contract reason
+                // spelled out on compareWithBuiltPayload.
+                //
+                // Every cache hit is compared, including a re-submission of an already
+                // committed block (whose entry no longer carries a header). An honest
+                // idempotent re-submit is byte-identical and passes; gating on the header
+                // would let a second, altered submission of the same blockHash overwrite the
+                // cached payload and still be answered VALID. op-geth likewise re-derives the
+                // hash on every newPayload, committed or not.
+                //
+                // SCOPE: payloads this node did NOT build (lookup miss) are a separate,
+                // pre-existing gap — they are answered VALID without being executed or
+                // stored at all. That is tracked as #5468 and deliberately not addressed
+                // here.
+                if (auto builtIt = m_payloadCache.find(payloadId); builtIt != m_payloadCache.end())
+                {
+                    if (auto mismatch = detail::compareWithBuiltPayload(
+                            request.executionPayload, builtIt->second.executionPayload))
+                    {
+                        co_return makeStatus(PayloadValidationStatus::InvalidBlockHash,
+                            std::nullopt, mismatch);
+                    }
+                }
             }
+
+            // If this payload was built locally (via updateForkchoice), commit the view's
+            // state changes to storage. Externally received payloads have no view to commit.
+            // NOTE: mergeView() exists (MultiLayerStorage.h) but is intentionally
+            // non-atomic (pushView and mergeBackStorage are independent critical
+            // sections). Using bare pushView here keeps the state change immediate;
+            // mergeBackStorage follows in the co_await block below.
+            auto it = m_payloadCache.find(payloadId);
+            if (it != m_payloadCache.end() && it->second.view)
+            {
+                commitState = true;
+                m_globalStateStorage.get().pushView(std::move(*it->second.view));
+                if (m_ledger && it->second.header)
+                {
+                    // Locally built payload: persist the ledger block tables atomically with
+                    // the state merge, using the same FIB-104 prewriteBlockToBuffer pattern the
+                    // BaselineScheduler commit path uses. Without these rows a produced block
+                    // is invisible to eth_getBlockByNumber / eth_getBlockByHash /
+                    // eth_getTransactionReceipt and to ledger::getBlockHash /
+                    // getCurrentBlockNumber.
+                    persistLedger = true;
+                    persistBlock = m_blockFactory->createBlock();
+                    persistBlock->setBlockHeader(it->second.header);
+                    // Persist the block-level logsBloom (computed in buildPayload from the
+                    // per-receipt blooms). Without it every block produced by this driver
+                    // answers eth_getBlockByNumber with 256 zero bytes — the legacy
+                    // BaselineScheduler commit path sets the block bloom before commit, so
+                    // this restores parity with that path (eth_getLogs uses it as a filter).
+                    auto const& bloom = it->second.executionPayload.logsBloom;
+                    persistBlock->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+                    // Raw-only entries (forced transactions) carry no decoded form and are
+                    // not modeled as ledger transactions until execution wiring lands; the
+                    // persisted transaction list therefore matches the receipts list, which
+                    // also only covers the executed (decoded) subset.
+                    for (auto const& tx : it->second.executionPayload.transactions)
+                    {
+                        if (tx.decoded)
+                        {
+                            persistBlock->appendTransaction(tx.decoded);
+                        }
+                    }
+                    for (auto const& receipt : it->second.receipts)
+                    {
+                        persistBlock->appendReceipt(receipt);
+                    }
+                    blockTxs = std::make_shared<protocol::ConstTransactions>(
+                        it->second.executionPayload.transactions |
+                        ::ranges::views::filter([](auto const& tx) { return tx.decoded != nullptr; }) |
+                        ::ranges::views::transform([](auto const& tx) {
+                            return protocol::Transaction::ConstPtr(tx.decoded);
+                        }) |
+                        ::ranges::to<std::vector>());
+                }
+            }
+        }  // x_state released — safe to co_await below.
+
+        if (persistLedger)
+        {
+            co_await ledger::prewriteBlockToBuffer(
+                *m_ledger, blockTxs, persistBlock, prewriteStorage);
+            co_await m_globalStateStorage.get().mergeBackStorage(prewriteStorage);
+        }
+        else if (commitState)
+        {
+            co_await m_globalStateStorage.get().mergeBackStorage();
         }
 
-        m_payloadCache[payloadId] = std::move(entry);
+        {
+            std::unique_lock lock(x_state);
+            m_payloadCache[payloadId] = std::move(entry);
 
-        // Evict stale payload entries. A payload is only read between updateForkchoice /
-        // getPayload and newPayload, so once a block is committed its payloadId and
-        // blockHash are unreachable. The built-in single-node driver mints one new
-        // payloadId per block_interval tick, so without eviction both maps grow by one
-        // row per produced block and hold strong references to every transaction ever
-        // executed (unbounded memory over time). Keep only the just-committed block; the
-        // newPayload() parent check accepts the head hash directly, so dropping older
-        // blockHash rows is safe.
-        std::erase_if(m_blockHashToPayloadId,
-            [&](auto const& kv) { return kv.first != request.executionPayload.blockHash; });
-        std::erase_if(m_payloadCache, [&](auto const& kv) { return kv.first != payloadId; });
+            // Evict stale payload entries. A payload is only read between updateForkchoice /
+            // getPayload and newPayload, so once a block is committed its payloadId and
+            // blockHash are unreachable. The built-in single-node driver mints one new
+            // payloadId per block_interval tick, so without eviction both maps grow by one
+            // row per produced block and hold strong references to every transaction ever
+            // executed (unbounded memory over time). Keep only the just-committed block; the
+            // newPayload() parent check accepts the head hash directly, so dropping older
+            // blockHash rows is safe.
+            std::erase_if(m_blockHashToPayloadId, [&](auto const& kv) {
+                return kv.first != request.executionPayload.blockHash;
+            });
+            std::erase_if(m_payloadCache, [&](auto const& kv) { return kv.first != payloadId; });
+        }
 
         co_return makeStatus(
             PayloadValidationStatus::Valid, request.executionPayload.blockHash, std::nullopt);

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -830,17 +830,19 @@ private:
         // SHANGHAI the V2 attributes (withdrawals). An older FCU on a newer chain is a CL
         // configuration error — the hashed header would demand fields the attributes never
         // supplied — so fail loudly instead of hashing absent fields as explicit zeros.
+        // UnsupportedFork maps to -38005 (geth answers the same for this mismatch); a
+        // bare std::invalid_argument would surface as a -32603 InternalError.
         if (forkVersion >= bcos::protocol::EthBlockVersion::CANCUN &&
             !payloadAttributes.parentBeaconBlockRoot.has_value())
         {
-            BOOST_THROW_EXCEPTION(std::invalid_argument{
+            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
                 "EngineService: chain EVM revision requires the V3 payload attributes "
                 "(parentBeaconBlockRoot); forkchoiceUpdated must be called at version >= 3"});
         }
         if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI &&
             !payloadAttributes.withdrawals.has_value())
         {
-            BOOST_THROW_EXCEPTION(std::invalid_argument{
+            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
                 "EngineService: chain EVM revision requires the V2 payload attributes "
                 "(withdrawals); forkchoiceUpdated must be called at version >= 2"});
         }

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -126,6 +126,10 @@ bcos::protocol::EthBlockVersion ethBlockVersionFor(evmc_revision rev);
 // (setEthBlockVersion), and compute + inject its RLP hash. Throws on validation/hash failure.
 // @p forkVersion is the era the header is hashed as, derived from the chain's EVM revision
 // (see ethBlockVersionFor); it drives which fork-gated fields the header carries.
+// PRECONDITION: when forkVersion >= CANCUN, @p payload must carry blobGasUsed,
+// excessBlobGas and @p parentBeaconBlockRoot must be engaged (this function uses .value()
+// on them and would throw std::bad_optional_access otherwise). buildPayload guarantees the
+// precondition under the same forkVersion-derived gate; a direct caller must too.
 void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
     const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
     bcos::protocol::EthBlockVersion forkVersion);
@@ -722,7 +726,7 @@ private:
 
     bcos::task::Task<BuildPayloadResult> buildPayload(const ForkchoiceState& forkchoiceState,
         const PayloadAttributes& payloadAttributes, const PayloadID& payloadId,
-        std::uint32_t version, bcos::protocol::BlockNumber nextBlockNumber,
+        std::uint32_t version [[maybe_unused]], bcos::protocol::BlockNumber nextBlockNumber,
         std::vector<protocol::Transaction::Ptr> sealedTxs, ViewType& view) const
     {
         // Dual carrier: every sealed transaction is stored with both its raw EIP-2718
@@ -821,9 +825,23 @@ private:
         // in ledger config), not from the Engine API method version: a CL/op-geth verifier
         // rebuilds the header from the chain's fork rules, so the hashed era must match the
         // chain even when the API method version and the chain progress independently.
-        auto forkVersion = bcos::engine::detail::ethBlockVersionFor(
-            ledgerConfig.evmcRevisionForBlock(nextBlockNumber)
-                .value_or(ledger::EVMC_REVISION_DEFAULT));
+        //
+        // A missing revision must FAIL CLOSED rather than default to the compile-time
+        // latest (EVMC_REVISION_DEFAULT = OSAKA -> PRAGUE, which would stamp requestsHash
+        // into every RLP hash): hashing under an assumed fork the chain never configured
+        // is exactly the silent-divergence failure this chain-derived selection exists to
+        // prevent. A v2 chain always persists its revision at genesis (Initializer refuses
+        // to boot one without it), so reaching this throw means a misconfigured chain.
+        auto chainRevision = ledgerConfig.evmcRevisionForBlock(nextBlockNumber);
+        if (!chainRevision.has_value())
+        {
+            BOOST_THROW_EXCEPTION(UnsupportedFork{} << bcos::errinfo_comment{
+                "EngineService: no on-chain EVM revision configured for block " +
+                std::to_string(nextBlockNumber) +
+                "; cannot derive the Eth header fork era (a v2 chain persists evmc_revision "
+                "at genesis)"});
+        }
+        auto forkVersion = bcos::engine::detail::ethBlockVersionFor(*chainRevision);
 
         // The method version's attribute shape must be able to express the chain fork's
         // header fields: CANCUN requires the V3 attributes (parentBeaconBlockRoot),

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -32,6 +32,7 @@
 #include "bcos-framework/transaction-executor/TransactionExecutor.h"
 #include "bcos-framework/transaction-scheduler/TransactionScheduler.h"
 #include "bcos-ledger/LedgerMethods.h"
+#include <bcos-ledger/mpt/Constants.h>
 #include "bcos-task/Task.h"
 #include "bcos-utilities/Bloom.h"
 #include "bcos-utilities/BoostLog.h"
@@ -112,6 +113,18 @@ std::optional<std::string> validateExecutionPayload(
 /// leaving it unchecked would leave a hash input unchecked.
 std::optional<std::string> compareWithBuiltPayload(
     const ExecutionPayload& submitted, const ExecutionPayload& built);
+
+// Map an Engine API version to the Ethereum fork era of the blocks it produces.
+bcos::protocol::EthBlockVersion ethBlockVersionFor(std::uint32_t version);
+
+// Fill the Ethereum header fields on a locally built header, mark it as an Eth header
+// (setEthBlockVersion), and compute + inject its RLP hash. Throws on validation/hash failure.
+void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
+    const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
+    std::uint32_t version);
+
+// The internal timestamp carrier is milliseconds (Types.h); the Eth header stores seconds.
+inline constexpr std::uint64_t c_millisPerSecond = 1000;
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -836,11 +849,12 @@ private:
         co_await ledger::getLedgerConfig(view, ledgerConfig, nextBlockNumber - 1, *m_blockFactory);
         auto blockVersion = ledgerConfig.compatibilityVersion();
 
-        // Fill gasLimit from ledger config (FISCO-BCOS does not use EIP-1559 baseFeePerGas,
-        // and logsBloom is not part of BlockHeader hash computation in FISCO-BCOS).
+        // Fill gasLimit from ledger config. baseFeePerGas is carried in the payload (currently
+        // 0 — FISCO-BCOS does not compute a real EIP-1559 base fee yet) and copied onto the Eth
+        // header by finalizeEthBlockHeader.
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
 
-        // Real EVM execution: execute transactions and compute real hashes.
+        // Execute transactions (if any) and finalize the Eth header with its RLP hash.
         if (executionPayload.transactions.empty())
         {
             auto emptyHeader = m_blockFactory->blockHeaderFactory()->createBlockHeader();
@@ -849,7 +863,11 @@ private:
             emptyHeader->setParentInfo(parentInfo);
             emptyHeader->setNumber(nextBlockNumber);
             emptyHeader->setVersion(blockVersion);
-            emptyHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
+            // Eth headers carry the timestamp in SECONDS (Types.h keeps the internal carrier in
+            // milliseconds); convert once here since an empty block never passes through the
+            // executor's millisecond-consuming path.
+            emptyHeader->setTimestamp(static_cast<int64_t>(
+                payloadAttributes.timestamp / detail::c_millisPerSecond));
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
             emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -857,12 +875,15 @@ private:
             // (bcos-tars-protocol/impl/TarsHashable.h).
             emptyHeader->setExtraData(std::move(extraData));
             emptyHeader->setStateRoot(co_await calculateStateRoot(view, emptyHeader->version()));
-            emptyHeader->setReceiptsRoot(h256{});
-            emptyHeader->setTxsRoot(h256{});
+            // An empty block's transaction/receipt tries are the canonical empty-trie root, not
+            // the all-zero hash (validateHeader rejects a zero receiptsRoot/txsRoot).
+            emptyHeader->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
+            emptyHeader->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
             emptyHeader->setGasUsed(0);
-            emptyHeader->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
+            detail::finalizeEthBlockHeader(
+                *emptyHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, version);
             executionPayload.stateRoot = emptyHeader->stateRoot();
-            executionPayload.receiptsRoot = h256{};
+            executionPayload.receiptsRoot = bcos::ledger::mpt::emptyRootHash();
             executionPayload.gasUsed = 0;
             executionPayload.blockHash = emptyHeader->hash();
             co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
@@ -903,8 +924,9 @@ private:
         // Step 2d: Compute transaction root (Merkle over tx hashes)
         // TODO: Use scheduler_v1::calculateTransactionRoot from BaselineScheduler.h
         // once MPTStorage is available. The current tx->hash() call lacks exception
-        // handling for malformed transactions.
-        h256 txRoot;
+        // handling for malformed transactions. An empty transaction list maps to the
+        // canonical empty-trie root (validateHeader rejects an all-zero txsRoot).
+        h256 txRoot = bcos::ledger::mpt::emptyRootHash();
         {
             auto& hashImpl = *m_blockFactory->cryptoSuite()->hashImpl();
             auto hasher = hashImpl.hasher();
@@ -929,8 +951,10 @@ private:
             }
         }
 
-        // Step 2e: Compute receipt root (Merkle over receipt hashes)
-        h256 receiptRoot;
+        // Step 2e: Compute receipt root (Merkle over receipt hashes). An empty receipt list
+        // maps to the canonical empty-trie root (validateHeader rejects an all-zero
+        // receiptsRoot).
+        h256 receiptRoot = bcos::ledger::mpt::emptyRootHash();
         {
             // Validate receipts are non-null before computing hashes
             if (::ranges::any_of(receipts, [](auto& r) { return !r; }))
@@ -976,12 +1000,21 @@ private:
         // Step 2g: Compute state root (MPT over state storage)
         h256 stateRoot = co_await calculateStateRoot(view, blockHeader->version());
 
-        // Step 2h: Set computed values in the block header and calculate block hash
+        // Step 2h: Set computed values in the block header and calculate the block hash.
+        // The executor consumed the header timestamp in milliseconds; the Eth header stores it in
+        // seconds, so switch units after execution and before the RLP hash is computed.
         blockHeader->setStateRoot(stateRoot);
         blockHeader->setReceiptsRoot(receiptRoot);
         blockHeader->setTxsRoot(txRoot);
         blockHeader->setGasUsed(totalGasUsed);
-        blockHeader->calculateHash(*m_blockFactory->cryptoSuite()->hashImpl());
+        blockHeader->setTimestamp(static_cast<int64_t>(
+            payloadAttributes.timestamp / detail::c_millisPerSecond));
+
+        // Copy the block bloom onto the payload before finalizeEthBlockHeader, which reads it
+        // onto the header (the header's logsBloom is part of the RLP hash).
+        executionPayload.logsBloom = logsBloom;
+        detail::finalizeEthBlockHeader(
+            *blockHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, version);
 
         // Step 2i: Fill the execution payload with real values
         executionPayload.stateRoot = stateRoot;
@@ -989,7 +1022,6 @@ private:
         executionPayload.gasUsed = totalGasUsed;
         executionPayload.blockHash = blockHeader->hash();
         executionPayload.gasLimit = std::get<0>(ledgerConfig.gasLimit());
-        executionPayload.logsBloom = logsBloom;
 
         co_return BuildPayloadResult{.executionPayload = std::move(executionPayload),
             .header = std::move(blockHeader),

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -114,14 +114,21 @@ std::optional<std::string> validateExecutionPayload(
 std::optional<std::string> compareWithBuiltPayload(
     const ExecutionPayload& submitted, const ExecutionPayload& built);
 
-// Map an Engine API version to the Ethereum fork era of the blocks it produces.
-bcos::protocol::EthBlockVersion ethBlockVersionFor(std::uint32_t version);
+// Map the chain's EVM revision (the per-block fork schedule from ledger config, i.e. the
+// geth config.LatestFork(timestamp) analog) to the Ethereum fork era the block header is
+// hashed as. The header fork must come from the CHAIN, not from the Engine API method
+// version — a CL/op-geth verifier recomputes the header hash from the chain's fork rules,
+// so a method-version-derived era would disagree with it once the API window and the chain
+// progress independently.
+bcos::protocol::EthBlockVersion ethBlockVersionFor(evmc_revision rev);
 
 // Fill the Ethereum header fields on a locally built header, mark it as an Eth header
 // (setEthBlockVersion), and compute + inject its RLP hash. Throws on validation/hash failure.
+// @p forkVersion is the era the header is hashed as, derived from the chain's EVM revision
+// (see ethBlockVersionFor); it drives which fork-gated fields the header carries.
 void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
     const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
-    std::uint32_t version);
+    bcos::protocol::EthBlockVersion forkVersion);
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -804,12 +811,50 @@ private:
             .withdrawalsRoot = std::nullopt,
         };
 
-        if (version >= static_cast<std::uint32_t>(ApiVersion::V2))
+        // Step 2a: Get LedgerConfig via storage-based LedgerMethods
+        // Uses the parent block number since system configs are effective up to the parent
+        ledger::LedgerConfig ledgerConfig;
+        co_await ledger::getLedgerConfig(view, ledgerConfig, nextBlockNumber - 1, *m_blockFactory);
+        auto blockVersion = ledgerConfig.compatibilityVersion();
+
+        // Header fork era comes from the chain's EVM revision (the per-block fork schedule
+        // in ledger config), not from the Engine API method version: a CL/op-geth verifier
+        // rebuilds the header from the chain's fork rules, so the hashed era must match the
+        // chain even when the API method version and the chain progress independently.
+        auto forkVersion = bcos::engine::detail::ethBlockVersionFor(
+            ledgerConfig.evmcRevisionForBlock(nextBlockNumber)
+                .value_or(ledger::EVMC_REVISION_DEFAULT));
+
+        // The method version's attribute shape must be able to express the chain fork's
+        // header fields: CANCUN requires the V3 attributes (parentBeaconBlockRoot),
+        // SHANGHAI the V2 attributes (withdrawals). An older FCU on a newer chain is a CL
+        // configuration error — the hashed header would demand fields the attributes never
+        // supplied — so fail loudly instead of hashing absent fields as explicit zeros.
+        if (forkVersion >= bcos::protocol::EthBlockVersion::CANCUN &&
+            !payloadAttributes.parentBeaconBlockRoot.has_value())
+        {
+            BOOST_THROW_EXCEPTION(std::invalid_argument{
+                "EngineService: chain EVM revision requires the V3 payload attributes "
+                "(parentBeaconBlockRoot); forkchoiceUpdated must be called at version >= 3"});
+        }
+        if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI &&
+            !payloadAttributes.withdrawals.has_value())
+        {
+            BOOST_THROW_EXCEPTION(std::invalid_argument{
+                "EngineService: chain EVM revision requires the V2 payload attributes "
+                "(withdrawals); forkchoiceUpdated must be called at version >= 2"});
+        }
+
+        // The payload SHAPE also follows the chain fork, not the request's method version
+        // (geth's config.LatestFork(timestamp) analog): a CANCUN chain built through a V1/V2
+        // forkchoiceUpdated still yields a CANCUN-shaped payload, so the served field set
+        // always matches the fork the header was hashed as.
+        if (forkVersion >= bcos::protocol::EthBlockVersion::SHANGHAI)
         {
             executionPayload.withdrawals =
                 payloadAttributes.withdrawals.value_or(std::vector<WithdrawalV1>{});
         }
-        if (version >= static_cast<std::uint32_t>(ApiVersion::V3))
+        if (forkVersion >= bcos::protocol::EthBlockVersion::CANCUN)
         {
             executionPayload.blobGasUsed = u256(0);
             executionPayload.excessBlobGas = u256(0);
@@ -834,17 +879,15 @@ private:
             // here, getPayloadV5 serializes it, and newPayloadV4 accepts it on presence
             // alone. Until C4 computes and verifies the real L2ToL1MessagePasser storage
             // root, no L1 withdrawal proof may be taken against a root produced by this
-            // node. The v2 instantiation serving the zero root is pinned by
+            // node. The v2 instantiation serving the empty-trie root is pinned by
             // TestEthereumExecutorScheduler/engineServiceKarstServesZeroWithdrawalsRoot,
             // which has to be updated when the real value lands.
-            executionPayload.withdrawalsRoot = h256{};
+            //
+            // The served payload value and the hashed header value must agree (both the
+            // empty-trie root): a consumer rebuilding the header from the payload's
+            // withdrawalsRoot field must reproduce blockHash.
+            executionPayload.withdrawalsRoot = bcos::ledger::mpt::emptyRootHash();
         }
-
-        // Step 2a: Get LedgerConfig via storage-based LedgerMethods
-        // Uses the parent block number since system configs are effective up to the parent
-        ledger::LedgerConfig ledgerConfig;
-        co_await ledger::getLedgerConfig(view, ledgerConfig, nextBlockNumber - 1, *m_blockFactory);
-        auto blockVersion = ledgerConfig.compatibilityVersion();
 
         // Fill gasLimit from ledger config. baseFeePerGas is carried in the payload (currently
         // 0 — FISCO-BCOS does not compute a real EIP-1559 base fee yet) and copied onto the Eth
@@ -877,7 +920,8 @@ private:
             emptyHeader->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
             emptyHeader->setGasUsed(0);
             detail::finalizeEthBlockHeader(
-                *emptyHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, version);
+                *emptyHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot,
+                forkVersion);
             executionPayload.stateRoot = emptyHeader->stateRoot();
             executionPayload.receiptsRoot = bcos::ledger::mpt::emptyRootHash();
             executionPayload.gasUsed = 0;
@@ -1010,7 +1054,7 @@ private:
         // onto the header (the header's logsBloom is part of the RLP hash).
         executionPayload.logsBloom = logsBloom;
         detail::finalizeEthBlockHeader(
-            *blockHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, version);
+            *blockHeader, executionPayload, payloadAttributes.parentBeaconBlockRoot, forkVersion);
 
         // Step 2i: Fill the execution payload with real values
         executionPayload.stateRoot = stateRoot;

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -867,7 +867,7 @@ private:
             // milliseconds); convert once here since an empty block never passes through the
             // executor's millisecond-consuming path.
             emptyHeader->setTimestamp(static_cast<int64_t>(
-                payloadAttributes.timestamp / detail::c_millisPerSecond));
+                payloadAttributes.timestamp * detail::c_millisPerSecond));
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
             emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -898,7 +898,8 @@ private:
         blockHeader->setParentInfo(parentInfo);
         blockHeader->setNumber(nextBlockNumber);
         blockHeader->setVersion(blockVersion);
-        blockHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
+        blockHeader->setTimestamp(static_cast<int64_t>(
+            payloadAttributes.timestamp * detail::c_millisPerSecond));
         blockHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -1007,8 +1008,6 @@ private:
         blockHeader->setReceiptsRoot(receiptRoot);
         blockHeader->setTxsRoot(txRoot);
         blockHeader->setGasUsed(totalGasUsed);
-        blockHeader->setTimestamp(static_cast<int64_t>(
-            payloadAttributes.timestamp / detail::c_millisPerSecond));
 
         // Copy the block bloom onto the payload before finalizeEthBlockHeader, which reads it
         // onto the header (the header's logsBloom is part of the RLP hash).

--- a/engine/bcos-engine/EngineServiceImpl.h
+++ b/engine/bcos-engine/EngineServiceImpl.h
@@ -122,9 +122,6 @@ bcos::protocol::EthBlockVersion ethBlockVersionFor(std::uint32_t version);
 void finalizeEthBlockHeader(bcos::protocol::BlockHeader& header,
     const ExecutionPayload& payload, std::optional<bcos::h256> parentBeaconBlockRoot,
     std::uint32_t version);
-
-// The internal timestamp carrier is milliseconds (Types.h); the Eth header stores seconds.
-inline constexpr std::uint64_t c_millisPerSecond = 1000;
 }  // namespace detail
 
 template <class MemPoolType, class GlobalStateStorageType, class ExecutorType, class SchedulerType>
@@ -863,11 +860,10 @@ private:
             emptyHeader->setParentInfo(parentInfo);
             emptyHeader->setNumber(nextBlockNumber);
             emptyHeader->setVersion(blockVersion);
-            // Eth headers carry the timestamp in SECONDS (Types.h keeps the internal carrier in
-            // milliseconds); convert once here since an empty block never passes through the
-            // executor's millisecond-consuming path.
-            emptyHeader->setTimestamp(static_cast<int64_t>(
-                payloadAttributes.timestamp * detail::c_millisPerSecond));
+            // BlockHeader stores the timestamp in milliseconds (matching the internal carrier
+            // and the executor's ms-consuming path); EthBlockHeader converts to seconds at the
+            // RLP boundary.
+            emptyHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
             emptyHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
             emptyHeader->setPrevRandao(payloadAttributes.prevRandao);
             emptyHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -898,8 +894,9 @@ private:
         blockHeader->setParentInfo(parentInfo);
         blockHeader->setNumber(nextBlockNumber);
         blockHeader->setVersion(blockVersion);
-        blockHeader->setTimestamp(static_cast<int64_t>(
-            payloadAttributes.timestamp * detail::c_millisPerSecond));
+        // BlockHeader stores milliseconds; EthBlockHeader converts to seconds at the RLP
+        // boundary (the executor consumes this header in milliseconds).
+        blockHeader->setTimestamp(static_cast<int64_t>(payloadAttributes.timestamp));
         blockHeader->setCoinbase(payloadAttributes.suggestedFeeRecipient);
         blockHeader->setPrevRandao(payloadAttributes.prevRandao);
         blockHeader->setGasLimit(u256(std::get<0>(ledgerConfig.gasLimit())));
@@ -1002,8 +999,8 @@ private:
         h256 stateRoot = co_await calculateStateRoot(view, blockHeader->version());
 
         // Step 2h: Set computed values in the block header and calculate the block hash.
-        // The executor consumed the header timestamp in milliseconds; the Eth header stores it in
-        // seconds, so switch units after execution and before the RLP hash is computed.
+        // The header timestamp stays in milliseconds throughout (the executor consumed it in
+        // milliseconds above); EthBlockHeader converts to seconds at the RLP boundary.
         blockHeader->setStateRoot(stateRoot);
         blockHeader->setReceiptsRoot(receiptRoot);
         blockHeader->setTxsRoot(txRoot);

--- a/engine/test/CMakeLists.txt
+++ b/engine/test/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(${TEST_BINARY_NAME} PRIVATE . ${CMAKE_SOURCE_DIR})
 
 find_package(Boost REQUIRED unit_test_framework)
 
-target_link_libraries(${TEST_BINARY_NAME} PUBLIC engine mempool protocol-tars Boost::unit_test_framework)
+target_link_libraries(${TEST_BINARY_NAME} PUBLIC engine mempool protocol-tars rlp-protocol Boost::unit_test_framework)
 set_source_files_properties("unittests/main/main.cpp" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
 set_target_properties(${TEST_BINARY_NAME} PROPERTIES UNITY_BUILD "ON")
 config_test_cases("" "${SOURCES}" ${TEST_BINARY_NAME} "" "")

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -1455,7 +1455,7 @@ BOOST_AUTO_TEST_CASE(per_method_version_windows_and_unknown_payload)
 
 /// Build a BlockHeader carrying every field EthBlockHeader::validateHeader requires for a
 /// CANCUN header, so finalizeEthBlockHeader's calculateRLPHash succeeds.
-static bcos::protocol::BlockHeader::Ptr makeValidCuncunHeader(
+static bcos::protocol::BlockHeader::Ptr makeValidCancunHeader(
     bcos::protocol::BlockFactory::Ptr blockFactory, bcos::crypto::HashType parentHash)
 {
     auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
@@ -1489,9 +1489,11 @@ BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEngineVersions)
         static_cast<int>(EthBlockVersion::SHANGHAI));
     BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(3)),
         static_cast<int>(EthBlockVersion::CANCUN));
-    // V4+ falls back to the newest known fork.
+    // V4 explicitly maps to the newest known fork.
     BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(4)),
         static_cast<int>(EthBlockVersion::PRAGUE));
+    // Versions beyond the known fork window fail loudly instead of silently mapping to PRAGUE.
+    BOOST_CHECK_THROW(bcos::engine::detail::ethBlockVersionFor(5), UnsupportedEngineApiVersion);
 }
 
 BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
@@ -1500,7 +1502,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
         bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
     auto parentHash = bcos::crypto::HashType(
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-    auto header = makeValidCuncunHeader(blockFactory, parentHash);
+    auto header = makeValidCancunHeader(blockFactory, parentHash);
 
     bcos::engine::ExecutionPayload payload;
     payload.logsBloom = bcos::Bloom{};
@@ -1547,7 +1549,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
 
     // V1/LONDON: baseFee present, no withdrawalsRoot / blob fields / beacon root.
     {
-        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
         bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 1);
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::LONDON);
         BOOST_REQUIRE(header->baseFee().has_value());
@@ -1559,7 +1561,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
 
     // V2/SHANGHAI: + withdrawalsRoot, no blob fields / beacon root.
     {
-        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
         bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 2);
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::SHANGHAI);
         BOOST_REQUIRE(header->withdrawalsRoot().has_value());
@@ -1570,7 +1572,7 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
 
     // V3/CANCUN: everything present.
     {
-        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
         auto beaconRoot = bcos::h256(
             "3333333333333333333333333333333333333333333333333333333333333333");
         payload.blobGasUsed = bcos::u256(0);
@@ -1581,6 +1583,23 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
         BOOST_REQUIRE(header->blobGasUsed().has_value());
         BOOST_REQUIRE(header->excessBlobGas().has_value());
         BOOST_REQUIRE(header->parentBeaconBlockRoot().has_value());
+    }
+
+    // V4/PRAGUE: everything plus the EIP-7685 empty requests hash — finalize must not throw
+    // (regression: PRAGUE previously produced a header that failed validateHeader).
+    {
+        auto header = makeValidCancunHeader(blockFactory, parentHash);
+        auto beaconRoot = bcos::h256(
+            "3333333333333333333333333333333333333333333333333333333333333333");
+        payload.blobGasUsed = bcos::u256(0);
+        payload.excessBlobGas = bcos::u256(0);
+        BOOST_CHECK_NO_THROW(bcos::engine::detail::finalizeEthBlockHeader(
+            *header, payload, beaconRoot, 4));
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::PRAGUE);
+        BOOST_REQUIRE(header->requestsHash().has_value());
+        BOOST_CHECK_EQUAL(header->requestsHash()->hex(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+        BOOST_CHECK_NE(header->hash(), bcos::crypto::HashType{});
     }
 }
 

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -168,6 +168,20 @@ struct RealGlobalStateStorageFixture
     RealGlobalCheckpointBackend checkpointBackend{backendStorage};
     RealGlobalStateStorage storage{checkpointBackend};
 
+    explicit RealGlobalStateStorageFixture(evmc_revision rev = EVMC_CANCUN)
+    {
+        // The Engine service runs only on executor_version=2 with an explicit EVMC
+        // revision. The default models the "Karst" chain (CANCUN) these tests mostly
+        // drive; tests that exercise older FCU method versions (V1/V2) pass SHANGHAI so
+        // the attribute shape the request can express matches the chain fork. Without an
+        // explicit revision, buildPayload's header-fork derivation would fall back to the
+        // compile-time default (OSAKA -> PRAGUE) instead of the intended era.
+        writeSysConfig(
+            magic_enum::enum_name(ledger::SystemConfig::executor_version),
+            std::to_string(ledger::ETHEREUM_EXECUTOR_VERSION));
+        writeSysConfig(ledger::SYSTEM_KEY_EVMC_REVISION, ledger::encodeEVMCRevisionConfig(rev, {}));
+    }
+
     void setBlockNumber(const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
     {
         task::syncWait(writeBlockNumberToStorage(backendStorage, blockHash, blockNumber));
@@ -182,6 +196,16 @@ struct RealGlobalStateStorageFixture
         std::copy_n(sender.begin(), std::min(sender.size(), sizeof(addr.bytes)), addr.bytes);
         ledger::account::EVMAccount account{backendStorage, addr, false};
         task::syncWait(account.setNonce(std::move(nonce)));
+    }
+
+private:
+    void writeSysConfig(std::string_view key, std::string value)
+    {
+        storage::Entry entry;
+        entry.set(bcos::storage::serialize::encode(
+            ledger::SystemConfigEntry{std::move(value), 0}));
+        task::syncWait(storage2::writeOne(backendStorage,
+            bcos::executor_v1::StateKey{ledger::SYS_CONFIG, key}, std::move(entry)));
     }
 };
 
@@ -438,7 +462,10 @@ BOOST_AUTO_TEST_CASE(exchange_capabilities_returns_supported_methods)
 BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_payload)
 {
     MemPoolImpl memPool;
-    RealGlobalStateStorageFixture globalStateStorageFixture;
+    // A SHANGHAI chain: the V2 forkchoiceUpdated attribute shape (withdrawals, no blob
+    // fields) matches this era; on the CANCUN default fixture the same request is rightly
+    // rejected for lacking parentBeaconBlockRoot.
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
     auto forkchoiceState = makeForkchoiceState();
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
         c_initialBlockNumber, c_initialBlockNumber);
@@ -808,14 +835,15 @@ BOOST_AUTO_TEST_CASE(payload_carries_parent_beacon_block_root_and_withdrawals_ro
     BOOST_REQUIRE(result.payloadId.has_value());
 
     // buildPayload stored the attributes' beacon root in the payload cache; getPayload
-    // must return it. withdrawalsRoot carries the zero placeholder on V3+ builds (B4:
-    // required for the getPayloadV5 -> newPayloadV4 round trip) until real-value header
-    // wiring lands.
+    // must return it. withdrawalsRoot carries the empty-trie root placeholder on
+    // SHANGHAI+ chains (B4: required for the getPayloadV5 -> newPayloadV4 round trip) until
+    // real-value header wiring lands — and the served value agrees with the hashed header.
     auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
     BOOST_REQUIRE(payload->parentBeaconBlockRoot.has_value());
     BOOST_CHECK_EQUAL(*payload->parentBeaconBlockRoot, *payloadAttributes.parentBeaconBlockRoot);
     BOOST_REQUIRE(payload->executionPayload.withdrawalsRoot.has_value());
-    BOOST_CHECK_EQUAL(*payload->executionPayload.withdrawalsRoot, h256{});
+    BOOST_CHECK_EQUAL(
+        *payload->executionPayload.withdrawalsRoot, bcos::ledger::mpt::emptyRootHash());
 
     // newPayload carries both fields back in; the committed cache entry keeps them.
     // This exercises the structure layer only: withdrawalsRoot is set directly on the
@@ -844,7 +872,8 @@ BOOST_AUTO_TEST_CASE(payload_carries_parent_beacon_block_root_and_withdrawals_ro
 BOOST_AUTO_TEST_CASE(build_payload_reassembles_web3_raw_bytes)
 {
     MemPoolImpl memPool;
-    RealGlobalStateStorageFixture globalStateStorageFixture;
+    // A SHANGHAI chain, matching the V2 forkchoiceUpdated attribute shape used below.
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
     auto forkchoiceState = makeForkchoiceState();
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
         c_initialBlockNumber, c_initialBlockNumber);
@@ -1121,7 +1150,8 @@ BOOST_AUTO_TEST_CASE(no_tx_pool_true_excludes_mempool_transactions)
 BOOST_AUTO_TEST_CASE(build_payload_aggregates_receipt_blooms)
 {
     MemPoolImpl memPool;
-    RealGlobalStateStorageFixture globalStateStorageFixture;
+    // A SHANGHAI chain, matching the V2 forkchoiceUpdated attribute shape used below.
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
     auto forkchoiceState = makeForkchoiceState();
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
         c_initialBlockNumber, c_initialBlockNumber);
@@ -1347,16 +1377,20 @@ BOOST_AUTO_TEST_CASE(new_payload_rejects_malformed_extra_data_shape)
 BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)
 {
     MemPoolImpl memPool;
-    RealGlobalStateStorageFixture globalStateStorageFixture;
+    // A SHANGHAI chain, matching the V2 forkchoiceUpdated attribute shape used below (the
+    // CANCUN default fixture would reject the request for lacking parentBeaconBlockRoot).
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
     auto forkchoiceState = makeForkchoiceState();
     setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
         c_initialBlockNumber, c_initialBlockNumber);
     auto payloadAttributes = makePayloadAttributesV2();
     auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
 
-    // A V2 build carries neither blobGasUsed/excessBlobGas nor withdrawalsRoot, so
-    // serializing it in the V5 response shape would fabricate them. op-geth's GetPayloadV5
-    // allows only PayloadV3 builds and answers UnsupportedFork otherwise; so does this.
+    // A V2-tagged build on a SHANGHAI chain carries withdrawals but no blob fields or
+    // withdrawalsRoot; the V5 service window is keyed on the build's version tag, and
+    // op-geth's GetPayloadV5 admits only PayloadV3 builds — it answers UnsupportedFork
+    // otherwise; so does this. Serializing a V1/V2-tagged entry in the V5 response shape
+    // would fabricate fields the tag does not commit to.
     auto result =
         task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));
     BOOST_REQUIRE(result.payloadId.has_value());
@@ -1485,20 +1519,24 @@ static bcos::protocol::BlockHeader::Ptr makeValidCancunHeader(
     return header;
 }
 
-BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEngineVersions)
+BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEvmRevisions)
 {
     using bcos::protocol::EthBlockVersion;
-    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(1)),
+    // Pre-London revisions cannot occur on a PoS/Engine path; they map to the minimal
+    // post-merge shape (LONDON).
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_LONDON)),
         static_cast<int>(EthBlockVersion::LONDON));
-    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(2)),
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_PARIS)),
+        static_cast<int>(EthBlockVersion::LONDON));
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_SHANGHAI)),
         static_cast<int>(EthBlockVersion::SHANGHAI));
-    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(3)),
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_CANCUN)),
         static_cast<int>(EthBlockVersion::CANCUN));
-    // V4 explicitly maps to the newest known fork.
-    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(4)),
+    // PRAGUE and OSAKA both hash as PRAGUE (OSAKA's header RLP adds no new fields).
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_PRAGUE)),
         static_cast<int>(EthBlockVersion::PRAGUE));
-    // Versions beyond the known fork window fail loudly instead of silently mapping to PRAGUE.
-    BOOST_CHECK_THROW(bcos::engine::detail::ethBlockVersionFor(5), UnsupportedEngineApiVersion);
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_OSAKA)),
+        static_cast<int>(EthBlockVersion::PRAGUE));
 }
 
 BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
@@ -1517,7 +1555,8 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
 
     auto beaconRoot = bcos::h256(
         "3333333333333333333333333333333333333333333333333333333333333333");
-    bcos::engine::detail::finalizeEthBlockHeader(*header, payload, beaconRoot, 3);
+    bcos::engine::detail::finalizeEthBlockHeader(
+        *header, payload, beaconRoot, bcos::protocol::EthBlockVersion::CANCUN);
 
     // The header is marked as an Eth CANCUN header.
     BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::CANCUN);
@@ -1555,7 +1594,8 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
     // V1/LONDON: baseFee present, no withdrawalsRoot / blob fields / beacon root.
     {
         auto header = makeValidCancunHeader(blockFactory, parentHash);
-        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 1);
+        bcos::engine::detail::finalizeEthBlockHeader(
+            *header, payload, std::nullopt, bcos::protocol::EthBlockVersion::LONDON);
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::LONDON);
         BOOST_REQUIRE(header->baseFee().has_value());
         BOOST_CHECK(!header->withdrawalsRoot().has_value());
@@ -1567,7 +1607,8 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
     // V2/SHANGHAI: + withdrawalsRoot, no blob fields / beacon root.
     {
         auto header = makeValidCancunHeader(blockFactory, parentHash);
-        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 2);
+        bcos::engine::detail::finalizeEthBlockHeader(
+            *header, payload, std::nullopt, bcos::protocol::EthBlockVersion::SHANGHAI);
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::SHANGHAI);
         BOOST_REQUIRE(header->withdrawalsRoot().has_value());
         BOOST_CHECK(!header->blobGasUsed().has_value());
@@ -1582,7 +1623,8 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
             "3333333333333333333333333333333333333333333333333333333333333333");
         payload.blobGasUsed = bcos::u256(0);
         payload.excessBlobGas = bcos::u256(0);
-        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, beaconRoot, 3);
+        bcos::engine::detail::finalizeEthBlockHeader(
+            *header, payload, beaconRoot, bcos::protocol::EthBlockVersion::CANCUN);
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::CANCUN);
         BOOST_REQUIRE(header->withdrawalsRoot().has_value());
         BOOST_REQUIRE(header->blobGasUsed().has_value());
@@ -1598,8 +1640,8 @@ BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
             "3333333333333333333333333333333333333333333333333333333333333333");
         payload.blobGasUsed = bcos::u256(0);
         payload.excessBlobGas = bcos::u256(0);
-        BOOST_CHECK_NO_THROW(bcos::engine::detail::finalizeEthBlockHeader(
-            *header, payload, beaconRoot, 4));
+        BOOST_CHECK_NO_THROW(bcos::engine::detail::finalizeEthBlockHeader(*header, payload,
+            beaconRoot, bcos::protocol::EthBlockVersion::PRAGUE));
         BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::PRAGUE);
         BOOST_REQUIRE(header->requestsHash().has_value());
         BOOST_CHECK_EQUAL(header->requestsHash()->hex(),

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -5,6 +5,7 @@
 
 #include "engine/bcos-engine/EngineServiceImpl.h"
 
+#include <bcos-rlp-protocol/EthBlockHeader.h>
 #include <bcos-codec/rlp/Common.h>
 #include <bcos-codec/rlp/RLPEncode.h>
 #include <bcos-concepts/ByteBuffer.h>
@@ -32,7 +33,10 @@ using namespace bcos::engine;
 
 namespace
 {
-constexpr std::uint64_t c_timestamp = 123456;
+// Whole-second milliseconds (1700000000s): every Eth header produced by finalizeEthBlockHeader
+// must satisfy validateHeader's "timestamp is a whole number of seconds" check, so a fixture
+// timestamp with sub-second milliseconds would make every build path throw.
+constexpr std::uint64_t c_timestamp = 1700000000ULL * 1000ULL;
 constexpr bcos::protocol::BlockNumber c_initialBlockNumber = 5;
 constexpr bcos::protocol::BlockNumber c_trackedInitialBlockNumber = 10;
 constexpr bcos::protocol::BlockNumber c_trackedNextBlockNumber = 11;
@@ -1462,7 +1466,8 @@ static bcos::protocol::BlockHeader::Ptr makeValidCancunHeader(
     header->setParentInfo(bcos::protocol::ParentInfo{
         .blockNumber = 9, .blockHash = parentHash});
     header->setNumber(10);
-    header->setTimestamp(1700000000);
+    // Internal BlockHeader timestamps are milliseconds: the whole-second value × 1000.
+    header->setTimestamp(1700000000 * 1000LL);
     header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
     header->setPrevRandao(
         bcos::h256("1111111111111111111111111111111111111111111111111111111111111111"));
@@ -1625,6 +1630,47 @@ BOOST_AUTO_TEST_CASE(buildPayloadEmptyBlockInjectsRlpHash)
     auto const& blockHash = payload->executionPayload.blockHash;
     BOOST_CHECK_NE(blockHash, bcos::engine::detail::syntheticHash(*result.payloadId));
     BOOST_CHECK_NE(blockHash, bcos::crypto::HashType{});
+
+    // Strong anchor: recompute keccak256(rlp(header)) from the payload fields via the
+    // EthBlockHeader bridge and compare against the block hash. The old anchor (≠ synthetic
+    // hash, ≠ zero) stayed green even when finalizeEthBlockHeader hashed a wrong timestamp,
+    // so it could not catch the merge-broken unit conversion.
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    auto const& executionPayload = payload->executionPayload;
+    header->setParentInfo(bcos::protocol::ParentInfo{
+        .blockNumber = static_cast<int64_t>(executionPayload.blockNumber) - 1,
+        .blockHash = executionPayload.parentHash});
+    header->setNumber(static_cast<int64_t>(executionPayload.blockNumber));
+    // Internal BlockHeader milliseconds; the bridge converts to seconds at encode.
+    header->setTimestamp(static_cast<int64_t>(executionPayload.timestamp));
+    header->setCoinbase(executionPayload.feeRecipient);
+    header->setUncleHash(bcos::crypto::HashType(
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"));
+    header->setPrevRandao(executionPayload.prevRandao);
+    header->setNonce(bcos::h64(0));
+    header->setDifficulty(bcos::u256(0));
+    header->setGasLimit(executionPayload.gasLimit);
+    header->setGasUsed(executionPayload.gasUsed);
+    header->setStateRoot(executionPayload.stateRoot);
+    header->setReceiptsRoot(bcos::ledger::mpt::emptyRootHash());
+    header->setTxsRoot(bcos::ledger::mpt::emptyRootHash());
+    header->setLogsBloom(bcos::bytesConstRef(
+        executionPayload.logsBloom.data(), executionPayload.logsBloom.size()));
+    header->setBaseFee(executionPayload.baseFeePerGas);
+    header->setWithdrawalsRoot(bcos::ledger::mpt::emptyRootHash());
+    header->setBlobGasUsed(executionPayload.blobGasUsed.value_or(bcos::u256(0)));
+    header->setExcessBlobGas(executionPayload.excessBlobGas.value_or(bcos::u256(0)));
+    header->setParentBeaconBlockRoot(
+        payloadAttributes.parentBeaconBlockRoot.value_or(bcos::h256{}));
+    header->setEthBlockVersion(bcos::protocol::EthBlockVersion::CANCUN);
+
+    bcos::protocol::EthBlockHeader ethHeader(*header);
+    bcos::bytes rlp;
+    ethHeader.rlpEncode(rlp);
+    BOOST_CHECK_EQUAL(
+        blockHash.hex(), bcos::crypto::keccak256Hash(bcos::ref(rlp)).hex());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -1453,4 +1453,159 @@ BOOST_AUTO_TEST_CASE(per_method_version_windows_and_unknown_payload)
         task::syncWait(engineService.getPayload("0x01", 6)), UnsupportedEngineApiVersion);
 }
 
+/// Build a BlockHeader carrying every field EthBlockHeader::validateHeader requires for a
+/// CANCUN header, so finalizeEthBlockHeader's calculateRLPHash succeeds.
+static bcos::protocol::BlockHeader::Ptr makeValidCuncunHeader(
+    bcos::protocol::BlockFactory::Ptr blockFactory, bcos::crypto::HashType parentHash)
+{
+    auto header = blockFactory->blockHeaderFactory()->createBlockHeader();
+    header->setParentInfo(bcos::protocol::ParentInfo{
+        .blockNumber = 9, .blockHash = parentHash});
+    header->setNumber(10);
+    header->setTimestamp(1700000000);
+    header->setCoinbase(bcos::Address("1234567890abcdef1234567890abcdef12345678"));
+    header->setPrevRandao(
+        bcos::h256("1111111111111111111111111111111111111111111111111111111111111111"));
+    header->setGasLimit(bcos::u256(30000000));
+    header->setGasUsed(bcos::u256(21000));
+    header->setStateRoot(
+        bcos::h256("4444444444444444444444444444444444444444444444444444444444444444"));
+    header->setTxsRoot(
+        bcos::h256("5555555555555555555555555555555555555555555555555555555555555555"));
+    header->setReceiptsRoot(
+        bcos::h256("6666666666666666666666666666666666666666666666666666666666666666"));
+    bcos::Bloom bloom;
+    bloom[0] = 0xab;
+    header->setLogsBloom(bcos::bytesConstRef(bloom.data(), bloom.size()));
+    return header;
+}
+
+BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEngineVersions)
+{
+    using bcos::protocol::EthBlockVersion;
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(1)),
+        static_cast<int>(EthBlockVersion::LONDON));
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(2)),
+        static_cast<int>(EthBlockVersion::SHANGHAI));
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(3)),
+        static_cast<int>(EthBlockVersion::CANCUN));
+    // V4+ falls back to the newest known fork.
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(4)),
+        static_cast<int>(EthBlockVersion::PRAGUE));
+}
+
+BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)
+{
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto parentHash = bcos::crypto::HashType(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    auto header = makeValidCuncunHeader(blockFactory, parentHash);
+
+    bcos::engine::ExecutionPayload payload;
+    payload.logsBloom = bcos::Bloom{};
+    payload.baseFeePerGas = bcos::u256(1000);
+    payload.blobGasUsed = bcos::u256(0);
+    payload.excessBlobGas = bcos::u256(0);
+
+    auto beaconRoot = bcos::h256(
+        "3333333333333333333333333333333333333333333333333333333333333333");
+    bcos::engine::detail::finalizeEthBlockHeader(*header, payload, beaconRoot, 3);
+
+    // The header is marked as an Eth CANCUN header.
+    BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::CANCUN);
+    // Post-merge constants.
+    BOOST_CHECK_EQUAL(header->uncleHash().hexPrefixed(),
+        "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    BOOST_CHECK_EQUAL(header->difficulty(), bcos::u256(0));
+    BOOST_CHECK_EQUAL(header->nonce(), bcos::h64(0));
+    // Base fee taken from the payload.
+    BOOST_REQUIRE(header->baseFee().has_value());
+    BOOST_CHECK_EQUAL(*header->baseFee(), bcos::u256(1000));
+    // SHANGHAI+ withdrawals root is the empty-trie root placeholder.
+    BOOST_REQUIRE(header->withdrawalsRoot().has_value());
+    BOOST_CHECK_EQUAL(*header->withdrawalsRoot(), bcos::ledger::mpt::emptyRootHash());
+    // CANCUN blob fields + beacon root.
+    BOOST_REQUIRE(header->blobGasUsed().has_value());
+    BOOST_REQUIRE(header->excessBlobGas().has_value());
+    BOOST_REQUIRE(header->parentBeaconBlockRoot().has_value());
+    BOOST_CHECK_EQUAL(*header->parentBeaconBlockRoot(), beaconRoot);
+    // The RLP hash was computed and injected (not a synthetic / zero hash).
+    BOOST_CHECK_NE(header->hash(), bcos::crypto::HashType{});
+}
+
+BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderVersionGatesFields)
+{
+    static auto blockFactory =
+        bcos::test::createBlockFactory(bcos::test::createNormalCryptoSuite());
+    auto parentHash = bcos::crypto::HashType(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+    bcos::engine::ExecutionPayload payload;
+    payload.logsBloom = bcos::Bloom{};
+    payload.baseFeePerGas = bcos::u256(1000);
+
+    // V1/LONDON: baseFee present, no withdrawalsRoot / blob fields / beacon root.
+    {
+        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 1);
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::LONDON);
+        BOOST_REQUIRE(header->baseFee().has_value());
+        BOOST_CHECK(!header->withdrawalsRoot().has_value());
+        BOOST_CHECK(!header->blobGasUsed().has_value());
+        BOOST_CHECK(!header->excessBlobGas().has_value());
+        BOOST_CHECK(!header->parentBeaconBlockRoot().has_value());
+    }
+
+    // V2/SHANGHAI: + withdrawalsRoot, no blob fields / beacon root.
+    {
+        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, std::nullopt, 2);
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::SHANGHAI);
+        BOOST_REQUIRE(header->withdrawalsRoot().has_value());
+        BOOST_CHECK(!header->blobGasUsed().has_value());
+        BOOST_CHECK(!header->excessBlobGas().has_value());
+        BOOST_CHECK(!header->parentBeaconBlockRoot().has_value());
+    }
+
+    // V3/CANCUN: everything present.
+    {
+        auto header = makeValidCuncunHeader(blockFactory, parentHash);
+        auto beaconRoot = bcos::h256(
+            "3333333333333333333333333333333333333333333333333333333333333333");
+        payload.blobGasUsed = bcos::u256(0);
+        payload.excessBlobGas = bcos::u256(0);
+        bcos::engine::detail::finalizeEthBlockHeader(*header, payload, beaconRoot, 3);
+        BOOST_CHECK(header->ethBlockVersion() == bcos::protocol::EthBlockVersion::CANCUN);
+        BOOST_REQUIRE(header->withdrawalsRoot().has_value());
+        BOOST_REQUIRE(header->blobGasUsed().has_value());
+        BOOST_REQUIRE(header->excessBlobGas().has_value());
+        BOOST_REQUIRE(header->parentBeaconBlockRoot().has_value());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(buildPayloadEmptyBlockInjectsRlpHash)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    // Empty block: no transactions, no mempool seeding.
+    auto payloadAttributes = makePayloadAttributesV3();
+    auto result =
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_REQUIRE(result.payloadId.has_value());
+
+    auto payload = task::syncWait(engineService.getPayload(*result.payloadId, 3));
+    BOOST_REQUIRE(payload);
+    // The block hash must be the injected RLP hash — deterministic and not the synthetic
+    // placeholder (which would have been derived from just the payloadId).
+    auto const& blockHash = payload->executionPayload.blockHash;
+    BOOST_CHECK_NE(blockHash, bcos::engine::detail::syntheticHash(*result.payloadId));
+    BOOST_CHECK_NE(blockHash, bcos::crypto::HashType{});
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -567,6 +567,31 @@ BOOST_AUTO_TEST_CASE(forkchoice_rejected_when_evm_revision_missing)
         });
 }
 
+// A non-empty withdrawals list is rejected at the ATTRIBUTE layer (payloadStatus INVALID,
+// not UnsupportedFork): the withdrawals trie root is not computed, so the hashed header
+// would commit the empty-trie root while geth derives DeriveSha(withdrawals) — a mismatch
+// every peer would reject (T5).
+BOOST_AUTO_TEST_CASE(forkchoice_rejects_non_empty_withdrawals)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto payloadAttributes = makePayloadAttributesV3();
+    payloadAttributes.withdrawals = std::vector<WithdrawalV1>{
+        WithdrawalV1{.index = 1, .validatorIndex = 2, .amount = 3, .address = Address{}}};
+    auto result = task::syncWait(
+        engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3));
+    BOOST_CHECK_EQUAL(static_cast<int>(result.payloadStatus.status),
+        static_cast<int>(PayloadValidationStatus::Invalid));
+    BOOST_REQUIRE(result.payloadStatus.validationError.has_value());
+    BOOST_CHECK_NE(result.payloadStatus.validationError->find("non-empty withdrawals"),
+        std::string::npos);
+}
+
 BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 {
     MemPoolImpl memPool;
@@ -884,8 +909,15 @@ BOOST_AUTO_TEST_CASE(get_payload_v5_rejects_a_v3_committed_entry_without_withdra
     BOOST_CHECK_EQUAL(
         static_cast<int>(status.status), static_cast<int>(PayloadValidationStatus::Valid));
 
-    BOOST_CHECK_THROW(
-        task::syncWait(engineService.getPayload(*result.payloadId, 5)), IncompatiblePayloadVersion);
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.getPayload(*result.payloadId, 5)), IncompatiblePayloadVersion,
+        [](const IncompatiblePayloadVersion& e) {
+            // Pin the REWRITE-path message (the entry was rewritten by the V3 commit and
+            // lost its withdrawalsRoot), not just the exception type — a swapped gate that
+            // keeps IncompatiblePayloadVersion must still fail (T4).
+            return std::string(e.what()).find("Payload does not carry the V4+ response shape") !=
+                   std::string::npos;
+        });
     // The V3 view of the same entry is still perfectly serviceable.
     auto v3 = task::syncWait(engineService.getPayload(*result.payloadId, 3));
     BOOST_CHECK(v3);
@@ -1541,6 +1573,14 @@ BOOST_AUTO_TEST_CASE(new_payload_v4_rejects_nonempty_lists_and_missing_fields)
     auto missingRootRequest = makeRequest();
     missingRootRequest.executionPayload.withdrawalsRoot = std::nullopt;
     expectInvalid(missingRootRequest, "withdrawalsRoot");
+
+    // A FOREIGN Isthmus withdrawalsRoot (anything other than withdrawalsRootFor(), i.e.
+    // the empty-trie placeholder) is rejected: the hashed header commits this node's own
+    // root, so a CL submitting a different value cannot reproduce blockHash (T5).
+    auto foreignRootRequest = makeRequest();
+    foreignRootRequest.executionPayload.withdrawalsRoot =
+        h256("9999999999999999999999999999999999999999999999999999999999999999");
+    expectInvalid(foreignRootRequest, "withdrawalsRoot");
 
     // parentBeaconBlockRoot is required at V3 and later.
     auto missingBeaconRequest = makeRequest();

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -380,12 +380,10 @@ PayloadAttributes makePayloadAttributesV2()
     payloadAttributes.prevRandao =
         h256("1111111111111111111111111111111111111111111111111111111111111111");
     payloadAttributes.suggestedFeeRecipient = Address("1234567890abcdef1234567890abcdef12345678");
-    WithdrawalV1 withdrawal;
-    withdrawal.index = 1;
-    withdrawal.validatorIndex = 2;
-    withdrawal.address = Address("abcdefabcdefabcdefabcdefabcdefabcdefabcd");
-    withdrawal.amount = 3;
-    payloadAttributes.withdrawals = std::vector<WithdrawalV1>{std::move(withdrawal)};
+    // The withdrawals list is empty: finalizeEthBlockHeader commits the empty-trie root as
+    // a placeholder, and validatePayloadAttributes rejects a NON-empty list paired with it
+    // (the real withdrawals trie root is not computed yet).
+    payloadAttributes.withdrawals = std::vector<WithdrawalV1>{};
     return payloadAttributes;
 }
 
@@ -510,9 +508,14 @@ BOOST_AUTO_TEST_CASE(forkchoice_v2_rejected_on_cancun_chain)
     auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
 
     auto payloadAttributes = makePayloadAttributesV2();
-    BOOST_CHECK_THROW(
+    // Pin the exact gate, not just the exception type: the same UnsupportedFork type is
+    // thrown by the V2-attr and the missing-revision gates with different what() text.
+    BOOST_CHECK_EXCEPTION(
         task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
-        UnsupportedFork);
+        UnsupportedFork, [](const UnsupportedFork& e) {
+            return std::string(e.what()).find("requires the V3 payload attributes") !=
+                   std::string::npos;
+        });
 }
 
 BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
@@ -1561,8 +1564,10 @@ BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEvmRevisions)
     // A future EVMC bump (a revision above OSAKA) must fail loudly: hashing under the
     // wrong fork rules would drop fork-gated fields and every peer would reject the
     // block, with no diagnostic.
-    BOOST_CHECK_THROW(bcos::engine::detail::ethBlockVersionFor(EVMC_EXPERIMENTAL),
-        UnsupportedFork);
+    BOOST_CHECK_EXCEPTION(bcos::engine::detail::ethBlockVersionFor(EVMC_EXPERIMENTAL),
+        UnsupportedFork, [](const UnsupportedFork& e) {
+            return std::string(e.what()).find("unsupported EVM revision") != std::string::npos;
+        });
 }
 
 BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -168,18 +168,24 @@ struct RealGlobalStateStorageFixture
     RealGlobalCheckpointBackend checkpointBackend{backendStorage};
     RealGlobalStateStorage storage{checkpointBackend};
 
-    explicit RealGlobalStateStorageFixture(evmc_revision rev = EVMC_CANCUN)
+    explicit RealGlobalStateStorageFixture(
+        evmc_revision rev = EVMC_CANCUN, bool writeEvmcRevision = true)
     {
         // The Engine service runs only on executor_version=2 with an explicit EVMC
         // revision. The default models the "Karst" chain (CANCUN) these tests mostly
         // drive; tests that exercise older FCU method versions (V1/V2) pass SHANGHAI so
-        // the attribute shape the request can express matches the chain fork. Without an
-        // explicit revision, buildPayload's header-fork derivation would fall back to the
-        // compile-time default (OSAKA -> PRAGUE) instead of the intended era.
+        // the attribute shape the request can express matches the chain fork.
+        // buildPayload FAILS CLOSED when the revision is absent (it never falls back to
+        // the compile-time default), so the missing-revision test passes writeEvmcRevision
+        // = false to reach that branch.
         writeSysConfig(
             magic_enum::enum_name(ledger::SystemConfig::executor_version),
             std::to_string(ledger::ETHEREUM_EXECUTOR_VERSION));
-        writeSysConfig(ledger::SYSTEM_KEY_EVMC_REVISION, ledger::encodeEVMCRevisionConfig(rev, {}));
+        if (writeEvmcRevision)
+        {
+            writeSysConfig(
+                ledger::SYSTEM_KEY_EVMC_REVISION, ledger::encodeEVMCRevisionConfig(rev, {}));
+        }
     }
 
     void setBlockNumber(const h256& blockHash, bcos::protocol::BlockNumber blockNumber)
@@ -515,6 +521,49 @@ BOOST_AUTO_TEST_CASE(forkchoice_v2_rejected_on_cancun_chain)
         UnsupportedFork, [](const UnsupportedFork& e) {
             return std::string(e.what()).find("requires the V3 payload attributes") !=
                    std::string::npos;
+        });
+}
+
+// The reverse direction of the fork/method-version gate: a V3 forkchoiceUpdated on a
+// SHANGHAI chain would build a payload whose required blob pair is absent (the payload
+// fields are filled by the chain-derived forkVersion, but getPayloadV3's response shape
+// requires them). Reject with the same UnsupportedFork as the older-FCU case.
+BOOST_AUTO_TEST_CASE(forkchoice_v3_rejected_on_shanghai_chain)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_SHANGHAI);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto payloadAttributes = makePayloadAttributesV3();
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3)),
+        UnsupportedFork, [](const UnsupportedFork& e) {
+            return std::string(e.what()).find("requires a CANCUN-or-later chain fork") !=
+                   std::string::npos;
+        });
+}
+
+// A v2 chain with no on-chain EVM revision must fail closed: hashing under an assumed fork
+// (the compile-time default, OSAKA -> PRAGUE) would stamp requestsHash into every RLP hash.
+// The gate throws UnsupportedFork with a distinguishing message; pin it.
+BOOST_AUTO_TEST_CASE(forkchoice_rejected_when_evm_revision_missing)
+{
+    MemPoolImpl memPool;
+    // executor_version=2 but NO SYSTEM_KEY_EVMC_REVISION row.
+    RealGlobalStateStorageFixture globalStateStorageFixture(EVMC_CANCUN, /*writeEvmcRevision=*/false);
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto payloadAttributes = makePayloadAttributesV3();
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 3)),
+        UnsupportedFork, [](const UnsupportedFork& e) {
+            return std::string(e.what()).find("no on-chain EVM revision") != std::string::npos;
         });
 }
 
@@ -1416,13 +1465,21 @@ BOOST_AUTO_TEST_CASE(get_payload_v5_accepts_only_v3_builds)
     auto result =
         task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2));
     BOOST_REQUIRE(result.payloadId.has_value());
-    BOOST_CHECK_THROW(
-        task::syncWait(engineService.getPayload(*result.payloadId, 5)), IncompatiblePayloadVersion);
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.getPayload(*result.payloadId, 5)), IncompatiblePayloadVersion,
+        [](const IncompatiblePayloadVersion& e) {
+            return std::string(e.what()).find("incompatible with requested method version") !=
+                   std::string::npos;
+        });
     // getPayloadV4 has the same window: op-geth's GetPayloadV4 also admits only
     // PayloadV3 builds, and the V4 response shape needs the same three fields a V2 build
     // does not have.
-    BOOST_CHECK_THROW(
-        task::syncWait(engineService.getPayload(*result.payloadId, 4)), IncompatiblePayloadVersion);
+    BOOST_CHECK_EXCEPTION(
+        task::syncWait(engineService.getPayload(*result.payloadId, 4)), IncompatiblePayloadVersion,
+        [](const IncompatiblePayloadVersion& e) {
+            return std::string(e.what()).find("incompatible with requested method version") !=
+                   std::string::npos;
+        });
     // The same build is still retrievable through its own method version.
     BOOST_CHECK_NO_THROW(task::syncWait(engineService.getPayload(*result.payloadId, 2)));
 }

--- a/engine/test/unittests/engine/EngineServiceTest.cpp
+++ b/engine/test/unittests/engine/EngineServiceTest.cpp
@@ -496,6 +496,25 @@ BOOST_AUTO_TEST_CASE(forkchoice_with_payload_attributes_builds_retrievable_paylo
     BOOST_CHECK(!fetched[0]);
 }
 
+// On a CANCUN chain the header-fork era outruns the V2 attribute shape, so a V2
+// forkchoiceUpdated is refused with UnsupportedFork (the RPC layer maps it to -38005,
+// matching geth's answer for the same CL/chain mismatch). The same attributes on a
+// SHANGHAI chain build (see forkchoice_with_payload_attributes_builds_retrievable_payload).
+BOOST_AUTO_TEST_CASE(forkchoice_v2_rejected_on_cancun_chain)
+{
+    MemPoolImpl memPool;
+    RealGlobalStateStorageFixture globalStateStorageFixture;  // default CANCUN
+    auto forkchoiceState = makeForkchoiceState();
+    setForkchoiceBlockNumbers(globalStateStorageFixture, forkchoiceState, c_initialBlockNumber,
+        c_initialBlockNumber, c_initialBlockNumber);
+    auto engineService = makeEngineServiceImpl(memPool, globalStateStorageFixture.storage);
+
+    auto payloadAttributes = makePayloadAttributesV2();
+    BOOST_CHECK_THROW(
+        task::syncWait(engineService.updateForkchoice(forkchoiceState, &payloadAttributes, 2)),
+        UnsupportedFork);
+}
+
 BOOST_AUTO_TEST_CASE(forkchoice_v3_tracks_safe_and_finalized_block_numbers)
 {
     MemPoolImpl memPool;
@@ -1522,8 +1541,10 @@ static bcos::protocol::BlockHeader::Ptr makeValidCancunHeader(
 BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEvmRevisions)
 {
     using bcos::protocol::EthBlockVersion;
-    // Pre-London revisions cannot occur on a PoS/Engine path; they map to the minimal
-    // post-merge shape (LONDON).
+    // Revisions strictly below LONDON (FRONTIER..BERLIN) cannot occur on a PoS/Engine
+    // path; they map to the minimal post-merge shape (LONDON).
+    BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_BERLIN)),
+        static_cast<int>(EthBlockVersion::LONDON));
     BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_LONDON)),
         static_cast<int>(EthBlockVersion::LONDON));
     BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_PARIS)),
@@ -1537,6 +1558,11 @@ BOOST_AUTO_TEST_CASE(ethBlockVersionForMapsEvmRevisions)
         static_cast<int>(EthBlockVersion::PRAGUE));
     BOOST_CHECK_EQUAL(static_cast<int>(bcos::engine::detail::ethBlockVersionFor(EVMC_OSAKA)),
         static_cast<int>(EthBlockVersion::PRAGUE));
+    // A future EVMC bump (a revision above OSAKA) must fail loudly: hashing under the
+    // wrong fork rules would drop fork-gated fields and every peer would reject the
+    // block, with no diagnostic.
+    BOOST_CHECK_THROW(bcos::engine::detail::ethBlockVersionFor(EVMC_EXPERIMENTAL),
+        UnsupportedFork);
 }
 
 BOOST_AUTO_TEST_CASE(finalizeEthBlockHeaderFillsEthFieldsAndHash)

--- a/libinitializer/Initializer.cpp
+++ b/libinitializer/Initializer.cpp
@@ -383,9 +383,12 @@ void Initializer::init(bcos::protocol::NodeArchitectureType _nodeArchType,
     // endpoint would silently serve the v1 EngineService built below, and an external
     // op-node — which trusts the EL and never cross-checks state roots — would drive a
     // chain with v1 (non-Ethereum) semantics. Fail fast instead. The only exception is the
-    // explicit test-only escape hatch unsafe_allow_v1_executor, which the v1 Engine API
-    // integration harness (tools/engine_integration_test.sh, driving the v1 EngineService
-    // over this endpoint with a mock CL / Lodestar) sets; production configs must not.
+    // explicit test-only escape hatch unsafe_allow_v1_executor, which the former v1 Engine
+    // API integration harness (tools/engine_integration_test.sh) set. The harness now runs
+    // executor_version=2 + evm_revision=cancun like production, and payload building in
+    // any case requires an on-chain EVM revision (buildPayload fails closed without one),
+    // so the escape hatch can no longer build payloads; production configs must never set
+    // it.
     if (m_nodeConfig->enableOpEngineRpc() && engineApiForV1Only)
     {
         if (!m_nodeConfig->opEngineAllowV1Executor())

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -372,15 +372,14 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
 
 
 def run_v2_block_flow() -> None:
-    """V2 FCU on this harness chain is refused as Unsupported fork (-38005).
+    """V2 FCU on the CANCUN harness chain is refused as Unsupported fork (-38005).
 
-    The harness chain has no explicit on-chain EVM revision (it drives the v1 executor
-    through unsafe_allow_v1_executor), so buildPayload's header-fork derivation falls
-    back to the compile-time default (OSAKA -> PRAGUE). A V2 forkchoiceUpdated cannot
-    express the PRAGUE attribute shape (parentBeaconBlockRoot / blob fields), so it is
-    refused with -38005 — the same answer geth gives for a CL/chain fork mismatch. The
-    pre-Karst V2 build loop itself is covered by the engine unit tests on a SHANGHAI
-    fixture.
+    The harness chain runs executor_version=2 with evm_revision=cancun (the production
+    [op_engine_rpc] configuration), so buildPayload's chain-derived header fork is CANCUN.
+    A V2 forkchoiceUpdated cannot express the CANCUN attribute shape
+    (parentBeaconBlockRoot), so it is refused with -38005 — the same answer geth gives
+    for a CL/chain fork mismatch. The pre-Karst V2 build loop itself is covered by the
+    engine unit tests on a SHANGHAI fixture.
     """
     _log_test("FCU V2 + getPayloadV2 + newPayloadV2 (pre-Karst surface)")
 
@@ -413,9 +412,9 @@ def test_eip1559_fields_are_v3_only() -> None:
     before Holocene", op-core/eip1559/eip1559.go:27-28).
 
     Attribute errors surface through the payloadStatus channel, not as a JSON-RPC error.
-    The control is a V3 FCU (the only version the harness chain's PRAGUE fork accepts);
-    the V2 + field cases are still rejected by validatePayloadAttributes, which runs
-    before buildPayload's chain-fork gate.
+    The control is a V3 FCU (the only version the CANCUN harness chain accepts); the
+    V2 + field cases are still rejected by validatePayloadAttributes, which runs before
+    buildPayload's chain-fork gate.
     """
     _log_test("eip1559Params / minBaseFee are rejected below forkchoiceUpdatedV3")
 

--- a/tests/mock_consensus_client.py
+++ b/tests/mock_consensus_client.py
@@ -372,11 +372,15 @@ def run_karst_block_flow(no_tx_pool: bool) -> bool:
 
 
 def run_v2_block_flow() -> None:
-    """The pre-Karst loop still works end to end: FCU V2 -> getPayloadV2 -> newPayloadV2.
+    """V2 FCU on this harness chain is refused as Unsupported fork (-38005).
 
-    Targeting Karst does not make the older method versions incompatible. A stock CL
-    driving the standard V1-V3 surface (and the v1 Engine API harness kept alive by
-    unsafe_allow_v1_executor) must keep building and submitting blocks.
+    The harness chain has no explicit on-chain EVM revision (it drives the v1 executor
+    through unsafe_allow_v1_executor), so buildPayload's header-fork derivation falls
+    back to the compile-time default (OSAKA -> PRAGUE). A V2 forkchoiceUpdated cannot
+    express the PRAGUE attribute shape (parentBeaconBlockRoot / blob fields), so it is
+    refused with -38005 — the same answer geth gives for a CL/chain fork mismatch. The
+    pre-Karst V2 build loop itself is covered by the engine unit tests on a SHANGHAI
+    fixture.
     """
     _log_test("FCU V2 + getPayloadV2 + newPayloadV2 (pre-Karst surface)")
 
@@ -393,31 +397,7 @@ def run_v2_block_flow() -> None:
         "withdrawals": [],
     }
 
-    fcu = rpc_result("engine_forkchoiceUpdatedV2", [fc_state, payload_attrs])
-    payload_id = fcu.get("payloadId")
-    if fcu["payloadStatus"]["status"] != "VALID" or not payload_id:
-        _log_fail(f"FCU V2 did not build a payload: {fcu}")
-        return
-
-    result = rpc_result("engine_getPayloadV2", [payload_id])
-    # V2 response shape: executionPayload + blockValue only — no blobsBundle (V3+),
-    # no executionRequests (V4+), no withdrawalsRoot on the payload (V4+).
-    if "executionPayload" not in result or "blockValue" not in result:
-        _log_fail(f"getPayloadV2 response is not the V2 shape: {sorted(result.keys())}")
-        return
-    if "blobsBundle" in result or "executionRequests" in result:
-        _log_fail(f"getPayloadV2 leaked V3+/V4+ response fields: {sorted(result.keys())}")
-        return
-    payload = result["executionPayload"]
-    if "withdrawalsRoot" in payload:
-        _log_fail("getPayloadV2 leaked the V4-only withdrawalsRoot field")
-        return
-
-    status = rpc_result("engine_newPayloadV2", [payload])
-    _log_info(f"newPayloadV2 status = {status['status']}")
-    if status["status"] != "VALID":
-        _log_fail(f"newPayloadV2 rejected the V2 payload it just built: {status}")
-        return
+    expect_error_code("engine_forkchoiceUpdatedV2", [fc_state, payload_attrs], -38005)
     _log_pass()
 
 
@@ -433,6 +413,9 @@ def test_eip1559_fields_are_v3_only() -> None:
     before Holocene", op-core/eip1559/eip1559.go:27-28).
 
     Attribute errors surface through the payloadStatus channel, not as a JSON-RPC error.
+    The control is a V3 FCU (the only version the harness chain's PRAGUE fork accepts);
+    the V2 + field cases are still rejected by validatePayloadAttributes, which runs
+    before buildPayload's chain-fork gate.
     """
     _log_test("eip1559Params / minBaseFee are rejected below forkchoiceUpdatedV3")
 
@@ -442,6 +425,17 @@ def test_eip1559_fields_are_v3_only() -> None:
         "safeBlockHash": head_hash,
         "finalizedBlockHash": head_hash,
     }
+
+    def v3_attrs(**extra: object) -> dict:
+        attrs = {
+            "timestamp": next_timestamp(),
+            "prevRandao": PREV_RANDAO,
+            "suggestedFeeRecipient": FEE_RECIPIENT,
+            "withdrawals": [],
+            "parentBeaconBlockRoot": ZERO_HASH,
+        }
+        attrs.update(extra)
+        return attrs
 
     def v2_attrs(**extra: object) -> dict:
         attrs = {
@@ -453,11 +447,11 @@ def test_eip1559_fields_are_v3_only() -> None:
         attrs.update(extra)
         return attrs
 
-    # Control: the same attributes without the two fields still build on V2, so a
-    # rejection below is attributable to the new gate and not to an unrelated V2 error.
-    control = rpc_result("engine_forkchoiceUpdatedV2", [fc_state, v2_attrs()])
+    # Control: the same V3 attributes build, so a rejection below is attributable to the
+    # V2-only field gate and not to an unrelated chain-fork error.
+    control = rpc_result("engine_forkchoiceUpdatedV3", [fc_state, v3_attrs()])
     if control["payloadStatus"]["status"] != "VALID" or not control.get("payloadId"):
-        _log_fail(f"control V2 FCU did not build a payload: {control}")
+        _log_fail(f"control V3 FCU did not build a payload: {control}")
         return
 
     for field, value in (

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -578,45 +578,25 @@ else
     log_pass
 fi
 
-# 3.6 pre-Karst surface still works: the V2 build/fetch/submit loop end to end.
-log_test "engine_forkchoiceUpdatedV2 + getPayloadV2 + newPayloadV2 (pre-Karst)"
+# 3.6 pre-Karst surface on a chain whose fork outruns V2: forkchoiceUpdatedV2 is refused
+# with -38005 Unsupported fork. The harness chain has no explicit on-chain EVM revision
+# (it drives the v1 executor through unsafe_allow_v1_executor), so the header-fork
+# derivation falls back to the compile-time default (OSAKA -> PRAGUE); a V2 attribute
+# shape cannot express PRAGUE (parentBeaconBlockRoot / blob fields), so the service
+# answers the same Unsupported fork error geth gives for this CL/chain mismatch. The V2
+# build/fetch/submit loop itself is covered by the engine unit tests on a SHANGHAI
+# fixture.
+log_test "engine_forkchoiceUpdatedV2 answers -38005 (chain fork outruns V2)"
 V2_HEAD=$(json_val "$(rpc_call "eth_getBlockByNumber" '["latest",false]')" "hash")
 V2_TS_SECS=$((TS_SECS + 12))
 V2_TS_HEX=$(printf '0x%x' "${V2_TS_SECS}")
 if [ -n "${V2_HEAD}" ]; then
     RESP=$(rpc_call "engine_forkchoiceUpdatedV2" \
         "[{\"headBlockHash\":\"${V2_HEAD}\",\"safeBlockHash\":\"${V2_HEAD}\",\"finalizedBlockHash\":\"${V2_HEAD}\"},{\"timestamp\":\"${V2_TS_HEX}\",\"prevRandao\":\"0x0000000000000000000000000000000000000000000000000000000000000001\",\"suggestedFeeRecipient\":\"0x0000000000000000000000000000000000000001\",\"withdrawals\":[]}]")
-    V2_PAYLOAD_ID=$(json_val "${RESP}" "payloadId")
     if echo "${RESP}" | grep -q '\-38005'; then
-        log_fail "forkchoiceUpdatedV2 was rejected as an unsupported fork: ${RESP}"
-    elif [ -z "${V2_PAYLOAD_ID}" ]; then
-        log_fail "forkchoiceUpdatedV2 built no payload: ${RESP}"
+        log_pass
     else
-        GET_RESP=$(rpc_call "engine_getPayloadV2" "[\"${V2_PAYLOAD_ID}\"]")
-        # V2 response shape: executionPayload + blockValue, no blobsBundle.
-        if ! echo "${GET_RESP}" | grep -q '"blockValue"' \
-            || echo "${GET_RESP}" | grep -q '"blobsBundle"'; then
-            log_fail "getPayloadV2 did not answer in the V2 shape: ${GET_RESP}"
-        else
-            V2_REQ_FILE="${WORK_DIR}/newPayloadV2_req.json"
-            echo "${GET_RESP}" | python3 -c "
-import sys,json
-d=json.load(sys.stdin)['result']
-p=d['executionPayload'] if 'executionPayload' in d else d
-print(json.dumps({'jsonrpc':'2.0','id':1,'method':'engine_newPayloadV2','params':[p]}))
-" 2>/dev/null > "${V2_REQ_FILE}"
-            V2_RESP=$(curl -s -X POST "${RPC_URL}" \
-                -H "Content-Type: application/json" \
-                -H "Authorization: Bearer ${JWT_TOKEN}" \
-                -d "@${V2_REQ_FILE}" 2>/dev/null || echo '{}')
-            V2_STATUS=$(json_val "${V2_RESP}" "status")
-            log_info "newPayloadV2 status = ${V2_STATUS}"
-            if [ "${V2_STATUS}" = "VALID" ]; then
-                log_pass
-            else
-                log_fail "Unexpected newPayloadV2 status: ${V2_RESP}"
-            fi
-        fi
+        log_fail "expected forkchoiceUpdatedV2 to be refused as -38005 Unsupported fork, got: ${RESP}"
     fi
 else
     log_fail "Cannot get head hash"

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -177,6 +177,9 @@ mkdir -p "${WORK_DIR}"
 
 # Generate genesis config
 cat > "${WORK_DIR}/config.genesis" << GENESIS_EOF
+[version]
+compatibility_version=3.18.0
+
 [consensus]
 consensus_type=pbft
 block_tx_count_limit=1000

--- a/tools/engine_integration_test.sh
+++ b/tools/engine_integration_test.sh
@@ -199,9 +199,8 @@ listen_ip=0.0.0.0
 listen_port=${RPC_PORT}
 jwt_secret_file=${WORK_DIR}/jwt.hex
 clock_skew_secs=300
-; this harness drives the v1 EngineService over the endpoint (no [executor] version=2
-; here); production chains must never set this test-only escape hatch
-unsafe_allow_v1_executor=true
+; The Karst Engine API surface is served by the v2 pure-Ethereum executor (executor_version=2
+; + executor.evm_revision=cancun below), matching the production [op_engine_rpc] configuration.
 
 [p2p]
 listen_ip=0.0.0.0
@@ -221,6 +220,11 @@ multi_ca_path=multiCaPath
 [certificate_whitelist]
 
 [executor]
+; executor_version=2 selects the pure-Ethereum EthereumExecutor; the header-fork derivation
+; in buildPayload keys off the chain's EVM revision, so an explicit evm_revision is required
+; (a missing one would fail closed rather than hash under an assumed fork).
+version=2
+evm_revision=cancun
 is_auth_check=false
 auth_admin_account=0x3443d6866e757893e6862f451f5d1b7976c54594
 is_serial_execute=true
@@ -579,13 +583,12 @@ else
 fi
 
 # 3.6 pre-Karst surface on a chain whose fork outruns V2: forkchoiceUpdatedV2 is refused
-# with -38005 Unsupported fork. The harness chain has no explicit on-chain EVM revision
-# (it drives the v1 executor through unsafe_allow_v1_executor), so the header-fork
-# derivation falls back to the compile-time default (OSAKA -> PRAGUE); a V2 attribute
-# shape cannot express PRAGUE (parentBeaconBlockRoot / blob fields), so the service
-# answers the same Unsupported fork error geth gives for this CL/chain mismatch. The V2
-# build/fetch/submit loop itself is covered by the engine unit tests on a SHANGHAI
-# fixture.
+# with -38005 Unsupported fork. The harness chain runs executor_version=2 with
+# evm_revision=cancun (the production [op_engine_rpc] configuration), so the header-fork
+# derivation keys off CANCUN; a V2 attribute shape cannot express CANCUN
+# (parentBeaconBlockRoot), so the service answers the same Unsupported fork error geth
+# gives for this CL/chain mismatch. The V2 build/fetch/submit loop itself is covered by
+# the engine unit tests on a SHANGHAI fixture.
 log_test "engine_forkchoiceUpdatedV2 answers -38005 (chain fork outruns V2)"
 V2_HEAD=$(json_val "$(rpc_call "eth_getBlockByNumber" '["latest",false]')" "hash")
 V2_TS_SECS=$((TS_SECS + 12))

--- a/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
+++ b/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
@@ -1232,11 +1232,12 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
 // with the canonical EMPTY-TRIE ROOT (EngineServiceImpl.h, TODO(C4 header fields)) instead
 // of the L2ToL1MessagePasser storage root, and the hashed header commits to the SAME value
 // (a consumer rebuilding the header from the payload's withdrawalsRoot must reproduce
-// blockHash). getPayloadV5 serves that root, and newPayloadV4 accepts it because
-// validateExecutionPayload can only check presence. Nothing about the executor version
-// changes that — buildPayload has no executor-version branch. When C4 computes the real
-// root this test MUST fail and be rewritten to assert the computed value; until then it
-// keeps the gap visible instead of letting the v2 path look covered.
+// blockHash). getPayloadV5 serves that root, and newPayloadV4 rejects any root OTHER than
+// withdrawalsRootFor() (validateExecutionPayload enforces the equality, not just
+// presence); a missing on-chain EVM revision also fails closed with UnsupportedFork.
+// When C4 computes the real root this test MUST fail and be rewritten to assert the
+// computed value; until then it keeps the gap visible instead of letting the v2 path look
+// covered.
 BOOST_AUTO_TEST_CASE(engineServiceKarstServesZeroWithdrawalsRoot)
 {
     task::syncWait([&, this]() -> task::Task<void> {

--- a/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
+++ b/transaction-scheduler/tests/TestEthereumExecutorScheduler.cpp
@@ -1103,6 +1103,17 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
                     std::string(magic_enum::enum_name(ledger::SystemConfig::executor_version))},
                 std::move(entry));
 
+            // LONDON chain, matching the V1 forkchoiceUpdated attribute shape used below
+            // (no withdrawals / parentBeaconBlockRoot): the header-fork derivation keys off
+            // the chain's EVM revision, and without an explicit one the compile-time
+            // default (OSAKA -> PRAGUE) would demand fields a V1 build cannot supply.
+            storage::Entry evmcEntry;
+            evmcEntry.set(bcos::storage::serialize::encode(ledger::SystemConfigEntry{
+                ledger::encodeEVMCRevisionConfig(EVMC_LONDON, {}), 0}));
+            co_await storage2::writeOne(backendStorage,
+                executor_v1::StateKey{ledger::SYS_CONFIG, ledger::SYSTEM_KEY_EVMC_REVISION},
+                std::move(evmcEntry));
+
             storage::Entry gasLimitEntry;
             gasLimitEntry.set(
                 bcos::storage::serialize::encode(ledger::SystemConfigEntry{"3000000000", 0}));
@@ -1180,7 +1191,9 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
         bcos::engine::ForkchoiceState fc{genesisHash, genesisHash, genesisHash};
         bcos::engine::PayloadAttributes attrs;
         attrs.prevRandao = cryptoSuite->hashImpl()->hash(std::string("randao"));
-        attrs.timestamp = 12345;
+        // Whole-second milliseconds: the header the build finalizes must satisfy
+        // validateHeader's "timestamp is a whole number of seconds" check.
+        attrs.timestamp = 12345ULL * 1000;
         auto fcResult = co_await engineService.updateForkchoice(fc, &attrs, 1);
         BOOST_REQUIRE(fcResult.payloadId.has_value());
 
@@ -1215,12 +1228,14 @@ BOOST_AUTO_TEST_CASE(engineServiceSealsAndExecutesRealTx)
 // op_engine_rpc, so this — not the v1 escape hatch the integration script drives — is the
 // configuration external CLs talk to.
 //
-// What it pins is a known defect, deliberately: buildPayload stamps withdrawalsRoot with a
-// zero PLACEHOLDER (EngineServiceImpl.h, TODO(C4 header fields)) instead of the
-// L2ToL1MessagePasser storage root, getPayloadV5 serves that zero, and newPayloadV4 accepts
-// it because validateExecutionPayload can only check presence. Nothing about the executor
-// version changes that — buildPayload has no executor-version branch. When C4 computes the
-// real root this test MUST fail and be rewritten to assert the computed value; until then it
+// What it pins is a known placeholder, deliberately: buildPayload stamps withdrawalsRoot
+// with the canonical EMPTY-TRIE ROOT (EngineServiceImpl.h, TODO(C4 header fields)) instead
+// of the L2ToL1MessagePasser storage root, and the hashed header commits to the SAME value
+// (a consumer rebuilding the header from the payload's withdrawalsRoot must reproduce
+// blockHash). getPayloadV5 serves that root, and newPayloadV4 accepts it because
+// validateExecutionPayload can only check presence. Nothing about the executor version
+// changes that — buildPayload has no executor-version branch. When C4 computes the real
+// root this test MUST fail and be rewritten to assert the computed value; until then it
 // keeps the gap visible instead of letting the v2 path look covered.
 BOOST_AUTO_TEST_CASE(engineServiceKarstServesZeroWithdrawalsRoot)
 {
@@ -1251,6 +1266,17 @@ BOOST_AUTO_TEST_CASE(engineServiceKarstServesZeroWithdrawalsRoot)
                 executor_v1::StateKey{ledger::SYS_CONFIG,
                     std::string(magic_enum::enum_name(ledger::SystemConfig::executor_version))},
                 std::move(entry));
+
+            // The Karst chain these tests model runs CANCUN; without an explicit revision
+            // getLedgerConfig falls back to the compile-time default (OSAKA -> PRAGUE),
+            // which would demand fields the V3 attribute shape still supplies, but an
+            // explicit value keeps the fixture honest.
+            storage::Entry evmcEntry;
+            evmcEntry.set(bcos::storage::serialize::encode(ledger::SystemConfigEntry{
+                ledger::encodeEVMCRevisionConfig(EVMC_CANCUN, {}), 0}));
+            co_await storage2::writeOne(backendStorage,
+                executor_v1::StateKey{ledger::SYS_CONFIG, ledger::SYSTEM_KEY_EVMC_REVISION},
+                std::move(evmcEntry));
         }
 
         static auto blockFactory =
@@ -1262,7 +1288,9 @@ BOOST_AUTO_TEST_CASE(engineServiceKarstServesZeroWithdrawalsRoot)
         bcos::engine::ForkchoiceState fc{genesisHash, genesisHash, genesisHash};
         bcos::engine::PayloadAttributes attrs;
         attrs.prevRandao = cryptoSuite->hashImpl()->hash(std::string("randao"));
-        attrs.timestamp = 12345;
+        // Whole-second milliseconds: the header the build finalizes must satisfy
+        // validateHeader's "timestamp is a whole number of seconds" check.
+        attrs.timestamp = 12345ULL * 1000;
         attrs.withdrawals = std::vector<bcos::engine::WithdrawalV1>{};
         attrs.parentBeaconBlockRoot = bcos::h256{};
         auto fcResult = co_await engineService.updateForkchoice(fc, &attrs, 3);
@@ -1270,9 +1298,11 @@ BOOST_AUTO_TEST_CASE(engineServiceKarstServesZeroWithdrawalsRoot)
 
         auto payload = co_await engineService.getPayload(*fcResult.payloadId, 5);
         BOOST_REQUIRE(payload);
-        // The zero placeholder, served verbatim to the CL by a v2 node.
+        // The empty-trie root placeholder, served verbatim to the CL by a v2 node, agreeing
+        // with the root committed to the hashed header.
         BOOST_REQUIRE(payload->executionPayload.withdrawalsRoot.has_value());
-        BOOST_CHECK_EQUAL(*payload->executionPayload.withdrawalsRoot, bcos::h256{});
+        BOOST_CHECK_EQUAL(
+            *payload->executionPayload.withdrawalsRoot, bcos::ledger::mpt::emptyRootHash());
 
         bcos::engine::NewPayloadRequest request;
         request.executionPayload = payload->executionPayload;


### PR DESCRIPTION
## 概述

在 FISCO-BCOS 承载 OP Stack L2（以太坊兼容层）的进程中，此前 Engine API 产出的区块只有 FISCO 原生头，`eth_*` RPC 返回的 `nonce` / `sha3Uncles` / `difficulty` / `baseFeePerGas` / `withdrawalsRoot` / `blobGasUsed` 等字段均为 mock 固定值，无法与 op-node/geth 对齐。

本 PR 是前序基建（`EthBlockHeader` RLP 桥、Tars schema eth 字段、`calculateHash` 的 eth 分派、eth genesis artifact，见 #5409 等）的最后一公里：把 Engine 产块写路径与 `eth_*` 读路径接入这套基建，同时统一 timestamp 单位模型并清理重复代码。

## 改动内容

### 1. rlp-protocol：统一 timestamp 为单一「秒」域（EthBlockHeader.h/.cpp）

- **单域时间戳模型**：`EthBlockHeaderData::timestamp` 统一为 **Ethereum RLP 域（秒）**；删除内部毫秒镜像 `m_timestampMs` 与 `timestampMs()`，只保留一个 timestamp。毫秒转换只在 tar 边界发生：
  - 构造 `EthBlockHeader(BlockHeader)`（ms→s `/1000`），并对**非整秒毫秒抛 `std::invalid_argument`**（消息携带实际毫秒值）——堵住「直接 ctor + rlpEncode」的 validate-skipping 路径（`validateHeader` 的 `% 1000` gate 只覆盖 `calculateRLPHash` 路径，消息同样携带实际值）；
  - `toTarsHeader`（s→ms `×1000`），带 int64 溢出检查，且**失败路径在返回前 `header->clear()`**，与同函数 `validateHeader` 失败路径保持一致的空状态后置条件。
- **删除 `decodeTarsHeader`**（FISCO 原生/非 eth OP 区块不存在需要 RLP 编码的场景，全仓库无调用方）及对应测试。
- **保留 `computeHash`**（`opstack-executor` 的区块身份函数，`OpScheduler.h` 5 处 + `OpSchedulerTest.cpp` 1 处共 6 个调用点）：无 validateHeader、不改写 header，供 `EthBlockVersion::NON_ETH` 头（`calculateRLPHash` 的 validateHeader 会拒绝）计算 `keccak256(rlp(header))`。
- **消除字段重复**：`rlpEncode`/`rlpDecode` 委托 `codec::rlp::encode/decode(EthBlockHeaderData)`——21 字段规范顺序的唯一来源（`EthBlockBody` 的 header 与 ommers 复用同一 codec）。同时保留负数防御检查与 `rlpDecode` 的 fork 版本派生逻辑（LONDON→PRAGUE）。

### 2. engine：产块收尾为 Eth 头并注入 RLP 哈希（EngineServiceImpl.h/.cpp）

- **header fork era 从链派生**：新增 `ethBlockVersionFor(evmc_revision)`，将链配置的逐块 EVM revision（`ledgerConfig.evmcRevisionForBlock`，即 geth `config.LatestFork(timestamp)` 的对应物）映射到 `EthBlockVersion`——LONDON/PARIS→LONDON、SHANGHAI→SHANGHAI、CANCUN→CANCUN、PRAGUE/OSAKA→PRAGUE；低于 LONDON 的 revision（FRONTIER..BERLIN）映射 LONDON 下限；**高于最高已映射 revision 的未知值抛 `UnsupportedFork`**（未来 EVMC bump 强制显式决策，避免以错误 fork 规则哈希区块）。
- **缺失 revision 时 fail closed**：`evmcRevisionForBlock` 返回空（未配置 on-chain `evmc_revision`）时抛 `UnsupportedFork`，**不再默认到编译期最新（OSAKA→PRAGUE）**——哈希路径不允许假设一个链从未配置的 fork。v2 链的 genesis 恒持久化 revision（Initializer 拒绝启动无 revision 的 v2 节点），因此该分支只命中配置错误的链。
- **`finalizeEthBlockHeader`**：填充 post-merge 常量（空 ommers 哈希 `0x1dcc4de8…`、difficulty=0、nonce=0）、透传 payload 的 `baseFee`/`logsBloom`；按 fork 门控设置 `withdrawalsRoot`（SHANGHAI+，empty-trie 占位）、blob 对与 `parentBeaconBlockRoot`（CANCUN+，`.value()` 而非 `value_or`，缺失字段不哈希成显式零；声明处注明前置条件）、EIP-7685 空 `requestsHash`（PRAGUE+，`0xe3b0c442…` = sha256("")）；标记 `EthBlockVersion` 并注入 `keccak256(rlp(header))`。
- **payload 形状与 header fork 同源**：`buildPayload` 的 payload 字段填充（`withdrawals`/`withdrawalsRoot`/blob 对）由链派生 `forkVersion` 驱动，保证「served payload 形状 == hashed header fork」恒成立；`buildPayload` 的 method `version` 参数不再参与函数体逻辑（标记 `[[maybe_unused]]`，`updateForkchoice` 调用点仍用它标记 `PayloadEntry`）。
- **方法版本与链 fork 一致性 gate**：CANCUN+ 链要求 V3 attributes（`parentBeaconBlockRoot`）、SHANGHAI+ 链要求 V2 attributes（`withdrawals`）；不满足抛 `UnsupportedFork`，RPC 层映射为 **`-38005 Unsupported fork`**（与 geth 对同一 CL/链不匹配的应答一致），而非 `-32603 InternalError`。
- **拒绝非空 withdrawals**：`withdrawals` trie root 尚未计算（`finalizeEthBlockHeader` 以 empty-trie root 占位），`validatePayloadAttributes` 拒绝「非空 withdrawals 列表」，否则 header 哈希的 root 与 geth 的 `DeriveSha(withdrawals)` 不一致、所有 peer 都会拒绝区块。
- **`withdrawalsRoot` 双端一致**：`executionPayload.withdrawalsRoot` 与 hashed header 均写入 `emptyRootHash()`（C1/F2），任何从 payload 字段重建 header 的消费者都能复现 `blockHash`。
- **修正空块根语义**：空区块的 `txsRoot`/`receiptsRoot` 从全零改为 canonical empty-trie root（`mpt::emptyRootHash()`），满足 Eth header 校验且可与 op-node 对拍。

### 3. rpc：`eth_*` 响应按 Eth 头直读 + 分叉门控（BlockResponse.cpp）

- **Eth 头**（`ethBlockVersion != NON_ETH`）：`nonce`/`sha3Uncles`/`miner`（EIP-55 checksum 地址）/`difficulty`/`mixHash`/`gasLimit`/`logsBloom` 等全部从 header 直读；分叉字段按版本门控输出——`baseFeePerGas`（LONDON+）、`withdrawals`/`withdrawalsRoot`（SHANGHAI+，root 无值时用 empty-trie root **无条件输出**）、`blobGasUsed`/`excessBlobGas`/`parentBeaconBlockRoot`（CANCUN+）、`requestsHash`（PRAGUE+）。
- **NON_ETH 原生头**：**行为保持不变**——`gasLimit` 回退固定值 `0x1c9c380`、mock 字段原样输出、`miner` 仍由 sealer 列表推导。
- **genesis `parentHash`**：改从 `parentInfo()` 直读（原实现对 `number == 0` 强制置零）。行为不变依赖「genesis header 永不携带 parentInfo」的不变量（`BlockHeaderImpl::parentInfo()` 对空列表返回零 hash，`Ledger.cpp` 已注释），并在此处补充说明性注释。

### 4. 其余

- `engine/CMakeLists.txt`：`rlp-protocol` 由 PUBLIC 改为 PRIVATE 链接。
- `Ledger.cpp`：补充 genesis parentInfo 语义注释。
- `engine/test/CMakeLists.txt`：测试目标链接 `rlp-protocol`（供强锚定测试使用）。

## 影响与兼容性

- **FISCO-BCOS 原生链的 RPC 响应行为保持不变**（gasLimit 仍为 `0x1c9c380`、mock 字段仍在、miner 仍由 sealer 推导）；仅 Engine API 产出的 Eth 区块走新的 header 直读 + 分叉门控路径。
- **V1/V2 forkchoiceUpdated 在 CANCUN+ 链上被显式拒绝 `-38005`**：链 EVM revision 为 CANCUN+ 时，V3 以下 FCU 属性形状无法表达链 fork 的 header 字段。V1/V2 端到端 build 循环由单测在 SHANGHAI/LONDON fixture 上覆盖；CI 集成测试的 V2 用例已改为断言 `-38005`。
- **CI 集成测试 harness 链升级为生产配置**：`tools/engine_integration_test.sh` 的 genesis 改为 `[executor] version=2` + `evm_revision=cancun`（移除测试逃生口 `unsafe_allow_v1_executor`），使 Engine API 集成测试驱动与生产一致的 v2 EthereumExecutor 路径。
- **占位/近似项**（与 op-node/geth 的完全对齐待后续 MPT 工作）：
  - `stateRoot` 为 XOR 近似（既有实现，已标注 TODO）；
  - `withdrawalsRoot` 为空 trie root 占位（header 与 payload 已一致；**非空 withdrawals 列表被拒绝**直至真实 root 计算落地）；
  - **非空块的 `txsRoot`/`receiptsRoot` 是 FISCO 二叉 Merkle 而非以太坊 trie root**——"与 op-node/geth 对齐"目前仅对空块成立；
  - `baseFee` 为 0（FISCO 尚不计算真实 EIP-1559 base fee）。
- 旧数据兼容性：base 期间初始化的 dev 链 genesis 头存的是秒，升级后需重建 devnet（特性未发布，可接受）。

## 测试

- `test-bcos-rlp-protocol`：64 用例全部通过——RLP 编解码 round-trip、golden 主网区块哈希（`0x95d7f597…`）、版本推导、NON_ETH round-trip、EthBlockBody/EthWithdrawal、`toTarsHeader` 溢出拒绝（含 clear-on-failure 后置条件）。
- `test-bcos-engine`：`ethBlockVersionFor` evmc_revision 映射（含 `EVMC_EXPERIMENTAL` 超范围拒绝、`BOOST_CHECK_EXCEPTION` 断言唯一 `what()`）、`finalizeEthBlockHeader` 字段填充与分叉门控（LONDON/SHANGHAI/CANCUN/PRAGUE）、空区块 RLP 哈希强锚定、CANCUN 链上 V2 FCU 拒绝（`UnsupportedFork`，断言唯一 gate 消息）、非空 withdrawals 拒绝。
- `GenesisEthHeaderTest`：eth genesis artifact 哈希与 python 参考一致、重启/篡改场景。
- `Web3ResponseTest`：每 fork（LONDON/SHANGHAI/CANCUN/PRAGUE）的 gated keys 精确 presence/absence 矩阵、logsBloom 数据源、EIP-55 独立 oracle（`0x5aAeb605…`）、NON_ETH 原生头行为保持。
- `EngineRpcTest`：服务层 `UnsupportedFork` → RPC `-38005` 映射。
- `opstack-executor-tests` / `opstack-executor-scheduler-tests`：`computeHash` 6 个调用点编译链接与运行全绿。
- 静态库：`ledger` / `engine` / `rpc` 编译通过；`fisco-bcos` 主程序编译链接通过。
- `engine_integration_test.sh` / `mock_consensus_client.py`：语法校验通过（完整运行依赖 CI 节点环境）。

## 备注

- **`newPayload` 不 re-hash**：既有问题，已在 `EngineServiceImpl.h` 注明延期（#5468）。
- **共享 `RLPDecode.h` 的 leading-zero 整数接受**：位于本 PR 文件集之外，`rlpDecode` 注释已如实记录 ACCEPT 语义（ywy 建议可作 follow-up）。
- **NON_ETH 分支的 hashed 字段零 mock**：Engine-built 区块恒走 ETH 分支，NON_ETH 零 mock 仅可能由非 Engine 生产者触发（ywy 建议可作 follow-up）。