### PR TITLE
ci: run Integration test - Air phases in parallel and seal blocks on demand

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -186,10 +186,11 @@ jobs:
         with:
           collection: https://raw.githubusercontent.com/FISCO-BCOS/FISCOBCOS-RPC-API/main/fiscobcos.rpcapi.collection.json
       - name: Integration test - Air
+        # ubuntu 两条腿资源充足（4 vCPU/16GB），三个阶段（non-sm/sm/baseline）并行运行
         if: matrix.os != 'windows-2025' && matrix.os != 'macos-15'
         run: |
           cd tools
-          bash .ci/ci_check_air.sh ${{ github.base_ref }} "true"
+          bash .ci/ci_check_air.sh ${{ github.base_ref }} "true" parallel
       - name: Ethereum executor integration test (executor_version=2)
         # Runs a single-node L2 chain with executor_version=2 (ethereum-executor),
         # pre-funds an EOA via genesis alloc, and drives a simple value transfer

--- a/tools/.ci/ci_check_air.sh
+++ b/tools/.ci/ci_check_air.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 console_branch="master"
-fisco_bcos_path="../build/fisco-bcos-air/fisco-bcos"
+# 使用绝对路径，支持在阶段工作目录（AIR_WORKDIR）中运行
+fisco_bcos_path="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/build/fisco-bcos-air/fisco-bcos"
 build_chain_path="BcosAirBuilder/build_chain.sh"
-current_path=`pwd`
+# AIR_WORKDIR 由并行编排器设置，指向阶段独立工作目录；默认为当前目录
+current_path="${AIR_WORKDIR:-$(pwd)}"
+cd "${current_path}" || exit 1
 node_list="node0"
 expanded_node="node3"
 check_web3_test="false"
 # 导出环境变量给子脚本使用：SKIP_BUILD=跳过下载构建，RUN_DMC=运行DMC转账测试
-export SKIP_BUILD="false"
+# 注意：并行编排器会以 SKIP_BUILD=true 启动各阶段，这里不能覆盖继承来的值
+export SKIP_BUILD="${SKIP_BUILD:-false}"
 export RUN_DMC="false"
+# 各阶段端口（set_phase_ports 按阶段隔离，默认保持原值）
+p2p_port_start=30300
+rpc_port_start=20200
+web3_port=8545
+export RPC_PORT=${rpc_port_start}
+export WEB3_PORT=${web3_port}
+
 LOG_ERROR() {
     local content=${1}
     echo -e "\033[31m ${content}\033[0m"
@@ -22,6 +33,36 @@ LOG_INFO() {
 LOG_WARN() {
     local content=${1}
     echo -e "\033[31m[ERROR] ${content}\033[0m"
+}
+
+# 按阶段设置隔离端口，保证三个阶段可以并行运行；
+# AIR_PORT_OFFSET 用于本地调试时整体偏移端口，避免与已有节点冲突
+set_phase_ports()
+{
+    local offset=${AIR_PORT_OFFSET:-0}
+    case "${1}" in
+        non-sm)
+            p2p_port_start=$((30300 + offset))
+            rpc_port_start=$((20200 + offset))
+            web3_port=$((8545 + offset))
+            ;;
+        sm)
+            p2p_port_start=$((31300 + offset))
+            rpc_port_start=$((21200 + offset))
+            web3_port=$((8555 + offset))
+            ;;
+        baseline)
+            p2p_port_start=$((32300 + offset))
+            rpc_port_start=$((22200 + offset))
+            web3_port=$((8565 + offset))
+            ;;
+        *)
+            LOG_ERROR "unknown phase: ${1}"
+            exit 1
+            ;;
+    esac
+    export RPC_PORT=${rpc_port_start}
+    export WEB3_PORT=${web3_port}
 }
 
 stop_node()
@@ -69,6 +110,12 @@ wait_and_start()
     fi
 }
 
+# 开启 node0 的 web3_rpc 并设置阶段隔离的 web3 端口
+enable_web3_rpc()
+{
+    perl -p -i -e 'if (/\[web3_rpc\]/) { $flag=1 } elsif ($flag && /^\[/) { $flag=0 } if ($flag) { s/enable\s*=\s*false/enable=true/i; s/listen_port=8545/listen_port='"${web3_port}"'/; }' nodes/127.0.0.1/node0/config.ini
+}
+
 init()
 {
     sm_option="${1}"
@@ -76,9 +123,9 @@ init()
     echo " ==> fisco-bcos version: "
     ${fisco_bcos_path} -v
     clear_node
-    bash ${build_chain_path} -l "127.0.0.1:1" -e ${fisco_bcos_path} "${sm_option}"
+    bash ${build_chain_path} -l "127.0.0.1:1" -p "${p2p_port_start},${rpc_port_start}" -e ${fisco_bcos_path} "${sm_option}"
     # enable web3_rpc on node0 config.ini
-    perl -p -i -e 'if (/\[web3_rpc\]/) { $flag=1 } elsif ($flag && s/enable\s*=\s*false/enable=true/i) { $flag=0; }' nodes/127.0.0.1/node0/config.ini
+    enable_web3_rpc
     cd nodes/127.0.0.1 && wait_and_start
 }
 
@@ -89,18 +136,22 @@ init_baseline()
     echo " ==> fisco-bcos version: "
     ${fisco_bcos_path} -v
     clear_node
-    bash ${build_chain_path} -l "127.0.0.1:1" -e ${fisco_bcos_path} "${sm_option}"
+    bash ${build_chain_path} -l "127.0.0.1:1" -p "${p2p_port_start},${rpc_port_start}" -e ${fisco_bcos_path} "${sm_option}"
 
     # 启用executor v1
     # Enable executor v1
     perl -p -i -e 's/version=0/version=1/g' nodes/127.0.0.1/node*/config.genesis
-    perl -p -i -e 'if (/web3_rpc/) { $flag=1 } elsif ($flag && s/enable\s*=\s*false/enable=true/i) { $flag=0; }' nodes/127.0.0.1/node0/config.ini
+    # enable web3_rpc on node0 config.ini
+    enable_web3_rpc
     cd nodes/127.0.0.1 && wait_and_start
 }
 
 expand_node()
 {
     sm_option="${1}"
+    local expanded_p2p_port=$((p2p_port_start + 3))
+    local expanded_rpc_port=$((rpc_port_start + 3))
+    local expanded_web3_port=$((web3_port + 1))
     LOG_INFO "expand node..."
     cd ${current_path}
     rm -rf config
@@ -113,10 +164,10 @@ expand_node()
     if [ "$(uname)" == "Darwin" ];then
         sed_cmd="sed -i .bkp"
     fi
-    ${sed_cmd}  's/listen_port=30300/listen_port=30303/g' config/config.ini
-    ${sed_cmd}  's/listen_port=20200/listen_port=20203/g' config/config.ini
-    ${sed_cmd}  's/listen_port=8545/listen_port=8546/g' config/config.ini
-    sed -e 's/"nodes":\[/"nodes":\["127.0.0.1:30303",/' config/nodes.json.tmp > config/nodes.json
+    ${sed_cmd}  "s/listen_port=${p2p_port_start}/listen_port=${expanded_p2p_port}/g" config/config.ini
+    ${sed_cmd}  "s/listen_port=${rpc_port_start}/listen_port=${expanded_rpc_port}/g" config/config.ini
+    ${sed_cmd}  "s/listen_port=${web3_port}/listen_port=${expanded_web3_port}/g" config/config.ini
+    sed -e 's/"nodes":\[/"nodes":\["127.0.0.1:'"${expanded_p2p_port}"'",/' config/nodes.json.tmp > config/nodes.json
     cat config/nodes.json
     bash ${build_chain_path} -C expand -c config -d config/ca -o nodes/127.0.0.1/node3 -e ${fisco_bcos_path} "${sm_option}"
     LOG_INFO "expand node success..."
@@ -146,13 +197,30 @@ expand_node()
     fi
 }
 
-# 检查节点是否已达成共识（出块），测试前健康检查
+# 检查节点是否已达成共识（出块），测试前健康检查；轮询 reachNewView 替代固定 sleep
 check_consensus()
 {
     cd ${current_path}/nodes/127.0.0.1
-    LOG_INFO "=== wait for the node to reach consensus, waitTime: 20s ====="
-    sleep 20
-    LOG_INFO "=== wait for the node to reach consensus finish ====="
+    LOG_INFO "=== wait for the node to reach consensus (polling reachNewView) ====="
+    local max_wait=60
+    local waited=0
+    local all_ok='false'
+    while [ $waited -lt $max_wait ]; do
+        all_ok='true'
+        for node in ${node_list}
+        do
+            if ! cat ${node}/log/* 2>/dev/null | grep -qi reachN; then
+                all_ok='false'
+                break
+            fi
+        done
+        if [ "${all_ok}" == 'true' ]; then
+            break
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+    LOG_INFO "=== wait for the node to reach consensus finish (waited ${waited}s) ====="
     for node in ${node_list}
     do
         LOG_INFO "check_consensus for ${node}"
@@ -175,8 +243,19 @@ clear_node()
     cd ${current_path}
     if [ -d "nodes" ]; then
         bash nodes/127.0.0.1/stop_all.sh 2>/dev/null
-        # 确保 fisco-bcos 进程确实已退出，防止僵尸进程占用端口
-        if pgrep -f "fisco-bcos" > /dev/null 2>&1; then
+        # 确保本工作目录下的 fisco-bcos 进程确实已退出，防止僵尸进程占用端口；
+        # 注意：只能 kill 属于本工作目录的进程，并行阶段之间不能互相误杀
+        if [ -d /proc ]; then
+            for pid in $(pgrep -f "fisco-bcos" 2>/dev/null); do
+                proc_cwd=$(readlink /proc/${pid}/cwd 2>/dev/null)
+                case "${proc_cwd}" in
+                    "${current_path}"*)
+                        LOG_ERROR "Node process ${pid} (cwd ${proc_cwd}) still running after stop, force killing..."
+                        kill -9 ${pid} 2>/dev/null || true
+                        ;;
+                esac
+            done
+        elif pgrep -f "fisco-bcos" > /dev/null 2>&1; then
             LOG_ERROR "Nodes still running after stop, force killing..."
             pkill -9 -f "fisco-bcos" 2>/dev/null || true
         fi
@@ -278,6 +357,197 @@ prebuild_deps()
     LOG_INFO "======== Prebuild dependencies done, SKIP_BUILD=true ========"
 }
 
+# ============ non-sm 测试（含扩容）============
+run_non_sm()
+{
+    LOG_INFO "======== check non-sm case ========"
+    export RUN_DMC="false"
+    init ""
+    expand_node ""
+    check_consensus
+    bash ${current_path}/.ci/console_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "console_integrationTest error"
+        exit 1
+    fi
+    LOG_INFO "console_integrationTest success"
+
+    bash ${current_path}/.ci/java_sdk_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "java_sdk_integrationTest error"
+        exit 1
+    fi
+    LOG_INFO "java_sdk_integrationTest success"
+
+    # java-sdk-demo 依赖 console 构建产物，串行执行
+    bash ${current_path}/.ci/java_sdk_demo_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "java_sdk_demo_ci_test error"
+        exit 1
+    fi
+    LOG_INFO "java_sdk_demo_ci_test success"
+    LOG_INFO "======== check non-sm success ========"
+    clear_node
+}
+
+# ============ sm 国密测试（扩容、不跑DMC）============
+run_sm()
+{
+    LOG_INFO "======== check sm case ========"
+    export RUN_DMC="false"
+    init "-s"
+    expand_node "-s"
+    check_consensus
+    bash ${current_path}/.ci/console_ci_test.sh ${console_branch} "true" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "console_integrationTest error"
+        exit 1
+    fi
+    LOG_INFO "console_integrationTest success"
+
+    bash ${current_path}/.ci/java_sdk_ci_test.sh ${console_branch} "true" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "java_sdk_integrationTest error"
+        exit 1
+    fi
+    LOG_INFO "java_sdk_integrationTest success"
+
+    bash ${current_path}/.ci/java_sdk_demo_ci_test.sh ${console_branch} "true" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "java_sdk_demo_ci_test error"
+        exit 1
+    fi
+    LOG_INFO "java_sdk_demo_ci_test success"
+    LOG_INFO "======== check sm case success ========"
+    clear_node
+}
+
+# ============ baseline 测试（executor v1，含 web3 测试）============
+run_baseline()
+{
+    LOG_INFO "======== check baseline cases ========"
+    export RUN_DMC="false"
+    init_baseline ""
+    expand_node ""
+    check_consensus
+    bash ${current_path}/.ci/console_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "console_integrationTest error"
+        exit 1
+    fi
+    LOG_INFO "console_integrationTest success"
+
+    bash ${current_path}/.ci/java_sdk_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "java_sdk_integrationTest error"
+        exit 1
+    fi
+    LOG_INFO "java_sdk_integrationTest success"
+
+    bash ${current_path}/.ci/java_sdk_demo_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
+    if [[ ${?} != "0" ]]; then
+        echo "java_sdk_demo_ci_test error"
+        exit 1
+    fi
+    LOG_INFO "java_sdk_demo_ci_test success"
+
+    if [[ ${check_web3_test} == "true" ]]; then
+        LOG_INFO "======== check web3 test ========"
+        cp ${current_path}/nodes/127.0.0.1/sdk/* ${current_path}/console/dist/conf/
+        rm -rf ${current_path}/console/dist/account/ecdsa/*
+        cp ${current_path}/nodes/ca/accounts/* ${current_path}/console/dist/account/ecdsa/
+        cd "${current_path}/console/dist/"
+        account=$(bash console.sh listAccount | grep "current account" | awk -F '(' '{print $1}')
+        bash console.sh addBalance "${account}" 200 ether
+        bash console.sh setSystemConfigByKey tx_gas_price 1
+        cd ${current_path}
+        bash ${current_path}/.ci/web3_test.sh "${current_path}/console/dist/account/ecdsa/${account}.pem"
+        if [[ ${?} == "0" ]]; then
+            LOG_INFO "web3 test success"
+        else
+            echo "web3 test error"
+            exit 1
+        fi
+    fi
+
+    stop_node
+    LOG_INFO "======== check baseline cases success ========"
+    clear_node
+    LOG_INFO "======== clear node after baseline test success ========"
+}
+
+# ============ 并行编排：三个阶段在独立工作目录中并行运行 ============
+run_parallel()
+{
+    # 前面步骤（如 RPCAPI 测试）可能在 tools/nodes 留下了运行中的链，先清理，
+    # 否则会与非-sm 阶段的默认端口冲突
+    clear_node
+    # 依赖只需预构建一次，之后硬链接复制到各阶段工作目录（写时复制，不占额外磁盘）
+    prebuild_deps
+
+    local base_dir=${current_path}/.air-parallel
+    rm -rf ${base_dir}
+    mkdir -p ${base_dir}
+    local phase_list="non-sm sm baseline"
+    local pid_non_sm=""
+    local pid_sm=""
+    local pid_baseline=""
+
+    for phase in ${phase_list}
+    do
+        local work_dir=${base_dir}/${phase}
+        mkdir -p ${work_dir}
+        # 实体复制（不能用硬链接：各阶段会向证书等文件写入不同内容，
+        # 共享 inode 会互相污染）
+        for dir in .ci BcosAirBuilder console java-sdk java-sdk-demo
+        do
+            cp -a ${dir} ${work_dir}/${dir}
+        done
+        # 示例链数据体积大且阶段内用不到，从副本中剔除
+        rm -rf ${work_dir}/BcosAirBuilder/nodes ${work_dir}/BcosAirBuilder/nodes.tar.gz
+        LOG_INFO "launch phase ${phase}, workdir: ${work_dir}, log: ${base_dir}/${phase}.log"
+        AIR_WORKDIR=${work_dir} SKIP_BUILD=true bash ${current_path}/.ci/ci_check_air.sh "${console_branch}" "${check_web3_test}" "${phase}" > ${base_dir}/${phase}.log 2>&1 &
+        case "${phase}" in
+            non-sm) pid_non_sm=$! ;;
+            sm) pid_sm=$! ;;
+            baseline) pid_baseline=$! ;;
+        esac
+    done
+
+    local failed_phases=""
+    for phase in ${phase_list}
+    do
+        local pid=""
+        case "${phase}" in
+            non-sm) pid=${pid_non_sm} ;;
+            sm) pid=${pid_sm} ;;
+            baseline) pid=${pid_baseline} ;;
+        esac
+        if wait ${pid}; then
+            LOG_INFO "======== phase ${phase} success ========"
+        else
+            LOG_ERROR "======== phase ${phase} FAILED, log below ========"
+            failed_phases="${failed_phases} ${phase}"
+        fi
+    done
+
+    if [ -n "${failed_phases}" ]; then
+        for phase in ${failed_phases}
+        do
+            LOG_ERROR "########## log of failed phase ${phase} ##########"
+            cat ${base_dir}/${phase}.log
+            LOG_ERROR "########## log of failed phase ${phase} end ##########"
+        done
+        # 失败时保留工作目录便于排查（CI runner 为一次性环境，无磁盘顾虑）
+        LOG_ERROR "parallel run failed, phases:${failed_phases}"
+        exit 1
+    fi
+
+    # 成功时清理工作目录
+    rm -rf ${base_dir}
+    LOG_INFO "======== all parallel phases success ========"
+}
+
 if [[ -n "${1}" ]]; then
      console_branch=${1}
 fi
@@ -286,115 +556,34 @@ if [[ -n "${2}" ]]; then
      check_web3_test=${2}
 fi
 
-# ============ 阶段1：预构建所有依赖（仅一次）============
-prebuild_deps
-
-# ============ 阶段2：non-sm 测试（含扩容）============
-LOG_INFO "======== check non-sm case ========"
-export RUN_DMC="false"
-init ""
-expand_node ""
-check_consensus
-bash ${current_path}/.ci/console_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "console_integrationTest error"
-    exit 1
-fi
-LOG_INFO "console_integrationTest success"
-
-bash ${current_path}/.ci/java_sdk_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "java_sdk_integrationTest error"
-    exit 1
-fi
-LOG_INFO "java_sdk_integrationTest success"
-
-# java-sdk-demo 依赖 console 构建产物，串行执行
-bash ${current_path}/.ci/java_sdk_demo_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "java_sdk_demo_ci_test error"
-    exit 1
-fi
-LOG_INFO "java_sdk_demo_ci_test success"
-LOG_INFO "======== check non-sm success ========"
-clear_node
-
-# ============ 阶段3：sm 国密测试（扩容、不跑DMC）============
-LOG_INFO "======== check sm case ========"
-export RUN_DMC="false"
-init "-s"
-expand_node "-s"
-check_consensus
-bash ${current_path}/.ci/console_ci_test.sh ${console_branch} "true" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "console_integrationTest error"
-    exit 1
-fi
-LOG_INFO "console_integrationTest success"
-
-bash ${current_path}/.ci/java_sdk_ci_test.sh ${console_branch} "true" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "java_sdk_integrationTest error"
-    exit 1
-fi
-LOG_INFO "java_sdk_integrationTest success"
-
-bash ${current_path}/.ci/java_sdk_demo_ci_test.sh ${console_branch} "true" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "java_sdk_demo_ci_test error"
-    exit 1
-fi
-LOG_INFO "java_sdk_demo_ci_test success"
-LOG_INFO "======== check sm case success ========"
-clear_node
-
-# ============ 阶段4：baseline 测试（executor v1）============
-LOG_INFO "======== check baseline cases ========"
-export RUN_DMC="false"
-init_baseline ""
-expand_node ""
-check_consensus
-bash ${current_path}/.ci/console_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "console_integrationTest error"
-    exit 1
-fi
-LOG_INFO "console_integrationTest success"
-
-bash ${current_path}/.ci/java_sdk_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "java_sdk_integrationTest error"
-    exit 1
-fi
-LOG_INFO "java_sdk_integrationTest success"
-
-bash ${current_path}/.ci/java_sdk_demo_ci_test.sh ${console_branch} "false" "${current_path}/nodes/127.0.0.1"
-if [[ ${?} != "0" ]]; then
-    echo "java_sdk_demo_ci_test error"
-    exit 1
-fi
-LOG_INFO "java_sdk_demo_ci_test success"
-
-if [[ ${check_web3_test} == "true" ]]; then
-    LOG_INFO "======== check web3 test ========"
-    cp ${current_path}/nodes/127.0.0.1/sdk/* ${current_path}/console/dist/conf/
-    rm -rf ${current_path}/console/dist/account/ecdsa/*
-    cp ${current_path}/nodes/ca/accounts/* ${current_path}/console/dist/account/ecdsa/
-    cd "${current_path}/console/dist/"
-    account=$(bash console.sh listAccount | grep "current account" | awk -F '(' '{print $1}')
-    bash console.sh addBalance "${account}" 200 ether
-    bash console.sh setSystemConfigByKey tx_gas_price 1
-    cd ${current_path}
-    bash ${current_path}/.ci/web3_test.sh "${current_path}/console/dist/account/ecdsa/${account}.pem"
-    if [[ ${?} == "0" ]]; then
-        LOG_INFO "web3 test success"
-    else
-        echo "web3 test error"
+# 第3个参数：运行模式
+#   all（默认）  三个阶段串行（self-hosted 工作流保持原行为）
+#   parallel     三个阶段并行（GitHub-hosted ubuntu runner）
+#   non-sm|sm|baseline  只跑单个阶段（并行编排器内部使用，也可单独调试）
+mode="${3:-all}"
+case "${mode}" in
+    all)
+        prebuild_deps
+        set_phase_ports "non-sm"
+        run_non_sm
+        set_phase_ports "sm"
+        run_sm
+        set_phase_ports "baseline"
+        run_baseline
+        ;;
+    parallel)
+        run_parallel
+        ;;
+    non-sm|sm|baseline)
+        set_phase_ports "${mode}"
+        case "${mode}" in
+            non-sm) run_non_sm ;;
+            sm) run_sm ;;
+            baseline) run_baseline ;;
+        esac
+        ;;
+    *)
+        echo "USAGE: ${0} console_branch check_web3_test [all|parallel|non-sm|sm|baseline]"
         exit 1
-    fi
-fi
-
-stop_node
-LOG_INFO "======== check baseline cases success ========"
-clear_node
-LOG_INFO "======== clear node after baseline test success ========"
+        ;;
+esac

--- a/tools/.ci/console_ci_test.sh
+++ b/tools/.ci/console_ci_test.sh
@@ -68,8 +68,8 @@ config_console()
     mkdir -p "./src/integration-test/resources/conf"
     cp -r ${node_path}/sdk/* ./src/integration-test/resources/conf
     cp ./src/integration-test/resources/config-example.toml ./src/integration-test/resources/config.toml
-    # 单节点模式：peer指向node0(20200)
-    ${sed_cmd} "s/peers=\[\"127.0.0.1:20200\", \"127.0.0.1:20201\"\]/peers=\[\"127.0.0.1:20200\"\]/g" ./src/integration-test/resources/config.toml
+    # 单节点模式：peer指向node0（RPC_PORT 由主脚本按阶段设置，默认20200）
+    ${sed_cmd} "s/peers=\[[^]]*\]/peers=\[\"127.0.0.1:${RPC_PORT:-20200}\"\]/g" ./src/integration-test/resources/config.toml
     cp -r ./src/main/resources/contract ./contracts
     
     local not_use_sm="true"

--- a/tools/.ci/java_sdk_ci_test.sh
+++ b/tools/.ci/java_sdk_ci_test.sh
@@ -82,8 +82,10 @@ config_java_sdk()
     
     use_sm_str="useSMCrypto = \"${use_sm}\""
     ${sed_cmd} "s/useSMCrypto = \"${not_use_sm}\"/${use_sm_str}/g" ./src/integration-test/resources/config.toml
-    # 单节点模式：peer指向node0(20200)
-    ${sed_cmd} 's/peers=\["127.0.0.1:20201"\]/peers=\["127.0.0.1:20200"\]/g' ./src/integration-test/resources/config.toml
+    # 单节点模式：peer指向node0（RPC_PORT 由主脚本按阶段设置，默认20200）
+    ${sed_cmd} "s/peers=\[[^]]*\]/peers=\[\"127.0.0.1:${RPC_PORT:-20200}\"\]/g" ./src/integration-test/resources/config.toml
+    ${sed_cmd} "s/peers=\[[^]]*\]/peers=\[\"127.0.0.1:${RPC_PORT:-20200}\"\]/g" ./src/integration-test/resources/amop/config-subscriber-for-test.toml
+    ${sed_cmd} "s/peers=\[[^]]*\]/peers=\[\"127.0.0.1:${RPC_PORT:-20200}\"\]/g" ./src/integration-test/resources/amop/config-publisher-for-test.toml
     ${sed_cmd} "s/useSMCrypto = \"${not_use_sm}\"/${use_sm_str}/g" ./src/integration-test/resources/amop/config-subscriber-for-test.toml
     ${sed_cmd} "s/useSMCrypto = \"${not_use_sm}\"/${use_sm_str}/g" ./src/integration-test/resources/amop/config-publisher-for-test.toml
     LOG_INFO "Build and Config java sdk success ..."

--- a/tools/.ci/java_sdk_demo_ci_test.sh
+++ b/tools/.ci/java_sdk_demo_ci_test.sh
@@ -120,8 +120,8 @@ config_console()
 
     cp -r ${node_path}/sdk/* ./dist/conf/
     cp ./dist/conf/config-example.toml ./dist/conf/config.toml
-    # 单节点模式：peer指向node0(20200)
-    ${sed_cmd} "s/peers=\[\"127.0.0.1:20200\", \"127.0.0.1:20201\"\]/peers=\[\"127.0.0.1:20200\"\]/g" ./dist/conf/config.toml
+    # 单节点模式：peer指向node0（RPC_PORT 由主脚本按阶段设置，默认20200）
+    ${sed_cmd} "s/peers=\[[^]]*\]/peers=\[\"127.0.0.1:${RPC_PORT:-20200}\"\]/g" ./dist/conf/config.toml
     ${sed_cmd} "s/messageTimeout = \"10000\"/messageTimeout = \"10000000\"/g" ./dist/conf/config.toml
 
     # config test contract
@@ -159,8 +159,8 @@ config_java_sdk_demo()
 
     cp -r ${node_path}/sdk/* ./dist/conf/
     cp ./dist/conf/config-example.toml ./dist/conf/config.toml
-    # 单节点模式：peer指向node0(20200)
-    ${sed_cmd} "s/peers=\[\"127.0.0.1:20200\", \"127.0.0.1:20201\"\]/peers=\[\"127.0.0.1:20200\"\]/g" ./dist/conf/config.toml
+    # 单节点模式：peer指向node0（RPC_PORT 由主脚本按阶段设置，默认20200）
+    ${sed_cmd} "s/peers=\[[^]]*\]/peers=\[\"127.0.0.1:${RPC_PORT:-20200}\"\]/g" ./dist/conf/config.toml
     ${sed_cmd} "s/messageTimeout = \"10000\"/messageTimeout = \"10000000\"/g" ./dist/conf/config.toml
 
     # config admin

--- a/tools/.ci/web3_test.sh
+++ b/tools/.ci/web3_test.sh
@@ -24,8 +24,8 @@ npm install node@22.14.0
 
 cat << EOF > .env
 PRIVATE_KEY=$hex_privatekey
-BCOS_HOST_URL=http://127.0.0.1:8545
-LOCAL_HOST_URL=http://127.0.0.1:8545
+BCOS_HOST_URL=http://127.0.0.1:${WEB3_PORT:-8545}
+LOCAL_HOST_URL=http://127.0.0.1:${WEB3_PORT:-8545}
 INFURA_API_KEY=your_infura_api_key_here
 MAINNET_URL=https://mainnet.infura.io/v3/your_infura_api_key_here
 SEPOLIA_URL=https://sepolia.infura.io/v3/your_infura_api_key_here
@@ -40,8 +40,8 @@ rm -rf .env
 
 cat << EOF > .env
 PRIVATE_KEY=$hex_privatekey
-BCOS_HOST_URL=ws://127.0.0.1:8545
-LOCAL_HOST_URL=ws://127.0.0.1:8545
+BCOS_HOST_URL=ws://127.0.0.1:${WEB3_PORT:-8545}
+LOCAL_HOST_URL=ws://127.0.0.1:${WEB3_PORT:-8545}
 INFURA_API_KEY=your_infura_api_key_here
 MAINNET_URL=https://mainnet.infura.io/v3/your_infura_api_key_here
 SEPOLIA_URL=https://sepolia.infura.io/v3/your_infura_api_key_here

--- a/tools/BcosAirBuilder/build_chain.sh
+++ b/tools/BcosAirBuilder/build_chain.sh
@@ -1471,7 +1471,7 @@ generate_common_ini() {
 
 [consensus]
     ; min block generation time(ms)
-    min_seal_time=500
+    min_seal_time=10
 
 [executor]
     enable_dag=true


### PR DESCRIPTION
## Motivation

`Integration test - Air` is the longest step of the ubuntu CI job (~15.5 min of a ~43 min leg, see [this run](https://github.com/FISCO-BCOS/FISCO-BCOS/actions/runs/32951003501/job/98152351358)). It runs three **independent** phases — non-sm / sm(国密) / baseline(executor v1) — strictly serially, each building its own single-node chain and running the console / java-sdk / java-sdk-demo suites.

This PR runs the three phases **in parallel** on the GitHub-hosted ubuntu legs and removes the artificial block-sealing delay, while leaving the self-hosted workflows' serial behavior untouched.

## Changes

**`tools/.ci/ci_check_air.sh`** — new third argument:
- `all` (default): unchanged serial behavior (self-hosted workflows keep calling it this way)
- `parallel`: the three phases run concurrently, each in an isolated work directory with per-phase p2p/rpc/web3 ports (30300/20200/8545, 31300/21200/8555, 32300/22200/8565); per-phase logs are captured and dumped on failure
- `non-sm`/`sm`/`baseline`: run a single phase (used by the parallel orchestrator; also handy for local debugging)

Safety details:
- `clear_node` only force-kills fisco-bcos processes whose cwd belongs to the script's own workdir (via /proc), so parallel phases cannot kill each other's nodes — or an unrelated node on the host (the old `pkill -9 -f fisco-bcos` was host-wide)
- the orchestrator stops the chain left behind by the RPCAPI test step before forking phases (it occupies the default ports)
- `SKIP_BUILD=true` passed by the orchestrator is no longer reset by the worker, so phases reuse the one-time prebuilt console/java-sdk/java-sdk-demo instead of re-cloning
- `check_consensus` polls for `reachNewView` instead of a fixed 20s sleep (~50s saved across phases)

**`tools/.ci/console_ci_test.sh` / `java_sdk_ci_test.sh` / `java_sdk_demo_ci_test.sh` / `web3_test.sh`** — node rpc/web3 ports come from `RPC_PORT`/`WEB3_PORT` (default 20200/8545) instead of hardcoded values, including the AMOP publisher/subscriber configs (they previously always pointed at 20200).

**`tools/BcosAirBuilder/build_chain.sh`** — `min_seal_time` 500 → 10ms. The sealer never produces empty blocks (`SealingManager::meetsProposalPreconditions` requires pending txs), so this only removes the artificial wait before sealing pending transactions; consensus timeout (3s) is unchanged.

**`.github/workflows/workflow.yml`** — the two ubuntu legs run the step with `parallel`.

## Verification

Local end-to-end run of `ci_check_air.sh master true parallel` (three phases concurrently, including the web3 hardhat suite): **all three phases pass**.

Companion test-suite speedups (independent of this PR): FISCO-BCOS/java-sdk#963 reduces the java-sdk integrationTest time by ~30% and fixes `amopAsyncSubTest`/`test52AsyncCRUDService` which could never fail.

## Expected impact

The step's critical path becomes the slowest phase (baseline, incl. web3) instead of the sum of three. Together with on-demand sealing and the polling fix, the step should drop from ~15.5 min to roughly 5-7 min on the ubuntu legs; self-hosted workflows are unaffected.